### PR TITLE
Increase frontend test coverage

### DIFF
--- a/frontend/src/components/Layout.test.js
+++ b/frontend/src/components/Layout.test.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+
+jest.mock('../context/AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('../context/LayoutContext', () => ({ useLayout: jest.fn() }));
+jest.mock('./Dashboard', () => () => <div data-testid="dash" />);
+jest.mock('./SearchBar', () => () => <div data-testid="search" />);
+jest.mock('react-router-dom', () => ({
+  Outlet: () => <div data-testid="outlet" />,
+  useLocation: jest.fn()
+}));
+
+import { useAuth } from '../context/AuthContext';
+import { useLayout } from '../context/LayoutContext';
+import { useLocation } from 'react-router-dom';
+import Layout from './Layout';
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  delete window.location;
+  window.location = { href: '' };
+});
+
+afterEach(() => {
+  TestUtils.act(() => root.unmount());
+  container.remove();
+  container = null;
+});
+
+test('redirects to login when no token', () => {
+  useAuth.mockReturnValue({ loading: false });
+  useLayout.mockReturnValue({ isDashboardCollapsed: false, toggleDashboard: jest.fn() });
+  useLocation.mockReturnValue({ pathname: '/' });
+  localStorage.removeItem('token');
+  TestUtils.act(() => { root.render(<Layout />); });
+  expect(window.location.href).toBe('/');
+});
+
+test('shows loader when loading', () => {
+  useAuth.mockReturnValue({ loading: true });
+  useLayout.mockReturnValue({ isDashboardCollapsed: false, toggleDashboard: jest.fn() });
+  useLocation.mockReturnValue({ pathname: '/' });
+  TestUtils.act(() => { root.render(<Layout />); });
+  expect(container.querySelector('svg')).toBeTruthy();
+});

--- a/frontend/src/components/Login.test.js
+++ b/frontend/src/components/Login.test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { post: jest.fn() }
+}));
+jest.mock('react-router-dom', () => ({ Link: ({children}) => <a>{children}</a> }));
+
+import Login from './Login';
+const axios = require('axios').default;
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  delete window.location;
+  window.location = { href: '' };
+  localStorage.clear();
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+  jest.clearAllMocks();
+  localStorage.clear();
+});
+
+test('submits credentials and redirects when verified', async () => {
+  axios.post.mockResolvedValue({ data: { token: 'tok', verified: true } });
+  await TestUtils.act(async () => {
+    root.render(<Login />);
+  });
+  const [email, pass] = container.querySelectorAll('input');
+  await TestUtils.act(async () => {
+    TestUtils.Simulate.change(email, { target: { value: 'a@b.com' } });
+    TestUtils.Simulate.change(pass, { target: { value: 'pw' } });
+  });
+  await TestUtils.act(async () => {
+    TestUtils.Simulate.submit(container.querySelector('form'));
+  });
+  expect(axios.post).toHaveBeenCalledWith('/api/auth/login', { email: 'a@b.com', password: 'pw' });
+  expect(localStorage.getItem('token')).toBe('tok');
+  expect(window.location.href).toBe('/feed');
+});
+
+test('shows error when not verified', async () => {
+  axios.post.mockResolvedValue({ data: { verified: false } });
+  await TestUtils.act(async () => {
+    root.render(<Login />);
+  });
+  await TestUtils.act(async () => {
+    TestUtils.Simulate.submit(container.querySelector('form'));
+  });
+  expect(container.textContent).toContain('Please verify your email');
+});

--- a/frontend/src/components/Pod.test.js
+++ b/frontend/src/components/Pod.test.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import Pod from './Pod';
+import { useAuth } from '../context/AuthContext';
+import { useNavigate, useParams } from 'react-router-dom';
+const axios = require('axios').default;
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn() }
+}));
+jest.mock('../context/AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+  useParams: jest.fn()
+}));
+
+let container;
+let root;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  localStorage.setItem('token', 't');
+  useAuth.mockReturnValue({ currentUser: { _id: 'u1' } });
+  useNavigate.mockReturnValue(jest.fn());
+  useParams.mockReturnValue({ podType: 'chat' });
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+  localStorage.clear();
+});
+
+const mockPod = { _id: '1', name: 'Room', description: 'Desc', type: 'chat', createdBy: { username: 'a' }, members: [] };
+
+async function renderPod() {
+  axios.get.mockResolvedValueOnce({ data: [mockPod] });
+  await TestUtils.act(async () => {
+    root.render(<Pod />);
+  });
+  // wait for useEffect
+  await TestUtils.act(async () => Promise.resolve());
+}
+
+test('fetches pods and displays them', async () => {
+  await renderPod();
+  expect(axios.get).toHaveBeenCalledWith('/api/pods/chat');
+  expect(container.textContent).toContain('Room');
+});
+
+test('join button posts and navigates', async () => {
+  const navigate = jest.fn();
+  useNavigate.mockReturnValue(navigate);
+  axios.get.mockResolvedValueOnce({ data: [mockPod] });
+  axios.post.mockResolvedValue({ data: mockPod });
+  await TestUtils.act(async () => {
+    root.render(<Pod />);
+  });
+  await TestUtils.act(async () => Promise.resolve());
+  const joinBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent.includes('Join'));
+  await TestUtils.act(async () => {
+    TestUtils.Simulate.click(joinBtn);
+  });
+  expect(axios.post).toHaveBeenCalledWith('/api/pods/1/join', {}, { headers: { Authorization: 'Bearer t' } });
+  expect(navigate).toHaveBeenCalledWith('/pods/chat/1');
+});

