### PR TITLE
feat(frontend): migrate DiscordIntegration, AgentCard, AdminUsers, AppsMarketplacePage to TypeScript (batch 35)

### DIFF
--- a/frontend/src/components/DiscordIntegration.tsx
+++ b/frontend/src/components/DiscordIntegration.tsx
@@ -28,71 +28,97 @@ import axios from 'axios';
 import getApiBaseUrl from '../utils/apiBaseUrl';
 import { AuthContext } from '../context/AuthContext';
 
+interface IntegrationConfig {
+  serverName?: string;
+  channelName?: string;
+  agentAccessEnabled?: boolean;
+  botToken?: string;
+}
+
+interface Integration {
+  _id: string;
+  type: string;
+  status: string;
+  config: IntegrationConfig;
+  createdBy?: string | { _id?: string };
+}
+
+interface PodInfo {
+  createdBy?: string | { _id?: string };
+}
+
+interface DiscordIntegrationProps {
+  podId: string;
+  viewOnly?: boolean;
+}
+
 // Discord logo component
-const DiscordIcon = () => (
+const DiscordIcon = (): React.ReactElement => (
   <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
     <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419-.0190 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9460 2.4189-2.1568 2.4189Z"/>
   </svg>
 );
 
 // Use OAuth flow with redirect instead of simple bot invite
-const getDiscordOAuthUrl = (podId) => {
+const getDiscordOAuthUrl = (podId: string): string => {
   const clientId = process.env.REACT_APP_DISCORD_CLIENT_ID;
   const redirectUri = encodeURIComponent(`${getApiBaseUrl()}/api/discord/callback`);
   const scopes = encodeURIComponent('bot applications.commands');
   const permissions = '536873984'; // Send Messages (2048) + Manage Webhooks (536870912) = 536873984
   const state = `pod_${podId}`;
   const timestamp = Date.now(); // Add timestamp to prevent caching
-  
+
   return `https://discord.com/api/oauth2/authorize?client_id=${clientId}&scope=${scopes}&permissions=${permissions}&redirect_uri=${redirectUri}&response_type=code&state=${state}&t=${timestamp}`;
 };
 
-const DiscordIntegration = ({ podId, viewOnly = false }) => {
+const DiscordIntegration: React.FC<DiscordIntegrationProps> = ({ podId, viewOnly = false }) => {
   const { user } = useContext(AuthContext);
-  const [integrations, setIntegrations] = useState([]);
+  const [integrations, setIntegrations] = useState<Integration[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [integrationToDelete, setIntegrationToDelete] = useState(null);
+  const [integrationToDelete, setIntegrationToDelete] = useState<Integration | null>(null);
   const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
-  const [integrationToConfigure, setIntegrationToConfigure] = useState(null);
+  const [integrationToConfigure, setIntegrationToConfigure] = useState<Integration | null>(null);
   const [botToken, setBotToken] = useState('');
   const [enableAgentAccess, setEnableAgentAccess] = useState(false);
   const [settingsSaving, setSettingsSaving] = useState(false);
-  const [podInfo, setPodInfo] = useState(null);
+  const [podInfo, setPodInfo] = useState<PodInfo | null>(null);
 
   // Check if user can delete integration (only used in non-viewOnly mode)
-  const canDeleteIntegration = (integration) => {
+  const canDeleteIntegration = (integration: Integration): boolean => {
     if (viewOnly) return false; // No delete in view-only mode
-    
+
     if (!user) return false;
-    
+
     // Admin can delete any integration
     if (user.role === 'admin') return true;
-    
+
     // Get user ID (different auth contexts use different field names)
-    const currentUserId = user.id || user._id;
-    
+    const currentUserId = (user as { id?: string; _id?: string }).id || (user as { id?: string; _id?: string })._id;
+
     // Pod owner can delete integrations in their pod
     if (podInfo) {
       const podOwnerId = typeof podInfo.createdBy === 'string' ? podInfo.createdBy : podInfo.createdBy?._id;
       if (podOwnerId === currentUserId) return true;
     }
-    
+
     // Integration creator can delete their own integration
-    const integrationCreatorId = integration.createdBy?._id || integration.createdBy;
+    const integrationCreatorId = typeof integration.createdBy === 'object'
+      ? integration.createdBy?._id
+      : integration.createdBy;
     if (integrationCreatorId === currentUserId) return true;
-    
+
     return false;
   };
 
   // Fetch existing integrations and pod info
-  const fetchIntegrations = async () => {
+  const fetchIntegrations = async (): Promise<void> => {
     try {
       setLoading(true);
       const token = localStorage.getItem('token');
-      
+
       // Fetch integrations and pod info in parallel
       const [integrationsResponse, podResponse] = await Promise.all([
         axios.get(`/api/integrations/${podId}`, {
@@ -100,20 +126,23 @@ const DiscordIntegration = ({ podId, viewOnly = false }) => {
         }),
         axios.get(`/api/pods/${podId}`, {
           headers: { Authorization: `Bearer ${token}` }
-        }).catch((error) => {
-          console.warn('Pod fetch failed:', error.response?.status, error.response?.data);
+        }).catch((err: unknown) => {
+          const e = err as { response?: { status?: number; data?: unknown } };
+          console.warn('Pod fetch failed:', e.response?.status, e.response?.data);
           return null; // Don't fail if pod info can't be fetched
         })
       ]);
-      
-      const discordIntegrations = integrationsResponse.data.filter(integration => integration.type === 'discord');
+
+      const discordIntegrations = (integrationsResponse.data as Integration[]).filter(
+        (integration) => integration.type === 'discord'
+      );
       setIntegrations(discordIntegrations);
-      
+
       if (podResponse) {
-        setPodInfo(podResponse.data);
+        setPodInfo((podResponse as { data: PodInfo }).data);
       }
-    } catch (error) {
-      console.error('Error fetching integrations:', error);
+    } catch (err) {
+      console.error('Error fetching integrations:', err);
       setError('Failed to load apps');
     } finally {
       setLoading(false);
@@ -126,57 +155,57 @@ const DiscordIntegration = ({ podId, viewOnly = false }) => {
     }
   }, [podId]);
 
-  const handleDelete = async (integrationId) => {
+  const handleDelete = async (integrationId: string): Promise<void> => {
     try {
       setLoading(true);
       const token = localStorage.getItem('token');
       await axios.delete(`/api/integrations/${integrationId}`, {
         headers: { Authorization: `Bearer ${token}` }
       });
-      
+
       setSuccess('App disconnected successfully');
       fetchIntegrations();
       setDeleteDialogOpen(false);
       setIntegrationToDelete(null);
-    } catch (error) {
-      console.error('Error deleting integration:', error);
+    } catch (err) {
+      console.error('Error deleting integration:', err);
       setError('Failed to disconnect app');
     } finally {
       setLoading(false);
     }
   };
 
-  const handleDeleteClick = (integration) => {
+  const handleDeleteClick = (integration: Integration): void => {
     setIntegrationToDelete(integration);
     setDeleteDialogOpen(true);
   };
 
-  const handleDeleteConfirm = () => {
+  const handleDeleteConfirm = (): void => {
     if (integrationToDelete) {
       handleDelete(integrationToDelete._id);
     }
   };
 
-  const handleDeleteCancel = () => {
+  const handleDeleteCancel = (): void => {
     setDeleteDialogOpen(false);
     setIntegrationToDelete(null);
   };
 
-  const handleSettingsOpen = (integration) => {
+  const handleSettingsOpen = (integration: Integration): void => {
     setIntegrationToConfigure(integration);
     setBotToken(integration?.config?.botToken || '');
     setEnableAgentAccess(Boolean(integration?.config?.agentAccessEnabled));
     setSettingsDialogOpen(true);
   };
 
-  const handleSettingsClose = () => {
+  const handleSettingsClose = (): void => {
     setSettingsDialogOpen(false);
     setIntegrationToConfigure(null);
     setBotToken('');
     setEnableAgentAccess(false);
   };
 
-  const handleSettingsSave = async () => {
+  const handleSettingsSave = async (): Promise<void> => {
     if (!integrationToConfigure?._id) return;
     try {
       setSettingsSaving(true);
@@ -193,14 +222,15 @@ const DiscordIntegration = ({ podId, viewOnly = false }) => {
       handleSettingsClose();
       await fetchIntegrations();
     } catch (updateError) {
+      const e = updateError as { response?: { data?: { message?: string } } };
       console.error('Error updating Discord integration settings:', updateError);
-      setError(updateError.response?.data?.message || 'Failed to update Discord settings');
+      setError(e.response?.data?.message || 'Failed to update Discord settings');
     } finally {
       setSettingsSaving(false);
     }
   };
 
-  const getStatusColor = (status) => {
+  const getStatusColor = (status: string): 'success' | 'warning' | 'error' | 'default' => {
     switch (status) {
       case 'connected': return 'success';
       case 'pending': return 'warning';
@@ -209,7 +239,7 @@ const DiscordIntegration = ({ podId, viewOnly = false }) => {
     }
   };
 
-  const getStatusText = (status) => {
+  const getStatusText = (status: string): string => {
     switch (status) {
       case 'connected': return 'Connected';
       case 'pending': return 'Connecting...';
@@ -229,21 +259,21 @@ const DiscordIntegration = ({ podId, viewOnly = false }) => {
   return (
     <Box sx={{ p: 0 }}>
       {/* Header removed - title is already in sidebar section */}
-      
+
       {/* Error/Success Messages */}
       {error && (
-        <Alert 
-          severity="error" 
-          sx={{ mb: 2, borderRadius: 2 }} 
+        <Alert
+          severity="error"
+          sx={{ mb: 2, borderRadius: 2 }}
           onClose={() => setError('')}
         >
           {error}
         </Alert>
       )}
       {success && (
-        <Alert 
-          severity="success" 
-          sx={{ mb: 2, borderRadius: 2 }} 
+        <Alert
+          severity="success"
+          sx={{ mb: 2, borderRadius: 2 }}
           onClose={() => setSuccess('')}
         >
           {success}
@@ -252,8 +282,8 @@ const DiscordIntegration = ({ podId, viewOnly = false }) => {
 
       {/* Apps List */}
       {integrations.length === 0 ? (
-        <Card 
-          sx={{ 
+        <Card
+          sx={{
             borderRadius: 3,
             border: '1px solid rgba(88, 101, 242, 0.1)',
             background: 'linear-gradient(135deg, #ffffff 0%, #f8f9ff 100%)',
@@ -268,8 +298,8 @@ const DiscordIntegration = ({ podId, viewOnly = false }) => {
           <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
             <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2, flexWrap: 'wrap' }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-                <Box 
-                  sx={{ 
+                <Box
+                  sx={{
                     color: '#5865F2',
                     display: 'flex',
                     alignItems: 'center',
@@ -345,11 +375,11 @@ const DiscordIntegration = ({ podId, viewOnly = false }) => {
           >
             Add Discord
           </Button>
-          
+
           {integrations.map((integration) => (
-            <Card 
-              key={integration._id} 
-              sx={{ 
+            <Card
+              key={integration._id}
+              sx={{
                 borderRadius: 3,
                 border: '1px solid rgba(88, 101, 242, 0.1)',
                 background: 'linear-gradient(135deg, #ffffff 0%, #f8f9ff 100%)',
@@ -364,8 +394,8 @@ const DiscordIntegration = ({ podId, viewOnly = false }) => {
               <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-                    <Box 
-                      sx={{ 
+                    <Box
+                      sx={{
                         color: '#5865F2',
                         display: 'flex',
                         alignItems: 'center',
@@ -387,9 +417,9 @@ const DiscordIntegration = ({ podId, viewOnly = false }) => {
                       </Typography>
                     </Box>
                   </Box>
-                  
+
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <Chip 
+                    <Chip
                       label={getStatusText(integration.status)}
                       size="small"
                       color={getStatusColor(integration.status)}
@@ -409,15 +439,15 @@ const DiscordIntegration = ({ podId, viewOnly = false }) => {
                         borderRadius: 2
                       }}
                     />
-                    
+
                     <Tooltip title="Refresh">
                       <IconButton
                         size="small"
                         onClick={fetchIntegrations}
                         disabled={loading}
-                        sx={{ 
+                        sx={{
                           color: 'text.secondary',
-                          '&:hover': { 
+                          '&:hover': {
                             color: '#5865F2',
                             backgroundColor: 'rgba(88, 101, 242, 0.1)'
                           }
@@ -445,7 +475,7 @@ const DiscordIntegration = ({ podId, viewOnly = false }) => {
                         </IconButton>
                       </Tooltip>
                     )}
-                    
+
                     {!viewOnly && (
                       <Tooltip title={canDeleteIntegration(integration) ? "Delete Integration" : "No permission to delete"}>
                         <IconButton
@@ -456,10 +486,10 @@ const DiscordIntegration = ({ podId, viewOnly = false }) => {
                             }
                           }}
                           disabled={loading || !canDeleteIntegration(integration)}
-                          sx={{ 
+                          sx={{
                             color: canDeleteIntegration(integration) ? 'error.main' : 'text.disabled',
                             opacity: canDeleteIntegration(integration) ? 0.8 : 0.4,
-                            '&:hover': { 
+                            '&:hover': {
                               opacity: canDeleteIntegration(integration) ? 1 : 0.4,
                               color: canDeleteIntegration(integration) ? 'error.dark' : 'text.disabled',
                               backgroundColor: canDeleteIntegration(integration) ? 'rgba(244, 67, 54, 0.1)' : 'transparent',
@@ -494,9 +524,9 @@ const DiscordIntegration = ({ podId, viewOnly = false }) => {
         </DialogContent>
         <DialogActions>
           <Button onClick={handleDeleteCancel}>Cancel</Button>
-          <Button 
-            onClick={handleDeleteConfirm} 
-            color="error" 
+          <Button
+            onClick={handleDeleteConfirm}
+            color="error"
             disabled={loading}
           >
             {loading ? <CircularProgress size={20} /> : 'Remove'}
@@ -541,4 +571,4 @@ const DiscordIntegration = ({ podId, viewOnly = false }) => {
   );
 };
 
-export default DiscordIntegration; 
+export default DiscordIntegration;

--- a/frontend/src/components/admin/AdminUsers.tsx
+++ b/frontend/src/components/admin/AdminUsers.tsx
@@ -25,7 +25,54 @@ import axios from '../../utils/axiosConfig';
 
 const DEFAULT_PAGE_SIZE = 5;
 
-const AdminUsers = ({ embedded = false }) => {
+interface User {
+  id: string;
+  username: string;
+  email: string;
+  role: string;
+  verified: boolean;
+}
+
+interface Invitation {
+  id: string;
+  code: string;
+  isActive: boolean;
+  useCount: number;
+  maxUses: number;
+  note?: string;
+  expiresAt?: string;
+}
+
+interface InvitationCode {
+  code: string;
+}
+
+interface WaitlistRequest {
+  id: string;
+  email: string;
+  status: string;
+  name?: string;
+  note?: string;
+  invitationCode?: InvitationCode;
+}
+
+interface InviteForm {
+  code: string;
+  note: string;
+  maxUses: number | string;
+  expiresAt: string;
+}
+
+interface FetchDataOptions {
+  nextInvitationsPage?: number;
+  nextWaitlistPage?: number;
+}
+
+interface AdminUsersProps {
+  embedded?: boolean;
+}
+
+const AdminUsers: React.FC<AdminUsersProps> = ({ embedded = false }) => {
   const [loading, setLoading] = useState(false);
   const [savingRoleId, setSavingRoleId] = useState('');
   const [deletingUserId, setDeletingUserId] = useState('');
@@ -36,9 +83,9 @@ const AdminUsers = ({ embedded = false }) => {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
 
-  const [users, setUsers] = useState([]);
-  const [invitations, setInvitations] = useState([]);
-  const [waitlistRequests, setWaitlistRequests] = useState([]);
+  const [users, setUsers] = useState<User[]>([]);
+  const [invitations, setInvitations] = useState<Invitation[]>([]);
+  const [waitlistRequests, setWaitlistRequests] = useState<WaitlistRequest[]>([]);
   const [userQuery, setUserQuery] = useState('');
   const [userRoleFilter, setUserRoleFilter] = useState('all');
   const [invitationsPage, setInvitationsPage] = useState(1);
@@ -46,14 +93,14 @@ const AdminUsers = ({ embedded = false }) => {
   const [waitlistPage, setWaitlistPage] = useState(1);
   const [waitlistTotalPages, setWaitlistTotalPages] = useState(1);
 
-  const [inviteForm, setInviteForm] = useState({
+  const [inviteForm, setInviteForm] = useState<InviteForm>({
     code: '',
     note: '',
     maxUses: 1,
     expiresAt: '',
   });
 
-  const fetchData = async ({ nextInvitationsPage, nextWaitlistPage } = {}) => {
+  const fetchData = async ({ nextInvitationsPage, nextWaitlistPage }: FetchDataOptions = {}): Promise<void> => {
     try {
       setLoading(true);
       setError('');
@@ -80,13 +127,14 @@ const AdminUsers = ({ embedded = false }) => {
         }),
       ]);
 
-      setUsers(usersRes.data?.users || []);
-      setInvitations(invitationsRes.data?.invitations || []);
-      setInvitationsTotalPages(Math.max(1, invitationsRes.data?.totalPages || 1));
-      setWaitlistRequests(waitlistRes.data?.requests || []);
-      setWaitlistTotalPages(Math.max(1, waitlistRes.data?.totalPages || 1));
+      setUsers((usersRes.data as { users?: User[] })?.users || []);
+      setInvitations((invitationsRes.data as { invitations?: Invitation[] })?.invitations || []);
+      setInvitationsTotalPages(Math.max(1, (invitationsRes.data as { totalPages?: number })?.totalPages || 1));
+      setWaitlistRequests((waitlistRes.data as { requests?: WaitlistRequest[] })?.requests || []);
+      setWaitlistTotalPages(Math.max(1, (waitlistRes.data as { totalPages?: number })?.totalPages || 1));
     } catch (err) {
-      setError(err.response?.data?.error || 'Failed to load admin users data');
+      const e = err as { response?: { data?: { error?: string } } };
+      setError(e.response?.data?.error || 'Failed to load admin users data');
     } finally {
       setLoading(false);
     }
@@ -96,7 +144,7 @@ const AdminUsers = ({ embedded = false }) => {
     fetchData();
   }, [invitationsPage, waitlistPage]);
 
-  const handleChangeRole = async (userId, role) => {
+  const handleChangeRole = async (userId: string, role: string): Promise<void> => {
     try {
       setSavingRoleId(userId);
       setError('');
@@ -105,13 +153,14 @@ const AdminUsers = ({ embedded = false }) => {
       setSuccess('User role updated.');
       await fetchData();
     } catch (err) {
-      setError(err.response?.data?.error || 'Failed to update user role');
+      const e = err as { response?: { data?: { error?: string } } };
+      setError(e.response?.data?.error || 'Failed to update user role');
     } finally {
       setSavingRoleId('');
     }
   };
 
-  const handleDeleteUser = async (userToDelete) => {
+  const handleDeleteUser = async (userToDelete: User): Promise<void> => {
     const confirmed = window.confirm(`Delete user "${userToDelete.username}"? This cannot be undone.`);
     if (!confirmed) return;
 
@@ -123,13 +172,14 @@ const AdminUsers = ({ embedded = false }) => {
       setSuccess('User deleted.');
       await fetchData();
     } catch (err) {
-      setError(err.response?.data?.error || 'Failed to delete user');
+      const e = err as { response?: { data?: { error?: string } } };
+      setError(e.response?.data?.error || 'Failed to delete user');
     } finally {
       setDeletingUserId('');
     }
   };
 
-  const handleCreateInvitation = async (e) => {
+  const handleCreateInvitation = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
     try {
       setSavingInvite(true);
@@ -151,13 +201,14 @@ const AdminUsers = ({ embedded = false }) => {
       setInvitationsPage(1);
       await fetchData({ nextInvitationsPage: 1 });
     } catch (err) {
-      setError(err.response?.data?.error || 'Failed to create invitation code');
+      const e = err as { response?: { data?: { error?: string } } };
+      setError(e.response?.data?.error || 'Failed to create invitation code');
     } finally {
       setSavingInvite(false);
     }
   };
 
-  const handleRevokeInvitation = async (invitationId) => {
+  const handleRevokeInvitation = async (invitationId: string): Promise<void> => {
     try {
       setRevokingInviteId(invitationId);
       setError('');
@@ -166,13 +217,14 @@ const AdminUsers = ({ embedded = false }) => {
       setSuccess('Invitation code revoked.');
       await fetchData();
     } catch (err) {
-      setError(err.response?.data?.error || 'Failed to revoke invitation code');
+      const e = err as { response?: { data?: { error?: string } } };
+      setError(e.response?.data?.error || 'Failed to revoke invitation code');
     } finally {
       setRevokingInviteId('');
     }
   };
 
-  const handleSendWaitlistInvite = async (requestId) => {
+  const handleSendWaitlistInvite = async (requestId: string): Promise<void> => {
     try {
       setSendingWaitlistId(requestId);
       setError('');
@@ -183,13 +235,14 @@ const AdminUsers = ({ embedded = false }) => {
       setSuccess('Invitation code generated and emailed to waitlist requester.');
       await fetchData();
     } catch (err) {
-      setError(err.response?.data?.error || 'Failed to send invitation email');
+      const e = err as { response?: { data?: { error?: string } } };
+      setError(e.response?.data?.error || 'Failed to send invitation email');
     } finally {
       setSendingWaitlistId('');
     }
   };
 
-  const handleUpdateWaitlistStatus = async (requestId, status) => {
+  const handleUpdateWaitlistStatus = async (requestId: string, status: string): Promise<void> => {
     try {
       setUpdatingWaitlistId(requestId);
       setError('');
@@ -198,7 +251,8 @@ const AdminUsers = ({ embedded = false }) => {
       setSuccess('Waitlist request updated.');
       await fetchData();
     } catch (err) {
-      setError(err.response?.data?.error || 'Failed to update waitlist request');
+      const e = err as { response?: { data?: { error?: string } } };
+      setError(e.response?.data?.error || 'Failed to update waitlist request');
     } finally {
       setUpdatingWaitlistId('');
     }
@@ -244,7 +298,7 @@ const AdminUsers = ({ embedded = false }) => {
                   <MenuItem value="admin">Admins</MenuItem>
                   <MenuItem value="user">Users</MenuItem>
                 </TextField>
-                <Button variant="outlined" onClick={fetchData}>
+                <Button variant="outlined" onClick={() => fetchData()}>
                   Refresh
                 </Button>
               </Stack>
@@ -412,7 +466,7 @@ const AdminUsers = ({ embedded = false }) => {
                 <Pagination
                   page={waitlistPage}
                   count={waitlistTotalPages}
-                  onChange={(_event, page) => setWaitlistPage(page)}
+                  onChange={(_event: React.ChangeEvent<unknown>, page: number) => setWaitlistPage(page)}
                   size="small"
                 />
               </Box>
@@ -525,7 +579,7 @@ const AdminUsers = ({ embedded = false }) => {
                 <Pagination
                   page={invitationsPage}
                   count={invitationsTotalPages}
-                  onChange={(_event, page) => setInvitationsPage(page)}
+                  onChange={(_event: React.ChangeEvent<unknown>, page: number) => setInvitationsPage(page)}
                   size="small"
                 />
               </Box>

--- a/frontend/src/components/agents/AgentCard.tsx
+++ b/frontend/src/components/agents/AgentCard.tsx
@@ -33,7 +33,7 @@ import {
 import { normalizeUploadUrl } from '../../utils/apiBaseUrl';
 
 // Agent type colors
-const agentTypeColors = {
+const agentTypeColors: Record<string, string> = {
   personal: '#8b5cf6',
   utility: '#06b6d4',
   analytics: '#ec4899',
@@ -43,7 +43,7 @@ const agentTypeColors = {
 };
 
 // Agent type icons
-const agentTypeIcons = {
+const agentTypeIcons: Record<string, string> = {
   personal: '🤖',
   utility: '🔧',
   analytics: '📊',
@@ -52,9 +52,71 @@ const agentTypeIcons = {
   default: '🤖',
 };
 
-const AgentCard = ({
+interface AgentStats {
+  installs?: number;
+  podsJoined?: number;
+  messagesProcessed?: number;
+}
+
+interface AgentManifest {
+  capabilities?: Array<{ name: string }>;
+}
+
+interface AgentInstallation {
+  instanceId?: string;
+}
+
+interface AgentProfile {
+  instanceId?: string;
+  iconUrl?: string;
+  avatarUrl?: string;
+}
+
+export interface Agent {
+  id?: string;
+  _id?: string;
+  name?: string;
+  displayName?: string;
+  agentName?: string;
+  instanceId?: string;
+  installation?: AgentInstallation;
+  profile?: AgentProfile;
+  description?: string;
+  type?: string;
+  categories?: string[];
+  verified?: boolean;
+  installs?: number;
+  capabilities?: string[];
+  manifest?: AgentManifest;
+  stats?: AgentStats;
+  lastHeartbeatAt?: string | null;
+  iconUrl?: string;
+}
+
+interface AgentCardProps {
+  agent: Agent;
+  variant?: 'default' | 'compact' | 'featured';
+  installed?: boolean;
+  onInstall?: (agent: Agent) => void;
+  onConfigure?: (agent: Agent) => void;
+  onRemove?: (agent: Agent) => void;
+  onMessage?: (agent: Agent) => void;
+  onEdit?: (agent: Agent) => void;
+  onViewProfile?: (agent: Agent) => void;
+  canRemove?: boolean;
+  canConfigure?: boolean;
+  installedActionLabel?: string;
+  canEdit?: boolean;
+  loading?: boolean;
+}
+
+interface AgentCardSkeletonProps {
+  variant: string;
+}
+
+const AgentCard: React.FC<AgentCardProps> = ({
   agent,
-  variant = 'default', // 'default', 'compact', 'featured'
+  variant = 'default',
   installed = false,
   onInstall,
   onConfigure,
@@ -75,7 +137,6 @@ const AgentCard = ({
   }
 
   // Handle both mock data and real API data formats
-  const id = agent.id || agent._id || agent.name;
   const displayName = agent.displayName || agent.name || 'Unknown Agent';
   const agentName = agent.agentName || agent.name || '';
   const instanceId = agent.instanceId || agent.installation?.instanceId || agent.profile?.instanceId || '';
@@ -83,12 +144,12 @@ const AgentCard = ({
   const type = agent.type || (agent.categories && agent.categories[0]) || 'default';
   const verified = agent.verified || false;
   const installs = agent.installs || agent.stats?.installs || 0;
-  const capabilities = agent.capabilities || agent.manifest?.capabilities?.map(c => c.name) || [];
+  const capabilities = agent.capabilities || agent.manifest?.capabilities?.map((c) => c.name) || [];
   const stats = agent.stats || {};
   const lastHeartbeatAt = agent.lastHeartbeatAt || null;
   const iconUrl = agent.iconUrl || agent.profile?.iconUrl || agent.profile?.avatarUrl || null;
 
-  const formatHeartbeat = (ts) => {
+  const formatHeartbeat = (ts: string | null): string | null => {
     if (!ts) return null;
     const diff = Math.floor((Date.now() - new Date(ts).getTime()) / 1000);
     if (diff < 60) return `${diff}s ago`;
@@ -245,9 +306,9 @@ const AgentCard = ({
                   </Tooltip>
                 )}
               </Box>
-          <Typography variant="body2" color="text.secondary">
-            @{agentName}{instanceId ? ` • id:${instanceId}` : ''}
-          </Typography>
+              <Typography variant="body2" color="text.secondary">
+                @{agentName}{instanceId ? ` • id:${instanceId}` : ''}
+              </Typography>
             </Box>
           </Box>
 
@@ -525,7 +586,7 @@ const AgentCard = ({
 };
 
 // Loading skeleton
-const AgentCardSkeleton = ({ variant }) => {
+const AgentCardSkeleton: React.FC<AgentCardSkeletonProps> = ({ variant }) => {
   if (variant === 'compact') {
     return (
       <Card

--- a/frontend/src/components/apps/AppsMarketplacePage.tsx
+++ b/frontend/src/components/apps/AppsMarketplacePage.tsx
@@ -36,7 +36,12 @@ import axios from 'axios';
 import AppCard from './AppCard';
 import OfficialIntegrationCard from './OfficialIntegrationCard';
 
-const categories = [
+interface Category {
+  id: string;
+  label: string;
+}
+
+const categories: Category[] = [
   { id: 'all', label: 'All Categories' },
   { id: 'productivity', label: 'Productivity' },
   { id: 'development', label: 'Development' },
@@ -46,7 +51,7 @@ const categories = [
   { id: 'other', label: 'Other' },
 ];
 
-const types = [
+const types: Category[] = [
   { id: 'all', label: 'All Types' },
   { id: 'agent', label: 'Agent Apps' },
   { id: 'integration', label: 'Integrations' },
@@ -54,43 +59,85 @@ const types = [
   { id: 'webhook', label: 'Webhook Apps' },
 ];
 
+interface App {
+  id: string;
+  name?: string;
+  displayName?: string;
+  installationId?: string;
+  [key: string]: unknown;
+}
 
-const AppsMarketplacePage = () => {
+interface OfficialEntry {
+  id: string;
+  name?: string;
+  type?: string;
+  capabilities?: string[];
+  [key: string]: unknown;
+}
+
+interface IntegrationCatalogEntry {
+  id: string;
+  catalog?: { capabilities?: string[] };
+  stats?: { activeIntegrations?: number };
+}
+
+interface IntegrationsById {
+  [id: string]: IntegrationCatalogEntry;
+}
+
+interface OfficialListing extends OfficialEntry {
+  capabilities: string[];
+  activeCount?: number;
+}
+
+interface Pod {
+  _id: string;
+  name: string;
+}
+
+interface SnackbarState {
+  open: boolean;
+  message: string;
+  severity: 'info' | 'error' | 'success' | 'warning';
+}
+
+const AppsMarketplacePage: React.FC = () => {
   const theme = useTheme();
-  const [apps, setApps] = useState([]);
-  const [featured, setFeatured] = useState([]);
-  const [officialEntries, setOfficialEntries] = useState([]);
+  const [apps, setApps] = useState<App[]>([]);
+  const [featured, setFeatured] = useState<App[]>([]);
+  const [officialEntries, setOfficialEntries] = useState<OfficialEntry[]>([]);
   const [officialLoading, setOfficialLoading] = useState(false);
-  const [officialError, setOfficialError] = useState(null);
-  const [integrationEntries, setIntegrationEntries] = useState([]);
+  const [officialError, setOfficialError] = useState<string | null>(null);
+  const [integrationEntries, setIntegrationEntries] = useState<IntegrationCatalogEntry[]>([]);
   const [integrationsLoading, setIntegrationsLoading] = useState(false);
-  const [integrationsError, setIntegrationsError] = useState(null);
-  const [installedApps, setInstalledApps] = useState([]);
-  const [userPods, setUserPods] = useState([]);
+  const [integrationsError, setIntegrationsError] = useState<string | null>(null);
+  const [installedApps, setInstalledApps] = useState<App[]>([]);
+  const [userPods, setUserPods] = useState<Pod[]>([]);
   const [selectedPodId, setSelectedPodId] = useState('');
   const [activeTab, setActiveTab] = useState(0);
   const [searchQuery, setSearchQuery] = useState('');
   const [category, setCategory] = useState('all');
   const [typeFilter, setTypeFilter] = useState('all');
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'info' });
+  const [error, setError] = useState<string | null>(null);
+  const [snackbar, setSnackbar] = useState<SnackbarState>({ open: false, message: '', severity: 'info' });
   const contribUrl =
     process.env.REACT_APP_MARKETPLACE_CONTRIB_URL ||
     'https://example.com/commonly-marketplace#contributing';
 
-  const getAuthHeaders = () => {
+  const getAuthHeaders = (): Record<string, string> => {
     const token = localStorage.getItem('token');
-    return { 'x-auth-token': token };
+    return { 'x-auth-token': token || '' };
   };
 
   useEffect(() => {
-    const fetchUserPods = async () => {
+    const fetchUserPods = async (): Promise<void> => {
       try {
         const response = await axios.get('/api/pods', { headers: getAuthHeaders() });
-        setUserPods(response.data || []);
-        if (!selectedPodId && response.data?.length > 0) {
-          setSelectedPodId(response.data[0]._id);
+        const pods = (response.data as Pod[]) || [];
+        setUserPods(pods);
+        if (!selectedPodId && pods.length > 0) {
+          setSelectedPodId(pods[0]._id);
         }
       } catch (err) {
         console.error('Error fetching pods:', err);
@@ -114,7 +161,7 @@ const AppsMarketplacePage = () => {
     }
   }, [selectedPodId]);
 
-  const fetchMarketplace = async () => {
+  const fetchMarketplace = async (): Promise<void> => {
     setLoading(true);
     setError(null);
 
@@ -129,8 +176,8 @@ const AppsMarketplacePage = () => {
         axios.get('/api/apps/marketplace/featured'),
       ]);
 
-      setApps(appsRes.data.apps || []);
-      setFeatured(featuredRes.data.apps || []);
+      setApps((appsRes.data as { apps?: App[] }).apps || []);
+      setFeatured((featuredRes.data as { apps?: App[] }).apps || []);
     } catch (err) {
       console.error('Error loading marketplace apps:', err);
       setError('Failed to load apps marketplace');
@@ -140,12 +187,12 @@ const AppsMarketplacePage = () => {
     }
   };
 
-  const fetchOfficialMarketplace = async () => {
+  const fetchOfficialMarketplace = async (): Promise<void> => {
     setOfficialLoading(true);
     setOfficialError(null);
     try {
       const response = await axios.get('/api/marketplace/official');
-      setOfficialEntries(response.data?.entries || []);
+      setOfficialEntries((response.data as { entries?: OfficialEntry[] })?.entries || []);
     } catch (err) {
       console.error('Error loading official marketplace:', err);
       setOfficialError('Failed to load official marketplace.');
@@ -155,7 +202,7 @@ const AppsMarketplacePage = () => {
     }
   };
 
-  const fetchIntegrations = async () => {
+  const fetchIntegrations = async (): Promise<void> => {
     const token = localStorage.getItem('token');
     if (!token) {
       setIntegrationEntries([]);
@@ -169,7 +216,7 @@ const AppsMarketplacePage = () => {
       const response = await axios.get('/api/integrations/catalog', {
         headers: getAuthHeaders(),
       });
-      setIntegrationEntries(response.data?.entries || []);
+      setIntegrationEntries((response.data as { entries?: IntegrationCatalogEntry[] })?.entries || []);
     } catch (err) {
       console.error('Error loading integrations catalog:', err);
       setIntegrationsError('Failed to load integrations catalog.');
@@ -178,18 +225,18 @@ const AppsMarketplacePage = () => {
     }
   };
 
-  const fetchInstalled = async () => {
+  const fetchInstalled = async (): Promise<void> => {
     try {
       const response = await axios.get(`/api/apps/pods/${selectedPodId}/apps`, {
         headers: getAuthHeaders(),
       });
-      setInstalledApps(response.data.apps || []);
+      setInstalledApps((response.data as { apps?: App[] }).apps || []);
     } catch (err) {
       console.error('Error fetching installed apps:', err);
     }
   };
 
-  const handleInstall = async (app) => {
+  const handleInstall = async (app: App): Promise<void> => {
     if (!selectedPodId) {
       setSnackbar({ open: true, message: 'Select a pod to install', severity: 'warning' });
       return;
@@ -204,16 +251,17 @@ const AppsMarketplacePage = () => {
       setSnackbar({ open: true, message: `Installed ${app.displayName || app.name}`, severity: 'success' });
       fetchInstalled();
     } catch (err) {
+      const e = err as { response?: { data?: { error?: string } } };
       console.error('Error installing app:', err);
       setSnackbar({
         open: true,
-        message: err.response?.data?.error || 'Failed to install app',
+        message: e.response?.data?.error || 'Failed to install app',
         severity: 'error',
       });
     }
   };
 
-  const handleRemove = async (app) => {
+  const handleRemove = async (app: App): Promise<void> => {
     if (!selectedPodId) return;
 
     try {
@@ -228,24 +276,24 @@ const AppsMarketplacePage = () => {
     }
   };
 
-  const isInstalled = (appId) => installedApps.some((a) => a.id === appId);
-  const integrationsById = integrationEntries.reduce((acc, entry) => {
+  const isInstalled = (appId: string): boolean => installedApps.some((a) => a.id === appId);
+  const integrationsById: IntegrationsById = integrationEntries.reduce((acc, entry) => {
     acc[entry.id] = entry;
     return acc;
-  }, {});
+  }, {} as IntegrationsById);
 
-  const officialListings = officialEntries.map((entry) => {
-    const integrationInfo = integrationsById[entry.id] || {};
+  const officialListings: OfficialListing[] = officialEntries.map((entry) => {
+    const integrationInfo = integrationsById[entry.id];
     return {
       ...entry,
-      capabilities: integrationInfo.catalog?.capabilities || entry.capabilities || [],
-      activeCount: integrationInfo.stats?.activeIntegrations,
+      capabilities: integrationInfo?.catalog?.capabilities || (entry.capabilities as string[]) || [],
+      activeCount: integrationInfo?.stats?.activeIntegrations,
     };
   });
   const officialIntegrations = officialListings.filter((entry) => entry.type !== 'mcp-app');
   const mcpListings = officialListings.filter((entry) => entry.type === 'mcp-app');
 
-  const handleConnect = (entry) => {
+  const handleConnect = (entry: OfficialEntry): void => {
     setSnackbar({
       open: true,
       message: `Open a pod to connect ${entry.name}.`,
@@ -293,7 +341,7 @@ const AppsMarketplacePage = () => {
             <Select
               value={selectedPodId || ''}
               label="Install to Pod"
-              onChange={(e) => setSelectedPodId(e.target.value)}
+              onChange={(e) => setSelectedPodId(e.target.value as string)}
             >
               {userPods.map((pod) => (
                 <MenuItem key={pod._id} value={pod._id}>
@@ -332,7 +380,7 @@ const AppsMarketplacePage = () => {
           <Select
             value={typeFilter}
             label="Type"
-            onChange={(e) => setTypeFilter(e.target.value)}
+            onChange={(e) => setTypeFilter(e.target.value as string)}
           >
             {types.map((t) => (
               <MenuItem key={t.id} value={t.id}>
@@ -365,7 +413,7 @@ const AppsMarketplacePage = () => {
       </Box>
 
       <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>
-        <Tabs value={activeTab} onChange={(e, v) => setActiveTab(v)}>
+        <Tabs value={activeTab} onChange={(_e: React.SyntheticEvent, v: number) => setActiveTab(v)}>
           <Tab label="Discover" icon={<AppsIcon />} iconPosition="start" />
           <Tab label={`Installed ${installedApps.length ? `(${installedApps.length})` : ''}`} />
         </Tabs>
@@ -499,6 +547,8 @@ const AppsMarketplacePage = () => {
             {loading
               ? [1, 2, 3, 4, 5, 6].map((i) => (
                   <Grid item xs={12} sm={6} md={4} lg={3} key={i}>
+                    {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+                    {/* @ts-ignore — AppCard is a JS component; loading skeleton omits app prop intentionally */}
                     <AppCard loading />
                   </Grid>
                 ))


### PR DESCRIPTION
## Summary
- `DiscordIntegration.js → .tsx`: `Integration`, `PodInfo`, `DiscordIntegrationProps` interfaces; typed all async handlers
- `AgentCard.js → .tsx`: `Agent`, `AgentStats`, `AgentCardProps`, `AgentCardSkeletonProps` interfaces; `agentTypeColors`/`agentTypeIcons` as `Record<string,string>`; exports `Agent` for downstream consumers
- `AdminUsers.js → .tsx`: `User`, `Invitation`, `WaitlistRequest`, `InviteForm`, `FetchDataOptions`, `AdminUsersProps` interfaces; all CRUD handlers typed
- `AppsMarketplacePage.js → .tsx`: `App`, `OfficialEntry`, `IntegrationCatalogEntry`, `OfficialListing`, `Pod`, `SnackbarState`, `Category` interfaces; `getAuthHeaders()` returns `Record<string,string>`

## Test plan
- [ ] `Test & Coverage` CI check passes
- [ ] `typecheck` (`tsc --noEmit`) passes locally (verified before push)

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)