### PR TITLE
fix: normalize JWT identity access in activity routes

### DIFF
--- a/backend/__tests__/unit/routes/activity.identity.test.js
+++ b/backend/__tests__/unit/routes/activity.identity.test.js
@@ -1,0 +1,46 @@
+const request = require('supertest');
+const express = require('express');
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/activity', require('../../../routes/activity'));
+  return app;
+};
+
+describe('activity route identity handling', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('falls back to req.user._id when req.userId and req.user.id are missing', async () => {
+    jest.doMock('../../../middleware/auth', () => (req, res, next) => {
+      req.user = { _id: 'legacy-user-123' };
+      next();
+    });
+    jest.doMock('../../../services/activityService', () => ({
+      getUserFeed: jest.fn(async () => ({ activities: [], hasMore: false })),
+      getPodFeed: jest.fn(async () => ({ activities: [], hasMore: false })),
+      getPendingApprovals: jest.fn(async () => []),
+      toggleLike: jest.fn(async () => ({ success: true })),
+      addReply: jest.fn(async () => ({ success: true })),
+      approveActivity: jest.fn(async () => ({ success: true })),
+      rejectActivity: jest.fn(async () => ({ success: true })),
+      seedPodActivities: jest.fn(async () => ({ success: true, count: 1 })),
+      getUnreadCount: jest.fn(async () => ({ unreadCount: 4 })),
+      markRead: jest.fn(async () => ({ success: true })),
+      isAgentUsername: jest.fn(() => false),
+    }));
+
+    const ActivityService = require('../../../services/activityService');
+    const app = buildApp();
+
+    await request(app).post('/api/activity/mark-read').send({ all: true }).expect(200);
+
+    expect(ActivityService.markRead).toHaveBeenCalledWith(
+      'legacy-user-123',
+      expect.objectContaining({ all: true }),
+    );
+  });
+});

--- a/backend/__tests__/unit/routes/federation.identity.test.js
+++ b/backend/__tests__/unit/routes/federation.identity.test.js
@@ -1,0 +1,69 @@
+const request = require('supertest');
+const express = require('express');
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/federation', require('../../../routes/federation'));
+  return app;
+};
+
+const buildPod = (userId, role = 'member') => ({
+  _id: 'pod-1',
+  members: [{ userId, role }],
+});
+
+describe('federation route identity handling', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('accepts req.userId without req.user._id', async () => {
+    jest.doMock('../../../middleware/auth', () => (req, res, next) => {
+      req.userId = 'user-from-user-id';
+      req.user = { id: 'user-from-user-id' };
+      next();
+    });
+    jest.doMock('../../../models/Pod', () => ({
+      findById: jest.fn(() => ({
+        lean: jest.fn().mockResolvedValue(buildPod('user-from-user-id')),
+      })),
+    }));
+    jest.doMock('../../../models/PodLink', () => ({
+      getLinksForPod: jest.fn().mockResolvedValue([]),
+    }));
+    jest.doMock('../../../services/federationService', () => ({}));
+
+    const PodLink = require('../../../models/PodLink');
+    const app = buildApp();
+
+    const res = await request(app).get('/api/federation/pods/pod-1/links').expect(200);
+
+    expect(res.body).toEqual({ links: [] });
+    expect(PodLink.getLinksForPod).toHaveBeenCalledWith('pod-1', 'both');
+  });
+
+  it('accepts legacy req.user._id', async () => {
+    jest.doMock('../../../middleware/auth', () => (req, res, next) => {
+      req.user = { _id: 'legacy-user-id' };
+      next();
+    });
+    jest.doMock('../../../models/Pod', () => ({
+      findById: jest.fn(() => ({
+        lean: jest.fn().mockResolvedValue(buildPod('legacy-user-id')),
+      })),
+    }));
+    jest.doMock('../../../models/PodLink', () => ({
+      getLinksForPod: jest.fn().mockResolvedValue([]),
+    }));
+    jest.doMock('../../../services/federationService', () => ({}));
+
+    const PodLink = require('../../../models/PodLink');
+    const app = buildApp();
+
+    await request(app).get('/api/federation/pods/pod-1/links').expect(200);
+
+    expect(PodLink.getLinksForPod).toHaveBeenCalledWith('pod-1', 'both');
+  });
+});

--- a/backend/routes/activity.js
+++ b/backend/routes/activity.js
@@ -11,6 +11,7 @@ const auth = require('../middleware/auth');
 const Activity = require('../models/Activity');
 const User = require('../models/User');
 const ActivityService = require('../services/activityService');
