### PR TITLE
feat(032): agent manifest registry backend

### DIFF
--- a/backend/__tests__/unit/routes/registry.publish.test.js
+++ b/backend/__tests__/unit/routes/registry.publish.test.js
@@ -1,0 +1,167 @@
+jest.mock('../../../middleware/auth', () => (req, res, next) => next());
+jest.mock('../../../middleware/adminAuth', () => (req, res, next) => next());
+
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentRegistry: {
+    getByName: jest.fn(),
+    create: jest.fn(),
+  },
+  AgentInstallation: {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    getInstalledAgents: jest.fn(),
+    install: jest.fn(),
+  },
+}));
+
+jest.mock('../../../models/AgentProfile', () => ({}));
+jest.mock('../../../models/Activity', () => ({}));
+jest.mock('../../../models/Pod', () => ({}));
+jest.mock('../../../models/User', () => ({}));
+jest.mock('../../../models/Gateway', () => ({}));
+jest.mock('../../../models/Integration', () => ({}));
+jest.mock('../../../models/AgentTemplate', () => ({}));
+
+jest.mock('../../../services/agentIdentityService', () => ({
+  getAgentTypes: jest.fn(() => ({})),
+}));
+jest.mock('../../../services/agentEventService', () => ({}));
+jest.mock('../../../services/dmService', () => ({}));
+jest.mock('../../../services/llmService', () => ({
+  generateText: jest.fn(),
+}));
+jest.mock('../../../services/agentProvisionerService', () => ({
+  provisionAgentRuntime: jest.fn(),
+  startAgentRuntime: jest.fn(),
+  stopAgentRuntime: jest.fn(),
+  restartAgentRuntime: jest.fn(),
+  getAgentRuntimeStatus: jest.fn(),
+  getAgentRuntimeLogs: jest.fn(),
+  clearAgentRuntimeSessions: jest.fn(),
+  isK8sMode: jest.fn(),
+  listOpenClawPlugins: jest.fn(),
+  listOpenClawBundledSkills: jest.fn(),
+  installOpenClawPlugin: jest.fn(),
+  writeOpenClawHeartbeatFile: jest.fn(),
+  readOpenClawHeartbeatFile: jest.fn(),
+  readOpenClawIdentityFile: jest.fn(),
+  writeWorkspaceIdentityFile: jest.fn(),
+  ensureWorkspaceIdentityFile: jest.fn(),
+  syncOpenClawSkills: jest.fn(),
+  resolveOpenClawAccountId: jest.fn(),
+}));
+jest.mock('../../../utils/secret', () => ({
+  hash: jest.fn(),
+  randomSecret: jest.fn(),
+}));
+
+const { AgentRegistry } = require('../../../models/AgentRegistry');
+const registryRoutes = require('../../../routes/registry');
+
+const getRouteHandler = (path, method) => {
+  const layer = registryRoutes.stack.find((entry) => (
+    entry.route
+    && entry.route.path === path
+    && entry.route.methods[method]
+  ));
+  if (!layer) throw new Error(`Route not found: ${method.toUpperCase()} ${path}`);
+  return layer.route.stack[layer.route.stack.length - 1].handle;
+};
+
+describe('registry publish route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('stores a normalized community manifest payload', async () => {
+    const handler = getRouteHandler('/publish', 'post');
+    const req = {
+      userId: 'user-1',
+      user: { id: 'user-1', username: 'nova' },
+      body: {
+        manifest: {
+          name: 'Support-Agent',
+          displayName: 'Support Agent',
+          version: '1.0.0',
+          description: ' Handles support questions ',
+          categories: ['support', 'support'],
+          tags: ['chat', 'automation'],
+          runtime: {
+            type: 'standalone',
+            connection: 'rest',
+          },
+        },
+        readme: 'hello',
+      },
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    AgentRegistry.getByName.mockResolvedValue(null);
+    AgentRegistry.create.mockResolvedValue({
+      agentName: 'support-agent',
+      latestVersion: '1.0.0',
+      status: 'active',
+    });
+
+    await handler(req, res);
+
+    expect(AgentRegistry.getByName).toHaveBeenCalledWith('support-agent');
+    expect(AgentRegistry.create).toHaveBeenCalledWith(expect.objectContaining({
+      agentName: 'support-agent',
+      displayName: 'Support Agent',
+      description: 'Handles support questions',
+      categories: ['support'],
+      tags: ['chat', 'automation'],
+      manifest: expect.objectContaining({
+        name: 'support-agent',
+        version: '1.0.0',
+        description: 'Handles support questions',
+        runtime: {
+          type: 'standalone',
+          connection: 'rest',
+        },
+      }),
+    }));
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      agent: {
+        name: 'support-agent',
+        version: '1.0.0',
+        status: 'active',
+      },
+    });
+  });
+
+  it('returns a 400 response when the manifest format is invalid', async () => {
+    const handler = getRouteHandler('/publish', 'post');
+    const req = {
+      userId: 'user-1',
+      user: { id: 'user-1', username: 'nova' },
+      body: {
+        manifest: {
+          name: 'Bad Agent Name',
+          version: 'draft',
+        },
+      },
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      error: 'Invalid agent manifest',
+      details: expect.arrayContaining([
+        expect.objectContaining({ field: 'manifest.name' }),
+        expect.objectContaining({ field: 'manifest.version' }),
+      ]),
+    }));
+    expect(AgentRegistry.getByName).not.toHaveBeenCalled();
+  });
+});

