### PR TITLE
feat(ts): migrate 6 backend services to TypeScript (batch 2)

### DIFF
--- a/backend/services/agentAutoJoinService.ts
+++ b/backend/services/agentAutoJoinService.ts
@@ -1,0 +1,130 @@
+import Pod from '../models/Pod';
+import Activity from '../models/Activity';
+import { AgentInstallation } from '../models/AgentRegistry';
+import AgentIdentityService from './agentIdentityService';
+
+const MAX_TOTAL_INSTALLS = Math.max(1, parseInt(process.env.AGENT_AUTO_JOIN_MAX_TOTAL || '200', 10));
+const MAX_PER_SOURCE = Math.max(1, parseInt(process.env.AGENT_AUTO_JOIN_MAX_PER_SOURCE || '25', 10));
+
+interface AutoJoinOptions {
+  source?: string;
+}
+
+interface AutoJoinResult {
+  source: string;
+  scannedSources: number;
+  installed: number;
+  skipped: number;
+  limits: { maxTotal: number; maxPerSource: number };
+}
+
+class AgentAutoJoinService {
+  static async runAutoJoinAgentOwnedPods({ source = 'scheduled' }: AutoJoinOptions = {}): Promise<AutoJoinResult> {
+    const sourceInstallations = await AgentInstallation.find({
+      status: 'active',
+      'config.autonomy.autoJoinAgentOwnedPods': true,
+    }).select('agentName instanceId displayName podId version scopes config installedBy').lean() as Array<Record<string, unknown>>;
+
+    if (!sourceInstallations.length) {
+      return { scannedSources: 0, installed: 0, skipped: 0, source, limits: { maxTotal: MAX_TOTAL_INSTALLS, maxPerSource: MAX_PER_SOURCE } };
+    }
+
+    let installed = 0;
+    let skipped = 0;
+
+    for (const sourceInstall of sourceInstallations) {
+      if (installed >= MAX_TOTAL_INSTALLS) break;
+      const instanceId = String(sourceInstall.instanceId || 'default');
+      // eslint-disable-next-line no-await-in-loop
+      const agentUser = await AgentIdentityService.getOrCreateAgentUser(String(sourceInstall.agentName), {
+        instanceId,
+        displayName: String(sourceInstall.displayName || ''),
+      });
+      // eslint-disable-next-line no-await-in-loop
+      const agentOwnedPods = await Pod.find({
+        createdBy: agentUser._id,
+        _id: { $ne: sourceInstall.podId },
+      }).select('_id').lean();
+
+      let installedForSource = 0;
+      // eslint-disable-next-line no-restricted-syntax
+      for (const pod of agentOwnedPods) {
+        if (installed >= MAX_TOTAL_INSTALLS || installedForSource >= MAX_PER_SOURCE) break;
+        // eslint-disable-next-line no-await-in-loop
+        const isInstalled = await AgentInstallation.isInstalled(String(sourceInstall.agentName), (pod as Record<string, unknown>)._id, instanceId);
+        if (isInstalled) {
+          skipped += 1;
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+
+        const sourceConfig = (sourceInstall.config || {}) as Record<string, unknown>;
+        const sourceAutonomy = (sourceConfig.autonomy || {}) as Record<string, unknown>;
+        const mergedConfig = {
+          ...sourceConfig,
+          heartbeat: { enabled: false },
+          autonomy: {
+            ...sourceAutonomy,
+            autoJoined: true,
+            autoJoinedFromPodId: sourceInstall.podId?.toString?.() || String(sourceInstall.podId),
+            autoJoinSource: source,
+          },
+        };
+
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          await AgentInstallation.install(String(sourceInstall.agentName), (pod as Record<string, unknown>)._id, {
+            version: String(sourceInstall.version || '1.0.0'),
+            config: mergedConfig,
+            scopes: Array.isArray(sourceInstall.scopes) ? sourceInstall.scopes as string[] : [],
+            installedBy: agentUser._id,
+            instanceId,
+            displayName: String(sourceInstall.displayName || ''),
+          });
+          // eslint-disable-next-line no-await-in-loop
+          await AgentIdentityService.ensureAgentInPod(agentUser, (pod as Record<string, unknown>)._id);
+          try {
+            const agentMeta = agentUser.botMetadata as Record<string, unknown> | undefined;
+            // eslint-disable-next-line no-await-in-loop
+            await Activity.create({
+              type: 'pod_event',
+              actor: {
+                id: agentUser._id,
+                name: agentMeta?.displayName || agentUser.username,
+                type: 'agent',
+                verified: true,
+              },
+              action: 'agent_auto_join',
+              content: `${String(sourceInstall.agentName)} auto-joined this pod via autonomy policy.`,
+              podId: (pod as Record<string, unknown>)._id,
+              sourceType: 'event',
+              sourceId: `${String(sourceInstall.agentName)}:${instanceId}`,
+              agentMetadata: {
+                agentName: sourceInstall.agentName,
+              },
+            });
+          } catch (activityError) {
+            console.warn('[agent-autojoin] failed to log activity:', (activityError as Error).message);
+          }
+          installed += 1;
+          installedForSource += 1;
+        } catch (error) {
+          skipped += 1;
+        }
+      }
+    }
+
+    return {
+      source,
+      scannedSources: sourceInstallations.length,
+      installed,
+      skipped,
+      limits: {
+        maxTotal: MAX_TOTAL_INSTALLS,
+        maxPerSource: MAX_PER_SOURCE,
+      },
+    };
+  }
+}
+
+export default AgentAutoJoinService;

