### PR TITLE
feat(ts): TypeScript companions for all 9 backend controllers (batch 19)

### DIFF
--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -1,0 +1,255 @@
+import type { Request, Response } from 'express';
+
+// eslint-disable-next-line global-require
+const bcryptjs = require('bcryptjs');
+// eslint-disable-next-line global-require
+const jwt = require('jsonwebtoken');
+// eslint-disable-next-line global-require
+const User = require('../models/User');
+// eslint-disable-next-line global-require
+const InvitationCode = require('../models/InvitationCode');
+// eslint-disable-next-line global-require
+const WaitlistRequest = require('../models/WaitlistRequest');
+// eslint-disable-next-line global-require
+const AgentIdentityService = require('../services/agentIdentityService');
+
+interface AuthRequest extends Request {
+  userId?: string;
+  user?: { id: string };
+}
+
+interface RegisterBody {
+  username?: string;
+  email?: string;
+  password?: string;
+  invitationCode?: string;
+}
+
+interface LoginBody {
+  email?: string;
+  password?: string;
+}
+
+interface WaitlistBody {
+  email?: string;
+  name?: string;
+  organization?: string;
+  useCase?: string;
+  note?: string;
+}
+
+exports.register = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { username, email, password, invitationCode } = req.body as RegisterBody;
+    if (!username || !email || !password) {
+      res.status(400).json({ msg: 'Username, email and password are required' });
+      return;
+    }
+
+    const existingUser = await User.findOne({ $or: [{ email }, { username }] });
+    if (existingUser) {
+      res.status(400).json({ msg: 'User already exists' });
+      return;
+    }
+
+    const salt = await bcryptjs.genSalt(10);
+    const hashedPassword = await bcryptjs.hash(password, salt);
+
+    const user = await User.create({
+      username,
+      email,
+      password: hashedPassword,
+      invitationCode: invitationCode || null,
+    });
+
+    const payload = { user: { id: user._id } };
+    const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '7d' });
+
+    res.json({
+      token,
+      verified: user.emailVerified || false,
+      user: {
+        id: user._id,
+        username: user.username,
+        email: user.email,
+        profilePicture: user.profilePicture,
+        role: user.role,
+      },
+    });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.getRegistrationPolicy = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const inviteCount = await InvitationCode.countDocuments({ isUsed: false });
+    res.json({
+      inviteOnly: process.env.INVITE_ONLY === 'true',
+      invitationRequired: process.env.INVITATION_REQUIRED === 'true',
+      hasInvitationCodes: inviteCount > 0,
+      registrationOpen: process.env.REGISTRATION_OPEN !== 'false',
+    });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.requestWaitlist = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { email, name, organization, useCase, note } = req.body as WaitlistBody;
+    if (!email) {
+      res.status(400).json({ msg: 'Email is required' });
+      return;
+    }
+    const existing = await WaitlistRequest.findOne({ email });
+    if (existing) {
+      res.json({ msg: 'Already on waitlist', exists: true });
+      return;
+    }
+    await WaitlistRequest.create({ email, name, organization, useCase, note });
+    res.json({ msg: 'Added to waitlist', exists: false });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.verifyEmail = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { token } = req.query as { token?: string };
+    if (!token) {
+      res.status(400).json({ msg: 'Token is required' });
+      return;
+    }
+    const decoded = jwt.verify(token, process.env.JWT_SECRET) as { user?: { id?: string } };
+    const userId = decoded?.user?.id;
+    if (!userId) {
+      res.status(400).json({ msg: 'Invalid token' });
+      return;
+    }
+    await User.findByIdAndUpdate(userId, { emailVerified: true });
+    res.json({ msg: 'Email verified' });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(400).json({ msg: 'Invalid or expired token' });
+  }
+};
+
+exports.login = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { email, password } = req.body as LoginBody;
+    if (!email || !password) {
+      res.status(400).json({ msg: 'Email and password are required' });
+      return;
+    }
+
+    const user = await User.findOne({ email });
+    if (!user) {
+      res.status(400).json({ msg: 'Invalid credentials' });
+      return;
+    }
+
+    const isMatch = await bcryptjs.compare(password, user.password);
+    if (!isMatch) {
+      res.status(400).json({ msg: 'Invalid credentials' });
+      return;
+    }
+
+    const payload = { user: { id: user._id } };
+    const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '7d' });
+
+    res.json({
+      token,
+      verified: user.emailVerified || false,
+      user: {
+        id: user._id,
+        username: user.username,
+        email: user.email,
+        profilePicture: user.profilePicture,
+        role: user.role,
+      },
+    });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.refresh = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const user = await User.findById(userId).select('-password');
+    if (!user) {
+      res.status(404).json({ msg: 'User not found' });
+      return;
+    }
+    const payload = { user: { id: user._id } };
+    const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '7d' });
+    res.json({ token, user });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.getProfile = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const user = await User.findById(userId).select('-password');
+    if (!user) {
+      res.status(404).json({ msg: 'User not found' });
+      return;
+    }
+    res.json(user);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.getCurrentUser = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const user = await User.findById(userId).select('-password');
+    if (!user) {
+      res.status(404).json({ msg: 'User not found' });
+      return;
+    }
+    res.json(user);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.updateProfile = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const { profilePicture } = req.body as { profilePicture?: string };
+    const user = await User.findByIdAndUpdate(
+      userId,
+      { profilePicture },
+      { new: true },
+    ).select('-password');
+    if (!user) {
+      res.status(404).json({ msg: 'User not found' });
+      return;
+    }
+    res.json(user);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};

