### PR TITLE
feat(agent-memory): ADR-003 Phase 1 — v2 envelope schema + backfill

### DIFF
--- a/backend/__tests__/integration/agent-memory-envelope.test.js
+++ b/backend/__tests__/integration/agent-memory-envelope.test.js
@@ -1,0 +1,457 @@
+/**
+ * ADR-003 Phase 1 — GET/PUT /memory envelope integration tests.
+ *
+ * Goes through the full agent-runtime auth pipeline (install agent → issue
+ * runtime token → hit /memory) so the handlers are exercised the way a real
+ * driver would hit them.
+ *
+ * Also covers the one-shot backfill script: v1 content-only records get
+ * sections populated; v2 records are skipped; re-running is idempotent.
+ */
+
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+const { setupMongoDb, closeMongoDb, clearMongoDb } = require('../utils/testUtils');
+
+const User = require('../../models/User');
+const Pod = require('../../models/Pod');
+const { AgentRegistry, AgentInstallation } = require('../../models/AgentRegistry');
+const AgentMemory = require('../../models/AgentMemory');
+
+const registryRoutes = require('../../routes/registry');
+const agentsRuntimeRoutes = require('../../routes/agentsRuntime');
+
+const { backfillAgentMemorySections } = require('../../scripts/backfill-agent-memory-sections');
+
+const JWT_SECRET = 'test-jwt-secret-for-memory-envelope';
+
+jest.setTimeout(60000);
+
+describe('AgentMemory envelope — GET/PUT /memory + backfill', () => {
+  let app;
+  let testUser;
+  let authToken;
+  let testPod;
+  let runtimeToken;
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = JWT_SECRET;
+    await setupMongoDb();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/registry', registryRoutes);
+    app.use('/api/agents/runtime', agentsRuntimeRoutes);
+
+    testUser = await User.create({
+      username: 'memory-admin',
+      email: 'memory-admin@test.com',
+      password: 'password123',
+    });
+    authToken = jwt.sign({ id: testUser._id.toString() }, JWT_SECRET);
+
+    testPod = await Pod.create({
+      name: 'Memory Pod',
+      type: 'chat',
+      createdBy: testUser._id,
+      members: [testUser._id],
+    });
+
+    await AgentRegistry.create({
+      agentName: 'mem-agent',
+      displayName: 'Mem Agent',
+      description: 'Agent for memory envelope tests',
+      registry: 'commonly-official',
+      verified: true,
+      manifest: {
+        name: 'mem-agent',
+        version: '1.0.0',
+        capabilities: [{ name: 'memory', description: 'uses memory' }],
+        context: { required: ['context:read'] },
+        runtime: { type: 'standalone', connection: 'rest' },
+      },
+      latestVersion: '1.0.0',
+      versions: [{ version: '1.0.0', publishedAt: new Date() }],
+    });
+  });
+
+  afterAll(async () => {
+    await closeMongoDb();
+  });
+
+  beforeEach(async () => {
+    // Fresh install + token per test so state is fully isolated.
+    await AgentInstallation.deleteMany({});
+    await AgentMemory.deleteMany({});
+    await User.updateMany({ isBot: true }, { $set: { agentRuntimeTokens: [] } });
+
+    await request(app)
+      .post('/api/registry/install')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        agentName: 'mem-agent',
+        podId: testPod._id.toString(),
+        scopes: ['context:read'],
+      });
+
+    const tokenRes = await request(app)
+      .post(`/api/registry/pods/${testPod._id}/agents/mem-agent/runtime-tokens`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ label: 'Memory Envelope Test Token' });
+    runtimeToken = tokenRes.body.token;
+    expect(runtimeToken).toMatch(/^cm_agent_/);
+  });
+
+  // ------------------------------------------------------------------- //
+  // GET /memory                                                          //
+  // ------------------------------------------------------------------- //
+
+  describe('GET /memory', () => {
+    it('returns empty content and undefined sections on a fresh record', async () => {
+      const res = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      expect(res.status).toBe(200);
+      expect(res.body.content).toBe('');
+      expect(res.body.sections).toBeUndefined();
+      expect(res.body.sourceRuntime).toBeUndefined();
+      expect(res.body.schemaVersion).toBeUndefined();
+    });
+
+    it('rejects unauthenticated requests', async () => {
+      const res = await request(app).get('/api/agents/runtime/memory');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns both content and sections when both are persisted', async () => {
+      const install = await AgentInstallation.findOne({ agentName: 'mem-agent' });
+      await AgentMemory.create({
+        agentName: install.agentName,
+        instanceId: install.instanceId || 'default',
+        content: 'v1 blob',
+        sections: {
+          long_term: { content: 'curated', visibility: 'private' },
+          shared: { content: 'public bio', visibility: 'public' },
+        },
+        sourceRuntime: 'openclaw',
+        schemaVersion: 2,
+      });
+      const res = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      expect(res.status).toBe(200);
+      expect(res.body.content).toBe('v1 blob');
+      expect(res.body.sections.long_term.content).toBe('curated');
+      expect(res.body.sections.shared.visibility).toBe('public');
+      expect(res.body.sourceRuntime).toBe('openclaw');
+      expect(res.body.schemaVersion).toBe(2);
+    });
+  });
+
+  // ------------------------------------------------------------------- //
+  // PUT /memory                                                          //
+  // ------------------------------------------------------------------- //
+
+  describe('PUT /memory', () => {
+    it('accepts the v1 shape and preserves content on read', async () => {
+      const put = await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ content: '# MEMORY.md\nhello' });
+      expect(put.status).toBe(200);
+      expect(put.body.ok).toBe(true);
+
+      const get = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      expect(get.body.content).toBe('# MEMORY.md\nhello');
+      // v1 writes do not auto-populate sections — that's the backfill's job.
+      expect(get.body.sections).toBeUndefined();
+    });
+
+    it('accepts the v2 shape and mirrors long_term.content into content', async () => {
+      const put = await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({
+          sections: {
+            long_term: { content: 'curated', visibility: 'private' },
+            dedup_state: { content: '## Commented\n{}' },
+          },
+          sourceRuntime: 'openclaw',
+          schemaVersion: 2,
+        });
+      expect(put.status).toBe(200);
+
+      const get = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      expect(get.body.content).toBe('curated'); // mirrored from long_term
+      expect(get.body.sections.long_term.content).toBe('curated');
+      expect(get.body.sections.dedup_state.content).toContain('Commented');
+      expect(get.body.sourceRuntime).toBe('openclaw');
+      expect(get.body.schemaVersion).toBe(2);
+    });
+
+    it('accepts both shapes in one request and stores each as given (no mirror override)', async () => {
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({
+          content: 'explicit v1 blob',
+          sections: { long_term: { content: 'different curated content' } },
+        })
+        .expect(200);
+
+      const get = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      expect(get.body.content).toBe('explicit v1 blob');
+      expect(get.body.sections.long_term.content).toBe('different curated content');
+    });
+
+    it('rejects a request with neither content nor sections', async () => {
+      const res = await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({});
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/content or sections/);
+    });
+
+    it('rejects a non-string content', async () => {
+      const res = await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ content: 42 });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/content must be a string/);
+    });
+
+    it('rejects sections that are not an object', async () => {
+      const res = await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ sections: 'nope' });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/sections must be an object/);
+    });
+
+    it('rejects an invalid visibility on a section', async () => {
+      const res = await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ sections: { long_term: { content: 'x', visibility: 'everyone' } } });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/visibility must be one of/);
+    });
+
+    it('rejects an invalid visibility on a daily entry', async () => {
+      const res = await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ sections: { daily: [{ date: '2026-04-14', visibility: 'everyone' }] } });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/daily\[\]\.visibility/);
+    });
+
+    it('rejects a relationships entry missing otherInstanceId', async () => {
+      const res = await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ sections: { relationships: [{ notes: 'orphan' }] } });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/otherInstanceId/);
+    });
+
+    it('rejects an empty sections object', async () => {
+      const res = await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ sections: {} });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/at least one key/);
+    });
+
+    it('rejects unknown section names', async () => {
+      const res = await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ sections: { notes: { content: 'x' } } });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/unknown section: notes/);
+    });
+
+    it('auto-sets schemaVersion to 2 when sections are written (not client-supplied)', async () => {
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ sections: { long_term: { content: 'x' } } })
+        .expect(200);
+      const get = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      expect(get.body.schemaVersion).toBe(2);
+    });
+
+    it('preserves sibling sections when a partial sections write lands', async () => {
+      // Seed with long_term + shared + v1 content.
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({
+          sections: {
+            long_term: { content: 'curated' },
+            shared: { content: 'bio', visibility: 'public' },
+          },
+          sourceRuntime: 'openclaw',
+        })
+        .expect(200);
+
+      // Partial write — only dedup_state. long_term, shared, and content must survive.
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ sections: { dedup_state: { content: '## Commented\n{}' } } })
+        .expect(200);
+
+      const get = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      expect(get.body.sections.long_term.content).toBe('curated');
+      expect(get.body.sections.shared.content).toBe('bio');
+      expect(get.body.sections.shared.visibility).toBe('public');
+      expect(get.body.sections.dedup_state.content).toContain('Commented');
+      expect(get.body.content).toBe('curated'); // mirrored from original long_term write; not overwritten
+      expect(get.body.sourceRuntime).toBe('openclaw');
+    });
+
+    it('does not overwrite content on a sections write that omits long_term', async () => {
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ content: 'original v1 content' })
+        .expect(200);
+
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ sections: { dedup_state: { content: '## Commented\n{}' } } })
+        .expect(200);
+
+      const get = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      expect(get.body.content).toBe('original v1 content');
+      expect(get.body.sections.dedup_state.content).toContain('Commented');
+    });
+
+    it('is idempotent — repeated writes with the same shape do not error or duplicate', async () => {
+      const put = () => request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ content: 'same every time' })
+        .expect(200);
+      await Promise.all([put(), put(), put()]);
+      const count = await AgentMemory.countDocuments({});
+      expect(count).toBe(1);
+    });
+
+    it('does not erase existing sections when only content is sent', async () => {
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ sections: { long_term: { content: 'seed' } } });
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ content: 'new content only' });
+      const get = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      expect(get.body.content).toBe('new content only');
+      expect(get.body.sections.long_term.content).toBe('seed');
+    });
+  });
+
+  // ------------------------------------------------------------------- //
+  // backfill-agent-memory-sections                                       //
+  // ------------------------------------------------------------------- //
+
+  describe('backfillAgentMemorySections', () => {
+    it('populates sections from legacy content for v1 records', async () => {
+      await AgentMemory.create({
+        agentName: 'openclaw',
+        instanceId: 'alpha',
+        content: '# MEMORY.md\nDurable stuff.\n## Commented\n{"a":1}',
+      });
+
+      const result = await backfillAgentMemorySections();
+      expect(result).toMatchObject({
+        total: 1, migrated: 1, skipped: 0, empty: 0,
+      });
+
+      const after = await AgentMemory.findOne({ instanceId: 'alpha' });
+      expect(after.sections.long_term.content).toContain('Durable stuff.');
+      expect(after.sections.long_term.content).not.toContain('## Commented');
+      expect(after.sections.dedup_state.content).toContain('## Commented');
+      // sourceRuntime intentionally left unset — first post-migration write
+      // will populate with the driver's own identifier (ADR-003 §Runtime
+      // driver expectations).
+      expect(after.sourceRuntime).toBeUndefined();
+      expect(after.schemaVersion).toBe(2);
+      // v1 blob is preserved — ADR-003 Phase 1 is additive.
+      expect(after.content).toContain('## Commented');
+    });
+
+    it('skips records that already have sections', async () => {
+      await AgentMemory.create({
+        agentName: 'openclaw',
+        instanceId: 'beta',
+        content: 'legacy',
+        sections: { long_term: { content: 'already migrated' } },
+        sourceRuntime: 'openclaw',
+        schemaVersion: 2,
+      });
+
+      const result = await backfillAgentMemorySections();
+      expect(result).toMatchObject({ total: 1, migrated: 0, skipped: 1 });
+
+      const after = await AgentMemory.findOne({ instanceId: 'beta' });
+      expect(after.sections.long_term.content).toBe('already migrated');
+    });
+
+    it('is idempotent — re-running does not re-migrate already-migrated records', async () => {
+      await AgentMemory.create({
+        agentName: 'openclaw',
+        instanceId: 'gamma',
+        content: 'plain content',
+      });
+
+      const first = await backfillAgentMemorySections();
+      expect(first.migrated).toBe(1);
+      const second = await backfillAgentMemorySections();
+      expect(second.migrated).toBe(0);
+      expect(second.skipped).toBe(1);
+    });
+
+    it('treats records with empty content as empty, not migrated', async () => {
+      await AgentMemory.create({ agentName: 'openclaw', instanceId: 'delta', content: '' });
+      const result = await backfillAgentMemorySections();
+      expect(result.empty).toBe(1);
+      expect(result.migrated).toBe(0);
+      const after = await AgentMemory.findOne({ instanceId: 'delta' });
+      expect(after.sections).toBeUndefined();
+    });
+
+    it('dryRun does not write changes', async () => {
+      await AgentMemory.create({ agentName: 'openclaw', instanceId: 'eps', content: '## Commented\n{}' });
+      const result = await backfillAgentMemorySections({ dryRun: true });
+      expect(result.migrated).toBe(1);
+      const after = await AgentMemory.findOne({ instanceId: 'eps' });
+      expect(after.sections).toBeUndefined();
+    });
+  });
+});

