### PR TITLE
feat(ts): migrate 3 core services to TypeScript (batch 6)

### DIFF
--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -1,0 +1,471 @@
+// eslint-disable-next-line global-require
+const AgentEventService = require('./agentEventService');
+// eslint-disable-next-line global-require
+const { AgentInstallation } = require('../models/AgentRegistry');
+// eslint-disable-next-line global-require
+const AgentProfile = require('../models/AgentProfile');
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
+// eslint-disable-next-line global-require
+const User = require('../models/User');
+// eslint-disable-next-line global-require
+const chatSummarizerService = require('./chatSummarizerService');
+
+const ChatSummarizerService = chatSummarizerService.constructor as {
+  getLatestPodSummary: (podId: string) => Promise<unknown>;
+};
+
+interface MentionTarget {
+  agentName: string;
+  instanceId: string;
+}
+
+interface MentionMapEntry {
+  agentName: string;
+  instanceId: string;
+  displayName: string;
+  displaySlug: string;
+}
+
+interface EnqueueMentionsOptions {
+  podId: string;
+  message: {
+    content?: string;
+    text?: string;
+    source?: string;
+    _id?: unknown;
+    id?: unknown;
+    messageType?: string;
+    message_type?: string;
+    createdAt?: unknown;
+    created_at?: unknown;
+    thread?: unknown;
+  };
+  userId: string;
+  username: string;
+}
+
+interface EnqueueDmOptions {
+  podId: string;
+  message: EnqueueMentionsOptions['message'];
+  userId: string;
+  username: string;
+}
+
+interface EnqueueResult {
+  enqueued: string[];
+  skipped: string[];
+}
+
+interface EnqueueDmResult {
+  enqueued: string[] | boolean;
+  skipped?: string[];
+  reason?: string;
+}
+
+interface SummaryPayload {
+  content: unknown;
+  title: unknown;
+  source: string;
+  sourceLabel: string;
+  channelName: string;
+  channelUrl: null;
+  messageCount: number;
+  timeRange: unknown;
+  summaryType: string;
+}
+
+interface SummaryEnqueueOptions {
+  podId: string;
+  instanceId: string;
+  summary: Record<string, unknown> | null;
+  pod: Record<string, unknown> | null;
+}
+
+/**
+ * Mention Aliases
+ *
+ * Maps @mention aliases to agent types
+ * agentType = the runtime type (openclaw, commonly-bot, etc.)
+ */
+const MENTION_ALIASES: Record<string, string[]> = {};
+
+const buildAliasMap = (): Map<string, string> => {
+  const aliasMap = new Map<string, string>();
+  Object.entries(MENTION_ALIASES).forEach(([agentType, aliases]) => {
+    aliases.forEach((alias) => {
+      aliasMap.set(alias.toLowerCase(), agentType);
+    });
+  });
+  return aliasMap;
+};
+
+const aliasMap = buildAliasMap();
+
+const extractMentions = (content = ''): string[] => {
+  if (!content || typeof content !== 'string') return [];
+  const mentions = new Set<string>();
+  const regex = /@([a-z0-9-]{2,})/gi;
+  let match;
+  // eslint-disable-next-line no-cond-assign
+  while ((match = regex.exec(content)) !== null) {
+    const raw = match[1]?.toLowerCase();
+    if (!raw) continue;
+    mentions.add(raw);
+  }
+  return Array.from(mentions);
+};
+
+const slugify = (value = ''): string => value
+  .toString()
+  .trim()
+  .toLowerCase()
+  .replace(/[^a-z0-9-]/g, '-')
+  .replace(/-+/g, '-')
+  .replace(/^-+|-+$/g, '');
+
+const buildMentionMap = (
+  installations: Array<Record<string, unknown>> = [],
+  profiles: Array<Record<string, unknown>> = [],
+): { map: Map<string, MentionTarget>; byAgent: Map<string, MentionMapEntry[]> } => {
+  const map = new Map<string, MentionTarget>();
+  const byAgent = new Map<string, MentionMapEntry[]>();
+
+  installations.forEach((installation) => {
+    const agentName = installation.agentName as string;
+    const instanceId = (installation.instanceId as string) || 'default';
+    const profile = profiles.find(
+      (p) => p.agentName === agentName && p.instanceId === instanceId,
+    );
+    const displayName = (installation.displayName as string) || (profile?.name as string) || agentName;
+    const displaySlug = slugify(displayName);
+
+    const list = byAgent.get(agentName) || [];
+    list.push({
+      agentName, instanceId, displayName, displaySlug,
+    });
+    byAgent.set(agentName, list);
+
+    // Always allow explicit instance references
+    map.set(`${agentName}-${instanceId}`.toLowerCase(), { agentName, instanceId });
+    map.set(instanceId.toLowerCase(), { agentName, instanceId });
+    if (displaySlug) {
+      map.set(displaySlug, { agentName, instanceId });
+    }
+  });
+
+  // Only allow bare agentName if there's a single installation in the pod
+  byAgent.forEach((list, agentName) => {
+    if (list.length === 1) {
+      map.set(agentName.toLowerCase(), { agentName, instanceId: list[0].instanceId });
+      const aliases = MENTION_ALIASES[agentName] || [];
+      aliases.forEach((alias) => {
+        map.set(alias.toLowerCase(), { agentName, instanceId: list[0].instanceId });
+      });
+    }
+  });
+
+  return { map, byAgent };
+};
+
+const buildSummaryPayload = (
+  summary: Record<string, unknown> | null,
+  pod: Record<string, unknown> | null,
+): SummaryPayload | null => {
+  if (!summary) return null;
+  const metadata = summary.metadata as Record<string, unknown> | undefined;
+  return {
+    content: summary.content,
+    title: summary.title,
+    source: 'chat',
+    sourceLabel: 'Commonly',
+    channelName: (metadata?.podName as string) || (pod?.name as string) || 'pod',
+    channelUrl: null,
+    messageCount: (metadata?.totalItems as number) || 0,
+    timeRange: summary.timeRange || null,
+    summaryType: (summary.type as string) || 'chats',
+  };
+};
+
+const enqueueSummarizerEvent = async ({
+  podId,
+  instanceId,
+  summary,
+  pod,
+}: SummaryEnqueueOptions): Promise<void> => {
+  const payload = buildSummaryPayload(summary, pod);
+  if (!payload) return;
+  await AgentEventService.enqueue({
+    agentName: 'commonly-bot',
+    instanceId,
+    podId,
+    type: 'summary.request',
+    payload: { summary: payload, source: 'chat' },
+  });
+};
+
+const enqueueMentions = async ({
+  podId,
+  message,
+  userId,
+  username,
+}: EnqueueMentionsOptions): Promise<EnqueueResult> => {
+  const content = message?.content || message?.text || '';
+  const source = message?.source || 'chat';
+  const eventType = source === 'thread' ? 'thread.mention' : 'chat.mention';
+  const rawMentions = extractMentions(content);
+  if (!podId || rawMentions.length === 0) {
+    return { enqueued: [], skipped: [] };
+  }
+
+  const enqueued: string[] = [];
+  const skipped: string[] = [];
+
+  let installations: Array<Record<string, unknown>> = [];
+  let profiles: Array<Record<string, unknown>> = [];
+  try {
+    installations = await AgentInstallation.find({
+      podId,
+      status: 'active',
+    }).lean();
+    profiles = await AgentProfile.find({ podId }).lean();
+  } catch (error) {
+    console.warn('Agent mention lookup failed:', (error as Error).message);
+  }
+
+  const { map: mentionMap, byAgent } = buildMentionMap(installations, profiles);
+  let pod: Record<string, unknown> | null = null;
+
+  await Promise.all(
+    rawMentions.map(async (raw) => {
+      const normalized = raw.toLowerCase();
+      const directMatch = mentionMap.get(normalized);
+      if (directMatch) {
+        try {
+          if (directMatch.agentName === 'commonly-bot') {
+            pod = pod || await Pod.findById(podId).lean();
+            let summary = await ChatSummarizerService.getLatestPodSummary(podId);
+            if (!summary) {
+              summary = await chatSummarizerService.summarizePodMessages(podId);
+            }
+            await enqueueSummarizerEvent({
+              podId,
+              instanceId: directMatch.instanceId || 'default',
+              summary: summary as Record<string, unknown> | null,
+              pod: pod as Record<string, unknown> | null,
+            });
+            enqueued.push(directMatch.agentName);
+            return;
+          }
+          await AgentEventService.enqueue({
+            agentName: directMatch.agentName,
+            instanceId: directMatch.instanceId || 'default',
+            podId,
+            type: eventType,
+            payload: {
+              messageId: message?._id || message?.id
+                ? String(message?._id || message?.id)
+                : undefined,
+              content,
+              userId,
+              username,
+              mentions: rawMentions,
+              source,
+              messageType: message?.messageType || message?.message_type || 'text',
+              createdAt: message?.createdAt || message?.created_at || new Date(),
+              thread: message?.thread || null,
+            },
+          });
+          enqueued.push(directMatch.agentName);
+        } catch (error) {
+          console.warn('Failed to enqueue agent mention:', (error as Error).message);
+        }
+        return;
+      }
+
+      const agentType = aliasMap.get(normalized);
+      if (agentType) {
+        const matches = byAgent.get(agentType) || [];
+        if (matches.length === 0) {
+          skipped.push(agentType);
+          return;
+        }
+        await Promise.all(
+          matches.map(async (match) => {
+            try {
+              if (agentType === 'commonly-bot') {
+                pod = pod || await Pod.findById(podId).lean();
+                let summary = await ChatSummarizerService.getLatestPodSummary(podId);
+                if (!summary) {
+                  summary = await chatSummarizerService.summarizePodMessages(podId);
+                }
+                await enqueueSummarizerEvent({
+                  podId,
+                  instanceId: match.instanceId || 'default',
+                  summary: summary as Record<string, unknown> | null,
+                  pod: pod as Record<string, unknown> | null,
+                });
+                enqueued.push(agentType);
+                return;
+              }
+              await AgentEventService.enqueue({
+                agentName: agentType,
+                instanceId: match.instanceId || 'default',
+                podId,
+                type: eventType,
+                payload: {
+                  messageId: message?._id || message?.id
+                    ? String(message?._id || message?.id)
+                    : undefined,
+                  content,
+                  userId,
+                  username,
+                  mentions: rawMentions,
+                  source,
+                  messageType: message?.messageType || message?.message_type || 'text',
+                  createdAt: message?.createdAt || message?.created_at || new Date(),
+                  thread: message?.thread || null,
+                },
+              });
+              enqueued.push(agentType);
+            } catch (error) {
+              console.warn('Failed to enqueue agent mention:', (error as Error).message);
+            }
+          }),
+        );
+        return;
+      }
+
+      skipped.push(raw);
+    }),
+  );
+
+  return { enqueued, skipped };
+};
+
+/**
+ * Auto-enqueue a DM-origin chat.mention event for every user message in an
+ * agent-admin pod. Unlike regular mentions, no explicit @mention is required
+ * because this is already a 1:1 human <-> agent channel.
+ */
+const enqueueDmEvent = async ({
+  podId, message, userId, username,
+}: EnqueueDmOptions): Promise<EnqueueDmResult> => {
+  const pod = await Pod.findById(podId).lean() as Record<string, unknown> | null;
+  if (!pod || pod.type !== 'agent-admin') {
+    return { enqueued: false, reason: 'not_dm_pod' };
+  }
+
+  const sender = await User.findById(userId).select('_id isBot').lean() as { _id: unknown; isBot?: boolean } | null;
+  if (sender?.isBot) {
+    return { enqueued: false, reason: 'sender_is_bot' };
+  }
+
+  const senderIdStr = String(userId);
+  const otherMemberIds = ((pod.members as unknown[]) || [])
+    .map((m: unknown) => {
+      const mem = m as { _id?: unknown } | string;
+      return String(typeof mem === 'object' && mem !== null ? mem._id || mem : mem);
+    })
+    .filter((id) => id !== senderIdStr);
+
+  if (otherMemberIds.length === 0) {
+    return { enqueued: false, reason: 'no_other_member' };
+  }
+
+  const agentMembers = await User.find({
+    _id: { $in: otherMemberIds },
+    isBot: true,
+  }).select('_id username botMetadata').lean() as Array<{
+    _id: unknown;
+    username: string;
+    botMetadata?: { agentName?: string; instanceId?: string };
+  }>;
+
+  if (agentMembers.length === 0) {
+    return { enqueued: false, reason: 'no_agent_user' };
+  }
+
+  const content = message?.content || message?.text || '';
+  const enqueued: string[] = [];
+
+  for (const agentUser of agentMembers) {
+    const agentName = agentUser.botMetadata?.agentName || agentUser.username;
+    const instanceId = agentUser.botMetadata?.instanceId || 'default';
+    const mentionHandle = `@${instanceId}`;
+
+    const installations = await AgentInstallation.find({
+      agentName: agentName.toLowerCase(),
+      instanceId,
+      status: 'active',
+    })
+      .select('podId installedBy')
+      .lean() as Array<{ podId: unknown; installedBy: unknown }>;
+
+    if (!Array.isArray(installations) || installations.length === 0) continue;
+
+    const senderScopedPodIds = new Set<string>(
+      installations
+        .filter((entry) => String(entry?.installedBy || '') === senderIdStr)
+        .map((entry) => String(entry?.podId || ''))
+        .filter(Boolean),
+    );
+
+    const memberPodCandidates = installations
+      .map((entry) => entry?.podId)
+      .filter(Boolean);
+    if (memberPodCandidates.length > 0) {
+      const memberPods = await Pod.find({
+        _id: { $in: memberPodCandidates },
+        members: userId,
+      }).select('_id').lean() as Array<{ _id: unknown }>;
+      memberPods.forEach((entry) => {
+        const id = String(entry?._id || '');
+        if (id) senderScopedPodIds.add(id);
+      });
+    }
+
+    const availablePods = senderScopedPodIds.size > 0
+      ? await Pod.find({ _id: { $in: Array.from(senderScopedPodIds) } })
+        .select('_id name type')
+        .lean() as Array<{ _id: unknown; name?: string; type?: string }>
+      : [];
+    const installationPodId = (installations[0]?.podId as { toString?: () => string })?.toString?.() || null;
+
+    await AgentEventService.enqueue({
+      agentName: agentName.toLowerCase(),
+      instanceId,
+      podId,
+      type: 'chat.mention',
+      payload: {
+        messageId: message?._id || message?.id
+          ? String(message?._id || message?.id)
+          : undefined,
+        content,
+        userId,
+        username,
+        mentions: [mentionHandle],
+        source: 'dm',
+        messageType: message?.messageType || message?.message_type || 'text',
+        createdAt: message?.createdAt || message?.created_at || new Date(),
+        dmPodId: String(podId),
+        installationPodId,
+        availablePods: (availablePods || []).map((entry) => ({
+          podId: String(entry?._id || ''),
+          name: entry?.name || null,
+          type: entry?.type || null,
+        })),
+      },
+    });
+    enqueued.push(agentName);
+  }
+
+  return { enqueued, skipped: [] };
+};
+
+export {
+  extractMentions,
+  enqueueMentions,
+  enqueueDmEvent,
+  MENTION_ALIASES,
+};