--- a/frontend/src/components/Register.test.js
+++ b/frontend/src/components/Register.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { post: jest.fn() }
+}));
+jest.mock('react-router-dom', () => ({ Link: ({children}) => <a>{children}</a> }));
+
+import Register from './Register';
+const axios = require('axios').default;
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+  jest.clearAllMocks();
+});
+
+test('shows success message on register', async () => {
+  axios.post.mockResolvedValue({ data: { message: 'ok' } });
+  await TestUtils.act(async () => { root.render(<Register />); });
+  const form = container.querySelector('form');
+  await TestUtils.act(async () => { TestUtils.Simulate.submit(form); });
+  expect(axios.post).toHaveBeenCalled();
+  expect(container.textContent).toContain('ok');
+});
+
+test('shows error on failure', async () => {
+  axios.post.mockRejectedValue({ response: { data: { error: 'bad' } } });
+  await TestUtils.act(async () => { root.render(<Register />); });
+  const form = container.querySelector('form');
+  await TestUtils.act(async () => { TestUtils.Simulate.submit(form); });
+  expect(container.textContent).toContain('bad');
+});

--- a/frontend/src/components/VerifyEmail.test.js
+++ b/frontend/src/components/VerifyEmail.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+jest.mock('axios', () => ({ __esModule: true, default: { get: jest.fn() } }));
+jest.mock('react-router-dom', () => ({ useSearchParams: jest.fn() }));
+
+import VerifyEmail from './VerifyEmail';
+import { useSearchParams } from 'react-router-dom';
+const axios = require('axios').default;
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  useSearchParams.mockReturnValue([{ get: () => 'tok' }]);
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+  jest.clearAllMocks();
+});
+
+test('calls verify endpoint and shows message', async () => {
+  axios.get.mockResolvedValue({ data: { message: 'done' } });
+  await TestUtils.act(async () => { root.render(<VerifyEmail />); });
+  expect(axios.get).toHaveBeenCalledWith('/api/auth/verify-email?token=tok');
+  expect(container.textContent).toContain('done');
+});
+
+test('shows error on failure', async () => {
+  axios.get.mockRejectedValue({ response: { data: { error: 'bad' } } });
+  await TestUtils.act(async () => { root.render(<VerifyEmail />); });
+  expect(container.textContent).toContain('bad');
+});

--- a/frontend/src/context/SocketContext.integration.test.js
+++ b/frontend/src/context/SocketContext.integration.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { SocketProvider, useSocket } from './SocketContext';
+import { useAuth } from './AuthContext';
+import io from 'socket.io-client';
+
+jest.mock('socket.io-client');
+jest.mock('./AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('axios', () => ({ get: jest.fn(), post: jest.fn() }));
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  const emit = jest.fn();
+  const on = jest.fn((event, cb) => { if(event==='connect') cb(); });
+  const disconnect = jest.fn();
+  io.mockReturnValue({ emit, on, disconnect });
+  useAuth.mockReturnValue({ token: 't', currentUser: { _id: 'u1' } });
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  container = null;
+});
+
+test('joinPod and sendMessage emit events', () => {
+  let value;
+  const Test = () => { value = useSocket(); return null; };
+  act(() => {
+    root.render(<SocketProvider><Test /></SocketProvider>);
+  });
+
+  act(() => { value.joinPod('42'); });
+  expect(io.mock.results[0].value.emit).toHaveBeenCalledWith('joinPod', '42');
+
+  act(() => { value.sendMessage('42', 'hi'); });
+  expect(io.mock.results[0].value.emit).toHaveBeenCalledWith('sendMessage', {
+    podId: '42', content: 'hi', messageType: 'text', userId: 'u1'
+  });
+});


### PR DESCRIPTION
## Summary
- remove `istanbul ignore` comments from components
- add unit tests for Login, Register, VerifyEmail and Layout components

## Testing
- `npm run lint`
- `npm test --prefix frontend -- --coverage --watchAll=false --coverageReporters=text-summary`