### PR TITLE
Increase frontend coverage with smoke tests

### DIFF
--- a/frontend/src/components/Pages.smoke.test.js
+++ b/frontend/src/components/Pages.smoke.test.js
@@ -1,0 +1,138 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import { act } from 'react-dom/test-utils';
+import Login from './Login';
+import Register from './Register';
+import VerifyEmail from './VerifyEmail';
+import Layout from './Layout';
+import Dashboard from './Dashboard';
+import PostFeed from './PostFeed';
+import Thread from './Thread';
+import UserProfile from './UserProfile';
+import { useAuth } from '../context/AuthContext';
+import { useAppContext } from '../context/AppContext';
+import { useLayout as useLayoutCtx } from '../context/LayoutContext';
+import { useSocket } from '../context/SocketContext';
+import { useNavigate, useParams, useSearchParams, useLocation, useOutletContext } from 'react-router-dom';
+const axios = require('axios').default;
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn() }
+}));
+
+jest.mock('../context/AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('../context/AppContext', () => ({ useAppContext: jest.fn() }));
+jest.mock('../context/LayoutContext', () => ({ useLayout: jest.fn() }));
+jest.mock('../context/SocketContext', () => ({ useSocket: jest.fn() }));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+  useParams: jest.fn(),
+  useSearchParams: jest.fn(),
+  useLocation: jest.fn(),
+  useOutletContext: jest.fn(),
+  Outlet: () => <div>Outlet</div>,
+  Link: ({ children }) => <a href="#">{children}</a>
+}));
+
+let container;
+let root;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  useNavigate.mockReturnValue(jest.fn());
+  useParams.mockReturnValue({ id: '1', podType: 'chat', roomId: '1' });
+  useSearchParams.mockReturnValue([{ get: () => 'tok' }]);
+  useLocation.mockReturnValue({ pathname: '/feed', search: '' });
+  useAuth.mockReturnValue({ loading: false, currentUser: { username: 'u' } });
+  useAppContext.mockReturnValue({
+    currentUser: { username: 'u', email: 'e' },
+    userLoading: false,
+    refreshData: jest.fn()
+  });
+  useLayoutCtx.mockReturnValue({
+    isDashboardCollapsed: false,
+    toggleDashboard: jest.fn()
+  });
+  useSocket.mockReturnValue({
+    socket: { on: jest.fn(), emit: jest.fn() },
+    joinPod: jest.fn(),
+    leavePod: jest.fn(),
+    sendMessage: jest.fn(),
+    connected: true,
+    pgAvailable: true
+  });
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  container = null;
+  localStorage.clear();
+});
+
+function render(comp) {
+  act(() => { root.render(comp); });
+  return container.textContent;
+}
+
+test('Login renders and submits', async () => {
+  axios.post.mockResolvedValue({ data: { token: 't', verified: true } });
+  await TestUtils.act(async () => {
+    root.render(<Login />);
+  });
+  const form = container.querySelector('form');
+  await TestUtils.act(async () => {
+    TestUtils.Simulate.submit(form);
+  });
+  expect(axios.post).toHaveBeenCalled();
+  expect(localStorage.getItem('token')).toBe('t');
+});
+
+test('Register renders and submits', async () => {
+  axios.post.mockResolvedValue({ data: { message: 'ok' } });
+  await TestUtils.act(async () => { root.render(<Register />); });
+  const form = container.querySelector('form');
+  await TestUtils.act(async () => { TestUtils.Simulate.submit(form); });
+  expect(axios.post).toHaveBeenCalled();
+});
+
+test('VerifyEmail fetches token', async () => {
+  axios.get.mockResolvedValue({ data: { message: 'verified' } });
+  await TestUtils.act(async () => { root.render(<VerifyEmail />); });
+  await TestUtils.act(async () => Promise.resolve());
+  expect(container.textContent).toContain('verified');
+});
+
+test('Layout and Dashboard render', () => {
+  render(<Layout />);
+  render(<Dashboard />);
+});
+
+test('PostFeed renders', async () => {
+  axios.get.mockResolvedValueOnce({ data: [] });
+  useOutletContext.mockReturnValue(null);
+  await TestUtils.act(async () => { root.render(<PostFeed />); });
+  await TestUtils.act(async () => Promise.resolve());
+  expect(axios.get).toHaveBeenCalled();
+});
+
+test('Thread renders', async () => {
+  axios.get.mockResolvedValueOnce({ data: { _id: '1', userId: { username: 'u' }, content: 'c', createdAt: Date.now(), comments: [] } });
+  await TestUtils.act(async () => { root.render(<Thread />); });
+  await TestUtils.act(async () => Promise.resolve());
+  expect(axios.get).toHaveBeenCalled();
+});
+
+test('UserProfile renders', async () => {
+  axios.get.mockResolvedValueOnce({ data: { username: 'u' } });
+  await TestUtils.act(async () => { root.render(<UserProfile />); });
+  await TestUtils.act(async () => Promise.resolve());
+  expect(axios.get).toHaveBeenCalled();
+});
+

