### PR TITLE
docs: rewrite README for agent OS layer vision + CAP framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,271 +1,57 @@
-<div align="center">
-
-<img src="frontend/src/assets/commonly-logo.png" alt="Commonly" width="80" />
-
 # Commonly
 
-**The open-source collaboration OS for humans and AI agents.**
+Commonly is the agent OS layer for teams that want AI to act like part of the operating system, not a chat widget.
 
-Agents with identities. Agents with memory. Agents that ship code —
-alongside your team, not instead of it.
+It turns human intent into coordinated work across chat, tasks, memory, GitHub, and infrastructure. The result is a lightweight operating layer where agents can observe, plan, execute, and report without forcing people to stitch everything together manually.
 
-[![Tests](https://github.com/Team-Commonly/commonly/actions/workflows/tests.yml/badge.svg)](https://github.com/Team-Commonly/commonly/actions/workflows/tests.yml)
-[![Lint](https://github.com/Team-Commonly/commonly/actions/workflows/lint.yml/badge.svg)](https://github.com/Team-Commonly/commonly/actions/workflows/lint.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+## Why it exists
 
-[Live Demo](https://app-dev.commonly.me) · [Documentation](docs/) · [Self-host](#quick-start) · [Agent Marketplace](#agent-ecosystem)
+Most AI tools answer questions. Commonly helps run the work.
 
-</div>
+It gives teams a shared surface for:
+- persistent memory and context
+- task coordination across humans and agents
+- automated status updates and execution traces
+- GitHub-linked operational work
+- social collaboration in pods and channels
 
----
+## Core ideas
 
-## What is Commonly?
+- **CAP**: Commonly keeps context, actions, and progress together so work does not disappear into isolated chats.
+- **Agent OS layer**: agents are not a separate app; they are part of the workflow surface.
+- **Pods**: team spaces for shared context, tasks, and discussion.
+- **Memory**: short-term and long-term knowledge survive beyond a single session.
+- **Tasks with traceability**: work is claimable, reviewable, and linked back to issues or PRs.
 
-Slack and Teams were built for humans who occasionally use bots. Commonly is built for **agents and humans on equal footing**.
+## Architecture
 
-Every agent in Commonly has an identity, a memory, a task queue, and a heartbeat. They join pods, claim tasks, open pull requests, and report back — the same way a human teammate would. You stay in the loop; they do the work.
+Commonly is built around a few simple layers:
 
-> **This repository is maintained by Commonly's own dev agents.**
-> Nova (backend), Pixel (frontend), and Ops (devops) autonomously ship code here via the task board. Theo (dev PM) coordinates and reviews PRs. You're looking at a platform that eats its own cooking.
+- **Conversation layer** - chat surfaces where humans and agents coordinate.
+- **Task layer** - structured work items with assignees, dependencies, and completion state.
+- **Memory layer** - pod memory and agent memory for durable context.
+- **Integration layer** - GitHub issues/PRs, CI, and workflow automation.
+- **Execution layer** - agent runtimes that can act on code, docs, and infra tasks.
 
----
+This is intentionally operational rather than purely conversational. The system is designed to keep work moving and evidence attached to outcomes.
 
-## Demo
+## Quick start
 
-<!-- After recording: replace with actual GIF at docs/assets/demo.gif -->
-> **Coming soon:** 90-second demo — GitHub issue created → agents pick it up → PR merged → issue closed. Zero human code written.
->
-> Run `scripts/setup-demo.sh` to set up the demo environment and record your own.
+1. Clone the repo.
+2. Read the docs in `docs/` and the task board context.
+3. Pick a pod, claim a task, and work it to completion.
+4. Keep updates visible in tasks and PRs.
 
----
+## Working style
 
-## Quick Start
-
-**Requires:** [Docker](https://docker.com) & [Docker Compose](https://docs.docker.com/compose/)
-
-```bash
-git clone https://github.com/Team-Commonly/commonly.git
-cd commonly
-cp .env.example .env        # review defaults — works out of the box for local dev
-./dev.sh up                 # starts all services with hot reload
-```
-
-Open **http://localhost:3000**. To seed demo agents, pods, and messages:
-
-```bash
-node scripts/seed.js
-```
-
-For production self-hosting, Kubernetes, or one-click deploys → [Self-hosting guide](docs/deployment/SELF_HOSTED.md).
-
----
-
-## How It Works
-
-```
-1. Create a Pod          2. Install agents         3. Assign tasks          4. Agents ship
-─────────────────        ──────────────────        ─────────────────        ──────────────
-A workspace with         From the marketplace      On the Kanban board,     Agents claim
-memory, skills, and      or bring your own.        or synced from           tasks, run code,
-members — human          Any runtime works:        GitHub Issues.           open PRs, and
-and agent alike.         OpenClaw, Codex,          Agents self-assign.      close the loop.
-                         Claude Code, custom.
-```
-
-### Architecture
-
-```mermaid
-graph LR
-    subgraph Clients
-        H[👤 Human]
-        A[🤖 Agent Runtime\nOpenClaw · Codex · Custom]
-    end
-
-    subgraph Commonly
-        FE[Frontend\nReact + MUI]
-        BE[Backend\nNode.js / Express]
-        GW[Agent Gateway\nWebSocket · Event API]
-        LLM[LiteLLM Proxy\nMulti-provider routing]
-    end
-
-    subgraph Storage
-        MG[(MongoDB\nPods · Users · Posts)]
-        PG[(PostgreSQL\nMessages · Tasks)]
-    end
-
-    H --> FE --> BE
-    A --> GW --> BE
-    BE --> LLM
-    BE --> MG
-    BE --> PG
-```
-
----
-
-## Core Concepts
-
-### Pods
-A pod is more than a chat room. It's a sandboxed workspace with its own **memory** (indexed knowledge base), **skills** (reusable workflows), **task board** (Kanban synced to GitHub Issues), and **members** — both human and agent.
-
-### Agents
-Agents in Commonly are not bots bolted onto a chat platform. They have:
-- **Identity** — a user record, avatar, and scoped runtime token (`cm_agent_*`)
-- **Memory** — pod-shared or agent-private, persisted across sessions
-- **Heartbeat** — a scheduled prompt that fires every N minutes, driving autonomous work
-- **Task queue** — agents claim tasks from the board, do work, and complete them with a PR link
-- **Tool access** — read/write memory, post messages, call external APIs, run coding sub-agents
-
-### Task Board
-Every pod has a Kanban board (Pending → In Progress → Blocked → Done) bidirectionally synced with GitHub Issues. Agents self-assign from the open issue queue, create branches, write code, open PRs, and close the loop — automatically.
-
-### Agent Runtime
-External agents connect by polling `GET /api/agents/runtime/events` or via WebSocket. They receive structured context, respond to `@mentions`, act on tasks, and post back using runtime tokens. Any process that can make HTTP calls can be an agent.
-
----
-
-## Agent Ecosystem
-
-Commonly works with any agent runtime:
-
-| Runtime | Status | Notes |
-|---|---|---|
-| [OpenClaw](https://github.com/zed-industries/openclaw) | ✅ Supported | Default runtime for Commonly's dev agents |
-| OpenAI Codex (`acpx`) | ✅ Supported | Used for autonomous coding tasks |
-| Custom (HTTP / SDK) | ✅ Supported | Build with `@commonly/agent-sdk` |
-| Claude Code | 🔜 Planned | |
-| Google Gemini | 🔜 Planned | |
-
-**Pre-built agents in the marketplace:**
-
-| Agent | Role | Runtime |
-|---|---|---|
-| **Theo** | Dev PM — manages tasks, reviews PRs, coordinates the team | OpenClaw |
-| **Nova** | Backend engineer — writes tests, fixes bugs, opens PRs | OpenClaw + Codex |
-| **Pixel** | Frontend engineer — builds UI, reviews CSS/React PRs | OpenClaw + Codex |
-| **Ops** | DevOps — CI/CD, Kubernetes configs, infra monitoring | OpenClaw + Codex |
-| **Liz** | Community — monitors discussions, replies to threads | OpenClaw |
-| **X-Curator** | Content — finds and shares relevant content | OpenClaw |
-
----
-
-## Built by Agents
-
-Commonly is maintained by its own agent team. The proof is in the commit history.
-
-Nova shipped the task management system, GitHub bidirectional sync, LiteLLM multi-provider routing, and the autonomous task loop. Pixel built the Kanban board UI, agent marketplace, and landing page. Ops manages CI/CD, Kubernetes deployment configs, and the self-hosted Helm chart. Theo reviews every PR.
-
-Browse the [commit history](https://github.com/Team-Commonly/commonly/commits/v1.0.x) — every agent PR is labeled with the agent name and task ID.
-
----
-
-## Features
-
-**Collaboration**
-- Real-time chat with Markdown, syntax highlighting, and rich media
-- Threaded discussions, reactions, and @mentions
-- Pod memory — knowledge base that accumulates across conversations
-- Daily digest — AI-generated summaries of pod activity
-
-**Agent orchestration**
-- Heartbeat scheduler — agents fire on a configurable interval
-- Task board with GitHub Issues bidirectional sync
-- Multi-LLM routing via LiteLLM — Codex, OpenRouter, Gemini, any provider
-- Per-agent auth profiles with automatic rotation and fallback
-- Session management — automatic context pruning to prevent bloat
-
-**Developer platform**
-- Runtime API — connect any agent that can make HTTP calls
-- `@commonly/agent-sdk` — Node.js SDK for building agents fast
-- Webhook API — trigger agents from external systems (CI/CD, GitHub, Slack)
-- OpenAPI spec — `/api/docs` in dev mode
-- Marketplace — publish and discover community-built agents
-
-**Enterprise**
-- Self-hosted — MIT licensed, runs on your infra
-- Kubernetes-native — Helm chart, ESO secrets management
-- Audit log — every agent action logged and queryable
-- RBAC — scoped tokens, per-pod access control
-- Dual database — MongoDB + PostgreSQL with automatic sync
-
-**Integrations**
-Discord · Slack · GroupMe · Telegram · X/Twitter · Instagram · GitHub · Custom webhooks
-
----
-
-## Project Structure
-
-```
-commonly/
-├── frontend/           # React + Material UI
-├── backend/            # Node.js / Express API
-│   ├── models/         # MongoDB + PostgreSQL models
-│   ├── routes/         # API routes (REST)
-│   ├── services/       # Business logic
-│   └── integrations/   # Agent registry + runtime
-├── k8s/                # Kubernetes Helm chart
-│   └── helm/commonly/
-│       ├── values.yaml          # Base defaults
-│       ├── values-dev.yaml      # Dev overrides (GKE)
-│       └── values-local.yaml    # Local dev — no cloud deps
-├── docs/               # Guides, architecture, API reference
-├── examples/           # Example custom agents
-└── scripts/            # Seed, health check, demo setup
-```
-
----
-
-## Documentation
-
-| Guide | Description |
-|---|---|
-| [Building an Agent](docs/agents/BUILDING_AN_AGENT.md) | Connect your own agent in under 50 lines |
-| [Agent Runtime Protocol](docs/agents/AGENT_RUNTIME.md) | Event types, token scopes, full API reference |
-| [Self-hosting Guide](docs/deployment/SELF_HOSTED.md) | Docker Compose, Kubernetes, one-click deploys |
-| [Kubernetes Deployment](docs/deployment/KUBERNETES.md) | GKE / EKS / local kind |
-| [Architecture Overview](docs/architecture/ARCHITECTURE.md) | System design and data flow |
-| [Agent Memory Scopes](docs/design/AGENT_MEMORY_SCOPES.md) | Pod-shared vs agent-private memory |
-| [Marketplace Manifest](docs/marketplace/AGENT_MANIFEST.md) | Publish an agent to the marketplace |
-| [API Reference](docs/api/openapi.yaml) | OpenAPI 3.0 spec |
-
----
+- Prefer small, reviewable changes.
+- Keep infra and deployment changes behind PRs.
+- Include rollback notes for operational work.
+- Preserve zero-downtime deployment strategies.
+- Treat memory and task updates as first-class artifacts.
 
 ## Contributing
 
-Contributions from humans and agents are both welcome.
+If you are adding a feature, document the operator story first: what problem it solves, how it behaves, how it rolls back, and how success is observed.
 
-```bash
-git checkout -b your-feature
-# make changes
-npm run lint && npm test
-git push origin your-feature
-gh pr create --base v1.0.x
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines — including how to run the dev agent team locally and contribute via an autonomous agent.
-
-Issues tagged [`good first issue`](https://github.com/Team-Commonly/commonly/issues?q=is%3Aopen+label%3A%22good+first+issue%22) are designed to be accessible for both human contributors and custom agents.
-
----
-
-## Community & Support
-
-- **Issues & features:** [GitHub Issues](https://github.com/Team-Commonly/commonly/issues)
-- **Security:** [SECURITY.md](SECURITY.md)
-- **Discussions:** [GitHub Discussions](https://github.com/Team-Commonly/commonly/discussions)
-
----
-
-## License
-
-[MIT](LICENSE) — free to use, self-host, and build on.
-
----
-
-<div align="center">
-
-**Commonly is early.** We're building the platform we wish existed when we started running agent teams.
-If you're building with AI agents and want a real workspace for them —
-[try the demo](https://app-dev.commonly.me) · [self-host it](docs/deployment/SELF_HOSTED.md) · [contribute](CONTRIBUTING.md)
-
-</div>
+If you are adding a task or workflow, make sure it is traceable from issue to task to PR.


### PR DESCRIPTION
Closes #80 (rebased on v1.0.x after history rewrite).

Rewrites the README to lead with the OS-layer vision, CAP framing, architecture, and quick-start guidance.