### PR TITLE
feat(ts): TypeScript companions for backend/integrations (batch 21)

### DIFF
--- a/backend/integrations/catalog.ts
+++ b/backend/integrations/catalog.ts
@@ -1,0 +1,72 @@
+// eslint-disable-next-line global-require
+const Integration = require('../models/Integration');
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
+// eslint-disable-next-line global-require
+const { manifests } = require('./manifests');
+
+interface ManifestEntry {
+  id: string;
+  requiredConfig: string[];
+  configSchema: unknown;
+  catalog: unknown;
+}
+
+interface CatalogEntry extends ManifestEntry {
+  stats?: { activeIntegrations: number };
+}
+
+function getManifestEntries(): ManifestEntry[] {
+  return Object.values(manifests as Record<string, ManifestEntry>).map((manifest) => ({
+    id: manifest.id,
+    requiredConfig: manifest.requiredConfig || [],
+    configSchema: manifest.configSchema || null,
+    catalog: manifest.catalog || null,
+  }));
+}
+
+async function buildCatalogEntries(params: { userId?: string }): Promise<CatalogEntry[]> {
+  const { userId } = params;
+  const manifestEntries = getManifestEntries();
+  if (!userId) {
+    return manifestEntries;
+  }
+
+  const pods = await Pod.find({ members: userId }).select('_id').lean() as Array<{ _id: unknown }>;
+  const podIds = pods.map((pod) => pod._id);
+  if (!podIds.length) {
+    return manifestEntries;
+  }
+
+  const counts = await Integration.aggregate([
+    {
+      $match: {
+        podId: { $in: podIds },
+        isActive: true,
+      },
+    },
+    {
+      $group: {
+        _id: '$type',
+        count: { $sum: 1 },
+      },
+    },
+  ]) as Array<{ _id: string; count: number }>;
+
+  const countsByType = counts.reduce<Record<string, number>>((acc, item) => ({
+    ...acc,
+    [item._id]: item.count,
+  }), {});
+
+  return manifestEntries.map((entry) => ({
+    ...entry,
+    stats: {
+      activeIntegrations: countsByType[entry.id] || 0,
+    },
+  }));
+}
+
+module.exports = {
+  getManifestEntries,
+  buildCatalogEntries,
+};

--- a/backend/integrations/index.ts
+++ b/backend/integrations/index.ts
@@ -1,0 +1,70 @@
+// Shared integration registry for backend providers.
+// Uses the open-sourceable SDK registry.
+
+interface IntegrationDoc {
+  _id: unknown;
+  config?: Record<string, unknown>;
+  platformIntegration?: unknown;
+  [key: string]: unknown;
+}
+
+interface IntegrationProvider {
+  validateConfig?: () => Promise<void>;
+  getWebhookHandlers?: () => Record<string, unknown>;
+  ingestEvent?: (payload: unknown) => Promise<unknown[]>;
+  syncRecent?: (opts?: unknown) => Promise<unknown>;
+  health?: () => Promise<{ ok: boolean; error?: string }>;
+}
+
+interface RegistryLike {
+  providers: Map<string, (integration: IntegrationDoc) => IntegrationProvider>;
+  register: (type: string, factory: (integration: IntegrationDoc) => IntegrationProvider) => void;
+  get: (type: string, config: IntegrationDoc) => IntegrationProvider;
+}
+
+let registry: RegistryLike;
+try {
+  // eslint-disable-next-line global-require, import/no-unresolved
+  ({ registry } = require('../../packages/integration-sdk/src'));
+} catch {
+  class IntegrationRegistry implements RegistryLike {
+    providers: Map<string, (integration: IntegrationDoc) => IntegrationProvider>;
+
+    constructor() {
+      this.providers = new Map();
+    }
+
+    register(type: string, factory: (integration: IntegrationDoc) => IntegrationProvider): void {
+      this.providers.set(type, factory);
+    }
+
+    get(type: string, config: IntegrationDoc): IntegrationProvider {
+      const factory = this.providers.get(type);
+      if (!factory) throw new Error(`No provider registered for ${type}`);
+      return factory(config);
+    }
+  }
+  registry = new IntegrationRegistry();
+}
+
+// eslint-disable-next-line global-require
+const createDiscordProvider = require('./providers/discordProvider');
+// eslint-disable-next-line global-require
+const createSlackProvider = require('./providers/slackProvider');
+// eslint-disable-next-line global-require
+const createGroupMeProvider = require('./providers/groupmeProvider');
+// eslint-disable-next-line global-require
+const createTelegramProvider = require('./providers/telegramProvider');
+// eslint-disable-next-line global-require
+const createXProvider = require('./providers/xProvider');
+// eslint-disable-next-line global-require
+const createInstagramProvider = require('./providers/instagramProvider');
+
+registry.register('discord', (integration) => createDiscordProvider(integration));
+registry.register('slack', (integration) => createSlackProvider(integration));
+registry.register('groupme', (integration) => createGroupMeProvider(integration));
+registry.register('telegram', (integration) => createTelegramProvider(integration));
+registry.register('x', (integration) => createXProvider(integration));
+registry.register('instagram', (integration) => createInstagramProvider(integration));
+
+module.exports = registry;

--- a/backend/integrations/manifests.ts
+++ b/backend/integrations/manifests.ts
@@ -1,0 +1,128 @@
+interface IntegrationManifest {
+  id: string;
+  requiredConfig: string[];
+  configSchema: unknown;
+  catalog: {
+    label: string;
+    provider: string;
+    category: string;
+    docsPath: string;
+    description: string;
+    capabilities: string[];
+  } | null;
+}
+
+let sdk: {
+  buildConfigSchema?: (fields?: string[]) => unknown;
+  validateManifest?: (manifest: IntegrationManifest) => IntegrationManifest;
+  catalog?: { register?: (manifest: IntegrationManifest) => void };
+};
+try {
+  // eslint-disable-next-line global-require, import/no-unresolved
+  sdk = require('../../packages/integration-sdk/src');
+} catch {
+  sdk = {
+    buildConfigSchema: (requiredFields: string[] = []) => ({
+      type: 'object',
+      additionalProperties: true,
+      properties: Object.fromEntries(requiredFields.map((f) => [f, { type: 'string' }])),
+      required: [...requiredFields],
+    }),
+    validateManifest: (manifest: IntegrationManifest) => manifest,
+  };
+}
+
+const { buildConfigSchema, validateManifest } = sdk as Required<typeof sdk>;
+
+const manifests: Record<string, IntegrationManifest> = {
+  discord: validateManifest({
+    id: 'discord',
+    requiredConfig: ['serverId', 'channelId', 'botToken'],
+    configSchema: buildConfigSchema(['serverId', 'channelId', 'botToken']),
+    catalog: {
+      label: 'Discord',
+      provider: 'discord',
+      category: 'chat',
+      docsPath: 'docs/discord/DISCORD.md',
+      description: 'Ingest Discord channel activity and post pod summaries.',
+      capabilities: ['webhook', 'gateway', 'summary', 'commands'],
+    },
+  }),
+  slack: validateManifest({
+    id: 'slack',
+    requiredConfig: ['botToken', 'signingSecret', 'channelId'],
+    configSchema: buildConfigSchema(['botToken', 'signingSecret', 'channelId']),
+    catalog: {
+      label: 'Slack',
+      provider: 'slack',
+      category: 'chat',
+      docsPath: 'docs/slack/README.md',
+      description: 'Ingest Slack Events API messages into pod summaries.',
+      capabilities: ['webhook', 'summary', 'commands'],
+    },
+  }),
+  groupme: validateManifest({
+    id: 'groupme',
+    requiredConfig: ['botId', 'groupId'],
+    configSchema: buildConfigSchema(['botId', 'groupId']),
+    catalog: {
+      label: 'GroupMe',
+      provider: 'groupme',
+      category: 'chat',
+      docsPath: 'docs/groupme/README.md',
+      description: 'Buffer GroupMe messages and summarize them into pods.',
+      capabilities: ['webhook', 'commands', 'summary'],
+    },
+  }),
+  telegram: validateManifest({
+    id: 'telegram',
+    requiredConfig: ['chatId'],
+    configSchema: buildConfigSchema(['chatId']),
+    catalog: {
+      label: 'Telegram',
+      provider: 'telegram',
+      category: 'chat',
+      docsPath: 'docs/telegram/README.md',
+      description: 'Ingest Telegram updates into pod summaries.',
+      capabilities: ['webhook', 'summary', 'commands'],
+    },
+  }),
+  x: validateManifest({
+    id: 'x',
+    requiredConfig: ['accessToken', 'username'],
+    configSchema: buildConfigSchema(['accessToken', 'username', 'userId', 'category']),
+    catalog: {
+      label: 'X',
+      provider: 'x',
+      category: 'social',
+      docsPath: 'docs/x/README.md',
+      description: 'Pull X posts into pods for searchable context and summaries.',
+      capabilities: ['polling', 'posts', 'summary'],
+    },
+  }),
+  instagram: validateManifest({
+    id: 'instagram',
+    requiredConfig: ['accessToken', 'igUserId'],
+    configSchema: buildConfigSchema(['accessToken', 'igUserId', 'username', 'category']),
+    catalog: {
+      label: 'Instagram',
+      provider: 'instagram',
+      category: 'social',
+      docsPath: 'docs/instagram/README.md',
+      description: 'Pull Instagram posts into pods for searchable context and summaries.',
+      capabilities: ['polling', 'posts', 'summary'],
+    },
+  }),
+};
+
+if (sdk.catalog && typeof sdk.catalog.register === 'function') {
+  Object.values(manifests).forEach((manifest) => {
+    try {
+      sdk.catalog!.register!(manifest);
+    } catch {
+      // Ignore catalog registration errors
+    }
+  });
+}
+
+module.exports = { manifests };

