### PR TITLE
feat(mcp): ADR-007 Phase 2 — expose CAP verbs as MCP tools

### DIFF
--- a/docs/adr/ADR-007-ecosystem-integration-strategy.md
+++ b/docs/adr/ADR-007-ecosystem-integration-strategy.md
@@ -157,9 +157,9 @@ An MCP server that exposes CAP verbs as MCP tools. Any agent framework that cons
 |---|---|---|
 | `commonly_poll_events` | poll | Fetch pending events |
 | `commonly_ack_event` | ack | Mark event processed |
-| `commonly_post_message` | post | Post content into a pod |
-| `commonly_get_memory` | memory (read) | Read agent's memory envelope |
-| `commonly_sync_memory` | memory (write) | Sync memory sections |
+| `commonly_post_message_cap` | post | Post content into a pod (agent-token auth — distinct from existing user-auth `commonly_post_message`) |
+| `commonly_memory_sync` | memory (write) | Sync memory sections (idempotent, supports `mode: full|patch`) |
+| *(no separate read tool)* | memory (read) | Reads happen via the resources/list + resources/read MCP surface, gated to user-auth mode |
 
 **Why MCP, not just webhook SDK:**
 - MCP is the *lingua franca* of agent tool consumption. Both major SDKs consume it natively.

--- a/packages/commonly-mcp/README.md
+++ b/packages/commonly-mcp/README.md
@@ -136,13 +136,72 @@ The server also exposes pod memory files as MCP resources:
 - `commonly://<podId>/CONTEXT.md` - Pod purpose and configuration
 - `commonly://<podId>/memory/<date>.md` - Daily activity logs
 
+## CAP verbs (agent mode)
+
+In addition to the user-space tools above, the server can expose the four
+**Commonly Agent Protocol (CAP)** verbs (per [ADR-004](../../docs/adr/ADR-004-commonly-agent-protocol.md))
+when started with an agent runtime token. This makes any MCP-enabled client
+act as a real Commonly agent — polling for events, posting messages under an
+agent identity, syncing memory.
+
+User mode and agent mode are independent:
+
+- **User token only** (`COMMONLY_USER_TOKEN`): the original 7 tools work, CAP tools throw a clear "agent token not configured" error.
+- **Agent token only** (`COMMONLY_AGENT_TOKEN`): the 4 CAP tools work, user-space tools throw "user token not configured."
+- **Both set**: all 11 tools available; pick whichever fits the action.
+
+### Configure agent mode
+
+```bash
+COMMONLY_AGENT_TOKEN=cm_agent_xxx commonly-mcp
+```
+
+Or in Claude Desktop / moltbot config, add `COMMONLY_AGENT_TOKEN` to the
+server's `env` block. Get a runtime token by installing your agent in a pod
+and calling `POST /api/registry/pods/:podId/agents/:agentName/runtime-tokens`
+(see [ADR-004 §Install + token lifecycle](../../docs/adr/ADR-004-commonly-agent-protocol.md)).
+
+### CAP tools
+
+| Tool | CAP verb | Description |
+|------|----------|-------------|
+| `commonly_poll_events` | poll | Fetch pending events for this agent |
+| `commonly_ack_event` | ack | Mark an event as processed |
+| `commonly_post_message_cap` | post | Post a message AS the agent (distinct from `commonly_post_message`, which posts as the user) |
+| `commonly_memory_sync` | memory | Promote sections of agent memory into the kernel envelope |
+
+### End-to-end snippet
+
+A typical CAP loop, as the agent would express it through MCP tool calls:
+
+```
+> commonly_poll_events()
+{ "events": [
+    { "id": "evt_42", "type": "mention.received",
+      "payload": { "podId": "pod_abc", "messageId": "msg_99", "text": "@bot ping?" } }
+] }
+
+> commonly_post_message_cap({ "podId": "pod_abc", "content": "pong",
+                              "replyToMessageId": "msg_99" })
+{ "messageId": "msg_100", "podId": "pod_abc",
+  "createdAt": "2026-04-16T10:00:00.000Z" }
+
+> commonly_ack_event({ "eventId": "evt_42" })
+{ "ok": true }
+```
+
+Per ADR-004, events deliver **at-least-once** — call `commonly_ack_event`
+only AFTER your handler succeeds, otherwise the event will re-deliver and
+you'll have lost the work without a retry.
+
 ## Environment Variables
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `COMMONLY_USER_TOKEN` | Yes | - | Commonly user token (`cm_*`) |
-| `OPENCLAW_USER_TOKEN` | No | - | OpenClaw user token alias (falls back if set) |
-| `COMMONLY_API_TOKEN` | No | - | Legacy token name (deprecated) |
+| `COMMONLY_USER_TOKEN` | One of these two | - | User token (`cm_*`) — enables user-space tools |
+| `COMMONLY_AGENT_TOKEN` | One of these two | - | Agent runtime token (`cm_agent_*`) — enables CAP verbs |
+| `OPENCLAW_USER_TOKEN` | No | - | Alias for `COMMONLY_USER_TOKEN` |
+| `COMMONLY_API_TOKEN` | No | - | Legacy alias for `COMMONLY_USER_TOKEN` (deprecated) |
 | `COMMONLY_API_URL` | No | `https://api.commonly.app` | API base URL |
 | `COMMONLY_DEFAULT_POD` | No | - | Default pod for tools |
 | `COMMONLY_DEBUG` | No | `false` | Enable debug logging |

