### PR TITLE
feat(ts): migrate 2 utility services to TypeScript (batch 4)

### DIFF
--- a/backend/services/digestTemplateService.ts
+++ b/backend/services/digestTemplateService.ts
@@ -1,0 +1,273 @@
+interface UserLike {
+  username: string;
+}
+
+interface AtmosphereLike {
+  overall_sentiment?: string;
+  energy_level?: string;
+  engagement_quality?: string;
+}
+
+interface InsightsLike {
+  totalItems?: number;
+  overallAtmosphere?: AtmosphereLike;
+  topUsers?: unknown[];
+  bestQuotes?: Array<{ text: string; author: string; context: string }>;
+  keyInsights?: Array<{ type: string; description: string }>;
+  timeline?: Array<{ timestamp: string; description: string }>;
+}
+
+interface MetadataLike {
+  subscribedPods?: number;
+}
+
+class DigestTemplateService {
+  static createDigestPrompt(organizedData: unknown, user: UserLike): string {
+    const { username } = user;
+    const date = new Date().toDateString();
+
+    return `Create a personalized daily digest newsletter for ${username} using this EXACT format and structure:
+
+COMMUNITY DATA:
+${JSON.stringify(organizedData, null, 2)}
+
+REQUIRED FORMAT (follow this structure exactly):
+
+# 🌅 Daily Digest - ${date}
+
+Good morning, ${username}!
+
+Ready for your daily dose of community insights? Let's dive into what's been happening while you were away.
+
+## ✨ Today's Highlights
+
+[List 3-5 most significant developments, each as a bullet point with descriptive titles]
+
+## 💬 Notable Moments
+
+### 🔥 Quote of the Day
+> "[Most engaging or insightful quote from discussions]"
+>
+> *— @[username] in [community/context]*
+
+### 🎯 Key Insights
+- **[Insight Type]**: [Brief description of trend, consensus, or development]
+- **[Community Vibe]**: [Description of overall mood and energy]
+
+## 📊 Community Pulse
+
+- **Overall Mood**: [Emoji] [Sentiment description]
+- **Energy Level**: [Emoji] [Activity level description]
+- **Engagement Quality**: [Emoji] [Type of discussions happening]
+- **Active Communities**: [Number] of your subscribed communities had activity
+
+## 🔮 Looking Ahead
+
+[2-3 sentences about trends, upcoming discussions, or community direction]
+
+---
+*Your personalized digest • Generated with ❤️ by Commonly AI*
+
+GUIDELINES:
+- Use engaging, friendly tone
+- Include specific details from the data
+- Personalize content for ${username}
+- Use emojis strategically for visual appeal
+- Keep sections concise but informative
+- Focus on community connection and engagement
+- If data is limited, acknowledge it positively
+- Highlight ${username}'s contributions when present`;
+  }
+
+  static createAnalyticsPrompt(messages: unknown, podName: string): string {
+    return `Analyze this chat data and extract structured analytics for community insights.
+
+CHAT DATA:
+Pod: ${podName}
+Messages: ${JSON.stringify(messages, null, 2)}
+
+Extract and return ONLY a valid JSON object with this structure:
+{
+  "timeline": [
+    {
+      "timestamp": "ISO date",
+      "event": "topic_shift|peak_activity|heated_discussion|new_participant|milestone",
+      "description": "Brief description of what happened",
+      "participants": ["username1", "username2"],
+      "intensity": 1-10
+    }
+  ],
+  "quotes": [
+    {
+      "text": "Exact quote text",
+      "author": "username",
+      "timestamp": "ISO date",
+      "context": "What was being discussed",
+      "sentiment": "positive|negative|neutral|humorous|insightful",
+      "reactions": 0
+    }
+  ],
+  "insights": [
+    {
+      "type": "trend|sentiment_shift|new_topic|consensus|disagreement|revelation",
+      "description": "What insight was gained",
+      "confidence": 0.0-1.0,
+      "impact": "low|medium|high",
+      "participants": ["username1"],
+      "timestamp": "ISO date"
+    }
+  ],
+  "atmosphere": {
+    "overall_sentiment": "very_positive|positive|neutral|negative|very_negative",
+    "energy_level": "very_low|low|medium|high|very_high",
+    "engagement_quality": "superficial|moderate|deep|intense",
+    "community_cohesion": 0.0-1.0,
+    "topics_diversity": 0.0-1.0,
+    "dominant_emotions": ["emotion1", "emotion2"]
+  },
+  "participation": {
+    "most_active_users": [
+      {
+        "username": "username",
+        "message_count": 0,
+        "engagement_score": 0.0-1.0,
+        "role": "moderator|contributor|lurker|newcomer"
+      }
+    ],
+    "engagement_patterns": {
+      "peak_hours": [14, 15, 16],
+      "discussion_length_avg": 0,
+      "response_time_avg": 0
+    }
+  }
+}
+
+IMPORTANT: Return ONLY the JSON object, no additional text or explanation.`;
+  }
+
+  static createFallbackDigest(user: UserLike, insights: InsightsLike, _startTime: Date, endTime: Date): string {
+    const { username } = user;
+    const date = endTime.toDateString();
+
+    return `# 🌅 Daily Digest - ${date}
+
+Good morning, ${username}!
+
+Ready for your daily community catch-up? Here's what's been happening.
+
+## ✨ Today's Highlights
+
+- **Community Activity**: ${insights.totalItems || 0} conversations and updates across your communities
+- **Active Discussions**: Your communities maintained ${insights.overallAtmosphere?.energy_level || 'moderate'} energy levels
+- **Community Engagement**: ${insights.topUsers?.length || 0} active community members contributing
+
+## 📊 Community Pulse
+
+- **Overall Mood**: 😊 ${insights.overallAtmosphere?.overall_sentiment || 'Positive'}
+- **Energy Level**: ⚡ ${insights.overallAtmosphere?.energy_level || 'Moderate'}
+- **Engagement Quality**: 🎯 ${insights.overallAtmosphere?.engagement_quality || 'Good'} discussions
+- **Active Communities**: Your subscribed communities are staying connected
+
+## 🔮 Looking Ahead
+
+Your communities continue to grow and evolve. Keep an eye out for new conversations and opportunities to connect with fellow members.
+
+---
+*Your personalized digest • Generated with ❤️ by Commonly AI*`;
+  }
+
+  static getPersonalizedGreeting(user: UserLike, timeOfDay: string, activityLevel: string): string {
+    const { username } = user;
+
+    const greetings: Record<string, Record<string, string>> = {
+      morning: {
+        high: `Rise and shine, ${username}! Your communities were buzzing overnight.`,
+        medium: `Good morning, ${username}! Here's what happened while you were away.`,
+        low: `Morning, ${username}! It was a quiet night, but there are still some gems to discover.`,
+      },
+      afternoon: {
+        high: `Good afternoon, ${username}! Catching up on a busy day in your communities?`,
+        medium: `Hey ${username}! Ready for your daily community roundup?`,
+        low: `Hi ${username}! Not much happened, but here's what's worth knowing.`,
+      },
+      evening: {
+        high: `Evening, ${username}! Your communities had quite the active day.`,
+        medium: `Good evening, ${username}! Time to catch up on today's highlights.`,
+        low: `Evening, ${username}! A peaceful day in your communities, but still some nice moments to share.`,
+      },
+    };
+
+    return (
+      greetings[timeOfDay]?.[activityLevel]
+      || `Hello, ${username}! Here's your daily community digest.`
+    );
+  }
+
+  static buildConditionalSections(insights: InsightsLike, _user: UserLike): string {
+    const sections: string[] = [];
+
+    if (insights.bestQuotes && insights.bestQuotes.length > 0) {
+      const topQuote = insights.bestQuotes[0];
+      sections.push(`### 🔥 Quote of the Day
+> "${topQuote.text}"
+>
+> *— @${topQuote.author} in ${topQuote.context}*`);
+    }
+
+    if (insights.keyInsights && insights.keyInsights.length > 0) {
+      let insightText = '### 🎯 Key Insights\n';
+      insights.keyInsights.slice(0, 3).forEach((insight) => {
+        insightText += `- **${insight.type.replace('_', ' ').toUpperCase()}**: ${insight.description}\n`;
+      });
+      sections.push(insightText.trim());
+    }
+
+    if (insights.timeline && insights.timeline.length > 0) {
+      let timelineText = '### ⏰ Timeline Highlights\n';
+      insights.timeline.slice(0, 3).forEach((event) => {
+        const time = new Date(event.timestamp).toLocaleTimeString('en-US', {
+          hour: 'numeric',
+          minute: '2-digit',
+        });
+        timelineText += `- **${time}**: ${event.description}\n`;
+      });
+      sections.push(timelineText.trim());
+    }
+
+    return sections.join('\n\n');
+  }
+
+  static formatCommunityPulse(atmosphere: AtmosphereLike | null, metadata: MetadataLike | null): string {
+    const moodEmojis: Record<string, string> = {
+      very_positive: '🌟',
+      positive: '😊',
+      neutral: '😐',
+      negative: '😔',
+      very_negative: '😞',
+    };
+
+    const energyEmojis: Record<string, string> = {
+      very_high: '🚀',
+      high: '⚡',
+      medium: '🔋',
+      low: '🔅',
+      very_low: '💤',
+    };
+
+    const engagementEmojis: Record<string, string> = {
+      intense: '🔥',
+      deep: '🎯',
+      moderate: '💬',
+      superficial: '👋',
+    };
+
+    return `## 📊 Community Pulse
+
+- **Overall Mood**: ${moodEmojis[atmosphere?.overall_sentiment || ''] || '😊'} ${atmosphere?.overall_sentiment?.replace('_', ' ') || 'Positive'}
+- **Energy Level**: ${energyEmojis[atmosphere?.energy_level || ''] || '🔋'} ${atmosphere?.energy_level?.replace('_', ' ') || 'Moderate'}
+- **Engagement Quality**: ${engagementEmojis[atmosphere?.engagement_quality || ''] || '💬'} ${atmosphere?.engagement_quality || 'Good'} discussions
+- **Active Communities**: ${metadata?.subscribedPods || 0} of your subscribed communities had activity`;
+  }
+}
+
+export default DigestTemplateService;

