### PR TITLE
feat(ts): migrate 4 backend services to TypeScript

### DIFF
--- a/backend/services/dmService.ts
+++ b/backend/services/dmService.ts
@@ -1,0 +1,256 @@
+import Pod from '../models/Pod';
+import User from '../models/User';
+import { AgentInstallation } from '../models/AgentRegistry';
+
+let PGPod: { addMember: (podId: string, userId: unknown) => Promise<void>; create: (name: string, description: string, type: string, creatorId: unknown, podId: string) => Promise<void> } | null;
+try {
+  // eslint-disable-next-line global-require
+  PGPod = require('../models/pg/Pod');
+} catch (error) {
+  PGPod = null;
+}
+
+interface DMOptions {
+  agentName?: string;
+  instanceId?: string;
+}
+
+class DMService {
+  static escapeRegex(value = ''): string {
+    return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  static async syncPgDmMembers(dmPodId: string, ownerId: unknown, agentId: unknown): Promise<void> {
+    try {
+      if (process.env.PG_HOST && PGPod) {
+        await PGPod.addMember(dmPodId, ownerId);
+        await PGPod.addMember(dmPodId, agentId);
+      }
+    } catch (pgError) {
+      console.error('Failed to sync DM pod members to PostgreSQL:', (pgError as Error).message);
+    }
+  }
+
+  static async ensureDmMembers(dmPod: InstanceType<typeof Pod>, ownerId: unknown, agentId: unknown): Promise<InstanceType<typeof Pod>> {
+    const existingMembers = new Set(
+      (dmPod.members || []).map((member: unknown) => String((member as Record<string, unknown>)?._id || member)),
+    );
+    const missingOwner = !existingMembers.has(String(ownerId));
+    const missingAgent = !existingMembers.has(String(agentId));
+    if (!missingOwner && !missingAgent) {
+      return dmPod;
+    }
+
+    (dmPod as Record<string, unknown>).members = Array.from(new Set([
+      ...Array.from(existingMembers),
+      String(ownerId),
+      String(agentId),
+    ]));
+    await dmPod.save();
+    await DMService.syncPgDmMembers(dmPod._id.toString(), ownerId, agentId);
+    return dmPod;
+  }
+
+  static async isCompatibleStalePod(dmPod: InstanceType<typeof Pod>, ownerId: unknown, agentId: unknown): Promise<boolean> {
+    const ownerIdStr = String(ownerId);
+    const agentIdStr = String(agentId);
+    const otherMemberIds = (dmPod.members || [])
+      .map((member: unknown) => String((member as Record<string, unknown>)?._id || member))
+      .filter((id: string) => id !== ownerIdStr);
+
+    if (!otherMemberIds.length) return true;
+
+    const botMembers = await User.find({
+      _id: { $in: otherMemberIds },
+      isBot: true,
+    }).select('_id').lean();
+
+    if (!botMembers.length) return true;
+
+    return botMembers.some((member) => String((member as Record<string, unknown>)._id) === agentIdStr);
+  }
+
+  /**
+   * Find or create a 1:1 agent-admin DM pod between an agent user and its
+   * installer (the owner who installed the agent into a pod).
+   */
+  static async getOrCreateAgentDM(agentUserId: unknown, ownerUserId: unknown, { agentName, instanceId }: DMOptions = {}): Promise<InstanceType<typeof Pod>> {
+    const agentId = String(agentUserId);
+    const ownerId = String(ownerUserId);
+
+    // Look for an existing agent-admin pod where both users are members and
+    // the agent name matches (prevents cross-agent DM collisions).
+    const existing = await Pod.findOne({
+      type: 'agent-admin',
+      members: { $all: [agentId, ownerId] },
+      description: { $regex: `\\b${agentName}\\b`, $options: 'i' },
+    });
+    if (existing) return DMService.ensureDmMembers(existing, ownerId, agentId);
+
+    // Fallback: broader search without description regex in case the
+    // description was edited or stored differently.
+    const fallback = await Pod.findOne({
+      type: 'agent-admin',
+      members: { $all: [agentId, ownerId] },
+      name: { $regex: agentName, $options: 'i' },
+    });
+    if (fallback) return DMService.ensureDmMembers(fallback, ownerId, agentId);
+
+    // Repair stale pods that match this agent hint but are missing one of the
+    // expected members (for example older records with owner-only membership).
+    const safeAgentName = DMService.escapeRegex(agentName || 'agent');
+    const staleCandidates = await Pod.find({
+      type: 'agent-admin',
+      members: ownerId,
+      $or: [
+        { description: { $regex: `\\b${safeAgentName}\\b`, $options: 'i' } },
+        { name: { $regex: safeAgentName, $options: 'i' } },
+      ],
+    })
+      .sort({ updatedAt: -1 })
+      .limit(5);
+    const staleChecks = await Promise.all(
+      staleCandidates.map(async (candidate) => ({
+        candidate,
+        compatible: await DMService.isCompatibleStalePod(candidate, ownerId, agentId),
+      })),
+    );
+    const stale = staleChecks.find((row) => row.compatible)?.candidate || null;
+    if (stale) {
+      return DMService.ensureDmMembers(stale, ownerId, agentId);
+    }
+
+    // Create a new DM pod
+    const label = agentName || 'agent';
+    const instanceSuffix = instanceId && instanceId !== 'default' ? ` (${instanceId})` : '';
+    const dmPod = new Pod({
+      name: `DM: ${label}${instanceSuffix}`,
+      description: `Debug channel for ${label}${instanceSuffix}`,
+      type: 'agent-admin',
+      joinPolicy: 'invite-only',
+      createdBy: ownerId,
+      members: [agentId, ownerId],
+    });
+    await dmPod.save();
+
+    // Sync to PostgreSQL
+    try {
+      if (process.env.PG_HOST && PGPod) {
+        await PGPod.create(
+          dmPod.name,
+          dmPod.description,
+          'agent-admin',
+          ownerId,
+          dmPod._id.toString(),
+        );
+        // Ensure both members exist in PG.
+        await DMService.syncPgDmMembers(dmPod._id.toString(), ownerId, agentId);
+      }
+    } catch (pgError) {
+      console.error('Failed to sync DM pod to PostgreSQL:', (pgError as Error).message);
+    }
+
+    console.log(
+      `[dm-service] Created agent-admin DM pod=${dmPod._id}`
+      + ` agent=${agentName} owner=${ownerId}`,
+    );
+
+    return dmPod;
+  }
+
+  /**
+   * Resolve the installer (owner) of a specific agent installation.
+   * Returns the userId of the person who installed the agent, or null.
+   */
+  static async resolveAgentOwner(agentName: string, podId: unknown, instanceId = 'default'): Promise<unknown | null> {
+    const installation = await AgentInstallation.findOne({
+      agentName: agentName.toLowerCase(),
+      podId,
+      instanceId,
+      status: { $in: ['active', 'paused'] },
+    }).select('installedBy').lean();
+
+    return (installation as Record<string, unknown> | null)?.installedBy || null;
+  }
+
+  /**
+   * Find or create the single shared DM pod for a given agent instance.
+   * Members: agent + installer/owner + all admin users.
+   * All members are treated as a unified admin/owner group — the agent does not
+   * distinguish between individual admins. Idempotent: new admins or a changed
+   * installer are merged in on every call (e.g. reprovision).
+   */
+  static async getOrCreateAdminDMPod(agentUserId: unknown, installerUserId: unknown, { agentName, instanceId }: DMOptions = {}): Promise<InstanceType<typeof Pod>> {
+    const agentId = String(agentUserId);
+    const label = agentName || 'agent';
+    const instanceSuffix = instanceId && instanceId !== 'default' ? `:${instanceId}` : '';
+    const podName = `Admin: ${label}${instanceSuffix}`;
+
+    const admins = await User.find({ role: 'admin' }).select('_id').lean();
+    const adminIds = admins.map((a) => String((a as Record<string, unknown>)._id));
+    // Include the installer even if they are not an admin (community-installed agents).
+    const installerId = installerUserId ? String(installerUserId) : null;
+    const allExpectedIds = [...new Set([agentId, ...adminIds, ...(installerId ? [installerId] : [])])];
+
+    // Look for the existing shared DM pod by canonical name.
+    const existing = await Pod.findOne({
+      type: 'agent-admin',
+      members: agentId,
+      name: podName,
+    });
+
+    if (existing) {
+      // Merge in any members missing since the pod was created (new admins, changed installer).
+      const existingMemberStrings = existing.members.map(String);
+      const missing = allExpectedIds.filter((id) => !existingMemberStrings.includes(id));
+      if (missing.length > 0) {
+        existing.members.push(...missing);
+        await existing.save();
+        try {
+          if (process.env.PG_HOST && PGPod) {
+            await Promise.all(missing.map((id) => PGPod!.addMember(existing._id.toString(), id)));
+          }
+        } catch (pgError) {
+          console.error('Failed to sync new members to PostgreSQL:', (pgError as Error).message);
+        }
+      }
+      return existing;
+    }
+
+    // Create the shared DM pod.
+    const creatorId = installerId || adminIds[0] || agentId;
+    const dmPod = new Pod({
+      name: podName,
+      description: `Admin & owner channel for ${label}${instanceSuffix}`,
+      type: 'agent-admin',
+      joinPolicy: 'invite-only',
+      createdBy: creatorId,
+      members: allExpectedIds,
+    });
+    await dmPod.save();
+
+    try {
+      if (process.env.PG_HOST && PGPod) {
+        await PGPod.create(
+          dmPod.name,
+          dmPod.description,
+          'agent-admin',
+          creatorId,
+          dmPod._id.toString(),
+        );
+        await Promise.all(allExpectedIds.map((id) => PGPod!.addMember(dmPod._id.toString(), id)));
+      }
+    } catch (pgError) {
+      console.error('Failed to sync admin DM pod to PostgreSQL:', (pgError as Error).message);
+    }
+
+    console.log(
+      `[dm-service] Created shared admin DM pod=${dmPod._id}`
+      + ` agent=${agentName} members=${allExpectedIds.length}`,
+    );
+
+    return dmPod;
+  }
+}
+
+export default DMService;

--- a/backend/services/githubAppService.ts
+++ b/backend/services/githubAppService.ts
@@ -1,0 +1,214 @@
+import jwt from 'jsonwebtoken';
+import axios from 'axios';
+
+export interface GitHubToken {
+  token: string;
+  expiresAt: string | null;
+}
+
+export interface GitHubIssueLabel {
+  name: string;
+  color?: string;
+}
+
+export interface GitHubIssue {
+  number: number;
+  title: string;
+  body: string;
+  html_url: string;
+  labels: GitHubIssueLabel[];
+  pull_request?: unknown;
+  milestone?: { title: string } | null;
+}
+
+interface ListIssuesOptions {
+  owner?: string;
+  repo?: string;
+  perPage?: number;
+}
+
+interface CreateIssueOptions {
+  owner?: string;
+  repo?: string;
+  title: string;
+  body?: string;
+  labels?: string[];
+}
+
+interface IssueCommentOptions {
+  owner?: string;
+  repo?: string;
+  issueNumber: number;
+  body: string;
+}
+
+interface CloseIssueOptions {
+  owner?: string;
+  repo?: string;
+  issueNumber: number;
+  comment?: string;
+}
+
+/**
+ * GitHubAppService — generates short-lived installation access tokens
+ * using a GitHub App's private key (RS256 JWT).
+ *
+ * Required env vars:
+ *   GITHUB_APP_ID                         — numeric app ID from GitHub App settings
+ *   GITHUB_APP_PRIVATE_KEY                — PEM private key (from GCP SM)
+ *   GITHUB_APP_INSTALLATION_ID_COMMONLY   — pre-known installation ID for Team-Commonly/commonly
+ */
+class GitHubAppService {
+  /**
+   * Generate a short-lived JWT to authenticate as the GitHub App itself (valid 10 min).
+   * Used as a stepping stone to get installation access tokens.
+   */
+  static generateAppJWT(): string {
+    const now = Math.floor(Date.now() / 1000);
+    return jwt.sign(
+      { iat: now - 60, exp: now + 600, iss: process.env.GITHUB_APP_ID },
+      process.env.GITHUB_APP_PRIVATE_KEY as string,
+      { algorithm: 'RS256' },
+    );
+  }
+
+  /**
+   * Exchange an installation ID for a short-lived installation access token (valid 1 hour).
+   * This token is what agents use with `gh` CLI and `git`.
+   */
+  static async getInstallationToken(installationId: string | number): Promise<GitHubToken> {
+    const appJWT = this.generateAppJWT();
+    const res = await axios.post(
+      `https://api.github.com/app/installations/${installationId}/access_tokens`,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${appJWT}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+    );
+    return { token: res.data.token, expiresAt: res.data.expires_at };
+  }
+
+  /**
+   * Look up the installation ID for any repo where the app is installed.
+   * Used for multi-repo support when owner/repo is not Team-Commonly/commonly.
+   */
+  static async getInstallationIdForRepo(owner: string, repo: string): Promise<number> {
+    const appJWT = this.generateAppJWT();
+    const res = await axios.get(
+      `https://api.github.com/repos/${owner}/${repo}/installation`,
+      {
+        headers: {
+          Authorization: `Bearer ${appJWT}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+    );
+    return res.data.id;
+  }
+
+  /**
+   * Check whether a PAT is configured (simpler alternative to GitHub App).
+   */
+  static isPatConfigured(): boolean {
+    return !!process.env.GITHUB_PAT;
+  }
+
+  /**
+   * Return the PAT directly as a token response.
+   * PATs don't have a server-issued expiry, so expiresAt is null.
+   */
+  static getPatToken(): GitHubToken {
+    return { token: process.env.GITHUB_PAT as string, expiresAt: null };
+  }
+
+  // ─── Issues API ──────────────────────────────────────────────────────────
+
+  /**
+   * Shared headers for GitHub REST API calls (uses PAT or App token).
+   */
+  static async _apiHeaders(token?: string): Promise<Record<string, string>> {
+    const pat = token || process.env.GITHUB_PAT;
+    return {
+      Authorization: `Bearer ${pat}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+  }
+
+  /**
+   * List open issues for a repo (excludes pull requests).
+   */
+  static async listOpenIssues({ owner = 'Team-Commonly', repo = 'commonly', perPage = 20 }: ListIssuesOptions = {}): Promise<GitHubIssue[]> {
+    const headers = await this._apiHeaders();
+    const res = await axios.get(
+      `https://api.github.com/repos/${owner}/${repo}/issues?state=open&per_page=${perPage}`,
+      { headers },
+    );
+    return (res.data as GitHubIssue[]).filter((i) => !i.pull_request);
+  }
+
+  /**
+   * Create a new GitHub issue.
+   */
+  static async createIssue({ owner = 'Team-Commonly', repo = 'commonly', title, body, labels }: CreateIssueOptions): Promise<GitHubIssue> {
+    const headers = await this._apiHeaders();
+    const payload: Record<string, unknown> = { title };
+    if (body) payload.body = body;
+    if (labels?.length) payload.labels = labels;
+    const res = await axios.post(
+      `https://api.github.com/repos/${owner}/${repo}/issues`,
+      payload,
+      { headers },
+    );
+    return res.data;
+  }
+
+  /**
+   * Add a comment to an existing issue.
+   */
+  static async addIssueComment({ owner = 'Team-Commonly', repo = 'commonly', issueNumber, body }: IssueCommentOptions): Promise<unknown> {
+    const headers = await this._apiHeaders();
+    const res = await axios.post(
+      `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+      { body },
+      { headers },
+    );
+    return res.data;
+  }
+
+  /**
+   * Close an issue (optionally with a final comment).
+   */
+  static async closeIssue({ owner = 'Team-Commonly', repo = 'commonly', issueNumber, comment }: CloseIssueOptions): Promise<unknown> {
+    if (comment) {
+      await this.addIssueComment({ owner, repo, issueNumber, body: comment });
+    }
+    const headers = await this._apiHeaders();
+    const res = await axios.patch(
+      `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}`,
+      { state: 'closed' },
+      { headers },
+    );
+    return res.data;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Check whether the GitHub App credentials are configured in env.
+   */
+  static isConfigured(): boolean {
+    return !!(
+      process.env.GITHUB_APP_ID &&
+      process.env.GITHUB_APP_PRIVATE_KEY &&
+      process.env.GITHUB_APP_INSTALLATION_ID_COMMONLY
+    );
+  }
+}
+
+export default GitHubAppService;

--- a/backend/services/globalModelConfigService.ts
+++ b/backend/services/globalModelConfigService.ts
@@ -1,0 +1,276 @@
+import SystemSetting from '../models/SystemSetting';
+
+const MODEL_CONFIG_KEY = 'llm.globalModelConfig';
+
+export interface OpenRouterServiceConfig {
+  baseUrl: string;
+  model: string;
+}
+
+export interface LlmServiceConfig {
+  provider: string;
+  model: string;
+  contextLimit: number;
+  openrouter: OpenRouterServiceConfig;
+}
+
+export interface CommunityAgentModel {
+  primary: string;
+  fallbacks: string[];
+}
+
+export interface OpenClawConfig {
+  provider: string;
+  model: string;
+  fallbackModels: string[];
+  devAgentIds: string[];
+  communityAgentModel: CommunityAgentModel;
+}
+
+export interface GlobalModelConfig {
+  llmService: LlmServiceConfig;
+  openclaw: OpenClawConfig;
+}
+
+const DEFAULT_CONFIG: GlobalModelConfig = {
+  llmService: {
+    provider: 'auto', // auto | gemini | litellm | openrouter
+    model: 'gemini-2.5-flash',
+    contextLimit: 128000, // max input tokens for the configured model
+    openrouter: {
+      baseUrl: 'https://openrouter.ai/api/v1',
+      model: '',
+    },
+  },
+  openclaw: {
+    provider: 'google', // google | openrouter | openai | anthropic | custom
+    model: 'google/gemini-2.5-flash',
+    fallbackModels: [
+      'google/gemini-2.5-flash',
+      'google/gemini-2.5-flash-lite',
+      'google/gemini-2.0-flash',
+    ],
+    // Agent IDs that use Codex as primary. All others use communityAgentModel as primary.
+    devAgentIds: ['theo', 'nova', 'pixel', 'ops'],
+    // Model used by non-dev agents (community agents like liz/tarik/tom/fakesam/x-curator).
+    communityAgentModel: {
+      primary: 'openrouter/nvidia/nemotron-3-super-120b-a12b:free',
+      fallbacks: ['openrouter/arcee-ai/trinity-large-preview:free'],
+    },
+  },
+};
+
+const CACHE_TTL_MS = 15000;
+let cachedConfig: GlobalModelConfig | null = null;
+let cachedAt = 0;
+
+const normalizeProvider = (value: unknown): string => {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (['auto', 'gemini', 'litellm', 'openrouter', 'openai', 'anthropic'].includes(normalized)) {
+    return normalized;
+  }
+  return DEFAULT_CONFIG.llmService.provider;
+};
+
+const normalizeOpenClawProvider = (value: unknown): string => {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (['google', 'openrouter', 'openai', 'anthropic', 'openai-codex', 'custom'].includes(normalized)) {
+    return normalized;
+  }
+  return DEFAULT_CONFIG.openclaw.provider;
+};
+
+const normalizeModel = (value: unknown, fallback = ''): string => {
+  const normalized = String(value || '').trim();
+  return normalized || fallback;
+};
+
+const normalizeOpenClawModel = ({ provider, model, fallback }: { provider: string; model: unknown; fallback: string }): string => {
+  const resolved = normalizeModel(model, fallback);
+  if (!resolved) return fallback;
+  if (provider === 'custom') return resolved;
+  if (provider === 'openrouter') {
+    if (resolved.startsWith('openrouter/')) return resolved;
+    if (resolved.startsWith('openrouter:')) {
+      return `openrouter/${resolved.slice('openrouter:'.length)}`;
+    }
+    return `openrouter/${resolved}`;
+  }
+  if (provider === 'openai-codex') {
+    if (resolved.startsWith('openai-codex/')) return resolved;
+    return `openai-codex/${resolved}`;
+  }
+  if (resolved.includes('/')) return resolved;
+  return `${provider}/${resolved}`;
+};
+
+const normalizeDevAgentIds = (value: unknown): string[] => {
+  let list: unknown[] = [];
+  if (Array.isArray(value)) {
+    list = value;
+  } else if (typeof value === 'string') {
+    list = value.split(',');
+  }
+  return Array.from(
+    new Set(list.map((id) => String(id || '').trim().toLowerCase()).filter(Boolean)),
+  );
+};
+
+const normalizeFallbackModels = (value: unknown, fallback: string[] = DEFAULT_CONFIG.openclaw.fallbackModels): string[] => {
+  let list: unknown[] = [];
+  if (Array.isArray(value)) {
+    list = value;
+  } else if (typeof value === 'string') {
+    list = value.split(',');
+  }
+  const normalized = Array.from(
+    new Set(
+      list
+        .map((entry) => String(entry || '').trim())
+        .filter(Boolean),
+    ),
+  );
+  if (normalized.length) return normalized;
+  return [...fallback];
+};
+
+const normalizeCommunityAgentModel = (value: unknown): CommunityAgentModel => {
+  const defaultVal = DEFAULT_CONFIG.openclaw.communityAgentModel;
+  if (!value || typeof value !== 'object') return { ...defaultVal };
+  const v = value as Partial<CommunityAgentModel>;
+  const primary = normalizeModel(v.primary, defaultVal.primary);
+  const fallbacks = normalizeFallbackModels(v.fallbacks, defaultVal.fallbacks);
+  return { primary, fallbacks };
+};
+
+const normalizeContextLimit = (value: unknown): number => {
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed) || parsed < 1024) return DEFAULT_CONFIG.llmService.contextLimit;
+  return Math.min(parsed, 2000000);
+};
+
+const sanitize = (candidate: Partial<GlobalModelConfig> = {}): GlobalModelConfig => {
+  const llm = candidate?.llmService || ({} as Partial<LlmServiceConfig>);
+  const oc = candidate?.openclaw || ({} as Partial<OpenClawConfig>);
+  const next: GlobalModelConfig = {
+    llmService: {
+      provider: normalizeProvider(llm?.provider),
+      model: normalizeModel(
+        (llm as Record<string, unknown>)?.model || (llm as Record<string, unknown>)?.defaultModel,
+        DEFAULT_CONFIG.llmService.model,
+      ),
+      contextLimit: normalizeContextLimit(llm?.contextLimit),
+      openrouter: {
+        baseUrl: normalizeModel(
+          llm?.openrouter?.baseUrl,
+          DEFAULT_CONFIG.llmService.openrouter.baseUrl,
+        ),
+        model: normalizeModel(llm?.openrouter?.model),
+      },
+    },
+    openclaw: {
+      provider: normalizeOpenClawProvider(oc?.provider),
+      model: normalizeOpenClawModel({
+        provider: normalizeOpenClawProvider(oc?.provider),
+        model: (oc as Record<string, unknown>)?.model || (oc as Record<string, unknown>)?.defaultModel,
+        fallback: DEFAULT_CONFIG.openclaw.model,
+      }),
+      fallbackModels: normalizeFallbackModels(oc?.fallbackModels),
+      devAgentIds: normalizeDevAgentIds(
+        oc?.devAgentIds ?? DEFAULT_CONFIG.openclaw.devAgentIds,
+      ),
+      communityAgentModel: normalizeCommunityAgentModel(oc?.communityAgentModel),
+    },
+  };
+  return next;
+};
+
+interface GetConfigOptions {
+  includeSecrets?: boolean;
+  forceRefresh?: boolean;
+}
+
+class GlobalModelConfigService {
+  static defaults(): GlobalModelConfig {
+    return JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+  }
+
+  static resetCache(): void {
+    cachedConfig = null;
+    cachedAt = 0;
+  }
+
+  static async getConfig({ includeSecrets = false, forceRefresh = false }: GetConfigOptions = {}): Promise<GlobalModelConfig> {
+    void includeSecrets;
+    if (!forceRefresh && cachedConfig && (Date.now() - cachedAt) < CACHE_TTL_MS) {
+      return JSON.parse(JSON.stringify(cachedConfig));
+    }
+    const setting = await SystemSetting.findOne({ key: MODEL_CONFIG_KEY }).lean() as Record<string, unknown> | null;
+    const stored = setting?.value && typeof setting.value === 'object' ? setting.value as Partial<GlobalModelConfig> : {};
+    const defaults = GlobalModelConfigService.defaults();
+    const merged = sanitize(
+      {
+        ...defaults,
+        ...stored,
+        llmService: {
+          ...defaults.llmService,
+          ...(stored.llmService || {}),
+          openrouter: {
+            ...defaults.llmService.openrouter,
+            ...(stored.llmService?.openrouter || {}),
+          },
+        },
+        openclaw: {
+          ...defaults.openclaw,
+          ...(stored.openclaw || {}),
+        },
+      },
+    );
+    cachedConfig = merged;
+    cachedAt = Date.now();
+
+    return JSON.parse(JSON.stringify(merged));
+  }
+
+  static async setConfig(patch: Partial<GlobalModelConfig> = {}, userId: string | null = null): Promise<GlobalModelConfig> {
+    const current = await GlobalModelConfigService.getConfig({ includeSecrets: true, forceRefresh: true });
+    const mergedCandidate: GlobalModelConfig = {
+      ...current,
+      ...(patch || {}),
+      llmService: {
+        ...current.llmService,
+        ...((patch && patch.llmService) || {}),
+        openrouter: {
+          ...current.llmService.openrouter,
+          ...((patch && patch.llmService && patch.llmService.openrouter) || {}),
+        },
+      },
+      openclaw: {
+        ...current.openclaw,
+        ...((patch && patch.openclaw) || {}),
+      },
+    };
+
+    const sanitized = sanitize(mergedCandidate);
+
+    await SystemSetting.findOneAndUpdate(
+      { key: MODEL_CONFIG_KEY },
+      {
+        $set: {
+          value: sanitized,
+          updatedBy: userId || null,
+        },
+      },
+      {
+        upsert: true,
+        new: true,
+      },
+    );
+
+    cachedConfig = sanitized;
+    cachedAt = Date.now();
+    return GlobalModelConfigService.getConfig({ includeSecrets: false, forceRefresh: false });
+  }
+}
+
+export default GlobalModelConfigService;

--- a/backend/services/llmService.ts
+++ b/backend/services/llmService.ts
@@ -1,0 +1,280 @@
+import axios from 'axios';
+import { GoogleGenerativeAI, GenerativeModel } from '@google/generative-ai';
+import GlobalModelConfigService from './globalModelConfigService';
+
+const DEFAULT_MODEL = 'gemini-2.5-flash';
+const DEFAULT_OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+const DEFAULT_MAX_OUTPUT_TOKENS = 2048;
+const DEFAULT_LLM_TIMEOUT_MS = Number(process.env.LLM_REQUEST_TIMEOUT_MS) || 120000;
+
+export interface GenerateOptions {
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+  timeout?: number;
+}
+
+interface LiteLLMConfig {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+}
+
+interface OpenRouterConfig {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+}
+
+interface LLMProviderError extends Error {
+  providerCode?: string | number;
+  providerType?: string;
+}
+
+let geminiClient: GoogleGenerativeAI | null = null;
+let geminiModel: GenerativeModel | null = null;
+let geminiModelName: string | null = null;
+
+const getGeminiModel = (modelName: string): GenerativeModel => {
+  if (!process.env.GEMINI_API_KEY) {
+    throw new Error('GEMINI_API_KEY is required for Gemini requests');
+  }
+  if (!geminiClient) {
+    geminiClient = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+  }
+  if (!geminiModel || geminiModelName !== modelName) {
+    geminiModelName = modelName;
+    geminiModel = geminiClient.getGenerativeModel({ model: modelName });
+  }
+  return geminiModel;
+};
+
+const getLiteLLMConfig = (): LiteLLMConfig | null => {
+  const baseUrl = process.env.LITELLM_BASE_URL;
+  if (!baseUrl) return null;
+  const apiKey = process.env.LITELLM_API_KEY || process.env.LITELLM_MASTER_KEY;
+  if (!apiKey) {
+    throw new Error('LITELLM_API_KEY or LITELLM_MASTER_KEY is required');
+  }
+  const model = process.env.LITELLM_CHAT_MODEL || DEFAULT_MODEL;
+  return {
+    baseUrl: baseUrl.replace(/\/$/, ''),
+    apiKey,
+    model,
+  };
+};
+
+const getOpenRouterConfig = (globalConfig: Record<string, unknown> | null = null): OpenRouterConfig => {
+  const settings = globalConfig || {};
+  const openrouterSettings = (settings?.llmService as Record<string, unknown>)?.openrouter as Record<string, unknown> || {};
+  const baseUrl = String(
+    openrouterSettings.baseUrl
+    || process.env.OPENROUTER_BASE_URL
+    || DEFAULT_OPENROUTER_BASE_URL,
+  ).trim().replace(/\/$/, '');
+  const apiKey = String(process.env.OPENROUTER_API_KEY || '').trim();
+  const model = String(
+    openrouterSettings.model
+    || (settings?.llmService as Record<string, unknown>)?.model
+    || (settings?.llmService as Record<string, unknown>)?.defaultModel
+    || process.env.OPENROUTER_MODEL
+    || DEFAULT_MODEL,
+  ).trim();
+  if (!apiKey) {
+    throw new Error('OpenRouter API key is required');
+  }
+  return {
+    baseUrl,
+    apiKey,
+    model,
+  };
+};
+
+const parseLiteLLMResponse = (data: unknown): string => {
+  const d = data as Record<string, unknown>;
+  // Check for OpenRouter/LiteLLM error payloads first
+  if (d?.error) {
+    const errObj = d.error as Record<string, unknown>;
+    const errMsg = String(errObj.message || errObj.type || 'Unknown provider error');
+    const errCode = errObj.code || errObj.status || '';
+    const err = new Error(`LLM provider error: ${errMsg}`) as LLMProviderError;
+    err.providerCode = errCode as string | number;
+    err.providerType = String(errObj.type || '');
+    throw err;
+  }
+  const choices = d?.choices as Array<Record<string, unknown>> | undefined;
+  const choice = choices?.[0];
+  const message = choice?.message as Record<string, unknown> | undefined;
+  const content = message?.content || choice?.text;
+  if (!content) {
+    throw new Error('LLM response missing content');
+  }
+  return String(content).trim();
+};
+
+const generateViaLiteLLM = async (prompt: string, options: GenerateOptions = {}): Promise<string> => {
+  const config = getLiteLLMConfig();
+  if (!config) {
+    throw new Error('LiteLLM base URL not configured');
+  }
+  const response = await axios.post(
+    `${config.baseUrl}/chat/completions`,
+    {
+      model: options.model || config.model,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: options.temperature ?? 0.4,
+      max_tokens: options.maxTokens || DEFAULT_MAX_OUTPUT_TOKENS,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      timeout: options.timeout || DEFAULT_LLM_TIMEOUT_MS,
+    },
+  );
+  return parseLiteLLMResponse(response.data);
+};
+
+const generateViaGemini = async (prompt: string, options: GenerateOptions = {}): Promise<string> => {
+  const modelName = options.model || DEFAULT_MODEL;
+  const model = getGeminiModel(modelName);
+  const result = await model.generateContent(prompt);
+  const response = await result.response;
+  return response.text();
+};
+
+const parseOpenRouterModel = (modelName: unknown): string => {
+  const normalized = String(modelName || '').trim();
+  if (!normalized) return '';
+  if (normalized.startsWith('openrouter/')) {
+    return normalized.slice('openrouter/'.length);
+  }
+  if (normalized.startsWith('openrouter:')) {
+    return normalized.slice('openrouter:'.length);
+  }
+  return normalized;
+};
+
+const stripProviderPrefix = (modelName: unknown): string => {
+  const stripped = parseOpenRouterModel(modelName);
+  // Also strip provider org prefixes like "anthropic/claude-3" -> not valid for Gemini
+  // If it contains a slash and doesn't start with "gemini", it's not a Gemini model
+  if (stripped.includes('/') && !stripped.startsWith('gemini')) {
+    return DEFAULT_MODEL;
+  }
+  return stripped || DEFAULT_MODEL;
+};
+
+const generateViaOpenRouter = async (
+  prompt: string,
+  options: GenerateOptions = {},
+  globalConfig: Record<string, unknown> | null = null,
+): Promise<string> => {
+  const config = getOpenRouterConfig(globalConfig);
+  const selectedModel = parseOpenRouterModel(options.model || config.model);
+  const response = await axios.post(
+    `${config.baseUrl}/chat/completions`,
+    {
+      model: selectedModel,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: options.temperature ?? 0.4,
+      max_tokens: options.maxTokens || DEFAULT_MAX_OUTPUT_TOKENS,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        'Content-Type': 'application/json',
+        'HTTP-Referer': process.env.OPENROUTER_HTTP_REFERER || process.env.FRONTEND_URL || 'https://commonly.me',
+        'X-Title': process.env.OPENROUTER_APP_TITLE || 'Commonly',
+      },
+      timeout: options.timeout || DEFAULT_LLM_TIMEOUT_MS,
+    },
+  );
+  return parseLiteLLMResponse(response.data);
+};
+
+export const generateText = async (prompt: string, options: GenerateOptions = {}): Promise<string> => {
+  const globalModelConfig = await GlobalModelConfigService.getConfig({
+    includeSecrets: true,
+  }).catch((configErr: Error) => {
+    console.warn('[llm-service] Failed to load model config, using defaults:', configErr.message);
+    return null;
+  });
+  const configuredProvider = String((globalModelConfig as Record<string, unknown>)?.llmService
+    ? ((globalModelConfig as Record<string, unknown>).llmService as Record<string, unknown>)?.provider
+    : 'auto' || 'auto').toLowerCase();
+  const llmServiceConfig = (globalModelConfig as Record<string, unknown>)?.llmService as Record<string, unknown> | undefined;
+  const configuredModel = String(
+    llmServiceConfig?.model
+    || llmServiceConfig?.defaultModel
+    || '',
+  ).trim();
+  const selectedModel = options.model || configuredModel || DEFAULT_MODEL;
+  const runOptions: GenerateOptions = {
+    ...options,
+    model: selectedModel,
+  };
+
+  const shouldUseOpenRouter = configuredProvider === 'openrouter'
+    || String(selectedModel).startsWith('openrouter/')
+    || String(selectedModel).startsWith('openrouter:');
+  if (shouldUseOpenRouter) {
+    try {
+      return await generateViaOpenRouter(prompt, runOptions, globalModelConfig as Record<string, unknown>);
+    } catch (error) {
+      const err = error as LLMProviderError;
+      console.warn(
+        `[llm-service] OpenRouter failed (model=${selectedModel}): ${err.message}${err.providerCode ? ` [code=${err.providerCode}]` : ''}`,
+      );
+      if (process.env.GEMINI_API_KEY) {
+        const geminiOptions = { ...runOptions, model: stripProviderPrefix(selectedModel) };
+        console.warn(`[llm-service] Falling back to Gemini (model=${geminiOptions.model})`);
+        return generateViaGemini(prompt, geminiOptions);
+      }
+      throw error;
+    }
+  }
+
+  if (configuredProvider === 'gemini') {
+    return generateViaGemini(prompt, runOptions);
+  }
+
+  if (configuredProvider === 'litellm') {
+    try {
+      return await generateViaLiteLLM(prompt, runOptions);
+    } catch (error) {
+      const err = error as Error;
+      console.warn(
+        `[llm-service] LiteLLM failed (model=${selectedModel}): ${err.message}`,
+      );
+      if (process.env.GEMINI_API_KEY) {
+        const geminiOptions = { ...runOptions, model: stripProviderPrefix(selectedModel) };
+        console.warn(`[llm-service] Falling back to Gemini (model=${geminiOptions.model})`);
+        return generateViaGemini(prompt, geminiOptions);
+      }
+      throw error;
+    }
+  }
+
+  const litellmDisabled = String(process.env.LITELLM_DISABLED || '').toLowerCase() === 'true';
+  if (!litellmDisabled && process.env.LITELLM_BASE_URL) {
+    try {
+      return await generateViaLiteLLM(prompt, runOptions);
+    } catch (error) {
+      const err = error as Error;
+      console.warn(
+        `[llm-service] LiteLLM (auto) failed (model=${selectedModel}): ${err.message}`,
+      );
+      if (process.env.GEMINI_API_KEY) {
+        const geminiOptions = { ...runOptions, model: stripProviderPrefix(selectedModel) };
+        console.warn(`[llm-service] Falling back to Gemini (model=${geminiOptions.model})`);
+        return generateViaGemini(prompt, geminiOptions);
+      }
+      throw error;
+    }
+  }
+  return generateViaGemini(prompt, runOptions);
+};
+
+export default { generateText };


### PR DESCRIPTION
## Summary

Batch 1 of #118 — TypeScript migration for core backend services.

Files added (`.ts` alongside existing `.js`):
- `backend/services/llmService.ts` — `GenerateOptions`, `LiteLLMConfig`, `OpenRouterConfig` interfaces; typed LiteLLM/Gemini/OpenRouter routing
- `backend/services/globalModelConfigService.ts` — `GlobalModelConfig`, `LlmServiceConfig`, `OpenClawConfig`, `CommunityAgentModel` interfaces; typed cache + sanitize helpers
- `backend/services/dmService.ts` — `DMOptions` interface; typed Pod/User/AgentInstallation usage; optional PGPod dynamic require preserved
- `backend/services/githubAppService.ts` — `GitHubToken`, `GitHubIssue` interfaces; typed RS256 JWT generation + Issues API methods

Follows the same pattern as PRs #121–#124 (models) and #126 (middleware): `allowJs:true` + `strict:false` means existing `.js` files are untouched and `.ts` files compile alongside them.

Closes part of #118.

## Test plan
- [ ] CI `Test & Coverage` passes (no new test failures)
- [ ] TypeScript compiles without errors: `cd backend && npx tsc --noEmit`
- [ ] No runtime behaviour changed (`.ts` files are additive)

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)