### PR TITLE
feat(frontend/ts): batch 32 — ActivityFeed, ActivityFeedPage, ActivityTimeline, AnalyticsDashboard

### DIFF
--- a/frontend/src/components/activity/ActivityFeed.tsx
+++ b/frontend/src/components/activity/ActivityFeed.tsx
@@ -5,7 +5,7 @@
  * The core social experience of Commonly.
  */
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState } from 'react';
 import {
   Box,
   Paper,
@@ -19,7 +19,6 @@ import {
   alpha,
   useTheme,
   Collapse,
-  Divider,
 } from '@mui/material';
 import {
   VerifiedUser as VerifiedIcon,
@@ -36,28 +35,87 @@ import {
   SmartToy as AgentIcon,
   Person as HumanIcon,
 } from '@mui/icons-material';
+import { SvgIconComponent } from '@mui/icons-material';
+import { Theme } from '@mui/material/styles';
+
+interface Actor {
+  id?: string;
+  name?: string;
+  type?: string;
+  verified?: boolean;
+  profilePicture?: string;
+}
+
+interface Target {
+  title?: string;
+  preview?: string;
+  description?: string;
+}
+
+interface AgentMetadata {
+  sources?: Array<{ title?: string }>;
+}
+
+interface Pod {
+  id: string;
+  name: string;
+}
+
+interface Participant {
+  name?: string;
+  type?: string;
+}
+
+interface Reply {
+  actor: { name?: string; type?: string };
+  content?: string;
+}
+
+export interface Activity {
+  id: string;
+  type?: string;
+  actor: Actor;
+  action?: string;
+  content?: string;
+  preview?: string;
+  timestamp: string;
+  reactions?: { likes?: number; liked?: boolean };
+  replyCount?: number;
+  replies?: Reply[];
+  target?: Target;
+  involves?: Participant[];
+  agentMetadata?: AgentMetadata;
+  pod?: Pod | null;
+  read?: boolean;
+  approval?: { status?: string };
+  flags?: Record<string, boolean>;
+}
+
+interface ParticipantStyle {
+  avatarShape: 'circular' | 'rounded';
+  badgeIcon: SvgIconComponent | null;
+  glowColor: ((theme: Theme) => string) | null;
+}
 
 // Participant type styling
-const participantStyles = {
-  human: {
-    avatarShape: 'circular',
-    badgeIcon: null,
-    glowColor: null,
-  },
+const participantStyles: Record<string, ParticipantStyle> = {
+  human: { avatarShape: 'circular', badgeIcon: null, glowColor: null },
   agent: {
     avatarShape: 'rounded',
     badgeIcon: AgentIcon,
     glowColor: (theme) => theme.palette.primary.main,
   },
-  system: {
-    avatarShape: 'rounded',
-    badgeIcon: null,
-    glowColor: null,
-  },
+  system: { avatarShape: 'rounded', badgeIcon: null, glowColor: null },
 };
 
+interface ActivityTypeInfo {
+  icon: SvgIconComponent | null;
+  color: string;
+  label: string;
+}
+
 // Activity type icons and colors
-const activityTypes = {
+const activityTypes: Record<string, ActivityTypeInfo> = {
   message: { icon: null, color: 'text.primary', label: '' },
   reply: { icon: ReplyIcon, color: 'text.secondary', label: 'replied' },
   skill_created: { icon: SkillIcon, color: 'secondary.main', label: 'created a skill' },
@@ -74,9 +132,25 @@ const activityTypes = {
   user_followed: { icon: HumanIcon, color: 'success.main', label: 'followed' },
 };
 
+interface ActivityItemProps {
+  activity: Activity;
+  onLike?: (activity: Activity) => void;
+  onReply?: (activity: Activity, content?: string) => void;
+  onApprove?: (activity: Activity) => void;
+  onReject?: (activity: Activity) => void;
+  onMarkRead?: (activity: Activity) => void;
+  onActorClick?: (actorId: string) => void;
+}
+
 // Single activity item
-const ActivityItem = ({
-  activity, onLike, onReply, onApprove, onReject, onMarkRead, onActorClick,
+const ActivityItem: React.FC<ActivityItemProps> = ({
+  activity,
+  onLike,
+  onReply,
+  onApprove,
+  onReject,
+  onMarkRead,
+  onActorClick,
 }) => {
   const theme = useTheme();
   const [showReplies, setShowReplies] = useState(false);
@@ -100,13 +174,13 @@ const ActivityItem = ({
 
   const isAgent = actor.type === 'agent';
   const isUnread = !read;
-  const style = participantStyles[actor.type] || participantStyles.human;
-  const actionType = activityTypes[action] || activityTypes.message;
+  const style = participantStyles[actor.type ?? 'human'] || participantStyles.human;
+  const actionType = activityTypes[action ?? 'message'] || activityTypes.message;
 
-  const formatTime = (ts) => {
+  const formatTime = (ts: string): string => {
     const date = new Date(ts);
     const now = new Date();
-    const diff = (now - date) / 1000;
+    const diff = (now.getTime() - date.getTime()) / 1000;
 
     if (diff < 60) return 'now';
     if (diff < 3600) return `${Math.floor(diff / 60)}m`;
@@ -114,7 +188,7 @@ const ActivityItem = ({
     return date.toLocaleDateString();
   };
 
-  const handleLike = () => {
+  const handleLike = (): void => {
     setIsLiked(!isLiked);
     onLike?.(activity);
   };
@@ -133,7 +207,9 @@ const ActivityItem = ({
           : theme.palette.background.paper,
         transition: 'all 0.2s ease',
         '&:hover': {
-          borderColor: isUnread ? alpha(theme.palette.error.main, 0.5) : theme.palette.grey[300],
+          borderColor: isUnread
+            ? alpha(theme.palette.error.main, 0.5)
+            : theme.palette.grey[300],
           backgroundColor: alpha(theme.palette.primary.main, 0.02),
         },
         opacity: read ? 0.92 : 1,
@@ -171,9 +247,7 @@ const ActivityItem = ({
                 p: 0.25,
               }}
             >
-              <VerifiedIcon
-                sx={{ fontSize: 14, color: theme.palette.primary.main }}
-              />
+              <VerifiedIcon sx={{ fontSize: 14, color: theme.palette.primary.main }} />
             </Box>
           )}
         </Box>
@@ -243,11 +317,7 @@ const ActivityItem = ({
                 label={pod.name}
                 size="small"
                 variant="outlined"
-                sx={{
-                  height: 18,
-                  fontSize: '0.625rem',
-                  ml: 0.5,
-                }}
+                sx={{ height: 18, fontSize: '0.625rem', ml: 0.5 }}
               />
             )}
             <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
@@ -259,11 +329,7 @@ const ActivityItem = ({
           {(content || preview) && (
             <Typography
               variant="body2"
-              sx={{
-                color: 'text.primary',
-                lineHeight: 1.6,
-                whiteSpace: 'pre-wrap',
-              }}
+              sx={{ color: 'text.primary', lineHeight: 1.6, whiteSpace: 'pre-wrap' }}
             >
               {content || preview}
             </Typography>
@@ -338,7 +404,7 @@ const ActivityItem = ({
           )}
 
           {/* Agent metadata */}
-          {isAgent && agentMetadata?.sources?.length > 0 && (
+          {isAgent && agentMetadata?.sources && agentMetadata.sources.length > 0 && (
             <Box sx={{ mt: 1, display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
               <Typography variant="caption" color="text.secondary">
                 Sources:
@@ -376,10 +442,7 @@ const ActivityItem = ({
           size="small"
           startIcon={isLiked ? <LikeIcon /> : <LikeOutlinedIcon />}
           onClick={handleLike}
-          sx={{
-            color: isLiked ? 'primary.main' : 'text.secondary',
-            fontWeight: 500,
-          }}
+          sx={{ color: isLiked ? 'primary.main' : 'text.secondary', fontWeight: 500 }}
         >
           {(reactions.likes || 0) + (isLiked ? 1 : 0)}
         </Button>
@@ -443,8 +506,22 @@ const ActivityItem = ({
   );
 };
 
+interface ActivityFeedProps {
+  activities?: Activity[];
+  loading?: boolean;
+  onLike?: (activity: Activity) => void;
+  onReply?: (activity: Activity, content?: string) => void;
+  onApprove?: (activity: Activity) => void;
+  onReject?: (activity: Activity) => void;
+  onMarkRead?: (activity: Activity) => void;
+  onActorClick?: (actorId: string) => void;
+  onLoadMore?: () => void;
+  hasMore?: boolean;
+  filter?: string;
+}
+
 // Main ActivityFeed component
-const ActivityFeed = ({
+const ActivityFeed: React.FC<ActivityFeedProps> = ({
   activities = [],
   loading = false,
   onLike,
@@ -455,10 +532,8 @@ const ActivityFeed = ({
   onActorClick,
   onLoadMore,
   hasMore = false,
-  filter = 'all', // 'all', 'humans', 'agents', 'skills'
+  filter = 'all',
 }) => {
-  const theme = useTheme();
-
   const filteredActivities = activities.filter((a) => {
     if (filter === 'all') return true;
     if (filter === 'humans') return a.actor.type === 'human';
@@ -479,13 +554,7 @@ const ActivityFeed = ({
 
   if (filteredActivities.length === 0) {
     return (
-      <Box
-        sx={{
-          textAlign: 'center',
-          py: 8,
-          color: 'text.secondary',
-        }}
-      >
+      <Box sx={{ textAlign: 'center', py: 8, color: 'text.secondary' }}>
         <Typography variant="h6" gutterBottom>
           No activity yet
         </Typography>
@@ -523,8 +592,11 @@ const ActivityFeed = ({
 };
 
 // Loading skeleton
-const ActivityItemSkeleton = () => (
-  <Paper elevation={0} sx={{ p: 2, mb: 1.5, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>
+const ActivityItemSkeleton: React.FC = () => (
+  <Paper
+    elevation={0}
+    sx={{ p: 2, mb: 1.5, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}
+  >
     <Box sx={{ display: 'flex', gap: 1.5 }}>
       <Skeleton variant="circular" width={44} height={44} />
       <Box sx={{ flex: 1 }}>

--- a/frontend/src/components/activity/ActivityFeedPage.tsx
+++ b/frontend/src/components/activity/ActivityFeedPage.tsx
@@ -35,37 +35,70 @@ import {
   Favorite as FollowingIcon,
   Chat as PodsIcon,
 } from '@mui/icons-material';
-import ActivityFeed from './ActivityFeed';
+import ActivityFeed, { Activity } from './ActivityFeed';
 import axios from 'axios';
 import { useSocket } from '../../context/SocketContext';
 import { useAuth } from '../../context/AuthContext';
 
-const ActivityFeedPage = () => {
-  const [activities, setActivities] = useState([]);
+interface UserPod {
+  _id: string;
+  name: string;
+}
+
+interface QuickPod {
+  id: string;
+  name: string;
+}
+
+interface FollowedThread {
+  postId: string;
+  url: string;
+  preview?: string;
+  newReplies: number;
+}
+
+interface QuickData {
+  social?: { followers?: number; following?: number };
+  recentPods?: QuickPod[];
+  followedThreads?: FollowedThread[];
+}
+
+interface SnackbarState {
+  open: boolean;
+  message: string;
+  severity: 'info' | 'error' | 'success' | 'warning';
+}
+
+const ActivityFeedPage: React.FC = () => {
+  const [activities, setActivities] = useState<Activity[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<string | null>(null);
   const [mode, setMode] = useState('updates');
   const [filter, setFilter] = useState('all');
   const [hasMore, setHasMore] = useState(true);
-  const [userPods, setUserPods] = useState([]);
-  const [quick, setQuick] = useState(null);
+  const [userPods, setUserPods] = useState<UserPod[]>([]);
+  const [quick, setQuick] = useState<QuickData | null>(null);
   const [liveUpdates, setLiveUpdates] = useState(0);
   const [unreadCount, setUnreadCount] = useState(0);
   const [selectedPodId, setSelectedPodId] = useState('all');
-  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'info' });
+  const [snackbar, setSnackbar] = useState<SnackbarState>({
+    open: false,
+    message: '',
+    severity: 'info',
+  });
   const { socket, connected } = useSocket();
   const { currentUser } = useAuth();
 
-  const getAuthHeaders = () => {
+  const getAuthHeaders = (): Record<string, string> => {
     const token = localStorage.getItem('token');
-    return { 'x-auth-token': token };
+    return { 'x-auth-token': token ?? '' };
   };
 
   // Fetch user's pods for the selector
   useEffect(() => {
-    const fetchUserPods = async () => {
+    const fetchUserPods = async (): Promise<void> => {
       try {
-        const response = await axios.get('/api/pods', {
+        const response = await axios.get<UserPod[]>('/api/pods', {
           headers: getAuthHeaders(),
         });
         setUserPods(response.data || []);
@@ -78,31 +111,31 @@ const ActivityFeedPage = () => {
 
   useEffect(() => {
     fetchActivities();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, filter, selectedPodId]);
 
   useEffect(() => {
     fetchUnreadCount();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, filter]);
 
-  const fetchUnreadCount = async () => {
+  const fetchUnreadCount = async (): Promise<void> => {
     try {
-      const response = await axios.get('/api/activity/unread-count', {
+      const response = await axios.get<{ unreadCount?: number }>('/api/activity/unread-count', {
         headers: getAuthHeaders(),
         params: { mode, filter },
       });
       setUnreadCount(response.data?.unreadCount || 0);
-    } catch (err) {
+    } catch {
       // keep current value
     }
   };
 
-  const fetchActivities = async () => {
+  const fetchActivities = async (): Promise<void> => {
     setLoading(true);
     try {
-      const params = { limit: 20 };
-      if (filter !== 'all') {
-        params.filter = filter;
-      }
+      const params: Record<string, unknown> = { limit: 20 };
+      if (filter !== 'all') params.filter = filter;
       params.mode = mode;
 
       let url = '/api/activity/feed';
@@ -110,7 +143,12 @@ const ActivityFeedPage = () => {
         url = `/api/activity/pods/${selectedPodId}`;
       }
 
-      const response = await axios.get(url, {
+      const response = await axios.get<{
+        activities?: Activity[];
+        hasMore?: boolean;
+        quick?: QuickData;
+        unreadCount?: number;
+      }>(url, {
         headers: getAuthHeaders(),
         params,
       });
@@ -136,28 +174,45 @@ const ActivityFeedPage = () => {
   };
 
   useEffect(() => {
-    if (!socket || !connected || !Array.isArray(userPods) || userPods.length === 0) return undefined;
+    if (!socket || !connected || !Array.isArray(userPods) || userPods.length === 0) {
+      return undefined;
+    }
     userPods.forEach((pod) => socket.emit('joinPod', pod._id));
 
-    const handleNewMessage = (message) => {
-      const pod = userPods.find((item) => item._id === (message.podId || message.pod_id));
-      const actorName = message.username || message.userId?.username || 'User';
-      const isAgent = actorName.toLowerCase().includes('bot') || actorName === 'commonly-ai-agent';
+    const handleNewMessage = (message: Record<string, unknown>): void => {
+      const pod = userPods.find(
+        (item) => item._id === (message.podId || message.pod_id),
+      );
+      const actorName =
+        (message.username as string) ||
+        ((message.userId as Record<string, unknown>)?.username as string) ||
+        'User';
+      const isAgent =
+        actorName.toLowerCase().includes('bot') || actorName === 'commonly-ai-agent';
 
-      const activity = {
-        id: `live_${message._id || message.id || Date.now()}`,
+      const activity: Activity = {
+        id: `live_${(message._id as string) || (message.id as string) || Date.now()}`,
         type: 'message',
         actor: {
-          id: message.userId?._id || message.userId || message.user_id,
+          id:
+            ((message.userId as Record<string, unknown>)?._id as string) ||
+            (message.userId as string) ||
+            (message.user_id as string),
           name: actorName,
           type: isAgent ? 'agent' : 'human',
           verified: isAgent,
-          profilePicture: message.profilePicture || message.profile_picture || message.userId?.profilePicture,
+          profilePicture:
+            (message.profilePicture as string) ||
+            (message.profile_picture as string) ||
+            ((message.userId as Record<string, unknown>)?.profilePicture as string),
         },
         action: 'message',
-        content: message.content || message.text || '',
-        preview: (message.content || message.text || '').slice(0, 200),
-        timestamp: message.createdAt || message.created_at || new Date().toISOString(),
+        content: (message.content as string) || (message.text as string) || '',
+        preview: ((message.content as string) || (message.text as string) || '').slice(0, 200),
+        timestamp:
+          (message.createdAt as string) ||
+          (message.created_at as string) ||
+          new Date().toISOString(),
         pod: pod ? { id: pod._id, name: pod.name } : null,
         reactions: { likes: 0, liked: false },
         replyCount: 0,
@@ -165,15 +220,19 @@ const ActivityFeedPage = () => {
         flags: {
           isAgentAction: isAgent,
           isMention: Boolean(
-            currentUser?.username
-            && (message.content || '').toLowerCase().includes(`@${currentUser.username.toLowerCase()}`),
+            currentUser?.username &&
+              ((message.content as string) || '').toLowerCase().includes(
+                `@${currentUser.username.toLowerCase()}`,
+              ),
           ),
           isFollowing: false,
           isThreadUpdate: false,
         },
       };
 
-      setActivities((prev) => [activity, ...prev.filter((item) => item.id !== activity.id)].slice(0, 50));
+      setActivities((prev) =>
+        [activity, ...prev.filter((item) => item.id !== activity.id)].slice(0, 50),
+      );
       setLiveUpdates((count) => count + 1);
       setUnreadCount((count) => count + 1);
     };
@@ -185,59 +244,50 @@ const ActivityFeedPage = () => {
     };
   }, [socket, connected, userPods, currentUser]);
 
-  const handleMarkRead = async (activity) => {
+  const handleMarkRead = async (activity: Activity): Promise<void> => {
     if (!activity?.id) return;
     try {
       await axios.post(
         '/api/activity/mark-read',
         { activityId: activity.id },
-        { headers: getAuthHeaders() }
+        { headers: getAuthHeaders() },
       );
-      setActivities((prev) => prev.map((item) => (
-        item.id === activity.id ? { ...item, read: true } : item
-      )));
+      setActivities((prev) =>
+        prev.map((item) => (item.id === activity.id ? { ...item, read: true } : item)),
+      );
       setUnreadCount((count) => Math.max(0, count - 1));
-    } catch (err) {
+    } catch {
       setSnackbar({ open: true, message: 'Failed to mark as read', severity: 'error' });
     }
   };
 
-  const handleMarkAllRead = async () => {
+  const handleMarkAllRead = async (): Promise<void> => {
     try {
       await axios.post(
         '/api/activity/mark-read',
         { all: true },
-        { headers: getAuthHeaders() }
+        { headers: getAuthHeaders() },
       );
       setActivities((prev) => prev.map((item) => ({ ...item, read: true })));
       setUnreadCount(0);
       setSnackbar({ open: true, message: 'All caught up', severity: 'success' });
-    } catch (err) {
+    } catch {
       setSnackbar({ open: true, message: 'Failed to mark all as read', severity: 'error' });
     }
   };
 
-  const handleLike = async (activity) => {
+  const handleLike = async (activity: Activity): Promise<void> => {
     try {
-      await axios.post(
-        `/api/activity/${activity.id}/like`,
-        {},
-        { headers: getAuthHeaders() }
-      );
-      // Optimistically update the UI
+      await axios.post(`/api/activity/${activity.id}/like`, {}, { headers: getAuthHeaders() });
       setActivities((prev) =>
         prev.map((a) =>
           a.id === activity.id
             ? {
                 ...a,
-                reactions: {
-                  ...a.reactions,
-                  likes: (a.reactions?.likes || 0) + 1,
-                  liked: true,
-                },
+                reactions: { ...a.reactions, likes: (a.reactions?.likes || 0) + 1, liked: true },
               }
-            : a
-        )
+            : a,
+        ),
       );
     } catch (err) {
       console.error('Error liking activity:', err);
@@ -245,26 +295,27 @@ const ActivityFeedPage = () => {
     }
   };
 
-  const handleReply = async (activity, content) => {
+  const handleReply = async (activity: Activity, content?: string): Promise<void> => {
     try {
-      const response = await axios.post(
+      const response = await axios.post<{ success: boolean; reply: unknown }>(
         `/api/activity/${activity.id}/reply`,
         { content },
-        { headers: getAuthHeaders() }
+        { headers: getAuthHeaders() },
       );
-
       if (response.data.success) {
-        // Update the activity with the new reply
         setActivities((prev) =>
           prev.map((a) =>
             a.id === activity.id
               ? {
                   ...a,
                   replyCount: (a.replyCount || 0) + 1,
-                  replies: [...(a.replies || []), response.data.reply],
+                  replies: [
+                    ...(a.replies || []),
+                    response.data.reply as Activity['replies'][0],
+                  ],
                 }
-              : a
-          )
+              : a,
+          ),
         );
         setSnackbar({ open: true, message: 'Reply added', severity: 'success' });
       }
@@ -274,25 +325,20 @@ const ActivityFeedPage = () => {
     }
   };
 
-  const handleApprove = async (activity) => {
+  const handleApprove = async (activity: Activity): Promise<void> => {
     try {
-      const response = await axios.post(
+      const response = await axios.post<{ success: boolean }>(
         `/api/activity/${activity.id}/approve`,
         { notes: 'Approved via UI' },
-        { headers: getAuthHeaders() }
+        { headers: getAuthHeaders() },
       );
-
       if (response.data.success) {
-        // Update the activity status
         setActivities((prev) =>
           prev.map((a) =>
             a.id === activity.id
-              ? {
-                  ...a,
-                  approval: { ...a.approval, status: 'approved' },
-                }
-              : a
-          )
+              ? { ...a, approval: { ...a.approval, status: 'approved' } }
+              : a,
+          ),
         );
         setSnackbar({ open: true, message: 'Approved successfully', severity: 'success' });
       }
@@ -302,25 +348,20 @@ const ActivityFeedPage = () => {
     }
   };
 
-  const handleReject = async (activity) => {
+  const handleReject = async (activity: Activity): Promise<void> => {
     try {
-      const response = await axios.post(
+      const response = await axios.post<{ success: boolean }>(
         `/api/activity/${activity.id}/reject`,
         { notes: 'Rejected via UI' },
-        { headers: getAuthHeaders() }
+        { headers: getAuthHeaders() },
       );
-
       if (response.data.success) {
-        // Update the activity status
         setActivities((prev) =>
           prev.map((a) =>
             a.id === activity.id
-              ? {
-                  ...a,
-                  approval: { ...a.approval, status: 'rejected' },
-                }
-              : a
-          )
+              ? { ...a, approval: { ...a.approval, status: 'rejected' } }
+              : a,
+          ),
         );
         setSnackbar({ open: true, message: 'Rejected', severity: 'info' });
       }
@@ -330,15 +371,16 @@ const ActivityFeedPage = () => {
     }
   };
 
-  const handleLoadMore = async () => {
+  const handleLoadMore = async (): Promise<void> => {
     if (activities.length === 0 || loading) return;
 
     const lastActivity = activities[activities.length - 1];
     try {
-      const params = { limit: 20, before: lastActivity.timestamp };
-      if (filter !== 'all') {
-        params.filter = filter;
-      }
+      const params: Record<string, unknown> = {
+        limit: 20,
+        before: lastActivity.timestamp,
+      };
+      if (filter !== 'all') params.filter = filter;
       params.mode = mode;
 
       let url = '/api/activity/feed';
@@ -346,7 +388,7 @@ const ActivityFeedPage = () => {
         url = `/api/activity/pods/${selectedPodId}`;
       }
 
-      const response = await axios.get(url, {
+      const response = await axios.get<{ activities?: Activity[]; hasMore?: boolean }>(url, {
         headers: getAuthHeaders(),
         params,
       });
@@ -358,17 +400,21 @@ const ActivityFeedPage = () => {
     }
   };
 
-  const handleSeedActivities = async () => {
+  const handleSeedActivities = async (): Promise<void> => {
     if (selectedPodId === 'all') {
-      setSnackbar({ open: true, message: 'Select a specific pod to seed activities', severity: 'warning' });
+      setSnackbar({
+        open: true,
+        message: 'Select a specific pod to seed activities',
+        severity: 'warning',
+      });
       return;
     }
 
     try {
-      const response = await axios.post(
+      const response = await axios.post<{ success: boolean; count: number }>(
         `/api/activity/seed/${selectedPodId}`,
         {},
-        { headers: getAuthHeaders() }
+        { headers: getAuthHeaders() },
       );
 
       if (response.data.success) {
@@ -377,7 +423,6 @@ const ActivityFeedPage = () => {
           message: `Seeded ${response.data.count} demo activities`,
           severity: 'success',
         });
-        // Refresh the feed
         fetchActivities();
       }
     } catch (err) {
@@ -389,7 +434,9 @@ const ActivityFeedPage = () => {
   return (
     <Container maxWidth="md" sx={{ py: 4 }}>
       {/* Header */}
-      <Box sx={{ mb: 4, display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+      <Box
+        sx={{ mb: 4, display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}
+      >
         <Box>
           <Typography variant="h4" fontWeight={700} gutterBottom>
             Activity
@@ -427,11 +474,7 @@ const ActivityFeedPage = () => {
           >
             Refresh
           </Button>
-          <Button
-            variant="contained"
-            size="small"
-            onClick={handleMarkAllRead}
-          >
+          <Button variant="contained" size="small" onClick={handleMarkAllRead}>
             Mark all read ({unreadCount})
           </Button>
         </Box>
@@ -444,8 +487,13 @@ const ActivityFeedPage = () => {
       )}
 
       {quick && (
-        <Paper elevation={0} sx={{ mb: 3, borderRadius: 2, p: 2, border: '1px solid', borderColor: 'divider' }}>
-          <Typography variant="subtitle2" sx={{ mb: 1 }}>Quick View</Typography>
+        <Paper
+          elevation={0}
+          sx={{ mb: 3, borderRadius: 2, p: 2, border: '1px solid', borderColor: 'divider' }}
+        >
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Quick View
+          </Typography>
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5, mb: 1.5 }}>
             <Button size="small" variant="outlined" disableElevation>
               Followers: {quick.social?.followers || 0}
@@ -478,9 +526,12 @@ const ActivityFeedPage = () => {
                 key={thread.postId}
                 variant="body2"
                 sx={{ cursor: 'pointer' }}
-                onClick={() => { window.location.href = thread.url; }}
+                onClick={() => {
+                  window.location.href = thread.url;
+                }}
               >
-                {thread.preview || 'Thread'} {thread.newReplies > 0 ? `• ${thread.newReplies} new replies` : ''}
+                {thread.preview || 'Thread'}{' '}
+                {thread.newReplies > 0 ? `• ${thread.newReplies} new replies` : ''}
               </Typography>
             ))}
             {(quick.followedThreads || []).length === 0 && (
@@ -496,18 +547,12 @@ const ActivityFeedPage = () => {
       <Paper elevation={0} sx={{ mb: 3, borderRadius: 2 }}>
         <Tabs
           value={mode}
-          onChange={(e, v) => {
+          onChange={(_e, v: string) => {
             setMode(v);
             setFilter('all');
           }}
           variant="fullWidth"
-          sx={{
-            '& .MuiTab-root': {
-              minHeight: 48,
-              textTransform: 'none',
-              fontWeight: 500,
-            },
-          }}
+          sx={{ '& .MuiTab-root': { minHeight: 48, textTransform: 'none', fontWeight: 500 } }}
         >
           <Tab icon={<UpdatesIcon />} iconPosition="start" label="Updates" value="updates" />
           <Tab icon={<ActionsIcon />} iconPosition="start" label="Actions" value="actions" />
@@ -518,26 +563,35 @@ const ActivityFeedPage = () => {
       <Paper elevation={0} sx={{ mb: 3, borderRadius: 2 }}>
         <Tabs
           value={filter}
-          onChange={(e, v) => setFilter(v)}
+          onChange={(_e, v: string) => setFilter(v)}
           variant="scrollable"
           allowScrollButtonsMobile
-          sx={{
-            '& .MuiTab-root': {
-              minHeight: 44,
-              textTransform: 'none',
-              fontWeight: 500,
-            },
-          }}
+          sx={{ '& .MuiTab-root': { minHeight: 44, textTransform: 'none', fontWeight: 500 } }}
         >
           <Tab icon={<AllIcon />} iconPosition="start" label="All" value="all" />
           {mode === 'updates' && (
-            <Tab icon={<MentionsIcon />} iconPosition="start" label="Mentions" value="mentions" />
+            <Tab
+              icon={<MentionsIcon />}
+              iconPosition="start"
+              label="Mentions"
+              value="mentions"
+            />
           )}
           {mode === 'updates' && (
-            <Tab icon={<FollowingIcon />} iconPosition="start" label="Following" value="following" />
+            <Tab
+              icon={<FollowingIcon />}
+              iconPosition="start"
+              label="Following"
+              value="following"
+            />
           )}
           {mode === 'updates' && (
-            <Tab icon={<ThreadsIcon />} iconPosition="start" label="Threads" value="threads" />
+            <Tab
+              icon={<ThreadsIcon />}
+              iconPosition="start"
+              label="Threads"
+              value="threads"
+            />
           )}
           {mode === 'updates' && (
             <Tab icon={<PodsIcon />} iconPosition="start" label="Pods" value="pods" />
@@ -580,7 +634,9 @@ const ActivityFeedPage = () => {
         onApprove={handleApprove}
         onReject={handleReject}
         onMarkRead={handleMarkRead}
-        onActorClick={(actorId) => { window.location.href = `/profile/${actorId}`; }}
+        onActorClick={(actorId) => {
+          window.location.href = `/profile/${actorId}`;
+        }}
         onLoadMore={handleLoadMore}
         hasMore={hasMore}
       />

--- a/frontend/src/components/analytics/ActivityTimeline.tsx
+++ b/frontend/src/components/analytics/ActivityTimeline.tsx
@@ -7,7 +7,7 @@ import {
   Select,
   MenuItem,
   CircularProgress,
-  Alert
+  Alert,
 } from '@mui/material';
 import {
   Chart as ChartJS,
@@ -19,6 +19,8 @@ import {
   Title,
   Tooltip,
   Legend,
+  ChartData,
+  ChartOptions,
 } from 'chart.js';
 import { Line, Bar } from 'react-chartjs-2';
 import axios from 'axios';
@@ -31,28 +33,47 @@ ChartJS.register(
   BarElement,
   Title,
   Tooltip,
-  Legend
+  Legend,
 );
 
-const ActivityTimeline = ({ timeRange = '24h' }) => {
-  const [activityData, setActivityData] = useState(null);
+interface ActivityDataPoint {
+  hour?: number;
+  day?: string;
+  timestamp?: string;
+  activity: number;
+  sentiment?: string;
+}
+
+interface ActivityData {
+  activity: ActivityDataPoint[];
+  totalDataPoints: number;
+}
+
+interface ActivityTimelineProps {
+  timeRange?: string;
+}
+
+const ActivityTimeline: React.FC<ActivityTimelineProps> = ({ timeRange = '24h' }) => {
+  const [activityData, setActivityData] = useState<ActivityData | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<string | null>(null);
   const [chartType, setChartType] = useState('hourly');
 
-  const fetchActivityData = async () => {
+  const fetchActivityData = async (): Promise<void> => {
     try {
       setLoading(true);
       const token = localStorage.getItem('token');
-      
-      const response = await axios.get(`/api/analytics/activity?timeRange=${timeRange}&type=${chartType}`, {
-        headers: { Authorization: `Bearer ${token}` }
-      });
-      
+
+      const response = await axios.get<ActivityData>(
+        `/api/analytics/activity?timeRange=${timeRange}&type=${chartType}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+
       setActivityData(response.data);
       setError(null);
-    } catch (err) {
-      setError(err.response?.data?.error || 'Failed to fetch activity data');
+    } catch (err: unknown) {
+      const axiosErr = err as { response?: { data?: { error?: string } } };
+      setError(axiosErr.response?.data?.error || 'Failed to fetch activity data');
       console.error('Error fetching activity data:', err);
     } finally {
       setLoading(false);
@@ -61,24 +82,22 @@ const ActivityTimeline = ({ timeRange = '24h' }) => {
 
   useEffect(() => {
     fetchActivityData();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [timeRange, chartType]);
 
-  const formatChartData = () => {
+  const formatChartData = (): ChartData<'line'> | ChartData<'bar'> | null => {
     if (!activityData?.activity) return null;
 
     const { activity } = activityData;
 
     if (chartType === 'hourly') {
-      // Create 24-hour format
       const hourlyData = Array.from({ length: 24 }, (_, hour) => {
-        const found = activity.find(a => a.hour === hour);
+        const found = activity.find((a) => a.hour === hour);
         return found ? found.activity : 0;
       });
 
       return {
-        labels: Array.from({ length: 24 }, (_, i) => 
-          `${i.toString().padStart(2, '0')}:00`
-        ),
+        labels: Array.from({ length: 24 }, (_, i) => `${i.toString().padStart(2, '0')}:00`),
         datasets: [
           {
             label: 'Activity Level',
@@ -86,63 +105,61 @@ const ActivityTimeline = ({ timeRange = '24h' }) => {
             borderColor: 'rgb(29, 161, 242)',
             backgroundColor: 'rgba(29, 161, 242, 0.1)',
             tension: 0.4,
-            fill: true
-          }
-        ]
-      };
+            fill: true,
+          },
+        ],
+      } as ChartData<'line'>;
     }
 
     if (chartType === 'daily') {
       return {
-        labels: activity.map(a => new Date(a.day).toLocaleDateString()),
+        labels: activity.map((a) => new Date(a.day ?? '').toLocaleDateString()),
         datasets: [
           {
             label: 'Daily Activity',
-            data: activity.map(a => a.activity),
+            data: activity.map((a) => a.activity),
             backgroundColor: 'rgba(29, 161, 242, 0.6)',
             borderColor: 'rgb(29, 161, 242)',
-            borderWidth: 1
-          }
-        ]
-      };
+            borderWidth: 1,
+          },
+        ],
+      } as ChartData<'bar'>;
     }
 
     if (chartType === 'sentiment') {
-      const sentimentColors = {
-        'very_positive': '#4caf50',
-        'positive': '#8bc34a',
-        'neutral': '#ffc107',
-        'negative': '#ff9800',
-        'very_negative': '#f44336'
+      const sentimentColors: Record<string, string> = {
+        very_positive: '#4caf50',
+        positive: '#8bc34a',
+        neutral: '#ffc107',
+        negative: '#ff9800',
+        very_negative: '#f44336',
       };
 
       return {
-        labels: activity.map(a => new Date(a.timestamp).toLocaleTimeString()),
+        labels: activity.map((a) => new Date(a.timestamp ?? '').toLocaleTimeString()),
         datasets: [
           {
             label: 'Sentiment Over Time',
-            data: activity.map(a => a.activity),
-            backgroundColor: activity.map(a => sentimentColors[a.sentiment] || '#9e9e9e'),
+            data: activity.map((a) => a.activity),
+            backgroundColor: activity.map((a) => sentimentColors[a.sentiment ?? ''] || '#9e9e9e'),
             borderColor: 'rgba(0,0,0,0.1)',
-            borderWidth: 1
-          }
-        ]
-      };
+            borderWidth: 1,
+          },
+        ],
+      } as ChartData<'bar'>;
     }
 
     return null;
   };
 
-  const chartOptions = {
+  const chartOptions: ChartOptions<'line'> | ChartOptions<'bar'> = {
     responsive: true,
     maintainAspectRatio: false,
     plugins: {
-      legend: {
-        position: 'top',
-      },
+      legend: { position: 'top' },
       title: {
         display: true,
-        text: `${chartType.charAt(0).toUpperCase() + chartType.slice(1)} Activity Pattern`
+        text: `${chartType.charAt(0).toUpperCase() + chartType.slice(1)} Activity Pattern`,
       },
     },
     scales: {
@@ -150,22 +167,26 @@ const ActivityTimeline = ({ timeRange = '24h' }) => {
         beginAtZero: true,
         title: {
           display: true,
-          text: chartType === 'sentiment' ? 'Activity Level' : 'Messages'
-        }
+          text: chartType === 'sentiment' ? 'Activity Level' : 'Messages',
+        },
       },
       x: {
         title: {
           display: true,
-          text: chartType === 'hourly' ? 'Hour of Day' : 
-                chartType === 'daily' ? 'Date' : 'Time'
+          text:
+            chartType === 'hourly'
+              ? 'Hour of Day'
+              : chartType === 'daily'
+                ? 'Date'
+                : 'Time',
         },
         ticks: {
           maxRotation: 45,
           minRotation: 45,
-          maxTicksLimit: chartType === 'hourly' ? 12 : 10
-        }
-      }
-    }
+          maxTicksLimit: chartType === 'hourly' ? 12 : 10,
+        },
+      },
+    },
   };
 
   const chartData = formatChartData();
@@ -176,12 +197,9 @@ const ActivityTimeline = ({ timeRange = '24h' }) => {
         <Typography variant="h6" component="h3">
           📈 Activity Timeline
         </Typography>
-        
+
         <FormControl size="small" sx={{ minWidth: 120 }}>
-          <Select
-            value={chartType}
-            onChange={(e) => setChartType(e.target.value)}
-          >
+          <Select value={chartType} onChange={(e) => setChartType(e.target.value)}>
             <MenuItem value="hourly">Hourly</MenuItem>
             <MenuItem value="daily">Daily</MenuItem>
             <MenuItem value="sentiment">Sentiment</MenuItem>
@@ -205,18 +223,20 @@ const ActivityTimeline = ({ timeRange = '24h' }) => {
         <Box sx={{ height: 300 }}>
           {chartData && activityData.activity.length > 0 ? (
             chartType === 'daily' || chartType === 'sentiment' ? (
-              <Bar data={chartData} options={chartOptions} />
+              <Bar data={chartData as ChartData<'bar'>} options={chartOptions as ChartOptions<'bar'>} />
             ) : (
-              <Line data={chartData} options={chartOptions} />
+              <Line data={chartData as ChartData<'line'>} options={chartOptions as ChartOptions<'line'>} />
             )
           ) : (
-            <Box sx={{ 
-              display: 'flex', 
-              justifyContent: 'center', 
-              alignItems: 'center', 
-              height: '100%',
-              color: 'text.secondary'
-            }}>
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                height: '100%',
+                color: 'text.secondary',
+              }}
+            >
               <Typography>No activity data available for this time period</Typography>
             </Box>
           )}

--- a/frontend/src/components/analytics/AnalyticsDashboard.tsx
+++ b/frontend/src/components/analytics/AnalyticsDashboard.tsx
@@ -8,26 +8,39 @@ import {
   Select,
   MenuItem,
   FormLabel,
-  Divider
+  Divider,
 } from '@mui/material';
 import ActivityTimeline from './ActivityTimeline';
 import KeywordCloud from './KeywordCloud';
 
-const AnalyticsDashboard = ({ defaultTimeRange = '24h' }) => {
+interface QuickStats {
+  totalSummaries: number;
+  totalActivity: number;
+  uniqueUsers: number;
+  dominantSentiment?: string;
+}
+
+interface AnalyticsDashboardProps {
+  defaultTimeRange?: string;
+}
+
+const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
+  defaultTimeRange = '24h',
+}) => {
   const [timeRange, setTimeRange] = useState(defaultTimeRange);
   const [viewMode, setViewMode] = useState('timeline');
 
-  const QuickStats = () => {
-    const [stats, setStats] = useState(null);
+  const QuickStatsPanel: React.FC = () => {
+    const [stats, setStats] = useState<QuickStats | null>(null);
 
     React.useEffect(() => {
-      const fetchStats = async () => {
+      const fetchStats = async (): Promise<void> => {
         try {
           const token = localStorage.getItem('token');
           const response = await fetch(`/api/analytics/summary?timeRange=${timeRange}`, {
-            headers: { Authorization: `Bearer ${token}` }
+            headers: { Authorization: `Bearer ${token}` },
           });
-          const data = await response.json();
+          const data = await response.json() as { summary: QuickStats };
           setStats(data.summary);
         } catch (error) {
           console.error('Error fetching stats:', error);
@@ -35,7 +48,7 @@ const AnalyticsDashboard = ({ defaultTimeRange = '24h' }) => {
       };
 
       fetchStats();
-    }, [timeRange]);
+    }, []);
 
     if (!stats) return null;
 
@@ -88,11 +101,20 @@ const AnalyticsDashboard = ({ defaultTimeRange = '24h' }) => {
   return (
     <Box sx={{ p: 2 }}>
       {/* Header Controls */}
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3, flexWrap: 'wrap', gap: 2 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 3,
+          flexWrap: 'wrap',
+          gap: 2,
+        }}
+      >
         <Typography variant="h5" component="h2" sx={{ fontWeight: 600 }}>
           📊 Community Analytics
         </Typography>
-        
+
         <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
           <FormControl size="small">
             <FormLabel sx={{ fontSize: '0.75rem', mb: 0.5 }}>Time Range</FormLabel>
@@ -106,7 +128,7 @@ const AnalyticsDashboard = ({ defaultTimeRange = '24h' }) => {
               <MenuItem value="7d">7 Days</MenuItem>
             </Select>
           </FormControl>
-          
+
           <FormControl size="small">
             <FormLabel sx={{ fontSize: '0.75rem', mb: 0.5 }}>View</FormLabel>
             <Select
@@ -123,7 +145,7 @@ const AnalyticsDashboard = ({ defaultTimeRange = '24h' }) => {
       </Box>
 
       {/* Quick Stats */}
-      <QuickStats />
+      <QuickStatsPanel />
 
       <Divider sx={{ my: 3 }} />
 
@@ -134,7 +156,7 @@ const AnalyticsDashboard = ({ defaultTimeRange = '24h' }) => {
             <ActivityTimeline timeRange={timeRange} />
           </Grid>
         )}
-        
+
         {(viewMode === 'keywords' || viewMode === 'both') && (
           <Grid item xs={12} lg={viewMode === 'both' ? 6 : 12}>
             <KeywordCloud timeRange={timeRange} />


### PR DESCRIPTION
## Summary
- `activity/ActivityFeed.js` → `.tsx` — Activity, Actor, Target, Reply, ActivityFeedProps interfaces; exported `Activity` type for use in ActivityFeedPage
- `activity/ActivityFeedPage.js` → `.tsx` — UserPod, QuickData, SnackbarState interfaces; socket newMessage handler typed with `Record<string, unknown>`
- `analytics/ActivityTimeline.js` → `.tsx` — ActivityDataPoint, ActivityData; chart.js ChartData/ChartOptions generics
- `analytics/AnalyticsDashboard.js` → `.tsx` — QuickStats interface, QuickStatsPanel as typed inner component

## Test plan
- [ ] `Test & Coverage` CI check passes
- [ ] `tsc --noEmit` exits clean (verified locally before PR)

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)