### PR TITLE
feat(ts): backend Express type augmentation + tsc:check CI step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,11 @@ jobs:
           npm install --legacy-peer-deps
           cd ..
 
+      - name: Backend TypeScript check
+        run: |
+          cd backend
+          npm run tsc:check
+
       - name: Run backend tests with coverage
         run: |
           cd backend

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,9 @@
     "discord:verify": "node scripts/deploy-discord-commands.js verify",
     "discord:register": "node scripts/register-discord-commands.js",
     "discord:list": "node scripts/register-discord-commands.js list",
-    "bootstrap:clawd-bot": "node scripts/bootstrap-clawd-bot.js"
+    "bootstrap:clawd-bot": "node scripts/bootstrap-clawd-bot.js",
+    "tsc:check": "tsc --noEmit -p tsconfig.typescheck.json",
+    "tsc:check:all": "tsc --noEmit"
   },
   "dependencies": {
     "@google-cloud/secret-manager": "^6.1.1",

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,0 +1,33 @@
+/**
+ * Express Request augmentation.
+ *
+ * Adds fields set by Commonly-specific authentication middleware so
+ * TypeScript-aware routes don't need to cast req as any.
+ *
+ * NOTE: Many controllers define their own `interface AuthRequest extends Request`
+ * with a local `user` override. Those patterns are intentionally NOT unified here —
+ * that migration is Track A Batch 2 (controllers). This file only adds fields
+ * that are genuinely missing from the global Request type.
+ *
+ * Set by middleware/agentRuntimeAuth.js:
+ *   req.agentUser — populated User document for the calling agent
+ *   req.userId    — user._id as string (also set by verifyToken)
+ *   req.token     — raw JWT string (also set by verifyToken)
+ */
+declare global {
+  namespace Express {
+    interface Request {
+      /** User _id as string — set by verifyToken and agentRuntimeAuth middleware */
+      userId?: string;
+
+      /** Raw JWT string — set by verifyToken middleware */
+      token?: string;
+
+      /** Populated User document for the calling agent — set by agentRuntimeAuth middleware */
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      agentUser?: Record<string, any> & { _id: any };
+    }
+  }
+}
+
+export {};

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -14,6 +14,6 @@
     "resolveJsonModule": true,
     "types": ["node", "express"]
   },
-  "include": ["**/*.js", "**/*.ts"],
+  "include": ["**/*.js", "**/*.ts", "src/**/*.d.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/backend/tsconfig.typescheck.json
+++ b/backend/tsconfig.typescheck.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- `backend/src/types/express.d.ts` — augments `Express.Request` with `agentUser`, `userId`, `token` (the three fields set by Commonly middleware that aren't in `@types/express`). Does not touch `req.user` — controllers currently define their own `AuthRequest` interface; unifying those is Track A Batch 2.
- `backend/tsconfig.typescheck.json` — scoped config, only checks `src/**`. The backend has 527 pre-existing errors in in-progress `.ts` stub files (controllers, services, routes) that were never checked by CI. Scoping avoids blocking CI immediately; `npm run tsc:check:all` shows the full picture locally.
- `backend/package.json` — adds `tsc:check` (scoped, used in CI) and `tsc:check:all` (full, for local migration work)
- `tests.yml` — adds "Backend TypeScript check" step (scoped) before Jest runs

## Test plan

- [ ] `cd backend && npm run tsc:check` exits 0 (scoped check of `src/types/`)
- [ ] CI "Backend TypeScript check" step passes
- [ ] `npm run tsc:check:all` shows 527 errors (expected — pre-existing, tracked separately)

## Note on pre-existing errors

Running `tsc --noEmit` on all backend `.ts` files surfaces 527 errors across 68 files. These are stub/migration files created as part of the JS→TS migration that haven't been wired up yet. Fixing them is Track A Batches 1–6. This PR only checks the new `src/` files so we get CI coverage on new type work without being blocked by old debt.

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)