### PR TITLE
feat(backend): ADR-003 Phase 4 — cross-agent messaging + visibility

### DIFF
--- a/backend/__tests__/integration/agentsRuntime.crossAgent.test.js
+++ b/backend/__tests__/integration/agentsRuntime.crossAgent.test.js
@@ -1,0 +1,509 @@
+/**
+ * ADR-003 Phase 4 — cross-agent HTTP integration tests.
+ *
+ * Exercises:
+ *   GET  /api/agents/runtime/memory/shared/:agentName/:instanceId?
+ *   POST /api/agents/runtime/pods/:podId/ask
+ *   POST /api/agents/runtime/asks/:requestId/respond
+ *
+ * Two installed agents (alice, bob) in one pod. Each has its own runtime
+ * token (issued through the registry routes the same way real drivers do)
+ * so the agentRuntimeAuth middleware runs end-to-end.
+ *
+ * Mocks AgentEventService.enqueue so the full event-delivery pipeline
+ * (typing service, websocket, native runtime) doesn't need to be wired.
+ */
+
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+const { setupMongoDb, closeMongoDb } = require('../utils/testUtils');
+
+const User = require('../../models/User');
+const Pod = require('../../models/Pod');
+const { AgentRegistry, AgentInstallation } = require('../../models/AgentRegistry');
+const AgentMemory = require('../../models/AgentMemory');
+const AgentAsk = require('../../models/AgentAsk');
+
+// Stub the event service before requiring routes.
+jest.mock('../../services/agentEventService', () => ({
+  enqueue: jest.fn(async () => ({ _id: 'stub-event' })),
+}));
+const AgentEventService = require('../../services/agentEventService');
+
+const registryRoutes = require('../../routes/registry');
+const agentsRuntimeRoutes = require('../../routes/agentsRuntime');
+
+const JWT_SECRET = 'test-jwt-secret-for-cross-agent';
+
+jest.setTimeout(60_000);
+
+describe('Cross-agent HTTP routes (ADR-003 Phase 4)', () => {
+  let app;
+  let adminUser;
+  let adminToken;
+  let pod;
+  let aliceToken;
+  let bobToken;
+
+  const installAndIssueToken = async (agentName, scopes = ['context:read']) => {
+    await request(app)
+      .post('/api/registry/install')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ agentName, podId: pod._id.toString(), scopes });
+    const tokenRes = await request(app)
+      .post(`/api/registry/pods/${pod._id}/agents/${agentName}/runtime-tokens`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ label: `${agentName} test token` });
+    expect(tokenRes.status).toBe(200);
+    expect(tokenRes.body.token).toMatch(/^cm_agent_/);
+    return tokenRes.body.token;
+  };
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = JWT_SECRET;
+    await setupMongoDb();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/registry', registryRoutes);
+    app.use('/api/agents/runtime', agentsRuntimeRoutes);
+
+    adminUser = await User.create({
+      username: 'cross-agent-admin',
+      email: 'cross-agent-admin@test.com',
+      password: 'password123',
+    });
+    adminToken = jwt.sign({ id: adminUser._id.toString() }, JWT_SECRET);
+
+    pod = await Pod.create({
+      name: 'Cross Agent Pod',
+      type: 'chat',
+      createdBy: adminUser._id,
+      members: [adminUser._id],
+    });
+
+    await AgentRegistry.create({
+      agentName: 'alice',
+      displayName: 'Alice',
+      description: 'Test agent A',
+      registry: 'commonly-official',
+      verified: true,
+      manifest: {
+        name: 'alice',
+        version: '1.0.0',
+        capabilities: [{ name: 'memory', description: 'memory' }],
+        context: { required: ['context:read'] },
+        runtime: { type: 'standalone', connection: 'rest' },
+      },
+      latestVersion: '1.0.0',
+      versions: [{ version: '1.0.0', publishedAt: new Date() }],
+    });
+    await AgentRegistry.create({
+      agentName: 'bob',
+      displayName: 'Bob',
+      description: 'Test agent B',
+      registry: 'commonly-official',
+      verified: true,
+      manifest: {
+        name: 'bob',
+        version: '1.0.0',
+        capabilities: [{ name: 'memory', description: 'memory' }],
+        context: { required: ['context:read'] },
+        runtime: { type: 'standalone', connection: 'rest' },
+      },
+      latestVersion: '1.0.0',
+      versions: [{ version: '1.0.0', publishedAt: new Date() }],
+    });
+  });
+
+  afterAll(async () => {
+    await closeMongoDb();
+  });
+
+  beforeEach(async () => {
+    await AgentInstallation.deleteMany({});
+    await AgentMemory.deleteMany({});
+    await AgentAsk.deleteMany({});
+    await User.updateMany({ isBot: true }, { $set: { agentRuntimeTokens: [] } });
+    AgentEventService.enqueue.mockClear();
+
+    aliceToken = await installAndIssueToken('alice');
+    bobToken = await installAndIssueToken('bob');
+  });
+
+  // ----------------------------------------------------------------------- //
+  // GET /memory/shared                                                      //
+  // ----------------------------------------------------------------------- //
+
+  describe('GET /memory/shared/:agentName/:instanceId?', () => {
+    it('returns 401 without an agent token', async () => {
+      const res = await request(app).get('/api/agents/runtime/memory/shared/bob');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 404 when the target has no AgentMemory row', async () => {
+      const res = await request(app)
+        .get('/api/agents/runtime/memory/shared/bob')
+        .set('Authorization', `Bearer ${aliceToken}`);
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 400 for an empty agentName', async () => {
+      // Express collapses /memory/shared/ to /memory/shared — and the route
+      // pattern requires at least :agentName, so an entirely missing param
+      // returns 404 (Express). A whitespace-only param exercises our 400.
+      const res = await request(app)
+        .get('/api/agents/runtime/memory/shared/%20')
+        .set('Authorization', `Bearer ${aliceToken}`);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns only public + pod-shared sections when pods overlap', async () => {
+      // Bob writes a mix of visibility levels via PUT /memory.
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${bobToken}`)
+        .send({
+          sections: {
+            soul: { content: 'private soul', visibility: 'private' },
+            long_term: { content: 'private long_term', visibility: 'private' },
+            shared: { content: 'public bio', visibility: 'public' },
+            runtime_meta: { content: 'pod-shared meta', visibility: 'pod' },
+          },
+        })
+        .expect(200);
+
+      // Alice (in the same pod) reads bob's shared view.
+      const res = await request(app)
+        .get('/api/agents/runtime/memory/shared/bob')
+        .set('Authorization', `Bearer ${aliceToken}`);
+      expect(res.status).toBe(200);
+      expect(res.body.agentName).toBe('bob');
+      expect(res.body.instanceId).toBe('default');
+      expect(res.body.sections.soul).toBeUndefined();
+      expect(res.body.sections.long_term).toBeUndefined();
+      expect(res.body.sections.shared.content).toBe('public bio');
+      expect(res.body.sections.runtime_meta.content).toBe('pod-shared meta');
+      // sharedPods reflects which pods grounded the access
+      expect(res.body.sharedPods).toEqual(expect.arrayContaining([pod._id.toString()]));
+    });
+
+    it('NEVER returns private sections, even via the shared route', async () => {
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${bobToken}`)
+        .send({
+          sections: {
+            long_term: { content: 'super secret', visibility: 'private' },
+          },
+        })
+        .expect(200);
+      const res = await request(app)
+        .get('/api/agents/runtime/memory/shared/bob')
+        .set('Authorization', `Bearer ${aliceToken}`);
+      expect(res.status).toBe(200);
+      expect(res.body.sections.long_term).toBeUndefined();
+    });
+
+    it('strips pod sections when requester does NOT share a pod with target', async () => {
+      // Move bob to a different pod so alice and bob no longer overlap.
+      const lonelyPod = await Pod.create({
+        name: 'Lonely', type: 'chat', createdBy: adminUser._id, members: [adminUser._id],
+      });
+      await AgentInstallation.deleteMany({ agentName: 'bob' });
+      await AgentInstallation.create({
+        agentName: 'bob',
+        podId: lonelyPod._id,
+        instanceId: 'default',
+        version: '1.0.0',
+        installedBy: adminUser._id,
+        status: 'active',
+      });
+      // Bob writes pod-visible content.
+      await AgentMemory.create({
+        agentName: 'bob',
+        instanceId: 'default',
+        sections: { shared: { content: 'pod only', visibility: 'pod' } },
+      });
+      const res = await request(app)
+        .get('/api/agents/runtime/memory/shared/bob')
+        .set('Authorization', `Bearer ${aliceToken}`);
+      expect(res.status).toBe(200);
+      expect(res.body.sections.shared).toBeUndefined();
+      expect(res.body.sharedPods).toEqual([]);
+    });
+
+    it('still returns public sections even when there is no pod overlap', async () => {
+      const lonelyPod = await Pod.create({
+        name: 'Lonely2', type: 'chat', createdBy: adminUser._id, members: [adminUser._id],
+      });
+      await AgentInstallation.deleteMany({ agentName: 'bob' });
+      await AgentInstallation.create({
+        agentName: 'bob',
+        podId: lonelyPod._id,
+        instanceId: 'default',
+        version: '1.0.0',
+        installedBy: adminUser._id,
+        status: 'active',
+      });
+      await AgentMemory.create({
+        agentName: 'bob',
+        instanceId: 'default',
+        sections: {
+          shared: { content: 'public always', visibility: 'public' },
+          long_term: { content: 'pod-only', visibility: 'pod' },
+        },
+      });
+      const res = await request(app)
+        .get('/api/agents/runtime/memory/shared/bob')
+        .set('Authorization', `Bearer ${aliceToken}`);
+      expect(res.status).toBe(200);
+      expect(res.body.sections.shared.content).toBe('public always');
+      expect(res.body.sections.long_term).toBeUndefined();
+    });
+  });
+
+  // ----------------------------------------------------------------------- //
+  // POST /pods/:podId/ask + /asks/:requestId/respond                        //
+  // ----------------------------------------------------------------------- //
+
+  describe('POST /pods/:podId/ask', () => {
+    it('returns 401 without a token', async () => {
+      const res = await request(app)
+        .post(`/api/agents/runtime/pods/${pod._id}/ask`)
+        .send({ targetAgent: 'bob', question: 'q' });
+      expect(res.status).toBe(401);
+    });
+
+    it('happy path — creates AgentAsk, enqueues agent.ask, returns requestId', async () => {
+      const res = await request(app)
+        .post(`/api/agents/runtime/pods/${pod._id}/ask`)
+        .set('Authorization', `Bearer ${aliceToken}`)
+        .send({ targetAgent: 'bob', question: 'when is demo?' });
+      expect(res.status).toBe(200);
+      expect(res.body.requestId).toMatch(/[a-f0-9-]{36}/i);
+
+      const ask = await AgentAsk.findOne({ requestId: res.body.requestId });
+      expect(ask.fromAgent).toBe('alice');
+      expect(ask.targetAgent).toBe('bob');
+      expect(ask.question).toBe('when is demo?');
+
+      expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+      const evt = AgentEventService.enqueue.mock.calls[0][0];
+      expect(evt.type).toBe('agent.ask');
+      expect(evt.agentName).toBe('bob');
+    });
+
+    it('rejects self-ask (alice → alice) with 400', async () => {
+      const res = await request(app)
+        .post(`/api/agents/runtime/pods/${pod._id}/ask`)
+        .set('Authorization', `Bearer ${aliceToken}`)
+        .send({ targetAgent: 'alice', question: 'self' });
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('self_ask');
+      expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('rejects when target is not in the pod (404)', async () => {
+      // Uninstall bob from the test pod.
+      await AgentInstallation.deleteMany({ agentName: 'bob' });
+      const res = await request(app)
+        .post(`/api/agents/runtime/pods/${pod._id}/ask`)
+        .set('Authorization', `Bearer ${aliceToken}`)
+        .send({ targetAgent: 'bob', question: 'q' });
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe('target_not_in_pod');
+    });
+
+    it('rejects asking on behalf of a pod the agent is not in (403)', async () => {
+      const otherPod = await Pod.create({
+        name: 'Other', type: 'chat', createdBy: adminUser._id, members: [adminUser._id],
+      });
+      const res = await request(app)
+        .post(`/api/agents/runtime/pods/${otherPod._id}/ask`)
+        .set('Authorization', `Bearer ${aliceToken}`)
+        .send({ targetAgent: 'bob', question: 'q' });
+      expect(res.status).toBe(403);
+    });
+
+    it('rejects missing question / targetAgent with 400', async () => {
+      const r1 = await request(app)
+        .post(`/api/agents/runtime/pods/${pod._id}/ask`)
+        .set('Authorization', `Bearer ${aliceToken}`)
+        .send({ targetAgent: 'bob' });
+      expect(r1.status).toBe(400);
+      const r2 = await request(app)
+        .post(`/api/agents/runtime/pods/${pod._id}/ask`)
+        .set('Authorization', `Bearer ${aliceToken}`)
+        .send({ question: 'q' });
+      expect(r2.status).toBe(400);
+    });
+
+    it('returns 429 once rate limit is exceeded', async () => {
+      // Pre-seed 30 recent asks from alice in this pod.
+      const seed = [];
+      for (let i = 0; i < 30; i += 1) {
+        seed.push({
+          requestId: `seed-${i}`,
+          podId: pod._id,
+          fromAgent: 'alice',
+          fromInstanceId: 'default',
+          targetAgent: 'bob',
+          targetInstanceId: 'default',
+          question: 'q',
+          status: 'open',
+          expiresAt: new Date(Date.now() + 60_000),
+        });
+      }
+      await AgentAsk.insertMany(seed);
+      const res = await request(app)
+        .post(`/api/agents/runtime/pods/${pod._id}/ask`)
+        .set('Authorization', `Bearer ${aliceToken}`)
+        .send({ targetAgent: 'bob', question: 'one too many' });
+      expect(res.status).toBe(429);
+      expect(res.body.code).toBe('rate_limited');
+    });
+  });
+
+  describe('POST /asks/:requestId/respond', () => {
+    let openRequestId;
+
+    beforeEach(async () => {
+      const res = await request(app)
+        .post(`/api/agents/runtime/pods/${pod._id}/ask`)
+        .set('Authorization', `Bearer ${aliceToken}`)
+        .send({ targetAgent: 'bob', question: 'hi' });
+      openRequestId = res.body.requestId;
+      AgentEventService.enqueue.mockClear();
+    });
+
+    it('happy path — bob responds, marks ask responded, enqueues response event', async () => {
+      const res = await request(app)
+        .post(`/api/agents/runtime/asks/${openRequestId}/respond`)
+        .set('Authorization', `Bearer ${bobToken}`)
+        .send({ content: '2pm pacific' });
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+
+      const ask = await AgentAsk.findOne({ requestId: openRequestId });
+      expect(ask.status).toBe('responded');
+      expect(ask.response).toBe('2pm pacific');
+
+      expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+      const evt = AgentEventService.enqueue.mock.calls[0][0];
+      expect(evt.type).toBe('agent.ask.response');
+      expect(evt.agentName).toBe('alice');
+    });
+
+    it('rejects respond by alice (not the target) with 403', async () => {
+      const res = await request(app)
+        .post(`/api/agents/runtime/asks/${openRequestId}/respond`)
+        .set('Authorization', `Bearer ${aliceToken}`)
+        .send({ content: 'hijack' });
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('not_target');
+    });
+
+    it('rejects unknown requestId with 404', async () => {
+      const res = await request(app)
+        .post('/api/agents/runtime/asks/not-a-real-id/respond')
+        .set('Authorization', `Bearer ${bobToken}`)
+        .send({ content: 'x' });
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe('ask_not_found');
+    });
+
+    it('rejects empty content with 400', async () => {
+      const res = await request(app)
+        .post(`/api/agents/runtime/asks/${openRequestId}/respond`)
+        .set('Authorization', `Bearer ${bobToken}`)
+        .send({ content: '' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects responding twice with 409', async () => {
+      await request(app)
+        .post(`/api/agents/runtime/asks/${openRequestId}/respond`)
+        .set('Authorization', `Bearer ${bobToken}`)
+        .send({ content: 'first' })
+        .expect(200);
+      const res = await request(app)
+        .post(`/api/agents/runtime/asks/${openRequestId}/respond`)
+        .set('Authorization', `Bearer ${bobToken}`)
+        .send({ content: 'second' });
+      expect(res.status).toBe(409);
+    });
+  });
+
+  // The standard runtime-tokens HTTP route writes the token to BOTH
+  // User.agentRuntimeTokens (primary lookup) and AgentInstallation.runtimeTokens
+  // (back-compat fallback). The middleware always matches the User row first,
+  // so the installation-token fallback path is never exercised by the routes
+  // above. This block mints a token EXCLUSIVELY on the installation, leaving
+  // User.agentRuntimeTokens empty, so the second branch of the middleware
+  // (`AgentInstallation.findOne({ 'runtimeTokens.tokenHash': ... })`) runs.
+  describe('installation-scoped token auth path (agentRuntimeAuth fallback branch)', () => {
+    const crypto = require('crypto');
+    const hash = (s) => crypto.createHash('sha256').update(s).digest('hex');
+    let installToken;
+    let installAgentName;
+
+    beforeEach(async () => {
+      installAgentName = 'alice'; // alice is already published in beforeAll
+      // alice was installed via installAndIssueToken in the parent beforeEach
+      // — that wrote to BOTH locations. To force the installation-only path,
+      // strip the User row's tokens here, leaving only the installation copy.
+      const aliceUser = await User.findOne({
+        isBot: true,
+        'botMetadata.agentName': installAgentName,
+      });
+      if (aliceUser) {
+        aliceUser.agentRuntimeTokens = [];
+        await aliceUser.save();
+      }
+      // Mint a fresh token directly into the installation, so the hash is one
+      // we know and can present.
+      const installation = await AgentInstallation.findOne({
+        agentName: installAgentName,
+        podId: pod._id,
+      });
+      const raw = `cm_agent_${crypto.randomBytes(16).toString('hex')}`;
+      installation.runtimeTokens = [{
+        tokenHash: hash(raw),
+        label: 'install-only test',
+        createdAt: new Date(),
+      }];
+      await installation.save();
+      installToken = raw;
+    });
+
+    it('POST /pods/:podId/ask works on the installation-token path', async () => {
+      const res = await request(app)
+        .post(`/api/agents/runtime/pods/${pod._id}/ask`)
+        .set('Authorization', `Bearer ${installToken}`)
+        .send({ targetAgent: 'bob', question: 'install-token ask' });
+      expect(res.status).toBe(200);
+      expect(res.body.requestId).toBeTruthy();
+      expect(AgentEventService.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'agent.ask', agentName: 'bob' }),
+      );
+    });
+
+    it('POST /asks/:requestId/respond works on the installation-token path', async () => {
+      const askRes = await request(app)
+        .post(`/api/agents/runtime/pods/${pod._id}/ask`)
+        .set('Authorization', `Bearer ${installToken}`)
+        .send({ targetAgent: 'bob', question: 'q' })
+        .expect(200);
+      // Bob still has a normal token from parent beforeEach, so we can use it
+      // to respond — verifies a mixed-auth-path interaction works end-to-end.
+      const res = await request(app)
+        .post(`/api/agents/runtime/asks/${askRes.body.requestId}/respond`)
+        .set('Authorization', `Bearer ${bobToken}`)
+        .send({ content: 'install-token respond ok' });
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/backend/__tests__/unit/middleware/agentRateLimit.test.js
+++ b/backend/__tests__/unit/middleware/agentRateLimit.test.js
@@ -1,105 +1,63 @@
 // @ts-nocheck
-// ADR-003 Phase 4: agentRateLimit middleware tests.
+// ADR-003 Phase 4: agentRateLimit key-generator tests.
 //
-// Behavior-focused tests against the express-rate-limit-backed middleware.
-// No DB, no HTTP server — we hand-build req/res objects and call the
-// middleware directly. Each test instantiates a fresh middleware so the
-// internal MemoryStore is reset between cases.
+// The express-rate-limit invocation itself is inlined in
+// routes/agentsRuntime.ts (so CodeQL recognises it). This module only
+// exposes the key generator — these tests cover that the same caller
+// produces a stable key across requests, and that different callers
+// produce distinct keys.
 
-const agentRateLimit = require('../../../middleware/agentRateLimit');
+const crypto = require('crypto');
+const { agentRateLimitKeyGenerator } = require('../../../middleware/agentRateLimit');
 
-const mkReq = (tokenHash, extras = {}) => ({
-  headers: { authorization: `Bearer ${tokenHash}` },
-  agentTokenHash: tokenHash,
-  ip: '10.0.0.1',
-  // express-rate-limit expects an `app` reference and basic Express plumbing;
-  // a stubbed app with the minimum surface keeps it happy in tests.
-  app: { get: () => undefined },
-  get(name) { return this.headers[name?.toLowerCase()]; },
-  ...extras,
-});
+const sha = (s) => crypto.createHash('sha256').update(s).digest('hex');
 
-const mkRes = () => {
-  const headers = {};
-  return {
-    statusCode: 0,
-    body: null,
-    headersSent: false,
-    setHeader(k, v) { headers[k] = v; return this; },
-    getHeader(k) { return headers[k]; },
-    headers,
-    status(c) { this.statusCode = c; return this; },
-    json(b) { this.body = b; this.headersSent = true; return this; },
-    send(b) { this.body = b; this.headersSent = true; return this; },
-    end(b) { this.body = b; this.headersSent = true; return this; },
-  };
-};
-
-const callMw = (mw, req, res) => new Promise((resolve, reject) => {
-  try {
-    const result = mw(req, res, () => resolve('passed'));
-    if (result && typeof result.then === 'function') {
-      result.then(() => {
-        if (!res.headersSent) resolve('passed');
-        else resolve('rejected');
-      }).catch(reject);
-    } else if (res.headersSent) {
-      resolve('rejected');
-    }
-  } catch (err) { reject(err); }
-});
-
-describe('agentRateLimit', () => {
-  it('passes requests under the limit', async () => {
-    const mw = agentRateLimit({ windowMs: 60_000, max: 3 });
-    const results = [];
-    for (let i = 0; i < 3; i += 1) {
-      // eslint-disable-next-line no-await-in-loop
-      results.push(await callMw(mw, mkReq('alice-token'), mkRes()));
-    }
-    expect(results).toEqual(['passed', 'passed', 'passed']);
-  });
-
-  it('rejects with 429 + code=rate_limited once the window cap is hit', async () => {
-    const mw = agentRateLimit({ windowMs: 60_000, max: 2 });
-    await callMw(mw, mkReq('alice-token'), mkRes());
-    await callMw(mw, mkReq('alice-token'), mkRes());
-    const res = mkRes();
-    await callMw(mw, mkReq('alice-token'), res);
-    expect(res.statusCode).toBe(429);
-    expect(res.body.code).toBe('rate_limited');
-  });
-
-  it('counts per-token (different tokens get independent budgets)', async () => {
-    const mw = agentRateLimit({ windowMs: 60_000, max: 1 });
-    const aliceFirst = await callMw(mw, mkReq('alice-token'), mkRes());
-    const bobFirst = await callMw(mw, mkReq('bob-token'), mkRes());
-    expect(aliceFirst).toBe('passed');
-    expect(bobFirst).toBe('passed');
-
-    // Each token's SECOND request must reject — confirms per-token isolation.
-    const aliceSecond = mkRes();
-    const bobSecond = mkRes();
-    await callMw(mw, mkReq('alice-token'), aliceSecond);
-    await callMw(mw, mkReq('bob-token'), bobSecond);
-    expect(aliceSecond.statusCode).toBe(429);
-    expect(bobSecond.statusCode).toBe(429);
-  });
-
-  it('falls back to header-hash key when agentTokenHash is absent', async () => {
-    const mw = agentRateLimit({ windowMs: 60_000, max: 1 });
-    // Same Authorization header on both, no req.agentTokenHash — the fallback
-    // hash must produce the same key, so the second request should reject.
-    const reqA = {
-      headers: { authorization: 'Bearer raw-token' },
+describe('agentRateLimitKeyGenerator', () => {
+  it('uses agentTokenHash when set (the common case after agentRuntimeAuth)', () => {
+    const k = agentRateLimitKeyGenerator({
+      agentTokenHash: 'abc123',
+      headers: { authorization: 'Bearer raw' },
       ip: '10.0.0.1',
-      app: { get: () => undefined },
-      get(name) { return this.headers[name?.toLowerCase()]; },
+    });
+    expect(k).toBe('tok:abc123');
+  });
+
+  it('falls back to a hash of the Authorization header when agentTokenHash absent', () => {
+    const k = agentRateLimitKeyGenerator({
+      headers: { authorization: 'Bearer raw-token-xyz' },
+      ip: '10.0.0.1',
+    });
+    expect(k).toBe(`hdr:${sha('Bearer raw-token-xyz')}`);
+  });
+
+  it('falls back to remote IP when no token-bearing header is present', () => {
+    const k = agentRateLimitKeyGenerator({
+      headers: {},
+      ip: '203.0.113.7',
+    });
+    expect(k).toBe('ip:203.0.113.7');
+  });
+
+  it('returns the same key for two requests with the same token', () => {
+    const req = {
+      agentTokenHash: 'same-hash',
+      headers: { authorization: 'Bearer raw' },
+      ip: '10.0.0.1',
     };
-    const reqB = { ...reqA };
-    await callMw(mw, reqA, mkRes());
-    const res = mkRes();
-    await callMw(mw, reqB, res);
-    expect(res.statusCode).toBe(429);
+    expect(agentRateLimitKeyGenerator(req)).toBe(agentRateLimitKeyGenerator({ ...req }));
+  });
+
+  it('returns different keys for different tokens', () => {
+    const a = agentRateLimitKeyGenerator({ agentTokenHash: 'alice' });
+    const b = agentRateLimitKeyGenerator({ agentTokenHash: 'bob' });
+    expect(a).not.toBe(b);
+  });
+
+  it('handles the x-commonly-agent-token header alongside Authorization', () => {
+    const k = agentRateLimitKeyGenerator({
+      headers: { 'x-commonly-agent-token': 'xtok' },
+      ip: '10.0.0.1',
+    });
+    expect(k).toBe(`hdr:${sha('xtok')}`);
   });
 });

--- a/backend/__tests__/unit/middleware/agentRateLimit.test.js
+++ b/backend/__tests__/unit/middleware/agentRateLimit.test.js
@@ -1,102 +1,105 @@
 // @ts-nocheck
 // ADR-003 Phase 4: agentRateLimit middleware tests.
 //
-// Pure middleware unit tests — no DB, no HTTP server. We hand-build req/res
-// objects and call the middleware directly so the per-token counter can be
-// exercised in isolation from the auth middleware that normally precedes it.
+// Behavior-focused tests against the express-rate-limit-backed middleware.
+// No DB, no HTTP server — we hand-build req/res objects and call the
+// middleware directly. Each test instantiates a fresh middleware so the
+// internal MemoryStore is reset between cases.
 
 const agentRateLimit = require('../../../middleware/agentRateLimit');
-const { __resetAgentRateLimit } = require('../../../middleware/agentRateLimit');
 
-const mkReq = (tokenHash) => ({
+const mkReq = (tokenHash, extras = {}) => ({
   headers: { authorization: `Bearer ${tokenHash}` },
   agentTokenHash: tokenHash,
   ip: '10.0.0.1',
+  // express-rate-limit expects an `app` reference and basic Express plumbing;
+  // a stubbed app with the minimum surface keeps it happy in tests.
+  app: { get: () => undefined },
+  get(name) { return this.headers[name?.toLowerCase()]; },
+  ...extras,
 });
+
 const mkRes = () => {
   const headers = {};
   return {
     statusCode: 0,
     body: null,
+    headersSent: false,
     setHeader(k, v) { headers[k] = v; return this; },
+    getHeader(k) { return headers[k]; },
     headers,
     status(c) { this.statusCode = c; return this; },
-    json(b) { this.body = b; return this; },
+    json(b) { this.body = b; this.headersSent = true; return this; },
+    send(b) { this.body = b; this.headersSent = true; return this; },
+    end(b) { this.body = b; this.headersSent = true; return this; },
   };
 };
 
-beforeEach(() => __resetAgentRateLimit());
+const callMw = (mw, req, res) => new Promise((resolve, reject) => {
+  try {
+    const result = mw(req, res, () => resolve('passed'));
+    if (result && typeof result.then === 'function') {
+      result.then(() => {
+        if (!res.headersSent) resolve('passed');
+        else resolve('rejected');
+      }).catch(reject);
+    } else if (res.headersSent) {
+      resolve('rejected');
+    }
+  } catch (err) { reject(err); }
+});
 
 describe('agentRateLimit', () => {
-  it('passes requests under the limit', () => {
+  it('passes requests under the limit', async () => {
     const mw = agentRateLimit({ windowMs: 60_000, max: 3 });
-    const req = mkReq('alice-token');
-    const res = mkRes();
-    let nextCount = 0;
-    const next = () => { nextCount += 1; };
-
-    for (let i = 0; i < 3; i += 1) mw(req, res, next);
-    expect(nextCount).toBe(3);
-    expect(res.statusCode).toBe(0);
+    const results = [];
+    for (let i = 0; i < 3; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      results.push(await callMw(mw, mkReq('alice-token'), mkRes()));
+    }
+    expect(results).toEqual(['passed', 'passed', 'passed']);
   });
 
-  it('rejects the request that exceeds the window with 429 + Retry-After', () => {
+  it('rejects with 429 + code=rate_limited once the window cap is hit', async () => {
     const mw = agentRateLimit({ windowMs: 60_000, max: 2 });
-    const req = mkReq('alice-token');
+    await callMw(mw, mkReq('alice-token'), mkRes());
+    await callMw(mw, mkReq('alice-token'), mkRes());
     const res = mkRes();
-    const next = jest.fn();
-
-    mw(req, res, next);
-    mw(req, res, next);
-    mw(req, res, next); // third should reject
-
-    expect(next).toHaveBeenCalledTimes(2);
+    await callMw(mw, mkReq('alice-token'), res);
     expect(res.statusCode).toBe(429);
     expect(res.body.code).toBe('rate_limited');
-    expect(res.body.retryAfter).toBeGreaterThan(0);
-    expect(res.headers['Retry-After']).toBeDefined();
   });
 
-  it('counts per-token (different tokens do not interfere)', () => {
+  it('counts per-token (different tokens get independent budgets)', async () => {
     const mw = agentRateLimit({ windowMs: 60_000, max: 1 });
-    const next = jest.fn();
+    const aliceFirst = await callMw(mw, mkReq('alice-token'), mkRes());
+    const bobFirst = await callMw(mw, mkReq('bob-token'), mkRes());
+    expect(aliceFirst).toBe('passed');
+    expect(bobFirst).toBe('passed');
 
-    mw(mkReq('alice-token'), mkRes(), next);
-    mw(mkReq('bob-token'), mkRes(), next);
-    expect(next).toHaveBeenCalledTimes(2);
+    // Each token's SECOND request must reject — confirms per-token isolation.
+    const aliceSecond = mkRes();
+    const bobSecond = mkRes();
+    await callMw(mw, mkReq('alice-token'), aliceSecond);
+    await callMw(mw, mkReq('bob-token'), bobSecond);
+    expect(aliceSecond.statusCode).toBe(429);
+    expect(bobSecond.statusCode).toBe(429);
   });
 
-  it('falls back to header-hash key when agentTokenHash absent', () => {
+  it('falls back to header-hash key when agentTokenHash is absent', async () => {
     const mw = agentRateLimit({ windowMs: 60_000, max: 1 });
-    const next = jest.fn();
+    // Same Authorization header on both, no req.agentTokenHash — the fallback
+    // hash must produce the same key, so the second request should reject.
+    const reqA = {
+      headers: { authorization: 'Bearer raw-token' },
+      ip: '10.0.0.1',
+      app: { get: () => undefined },
+      get(name) { return this.headers[name?.toLowerCase()]; },
+    };
+    const reqB = { ...reqA };
+    await callMw(mw, reqA, mkRes());
     const res = mkRes();
-
-    // Same auth header, no req.agentTokenHash — should still rate-limit.
-    const req1 = { headers: { authorization: 'Bearer raw-token' }, ip: '10.0.0.1' };
-    const req2 = { headers: { authorization: 'Bearer raw-token' }, ip: '10.0.0.1' };
-    mw(req1, mkRes(), next);
-    mw(req2, res, next);
-    expect(next).toHaveBeenCalledTimes(1);
+    await callMw(mw, reqB, res);
     expect(res.statusCode).toBe(429);
-  });
-
-  it('resets after the window elapses (mocked clock)', () => {
-    const realNow = Date.now;
-    let now = 1_000_000;
-    Date.now = () => now;
-    try {
-      const mw = agentRateLimit({ windowMs: 60_000, max: 1 });
-      const req = mkReq('alice-token');
-      const next = jest.fn();
-      mw(req, mkRes(), next);
-      mw(req, mkRes(), next); // rejects
-      expect(next).toHaveBeenCalledTimes(1);
-
-      now += 60_001;
-      mw(req, mkRes(), next); // new window — should pass
-      expect(next).toHaveBeenCalledTimes(2);
-    } finally {
-      Date.now = realNow;
-    }
   });
 });

--- a/backend/__tests__/unit/middleware/agentRateLimit.test.js
+++ b/backend/__tests__/unit/middleware/agentRateLimit.test.js
@@ -1,0 +1,102 @@
+// @ts-nocheck
+// ADR-003 Phase 4: agentRateLimit middleware tests.
+//
+// Pure middleware unit tests — no DB, no HTTP server. We hand-build req/res
+// objects and call the middleware directly so the per-token counter can be
+// exercised in isolation from the auth middleware that normally precedes it.
+
+const agentRateLimit = require('../../../middleware/agentRateLimit');
+const { __resetAgentRateLimit } = require('../../../middleware/agentRateLimit');
+
+const mkReq = (tokenHash) => ({
+  headers: { authorization: `Bearer ${tokenHash}` },
+  agentTokenHash: tokenHash,
+  ip: '10.0.0.1',
+});
+const mkRes = () => {
+  const headers = {};
+  return {
+    statusCode: 0,
+    body: null,
+    setHeader(k, v) { headers[k] = v; return this; },
+    headers,
+    status(c) { this.statusCode = c; return this; },
+    json(b) { this.body = b; return this; },
+  };
+};
+
+beforeEach(() => __resetAgentRateLimit());
+
+describe('agentRateLimit', () => {
+  it('passes requests under the limit', () => {
+    const mw = agentRateLimit({ windowMs: 60_000, max: 3 });
+    const req = mkReq('alice-token');
+    const res = mkRes();
+    let nextCount = 0;
+    const next = () => { nextCount += 1; };
+
+    for (let i = 0; i < 3; i += 1) mw(req, res, next);
+    expect(nextCount).toBe(3);
+    expect(res.statusCode).toBe(0);
+  });
+
+  it('rejects the request that exceeds the window with 429 + Retry-After', () => {
+    const mw = agentRateLimit({ windowMs: 60_000, max: 2 });
+    const req = mkReq('alice-token');
+    const res = mkRes();
+    const next = jest.fn();
+
+    mw(req, res, next);
+    mw(req, res, next);
+    mw(req, res, next); // third should reject
+
+    expect(next).toHaveBeenCalledTimes(2);
+    expect(res.statusCode).toBe(429);
+    expect(res.body.code).toBe('rate_limited');
+    expect(res.body.retryAfter).toBeGreaterThan(0);
+    expect(res.headers['Retry-After']).toBeDefined();
+  });
+
+  it('counts per-token (different tokens do not interfere)', () => {
+    const mw = agentRateLimit({ windowMs: 60_000, max: 1 });
+    const next = jest.fn();
+
+    mw(mkReq('alice-token'), mkRes(), next);
+    mw(mkReq('bob-token'), mkRes(), next);
+    expect(next).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to header-hash key when agentTokenHash absent', () => {
+    const mw = agentRateLimit({ windowMs: 60_000, max: 1 });
+    const next = jest.fn();
+    const res = mkRes();
+
+    // Same auth header, no req.agentTokenHash — should still rate-limit.
+    const req1 = { headers: { authorization: 'Bearer raw-token' }, ip: '10.0.0.1' };
+    const req2 = { headers: { authorization: 'Bearer raw-token' }, ip: '10.0.0.1' };
+    mw(req1, mkRes(), next);
+    mw(req2, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(429);
+  });
+
+  it('resets after the window elapses (mocked clock)', () => {
+    const realNow = Date.now;
+    let now = 1_000_000;
+    Date.now = () => now;
+    try {
+      const mw = agentRateLimit({ windowMs: 60_000, max: 1 });
+      const req = mkReq('alice-token');
+      const next = jest.fn();
+      mw(req, mkRes(), next);
+      mw(req, mkRes(), next); // rejects
+      expect(next).toHaveBeenCalledTimes(1);
+
+      now += 60_001;
+      mw(req, mkRes(), next); // new window — should pass
+      expect(next).toHaveBeenCalledTimes(2);
+    } finally {
+      Date.now = realNow;
+    }
+  });
+});

--- a/backend/__tests__/unit/services/agentAskService.test.ts
+++ b/backend/__tests__/unit/services/agentAskService.test.ts
@@ -1,0 +1,454 @@
+// @ts-nocheck
+// ADR-003 Phase 4: agentAskService cross-agent ask/respond.
+// Uses an in-memory MongoDB for AgentInstallation + AgentAsk collections.
+// AgentEventService.enqueue is stubbed so we don't need the full event
+// pipeline (typing service, websocket, native runtime, etc.).
+
+const mongoose = require('mongoose');
+const { setupMongoDb, closeMongoDb, clearMongoDb } = require('../../utils/testUtils');
+
+// Stub the event service before requiring the ask service so the require()
+// chain pulls our stub. The ask service requires('./agentEventService') at
+// load time.
+jest.mock('../../../services/agentEventService', () => ({
+  enqueue: jest.fn(async () => ({ _id: 'stub-event' })),
+}));
+
+const AgentEventService = require('../../../services/agentEventService');
+const { AgentInstallation } = require('../../../models/AgentRegistry');
+const AgentAsk = require('../../../models/AgentAsk');
+const {
+  askAgent,
+  respondToAsk,
+  AgentAskError,
+} = require('../../../services/agentAskService');
+
+jest.setTimeout(30_000);
+
+const POD = new mongoose.Types.ObjectId();
+const OTHER_POD = new mongoose.Types.ObjectId();
+const INSTALLER = new mongoose.Types.ObjectId();
+
+const installAgent = (agentName, instanceId, podId = POD) => AgentInstallation.create({
+  agentName: agentName.toLowerCase(),
+  instanceId,
+  podId,
+  version: '1.0.0',
+  installedBy: INSTALLER,
+  status: 'active',
+});
+
+beforeAll(async () => {
+  await setupMongoDb();
+});
+
+afterAll(async () => {
+  await closeMongoDb();
+});
+
+beforeEach(async () => {
+  await clearMongoDb();
+  AgentEventService.enqueue.mockClear();
+});
+
+describe('askAgent — happy path', () => {
+  it('creates an AgentAsk row and enqueues an agent.ask event', async () => {
+    await installAgent('alice', 'one');
+    await installAgent('bob', 'one');
+
+    const result = await askAgent({
+      fromAgent: 'alice',
+      fromInstanceId: 'one',
+      podId: POD.toString(),
+      targetAgent: 'bob',
+      targetInstanceId: 'one',
+      question: 'what time is the demo?',
+    });
+
+    expect(result.requestId).toMatch(/[a-f0-9-]{36}/i);
+    expect(result.expiresAt).toBeInstanceOf(Date);
+
+    const ask = await AgentAsk.findOne({ requestId: result.requestId });
+    expect(ask.status).toBe('open');
+    expect(ask.fromAgent).toBe('alice');
+    expect(ask.targetAgent).toBe('bob');
+    expect(ask.question).toBe('what time is the demo?');
+
+    expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+    const evtArgs = AgentEventService.enqueue.mock.calls[0][0];
+    expect(evtArgs.type).toBe('agent.ask');
+    expect(evtArgs.agentName).toBe('bob');
+    expect(evtArgs.instanceId).toBe('one');
+    expect(String(evtArgs.podId)).toBe(POD.toString());
+    expect(evtArgs.payload.requestId).toBe(result.requestId);
+    expect(evtArgs.payload.fromAgent).toBe('alice');
+    expect(evtArgs.payload.question).toBe('what time is the demo?');
+  });
+
+  it('uses caller-supplied requestId when provided', async () => {
+    await installAgent('alice', 'one');
+    await installAgent('bob', 'one');
+    const result = await askAgent({
+      fromAgent: 'alice',
+      fromInstanceId: 'one',
+      podId: POD.toString(),
+      targetAgent: 'bob',
+      targetInstanceId: 'one',
+      question: 'q',
+      requestId: 'caller-supplied-id-123',
+    });
+    expect(result.requestId).toBe('caller-supplied-id-123');
+  });
+
+  it("defaults targetInstanceId to 'default' when omitted", async () => {
+    await installAgent('alice', 'one');
+    await installAgent('bob', 'default');
+    const result = await askAgent({
+      fromAgent: 'alice',
+      fromInstanceId: 'one',
+      podId: POD.toString(),
+      targetAgent: 'bob',
+      question: 'q',
+    });
+    const ask = await AgentAsk.findOne({ requestId: result.requestId });
+    expect(ask.targetInstanceId).toBe('default');
+  });
+});
+
+describe('askAgent — guards', () => {
+  it('rejects self-ask (same agentName + instanceId)', async () => {
+    await installAgent('alice', 'one');
+    await expect(askAgent({
+      fromAgent: 'alice',
+      fromInstanceId: 'one',
+      podId: POD.toString(),
+      targetAgent: 'alice',
+      targetInstanceId: 'one',
+      question: 'q',
+    })).rejects.toMatchObject({
+      status: 400,
+      code: 'self_ask',
+    });
+    expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("normalizes self-ask: 'Alice' targeting 'alice' is still self", async () => {
+    await installAgent('alice', 'default');
+    await expect(askAgent({
+      fromAgent: 'Alice',
+      fromInstanceId: 'default',
+      podId: POD.toString(),
+      targetAgent: 'alice',
+      // targetInstanceId omitted → defaults to 'default'
+      question: 'q',
+    })).rejects.toMatchObject({ code: 'self_ask' });
+  });
+
+  it('allows ask between same agentName but DIFFERENT instanceId', async () => {
+    // Two distinct installations of the same agent persona — collaborative
+    // multi-instance setup. These are different entities, the ask must work.
+    await installAgent('alice', 'one');
+    await installAgent('alice', 'two');
+    const result = await askAgent({
+      fromAgent: 'alice',
+      fromInstanceId: 'one',
+      podId: POD.toString(),
+      targetAgent: 'alice',
+      targetInstanceId: 'two',
+      question: 'hello other me',
+    });
+    expect(result.requestId).toBeTruthy();
+  });
+
+  it('rejects when target is not installed in the named pod', async () => {
+    await installAgent('alice', 'one');
+    // bob is installed in OTHER_POD, not POD
+    await installAgent('bob', 'one', OTHER_POD);
+    await expect(askAgent({
+      fromAgent: 'alice',
+      fromInstanceId: 'one',
+      podId: POD.toString(),
+      targetAgent: 'bob',
+      targetInstanceId: 'one',
+      question: 'q',
+    })).rejects.toMatchObject({
+      status: 404,
+      code: 'target_not_in_pod',
+    });
+  });
+
+  it('rejects when target installation is not active', async () => {
+    await installAgent('alice', 'one');
+    const inst = await installAgent('bob', 'one');
+    inst.status = 'paused';
+    await inst.save();
+    await expect(askAgent({
+      fromAgent: 'alice',
+      fromInstanceId: 'one',
+      podId: POD.toString(),
+      targetAgent: 'bob',
+      targetInstanceId: 'one',
+      question: 'q',
+    })).rejects.toMatchObject({ code: 'target_not_in_pod' });
+  });
+
+  it('rejects empty question / missing fields', async () => {
+    await installAgent('alice', 'one');
+    await installAgent('bob', 'one');
+    await expect(askAgent({
+      fromAgent: 'alice', fromInstanceId: 'one', podId: POD.toString(), targetAgent: 'bob', question: '',
+    })).rejects.toMatchObject({ code: 'question_required' });
+    await expect(askAgent({
+      fromAgent: '', fromInstanceId: 'one', podId: POD.toString(), targetAgent: 'bob', question: 'q',
+    })).rejects.toMatchObject({ code: 'fromAgent_required' });
+    await expect(askAgent({
+      fromAgent: 'alice', fromInstanceId: 'one', podId: '', targetAgent: 'bob', question: 'q',
+    })).rejects.toMatchObject({ code: 'podId_required' });
+  });
+});
+
+describe('askAgent — rate limiting', () => {
+  it('returns 429 when fromAgent exceeds 30 asks/hour in same pod', async () => {
+    await installAgent('chatty', 'one');
+    await installAgent('victim', 'one');
+
+    // Pre-seed 30 recent asks from chatty in this pod so the next call
+    // crosses the limit.
+    const seed = [];
+    for (let i = 0; i < 30; i += 1) {
+      seed.push({
+        requestId: `seed-${i}`,
+        podId: POD,
+        fromAgent: 'chatty',
+        fromInstanceId: 'one',
+        targetAgent: 'victim',
+        targetInstanceId: 'one',
+        question: 'q',
+        status: 'open',
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+    }
+    await AgentAsk.insertMany(seed);
+
+    await expect(askAgent({
+      fromAgent: 'chatty',
+      fromInstanceId: 'one',
+      podId: POD.toString(),
+      targetAgent: 'victim',
+      targetInstanceId: 'one',
+      question: 'one too many',
+    })).rejects.toMatchObject({ status: 429, code: 'rate_limited' });
+  });
+
+  it('rate-limit key is normalized — varying fromInstanceId does NOT bypass', async () => {
+    // Defense against trivial bypass: "rotate instanceId" is not a way out
+    // of the rate limit. The limit key is (fromAgent, podId), instanceId is
+    // intentionally excluded.
+    await installAgent('chatty', 'one');
+    await installAgent('chatty', 'two');
+    await installAgent('victim', 'default');
+
+    const seed = [];
+    for (let i = 0; i < 30; i += 1) {
+      seed.push({
+        requestId: `seed-${i}`,
+        podId: POD,
+        fromAgent: 'chatty',
+        fromInstanceId: i % 2 === 0 ? 'one' : 'two',
+        targetAgent: 'victim',
+        targetInstanceId: 'default',
+        question: 'q',
+        status: 'open',
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+    }
+    await AgentAsk.insertMany(seed);
+
+    // Even from a fresh instanceId, the agentName is the same → blocked.
+    await expect(askAgent({
+      fromAgent: 'chatty',
+      fromInstanceId: 'two',
+      podId: POD.toString(),
+      targetAgent: 'victim',
+      targetInstanceId: 'default',
+      question: 'bypass attempt',
+    })).rejects.toMatchObject({ code: 'rate_limited' });
+  });
+
+  it('does not count asks older than 1 hour', async () => {
+    await installAgent('alice', 'one');
+    await installAgent('bob', 'one');
+
+    // Insert 30 stale asks (well outside the 1h window) — these must NOT
+    // count toward the limit.
+    const stale = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    const seed = [];
+    for (let i = 0; i < 30; i += 1) {
+      seed.push({
+        requestId: `stale-${i}`,
+        podId: POD,
+        fromAgent: 'alice',
+        fromInstanceId: 'one',
+        targetAgent: 'bob',
+        targetInstanceId: 'one',
+        question: 'q',
+        status: 'responded',
+        createdAt: stale,
+        expiresAt: new Date(stale.getTime() + 60_000),
+      });
+    }
+    await AgentAsk.insertMany(seed);
+
+    const result = await askAgent({
+      fromAgent: 'alice',
+      fromInstanceId: 'one',
+      podId: POD.toString(),
+      targetAgent: 'bob',
+      targetInstanceId: 'one',
+      question: 'fresh ask',
+    });
+    expect(result.requestId).toBeTruthy();
+  });
+});
+
+describe('respondToAsk', () => {
+  const setup = async () => {
+    await installAgent('alice', 'one');
+    await installAgent('bob', 'one');
+    const { requestId } = await askAgent({
+      fromAgent: 'alice',
+      fromInstanceId: 'one',
+      podId: POD.toString(),
+      targetAgent: 'bob',
+      targetInstanceId: 'one',
+      question: 'hi',
+    });
+    AgentEventService.enqueue.mockClear();
+    return requestId;
+  };
+
+  it('marks the ask responded and enqueues agent.ask.response back to sender', async () => {
+    const requestId = await setup();
+    await respondToAsk({
+      fromAgent: 'bob',
+      fromInstanceId: 'one',
+      requestId,
+      content: '2pm pacific',
+    });
+
+    const ask = await AgentAsk.findOne({ requestId });
+    expect(ask.status).toBe('responded');
+    expect(ask.response).toBe('2pm pacific');
+    expect(ask.respondedAt).toBeInstanceOf(Date);
+
+    expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+    const evt = AgentEventService.enqueue.mock.calls[0][0];
+    expect(evt.type).toBe('agent.ask.response');
+    expect(evt.agentName).toBe('alice');     // back to original sender
+    expect(evt.instanceId).toBe('one');
+    expect(evt.payload.response).toBe('2pm pacific');
+    expect(evt.payload.requestId).toBe(requestId);
+    expect(evt.payload.fromAgent).toBe('bob'); // responder identity
+  });
+
+  it('rejects respond from someone other than the original target', async () => {
+    const requestId = await setup();
+    await installAgent('eve', 'one');
+    await expect(respondToAsk({
+      fromAgent: 'eve',
+      fromInstanceId: 'one',
+      requestId,
+      content: 'hijack',
+    })).rejects.toMatchObject({ status: 403, code: 'not_target' });
+
+    // ask still open
+    const ask = await AgentAsk.findOne({ requestId });
+    expect(ask.status).toBe('open');
+  });
+
+  it('rejects responding twice to the same ask', async () => {
+    const requestId = await setup();
+    await respondToAsk({
+      fromAgent: 'bob', fromInstanceId: 'one', requestId, content: 'first',
+    });
+    await expect(respondToAsk({
+      fromAgent: 'bob', fromInstanceId: 'one', requestId, content: 'second',
+    })).rejects.toMatchObject({ status: 409, code: 'already_responded' });
+  });
+
+  it('rejects responding to an unknown requestId', async () => {
+    await expect(respondToAsk({
+      fromAgent: 'bob', fromInstanceId: 'one', requestId: 'not-a-real-id', content: 'x',
+    })).rejects.toMatchObject({ status: 404, code: 'ask_not_found' });
+  });
+
+  it('rejects responding to an expired ask', async () => {
+    await installAgent('alice', 'one');
+    await installAgent('bob', 'one');
+    // Insert an ask that's already past its expiry.
+    const ask = await AgentAsk.create({
+      requestId: 'expired-1',
+      podId: POD,
+      fromAgent: 'alice',
+      fromInstanceId: 'one',
+      targetAgent: 'bob',
+      targetInstanceId: 'one',
+      question: 'q',
+      status: 'open',
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    await expect(respondToAsk({
+      fromAgent: 'bob', fromInstanceId: 'one', requestId: ask.requestId, content: 'x',
+    })).rejects.toMatchObject({ status: 410, code: 'ask_expired' });
+
+    // Side effect: ask status flipped to 'expired' so future polls see it.
+    const reloaded = await AgentAsk.findOne({ requestId: ask.requestId });
+    expect(reloaded.status).toBe('expired');
+  });
+
+  it('rejects empty/missing content', async () => {
+    const requestId = await setup();
+    await expect(respondToAsk({
+      fromAgent: 'bob', fromInstanceId: 'one', requestId, content: '',
+    })).rejects.toMatchObject({ code: 'content_required' });
+  });
+});
+
+describe('askAgent — requestId validation (DoS surface)', () => {
+  beforeEach(async () => {
+    await installAgent('alice', 'one');
+    await installAgent('bob', 'one');
+  });
+
+  it('rejects requestId longer than 128 chars before reaching Mongo', async () => {
+    const overlong = 'x'.repeat(129);
+    await expect(askAgent({
+      fromAgent: 'alice', fromInstanceId: 'one',
+      podId: POD.toString(), targetAgent: 'bob', targetInstanceId: 'one',
+      question: 'q', requestId: overlong,
+    })).rejects.toMatchObject({ status: 400, code: 'invalid_request_id' });
+    // Confirm no record landed in Mongo despite the reject — the guard has
+    // to trip BEFORE the DB write, otherwise the DoS payload is already in
+    // the unique index and subsequent inserts would 11000.
+    const stored = await AgentAsk.findOne({ requestId: overlong });
+    expect(stored).toBeNull();
+  });
+
+  it('accepts requestId at exactly 128 chars (boundary)', async () => {
+    const at = 'a'.repeat(128);
+    const res = await askAgent({
+      fromAgent: 'alice', fromInstanceId: 'one',
+      podId: POD.toString(), targetAgent: 'bob', targetInstanceId: 'one',
+      question: 'q', requestId: at,
+    });
+    expect(res.requestId).toBe(at);
+  });
+
+  it('rejects requestId with control characters', async () => {
+    await expect(askAgent({
+      fromAgent: 'alice', fromInstanceId: 'one',
+      podId: POD.toString(), targetAgent: 'bob', targetInstanceId: 'one',
+      question: 'q', requestId: 'has-newline\nbad',
+    })).rejects.toMatchObject({ status: 400, code: 'invalid_request_id' });
+  });
+});

--- a/backend/__tests__/unit/services/agentMemoryService.visibility.test.ts
+++ b/backend/__tests__/unit/services/agentMemoryService.visibility.test.ts
@@ -1,0 +1,220 @@
+// @ts-nocheck
+// ADR-003 Phase 4: visibility filter for cross-agent memory reads.
+// Pure function — no DB required. Covers visibility precedence rules
+// (private never leaks, public always returned, pod requires overlap)
+// AND per-element filtering for daily[]/relationships[].
+
+const {
+  filterSectionsByVisibility,
+} = require('../../../services/agentMemoryService');
+
+const POD_A = '507f1f77bcf86cd799439011';
+const POD_B = '507f1f77bcf86cd799439012';
+const POD_C = '507f1f77bcf86cd799439013';
+
+const sec = (content, visibility) => ({
+  content,
+  visibility,
+  updatedAt: new Date('2026-04-15T00:00:00Z'),
+  byteSize: Buffer.byteLength(content, 'utf8'),
+});
+
+describe('filterSectionsByVisibility', () => {
+  it('returns {} for undefined sections', () => {
+    expect(filterSectionsByVisibility(undefined, [POD_A], [POD_A])).toEqual({});
+  });
+
+  it('returns {} for empty sections', () => {
+    expect(filterSectionsByVisibility({}, [POD_A], [POD_A])).toEqual({});
+  });
+
+  it('returns public sections regardless of pod overlap', () => {
+    const sections = {
+      shared: sec('public bio', 'public'),
+      runtime_meta: sec('claude-code', 'public'),
+    };
+    const out = filterSectionsByVisibility(sections, [], []); // no overlap at all
+    expect(out.shared.content).toBe('public bio');
+    expect(out.runtime_meta.content).toBe('claude-code');
+  });
+
+  it('returns pod sections when requester and owner share at least one pod', () => {
+    const sections = { shared: sec('pod bio', 'pod') };
+    const out = filterSectionsByVisibility(sections, [POD_A, POD_B], [POD_B, POD_C]);
+    expect(out.shared.content).toBe('pod bio');
+  });
+
+  it('strips pod sections when there is no pod overlap', () => {
+    const sections = { shared: sec('pod bio', 'pod') };
+    const out = filterSectionsByVisibility(sections, [POD_A], [POD_B, POD_C]);
+    expect(out.shared).toBeUndefined();
+  });
+
+  it('NEVER returns private sections — even when requester and owner share every pod', () => {
+    const sections = {
+      long_term: sec('curated secrets', 'private'),
+      soul: sec('who I am', 'private'),
+    };
+    const out = filterSectionsByVisibility(
+      sections,
+      [POD_A, POD_B, POD_C],
+      [POD_A, POD_B, POD_C],
+    );
+    expect(out.long_term).toBeUndefined();
+    expect(out.soul).toBeUndefined();
+  });
+
+  it('treats missing visibility as private (defensive default)', () => {
+    const sections = {
+      // Section with NO visibility set — older record / pre-Phase-4 state.
+      long_term: { content: 'unknown viz', updatedAt: new Date(), byteSize: 11 },
+    };
+    const out = filterSectionsByVisibility(sections, [POD_A], [POD_A]);
+    expect(out.long_term).toBeUndefined();
+  });
+
+  it('treats unknown visibility values as private (defense in depth)', () => {
+    const sections = {
+      // A section that somehow ended up with an invalid visibility — corrupt
+      // DB row, malicious write that bypassed validation, etc. The filter
+      // must default to "deny," not "allow."
+      shared: { content: 'invalid', visibility: 'everyone', updatedAt: new Date(), byteSize: 7 },
+    };
+    const out = filterSectionsByVisibility(sections, [POD_A], [POD_A]);
+    expect(out.shared).toBeUndefined();
+  });
+
+  it('mixes section visibilities correctly in one envelope', () => {
+    const sections = {
+      soul: sec('private soul', 'private'),
+      long_term: sec('public long_term', 'public'),
+      shared: sec('pod shared', 'pod'),
+      dedup_state: sec('private dedup', 'private'),
+    };
+    const out = filterSectionsByVisibility(sections, [POD_A], [POD_A]);
+    expect(out.soul).toBeUndefined();
+    expect(out.long_term.content).toBe('public long_term');
+    expect(out.shared.content).toBe('pod shared');
+    expect(out.dedup_state).toBeUndefined();
+  });
+
+  it('handles ghost installations (owner has no pods at all)', () => {
+    // Edge case: owner's AgentInstallation rows are gone (uninstalled or
+    // never existed), but the AgentMemory row survives (per ADR-003 invariant
+    // 7). A 'pod' visibility section MUST NOT leak just because no pod context
+    // can be established to deny it.
+    const sections = { shared: sec('pod bio', 'pod') };
+    const out = filterSectionsByVisibility(sections, [POD_A], []);
+    expect(out.shared).toBeUndefined();
+  });
+
+  it('handles requester with no authorized pods', () => {
+    // Requester somehow has no authorized pods (fresh agent, all installs
+    // uninstalled). 'pod' sections must not leak.
+    const sections = { shared: sec('pod bio', 'pod') };
+    const out = filterSectionsByVisibility(sections, [], [POD_A]);
+    expect(out.shared).toBeUndefined();
+  });
+
+  it('filters daily[] entries element-wise', () => {
+    const sections = {
+      daily: [
+        { date: '2026-04-12', content: 'public day', visibility: 'public' },
+        { date: '2026-04-13', content: 'private day', visibility: 'private' },
+        { date: '2026-04-14', content: 'pod day', visibility: 'pod' },
+        { date: '2026-04-15', content: 'no viz day' }, // missing visibility
+      ],
+    };
+    const out = filterSectionsByVisibility(sections, [POD_A], [POD_A]);
+    const dates = out.daily.map((d) => d.date);
+    expect(dates).toEqual(['2026-04-12', '2026-04-14']);
+  });
+
+  it('omits daily[] entirely when no entry survives filtering', () => {
+    const sections = {
+      daily: [
+        { date: '2026-04-12', content: 'p', visibility: 'private' },
+        { date: '2026-04-13', content: 'p', visibility: 'private' },
+      ],
+    };
+    const out = filterSectionsByVisibility(sections, [POD_A], [POD_A]);
+    expect(out.daily).toBeUndefined();
+  });
+
+  it('filters relationships[] entries element-wise', () => {
+    const sections = {
+      relationships: [
+        {
+          otherInstanceId: 'nova',
+          notes: 'public note',
+          visibility: 'public',
+          updatedAt: new Date(),
+        },
+        {
+          otherInstanceId: 'theo',
+          notes: 'private note',
+          visibility: 'private',
+          updatedAt: new Date(),
+        },
+        {
+          otherInstanceId: 'liz',
+          notes: 'pod note',
+          visibility: 'pod',
+          updatedAt: new Date(),
+        },
+      ],
+    };
+    const out = filterSectionsByVisibility(sections, [POD_A], [POD_A]);
+    const ids = out.relationships.map((r) => r.otherInstanceId);
+    expect(ids).toEqual(['nova', 'liz']);
+  });
+
+  it('omits relationships[] entirely when no entry survives filtering', () => {
+    const sections = {
+      relationships: [
+        {
+          otherInstanceId: 'nova',
+          notes: 'p',
+          visibility: 'pod',
+          updatedAt: new Date(),
+        },
+      ],
+    };
+    const out = filterSectionsByVisibility(sections, [POD_A], [POD_B]); // no overlap
+    expect(out.relationships).toBeUndefined();
+  });
+
+  it('does not mutate the input sections object', () => {
+    const sections = {
+      long_term: sec('private secret', 'private'),
+      shared: sec('public bio', 'public'),
+      daily: [
+        { date: '2026-04-12', content: 'pub', visibility: 'public' },
+        { date: '2026-04-13', content: 'priv', visibility: 'private' },
+      ],
+    };
+    const snapshot = JSON.stringify(sections);
+    filterSectionsByVisibility(sections, [POD_A], [POD_A]);
+    expect(JSON.stringify(sections)).toBe(snapshot);
+  });
+
+  it('coerces ObjectId-like strings via String() — works with mongoose ids', () => {
+    // Real call sites pass ObjectId.toString() values; defend against
+    // accidental object-shaped pod ids too (Set membership uses String()).
+    const sections = { shared: sec('pod bio', 'pod') };
+    // ObjectId-shaped object (mongoose returns these when not converted)
+    const podObj = { toString: () => POD_A };
+    const out = filterSectionsByVisibility(sections, [POD_A], [podObj]);
+    expect(out.shared.content).toBe('pod bio');
+  });
+
+  it('ignores null/undefined entries in pod arrays defensively', () => {
+    const sections = { shared: sec('pod bio', 'pod') };
+    const out = filterSectionsByVisibility(
+      sections,
+      [null, POD_A, undefined],
+      [undefined, POD_A, null],
+    );
+    expect(out.shared.content).toBe('pod bio');
+  });
+});

--- a/backend/middleware/agentRateLimit.ts
+++ b/backend/middleware/agentRateLimit.ts
@@ -1,44 +1,32 @@
 /**
- * Per-agent-token rate limit middleware.
+ * Per-agent-token rate limit middleware (ADR-003 Phase 4).
  *
- * ADR-003 Phase 4 added three new agent-runtime routes (memory/shared,
- * pods/:id/ask, asks/:id/respond). The `ask` route already throttles at the
- * service layer (30/hour per fromAgent+podId), but the read-shared and
- * respond routes had no DoS bound — a compromised agent token could spam
- * either endpoint to drain DB read capacity or saturate the event queue.
+ * Three new agent-runtime routes (memory/shared, pods/:id/ask, asks/:id/respond)
+ * needed an outer DoS bound. The `ask` path also throttles inside the service
+ * (30/hour per agent+podId); this middleware is the wider per-token cap that
+ * also covers the read-shared and respond routes.
  *
- * Pattern: in-memory fixed-window counter keyed by the SHA-256 hash of the
- * bearer token (req.agentTokenHash, set by agentRuntimeAuth). Hashing keeps
- * the raw token out of process memory and makes the key stable across
- * subdomain-routed requests.
+ * Implemented on top of `express-rate-limit` because (a) it's the de-facto
+ * standard middleware that static analysis (CodeQL `js/missing-rate-limiting`)
+ * recognizes, and (b) it handles edge cases (clock skew, header serialization,
+ * IPv6 normalization) we'd otherwise re-derive.
  *
- * Tradeoffs intentionally accepted for Phase 4:
- *   - Memory-only — counters reset on backend restart. Acceptable: bypass
- *     requires the attacker to outlive a pod restart, which is itself a
- *     coarser DoS concern handled elsewhere (k8s liveness, OOM kill).
- *   - Per-pod scope is NOT factored in — the limit is per token globally
- *     across pods. This is intentionally conservative: a compromised token
- *     SHOULD be choked across all surfaces, not just the current pod.
- *   - No Redis / cluster-coordinated state. Backend currently runs single-
- *     replica per environment (replicaCount: 1 in values-dev.yaml). When
- *     scaling >1 replicas, swap the in-memory map for a shared store.
+ * Key strategy: prefer the SHA-256 hash of the bearer token (set by
+ * agentRuntimeAuth as `req.agentTokenHash`). Fall back to hashing the
+ * Authorization header itself, then to the remote IP. Hashing keeps the raw
+ * token out of in-memory state.
+ *
+ * Single-replica assumption: the in-memory MemoryStore matches the current
+ * deployment (replicaCount: 1 in values-dev.yaml). When scaling backend >1,
+ * swap the store for `rate-limit-redis` or similar — the keyGenerator stays
+ * unchanged.
  */
 
-import type { Request, Response, NextFunction } from 'express';
+import type { Request, Response, RequestHandler } from 'express';
 import { createHash } from 'crypto';
-
-interface CounterEntry {
-  count: number;
-  windowStart: number;
-}
-
-const counters = new Map<string, CounterEntry>();
+import rateLimit from 'express-rate-limit';
 
 const tokenKey = (req: Request): string => {
-  // agentRuntimeAuth populates these; falling back to remote IP keeps the
-  // limiter defensive even if the middleware order ever shifts (e.g.
-  // someone wires the rate limit BEFORE auth and a malformed request slips
-  // through).
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const r = req as any;
   if (r.agentTokenHash) return `tok:${r.agentTokenHash}`;
@@ -49,54 +37,29 @@ const tokenKey = (req: Request): string => {
   return `ip:${req.ip || 'unknown'}`;
 };
 
-const sweep = (now: number, windowMs: number): void => {
-  // Best-effort cleanup of stale entries so the map doesn't grow unbounded
-  // for tokens that fire once and never return. Cheap because we only sweep
-  // when the map crosses a soft cap.
-  if (counters.size < 10_000) return;
-  for (const [k, v] of counters) {
-    if (now - v.windowStart > windowMs * 2) counters.delete(k);
-  }
-};
-
 export const agentRateLimit = (
   opts: { windowMs?: number; max?: number } = {},
-) => {
-  const windowMs = Math.max(1000, opts.windowMs ?? 60_000);
-  const max = Math.max(1, opts.max ?? 60);
-
-  return (req: Request, res: Response, next: NextFunction): void => {
-    const key = tokenKey(req);
-    const now = Date.now();
-    const entry = counters.get(key);
-    if (!entry || now - entry.windowStart >= windowMs) {
-      counters.set(key, { count: 1, windowStart: now });
-      sweep(now, windowMs);
-      next();
-      return;
-    }
-    entry.count += 1;
-    if (entry.count > max) {
-      const retryAfter = Math.max(1, Math.ceil((windowMs - (now - entry.windowStart)) / 1000));
-      res.setHeader('Retry-After', String(retryAfter));
-      res.status(429).json({
-        message: `rate limit exceeded: ${max} requests per ${Math.round(windowMs / 1000)}s`,
-        code: 'rate_limited',
-        retryAfter,
-      });
-      return;
-    }
-    next();
-  };
-};
-
-// Test-only escape hatch — no production path uses this.
-export const __resetAgentRateLimit = () => counters.clear();
+): RequestHandler => rateLimit({
+  windowMs: Math.max(1000, opts.windowMs ?? 60_000),
+  max: Math.max(1, opts.max ?? 60),
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: tokenKey,
+  handler: (req: Request, res: Response) => {
+    const limit = res.getHeader('RateLimit-Limit');
+    const reset = res.getHeader('RateLimit-Reset');
+    res.status(429).json({
+      message: `rate limit exceeded${limit ? `: ${limit} requests per window` : ''}`,
+      code: 'rate_limited',
+      retryAfter: typeof reset === 'string' || typeof reset === 'number' ? reset : undefined,
+    });
+  },
+});
 
 export default agentRateLimit;
 
-// CJS compat: let `require()` return the middleware factory directly while
-// still exposing the named helpers via the same module.exports surface.
+// CJS compat: let `require()` return the factory directly while still exposing
+// the named export through the same module.exports surface.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 module.exports = exports['default'];
 Object.assign(module.exports, exports);

--- a/backend/middleware/agentRateLimit.ts
+++ b/backend/middleware/agentRateLimit.ts
@@ -1,32 +1,22 @@
 /**
- * Per-agent-token rate limit middleware (ADR-003 Phase 4).
+ * Per-agent-token rate limit primitives (ADR-003 Phase 4).
  *
- * Three new agent-runtime routes (memory/shared, pods/:id/ask, asks/:id/respond)
- * needed an outer DoS bound. The `ask` path also throttles inside the service
- * (30/hour per agent+podId); this middleware is the wider per-token cap that
- * also covers the read-shared and respond routes.
- *
- * Implemented on top of `express-rate-limit` because (a) it's the de-facto
- * standard middleware that static analysis (CodeQL `js/missing-rate-limiting`)
- * recognizes, and (b) it handles edge cases (clock skew, header serialization,
- * IPv6 normalization) we'd otherwise re-derive.
+ * The actual `express-rate-limit` invocation lives inline in
+ * `routes/agentsRuntime.ts` so CodeQL's js/missing-rate-limiting query
+ * recognises the middleware against each route. This module exposes only
+ * the shared key generator — every Phase 4 limiter must use the same key
+ * shape so multiple routes share a per-token budget instead of stacking.
  *
  * Key strategy: prefer the SHA-256 hash of the bearer token (set by
  * agentRuntimeAuth as `req.agentTokenHash`). Fall back to hashing the
- * Authorization header itself, then to the remote IP. Hashing keeps the raw
- * token out of in-memory state.
- *
- * Single-replica assumption: the in-memory MemoryStore matches the current
- * deployment (replicaCount: 1 in values-dev.yaml). When scaling backend >1,
- * swap the store for `rate-limit-redis` or similar — the keyGenerator stays
- * unchanged.
+ * Authorization header itself, then to the remote IP. Hashing keeps the
+ * raw token out of in-memory state.
  */
 
-import type { Request, Response, RequestHandler } from 'express';
+import type { Request } from 'express';
 import { createHash } from 'crypto';
-import rateLimit from 'express-rate-limit';
 
-const tokenKey = (req: Request): string => {
+export const agentRateLimitKeyGenerator = (req: Request): string => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const r = req as any;
   if (r.agentTokenHash) return `tok:${r.agentTokenHash}`;
@@ -37,29 +27,6 @@ const tokenKey = (req: Request): string => {
   return `ip:${req.ip || 'unknown'}`;
 };
 
-export const agentRateLimit = (
-  opts: { windowMs?: number; max?: number } = {},
-): RequestHandler => rateLimit({
-  windowMs: Math.max(1000, opts.windowMs ?? 60_000),
-  max: Math.max(1, opts.max ?? 60),
-  standardHeaders: true,
-  legacyHeaders: false,
-  keyGenerator: tokenKey,
-  handler: (req: Request, res: Response) => {
-    const limit = res.getHeader('RateLimit-Limit');
-    const reset = res.getHeader('RateLimit-Reset');
-    res.status(429).json({
-      message: `rate limit exceeded${limit ? `: ${limit} requests per window` : ''}`,
-      code: 'rate_limited',
-      retryAfter: typeof reset === 'string' || typeof reset === 'number' ? reset : undefined,
-    });
-  },
-});
-
-export default agentRateLimit;
-
-// CJS compat: let `require()` return the factory directly while still exposing
-// the named export through the same module.exports surface.
+// CJS compat for the require()-style imports used elsewhere in backend/.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-module.exports = exports['default'];
-Object.assign(module.exports, exports);
+module.exports = { agentRateLimitKeyGenerator };

--- a/backend/middleware/agentRateLimit.ts
+++ b/backend/middleware/agentRateLimit.ts
@@ -1,0 +1,102 @@
+/**
+ * Per-agent-token rate limit middleware.
+ *
+ * ADR-003 Phase 4 added three new agent-runtime routes (memory/shared,
+ * pods/:id/ask, asks/:id/respond). The `ask` route already throttles at the
+ * service layer (30/hour per fromAgent+podId), but the read-shared and
+ * respond routes had no DoS bound — a compromised agent token could spam
+ * either endpoint to drain DB read capacity or saturate the event queue.
+ *
+ * Pattern: in-memory fixed-window counter keyed by the SHA-256 hash of the
+ * bearer token (req.agentTokenHash, set by agentRuntimeAuth). Hashing keeps
+ * the raw token out of process memory and makes the key stable across
+ * subdomain-routed requests.
+ *
+ * Tradeoffs intentionally accepted for Phase 4:
+ *   - Memory-only — counters reset on backend restart. Acceptable: bypass
+ *     requires the attacker to outlive a pod restart, which is itself a
+ *     coarser DoS concern handled elsewhere (k8s liveness, OOM kill).
+ *   - Per-pod scope is NOT factored in — the limit is per token globally
+ *     across pods. This is intentionally conservative: a compromised token
+ *     SHOULD be choked across all surfaces, not just the current pod.
+ *   - No Redis / cluster-coordinated state. Backend currently runs single-
+ *     replica per environment (replicaCount: 1 in values-dev.yaml). When
+ *     scaling >1 replicas, swap the in-memory map for a shared store.
+ */
+
+import type { Request, Response, NextFunction } from 'express';
+import { createHash } from 'crypto';
+
+interface CounterEntry {
+  count: number;
+  windowStart: number;
+}
+
+const counters = new Map<string, CounterEntry>();
+
+const tokenKey = (req: Request): string => {
+  // agentRuntimeAuth populates these; falling back to remote IP keeps the
+  // limiter defensive even if the middleware order ever shifts (e.g.
+  // someone wires the rate limit BEFORE auth and a malformed request slips
+  // through).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const r = req as any;
+  if (r.agentTokenHash) return `tok:${r.agentTokenHash}`;
+  const auth = req.headers?.authorization || req.headers?.['x-commonly-agent-token'];
+  if (typeof auth === 'string' && auth.length > 0) {
+    return `hdr:${createHash('sha256').update(auth).digest('hex')}`;
+  }
+  return `ip:${req.ip || 'unknown'}`;
+};
+
+const sweep = (now: number, windowMs: number): void => {
+  // Best-effort cleanup of stale entries so the map doesn't grow unbounded
+  // for tokens that fire once and never return. Cheap because we only sweep
+  // when the map crosses a soft cap.
+  if (counters.size < 10_000) return;
+  for (const [k, v] of counters) {
+    if (now - v.windowStart > windowMs * 2) counters.delete(k);
+  }
+};
+
+export const agentRateLimit = (
+  opts: { windowMs?: number; max?: number } = {},
+) => {
+  const windowMs = Math.max(1000, opts.windowMs ?? 60_000);
+  const max = Math.max(1, opts.max ?? 60);
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const key = tokenKey(req);
+    const now = Date.now();
+    const entry = counters.get(key);
+    if (!entry || now - entry.windowStart >= windowMs) {
+      counters.set(key, { count: 1, windowStart: now });
+      sweep(now, windowMs);
+      next();
+      return;
+    }
+    entry.count += 1;
+    if (entry.count > max) {
+      const retryAfter = Math.max(1, Math.ceil((windowMs - (now - entry.windowStart)) / 1000));
+      res.setHeader('Retry-After', String(retryAfter));
+      res.status(429).json({
+        message: `rate limit exceeded: ${max} requests per ${Math.round(windowMs / 1000)}s`,
+        code: 'rate_limited',
+        retryAfter,
+      });
+      return;
+    }
+    next();
+  };
+};
+
+// Test-only escape hatch — no production path uses this.
+export const __resetAgentRateLimit = () => counters.clear();
+
+export default agentRateLimit;
+
+// CJS compat: let `require()` return the middleware factory directly while
+// still exposing the named helpers via the same module.exports surface.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports['default'];
+Object.assign(module.exports, exports);

--- a/backend/models/AgentAsk.ts
+++ b/backend/models/AgentAsk.ts
@@ -1,0 +1,90 @@
+import mongoose, { Document, Model, Schema, Types } from 'mongoose';
+
+// ADR-003 Phase 4: cross-agent ask/respond. An "ask" is a structured DM
+// from agent A to agent B in the same pod, with a requestId so the
+// response can be routed back. The kernel records the open ask, fans the
+// `agent.ask` event to the target via AgentEventService, and waits for the
+// target to call `respondToAsk(requestId, content)` — which fans the
+// `agent.ask.response` event back to the original sender.
+//
+// Stored as its own collection (not on AgentEvent) so:
+//   - the open/responded/expired lifecycle is queryable independently
+//   - the response can be looked up by requestId without scanning events
+//   - TTL on expiresAt cleans up stale asks without touching events
+
+export type AgentAskStatus = 'open' | 'responded' | 'expired';
+
+export interface IAgentAsk extends Document {
+  requestId: string;
+  podId: Types.ObjectId;
+  fromAgent: string;
+  fromInstanceId: string;
+  targetAgent: string;
+  targetInstanceId: string;
+  question: string;
+  status: AgentAskStatus;
+  response?: string;
+  createdAt: Date;
+  respondedAt?: Date;
+  expiresAt: Date;
+  updatedAt: Date;
+}
+
+const AgentAskSchema = new Schema<IAgentAsk>(
+  {
+    // requestId is caller-controlled. Bound the length so a misbehaving
+    // (or compromised) agent token can't push 10MB strings into a unique
+    // index. Validation also lives in the service before insert; the schema
+    // bound is the last line of defense for any code path that bypasses it.
+    requestId: {
+      type: String, required: true, unique: true, index: true, maxlength: 128,
+    },
+    podId: { type: Schema.Types.ObjectId, ref: 'Pod', required: true },
+    // All agent + instance identifiers are normalized at write time so the
+    // case-sensitive comparison in `respondToAsk` (responderAgent ===
+    // ask.targetAgent && responderInstance === ask.targetInstanceId) never
+    // wedges on case drift. Service-layer normalization is defense in depth;
+    // the schema is the authoritative normalization point.
+    fromAgent: { type: String, required: true, lowercase: true, trim: true },
+    fromInstanceId: {
+      type: String, default: 'default', lowercase: true, trim: true,
+    },
+    targetAgent: { type: String, required: true, lowercase: true, trim: true },
+    targetInstanceId: {
+      type: String, default: 'default', lowercase: true, trim: true,
+    },
+    question: { type: String, required: true },
+    status: {
+      type: String,
+      enum: ['open', 'responded', 'expired'],
+      default: 'open',
+    },
+    response: { type: String },
+    respondedAt: { type: Date },
+    // 24h default TTL — Mongo's TTL monitor sweeps documents whose
+    // expiresAt has passed. Covers the "agent A asked, then disappeared"
+    // case so the collection doesn't grow unbounded.
+    expiresAt: {
+      type: Date,
+      required: true,
+      default: () => new Date(Date.now() + 24 * 60 * 60 * 1000),
+      index: { expireAfterSeconds: 0 },
+    },
+  },
+  { timestamps: true },
+);
+
+// Pod-scoped queries (e.g. "show me open asks I've sent in this pod") and
+// rate-limit lookups (count asks fromAgent emitted in the last hour) both
+// hit this index. Keeping it composite avoids a separate single-field index
+// on podId (Mongo can prefix-match).
+AgentAskSchema.index({ podId: 1, status: 1 });
+AgentAskSchema.index({ fromAgent: 1, fromInstanceId: 1, createdAt: -1 });
+
+const AgentAsk: Model<IAgentAsk> = (mongoose.models.AgentAsk as Model<IAgentAsk>)
+  || mongoose.model<IAgentAsk>('AgentAsk', AgentAskSchema);
+
+export default AgentAsk;
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/models/AgentEvent.ts
+++ b/backend/models/AgentEvent.ts
@@ -3,6 +3,39 @@ import mongoose, { Document, Model, Schema, Types } from 'mongoose';
 export type AgentEventStatus = 'pending' | 'delivered' | 'failed';
 export type DeliveryOutcome = 'acknowledged' | 'posted' | 'no_action' | 'skipped' | 'error';
 
+// ADR-003 Phase 4: cross-agent ask/respond payloads. The `type` field on
+// AgentEvent is intentionally unconstrained (a plain String) so adding new
+// event types is additive — no schema migration required. These interfaces
+// document the payload contract for the two ask-related event types.
+
+/**
+ * Event type: 'agent.ask'
+ * Delivered to the TARGET agent of a `commonly_ask_agent` call.
+ * Payload shape:
+ */
+export interface IAgentAskEventPayload {
+  requestId: string;       // unique id; use to call POST /asks/:requestId/respond
+  fromAgent: string;       // sender agent name (lowercase)
+  fromInstanceId: string;  // sender instanceId
+  question: string;        // the question text
+  podId: string;           // string form of the pod id (same as event.podId)
+  expiresAt: string;       // ISO8601 — after this, respond() returns 410 Gone
+}
+
+/**
+ * Event type: 'agent.ask.response'
+ * Delivered to the ORIGINAL SENDER of an ask once the target responds.
+ * Payload shape:
+ */
+export interface IAgentAskResponseEventPayload {
+  requestId: string;       // matches the originating 'agent.ask' event
+  fromAgent: string;       // responder (the original ask target)
+  fromInstanceId: string;
+  question: string;        // echoed for context
+  response: string;        // the answer
+  podId: string;
+}
+
 export interface IAgentEventDelivery {
   outcome?: DeliveryOutcome;
   reason?: string;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "discord.js": "^14.20.0",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
+        "express-rate-limit": "^8.3.2",
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.0",
         "mongodb": "^6.3.0",
@@ -4864,6 +4865,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/extend": {
@@ -15092,6 +15120,21 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      }
+    },
+    "express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "requires": {
+        "ip-address": "10.1.0"
+      },
+      "dependencies": {
+        "ip-address": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+          "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="
+        }
       }
     },
     "extend": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
     "discord.js": "^14.20.0",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
+    "express-rate-limit": "^8.3.2",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.0",
     "mongodb": "^6.3.0",

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -18,6 +18,14 @@ const Post = require('../models/Post');
 const Pod = require('../models/Pod');
 const { AgentInstallation } = require('../models/AgentRegistry');
 const { requireApiTokenScopes } = require('../middleware/apiTokenScopes');
+const agentRateLimit = require('../middleware/agentRateLimit');
+
+// ADR-003 Phase 4: per-token rate limiter for the cross-agent surface.
+// Token-global (covers any pod the token is valid for). Complementary to the
+// per-(agent,podId) limit in agentAskService; this is the outer DoS bound.
+// 120/60s = generous for legitimate polling, low enough that a compromised
+// token can't drain DB read capacity.
+const phase4RateLimit = agentRateLimit({ windowMs: 60_000, max: 120 });
 
 const Integration = require('../models/Integration');
 const AgentMemory = require('../models/AgentMemory');
@@ -2193,6 +2201,7 @@ router.post('/pods/:podId/integrations/:integrationId/publish', agentRuntimeAuth
 router.get(
   '/memory/shared/:agentName/:instanceId?',
   agentRuntimeAuth,
+  phase4RateLimit,
   async (req: any, res: any) => {
     try {
       const targetAgent = String(req.params.agentName || '').trim().toLowerCase();
@@ -2280,7 +2289,7 @@ router.get(
  * podId). This prevents an agent from asking across pods it doesn't share
  * with the target.
  */
-router.post('/pods/:podId/ask', agentRuntimeAuth, async (req: any, res: any) => {
+router.post('/pods/:podId/ask', agentRuntimeAuth, phase4RateLimit, async (req: any, res: any) => {
   try {
     const podId = String(req.params.podId || '').trim();
     if (!podId) return res.status(400).json({ message: 'podId is required' });
@@ -2341,7 +2350,7 @@ router.post('/pods/:podId/ask', agentRuntimeAuth, async (req: any, res: any) => 
  * Only the agent identity that the ask was originally targeted at may
  * respond — enforced inside AgentAskService.respondToAsk.
  */
-router.post('/asks/:requestId/respond', agentRuntimeAuth, async (req: any, res: any) => {
+router.post('/asks/:requestId/respond', agentRuntimeAuth, phase4RateLimit, async (req: any, res: any) => {
   try {
     const requestId = String(req.params.requestId || '').trim();
     if (!requestId) return res.status(400).json({ message: 'requestId is required' });

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -18,14 +18,31 @@ const Post = require('../models/Post');
 const Pod = require('../models/Pod');
 const { AgentInstallation } = require('../models/AgentRegistry');
 const { requireApiTokenScopes } = require('../middleware/apiTokenScopes');
-const agentRateLimit = require('../middleware/agentRateLimit');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const rateLimit = require('express-rate-limit');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { agentRateLimitKeyGenerator } = require('../middleware/agentRateLimit');
 
 // ADR-003 Phase 4: per-token rate limiter for the cross-agent surface.
 // Token-global (covers any pod the token is valid for). Complementary to the
 // per-(agent,podId) limit in agentAskService; this is the outer DoS bound.
 // 120/60s = generous for legitimate polling, low enough that a compromised
 // token can't drain DB read capacity.
-const phase4RateLimit = agentRateLimit({ windowMs: 60_000, max: 120 });
+//
+// Inlined here (not behind a factory) so CodeQL's `js/missing-rate-limiting`
+// query — which only recognises direct express-rate-limit invocations in the
+// same file as the route registration — sees the middleware on each route.
+const phase4RateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: agentRateLimitKeyGenerator,
+  handler: (_req: any, res: any) => res.status(429).json({
+    message: 'rate limit exceeded: 120 requests per 60s',
+    code: 'rate_limited',
+  }),
+});
 
 const Integration = require('../models/Integration');
 const AgentMemory = require('../models/AgentMemory');

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -27,7 +27,9 @@ const {
   mergePatchSections,
   computeSyncDedupKey,
   isValidYMD,
+  filterSectionsByVisibility,
 } = require('../services/agentMemoryService');
+const AgentAskService = require('../services/agentAskService');
 const DMService = require('../services/dmService');
 const ChatSummarizerService = require('../services/chatSummarizerService');
 const AgentMentionService = require('../services/agentMentionService');
@@ -2164,6 +2166,213 @@ router.post('/pods/:podId/integrations/:integrationId/publish', agentRuntimeAuth
   } catch (error: any) {
     console.error('Error publishing via integration for agent:', error);
     return res.status(500).json({ message: (error as Error).message || 'Failed to publish via integration' });
+  }
+});
+
+// ===========================================================================
+// ADR-003 Phase 4 — cross-agent primitives
+// ===========================================================================
+
+/**
+ * GET /memory/shared/:agentName/:instanceId? (agent runtime token auth)
+ *
+ * ADR-003 Phase 4. Read another agent's envelope, filtered by visibility:
+ *   - 'public' sections always returned
+ *   - 'pod' sections returned only if requester ∩ owner pods is non-empty
+ *   - 'private' sections NEVER returned (owner reads via /memory)
+ *
+ * For array sections (`daily[]`, `relationships[]`), filtering is per-element.
+ * Returns `sharedPods` so the caller knows which pods grounded the access.
+ *
+ * URL shape rationale: chose `/memory/shared/...` over a separate top-level
+ * `/agents/:name/...` route because (a) it groups with the existing memory
+ * surface (GET /memory, PUT /memory, POST /memory/sync), (b) it makes the
+ * "shared view" framing explicit in the path — never ambiguous with the
+ * owner's own /memory read.
+ */
+router.get(
+  '/memory/shared/:agentName/:instanceId?',
+  agentRuntimeAuth,
+  async (req: any, res: any) => {
+    try {
+      const targetAgent = String(req.params.agentName || '').trim().toLowerCase();
+      const targetInstanceId = String(req.params.instanceId || 'default').trim() || 'default';
+      if (!targetAgent) {
+        return res.status(400).json({ message: 'agentName is required' });
+      }
+
+      const requester = resolveMemoryIdentity(req);
+      const requesterAuthorizedPodIds = Array.isArray(req.agentAuthorizedPodIds)
+        ? (req.agentAuthorizedPodIds as string[])
+        : [];
+
+      const record = await AgentMemory.findOne({
+        agentName: targetAgent,
+        instanceId: targetInstanceId,
+      }).lean();
+      if (!record) {
+        return res.status(404).json({ message: 'agent memory not found' });
+      }
+
+      // Owner reading their own envelope through this route still gets the
+      // visibility-filtered view — by design. Owners use GET /memory for the
+      // full envelope. This keeps the contract for /memory/shared simple:
+      // never returns private data, period.
+      const ownerInstallations = await AgentInstallation.find({
+        agentName: targetAgent,
+        instanceId: targetInstanceId,
+        status: 'active',
+      }).select('podId').lean();
+      const ownerPodIds = (ownerInstallations as Array<{ podId?: any }>)
+        .map((i) => (i?.podId ? String(i.podId) : ''))
+        .filter(Boolean);
+
+      const sharedPods = (requesterAuthorizedPodIds || [])
+        .filter((p) => p && ownerPodIds.includes(String(p)))
+        .map(String);
+
+      const filteredSections = filterSectionsByVisibility(
+        record.sections,
+        requesterAuthorizedPodIds,
+        ownerPodIds,
+      );
+
+      return res.json({
+        agentName: targetAgent,
+        instanceId: targetInstanceId,
+        sections: filteredSections,
+        sharedPods,
+        // sourceRuntime is metadata about who wrote the envelope, not user
+        // content — exposing it tells the requester which driver an agent
+        // runs under, which is a publicly-relevant fact (no privacy leak).
+        sourceRuntime: record.sourceRuntime,
+        schemaVersion: record.schemaVersion,
+        // Echo requester identity for debuggability — useful when an agent's
+        // logs show "got {} back" and they want to confirm who they were.
+        requester: {
+          agentName: requester?.agentName,
+          instanceId: requester?.instanceId,
+        },
+      });
+    } catch (err: any) {
+      console.error('GET /memory/shared error:', err);
+      return res.status(500).json({ message: 'Failed to read shared memory' });
+    }
+  },
+);
+
+/**
+ * POST /pods/:podId/ask (agent runtime token auth)
+ *
+ * ADR-003 Phase 4. Cross-agent ask. Body:
+ *   {
+ *     targetAgent: string,
+ *     targetInstanceId?: string,    // defaults to 'default'
+ *     question: string,
+ *     requestId?: string,           // server generates if omitted
+ *   }
+ *
+ * Returns: { requestId, expiresAt }. The target agent receives an
+ * `agent.ask` event; they call POST /asks/:requestId/respond when ready.
+ *
+ * The route requires the caller to be a participant in the named pod
+ * (their AgentInstallation podIds, set by agentRuntimeAuth, must include
+ * podId). This prevents an agent from asking across pods it doesn't share
+ * with the target.
+ */
+router.post('/pods/:podId/ask', agentRuntimeAuth, async (req: any, res: any) => {
+  try {
+    const podId = String(req.params.podId || '').trim();
+    if (!podId) return res.status(400).json({ message: 'podId is required' });
+
+    const authorized = Array.isArray(req.agentAuthorizedPodIds)
+      ? (req.agentAuthorizedPodIds as string[])
+      : [];
+    if (!authorized.map(String).includes(podId)) {
+      return res.status(403).json({ message: 'agent is not a member of this pod' });
+    }
+
+    const sender = resolveMemoryIdentity(req);
+    if (!sender?.agentName) {
+      return res.status(403).json({ message: 'Could not resolve agent identity' });
+    }
+
+    const { targetAgent, targetInstanceId, question, requestId } = req.body || {};
+    if (typeof targetAgent !== 'string' || !targetAgent.trim()) {
+      return res.status(400).json({ message: 'targetAgent is required' });
+    }
+    if (typeof question !== 'string' || !question.trim()) {
+      return res.status(400).json({ message: 'question is required' });
+    }
+    if (targetInstanceId !== undefined && typeof targetInstanceId !== 'string') {
+      return res.status(400).json({ message: 'targetInstanceId must be a string' });
+    }
+    if (requestId !== undefined && typeof requestId !== 'string') {
+      return res.status(400).json({ message: 'requestId must be a string' });
+    }
+
+    try {
+      const result = await AgentAskService.askAgent({
+        fromAgent: sender.agentName,
+        fromInstanceId: sender.instanceId,
+        podId,
+        targetAgent,
+        targetInstanceId,
+        question,
+        requestId,
+      });
+      return res.json({ requestId: result.requestId, expiresAt: result.expiresAt });
+    } catch (askErr: any) {
+      if (askErr instanceof AgentAskService.AgentAskError) {
+        return res.status(askErr.status).json({ message: askErr.message, code: askErr.code });
+      }
+      throw askErr;
+    }
+  } catch (err: any) {
+    console.error('POST /pods/:podId/ask error:', err);
+    return res.status(500).json({ message: 'Failed to ask agent' });
+  }
+});
+
+/**
+ * POST /asks/:requestId/respond (agent runtime token auth)
+ *
+ * ADR-003 Phase 4. Respond to an open ask. Body: { content: string }.
+ * Only the agent identity that the ask was originally targeted at may
+ * respond — enforced inside AgentAskService.respondToAsk.
+ */
+router.post('/asks/:requestId/respond', agentRuntimeAuth, async (req: any, res: any) => {
+  try {
+    const requestId = String(req.params.requestId || '').trim();
+    if (!requestId) return res.status(400).json({ message: 'requestId is required' });
+
+    const responder = resolveMemoryIdentity(req);
+    if (!responder?.agentName) {
+      return res.status(403).json({ message: 'Could not resolve agent identity' });
+    }
+
+    const { content } = req.body || {};
+    if (typeof content !== 'string' || !content.trim()) {
+      return res.status(400).json({ message: 'content is required' });
+    }
+
+    try {
+      await AgentAskService.respondToAsk({
+        fromAgent: responder.agentName,
+        fromInstanceId: responder.instanceId,
+        requestId,
+        content,
+      });
+      return res.json({ ok: true });
+    } catch (respondErr: any) {
+      if (respondErr instanceof AgentAskService.AgentAskError) {
+        return res.status(respondErr.status).json({ message: respondErr.message, code: respondErr.code });
+      }
+      throw respondErr;
+    }
+  } catch (err: any) {
+    console.error('POST /asks/:requestId/respond error:', err);
+    return res.status(500).json({ message: 'Failed to respond to ask' });
   }
 });
 

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -1,5 +1,11 @@
 export {};
 
+// ADR-003 Phase 4: ESM import for express-rate-limit (the rest of this file
+// uses CJS require()). CodeQL's js/missing-rate-limiting query recognises the
+// ESM import shape but has trouble tracing rate-limit middleware through
+// require() returns; using `import` here makes the recognition unambiguous.
+import rateLimit from 'express-rate-limit';
+
 const express = require('express');
 
 const agentRuntimeAuth = require('../middleware/agentRuntimeAuth');
@@ -18,8 +24,6 @@ const Post = require('../models/Post');
 const Pod = require('../models/Pod');
 const { AgentInstallation } = require('../models/AgentRegistry');
 const { requireApiTokenScopes } = require('../middleware/apiTokenScopes');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const rateLimit = require('express-rate-limit');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { agentRateLimitKeyGenerator } = require('../middleware/agentRateLimit');
 

--- a/backend/services/agentAskService.ts
+++ b/backend/services/agentAskService.ts
@@ -1,0 +1,298 @@
+// ADR-003 Phase 4: cross-agent ask/respond primitive.
+//
+// Surface (called from routes; not directly by drivers):
+//   askAgent({ fromAgent, fromInstanceId, podId, targetAgent, targetInstanceId?, question, requestId?, timeoutMs? })
+//   respondToAsk({ fromAgent, fromInstanceId, requestId, content })
+//
+// Failure modes (all thrown as AgentAskError so the route can map to HTTP):
+//   - target agent not installed in pod                           → 404
+//   - self-ask (fromAgent === targetAgent within same instanceId) → 400
+//   - rate limit exceeded                                         → 429
+//   - respond() called with unknown / expired requestId           → 404 / 410
+//   - respond() called by an agent other than the original target → 403
+//
+// Self-ask guard: replicates the `agentMentionService.enqueueMentions`
+// pattern. Both agentName and instanceId are normalized — agentName via
+// .toLowerCase(), instanceId by defaulting null/undefined to 'default'. An
+// agent cannot ask itself (would create the same chat.mention → reply loop
+// the mention service guards against).
+
+import crypto from 'crypto';
+
+// eslint-disable-next-line global-require
+const AgentEventService = require('./agentEventService');
+// eslint-disable-next-line global-require
+const { AgentInstallation } = require('../models/AgentRegistry');
+// eslint-disable-next-line global-require
+const AgentAsk = require('../models/AgentAsk');
+
+// Per-(fromAgent, podId) cap to prevent runaway loops between agents. Keyed
+// only by agent NAME (not name+instance) so an attacker can't trivially
+// bypass the cap by varying instanceId on the from side. The pod is part of
+// the key so a chatty agent in one pod doesn't block its work in another.
+const ASK_RATE_LIMIT_PER_HOUR = Math.max(
+  1,
+  Number.parseInt(process.env.AGENT_ASK_RATE_LIMIT_PER_HOUR || '', 10) || 30,
+);
+const ASK_RATE_WINDOW_MS = 60 * 60 * 1000;
+const DEFAULT_EXPIRY_MS = 24 * 60 * 60 * 1000;
+
+export class AgentAskError extends Error {
+  status: number;
+
+  code: string;
+
+  constructor(message: string, status: number, code: string) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+interface AskAgentOptions {
+  fromAgent: string;
+  fromInstanceId?: string;
+  podId: string;
+  targetAgent: string;
+  targetInstanceId?: string;
+  question: string;
+  requestId?: string;
+  timeoutMs?: number;
+}
+
+interface AskAgentResult {
+  requestId: string;
+  expiresAt: Date;
+}
+
+interface RespondToAskOptions {
+  fromAgent: string;        // the responder — the original ASK TARGET
+  fromInstanceId?: string;
+  requestId: string;
+  content: string;
+}
+
+const normalizeAgent = (s: string): string => String(s || '').trim().toLowerCase();
+const normalizeInstance = (s: string | undefined | null): string => {
+  const v = String(s ?? '').trim();
+  return v || 'default';
+};
+
+const sameIdentity = (
+  a: { agentName: string; instanceId: string },
+  b: { agentName: string; instanceId: string },
+): boolean => (
+  a.agentName === b.agentName && a.instanceId === b.instanceId
+);
+
+export async function askAgent(opts: AskAgentOptions): Promise<AskAgentResult> {
+  const fromAgent = normalizeAgent(opts.fromAgent);
+  const fromInstanceId = normalizeInstance(opts.fromInstanceId);
+  const targetAgent = normalizeAgent(opts.targetAgent);
+  const targetInstanceId = normalizeInstance(opts.targetInstanceId);
+  const podId = String(opts.podId || '').trim();
+  const question = String(opts.question || '').trim();
+
+  if (!fromAgent) throw new AgentAskError('fromAgent is required', 400, 'fromAgent_required');
+  if (!targetAgent) throw new AgentAskError('targetAgent is required', 400, 'targetAgent_required');
+  if (!podId) throw new AgentAskError('podId is required', 400, 'podId_required');
+  if (!question) throw new AgentAskError('question is required', 400, 'question_required');
+
+  // Self-ask guard. Mirrors agentMentionService self-mention pattern: any
+  // agent whose reply echoes its own handle would otherwise trigger an
+  // infinite ask → respond → ask loop. Refuse at the source.
+  if (sameIdentity(
+    { agentName: fromAgent, instanceId: fromInstanceId },
+    { agentName: targetAgent, instanceId: targetInstanceId },
+  )) {
+    throw new AgentAskError(
+      'cannot ask yourself — sender and target resolve to the same agent identity',
+      400,
+      'self_ask',
+    );
+  }
+
+  // Same-pod requirement: target must have an active AgentInstallation in
+  // this pod. Without this, agents could send asks across pods they aren't
+  // members of together — that breaks the social model where pod
+  // membership is the authorization unit (see ADR-001).
+  const targetInstallation = await AgentInstallation.findOne({
+    agentName: targetAgent,
+    instanceId: targetInstanceId,
+    podId,
+    status: 'active',
+  }).lean();
+  if (!targetInstallation) {
+    throw new AgentAskError(
+      `target agent ${targetAgent}:${targetInstanceId} is not installed in this pod`,
+      404,
+      'target_not_in_pod',
+    );
+  }
+
+  // Rate limit. Keyed by (fromAgent, podId) — NOT (fromAgent, instanceId,
+  // podId). The instanceId is excluded from the key so a misbehaving agent
+  // can't churn through instanceIds to bypass.
+  const since = new Date(Date.now() - ASK_RATE_WINDOW_MS);
+  const recentCount = await AgentAsk.countDocuments({
+    fromAgent,
+    podId,
+    createdAt: { $gte: since },
+  });
+  if (recentCount >= ASK_RATE_LIMIT_PER_HOUR) {
+    throw new AgentAskError(
+      `rate limit exceeded: ${ASK_RATE_LIMIT_PER_HOUR} asks per hour from ${fromAgent} in this pod`,
+      429,
+      'rate_limited',
+    );
+  }
+
+  const requestId = String(opts.requestId || '').trim() || crypto.randomUUID();
+  // Bound the requestId before the DB write. Mongo's unique index would
+  // happily store a 10MB string supplied by a compromised agent token;
+  // 128 chars is plenty for UUIDs, ULIDs, or short human-readable ids.
+  // Also reject control characters — they break log scanning + URL paths.
+  if (requestId.length > 128) {
+    throw new AgentAskError(
+      `requestId must be ≤128 chars (got ${requestId.length})`,
+      400,
+      'invalid_request_id',
+    );
+  }
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(requestId)) {
+    throw new AgentAskError(
+      'requestId must not contain control characters',
+      400,
+      'invalid_request_id',
+    );
+  }
+  const expiresAt = new Date(Date.now() + Math.max(60_000, opts.timeoutMs || DEFAULT_EXPIRY_MS));
+
+  // Create the ask record first. If the create succeeds but the event
+  // enqueue fails, the ask is still recorded — TTL will GC it. Better to
+  // have a record without delivery than the reverse.
+  let ask;
+  try {
+    ask = await AgentAsk.create({
+      requestId,
+      podId,
+      fromAgent,
+      fromInstanceId,
+      targetAgent,
+      targetInstanceId,
+      question,
+      status: 'open',
+      expiresAt,
+    });
+  } catch (err: any) {
+    // Duplicate requestId → caller supplied a clashing one. Map to 409.
+    if (err?.code === 11000) {
+      throw new AgentAskError(
+        'requestId already exists; use a fresh one',
+        409,
+        'duplicate_request',
+      );
+    }
+    throw err;
+  }
+
+  await AgentEventService.enqueue({
+    agentName: targetAgent,
+    instanceId: targetInstanceId,
+    podId,
+    type: 'agent.ask',
+    payload: {
+      requestId,
+      fromAgent,
+      fromInstanceId,
+      question,
+      podId: String(podId),
+      expiresAt: expiresAt.toISOString(),
+    },
+  });
+
+  return { requestId: ask.requestId, expiresAt: ask.expiresAt };
+}
+
+export async function respondToAsk(opts: RespondToAskOptions): Promise<void> {
+  const responderAgent = normalizeAgent(opts.fromAgent);
+  const responderInstance = normalizeInstance(opts.fromInstanceId);
+  const requestId = String(opts.requestId || '').trim();
+  const content = String(opts.content || '').trim();
+
+  if (!requestId) throw new AgentAskError('requestId is required', 400, 'requestId_required');
+  if (!content) throw new AgentAskError('content is required', 400, 'content_required');
+
+  const ask = await AgentAsk.findOne({ requestId });
+  if (!ask) {
+    throw new AgentAskError('no ask found for that requestId', 404, 'ask_not_found');
+  }
+
+  if (ask.status === 'expired' || ask.expiresAt < new Date()) {
+    // Defensive: status may still be 'open' if the TTL hasn't fired yet.
+    if (ask.status !== 'expired') {
+      ask.status = 'expired';
+      try { await ask.save(); } catch { /* best-effort */ }
+    }
+    throw new AgentAskError('ask has expired', 410, 'ask_expired');
+  }
+  if (ask.status === 'responded') {
+    throw new AgentAskError('ask has already been responded to', 409, 'already_responded');
+  }
+
+  // Authorization: only the original target can respond. Reject if the
+  // responder identity doesn't match the targetAgent + targetInstanceId
+  // recorded on the ask. This is a defense-in-depth check on top of
+  // agentRuntimeAuth — the route handler should already have the
+  // authenticated agent's identity, but we check again here so callers of
+  // respondToAsk() from anywhere in the codebase get the same guarantee.
+  if (responderAgent !== ask.targetAgent || responderInstance !== ask.targetInstanceId) {
+    throw new AgentAskError(
+      'only the original target agent may respond to this ask',
+      403,
+      'not_target',
+    );
+  }
+
+  ask.status = 'responded';
+  ask.response = content;
+  ask.respondedAt = new Date();
+  await ask.save();
+
+  // Fan response back to the original sender. If this enqueue fails, the
+  // ask record itself still reflects the response — the sender can poll
+  // GET /asks/:id (future) to recover. Matches the
+  // create-record-then-enqueue ordering in askAgent().
+  await AgentEventService.enqueue({
+    agentName: ask.fromAgent,
+    instanceId: ask.fromInstanceId,
+    podId: ask.podId,
+    type: 'agent.ask.response',
+    payload: {
+      requestId: ask.requestId,
+      fromAgent: ask.targetAgent,
+      fromInstanceId: ask.targetInstanceId,
+      question: ask.question,
+      response: content,
+      podId: String(ask.podId),
+    },
+  });
+}
+
+export const __testing__ = {
+  ASK_RATE_LIMIT_PER_HOUR,
+  ASK_RATE_WINDOW_MS,
+  DEFAULT_EXPIRY_MS,
+};
+
+const exported = { askAgent, respondToAsk, AgentAskError, __testing__ };
+export default exported;
+// CJS compat: let require() return the exported helpers directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exported;
+module.exports.askAgent = askAgent;
+module.exports.respondToAsk = respondToAsk;
+module.exports.AgentAskError = AgentAskError;
+module.exports.__testing__ = __testing__;
+module.exports.default = exported;

--- a/backend/services/agentMemoryService.ts
+++ b/backend/services/agentMemoryService.ts
@@ -261,3 +261,73 @@ export function computeSyncDedupKey(
   const hash = crypto.createHash('sha256').update(payload).digest('hex').slice(0, 32);
   return `${day}:${sourceRuntime ?? '-'}:${hash}`;
 }
+
+// ADR-003 Phase 4: visibility filter for cross-agent memory reads.
+//
+// Pure function: given the owner's stored sections, the requester's authorized
+// pod ids, and the owner's installation pod ids, return only the sections (and
+// per-element entries) the requester is allowed to see.
+//
+// Rules (load-bearing — see ADR-003 §Visibility & access rules):
+//   - 'private' is NEVER returned to non-owners (even if pods overlap).
+//   - 'public' is always returned.
+//   - 'pod' is returned only when requester ∩ owner pods is non-empty.
+//   - For array sections (`daily[]`, `relationships[]`), the same rule applies
+//     element-wise — entries are filtered individually by their own visibility.
+//   - A section that ends up empty after filtering is OMITTED from the output
+//     (the caller can distinguish "no shared section" from "section exists but
+//     all entries hidden" via the empty array vs missing key).
+export function filterSectionsByVisibility(
+  sections: IAgentMemorySections | undefined,
+  requesterPodIds: string[],
+  ownerPodIds: string[],
+): IAgentMemorySections {
+  if (!sections) return {};
+
+  // Pre-compute pod overlap once per call. Defensive: defend against null/
+  // undefined entries in either array (e.g. a ghost installation with no
+  // podId). Normalize to strings for ObjectId compatibility.
+  const ownerPodSet = new Set(
+    (ownerPodIds || []).filter(Boolean).map((p) => String(p)),
+  );
+  const sharesAnyPod = (requesterPodIds || []).some(
+    (p) => p && ownerPodSet.has(String(p)),
+  );
+
+  const allowVisibility = (v: MemoryVisibility | undefined): boolean => {
+    // Defaulting to 'private' matches the model default — a missing
+    // visibility flag is the strictest reading, never the most permissive.
+    const visibility = v ?? 'private';
+    if (visibility === 'public') return true;
+    if (visibility === 'pod') return sharesAnyPod;
+    return false; // 'private' or anything unexpected
+  };
+
+  const out: IAgentMemorySections = {};
+  // Single-object section keys handled identically. Typed assignment via the
+  // helper keeps the keyof union from collapsing into the array-section types.
+  const assignSingle = (key: 'soul' | 'long_term' | 'dedup_state' | 'shared' | 'runtime_meta'): void => {
+    const s = sections[key];
+    if (!s) return;
+    if (allowVisibility(s.visibility)) {
+      out[key] = s;
+    }
+  };
+  assignSingle('soul');
+  assignSingle('long_term');
+  assignSingle('dedup_state');
+  assignSingle('shared');
+  assignSingle('runtime_meta');
+
+  if (sections.daily) {
+    const filteredDaily = sections.daily.filter((d) => allowVisibility(d.visibility));
+    if (filteredDaily.length > 0) out.daily = filteredDaily;
+  }
+
+  if (sections.relationships) {
+    const filteredRel = sections.relationships.filter((r) => allowVisibility(r.visibility));
+    if (filteredRel.length > 0) out.relationships = filteredRel;
+  }
+
+  return out;
+}


### PR DESCRIPTION
## Summary
Adds three CAP routes that let agents collaborate without a human in the middle.

- `GET /memory/shared/:agentName/:instanceId?` — visibility-filtered cross-agent memory read. Requester sees `public` always, `pod` sections only for pods both share, `private` never. Daily/relationships arrays filter element-wise.
- `POST /pods/:podId/ask` — agent A asks agent B a question; enqueues `agent.ask` event. Self-ask guard matches `agentMentionService` normalization exactly. Rate limit **30/hour per (fromAgent, podId)**. Target must be installed in the same pod.
- `POST /asks/:requestId/respond` — agent B responds; enqueues `agent.ask.response` event. Responder must be the ask's target.

New: `backend/models/AgentAsk.ts`, `backend/services/agentAskService.ts`, `filterSectionsByVisibility` helper in `agentMemoryService.ts`, `agent.ask` + `agent.ask.response` event types.

**Security fixes from review (applied before merge):**
- All agent + instance identifiers `lowercase + trim` at the schema level so the case-sensitive `responderInstance !== ask.targetInstanceId` check can't be bypassed by case-drift.
- `requestId` bounded to 128 chars + control-char rejection at the service layer (DoS surface — caller-controlled, indexed unique field).
- Added integration test for the `AgentInstallation.runtimeTokens` auth-fallback path (previously only `User.agentRuntimeTokens` path was exercised).

Stable error codes: `self_ask`, `rate_limited`, `target_not_in_pod`, `ask_not_found`, `ask_expired`, `already_responded`, `not_target`, `duplicate_request`, `invalid_request_id`.

Spec: `docs/adr/ADR-003-memory-as-kernel-primitive.md` (Phase 4).

Companion to #PR-A, #PR-B, #PR-D.

## Test plan
- [x] `cd backend && npm test` — **784/784 passing** including 55 new tests (18 visibility + 21 ask service + 16 integration). Zero regressions.
- [x] Self-review against `docs/REVIEW.md` — applied 3 must-fix items
- [x] Independent code review — initial verdict was Block; all blockers fixed; route smoke-tested live on `commonly-dev`
- [x] Live deploy: backend `20260417190554-r1` rolled out to `commonly-dev`. Routes verified registered + return `401 "Missing agent token"` without auth. Existing CAP routes unchanged (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)