--- a/backend/__tests__/unit/utils/agentManifestRegistry.test.js
+++ b/backend/__tests__/unit/utils/agentManifestRegistry.test.js
@@ -1,0 +1,144 @@
+const {
+  ManifestValidationError,
+  normalizePublishPayload,
+} = require('../../../utils/agentManifestRegistry');
+
+describe('agent manifest registry payload normalization', () => {
+  it('normalizes and sanitizes a valid publish payload', () => {
+    const payload = normalizePublishPayload({
+      manifest: {
+        name: '  Valid-Agent  ',
+        displayName: '  Valid Agent  ',
+        version: '1.2.3',
+        description: ' Registry-safe manifest ',
+        homepage: 'https://example.com/docs',
+        repository: 'https://github.com/acme/valid-agent',
+        categories: ['support', 'support', 'ops'],
+        tags: ['chat', 'chat', 'automation'],
+        capabilities: [
+          { name: ' Summarize ', description: ' Summaries ' },
+          { name: 'Summarize', description: 'duplicate' },
+        ],
+        context: {
+          required: ['messages:write', 'messages:write'],
+          optional: ['context:read'],
+        },
+        integrations: {
+          supported: ['discord', 'slack', 'discord'],
+          required: ['discord'],
+        },
+        models: {
+          supported: ['gpt-5-mini', 'gpt-5-mini', 'gpt-5'],
+          recommended: 'gpt-5',
+        },
+        runtime: {
+          type: 'standalone',
+          connection: 'rest',
+          minMemory: '512mb',
+          ports: {
+            http: 8080,
+          },
+        },
+        configSchema: {
+          type: 'object',
+        },
+        hooks: {
+          postInstall: 'npm run setup',
+        },
+      },
+      readme: '# Readme\n',
+    });
+
+    expect(payload).toEqual({
+      displayName: 'Valid Agent',
+      readme: '# Readme\n',
+      categories: ['support', 'ops'],
+      tags: ['chat', 'automation'],
+      manifest: {
+        name: 'valid-agent',
+        version: '1.2.3',
+        description: 'Registry-safe manifest',
+        homepage: 'https://example.com/docs',
+        repository: 'https://github.com/acme/valid-agent',
+        capabilities: [
+          { name: 'Summarize', description: 'Summaries' },
+        ],
+        context: {
+          required: ['messages:write'],
+          optional: ['context:read'],
+        },
+        integrations: {
+          supported: ['discord', 'slack'],
+          required: ['discord'],
+        },
+        models: {
+          supported: ['gpt-5-mini', 'gpt-5'],
+          recommended: 'gpt-5',
+        },
+        runtime: {
+          type: 'standalone',
+          connection: 'rest',
+          minMemory: '512MB',
+          ports: {
+            http: 8080,
+          },
+        },
+        configSchema: {
+          type: 'object',
+        },
+        hooks: {
+          postInstall: 'npm run setup',
+        },
+      },
+    });
+  });
+
+  it('rejects malformed manifests with structured validation errors', () => {
+    expect(() => normalizePublishPayload({
+      manifest: {
+        name: 'No Spaces Allowed',
+        version: 'latest',
+        homepage: 'ftp://example.com/file',
+        integrations: {
+          supported: ['discord'],
+          required: ['slack'],
+        },
+        runtime: {
+          ports: {
+            http: 70000,
+          },
+        },
+      },
+      readme: { invalid: true },
+    })).toThrow(ManifestValidationError);
+
+    try {
+      normalizePublishPayload({
+        manifest: {
+          name: 'No Spaces Allowed',
+          version: 'latest',
+          homepage: 'ftp://example.com/file',
+          integrations: {
+            supported: ['discord'],
+            required: ['slack'],
+          },
+          runtime: {
+            ports: {
+              http: 70000,
+            },
+          },
+        },
+        readme: { invalid: true },
+      });
+    } catch (error) {
+      expect(error.details).toEqual(expect.arrayContaining([
+        expect.objectContaining({ field: 'manifest.name' }),
+        expect.objectContaining({ field: 'manifest.version' }),
+        expect.objectContaining({ field: 'manifest.homepage' }),
+        expect.objectContaining({ field: 'manifest.integrations.required' }),
+        expect.objectContaining({ field: 'manifest.runtime.ports.http' }),
+        expect.objectContaining({ field: 'readme' }),
+      ]));
+    }
+  });
+});

