### PR TITLE
docs(cli): enrich --help output with examples + next-step pointers

### DIFF
--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -451,6 +451,24 @@ export const performDetach = async ({
 export const registerAgent = (program) => {
   const agent = program.command('agent').description('Manage agents');
 
+  agent.addHelpText('after', `
+Examples:
+  # Wrap your local claude binary as a pod agent (ADR-005)
+  $ commonly agent attach claude --pod <podId> --name my-claude
+  $ commonly agent run my-claude
+  $ commonly agent detach my-claude
+
+  # Scaffold a custom Python agent (ADR-006)
+  $ commonly agent init --language python --name research-bot --pod <podId>
+
+  # List installed agents
+  $ commonly agent list
+
+Docs:
+  https://github.com/Team-Commonly/commonly/blob/main/docs/agents/LOCAL_CLI_WRAPPER.md
+  https://github.com/Team-Commonly/commonly/blob/main/docs/agents/WEBHOOK_SDK.md
+`);
+
   // ── register ──────────────────────────────────────────────────────────────
   agent
     .command('register')

--- a/cli/src/commands/dev.js
+++ b/cli/src/commands/dev.js
@@ -44,6 +44,17 @@ const runDevSh = (args, opts = {}) => {
 export const registerDev = (program) => {
   const dev = program.command('dev').description('Local development environment');
 
+  dev.addHelpText('after', `
+Examples:
+  $ commonly dev up              # Start a local docker-compose stack
+  $ commonly dev status          # Check health
+  $ commonly dev logs backend    # Tail backend logs
+  $ commonly dev down            # Stop everything
+
+Login against the local instance with:
+  $ commonly login --instance http://localhost:5000
+`);
+
   // ── up ────────────────────────────────────────────────────────────────────
   dev
     .command('up')

--- a/cli/src/commands/login.js
+++ b/cli/src/commands/login.js
@@ -41,6 +41,15 @@ export const registerLogin = (program) => {
     .description('Authenticate to a Commonly instance')
     .option('--instance <url>', 'Instance URL (default: https://api.commonly.me)')
     .option('--key <name>', 'Config key to save as (default: "default" or "local")')
+    .addHelpText('after', `
+Examples:
+  $ commonly login                                                   # production (default key)
+  $ commonly login --instance https://api-dev.commonly.me --key dev  # named profile
+  $ commonly login --instance http://localhost:5000                  # saved as "local"
+
+Tokens are stored in ~/.commonly/config.json. Other commands take
+--instance <url-or-key> to target the right profile.
+`)
     .action(async (opts) => {
       const instanceUrl = opts.instance
         ? opts.instance.replace(/\/$/, '')

--- a/cli/src/commands/pod.js
+++ b/cli/src/commands/pod.js
@@ -12,6 +12,16 @@ import { getToken, resolveInstanceUrl } from '../lib/config.js';
 export const registerPod = (program) => {
   const pod = program.command('pod').description('Manage pods');
 
+  pod.addHelpText('after', `
+Examples:
+  $ commonly pod list
+  $ commonly pod send <podId> "hello from the CLI"
+  $ commonly pod tail <podId>
+
+Each command accepts --instance <url-or-key> to target a non-default
+Commonly instance (see: commonly login --help).
+`);
+
   // ── list ──────────────────────────────────────────────────────────────────
   pod
     .command('list')

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -27,7 +27,8 @@ const program = new Command();
 program
   .name('commonly')
   .description('The Commonly CLI — connect agents, manage pods, iterate fast')
-  .version(pkg.version);
+  .version(pkg.version)
+  .showHelpAfterError('(run `commonly --help` for usage)');
 
 // Auth
 registerLogin(program);
@@ -45,5 +46,28 @@ registerDev(program);
 // Each subcommand owns its own `--instance <url>` flag; a program-level
 // duplicate shadowed the subcommand value on commander v12, causing
 // `commonly login --instance …` to silently fall back to the default URL.
+
+program.addHelpText('after', `
+Quick start:
+  $ commonly login --instance https://api-dev.commonly.me --key dev
+  $ commonly agent attach claude --pod <podId> --name my-claude
+  $ commonly agent run my-claude                       # Ctrl+C to stop
+  $ commonly agent detach my-claude                    # clean uninstall
+
+Custom Python agent:
+  $ commonly agent init --language python --name research-bot --pod <podId>
+  $ python3 research-bot.py
+
+Subcommand help:
+  $ commonly login --help
+  $ commonly agent attach --help
+  $ commonly agent run --help
+  $ commonly pod tail --help
+
+Note: --instance is a subcommand option, not a program option. It accepts
+either a saved key name ("dev", "local", "default") or a full URL.
+
+Docs: https://github.com/Team-Commonly/commonly/blob/main/docs/cli/README.md
+`);
 
 program.parse(process.argv);


### PR DESCRIPTION
## Summary
\`commonly --help\` was actively unhelpful — bare command list, no examples, no pointers. Malformed invocations like \`commonly --instance <url>\` exited with \`error: unknown option\` and no guidance.

Fix: four \`addHelpText('after', ...)\` blocks and one \`showHelpAfterError\`.

## Result

**Top-level:** Quick start, Custom Python agent, subcommand-help pointers, --instance note, docs URL.
**\`commonly agent --help\`:** attach/run/detach example, init example, docs links.
**\`commonly pod --help\`:** 3-line example block.
**\`commonly dev --help\`:** up/status/logs/down example + localhost login hint.
**\`commonly login --help\`:** three common shapes.
**Error path:** \`error: unknown option '--instance'\` now prints \`(run \`commonly --help\` for usage)\` after it.

## Test plan
- [x] 71/71 CLI tests passing
- [x] Manual verification of --help at each level
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)