### PR TITLE
Increase backend test coverage

### DIFF
--- a/backend/__tests__/unit/config/db-pg.test.js
+++ b/backend/__tests__/unit/config/db-pg.test.js
@@ -1,0 +1,39 @@
+jest.mock('fs');
+
+const fs = require('fs');
+
+const mockClient = {
+  query: jest.fn().mockResolvedValue({ rows: [{ version: '1' }] }),
+  release: jest.fn(),
+};
+
+const mockPool = {
+  connect: jest.fn().mockResolvedValue(mockClient),
+  query: jest.fn(),
+};
+
+jest.mock('pg', () => ({
+  Pool: jest.fn(() => mockPool),
+}));
+
+delete require.cache[require.resolve('../../../config/db-pg')];
+const { pool, connectPG } = require('../../../config/db-pg');
+
+describe('connectPG', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fs.existsSync.mockReturnValue(false);
+  });
+
+  it('returns the pool on successful connection', async () => {
+    const result = await connectPG();
+    expect(result).toBe(pool);
+    expect(mockPool.connect).toHaveBeenCalled();
+  });
+
+  it('returns null on connection error', async () => {
+    mockPool.connect.mockRejectedValueOnce(new Error('fail'));
+    const result = await connectPG();
+    expect(result).toBeNull();
+  });
+});

--- a/backend/__tests__/unit/config/db.test.js
+++ b/backend/__tests__/unit/config/db.test.js
@@ -1,0 +1,29 @@
+const mongoose = require('mongoose');
+const connectDB = require('../../../config/db');
+
+jest.mock('mongoose', () => ({
+  connect: jest.fn(),
+}));
+
+describe('connectDB', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.MONGO_URI = 'mongodb://localhost/test';
+  });
+
+  it('connects using mongoose with provided URI', async () => {
+    await connectDB();
+    expect(mongoose.connect).toHaveBeenCalledWith(process.env.MONGO_URI, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+  });
+
+  it('exits process when connection fails', async () => {
+    mongoose.connect.mockRejectedValueOnce(new Error('fail'));
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+    await connectDB();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+});

--- a/backend/__tests__/unit/config/init-pg-db.test.js
+++ b/backend/__tests__/unit/config/init-pg-db.test.js
@@ -1,0 +1,30 @@
+jest.mock('fs');
+const fs = require('fs');
+const { pool } = require('../../../config/db-pg');
+
+delete require.cache[require.resolve('../../../config/init-pg-db')];
+const initDb = require('../../../config/init-pg-db');
+
+describe('initializeDatabase', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('executes schema when file exists', async () => {
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue('SQL');
+    const client = { query: jest.fn(), release: jest.fn() };
+    pool.connect = jest.fn().mockResolvedValue(client);
+    const result = await initDb();
+    expect(client.query).toHaveBeenCalledWith('SQL');
+    expect(result).toBe(true);
+  });
+
+  it('returns false when schema file missing', async () => {
+    fs.existsSync.mockReturnValue(false);
+    const client = { release: jest.fn() };
+    pool.connect = jest.fn().mockResolvedValue(client);
+    const result = await initDb();
+    expect(result).toBe(false);
+  });
+});

