### PR TITLE
Increase frontend test coverage

### DIFF
--- a/frontend/src/components/ChatRoom.test.js
+++ b/frontend/src/components/ChatRoom.test.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import ChatRoom from './ChatRoom';
+import { useAuth } from '../context/AuthContext';
+import { useSocket } from '../context/SocketContext';
+import { useLayout } from '../context/LayoutContext';
+import { useParams, useNavigate } from 'react-router-dom';
+const axios = require('axios');
+
+jest.mock('axios', () => ({ get: jest.fn(), post: jest.fn(), delete: jest.fn() }));
+jest.mock('../context/AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('../context/SocketContext', () => ({ useSocket: jest.fn() }));
+jest.mock('../context/LayoutContext', () => ({ useLayout: jest.fn() }));
+jest.mock('react-router-dom', () => ({ useParams: jest.fn(), useNavigate: jest.fn() }));
+jest.mock('../utils/avatarUtils', () => ({ getAvatarColor: () => 'red' }));
+jest.mock('emoji-picker-react', () => {
+  const Picker = () => <div>emoji</div>;
+  Picker.displayName = 'EmojiPickerMock';
+  return Picker;
+});
+
+let container;
+let root;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  useAuth.mockReturnValue({ currentUser: { _id: 'u1', username: 'A' } });
+  useSocket.mockReturnValue({ socket: { on: jest.fn(), off: jest.fn() }, connected: false, pgAvailable: false, joinPod: jest.fn(), leavePod: jest.fn(), sendMessage: jest.fn() });
+  useLayout.mockReturnValue({ isDashboardCollapsed: false });
+  useParams.mockReturnValue({ podType: 'chat', roomId: '1' });
+  useNavigate.mockReturnValue(jest.fn());
+});
+
+afterEach(() => {
+  TestUtils.act(() => root.unmount());
+  container.remove();
+  container = null;
+});
+
+test('fetches pod data on mount', async () => {
+  axios.get.mockResolvedValueOnce({ data: { available: false } });
+  axios.get.mockResolvedValueOnce({ data: { _id: '1', name: 'Room', createdBy: { _id: 'u1' }, members: [] } });
+  axios.get.mockResolvedValue({ data: [] });
+  await TestUtils.act(async () => { root.render(<ChatRoom />); });
+  await TestUtils.act(async () => Promise.resolve());
+  expect(axios.get).toHaveBeenCalledWith('/api/pods/chat/1', expect.anything());
+  expect(container.textContent).toContain('Room');
+});

--- a/frontend/src/components/Layout.test.js
+++ b/frontend/src/components/Layout.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import { MemoryRouter } from 'react-router-dom';
+import Layout from './Layout';
+import { useAuth } from '../context/AuthContext';
+import { useLayout as useLayoutCtx } from '../context/LayoutContext';
+
+jest.mock('../context/AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('../context/LayoutContext', () => ({ useLayout: jest.fn() }));
+jest.mock('./Dashboard', () => {
+  const DashboardMock = () => <div>dash</div>;
+  DashboardMock.displayName = 'DashboardMock';
+  return DashboardMock;
+});
+jest.mock('./SearchBar', () => {
+  const SearchBarMock = () => <div>search</div>;
+  SearchBarMock.displayName = 'SearchBarMock';
+  return { __esModule: true, default: SearchBarMock };
+});
+
+let container;
+let root;
+let oldLocation;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  oldLocation = window.location;
+  delete window.location;
+  window.location = { href: '' };
+});
+
+afterEach(() => {
+  TestUtils.act(() => root.unmount());
+  container.remove();
+  container = null;
+  window.location = oldLocation;
+});
+
+test('shows spinner when loading', () => {
+  useAuth.mockReturnValue({ loading: true });
+  useLayoutCtx.mockReturnValue({ isDashboardCollapsed: false, toggleDashboard: jest.fn() });
+  TestUtils.act(() => { root.render(<MemoryRouter><Layout /></MemoryRouter>); });
+  expect(container.querySelector('svg')).not.toBeNull();
+});
+
+test('redirects to login if no token', () => {
+  useAuth.mockReturnValue({ loading: false });
+  useLayoutCtx.mockReturnValue({ isDashboardCollapsed: false, toggleDashboard: jest.fn() });
+  localStorage.removeItem('token');
+  TestUtils.act(() => { root.render(<MemoryRouter><Layout /></MemoryRouter>); });
+  expect(window.location.href).toBe('/');
+});

