### PR TITLE
fix(helm): deduplicate namespace, agent-provisioner SA, and postgres-ca-cert

### DIFF
--- a/k8s/helm/commonly/templates/agents/agent-provisioner-rbac.yaml
+++ b/k8s/helm/commonly/templates/agents/agent-provisioner-rbac.yaml
@@ -1,4 +1,9 @@
-{{- if .Values.rbac.create }}
+{{/*
+  Legacy agent-provisioner RBAC. Superseded by templates/agent-provisioning/rbac.yaml
+  which also creates an SA named 'agent-provisioner'. Kept as a fallback for
+  installs that explicitly set agentProvisioning.enabled=false.
+*/}}
+{{- if and .Values.rbac.create (not .Values.agentProvisioning.enabled) }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/k8s/helm/commonly/templates/namespace.yaml
+++ b/k8s/helm/commonly/templates/namespace.yaml
@@ -1,3 +1,11 @@
+{{/*
+  Chart-managed namespace. Default true to preserve existing prod behavior
+  (the dev/prod releases own their namespace via this template). For fresh
+  kind/local installs that use `helm install --create-namespace`, set
+  `createNamespace: false` to avoid a "namespace already exists" conflict.
+  values-local.yaml disables this for that reason.
+*/}}
+{{- if .Values.createNamespace }}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -5,3 +13,4 @@ metadata:
   labels:
     {{- include "commonly.labels" . | nindent 4 }}
     name: {{ include "commonly.namespace" . }}
+{{- end }}

--- a/k8s/helm/commonly/templates/secrets/local-secrets.yaml
+++ b/k8s/helm/commonly/templates/secrets/local-secrets.yaml
@@ -69,8 +69,11 @@ stringData:
   mongo-uri: {{ .Values.localSecrets.mongoUri | default (printf "mongodb://admin:locally@mongodb.%s.svc.cluster.local:27017/commonly?authSource=admin" (include "commonly.namespace" .)) | quote }}
   # PostgreSQL
   postgres-password: {{ .Values.localSecrets.postgresPassword | default "locally" | quote }}
+{{- if not .Values.configMaps.postgresCA.enabled }}
 ---
-# Postgres CA cert — empty placeholder; SSL is disabled in local mode
+# Postgres CA cert — empty placeholder; SSL is disabled in local mode.
+# Only rendered when configMaps.postgresCA.enabled=false; otherwise the
+# postgres-ca-cert Secret is created by templates/configmaps/backend-config.yaml.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -82,4 +85,5 @@ type: Opaque
 data:
   # Empty cert — not used when PG_SSL_ENABLED=false
   ca.pem: ""
+{{- end }}
 {{- end }}

--- a/k8s/helm/commonly/values-local.yaml
+++ b/k8s/helm/commonly/values-local.yaml
@@ -24,6 +24,10 @@ global:
   namespace: commonly-local
   environment: local
 
+# Local install uses `helm install --create-namespace` — disable the
+# chart-side namespace template to avoid a "namespace already exists" race.
+createNamespace: false
+
 # ── Core services ─────────────────────────────────────────────────────────────
 
 backend:

--- a/k8s/helm/commonly/values.yaml
+++ b/k8s/helm/commonly/values.yaml
@@ -7,6 +7,12 @@ global:
   namespace: commonly
   environment: development
 
+# Whether the chart creates its own Namespace resource. Default true to
+# preserve existing dev/prod behavior. Set to false when using
+# `helm install --create-namespace` (e.g. local kind smoke tests) —
+# otherwise both sides fight over the same namespace.
+createNamespace: true
+
 # Agent provisioning (RBAC + PVCs)
 agentProvisioning:
   enabled: true


### PR DESCRIPTION
## Summary
- Kind-cluster smoke test has been failing on every push to main because three chart resources were rendering twice, causing fresh \`helm install\` to error with \"already exists\"
- \`helm upgrade\` on prod was unaffected (no re-creates) — this only broke fresh installs and the smoke test
- Three surgical gates; no behavior change for prod

## Fixes

1. **Namespace \`commonly-local\`** — \`smoke-test.yml\` uses \`--create-namespace\` AND the chart's \`templates/namespace.yaml\`. Added a new \`createNamespace\` value (default \`true\` to preserve prod); \`values-local.yaml\` sets it to \`false\`.

2. **SA \`agent-provisioner\`** — both \`agents/agent-provisioner-rbac.yaml\` (legacy) and \`agent-provisioning/rbac.yaml\` (current) created it. Legacy template is now gated on \`and rbac.create (not agentProvisioning.enabled)\` so it's only a fallback when the newer one is explicitly disabled.

3. **Secret \`postgres-ca-cert\`** — both \`configmaps/backend-config.yaml\` and \`secrets/local-secrets.yaml\` created it. The local-secrets copy is now gated on \`not configMaps.postgresCA.enabled\`.

## Verification
| Config | Total docs | Unique | Duplicates | Namespaces |
|--------|-----------|--------|------------|-----------|
| values-local | 20 | 20 | 0 | [] |
| values-dev + private | 31 | 31 | 0 | [commonly-dev] |

\`helm lint\` clean. Legacy \`replicasets\` RBAC verb (only in the retained role) confirmed unused by the backend.

## Test plan
- [x] \`helm template\` on values-local and values-dev → 0 duplicates
- [x] \`helm lint\` clean
- [ ] Smoke Tests (kind cluster) passes on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)