--- a/packages/commonly-mcp/src/__tests__/cap-tools.test.ts
+++ b/packages/commonly-mcp/src/__tests__/cap-tools.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleToolCall } from "../tools/index.js";
+import { CommonlyClient, MCPClientError } from "../client.js";
+import type { Config } from "../index.js";
+
+/**
+ * CAP-tool tests (ADR-007 Phase 2).
+ *
+ * Mock pattern matches existing tools.test.ts: hand handleToolCall a stub
+ * client object that has just the methods the tool will call. Each test
+ * touches one tool so failures point straight at the broken tool.
+ */
+
+const baseConfig = (overrides: Partial<Config> = {}): Config => ({
+  apiUrl: "https://api.commonly.app",
+  agentToken: "cm_agent_test",
+  debug: false,
+  ...overrides,
+});
+
+describe("commonly_poll_events", () => {
+  it("returns events from the client", async () => {
+    const client = {
+      pollEvents: vi
+        .fn()
+        .mockResolvedValue({ events: [{ id: "evt_1", type: "mention.received" }] }),
+    } as unknown as CommonlyClient;
+
+    const result = await handleToolCall(
+      client,
+      "commonly_poll_events",
+      { limit: 10 },
+      baseConfig()
+    );
+
+    expect(client.pollEvents).toHaveBeenCalledWith({ since: undefined, limit: 10 });
+    expect(result).toEqual({ events: [{ id: "evt_1", type: "mention.received" }] });
+  });
+
+  it("returns {events: []} on empty queue (not an error)", async () => {
+    const client = {
+      pollEvents: vi.fn().mockResolvedValue({ events: [] }),
+    } as unknown as CommonlyClient;
+
+    const result = await handleToolCall(
+      client,
+      "commonly_poll_events",
+      {},
+      baseConfig()
+    );
+
+    expect(result).toEqual({ events: [] });
+  });
+
+  it("propagates 4xx errors from backend", async () => {
+    const client = {
+      pollEvents: vi
+        .fn()
+        .mockRejectedValue(new Error("Commonly CAP Error (401): unauthorized")),
+    } as unknown as CommonlyClient;
+
+    await expect(
+      handleToolCall(client, "commonly_poll_events", {}, baseConfig())
+    ).rejects.toThrow(/401/);
+  });
+
+  it("surfaces missing-agent-token error from client", async () => {
+    // A real client without an agent token throws MCPClientError on call.
+    const client = {
+      pollEvents: vi
+        .fn()
+        .mockRejectedValue(
+          new MCPClientError(
+            "agent token not configured; set COMMONLY_AGENT_TOKEN to use CAP verbs"
+          )
+        ),
+    } as unknown as CommonlyClient;
+
+    await expect(
+      handleToolCall(client, "commonly_poll_events", {}, baseConfig())
+    ).rejects.toThrow(/agent token not configured/);
+  });
+});
+
+describe("commonly_ack_event", () => {
+  it("calls ackEvent with the eventId", async () => {
+    const client = {
+      ackEvent: vi.fn().mockResolvedValue({ success: true }),
+    } as unknown as CommonlyClient;
+
+    const result = await handleToolCall(
+      client,
+      "commonly_ack_event",
+      { eventId: "evt_123" },
+      baseConfig()
+    );
+
+    expect(client.ackEvent).toHaveBeenCalledWith("evt_123");
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects when eventId is missing", async () => {
+    const client = { ackEvent: vi.fn() } as unknown as CommonlyClient;
+    await expect(
+      handleToolCall(client, "commonly_ack_event", {}, baseConfig())
+    ).rejects.toThrow(/eventId/);
+    expect(client.ackEvent).not.toHaveBeenCalled();
+  });
+
+  it("propagates 4xx from backend", async () => {
+    const client = {
+      ackEvent: vi
+        .fn()
+        .mockRejectedValue(new Error("Commonly CAP Error (404): event not found")),
+    } as unknown as CommonlyClient;
+    await expect(
+      handleToolCall(client, "commonly_ack_event", { eventId: "x" }, baseConfig())
+    ).rejects.toThrow(/404/);
+  });
+});
+
+describe("commonly_post_message_cap", () => {
+  it("posts via CAP and returns normalized shape", async () => {
+    const client = {
+      postMessageCAP: vi.fn().mockResolvedValue({
+        success: true,
+        message: {
+          _id: "msg_42",
+          podId: "pod_xyz",
+          createdAt: "2026-04-16T10:00:00.000Z",
+        },
+      }),
+    } as unknown as CommonlyClient;
+
+    const result = await handleToolCall(
+      client,
+      "commonly_post_message_cap",
+      { podId: "pod_xyz", content: "hello pod" },
+      baseConfig()
+    );
+
+    expect(client.postMessageCAP).toHaveBeenCalledWith("pod_xyz", {
+      content: "hello pod",
+      replyToMessageId: undefined,
+      messageType: undefined,
+      metadata: undefined,
+    });
+    expect(result).toEqual({
+      messageId: "msg_42",
+      podId: "pod_xyz",
+      createdAt: "2026-04-16T10:00:00.000Z",
+    });
+  });
+
+  it("falls back to defaultPodId when podId omitted", async () => {
+    const client = {
+      postMessageCAP: vi.fn().mockResolvedValue({ success: true, message: {} }),
+    } as unknown as CommonlyClient;
+
+    await handleToolCall(
+      client,
+      "commonly_post_message_cap",
+      { content: "hi" },
+      baseConfig({ defaultPodId: "pod_default" })
+    );
+
+    expect(client.postMessageCAP).toHaveBeenCalledWith("pod_default", expect.any(Object));
+  });
+
+  it("rejects when content missing", async () => {
+    const client = { postMessageCAP: vi.fn() } as unknown as CommonlyClient;
+    await expect(
+      handleToolCall(
+        client,
+        "commonly_post_message_cap",
+        { podId: "pod_xyz" },
+        baseConfig()
+      )
+    ).rejects.toThrow(/content/);
+    expect(client.postMessageCAP).not.toHaveBeenCalled();
+  });
+
+  it("rejects when no podId resolvable", async () => {
+    const client = { postMessageCAP: vi.fn() } as unknown as CommonlyClient;
+    await expect(
+      handleToolCall(
+        client,
+        "commonly_post_message_cap",
+        { content: "hi" },
+        baseConfig()
+      )
+    ).rejects.toThrow(/podId/);
+  });
+
+  it("propagates 4xx from backend", async () => {
+    const client = {
+      postMessageCAP: vi
+        .fn()
+        .mockRejectedValue(new Error("Commonly CAP Error (403): not in pod")),
+    } as unknown as CommonlyClient;
+    await expect(
+      handleToolCall(
+        client,
+        "commonly_post_message_cap",
+        { podId: "pod_xyz", content: "hi" },
+        baseConfig()
+      )
+    ).rejects.toThrow(/403/);
+  });
+});
+
+describe("commonly_memory_sync", () => {
+  it("calls syncMemory with sections+mode", async () => {
+    const client = {
+      syncMemory: vi.fn().mockResolvedValue({ ok: true, schemaVersion: 2 }),
+    } as unknown as CommonlyClient;
+
+    const result = await handleToolCall(
+      client,
+      "commonly_memory_sync",
+      {
+        sections: { soul: { content: "x" } },
+        mode: "patch",
+        sourceRuntime: "mcp-client",
+      },
+      baseConfig()
+    );
+
+    expect(client.syncMemory).toHaveBeenCalledWith({
+      sections: { soul: { content: "x" } },
+      mode: "patch",
+      sourceRuntime: "mcp-client",
+    });
+    expect(result).toEqual({
+      updated: true,
+      deduped: undefined,
+      byteSize: undefined,
+      schemaVersion: 2,
+    });
+  });
+
+  it("passes through deduped=true and reports updated=false", async () => {
+    const client = {
+      syncMemory: vi.fn().mockResolvedValue({ ok: true, deduped: true }),
+    } as unknown as CommonlyClient;
+
+    const result = await handleToolCall(
+      client,
+      "commonly_memory_sync",
+      { sections: {}, mode: "full" },
+      baseConfig()
+    );
+
+    expect(result).toMatchObject({ updated: false, deduped: true });
+  });
+
+  it("rejects invalid mode", async () => {
+    const client = { syncMemory: vi.fn() } as unknown as CommonlyClient;
+    await expect(
+      handleToolCall(
+        client,
+        "commonly_memory_sync",
+        { sections: {}, mode: "weird" },
+        baseConfig()
+      )
+    ).rejects.toThrow(/mode must be/);
+    expect(client.syncMemory).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing sections", async () => {
+    const client = { syncMemory: vi.fn() } as unknown as CommonlyClient;
+    await expect(
+      handleToolCall(
+        client,
+        "commonly_memory_sync",
+        { mode: "full" },
+        baseConfig()
+      )
+    ).rejects.toThrow(/sections/);
+  });
+
+  it("propagates 4xx from backend", async () => {
+    const client = {
+      syncMemory: vi
+        .fn()
+        .mockRejectedValue(new Error("Commonly CAP Error (400): bad sections")),
+    } as unknown as CommonlyClient;
+    await expect(
+      handleToolCall(
+        client,
+        "commonly_memory_sync",
+        { sections: {}, mode: "full" },
+        baseConfig()
+      )
+    ).rejects.toThrow(/400/);
+  });
+});

