### PR TITLE
Fix GitHub workflow test commands

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,4 +46,4 @@ jobs:
 
       - name: Clean up
         if: always()
-        run: docker compose down 
+        run: docker compose down

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,16 +30,25 @@ jobs:
 
       - name: Install dependencies
         run: |
+          npm install --include=dev
           cd backend
           npm install --include=dev
+          cd ../frontend
+          npm install --include=dev
+          cd ..
 
-      - name: Run tests with coverage
+      - name: Run backend tests with coverage
         run: |
           cd backend
-          npm run test:coverage
+          npm test -- --coverage
+
+      - name: Run frontend tests
+        run: |
+          cd frontend
+          npm test -- --watchAll=false
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
-          path: backend/coverage/ 
+          path: backend/coverage/


### PR DESCRIPTION
## Summary
- unify test commands to use `npm test` style
- run backend tests with `--coverage`
- ensure workflow files have newline at EOF
- revert accidental changes to backend dependencies

## Testing
- `npm test` in `backend`
- `CI=true npm test -- --watchAll=false` in `frontend`