--- a/backend/services/podContextService.ts
+++ b/backend/services/podContextService.ts
@@ -1,0 +1,566 @@
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
+// eslint-disable-next-line global-require
+const Summary = require('../models/Summary');
+// eslint-disable-next-line global-require
+const PodAsset = require('../models/PodAsset');
+// eslint-disable-next-line global-require
+const PodAssetService = require('./podAssetService');
+// eslint-disable-next-line global-require
+const PodSkillService = require('./podSkillService');
+
+const CHARS_PER_TOKEN = 3; // Conservative estimate for JSON/markdown content
+
+const GENERIC_TAGS = new Set([
+  'active', 'activity', 'bot', 'channel', 'chat', 'commonly-bot',
+  'commonly-ai-agent', 'discussion', 'during', 'everyone', 'exchanged',
+  'general', 'hour', 'integration', 'last', 'member', 'members', 'message',
+  'messages', 'moment', 'pod', 'quiet', 'room', 'summary', 'system', 'thread', 'window',
+]);
+
+const ASSET_TYPE_WEIGHTS: Record<string, number> = {
+  'integration-summary': 1.35,
+  summary: 1.2,
+  message: 1.0,
+  thread: 1.1,
+  file: 1.15,
+  doc: 1.25,
+  link: 1.05,
+};
+
+interface CodedError extends Error {
+  code: string;
+  status: number;
+}
+
+interface AssetDoc {
+  _id: unknown;
+  title?: string;
+  type?: string;
+  tags?: string[];
+  content?: string;
+  createdAt?: unknown;
+  updatedAt?: unknown;
+  relevanceScore?: number;
+  metadata?: Record<string, unknown>;
+  sourceType?: string;
+  sourceRef?: unknown;
+  score?: number;
+}
+
+interface SummaryDoc extends AssetDoc {
+  timeRange?: unknown;
+}
+
+interface SummaryWithTags extends SummaryDoc {
+  tags: string[];
+}
+
+interface TagEntry {
+  tag: string;
+  count: number;
+}
+
+interface SkillCandidate {
+  id: string;
+  name: string;
+  tags: string[];
+  score: number;
+  frequency: number;
+  latestAt: unknown;
+  assetIds: string[];
+  summaryIds: string[];
+  preview: Array<{
+    id: string;
+    title: string;
+    type: string;
+    createdAt: unknown;
+  }>;
+}
+
+interface LoadPodOptions {
+  podId: string;
+  userId: string;
+}
+
+interface GetPodContextOptions {
+  podId: string;
+  userId: string;
+  agentContext?: unknown;
+  task?: string;
+  summaryLimit?: number;
+  assetLimit?: number;
+  tagLimit?: number;
+  skillLimit?: number;
+  skillMode?: string;
+  skillRefreshHours?: number;
+  maxContextTokens?: number;
+}
+
+interface PodDescriptor {
+  id: string;
+  name: string;
+  description: string;
+  type: string;
+}
+
+function buildError(code: string, message: string, status: number): CodedError {
+  const error = new Error(message) as CodedError;
+  error.code = code;
+  error.status = status;
+  return error;
+}
+
+function toObjectIdString(value: unknown): string {
+  if (!value) return '';
+  if (typeof value === 'string') return value;
+  if (typeof (value as { toString: unknown }).toString === 'function') {
+    return (value as { toString: () => string }).toString();
+  }
+  return String(value);
+}
+
+function ensureMembership(pod: { members?: unknown[] }, userId: unknown): boolean {
+  const memberIds = (pod.members || []).map((member) => toObjectIdString(member));
+  return memberIds.includes(toObjectIdString(userId));
+}
+
+function rankByTask<T extends AssetDoc>(
+  items: T[],
+  taskTokens: Set<string>,
+  getTags: (item: T) => string[],
+): T[] {
+  if (!taskTokens.size) return items;
+
+  const scored = items.map((item) => {
+    const tags = (getTags(item) || []).map((tag) => String(tag).toLowerCase());
+    const matchCount = tags.reduce(
+      (count, tag) => (taskTokens.has(tag) ? count + 1 : count),
+      0,
+    );
+    return {
+      ...item,
+      relevanceScore: matchCount,
+    };
+  });
+
+  return scored.sort((a, b) => {
+    if ((b.relevanceScore || 0) !== (a.relevanceScore || 0)) {
+      return (b.relevanceScore || 0) - (a.relevanceScore || 0);
+    }
+    return new Date(b.createdAt as string || 0).getTime() - new Date(a.createdAt as string || 0).getTime();
+  });
+}
+
+function addTagCounts(tagCounts: Map<string, number>, tags: string[]): void {
+  (tags || []).forEach((tag) => {
+    const normalized = String(tag).trim().toLowerCase();
+    if (!normalized) return;
+    tagCounts.set(normalized, (tagCounts.get(normalized) || 0) + 1);
+  });
+}
+
+function sortTagCounts(tagCounts: Map<string, number>, limit: number): TagEntry[] {
+  return [...tagCounts.entries()]
+    .sort((a, b) => {
+      if (b[1] !== a[1]) return b[1] - a[1];
+      return a[0].localeCompare(b[0]);
+    })
+    .slice(0, limit)
+    .map(([tag, count]) => ({ tag, count }));
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function isGenericTag(tag: string): boolean {
+  return GENERIC_TAGS.has(String(tag).trim().toLowerCase());
+}
+
+function daysSince(dateValue: unknown): number {
+  const date = new Date(dateValue as string | number);
+  if (Number.isNaN(date.getTime())) return Number.POSITIVE_INFINITY;
+  const diffMs = Date.now() - date.getTime();
+  return diffMs / (1000 * 60 * 60 * 24);
+}
+
+function hoursSince(dateValue: unknown): number {
+  const date = new Date(dateValue as string | number);
+  if (Number.isNaN(date.getTime())) return Number.POSITIVE_INFINITY;
+  const diffMs = Date.now() - date.getTime();
+  return diffMs / (1000 * 60 * 60);
+}
+
+function recencyBoost(latestAt: unknown): number {
+  const days = daysSince(latestAt);
+  if (days <= 1) return 3;
+  if (days <= 3) return 2;
+  if (days <= 7) return 1.5;
+  if (days <= 30) return 1;
+  return 0.5;
+}
+
+function typeWeightForEntry(entry: AssetDoc & { entryType?: string }): number {
+  if (entry.entryType === 'summary') return 1.2;
+  return ASSET_TYPE_WEIGHTS[entry.type || ''] || 1.0;
+}
+
+function buildSkillCandidates({ assets, summariesWithTags, maxSkills = 6 }: {
+  assets: AssetDoc[];
+  summariesWithTags: SummaryWithTags[];
+  maxSkills?: number;
+}): SkillCandidate[] {
+  type EntryWithType = AssetDoc & { entryType: string };
+  const entries: EntryWithType[] = [
+    ...assets.map((asset) => ({ ...asset, entryType: 'asset' as const })),
+    ...summariesWithTags.map((summary) => ({ ...summary, entryType: 'summary' as const })),
+  ];
+
+  interface TagRecord {
+    tag: string;
+    count: number;
+    latestAt: unknown;
+    assetIds: Set<string>;
+    summaryIds: Set<string>;
+    typeWeights: number[];
+    entries: Array<{ id: unknown; title?: string; createdAt?: unknown; entryType: string; type?: string }>;
+  }
+
+  const tagMap = new Map<string, TagRecord>();
+
+  entries.forEach((entry) => {
+    const tags = (entry.tags || [])
+      .map((tag) => String(tag).trim().toLowerCase())
+      .filter((tag) => tag.length >= 3 && !isGenericTag(tag));
+
+    const weight = typeWeightForEntry(entry);
+
+    tags.forEach((tag) => {
+      if (!tagMap.has(tag)) {
+        tagMap.set(tag, {
+          tag,
+          count: 0,
+          latestAt: entry.createdAt || entry.updatedAt || new Date(),
+          assetIds: new Set<string>(),
+          summaryIds: new Set<string>(),
+          typeWeights: [],
+          entries: [],
+        });
+      }
+
+      const record = tagMap.get(tag)!;
+      record.count += 1;
+      record.latestAt = new Date(record.latestAt as string) > new Date(entry.createdAt as string || 0)
+        ? record.latestAt
+        : (entry.createdAt || record.latestAt);
+      record.typeWeights.push(weight);
+      record.entries.push({
+        id: entry._id,
+        title: entry.title,
+        createdAt: entry.createdAt,
+        entryType: entry.entryType,
+        type: entry.type,
+      });
+
+      if (entry.entryType === 'asset') {
+        record.assetIds.add(toObjectIdString(entry._id));
+      } else {
+        record.summaryIds.add(toObjectIdString(entry._id));
+      }
+    });
+  });
+
+  const skills = [...tagMap.values()]
+    .map((record): SkillCandidate => {
+      const avgTypeWeight = record.typeWeights.length
+        ? record.typeWeights.reduce((sum, value) => sum + value, 0) / record.typeWeights.length
+        : 1;
+      const score = (record.count * 2) + recencyBoost(record.latestAt) + avgTypeWeight;
+      const preview = [...record.entries]
+        .sort((a, b) => new Date(b.createdAt as string || 0).getTime() - new Date(a.createdAt as string || 0).getTime())
+        .slice(0, 3)
+        .map((entry) => ({
+          id: toObjectIdString(entry.id),
+          title: (entry.title as string) || (entry.type as string) || 'Untitled',
+          type: entry.entryType === 'summary' ? 'summary' : (entry.type || 'asset'),
+          createdAt: entry.createdAt || null,
+        }));
+
+      return {
+        id: `skill:${record.tag}`,
+        name: record.tag,
+        tags: [record.tag],
+        score: Number(score.toFixed(2)),
+        frequency: record.count,
+        latestAt: record.latestAt,
+        assetIds: [...record.assetIds].slice(0, 8),
+        summaryIds: [...record.summaryIds].slice(0, 8),
+        preview,
+      };
+    })
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      return new Date(b.latestAt as string || 0).getTime() - new Date(a.latestAt as string || 0).getTime();
+    })
+    .slice(0, maxSkills);
+
+  return skills;
+}
+
+class PodContextService {
+  static async loadPodForMember({ podId, userId }: LoadPodOptions): Promise<Record<string, unknown>> {
+    const pod = await Pod.findById(podId)
+      .select('_id name description type members createdAt updatedAt')
+      .lean() as Record<string, unknown> | null;
+
+    if (!pod) {
+      throw buildError('POD_NOT_FOUND', 'Pod not found', 404);
+    }
+
+    if (!ensureMembership(pod as { members?: unknown[] }, userId)) {
+      throw buildError('NOT_A_MEMBER', 'Not authorized for this pod', 403);
+    }
+
+    return pod;
+  }
+
+  static buildTaskTokens(task: string | null): Set<string> {
+    if (!task) return new Set();
+    const tokens: string[] = PodAssetService.extractKeywords(task, { limit: 12 });
+    return new Set(tokens.map((token: string) => token.toLowerCase()));
+  }
+
+  static estimateTokens(text: string | null | undefined): number {
+    if (!text) return 0;
+    return Math.ceil(String(text).length / CHARS_PER_TOKEN);
+  }
+
+  static truncateToTokenBudget<T>(
+    items: T[],
+    budget: number,
+    getContent: (item: T) => string,
+  ): T[] {
+    if (!budget || budget <= 0) return items;
+    let used = 0;
+    const result: T[] = [];
+    for (const item of items) {
+      const tokens = PodContextService.estimateTokens(getContent(item));
+      if (used + tokens > budget && result.length > 0) break;
+      result.push(item);
+      used += tokens;
+    }
+    return result;
+  }
+
+  static async getPodContext({
+    podId,
+    userId,
+    agentContext = null,
+    task = '',
+    summaryLimit = 6,
+    assetLimit = 12,
+    tagLimit = 16,
+    skillLimit = 6,
+    skillMode = 'llm',
+    skillRefreshHours = 6,
+    maxContextTokens = 0,
+  }: GetPodContextOptions): Promise<Record<string, unknown>> {
+    const pod = await PodContextService.loadPodForMember({ podId, userId });
+
+    const podDescriptor: PodDescriptor = {
+      id: toObjectIdString(pod._id),
+      name: pod.name as string,
+      description: (pod.description as string) || '',
+      type: pod.type as string,
+    };
+
+    const visibilityFilter = PodAssetService.buildAgentScopeFilter(agentContext);
+    const assetQuery = PodAssetService.applyVisibilityFilter(
+      { podId, status: 'active', type: { $ne: 'skill' } },
+      visibilityFilter,
+    );
+
+    const [summaries, assets] = await Promise.all([
+      Summary.find({ podId, type: 'chats' })
+        .sort({ createdAt: -1 })
+        .limit(summaryLimit)
+        .lean() as Promise<SummaryDoc[]>,
+      PodAsset.find(assetQuery)
+        .sort({ createdAt: -1 })
+        .limit(assetLimit)
+        .lean() as Promise<AssetDoc[]>,
+    ]);
+
+    const taskTokens = PodContextService.buildTaskTokens(task);
+    const tagCounts = new Map<string, number>();
+
+    const summariesWithTags: SummaryWithTags[] = summaries.map((summary) => {
+      const tags: string[] = PodAssetService.buildSummaryTags(summary);
+      addTagCounts(tagCounts, tags);
+      return {
+        ...summary,
+        tags,
+      };
+    });
+
+    assets.forEach((asset) => addTagCounts(tagCounts, asset.tags || []));
+
+    const rankedAssets = rankByTask(assets, taskTokens, (item) => item.tags || []);
+    const rankedSummaries = rankByTask(
+      summariesWithTags,
+      taskTokens,
+      (item) => item.tags || [],
+    );
+
+    const tags = sortTagCounts(tagCounts, tagLimit);
+    const normalizedSkillMode = ['llm', 'heuristic', 'none'].includes(skillMode)
+      ? skillMode
+      : 'llm';
+    let skillModeUsed = normalizedSkillMode;
+    const skillWarnings: string[] = [];
+
+    const refreshHours = clamp(Number(skillRefreshHours) || 6, 1, 72);
+    const latestSkillQuery = PodAssetService.applyVisibilityFilter(
+      { podId, type: 'skill', status: 'active' },
+      visibilityFilter,
+    );
+    const latestSkillAsset = await PodAsset.findOne(latestSkillQuery)
+      .sort({ updatedAt: -1 })
+      .select('updatedAt')
+      .lean() as { updatedAt: unknown } | null;
+    const skillAgeHours = latestSkillAsset ? hoursSince(latestSkillAsset.updatedAt) : Number.POSITIVE_INFINITY;
+
+    const shouldRefreshSkills = skillModeUsed === 'llm'
+      && PodSkillService.isAvailable()
+      && (taskTokens.size > 0 || skillAgeHours > refreshHours);
+
+    if (skillModeUsed === 'llm' && !PodSkillService.isAvailable()) {
+      skillWarnings.push('LLM skill synthesis is unavailable (missing GEMINI_API_KEY).');
+      skillModeUsed = 'none';
+    }
+
+    if (shouldRefreshSkills) {
+      const synthesisResult = await PodSkillService.synthesizeSkills({
+        pod: podDescriptor,
+        task,
+        summaries: rankedSummaries,
+        assets: rankedAssets,
+        skillLimit,
+        taskTokens,
+      });
+      skillWarnings.push(...(synthesisResult.warnings || []));
+    }
+
+    const skillAssetsQuery = PodAssetService.applyVisibilityFilter(
+      { podId, type: 'skill', status: 'active' },
+      visibilityFilter,
+    );
+    const skillAssets: AssetDoc[] = skillModeUsed === 'none'
+      ? []
+      : await PodAsset.find(skillAssetsQuery)
+        .sort({ 'metadata.score': -1, updatedAt: -1 })
+        .limit(skillLimit)
+        .lean();
+
+    const importedSkillQuery = PodAssetService.applyVisibilityFilter(
+      { podId, type: 'skill', status: 'active', sourceType: 'imported-skill' },
+      visibilityFilter,
+    );
+    const importedSkillAssets: AssetDoc[] = await PodAsset.find(importedSkillQuery)
+      .sort({ updatedAt: -1 })
+      .limit(40)
+      .lean();
+
+    const mergeSkills = (primary: AssetDoc[], secondary: AssetDoc[]): AssetDoc[] => {
+      const seen = new Set<string>();
+      const merged: AssetDoc[] = [];
+      const pushSkill = (skill: AssetDoc | null | undefined) => {
+        if (!skill) return;
+        const meta = skill.metadata as Record<string, unknown> | undefined;
+        const key = (meta?.skillKey as string) || (skill._id as { toString?: () => string })?.toString?.();
+        if (key && seen.has(key)) return;
+        if (key) seen.add(key);
+        merged.push(skill);
+      };
+      primary.forEach(pushSkill);
+      secondary.forEach(pushSkill);
+      return merged;
+    };
+
+    const synthesizedSkills: AssetDoc[] = skillModeUsed === 'heuristic'
+      ? buildSkillCandidates({
+        assets: rankedAssets,
+        summariesWithTags: rankedSummaries,
+        maxSkills: skillLimit,
+      }).map((skill) => ({
+        _id: skill.id,
+        title: `Skill: ${skill.name}`,
+        content: '',
+        tags: skill.tags || [],
+        metadata: {
+          score: skill.score,
+          frequency: skill.frequency,
+          heuristic: true,
+        },
+      }))
+      : skillAssets.map((skill) => ({
+        ...skill,
+        score: (skill.metadata?.score as number) || 0,
+        tags: skill.tags || (skill.metadata?.tags as string[]) || [],
+      }));
+
+    const skills = mergeSkills(importedSkillAssets, synthesizedSkills);
+
+    const hasActivity = summaries.length > 0 || assets.length > 0;
+
+    let finalSummaries: SummaryWithTags[] = rankedSummaries;
+    let finalAssets: AssetDoc[] = rankedAssets;
+    let finalSkills: AssetDoc[] = skills;
+    let tokenEstimate = 0;
+
+    if (maxContextTokens > 0) {
+      const summaryBudget = Math.floor(maxContextTokens * 0.4);
+      const assetBudget = Math.floor(maxContextTokens * 0.35);
+      const skillBudget = Math.floor(maxContextTokens * 0.25);
+
+      finalSummaries = PodContextService.truncateToTokenBudget(
+        rankedSummaries, summaryBudget, (s) => s.content as string || '',
+      );
+      finalAssets = PodContextService.truncateToTokenBudget(
+        rankedAssets, assetBudget, (a) => a.content || a.title || '',
+      );
+      finalSkills = PodContextService.truncateToTokenBudget(
+        skills, skillBudget, (s) => s.content || s.title || '',
+      );
+
+      tokenEstimate = [
+        ...finalSummaries.map((s) => PodContextService.estimateTokens(s.content as string || '')),
+        ...finalAssets.map((a) => PodContextService.estimateTokens(a.content || a.title || '')),
+        ...finalSkills.map((s) => PodContextService.estimateTokens(s.content || s.title || '')),
+      ].reduce((sum, t) => sum + t, 0);
+    }
+
+    return {
+      _status: 'success',
+      activityAvailable: hasActivity,
+      pod: podDescriptor,
+      task: task || null,
+      stats: {
+        summaries: finalSummaries.length,
+        assets: finalAssets.length,
+        tags: tagCounts.size,
+        skills: finalSkills.length,
+        ...(maxContextTokens > 0 ? { tokenEstimate, tokenBudget: maxContextTokens } : {}),
+      },
+      skillModeUsed,
+      skillWarnings: skillWarnings.filter((w) => !w.includes('GEMINI_API_KEY')),
+      skills: finalSkills,
+      tags,
+      summaries: finalSummaries,
+      assets: finalAssets,
+    };
+  }
+}
+
+export default PodContextService;