--- a/backend/routes/registry.js
+++ b/backend/routes/registry.js
@@ -45,6 +45,10 @@ const {
   resolveOpenClawAccountId,
 } = require('../services/agentProvisionerService');
 const { hash, randomSecret } = require('../utils/secret');
+const {
+  ManifestValidationError,
+  normalizePublishPayload,
+} = require('../utils/agentManifestRegistry');
 
 const buildIdentityContent = (name, persona) => {
   const toneMap = {
@@ -6240,18 +6244,26 @@ router.patch('/pods/:podId/agents/:name', auth, async (req, res) => {
  */
 router.post('/publish', auth, async (req, res) => {
   try {
-    const { manifest, readme } = req.body;
     const userId = getUserId(req);
     if (!userId) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
 
-    if (!manifest?.name || !manifest?.version) {
-      return res.status(400).json({ error: 'Manifest must include name and version' });
-    }
+    const {
+      manifest,
+      displayName,
+      readme,
+      categories,
+      tags,
+    } = normalizePublishPayload(req.body);
 
     // Check if agent already exists
     let agent = await AgentRegistry.getByName(manifest.name);
+    const versionPayload = {
+      version: manifest.version,
+      manifest,
+      publishedAt: new Date(),
+    };
 
     if (agent) {
       // Check ownership
@@ -6259,39 +6271,37 @@ router.post('/publish', auth, async (req, res) => {
         return res.status(403).json({ error: 'Not authorized to update this agent' });
       }
 
-      // Add new version
-      agent.versions.push({
-        version: manifest.version,
-        manifest,
-        publishedAt: new Date(),
-      });
+      agent.versions = Array.isArray(agent.versions)
+        ? [
+          ...agent.versions.filter((entry) => entry.version !== manifest.version),
+          versionPayload,
+        ]
+        : [versionPayload];
       agent.latestVersion = manifest.version;
       agent.manifest = manifest;
-      if (readme) agent.readme = readme;
+      agent.displayName = displayName;
+      agent.description = manifest.description || '';
+      agent.categories = categories;
+      agent.tags = tags;
+      if (readme !== null) agent.readme = readme;
       await agent.save();
     } else {
       // Create new agent
       agent = await AgentRegistry.create({
         agentName: manifest.name.toLowerCase(),
-        displayName: manifest.name,
+        displayName,
         description: manifest.description || '',
         readme,
         manifest,
         latestVersion: manifest.version,
-        versions: [
-          {
-            version: manifest.version,
-            manifest,
-            publishedAt: new Date(),
-          },
-        ],
+        versions: [versionPayload],
         registry: 'commonly-community',
         publisher: {
           userId,
           name: req.user.username,
         },
-        categories: manifest.categories || [],
-        tags: manifest.tags || [],
+        categories,
+        tags,
       });
     }
 
@@ -6304,6 +6314,12 @@ router.post('/publish', auth, async (req, res) => {
       },
     });
   } catch (error) {
+    if (error instanceof ManifestValidationError) {
+      return res.status(400).json({
+        error: error.message,
+        details: error.details,
+      });
+    }
     console.error('Error publishing agent:', error);
     res.status(500).json({ error: error.message || 'Failed to publish agent' });
   }

--- a/backend/utils/agentManifestRegistry.js
+++ b/backend/utils/agentManifestRegistry.js
@@ -1,0 +1,400 @@
+const AGENT_NAME_PATTERN = /^[a-z0-9-]+$/;
+const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/;
+const SLUG_PATTERN = /^[a-z0-9-]+$/;
+const SCOPE_PATTERN = /^[a-z0-9:_-]+$/i;
+const MEMORY_PATTERN = /^\d+(?:\.\d+)?(?:kb|mb|gb|tb)$/i;
+
+class ManifestValidationError extends Error {
+  constructor(details) {
+    super('Invalid agent manifest');
+    this.name = 'ManifestValidationError';
+    this.details = details;
+  }
+}
+
+const isPlainObject = (value) => (
+  value !== null
+  && typeof value === 'object'
+  && !Array.isArray(value)
+);
+
+const addError = (details, field, message) => {
+  details.push({ field, message });
+};
+
+const normalizeString = (value, {
+  trim = true,
+  maxLength = 200,
+} = {}) => {
+  if (typeof value !== 'string') return '';
+  const nextValue = trim ? value.trim() : value;
+  if (!nextValue) return '';
+  return nextValue.slice(0, maxLength);
+};
+
+const normalizeSlugList = (value, field, details, maxItems = 20) => {
+  if (value == null) return [];
+  if (!Array.isArray(value)) {
+    addError(details, field, 'Must be an array of lowercase slugs');
+    return [];
+  }
+
+  const seen = new Set();
+  const normalized = [];
+
+  value.forEach((entry, index) => {
+    const nextValue = normalizeString(entry, { maxLength: 64 }).toLowerCase();
+    if (!nextValue) return;
+    if (!SLUG_PATTERN.test(nextValue)) {
+      addError(details, `${field}[${index}]`, 'Must contain only lowercase letters, numbers, and hyphens');
+      return;
+    }
+    if (seen.has(nextValue)) return;
+    seen.add(nextValue);
+    if (normalized.length < maxItems) normalized.push(nextValue);
+  });
+
+  if (value.length > maxItems) {
+    addError(details, field, `Must not contain more than ${maxItems} entries`);
+  }
+
+  return normalized;
+};
+
+const normalizeScopeList = (value, field, details, maxItems = 50) => {
+  if (value == null) return [];
+  if (!Array.isArray(value)) {
+    addError(details, field, 'Must be an array of scope strings');
+    return [];
+  }
+
+  const seen = new Set();
+  const normalized = [];
+
+  value.forEach((entry, index) => {
+    const nextValue = normalizeString(entry, { maxLength: 100 });
+    if (!nextValue) return;
+    if (!SCOPE_PATTERN.test(nextValue)) {
+      addError(details, `${field}[${index}]`, 'Must be a valid scope string');
+      return;
+    }
+    if (seen.has(nextValue)) return;
+    seen.add(nextValue);
+    if (normalized.length < maxItems) normalized.push(nextValue);
+  });
+
+  if (value.length > maxItems) {
+    addError(details, field, `Must not contain more than ${maxItems} entries`);
+  }
+
+  return normalized;
+};
+
+const normalizeStringList = (value, field, details, {
+  maxItems = 50,
+  maxLength = 100,
+} = {}) => {
+  if (value == null) return [];
+  if (!Array.isArray(value)) {
+    addError(details, field, 'Must be an array of strings');
+    return [];
+  }
+
+  const seen = new Set();
+  const normalized = [];
+
+  value.forEach((entry) => {
+    const nextValue = normalizeString(entry, { maxLength });
+    if (!nextValue) return;
+    if (seen.has(nextValue)) return;
+    seen.add(nextValue);
+    if (normalized.length < maxItems) normalized.push(nextValue);
+  });
+
+  if (value.length > maxItems) {
+    addError(details, field, `Must not contain more than ${maxItems} entries`);
+  }
+
+  return normalized;
+};
+
+const normalizeUrl = (value, field, details) => {
+  const nextValue = normalizeString(value, { maxLength: 500 });
+  if (!nextValue) return '';
+
+  try {
+    const parsed = new URL(nextValue);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      addError(details, field, 'Must use http or https');
+      return '';
+    }
+    return parsed.toString();
+  } catch (error) {
+    addError(details, field, 'Must be a valid URL');
+    return '';
+  }
+};
+
+const normalizeCapabilities = (value, details) => {
+  if (value == null) return [];
+  if (!Array.isArray(value)) {
+    addError(details, 'manifest.capabilities', 'Must be an array');
+    return [];
+  }
+
+  const seen = new Set();
+  const normalized = [];
+
+  value.forEach((entry, index) => {
+    if (!isPlainObject(entry)) {
+      addError(details, `manifest.capabilities[${index}]`, 'Must be an object');
+      return;
+    }
+    const name = normalizeString(entry.name, { maxLength: 80 });
+    if (!name) {
+      addError(details, `manifest.capabilities[${index}].name`, 'Capability name is required');
+      return;
+    }
+    const dedupeKey = name.toLowerCase();
+    if (seen.has(dedupeKey)) return;
+    seen.add(dedupeKey);
+    normalized.push({
+      name,
+      ...(normalizeString(entry.description, { maxLength: 200 }) ? {
+        description: normalizeString(entry.description, { maxLength: 200 }),
+      } : {}),
+    });
+  });
+
+  if (value.length > 50) {
+    addError(details, 'manifest.capabilities', 'Must not contain more than 50 entries');
+  }
+
+  return normalized;
+};
+
+const normalizeRuntime = (value, details) => {
+  if (value == null) return null;
+  if (!isPlainObject(value)) {
+    addError(details, 'manifest.runtime', 'Must be an object');
+    return null;
+  }
+
+  const runtime = {};
+  const type = normalizeString(value.type, { maxLength: 40 });
+  if (type) {
+    if (!['standalone', 'commonly-hosted', 'hybrid'].includes(type)) {
+      addError(details, 'manifest.runtime.type', 'Must be standalone, commonly-hosted, or hybrid');
+    } else {
+      runtime.type = type;
+    }
+  }
+
+  const connection = normalizeString(value.connection, { maxLength: 40 });
+  if (connection) {
+    if (!['mcp', 'rest', 'websocket'].includes(connection)) {
+      addError(details, 'manifest.runtime.connection', 'Must be mcp, rest, or websocket');
+    } else {
+      runtime.connection = connection;
+    }
+  }
+
+  const minMemory = normalizeString(value.minMemory, { maxLength: 40 });
+  if (minMemory) {
+    if (!MEMORY_PATTERN.test(minMemory)) {
+      addError(details, 'manifest.runtime.minMemory', 'Must look like 512MB or 1GB');
+    } else {
+      runtime.minMemory = minMemory.toUpperCase();
+    }
+  }
+
+  if (value.ports != null) {
+    if (!isPlainObject(value.ports)) {
+      addError(details, 'manifest.runtime.ports', 'Must be an object keyed by port name');
+    } else {
+      const ports = {};
+      Object.entries(value.ports).forEach(([key, portValue]) => {
+        const portName = normalizeString(key, { maxLength: 50 });
+        const portNumber = Number(portValue);
+        if (!portName) {
+          addError(details, 'manifest.runtime.ports', 'Port names are required');
+          return;
+        }
+        if (!Number.isInteger(portNumber) || portNumber < 1 || portNumber > 65535) {
+          addError(details, `manifest.runtime.ports.${portName}`, 'Must be an integer between 1 and 65535');
+          return;
+        }
+        ports[portName] = portNumber;
+      });
+      if (Object.keys(ports).length) runtime.ports = ports;
+    }
+  }
+
+  return Object.keys(runtime).length ? runtime : null;
+};
+
+const normalizeHooks = (value, details) => {
+  if (value == null) return null;
+  if (!isPlainObject(value)) {
+    addError(details, 'manifest.hooks', 'Must be an object');
+    return null;
+  }
+
+  const hooks = {};
+  ['postInstall', 'preUpdate', 'postUpdate'].forEach((field) => {
+    const nextValue = normalizeString(value[field], { maxLength: 200 });
+    if (nextValue) hooks[field] = nextValue;
+  });
+
+  return Object.keys(hooks).length ? hooks : null;
+};
+
+const normalizeManifest = (input, details) => {
+  if (!isPlainObject(input)) {
+    addError(details, 'manifest', 'Manifest must be an object');
+    return null;
+  }
+
+  const name = normalizeString(input.name, { maxLength: 100 }).toLowerCase();
+  if (!name) {
+    addError(details, 'manifest.name', 'Name is required');
+  } else if (!AGENT_NAME_PATTERN.test(name)) {
+    addError(details, 'manifest.name', 'Must contain only lowercase letters, numbers, and hyphens');
+  }
+
+  const version = normalizeString(input.version, { maxLength: 40 });
+  if (!version) {
+    addError(details, 'manifest.version', 'Version is required');
+  } else if (!SEMVER_PATTERN.test(version)) {
+    addError(details, 'manifest.version', 'Must be a valid semantic version');
+  }
+
+  const manifest = {
+    name,
+    version,
+  };
+
+  const description = normalizeString(input.description, { maxLength: 500 });
+  if (description) manifest.description = description;
+
+  const author = normalizeString(input.author, { maxLength: 120 });
+  if (author) manifest.author = author;
+
+  const license = normalizeString(input.license, { maxLength: 80 });
+  if (license) manifest.license = license;
+
+  const homepage = normalizeUrl(input.homepage, 'manifest.homepage', details);
+  if (homepage) manifest.homepage = homepage;
+
+  const repository = normalizeUrl(input.repository, 'manifest.repository', details);
+  if (repository) manifest.repository = repository;
+
+  const capabilities = normalizeCapabilities(input.capabilities, details);
+  if (capabilities.length) manifest.capabilities = capabilities;
+
+  if (input.context != null) {
+    if (!isPlainObject(input.context)) {
+      addError(details, 'manifest.context', 'Must be an object');
+    } else {
+      const required = normalizeScopeList(input.context.required, 'manifest.context.required', details);
+      const optional = normalizeScopeList(input.context.optional, 'manifest.context.optional', details);
+      if (required.length || optional.length) {
+        manifest.context = {};
+        if (required.length) manifest.context.required = required;
+        if (optional.length) manifest.context.optional = optional;
+      }
+    }
+  }
+
+  if (input.integrations != null) {
+    if (!isPlainObject(input.integrations)) {
+      addError(details, 'manifest.integrations', 'Must be an object');
+    } else {
+      const supported = normalizeSlugList(input.integrations.supported, 'manifest.integrations.supported', details, 30);
+      const required = normalizeSlugList(input.integrations.required, 'manifest.integrations.required', details, 30);
+      if (required.some((entry) => !supported.includes(entry))) {
+        addError(details, 'manifest.integrations.required', 'Required integrations must also appear in supported');
+      }
+      if (supported.length || required.length) {
+        manifest.integrations = {};
+        if (supported.length) manifest.integrations.supported = supported;
+        if (required.length) manifest.integrations.required = required;
+      }
+    }
+  }
+
+  if (input.models != null) {
+    if (!isPlainObject(input.models)) {
+      addError(details, 'manifest.models', 'Must be an object');
+    } else {
+      const supported = normalizeStringList(input.models.supported, 'manifest.models.supported', details, {
+        maxItems: 30,
+        maxLength: 80,
+      });
+      const recommended = normalizeString(input.models.recommended, { maxLength: 80 });
+      if (recommended && supported.length && !supported.includes(recommended)) {
+        addError(details, 'manifest.models.recommended', 'Recommended model must appear in supported');
+      }
+      if (supported.length || recommended) {
+        manifest.models = {};
+        if (supported.length) manifest.models.supported = supported;
+        if (recommended) manifest.models.recommended = recommended;
+      }
+    }
+  }
+
+  const runtime = normalizeRuntime(input.runtime, details);
+  if (runtime) manifest.runtime = runtime;
+
+  if (input.configSchema != null) {
+    if (typeof input.configSchema === 'boolean' || isPlainObject(input.configSchema)) {
+      manifest.configSchema = input.configSchema;
+    } else {
+      addError(details, 'manifest.configSchema', 'Must be a JSON object or boolean');
+    }
+  }
+
+  const hooks = normalizeHooks(input.hooks, details);
+  if (hooks) manifest.hooks = hooks;
+
+  return manifest;
+};
+
+const normalizePublishPayload = (payload = {}) => {
+  const details = [];
+  if (!isPlainObject(payload)) {
+    throw new ManifestValidationError([{ field: 'body', message: 'Request body must be an object' }]);
+  }
+
+  const manifest = normalizeManifest(payload.manifest, details);
+  const displayName = normalizeString(payload.manifest?.displayName, { maxLength: 100 })
+    || manifest?.name
+    || '';
+  const readme = payload.readme == null ? null : normalizeString(payload.readme, {
+    trim: false,
+    maxLength: 50000,
+  });
+  const categories = normalizeSlugList(payload.manifest?.categories, 'manifest.categories', details, 20);
+  const tags = normalizeSlugList(payload.manifest?.tags, 'manifest.tags', details, 30);
+
+  if (payload.readme != null && typeof payload.readme !== 'string') {
+    addError(details, 'readme', 'Must be a string');
+  }
+
+  if (details.length) {
+    throw new ManifestValidationError(details);
+  }
+
+  return {
+    manifest,
+    displayName,
+    readme,
+    categories,
+    tags,
+  };
+};
+
+module.exports = {
+  ManifestValidationError,
+  normalizePublishPayload,
+};


### PR DESCRIPTION
Resolves TASK-032

Changes:
- validate and normalize community agent manifest publish payloads before writing to the registry
- return structured 400 errors for invalid manifest format and dedupe version writes by manifest version
- add focused unit coverage for publish route and manifest normalization utility

Tests:
- backend targeted Jest: 4 passing
- backend full npm test: blocked by existing mongodb-memory-server Debian 12 / MongoDB 6.0.14 incompatibility in __tests__/services/agentEnsembleService.test.js

Security: ✓ Auth checked, inputs validated, errors handled