### PR TITLE
docs: ADR-009 test tiers + CI/CD to GKE (+ WIF runbook, Path A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ Commonly is collapsing the legacy `App` + `AgentRegistry` split into a single `I
 - **ADR-004 Commonly Agent Protocol (CAP)**: `/docs/adr/ADR-004-commonly-agent-protocol.md` — the four-verb driver-facing surface; required reading before any driver work
 - **ADR-005 Local CLI Wrapper Driver**: `/docs/adr/ADR-005-local-cli-wrapper-driver.md` — `commonly agent attach <cli>` + adapter pattern
 - **ADR-006 Webhook SDK + Self-Serve Install**: `/docs/adr/ADR-006-webhook-sdk-and-self-serve-install.md` — reference SDK + self-serve webhook install
+- **ADR-009 Test tiers + CI/CD to GKE**: `/docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md` — four-tier test taxonomy (unit / service / cluster / dev-env) and workflow-triggered GKE deploys via WIF
 - **Summarizer & Agents**: `/docs/SUMMARIZER_AND_AGENTS.md`
 - **Discord Integration**: `/docs/DISCORD_INTEGRATION_ARCHITECTURE.md`
 - **PostgreSQL Migration**: `/docs/POSTGRESQL_MIGRATION.md`

--- a/docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md
+++ b/docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md
@@ -82,7 +82,7 @@ Target state: the *secret* content in `values-private.yaml` moves to GCP Secret 
 
 - **OIDC audience.** WIF provider must scope to `repo:Team-Commonly/commonly:ref:refs/heads/main` (dev) and `repo:Team-Commonly/commonly:environment:prod` (prod). A forked PR cannot mint a token for either.
 - **Image registry push scope.** The WIF-backed SA has `roles/artifactregistry.writer` on the `docker` repo only. No project-wide admin.
-- **Helm upgrade scope.** Deploy SA has `roles/container.developer` on the `commonly-dev` / `commonly-prod` clusters only. No ability to create new clusters or modify node pools.
+- **Helm upgrade scope.** Deploy SA has only `roles/container.clusterViewer` at the IAM layer (auth to any cluster, no mutation). Real deploy permissions come from a Kubernetes `ClusterRoleBinding` of `edit` scoped per cluster — revoking `commonly-dev` access is `kubectl delete clusterrolebinding deploy-github` on that cluster, with no effect on `commonly-prod` or any future cluster.
 - **No secrets echoed in logs.** `set -x` banned in the deploy workflow; `::add-mask::` used for any intermediate token output.
 - **Tier 3 probes are unauthenticated only (Phase 4 scope).** `GET /api/health/live` and `GET /api/health/ready` cover the "did the pod come up and can it reach Mongo + Postgres" question — which is the overwhelming majority of deploy regressions. Authenticated round-trips (login + domain-endpoint call) need a credential story (dedicated smoke account, its User row in Mongo, ESO-rotated secret, workflow retrieval of the credential) that isn't resolved yet; deferred to a later phase so it doesn't block Phase 4.
 
@@ -134,7 +134,7 @@ Deferred. Preview environments per PR are the ideal but cost real GKE capacity p
 
 ### Phase 3 — WIF + dev deploy workflow (one PR + GCP setup)
 
-- [ ] GCP: create WIF pool + provider in `commonly-493005`; grant `artifactregistry.writer` and `container.developer` to the deploy SA scoped to dev.
+- [ ] GCP: create WIF pool + provider in `commonly-493005`; grant `artifactregistry.writer` on the `docker` repo and `container.clusterViewer` at project level; apply a `ClusterRoleBinding` of `edit` against `commonly-dev` (Kubernetes RBAC, not IAM). Details in `docs/deployment/GITHUB_DEPLOY_SETUP.md`.
 - [ ] GitHub: configure `dev` environment with no approvals (auto-deploy).
 - [ ] `.github/workflows/deploy-dev.yml`: build backend + frontend + gateway images, push to AR, `helm upgrade commonly-dev --set image.tag=${sha}`, post status.
 - [ ] Retire `values-private.yaml` for dev: migrate its content to committed `values-dev.yaml` (non-secret config) and ESO (secrets).

--- a/docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md
+++ b/docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md
@@ -116,35 +116,68 @@ Deferred. Preview environments per PR are the ideal but cost real GKE capacity p
 
 ### Phase 1 — Rename + fix Tier 1 (one PR)
 
-- [ ] Rename `__tests__/integration/` → `__tests__/service/` and update jest projects.
-- [ ] `setupMongoDb()` / `setupPgDb()` read `INTEGRATION_TEST=true` and connect to `MONGO_URI` / `PG_*` env instead of in-memory, when set.
-- [ ] Verify all existing "integration" tests still pass against the CI service containers. Fix the ones that silently relied on `MongoMemoryServer` quirks (expect a few).
-- [ ] Update `backend/TESTING.md` with the new tier names.
+- [ ] Rename `backend/__tests__/integration/` → `backend/__tests__/service/`. Update `backend/jest.config.js` only if the rename breaks discovery — current config (`testPathIgnorePatterns` excludes `utils/`, no `testMatch` override) auto-picks `*.test.js` under any path, so a directory rename alone should work. Run `npx jest --listTests` to confirm.
+- [ ] `backend/__tests__/utils/testUtils.js`: `setupMongoDb()` and `setupPgDb()` branch on `process.env.INTEGRATION_TEST === 'true'` — when set, connect to `process.env.MONGO_URI` / `process.env.PG_*` via `mongoose.connect` and `new pg.Pool` respectively, and skip the in-memory server. The existing `__tests__/setup.js` already sets those envs when `INTEGRATION_TEST=true`; no new toggle needed. Keep `MongoMemoryServer` / `pg-mem` for the unset default so Tier 0 stays in-memory.
+- [ ] Audit for likely breakage in the renamed suites. Specific patterns that silently depend on in-memory quirks:
+  - Direct calls to `mongoServer.getUri()` / `pgPool` that the test bodies import from `testUtils` (real-service branch won't export `mongoServer`). Grep: `mongoServer\.|pgDb\.`.
+  - `pg-mem` functions registered in `setupPgDb()` (e.g. `gen_random_uuid`). Real Postgres 16 has `gen_random_uuid` only with `pgcrypto` — add `CREATE EXTENSION IF NOT EXISTS pgcrypto` at start of real-services setup.
+  - Tests that expect `collection.deleteMany({})` to be instant (real Mongo is slower; adjust timeouts if any fall under `jest.setTimeout(default)`).
+  - `pg-mem` schema drift: the in-memory setup creates `pods`, `pod_members`, `messages` tables by hand — real PG gets its schema from `backend/config/init-pg-db.js`. Verify the two match; migrate the init-pg setup into the real-services branch.
+- [ ] Update `backend/TESTING.md`: add a "Tier 0 / Tier 1" section matching the Decision table; deprecate the "integration" label and point at the new dir.
+- [ ] `.github/workflows/tests.yml` already sets `INTEGRATION_TEST: "true"` and boots `mongo:7` + `postgres:16` — verify the new real-services branch actually fires in CI after the rename (add a one-line log assertion, e.g. `console.log('[tier1] using real services')` gated on the env, and grep the workflow log).
 
 ### Phase 1.5 — Chart-lint on every push (one small PR)
 
-- [ ] New job in `tests.yml` (or separate `chart-lint.yml`): `helm template k8s/helm/commonly -f values.yaml -f values-dev.yaml | kubeconform --strict --schema-location default` on every push.
-- [ ] Also run against `values-prod.yaml` once it's committed (Phase 3).
-- [ ] Required check on all PRs — it's cheap enough that "always on" is fine.
+- [ ] New job `chart-lint` added to `.github/workflows/tests.yml` (single-workflow policy, not a separate file) running on every push. Command: `helm template k8s/helm/commonly -f k8s/helm/commonly/values.yaml -f k8s/helm/commonly/values-dev.yaml | kubeconform --strict --summary -output text`.
+- [ ] CRD schemas: default `kubeconform` schemas cover core Kubernetes only. The chart uses ESO `ExternalSecret`, Ingress (GKE), and possibly cert-manager — supply these via `--schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' --schema-location default`. Pin to a specific `datreeio/CRDs-catalog` commit SHA to avoid drift.
+- [ ] Optional second invocation against `-f values-prod.yaml` — gated on that file existing in-tree (it lands in Phase 5, not Phase 3). Use `if [ -f k8s/helm/commonly/values-prod.yaml ]; then ... fi` so Phase 1.5 merges independently of Phase 5.
+- [ ] Add the `chart-lint` check to branch protection on `main`.
 
 ### Phase 2 — Gate Tier 2 on PRs (one small PR)
 
-- [ ] `smoke-test.yml`: add `on.pull_request.paths` filter for `k8s/**`, `backend/Dockerfile`, `frontend/Dockerfile`, `dev.sh`, `.github/workflows/**`. Keep post-merge trigger.
-- [ ] Surface the kind smoke as a required check on PRs with a matching path.
+- [ ] `.github/workflows/smoke-test.yml`: add `on.pull_request.paths` filter. Paths to include: `k8s/**`, `backend/Dockerfile`, `frontend/Dockerfile`, `_external/clawdbot/**` (gateway source per CLAUDE.md §Build & Deploy), `dev.sh`, `.github/workflows/**`. Keep the existing `workflow_run` post-merge trigger.
+- [ ] Add the smoke-test check to branch protection on `main` as **required only when status exists** (so PRs that don't touch the filtered paths — and thus don't run the check — aren't blocked by a missing status).
+- [ ] **Human action:** repo admin adds `kind cluster smoke test` as an "optional" required check in the branch-protection rule (GitHub's "Require status checks to pass → expect checks from each PR" with no entries forces only-when-present semantics; alternately, use `required_status_checks.checks` with `app_id: null` in a custom ruleset — document whichever the admin picks).
 
 ### Phase 3 — WIF + dev deploy workflow (one PR + GCP setup)
 
-- [ ] GCP: create WIF pool + provider in `commonly-493005`; grant `artifactregistry.writer` on the `docker` repo and `container.clusterViewer` at project level; apply a `ClusterRoleBinding` of `edit` against `commonly-dev` (Kubernetes RBAC, not IAM). Details in `docs/deployment/GITHUB_DEPLOY_SETUP.md`.
-- [ ] GitHub: configure `dev` environment with no approvals (auto-deploy).
-- [ ] `.github/workflows/deploy-dev.yml`: build backend + frontend + gateway images, push to AR, `helm upgrade commonly-dev --set image.tag=${sha}`, post status.
-- [ ] Retire `values-private.yaml` for dev: migrate its content to committed `values-dev.yaml` (non-secret config) and ESO (secrets).
-- [ ] Remove the `/home/xcjam/workspace/commonly/.dev/values-private.yaml` reference from CLAUDE.md; document the new shape.
+- [ ] **GCP setup** (follow `docs/deployment/GITHUB_DEPLOY_SETUP.md` in full): WIF pool + GitHub provider with `assertion.repository=='Team-Commonly/commonly'` condition; `deploy-github` SA with `roles/artifactregistry.writer` on the `docker` repo, `roles/container.clusterViewer` at project level; Kubernetes `ClusterRoleBinding` of `edit` against the SA's identity on `commonly-dev` only.
+- [ ] **Secrets in GitHub:** `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`. **Environment:** create `dev` with no approvers.
+- [ ] **Submodule:** `actions/checkout@v4` with `submodules: recursive` — the gateway image is built from `_external/clawdbot/`, a git submodule. Without this the gateway build step fails immediately.
+- [ ] **Build step** (three images, one tag each, all set to the current commit SHA for simplicity and rollback symmetry):
+  ```bash
+  export IMG_TAG=${GITHUB_SHA::8}
+  export REG=us-central1-docker.pkg.dev/commonly-493005/docker
+  docker build backend  -t $REG/commonly-backend:$IMG_TAG  && docker push $REG/commonly-backend:$IMG_TAG
+  docker build frontend --build-arg REACT_APP_API_URL=https://api-dev.commonly.me -t $REG/commonly-frontend:$IMG_TAG && docker push $REG/commonly-frontend:$IMG_TAG
+  cd _external/clawdbot && docker build --build-arg OPENCLAW_EXTENSIONS=acpx --build-arg OPENCLAW_INSTALL_GH_CLI=1 -t $REG/clawdbot-gateway:$IMG_TAG . && docker push $REG/clawdbot-gateway:$IMG_TAG
+  ```
+- [ ] **Helm upgrade step** — the chart has three separate image keys at `backend.image.tag`, `frontend.image.tag`, `agents.clawdbot.image.tag` (verified against `values.yaml` line 22, 75, 182). Set all three in one command:
+  ```bash
+  helm upgrade commonly-dev k8s/helm/commonly -n commonly-dev \
+    -f k8s/helm/commonly/values.yaml \
+    -f k8s/helm/commonly/values-dev.yaml \
+    --set backend.image.tag=$IMG_TAG \
+    --set frontend.image.tag=$IMG_TAG \
+    --set agents.clawdbot.image.tag=$IMG_TAG
+  ```
+  Note the removed third `-f values-private.yaml` — covered by the next bullet.
+- [ ] **Retire `values-private.yaml`** (this is the load-bearing migration; no agent can do it without a human pulling the actual file from Lily's laptop):
+  - **Human action**: open `/home/xcjam/workspace/commonly/.dev/values-private.yaml` and categorize each key as (a) non-secret config → `values-dev.yaml` commit, (b) secret → GCP Secret Manager entry + `ExternalSecret` manifest under `k8s/helm/commonly/templates/`.
+  - Non-secret keys expected (per CLAUDE.md §Kubernetes): `global.gcpProjectId`, `postgresql.host`, `*.image.repository` overrides. These go into `values-dev.yaml`; `values.yaml`'s `YOUR_GCP_PROJECT_ID` placeholders stay as the OSS-safe default.
+  - Any key named like a credential (`*_password`, `*_token`, `*_key`, `jwtSecret`, `*_connectionString`) → Secret Manager. The existing `api-keys` ESO pattern (CLAUDE.md §Agent Runtime) is the template.
+  - Update `docs/deployment/KUBERNETES.md` and `CLAUDE.md` §Kubernetes to remove the three-`-f` instruction and reference the new two-file shape.
+- [ ] **Status reporting:** the workflow posts **both** a GitHub status check (`deploy-dev / build-and-deploy`) and a PR/commit comment with the deploy outcome (tag, Helm revision, probe results). Agents observe via `mcp__github__pull_request_read` → `get_check_runs` or `get_comments`.
 
 ### Phase 4 — Tier 3 smoke + rollback (one PR)
 
 - [ ] `deploy-dev.yml` adds post-deploy HTTP probes against `api-dev.commonly.me` — **unauthenticated only this phase**: `GET /api/health/live` and `GET /api/health/ready`. Covers pod-came-up and DB-reachability. Auth round-trip probes deferred until a smoke credential story lands (dedicated account + ESO-rotated secret + workflow retrieval).
-- [ ] `helm rollback commonly-dev 0` on probe failure.
-- [ ] Three-consecutive-rollbacks → hard CI failure + GitHub issue auto-opened.
+- [ ] **Rollback target** — match the Decision's "last-known-good revision" design:
+  - On a passing deploy, the workflow stamps `commonly.me/last-good-revision: <helm-revision-number>` as an annotation on the Helm release (via `kubectl annotate deployment/backend` on the namespace, or on the Helm-managed `Secret` carrying release state).
+  - On a probe failure, the workflow reads that annotation and runs `helm rollback commonly-dev <last-good-revision>`. **Not** `helm rollback commonly-dev 0`.
+  - Edge case — first-ever deploy: if `helm history commonly-dev -o json | jq 'length'` is `1` (no prior revision), **skip auto-rollback**. Workflow fails loudly, leaves the broken release in place, and pages via the same GitHub-issue mechanism below. Rationale: there's nothing known-good to roll back to.
+- [ ] **Consecutive-failure escalation** — keyed on the last-good pointer, not the commit SHA:
+  - If three deploys in a row roll back and the pointer doesn't advance, the workflow (a) fails the `deploy-dev` status check hard, (b) opens a GitHub issue via `gh issue create` labeled `deploy-stuck` with the three failed SHAs, (c) stops auto-rolling-back until the issue is closed (workflow checks for open issues with that label at start).
 
 ### Phase 5 — Prod path (one PR + GCP setup)
 
@@ -161,11 +194,13 @@ Deferred. Preview environments per PR are the ideal but cost real GKE capacity p
 
 ## Open questions
 
-- **Tier 1 cost at scale.** Service-container startup adds ~20s to each CI run. If the Tier 1 suite grows beyond the budget we accept, do we shard it across jobs or start excluding routes? Track Tier 1 wall time; revisit at > 5 min.
-- **Where does cloud-agent status appear?** PR comment? Commit status? Both? A status check is the normal place; a PR comment is friendlier for the agent to observe via `mcp__github__pull_request_read`. Start with both and drop one if it's noise.
-- **Migration risk for `values-private.yaml`.** The file encodes some decisions (PG host choice, custom image repo) that may not be safe to put in a public file. Audit before migration; anything truly sensitive stays in Secret Manager.
-- **Should Tier 2 block merge or just warn?** If cluster smoke takes 20 min and PRs touch `k8s/` rarely, blocking is fine. If it becomes frequent, consider warning-only with a label (`cluster-smoke-required`) that promotes it to blocking when needed.
-- **What about `backend/TESTING.md` / `frontend/TESTING.md`?** These reference the current naming. They get updated in Phase 1. Track so they don't drift.
+- **Tier 1 cost at scale.** Service-container startup adds ~20s to each CI run. If the Tier 1 suite grows beyond the budget we accept, do we shard it across jobs or start excluding routes? Track Tier 1 wall time; revisit at > 5 min. *Not blocking any phase; monitor once Phase 1 lands.*
+- **Migration risk for `values-private.yaml`.** The file encodes keys we haven't enumerated in the repo. Audit during the Phase 3 migration (which is human-driven — see Phase 3's "Retire values-private.yaml" checklist). Anything not clearly non-secret goes to Secret Manager by default.
+
+*Previously-listed questions resolved during review:*
+- *Cloud-agent status output* → both a GitHub check-run and a PR comment (Phase 3 checklist).
+- *Tier 2 blocking-vs-warning* → blocks merge, but only when the check ran (path-filtered); see Phase 2 human-action bullet.
+- *`backend/TESTING.md` / `frontend/TESTING.md`* → updated in Phase 1 (now a checklist item).
 
 ---
 

--- a/docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md
+++ b/docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md
@@ -1,0 +1,165 @@
+# ADR-009: Test tiers and CI/CD to GKE
+
+**Status:** Draft — 2026-04-19
+**Author:** Sam Xu
+**Companion:** [`REVIEW.md`](../../REVIEW.md), [`docs/deployment/KUBERNETES.md`](../deployment/KUBERNETES.md)
+
+---
+
+## Context
+
+Two related gaps surfaced while landing ADR-002 Phase 1b-a (#216):
+
+**1. Test tiers are muddled.** The repo calls a suite "integration" and wires `INTEGRATION_TEST=true` in CI with real `mongo:7` + `postgres:16` service containers — but `__tests__/utils/testUtils.setupMongoDb()` ignores `MONGO_URI` and spins up `MongoMemoryServer` anyway. The service containers sit idle. Tests that are named integration don't, in fact, hit real databases. Meanwhile `smoke-test.yml` runs the kind cluster only on post-merge `main` (via `workflow_run`), so PRs never get cluster signal. The result: a PR can pass "integration tests" despite its query not working against real Mongo/PG, and we find out on dev.
+
+**2. Deploys are manual and cloud-agent-hostile.** Deploying dev today is a human-driven sequence on a laptop: `docker build`, `docker push` to `us-central1-docker.pkg.dev/...`, bump the image tag in `values-dev.yaml`, run `helm upgrade` with three `-f` flags including the uncommitted `values-private.yaml`. CLAUDE.md §Build & Deploy documents this. It works for Lily on her machine; it doesn't work for a cloud-based Claude session (no docker daemon, no gcloud auth, no access to `values-private.yaml`) and it's brittle for humans too (the three-`-f` rule with `values-private.yaml` is a known foot-gun that's bitten the team before).
+
+The two gaps interact. A merge that passes current CI can still break dev at deploy time — and the agent that made the change can't trigger or observe the deploy, so verification falls to whoever pulls the latest image tag next. This is the "cloud-agent-hostile" bit from the ADR-002 Phase 1b-a review: if we want agents doing real work against real clusters, the loop has to close without a human in the middle.
+
+---
+
+## Decision
+
+Adopt a four-tier test taxonomy with explicit names and explicit PR gating, and wire a workflow-triggered GKE deploy path that neither human nor agent has to run locally.
+
+### Test tiers
+
+| Tier | Name | What it exercises | Runs on | Gate |
+|---|---|---|---|---|
+| 0 | **Unit** | In-memory everything; route handlers with mocked models; single-module tests | every push | required |
+| 1 | **Service** | Real Mongo + Postgres (service containers); model queries, regex semantics, ObjectId coercion, PG ILIKE | every push | required |
+| 2 | **Cluster smoke** | Full Helm install on kind; pods come up, health probes pass, HTTP smoke against ingress | PRs touching `k8s/`, `Dockerfile`, `dev.sh cluster`; `workflow_dispatch` | required on eligible paths |
+| 3 | **Dev-env smoke** | Real GKE `commonly-dev` after deploy-on-merge; HTTP probes against `api-dev.commonly.me`; auto-rollback on failure | merge to `main` | informational (rolls back on fail) |
+
+**Tier 1 is the rename most of the audit turns on.** The current "integration" suite becomes Tier 1 *and* actually uses the service containers, not `MongoMemoryServer`. `setupMongoDb()` gets a `useRealServices` branch that `mongoose.connect(process.env.MONGO_URI)` when `INTEGRATION_TEST=true`, and leaves the memory server for Tier 0. `pg-mem` similarly falls back to a real `pg.Pool` against the `postgres:16` container when the env says so. Nothing else in the test body changes — same fixtures, same assertions.
+
+**Tier 2 is clarified, not new.** `smoke-test.yml` already spins up kind and runs `./dev.sh cluster test`. We change the trigger so it runs on PRs that touch deployment surfaces (path-filtered `on.pull_request.paths`) and keep the post-merge run. Every PR that *could* break a deploy gets cluster signal before merge.
+
+**Tier 3 is new and depends on the deploy path below.**
+
+### CI/CD to GKE
+
+**Auth: Workload Identity Federation only.** No service account JSON keys in GitHub secrets. One WIF pool in the `commonly-493005` GCP project federates trust to the `Team-Commonly/commonly` repo; GitHub Actions exchanges its OIDC token for a short-lived GCP access token via `google-github-actions/auth@v2`. Keys never leave GCP.
+
+**Triggers:**
+- **Dev**: merge to `main` → build images → push to `us-central1-docker.pkg.dev/...` → `helm upgrade commonly-dev` → Tier 3 smoke against `api-dev.commonly.me` → `helm rollback` on smoke failure.
+- **Prod**: tag push `v*.*.*` → identical pipeline against `commonly-prod`, gated by a GitHub environment with one-reviewer approval. No automatic prod deploys.
+
+**Values handling — the `values-private.yaml` problem.**
+
+Current state: `values-private.yaml` lives only on Lily's laptop at `/home/xcjam/workspace/commonly/.dev/values-private.yaml`. It holds the real GCP project ID, PG host, and image repo overrides. Anyone else running `helm upgrade` either doesn't have it (deploy fails) or recreates it from memory (drift).
+
+Target state: the *secret* content in `values-private.yaml` moves to GCP Secret Manager and is pulled into the cluster by ESO (which already owns `api-keys` per CLAUDE.md §Agent Runtime). The *config* content (GCP project ID, PG host, image repo) moves into a committed `values-dev.yaml` / `values-prod.yaml` — these are not secrets and hiding them just makes the repo unusable to new contributors. One uncommitted file disappears; three committed files + ESO handle what it used to.
+
+**Image tags.** Workflow sets image tag to `${sha}` (short SHA) and passes it via `--set image.tag=...` on helm upgrade, not by editing `values-dev.yaml`. That keeps the workflow git-clean (no auto-commit back to main), keeps `values-dev.yaml` reviewable, and makes rollback a matter of `helm upgrade --set image.tag=<previous-sha>` rather than a values-file revert.
+
+**Rollback.** Tier 3 smoke is the gate. On failure, workflow runs `helm rollback commonly-dev 0` (last revision) and posts the failed probe output to the PR or commit. Human decides whether to fix forward or investigate.
+
+---
+
+## Consequences
+
+### Positive
+
+- **PRs get signal against real services.** Tier 1 catches the class of bug where a query works against `MongoMemoryServer` but not real Mongo (index behavior, regex semantics, ObjectId coercion). ADR-002 Phase 1b-a's review would have caught `findOne` false-deny and the profile-picture URL-shape mismatch during CI, not during inline review — same caliber of bug, found earlier.
+- **Cloud-agent workflow closes.** A Claude session on `claude.ai/code` can now: open a PR → CI runs Tier 0/1/2 → merge → Tier 3 deploys dev and reports back via PR comment or commit status → agent observes the outcome via `mcp__github__pull_request_read`. No laptop required.
+- **Deploy is auditable.** Every image tag on `commonly-dev` traces to a commit SHA and a workflow run. Current state ("who pushed the `20260417212525-r2` image?") becomes "click the deploy run."
+- **No long-lived GCP keys.** WIF removes the SA JSON from GitHub secrets. If a repo collaborator goes rogue, they can't steal a deploy credential — they'd need to modify a workflow and get it merged.
+- **New contributors can deploy.** The `values-private.yaml` ritual goes away. `./dev.sh` + a committed `values-dev.yaml` is enough to understand what ships.
+
+### Negative / risks
+
+- **Tier 1 run time.** Hitting real Mongo + PG adds seconds per test. If the full Tier 1 suite runs > 5 min the signal-to-friction ratio drops. Mitigation: keep Tier 0 fast (< 30s) so PRs fail fast on trivial breaks before paying Tier 1 cost.
+- **Cluster smoke (Tier 2) latency.** kind brings up ~20 min. Gating only on deployment-surface paths keeps most PRs free of it; PRs that need it pay the cost because the alternative is breaking dev.
+- **WIF setup is one-time but irreversible-ish.** Once we cut over, dropping back to SA keys is a conscious decision, not a default. This is fine — the whole point — but worth noting.
+- **Auto-rollback hides failures.** If Tier 3 rolls back automatically, a subtle prod-only bug could ping-pong between deploy attempts. Mitigation: three consecutive rollbacks on the same commit → workflow escalates to a status-check failure and pages whoever merged.
+- **Prod deploy is now one approval click away.** The one-reviewer gate is minimal; we may want two reviewers or an SRE-team requirement before `v1.0.0` ships. Set per-environment in GitHub; costs nothing to tighten later.
+
+### Security notes
+
+- **OIDC audience.** WIF provider must scope to `repo:Team-Commonly/commonly:ref:refs/heads/main` (dev) and `repo:Team-Commonly/commonly:environment:prod` (prod). A forked PR cannot mint a token for either.
+- **Image registry push scope.** The WIF-backed SA has `roles/artifactregistry.writer` on the `docker` repo only. No project-wide admin.
+- **Helm upgrade scope.** Deploy SA has `roles/container.developer` on the `commonly-dev` / `commonly-prod` clusters only. No ability to create new clusters or modify node pools.
+- **No secrets echoed in logs.** `set -x` banned in the deploy workflow; `::add-mask::` used for any intermediate token output.
+- **Tier 3 smoke uses a dedicated test account.** Smoke probes don't use real user credentials — a `smoke@commonly.me` service account gets minimal read access and is rotated via ESO.
+
+---
+
+## Alternatives considered
+
+### A. Keep `MongoMemoryServer` in "integration," add a separate "real-services" tier on top.
+
+Rejected. We'd end up with five tiers, two of which ("integration", "real-services") sound identical to anyone who hasn't read this ADR. Rename-in-place is clearer.
+
+### B. Cloud Build instead of GitHub Actions.
+
+Rejected. Per CLAUDE.md §Build & Deploy: "Cloud Build org policy blocks AR uploads — use local Docker instead." The org policy is non-negotiable at this scale; GitHub Actions + WIF is the working path.
+
+### C. Argo CD / pull-based GitOps.
+
+Considered. Reduces the need for a deploy workflow — Argo watches the cluster and reconciles to a Git-declared state. Rejected for now because (a) it adds a second control plane to operate, (b) image-tag bumps still need a mechanism (e.g. Argo Image Updater), and (c) we're a small team and a push-based workflow is easier to reason about. Revisit at 5+ environments or when multi-cluster lands.
+
+### D. Auto-deploy prod on tag, no approval gate.
+
+Rejected. One unreviewed merge that touches `values-prod.yaml` or bumps a load-bearing image should not reach production unreviewed. The approval gate is cheap friction for a large class of preventable outages.
+
+### E. Run Tier 3 smoke on every PR against a preview environment.
+
+Deferred. Preview environments per PR are the ideal but cost real GKE capacity per open PR. When the PR volume and the budget both support it, revisit — probably after prod launch.
+
+---
+
+## Implementation plan
+
+### Phase 1 — Rename + fix Tier 1 (one PR)
+
+- [ ] Rename `__tests__/integration/` → `__tests__/service/` and update jest projects.
+- [ ] `setupMongoDb()` / `setupPgDb()` read `INTEGRATION_TEST=true` and connect to `MONGO_URI` / `PG_*` env instead of in-memory, when set.
+- [ ] Verify all existing "integration" tests still pass against the CI service containers. Fix the ones that silently relied on `MongoMemoryServer` quirks (expect a few).
+- [ ] Update `backend/TESTING.md` with the new tier names.
+
+### Phase 2 — Gate Tier 2 on PRs (one small PR)
+
+- [ ] `smoke-test.yml`: add `on.pull_request.paths` filter for `k8s/**`, `backend/Dockerfile`, `frontend/Dockerfile`, `dev.sh`, `.github/workflows/**`. Keep post-merge trigger.
+- [ ] Surface the kind smoke as a required check on PRs with a matching path.
+
+### Phase 3 — WIF + dev deploy workflow (one PR + GCP setup)
+
+- [ ] GCP: create WIF pool + provider in `commonly-493005`; grant `artifactregistry.writer` and `container.developer` to the deploy SA scoped to dev.
+- [ ] GitHub: configure `dev` environment with no approvals (auto-deploy).
+- [ ] `.github/workflows/deploy-dev.yml`: build backend + frontend + gateway images, push to AR, `helm upgrade commonly-dev --set image.tag=${sha}`, post status.
+- [ ] Retire `values-private.yaml` for dev: migrate its content to committed `values-dev.yaml` (non-secret config) and ESO (secrets).
+- [ ] Remove the `/home/xcjam/workspace/commonly/.dev/values-private.yaml` reference from CLAUDE.md; document the new shape.
+
+### Phase 4 — Tier 3 smoke + rollback (one PR)
+
+- [ ] `deploy-dev.yml` adds post-deploy HTTP probes against `api-dev.commonly.me` (health, auth round-trip, one representative domain endpoint).
+- [ ] `helm rollback commonly-dev 0` on probe failure.
+- [ ] Three-consecutive-rollbacks → hard CI failure + GitHub issue auto-opened.
+
+### Phase 5 — Prod path (one PR + GCP setup)
+
+- [ ] Mirror phases 3–4 for `commonly-prod` with the `prod` environment gated by one reviewer.
+- [ ] Trigger on tag push `v*.*.*` only.
+- [ ] Document release procedure in `docs/deployment/RELEASE.md`.
+
+### Phase 6 — Preview environments (deferred)
+
+- [ ] Per-PR preview namespace in `commonly-dev` cluster, auto-torn-down on PR close.
+- [ ] Revisit only after prod is live and PR volume justifies.
+
+---
+
+## Open questions
+
+- **Tier 1 cost at scale.** Service-container startup adds ~20s to each CI run. If the Tier 1 suite grows beyond the budget we accept, do we shard it across jobs or start excluding routes? Track Tier 1 wall time; revisit at > 5 min.
+- **Where does cloud-agent status appear?** PR comment? Commit status? Both? A status check is the normal place; a PR comment is friendlier for the agent to observe via `mcp__github__pull_request_read`. Start with both and drop one if it's noise.
+- **Migration risk for `values-private.yaml`.** The file encodes some decisions (PG host choice, custom image repo) that may not be safe to put in a public file. Audit before migration; anything truly sensitive stays in Secret Manager.
+- **Should Tier 2 block merge or just warn?** If cluster smoke takes 20 min and PRs touch `k8s/` rarely, blocking is fine. If it becomes frequent, consider warning-only with a label (`cluster-smoke-required`) that promotes it to blocking when needed.
+- **What about `backend/TESTING.md` / `frontend/TESTING.md`?** These reference the current naming. They get updated in Phase 1. Track so they don't drift.
+
+---
+
+## Decision log
+
+- 2026-04-19: Draft created. Motivated by the ADR-002 Phase 1b-a PR review surfacing two gaps: (1) unit tests couldn't catch ACL false-denies or profile-picture URL shape mismatches because they mocked Mongoose queries, and (2) the Claude cloud agent that authored the PR had no path to observe a real-cluster deployment. Both gaps are structural to CI/CD, not to ADR-002.

--- a/docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md
+++ b/docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md
@@ -28,10 +28,13 @@ Adopt a four-tier test taxonomy with explicit names and explicit PR gating, and 
 |---|---|---|---|---|
 | 0 | **Unit** | In-memory everything; route handlers with mocked models; single-module tests | every push | required |
 | 1 | **Service** | Real Mongo + Postgres (service containers); model queries, regex semantics, ObjectId coercion, PG ILIKE | every push | required |
+| 1.5 | **Chart lint** | `helm template` + `kubeconform` / `kubeval` against the rendered manifests | every push | required |
 | 2 | **Cluster smoke** | Full Helm install on kind; pods come up, health probes pass, HTTP smoke against ingress | PRs touching `k8s/`, `Dockerfile`, `dev.sh cluster`; `workflow_dispatch` | required on eligible paths |
 | 3 | **Dev-env smoke** | Real GKE `commonly-dev` after deploy-on-merge; HTTP probes against `api-dev.commonly.me`; auto-rollback on failure | merge to `main` | informational (rolls back on fail) |
 
 **Tier 1 is the rename most of the audit turns on.** The current "integration" suite becomes Tier 1 *and* actually uses the service containers, not `MongoMemoryServer`. `setupMongoDb()` gets a `useRealServices` branch that `mongoose.connect(process.env.MONGO_URI)` when `INTEGRATION_TEST=true`, and leaves the memory server for Tier 0. `pg-mem` similarly falls back to a real `pg.Pool` against the `postgres:16` container when the env says so. Nothing else in the test body changes — same fixtures, same assertions.
+
+**Tier 1.5 (chart lint) is new** and closes a real gap: a PR that adds `process.env.NEW_REQUIRED_FLAG` to `backend/` without a matching chart update passes Tier 0 and Tier 1 (neither renders Helm) and doesn't trigger Tier 2's path filter (only `backend/` changed). It merges green and breaks dev on Phase 3 deploy. `helm template k8s/helm/commonly -f values.yaml -f values-dev.yaml | kubeconform` runs in < 30s, catches missing values / schema / required-env-var-in-ConfigMap drift, and is cheap enough to run on every push. Keeps Tier 2 as the "real cluster" signal and lets chart-lint be the always-on first line of defense.
 
 **Tier 2 is clarified, not new.** `smoke-test.yml` already spins up kind and runs `./dev.sh cluster test`. We change the trigger so it runs on PRs that touch deployment surfaces (path-filtered `on.pull_request.paths`) and keep the post-merge run. Every PR that *could* break a deploy gets cluster signal before merge.
 
@@ -53,7 +56,7 @@ Target state: the *secret* content in `values-private.yaml` moves to GCP Secret 
 
 **Image tags.** Workflow sets image tag to `${sha}` (short SHA) and passes it via `--set image.tag=...` on helm upgrade, not by editing `values-dev.yaml`. That keeps the workflow git-clean (no auto-commit back to main), keeps `values-dev.yaml` reviewable, and makes rollback a matter of `helm upgrade --set image.tag=<previous-sha>` rather than a values-file revert.
 
-**Rollback.** Tier 3 smoke is the gate. On failure, workflow runs `helm rollback commonly-dev 0` (last revision) and posts the failed probe output to the PR or commit. Human decides whether to fix forward or investigate.
+**Rollback.** Tier 3 smoke is the gate. On failure, the workflow rolls the release back to the **last known-good revision** tracked in a Helm chart annotation (`commonly.me/last-good-revision`) that the workflow stamps on every passing deploy. This avoids two failure modes of naive `helm rollback commonly-dev 0`: (1) the first-ever deploy has no prior revision to roll back to, so the workflow short-circuits to "fail loudly, don't auto-rollback" when `helm history` has one entry; (2) a second failing deploy could otherwise roll back to the first failing deploy's revision rather than the last good one. The 3-strikes escalation triggers a CI failure and an auto-opened GitHub issue when the last-known-good pointer gets stale (three consecutive rollbacks against the same pointer).
 
 ---
 
@@ -81,7 +84,7 @@ Target state: the *secret* content in `values-private.yaml` moves to GCP Secret 
 - **Image registry push scope.** The WIF-backed SA has `roles/artifactregistry.writer` on the `docker` repo only. No project-wide admin.
 - **Helm upgrade scope.** Deploy SA has `roles/container.developer` on the `commonly-dev` / `commonly-prod` clusters only. No ability to create new clusters or modify node pools.
 - **No secrets echoed in logs.** `set -x` banned in the deploy workflow; `::add-mask::` used for any intermediate token output.
-- **Tier 3 smoke uses a dedicated test account.** Smoke probes don't use real user credentials — a `smoke@commonly.me` service account gets minimal read access and is rotated via ESO.
+- **Tier 3 probes are unauthenticated only (Phase 4 scope).** `GET /api/health/live` and `GET /api/health/ready` cover the "did the pod come up and can it reach Mongo + Postgres" question — which is the overwhelming majority of deploy regressions. Authenticated round-trips (login + domain-endpoint call) need a credential story (dedicated smoke account, its User row in Mongo, ESO-rotated secret, workflow retrieval of the credential) that isn't resolved yet; deferred to a later phase so it doesn't block Phase 4.
 
 ---
 
@@ -118,6 +121,12 @@ Deferred. Preview environments per PR are the ideal but cost real GKE capacity p
 - [ ] Verify all existing "integration" tests still pass against the CI service containers. Fix the ones that silently relied on `MongoMemoryServer` quirks (expect a few).
 - [ ] Update `backend/TESTING.md` with the new tier names.
 
+### Phase 1.5 — Chart-lint on every push (one small PR)
+
+- [ ] New job in `tests.yml` (or separate `chart-lint.yml`): `helm template k8s/helm/commonly -f values.yaml -f values-dev.yaml | kubeconform --strict --schema-location default` on every push.
+- [ ] Also run against `values-prod.yaml` once it's committed (Phase 3).
+- [ ] Required check on all PRs — it's cheap enough that "always on" is fine.
+
 ### Phase 2 — Gate Tier 2 on PRs (one small PR)
 
 - [ ] `smoke-test.yml`: add `on.pull_request.paths` filter for `k8s/**`, `backend/Dockerfile`, `frontend/Dockerfile`, `dev.sh`, `.github/workflows/**`. Keep post-merge trigger.
@@ -133,7 +142,7 @@ Deferred. Preview environments per PR are the ideal but cost real GKE capacity p
 
 ### Phase 4 — Tier 3 smoke + rollback (one PR)
 
-- [ ] `deploy-dev.yml` adds post-deploy HTTP probes against `api-dev.commonly.me` (health, auth round-trip, one representative domain endpoint).
+- [ ] `deploy-dev.yml` adds post-deploy HTTP probes against `api-dev.commonly.me` — **unauthenticated only this phase**: `GET /api/health/live` and `GET /api/health/ready`. Covers pod-came-up and DB-reachability. Auth round-trip probes deferred until a smoke credential story lands (dedicated account + ESO-rotated secret + workflow retrieval).
 - [ ] `helm rollback commonly-dev 0` on probe failure.
 - [ ] Three-consecutive-rollbacks → hard CI failure + GitHub issue auto-opened.
 

--- a/docs/deployment/GITHUB_DEPLOY_SETUP.md
+++ b/docs/deployment/GITHUB_DEPLOY_SETUP.md
@@ -1,17 +1,17 @@
 # GitHub Actions → GKE deploy setup
 
-Companion to [`ADR-009`](../adr/ADR-009-test-tiers-and-ci-cd-to-gke.md). Two
-paths: **Workload Identity Federation** (recommended, no long-lived credential
-in GitHub) and **Service Account JSON key** (fast path, one secret in GitHub,
-rotatable-forever).
+Companion to [`ADR-009`](../adr/ADR-009-test-tiers-and-ci-cd-to-gke.md).
+ADR-009 commits to **Workload Identity Federation only** — no long-lived
+service account keys in GitHub. This runbook is the concrete gcloud sequence.
 
-Pick one. Run the gcloud blocks once from an account with `roles/owner` (or
+Run the blocks below once from an account with `roles/owner` (or
 `roles/iam.workloadIdentityPoolAdmin` + `roles/iam.serviceAccountAdmin` +
-`roles/resourcemanager.projectIamAdmin`) on `commonly-493005`.
+`roles/resourcemanager.projectIamAdmin`) on `commonly-493005`. Expect
+~15 minutes end-to-end.
 
 ---
 
-## Prep (both paths)
+## Prep
 
 ```bash
 # Replace if your project differs.
@@ -39,7 +39,7 @@ gcloud artifacts repositories list --location=us-central1 # should show 'docker'
 
 ---
 
-## Path A — Workload Identity Federation (recommended)
+## Setup
 
 Short-lived tokens minted per workflow run; no JSON key ever leaves GCP.
 
@@ -63,17 +63,49 @@ gcloud artifacts repositories add-iam-policy-binding docker \
   --member="serviceAccount:$DEPLOY_SA_EMAIL" \
   --role=roles/artifactregistry.writer
 
-# Talk to the dev cluster. Repeat for prod when you add it.
-gcloud container clusters get-credentials commonly-dev --region=us-central1
+# Authenticate to ANY cluster in the project (read-only). Least-privilege
+# IAM bootstrap so gcloud can fetch kubeconfig; the real deploy permissions
+# come from the Kubernetes RBAC binding below.
 gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:$DEPLOY_SA_EMAIL" \
-  --role=roles/container.developer \
-  --condition="expression=resource.name.endsWith('/clusters/commonly-dev'),title=commonly-dev-only"
+  --role=roles/container.clusterViewer
 ```
 
-> **Note:** `roles/container.developer` at project level with a condition is
-> simpler than cluster-level RBAC and fine for a two-cluster setup. Tighten to
-> cluster RBAC if you add a third environment.
+Then grant deploy permissions at the **Kubernetes layer**, scoped to
+`commonly-dev` only. This is the reviewer-preferred alternative to
+IAM-conditioned `roles/container.developer`: IAM conditions only evaluate
+against cluster-shaped resources, which can silently deny mid-deploy when
+Helm touches operation / node-pool / workload resources with different
+resource paths. Kubernetes RBAC scopes cleanly to one cluster and covers
+every resource type Helm needs.
+
+```bash
+gcloud container clusters get-credentials commonly-dev --region=us-central1
+
+# The SA's K8s identity follows a fixed naming pattern; RoleBinding binds
+# the existing cluster-admin or deploy-oriented ClusterRole to it.
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: deploy-github
+subjects:
+  - kind: User
+    name: $DEPLOY_SA_EMAIL
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  # `edit` is sufficient for helm upgrade on application namespaces.
+  # Use `admin` if deploys also need to create namespaces or RBAC objects,
+  # or define a custom ClusterRole and tighten to exactly helm's verbs.
+  name: edit
+  apiGroup: rbac.authorization.k8s.io
+EOF
+```
+
+Repeat the `kubectl apply` against `commonly-prod` when that cluster is
+added — each cluster gets its own binding, and revoking access to one
+cluster is a single `kubectl delete clusterrolebinding deploy-github`.
 
 ### 3. Create the WIF pool + GitHub provider
 
@@ -178,94 +210,18 @@ jobs:
 
 ---
 
-## Path B — Service Account JSON key (fast path)
-
-One secret in GitHub, long-lived credential that you rotate manually. Use if
-you need to deploy *today* and can't wait for the WIF setup to land.
-
-### 1–2. SA + roles
-
-Same as Path A steps 1 and 2. Skip WIF pool/provider/binding (steps 3–4).
-
-### 3. Create a key
-
-```bash
-gcloud iam service-accounts keys create /tmp/deploy-github-key.json \
-  --iam-account=$DEPLOY_SA_EMAIL
-
-# Base64 so GitHub accepts it as a single-line secret.
-base64 -w0 /tmp/deploy-github-key.json > /tmp/deploy-github-key.b64
-cat /tmp/deploy-github-key.b64
-```
-
-### 4. GitHub secret
-
-**Settings → Secrets and variables → Actions**:
-
-```
-GCP_SA_KEY   <paste the base64 blob>
-```
-
-### 5. Workflow usage
-
-```yaml
-# .github/workflows/deploy-dev.yml (excerpt)
-permissions:
-  contents: read   # no id-token needed
-
-jobs:
-  deploy:
-    environment: dev
-    steps:
-      - uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-```
-
-### 6. Clean up the local file
-
-```bash
-shred -u /tmp/deploy-github-key.json /tmp/deploy-github-key.b64
-```
-
-### 7. Rotation
-
-```bash
-# List active keys
-gcloud iam service-accounts keys list --iam-account=$DEPLOY_SA_EMAIL
-
-# Revoke an old key by ID (after confirming the new one works)
-gcloud iam service-accounts keys delete <KEY_ID> --iam-account=$DEPLOY_SA_EMAIL
-```
-
-Do this at least every 90 days. Set a calendar reminder — there is no
-automatic expiry.
-
----
-
-## Migration: Path B → Path A
-
-If you start with the JSON key and want to move to WIF later:
-
-1. Run Path A steps 3–6 (WIF pool, provider, binding, secrets).
-2. Update workflows to the Path A auth step.
-3. Verify one green deploy on the new path.
-4. Delete the SA key via step 7 of Path B.
-5. Delete the `GCP_SA_KEY` GitHub secret.
-
-No disruption if the workflow is updated in the same PR as the WIF binding.
-
----
-
-## Revocation (both paths)
+## Revocation
 
 ### Revoke deploy access entirely
 
 ```bash
-# Strips all IAM bindings on the SA. Deploys fail immediately.
+# Strip the K8s binding first — one cluster at a time, fastest cut-off.
+kubectl delete clusterrolebinding deploy-github
+
+# Then strip IAM so the SA can't even authenticate to other clusters.
 gcloud projects remove-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:$DEPLOY_SA_EMAIL" \
-  --role=roles/container.developer
+  --role=roles/container.clusterViewer
 
 gcloud artifacts repositories remove-iam-policy-binding docker \
   --location=us-central1 \
@@ -284,19 +240,26 @@ gcloud iam service-accounts delete $DEPLOY_SA_EMAIL
 ## Troubleshooting
 
 **`google-github-actions/auth` fails with `Permission 'iam.serviceAccounts.getAccessToken' denied`.**
-The SA binding to the pool is wrong. Re-run Path A step 4 and check that
+The SA binding to the pool is wrong. Re-run step 4 and check that
 `attribute.ref` / `attribute.environment` match the workflow's context.
 
 **Auth succeeds but `docker push` returns 403.**
-Missing `roles/artifactregistry.writer` on the `docker` repo. Re-run Path A
-step 2.
+Missing `roles/artifactregistry.writer` on the `docker` repo. Re-run step 2.
 
-**`helm upgrade` fails with `Unauthorized`.**
-Missing `roles/container.developer` OR the SA is valid but `kubectl` is using
-an old kubeconfig. Run `gcloud container clusters get-credentials` in the
-workflow before `helm`.
+**`helm upgrade` fails with `Unauthorized` or `forbidden`.**
+The Kubernetes RBAC binding is missing on this cluster. Re-run the
+`kubectl apply` block from step 2 against the target cluster. If auth
+itself is the issue, confirm the SA has `roles/container.clusterViewer`
+at project level so `gcloud container clusters get-credentials` can
+fetch kubeconfig.
+
+**`helm upgrade` returns `Forbidden: cannot create namespaces`.**
+The `edit` ClusterRole doesn't grant namespace creation. Either
+pre-create namespaces out-of-band, or switch the `roleRef.name` in the
+RBAC binding to `admin` (cluster-scoped admin on a specific cluster is
+still narrower than project-wide `roles/container.developer`).
 
 **PR from a fork triggers the workflow and `auth` succeeds.**
-`attribute-condition` on the provider was missed (Path A step 3). The
+`attribute-condition` on the provider was missed (step 3). The
 condition must include `assertion.repository=='Team-Commonly/commonly'` —
 verify with `gcloud iam workload-identity-pools providers describe`.

--- a/docs/deployment/GITHUB_DEPLOY_SETUP.md
+++ b/docs/deployment/GITHUB_DEPLOY_SETUP.md
@@ -1,0 +1,302 @@
+# GitHub Actions → GKE deploy setup
+
+Companion to [`ADR-009`](../adr/ADR-009-test-tiers-and-ci-cd-to-gke.md). Two
+paths: **Workload Identity Federation** (recommended, no long-lived credential
+in GitHub) and **Service Account JSON key** (fast path, one secret in GitHub,
+rotatable-forever).
+
+Pick one. Run the gcloud blocks once from an account with `roles/owner` (or
+`roles/iam.workloadIdentityPoolAdmin` + `roles/iam.serviceAccountAdmin` +
+`roles/resourcemanager.projectIamAdmin`) on `commonly-493005`.
+
+---
+
+## Prep (both paths)
+
+```bash
+# Replace if your project differs.
+export PROJECT_ID=commonly-493005
+export PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format='value(projectNumber)')
+export REPO=Team-Commonly/commonly
+
+gcloud config set project $PROJECT_ID
+
+# Enable APIs the deploy workflow needs.
+gcloud services enable \
+  iamcredentials.googleapis.com \
+  iam.googleapis.com \
+  artifactregistry.googleapis.com \
+  container.googleapis.com \
+  sts.googleapis.com
+```
+
+Sanity check:
+
+```bash
+gcloud container clusters list --filter="name~commonly"   # should show commonly-dev
+gcloud artifacts repositories list --location=us-central1 # should show 'docker'
+```
+
+---
+
+## Path A — Workload Identity Federation (recommended)
+
+Short-lived tokens minted per workflow run; no JSON key ever leaves GCP.
+
+### 1. Create the deploy service account
+
+```bash
+export DEPLOY_SA=deploy-github
+export DEPLOY_SA_EMAIL=$DEPLOY_SA@$PROJECT_ID.iam.gserviceaccount.com
+
+gcloud iam service-accounts create $DEPLOY_SA \
+  --display-name="GitHub Actions deploy (WIF)" \
+  --description="Used by .github/workflows/deploy-*.yml via WIF"
+```
+
+### 2. Grant the SA only what it needs
+
+```bash
+# Push images to the 'docker' AR repo (scoped, not project-wide admin).
+gcloud artifacts repositories add-iam-policy-binding docker \
+  --location=us-central1 \
+  --member="serviceAccount:$DEPLOY_SA_EMAIL" \
+  --role=roles/artifactregistry.writer
+
+# Talk to the dev cluster. Repeat for prod when you add it.
+gcloud container clusters get-credentials commonly-dev --region=us-central1
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:$DEPLOY_SA_EMAIL" \
+  --role=roles/container.developer \
+  --condition="expression=resource.name.endsWith('/clusters/commonly-dev'),title=commonly-dev-only"
+```
+
+> **Note:** `roles/container.developer` at project level with a condition is
+> simpler than cluster-level RBAC and fine for a two-cluster setup. Tighten to
+> cluster RBAC if you add a third environment.
+
+### 3. Create the WIF pool + GitHub provider
+
+```bash
+export POOL=github
+export PROVIDER=github-provider
+
+gcloud iam workload-identity-pools create $POOL \
+  --location=global \
+  --display-name="GitHub Actions"
+
+gcloud iam workload-identity-pools providers create-oidc $PROVIDER \
+  --location=global \
+  --workload-identity-pool=$POOL \
+  --display-name="GitHub OIDC" \
+  --issuer-uri="https://token.actions.githubusercontent.com" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.ref=assertion.ref,attribute.environment=assertion.environment,attribute.actor=assertion.actor" \
+  --attribute-condition="assertion.repository=='$REPO'"
+```
+
+The `attribute-condition` is the critical line — it blocks tokens minted by
+forks or other repos from ever exchanging for a GCP token, regardless of the
+binding below.
+
+### 4. Bind the SA to the pool
+
+Scope the binding to the branches/environments that should deploy. Two
+bindings: one for merge-to-main → dev, one for the prod environment.
+
+```bash
+export POOL_NAME=projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL
+
+# Dev: only refs/heads/main
+gcloud iam service-accounts add-iam-policy-binding $DEPLOY_SA_EMAIL \
+  --role=roles/iam.workloadIdentityUser \
+  --member="principalSet://iam.googleapis.com/$POOL_NAME/attribute.ref/refs/heads/main"
+
+# Prod: only the 'prod' GitHub environment (gated by reviewer in GitHub).
+gcloud iam service-accounts add-iam-policy-binding $DEPLOY_SA_EMAIL \
+  --role=roles/iam.workloadIdentityUser \
+  --member="principalSet://iam.googleapis.com/$POOL_NAME/attribute.environment/prod"
+```
+
+### 5. Capture the two values for GitHub
+
+```bash
+echo "WIF_PROVIDER=$POOL_NAME/providers/$PROVIDER"
+echo "WIF_SERVICE_ACCOUNT=$DEPLOY_SA_EMAIL"
+```
+
+### 6. Configure GitHub
+
+Repo **Settings → Secrets and variables → Actions → Repository secrets**:
+
+```
+WIF_PROVIDER          <value from above>
+WIF_SERVICE_ACCOUNT   deploy-github@commonly-493005.iam.gserviceaccount.com
+```
+
+Repo **Settings → Environments**:
+
+- Create `dev` — no approvers. Deploy-on-merge fires automatically.
+- Create `prod` — add **Required reviewers** (at least one), restrict to tags
+  matching `v*.*.*` under **Deployment branches and tags**.
+
+### 7. Workflow usage
+
+```yaml
+# .github/workflows/deploy-dev.yml (excerpt)
+permissions:
+  id-token: write   # required to mint the OIDC token
+  contents: read
+
+jobs:
+  deploy:
+    environment: dev
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      # docker build + push, helm upgrade, smoke probes — per ADR-009 Phase 3/4.
+```
+
+### 8. Verify
+
+```bash
+# From a workflow run log, confirm:
+#   google-github-actions/auth  succeeded
+#   `gcloud auth list` shows the deploy SA as active
+#   `gcloud container clusters get-credentials commonly-dev` succeeds
+```
+
+---
+
+## Path B — Service Account JSON key (fast path)
+
+One secret in GitHub, long-lived credential that you rotate manually. Use if
+you need to deploy *today* and can't wait for the WIF setup to land.
+
+### 1–2. SA + roles
+
+Same as Path A steps 1 and 2. Skip WIF pool/provider/binding (steps 3–4).
+
+### 3. Create a key
+
+```bash
+gcloud iam service-accounts keys create /tmp/deploy-github-key.json \
+  --iam-account=$DEPLOY_SA_EMAIL
+
+# Base64 so GitHub accepts it as a single-line secret.
+base64 -w0 /tmp/deploy-github-key.json > /tmp/deploy-github-key.b64
+cat /tmp/deploy-github-key.b64
+```
+
+### 4. GitHub secret
+
+**Settings → Secrets and variables → Actions**:
+
+```
+GCP_SA_KEY   <paste the base64 blob>
+```
+
+### 5. Workflow usage
+
+```yaml
+# .github/workflows/deploy-dev.yml (excerpt)
+permissions:
+  contents: read   # no id-token needed
+
+jobs:
+  deploy:
+    environment: dev
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+```
+
+### 6. Clean up the local file
+
+```bash
+shred -u /tmp/deploy-github-key.json /tmp/deploy-github-key.b64
+```
+
+### 7. Rotation
+
+```bash
+# List active keys
+gcloud iam service-accounts keys list --iam-account=$DEPLOY_SA_EMAIL
+
+# Revoke an old key by ID (after confirming the new one works)
+gcloud iam service-accounts keys delete <KEY_ID> --iam-account=$DEPLOY_SA_EMAIL
+```
+
+Do this at least every 90 days. Set a calendar reminder — there is no
+automatic expiry.
+
+---
+
+## Migration: Path B → Path A
+
+If you start with the JSON key and want to move to WIF later:
+
+1. Run Path A steps 3–6 (WIF pool, provider, binding, secrets).
+2. Update workflows to the Path A auth step.
+3. Verify one green deploy on the new path.
+4. Delete the SA key via step 7 of Path B.
+5. Delete the `GCP_SA_KEY` GitHub secret.
+
+No disruption if the workflow is updated in the same PR as the WIF binding.
+
+---
+
+## Revocation (both paths)
+
+### Revoke deploy access entirely
+
+```bash
+# Strips all IAM bindings on the SA. Deploys fail immediately.
+gcloud projects remove-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:$DEPLOY_SA_EMAIL" \
+  --role=roles/container.developer
+
+gcloud artifacts repositories remove-iam-policy-binding docker \
+  --location=us-central1 \
+  --member="serviceAccount:$DEPLOY_SA_EMAIL" \
+  --role=roles/artifactregistry.writer
+```
+
+### Delete the SA (nuclear)
+
+```bash
+gcloud iam service-accounts delete $DEPLOY_SA_EMAIL
+```
+
+---
+
+## Troubleshooting
+
+**`google-github-actions/auth` fails with `Permission 'iam.serviceAccounts.getAccessToken' denied`.**
+The SA binding to the pool is wrong. Re-run Path A step 4 and check that
+`attribute.ref` / `attribute.environment` match the workflow's context.
+
+**Auth succeeds but `docker push` returns 403.**
+Missing `roles/artifactregistry.writer` on the `docker` repo. Re-run Path A
+step 2.
+
+**`helm upgrade` fails with `Unauthorized`.**
+Missing `roles/container.developer` OR the SA is valid but `kubectl` is using
+an old kubeconfig. Run `gcloud container clusters get-credentials` in the
+workflow before `helm`.
+
+**PR from a fork triggers the workflow and `auth` succeeds.**
+`attribute-condition` on the provider was missed (Path A step 3). The
+condition must include `assertion.repository=='Team-Commonly/commonly'` —
+verify with `gcloud iam workload-identity-pools providers describe`.


### PR DESCRIPTION
Two docs-only commits. Locks in the direction; execution lands in follow-up PRs.

## What this PR decides

- **ADR-009** (`docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md`) — four-tier test taxonomy (unit / service / cluster / dev-env) with explicit PR gating, and workflow-triggered GKE deploys. Motivated by two gaps the ADR-002 Phase 1b-a review surfaced: "integration" tests don't actually use the CI service containers, and deploys require a local laptop.

- **Auth mechanism: Path A — Workload Identity Federation**. No long-lived SA JSON key in GitHub secrets; OIDC tokens minted per workflow run, exchanged for short-lived GCP tokens. See `docs/deployment/GITHUB_DEPLOY_SETUP.md` for exact `gcloud` commands.

## What this PR does NOT do

- Rename `__tests__/integration/` → `__tests__/service/` (Phase 1, follow-up PR).
- Add `.github/workflows/deploy-dev.yml` (Phase 3, blocked on human running the gcloud commands below).
- Touch `values-private.yaml` or migrate config to committed `values-dev.yaml` (Phase 3).

## Human action required before Phase 3 can land

From `docs/deployment/GITHUB_DEPLOY_SETUP.md` Path A, run the gcloud blocks against `commonly-493005` (needs `roles/owner` or equivalent), then configure GitHub:

1. Create the `deploy-github@` SA + scope `roles/artifactregistry.writer` (on `docker` AR repo) and `roles/container.developer` (conditional, `commonly-dev` only for now).
2. Stand up the WIF pool + provider with `assertion.repository=='Team-Commonly/commonly'`.
3. Bind SA to pool: `refs/heads/main` for dev, `environment:prod` for prod.
4. Repo secrets: `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`.
5. Repo environments: `dev` (no approvers), `prod` (required reviewer + tag filter `v*.*.*`).

Once those are in place I can scaffold `deploy-dev.yml` in a follow-up PR.

## Test plan

- [x] ADR references `REVIEW.md`, `KUBERNETES.md`, `ADR-002` correctly.
- [x] CLAUDE.md key-docs list updated to include ADR-009.
- [x] Runbook gcloud commands match required roles (AR writer scoped to `docker` repo; container.developer with cluster-name condition).
- [ ] Team sanity-checks the tier renames (naming bikeshed welcome) and the WIF setup plan.
- [ ] Human runs Path A setup; confirms `WIF_PROVIDER` + `WIF_SERVICE_ACCOUNT` are in repo secrets.
- [ ] Follow-up PR: Phase 1 rename + `setupMongoDb` / `setupPgDb` honor `INTEGRATION_TEST=true`.
- [ ] Follow-up PR: Phase 3 `deploy-dev.yml` (unblocks after WIF setup).

https://claude.ai/code/session_01JGkwSJkDKerKRsnzUe8Mxe