### PR TITLE
Add route tests to boost backend coverage

### DIFF
--- a/backend/__tests__/unit/routes/pods.announcements.test.js
+++ b/backend/__tests__/unit/routes/pods.announcements.test.js
@@ -1,0 +1,80 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.user = { id: 'user1' };
+  req.userId = 'user1';
+  next();
+});
+
+const Pod = require('../../../models/Pod');
+const Announcement = require('../../../models/Announcement');
+
+jest.mock('../../../models/Pod');
+jest.mock('../../../models/Announcement');
+
+const routes = require('../../../routes/pods');
+
+describe('pods routes - announcements', () => {
+  let app;
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/pods', routes);
+    jest.clearAllMocks();
+  });
+
+  it('creates an announcement successfully', async () => {
+    const podSave = jest.fn();
+    Pod.findById.mockResolvedValue({
+      createdBy: { toString: () => 'user1' },
+      announcements: [],
+      save: podSave,
+    });
+    const annSave = jest.fn();
+    Announcement.mockImplementation((data) => ({ ...data, save: annSave, _id: 'a1' }));
+
+    await request(app)
+      .post('/api/pods/announcement')
+      .send({ podId: 'p1', title: 't', content: 'c' })
+      .expect(201);
+
+    expect(Announcement).toHaveBeenCalledWith({
+      podId: 'p1',
+      title: 't',
+      content: 'c',
+      createdBy: 'user1',
+    });
+    expect(annSave).toHaveBeenCalled();
+    expect(podSave).toHaveBeenCalled();
+  });
+
+  it('returns 400 when required fields missing', async () => {
+    await request(app).post('/api/pods/announcement').send({}).expect(400);
+  });
+
+  it('returns 404 when pod not found', async () => {
+    Pod.findById.mockResolvedValue(null);
+    await request(app).post('/api/pods/announcement').send({ podId: 'p1', title: 't', content: 'c' }).expect(404);
+  });
+
+  it('returns 403 when user is not owner', async () => {
+    Pod.findById.mockResolvedValue({ createdBy: { toString: () => 'other' } });
+    await request(app).post('/api/pods/announcement').send({ podId: 'p1', title: 't', content: 'c' }).expect(403);
+  });
+
+  it('returns 404 when pod missing on announcements fetch', async () => {
+    Pod.findById.mockResolvedValue(null);
+    await request(app).get('/api/pods/p1/announcements').expect(404);
+  });
+
+  it('fetches announcements successfully', async () => {
+    Pod.findById.mockResolvedValue({ members: ['user1'] });
+    Announcement.find.mockReturnValue({
+      sort: jest.fn().mockReturnThis(),
+      populate: jest.fn().mockResolvedValue(['a1']),
+    });
+    const res = await request(app).get('/api/pods/p1/announcements').expect(200);
+    expect(res.body).toEqual(['a1']);
+  });
+});