--- a/backend/integrations/normalizeBufferMessage.ts
+++ b/backend/integrations/normalizeBufferMessage.ts
@@ -1,0 +1,50 @@
+interface RawMessage {
+  messageId?: unknown;
+  externalId?: unknown;
+  authorId?: unknown;
+  authorName?: string;
+  content?: string;
+  timestamp?: unknown;
+  attachments?: Array<string | null | { url?: string; title?: string }>;
+  [key: string]: unknown;
+}
+
+interface NormalizedMessage {
+  messageId?: string;
+  authorId?: string;
+  authorName: string;
+  content: string;
+  timestamp: Date;
+  attachments: string[];
+}
+
+function normalizeBufferMessage(message: RawMessage | null | undefined): NormalizedMessage | null {
+  if (!message) return null;
+
+  const externalId = message.messageId || message.externalId;
+  let attachments: string[] = [];
+  if (Array.isArray(message.attachments)) {
+    attachments = message.attachments
+      .map((attachment) => {
+        if (!attachment) return null;
+        if (typeof attachment === 'string') return attachment;
+        if ((attachment as { url?: string }).url) return (attachment as { url: string }).url;
+        if ((attachment as { title?: string }).title) return (attachment as { title: string }).title;
+        return null;
+      })
+      .filter((a): a is string => a !== null);
+  }
+  const content =
+    message.content || (attachments.length ? 'Shared an attachment' : '');
+
+  return {
+    messageId: externalId ? String(externalId) : undefined,
+    authorId: message.authorId ? String(message.authorId) : undefined,
+    authorName: message.authorName || 'Unknown',
+    content,
+    timestamp: message.timestamp ? new Date(message.timestamp as string) : new Date(),
+    attachments,
+  };
+}
+
+module.exports = { normalizeBufferMessage };

--- a/backend/integrations/providers/discordProvider.ts
+++ b/backend/integrations/providers/discordProvider.ts
@@ -1,0 +1,113 @@
+// eslint-disable-next-line global-require
+const DiscordService = require('../../services/discordService');
+// eslint-disable-next-line global-require
+const { manifests } = require('../manifests');
+
+interface IntegrationDoc {
+  _id: unknown;
+  config?: Record<string, unknown>;
+  platformIntegration?: {
+    toObject?: () => Record<string, unknown>;
+    botToken?: string;
+    [key: string]: unknown;
+  };
+}
+
+interface DiscordConfig extends Record<string, unknown> {
+  botToken?: string;
+  webhookUrl?: string;
+}
+
+interface DiscordProvider {
+  validateConfig(): Promise<void>;
+  getWebhookHandlers(): Record<string, (req: unknown, res: { json: (data: unknown) => void }) => unknown>;
+  ingestEvent(payload: unknown): Promise<unknown[]>;
+  syncRecent(opts?: { hours?: number }): Promise<unknown>;
+  health(): Promise<{ ok: boolean; error?: string }>;
+}
+
+let ValidationError: new (msg: string) => Error;
+let validateRequiredConfig: (config: unknown, manifest: unknown) => void;
+try {
+  // eslint-disable-next-line global-require, import/no-unresolved
+  ({ ValidationError } = require('../../../packages/integration-sdk/src/errors'));
+  // eslint-disable-next-line global-require, import/no-unresolved
+  ({ validateRequiredConfig } = require('../../../packages/integration-sdk/src/manifest'));
+} catch {
+  ValidationError = class extends Error {};
+  validateRequiredConfig = (config: unknown, manifest: unknown) => {
+    const required = (manifest as { requiredConfig?: string[] })?.requiredConfig || [];
+    const missing = required.filter((f) => !(config as Record<string, unknown>)?.[f]);
+    if (missing.length) throw new ValidationError(`Missing fields: ${missing.join(', ')}`);
+  };
+}
+
+function buildEffectiveConfig(integration: IntegrationDoc): DiscordConfig {
+  const platformConfig = integration?.platformIntegration?.toObject
+    ? integration.platformIntegration.toObject()
+    : integration?.platformIntegration || {};
+
+  return {
+    ...integration?.config,
+    ...(platformConfig as Record<string, unknown>),
+    botToken:
+      (integration?.config?.botToken as string | undefined)
+      || (platformConfig as { botToken?: string }).botToken
+      || process.env.DISCORD_BOT_TOKEN,
+  };
+}
+
+function createDiscordProvider(integration: IntegrationDoc): DiscordProvider {
+  const config = buildEffectiveConfig(integration);
+
+  return {
+    async validateConfig() {
+      try {
+        validateRequiredConfig(config, manifests.discord);
+        if (config.webhookUrl) {
+          await DiscordService.validateConfig(config);
+        }
+      } catch (err) {
+        const e = err as { message?: string };
+        throw new ValidationError(e.message || 'Validation failed');
+      }
+    },
+
+    getWebhookHandlers() {
+      return {
+        verify: (_req: unknown, res: { json: (data: unknown) => void }) => res.json({ type: 1 }),
+        events: async (req: { body: unknown }, res: { json: (data: unknown) => void }) => {
+          const service = new DiscordService(integration._id);
+          await service.handleWebhook(req.body);
+          res.json({ success: true });
+        },
+      };
+    },
+
+    async ingestEvent(payload: unknown): Promise<unknown[]> {
+      const service = new DiscordService(integration._id);
+      await service.handleWebhook(payload);
+      return [];
+    },
+
+    async syncRecent({ hours = 1 } = {}): Promise<unknown> {
+      const service = new DiscordService(integration._id);
+      await service.initialize();
+      return service.syncRecentMessages(hours);
+    },
+
+    async health(): Promise<{ ok: boolean; error?: string }> {
+      const service = new DiscordService(integration._id);
+      try {
+        await service.ensureClientReady();
+        return { ok: true };
+      } catch (err) {
+        const e = err as { message?: string };
+        return { ok: false, error: e.message };
+      }
+    },
+  };
+}
+
+module.exports = createDiscordProvider;
+// LEGACY: in-platform provider. External service will replace this module.

