### PR TITLE
feat(ts): migrate 3 more backend services to TypeScript (batch 3)

### DIFF
--- a/backend/services/appService.ts
+++ b/backend/services/appService.ts
@@ -1,0 +1,408 @@
+import crypto from 'crypto';
+import axios from 'axios';
+import App from '../models/App';
+import AppInstallation from '../models/AppInstallation';
+
+// eslint-disable-next-line global-require
+const { hash, randomSecret } = require('../utils/secret') as {
+  hash: (value: string) => string;
+  verify: (value: string, hash: string) => boolean;
+  randomSecret: () => string;
+};
+
+interface WebhookResult {
+  success: boolean;
+  reason?: string;
+  statusCode?: number;
+}
+
+interface InstallResult {
+  installationId: string;
+  token: string;
+  scopes: string[];
+  events: string[];
+}
+
+interface MarketplaceApp {
+  id: string;
+  name: string;
+  displayName: string;
+  description: string;
+  type: string;
+  homepage: string;
+  category: string;
+  tags: string[];
+  logo: string | null;
+  verified: boolean;
+  rating: number;
+  ratingCount: number;
+  installs: number;
+  capabilities: string[];
+  scopes: string[];
+  createdAt: Date;
+}
+
+interface GetMarketplaceOptions {
+  category?: string;
+  type?: string;
+  search?: string;
+  limit?: number;
+  skip?: number;
+  sort?: string;
+}
+
+interface ValidatedToken {
+  installation: InstanceType<typeof AppInstallation>;
+  app: InstanceType<typeof App>;
+  scopes: string[];
+  targetType: string;
+  targetId: unknown;
+}
+
+class AppService {
+  static async deliverWebhook(app: InstanceType<typeof App>, event: string, payload: unknown, webhookSecret: string): Promise<WebhookResult> {
+    const appDoc = app as Record<string, unknown>;
+    if (appDoc.status !== 'active' || !appDoc.webhookUrl) {
+      return { success: false, reason: 'App inactive or no webhook URL' };
+    }
+
+    const body = JSON.stringify({
+      event,
+      timestamp: new Date().toISOString(),
+      payload,
+    });
+
+    const signature = crypto.createHmac('sha256', webhookSecret).update(body).digest('hex');
+
+    try {
+      const response = await axios.post(String(appDoc.webhookUrl), body, {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Commonly-Signature': `sha256=${signature}`,
+          'X-Commonly-Event': event,
+          'X-Commonly-Delivery': crypto.randomUUID(),
+        },
+        timeout: 10000,
+      });
+
+      const stats = appDoc.stats as Record<string, unknown>;
+      (stats.webhooksDelivered as number) += 1;
+      stats.lastActivity = new Date();
+      await app.save();
+
+      return {
+        success: true,
+        statusCode: response.status,
+      };
+    } catch (error) {
+      const err = error as Error & { response?: { status?: number } };
+      console.error(`Webhook delivery failed for app ${String(appDoc.name)}:`, err.message);
+      return {
+        success: false,
+        reason: err.message,
+        statusCode: err.response?.status,
+      };
+    }
+  }
+
+  static async dispatchEvent(event: string, targetType: string, targetId: unknown, payload: unknown): Promise<Array<Record<string, unknown>>> {
+    try {
+      const installations = await AppInstallation.find({
+        targetType,
+        targetId,
+        status: 'active',
+        events: event,
+        $or: [{ tokenExpiresAt: null }, { tokenExpiresAt: { $gt: new Date() } }],
+      }).populate('appId');
+
+      const results = await Promise.all(
+        installations.map(async (installation) => {
+          const app = (installation as Record<string, unknown>).appId as InstanceType<typeof App>;
+          const appDoc = app as Record<string, unknown>;
+          if (!app || appDoc.status !== 'active') return [];
+
+          const entries: Array<Record<string, unknown>> = [];
+
+          if (appDoc.type === 'webhook' || appDoc.type === 'integration') {
+            const result = await AppService.deliverWebhookByInstallation(installation, event, payload);
+            entries.push({ appId: appDoc._id, appName: appDoc.name, ...result });
+          }
+
+          if (appDoc.type === 'agent') {
+            entries.push({
+              appId: appDoc._id,
+              appName: appDoc.name,
+              success: true,
+              note: 'Agent event queued',
+            });
+          }
+
+          return entries;
+        }),
+      );
+
+      return results.flat();
+    } catch (error) {
+      console.error('Event dispatch error:', error);
+      return [];
+    }
+  }
+
+  static async deliverWebhookByInstallation(installation: InstanceType<typeof AppInstallation>, event: string, payload: unknown): Promise<WebhookResult> {
+    const app = (installation as Record<string, unknown>).appId as Record<string, unknown>;
+    if (!app.webhookUrl) {
+      return { success: false, reason: 'No webhook URL' };
+    }
+
+    const body = JSON.stringify({
+      event,
+      installationId: (installation as Record<string, unknown>)._id?.toString(),
+      targetType: (installation as Record<string, unknown>).targetType,
+      targetId: (installation as Record<string, unknown>).targetId?.toString(),
+      timestamp: new Date().toISOString(),
+      payload,
+    });
+
+    const tokenHash = String((installation as Record<string, unknown>).tokenHash || '');
+    const signature = crypto
+      .createHmac('sha256', tokenHash.substring(0, 32))
+      .update(body)
+      .digest('hex');
+
+    try {
+      const response = await axios.post(String(app.webhookUrl), body, {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Commonly-Signature': `sha256=${signature}`,
+          'X-Commonly-Event': event,
+          'X-Commonly-Installation': (installation as Record<string, unknown>)._id?.toString(),
+        },
+        timeout: 10000,
+      });
+
+      return { success: true, statusCode: response.status };
+    } catch (error) {
+      return { success: false, reason: (error as Error).message };
+    }
+  }
+
+  static async getMarketplaceApps(options: GetMarketplaceOptions = {}): Promise<MarketplaceApp[]> {
+    const {
+      category, type, search, limit = 50, skip = 0, sort = 'popular',
+    } = options;
+
+    const query: Record<string, unknown> = { 'marketplace.published': true, status: 'active' };
+
+    if (category && category !== 'all') {
+      query['marketplace.category'] = category;
+    }
+
+    if (type) {
+      query.type = type;
+    }
+
+    let sortOptions: Record<string, unknown> = {};
+    switch (sort) {
+      case 'popular':
+        sortOptions = { 'marketplace.installCount': -1 };
+        break;
+      case 'rating':
+        sortOptions = { 'marketplace.rating': -1 };
+        break;
+      case 'recent':
+        sortOptions = { createdAt: -1 };
+        break;
+      default:
+        sortOptions = { 'marketplace.installCount': -1 };
+    }
+
+    let apps: InstanceType<typeof App>[];
+    if (search) {
+      apps = await App.find({
+        ...query,
+        $text: { $search: search },
+      })
+        .select('-clientSecretHash -webhookSecretHash')
+        .sort({ score: { $meta: 'textScore' }, ...sortOptions })
+        .skip(skip)
+        .limit(limit) as InstanceType<typeof App>[];
+    } else {
+      apps = await App.find(query)
+        .select('-clientSecretHash -webhookSecretHash')
+        .sort(sortOptions)
+        .skip(skip)
+        .limit(limit) as InstanceType<typeof App>[];
+    }
+
+    return apps.map((app) => AppService.formatForMarketplace(app));
+  }
+
+  static formatForMarketplace(app: InstanceType<typeof App>): MarketplaceApp {
+    const a = app as Record<string, unknown>;
+    return {
+      id: (a._id as { toString(): string }).toString(),
+      name: String(a.name),
+      displayName: String((a.agent as Record<string, unknown>)?.displayName || a.name),
+      description: String(a.description || ''),
+      type: String(a.type),
+      homepage: String(a.homepage || ''),
+      category: String((a.marketplace as Record<string, unknown>)?.category || 'other'),
+      tags: ((a.marketplace as Record<string, unknown>)?.tags as string[]) || [],
+      logo: ((a.marketplace as Record<string, unknown>)?.logo || (a.agent as Record<string, unknown>)?.avatar) as string | null,
+      verified: Boolean((a.marketplace as Record<string, unknown>)?.verified),
+      rating: Number((a.marketplace as Record<string, unknown>)?.rating || 0),
+      ratingCount: Number((a.marketplace as Record<string, unknown>)?.ratingCount || 0),
+      installs: Number((a.marketplace as Record<string, unknown>)?.installCount || 0),
+      capabilities: ((a.agent as Record<string, unknown>)?.capabilities as string[]) || [],
+      scopes: (a.defaultScopes as string[]) || [],
+      createdAt: a.createdAt as Date,
+    };
+  }
+
+  static async getFeaturedApps(limit = 6): Promise<MarketplaceApp[]> {
+    const apps = await App.find({
+      'marketplace.published': true,
+      'marketplace.verified': true,
+      status: 'active',
+    })
+      .select('-clientSecretHash -webhookSecretHash')
+      .sort({ 'marketplace.rating': -1, 'marketplace.installCount': -1 })
+      .limit(limit) as InstanceType<typeof App>[];
+
+    return apps.map((app) => AppService.formatForMarketplace(app));
+  }
+
+  static async installApp(appId: unknown, podId: unknown, userId: unknown, options: { scopes?: string[]; events?: string[]; expiresIn?: number } = {}): Promise<InstallResult> {
+    const app = await App.findById(appId);
+    if (!app) {
+      throw new Error('App not found');
+    }
+    const appDoc = app as Record<string, unknown>;
+    if (appDoc.status !== 'active') {
+      throw new Error('App is not active');
+    }
+
+    const existing = await AppInstallation.findOne({
+      appId,
+      targetType: 'pod',
+      targetId: podId,
+      status: 'active',
+    });
+
+    if (existing) {
+      throw new Error('App already installed');
+    }
+
+    const token = randomSecret();
+    const tokenHash = hash(token);
+
+    const installation = await AppInstallation.create({
+      appId,
+      targetType: 'pod',
+      targetId: podId,
+      scopes: options.scopes || appDoc.defaultScopes,
+      events: options.events || appDoc.allowedEvents,
+      tokenHash,
+      tokenExpiresAt: options.expiresIn ? new Date(Date.now() + options.expiresIn * 1000) : null,
+      createdBy: userId,
+    });
+
+    await (app as Record<string, unknown> & { recordInstall(): Promise<void> }).recordInstall();
+
+    await AppService.dispatchEvent('app.installed', 'pod', podId, {
+      appId: appDoc._id?.toString(),
+      appName: appDoc.name,
+      installationId: (installation as Record<string, unknown>)._id?.toString(),
+    });
+
+    const instDoc = installation as Record<string, unknown>;
+    return {
+      installationId: String(instDoc._id),
+      token,
+      scopes: (instDoc.scopes as string[]) || [],
+      events: (instDoc.events as string[]) || [],
+    };
+  }
+
+  static async uninstallApp(installationId: unknown, _userId: unknown): Promise<{ success: boolean }> {
+    const installation = await AppInstallation.findById(installationId).populate('appId');
+    if (!installation) {
+      throw new Error('Installation not found');
+    }
+
+    const app = (installation as Record<string, unknown>).appId as InstanceType<typeof App> | null;
+    const instDoc = installation as Record<string, unknown>;
+    instDoc.status = 'revoked';
+    await installation.save();
+
+    if (app) {
+      await (app as Record<string, unknown> & { recordUninstall(): Promise<void> }).recordUninstall();
+    }
+
+    if (app) {
+      const appDoc = app as Record<string, unknown>;
+      await AppService.dispatchEvent('app.uninstalled', String(instDoc.targetType), instDoc.targetId, {
+        appId: appDoc._id?.toString(),
+        appName: appDoc.name,
+      });
+    }
+
+    return { success: true };
+  }
+
+  static async getInstalledApps(podId: unknown): Promise<Array<MarketplaceApp & { installationId: string; scopes: string[]; events: string[]; installedAt: Date }>> {
+    const installations = await AppInstallation.find({
+      targetType: 'pod',
+      targetId: podId,
+      status: 'active',
+    }).populate('appId', '-clientSecretHash -webhookSecretHash');
+
+    return installations
+      .filter((i) => (i as Record<string, unknown>).appId)
+      .map((installation) => {
+        const instDoc = installation as Record<string, unknown>;
+        return {
+          installationId: String(instDoc._id),
+          ...AppService.formatForMarketplace(instDoc.appId as InstanceType<typeof App>),
+          scopes: (instDoc.scopes as string[]) || [],
+          events: (instDoc.events as string[]) || [],
+          installedAt: instDoc.createdAt as Date,
+        };
+      });
+  }
+
+  static async validateToken(token: string): Promise<ValidatedToken | null> {
+    const tokenHash = hash(token);
+
+    const installation = await AppInstallation.findOne({
+      tokenHash,
+      status: 'active',
+      $or: [{ tokenExpiresAt: null }, { tokenExpiresAt: { $gt: new Date() } }],
+    }).populate('appId');
+
+    const instDoc = installation as Record<string, unknown> | null;
+    if (!instDoc || !instDoc.appId) {
+      return null;
+    }
+
+    return {
+      installation: installation as InstanceType<typeof AppInstallation>,
+      app: instDoc.appId as InstanceType<typeof App>,
+      scopes: (instDoc.scopes as string[]) || [],
+      targetType: String(instDoc.targetType),
+      targetId: instDoc.targetId,
+    };
+  }
+
+  static async hasScope(token: string, scope: string, targetType: string, targetId: unknown): Promise<boolean> {
+    const validated = await AppService.validateToken(token);
+    if (!validated) return false;
+
+    if (validated.targetType !== targetType) return false;
+    if (String(validated.targetId) !== String(targetId)) return false;
+
+    return validated.scopes.includes(scope) || validated.scopes.includes('*');
+  }
+}
+
+export default AppService;

