### PR TITLE
fix(tests): improve MongoMemoryServer reliability in agentEnsembleService tests

### DIFF
--- a/backend/__tests__/services/agentEnsembleService.test.js
+++ b/backend/__tests__/services/agentEnsembleService.test.js
@@ -35,14 +35,28 @@ describe('AgentEnsembleService', () => {
   let testPod;
 
   beforeAll(async () => {
-    mongoServer = await MongoMemoryServer.create();
+    mongoServer = await MongoMemoryServer.create({
+      binary: {
+        version: '7.0.11',
+        skipMD5: true,
+      },
+      instance: {
+        dbName: 'agent-ensemble-service-test',
+      },
+    });
     const uri = mongoServer.getUri();
     await mongoose.connect(uri);
   });
 
   afterAll(async () => {
     await mongoose.disconnect();
-    await mongoServer.stop();
+    if (mongoServer) {
+      try {
+        await mongoServer.stop();
+      } catch (error) {
+        // Ignore cleanup errors so a failed in-memory server startup does not mask the test result.
+      }
+    }
   });
 
   beforeEach(async () => {


### PR DESCRIPTION
Recreates the test reliability fix from TASK-010 on a fresh branch after syncing the rewritten main.

Changes:
- stabilizes MongoMemoryServer lifecycle in agentEnsembleService tests

Tests: targeted agentEnsembleService test run in progress