### PR TITLE
feat(cli): ADR-005 Phase 1a — local-CLI wrapper attach + run skeleton

### DIFF
--- a/cli/__tests__/attach.test.mjs
+++ b/cli/__tests__/attach.test.mjs
@@ -1,0 +1,177 @@
+/**
+ * attach.test.mjs — ADR-005 Phase 1a
+ *
+ * Covers the pure attach core + the token-file persistence helpers.
+ * - performAttach:   detect → publish → install → mint runtime token
+ * - saveAgentToken / loadAgentToken:  ~/.commonly/tokens/<name>.json round trip
+ *
+ * We stub `homedir` so all token writes land in a throwaway temp dir, and pass
+ * a hand-rolled `client` with jest.fn() for get/post — no HTTP.
+ */
+
+import { jest } from '@jest/globals';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+const tokensTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-attach-test-'));
+
+await jest.unstable_mockModule('os', () => {
+  const actual = os;
+  return {
+    ...actual,
+    default: { ...actual, homedir: () => tokensTmpDir },
+    homedir: () => tokensTmpDir,
+  };
+});
+
+const {
+  performAttach,
+  saveAgentToken,
+  loadAgentToken,
+} = await import('../src/commands/agent.js');
+
+const makeClient = ({ publishOk = true, runtimeToken = null } = {}) => {
+  const post = jest.fn(async (route, body) => {
+    if (route === '/api/registry/publish') {
+      if (!publishOk) throw new Error('already published');
+      return { ok: true };
+    }
+    if (route === '/api/registry/install') {
+      return {
+        installation: {
+          agentName: body.agentName,
+          instanceId: 'default',
+          podId: body.podId,
+        },
+        ...(runtimeToken ? { runtimeToken } : {}),
+      };
+    }
+    if (route.endsWith('/runtime-tokens')) {
+      return { token: 'cm_agent_from_tokens_route' };
+    }
+    throw new Error(`unexpected POST to ${route}`);
+  });
+  return { post, get: jest.fn() };
+};
+
+describe('performAttach', () => {
+  beforeEach(() => {
+    fs.rmSync(path.join(tokensTmpDir, '.commonly'), { recursive: true, force: true });
+  });
+
+  test('detects the adapter, publishes, installs, and returns a runtime token', async () => {
+    const client = makeClient({ runtimeToken: 'cm_agent_from_install' });
+    const result = await performAttach({
+      client,
+      adapterName: 'stub',
+      agentName: 'my-stub',
+      podId: 'pod-1',
+      displayName: 'My Stub',
+    });
+
+    expect(result.runtimeToken).toBe('cm_agent_from_install');
+    expect(result.wrappedCli).toBe('stub');
+    expect(result.installation.agentName).toBe('my-stub');
+    expect(result.instanceId).toBe('default');
+    expect(result.detected.path).toBe('(builtin)');
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/registry/publish',
+      expect.objectContaining({
+        manifest: expect.objectContaining({
+          name: 'my-stub',
+          runtimeType: 'local-cli',
+        }),
+      }),
+    );
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/registry/install',
+      expect.objectContaining({
+        agentName: 'my-stub',
+        podId: 'pod-1',
+        config: expect.objectContaining({
+          runtime: expect.objectContaining({
+            runtimeType: 'local-cli',
+            wrappedCli: 'stub',
+          }),
+        }),
+      }),
+    );
+  });
+
+  test('falls back to /runtime-tokens when install does not return runtimeToken', async () => {
+    const client = makeClient({ runtimeToken: null });
+    const result = await performAttach({
+      client,
+      adapterName: 'stub',
+      agentName: 'my-stub',
+      podId: 'pod-2',
+    });
+
+    expect(result.runtimeToken).toBe('cm_agent_from_tokens_route');
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/registry/pods/pod-2/agents/my-stub/runtime-tokens',
+      {},
+    );
+  });
+
+  test('swallows publish errors (agent may already be published) and continues', async () => {
+    const client = makeClient({ publishOk: false, runtimeToken: 'cm_agent_ok' });
+    const result = await performAttach({
+      client,
+      adapterName: 'stub',
+      agentName: 'my-stub',
+      podId: 'pod-3',
+    });
+
+    expect(result.runtimeToken).toBe('cm_agent_ok');
+    // publish was attempted and swallowed; install still happened
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/registry/install',
+      expect.any(Object),
+    );
+  });
+
+  test('rejects unknown adapter names', async () => {
+    const client = makeClient();
+    await expect(performAttach({
+      client,
+      adapterName: 'does-not-exist',
+      agentName: 'x',
+      podId: 'p',
+    })).rejects.toThrow(/Unknown adapter/);
+    expect(client.post).not.toHaveBeenCalled();
+  });
+});
+
+describe('saveAgentToken / loadAgentToken', () => {
+  beforeEach(() => {
+    fs.rmSync(path.join(tokensTmpDir, '.commonly'), { recursive: true, force: true });
+  });
+
+  test('persists and reads back the token record, stamping savedAt', () => {
+    saveAgentToken('my-stub', {
+      agentName: 'my-stub',
+      instanceId: 'default',
+      podId: 'pod-1',
+      instanceUrl: 'http://localhost:5000',
+      runtimeToken: 'cm_agent_xyz',
+      adapter: 'stub',
+    });
+
+    const loaded = loadAgentToken('my-stub');
+    expect(loaded.runtimeToken).toBe('cm_agent_xyz');
+    expect(loaded.adapter).toBe('stub');
+    expect(loaded.podId).toBe('pod-1');
+    expect(loaded.savedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    // On-disk file is at ~/.commonly/tokens/<name>.json
+    const file = path.join(tokensTmpDir, '.commonly', 'tokens', 'my-stub.json');
+    expect(fs.existsSync(file)).toBe(true);
+  });
+
+  test('loadAgentToken returns null when the file does not exist', () => {
+    expect(loadAgentToken('never-attached')).toBeNull();
+  });
+});

--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -1,0 +1,287 @@
+/**
+ * run-loop.test.mjs — ADR-005 Phase 1a
+ *
+ * Covers performRun, the local-CLI wrapper's poll/spawn/post/ack loop.
+ *
+ * Verifies:
+ *  - Happy path: event → adapter.spawn → post to pod → ack
+ *  - No-prompt event: no spawn, still acked as 'no_action'
+ *  - Adapter failure: no post, no ack (kernel re-delivers — ADR-005)
+ *  - Session continuity: newSessionId persists; next event sees it
+ *  - stop() halts further polling
+ *
+ * Mocks `createClient` from api.js so no HTTP is ever issued. A no-op
+ * setTimeout is injected so the loop runs exactly one cycle per test.
+ */
+
+import { jest } from '@jest/globals';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+const sessionsTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-run-test-'));
+
+await jest.unstable_mockModule('os', () => {
+  const actual = os;
+  return {
+    ...actual,
+    default: { ...actual, homedir: () => sessionsTmpDir },
+    homedir: () => sessionsTmpDir,
+  };
+});
+
+await jest.unstable_mockModule('../src/lib/api.js', () => ({
+  createClient: jest.fn(),
+  login: jest.fn(),
+}));
+
+const { createClient } = await import('../src/lib/api.js');
+const { performRun } = await import('../src/commands/agent.js');
+const { getSession, setSession, clearSessions } = await import('../src/lib/session-store.js');
+const stubAdapter = (await import('../src/lib/adapters/stub.js')).default;
+
+const makeEvent = (overrides = {}) => ({
+  _id: 'evt-1',
+  type: 'chat.mention',
+  podId: 'pod-abc',
+  agentName: 'my-stub',
+  instanceId: 'default',
+  payload: { content: 'hello from tester' },
+  ...overrides,
+});
+
+// setTimeout that never fires — ensures performRun executes exactly one cycle.
+const noopTimeout = () => 0;
+
+// Let the initial tick() promise chain drain before stopping. We loop
+// several times so `get → for(event) → spawn → post → ack` all settle — a
+// single setImmediate only drains one await depth and races as Phase 1b
+// adds the memory bridge.
+const drainMicrotasks = async () => {
+  for (let i = 0; i < 10; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => setImmediate(r));
+  }
+};
+
+describe('performRun', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fs.rmSync(path.join(sessionsTmpDir, '.commonly'), { recursive: true, force: true });
+  });
+
+  test('event with content → adapter.spawn → message posted → event acked', async () => {
+    const events = [makeEvent()];
+    const mockGet = jest.fn().mockResolvedValue({ events });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn(async () => ({ text: 'hello back' }));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      instanceId: 'default',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    expect(mockGet).toHaveBeenCalledWith(
+      '/api/agents/runtime/events',
+      expect.objectContaining({ agentName: 'my-stub', instanceId: 'default' }),
+    );
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn.mock.calls[0][0]).toBe('hello from tester');
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/pods/pod-abc/messages',
+      { content: 'hello back' },
+    );
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-1/ack',
+      { result: { outcome: 'posted' } },
+    );
+  });
+
+  test('heartbeat event with payload.content is suppressed — chat-only events spawn', async () => {
+    // Regression: a heartbeat with a stray `content` field must NOT trigger
+    // a spawn. Only CHAT_EVENT_TYPES are forwarded to the CLI.
+    const events = [makeEvent({
+      _id: 'evt-hb',
+      type: 'heartbeat',
+      payload: { content: 'do not spawn me' },
+    })];
+    const mockGet = jest.fn().mockResolvedValue({ events });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn();
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-hb/ack',
+      { result: { outcome: 'no_action' } },
+    );
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  test('chat event with no podId → no spawn, no message, acked as no_action', async () => {
+    const events = [makeEvent({ _id: 'evt-nopod', podId: null })];
+    const mockGet = jest.fn().mockResolvedValue({ events });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn();
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    // No destination → skip spawn entirely, don't burn a CLI turn.
+    expect(spawn).not.toHaveBeenCalled();
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-nopod/ack',
+      { result: { outcome: 'no_action' } },
+    );
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  test('adapter.spawn throws → no post, no ack (re-delivery path)', async () => {
+    const events = [makeEvent({ _id: 'evt-boom' })];
+    const mockGet = jest.fn().mockResolvedValue({ events });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn().mockRejectedValue(new Error('claude process died'));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+    const errors = [];
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+      onError: (err) => errors.push(err),
+    });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(/claude process died/);
+
+    // CRITICAL: no message post, no ack — kernel MUST re-deliver.
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  test('newSessionId from spawn is persisted and reused on the next turn', async () => {
+    const mockGet = jest.fn()
+      .mockResolvedValueOnce({ events: [makeEvent({ _id: 'turn-1' })] })
+      .mockResolvedValueOnce({ events: [makeEvent({ _id: 'turn-2' })] });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const seenSessionIds = [];
+    const spawn = jest.fn(async (_prompt, ctx) => {
+      seenSessionIds.push(ctx.sessionId);
+      return { text: 'ok', newSessionId: 'claude-sid-42' };
+    });
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    // Cycle 1 — no session yet.
+    const run1 = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    run1.stop();
+
+    // Disk state: newSessionId should be persisted.
+    expect(getSession('my-stub', 'pod-abc')).toBe('claude-sid-42');
+
+    // Cycle 2 — should see the persisted session id injected into ctx.
+    const run2 = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    run2.stop();
+
+    expect(seenSessionIds).toEqual([null, 'claude-sid-42']);
+  });
+
+  test('clearSessions removes persisted session ids for an agent', async () => {
+    setSession('my-stub', 'pod-a', 'sid-a');
+    setSession('my-stub', 'pod-b', 'sid-b');
+    setSession('other', 'pod-a', 'sid-other');
+    expect(getSession('my-stub', 'pod-a')).toBe('sid-a');
+
+    clearSessions('my-stub');
+
+    expect(getSession('my-stub', 'pod-a')).toBeNull();
+    expect(getSession('my-stub', 'pod-b')).toBeNull();
+    // Other agents' sessions are untouched (per-agent file isolation).
+    expect(getSession('other', 'pod-a')).toBe('sid-other');
+  });
+
+  test('stop() prevents subsequent events within the same cycle from being processed', async () => {
+    const events = [makeEvent({ _id: 'e1' }), makeEvent({ _id: 'e2' })];
+    const mockGet = jest.fn().mockResolvedValue({ events });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    let handle;
+    const spawn = jest.fn(async () => {
+      // After the first spawn, stop the loop.
+      handle?.stop();
+      return { text: 'only-one' };
+    });
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    handle = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+
+    // Only the first event was processed; the second skipped due to stop().
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const ackCalls = mockPost.mock.calls.filter(
+      ([route]) => route.includes('/events/') && route.endsWith('/ack'),
+    );
+    expect(ackCalls).toHaveLength(1);
+    expect(ackCalls[0][0]).toContain('/events/e1/ack');
+  });
+});

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -3,15 +3,232 @@
  *
  * register   — register a webhook agent against an instance
  * connect    — local dev loop: poll events → forward to localhost