--- a/packages/commonly-mcp/src/__tests__/client-cap.test.ts
+++ b/packages/commonly-mcp/src/__tests__/client-cap.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { CommonlyClient, MCPClientError } from "../client.js";
+
+/**
+ * Client-level CAP tests. Focus: which axios instance is used for which call,
+ * what URL prefix gets applied, what header sets the bearer token, and the
+ * shape of the error when an auth mode isn't configured.
+ *
+ * We mock axios.create to capture the per-instance config (so we can assert
+ * the Authorization header) and stub the per-instance .request/.get/.post.
+ */
+
+type MockAxios = {
+  request: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  interceptors: { response: { use: ReturnType<typeof vi.fn> } };
+  // expose the create-time config so tests can read which token was set
+  _config: Record<string, unknown>;
+};
+
+const createdInstances: MockAxios[] = [];
+
+vi.mock("axios", () => {
+  const create = vi.fn((config: Record<string, unknown>) => {
+    const inst: MockAxios = {
+      request: vi.fn().mockResolvedValue({ data: { events: [] } }),
+      get: vi.fn().mockResolvedValue({ data: {} }),
+      post: vi.fn().mockResolvedValue({ data: {} }),
+      put: vi.fn().mockResolvedValue({ data: {} }),
+      interceptors: { response: { use: vi.fn() } },
+      _config: config,
+    };
+    createdInstances.push(inst);
+    return inst;
+  });
+  return {
+    default: { create },
+    create,
+  };
+});
+
+beforeEach(() => {
+  createdInstances.length = 0;
+});
+
+describe("CommonlyClient construction", () => {
+  it("creates only the user axios instance when only userToken is set", () => {
+    const client = new CommonlyClient({
+      apiUrl: "https://api.commonly.app",
+      userToken: "cm_user_x",
+    });
+    expect(createdInstances).toHaveLength(1);
+    expect(client.hasUserAuth()).toBe(true);
+    expect(client.hasAgentAuth()).toBe(false);
+    const headers = (createdInstances[0]._config.headers as Record<string, string>);
+    expect(headers.Authorization).toBe("Bearer cm_user_x");
+  });
+
+  it("creates only the agent axios instance when only agentToken is set", () => {
+    const client = new CommonlyClient({
+      apiUrl: "https://api.commonly.app",
+      agentToken: "cm_agent_x",
+    });
+    expect(createdInstances).toHaveLength(1);
+    expect(client.hasUserAuth()).toBe(false);
+    expect(client.hasAgentAuth()).toBe(true);
+    const headers = (createdInstances[0]._config.headers as Record<string, string>);
+    expect(headers.Authorization).toBe("Bearer cm_agent_x");
+  });
+
+  it("creates both instances with separate tokens when both are set", () => {
+    new CommonlyClient({
+      apiUrl: "https://api.commonly.app",
+      userToken: "cm_user_x",
+      agentToken: "cm_agent_x",
+    });
+    expect(createdInstances).toHaveLength(2);
+    const tokens = createdInstances.map(
+      (i) => (i._config.headers as Record<string, string>).Authorization
+    );
+    expect(tokens).toContain("Bearer cm_user_x");
+    expect(tokens).toContain("Bearer cm_agent_x");
+  });
+
+  it("throws MCPClientError when neither token is provided", () => {
+    expect(
+      () =>
+        new CommonlyClient({
+          apiUrl: "https://api.commonly.app",
+        })
+    ).toThrow(MCPClientError);
+  });
+});
+
+describe("CommonlyClient CAP methods — URL construction", () => {
+  it("pollEvents hits /api/agents/runtime/events with limit param", async () => {
+    const client = new CommonlyClient({
+      apiUrl: "https://api.commonly.app",
+      agentToken: "cm_agent_x",
+    });
+    const agentInst = createdInstances[0];
+    agentInst.request.mockResolvedValueOnce({ data: { events: [] } });
+
+    await client.pollEvents({ limit: 5 });
+
+    expect(agentInst.request).toHaveBeenCalledWith({
+      method: "get",
+      url: "/api/agents/runtime/events",
+      data: undefined,
+      params: { limit: 5 },
+    });
+  });
+
+  it("pollEvents drops undefined params (no `since=undefined` in query)", async () => {
+    const client = new CommonlyClient({
+      apiUrl: "https://api.commonly.app",
+      agentToken: "cm_agent_x",
+    });
+    const agentInst = createdInstances[0];
+    agentInst.request.mockResolvedValueOnce({ data: { events: [] } });
+
+    await client.pollEvents({});
+
+    const call = agentInst.request.mock.calls[0][0];
+    expect(call.params).toEqual({});
+  });
+
+  it("ackEvent URL-encodes the event id", async () => {
+    const client = new CommonlyClient({
+      apiUrl: "https://api.commonly.app",
+      agentToken: "cm_agent_x",
+    });
+    const agentInst = createdInstances[0];
+    agentInst.request.mockResolvedValueOnce({ data: { success: true } });
+
+    await client.ackEvent("evt/with slash");
+
+    expect(agentInst.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "post",
+        url: "/api/agents/runtime/events/evt%2Fwith%20slash/ack",
+      })
+    );
+  });
+
+  it("postMessageCAP posts to /api/agents/runtime/pods/:podId/messages with full body", async () => {
+    const client = new CommonlyClient({
+      apiUrl: "https://api.commonly.app",
+      agentToken: "cm_agent_x",
+    });
+    const agentInst = createdInstances[0];
+    agentInst.request.mockResolvedValueOnce({ data: { success: true, message: {} } });
+
+    await client.postMessageCAP("pod_xyz", {
+      content: "hi",
+      replyToMessageId: "msg_1",
+      messageType: "text",
+      metadata: { kind: "install-intro" },
+    });
+
+    expect(agentInst.request).toHaveBeenCalledWith({
+      method: "post",
+      url: "/api/agents/runtime/pods/pod_xyz/messages",
+      data: {
+        content: "hi",
+        replyToMessageId: "msg_1",
+        messageType: "text",
+        metadata: { kind: "install-intro" },
+      },
+      params: undefined,
+    });
+  });
+
+  it("readMemory hits /api/agents/runtime/memory", async () => {
+    const client = new CommonlyClient({
+      apiUrl: "https://api.commonly.app",
+      agentToken: "cm_agent_x",
+    });
+    const agentInst = createdInstances[0];
+    agentInst.request.mockResolvedValueOnce({ data: { content: "" } });
+
+    await client.readMemory();
+
+    expect(agentInst.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "get",
+        url: "/api/agents/runtime/memory",
+      })
+    );
+  });
+
+  it("syncMemory posts /api/agents/runtime/memory/sync with mode + sections", async () => {
+    const client = new CommonlyClient({
+      apiUrl: "https://api.commonly.app",
+      agentToken: "cm_agent_x",
+    });
+    const agentInst = createdInstances[0];
+    agentInst.request.mockResolvedValueOnce({ data: { ok: true } });
+
+    await client.syncMemory({
+      sections: { soul: { content: "x" } },
+      mode: "patch",
+      sourceRuntime: "mcp-client",
+    });
+
+    expect(agentInst.request).toHaveBeenCalledWith({
+      method: "post",
+      url: "/api/agents/runtime/memory/sync",
+      data: {
+        sections: { soul: { content: "x" } },
+        mode: "patch",
+        sourceRuntime: "mcp-client",
+      },
+      params: undefined,
+    });
+  });
+
+  it("CAP method throws MCPClientError when only userToken configured", async () => {
+    const client = new CommonlyClient({
+      apiUrl: "https://api.commonly.app",
+      userToken: "cm_user_x",
+    });
+
+    await expect(client.pollEvents()).rejects.toThrow(MCPClientError);
+    await expect(client.pollEvents()).rejects.toThrow(/agent token not configured/);
+  });
+
+  it("user-space method throws MCPClientError when only agentToken configured", async () => {
+    const client = new CommonlyClient({
+      apiUrl: "https://api.commonly.app",
+      agentToken: "cm_agent_x",
+    });
+
+    await expect(client.listPods()).rejects.toThrow(MCPClientError);
+    await expect(client.listPods()).rejects.toThrow(/user token not configured/);
+  });
+
+  it("syncMemory rejects invalid mode locally (no HTTP call)", async () => {
+    const client = new CommonlyClient({
+      apiUrl: "https://api.commonly.app",
+      agentToken: "cm_agent_x",
+    });
+    const agentInst = createdInstances[0];
+
+    await expect(
+      // intentionally bad mode
+      client.syncMemory({ sections: {}, mode: "weird" as unknown as "full" })
+    ).rejects.toThrow(/mode must be/);
+    expect(agentInst.request).not.toHaveBeenCalled();
+  });
+});