--- a/frontend/src/components/Login.test.js
+++ b/frontend/src/components/Login.test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import Login from './Login';
+const axios = require('axios').default;
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { post: jest.fn() }
+}));
+// Simple Link mock
+jest.mock('react-router-dom', () => ({ Link: ({ children }) => <a>{children}</a> }));
+
+let container;
+let root;
+let oldLocation;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  oldLocation = window.location;
+  delete window.location;
+  window.location = { href: '' };
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+  window.location = oldLocation;
+  localStorage.clear();
+});
+
+test('successful login stores token and redirects', async () => {
+  axios.post.mockResolvedValue({ data: { token: 'abc', verified: true } });
+  await TestUtils.act(async () => {
+    root.render(<Login />);
+  });
+  const email = container.querySelector('input[type="email"]');
+  const password = container.querySelector('input[type="password"]');
+  const form = container.querySelector('form');
+  TestUtils.act(() => { TestUtils.Simulate.change(email, { target: { value: 'a@b.com' } }); });
+  TestUtils.act(() => { TestUtils.Simulate.change(password, { target: { value: 'pw' } }); });
+  await TestUtils.act(async () => {
+    TestUtils.Simulate.submit(form);
+  });
+  expect(axios.post).toHaveBeenCalledWith('/api/auth/login', { email: 'a@b.com', password: 'pw' });
+  expect(localStorage.getItem('token')).toBe('abc');
+  expect(window.location.href).toBe('/feed');
+});
+
+test('failed login shows error', async () => {
+  axios.post.mockRejectedValue({ response: { data: { error: 'bad' } } });
+  await TestUtils.act(async () => { root.render(<Login />); });
+  const form = container.querySelector('form');
+  await TestUtils.act(async () => { TestUtils.Simulate.submit(form); });
+  expect(container.textContent).toContain('bad');
+});

--- a/frontend/src/components/Pod.test.js
+++ b/frontend/src/components/Pod.test.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import Pod from './Pod';
+import { useAuth } from '../context/AuthContext';
+import { useNavigate, useParams } from 'react-router-dom';
+const axios = require('axios').default;
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn() }
+}));
+jest.mock('../context/AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+  useParams: jest.fn()
+}));
+
+let container;
+let root;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  localStorage.setItem('token', 't');
+  useAuth.mockReturnValue({ currentUser: { _id: 'u1' } });
+  useNavigate.mockReturnValue(jest.fn());
+  useParams.mockReturnValue({ podType: 'chat' });
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+  localStorage.clear();
+});
+
+const mockPod = { _id: '1', name: 'Room', description: 'Desc', type: 'chat', createdBy: { username: 'a' }, members: [] };
+
+async function renderPod() {
+  axios.get.mockResolvedValueOnce({ data: [mockPod] });
+  await TestUtils.act(async () => {
+    root.render(<Pod />);
+  });
+  // wait for useEffect
+  await TestUtils.act(async () => Promise.resolve());
+}
+
+test('fetches pods and displays them', async () => {
+  await renderPod();
+  expect(axios.get).toHaveBeenCalledWith('/api/pods/chat');
+  expect(container.textContent).toContain('Room');
+});
+
+test('join button posts and navigates', async () => {
+  const navigate = jest.fn();
+  useNavigate.mockReturnValue(navigate);
+  axios.get.mockResolvedValueOnce({ data: [mockPod] });
+  axios.post.mockResolvedValue({ data: mockPod });
+  await TestUtils.act(async () => {
+    root.render(<Pod />);
+  });
+  await TestUtils.act(async () => Promise.resolve());
+  const joinBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent.includes('Join'));
+  await TestUtils.act(async () => {
+    TestUtils.Simulate.click(joinBtn);
+  });
+  expect(axios.post).toHaveBeenCalledWith('/api/pods/1/join', {}, { headers: { Authorization: 'Bearer t' } });
+  expect(navigate).toHaveBeenCalledWith('/pods/chat/1');
+});

--- a/frontend/src/components/PostFeed.test.js
+++ b/frontend/src/components/PostFeed.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import PostFeed from './PostFeed';
+import { useAppContext } from '../context/AppContext';
+import { useNavigate } from 'react-router-dom';
+const axios = require('axios');
+
+jest.mock('axios', () => ({ get: jest.fn(), post: jest.fn(), delete: jest.fn() }));
+jest.mock('../context/AppContext', () => ({ useAppContext: jest.fn() }));
+jest.mock('react-router-dom', () => ({ useNavigate: jest.fn(), useOutletContext: () => null }));
+jest.mock('../utils/avatarUtils', () => ({ getAvatarColor: () => 'red' }));
+jest.mock('emoji-picker-react', () => {
+  const Picker = () => <div>emoji</div>;
+  Picker.displayName = 'EmojiPickerMock';
+  return Picker;
+});
+
+let container;
+let root;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  useAppContext.mockReturnValue({ currentUser: { _id: 'u1', username: 'A' }, refreshData: jest.fn(), setPosts: jest.fn(), removePost: jest.fn(), postsLoading: false });
+  useNavigate.mockReturnValue(jest.fn());
+});
+
+afterEach(() => {
+  TestUtils.act(() => root.unmount());
+  container.remove();
+  container = null;
+});
+
+test('loads posts on mount', async () => {
+  axios.get.mockResolvedValueOnce({ data: [] });
+  await TestUtils.act(async () => { root.render(<PostFeed />); });
+  await TestUtils.act(async () => Promise.resolve());
+  expect(axios.get).toHaveBeenCalled();
+});

