### PR TITLE
fix(cli): resolve --instance symmetrically (saved key OR URL)

### DIFF
--- a/cli/__tests__/lib.test.mjs
+++ b/cli/__tests__/lib.test.mjs
@@ -104,6 +104,68 @@ describe('config.js', () => {
     expect(token).toBe('cm_from_env');
   });
 
+  test('resolveInstanceUrl("dev") returns the saved URL when "dev" is a key (not a URL)', () => {
+    // This is the asymmetry fix: historically this returned "dev" literally
+    // as a URL and any HTTP call would ENOTFOUND.
+    saveInstance({
+      key: 'dev', url: 'https://api-dev.commonly.me', token: 'cm_dev',
+      userId: 'u1', username: 'alice',
+    });
+    expect(resolveInstanceUrl('dev')).toBe('https://api-dev.commonly.me');
+  });
+
+  test('getToken("https://...") returns the saved token when the URL matches a saved key', () => {
+    // Mirror of the above: historically this returned null because getToken
+    // treated the arg as a config key and looked up instances["https://..."].
+    saveInstance({
+      key: 'dev', url: 'https://api-dev.commonly.me', token: 'cm_dev_token',
+      userId: 'u1', username: 'alice',
+    });
+    expect(getToken('https://api-dev.commonly.me')).toBe('cm_dev_token');
+    // Also works with trailing slash (normalized on both sides of compare)
+    expect(getToken('https://api-dev.commonly.me/')).toBe('cm_dev_token');
+  });
+
+  test('resolveInstanceUrl("http://brand-new-url") returns the URL with no saved match', () => {
+    // Unknown URLs still work (used for bootstrapping a new instance)
+    expect(resolveInstanceUrl('http://brand-new-url.test/')).toBe('http://brand-new-url.test');
+  });
+
+  test('resolveInstanceUrl("dev") returns the dev entry even when another key has the same URL', () => {
+    // Collision ordering: exact key match stays exact, it doesn't bleed into
+    // the URL match. Here both keys exist; "dev" must not be coerced to
+    // "prod" just because prod happens to share a URL with something.
+    saveInstance({
+      key: 'prod', url: 'https://api.commonly.me', token: 'cm_prod',
+      userId: 'u1', username: 'alice',
+    });
+    saveInstance({
+      key: 'dev', url: 'https://api-dev.commonly.me', token: 'cm_dev',
+      userId: 'u2', username: 'bob',
+    });
+    expect(resolveInstanceUrl('dev')).toBe('https://api-dev.commonly.me');
+    expect(getToken('dev')).toBe('cm_dev');
+  });
+
+  test('resolveInstanceUrl matches saved URL case-insensitively (and preserves unknown URL case)', () => {
+    saveInstance({
+      key: 'dev', url: 'https://api-dev.commonly.me', token: 'cm_dev',
+      userId: 'u1', username: 'alice',
+    });
+    // Case-variant URL finds the saved record
+    expect(getToken('HTTPS://API-DEV.commonly.me/')).toBe('cm_dev');
+    // Unknown URL keeps caller-supplied case (paths can be case-sensitive)
+    expect(resolveInstanceUrl('https://Brand-New.test/Path')).toBe('https://Brand-New.test/Path');
+  });
+
+  test('getToken("unknown-key") returns null', () => {
+    saveInstance({
+      key: 'dev', url: 'https://api-dev.commonly.me', token: 'cm_dev',
+      userId: 'u1', username: 'alice',
+    });
+    expect(getToken('unknown-key')).toBeNull();
+  });
+
   test('listInstances returns each instance with an active flag', () => {
     saveInstance({ key: 'prod', url: 'https://api.commonly.me', token: 'cm_prod', userId: 'u1', username: 'alice' });
     saveInstance({ key: 'dev', url: 'http://localhost:5000', token: 'cm_dev', userId: 'u2', username: 'bob' });

--- a/cli/src/lib/config.js
+++ b/cli/src/lib/config.js
@@ -31,20 +31,69 @@ const write = (config) => {
 
 export const getConfig = () => read();
 
-export const getActiveInstance = (instanceOverride = null) => {
+const normalizeUrl = (value) => (value || '').replace(/\/$/, '').toLowerCase();
+
+/**
+ * Resolve an instance identifier to the saved instance record.
+ *
+ * Accepts either form:
+ *   - A saved key:  'dev', 'default', 'local'
+ *   - A URL:        'https://api-dev.commonly.me' (any case; trailing / ok)
+ *   - null:         falls back to config.active
+ *
+ * Historically `resolveInstanceUrl` treated the arg as a URL and `getToken`
+ * treated it as a key — so `--instance dev` and `--instance <url>` each
+ * worked for exactly one of URL-resolution or token-lookup and broke the
+ * other. Funneling both through this helper closes that asymmetry.
+ *
+ * URL-shaped inputs (http[s]://) go through URL resolution first so a
+ * hypothetical key named `"https-backup"` can't collide with a real URL.
+ * For an unknown URL (no saved match) we return the URL with a null token,
+ * which is needed for login bootstrap (there is no saved instance yet) and
+ * for unauthenticated probe calls.
+ */
+export const resolveInstance = (identifier = null) => {
   const config = read();
-  const key = instanceOverride || config.active || 'default';
-  const inst = config.instances[key];
-  if (!inst) return null;
-  return { key, ...inst };
+
+  if (!identifier) {
+    const key = config.active || 'default';
+    const inst = config.instances[key];
+    return inst ? { key, ...inst } : null;
+  }
+
+  // URL-shaped inputs: resolve by URL first. Case-insensitive match so that
+  // `HTTPS://API-DEV.commonly.me/` finds a record saved as the lowercased
+  // `https://api-dev.commonly.me`.
+  const looksLikeUrl = /^https?:\/\//i.test(identifier);
+  if (looksLikeUrl) {
+    const normalized = normalizeUrl(identifier);
+    const urlEntry = Object.entries(config.instances)
+      .find(([, v]) => normalizeUrl(v.url) === normalized);
+    if (urlEntry) {
+      const [key, value] = urlEntry;
+      return { key, ...value };
+    }
+    // Unknown URL — still usable for bootstrapping. Preserve the caller's
+    // original case in the returned URL (some servers are case-sensitive on
+    // paths; we only lowercase for match comparison above).
+    return { key: null, url: identifier.replace(/\/$/, ''), token: null };
+  }
+
+  // Key-shaped inputs: exact lookup only.
+  if (config.instances[identifier]) {
+    return { key: identifier, ...config.instances[identifier] };
+  }
+
+  // Unknown key — caller falls back to defaults.
+  return null;
 };
 
+// Alias kept for existing imports (login.js). Functionally identical to
+// resolveInstance; callers using this name pre-date the refactor.
+export const getActiveInstance = (instanceOverride = null) => resolveInstance(instanceOverride);
+
 export const resolveInstanceUrl = (instanceArg = null) => {
-  if (instanceArg) {
-    // Explicit --instance flag — return as-is, may not be in config
-    return instanceArg.replace(/\/$/, '');
-  }
-  const inst = getActiveInstance();
+  const inst = resolveInstance(instanceArg);
   if (inst?.url) return inst.url.replace(/\/$/, '');
   return DEFAULT_INSTANCE_URL;
 };
@@ -72,7 +121,7 @@ export const setActive = (key) => {
 export const getToken = (instanceOverride = null) => {
   // Env var takes precedence (CI, scripts)
   if (process.env.COMMONLY_TOKEN) return process.env.COMMONLY_TOKEN;
-  const inst = getActiveInstance(instanceOverride);
+  const inst = resolveInstance(instanceOverride);
   return inst?.token || null;
 };
 


### PR DESCRIPTION
## Summary
- \`resolveInstanceUrl\` treated \`--instance\` as a URL; \`getToken\` treated it as a config key. Neither form worked end-to-end
- \`--instance https://api-dev.commonly.me\` → URL OK, token null → 401
- \`--instance dev\` → token OK, URL literally \"dev\" → ENOTFOUND

Filed as a follow-up during ADR-005 Phase 1b live smoke.

## Fix
New \`resolveInstance(identifier)\` helper that both \`resolveInstanceUrl\` and \`getToken\` share. Resolution order:
1. URL-shaped (\`http[s]://\`) → saved-URL lookup (case-insensitive, trailing-slash tolerant) → if no match, return as raw URL with null token (needed for \`login\` bootstrap)
2. Otherwise → saved-key lookup
3. Null identifier → \`config.active\`

URL-first ordering prevents a hypothetical key named \`http-backup\` from colliding with real URLs.

## Test plan
- [x] 21/21 lib.test.mjs passing (up from 15 — 6 new tests including the collision ordering and case-insensitive URL match)
- [x] Full CLI suite 61/61 passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)