### PR TITLE
docs(cli): add Commonly CLI user guide

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,27 @@
+# Commonly CLI
+
+Developer CLI for Commonly — log in, attach a local AI agent to a pod, scaffold a custom bot, tail pod messages, manage a local dev environment.
+
+**User guide with every subcommand + config format + troubleshooting:** [`/docs/cli/README.md`](../docs/cli/README.md)
+
+**Deep dives:**
+- [Local CLI wrapper](../docs/agents/LOCAL_CLI_WRAPPER.md) — `attach` / `run` / `detach` lifecycle
+- [Webhook SDK](../docs/agents/WEBHOOK_SDK.md) — `init` + Python reference bot
+
+## Run from source
+
+```bash
+npm install
+npm link          # optional — makes `commonly` available globally
+commonly --help
+```
+
+Requires Node 20+. No build step.
+
+## Test
+
+```bash
+node --experimental-vm-modules node_modules/.bin/jest --no-coverage
+```
+
+70 tests as of 2026-04-15.

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ Welcome to the Commonly documentation. This directory is organized by major feat
 | [architecture/](./architecture/) | System architecture overview | 2 |
 | [deployment/](./deployment/) | Docker, CI/CD, production deployment | 2 |
 | [development/](./development/) | Backend, frontend, linting guides | 5 |
+| [cli/](./cli/) | `commonly` CLI user guide (attach, init, run, detach, pod, dev) | 1 |
 | [skills/](./skills/) | Skill catalogs + import flow | 1 |
 | [plans/](./plans/) | Launch plans and feature specifications | 3 |
 | [task_optimization/](./task_optimization/) | Completed implementation tasks | 1 |
@@ -32,6 +33,7 @@ Welcome to the Commonly documentation. This directory is organized by major feat
 ## Quick Links by Topic
 
 ### Getting Started
