### PR TITLE
fix(agent-memory): server-stamp byteSize + updatedAt on PUT /memory

### DIFF
--- a/backend/__tests__/integration/agent-memory-envelope.test.js
+++ b/backend/__tests__/integration/agent-memory-envelope.test.js
@@ -296,6 +296,100 @@ describe('AgentMemory envelope — GET/PUT /memory + backfill', () => {
       expect(get.body.schemaVersion).toBe(2);
     });
 
+    it('server-stamps byteSize from content and ignores client-supplied values', async () => {
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({
+          sections: {
+            long_term: { content: '😀 hi', byteSize: 9999, updatedAt: '2000-01-01T00:00:00Z' },
+          },
+        })
+        .expect(200);
+      const get = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      expect(get.body.sections.long_term.byteSize).toBe(Buffer.byteLength('😀 hi', 'utf8'));
+      const updatedAt = new Date(get.body.sections.long_term.updatedAt);
+      expect(Date.now() - updatedAt.getTime()).toBeLessThan(60_000);
+    });
+
+    it('array sections (relationships, daily) are whole-array replace — Phase 1 intentional', async () => {
+      // Seed two relationships.
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({
+          sections: {
+            relationships: [
+              { otherInstanceId: 'nova', notes: 'met in dev' },
+              { otherInstanceId: 'theo', notes: 'pr review' },
+            ],
+          },
+        })
+        .expect(200);
+
+      // Partial resend with ONE relationship — old entries are replaced, not merged.
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({
+          sections: { relationships: [{ otherInstanceId: 'liz', notes: 'new' }] },
+        })
+        .expect(200);
+
+      const get = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      const ids = (get.body.sections.relationships || []).map((r) => r.otherInstanceId);
+      expect(ids).toEqual(['liz']); // nova and theo are intentionally replaced
+    });
+
+    it('sending long_term with empty content blanks the v1 content mirror (deliberate clear)', async () => {
+      // Seed long_term with content so v1 mirror is non-empty.
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ sections: { long_term: { content: 'seeded' } } })
+        .expect(200);
+
+      // Explicit clear.
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ sections: { long_term: { content: '' } } })
+        .expect(200);
+
+      const get = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      expect(get.body.content).toBe('');
+      expect(get.body.sections.long_term.content).toBe('');
+      expect(get.body.sections.long_term.byteSize).toBe(0);
+    });
+
+    it('stamps byteSize per section when multiple sections arrive in one write', async () => {
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({
+          sections: {
+            long_term: { content: 'abcd' },
+            shared: { content: 'hi', visibility: 'public' },
+            dedup_state: { content: '## Commented\n{}' },
+          },
+        })
+        .expect(200);
+      const get = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      expect(get.body.sections.long_term.byteSize).toBe(4);
+      expect(get.body.sections.shared.byteSize).toBe(2);
+      expect(get.body.sections.dedup_state.byteSize).toBe(
+        Buffer.byteLength('## Commented\n{}', 'utf8'),
+      );
+    });
+
     it('preserves sibling sections when a partial sections write lands', async () => {
       // Seed with long_term + shared + v1 content.
       await request(app)

--- a/backend/__tests__/unit/services/agentMemoryService.test.ts
+++ b/backend/__tests__/unit/services/agentMemoryService.test.ts
@@ -6,6 +6,7 @@ const {
   parseContentIntoSections,
   buildSectionsFromLegacyContent,
   mirrorContentFromSections,
+  stampSectionsForWrite,
 } = require('../../../services/agentMemoryService');
 
 describe('parseContentIntoSections', () => {
@@ -133,5 +134,94 @@ describe('mirrorContentFromSections', () => {
     expect(mirrorContentFromSections(undefined)).toBe('');
     expect(mirrorContentFromSections({})).toBe('');
     expect(mirrorContentFromSections({ dedup_state: { content: 'x' } })).toBe('');
+  });
+});
+
+describe('stampSectionsForWrite', () => {
+  const FIXED = new Date('2026-04-14T12:00:00Z');
+
+  it('stamps updatedAt and byteSize on single-object sections', () => {
+    const out = stampSectionsForWrite({
+      long_term: { content: 'hello' },
+    }, FIXED);
+    expect(out.long_term.content).toBe('hello');
+    expect(out.long_term.updatedAt).toEqual(FIXED);
+    expect(out.long_term.byteSize).toBe(5);
+    expect(out.long_term.visibility).toBe('private');
+  });
+
+  it('computes byteSize in utf-8 bytes for multi-byte content', () => {
+    const out = stampSectionsForWrite({ long_term: { content: '😀 hi' } }, FIXED);
+    expect(out.long_term.byteSize).toBe(Buffer.byteLength('😀 hi', 'utf8'));
+  });
+
+  it('overrides client-supplied byteSize and updatedAt', () => {
+    const out = stampSectionsForWrite({
+      long_term: {
+        content: 'x',
+        byteSize: 9999,
+        updatedAt: new Date('2000-01-01'),
+      },
+    }, FIXED);
+    expect(out.long_term.byteSize).toBe(1);
+    expect(out.long_term.updatedAt).toEqual(FIXED);
+  });
+
+  it('preserves caller-supplied visibility', () => {
+    const out = stampSectionsForWrite({
+      shared: { content: 'bio', visibility: 'public' },
+    }, FIXED);
+    expect(out.shared.visibility).toBe('public');
+  });
+
+  it('defaults visibility to private when omitted', () => {
+    const out = stampSectionsForWrite({
+      long_term: { content: 'x' },
+    }, FIXED);
+    expect(out.long_term.visibility).toBe('private');
+  });
+
+  it('only stamps sections present in input (no sibling creation)', () => {
+    const out = stampSectionsForWrite({ dedup_state: { content: 'x' } }, FIXED);
+    expect(out.dedup_state).toBeDefined();
+    expect(out.long_term).toBeUndefined();
+    expect(out.shared).toBeUndefined();
+    expect(out.soul).toBeUndefined();
+  });
+
+  it('stamps daily entries without byteSize/updatedAt (per ADR shape)', () => {
+    const out = stampSectionsForWrite({
+      daily: [{ date: '2026-04-14', content: 'today', visibility: 'pod' }],
+    }, FIXED);
+    expect(out.daily).toHaveLength(1);
+    expect(out.daily[0].date).toBe('2026-04-14');
+    expect(out.daily[0].content).toBe('today');
+    expect(out.daily[0].visibility).toBe('pod');
+    expect(out.daily[0].byteSize).toBeUndefined();
+    expect(out.daily[0].updatedAt).toBeUndefined();
+  });
+
+  it('stamps relationships entries with updatedAt but no byteSize', () => {
+    const out = stampSectionsForWrite({
+      relationships: [
+        { otherInstanceId: 'nova', notes: 'met in dev', updatedAt: new Date('2000-01-01') },
+      ],
+    }, FIXED);
+    expect(out.relationships).toHaveLength(1);
+    expect(out.relationships[0].otherInstanceId).toBe('nova');
+    expect(out.relationships[0].updatedAt).toEqual(FIXED);
+    expect(out.relationships[0].byteSize).toBeUndefined();
+  });
+
+  it('is idempotent under same `now` — repeated stamping yields equivalent output (covers object + array sections)', () => {
+    const input = {
+      long_term: { content: 'x' },
+      dedup_state: { content: '## Commented\n{}' },
+      daily: [{ date: '2026-04-14', content: 'today', visibility: 'private' }],
+      relationships: [{ otherInstanceId: 'nova', notes: 'n' }],
+    };
+    const a = stampSectionsForWrite(input, FIXED);
+    const b = stampSectionsForWrite(a, FIXED);
+    expect(b).toEqual(a);
   });
 });

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -21,7 +21,7 @@ const { requireApiTokenScopes } = require('../middleware/apiTokenScopes');
 
 const Integration = require('../models/Integration');
 const AgentMemory = require('../models/AgentMemory');
-const { mirrorContentFromSections } = require('../services/agentMemoryService');
+const { mirrorContentFromSections, stampSectionsForWrite } = require('../services/agentMemoryService');
 const DMService = require('../services/dmService');
 const ChatSummarizerService = require('../services/chatSummarizerService');
 const AgentMentionService = require('../services/agentMentionService');
@@ -1283,13 +1283,24 @@ router.get('/memory', agentRuntimeAuth, async (req: any, res: any) => {
  * Accepts v1 (`{ content }`) or v2 (`{ sections, sourceRuntime? }`) or both.
  *
  * Semantics:
- * - Sections are MERGED per-key. Sibling sections the caller did not include
- *   are preserved (e.g. writing just `dedup_state` leaves `long_term` alone).
+ * - Single-object sections (`soul | long_term | dedup_state | shared |
+ *   runtime_meta`) are MERGED per-key. Sibling sections the caller did not
+ *   include are preserved (e.g. writing just `dedup_state` leaves
+ *   `long_term` alone).
+ * - Array sections (`daily`, `relationships`) are **whole-array replace**.
+ *   Sending `{ relationships: [...] }` replaces the entire stored array.
+ *   Phase 2's POST /memory/sync with `mode: 'patch'` will add element-level
+ *   merge. Callers that need to add a single entry must resend the full
+ *   array for now.
  * - `content` is mirrored from `sections.long_term.content` only when the
  *   caller actually supplied `long_term` AND did not also supply an explicit
- *   `content`. Otherwise existing `content` is untouched.
+ *   `content`. Sending `{ sections: { long_term: { content: '' } } }` is a
+ *   deliberate clear and will blank `content`. Otherwise existing `content`
+ *   is untouched.
  * - `schemaVersion` is server-set to 2 whenever sections are written; not
  *   client-supplied. Phase 2 (/memory/sync) introduces explicit mode flags.
+ * - `byteSize` and `updatedAt` are always server-stamped via
+ *   `stampSectionsForWrite`; client-supplied values are discarded.
  */
 router.put('/memory', agentRuntimeAuth, async (req: any, res: any) => {
   try {
@@ -1314,14 +1325,16 @@ router.put('/memory', agentRuntimeAuth, async (req: any, res: any) => {
 
     const setOps: Record<string, unknown> = {};
     if (sections !== undefined) {
+      // Server-stamp byteSize + updatedAt so clients can't fabricate them.
+      const stamped = stampSectionsForWrite(sections);
       // Per-key merge via dotted $set paths — preserves sibling sections the
       // caller didn't include in this write.
-      for (const key of Object.keys(sections)) {
-        setOps[`sections.${key}`] = sections[key];
+      for (const key of Object.keys(stamped)) {
+        setOps[`sections.${key}`] = (stamped as any)[key];
       }
       setOps.schemaVersion = 2;
-      if (content === undefined && sections.long_term !== undefined) {
-        setOps.content = mirrorContentFromSections(sections);
+      if (content === undefined && stamped.long_term !== undefined) {
+        setOps.content = mirrorContentFromSections(stamped);
       }
     }
     if (content !== undefined) setOps.content = content;

--- a/backend/services/agentMemoryService.ts
+++ b/backend/services/agentMemoryService.ts
@@ -1,6 +1,8 @@
 import type {
   IAgentMemorySections,
+  IDailySection,
   IMemorySection,
+  IRelationshipNote,
   MemoryVisibility,
 } from '../models/AgentMemory';
 
@@ -113,4 +115,55 @@ export function mirrorContentFromSections(
   sections: IAgentMemorySections | undefined,
 ): string {
   return sections?.long_term?.content ?? '';
+}
+
+// Server-stamp metadata the caller shouldn't be trusted to compute: `byteSize`
+// (derived from `content`) and `updatedAt` (now). Callers supply `content` +
+// `visibility`; everything else is enforced server-side. Only stamps the
+// sections actually present in the input — the per-key merge in PUT /memory
+// preserves siblings, so siblings keep their previous stamp.
+//
+// Phase 1 array-section semantics (`daily`, `relationships`) are **whole-array
+// replace**: sending `{ relationships: [...] }` replaces the entire stored
+// array with the one in the payload, and every entry gets `updatedAt = now`.
+// This is consistent with the way the per-key dotted-$set merge in the PUT
+// handler stores arrays. A client that wants to add one entry must currently
+// resend all pre-existing entries. Phase 2's POST /memory/sync with explicit
+// `mode: 'patch'` will introduce key-level merge (by `otherInstanceId` /
+// `date`). Until then, if you need element-level freshness, don't persist
+// relationships via this endpoint.
+export function stampSectionsForWrite(
+  sections: IAgentMemorySections,
+  now: Date = new Date(),
+): IAgentMemorySections {
+  const out: IAgentMemorySections = {};
+  // Cast is safe here: validateSectionsPayload in the route rejects any key
+  // outside the allowed set before we get here.
+  for (const key of Object.keys(sections) as (keyof IAgentMemorySections)[]) {
+    const v = sections[key];
+    if (v === undefined) continue;
+
+    if (key === 'daily') {
+      out.daily = ((v as IDailySection[]) || []).map((d): IDailySection => ({
+        date: d.date,
+        content: d.content ?? '',
+        visibility: (d.visibility ?? 'private') as MemoryVisibility,
+      }));
+      continue;
+    }
+
+    if (key === 'relationships') {
+      out.relationships = ((v as IRelationshipNote[]) || []).map((r): IRelationshipNote => ({
+        otherInstanceId: r.otherInstanceId,
+        notes: r.notes ?? '',
+        visibility: (r.visibility ?? 'private') as MemoryVisibility,
+        updatedAt: now,
+      }));
+      continue;
+    }
+
+    const s = v as IMemorySection;
+    out[key] = makeSection(s.content ?? '', s.visibility ?? 'private', now);
+  }
+  return out;
 }


### PR DESCRIPTION
## Summary

Follow-up to ADR-003 Phase 1 (#188). Production smoke test surfaced \`byteSize: 0\` in GET /memory responses because the route was trusting client-supplied metadata. This patch stamps \`byteSize\` (UTF-8 byte length of \`content\`) and \`updatedAt\` (now) server-side on every section write; client-supplied values for these fields are discarded. Also defaults missing \`visibility\` to \`'private'\` at the write layer so ADR-003 invariant #2 ("Private by default") is enforced both schema-side and route-side.

## Scope (strict)

- **Server-stamp** \`byteSize\` + \`updatedAt\` on single-object sections (\`soul | long_term | dedup_state | shared | runtime_meta\`)
- **Server-stamp** \`updatedAt\` on \`relationships[]\` entries
- **Don't stamp** \`daily[]\` entries (no byteSize/updatedAt per ADR shape)
- **Document** the whole-array-replace semantics for \`daily\` / \`relationships\` — Phase 2's \`/memory/sync\` with \`mode: 'patch'\` will add element-level merge keyed by \`date\` / \`otherInstanceId\`
- **Document** that \`sections: { long_term: { content: '' } }\` is an intentional clear that blanks the v1 mirror

## Changes

- \`backend/services/agentMemoryService.ts\` — \`stampSectionsForWrite(sections, now?)\`. Object sections routed through \`makeSection\`; array sections whole-replaced with per-entry stamp on relationships
- \`backend/routes/agentsRuntime.ts\` PUT \`/memory\` — call the stamper before per-key \`\$set\` merge; expanded docstring codifies merge semantics
- Tests (13 new; 63/63 agent-memory tests pass)

## Reviewer findings addressed

Reviewed by the \`code-reviewer\` subagent pre-commit. Verdict: **Approve with suggestions**. Applied fixes:

- Locked whole-array replace semantics for \`relationships\`/\`daily\` with a test (Important #2) — intentional Phase 1 scope; \`/memory/sync\` adds merge in Phase 2
- Refactored helper to use \`makeSection\` instead of inlining (Nit)
- Added comment explaining the TS cast on \`Object.keys(sections)\` relies on upstream validation (Nit)
- Extended idempotence test to cover \`daily\` + \`relationships\` (Nit)
- Added integration test locking the "empty \`long_term.content\` clears v1 mirror" semantics (Q5)

## Follow-ups deliberately deferred

- Per-entry freshness for \`relationships\` (stamp only when content changes) — needs Phase 2 \`/memory/sync\` patch mode to be meaningful
- Date shape validation (\`'YYYY-MM-DD'\`) on \`daily[]\` entries — will land with \`/memory/sync\` validator

## Test plan

- [x] 63/63 agent-memory tests pass locally
- [x] Reviewer agent pass with all suggestions addressed
- [ ] CI green
- [ ] Post-merge: rebuild backend, helm upgrade, verify \`byteSize\` non-zero in live GET

🤖 Generated with [Claude Code](https://claude.com/claude-code)