+ * attach     — wrap a local CLI as a Commonly agent (ADR-005)
+ * run        — poll events, spawn the wrapped CLI, post results (ADR-005)
  * list       — list installed agents
  * logs       — stream recent events for an agent
  * heartbeat  — manually trigger an agent's heartbeat
  */
 
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { homedir, tmpdir } from 'os';
+
 import { createClient } from '../lib/api.js';
 import { getToken, resolveInstanceUrl } from '../lib/config.js';
 import { startPoller } from '../lib/poller.js';
 import { startWebhookServer, forwardToLocalWebhook } from '../lib/webhook-server.js';
+import { getAdapter, listAdapterNames } from '../lib/adapters/index.js';
+import { getSession, setSession } from '../lib/session-store.js';
+
+// ── Token file I/O — ~/.commonly/tokens/<name>.json (ADR-005) ───────────────
+
+const tokensDir = () => join(homedir(), '.commonly', 'tokens');
+const tokenFile = (name) => join(tokensDir(), `${name}.json`);
+
+export const saveAgentToken = (name, record) => {
+  if (!existsSync(tokensDir())) mkdirSync(tokensDir(), { recursive: true });
+  writeFileSync(
+    tokenFile(name),
+    JSON.stringify({ ...record, savedAt: new Date().toISOString() }, null, 2),
+    'utf8',
+  );
+};
+
+export const loadAgentToken = (name) => {
+  const file = tokenFile(name);
+  if (!existsSync(file)) return null;
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+};
+
+// Event types that carry a human/agent-authored prompt the wrapper should
+// forward to the CLI. Other event types (heartbeat, delivery, etc.) are acked
+// as no_action even if they happen to carry `content` in their payload.
+const CHAT_EVENT_TYPES = new Set(['chat.mention', 'message.posted', 'dm.message']);
+
+// ── attach: register a local-CLI-wrapped agent (ADR-005) ────────────────────
+
+/**
+ * Publish, install, and mint a runtime token for a local-CLI-wrapped agent.
+ * Pure core — the commander action wraps this with config loading + logging.
+ */
+export const performAttach = async ({
+  client,
+  adapterName,
+  agentName,
+  podId,
+  displayName,
+  log = () => {},
+}) => {
+  const adapter = getAdapter(adapterName);
+  if (!adapter) {
+    throw new Error(
+      `Unknown adapter "${adapterName}". Known: ${listAdapterNames().join(', ')}`,
+    );
+  }
+
+  const detected = await adapter.detect();
+  if (!detected) {
+    throw new Error(`${adapterName} not found on PATH. Install it and retry.`);
+  }
+
+  // Idempotent publish — already-published is expected and fine. Install will
+  // surface the real error if the manifest is truly unusable.
+  try {
+    await client.post('/api/registry/publish', {
+      manifest: {
+        name: agentName,
+        version: '1.0.0',
+        description: displayName || agentName,
+        runtimeType: 'local-cli',
+      },
+      displayName: displayName || agentName,
+    });
+  } catch (err) {
+    log(`publish skipped: ${err.message}`);
+  }
+
+  // config.runtime is an opaque blob the backend stores verbatim — kernel
+  // does not interpret runtimeType here. ADR-004 §Identity's `sourceRuntime`
+  // is a different field (memory-sync tag); don't conflate the two.
+  const installResult = await client.post('/api/registry/install', {
+    agentName,
+    podId,
+    displayName: displayName || agentName,
+    version: '1.0.0',
+    config: {
+      runtime: {
+        runtimeType: 'local-cli',
+        wrappedCli: adapter.name,
+      },
+    },
+    scopes: ['context:read', 'messages:write', 'memory:read', 'memory:write'],
+  });
+
+  const installation = installResult.installation || installResult;
+  const instanceId = installation.instanceId || 'default';
+
+  let runtimeToken = installResult.runtimeToken;
+  if (!runtimeToken) {
+    const tokenData = await client.post(
+      `/api/registry/pods/${podId}/agents/${agentName}/runtime-tokens`, {},
+    );
+    runtimeToken = tokenData.token;
+  }
+  if (!runtimeToken) {
+    throw new Error('Runtime token was not returned by install or tokens endpoint');
+  }
+
+  return { installation, instanceId, runtimeToken, detected, wrappedCli: adapter.name };
+};
+
+// ── run: local-CLI wrapper loop (ADR-005) ────────────────────────────────────
+
+const extractPrompt = (event) => {
+  if (!CHAT_EVENT_TYPES.has(event.type)) return null;
+  const p = event.payload || {};
+  return p.content || p.prompt || p.text || null;
+};
+
+/**
+ * Start the run loop. Polls /events, spawns the adapter per event, posts the
+ * result into the pod, acks.
+ *
+ * ADR-005 invariant #4: serialized per agent. The outer poll loop awaits each
+ * event before moving to the next; this function is only ever invoked once
+ * per `commonly agent run` process, so two spawns never overlap for the same
+ * agent.
+ *
+ * ADR-005 §Spawning semantics: on adapter failure the event is NOT acked, so
+ * the kernel re-delivers. This diverges from `startPoller` (which acks all
+ * outcomes) — the local-CLI wrapper needs re-delivery on spawn failure because
+ * spawn failure is a runtime problem, not a "processed and declined" outcome.
+ */
+export const performRun = ({
+  instanceUrl,
+  token,
+  adapter,
+  agentName,
+  instanceId = 'default',
+  podId = null,
+  intervalMs = 5000,
+  log = () => {},
+  onError,
+  setTimeoutImpl = setTimeout,
+}) => {
+  const client = createClient({ instance: instanceUrl, token });
+  let running = true;
+
+  const processEvent = async (event) => {
+    const eventPodId = event.podId || podId;
+    const prompt = extractPrompt(event);
+    if (!prompt || !eventPodId) {
+      // No prompt, or nowhere to post the response — skip spawn entirely so
+      // we never consume a CLI turn for a message with no destination.
+      log(`[${event.type}] no prompt — no-op`);
+      return { outcome: 'no_action' };
+    }
+
+    const sessionId = getSession(agentName, eventPodId);
+    log(`[${event.type}] spawning ${adapter.name}`);
+    // memoryLongTerm is the memory-bridge injection point — see ADR-005
+    // §Memory bridge. Wired in Phase 1b together with adapters/claude.js.
+    const result = await adapter.spawn(prompt, {
+      sessionId,
+      cwd: join(tmpdir(), 'commonly-agents', agentName),
+      env: process.env,
+      memoryLongTerm: '',
+      metadata: { event },
+    });
+
+    if (result.newSessionId) {
+      setSession(agentName, eventPodId, result.newSessionId);
+    }
+    if (result.text) {
+      await client.post(`/api/agents/runtime/pods/${eventPodId}/messages`, {
+        content: result.text,
+      });
+      log(`[${event.type}] posted ${Buffer.byteLength(result.text)} bytes`);
+    }
+    return { outcome: 'posted' };
+  };
+
+  const tick = async () => {
+    if (!running) return;
+    try {
+      const { events = [] } = await client.get('/api/agents/runtime/events', {
+        agentName, instanceId, limit: 10,
+      });
+      for (const event of events) {
+        if (!running) break;
+        let result;
+        try {
+          result = await processEvent(event);
+        } catch (err) {
+          // Spawn failed — skip ack, let kernel re-deliver (ADR-005).
+          log(`[${event.type}] spawn error: ${err.message}`);
+          onError?.(err);
+          continue;
+        }
+        try {
+          await client.post(`/api/agents/runtime/events/${event._id}/ack`, { result });
+        } catch (ackErr) {
+          onError?.(new Error(`Ack failed for ${event._id}: ${ackErr.message}`));
+        }
+      }
+    } catch (err) {
+      onError?.(err);
+    }
+    if (running) setTimeoutImpl(tick, intervalMs);
+  };
+
+  tick();
+  return { stop: () => { running = false; } };
+};
 
 export const registerAgent = (program) => {
   const agent = program.command('agent').description('Manage agents');
@@ -157,6 +374,90 @@ export const registerAgent = (program) => {
         console.log('\nStopping...');
         poller.stop();
         close();
+        process.exit(0);
+      });
+    });
+
+  // ── attach (ADR-005) ──────────────────────────────────────────────────────
+  agent
+    .command('attach <adapter>')
+    .description('Wrap a local CLI as a Commonly agent (stub|claude|codex|…)')
+    .requiredOption('--pod <podId>', 'Pod ID to install into')
+    .requiredOption('--name <name>', 'Agent name (e.g. my-claude)')
+    .option('--display <name>', 'Display name shown in the pod')
+    .option('--instance <url>', 'Target Commonly instance')
+    .action(async (adapterName, opts) => {
+      const instanceUrl = resolveInstanceUrl(opts.instance);
+      const token = getToken(opts.instance);
+      if (!token) { console.error('Not logged in. Run: commonly login'); process.exit(1); }
+
+      const client = createClient({ instance: instanceUrl, token });
+
+      try {
+        const { installation, instanceId, runtimeToken, detected, wrappedCli } =
+          await performAttach({
+            client,
+            adapterName,
+            agentName: opts.name,
+            podId: opts.pod,
+            displayName: opts.display,
+            log: (line) => console.warn(`[attach] ${line}`),
+          });
+
+        saveAgentToken(opts.name, {
+          agentName: opts.name,
+          instanceId,
+          podId: opts.pod,
+          instanceUrl,
+          runtimeToken,
+          adapter: wrappedCli,
+        });
+
+        console.log(`✓ ${wrappedCli} detected at ${detected.path} (${detected.version})`);
+        console.log(`✓ Agent '${installation.agentName}' registered in pod ${opts.pod} (${instanceId})`);
+        console.log(`✓ Runtime token saved to ${tokenFile(opts.name)}`);
+        console.log(`\n  Run with: commonly agent run ${opts.name}`);
+      } catch (err) {
+        console.error(`Attach failed: ${err.message}`);
+        process.exit(1);
+      }
+    });
+
+  // ── run (ADR-005) ─────────────────────────────────────────────────────────
+  agent
+    .command('run <name>')
+    .description('Run the local-CLI wrapper loop for an attached agent')
+    .option('--interval <ms>', 'Poll interval in ms', '5000')
+    .action(async (name, opts) => {
+      const record = loadAgentToken(name);
+      if (!record) {
+        console.error(`No token for '${name}'. Run: commonly agent attach <adapter> --pod <podId> --name ${name}`);
+        process.exit(1);
+      }
+
+      const adapter = getAdapter(record.adapter);
+      if (!adapter) {
+        console.error(`Unknown adapter '${record.adapter}' in token file. Known: ${listAdapterNames().join(', ')}`);
+        process.exit(1);
+      }
+
+      console.log(`[${name}] polling ${record.instanceUrl} for events (ctrl+c to stop)`);
+
+      const { stop } = performRun({
+        instanceUrl: record.instanceUrl,
+        token: record.runtimeToken,
+        adapter,
+        agentName: record.agentName,
+        instanceId: record.instanceId,
+        podId: record.podId,
+        intervalMs: parseInt(opts.interval, 10),
+        log: (line) => console.log(`[${name}] ${line}`),
+        onError: (err) => console.error(`[${name}] ${err.message}`),
+      });
+
+      process.on('SIGINT', () => {
+        console.log(`\n[${name}] stopping...`);
+        stop();
         process.exit(0);
       });
     });

