### PR TITLE
feat(ts): migrate externalFeedService and federationService to TypeScript (batch 7)

### DIFF
--- a/backend/services/externalFeedService.ts
+++ b/backend/services/externalFeedService.ts
@@ -1,0 +1,458 @@
+// eslint-disable-next-line global-require
+const Integration = require('../models/Integration');
+// eslint-disable-next-line global-require
+const Post = require('../models/Post');
+// eslint-disable-next-line global-require
+const { AgentInstallation } = require('../models/AgentRegistry');
+// eslint-disable-next-line global-require
+const registry = require('../integrations');
+// eslint-disable-next-line global-require
+const { normalizeBufferMessage } = require('../integrations/normalizeBufferMessage');
+// eslint-disable-next-line global-require
+const AgentEventService = require('./agentEventService');
+
+const FEED_TYPES = ['x', 'instagram'];
+const DEFAULT_CATEGORY = 'Social';
+
+interface NormalizedMessage {
+  externalId?: string | number;
+  content?: string;
+  attachments?: Array<string | { url?: string }>;
+  timestamp?: string;
+  authorName?: string;
+  metadata?: {
+    url?: string;
+    authorUrl?: string;
+    username?: string;
+  };
+}
+
+interface IntegrationDoc {
+  _id: unknown;
+  podId: unknown;
+  type: string;
+  isActive: boolean;
+  status: string;
+  createdBy: unknown;
+  config?: {
+    category?: string;
+    messageBuffer?: Array<{ messageId?: string }>;
+    lastExternalId?: string;
+    lastExternalTimestamp?: Date;
+    maxBufferSize?: number;
+    accessToken?: string;
+    refreshToken?: string;
+  };
+}
+
+interface SyncMeta {
+  userId?: string;
+  username?: string;
+  lastExternalIdsByUser?: Record<string, string>;
+  watchedUserIds?: string[];
+  tokenRefreshed?: boolean;
+  refreshedAccessToken?: string;
+  refreshedRefreshToken?: string;
+  refreshedTokenType?: string;
+  refreshedScope?: string;
+  refreshedExpiresIn?: number;
+  lastExternalIdsByUser?: Record<string, string>;
+}
+
+interface SyncResult {
+  messages?: NormalizedMessage[];
+  content?: string;
+  meta?: SyncMeta;
+}
+
+interface CuratorDispatch {
+  enqueued: number;
+  reason?: string;
+  targets?: Array<{ agentName: string; instanceId: string }>;
+}
+
+interface FeedSyncResult {
+  integrationId: unknown;
+  success: boolean;
+  messageCount: number;
+  createdPosts?: number;
+  curatorEventsEnqueued?: number;
+  curatorTargets?: Array<{ agentName: string; instanceId: string }>;
+  content: string;
+}
+
+function shouldPersistExternalFeedPosts(): boolean {
+  return process.env.EXTERNAL_FEED_PERSIST_POSTS === '1';
+}
+
+function getAttachmentUrl(attachments: NormalizedMessage['attachments'] = []): string {
+  if (!Array.isArray(attachments) || attachments.length === 0) return '';
+  const first = attachments[0];
+  if (!first) return '';
+  if (typeof first === 'string') return first;
+  return first.url || '';
+}
+
+function getNewestTimestamp(messages: NormalizedMessage[] = []): Date | null {
+  let newest: Date | null = null;
+  messages.forEach((message) => {
+    const ts = new Date(message.timestamp as string);
+    if (Number.isNaN(ts.valueOf())) return;
+    if (!newest || ts > newest) {
+      newest = ts;
+    }
+  });
+  return newest;
+}
+
+async function persistExternalPosts({
+  integration, messages,
+}: { integration: IntegrationDoc; messages: NormalizedMessage[] }): Promise<{ created: number }> {
+  if (!integration || !messages?.length) return { created: 0 };
+
+  const externalIds = messages
+    .map((message) => message.externalId)
+    .filter(Boolean)
+    .map(String);
+
+  if (!externalIds.length) return { created: 0 };
+
+  const existingPosts = await Post.find({
+    podId: integration.podId,
+    'source.provider': integration.type,
+    'source.externalId': { $in: externalIds },
+  })
+    .select('source.externalId')
+    .lean() as Array<{ source?: { externalId?: string } }>;
+
+  const existingIds = new Set(existingPosts.map((post) => post.source?.externalId));
+  const category = integration.config?.category || DEFAULT_CATEGORY;
+  const { createdBy } = integration;
+
+  const creations = messages
+    .filter((message) => message.externalId && !existingIds.has(String(message.externalId)))
+    .map((message) => {
+      const image = getAttachmentUrl(message.attachments);
+      return new Post({
+        podId: integration.podId,
+        userId: createdBy,
+        content: message.content || (image ? 'Shared an attachment' : ''),
+        image,
+        category,
+        source: {
+          type: 'external',
+          provider: integration.type,
+          externalId: String(message.externalId),
+          url: message.metadata?.url,
+          author: message.authorName,
+          authorUrl: message.metadata?.authorUrl,
+          channel: message.metadata?.username || integration.config?.accessToken || null,
+        },
+      });
+    });
+
+  if (!creations.length) return { created: 0 };
+  await Post.insertMany(creations);
+  return { created: creations.length };
+}
+
+function dedupeBatchByExternalId(messages: NormalizedMessage[] = []): NormalizedMessage[] {
+  const seen = new Set<string>();
+  return messages.filter((message) => {
+    const externalId = message?.externalId ? String(message.externalId) : '';
+    if (!externalId) return false;
+    if (seen.has(externalId)) return false;
+    seen.add(externalId);
+    return true;
+  });
+}
+
+async function filterAlreadySeenMessages({
+  integration, messages,
+}: { integration: IntegrationDoc; messages: NormalizedMessage[] }): Promise<NormalizedMessage[]> {
+  if (!integration || !messages?.length) return [];
+
+  const candidateMessages = dedupeBatchByExternalId(messages);
+  if (!candidateMessages.length) return [];
+
+  const bufferedIds = new Set(
+    (integration.config?.messageBuffer || [])
+      .map((entry) => String(entry?.messageId || '').trim())
+      .filter(Boolean),
+  );
+  const unseenFromBuffer = candidateMessages.filter(
+    (message) => !bufferedIds.has(String(message.externalId)),
+  );
+  if (!unseenFromBuffer.length) return [];
+
+  const externalIds = unseenFromBuffer.map((message) => String(message.externalId));
+  const existingPosts = await Post.find({
+    podId: integration.podId,
+    'source.provider': integration.type,
+    'source.externalId': { $in: externalIds },
+  })
+    .select('source.externalId')
+    .lean() as Array<{ source?: { externalId?: string } }>;
+  const existingPostIds = new Set(
+    existingPosts
+      .map((post) => String(post?.source?.externalId || '').trim())
+      .filter(Boolean),
+  );
+
+  return unseenFromBuffer.filter(
+    (message) => !existingPostIds.has(String(message.externalId)),
+  );
+}
+
+async function appendIntegrationBuffer(
+  integrationId: unknown,
+  messages: NormalizedMessage[],
+  maxBufferSize = 1000,
+): Promise<void> {
+  const bufferMessages = (messages || [])
+    .map((message) => normalizeBufferMessage(message))
+    .filter(Boolean);
+
+  if (!bufferMessages.length) return;
+
+  await Integration.findByIdAndUpdate(
+    integrationId,
+    {
+      $push: {
+        'config.messageBuffer': {
+          $each: bufferMessages,
+          $slice: -1 * maxBufferSize,
+        },
+      },
+    },
+  );
+}
+
+function isCuratorInstallation(installation: Record<string, unknown>): boolean {
+  const instanceId = String(installation?.instanceId || '').toLowerCase();
+  const displayName = String(installation?.displayName || '').toLowerCase();
+  const agentName = String(installation?.agentName || '').toLowerCase();
+  if (instanceId.includes('curator')) return true;
+  if (displayName.includes('curator')) return true;
+  return agentName.includes('curator');
+}
+
+async function enqueueCuratorEvents({
+  integration, messageCount,
+}: { integration: IntegrationDoc; messageCount: number }): Promise<CuratorDispatch> {
+  if (!integration?.podId) {
+    return { enqueued: 0, reason: 'missing_pod' };
+  }
+
+  const installations = await AgentInstallation.find({
+    podId: integration.podId,
+    status: 'active',
+  }).select('agentName instanceId displayName config.autonomy').lean() as Array<Record<string, unknown>>;
+
+  const eligibleInstallations = installations
+    .filter((installation) => {
+      const config = installation?.config as Record<string, unknown> | undefined;
+      const autonomy = config?.autonomy as Record<string, unknown> | undefined;
+      return autonomy?.enabled !== false;
+    })
+    .filter((installation) => isCuratorInstallation(installation));
+
+  if (!eligibleInstallations.length) {
+    return { enqueued: 0, reason: 'no_curator_installations' };
+  }
+
+  const uniqueInstallations = Array.from(
+    new Map(
+      eligibleInstallations.map((installation) => {
+        const key = [
+          String(installation.agentName || '').toLowerCase(),
+          String(installation.instanceId || 'default'),
+        ].join(':');
+        return [key, installation];
+      }),
+    ).values(),
+  );
+
+  await Promise.all(
+    uniqueInstallations.map((installation) => (
+      AgentEventService.enqueue({
+        agentName: installation.agentName,
+        instanceId: installation.instanceId || 'default',
+        podId: integration.podId,
+        type: 'curate',
+        payload: {
+          source: 'external-feed-sync',
+          provider: integration.type,
+          integrationId: String(integration._id),
+          messageCount: Number(messageCount) || 0,
+          topN: 3,
+          limit: 40,
+        },
+      })
+    )),
+  );
+
+  return {
+    enqueued: uniqueInstallations.length,
+    targets: uniqueInstallations.map((installation) => ({
+      agentName: installation.agentName as string,
+      instanceId: (installation.instanceId as string) || 'default',
+    })),
+  };
+}
+
+async function syncExternalFeeds(): Promise<FeedSyncResult[]> {
+  const integrations = await Integration.find({
+    type: { $in: FEED_TYPES },
+    isActive: true,
+    status: 'connected',
+  }).lean() as IntegrationDoc[];
+
+  if (!integrations.length) return [];
+
+  const results = await Promise.all(
+    integrations.map(async (integration): Promise<FeedSyncResult> => {
+      try {
+        const provider = registry.get(integration.type, integration);
+        const sinceId = integration.config?.lastExternalId;
+        const sinceTimestamp = integration.config?.lastExternalTimestamp;
+        const syncResult: SyncResult = await provider.syncRecent({ sinceId, sinceTimestamp });
+
+        const updateSet: Record<string, unknown> = {
+          lastSync: new Date(),
+          status: 'connected',
+          errorMessage: null,
+          isActive: true,
+        };
+        if (syncResult.meta?.userId) {
+          updateSet['config.userId'] = syncResult.meta.userId;
+        }
+        if (syncResult.meta?.username) {
+          updateSet['config.username'] = syncResult.meta.username;
+        }
+        if (syncResult.meta?.lastExternalIdsByUser && typeof syncResult.meta.lastExternalIdsByUser === 'object') {
+          const watchedUserIds = Array.isArray(syncResult.meta?.watchedUserIds)
+            ? syncResult.meta.watchedUserIds.map((id) => String(id || '').trim()).filter(Boolean)
+            : [];
+          const pruned = Object.entries(syncResult.meta.lastExternalIdsByUser).reduce<Record<string, string>>((acc, [key, value]) => {
+            const userId = String(key || '').trim();
+            const sinceValue = String(value || '').trim();
+            if (!userId || !sinceValue) return acc;
+            if (watchedUserIds.length && !watchedUserIds.includes(userId)) return acc;
+            acc[userId] = sinceValue;
+            return acc;
+          }, {});
+          updateSet['config.lastExternalIdsByUser'] = pruned;
+        }
+        if (syncResult.meta?.tokenRefreshed && syncResult.meta?.refreshedAccessToken) {
+          updateSet['config.accessToken'] = syncResult.meta.refreshedAccessToken;
+        }
+        if (syncResult.meta?.tokenRefreshed && syncResult.meta?.refreshedRefreshToken) {
+          updateSet['config.refreshToken'] = syncResult.meta.refreshedRefreshToken;
+        }
+        if (syncResult.meta?.tokenRefreshed && syncResult.meta?.refreshedTokenType) {
+          updateSet['config.tokenType'] = syncResult.meta.refreshedTokenType;
+        }
+        if (syncResult.meta?.tokenRefreshed && syncResult.meta?.refreshedScope) {
+          updateSet['config.oauthScopes'] = String(syncResult.meta.refreshedScope)
+            .split(/\s+/)
+            .map((entry) => entry.trim())
+            .filter(Boolean);
+        }
+        if (syncResult.meta?.tokenRefreshed && syncResult.meta?.refreshedExpiresIn) {
+          const seconds = Number(syncResult.meta.refreshedExpiresIn);
+          if (Number.isFinite(seconds) && seconds > 0) {
+            updateSet['config.tokenExpiresAt'] = new Date(Date.now() + (seconds * 1000));
+          }
+        }
+
+        const messages = await filterAlreadySeenMessages({
+          integration,
+          messages: syncResult.messages || [],
+        });
+        if (!messages.length) {
+          await Integration.findByIdAndUpdate(integration._id, { $set: updateSet });
+          return {
+            integrationId: integration._id,
+            success: true,
+            messageCount: 0,
+            content: syncResult.content || 'No new posts',
+          };
+        }
+
+        const newestTimestamp = getNewestTimestamp(messages);
+        const newestMessage = messages.reduce<NormalizedMessage | null>((acc, message) => {
+          if (!message.timestamp) return acc;
+          const ts = new Date(message.timestamp);
+          if (Number.isNaN(ts.valueOf())) return acc;
+          if (!acc || ts > new Date(acc.timestamp as string)) return message;
+          return acc;
+        }, null);
+
+        const created = shouldPersistExternalFeedPosts()
+          ? (await persistExternalPosts({ integration, messages })).created
+          : 0;
+        await appendIntegrationBuffer(
+          integration._id,
+          messages,
+          integration.config?.maxBufferSize || 1000,
+        );
+        const curatorDispatch = await enqueueCuratorEvents({
+          integration,
+          messageCount: messages.length,
+        });
+
+        if (newestMessage?.externalId) {
+          updateSet['config.lastExternalId'] = String(newestMessage.externalId);
+        }
+        if (newestTimestamp) {
+          updateSet['config.lastExternalTimestamp'] = newestTimestamp;
+        }
+
+        await Integration.findByIdAndUpdate(integration._id, { $set: updateSet });
+
+        return {
+          integrationId: integration._id,
+          success: true,
+          messageCount: messages.length,
+          createdPosts: created,
+          curatorEventsEnqueued: curatorDispatch.enqueued,
+          curatorTargets: curatorDispatch.targets || [],
+          content: syncResult.content || 'Synced external feed',
+        };
+      } catch (error) {
+        const err = error as {
+          response?: { data?: { error_description?: string; error?: string; detail?: string; title?: string } };
+          message?: string;
+        };
+        const detail = err?.response?.data?.error_description
+          || err?.response?.data?.error
+          || err?.response?.data?.detail
+          || err?.response?.data?.title
+          || err?.message
+          || 'External feed sync failed';
+        try {
+          await Integration.findByIdAndUpdate(integration._id, {
+            $set: {
+              status: 'error',
+              errorMessage: detail,
+              lastSync: new Date(),
+            },
+          });
+        } catch (updateError) {
+          console.warn('Failed to persist integration sync error state:', (updateError as Error).message);
+        }
+        return {
+          integrationId: integration._id,
+          success: false,
+          messageCount: 0,
+          content: detail,
+        };
+      }
+    }),
+  );
+
+  return results;
+}
+
+export { syncExternalFeeds, FEED_TYPES };