--- a/backend/services/agentBootstrapService.ts
+++ b/backend/services/agentBootstrapService.ts
@@ -1,0 +1,100 @@
+import fs from 'fs';
+import path from 'path';
+import { AgentRegistry } from '../models/AgentRegistry';
+
+const AGENT_SERVICES_DIR = path.join(
+  __dirname,
+  '..',
+  '..',
+  'external',
+  'commonly-agent-services',
+);
+
+interface AgentManifest {
+  agentName: string;
+  displayName: string;
+  description: string;
+  manifest: unknown;
+  version: string;
+  categories?: string[];
+  tags?: string[];
+  registry?: string;
+  verified?: boolean;
+}
+
+class AgentBootstrapService {
+  static loadManifests(): AgentManifest[] {
+    const manifests: AgentManifest[] = [];
+
+    if (!fs.existsSync(AGENT_SERVICES_DIR)) {
+      console.log('[agent-bootstrap] No agent services directory found');
+      return manifests;
+    }
+
+    const entries = fs.readdirSync(AGENT_SERVICES_DIR, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const manifestPath = path.join(AGENT_SERVICES_DIR, entry.name, 'manifest.json');
+      if (!fs.existsSync(manifestPath)) continue;
+
+      try {
+        const content = fs.readFileSync(manifestPath, 'utf8');
+        const manifest = JSON.parse(content) as AgentManifest;
+        manifests.push(manifest);
+      } catch (error) {
+        console.error(`[agent-bootstrap] Failed to load ${entry.name}/manifest.json:`, (error as Error).message);
+      }
+    }
+
+    return manifests;
+  }
+
+  static async bootstrap(): Promise<void> {
+    const manifests = this.loadManifests();
+
+    if (manifests.length === 0) {
+      console.log('[agent-bootstrap] No agent manifests found');
+      return;
+    }
+
+    console.log(`[agent-bootstrap] Registering ${manifests.length} agents...`);
+
+    for (const agent of manifests) {
+      try {
+        await AgentRegistry.findOneAndUpdate(
+          { agentName: agent.agentName },
+          {
+            $set: {
+              displayName: agent.displayName,
+              description: agent.description,
+              manifest: agent.manifest,
+              latestVersion: agent.version,
+              categories: agent.categories || [],
+              tags: agent.tags || [],
+              registry: agent.registry || 'commonly-official',
+              verified: agent.verified || false,
+            },
+            $setOnInsert: {
+              stats: { installs: 0, weeklyInstalls: 0, rating: 0, ratingCount: 0 },
+              versions: [{
+                version: agent.version,
+                manifest: agent.manifest,
+                publishedAt: new Date(),
+              }],
+            },
+          },
+          { upsert: true },
+        );
+        console.log(`[agent-bootstrap] ${agent.agentName} registered`);
+      } catch (error) {
+        console.error(`[agent-bootstrap] Failed to register ${agent.agentName}:`, (error as Error).message);
+      }
+    }
+
+    console.log('[agent-bootstrap] Done');
+  }
+}
+
+export default AgentBootstrapService;