--- a/backend/__tests__/unit/models/PgMessage.test.js
+++ b/backend/__tests__/unit/models/PgMessage.test.js
@@ -1,0 +1,112 @@
+jest.mock('../../../config/db-pg', () => ({
+  pool: {
+    query: jest.fn(),
+  },
+}));
+
+const { pool } = require('../../../config/db-pg');
+const Message = require('../../../models/pg/Message');
+
+describe('PG Message model', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('create inserts message and updates pod timestamp', async () => {
+    pool.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: '1',
+          pod_id: 'p',
+          user_id: 'u',
+          content: 'c',
+          message_type: 'text',
+        }],
+      })
+      .mockResolvedValueOnce({});
+    const result = await Message.create('p', 'u', 'c', 'text');
+    expect(pool.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('INSERT INTO messages'),
+      ['p', 'u', 'c', 'text'],
+    );
+    expect(pool.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('UPDATE pods'),
+      ['p'],
+    );
+    expect(result).toEqual({
+      id: '1',
+      pod_id: 'p',
+      user_id: 'u',
+      content: 'c',
+      message_type: 'text',
+    });
+  });
+
+  it('findByPodId formats returned rows', async () => {
+    pool.query.mockResolvedValueOnce({
+      rows: [{
+        id: '1',
+        pod_id: 'p',
+        user_id: 'u',
+        content: 'hi',
+        message_type: 'text',
+        created_at: new Date(),
+        username: 'name',
+        profile_picture: 'pic',
+      }],
+    });
+    const res = await Message.findByPodId('p');
+    expect(pool.query).toHaveBeenCalled();
+    expect(res[0]).toHaveProperty('_id', '1');
+    expect(res[0]).toHaveProperty('userId');
+    expect(res[0]).toHaveProperty('messageType', 'text');
+  });
+
+  it('findById returns formatted message', async () => {
+    pool.query.mockResolvedValueOnce({
+      rows: [{
+        id: '1',
+        pod_id: 'p',
+        user_id: 'u',
+        content: 'hi',
+        message_type: 'text',
+        created_at: new Date(),
+        username: 'name',
+        profile_picture: 'pic',
+      }],
+    });
+    const msg = await Message.findById('1');
+    expect(pool.query).toHaveBeenCalledWith(expect.any(String), ['1']);
+    expect(msg).toHaveProperty('id', '1');
+    expect(msg).toHaveProperty('messageType');
+  });
+
+  it('update runs update query', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [{ id: '1' }] });
+    await Message.update('1', 'new');
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE messages'),
+      ['new', '1'],
+    );
+  });
+
+  it('delete runs delete query', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [{ id: '1' }] });
+    await Message.delete('1');
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM messages'),
+      ['1'],
+    );
+  });
+
+  it('deleteByPodId runs delete by pod query', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] });
+    await Message.deleteByPodId('p');
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM messages'),
+      ['p'],
+    );
+  });
+});

--- a/backend/__tests__/unit/routes/pg-pods.test.js
+++ b/backend/__tests__/unit/routes/pg-pods.test.js
@@ -1,0 +1,28 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../controllers/pgPodController', () => ({
+  getAllPods: jest.fn((req, res) => res.status(200).end()),
+  getPodById: jest.fn((req, res) => res.status(200).end()),
+  createPod: jest.fn((req, res) => res.status(201).end()),
+  updatePod: jest.fn((req, res) => res.status(200).end()),
+  deletePod: jest.fn((req, res) => res.status(200).end()),
+  joinPod: jest.fn((req, res) => res.status(200).end()),
+  leavePod: jest.fn((req, res) => res.status(200).end()),
+}));
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => next());
+
+const routes = require('../../../routes/pg-pods');
+const controllers = require('../../../controllers/pgPodController');
+
+describe('pg pods routes', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/pg/pods', routes);
+
+  it('GET /api/pg/pods calls getAllPods', async () => {
+    await request(app).get('/api/pg/pods').expect(200);
+    expect(controllers.getAllPods).toHaveBeenCalled();
+  });
+});

--- a/backend/__tests__/unit/routes/pg-status.test.js
+++ b/backend/__tests__/unit/routes/pg-status.test.js
@@ -1,0 +1,23 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../controllers/pgStatusController', () => ({
+  checkStatus: jest.fn((req, res) => res.status(200).end()),
+  syncUser: jest.fn((req, res) => res.status(200).end()),
+}));
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => next());
+
+const routes = require('../../../routes/pg-status');
+const controllers = require('../../../controllers/pgStatusController');
+
+describe('pg status routes', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/pg/status', routes);
+
+  it('GET /api/pg/status calls checkStatus', async () => {
+    await request(app).get('/api/pg/status').expect(200);
+    expect(controllers.checkStatus).toHaveBeenCalled();
+  });
+});

