### PR TITLE
feat(cli): agent list --local shows laptop-attached agents

### DIFF
--- a/cli/__tests__/detach.test.mjs
+++ b/cli/__tests__/detach.test.mjs
@@ -28,6 +28,7 @@ const {
   performDetach,
   saveAgentToken,
   loadAgentToken,
+  listLocalAgents,
 } = await import('../src/commands/agent.js');
 const { setSession, getSession } = await import('../src/lib/session-store.js');
 
@@ -152,5 +153,73 @@ describe('performDetach', () => {
     // clearSessions / deleteAgentToken no-op when files don't exist.
     expect(result.localCleaned).toBe(true);
     expect(del).not.toHaveBeenCalled();
+  });
+});
+
+describe('listLocalAgents', () => {
+  beforeEach(() => {
+    fs.rmSync(path.join(tmp, '.commonly'), { recursive: true, force: true });
+  });
+
+  test('returns [] when no tokens dir exists', () => {
+    expect(listLocalAgents()).toEqual([]);
+  });
+
+  test('enumerates each token file as one record with name/adapter/pod/instanceUrl', () => {
+    saveAgentToken('alpha', {
+      agentName: 'alpha', instanceId: 'default', podId: 'pod-a',
+      instanceUrl: 'http://localhost:5000', runtimeToken: 'cm_agent_a',
+      adapter: 'claude',
+    });
+    saveAgentToken('beta', {
+      agentName: 'beta', instanceId: 'default', podId: 'pod-b',
+      instanceUrl: 'https://api-dev.commonly.me', runtimeToken: 'cm_agent_b',
+      adapter: 'codex',
+    });
+
+    const agents = listLocalAgents();
+    const byName = Object.fromEntries(agents.map((a) => [a.name, a]));
+    expect(Object.keys(byName).sort()).toEqual(['alpha', 'beta']);
+    expect(byName.alpha.adapter).toBe('claude');
+    expect(byName.alpha.podId).toBe('pod-a');
+    expect(byName.alpha.instanceUrl).toBe('http://localhost:5000');
+    expect(byName.beta.adapter).toBe('codex');
+    // lastTurn is null until a session entry lands — see next test.
+    expect(byName.alpha.lastTurn).toBeNull();
+  });
+
+  test('surfaces the most-recent lastTurn across pods from the session store', () => {
+    saveAgentToken('multipod', {
+      agentName: 'multipod', instanceId: 'default', podId: 'pod-x',
+      instanceUrl: 'http://localhost:5000', runtimeToken: 'cm_agent_m',
+      adapter: 'claude',
+    });
+    // Two pods with different lastTurn timestamps. `getSession`/`setSession`
+    // write to the same file, so we can rely on the existing API.
+    setSession('multipod', 'pod-x', 'sid-x');
+    // Manually write a second pod entry to force distinct timestamps.
+    const sessionsFile = path.join(tmp, '.commonly', 'sessions', 'multipod.json');
+    const state = JSON.parse(fs.readFileSync(sessionsFile, 'utf8'));
+    state['pod-y'] = { sessionId: 'sid-y', lastTurn: '2099-01-01T00:00:00.000Z' };
+    fs.writeFileSync(sessionsFile, JSON.stringify(state), 'utf8');
+
+    const [agent] = listLocalAgents();
+    // The 2099 timestamp on pod-y should win over setSession's "now".
+    expect(agent.lastTurn).toBe('2099-01-01T00:00:00.000Z');
+  });
+
+  test('survives a corrupt session file (returns null lastTurn, does not throw)', () => {
+    saveAgentToken('corrupt', {
+      agentName: 'corrupt', instanceId: 'default', podId: 'pod-c',
+      instanceUrl: 'http://localhost:5000', runtimeToken: 'cm_agent_c',
+      adapter: 'claude',
+    });
+    const sessionsFile = path.join(tmp, '.commonly', 'sessions', 'corrupt.json');
+    fs.mkdirSync(path.dirname(sessionsFile), { recursive: true });
+    fs.writeFileSync(sessionsFile, 'not json {', 'utf8');
+
+    const [agent] = listLocalAgents();
+    expect(agent.name).toBe('corrupt');
+    expect(agent.lastTurn).toBeNull();
   });
 });

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -11,7 +11,7 @@
  * heartbeat  — manually trigger an agent's heartbeat
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync, readdirSync } from 'fs';
 import { join, dirname, resolve as pathResolve } from 'path';
 import { homedir, tmpdir } from 'os';
 import { fileURLToPath } from 'url';
