### PR TITLE
feat(ci): add integration-test job with real Mongo + PG services

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,3 +60,64 @@ jobs:
         with:
           name: coverage-report
           path: backend/coverage/
+
+  integration-test:
+    name: Integration Tests (real DBs)
+    runs-on: ubuntu-latest
+    needs: test
+
+    services:
+      mongo:
+        image: mongo:7
+        ports: ["27017:27017"]
+        options: >-
+          --health-cmd "mongosh --eval 'db.runCommand(\"ping\").ok'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      postgres:
+        image: postgres:16
+        ports: ["5432:5432"]
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: commonly-test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      JWT_SECRET: test-jwt-secret
+      SENDGRID_API_KEY: fake-api-key
+      SENDGRID_FROM_EMAIL: test@example.com
+      FRONTEND_URL: http://localhost:3000
+      INTEGRATION_TEST: "true"
+      MONGO_URI: mongodb://localhost:27017/commonly-test
+      PG_HOST: localhost
+      PG_PORT: "5432"
+      PG_DATABASE: commonly-test
+      PG_USER: postgres
+      PG_PASSWORD: postgres
+      PG_SSL_ENABLED: "false"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install backend dependencies
+        run: cd backend && npm ci --include=dev
+
+      - name: Run integration tests
+        run: |
+          cd backend
+          npx jest --testPathPattern="__tests__/integration" --forceExit --runInBand


### PR DESCRIPTION
## Summary

- Adds an `integration-test` job to `tests.yml` that runs after the unit-test job passes
- Uses GitHub Actions native services: `mongo:7` and `postgres:16` with health checks
- Sets `INTEGRATION_TEST=true` so `backend/__tests__/setup.js` switches to real DB connections
- Runs only `__tests__/integration/**` with `--runInBand` (sequential, avoids port contention)
- No code changes to tests — all existing integration tests already pass with in-memory DBs; this adds a real-DB validation layer for any future tests that use `process.env.MONGO_URI`/`PG_HOST` directly

## Test plan

- [ ] `integration-test` job appears in CI on this PR
- [ ] Job runs after `test` job completes (needs: test)
- [ ] Mongo + PG service containers become healthy before tests run
- [ ] All 11 integration test files complete successfully

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)