--- a/backend/__tests__/unit/routes/pods.test.js
+++ b/backend/__tests__/unit/routes/pods.test.js
@@ -1,0 +1,28 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../controllers/podController', () => ({
+  getAllPods: jest.fn((req, res) => res.status(200).end()),
+  getPodsByType: jest.fn((req, res) => res.status(200).end()),
+  getPodById: jest.fn((req, res) => res.status(200).end()),
+  createPod: jest.fn((req, res) => res.status(201).end()),
+  joinPod: jest.fn((req, res) => res.status(200).end()),
+  leavePod: jest.fn((req, res) => res.status(200).end()),
+  deletePod: jest.fn((req, res) => res.status(200).end()),
+}));
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => next());
+
+const routes = require('../../../routes/pods');
+const controllers = require('../../../controllers/podController');
+
+describe('pods routes', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/pods', routes);
+
+  it('GET /api/pods calls getAllPods', async () => {
+    await request(app).get('/api/pods').expect(200);
+    expect(controllers.getAllPods).toHaveBeenCalled();
+  });
+});

--- a/backend/__tests__/unit/routes/posts.test.js
+++ b/backend/__tests__/unit/routes/posts.test.js
@@ -1,0 +1,29 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../controllers/postController', () => ({
+  createPost: jest.fn((req, res) => res.status(201).end()),
+  getPosts: jest.fn((req, res) => res.status(200).end()),
+  getPostById: jest.fn((req, res) => res.status(200).end()),
+  addComment: jest.fn((req, res) => res.status(200).end()),
+  searchPosts: jest.fn((req, res) => res.status(200).end()),
+  likePost: jest.fn((req, res) => res.status(200).end()),
+  deletePost: jest.fn((req, res) => res.status(200).end()),
+  deleteComment: jest.fn((req, res) => res.status(200).end()),
+}));
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => next());
+
+const routes = require('../../../routes/posts');
+const controllers = require('../../../controllers/postController');
+
+describe('posts routes', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/posts', routes);
+
+  it('POST /api/posts calls createPost', async () => {
+    await request(app).post('/api/posts').send({}).expect(201);
+    expect(controllers.createPost).toHaveBeenCalled();
+  });
+});

--- a/backend/__tests__/unit/routes/uploads.test.js
+++ b/backend/__tests__/unit/routes/uploads.test.js
@@ -1,0 +1,22 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../models/File', () => ({
+  findByFileName: jest.fn().mockResolvedValue({ data: Buffer.from('x'), contentType: 'text/plain' }),
+}));
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => next());
+
+const routes = require('../../../routes/uploads');
+const File = require('../../../models/File');
+
+describe('uploads routes', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/uploads', routes);
+
+  it('GET /api/uploads/:file calls findByFileName', async () => {
+    await request(app).get('/api/uploads/test').expect(200);
+    expect(File.findByFileName).toHaveBeenCalledWith('test');
+  });
+});

--- a/backend/__tests__/unit/scripts/add-message-type.test.js
+++ b/backend/__tests__/unit/scripts/add-message-type.test.js
@@ -1,0 +1,28 @@
+const { pool } = require('../../../config/db-pg');
+const addColumn = require('../../../add-message-type');
+
+jest.mock('../../../config/db-pg', () => ({
+  pool: {
+    query: jest.fn(),
+    end: jest.fn(),
+  },
+}));
+
+describe('add-message-type migration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('adds column when missing', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] });
+    await addColumn();
+    expect(pool.query).toHaveBeenCalledTimes(2);
+    expect(pool.query.mock.calls[1][0]).toMatch(/ALTER TABLE messages/);
+  });
+
+  it('does nothing when column exists', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [{}] });
+    await addColumn();
+    expect(pool.query).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/add-message-type.js
+++ b/backend/add-message-type.js
@@ -34,5 +34,9 @@ async function addMessageTypeColumn() {
   }
 }
 
-// Run the migration
-addMessageTypeColumn();
+if (require.main === module) {
+  // Run the migration only when executed directly
+  addMessageTypeColumn();
+}
+
+module.exports = addMessageTypeColumn;


### PR DESCRIPTION
## Summary
- add ability to import migration script without executing it
- cover DB connection helpers with unit tests
- cover PG Message model
- add route unit tests for posts, pods, uploads, pg pods and pg status
- add migration script tests

## Testing
- `npm run lint`
- `npm test`