### PR TITLE
Add additional frontend tests

### DIFF
--- a/frontend/src/components/PostFeed.test.js
+++ b/frontend/src/components/PostFeed.test.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import PostFeed from './PostFeed';
+import { useAppContext } from '../context/AppContext';
+import { useOutletContext, useNavigate } from 'react-router-dom';
+const axios = require('axios').default;
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn(), delete: jest.fn() }
+}));
+jest.mock('../context/AppContext', () => ({ useAppContext: jest.fn() }));
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+  useOutletContext: jest.fn()
+}));
+
+let container;
+let root;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  localStorage.setItem('token', 't');
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+  localStorage.clear();
+  jest.useRealTimers();
+  // reset location
+  delete window.location;
+  window.location = new URL('http://localhost');
+});
+
+const mockPost = {
+  _id: '1',
+  content: 'hello',
+  userId: { _id: 'u1', username: 'user', profilePicture: null },
+  likes: 0,
+  comments: []
+};
+
+async function renderFeed(appCtx = {}) {
+  useAppContext.mockReturnValue({
+    currentUser: { _id: 'u2', username: 'other' },
+    setPosts: jest.fn(),
+    refreshData: jest.fn(),
+    removePost: jest.fn(),
+    postsLoading: false,
+    ...appCtx
+  });
+  useOutletContext.mockReturnValue(null);
+  useNavigate.mockReturnValue(jest.fn());
+  axios.get.mockResolvedValueOnce({ data: [mockPost] });
+  await TestUtils.act(async () => {
+    root.render(<PostFeed />);
+  });
+  await TestUtils.act(async () => Promise.resolve());
+}
+
+test('fetches posts and displays them', async () => {
+  await renderFeed();
+  expect(axios.get).toHaveBeenCalledWith('/api/posts', { headers: { Authorization: 'Bearer t' } });
+  expect(container.textContent).toContain('hello');
+});
+
+test('clicking like sends request and toggles', async () => {
+  await renderFeed();
+  axios.post.mockResolvedValue({ data: { likes: 1, liked: true } });
+  const likeBtn = container.querySelector('.like-button');
+  await TestUtils.act(async () => {
+    TestUtils.Simulate.click(likeBtn);
+  });
+  await TestUtils.act(async () => Promise.resolve());
+  expect(axios.post).toHaveBeenCalledWith('/api/posts/1/like', {}, { headers: { Authorization: 'Bearer t' } });
+  expect(likeBtn.className).toContain('active');
+});
+
+test('creating post submits and reloads', async () => {
+  Object.defineProperty(window, 'location', { configurable: true, value: { ...window.location, reload: jest.fn() } });
+  useAppContext.mockReturnValue({ currentUser: { _id: 'u2', username: 'u' }, setPosts: jest.fn(), refreshData: jest.fn(), removePost: jest.fn(), postsLoading: false });
+  useOutletContext.mockReturnValue(null);
+  useNavigate.mockReturnValue(jest.fn());
+  axios.get.mockResolvedValueOnce({ data: [] });
+  axios.post.mockResolvedValue({});
+  await TestUtils.act(async () => { root.render(<PostFeed />); });
+  await TestUtils.act(async () => Promise.resolve());
+  const textarea = container.querySelector('textarea');
+  const postBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Post');
+  TestUtils.act(() => { TestUtils.Simulate.change(textarea, { target: { value: '#tag hi' } }); });
+  await TestUtils.act(async () => { TestUtils.Simulate.click(postBtn); });
+  expect(axios.post).toHaveBeenCalledWith('/api/posts', { content: '#tag hi', tags: ['tag'] }, { headers: { Authorization: 'Bearer t' } });
+  expect(window.location.reload).toHaveBeenCalled();
+});
+

