### PR TITLE
feat(ts): migrate podSkillService + agentWebSocketService to TypeScript (batch 9)

### DIFF
--- a/backend/services/agentWebSocketService.ts
+++ b/backend/services/agentWebSocketService.ts
@@ -1,0 +1,408 @@
+// eslint-disable-next-line global-require
+const jwt = require('jsonwebtoken');
+// eslint-disable-next-line global-require
+const AgentEventService = require('./agentEventService');
+// eslint-disable-next-line global-require
+const { AgentInstallation } = require('../models/AgentRegistry');
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
+// eslint-disable-next-line global-require
+const User = require('../models/User');
+// eslint-disable-next-line global-require
+const { hash } = require('../utils/secret');
+
+interface AgentSocket {
+  agentName: string;
+  instanceId: string;
+  agentUserId: string | null;
+  agentKey: string;
+  subscribedPods: Set<string>;
+  handshake: { auth?: { token?: string } };
+  join(room: string): void;
+  leave(room: string): void;
+  emit(event: string, data?: unknown): void;
+  on(event: string, handler: (...args: unknown[]) => void): void;
+  connected: boolean;
+}
+
+interface AgentNamespace {
+  use(fn: (socket: AgentSocket, next: (err?: Error) => void) => void): void;
+  on(event: string, handler: (socket: AgentSocket) => void): void;
+  to(room: string): { emit(event: string, data?: unknown): void };
+  emit(event: string, data?: unknown): void;
+}
+
+interface IoServer {
+  of(namespace: string): AgentNamespace;
+}
+
+interface ConnectedAgentData {
+  socket: AgentSocket;
+  lastPong: number;
+}
+
+interface AgentTokenInfo {
+  agentName: string;
+  instanceId: string;
+  agentUserId?: string;
+  podId?: unknown;
+}
+
+interface AgentEvent {
+  _id?: unknown;
+  type?: string;
+  agentName: string;
+  instanceId?: string;
+  podId?: unknown;
+  payload?: { trigger?: string };
+}
+
+interface AgentUserDoc {
+  _id?: unknown;
+  username?: string;
+  isBot?: boolean;
+  botMetadata?: Record<string, unknown>;
+  agentRuntimeTokens?: Array<{ tokenHash: string; lastUsedAt?: Date }>;
+}
+
+interface InstallationDoc {
+  _id?: unknown;
+  agentName: string;
+  instanceId?: string;
+  podId?: unknown;
+  status?: string;
+  runtimeTokens?: Array<{ tokenHash: string; lastUsedAt?: Date }>;
+}
+
+const normalizeTokenIdentityValue = (value: unknown): string => (
+  String(value || '').trim().toLowerCase()
+);
+
+const deriveInstanceIdFromUsername = (agentName: string, username: string): string | null => {
+  const normalizedAgent = normalizeTokenIdentityValue(agentName);
+  const normalizedUsername = normalizeTokenIdentityValue(username);
+  if (!normalizedAgent || !normalizedUsername) return null;
+  if (normalizedUsername === normalizedAgent) return 'default';
+  const prefix = `${normalizedAgent}-`;
+  if (normalizedUsername.startsWith(prefix)) {
+    const suffix = normalizedUsername.slice(prefix.length).trim();
+    return suffix || null;
+  }
+  return null;
+};
+
+const resolveTokenAgentIdentity = (agentUser: AgentUserDoc): { agentName: string; instanceId: string } => {
+  const meta = (agentUser?.botMetadata || {}) as Record<string, unknown>;
+  const username = normalizeTokenIdentityValue(agentUser?.username);
+  const agentName = normalizeTokenIdentityValue(meta.agentName || meta.agentType || username);
+
+  const metadataInstanceId = normalizeTokenIdentityValue(meta.instanceId);
+  const usernameInstanceId = deriveInstanceIdFromUsername(agentName, username);
+  let instanceId = metadataInstanceId || usernameInstanceId || 'default';
+  if (usernameInstanceId && (!metadataInstanceId || metadataInstanceId === 'default')) {
+    instanceId = usernameInstanceId;
+  }
+
+  return { agentName, instanceId };
+};
+
+class AgentWebSocketService {
+  private io: IoServer | null;
+
+  private agentNamespace: AgentNamespace | null;
+
+  private connectedAgents: Map<string, ConnectedAgentData>;
+
+  private pingInterval: NodeJS.Timeout | null;
+
+  constructor() {
+    this.io = null;
+    this.agentNamespace = null;
+    this.connectedAgents = new Map();
+    this.pingInterval = null;
+  }
+
+  init(io: IoServer): void {
+    this.io = io;
+    this.agentNamespace = io.of('/agents');
+
+    this.agentNamespace.use(async (socket, next) => {
+      try {
+        const token = socket.handshake.auth?.token;
+        if (!token) {
+          return next(new Error('Authentication required'));
+        }
+
+        const agentInfo = await this.validateAgentToken(token);
+        if (!agentInfo) {
+          return next(new Error('Invalid agent token'));
+        }
+
+        socket.agentName = agentInfo.agentName;
+        socket.instanceId = agentInfo.instanceId || 'default';
+        socket.agentUserId = agentInfo.agentUserId || null;
+        socket.agentKey = `${socket.agentName}:${socket.instanceId}`;
+        socket.subscribedPods = new Set();
+
+        return next();
+      } catch (err) {
+        return next(new Error(`Authentication failed: ${(err as Error).message}`));
+      }
+    });
+
+    this.agentNamespace.on('connection', (socket) => {
+      console.log(`[agent-ws] Agent connected: ${socket.agentKey}`);
+
+      this.connectedAgents.set(socket.agentKey, {
+        socket,
+        lastPong: Date.now(),
+      });
+
+      socket.join(`agent:${socket.agentKey}`);
+
+      this.replayPendingEvents(socket);
+
+      socket.on('subscribe', (payload: unknown) => {
+        const { podIds } = payload as { podIds?: unknown[] };
+        if (!Array.isArray(podIds)) return;
+
+        podIds.forEach((podId) => {
+          socket.join(`pod:${podId}`);
+          socket.subscribedPods.add(String(podId));
+        });
+
+        console.log(`[agent-ws] ${socket.agentKey} subscribed to ${podIds.length} pods`);
+      });
+
+      socket.on('unsubscribe', (payload: unknown) => {
+        const { podIds } = payload as { podIds?: unknown[] };
+        if (!Array.isArray(podIds)) return;
+
+        podIds.forEach((podId) => {
+          socket.leave(`pod:${podId}`);
+          socket.subscribedPods.delete(String(podId));
+        });
+      });
+
+      socket.on('pong', () => {
+        const data = this.connectedAgents.get(socket.agentKey);
+        if (data) {
+          data.lastPong = Date.now();
+        }
+      });
+
+      socket.on('ack', async (payload: unknown) => {
+        const { eventId } = payload as { eventId?: string };
+        if (!eventId) return;
+
+        try {
+          await AgentEventService.acknowledge(eventId, socket.agentName, socket.instanceId);
+          console.log(`[agent-ws] Ack received from ${socket.agentKey} for event ${eventId}`);
+          socket.emit('ack:success', { eventId });
+        } catch (err) {
+          console.warn(`[agent-ws] Ack failed from ${socket.agentKey} for event ${eventId}: ${(err as Error).message}`);
+          socket.emit('ack:error', { eventId, error: (err as Error).message });
+        }
+      });
+
+      socket.on('disconnect', (reason: unknown) => {
+        console.log(`[agent-ws] Agent disconnected: ${socket.agentKey} (${reason})`);
+        this.connectedAgents.delete(socket.agentKey);
+      });
+
+      socket.emit('connected', {
+        agentName: socket.agentName,
+        instanceId: socket.instanceId,
+        message: 'Connected to Commonly agent WebSocket',
+      });
+    });
+
+    this.startPingInterval();
+
+    console.log('[agent-ws] Agent WebSocket namespace initialized on /agents');
+  }
+
+  async replayPendingEvents(socket: AgentSocket, limit = 50): Promise<void> {
+    try {
+      const installations = await AgentInstallation.find({
+        agentName: socket.agentName.toLowerCase(),
+        instanceId: socket.instanceId || 'default',
+        status: 'active',
+      }).select('podId').lean() as Array<{ podId?: unknown }>;
+
+      const installationPodIds = Array.from(
+        new Set(
+          (installations || [])
+            .map((installation) => installation?.podId?.toString())
+            .filter(Boolean) as string[],
+        ),
+      );
+
+      let dmPodIds: string[] = [];
+      if (socket.agentUserId) {
+        const dmPods = await Pod.find({
+          type: 'agent-admin',
+          members: socket.agentUserId,
+        }).select('_id').lean() as Array<{ _id?: unknown }>;
+        dmPodIds = dmPods.map((pod) => pod?._id?.toString()).filter(Boolean) as string[];
+      }
+      const podIds = Array.from(new Set([...installationPodIds, ...dmPodIds]));
+
+      if (!podIds.length) return;
+
+      const events = await AgentEventService.list({
+        agentName: socket.agentName,
+        instanceId: socket.instanceId || 'default',
+        podIds,
+        limit,
+      }) as AgentEvent[];
+
+      if (!events.length) return;
+
+      events.forEach((event) => {
+        socket.emit('event', event);
+      });
+
+      console.log(`[agent-ws] Replayed ${events.length} pending event(s) for ${socket.agentKey}`);
+    } catch (error) {
+      console.warn(`[agent-ws] Failed to replay pending events for ${socket?.agentKey}: ${(error as Error).message}`);
+    }
+  }
+
+  startPingInterval(): void {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval);
+    }
+
+    this.pingInterval = setInterval(() => {
+      const now = Date.now();
+      const staleThreshold = 90000;
+
+      this.connectedAgents.forEach((data, agentKey) => {
+        const { socket, lastPong } = data;
+
+        if (now - lastPong > staleThreshold) {
+          console.log(`[agent-ws] Stale connection detected: ${agentKey} (last pong ${Math.round((now - lastPong) / 1000)}s ago)`);
+        }
+
+        if (socket?.connected) {
+          socket.emit('ping');
+        }
+      });
+    }, 30000);
+  }
+
+  stopPingInterval(): void {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval);
+      this.pingInterval = null;
+    }
+  }
+
+  async validateAgentToken(token: string): Promise<AgentTokenInfo | null> {
+    if (token.startsWith('cm_agent_')) {
+      try {
+        const tokenHash = hash(token);
+        const agentUser = await User.findOne({
+          'agentRuntimeTokens.tokenHash': tokenHash,
+          isBot: true,
+        }) as AgentUserDoc | null;
+
+        if (agentUser) {
+          try {
+            await User.updateOne(
+              { _id: agentUser._id, 'agentRuntimeTokens.tokenHash': tokenHash },
+              { $set: { 'agentRuntimeTokens.$.lastUsedAt': new Date() } },
+            );
+          } catch (err) {
+            console.warn('Failed to update agent token usage on User:', (err as Error).message);
+          }
+
+          const { agentName, instanceId } = resolveTokenAgentIdentity(agentUser);
+
+          if (agentName) {
+            return { agentName, instanceId, agentUserId: String(agentUser._id || '') };
+          }
+        }
+
+        const installation = await AgentInstallation.findOne({
+          'runtimeTokens.tokenHash': tokenHash,
+          status: 'active',
+        }) as InstallationDoc | null;
+
+        if (installation) {
+          try {
+            await AgentInstallation.updateOne(
+              { _id: installation._id, 'runtimeTokens.tokenHash': tokenHash },
+              { $set: { 'runtimeTokens.$.lastUsedAt': new Date() } },
+            );
+          } catch (err) {
+            console.warn('Failed to update agent token usage:', (err as Error).message);
+          }
+
+          return {
+            agentName: installation.agentName,
+            instanceId: installation.instanceId || 'default',
+            podId: installation.podId,
+          };
+        }
+      } catch {
+        // Continue to JWT validation
+      }
+    }
+
+    try {
+      const decoded = jwt.verify(token, process.env.JWT_SECRET) as Record<string, unknown>;
+      if (decoded.agentName) {
+        return {
+          agentName: String(decoded.agentName),
+          instanceId: String(decoded.instanceId || 'default'),
+        };
+      }
+    } catch {
+      // Token invalid
+    }
+
+    return null;
+  }
+
+  pushEvent(event: AgentEvent): boolean {
+    if (!this.agentNamespace) return false;
+
+    const agentKey = `${event.agentName}:${event.instanceId || 'default'}`;
+
+    this.agentNamespace.to(`agent:${agentKey}`).emit('event', event);
+
+    if (event.podId) {
+      this.agentNamespace.to(`pod:${String(event.podId)}`).emit('event', event);
+    }
+
+    console.log(
+      `[agent-ws] Event pushed id=${event?._id || 'n/a'} type=${event?.type || 'n/a'} `
+      + `agent=${agentKey} pod=${event?.podId || 'n/a'} trigger=${event?.payload?.trigger || 'n/a'}`,
+    );
+
+    return true;
+  }
+
+  isAgentConnected(agentName: string, instanceId = 'default'): boolean {
+    return this.connectedAgents.has(`${agentName}:${instanceId}`);
+  }
+
+  getConnectedCount(): number {
+    return this.connectedAgents.size;
+  }
+
+  getConnectedAgents(): string[] {
+    return Array.from(this.connectedAgents.keys());
+  }
+
+  broadcast(eventName: string, data?: unknown): void {
+    if (!this.agentNamespace) return;
+    this.agentNamespace.emit(eventName, data);
+  }
+}
+
+const agentWebSocketService = new AgentWebSocketService();
+
+export default agentWebSocketService;

