### PR TITLE
docs(adr): ADR-004 (CAP) + ADR-005 (local-CLI wrapper) + ADR-006 (webhook SDK); amend ADR-003

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,9 @@ Commonly is collapsing the legacy `App` + `AgentRegistry` split into a single `I
 - **ADR-001 Installable Taxonomy**: `/docs/adr/ADR-001-installable-taxonomy.md` — the single-table model, component types, scopes, phases
 - **ADR-002 Attachments & Object Storage**: `/docs/adr/ADR-002-attachments-and-object-storage.md`
 - **ADR-003 Memory as Kernel Primitive**: `/docs/adr/ADR-003-memory-as-kernel-primitive.md`
+- **ADR-004 Commonly Agent Protocol (CAP)**: `/docs/adr/ADR-004-commonly-agent-protocol.md` — the four-verb driver-facing surface; required reading before any driver work
+- **ADR-005 Local CLI Wrapper Driver**: `/docs/adr/ADR-005-local-cli-wrapper-driver.md` — `commonly agent attach <cli>` + adapter pattern
+- **ADR-006 Webhook SDK + Self-Serve Install**: `/docs/adr/ADR-006-webhook-sdk-and-self-serve-install.md` — reference SDK + self-serve webhook install
 - **Summarizer & Agents**: `/docs/SUMMARIZER_AND_AGENTS.md`
 - **Discord Integration**: `/docs/DISCORD_INTEGRATION_ARCHITECTURE.md`
 - **PostgreSQL Migration**: `/docs/POSTGRESQL_MIGRATION.md`

--- a/docs/adr/ADR-003-memory-as-kernel-primitive.md
+++ b/docs/adr/ADR-003-memory-as-kernel-primitive.md
@@ -1,9 +1,18 @@
 # ADR-003: Memory as a Kernel Primitive
 
-**Status:** Draft — 2026-04-14
+**Status:** Accepted — 2026-04-14 (Phases 1, 1.1, 2a, 2b shipped to `commonly-dev`)
 **Author:** Lily Shen
 **Supersedes:** (none — amends the ad-hoc implementation in `backend/models/AgentMemory.ts` and `backend/routes/agentsRuntime.ts`)
-**Companion:** [`docs/COMMONLY_SCOPE.md`](../COMMONLY_SCOPE.md), [`ADR-001`](ADR-001-installable-taxonomy.md)
+**Companion:** [`docs/COMMONLY_SCOPE.md`](../COMMONLY_SCOPE.md), [`ADR-001`](ADR-001-installable-taxonomy.md), [`ADR-004`](ADR-004-commonly-agent-protocol.md), [`ADR-005`](ADR-005-local-cli-wrapper-driver.md), [`ADR-006`](ADR-006-webhook-sdk-and-self-serve-install.md)
+
+## Revision history
+
+- **2026-04-14 (initial draft):** envelope schema, POST `/memory/sync`, 5-phase migration.
+- **2026-04-14 (post-Phase-2b amendment):** corrections from what actually shipped, and driver-coupling corrections.
+  - **Shipped to `commonly-dev`**: Phase 1 (v2 schema + backfill, PR #188), Phase 1.1 (server-stamp `byteSize` + `updatedAt`, PR #189), Phase 2a (`POST /memory/sync` with mode + dedup, PR #191), Phase 2b (OpenClaw `commonly_read_my_memory` + `commonly_save_my_memory` tool shims as the first driver consumer, PR #192).
+  - **New invariants named (8–11 below)**: cross-writer dedup invalidation; server-stamped `byteSize` / `updatedAt` / `schemaVersion`; canonical-stringify dedup keys; array-section merge is mode-dependent.
+  - **Phase 3 reframed driver-agnostic** (was "OpenClaw driver promotion"). Driver-side promotion is delegated to the per-driver ADRs: ADR-005 (local CLI wrapper) and ADR-006 (webhook SDK). OpenClaw's HEARTBEAT-template update, if done, is one OpenClaw-internal task among many, not a gate on other drivers.
+  - **Kernel-coupling to OpenClaw deliberately removed** — drivers land via ADR-005 and ADR-006 alongside the existing OpenClaw driver, not ahead of it.
 
 ---
 
@@ -155,16 +164,19 @@ The existing `GET /memory` / `PUT /memory` endpoints remain for v1 compatibility
 
 ### Tool surface
 
-OpenClaw `commonly.*` tool extension gains four tools, retires none:
+Tools are driver-local. The surface below is what a driver SHOULD expose to an agent running under it; each driver implements these by calling the kernel HTTP surface (ADR-004). The first four are required; the last two are Phase 4.
 
-| Tool | Purpose |
-|---|---|
-| `commonly_read_my_memory(section?)` | Replaces `commonly_read_agent_memory`. Reads this agent's envelope. Optional `section` param returns just one. |
-| `commonly_save_my_memory(section, content, visibility?)` | Replaces `commonly_save_agent_memory`. Writes one section. Visibility defaults to current (or `private` if new). |
-| `commonly_ask_agent(instanceId, question)` | Structured DM — owner agent receives and mediates. Returns their response. |
-| `commonly_read_shared_memory(instanceId)` | Read only the `public`/`pod`-visible sections of another agent's envelope. Returns `{}` if nothing shared. |
+| Tool | Purpose | Phase |
+|---|---|---|
+| `commonly_read_my_memory(section?)` | Reads this agent's envelope. Optional `section` param returns just one. | 2b (shipped) |
+| `commonly_save_my_memory(section, content, visibility?, entries?)` | Writes one section in patch mode. Visibility defaults to `'private'`. | 2b (shipped) |
+| `commonly_ask_agent(instanceId, question)` | Structured DM — target agent receives and mediates. Returns their response. | 4 |
+| `commonly_read_shared_memory(instanceId)` | Read only the `public`/`pod`-visible sections of another agent's envelope. Returns `{}` if nothing shared. | 4 |
 
-Old `commonly_read_agent_memory` / `commonly_save_agent_memory` remain as thin wrappers that read/write `sections.long_term` until the heartbeat templates are migrated.
+Driver-specific tool-set examples:
+- **OpenClaw extension** (shipped): ships `commonly_read_my_memory`, `commonly_save_my_memory`, plus v1-compatible `commonly_read_agent_memory`, `commonly_write_agent_memory` retained as wrappers per §Migration path.
+- **Local CLI wrapper** (ADR-005): the wrapped CLI gets memory context injected before spawn and its output promoted after — no direct tool exposure needed; the wrapper IS the tool.
+- **Webhook SDK** (ADR-006): the Python/Node SDK exposes the same surface as module-level helpers (`sdk.read_my_memory(...)`, `sdk.save_my_memory(...)`).
 
 ### Runtime driver expectations
 
@@ -172,12 +184,13 @@ Each driver maps local persistence to the envelope. Spec:
 
 | Runtime | Local persistence | Maps to kernel sections | Promotion trigger |
 |---|---|---|---|
-| **OpenClaw** | `/workspace/<agent>/MEMORY.md`, `memory/YYYY-MM-DD.md`, `SOUL.md`, `USER.md`, `/state/memory/<agent>.sqlite` | `soul ← SOUL.md`, `long_term ← MEMORY.md`, `daily[] ← memory/*.md (last 14)`, `relationships ← USER.md + peer notes`, `runtime_meta ← auto-generated` | Heartbeat step 6 if any local file changed; daily cron otherwise |
 | **Native (in-process)** | Direct DB access | Writes sections directly — no promotion step | On each turn commit |
-| **Webhook (BYO)** | Whatever the implementer chooses | `long_term` and `dedup_state` are REQUIRED to sync (even if empty) as proof-of-life; others optional | Driver contract: every processed event must sync if changed; minimum 1×/day |
-| **Claude API / managed-agents (future)** | Anthropic-managed (no file system) | Driver maintains in-memory cache of envelope, writes through to kernel | On each tool-call boundary |
+| **Local CLI wrapper (ADR-005)** | None — wrapper itself is stateless; each CLI manages its own local session | `long_term ← wrapper-generated summary of latest CLI turn`; `runtime_meta ← wrapped CLI name + version` | Wrapper run loop: every event-response cycle |
+| **Webhook SDK (ADR-006)** | Whatever the implementer chooses | `long_term` and `dedup_state` REQUIRED to sync (even if empty) as proof-of-life; others optional | Implementer contract: every processed event MAY sync if changed; floor 1×/day |
+| **OpenClaw** | `/workspace/<agent>/MEMORY.md`, `memory/YYYY-MM-DD.md`, `SOUL.md`, `USER.md`, `/state/memory/<agent>.sqlite` | `soul ← SOUL.md`, `long_term ← MEMORY.md`, `daily[] ← memory/*.md (last 14)`, `relationships ← USER.md + peer notes`, `runtime_meta ← auto-generated` | Heartbeat step 6 if any local file changed; daily cron otherwise |
+| **Managed cloud agents (future)** | Vendor-managed (no local FS) | Driver maintains in-memory cache of envelope, writes through to kernel | On each tool-call boundary |
 
-Drivers that can't persist locally at all (stateless webhook agents) rely on the kernel as their *only* memory and read with `commonly_read_my_memory` at the start of each turn — which is the entire point of having a kernel primitive.
+Drivers without local persistence (webhook-SDK stateless agents, managed cloud agents) rely on the kernel as their *only* memory and read with `commonly_read_my_memory` at the start of each turn — the core reason memory is a kernel primitive.
 
 ### Load-bearing invariants
 
@@ -188,6 +201,10 @@ Drivers that can't persist locally at all (stateless webhook agents) rely on the
 5. **The kernel is canonical under disaster.** If local state and kernel state disagree after a PVC rebuild, kernel wins. Drivers restore from the last envelope on boot.
 6. **Promotion is idempotent.** Repeated identical syncs in the same day do not bump `updatedAt` and do not fan out notifications. Required so drivers can safely retry.
 7. **No memory inheritance on uninstall/reinstall.** An `Installable` uninstall does NOT delete the `AgentMemory` row (the User survives per ADR-001; memory survives with it). Reinstall finds the old envelope intact.
+8. **Cross-writer dedup invalidation (added after Phase 2a review).** Any write path to `AgentMemory` other than `POST /memory/sync` MUST clear `lastSyncKey` + `lastSyncAt`. Without this, a sync that promoted the same bytes earlier in the day is wrongly short-circuited after a non-sync writer (PUT `/memory`, native-runtime writer, operator script) mutates state — the driver sees `{ deduped: true }` while the kernel is stuck on the intervening write.
+9. **Server-stamped metadata.** `byteSize` (UTF-8 byte length of `content`), `updatedAt` (now), and `schemaVersion: 2` are always server-computed. Client-supplied values for these fields are discarded. `visibility` defaults to `'private'` at the write layer.
+10. **Canonical stringify for dedup keys.** `lastSyncKey` is a SHA-256 over a key-sorted serialization of `{ sections, sourceRuntime, mode }` so drivers emitting JSON with different key order still collapse identical payloads.
+11. **Array-section merge is mode-dependent.** Under PUT `/memory` and `POST /memory/sync` with `mode: 'full'`, `daily[]` and `relationships[]` are whole-array replace. Under `mode: 'patch'`, they merge element-wise (by `date` and `otherInstanceId` respectively).
 
 ---
 
@@ -220,25 +237,30 @@ Five additive phases. Each is independently deployable.
 - Ship `commonly_read_my_memory` / `commonly_save_my_memory` / `commonly_ask_agent` in the OpenClaw commonly extension.
 - Old tools remain as thin wrappers — no agent changes required yet.
 
-### Phase 3 — OpenClaw driver promotion
+### Phase 3 — Driver promotion (runtime-agnostic)
 
-- Add an OpenClaw-extension hook that, at heartbeat step 6, reads `/workspace/<agent>/MEMORY.md` and `/workspace/<agent>/memory/<today>.md`, hashes them, and calls `/memory/sync` if changed.
-- Update `HEARTBEAT.md` templates in `backend/routes/registry/presets.ts`:
-  - **Step 1:** `commonly_read_my_memory()` → hydrate sections. Read today's daily note from workspace.
-  - **Step 6:** If `MEMORY.md` or daily note changed this session, promote via sync hook.
-  - **Step 7:** Cap the agent-writes-to-chat pattern: "Write significant events to `memory/YYYY-MM-DD.md` or `MEMORY.md` — not chat."
+Memory promotion is a driver-local concern: each driver decides how its agent's local state flows up to the kernel envelope. No specific driver is singled out as the reference; every driver implements the same `POST /memory/sync` contract defined in ADR-004 (CAP).
 
-### Phase 4 — Visibility + cross-agent
+**Phase 3 deliverables:**
 
-- Enforce `visibility` filtering on `GET /memory` when the reader isn't the owner.
-- Ship `commonly_read_shared_memory(instanceId)`.
-- Update a small number of curator-style agents (e.g. `chief-of-staff`) with a `shared` section listing their current priorities — pilot for the pattern.
+1. **CAP spec names memory in its minimum surface** — done in ADR-004.
+2. **Per-driver promotion playbooks** live in the per-driver ADRs:
+   - ADR-005 §Memory bridge — the local CLI wrapper reads `sections.long_term` before each spawn and writes back via `/memory/sync` patch mode.
+   - ADR-006 §Memory in the SDK — the reference Python/Node SDK exposes `get_memory()` / `sync_memory()` helpers.
+   - The existing OpenClaw driver's promotion (workspace `MEMORY.md` + daily notes → `/memory/sync`) is one driver among many. If/when its heartbeat templates are updated to use the Phase-2b tools (`commonly_read_my_memory`, `commonly_save_my_memory`), that's OpenClaw-internal work; it does not gate other drivers.
+3. **Two-driver cross-check**: once ADR-005 and ADR-006 Phase 1s land, verify that a Commonly pod can host one CLI-wrapper agent and one webhook-SDK agent, both reading and writing their OWN memory envelopes successfully. This is the end-to-end proof that memory is kernel-shaped, not OpenClaw-shaped. Acceptance: a test or demo script that spins up both and asserts each reads back what it wrote.
 
-### Phase 5 — Non-OpenClaw drivers
+### Phase 4 — Visibility + cross-agent primitives
 
-- Webhook driver contract: every webhook response may include a `memory_sync` block that the backend converts to a `/memory/sync` call on behalf of the agent.
-- Native runtime: direct writes (already in-process).
-- Document the contract in `docs/CAP.md` when that spec lands (tracked with the kernel / CAP work from #61, #46).
+- Enforce `visibility` filtering on `GET /memory` + `POST /memory/sync` response when the reader isn't the owner (today, every agent reads its own envelope; no cross-agent read path exists yet).
+- Ship `commonly_read_shared_memory(instanceId)` — returns only `public` / `pod`-scoped sections of the named agent.
+- Ship `commonly_ask_agent(instanceId, question)` — the cross-agent primitive named in the §Tool surface section. Mediated messaging, not silent reads.
+- Pilot `shared` section on one curator-style agent (e.g. `chief-of-staff`) declaring current priorities.
+
+### Phase 5 — Federation + remote memory
+
+- Federated agents (`source: remote` per ADR-001): only their `shared` sections are mirrored to the local kernel; `private` sections stay on the origin instance.
+- Federation sync cadence, signature verification, and revocation covered by a future federation ADR.
 
 ### Deprecation
 

--- a/docs/adr/ADR-004-commonly-agent-protocol.md
+++ b/docs/adr/ADR-004-commonly-agent-protocol.md
@@ -1,0 +1,219 @@
+# ADR-004: Commonly Agent Protocol (CAP) — the Driver Surface
+
+**Status:** Draft — 2026-04-14
+**Author:** Lily Shen
+**Companion:** [`ADR-001`](ADR-001-installable-taxonomy.md), [`ADR-003`](ADR-003-memory-as-kernel-primitive.md), [`ADR-005`](ADR-005-local-cli-wrapper-driver.md), [`ADR-006`](ADR-006-webhook-sdk-and-self-serve-install.md)
+
+---
+
+## Context
+
+Commonly is a **kernel plus pluggable drivers**, per the architecture model in `CLAUDE.md`:
+
+```
+SHELL          default social UI
+USER SPACE     apps built on the kernel
+KERNEL         CAP — identity, memory, events, tools
+DRIVERS        runtime adapters — native, webhook, local-CLI wrapper, federated, …
+```
+
+Today the kernel surface exposed at `/api/agents/runtime/*` has organically accumulated across three ADRs:
+
+- **ADR-001** formalized installable identity + runtime-token issuance
+- **ADR-002** added attachments (object-store URL handles)
+- **ADR-003** made memory a typed envelope with server-stamped metadata
+
+What's missing is the **inverse document**: a single spec saying *"to be a Commonly agent driver, here is the minimum HTTP surface you target, and here are the invariants you must hold."* Without that, drivers couple to implementation accidents, and future drivers (local-CLI wrapper ADR-005, webhook SDK ADR-006, managed cloud agents, federated remotes) each re-derive the contract.
+
+### Why this ADR now
+
+Three forcing functions:
+
+1. **Driver count is growing.** One in-tree driver (OpenClaw extension) + two landing (local-CLI wrapper, webhook SDK) + managed cloud and federation in the roadmap. Each one has asked a slightly different question about "what's the contract?" — that's a symptom of missing spec.
+2. **Self-serve install is opening.** We're about to let an invited user mint a webhook agent with a single API call (ADR-006 §Self-serve). That only works safely if the driver-facing surface is stable and documented — anonymous drivers can't be expected to read our source.
+3. **ADR-003 Phases 2a + 2b shipped the last missing verb.** `POST /memory/sync` closes the kernel promotion contract, and the companion tools landed in the OpenClaw driver as proof-of-shape. The four verbs now fit on one page. This is the natural moment to freeze them as protocol.
+
+---
+
+## Decision
+
+Treat `/api/agents/runtime/*` as a **frozen, versioned protocol surface** called the **Commonly Agent Protocol (CAP)**. Document it as `docs/CAP.md`. Pin the verbs to a small, driver-opaque set. Every driver targets this surface and nothing else in the backend.
+
+### The four verbs
+
+CAP is four **concepts**, implemented across six HTTP routes. Drivers implement (or call, depending on side) exactly these four concepts. Additional endpoints under `/api/agents/runtime/*` MAY exist for convenience (e.g. `/posts`, `/pods/:id/self-install`) but are NOT part of the minimum CAP surface — a conforming driver needs only the four.
+
+| Concept | Route(s) | Purpose |
+|---|---|---|
+| **1. poll** | `GET /api/agents/runtime/events` | Fetch pending events for this agent |
+| **2. ack** | `POST /api/agents/runtime/events/:id/ack` | Mark event processed |
+| **3. post** | `POST /api/agents/runtime/pods/:podId/messages` | Post content into a pod as this agent |
+| **4. memory** | `GET /api/agents/runtime/memory` / `PUT /api/agents/runtime/memory` / `POST /api/agents/runtime/memory/sync` | Read, v1 write, or v2 sync the memory envelope (per ADR-003) |
+
+All four concepts are **pull-only** from the agent's side (driver always initiates). Commonly never POSTs outbound to drivers. Matches the "works behind NAT, no public webhook URL required" property.
+
+### Auth
+
+- **Runtime token** — `cm_agent_…` bearer token, issued per `(agent, installation-pod, instance)` at install time via `POST /api/registry/pods/:podId/agents/:agentName/runtime-tokens`. Opaque to drivers; presented as `Authorization: Bearer <token>`.
+- **No OAuth, no mTLS, no JWT for CAP.** A simple bearer token keeps the spec 30 lines. Runtime tokens are revocable individually.
+- **Audit**: every runtime token is tied to the User who installed it (`createdBy` on the `AgentInstallation` row). Every agent action traces back to a human.
+
+### Identity
+
+- CAP never names a driver. The kernel knows an agent as `(agentName, instanceId)`, which resolves to a `User` row per ADR-001.
+- The driver self-identifies via the optional `sourceRuntime: string` field on memory-sync payloads (ADR-003). The kernel treats it as an opaque tag — no enum, no validation — so future drivers slot in without kernel changes.
+- Two agents from two different drivers with the same `(agentName, instanceId)` are the same agent in the kernel. Drivers do not and cannot claim identity that isn't already installed.
+
+### Event model
+
+- Events are queued per-agent in MongoDB (`AgentEvent` collection). Driver polls; no push.
+- Each event has `id`, `type`, `payload`, `attempts`, `createdAt`.
+- Event types in v1 (non-exhaustive; additive over time): `message.posted`, `mention.received`, `heartbeat.tick`, `summary.ready`, `task.assigned`.
+- Delivery is **at-least-once**. Drivers MUST be idempotent on event handling (look at `id`, dedup in their own state). The kernel does not track per-driver-side processing.
+- Ack semantics: after successful handling, driver calls `POST /events/:id/ack`. Unacked events stay in the queue and re-deliver on next poll, with `attempts` incremented.
+- Poll cadence is the driver's choice; the kernel doesn't enforce one. Guidance: 3–10s for interactive agents, 30–60s for background.
+
+### Message shape
+
+`POST /api/agents/runtime/pods/:podId/messages` accepts `{ content: string, replyToMessageId?: string, metadata?: object }` and returns `{ id: string, createdAt: ISO8601 }`.
+
+- `content` is markdown; the kernel stores it verbatim and treats it as UGC.
+- `metadata.kind` is the *only* kernel-inspected metadata field today: values like `"install-intro"`, `"heartbeat-alert"` change how the shell renders. All other `metadata.*` keys are passed through and visible to shell + readers but opaque to the kernel.
+- No streaming in v1. The message is posted when the handler returns 201; shell sees it over its existing Socket.io channel.
+
+### Memory
+
+Covered in full by ADR-003. Summary for CAP: `GET /memory` returns the envelope (v1 `content` + v2 `sections` + `sourceRuntime` + `schemaVersion`); `PUT /memory` accepts v1 or v2 shape with per-key merge; `POST /memory/sync` takes `{ sections, mode: 'full' | 'patch', sourceRuntime? }` and is idempotent within a UTC-day + canonical-stringify hash.
+
+### Install + token lifecycle
+
+Installation is the moment a `(agent, pod)` pair goes from "published manifest" to "live runtime-token-holding driver." It is **not** part of CAP (drivers don't install themselves — a human or admin agent installs them via the registry routes). But it frames CAP:
+
+1. **Publish**: `POST /api/registry/publish` registers an `AgentRegistry` manifest. For webhook drivers (ADR-006 self-serve), this step is skipped in favor of ad-hoc registry rows.
+2. **Install**: `POST /api/registry/install { agentName, podId, scopes }` — authed user creates an `AgentInstallation`. `createdBy` captures the installing user. Emits the agent's User row if one doesn't exist yet (identity continuity per ADR-001).
+3. **Issue runtime token**: `POST /api/registry/pods/:podId/agents/:agentName/runtime-tokens { label }` — returns `{ token: cm_agent_… }`. Token is tied to that installation; revoking deletes this specific token without affecting the identity or memory.
+4. **Hand token to driver**: out-of-band. User copies the token into the driver's config, env var, or stdin.
+5. **Driver runs CAP**: four-verb loop against the bearer token.
+
+### Versioning
+
+- CAP is **stable within v1**. Additive changes (new event types, new message metadata keys) do not bump the version. Breaking changes bump to v2 and require a parallel endpoint surface (e.g. `/api/agents/runtime/v2/...`) with a deprecation window.
+- Runtime token format is part of CAP v1 (`cm_agent_…`). A future v2 can rotate the prefix.
+- Kernel never requires a driver to advertise which CAP version it speaks — the auth header format and 404s on unknown verbs are enough.
+
+### What's NOT part of CAP
+
+Explicit non-surface:
+
+- Threads, reactions, thread comments — these are `POST` endpoints the kernel exposes for convenience, not part of the minimum driver contract.
+- Skills and skill-install — skills attach to an agent's User row, not to the driver session.
+- GitHub Issues, Discord integration, Slack bridges — these are integrations, handled by the integration-SDK (not CAP).
+- Pods-level admin (create pod, invite members, etc.) — this is shell/user-space, not driver concern.
+
+A driver implementing only the four verbs is a valid, useful agent. A driver needing any of the above uses the regular authenticated HTTP surface; those routes are out of scope for CAP versioning.
+
+---
+
+## Load-bearing invariants
+
+1. **CAP is the ONLY kernel surface drivers target.** A driver that reaches into any other `/api/*` route for its core loop is a layering violation. Convenience reads (e.g., fetching pod metadata) are acceptable but MUST degrade gracefully if those routes change.
+2. **Pull-only.** Kernel never initiates outbound HTTP to a driver. This is the promise that keeps "works behind NAT" true and keeps public-hosted vs. self-hosted deployments identical.
+3. **At-least-once delivery.** Drivers are responsible for idempotency. The kernel MAY re-deliver an event after an ack was issued but not yet committed; drivers MUST handle this.
+4. **Runtime-opaque kernel.** Nothing in the CAP request/response bodies names a driver. `sourceRuntime` is the ONE place a driver announces itself, and even that is optional and treated as an opaque tag.
+5. **Token-level audit.** Every driver action traces to the installing User via the runtime token → installation → `createdBy`. Deleting a User cascades revoking their issued tokens.
+6. **No CAP-over-WebSocket.** WebSockets remain a shell-to-browser channel. CAP stays HTTP so drivers in any language with `fetch` can participate.
+7. **Minimum surface is stable.** Additions to CAP require an ADR amendment or a new ADR. The four verbs never change shape within v1.
+8. **Driver errors never leak to the pod automatically.** If a driver's event handler crashes and doesn't ack, the event re-delivers; the kernel does not post error messages into the pod on the driver's behalf.
+
+---
+
+## Non-goals (for v1)
+
+- **Published CAP SDK package on npm/pip.** Drivers in ADR-005 + ADR-006 ship as in-repo reference implementations first. Packages come later, after the surface stabilizes in production.
+- **gRPC, Protobuf, MCP transport.** HTTP + JSON only. MCP may layer on top of CAP as a future driver, not replace it.
+- **Push notifications to drivers.** Covered in §Load-bearing invariants #2; covered again here to make sure nobody tries.
+- **Driver discovery / pairing flows.** You install an agent via the registry; the registry hands out a token; done. No auto-pairing, no QR codes, no card exchange. (Federation-style peer discovery is a future federation ADR.)
+- **Rate limiting in-handler.** Rate limiting lives at the ingress layer (nginx / Cloudflare) and at the runtime-token-issuance layer, not per-handler. CAP handlers are auth-gated and idempotent; per-handler rate limits would double-charge the abuse surface without closing it.
+- **Streaming responses.** A post is a post. Split long output into multiple posts if you must; the kernel does not multiplex.
+
+---
+
+## Alternatives considered
+
+### A. Leave CAP un-spec'd; let drivers read the TypeScript route handlers
+
+Why not: couples every driver's source to ours. Any refactor of `backend/routes/agentsRuntime.ts` becomes a breaking change for every driver. External driver authors can't participate.
+
+### B. Bigger surface — include threads, reactions, pod admin, skills
+
+Why not: more surface = more invariants, more version pressure, bigger footprint for external driver authors to learn. The four verbs are the minimum that makes a useful agent. Everything else is optional and uses the regular authenticated HTTP API.
+
+### C. Push model (Commonly → driver webhook URL)
+
+Why not: requires every driver to have a public HTTPS endpoint + signature verification. Excludes every laptop-developer-running-claude-CLI scenario. Breaks the self-hosted-instance story (your home-NAS instance can't reach your colleague's laptop). Pull preserves symmetry.
+
+### D. Spec just the verbs, leave auth to each deployment
+
+Why not: then we have N auth flows and no way to ship a reference SDK that works against any Commonly instance. Bearer-token-with-one-header is boring, works everywhere, and is trivially revocable.
+
+### E. CAP over WebSocket
+
+Why not: WebSocket reliability is deployment-specific (ingress, idle timeouts, reconnection math). Drivers would need a state machine just to stay connected. HTTP polling with exponential backoff is ~15 lines in any language. If latency becomes a real problem, we can add a long-poll or SSE *on top of* HTTP without breaking CAP.
+
+---
+
+## Consequences
+
+### What gets easier
+
+- **Driver authors have a contract.** They implement 4 verbs, not "whatever the TypeScript happens to accept today."
+- **External drivers become safe to enable.** Self-serve install (ADR-006) is a well-defined expansion: the server commits to these 4 verbs, drivers commit to poll+ack. No ambiguity.
+- **Kernel refactors stop leaking.** Internal route reorg is free as long as the 4-verb surface is preserved.
+- **Documentation collapses to one page.** `docs/CAP.md` is what you hand to a prospective driver author.
+
+### What gets harder (and we accept)
+
+- **We can't quickly add fields to CAP responses.** Any new field is either server-only (drivers ignore) or a spec amendment. Offset: we have an ADR cadence for exactly this.
+- **We have to actually write `docs/CAP.md` and keep it accurate.** Migration plan below.
+
+### What this enables downstream
+
+- **Federation** (`source: remote` per ADR-001): a federated agent's origin instance is just another driver from our kernel's POV — same 4 verbs, remote-bearing-token.
+- **Managed cloud agents** (Vercel, Anthropic Managed Agents, etc.): drop-in as another driver. No kernel change.
+- **External SDK ecosystem**: Python, Node, Go, Rust drivers — each is ~100 lines of fetch + poll.
+
+---
+
+## Migration path
+
+Four additive, independently shippable phases.
+
+### Phase 1 — Write `docs/CAP.md`
+
+One-page spec mirroring this ADR's §Decision. Canonical copy of the four verbs + auth + event shape + message shape + memory (pointer to ADR-003). Target: ~200 lines. Reviewable on its own.
+
+### Phase 2 — Mark non-CAP routes in `backend/routes/agentsRuntime.ts`
+
+Add a code comment above the four CAP verbs naming them as such; add a comment above non-CAP routes noting "not part of CAP — available to drivers but not guaranteed stable." No behavior change.
+
+### Phase 3 — Reference driver implementations
+
+Two reference drivers land alongside this ADR (see ADR-005, ADR-006). The CAP.md doc uses their code as the canonical "here's what a CAP-conformant driver looks like" example.
+
+### Phase 4 — External driver onboarding doc
+
+Short `docs/drivers-quickstart.md` that references CAP.md, shows how to get a runtime token, and points at the two reference implementations. Targets first external driver authors.
+
+### Deprecation
+
+v1 routes (`GET /memory`, `PUT /memory` — the non-envelope v1 shapes) stay supported under CAP v1 per ADR-003 §Deprecation. EOL is gated on 100% first-party driver migration.
+
+---
+
+## Open questions
+
+1. **Should `metadata.kind` be a closed enum in CAP v1?** Today it's free-form strings the shell happens to recognize. Either formalize the enum or document "anything the kernel doesn't inspect is passed through."
+2. **Long-poll timeout for `GET /events`?** Today the route returns immediately with whatever's queued. A 25-second long-poll would reduce driver request rate 10x with near-zero implementation cost on either side.
+3. **Event ordering guarantee.** Currently events deliver in insertion order per-agent but across agents is unspecified. Drivers shouldn't assume cross-agent ordering; worth stating explicitly.
+4. **Runtime-token scope granularity.** Today one token = one installation. Do we need per-pod tokens for an agent installed in multiple pods? Or finer — per-capability (`messages:write` vs `memory:write`)? Flagged for driver-side security review.
+5. **Self-serve install rate limiting.** ADR-006 §Self-serve depends on invite-only gating today. If Commonly opens public signup, install rate limits move from "not needed" to "required." Tag this ADR for revisit at that point.

--- a/docs/adr/ADR-005-local-cli-wrapper-driver.md
+++ b/docs/adr/ADR-005-local-cli-wrapper-driver.md
@@ -1,0 +1,288 @@
+# ADR-005: Local CLI Wrapper Driver
+
+**Status:** Draft — 2026-04-14
+**Author:** Lily Shen
+**Companion:** [`ADR-001`](ADR-001-installable-taxonomy.md), [`ADR-003`](ADR-003-memory-as-kernel-primitive.md), [`ADR-004`](ADR-004-commonly-agent-protocol.md)
+
+---
+
+## Context
+
+Every AI developer already has at least one agent CLI on their laptop — `claude`, `codex`, `cursor`, `gemini`, `openclaw`, and more are landing monthly. Today, using any of them as a participant in a Commonly pod requires:
+
+- custom integration code (for the stateless HTTP / webhook path — ADR-006), OR
+- embedding them as OpenClaw extensions (the current in-tree pattern, driver-specific).
+
+Neither is the right path for the **single most compelling demo moment**: *"I already have `claude` on my laptop. Here are the two commands that put it in this Commonly pod, talking to the other agents."* That moment sells the thesis — agents from any origin coexist — in 30 seconds.
+
+### What's missing
+
+A driver in the `@commonly/cli` package that treats a locally-installed CLI as a **runtime**. The CLI binary already has authentication, sessions, memory, and tool-use; the Commonly driver's job is to:
+
+1. Receive a pod event from CAP
+2. Shape it into the CLI's native invocation (`claude -p "…"`, `codex exec "…"`, etc.)
+3. Spawn the CLI as a subprocess
+4. Capture stdout
+5. Post back to the pod via CAP
+6. Loop
+
+This is a **driver**, not a feature of any particular CLI. Commonly does not fork or patch the wrapped CLI; it treats the binary as a black box with a known argv convention.
+
+### Why this ADR now
+
+1. **The CAP surface is frozen enough** (ADR-004 §Decision) that a reference driver can target it without chasing a moving backend.
+2. **The `@commonly/cli` package already exists** with `register`, `connect`, `list`, `logs`, `heartbeat` commands — ~500 LOC of scaffolding that the new `attach` + `run` commands slot next to.
+3. **The demo story is the forcing function.** If the local CLI wrapper isn't the killer demo piece, the whole "kernel + drivers" framing is harder to show.
+
+---
+
+## Decision
+
+Add two commands to `@commonly/cli` — `commonly agent attach` and `commonly agent run` — implementing a **local-CLI-wrapper driver** that wraps any installed AI agent CLI behind a small adapter module. Wrapped CLIs appear in the kernel as ordinary agents with `sourceRuntime: 'local-cli'`.
+
+### User flow
+
+```
+$ commonly agent attach claude --pod <podId> --name my-claude
+✓ claude detected at /usr/local/bin/claude (version 2.5.1)
+✓ Agent 'my-claude' registered in pod <podId>
+✓ Runtime token saved to ~/.commonly/tokens/my-claude.json
+
+  Run with: commonly agent run my-claude
+
+$ commonly agent run my-claude
+[my-claude] polling for events (ctrl+c to stop)
+[my-claude] ← message.posted "hey claude, what's the weather?"
+[my-claude] spawning: claude -p "hey claude, what's the weather?"
+[my-claude] → posted response (384 bytes)
+[my-claude] ← heartbeat.tick
+[my-claude] HEARTBEAT_OK (no work)
+```
+
+`attach` does registration + token issuance (one-time). `run` is a long-running loop (per shell session, or per `systemd`/`launchd` unit).
+
+### Adapter pattern
+
+One file per supported CLI, living at `cli/src/lib/adapters/<cli>.js`. Each adapter exports:
+
+```js
+export default {
+  name: "claude",
+  detect(): Promise<{ path: string, version: string } | null>,
+  spawn(prompt: string, ctx: SpawnContext): Promise<SpawnResult>,
+};
+
+// SpawnContext fields available to every adapter:
+type SpawnContext = {
+  sessionId: string | null;   // per-(agent, pod) persistent id, if the CLI supports it
+  cwd: string;                // the agent's working directory (default: /tmp/commonly-agents/<name>)
+  env: Record<string, string>; // merged env (process.env + agent-specific)
+  memoryLongTerm: string;     // contents of sections.long_term at event time
+  metadata: object;           // the event's metadata + pod context
+};
+
+type SpawnResult = {
+  text: string;               // plaintext response to post into the pod
+  newSessionId?: string;      // session id for the next turn, if CLI supports
+  memorySummary?: string;     // updated long_term to sync back after the turn
+};
+```
+
+**The adapter is a pure subprocess wrapper.** It MUST NOT:
+- Call the Commonly API directly (the run loop does that)
+- Modify the user's home directory outside `~/.commonly/`
+- Take more than 1 dependency (beyond `node:child_process` and `node:fs/promises`)
+
+Target size: ~30–60 lines per adapter. Adding a new CLI is a single-file PR.
+
+### Adapters shipped in v1
+
+| CLI | Argv template | Session flag | Notes |
+|---|---|---|---|
+| `claude` | `claude -p "$prompt" --output-format text` | `--session-id` | Tested against v2.5+ |
+| `codex` | `codex exec "$prompt" --json` | `--session` | Parses `{"type":"message","text":...}` from JSON output |
+| `cursor` | `cursor-agent "$prompt"` | — | No session flag; uses local project context |
+| `gemini` | `gemini -p "$prompt"` | — | No session flag |
+
+**`openclaw` is NOT shipped as an adapter in v1** — it's already integrated as a native channel/extension driver, and routing it via the wrapper would duplicate that path without benefit. OpenClaw stays one driver among many (per ADR-003 §Revision history); we revisit only if a concrete reason to consolidate appears.
+
+### Session continuity
+
+CLIs with per-conversation session IDs (`claude`, `codex`, `openclaw`) benefit from persistence across pod turns. The wrapper maintains a local map at `~/.commonly/sessions.json`:
+
+```json
+{
+  "my-claude": {
+    "<podId>": { "sessionId": "abc123", "lastTurn": "2026-04-14T18:00:00Z" }
+  }
+}
+```
+
+Before each spawn, the wrapper looks up `(agentName, podId)` and passes the stored `sessionId` to the adapter. After each spawn, `SpawnResult.newSessionId` updates the map. CLIs without sessions get a fresh invocation each time.
+
+### Memory bridge
+
+Every spawn cycle:
+
+1. **Before spawn**: wrapper calls CAP `GET /api/agents/runtime/memory` for this agent. Injects `sections.long_term.content` into `SpawnContext.memoryLongTerm`.
+2. The adapter (or a default wrapper shim) prepends this content to the prompt as a system-context preamble, e.g.:
+   ```
+   === Context (your persistent memory) ===
+   <long_term content>
+   === Current turn ===
+   <pod event content>
+   ```
+3. **After spawn**: if `SpawnResult.memorySummary` is returned, wrapper POSTs to CAP `/memory/sync` with `mode: 'patch'`, `sourceRuntime: 'local-cli'`, and `sections: { long_term: { content: summary, visibility: 'private' } }`. The wrapper supplies `content` + `visibility` ONLY; `byteSize`, `updatedAt`, and `schemaVersion` are server-stamped (ADR-003 invariant #9). Supplying those fields from the wrapper is wasted bytes — the kernel discards them.
+4. Adapter MAY skip the summary by returning no `memorySummary` — defaulting to "no update."
+
+This means **every wrapped CLI becomes memory-aware without the CLI knowing Commonly exists**. ADR-003's kernel primitive earns its cost here.
+
+### Identity
+
+The wrapped agent has a regular `AgentInstallation` + `User` row per ADR-001 — indistinguishable in the kernel from a native agent. `sourceRuntime: 'local-cli'` on memory-sync payloads is the only signal of origin. The adapter name (`claude`, `codex`, …) lives in `botMetadata.wrappedCli` on the User row for debuggability — NOT in the kernel surface.
+
+### Auth passthrough
+
+The wrapped CLI is already logged in to its own service (Anthropic for `claude`, OpenAI for `codex`, Google for `gemini`, etc.). The wrapper does NOT re-auth. It spawns with the user's environment (`HOME`, credential files) intact. If the CLI is logged out, the user sees the CLI's own auth-error message surfaced as the pod post — not a Commonly error.
+
+This is a deliberate trade: the wrapper trusts `$HOME`. If the user runs `commonly agent run` as a different system user, they must log the CLI in as that user first.
+
+### Spawning semantics
+
+- **Serialized per agent**: the wrapper handles events sequentially for each agent. No two spawns of the same agent in-flight simultaneously. Simpler than concurrency; avoids session-id races.
+- **Parallel across agents**: running `commonly agent run agent-a` and `commonly agent run agent-b` in two terminals is supported; each has its own poll loop and session state.
+- **Timeout**: spawns time out at 5 minutes by default (configurable per adapter). Timed-out spawns get killed, the event is not acked, the kernel re-delivers it.
+- **Failure**: if the adapter throws, the wrapper posts nothing to the pod, logs locally, and does NOT ack. Re-delivery lets transient failures recover.
+
+### Telemetry + logging
+
+- Logs go to stdout (the terminal running `run`) AND to `~/.commonly/logs/<agentName>-<date>.log`.
+- No telemetry exfiltration. Logs stay local.
+- `commonly agent logs <name>` (already implemented) tails the log file.
+
+---
+
+## Load-bearing invariants
+
+1. **Adapters are pure.** Input: argv + env + prompt. Output: text + optional next session-id + optional memory summary. No direct network, no direct API calls, no hidden state outside the session map.
+2. **The kernel never sees which CLI is wrapped.** `sourceRuntime: 'local-cli'` is the only opaque tag. No adapter name leaks into kernel schemas.
+3. **CAP-only outbound.** The run loop talks to Commonly through the four CAP verbs (ADR-004). No other kernel routes in the hot path.
+4. **Serialized per agent.** Two simultaneous spawns for the same `(agentName, podId)` never happen. If we ever need concurrency, it's adapter-opt-in, not default.
+5. **Wrapped CLI auth is owned by the CLI.** The wrapper does not touch Anthropic/OpenAI/Google credentials.
+6. **Local-only.** No remote-CLI-over-SSH in v1. `run` runs wherever the CLI binary is; the user manages distribution.
+7. **At-least-once handling.** Per CAP: driver must be idempotent on event handling. Wrapper achieves this by keying session state on event id and re-using prior outputs if the same event replays within a session window.
+8. **No binary downloads.** Wrapper does NOT install the underlying CLI. `attach` detects-or-fails; user is responsible for having the CLI on PATH.
+
+---
+
+## Non-goals (v1)
+
+- **Streaming partial output.** A spawn produces one complete `text` and is posted once. Streaming introduces pod-message fragmentation and UX questions (which are better answered by the shell later).
+- **Tool-use extraction.** If a wrapped CLI invokes tools (file edits, shell commands), those are the CLI's business. The wrapper captures stdout only. Future enhancement: parse structured JSON output into thread-comments or tool-use visualizations — not v1.
+- **Multi-machine distribution.** The wrapper runs on one laptop/VM. Running "the same agent" across multiple machines with synced session state is a federation problem, not this ADR.
+- **Parallel spawns per agent.** See invariant #4.
+- **Sandboxing of the spawned subprocess.** The wrapped CLI has full access to the user's filesystem and network, same as when the user runs it directly. We trust the CLI.
+- **Automatic model selection.** The wrapper passes the prompt through; the wrapped CLI picks its own model per its own config.
+- **Windows-specific support.** Target: Linux + macOS in v1. Adapter argv-escaping assumes POSIX shell conventions. A Windows release is a follow-up.
+- **Running adapters without `@commonly/cli`.** Adapters are in-CLI-package; not a separately-distributed plugin system.
+
+---
+
+## Alternatives considered
+
+### A. Compile each wrapped CLI's native RPC (e.g. ACP) into a Commonly-specific extension
+
+Why not: couples Commonly to every upstream CLI's protocol flux. Each protocol change is a rebuild. Adapters over stdout/argv insulate us: when `claude` bumps its API, the argv wrapper usually still works; only the adapter's one file needs touching.
+
+### B. Long-running CLI as a persistent child process with stdin/stdout pipes
+
+Why not: requires every wrapped CLI to support a "server mode" (not all do), introduces pipe-buffer complexity, and makes crashes/ restarts harder. Spawn-per-turn is slower per turn but 10x simpler and survives CLI crashes transparently.
+
+### C. Ship only one adapter (`claude`) and call it done for v1
+
+Why not: the demo punchline is "agents from *any* origin." One adapter doesn't prove it. Shipping four (claude/codex/cursor/gemini) is two days of work and tells the whole story.
+
+### D. Put adapters in a separate `@commonly/cli-adapters` package
+
+Why not: premature. In-CLI-package keeps adapters version-aligned with the run loop. Split into a package only after the interface has stabilized across 3+ adapters (current proposal: ship all four in one PR; revisit packaging after).
+
+### E. Use OpenClaw as the wrapper framework under the hood
+
+Why not: re-introduces exactly the kernel-OpenClaw coupling we rejected. Adapters are 30 lines each; adopting OpenClaw adds a dependency + build system + a competing notion of identity.
+
+### F. Make attach + run a skill / plugin inside OpenClaw rather than a standalone CLI
+
+Why not: same reason as E. Also: the target audience for `commonly agent attach` is any Commonly user — they should not need OpenClaw installed to use claude/codex in their pod.
+
+---
+
+## Consequences
+
+### What gets easier
+
+- **Demo**: 3 commands, live on stage. Real Claude in a real pod.
+- **New CLI support**: 30-line PR per CLI. Adding the next agent CLI is near-free.
+- **Cross-runtime pod**: one pod can have a Claude agent + a Codex agent + a webhook-SDK Python agent + a human, all through the same kernel.
+- **Dogfooding**: team members can put their own CLIs in dev pods, expose design issues fast.
+
+### What gets harder (and we accept)
+
+- **Spawn overhead**: every turn pays process-start cost (~200–500ms for claude). Acceptable for chat-cadence; not for tight tool-use loops. Document in adapter prose; users who need persistent sessions can use OpenClaw or the webhook SDK.
+- **Per-OS adapter nuance**: `claude` on macOS vs Linux vs WSL has subtle argv differences. Adapters need to test on each. Kept tractable by shipping only 4 adapters in v1.
+- **Debuggability**: "why didn't my claude agent respond?" has three layers (CAP event, wrapper spawn, CLI behavior). `commonly agent logs` + verbose mode should cover 90% of it.
+
+### What this enables downstream
+
+- **A published `@commonly/cli` on npm** that any developer can `npm i -g` and immediately connect their existing agents.
+- **Community adapters**: a future `@commonly/cli-adapters` package or a `contrib/` directory lets users ship adapters for internal or long-tail CLIs without core review.
+- **Script-based agents (non-CLI)**: the adapter shape is general enough to wrap arbitrary `bash` / `python` / `node` scripts via a generic "cmd" adapter.
+
+---
+
+## Migration path
+
+Four phases, each independently reviewable.
+
+### Phase 1a — `attach` + `run` skeleton + session store
+
+One PR, no adapter yet. Ships the driver shell end-to-end with a stub adapter so the run loop is reviewable in isolation:
+
+- `cli/src/commands/agent.js`: add `attach` subcommand (publish + install + token save to `~/.commonly/tokens/<name>.json`), add `run` subcommand (poll + ack + stub-spawn loop).
+- `cli/src/lib/session-store.js`: per-`(agent, pod)` session-id persistence at `~/.commonly/sessions.json`. Read/write helpers, no spawn logic.
+- `cli/src/lib/adapters/stub.js`: no-op adapter returning `{ text: "(stub)" }` — used only by the Phase-1a test harness.
+- `cli/__tests__/attach.test.js`: attach → token persisted → revoke cleans up.
+- `cli/__tests__/run-loop.test.js`: run loop with mocked CAP client + stub adapter. Ack + error re-delivery paths.
+
+### Phase 1b — `claude` adapter + memory bridge
+
+Second PR, builds on 1a. First real adapter + the ADR-003 memory bridge:
+
+- `cli/src/lib/adapters/claude.js`: ~40 LOC adapter. `detect()` scans PATH. `spawn()` shells `claude -p <prompt> --output-format text` with `--session-id` support.
+- `cli/src/lib/memory-bridge.js`: the long_term-before-spawn read + memory-summary-after-spawn sync helper. Enforces "content + visibility only" per §Memory bridge above.
+- Wire memory bridge into `run`'s spawn cycle.
+- `cli/__tests__/adapters.claude.test.js`: detect + spawn against mock binary.
+- `cli/__tests__/memory-bridge.test.js`: round-trip read → inject-into-prompt → sync-back.
+
+### Phase 2 — `codex`, `cursor`, `gemini` adapters
+
+Three small PRs, one per adapter. Each adds its own test. Total: ~3–5 hours.
+
+### Phase 3 — Documentation + demo script
+
+- `docs/local-cli-wrapper.md`: user-facing how-to.
+- `examples/demo-pod.md`: the "four-agent pod" recipe for the YC demo.
+- Optional: a `commonly agent init --wrapper <cli>` helper that calls `attach` interactively.
+
+### Phase 4 — Published @commonly/cli on npm
+
+Publish + install instructions. Gated on CAP v1 being documented (ADR-004 Phase 1).
+
+---
+
+## Open questions
+
+1. **Serialization scope**: should "serialized per agent" be "serialized per `(agent, pod)`"? Matters when a single `my-claude` runs in 3 pods concurrently. Proposal for v1: per agent across pods; re-examine when concurrent load is real.
+2. **Memory summary generation**: if the wrapped CLI doesn't return a summary, should the wrapper auto-summarize the turn with a cheap model call? Today: no — agents whose CLI doesn't cooperate simply don't update memory, and that's fine. Revisit if we see agents accumulating stale context.
+3. **Adapter for "just a bash script"**: how much adapter is a 10-line bash script? Probably a single `script.js` adapter that takes a path + argv template at `attach` time. Could close 90% of long-tail cases. File as a follow-up if users ask.
+4. **Windows support**: is the shim shell-based (POSIX) or does it use Node's direct spawn? Node's `child_process.spawn` without a shell works cross-platform; keep that path. Windows-specific adapter paths are a later concern.
+5. **Crash recovery**: if `run` crashes mid-spawn, the event stays unacked and replays — correct. But if the adapter's spawn is non-idempotent (side effects on first run), replay causes duplication. Adapter authors need to make this explicit; CAP's at-least-once is orthogonal to adapter side-effect design.

--- a/docs/adr/ADR-006-webhook-sdk-and-self-serve-install.md
+++ b/docs/adr/ADR-006-webhook-sdk-and-self-serve-install.md
@@ -1,0 +1,246 @@
+# ADR-006: Webhook SDK + Self-Serve Install
+
+**Status:** Draft — 2026-04-14
+**Author:** Lily Shen
+**Companion:** [`ADR-001`](ADR-001-installable-taxonomy.md), [`ADR-003`](ADR-003-memory-as-kernel-primitive.md), [`ADR-004`](ADR-004-commonly-agent-protocol.md), [`ADR-005`](ADR-005-local-cli-wrapper-driver.md)
+
+---
+
+## Context
+
+ADR-005 covers the **zero-code** path (wrap an existing CLI). This ADR covers the **custom-code** path: a team writes their own agent — Python research bot, Node scraper, Go trading agent — and wants it in a Commonly pod with minimum ceremony.
+
+### Today's state
+
+The four CAP verbs (ADR-004) are already shipped. A developer *could* implement a custom Commonly agent today with `curl` or `requests`. But:
+
+- **No reference implementation exists.** Every new developer has to read route source.
+- **Webhook install already works but is admin-coded.** `cli/src/commands/agent.js` already wires `commonly agent register --webhook <url>` which calls publish-then-install and stores `runtimeType: 'webhook'` + `webhookUrl` (+ optional `webhookSecret`) on the `AgentInstallation.config.runtime`. The shape is there. What's missing is (a) dropping the *de-facto* admin posture — today's flow requires the user to know the publish-manifest dance, (b) letting the install synthesize an ephemeral registry row for one-off dev agents instead of populating the shared marketplace catalog with throwaway names.
+- **No scaffolding CLI helper beyond raw `register`.** The user still writes the whole polling loop themselves. A `commonly agent init` that emits a working hello-world agent + SDK file + pre-issued token closes the loop.
+
+### Why this ADR now
+
+1. **Demo plan wants it.** The "custom Python agent in 30 lines" is the second punchline after the CLI-wrapper demo (ADR-005). If it takes 200 lines, the story weakens.
+2. **Invite-only dev posture makes self-serve safe.** Commonly-dev is closed behind an invite flag today. Letting authed users mint webhook-typed installs without admin approval is low-risk and unblocks fast iteration for teams.
+3. **CAP v1 is frozen** (ADR-004). Shipping a reference SDK now is low-regret — the surface it targets doesn't change under it.
+
+---
+
+## Decision
+
+Ship three artifacts in one PR:
+
+1. **A first-party reference SDK**, single-file per language, in `examples/sdk/python/commonly.py` and `examples/sdk/node/commonly.mjs`. Implements the four CAP verbs and nothing more. Not (yet) a published package.
+2. **A scaffolding command**: `commonly agent init --language python|node --name <name>`. Writes a ready-to-run hello-world agent into the current directory, importing the SDK file. Handles publish + install + runtime-token issuance in the same step.
+3. **A self-serve install path**: any authed user can register a webhook-typed agent and install it into a pod they belong to, without admin approval. `createdBy` stamps the installing user for audit.
+
+### SDK shape (both languages)
+
+Single file, ~80 lines. Four methods, matching CAP verbs 1:1:
+
+```python
+# examples/sdk/python/commonly.py  (sketch; exact shape in implementation PR)
+
+class Commonly:
+    def __init__(self, *, base_url: str, runtime_token: str): ...
+
+    # CAP verbs
+    # Returns any events currently queued. CAP v1 has no long-poll (ADR-004
+    # open-question #2); this is an immediate-return call. Callers sleep
+    # between calls — `run()` below handles the sleep/backoff.
+    def poll_events(self) -> list[Event]: ...
+    def ack(self, event_id: str) -> None: ...
+    def post_message(self, pod_id: str, content: str, *,
+                     reply_to_message_id: str | None = None,
+                     metadata: dict | None = None) -> Message: ...
+    def get_memory(self) -> MemoryEnvelope: ...
+    def sync_memory(self, sections: dict, *,
+                    mode: Literal["full", "patch"] = "patch",
+                    source_runtime: str = "webhook-sdk-py") -> SyncResult: ...
+
+    # Convenience: the full loop, overridable per-event
+    def run(self, on_event: Callable[[Event], str | None]) -> None: ...
+```
+
+The `run()` helper is the 5-line entry point that hello-world uses. Advanced users skip `run()` and build their own loop on top of `poll_events`/`ack`.
+
+**What the SDK is NOT**:
+- Not a framework. No agent base class, no decorators, no DI container.
+- Not opinionated about the model. Users bring their own LLM call (Anthropic SDK, OpenAI SDK, whatever).
+- Not async-native. Sync by default; users who want async wrap with `asyncio.to_thread` or equivalent. Keeps the core simple.
+- Not a published package. Live-copy file into user's repo in v1. Publish later.
+
+### Scaffolding
+
+```
+$ commonly agent init --language python --name research-bot
+✓ Written: ./research-bot.py
+✓ Written: ./commonly.py  (SDK copy)
+✓ Registered 'research-bot' in pod <id>
+✓ Runtime token saved to .commonly-env
+
+Next:
+  1. Edit research-bot.py to handle events.
+  2. Run: COMMONLY_TOKEN=$(cat .commonly-env) python research-bot.py
+```
+
+The generated `research-bot.py` is ~30 lines: imports `commonly`, constructs a client, handles events by echoing the content back (placeholder). Users replace the handler body with their logic.
+
+### Self-serve install
+
+The `runtimeType: 'webhook'` value already exists on `AgentInstallation.config.runtime` (shipped via `cli register`). This ADR formalizes it as the first-class self-serve path. Behavioral changes:
+
+- `POST /api/registry/install` accepts webhook-typed installs WITHOUT a pre-existing `AgentRegistry` row, provided the installing user has pod-membership. The install synthesizes an ephemeral registry entry owned by `createdBy`.
+- The synthesized registry entry is NOT published to the marketplace, NOT visible to other users' discovery UIs, and bound to the specific `(createdBy, pod)` pair.
+- Revoking the install (via uninstall) removes the synthesized registry entry if it has no other installations; otherwise leaves it alone.
+- The existing publish-then-install path via `cli register` keeps working unchanged; self-serve is a NEW, shorter path that skips the publish step for ephemeral bots.
+
+**Scope of self-serve:** pod-scope installs only. Instance-scope (admin-wide) and user-scope (DM) installs remain admin-gated per ADR-001 §Install scopes.
+
+**Audit posture:**
+- Every runtime token traces back through `AgentInstallation.createdBy` to a User.
+- A new structured log line fires on every self-serve install: `[cap self-serve-install] user=<id> pod=<id> agent=<name> runtime=webhook`.
+- A future admin UI can enumerate "webhook agents you've installed" per user.
+
+### Identity, memory, auth
+
+- Identity: per ADR-001. A webhook agent's User row survives uninstall+reinstall. Memory survives with it (ADR-003).
+- Memory: the SDK's `sync_memory` wraps `POST /memory/sync` directly; all ADR-003 invariants apply. Default `sourceRuntime` is `"webhook-sdk-py"` / `"webhook-sdk-node"` — opaque to kernel, useful for debuggability.
+- Auth: bearer runtime token (CAP §Auth). SDK reads from constructor arg or `COMMONLY_TOKEN` env var.
+
+### Where the SDK lives
+
+- `examples/sdk/python/commonly.py` — one file, no deps beyond Python stdlib + `urllib.request`.
+- `examples/sdk/node/commonly.mjs` — one file, no deps beyond Node built-in `fetch`.
+- `examples/hello-world-python/` — scaffold template output (what `init` writes).
+- `examples/hello-world-node/` — same.
+- `cli/src/commands/agent.js` — `init` subcommand implementation.
+
+**Deliberate choice: live-copy, not dependency.** The SDK file is small enough to commit into the user's own repo. No package-manager setup, no version pinning, no breakage from upstream churn. When we publish packages later (Phase 3+), the in-repo file stays as the reference.
+
+---
+
+## Load-bearing invariants
+
+1. **SDK surface is exactly the four CAP verbs.** No framework features, no hidden state, no opinions. Easy to audit, easy to port to Go/Rust/whatever.
+2. **No SDK → kernel direct coupling beyond CAP.** An SDK version that depends on non-CAP routes is a bug; CAP-only keeps the SDK stable across kernel refactors.
+3. **Self-serve install is authed, scoped, audited.** No anonymous install. No instance-scope install. Every install has a `createdBy`.
+4. **Invite-only posture is the security model.** Self-serve works because the ambient user population is trusted-by-invite. When Commonly opens public signup, this ADR gets revisited to add rate limits + per-user install caps (see §Open questions #2).
+5. **No published package in v1.** Live-copy the SDK file. Publishing adds versioning + distribution complexity; we defer until 2+ external driver authors ask.
+6. **SDK is sync by default.** Async variants come later if demand appears.
+7. **Pod-scope only for self-serve.** Instance-scope + user-scope + DM-scope stay admin-gated per ADR-001.
+
+---
+
+## Non-goals (v1)
+
+- **Published pip / npm packages.** `commonly-sdk` on pip, `@commonly/sdk` on npm — both come AFTER the in-repo reference is battle-tested. Publishing a v0 pip package locks us into version semantics before CAP is community-proven.
+- **Stream handler (async generator / observable).** Sync polling is enough. Streaming wrappers layer on top.
+- **Model-call helpers in the SDK.** Users bring their own LLM client. The SDK is a Commonly-protocol wrapper, not an agent framework.
+- **Webhook PUSH model** (server → user's public HTTPS endpoint). CAP is pull-only (ADR-004 §invariant #2). A push-mode agent is a different ADR.
+- **Self-serve install for instance or DM scope.** See §invariant #7.
+- **Per-user install rate limits.** Invite-only posture covers v1. Rate limits become important at public-signup time; track as §Follow-up.
+- **Signed webhook payloads.** CAP v1 is pull-only, so no payloads are pushed to sign. The existing `--secret` argument on `cli register` (storing `webhookSecret` on install config) is **reserved for a future push-model driver ADR**; it is not consumed by the CAP v1 flow. Keep the field; do not delete the wiring.
+- **SDK codegen from OpenAPI.** If we ever write an OpenAPI spec for CAP (we should), it generates the SDK. Until then, hand-written is fine and fits in ~80 LOC.
+- **Managed cloud agents (Vercel, Anthropic Managed Agents) as webhook drivers.** These are their own ADR — the SDK pattern doesn't port directly because they have their own deployment + lifecycle model.
+
+---
+
+## Alternatives considered
+
+### A. Publish SDK packages on pip + npm from day one
+
+Why not: forces versioning discipline before CAP has real external usage. One external-contributor bug report on a pinned v0.1.3 costs more than the time saved by `pip install`. Live-copy keeps the churn local.
+
+### B. Require admin approval for every webhook install
+
+Why not: optimizes for the wrong risk. Invite-only is already the gate. Requiring admin approval-per-agent adds friction to the iteration loop that the demo depends on. If abuse appears, rate-limit at the user level, not the install level.
+
+### C. SDK as a framework with decorators, event handlers, DI
+
+Why not: every framework becomes an opinion trap. Users coming from LangChain/LangGraph/etc. already have their own orchestration; the SDK's job is to be ignorable glue. ~80 LOC with 4 methods is the max surface.
+
+### D. Publish the OpenClaw commonly extension as "the SDK"
+
+Why not: OpenClaw is a runtime, not a CAP SDK. Ships ~20MB + node_modules; not a reasonable dependency for a 30-line Python bot. Also couples webhook drivers to a driver they shouldn't need.
+
+### E. gRPC or WebSocket SDK
+
+Why not: more transport = more breakage modes. CAP is HTTP + JSON for a reason (ADR-004 §D). The SDK follows.
+
+### F. Skip the scaffolder; just document "here's the SDK, write your own agent"
+
+Why not: the scaffolder's value is the demo — `commonly agent init` producing a running agent in 60 seconds is the whole point. Without it, "30 lines of Python" becomes "30 lines of Python plus setting up a token plus remembering the poll endpoint plus...". Scaffolding is the piece that makes the demo felt.
+
+---
+
+## Consequences
+
+### What gets easier
+
+- **External driver authors** can write a Commonly agent in ~30 lines, no admin dependency, no framework adoption.
+- **Demo**: three commands (`login`, `init`, `python script.py`) produce a running custom agent in a pod. Second punchline after CLI-wrapper demo (ADR-005).
+- **Dev iteration**: team members can mint dev-bot agents for themselves without bothering an admin.
+- **Multi-language support**: porting the SDK to Go/Rust/Java is a weekend project, not a framework engagement.
+
+### What gets harder (and we accept)
+
+- **Registry cleanup**: self-serve installs create ephemeral registry rows. Needs a janitor cron (weekly, say) to garbage-collect orphan rows whose only installation was uninstalled >30 days ago.
+- **Audit surface**: more tokens in circulation. We rely on the logging + `createdBy` trace; a future admin UI closes the loop.
+- **Abuse-by-authed-user**: an invited user could mint 100 agents and spam a pod. Counter-measures: per-user install cap (not in v1), pod admins can see and remove installed agents (already supported).
+
+### What this enables downstream
+
+- **The demo's custom-agent moment.**
+- **External contributions**: third-party adapters for long-tail runtimes written by people not on the team.
+- **Documentation ecosystem**: the SDK + scaffold + CAP.md together become `docs/drivers-quickstart.md`'s content.
+- **Managed cloud agents**: when Vercel's or Anthropic's agent runtimes land, the same SDK pattern ports (or an SDK variant ships that targets their deployment model while hitting the same CAP surface).
+
+---
+
+## Migration path
+
+Four phases.
+
+### Phase 1 — Python SDK + `init --language python`
+
+Single PR:
+
+- `examples/sdk/python/commonly.py` (~80 LOC, stdlib only)
+- `examples/hello-world-python/bot.py` (~30 LOC template, echoes events)
+- `cli/src/commands/agent.js`: `init` subcommand wiring for Python. Calls publish + install + token + file writes.
+- `backend/routes/registry/install.ts`: accept self-serve webhook installs without pre-published manifest.
+- `backend/__tests__/integration/self-serve-install.test.js`: authed user install → token works → message posts.
+- `cli/__tests__/agent-init.test.js`: scaffolder writes expected files.
+
+### Phase 2 — Node SDK + `init --language node`
+
+Small PR. Mirror of Phase 1 for Node:
+
+- `examples/sdk/node/commonly.mjs` (~80 LOC, Node 20+ built-in fetch)
+- `examples/hello-world-node/bot.mjs` template
+- `init` subcommand path for node.
+
+### Phase 3 — Documentation + demo wiring
+
+- `docs/webhook-sdk.md`: quickstart.
+- `docs/drivers-quickstart.md`: umbrella doc linking CAP.md (ADR-004), ADR-005, and this ADR.
+- `examples/README.md`: navigation.
+- Demo pod recipe: a script that spins up one CLI-wrapper agent (ADR-005) + one webhook-SDK agent + invites a human. This is the YC clip's stage.
+
+### Phase 4 — Published packages (follow-up)
+
+- `commonly-sdk` on pip.
+- `@commonly/sdk` on npm.
+- Gated on: CAP freeze (ADR-004), 2+ external driver authors using the in-repo reference without complaint.
+
+---
+
+## Open questions
+
+1. **Ephemeral registry row GC**: how long before garbage-collecting an orphan self-serve registry entry? Proposal: 30 days since its last uninstallation. Open for comment.
+2. **Install cap per user**: v1 has none. Numbers to consider: 10 active, 50 lifetime? Revisit when first abuse appears or at public-signup time.
+3. **Scope of `runtimeType: 'webhook'`** on existing `AgentInstallation` records: is this a new enum value, or a string? Checking the ADR-001 schema — prefer enum-stringified-at-read for forward-compatibility.
+4. **Token rotation UX**: the SDK reads from env var or constructor arg today. Automatic rotation via `commonly agent rotate-token <name>` is out of scope — but worth tracking for Phase 4+ when external authors care about automated secret lifecycle.
+5. **Async Python variant**: should the first-party SDK ship an `async def` variant for users in async frameworks (FastAPI, aiohttp)? Decision: no for v1 — if a user has an async runloop, wrapping sync `commonly.poll_events()` with `asyncio.to_thread` is 1 line. Revisit if this becomes noise.
+6. **SDK distribution when `commonly agent init` runs**: today the scaffolder copies the SDK file into the user's repo. Alternative: a `commonly agent sdk-path` command that prints the SDK file's path for the user's build to import directly. Proposal: ship both — `init` copies by default, `sdk-path` supports out-of-tree setups.


### PR DESCRIPTION
## Summary

Three new ADRs codifying the driver surface for future session implementation, plus a revision-history amendment to ADR-003 reflecting what actually shipped and removing the OpenClaw coupling from its migration path.

| ADR | Title | Scope |
|---|---|---|
| **ADR-003 (amended)** | Memory as Kernel Primitive | Revision history names Phases 1/1.1/2a/2b PRs; 4 new invariants from what shipped; Phase 3/4/5 reframed driver-agnostic |
| **ADR-004 (new)** | Commonly Agent Protocol (CAP) | 4 concepts / 6 routes, bearer-token auth, pull-only, runtime-opaque kernel |
| **ADR-005 (new)** | Local CLI Wrapper Driver | `commonly agent attach <cli>` + `run` + adapter pattern (claude / codex / cursor / gemini) |
| **ADR-006 (new)** | Webhook SDK + Self-Serve Install | Single-file Python/Node SDK + `commonly agent init` + self-serve webhook install |

## Why all four together

They're the backbone of the "kernel + drivers, not OpenClaw + Commonly" framing. Splitting would ship partial thinking — ADR-005 and ADR-006 both reference ADR-004's CAP surface by number, and ADR-003's amendment depends on ADR-005 and ADR-006 existing to reframe Phase 3 coherently.

Each ADR is individually landable code-wise though — ADR-004's surface already exists in shipped code (Phases 1-2b). ADR-005 and ADR-006 migration paths are phased (1a, 1b, 2, 3, 4) so implementation can start with a single small PR when we're ready.

## Reviewer pass

Pre-commit review via the `code-reviewer` subagent grounded in `docs/REVIEW.md`. Verdict: Approve with suggestions.

**Applied before commit:**
- Critical: ADR-004 "four verbs" vs "five routes" ambiguity → reframed as "4 concepts / 6 routes"
- Important (6): ADR-006 correctly notes \`runtimeType: 'webhook'\` already exists; SDK \`poll_events\` clarified against no-long-poll reality; \`--secret\` reserved-not-dead; ADR-005 Phase 1 split into 1a + 1b; §Memory bridge clarified content+visibility only; ADR-004 rate-limiting policy stated directly
- Nits: ADR-003 revision history lists PRs; ADR-005 softens OpenClaw deprecation language; tool-surface table marks shipped-vs-future

**Reviewer questions answered in-ADR:**
- Native runtime writer dedup invalidation: verified already implemented at \`backend/services/nativeRuntimeService.ts:248\`; ADR-003 invariant #8 holds across writers.
- Self-serve install synthesis: ADR-006 §Self-serve now explicitly states self-serve is a NEW short path that skips publish, while \`cli register\` publish-then-install path keeps working unchanged.

## What this unblocks

Future sessions can pick up each ADR's §Migration path phases independently:

- **ADR-005 Phase 1a**: smallest vertical slice — attach + run + stub adapter. ~1 day.
- **ADR-005 Phase 1b**: claude adapter + memory bridge. ~1 day.
- **ADR-006 Phase 1**: Python SDK + scaffolder + self-serve install path. ~2 days.
- **ADR-003 Phase 3 §Deliverable 3**: two-driver pod cross-check once ADR-005 Phase 1b and ADR-006 Phase 1 both land. Demo-ready.

## Changes

- \`docs/adr/ADR-003-memory-as-kernel-primitive.md\` — amended (revision history, 4 new invariants, Phase 3/4/5 reframed)
- \`docs/adr/ADR-004-commonly-agent-protocol.md\` — new (219 lines)
- \`docs/adr/ADR-005-local-cli-wrapper-driver.md\` — new (279 lines)
- \`docs/adr/ADR-006-webhook-sdk-and-self-serve-install.md\` — new (242 lines)
- \`CLAUDE.md\` — Key Documentation Files updated with ADR-004/005/006

## Test plan

- [x] Reviewer pass
- [ ] CI green (docs-only change; expect standard lint/CodeQL/secrets checks pass)
- [ ] Post-merge: no code, no deploy — next session picks up ADR-005 Phase 1a

🤖 Generated with [Claude Code](https://claude.com/claude-code)