--- a/backend/services/skillsCatalogService.ts
+++ b/backend/services/skillsCatalogService.ts
@@ -1,0 +1,219 @@
+import fs from 'fs';
+import path from 'path';
+
+const DEFAULT_SOURCE = 'awesome';
+
+interface SkillItem {
+  [key: string]: unknown;
+}
+
+interface Catalog {
+  source: string;
+  updatedAt: string | null;
+  items: SkillItem[];
+}
+
+interface FetchSkillContentResult {
+  content: string;
+  resolvedUrl: string;
+}
+
+interface SkillFile {
+  path: string;
+  content: string;
+}
+
+interface FetchDirectoryOptions {
+  maxFiles?: number;
+  maxBytes?: number;
+}
+
+interface GitHubSourceInfo {
+  owner: string;
+  repo: string;
+  branch: string;
+  path: string;
+  mode: string;
+}
+
+const resolveCatalogPath = (source: string): string | null => {
+  if (source === DEFAULT_SOURCE) {
+    if (process.env.SKILLS_CATALOG_PATH) {
+      return process.env.SKILLS_CATALOG_PATH;
+    }
+    if (process.env.SKILLS_CATALOG_DIR) {
+      return path.join(process.env.SKILLS_CATALOG_DIR, 'awesome-agent-skills-index.json');
+    }
+    return path.resolve(__dirname, '../../docs/skills/awesome-agent-skills-index.json');
+  }
+  return null;
+};
+
+export const loadCatalog = (source = DEFAULT_SOURCE): Catalog => {
+  const catalogPath = resolveCatalogPath(source);
+  if (!catalogPath) {
+    return { source, updatedAt: null, items: [] };
+  }
+  if (!fs.existsSync(catalogPath)) {
+    return { source, updatedAt: null, items: [] };
+  }
+  try {
+    const raw = fs.readFileSync(catalogPath, 'utf8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const items = Array.isArray(parsed.items) ? parsed.items as SkillItem[] : [];
+    return {
+      source,
+      updatedAt: (parsed.updatedAt as string) || null,
+      items,
+    };
+  } catch (error) {
+    console.warn(`[skills-catalog] Failed to read ${catalogPath}:`, (error as Error).message);
+    return { source, updatedAt: null, items: [] };
+  }
+};
+
+const toRawGitHubUrl = (sourceUrl: string): string => {
+  try {
+    const url = new URL(sourceUrl);
+    if (url.hostname !== 'github.com') return sourceUrl;
+    const parts = url.pathname.split('/').filter(Boolean);
+    if (parts.length < 5) return sourceUrl;
+    const [owner, repo, mode, branch, ...rest] = parts;
+    if (mode !== 'blob' && mode !== 'tree') return sourceUrl;
+    const pathPart = rest.join('/');
+    if (!pathPart) return sourceUrl;
+    return `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${pathPart}`;
+  } catch (error) {
+    return sourceUrl;
+  }
+};
+
+const parseGitHubSource = (sourceUrl: string): GitHubSourceInfo | null => {
+  try {
+    const url = new URL(sourceUrl);
+    const parts = url.pathname.split('/').filter(Boolean);
+    if (url.hostname === 'github.com') {
+      if (parts.length < 5) return null;
+      const [owner, repo, mode, branch, ...rest] = parts;
+      if (mode !== 'blob' && mode !== 'tree') return null;
+      const pathPart = rest.join('/');
+      return {
+        owner,
+        repo,
+        branch,
+        path: pathPart,
+        mode,
+      };
+    }
+    if (url.hostname === 'raw.githubusercontent.com') {
+      if (parts.length < 4) return null;
+      const [owner, repo, branch, ...rest] = parts;
+      const pathPart = rest.join('/');
+      return {
+        owner,
+        repo,
+        branch,
+        path: pathPart,
+        mode: 'raw',
+      };
+    }
+    return null;
+  } catch (error) {
+    return null;
+  }
+};
+
+const allowedExtensions = new Set([
+  '.md', '.markdown', '.txt', '.json', '.jsonc', '.js', '.ts', '.tsx',
+  '.py', '.sh', '.bash', '.zsh', '.yml', '.yaml', '.toml', '.env',
+  '.sql', '.css', '.html', '.csv', '.ini',
+]);
+
+const shouldIncludeFile = (pathName: string): boolean => {
+  const lower = pathName.toLowerCase();
+  if (lower.endsWith('/skill.md') || lower.endsWith('/skill.md'.toLowerCase())) return false;
+  const idx = lower.lastIndexOf('.');
+  if (idx === -1) return false;
+  return allowedExtensions.has(lower.slice(idx));
+};
+
+const fetchJson = async (url: string): Promise<unknown> => {
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'commonly-app',
+      Accept: 'application/vnd.github.v3+json',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch (${response.status})`);
+  }
+  return response.json();
+};
+
+export const fetchSkillDirectoryFiles = async (sourceUrl: string, options: FetchDirectoryOptions = {}): Promise<SkillFile[]> => {
+  const parsed = parseGitHubSource(sourceUrl);
+  if (!parsed) return [];
+
+  const { owner, repo, branch } = parsed;
+  let dirPath = parsed.path || '';
+  if (dirPath.endsWith('SKILL.md')) {
+    dirPath = dirPath.replace(/\/?SKILL\.md$/i, '');
+  }
+  if (!dirPath) return [];
+
+  const maxFiles = options.maxFiles || 50;
+  const maxBytes = options.maxBytes || 200_000;
+  let totalBytes = 0;
+  const files: SkillFile[] = [];
+
+  const walk = async (currentPath: string): Promise<void> => {
+    if (files.length >= maxFiles || totalBytes >= maxBytes) return;
+    const apiUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${currentPath}?ref=${branch}`;
+    const listing = await fetchJson(apiUrl);
+    if (!Array.isArray(listing)) return;
+    for (const item of listing as Array<Record<string, unknown>>) {
+      if (files.length >= maxFiles || totalBytes >= maxBytes) break;
+      if (item.type === 'dir') {
+        await walk(String(item.path));
+        continue;
+      }
+      if (item.type !== 'file') continue;
+      if (!item.path || !item.download_url) continue;
+      if (!shouldIncludeFile(String(item.path))) continue;
+      if (item.size && Number(item.size) > maxBytes) continue;
+      const resp = await fetch(String(item.download_url));
+      if (!resp.ok) continue;
+      const content = await resp.text();
+      totalBytes += content.length;
+      if (totalBytes > maxBytes) break;
+      files.push({
+        path: String(item.path).replace(new RegExp(`^${dirPath}/?`), ''),
+        content,
+      });
+    }
+  };
+
+  try {
+    await walk(dirPath);
+  } catch (error) {
+    console.warn('[skills-catalog] Failed to fetch extra files:', (error as Error).message);
+  }
+
+  return files;
+};
+
+export const fetchSkillContentFromSource = async (sourceUrl: string): Promise<FetchSkillContentResult> => {
+  if (!sourceUrl) return { content: '', resolvedUrl: sourceUrl };
+  const resolvedUrl = toRawGitHubUrl(sourceUrl);
+  if (!/^https?:\/\//i.test(resolvedUrl)) {
+    throw new Error('Unsupported skill source URL.');
+  }
+  const response = await fetch(resolvedUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch skill content (${response.status}).`);
+  }
+  const content = await response.text();
+  return { content, resolvedUrl };
+};
+
+export default { loadCatalog, fetchSkillContentFromSource, fetchSkillDirectoryFiles };

--- a/backend/services/socialPolicyService.ts
+++ b/backend/services/socialPolicyService.ts
@@ -1,0 +1,68 @@
+import SystemSetting from '../models/SystemSetting';
+
+const SOCIAL_POLICY_KEY = 'social.publishPolicy';
+
+export interface SocialPolicy {
+  socialMode: 'repost' | 'rewrite';
+  publishEnabled: boolean;
+  strictAttribution: boolean;
+}
+
+const DEFAULT_POLICY: SocialPolicy = {
+  socialMode: 'repost',
+  publishEnabled: false,
+  strictAttribution: true,
+};
+
+const normalizeMode = (mode: unknown): 'repost' | 'rewrite' => {
+  const value = String(mode || '').toLowerCase();
+  if (value === 'rewrite') return 'rewrite';
+  return 'repost';
+};
+
+const sanitizePolicy = (candidate: Partial<SocialPolicy> = {}): SocialPolicy => ({
+  socialMode: normalizeMode(candidate.socialMode || DEFAULT_POLICY.socialMode),
+  publishEnabled: Boolean(candidate.publishEnabled),
+  strictAttribution: Boolean(
+    typeof candidate.strictAttribution === 'boolean'
+      ? candidate.strictAttribution
+      : DEFAULT_POLICY.strictAttribution,
+  ),
+});
+
+class SocialPolicyService {
+  static defaults(): SocialPolicy {
+    return { ...DEFAULT_POLICY };
+  }
+
+  static async getPolicy(): Promise<SocialPolicy> {
+    const setting = await SystemSetting.findOne({ key: SOCIAL_POLICY_KEY }).lean() as Record<string, unknown> | null;
+    if (!setting?.value || typeof setting.value !== 'object') {
+      return SocialPolicyService.defaults();
+    }
+    return sanitizePolicy({
+      ...DEFAULT_POLICY,
+      ...(setting.value as Partial<SocialPolicy>),
+    });
+  }
+
+  static async setPolicy(policy: Partial<SocialPolicy>, userId: string | null = null): Promise<SocialPolicy> {
+    const next = sanitizePolicy(policy);
+    await SystemSetting.findOneAndUpdate(
+      { key: SOCIAL_POLICY_KEY },
+      {
+        $set: {
+          value: next,
+          updatedBy: userId || null,
+        },
+      },
+      {
+        upsert: true,
+        new: true,
+      },
+    );
+    return next;
+  }
+}
+
+export default SocialPolicyService;


### PR DESCRIPTION
## Summary

Batch 3 of #118 — TypeScript migration for 3 more backend services.

Files added (`.ts` alongside existing `.js`):
- `socialPolicyService.ts` — `SocialPolicy` interface; typed sanitize helpers + `SystemSetting` upsert
- `skillsCatalogService.ts` — `Catalog`, `SkillItem`, `GitHubSourceInfo`, `SkillFile` interfaces; typed fs catalog loading + GitHub directory fetch helpers
- `appService.ts` — `MarketplaceApp`, `InstallResult`, `WebhookResult`, `ValidatedToken` interfaces; typed webhook delivery, app install/uninstall, marketplace queries

Closes part of #118.

## Test plan
- [ ] CI `Test & Coverage` passes
- [ ] TypeScript compiles without errors: `cd backend && npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)