--- a/backend/services/keywordExtractionService.ts
+++ b/backend/services/keywordExtractionService.ts
@@ -1,0 +1,290 @@
+interface KeywordItem {
+  word: string;
+  frequency: number;
+  weight: number;
+}
+
+interface TrendingKeyword extends KeywordItem {
+  trend: 'rising';
+  growthRate: number;
+  isNew: boolean;
+}
+
+interface TopicCluster {
+  topic: string;
+  keywords: KeywordItem[];
+  strength: number;
+  relatedSummaries: Array<{ id: unknown; title: string; relevance: number }>;
+}
+
+interface UserRelationships {
+  userActivity: Array<{ user: string; count: number }>;
+  relationships: Array<{ user1: string; user2: string; strength: number }>;
+}
+
+interface ActivityPatterns {
+  hourlyPattern: Array<{ hour: number; activity: number }>;
+  dailyPattern: Array<{ day: string; activity: number }>;
+  sentimentTimeline: Array<{ timestamp: string; sentiment: string; activity: number }>;
+}
+
+interface SummaryLike {
+  title: string;
+  content: string;
+  _id?: unknown;
+  createdAt?: Date | string;
+  metadata?: Record<string, unknown>;
+  analytics?: Record<string, unknown>;
+}
+
+interface ExtractKeywordsOptions {
+  maxKeywords?: number;
+  minFrequency?: number;
+}
+
+class KeywordExtractionService {
+  static extractKeywords(summaries: SummaryLike[], options: ExtractKeywordsOptions = {}): KeywordItem[] {
+    const { maxKeywords = 20, minFrequency = 2 } = options;
+
+    const allText = summaries
+      .map((s) => `${s.title} ${s.content}`)
+      .join(' ')
+      .toLowerCase();
+
+    const words = this.preprocessText(allText);
+    const wordFreqs = this.calculateWordFrequencies(words);
+
+    const keywords = Object.entries(wordFreqs)
+      .filter(([word, freq]) => freq >= minFrequency && word.length > 3)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, maxKeywords)
+      .map(([word, frequency]) => ({
+        word,
+        frequency,
+        weight: this.calculateTFIDF(word, words, [words]),
+      }));
+
+    return keywords;
+  }
+
+  static generateTopicClusters(keywords: KeywordItem[], summaries: SummaryLike[]): TopicCluster[] {
+    const clusters: TopicCluster[] = [];
+    const usedKeywords = new Set<string>();
+
+    keywords.forEach((keyword) => {
+      if (usedKeywords.has(keyword.word)) return;
+
+      const cluster: TopicCluster = {
+        topic: this.generateTopicName(keyword.word),
+        keywords: [keyword],
+        strength: keyword.weight,
+        relatedSummaries: this.findRelatedSummaries(keyword.word, summaries),
+      };
+
+      keywords.forEach((otherKeyword) => {
+        if (
+          otherKeyword.word !== keyword.word
+          && !usedKeywords.has(otherKeyword.word)
+          && this.areWordsRelated(keyword.word, otherKeyword.word)
+        ) {
+          cluster.keywords.push(otherKeyword);
+          usedKeywords.add(otherKeyword.word);
+        }
+      });
+
+      usedKeywords.add(keyword.word);
+      clusters.push(cluster);
+    });
+
+    return clusters.slice(0, 8);
+  }
+
+  static extractUserRelationships(summaries: SummaryLike[]): UserRelationships {
+    const relationships = new Map<string, number>();
+    const userMentions = new Map<string, number>();
+
+    summaries.forEach((summary) => {
+      const users: string[] = (summary.metadata?.topUsers as string[]) || [];
+
+      users.forEach((user) => {
+        userMentions.set(user, (userMentions.get(user) || 0) + 1);
+      });
+
+      for (let i = 0; i < users.length; i += 1) {
+        for (let j = i + 1; j < users.length; j += 1) {
+          const pair = [users[i], users[j]].sort().join('-');
+          relationships.set(pair, (relationships.get(pair) || 0) + 1);
+        }
+      }
+    });
+
+    return {
+      userActivity: Array.from(userMentions.entries())
+        .map(([user, count]) => ({ user, count }))
+        .sort((a, b) => b.count - a.count),
+      relationships: Array.from(relationships.entries())
+        .map(([pair, strength]) => {
+          const [user1, user2] = pair.split('-');
+          return { user1, user2, strength };
+        })
+        .sort((a, b) => b.strength - a.strength),
+    };
+  }
+
+  static analyzeActivityPatterns(summaries: SummaryLike[]): ActivityPatterns {
+    const hourlyActivity = new Map<number, number>();
+    const dailyActivity = new Map<string, number>();
+    const sentimentOverTime: Array<{ timestamp: string; sentiment: string; activity: number }> = [];
+
+    summaries.forEach((summary) => {
+      const date = new Date(summary.createdAt as string | Date);
+      const hour = date.getHours();
+      const day = date.toDateString();
+
+      hourlyActivity.set(
+        hour,
+        (hourlyActivity.get(hour) || 0) + ((summary.metadata?.totalItems as number) || 1),
+      );
+
+      dailyActivity.set(
+        day,
+        (dailyActivity.get(day) || 0) + ((summary.metadata?.totalItems as number) || 1),
+      );
+
+      const atmosphere = (summary.analytics as Record<string, unknown>)?.atmosphere as Record<string, unknown> | undefined;
+      if (atmosphere?.overall_sentiment) {
+        sentimentOverTime.push({
+          timestamp: date.toISOString(),
+          sentiment: String(atmosphere.overall_sentiment),
+          activity: (summary.metadata?.totalItems as number) || 0,
+        });
+      }
+    });
+
+    return {
+      hourlyPattern: Array.from(hourlyActivity.entries())
+        .map(([hour, activity]) => ({ hour, activity }))
+        .sort((a, b) => a.hour - b.hour),
+      dailyPattern: Array.from(dailyActivity.entries())
+        .map(([day, activity]) => ({ day, activity }))
+        .sort((a, b) => new Date(a.day).getTime() - new Date(b.day).getTime()),
+      sentimentTimeline: sentimentOverTime.sort(
+        (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+      ),
+    };
+  }
+
+  static identifyTrendingTopics(currentKeywords: KeywordItem[], previousKeywords: KeywordItem[] = []): TrendingKeyword[] {
+    const trending: TrendingKeyword[] = [];
+    const previousMap = new Map(
+      previousKeywords.map((k) => [k.word, k.frequency]),
+    );
+
+    currentKeywords.forEach((keyword) => {
+      const previousFreq = previousMap.get(keyword.word) || 0;
+      const change = keyword.frequency - previousFreq;
+      const growthRate = previousFreq > 0 ? (change / previousFreq) * 100 : 100;
+
+      if (growthRate > 50 || (previousFreq === 0 && keyword.frequency > 2)) {
+        trending.push({
+          ...keyword,
+          trend: 'rising',
+          growthRate: Math.round(growthRate),
+          isNew: previousFreq === 0,
+        });
+      }
+    });
+
+    return trending.sort((a, b) => b.growthRate - a.growthRate);
+  }
+
+  // Helper methods
+  static preprocessText(text: string): string[] {
+    const stopWords = new Set([
+      'the', 'is', 'at', 'which', 'on', 'a', 'an', 'and', 'or', 'but', 'in', 'with',
+      'to', 'for', 'of', 'as', 'by', 'this', 'that', 'these', 'those', 'i', 'you',
+      'he', 'she', 'it', 'we', 'they', 'me', 'him', 'her', 'us', 'them', 'my', 'your',
+      'his', 'its', 'our', 'their', 'am', 'are', 'was', 'were', 'be', 'been', 'being',
+      'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could', 'should',
+      'may', 'might', 'must', 'can', 'cannot', 'cant', 'dont', 'wont', 'isnt', 'arent',
+      'wasnt', 'werent', 'hasnt', 'havent', 'hadnt', 'community', 'members', 'discussion',
+      'conversations', 'chat', 'messages', 'today', 'yesterday', 'tomorrow',
+    ]);
+
+    return text
+      .replace(/[^\w\s]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .split(' ')
+      .filter((word) => word.length > 2 && !stopWords.has(word))
+      .filter((word) => !/^\d+$/.test(word));
+  }
+
+  static calculateWordFrequencies(words: string[]): Record<string, number> {
+    const frequencies: Record<string, number> = {};
+    words.forEach((word) => {
+      frequencies[word] = (frequencies[word] || 0) + 1;
+    });
+    return frequencies;
+  }
+
+  static calculateTFIDF(word: string, document: string[], corpus: string[][]): number {
+    const tf = document.filter((w) => w === word).length / document.length;
+    const df = corpus.filter((doc) => doc.includes(word)).length;
+    const idf = Math.log(corpus.length / (df + 1));
+    return tf * idf;
+  }
+
+  static generateTopicName(keyword: string): string {
+    const topicMap: Record<string, string> = {
+      react: 'Frontend Development',
+      javascript: 'Web Development',
+      boba: 'Food & Drinks',
+      tea: 'Beverages',
+      discord: 'Community Chat',
+      testing: 'Quality Assurance',
+      framework: 'Development Tools',
+      async: 'Programming Concepts',
+    };
+
+    return (
+      topicMap[keyword]
+      || `${keyword.charAt(0).toUpperCase() + keyword.slice(1)} Discussion`
+    );
+  }
+
+  static findRelatedSummaries(keyword: string, summaries: SummaryLike[]): Array<{ id: unknown; title: string; relevance: number }> {
+    return summaries
+      .filter(
+        (summary) => summary.title.toLowerCase().includes(keyword)
+          || summary.content.toLowerCase().includes(keyword),
+      )
+      .map((summary) => ({
+        id: summary._id,
+        title: summary.title,
+        relevance: this.calculateRelevance(keyword, summary),
+      }))
+      .sort((a, b) => b.relevance - a.relevance)
+      .slice(0, 3);
+  }
+
+  static calculateRelevance(keyword: string, summary: SummaryLike): number {
+    const text = `${summary.title} ${summary.content}`.toLowerCase();
+    const occurrences = (text.match(new RegExp(keyword, 'g')) || []).length;
+    return occurrences / text.split(' ').length;
+  }
+
+  static areWordsRelated(word1: string, word2: string): boolean {
+    const relatedGroups: string[][] = [
+      ['react', 'javascript', 'frontend', 'web', 'component'],
+      ['boba', 'tea', 'drink', 'beverage', 'ume'],
+      ['discord', 'chat', 'message', 'conversation'],
+      ['test', 'testing', 'framework', 'development'],
+    ];
+
+    return relatedGroups.some(
+      (group) => group.includes(word1) && group.includes(word2),
+    );
+  }
+}
+
+export default KeywordExtractionService;


### PR DESCRIPTION
## Summary

Batch 4 of #118 — TypeScript migration for 2 pure-utility services (no DB dependencies).

Files added:
- `keywordExtractionService.ts` — `KeywordItem`, `TrendingKeyword`, `TopicCluster`, `UserRelationships`, `ActivityPatterns` interfaces; typed TF-IDF + keyword clustering
- `digestTemplateService.ts` — `UserLike`, `InsightsLike`, `AtmosphereLike` interfaces; typed digest/analytics prompt builders

Closes part of #118.

## Test plan
- [ ] CI `Test & Coverage` passes
- [ ] `cd backend && npx tsc --noEmit` succeeds

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)