### PR TITLE
feat(ts): migrate podAssetService, contextAssemblerService, vectorSearchService (batch 8)

### DIFF
--- a/backend/services/contextAssemblerService.ts
+++ b/backend/services/contextAssemblerService.ts
@@ -1,0 +1,747 @@
+/**
+ * Context Assembler Service
+ *
+ * Assembles structured context for agents from pod memory, skills, assets, and summaries.
+ * This is the core service that powers the Context API and MCP server.
+ */
+
+// eslint-disable-next-line global-require
+const PodAsset = require('../models/PodAsset');
+// eslint-disable-next-line global-require
+const Summary = require('../models/Summary');
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
+// eslint-disable-next-line global-require
+const PodAssetService = require('./podAssetService');
+
+// Lazy load vector search (optional dependency)
+let vectorSearchService: Record<string, unknown> | null = null;
+try {
+  // eslint-disable-next-line global-require
+  vectorSearchService = require('./vectorSearchService');
+} catch {
+  console.log('Vector search not available, using keyword fallback');
+  vectorSearchService = null;
+}
+const getVectorSearch = () => vectorSearchService;
+
+// Token estimation (rough approximation)
+const CHARS_PER_TOKEN = 4;
+
+interface AssembleContextOptions {
+  task?: string | null;
+  includeMemory?: boolean;
+  includeSkills?: boolean;
+  includeSummaries?: boolean;
+  maxTokens?: number;
+  userId?: unknown;
+  agentContext?: unknown;
+}
+
+interface WriteMemoryOptions {
+  target: string;
+  content: string;
+  tags?: string[];
+  source?: Record<string, unknown>;
+  agentContext?: unknown;
+  scope?: string;
+  metadata?: Record<string, unknown>;
+  title?: string;
+}
+
+interface GetRelevantSkillsOptions {
+  limit?: number;
+  maxTokens?: number;
+  agentContext?: unknown;
+}
+
+interface SearchAssetsOptions {
+  limit?: number;
+  types?: string[] | null;
+  maxTokens?: number;
+  agentContext?: unknown;
+}
+
+interface GetRecentSummariesOptions {
+  hours?: number;
+  limit?: number;
+  types?: string[] | null;
+  maxTokens?: number;
+}
+
+interface ReadMemoryFileOptions {
+  agentContext?: unknown;
+}
+
+interface AssetDoc {
+  _id: unknown;
+  title?: string;
+  content?: string;
+  type?: string;
+  tags?: string[];
+  sourceRef?: unknown;
+  relevance?: number;
+  matchedChunk?: string;
+  updatedAt?: unknown;
+}
+
+interface SummaryDoc {
+  _id: unknown;
+  type?: string;
+  content?: string;
+  timeRange?: { start?: Date; end?: Date };
+  createdAt?: Date;
+  metadata?: unknown;
+}
+
+interface SkillDoc {
+  _id: unknown;
+  title?: string;
+  content?: string;
+  tags?: string[];
+  sourceRef?: unknown;
+  relevance?: number;
+}
+
+interface ContextResult {
+  pod: Record<string, unknown> | null;
+  memory: string | null;
+  skills: unknown[];
+  assets: unknown[];
+  summaries: unknown[];
+  meta: {
+    tokenEstimate: number;
+    assembledAt: string;
+  };
+}
+
+class ContextAssemblerService {
+  /**
+   * Assemble context for a pod
+   */
+  static async assembleContext(
+    podId: unknown,
+    options: AssembleContextOptions = {},
+  ): Promise<ContextResult> {
+    const {
+      task = null,
+      includeMemory = true,
+      includeSkills = true,
+      includeSummaries = true,
+      maxTokens = 8000,
+      userId = null,
+      agentContext = null,
+    } = options;
+
+    const context: ContextResult = {
+      pod: null,
+      memory: null,
+      skills: [],
+      assets: [],
+      summaries: [],
+      meta: {
+        tokenEstimate: 0,
+        assembledAt: new Date().toISOString(),
+      },
+    };
+
+    const pod = await Pod.findById(podId).lean() as Record<string, unknown> | null;
+    if (!pod) {
+      throw new Error('Pod not found');
+    }
+
+    let role = 'viewer';
+    if (userId) {
+      const members = pod.members as Array<{ userId?: unknown; role?: string }> | undefined;
+      const membership = members?.find((m) => m.userId?.toString() === String(userId));
+      role = membership?.role || 'viewer';
+    }
+
+    context.pod = {
+      id: String(pod._id),
+      name: pod.name,
+      description: pod.description,
+      type: pod.type,
+      role,
+    };
+
+    let remainingTokens = maxTokens;
+
+    if (includeMemory) {
+      const normalizedAgent = PodAssetService.normalizeAgentContext(agentContext);
+      let memoryAsset: AssetDoc | null = null;
+      if (normalizedAgent) {
+        memoryAsset = await PodAsset.findOne({
+          podId,
+          type: 'memory',
+          title: 'MEMORY.md',
+          'metadata.scope': 'agent',
+          'metadata.agentName': normalizedAgent.agentName,
+          'metadata.instanceId': normalizedAgent.instanceId,
+        }).lean();
+      }
+      if (!memoryAsset) {
+        memoryAsset = await PodAsset.findOne({
+          podId,
+          type: 'memory',
+          title: 'MEMORY.md',
+          'metadata.scope': { $ne: 'agent' },
+        }).lean();
+      }
+
+      if (memoryAsset?.content) {
+        const memoryTokens = ContextAssemblerService.estimateTokens(memoryAsset.content);
+        if (memoryTokens <= remainingTokens * 0.3) {
+          context.memory = memoryAsset.content;
+          remainingTokens -= memoryTokens;
+          context.meta.tokenEstimate += memoryTokens;
+        }
+      }
+    }
+
+    if (includeSkills) {
+      const skills = await ContextAssemblerService.getRelevantSkills(podId, task, {
+        limit: 5,
+        maxTokens: remainingTokens * 0.2,
+        agentContext,
+      });
+
+      context.skills = skills.map((s) => ({
+        id: String(s._id),
+        name: s.title,
+        description: s.content?.substring(0, 200),
+        instructions: s.content,
+        tags: s.tags || [],
+        sourceAssetIds: s.sourceRef ? [String(s.sourceRef)] : [],
+      }));
+
+      const skillTokens = skills.reduce(
+        (sum, s) => sum + ContextAssemblerService.estimateTokens(s.content || ''), 0,
+      );
+      remainingTokens -= skillTokens;
+      context.meta.tokenEstimate += skillTokens;
+    }
+
+    if (task) {
+      const assets = await ContextAssemblerService.searchAssets(podId, task, {
+        limit: 10,
+        maxTokens: remainingTokens * 0.3,
+        agentContext,
+      });
+
+      context.assets = assets.map((a) => ({
+        id: String(a._id),
+        title: a.title,
+        type: a.type,
+        snippet: a.content?.substring(0, 300),
+        source: {
+          type: (a.sourceRef as Record<string, unknown>)?.type || 'unknown',
+          ref: (a.sourceRef as Record<string, unknown>)?.id?.toString?.(),
+        },
+        tags: a.tags || [],
+        relevance: a.relevance || 0,
+      }));
+
+      const assetTokens = assets.reduce(
+        (sum, a) => sum + ContextAssemblerService.estimateTokens(a.content?.substring(0, 300) || ''), 0,
+      );
+      remainingTokens -= assetTokens;
+      context.meta.tokenEstimate += assetTokens;
+    }
+
+    if (includeSummaries) {
+      const summaries = await ContextAssemblerService.getRecentSummaries(podId, {
+        hours: 24,
+        limit: 5,
+        maxTokens: remainingTokens,
+      });
+
+      context.summaries = summaries.map((s) => ({
+        id: String(s._id),
+        type: s.type,
+        content: s.content,
+        period: {
+          start: s.timeRange?.start?.toISOString() || s.createdAt?.toISOString(),
+          end: s.timeRange?.end?.toISOString() || s.createdAt?.toISOString(),
+        },
+        metadata: s.metadata,
+      }));
+
+      const summaryTokens = summaries.reduce(
+        (sum, s) => sum + ContextAssemblerService.estimateTokens(s.content || ''), 0,
+      );
+      context.meta.tokenEstimate += summaryTokens;
+    }
+
+    return context;
+  }
+
+  /**
+   * Get skills relevant to a task using vector search when available
+   */
+  static async getRelevantSkills(
+    podId: unknown,
+    task: string | null,
+    options: GetRelevantSkillsOptions = {},
+  ): Promise<SkillDoc[]> {
+    const { limit = 5, agentContext = null } = options;
+    const visibilityFilter = PodAssetService.buildAgentScopeFilter(agentContext);
+
+    if (!task) {
+      const query = PodAssetService.applyVisibilityFilter(
+        { podId, type: 'skill' },
+        visibilityFilter,
+      );
+      return PodAsset.find(query).sort({ updatedAt: -1 }).limit(limit).lean();
+    }
+
+    const vs = getVectorSearch();
+    if (vs) {
+      try {
+        const results = await (vs as Record<string, Function>).search(podId, task, {
+          limit,
+          types: ['skill'],
+          hybrid: true,
+        }) as Array<{ asset_id: string; combinedScore?: number }>;
+
+        if (results && results.length > 0) {
+          const assetIds = results.map((r) => r.asset_id);
+          const baseQuery = PodAssetService.applyVisibilityFilter(
+            { _id: { $in: assetIds } },
+            visibilityFilter,
+          );
+          const skills: SkillDoc[] = await PodAsset.find(baseQuery).lean();
+
+          return assetIds
+            .map((id) => {
+              const skill = skills.find((s) => String(s._id) === id);
+              const result = results.find((r) => r.asset_id === id);
+              return skill ? { ...skill, relevance: result?.combinedScore || 0 } : null;
+            })
+            .filter((s): s is SkillDoc => s !== null);
+        }
+      } catch (error) {
+        console.error('Skill vector search error:', (error as Error).message);
+      }
+    }
+
+    const keywords = task.toLowerCase().split(/\s+/).filter((w) => w.length > 3);
+    const query: Record<string, unknown> = PodAssetService.applyVisibilityFilter(
+      { podId, type: 'skill' },
+      visibilityFilter,
+    );
+
+    if (keywords.length > 0) {
+      query.$or = [
+        { tags: { $in: keywords } },
+        { title: { $regex: keywords.join('|'), $options: 'i' } },
+      ];
+    }
+
+    return PodAsset.find(query).sort({ updatedAt: -1 }).limit(limit).lean();
+  }
+
+  /**
+   * Search assets by task/query using hybrid vector + keyword search
+   */
+  static async searchAssets(
+    podId: unknown,
+    query: string,
+    options: SearchAssetsOptions = {},
+  ): Promise<AssetDoc[]> {
+    const {
+      limit = 10, types = null, maxTokens = 4000, agentContext = null,
+    } = options;
+    const visibilityFilter = PodAssetService.buildAgentScopeFilter(agentContext);
+
+    const vs = getVectorSearch();
+    if (vs) {
+      try {
+        const searchTypes = types || ['summary', 'integration-summary', 'doc', 'file', 'link', 'thread', 'daily-log'];
+        const results = await (vs as Record<string, Function>).search(podId, query, {
+          limit: limit * 2,
+          types: searchTypes,
+          hybrid: true,
+        }) as Array<{ asset_id: string; combinedScore?: number; chunk_text?: string }>;
+
+        if (results && results.length > 0) {
+          const assetIds = [...new Set(results.map((r) => r.asset_id))];
+          const assetsQuery = PodAssetService.applyVisibilityFilter(
+            { _id: { $in: assetIds } },
+            visibilityFilter,
+          );
+          const assets: AssetDoc[] = await PodAsset.find(assetsQuery).lean();
+
+          let tokenCount = 0;
+          const merged: AssetDoc[] = [];
+
+          for (let i = 0; i < results.length; i += 1) {
+            const result = results[i];
+            const asset = assets.find((a) => (
+              String(a._id) === result.asset_id
+              && PodAssetService.isAssetVisible(a, agentContext)
+            ));
+            if (asset) {
+              const assetTokens = ContextAssemblerService.estimateTokens(
+                asset.content?.substring(0, 300) || '',
+              );
+              if (tokenCount + assetTokens > maxTokens && merged.length > 0) break;
+
+              merged.push({
+                ...asset,
+                relevance: result.combinedScore || 0,
+                matchedChunk: result.chunk_text,
+              });
+              tokenCount += assetTokens;
+
+              if (merged.length >= limit) break;
+            }
+          }
+
+          return merged;
+        }
+      } catch (error) {
+        console.error('Vector search error, falling back to keyword:', (error as Error).message);
+      }
+    }
+
+    const searchQuery: Record<string, unknown> = PodAssetService.applyVisibilityFilter(
+      {
+        podId,
+        type: { $nin: ['skill', 'memory'] },
+      },
+      visibilityFilter,
+    );
+
+    if (types) {
+      searchQuery.type = { $in: types };
+    }
+
+    const keywords = query.toLowerCase().split(/\s+/).filter((w) => w.length > 3);
+    if (keywords.length > 0) {
+      searchQuery.$or = [
+        { tags: { $in: keywords } },
+        { title: { $regex: keywords.join('|'), $options: 'i' } },
+        { content: { $regex: keywords.join('|'), $options: 'i' } },
+      ];
+    }
+
+    const assets: AssetDoc[] = await PodAsset.find(searchQuery).sort({ updatedAt: -1 }).limit(limit).lean();
+
+    return assets.map((a) => ({
+      ...a,
+      relevance: ContextAssemblerService.calculateRelevance(a, keywords),
+    }));
+  }
+
+  /**
+   * Get recent summaries for a pod
+   */
+  static async getRecentSummaries(
+    podId: unknown,
+    options: GetRecentSummariesOptions = {},
+  ): Promise<SummaryDoc[]> {
+    const { hours = 24, limit = 5, types = null } = options;
+
+    const since = new Date(Date.now() - hours * 60 * 60 * 1000);
+
+    const query: Record<string, unknown> = {
+      podId,
+      createdAt: { $gte: since },
+      type: { $ne: 'daily-digest' },
+    };
+
+    if (types) {
+      query.type = { $in: types };
+    }
+
+    return Summary.find(query).sort({ createdAt: -1 }).limit(limit).lean();
+  }
+
+  /**
+   * Read a memory file
+   */
+  static async readMemoryFile(
+    podId: unknown,
+    filePath: string,
+    options: ReadMemoryFileOptions = {},
+  ): Promise<string> {
+    const { agentContext = null } = options;
+    const normalizedAgent = PodAssetService.normalizeAgentContext(agentContext);
+
+    if (filePath === 'MEMORY.md') {
+      let asset: AssetDoc | null = null;
+      if (normalizedAgent) {
+        asset = await PodAsset.findOne({
+          podId,
+          type: 'memory',
+          title: 'MEMORY.md',
+          'metadata.scope': 'agent',
+          'metadata.agentName': normalizedAgent.agentName,
+          'metadata.instanceId': normalizedAgent.instanceId,
+        }).lean();
+      }
+      if (!asset) {
+        asset = await PodAsset.findOne({
+          podId,
+          type: 'memory',
+          title: 'MEMORY.md',
+          'metadata.scope': { $ne: 'agent' },
+        }).lean();
+      }
+      return asset?.content || '# Pod Memory\n\nNo curated memory yet.';
+    }
+
+    if (filePath === 'SKILLS.md') {
+      const skillsQuery = PodAssetService.applyVisibilityFilter(
+        { podId, type: 'skill' },
+        PodAssetService.buildAgentScopeFilter(agentContext),
+      );
+      const skills: AssetDoc[] = await PodAsset.find(skillsQuery).sort({ updatedAt: -1 }).lean();
+      return ContextAssemblerService.formatSkillsAsMarkdown(skills);
+    }
+
+    if (filePath === 'CONTEXT.md') {
+      const pod = await Pod.findById(podId).lean() as Record<string, unknown> | null;
+      return ContextAssemblerService.formatContextAsMarkdown(pod);
+    }
+
+    const dateMatch = filePath.match(/^memory\/(\d{4}-\d{2}-\d{2})\.md$/);
+    if (dateMatch) {
+      const date = dateMatch[1];
+      let asset: AssetDoc | null = null;
+      if (normalizedAgent) {
+        asset = await PodAsset.findOne({
+          podId,
+          type: 'daily-log',
+          title: `${date}.md`,
+          'metadata.scope': 'agent',
+          'metadata.agentName': normalizedAgent.agentName,
+          'metadata.instanceId': normalizedAgent.instanceId,
+        }).lean();
+      }
+      if (!asset) {
+        asset = await PodAsset.findOne({
+          podId,
+          type: 'daily-log',
+          title: `${date}.md`,
+          'metadata.scope': { $ne: 'agent' },
+        }).lean();
+      }
+      return asset?.content || `# ${date}\n\nNo activity logged.`;
+    }
+
+    const assetQuery = PodAssetService.applyVisibilityFilter(
+      { podId, title: filePath },
+      PodAssetService.buildAgentScopeFilter(agentContext),
+    );
+    const asset: AssetDoc | null = await PodAsset.findOne(assetQuery).lean();
+
+    if (!asset) {
+      throw new Error(`Memory file not found: ${filePath}`);
+    }
+
+    return asset.content || '';
+  }
+
+  /**
+   * Write to pod memory and index in vector search
+   */
+  static async writeMemory(podId: unknown, options: WriteMemoryOptions): Promise<{ success: boolean; assetId: string }> {
+    const {
+      target, content, tags = [], source = {},
+    } = options;
+    const agentContext = options.agentContext || null;
+    const scope = target === 'memory' ? 'pod' : (options.scope || (agentContext ? 'agent' : 'pod'));
+    const normalizedAgent = PodAssetService.normalizeAgentContext(agentContext as Record<string, unknown>);
+    const metadata = {
+      ...(options.metadata || {}),
+      scope,
+      agentName: normalizedAgent?.agentName,
+      instanceId: normalizedAgent?.instanceId,
+    };
+    const scopeQuery = (() => {
+      if (scope === 'agent' && normalizedAgent) {
+        return {
+          'metadata.scope': 'agent',
+          'metadata.agentName': normalizedAgent.agentName,
+          'metadata.instanceId': normalizedAgent.instanceId,
+        };
+      }
+      if (scope === 'pod') {
+        return {
+          $or: [
+            { 'metadata.scope': 'pod' },
+            { 'metadata.scope': { $exists: false } },
+            { 'metadata.scope': null },
+          ],
+        };
+      }
+      return { 'metadata.scope': { $ne: 'agent' } };
+    })();
+
+    const indexAsset = async (asset: { _id: unknown; [key: string]: unknown }): Promise<void> => {
+      const vs = getVectorSearch();
+      if (vs) {
+        try {
+          await (vs as Record<string, Function>).indexAsset(podId, asset);
+        } catch (e) {
+          console.warn('Failed to index asset in vector search:', (e as Error).message);
+        }
+      }
+    };
+
+    if (target === 'daily') {
+      const today = new Date().toISOString().split('T')[0];
+      const timestamp = new Date().toISOString().split('T')[1].substring(0, 5);
+
+      const dailyQuery = PodAssetService.applyVisibilityFilter(
+        { podId, type: 'daily-log', title: `${today}.md` },
+        scopeQuery,
+      );
+      let asset = await PodAsset.findOne(dailyQuery);
+
+      if (!asset) {
+        asset = new PodAsset({
+          podId,
+          type: 'daily-log',
+          title: `${today}.md`,
+          content: `# ${today}\n\n`,
+          tags: [],
+          metadata,
+          createdByType: normalizedAgent ? 'agent' : 'user',
+        });
+      }
+
+      const entry = `**${timestamp}** ${source.agent ? `(${source.agent})` : ''}\n${content}\n\n`;
+      asset.content += entry;
+      asset.tags = [...new Set([...asset.tags, ...tags])];
+      asset.metadata = { ...(asset.metadata || {}), ...metadata };
+      await asset.save();
+      await indexAsset(asset);
+
+      return { success: true, assetId: String(asset._id) };
+    }
+
+    if (target === 'memory') {
+      const memoryQuery = PodAssetService.applyVisibilityFilter(
+        { podId, type: 'memory', title: 'MEMORY.md' },
+        scopeQuery,
+      );
+      let asset = await PodAsset.findOne(memoryQuery);
+
+      if (!asset) {
+        asset = new PodAsset({
+          podId,
+          type: 'memory',
+          title: 'MEMORY.md',
+          content: '# Pod Memory\n\n',
+          tags: [],
+          metadata,
+          createdByType: normalizedAgent ? 'agent' : 'user',
+        });
+      }
+
+      asset.content = content;
+      asset.tags = [...new Set([...asset.tags, ...tags])];
+      asset.metadata = { ...(asset.metadata || {}), ...metadata };
+      await asset.save();
+      await indexAsset(asset);
+
+      return { success: true, assetId: String(asset._id) };
+    }
+
+    if (target === 'skill') {
+      const asset = new PodAsset({
+        podId,
+        type: 'skill',
+        title: options.title || tags[0] || 'Untitled Skill',
+        content,
+        tags,
+        sourceRef: source,
+      });
+      await asset.save();
+      await indexAsset(asset);
+
+      return { success: true, assetId: String(asset._id) };
+    }
+
+    throw new Error(`Unknown target: ${target}`);
+  }
+
+  /**
+   * Estimate token count for text
+   */
+  static estimateTokens(text: string | null | undefined): number {
+    if (!text) return 0;
+    return Math.ceil(text.length / CHARS_PER_TOKEN);
+  }
+
+  /**
+   * Calculate basic relevance score
+   */
+  static calculateRelevance(asset: AssetDoc, keywords: string[]): number {
+    if (!keywords || keywords.length === 0) return 0.5;
+
+    let score = 0;
+    const titleLower = (asset.title || '').toLowerCase();
+    const contentLower = (asset.content || '').toLowerCase();
+    const tagArr = asset.tags || [];
+
+    keywords.forEach((keyword) => {
+      if (titleLower.includes(keyword)) score += 0.3;
+      if (contentLower.includes(keyword)) score += 0.2;
+      if (tagArr.some((t) => t.toLowerCase().includes(keyword))) score += 0.25;
+    });
+
+    return Math.min(score / keywords.length, 1);
+  }
+
+  /**
+   * Format skills as markdown
+   */
+  static formatSkillsAsMarkdown(skills: AssetDoc[]): string {
+    if (!skills || skills.length === 0) {
+      return '# Pod Skills\n\nNo skills have been derived yet.';
+    }
+
+    let md = '# Pod Skills\n\n';
+    md += `*${skills.length} skills derived from pod activity*\n\n`;
+
+    skills.forEach((skill) => {
+      md += `## ${skill.title}\n\n`;
+      if ((skill.tags || []).length > 0) {
+        md += `**Tags:** ${(skill.tags || []).join(', ')}\n\n`;
+      }
+      if (skill.content) {
+        md += `${skill.content}\n\n`;
+      }
+      md += '---\n\n';
+    });
+
+    return md;
+  }
+
+  /**
+   * Format context as markdown
+   */
+  static formatContextAsMarkdown(pod: Record<string, unknown> | null): string {
+    if (!pod) {
+      return '# Pod Context\n\nPod not found.';
+    }
+
+    let md = `# ${pod.name}\n\n`;
+
+    if (pod.description) {
+      md += `${pod.description}\n\n`;
+    }
+
+    const members = pod.members as unknown[] | undefined;
+    md += `**Type:** ${pod.type}\n`;
+    md += `**Members:** ${members?.length || 0}\n\n`;
+
+    return md;
+  }
+}
+
+export default ContextAssemblerService;