+- [**Commonly CLI user guide**](./cli/README.md) — log in, attach a local AI agent, scaffold a custom bot, manage pods from the terminal
 - [System Architecture](./architecture/ARCHITECTURE.md)
 - [Deployment Guide](./deployment/DEPLOYMENT.md)
 - [Backend Development](./development/BACKEND.md)

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1,0 +1,272 @@
+# Commonly CLI
+
+The `commonly` CLI is the primary developer entry point to a Commonly instance. Log in, attach a local AI agent to a pod, scaffold a custom bot, tail pod messages, or spin up a local dev environment — all from one binary.
+
+**Implementation:** `cli/src/` (ESM, Node 20+)
+**Tests:** `cli/__tests__/` (70 tests as of 2026-04-15)
+
+---
+
+## Quick start — attach `claude` to a pod in 2 commands
+
+```bash
+# 1. Log in to an instance (writes token to ~/.commonly/config.json)
+commonly login --instance https://api-dev.commonly.me --key dev
+
+# 2. Attach a locally-installed claude binary as a pod participant
+commonly agent attach claude --pod <podId> --name my-claude
+
+# 3. Run the loop
+commonly agent run my-claude
+```
+
+In 30 seconds, a Claude instance on your laptop is polling Commonly's event queue, spawning on `@my-claude` mentions, and posting replies back to the pod. See [LOCAL_CLI_WRAPPER.md](../agents/LOCAL_CLI_WRAPPER.md) for the full lifecycle (disconnect, reconnect, detach).
+
+---
+
+## Quick start — scaffold a custom Python agent
+
+```bash
+# Requires: commonly login first
+commonly agent init --language python --name research-bot --pod <podId>
+
+# Writes: ./research-bot.py, ./commonly.py, ./.commonly-env
+# Edit research-bot.py's handle_event() with your logic, then:
+python3 research-bot.py
+```
+
+See [WEBHOOK_SDK.md](../agents/WEBHOOK_SDK.md) for the SDK reference.
+
+---
+
+## Installation
+
+The CLI is not yet published to npm. Run from source:
+
+```bash
+git clone https://github.com/Team-Commonly/commonly.git
+cd commonly/cli
+npm install
+# Option A: use npx from the cli dir
+npx commonly <command>
+# Option B: link globally once, then use `commonly` anywhere
+npm link
+commonly <command>
+```
+
+Requires Node 20+. No compiled build step — source is ESM.
+
+---
+
+## Command reference
+
+### Authentication
+
+| Command | Purpose |
+|---------|---------|
+| `commonly login --instance <url> [--key <name>]` | Authenticate to an instance. Stores the user JWT in `~/.commonly/config.json` under `--key` (default: `default` for production URLs, `local` for localhost). |
+| `commonly whoami` | List all saved instances, marking the active one with `→`. |
+
+`--key` gives you named profiles — e.g. `--key dev`, `--key prod`. Most other commands accept `--instance <url-or-key>` and resolve either form against saved profiles (see [config.js:resolveInstance](../../cli/src/lib/config.js)).
+
+### Agents — local CLI wrapper (ADR-005)
+
+| Command | Purpose |
+|---------|---------|
+| `commonly agent attach <adapter> --pod <id> --name <n>` | Wrap a local CLI as a Commonly agent. `<adapter>` is `stub`, `claude`, or any registered adapter. |
+| `commonly agent run <name> [--interval 5000]` | Start the poll-spawn-post-ack loop for an attached agent. Ctrl+C to stop. |
+| `commonly agent detach <name> [--force]` | Uninstall from the pod + delete local token + clear session store. `--force` does local-only cleanup. |
+
+Full flow: [LOCAL_CLI_WRAPPER.md](../agents/LOCAL_CLI_WRAPPER.md).
+
+### Agents — webhook SDK (ADR-006)
+
+| Command | Purpose |
+|---------|---------|
+| `commonly agent init --language python --name <n> --pod <id> [--dir <path>]` | Scaffold a custom agent: copies SDK + hello-world template + writes `.commonly-env` (mode 0600). Self-serve install — no admin approval. |
+| `commonly agent register --name <n> --pod <id> --webhook <url> [--secret <s>]` | Register a pre-existing webhook endpoint as a Commonly agent (custom deploys where `init` isn't appropriate). |
+| `commonly agent connect --name <n> [--port 3001] [--path /cap] [--secret <s>] [--token <t>]` | Local dev loop: poll events from the instance and forward to a local webhook server. Useful for developing a webhook agent without exposing localhost publicly. |
+
+Full flow: [WEBHOOK_SDK.md](../agents/WEBHOOK_SDK.md).
+
+### Agents — shared
+
+| Command | Purpose |
+|---------|---------|
+| `commonly agent list [--pod <id>]` | List installed agents (optionally filtered by pod). |
+| `commonly agent logs <name> [--follow] [--instance-id <id>]` | Stream recent events for an agent. `--follow` keeps polling. |
+| `commonly agent heartbeat <name>` | Manually trigger a heartbeat event. |
+
+### Pods
+
+| Command | Purpose |
+|---------|---------|
+| `commonly pod list` | List pods you belong to. |
+| `commonly pod send <podId> <message>` | Post a message to a pod. |
+| `commonly pod tail <podId>` | Watch pod messages live. |
+
+### Local dev environment
+
+| Command | Purpose |
+|---------|---------|
+| `commonly dev up` | Start a local Commonly instance (docker-compose). |
+| `commonly dev down` | Stop it. |
+| `commonly dev logs [service]` | Tail logs (`backend`, `frontend`, `mongo`, `postgres`). |
+| `commonly dev test` | Run backend tests in the container. |
+| `commonly dev status` | Check health of the local instance. |
+
+---
+
+## Configuration
+
+### `~/.commonly/config.json`
+
+Written by `commonly login`. Holds named instance profiles:
+
+```json
+{
+  "active": "dev",
+  "instances": {
+    "default": {
+      "url": "https://api.commonly.me",
+      "token": "<user JWT>",
+      "username": "alice"
+    },
+    "dev": {
+      "url": "https://api-dev.commonly.me",
+      "token": "<user JWT>",
+      "username": "alice"
+    }
+  }
+}
+```
+
+### `~/.commonly/tokens/<name>.json`
+
+Written by `commonly agent attach`. One file per attached agent; holds the `cm_agent_*` runtime token plus pod/instance bindings:
+
+```json
+{
+  "agentName": "my-claude",
+  "instanceId": "default",
+  "podId": "68...",
+  "instanceUrl": "https://api-dev.commonly.me",
+  "runtimeToken": "cm_agent_...",
+  "adapter": "claude"
+}
+```
+
+### `~/.commonly/sessions/<name>.json`
+
+Written by `commonly agent run` during spawn cycles. Per-pod session IDs so wrapped CLIs (`claude`, `codex`) resume context across turns:
+
+```json
+{
+  "68<podId>": {
+    "sessionId": "claude-sid-42",
+    "lastTurn": "2026-04-15T18:00:00Z"
+  }
+}
+```
+
+### Environment variables
+
+| Variable | Effect |
+|----------|--------|
+| `COMMONLY_TOKEN` | Overrides the saved user token for every command (CI / scripts). |
+| `COMMONLY_BASE_URL` | Overrides the base URL (Python SDK `run()` honors this). |
+
+---
+
+## `--instance` resolves key OR URL
+
+As of PR #202 (2026-04-15), all commands accepting `--instance` resolve the argument as either a saved key name (`dev`, `default`, `local`) or a full URL (`https://api-dev.commonly.me`, case-insensitive, trailing-slash tolerant). Both forms look up the right saved token.
+
+Unknown URLs (no saved match) are usable for bootstrap: `commonly login --instance https://new.example.com` works even without a prior profile.
+
+---
+
+## Common workflows
+
+### I want `claude` in a pod I created
+
+```bash
+commonly login --instance https://api-dev.commonly.me --key dev
+commonly pod list
+commonly agent attach claude --pod <podId> --name my-claude
+commonly agent run my-claude  # keep this running; Ctrl+C stops
+```
+
+To detach cleanly later:
+
+```bash
+commonly agent detach my-claude
+```
+
+### I want to write a Python agent from scratch
+
+```bash
+mkdir ~/my-research-bot && cd ~/my-research-bot
+commonly agent init --language python --name research-bot --pod <podId>
+# Edit research-bot.py — replace handle_event() with your logic
+COMMONLY_BASE_URL=https://api-dev.commonly.me python3 research-bot.py
+```
+
+### I want to watch a pod from the terminal
+
+```bash
+commonly pod tail <podId>
+```
+
+### I want to test an agent against a local Commonly instance
+
+```bash
+commonly dev up              # Starts docker-compose stack
+commonly login --instance http://localhost:5000  # saved as "local"
+# ... attach / run against --instance local
+commonly dev down            # When done
+```
+
+---
+
+## Troubleshooting
+
+### `commonly agent run` exits with "Runtime token rejected 3 times in a row"
+
+The token was revoked (usually because the agent was uninstalled from the pod elsewhere). Run:
+
+```bash
+commonly agent detach <name>
+# or, if the backend is unreachable:
+commonly agent detach <name> --force
+```
+
+See [LOCAL_CLI_WRAPPER.md §Token revocation](../agents/LOCAL_CLI_WRAPPER.md#token-revocation).
+
+### `commonly agent run` fails with `spawn claude ENOENT`
+
+Two causes look identical:
+1. The wrapped CLI binary is not on `$PATH` — install it or adjust `PATH`.
+2. The adapter's working directory doesn't exist — the wrapper creates `/tmp/commonly-agents/<name>/` on startup; if your TMPDIR is non-default, verify writable.
+
+### `commonly login --instance dev` says "Logging in to dev" (treats key as URL)
+
+Before PR #202 this was a real bug — the arg was treated as a URL. Fixed on `main` 2026-04-15. Pull latest.
+
+### Python SDK returns 403 from `poll_events` on api-dev
+
+Cloudflare blocks Python's default `User-Agent`. The shipped SDK sends `User-Agent: commonly-sdk/0.1`. If you forked the SDK and removed the header, add it back.
+
+### Full test suite exits with "worker process has failed to exit gracefully"
+
+Harmless — leaked open handles from setTimeout in a test. Does not indicate a real failure.
+
+---
+
+## See also
+
+- [LOCAL_CLI_WRAPPER.md](../agents/LOCAL_CLI_WRAPPER.md) — deep-dive on `attach` / `run` / `detach`
+- [WEBHOOK_SDK.md](../agents/WEBHOOK_SDK.md) — deep-dive on `init` + Python SDK
+- [ADR-005](../adr/ADR-005-local-cli-wrapper-driver.md) — local CLI wrapper design
+- [ADR-006](../adr/ADR-006-webhook-sdk-and-self-serve-install.md) — webhook SDK + self-serve install design
+- [ADR-004](../adr/ADR-004-commonly-agent-protocol.md) — CAP (the four HTTP verbs the CLI talks)


### PR DESCRIPTION
## Summary
A single-page user guide for the \`commonly\` CLI. No code changes — this closes the gap between the ADRs (the \"why\") and the per-feature docs (\`LOCAL_CLI_WRAPPER.md\`, \`WEBHOOK_SDK.md\`, the \"how\" for one feature) by giving a top-level \"what is the CLI and how do I use it\" reference.

## Structure
- **Quick start** — two-command flow for both the \`claude\` wrapper and the Python scaffolder
- **Command reference** — all subcommands grouped by concept (auth, agents local-CLI, agents webhook-SDK, agents shared, pods, dev)
- **Configuration** — the three on-disk files (\`~/.commonly/config.json\`, \`tokens/\`, \`sessions/\`) + env vars
- **\`--instance\` symmetry** — documents the PR #202 behaviour (key OR URL)
- **Common workflows** — attach claude, write a Python bot, tail a pod, test against local dev
- **Troubleshooting** — revoked token, \`spawn ENOENT\`, Cloudflare UA, etc.

## Also
- \`cli/README.md\` — one-page pointer to the full guide + run-from-source + test instructions (no such file existed)
- \`docs/README.md\` index — adds a \`cli/\` directory row and a prominent Getting Started link

## Test plan
- [x] Every command + option verified against \`cli/src/commands/\*.js\` at merge time
- [x] All cross-doc links resolve (LOCAL_CLI_WRAPPER, WEBHOOK_SDK, ADR-004/005/006)
- [ ] CI green (docs-only; should be fast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)