--- a/backend/services/podSkillService.ts
+++ b/backend/services/podSkillService.ts
@@ -1,0 +1,386 @@
+// eslint-disable-next-line global-require
+const PodAssetService = require('./podAssetService');
+// eslint-disable-next-line global-require
+const { generateText } = require('./llmService');
+
+const MODEL_NAME = 'gemini-2.5-flash';
+const MAX_REFERENCES = 14;
+
+interface ReferenceEntry {
+  refId: string;
+  type: string;
+  id: unknown;
+  title: string;
+  createdAt: unknown;
+  tags: string[];
+  content: string;
+}
+
+interface SummaryLike {
+  _id?: unknown;
+  title?: string;
+  createdAt?: unknown;
+  tags?: string[];
+  content?: string;
+}
+
+interface AssetLike {
+  _id?: unknown;
+  type?: string;
+  title?: string;
+  createdAt?: unknown;
+  tags?: string[];
+  content?: string;
+}
+
+interface PodDescriptor {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+interface RawSkill {
+  name?: unknown;
+  summary?: unknown;
+  whenToUse?: unknown;
+  steps?: unknown[];
+  tags?: unknown[];
+  references?: unknown[];
+}
+
+interface NormalizedSkill {
+  name: string;
+  summary: string;
+  whenToUse: string;
+  steps: string[];
+  tags: string[];
+}
+
+interface GenerateSkillsResult {
+  skills: RawSkill[];
+  warnings: string[];
+}
+
+interface SynthesizeSkillsOptions {
+  pod: PodDescriptor;
+  task?: string | null;
+  summaries?: SummaryLike[];
+  assets?: AssetLike[];
+  skillLimit?: number;
+  taskTokens?: Set<string>;
+}
+
+interface SynthesizeSkillsResult {
+  skills: unknown[];
+  warnings: string[];
+}
+
+function safeDate(value: unknown): Date | null {
+  const date = new Date(value as string | number);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function recencyBoost(dateValue: unknown): number {
+  const date = safeDate(dateValue);
+  if (!date) return 0;
+  const diffDays = (Date.now() - date.getTime()) / (1000 * 60 * 60 * 24);
+  if (diffDays <= 1) return 3;
+  if (diffDays <= 3) return 2;
+  if (diffDays <= 7) return 1.5;
+  if (diffDays <= 30) return 1;
+  return 0.25;
+}
+
+function extractJson(text: string | null): Record<string, unknown> | null {
+  if (!text) return null;
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) return null;
+  const candidate = text.slice(start, end + 1);
+  try {
+    return JSON.parse(candidate) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeText(value: unknown, fallback = ''): string {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || fallback;
+  }
+  return fallback;
+}
+
+function normalizeList(value: unknown, { limit = 8 } = {}): string[] {
+  if (!Array.isArray(value)) return [];
+  return (value as unknown[])
+    .map((item) => normalizeText(item))
+    .filter(Boolean)
+    .slice(0, limit);
+}
+
+function buildReferenceEntries({
+  summaries = [], assets = [],
+}: { summaries?: SummaryLike[]; assets?: AssetLike[] }): ReferenceEntry[] {
+  const summaryEntries: ReferenceEntry[] = summaries.map((summary, index) => ({
+    refId: `S${index + 1}`,
+    type: 'summary',
+    id: summary._id,
+    title: summary.title || 'Untitled summary',
+    createdAt: summary.createdAt,
+    tags: summary.tags || [],
+    content: summary.content || '',
+  }));
+
+  const assetEntries: ReferenceEntry[] = assets.map((asset, index) => ({
+    refId: `A${index + 1}`,
+    type: asset.type || 'asset',
+    id: asset._id,
+    title: asset.title || 'Untitled asset',
+    createdAt: asset.createdAt,
+    tags: asset.tags || [],
+    content: asset.content || '',
+  }));
+
+  return [...summaryEntries, ...assetEntries]
+    .filter((entry) => entry.content || entry.title)
+    .slice(0, MAX_REFERENCES);
+}
+
+function referenceEntriesToPrompt(referenceEntries: ReferenceEntry[]): string {
+  return referenceEntries
+    .map((entry) => {
+      const createdAt = safeDate(entry.createdAt);
+      const dateLabel = createdAt ? createdAt.toISOString() : 'unknown-date';
+      const tags = (entry.tags || []).slice(0, 8).join(', ');
+      const content = normalizeText(entry.content).slice(0, 800);
+      return [
+        `${entry.refId} | ${entry.type} | ${entry.title} | ${dateLabel}`,
+        `Tags: ${tags || 'none'}`,
+        `Content: ${content || 'n/a'}`,
+      ].join('\n');
+    })
+    .join('\n\n');
+}
+
+function buildSkillPrompt({
+  pod, task, referenceEntries, skillLimit,
+}: {
+  pod: PodDescriptor;
+  task?: string | null;
+  referenceEntries: ReferenceEntry[];
+  skillLimit: number;
+}): string {
+  const referencesBlock = referenceEntriesToPrompt(referenceEntries);
+  const taskLine = task ? `Task focus: ${task}` : 'Task focus: general pod memory';
+
+  return `You are synthesizing a SMALL set of reusable skills for an AI agent working inside a pod.
+
+Pod: ${pod.name}
+Description: ${pod.description || 'n/a'}
+${taskLine}
+
+You are given pod references. Each reference has a stable refId like S1 or A2.
+Use those refIds in your references output.
+
+Pod references:
+${referencesBlock}
+
+Return STRICT JSON only, with this shape:
+{
+  "skills": [
+    {
+      "name": "short skill name",
+      "summary": "1-2 sentence TL;DR",
+      "whenToUse": "when this applies",
+      "steps": ["step 1", "step 2"],
+      "references": ["S1", "A2"],
+      "tags": ["tag-a", "tag-b"]
+    }
+  ]
+}
+
+Constraints:
+- Generate between 2 and ${skillLimit} skills.
+- Prefer durable team knowledge, procedures, checklists, and decision rules.
+- Avoid filler words, greetings, and generic chat artifacts.
+- Avoid using people's names as skill names unless essential.
+- Every skill should cite 1-4 references by refId.
+- Skills should be distinct and non-overlapping.`;
+}
+
+function resolveReferences(
+  referenceIds: unknown,
+  referenceMap: Map<string, ReferenceEntry>,
+): { validIds: string[]; references: ReferenceEntry[] } {
+  const ids: unknown[] = Array.isArray(referenceIds) ? referenceIds : [];
+  const validIds = (ids as string[]).filter((refId) => referenceMap.has(refId));
+  const references = validIds.map((refId) => referenceMap.get(refId)!);
+  return { validIds, references };
+}
+
+function scoreSkill(
+  skill: { name: string; tags: string[]; steps: string[] },
+  references: ReferenceEntry[],
+  taskTokens: Set<string>,
+): number {
+  const latestRefDate = references
+    .map((ref) => safeDate(ref.createdAt))
+    .filter((d): d is Date => d !== null)
+    .sort((a, b) => b.getTime() - a.getTime())[0];
+
+  const referenceScore = references.length * 3;
+  const stepsScore = (skill.steps || []).length;
+  const recencyScore = recencyBoost(latestRefDate);
+
+  const nameTokens: string[] = PodAssetService.extractKeywords(skill.name || '', { limit: 6 });
+  const tagTokens = (skill.tags || []).map((tag) => String(tag).toLowerCase());
+  const taskMatchCount = [...taskTokens].reduce((count, token) => (
+    nameTokens.includes(token) || tagTokens.includes(token) ? count + 1 : count
+  ), 0);
+
+  const taskScore = taskMatchCount * 2;
+  const total = referenceScore + stepsScore + recencyScore + taskScore;
+  return Number(total.toFixed(2));
+}
+
+function buildSkillMarkdown(
+  skill: NormalizedSkill,
+  references: ReferenceEntry[],
+): string {
+  const steps = (skill.steps || []).map((step, index) => `${index + 1}. ${step}`).join('\n');
+  const sources = references
+    .map((ref) => {
+      const date = safeDate(ref.createdAt);
+      const dateLabel = date ? date.toISOString().slice(0, 10) : 'unknown-date';
+      return `- ${ref.refId} · ${ref.title} (${dateLabel})`;
+    })
+    .join('\n');
+
+  const fallbackSteps = [
+    '1. Review the referenced context.',
+    '2. Apply the guidance carefully.',
+  ].join('\n');
+
+  return [
+    `### ${skill.name}`,
+    '',
+    '**TL;DR**',
+    skill.summary,
+    '',
+    '**When To Use**',
+    skill.whenToUse,
+    '',
+    '**Steps**',
+    steps || fallbackSteps,
+    '',
+    '**Sources**',
+    sources || '- None cited',
+  ].join('\n');
+}
+
+class PodSkillService {
+  private available: boolean;
+
+  constructor() {
+    this.available = Boolean(process.env.LITELLM_BASE_URL || process.env.GEMINI_API_KEY);
+  }
+
+  isAvailable(): boolean {
+    return this.available;
+  }
+
+  async generateSkillsWithLLM({
+    pod, task, referenceEntries, skillLimit,
+  }: {
+    pod: PodDescriptor;
+    task?: string | null;
+    referenceEntries: ReferenceEntry[];
+    skillLimit: number;
+  }): Promise<GenerateSkillsResult> {
+    if (!this.isAvailable()) {
+      return { skills: [], warnings: ['LLM is not configured (set LITELLM_BASE_URL or GEMINI_API_KEY).'] };
+    }
+
+    const prompt = buildSkillPrompt({
+      pod, task, referenceEntries, skillLimit,
+    });
+
+    try {
+      const text: string = await generateText(prompt, { model: MODEL_NAME, temperature: 0.2 });
+      const parsed = extractJson(text);
+      if (!parsed || !Array.isArray(parsed.skills)) {
+        return { skills: [], warnings: ['LLM response was not valid JSON.'] };
+      }
+      return { skills: parsed.skills as RawSkill[], warnings: [] };
+    } catch (error) {
+      console.error('Failed to synthesize pod skills with LLM:', error);
+      return { skills: [], warnings: ['LLM skill synthesis failed.'] };
+    }
+  }
+
+  async synthesizeSkills({
+    pod, task, summaries = [], assets = [], skillLimit = 6, taskTokens = new Set(),
+  }: SynthesizeSkillsOptions): Promise<SynthesizeSkillsResult> {
+    const referenceEntries = buildReferenceEntries({ summaries, assets });
+    if (!referenceEntries.length) {
+      return { skills: [], warnings: ['No references available to synthesize skills.'] };
+    }
+
+    const referenceMap = new Map<string, ReferenceEntry>(
+      referenceEntries.map((entry) => [entry.refId, entry]),
+    );
+
+    const { skills: rawSkills, warnings } = await this.generateSkillsWithLLM({
+      pod, task, referenceEntries, skillLimit,
+    });
+
+    const limitedSkills = rawSkills.slice(0, skillLimit);
+    const skillPromises = limitedSkills.map(async (rawSkill) => {
+      const name = normalizeText(rawSkill.name);
+      if (!name) return null;
+
+      const summary = normalizeText(rawSkill.summary, 'No TL;DR provided.');
+      const whenToUse = normalizeText(rawSkill.whenToUse, 'Use when this topic appears.');
+      const steps = normalizeList(rawSkill.steps, { limit: 8 });
+      const tags = normalizeList(rawSkill.tags, { limit: 10 });
+      const { validIds, references } = resolveReferences(rawSkill.references, referenceMap);
+
+      const score = scoreSkill({ name, tags, steps }, references, taskTokens);
+      const markdown = buildSkillMarkdown({ name, summary, whenToUse, steps, tags }, references);
+
+      return PodAssetService.upsertSkillAsset({
+        podId: pod.id,
+        name,
+        markdown,
+        tags,
+        metadata: {
+          score,
+          summary,
+          whenToUse,
+          steps,
+          references: validIds,
+          referenceDetails: references.map((ref) => ({
+            refId: ref.refId,
+            id: ref.id,
+            type: ref.type,
+            title: ref.title,
+            createdAt: ref.createdAt || null,
+          })),
+          generatedAt: new Date(),
+          generator: 'gemini',
+        },
+      });
+    });
+
+    const upsertedSkills = (await Promise.all(skillPromises)).filter(Boolean);
+
+    return {
+      skills: upsertedSkills,
+      warnings,
+    };
+  }
+}
+
+export default new PodSkillService();


### PR DESCRIPTION
## Summary

- **podSkillService.ts**: Full TypeScript migration of the LLM skill synthesis singleton. Interfaces: ReferenceEntry, SummaryLike, AssetLike, PodDescriptor, RawSkill, NormalizedSkill, GenerateSkillsResult, SynthesizeSkillsOptions, SynthesizeSkillsResult. Singleton via export default new PodSkillService().
- **agentWebSocketService.ts**: Full TypeScript migration of the agent WebSocket service. Interfaces: AgentSocket, AgentNamespace, IoServer, ConnectedAgentData, AgentTokenInfo, AgentEvent, AgentUserDoc, InstallationDoc. Typed connectedAgents Map, pingInterval, all methods typed. Singleton via export default agentWebSocketService.

Part of the backend TypeScript migration tracked in issues #109-#113.

## Test plan
- [ ] Test & Coverage CI check passes
- [ ] No new TypeScript errors introduced (existing .js files untouched, allowJs: true)

Generated with Claude Code via Happy