### PR TITLE
feat(ts): migrate agentEnsembleService + activityService to TypeScript (batch 14)

### DIFF
--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -1,0 +1,1040 @@
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
+// eslint-disable-next-line global-require
+const User = require('../models/User');
+// eslint-disable-next-line global-require
+const Activity = require('../models/Activity');
+// eslint-disable-next-line global-require
+const Summary = require('../models/Summary');
+// eslint-disable-next-line global-require
+const Post = require('../models/Post');
+
+let PGMessage: unknown = null;
+try {
+  // eslint-disable-next-line global-require
+  PGMessage = require('../models/pg/Message');
+} catch (e) {
+  PGMessage = null;
+}
+
+let Message: unknown = null;
+try {
+  // eslint-disable-next-line global-require
+  Message = require('../models/Message');
+} catch (e) {
+  Message = null;
+}
+
+interface ActorInfo {
+  id?: string | null;
+  name?: string;
+  type?: string;
+  verified?: boolean;
+  profilePicture?: string;
+}
+
+interface ActivityFlags {
+  isAgentAction: boolean;
+  isMention: boolean;
+  isFollowing: boolean;
+  isThreadUpdate: boolean;
+}
+
+interface ActivityItem {
+  id: string;
+  type: string;
+  actor: ActorInfo;
+  action: string;
+  content?: string;
+  preview?: string;
+  timestamp: Date | string | null;
+  pod?: { id: string; name: string } | null;
+  target?: { title?: string; description?: string; url?: string } | null;
+  approval?: unknown;
+  agentMetadata?: { agentName?: string; sources?: unknown[] };
+  involves?: unknown;
+  reactions: { likes: number; liked: boolean };
+  replyCount: number;
+  replies: unknown[];
+  flags?: ActivityFlags;
+  read?: boolean;
+}
+
+interface UserDoc {
+  _id: unknown;
+  username?: string;
+  following?: unknown[];
+  followers?: unknown[];
+  followedThreads?: Array<{ postId: unknown; followedAt?: Date }>;
+  activityFeed?: { lastViewedAt?: Date | string; readItemIds?: unknown[] };
+}
+
+interface PodDoc {
+  _id: unknown;
+  name: string;
+  type?: string;
+  createdBy?: unknown;
+  members?: unknown[];
+  agentEnsemble?: unknown;
+  updatedAt?: Date;
+  createdAt?: Date;
+}
+
+interface GetFeedOptions {
+  limit?: number;
+  before?: string;
+  filter?: string;
+  mode?: string;
+}
+
+interface ComputeFlagsOptions {
+  actor?: ActorInfo;
+  type?: string;
+  action?: string;
+  content?: string;
+  target?: { description?: string };
+  username?: string;
+  followingIds?: Set<string>;
+}
+
+class ActivityService {
+  static async getUserFeed(
+    userId: unknown,
+    options: GetFeedOptions = {},
+  ): Promise<Record<string, unknown>> {
+    const {
+      limit = 20, before, filter, mode = 'updates',
+    } = options;
+
+    try {
+      const user: UserDoc | null = await User.findById(userId)
+        .select('_id username following followers followedThreads')
+        .lean();
+      if (!user) {
+        return { activities: [], hasMore: false, quick: null };
+      }
+
+      const pods: PodDoc[] = await Pod.find({
+        $or: [
+          { createdBy: userId },
+          { 'members.userId': userId },
+          { members: userId },
+        ],
+      })
+        .select('_id name type')
+        .lean();
+
+      const podIds = pods.map((p) => p._id);
+      const podMap = new Map(pods.map((p) => [String(p._id), p]));
+
+      const activities = await ActivityService.aggregateActivities(podIds, podMap, user, {
+        limit, before, filter, mode,
+      });
+      const readState = user.activityFeed || {};
+      const withReadState = ActivityService.annotateReadState(activities, readState);
+      const quick = await ActivityService.getQuickOverview(user, pods);
+
+      return {
+        activities: withReadState,
+        hasMore: withReadState.length === limit,
+        quick,
+        unreadCount: withReadState.filter((item) => !item.read).length,
+      };
+    } catch (error) {
+      console.error('Error in getUserFeed:', error);
+      throw error;
+    }
+  }
+
+  static async getPodFeed(
+    podId: unknown,
+    userId: unknown,
+    options: GetFeedOptions = {},
+  ): Promise<Record<string, unknown>> {
+    const {
+      limit = 20, before, filter, mode = 'updates',
+    } = options;
+
+    try {
+      const user: UserDoc | null = await User.findById(userId)
+        .select('_id username following followers followedThreads')
+        .lean();
+      if (!user) {
+        throw new Error('Access denied');
+      }
+
+      const pod: PodDoc | null = await Pod.findById(podId).lean();
+      if (!pod) {
+        throw new Error('Pod not found');
+      }
+
+      const isMember = String(pod.createdBy) === String(userId)
+        || (pod.members as unknown[])?.some(
+          (m: unknown) => {
+            const member = m as { userId?: unknown };
+            return (String(member.userId) || String(m)) === String(userId);
+          },
+        );
+
+      if (!isMember) {
+        throw new Error('Access denied');
+      }
+
+      const podMap = new Map([[String(podId), pod]]);
+      const activities = await ActivityService.aggregateActivities([podId], podMap, user, {
+        limit, before, filter, mode,
+      });
+      const withReadState = ActivityService.annotateReadState(activities, user.activityFeed || {});
+
+      return {
+        activities: withReadState,
+        hasMore: withReadState.length === limit,
+      };
+    } catch (error) {
+      console.error('Error in getPodFeed:', error);
+      throw error;
+    }
+  }
+
+  static async aggregateActivities(
+    podIds: unknown[],
+    podMap: Map<string, PodDoc>,
+    user: UserDoc,
+    options: GetFeedOptions = {},
+  ): Promise<ActivityItem[]> {
+    const {
+      limit = 20, before, filter, mode = 'updates',
+    } = options;
+    const allActivities: ActivityItem[] = [];
+
+    try {
+      const followingIds = new Set((user.following || []).map((id) => String(id)));
+      const username = user.username || '';
+
+      const storedActivities = await ActivityService.getStoredActivities(podIds, podMap, user, {
+        limit, before, filter,
+      });
+      allActivities.push(...storedActivities);
+
+      if (!filter || filter === 'all' || filter === 'humans' || filter === 'agents') {
+        const messages = await ActivityService.getMessageActivities(podIds, podMap, {
+          limit, before, filter, username, followingIds,
+        });
+        allActivities.push(...messages);
+      }
+
+      if (!filter || filter === 'all' || filter === 'skills') {
+        const summaries = await ActivityService.getSummaryActivities(podIds, podMap, {
+          limit, before,
+        });
+        allActivities.push(...summaries);
+      }
+
+      if (!filter || ['all', 'threads', 'following', 'mentions'].includes(filter)) {
+        const threadUpdates = await ActivityService.getFollowedThreadActivities(user, {
+          limit, before, podMap, followingIds, username,
+        });
+        allActivities.push(...threadUpdates);
+      }
+
+      const seen = new Set<string>();
+      const uniqueActivities = allActivities.filter((a) => {
+        if (seen.has(a.id)) return false;
+        seen.add(a.id);
+        return true;
+      });
+
+      uniqueActivities.sort(
+        (a, b) => new Date(b.timestamp as string).getTime() - new Date(a.timestamp as string).getTime(),
+      );
+      const filtered = uniqueActivities.filter((activity) => ActivityService.matchesModeAndFilter(activity, {
+        mode,
+        filter,
+      }));
+
+      return filtered.slice(0, limit);
+    } catch (error) {
+      console.error('Error aggregating activities:', error);
+      return [];
+    }
+  }
+
+  static async getStoredActivities(
+    podIds: unknown[],
+    podMap: Map<string, PodDoc>,
+    user: UserDoc,
+    options: GetFeedOptions = {},
+  ): Promise<ActivityItem[]> {
+    const { limit = 20, before, filter } = options;
+    const activities: ActivityItem[] = [];
+
+    try {
+      const query: Record<string, unknown> = { deleted: { $ne: true } };
+      const scopeFilters: unknown[] = [];
+      if (podIds.length > 0) {
+        scopeFilters.push({ podId: { $in: podIds } });
+      }
+      scopeFilters.push({
+        visibility: 'private',
+        $or: [
+          { 'actor.id': user._id },
+          { 'involves.id': user._id },
+        ],
+      });
+      query.$or = scopeFilters;
+
+      if (before) {
+        query.createdAt = { $lt: new Date(before) };
+      }
+
+      if (filter === 'humans') {
+        query['actor.type'] = 'human';
+      } else if (filter === 'agents') {
+        query['actor.type'] = { $in: ['agent', 'system'] };
+      } else if (filter === 'skills') {
+        query.type = 'skill_created';
+      }
+
+      const stored: Array<Record<string, unknown>> = await Activity.find(query)
+        .sort({ createdAt: -1 })
+        .limit(limit)
+        .lean();
+
+      stored.forEach((activity) => {
+        const pod = podMap.get(String(activity.podId));
+        const actor = activity.actor as ActorInfo;
+        const followingIds = new Set((user.following || []).map((id) => String(id)));
+        const replies = (activity.replies as Array<Record<string, unknown>> || []);
+
+        activities.push({
+          id: String(activity._id),
+          type: activity.type as string,
+          actor,
+          action: activity.action as string,
+          content: activity.content as string | undefined,
+          preview: (activity.content as string | undefined)?.substring(0, 200),
+          timestamp: activity.createdAt as Date,
+          pod: pod ? { id: String(pod._id), name: pod.name } : null,
+          target: activity.target as ActivityItem['target'],
+          approval: activity.approval,
+          agentMetadata: activity.agentMetadata as ActivityItem['agentMetadata'],
+          involves: activity.involves,
+          reactions: {
+            likes: (activity.reactions as { likes?: number })?.likes || 0,
+            liked: false,
+          },
+          replyCount: (activity.replyCount as number) || 0,
+          replies: replies.slice(0, 3).map((r) => ({
+            actor: {
+              id: String(r.actorId),
+              name: r.actorName,
+              type: r.actorType,
+            },
+            content: r.content,
+            timestamp: r.createdAt,
+          })),
+          flags: ActivityService.computeFlags({
+            actor,
+            type: activity.type as string,
+            action: activity.action as string,
+            content: activity.content as string,
+            target: activity.target as { description?: string },
+            username: user.username,
+            followingIds,
+          }),
+        });
+      });
+    } catch (error) {
+      console.error('Error getting stored activities:', error);
+    }
+
+    return activities;
+  }
+
+  static async getMessageActivities(
+    podIds: unknown[],
+    podMap: Map<string, PodDoc>,
+    options: GetFeedOptions & {
+      username?: string;
+      followingIds?: Set<string>;
+    } = {},
+  ): Promise<ActivityItem[]> {
+    const {
+      limit = 20, before, filter, username = '', followingIds = new Set(),
+    } = options;
+    const activities: ActivityItem[] = [];
+
+    try {
+      let messages: Array<Record<string, unknown>> = [];
+
+      if (PGMessage) {
+        try {
+          const podMessagesList = await Promise.all(
+            podIds.slice(0, 5).map((podId) => (PGMessage as { findByPodId(id: unknown, limit: number): Promise<unknown[]> }).findByPodId(podId, limit)),
+          );
+          messages = podMessagesList.flat() as Array<Record<string, unknown>>;
+        } catch (e) {
+          console.warn('PG message fetch failed, trying MongoDB');
+        }
+      }
+
+      if (messages.length === 0 && Message) {
+        const query: Record<string, unknown> = { podId: { $in: podIds } };
+        if (before) {
+          query.createdAt = { $lt: new Date(before) };
+        }
+
+        messages = await (Message as { find(q: unknown): { sort(s: unknown): { limit(n: number): { populate(f: string, s: string): { lean(): Promise<Array<Record<string, unknown>>> } } } } })
+          .find(query)
+          .sort({ createdAt: -1 })
+          .limit(limit)
+          .populate('userId', 'username profilePicture')
+          .lean();
+      }
+
+      messages.forEach((msg) => {
+        const userId = msg.userId as Record<string, unknown> | undefined;
+        const authorName = (msg.username as string) || (userId?.username as string) || 'Unknown';
+        const isAgent = ActivityService.isAgentUsername(authorName);
+
+        if (filter === 'humans' && isAgent) return;
+        if (filter === 'agents' && !isAgent) return;
+
+        const pod = podMap.get(String(msg.podId) || String(msg.pod_id));
+
+        activities.push({
+          id: `msg_${msg._id || msg.id}`,
+          type: 'message',
+          actor: {
+            id: String(userId?._id || msg.user_id),
+            name: authorName,
+            type: isAgent ? 'agent' : 'human',
+            verified: authorName === 'commonly-ai-agent' || authorName === 'commonly-bot',
+            profilePicture: (msg.profile_picture as string) || (userId?.profilePicture as string),
+          },
+          action: 'message',
+          content: (msg.content || msg.text) as string | undefined,
+          preview: String(msg.content || msg.text || '').substring(0, 200),
+          timestamp: (msg.createdAt || msg.created_at) as Date,
+          pod: pod ? { id: String(pod._id), name: pod.name } : null,
+          reactions: { likes: 0, liked: false },
+          replyCount: 0,
+          replies: [],
+          flags: ActivityService.computeFlags({
+            actor: {
+              id: String(userId?._id || msg.user_id),
+              type: isAgent ? 'agent' : 'human',
+            },
+            type: 'message',
+            action: 'message',
+            content: String(msg.content || msg.text || ''),
+            username,
+            followingIds,
+          }),
+        });
+      });
+    } catch (error) {
+      console.error('Error getting message activities:', error);
+    }
+
+    return activities;
+  }
+
+  static async getSummaryActivities(
+    podIds: unknown[],
+    podMap: Map<string, PodDoc>,
+    options: { limit?: number; before?: string } = {},
+  ): Promise<ActivityItem[]> {
+    const { limit = 10, before } = options;
+    const activities: ActivityItem[] = [];
+
+    try {
+      const query: Record<string, unknown> = {
+        podId: { $in: podIds },
+        type: { $in: ['skills', 'chats', 'daily-digest'] },
+      };
+      if (before) {
+        query.createdAt = { $lt: new Date(before) };
+      }
+
+      const summaries: Array<Record<string, unknown>> = await Summary.find(query)
+        .sort({ createdAt: -1 })
+        .limit(limit)
+        .lean();
+
+      summaries.forEach((summary) => {
+        const pod = podMap.get(String(summary.podId));
+        const isSkill = summary.type === 'skills';
+
+        activities.push({
+          id: `sum_${summary._id}`,
+          type: isSkill ? 'skill_created' : 'summary',
+          actor: {
+            id: 'system',
+            name: 'commonly-bot',
+            type: 'agent',
+            verified: true,
+          },
+          action: isSkill ? 'skill_created' : 'message',
+          content: summary.content as string | undefined,
+          preview: (summary.content as string | undefined)?.substring(0, 200),
+          timestamp: summary.createdAt as Date,
+          pod: pod ? { id: String(pod._id), name: pod.name } : null,
+          target: isSkill
+            ? {
+              title: `${pod?.name || 'Pod'} Skills`,
+              description: (summary.content as string | undefined)?.substring(0, 100),
+            }
+            : null,
+          reactions: { likes: 0, liked: false },
+          replyCount: 0,
+          agentMetadata: {
+            sources: (summary.metadata as { sources?: unknown[] })?.sources || [],
+          },
+          replies: [],
+          flags: {
+            isAgentAction: true,
+            isMention: false,
+            isFollowing: false,
+            isThreadUpdate: false,
+          },
+        });
+      });
+    } catch (error) {
+      console.error('Error getting summary activities:', error);
+    }
+
+    return activities;
+  }
+
+  static computeFlags(options: ComputeFlagsOptions): ActivityFlags {
+    const {
+      actor, type, action, content, target, username, followingIds = new Set(),
+    } = options;
+    const actorId = actor?.id ? String(actor.id) : '';
+    const lowerContent = `${content || ''} ${target?.description || ''}`.toLowerCase();
+    const lowerUsername = (username || '').toLowerCase();
+    const mentionNeedle = lowerUsername ? `@${lowerUsername}` : '';
+
+    return {
+      isAgentAction: actor?.type === 'agent' || actor?.type === 'system' || type === 'agent_action',
+      isMention: Boolean(mentionNeedle && lowerContent.includes(mentionNeedle)),
+      isFollowing: Boolean(actorId && followingIds.has(actorId)),
+      isThreadUpdate: action === 'thread_comment' || action === 'thread_followed' || type === 'thread_update',
+    };
+  }
+
+  static annotateReadState(
+    activities: ActivityItem[] = [],
+    readState: UserDoc['activityFeed'] = {},
+  ): ActivityItem[] {
+    const lastViewedAt = readState?.lastViewedAt ? new Date(readState.lastViewedAt as string) : new Date(0);
+    const readItemIds = new Set((readState?.readItemIds || []).map((id) => String(id)));
+    return activities.map((activity) => {
+      const activityTime = activity?.timestamp ? new Date(activity.timestamp as string) : new Date(0);
+      const isExplicitlyRead = readItemIds.has(String(activity.id));
+      const read = isExplicitlyRead || activityTime <= lastViewedAt;
+      return { ...activity, read };
+    });
+  }
+
+  static async markRead(userId: unknown, options: { activityId?: string | null; all?: boolean } = {}): Promise<Record<string, unknown>> {
+    const { activityId = null, all = false } = options;
+    const user = await User.findById(userId).select('_id activityFeed');
+    if (!user) return { success: false, error: 'User not found' };
+
+    if (!user.activityFeed) {
+      user.activityFeed = { lastViewedAt: new Date(0), readItemIds: [] };
+    }
+
+    if (all) {
+      user.activityFeed.lastViewedAt = new Date();
+      user.activityFeed.readItemIds = [];
+    } else if (activityId) {
+      const next = new Set((user.activityFeed.readItemIds || []).map((id: unknown) => String(id)));
+      next.add(String(activityId));
+      user.activityFeed.readItemIds = Array.from(next).slice(-500);
+    }
+
+    await user.save();
+    return {
+      success: true,
+      lastViewedAt: user.activityFeed.lastViewedAt,
+      readItemIds: user.activityFeed.readItemIds || [],
+    };
+  }
+
+  static async getUnreadCount(userId: unknown, options: GetFeedOptions = {}): Promise<{ unreadCount: number }> {
+    const activitiesResult = await ActivityService.getUserFeed(userId, {
+      ...options,
+      limit: 100,
+    });
+    const unreadCount = (activitiesResult.activities as ActivityItem[] || []).filter((item) => !item.read).length;
+    return { unreadCount };
+  }
+
+  static matchesModeAndFilter(
+    activity: ActivityItem,
+    options: { mode?: string; filter?: string } = {},
+  ): boolean {
+    const { mode = 'updates', filter = 'all' } = options;
+    const flags = activity.flags || {} as ActivityFlags;
+    const isAgent = flags.isAgentAction || activity.actor?.type === 'agent' || activity.actor?.type === 'system';
+
+    if (mode === 'actions') {
+      if (filter === 'agents') return isAgent;
+      if (filter === 'humans') return !isAgent;
+      if (filter === 'skills') return activity.type === 'skill_created' || activity.type === 'summary';
+      return isAgent || activity.type === 'agent_action' || activity.type === 'skill_created';
+    }
+
+    if (filter === 'mentions') return flags.isMention;
+    if (filter === 'following') return flags.isFollowing || activity.action === 'user_followed';
+    if (filter === 'threads') return flags.isThreadUpdate;
+    if (filter === 'pods') return Boolean(activity.pod?.id);
+    if (filter === 'humans') return !isAgent;
+    if (filter === 'agents') return isAgent;
+    return true;
+  }
+
+  static async getFollowedThreadActivities(
+    user: UserDoc,
+    options: {
+      before?: string;
+      podMap?: Map<string, PodDoc>;
+      followingIds?: Set<string>;
+      username?: string;
+      limit?: number;
+    } = {},
+  ): Promise<ActivityItem[]> {
+    const {
+      before, podMap = new Map(), followingIds = new Set(), username, limit = 20,
+    } = options;
+
+    const followedThreads = Array.isArray(user.followedThreads) ? user.followedThreads : [];
+    if (!followedThreads.length) return [];
+
+    const threadMap = new Map(
+      followedThreads.map((thread) => [String(thread.postId), thread.followedAt || new Date(0)]),
+    );
+    const postIds = Array.from(threadMap.keys());
+
+    const posts: Array<Record<string, unknown>> = await Post.find({ _id: { $in: postIds } })
+      .select('_id podId userId content comments createdAt')
+      .populate('userId', 'username profilePicture')
+      .populate('podId', 'name type')
+      .populate('comments.userId', 'username profilePicture')
+      .lean();
+
+    const activities: ActivityItem[] = [];
+    posts.forEach((post) => {
+      const followedAt = threadMap.get(String(post._id)) || new Date(0);
+      const comments = post.comments as Array<Record<string, unknown>> || [];
+
+      const relevantComments = comments
+        .filter((comment) => {
+          const createdAt = comment.createdAt ? new Date(comment.createdAt as string) : null;
+          if (!createdAt) return false;
+          if (before && createdAt >= new Date(before)) return false;
+          if (createdAt <= followedAt) return false;
+          const commentUserId = comment.userId as Record<string, unknown> | undefined;
+          return String(commentUserId?._id || comment.userId) !== String(user._id);
+        })
+        .sort((a, b) => new Date(b.createdAt as string).getTime() - new Date(a.createdAt as string).getTime());
+
+      if (!relevantComments.length) return;
+
+      const latest = relevantComments[0];
+      const postPodId = post.podId as Record<string, unknown> | null;
+      const pod: { id: string; name: string } | PodDoc | undefined = postPodId?._id
+        ? { id: String(postPodId._id), name: postPodId.name as string }
+        : podMap.get(String(post.podId));
+
+      const latestUserId = latest.userId as Record<string, unknown> | undefined;
+      const actor: ActorInfo = {
+        id: String(latestUserId?._id || latestUserId || 'unknown'),
+        name: (latestUserId?.username as string) || 'User',
+        type: ActivityService.isAgentUsername(latestUserId?.username as string) ? 'agent' : 'human',
+        verified: ActivityService.isAgentUsername(latestUserId?.username as string),
+        profilePicture: latestUserId?.profilePicture as string | undefined,
+      };
+
+      activities.push({
+        id: `thread_${post._id}_${latest._id || latest.createdAt}`,
+        type: 'thread_update',
+        actor,
+        action: 'thread_comment',
+        content: latest.text as string | undefined,
+        preview: (latest.text as string | undefined)?.substring(0, 200),
+        timestamp: latest.createdAt as Date,
+        pod: pod ? { id: String((pod as PodDoc)._id || (pod as { id: string }).id), name: (pod as PodDoc).name || (pod as { name: string }).name } : null,
+        target: {
+          title: `Thread update: ${String(post.content || '').slice(0, 80)}`,
+          description:
+            `${relevantComments.length} new repl${relevantComments.length === 1 ? 'y' : 'ies'} `
+            + 'since you followed',
+          url: `/thread/${post._id}`,
+        },
+        reactions: { likes: 0, liked: false },
+        replyCount: 0,
+        replies: [],
+        flags: ActivityService.computeFlags({
+          actor,
+          type: 'thread_update',
+          action: 'thread_comment',
+          content: latest.text as string,
+          target: { description: post.content as string },
+          username,
+          followingIds,
+        }),
+      });
+    });
+
+    activities.sort(
+      (a, b) => new Date(b.timestamp as string).getTime() - new Date(a.timestamp as string).getTime(),
+    );
+    return activities.slice(0, limit);
+  }
+
+  static async getQuickOverview(user: UserDoc, pods: PodDoc[] = []): Promise<Record<string, unknown>> {
+    const recentPods = (pods || [])
+      .slice()
+      .sort((a, b) => new Date(b.updatedAt || b.createdAt || 0).getTime() - new Date(a.updatedAt || a.createdAt || 0).getTime())
+      .slice(0, 6)
+      .map((pod) => ({
+        id: String(pod._id),
+        name: pod.name,
+        type: pod.type,
+        updatedAt: pod.updatedAt || pod.createdAt,
+        membersCount: Array.isArray(pod.members) ? pod.members.length : 0,
+      }));
+
+    const followedThreads = Array.isArray(user.followedThreads) ? user.followedThreads : [];
+    const followedIds = followedThreads.map((thread) => thread.postId).filter(Boolean);
+    let followedThreadItems: unknown[] = [];
+    if (followedIds.length > 0) {
+      const followedAtMap = new Map(
+        followedThreads.map((thread) => [String(thread.postId), thread.followedAt || new Date(0)]),
+      );
+      const posts: Array<Record<string, unknown>> = await Post.find({ _id: { $in: followedIds } })
+        .select('_id content comments createdAt')
+        .sort({ createdAt: -1 })
+        .lean();
+
+      followedThreadItems = posts.slice(0, 6).map((post) => {
+        const followedAt = followedAtMap.get(String(post._id)) || new Date(0);
+        const comments = post.comments as Array<Record<string, unknown>> || [];
+        const newReplies = comments.filter((comment) => (
+          comment.createdAt && new Date(comment.createdAt as string) > followedAt
+          && String(comment.userId) !== String(user._id)
+        )).length;
+        return {
+          postId: String(post._id),
+          preview: String(post.content || '').slice(0, 120),
+          followedAt,
+          newReplies,
+          url: `/thread/${post._id}`,
+        };
+      });
+    }
+
+    return {
+      social: {
+        followers: Array.isArray(user.followers) ? user.followers.length : 0,
+        following: Array.isArray(user.following) ? user.following.length : 0,
+      },
+      recentPods,
+      followedThreads: followedThreadItems,
+    };
+  }
+
+  static isAgentUsername(username: string | undefined | null): boolean {
+    if (!username) return false;
+    const lower = username.toLowerCase();
+    return (
+      lower.includes('-bot')
+      || lower.includes('_bot')
+      || lower.endsWith('bot')
+      || lower === 'moltbot'
+      || lower === 'commonly-bot'
+      || lower === 'commonly-ai-agent'
+    );
+  }
+
+  static async createMessageActivity(
+    message: unknown,
+    podId: unknown,
+    user: unknown,
+  ): Promise<unknown> {
+    try {
+      const pod = await Pod.findById(podId).select('_id name').lean();
+      if (!pod) return null;
+      return Activity.createFromMessage(message, pod, user);
+    } catch (error) {
+      console.error('Error creating message activity:', error);
+      return null;
+    }
+  }
+
+  static async createSkillActivity(summary: unknown, podId: unknown): Promise<unknown> {
+    try {
+      const pod = await Pod.findById(podId).select('_id name').lean();
+      if (!pod) return null;
+      return Activity.createSkillActivity(summary, pod);
+    } catch (error) {
+      console.error('Error creating skill activity:', error);
+      return null;
+    }
+  }
+
+  static async createApprovalRequest(options: unknown): Promise<unknown> {
+    try {
+      return Activity.createApprovalRequest(options);
+    } catch (error) {
+      console.error('Error creating approval request:', error);
+      return null;
+    }
+  }
+
+  static async toggleLike(activityId: string, userId: unknown): Promise<Record<string, unknown>> {
+    try {
+      if (activityId.startsWith('msg_') || activityId.startsWith('sum_')) {
+        return { success: true, liked: true };
+      }
+
+      const activity = await Activity.findById(activityId);
+      if (!activity) {
+        return { success: false, error: 'Activity not found' };
+      }
+
+      const liked = await activity.toggleLike(userId);
+      return { success: true, liked, likes: activity.reactions.likes };
+    } catch (error) {
+      const err = error as { message?: string };
+      console.error('Error toggling like:', error);
+      return { success: false, error: err.message };
+    }
+  }
+
+  static async addReply(activityId: string, userId: unknown, content: string): Promise<Record<string, unknown>> {
+    try {
+      const user = await User.findById(userId).select('username').lean() as { username?: string } | null;
+      const userName = user?.username || 'User';
+      const isAgent = ActivityService.isAgentUsername(userName);
+
+      if (activityId.startsWith('msg_') || activityId.startsWith('sum_')) {
+        return {
+          success: true,
+          reply: {
+            id: `reply_${Date.now()}`,
+            actor: {
+              id: String(userId),
+              name: userName,
+              type: isAgent ? 'agent' : 'human',
+            },
+            content,
+            timestamp: new Date().toISOString(),
+          },
+        };
+      }
+
+      const activity = await Activity.findById(activityId);
+      if (!activity) {
+        return { success: false, error: 'Activity not found' };
+      }
+
+      await activity.addReply(userId, userName, content, isAgent);
+
+      return {
+        success: true,
+        reply: {
+          id: activity.replies[activity.replies.length - 1]._id.toString(),
+          actor: {
+            id: String(userId),
+            name: userName,
+            type: isAgent ? 'agent' : 'human',
+          },
+          content,
+          timestamp: new Date().toISOString(),
+        },
+      };
+    } catch (error) {
+      const err = error as { message?: string };
+      console.error('Error adding reply:', error);
+      return { success: false, error: err.message };
+    }
+  }
+
+  static async approveActivity(activityId: string, userId: unknown, notes: string): Promise<Record<string, unknown>> {
+    try {
+      const activity = await Activity.findById(activityId);
+      if (!activity) {
+        return { success: false, error: 'Activity not found' };
+      }
+
+      if (activity.type !== 'approval_needed') {
+        return { success: false, error: 'Activity is not an approval request' };
+      }
+
+      await activity.approve(userId, notes);
+      return { success: true, status: 'approved' };
+    } catch (error) {
+      const err = error as { message?: string };
+      console.error('Error approving activity:', error);
+      return { success: false, error: err.message };
+    }
+  }
+
+  static async rejectActivity(activityId: string, userId: unknown, notes: string): Promise<Record<string, unknown>> {
+    try {
+      const activity = await Activity.findById(activityId);
+      if (!activity) {
+        return { success: false, error: 'Activity not found' };
+      }
+
+      if (activity.type !== 'approval_needed') {
+        return { success: false, error: 'Activity is not an approval request' };
+      }
+
+      await activity.reject(userId, notes);
+      return { success: true, status: 'rejected' };
+    } catch (error) {
+      const err = error as { message?: string };
+      console.error('Error rejecting activity:', error);
+      return { success: false, error: err.message };
+    }
+  }
+
+  static async getPendingApprovals(userId: unknown): Promise<unknown[]> {
+    try {
+      const pods: Array<{ _id: unknown }> = await Pod.find({
+        $or: [
+          { createdBy: userId },
+          { 'members.userId': userId, 'members.role': 'admin' },
+        ],
+      })
+        .select('_id')
+        .lean();
+
+      const podIds = pods.map((p) => p._id);
+      return Activity.getPendingApprovals(podIds);
+    } catch (error) {
+      console.error('Error getting pending approvals:', error);
+      return [];
+    }
+  }
+
+  static async seedPodActivities(podId: unknown, userId: unknown): Promise<Record<string, unknown>> {
+    try {
+      const pod = await Pod.findById(podId).lean();
+      if (!pod) return { success: false, error: 'Pod not found' };
+
+      const user = await User.findById(userId).lean() as { username?: string } | null;
+      if (!user) return { success: false, error: 'User not found' };
+
+      const activities: unknown[] = [];
+
+      activities.push(
+        await Activity.create({
+          type: 'message',
+          actor: {
+            id: userId,
+            name: user.username,
+            type: 'human',
+            verified: false,
+          },
+          action: 'message',
+          content: 'Just pushed the new authentication flow. Can someone review the PR?',
+          podId,
+          reactions: { likes: 3 },
+          replyCount: 1,
+          replies: [
+            {
+              actorId: null,
+              actorName: 'Code Reviewer',
+              actorType: 'agent',
+              content: "I've analyzed the PR. Found 2 potential issues with the token refresh logic.",
+              createdAt: new Date(Date.now() - 4 * 60 * 1000),
+            },
+          ],
+        }),
+      );
+
+      activities.push(
+        await Activity.create({
+          type: 'skill_created',
+          actor: {
+            id: null,
+            name: 'Moltbot',
+            type: 'agent',
+            verified: true,
+          },
+          action: 'skill_created',
+          content: 'Created a new skill from recent discussions',
+          podId,
+          target: {
+            title: 'API Rate Limiting Best Practices',
+            description: 'Guidelines for implementing rate limiting in REST APIs',
+          },
+          agentMetadata: {
+            agentName: 'moltbot',
+            sources: [{ title: 'Backend discussion' }, { title: 'API design doc' }],
+          },
+          reactions: { likes: 7 },
+        }),
+      );
+
+      activities.push(
+        await Activity.create({
+          type: 'approval_needed',
+          actor: {
+            id: null,
+            name: 'commonly-bot',
+            type: 'system',
+            verified: true,
+          },
+          action: 'approval_needed',
+          content: 'An agent is requesting access to the Production pod',
+          podId,
+          approval: {
+            status: 'pending',
+            requestedBy: userId,
+            requestedScopes: ['context:read', 'memory:write'],
+          },
+          agentMetadata: {
+            agentName: 'analytics-bot',
+          },
+        }),
+      );
+
+      activities.push(
+        await Activity.create({
+          type: 'message',
+          actor: {
+            id: null,
+            name: 'Meeting Notes',
+            type: 'agent',
+            verified: false,
+          },
+          action: 'message',
+          content:
+            'Sprint Planning Summary\n\n- 12 stories planned for this sprint\n'
+            + '- Focus areas: Authentication, API performance\n'
+            + '- Blockers discussed: CI/CD pipeline issues\n\n'
+            + 'Action items assigned to 5 team members.',
+          podId,
+          reactions: { likes: 12 },
+          replyCount: 3,
+        }),
+      );
+
+      return { success: true, count: activities.length };
+    } catch (error) {
+      const err = error as { message?: string };
+      console.error('Error seeding activities:', error);
+      return { success: false, error: err.message };
+    }
+  }
+}
+
+module.exports = ActivityService;