--- a/backend/controllers/discordController.ts
+++ b/backend/controllers/discordController.ts
@@ -1,0 +1,183 @@
+import type { Request, Response } from 'express';
+
+// eslint-disable-next-line global-require
+const DiscordService = require('../services/discordService');
+// eslint-disable-next-line global-require
+const DiscordIntegration = require('../models/DiscordIntegration');
+// eslint-disable-next-line global-require
+const Integration = require('../models/Integration');
+
+interface AuthRequest extends Request {
+  user?: { id: string };
+}
+
+interface CreateIntegrationBody {
+  podId?: string;
+  serverId?: string;
+  serverName?: string;
+  channelId?: string;
+  channelName?: string;
+  webhookUrl?: string;
+  botToken?: string;
+}
+
+interface UpdateIntegrationBody {
+  serverName?: string;
+  channelName?: string;
+  webhookUrl?: string;
+  botToken?: string;
+}
+
+exports.createIntegration = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const {
+      podId, serverId, serverName, channelId, channelName, webhookUrl, botToken,
+    } = req.body as CreateIntegrationBody;
+
+    const discordIntegration = await DiscordIntegration.create({
+      serverId,
+      serverName,
+      channelId,
+      channelName,
+      webhookUrl,
+      botToken,
+    });
+
+    const integration = await Integration.create({
+      podId,
+      type: 'discord',
+      config: {},
+      createdBy: req.user?.id,
+      platformIntegration: discordIntegration._id,
+      status: 'pending',
+    });
+
+    res.json({ integration, discordIntegration });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error('Error creating Discord integration:', e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.getIntegration = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const id = req.params.id || req.params.integrationId;
+    const integration = await Integration.findById(id).populate('platformIntegration');
+    if (!integration) {
+      res.status(404).json({ msg: 'Integration not found' });
+      return;
+    }
+    res.json(integration);
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Integration not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.updateIntegration = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const id = req.params.id || req.params.integrationId;
+    const { serverName, channelName, webhookUrl, botToken } = req.body as UpdateIntegrationBody;
+
+    const integration = await Integration.findById(id).populate('platformIntegration') as {
+      platformIntegration?: { _id: unknown };
+    } | null;
+    if (!integration) {
+      res.status(404).json({ msg: 'Integration not found' });
+      return;
+    }
+
+    const update: Record<string, unknown> = {};
+    if (serverName !== undefined) update.serverName = serverName;
+    if (channelName !== undefined) update.channelName = channelName;
+    if (webhookUrl !== undefined) update.webhookUrl = webhookUrl;
+    if (botToken !== undefined) update.botToken = botToken;
+
+    const discordIntegration = await DiscordIntegration.findByIdAndUpdate(
+      integration.platformIntegration?._id,
+      update,
+      { new: true },
+    );
+
+    res.json({ integration, discordIntegration });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.getChannels = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const id = req.params.id || req.params.integrationId;
+    const service = new DiscordService(id);
+    await service.initialize();
+    const channels = await service.getChannels();
+    res.json(channels);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error('Error fetching Discord channels:', e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.generateInviteLink = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { clientId, permissions = '8', guildId } = req.body as {
+      clientId?: string;
+      permissions?: string;
+      guildId?: string;
+    };
+    if (!clientId) {
+      res.status(400).json({ msg: 'clientId is required' });
+      return;
+    }
+    let url = `https://discord.com/api/oauth2/authorize?client_id=${clientId}&permissions=${permissions}&scope=bot%20applications.commands`;
+    if (guildId) url += `&guild_id=${guildId}`;
+    res.json({ url });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.testWebhook = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { webhookUrl } = req.body as { webhookUrl?: string };
+    if (!webhookUrl) {
+      res.status(400).json({ msg: 'webhookUrl is required' });
+      return;
+    }
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: '✅ Webhook test from Commonly' }),
+    });
+    res.json({ success: response.ok, status: response.status });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error('Webhook test failed:', e.message);
+    res.status(500).json({ success: false, error: e.message });
+  }
+};
+
+exports.getStats = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const id = req.params.id || req.params.integrationId;
+    const service = new DiscordService(id);
+    await service.initialize();
+    const stats = await service.getStats();
+    res.json(stats);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error('Error getting Discord stats:', e.message);
+    res.status(500).send('Server Error');
+  }
+};