--- a/backend/integrations/providers/groupmeProvider.ts
+++ b/backend/integrations/providers/groupmeProvider.ts
@@ -1,0 +1,270 @@
+// eslint-disable-next-line global-require
+const Integration = require('../../models/Integration');
+// eslint-disable-next-line global-require
+const { normalizeBufferMessage } = require('../normalizeBufferMessage');
+// eslint-disable-next-line global-require
+const IntegrationSummaryService = require('../../services/integrationSummaryService');
+// eslint-disable-next-line global-require
+const AgentEventService = require('../../services/agentEventService');
+// eslint-disable-next-line global-require
+const groupmeService = require('../../services/groupmeService');
+// eslint-disable-next-line global-require
+const Summary = require('../../models/Summary');
+// eslint-disable-next-line global-require
+const { manifests } = require('../manifests');
+
+interface GroupMePayload {
+  system?: boolean;
+  sender_type?: string;
+  attachments?: Array<{ url?: string; text?: string }>;
+  text?: string;
+  created_at?: number;
+  id?: string | number;
+  user_id?: string | number;
+  sender_id?: string | number;
+  name?: string;
+  group_id?: string | number;
+  [key: string]: unknown;
+}
+
+interface NormalizedGroupMeMessage {
+  source: 'groupme';
+  externalId: string | undefined;
+  authorId: string;
+  authorName: string | undefined;
+  content: string;
+  timestamp: string;
+  attachments: Array<{ type: string; url: string }>;
+  metadata: { groupId: string | undefined };
+  raw: unknown;
+}
+
+interface GroupMeProvider {
+  validateConfig(): Promise<void>;
+  getWebhookHandlers(): Record<string, (req: unknown, res: unknown) => unknown>;
+  ingestEvent(payload: unknown): Promise<NormalizedGroupMeMessage[]>;
+  syncRecent(opts?: unknown): Promise<{ success: boolean; messageCount: number; messages: unknown[]; content: string }>;
+  health(): Promise<{ ok: boolean; error?: string }>;
+}
+
+let ValidationError: new (msg: string) => Error;
+let validateRequiredConfig: (config: unknown, manifest: unknown) => void;
+try {
+  // eslint-disable-next-line global-require, import/no-unresolved
+  ({ ValidationError } = require('../../../packages/integration-sdk/src/errors'));
+  // eslint-disable-next-line global-require, import/no-unresolved
+  ({ validateRequiredConfig } = require('../../../packages/integration-sdk/src/manifest'));
+} catch {
+  ValidationError = class extends Error {};
+  validateRequiredConfig = (config: unknown, manifest: unknown) => {
+    const required = (manifest as { requiredConfig?: string[] })?.requiredConfig || [];
+    const missing = required.filter((f) => !(config as Record<string, unknown>)?.[f]);
+    if (missing.length) throw new ValidationError(`Missing fields: ${missing.join(', ')}`);
+  };
+}
+
+function normalizeGroupMe(payload: unknown): NormalizedGroupMeMessage | null {
+  if (!payload) return null;
+  const p = payload as GroupMePayload;
+  if (p.system) return null;
+  if (p.sender_type === 'bot') return null;
+
+  const attachments = (p.attachments || []).map((a) => a.url || a.text).filter(Boolean) as string[];
+  const content = p.text || (attachments.length ? 'Shared an attachment' : '');
+  const timestamp = p.created_at
+    ? new Date(p.created_at * 1000).toISOString()
+    : new Date().toISOString();
+
+  return {
+    source: 'groupme',
+    externalId: p.id ? String(p.id) : undefined,
+    authorId: p.user_id ? String(p.user_id) : String(p.sender_id || ''),
+    authorName: p.name,
+    content,
+    timestamp,
+    attachments: attachments.map((url) => ({ type: 'link', url })),
+    metadata: {
+      groupId: p.group_id ? String(p.group_id) : undefined,
+    },
+    raw: payload,
+  };
+}
+
+const GROUPME_COMMANDS = {
+  SUMMARY: '!summary',
+  POD_SUMMARY: '!pod-summary',
+  POD: '!pod',
+  PODSUMMARY: '!podsummary',
+};
+
+const MAX_GROUPME_MESSAGE_LENGTH = 900;
+
+function truncateGroupmeMessage(text: string): string {
+  if (!text) return '';
+  if (text.length <= MAX_GROUPME_MESSAGE_LENGTH) return text;
+  return `${text.slice(0, MAX_GROUPME_MESSAGE_LENGTH - 1)}…`;
+}
+
+function createGroupMeProvider(integration: { _id: unknown; config?: Record<string, unknown>; podId?: unknown; [key: string]: unknown }): GroupMeProvider {
+  const config = integration?.config || {};
+
+  return {
+    async validateConfig() {
+      validateRequiredConfig(config, manifests.groupme);
+    },
+
+    getWebhookHandlers() {
+      return {
+        events: async (req: { body: Record<string, unknown> }, res: { status: (n: number) => { send: (s: string) => unknown }; sendStatus: (n: number) => unknown }) => {
+          if (!req.body) return res.status(400).send('missing body');
+
+          const latest = await Integration.findById(integration._id).lean() as { config?: Record<string, unknown>; podId?: unknown; _id?: unknown } | null;
+          const effectiveConfig = latest?.config || config;
+
+          if (effectiveConfig.groupId && req.body.group_id && `${req.body.group_id}` !== `${effectiveConfig.groupId}`) {
+            return res.status(403).send('group mismatch');
+          }
+          const rawText = (req.body.text as string) || '';
+          const text = rawText.replace(/^\uFEFF/, '').trim();
+          const lowerText = text.toLowerCase();
+          const command = lowerText.split(/\s+/)[0];
+          const isSummaryCommand = /^!summary\b/i.test(text);
+          const isPodCommand = /^!pod(-summary|summary)?\b/i.test(text);
+          const { botId } = effectiveConfig as { botId?: string };
+
+          if (botId && text.startsWith('!')) {
+            console.log('GroupMe command received', {
+              integrationId: integration._id,
+              command,
+              text,
+              hasBotId: !!botId,
+            });
+
+            if (isSummaryCommand || command.startsWith(GROUPME_COMMANDS.SUMMARY)) {
+              try {
+                const buffer = (latest?.config?.messageBuffer as unknown[]) || [];
+                if (!buffer.length) {
+                  await groupmeService.sendMessage(botId, 'No recent GroupMe activity to summarize.');
+                  return res.sendStatus(200);
+                }
+
+                const summary = await IntegrationSummaryService.createSummary(latest, buffer);
+                // eslint-disable-next-line global-require
+                const { AgentInstallation } = require('../../models/AgentRegistry');
+                let installations: Array<{ instanceId?: string }> = [];
+                try {
+                  installations = await AgentInstallation.find({
+                    agentName: 'commonly-bot',
+                    podId: latest?.podId,
+                    status: 'active',
+                  }).lean();
+                } catch (err) {
+                  const e = err as { message?: string };
+                  console.warn('groupme agent lookup failed', e.message);
+                }
+
+                const targets = installations.length > 0 ? installations : [{ instanceId: 'default' }];
+
+                await Promise.all(
+                  targets.map((installation) => (
+                    AgentEventService.enqueue({
+                      agentName: 'commonly-bot',
+                      instanceId: installation.instanceId || 'default',
+                      podId: latest?.podId,
+                      type: 'integration.summary',
+                      payload: {
+                        summary,
+                        integrationId: latest?._id?.toString(),
+                        source: 'groupme',
+                      },
+                    })
+                  )),
+                );
+
+                await Integration.findByIdAndUpdate(integration._id, {
+                  'config.messageBuffer': [],
+                  'config.lastSummaryAt': new Date(),
+                });
+                await groupmeService.sendMessage(botId, '✅ Queued GroupMe summary for Commonly Bot.');
+              } catch (err) {
+                const e = err as { message?: string };
+                console.warn('groupme summary command failed', e.message);
+              }
+              return res.sendStatus(200);
+            }
+
+            if (
+              isPodCommand
+              || command.startsWith(GROUPME_COMMANDS.POD_SUMMARY)
+              || command.startsWith(GROUPME_COMMANDS.PODSUMMARY)
+              || command === GROUPME_COMMANDS.POD
+            ) {
+              try {
+                const latestSummary = await Summary.findOne({
+                  type: 'chats',
+                  podId: integration.podId,
+                })
+                  .sort({ createdAt: -1 })
+                  .lean() as { title?: string; content?: string } | null;
+
+                if (!latestSummary) {
+                  await groupmeService.sendMessage(botId, '📝 No recent pod summaries available yet.');
+                  return res.sendStatus(200);
+                }
+
+                const title = latestSummary.title || 'Pod Summary';
+                const summaryText = `${title}\n\n${latestSummary.content}`;
+                await groupmeService.sendMessage(botId, truncateGroupmeMessage(summaryText));
+              } catch (err) {
+                const e = err as { message?: string };
+                console.warn('groupme pod summary command failed', e.message);
+              }
+              return res.sendStatus(200);
+            }
+          }
+
+          const normalized = normalizeGroupMe(req.body);
+          const bufferMessage = normalizeBufferMessage(normalized);
+          if (!bufferMessage) return res.sendStatus(200);
+
+          try {
+            await Integration.findByIdAndUpdate(integration._id, {
+              $push: {
+                'config.messageBuffer': {
+                  $each: [bufferMessage],
+                  $slice: -1 * ((effectiveConfig.maxBufferSize as number) || 1000),
+                },
+              },
+            });
+          } catch (err) {
+            const e = err as { message?: string };
+            console.warn('groupme buffer update failed', e.message);
+          }
+
+          return res.sendStatus(200);
+        },
+      };
+    },
+
+    async ingestEvent(payload: unknown): Promise<NormalizedGroupMeMessage[]> {
+      const normalized = normalizeGroupMe(payload);
+      return normalized ? [normalized] : [];
+    },
+
+    async syncRecent() {
+      return {
+        success: false,
+        messageCount: 0,
+        messages: [],
+        content: 'syncRecent not implemented for groupme',
+      };
+    },
+
+    async health() {
+      return { ok: true };
+    },
+  };
+}
+
+module.exports = createGroupMeProvider;
+// LEGACY: in-platform provider. External service will replace this module.