--- a/cli/src/lib/adapters/index.js
+++ b/cli/src/lib/adapters/index.js
@@ -1,0 +1,18 @@
+/**
+ * Adapter registry — ADR-005 §Adapter pattern.
+ *
+ * `attach <adapter>` and `run <name>` both resolve an adapter by its string
+ * name through this single registry. Adding a new CLI (claude, codex, cursor,
+ * gemini, …) is a one-file PR that exports a default adapter and adds an
+ * entry below.
+ */
+
+import stub from './stub.js';
+
+const ADAPTERS = {
+  [stub.name]: stub,
+};
+
+export const listAdapterNames = () => Object.keys(ADAPTERS);
+
+export const getAdapter = (name) => ADAPTERS[name] || null;

--- a/cli/src/lib/adapters/stub.js
+++ b/cli/src/lib/adapters/stub.js
@@ -1,0 +1,24 @@
+/**
+ * Stub adapter — the no-op reference implementation of the ADR-005 adapter
+ * contract. Used by `commonly agent attach stub` and the Phase-1a test
+ * harness so the run loop can be reviewed end-to-end without a real CLI
+ * on PATH.
+ *
+ * Contract (ADR-005 §Adapter pattern):
+ *   detect(): Promise<{ path, version } | null>
+ *   spawn(prompt, ctx): Promise<{ text, newSessionId?, memorySummary? }>
+ *
+ * The adapter MUST be pure: input (argv + env + prompt) → output (text + optional
+ * next session-id + optional memory summary). No direct network, no direct API
+ * calls, no hidden state. The run loop handles all Commonly-facing I/O.
+ */
+
+export default {
+  name: 'stub',
+  async detect() {
+    return { path: '(builtin)', version: '0.0.0' };
+  },
+  async spawn(prompt, _ctx) {
+    return { text: `(stub) received: ${String(prompt ?? '').slice(0, 200)}` };
+  },
+};

