### PR TITLE
feat(ts): migrate 5 integration/search services to TypeScript (batch 5)

### DIFF
--- a/backend/services/groupmeService.ts
+++ b/backend/services/groupmeService.ts
@@ -1,0 +1,108 @@
+import axios from 'axios';
+
+const GROUPME_API_BASE = 'https://api.groupme.com/v3';
+
+interface SendResult {
+  success: boolean;
+  error?: string;
+}
+
+interface FetchOptions {
+  groupId: string;
+  accessToken: string;
+  limit?: number;
+  before?: string;
+  after?: string;
+}
+
+interface NormalizedMessage {
+  id: string;
+  authorId: string;
+  authorName: string;
+  content: string;
+  timestamp: string | null;
+  attachments: string[];
+  reactions: unknown[];
+  isBot: boolean;
+}
+
+interface GroupMeMessageRaw {
+  id: string;
+  user_id?: string;
+  sender_id?: string;
+  name?: string;
+  text?: string;
+  created_at?: number;
+  attachments?: Array<{ url?: string; text?: string }>;
+  sender_type?: string;
+}
+
+interface GroupMeHistoryResponse {
+  response?: {
+    messages?: GroupMeMessageRaw[];
+  };
+}
+
+interface FetchParams {
+  token: string;
+  limit: number;
+  before_id?: string;
+  after_id?: string;
+}
+
+async function sendMessage(botId: string, text: string): Promise<SendResult> {
+  if (!botId || !text) {
+    return { success: false, error: 'Missing botId or text' };
+  }
+
+  try {
+    const response = await axios.post(`${GROUPME_API_BASE}/bots/post`, {
+      bot_id: botId,
+      text,
+    });
+
+    console.log('GroupMe message sent', { botId, status: response.status });
+    return { success: response.status === 202 };
+  } catch (error) {
+    const err = error as { response?: { data: unknown }; message: string };
+    console.error('Error sending GroupMe message:', err.response?.data || err.message);
+    return { success: false, error: err.message };
+  }
+}
+
+async function fetchMessages(options: FetchOptions = {} as FetchOptions): Promise<NormalizedMessage[]> {
+  const {
+    groupId, accessToken, limit = 50, before, after,
+  } = options;
+
+  if (!groupId || !accessToken) {
+    throw new Error('Missing groupId or accessToken');
+  }
+
+  const params: FetchParams = {
+    token: accessToken,
+    limit: Math.min(Math.max(parseInt(String(limit), 10) || 50, 1), 100),
+  };
+
+  if (before) params.before_id = before;
+  if (after) params.after_id = after;
+
+  const response = await axios.get<GroupMeHistoryResponse>(
+    `${GROUPME_API_BASE}/groups/${groupId}/messages`,
+    { params },
+  );
+  const messages = response.data?.response?.messages || [];
+
+  return messages.map((msg) => ({
+    id: msg.id,
+    authorId: msg.user_id || msg.sender_id || '',
+    authorName: msg.name || 'Unknown',
+    content: msg.text || '',
+    timestamp: msg.created_at ? new Date(msg.created_at * 1000).toISOString() : null,
+    attachments: (msg.attachments || []).map((att) => att.url || att.text || '').filter(Boolean),
+    reactions: [],
+    isBot: msg.sender_type === 'bot',
+  }));
+}
+
+export { sendMessage, fetchMessages };