--- a/backend/integrations/providers/instagramProvider.ts
+++ b/backend/integrations/providers/instagramProvider.ts
@@ -1,0 +1,258 @@
+// eslint-disable-next-line global-require
+const axios = require('axios');
+// eslint-disable-next-line global-require
+const { manifests } = require('../manifests');
+
+interface InstagramConfig {
+  accessToken?: string;
+  igUserId?: string;
+  username?: string;
+  apiBase?: string;
+  maxResults?: number;
+  [key: string]: unknown;
+}
+
+interface InstagramMediaItem {
+  id?: string | number;
+  caption?: string;
+  media_type?: string;
+  media_url?: string;
+  thumbnail_url?: string;
+  permalink?: string;
+  timestamp?: string;
+  username?: string;
+}
+
+interface NormalizedInstagramPost {
+  source: 'instagram';
+  externalId: string | undefined;
+  authorId: string;
+  authorName: string;
+  content: string;
+  timestamp: string;
+  attachments: Array<{ type: string; url: string; title: string | undefined }>;
+  metadata: { username: string | undefined; url: string | undefined; mediaType: string | undefined };
+  raw: unknown;
+}
+
+interface SyncRecentOpts {
+  sinceTimestamp?: string;
+}
+
+interface PublishPostOpts {
+  caption?: string;
+  imageUrl?: string;
+  hashtags?: unknown[];
+  sourceUrl?: string;
+}
+
+interface InstagramProvider {
+  validateConfig(): Promise<void>;
+  getWebhookHandlers(): Record<string, (req: unknown, res: unknown) => unknown>;
+  ingestEvent(payload: unknown): Promise<NormalizedInstagramPost[]>;
+  syncRecent(opts?: SyncRecentOpts): Promise<unknown>;
+  health(): Promise<{ ok: boolean; error?: string }>;
+  publishPost(opts?: PublishPostOpts): Promise<{ success: boolean; provider: string; externalId: string | null; caption: string }>;
+}
+
+let ValidationError: new (msg: string) => Error;
+let validateRequiredConfig: (config: unknown, manifest: unknown) => void;
+try {
+  // eslint-disable-next-line global-require, import/no-unresolved
+  ({ ValidationError } = require('../../../packages/integration-sdk/src/errors'));
+  // eslint-disable-next-line global-require, import/no-unresolved
+  ({ validateRequiredConfig } = require('../../../packages/integration-sdk/src/manifest'));
+} catch {
+  ValidationError = class extends Error {};
+  validateRequiredConfig = (config: unknown, manifest: unknown) => {
+    const required = (manifest as { requiredConfig?: string[] })?.requiredConfig || [];
+    const missing = required.filter((f) => !(config as Record<string, unknown>)?.[f]);
+    if (missing.length) throw new ValidationError(`Missing fields: ${missing.join(', ')}`);
+  };
+}
+
+const DEFAULT_API_BASE = 'https://graph.facebook.com/v19.0';
+const IG_FIELDS = [
+  'id',
+  'caption',
+  'media_type',
+  'media_url',
+  'thumbnail_url',
+  'permalink',
+  'timestamp',
+  'username',
+].join(',');
+
+async function fetchInstagramMedia({ apiBase, accessToken, igUserId, limit }: { apiBase: string; accessToken: string; igUserId: string; limit?: number }): Promise<InstagramMediaItem[]> {
+  const response = await axios.get(`${apiBase}/${igUserId}/media`, {
+    params: {
+      fields: IG_FIELDS,
+      access_token: accessToken,
+      limit: limit || 25,
+    },
+  });
+  return (response.data?.data || []) as InstagramMediaItem[];
+}
+
+function normalizeInstagramMedia(item: unknown, config: InstagramConfig): NormalizedInstagramPost | null {
+  if (!item) return null;
+  const media = item as InstagramMediaItem;
+  const username = media.username || config.username;
+  const authorName = username ? `@${username}` : 'Instagram';
+  const timestamp = media.timestamp || new Date().toISOString();
+  const attachmentUrl = media.media_url || media.thumbnail_url;
+  const attachments = attachmentUrl
+    ? [{ type: 'image', url: attachmentUrl, title: media.media_type }]
+    : [];
+
+  return {
+    source: 'instagram',
+    externalId: media.id ? String(media.id) : undefined,
+    authorId: config.igUserId ? String(config.igUserId) : 'unknown',
+    authorName,
+    content: media.caption || `${media.media_type || 'Instagram'} post`,
+    timestamp,
+    attachments,
+    metadata: {
+      username,
+      url: media.permalink,
+      mediaType: media.media_type,
+    },
+    raw: item,
+  };
+}
+
+function createInstagramProvider(integration: { _id: unknown; config?: InstagramConfig; [key: string]: unknown }): InstagramProvider {
+  const config = (integration?.config || {}) as InstagramConfig;
+  const apiBase = config.apiBase || process.env.INSTAGRAM_GRAPH_API_BASE || DEFAULT_API_BASE;
+
+  return {
+    async validateConfig() {
+      try {
+        validateRequiredConfig(config, manifests.instagram);
+      } catch (err) {
+        const e = err as { message?: string };
+        throw new ValidationError(e.message || 'Validation failed');
+      }
+    },
+
+    getWebhookHandlers() {
+      return {
+        verify: (_req: unknown, res: { sendStatus: (n: number) => unknown }) => res.sendStatus(200),
+        events: (_req: unknown, res: { sendStatus: (n: number) => unknown }) => res.sendStatus(200),
+      };
+    },
+
+    async ingestEvent(payload: unknown): Promise<NormalizedInstagramPost[]> {
+      if (!payload) return [];
+      const p = payload as { data?: unknown[]; media?: unknown };
+      const items = Array.isArray(p.data) ? p.data : [p.media || payload];
+      return items.map((item) => normalizeInstagramMedia(item, config)).filter((x): x is NormalizedInstagramPost => x !== null);
+    },
+
+    async syncRecent({ sinceTimestamp } = {}): Promise<unknown> {
+      const { accessToken } = config;
+      if (!accessToken) {
+        throw new Error('Missing Instagram access token');
+      }
+      if (!config.igUserId) {
+        throw new Error('Missing Instagram IG user id');
+      }
+
+      const media = await fetchInstagramMedia({
+        apiBase,
+        accessToken,
+        igUserId: config.igUserId,
+        limit: config.maxResults || 25,
+      });
+
+      const sinceDate = sinceTimestamp ? new Date(sinceTimestamp) : null;
+      const filtered = sinceDate
+        ? media.filter((item) => {
+          const ts = new Date(item.timestamp || '');
+          return Number.isNaN(ts.valueOf()) ? true : ts > sinceDate;
+        })
+        : media;
+
+      const messages = filtered
+        .map((item) => normalizeInstagramMedia(item, config))
+        .filter(Boolean);
+
+      return {
+        success: true,
+        messageCount: messages.length,
+        messages,
+        content: messages.length ? `Fetched ${messages.length} post(s) from Instagram` : 'No new posts',
+        meta: {
+          username: config.username,
+        },
+      };
+    },
+
+    async health(): Promise<{ ok: boolean; error?: string }> {
+      const { accessToken } = config;
+      if (!accessToken || !config.igUserId) {
+        return { ok: false, error: 'Missing Instagram access configuration' };
+      }
+      return { ok: true };
+    },
+
+    async publishPost({ caption, imageUrl, hashtags = [], sourceUrl } = {}): Promise<{ success: boolean; provider: string; externalId: string | null; caption: string }> {
+      const { accessToken } = config;
+      if (!accessToken || !config.igUserId) {
+        throw new Error('Missing Instagram access configuration');
+      }
+      if (!imageUrl) {
+        throw new Error('imageUrl is required for Instagram publishing');
+      }
+
+      const normalizedTags = Array.isArray(hashtags)
+        ? hashtags.map((tag) => String(tag || '').trim()).filter(Boolean).slice(0, 8)
+        : [];
+      const baseCaption = String(caption || '').trim();
+      const sourceLine = sourceUrl ? `\n\nSource: ${String(sourceUrl).trim()}` : '';
+      const tagsLine = normalizedTags.length ? `\n\n${normalizedTags.join(' ')}` : '';
+      let finalCaption = `${baseCaption}${tagsLine}${sourceLine}`.trim();
+      if (finalCaption.length > 2200) {
+        finalCaption = `${finalCaption.slice(0, 2197)}...`;
+      }
+
+      const createRes = await axios.post(
+        `${apiBase}/${config.igUserId}/media`,
+        null,
+        {
+          params: {
+            image_url: String(imageUrl).trim(),
+            caption: finalCaption,
+            access_token: accessToken,
+          },
+        },
+      );
+
+      const creationId = createRes?.data?.id as string | undefined;
+      if (!creationId) {
+        throw new Error('Failed to create Instagram media container');
+      }
+
+      const publishRes = await axios.post(
+        `${apiBase}/${config.igUserId}/media_publish`,
+        null,
+        {
+          params: {
+            creation_id: creationId,
+            access_token: accessToken,
+          },
+        },
+      );
+
+      return {
+        success: true,
+        provider: 'instagram',
+        externalId: (publishRes?.data?.id as string) || null,
+        caption: finalCaption,
+      };
+    },
+  };
+}
+
+module.exports = createInstagramProvider;

--- a/backend/integrations/providers/slackNormalizer.ts
+++ b/backend/integrations/providers/slackNormalizer.ts
@@ -1,0 +1,42 @@
+interface SlackEvent {
+  type?: string;
+  subtype?: string;
+  client_msg_id?: string;
+  ts?: string;
+  thread_ts?: string;
+  user?: string;
+  text?: string;
+  channel?: string;
+  [key: string]: unknown;
+}
+
+interface NormalizedSlackMessage {
+  source: 'slack';
+  externalId: string;
+  threadId: string | null;
+  authorId: string | undefined;
+  authorName: string | undefined;
+  content: string;
+  timestamp: string;
+  attachments: unknown[];
+  metadata: { channelId: string | undefined };
+}
+
+function normalizeSlackMessage(event: SlackEvent): NormalizedSlackMessage | null {
+  if (!event || event.type !== 'message' || event.subtype) return null;
+  return {
+    source: 'slack',
+    externalId: event.client_msg_id || event.ts || '',
+    threadId: event.thread_ts || null,
+    authorId: event.user,
+    authorName: event.user,
+    content: event.text || '',
+    timestamp: new Date(Number((event.ts || '0').split('.')[0]) * 1000).toISOString(),
+    attachments: [],
+    metadata: {
+      channelId: event.channel,
+    },
+  };
+}
+
+module.exports = { normalizeSlackMessage };