--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -1,0 +1,240 @@
+import type { Request, Response } from 'express';
+
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
+// eslint-disable-next-line global-require
+const MongoMessage = require('../models/Message');
+// eslint-disable-next-line global-require
+const PGMessage = require('../models/pg/Message');
+// eslint-disable-next-line global-require
+const AgentMentionService = require('../services/agentMentionService');
+
+interface AuthRequest extends Request {
+  userId?: string;
+  user?: { id: string; username?: string };
+}
+
+interface NormalizedMessage {
+  id: string;
+  pod_id: string;
+  user_id: string;
+  content: string;
+  message_type: string;
+  created_at: unknown;
+  updated_at: unknown;
+  user?: { username: string; profile_picture?: string };
+}
+
+const pgAvailable = (): boolean => {
+  try {
+    // eslint-disable-next-line global-require
+    const { pool } = require('../config/db-pg');
+    return !!pool;
+  } catch {
+    return false;
+  }
+};
+
+const normalizeMongo = (m: Record<string, unknown>): NormalizedMessage => ({
+  id: (m._id as { toString(): string }).toString(),
+  pod_id: (m.podId as { toString(): string }).toString(),
+  user_id: (m.userId as { toString(): string }).toString(),
+  content: m.content as string,
+  message_type: (m.messageType as string) || 'text',
+  created_at: m.createdAt,
+  updated_at: m.updatedAt,
+  user: (m.userId as { username?: string } | undefined)?.username
+    ? {
+        username: (m.userId as { username: string }).username,
+        profile_picture: (m.userId as { profilePicture?: string }).profilePicture,
+      }
+    : undefined,
+});
+
+exports.getMessages = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { podId } = req.params;
+    const { limit = 50, before } = req.query as { limit?: number; before?: string };
+
+    if (!podId) {
+      res.status(400).json({ msg: 'Pod ID is required' });
+      return;
+    }
+
+    const pod = await Pod.findById(podId) as { members: Array<{ toString(): string }> } | null;
+    if (!pod) {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+
+    const userId = req.userId || req.user?.id;
+    if (!userId) {
+      res.status(401).json({ msg: 'User authentication failed' });
+      return;
+    }
+
+    const userIdStr = userId.toString();
+    const isUserMember = pod.members.some((memberId) => memberId.toString() === userIdStr);
+    if (!isUserMember) {
+      res.status(401).json({ msg: 'Not authorized to view messages in this pod' });
+      return;
+    }
+
+    try {
+      const messages = await PGMessage.findByPodId(podId, parseInt(String(limit), 10), before);
+      res.json(messages);
+      return;
+    } catch (pgErr) {
+      const e = pgErr as { message?: string };
+      console.warn('PG unavailable for getMessages, falling back to MongoDB:', e.message);
+    }
+
+    const query: Record<string, unknown> = { podId };
+    if (before) query.createdAt = { $lt: new Date(before) };
+    const messages = await MongoMessage.find(query)
+      .populate('userId', 'username profilePicture')
+      .sort({ createdAt: -1 })
+      .limit(parseInt(String(limit), 10));
+    res.json(messages.map(normalizeMongo));
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error('Error in getMessages:', e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ error: 'Pod not found' });
+      return;
+    }
+    res.status(500).json({ error: 'Server Error' });
+  }
+};
+
+exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { podId } = req.params;
+    const { content, text, attachments, replyToMessageId } = req.body as {
+      content?: string;
+      text?: string;
+      attachments?: unknown[];
+      replyToMessageId?: string;
+    };
+
+    if (!podId) {
+      res.status(400).json({ msg: 'Pod ID is required' });
+      return;
+    }
+
+    const messageContent = content || text;
+    if (!messageContent && (!attachments || attachments.length === 0)) {
+      res.status(400).json({ msg: 'Message text or attachments are required' });
+      return;
+    }
+
+    const pod = await Pod.findById(podId) as {
+      members: Array<{ toString(): string }>;
+      type?: string;
+      createdBy?: { toString(): string };
+    } | null;
+    if (!pod) {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+
+    const userId = req.userId || req.user?.id;
+    if (!userId) {
+      res.status(401).json({ msg: 'User authentication failed' });
+      return;
+    }
+
+    const userIdStr = userId.toString();
+    const isUserMember = pod.members.some((memberId) => memberId.toString() === userIdStr);
+    if (!isUserMember) {
+      res.status(401).json({ msg: 'Not authorized to post in this pod' });
+      return;
+    }
+
+    let message: NormalizedMessage;
+
+    try {
+      message = await PGMessage.create(
+        podId,
+        userId,
+        messageContent || '',
+        'text',
+        replyToMessageId || null,
+      ) as NormalizedMessage;
+    } catch (pgErr) {
+      const e = pgErr as { message?: string };
+      console.warn('PG unavailable for createMessage, falling back to MongoDB:', e.message);
+      const mongoMsg = await MongoMessage.create({
+        podId,
+        userId,
+        content: messageContent || '',
+        messageType: 'text',
+      });
+      message = normalizeMongo(mongoMsg);
+    }
+
+    const username = req.user?.username;
+    if (pod.type === 'agent-admin') {
+      await AgentMentionService.enqueueDmEvent({ podId, message, userId, username });
+    } else {
+      await AgentMentionService.enqueueMentions({ podId, message, userId, username });
+    }
+
+    res.json(message);
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error('Error in createMessage:', e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ error: 'Pod not found' });
+      return;
+    }
+    res.status(500).json({ error: 'Server Error' });
+  }
+};
+
+exports.deleteMessage = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    let message: NormalizedMessage | null = null;
+    try {
+      message = await PGMessage.findById(req.params.id) as NormalizedMessage | null;
+    } catch {
+      const mongoMsg = await MongoMessage.findById(req.params.id) as Record<string, unknown> | null;
+      if (mongoMsg) message = normalizeMongo(mongoMsg);
+    }
+
+    if (!message) {
+      res.status(404).json({ msg: 'Message not found' });
+      return;
+    }
+
+    const userId = req.userId || req.user?.id;
+    if (!userId) {
+      res.status(401).json({ msg: 'User authentication failed' });
+      return;
+    }
+
+    if (message.user_id.toString() !== userId.toString()) {
+      const pod = await Pod.findById(message.pod_id) as { createdBy?: { toString(): string } } | null;
+      if (!pod || pod.createdBy?.toString() !== userId.toString()) {
+        res.status(401).json({ msg: 'Not authorized to delete this message' });
+        return;
+      }
+    }
+
+    try {
+      await PGMessage.delete(req.params.id);
+    } catch {
+      await MongoMessage.findByIdAndDelete(req.params.id);
+    }
+
+    res.json({ msg: 'Message deleted' });
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error('Error in deleteMessage:', e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ error: 'Message not found' });
+      return;
+    }
+    res.status(500).json({ error: 'Server Error' });
+  }
+};