--- a/backend/services/podAssetService.ts
+++ b/backend/services/podAssetService.ts
@@ -1,0 +1,391 @@
+// eslint-disable-next-line global-require
+const PodAsset = require('../models/PodAsset');
+
+const STOP_WORDS = new Set([
+  'about', 'after', 'again', 'against', 'almost', 'also', 'among', 'and',
+  'because', 'been', 'before', 'being', 'between', 'both', 'came', 'could',
+  'each', 'ever', 'from', 'have', 'having', 'into', 'just', 'like', 'made',
+  'make', 'many', 'more', 'most', 'much', 'must', 'only', 'other', 'over',
+  'same', 'some', 'such', 'than', 'that', 'their', 'them', 'then', 'there',
+  'these', 'they', 'this', 'those', 'through', 'time', 'very', 'want', 'were',
+  'what', 'when', 'where', 'which', 'while', 'will', 'with', 'would', 'your',
+]);
+
+interface AgentContextInput {
+  agentName?: string;
+  name?: string;
+  type?: string;
+  instanceId?: string;
+}
+
+interface NormalizedAgentContext {
+  agentName: string;
+  instanceId: string;
+}
+
+interface ScopedSkillKeyOptions {
+  name: string;
+  scope?: string;
+  agentName?: string;
+  instanceId?: string;
+}
+
+interface ChatSummaryInput {
+  _id?: unknown;
+  title?: string;
+  content?: string;
+  type?: string;
+  timeRange?: unknown;
+  metadata?: {
+    topTags?: string[];
+    topUsers?: string[];
+    totalItems?: number;
+    podName?: string;
+  };
+}
+
+interface IntegrationInput {
+  _id?: unknown;
+  podId?: unknown;
+  type?: string;
+}
+
+interface IntegrationSummaryInput {
+  sourceLabel?: string;
+  channelName?: string;
+  content?: string;
+  channelUrl?: string;
+  timeRange?: unknown;
+  messageCount?: number;
+  summaryType?: string;
+  source?: string;
+}
+
+interface SkillAssetInput {
+  podId: unknown;
+  name: string;
+  markdown: string;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+interface ImportedSkillAssetInput extends SkillAssetInput {
+  createdBy?: unknown;
+}
+
+interface ExtractKeywordsOptions {
+  limit?: number;
+}
+
+function truncate(text: string, maxLength = 2000): string {
+  if (!text) return '';
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength - 1)}…`;
+}
+
+function toSkillKey(value: string): string {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return normalized.slice(0, 64);
+}
+
+function tokenize(text: string): string[] {
+  if (!text) return [];
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/g)
+    .map((token) => token.trim())
+    .filter((token) => (
+      token
+      && token.length >= 4
+      && !STOP_WORDS.has(token)
+      && !/^\d+$/.test(token)
+    ));
+}
+
+function countTokens(tokens: string[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  tokens.forEach((token) => {
+    counts.set(token, (counts.get(token) || 0) + 1);
+  });
+  return counts;
+}
+
+function topTokens(counts: Map<string, number>, limit: number): string[] {
+  return [...counts.entries()]
+    .sort((a, b) => {
+      if (b[1] !== a[1]) return b[1] - a[1];
+      return a[0].localeCompare(b[0]);
+    })
+    .slice(0, limit)
+    .map(([token]) => token);
+}
+
+class PodAssetService {
+  static normalizeAgentContext(agentContext: AgentContextInput | null = null): NormalizedAgentContext | null {
+    if (!agentContext || typeof agentContext !== 'object') return null;
+    const rawName = agentContext.agentName || agentContext.name || agentContext.type;
+    if (!rawName) return null;
+    return {
+      agentName: String(rawName).trim().toLowerCase(),
+      instanceId: String(agentContext.instanceId || 'default').trim().toLowerCase(),
+    };
+  }
+
+  static buildAgentScopeFilter(agentContext: AgentContextInput | null = null): Record<string, unknown> {
+    const normalized = PodAssetService.normalizeAgentContext(agentContext);
+    if (!normalized) {
+      return { 'metadata.scope': { $ne: 'agent' } };
+    }
+
+    return {
+      $or: [
+        { 'metadata.scope': { $ne: 'agent' } },
+        {
+          'metadata.scope': 'agent',
+          'metadata.agentName': normalized.agentName,
+          'metadata.instanceId': normalized.instanceId,
+        },
+      ],
+    };
+  }
+
+  static applyVisibilityFilter(
+    query: Record<string, unknown>,
+    visibilityFilter: Record<string, unknown> | null,
+  ): Record<string, unknown> {
+    if (!visibilityFilter) return query;
+    if (!query || typeof query !== 'object') return { $and: [visibilityFilter] };
+    if (Array.isArray(query.$and)) {
+      return { ...query, $and: [...(query.$and as unknown[]), visibilityFilter] };
+    }
+    return { ...query, $and: [visibilityFilter] };
+  }
+
+  static isAssetVisible(asset: Record<string, unknown> | null, agentContext: AgentContextInput | null = null): boolean {
+    if (!asset) return false;
+    const metadata = asset?.metadata as Record<string, unknown> | undefined;
+    const scope = metadata?.scope;
+    if (scope !== 'agent') return true;
+    const normalized = PodAssetService.normalizeAgentContext(agentContext);
+    if (!normalized) return false;
+    return (
+      String(metadata?.agentName || '').toLowerCase() === normalized.agentName
+      && String(metadata?.instanceId || '').toLowerCase() === normalized.instanceId
+    );
+  }
+
+  static extractKeywords(text: string, { limit = 8 }: ExtractKeywordsOptions = {}): string[] {
+    const tokens = tokenize(text);
+    if (!tokens.length) return [];
+    const counts = countTokens(tokens);
+    return topTokens(counts, limit);
+  }
+
+  static normalizeTags(...tagSets: Array<unknown[] | string | undefined | null>): string[] {
+    const merged = (tagSets as unknown[])
+      .flat()
+      .filter(Boolean)
+      .map((tag) => String(tag).trim().toLowerCase())
+      .filter((tag) => tag.length >= 3);
+
+    return [...new Set(merged)];
+  }
+
+  static normalizeSkillKey(name: string): string {
+    return toSkillKey(name || 'skill');
+  }
+
+  static buildScopedSkillKey({
+    name, scope, agentName, instanceId,
+  }: ScopedSkillKeyOptions): string {
+    const base = PodAssetService.normalizeSkillKey(name);
+    if (scope === 'agent' && agentName) {
+      const suffix = [agentName, instanceId || 'default']
+        .map((value) => String(value || '').trim().toLowerCase())
+        .filter(Boolean)
+        .join('-');
+      return PodAssetService.normalizeSkillKey(`${base}-${suffix}`);
+    }
+    return base;
+  }
+
+  static buildSummaryTags(summary: ChatSummaryInput): string[] {
+    const metadataTags = summary?.metadata?.topTags || [];
+    const keywordTags = PodAssetService.extractKeywords(
+      `${summary?.title || ''} ${summary?.content || ''}`,
+    );
+    const topUsers = summary?.metadata?.topUsers || [];
+
+    return PodAssetService.normalizeTags(metadataTags, keywordTags, topUsers);
+  }
+
+  static async createChatSummaryAsset({ podId, summary }: { podId: unknown; summary: ChatSummaryInput }): Promise<unknown> {
+    const tags = PodAssetService.buildSummaryTags(summary);
+    const title = summary?.title || 'Chat Summary';
+
+    const asset = await PodAsset.create({
+      podId,
+      type: 'summary',
+      title,
+      content: truncate(summary?.content || ''),
+      tags,
+      sourceType: 'chat-summary',
+      sourceRef: {
+        summaryId: summary?._id || null,
+      },
+      metadata: {
+        summaryType: summary?.type || 'chats',
+        timeRange: summary?.timeRange || null,
+        totalItems: summary?.metadata?.totalItems || 0,
+        topUsers: summary?.metadata?.topUsers || [],
+        podName: summary?.metadata?.podName || null,
+      },
+      createdByType: 'system',
+      status: 'active',
+    });
+
+    return asset;
+  }
+
+  static async createIntegrationSummaryAsset({
+    integration, summary,
+  }: { integration: IntegrationInput; summary: IntegrationSummaryInput }): Promise<unknown> {
+    const sourceLabel = summary?.sourceLabel || integration?.type || 'External';
+    const channelName = summary?.channelName || 'channel';
+    const title = `${sourceLabel} Summary · ${channelName}`;
+
+    const tags = PodAssetService.normalizeTags(
+      integration?.type,
+      sourceLabel,
+      channelName,
+      PodAssetService.extractKeywords(summary?.content || ''),
+    );
+
+    const asset = await PodAsset.create({
+      podId: integration?.podId,
+      type: 'integration-summary',
+      title,
+      content: truncate(summary?.content || ''),
+      tags,
+      sourceType: `${integration?.type || 'external'}-summary`,
+      sourceRef: {
+        integrationId: integration?._id || null,
+      },
+      metadata: {
+        integrationType: integration?.type || null,
+        integrationId: integration?._id || null,
+        source: summary?.source || integration?.type || 'external',
+        sourceLabel,
+        channelName,
+        channelUrl: summary?.channelUrl || null,
+        timeRange: summary?.timeRange || null,
+        messageCount: summary?.messageCount || 0,
+        summaryType: summary?.summaryType || null,
+      },
+      createdByType: 'system',
+      status: 'active',
+    });
+
+    return asset;
+  }
+
+  static async upsertSkillAsset({
+    podId, name, markdown, tags = [], metadata = {},
+  }: SkillAssetInput): Promise<unknown> {
+    const skillKey = PodAssetService.normalizeSkillKey(name);
+    const title = `Skill: ${name}`;
+    const normalizedTags = PodAssetService.normalizeTags(
+      tags,
+      (metadata as Record<string, unknown>)?.tags as string[],
+      PodAssetService.extractKeywords(name, { limit: 4 }),
+    ).slice(0, 16);
+
+    const nextMetadata = {
+      ...metadata,
+      tags: normalizedTags,
+      skillKey,
+      skillName: name,
+    };
+
+    const asset = await PodAsset.findOneAndUpdate(
+      { podId, type: 'skill', 'metadata.skillKey': skillKey },
+      {
+        $set: {
+          podId,
+          type: 'skill',
+          title,
+          content: truncate(markdown || '', 8000),
+          tags: normalizedTags,
+          sourceType: 'llm-skill',
+          metadata: nextMetadata,
+          createdByType: 'system',
+          status: 'active',
+        },
+      },
+      {
+        new: true,
+        upsert: true,
+        setDefaultsOnInsert: true,
+      },
+    );
+
+    return asset;
+  }
+
+  static async upsertImportedSkillAsset({
+    podId, name, markdown, tags = [], metadata = {}, createdBy,
+  }: ImportedSkillAssetInput): Promise<unknown> {
+    const meta = metadata as Record<string, unknown>;
+    const scope = (meta?.scope as string) || 'pod';
+    const skillKey = PodAssetService.buildScopedSkillKey({
+      name,
+      scope,
+      agentName: meta?.agentName as string,
+      instanceId: meta?.instanceId as string,
+    });
+    const title = `Skill: ${name}`;
+    const normalizedTags = PodAssetService.normalizeTags(
+      tags,
+      meta?.tags as string[],
+      PodAssetService.extractKeywords(name, { limit: 4 }),
+    ).slice(0, 16);
+
+    const nextMetadata = {
+      ...metadata,
+      tags: normalizedTags,
+      skillKey,
+      skillName: name,
+    };
+
+    const asset = await PodAsset.findOneAndUpdate(
+      { podId, type: 'skill', 'metadata.skillKey': skillKey },
+      {
+        $set: {
+          podId,
+          type: 'skill',
+          title,
+          content: truncate(markdown || '', 8000),
+          tags: normalizedTags,
+          sourceType: 'imported-skill',
+          metadata: nextMetadata,
+          createdBy: createdBy || null,
+          createdByType: createdBy ? 'user' : 'system',
+          status: 'active',
+        },
+      },
+      {
+        new: true,
+        upsert: true,
+        setDefaultsOnInsert: true,
+      },
+    );
+
+    return asset;
+  }
+}
+
+export default PodAssetService;

--- a/backend/services/vectorSearchService.ts
+++ b/backend/services/vectorSearchService.ts
@@ -1,0 +1,659 @@
+/**
+ * VectorSearchService
+ *
+ * Provides semantic search over pod knowledge using sqlite-vec.
+ * Each pod gets its own isolated SQLite database with vector indices.
+ */
+
+/* eslint-disable global-require, import/no-unresolved, no-restricted-syntax, no-await-in-loop, no-plusplus, class-methods-use-this */
+
+import path from 'path';
+import fs from 'fs';
+import axios from 'axios';
+
+// Lazy-loaded dependencies (may not be installed yet)
+let Database: (new (path: string) => DatabaseInstance) | null = null;
+let sqliteVec: { load: (db: DatabaseInstance) => void } | null = null;
+
+// Embedding provider configuration
+const EMBEDDING_CONFIG = {
+  provider: process.env.EMBEDDING_PROVIDER || 'gemini',
+  model: process.env.EMBEDDING_MODEL || 'text-embedding-004',
+  dimensions: parseInt(process.env.EMBEDDING_DIMENSIONS || '768', 10),
+  chunkSize: 400,
+  chunkOverlap: 80,
+};
+
+// Data directory for vector databases
+const VECTORS_DIR = path.join(__dirname, '..', 'data', 'vectors');
+
+interface PreparedStatement {
+  all: (...params: unknown[]) => Array<Record<string, unknown>>;
+  run: (...params: unknown[]) => { lastInsertRowid: number };
+  get: () => Record<string, unknown>;
+}
+
+interface DatabaseInstance {
+  exec: (sql: string) => void;
+  prepare: (sql: string) => PreparedStatement;
+  transaction: (fn: () => Promise<void>) => () => Promise<void>;
+  close: () => void;
+}
+
+interface TextChunk {
+  text: string;
+  position: { start: number; end: number };
+}
+
+interface SearchResult {
+  asset_id: string;
+  asset_type: string;
+  chunk_text: string;
+  metadata: string;
+  vectorScore?: number;
+  keywordScore?: number;
+  combinedScore?: number;
+  distance?: number;
+  bm25_score?: number;
+}
+
+interface SearchOptions {
+  limit?: number;
+  types?: string[] | null;
+  hybrid?: boolean;
+  vectorWeight?: number;
+  keywordWeight?: number;
+  keywordOnly?: boolean;
+}
+
+interface IndexResult {
+  success: boolean;
+  chunksIndexed?: number;
+  error?: string;
+}
+
+interface StatsResult {
+  available: boolean;
+  chunks?: number;
+  assets?: number;
+  embeddings?: number;
+}
+
+/**
+ * Initialize dependencies
+ */
+const initDependencies = async (): Promise<boolean> => {
+  if (Database && sqliteVec) return true;
+
+  try {
+    Database = require('better-sqlite3');
+    sqliteVec = require('sqlite-vec');
+    return true;
+  } catch {
+    console.warn('Vector search dependencies not installed. Run: npm install better-sqlite3 sqlite-vec');
+    return false;
+  }
+};
+
+/**
+ * Ensure data directory exists
+ */
+const ensureDataDir = (): void => {
+  if (!fs.existsSync(VECTORS_DIR)) {
+    fs.mkdirSync(VECTORS_DIR, { recursive: true });
+  }
+};
+
+/**
+ * VectorSearchService class - per-pod instance
+ */
+class VectorSearchService {
+  private podId: string;
+
+  private db: DatabaseInstance | null;
+
+  private initialized: boolean;
+
+  constructor(podId: string) {
+    this.podId = podId;
+    this.db = null;
+    this.initialized = false;
+  }
+
+  /**
+   * Initialize the database and schema
+   */
+  async init(): Promise<boolean> {
+    if (this.initialized) return true;
+
+    const depsAvailable = await initDependencies();
+    if (!depsAvailable) {
+      console.warn(`Vector search not available for pod ${this.podId}`);
+      return false;
+    }
+
+    ensureDataDir();
+
+    const dbPath = path.join(VECTORS_DIR, `${this.podId}.sqlite`);
+    this.db = new Database!(dbPath);
+
+    sqliteVec!.load(this.db);
+
+    this.initSchema();
+    this.initialized = true;
+
+    return true;
+  }
+
+  /**
+   * Initialize database schema
+   */
+  initSchema(): void {
+    this.db!.exec(`
+      CREATE TABLE IF NOT EXISTS chunks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        asset_id TEXT NOT NULL,
+        asset_type TEXT NOT NULL,
+        chunk_index INTEGER NOT NULL,
+        chunk_text TEXT NOT NULL,
+        metadata TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(asset_id, chunk_index)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_chunks_asset_id ON chunks(asset_id);
+      CREATE INDEX IF NOT EXISTS idx_chunks_asset_type ON chunks(asset_type);
+    `);
+
+    this.db!.exec(`
+      CREATE VIRTUAL TABLE IF NOT EXISTS chunk_embeddings USING vec0(
+        chunk_id INTEGER PRIMARY KEY,
+        embedding FLOAT[${EMBEDDING_CONFIG.dimensions}]
+      );
+    `);
+
+    this.db!.exec(`
+      CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+        chunk_text,
+        asset_type,
+        content='chunks',
+        content_rowid='id'
+      );
+
+      -- Triggers to keep FTS in sync
+      CREATE TRIGGER IF NOT EXISTS chunks_ai AFTER INSERT ON chunks BEGIN
+        INSERT INTO chunks_fts(rowid, chunk_text, asset_type)
+        VALUES (new.id, new.chunk_text, new.asset_type);
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS chunks_ad AFTER DELETE ON chunks BEGIN
+        INSERT INTO chunks_fts(chunks_fts, rowid, chunk_text, asset_type)
+        VALUES ('delete', old.id, old.chunk_text, old.asset_type);
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS chunks_au AFTER UPDATE ON chunks BEGIN
+        INSERT INTO chunks_fts(chunks_fts, rowid, chunk_text, asset_type)
+        VALUES ('delete', old.id, old.chunk_text, old.asset_type);
+        INSERT INTO chunks_fts(rowid, chunk_text, asset_type)
+        VALUES (new.id, new.chunk_text, new.asset_type);
+      END;
+    `);
+  }
+
+  /**
+   * Index an asset (chunk and embed)
+   */
+  async indexAsset(asset: {
+    _id: unknown;
+    type?: string;
+    title?: string;
+    content?: string;
+    tags?: string[];
+  }): Promise<IndexResult> {
+    if (!this.initialized) await this.init();
+    if (!this.db) return { success: false, error: 'Database not available' };
+
+    const {
+      _id, type, title = '', content = '', tags = [],
+    } = asset;
+    const assetId = String(_id);
+
+    await this.removeAsset(assetId);
+
+    const chunks = this.chunkText(content, title);
+
+    const insertChunk = this.db.prepare(`
+      INSERT INTO chunks (asset_id, asset_type, chunk_index, chunk_text, metadata)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+
+    const insertEmbedding = this.db.prepare(`
+      INSERT INTO chunk_embeddings (chunk_id, embedding)
+      VALUES (?, ?)
+    `);
+
+    const transaction = this.db.transaction(async () => {
+      for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i];
+
+        const result = insertChunk.run(
+          assetId,
+          type,
+          i,
+          chunk.text,
+          JSON.stringify({ title, tags, position: chunk.position }),
+        );
+
+        const embedding = await this.embed(chunk.text);
+        if (embedding) {
+          insertEmbedding.run(result.lastInsertRowid, new Float32Array(embedding));
+        }
+      }
+    });
+
+    try {
+      await transaction();
+      return { success: true, chunksIndexed: chunks.length };
+    } catch (error) {
+      console.error(`Error indexing asset ${assetId}:`, error);
+      return { success: false, error: (error as Error).message };
+    }
+  }
+
+  /**
+   * Remove an asset from the index
+   */
+  async removeAsset(assetId: string): Promise<void> {
+    if (!this.db) return;
+
+    const chunks = this.db.prepare('SELECT id FROM chunks WHERE asset_id = ?').all(assetId);
+    const deleteEmbedding = this.db.prepare('DELETE FROM chunk_embeddings WHERE chunk_id = ?');
+    for (const chunk of chunks) {
+      deleteEmbedding.run(chunk.id);
+    }
+
+    this.db.prepare('DELETE FROM chunks WHERE asset_id = ?').run(assetId);
+  }
+
+  /**
+   * Hybrid search: vector + keyword
+   */
+  async search(query: string, options: SearchOptions = {}): Promise<SearchResult[]> {
+    if (!this.initialized) await this.init();
+    if (!this.db) {
+      return this.keywordSearchFallback(query, options);
+    }
+
+    const {
+      limit = 10,
+      types = null,
+      hybrid = true,
+      vectorWeight = 0.7,
+      keywordWeight = 0.3,
+    } = options;
+
+    const results = new Map<string, SearchResult>();
+
+    if (hybrid || !options.keywordOnly) {
+      const queryEmbedding = await this.embed(query);
+      if (queryEmbedding) {
+        const vectorResults = this.vectorSearch(queryEmbedding, limit * 2, types);
+        for (const result of vectorResults) {
+          results.set(result.asset_id, {
+            ...result,
+            vectorScore: result.distance,
+            keywordScore: 0,
+          });
+        }
+      }
+    }
+
+    if (hybrid || options.keywordOnly) {
+      const keywordResults = this.keywordSearch(query, limit * 2, types);
+      for (const result of keywordResults) {
+        if (results.has(result.asset_id)) {
+          results.get(result.asset_id)!.keywordScore = result.bm25_score;
+        } else {
+          results.set(result.asset_id, {
+            ...result,
+            vectorScore: 0,
+            keywordScore: result.bm25_score,
+          });
+        }
+      }
+    }
+
+    const combined = Array.from(results.values()).map((r) => ({
+      ...r,
+      combinedScore: (r.vectorScore || 0) * vectorWeight + (r.keywordScore || 0) * keywordWeight,
+    }));
+
+    combined.sort((a, b) => (b.combinedScore || 0) - (a.combinedScore || 0));
+    return combined.slice(0, limit);
+  }
+
+  /**
+   * Vector similarity search
+   */
+  vectorSearch(queryEmbedding: number[], limit: number, types: string[] | null = null): SearchResult[] {
+    let sql = `
+      SELECT
+        c.asset_id,
+        c.asset_type,
+        c.chunk_text,
+        c.metadata,
+        vec_distance_cosine(e.embedding, ?) as distance
+      FROM chunk_embeddings e
+      JOIN chunks c ON c.id = e.chunk_id
+    `;
+
+    const params: unknown[] = [new Float32Array(queryEmbedding)];
+
+    if (types && types.length > 0) {
+      sql += ` WHERE c.asset_type IN (${types.map(() => '?').join(',')})`;
+      params.push(...types);
+    }
+
+    sql += ' ORDER BY distance ASC LIMIT ?';
+    params.push(limit);
+
+    try {
+      return this.db!.prepare(sql).all(...params) as SearchResult[];
+    } catch (error) {
+      console.error('Vector search error:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Keyword search using FTS5 BM25
+   */
+  keywordSearch(query: string, limit: number, types: string[] | null = null): SearchResult[] {
+    const escapedQuery = query.replace(/['"]/g, '').trim();
+
+    let sql = `
+      SELECT
+        c.asset_id,
+        c.asset_type,
+        c.chunk_text,
+        c.metadata,
+        bm25(chunks_fts) as bm25_score
+      FROM chunks_fts
+      JOIN chunks c ON c.id = chunks_fts.rowid
+      WHERE chunks_fts MATCH ?
+    `;
+
+    const params: unknown[] = [escapedQuery];
+
+    if (types && types.length > 0) {
+      sql += ` AND c.asset_type IN (${types.map(() => '?').join(',')})`;
+      params.push(...types);
+    }
+
+    sql += ' ORDER BY bm25_score LIMIT ?';
+    params.push(limit);
+
+    try {
+      return this.db!.prepare(sql).all(...params) as SearchResult[];
+    } catch (error) {
+      console.error('Keyword search error:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Fallback keyword search when vector DB not available
+   */
+  async keywordSearchFallback(query: string, options: SearchOptions): Promise<SearchResult[]> {
+    // eslint-disable-next-line global-require
+    const PodAsset = require('../models/PodAsset');
+
+    const filter: Record<string, unknown> = {
+      podId: this.podId,
+      $text: { $search: query },
+    };
+
+    if (options.types) {
+      filter.type = { $in: options.types };
+    }
+
+    const results = await PodAsset.find(filter, { score: { $meta: 'textScore' } })
+      .sort({ score: { $meta: 'textScore' } })
+      .limit(options.limit || 10)
+      .lean() as Array<Record<string, unknown>>;
+
+    return results.map((r) => ({
+      asset_id: String(r._id),
+      asset_type: r.type as string,
+      chunk_text: (r.content as string)?.substring(0, 500),
+      metadata: JSON.stringify({ title: r.title, tags: r.tags }),
+      combinedScore: r.score as number,
+    }));
+  }
+
+  /**
+   * Chunk text into overlapping segments
+   */
+  chunkText(text: string, title = ''): TextChunk[] {
+    if (!text) return [];
+
+    const words = text.split(/\s+/);
+    const chunks: TextChunk[] = [];
+    const { chunkSize } = EMBEDDING_CONFIG;
+    const overlap = EMBEDDING_CONFIG.chunkOverlap;
+
+    const titlePrefix = title ? `${title}: ` : '';
+
+    for (let i = 0; i < words.length; i += chunkSize - overlap) {
+      const chunkWords = words.slice(i, i + chunkSize);
+      const isFirst = i === 0;
+
+      chunks.push({
+        text: (isFirst ? titlePrefix : '') + chunkWords.join(' '),
+        position: { start: i, end: Math.min(i + chunkSize, words.length) },
+      });
+
+      if (i + chunkSize >= words.length) break;
+    }
+
+    return chunks;
+  }
+
+  /**
+   * Get embedding for text
+   */
+  async embed(text: string): Promise<number[] | null> {
+    if (!text || text.trim().length === 0) return null;
+
+    try {
+      switch (EMBEDDING_CONFIG.provider) {
+        case 'gemini':
+          return await this.embedWithGemini(text);
+        case 'openai':
+          return await this.embedWithOpenAI(text);
+        case 'litellm':
+          return await this.embedWithLiteLLM(text);
+        default:
+          console.warn(`Unknown embedding provider: ${EMBEDDING_CONFIG.provider}`);
+          return null;
+      }
+    } catch (error) {
+      console.error('Embedding error:', error);
+      return null;
+    }
+  }
+
+  async embedWithGemini(text: string): Promise<number[]> {
+    // eslint-disable-next-line global-require
+    const { GoogleGenerativeAI } = require('@google/generative-ai');
+    const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+
+    const model = genAI.getGenerativeModel({ model: EMBEDDING_CONFIG.model });
+    const result = await model.embedContent(text);
+
+    return result.embedding.values as number[];
+  }
+
+  async embedWithOpenAI(text: string): Promise<number[]> {
+    // eslint-disable-next-line global-require
+    const OpenAI = require('openai');
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+    const response = await openai.embeddings.create({
+      model: EMBEDDING_CONFIG.model,
+      input: text,
+    });
+
+    return response.data[0].embedding as number[];
+  }
+
+  async embedWithLiteLLM(text: string): Promise<number[]> {
+    const baseUrl = process.env.LITELLM_BASE_URL;
+    const apiKey = process.env.LITELLM_API_KEY || process.env.LITELLM_MASTER_KEY;
+    if (!baseUrl || !apiKey) {
+      throw new Error('LiteLLM embedding requires LITELLM_BASE_URL + LITELLM_API_KEY');
+    }
+
+    const response = await axios.post<{ data: Array<{ embedding: number[] }> }>(
+      `${baseUrl.replace(/\/$/, '')}/embeddings`,
+      {
+        model: EMBEDDING_CONFIG.model,
+        input: text,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    const embedding = response?.data?.data?.[0]?.embedding;
+    if (!embedding) {
+      throw new Error('LiteLLM embedding response missing embedding vector');
+    }
+    return embedding;
+  }
+
+  /**
+   * Get statistics for this pod's vector index
+   */
+  getStats(): StatsResult {
+    if (!this.db) return { available: false };
+
+    const chunkCount = this.db.prepare('SELECT COUNT(*) as count FROM chunks').get();
+    const assetCount = this.db.prepare('SELECT COUNT(DISTINCT asset_id) as count FROM chunks').get();
+    const embeddingCount = this.db.prepare('SELECT COUNT(*) as count FROM chunk_embeddings').get();
+
+    return {
+      available: true,
+      chunks: chunkCount.count as number,
+      assets: assetCount.count as number,
+      embeddings: embeddingCount.count as number,
+    };
+  }
+
+  /**
+   * Close database connection
+   */
+  close(): void {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+      this.initialized = false;
+    }
+  }
+}
+
+// Cache of VectorSearchService instances per pod
+const serviceCache = new Map<string, VectorSearchService>();
+
+const getServiceForPod = async (podId: unknown): Promise<VectorSearchService> => {
+  const podIdStr = String(podId);
+
+  if (!serviceCache.has(podIdStr)) {
+    const service = new VectorSearchService(podIdStr);
+    await service.init();
+    serviceCache.set(podIdStr, service);
+  }
+
+  return serviceCache.get(podIdStr)!;
+};
+
+const indexAsset = async (
+  podId: unknown,
+  asset: Parameters<VectorSearchService['indexAsset']>[0],
+): Promise<IndexResult> => {
+  const service = await getServiceForPod(podId);
+  return service.indexAsset(asset);
+};
+
+const removeAsset = async (podId: unknown, assetId: string): Promise<void> => {
+  const service = await getServiceForPod(podId);
+  return service.removeAsset(assetId);
+};
+
+const search = async (
+  podId: unknown,
+  query: string,
+  options: SearchOptions = {},
+): Promise<SearchResult[]> => {
+  const service = await getServiceForPod(podId);
+  return service.search(query, options);
+};
+
+const getStats = async (podId: unknown): Promise<StatsResult> => {
+  const service = await getServiceForPod(podId);
+  return service.getStats();
+};
+
+const resetIndex = async (podId: unknown): Promise<{ success: boolean }> => {
+  const podIdStr = String(podId);
+  const service = serviceCache.get(podIdStr);
+  if (service) {
+    service.close();
+    serviceCache.delete(podIdStr);
+  }
+
+  const dbPath = path.join(VECTORS_DIR, `${podIdStr}.sqlite`);
+  if (fs.existsSync(dbPath)) {
+    fs.unlinkSync(dbPath);
+  }
+
+  return { success: true };
+};
+
+const rebuildIndex = async (podId: unknown): Promise<{ indexed: number; errors: number; total: number }> => {
+  // eslint-disable-next-line global-require
+  const PodAsset = require('../models/PodAsset');
+  const service = await getServiceForPod(podId);
+
+  const assets = await PodAsset.find({ podId }).lean() as Array<Record<string, unknown>>;
+
+  let indexed = 0;
+  let errors = 0;
+
+  for (const asset of assets) {
+    // eslint-disable-next-line no-await-in-loop
+    const result = await service.indexAsset(asset as Parameters<VectorSearchService['indexAsset']>[0]);
+    if (result.success) {
+      indexed++;
+    } else {
+      errors++;
+    }
+  }
+
+  return { indexed, errors, total: assets.length };
+};
+
+export {
+  VectorSearchService,
+  getServiceForPod,
+  indexAsset,
+  removeAsset,
+  search,
+  getStats,
+  resetIndex,
+  rebuildIndex,
+  EMBEDDING_CONFIG,
+};


### PR DESCRIPTION
## Summary

- `podAssetService.ts` — Skill/summary/integration-summary asset CRUD, scope filtering, and keyword extraction
- `contextAssemblerService.ts` — Token-budgeted context assembly with memory R/W and hybrid search
- `vectorSearchService.ts` — Per-pod sqlite-vec hybrid search with Gemini/OpenAI/LiteLLM embedding support

Part of issue #118. JS originals untouched.

## Test plan
- [ ] `Test & Coverage` passes (tsc + jest)

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)