--- a/frontend/src/components/Register.test.js
+++ b/frontend/src/components/Register.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import Register from './Register';
+const axios = require('axios').default;
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { post: jest.fn() }
+}));
+jest.mock('react-router-dom', () => ({ Link: ({ children }) => <a>{children}</a> }));
+
+let container;
+let root;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+});
+
+test('successful register shows message', async () => {
+  axios.post.mockResolvedValue({ data: { message: 'ok' } });
+  await TestUtils.act(async () => { root.render(<Register />); });
+  const form = container.querySelector('form');
+  await TestUtils.act(async () => { TestUtils.Simulate.submit(form); });
+  expect(axios.post).toHaveBeenCalled();
+  expect(container.textContent).toContain('ok');
+});
+
+test('error register displays failure', async () => {
+  axios.post.mockRejectedValue({ response: { data: { error: 'no' } } });
+  await TestUtils.act(async () => { root.render(<Register />); });
+  const form = container.querySelector('form');
+  await TestUtils.act(async () => { TestUtils.Simulate.submit(form); });
+  expect(container.textContent).toContain('no');
+});

--- a/frontend/src/components/VerifyEmail.test.js
+++ b/frontend/src/components/VerifyEmail.test.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import { MemoryRouter } from 'react-router-dom';
+import VerifyEmail from './VerifyEmail';
+const axios = require('axios').default;
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { get: jest.fn() }
+}));
+
+let container;
+let root;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+});
+
+test('displays success message', async () => {
+  axios.get.mockResolvedValue({ data: { message: 'verified' } });
+  await TestUtils.act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[ '/verify?token=abc' ]}>
+        <VerifyEmail />
+      </MemoryRouter>
+    );
+  });
+  await TestUtils.act(async () => Promise.resolve());
+  expect(axios.get).toHaveBeenCalledWith('/api/auth/verify-email?token=abc');
+  expect(container.textContent).toContain('verified');
+});
+
+test('displays failure message', async () => {
+  axios.get.mockRejectedValue({ response: { data: { error: 'bad' } } });
+  await TestUtils.act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[ '/verify?token=x' ]}>
+        <VerifyEmail />
+      </MemoryRouter>
+    );
+  });
+  await TestUtils.act(async () => Promise.resolve());
+  expect(container.textContent).toContain('bad');
+});

--- a/frontend/src/context/SocketContext.integration.test.js
+++ b/frontend/src/context/SocketContext.integration.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { SocketProvider, useSocket } from './SocketContext';
+import { useAuth } from './AuthContext';
+import io from 'socket.io-client';
+
+jest.mock('socket.io-client');
+jest.mock('./AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('axios', () => ({ get: jest.fn(), post: jest.fn() }));
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  const emit = jest.fn();
+  const on = jest.fn((event, cb) => { if(event==='connect') cb(); });
+  const disconnect = jest.fn();
+  io.mockReturnValue({ emit, on, disconnect });
+  useAuth.mockReturnValue({ token: 't', currentUser: { _id: 'u1' } });
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  container = null;
+});
+
+test('joinPod and sendMessage emit events', () => {
+  let value;
+  const Test = () => { value = useSocket(); return null; };
+  act(() => {
+    root.render(<SocketProvider><Test /></SocketProvider>);
+  });
+
+  act(() => { value.joinPod('42'); });
+  expect(io.mock.results[0].value.emit).toHaveBeenCalledWith('joinPod', '42');
+
+  act(() => { value.sendMessage('42', 'hi'); });
+  expect(io.mock.results[0].value.emit).toHaveBeenCalledWith('sendMessage', {
+    podId: '42', content: 'hi', messageType: 'text', userId: 'u1'
+  });
+});


### PR DESCRIPTION
## Summary
- remove istanbul ignore file comments from components
- add tests for login, registration, email verification and layout
- add basic ChatRoom and PostFeed tests

## Testing
- `npm run lint`
- `npm test --prefix frontend -- --coverage --watchAll=false --coverageReporters=text-summary`
