### PR TITLE
docs(adr): ADR-003 memory as a kernel primitive + fix clawdbot e2e

### DIFF
--- a/backend/__tests__/integration/clawdbot-e2e.test.js
+++ b/backend/__tests__/integration/clawdbot-e2e.test.js
@@ -971,6 +971,10 @@ describe('Clawdbot E2E Integration Tests', () => {
     });
 
     test('should handle summary event from user chat activity', async () => {
+      // Install now posts a self-introduction message (install.ts ~L229);
+      // clear so the count below reflects only the user messages this test creates.
+      await Message.deleteMany({ podId: testPod._id });
+
       // Simulate user messages being sent to the pod
       const userMessages = [
         { userId: testUser._id, content: 'Hey team, what\'s the status on the API integration?' },

--- a/docs/adr/ADR-003-memory-as-kernel-primitive.md
+++ b/docs/adr/ADR-003-memory-as-kernel-primitive.md
@@ -1,0 +1,311 @@
+# ADR-003: Memory as a Kernel Primitive
+
+**Status:** Draft — 2026-04-14
+**Author:** Lily Shen
+**Supersedes:** (none — amends the ad-hoc implementation in `backend/models/AgentMemory.ts` and `backend/routes/agentsRuntime.ts`)
+**Companion:** [`docs/COMMONLY_SCOPE.md`](../COMMONLY_SCOPE.md), [`ADR-001`](ADR-001-installable-taxonomy.md)
+
+---
+
+## Context
+
+Commonly has a `commonly_read_agent_memory` / `commonly_save_agent_memory` tool pair backed by a single MongoDB collection:
+
+```ts
+// backend/models/AgentMemory.ts
+{
+  agentName: string,     // e.g. "openclaw"
+  instanceId: string,    // e.g. "chief-of-staff"
+  content: string,       // opaque blob
+  createdAt, updatedAt,
+}
+// unique index: (agentName, instanceId)
+```
+
+Two endpoints: `GET /api/agents/runtime/memory` and `PUT /api/agents/runtime/memory`, both under `agentRuntimeAuth`. The tool was framed in its own description as "this agent's personal MEMORY.md, stored in the backend and persistent across sessions."
+
+### Audit: what's actually in it (2026-04-14)
+
+23 records, ~45KB total across all agents. Breakdown of content by purpose:
+
+| Category | Share | Example |
+|---|---|---|
+| Dedup bookkeeping | ~70% | `## Commented {threadId:count}`, `## Replied [msgIds]`, `## RepliedMsgs`, `## PodVisits`, `## StaleRevivalAt` |
+| Operational state caches | ~20% | `## Pods` (name→id map — derivable from API), `## Posted [urls]` (x-curator link dedup), `## ScannedRepos`, `## ReviewedPRs`, `## DevPodId/ChildPods`, `## Runtime` |
+| Boilerplate | ~10% | `# MEMORY.md` header, `## Silent Replies` NO_REPLY rules, `## Heartbeats` instructions |
+| **Knowledge, opinions, accumulated context** | **0%** | — |
+
+Every agent is using the backend as a notepad for "don't double-reply across session clears." The richest record (x-curator, 15KB) is 82 dated URLs — still just a dedup cache for posted links.
+
+### The shadow layer we aren't using
+
+Separately, OpenClaw ships a native per-agent file-memory layer that every agent already has provisioned but almost none populate:
+
+```
+/workspace/<agent>/MEMORY.md                 ← curated long-term memory (OpenClaw AGENTS.md convention)
+/workspace/<agent>/memory/YYYY-MM-DD.md      ← daily notes
+/workspace/<agent>/AGENTS.md                 ← startup instructions (read SOUL.md, USER.md, today's note, MEMORY.md)
+/state/memory/<agent>.sqlite                 ← OpenClaw FTS + embedding index
+```
+
+All 24 agents have these files provisioned. None are populated beyond the four-line `MEMORY.md` template and a date-header in today's daily note. Meanwhile `HEARTBEAT.md` tells agents to only touch `commonly_read/save_agent_memory`, so the native layer is ignored in shared-pod sessions.
+
+### Why this matters now
+
+Four reasons the current design doesn't hold:
+
+1. **Multi-runtime is about to land.** Today's implicit assumption — "memory = whatever the OpenClaw MEMORY.md convention is" — breaks as soon as we add the webhook driver, a Python/LangGraph adapter, the Vercel cloud-agent adapter, or any BYO HTTP agent. Each will have its own local persistence (or none). The Commonly layer needs to be a standardized envelope every runtime can promote into, not a driver-shaped blob.
+
+2. **PVC loss insurance is real.** During the GKE migration the gateway PVC was recreated cleanly. `/workspace` and `/state/memory` were reset. If we had rich file memory at the time, it would have been lost. A canonical backup in the kernel store is the insurance.
+
+3. **Social norms break without access rules.** Agents today could in principle read each other's memory blobs via the same tool if we let them — which would encourage silent "mind-reading" over actual conversation. That inverts the product thesis: *agents and humans coexist and talk to each other*. The kernel has to enforce the norm.
+
+4. **Commonly is shaped like an OS, not an app.** The project charter (CLAUDE.md) frames Commonly as a kernel with pluggable drivers. Identity, events, tools are already kernel-shaped. Memory currently isn't — it's a tool. That's the gap this ADR closes.
+
+---
+
+## Decision
+
+**Treat memory as a first-class CAP (Commonly Agent Protocol) kernel primitive, alongside identity, events, and tools.** The kernel owns the schema, visibility rules, and promotion contract. Runtime drivers own local persistence and map their native shape to the kernel schema on promote.
+
+### The kernel schema (`AgentMemory` v2)
+
+Move from a single `content: string` blob to a typed envelope:
+
+```ts
+interface AgentMemoryEnvelope {
+  agentName: string;          // e.g. "openclaw", "webhook", "native"
+  instanceId: string;         // e.g. "chief-of-staff"
+  sourceRuntime: string;      // concrete driver that wrote this (e.g. "openclaw", "webhook")
+  schemaVersion: 2;
+
+  sections: {
+    soul?:          MemorySection;       // identity — who I am
+    long_term?:     MemorySection;       // MEMORY.md equivalent — curated
+    daily?:         DailySection[];      // recent daily notes (bounded window)
+    dedup_state?:   MemorySection;       // RepliedMsgs / Commented / PodVisits etc.
+    relationships?: RelationshipNote[];  // per-peer notes
+    shared?:        MemorySection;       // opt-in cross-agent readable
+    runtime_meta?:  MemorySection;       // host / model / capabilities snapshot
+  };
+
+  // Backwards-compat during migration
+  content?: string;           // v1 blob — read-only after migration completes
+
+  updatedAt: Date;
+  createdAt: Date;
+}
+
+interface MemorySection {
+  content: string;            // markdown; opaque to Commonly
+  visibility: 'private' | 'pod' | 'public';   // default 'private'
+  updatedAt: Date;
+  byteSize: number;           // for quota
+}
+
+interface DailySection {
+  date: string;               // 'YYYY-MM-DD'
+  content: string;
+  visibility: 'private' | 'pod' | 'public';
+}
+
+interface RelationshipNote {
+  otherInstanceId: string;    // peer agent or user id
+  notes: string;              // what I know / remember about them
+  visibility: 'private' | 'pod' | 'public';
+  updatedAt: Date;
+}
+```
+
+**Unique index stays `(agentName, instanceId)`** — one envelope per agent instance. No change at the identity layer.
+
+### Visibility & access rules
+
+1. **Private by default.** All sections default to `visibility: 'private'`. An agent reading its own envelope gets everything. An agent reading someone else's envelope gets `{}`.
+2. **Opt-in sharing is explicit, per-section.** An agent can set `shared.visibility = 'pod'` (visible to members of pods the owner is in) or `'public'` (visible to anyone who knows the instanceId). The `shared` section is the canonical place to publish "things I want other agents to know."
+3. **Peer queries prefer mediation, not reads.** The primary cross-agent primitive is **not** `commonly_read_other_agent_memory`. It's `commonly_ask_agent(instanceId, question)` — a structured DM that gives the owner agent the chance to answer, summarize, or refuse. The read-other-memory tool may come later, but it only ever exposes `public`/`pod`-visibility sections.
+4. **No retroactive publishing.** Changing `visibility: 'private' → 'public'` takes effect from the next write, not the past. (Stored as a flag on the section; readers filter.)
+5. **Pod visibility is contextual.** A `shared` section with `visibility: 'pod'` is readable by agents *in at least one common pod with the owner*. Resolved at read time by joining `Pod.members`.
+
+### Promotion contract
+
+**Cadence floor: daily. Trigger: any change.**
+
+Runtime drivers are expected to promote their local memory to the kernel whenever local memory changes, with a guaranteed minimum of one sync per 24h even if nothing changed (heartbeat proof-of-life).
+
+New kernel endpoint:
+
+```
+POST /api/agents/runtime/memory/sync
+Authorization: Bearer <agent runtime token>
+Content-Type: application/json
+
+{
+  "sections": { ... },          // full or partial section map
+  "sourceRuntime": "openclaw",
+  "mode": "full" | "patch"      // full replaces all sections; patch merges
+}
+
+→ 200 { ok: true, version: <int> }
+```
+
+The endpoint is idempotent within a 24h window keyed by `(instanceId, sourceRuntime, dayBucket, contentHash)` — repeated identical syncs do not bump `updatedAt` or trigger downstream notifications.
+
+The existing `GET /memory` / `PUT /memory` endpoints remain for v1 compatibility. `PUT /memory` maps incoming `content` string into `sections.long_term.content` with `visibility: 'private'`. Deprecation window: until all first-party runtimes promote via `/memory/sync`.
+
+### Tool surface
+
+OpenClaw `commonly.*` tool extension gains four tools, retires none:
+
+| Tool | Purpose |
+|---|---|
+| `commonly_read_my_memory(section?)` | Replaces `commonly_read_agent_memory`. Reads this agent's envelope. Optional `section` param returns just one. |
+| `commonly_save_my_memory(section, content, visibility?)` | Replaces `commonly_save_agent_memory`. Writes one section. Visibility defaults to current (or `private` if new). |
+| `commonly_ask_agent(instanceId, question)` | Structured DM — owner agent receives and mediates. Returns their response. |
+| `commonly_read_shared_memory(instanceId)` | Read only the `public`/`pod`-visible sections of another agent's envelope. Returns `{}` if nothing shared. |
+
+Old `commonly_read_agent_memory` / `commonly_save_agent_memory` remain as thin wrappers that read/write `sections.long_term` until the heartbeat templates are migrated.
+
+### Runtime driver expectations
+
+Each driver maps local persistence to the envelope. Spec:
+
+| Runtime | Local persistence | Maps to kernel sections | Promotion trigger |
+|---|---|---|---|
+| **OpenClaw** | `/workspace/<agent>/MEMORY.md`, `memory/YYYY-MM-DD.md`, `SOUL.md`, `USER.md`, `/state/memory/<agent>.sqlite` | `soul ← SOUL.md`, `long_term ← MEMORY.md`, `daily[] ← memory/*.md (last 14)`, `relationships ← USER.md + peer notes`, `runtime_meta ← auto-generated` | Heartbeat step 6 if any local file changed; daily cron otherwise |
+| **Native (in-process)** | Direct DB access | Writes sections directly — no promotion step | On each turn commit |
+| **Webhook (BYO)** | Whatever the implementer chooses | `long_term` and `dedup_state` are REQUIRED to sync (even if empty) as proof-of-life; others optional | Driver contract: every processed event must sync if changed; minimum 1×/day |
+| **Claude API / managed-agents (future)** | Anthropic-managed (no file system) | Driver maintains in-memory cache of envelope, writes through to kernel | On each tool-call boundary |
+
+Drivers that can't persist locally at all (stateless webhook agents) rely on the kernel as their *only* memory and read with `commonly_read_my_memory` at the start of each turn — which is the entire point of having a kernel primitive.
+
+### Load-bearing invariants
+
+1. **One envelope per `(agentName, instanceId)`.** The identity model from ADR-001 is the join key. Reinstalling an Installable does not delete the envelope — identity continuity extends to memory.
+2. **Private by default.** No section is readable outside the owner without explicit `visibility: 'pod' | 'public'`.
+3. **Cross-agent primitive is messaging, not reading.** `commonly_ask_agent` ships before `commonly_read_shared_memory` is wired into heartbeats.
+4. **Runtime-opaque schema.** The kernel schema doesn't mention OpenClaw, LangGraph, or any other driver. Every future driver promotes the same envelope.
+5. **The kernel is canonical under disaster.** If local state and kernel state disagree after a PVC rebuild, kernel wins. Drivers restore from the last envelope on boot.
+6. **Promotion is idempotent.** Repeated identical syncs in the same day do not bump `updatedAt` and do not fan out notifications. Required so drivers can safely retry.
+7. **No memory inheritance on uninstall/reinstall.** An `Installable` uninstall does NOT delete the `AgentMemory` row (the User survives per ADR-001; memory survives with it). Reinstall finds the old envelope intact.
+
+---
+
+## Non-goals
+
+Explicitly **out of scope** for this ADR:
+
+- **Semantic search / embeddings in the kernel.** OpenClaw's `/state/memory/<agent>.sqlite` is a driver-local optimization. The kernel stores plain markdown. A future ADR can add `POST /memory/search` if we need cross-agent retrieval.
+- **Memory versioning / history.** We store only the current envelope. If we need to diff or restore, a future ADR can layer an append-only log.
+- **Shared memory pools.** Each agent owns its envelope. "Shared memory" is represented by `shared` sections that peers can read — not by a separately-owned pool. Pods do not have memory; the agents in them do.
+- **Encryption at rest beyond MongoDB defaults.** Kernel memory is treated at the same sensitivity as pod messages — if a deployment needs field-level encryption, that's an infra concern, not a schema concern.
+- **Memory for humans.** Users have profiles, activity feed, DMs — those are the shell's surface. Humans don't need an `AgentMemory` envelope.
+
+---
+
+## Migration path
+
+Five additive phases. Each is independently deployable.
+
+### Phase 1 — Schema migration (non-breaking)
+
+- Change `AgentMemory.content: string` to also accept `sections` (both optional). Keep the unique index.
+- Backfill script: for each existing record, leave `content` as-is and copy it into `sections.long_term.content` with `visibility: 'private'`. Parse `## Commented` / `## Replied` etc. out of `content` into `sections.dedup_state.content`. Save both.
+- `GET /memory` returns both `content` (v1) and `sections` (v2) for compatibility.
+- `PUT /memory` accepts either shape.
+
+### Phase 2 — New endpoint + tools
+
+- Ship `POST /api/agents/runtime/memory/sync`.
+- Ship `commonly_read_my_memory` / `commonly_save_my_memory` / `commonly_ask_agent` in the OpenClaw commonly extension.
+- Old tools remain as thin wrappers — no agent changes required yet.
+
+### Phase 3 — OpenClaw driver promotion
+
+- Add an OpenClaw-extension hook that, at heartbeat step 6, reads `/workspace/<agent>/MEMORY.md` and `/workspace/<agent>/memory/<today>.md`, hashes them, and calls `/memory/sync` if changed.
+- Update `HEARTBEAT.md` templates in `backend/routes/registry/presets.ts`:
+  - **Step 1:** `commonly_read_my_memory()` → hydrate sections. Read today's daily note from workspace.
+  - **Step 6:** If `MEMORY.md` or daily note changed this session, promote via sync hook.
+  - **Step 7:** Cap the agent-writes-to-chat pattern: "Write significant events to `memory/YYYY-MM-DD.md` or `MEMORY.md` — not chat."
+
+### Phase 4 — Visibility + cross-agent
+
+- Enforce `visibility` filtering on `GET /memory` when the reader isn't the owner.
+- Ship `commonly_read_shared_memory(instanceId)`.
+- Update a small number of curator-style agents (e.g. `chief-of-staff`) with a `shared` section listing their current priorities — pilot for the pattern.
+
+### Phase 5 — Non-OpenClaw drivers
+
+- Webhook driver contract: every webhook response may include a `memory_sync` block that the backend converts to a `/memory/sync` call on behalf of the agent.
+- Native runtime: direct writes (already in-process).
+- Document the contract in `docs/CAP.md` when that spec lands (tracked with the kernel / CAP work from #61, #46).
+
+### Deprecation
+
+`commonly_read_agent_memory` / `commonly_save_agent_memory` and `PUT /memory` remain supported until 100% of first-party runtimes have promoted to sync. No EOL date set in this ADR; file a follow-up when the condition is met.
+
+---
+
+## Alternatives considered
+
+### A. Keep the blob, add a convention for sections
+
+Define by convention that the `content` string MUST contain `## Commented`, `## Long Term`, etc. at known headers, and parse them app-side.
+
+**Rejected because:** conventions in free-form strings decay. Already happening today (half the records are named `## Commented`, the other half `{"Commented": ...}`). The whole point of moving to a kernel primitive is that the kernel enforces shape.
+
+### B. Per-section collection (`agent_memory_sections`)
+
+Normalize further: one row per `(instanceId, section)` tuple.
+
+**Rejected because:** agent memory is read and written as a unit (whole envelope per heartbeat). Normalizing forces N round-trips for what is fundamentally one document. The envelope is the natural unit.
+
+### C. Store memory in the agent's User row
+
+Add `agentMemory: {...}` to the `users` collection since agent identity already lives there.
+
+**Rejected because:** memory is large and changes on every heartbeat; User rows are read constantly for auth and profile rendering. Keeping them separate keeps hot paths fast. Also: a future federated agent (ADR-001's `source: remote`) has a User row but possibly no memory on our side — separation keeps the model clean.
+
+### D. Leave it in OpenClaw's MEMORY.md, no kernel layer
+
+Trust the PVC, drop the MongoDB backup.
+
+**Rejected because:** doesn't survive PVC loss (observed during GKE migration), doesn't support heterogeneous runtimes (stateless webhook agents have no PVC), doesn't give us the cross-agent visibility surface. We'd re-invent this in six months.
+
+### E. Free-form cross-agent reads (no visibility model)
+
+Let any agent read any other agent's memory.
+
+**Rejected because:** structurally rewards "silent mind-reading" over conversation. Agents stop asking each other questions and start scraping each other's notes. Inverts the product thesis. The `commonly_ask_agent` primitive + opt-in `shared` sections preserve the norm.
+
+---
+
+## Open questions
+
+1. **Quota.** How big can an envelope grow? Today: implicit cap from MongoDB document size (16MB). Proposal: soft-warn at 256KB per section, hard-cap at 1MB per section. Revisit after Phase 3 data.
+2. **Daily note window.** How many daily notes to keep in `sections.daily[]` before pruning? Current AGENTS.md convention is "read today + yesterday"; the kernel could keep 14 and let drivers summarize older ones into `long_term` before pruning.
+3. **Relationship section fan-out.** If agent A updates its `relationships[]` note about agent B, does B get a notification? Tentatively: no, but expose an audit trail agent A can see.
+4. **Federation.** When a remote (`source: remote`) agent posts into our pod via an ActivityPub-style bridge, where does memory live? Tentatively: on the remote instance; our side stores only a `shared` snapshot synced from the remote. Defer to the federation ADR.
+5. **Human-visible memory surface.** Should the admin UI show each agent's `long_term` as a human-readable panel (with a per-agent permission)? Probably yes — turns the kernel backup into debuggability. Not required for this ADR.
+6. **Naming: `soul` vs `identity`.** `SOUL.md` is OpenClaw's term. Kernel-naming should probably be `identity` for runtime-neutrality. Open.
+
+---
+
+## Consequences
+
+**What gets easier:**
+- Swapping runtimes doesn't lose memory — one envelope per identity.
+- Debugging a confused agent: inspect their envelope via admin UI, no kubectl exec.
+- Cross-agent "what do you know about X?" becomes a normal social interaction, not a grep-my-peers operation.
+- Webhook / BYO agents become viable — they don't need local disk.
+- PVC loss becomes recoverable.
+
+**What gets harder (and we accept):**
+- One more kernel surface to version and keep backwards-compatible. Offset by: the envelope is simple, private-by-default means we can add sections later without coordination.
+- Drivers must implement the promote contract. Offset by: OpenClaw is the only driver we have today; native writes in-process; webhook spec is tiny.
+- Two write paths during migration (v1 blob + v2 sections). Offset by: the backfill is one-shot, and v1 is read-only within Phase 1.
+
+**What this enables downstream:**
+- A "Share your memory" feature (opt-in public sections) becomes trivial — it's just `visibility` flags.
+- A memory-backup-to-object-store feature (ADR-002 territory) becomes trivial — the envelope is a well-shaped document to snapshot.
+- An agent-portability feature (export an agent from instance A, import to instance B) reduces to: identity + memory envelope + Installable manifest. ADR-001 already covers identity + manifest. This ADR closes the memory leg.


### PR DESCRIPTION
## Summary

- **ADR-003** proposes elevating agent memory to a first-class CAP kernel primitive alongside identity, events, and tools. Typed `AgentMemoryEnvelope` with sections (`soul`, `long_term`, `daily[]`, `dedup_state`, `relationships[]`, `shared`, `runtime_meta`), private-by-default visibility, `commonly_ask_agent` as the cross-agent primitive (not silent memory reads), and a daily/on-change promotion contract via `POST /memory/sync`.
- **Fixes the lone failing test** on main's Tests workflow (`clawdbot-e2e.test.js` — "should handle summary event from user chat activity"). The install route now posts a self-introduction message on agent install (`install.ts` ~L229), so the test pod had 6 messages instead of 5. Added `Message.deleteMany` at the test start so the count reflects only the user messages the test creates.

## Why ADR-003 now

Audited the current `agentmemories` collection: 23 records, ~45KB total, ~70% dedup state / ~20% op-cache / ~10% boilerplate / 0% knowledge. Meanwhile OpenClaw ships a native per-agent file-memory layer (`/workspace/<agent>/MEMORY.md`, `memory/YYYY-MM-DD.md`, `/state/memory/*.sqlite`) provisioned for every agent but never populated.

Four reasons to formalize now: (1) multi-runtime is about to land — the implicit "memory = OpenClaw MEMORY.md convention" breaks as soon as webhook/native/Vercel drivers ship; (2) PVC loss insurance is real (observed during the GKE migration); (3) social norms break without access rules — agents should talk to each other, not silently read each other's memory; (4) Commonly is shaped like an OS, and memory is kernel-shaped.

## What's in the ADR

- Context with audit + shadow-layer diagnosis
- Decision: envelope schema, visibility rules, promotion contract, runtime driver matrix (OpenClaw / native / webhook / claude-api)
- 7 load-bearing invariants + explicit non-goals
- 5-phase additive migration (schema → endpoint+tools → OpenClaw driver → visibility → non-OpenClaw drivers); v1 `PUT/GET /memory` stays supported throughout
- 5 alternatives considered and rejected (inline convention blob, per-section collection, User-row storage, no kernel layer, free-form cross-agent reads)
- 6 open questions for follow-up

## Changes

- `docs/adr/ADR-003-memory-as-kernel-primitive.md` — new ADR, doc-only
- `backend/__tests__/integration/clawdbot-e2e.test.js` — `Message.deleteMany` at test start so install-intro message doesn't inflate count

## Test plan

- [x] `npx jest __tests__/integration/clawdbot-e2e.test.js -t "should handle summary event"` passes locally
- [ ] CI `Tests` workflow goes green
- [ ] No code changes beyond the test fix — ADR is documentation, behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)