--- a/backend/services/integrationSummaryService.ts
+++ b/backend/services/integrationSummaryService.ts
@@ -1,0 +1,126 @@
+// eslint-disable-next-line global-require
+const summarizerService = require('./summarizerService');
+// eslint-disable-next-line global-require
+const { normalizeBufferMessage } = require('../integrations/normalizeBufferMessage');
+
+const SOURCE_LABELS: Record<string, string> = {
+  discord: 'Discord',
+  slack: 'Slack',
+  telegram: 'Telegram',
+  groupme: 'GroupMe',
+  whatsapp: 'WhatsApp',
+  messenger: 'Messenger',
+  x: 'X',
+  instagram: 'Instagram',
+};
+
+interface NormalizedMessage {
+  authorName?: string;
+  content?: string;
+  timestamp?: string | Date;
+}
+
+interface IntegrationConfig {
+  serverName?: string;
+  channelName?: string;
+  groupName?: string;
+  chatTitle?: string;
+  username?: string;
+  igUserId?: string;
+  channelId?: string;
+  groupId?: string;
+  chatId?: string;
+  channelUrl?: string;
+  groupUrl?: string;
+  serverId?: string;
+}
+
+interface Integration {
+  type: string;
+  config?: IntegrationConfig;
+}
+
+interface SummaryResult {
+  content: string;
+  messageCount: number;
+  timeRange: { start: Date; end: Date };
+  source: string;
+  sourceLabel: string;
+  serverName: string | null;
+  channelName: string;
+  channelUrl: string | null;
+  serverId: string | null;
+  channelId: string | null;
+  summaryType: string;
+}
+
+class IntegrationSummaryService {
+  static buildSummaryContent(messages: NormalizedMessage[]): string | Promise<string> {
+    const userMessages = messages.filter((msg) => msg.authorName && msg.content);
+
+    if (userMessages.length === 0) {
+      return 'Recent activity consisted mainly of system updates or empty messages.';
+    }
+
+    if (userMessages.length <= 2) {
+      return userMessages
+        .map((msg) => `${msg.authorName}: ${msg.content}`)
+        .join('\n');
+    }
+
+    const messageContent = userMessages
+      .map((msg) => `${msg.authorName}: ${msg.content}`)
+      .join('\n');
+
+    return summarizerService.generateSummary(messageContent, 'integration') as Promise<string>;
+  }
+
+  static async createSummary(integration: Integration, bufferMessages: unknown[]): Promise<SummaryResult> {
+    const messages: NormalizedMessage[] = (bufferMessages || [])
+      .map((msg) => normalizeBufferMessage(msg) as NormalizedMessage)
+      .filter(Boolean);
+
+    const timestamps = messages
+      .map((msg) => new Date(msg.timestamp as string | Date).getTime())
+      .filter((value) => !Number.isNaN(value))
+      .sort((a, b) => a - b);
+
+    const timeRange = {
+      start: timestamps.length ? new Date(timestamps[0]) : new Date(),
+      end: timestamps.length ? new Date(timestamps[timestamps.length - 1]) : new Date(),
+    };
+
+    const content = await IntegrationSummaryService.buildSummaryContent(messages);
+
+    const summaryType = integration.type === 'discord'
+      ? 'discord-hourly'
+      : `${integration.type}-hourly`;
+
+    return {
+      content: content as string,
+      messageCount: messages.length,
+      timeRange,
+      source: integration.type,
+      sourceLabel: SOURCE_LABELS[integration.type] || 'External',
+      serverName: integration.config?.serverName || null,
+      channelName:
+        integration.config?.channelName
+        || integration.config?.groupName
+        || integration.config?.chatTitle
+        || integration.config?.username
+        || integration.config?.igUserId
+        || integration.config?.channelId
+        || integration.config?.groupId
+        || integration.config?.chatId
+        || 'channel',
+      channelUrl: integration.config?.channelUrl
+        || integration.config?.groupUrl
+        || null,
+      serverId: integration.config?.serverId || null,
+      channelId: integration.config?.channelId || integration.config?.chatId || null,
+      summaryType,
+    };
+  }
+}
+
+export default IntegrationSummaryService;