--- a/backend/services/federationService.ts
+++ b/backend/services/federationService.ts
@@ -1,0 +1,404 @@
+/**
+ * Federation Service
+ *
+ * Handles cross-pod queries with explicit scope checking and audit logging.
+ * All cross-pod access must go through this service.
+ */
+
+// eslint-disable-next-line global-require
+const PodLink = require('../models/PodLink');
+// eslint-disable-next-line global-require
+const PodAsset = require('../models/PodAsset');
+// eslint-disable-next-line global-require
+const Summary = require('../models/Summary');
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
+// eslint-disable-next-line global-require
+const ContextAssemblerService = require('./contextAssemblerService');
+// eslint-disable-next-line global-require
+const PodAssetService = require('./podAssetService');
+
+interface QueryLinkedPodOptions {
+  sourcePodId: unknown;
+  targetPodId: unknown;
+  queryType: string;
+  filters?: Record<string, unknown>;
+  actorId?: unknown;
+  actorType?: string;
+  limit?: number;
+}
+
+interface FederatedItem {
+  _federated: boolean;
+  _sourcePodId: string;
+  [key: string]: unknown;
+}
+
+interface FederatedSearchOptions {
+  sourcePodId: unknown;
+  query: string;
+  queryTypes?: string[];
+  actorId?: unknown;
+  actorType?: string;
+  limit?: number;
+}
+
+interface LinkDoc {
+  _id: unknown;
+  scopes: Array<{ type: string; filters?: Record<string, unknown> }>;
+  sourcePodId: { _id: unknown; name?: string; type?: string; description?: string };
+  hasScope: (type: string, filters?: Record<string, unknown>) => boolean;
+  recordQuery: (actorId: unknown, actorType: string, opts: Record<string, unknown>) => Promise<void>;
+}
+
+class FederationService {
+  /**
+   * Query a linked pod's resources
+   */
+  static async queryLinkedPod(options: QueryLinkedPodOptions): Promise<{
+    results: unknown;
+    meta: Record<string, unknown>;
+  }> {
+    const {
+      sourcePodId,
+      targetPodId,
+      queryType,
+      filters = {},
+      actorId,
+      actorType = 'human',
+      limit = 10,
+    } = options;
+
+    // 1. Find active link
+    const link: LinkDoc | null = await PodLink.findActiveLink(targetPodId, sourcePodId);
+    if (!link) {
+      throw new Error('No active link to target pod');
+    }
+
+    // 2. Check scope
+    const scopeType = `${queryType}:read`;
+    if (!link.hasScope(scopeType, filters)) {
+      throw new Error(`Query exceeds granted scopes: ${scopeType}`);
+    }
+
+    // 3. Execute query based on type
+    let results: unknown;
+    let itemCount = 0;
+
+    switch (queryType) {
+      case 'summaries':
+        results = await FederationService.querySummaries(targetPodId, filters, link, limit);
+        itemCount = (results as unknown[]).length;
+        break;
+
+      case 'skills':
+        results = await FederationService.querySkills(targetPodId, filters, link, limit);
+        itemCount = (results as unknown[]).length;
+        break;
+
+      case 'assets':
+        results = await FederationService.queryAssets(targetPodId, filters, link, limit);
+        itemCount = (results as unknown[]).length;
+        break;
+
+      case 'memory':
+        results = await FederationService.queryMemory(targetPodId, filters, link);
+        itemCount = 1;
+        break;
+
+      case 'context':
+        results = await FederationService.queryContext(targetPodId, filters, link);
+        itemCount = 1;
+        break;
+
+      default:
+        throw new Error(`Unknown query type: ${queryType}`);
+    }
+
+    // 4. Audit log
+    await link.recordQuery(actorId, actorType, {
+      queryType,
+      filters,
+      itemCount,
+    });
+
+    return {
+      results,
+      meta: {
+        sourcePodId: String(sourcePodId),
+        targetPodId: String(targetPodId),
+        queryType,
+        itemCount,
+        link: {
+          id: String(link._id),
+          scopes: link.scopes,
+        },
+      },
+    };
+  }
+
+  /**
+   * Query summaries from linked pod
+   */
+  static async querySummaries(
+    podId: unknown,
+    filters: Record<string, unknown>,
+    link: LinkDoc,
+    limit: number,
+  ): Promise<FederatedItem[]> {
+    const query: Record<string, unknown> = { podId };
+
+    const scope = link.scopes.find((s) => s.type === 'summaries:read');
+    const scopeFilters = scope?.filters as Record<string, string[]> | undefined;
+    if ((scopeFilters?.types || []).length > 0) {
+      query.type = { $in: scopeFilters!.types };
+    }
+    if (scopeFilters?.since) {
+      query.createdAt = { $gte: scopeFilters.since };
+    }
+
+    if (filters.type) {
+      query.type = filters.type;
+    }
+    if (filters.since) {
+      query.createdAt = { ...(query.createdAt as object), $gte: new Date(filters.since as string) };
+    }
+
+    const summaries = await Summary.find(query)
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .lean() as Array<Record<string, unknown>>;
+
+    return summaries.map((s) => ({
+      id: String(s._id),
+      type: s.type,
+      content: s.content,
+      period: s.timeRange,
+      createdAt: s.createdAt,
+      _federated: true,
+      _sourcePodId: String(podId),
+    }));
+  }
+
+  /**
+   * Query skills from linked pod
+   */
+  static async querySkills(
+    podId: unknown,
+    filters: Record<string, unknown>,
+    link: LinkDoc,
+    limit: number,
+  ): Promise<FederatedItem[]> {
+    const query: Record<string, unknown> = PodAssetService.applyVisibilityFilter(
+      { podId, type: 'skill' },
+      PodAssetService.buildAgentScopeFilter(null),
+    );
+
+    const scope = link.scopes.find((s) => s.type === 'skills:read');
+    const scopeFilters = scope?.filters as Record<string, string[]> | undefined;
+    if ((scopeFilters?.tags || []).length > 0) {
+      query.tags = { $in: scopeFilters!.tags };
+    }
+
+    if (filters.tags) {
+      query.tags = { $in: Array.isArray(filters.tags) ? filters.tags : [filters.tags] };
+    }
+    if (filters.search) {
+      query.$or = [
+        { title: { $regex: filters.search, $options: 'i' } },
+        { content: { $regex: filters.search, $options: 'i' } },
+      ];
+    }
+
+    const skills = await PodAsset.find(query)
+      .sort({ updatedAt: -1 })
+      .limit(limit)
+      .lean() as Array<Record<string, unknown>>;
+
+    return skills.map((s) => ({
+      id: String(s._id),
+      name: s.title,
+      instructions: s.content,
+      tags: s.tags,
+      createdAt: s.createdAt,
+      _federated: true,
+      _sourcePodId: String(podId),
+    }));
+  }
+
+  /**
+   * Query assets from linked pod
+   */
+  static async queryAssets(
+    podId: unknown,
+    filters: Record<string, unknown>,
+    link: LinkDoc,
+    limit: number,
+  ): Promise<FederatedItem[]> {
+    const query: Record<string, unknown> = PodAssetService.applyVisibilityFilter(
+      { podId },
+      PodAssetService.buildAgentScopeFilter(null),
+    );
+
+    const scope = link.scopes.find((s) => s.type === 'assets:read');
+    const scopeFilters = scope?.filters as Record<string, string[]> | undefined;
+    if ((scopeFilters?.types || []).length > 0) {
+      query.type = { $in: scopeFilters!.types };
+    }
+    if ((scopeFilters?.tags || []).length > 0) {
+      query.tags = { $in: scopeFilters!.tags };
+    }
+
+    if (filters.type) {
+      query.type = filters.type;
+    }
+    if (filters.search) {
+      query.$or = [
+        { title: { $regex: filters.search, $options: 'i' } },
+        { content: { $regex: filters.search, $options: 'i' } },
+      ];
+    }
+
+    const assets = await PodAsset.find(query)
+      .sort({ updatedAt: -1 })
+      .limit(limit)
+      .lean() as Array<Record<string, unknown>>;
+
+    return assets.map((a) => ({
+      id: String(a._id),
+      title: a.title,
+      type: a.type,
+      snippet: (a.content as string)?.substring(0, 300),
+      tags: a.tags,
+      createdAt: a.createdAt,
+      _federated: true,
+      _sourcePodId: String(podId),
+    }));
+  }
+
+  /**
+   * Query memory from linked pod
+   */
+  static async queryMemory(
+    podId: unknown,
+    _filters: Record<string, unknown>,
+    _link: LinkDoc,
+  ): Promise<FederatedItem> {
+    const content = await ContextAssemblerService.readMemoryFile(podId, 'MEMORY.md') as string;
+    return {
+      content,
+      _federated: true,
+      _sourcePodId: String(podId),
+    };
+  }
+
+  /**
+   * Query assembled context from linked pod
+   */
+  static async queryContext(
+    podId: unknown,
+    filters: Record<string, unknown>,
+    link: LinkDoc,
+  ): Promise<FederatedItem> {
+    const options = {
+      task: filters.task,
+      includeMemory: link.hasScope('memory:read'),
+      includeSkills: link.hasScope('skills:read'),
+      includeSummaries: link.hasScope('summaries:read'),
+      maxTokens: filters.maxTokens || 4000,
+    };
+
+    const context = await ContextAssemblerService.assembleContext(podId, options) as Record<string, unknown>;
+
+    return {
+      ...context,
+      _federated: true,
+      _sourcePodId: String(podId),
+    };
+  }
+
+  /**
+   * Get all accessible pods for a source pod (through links)
+   */
+  static async getAccessiblePods(podId: unknown): Promise<Array<{
+    pod: { id: string; name?: string; type?: string; description?: string };
+    scopes: LinkDoc['scopes'];
+    linkId: string;
+  }>> {
+    const links = await PodLink.find({
+      targetPodId: podId,
+      status: 'active',
+      $or: [{ expiresAt: null }, { expiresAt: { $gt: new Date() } }],
+    })
+      .populate('sourcePodId', 'name type description')
+      .lean() as LinkDoc[];
+
+    return links.map((link) => ({
+      pod: {
+        id: String(link.sourcePodId._id),
+        name: link.sourcePodId.name,
+        type: link.sourcePodId.type,
+        description: link.sourcePodId.description,
+      },
+      scopes: link.scopes,
+      linkId: String(link._id),
+    }));
+  }
+
+  /**
+   * Search across all accessible pods
+   */
+  static async federatedSearch(options: FederatedSearchOptions): Promise<FederatedItem[]> {
+    const {
+      sourcePodId,
+      query,
+      queryTypes = ['skills', 'assets'],
+      actorId,
+      actorType,
+      limit = 10,
+    } = options;
+
+    const accessiblePods = await FederationService.getAccessiblePods(sourcePodId);
+
+    const allResults = (await Promise.all(
+      accessiblePods.map(async ({ pod, scopes }) => {
+        const perPodResults = await Promise.all(
+          queryTypes.map(async (queryType) => {
+            const scopeType = `${queryType}:read`;
+            const hasScope = scopes.some((s) => s.type === scopeType);
+
+            if (!hasScope) return [];
+
+            try {
+              const { results } = await FederationService.queryLinkedPod({
+                sourcePodId,
+                targetPodId: pod.id,
+                queryType,
+                filters: { search: query },
+                actorId,
+                actorType,
+                limit: Math.ceil(limit / accessiblePods.length),
+              });
+
+              return (results as FederatedItem[]).map((r) => ({
+                ...r,
+                _sourcePod: pod,
+              }));
+            } catch (error) {
+              console.error(`Federation search error for pod ${pod.id}:`, (error as Error).message);
+              return [];
+            }
+          }),
+        );
+
+        return perPodResults.flat();
+      }),
+    )).flat();
+
+    allResults.sort((a, b) => new Date(b.createdAt as string).getTime() - new Date(a.createdAt as string).getTime());
+
+    return allResults.slice(0, limit);
+  }
+}
+
+export default FederationService;


### PR DESCRIPTION
## Summary

- `externalFeedService.ts` — X/Instagram feed sync pipeline with curator event dispatch, typed
- `federationService.ts` — Cross-pod query service with scope checking and audit logging, typed

Part of issue #118. JS originals untouched.

## Test plan
- [ ] `Test & Coverage` passes (tsc + jest)

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)