--- a/frontend/src/components/Pod.test.js
+++ b/frontend/src/components/Pod.test.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import Pod from './Pod';
+import { useAuth } from '../context/AuthContext';
+import { useNavigate, useParams } from 'react-router-dom';
+const axios = require('axios').default;
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn() }
+}));
+jest.mock('../context/AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+  useParams: jest.fn()
+}));
+
+let container;
+let root;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  localStorage.setItem('token', 't');
+  useAuth.mockReturnValue({ currentUser: { _id: 'u1' } });
+  useNavigate.mockReturnValue(jest.fn());
+  useParams.mockReturnValue({ podType: 'chat' });
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+  localStorage.clear();
+});
+
+const mockPod = { _id: '1', name: 'Room', description: 'Desc', type: 'chat', createdBy: { username: 'a' }, members: [] };
+
+async function renderPod() {
+  axios.get.mockResolvedValueOnce({ data: [mockPod] });
+  await TestUtils.act(async () => {
+    root.render(<Pod />);
+  });
+  // wait for useEffect
+  await TestUtils.act(async () => Promise.resolve());
+}
+
+test('fetches pods and displays them', async () => {
+  await renderPod();
+  expect(axios.get).toHaveBeenCalledWith('/api/pods/chat');
+  expect(container.textContent).toContain('Room');
+});
+
+test('join button posts and navigates', async () => {
+  const navigate = jest.fn();
+  useNavigate.mockReturnValue(navigate);
+  axios.get.mockResolvedValueOnce({ data: [mockPod] });
+  axios.post.mockResolvedValue({ data: mockPod });
+  await TestUtils.act(async () => {
+    root.render(<Pod />);
+  });
+  await TestUtils.act(async () => Promise.resolve());
+  const joinBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent.includes('Join'));
+  await TestUtils.act(async () => {
+    TestUtils.Simulate.click(joinBtn);
+  });
+  expect(axios.post).toHaveBeenCalledWith('/api/pods/1/join', {}, { headers: { Authorization: 'Bearer t' } });
+  expect(navigate).toHaveBeenCalledWith('/pods/chat/1');
+});

--- a/frontend/src/context/SocketContext.integration.test.js
+++ b/frontend/src/context/SocketContext.integration.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { SocketProvider, useSocket } from './SocketContext';
+import { useAuth } from './AuthContext';
+import io from 'socket.io-client';
+
+jest.mock('socket.io-client');
+jest.mock('./AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('axios', () => ({ get: jest.fn(), post: jest.fn() }));
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  const emit = jest.fn();
+  const on = jest.fn((event, cb) => { if(event==='connect') cb(); });
+  const disconnect = jest.fn();
+  io.mockReturnValue({ emit, on, disconnect });
+  useAuth.mockReturnValue({ token: 't', currentUser: { _id: 'u1' } });
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  container = null;
+});
+
+test('joinPod and sendMessage emit events', () => {
+  let value;
+  const Test = () => { value = useSocket(); return null; };
+  act(() => {
+    root.render(<SocketProvider><Test /></SocketProvider>);
+  });
+
+  act(() => { value.joinPod('42'); });
+  expect(io.mock.results[0].value.emit).toHaveBeenCalledWith('joinPod', '42');
+
+  act(() => { value.sendMessage('42', 'hi'); });
+  expect(io.mock.results[0].value.emit).toHaveBeenCalledWith('sendMessage', {
+    podId: '42', content: 'hi', messageType: 'text', userId: 'u1'
+  });
+});


### PR DESCRIPTION
## Summary
- remove Istanbul ignore comments from components
- add smoke tests for key pages to exercise APIs

## Testing
- `npm run lint`
- `npm run test:coverage`