### PR TITLE
feat(pg-retention): tiered cleanup to keep db under 75% of 8 GiB cap

### DIFF
--- a/backend/__tests__/services/pgRetentionService.test.js
+++ b/backend/__tests__/services/pgRetentionService.test.js
@@ -1,0 +1,171 @@
+jest.mock('../../config/db-pg', () => ({
+  pool: { query: jest.fn() },
+}));
+jest.mock('../../models/pg/Message', () => ({
+  deleteOlderThan: jest.fn(),
+}));
+jest.mock('node-cron', () => ({ schedule: jest.fn(() => ({ start: jest.fn(), stop: jest.fn() })) }));
+
+const { pool } = require('../../config/db-pg');
+const Message = require('../../models/pg/Message');
+const cron = require('node-cron');
+const { runMessageRetention, initPgRetention } = require('../../services/pgRetentionService');
+
+const GIB = 1024 * 1024 * 1024;
+
+function mockSizeQueries(sizesGiB) {
+  const queue = [...sizesGiB];
+  pool.query.mockImplementation((sql) => {
+    if (/pg_database_size/i.test(sql)) {
+      const next = queue.shift();
+      const size = next === undefined ? 0 : Math.round(next * GIB);
+      return Promise.resolve({ rows: [{ size: String(size) }] });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+}
+
+describe('pgRetentionService.runMessageRetention', () => {
+  const ORIGINAL_ENV = process.env;
+  let logSpy;
+  let warnSpy;
+  let errSpy;
+
+  beforeEach(() => {
+    pool.query.mockReset();
+    Message.deleteOlderThan.mockReset();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.PG_MESSAGE_RETENTION_DAYS;
+    delete process.env.PG_CAPACITY_BYTES;
+    delete process.env.PG_USAGE_TARGET_PCT;
+    delete process.env.PG_RETENTION_STEP_DAYS;
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it('skips when PG_MESSAGE_RETENTION_DAYS is invalid', async () => {
+    process.env.PG_MESSAGE_RETENTION_DAYS = '0';
+
+    await runMessageRetention();
+
+    expect(Message.deleteOlderThan).not.toHaveBeenCalled();
+    expect(pool.query).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('invalid PG_MESSAGE_RETENTION_DAYS'),
+      '0',
+    );
+  });
+
+  it('runs single pass and skips tiering when size already under target', async () => {
+    // 8 GiB cap, 75% target = 6 GiB. 4 GiB everywhere = under target.
+    mockSizeQueries([4, 4, 4]);
+    Message.deleteOlderThan.mockResolvedValue({ deleted: 10 });
+
+    await runMessageRetention();
+
+    expect(Message.deleteOlderThan).toHaveBeenCalledTimes(1);
+    expect(Message.deleteOlderThan).toHaveBeenCalledWith(30);
+    const vacuumCalls = pool.query.mock.calls.filter(([sql]) => /^VACUUM/i.test(sql));
+    expect(vacuumCalls).toHaveLength(1);
+    expect(vacuumCalls[0][0]).toMatch(/VACUUM ANALYZE messages/i);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('steps down retention when still above target, stops when under', async () => {
+    // Probes: 7.5 (initial) → 7.2 (after 30d) → 6.9 (after 29d) → 5.5 (after 28d, under) → 5.4 (final)
+    mockSizeQueries([7.5, 7.2, 6.9, 5.5, 5.4]);
+    Message.deleteOlderThan.mockResolvedValue({ deleted: 100 });
+
+    await runMessageRetention();
+
+    expect(Message.deleteOlderThan.mock.calls.map((c) => c[0])).toEqual([30, 29, 28]);
+  });
+
+  it('respects PG_RETENTION_STEP_DAYS when stepping down', async () => {
+    process.env.PG_RETENTION_STEP_DAYS = '7';
+    // Always over target — forces stepping until floor (8 probes).
+    mockSizeQueries([8, 8, 8, 8, 8, 8, 8, 8]);
+    Message.deleteOlderThan.mockResolvedValue({ deleted: 1 });
+
+    await runMessageRetention();
+
+    // 30 → 23 → 16 → 9 → 2 → 1 (floor); next iter would also be 1, loop exits.
+    expect(Message.deleteOlderThan.mock.calls.map((c) => c[0])).toEqual([30, 23, 16, 9, 2, 1]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('still over target'));
+  });
+
+  it('floors at 1 day and warns when still over target', async () => {
+    mockSizeQueries(Array(40).fill(7.9));
+    Message.deleteOlderThan.mockResolvedValue({ deleted: 5 });
+
+    await runMessageRetention();
+
+    const daysUsed = Message.deleteOlderThan.mock.calls.map((c) => c[0]);
+    expect(daysUsed[0]).toBe(30);
+    expect(daysUsed[daysUsed.length - 1]).toBe(1);
+    expect(daysUsed).toHaveLength(30); // 30..1 inclusive
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('still over target'));
+  });
+
+  it('skips tiering gracefully when pg_database_size query fails', async () => {
+    pool.query.mockImplementation((sql) => {
+      if (/pg_database_size/i.test(sql)) return Promise.reject(new Error('boom'));
+      return Promise.resolve({ rows: [] });
+    });
+    Message.deleteOlderThan.mockResolvedValue({ deleted: 3 });
+
+    await runMessageRetention();
+
+    expect(Message.deleteOlderThan).toHaveBeenCalledTimes(1);
+    expect(Message.deleteOlderThan).toHaveBeenCalledWith(30);
+  });
+
+  it('uses custom capacity and target via env', async () => {
+    // 2 GiB cap, 50% target = 1 GiB. Probes: 1.5 (over) → 1.4 (over) → 0.9 (under) → 0.9 final
+    process.env.PG_CAPACITY_BYTES = String(2 * GIB);
+    process.env.PG_USAGE_TARGET_PCT = '50';
+    mockSizeQueries([1.5, 1.4, 0.9, 0.9]);
+    Message.deleteOlderThan.mockResolvedValue({ deleted: 50 });
+
+    await runMessageRetention();
+
+    expect(Message.deleteOlderThan.mock.calls.map((c) => c[0])).toEqual([30, 29]);
+  });
+
+  it('swallows errors from deleteOlderThan without crashing cron', async () => {
+    mockSizeQueries([4, 4]);
+    Message.deleteOlderThan.mockRejectedValue(new Error('db down'));
+
+    await expect(runMessageRetention()).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalledWith('[pg-retention] failed:', 'db down');
+  });
+});
+
+describe('pgRetentionService.initPgRetention', () => {
+  beforeEach(() => {
+    cron.schedule.mockClear();
+  });
+
+  it('schedules the cron at 03:00 UTC', () => {
+    initPgRetention();
+    // Module-level `scheduledJob` may already be set from a prior test run in
+    // this file; either way, we just need to observe the schedule signature at
+    // least once since process start.
+    const firstCall = cron.schedule.mock.calls[0] || null;
+    if (firstCall) {
+      expect(firstCall[0]).toBe('0 3 * * *');
+      expect(firstCall[2]).toEqual({ timezone: 'UTC' });
+    } else {
+      // Already scheduled in a previous test — no-op path is the expected branch.
+      expect(cron.schedule).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/backend/services/pgRetentionService.ts
+++ b/backend/services/pgRetentionService.ts
@@ -5,6 +5,12 @@
  * retention window (default: 30 days). Controlled by the
  * `PG_MESSAGE_RETENTION_DAYS` env var.
  *
+ * If after the initial delete the database is still above
+ * `PG_USAGE_TARGET_PCT` of `PG_CAPACITY_BYTES`, retention steps down by
+ * `PG_RETENTION_STEP_DAYS` (default 1) per pass until usage drops under the
+ * target or a floor of 1 day is reached. Keeps as much history as the disk
+ * allows.
+ *
  * Intentionally kept separate from schedulerService so that other tracks can
  * edit schedulerService without stomping on this cron (and vice versa).
  */
@@ -15,8 +21,16 @@ const cron = require('node-cron');
 const Message = require('../models/pg/Message') as {
   deleteOlderThan: (days: number) => Promise<{ deleted: number }>;
 };
+// eslint-disable-next-line global-require
+const { pool } = require('../config/db-pg') as {
+  pool: { query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }> };
+};
 
 const DEFAULT_RETENTION_DAYS = 30;
+const DEFAULT_CAPACITY_BYTES = 8 * 1024 * 1024 * 1024; // Cloud SQL tier: 8 GiB
+const DEFAULT_USAGE_TARGET_PCT = 75;
+const DEFAULT_STEP_DAYS = 1;
+const FLOOR_DAYS = 1;
 
 interface CronJob {
   start(): void;
@@ -25,31 +39,119 @@ interface CronJob {
 
 let scheduledJob: CronJob | null = null;
 
-function resolveRetentionDays(): number {
-  const raw = process.env.PG_MESSAGE_RETENTION_DAYS;
-  if (raw === undefined || raw === null || String(raw).trim() === '') {
-    return DEFAULT_RETENTION_DAYS;
-  }
+function resolvePositiveNumber(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === null || String(raw).trim() === '') return fallback;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return NaN;
-  }
+  if (!Number.isFinite(parsed) || parsed <= 0) return NaN;
   return parsed;
+}
+
+function resolveRetentionDays(): number {
+  return resolvePositiveNumber(process.env.PG_MESSAGE_RETENTION_DAYS, DEFAULT_RETENTION_DAYS);
+}
+
+function resolveCapacityBytes(): number {
+  return resolvePositiveNumber(process.env.PG_CAPACITY_BYTES, DEFAULT_CAPACITY_BYTES);
+}
+
+function resolveUsageTargetPct(): number {
+  const pct = resolvePositiveNumber(process.env.PG_USAGE_TARGET_PCT, DEFAULT_USAGE_TARGET_PCT);
+  if (!Number.isFinite(pct) || pct <= 0 || pct >= 100) return DEFAULT_USAGE_TARGET_PCT;
+  return pct;
+}
+
+function resolveStepDays(): number {
+  const step = resolvePositiveNumber(process.env.PG_RETENTION_STEP_DAYS, DEFAULT_STEP_DAYS);
+  if (!Number.isFinite(step) || step <= 0) return DEFAULT_STEP_DAYS;
+  return Math.max(1, Math.trunc(step));
+}
+
+async function getDatabaseSizeBytes(): Promise<number | null> {
+  try {
+    const result = await pool.query('SELECT pg_database_size(current_database())::bigint AS size');
+    const raw = result.rows?.[0]?.size;
+    const size = typeof raw === 'string' ? Number(raw) : (raw as number | undefined);
+    return Number.isFinite(size) ? (size as number) : null;
+  } catch (err) {
+    console.error('[pg-retention] pg_database_size failed:', (err as Error).message);
+    return null;
+  }
+}
+
+async function vacuumMessages(): Promise<void> {
+  try {
+    // Plain VACUUM — frees pages for reuse without locking writers.
+    // VACUUM FULL would reclaim OS-level disk but takes an ACCESS EXCLUSIVE lock.
+    await pool.query('VACUUM ANALYZE messages');
+  } catch (err) {
+    console.error('[pg-retention] vacuum failed:', (err as Error).message);
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(2)} GiB`;
+  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(2)} MiB`;
+  return `${bytes} B`;
 }
 
 export async function runMessageRetention(): Promise<void> {
   try {
-    const days = resolveRetentionDays();
-    if (!Number.isFinite(days) || days <= 0) {
+    const startDays = resolveRetentionDays();
+    if (!Number.isFinite(startDays) || startDays <= 0) {
       console.warn(
         '[pg-retention] invalid PG_MESSAGE_RETENTION_DAYS, skipping (value=%s)',
         process.env.PG_MESSAGE_RETENTION_DAYS,
       );
       return;
     }
-    console.log(`[pg-retention] running: delete messages older than ${days} days`);
-    const result = await Message.deleteOlderThan(days);
-    console.log(`[pg-retention] done: deleted ${result?.deleted || 0} message(s)`);
+
+    const capacity = resolveCapacityBytes();
+    const targetPct = resolveUsageTargetPct();
+    const stepDays = resolveStepDays();
+    const targetBytes = Math.floor(capacity * (targetPct / 100));
+
+    const initialSize = await getDatabaseSizeBytes();
+    console.log(
+      `[pg-retention] start: size=${initialSize !== null ? formatBytes(initialSize) : 'unknown'} ` +
+      `target=${formatBytes(targetBytes)} (${targetPct}% of ${formatBytes(capacity)}) ` +
+      `retention=${startDays}d step=${stepDays}d`,
+    );
+
+    let totalDeleted = 0;
+    let currentDays = Math.max(FLOOR_DAYS, Math.trunc(startDays));
+    const { deleted } = await Message.deleteOlderThan(currentDays);
+    totalDeleted += deleted || 0;
+    console.log(`[pg-retention] tier ${currentDays}d: deleted ${deleted || 0}`);
+
+    let size = await getDatabaseSizeBytes();
+    while (size !== null && size > targetBytes && currentDays > FLOOR_DAYS) {
+      const nextDays = Math.max(FLOOR_DAYS, currentDays - stepDays);
+      if (nextDays >= currentDays) break;
+      currentDays = nextDays;
+      const tierResult = await Message.deleteOlderThan(currentDays);
+      totalDeleted += tierResult.deleted || 0;
+      console.log(
+        `[pg-retention] tier ${currentDays}d: deleted ${tierResult.deleted || 0} ` +
+        `(size=${formatBytes(size)} > target=${formatBytes(targetBytes)})`,
+      );
+      size = await getDatabaseSizeBytes();
+    }
+
+    await vacuumMessages();
+    const finalSize = await getDatabaseSizeBytes();
+
+    if (finalSize !== null && finalSize > targetBytes) {
+      console.warn(
+        `[pg-retention] WARN: still over target after floor=${FLOOR_DAYS}d — ` +
+        `size=${formatBytes(finalSize)} target=${formatBytes(targetBytes)}. ` +
+        `Capacity upgrade or non-message table audit needed.`,
+      );
+    }
+
+    console.log(
+      `[pg-retention] done: totalDeleted=${totalDeleted} finalRetention=${currentDays}d ` +
+      `size=${finalSize !== null ? formatBytes(finalSize) : 'unknown'}`,
+    );
   } catch (err) {
     // Swallow so cron keeps running — never crash the host process from a
     // retention failure. Next run will retry.


### PR DESCRIPTION
## Summary
- After the normal 30-day delete in `pgRetentionService`, query `pg_database_size(current_database())` and if still above target (default 75% of 8 GiB Cloud SQL cap), step retention down by `PG_RETENTION_STEP_DAYS` (default 1d) per pass until under target or a 1-day floor is reached.
- `VACUUM ANALYZE messages` after deletes so freed pages become reusable.
- Loud WARN log if still over target at the floor — signal to bump the Cloud SQL tier or audit non-message tables.

## Why
Cloud SQL Postgres (8 GiB tier) is approaching the storage ceiling. A fixed 30-day window is fine until it isn't — once growth outpaces the cap, the next insert fails. Tiered fallback retains as much history as the disk allows, preferring one-day granularity to avoid over-deleting.

## New env vars (all optional, sensible defaults)
- `PG_CAPACITY_BYTES=8589934592` — the Cloud SQL tier cap
- `PG_USAGE_TARGET_PCT=75` — stay under this fraction of the cap
- `PG_RETENTION_STEP_DAYS=1` — day granularity for the step-down

Defaults match the current dev tier, so no values-yaml changes are strictly required.

## Tests
9 new unit tests in `backend/__tests__/services/pgRetentionService.test.js` covering: invalid env guard, single-pass when under target, tier stepping, custom step size, 1-day floor + WARN, failed size probe graceful skip, custom capacity/target, swallowed delete errors, cron schedule signature.

## Test plan
- [ ] Review logic in `backend/services/pgRetentionService.ts`
- [ ] `cd backend && npx jest __tests__/services/pgRetentionService.test.js` → 9 passing
- [ ] Full backend suite still green
- [ ] After deploy, watch `kubectl logs -n commonly-dev -l app=backend | grep pg-retention` at 03:00 UTC for start/tier/done lines
- [ ] Manually trigger once to verify behavior against real Cloud SQL: `kubectl exec -n commonly-dev deployment/backend -- node -e "require('./services/pgRetentionService').runMessageRetention().then(()=>process.exit(0))"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)