### PR TITLE
fix(cli): two bugs from ADR-005 Phase 1b live smoke

### DIFF
--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -109,6 +109,33 @@ describe('performRun', () => {
     );
   });
 
+  test('ensures adapter cwd exists before spawning — avoids confusing spawn ENOENT on missing dir', async () => {
+    const agentCwd = path.join(os.tmpdir(), 'commonly-agents', 'cwd-fresh-agent');
+    fs.rmSync(agentCwd, { recursive: true, force: true });
+    expect(fs.existsSync(agentCwd)).toBe(false);
+
+    const mockGet = jest.fn().mockResolvedValue({ events: [] });
+    const mockPost = jest.fn();
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn: jest.fn() };
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'cwd-fresh-agent',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    // Dir must be created at run start, NOT lazily on first spawn — otherwise
+    // a run with only heartbeat events fails silently the first time a real
+    // chat event lands.
+    expect(fs.existsSync(agentCwd)).toBe(true);
+    fs.rmSync(agentCwd, { recursive: true, force: true });
+  });
+
   test('heartbeat event with payload.content is suppressed — chat-only events spawn', async () => {
     // Regression: a heartbeat with a stray `content` field must NOT trigger
     // a spawn. Only CHAT_EVENT_TYPES are forwarded to the CLI.

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -164,6 +164,13 @@ export const performRun = ({
   const client = createClient({ instance: instanceUrl, token });
   let running = true;
 
+  // Adapters default `ctx.cwd` to this path. Node's child_process.spawn
+  // rejects with "spawn <bin> ENOENT" when cwd does not exist — same shape
+  // as binary-not-found — so we ensure it up front to avoid the confusing
+  // diagnostic.
+  const agentCwd = join(tmpdir(), 'commonly-agents', agentName);
+  if (!existsSync(agentCwd)) mkdirSync(agentCwd, { recursive: true });
+
   const processEvent = async (event) => {
     const eventPodId = event.podId || podId;
     const prompt = extractPrompt(event);
@@ -181,7 +188,7 @@ export const performRun = ({
     log(`[${event.type}] spawning ${adapter.name}`);
     const result = await adapter.spawn(prompt, {
       sessionId,
-      cwd: join(tmpdir(), 'commonly-agents', agentName),
+      cwd: agentCwd,
       env: process.env,
       memoryLongTerm,
       metadata: { event },

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -42,7 +42,8 @@ registerPod(program);
 // Local dev environment
 registerDev(program);
 
-// Use instance flag globally
-program.option('--instance <url>', 'Override target Commonly instance');
+// Each subcommand owns its own `--instance <url>` flag; a program-level
+// duplicate shadowed the subcommand value on commander v12, causing
+// `commonly login --instance …` to silently fall back to the default URL.
 
 program.parse(process.argv);


### PR DESCRIPTION
## Summary

Follow-up to #195. Smoke-tested Phase 1b against \`api-dev.commonly.me\` (pod \`adr-005-smoke\`) — memory round-trip works end-to-end: seeded \`long_term\` on CAP \`/memory\`, posted \`@smoke-claude what fruit should I avoid?\`, claude replied *\"You should avoid kiwi fruit due to your allergy.\"* in one sentence, exactly matching the seeded memory. Attach → run → spawn → post → ack all validated.

Two bugs surfaced on the way:

### 1. \`performRun\` never created its per-agent cwd
\`join(tmpdir(), 'commonly-agents', <agent>)\` was passed as \`ctx.cwd\` without ever being \`mkdir\`-ed. Node's \`child_process.spawn\` rejects with \`spawn claude ENOENT\` when cwd doesn't exist — **same shape** as binary-missing — so the first live claude run failed with a misleading ENOENT and kept re-delivering (no ack on spawn failure, per ADR-005). New test asserts the dir is created at \`performRun\` start even when no chat event arrives, so a heartbeat-only run can't break on its first real spawn.

### 2. Program-level \`--instance\` shadowed subcommand option
Commander v12 routed \`commonly login --instance <url>\` to an unset program-level flag, so the URL was silently ignored and login fell back to \`api.commonly.me\`. Removed the duplicate; every subcommand already owns its own \`--instance\`.

## Not in this PR (filed as follow-ups)

- **Self-mention loop** (kernel-side): \`agentMentionService.enqueueMentions\` fires \`chat.mention\` events for messages authored by the mentioned agent itself. The stub adapter echoes the prompt → its own post re-triggers → infinite loop in the pod. Affects every driver (openclaw, webhook, local-cli), not just this one. Should be fixed at the backend — skip enqueue when \`userId === agentUser._id\`. Will file as a separate backend PR.
- **config.js \`getToken(url)\` asymmetry**: \`resolveInstanceUrl\` accepts a URL, but \`getToken\` treats its arg as a config key. Worked around by using \`--key\` on login; not blocking, separate cleanup.

## Test plan

- [x] \`cd cli && npm test\` — 53/53 passing (52 + 1 new cwd-creation test)
- [x] Live smoke on \`api-dev.commonly.me\` — memory round-trip confirmed (one-sentence kiwi-allergy reply); smoke agents + pod cleaned up
- [x] \`npm run lint\` — 0 new errors in \`cli/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)