@@ -51,6 +51,49 @@ export const loadAgentToken = (name) => {
 export const deleteAgentToken = (name) => {
   const file = tokenFile(name);
   if (existsSync(file)) rmSync(file);
+};
+
+/**
+ * Enumerate every agent attached on this laptop — i.e. every file in
+ * ~/.commonly/tokens/*.json. Cross-references the session store for a
+ * "last turn" timestamp per agent so the user sees cold vs. live agents.
+ *
+ * Returns an array of plain records so the CLI table formatter stays simple
+ * and tests can assert on shape directly.
+ */
+export const listLocalAgents = () => {
+  const dir = tokensDir();
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => f.slice(0, -'.json'.length))
+    .map((name) => {
+      const record = loadAgentToken(name);
+      if (!record) return null;
+      let lastTurn = null;
+      try {
+        const sessionsFile = join(homedir(), '.commonly', 'sessions', `${name}.json`);
+        if (existsSync(sessionsFile)) {
+          const sessions = JSON.parse(readFileSync(sessionsFile, 'utf8'));
+          // One entry per pod — we surface the most recent across pods.
+          Object.values(sessions).forEach((s) => {
+            if (s?.lastTurn && (!lastTurn || s.lastTurn > lastTurn)) lastTurn = s.lastTurn;
+          });
+        }
+      } catch {
+        // Corrupt session store — not a hard error, just skip.
+      }
+      return {
+        name,
+        adapter: record.adapter || '?',
+        podId: record.podId || '?',
+        instanceUrl: record.instanceUrl || '?',
+        instanceId: record.instanceId || 'default',
+        savedAt: record.savedAt || null,
+        lastTurn,
+      };
+    })
+    .filter(Boolean);
 };
 
 // Event types that carry a human/agent-authored prompt the wrapper should
@@ -798,10 +841,35 @@ Docs:
   // ── list ──────────────────────────────────────────────────────────────────
   agent
     .command('list')
-    .description('List installed agents')
-    .option('--pod <podId>', 'Filter by pod')
-    .option('--instance <url>', 'Target Commonly instance')
+    .description('List agents — installed on backend (default) or attached locally (--local)')
+    .option('--local', 'List agents attached on this laptop (~/.commonly/tokens/)')
+    .option('--pod <podId>', 'Filter by pod (backend mode only)')
+    .option('--instance <url>', 'Target Commonly instance (backend mode only)')
+    .addHelpText('after', `
+The two modes answer different questions:
+
+  backend (default)  — who is installed in pods I can see, on any driver
+  --local            — who have I attached on THIS laptop via 'agent attach'
+
+Use --local to find the name you'd pass to 'agent run' or 'agent detach'.
+`)
     .action(async (opts) => {
+      if (opts.local) {
+        const agents = listLocalAgents();
+        if (agents.length === 0) {
+          console.log('No agents attached locally. Run: commonly agent attach <adapter> --pod <podId> --name <n>');
+          return;
+        }
+        const col = (s, w) => String(s ?? '').padEnd(w).slice(0, w);
+        console.log(`${col('NAME', 20)} ${col('ADAPTER', 10)} ${col('POD', 26)} LAST TURN`);
+        console.log('─'.repeat(80));
+        agents.forEach((a) => {
+          const lastTurn = a.lastTurn ? new Date(a.lastTurn).toLocaleString() : 'never';
+          console.log(`${col(a.name, 20)} ${col(a.adapter, 10)} ${col(a.podId, 26)} ${lastTurn}`);
+        });
+        return;
+      }
+
       const token = getToken(opts.instance);
       if (!token) { console.error('Not logged in. Run: commonly login'); process.exit(1); }
 

--- a/docs/agents/LOCAL_CLI_WRAPPER.md
+++ b/docs/agents/LOCAL_CLI_WRAPPER.md
@@ -81,6 +81,16 @@ If the token is revoked while `run` is polling (for example, you uninstalled the
 
 Before this guard (PR #204), a revoked token produced an invisible infinite backoff loop — don't be surprised if older docs describe that behaviour.
 
+### Enumerate what you've attached
+
+```
+commonly agent list --local
+```
+
+Reads `~/.commonly/tokens/*.json` and shows name, adapter, pod, and last turn timestamp per agent. Use this when you've forgotten the name to pass to `run` or `detach`, or to spot stale attachments that should be cleaned up.
+
+The default `commonly agent list` (no `--local`) hits the backend and shows installed agents across all drivers; the two modes don't overlap.
+
 ### Detach — clean uninstall
 
 ```

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -93,9 +93,12 @@ Full flow: [WEBHOOK_SDK.md](../agents/WEBHOOK_SDK.md).
 
 | Command | Purpose |
 |---------|---------|
-| `commonly agent list [--pod <id>]` | List installed agents (optionally filtered by pod). |
+| `commonly agent list [--pod <id>] [--instance <url-or-key>]` | List agents installed on the backend (any driver, any pod you can see). |
+| `commonly agent list --local` | List agents attached on THIS laptop (from `~/.commonly/tokens/`). Shows adapter, pod, and last turn — use this to find the name you'd pass to `agent run` or `agent detach`. |
 | `commonly agent logs <name> [--follow] [--instance-id <id>]` | Stream recent events for an agent. `--follow` keeps polling. |
 | `commonly agent heartbeat <name>` | Manually trigger a heartbeat event. |
+
+The two `list` modes answer different questions — backend mode is "who is installed where", `--local` is "who have I attached on this laptop". They don't overlap.
 
 ### Pods
 


### PR DESCRIPTION
## Summary
Closes the gap surfaced earlier today: `commonly agent list` only hit the backend, so there was no way to see what you'd attached on THIS laptop. Now `--local` reads `~/.commonly/tokens/` and shows adapter, pod, last turn.

## Live test
```
$ commonly agent list --local
NAME                 ADAPTER    POD                        LAST TURN
────────────────────────────────────────────────────────────────────────────────
sam-claude           claude     69db5da7b0701e51e5ba74ac   4/16/2026, 12:27:24 AM
```

## Test plan
- [x] 77/77 CLI suite passing (was 73)
- [x] Manual verification against live `~/.commonly/tokens/`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)