### PR TITLE
feat(cli): ADR-008 Phase 1 — agent environment primitive

### DIFF
--- a/cli/__tests__/adapters.claude.environment.test.mjs
+++ b/cli/__tests__/adapters.claude.environment.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * adapters.claude.environment.test.mjs — ADR-008 Phase 1
+ *
+ * Asserts the claude adapter honours ctx.environment:
+ *   - sandbox.mode='bwrap' → spawn binary is `bwrap`, not `claude`
+ *   - mcp[]               → --mcp-config <path> added to inner argv,
+ *                            and the JSON file written under <cwd>/.commonly/
+ *   - skills.claude[]     → linkSkills called against the workspace
+ *
+ * Uses ctx._spawnImpl (the same test seam as adapters.claude.test.mjs) so
+ * no real claude/bwrap binary runs.
+ */
+
+import { jest } from '@jest/globals';
+import { EventEmitter } from 'events';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+const onLinux = process.platform === 'linux';
+
+await jest.unstable_mockModule('child_process', () => ({
+  spawnSync: jest.fn(),
+  spawn: jest.fn(),
+}));
+
+const claude = (await import('../src/lib/adapters/claude.js')).default;
+
+const fakeChild = ({ stdout = '', code = 0 } = {}) => {
+  const proc = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = jest.fn();
+  setTimeout(() => {
+    if (stdout) proc.stdout.emit('data', Buffer.from(stdout));
+    proc.emit('close', code);
+  }, 0);
+  return proc;
+};
+
+const makeSpawnImpl = () => {
+  const calls = [];
+  const impl = (cmd, args, opts) => {
+    calls.push({ cmd, args, opts });
+    return fakeChild({ stdout: 'ok' });
+  };
+  return { impl, calls };
+};
+
+describe('claude adapter — ctx.environment', () => {
+  let cwd;
+  beforeEach(() => {
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-claude-env-'));
+  });
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  test('writes <cwd>/.commonly/mcp-config.json and adds --mcp-config when env.mcp declared', async () => {
+    const { impl, calls } = makeSpawnImpl();
+    const environment = {
+      mcp: [
+        { name: 'github', transport: 'http', url: 'http://localhost:3000/github-mcp' },
+        { name: 'local-db', transport: 'stdio', command: ['postgres-mcp', '--db', 'mydb'] },
+      ],
+    };
+
+    await claude.spawn('hi', {
+      sessionId: null,
+      cwd,
+      environment,
+      _spawnImpl: impl,
+    });
+
+    const cfgPath = path.join(cwd, '.commonly', 'mcp-config.json');
+    expect(fs.existsSync(cfgPath)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    expect(parsed.mcpServers.github).toMatchObject({ type: 'http', url: 'http://localhost:3000/github-mcp' });
+    expect(parsed.mcpServers['local-db']).toMatchObject({
+      type: 'stdio', command: 'postgres-mcp', args: ['--db', 'mydb'],
+    });
+
+    expect(calls).toHaveLength(1);
+    const innerArgs = calls[0].args;
+    expect(innerArgs).toContain('--mcp-config');
+    const idx = innerArgs.indexOf('--mcp-config');
+    expect(innerArgs[idx + 1]).toBe(cfgPath);
+  });
+
+  test('symlinks skills.claude entries into <cwd>/.claude/skills/', async () => {
+    const { impl } = makeSpawnImpl();
+    const skillSrc = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-claude-skill-'));
+    fs.writeFileSync(path.join(skillSrc, 'SKILL.md'), 'x', 'utf8');
+
+    await claude.spawn('hi', {
+      sessionId: null,
+      cwd,
+      environment: { skills: { claude: [skillSrc] } },
+      _spawnImpl: impl,
+    });
+
+    const link = path.join(cwd, '.claude', 'skills', path.basename(skillSrc));
+    expect(fs.lstatSync(link).isSymbolicLink()).toBe(true);
+
+    fs.rmSync(skillSrc, { recursive: true, force: true });
+  });
+
+  (onLinux ? test : test.skip)('sandbox.mode=bwrap → spawn binary is `bwrap`, claude moves into inner argv', async () => {
+    const { impl, calls } = makeSpawnImpl();
+
+    await claude.spawn('hi', {
+      sessionId: null,
+      cwd,
+      environment: {
+        sandbox: { mode: 'bwrap', network: { policy: 'unrestricted' } },
+      },
+      _spawnImpl: impl,
+    });
+
+    expect(calls[0].cmd).toBe('bwrap');
+    // Inner argv after `--` must start with `claude`.
+    const sepIdx = calls[0].args.indexOf('--');
+    expect(sepIdx).toBeGreaterThan(-1);
+    expect(calls[0].args[sepIdx + 1]).toBe('claude');
+  });
+
+  test('no environment → behaviour identical to pre-ADR-008 (cmd=claude, no MCP file)', async () => {
+    const { impl, calls } = makeSpawnImpl();
+    await claude.spawn('hi', { sessionId: null, cwd, _spawnImpl: impl });
+    expect(calls[0].cmd).toBe('claude');
+    expect(calls[0].args).not.toContain('--mcp-config');
+    expect(fs.existsSync(path.join(cwd, '.commonly'))).toBe(false);
+    expect(fs.existsSync(path.join(cwd, '.claude'))).toBe(false);
+  });
+});

--- a/cli/__tests__/bwrap.test.mjs
+++ b/cli/__tests__/bwrap.test.mjs
@@ -1,0 +1,106 @@
+/**
+ * bwrap.test.mjs — ADR-008 Phase 1
+ *
+ * Covers the bwrap sandbox helper: detection, argv wrapping, macOS refusal.
+ * Linux-only assertions guard with `process.platform !== 'linux'` so the
+ * suite passes on a macOS dev box without false negatives.
+ */
+
+import {
+  detectBwrap,
+  wrapArgvWithBwrap,
+  BWRAP_MACOS_MESSAGE,
+} from '../src/lib/sandbox/bwrap.js';
+
+const onLinux = process.platform === 'linux';
+const itLinux = onLinux ? test : test.skip;
+const itMac = process.platform === 'darwin' ? test : test.skip;
+
+describe('detectBwrap', () => {
+  itLinux('returns {available:true} when bwrap is on PATH (skipped if not installed)', () => {
+    const res = detectBwrap();
+    if (!res.available) {
+      // Don't fail CI on a Linux box without bubblewrap — the production
+      // attach flow is already the loud surface for "you need to install it".
+      expect(res.error).toMatch(/bwrap not found|bubblewrap/);
+      return;
+    }
+    expect(res.available).toBe(true);
+    expect(res.path).toBe('bwrap');
+  });
+
+  itMac('returns the macOS-specific error on darwin', () => {
+    const res = detectBwrap();
+    expect(res.available).toBe(false);
+    expect(res.error).toBe(BWRAP_MACOS_MESSAGE);
+  });
+});
+
+describe('wrapArgvWithBwrap', () => {
+  itMac('throws the documented macOS message on darwin', () => {
+    expect(() => wrapArgvWithBwrap(['claude', '-p', 'hi'], {}, {
+      workspacePath: '/tmp/ws',
+    })).toThrow(BWRAP_MACOS_MESSAGE);
+  });
+
+  itLinux('produces the expected isolation flag set', () => {
+    const argv = wrapArgvWithBwrap(
+      ['claude', '-p', 'hi'],
+      { sandbox: { network: { policy: 'unrestricted' } } },
+      { workspacePath: '/tmp/ws' },
+    );
+    expect(argv[0]).toBe('bwrap');
+    expect(argv).toContain('--unshare-all');
+    expect(argv).toContain('--share-net');
+    expect(argv).toContain('--die-with-parent');
+    expect(argv).toContain('--new-session');
+    expect(argv).toContain('--proc');
+    expect(argv).toContain('--dev');
+    expect(argv).toContain('--tmpfs');
+    // workspace bind RW + chdir + HOME
+    const bindIdx = argv.indexOf('--bind');
+    expect(bindIdx).toBeGreaterThan(-1);
+    expect(argv[bindIdx + 1]).toBe('/tmp/ws');
+    expect(argv[bindIdx + 2]).toBe('/tmp/ws');
+    expect(argv).toContain('--chdir');
+    expect(argv).toContain('--setenv');
+    // inner argv preserved at the end after `--`
+    const sepIdx = argv.indexOf('--');
+    expect(sepIdx).toBeGreaterThan(-1);
+    expect(argv.slice(sepIdx + 1)).toEqual(['claude', '-p', 'hi']);
+  });
+
+  itLinux('switches to --unshare-net when network.policy=restricted', () => {
+    const argv = wrapArgvWithBwrap(
+      ['claude'],
+      { sandbox: { network: { policy: 'restricted' } } },
+      { workspacePath: '/tmp/ws' },
+    );
+    expect(argv).toContain('--unshare-net');
+    expect(argv).not.toContain('--share-net');
+  });
+
+  itLinux('appends user read-outside paths as --ro-bind-try', () => {
+    const argv = wrapArgvWithBwrap(
+      ['claude'],
+      { sandbox: { filesystem: { 'read-outside': ['/home/user/.claude'] } } },
+      { workspacePath: '/tmp/ws' },
+    );
+    const idx = argv.indexOf('/home/user/.claude');
+    expect(idx).toBeGreaterThan(-1);
+    expect(argv[idx - 1]).toBe('/home/user/.claude');
+    expect(argv[idx - 2]).toBe('--ro-bind-try');
+  });
+
+  itLinux('rejects empty inner argv', () => {
+    expect(() => wrapArgvWithBwrap([], {}, { workspacePath: '/tmp/ws' })).toThrow(
+      /non-empty innerArgv/,
+    );
+  });
+
+  itLinux('rejects relative workspace paths', () => {
+    expect(() => wrapArgvWithBwrap(['x'], {}, { workspacePath: 'relative/ws' })).toThrow(
+      /absolute path/,
+    );
+  });
+});

--- a/cli/__tests__/environment.test.mjs
+++ b/cli/__tests__/environment.test.mjs
@@ -1,0 +1,281 @@
+/**
+ * environment.test.mjs — ADR-008 Phase 1
+ *
+ * Covers parseEnvironmentFile, validateEnvironmentSpec, resolveWorkspace,
+ * linkSkills. The module is pure I/O against the local FS — we use real temp
+ * dirs and a mocked `os.homedir` so `~` expansion and the default workspace
+ * path land somewhere disposable.
+ */
+
+import { jest } from '@jest/globals';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-env-test-'));
+
+await jest.unstable_mockModule('os', () => {
+  const actual = os;
+  return {
+    ...actual,
+    default: { ...actual, homedir: () => tmpHome },
+    homedir: () => tmpHome,
+  };
+});
+
+const {
+  parseEnvironmentFile,
+  validateEnvironmentSpec,
+  resolveWorkspace,
+  linkSkills,
+} = await import('../src/lib/environment.js');
+
+const writeJson = (dir, name, obj) => {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, JSON.stringify(obj, null, 2), 'utf8');
+  return file;
+};
+
+describe('parseEnvironmentFile', () => {
+  let dir;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-env-parse-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('parses a valid JSON env file and returns the bare spec', async () => {
+    const file = writeJson(dir, 'env.json', {
+      version: 1,
+      workspace: { path: '~/projects/foo' },
+      sandbox: { mode: 'bwrap' },
+    });
+    const spec = await parseEnvironmentFile(file);
+    expect(spec.version).toBe(1);
+    expect(spec.workspace.path).toBe('~/projects/foo');
+    // Spec must NOT carry envFileDir / _envFileDir — that path is host-private
+    // and would leak to the backend on `config.environment` install POST.
+    expect(spec._envFileDir).toBeUndefined();
+    expect(spec.envFileDir).toBeUndefined();
+  });
+
+  test('rejects YAML files in Phase 1 with a JSON-conversion hint', async () => {
+    const file = path.join(dir, 'env.yaml');
+    fs.writeFileSync(file, 'version: 1\n', 'utf8');
+    await expect(parseEnvironmentFile(file)).rejects.toThrow(
+      /YAML environment files are not supported.*JSON/s,
+    );
+  });
+
+  test('rejects malformed JSON with the file path in the error', async () => {
+    const file = path.join(dir, 'bad.json');
+    fs.writeFileSync(file, '{ not-json', 'utf8');
+    await expect(parseEnvironmentFile(file)).rejects.toThrow(/Failed to parse/);
+  });
+
+  test('surfaces validation errors before returning', async () => {
+    const file = writeJson(dir, 'env.json', {
+      version: 99, sandbox: { mode: 'unknown-mode' },
+    });
+    await expect(parseEnvironmentFile(file)).rejects.toThrow(
+      /version must be 1|sandbox.mode must be/,
+    );
+  });
+
+  test('rejects relative paths (callers must resolve first)', async () => {
+    await expect(parseEnvironmentFile('env.json')).rejects.toThrow(
+      /requires an absolute path/,
+    );
+  });
+});
+
+describe('validateEnvironmentSpec', () => {
+  test('accepts a minimal valid spec', () => {
+    expect(validateEnvironmentSpec({ version: 1 })).toEqual({ ok: true, errors: [] });
+  });
+
+  test('rejects unknown top-level keys', () => {
+    const res = validateEnvironmentSpec({ version: 1, sandbax: {} });
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(' ')).toMatch(/unknown top-level key.*sandbax/);
+  });
+
+  test('rejects bad sandbox.mode', () => {
+    const res = validateEnvironmentSpec({ sandbox: { mode: 'rocket' } });
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(' ')).toMatch(/sandbox.mode/);
+  });
+
+  test('rejects bad sandbox.network.policy', () => {
+    const res = validateEnvironmentSpec({
+      sandbox: { network: { policy: 'kinda-restricted' } },
+    });
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(' ')).toMatch(/network.policy/);
+  });
+
+  test('rejects skills.claude that is not an array of strings', () => {
+    const res = validateEnvironmentSpec({ skills: { claude: 'not-an-array' } });
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(' ')).toMatch(/skills.claude/);
+  });
+
+  test('mcp entries require name; flag missing-name with index', () => {
+    const res = validateEnvironmentSpec({ mcp: [{ transport: 'http' }] });
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(' ')).toMatch(/mcp\[0\].name/);
+  });
+
+  test('underscore-prefixed keys are rejected (no internal annotations on the spec)', () => {
+    // Spec must be serialization-clean for backend. Underscore-prefixed keys
+    // were a v1-design holdover; we now enforce a closed allow-list.
+    const res = validateEnvironmentSpec({ _envFileDir: '/tmp', version: 1 });
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(' ')).toMatch(/unknown top-level key.*_envFileDir/);
+  });
+});
+
+describe('resolveWorkspace', () => {
+  test('expands ~ and creates the workspace dir; reports created=true', async () => {
+    const spec = { workspace: { path: '~/projects/sandbox-research' } };
+    const { path: ws, created } = await resolveWorkspace(spec, 'research');
+    expect(ws).toBe(path.join(tmpHome, 'projects', 'sandbox-research'));
+    expect(created).toBe(true);
+    expect(fs.existsSync(ws)).toBe(true);
+    fs.rmSync(ws, { recursive: true, force: true });
+  });
+
+  test('defaults to ~/.commonly/workspaces/<agent> when workspace.path absent', async () => {
+    const { path: ws, created } = await resolveWorkspace({}, 'liz');
+    expect(ws).toBe(path.join(tmpHome, '.commonly', 'workspaces', 'liz'));
+    expect(created).toBe(true);
+    expect(fs.existsSync(ws)).toBe(true);
+    fs.rmSync(ws, { recursive: true, force: true });
+  });
+
+  test('reports created=false when workspace already exists', async () => {
+    const ws = path.join(tmpHome, 'preexisting-ws');
+    fs.mkdirSync(ws, { recursive: true });
+    const { path: out, created } = await resolveWorkspace({ workspace: { path: ws } }, 'x');
+    expect(out).toBe(ws);
+    expect(created).toBe(false);
+    fs.rmSync(ws, { recursive: true, force: true });
+  });
+
+  test('copies seed paths into a freshly-created workspace', async () => {
+    const envDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-env-seed-'));
+    fs.writeFileSync(path.join(envDir, 'README.md'), '# seed', 'utf8');
+    fs.mkdirSync(path.join(envDir, 'prompts'));
+    fs.writeFileSync(path.join(envDir, 'prompts', 'a.txt'), 'hi', 'utf8');
+
+    const wsTarget = path.join(tmpHome, 'seeded-ws');
+    const { path: ws } = await resolveWorkspace(
+      { workspace: { path: wsTarget, seed: ['./README.md', './prompts'] } },
+      'seeded',
+      envDir, // envFileDir as a separate arg, not embedded in the spec
+    );
+    expect(fs.existsSync(path.join(ws, 'README.md'))).toBe(true);
+    expect(fs.existsSync(path.join(ws, 'prompts', 'a.txt'))).toBe(true);
+
+    fs.rmSync(envDir, { recursive: true, force: true });
+    fs.rmSync(ws, { recursive: true, force: true });
+  });
+});
+
+describe('linkSkills', () => {
+  let workspace;
+  let skillSrc;
+
+  beforeEach(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-env-ws-'));
+    skillSrc = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-env-skill-'));
+    fs.writeFileSync(path.join(skillSrc, 'SKILL.md'), '# my skill', 'utf8');
+  });
+  afterEach(() => {
+    fs.rmSync(workspace, { recursive: true, force: true });
+    fs.rmSync(skillSrc, { recursive: true, force: true });
+  });
+
+  test('creates .claude/skills/<basename> symlink to the source dir', async () => {
+    const { linked, skipped, conflicted } = await linkSkills(
+      { skills: { claude: [skillSrc] } },
+      workspace,
+    );
+    expect(linked).toEqual([skillSrc]);
+    expect(skipped).toEqual([]);
+    expect(conflicted).toEqual([]);
+
+    const linkPath = path.join(workspace, '.claude', 'skills', path.basename(skillSrc));
+    expect(fs.lstatSync(linkPath).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(path.join(linkPath, 'SKILL.md'), 'utf8')).toBe('# my skill');
+  });
+
+  test('idempotent: re-running with the same source reports as already-linked', async () => {
+    await linkSkills({ skills: { claude: [skillSrc] } }, workspace);
+    const second = await linkSkills({ skills: { claude: [skillSrc] } }, workspace);
+    expect(second.linked).toEqual([]);
+    expect(second.skipped).toEqual([skillSrc]);
+    expect(second.conflicted).toEqual([]);
+  });
+
+  test('refuses to overwrite a different existing symlink at the same slot — reports `different-target`', async () => {
+    // Two different source dirs, same basename — second one must surface as
+    // a conflict so the caller can warn the user (NOT silently merged into
+    // skipped, which would mask the user's intent being lost).
+    const otherSrc = fs.mkdtempSync(path.join(path.dirname(skillSrc),
+      `${path.basename(skillSrc).slice(0, -6)}-X-`));
+    const slotName = path.basename(skillSrc);
+    const slotPath = path.join(workspace, '.claude', 'skills', slotName);
+    fs.mkdirSync(path.dirname(slotPath), { recursive: true });
+    fs.symlinkSync(otherSrc, slotPath);
+
+    const { linked, skipped, conflicted } = await linkSkills(
+      { skills: { claude: [skillSrc] } },
+      workspace,
+    );
+    expect(linked).toEqual([]);
+    expect(skipped).toEqual([]);
+    expect(conflicted).toEqual([{ path: skillSrc, reason: 'different-target' }]);
+    // Existing link untouched.
+    expect(fs.readlinkSync(slotPath)).toBe(otherSrc);
+
+    fs.rmSync(otherSrc, { recursive: true, force: true });
+  });
+
+  test('returns empty buckets when no skills are declared', async () => {
+    expect(await linkSkills({}, workspace)).toEqual({
+      linked: [], skipped: [], conflicted: [],
+    });
+  });
+
+  test('non-existent source paths surface as `missing-source` conflicts (not silent skips)', async () => {
+    const ghost = path.join(skillSrc, 'does-not-exist');
+    const { linked, skipped, conflicted } = await linkSkills(
+      { skills: { claude: [ghost] } },
+      workspace,
+    );
+    expect(linked).toEqual([]);
+    expect(skipped).toEqual([]);
+    expect(conflicted).toEqual([{ path: ghost, reason: 'missing-source' }]);
+  });
+
+  test('non-symlink occupants (real files/dirs) surface as `not-symlink` conflicts', async () => {
+    // A user might have hand-created a real dir at the slot — never overwrite.
+    const slotName = path.basename(skillSrc);
+    const slotPath = path.join(workspace, '.claude', 'skills', slotName);
+    fs.mkdirSync(path.dirname(slotPath), { recursive: true });
+    fs.mkdirSync(slotPath);
+    fs.writeFileSync(path.join(slotPath, 'hand-edited.md'), 'mine', 'utf8');
+
+    const { linked, skipped, conflicted } = await linkSkills(
+      { skills: { claude: [skillSrc] } },
+      workspace,
+    );
+    expect(linked).toEqual([]);
+    expect(skipped).toEqual([]);
+    expect(conflicted).toEqual([{ path: skillSrc, reason: 'not-symlink' }]);
+    // Hand-edited file untouched.
+    expect(fs.existsSync(path.join(slotPath, 'hand-edited.md'))).toBe(true);
+  });
+});

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -23,6 +23,8 @@ import { startWebhookServer, forwardToLocalWebhook } from '../lib/webhook-server
 import { getAdapter, listAdapterNames } from '../lib/adapters/index.js';
 import { getSession, setSession, clearSessions } from '../lib/session-store.js';
 import { readLongTerm, syncBack } from '../lib/memory-bridge.js';
