### PR TITLE
feat(cli): ADR-005 Phase 1b — claude adapter + memory bridge

### DIFF
--- a/cli/__tests__/adapters.claude.test.mjs
+++ b/cli/__tests__/adapters.claude.test.mjs
@@ -1,0 +1,153 @@
+/**
+ * adapters.claude.test.mjs — ADR-005 Phase 1b
+ *
+ * Covers the claude-CLI adapter. The real `claude` binary is never invoked
+ * here: `child_process.spawnSync` is mocked at the module level for detect(),
+ * and the adapter's `_spawnImpl` test seam (ctx field) replaces childSpawn
+ * for spawn(). Both are internal-only seams — production code never touches
+ * `_spawnImpl`.
+ */
+
+import { jest } from '@jest/globals';
+import { EventEmitter } from 'events';
+
+// Mock child_process.spawnSync used by detect(). We leave `spawn` real so
+// nothing else in the module breaks — the adapter uses `_spawnImpl` instead.
+const spawnSyncMock = jest.fn();
+await jest.unstable_mockModule('child_process', () => ({
+  spawnSync: spawnSyncMock,
+  spawn: jest.fn(),
+}));
+
+const claude = (await import('../src/lib/adapters/claude.js')).default;
+
+// Fake child process — returned by the injected `_spawnImpl`.
+const fakeChild = ({ stdout = '', stderr = '', code = 0, delayMs = 0 } = {}) => {
+  const proc = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = jest.fn();
+  setTimeout(() => {
+    if (stdout) proc.stdout.emit('data', Buffer.from(stdout));
+    if (stderr) proc.stderr.emit('data', Buffer.from(stderr));
+    proc.emit('close', code);
+  }, delayMs);
+  return proc;
+};
+
+const makeSpawnImpl = (childOpts) => {
+  const calls = [];
+  const impl = (cmd, args, opts) => {
+    calls.push({ cmd, args, opts });
+    return fakeChild(childOpts);
+  };
+  return { impl, calls };
+};
+
+describe('claude adapter — detect()', () => {
+  beforeEach(() => { spawnSyncMock.mockReset(); });
+
+  test('returns { path, version } when `claude --version` exits 0', async () => {
+    spawnSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'which') return { status: 0, stdout: '/usr/local/bin/claude\n' };
+      return { status: 0, stdout: '2.5.1 (Claude Code)\n', error: null };
+    });
+    const res = await claude.detect();
+    expect(res).toEqual({ path: '/usr/local/bin/claude', version: '2.5.1' });
+    expect(spawnSyncMock).toHaveBeenCalledWith('claude', ['--version'], expect.any(Object));
+  });
+
+  test('falls back to `claude` as path when `which` is unavailable (e.g. Windows)', async () => {
+    spawnSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'which') return { status: 127, error: new Error('ENOENT') };
+      return { status: 0, stdout: '2.5.1\n' };
+    });
+    const res = await claude.detect();
+    expect(res.path).toBe('claude');
+    expect(res.version).toBe('2.5.1');
+  });
+
+  test('returns null when claude is not on PATH (spawnSync error)', async () => {
+    spawnSyncMock.mockReturnValue({ status: null, error: new Error('ENOENT') });
+    expect(await claude.detect()).toBeNull();
+  });
+
+  test('returns null when claude exits non-zero', async () => {
+    spawnSyncMock.mockReturnValue({ status: 1, stdout: '', stderr: 'boom', error: null });
+    expect(await claude.detect()).toBeNull();
+  });
+});
+
+describe('claude adapter — spawn()', () => {
+  test('builds argv with -p <prompt> --output-format text --session-id <sid>', async () => {
+    const { impl, calls } = makeSpawnImpl({ stdout: 'hello\n' });
+    const res = await claude.spawn('hello world', {
+      sessionId: 'sid-123',
+      cwd: '/tmp/commonly-agents/my-claude',
+      env: {},
+      memoryLongTerm: '',
+      _spawnImpl: impl,
+    });
+
+    expect(res.text).toBe('hello');
+    expect(res.newSessionId).toBe('sid-123');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].cmd).toBe('claude');
+    expect(calls[0].args).toEqual(
+      ['-p', 'hello world', '--output-format', 'text', '--session-id', 'sid-123'],
+    );
+  });
+
+  test('mints a new session id on first turn when ctx.sessionId is null', async () => {
+    const { impl, calls } = makeSpawnImpl({ stdout: 'ok' });
+    const res = await claude.spawn('hi', { sessionId: null, _spawnImpl: impl });
+
+    // UUID v4 shape: 8-4-4-4-12 hex groups.
+    expect(res.newSessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(calls[0].args).toContain(res.newSessionId);
+  });
+
+  test('prepends the memory preamble when ctx.memoryLongTerm is non-empty', async () => {
+    const { impl, calls } = makeSpawnImpl({ stdout: 'ok' });
+    await claude.spawn('current message', {
+      sessionId: 'sid-1',
+      memoryLongTerm: 'I remember the user prefers dark mode.',
+      _spawnImpl: impl,
+    });
+
+    const promptArg = calls[0].args[1]; // args = ['-p', <prompt>, ...]
+    expect(promptArg).toContain('=== Context');
+    expect(promptArg).toContain('I remember the user prefers dark mode.');
+    expect(promptArg).toContain('=== Current turn ===');
+    expect(promptArg).toContain('current message');
+  });
+
+  test('no preamble when memoryLongTerm is empty — prompt passed verbatim', async () => {
+    const { impl, calls } = makeSpawnImpl({ stdout: 'ok' });
+    await claude.spawn('just this', { sessionId: 'sid-1', memoryLongTerm: '', _spawnImpl: impl });
+    expect(calls[0].args[1]).toBe('just this');
+  });
+
+  test('rejects when claude exits non-zero, surfacing stderr', async () => {
+    const { impl } = makeSpawnImpl({ stdout: '', stderr: 'auth error', code: 1 });
+    await expect(
+      claude.spawn('x', { sessionId: 'sid-1', _spawnImpl: impl }),
+    ).rejects.toThrow(/claude exited with code 1.*auth error/);
+  });
+
+  test('rejects on timeout and SIGTERMs the child', async () => {
+    // Child never emits close within the window.
+    const proc = new EventEmitter();
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = jest.fn();
+    const impl = () => proc;
+
+    const p = claude.spawn('x', { sessionId: 'sid-1', timeoutMs: 20, _spawnImpl: impl });
+    // After kill, simulate the process closing so the adapter resolves its close handler.
+    setTimeout(() => proc.emit('close', null), 40);
+
+    await expect(p).rejects.toThrow(/timed out after 20ms/);
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+});

--- a/cli/__tests__/memory-bridge.test.mjs
+++ b/cli/__tests__/memory-bridge.test.mjs
@@ -1,0 +1,133 @@
+/**
+ * memory-bridge.test.mjs — ADR-005 §Memory bridge, ADR-003 Phase 2
+ *
+ * Exercises the two CAP shims the run loop calls around every spawn cycle.
+ * Identity (agentName, instanceId) is server-derived from the runtime token,
+ * so neither helper takes them — the mocked client just records routes+bodies.
+ */
+
+import { jest } from '@jest/globals';
+import { readLongTerm, syncBack, SOURCE_RUNTIME } from '../src/lib/memory-bridge.js';
+
+const makeClient = ({ memoryPayload = null, getThrows = false, postThrows = false } = {}) => {
+  const get = jest.fn(async () => {
+    if (getThrows) throw new Error('404 not found');
+    return memoryPayload;
+  });
+  const post = jest.fn(async () => {
+    if (postThrows) throw new Error('500 sync failed');
+    return { ok: true };
+  });
+  return { get, post };
+};
+
+describe('readLongTerm', () => {
+  test('extracts sections.long_term.content from the envelope', async () => {
+    const client = makeClient({
+      memoryPayload: {
+        content: 'legacy mirror',
+        sections: {
+          long_term: { content: 'I remember dark mode.', byteSize: 99 },
+          soul: { content: 'the agent persona' },
+        },
+        sourceRuntime: 'local-cli',
+        schemaVersion: 2,
+      },
+    });
+
+    const got = await readLongTerm(client);
+    expect(got).toBe('I remember dark mode.');
+    expect(client.get).toHaveBeenCalledWith('/api/agents/runtime/memory');
+  });
+
+  test('returns empty string when the envelope has no long_term section', async () => {
+    const client = makeClient({
+      memoryPayload: { sections: { soul: { content: 'persona' } } },
+    });
+    expect(await readLongTerm(client)).toBe('');
+  });
+
+  test('returns empty string on 404 and does NOT surface via onError (fresh agent)', async () => {
+    const err404 = Object.assign(new Error('not found'), { status: 404 });
+    const client = {
+      get: jest.fn(async () => { throw err404; }),
+      post: jest.fn(),
+    };
+    const onError = jest.fn();
+    expect(await readLongTerm(client, { onError })).toBe('');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test('returns empty string BUT surfaces non-404 errors via onError (auth revoked, 500, etc.)', async () => {
+    const err401 = Object.assign(new Error('unauthorized'), { status: 401 });
+    const client = {
+      get: jest.fn(async () => { throw err401; }),
+      post: jest.fn(),
+    };
+    const onError = jest.fn();
+    expect(await readLongTerm(client, { onError })).toBe('');
+    expect(onError).toHaveBeenCalledWith(err401);
+  });
+
+  test('network-level errors (no status) are swallowed silently — no onError', async () => {
+    // A fetch-level failure before any response is comparable to "fresh
+    // agent": the spawn should proceed with empty context, no noise.
+    const client = {
+      get: jest.fn(async () => { throw new Error('ECONNREFUSED'); }),
+      post: jest.fn(),
+    };
+    const onError = jest.fn();
+    expect(await readLongTerm(client, { onError })).toBe('');
+    expect(onError).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncBack', () => {
+  test('POSTs patch with sourceRuntime:local-cli and content+visibility only', async () => {
+    const client = makeClient();
+    const res = await syncBack(client, { summary: 'User prefers dark mode.' });
+
+    expect(res).toEqual({ skipped: false });
+    expect(client.post).toHaveBeenCalledWith('/api/agents/runtime/memory/sync', {
+      mode: 'patch',
+      sourceRuntime: SOURCE_RUNTIME,
+      sections: {
+        long_term: {
+          content: 'User prefers dark mode.',
+          visibility: 'private',
+        },
+      },
+    });
+  });
+
+  test('never sends byteSize / updatedAt / schemaVersion — server-stamped (ADR-003 invariant #9)', async () => {
+    const client = makeClient();
+    await syncBack(client, { summary: 'anything' });
+
+    const body = client.post.mock.calls[0][1];
+    const longTerm = body.sections.long_term;
+    expect(longTerm).toEqual({ content: 'anything', visibility: 'private' });
+    expect(longTerm).not.toHaveProperty('byteSize');
+    expect(longTerm).not.toHaveProperty('updatedAt');
+    expect(body).not.toHaveProperty('schemaVersion');
+  });
+
+  test('no-op on empty summary — no POST issued', async () => {
+    const client = makeClient();
+    const res = await syncBack(client, { summary: '' });
+    expect(res).toEqual({ skipped: true });
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  test('no-op when summary field is absent', async () => {
+    const client = makeClient();
+    const res = await syncBack(client, {});
+    expect(res).toEqual({ skipped: true });
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  test('post errors propagate — callers decide whether to swallow', async () => {
+    const client = makeClient({ postThrows: true });
+    await expect(syncBack(client, { summary: 'x' })).rejects.toThrow(/sync failed/);
+  });
+});

--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -53,12 +53,14 @@ const makeEvent = (overrides = {}) => ({
 // setTimeout that never fires — ensures performRun executes exactly one cycle.
 const noopTimeout = () => 0;
 
-// Let the initial tick() promise chain drain before stopping. We loop
-// several times so `get → for(event) → spawn → post → ack` all settle — a
-// single setImmediate only drains one await depth and races as Phase 1b
-// adds the memory bridge.
+// Let the initial tick() promise chain drain before stopping. The longest
+// chain is currently:  get(/events) → get(/memory) → adapter.spawn →
+// post(/messages) → post(/memory/sync) → post(/events/:id/ack)  — 6 await
+// boundaries. Loop DRAIN_DEPTH setImmediates so each level resolves. Bump
+// this if another phase extends the chain.
+const DRAIN_DEPTH = 10;
 const drainMicrotasks = async () => {
-  for (let i = 0; i < 10; i += 1) {
+  for (let i = 0; i < DRAIN_DEPTH; i += 1) {
     // eslint-disable-next-line no-await-in-loop
     await new Promise((r) => setImmediate(r));
   }
@@ -198,9 +200,17 @@ describe('performRun', () => {
   });
 
   test('newSessionId from spawn is persisted and reused on the next turn', async () => {
-    const mockGet = jest.fn()
-      .mockResolvedValueOnce({ events: [makeEvent({ _id: 'turn-1' })] })
-      .mockResolvedValueOnce({ events: [makeEvent({ _id: 'turn-2' })] });
+    // Route-aware mock: /events yields a fresh event each call, /memory
+    // returns an empty envelope. `mockResolvedValueOnce` chaining broke once
+    // the memory bridge landed because `/memory` began consuming the queue.
+    let eventTurn = 0;
+    const eventIds = ['turn-1', 'turn-2'];
+    const mockGet = jest.fn(async (route) => {
+      if (route === '/api/agents/runtime/memory') return { sections: {} };
+      const id = eventIds[eventTurn];
+      eventTurn += 1;
+      return { events: id ? [makeEvent({ _id: id })] : [] };
+    });
     const mockPost = jest.fn().mockResolvedValue({});
     createClient.mockReturnValue({ get: mockGet, post: mockPost });
 
@@ -251,6 +261,143 @@ describe('performRun', () => {
     expect(getSession('my-stub', 'pod-b')).toBeNull();
     // Other agents' sessions are untouched (per-agent file isolation).
     expect(getSession('other', 'pod-a')).toBe('sid-other');
+  });
+
+  test('memory bridge: reads /memory before spawn, injects into ctx.memoryLongTerm', async () => {
+    const events = [makeEvent({ _id: 'mem-1' })];
+    const mockGet = jest.fn(async (route) => {
+      if (route === '/api/agents/runtime/memory') {
+        return { sections: { long_term: { content: 'remembered: likes dark mode' } } };
+      }
+      return { events };
+    });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    let seenCtx;
+    const spawn = jest.fn(async (_p, ctx) => {
+      seenCtx = ctx;
+      return { text: 'ok' };
+    });
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    expect(mockGet).toHaveBeenCalledWith('/api/agents/runtime/memory');
+    expect(seenCtx.memoryLongTerm).toBe('remembered: likes dark mode');
+  });
+
+  test('memory bridge: syncs back when adapter returns memorySummary', async () => {
+    const events = [makeEvent({ _id: 'sum-1' })];
+    const mockGet = jest.fn(async (route) => {
+      if (route === '/api/agents/runtime/memory') return { sections: {} };
+      return { events };
+    });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn(async () => ({
+      text: 'response',
+      memorySummary: 'user complained about loading spinner',
+    }));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/memory/sync',
+      expect.objectContaining({
+        mode: 'patch',
+        sourceRuntime: 'local-cli',
+        sections: {
+          long_term: {
+            content: 'user complained about loading spinner',
+            visibility: 'private',
+          },
+        },
+      }),
+    );
+  });
+
+  test('memory bridge: does NOT sync back when adapter omits memorySummary', async () => {
+    const events = [makeEvent({ _id: 'no-sum' })];
+    const mockGet = jest.fn(async (route) => {
+      if (route === '/api/agents/runtime/memory') return { sections: {} };
+      return { events };
+    });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn(async () => ({ text: 'just a reply' }));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    const syncCalls = mockPost.mock.calls.filter(
+      ([route]) => route === '/api/agents/runtime/memory/sync',
+    );
+    expect(syncCalls).toHaveLength(0);
+  });
+
+  test('memory bridge: sync failure is non-fatal — message still posted, event still acked', async () => {
+    const events = [makeEvent({ _id: 'sync-fail' })];
+    const mockGet = jest.fn(async (route) => {
+      if (route === '/api/agents/runtime/memory') return { sections: {} };
+      return { events };
+    });
+    const mockPost = jest.fn(async (route) => {
+      if (route === '/api/agents/runtime/memory/sync') throw new Error('500 sync down');
+      return { ok: true };
+    });
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn(async () => ({ text: 'reply', memorySummary: 'summary' }));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+    const errors = [];
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+      onError: (err) => errors.push(err),
+    });
+    await drainMicrotasks();
+    stop();
+
+    // Pod message still posted; event still acked as posted.
+    const msgPosts = mockPost.mock.calls.filter(([r]) => r.includes('/messages'));
+    const ackPosts = mockPost.mock.calls.filter(([r]) => r.endsWith('/ack'));
+    expect(msgPosts).toHaveLength(1);
+    expect(ackPosts).toHaveLength(1);
+    expect(ackPosts[0][1]).toEqual({ result: { outcome: 'posted' } });
+    // Sync failure surfaced via onError but didn't throw out of processEvent.
+    expect(errors.some((e) => /memory sync failed/.test(e.message))).toBe(true);
   });
 
   test('stop() prevents subsequent events within the same cycle from being processed', async () => {

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -20,6 +20,7 @@ import { startPoller } from '../lib/poller.js';
 import { startWebhookServer, forwardToLocalWebhook } from '../lib/webhook-server.js';
 import { getAdapter, listAdapterNames } from '../lib/adapters/index.js';
 import { getSession, setSession } from '../lib/session-store.js';
+import { readLongTerm, syncBack } from '../lib/memory-bridge.js';
 
 // ── Token file I/O — ~/.commonly/tokens/<name>.json (ADR-005) ───────────────
 
@@ -174,14 +175,15 @@ export const performRun = ({
     }
 
     const sessionId = getSession(agentName, eventPodId);
+    // ADR-005 §Memory bridge: read long_term before spawn, inject via ctx,
+    // and (if the adapter returns a summary) patch-sync back after.
+    const memoryLongTerm = await readLongTerm(client, { onError });
     log(`[${event.type}] spawning ${adapter.name}`);
-    // memoryLongTerm is the memory-bridge injection point — see ADR-005
-    // §Memory bridge. Wired in Phase 1b together with adapters/claude.js.
     const result = await adapter.spawn(prompt, {
       sessionId,
       cwd: join(tmpdir(), 'commonly-agents', agentName),
       env: process.env,
-      memoryLongTerm: '',
+      memoryLongTerm,
       metadata: { event },
     });
 
@@ -193,6 +195,18 @@ export const performRun = ({
         content: result.text,
       });
       log(`[${event.type}] posted ${Buffer.byteLength(result.text)} bytes`);
+    }
+    if (result.memorySummary) {
+      try {
+        await syncBack(client, { summary: result.memorySummary });
+        log(`[${event.type}] memory synced (${Buffer.byteLength(result.memorySummary)} bytes)`);
+      } catch (err) {
+        // Memory-sync failure is non-fatal: the turn already posted, and the
+        // next spawn will re-read from the kernel anyway. Surface, don't
+        // throw. Preserve the original error via `cause` so the stack trace
+        // survives for CLI debugging.
+        onError?.(new Error(`memory sync failed: ${err.message}`, { cause: err }));
+      }
     }
     return { outcome: 'posted' };
   };

--- a/cli/src/lib/adapters/claude.js
+++ b/cli/src/lib/adapters/claude.js
@@ -1,0 +1,99 @@
+/**
+ * claude adapter — wraps the local `claude` CLI as a Commonly agent.
+ *
+ * Contract: ADR-005 §Adapter pattern. Argv shape per ADR-005 §Adapters
+ * shipped in v1: `claude -p "$prompt" --output-format text --session-id $sid`.
+ *
+ * Memory preamble: if ctx.memoryLongTerm is non-empty, the adapter prepends
+ * it to the prompt as a system-context preamble (§Memory bridge).
+ *
+ * Session continuity: we pass the same stable session id to claude on every
+ * turn and return it as `newSessionId` so the run loop persists it. First
+ * turn mints a UUID; subsequent turns re-use it. claude keeps the
+ * conversation alive on its side for this id.
+ *
+ * Purity (§Load-bearing invariants #1): input = argv + env + prompt;
+ * output = text + session id. No direct network, no direct CAP calls.
+ *
+ * Test seam: `ctx._spawnImpl` is the sanctioned way for any adapter in this
+ * codebase to swap `child_process.spawn` out for a mock. Unit tests pass a
+ * fake that returns an EventEmitter; production never sets `_spawnImpl` so
+ * the default `childSpawn` is used. Future adapters should follow the same
+ * convention rather than inventing their own seam.
+ *
+ * Timeout caveat: we SIGTERM at `timeoutMs` and wait for `close`. If claude
+ * ignores SIGTERM the promise never resolves — the run loop stalls silently.
+ * SIGKILL escalation is a post-v1 concern (ADR-005 §Spawning semantics).
+ */
+
+import { spawn as childSpawn, spawnSync } from 'child_process';
+import { randomUUID } from 'crypto';
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // ADR-005 §Spawning semantics
+
+const buildPrompt = (prompt, memoryLongTerm) => {
+  if (!memoryLongTerm) return prompt;
+  return `=== Context (your persistent memory) ===\n${memoryLongTerm}\n=== Current turn ===\n${prompt}`;
+};
+
+const runClaude = ({ args, cwd, env, timeoutMs, spawnImpl = childSpawn }) => new Promise((resolve, reject) => {
+  const proc = spawnImpl('claude', args, { cwd, env });
+  let stdout = '';
+  let stderr = '';
+  let timedOut = false;
+
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill('SIGTERM');
+  }, timeoutMs);
+
+  proc.stdout?.on('data', (chunk) => { stdout += chunk.toString(); });
+  proc.stderr?.on('data', (chunk) => { stderr += chunk.toString(); });
+  proc.on('error', (err) => {
+    clearTimeout(timer);
+    reject(err);
+  });
+  proc.on('close', (code) => {
+    clearTimeout(timer);
+    if (timedOut) return reject(new Error(`claude timed out after ${timeoutMs}ms`));
+    if (code !== 0) return reject(new Error(`claude exited with code ${code}: ${stderr.trim()}`));
+    resolve(stdout);
+  });
+});
+
+export default {
+  name: 'claude',
+
+  async detect() {
+    try {
+      const res = spawnSync('claude', ['--version'], { encoding: 'utf8' });
+      if (res.error || res.status !== 0) return null;
+      // `claude --version` prints e.g. "2.5.1 (Claude Code)" — first token is enough
+      const version = (res.stdout || '').trim().split(/\s+/)[0] || 'unknown';
+      // Best-effort resolve of the binary path for clearer UX ("claude detected
+      // at /usr/local/bin/claude"). Falls back to the bare command name on
+      // platforms without `which` (e.g. Windows).
+      const where = spawnSync('which', ['claude'], { encoding: 'utf8' });
+      const path = where.status === 0 ? (where.stdout || '').trim() || 'claude' : 'claude';
+      return { path, version };
+    } catch {
+      return null;
+    }
+  },
+
+  async spawn(prompt, ctx = {}) {
+    const sessionId = ctx.sessionId || randomUUID();
+    const fullPrompt = buildPrompt(prompt, ctx.memoryLongTerm || '');
+    const args = ['-p', fullPrompt, '--output-format', 'text', '--session-id', sessionId];
+
+    const stdout = await runClaude({
+      args,
+      cwd: ctx.cwd,
+      env: ctx.env,
+      timeoutMs: ctx.timeoutMs || DEFAULT_TIMEOUT_MS,
+      spawnImpl: ctx._spawnImpl, // test seam only — do not use in production
+    });
+
+    return { text: stdout.trim(), newSessionId: sessionId };
+  },
+};

--- a/cli/src/lib/adapters/index.js
+++ b/cli/src/lib/adapters/index.js
@@ -8,9 +8,11 @@
  */
 
 import stub from './stub.js';
+import claude from './claude.js';
 
 const ADAPTERS = {
   [stub.name]: stub,
+  [claude.name]: claude,
 };
 
 export const listAdapterNames = () => Object.keys(ADAPTERS);

--- a/cli/src/lib/memory-bridge.js
+++ b/cli/src/lib/memory-bridge.js
@@ -1,0 +1,54 @@
+/**
+ * Memory bridge — ADR-005 §Memory bridge, ADR-003 Phase 2.
+ *
+ * Two thin CAP shims the run loop calls around every spawn cycle:
+ *
+ *   readLongTerm(client)            — GET  /api/agents/runtime/memory,
+ *                                      returns sections.long_term.content or ''
+ *   syncBack(client, { summary })   — POST /api/agents/runtime/memory/sync
+ *                                      with mode:'patch', sourceRuntime:'local-cli'.
+ *                                      No-op when summary is falsy.
+ *
+ * Identity (agentName, instanceId) is derived server-side from the runtime
+ * token (agentRuntimeAuth), so neither helper needs to pass it. Keeping it
+ * server-derived is invariant-preserving: a bug in the wrapper can't write
+ * to the wrong agent's memory.
+ *
+ * ADR-003 invariant #9: the wrapper supplies `content` + `visibility` ONLY.
+ * `byteSize`, `updatedAt`, and `schemaVersion` are server-stamped; supplying
+ * them from the client is wasted bytes and the kernel discards them.
+ */
+
+export const SOURCE_RUNTIME = 'local-cli';
+
+export const readLongTerm = async (client, { onError } = {}) => {
+  try {
+    const body = await client.get('/api/agents/runtime/memory');
+    return body?.sections?.long_term?.content || '';
+  } catch (err) {
+    // A fresh agent has no memory row yet — treat as empty rather than fail
+    // the spawn. The kernel upserts on first write. For anything OTHER than
+    // a 404 (auth revoked, backend down, network out), surface via onError
+    // so the user sees "something's wrong with memory" instead of a silently
+    // context-less agent.
+    if (err?.status && err.status !== 404) {
+      onError?.(err);
+    }
+    return '';
+  }
+};
+
+export const syncBack = async (client, { summary } = {}) => {
+  if (!summary) return { skipped: true };
+  await client.post('/api/agents/runtime/memory/sync', {
+    mode: 'patch',
+    sourceRuntime: SOURCE_RUNTIME,
+    sections: {
+      long_term: {
+        content: summary,
+        visibility: 'private',
+      },
+    },
+  });
+  return { skipped: false };
+};

--- a/docs/adr/ADR-005-local-cli-wrapper-driver.md
+++ b/docs/adr/ADR-005-local-cli-wrapper-driver.md
@@ -95,6 +95,8 @@ type SpawnResult = {
 
 Target size: ~30–60 lines per adapter. Adding a new CLI is a single-file PR.
 
+**Test seam:** adapters SHOULD accept an optional `ctx._spawnImpl` parameter that replaces `child_process.spawn` for unit tests. In production the field is `undefined` and the adapter uses the real spawn. This pattern is the sanctioned way to unit-test an adapter without module-mocking `child_process` for every spawn test — new adapters should follow it rather than inventing their own seam.
+
 ### Adapters shipped in v1
 
 | CLI | Argv template | Session flag | Notes |


### PR DESCRIPTION
## Summary

Builds on #194 (Phase 1a). Wires the first real CLI adapter and the ADR-003 memory bridge into the local-CLI wrapper's run loop. A user with `claude` on their PATH can now `commonly agent attach claude … && commonly agent run` and participate as a memory-aware Commonly agent.

## What's in

- **`cli/src/lib/adapters/claude.js`** — subprocess wrapper. `detect()` runs `claude --version` (plus best-effort `which` for path display). `spawn()` builds `-p <prompt> --output-format text --session-id <sid>`, prepends the §Memory bridge preamble when `ctx.memoryLongTerm` is non-empty, mints a UUID on first turn and returns it as `newSessionId`, 5-min SIGTERM timeout. `ctx._spawnImpl` is the sanctioned test seam — ADR-005 §Adapter pattern now documents the pattern so future adapters don't invent their own.
- **`cli/src/lib/memory-bridge.js`** — two CAP shims. `readLongTerm()` extracts `sections.long_term.content` from GET `/memory`; returns `''` on 404/network errors; surfaces non-404 HTTP errors via `onError` instead of swallowing. `syncBack()` POSTs `/memory/sync` with `mode:'patch'`, `sourceRuntime:'local-cli'`, `content`+`visibility` ONLY per ADR-003 invariant #9. No-op on empty summary.
- **`cli/src/commands/agent.js`** — `performRun.processEvent` now reads memory before spawn, injects into ctx, and syncs back after the turn when the adapter returned `memorySummary`. Sync failure is non-fatal (pod message already posted; original error preserved via `{ cause }` for CLI debug).
- **`cli/src/lib/adapters/index.js`** — one-line registration of `claude` next to `stub`.
- **Tests** — 3 new/extended suites: 
  - `adapters.claude.test.mjs` — detect, argv construction, UUID mint, preamble injection, stderr surfacing, SIGTERM timeout.
  - `memory-bridge.test.mjs` — read/extract, no long_term section, 404 silent, 401/500 via onError, network-level errors silent, syncBack POST shape, invariant #9 (no byteSize/updatedAt/schemaVersion), empty summary no-op.
  - `run-loop.test.mjs` — end-to-end memory round-trip, summary sync, sync failure non-fatal, session-continuity regression fix (route-aware mockGet after `/memory` started consuming the GET queue).
  - 52/52 passing.

## What's NOT in (deferred)

- codex / cursor / gemini adapters — Phase 2 of ADR-005. Each is a one-file PR.
- Session retirement policy (no TTL on UUIDs) — revisit when long-running agents surface the issue.
- SIGKILL escalation if claude ignores SIGTERM — accepted gap, documented inline.
- ADR-006 Phase 6.1 (webhook SDK + self-serve install) — next phase per the agreed order.

## Reviewer pass (code-reviewer subagent, grounded in docs/REVIEW.md)

4 Important + 4 Nits addressed before commit:
- `readLongTerm` swallow narrowed — 404/network silent (fresh-agent path); 401/5xx now surfaced via `onError`.
- Sync-error wrap preserves original stack via `{ cause: err }`.
- ADR-005 §Adapter pattern now documents the `_spawnImpl` test seam so future adapters follow the same convention.
- Drain-loop magic number → named `DRAIN_DEPTH` with a comment enumerating the 6 await boundaries.
- `detect()` now resolves the binary path via `which claude` for accurate UX (\"claude detected at /usr/local/bin/claude\"), falls back cleanly on Windows.
- Timeout-caveat note at the top of `claude.js` acknowledging no SIGKILL escalation in v1.

## Test plan

- [x] `cd cli && npm test` — 52/52 passing (5 suites)
- [x] `npm run lint` from repo root — 0 new errors in `cli/`
- [ ] Live against `api-dev.commonly.me` — pending real token; will validate with a throwaway pod before calling Phase 1b done on the cluster side

🤖 Generated with [Claude Code](https://claude.com/claude-code)