--- a/frontend/src/components/SearchBar.test.js
+++ b/frontend/src/components/SearchBar.test.js
@@ -22,12 +22,14 @@ beforeEach(() => {
   container = document.createElement('div');
   document.body.appendChild(container);
   root = ReactDOM.createRoot(container);
+  localStorage.setItem('token', 't');
 });
 
 afterEach(() => {
   root.unmount();
   container.remove();
   container = null;
+  localStorage.clear();
 });
 
 test('typing triggers local search on feed page', async () => {
@@ -64,4 +66,46 @@ test('submitting navigates to feed with query', () => {
     TestUtils.Simulate.submit(form);
   });
   expect(navigate).toHaveBeenCalledWith({ pathname: '/feed', search: 'q=abc' });
+});
+
+test('mount with query param triggers search', async () => {
+  const navigate = jest.fn();
+  useNavigate.mockReturnValue(navigate);
+  useLocation.mockReturnValue({ pathname: '/feed', search: '?q=tag' });
+  axios.get.mockResolvedValue({ data: ['x'] });
+  const onResults = jest.fn();
+  await TestUtils.act(async () => {
+    root.render(<SearchBar onSearchResults={onResults} />);
+  });
+  await TestUtils.act(async () => Promise.resolve());
+  expect(axios.get).toHaveBeenCalledWith('/api/posts/search', { params: { query: 'tag' } });
+  expect(onResults).toHaveBeenCalledWith(['x']);
+});
+
+test('empty submit fetches all posts', async () => {
+  const navigate = jest.fn();
+  useNavigate.mockReturnValue(navigate);
+  useLocation.mockReturnValue({ pathname: '/feed', search: '' });
+  axios.get.mockResolvedValue({ data: ['all'] });
+  const onResults = jest.fn();
+  await TestUtils.act(async () => {
+    root.render(<SearchBar onSearchResults={onResults} />);
+  });
+  const form = container.querySelector('form');
+  await TestUtils.act(async () => {
+    TestUtils.Simulate.submit(form);
+  });
+  expect(axios.get).toHaveBeenCalledWith('/api/posts', { headers: { Authorization: 'Bearer t' } });
+  expect(onResults).toHaveBeenCalledWith(['all']);
+});
+
+test('adds pod-search class on pod pages', () => {
+  useNavigate.mockReturnValue(jest.fn());
+  useLocation.mockReturnValue({ pathname: '/pods/chat', search: '' });
+  const onResults = jest.fn();
+  TestUtils.act(() => {
+    root.render(<SearchBar onSearchResults={onResults} />);
+  });
+  const div = container.querySelector('.search-bar');
+  expect(div.className).toContain('pod-search');
 });

--- a/frontend/src/components/Thread.test.js
+++ b/frontend/src/components/Thread.test.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import Thread from './Thread';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useAppContext } from '../context/AppContext';
+const axios = require('axios').default;
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn(), delete: jest.fn() }
+}));
+jest.mock('../context/AppContext', () => ({ useAppContext: jest.fn() }));
+jest.mock('react-router-dom', () => ({
+  useParams: jest.fn(),
+  useNavigate: jest.fn()
+}));
+
+let container;
+let root;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  localStorage.setItem('token', 't');
+  useParams.mockReturnValue({ id: '1' });
+  useNavigate.mockReturnValue(jest.fn());
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+  localStorage.clear();
+});
+
+const mockPost = {
+  _id: '1',
+  content: 'thread post',
+  userId: { _id: 'u1', username: 'user', profilePicture: null },
+  createdAt: new Date().toISOString(),
+  comments: [],
+  likes: 0,
+  likedBy: []
+};
+
+async function renderThread(ctx = {}) {
+  useAppContext.mockReturnValue({ currentUser: { _id: 'u2' }, refreshData: jest.fn(), removePost: jest.fn(), ...ctx });
+  axios.get.mockResolvedValueOnce({ data: mockPost });
+  await TestUtils.act(async () => { root.render(<Thread />); });
+  await TestUtils.act(async () => Promise.resolve());
+}
+
+test('fetches post and displays content', async () => {
+  await renderThread();
+  expect(axios.get).toHaveBeenCalledWith('/api/posts/1');
+  expect(container.textContent).toContain('thread post');
+});
+
+test('submitting comment posts and updates UI', async () => {
+  await renderThread();
+  axios.post.mockResolvedValue({ data: { _id: 'c1', text: 'hi', userId: { _id: 'u2', username: 'me' }, createdAt: new Date().toISOString() } });
+  const textarea = container.querySelector('textarea');
+  const form = container.querySelector('form');
+  TestUtils.act(() => { TestUtils.Simulate.change(textarea, { target: { value: 'hi' } }); });
+  await TestUtils.act(async () => { TestUtils.Simulate.submit(form); });
+  expect(axios.post).toHaveBeenCalledWith('/api/posts/1/comments', { text: 'hi' }, { headers: { Authorization: 'Bearer t' } });
+  expect(container.textContent).toContain('hi');
+});
+
+test('liking post sends request', async () => {
+  await renderThread();
+  axios.post.mockResolvedValue({ data: { likes: 1, liked: true } });
+  const likeBtn = container.querySelector('button');
+  await TestUtils.act(async () => { TestUtils.Simulate.click(likeBtn); });
+  expect(axios.post).toHaveBeenCalledWith('/api/posts/1/like', {}, { headers: { Authorization: 'Bearer t' } });
+});


### PR DESCRIPTION
## Summary
- expand SearchBar tests for query params, empty submit, and pod pages
- add PostFeed test suite covering likes and creating posts
- add Thread tests for commenting and liking

## Testing
- `npm run lint`
- `npm test -- --watchAll=false`
- `npm run test:coverage`