--- a/backend/services/agentIdentityService.ts
+++ b/backend/services/agentIdentityService.ts
@@ -1,0 +1,333 @@
+import User from '../models/User';
+import Pod from '../models/Pod';
+
+let dbPg: { pool: { query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }> } } | null;
+try {
+  // eslint-disable-next-line global-require
+  dbPg = require('../config/db-pg');
+} catch (error) {
+  dbPg = null;
+}
+
+let PGMessage: unknown | null;
+try {
+  // eslint-disable-next-line global-require
+  PGMessage = require('../models/pg/Message');
+} catch (error) {
+  PGMessage = null;
+}
+
+let PGPod: { removeMember: (podId: unknown, userId: string) => Promise<void> } | null;
+try {
+  // eslint-disable-next-line global-require
+  PGPod = require('../models/pg/Pod');
+} catch (error) {
+  PGPod = null;
+}
+
+const normalizeSegment = (value: unknown): string => (
+  (String(value || '')).toLowerCase().replace(/[^a-z0-9-]/g, '').slice(0, 40)
+);
+
+const buildAgentUsername = (agentType: string, instanceId: string): string => {
+  const normalized = normalizeSegment(agentType);
+  const instance = normalizeSegment(instanceId);
+  if (!instance || instance === 'default' || instance === normalized) {
+    return normalized || 'agent';
+  }
+  return `${normalized}-${instance}`;
+};
+
+const buildAgentEmail = (agentType: string, instanceId: string): string => {
+  const username = buildAgentUsername(agentType, instanceId);
+  return `${username || 'agent'}@agents.commonly.local`;
+};
+
+interface AgentTypeConfig {
+  officialDisplayName: string;
+  officialDescription: string;
+  icon: string;
+  botType: string;
+  capabilities: string[];
+  runtime: string;
+}
+
+const AGENT_TYPES: Record<string, AgentTypeConfig> = {
+  openclaw: {
+    officialDisplayName: 'Cuz 🦞',
+    officialDescription: 'Your friendly AI assistant powered by Claude - ready to chat, help, and remember!',
+    icon: '🦞',
+    botType: 'agent',
+    capabilities: ['chat', 'memory', 'context', 'summarize', 'code'],
+    runtime: 'moltbot',
+  },
+  'commonly-bot': {
+    officialDisplayName: 'Commonly Bot',
+    officialDescription: 'Built-in summary bot for integrations, pod activity, and digest context',
+    icon: '📋',
+    botType: 'system',
+    capabilities: ['notify', 'summarize', 'integrate', 'digest'],
+    runtime: 'internal',
+  },
+  'commonly-summarizer': {
+    officialDisplayName: 'Commonly Summarizer (Legacy)',
+    officialDescription: 'Legacy alias for Commonly Bot',
+    icon: '📋',
+    botType: 'system',
+    capabilities: ['notify', 'summarize', 'integrate', 'digest'],
+    runtime: 'internal',
+  },
+  'claude-code': {
+    officialDisplayName: 'Claude Code',
+    officialDescription: 'Claude Code integration for development assistance',
+    icon: '💻',
+    botType: 'agent',
+    capabilities: ['code', 'chat', 'memory'],
+    runtime: 'claude-code',
+  },
+  codex: {
+    officialDisplayName: 'Codex',
+    officialDescription: 'OpenAI Codex integration for code generation',
+    icon: '🤖',
+    botType: 'agent',
+    capabilities: ['code', 'chat'],
+    runtime: 'openai',
+  },
+  newshound: {
+    officialDisplayName: 'NewsHound 🐕',
+    officialDescription: 'News aggregation and analysis agent - curious, thorough, analytical',
+    icon: '🐕',
+    botType: 'agent',
+    capabilities: ['news', 'search', 'summarize', 'analyze', 'trends'],
+    runtime: 'moltbot',
+  },
+  socialpulse: {
+    officialDisplayName: 'SocialPulse 📊',
+    officialDescription: 'Social media monitoring and sentiment analysis agent - trendy, observant, conversational',
+    icon: '📊',
+    botType: 'agent',
+    capabilities: ['social', 'trends', 'sentiment', 'monitor', 'analyze'],
+    runtime: 'moltbot',
+  },
+};
+
+// Legacy agent name mapping is intentionally disabled to avoid alias collisions.
+const LEGACY_AGENT_MAP: Record<string, string> = {
+  'commonly-summarizer': 'commonly-bot',
+};
+
+interface GetOrCreateOptions {
+  displayName?: string;
+  description?: string;
+  instanceId?: string;
+  runtimeId?: string;
+  capabilities?: string[];
+  botType?: string;
+}
+
+class AgentIdentityService {
+  /**
+   * Get or create an agent user with proper bot metadata
+   */
+  static async getOrCreateAgentUser(agentType: string, options: GetOrCreateOptions = {}): Promise<InstanceType<typeof User>> {
+    if (!agentType) {
+      throw new Error('agentType is required');
+    }
+
+    // Handle legacy agent names
+    const resolvedType = AgentIdentityService.resolveAgentType(agentType);
+    const typeConfig = AGENT_TYPES[resolvedType];
+
+    const instanceId = options.instanceId || 'default';
+    const username = buildAgentUsername(resolvedType, instanceId);
+    let agentUser = await User.findOne({ username });
+
+    // Determine if this is an official (default instance) agent
+    const isOfficial = instanceId === 'default' && !!typeConfig;
+
+    if (!agentUser) {
+      const botMetadata = {
+        displayName: options.displayName || typeConfig?.officialDisplayName || resolvedType,
+        description: options.description || typeConfig?.officialDescription || `${resolvedType} agent`,
+        icon: typeConfig?.icon || '🤖',
+        runtimeId: options.runtimeId || null,
+        officialAgent: isOfficial,
+        capabilities: options.capabilities || typeConfig?.capabilities || [],
+        agentName: resolvedType,
+        instanceId,
+        runtime: typeConfig?.runtime || 'unknown',
+      };
+
+      agentUser = new User({
+        username,
+        email: buildAgentEmail(resolvedType, instanceId),
+        password: `agent-password-${Date.now()}`,
+        verified: true,
+        profilePicture: 'default',
+        role: 'user',
+        isBot: true,
+        botType: typeConfig?.botType || options.botType || 'agent',
+        botMetadata,
+      });
+
+      await agentUser.save();
+      console.log(`Created bot user: ${username} (${botMetadata.displayName})`);
+    } else if (!agentUser.isBot) {
+      // Upgrade existing user to bot if not already marked
+      agentUser.isBot = true;
+      agentUser.botType = typeConfig?.botType || options.botType || 'agent';
+      agentUser.botMetadata = {
+        displayName: options.displayName || typeConfig?.officialDisplayName || agentUser.username,
+        description: options.description || typeConfig?.officialDescription || `${resolvedType} agent`,
+        icon: typeConfig?.icon || '🤖',
+        runtimeId: options.runtimeId || agentUser.botMetadata?.runtimeId || null,
+        officialAgent: isOfficial,
+        capabilities: options.capabilities || typeConfig?.capabilities || [],
+        agentName: resolvedType,
+        instanceId,
+        runtime: typeConfig?.runtime || 'unknown',
+      };
+      await agentUser.save();
+      console.log(`Upgraded user to bot: ${username}`);
+    } else {
+      const existingMeta = agentUser.botMetadata || {};
+      const requestedDisplayName = options.displayName
+        ? String(options.displayName).trim()
+        : '';
+      const needsUpdate = !existingMeta.agentName
+        || existingMeta.agentName !== resolvedType
+        || existingMeta.instanceId !== instanceId
+        || !existingMeta.runtime
+        || (requestedDisplayName && existingMeta.displayName !== requestedDisplayName);
+      if (needsUpdate) {
+        agentUser.botMetadata = {
+          ...existingMeta,
+          displayName: options.displayName || existingMeta.displayName || typeConfig?.officialDisplayName || resolvedType,
+          description: options.description || existingMeta.description || typeConfig?.officialDescription || `${resolvedType} agent`,
+          icon: existingMeta.icon || typeConfig?.icon || '🤖',
+          runtimeId: options.runtimeId || existingMeta.runtimeId || null,
+          officialAgent: instanceId === 'default' && !!typeConfig,
+          capabilities: options.capabilities || existingMeta.capabilities || typeConfig?.capabilities || [],
+          agentName: resolvedType,
+          instanceId,
+          runtime: existingMeta.runtime || typeConfig?.runtime || 'unknown',
+        };
+        await agentUser.save();
+        console.log(`Refreshed bot metadata: ${username}`);
+      }
+    }
+
+    return agentUser;
+  }
+
+  static getAgentTypes(): Record<string, AgentTypeConfig> {
+    return { ...AGENT_TYPES };
+  }
+
+  static getAgentTypeConfig(agentType: string): AgentTypeConfig | null {
+    const resolvedType = this.resolveAgentType(agentType);
+    return AGENT_TYPES[resolvedType] || null;
+  }
+
+  static isKnownAgentType(agentType: string): boolean {
+    const resolvedType = this.resolveAgentType(agentType);
+    return !!AGENT_TYPES[resolvedType];
+  }
+
+  static resolveAgentType(agentNameOrType: string): string {
+    const normalized = agentNameOrType?.toLowerCase();
+    return LEGACY_AGENT_MAP[normalized] || normalized;
+  }
+
+  static buildAgentUsername(agentType: string, instanceId: string): string {
+    return buildAgentUsername(agentType, instanceId);
+  }
+
+  static async ensureAgentInPod(agentUser: InstanceType<typeof User>, podId: unknown): Promise<InstanceType<typeof Pod> | null> {
+    if (!agentUser || !podId) return null;
+    const pod = await Pod.findById(podId);
+    if (!pod) return null;
+    if (!pod.members.includes(agentUser._id)) {
+      pod.members.push(agentUser._id);
+      await pod.save();
+    }
+    return pod;
+  }
+
+  static async removeAgentFromPod(agentType: string, podId: unknown, instanceId = 'default'): Promise<InstanceType<typeof Pod> | null> {
+    if (!agentType || !podId) return null;
+    const username = buildAgentUsername(agentType, instanceId);
+    const agentUser = await User.findOne({ username });
+    if (!agentUser) return null;
+
+    const pod = await Pod.findById(podId);
+    if (!pod) return null;
+
+    const agentId = agentUser._id.toString();
+    const hadMember = pod.members?.some((member: unknown) => String(member).toString() === agentId);
+    if (hadMember) {
+      pod.members = pod.members.filter((member: unknown) => String(member).toString() !== agentId);
+      await pod.save();
+    }
+
+    if (process.env.PG_HOST && PGPod) {
+      try {
+        await PGPod.removeMember(podId, agentId);
+      } catch (error) {
+        console.warn('Failed to remove agent from PostgreSQL pod members:', (error as Error).message);
+      }
+    }
+
+    return pod;
+  }
+
+  static async syncUserToPostgreSQL(user: InstanceType<typeof User>): Promise<void> {
+    if (!PGMessage || !process.env.PG_HOST || !dbPg) return;
+    try {
+      const { pool } = dbPg;
+      const checkQuery = 'SELECT _id FROM users WHERE _id = $1';
+      const checkResult = await pool.query(checkQuery, [user._id.toString()]);
+
+      // For bot users, use display name as username for better UX
+      const displayUsername = user.isBot && user.botMetadata?.displayName
+        ? user.botMetadata.displayName
+        : user.username;
+
+      const isBot = user.isBot === true;
+
+      if (checkResult.rows.length > 0) {
+        const updateQuery = `
+          UPDATE users
+          SET username = $2, profile_picture = $3, is_bot = $4, updated_at = $5
+          WHERE _id = $1
+        `;
+        await pool.query(updateQuery, [
+          user._id.toString(),
+          displayUsername,
+          user.profilePicture || null,
+          isBot,
+          new Date(),
+        ]);
+        return;
+      }
+
+      const insertQuery = `
+        INSERT INTO users (_id, username, profile_picture, is_bot, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6)
+      `;
+
+      await pool.query(insertQuery, [
+        user._id.toString(),
+        displayUsername,
+        user.profilePicture,
+        isBot,
+        user.createdAt,
+        new Date(),
+      ]);
+    } catch (error) {
+      console.error('Failed to sync agent user to PostgreSQL:', error);
+    }
+  }
+}
+
+export default AgentIdentityService;