--- a/backend/__tests__/unit/models/AgentMemory.test.ts
+++ b/backend/__tests__/unit/models/AgentMemory.test.ts
@@ -1,0 +1,137 @@
+// @ts-nocheck
+// ADR-003 Phase 1: schema-level tests for the v2 AgentMemory envelope.
+// Verifies unique index preservation, section sub-schema defaults, visibility
+// enum enforcement, and that v1 (`content` only) writes still work.
+
+const AgentMemory = require('../../../models/AgentMemory');
+const { setupMongoDb, closeMongoDb, clearMongoDb } = require('../../utils/testUtils');
+
+describe('AgentMemory (ADR-003 v2 schema)', () => {
+  beforeAll(async () => {
+    await setupMongoDb();
+  });
+
+  afterAll(async () => {
+    await closeMongoDb();
+  });
+
+  afterEach(async () => {
+    await clearMongoDb();
+  });
+
+  it('accepts the legacy v1 shape with only content', async () => {
+    const doc = await AgentMemory.create({
+      agentName: 'openclaw',
+      instanceId: 'alice',
+      content: '# MEMORY.md\nSome long-term stuff.',
+    });
+    expect(doc.content).toContain('long-term stuff');
+    expect(doc.sections).toBeUndefined();
+    expect(doc.sourceRuntime).toBeUndefined();
+    expect(doc.schemaVersion).toBeUndefined();
+  });
+
+  it('accepts the v2 envelope with typed sections', async () => {
+    const now = new Date();
+    const doc = await AgentMemory.create({
+      agentName: 'openclaw',
+      instanceId: 'bob',
+      content: '',
+      sections: {
+        long_term: { content: 'curated', visibility: 'private', updatedAt: now, byteSize: 7 },
+        dedup_state: { content: '## Commented\n{}', visibility: 'private' },
+        daily: [{ date: '2026-04-14', content: 'today', visibility: 'private' }],
+        relationships: [
+          { otherInstanceId: 'nova', notes: 'met in dev pod', visibility: 'private' },
+        ],
+        shared: { content: 'my bio', visibility: 'public' },
+      },
+      sourceRuntime: 'openclaw',
+      schemaVersion: 2,
+    });
+    expect(doc.sections?.long_term?.content).toBe('curated');
+    expect(doc.sections?.dedup_state?.content).toContain('Commented');
+    expect(doc.sections?.daily?.[0]?.date).toBe('2026-04-14');
+    expect(doc.sections?.relationships?.[0]?.otherInstanceId).toBe('nova');
+    expect(doc.sections?.shared?.visibility).toBe('public');
+    expect(doc.sourceRuntime).toBe('openclaw');
+    expect(doc.schemaVersion).toBe(2);
+  });
+
+  it('defaults visibility to "private" on sections', async () => {
+    const doc = await AgentMemory.create({
+      agentName: 'openclaw',
+      instanceId: 'carol',
+      sections: { long_term: { content: 'x' } },
+    });
+    expect(doc.sections?.long_term?.visibility).toBe('private');
+  });
+
+  it('rejects an invalid visibility value', async () => {
+    await expect(
+      AgentMemory.create({
+        agentName: 'openclaw',
+        instanceId: 'dave',
+        sections: { long_term: { content: 'x', visibility: 'everyone' } },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('enforces unique (agentName, instanceId)', async () => {
+    await AgentMemory.create({ agentName: 'openclaw', instanceId: 'eve', content: 'a' });
+    await expect(
+      AgentMemory.create({ agentName: 'openclaw', instanceId: 'eve', content: 'b' }),
+    ).rejects.toThrow();
+  });
+
+  it('permits different instanceIds under the same agentName', async () => {
+    await AgentMemory.create({ agentName: 'openclaw', instanceId: 'a', content: '1' });
+    await AgentMemory.create({ agentName: 'openclaw', instanceId: 'b', content: '2' });
+    const rows = await AgentMemory.find({ agentName: 'openclaw' });
+    expect(rows.length).toBe(2);
+  });
+
+  it('permits the same instanceId under different agentName (envelope is keyed by both)', async () => {
+    await AgentMemory.create({ agentName: 'openclaw', instanceId: 'shared', content: '1' });
+    await AgentMemory.create({ agentName: 'webhook', instanceId: 'shared', content: '2' });
+    const rows = await AgentMemory.find({ instanceId: 'shared' });
+    expect(rows.length).toBe(2);
+  });
+
+  it('sets createdAt and updatedAt via timestamps:true', async () => {
+    const doc = await AgentMemory.create({ agentName: 'openclaw', instanceId: 'f', content: 'x' });
+    expect(doc.createdAt).toBeInstanceOf(Date);
+    expect(doc.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('requires a daily entry to have a date', async () => {
+    await expect(
+      AgentMemory.create({
+        agentName: 'openclaw',
+        instanceId: 'g',
+        sections: { daily: [{ content: 'no date' }] },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('requires a relationship entry to have otherInstanceId', async () => {
+    await expect(
+      AgentMemory.create({
+        agentName: 'openclaw',
+        instanceId: 'h',
+        sections: { relationships: [{ notes: 'orphan' }] },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('does not drop content when sections are also written', async () => {
+    const doc = await AgentMemory.create({
+      agentName: 'openclaw',
+      instanceId: 'i',
+      content: 'legacy blob',
+      sections: { long_term: { content: 'new' } },
+    });
+    expect(doc.content).toBe('legacy blob');
+    expect(doc.sections?.long_term?.content).toBe('new');
+  });
+});

--- a/backend/__tests__/unit/services/agentMemoryService.test.ts
+++ b/backend/__tests__/unit/services/agentMemoryService.test.ts
@@ -1,0 +1,137 @@
+// @ts-nocheck
+// ADR-003 Phase 1: parser logic that maps legacy v1 `content` blobs into
+// v2 `sections`. Pure functions — no DB required.
+
+const {
+  parseContentIntoSections,
+  buildSectionsFromLegacyContent,
+  mirrorContentFromSections,
+} = require('../../../services/agentMemoryService');
+
+describe('parseContentIntoSections', () => {
+  it('returns empty sections on empty input', () => {
+    expect(parseContentIntoSections('')).toEqual({ long_term: '', dedup_state: '' });
+    expect(parseContentIntoSections('   \n\n  ')).toEqual({ long_term: '', dedup_state: '' });
+  });
+
+  it('puts content with no ## headers entirely in long_term', () => {
+    const r = parseContentIntoSections('Just a preamble with no headers.');
+    expect(r.long_term).toBe('Just a preamble with no headers.');
+    expect(r.dedup_state).toBe('');
+  });
+
+  it('extracts ## Commented into dedup_state', () => {
+    const src = [
+      '# MEMORY.md',
+      'Durable stuff.',
+      '## Commented',
+      '{"abc": 3}',
+    ].join('\n');
+    const r = parseContentIntoSections(src);
+    expect(r.dedup_state).toContain('## Commented');
+    expect(r.dedup_state).toContain('{"abc": 3}');
+    expect(r.long_term).toContain('# MEMORY.md');
+    expect(r.long_term).toContain('Durable stuff.');
+    expect(r.long_term).not.toContain('## Commented');
+  });
+
+  it('extracts all known dedup headers together', () => {
+    const src = [
+      '## Commented',
+      '{}',
+      '## Replied',
+      '[]',
+      '## RepliedMsgs',
+      '[]',
+      '## PodVisits',
+      '{}',
+      '## StaleRevivalAt',
+      '{}',
+      '## NotDedup',
+      'keep me',
+    ].join('\n');
+    const r = parseContentIntoSections(src);
+    for (const h of ['Commented', 'Replied', 'RepliedMsgs', 'PodVisits', 'StaleRevivalAt']) {
+      expect(r.dedup_state).toContain(`## ${h}`);
+    }
+    expect(r.dedup_state).not.toContain('## NotDedup');
+    expect(r.long_term).toContain('## NotDedup');
+    expect(r.long_term).toContain('keep me');
+  });
+
+  it('is case-insensitive on dedup header matching', () => {
+    const src = '## commented\nfoo\n## Replied\nbar';
+    const r = parseContentIntoSections(src);
+    expect(r.dedup_state).toContain('commented');
+    expect(r.dedup_state).toContain('Replied');
+    expect(r.long_term).toBe('');
+  });
+
+  it('ignores unknown headers and leaves them in long_term', () => {
+    const src = '## Pods\n{}\n## ScannedRepos\n[]';
+    const r = parseContentIntoSections(src);
+    expect(r.long_term).toContain('## Pods');
+    expect(r.long_term).toContain('## ScannedRepos');
+    expect(r.dedup_state).toBe('');
+  });
+
+  it('keeps preamble before the first ## header in long_term', () => {
+    const src = 'Preamble line.\n\n## Commented\n{}';
+    const r = parseContentIntoSections(src);
+    expect(r.long_term).toContain('Preamble line.');
+    expect(r.dedup_state).toContain('## Commented');
+  });
+
+  it('re-parsing the already-extracted long_term produces no dedup noise', () => {
+    const src = 'intro\n## Commented\n{}\n## Other\nfoo';
+    const first = parseContentIntoSections(src);
+    const second = parseContentIntoSections(first.long_term);
+    expect(second.dedup_state).toBe('');
+    expect(second.long_term).toBe(first.long_term);
+  });
+});
+
+describe('buildSectionsFromLegacyContent', () => {
+  it('produces long_term and dedup_state sections with defaults', () => {
+    const sections = buildSectionsFromLegacyContent('## Commented\n{}\n## Other\nx');
+    expect(sections.long_term).toBeDefined();
+    expect(sections.long_term.visibility).toBe('private');
+    expect(typeof sections.long_term.byteSize).toBe('number');
+    expect(sections.dedup_state).toBeDefined();
+    expect(sections.dedup_state.visibility).toBe('private');
+  });
+
+  it('omits long_term when content is entirely dedup', () => {
+    const sections = buildSectionsFromLegacyContent('## Commented\n{}');
+    expect(sections.long_term).toBeUndefined();
+    expect(sections.dedup_state).toBeDefined();
+  });
+
+  it('omits dedup_state when there is no dedup content', () => {
+    const sections = buildSectionsFromLegacyContent('# Title\nbody');
+    expect(sections.long_term).toBeDefined();
+    expect(sections.dedup_state).toBeUndefined();
+  });
+
+  it('returns {} for empty/whitespace input', () => {
+    expect(buildSectionsFromLegacyContent('')).toEqual({});
+    expect(buildSectionsFromLegacyContent('   \n')).toEqual({});
+  });
+
+  it('counts byteSize in utf-8 bytes (multi-byte chars)', () => {
+    const sections = buildSectionsFromLegacyContent('😀 hi');
+    expect(sections.long_term?.byteSize).toBe(Buffer.byteLength('😀 hi', 'utf8'));
+  });
+});
+
+describe('mirrorContentFromSections', () => {
+  it('returns long_term.content when present', () => {
+    expect(mirrorContentFromSections({ long_term: { content: 'hello' } })).toBe('hello');
+  });
+
+  it('returns empty string when sections are missing or have no long_term', () => {
+    expect(mirrorContentFromSections(undefined)).toBe('');
+    expect(mirrorContentFromSections({})).toBe('');
+    expect(mirrorContentFromSections({ dedup_state: { content: 'x' } })).toBe('');
+  });
+});

--- a/backend/models/AgentMemory.ts
+++ b/backend/models/AgentMemory.ts
@@ -1,18 +1,110 @@
 import mongoose, { Document, Model, Schema } from 'mongoose';
 
+// ADR-003: Memory is a kernel primitive. The envelope below is the
+// standardized shape every runtime driver promotes into. Runtime-opaque:
+// no field names reference a specific driver (OpenClaw, webhook, etc.).
+
+export type MemoryVisibility = 'private' | 'pod' | 'public';
+
+export interface IMemorySection {
+  content: string;
+  visibility: MemoryVisibility;
+  updatedAt: Date;
+  byteSize: number;
+}
+
+export interface IDailySection {
+  date: string; // YYYY-MM-DD
+  content: string;
+  visibility: MemoryVisibility;
+}
+
+export interface IRelationshipNote {
+  otherInstanceId: string;
+  notes: string;
+  visibility: MemoryVisibility;
+  updatedAt: Date;
+}
+
+export interface IAgentMemorySections {
+  soul?: IMemorySection;
+  long_term?: IMemorySection;
+  daily?: IDailySection[];
+  dedup_state?: IMemorySection;
+  relationships?: IRelationshipNote[];
+  shared?: IMemorySection;
+  runtime_meta?: IMemorySection;
+}
+
 export interface IAgentMemory extends Document {
   agentName: string;
   instanceId: string;
-  content: string;
+  content: string; // v1 blob; still written during Phase 1 for compatibility
+  sections?: IAgentMemorySections;
+  sourceRuntime?: string;
+  schemaVersion?: number;
   createdAt: Date;
   updatedAt: Date;
 }
+
+export const VISIBILITY_VALUES: MemoryVisibility[] = ['private', 'pod', 'public'];
+
+// Phase 1 invariant: all section sub-fields use `default: undefined` so a newly
+// created envelope does NOT auto-insert empty sub-documents. Callers opt in to
+// each section by writing it explicitly. This keeps GET /memory responses
+// small for fresh records and makes "section missing" distinguishable from
+// "section set to empty."
+
+const memorySectionSchema = new Schema<IMemorySection>(
+  {
+    content: { type: String, default: '' },
+    visibility: { type: String, enum: VISIBILITY_VALUES, default: 'private' },
+    updatedAt: { type: Date, default: Date.now },
+    byteSize: { type: Number, default: 0 },
+  },
+  { _id: false },
+);
+
+const dailySectionSchema = new Schema<IDailySection>(
+  {
+    date: { type: String, required: true },
+    content: { type: String, default: '' },
+    visibility: { type: String, enum: VISIBILITY_VALUES, default: 'private' },
+  },
+  { _id: false },
+);
+
+const relationshipNoteSchema = new Schema<IRelationshipNote>(
+  {
+    otherInstanceId: { type: String, required: true },
+    notes: { type: String, default: '' },
+    visibility: { type: String, enum: VISIBILITY_VALUES, default: 'private' },
+    updatedAt: { type: Date, default: Date.now },
+  },
+  { _id: false },
+);
+
+const agentMemorySectionsSchema = new Schema<IAgentMemorySections>(
+  {
+    soul: { type: memorySectionSchema, default: undefined },
+    long_term: { type: memorySectionSchema, default: undefined },
+    daily: { type: [dailySectionSchema], default: undefined },
+    dedup_state: { type: memorySectionSchema, default: undefined },
+    relationships: { type: [relationshipNoteSchema], default: undefined },
+    shared: { type: memorySectionSchema, default: undefined },
+    runtime_meta: { type: memorySectionSchema, default: undefined },
+  },
+  { _id: false },
+);
 
 const agentMemorySchema = new Schema<IAgentMemory>(
   {
     agentName: { type: String, required: true },
     instanceId: { type: String, default: 'default' },
     content: { type: String, default: '' },
+    sections: { type: agentMemorySectionsSchema, default: undefined },
+    sourceRuntime: { type: String, default: undefined },
+    schemaVersion: { type: Number, default: undefined },
   },
   { timestamps: true },
 );

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -21,6 +21,7 @@ const { requireApiTokenScopes } = require('../middleware/apiTokenScopes');
 
 const Integration = require('../models/Integration');
 const AgentMemory = require('../models/AgentMemory');
+const { mirrorContentFromSections } = require('../services/agentMemoryService');
 const DMService = require('../services/dmService');
 const ChatSummarizerService = require('../services/chatSummarizerService');
 const AgentMentionService = require('../services/agentMentionService');
@@ -1188,26 +1189,89 @@ router.post('/threads/:threadId/comments', agentRuntimeAuth, async (req: any, re
   }
 });
 
+// ADR-003 Phase 1: GET/PUT /memory accept both v1 (`{ content }`) and
+// v2 (`{ sections, sourceRuntime }`) shapes. GET always returns both for
+// compatibility. `schemaVersion` is server-set (2 whenever sections are
+// written), not client-supplied. New CAP endpoint (POST /memory/sync) with
+// explicit full/patch mode lands in Phase 2.
+
+// Single source of truth — shared with the model schema.
+const { VISIBILITY_VALUES } = require('../models/AgentMemory');
+const VALID_VISIBILITIES = new Set(VISIBILITY_VALUES);
+
+function resolveMemoryIdentity(req: any): { agentName?: string; instanceId: string } {
+  const agentInstallation = req.agentInstallation;
+  const agentName =
+    agentInstallation?.agentName ||
+    req.agentUser?.botMetadata?.agentName ||
+    req.agentUser?.username;
+  const instanceId =
+    agentInstallation?.instanceId ||
+    req.agentUser?.botMetadata?.instanceId ||
+    'default';
+  return { agentName, instanceId };
+}
+
+function validateSectionsPayload(sections: any): string | null {
+  if (typeof sections !== 'object' || sections === null || Array.isArray(sections)) {
+    return 'sections must be an object';
+  }
+  if (Object.keys(sections).length === 0) {
+    return 'sections must have at least one key';
+  }
+  const allowed = new Set(['soul', 'long_term', 'dedup_state', 'shared', 'runtime_meta', 'daily', 'relationships']);
+  for (const key of Object.keys(sections)) {
+    if (!allowed.has(key)) return `unknown section: ${key}`;
+  }
+  const singleSectionKeys = ['soul', 'long_term', 'dedup_state', 'shared', 'runtime_meta'];
+  for (const key of singleSectionKeys) {
+    const s = sections[key];
+    if (s === undefined) continue;
+    if (typeof s !== 'object' || s === null) return `sections.${key} must be an object`;
+    if (s.content !== undefined && typeof s.content !== 'string') return `sections.${key}.content must be a string`;
+    if (s.visibility !== undefined && !VALID_VISIBILITIES.has(s.visibility)) {
+      return `sections.${key}.visibility must be one of private|pod|public`;
+    }
+  }
+  if (sections.daily !== undefined) {
+    if (!Array.isArray(sections.daily)) return 'sections.daily must be an array';
+    for (const d of sections.daily) {
+      if (typeof d?.date !== 'string') return 'sections.daily[].date must be a string';
+      if (d.visibility !== undefined && !VALID_VISIBILITIES.has(d.visibility)) {
+        return 'sections.daily[].visibility must be one of private|pod|public';
+      }
+    }
+  }
+  if (sections.relationships !== undefined) {
+    if (!Array.isArray(sections.relationships)) return 'sections.relationships must be an array';
+    for (const r of sections.relationships) {
+      if (typeof r?.otherInstanceId !== 'string') return 'sections.relationships[].otherInstanceId must be a string';
+      if (r.visibility !== undefined && !VALID_VISIBILITIES.has(r.visibility)) {
+        return 'sections.relationships[].visibility must be one of private|pod|public';
+      }
+    }
+  }
+  return null;
+}
+
 /**
  * GET /memory (agent runtime token auth)
- * Read this agent's personal MEMORY.md (persistent across sessions)
+ * Returns this agent's memory in both v1 (`content`) and v2 (`sections`)
+ * shapes. v1 callers read `content`; v2 callers read `sections` directly.
  */
 router.get('/memory', agentRuntimeAuth, async (req: any, res: any) => {
   try {
-    const agentInstallation = req.agentInstallation;
-    const agentName =
-      agentInstallation?.agentName ||
-      req.agentUser?.botMetadata?.agentName ||
-      req.agentUser?.username;
-    const instanceId =
-      agentInstallation?.instanceId ||
-      req.agentUser?.botMetadata?.instanceId ||
-      'default';
+    const { agentName, instanceId } = resolveMemoryIdentity(req);
     if (!agentName) {
       return res.status(403).json({ message: 'Could not resolve agent identity' });
     }
     const record = await AgentMemory.findOne({ agentName, instanceId }).lean();
-    return res.json({ content: record?.content ?? '' });
+    return res.json({
+      content: record?.content ?? '',
+      sections: record?.sections,
+      sourceRuntime: record?.sourceRuntime,
+      schemaVersion: record?.schemaVersion,
+    });
   } catch (err: any) {
     console.error('GET /memory error:', err);
     return res.status(500).json({ message: 'Failed to read agent memory' });
@@ -1216,31 +1280,65 @@ router.get('/memory', agentRuntimeAuth, async (req: any, res: any) => {
 
 /**
  * PUT /memory (agent runtime token auth)
- * Write this agent's personal MEMORY.md (overwrites full content)
+ * Accepts v1 (`{ content }`) or v2 (`{ sections, sourceRuntime? }`) or both.
+ *
+ * Semantics:
+ * - Sections are MERGED per-key. Sibling sections the caller did not include
+ *   are preserved (e.g. writing just `dedup_state` leaves `long_term` alone).
+ * - `content` is mirrored from `sections.long_term.content` only when the
+ *   caller actually supplied `long_term` AND did not also supply an explicit
+ *   `content`. Otherwise existing `content` is untouched.
+ * - `schemaVersion` is server-set to 2 whenever sections are written; not
+ *   client-supplied. Phase 2 (/memory/sync) introduces explicit mode flags.
  */
 router.put('/memory', agentRuntimeAuth, async (req: any, res: any) => {
   try {
-    const agentInstallation = req.agentInstallation;
-    const agentName =
-      agentInstallation?.agentName ||
-      req.agentUser?.botMetadata?.agentName ||
-      req.agentUser?.username;
-    const instanceId =
-      agentInstallation?.instanceId ||
-      req.agentUser?.botMetadata?.instanceId ||
-      'default';
+    const { agentName, instanceId } = resolveMemoryIdentity(req);
     if (!agentName) {
       return res.status(403).json({ message: 'Could not resolve agent identity' });
     }
-    const { content } = req.body || {};
-    if (typeof content !== 'string') {
+    const { content, sections, sourceRuntime } = req.body || {};
+    if (content === undefined && sections === undefined) {
+      return res.status(400).json({ message: 'must provide content or sections' });
+    }
+    if (content !== undefined && typeof content !== 'string') {
       return res.status(400).json({ message: 'content must be a string' });
     }
+    if (sections !== undefined) {
+      const sectionsError = validateSectionsPayload(sections);
+      if (sectionsError) return res.status(400).json({ message: sectionsError });
+    }
+    if (sourceRuntime !== undefined && typeof sourceRuntime !== 'string') {
+      return res.status(400).json({ message: 'sourceRuntime must be a string' });
+    }
+
+    const setOps: Record<string, unknown> = {};
+    if (sections !== undefined) {
+      // Per-key merge via dotted $set paths — preserves sibling sections the
+      // caller didn't include in this write.
+      for (const key of Object.keys(sections)) {
+        setOps[`sections.${key}`] = sections[key];
+      }
+      setOps.schemaVersion = 2;
+      if (content === undefined && sections.long_term !== undefined) {
+        setOps.content = mirrorContentFromSections(sections);
+      }
+    }
+    if (content !== undefined) setOps.content = content;
+    if (sourceRuntime !== undefined) setOps.sourceRuntime = sourceRuntime;
+
     await AgentMemory.findOneAndUpdate(
       { agentName, instanceId },
-      { content, updatedAt: new Date() },
-      { upsert: true, new: true },
+      { $set: setOps },
+      { upsert: true, new: true, setDefaultsOnInsert: true },
     );
+    console.log('[agent-memory PUT]', {
+      agentName,
+      instanceId,
+      sectionKeys: sections ? Object.keys(sections) : [],
+      contentProvided: content !== undefined,
+      sourceRuntime,
+    });
     return res.json({ ok: true });
   } catch (err: any) {
     console.error('PUT /memory error:', err);

--- a/backend/scripts/backfill-agent-memory-sections.ts
+++ b/backend/scripts/backfill-agent-memory-sections.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/*
+ * ADR-003 Phase 1 backfill. For each AgentMemory record that has v1 `content`
+ * but no `sections`, parse the content into `sections.long_term` +
+ * `sections.dedup_state` and save. Idempotent: records already carrying
+ * sections are skipped. Dry-run with `--dry`. Safe to run multiple times.
+ */
+
+import mongoose from 'mongoose';
+import AgentMemory from '../models/AgentMemory';
+import { buildSectionsFromLegacyContent } from '../services/agentMemoryService';
+
+interface BackfillResult {
+  total: number;
+  migrated: number;
+  skipped: number;
+  empty: number;
+}
+
+export async function backfillAgentMemorySections(
+  options: { dryRun?: boolean } = {},
+): Promise<BackfillResult> {
+  const dryRun = options.dryRun === true;
+  const result: BackfillResult = { total: 0, migrated: 0, skipped: 0, empty: 0 };
+
+  const cursor = AgentMemory.find({}).cursor();
+  for await (const doc of cursor) {
+    result.total += 1;
+
+    // A record is considered already-migrated if any concrete section exists.
+    // Checking `Object.keys(sections).length > 0` misclassifies a stray empty
+    // `sections: {}` sub-doc as migrated; check specific section fields instead.
+    const s = doc.sections;
+    const alreadyMigrated = !!(
+      s && (
+        s.long_term || s.dedup_state || s.soul || s.shared || s.runtime_meta
+        || (Array.isArray(s.daily) && s.daily.length > 0)
+        || (Array.isArray(s.relationships) && s.relationships.length > 0)
+      )
+    );
+    if (alreadyMigrated) {
+      result.skipped += 1;
+      continue;
+    }
+
+    if (!doc.content || !doc.content.trim()) {
+      result.empty += 1;
+      continue;
+    }
+
+    const sections = buildSectionsFromLegacyContent(doc.content, doc.updatedAt || new Date());
+    if (Object.keys(sections).length === 0) {
+      result.empty += 1;
+      continue;
+    }
+
+    if (!dryRun) {
+      doc.sections = sections;
+      // Leave `sourceRuntime` unset — the first real post-migration write
+      // will populate it with the driver's own identifier (ADR-003 §Runtime
+      // driver expectations). `'legacy'` is not an ADR-recognized runtime.
+      doc.schemaVersion = doc.schemaVersion ?? 2;
+      await doc.save();
+    }
+    result.migrated += 1;
+  }
+
+  return result;
+}
+
+// Only run when invoked directly (node/ts-node), not when imported by tests.
+if (require.main === module) {
+  const dryRun = process.argv.includes('--dry');
+  const uri = process.env.MONGO_URI;
+  if (!uri) {
+    console.error('MONGO_URI is required.');
+    process.exit(1);
+  }
+  (async () => {
+    await mongoose.connect(uri);
+    try {
+      const r = await backfillAgentMemorySections({ dryRun });
+      console.log(
+        `AgentMemory backfill ${dryRun ? '(dry-run) ' : ''}`
+        + `total=${r.total} migrated=${r.migrated} skipped=${r.skipped} empty=${r.empty}`,
+      );
+    } finally {
+      await mongoose.disconnect();
+    }
+  })().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/backend/services/agentMemoryService.ts
+++ b/backend/services/agentMemoryService.ts
@@ -1,0 +1,116 @@
+import type {
+  IAgentMemorySections,
+  IMemorySection,
+  MemoryVisibility,
+} from '../models/AgentMemory';
+
+// ADR-003 Phase 1: parse legacy v1 `content` blobs into a v2 section envelope.
+// The parser splits markdown on top-level `## ` headers and buckets each
+// section into `dedup_state` (if the header name matches a known dedup tag)
+// or `long_term` (everything else, including the preamble above the first
+// header). Unknown shape is preserved verbatim — the kernel does not try to
+// understand markdown beyond finding section boundaries.
+
+// Dedup section names emitted by OpenClaw heartbeat templates today — see
+// `backend/routes/registry/presets.ts` HEARTBEAT.md content for the authoritative
+// list. When Phase 2 heartbeat changes add or rename a header, update here.
+// Match is case-insensitive and non-alphanumeric-stripped (see normalizeHeader).
+const DEDUP_HEADERS = new Set(
+  [
+    'commented',
+    'replied',
+    'repliedmsgs',
+    'podvisits',
+    'stalerevivalat',
+  ],
+);
+
+const HEADER_LINE = /^## +(.+?)\s*$/gm;
+
+interface ParsedSections {
+  long_term: string;
+  dedup_state: string;
+}
+
+function normalizeHeader(raw: string): string {
+  return raw.replace(/[^a-z0-9]/gi, '').toLowerCase();
+}
+
+function byteSize(s: string): number {
+  return Buffer.byteLength(s, 'utf8');
+}
+
+function makeSection(
+  content: string,
+  visibility: MemoryVisibility = 'private',
+  updatedAt: Date = new Date(),
+): IMemorySection {
+  return {
+    content,
+    visibility,
+    updatedAt,
+    byteSize: byteSize(content),
+  };
+}
+
+export function parseContentIntoSections(content: string): ParsedSections {
+  if (!content || !content.trim()) {
+    return { long_term: '', dedup_state: '' };
+  }
+
+  const matches: { header: string; start: number; end: number }[] = [];
+  for (const m of content.matchAll(HEADER_LINE)) {
+    const start = m.index ?? 0;
+    matches.push({ header: m[1], start, end: start + m[0].length });
+  }
+
+  if (matches.length === 0) {
+    return { long_term: content, dedup_state: '' };
+  }
+
+  const longTermChunks: string[] = [];
+  const dedupChunks: string[] = [];
+
+  // Preamble before the first header is always long_term.
+  if (matches[0].start > 0) {
+    longTermChunks.push(content.slice(0, matches[0].start));
+  }
+
+  for (let i = 0; i < matches.length; i++) {
+    const { header, start } = matches[i];
+    const nextStart = i + 1 < matches.length ? matches[i + 1].start : content.length;
+    const block = content.slice(start, nextStart);
+    if (DEDUP_HEADERS.has(normalizeHeader(header))) {
+      dedupChunks.push(block);
+    } else {
+      longTermChunks.push(block);
+    }
+  }
+
+  return {
+    long_term: longTermChunks.join('').replace(/\n+$/, ''),
+    dedup_state: dedupChunks.join('').replace(/\n+$/, ''),
+  };
+}
+
+// Build a sections envelope from a legacy v1 `content` string. Returns the
+// sections object the model will accept directly.
+export function buildSectionsFromLegacyContent(
+  content: string,
+  now: Date = new Date(),
+): IAgentMemorySections {
+  const { long_term, dedup_state } = parseContentIntoSections(content);
+  const sections: IAgentMemorySections = {};
+  if (long_term) sections.long_term = makeSection(long_term, 'private', now);
+  if (dedup_state) sections.dedup_state = makeSection(dedup_state, 'private', now);
+  return sections;
+}
+
+// When a v2 caller writes sections, mirror `long_term.content` back into the
+// `content` field so v1 readers of GET /memory still see their data. If
+// there's no long_term, leave content empty.
+export function mirrorContentFromSections(
+  sections: IAgentMemorySections | undefined,
+): string {
+  return sections?.long_term?.content ?? '';
+}


### PR DESCRIPTION
## Summary

ADR-003 Phase 1: extend the \`AgentMemory\` kernel primitive with an optional, typed v2 section envelope alongside the existing v1 \`content\` blob. Strictly additive — v1 callers are untouched. Phase 2 (new \`/memory/sync\` endpoint + \`commonly_ask_agent\` / \`commonly_read_my_memory\` tools) is a separate change.

50 new tests; 664/664 backend tests pass locally.

## Why

Per ADR-003, agent memory is a CAP kernel primitive. Phase 1 shapes the storage layer so every future runtime driver — OpenClaw, native, webhook, Vercel cloud agent, BYO — can promote into the same envelope without reshuffling the kernel schema later.

## What's in

### Model (\`backend/models/AgentMemory.ts\`)
- Optional \`sections\` sub-document: \`soul | long_term | daily[] | dedup_state | relationships[] | shared | runtime_meta\`
- Each section: \`content\`, \`visibility\` (\`private | pod | public\`, default \`private\`), \`updatedAt\`, \`byteSize\`
- Optional \`sourceRuntime\`, \`schemaVersion\` scalars
- \`(agentName, instanceId)\` unique index unchanged — ADR-003 invariant #1
- Every section uses \`default: undefined\` so fresh records don't auto-insert empty sub-docs
- \`VISIBILITY_VALUES\` exported as single source of truth

### Service (\`backend/services/agentMemoryService.ts\`) — new
- Pure parser: \`parseContentIntoSections\`, \`buildSectionsFromLegacyContent\`, \`mirrorContentFromSections\`
- Splits legacy \`content\` on \`## \` headers; known dedup names (Commented/Replied/RepliedMsgs/PodVisits/StaleRevivalAt, sourced from registry heartbeat templates) bucket into \`dedup_state\`

### Routes (GET/PUT \`/memory\`)
- GET always returns \`{ content, sections, sourceRuntime, schemaVersion }\`
- PUT accepts v1 or v2 or both. **Sections merge per-key via dotted \`\$set\` paths** — partial writes preserve siblings. \`content\` is mirrored from \`sections.long_term.content\` only when the caller explicitly supplied \`long_term\` AND didn't also send an explicit \`content\`
- \`schemaVersion\` server-set to 2 when sections are written (not client-supplied — Phase 2's \`/memory/sync\` adds explicit mode flags)
- Rejects unknown section names, empty \`sections: {}\`, invalid visibility, malformed entries
- Structured log line per write for kernel-surface observability

### Backfill (\`backend/scripts/backfill-agent-memory-sections.ts\`) — new
- One-shot, idempotent, cursor-based. Parses v1 content into sections for records without any concrete section field. Preserves the v1 blob
- \`--dry\` flag. Returns \`{ total, migrated, skipped, empty }\`
- Leaves \`sourceRuntime\` unset; first real post-migration write populates with the driver's own identifier (ADR-003 §Runtime driver expectations — \`'legacy'\` is not an ADR-recognized runtime)

## Code review

Reviewed by the \`code-reviewer\` subagent against \`docs/REVIEW.md\` **before commit**. Critical finding: the initial PUT handler did a full \`\$set\` on \`sections\`, which would have silently wiped sibling sections and blanked \`content\` on any partial-sections write. Fixed by switching to per-key dotted \`\$set\` paths and gating the \`content\` mirror on the presence of \`long_term\` in the request. Five regression tests added to lock the fix.

Other review feedback addressed in the same commit:
- Reject empty \`sections: {}\` and unknown section names (validation gaps)
- Server-set \`schemaVersion\` instead of client-supplied (reduces surface area)
- Shared \`VISIBILITY_VALUES\` between model and route (drift prevention)
- Kernel-surface observability log on every write
- Backfill skip check on specific section keys, not \`Object.keys\` length (robustness if stray empty sections ever land)
- Dropped \`sourceRuntime: 'legacy'\` default from backfill

## Changes

- \`backend/models/AgentMemory.ts\` (extended — backwards compatible)
- \`backend/routes/agentsRuntime.ts\` (GET/PUT /memory handlers)
- \`backend/services/agentMemoryService.ts\` (new)
- \`backend/scripts/backfill-agent-memory-sections.ts\` (new)
- \`backend/__tests__/unit/models/AgentMemory.test.ts\` (11 tests)
- \`backend/__tests__/unit/services/agentMemoryService.test.ts\` (15 tests)
- \`backend/__tests__/integration/agent-memory-envelope.test.js\` (24 tests)

## Test plan

- [x] All 50 new tests pass locally
- [x] Full backend suite 664/664 passing
- [x] Lint: no new errors introduced by Phase 1 files (baseline unchanged)
- [x] TypeScript: no new errors in modified/new files
- [x] Reviewer agent pass with fixes applied
- [ ] CI green
- [ ] Post-merge: run backfill on dev (\`node backend/scripts/backfill-agent-memory-sections.js --dry\` first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)