--- a/backend/services/podCurationService.ts
+++ b/backend/services/podCurationService.ts
@@ -1,0 +1,344 @@
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
+// eslint-disable-next-line global-require
+const Post = require('../models/Post');
+// eslint-disable-next-line global-require
+const User = require('../models/User');
+// eslint-disable-next-line global-require
+const AgentProfile = require('../models/AgentProfile');
+// eslint-disable-next-line global-require
+const { AgentRegistry, AgentInstallation } = require('../models/AgentRegistry');
+// eslint-disable-next-line global-require
+const AgentIdentityService = require('./agentIdentityService');
+// eslint-disable-next-line global-require
+const AgentEventService = require('./agentEventService');
+
+const DEFAULT_SUMMARY_AGENT = 'commonly-bot';
+const DEFAULT_SUMMARY_SCOPES = [
+  'context:read',
+  'summaries:read',
+  'messages:write',
+  'integration:read',
+  'integration:messages:read',
+  'integration:write',
+];
+
+interface ThemePreset {
+  key: string;
+  name: string;
+  description: string;
+  keywords: string[];
+}
+
+interface ThemeScore {
+  theme: ThemePreset;
+  score: number;
+  matches: Record<string, unknown>[];
+}
+
+interface PodRecord {
+  _id: unknown;
+  name?: string;
+  type?: string;
+  members?: unknown[];
+}
+
+interface RunAutonomyOptions {
+  hours?: number;
+  minMatches?: number;
+  source?: string;
+}
+
+interface AutonomyResult {
+  scannedPosts?: number;
+  createdPods: Array<{ podId: string; podName?: string; theme: string; score: number }>;
+  triggeredPods: Array<{ podId: string; podName?: string; queuedTargets: number }>;
+  themeMatches?: Array<{ theme: string; score: number }>;
+  skipped?: string;
+}
+
+const THEME_PRESETS: ThemePreset[] = [
+  {
+    key: 'ai-tech',
+    name: 'AI & Tech Radar',
+    description: 'Curated AI and technology updates from social feeds.',
+    keywords: ['ai', 'openai', 'anthropic', 'llm', 'gemini', 'agent', 'automation', 'developer', 'software'],
+  },
+  {
+    key: 'design-ux',
+    name: 'Design & UX Signals',
+    description: 'Design, UX, and product craft highlights.',
+    keywords: ['design', 'ux', 'ui', 'figma', 'branding', 'product design', 'typography', 'visual'],
+  },
+  {
+    key: 'startup-market',
+    name: 'Startup & Market Pulse',
+    description: 'Startup, product launch, and market momentum highlights.',
+    keywords: ['startup', 'funding', 'saas', 'growth', 'launch', 'product hunt', 'founder', 'vc'],
+  },
+];
+
+const normalize = (value: string): string => String(value || '').toLowerCase();
+
+const buildAgentProfileId = (agentName: string, instanceId = 'default'): string => (
+  `${agentName.toLowerCase()}:${instanceId || 'default'}`
+);
+
+const ensureSummaryAgentRegistry = async (): Promise<Record<string, unknown>> => {
+  let agent = await AgentRegistry.findOne({ agentName: DEFAULT_SUMMARY_AGENT });
+  if (agent) return agent;
+
+  const typeConfig = AgentIdentityService.getAgentTypeConfig(DEFAULT_SUMMARY_AGENT);
+  agent = await AgentRegistry.create({
+    agentName: DEFAULT_SUMMARY_AGENT,
+    displayName: typeConfig?.officialDisplayName || 'Commonly Bot',
+    description: typeConfig?.officialDescription
+      || 'Built-in summary bot for integrations, pod activity, and digest context',
+    registry: 'commonly-official',
+    categories: ['automation', 'summaries', 'communication'],
+    tags: ['summaries', 'digest', 'integrations'],
+    verified: true,
+    iconUrl: '/icons/commonly-bot.png',
+    manifest: {
+      name: DEFAULT_SUMMARY_AGENT,
+      version: '1.0.0',
+      capabilities: (typeConfig?.capabilities || ['summarize', 'digest', 'integrate'])
+        .map((name: string) => ({ name, description: name })),
+      context: {
+        required: ['context:read', 'summaries:read', 'messages:write'],
+      },
+      runtime: {
+        type: 'standalone',
+        connection: 'rest',
+      },
+    },
+    latestVersion: '1.0.0',
+    versions: [{ version: '1.0.0', publishedAt: new Date() }],
+    stats: { installs: 0, rating: 0, ratingCount: 0 },
+  });
+
+  return agent;
+};
+
+const ensureSummaryAgentInstalled = async ({
+  pod, userId,
+}: { pod: PodRecord; userId: unknown }): Promise<void> => {
+  const agent = await ensureSummaryAgentRegistry();
+  const instanceId = 'default';
+  const alreadyInstalled = await AgentInstallation.isInstalled(
+    (agent as Record<string, unknown>).agentName, pod._id, instanceId,
+  );
+  if (alreadyInstalled) return;
+
+  const manifest = (agent as Record<string, unknown>).manifest as Record<string, unknown> | undefined;
+  const context = manifest?.context as Record<string, unknown> | undefined;
+  const requiredScopes: string[] = (context?.required as string[]) || [];
+  const scopes = Array.from(new Set([...requiredScopes, ...DEFAULT_SUMMARY_SCOPES]));
+
+  const installation = await AgentInstallation.install(
+    (agent as Record<string, unknown>).agentName, pod._id, {
+      version: (agent as Record<string, unknown>).latestVersion || '1.0.0',
+      config: {
+        preset: 'themed-pod-default',
+        autoInstalled: true,
+        themedPodAutoInstall: true,
+      },
+      scopes,
+      installedBy: userId,
+      instanceId,
+      displayName: (agent as Record<string, unknown>).displayName || 'Commonly Bot',
+    },
+  );
+
+  await AgentRegistry.incrementInstalls((agent as Record<string, unknown>).agentName);
+  await AgentProfile.updateOne(
+    {
+      podId: pod._id,
+      agentName: (agent as Record<string, unknown>).agentName,
+      instanceId,
+    },
+    {
+      $setOnInsert: {
+        agentId: buildAgentProfileId(
+          (agent as Record<string, unknown>).agentName as string, instanceId,
+        ),
+        name: installation.displayName || (agent as Record<string, unknown>).displayName || 'Commonly Bot',
+        purpose: 'Social helper that summarizes pod and integration activity, curates highlights, and contributes digest context.',
+        instructions: 'You summarize key activity, share concise social highlights, and suggest what members should discuss next.',
+        createdBy: userId,
+      },
+      $set: {
+        status: 'active',
+        persona: {
+          tone: 'friendly',
+          specialties: ['summarization', 'social highlights', 'conversation prompts', 'digest updates'],
+        },
+      },
+    },
+    { upsert: true },
+  );
+
+  try {
+    const agentUser = await AgentIdentityService.getOrCreateAgentUser(
+      (agent as Record<string, unknown>).agentName, {
+        instanceId,
+        displayName: installation.displayName || (agent as Record<string, unknown>).displayName || 'Commonly Bot',
+      },
+    );
+    await AgentIdentityService.ensureAgentInPod(agentUser, pod._id);
+  } catch (error) {
+    console.warn('[pod-curation] failed to ensure commonly-bot identity in themed pod:', (error as Error).message);
+  }
+};
+
+const getSeedUser = async (): Promise<unknown> => {
+  const admin = await User.findOne({ role: 'admin' }).select('_id').lean() as { _id: unknown } | null;
+  if (admin?._id) return admin._id;
+  const anyUser = await User.findOne({}).select('_id').lean() as { _id: unknown } | null;
+  return anyUser?._id || null;
+};
+
+const getRecentSocialPosts = async ({
+  hours = 12, limit = 300,
+} = {}): Promise<Record<string, unknown>[]> => {
+  const since = new Date(Date.now() - (hours * 60 * 60 * 1000));
+  return Post.find({
+    createdAt: { $gte: since },
+    $or: [
+      { category: 'Social' },
+      { 'source.provider': { $in: ['x', 'instagram'] } },
+    ],
+  })
+    .sort({ createdAt: -1 })
+    .limit(limit)
+    .lean();
+};
+
+const scoreTheme = (theme: ThemePreset, posts: Record<string, unknown>[]): ThemeScore => {
+  const keywords = theme.keywords.map(normalize);
+  const matches = posts.filter((post) => {
+    const tags = (post.tags as string[] || []).join(' ');
+    const haystack = normalize(`${post.content || ''} ${tags}`);
+    return keywords.some((keyword) => haystack.includes(keyword));
+  });
+  return {
+    theme,
+    score: matches.length,
+    matches,
+  };
+};
+
+const createThemedPod = async ({
+  theme, createdBy,
+}: { theme: ThemePreset; createdBy: unknown }): Promise<{ pod: PodRecord; created: boolean }> => {
+  const existing = await Pod.findOne({ name: theme.name }).lean() as PodRecord | null;
+  if (existing) {
+    return { pod: existing, created: false };
+  }
+
+  const pod = await Pod.create({
+    name: theme.name,
+    description: theme.description,
+    type: 'chat',
+    createdBy,
+    members: [createdBy],
+  }) as PodRecord;
+
+  return { pod, created: true };
+};
+
+const enqueueCurateEvent = async ({
+  podId, source = 'themed-pod-autonomy',
+}: { podId: unknown; source?: string }): Promise<number> => {
+  const installations = await AgentInstallation.find({
+    agentName: DEFAULT_SUMMARY_AGENT,
+    podId,
+    status: 'active',
+  }).select('instanceId').lean() as Array<{ instanceId?: string }>;
+
+  if (!installations.length) return 0;
+
+  await Promise.all(
+    installations.map((installation) => (
+      AgentEventService.enqueue({
+        agentName: DEFAULT_SUMMARY_AGENT,
+        instanceId: installation.instanceId || 'default',
+        podId,
+        type: 'curate',
+        payload: {
+          source,
+          topN: 3,
+          limit: 40,
+        },
+      })
+    )),
+  );
+
+  return installations.length;
+};
+
+class PodCurationService {
+  static async runThemedPodAutonomy({
+    hours = 12, minMatches = 4, source = 'themed-pod-autonomy',
+  }: RunAutonomyOptions = {}): Promise<AutonomyResult> {
+    const seedUserId = await getSeedUser();
+    if (!seedUserId) {
+      return { createdPods: [], triggeredPods: [], skipped: 'no-seed-user' };
+    }
+
+    const posts = await getRecentSocialPosts({ hours });
+    if (!posts.length) {
+      return { createdPods: [], triggeredPods: [], scannedPosts: 0 };
+    }
+
+    const themeScores = THEME_PRESETS
+      .map((theme) => scoreTheme(theme, posts))
+      .filter((result) => result.score >= minMatches);
+
+    const createdPods: AutonomyResult['createdPods'] = [];
+    const triggeredPods: AutonomyResult['triggeredPods'] = [];
+
+    for (const themeResult of themeScores) {
+      const { pod, created } = await createThemedPod({
+        theme: themeResult.theme,
+        createdBy: seedUserId,
+      });
+      if (!pod?._id) continue;
+
+      await ensureSummaryAgentInstalled({
+        pod,
+        userId: seedUserId,
+      });
+
+      const queuedTargets = await enqueueCurateEvent({ podId: pod._id, source });
+      if (queuedTargets > 0) {
+        triggeredPods.push({
+          podId: String(pod._id),
+          podName: pod.name,
+          queuedTargets,
+        });
+      }
+
+      if (created) {
+        createdPods.push({
+          podId: String(pod._id),
+          podName: pod.name,
+          theme: themeResult.theme.key,
+          score: themeResult.score,
+        });
+      }
+    }
+
+    return {
+      scannedPosts: posts.length,
+      createdPods,
+      triggeredPods,
+      themeMatches: themeScores.map((item) => ({
+        theme: item.theme.key,
+        score: item.score,
+      })),
+    };
+  }
+}
+
+export default PodCurationService;


### PR DESCRIPTION
## Summary

- `agentMentionService.ts` — Typed mention routing (chat.mention, thread.mention, DM events)
- `podContextService.ts` — Typed pod context assembly with skill synthesis and token budgeting
- `podCurationService.ts` — Typed themed pod autonomy and curation agent lifecycle

Part of issue #118. JS originals untouched.

## Test plan
- [ ] `Test & Coverage` passes (tsc + jest)
- [ ] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)