--- a/backend/services/agentPersonalityService.ts
+++ b/backend/services/agentPersonalityService.ts
@@ -1,0 +1,203 @@
+import User from '../models/User';
+
+interface PersonalityConfig {
+  tone?: string;
+  interests?: string[];
+  behavior?: string;
+  responseStyle?: string;
+  specialties?: string[];
+  boundaries?: string[];
+  customInstructions?: string;
+}
+
+interface GenerateSystemPromptOptions {
+  tone: string;
+  interests?: string[];
+  behavior: string;
+  responseStyle: string;
+  specialties?: string[];
+  boundaries?: string[];
+  customInstructions?: string;
+}
+
+class AgentPersonalityService {
+  static generateSystemPrompt({
+    tone, interests, behavior, responseStyle, specialties = [], boundaries = [], customInstructions = '',
+  }: GenerateSystemPromptOptions): string {
+    const tonePrompts: Record<string, string> = {
+      friendly: 'You are warm, welcoming, and helpful. Use casual language and emojis occasionally. Make users feel comfortable.',
+      professional: 'You are polite, formal, and competent. Provide well-structured, business-appropriate responses. Maintain professionalism.',
+      sarcastic: 'You have a witty, sarcastic personality. Use humor while still being helpful. Keep things entertaining but constructive.',
+      educational: 'You are a knowledgeable teacher. Explain concepts clearly with examples. Help users learn and understand deeply.',
+      humorous: 'You are funny and entertaining. Make people laugh while being helpful. Use jokes, puns, and playful language.',
+    };
+
+    const behaviorPrompts: Record<string, string> = {
+      reactive: 'Only respond when directly mentioned or asked a question. Wait for explicit user engagement.',
+      proactive: 'Actively participate in discussions and share relevant insights. Initiate helpful conversations when appropriate.',
+      balanced: 'Respond to mentions and occasionally contribute to relevant discussions. Balance between reactive and proactive.',
+    };
+
+    const stylePrompts: Record<string, string> = {
+      concise: 'Keep responses brief and to the point (1-2 sentences). Value clarity over completeness.',
+      detailed: 'Provide comprehensive, well-explained responses. Include context, examples, and thorough explanations.',
+      conversational: 'Write in a natural, friendly conversational style. Sound like a real person having a chat.',
+    };
+
+    let prompt = 'You are an AI agent participating in a social community.\n\n';
+
+    prompt += `**Communication Tone**: ${tonePrompts[tone] || tonePrompts.friendly}\n\n`;
+    prompt += `**Behavior**: ${behaviorPrompts[behavior] || behaviorPrompts.reactive}\n\n`;
+    prompt += `**Response Style**: ${stylePrompts[responseStyle] || stylePrompts.conversational}\n\n`;
+
+    if (interests && interests.length > 0) {
+      prompt += `**Your Interests**: ${interests.join(', ')}. You enjoy discussing these topics and bring relevant insights when they come up.\n\n`;
+    }
+
+    if (specialties && specialties.length > 0) {
+      prompt += `**Your Specialties**:\n${specialties.map((s) => `- ${s}`).join('\n')}\n\n`;
+    }
+
+    if (boundaries && boundaries.length > 0) {
+      prompt += `**Your Boundaries** (what you won't do):\n${boundaries.map((b) => `- ${b}`).join('\n')}\n\n`;
+    }
+
+    if (customInstructions) {
+      prompt += `**Additional Instructions**:\n${customInstructions}\n\n`;
+    }
+
+    prompt += '**Overall Guidance**: Be authentic, engaging, and add value to conversations. Respect boundaries while being helpful and friendly.';
+
+    return prompt;
+  }
+
+  static async updatePersonality(userId: unknown, personalityConfig: PersonalityConfig): Promise<InstanceType<typeof User> | null> {
+    const user = await User.findByIdAndUpdate(
+      userId,
+      {
+        'agentConfig.personality': personalityConfig,
+        'agentConfig.systemPrompt': this.generateSystemPrompt(personalityConfig as GenerateSystemPromptOptions),
+      },
+      { new: true },
+    );
+    return user;
+  }
+
+  static async getPersonalityConfig(userId: unknown): Promise<PersonalityConfig> {
+    const user = await User.findById(userId).lean() as Record<string, unknown> | null;
+    if (!user || !user.agentConfig) {
+      return this.getDefaultPersonality();
+    }
+    return (user.agentConfig as Record<string, unknown>).personality as PersonalityConfig || this.getDefaultPersonality();
+  }
+
+  static getDefaultPersonality(): PersonalityConfig {
+    return {
+      tone: 'friendly',
+      interests: [],
+      behavior: 'reactive',
+      responseStyle: 'conversational',
+      specialties: [],
+      boundaries: [
+        'Generate harmful or illegal content',
+        'Impersonate real people',
+        'Share private or sensitive information',
+      ],
+      customInstructions: '',
+    };
+  }
+
+  static generateExamplePersonality(agentType: string): PersonalityConfig {
+    const examples: Record<string, PersonalityConfig> = {
+      'curator-bot': {
+        tone: 'friendly',
+        interests: ['trending topics', 'social media', 'content discovery', 'community building'],
+        behavior: 'proactive',
+        responseStyle: 'conversational',
+        specialties: [
+          'Finding interesting content',
+          'Identifying trending topics',
+          'Curating quality discussions',
+          'Highlighting important updates',
+        ],
+        boundaries: [
+          'Share spam or low-quality content',
+          'Promote harmful or offensive material',
+          'Violate content policies',
+        ],
+        customInstructions: 'You love discovering and sharing interesting content. When you find something noteworthy, you provide context and explain why it matters to the community.',
+      },
+      'commonly-bot': {
+        tone: 'friendly',
+        interests: ['community activity', 'summaries', 'daily digests', 'social trends', 'conversation starters'],
+        behavior: 'proactive',
+        responseStyle: 'concise',
+        specialties: [
+          'Creating engaging summaries',
+          'Tracking community activity',
+          'Highlighting key moments',
+          'Generating insights',
+          'Curating social feed highlights',
+        ],
+        boundaries: [
+          'Share private messages',
+          'Reveal sensitive information',
+          'Misrepresent user activity',
+          'Copy protected content verbatim from external platforms',
+        ],
+        customInstructions: 'You help users stay updated with friendly summaries, concise social highlights, and useful prompts that spark discussion.',
+      },
+      openclaw: {
+        tone: 'friendly',
+        interests: ['conversation', 'helping users', 'problem solving', 'learning'],
+        behavior: 'reactive',
+        responseStyle: 'conversational',
+        specialties: [
+          'Natural conversation',
+          'Answering questions',
+          'Providing assistance',
+          'Context-aware responses',
+        ],
+        boundaries: [
+          'Generate harmful content',
+          'Impersonate users',
+          'Access restricted information',
+        ],
+        customInstructions: 'You are a helpful conversational AI that responds naturally to user messages.',
+      },
+      'content-curator': {
+        tone: 'friendly',
+        interests: ['trending topics', 'social media', 'content discovery', 'community building', 'quality content'],
+        behavior: 'proactive',
+        responseStyle: 'conversational',
+        specialties: [
+          'Finding interesting content from social feeds',
+          'Identifying trending topics and viral potential',
+          'Providing context and background for shared posts',
+          'Curating quality discussions',
+          'Highlighting valuable insights',
+        ],
+        boundaries: [
+          'Share spam or low-quality content',
+          'Promote harmful or offensive material',
+          'Violate content policies or copyright',
+          'Share private or sensitive information',
+        ],
+        customInstructions: `You are a content curator who loves discovering and sharing interesting posts from social feeds (X, Instagram, etc.).
+
+When you find noteworthy content, you:
+- Explain WHY it matters to the community
+- Provide context and background
+- Connect it to community interests
+- Highlight key insights
+- Add your unique perspective
+
+You proactively monitor feeds and share 2-3 curated picks every few hours. Quality over quantity!`,
+      },
+    };
+
+    return examples[agentType] || this.getDefaultPersonality();
+  }
+}
+
+export default AgentPersonalityService;

