### PR TITLE
chore(agent-memory): ADR-003 Phase 2b — bump openclaw + gateway tag

### DIFF
--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -13,7 +13,7 @@ backend:
   replicaCount: 1
   image:
     repository: gcr.io/YOUR_GCP_PROJECT_ID/commonly-backend
-    tag: "pr185b-20260413234302"
+    tag: "20260414125715"
     pullPolicy: Always  # Always pull in dev
   nodeSelector:
     pool: dev
@@ -99,7 +99,7 @@ agents:
     enabled: true
     image:
       repository: gcr.io/YOUR_GCP_PROJECT_ID/clawdbot-gateway
-      tag: "20260412043233"
+      tag: "20260414192025"
       pullPolicy: Always
     strategy:
       type: Recreate


### PR DESCRIPTION
## Summary

Phase 2b deployment artifacts — submodule pointer + values bump for the new OpenClaw tool shims (\`commonly_read_my_memory\`, \`commonly_save_my_memory\`) that wrap the Phase 2a \`POST /memory/sync\` kernel endpoint.

- \`_external/clawdbot\` → \`826d46475\` (Team-Commonly/openclaw \`rebase-2026.3.29\`)
- \`agents.clawdbot.image.tag\` → \`20260414192025\` (gateway image with the new tools)
- \`backend.image.tag\` → \`20260414125715\` (Phase 2a, already deployed; committing in-tree value to match live)

## Tool work in the submodule

Already pushed to \`Team-Commonly/openclaw rebase-2026.3.29\` at \`826d46475\`. Highlights:

- New typed envelope types in \`extensions/commonly/src/client.ts\` + new \`syncAgentMemory(sections, { mode, sourceRuntime })\` method
- New \`commonly_read_my_memory({ section? })\` tool — returns full envelope or one validated section
- New \`commonly_save_my_memory({ section, content?, visibility?, entries? })\` tool — patch-mode sync; siblings preserved; daily merges by date; relationships by otherInstanceId
- Visibility defaults to \`private\` at the tool layer (ADR-003 invariant #2 enforced on the wire, not just server-side)
- Section names validated against \`MemorySectionName\` — typos rejected with structured error
- \`entries\` + \`content\` conflict rejected up-front (no silent drops)
- Kernel 4xx caught and returned as \`{ ok:false, error:'kernel rejected: ...' }\`
- Old \`commonly_read_agent_memory\` / \`commonly_write_agent_memory\` untouched (per ADR §Phase 2 "Old tools remain as thin wrappers")
- 5 new client tests; 20/20 ext tests pass locally

## Reviewer findings (pre-commit on submodule)

Verdict was Approve with suggestions; all 5 Important + relevant Nits applied before commit. No Critical.

## Test plan

- [x] 20/20 commonly extension vitest tests pass locally
- [x] Gateway image \`clawdbot-gateway:20260414192025\` built + pushed
- [ ] CI green
- [ ] Post-merge: helm upgrade to revision 58, verify the new tools appear in agent session jsonl, live-test \`commonly_save_my_memory\` end-to-end via one agent

## Deferred to Phase 2c

- \`commonly_ask_agent\` — cross-agent mediated DM, needs a new backend primitive
- \`commonly_read_shared_memory\` — needs visibility-filtering read endpoint (Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)