--- a/cli/src/lib/session-store.js
+++ b/cli/src/lib/session-store.js
@@ -1,0 +1,56 @@
+/**
+ * Session store — per-(agent, pod) session IDs at ~/.commonly/sessions/<agent>.json.
+ *
+ * Used by the local-CLI wrapper driver (ADR-005). Wrapped CLIs that support
+ * conversation session IDs (claude --session-id, codex --session, …) call
+ * getSession / setSession around each spawn so the next turn continues where
+ * the previous one left off.
+ *
+ * One file per agent so two `commonly agent run` processes for different
+ * agents never race on the same file (ADR-005 §Spawning semantics permits
+ * parallel agents). Shape on disk:
+ *   {
+ *     "<podId>": { "sessionId": "abc123", "lastTurn": "2026-04-14T18:00:00Z" }
+ *   }
+ *
+ * CLIs without sessions simply never call setSession — getSession returns null.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+const sessionsDir = () => join(homedir(), '.commonly', 'sessions');
+const sessionsFile = (agentName) => join(sessionsDir(), `${agentName}.json`);
+
+const readAgent = (agentName) => {
+  const file = sessionsFile(agentName);
+  if (!existsSync(file)) return {};
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'));
+  } catch {
+    return {};
+  }
+};
+
+const writeAgent = (agentName, state) => {
+  if (!existsSync(sessionsDir())) mkdirSync(sessionsDir(), { recursive: true });
+  writeFileSync(sessionsFile(agentName), JSON.stringify(state, null, 2), 'utf8');
+};
+
+export const getSession = (agentName, podId) => {
+  if (!agentName || !podId) return null;
+  return readAgent(agentName)[podId]?.sessionId || null;
+};
+
+export const setSession = (agentName, podId, sessionId) => {
+  if (!agentName || !podId) return;
+  const state = readAgent(agentName);
+  state[podId] = { sessionId, lastTurn: new Date().toISOString() };
+  writeAgent(agentName, state);
+};
+
+export const clearSessions = (agentName) => {
+  const file = sessionsFile(agentName);
+  if (existsSync(file)) rmSync(file);
+};

--- a/docs/adr/ADR-005-local-cli-wrapper-driver.md
+++ b/docs/adr/ADR-005-local-cli-wrapper-driver.md
@@ -108,17 +108,15 @@ Target size: ~30–60 lines per adapter. Adding a new CLI is a single-file PR.
 
 ### Session continuity
 
-CLIs with per-conversation session IDs (`claude`, `codex`, `openclaw`) benefit from persistence across pod turns. The wrapper maintains a local map at `~/.commonly/sessions.json`:
+CLIs with per-conversation session IDs (`claude`, `codex`, `openclaw`) benefit from persistence across pod turns. The wrapper keeps one file per agent at `~/.commonly/sessions/<agentName>.json`:
 
 ```json
 {
-  "my-claude": {
-    "<podId>": { "sessionId": "abc123", "lastTurn": "2026-04-14T18:00:00Z" }
-  }
+  "<podId>": { "sessionId": "abc123", "lastTurn": "2026-04-14T18:00:00Z" }
 }
 ```
 
-Before each spawn, the wrapper looks up `(agentName, podId)` and passes the stored `sessionId` to the adapter. After each spawn, `SpawnResult.newSessionId` updates the map. CLIs without sessions get a fresh invocation each time.
+One file per agent — not a single shared map — so two `commonly agent run` processes for different agents never race on the same file (see §Spawning semantics). Before each spawn, the wrapper looks up `(agentName, podId)` and passes the stored `sessionId` to the adapter. After each spawn, `SpawnResult.newSessionId` updates the file. CLIs without sessions get a fresh invocation each time.
 
 ### Memory bridge
 
@@ -149,8 +147,9 @@ This is a deliberate trade: the wrapper trusts `$HOME`. If the user runs `common
 
 ### Spawning semantics
 
-- **Serialized per agent**: the wrapper handles events sequentially for each agent. No two spawns of the same agent in-flight simultaneously. Simpler than concurrency; avoids session-id races.
-- **Parallel across agents**: running `commonly agent run agent-a` and `commonly agent run agent-b` in two terminals is supported; each has its own poll loop and session state.
+- **Serialized per run process**: the wrapper handles events sequentially within a single `commonly agent run` process — no two spawns in-flight simultaneously. Simpler than concurrency; avoids session-id races within the process.
+- **Parallel across agents**: running `commonly agent run agent-a` and `commonly agent run agent-b` in two terminals is supported; each has its own poll loop and its own session file.
+- **Two terminals for the same agent are unsupported in v1.** Running `commonly agent run my-claude` twice concurrently would produce duplicate spawns and post twice to the pod. The wrapper does not enforce single-instance — it is the user's responsibility (a pidfile is a candidate post-v1).
 - **Timeout**: spawns time out at 5 minutes by default (configurable per adapter). Timed-out spawns get killed, the event is not acked, the kernel re-delivers it.
 - **Failure**: if the adapter throws, the wrapper posts nothing to the pod, logs locally, and does NOT ack. Re-delivery lets transient failures recover.
 
@@ -281,7 +280,7 @@ Publish + install instructions. Gated on CAP v1 being documented (ADR-004 Phase 
 
 ## Open questions
 
-1. **Serialization scope**: should "serialized per agent" be "serialized per `(agent, pod)`"? Matters when a single `my-claude` runs in 3 pods concurrently. Proposal for v1: per agent across pods; re-examine when concurrent load is real.
+1. **Serialization scope**: should "serialized per run process" be "serialized per `(agent, pod)`"? Matters when a single `my-claude` runs in 3 pods concurrently. Resolved for v1: serialized per run process — one `commonly agent run` means one spawn at a time. Two terminals for the same agent name are unsupported (see §Spawning semantics). Re-examine when concurrent load is real.
 2. **Memory summary generation**: if the wrapped CLI doesn't return a summary, should the wrapper auto-summarize the turn with a cheap model call? Today: no — agents whose CLI doesn't cooperate simply don't update memory, and that's fine. Revisit if we see agents accumulating stale context.
 3. **Adapter for "just a bash script"**: how much adapter is a 10-line bash script? Probably a single `script.js` adapter that takes a path + argv template at `attach` time. Could close 90% of long-tail cases. File as a follow-up if users ask.
 4. **Windows support**: is the shim shell-based (POSIX) or does it use Node's direct spawn? Node's `child_process.spawn` without a shell works cross-platform; keep that path. Windows-specific adapter paths are a later concern.


### PR DESCRIPTION
## Summary

Smallest reviewable slice of [ADR-005](../blob/main/docs/adr/ADR-005-local-cli-wrapper-driver.md) — the local-CLI-wrapper driver. Ships `commonly agent attach` + `commonly agent run` end-to-end against a no-op **stub adapter** so the run loop is reviewable in isolation. Real CLI adapters (claude/codex/…) + the ADR-003 memory bridge land in Phase 1b.

## What's in

- `cli/src/commands/agent.js` — `attach` + `run` subcommands. Pure cores (`performAttach`, `performRun`, `saveAgentToken`, `loadAgentToken`) exported for testability.
- `cli/src/lib/session-store.js` — per-(agent, pod) session IDs at `~/.commonly/sessions/<agent>.json`. One file per agent so two `commonly agent run` processes for different agents don't race.
- `cli/src/lib/adapters/stub.js` + `adapters/index.js` — no-op reference adapter + tiny registry. Adding `claude` in Phase 1b is a one-line change in `index.js`.
- `cli/__tests__/attach.test.mjs` + `run-loop.test.mjs` — 14 new tests. Mocks `createClient` + `os.homedir` (same pattern as existing `lib.test.mjs`). Covers attach flow, token-file round trip, happy-path spawn/post/ack, chat-type filtering, no-pod no_action, **adapter-failure re-delivery (no ack)**, session-id continuity, stop() semantics, clearSessions.
- `docs/adr/ADR-005` — clarified serialization scope (per run process) and per-agent session-file layout; closed Open Question #1.

## What's NOT in (by design)

- Memory bridge (Phase 1b per ADR-005 §Migration path).
- Real CLI adapters — only `stub` exists.
- Backend awareness of `runtimeType: 'local-cli'` — install stores `config.runtime` as an opaque blob per ADR-001; no backend change needed for Phase 1a.
- At-least-once idempotency via event-id dedup (ADR-005 invariant #7) — parked; Phase 1a relies on kernel re-delivery only on adapter failure.

## Reviewer-pass findings addressed before commit

- **Critical**: null-pod events now skip spawn entirely (was acked as `posted` without posting).
- **Important**: publish errors now logged, not silently swallowed.
- **Important**: session store switched to per-agent files to close the concurrent-write race.
- **Important**: `extractPrompt` now filters on `CHAT_EVENT_TYPES` so a heartbeat with a stray `content` field can't trigger a spawn.
- **Nit**: `cwd` uses `os.tmpdir()` instead of hardcoded `/tmp`; Phase-1b TODO comment now cites the ADR section.

## Test plan

- [x] `cd cli && npm test` — 28/28 passing (3 suites)
- [x] `npm run lint` from repo root — 0 new errors in `cli/`
- [ ] Live against `api-dev.commonly.me` (attach stub + run, verify token file + ack loop) — deferred to Phase 1b when a real adapter exists to spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)