### PR TITLE
Add more frontend tests

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -41,3 +41,14 @@ test('adds class to body on mount', () => {
   });
   expect(document.body.classList.contains('modern-ui')).toBe(true);
 });
+
+test('removes class on unmount', () => {
+  act(() => {
+    root.render(<App />);
+  });
+  expect(document.body.classList.contains('modern-ui')).toBe(true);
+  act(() => {
+    root.unmount();
+  });
+  expect(document.body.classList.contains('modern-ui')).toBe(false);
+});

--- a/frontend/src/components/Login.test.js
+++ b/frontend/src/components/Login.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import Login from './Login';
+import { BrowserRouter } from 'react-router-dom';
+const axios = require('axios').default;
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { post: jest.fn() }
+}));
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+  delete window.location;
+  window.location = { href: 'start' };
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+  localStorage.clear();
+});
+
+async function renderAndSubmit() {
+  await TestUtils.act(async () => {
+    root.render(
+      <BrowserRouter>
+        <Login />
+      </BrowserRouter>
+    );
+  });
+  const [email, pass] = container.querySelectorAll('input');
+  TestUtils.act(() => { TestUtils.Simulate.change(email, { target: { value: 'e' } }); });
+  TestUtils.act(() => { TestUtils.Simulate.change(pass, { target: { value: 'p' } }); });
+  const form = container.querySelector('form');
+  await TestUtils.act(async () => { TestUtils.Simulate.submit(form); });
+}
+
+test('successful login stores token and redirects', async () => {
+  axios.post.mockResolvedValueOnce({ data: { token: 't', verified: true } });
+  await renderAndSubmit();
+  expect(axios.post).toHaveBeenCalledWith('/api/auth/login', { email: 'e', password: 'p' });
+  expect(localStorage.getItem('token')).toBe('t');
+  expect(window.location.href).toBe('/feed');
+});
+
+test('shows error when email not verified', async () => {
+  axios.post.mockResolvedValueOnce({ data: { verified: false } });
+  await renderAndSubmit();
+  expect(container.textContent).toContain('Please verify your email');
+});

--- a/frontend/src/components/Register.test.js
+++ b/frontend/src/components/Register.test.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import Register from './Register';
+import { BrowserRouter } from 'react-router-dom';
+const axios = require('axios').default;
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { post: jest.fn() }
+}));
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+});
+
+async function renderAndSubmit() {
+  await TestUtils.act(async () => {
+    root.render(
+      <BrowserRouter>
+        <Register />
+      </BrowserRouter>
+    );
+  });
+  const [user, email, pass] = container.querySelectorAll('input');
+  TestUtils.act(() => { TestUtils.Simulate.change(user, { target: { value: 'u' } }); });
+  TestUtils.act(() => { TestUtils.Simulate.change(email, { target: { value: 'e' } }); });
+  TestUtils.act(() => { TestUtils.Simulate.change(pass, { target: { value: 'p' } }); });
+  const form = container.querySelector('form');
+  await TestUtils.act(async () => { TestUtils.Simulate.submit(form); });
+}
+
+test('shows success message on registration', async () => {
+  axios.post.mockResolvedValueOnce({ data: { message: 'ok' } });
+  await renderAndSubmit();
+  expect(axios.post).toHaveBeenCalledWith('/api/auth/register', {
+    username: 'u',
+    email: 'e',
+    password: 'p'
+  });
+  expect(container.textContent).toContain('ok');
+});
+
+test('shows error when registration fails', async () => {
+  axios.post.mockRejectedValueOnce({ response: { data: { error: 'fail' } } });
+  await renderAndSubmit();
+  expect(container.textContent).toContain('fail');
+});

--- a/frontend/src/components/VerifyEmail.test.js
+++ b/frontend/src/components/VerifyEmail.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
+import VerifyEmail from './VerifyEmail';
+import { useSearchParams } from 'react-router-dom';
+const axios = require('axios').default;
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { get: jest.fn() }
+}));
+jest.mock('react-router-dom', () => ({ useSearchParams: jest.fn() }));
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = ReactDOM.createRoot(container);
+});
+
+afterEach(() => {
+  root.unmount();
+  container.remove();
+  container = null;
+});
+
+async function renderComponent(token) {
+  useSearchParams.mockReturnValue([{ get: () => token }]);
+  await TestUtils.act(async () => { root.render(<VerifyEmail />); });
+  await TestUtils.act(async () => Promise.resolve());
+}
+
+test('verifies email and shows success message', async () => {
+  axios.get.mockResolvedValueOnce({ data: { message: 'verified' } });
+  await renderComponent('t1');
+  expect(axios.get).toHaveBeenCalledWith('/api/auth/verify-email?token=t1');
+  expect(container.textContent).toContain('verified');
+});
+
+test('shows error when verification fails', async () => {
+  axios.get.mockRejectedValueOnce({ response: { data: { error: 'bad' } } });
+  await renderComponent('t2');
+  expect(container.textContent).toContain('bad');
+});
+


### PR DESCRIPTION
## Summary
- boost test coverage for the frontend
- cover Register component
- cover VerifyEmail component
- test Login and App behaviour

## Testing
- `npm run lint`
- `npm test -- --coverage --watchAll=false`