### PR TITLE
Improve frontend test coverage

### DIFF
--- a/frontend/src/context/AuthContext.test.js
+++ b/frontend/src/context/AuthContext.test.js
@@ -59,3 +59,26 @@ test('logout clears token and user', () => {
   expect(localStorage.getItem('token')).toBeNull();
   expect(global.testAuth.currentUser).toBeNull();
 });
+
+test('login stores token and user', async () => {
+  axios.post.mockResolvedValueOnce({ data: { token: 'tok', user: { name: 'Alice' } } });
+  await act(async () => {
+    await global.testAuth.login('a', 'b');
+  });
+  expect(localStorage.getItem('token')).toBe('tok');
+  expect(global.testAuth.currentUser).toEqual({ name: 'Alice' });
+  expect(axios.post).toHaveBeenCalledWith('/api/auth/login', { email: 'a', password: 'b' });
+});
+
+test('updateProfile sends auth header and updates user', async () => {
+  axios.post.mockResolvedValueOnce({ data: { token: 'tok', user: { name: 'Init' } } });
+  await act(async () => { await global.testAuth.login('a', 'b'); });
+  axios.put.mockResolvedValueOnce({ data: { name: 'Updated' } });
+  await act(async () => {
+    await global.testAuth.updateProfile({ foo: 'bar' });
+  });
+  expect(axios.put).toHaveBeenCalledWith('/api/users/profile', { foo: 'bar' }, {
+    headers: { Authorization: 'Bearer tok', 'Content-Type': 'multipart/form-data' }
+  });
+  expect(global.testAuth.currentUser).toEqual({ name: 'Updated' });
+});

--- a/frontend/src/utils/focusUtils.test.js
+++ b/frontend/src/utils/focusUtils.test.js
@@ -23,3 +23,18 @@ describe('focusUtils', () => {
     input.remove();
   });
 });
+
+test('setupFocusManagement blurs on outside click', () => {
+  setupFocusManagement();
+  const menu = document.createElement('div');
+  menu.setAttribute('role', 'menu');
+  document.body.appendChild(menu);
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+  input.focus();
+  const event = new MouseEvent('mousedown', { bubbles: true });
+  document.body.dispatchEvent(event);
+  expect(document.activeElement).not.toBe(input);
+  menu.remove();
+  input.remove();
+});

--- a/frontend/src/utils/refreshUtils.test.js
+++ b/frontend/src/utils/refreshUtils.test.js
@@ -35,4 +35,21 @@ describe('refreshUtils', () => {
     checkAndRefresh('flag');
     expect(sessionStorage.getItem('flag')).toBe('2');
   });
+  test("refreshPage triggers reload after delay", () => {
+    const { refreshPage } = require("./refreshUtils");
+    refreshPage(200);
+    expect(window.location.reload).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(200);
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+
+  test("multipleRefreshes triggers reload for each delay", () => {
+    const { multipleRefreshes } = require("./refreshUtils");
+    multipleRefreshes([100, 200]);
+    jest.advanceTimersByTime(100);
+    expect(window.location.reload).toHaveBeenCalledTimes(1);
+    jest.advanceTimersByTime(100);
+    expect(window.location.reload).toHaveBeenCalledTimes(2);
+  });
+
 });


### PR DESCRIPTION
## Summary
- add tests for AuthContext login and profile update
- add outside click test for focusUtils
- add refreshUtils tests for refreshPage and multipleRefreshes

## Testing
- `npm run lint`
- `npm test -- --coverage --watchAll=false`