--- a/backend/integrations/providers/slackProvider.ts
+++ b/backend/integrations/providers/slackProvider.ts
@@ -1,0 +1,139 @@
+import crypto from 'crypto';
+
+// eslint-disable-next-line global-require
+const Integration = require('../../models/Integration');
+// eslint-disable-next-line global-require
+const { manifests } = require('../manifests');
+// eslint-disable-next-line global-require
+const SlackApi = require('../../services/slackApi');
+// eslint-disable-next-line global-require
+const { normalizeSlackMessage } = require('./slackNormalizer');
+// eslint-disable-next-line global-require
+const { normalizeBufferMessage } = require('../normalizeBufferMessage');
+
+interface SlackProvider {
+  validateConfig(): Promise<void>;
+  getWebhookHandlers(): Record<string, (req: unknown, res: unknown) => unknown>;
+  ingestEvent(payload: unknown): Promise<unknown[]>;
+  syncRecent(opts?: { hours?: number }): Promise<unknown>;
+  health(): Promise<{ ok: boolean; error?: string }>;
+}
+
+let ValidationError: new (msg: string) => Error;
+let validateRequiredConfig: (config: unknown, manifest: unknown) => void;
+try {
+  // eslint-disable-next-line global-require, import/no-unresolved
+  ({ ValidationError } = require('../../../packages/integration-sdk/src/errors'));
+  // eslint-disable-next-line global-require, import/no-unresolved
+  ({ validateRequiredConfig } = require('../../../packages/integration-sdk/src/manifest'));
+} catch {
+  ValidationError = class extends Error {};
+  validateRequiredConfig = (config: unknown, manifest: unknown) => {
+    const required = (manifest as { requiredConfig?: string[] })?.requiredConfig || [];
+    const missing = required.filter((f) => !(config as Record<string, unknown>)?.[f]);
+    if (missing.length) throw new ValidationError(`Missing fields: ${missing.join(', ')}`);
+  };
+}
+
+function verifySlackSignature(signingSecret: string, timestamp: string, body: string, signature: string | undefined): boolean {
+  const basestring = `v0:${timestamp}:${body}`;
+  const mySig = `v0=${crypto.createHmac('sha256', signingSecret).update(basestring).digest('hex')}`;
+  if (!signature) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(mySig, 'utf8'), Buffer.from(signature, 'utf8'));
+  } catch {
+    return false;
+  }
+}
+
+function createSlackProvider(integration: { _id: unknown; config?: Record<string, unknown>; [key: string]: unknown }): SlackProvider {
+  const config = integration?.config || {};
+
+  return {
+    async validateConfig() {
+      validateRequiredConfig(config, manifests.slack);
+    },
+
+    getWebhookHandlers() {
+      return {
+        verify: (_req: unknown, res: { sendStatus: (n: number) => unknown }) => res.sendStatus(200),
+        events: async (req: { headers: Record<string, string>; body: Record<string, unknown>; rawBody?: string }, res: { status: (n: number) => { send: (s: unknown) => unknown }; sendStatus: (n: number) => unknown }) => {
+          if (req.body?.type === 'url_verification') {
+            return res.status(200).send(req.body.challenge);
+          }
+          const ts = req.headers['x-slack-request-timestamp'];
+          const sig = req.headers['x-slack-signature'];
+          const raw = req.rawBody || '';
+          if (!verifySlackSignature(config.signingSecret as string, ts, raw, sig)) {
+            return res.status(401).send('invalid signature');
+          }
+          const normalized = normalizeSlackMessage(req.body?.event);
+          if (normalized && config.channelId && normalized.metadata?.channelId !== config.channelId) {
+            return res.sendStatus(200);
+          }
+
+          if (normalized) {
+            const bufferMessage = normalizeBufferMessage({
+              messageId: normalized.externalId,
+              authorId: normalized.authorId,
+              authorName: normalized.authorName,
+              content: normalized.content,
+              timestamp: normalized.timestamp,
+              attachments: normalized.attachments,
+            });
+
+            if (!bufferMessage) {
+              return res.sendStatus(200);
+            }
+
+            try {
+              await Integration.findByIdAndUpdate(integration._id, {
+                $push: {
+                  'config.messageBuffer': {
+                    $each: [bufferMessage],
+                    $slice: -1 * ((config.maxBufferSize as number) || 1000),
+                  },
+                },
+              });
+            } catch (err) {
+              const e = err as { message?: string };
+              console.warn('slack buffer update failed', e.message);
+            }
+          }
+
+          return res.sendStatus(200);
+        },
+      };
+    },
+
+    async ingestEvent(payload: unknown): Promise<unknown[]> {
+      const p = payload as { event?: unknown } | null;
+      if (!p?.event) return [];
+      const normalized = normalizeSlackMessage(p.event);
+      return normalized ? [normalized] : [];
+    },
+
+    async syncRecent({ hours = 1 } = {}): Promise<unknown> {
+      const api = new SlackApi(config.botToken as string);
+      const oldest = `${(Date.now() - hours * 3600 * 1000) / 1000}`;
+      const hist = await api.history(config.channelId as string, oldest, undefined, 200) as { messages?: unknown[] };
+      const messages = (hist.messages || [])
+        .map(normalizeSlackMessage)
+        .filter(Boolean)
+        .reverse();
+      return {
+        success: true,
+        messageCount: messages.length,
+        messages,
+        content: `Fetched ${messages.length} messages`,
+      };
+    },
+
+    async health(): Promise<{ ok: boolean; error?: string }> {
+      return { ok: !!config.botToken && !!config.channelId };
+    },
+  };
+}
+
+module.exports = createSlackProvider;
+// LEGACY: in-platform provider. External service will replace this module.

--- a/backend/integrations/providers/telegramProvider.ts
+++ b/backend/integrations/providers/telegramProvider.ts
@@ -1,0 +1,164 @@
+// eslint-disable-next-line global-require
+const { normalizeBufferMessage } = require('../normalizeBufferMessage');
+// eslint-disable-next-line global-require
+const { manifests } = require('../manifests');
+
+interface TelegramUpdate {
+  message?: TelegramMessage;
+  channel_post?: TelegramMessage;
+  [key: string]: unknown;
+}
+
+interface TelegramMessage {
+  message_id?: number;
+  date?: number;
+  text?: string;
+  caption?: string;
+  via_bot?: unknown;
+  from?: {
+    id?: number;
+    is_bot?: boolean;
+    first_name?: string;
+    last_name?: string;
+  };
+  sender_chat?: { title?: string };
+  chat?: { id?: number; title?: string };
+}
+
+interface NormalizedTelegramMessage {
+  source: 'telegram';
+  externalId: string | undefined;
+  authorId: string | undefined;
+  authorName: string;
+  content: string;
+  timestamp: string;
+  attachments: unknown[];
+  metadata: { chatId: string | undefined };
+  raw: unknown;
+}
+
+interface TelegramProvider {
+  validateConfig(): Promise<void>;
+  getWebhookHandlers(): Record<string, (req: unknown, res: unknown) => unknown>;
+  ingestEvent(payload: unknown): Promise<NormalizedTelegramMessage[]>;
+  syncRecent(opts?: unknown): Promise<{ success: boolean; messageCount: number; messages: unknown[]; content: string }>;
+  health(): Promise<{ ok: boolean; error?: string }>;
+}
+
+let ValidationError: new (msg: string) => Error;
+let validateRequiredConfig: (config: unknown, manifest: unknown) => void;
+try {
+  // eslint-disable-next-line global-require, import/no-unresolved
+  ({ ValidationError } = require('../../../packages/integration-sdk/src/errors'));
+  // eslint-disable-next-line global-require, import/no-unresolved
+  ({ validateRequiredConfig } = require('../../../packages/integration-sdk/src/manifest'));
+} catch {
+  ValidationError = class extends Error {};
+  validateRequiredConfig = (config: unknown, manifest: unknown) => {
+    const required = (manifest as { requiredConfig?: string[] })?.requiredConfig || [];
+    const missing = required.filter((f) => !(config as Record<string, unknown>)?.[f]);
+    if (missing.length) throw new ValidationError(`Missing fields: ${missing.join(', ')}`);
+  };
+}
+
+function verifyTelegramSecret(headerToken: unknown, expectedToken: unknown): boolean {
+  return !!headerToken && !!expectedToken && headerToken === expectedToken;
+}
+
+function normalizeTelegram(update: unknown): NormalizedTelegramMessage | null {
+  if (!update) return null;
+  const u = update as TelegramUpdate;
+  const msg = u.message || u.channel_post;
+  if (!msg) return null;
+  if (msg.via_bot || msg.from?.is_bot) return null;
+
+  const senderName = msg.from
+    ? [msg.from?.first_name, msg.from?.last_name].filter(Boolean).join(' ').trim()
+    : msg.sender_chat?.title
+      || msg.chat?.title
+      || 'Unknown';
+
+  const timestamp = msg.date
+    ? new Date(msg.date * 1000).toISOString()
+    : new Date().toISOString();
+
+  return {
+    source: 'telegram',
+    externalId: msg.message_id ? String(msg.message_id) : undefined,
+    authorId: msg.from?.id?.toString(),
+    authorName: senderName || 'Unknown',
+    content: msg.text || msg.caption || '',
+    timestamp,
+    attachments: [],
+    metadata: {
+      chatId: msg.chat?.id ? String(msg.chat.id) : undefined,
+    },
+    raw: update,
+  };
+}
+
+function createTelegramProvider(integration: { _id: unknown; config?: Record<string, unknown>; [key: string]: unknown }): TelegramProvider {
+  const config = integration?.config || {};
+
+  return {
+    async validateConfig() {
+      validateRequiredConfig(config, manifests.telegram);
+    },
+
+    getWebhookHandlers() {
+      return {
+        events: async (req: { headers: Record<string, unknown>; body: unknown }, res: { status: (n: number) => { send: (s: string) => unknown }; sendStatus: (n: number) => unknown }) => {
+          if (config.secretToken) {
+            const headerToken = req.headers['x-telegram-bot-api-secret-token'];
+            if (!verifyTelegramSecret(headerToken, config.secretToken)) {
+              return res.status(401).send('invalid secret token');
+            }
+          }
+
+          const normalized = normalizeTelegram(req.body);
+          const bufferMessage = normalizeBufferMessage(normalized);
+          if (!bufferMessage) return res.sendStatus(200);
+
+          try {
+            // eslint-disable-next-line global-require
+            const Integration = require('../../models/Integration');
+            await Integration.findByIdAndUpdate(integration._id, {
+              $push: {
+                'config.messageBuffer': {
+                  $each: [bufferMessage],
+                  $slice: -1 * ((config.maxBufferSize as number) || 1000),
+                },
+              },
+            });
+          } catch (err) {
+            const e = err as { message?: string };
+            console.warn('telegram buffer update failed', e.message);
+          }
+
+          return res.sendStatus(200);
+        },
+      };
+    },
+
+    async ingestEvent(payload: unknown): Promise<NormalizedTelegramMessage[]> {
+      const normalized = normalizeTelegram(payload);
+      return normalized ? [normalized] : [];
+    },
+
+    async syncRecent() {
+      return {
+        success: false,
+        messageCount: 0,
+        messages: [],
+        content: 'syncRecent not implemented for telegram',
+      };
+    },
+
+    async health() {
+      return { ok: true };
+    },
+  };
+}
+
+module.exports = createTelegramProvider;
+// LEGACY: in-platform provider. External service will replace this module.

