### PR TITLE
feat(ts): migrate 5 backend models to TypeScript

### DIFF
--- a/backend/models/AgentMemory.ts
+++ b/backend/models/AgentMemory.ts
@@ -1,0 +1,26 @@
+import mongoose, { Document, Model, Schema } from 'mongoose';
+
+export interface IAgentMemory extends Document {
+  agentName: string;
+  instanceId: string;
+  content: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const agentMemorySchema = new Schema<IAgentMemory>(
+  {
+    agentName: { type: String, required: true },
+    instanceId: { type: String, default: 'default' },
+    content: { type: String, default: '' },
+  },
+  { timestamps: true },
+);
+
+agentMemorySchema.index({ agentName: 1, instanceId: 1 }, { unique: true });
+
+const AgentMemory: Model<IAgentMemory> =
+  (mongoose.models.AgentMemory as Model<IAgentMemory>) ||
+  mongoose.model<IAgentMemory>('AgentMemory', agentMemorySchema);
+
+export default AgentMemory;

--- a/backend/models/Gateway.ts
+++ b/backend/models/Gateway.ts
@@ -1,0 +1,34 @@
+import mongoose, { Document, Model, Schema, Types } from 'mongoose';
+
+export interface IGateway extends Document {
+  name: string;
+  slug: string;
+  type: 'openclaw';
+  mode: 'local' | 'remote' | 'k8s';
+  baseUrl: string;
+  configPath: string;
+  status: 'active' | 'paused' | 'disabled';
+  metadata?: Record<string, unknown>;
+  createdBy?: Types.ObjectId;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const GatewaySchema = new Schema<IGateway>(
+  {
+    name: { type: String, required: true },
+    slug: { type: String, required: true, unique: true },
+    type: { type: String, enum: ['openclaw'], default: 'openclaw' },
+    mode: { type: String, enum: ['local', 'remote', 'k8s'], default: 'local' },
+    baseUrl: { type: String, default: '' },
+    configPath: { type: String, default: '' },
+    status: { type: String, enum: ['active', 'paused', 'disabled'], default: 'active' },
+    metadata: { type: Schema.Types.Mixed },
+    createdBy: { type: Schema.Types.ObjectId, ref: 'User' },
+  },
+  { timestamps: true },
+);
+
+GatewaySchema.index({ slug: 1 }, { unique: true });
+
+export default mongoose.model<IGateway>('Gateway', GatewaySchema);

--- a/backend/models/Message.ts
+++ b/backend/models/Message.ts
@@ -1,0 +1,29 @@
+import mongoose, { Document, Model, Schema, Types } from 'mongoose';
+
+export type MessageType = 'text' | 'image' | 'system';
+
+export interface IMessage extends Document {
+  podId: Types.ObjectId;
+  userId: Types.ObjectId;
+  content: string;
+  messageType: MessageType;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const MessageSchema = new Schema<IMessage>({
+  podId: { type: Schema.Types.ObjectId, ref: 'Pod', required: true },
+  userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  content: { type: String, required: true },
+  messageType: {
+    type: String,
+    enum: ['text', 'image', 'system'],
+    default: 'text',
+  },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+export const Message: Model<IMessage> = mongoose.model<IMessage>('Message', MessageSchema);
+
+export default Message;

--- a/backend/models/SystemSetting.ts
+++ b/backend/models/SystemSetting.ts
@@ -1,0 +1,25 @@
+import mongoose, { Document, Model, Schema, Types } from 'mongoose';
+
+export interface ISystemSetting extends Document {
+  key: string;
+  value: unknown;
+  updatedBy?: Types.ObjectId | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const SystemSettingSchema = new Schema<ISystemSetting>(
+  {
+    key: { type: String, required: true, unique: true, index: true },
+    value: { type: Schema.Types.Mixed, default: {} },
+    updatedBy: { type: Schema.Types.ObjectId, ref: 'User', default: null },
+  },
+  { timestamps: true, collection: 'system_settings' },
+);
+
+const SystemSetting: Model<ISystemSetting> = mongoose.model<ISystemSetting>(
+  'SystemSetting',
+  SystemSettingSchema,
+);
+
+export default SystemSetting;

--- a/backend/models/Task.ts
+++ b/backend/models/Task.ts
@@ -1,0 +1,79 @@
+import mongoose, { Document, Model, Schema, Types } from 'mongoose';
+
+export type TaskStatus = 'pending' | 'claimed' | 'done' | 'blocked';
+
+export interface ITaskUpdate {
+  text: string;
+  author: string;
+  authorId?: string | null;
+  createdAt: Date;
+}
+
+export interface ITask extends Document {
+  podId: Types.ObjectId;
+  taskNum: number;
+  taskId: string;
+  title: string;
+  assignee?: string | null;
+  dep?: string | null;
+  depMockOk: boolean;
+  parentTask?: string | null;
+  status: TaskStatus;
+  claimedBy?: string | null;
+  claimedAt?: Date | null;
+  completedAt?: Date | null;
+  prUrl?: string | null;
+  notes?: string | null;
+  source: string;
+  sourceRef?: string;
+  githubIssueNumber?: number | null;
+  githubIssueUrl?: string | null;
+  updates: ITaskUpdate[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const TaskSchema = new Schema<ITask>(
+  {
+    podId: { type: Schema.Types.ObjectId, required: true, ref: 'Pod' },
+    taskNum: { type: Number, required: true },
+    taskId: { type: String, required: true },
+    title: { type: String, required: true },
+    assignee: { type: String, default: null },
+    dep: { type: String, default: null },
+    depMockOk: { type: Boolean, default: false },
+    parentTask: { type: String, default: null },
+    status: {
+      type: String,
+      enum: ['pending', 'claimed', 'done', 'blocked'],
+      default: 'pending',
+    },
+    claimedBy: { type: String, default: null },
+    claimedAt: { type: Date, default: null },
+    completedAt: { type: Date, default: null },
+    prUrl: { type: String, default: null },
+    notes: { type: String, default: null },
+    source: { type: String, default: 'human' },
+    sourceRef: { type: String },
+    githubIssueNumber: { type: Number, default: null },
+    githubIssueUrl: { type: String, default: null },
+    updates: [
+      {
+        text: { type: String, required: true },
+        author: { type: String, required: true },
+        authorId: { type: String, default: null },
+        createdAt: { type: Date, default: Date.now },
+      },
+    ],
+  },
+  { timestamps: true },
+);
+
+TaskSchema.index({ podId: 1, status: 1 });
+TaskSchema.index({ podId: 1, assignee: 1, status: 1 });
+TaskSchema.index({ podId: 1, taskId: 1 }, { unique: true });
+TaskSchema.index({ podId: 1, sourceRef: 1 }, { unique: true, sparse: true });
+
+export const Task: Model<ITask> = mongoose.model<ITask>('Task', TaskSchema);
+
+export default Task;


### PR DESCRIPTION
## Summary

Migrates the 5 smallest, most self-contained backend models to TypeScript. Establishes the migration pattern for the remaining 27 models.

## Models migrated

| File | Interface | Key types |
|------|-----------|-----------|
| `AgentMemory.ts` | `IAgentMemory` | basic fields |
| `Gateway.ts` | `IGateway` | enum literals for type/mode/status |
| `SystemSetting.ts` | `ISystemSetting` | `value: unknown`, collection name preserved |
| `Message.ts` | `IMessage` | `MessageType` union export |
| `Task.ts` | `ITask` | `TaskStatus` union, `ITaskUpdate` sub-interface |

## Pattern established

```typescript
import mongoose, { Document, Model, Schema, Types } from 'mongoose';

export interface IModel extends Document {
  field: string;
  ref?: Types.ObjectId;
}

const schema = new Schema<IModel>({ ... });
export default mongoose.model<IModel>('Model', schema);
```

## What's preserved

- All existing `.js` files untouched — `.ts` files coexist during migration
- Indexes, collection names, enum values — all identical to JS originals
- No behavior changes — types only

## Follow-up

- Remaining 27 models (User, Pod, Post, AgentInstallation, etc.) — assigned to Nova via #115
- Once all models done: #116 (middleware), #118 (services) can begin

Partial close #115