### PR TITLE
feat(frontend/ts): batch 37 — UserProfile, Thread to TypeScript

### DIFF
--- a/frontend/src/components/Thread.tsx
+++ b/frontend/src/components/Thread.tsx
@@ -25,20 +25,67 @@ import { refreshPage } from '../utils/refreshUtils';
 import './Thread.css';
 import '../components/PostFeed.css';
 
-const normalizeAgentSegment = (value) => (
+interface PostUser {
+    _id: string;
+    username: string;
+    profilePicture?: string;
+    isBot?: boolean;
+    botMetadata?: { displayName?: string };
+}
+
+interface Comment {
+    _id: string;
+    text: string;
+    createdAt: string;
+    replyTo?: string;
+    userId?: PostUser;
+}
+
+interface Post {
+    _id: string;
+    content: string;
+    createdAt: string;
+    likes?: number;
+    likedBy?: Array<string | { _id: string }>;
+    comments: Comment[];
+    image?: string;
+    podId?: string | { _id?: string };
+    userId: PostUser;
+    agentCommentsDisabled?: boolean;
+}
+
+interface PodAgent {
+    name: string;
+    instanceId?: string;
+    profile?: { displayName?: string; iconUrl?: string; avatarUrl?: string };
+    displayName?: string;
+    iconUrl?: string;
+}
+
+interface MentionableItem {
+    id: string;
+    label: string;
+    labelLower: string;
+    subtitle: string;
+    avatar: string;
+    isAgent: boolean;
+    value: string;
+}
+
+const normalizeAgentSegment = (value: string): string => (
     (value || '').toLowerCase().replace(/[^a-z0-9-]/g, '').slice(0, 40)
 );
 
-const buildAgentUsername = (agentName, instanceId) => {
+const buildAgentUsername = (agentName: string, instanceId?: string): string => {
     const normalized = normalizeAgentSegment(agentName);
-    const instance = normalizeAgentSegment(instanceId);
+    const instance = normalizeAgentSegment(instanceId || '');
     if (!instance || instance === 'default' || instance === normalized) {
         return normalized || 'agent';
     }
     return `${normalized}-${instance}`;
 };
 
-const slugify = (value = '') => value
+const slugify = (value = ''): string => value
     .toString()
     .trim()
     .toLowerCase()
@@ -46,43 +93,44 @@ const slugify = (value = '') => value
     .replace(/-+/g, '-')
     .replace(/^-+|-+$/g, '');
 
-const getUserDisplayName = (user) => {
+const getUserDisplayName = (user?: PostUser | null): string => {
     if (!user) return 'Unknown';
     if (user.isBot && user.botMetadata?.displayName) return user.botMetadata.displayName;
     return user.username || 'Unknown';
 };
 
 const Thread = () => {
-    const { id } = useParams();
+    const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
     const { currentUser, refreshData, removePost } = useAppContext();
-    const [post, setPost] = useState(null);
+    const [post, setPost] = useState<Post | null>(null);
     const [error, setError] = useState('');
     const [comment, setComment] = useState('');
     const [showEmojiPicker, setShowEmojiPicker] = useState(false);
     const [liked, setLiked] = useState(false);
     const [threadFollowed, setThreadFollowed] = useState(false);
     const [threadFollowLoading, setThreadFollowLoading] = useState(false);
-    const [menuAnchorEl, setMenuAnchorEl] = useState(null);
-    const [selectedItemId, setSelectedItemId] = useState(null);
-    const [itemType, setItemType] = useState(null); // 'post' or 'comment'
+    const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
+    const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
+    const [itemType, setItemType] = useState<'post' | 'comment' | null>(null);
     const [loading, setLoading] = useState(true);
-    const [podAgents, setPodAgents] = useState([]);
-    const [threadPodId, setThreadPodId] = useState(null);
+    const [podAgents, setPodAgents] = useState<PodAgent[]>([]);
+    const [threadPodId, setThreadPodId] = useState<string | null>(null);
     const [mentionOpen, setMentionOpen] = useState(false);
     const [mentionQuery, setMentionQuery] = useState('');
     const [mentionStart, setMentionStart] = useState(-1);
     const [mentionIndex, setMentionIndex] = useState(0);
-    const [lightboxImage, setLightboxImage] = useState(null);
+    const [lightboxImage, setLightboxImage] = useState<string | null>(null);
     const [lightboxAlt, setLightboxAlt] = useState('');
     const [lightboxZoomed, setLightboxZoomed] = useState(false);
-    const [replyingTo, setReplyingTo] = useState(null);
+    const [replyingTo, setReplyingTo] = useState<Comment | null>(null);
     const [agentCommentsDisabled, setAgentCommentsDisabled] = useState(false);
-    const emojiButtonRef = useRef(null);
-    const commentInputRef = useRef(null);
-    const mentionDropdownRef = useRef(null);
+    const emojiButtonRef = useRef<HTMLButtonElement>(null);
+    const commentInputRef = useRef<HTMLTextAreaElement>(null);
+    const mentionDropdownRef = useRef<HTMLDivElement>(null);
+    const scrollHighlightTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    const getAgentIconSrc = (username) => {
+    const getAgentIconSrc = (username: string): string | null => {
         if (!username) return null;
         const agent = (podAgents || []).find(
             (a) => buildAgentUsername(a.name, a.instanceId) === username,
@@ -90,8 +138,8 @@ const Thread = () => {
         return agent?.profile?.iconUrl || agent?.iconUrl || null;
     };
 
-    const mentionableItems = useMemo(() => {
-        const items = [];
+    const mentionableItems = useMemo<MentionableItem[]>(() => {
+        const items: MentionableItem[] = [];
         (podAgents || []).forEach((agent) => {
             const agentName = agent?.name;
             if (!agentName) return;
@@ -116,24 +164,23 @@ const Thread = () => {
         return items;
     }, [podAgents]);
 
-    const commentMap = useMemo(() => {
+    const commentMap = useMemo<Record<string, Comment>>(() => {
         if (!post?.comments) return {};
-        return post.comments.reduce((acc, c) => {
+        return post.comments.reduce((acc: Record<string, Comment>, c) => {
             acc[c._id] = c;
             return acc;
         }, {});
     }, [post?.comments]);
 
-    const filteredMentions = useMemo(() => {
+    const filteredMentions = useMemo<MentionableItem[]>(() => {
         if (!mentionOpen) return [];
         const query = mentionQuery.trim().toLowerCase();
         const result = mentionableItems.filter((item) => item.labelLower.includes(query));
         return result.slice(0, 8);
     }, [mentionOpen, mentionQuery, mentionableItems]);
 
-    const scrollHighlightTimer = useRef(null);
-    const scrollToComment = (commentId) => {
-        clearTimeout(scrollHighlightTimer.current);
+    const scrollToComment = (commentId: string) => {
+        clearTimeout(scrollHighlightTimer.current!);
         scrollHighlightTimer.current = scrollToElementById(`comment-${commentId}`, 'comment-highlight');
     };
 
@@ -148,8 +195,8 @@ const Thread = () => {
                 // Check if current user has liked this post
                 if (currentUser && res.data.likedBy) {
                     // Check if likedBy contains the current user's ID
-                    const isLiked = res.data.likedBy.some(user => 
-                        user._id === currentUser._id || user === currentUser._id
+                    const isLiked = res.data.likedBy.some((u: string | { _id: string }) =>
+                        (typeof u === 'object' ? u._id : u) === currentUser._id
                     );
                     setLiked(isLiked);
                 } else {
@@ -172,7 +219,7 @@ const Thread = () => {
                     headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
                 });
                 const threads = response.data?.threads || [];
-                setThreadFollowed(threads.some((thread) => thread._id === id));
+                setThreadFollowed(threads.some((thread: { _id: string }) => thread._id === id));
             } catch (err) {
                 // Keep default state if endpoint fails
             }
@@ -191,7 +238,7 @@ const Thread = () => {
 
             try {
                 const postPodId = typeof post?.podId === 'object' ? post.podId?._id : post?.podId;
-                let resolvedPodId = postPodId || null;
+                let resolvedPodId: string | null = postPodId || null;
                 if (!resolvedPodId) {
                     const podsRes = await axios.get('/api/pods', authHeaders);
                     const pods = Array.isArray(podsRes.data) ? podsRes.data : podsRes.data?.pods || [];
@@ -208,14 +255,14 @@ const Thread = () => {
                 const agentsRes = await axios.get(`/api/registry/pods/${resolvedPodId}/agents`, authHeaders);
                 setPodAgents(agentsRes.data?.agents || []);
             } catch (err) {
-                console.warn('Failed to fetch thread agents:', err.response?.status);
+                console.warn('Failed to fetch thread agents:', (err as { response?: { status: number } })?.response?.status);
             }
         };
 
         fetchThreadAgents();
     }, [post, currentUser]);
 
-    const openLightbox = (src, alt = '') => {
+    const openLightbox = (src: string, alt = '') => {
         setLightboxImage(src);
         setLightboxAlt(alt);
         setLightboxZoomed(false);
@@ -227,10 +274,10 @@ const Thread = () => {
         setLightboxZoomed(false);
     };
 
-    const handleCommentSubmit = async (e) => {
+    const handleCommentSubmit = async (e: { preventDefault: () => void }) => {
         e.preventDefault();
         if (!comment.trim()) return;
-    
+
         try {
             const payload = {
                 text: comment,
@@ -241,17 +288,17 @@ const Thread = () => {
                 payload,
                 { headers: { Authorization: `Bearer ${localStorage.getItem('token')}` } }
             );
-            setPost(prevPost => ({
+            setPost((prevPost) => prevPost ? ({
                 ...prevPost,
                 comments: [...prevPost.comments, res.data]
-            }));
+            }) : prevPost);
             setComment('');
             setShowEmojiPicker(false);
             setMentionOpen(false);
             setMentionQuery('');
             setMentionStart(-1);
             setReplyingTo(null);
-            
+
             // Refresh data to ensure consistency
             refreshData();
         } catch (err) {
@@ -262,22 +309,22 @@ const Thread = () => {
     const handleLike = async () => {
         // Store current liked state
         const wasLiked = liked;
-        
+
         try {
             // Update UI immediately for better user experience
             setLiked(!wasLiked);
-            
+
             // Send request to server
             const response = await axios.post(`/api/posts/${id}/like`, {}, {
                 headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
             });
-            
+
             // Update post likes count
-            setPost(prevPost => ({
+            setPost((prevPost) => prevPost ? ({
                 ...prevPost,
                 likes: response.data.likes
-            }));
-            
+            }) : prevPost);
+
             // If server response doesn't match our optimistic update, correct it
             if (response.data.liked !== !wasLiked) {
                 setLiked(response.data.liked);
@@ -311,7 +358,7 @@ const Thread = () => {
         }
     };
 
-    const handleMenuOpen = (event, itemId, type) => {
+    const handleMenuOpen = (event: React.MouseEvent<HTMLElement>, itemId: string, type: 'post' | 'comment') => {
         event.stopPropagation();
         setMenuAnchorEl(event.currentTarget);
         setSelectedItemId(itemId);
@@ -327,7 +374,7 @@ const Thread = () => {
 
     const handleToggleAgentComments = async () => {
         try {
-            const res = await axios.patch(`/api/posts/${post._id}/agent-comments`, {}, {
+            const res = await axios.patch(`/api/posts/${post!._id}/agent-comments`, {}, {
                 headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
             });
             setAgentCommentsDisabled(res.data.agentCommentsDisabled);
@@ -338,37 +385,37 @@ const Thread = () => {
 
     const handleDelete = async () => {
         if (!selectedItemId) return;
-        
+
         try {
             // Close the menu first
             handleMenuClose();
-            
+
             if (itemType === 'post') {
                 // Use the removePost function from context
                 removePost(selectedItemId);
-                
+
                 // Navigate back to feed immediately
                 navigate('/feed');
-                
+
                 // Send the delete request to the server
                 await axios.delete(`/api/posts/${selectedItemId}`, {
                     headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
                 });
-                
+
                 // Trigger a page refresh after a short delay
                 refreshPage(500);
             } else if (itemType === 'comment') {
                 // Remove the deleted comment from the state immediately
-                setPost(prevPost => ({
+                setPost((prevPost) => prevPost ? ({
                     ...prevPost,
-                    comments: prevPost.comments.filter(comment => comment._id !== selectedItemId)
-                }));
-                
+                    comments: prevPost.comments.filter((c) => c._id !== selectedItemId)
+                }) : prevPost);
+
                 // Send the delete request to the server
                 await axios.delete(`/api/posts/${id}/comments/${selectedItemId}`, {
                     headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
                 });
-                
+
                 // No refresh needed for comment deletion as we've already updated the state
             }
         } catch (err) {
@@ -378,15 +425,15 @@ const Thread = () => {
         }
     };
 
-    const onEmojiClick = (emojiObj) => {
+    const onEmojiClick = (emojiObj: { emoji?: string; unified?: string }) => {
         // Support both older and newer emoji-picker-react versions
         const emoji = emojiObj.emoji || (emojiObj.unified && String.fromCodePoint(parseInt(emojiObj.unified, 16)));
         if (emoji) {
-            setComment(prevComment => prevComment + emoji);
+            setComment((prevComment) => prevComment + emoji);
         }
     };
 
-    const getMentionContext = (text, cursor) => {
+    const getMentionContext = (text: string, cursor: number | null | undefined): { start: number; query: string } | null => {
         if (!text || cursor === null || cursor === undefined) return null;
         const atIndex = text.lastIndexOf('@', cursor - 1);
         if (atIndex < 0) return null;
@@ -397,7 +444,7 @@ const Thread = () => {
         return { start: atIndex, query: between };
     };
 
-    const updateMentionState = (nextValue, cursorPosition) => {
+    const updateMentionState = (nextValue: string, cursorPosition: number | null) => {
         const context = getMentionContext(nextValue, cursorPosition);
         if (!context) {
             setMentionOpen(false);
@@ -411,7 +458,7 @@ const Thread = () => {
         setMentionIndex(0);
     };
 
-    const handleMentionSelect = (item) => {
+    const handleMentionSelect = (item: MentionableItem) => {
         const input = commentInputRef.current;
         if (!input) return;
         const cursor = input.selectionStart ?? comment.length;
@@ -430,7 +477,7 @@ const Thread = () => {
         });
     };
 
-    const handleCommentKeyDown = (event) => {
+    const handleCommentKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
         if (mentionOpen && filteredMentions.length > 0) {
             if (event.key === 'ArrowDown') {
                 event.preventDefault();
@@ -469,11 +516,11 @@ const Thread = () => {
 
     // Handle clicking outside emoji picker
     useEffect(() => {
-        const handleClickOutside = (event) => {
-            if (showEmojiPicker && 
-                emojiButtonRef.current && 
-                !emojiButtonRef.current.contains(event.target) &&
-                !event.target.closest('.emoji-picker-portal')) {
+        const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+            if (showEmojiPicker &&
+                emojiButtonRef.current &&
+                !emojiButtonRef.current.contains(event.target as Node) &&
+                !(event.target as Element).closest('.emoji-picker-portal')) {
                 setShowEmojiPicker(false);
             }
         };
@@ -490,10 +537,10 @@ const Thread = () => {
     }, [showEmojiPicker]);
 
     useEffect(() => {
-        const handleMentionClickOutside = (event) => {
+        const handleMentionClickOutside = (event: MouseEvent) => {
             if (!mentionOpen) return;
-            if (mentionDropdownRef.current && mentionDropdownRef.current.contains(event.target)) return;
-            if (commentInputRef.current && commentInputRef.current.contains(event.target)) return;
+            if (mentionDropdownRef.current && mentionDropdownRef.current.contains(event.target as Node)) return;
+            if (commentInputRef.current && commentInputRef.current.contains(event.target as Node)) return;
             setMentionOpen(false);
         };
 
@@ -542,11 +589,11 @@ const Thread = () => {
                         <div className="post-meta">
                             {post.userId.isBot ? (
                                 <AgentAvatar
-                                    className="post-avatar"
                                     username={post.userId.username}
                                     src={getAgentIconSrc(post.userId.username)}
                                     size={40}
                                     showBadge={false}
+                                    sx={{ mr: 1 }}
                                 />
                             ) : (
                                 <Avatar
@@ -565,8 +612,8 @@ const Thread = () => {
                             </div>
                         </div>
                         {currentUser && (currentUser._id === post.userId._id) && (
-                            <IconButton 
-                                size="small" 
+                            <IconButton
+                                size="small"
                                 onClick={(e) => handleMenuOpen(e, post._id, 'post')}
                                 aria-label="post options"
                                 id="post-options-button"
@@ -595,18 +642,18 @@ const Thread = () => {
                                 return part;
                             })}
                         </Typography>
-                    
+
                         {post.image && (
-                            <Box 
-                                sx={{ 
-                                    mt: 1, 
-                                    mb: 3, 
+                            <Box
+                                sx={{
+                                    mt: 1,
+                                    mb: 3,
                                     borderRadius: '8px',
                                     overflow: 'hidden',
                                     maxHeight: '500px',
                                 }}
                                 className="post-image-container"
-                                onClick={() => openLightbox(normalizeUploadUrl(post.image), post.content)}
+                                onClick={() => openLightbox(normalizeUploadUrl(post.image!), post.content)}
                             >
                                 <Box
                                     component="img"
@@ -623,7 +670,7 @@ const Thread = () => {
                                 />
                             </Box>
                         )}
-                    
+
                         <Box sx={{ display: 'flex', alignItems: 'center', mt: 2 }}>
                             <IconButton onClick={handleLike} color="primary">
                                 {liked ? <FavoriteIcon /> : <FavoriteBorderIcon />}
@@ -721,8 +768,8 @@ const Thread = () => {
                                 updateMentionState(nextValue, e.target.selectionStart);
                             }}
                             onKeyDown={handleCommentKeyDown}
-                            onClick={(e) => updateMentionState(e.target.value, e.target.selectionStart)}
-                            onKeyUp={(e) => updateMentionState(e.target.value, e.target.selectionStart)}
+                            onClick={(e) => updateMentionState((e.target as HTMLTextAreaElement).value, (e.target as HTMLTextAreaElement).selectionStart)}
+                            onKeyUp={(e) => updateMentionState((e.target as HTMLTextAreaElement).value, (e.target as HTMLTextAreaElement).selectionStart)}
                             placeholder={replyingTo ? `Reply to @${getUserDisplayName(replyingTo.userId)}...` : 'Write a comment...'}
                             ref={commentInputRef}
                         />
@@ -742,10 +789,10 @@ const Thread = () => {
 
             {/* Emoji Picker Portal - Positioned outside the comment form container */}
             {showEmojiPicker && (
-                <Box 
+                <Box
                     className="emoji-picker-portal"
-                    sx={{ 
-                        position: 'fixed', 
+                    sx={{
+                        position: 'fixed',
                         zIndex: 1300,
                         top: (() => {
                             if (emojiButtonRef.current) {
@@ -771,7 +818,7 @@ const Thread = () => {
                     }}
                     onClick={(e) => e.stopPropagation()}
                 >
-                    <Box 
+                    <Box
                         className="emoji-picker-container"
                         sx={{
                             backgroundColor: 'rgba(15, 23, 42, 0.98)',
@@ -781,15 +828,16 @@ const Thread = () => {
                             overflow: 'hidden'
                         }}
                     >
-                        <EmojiPicker 
+                        <EmojiPicker
                             onEmojiClick={onEmojiClick}
                             width={320}
                             height={380}
-                            emojiStyle="native"
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            emojiStyle={"native" as any}
                             searchDisabled={false}
                             skinTonesDisabled={true}
                             previewConfig={{ showPreview: false }}
-                            style={{ transform: 'none', scale: 1 }}
+                            style={{ transform: 'none', scale: '1' }}
                         />
                     </Box>
                 </Box>
@@ -799,10 +847,10 @@ const Thread = () => {
                 Comments ({post.comments.length})
             </Typography>
 
-            {post.comments.map((comment) => {
-                const quotedComment = comment.replyTo ? commentMap[comment.replyTo] : null;
+            {post.comments.map((threadComment) => {
+                const quotedComment = threadComment.replyTo ? commentMap[threadComment.replyTo] : null;
                 return (
-                <Paper key={comment._id} id={`comment-${comment._id}`} className="comment-item">
+                <Paper key={threadComment._id} id={`comment-${threadComment._id}`} className="comment-item">
                     {quotedComment && (
                         <div
                             className="comment-quote-bubble"
@@ -821,11 +869,10 @@ const Thread = () => {
                         </div>
                     )}
                     <div className="comment-row">
-                        {comment.userId?.isBot ? (
+                        {threadComment.userId?.isBot ? (
                             <AgentAvatar
-                                className="comment-avatar"
-                                username={comment.userId.username}
-                                src={getAgentIconSrc(comment.userId.username)}
+                                username={threadComment.userId.username}
+                                src={getAgentIconSrc(threadComment.userId.username)}
                                 size={32}
                                 showBadge={false}
                             />
@@ -833,21 +880,21 @@ const Thread = () => {
                             <Avatar
                                 className="comment-avatar"
                                 sx={{
-                                    bgcolor: getAvatarColor(comment.userId && comment.userId.profilePicture)
+                                    bgcolor: getAvatarColor(threadComment.userId && threadComment.userId.profilePicture)
                                 }}
-                                src={getAvatarSrc(comment.userId && comment.userId.profilePicture)}
+                                src={getAvatarSrc(threadComment.userId && threadComment.userId.profilePicture)}
                             >
-                                {comment.userId && comment.userId.username ? comment.userId.username.charAt(0).toUpperCase() : '?'}
+                                {threadComment.userId && threadComment.userId.username ? threadComment.userId.username.charAt(0).toUpperCase() : '?'}
                             </Avatar>
                         )}
                         <div className="comment-content">
                             <div className="comment-header">
                                 <div className="comment-meta">
                                     <Typography variant="subtitle2">
-                                        {getUserDisplayName(comment.userId)}
+                                        {getUserDisplayName(threadComment.userId)}
                                     </Typography>
                                     <Typography variant="caption" color="text.secondary">
-                                        {formatDistanceToNow(new Date(comment.createdAt))} ago
+                                        {formatDistanceToNow(new Date(threadComment.createdAt))} ago
                                     </Typography>
                                 </div>
                                 <div style={{ display: 'flex', alignItems: 'center' }}>
@@ -855,16 +902,16 @@ const Thread = () => {
                                         <IconButton
                                             size="small"
                                             className="comment-reply-button"
-                                            onClick={() => { setReplyingTo(comment); commentInputRef.current?.focus(); }}
+                                            onClick={() => { setReplyingTo(threadComment); commentInputRef.current?.focus(); }}
                                             aria-label="reply to comment"
                                         >
                                             <ReplyIcon fontSize="inherit" />
                                         </IconButton>
                                     </Tooltip>
-                                    {currentUser && comment.userId && (currentUser._id === comment.userId._id) && (
+                                    {currentUser && threadComment.userId && (currentUser._id === threadComment.userId._id) && (
                                         <IconButton
                                             size="small"
-                                            onClick={(e) => handleMenuOpen(e, comment._id, 'comment')}
+                                            onClick={(e) => handleMenuOpen(e, threadComment._id, 'comment')}
                                             aria-label="comment options"
                                             id="post-options-button"
                                         >
@@ -876,9 +923,9 @@ const Thread = () => {
                             <Box className="comment-body">
                                 <MarkdownContent
                                     variant="comment"
-                                    onHashtagClick={(tag) => navigate(`/feed?q=${tag}`)}
+                                    onHashtagClick={(tag: string) => navigate(`/feed?q=${tag}`)}
                                 >
-                                    {comment.text}
+                                    {threadComment.text}
                                 </MarkdownContent>
                             </Box>
                         </div>
@@ -896,11 +943,6 @@ const Thread = () => {
                 MenuListProps={{
                     'aria-labelledby': 'post-options-button',
                     autoFocusItem: false,
-                }}
-                slotProps={{
-                    backdrop: {
-                        onClick: handleMenuClose
-                    }
                 }}
             >
                 <MenuItem

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -42,30 +42,72 @@ import AppsManagement from './AppsManagement';
 import AvatarGenerator from './agents/AvatarGenerator';
 import AdminUsers from './admin/AdminUsers';
 
+interface ProfileUser {
+    _id: string;
+    username: string;
+    email: string;
+    role?: string;
+    profilePicture?: string;
+    createdAt: string;
+    isFollowing?: boolean;
+    followersCount?: number;
+    followingCount?: number;
+}
+
+interface UserStats {
+    postCount: number;
+    commentCount: number;
+}
+
+interface PublicPost {
+    id: string;
+    content?: string;
+    category?: string;
+    createdAt: string;
+}
+
+interface JoinedPod {
+    id: string;
+    name: string;
+    type?: string;
+    membersCount?: number;
+}
+
+interface PublicActivity {
+    recentPublicPosts: PublicPost[];
+    joinedPods: JoinedPod[];
+}
+
+interface SnackbarState {
+    open: boolean;
+    message: string;
+    severity: 'info' | 'error' | 'success' | 'warning';
+}
+
 const UserProfile = () => {
     const { refreshAvatars } = useAppContext();
     const { currentUser } = useAuth();
     const navigate = useNavigate();
     const location = useLocation();
-    const { id: profileId } = useParams();
-    const [user, setUser] = useState(null);
-    const [userStats, setUserStats] = useState({ postCount: 0, commentCount: 0 });
+    const { id: profileId } = useParams<{ id?: string }>();
+    const [user, setUser] = useState<ProfileUser | null>(null);
+    const [userStats, setUserStats] = useState<UserStats>({ postCount: 0, commentCount: 0 });
     const [error, setError] = useState('');
     const [openAvatarDialog, setOpenAvatarDialog] = useState(false);
     const [selectedAvatar, setSelectedAvatar] = useState('default');
-    const [avatarFile, setAvatarFile] = useState(null);
+    const [avatarFile, setAvatarFile] = useState<File | null>(null);
     const [avatarPreview, setAvatarPreview] = useState('');
     const [isUpdating, setIsUpdating] = useState(false);
     const [avatarGeneratorOpen, setAvatarGeneratorOpen] = useState(false);
     const [currentTab, setCurrentTab] = useState('overview');
-    const [apiToken, setApiToken] = useState(null);
-    const [apiTokenCreatedAt, setApiTokenCreatedAt] = useState(null);
+    const [apiToken, setApiToken] = useState<string | null>(null);
+    const [apiTokenCreatedAt, setApiTokenCreatedAt] = useState<string | null>(null);
     const [isGeneratingToken, setIsGeneratingToken] = useState(false);
     const [isRevokingToken, setIsRevokingToken] = useState(false);
     const [isFollowLoading, setIsFollowLoading] = useState(false);
     const [showToken, setShowToken] = useState(false);
-    const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'info' });
-    const [publicActivity, setPublicActivity] = useState({ recentPublicPosts: [], joinedPods: [] });
+    const [snackbar, setSnackbar] = useState<SnackbarState>({ open: false, message: '', severity: 'info' });
+    const [publicActivity, setPublicActivity] = useState<PublicActivity>({ recentPublicPosts: [], joinedPods: [] });
     const [publicActivityLoading, setPublicActivityLoading] = useState(false);
 
     useEffect(() => {
@@ -114,11 +156,11 @@ const UserProfile = () => {
 
                 // Calculate post count and comment count
                 const allPosts = postsRes.data.posts || postsRes.data;
-                const userPosts = allPosts.filter(post => post.userId && post.userId._id === userRes.data._id);
-                const userComments = allPosts.reduce((count, post) => {
-                    return count + (post.comments || []).filter(comment => 
-                        comment.userId && 
-                        comment.userId._id && 
+                const userPosts = allPosts.filter((post: { userId?: { _id?: string } }) => post.userId && post.userId._id === userRes.data._id);
+                const userComments = allPosts.reduce((count: number, post: { comments?: Array<{ userId?: { _id?: string } }> }) => {
+                    return count + (post.comments || []).filter((comment) =>
+                        comment.userId &&
+                        comment.userId._id &&
                         comment.userId._id === userRes.data._id
                     ).length;
                 }, 0);
@@ -153,13 +195,13 @@ const UserProfile = () => {
         blurActiveElement();
     };
 
-    const handleAvatarSelect = (avatarId) => {
+    const handleAvatarSelect = (avatarId: string) => {
         setSelectedAvatar(avatarId);
         setAvatarFile(null);
         setAvatarPreview('');
     };
 
-    const handleGeneratedAvatarSelect = (avatarDataUri) => {
+    const handleGeneratedAvatarSelect = (avatarDataUri: string) => {
         if (!avatarDataUri) return;
         setSelectedAvatar(avatarDataUri);
         setAvatarFile(null);
@@ -167,7 +209,7 @@ const UserProfile = () => {
         setAvatarGeneratorOpen(false);
     };
 
-    const handleAvatarFileChange = (event) => {
+    const handleAvatarFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         const file = event.target.files?.[0];
         if (!file) return;
         setAvatarFile(file);
@@ -183,7 +225,7 @@ const UserProfile = () => {
                 const formData = new FormData();
                 formData.append('image', avatarFile);
                 const uploadRes = await axios.post('/api/uploads', formData, {
-                    headers: { 
+                    headers: {
                         Authorization: `Bearer ${localStorage.getItem('token')}`,
                         'Content-Type': 'multipart/form-data'
                     }
@@ -197,7 +239,7 @@ const UserProfile = () => {
             );
             setUser(response.data);
             handleCloseAvatarDialog();
-            
+
             // Use the refreshAvatars function instead to ensure consistent avatar display
             refreshAvatars();
         } catch (err) {
@@ -215,20 +257,20 @@ const UserProfile = () => {
                 const response = await axios.delete(`/api/users/${user._id}/follow`, {
                     headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
                 });
-                setUser((prev) => ({
+                setUser((prev) => prev ? ({
                     ...prev,
                     isFollowing: false,
                     followersCount: response.data?.target?.followersCount ?? Math.max((prev.followersCount || 1) - 1, 0),
-                }));
+                }) : prev);
             } else {
                 const response = await axios.post(`/api/users/${user._id}/follow`, {}, {
                     headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
                 });
-                setUser((prev) => ({
+                setUser((prev) => prev ? ({
                     ...prev,
                     isFollowing: true,
                     followersCount: response.data?.target?.followersCount ?? ((prev.followersCount || 0) + 1),
-                }));
+                }) : prev);
             }
         } catch (err) {
             setSnackbar({
@@ -247,7 +289,7 @@ const UserProfile = () => {
             const response = await axios.post('/api/auth/api-token/generate', {}, {
                 headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
             });
-            
+
             setApiToken(response.data.apiToken);
             setApiTokenCreatedAt(response.data.createdAt);
             setShowToken(true);
@@ -273,7 +315,7 @@ const UserProfile = () => {
             await axios.delete('/api/auth/api-token', {
                 headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
             });
-            
+
             setApiToken(null);
             setApiTokenCreatedAt(null);
             setShowToken(false);
@@ -333,10 +375,10 @@ const UserProfile = () => {
                         <Grid item xs={12} md={4}>
                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
                                 <Box sx={{ position: 'relative' }}>
-                                    <Avatar 
-                                        sx={{ 
-                                            width: 96, 
-                                            height: 96, 
+                                    <Avatar
+                                        sx={{
+                                            width: 96,
+                                            height: 96,
                                             bgcolor: getAvatarColor(user.profilePicture),
                                             fontSize: '2.2rem'
                                         }}
@@ -345,10 +387,10 @@ const UserProfile = () => {
                                         {user.username.charAt(0).toUpperCase()}
                                     </Avatar>
                                     {isOwnProfile && (
-                                        <IconButton 
-                                            sx={{ 
-                                                position: 'absolute', 
-                                                bottom: 0, 
+                                        <IconButton
+                                            sx={{
+                                                position: 'absolute',
+                                                bottom: 0,
                                                 right: -4,
                                                 bgcolor: 'background.paper',
                                                 border: '1px solid',
@@ -434,14 +476,14 @@ const UserProfile = () => {
                     </Grid>
 
                     <Divider sx={{ my: 3 }} />
-                    
+
                     <Grid container spacing={2} alignItems="center">
                         <Grid item xs={12} md={6}>
                             <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                                 <Typography variant="h6" color="primary">
                                     Account Type
                                 </Typography>
-                                <Chip 
+                                <Chip
                                     icon={user.role === 'admin' ? <AdminPanelSettingsIcon /> : undefined}
                                     label={user.role === 'admin' ? 'Administrator' : 'User'}
                                     color={user.role === 'admin' ? 'primary' : 'default'}
@@ -476,16 +518,16 @@ const UserProfile = () => {
             {/* Profile Tabs */}
             {isOwnProfile ? (
             <Card>
-                <Tabs 
-                    value={currentTab} 
-                    onChange={(e, newValue) => setCurrentTab(newValue)}
+                <Tabs
+                    value={currentTab}
+                    onChange={(_e: React.SyntheticEvent, newValue: string) => setCurrentTab(newValue)}
                     sx={{ borderBottom: 1, borderColor: 'divider' }}
                 >
                     <Tab value="overview" label="Overview" />
-                    <Tab 
+                    <Tab
                         value="apps"
-                        label="Apps" 
-                        icon={<AppsIcon />} 
+                        label="Apps"
+                        icon={<AppsIcon />}
                         iconPosition="start"
                     />
                     <Tab
@@ -503,7 +545,7 @@ const UserProfile = () => {
                         />
                     )}
                 </Tabs>
-                
+
                 <CardContent>
                     {currentTab === 'overview' && (
                         <Box>
@@ -515,27 +557,27 @@ const UserProfile = () => {
                             </Typography>
                         </Box>
                     )}
-                    
+
                     {currentTab === 'apps' && <AppsManagement />}
-                    
+
                     {currentTab === 'api-token' && (
                         <Box>
                             <Typography variant="h6" gutterBottom>
                                 API Token Management
                             </Typography>
                             <Typography variant="body2" color="text.secondary" gutterBottom>
-                                Generate an API token to access the Commonly API programmatically. 
+                                Generate an API token to access the Commonly API programmatically.
                                 Keep your token secure and don&apos;t share it publicly.
                             </Typography>
-                            
+
                             {apiToken ? (
                                 <Box sx={{ mt: 3 }}>
                                     <Alert severity="info" sx={{ mb: 3 }}>
                                         Your API token was created on {' '}
-                                        {new Date(apiTokenCreatedAt).toLocaleDateString()} at {' '}
-                                        {new Date(apiTokenCreatedAt).toLocaleTimeString()}
+                                        {new Date(apiTokenCreatedAt!).toLocaleDateString()} at {' '}
+                                        {new Date(apiTokenCreatedAt!).toLocaleTimeString()}
                                     </Alert>
-                                    
+
                                     <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', mb: 2 }}>
                                         <TextField
                                             label="API Token"
@@ -553,7 +595,7 @@ const UserProfile = () => {
                                             </IconButton>
                                         </Tooltip>
                                         <Tooltip title={showToken ? "Hide token" : "Show token"}>
-                                            <IconButton 
+                                            <IconButton
                                                 onClick={() => setShowToken(!showToken)}
                                                 color="primary"
                                             >
@@ -561,7 +603,7 @@ const UserProfile = () => {
                                             </IconButton>
                                         </Tooltip>
                                     </Box>
-                                    
+
                                     <Box sx={{ display: 'flex', gap: 2 }}>
                                         <Button
                                             variant="outlined"
@@ -598,16 +640,16 @@ const UserProfile = () => {
                                     </Button>
                                 </Box>
                             )}
-                            
+
                             <Divider sx={{ my: 3 }} />
-                            
+
                             <Typography variant="h6" gutterBottom>
                                 Usage Example
                             </Typography>
                             <Paper sx={{ p: 2, bgcolor: 'grey.100', mt: 2 }}>
-                                <Typography 
-                                    variant="body2" 
-                                    component="pre" 
+                                <Typography
+                                    variant="body2"
+                                    component="pre"
                                     sx={{ fontFamily: 'monospace', whiteSpace: 'pre-wrap' }}
                                 >
 {`curl -H "Authorization: Bearer YOUR_API_TOKEN" \\
@@ -688,8 +730,8 @@ const UserProfile = () => {
 
             {/* Avatar Selection Dialog */}
             {isOwnProfile && (
-            <Dialog 
-                open={openAvatarDialog} 
+            <Dialog
+                open={openAvatarDialog}
                 onClose={handleCloseAvatarDialog}
                 disableRestoreFocus={true}
             >
@@ -703,7 +745,7 @@ const UserProfile = () => {
                                 bgcolor: getAvatarColor(selectedAvatar),
                                 fontSize: '1.6rem'
                             }}
-                            src={avatarPreview || (isSelectedAvatarColor ? null : getAvatarSrc(selectedAvatar)) || null}
+                            src={avatarPreview || (isSelectedAvatarColor ? undefined : getAvatarSrc(selectedAvatar)) || undefined}
                         >
                             {user.username.charAt(0).toUpperCase()}
                         </Avatar>
@@ -748,9 +790,9 @@ const UserProfile = () => {
                 </DialogContent>
                 <DialogActions>
                     <Button onClick={handleCloseAvatarDialog}>Cancel</Button>
-                    <Button 
-                        onClick={handleSaveAvatar} 
-                        variant="contained" 
+                    <Button
+                        onClick={handleSaveAvatar}
+                        variant="contained"
                         disabled={isUpdating}
                     >
                         {isUpdating ? 'Saving...' : 'Save'}
@@ -776,8 +818,8 @@ const UserProfile = () => {
                 onClose={handleCloseSnackbar}
                 anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
             >
-                <Alert 
-                    onClose={handleCloseSnackbar} 
+                <Alert
+                    onClose={handleCloseSnackbar}
                     severity={snackbar.severity}
                     variant="filled"
                 >


### PR DESCRIPTION
## Summary
- `UserProfile.tsx`: `ProfileUser`, `UserStats`, `PublicActivity`, `SnackbarState` interfaces; `File | null` for `avatarFile`; null-safe `setUser` callbacks
- `Thread.tsx`: `PostUser`, `Comment`, `Post`, `PodAgent`, `MentionableItem` interfaces; `scrollHighlightTimer` typed as `ReturnType<typeof setTimeout> | null`; `handleCommentKeyDown` typed for `React.KeyboardEvent<HTMLTextAreaElement>`; loop var renamed `threadComment` to avoid shadowing `comment` state; removed unsupported `className` from `AgentAvatar`; `emojiStyle` cast via `any` (Jest mock doesn't export `EmojiStyle` enum)

## Test plan
- [ ] `tsc --noEmit` passes (0 errors)
- [ ] `Test & Coverage` CI passes
- [ ] UserProfile renders — avatar dialog, tabs, follow/unfollow
- [ ] Thread renders — comments, emoji picker, @mention dropdown

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)