### PR TITLE
Add frontend utility tests

### DIFF
--- a/frontend/src/utils/avatarUtils.test.js
+++ b/frontend/src/utils/avatarUtils.test.js
@@ -1,0 +1,11 @@
+import { getAvatarColor } from './avatarUtils';
+
+describe('getAvatarColor', () => {
+  test('returns specific color for known id', () => {
+    expect(getAvatarColor('red')).toBe('#e53935');
+  });
+
+  test('falls back to default color for unknown id', () => {
+    expect(getAvatarColor('unknown')).toBe('primary.main');
+  });
+});

--- a/frontend/src/utils/refreshUtils.test.js
+++ b/frontend/src/utils/refreshUtils.test.js
@@ -1,0 +1,38 @@
+import { setRefreshFlag, checkAndRefresh } from './refreshUtils';
+
+describe('refreshUtils', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    sessionStorage.clear();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: jest.fn() },
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    // Reset the location object
+    delete window.location;
+    window.location = new URL('http://localhost');
+  });
+
+  test('setRefreshFlag stores value in sessionStorage', () => {
+    setRefreshFlag('flag', 2);
+    expect(sessionStorage.getItem('flag')).toBe('2');
+  });
+
+  test('checkAndRefresh triggers reload and clears flag when count is 1', () => {
+    setRefreshFlag('flag', 1);
+    checkAndRefresh('flag');
+    jest.runAllTimers();
+    expect(window.location.reload).toHaveBeenCalled();
+    expect(sessionStorage.getItem('flag')).toBeNull();
+  });
+
+  test('checkAndRefresh decrements count when greater than 1', () => {
+    setRefreshFlag('flag', 3);
+    checkAndRefresh('flag');
+    expect(sessionStorage.getItem('flag')).toBe('2');
+  });
+});

--- a/frontend/src/utils/styleUtils.test.js
+++ b/frontend/src/utils/styleUtils.test.js
@@ -1,0 +1,17 @@
+import { forceReflow, applyBodyClass } from './styleUtils';
+
+describe('styleUtils', () => {
+  test('forceReflow reads offsetHeight', () => {
+    const el = document.createElement('div');
+    const spy = jest.spyOn(el, 'offsetHeight', 'get').mockReturnValue(0);
+    forceReflow(el);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test('applyBodyClass adds and removes class on body', () => {
+    const cleanup = applyBodyClass('test-class');
+    expect(document.body.classList.contains('test-class')).toBe(true);
+    cleanup();
+    expect(document.body.classList.contains('test-class')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests for avatar utils, refresh utils and style utils

## Testing
- `npm run lint:frontend`
- `CI=true npm test -- --runTestsByPath src/utils/avatarUtils.test.js src/utils/refreshUtils.test.js src/utils/styleUtils.test.js`