--- a/backend/services/agentThreadService.ts
+++ b/backend/services/agentThreadService.ts
@@ -1,0 +1,109 @@
+import Post from '../models/Post';
+import AgentIdentityService from './agentIdentityService';
+
+interface PostCommentOptions {
+  agentName: string;
+  instanceId?: string;
+  displayName?: string;
+  threadId: string;
+  content: string;
+  replyToCommentId?: string | null;
+}
+
+interface PostCommentResult {
+  success: boolean;
+  comment?: unknown;
+  duplicate?: boolean;
+  agentCommentsDisabled?: boolean;
+  selfReply?: boolean;
+}
+
+class AgentThreadService {
+  static async postComment({
+    agentName,
+    instanceId = 'default',
+    displayName,
+    threadId,
+    content,
+    replyToCommentId = null,
+  }: PostCommentOptions): Promise<PostCommentResult> {
+    if (!agentName || !threadId) {
+      throw new Error('agentName and threadId are required');
+    }
+    if (!content) {
+      throw new Error('content is required');
+    }
+
+    const agentUser = await AgentIdentityService.getOrCreateAgentUser(agentName, {
+      instanceId,
+      displayName,
+    });
+
+    const post = await Post.findById(threadId);
+    if (!post) {
+      throw new Error('Thread not found');
+    }
+
+    // Respect per-post agent comment opt-out
+    if ((post as Record<string, unknown>).agentCommentsDisabled) {
+      return { success: false, agentCommentsDisabled: true };
+    }
+
+    // Prevent agent from replying to its own comment
+    if (replyToCommentId) {
+      const postDoc = post as Record<string, unknown>;
+      const comments = postDoc.comments as Array<Record<string, unknown>>;
+      const targetComment = comments?.find(
+        (c) => c._id.toString() === replyToCommentId.toString(),
+      );
+      if (targetComment && targetComment.userId?.toString() === agentUser._id.toString()) {
+        return { success: false, selfReply: true };
+      }
+    }
+
+    // Dedup: one standalone comment per agent instance per post
+    if (!replyToCommentId) {
+      const postDoc = post as Record<string, unknown>;
+      const comments = postDoc.comments as Array<Record<string, unknown>>;
+      const alreadyCommented = comments?.some(
+        (c) => c.userId && c.userId.toString() === agentUser._id.toString() && !c.replyTo,
+      );
+      if (alreadyCommented) {
+        const existing = await Post.findById(post._id)
+          .populate('comments.userId', 'username profilePicture')
+          .lean() as Record<string, unknown>;
+        const existingComments = (existing.comments as Array<Record<string, unknown>>);
+        const existingComment = [...existingComments]
+          .reverse()
+          .find((c) => {
+            const userId = c.userId as Record<string, unknown> | undefined;
+            return userId && userId._id?.toString() === agentUser._id.toString() && !c.replyTo;
+          });
+        return { success: true, comment: existingComment, duplicate: true };
+      }
+    }
+
+    const comment = {
+      userId: agentUser._id,
+      text: content,
+      replyTo: replyToCommentId || null,
+      createdAt: new Date(),
+    };
+
+    (post as Record<string, unknown[]>).comments.push(comment as never);
+    await post.save();
+
+    const updated = await Post.findById(post._id)
+      .populate('comments.userId', 'username profilePicture')
+      .lean() as Record<string, unknown>;
+    const updatedComments = updated.comments as Array<unknown>;
+    const newComment = updatedComments[updatedComments.length - 1];
+
+    return {
+      success: true,
+      comment: newComment,
+    };
+  }
+}
+
+export default AgentThreadService;