--- a/backend/services/podMemorySearchService.ts
+++ b/backend/services/podMemorySearchService.ts
@@ -1,0 +1,316 @@
+// eslint-disable-next-line global-require
+const PodAsset = require('../models/PodAsset');
+// eslint-disable-next-line global-require
+const PodAssetService = require('./podAssetService');
+// eslint-disable-next-line global-require
+const PodContextService = require('./podContextService');
+
+const MAX_LIMIT = 40;
+const DEFAULT_LIMIT = 8;
+const MAX_EXCERPT_LINES = 100;
+const DEFAULT_EXCERPT_LINES = 12;
+const MAX_SNIPPET_CHARS = 320;
+const MAX_EXCERPT_CHARS = 2000;
+
+interface CodedError extends Error {
+  code: string;
+  status: number;
+}
+
+interface AssetDoc {
+  _id: unknown;
+  title?: string;
+  type?: string;
+  tags?: string[];
+  content?: string;
+  score?: number;
+  sourceType?: string | null;
+  sourceRef?: Record<string, unknown>;
+  createdAt?: unknown;
+  updatedAt?: unknown;
+}
+
+interface SearchOptions {
+  podId: string;
+  userId: string;
+  agentContext?: unknown;
+  query: string;
+  limit?: number;
+  includeSkills?: boolean;
+  types?: string[];
+}
+
+interface SearchResult {
+  assetId: string;
+  title?: string;
+  type?: string;
+  tags: string[];
+  score: number;
+  snippet: string;
+  sourceType: string | null;
+  sourceRef: Record<string, unknown>;
+  createdAt: unknown;
+  updatedAt: unknown;
+}
+
+interface SearchResponse {
+  query: string;
+  usedTextSearch: boolean;
+  results: SearchResult[];
+}
+
+interface ExcerptOptions {
+  podId: string;
+  userId: string;
+  agentContext?: unknown;
+  assetId: string;
+  from?: number;
+  lines?: number;
+}
+
+interface ExcerptResult {
+  assetId: string;
+  title?: string;
+  type?: string;
+  tags: string[];
+  sourceType: string | null;
+  sourceRef: Record<string, unknown>;
+  createdAt: unknown;
+  updatedAt: unknown;
+  text: string;
+  startLine: number;
+  endLine: number;
+  totalLines: number;
+}
+
+interface SnippetOptions {
+  content: string;
+  query: string;
+  maxChars?: number;
+}
+
+interface ExcerptParts {
+  text: string;
+  startLine: number;
+  endLine: number;
+  totalLines: number;
+}
+
+function buildError(code: string, message: string, status: number): CodedError {
+  const error = new Error(message) as CodedError;
+  error.code = code;
+  error.status = status;
+  return error;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function escapeRegex(input: string): string {
+  return String(input || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeText(value: string): string {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function buildSnippet({ content, query, maxChars = MAX_SNIPPET_CHARS }: SnippetOptions): string {
+  const normalized = normalizeText(content);
+  if (!normalized) return '';
+  const needle = String(query || '').trim().toLowerCase();
+  if (!needle) return normalized.slice(0, maxChars);
+  const haystack = normalized.toLowerCase();
+  const index = haystack.indexOf(needle);
+  if (index === -1) {
+    return normalized.slice(0, maxChars);
+  }
+  const half = Math.floor(maxChars / 2);
+  const start = Math.max(0, index - half);
+  const end = Math.min(normalized.length, start + maxChars);
+  let snippet = normalized.slice(start, end).trim();
+  if (start > 0) snippet = `…${snippet}`;
+  if (end < normalized.length) snippet = `${snippet}…`;
+  return snippet;
+}
+
+function buildExcerpt(content: string, from: number, lines: number): ExcerptParts {
+  const text = String(content || '');
+  if (!text) {
+    return {
+      text: '',
+      startLine: 0,
+      endLine: 0,
+      totalLines: 0,
+    };
+  }
+  const rows = text.split(/\r?\n/);
+  const totalLines = rows.length;
+  const safeFrom = clamp(from, 1, totalLines);
+  const safeLines = clamp(lines, 1, MAX_EXCERPT_LINES);
+  const startIndex = safeFrom - 1;
+  const endIndex = Math.min(totalLines, startIndex + safeLines);
+  let excerpt = rows.slice(startIndex, endIndex).join('\n');
+  if (excerpt.length > MAX_EXCERPT_CHARS) {
+    excerpt = `${excerpt.slice(0, MAX_EXCERPT_CHARS - 1)}…`;
+  }
+  return {
+    text: excerpt,
+    startLine: safeFrom,
+    endLine: endIndex,
+    totalLines,
+  };
+}
+
+function computeFallbackScore(asset: AssetDoc, tokens: string[]): number {
+  if (!tokens.length) return 0;
+  const title = String(asset.title || '').toLowerCase();
+  const content = String(asset.content || '').toLowerCase();
+  const tags = (asset.tags || []).map((tag) => String(tag).toLowerCase());
+  let score = 0;
+  tokens.forEach((token) => {
+    if (tags.includes(token)) score += 4;
+    if (title.includes(token)) score += 3;
+    if (content.includes(token)) score += 1;
+  });
+  return score;
+}
+
+class PodMemorySearchService {
+  static async searchPodMemory({
+    podId,
+    userId,
+    agentContext = null,
+    query,
+    limit = DEFAULT_LIMIT,
+    includeSkills = false,
+    types = [],
+  }: SearchOptions): Promise<SearchResponse> {
+    await PodContextService.loadPodForMember({ podId, userId });
+
+    const cleanedQuery = String(query || '').trim();
+    if (!cleanedQuery) {
+      throw buildError('QUERY_REQUIRED', 'Query is required', 400);
+    }
+
+    const safeLimit = clamp(Number(limit) || DEFAULT_LIMIT, 1, MAX_LIMIT);
+    const filter = PodAssetService.applyVisibilityFilter(
+      {
+        podId,
+        status: 'active',
+      },
+      PodAssetService.buildAgentScopeFilter(agentContext),
+    );
+
+    if (Array.isArray(types) && types.length) {
+      filter.type = { $in: types };
+    } else if (!includeSkills) {
+      filter.type = { $ne: 'skill' };
+    }
+
+    let assets: AssetDoc[] = [];
+    let usedTextSearch = true;
+
+    try {
+      assets = await PodAsset.find(
+        { ...filter, $text: { $search: cleanedQuery } },
+        { score: { $meta: 'textScore' } },
+      )
+        .sort({ score: { $meta: 'textScore' }, updatedAt: -1 })
+        .limit(safeLimit)
+        .lean();
+    } catch {
+      usedTextSearch = false;
+    }
+
+    if (!usedTextSearch) {
+      const tokens: string[] = PodAssetService.extractKeywords(cleanedQuery, { limit: 8 });
+      const pattern = tokens.length
+        ? tokens.map(escapeRegex).join('|')
+        : escapeRegex(cleanedQuery);
+      const regex = new RegExp(pattern, 'i');
+      assets = await PodAsset.find({
+        ...filter,
+        $or: [
+          { title: regex },
+          { content: regex },
+          { tags: regex },
+        ],
+      })
+        .sort({ updatedAt: -1 })
+        .limit(safeLimit)
+        .lean();
+      assets = assets.map((asset: AssetDoc) => ({
+        ...asset,
+        score: computeFallbackScore(asset, tokens),
+      }))
+        .sort((a: AssetDoc, b: AssetDoc) => {
+          if ((b.score || 0) !== (a.score || 0)) {
+            return (b.score || 0) - (a.score || 0);
+          }
+          return new Date(b.updatedAt as string || 0).getTime() - new Date(a.updatedAt as string || 0).getTime();
+        })
+        .slice(0, safeLimit);
+    }
+
+    const results: SearchResult[] = assets.map((asset) => ({
+      assetId: (asset._id as { toString?: () => string })?.toString?.() || String(asset._id),
+      title: asset.title,
+      type: asset.type,
+      tags: asset.tags || [],
+      score: Number(asset.score || 0),
+      snippet: buildSnippet({ content: asset.content || asset.title || '', query: cleanedQuery }),
+      sourceType: asset.sourceType || null,
+      sourceRef: asset.sourceRef || {},
+      createdAt: asset.createdAt || null,
+      updatedAt: asset.updatedAt || null,
+    }));
+
+    return {
+      query: cleanedQuery,
+      usedTextSearch,
+      results,
+    };
+  }
+
+  static async getAssetExcerpt({
+    podId,
+    userId,
+    agentContext = null,
+    assetId,
+    from = 1,
+    lines = DEFAULT_EXCERPT_LINES,
+  }: ExcerptOptions): Promise<ExcerptResult> {
+    await PodContextService.loadPodForMember({ podId, userId });
+
+    const assetQuery = PodAssetService.applyVisibilityFilter(
+      {
+        _id: assetId,
+        podId,
+        status: 'active',
+      },
+      PodAssetService.buildAgentScopeFilter(agentContext),
+    );
+    const asset: AssetDoc | null = await PodAsset.findOne(assetQuery).lean();
+
+    if (!asset) {
+      throw buildError('ASSET_NOT_FOUND', 'Asset not found', 404);
+    }
+
+    const excerpt = buildExcerpt(asset.content || '', Number(from) || 1, Number(lines) || DEFAULT_EXCERPT_LINES);
+
+    return {
+      assetId: (asset._id as { toString?: () => string })?.toString?.() || String(asset._id),
+      title: asset.title,
+      type: asset.type,
+      tags: asset.tags || [],
+      sourceType: asset.sourceType || null,
+      sourceRef: asset.sourceRef || {},
+      createdAt: asset.createdAt || null,
+      updatedAt: asset.updatedAt || null,
+      ...excerpt,
+    };
+  }
+}
+
+export default PodMemorySearchService;

--- a/backend/services/slackApi.ts
+++ b/backend/services/slackApi.ts
@@ -1,0 +1,55 @@
+import axios, { AxiosInstance } from 'axios';
+
+interface PostMessageResponse {
+  ok: boolean;
+  ts?: string;
+  error?: string;
+  [key: string]: unknown;
+}
+
+interface HistoryResponse {
+  ok: boolean;
+  messages?: unknown[];
+  error?: string;
+  [key: string]: unknown;
+}
+
+interface HistoryParams {
+  channel: string;
+  limit: number;
+  oldest?: string;
+  latest?: string;
+}
+
+class SlackApi {
+  private client: AxiosInstance;
+
+  constructor(botToken: string) {
+    this.client = axios.create({
+      baseURL: 'https://slack.com/api',
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  async postMessage(channel: string, text: string, blocks?: unknown): Promise<PostMessageResponse> {
+    const res = await this.client.post<PostMessageResponse>('/chat.postMessage', {
+      channel,
+      text,
+      blocks,
+    });
+    return res.data;
+  }
+
+  async history(channel: string, oldest?: string, latest?: string, limit = 200): Promise<HistoryResponse> {
+    const params: HistoryParams = { channel, limit };
+    if (oldest) params.oldest = oldest;
+    if (latest) params.latest = latest;
+    const res = await this.client.get<HistoryResponse>('/conversations.history', { params });
+    return res.data;
+  }
+}
+
+export = SlackApi;

--- a/backend/services/telegramService.ts
+++ b/backend/services/telegramService.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+
+interface SendResult {
+  success: boolean;
+  error?: string;
+}
+
+async function sendMessage(botToken: string, chatId: string | number, text: string): Promise<SendResult> {
+  if (!botToken || !chatId || !text) {
+    return { success: false, error: 'Missing botToken, chatId, or text' };
+  }
+
+  try {
+    const response = await axios.post<{ ok: boolean }>(
+      `https://api.telegram.org/bot${botToken}/sendMessage`,
+      {
+        chat_id: chatId,
+        text,
+        parse_mode: 'HTML',
+        disable_web_page_preview: true,
+      },
+    );
+
+    return { success: response.data?.ok === true };
+  } catch (error) {
+    const err = error as { response?: { data: unknown }; message: string };
+    console.error(
+      'Error sending Telegram message:',
+      err.response?.data || err.message,
+    );
+    return { success: false, error: err.message };
+  }
+}
+
+export { sendMessage };


### PR DESCRIPTION
## Summary

- `slackApi.ts` — Slack Web API client with typed request/response shapes
- `telegramService.ts` — Telegram Bot API sendMessage helper typed
- `groupmeService.ts` — GroupMe bot send + message fetch with full types
- `integrationSummaryService.ts` — Multi-source integration summary builder typed
- `podMemorySearchService.ts` — Full-text + fallback regex pod memory search typed

Part of issue #118 (TypeScript migration). JS originals untouched; TS files are drop-in companions.

## Test plan
- [ ] `Test & Coverage` passes (tsc + jest)
- [ ] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)