### PR TITLE
Add design docs for Discord integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ development.
   its own Jest test suite.
 - `frontend/` – React application bootstrapped with `react-scripts`.
 - `docs/` – Detailed architecture and development docs.
+- `docs/design/` – Design proposals for new features.
 - `docker-compose.yml` – Spins up the full stack locally.
 - `package.json` in the repo root – exposes lint scripts that call into
   each package.
@@ -36,8 +37,12 @@ and development conventions:
 - `DEPLOYMENT.md`
 - `LINTING.md`
 
-Use these documents as a reference when implementing new features or
-updating existing code.
+Design documents in `docs/design/` provide additional details for upcoming
+features. Review them and add new design docs when planning major
+functionality.
+
+Use these documents and any relevant design docs as a reference when
+implementing new features or updating existing code.
 When you add or modify features, update the relevant docs and this AGENTS file so future agents have accurate guidance.
 
 ## Running tests

--- a/docs/design/DISCORD_INTEGRATION.md
+++ b/docs/design/DISCORD_INTEGRATION.md
@@ -1,0 +1,23 @@
+# Discord Integration Design
+
+This document outlines the initial approach for integrating Discord with the Commonly platform. The goal is to enable users to receive updates from Discord channels and leverage the AI summarizer within our chat system.
+
+## Overview
+
+The integration will use Discord Webhooks and API endpoints. Users can choose one of two connection methods:
+
+1. **Account Binding** – The user connects their own Discord account to Commonly. This grants our application permission to read messages from specific channels. While convenient, this approach requires storing OAuth tokens and should be treated with extra security considerations.
+2. **Bot Addition** – The user adds the Commonly bot to a Discord server or channel. The bot receives events through webhooks and forwards relevant data to our backend. This option keeps user credentials private and is generally more secure.
+
+## User Flow
+
+1. In the chat sidebar, an "External Links" section will include an option to link a Discord channel.
+2. Selecting this option will provide instructions for adding the Commonly bot or connecting a personal account.
+3. Once connected, the backend listens for webhook events from Discord and stores them in the database.
+4. The AI summarizer can then generate summaries of recent messages and present them within the chat interface.
+
+## Next Steps
+
+- Define database schema for storing Discord integration details (server, channel, webhook URL).
+- Implement authentication flow for adding the bot or connecting accounts.
+- Expose API endpoints for retrieving and displaying summaries in the chat UI.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,5 @@
+# Design Documents
+
+This directory contains design proposals and architecture notes for new features. Each document outlines goals, user flows, and potential technical approaches.
+
+Refer to these documents before implementing new functionality and feel free to add more as the project evolves.


### PR DESCRIPTION
## Summary
- create docs/design directory with README
- write Discord integration design document
- update AGENTS instructions with design doc guidelines

## Testing
- `npm run lint`
- `npm test` in `backend`
- `npm test` in `frontend`