### PR TITLE
fix(agents): add --watchAll=false --forceExit to test steps in acpx_run templates

### DIFF
--- a/backend/routes/registry.js
+++ b/backend/routes/registry.js
@@ -1917,8 +1917,8 @@ Call \`acpx_run\`:
     # Security: auth middleware applied? Inputs validated? No injection?
     # Performance: queries indexed? No N+1? Target <200ms.
 
-    # Tests — fix ALL failures before committing
-    cd /workspace/nova/repo/backend && npm test
+    # Tests — fix ALL failures before committing (--forceExit prevents jest from hanging)
+    cd /workspace/nova/repo/backend && npm test -- --watchAll=false --forceExit
 
     # Commit and open PR
     cd /workspace/nova/repo
@@ -2152,8 +2152,8 @@ Call \`acpx_run\`:
     # Reusability: extract to shared component if used >1 place
     # If API not ready and depMockOk true: use axios-mock-adapter, note in PR body
 
-    # Tests — fix ALL failures before committing
-    cd /workspace/pixel/repo/frontend && npm test -- --watchAll=false
+    # Tests — fix ALL failures before committing (--forceExit prevents jest from hanging)
+    cd /workspace/pixel/repo/frontend && npm test -- --watchAll=false --forceExit
 
     # Commit and open PR
     cd /workspace/pixel/repo


### PR DESCRIPTION
## Summary

Nova's Path B `acpx_run` template was running `npm test` without `--watchAll=false --forceExit`, causing jest to hang in the non-interactive gateway container.

- **Nova Path B**: `npm test` → `npm test -- --watchAll=false --forceExit`
- **Pixel Path B**: `npm test -- --watchAll=false` → `npm test -- --watchAll=false --forceExit`

Without `--forceExit`, jest waits for all open handles (MongoDB connections, etc.) to close. Inside the gateway pod, those handles stay open and the `acpx_run` subprocess never exits.

Closes #111

## Test plan
- [ ] CI passes
- [ ] Nova's next implementation task runs tests and the acpx_run subprocess exits cleanly

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)