### PR TITLE
fix(mentions): guard against self-mention infinite loop

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -41,6 +41,12 @@ const User = require('../../../models/User');
 describe('AgentMentionService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default sender for enqueueMentions lookups — a regular human user.
+    // Tests that need a bot sender (self-mention guard) override this.
+    User.findById.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue({ _id: 'user-1', isBot: false }),
+    });
   });
 
   test('extractMentions finds supported agent aliases', () => {
@@ -213,6 +219,98 @@ describe('AgentMentionService', () => {
       }),
     );
     expect(result.enqueued).toEqual(['openclaw']);
+  });
+
+  test('enqueueMentions skips when the sender is the mentioned agent (self-mention loop guard)', async () => {
+    // Installation: one agent "smoke-echo" in the pod
+    AgentInstallation.find.mockReturnValue({
+      lean: jest.fn().mockResolvedValue([
+        { agentName: 'smoke-echo', instanceId: 'default', displayName: 'Smoke Echo' },
+      ]),
+    });
+    AgentProfile.find.mockReturnValue({
+      lean: jest.fn().mockResolvedValue([]),
+    });
+    // Sender is the bot itself — botMetadata matches the mention target
+    User.findById.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue({
+        _id: 'agent-user-1',
+        isBot: true,
+        botMetadata: { agentName: 'smoke-echo', instanceId: 'default' },
+      }),
+    });
+
+    const res = await AgentMentionService.enqueueMentions({
+      podId: 'pod-1',
+      message: { content: 'echo: @smoke-echo hello', id: 'msg-99' },
+      userId: 'agent-user-1',
+      username: 'smoke-echo',
+    });
+
+    // Must NOT re-enqueue an event back to the sender
+    expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+    expect(res.enqueued).toEqual([]);
+    expect(res.skipped).toEqual(['smoke-echo:self']);
+  });
+
+  test('enqueueMentions still enqueues when a different bot mentions this agent', async () => {
+    AgentInstallation.find.mockReturnValue({
+      lean: jest.fn().mockResolvedValue([
+        { agentName: 'smoke-echo', instanceId: 'default', displayName: 'Smoke Echo' },
+      ]),
+    });
+    AgentProfile.find.mockReturnValue({
+      lean: jest.fn().mockResolvedValue([]),
+    });
+    // Sender is a DIFFERENT bot — self-mention guard must not fire
+    User.findById.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue({
+        _id: 'agent-user-2',
+        isBot: true,
+        botMetadata: { agentName: 'other-agent', instanceId: 'default' },
+      }),
+    });
+
+    const res = await AgentMentionService.enqueueMentions({
+      podId: 'pod-1',
+      message: { content: '@smoke-echo please help', id: 'msg-100' },
+      userId: 'agent-user-2',
+      username: 'other-agent',
+    });
+
+    expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+    expect(AgentEventService.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ agentName: 'smoke-echo', instanceId: 'default' }),
+    );
+    expect(res.enqueued).toEqual(['smoke-echo']);
+  });
+
+  test('enqueueMentions still enqueues when sender lookup fails (guard degrades to no-op)', async () => {
+    AgentInstallation.find.mockReturnValue({
+      lean: jest.fn().mockResolvedValue([
+        { agentName: 'smoke-echo', instanceId: 'default', displayName: 'Smoke Echo' },
+      ]),
+    });
+    AgentProfile.find.mockReturnValue({
+      lean: jest.fn().mockResolvedValue([]),
+    });
+    // Simulate a transient DB failure during sender lookup — the guard
+    // should log and fall through, not block the mention enqueue.
+    User.findById.mockImplementationOnce(() => {
+      throw new Error('mongo connection lost');
+    });
+
+    const res = await AgentMentionService.enqueueMentions({
+      podId: 'pod-1',
+      message: { content: '@smoke-echo hello', id: 'msg-101' },
+      userId: 'user-1',
+      username: 'alice',
+    });
+
+    expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+    expect(res.enqueued).toEqual(['smoke-echo']);
   });
 
   test('enqueueDmEvent skips non-agent-admin pods', async () => {

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -82,6 +82,11 @@ interface SummaryEnqueueOptions {
   pod: Record<string, unknown> | null;
 }
 
+interface SenderRow {
+  isBot?: boolean;
+  botMetadata?: { agentName?: string; instanceId?: string };
+}
+
 /**
  * Mention Aliases
  *
@@ -236,11 +241,36 @@ const enqueueMentions = async ({
   const { map: mentionMap, byAgent } = buildMentionMap(installations, profiles);
   let pod: Record<string, unknown> | null = null;
 
+  // Self-mention guard: if the sender is a bot, resolve their own
+  // (agentName, instanceId) so we can skip re-enqueuing an event on themselves.
+  // Without this, any agent whose reply echoes its own handle (e.g. the
+  // webhook-SDK "echo:" template, or a CLI-wrapper that quotes the mention)
+  // triggers an infinite chat.mention → reply → chat.mention loop.
+  let sender: SenderRow | null = null;
+  try {
+    sender = await User.findById(userId).select('isBot botMetadata').lean() as SenderRow | null;
+  } catch (error) {
+    // Non-fatal: missing sender just means we can't suppress self-mentions,
+    // which is a strictly weaker invariant than the one we had before.
+    console.warn('Agent mention sender lookup failed:', (error as Error).message);
+  }
+  const senderAgentName = sender?.isBot ? sender.botMetadata?.agentName?.toLowerCase() : null;
+  const senderInstanceId = sender?.isBot ? (sender.botMetadata?.instanceId || 'default') : null;
+  const isSelfMention = (target: MentionTarget): boolean => (
+    !!senderAgentName
+    && target.agentName.toLowerCase() === senderAgentName
+    && (target.instanceId || 'default') === senderInstanceId
+  );
+
   await Promise.all(
     rawMentions.map(async (raw) => {
       const normalized = raw.toLowerCase();
       const directMatch = mentionMap.get(normalized);
       if (directMatch) {
+        if (isSelfMention(directMatch)) {
+          skipped.push(`${directMatch.agentName}:self`);
+          return;
+        }
         try {
           if (directMatch.agentName === 'commonly-bot') {
             pod = pod || await Pod.findById(podId).lean();
@@ -292,6 +322,10 @@ const enqueueMentions = async ({
         }
         await Promise.all(
           matches.map(async (match) => {
+            if (isSelfMention({ agentName: agentType, instanceId: match.instanceId })) {
+              skipped.push(`${agentType}:self`);
+              return;
+            }
             try {
               if (agentType === 'commonly-bot') {
                 pod = pod || await Pod.findById(podId).lean();


### PR DESCRIPTION
## Summary
- When an agent's reply echoes its own handle (e.g. webhook-SDK \`echo:\` template, CLI-wrapper quoting), the kernel re-enqueued a \`chat.mention\` event back to the same agent → replies again → infinite loop
- Affects ALL drivers uniformly (CLI-wrapper, webhook SDK, OpenClaw) — not driver-specific
- Discovered during ADR-005 Phase 1b live smoke

## Fix
In \`enqueueMentions\`, fetch the sender's User row once. When a mention resolves to the sender's own \`(agentName, instanceId)\`, skip the enqueue. Narrow scope: bot-to-bot mentions between DIFFERENT agents are still delivered (agent collaboration is first-class per ADR-003).

## Test plan
- [x] \`enqueueMentions\` tests: 10/10 passing, including:
  - self-mention is skipped
  - different-bot mention still enqueues
  - sender lookup DB failure degrades to no-op (no crash)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)