### PR TITLE
Add layout and dashboard tests

### DIFF
--- a/frontend/src/components/Dashboard.test.js
+++ b/frontend/src/components/Dashboard.test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import Dashboard from './Dashboard';
+import { useAppContext } from '../context/AppContext';
+import { useLayout } from '../context/LayoutContext';
+import { useLocation } from 'react-router-dom';
+
+jest.mock('../context/AppContext', () => ({ useAppContext: jest.fn() }));
+jest.mock('../context/LayoutContext', () => ({ useLayout: jest.fn() }));
+jest.mock('react-router-dom', () => ({ useLocation: jest.fn() }));
+// Mock axios to avoid ESM parsing issues
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn() },
+}));
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  delete window.location;
+  window.location = { href: 'start' };
+  jest.resetAllMocks();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+});
+
+function renderDashboard() {
+  TestUtils.act(() => {
+    root.render(<Dashboard />);
+  });
+}
+
+test('shows collapse button when collapsed and toggles on click', () => {
+  const toggle = jest.fn();
+  useAppContext.mockReturnValue({ currentUser: null, userLoading: false, refreshData: jest.fn() });
+  useLayout.mockReturnValue({ isDashboardCollapsed: true, toggleDashboard: toggle });
+  useLocation.mockReturnValue({ pathname: '/feed' });
+  renderDashboard();
+  const button = container.querySelector('button');
+  TestUtils.act(() => { button.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+  expect(toggle).toHaveBeenCalled();
+});
+
+test('shows feed item when expanded', () => {
+  useAppContext.mockReturnValue({ currentUser: { username: 'u', email: 'e' }, userLoading: false, refreshData: jest.fn() });
+  useLayout.mockReturnValue({ isDashboardCollapsed: false, toggleDashboard: jest.fn() });
+  useLocation.mockReturnValue({ pathname: '/other' });
+  renderDashboard();
+  expect(container.textContent).toContain('Feed');
+});

--- a/frontend/src/components/Layout.test.js
+++ b/frontend/src/components/Layout.test.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import Layout from './Layout';
+import { BrowserRouter } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { useLayout } from '../context/LayoutContext';
+import { useAppContext } from '../context/AppContext';
+import { useLocation } from 'react-router-dom';
+
+jest.mock('../context/AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('../context/LayoutContext', () => ({ useLayout: jest.fn() }));
+jest.mock('../context/AppContext', () => ({ useAppContext: jest.fn() }));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn(),
+}));
+// axios is ESM; mock it so Jest doesn't try to parse the module
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn() },
+}));
+
+// Mock Material UI hooks that depend on window.matchMedia
+jest.mock('@mui/material', () => ({
+  ...jest.requireActual('@mui/material'),
+  useMediaQuery: () => false,
+  useTheme: () => ({ breakpoints: { down: () => false } }),
+}));
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  delete window.location;
+  window.location = { href: 'start' };
+  jest.resetAllMocks();
+  // provide default context values so Dashboard can render
+  useAppContext.mockReturnValue({ currentUser: null, userLoading: false, refreshData: jest.fn() });
+  localStorage.clear();
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+});
+
+function renderLayout() {
+  TestUtils.act(() => {
+    root.render(
+      <BrowserRouter>
+        <Layout />
+      </BrowserRouter>
+    );
+  });
+}
+
+test('shows loading indicator when auth is loading', () => {
+  useAuth.mockReturnValue({ loading: true });
+  useLayout.mockReturnValue({ isDashboardCollapsed: false, toggleDashboard: jest.fn() });
+  useLocation.mockReturnValue({ pathname: '/' });
+  renderLayout();
+  expect(container.querySelector('svg')).toBeTruthy();
+});
+
+test('redirects to root when no token found', () => {
+  useAuth.mockReturnValue({ loading: false });
+  useLayout.mockReturnValue({ isDashboardCollapsed: false, toggleDashboard: jest.fn() });
+  useLocation.mockReturnValue({ pathname: '/' });
+  renderLayout();
+  expect(window.location.href).toBe('/');
+});
+
+test('calls toggleDashboard when button clicked', () => {
+  localStorage.setItem('token', 't');
+  const toggle = jest.fn();
+  useAuth.mockReturnValue({ loading: false });
+  useLayout.mockReturnValue({ isDashboardCollapsed: false, toggleDashboard: toggle });
+  useLocation.mockReturnValue({ pathname: '/feed' });
+  renderLayout();
+  const button = container.querySelector('.toggle-dashboard-button');
+  TestUtils.act(() => { TestUtils.Simulate.click(button); });
+  expect(toggle).toHaveBeenCalled();
+});
+
+test('pod detail layout classes applied when on pod page', () => {
+  localStorage.setItem('token', 't');
+  useAuth.mockReturnValue({ loading: false });
+  useLayout.mockReturnValue({ isDashboardCollapsed: true, toggleDashboard: jest.fn() });
+  useLocation.mockReturnValue({ pathname: '/pods/chat/1' });
+  renderLayout();
+  expect(container.firstChild.className).toContain('pods-view');
+  expect(container.firstChild.className).toContain('pod-detail');
+  expect(container.firstChild.className).toContain('dashboard-collapsed');
+});

--- a/frontend/src/utils/styleUtils.test.js
+++ b/frontend/src/utils/styleUtils.test.js
@@ -1,4 +1,4 @@
-import { forceReflow, applyBodyClass } from './styleUtils';
+import { forceReflow, applyBodyClass, applyStylesToElements, reloadStylesheets, forceImmediateStyleApplication } from './styleUtils';
 
 describe('styleUtils', () => {
   test('forceReflow reads offsetHeight', () => {
@@ -13,5 +13,43 @@ describe('styleUtils', () => {
     expect(document.body.classList.contains('test-class')).toBe(true);
     cleanup();
     expect(document.body.classList.contains('test-class')).toBe(false);
+  });
+
+  test('applyStylesToElements applies class', () => {
+    const el1 = document.createElement('div');
+    el1.className = 't';
+    const el2 = document.createElement('div');
+    el2.className = 't';
+    document.body.appendChild(el1);
+    document.body.appendChild(el2);
+    applyStylesToElements('.t');
+    expect(el1.classList.contains('style-applied')).toBe(true);
+    expect(el2.classList.contains('style-applied')).toBe(true);
+    el1.remove();
+    el2.remove();
+  });
+
+  test('reloadStylesheets replaces links', () => {
+    jest.useFakeTimers();
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'style.css';
+    document.head.appendChild(link);
+    reloadStylesheets();
+    const newLink = document.head.querySelector('link[rel="stylesheet"]:not([href="style.css"])');
+    expect(newLink).toBeTruthy();
+    jest.runAllTimers();
+    expect(document.head.querySelector('link[href="style.css"]')).toBeNull();
+    newLink.remove();
+    jest.useRealTimers();
+  });
+
+  test('forceImmediateStyleApplication hides body temporarily', () => {
+    jest.useFakeTimers();
+    forceImmediateStyleApplication();
+    expect(document.body.style.visibility).toBe('hidden');
+    jest.runAllTimers();
+    expect(document.body.style.visibility).toBe('');
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- add tests for Layout component
- add tests for Dashboard component
- add additional tests for style utilities

## Testing
- `npm run lint`
- `CI=true npm test` in `frontend`
- `npm run test:coverage` in `frontend` (coverage ~42%)