+import { parseEnvironmentFile, resolveWorkspace } from '../lib/environment.js';
+import { detectBwrap } from '../lib/sandbox/bwrap.js';
 
 // ── Token file I/O — ~/.commonly/tokens/<name>.json (ADR-005) ───────────────
 
@@ -113,6 +115,7 @@ export const performAttach = async ({
   agentName,
   podId,
   displayName,
+  envPath = null,
   log = () => {},
 }) => {
   const adapter = getAdapter(adapterName);
@@ -125,6 +128,36 @@ export const performAttach = async ({
   const detected = await adapter.detect();
   if (!detected) {
     throw new Error(`${adapterName} not found on PATH. Install it and retry.`);
+  }
+
+  // ADR-008 §invariant #4: sandbox failure is a hard stop. Validate the env
+  // here so attach refuses up front rather than handing the user a runtime
+  // that silently degrades to unsandboxed.
+  let environment = null;
+  let workspace = null;
+  if (envPath) {
+    environment = await parseEnvironmentFile(envPath);
+    workspace = await resolveWorkspace(environment, agentName, dirname(envPath));
+    log(`workspace: ${workspace.path}${workspace.created ? ' (created)' : ''}`);
+
+    const sandboxMode = environment.sandbox?.mode || 'none';
+    if (sandboxMode === 'bwrap') {
+      const bwrap = detectBwrap();
+      if (!bwrap.available) {
+        throw new Error(`sandbox.mode=bwrap requested but unavailable: ${bwrap.error}`);
+      }
+      if (environment.sandbox?.network?.policy === 'restricted') {
+        log(
+          'WARNING: bwrap mode does not enforce host allowlist; declared hosts '
+          + 'are advisory in Phase 1. Use sandbox.mode=container for enforced policy.',
+        );
+      }
+    } else if (sandboxMode !== 'none' && sandboxMode !== undefined) {
+      throw new Error(
+        `sandbox.mode=${sandboxMode} is not yet implemented in the local-CLI driver. `
+        + `Phase 1 supports: none, bwrap.`,
+      );
+    }
   }
 
   // Idempotent publish — already-published is expected and fine. Install will
@@ -146,6 +179,9 @@ export const performAttach = async ({
   // config.runtime is an opaque blob the backend stores verbatim — kernel
   // does not interpret runtimeType here. ADR-004 §Identity's `sourceRuntime`
   // is a different field (memory-sync tag); don't conflate the two.
+  // ADR-008 §Attach + run with an environment: include the resolved env spec
+  // on config.environment so cross-driver implementations can realize it
+  // server-side without re-reading the user's file.
   const installResult = await client.post('/api/registry/install', {
     agentName,
     podId,
@@ -156,6 +192,7 @@ export const performAttach = async ({
         runtimeType: 'local-cli',
         wrappedCli: adapter.name,
       },
+      ...(environment ? { environment } : {}),
     },
     scopes: ['context:read', 'messages:write', 'memory:read', 'memory:write'],
   });
@@ -174,7 +211,15 @@ export const performAttach = async ({
     throw new Error('Runtime token was not returned by install or tokens endpoint');
   }
 
-  return { installation, instanceId, runtimeToken, detected, wrappedCli: adapter.name };
+  return {
+    installation,
+    instanceId,
+    runtimeToken,
+    detected,
+    wrappedCli: adapter.name,
+    environment,
+    workspace,
+  };
 };
 
 // ── run: local-CLI wrapper loop (ADR-005) ────────────────────────────────────
@@ -206,6 +251,8 @@ export const performRun = ({
   agentName,
   instanceId = 'default',
   podId = null,
+  environment = null,
+  workspacePath = null,
   intervalMs = 5000,
   log = () => {},
   onError,
@@ -224,8 +271,9 @@ export const performRun = ({
   // Adapters default `ctx.cwd` to this path. Node's child_process.spawn
   // rejects with "spawn <bin> ENOENT" when cwd does not exist — same shape
   // as binary-not-found — so we ensure it up front to avoid the confusing
-  // diagnostic.
-  const agentCwd = join(tmpdir(), 'commonly-agents', agentName);
+  // diagnostic. ADR-008: when an environment spec was attached, the resolved
+  // workspace path replaces the /tmp default.
+  const agentCwd = workspacePath || join(tmpdir(), 'commonly-agents', agentName);
   if (!existsSync(agentCwd)) mkdirSync(agentCwd, { recursive: true });
 
   const processEvent = async (event) => {
@@ -248,6 +296,7 @@ export const performRun = ({
       cwd: agentCwd,
       env: process.env,
       memoryLongTerm,
+      environment,
       metadata: { event },
     });
 
@@ -657,13 +706,14 @@ Docs:
       });
     });
 
-  // ── attach (ADR-005) ──────────────────────────────────────────────────────
+  // ── attach (ADR-005, ADR-008) ─────────────────────────────────────────────
   agent
     .command('attach <adapter>')
     .description('Wrap a local CLI as a Commonly agent (stub|claude|codex|…)')
     .requiredOption('--pod <podId>', 'Pod ID to install into')
     .requiredOption('--name <name>', 'Agent name (e.g. my-claude)')
     .option('--display <name>', 'Display name shown in the pod')
+    .option('--env <path>', 'Path to environment.json (ADR-008 — sandbox/skills/MCP)')
     .option('--instance <url>', 'Target Commonly instance')
     .action(async (adapterName, opts) => {
       const instanceUrl = resolveInstanceUrl(opts.instance);
@@ -673,15 +723,19 @@ Docs:
       const client = createClient({ instance: instanceUrl, token });
 
       try {
-        const { installation, instanceId, runtimeToken, detected, wrappedCli } =
-          await performAttach({
-            client,
-            adapterName,
-            agentName: opts.name,
-            podId: opts.pod,
-            displayName: opts.display,
-            log: (line) => console.warn(`[attach] ${line}`),
-          });
+        const envAbsPath = opts.env ? pathResolve(opts.env) : null;
+        const {
+          installation, instanceId, runtimeToken, detected, wrappedCli,
+          environment, workspace,
+        } = await performAttach({
+          client,
+          adapterName,
+          agentName: opts.name,
+          podId: opts.pod,
+          displayName: opts.display,
+          envPath: envAbsPath,
+          log: (line) => console.warn(`[attach] ${line}`),
+        });
 
         saveAgentToken(opts.name, {
           agentName: opts.name,
@@ -690,11 +744,18 @@ Docs:
           instanceUrl,
           runtimeToken,
           adapter: wrappedCli,
+          ...(environment ? {
+            environment,
+            workspacePath: workspace?.path || null,
+          } : {}),
         });
 
         console.log(`✓ ${wrappedCli} detected at ${detected.path} (${detected.version})`);
         console.log(`✓ Agent '${installation.agentName}' registered in pod ${opts.pod} (${instanceId})`);
         console.log(`✓ Runtime token saved to ${tokenFile(opts.name)}`);
+        if (workspace) {
+          console.log(`✓ Workspace: ${workspace.path}${workspace.created ? ' (created)' : ''}`);
+        }
         console.log(`\n  Run with: commonly agent run ${opts.name}`);
       } catch (err) {
         console.error(`Attach failed: ${err.message}`);
@@ -729,6 +790,8 @@ Docs:
         agentName: record.agentName,
         instanceId: record.instanceId,
         podId: record.podId,
+        environment: record.environment || null,
+        workspacePath: record.workspacePath || null,
         intervalMs: parseInt(opts.interval, 10),
         log: (line) => console.log(`[${name}] ${line}`),
         onError: (err) => console.error(`[${name}] ${err.message}`),

--- a/cli/src/lib/adapters/claude.js
+++ b/cli/src/lib/adapters/claude.js
@@ -6,6 +6,13 @@
  * Memory preamble: if ctx.memoryLongTerm is non-empty, the adapter prepends
  * it to the prompt as a system-context preamble (§Memory bridge).
  *
+ * Environment (ADR-008 Phase 1): if ctx.environment is present, the adapter
+ * symlinks declared Claude skills into `<cwd>/.claude/skills/`, writes an MCP
+ * config file at `<cwd>/.commonly/mcp-config.json` when `mcp` is declared,
+ * and wraps the argv with bwrap when `sandbox.mode === 'bwrap'`. The spawn
+ * binary becomes `bwrap` in that case — claude moves to the inner argv.
+ * When ctx.environment is absent, behaviour is identical to pre-ADR-008.
+ *
  * Session continuity (IMPORTANT — the two claude flags are not interchangeable):
  *   - First turn (no persisted id): mint a UUID and pass `--session-id <uuid>`.
  *     claude treats `--session-id` as "CREATE a session with this exact UUID"
@@ -32,6 +39,11 @@
 
 import { spawn as childSpawn, spawnSync } from 'child_process';
 import { randomUUID } from 'crypto';
+import { mkdir, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+import { linkSkills } from '../environment.js';
+import { wrapArgvWithBwrap } from '../sandbox/bwrap.js';
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // ADR-005 §Spawning semantics
 
@@ -40,8 +52,8 @@ const buildPrompt = (prompt, memoryLongTerm) => {
   return `=== Context (your persistent memory) ===\n${memoryLongTerm}\n=== Current turn ===\n${prompt}`;
 };
 
-const runClaude = ({ args, cwd, env, timeoutMs, spawnImpl = childSpawn }) => new Promise((resolve, reject) => {
-  const proc = spawnImpl('claude', args, { cwd, env });
+const runClaude = ({ cmd, args, cwd, env, timeoutMs, spawnImpl = childSpawn }) => new Promise((resolve, reject) => {
+  const proc = spawnImpl(cmd, args, { cwd, env });
   let stdout = '';
   let stderr = '';
   let timedOut = false;
@@ -64,6 +76,61 @@ const runClaude = ({ args, cwd, env, timeoutMs, spawnImpl = childSpawn }) => new
     resolve(stdout);
   });
 });
+
+// ── MCP config write — claude consumes this via --mcp-config <path> ─────────
+
+const buildMcpConfig = (mcpServers) => {
+  // Shape: `{ mcpServers: { <name>: { ... } } }` — the standard MCP client
+  // config, which claude's `--mcp-config` reads directly.
+  const mcpServersMap = {};
+  for (const server of mcpServers) {
+    const entry = { type: server.transport || 'stdio' };
+    if (server.url) entry.url = server.url;
+    if (server.command) {
+      const [command, ...args] = server.command;
+      entry.command = command;
+      if (args.length) entry.args = args;
+    }
+    if (server.env) entry.env = server.env;
+    mcpServersMap[server.name] = entry;
+  }
+  return { mcpServers: mcpServersMap };
+};
+
+// Regenerated on every spawn from the env spec; do not hand-edit — the file
+// is overwritten before each `claude` invocation, so any local changes are
+// silently clobbered. ADR-008 §invariant #5 (edits propagate on next spawn).
+const writeMcpConfig = async (cwd, mcpServers) => {
+  const dir = join(cwd, '.commonly');
+  await mkdir(dir, { recursive: true });
+  const file = join(dir, 'mcp-config.json');
+  await writeFile(file, JSON.stringify(buildMcpConfig(mcpServers), null, 2), 'utf8');
+  return file;
+};
+
+// ── argv preparation — environment-aware ────────────────────────────────────
+
+const prepareArgv = async (innerArgv, ctx) => {
+  const env = ctx.environment;
+  if (!env) return { cmd: 'claude', args: innerArgv };
+
+  if (Array.isArray(env.mcp) && env.mcp.length > 0 && ctx.cwd) {
+    const configPath = await writeMcpConfig(ctx.cwd, env.mcp);
+    // Insert --mcp-config immediately after the subcommand-style `-p` block
+    // so claude parses it before prompt collection begins.
+    innerArgv = [...innerArgv, '--mcp-config', configPath];
+  }
+
+  const sandboxMode = env.sandbox?.mode;
+  if (sandboxMode === 'bwrap') {
+    const wrapped = wrapArgvWithBwrap(['claude', ...innerArgv], env, {
+      workspacePath: ctx.cwd,
+    });
+    return { cmd: wrapped[0], args: wrapped.slice(1) };
+  }
+
+  return { cmd: 'claude', args: innerArgv };
+};
 
 export default {
   name: 'claude',
@@ -90,10 +157,24 @@ export default {
     const sessionId = ctx.sessionId || randomUUID();
     const fullPrompt = buildPrompt(prompt, ctx.memoryLongTerm || '');
     const sessionFlag = isResume ? '--resume' : '--session-id';
-    const args = ['-p', fullPrompt, '--output-format', 'text', sessionFlag, sessionId];
+    const baseArgs = ['-p', fullPrompt, '--output-format', 'text', sessionFlag, sessionId];
+
+    if (ctx.environment && ctx.cwd) {
+      const skills = await linkSkills(ctx.environment, ctx.cwd);
+      if (skills.conflicted.length > 0) {
+        for (const c of skills.conflicted) {
+          // eslint-disable-next-line no-console
+          console.warn(`[claude] skill not linked (${c.reason}): ${c.path}`);
+        }
+      }
+      if (ctx.onSkillsLinked) ctx.onSkillsLinked(skills);
+    }
+
+    const { cmd, args } = await prepareArgv(baseArgs, ctx);
 
     try {
       const stdout = await runClaude({
+        cmd,
         args,
         cwd: ctx.cwd,
         env: ctx.env,
@@ -108,8 +189,11 @@ export default {
       // session id poisons every subsequent event re-delivery.
       if (isResume && /already in use|no conversation|no session/i.test(String(err.message))) {
         const freshId = randomUUID();
+        const retryBase = ['-p', fullPrompt, '--output-format', 'text', '--session-id', freshId];
+        const retry = await prepareArgv(retryBase, ctx);
         const stdout = await runClaude({
-          args: ['-p', fullPrompt, '--output-format', 'text', '--session-id', freshId],
+          cmd: retry.cmd,
+          args: retry.args,
           cwd: ctx.cwd,
           env: ctx.env,
           timeoutMs: ctx.timeoutMs || DEFAULT_TIMEOUT_MS,

--- a/cli/src/lib/environment.js
+++ b/cli/src/lib/environment.js
@@ -1,0 +1,326 @@
+/**
+ * Agent Environment resolver — ADR-008 Phase 1.
+ *
+ * An environment.yaml/.json file is the user-authored, driver-neutral spec for
+ * how an agent's runtime should be shaped: workspace path, sandbox mode, the
+ * Claude skills to mount, the MCP servers to expose. This module is the
+ * adapter-facing read-side: parse, validate, and realize the workspace +
+ * skill links on disk. Sandbox argv wrapping lives in `./sandbox/bwrap.js`
+ * because it is per-driver (Linux-only, bwrap-specific).
+ *
+ * Zero runtime deps: Node 20 has no built-in YAML, so we accept JSON only and
+ * surface a clear error on .yaml/.yml inputs (per task brief). When a future
+ * Node version exposes `node:yaml` natively, parseEnvironmentFile is the one
+ * place to add a `.yaml` branch — the rest of the module is parser-agnostic.
+ */
+
+import { readFile, mkdir, symlink, lstat, readlink, cp } from 'fs/promises';
+import { existsSync } from 'fs';
+import { dirname, isAbsolute, join, resolve as pathResolve, basename } from 'path';
+import { homedir } from 'os';
+
+// ── Schema — keep the allow-list narrow; ADR-008 §invariants #1+#2 ──────────
+//
+// Deliberate omission: the env file's directory (needed to resolve `seed` and
+// relative skill paths) is NOT stored on the returned spec. Leaking the user's
+// absolute filesystem path into `config.environment` sent to the backend
+// exposes `$HOME` layout for zero server-side benefit. Callers pass
+// `envFileDir` as a separate argument to resolveWorkspace / linkSkills.
+
+const ALLOWED_TOP_KEYS = new Set([
+  'version', 'workspace', 'sandbox', 'skills', 'mcp',
+]);
+const ALLOWED_SANDBOX_MODES = new Set(['none', 'bwrap', 'firejail', 'container', 'managed']);
+const ALLOWED_NETWORK_POLICIES = new Set(['unrestricted', 'restricted']);
+
+const expandHome = (p) => {
+  if (!p || typeof p !== 'string') return p;
+  if (p === '~') return homedir();
+  if (p.startsWith('~/')) return join(homedir(), p.slice(2));
+  return p;
+};
+
+// ── parseEnvironmentFile ────────────────────────────────────────────────────
+
+/**
+ * Read and parse the env file. Accepts JSON only in Phase 1 — .yaml/.yml
+ * inputs fail with a specific error pointing the user at JSON, so we never
+ * silently misread a YAML file as JSON.
+ */
+export const parseEnvironmentFile = async (absolutePath) => {
+  if (!isAbsolute(absolutePath)) {
+    throw new Error(`parseEnvironmentFile requires an absolute path, got: ${absolutePath}`);
+  }
+  if (!existsSync(absolutePath)) {
+    throw new Error(`Environment file not found: ${absolutePath}`);
+  }
+
+  const lower = absolutePath.toLowerCase();
+  if (lower.endsWith('.yaml') || lower.endsWith('.yml')) {
+    throw new Error(
+      `YAML environment files are not supported in Phase 1 — Node 20 has no `
+      + `built-in YAML parser and we keep zero runtime deps. Convert ${absolutePath} `
+      + `to JSON (same shape) and pass that instead.`,
+    );
+  }
+
+  const raw = await readFile(absolutePath, 'utf8');
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Failed to parse environment file ${absolutePath}: ${err.message}`);
+  }
+
+  const validation = validateEnvironmentSpec(parsed);
+  if (!validation.ok) {
+    throw new Error(
+      `Invalid environment spec in ${absolutePath}:\n  - ${validation.errors.join('\n  - ')}`,
+    );
+  }
+
+  // Return the bare spec — no envFileDir wrapping, no underscore-prefixed
+  // annotations. The caller is responsible for tracking envFileDir separately
+  // (compute via `dirname(envPath)`) and passing it explicitly to
+  // resolveWorkspace / linkSkills when relative paths in the spec need to
+  // resolve. This keeps the spec safe to serialize and ship to the backend
+  // (`config.environment` on AgentInstallation) without leaking $HOME layout.
+  return parsed;
+};
+
+// ── validateEnvironmentSpec ─────────────────────────────────────────────────
+
+export const validateEnvironmentSpec = (spec) => {
+  const errors = [];
+
+  if (!spec || typeof spec !== 'object' || Array.isArray(spec)) {
+    return { ok: false, errors: ['env spec must be a JSON object'] };
+  }
+
+  for (const key of Object.keys(spec)) {
+    if (!ALLOWED_TOP_KEYS.has(key)) {
+      errors.push(`unknown top-level key: "${key}" (allowed: ${[...ALLOWED_TOP_KEYS].join(', ')})`);
+    }
+  }
+
+  if (spec.version !== undefined && spec.version !== 1) {
+    errors.push(`version must be 1, got ${JSON.stringify(spec.version)}`);
+  }
+
+  if (spec.workspace !== undefined) {
+    if (typeof spec.workspace !== 'object' || spec.workspace === null) {
+      errors.push('workspace must be an object');
+    } else {
+      if (spec.workspace.path !== undefined && typeof spec.workspace.path !== 'string') {
+        errors.push('workspace.path must be a string');
+      }
+      if (spec.workspace.seed !== undefined) {
+        if (!Array.isArray(spec.workspace.seed)
+          || !spec.workspace.seed.every((s) => typeof s === 'string')) {
+          errors.push('workspace.seed must be an array of strings');
+        }
+      }
+    }
+  }
+
+  if (spec.sandbox !== undefined) {
+    if (typeof spec.sandbox !== 'object' || spec.sandbox === null) {
+      errors.push('sandbox must be an object');
+    } else {
+      const { mode, network, filesystem } = spec.sandbox;
+      if (mode !== undefined && !ALLOWED_SANDBOX_MODES.has(mode)) {
+        errors.push(`sandbox.mode must be one of: ${[...ALLOWED_SANDBOX_MODES].join(', ')}`);
+      }
+      if (network !== undefined) {
+        if (typeof network !== 'object' || network === null) {
+          errors.push('sandbox.network must be an object');
+        } else {
+          if (network.policy !== undefined && !ALLOWED_NETWORK_POLICIES.has(network.policy)) {
+            errors.push(`sandbox.network.policy must be one of: ${[...ALLOWED_NETWORK_POLICIES].join(', ')}`);
+          }
+          if (network['allow-hosts'] !== undefined
+            && (!Array.isArray(network['allow-hosts'])
+              || !network['allow-hosts'].every((h) => typeof h === 'string'))) {
+            errors.push('sandbox.network.allow-hosts must be an array of strings');
+          }
+        }
+      }
+      if (filesystem !== undefined) {
+        if (typeof filesystem !== 'object' || filesystem === null) {
+          errors.push('sandbox.filesystem must be an object');
+        } else {
+          for (const f of ['read-outside', 'write-outside']) {
+            if (filesystem[f] !== undefined
+              && (!Array.isArray(filesystem[f])
+                || !filesystem[f].every((p) => typeof p === 'string'))) {
+              errors.push(`sandbox.filesystem.${f} must be an array of strings`);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (spec.skills !== undefined) {
+    if (typeof spec.skills !== 'object' || spec.skills === null) {
+      errors.push('skills must be an object');
+    } else {
+      if (spec.skills.claude !== undefined
+        && (!Array.isArray(spec.skills.claude)
+          || !spec.skills.claude.every((p) => typeof p === 'string'))) {
+        errors.push('skills.claude must be an array of strings');
+      }
+      if (spec.skills.commonly !== undefined
+        && (!Array.isArray(spec.skills.commonly)
+          || !spec.skills.commonly.every((p) => typeof p === 'string'))) {
+        errors.push('skills.commonly must be an array of strings');
+      }
+    }
+  }
+
+  if (spec.mcp !== undefined) {
+    if (!Array.isArray(spec.mcp)) {
+      errors.push('mcp must be an array');
+    } else {
+      spec.mcp.forEach((server, i) => {
+        if (!server || typeof server !== 'object' || Array.isArray(server)) {
+          errors.push(`mcp[${i}] must be an object`);
+          return;
+        }
+        if (typeof server.name !== 'string' || !server.name) {
+          errors.push(`mcp[${i}].name is required and must be a non-empty string`);
+        }
+        if (server.transport !== undefined
+          && !['http', 'stdio', 'sse'].includes(server.transport)) {
+          errors.push(`mcp[${i}].transport must be one of: http, stdio, sse`);
+        }
+      });
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+};
+
+// ── resolveWorkspace ────────────────────────────────────────────────────────
+
+/**
+ * Compute the workspace path and ensure it exists. On first creation, copy
+ * any `workspace.seed` paths in. Returns `{ path, created }` so the caller
+ * can log the outcome and (in the future) gate one-time setup.
+ *
+ * `envFileDir` is the directory of the env file (used to resolve relative
+ * seed paths). Required when `workspace.seed` contains relative entries;
+ * ignored otherwise.
+ */
+export const resolveWorkspace = async (spec, agentName, envFileDir = null) => {
+  if (!agentName) throw new Error('resolveWorkspace requires agentName');
+  const declared = spec?.workspace?.path;
+  const path = expandHome(declared) || join(homedir(), '.commonly', 'workspaces', agentName);
+  const absPath = isAbsolute(path) ? path : pathResolve(path);
+
+  const created = !existsSync(absPath);
+  await mkdir(absPath, { recursive: true });
+
+  if (created && Array.isArray(spec?.workspace?.seed)) {
+    for (const entry of spec.workspace.seed) {
+      const src = isAbsolute(entry)
+        ? entry
+        : (envFileDir ? pathResolve(envFileDir, entry) : pathResolve(entry));
+      if (!existsSync(src)) {
+        throw new Error(`workspace.seed entry not found: ${src}`);
+      }
+      const dest = join(absPath, basename(src));
+      // eslint-disable-next-line no-await-in-loop
+      await cp(src, dest, { recursive: true, force: false, errorOnExist: false });
+    }
+  }
+
+  return { path: absPath, created };
+};
+
+// ── linkSkills ──────────────────────────────────────────────────────────────
+
+/**
+ * Symlink each `skills.claude[]` source path into `<workspacePath>/.claude/skills/`.
+ *
+ * Idempotent: if a symlink already points at the declared source, it is
+ * counted in `skipped` and left in place. If a DIFFERENT file or symlink
+ * occupies the slot, it is recorded in `conflicted` with a reason — never
+ * overwritten (a user-edited skill in the workspace must not be clobbered).
+ * Missing source paths are also reported in `conflicted` so the caller can
+ * surface them.
+ *
+ * `envFileDir` is the directory of the env file (used to resolve relative
+ * skill paths). Optional — when omitted, relative paths fall back to
+ * `workspacePath`. Pass it from `performAttach` for attach-time resolution
+ * matching the env file's location.
+ *
+ * Returns `{ linked, skipped, conflicted }`:
+ *   - `linked`:     string[]            — newly created symlinks (absolute source paths)
+ *   - `skipped`:    string[]            — already correctly linked (no-op)
+ *   - `conflicted`: Array<{path, reason}> where reason ∈
+ *       'different-target' | 'not-symlink' | 'missing-source'
+ */
+export const linkSkills = async (spec, workspacePath, envFileDir = null) => {
+  const sources = Array.isArray(spec?.skills?.claude) ? spec.skills.claude : [];
+  const linked = [];
+  const skipped = [];
+  const conflicted = [];
+  if (sources.length === 0) return { linked, skipped, conflicted };
+
+  const skillsDir = join(workspacePath, '.claude', 'skills');
+  await mkdir(skillsDir, { recursive: true });
+
+  for (const rawSource of sources) {
+    const source = expandHome(rawSource);
+    const absSource = isAbsolute(source)
+      ? source
+      : pathResolve(envFileDir || workspacePath, source);
+    if (!existsSync(absSource)) {
+      conflicted.push({ path: absSource, reason: 'missing-source' });
+      continue;
+    }
+    const linkPath = join(skillsDir, basename(absSource));
+
+    let existingTarget = null;
+    let slotIsNonSymlink = false;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const stat = await lstat(linkPath);
+      if (stat.isSymbolicLink()) {
+        // eslint-disable-next-line no-await-in-loop
+        existingTarget = await readlink(linkPath);
+      } else {
+        slotIsNonSymlink = true;
+      }
+    } catch (err) {
+      // Only ENOENT means "slot is free, proceed." EACCES / EPERM / EIO are
+      // real failures that should surface — without this narrowing the
+      // subsequent symlink() call fails with a confusing follow-on error.
+      if (err.code !== 'ENOENT') throw err;
+    }
+
+    if (slotIsNonSymlink) {
+      conflicted.push({ path: absSource, reason: 'not-symlink' });
+      continue;
+    }
+
+    if (existingTarget) {
+      const resolvedExisting = isAbsolute(existingTarget)
+        ? existingTarget
+        : pathResolve(skillsDir, existingTarget);
+      if (resolvedExisting === absSource) {
+        skipped.push(absSource);
+        continue;
+      }
+      conflicted.push({ path: absSource, reason: 'different-target' });
+      continue;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    await symlink(absSource, linkPath);
+    linked.push(absSource);
+  }
+
+  return { linked, skipped, conflicted };
+};

--- a/cli/src/lib/sandbox/bwrap.js
+++ b/cli/src/lib/sandbox/bwrap.js
@@ -1,0 +1,112 @@
+/**
+ * bubblewrap sandbox adapter — ADR-008 Phase 1.
+ *
+ * Wraps an inner adapter argv (e.g. claude -p ...) in a bwrap invocation that
+ * pins the spawn into a workspace, isolates the network namespace, and
+ * read-only-binds a small allowlist of host paths the adapter needs to start
+ * (TLS certs, libc, the binary itself).
+ *
+ * Linux-only by design: bwrap is a setuid Linux helper. macOS callers get a
+ * loud, specific error at attach time so the failure shape never reaches run.
+ *
+ * Detection idiom mirrors `claude.js#detect`: spawnSync with --version, treat
+ * non-zero or spawn error as "not available."
+ */
+
+import { spawnSync } from 'child_process';
+import { isAbsolute } from 'path';
+
+const MACOS_MESSAGE = 'bwrap is Linux-only; use sandbox.mode: none in Phase 1 or wait for sandbox-exec adapter';
+
+const DEFAULT_RO_BINDS = [
+  '/etc/ssl/certs',
+  '/etc/resolv.conf',
+  '/usr/lib',
+  '/usr/lib64',
+  '/usr/bin',
+  '/bin',
+  '/lib',
+  '/lib64',
+];
+
+export const detectBwrap = () => {
+  if (process.platform !== 'linux') {
+    return { available: false, error: MACOS_MESSAGE };
+  }
+  try {
+    const res = spawnSync('bwrap', ['--version'], { encoding: 'utf8' });
+    if (res.error || res.status !== 0) {
+      return {
+        available: false,
+        error: 'bwrap not found on PATH. Install bubblewrap: `apt install bubblewrap` (Debian/Ubuntu) or `dnf install bubblewrap` (Fedora).',
+      };
+    }
+    return { available: true, path: 'bwrap' };
+  } catch (err) {
+    return { available: false, error: `bwrap detection failed: ${err.message}` };
+  }
+};
+
+/**
+ * Build the bwrap-wrapped argv. Caller spawns argv[0] with argv.slice(1).
+ *
+ * Network policy honesty (ADR-008 §invariant #4 informs this):
+ *   - unrestricted → --share-net (host networking inside the namespace)
+ *   - restricted   → --unshare-net (NO network at all). Host-allowlist
+ *     filtering needs an outbound proxy or per-host TLS interception, neither
+ *     of which is in Phase 1 scope. Attach-time emits a loud warning so the
+ *     user sees the gap before they think they're protected.
+ *
+ * The expansion order matches `bwrap`'s left-to-right argument application:
+ * isolation flags first, then binds (later binds win on collision), then
+ * --setenv, then `--` and the inner argv.
+ */
+export const wrapArgvWithBwrap = (innerArgv, env, opts = {}) => {
+  if (process.platform !== 'linux') {
+    throw new Error(MACOS_MESSAGE);
+  }
+  if (!Array.isArray(innerArgv) || innerArgv.length === 0) {
+    throw new Error('wrapArgvWithBwrap requires a non-empty innerArgv');
+  }
+  if (!opts.workspacePath || !isAbsolute(opts.workspacePath)) {
+    throw new Error('wrapArgvWithBwrap requires opts.workspacePath as an absolute path');
+  }
+
+  const policy = env?.sandbox?.network?.policy || 'unrestricted';
+  const networkFlags = policy === 'restricted'
+    ? ['--unshare-net']
+    : ['--share-net'];
+
+  const flags = [
+    '--unshare-all',
+    ...networkFlags,
+    '--die-with-parent',
+    '--new-session',
+    '--proc', '/proc',
+    '--dev', '/dev',
+    '--tmpfs', '/tmp',
+  ];
+
+  const userReadOutside = Array.isArray(env?.sandbox?.filesystem?.['read-outside'])
+    ? env.sandbox.filesystem['read-outside']
+    : [];
+  const roBinds = [...new Set([...DEFAULT_RO_BINDS, ...userReadOutside])];
+  for (const p of roBinds) {
+    flags.push('--ro-bind-try', p, p);
+  }
+
+  const userWriteOutside = Array.isArray(env?.sandbox?.filesystem?.['write-outside'])
+    ? env.sandbox.filesystem['write-outside']
+    : [];
+  for (const p of userWriteOutside) {
+    flags.push('--bind-try', p, p);
+  }
+
+  flags.push('--bind', opts.workspacePath, opts.workspacePath);
+  flags.push('--chdir', opts.workspacePath);
+  flags.push('--setenv', 'HOME', opts.workspacePath);
+
+  return ['bwrap', ...flags, '--', ...innerArgv];
+};
+
+export const BWRAP_MACOS_MESSAGE = MACOS_MESSAGE;


### PR DESCRIPTION
## Summary
- Adds `--env <path>` to `commonly agent attach`. Parses a declarative `environment.json` controlling **workspace**, **bwrap sandbox** (Linux), **Claude skills** symlinking, and **MCP server** wiring for the claude adapter.
- New: `cli/src/lib/environment.js`, `cli/src/lib/sandbox/bwrap.js`. Modified: `claude.js` adapter, `agent.js` commands.
- Other adapters (codex/cursor/gemini) inherit env support in Phase 2.
- `bwrap` `network.policy=restricted` degrades to `--unshare-net` (no network) with a loud attach-time warning that host allowlist is advisory until `sandbox.mode=container` lands in Phase 2.
- `linkSkills` returns structured `{linked, skipped, conflicted}` so callers can surface `different-target` / `not-symlink` / `missing-source` instead of silently dropping.
- `parseEnvironmentFile` returns the bare spec — env file directory tracked separately by the caller so it doesn't leak to the backend on install.

Companion track to #PR-B (CAP MCP tools), #PR-C (cross-agent backend), #PR-D (demo quickstart).

Spec: `docs/adr/ADR-008-agent-environment-primitive.md` (#210).

## Test plan
- [x] `cd cli && npm test` — 109 passed, 2 skipped (Linux-only paths)
- [x] Self-review against `docs/REVIEW.md` — applied 4 fixes (envFileDir leak, structured linkSkills return, EACCES catch, regen-per-spawn comment)
- [x] Independent code review — approved with non-blocking notes
- [x] Integration smoke: built into `integration/demo-readiness-2026-04-17`, deployed to `commonly-dev`, no regressions
- [ ] Live record: pending Linux machine with `claude` + `bwrap` + the demo flow in #PR-D

🤖 Generated with [Claude Code](https://claude.com/claude-code)