--- a/backend/integrations/providers/xProvider.ts
+++ b/backend/integrations/providers/xProvider.ts
@@ -1,0 +1,619 @@
+// eslint-disable-next-line global-require
+const axios = require('axios');
+// eslint-disable-next-line global-require
+const { manifests } = require('../manifests');
+
+interface XConfig {
+  accessToken?: string;
+  refreshToken?: string;
+  userId?: string;
+  username?: string;
+  apiBase?: string;
+  maxResults?: number;
+  followUsernames?: unknown[];
+  followUserIds?: unknown[];
+  followingWhitelistUserIds?: unknown[];
+  followFromAuthenticatedUser?: boolean;
+  followingMaxUsers?: number;
+  exclude?: string;
+  tokenExpiresAt?: string;
+  lastExternalIdsByUser?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+interface XUser {
+  id: string;
+  name?: string;
+  username?: string;
+  profile_image_url?: string;
+}
+
+interface XTweet {
+  id?: string | number;
+  text?: string;
+  created_at?: string;
+  author_id?: string;
+  username?: string;
+}
+
+interface NormalizedXPost {
+  source: 'x';
+  externalId: string | undefined;
+  authorId: string;
+  authorName: string;
+  content: string;
+  timestamp: string;
+  attachments: unknown[];
+  metadata: {
+    userId: string | undefined;
+    username: string | undefined;
+    url: string | null;
+    authorUrl: string | undefined;
+  };
+  raw: unknown;
+}
+
+interface SyncRecentOpts {
+  sinceId?: string;
+  sinceTimestamp?: string;
+}
+
+interface PublishPostOpts {
+  text?: string;
+  hashtags?: unknown[];
+  sourceUrl?: string;
+}
+
+interface RefreshMeta {
+  tokenType: string | null;
+  expiresIn: number | null;
+  scope: string | null;
+}
+
+interface OAuthClientConfig {
+  clientId: string;
+  clientSecret: string;
+  tokenEndpoint: string;
+}
+
+interface XProvider {
+  validateConfig(): Promise<void>;
+  getWebhookHandlers(): Record<string, (req: unknown, res: unknown) => unknown>;
+  ingestEvent(payload: unknown): Promise<NormalizedXPost[]>;
+  syncRecent(opts?: SyncRecentOpts): Promise<unknown>;
+  health(): Promise<{ ok: boolean; error?: string; status?: number }>;
+  publishPost(opts?: PublishPostOpts): Promise<{ success: boolean; provider: string; externalId: string | null; url: string | null; text: string }>;
+}
+
+let ValidationError: new (msg: string) => Error;
+let validateRequiredConfig: (config: unknown, manifest: unknown) => void;
+try {
+  // eslint-disable-next-line global-require, import/no-unresolved
+  ({ ValidationError } = require('../../../packages/integration-sdk/src/errors'));
+  // eslint-disable-next-line global-require, import/no-unresolved
+  ({ validateRequiredConfig } = require('../../../packages/integration-sdk/src/manifest'));
+} catch {
+  ValidationError = class extends Error {};
+  validateRequiredConfig = (config: unknown, manifest: unknown) => {
+    const required = (manifest as { requiredConfig?: string[] })?.requiredConfig || [];
+    const missing = required.filter((f) => !(config as Record<string, unknown>)?.[f]);
+    if (missing.length) throw new ValidationError(`Missing fields: ${missing.join(', ')}`);
+  };
+}
+
+const DEFAULT_API_BASE = 'https://api.x.com/2';
+const DEFAULT_TOKEN_ENDPOINT = 'https://api.x.com/2/oauth2/token';
+
+const getOAuthClientConfig = (): OAuthClientConfig => ({
+  clientId: process.env.X_OAUTH_CLIENT_ID || process.env.X_CLIENT_ID || '',
+  clientSecret: process.env.X_OAUTH_CLIENT_SECRET || process.env.X_CLIENT_SECRET || '',
+  tokenEndpoint: process.env.X_OAUTH_TOKEN_URL || DEFAULT_TOKEN_ENDPOINT,
+});
+
+const buildOAuthTokenHeaders = ({ clientId, clientSecret }: { clientId: string; clientSecret: string }): Record<string, string> => {
+  if (!clientId) {
+    throw new Error('Missing X OAuth client id');
+  }
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+  };
+  if (clientSecret) {
+    const basic = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+    headers.Authorization = `Basic ${basic}`;
+  }
+  return headers;
+};
+
+const buildXPostUrl = (username: string | undefined, tweetId: string | number | null | undefined): string | null => {
+  if (!username || !tweetId) return null;
+  return `https://x.com/${username}/status/${tweetId}`;
+};
+
+async function fetchXUser({ apiBase, accessToken, username }: { apiBase: string; accessToken: string; username: string }): Promise<XUser | null> {
+  const response = await axios.get(`${apiBase}/users/by/username/${username}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    params: { 'user.fields': 'id,name,username,profile_image_url' },
+  });
+  return (response.data?.data as XUser) || null;
+}
+
+async function fetchXTweets({ apiBase, accessToken, userId, sinceId, maxResults, exclude }: {
+  apiBase: string;
+  accessToken: string;
+  userId: string;
+  sinceId?: string;
+  maxResults?: number;
+  exclude?: string;
+}): Promise<XTweet[]> {
+  const params: Record<string, unknown> = {
+    max_results: maxResults || 5,
+    'tweet.fields': 'created_at,author_id',
+  };
+  if (exclude) {
+    params.exclude = exclude;
+  }
+  if (sinceId) {
+    params.since_id = sinceId;
+  }
+  const response = await axios.get(`${apiBase}/users/${userId}/tweets`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    params,
+  });
+  return (response.data?.data as XTweet[]) || [];
+}
+
+async function fetchXFollowing({ apiBase, accessToken, userId, maxResults = 100 }: {
+  apiBase: string;
+  accessToken: string;
+  userId: string;
+  maxResults?: number;
+}): Promise<XUser[]> {
+  const response = await axios.get(`${apiBase}/users/${userId}/following`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    params: {
+      max_results: maxResults,
+      'user.fields': 'id,name,username,profile_image_url',
+    },
+  });
+  return Array.isArray(response?.data?.data) ? (response.data.data as XUser[]) : [];
+}
+
+const compareTweetIds = (left: unknown, right: unknown): number => {
+  const a = String(left || '').trim();
+  const b = String(right || '').trim();
+  if (!a && !b) return 0;
+  if (!a) return -1;
+  if (!b) return 1;
+  if (a.length !== b.length) return a.length - b.length;
+  if (a === b) return 0;
+  return a > b ? 1 : -1;
+};
+
+const pickNewestTweetId = (tweets: XTweet[] = []): string | null => {
+  if (!Array.isArray(tweets) || !tweets.length) return null;
+  let newest: string | null = null;
+  tweets.forEach((tweet) => {
+    const id = String(tweet?.id || '').trim();
+    if (!id) return;
+    if (!newest || compareTweetIds(id, newest) > 0) {
+      newest = id;
+    }
+  });
+  return newest;
+};
+
+async function refreshXAccessToken({ refreshToken }: { refreshToken: string }): Promise<Record<string, unknown>> {
+  const { clientId, clientSecret, tokenEndpoint } = getOAuthClientConfig();
+  if (!refreshToken) {
+    throw new Error('Missing X refresh token');
+  }
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: clientId,
+  });
+  const response = await axios.post(tokenEndpoint, body.toString(), {
+    headers: buildOAuthTokenHeaders({ clientId, clientSecret }),
+  });
+  return (response.data as Record<string, unknown>) || {};
+}
+
+function normalizeXTweet(tweet: unknown, user: Partial<XUser> = {}): NormalizedXPost | null {
+  if (!tweet) return null;
+  const t = tweet as XTweet;
+  const username = user.username || t.username;
+  const authorName = username ? `@${username}` : (user.name || 'Unknown');
+  const authorId = t.author_id || user.id || 'unknown';
+  const timestamp = t.created_at || new Date().toISOString();
+  const url = buildXPostUrl(username, t.id);
+
+  return {
+    source: 'x',
+    externalId: t.id ? String(t.id) : undefined,
+    authorId: String(authorId),
+    authorName,
+    content: t.text || '',
+    timestamp,
+    attachments: [],
+    metadata: {
+      userId: user.id || t.author_id,
+      username,
+      url,
+      authorUrl: username ? `https://x.com/${username}` : undefined,
+    },
+    raw: tweet,
+  };
+}
+
+function createXProvider(integration: { _id: unknown; config?: XConfig; [key: string]: unknown }): XProvider {
+  const config = (integration?.config || {}) as XConfig;
+  const apiBase = config.apiBase || process.env.X_API_BASE_URL || DEFAULT_API_BASE;
+  const sanitizedUsername = config.username ? config.username.replace(/^@/, '') : '';
+  const followUsernames = Array.isArray(config.followUsernames)
+    ? config.followUsernames.map((item) => String(item || '').trim().replace(/^@/, '')).filter(Boolean)
+    : [];
+  const followUserIds = Array.isArray(config.followUserIds)
+    ? config.followUserIds.map((item) => String(item || '').trim()).filter(Boolean)
+    : [];
+  const followingWhitelistUserIds = Array.isArray(config.followingWhitelistUserIds)
+    ? config.followingWhitelistUserIds.map((item) => String(item || '').trim()).filter(Boolean)
+    : [];
+  const followFromAuthenticatedUser = config.followFromAuthenticatedUser === true;
+
+  return {
+    async validateConfig() {
+      try {
+        validateRequiredConfig(config, manifests.x);
+      } catch (err) {
+        const e = err as { message?: string };
+        throw new ValidationError(e.message || 'Validation failed');
+      }
+    },
+
+    getWebhookHandlers() {
+      return {
+        verify: (_req: unknown, res: { sendStatus: (n: number) => unknown }) => res.sendStatus(200),
+        events: (_req: unknown, res: { sendStatus: (n: number) => unknown }) => res.sendStatus(200),
+      };
+    },
+
+    async ingestEvent(payload: unknown): Promise<NormalizedXPost[]> {
+      if (!payload) return [];
+      const p = payload as { data?: unknown[]; tweet?: unknown; user?: unknown; includes?: { users?: unknown[] } };
+      const items = Array.isArray(p.data) ? p.data : [p.tweet || payload];
+      const user = (p.user || (p.includes?.users?.[0]) || {}) as Partial<XUser>;
+      return items.map((tweet) => normalizeXTweet(tweet, user)).filter((x): x is NormalizedXPost => x !== null);
+    },
+
+    async syncRecent({ sinceId, sinceTimestamp } = {}): Promise<unknown> {
+      let { accessToken } = config;
+      let { refreshToken } = config;
+      const previousSinceByUser = (config.lastExternalIdsByUser && typeof config.lastExternalIdsByUser === 'object')
+        ? Object.entries(config.lastExternalIdsByUser).reduce<Record<string, string>>((acc, [key, value]) => {
+          const normalizedKey = String(key || '').trim();
+          const normalizedValue = String(value || '').trim();
+          if (normalizedKey && normalizedValue) acc[normalizedKey] = normalizedValue;
+          return acc;
+        }, {})
+        : {};
+      const parsedMaxResults = Number(config.maxResults);
+      const effectiveMaxResults = Number.isFinite(parsedMaxResults)
+        ? Math.min(Math.max(Math.trunc(parsedMaxResults), 1), 5)
+        : 5;
+      const parsedFollowingMaxUsers = Number(config.followingMaxUsers);
+      const followingMaxUsers = Number.isFinite(parsedFollowingMaxUsers)
+        ? Math.min(Math.max(Math.trunc(parsedFollowingMaxUsers), 1), 100)
+        : 5;
+      const exclude = config.exclude || 'replies,retweets';
+      if (!accessToken) {
+        throw new Error('Missing X access token');
+      }
+
+      const resolvedUsers: XUser[] = [];
+
+      if (config.userId) {
+        resolvedUsers.push({
+          id: config.userId,
+          username: config.username,
+          name: config.username,
+        });
+      } else if (sanitizedUsername) {
+        const primaryUser = await fetchXUser({ apiBase, accessToken, username: sanitizedUsername });
+        if (primaryUser?.id) resolvedUsers.push(primaryUser);
+      }
+
+      if (followUserIds.length > 0) {
+        followUserIds.forEach((id) => {
+          resolvedUsers.push({ id });
+        });
+      }
+
+      if (followUsernames.length > 0) {
+        const extraUsers = await Promise.all(
+          followUsernames.map((username) => (
+            fetchXUser({ apiBase, accessToken: accessToken!, username }).catch(() => null)
+          )),
+        );
+        extraUsers.filter((user): user is XUser => !!(user?.id)).forEach((user) => {
+          resolvedUsers.push(user);
+        });
+      }
+
+      let tokenRefreshed = false;
+      let refreshMeta: RefreshMeta | null = null;
+      const proactiveRefreshThresholdSecondsRaw = Number(process.env.X_OAUTH_REFRESH_BUFFER_SECONDS);
+      const proactiveRefreshThresholdSeconds = Number.isFinite(proactiveRefreshThresholdSecondsRaw)
+        ? Math.max(0, Math.trunc(proactiveRefreshThresholdSecondsRaw))
+        : 1800;
+
+      const tryRefreshToken = async ({ force = false } = {}): Promise<boolean> => {
+        if (!refreshToken) return false;
+
+        if (!force) {
+          const expiresAt = config?.tokenExpiresAt ? new Date(config.tokenExpiresAt) : null;
+          const expiresAtMs = expiresAt instanceof Date ? expiresAt.valueOf() : Number.NaN;
+          if (!Number.isNaN(expiresAtMs)) {
+            const refreshAtMs = expiresAtMs - (proactiveRefreshThresholdSeconds * 1000);
+            if (Date.now() < refreshAtMs) {
+              return false;
+            }
+          } else {
+            return false;
+          }
+        }
+
+        const refreshed = await refreshXAccessToken({ refreshToken });
+        const nextAccessToken = (refreshed.access_token as string) || accessToken;
+        if (!nextAccessToken) {
+          throw new Error('Missing X access token in refresh response');
+        }
+        accessToken = nextAccessToken;
+        refreshToken = (refreshed.refresh_token as string) || refreshToken;
+        tokenRefreshed = Boolean(refreshed.access_token) || tokenRefreshed;
+        refreshMeta = {
+          tokenType: (refreshed.token_type as string) || refreshMeta?.tokenType || null,
+          expiresIn: (refreshed.expires_in as number) || refreshMeta?.expiresIn || null,
+          scope: (refreshed.scope as string) || refreshMeta?.scope || null,
+        };
+        return Boolean(refreshed.access_token);
+      };
+
+      await tryRefreshToken({ force: false });
+
+      if (followFromAuthenticatedUser && config.userId) {
+        try {
+          const followingUsers = await fetchXFollowing({
+            apiBase,
+            accessToken: accessToken!,
+            userId: config.userId,
+            maxResults: followingMaxUsers,
+          });
+          const whitelistSet = new Set(followingWhitelistUserIds.map(String));
+          const filteredFollowing = whitelistSet.size > 0
+            ? followingUsers.filter((user) => whitelistSet.has(String(user?.id || '')))
+            : followingUsers;
+          filteredFollowing.forEach((user) => {
+            if (user?.id) resolvedUsers.push(user);
+          });
+        } catch (error) {
+          const err = error as { response?: { status?: number } };
+          const canRefresh = err?.response?.status === 401 && refreshToken;
+          if (canRefresh) {
+            try {
+              await tryRefreshToken({ force: true });
+              const followingUsers = await fetchXFollowing({
+                apiBase,
+                accessToken: accessToken!,
+                userId: config.userId!,
+                maxResults: followingMaxUsers,
+              });
+              const whitelistSet = new Set(followingWhitelistUserIds.map(String));
+              const filteredFollowing = whitelistSet.size > 0
+                ? followingUsers.filter((user) => whitelistSet.has(String(user?.id || '')))
+                : followingUsers;
+              filteredFollowing.forEach((user) => {
+                if (user?.id) resolvedUsers.push(user);
+              });
+            } catch (refreshError) {
+              const re = refreshError as { response?: { data?: unknown }; message?: string };
+              console.warn('[xProvider] failed to fetch following list after token refresh:', re?.response?.data || re?.message || refreshError);
+            }
+          } else {
+            const e = error as { response?: { data?: unknown }; message?: string };
+            console.warn('[xProvider] failed to fetch following list:', e?.response?.data || e?.message || error);
+          }
+        }
+      }
+
+      const uniqueUsers = Array.from(
+        resolvedUsers.reduce((map, user) => {
+          if (!user?.id) return map;
+          map.set(String(user.id), user);
+          return map;
+        }, new Map<string, XUser>()).values(),
+      );
+
+      if (!uniqueUsers.length) {
+        throw new Error('Missing X userId/username');
+      }
+
+      const shouldUsePerUserSince = (
+        followUserIds.length > 0
+        || followUsernames.length > 0
+        || followFromAuthenticatedUser
+      );
+
+      let tweetsByUser: Array<{ user: XUser; tweets: XTweet[] }>;
+      try {
+        tweetsByUser = await Promise.all(
+          uniqueUsers.map(async (user) => {
+            const userKey = String(user?.id || '').trim();
+            const tweets = await fetchXTweets({
+              apiBase,
+              accessToken: accessToken!,
+              userId: user.id,
+              sinceId: shouldUsePerUserSince ? previousSinceByUser[userKey] : sinceId,
+              maxResults: effectiveMaxResults,
+              exclude,
+            });
+            return { user, tweets };
+          }),
+        );
+      } catch (error) {
+        const err = error as { response?: { status?: number } };
+        if (err?.response?.status === 401 && refreshToken) {
+          await tryRefreshToken({ force: true });
+          tweetsByUser = await Promise.all(
+            uniqueUsers.map(async (user) => {
+              const userKey = String(user?.id || '').trim();
+              const tweets = await fetchXTweets({
+                apiBase,
+                accessToken: accessToken!,
+                userId: user.id,
+                sinceId: shouldUsePerUserSince ? previousSinceByUser[userKey] : sinceId,
+                maxResults: effectiveMaxResults,
+                exclude,
+              });
+              return { user, tweets };
+            }),
+          );
+        } else {
+          throw error;
+        }
+      }
+
+      const sinceDate = sinceTimestamp ? new Date(sinceTimestamp) : null;
+      const messages = tweetsByUser
+        .flatMap(({ user, tweets }) => (
+          tweets.map((tweet) => normalizeXTweet(tweet, user)).filter(Boolean)
+        ))
+        .filter((message): message is NormalizedXPost => {
+          if (!message) return false;
+          if (!sinceDate || Number.isNaN(sinceDate.valueOf())) return true;
+          const ts = new Date(message.timestamp);
+          if (Number.isNaN(ts.valueOf())) return true;
+          return ts > sinceDate;
+        })
+        .sort((a, b) => new Date(a.timestamp).valueOf() - new Date(b.timestamp).valueOf());
+
+      const lastExternalIdsByUser: Record<string, string> = { ...previousSinceByUser };
+      tweetsByUser.forEach(({ user, tweets }) => {
+        const userKey = String(user?.id || '').trim();
+        if (!userKey) return;
+        const newestId = pickNewestTweetId(tweets);
+        if (newestId) {
+          lastExternalIdsByUser[userKey] = newestId;
+        }
+      });
+
+      return {
+        success: true,
+        messageCount: messages.length,
+        messages,
+        content: messages.length ? `Fetched ${messages.length} post(s) from X` : 'No new posts',
+        meta: {
+          userId: uniqueUsers[0]?.id,
+          username: uniqueUsers[0]?.username || sanitizedUsername,
+          watchedUsers: uniqueUsers.length,
+          watchedUserIds: uniqueUsers.map((user) => String(user?.id || '')).filter(Boolean),
+          watchedViaFollowing: followFromAuthenticatedUser,
+          lastExternalIdsByUser,
+          tokenRefreshed,
+          refreshedAccessToken: tokenRefreshed ? accessToken : undefined,
+          refreshedRefreshToken: tokenRefreshed ? refreshToken : undefined,
+          refreshedTokenType: refreshMeta?.tokenType || undefined,
+          refreshedExpiresIn: refreshMeta?.expiresIn || undefined,
+          refreshedScope: refreshMeta?.scope || undefined,
+        },
+      };
+    },
+
+    async health(): Promise<{ ok: boolean; error?: string; status?: number }> {
+      const { accessToken } = config;
+      if (!accessToken || (!config.username && !config.userId)) {
+        return { ok: false, error: 'Missing X access configuration' };
+      }
+      try {
+        if (config.userId) {
+          await fetchXTweets({
+            apiBase,
+            accessToken,
+            userId: config.userId,
+            maxResults: 5,
+            exclude: config.exclude || 'replies,retweets',
+          });
+          return { ok: true };
+        }
+
+        const username = sanitizedUsername;
+        if (!username) {
+          return { ok: false, error: 'Missing X username' };
+        }
+        const user = await fetchXUser({ apiBase, accessToken, username });
+        if (!user?.id) {
+          return { ok: false, error: 'X user lookup failed' };
+        }
+        await fetchXTweets({
+          apiBase,
+          accessToken,
+          userId: user.id,
+          maxResults: 5,
+          exclude: config.exclude || 'replies,retweets',
+        });
+        return { ok: true };
+      } catch (error) {
+        const err = error as { response?: { status?: number; data?: { detail?: string; title?: string; error?: string } }; message?: string };
+        const status = err?.response?.status;
+        const detail = err?.response?.data?.detail
+          || err?.response?.data?.title
+          || err?.response?.data?.error
+          || err?.message
+          || 'Failed to validate X credentials';
+        return {
+          ok: false,
+          error: status ? `X API ${status}: ${detail}` : detail,
+          status,
+        };
+      }
+    },
+
+    async publishPost({ text, hashtags = [], sourceUrl } = {}): Promise<{ success: boolean; provider: string; externalId: string | null; url: string | null; text: string }> {
+      const { accessToken } = config;
+      if (!accessToken) {
+        throw new Error('Missing X access token');
+      }
+
+      const baseText = String(text || '').trim();
+      if (!baseText) {
+        throw new Error('text is required for X publishing');
+      }
+
+      const normalizedTags = Array.isArray(hashtags)
+        ? hashtags.map((tag) => String(tag || '').trim()).filter(Boolean).slice(0, 4)
+        : [];
+      const sourceSuffix = sourceUrl ? `\n\nSource: ${String(sourceUrl).trim()}` : '';
+      const tagSuffix = normalizedTags.length ? `\n\n${normalizedTags.join(' ')}` : '';
+      let tweetText = `${baseText}${tagSuffix}${sourceSuffix}`.trim();
+      if (tweetText.length > 280) {
+        tweetText = `${tweetText.slice(0, 277)}...`;
+      }
+
+      const response = await axios.post(
+        `${apiBase}/tweets`,
+        { text: tweetText },
+        { headers: { Authorization: `Bearer ${accessToken}` } },
+      );
+
+      const id = (response?.data?.data?.id as string) || null;
+      return {
+        success: true,
+        provider: 'x',
+        externalId: id,
+        url: buildXPostUrl(sanitizedUsername || config.username, id),
+        text: tweetText,
+      };
+    },
+  };
+}
+
+module.exports = createXProvider;


### PR DESCRIPTION
## Summary
- TypeScript companions for all 11 files in `backend/integrations/` and `backend/integrations/providers/`
- `normalizeBufferMessage.ts`, `manifests.ts`, `catalog.ts`, `index.ts`, `slackNormalizer.ts`
- Provider companions: `discordProvider.ts`, `slackProvider.ts`, `telegramProvider.ts`, `groupmeProvider.ts`, `instagramProvider.ts`, `xProvider.ts`
- Strategy: `allowJs: true`, `strict: false` — companions sit alongside JS, never replacing it

## Test plan
- [ ] `Test & Coverage` CI passes
- [ ] No tsc errors beyond pre-existing `@types/express` missing type definition

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)