### PR TITLE
fix(cli): use --resume for claude continuation; self-heal stale session ids

### DIFF
--- a/cli/__tests__/adapters.claude.test.mjs
+++ b/cli/__tests__/adapters.claude.test.mjs
@@ -79,7 +79,21 @@ describe('claude adapter — detect()', () => {
 });
 
 describe('claude adapter — spawn()', () => {
-  test('builds argv with -p <prompt> --output-format text --session-id <sid>', async () => {
+  test('first turn (no persisted id): mints UUID + passes --session-id to CREATE the session', async () => {
+    const { impl, calls } = makeSpawnImpl({ stdout: 'ok' });
+    const res = await claude.spawn('hi', { sessionId: null, _spawnImpl: impl });
+
+    // UUID v4 shape: 8-4-4-4-12 hex groups.
+    expect(res.newSessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(calls[0].args).toContain('--session-id');
+    expect(calls[0].args).toContain(res.newSessionId);
+    expect(calls[0].args).not.toContain('--resume');
+  });
+
+  test('subsequent turn (persisted id): passes --resume to CONTINUE the session (NOT --session-id)', async () => {
+    // REGRESSION: using `--session-id` on a previously-used UUID makes claude
+    // error with "Session ID ... is already in use". We must use `--resume`
+    // on subsequent turns so the conversation continues instead.
     const { impl, calls } = makeSpawnImpl({ stdout: 'hello\n' });
     const res = await claude.spawn('hello world', {
       sessionId: 'sid-123',
@@ -94,17 +108,53 @@ describe('claude adapter — spawn()', () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].cmd).toBe('claude');
     expect(calls[0].args).toEqual(
-      ['-p', 'hello world', '--output-format', 'text', '--session-id', 'sid-123'],
+      ['-p', 'hello world', '--output-format', 'text', '--resume', 'sid-123'],
     );
+    // Explicit: must NOT use --session-id on resume path — the whole point.
+    expect(calls[0].args).not.toContain('--session-id');
   });
 
-  test('mints a new session id on first turn when ctx.sessionId is null', async () => {
-    const { impl, calls } = makeSpawnImpl({ stdout: 'ok' });
-    const res = await claude.spawn('hi', { sessionId: null, _spawnImpl: impl });
+  test('self-heals when --resume hits "already in use": retries with fresh UUID + --session-id', async () => {
+    // Two calls: first rejects with the poison-pill error; second succeeds.
+    const calls = [];
+    let call = 0;
+    const impl = (cmd, args, opts) => {
+      call += 1;
+      calls.push({ cmd, args, opts });
+      if (call === 1) {
+        return fakeChild({
+          stderr: 'Error: Session ID abc-123 is already in use.',
+          code: 1,
+        });
+      }
+      return fakeChild({ stdout: 'recovered\n' });
+    };
 
-    // UUID v4 shape: 8-4-4-4-12 hex groups.
-    expect(res.newSessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-    expect(calls[0].args).toContain(res.newSessionId);
+    const res = await claude.spawn('hello', {
+      sessionId: 'abc-123',
+      _spawnImpl: impl,
+    });
+
+    expect(calls).toHaveLength(2);
+    // First attempt used --resume (the failing path)
+    expect(calls[0].args).toContain('--resume');
+    expect(calls[0].args).toContain('abc-123');
+    // Second attempt used --session-id with a FRESH UUID (not the stale one)
+    expect(calls[1].args).toContain('--session-id');
+    expect(calls[1].args).not.toContain('abc-123');
+    // newSessionId returned is the fresh one so the wrapper persists it next turn
+    expect(res.newSessionId).not.toBe('abc-123');
+    expect(res.newSessionId).toMatch(/^[0-9a-f]{8}-/);
+    expect(res.text).toBe('recovered');
+  });
+
+  test('does NOT self-heal on generic spawn errors — only session-ID poison-pills', async () => {
+    const { impl, calls } = makeSpawnImpl({ stderr: 'some other error', code: 1 });
+    await expect(
+      claude.spawn('x', { sessionId: 'sid-1', _spawnImpl: impl }),
+    ).rejects.toThrow(/some other error/);
+    // Should be exactly 1 call — no retry for non-session errors.
+    expect(calls).toHaveLength(1);
   });
 
   test('prepends the memory preamble when ctx.memoryLongTerm is non-empty', async () => {

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -451,6 +451,24 @@ export const performDetach = async ({
 export const registerAgent = (program) => {
   const agent = program.command('agent').description('Manage agents');
 
+  agent.addHelpText('after', `
+Examples:
+  # Wrap your local claude binary as a pod agent (ADR-005)
+  $ commonly agent attach claude --pod <podId> --name my-claude
+  $ commonly agent run my-claude
+  $ commonly agent detach my-claude
+
+  # Scaffold a custom Python agent (ADR-006)
+  $ commonly agent init --language python --name research-bot --pod <podId>
+
+  # List installed agents
+  $ commonly agent list
+
+Docs:
+  https://github.com/Team-Commonly/commonly/blob/main/docs/agents/LOCAL_CLI_WRAPPER.md
+  https://github.com/Team-Commonly/commonly/blob/main/docs/agents/WEBHOOK_SDK.md
+`);
+
   // ── register ──────────────────────────────────────────────────────────────
   agent
     .command('register')

--- a/cli/src/commands/dev.js
+++ b/cli/src/commands/dev.js
@@ -44,6 +44,17 @@ const runDevSh = (args, opts = {}) => {
 export const registerDev = (program) => {
   const dev = program.command('dev').description('Local development environment');
 
+  dev.addHelpText('after', `
+Examples:
+  $ commonly dev up              # Start a local docker-compose stack
+  $ commonly dev status          # Check health
+  $ commonly dev logs backend    # Tail backend logs
+  $ commonly dev down            # Stop everything
+
+Login against the local instance with:
+  $ commonly login --instance http://localhost:5000
+`);
+
   // ── up ────────────────────────────────────────────────────────────────────
   dev
     .command('up')

--- a/cli/src/commands/login.js
+++ b/cli/src/commands/login.js
@@ -41,6 +41,15 @@ export const registerLogin = (program) => {
     .description('Authenticate to a Commonly instance')
     .option('--instance <url>', 'Instance URL (default: https://api.commonly.me)')
     .option('--key <name>', 'Config key to save as (default: "default" or "local")')
+    .addHelpText('after', `
+Examples:
+  $ commonly login                                                   # production (default key)
+  $ commonly login --instance https://api-dev.commonly.me --key dev  # named profile
+  $ commonly login --instance http://localhost:5000                  # saved as "local"
+
+Tokens are stored in ~/.commonly/config.json. Other commands take
+--instance <url-or-key> to target the right profile.
+`)
     .action(async (opts) => {
       const instanceUrl = opts.instance
         ? opts.instance.replace(/\/$/, '')

--- a/cli/src/commands/pod.js
+++ b/cli/src/commands/pod.js
@@ -12,6 +12,16 @@ import { getToken, resolveInstanceUrl } from '../lib/config.js';
 export const registerPod = (program) => {
   const pod = program.command('pod').description('Manage pods');
 
+  pod.addHelpText('after', `
+Examples:
+  $ commonly pod list
+  $ commonly pod send <podId> "hello from the CLI"
+  $ commonly pod tail <podId>
+
+Each command accepts --instance <url-or-key> to target a non-default
+Commonly instance (see: commonly login --help).
+`);
+
   // ── list ──────────────────────────────────────────────────────────────────
   pod
     .command('list')

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -27,7 +27,8 @@ const program = new Command();
 program
   .name('commonly')
   .description('The Commonly CLI — connect agents, manage pods, iterate fast')
-  .version(pkg.version);
+  .version(pkg.version)
+  .showHelpAfterError('(run `commonly --help` for usage)');
 
 // Auth
 registerLogin(program);
@@ -45,5 +46,28 @@ registerDev(program);
 // Each subcommand owns its own `--instance <url>` flag; a program-level
 // duplicate shadowed the subcommand value on commander v12, causing
 // `commonly login --instance …` to silently fall back to the default URL.
+
+program.addHelpText('after', `
+Quick start:
+  $ commonly login --instance https://api-dev.commonly.me --key dev
+  $ commonly agent attach claude --pod <podId> --name my-claude
+  $ commonly agent run my-claude                       # Ctrl+C to stop
+  $ commonly agent detach my-claude                    # clean uninstall
+
+Custom Python agent:
+  $ commonly agent init --language python --name research-bot --pod <podId>
+  $ python3 research-bot.py
+
+Subcommand help:
+  $ commonly login --help
+  $ commonly agent attach --help
+  $ commonly agent run --help
+  $ commonly pod tail --help
+
+Note: --instance is a subcommand option, not a program option. It accepts
+either a saved key name ("dev", "local", "default") or a full URL.
+
+Docs: https://github.com/Team-Commonly/commonly/blob/main/docs/cli/README.md
+`);
 
 program.parse(process.argv);

--- a/cli/src/lib/adapters/claude.js
+++ b/cli/src/lib/adapters/claude.js
@@ -1,16 +1,20 @@
 /**
  * claude adapter — wraps the local `claude` CLI as a Commonly agent.
  *
- * Contract: ADR-005 §Adapter pattern. Argv shape per ADR-005 §Adapters
- * shipped in v1: `claude -p "$prompt" --output-format text --session-id $sid`.
+ * Contract: ADR-005 §Adapter pattern.
  *
  * Memory preamble: if ctx.memoryLongTerm is non-empty, the adapter prepends
  * it to the prompt as a system-context preamble (§Memory bridge).
  *
- * Session continuity: we pass the same stable session id to claude on every
- * turn and return it as `newSessionId` so the run loop persists it. First
- * turn mints a UUID; subsequent turns re-use it. claude keeps the
- * conversation alive on its side for this id.
+ * Session continuity (IMPORTANT — the two claude flags are not interchangeable):
+ *   - First turn (no persisted id): mint a UUID and pass `--session-id <uuid>`.
+ *     claude treats `--session-id` as "CREATE a session with this exact UUID"
+ *     and rejects with "Session ID ... is already in use" if the UUID was
+ *     already used.
+ *   - Subsequent turns (persisted id present): pass `--resume <uuid>` instead.
+ *     `--resume` means "continue this existing session."
+ *   The wrapper persists the UUID so the SAME id is used across turns — this
+ *   adapter just picks the right flag for it.
  *
  * Purity (§Load-bearing invariants #1): input = argv + env + prompt;
  * output = text + session id. No direct network, no direct CAP calls.
@@ -82,18 +86,38 @@ export default {
   },
 
   async spawn(prompt, ctx = {}) {
+    const isResume = !!ctx.sessionId;
     const sessionId = ctx.sessionId || randomUUID();
     const fullPrompt = buildPrompt(prompt, ctx.memoryLongTerm || '');
-    const args = ['-p', fullPrompt, '--output-format', 'text', '--session-id', sessionId];
+    const sessionFlag = isResume ? '--resume' : '--session-id';
+    const args = ['-p', fullPrompt, '--output-format', 'text', sessionFlag, sessionId];
 
-    const stdout = await runClaude({
-      args,
-      cwd: ctx.cwd,
-      env: ctx.env,
-      timeoutMs: ctx.timeoutMs || DEFAULT_TIMEOUT_MS,
-      spawnImpl: ctx._spawnImpl, // test seam only — do not use in production
-    });
-
-    return { text: stdout.trim(), newSessionId: sessionId };
+    try {
+      const stdout = await runClaude({
+        args,
+        cwd: ctx.cwd,
+        env: ctx.env,
+        timeoutMs: ctx.timeoutMs || DEFAULT_TIMEOUT_MS,
+        spawnImpl: ctx._spawnImpl, // test seam only — do not use in production
+      });
+      return { text: stdout.trim(), newSessionId: sessionId };
+    } catch (err) {
+      // Self-heal against a corrupted session store. If the persisted id is
+      // already in use (or claude has forgotten about it), discard it and
+      // restart the turn with a fresh UUID. Without this, a single bad
+      // session id poisons every subsequent event re-delivery.
+      if (isResume && /already in use|no conversation|no session/i.test(String(err.message))) {
+        const freshId = randomUUID();
+        const stdout = await runClaude({
+          args: ['-p', fullPrompt, '--output-format', 'text', '--session-id', freshId],
+          cwd: ctx.cwd,
+          env: ctx.env,
+          timeoutMs: ctx.timeoutMs || DEFAULT_TIMEOUT_MS,
+          spawnImpl: ctx._spawnImpl,
+        });
+        return { text: stdout.trim(), newSessionId: freshId };
+      }
+      throw err;
+    }
   },
 };


### PR DESCRIPTION
## Summary
Second-mention crash on the local CLI wrapper. Live smoke on api-dev:

\`\`\`
[sam-claude] [chat.mention] spawn error: claude exited with code 1:
  Error: Session ID 62fc8c40-1a2c-437b-ab9c-d7af514ec3ab is already in use.
\`\`\`

## Root cause
The adapter passed \`--session-id <uuid>\` on every turn. In claude,
\`--session-id\` means \"CREATE a session with this UUID (must be fresh).\"
The correct flag for continuation is \`--resume <uuid>\`.

Because the event was never ack'd (spawn threw), the kernel kept
re-delivering it — producing an infinite loop of the same error.

## Fix
- **First turn** (no persisted id): mint UUID, pass \`--session-id\`.
- **Subsequent turns** (persisted id): pass \`--resume\`.
- **Self-heal**: if claude rejects \`--resume\` with \"already in use\",
  \"no conversation\", or \"no session\", retry once with a fresh UUID via
  \`--session-id\`. Prevents a corrupted session store from poisoning every
  re-delivered event.

## Unblock for running agents today
Users hitting this on an existing \`sam-claude\` install can unblock by
deleting \`~/.commonly/sessions/<name>.json\` before merging; after merge
the adapter self-heals on the first bad \`--resume\` response.

## Test plan
- [x] 12/12 adapters.claude.test.mjs; 73/73 full CLI suite
- [x] New regression tests lock down both flags and the self-heal path
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)