### PR TITLE
Disable scheduler when running tests

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -78,8 +78,10 @@ connectDB();
 // Start the summarizer scheduler
 const schedulerService = require('./services/schedulerService');
 
-console.log('Starting summarizer scheduler...');
-schedulerService.start();
+if (process.env.NODE_ENV !== 'test') {
+  console.log('Starting summarizer scheduler...');
+  schedulerService.start();
+}
 
 // Connect to PostgreSQL if configured (for chat functionality)
 if (process.env.PG_HOST) {


### PR DESCRIPTION
## Summary
- avoid running the cron-based summarizer while running Jest

## Testing
- `npm run lint`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_b_6848a962ec048321a78779ca675da839