--- a/packages/commonly-mcp/src/cli.ts
+++ b/packages/commonly-mcp/src/cli.ts
@@ -2,44 +2,71 @@
 /**
  * CLI entry point for commonly-mcp server
  *
+ * Two auth modes (either or both — at least one required):
+ *
+ *   COMMONLY_USER_TOKEN=cm_...        # /api/v1/* user-space tools
+ *   COMMONLY_AGENT_TOKEN=cm_agent_... # /api/agents/runtime/* CAP verbs (ADR-004)
+ *
  * Usage:
- *   COMMONLY_USER_TOKEN=... commonly-mcp
- *   COMMONLY_USER_TOKEN=... commonly-mcp --debug
+ *   COMMONLY_USER_TOKEN=...  commonly-mcp
+ *   COMMONLY_AGENT_TOKEN=... commonly-mcp
+ *   COMMONLY_USER_TOKEN=... COMMONLY_AGENT_TOKEN=... commonly-mcp --debug
  *   COMMONLY_USER_TOKEN=... COMMONLY_API_URL=http://localhost:5000 commonly-mcp
  */
 
 import { CommonlyMCPServer } from "./index.js";
 
+function printUsage(): void {
+  console.error("");
+  console.error("Usage:");
+  console.error("  COMMONLY_USER_TOKEN=cm_... commonly-mcp           # user-space tools only");
+  console.error("  COMMONLY_AGENT_TOKEN=cm_agent_... commonly-mcp    # CAP verbs only (agent mode)");
+  console.error("  COMMONLY_USER_TOKEN=... COMMONLY_AGENT_TOKEN=... commonly-mcp  # both");
+  console.error("");
+  console.error("Auth modes (at least one required):");
+  console.error("  COMMONLY_USER_TOKEN   - user token (cm_*)        — context, search, write, etc.");
+  console.error("  COMMONLY_AGENT_TOKEN  - agent runtime token (cm_agent_*) — CAP verbs (poll/ack/post/memory)");
+  console.error("");
+  console.error("Optional environment variables:");
+  console.error("  COMMONLY_API_URL      - API base URL (default: https://api.commonly.app)");
+  console.error("  COMMONLY_DEFAULT_POD  - Default pod ID for tools");
+  console.error("  COMMONLY_DEBUG        - Enable debug logging (true/false)");
+  console.error("  OPENCLAW_USER_TOKEN   - Alias for COMMONLY_USER_TOKEN");
+  console.error("  COMMONLY_API_TOKEN    - Legacy token name (deprecated)");
+}
+
 async function main() {
   // Parse environment and args
   const apiUrl = process.env.COMMONLY_API_URL || "https://api.commonly.app";
-  const apiToken =
+  const userToken =
     process.env.COMMONLY_USER_TOKEN ||
     process.env.OPENCLAW_USER_TOKEN ||
     process.env.COMMONLY_API_TOKEN;
+  const agentToken = process.env.COMMONLY_AGENT_TOKEN;
   const defaultPodId = process.env.COMMONLY_DEFAULT_POD;
   const debug = process.argv.includes("--debug") || process.env.COMMONLY_DEBUG === "true";
 
-  if (!apiToken) {
+  if (!userToken && !agentToken) {
     console.error(
-      "Error: COMMONLY_USER_TOKEN (or OPENCLAW_USER_TOKEN) environment variable is required",
+      "Error: at least one of COMMONLY_USER_TOKEN or COMMONLY_AGENT_TOKEN must be set"
     );
-    console.error("");
-    console.error("Usage:");
-    console.error("  COMMONLY_USER_TOKEN=your-token commonly-mcp");
-    console.error("");
-    console.error("Optional environment variables:");
-    console.error("  COMMONLY_API_URL      - API base URL (default: https://api.commonly.app)");
-    console.error("  COMMONLY_DEFAULT_POD  - Default pod ID for tools");
-    console.error("  COMMONLY_DEBUG        - Enable debug logging (true/false)");
-    console.error("  COMMONLY_API_TOKEN    - Legacy token name (deprecated)");
+    printUsage();
     process.exit(1);
   }
+
+  // Surface which modes are active so misconfigured clients are obvious in
+  // logs. stderr only — stdout is the MCP transport channel.
+  console.error(
+    `[commonly-mcp] auth modes — user-token: ${userToken ? "yes" : "no"}, agent-token: ${
+      agentToken ? "yes" : "no"
+    }`
+  );
 
   try {
     const server = new CommonlyMCPServer({
       apiUrl,
-      apiToken,
+      userToken,
+      agentToken,
       defaultPodId,
       debug,
     });

--- a/packages/commonly-mcp/src/client.ts
+++ b/packages/commonly-mcp/src/client.ts
@@ -2,14 +2,119 @@
  * Commonly API Client
  *
  * HTTP client for communicating with the Commonly Context API.
+ *
+ * Two auth modes are supported in parallel:
+ *
+ * - **User token** (`cm_*`) — used for the `/api/v1/*` user-space surface
+ *   (pods, search, context, memory files, write, post-message). This is what
+ *   end-users carry from their account settings.
+ * - **Agent token** (`cm_agent_*`) — used for the `/api/agents/runtime/*`
+ *   CAP surface (poll, ack, post, memory; per ADR-004). Issued per
+ *   installation; lets the MCP client act AS a Commonly agent.
+ *
+ * The two surfaces are intentionally kept on separate code paths. They are
+ * different kernels (user-space vs agent-runtime), with different auth, error
+ * shapes, and lifecycle. Folding them together would hide bugs.
  */
 
 import axios, { AxiosInstance, AxiosError } from "axios";
 
 export interface ClientConfig {
   apiUrl: string;
-  apiToken: string;
+  /**
+   * User token (`cm_*`). Required for `/api/v1/*` methods.
+   * If omitted, those methods throw MCPClientError.
+   */
+  userToken?: string;
+  /**
+   * Agent runtime token (`cm_agent_*`). Required for CAP methods.
+   * If omitted, CAP methods throw MCPClientError.
+   */
+  agentToken?: string;
+  /**
+   * Legacy alias for `userToken`. Deprecated; prefer `userToken`.
+   */
+  apiToken?: string;
   timeout?: number;
+}
+
+/**
+ * Error thrown when the client is misused — e.g. calling a CAP method
+ * without an agent token configured. Distinct from upstream HTTP errors so
+ * callers can tell "you forgot to set the env var" from "the server said no."
+ */
+export class MCPClientError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MCPClientError";
+  }
+}
+
+/**
+ * Single CAP event as returned by GET /api/agents/runtime/events.
+ * Shape per ADR-004 §Event model. `payload` is type-specific and opaque
+ * to the client.
+ */
+export interface CAPEvent {
+  id: string;
+  type: string;
+  payload?: Record<string, unknown>;
+  attempts?: number;
+  createdAt?: string;
+  [key: string]: unknown;
+}
+
+export interface CAPEventsResponse {
+  events: CAPEvent[];
+}
+
+export interface CAPAckResponse {
+  success?: boolean;
+  ok?: boolean;
+  [key: string]: unknown;
+}
+
+export interface CAPPostMessageOptions {
+  content: string;
+  replyToMessageId?: string;
+  messageType?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CAPPostMessageResponse {
+  success?: boolean;
+  message?: {
+    id?: string;
+    podId?: string;
+    createdAt?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface CAPMemorySections {
+  [section: string]: unknown;
+}
+
+export interface CAPMemoryResponse {
+  content?: string;
+  sections?: CAPMemorySections;
+  sourceRuntime?: string;
+  schemaVersion?: number;
+}
+
+export interface CAPMemorySyncOptions {
+  sections: CAPMemorySections;
+  mode: "full" | "patch";
+  sourceRuntime?: string;
+}
+
+export interface CAPMemorySyncResponse {
+  ok?: boolean;
+  deduped?: boolean;
+  byteSize?: number;
+  schemaVersion?: number;
+  [key: string]: unknown;
 }
 
 export interface Pod {
@@ -101,39 +206,136 @@ export interface MessageResponse {
   [key: string]: unknown;
 }
 
+/**
+ * Shared response interceptor — converts upstream HTTP errors to friendlier
+ * Error messages while preserving status code in the text. Used identically
+ * for both user-auth and agent-auth axios instances so error shape is
+ * consistent regardless of which surface failed.
+ */
+function attachErrorInterceptor(http: AxiosInstance, label: string): void {
+  http.interceptors.response.use(
+    (response) => response,
+    (error: AxiosError) => {
+      if (error.response) {
+        const data = error.response.data as { message?: string; error?: string };
+        const message = data?.message || data?.error || error.message;
+        throw new Error(`${label} (${error.response.status}): ${message}`);
+      }
+      throw error;
+    }
+  );
+}
+
 export class CommonlyClient {
-  private http: AxiosInstance;
+  private userHttp: AxiosInstance | null = null;
+  private agentHttp: AxiosInstance | null = null;
 
   constructor(config: ClientConfig) {
-    this.http = axios.create({
-      baseURL: config.apiUrl,
-      timeout: config.timeout || 30000,
-      headers: {
-        Authorization: `Bearer ${config.apiToken}`,
-        "Content-Type": "application/json",
-        "User-Agent": "commonly-mcp/0.1.0",
-      },
-    });
+    const userToken = config.userToken || config.apiToken;
+    const agentToken = config.agentToken;
+    const timeout = config.timeout || 30000;
 
-    // Error interceptor for better error messages
-    this.http.interceptors.response.use(
-      (response) => response,
-      (error: AxiosError) => {
-        if (error.response) {
-          const data = error.response.data as { message?: string; error?: string };
-          const message = data?.message || data?.error || error.message;
-          throw new Error(`Commonly API Error (${error.response.status}): ${message}`);
-        }
-        throw error;
-      }
-    );
+    if (!userToken && !agentToken) {
+      throw new MCPClientError(
+        "CommonlyClient requires at least one of `userToken` or `agentToken`"
+      );
+    }
+
+    if (userToken) {
+      this.userHttp = axios.create({
+        baseURL: config.apiUrl,
+        timeout,
+        headers: {
+          Authorization: `Bearer ${userToken}`,
+          "Content-Type": "application/json",
+          "User-Agent": "commonly-mcp/0.1.0",
+        },
+      });
+      attachErrorInterceptor(this.userHttp, "Commonly API Error");
+    }
+
+    if (agentToken) {
+      this.agentHttp = axios.create({
+        baseURL: config.apiUrl,
+        timeout,
+        headers: {
+          Authorization: `Bearer ${agentToken}`,
+          "Content-Type": "application/json",
+          "User-Agent": "commonly-mcp/0.1.0",
+        },
+      });
+      attachErrorInterceptor(this.agentHttp, "Commonly CAP Error");
+    }
   }
+
+  /**
+   * Whether this client can call user-auth (`/api/v1/*`) methods.
+   */
+  hasUserAuth(): boolean {
+    return this.userHttp !== null;
+  }
+
+  /**
+   * Whether this client can call CAP (`/api/agents/runtime/*`) methods.
+   */
+  hasAgentAuth(): boolean {
+    return this.agentHttp !== null;
+  }
+
+  private requireUserHttp(): AxiosInstance {
+    if (!this.userHttp) {
+      throw new MCPClientError(
+        "user token not configured; set COMMONLY_USER_TOKEN to use user-space tools"
+      );
+    }
+    return this.userHttp;
+  }
+
+  private requireAgentHttp(): AxiosInstance {
+    if (!this.agentHttp) {
+      throw new MCPClientError(
+        "agent token not configured; set COMMONLY_AGENT_TOKEN to use CAP verbs"
+      );
+    }
+    return this.agentHttp;
+  }
+
+  // --- HTTP helper for CAP routes ---
+  // Kept distinct from the user-auth `http` instance on purpose. Sharing the
+  // helper would mean one bug at the path-prefix or auth layer breaks BOTH
+  // surfaces. They're separate kernels; keep them separate in code.
+  private async _capRequest<T>(
+    method: "get" | "post" | "put" | "delete",
+    path: string,
+    body?: unknown,
+    params?: Record<string, string | number | undefined>
+  ): Promise<T> {
+    const http = this.requireAgentHttp();
+    const url = `/api/agents/runtime${path}`;
+    const cleanedParams: Record<string, string | number> | undefined = params
+      ? Object.fromEntries(
+          Object.entries(params).filter(([, v]) => v !== undefined)
+        ) as Record<string, string | number>
+      : undefined;
+    const response = await http.request<T>({
+      method,
+      url,
+      data: body,
+      params: cleanedParams,
+    });
+    return response.data;
+  }
+
+  // ===========================================================================
+  // User-auth surface (`/api/v1/*`). Uses `userToken`. Requires user-auth.
+  // ===========================================================================
 
   /**
    * List pods the authenticated user has access to
    */
   async listPods(): Promise<Pod[]> {
-    const response = await this.http.get<{ pods: Pod[] }>("/api/v1/pods");
+    const http = this.requireUserHttp();
+    const response = await http.get<{ pods: Pod[] }>("/api/v1/pods");
     return response.data.pods;
   }
 
@@ -141,7 +343,8 @@ export class CommonlyClient {
    * Get a specific pod by ID
    */
   async getPod(podId: string): Promise<Pod> {
-    const response = await this.http.get<Pod>(`/api/v1/pods/${podId}`);
+    const http = this.requireUserHttp();
+    const response = await http.get<Pod>(`/api/v1/pods/${podId}`);
     return response.data;
   }
 
@@ -157,6 +360,7 @@ export class CommonlyClient {
       maxTokens?: number;
     } = {}
   ): Promise<Context> {
+    const http = this.requireUserHttp();
     const params = new URLSearchParams();
     if (options.task) params.set("task", options.task);
     if (options.includeSkills !== undefined)
@@ -165,7 +369,7 @@ export class CommonlyClient {
       params.set("includeMemory", String(options.includeMemory));
     if (options.maxTokens) params.set("maxTokens", String(options.maxTokens));
 
-    const response = await this.http.get<Context>(
+    const response = await http.get<Context>(
       `/api/v1/context/${podId}?${params.toString()}`
     );
     return response.data;
@@ -183,13 +387,14 @@ export class CommonlyClient {
       since?: string;
     } = {}
   ): Promise<SearchResponse> {
+    const http = this.requireUserHttp();
     const params = new URLSearchParams();
     params.set("q", query);
     if (options.limit) params.set("limit", String(options.limit));
     if (options.types) params.set("types", options.types.join(","));
     if (options.since) params.set("since", options.since);
 
-    const response = await this.http.get<SearchResponse>(
+    const response = await http.get<SearchResponse>(
       `/api/v1/search/${podId}?${params.toString()}`
     );
     return response.data;
@@ -199,7 +404,8 @@ export class CommonlyClient {
    * Read a specific asset from a pod
    */
   async readAsset(podId: string, assetId: string): Promise<Asset> {
-    const response = await this.http.get<Asset>(
+    const http = this.requireUserHttp();
+    const response = await http.get<Asset>(
       `/api/v1/pods/${podId}/assets/${assetId}`
     );
     return response.data;
@@ -209,7 +415,8 @@ export class CommonlyClient {
    * Read a virtual memory file (MEMORY.md, daily logs, etc.)
    */
   async readMemoryFile(podId: string, path: string): Promise<string> {
-    const response = await this.http.get<{ content: string }>(
+    const http = this.requireUserHttp();
+    const response = await http.get<{ content: string }>(
       `/api/v1/pods/${podId}/memory/${encodeURIComponent(path)}`
     );
     return response.data.content;
@@ -230,7 +437,8 @@ export class CommonlyClient {
       };
     }
   ): Promise<WriteResponse> {
-    const response = await this.http.post<WriteResponse>(
+    const http = this.requireUserHttp();
+    const response = await http.post<WriteResponse>(
       `/api/v1/memory/${podId}`,
       options
     );
@@ -238,7 +446,8 @@ export class CommonlyClient {
   }
 
   /**
-   * Post a chat message into a pod
+   * Post a chat message into a pod (user auth — `/api/messages/:podId`).
+   * Distinct from `postMessageCAP` which uses agent auth and the CAP route.
    */
   async postMessage(
     podId: string,
@@ -248,7 +457,8 @@ export class CommonlyClient {
       attachments?: unknown[];
     }
   ): Promise<MessageResponse> {
-    const response = await this.http.post<MessageResponse>(
+    const http = this.requireUserHttp();
+    const response = await http.post<MessageResponse>(
       `/api/messages/${podId}`,
       {
         content: options.content,
@@ -269,11 +479,12 @@ export class CommonlyClient {
       limit?: number;
     } = {}
   ): Promise<Skill[]> {
+    const http = this.requireUserHttp();
     const params = new URLSearchParams();
     if (options.tags) params.set("tags", options.tags.join(","));
     if (options.limit) params.set("limit", String(options.limit));
 
-    const response = await this.http.get<{ skills: Skill[] }>(
+    const response = await http.get<{ skills: Skill[] }>(
       `/api/v1/pods/${podId}/skills?${params.toString()}`
     );
     return response.data.skills;
@@ -290,14 +501,121 @@ export class CommonlyClient {
       limit?: number;
     } = {}
   ): Promise<Summary[]> {
+    const http = this.requireUserHttp();
     const params = new URLSearchParams();
     if (options.hours) params.set("hours", String(options.hours));
     if (options.types) params.set("types", options.types.join(","));
     if (options.limit) params.set("limit", String(options.limit));
 
-    const response = await this.http.get<{ summaries: Summary[] }>(
+    const response = await http.get<{ summaries: Summary[] }>(
       `/api/v1/pods/${podId}/summaries?${params.toString()}`
     );
     return response.data.summaries;
+  }
+
+  // ===========================================================================
+  // CAP surface (`/api/agents/runtime/*`). Uses `agentToken`. Per ADR-004.
+  // Each verb maps to one CAP route. No retries, no dedup, no in-memory state
+  // — drivers are responsible for idempotency (ADR-004 §Load-bearing #3).
+  // ===========================================================================
+
+  /**
+   * CAP verb #1 — poll. `GET /api/agents/runtime/events`.
+   *
+   * `since` is accepted for forward-compat with a future server-side cursor;
+   * the v1 backend does not currently filter by it (ADR-004 §Open Q #2/#3),
+   * but passing it through is harmless and keeps the client API stable.
+   */
+  async pollEvents(
+    options: {
+      since?: string;
+      limit?: number;
+    } = {}
+  ): Promise<CAPEventsResponse> {
+    return this._capRequest<CAPEventsResponse>("get", "/events", undefined, {
+      since: options.since,
+      limit: options.limit,
+    });
+  }
+
+  /**
+   * CAP verb #2 — ack. `POST /api/agents/runtime/events/:id/ack`.
+   * Drivers MUST call this after successful handling, or the event will
+   * re-deliver on the next poll (ADR-004 §Event model).
+   */
+  async ackEvent(eventId: string): Promise<CAPAckResponse> {
+    if (!eventId) {
+      throw new MCPClientError("ackEvent requires a non-empty eventId");
+    }
+    return this._capRequest<CAPAckResponse>(
+      "post",
+      `/events/${encodeURIComponent(eventId)}/ack`,
+      {}
+    );
+  }
+
+  /**
+   * CAP verb #3 — post. `POST /api/agents/runtime/pods/:podId/messages`.
+   *
+   * This is the agent-auth post path (CAP). Distinct from `postMessage`
+   * which uses user-auth and a different backend route. Both exist on
+   * purpose so end users can pick which auth mode they want exposed.
+   */
+  async postMessageCAP(
+    podId: string,
+    options: CAPPostMessageOptions
+  ): Promise<CAPPostMessageResponse> {
+    if (!podId) {
+      throw new MCPClientError("postMessageCAP requires a non-empty podId");
+    }
+    if (!options.content) {
+      throw new MCPClientError("postMessageCAP requires content");
+    }
+    return this._capRequest<CAPPostMessageResponse>(
+      "post",
+      `/pods/${encodeURIComponent(podId)}/messages`,
+      {
+        content: options.content,
+        replyToMessageId: options.replyToMessageId,
+        messageType: options.messageType,
+        metadata: options.metadata,
+      }
+    );
+  }
+
+  /**
+   * CAP verb #4a — read memory. `GET /api/agents/runtime/memory`.
+   * Returns the v2 envelope (`sections` + `sourceRuntime` + `schemaVersion`)
+   * with `content` for v1 readers (per ADR-003).
+   */
+  async readMemory(): Promise<CAPMemoryResponse> {
+    return this._capRequest<CAPMemoryResponse>("get", "/memory");
+  }
+
+  /**
+   * CAP verb #4b — sync memory. `POST /api/agents/runtime/memory/sync`.
+   * `mode: 'full'` replaces, `'patch'` merges (per ADR-003 Phase 2).
+   * Server passes `deduped: true` if the same payload was synced earlier
+   * in the same UTC day; we surface that field through unchanged.
+   */
+  async syncMemory(options: CAPMemorySyncOptions): Promise<CAPMemorySyncResponse> {
+    if (!options || typeof options !== "object") {
+      throw new MCPClientError("syncMemory requires an options object");
+    }
+    if (options.mode !== "full" && options.mode !== "patch") {
+      throw new MCPClientError("syncMemory mode must be 'full' or 'patch'");
+    }
+    if (!options.sections || typeof options.sections !== "object") {
+      throw new MCPClientError("syncMemory requires sections object");
+    }
+    return this._capRequest<CAPMemorySyncResponse>(
+      "post",
+      "/memory/sync",
+      {
+        sections: options.sections,
+        mode: options.mode,
+        sourceRuntime: options.sourceRuntime,
+      }
+    );
   }
 }

--- a/packages/commonly-mcp/src/index.ts
+++ b/packages/commonly-mcp/src/index.ts
@@ -21,12 +21,31 @@ import { tools, handleToolCall } from "./tools/index.js";
 import { getResources, readResource } from "./resources/index.js";
 
 // Configuration schema
-const ConfigSchema = z.object({
-  apiUrl: z.string().url().default("https://api.commonly.app"),
-  apiToken: z.string().min(1),
-  defaultPodId: z.string().optional(),
-  debug: z.boolean().default(false),
-});
+//
+// At least one of `userToken` or `agentToken` must be supplied. `apiToken` is
+// kept as a deprecated alias for `userToken` so existing callers don't break.
+// Validation that "at least one" is present is done after parse — Zod's
+// `.refine` would work too but a post-check gives a clearer error message
+// for the CLI path.
+const ConfigSchema = z
+  .object({
+    apiUrl: z.string().url().default("https://api.commonly.app"),
+    /** User token (cm_*) — required for `/api/v1/*` tools (the original 7). */
+    userToken: z.string().min(1).optional(),
+    /** Agent runtime token (cm_agent_*) — required for CAP verbs (ADR-004). */
+    agentToken: z.string().min(1).optional(),
+    /** Deprecated alias for `userToken`. */
+    apiToken: z.string().min(1).optional(),
+    defaultPodId: z.string().optional(),
+    debug: z.boolean().default(false),
+  })
+  .refine(
+    (cfg) => Boolean(cfg.userToken || cfg.agentToken || cfg.apiToken),
+    {
+      message:
+        "Config requires at least one of `userToken`, `agentToken`, or `apiToken`",
+    }
+  );
 
 export type Config = z.infer<typeof ConfigSchema>;
 
@@ -39,7 +58,8 @@ export class CommonlyMCPServer {
     this.config = ConfigSchema.parse(config);
     this.client = new CommonlyClient({
       apiUrl: this.config.apiUrl,
-      apiToken: this.config.apiToken,
+      userToken: this.config.userToken || this.config.apiToken,
+      agentToken: this.config.agentToken,
     });
 
     this.server = new Server(
@@ -114,6 +134,24 @@ export class CommonlyMCPServer {
     // Read a specific resource
     this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
       const { uri } = request.params;
+      // Resources (MEMORY.md, daily logs, etc.) all live on the user-auth
+      // surface. In agent-only mode we have nothing to serve — return the
+      // same shape the tool-call catch uses (isError: true + text message)
+      // rather than letting requireUserHttp() bubble an MCPClientError.
+      if (!this.client.hasUserAuth()) {
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: "text/plain",
+              text:
+                "Error: resource reads require a user token (set COMMONLY_USER_TOKEN). " +
+                "This MCP server is running in agent-only mode.",
+            },
+          ],
+          isError: true,
+        };
+      }
       const content = await readResource(this.client, uri);
       return {
         contents: [

--- a/packages/commonly-mcp/src/resources/index.ts
+++ b/packages/commonly-mcp/src/resources/index.ts
@@ -15,9 +15,17 @@ export interface Resource {
 }
 
 /**
- * Get list of available resources (pod memory files)
+ * Get list of available resources (pod memory files).
+ *
+ * Resources are derived from the user's pod list, which requires a user
+ * token. In agent-only mode (CAP-only deployment) the user token is absent
+ * and we have no way to enumerate pods — return an empty list rather than
+ * throwing, so the MCP `resources/list` request still succeeds.
  */
 export async function getResources(client: CommonlyClient): Promise<Resource[]> {
+  if (!client.hasUserAuth()) {
+    return [];
+  }
   const pods = await client.listPods();
 
   const resources: Resource[] = [];

--- a/packages/commonly-mcp/src/tools/cap-ack.ts
+++ b/packages/commonly-mcp/src/tools/cap-ack.ts
@@ -1,0 +1,41 @@
+/**
+ * CAP verb #2 — ack. Maps to POST /api/agents/runtime/events/:id/ack.
+ *
+ * Drivers MUST call this after successfully processing each event from
+ * commonly_poll_events. Unacked events re-deliver on the next poll
+ * (ADR-004 §Event model).
+ */
+
+import { CommonlyClient } from "../client.js";
+
+export const definition = {
+  name: "commonly_ack_event",
+  description:
+    "CAP verb (ack). Mark a previously polled event as processed so it stops " +
+    "re-delivering. Requires COMMONLY_AGENT_TOKEN. Call this AFTER your " +
+    "handler succeeds — calling before handling risks dropping work on a crash.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      eventId: {
+        type: "string",
+        description: "The event id returned by commonly_poll_events.",
+      },
+    },
+    required: ["eventId"],
+  },
+};
+
+export interface CapAckArgs {
+  eventId: string;
+}
+
+export async function handler(
+  client: CommonlyClient,
+  args: CapAckArgs
+): Promise<{ ok: true }> {
+  await client.ackEvent(args.eventId);
+  // Backend returns { success: true } on the wire; we standardize to { ok: true }
+  // in the tool surface so downstream agents can rely on a single shape.
+  return { ok: true };
+}

--- a/packages/commonly-mcp/src/tools/cap-memory-sync.ts
+++ b/packages/commonly-mcp/src/tools/cap-memory-sync.ts
@@ -1,0 +1,88 @@
+/**
+ * CAP verb #4 — memory sync. Maps to POST /api/agents/runtime/memory/sync.
+ *
+ * Per ADR-003 Phase 2: drivers promote local memory state into the kernel
+ * envelope. Server is idempotent within a UTC-day bucket on
+ * (sourceRuntime, canonical-stringify(sections+mode)) — repeated identical
+ * payloads return { deduped: true } without writing. We pass that flag
+ * through unchanged so the calling agent can tell "already synced today" from
+ * "newly written."
+ *
+ * Mode semantics (from the server):
+ *   - "full":  replaces sections wholesale. Anything not in payload is cleared.
+ *   - "patch": merges. Object sections $set per-key, array sections merge by
+ *              `date` / `otherInstanceId`.
+ */
+
+import { CommonlyClient } from "../client.js";
+
+export const definition = {
+  name: "commonly_memory_sync",
+  description:
+    "CAP verb (memory). Promote sections of agent memory into the kernel " +
+    "envelope (ADR-003). Requires COMMONLY_AGENT_TOKEN. Use mode='full' for " +
+    "a complete snapshot, mode='patch' for incremental updates. Server " +
+    "deduplicates identical payloads within a UTC day; check `deduped` in the " +
+    "response to distinguish a no-op from a write.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      sections: {
+        type: "object",
+        description:
+          "Memory sections envelope (soul, long_term, daily, relationships, dedup_state, shared, runtime_meta).",
+      },
+      mode: {
+        type: "string",
+        enum: ["full", "patch"],
+        description: "'full' replaces all sections; 'patch' merges with existing.",
+      },
+      sourceRuntime: {
+        type: "string",
+        description:
+          "Optional driver self-id (e.g. 'mcp-client', 'claude-desktop'). Opaque tag.",
+      },
+    },
+    required: ["sections", "mode"],
+  },
+};
+
+export interface CapMemorySyncArgs {
+  sections: Record<string, unknown>;
+  mode: "full" | "patch";
+  sourceRuntime?: string;
+}
+
+export interface CapMemorySyncResult {
+  updated: boolean;
+  byteSize?: number;
+  deduped?: boolean;
+  schemaVersion?: number;
+}
+
+export async function handler(
+  client: CommonlyClient,
+  args: CapMemorySyncArgs
+): Promise<CapMemorySyncResult> {
+  if (args.mode !== "full" && args.mode !== "patch") {
+    throw new Error("commonly_memory_sync: mode must be 'full' or 'patch'");
+  }
+  if (!args.sections || typeof args.sections !== "object") {
+    throw new Error("commonly_memory_sync: sections must be an object");
+  }
+  const response = await client.syncMemory({
+    sections: args.sections,
+    mode: args.mode,
+    sourceRuntime: args.sourceRuntime,
+  });
+  // `updated` reflects whether a write actually happened. Deduped requests
+  // are a no-op on the server; surface that explicitly so callers don't
+  // rely on side effects that didn't occur.
+  return {
+    updated: !response.deduped,
+    deduped: response.deduped === true ? true : undefined,
+    byteSize: typeof response.byteSize === "number" ? response.byteSize : undefined,
+    schemaVersion:
+      typeof response.schemaVersion === "number" ? response.schemaVersion : undefined,
+  };
+}

--- a/packages/commonly-mcp/src/tools/cap-poll.ts
+++ b/packages/commonly-mcp/src/tools/cap-poll.ts
@@ -1,0 +1,50 @@
+/**
+ * CAP verb #1 — poll. Maps to GET /api/agents/runtime/events.
+ *
+ * Per ADR-004: drivers poll for pending events; delivery is at-least-once,
+ * drivers are responsible for idempotency. We intentionally do not maintain
+ * any client-side dedup state — each tool call is independent.
+ */
+
+import { CommonlyClient } from "../client.js";
+
+export const definition = {
+  name: "commonly_poll_events",
+  description:
+    "CAP verb (poll). Fetch pending events queued for this agent (mentions, " +
+    "messages, scheduled ticks, etc.). Requires COMMONLY_AGENT_TOKEN. " +
+    "Returns {events: []} when none are queued — that is not an error. " +
+    "Per ADR-004 events deliver at-least-once; ack each event after handling.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      since: {
+        type: "string",
+        description:
+          "Optional ISO-8601 cursor; reserved for forward-compat. Server may ignore in v1.",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum events to return (1–50, default 20).",
+      },
+    },
+  },
+};
+
+export interface CapPollArgs {
+  since?: string;
+  limit?: number;
+}
+
+export async function handler(
+  client: CommonlyClient,
+  args: CapPollArgs
+): Promise<{ events: unknown[] }> {
+  const response = await client.pollEvents({
+    since: args.since,
+    limit: args.limit,
+  });
+  // Always return { events: [] } not an error when empty — empty queue is the
+  // common steady-state, not a failure mode.
+  return { events: response.events ?? [] };
+}

--- a/packages/commonly-mcp/src/tools/cap-post.ts
+++ b/packages/commonly-mcp/src/tools/cap-post.ts
@@ -1,0 +1,94 @@
+/**
+ * CAP verb #3 — post. Maps to POST /api/agents/runtime/pods/:podId/messages.
+ *
+ * This is the agent-auth post path. The existing `commonly_post_message` tool
+ * uses user-auth (`/api/messages/:podId`) and posts AS the user. This tool
+ * uses agent-auth and posts AS the agent identity (cm_agent_* token). They
+ * are intentionally distinct so end users can pick which auth mode to expose
+ * — without that, a user installing the MCP server can't predict who their
+ * messages will be attributed to.
+ */
+
+import { CommonlyClient } from "../client.js";
+import type { Config } from "../index.js";
+
+export const definition = {
+  name: "commonly_post_message_cap",
+  description:
+    "CAP verb (post). Post a message into a pod AS the agent identity. " +
+    "Requires COMMONLY_AGENT_TOKEN. Distinct from commonly_post_message " +
+    "(which posts as the human user via user token). Use this when the " +
+    "client should appear in the pod as an agent, not as a person.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      podId: {
+        type: "string",
+        description:
+          "Target pod id. If omitted, falls back to COMMONLY_DEFAULT_POD.",
+      },
+      content: {
+        type: "string",
+        description: "Markdown message body. Stored verbatim by the kernel.",
+      },
+      replyToMessageId: {
+        type: "string",
+        description: "Optional message id to thread under.",
+      },
+      messageType: {
+        type: "string",
+        description: "Optional message type tag (default: text).",
+      },
+      metadata: {
+        type: "object",
+        description:
+          "Optional metadata. `metadata.kind` is the only field the kernel inspects (changes shell rendering).",
+      },
+    },
+    required: ["content"],
+  },
+};
+
+export interface CapPostArgs {
+  podId?: string;
+  content: string;
+  replyToMessageId?: string;
+  messageType?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CapPostResult {
+  messageId: string | undefined;
+  podId: string;
+  createdAt: string | undefined;
+}
+
+export async function handler(
+  client: CommonlyClient,
+  args: CapPostArgs,
+  config: Config
+): Promise<CapPostResult> {
+  const podId = args.podId || config.defaultPodId;
+  if (!podId) {
+    throw new Error(
+      "podId is required for commonly_post_message_cap (or set COMMONLY_DEFAULT_POD)"
+    );
+  }
+  const response = await client.postMessageCAP(podId, {
+    content: args.content,
+    replyToMessageId: args.replyToMessageId,
+    messageType: args.messageType,
+    metadata: args.metadata,
+  });
+  // Backend shape per agentMessageService: { success, message: { _id, podId, createdAt, ... } }
+  // Mongo returns `_id`; some other code paths surface `id`. Try both.
+  const message: Record<string, unknown> = (response.message ?? {}) as Record<string, unknown>;
+  const rawId = message._id ?? message.id;
+  const messagePodId = message.podId;
+  const messageCreatedAt = message.createdAt;
+  return {
+    messageId: rawId !== undefined && rawId !== null ? String(rawId) : undefined,
+    podId: typeof messagePodId === "string" ? messagePodId : podId,
+    createdAt: typeof messageCreatedAt === "string" ? messageCreatedAt : undefined,
+  };
+}

--- a/packages/commonly-mcp/src/tools/index.ts
+++ b/packages/commonly-mcp/src/tools/index.ts
@@ -7,6 +7,10 @@
 
 import { CommonlyClient } from "../client.js";
 import { Config } from "../index.js";
+import * as CapPoll from "./cap-poll.js";
+import * as CapAck from "./cap-ack.js";
+import * as CapPost from "./cap-post.js";
+import * as CapMemorySync from "./cap-memory-sync.js";
 
 export interface Tool {
   name: string;
@@ -202,6 +206,16 @@ export const tools: Tool[] = [
       required: ["podId"],
     },
   },
+  // ---------------------------------------------------------------------------
+  // CAP verbs (ADR-004) — added in ADR-007 Phase 2.
+  // These require COMMONLY_AGENT_TOKEN and hit /api/agents/runtime/* instead
+  // of /api/v1/*. They are ADDITIVE — the 7 user-space tools above are
+  // unchanged and continue to use the user token.
+  // ---------------------------------------------------------------------------
+  CapPoll.definition,
+  CapAck.definition,
+  CapPost.definition,
+  CapMemorySync.definition,
 ];
 
 /**
@@ -344,6 +358,46 @@ export async function handleToolCall(
         })),
         hint: "Skills are derived from team activity. Use instructions as guidance for tasks.",
       };
+    }
+
+    // -------------------------------------------------------------------------
+    // CAP verbs (ADR-004 / ADR-007 Phase 2). Each handler lives in its own
+    // module so it can be tested independently and so adding/removing CAP
+    // verbs doesn't churn the user-space switch above.
+    // -------------------------------------------------------------------------
+    case CapPoll.definition.name:
+      return CapPoll.handler(client, args as CapPoll.CapPollArgs);
+
+    case CapAck.definition.name: {
+      const eventId = args.eventId as string | undefined;
+      if (!eventId) throw new Error("eventId is required");
+      return CapAck.handler(client, { eventId });
+    }
+
+    case CapPost.definition.name: {
+      const content = args.content as string | undefined;
+      if (!content) throw new Error("content is required");
+      return CapPost.handler(
+        client,
+        {
+          podId: args.podId as string | undefined,
+          content,
+          replyToMessageId: args.replyToMessageId as string | undefined,
+          messageType: args.messageType as string | undefined,
+          metadata: args.metadata as Record<string, unknown> | undefined,
+        },
+        config
+      );
+    }
+
+    case CapMemorySync.definition.name: {
+      // Validation lives in the tool module (cap-memory-sync.ts) and in the
+      // client (client.ts). Dispatch just coerces arg shapes and forwards.
+      return CapMemorySync.handler(client, {
+        sections: args.sections as Record<string, unknown>,
+        mode: args.mode as "full" | "patch",
+        sourceRuntime: args.sourceRuntime as string | undefined,
+      });
     }
 
     default:


### PR DESCRIPTION
## Summary
Adds four new MCP tools to `@commonly/mcp-server` that hit the CAP routes at `/api/agents/runtime/*` using `cm_agent_*` tokens, so any MCP-enabled tool (Cursor, Claude Desktop, ChatGPT desktop) can act as a real Commonly agent.

- `commonly_poll_events` → `GET /events`
- `commonly_ack_event` → `POST /events/:id/ack`
- `commonly_post_message_cap` → `POST /pods/:podId/messages` (agent auth — distinct from existing user-auth `commonly_post_message`)
- `commonly_memory_sync` → `POST /memory/sync`

Dual-auth client: separate axios instances for user vs agent token, separate error labels, no shared mutable state. Either or both tokens can be set via `COMMONLY_USER_TOKEN` / `COMMONLY_AGENT_TOKEN`. `readResource` degrades cleanly in agent-only mode (no UserAuth crash); `getResources` returns `[]`.

The 7 existing context-hub tools are unchanged.

Companion to #PR-A (env), #PR-C (backend Phase 4), #PR-D (demo).

Spec: `docs/adr/ADR-007-ecosystem-integration-strategy.md` (Phase 2). ADR table updated to match shipped tool name (`commonly_post_message_cap`).

## Test plan
- [x] `npx vitest run` — 32/32 passed (13 client-level + 17 tool-level + 2 existing user-auth)
- [x] `npx tsc --noEmit` — clean (TypeScript strict)
- [x] Self-review against `docs/REVIEW.md`
- [x] Independent code review — approved with non-blocking notes
- [ ] Functional: point Cursor or Claude Desktop at the running server with a real `cm_agent_*` token and confirm `commonly_poll_events` returns the event queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)