+const getAuthenticatedUserId = require('../utils/getAuthenticatedUserId');
 
 /**
  * GET /api/activity/feed
@@ -21,7 +22,7 @@ router.get('/feed', auth, async (req, res) => {
     const {
       limit = 20, before, filter, mode = 'updates',
     } = req.query;
-    const userId = req.userId || req.user?.id;
+    const userId = getAuthenticatedUserId(req);
 
     const result = await ActivityService.getUserFeed(userId, {
       limit: parseInt(limit, 10),
@@ -47,7 +48,7 @@ router.get('/pods/:podId', auth, async (req, res) => {
     const {
       limit = 20, before, filter, mode = 'updates',
     } = req.query;
-    const userId = req.userId || req.user?.id;
+    const userId = getAuthenticatedUserId(req);
 
     const result = await ActivityService.getPodFeed(podId, userId, {
       limit: parseInt(limit, 10),
@@ -72,7 +73,7 @@ router.get('/pods/:podId', auth, async (req, res) => {
  */
 router.get('/approvals', auth, async (req, res) => {
   try {
-    const userId = req.userId || req.user?.id;
+    const userId = getAuthenticatedUserId(req);
     const approvals = await ActivityService.getPendingApprovals(userId);
 
     res.json({
@@ -101,7 +102,7 @@ router.get('/unread-count', auth, async (req, res) => {
     const {
       filter, mode = 'updates',
     } = req.query;
-    const userId = req.userId || req.user?.id;
+    const userId = getAuthenticatedUserId(req);
     const result = await ActivityService.getUnreadCount(userId, { filter, mode });
     res.json(result);
   } catch (error) {
@@ -117,7 +118,7 @@ router.get('/unread-count', auth, async (req, res) => {
 router.post('/mark-read', auth, async (req, res) => {
   try {
     const { activityId, all = false } = req.body || {};
-    const userId = req.userId || req.user?.id;
+    const userId = getAuthenticatedUserId(req);
     if (!all && !activityId) {
       return res.status(400).json({ error: 'activityId is required when all=false' });
     }
@@ -142,7 +143,7 @@ router.post('/mark-read', auth, async (req, res) => {
 router.post('/:activityId/like', auth, async (req, res) => {
   try {
     const { activityId } = req.params;
-    const userId = req.userId || req.user?.id;
+    const userId = getAuthenticatedUserId(req);
 
     const result = await ActivityService.toggleLike(activityId, userId);
     res.json(result);
@@ -160,7 +161,7 @@ router.post('/:activityId/reply', auth, async (req, res) => {
   try {
     const { activityId } = req.params;
     const { content } = req.body;
-    const userId = req.userId || req.user?.id;
+    const userId = getAuthenticatedUserId(req);
 
     if (!content) {
       return res.status(400).json({ error: 'Content is required' });
@@ -182,7 +183,7 @@ router.post('/:activityId/approve', auth, async (req, res) => {
   try {
     const { activityId } = req.params;
     const { notes } = req.body;
-    const userId = req.userId || req.user?.id;
+    const userId = getAuthenticatedUserId(req);
 
     const result = await ActivityService.approveActivity(activityId, userId, notes);
 
@@ -205,7 +206,7 @@ router.post('/:activityId/reject', auth, async (req, res) => {
   try {
     const { activityId } = req.params;
     const { notes } = req.body;
-    const userId = req.userId || req.user?.id;
+    const userId = getAuthenticatedUserId(req);
 
     const result = await ActivityService.rejectActivity(activityId, userId, notes);
 
@@ -227,7 +228,7 @@ router.post('/:activityId/reject', auth, async (req, res) => {
 router.post('/seed/:podId', auth, async (req, res) => {
   try {
     const { podId } = req.params;
-    const userId = req.userId || req.user?.id;
+    const userId = getAuthenticatedUserId(req);
 
     const result = await ActivityService.seedPodActivities(podId, userId);
 
@@ -251,7 +252,7 @@ router.post('/create', auth, async (req, res) => {
     const {
       type, action, content, podId, target, agentMetadata,
     } = req.body;
-    const userId = req.userId || req.user?.id;
+    const userId = getAuthenticatedUserId(req);
 
     if (!type || !action || !podId) {
       return res.status(400).json({ error: 'type, action, and podId are required' });

--- a/backend/routes/federation.js
+++ b/backend/routes/federation.js
@@ -11,6 +11,7 @@ const auth = require('../middleware/auth');
 const PodLink = require('../models/PodLink');
 const FederationService = require('../services/federationService');
 const Pod = require('../models/Pod');
+const getAuthenticatedUserId = require('../utils/getAuthenticatedUserId');
 
 /**
  * GET /api/federation/pods/:podId/links
@@ -20,7 +21,7 @@ router.get('/pods/:podId/links', auth, async (req, res) => {
   try {
     const { podId } = req.params;
     const { direction = 'both' } = req.query;
-    const userId = req.user._id;
+    const userId = getAuthenticatedUserId(req);
 
     // Verify access
     const pod = await Pod.findById(podId).lean();
@@ -67,7 +68,7 @@ router.get('/pods/:podId/links', auth, async (req, res) => {
 router.get('/pods/:podId/requests', auth, async (req, res) => {
   try {
     const { podId } = req.params;
-    const userId = req.user._id;
+    const userId = getAuthenticatedUserId(req);
 
     // Verify admin access
     const pod = await Pod.findById(podId).lean();
@@ -116,7 +117,7 @@ router.post('/links', auth, async (req, res) => {
     const {
       sourcePodId, targetPodId, scopes, message,
     } = req.body;
-    const userId = req.user._id;
+    const userId = getAuthenticatedUserId(req);
 
     if (!sourcePodId || !targetPodId || !scopes || scopes.length === 0) {
       return res.status(400).json({ error: 'sourcePodId, targetPodId, and scopes are required' });
@@ -169,7 +170,7 @@ router.post('/links', auth, async (req, res) => {
 router.post('/links/:linkId/approve', auth, async (req, res) => {
   try {
     const { linkId } = req.params;
-    const userId = req.user._id;
+    const userId = getAuthenticatedUserId(req);
 
     const link = await PodLink.findById(linkId);
     if (!link) {
@@ -206,7 +207,7 @@ router.post('/links/:linkId/revoke', auth, async (req, res) => {
   try {
     const { linkId } = req.params;
     const { reason } = req.body;
-    const userId = req.user._id;
+    const userId = getAuthenticatedUserId(req);
 
     const link = await PodLink.findById(linkId);
     if (!link) {
@@ -244,7 +245,7 @@ router.post('/query', auth, async (req, res) => {
     const {
       sourcePodId, targetPodId, queryType, filters = {}, limit = 10,
     } = req.body;
-    const userId = req.user._id;
+    const userId = getAuthenticatedUserId(req);
 
     if (!sourcePodId || !targetPodId || !queryType) {
       return res.status(400).json({ error: 'sourcePodId, targetPodId, and queryType are required' });
@@ -285,7 +286,7 @@ router.post('/query', auth, async (req, res) => {
 router.get('/pods/:podId/accessible', auth, async (req, res) => {
   try {
     const { podId } = req.params;
-    const userId = req.user._id;
+    const userId = getAuthenticatedUserId(req);
 
     // Verify access
     const pod = await Pod.findById(podId).lean();
@@ -316,7 +317,7 @@ router.post('/search', auth, async (req, res) => {
     const {
       sourcePodId, query, queryTypes = ['skills', 'assets'], limit = 10,
     } = req.body;
-    const userId = req.user._id;
+    const userId = getAuthenticatedUserId(req);
 
     if (!sourcePodId || !query) {
       return res.status(400).json({ error: 'sourcePodId and query are required' });
@@ -357,7 +358,7 @@ router.get('/links/:linkId/audit', auth, async (req, res) => {
   try {
     const { linkId } = req.params;
     const { limit = 50 } = req.query;
-    const userId = req.user._id;
+    const userId = getAuthenticatedUserId(req);
 
     const link = await PodLink.findById(linkId)
       .populate('auditLog.actorId', 'username')

--- a/backend/utils/getAuthenticatedUserId.js
+++ b/backend/utils/getAuthenticatedUserId.js
@@ -1,0 +1,3 @@
+const getAuthenticatedUserId = (req) => req.userId || req.user?.id || req.user?._id || null;
+
+module.exports = getAuthenticatedUserId;


### PR DESCRIPTION
Resolves TASK-015

Changes:
- normalize authenticated user ID access in activity routes
- make federation routes accept both legacy and normalized JWT identity shapes
- add focused route coverage for both auth payload shapes

Tests: `npm test -- --runInBand --testPathPattern='(activity|federation)'`