--- a/backend/services/agentEnsembleService.ts
+++ b/backend/services/agentEnsembleService.ts
@@ -1,0 +1,757 @@
+// eslint-disable-next-line global-require
+const AgentEnsembleState = require('../models/AgentEnsembleState');
+// eslint-disable-next-line global-require
+const AgentEventService = require('./agentEventService');
+// eslint-disable-next-line global-require
+const AgentIdentityService = require('./agentIdentityService');
+// eslint-disable-next-line global-require
+const AgentProfile = require('../models/AgentProfile');
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
+
+interface ScheduleConfig {
+  enabled?: boolean;
+  frequencyMinutes?: number;
+  cronExpression?: string;
+  timezone?: string;
+  lastScheduledAt?: Date | null;
+  nextScheduledAt?: Date | null;
+}
+
+interface ParticipantConfig {
+  agentType: string;
+  instanceId?: string;
+  displayName?: string;
+  role?: string;
+}
+
+interface StopConditions {
+  maxMessages?: number;
+  maxRounds?: number;
+  maxDurationMinutes?: number;
+}
+
+interface StartDiscussionOptions {
+  topic?: string;
+  createdBy?: string;
+  participants?: ParticipantConfig[];
+  maxMessages?: number;
+  maxRounds?: number;
+  maxDurationMinutes?: number;
+}
+
+interface AgentRef {
+  agentType: string;
+  instanceId?: string;
+}
+
+interface TurnState {
+  currentAgent: AgentRef;
+  turnNumber: number;
+  roundNumber: number;
+  turnStartedAt: Date;
+  waitingForResponse: boolean;
+}
+
+interface CheckpointEntry {
+  agentType: string;
+  instanceId?: string;
+  content: string;
+  timestamp: Date;
+}
+
+interface Checkpoint {
+  recentHistory: CheckpointEntry[];
+  lastMessageId?: string;
+  savedAt?: Date;
+}
+
+interface EnsembleStats {
+  startedAt?: Date;
+  lastActivityAt?: Date;
+  pausedAt?: Date;
+  completedAt?: Date;
+  completionReason?: string;
+  totalMessages: number;
+}
+
+interface KeyPoint {
+  content: string;
+}
+
+interface EnsembleStateDoc {
+  _id: { toString(): string };
+  podId: unknown;
+  status: string;
+  topic: string;
+  participants: ParticipantConfig[];
+  turnState: TurnState;
+  stopConditions: Required<StopConditions>;
+  stats: EnsembleStats;
+  schedule?: ScheduleConfig & {
+    lastScheduledAt?: Date | null;
+    nextScheduledAt?: Date | null;
+  };
+  checkpoint?: Checkpoint;
+  keyPoints?: KeyPoint[];
+  summary?: {
+    keyInsights: string[];
+    generatedAt: Date;
+  };
+  lastProcessedMessageId?: string;
+  createdBy?: unknown;
+  advanceTurn(): void;
+  save(): Promise<void>;
+}
+
+interface AgentProfileDoc {
+  name?: string;
+  purpose?: string;
+  instructions?: string;
+  persona?: string;
+  toolPolicy?: unknown;
+  contextPolicy?: unknown;
+  buildSystemPrompt?: () => string;
+}
+
+interface UpdateConfigOptions {
+  topic?: string;
+  participants?: ParticipantConfig[];
+  stopConditions?: StopConditions;
+  schedule?: ScheduleConfig;
+}
+
+class AgentEnsembleService {
+  static resolveNextScheduledAt(
+    schedule: ScheduleConfig | null | undefined,
+    now = Date.now(),
+  ): Date | null {
+    if (!schedule?.enabled) return null;
+    const frequencyMinutes = Number(schedule.frequencyMinutes) || 20;
+    return new Date(now + frequencyMinutes * 60 * 1000);
+  }
+
+  static async startDiscussion(
+    podId: string,
+    options: StartDiscussionOptions = {},
+  ): Promise<EnsembleStateDoc> {
+    const pod = await Pod.findById(podId);
+    if (!pod) {
+      throw new Error('Pod not found');
+    }
+
+    const existing = await AgentEnsembleState.findOne({
+      podId,
+      status: { $in: ['active', 'paused'] },
+    }).sort({ createdAt: -1 });
+    if (existing) {
+      if (existing.status === 'paused') {
+        throw new Error('Discussion is paused in this pod. Please resume instead.');
+      }
+      throw new Error('Discussion already active in this pod');
+    }
+
+    const config = pod.agentEnsemble || {};
+    const participants: ParticipantConfig[] = options.participants || config.participants || [];
+    const speakingParticipants = participants.filter((p) => p.role !== 'observer');
+
+    if (speakingParticipants.length < 2) {
+      throw new Error('At least 2 speaking participants required for ensemble discussion');
+    }
+
+    await Promise.all(
+      participants.map(async (p) => {
+        const agentUser = await AgentIdentityService.getOrCreateAgentUser(
+          p.agentType,
+          { instanceId: p.instanceId || 'default' },
+        );
+        await AgentIdentityService.ensureAgentInPod(agentUser, podId);
+      }),
+    );
+
+    const starterIndex = participants.findIndex((p) => p.role === 'starter' && p.role !== 'observer');
+    const starterParticipant = starterIndex >= 0 ? participants[starterIndex] : speakingParticipants[0];
+
+    const scheduleConfig: ScheduleConfig = config.schedule || {};
+    const nextScheduledAt = AgentEnsembleService.resolveNextScheduledAt(scheduleConfig);
+
+    const state = await AgentEnsembleState.create({
+      podId,
+      status: 'active',
+      topic: options.topic || config.topic || 'Open discussion',
+      participants: participants.map((p, i) => ({
+        agentType: p.agentType,
+        instanceId: p.instanceId || 'default',
+        displayName: p.displayName,
+        role: i === 0 && !participants.some((x) => x.role === 'starter')
+          ? 'starter'
+          : (p.role || 'responder'),
+      })),
+      turnState: {
+        currentAgent: {
+          agentType: starterParticipant.agentType,
+          instanceId: starterParticipant.instanceId || 'default',
+        },
+        turnNumber: 0,
+        roundNumber: 0,
+        turnStartedAt: new Date(),
+        waitingForResponse: true,
+      },
+      stopConditions: {
+        maxMessages: options.maxMessages || config.stopConditions?.maxMessages || 20,
+        maxRounds: options.maxRounds || config.stopConditions?.maxRounds || 5,
+        maxDurationMinutes: options.maxDurationMinutes
+          || config.stopConditions?.maxDurationMinutes || 60,
+      },
+      stats: {
+        startedAt: new Date(),
+        lastActivityAt: new Date(),
+      },
+      schedule: {
+        enabled: Boolean(scheduleConfig.enabled),
+        cronExpression: scheduleConfig.cronExpression,
+        timezone: scheduleConfig.timezone || 'UTC',
+        lastScheduledAt: scheduleConfig.enabled ? new Date() : null,
+        nextScheduledAt,
+      },
+      createdBy: options.createdBy,
+    });
+
+    await AgentEnsembleService.enqueueTurnEvent(state);
+    console.log(`[ensemble] Started discussion in pod ${podId} with ${participants.length} agents`);
+    return state as EnsembleStateDoc;
+  }
+
+  static async enqueueTurnEvent(state: EnsembleStateDoc): Promise<void> {
+    const { turnState, participants, topic, podId } = state;
+    const speakingParticipants = (participants || []).filter((p) => p.role !== 'observer');
+    if (!speakingParticipants.length) {
+      console.warn('[ensemble] No speaking participants available for turn rotation');
+      return;
+    }
+
+    const expectedAgent = speakingParticipants[turnState.turnNumber % speakingParticipants.length];
+    const currentAgentMatches = turnState.currentAgent?.agentType === expectedAgent.agentType
+      && (turnState.currentAgent?.instanceId || 'default') === (expectedAgent.instanceId || 'default');
+
+    if (!currentAgentMatches) {
+      state.turnState.currentAgent = {
+        agentType: expectedAgent.agentType,
+        instanceId: expectedAgent.instanceId || 'default',
+      };
+      await state.save();
+    }
+
+    const currentAgent = state.turnState.currentAgent;
+    if (!currentAgent?.agentType) {
+      console.warn('[ensemble] No current agent to enqueue turn for');
+      return;
+    }
+
+    let agentProfilePayload: Record<string, unknown> | null = null;
+    try {
+      const profile: AgentProfileDoc | null = await AgentProfile.findOne({
+        podId,
+        agentName: currentAgent.agentType?.toLowerCase?.() || currentAgent.agentType,
+        instanceId: currentAgent.instanceId || 'default',
+      });
+      if (profile) {
+        agentProfilePayload = {
+          name: profile.name,
+          purpose: profile.purpose,
+          instructions: profile.instructions,
+          persona: profile.persona,
+          toolPolicy: profile.toolPolicy,
+          contextPolicy: profile.contextPolicy,
+          systemPrompt: typeof profile.buildSystemPrompt === 'function'
+            ? profile.buildSystemPrompt()
+            : null,
+        };
+      }
+    } catch (error) {
+      const err = error as { message?: string };
+      console.warn('[ensemble] Failed to load agent profile:', err.message);
+    }
+
+    const context = {
+      topic,
+      turnNumber: turnState.turnNumber,
+      roundNumber: turnState.roundNumber,
+      isStarter: turnState.turnNumber === 0,
+      recentHistory: state.checkpoint?.recentHistory || [],
+      keyPoints: state.keyPoints?.slice(-5) || [],
+    };
+
+    await AgentEventService.enqueue({
+      agentName: currentAgent.agentType,
+      instanceId: currentAgent.instanceId || 'default',
+      podId,
+      type: 'ensemble.turn',
+      payload: {
+        ensembleId: state._id.toString(),
+        context,
+        agentProfile: agentProfilePayload,
+        participants: participants.map((p) => ({
+          agentType: p.agentType,
+          instanceId: p.instanceId,
+          displayName: p.displayName,
+          role: p.role,
+        })),
+      },
+    });
+
+    console.log(`[ensemble] Enqueued turn ${turnState.turnNumber} for ${currentAgent.agentType}`);
+  }
+
+  static async processAgentResponse(
+    ensembleId: string,
+    response: { agentType: string; instanceId?: string; content?: string; messageId?: string },
+  ): Promise<EnsembleStateDoc> {
+    const state: EnsembleStateDoc = await AgentEnsembleState.findById(ensembleId);
+    if (!state) {
+      throw new Error('Ensemble state not found');
+    }
+
+    if (state.status !== 'active') {
+      console.log(`[ensemble] Ignoring response for non-active ensemble: ${state.status}`);
+      return state;
+    }
+
+    const { turnState } = state;
+
+    if (
+      response.agentType !== turnState.currentAgent?.agentType
+      || (response.instanceId || 'default') !== (turnState.currentAgent?.instanceId || 'default')
+    ) {
+      const expected = `${turnState.currentAgent?.agentType}:${turnState.currentAgent?.instanceId || 'default'}`;
+      const received = `${response.agentType}:${response.instanceId || 'default'}`;
+      throw new Error(`Wrong agent responded. Expected ${expected}, got ${received}`);
+    }
+
+    if (state.lastProcessedMessageId === response.messageId) {
+      console.log(
+        `[ensemble] Duplicate response from ${response.agentType}:${response.instanceId || 'default'} ignored`,
+      );
+      return state;
+    }
+
+    const normalizedContent = (response.content || '').trim();
+    const isNoReply = normalizedContent === 'NO_REPLY';
+
+    state.stats.lastActivityAt = new Date();
+    turnState.waitingForResponse = false;
+
+    if (!isNoReply) {
+      state.stats.totalMessages += 1;
+
+      if (!state.checkpoint) {
+        state.checkpoint = { recentHistory: [] };
+      }
+      state.checkpoint.recentHistory.push({
+        agentType: turnState.currentAgent.agentType,
+        instanceId: turnState.currentAgent.instanceId,
+        content: (response.content || '').substring(0, 500),
+        timestamp: new Date(),
+      });
+
+      if (state.checkpoint.recentHistory.length > 10) {
+        state.checkpoint.recentHistory = state.checkpoint.recentHistory.slice(-10);
+      }
+
+      state.lastProcessedMessageId = response.messageId;
+      state.checkpoint.lastMessageId = response.messageId;
+      state.checkpoint.savedAt = new Date();
+    }
+
+    const stopReason = AgentEnsembleService.checkStopConditions(state);
+    if (stopReason) {
+      await AgentEnsembleService.completeDiscussion(state._id.toString(), stopReason);
+      return state;
+    }
+
+    state.advanceTurn();
+    await state.save();
+    await AgentEnsembleService.enqueueTurnEvent(state);
+    return state;
+  }
+
+  static checkStopConditions(state: EnsembleStateDoc): string | null {
+    const { stopConditions, stats, turnState } = state;
+
+    if (stats.totalMessages >= stopConditions.maxMessages) {
+      return 'max_messages';
+    }
+    if (turnState.roundNumber >= stopConditions.maxRounds) {
+      return 'max_rounds';
+    }
+    if (stopConditions.maxDurationMinutes > 0 && stats.startedAt) {
+      const elapsed = (Date.now() - stats.startedAt.getTime()) / 1000 / 60;
+      if (elapsed >= stopConditions.maxDurationMinutes) {
+        return 'max_duration';
+      }
+    }
+    return null;
+  }
+
+  static async pauseDiscussion(podId: string): Promise<EnsembleStateDoc> {
+    const activeStates: EnsembleStateDoc[] = await AgentEnsembleState.find({
+      podId,
+      status: 'active',
+    }).sort({ createdAt: -1 });
+
+    if (!activeStates.length) {
+      throw new Error('No active discussion found');
+    }
+
+    const pausedAt = new Date();
+    await AgentEnsembleState.updateMany(
+      { podId, status: 'active' },
+      { $set: { status: 'paused', 'stats.pausedAt': pausedAt } },
+    );
+
+    const state = activeStates[0];
+    state.status = 'paused';
+    state.stats.pausedAt = pausedAt;
+    console.log(`[ensemble] Paused discussion in pod ${podId}`);
+    return state;
+  }
+
+  static async resumeDiscussion(podId: string): Promise<EnsembleStateDoc> {
+    const state: EnsembleStateDoc = await AgentEnsembleState.findOne({
+      podId,
+      status: 'paused',
+    }).sort({ 'stats.pausedAt': -1 });
+
+    if (!state) {
+      throw new Error('No paused discussion found to resume');
+    }
+
+    state.status = 'active';
+    state.turnState.turnStartedAt = new Date();
+    state.turnState.waitingForResponse = true;
+    state.stats.lastActivityAt = new Date();
+    await state.save();
+    await AgentEnsembleService.enqueueTurnEvent(state);
+    console.log(`[ensemble] Resumed discussion in pod ${podId} at turn ${state.turnState.turnNumber}`);
+    return state;
+  }
+
+  static async completeDiscussion(ensembleId: string, reason = 'manual'): Promise<EnsembleStateDoc> {
+    const state: EnsembleStateDoc = await AgentEnsembleState.findById(ensembleId);
+    if (!state) {
+      throw new Error('Ensemble state not found');
+    }
+
+    state.status = 'completed';
+    state.stats.completedAt = new Date();
+    state.stats.completionReason = reason;
+
+    if (state.keyPoints?.length) {
+      state.summary = {
+        keyInsights: state.keyPoints.map((kp) => kp.content),
+        generatedAt: new Date(),
+      };
+    }
+
+    await state.save();
+
+    if (state.schedule?.enabled) {
+      state.schedule.lastScheduledAt = new Date();
+      state.schedule.nextScheduledAt = AgentEnsembleService.resolveNextScheduledAt(state.schedule);
+      await state.save();
+    }
+
+    console.log(`[ensemble] Completed discussion ${ensembleId}: ${reason}`);
+    return state;
+  }
+
+  static async completeActiveForPod(podId: string, reason = 'manual'): Promise<EnsembleStateDoc> {
+    const states: EnsembleStateDoc[] = await AgentEnsembleState.find({
+      podId,
+      status: { $in: ['active', 'paused'] },
+    }).sort({ createdAt: -1 });
+
+    if (!states.length) {
+      throw new Error('No active discussion to complete');
+    }
+
+    const completedStates = await Promise.all(states.map(async (state) => {
+      state.status = 'completed';
+      state.stats.completedAt = new Date();
+      state.stats.completionReason = reason;
+
+      if (state.keyPoints?.length) {
+        state.summary = {
+          keyInsights: state.keyPoints.map((kp) => kp.content),
+          generatedAt: new Date(),
+        };
+      }
+
+      await state.save();
+      return state;
+    }));
+
+    console.log(`[ensemble] Completed ${completedStates.length} discussions in pod ${podId}: ${reason}`);
+    return completedStates[0];
+  }
+
+  static async getState(podId: string): Promise<EnsembleStateDoc | null> {
+    const activeStates: EnsembleStateDoc[] = await AgentEnsembleState.find({
+      podId,
+      status: { $in: ['active', 'paused'] },
+    }).sort({ createdAt: -1 });
+
+    const state = activeStates[0];
+
+    if (activeStates.length > 1) {
+      await Promise.all(
+        activeStates.slice(1).map(async (older) => {
+          older.status = 'completed';
+          older.stats.completedAt = new Date();
+          older.stats.completionReason = 'scheduled_restart';
+          await older.save();
+        }),
+      );
+    }
+
+    if (state) {
+      return state;
+    }
+
+    return AgentEnsembleState.findOne({ podId })
+      .sort({ createdAt: -1 })
+      .lean() as Promise<EnsembleStateDoc | null>;
+  }
+
+  static async updateConfig(podId: string, config: UpdateConfigOptions): Promise<unknown> {
+    if (config.participants) {
+      const speakingCount = config.participants.filter((p) => p.role !== 'observer').length;
+      if (speakingCount < 2) {
+        throw new Error('At least 2 speaking participants required for ensemble discussion');
+      }
+    }
+
+    const state: EnsembleStateDoc | null = await AgentEnsembleState.findOne({
+      podId,
+      status: { $in: ['active', 'pending', 'paused'] },
+    }).sort({ createdAt: -1 });
+
+    if (state) {
+      if (state.status === 'active' && config.participants) {
+        const currentCount = state.participants?.length || 0;
+        const newCount = config.participants?.length || 0;
+
+        if (newCount < currentCount) {
+          throw new Error(
+            'Cannot remove participants during active discussion. Please stop the discussion first.',
+          );
+        }
+
+        const existingChanged = config.participants.slice(0, currentCount).some((p, i) => {
+          const current = state.participants[i];
+          return (
+            p.agentType !== current.agentType
+            || (p.instanceId || 'default') !== (current.instanceId || 'default')
+          );
+        });
+
+        if (existingChanged) {
+          throw new Error('Cannot modify existing participant identities during active discussion');
+        }
+
+        if (newCount > currentCount) {
+          const newParticipants = config.participants.slice(currentCount);
+          await Promise.all(
+            newParticipants.map(async (p) => {
+              const agentUser = await AgentIdentityService.getOrCreateAgentUser(
+                p.agentType,
+                { instanceId: p.instanceId || 'default' },
+              );
+              await AgentIdentityService.ensureAgentInPod(agentUser, podId);
+            }),
+          );
+        }
+      }
+
+      if (config.topic !== undefined) state.topic = config.topic;
+      if (config.participants) {
+        state.participants = config.participants;
+      }
+      if (config.stopConditions) {
+        state.stopConditions = { ...state.stopConditions, ...config.stopConditions } as Required<StopConditions>;
+      }
+      if (config.schedule) {
+        const nextScheduledAt = AgentEnsembleService.resolveNextScheduledAt(config.schedule);
+        state.schedule = {
+          ...state.schedule,
+          ...config.schedule,
+          nextScheduledAt,
+        };
+      }
+      await state.save();
+    }
+
+    const pod = await Pod.findById(podId);
+    if (pod) {
+      const existing = pod.agentEnsemble?.toObject ? pod.agentEnsemble.toObject() : (pod.agentEnsemble || {});
+      const cleanExisting = Object.fromEntries(Object.entries(existing as Record<string, unknown>).filter(([, v]) => v !== undefined));
+      pod.agentEnsemble = { ...cleanExisting, ...config };
+      await pod.save();
+      if (!state) {
+        const scheduleConfig: ScheduleConfig = config.schedule || pod.agentEnsemble?.schedule || {};
+        const participants: ParticipantConfig[] = config.participants || pod.agentEnsemble?.participants || [];
+        if (scheduleConfig.enabled && participants.length >= 2) {
+          const nextScheduledAt = AgentEnsembleService.resolveNextScheduledAt(scheduleConfig);
+          const existingScheduled: EnsembleStateDoc | null = await AgentEnsembleState.findOne({
+            podId,
+            status: 'completed',
+            'schedule.enabled': true,
+          }).sort({ 'schedule.nextScheduledAt': -1, createdAt: -1 });
+
+          if (existingScheduled) {
+            existingScheduled.status = 'pending';
+            existingScheduled.topic = config.topic || pod.agentEnsemble?.topic || 'Open discussion';
+            existingScheduled.participants = participants;
+            existingScheduled.stopConditions = {
+              maxMessages: config.stopConditions?.maxMessages || pod.agentEnsemble?.stopConditions?.maxMessages || 20,
+              maxRounds: config.stopConditions?.maxRounds || pod.agentEnsemble?.stopConditions?.maxRounds || 5,
+              maxDurationMinutes: config.stopConditions?.maxDurationMinutes
+                || pod.agentEnsemble?.stopConditions?.maxDurationMinutes || 60,
+            };
+            existingScheduled.schedule = {
+              enabled: Boolean(scheduleConfig.enabled),
+              cronExpression: scheduleConfig.cronExpression,
+              timezone: scheduleConfig.timezone || 'UTC',
+              lastScheduledAt: null,
+              nextScheduledAt,
+            };
+            await existingScheduled.save();
+            return existingScheduled;
+          }
+
+          const pendingState: EnsembleStateDoc = await AgentEnsembleState.create({
+            podId,
+            status: 'pending',
+            topic: config.topic || pod.agentEnsemble?.topic || 'Open discussion',
+            participants,
+            stopConditions: {
+              maxMessages: config.stopConditions?.maxMessages || pod.agentEnsemble?.stopConditions?.maxMessages || 20,
+              maxRounds: config.stopConditions?.maxRounds || pod.agentEnsemble?.stopConditions?.maxRounds || 5,
+              maxDurationMinutes: config.stopConditions?.maxDurationMinutes
+                || pod.agentEnsemble?.stopConditions?.maxDurationMinutes || 60,
+            },
+            schedule: {
+              enabled: Boolean(scheduleConfig.enabled),
+              cronExpression: scheduleConfig.cronExpression,
+              timezone: scheduleConfig.timezone || 'UTC',
+              lastScheduledAt: null,
+              nextScheduledAt,
+            },
+            createdBy: pod.createdBy,
+          });
+          return pendingState;
+        }
+      }
+      return state || pod;
+    }
+
+    throw new Error('Pod not found');
+  }
+
+  static async resumeAllPaused(): Promise<void> {
+    const pausedStates: EnsembleStateDoc[] = await AgentEnsembleState.findPausedForResume();
+    console.log(`[ensemble] Found ${pausedStates.length} paused discussions to resume`);
+
+    await Promise.allSettled(
+      pausedStates.map(async (state) => {
+        try {
+          state.status = 'active';
+          state.turnState.turnStartedAt = new Date();
+          state.turnState.waitingForResponse = true;
+          await state.save();
+          await AgentEnsembleService.enqueueTurnEvent(state);
+          console.log(`[ensemble] Resumed pod ${state.podId} from turn ${state.turnState.turnNumber}`);
+        } catch (err) {
+          const e = err as { message?: string };
+          console.error(`[ensemble] Failed to resume pod ${state.podId}:`, e.message);
+        }
+      }),
+    );
+  }
+
+  static async processScheduled(): Promise<void> {
+    const dueStates: EnsembleStateDoc[] = await AgentEnsembleState.findScheduledDue().sort({ createdAt: -1 });
+    const seenPods = new Set<string>();
+    const duplicates: unknown[] = [];
+    const scheduledStates: EnsembleStateDoc[] = [];
+
+    dueStates.forEach((state) => {
+      const podKey = String(state.podId);
+      if (seenPods.has(podKey)) {
+        duplicates.push(state._id);
+      } else {
+        seenPods.add(podKey);
+        scheduledStates.push(state);
+      }
+    });
+
+    if (duplicates.length) {
+      const completedAt = new Date();
+      await AgentEnsembleState.updateMany(
+        { _id: { $in: duplicates } },
+        {
+          $set: {
+            status: 'completed',
+            'schedule.enabled': false,
+            'stats.completedAt': completedAt,
+            'stats.completionReason': 'scheduled_restart',
+          },
+        },
+      );
+      console.warn(`[ensemble] Deduped ${duplicates.length} scheduled states`);
+    }
+
+    console.log(`[ensemble] Found ${scheduledStates.length} scheduled discussions to start`);
+
+    await Promise.allSettled(
+      scheduledStates.map(async (state) => {
+        try {
+          if (state.status === 'completed' && state.schedule?.nextScheduledAt) {
+            return;
+          }
+
+          const paused: EnsembleStateDoc | null = await AgentEnsembleState.findOne({
+            podId: state.podId,
+            status: 'paused',
+          }).sort({ createdAt: -1 });
+          if (paused) {
+            console.log(`[ensemble] Skipping scheduled start because discussion is paused in pod ${state.podId}`);
+            return;
+          }
+
+          const existing: EnsembleStateDoc | null = await AgentEnsembleState.findActiveForPod(state.podId);
+          if (existing) {
+            console.log(`[ensemble] Auto-completing active discussion before starting scheduled one in pod ${state.podId}`);
+            await AgentEnsembleService.completeActiveForPod(String(state.podId), 'scheduled_restart');
+          }
+
+          await AgentEnsembleService.startDiscussion(String(state.podId), {
+            topic: state.topic,
+            participants: state.participants,
+          });
+
+          if (state.schedule) {
+            state.schedule.lastScheduledAt = new Date();
+            state.schedule.nextScheduledAt = AgentEnsembleService.resolveNextScheduledAt(state.schedule);
+          }
+          await state.save();
+        } catch (err) {
+          const e = err as { message?: string };
+          console.error('[ensemble] Failed to start scheduled discussion:', e.message);
+        }
+      }),
+    );
+  }
+}
+
+module.exports = AgentEnsembleService;


### PR DESCRIPTION
## Summary
- `agentEnsembleService.ts`: 738-line multi-agent ensemble orchestration service. Interfaces: `ScheduleConfig`, `ParticipantConfig`, `StopConditions`, `TurnState`, `CheckpointEntry`, `EnsembleStateDoc`, `AgentProfileDoc`, `UpdateConfigOptions`. All static methods typed. `module.exports = AgentEnsembleService`.
- `activityService.ts`: 991-line unified activity feed aggregator (messages, activities, summaries, threads). Interfaces: `ActorInfo`, `ActivityFlags`, `ActivityItem`, `UserDoc`, `PodDoc`, `GetFeedOptions`, `ComputeFlagsOptions`. Lazy-load pattern for PGMessage/Message. Typed Map/Set. `module.exports = ActivityService`.

Part of the TypeScript migration initiative — `allowJs: true`, `checkJs: false`, `strict: false`.

## Test plan
- [ ] CI passes (`Test & Coverage` check)
- [ ] No new lint errors
- [ ] Existing JS files untouched

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)