--- a/backend/controllers/pgMessageController.ts
+++ b/backend/controllers/pgMessageController.ts
@@ -1,0 +1,199 @@
+import type { Request, Response } from 'express';
+
+// eslint-disable-next-line global-require
+const PGPod = require('../models/pg/Pod');
+// eslint-disable-next-line global-require
+const PGMessage = require('../models/pg/Message');
+// eslint-disable-next-line global-require
+const MongoPod = require('../models/Pod');
+
+interface AuthRequest extends Request {
+  userId?: string;
+  user?: { id: string };
+}
+
+async function syncPodFromMongo(podId: string, requestingUserId: string): Promise<unknown> {
+  const mongoPod = await MongoPod.findById(podId).lean() as {
+    name?: string;
+    description?: string;
+    type?: string;
+  } | null;
+  if (!mongoPod) return null;
+  return PGPod.create(
+    mongoPod.name,
+    mongoPod.description || '',
+    mongoPod.type || 'chat',
+    requestingUserId,
+    podId,
+  );
+}
+
+exports.getMessages = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { podId } = req.params;
+    const { limit = 50, before } = req.query as { limit?: number; before?: string };
+
+    if (!podId) {
+      res.status(400).json({ msg: 'Pod ID is required' });
+      return;
+    }
+
+    const userId = req.userId || req.user?.id;
+    if (!userId) {
+      res.status(401).json({ msg: 'User authentication failed' });
+      return;
+    }
+
+    let pod = await PGPod.findById(podId);
+    if (!pod) {
+      pod = await syncPodFromMongo(podId, userId);
+      if (!pod) {
+        res.status(404).json({ msg: 'Pod not found' });
+        return;
+      }
+    }
+
+    console.log(`Checking message access for pod ${podId} by user ${userId}`);
+
+    const isMember = await PGPod.isMember(podId, userId);
+    if (!isMember) {
+      console.error(`User ${userId} is not a member of pod ${podId}`);
+      try {
+        console.log(`Attempting to resolve membership for user ${userId} in pod ${podId}`);
+        await PGPod.addMember(podId, userId);
+        const verifyMembership = await PGPod.isMember(podId, userId);
+        if (verifyMembership) {
+          console.log(`Successfully resolved membership for user ${userId} in pod ${podId}`);
+        } else {
+          console.error(`Failed to resolve membership for user ${userId} in pod ${podId}`);
+          res.status(401).json({ msg: 'Not authorized to view messages in this pod' });
+          return;
+        }
+      } catch (membershipError) {
+        const me = membershipError as { message?: string };
+        console.error(`Error resolving membership: ${me.message}`);
+        res.status(401).json({ msg: 'Not authorized to view messages in this pod' });
+        return;
+      }
+    }
+
+    const messages = await PGMessage.findByPodId(podId, limit, before);
+    res.json(messages);
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error('Error in PG getMessages:', e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { podId } = req.params;
+    const { content } = req.body as { content?: string };
+
+    if (!podId) {
+      res.status(400).json({ msg: 'Pod ID is required' });
+      return;
+    }
+
+    const userId = req.userId || req.user?.id;
+    if (!userId) {
+      res.status(401).json({ msg: 'User authentication failed' });
+      return;
+    }
+
+    const pod = (await PGPod.findById(podId)) || (await syncPodFromMongo(podId, userId));
+    if (!pod) {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+
+    const isMember = await PGPod.isMember(podId, userId);
+    if (!isMember) {
+      res.status(401).json({ msg: 'Not authorized to post in this pod' });
+      return;
+    }
+
+    const newMessage = await PGMessage.create(podId, userId, content);
+    const message = await PGMessage.findById(newMessage.id);
+    res.json(message);
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error('Error in PG createMessage:', e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.updateMessage = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { content } = req.body as { content?: string };
+    const message = await PGMessage.findById(req.params.id) as { user_id?: string } | null;
+    if (!message) {
+      res.status(404).json({ msg: 'Message not found' });
+      return;
+    }
+    if (message.user_id !== req.user?.id) {
+      res.status(401).json({ msg: 'Not authorized to update this message' });
+      return;
+    }
+    const updatedMessage = await PGMessage.update(req.params.id, content);
+    res.json(updatedMessage);
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Message not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.deleteMessage = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    if (!id) {
+      res.status(400).json({ msg: 'Message ID is required' });
+      return;
+    }
+
+    const message = await PGMessage.findById(id) as { user_id?: string; pod_id?: string } | null;
+    if (!message) {
+      res.status(404).json({ msg: 'Message not found' });
+      return;
+    }
+
+    const userId = req.userId || req.user?.id;
+    if (!userId) {
+      res.status(401).json({ msg: 'User authentication failed' });
+      return;
+    }
+
+    if (message.user_id !== userId) {
+      const pod = await PGPod.findById(message.pod_id) as { created_by?: string } | null;
+      if (!pod || pod.created_by !== userId) {
+        res.status(401).json({ msg: 'Not authorized to delete this message' });
+        return;
+      }
+    }
+
+    await PGMessage.delete(id);
+    res.json({ msg: 'Message deleted' });
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error('Error in PG deleteMessage:', e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Message not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};

--- a/backend/controllers/pgPodController.ts
+++ b/backend/controllers/pgPodController.ts
@@ -1,0 +1,174 @@
+import type { Request, Response } from 'express';
+
+// eslint-disable-next-line global-require
+const PGPod = require('../models/pg/Pod');
+// eslint-disable-next-line global-require
+const PGMessage = require('../models/pg/Message');
+
+interface AuthRequest extends Request {
+  user?: { id: string };
+}
+
+exports.getAllPods = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { type } = req.query as { type?: string };
+    const pods = await PGPod.findAll(type);
+    res.json(pods);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.getPodById = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const pod = await PGPod.findById(req.params.id);
+    if (!pod) {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    res.json(pod);
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.createPod = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { name, description, type } = req.body as { name?: string; description?: string; type?: string };
+    const newPod = await PGPod.create(name, description, type, req.user?.id);
+    res.json(newPod);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.updatePod = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { name, description } = req.body as { name?: string; description?: string };
+    const pod = await PGPod.findById(req.params.id);
+    if (!pod) {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    if ((pod as { created_by: string }).created_by !== req.user?.id) {
+      res.status(401).json({ msg: 'Not authorized to update this pod' });
+      return;
+    }
+    const updatedPod = await PGPod.update(req.params.id, name, description);
+    res.json(updatedPod);
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.deletePod = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const pod = await PGPod.findById(req.params.id);
+    if (!pod) {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    if ((pod as { created_by: string }).created_by !== req.user?.id) {
+      res.status(401).json({ msg: 'Not authorized to delete this pod' });
+      return;
+    }
+    await PGMessage.deleteByPodId(req.params.id);
+    await PGPod.delete(req.params.id);
+    res.json({ msg: 'Pod deleted' });
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.joinPod = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    console.log('Join pod request received:', {
+      podId: req.params.id,
+      userId: req.user?.id,
+      userIdType: typeof req.user?.id,
+    });
+
+    const pod = await PGPod.findById(req.params.id);
+    if (!pod) {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+
+    const isMember = await PGPod.isMember(req.params.id, req.user?.id);
+    if (isMember) {
+      console.log(`User ${req.user?.id} is already a member of pod ${req.params.id}`);
+      const updatedPod = await PGPod.findById(req.params.id);
+      res.json(updatedPod);
+      return;
+    }
+
+    await PGPod.addMember(req.params.id, req.user?.id);
+    console.log(`User ${req.user?.id} successfully added to pod ${req.params.id}`);
+
+    const membershipVerified = await PGPod.isMember(req.params.id, req.user?.id);
+    if (!membershipVerified) {
+      console.error(`Failed to verify membership after adding user ${req.user?.id} to pod ${req.params.id}`);
+    }
+
+    const updatedPod = await PGPod.findById(req.params.id);
+    res.json(updatedPod);
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error('Error in pgPodController.joinPod:', e.message);
+    console.error('Request details:', {
+      podId: req.params.id,
+      userId: (req as AuthRequest).user?.id || 'undefined',
+    });
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.leavePod = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const pod = await PGPod.findById(req.params.id);
+    if (!pod) {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    if ((pod as { created_by: string }).created_by === req.user?.id) {
+      res.status(400).json({ msg: 'Pod creator cannot leave the pod' });
+      return;
+    }
+    await PGPod.removeMember(req.params.id, req.user?.id);
+    res.json({ msg: 'Left pod successfully' });
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};

--- a/backend/controllers/pgStatusController.ts
+++ b/backend/controllers/pgStatusController.ts
@@ -1,0 +1,60 @@
+import type { Request, Response } from 'express';
+
+// eslint-disable-next-line global-require
+const { pool } = require('../config/db-pg');
+// eslint-disable-next-line global-require
+const User = require('../models/User');
+
+exports.checkStatus = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    if (!pool) {
+      res.json({ available: false });
+      return;
+    }
+    const result = await pool.query(
+      "SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='messages' LIMIT 1",
+    );
+    res.json({ available: result.rowCount > 0 });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error('PG status check failed:', e.message);
+    res.json({ available: false });
+  }
+};
+
+exports.syncUser = async (req: Request & { userId?: string }, res: Response): Promise<void> => {
+  try {
+    const user = await User.findById((req as unknown as { userId?: string }).userId);
+
+    if (!user) {
+      res.status(404).json({ msg: 'User not found' });
+      return;
+    }
+
+    const query = `
+      INSERT INTO users (_id, username, profile_picture, updated_at)
+      VALUES ($1, $2, $3, CURRENT_TIMESTAMP)
+      ON CONFLICT (_id)
+      DO UPDATE SET
+        username = $2,
+        profile_picture = $3,
+        updated_at = CURRENT_TIMESTAMP
+      RETURNING *
+    `;
+
+    const result = await pool.query(query, [
+      user._id.toString(),
+      user.username,
+      user.profilePicture || null,
+    ]);
+
+    console.log(
+      `User ${user.username} synchronized with PostgreSQL for chat functionality`,
+    );
+    res.json(result.rows[0]);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error('Error syncing user to PostgreSQL for chat:', e.message);
+    res.status(500).send('Server Error');
+  }
+};

--- a/backend/controllers/podController.ts
+++ b/backend/controllers/podController.ts
@@ -1,0 +1,352 @@
+import type { Request, Response } from 'express';
+
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
+// eslint-disable-next-line global-require
+const Message = require('../models/Message');
+// eslint-disable-next-line global-require
+const Post = require('../models/Post');
+// eslint-disable-next-line global-require
+const Summary = require('../models/Summary');
+// eslint-disable-next-line global-require
+const PodAsset = require('../models/PodAsset');
+// eslint-disable-next-line global-require
+const Integration = require('../models/Integration');
+// eslint-disable-next-line global-require
+const { AgentRegistry, AgentInstallation, AgentProfile } = require('../models/AgentRegistry');
+// eslint-disable-next-line global-require
+const AgentIdentityService = require('../services/agentIdentityService');
+// eslint-disable-next-line global-require
+const User = require('../models/User');
+
+const VALID_POD_TYPES = ['chat', 'study', 'games', 'agent-ensemble', 'agent-admin', 'team'] as const;
+type PodType = typeof VALID_POD_TYPES[number];
+
+const DEFAULT_POD_AGENT = 'commonly-bot';
+const DEFAULT_POD_AGENT_SCOPES = [
+  'context:read',
+  'summaries:read',
+  'messages:write',
+  'integration:read',
+  'integration:messages:read',
+  'integration:write',
+];
+
+interface AuthRequest extends Request {
+  userId?: string;
+  user?: { id: string; role?: string };
+}
+
+interface CreatePodBody {
+  name?: string;
+  description?: string;
+  type?: PodType;
+  joinPolicy?: 'open' | 'invite-only';
+  parentPod?: string;
+}
+
+function isGlobalAdminRequest(req: AuthRequest): boolean {
+  return req.user?.role === 'admin';
+}
+
+async function ensureDefaultAgentRegistryEntry(agentName: string): Promise<unknown> {
+  let entry = await AgentRegistry.findOne({ agentName });
+  if (!entry) {
+    entry = await AgentRegistry.create({
+      agentName,
+      displayName: agentName,
+      description: 'Default pod agent',
+      isPublic: true,
+    });
+  }
+  return entry;
+}
+
+function buildDefaultAgentProfileId(agentName: string, instanceId: string): string {
+  return `${agentName}:${instanceId}`;
+}
+
+async function installDefaultAgentForPod(params: { pod: { _id: unknown; name?: string; type?: string }; userId: string }): Promise<void> {
+  try {
+    const { pod, userId } = params;
+    const agentUser = await AgentIdentityService.getOrCreateAgentUser('openclaw', { instanceId: DEFAULT_POD_AGENT });
+    await ensureDefaultAgentRegistryEntry(DEFAULT_POD_AGENT);
+
+    const existing = await AgentInstallation.findOne({
+      agentName: DEFAULT_POD_AGENT,
+      podId: pod._id,
+      status: 'active',
+    });
+    if (existing) return;
+
+    await AgentInstallation.install({
+      agentName: DEFAULT_POD_AGENT,
+      instanceId: DEFAULT_POD_AGENT,
+      podId: pod._id,
+      installedBy: userId,
+      config: {
+        preset: 'default-pod-agent',
+        autoInstalled: true,
+        scopes: DEFAULT_POD_AGENT_SCOPES,
+        version: '1.0.0',
+        displayName: DEFAULT_POD_AGENT,
+        instanceId: DEFAULT_POD_AGENT,
+      },
+    });
+
+    if (agentUser && !pod.members) {
+      await Pod.findByIdAndUpdate(pod._id, { $addToSet: { members: agentUser._id } });
+    }
+  } catch (err) {
+    const e = err as { message?: string };
+    console.warn('[podController] Failed to install default agent:', e.message);
+  }
+}
+
+exports.getAllPods = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { type } = req.query as { type?: string };
+    const filter: Record<string, unknown> = {};
+    if (type) {
+      filter.type = type;
+    } else if (!isGlobalAdminRequest(req)) {
+      filter.type = { $ne: 'agent-admin' };
+    }
+    const pods = await Pod.find(filter)
+      .populate('createdBy', 'username profilePicture')
+      .populate('members', 'username profilePicture')
+      .lean();
+    res.json(pods);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.getPodsByType = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { type } = req.params;
+    const pods = await Pod.find({ type })
+      .populate('createdBy', 'username profilePicture')
+      .populate('members', 'username profilePicture')
+      .lean();
+    res.json(pods);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.getPodById = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const pod = await Pod.findById(req.params.id)
+      .populate('createdBy', 'username profilePicture')
+      .populate('members', 'username profilePicture')
+      .lean();
+    if (!pod) {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    res.json(pod);
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.createPod = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const { name, description, type = 'chat', joinPolicy = 'open', parentPod } = req.body as CreatePodBody;
+
+    if (!name) {
+      res.status(400).json({ msg: 'Pod name is required' });
+      return;
+    }
+    if (!VALID_POD_TYPES.includes(type as PodType)) {
+      res.status(400).json({ msg: `Invalid pod type. Valid types: ${VALID_POD_TYPES.join(', ')}` });
+      return;
+    }
+
+    const pod = await Pod.create({
+      name,
+      description: description || '',
+      type,
+      joinPolicy,
+      createdBy: userId,
+      members: [userId],
+      parentPod: parentPod || null,
+    });
+
+    // Auto-install default agent (fire-and-forget)
+    installDefaultAgentForPod({ pod, userId: String(userId) }).catch((err) => {
+      const e = err as { message?: string };
+      console.warn('[podController] Default agent install failed:', e.message);
+    });
+
+    const populated = await Pod.findById(pod._id)
+      .populate('createdBy', 'username profilePicture')
+      .populate('members', 'username profilePicture')
+      .lean();
+    res.json(populated);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.joinPod = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const pod = await Pod.findById(req.params.id) as {
+      _id: unknown;
+      joinPolicy?: string;
+      members?: Array<{ toString(): string }>;
+      save(): Promise<void>;
+    } | null;
+    if (!pod) {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    if (pod.joinPolicy === 'invite-only') {
+      res.status(403).json({ msg: 'This pod requires an invitation' });
+      return;
+    }
+    if (!pod.members) pod.members = [];
+    const alreadyMember = pod.members.some((id) => id.toString() === String(userId));
+    if (!alreadyMember) {
+      pod.members.push(userId as unknown as { toString(): string });
+      await pod.save();
+    }
+    const populated = await Pod.findById(pod._id)
+      .populate('createdBy', 'username profilePicture')
+      .populate('members', 'username profilePicture')
+      .lean();
+    res.json(populated);
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.leavePod = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const pod = await Pod.findById(req.params.id) as {
+      _id: unknown;
+      createdBy?: { toString(): string };
+      members?: Array<{ toString(): string }>;
+      save(): Promise<void>;
+    } | null;
+    if (!pod) {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    if (pod.createdBy?.toString() === String(userId)) {
+      res.status(400).json({ msg: 'Pod creator cannot leave the pod' });
+      return;
+    }
+    if (pod.members) {
+      pod.members = pod.members.filter((id) => id.toString() !== String(userId));
+    }
+    await pod.save();
+    res.json({ msg: 'Left pod successfully' });
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.removeMember = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const { id: podId, memberId } = req.params;
+    const pod = await Pod.findById(podId) as {
+      _id: unknown;
+      createdBy?: { toString(): string };
+      members?: Array<{ toString(): string }>;
+      save(): Promise<void>;
+    } | null;
+    if (!pod) {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    if (pod.createdBy?.toString() !== String(userId)) {
+      res.status(401).json({ msg: 'Not authorized to remove members from this pod' });
+      return;
+    }
+    if (pod.members) {
+      pod.members = pod.members.filter((id) => id.toString() !== memberId);
+    }
+    await pod.save();
+    const populated = await Pod.findById(pod._id)
+      .populate('createdBy', 'username profilePicture')
+      .populate('members', 'username profilePicture')
+      .lean();
+    res.json(populated);
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.deletePod = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const pod = await Pod.findById(req.params.id) as {
+      _id: unknown;
+      createdBy?: { toString(): string };
+      deleteOne?(): Promise<void>;
+    } | null;
+    if (!pod) {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    if (pod.createdBy?.toString() !== String(userId) && !isGlobalAdminRequest(req)) {
+      res.status(401).json({ msg: 'Not authorized to delete this pod' });
+      return;
+    }
+    // Cascade delete associated data
+    await Promise.all([
+      Message.deleteMany({ podId: pod._id }),
+      Post.deleteMany({ podId: pod._id }),
+      Summary.deleteMany({ podId: pod._id }),
+      PodAsset.deleteMany({ podId: pod._id }),
+      Integration.deleteMany({ podId: pod._id }),
+      AgentInstallation.deleteMany({ podId: pod._id }),
+    ]);
+    await pod.deleteOne?.();
+    res.json({ msg: 'Pod deleted' });
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Pod not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};

--- a/backend/controllers/postController.ts
+++ b/backend/controllers/postController.ts
@@ -1,0 +1,383 @@
+import type { Request, Response } from 'express';
+
+// eslint-disable-next-line global-require
+const Post = require('../models/Post');
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
+// eslint-disable-next-line global-require
+const User = require('../models/User');
+// eslint-disable-next-line global-require
+const Activity = require('../models/Activity');
+
+interface AuthRequest extends Request {
+  userId?: string;
+  user?: { id: string; username?: string };
+}
+
+interface CreatePostBody {
+  content?: string;
+  image?: string;
+  tags?: string[];
+  podId?: string | null;
+  category?: string;
+  source?: {
+    type?: string;
+    provider?: string;
+    externalId?: string;
+    url?: string;
+    author?: string;
+    authorUrl?: string;
+    channel?: string;
+  };
+}
+
+interface AddCommentBody {
+  text?: string;
+  podId?: string;
+  replyToCommentId?: string;
+}
+
+interface GetPostsQuery {
+  podId?: string;
+  category?: string;
+  sort?: string;
+  page?: string;
+  limit?: string;
+}
+
+interface SearchPostsQuery {
+  query?: string;
+  tags?: string;
+  podId?: string;
+  category?: string;
+}
+
+exports.createPost = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const { content, image, tags, podId, category, source } = req.body as CreatePostBody;
+    if (!content) {
+      res.status(400).json({ msg: 'Content is required' });
+      return;
+    }
+    const post = await Post.create({
+      userId,
+      content,
+      image,
+      tags: tags || [],
+      podId: podId || null,
+      category: category || 'General',
+      source: source || null,
+    });
+    res.json(post);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.getUserStats = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.params.id || req.userId || req.user?.id;
+    const [postCount, commentCount] = await Promise.all([
+      Post.countDocuments({ userId }),
+      Post.countDocuments({ 'comments.userId': userId }),
+    ]);
+    res.json({ postCount, commentCount });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.searchPosts = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { query, tags, podId, category } = req.query as SearchPostsQuery;
+    const filter: Record<string, unknown> = {};
+    if (podId) filter.podId = podId;
+    if (category) filter.category = category;
+    if (tags) filter.tags = { $in: tags.split(',').map((t) => t.trim()) };
+    if (query) {
+      filter.$text = { $search: query };
+    }
+    const posts = await Post.find(filter)
+      .populate('userId', 'username profilePicture')
+      .sort({ createdAt: -1 })
+      .limit(50)
+      .lean();
+    res.json(posts);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.getPosts = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { podId, category, sort = 'recent', page = '1', limit = '20' } = req.query as GetPostsQuery;
+    const pageNum = Math.max(parseInt(page, 10) || 1, 1);
+    const limitNum = Math.min(parseInt(limit, 10) || 20, 100);
+    const skip = (pageNum - 1) * limitNum;
+
+    const filter: Record<string, unknown> = {};
+    if (podId) filter.podId = podId;
+    if (category) filter.category = category;
+
+    const sortOrder = sort === 'hot' ? { likes: -1, createdAt: -1 } : { createdAt: -1 };
+
+    const [posts, total] = await Promise.all([
+      Post.find(filter)
+        .populate('userId', 'username profilePicture')
+        .sort(sortOrder)
+        .skip(skip)
+        .limit(limitNum)
+        .lean(),
+      Post.countDocuments(filter),
+    ]);
+
+    res.json({
+      posts,
+      hasMore: skip + posts.length < total,
+      total,
+      page: pageNum,
+    });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.getPostById = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const post = await Post.findById(req.params.id)
+      .populate('userId', 'username profilePicture')
+      .lean();
+    if (!post) {
+      res.status(404).json({ msg: 'Post not found' });
+      return;
+    }
+    res.json(post);
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Post not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.addComment = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const { text, podId, replyToCommentId } = req.body as AddCommentBody;
+    if (!text) {
+      res.status(400).json({ msg: 'Comment text is required' });
+      return;
+    }
+    const post = await Post.findById(req.params.id);
+    if (!post) {
+      res.status(404).json({ msg: 'Post not found' });
+      return;
+    }
+    const comment: Record<string, unknown> = { userId, text, createdAt: new Date() };
+    if (replyToCommentId) comment.replyTo = replyToCommentId;
+    post.comments.push(comment);
+    await post.save();
+
+    const savedComment = post.comments[post.comments.length - 1] as Record<string, unknown>;
+
+    // Enqueue agent mentions (lazy import to avoid circular deps)
+    try {
+      // eslint-disable-next-line global-require
+      const AgentMentionService = require('../services/agentMentionService');
+      await AgentMentionService.enqueueMentions({
+        podId: podId || post.podId,
+        message: { id: savedComment._id, content: text, user_id: userId },
+        userId,
+        username: req.user?.username,
+      });
+    } catch (mentionErr) {
+      const me = mentionErr as { message?: string };
+      console.warn('AgentMentionService error on comment:', me.message);
+    }
+
+    res.json(post);
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Post not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.likePost = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const post = await Post.findById(req.params.id) as {
+      likes?: Array<{ toString(): string }>;
+      save(): Promise<void>;
+      _id: unknown;
+    } | null;
+    if (!post) {
+      res.status(404).json({ msg: 'Post not found' });
+      return;
+    }
+    if (!post.likes) post.likes = [];
+    const alreadyLiked = post.likes.some((id) => id.toString() === String(userId));
+    if (alreadyLiked) {
+      post.likes = post.likes.filter((id) => id.toString() !== String(userId));
+    } else {
+      post.likes.push(userId as unknown as { toString(): string });
+    }
+    await post.save();
+    res.json({ likes: post.likes.length, liked: !alreadyLiked });
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Post not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.deletePost = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const post = await Post.findById(req.params.id) as { userId?: { toString(): string }; deleteOne?(): Promise<void> } | null;
+    if (!post) {
+      res.status(404).json({ msg: 'Post not found' });
+      return;
+    }
+    if (post.userId?.toString() !== String(userId)) {
+      res.status(401).json({ msg: 'Not authorized to delete this post' });
+      return;
+    }
+    await post.deleteOne?.();
+    res.json({ msg: 'Post deleted' });
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Post not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.deleteComment = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const post = await Post.findById(req.params.id) as {
+      comments: Array<{ _id: { toString(): string }; userId?: { toString(): string } }>;
+      save(): Promise<void>;
+    } | null;
+    if (!post) {
+      res.status(404).json({ msg: 'Post not found' });
+      return;
+    }
+    const comment = post.comments.find((c) => c._id.toString() === req.params.commentId);
+    if (!comment) {
+      res.status(404).json({ msg: 'Comment not found' });
+      return;
+    }
+    if (comment.userId?.toString() !== String(userId)) {
+      res.status(401).json({ msg: 'Not authorized to delete this comment' });
+      return;
+    }
+    post.comments = post.comments.filter((c) => c._id.toString() !== req.params.commentId) as typeof post.comments;
+    await post.save();
+    res.json(post);
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'Post or comment not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.followThread = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    await User.findByIdAndUpdate(userId, { $addToSet: { followedThreads: req.params.id } });
+    res.json({ msg: 'Thread followed' });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.unfollowThread = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    await User.findByIdAndUpdate(userId, { $pull: { followedThreads: req.params.id } });
+    res.json({ msg: 'Thread unfollowed' });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.toggleAgentComments = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const post = await Post.findById(req.params.id) as {
+      userId?: { toString(): string };
+      agentCommentsDisabled?: boolean;
+      save(): Promise<void>;
+    } | null;
+    if (!post) {
+      res.status(404).json({ msg: 'Post not found' });
+      return;
+    }
+    if (post.userId?.toString() !== String(userId)) {
+      res.status(401).json({ msg: 'Not authorized' });
+      return;
+    }
+    post.agentCommentsDisabled = !post.agentCommentsDisabled;
+    await post.save();
+    res.json({ agentCommentsDisabled: post.agentCommentsDisabled });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.getFollowedThreads = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const user = await User.findById(userId).select('followedThreads').lean() as {
+      followedThreads?: string[];
+    } | null;
+    if (!user) {
+      res.status(404).json({ msg: 'User not found' });
+      return;
+    }
+    const threads = user.followedThreads || [];
+    const posts = await Post.find({ _id: { $in: threads } })
+      .populate('userId', 'username profilePicture')
+      .lean();
+    res.json(posts);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};

--- a/backend/controllers/userController.ts
+++ b/backend/controllers/userController.ts
@@ -1,0 +1,173 @@
+import type { Request, Response } from 'express';
+
+// eslint-disable-next-line global-require
+const User = require('../models/User');
+// eslint-disable-next-line global-require
+const Activity = require('../models/Activity');
+// eslint-disable-next-line global-require
+const Post = require('../models/Post');
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
+// eslint-disable-next-line global-require
+const AgentIdentityService = require('../services/agentIdentityService');
+
+interface AuthRequest extends Request {
+  userId?: string;
+  user?: { id: string };
+}
+
+exports.getCurrentProfile = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const user = await User.findById(userId).select('-password');
+    if (!user) {
+      res.status(404).json({ msg: 'User not found' });
+      return;
+    }
+    res.json(user);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.updateProfile = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId || req.user?.id;
+    const { username, bio, profilePicture } = req.body as {
+      username?: string;
+      bio?: string;
+      profilePicture?: string;
+    };
+    const update: Record<string, unknown> = {};
+    if (username !== undefined) update.username = username;
+    if (bio !== undefined) update.bio = bio;
+    if (profilePicture !== undefined) update.profilePicture = profilePicture;
+    const user = await User.findByIdAndUpdate(userId, update, { new: true }).select('-password');
+    if (!user) {
+      res.status(404).json({ msg: 'User not found' });
+      return;
+    }
+    res.json(user);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.getUserById = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const user = await User.findById(req.params.id).select('-password');
+    if (!user) {
+      res.status(404).json({ msg: 'User not found' });
+      return;
+    }
+    res.json(user);
+  } catch (err) {
+    const e = err as { message?: string; kind?: string };
+    console.error(e.message);
+    if (e.kind === 'ObjectId') {
+      res.status(404).json({ msg: 'User not found' });
+      return;
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.getUserPublicActivity = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const user = await User.findById(req.params.id).select('-password') as {
+      _id: unknown; username: string;
+    } | null;
+    if (!user) {
+      res.status(404).json({ msg: 'User not found' });
+      return;
+    }
+    const [posts, pods] = await Promise.all([
+      Post.find({ userId: user._id, podId: null })
+        .sort({ createdAt: -1 })
+        .limit(10)
+        .lean(),
+      Pod.find({ members: user._id })
+        .populate('createdBy', 'username profilePicture')
+        .lean(),
+    ]);
+    res.json({
+      userId: user._id,
+      username: user.username,
+      recentPublicPosts: posts,
+      joinedPods: pods,
+    });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.followUser = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const actorId = req.userId || req.user?.id;
+    const targetId = req.params.id;
+    const [actor, target] = await Promise.all([
+      User.findById(actorId),
+      User.findById(targetId),
+    ]);
+    if (!actor || !target) {
+      res.status(404).json({ msg: 'User not found' });
+      return;
+    }
+    if (!actor.following) actor.following = [];
+    if (!target.followers) target.followers = [];
+    const alreadyFollowing = actor.following.some((id: { toString(): string }) => id.toString() === targetId);
+    if (!alreadyFollowing) {
+      actor.following.push(targetId);
+      target.followers.push(actorId);
+      await Promise.all([actor.save(), target.save()]);
+    }
+    res.json({
+      success: true,
+      following: true,
+      target: { id: target._id, username: target.username, followersCount: target.followers.length },
+      actor: { id: actor._id, username: actor.username, followingCount: actor.following.length },
+    });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+exports.unfollowUser = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const actorId = req.userId || req.user?.id;
+    const targetId = req.params.id;
+    const [actor, target] = await Promise.all([
+      User.findById(actorId),
+      User.findById(targetId),
+    ]);
+    if (!actor || !target) {
+      res.status(404).json({ msg: 'User not found' });
+      return;
+    }
+    if (actor.following) {
+      actor.following = actor.following.filter((id: { toString(): string }) => id.toString() !== targetId);
+    }
+    if (target.followers) {
+      target.followers = target.followers.filter((id: { toString(): string }) => id.toString() !== actorId);
+    }
+    await Promise.all([actor.save(), target.save()]);
+    res.json({
+      success: true,
+      following: false,
+      target: { id: target._id, username: target.username, followersCount: (target.followers || []).length },
+      actor: { id: actor._id, username: actor.username, followingCount: (actor.following || []).length },
+    });
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error(e.message);
+    res.status(500).send('Server Error');
+  }
+};


### PR DESCRIPTION
## Summary
TypeScript companions for all 9 Express controllers in `backend/controllers/`:

- `pgStatusController.ts` — PG health check + user sync
- `pgPodController.ts` — PG-native pod CRUD
- `pgMessageController.ts` — PG-native message CRUD with MongoDB auto-sync
- `messageController.ts` — PG+MongoDB dual-write message controller
- `userController.ts` — User profile, follow/unfollow, public activity
- `discordController.ts` — Discord integration CRUD + webhook test
- `authController.ts` — Register, login, JWT refresh, email verify, waitlist
- `postController.ts` — Post/comment CRUD, likes, thread follow, agent toggle
- `podController.ts` — Pod CRUD with default agent auto-install

## Strategy
`allowJs: true`, `checkJs: false`, `strict: false`. All exports use `exports.fn = async (req: AuthRequest, res: Response)`. `req.userId` typed via `AuthRequest` interface. All errors narrowed with `const e = err as { message?: string }`.

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)