--- a/backend/services/integrationService.ts
+++ b/backend/services/integrationService.ts
@@ -1,0 +1,83 @@
+import Integration from '../models/Integration';
+
+/**
+ * Common Integration Service
+ * Abstract base class for all platform integrations
+ */
+class IntegrationService {
+  protected integrationId: unknown;
+  protected integration: InstanceType<typeof Integration> | null;
+
+  constructor(integrationId: unknown) {
+    this.integrationId = integrationId;
+    this.integration = null;
+  }
+
+  static async initialize(): Promise<boolean> {
+    throw new Error('initialize() must be implemented by subclass');
+  }
+
+  static async connect(): Promise<boolean> {
+    throw new Error('connect() must be implemented by subclass');
+  }
+
+  static async disconnect(): Promise<boolean> {
+    throw new Error('disconnect() must be implemented by subclass');
+  }
+
+  static async fetchMessages(_options: Record<string, unknown> = {}): Promise<unknown[]> {
+    throw new Error('fetchMessages() must be implemented by subclass');
+  }
+
+  static async sendMessage(_message: string, _options: Record<string, unknown> = {}): Promise<unknown> {
+    throw new Error('sendMessage() must be implemented by subclass');
+  }
+
+  static async getChannels(): Promise<unknown[]> {
+    throw new Error('getChannels() must be implemented by subclass');
+  }
+
+  static async getStatus(): Promise<string> {
+    throw new Error('getStatus() must be implemented by subclass');
+  }
+
+  static async testConnection(): Promise<boolean> {
+    throw new Error('testConnection() must be implemented by subclass');
+  }
+
+  async updateStatus(status: string, errorMessage: string | null = null): Promise<void> {
+    try {
+      await Integration.findByIdAndUpdate(this.integrationId, {
+        status,
+        errorMessage,
+        lastSync:
+          status === 'connected' ? new Date() : (this.integration as Record<string, unknown>)?.lastSync,
+      });
+
+      if (this.integration) {
+        (this.integration as Record<string, unknown>).status = status;
+        (this.integration as Record<string, unknown>).errorMessage = errorMessage;
+        if (status === 'connected') {
+          (this.integration as Record<string, unknown>).lastSync = new Date();
+        }
+      }
+    } catch (error) {
+      console.error('Error updating integration status:', error);
+      throw error;
+    }
+  }
+
+  static async validateConfig(_config: Record<string, unknown>): Promise<boolean> {
+    throw new Error('validateConfig() must be implemented by subclass');
+  }
+
+  static async getStats(): Promise<Record<string, unknown>> {
+    throw new Error('getStats() must be implemented by subclass');
+  }
+
+  static async handleWebhook(_event: Record<string, unknown>): Promise<void> {
+    throw new Error('handleWebhook() must be implemented by subclass');
+  }
+}
+
+export default IntegrationService;


### PR DESCRIPTION
## Summary

Batch 2 of #118 — TypeScript migration for 6 more backend services.

Files added (`.ts` alongside existing `.js`):
- `agentIdentityService.ts` — `GetOrCreateOptions`, `AgentTypeConfig` interfaces; typed `AGENT_TYPES` registry; PostgreSQL sync
- `agentBootstrapService.ts` — `AgentManifest` interface; typed fs/path manifest loading
- `agentAutoJoinService.ts` — `AutoJoinResult` interface; typed installation iteration with limits
- `agentThreadService.ts` — `PostCommentOptions`/`PostCommentResult` interfaces; typed comment dedup logic
- `agentPersonalityService.ts` — `PersonalityConfig`, `GenerateSystemPromptOptions` interfaces; typed prompt generation
- `integrationService.ts` — abstract base class with typed method signatures; protected constructor fields

Follows the same pattern as PRs #121–#126 (models + middleware) and PR #127 (services batch 1): `allowJs:true` + `strict:false` — `.js` files untouched, `.ts` files compile alongside them.

Closes part of #118.

## Test plan
- [ ] CI `Test & Coverage` passes
- [ ] TypeScript compiles without errors: `cd backend && npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)