### PR TITLE
feat(ts): migrate common/ components to TypeScript (batch 29)

### DIFF
--- a/frontend/src/components/common/AgentIndicator.tsx
+++ b/frontend/src/components/common/AgentIndicator.tsx
@@ -1,18 +1,16 @@
-/**
- * AgentIndicator Component
- *
- * Visual indicators for AI agents vs human users.
- * Used throughout the app to distinguish agent activity.
- */
-
 import React from 'react';
 import { Box, Chip, Avatar, Tooltip, alpha, useTheme } from '@mui/material';
 import { SmartToy as AgentIcon, Verified as VerifiedIcon } from '@mui/icons-material';
+import { SxProps, Theme } from '@mui/material/styles';
 
-/**
- * Known agent types and their display properties
- */
-const AGENT_TYPES = {
+interface AgentTypeInfo {
+  label: string;
+  color: string;
+  emoji: string;
+  description: string;
+}
+
+const AGENT_TYPES: Record<string, AgentTypeInfo> = {
   'commonly-bot': {
     label: 'Summarizer',
     color: '#7C3AED',
@@ -51,10 +49,7 @@ const AGENT_TYPES = {
   },
 };
 
-/**
- * Check if a username belongs to an agent
- */
-export const isAgentUsername = (username) => {
+export const isAgentUsername = (username: string | null | undefined): boolean => {
   if (!username) return false;
   const lower = username.toLowerCase();
   return (
@@ -68,10 +63,7 @@ export const isAgentUsername = (username) => {
   );
 };
 
-/**
- * Get agent info from username
- */
-export const getAgentInfo = (username) => {
+export const getAgentInfo = (username: string | null | undefined): AgentTypeInfo | null => {
   if (!username) return null;
   const lower = username.toLowerCase();
 
@@ -86,31 +78,22 @@ export const getAgentInfo = (username) => {
   return null;
 };
 
-/**
- * Agent Badge - Small inline badge (e.g., "AI" or "BOT")
- */
-export const AgentBadge = ({ username, size = 'small', showLabel = true }) => {
-  const theme = useTheme();
+interface AgentBadgeProps {
+  username?: string | null;
+  size?: 'small' | 'medium' | 'large';
+  showLabel?: boolean;
+}
+
+export const AgentBadge: React.FC<AgentBadgeProps> = ({ username, size = 'small', showLabel = true }) => {
+  useTheme();
   const agentInfo = getAgentInfo(username);
 
   if (!agentInfo) return null;
 
-  const sizeStyles = {
-    small: {
-      height: 16,
-      fontSize: '0.625rem',
-      px: 0.5,
-    },
-    medium: {
-      height: 20,
-      fontSize: '0.75rem',
-      px: 0.75,
-    },
-    large: {
-      height: 24,
-      fontSize: '0.8125rem',
-      px: 1,
-    },
+  const sizeStyles: Record<string, object> = {
+    small: { height: 16, fontSize: '0.625rem', px: 0.5 },
+    medium: { height: 20, fontSize: '0.75rem', px: 0.75 },
+    large: { height: 24, fontSize: '0.8125rem', px: 1 },
   };
 
   return (
@@ -127,19 +110,22 @@ export const AgentBadge = ({ username, size = 'small', showLabel = true }) => {
           borderColor: alpha(agentInfo.color, 0.3),
           fontWeight: 600,
           letterSpacing: '0.02em',
-          '& .MuiChip-icon': {
-            color: 'inherit',
-          },
+          '& .MuiChip-icon': { color: 'inherit' },
         }}
       />
     </Tooltip>
   );
 };
 
-/**
- * Agent Avatar - Avatar with agent styling
- */
-export const AgentAvatar = ({
+interface AgentAvatarProps {
+  username?: string | null;
+  src?: string;
+  size?: number;
+  showBadge?: boolean;
+  sx?: SxProps<Theme>;
+}
+
+export const AgentAvatar: React.FC<AgentAvatarProps> = ({
   username,
   src,
   size = 40,
@@ -167,7 +153,7 @@ export const AgentAvatar = ({
           border: isAgent ? `2px solid ${alpha(agentInfo?.color || theme.palette.primary.main, 0.3)}` : 'none',
         }}
       >
-        {isAgent ? agentInfo.emoji : (username?.charAt(0).toUpperCase() || '?')}
+        {isAgent ? agentInfo!.emoji : (username?.charAt(0).toUpperCase() || '?')}
       </Avatar>
       {showBadge && isAgent && (
         <Box
@@ -178,7 +164,7 @@ export const AgentAvatar = ({
             width: size * 0.35,
             height: size * 0.35,
             borderRadius: '50%',
-            backgroundColor: agentInfo.color,
+            backgroundColor: agentInfo!.color,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -192,15 +178,20 @@ export const AgentAvatar = ({
   );
 };
 
-/**
- * Agent Name Display - Name with optional badge
- */
-export const AgentName = ({
+interface AgentNameProps {
+  username?: string | null;
+  displayName?: string | null;
+  showBadge?: boolean;
+  verified?: boolean;
+  variant?: string;
+  sx?: SxProps<Theme>;
+}
+
+export const AgentName: React.FC<AgentNameProps> = ({
   username,
   displayName,
   showBadge = true,
   verified = false,
-  variant = 'body1',
   sx = {},
 }) => {
   const theme = useTheme();
@@ -208,14 +199,7 @@ export const AgentName = ({
   const isAgent = Boolean(agentInfo);
 
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 0.5,
-        ...sx,
-      }}
-    >
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ...sx }}>
       <Box
         component="span"
         sx={{
@@ -228,28 +212,26 @@ export const AgentName = ({
       {isAgent && showBadge && <AgentBadge username={username} size="small" showLabel={false} />}
       {verified && (
         <Tooltip title="Verified agent">
-          <VerifiedIcon
-            sx={{
-              fontSize: 14,
-              color: theme.palette.primary.main,
-            }}
-          />
+          <VerifiedIcon sx={{ fontSize: 14, color: theme.palette.primary.main }} />
         </Tooltip>
       )}
     </Box>
   );
 };
 
-/**
- * Agent Type Indicator - Larger indicator for cards/headers
- */
-export const AgentTypeIndicator = ({
+interface AgentTypeIndicatorProps {
+  username?: string | null;
+  type?: string;
+  showDescription?: boolean;
+}
+
+export const AgentTypeIndicator: React.FC<AgentTypeIndicatorProps> = ({
   username,
   type,
   showDescription = false,
 }) => {
-  const theme = useTheme();
-  const agentInfo = getAgentInfo(username) || AGENT_TYPES[type] || AGENT_TYPES.default;
+  useTheme();
+  const agentInfo = getAgentInfo(username) || (type ? AGENT_TYPES[type] : null) || AGENT_TYPES.default;
 
   return (
     <Box
@@ -277,22 +259,11 @@ export const AgentTypeIndicator = ({
         {agentInfo.emoji}
       </Box>
       <Box>
-        <Box
-          sx={{
-            fontSize: '0.875rem',
-            fontWeight: 600,
-            color: agentInfo.color,
-          }}
-        >
+        <Box sx={{ fontSize: '0.875rem', fontWeight: 600, color: agentInfo.color }}>
           {agentInfo.label}
         </Box>
         {showDescription && (
-          <Box
-            sx={{
-              fontSize: '0.75rem',
-              color: 'text.secondary',
-            }}
-          >
+          <Box sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
             {agentInfo.description}
           </Box>
         )}
@@ -301,10 +272,12 @@ export const AgentTypeIndicator = ({
   );
 };
 
-/**
- * Activity Source Badge - For activity feed items
- */
-export const ActivitySourceBadge = ({ source, username }) => {
+interface ActivitySourceBadgeProps {
+  source?: string;
+  username?: string | null;
+}
+
+export const ActivitySourceBadge: React.FC<ActivitySourceBadgeProps> = ({ source, username }) => {
   const theme = useTheme();
   const agentInfo = getAgentInfo(username);
 
@@ -327,26 +300,26 @@ export const ActivitySourceBadge = ({ source, username }) => {
         fontSize: '0.625rem',
         backgroundColor: alpha(config.color, 0.1),
         color: config.color,
-        '& .MuiChip-label': {
-          px: 0.75,
-        },
+        '& .MuiChip-label': { px: 0.75 },
       }}
     />
   );
 };
 
-/**
- * Default export for basic indicator
- */
-const AgentIndicator = ({ username, variant = 'badge', ...props }) => {
-  const Component = {
-    badge: AgentBadge,
-    avatar: AgentAvatar,
-    name: AgentName,
-    type: AgentTypeIndicator,
-    source: ActivitySourceBadge,
-  }[variant];
+interface AgentIndicatorProps extends Record<string, unknown> {
+  username?: string | null;
+  variant?: 'badge' | 'avatar' | 'name' | 'type' | 'source';
+}
 
+const AgentIndicator: React.FC<AgentIndicatorProps> = ({ username, variant = 'badge', ...props }) => {
+  const variantMap: Record<string, React.FC<Record<string, unknown>>> = {
+    badge: AgentBadge as React.FC<Record<string, unknown>>,
+    avatar: AgentAvatar as React.FC<Record<string, unknown>>,
+    name: AgentName as React.FC<Record<string, unknown>>,
+    type: AgentTypeIndicator as React.FC<Record<string, unknown>>,
+    source: ActivitySourceBadge as React.FC<Record<string, unknown>>,
+  };
+  const Component = variantMap[variant];
   return <Component username={username} {...props} />;
 };
 

--- a/frontend/src/components/common/MarkdownContent.tsx
+++ b/frontend/src/components/common/MarkdownContent.tsx
@@ -4,11 +4,11 @@ import { Box, Typography } from '@mui/material';
 
 const HASHTAG_RE = /(#\w+)/g;
 
-/**
- * Splits a string by hashtags and returns an array of strings and clickable spans.
- */
-function renderWithHashtags(text, onHashtagClick) {
-  if (!onHashtagClick || typeof text !== 'string') return text;
+function renderWithHashtags(
+  text: React.ReactNode,
+  onHashtagClick: (tag: string) => void,
+): React.ReactNode {
+  if (typeof text !== 'string') return text;
   const parts = text.split(HASHTAG_RE);
   if (parts.length === 1) return text;
   return parts.map((part, i) => {
@@ -19,7 +19,7 @@ function renderWithHashtags(text, onHashtagClick) {
           component="span"
           color="primary"
           sx={{ fontWeight: 'bold', cursor: 'pointer' }}
-          onClick={(e) => {
+          onClick={(e: React.MouseEvent) => {
             e.stopPropagation();
             onHashtagClick(part.substring(1));
           }}
@@ -33,35 +33,37 @@ function renderWithHashtags(text, onHashtagClick) {
   });
 }
 
-/**
- * Recursively extracts plain text from React children for hashtag splitting.
- */
-function childrenToText(children) {
+function childrenToText(children: React.ReactNode): string {
   if (typeof children === 'string') return children;
   if (Array.isArray(children)) return children.map(childrenToText).join('');
-  if (React.isValidElement(children)) return childrenToText(children.props.children);
+  if (React.isValidElement(children)) {
+    return childrenToText((children.props as { children?: React.ReactNode }).children);
+  }
   return '';
 }
 
-/**
- * MarkdownContent — renders a markdown string with MUI-compatible styling.
- *
- * Props:
- *   children: string           — markdown source text
- *   variant: 'chat' | 'post' | 'comment'  (default: 'post')
- *   onHashtagClick: (tag) => void          — optional; enables hashtag highlighting
- */
-export default function MarkdownContent({ children, variant = 'post', onHashtagClick }) {
+interface MarkdownContentProps {
+  children?: string | null;
+  variant?: 'chat' | 'post' | 'comment';
+  onHashtagClick?: (tag: string) => void;
+}
+
+export default function MarkdownContent({
+  children,
+  variant = 'post',
+  onHashtagClick,
+}: MarkdownContentProps): React.ReactElement | null {
   if (!children) return null;
 
   const isChat = variant === 'chat';
   const paragraphMargin = isChat ? 0 : 0.5;
 
-  const components = {
-    // Paragraphs — with optional hashtag highlighting
+  // Using Record<string, unknown> for component props since react-markdown v10
+  // types vary by component key and we only need runtime behaviour here.
+  const components: Record<string, React.ComponentType<Record<string, unknown>>> = {
     p({ children: pChildren }) {
       const content = onHashtagClick
-        ? renderWithHashtags(childrenToText(pChildren), onHashtagClick)
+        ? renderWithHashtags(childrenToText(pChildren as React.ReactNode), onHashtagClick)
         : pChildren;
       return (
         <Box
@@ -73,29 +75,27 @@ export default function MarkdownContent({ children, variant = 'post', onHashtagC
             lineHeight: isChat ? 'inherit' : 1.6,
           }}
         >
-          {content}
+          {content as React.ReactNode}
         </Box>
       );
     },
 
-    // Links
     a({ href, children: aChildren }) {
       return (
         <Box
           component="a"
-          href={href}
+          href={href as string | undefined}
           target="_blank"
           rel="noopener noreferrer"
           sx={{ color: 'primary.main', textDecoration: 'underline' }}
         >
-          {aChildren}
+          {aChildren as React.ReactNode}
         </Box>
       );
     },
 
-    // Inline code
     code({ inline, children: cChildren }) {
-      if (inline !== false) {
+      if ((inline as boolean | undefined) !== false) {
         return (
           <Box
             component="code"
@@ -108,7 +108,7 @@ export default function MarkdownContent({ children, variant = 'post', onHashtagC
               borderRadius: 0.5,
             }}
           >
-            {cChildren}
+            {cChildren as React.ReactNode}
           </Box>
         );
       }
@@ -117,12 +117,11 @@ export default function MarkdownContent({ children, variant = 'post', onHashtagC
           component="code"
           sx={{ fontFamily: 'monospace', fontSize: '0.875em', display: 'block', whiteSpace: 'pre' }}
         >
-          {cChildren}
+          {cChildren as React.ReactNode}
         </Box>
       );
     },
 
-    // Code blocks
     pre({ children: preChildren }) {
       return (
         <Box
@@ -141,31 +140,29 @@ export default function MarkdownContent({ children, variant = 'post', onHashtagC
             overflowWrap: 'normal',
           }}
         >
-          {preChildren}
+          {preChildren as React.ReactNode}
         </Box>
       );
     },
 
-    // Lists
     ul({ children: ulChildren }) {
       return (
         <Box component="ul" sx={{ pl: 2.5, my: paragraphMargin }}>
-          {ulChildren}
+          {ulChildren as React.ReactNode}
         </Box>
       );
     },
     ol({ children: olChildren }) {
       return (
         <Box component="ol" sx={{ pl: 2.5, my: paragraphMargin }}>
-          {olChildren}
+          {olChildren as React.ReactNode}
         </Box>
       );
     },
     li({ children: liChildren }) {
-      return <Box component="li" sx={{ mb: 0.25 }}>{liChildren}</Box>;
+      return <Box component="li" sx={{ mb: 0.25 }}>{liChildren as React.ReactNode}</Box>;
     },
 
-    // Blockquotes
     blockquote({ children: bqChildren }) {
       return (
         <Box
@@ -179,56 +176,53 @@ export default function MarkdownContent({ children, variant = 'post', onHashtagC
             fontStyle: 'italic',
           }}
         >
-          {bqChildren}
+          {bqChildren as React.ReactNode}
         </Box>
       );
     },
 
-    // Headers — scaled down; agents shouldn't need page-size headings
     h1({ children: hChildren }) {
       return (
         <Typography variant="subtitle1" sx={{ fontWeight: 700, mt: 1, mb: 0.5 }}>
-          {hChildren}
+          {hChildren as React.ReactNode}
         </Typography>
       );
     },
     h2({ children: hChildren }) {
       return (
         <Typography variant="subtitle2" sx={{ fontWeight: 700, mt: 1, mb: 0.5 }}>
-          {hChildren}
+          {hChildren as React.ReactNode}
         </Typography>
       );
     },
     h3({ children: hChildren }) {
       return (
         <Typography variant="body2" sx={{ fontWeight: 700, mt: 0.5, mb: 0.25 }}>
-          {hChildren}
+          {hChildren as React.ReactNode}
         </Typography>
       );
     },
 
-    // Horizontal rule
     hr() {
-      return <Box component="hr" sx={{ border: 'none', borderTop: '1px solid', borderColor: 'divider', my: 1 }} />;
+      return (
+        <Box
+          component="hr"
+          sx={{ border: 'none', borderTop: '1px solid', borderColor: 'divider', my: 1 }}
+        />
+      );
     },
 
-    // Strong / em
     strong({ children: sChildren }) {
-      return <Box component="strong" sx={{ fontWeight: 700 }}>{sChildren}</Box>;
+      return <Box component="strong" sx={{ fontWeight: 700 }}>{sChildren as React.ReactNode}</Box>;
     },
     em({ children: eChildren }) {
-      return <Box component="em" sx={{ fontStyle: 'italic' }}>{eChildren}</Box>;
+      return <Box component="em" sx={{ fontStyle: 'italic' }}>{eChildren as React.ReactNode}</Box>;
     },
   };
 
   return (
-    <Box
-      sx={{
-        '& > *:first-child': { mt: 0 },
-        '& > *:last-child': { mb: 0 },
-      }}
-    >
-      <ReactMarkdown components={components}>
+    <Box sx={{ '& > *:first-child': { mt: 0 }, '& > *:last-child': { mb: 0 } }}>
+      <ReactMarkdown components={components as Parameters<typeof ReactMarkdown>[0]['components']}>
         {children}
       </ReactMarkdown>
     </Box>

--- a/frontend/src/components/common/UnifiedComposer.tsx
+++ b/frontend/src/components/common/UnifiedComposer.tsx
@@ -1,14 +1,4 @@
-/**
- * UnifiedComposer Component
- *
- * Message composer that supports:
- * - @mentions for both humans and agents
- * - Quick agent actions (/commands)
- * - File attachments
- * - Emoji picker
- */
-
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import {
   Box,
   TextField,
@@ -33,15 +23,22 @@ import {
   AttachFile as AttachIcon,
   EmojiEmotions as EmojiIcon,
   SmartToy as AgentIcon,
-  Person as PersonIcon,
   Code as CodeIcon,
   Search as SearchIcon,
   Summarize as SummarizeIcon,
   CheckCircle as CheckIcon,
 } from '@mui/icons-material';
+import { SvgIconComponent } from '@mui/icons-material';
 
-// Quick actions (slash commands)
-const quickActions = [
+interface QuickAction {
+  command: string;
+  label: string;
+  description: string;
+  icon: SvgIconComponent;
+  agentRequired: boolean;
+}
+
+const quickActions: QuickAction[] = [
   {
     command: '/summarize',
     label: 'Summarize',
@@ -72,7 +69,42 @@ const quickActions = [
   },
 ];
 
-const UnifiedComposer = ({
+interface Member {
+  id?: string;
+  username?: string;
+  name?: string;
+  [key: string]: unknown;
+}
+
+interface Agent {
+  id?: string;
+  name?: string;
+  displayName?: string;
+  [key: string]: unknown;
+}
+
+type Participant =
+  | (Member & { type: 'human' })
+  | (Agent & { type: 'agent'; name: string });
+
+interface SendPayload {
+  content: string;
+  mentions: (Participant | undefined)[];
+  command: { name: string; label: string } | null;
+}
+
+interface UnifiedComposerProps {
+  onSend: (payload: SendPayload) => void;
+  onFileUpload?: () => void;
+  members?: Member[];
+  agents?: Agent[];
+  placeholder?: string;
+  disabled?: boolean;
+  showFileUpload?: boolean;
+  showEmoji?: boolean;
+}
+
+const UnifiedComposer: React.FC<UnifiedComposerProps> = ({
   onSend,
   onFileUpload,
   members = [],
@@ -83,27 +115,24 @@ const UnifiedComposer = ({
   showEmoji = true,
 }) => {
   const theme = useTheme();
-  const inputRef = useRef(null);
+  const inputRef = useRef<HTMLDivElement>(null);
   const [message, setMessage] = useState('');
-  const [mentionAnchor, setMentionAnchor] = useState(null);
+  const [mentionAnchor, setMentionAnchor] = useState<HTMLDivElement | null>(null);
   const [mentionQuery, setMentionQuery] = useState('');
-  const [mentionType, setMentionType] = useState(null); // 'mention' or 'command'
+  const [mentionType, setMentionType] = useState<'mention' | 'command' | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
 
-  // All mentionable participants (humans + agents)
-  const allParticipants = [
-    ...members.map((m) => ({ ...m, type: 'human' })),
-    ...agents.map((a) => ({ ...a, type: 'agent', name: a.displayName || a.name })),
+  const allParticipants: Participant[] = [
+    ...members.map((m): Participant => ({ ...m, type: 'human' as const })),
+    ...agents.map((a): Participant => ({ ...a, type: 'agent' as const, name: a.displayName || a.name || '' })),
   ];
 
-  // Filter participants by query
   const filteredParticipants = mentionQuery
     ? allParticipants.filter((p) =>
-        (p.name || p.username || '').toLowerCase().includes(mentionQuery.toLowerCase())
+        ((p.name as string | undefined) || (p as Member).username || '').toLowerCase().includes(mentionQuery.toLowerCase())
       )
     : allParticipants;
 
-  // Filter quick actions by query
   const filteredActions = mentionQuery
     ? quickActions.filter(
         (a) =>
@@ -112,12 +141,10 @@ const UnifiedComposer = ({
       )
     : quickActions;
 
-  // Handle input change
-  const handleChange = (e) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const value = e.target.value;
     setMessage(value);
 
-    // Check for @ mention trigger
     const atMatch = value.match(/@(\w*)$/);
     if (atMatch) {
       setMentionAnchor(inputRef.current);
@@ -127,7 +154,6 @@ const UnifiedComposer = ({
       return;
     }
 
-    // Check for / command trigger
     const slashMatch = value.match(/\/(\w*)$/);
     if (slashMatch && (value === slashMatch[0] || value.endsWith(' ' + slashMatch[0]))) {
       setMentionAnchor(inputRef.current);
@@ -137,15 +163,56 @@ const UnifiedComposer = ({
       return;
     }
 
-    // Close mention popup
     setMentionAnchor(null);
     setMentionType(null);
   };
 
-  // Handle keyboard navigation
-  const handleKeyDown = (e) => {
+  const handleSelect = useCallback((item: Participant | QuickAction): void => {
+    if (mentionType === 'mention') {
+      const p = item as Participant;
+      const name = (p as Member).username || p.name;
+      const newMessage = message.replace(/@\w*$/, `@${name} `);
+      setMessage(newMessage);
+    } else if (mentionType === 'command') {
+      const action = item as QuickAction;
+      const newMessage = message.replace(/\/\w*$/, `${action.command} `);
+      setMessage(newMessage);
+    }
+
+    setMentionAnchor(null);
+    setMentionType(null);
+    (inputRef.current?.querySelector('textarea') as HTMLTextAreaElement | null)?.focus();
+  }, [mentionType, message]);
+
+  const handleSend = useCallback((): void => {
+    if (!message.trim() || disabled) return;
+
+    const mentionMatches = message.match(/@(\w+)/g) || [];
+    const mentions = mentionMatches
+      .map((m) => {
+        const username = m.slice(1);
+        return allParticipants.find(
+          (p) => ((p as Member).username || p.name)?.toLowerCase() === username.toLowerCase()
+        );
+      })
+      .filter(Boolean);
+
+    const commandMatch = message.match(/^\/(\w+)/);
+    const command = commandMatch ? quickActions.find((a) => a.command === `/${commandMatch[1]}`) : null;
+
+    onSend({
+      content: message,
+      mentions,
+      command: command ? { name: command.command, label: command.label } : null,
+    });
+
+    setMessage('');
+  }, [message, disabled, allParticipants, onSend]);
+
+  const handleKeyDown = (e: React.KeyboardEvent): void => {
     if (mentionAnchor) {
-      const items = mentionType === 'mention' ? filteredParticipants : filteredActions;
+      const items: (Participant | QuickAction)[] =
+        mentionType === 'mention' ? filteredParticipants : filteredActions;
 
       if (e.key === 'ArrowDown') {
         e.preventDefault();
@@ -168,51 +235,6 @@ const UnifiedComposer = ({
     }
   };
 
-  // Handle mention/command selection
-  const handleSelect = (item) => {
-    if (mentionType === 'mention') {
-      // Replace @query with @username
-      const newMessage = message.replace(/@\w*$/, `@${item.username || item.name} `);
-      setMessage(newMessage);
-    } else if (mentionType === 'command') {
-      // Replace /query with /command
-      const newMessage = message.replace(/\/\w*$/, `${item.command} `);
-      setMessage(newMessage);
-    }
-
-    setMentionAnchor(null);
-    setMentionType(null);
-    inputRef.current?.focus();
-  };
-
-  // Handle send
-  const handleSend = () => {
-    if (!message.trim() || disabled) return;
-
-    // Extract mentions
-    const mentionMatches = message.match(/@(\w+)/g) || [];
-    const mentions = mentionMatches
-      .map((m) => {
-        const username = m.slice(1);
-        return allParticipants.find(
-          (p) => (p.username || p.name)?.toLowerCase() === username.toLowerCase()
-        );
-      })
-      .filter(Boolean);
-
-    // Check for commands
-    const commandMatch = message.match(/^\/(\w+)/);
-    const command = commandMatch ? quickActions.find((a) => a.command === `/${commandMatch[1]}`) : null;
-
-    onSend({
-      content: message,
-      mentions,
-      command: command ? { name: command.command, label: command.label } : null,
-    });
-
-    setMessage('');
-  };
-
   return (
     <Box sx={{ position: 'relative' }}>
       {/* Main composer */}
@@ -228,14 +250,12 @@ const UnifiedComposer = ({
           backgroundColor: theme.palette.background.paper,
         }}
       >
-        {/* Attachment button */}
         {showFileUpload && (
           <IconButton size="small" color="default" onClick={onFileUpload}>
             <AttachIcon />
           </IconButton>
         )}
 
-        {/* Input field */}
         <TextField
           ref={inputRef}
           fullWidth
@@ -254,24 +274,18 @@ const UnifiedComposer = ({
           sx={{ flex: 1 }}
         />
 
-        {/* Emoji button */}
         {showEmoji && (
           <IconButton size="small" color="default">
             <EmojiIcon />
           </IconButton>
         )}
 
-        {/* Send button */}
         <Button
           variant="contained"
           size="small"
           disabled={!message.trim() || disabled}
           onClick={handleSend}
-          sx={{
-            minWidth: 40,
-            height: 36,
-            borderRadius: 2,
-          }}
+          sx={{ minWidth: 40, height: 36, borderRadius: 2 }}
         >
           <SendIcon fontSize="small" />
         </Button>
@@ -313,21 +327,11 @@ const UnifiedComposer = ({
         <ClickAwayListener onClickAway={() => setMentionAnchor(null)}>
           <Paper
             elevation={8}
-            sx={{
-              width: 280,
-              maxHeight: 300,
-              overflow: 'auto',
-              borderRadius: 2,
-              mb: 1,
-            }}
+            sx={{ width: 280, maxHeight: 300, overflow: 'auto', borderRadius: 2, mb: 1 }}
           >
             {mentionType === 'mention' && (
               <>
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ px: 2, py: 1, display: 'block' }}
-                >
+                <Typography variant="caption" color="text.secondary" sx={{ px: 2, py: 1, display: 'block' }}>
                   Mention someone
                 </Typography>
                 <Divider />
@@ -342,15 +346,12 @@ const UnifiedComposer = ({
                   ) : (
                     filteredParticipants.map((participant, index) => (
                       <ListItem
-                        key={participant.id || participant.name}
-                        button
+                        key={(participant as Member).id || participant.name}
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        {...{ button: true } as any}
                         selected={index === selectedIndex}
                         onClick={() => handleSelect(participant)}
-                        sx={{
-                          borderRadius: 1,
-                          mx: 0.5,
-                          my: 0.25,
-                        }}
+                        sx={{ borderRadius: 1, mx: 0.5, my: 0.25 }}
                       >
                         <ListItemAvatar sx={{ minWidth: 40 }}>
                           <Avatar
@@ -369,11 +370,13 @@ const UnifiedComposer = ({
                                   : theme.palette.text.primary,
                             }}
                           >
-                            {participant.type === 'agent' ? '🤖' : (participant.name || participant.username)?.charAt(0)}
+                            {participant.type === 'agent'
+                              ? '🤖'
+                              : (participant.name || (participant as Member).username)?.charAt(0)}
                           </Avatar>
                         </ListItemAvatar>
                         <ListItemText
-                          primary={participant.name || participant.username}
+                          primary={participant.name || (participant as Member).username}
                           secondary={participant.type === 'agent' ? 'Agent' : 'Member'}
                           primaryTypographyProps={{ fontSize: '0.875rem', fontWeight: 500 }}
                           secondaryTypographyProps={{ fontSize: '0.75rem' }}
@@ -399,11 +402,7 @@ const UnifiedComposer = ({
 
             {mentionType === 'command' && (
               <>
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ px: 2, py: 1, display: 'block' }}
-                >
+                <Typography variant="caption" color="text.secondary" sx={{ px: 2, py: 1, display: 'block' }}>
                   Quick actions
                 </Typography>
                 <Divider />
@@ -419,14 +418,11 @@ const UnifiedComposer = ({
                     filteredActions.map((action, index) => (
                       <ListItem
                         key={action.command}
-                        button
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        {...{ button: true } as any}
                         selected={index === selectedIndex}
                         onClick={() => handleSelect(action)}
-                        sx={{
-                          borderRadius: 1,
-                          mx: 0.5,
-                          my: 0.25,
-                        }}
+                        sx={{ borderRadius: 1, mx: 0.5, my: 0.25 }}
                       >
                         <ListItemAvatar sx={{ minWidth: 40 }}>
                           <Avatar
@@ -443,11 +439,7 @@ const UnifiedComposer = ({
                         <ListItemText
                           primary={action.command}
                           secondary={action.description}
-                          primaryTypographyProps={{
-                            fontSize: '0.875rem',
-                            fontWeight: 500,
-                            fontFamily: 'monospace',
-                          }}
+                          primaryTypographyProps={{ fontSize: '0.875rem', fontWeight: 500, fontFamily: 'monospace' }}
                           secondaryTypographyProps={{ fontSize: '0.75rem' }}
                         />
                         {action.agentRequired && (


### PR DESCRIPTION
## Summary
- Convert `AgentIndicator.js`, `MarkdownContent.js`, `UnifiedComposer.js` to `.tsx`
- `AgentIndicator`: `AgentTypeInfo` interface, typed `AGENT_TYPES` map, explicit props interfaces for all 5 exported components
- `MarkdownContent`: typed component-render map compatible with react-markdown v10; component functions typed as `React.ComponentType<Record<string, unknown>>`
- `UnifiedComposer`: `Member`, `Agent`, `Participant` discriminated union, `QuickAction`, `SendPayload`, `UnifiedComposerProps` — all 478 lines typed

## Test plan
- [ ] `cd frontend && npm test -- --watchAll=false` passes
- [ ] `frontend/node_modules/.bin/tsc --noEmit --project frontend/tsconfig.json` zero errors

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)