--- a/backend/__tests__/unit/routes/pods.external-links.test.js
+++ b/backend/__tests__/unit/routes/pods.external-links.test.js
@@ -1,0 +1,146 @@
+const request = require('supertest');
+const express = require('express');
+const fs = require('fs');
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.user = { id: 'user1' };
+  req.userId = 'user1';
+  next();
+});
+
+const Pod = require('../../../models/Pod');
+const ExternalLink = require('../../../models/ExternalLink');
+
+jest.mock('../../../models/Pod');
+jest.mock('../../../models/ExternalLink');
+jest.mock('fs');
+
+const routes = require('../../../routes/pods');
+
+describe('pods routes - external links', () => {
+  let app;
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use((req, res, next) => {
+      res.sendFile = jest.fn(() => res.status(200).end());
+      next();
+    });
+    app.use('/api/pods', routes);
+    jest.clearAllMocks();
+  });
+
+  it('creates external link with url', async () => {
+    const podSave = jest.fn();
+    Pod.findById.mockResolvedValue({ createdBy: { toString: () => 'user1' }, externalLinks: [], save: podSave });
+    const linkSave = jest.fn();
+    ExternalLink.mockImplementation((data) => ({ ...data, _id: 'l1', save: linkSave }));
+
+    await request(app)
+      .post('/api/pods/external-link')
+      .send({
+        podId: 'p1',
+        name: 'Link',
+        type: 'discord',
+        url: 'http://x',
+      })
+      .expect(201);
+
+    expect(ExternalLink).toHaveBeenCalledWith(expect.objectContaining({
+      podId: 'p1',
+      name: 'Link',
+      type: 'discord',
+      createdBy: 'user1',
+    }));
+    expect(linkSave).toHaveBeenCalled();
+    expect(podSave).toHaveBeenCalled();
+  });
+
+  it('returns 400 when required fields missing', async () => {
+    await request(app).post('/api/pods/external-link').send({}).expect(400);
+  });
+
+  it('returns 404 when pod not found', async () => {
+    Pod.findById.mockResolvedValue(null);
+    await request(app)
+      .post('/api/pods/external-link')
+      .send({
+        podId: 'p1',
+        name: 'n',
+        type: 'discord',
+        url: 'u',
+      })
+      .expect(404);
+  });
+
+  it('returns 403 when user not owner', async () => {
+    Pod.findById.mockResolvedValue({ createdBy: { toString: () => 'other' } });
+    await request(app)
+      .post('/api/pods/external-link')
+      .send({
+        podId: 'p1',
+        name: 'n',
+        type: 'discord',
+        url: 'u',
+      })
+      .expect(403);
+  });
+
+  it('deletes external link successfully', async () => {
+    const podSave = jest.fn();
+    ExternalLink.findById.mockResolvedValue({ podId: 'p1', qrCodePath: 'code.png' });
+    Pod.findById.mockResolvedValue({ createdBy: { toString: () => 'user1' }, externalLinks: ['l1'], save: podSave });
+    fs.existsSync.mockReturnValue(true);
+
+    await request(app).delete('/api/pods/external-link/l1').expect(200);
+
+    expect(ExternalLink.findByIdAndDelete).toHaveBeenCalledWith('l1');
+    expect(fs.unlinkSync).toHaveBeenCalledWith('code.png');
+    expect(podSave).toHaveBeenCalled();
+  });
+
+  it('returns 404 when external link missing on delete', async () => {
+    ExternalLink.findById.mockResolvedValue(null);
+    await request(app).delete('/api/pods/external-link/l1').expect(404);
+  });
+
+  it('returns 403 when deleting link as non-owner', async () => {
+    ExternalLink.findById.mockResolvedValue({ podId: 'p1' });
+    Pod.findById.mockResolvedValue({ createdBy: { toString: () => 'other' } });
+    await request(app).delete('/api/pods/external-link/l1').expect(403);
+  });
+
+  it('fetches qrcode when user is member', async () => {
+    ExternalLink.findById.mockResolvedValue({ podId: 'p1', type: 'wechat', qrCodePath: 'code.png' });
+    Pod.findById.mockResolvedValue({ members: ['user1'] });
+
+    await request(app).get('/api/pods/external-link/l1/qrcode').expect(200);
+  });
+
+  it('returns 404 when qrcode not found', async () => {
+    ExternalLink.findById.mockResolvedValue(null);
+    await request(app).get('/api/pods/external-link/l1/qrcode').expect(404);
+  });
+
+  it('returns 403 when user not member for qrcode', async () => {
+    ExternalLink.findById.mockResolvedValue({ podId: 'p1', type: 'wechat', qrCodePath: 'code.png' });
+    Pod.findById.mockResolvedValue({ members: [] });
+    await request(app).get('/api/pods/external-link/l1/qrcode').expect(403);
+  });
+
+  it('fetches external links list', async () => {
+    Pod.findById.mockResolvedValue({ members: ['user1'] });
+    ExternalLink.find.mockReturnValue({
+      sort: jest.fn().mockReturnThis(),
+      populate: jest.fn().mockResolvedValue(['l1']),
+    });
+
+    const res = await request(app).get('/api/pods/p1/external-links').expect(200);
+    expect(res.body).toEqual(['l1']);
+  });
+
+  it('returns 404 when pod missing on external links fetch', async () => {
+    Pod.findById.mockResolvedValue(null);
+    await request(app).get('/api/pods/p1/external-links').expect(404);
+  });
+});

--- a/backend/__tests__/unit/routes/uploads.post.test.js
+++ b/backend/__tests__/unit/routes/uploads.post.test.js
@@ -1,0 +1,50 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../models/File', () => {
+  const saveMock = jest.fn();
+  const File = jest.fn().mockImplementation((data) => ({ ...data, save: saveMock }));
+  File.findByFileName = jest.fn();
+  File.__saveMock = saveMock;
+  return File;
+});
+const File = require('../../../models/File');
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.userId = 'user1';
+  next();
+});
+
+const routes = require('../../../routes/uploads');
+
+describe('uploads POST route', () => {
+  let app;
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/uploads', routes);
+    File.__saveMock.mockReset();
+    File.mockClear();
+  });
+
+  it('uploads image and saves file', async () => {
+    await request(app)
+      .post('/api/uploads')
+      .attach('image', Buffer.from('data'), 'photo.png')
+      .expect(200);
+    expect(File).toHaveBeenCalled();
+    expect(File.__saveMock).toHaveBeenCalled();
+  });
+
+  it('returns 400 when no file provided', async () => {
+    const res = await request(app).post('/api/uploads').expect(400);
+    expect(res.body.msg).toBe('No file uploaded');
+  });
+
+  it('rejects invalid file types', async () => {
+    await request(app)
+      .post('/api/uploads')
+      .attach('image', Buffer.from('data'), 'text.txt')
+      .expect(500);
+  });
+});


### PR DESCRIPTION
## Summary
- add announcement flow tests for pods router
- add upload endpoint tests
- add external link route tests to cover create, delete, fetch

## Testing
- `npm run lint`
- `cd backend && npm test -- -i`
