### PR TITLE
Add project pod workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ Agents Hub `Installed` and `Discover` tabs should resolve agent avatars with the
 Registry installed-agent listing (`/api/registry/pods/:podId/agents`) should prefer matching template `iconUrl` by `(agentName + displayName)` before falling back to registry icon.
 Pod browse page (`/pods/:type`) should prioritize pre-entry UX: quick filters (`All`, `Joined`, `Discover`), preview-before-join action, and responsive controls that stay usable on phones.
 Pod browse cards should show a role-aware member avatar strip (users/agents, max 4 + overflow) so users can gauge pod makeup before joining.
+Project pods (`type="project"`) use a dedicated two-tab workspace (`Chat`, `Tasks`) rather than the generic pod shell; keep the project header prominent, keep the brief/key info in the right sidebar on chat, and treat task state as structured project data rather than a kanban board.
 Pod overview member strips should resolve agent avatars from `/api/registry/pods/:podId/agents` so displayed agent icons match Agent Hub card avatars.
 Joined pod cards should display an obvious unread signal (red dot + unread chip) when new pod messages arrive after the local per-pod read cursor.
 Pod card lightbulb should toggle between description and cached summary without auto-regenerating; summary regeneration should require the refresh action, and view mode should persist per pod.

--- a/backend/__tests__/unit/controllers/podController.test.js
+++ b/backend/__tests__/unit/controllers/podController.test.js
@@ -72,6 +72,56 @@ describe('podController', () => {
     expect(res.json).toHaveBeenCalledWith([]);
   });
 
+  it('createPod accepts project type and project metadata', async () => {
+    const savedPod = {
+      _id: 'project-1',
+      name: 'Website Relaunch',
+      type: 'project',
+      projectMeta: {
+        goal: 'Ship the new marketing site',
+        scope: 'Landing page and onboarding',
+        successCriteria: ['launch', 'handoff'],
+        status: 'planning',
+      },
+      populate: jest.fn().mockResolvedValue(),
+    };
+    const save = jest.fn().mockResolvedValue(savedPod);
+    Pod.mockImplementation((payload) => ({
+      ...payload,
+      save,
+    }));
+    AgentRegistry.findOne.mockResolvedValue(null);
+
+    const req = {
+      body: {
+        name: 'Website Relaunch',
+        description: 'Project pod',
+        type: 'project',
+        projectMeta: {
+          goal: 'Ship the new marketing site',
+          scope: 'Landing page and onboarding',
+          successCriteria: ['launch', 'handoff'],
+        },
+      },
+      userId: 'creator',
+    };
+    const res = { json: jest.fn(), status: jest.fn().mockReturnThis(), send: jest.fn() };
+
+    await podController.createPod(req, res);
+
+    expect(Pod).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'project',
+      projectMeta: expect.objectContaining({
+        goal: 'Ship the new marketing site',
+        scope: 'Landing page and onboarding',
+        successCriteria: ['launch', 'handoff'],
+        status: 'planning',
+        ownerIds: ['creator'],
+      }),
+    }));
+    expect(res.json).toHaveBeenCalledWith(savedPod);
+  });
+
   it('createPod accepts agent-ensemble type', async () => {
     const savedPod = { _id: 'p1', populate: jest.fn().mockResolvedValue() };
     const save = jest.fn().mockResolvedValue(savedPod);

--- a/backend/__tests__/unit/models/Pod.test.js
+++ b/backend/__tests__/unit/models/Pod.test.js
@@ -174,4 +174,29 @@ describe('Pod Model Tests', () => {
       mockExternalLinkId.toString(),
     );
   });
+
+  it('should save project metadata on project pods', async () => {
+    const pod = new Pod({
+      name: 'Project Pod',
+      description: 'Work workspace',
+      type: 'project',
+      createdBy: testUser._id,
+      projectMeta: {
+        goal: 'Launch v1',
+        scope: 'Frontend and backend',
+        successCriteria: ['launch checklist complete'],
+        status: 'planning',
+        keyLinks: [{ label: 'Figma', url: 'https://example.com/figma' }],
+      },
+    });
+
+    const savedPod = await pod.save();
+
+    expect(savedPod.type).toBe('project');
+    expect(savedPod.projectMeta.goal).toBe('Launch v1');
+    expect(savedPod.projectMeta.scope).toBe('Frontend and backend');
+    expect(savedPod.projectMeta.successCriteria).toEqual(['launch checklist complete']);
+    expect(savedPod.projectMeta.status).toBe('planning');
+    expect(savedPod.projectMeta.keyLinks).toHaveLength(1);
+  });
 });

--- a/backend/controllers/podController.ts
+++ b/backend/controllers/podController.ts
@@ -16,7 +16,7 @@ if (process.env.PG_HOST) {
   PGMessage = require('../models/pg/Message');
 }
 
-const VALID_POD_TYPES = ['chat', 'study', 'games', 'agent-ensemble', 'agent-admin', 'agent-room', 'team'];
+const VALID_POD_TYPES = ['chat', 'study', 'games', 'project', 'agent-ensemble', 'agent-admin', 'agent-room', 'team'];
 const DEFAULT_POD_AGENT = process.env.DEFAULT_POD_AGENT_NAME || 'commonly-bot';
 const DEFAULT_POD_AGENT_SCOPES = [
   'context:read',
@@ -242,7 +242,7 @@ exports.getPodById = async (req: any, res: any) => {
 exports.createPod = async (req: any, res: any) => {
   try {
     const {
-      name, description, type, joinPolicy, parentPod,
+      name, description, type, joinPolicy, parentPod, projectMeta,
     } = req.body;
 
     if (!name || !type) {
@@ -258,6 +258,19 @@ exports.createPod = async (req: any, res: any) => {
       description,
       type,
       joinPolicy: joinPolicy === 'invite-only' ? 'invite-only' : 'open',
+      projectMeta: type === 'project'
+        ? {
+            goal: projectMeta?.goal || description || '',
+            scope: projectMeta?.scope || '',
+            successCriteria: Array.isArray(projectMeta?.successCriteria) ? projectMeta.successCriteria : [],
+            status: projectMeta?.status || 'planning',
+            dueDate: projectMeta?.dueDate || null,
+            ownerIds: Array.isArray(projectMeta?.ownerIds) && projectMeta.ownerIds.length
+              ? projectMeta.ownerIds
+              : [req.userId],
+            keyLinks: Array.isArray(projectMeta?.keyLinks) ? projectMeta.keyLinks : [],
+          }
+        : undefined,
       parentPod: parentPod || null,
       createdBy: req.userId,
       members: [req.userId],
@@ -304,6 +317,74 @@ exports.createPod = async (req: any, res: any) => {
   } catch (err: any) {
     console.error(err.message);
     res.status(500).send('Server Error');
+  }
+};
+
+exports.updatePod = async (req: any, res: any) => {
+  try {
+    const { id } = req.params;
+    const {
+      name, description, joinPolicy, parentPod, projectMeta,
+    } = req.body || {};
+
+    const pod = await Pod.findById(id);
+    if (!pod) {
+      return res.status(404).json({ msg: 'Pod not found' });
+    }
+
+    const requesterId = req.userId || req.user?.id || req.user?._id;
+    const isCreator = pod.createdBy.toString() === requesterId?.toString();
+    const isGlobalAdmin = await isGlobalAdminRequest(req);
+    if (!isCreator && !isGlobalAdmin) {
+      return res.status(403).json({ msg: 'Not authorized to update this pod' });
+    }
+
+    if (typeof name === 'string') pod.name = name.trim();
+    if (typeof description === 'string') pod.description = description.trim();
+    if (joinPolicy === 'invite-only' || joinPolicy === 'open') pod.joinPolicy = joinPolicy;
+    if (parentPod !== undefined) pod.parentPod = parentPod || null;
+
+    if (pod.type === 'project' && projectMeta && typeof projectMeta === 'object') {
+      if (typeof projectMeta.goal === 'string') pod.projectMeta.goal = projectMeta.goal.trim();
+      if (typeof projectMeta.scope === 'string') pod.projectMeta.scope = projectMeta.scope.trim();
+      if (Array.isArray(projectMeta.successCriteria)) {
+        pod.projectMeta.successCriteria = projectMeta.successCriteria
+          .map((value: unknown) => String(value || '').trim())
+          .filter(Boolean);
+      }
+      if (['planning', 'on-track', 'at-risk', 'blocked', 'complete'].includes(String(projectMeta.status))) {
+        pod.projectMeta.status = String(projectMeta.status);
+      }
+      if (projectMeta.dueDate === null || projectMeta.dueDate === '') {
+        pod.projectMeta.dueDate = null;
+      } else if (projectMeta.dueDate) {
+        pod.projectMeta.dueDate = new Date(projectMeta.dueDate);
+      }
+      if (Array.isArray(projectMeta.ownerIds)) {
+        pod.projectMeta.ownerIds = projectMeta.ownerIds;
+      }
+      if (Array.isArray(projectMeta.keyLinks)) {
+        pod.projectMeta.keyLinks = projectMeta.keyLinks
+          .map((link: any) => ({
+            label: String(link?.label || '').trim(),
+            url: String(link?.url || '').trim(),
+          }))
+          .filter((link: any) => link.label || link.url);
+      }
+    }
+
+    pod.updatedAt = Date.now();
+    await pod.save();
+    await pod.populate('createdBy', 'username profilePicture');
+    await pod.populate('members', 'username profilePicture');
+
+    return res.json(pod);
+  } catch (err: any) {
+    console.error('Error updating pod:', err.message);
+    if (err.kind === 'ObjectId') {
+      return res.status(404).json({ msg: 'Pod not found' });
+    }
+    return res.status(500).json({ msg: 'Server Error' });
   }
 };
 

--- a/backend/models/Pod.ts
+++ b/backend/models/Pod.ts
@@ -1,9 +1,10 @@
 import mongoose, { Document, Schema, Types } from 'mongoose';
 
-export type PodType = 'chat' | 'study' | 'games' | 'agent-ensemble' | 'agent-admin' | 'agent-room' | 'team';
+export type PodType = 'chat' | 'study' | 'games' | 'project' | 'agent-ensemble' | 'agent-admin' | 'agent-room' | 'team';
 export type PodJoinPolicy = 'open' | 'invite-only';
 export type EnsembleParticipantRole = 'starter' | 'responder' | 'synthesizer' | 'observer';
 export type HumanParticipation = 'none' | 'read-only' | 'participate';
+export type ProjectStatus = 'planning' | 'on-track' | 'at-risk' | 'blocked' | 'complete';
 
 export interface IEnsembleParticipant {
   agentType: string;
@@ -16,6 +17,18 @@ export interface IPod extends Document {
   description?: string;
   type: PodType;
   joinPolicy: PodJoinPolicy;
+  projectMeta: {
+    goal?: string;
+    scope?: string;
+    successCriteria: string[];
+    status: ProjectStatus;
+    dueDate?: Date | null;
+    ownerIds: Types.ObjectId[];
+    keyLinks: Array<{
+      label: string;
+      url: string;
+    }>;
+  };
   parentPod?: Types.ObjectId | null;
   agentEnsemble: {
     enabled: boolean;
@@ -48,13 +61,31 @@ const PodSchema = new Schema<IPod>(
     description: { type: String, trim: true },
     type: {
       type: String,
-      enum: ['chat', 'study', 'games', 'agent-ensemble', 'agent-admin', 'agent-room', 'team'],
+      enum: ['chat', 'study', 'games', 'project', 'agent-ensemble', 'agent-admin', 'agent-room', 'team'],
       default: 'chat',
     },
     joinPolicy: {
       type: String,
       enum: ['open', 'invite-only'],
       default: 'open',
+    },
+    projectMeta: {
+      goal: { type: String, trim: true, default: '' },
+      scope: { type: String, trim: true, default: '' },
+      successCriteria: { type: [String], default: [] },
+      status: {
+        type: String,
+        enum: ['planning', 'on-track', 'at-risk', 'blocked', 'complete'],
+        default: 'planning',
+      },
+      dueDate: { type: Date, default: null },
+      ownerIds: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+      keyLinks: [
+        {
+          label: { type: String, trim: true, default: '' },
+          url: { type: String, trim: true, default: '' },
+        },
+      ],
     },
     parentPod: { type: Schema.Types.ObjectId, ref: 'Pod', default: null },
     agentEnsemble: {

--- a/backend/models/Task.ts
+++ b/backend/models/Task.ts
@@ -1,11 +1,15 @@
 import mongoose, { Document, Model, Schema, Types } from 'mongoose';
 
 export type TaskStatus = 'pending' | 'claimed' | 'done' | 'blocked';
+export type TaskUpdateKind = 'note' | 'progress' | 'blocker' | 'handoff' | 'decision' | 'completion';
 
 export interface ITaskUpdate {
   text: string;
   author: string;
   authorId?: string | null;
+  kind?: TaskUpdateKind;
+  progressPercent?: number | null;
+  nextStep?: string | null;
   createdAt: Date;
 }
 
@@ -14,11 +18,17 @@ export interface ITask extends Document {
   taskNum: number;
   taskId: string;
   title: string;
+  description?: string | null;
   assignee?: string | null;
+  assigneeType?: 'human' | 'agent' | null;
+  assigneeRef?: string | null;
   dep?: string | null;
   depMockOk: boolean;
   parentTask?: string | null;
   status: TaskStatus;
+  priority?: 'low' | 'medium' | 'high' | null;
+  dueDate?: Date | null;
+  progressPercent?: number | null;
   claimedBy?: string | null;
   claimedAt?: Date | null;
   completedAt?: Date | null;
@@ -28,6 +38,15 @@ export interface ITask extends Document {
   sourceRef?: string;
   githubIssueNumber?: number | null;
   githubIssueUrl?: string | null;
+  blocker?: {
+    open: boolean;
+    reason?: string | null;
+    waitingOn?: string | null;
+    severity?: 'low' | 'medium' | 'high' | null;
+    openedAt?: Date | null;
+    openedBy?: string | null;
+    resolvedAt?: Date | null;
+  };
   updates: ITaskUpdate[];
   createdAt: Date;
   updatedAt: Date;
@@ -39,7 +58,10 @@ const TaskSchema = new Schema<ITask>(
     taskNum: { type: Number, required: true },
     taskId: { type: String, required: true },
     title: { type: String, required: true },
+    description: { type: String, default: null },
     assignee: { type: String, default: null },
+    assigneeType: { type: String, enum: ['human', 'agent'], default: null },
+    assigneeRef: { type: String, default: null },
     dep: { type: String, default: null },
     depMockOk: { type: Boolean, default: false },
     parentTask: { type: String, default: null },
@@ -48,6 +70,13 @@ const TaskSchema = new Schema<ITask>(
       enum: ['pending', 'claimed', 'done', 'blocked'],
       default: 'pending',
     },
+    priority: {
+      type: String,
+      enum: ['low', 'medium', 'high'],
+      default: 'medium',
+    },
+    dueDate: { type: Date, default: null },
+    progressPercent: { type: Number, default: 0, min: 0, max: 100 },
     claimedBy: { type: String, default: null },
     claimedAt: { type: Date, default: null },
     completedAt: { type: Date, default: null },
@@ -57,11 +86,31 @@ const TaskSchema = new Schema<ITask>(
     sourceRef: { type: String },
     githubIssueNumber: { type: Number, default: null },
     githubIssueUrl: { type: String, default: null },
+    blocker: {
+      open: { type: Boolean, default: false },
+      reason: { type: String, default: null },
+      waitingOn: { type: String, default: null },
+      severity: {
+        type: String,
+        enum: ['low', 'medium', 'high'],
+        default: 'medium',
+      },
+      openedAt: { type: Date, default: null },
+      openedBy: { type: String, default: null },
+      resolvedAt: { type: Date, default: null },
+    },
     updates: [
       {
         text: { type: String, required: true },
         author: { type: String, required: true },
         authorId: { type: String, default: null },
+        kind: {
+          type: String,
+          enum: ['note', 'progress', 'blocker', 'handoff', 'decision', 'completion'],
+          default: 'note',
+        },
+        progressPercent: { type: Number, default: null, min: 0, max: 100 },
+        nextStep: { type: String, default: null },
         createdAt: { type: Date, default: Date.now },
       },
     ],

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -1676,7 +1676,7 @@ router.post('/pods', agentRuntimeAuth, async (req: any, res: any) => {
       return res.status(400).json({ message: 'name and type are required' });
     }
 
-    const VALID_POD_TYPES = ['chat', 'study', 'games', 'agent-ensemble', 'agent-admin'];
+    const VALID_POD_TYPES = ['chat', 'project', 'study', 'games', 'agent-ensemble', 'agent-admin'];
     if (!VALID_POD_TYPES.includes(type)) {
       return res.status(400).json({ message: `Invalid pod type. Must be one of: ${VALID_POD_TYPES.join(', ')}` });
     }

--- a/backend/routes/pods.ts
+++ b/backend/routes/pods.ts
@@ -7,7 +7,7 @@ const multer = require('multer');
 // eslint-disable-next-line global-require
 const auth = require('../middleware/auth');
 // eslint-disable-next-line global-require
-const { getAllPods, getPodsByType, getPodById, createPod, joinPod, leavePod, removeMember, deletePod } = require('../controllers/podController');
+const { getAllPods, getPodsByType, getPodById, createPod, updatePod, joinPod, leavePod, removeMember, deletePod } = require('../controllers/podController');
 // eslint-disable-next-line global-require
 const Pod = require('../models/Pod');
 // eslint-disable-next-line global-require
@@ -59,6 +59,7 @@ const upload = multer({
 
 router.get('/', auth, getAllPods);
 router.post('/', auth, createPod);
+router.patch('/:id', auth, updatePod);
 
 router.post('/announcement', auth, async (req: AuthReq, res: Res) => {
   try {

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -13,7 +13,11 @@ const Task = require('../models/Task');
 // eslint-disable-next-line global-require
 const User = require('../models/User');
 // eslint-disable-next-line global-require
+const { AgentInstallation } = require('../models/AgentRegistry');
+// eslint-disable-next-line global-require
 const GitHubAppService = require('../services/githubAppService');
+// eslint-disable-next-line global-require
+const AgentEventService = require('../services/agentEventService');
 // eslint-disable-next-line global-require
 const { emitTaskUpdated } = require('../services/taskEventService');
 
@@ -53,6 +57,74 @@ async function resolveAuthor(req: AuthReq): Promise<string> {
 function resolveAgentInstanceId(req: AuthReq): string | null {
   if (!req.user?.isBot) return null;
   return req.user.botMetadata?.instanceId || req.user.botMetadata?.agentName || null;
+}
+
+function slugify(value: unknown): string {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+async function enqueueTaskAssignedIfNeeded({
+  podId,
+  task,
+}: {
+  podId: string;
+  task: Record<string, unknown>;
+}): Promise<void> {
+  if (!task || task.assigneeType !== 'agent') return;
+
+  const assigneeRef = String(task.assigneeRef || '').trim().toLowerCase();
+  const assigneeLabel = String(task.assignee || '').trim();
+
+  let installation = null;
+  if (assigneeRef) {
+    installation = await AgentInstallation.findOne({
+      podId: mongoose.Types.ObjectId.createFromHexString(podId),
+      instanceId: assigneeRef,
+      status: 'active',
+    }).lean();
+  }
+
+  if (!installation && assigneeLabel) {
+    const installs = await AgentInstallation.find({
+      podId: mongoose.Types.ObjectId.createFromHexString(podId),
+      status: 'active',
+    }).select('agentName instanceId displayName').lean();
+    const normalizedLabel = slugify(assigneeLabel);
+    installation = installs.find((item: any) => (
+      slugify(item.instanceId) === normalizedLabel
+      || slugify(item.displayName) === normalizedLabel
+      || slugify(item.agentName) === normalizedLabel
+      || slugify(`${item.agentName}-${item.instanceId}`) === normalizedLabel
+    )) || null;
+  }
+
+  if (!installation) return;
+
+  await AgentEventService.enqueue({
+    agentName: installation.agentName,
+    instanceId: installation.instanceId || 'default',
+    podId,
+    type: 'task.assigned',
+    payload: {
+      taskId: task.taskId,
+      title: task.title,
+      description: task.description || null,
+      notes: task.notes || null,
+      priority: task.priority || 'medium',
+      dueDate: task.dueDate || null,
+      progressPercent: task.progressPercent ?? 0,
+      assignee: task.assignee || null,
+      assigneeRef: task.assigneeRef || null,
+      dep: task.dep || null,
+      parentTask: task.parentTask || null,
+      blocker: task.blocker || null,
+    },
+  });
 }
 
 async function requirePodMember(podId: string, userId: unknown, { write = false } = {}): Promise<{ error?: string; status?: number; pod?: unknown }> {
@@ -97,7 +169,26 @@ router.post('/:podId', auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId } = req.params || {};
     const userId = req.userId || req.user?._id || req.agentUser?._id;
-    const { title, assignee, dep, depMockOk, parentTask, source, sourceRef, githubIssueNumber, githubIssueUrl, createGithubIssue } = (req.body || {}) as { title?: string; assignee?: string; dep?: string; depMockOk?: boolean; parentTask?: string; source?: string; sourceRef?: string; githubIssueNumber?: number; githubIssueUrl?: string; createGithubIssue?: boolean };
+    const {
+      title, description, assignee, assigneeType, assigneeRef, dep, depMockOk, parentTask,
+      source, sourceRef, githubIssueNumber, githubIssueUrl, createGithubIssue, priority, dueDate,
+    } = (req.body || {}) as {
+      title?: string;
+      description?: string;
+      assignee?: string;
+      assigneeType?: 'human' | 'agent';
+      assigneeRef?: string;
+      dep?: string;
+      depMockOk?: boolean;
+      parentTask?: string;
+      source?: string;
+      sourceRef?: string;
+      githubIssueNumber?: number;
+      githubIssueUrl?: string;
+      createGithubIssue?: boolean;
+      priority?: 'low' | 'medium' | 'high';
+      dueDate?: string;
+    };
     if (!title) return res.status(400).json({ error: 'title is required' });
     const access = await requirePodMember(podId || '', userId, { write: true });
     if (access.error) return res.status(access.status || 500).json({ error: access.error });
@@ -140,7 +231,26 @@ router.post('/:podId', auth, async (req: AuthReq, res: Res) => {
     if (sourceRef) initUpdate.text = `Created by ${author} from ${sourceRef}${assignee ? ` · assigned to ${assignee}` : ''}`;
     if (ghNumber) initUpdate.text += ` · GH#${ghNumber}`;
     if (parentTask) initUpdate.text += ` · sub-task of ${parentTask}`;
-    const task = await Task.create({ podId, taskNum, taskId, title, assignee: assignee || null, dep: dep || null, depMockOk: !!depMockOk, parentTask: parentTask || null, source: source || (ghNumber ? 'github' : 'human'), sourceRef: sourceRef || (ghNumber ? `GH#${ghNumber}` : undefined), githubIssueNumber: ghNumber, githubIssueUrl: ghUrl, updates: [initUpdate] });
+    const task = await Task.create({
+      podId,
+      taskNum,
+      taskId,
+      title,
+      description: description || null,
+      assignee: assignee || null,
+      assigneeType: assigneeType || (assignee ? 'human' : null),
+      assigneeRef: assigneeRef || null,
+      dep: dep || null,
+      depMockOk: !!depMockOk,
+      parentTask: parentTask || null,
+      priority: priority || 'medium',
+      dueDate: dueDate ? new Date(dueDate) : null,
+      source: source || (ghNumber ? 'github' : 'human'),
+      sourceRef: sourceRef || (ghNumber ? `GH#${ghNumber}` : undefined),
+      githubIssueNumber: ghNumber,
+      githubIssueUrl: ghUrl,
+      updates: [initUpdate],
+    });
     if (parentTask && GitHubAppService.isPatConfigured()) {
       try {
         const parent = await Task.findOne({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId: parentTask }).lean() as { githubIssueNumber?: number } | null;
@@ -153,6 +263,10 @@ router.post('/:podId', auth, async (req: AuthReq, res: Res) => {
       }
     }
     emitTaskUpdated(podId, task, 'created');
+    await enqueueTaskAssignedIfNeeded({
+      podId,
+      task: task.toObject ? task.toObject() : task,
+    });
     return res.status(201).json({ task });
   } catch (err) {
     console.error('POST /tasks error:', err);
@@ -192,7 +306,34 @@ router.post('/:podId/:taskId/complete', auth, async (req: AuthReq, res: Res) => 
     const access = await requirePodMember(podId || '', userId, { write: true });
     if (access.error) return res.status(access.status || 500).json({ error: access.error });
     const updateText = prUrl ? `Completed by ${author} · PR: ${prUrl}` : `Completed by ${author}`;
-    const update = { $set: { status: 'done', completedAt: new Date(), ...(prUrl && { prUrl }), ...(notes && { notes }) }, $push: { updates: { text: updateText, author, authorId: userId?.toString() || null, createdAt: new Date() } } };
+    const update = {
+      $set: {
+        status: 'done',
+        completedAt: new Date(),
+        progressPercent: 100,
+        blocker: {
+          open: false,
+          reason: null,
+          waitingOn: null,
+          severity: 'medium',
+          openedAt: null,
+          openedBy: null,
+          resolvedAt: new Date(),
+        },
+        ...(prUrl && { prUrl }),
+        ...(notes && { notes }),
+      },
+      $push: {
+        updates: {
+          text: updateText,
+          author,
+          authorId: userId?.toString() || null,
+          createdAt: new Date(),
+          kind: 'completion',
+          progressPercent: 100,
+        },
+      },
+    };
     const task = await Task.findOneAndUpdate({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId, status: { $in: ['claimed', 'pending'] } }, update, { new: true }) as { githubIssueNumber?: number; taskId?: string; updates?: unknown[] } | null;
     if (!task) {
       const existing = await Task.findOne({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId }).lean() as { status?: string } | null;
@@ -226,12 +367,38 @@ router.post('/:podId/:taskId/updates', auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId, taskId } = req.params || {};
     const userId = req.userId || req.user?._id || req.agentUser?._id;
-    const { text } = (req.body || {}) as { text?: string };
+    const { text, kind, progressPercent, nextStep } = (req.body || {}) as {
+      text?: string;
+      kind?: 'note' | 'progress' | 'blocker' | 'handoff' | 'decision' | 'completion';
+      progressPercent?: number;
+      nextStep?: string;
+    };
     if (!text?.trim()) return res.status(400).json({ error: 'text is required' });
     const access = await requirePodMember(podId || '', userId, { write: true });
     if (access.error) return res.status(access.status || 500).json({ error: access.error });
     const author = await resolveAuthor(req);
-    const task = await Task.findOneAndUpdate({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId }, { $push: { updates: { text: text.trim(), author, authorId: userId?.toString() || null, createdAt: new Date() } } }, { new: true });
+    const updatePayload: Record<string, unknown> = {
+      text: text.trim(),
+      author,
+      authorId: userId?.toString() || null,
+      createdAt: new Date(),
+      kind: kind || 'note',
+    };
+    if (progressPercent !== undefined && progressPercent !== null) {
+      updatePayload.progressPercent = Math.max(0, Math.min(100, Number(progressPercent)));
+    }
+    if (nextStep) updatePayload.nextStep = String(nextStep);
+    const taskUpdate: Record<string, unknown> = {
+      $push: { updates: updatePayload },
+    };
+    if (progressPercent !== undefined && progressPercent !== null) {
+      taskUpdate.$set = { progressPercent: Math.max(0, Math.min(100, Number(progressPercent))) };
+    }
+    const task = await Task.findOneAndUpdate(
+      { podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId },
+      taskUpdate,
+      { new: true },
+    );
     if (!task) return res.status(404).json({ error: 'Task not found' });
     emitTaskUpdated(podId, task, 'updated');
     return res.json({ task });
@@ -245,7 +412,10 @@ router.patch('/:podId/:taskId', auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId, taskId } = req.params || {};
     const userId = req.userId || req.user?._id || req.agentUser?._id;
-    const allowed = ['title', 'assignee', 'dep', 'depMockOk', 'parentTask', 'status', 'notes', 'prUrl'];
+    const allowed = [
+      'title', 'description', 'assignee', 'assigneeType', 'assigneeRef', 'dep', 'depMockOk', 'parentTask',
+      'status', 'notes', 'prUrl', 'priority', 'dueDate', 'progressPercent', 'blocker',
+    ];
     const fieldUpdates: Record<string, unknown> = {};
     const body = (req.body || {}) as Record<string, unknown>;
     allowed.forEach((k) => { if (body[k] !== undefined) fieldUpdates[k] = body[k]; });
@@ -255,17 +425,29 @@ router.patch('/:podId/:taskId', auth, async (req: AuthReq, res: Res) => {
     const author = await resolveAuthor(req);
     const changeParts: string[] = [];
     if (fieldUpdates.assignee !== undefined) changeParts.push(`reassigned to ${fieldUpdates.assignee || 'unassigned'}`);
+    if (fieldUpdates.assigneeType !== undefined) changeParts.push(`assignee type → ${fieldUpdates.assigneeType || 'none'}`);
     if (fieldUpdates.status !== undefined) changeParts.push(`status → ${fieldUpdates.status}`);
     if (fieldUpdates.dep !== undefined) changeParts.push(`dep → ${fieldUpdates.dep || 'none'}`);
     if (fieldUpdates.parentTask !== undefined) changeParts.push(`parent → ${fieldUpdates.parentTask || 'none'}`);
     if (fieldUpdates.prUrl !== undefined) changeParts.push(`PR: ${fieldUpdates.prUrl}`);
     if (fieldUpdates.notes !== undefined) changeParts.push('notes updated');
     if (fieldUpdates.title !== undefined) changeParts.push('title updated');
+    if (fieldUpdates.progressPercent !== undefined) changeParts.push(`progress → ${fieldUpdates.progressPercent}%`);
+    if (fieldUpdates.blocker !== undefined) {
+      const blocker = fieldUpdates.blocker as { open?: boolean };
+      changeParts.push(blocker?.open ? 'blocker raised' : 'blocker cleared');
+    }
     const update: Record<string, unknown> = { $set: fieldUpdates };
     if (changeParts.length > 0) update.$push = { updates: { text: `${author} updated: ${changeParts.join(', ')}`, author, authorId: userId?.toString() || null, createdAt: new Date() } };
     const task = await Task.findOneAndUpdate({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId }, update, { new: true });
     if (!task) return res.status(404).json({ error: 'Task not found' });
     emitTaskUpdated(podId, task, 'updated');
+    if (fieldUpdates.assignee !== undefined || fieldUpdates.assigneeRef !== undefined || fieldUpdates.assigneeType !== undefined) {
+      await enqueueTaskAssignedIfNeeded({
+        podId,
+        task: task.toObject ? task.toObject() : task,
+      });
+    }
     return res.json({ task });
   } catch (err) {
     console.error('PATCH /tasks error:', err);

--- a/backend/start-dev.sh
+++ b/backend/start-dev.sh
@@ -6,7 +6,10 @@ echo "Starting Commonly Backend (dev)..."
 if [ ! -d "/app/node_modules" ] \
     || [ -z "$(ls -A /app/node_modules 2>/dev/null)" ] \
     || [ ! -d "/app/node_modules/@google/generative-ai" ] \
-    || [ ! -f "/app/node_modules/.bin/ts-node" ]; then
+    || [ ! -f "/app/node_modules/.bin/ts-node" ] \
+    || [ ! -f "/app/node_modules/.bin/jest" ] \
+    || [ ! -f "/app/node_modules/.bin/tsc" ] \
+    || [ ! -d "/app/node_modules/ts-jest" ]; then
     echo "Installing backend dependencies (dev)..."
     npm install --include=dev
 else

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,7 +23,7 @@ services:
       POSTGRES_PASSWORD: ${PG_PASSWORD:-postgres}
       POSTGRES_DB: ${PG_DATABASE:-commonly}
     volumes:
-      - postgres-data-dev:/var/lib/postgresql/data
+      - postgres-data-dev:/var/lib/postgresql
     networks:
       - app-network-dev
 

--- a/docs/design/PROJECT_POD.md
+++ b/docs/design/PROJECT_POD.md
@@ -1,0 +1,342 @@
+# Project Pod
+
+## Summary
+
+`Project` is a new pod type for work coordination between humans and agents.
+
+It keeps the pod model, chat transport, agent installs, and shared memory that already exist in Commonly, but it replaces the generic pod presentation with a dedicated execution-first workspace:
+
+- `Chat` tab:
+  - persistent project header
+  - main chat as the primary collaboration surface
+  - right sidebar for brief, success criteria, key links, owners, blockers, and member/agent context
+- `Tasks` tab:
+  - full task navigator + task detail workspace
+  - no board view
+  - task actions centered on assignment, progress, blockers, and completion
+
+The intent is to shift Commonly from "social/chat with tasks attached" toward "work coordination with chat built in."
+
+## Goals
+
+- Keep pods as the collaboration boundary.
+- Add a work-first pod template without breaking existing chat/study/game/team pods.
+- Make humans and agents feel like members of the same delivery team.
+- Track execution state in structured task records instead of freeform chat.
+- Preserve existing agent runtime/event plumbing so project pods participate in the same ecosystem.
+
+## UX
+
+### Header
+
+The top of a project pod always shows:
+
+- project name
+- short description
+- project health/status
+- due date
+- open-task and blocker counts
+- primary actions: `New Task`, `Edit Project`
+
+### Chat Tab
+
+The chat tab stays primary for day-to-day collaboration.
+
+Layout:
+
+- main center column: chat stream + composer
+- right sidebar:
+  - brief/goal
+  - scope
+  - success criteria
+  - key information
+  - key links
+  - members and installed agents
+
+Rule:
+
+- chat is for discussion
+- task updates may be discussed in chat
+- source of truth for execution lives in tasks, not chat messages
+
+### Tasks Tab
+
+The tasks tab is not a kanban board.
+
+Layout:
+
+- left rail:
+  - search
+  - filters (`all`, `mine`, `human`, `agent`, `blocked`, `done`)
+  - task list
+- main pane:
+  - task header and status
+  - assignee/meta chips
+  - description
+  - blocker state
+  - update timeline
+  - task action buttons
+
+## Task Workflow
+
+Current implementation maps onto the existing backend task statuses:
+
+- `pending` → Todo
+- `claimed` → In Progress
+- `blocked` → Blocked
+- `done` → Done
+
+Supported actions in the project pod UI:
+
+- `Take task`
+- `Assign`
+- `Post progress`
+- `Raise blocker`
+- `Clear blocker`
+- `Complete`
+
+## Data Model
+
+### Pod
+
+`Pod.type` now includes `project`.
+
+`pod.projectMeta` stores project-level information:
+
+- `goal`
+- `scope`
+- `successCriteria[]`
+- `status`
+- `dueDate`
+- `ownerIds[]`
+- `keyLinks[]`
+
+### Task
+
+Tasks extend the existing schema with structured work fields:
+
+- `description`
+- `assigneeType`
+- `assigneeRef`
+- `priority`
+- `dueDate`
+- `progressPercent`
+- `blocker`
+- structured `updates.kind`
+- structured `updates.progressPercent`
+- structured `updates.nextStep`
+
+This is intentionally incremental. It upgrades the current task system without introducing a separate `ProjectTask` collection.
+
+## Agent Workflow
+
+Project pods reuse the current agent installation and runtime architecture.
+
+Key changes:
+
+- runtime pod creation now accepts `project`
+- task assignment to an agent emits `task.assigned`
+- agent assignees are modeled explicitly through `assigneeType="agent"` and `assigneeRef=<instanceId>`
+
+Expected agent behavior in project pods:
+
+- take or receive assigned work
+- post progress updates
+- raise blockers
+- complete tasks with structured history
+
+## Infra / DB Notes
+
+- MongoDB remains the source of truth for project pod metadata and tasks.
+- No new infrastructure tier is required for MVP.
+- Existing Socket.io `task_updated` events continue to drive live task refresh.
+- Existing runtime polling/native-dispatch model remains valid.
+
+## Rollout
+
+### Phase 1
+
+- add `project` pod type
+- add `projectMeta`
+- add dedicated frontend project room
+- add structured task fields
+
+### Phase 2
+
+- expand task/project reporting
+- add richer milestone support
+- add project-specific agent tools for progress/blocker management
+
+### Phase 3
+
+- add deeper automation: standups, stale blocker reminders, milestone risk summaries
+
+## Current MVP Status
+
+The current implementation covers the first slice of the project pod idea:
+
+- `project` is a real pod type
+- project pods have a dedicated two-tab UI:
+  - `Chat`
+  - `Tasks`
+- project pods support project-level metadata through `pod.projectMeta`
+- tasks support richer fields:
+  - `description`
+  - typed assignees
+  - `priority`
+  - `dueDate`
+  - `progressPercent`
+  - `blocker`
+  - structured updates
+- assigning a task to an agent emits `task.assigned`
+
+This is enough for an MVP, but it is not yet the full project-coordination system described in the original vision.
+
+## Remaining Work
+
+### Project Creation UX
+
+The current pod creation flow only lightly seeds project metadata.
+
+Still needed:
+
+- dedicated `Create Project Pod` flow
+- structured input for:
+  - goal
+  - scope
+  - owners
+  - due date
+  - success criteria
+  - key links
+
+### Milestones
+
+There is no milestone model yet.
+
+Still needed:
+
+- first-class milestone records
+- milestone status/health
+- task ↔ milestone linkage
+- milestone summaries in the project sidebar
+
+### Task Workflow
+
+The current backend status model is still implementation-shaped:
+
+- `pending`
+- `claimed`
+- `blocked`
+- `done`
+
+Still needed:
+
+- clearer product-facing workflow such as:
+  - `todo`
+  - `in_progress`
+  - `blocked`
+  - `in_review`
+  - `done`
+- migration/update plan for existing tasks
+
+### Task Structure
+
+The current task model is richer than before, but still incomplete for real project execution.
+
+Still needed:
+
+- checklist/subtask support in the dedicated project UI
+- acceptance criteria
+- review state
+- handoff target/state
+- stronger dependency visualization
+- overdue and due-soon signals
+
+### Agent Workflow
+
+The current implementation emits `task.assigned` for agent assignees, but the broader work loop is still incomplete.
+
+Still needed:
+
+- agent tools/runtime support for:
+  - take task
+  - post progress
+  - raise blocker
+  - clear blocker
+  - complete task
+- better task-state mirroring between runtime actions and UI state
+- clearer distinction between chat participation and work ownership
+
+### Chat Tab Context
+
+The right sidebar exists, but it still needs more live execution surfaces.
+
+Still needed:
+
+- `Assigned to me`
+- `Agent tasks`
+- `Open blockers`
+- `Due soon`
+- `Recent decisions`
+
+### Activity / Timeline
+
+The current two-tab model intentionally avoids adding a separate timeline page.
+
+Still needed:
+
+- compact project activity stream inside existing tabs
+- visibility for:
+  - progress updates
+  - blockers
+  - handoffs
+  - completions
+  - major decisions
+
+### Assignment Identity
+
+The model now supports `assigneeType` and `assigneeRef`, but there is still some reliance on human-readable labels.
+
+Still needed:
+
+- make typed identity the source of truth everywhere
+- treat display labels as presentation only
+- tighten agent installation lookup paths
+
+### Database / Query Support
+
+MongoDB is still the right store for this phase, but indexing/query support should be improved.
+
+Still needed:
+
+- indexes for:
+  - `podId + status`
+  - `podId + assigneeRef`
+  - `podId + dueDate`
+  - `podId + blocker.open`
+
+### Documentation
+
+The dedicated design doc exists, but broader product and engineering docs still lag the implementation.
+
+Still needed:
+
+- update architecture/backend/frontend/database docs
+- update API docs for project pod fields and task fields
+- document project pod creation and usage flow
+
+### Verification / Tooling
+
+Backend and frontend verification should be part of the rollout path.
+
+Still needed:
+
+- ensure dev containers always have full dev toolchains
+- run backend test/typecheck coverage against the new task/project paths
+- expand frontend coverage beyond route/browse behavior
+
+## Open Follow-Ups
+
+- milestone model is still lightweight and should likely become first-class later
+- project pod chat currently reuses message transport but not the full legacy chat feature surface
+- future task status normalization should likely move from `pending/claimed/done` to clearer product-facing workflow names

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -31,5 +31,8 @@ EXPOSE 3000
 # Add a label to indicate this is development
 LABEL com.commonly.environment="development"
 
-# For development, use the development server
-CMD ["npm", "start"]
+# Make dev startup script executable
+RUN chmod +x /app/start-dev.sh
+
+# For development, ensure deps then run the dev server
+CMD ["/bin/bash", "/app/start-dev.sh"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import Layout from './components/Layout';
 import Pod from './components/Pod';
 import PodRedirect from './components/PodRedirect';
 import ChatRoom from './components/ChatRoom';
+import PodRoomRouter from './components/PodRoomRouter';
 import ApiDevPage from './components/ApiDevPage';
 import PodContextDevPage from './components/PodContextDevPage';
 import DiscordCallback from './components/DiscordCallback';
@@ -232,7 +233,7 @@ function App(): React.ReactElement {
                       } />
                       <Route path="/pods" element={<PodRedirect />} />
                       <Route path="/pods/:podType" element={<Pod />} />
-                      <Route path="/pods/:podType/:roomId" element={<ChatRoom />} />
+                      <Route path="/pods/:podType/:roomId" element={<PodRoomRouter />} />
                       <Route path="/dev/api" element={
                         <ProtectedRoute requireAdmin={true}>
                           <ApiDevPage />

--- a/frontend/src/components/Pod.test.tsx
+++ b/frontend/src/components/Pod.test.tsx
@@ -292,9 +292,17 @@ test('tab change navigates', async () => {
   
   // Get all tabs and click the second one (Study tab)
   const tabs = screen.getAllByRole('tab');
-  expect(tabs).toHaveLength(6); // Chat, Study, Games, Ensemble, Teams, Agent DMs
-  
-  const studyTab = tabs[1]; // Study is the second tab
+  expect(tabs).toHaveLength(7); // Chat, Project, Study, Games, Ensemble, Teams, Agent DMs
+
+  const projectTab = tabs[1];
+  expect(projectTab).toHaveTextContent('Project');
+  fireEvent.click(projectTab);
+
+  await waitFor(() => {
+    expect(mockNavigate).toHaveBeenCalledWith('/pods/project');
+  });
+
+  const studyTab = tabs[2]; // Study is the third tab
   expect(studyTab).toHaveTextContent('Study');
   
   fireEvent.click(studyTab);
@@ -304,12 +312,29 @@ test('tab change navigates', async () => {
     expect(mockNavigate).toHaveBeenCalledWith('/pods/study');
   });
 
-  const ensembleTab = tabs[3];
+  const ensembleTab = tabs[4];
   expect(ensembleTab).toHaveTextContent('Ensemble');
   fireEvent.click(ensembleTab);
 
   await waitFor(() => {
     expect(mockNavigate).toHaveBeenCalledWith('/pods/agent-ensemble');
+  });
+});
+
+test('create dialog includes project pod type option', async () => {
+  axios.get.mockResolvedValueOnce({ data: [mockPod] });
+
+  renderPodWithRouter(<Pod />);
+
+  await waitFor(() => {
+    expect(screen.getByText('Room')).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByText('Create Room'));
+
+  await waitFor(() => {
+    expect(screen.getByText('Create a New Pod')).toBeInTheDocument();
+    expect(screen.getAllByText('Project').length).toBeGreaterThan(1);
   });
 });
 

--- a/frontend/src/components/Pod.tsx
+++ b/frontend/src/components/Pod.tsx
@@ -64,6 +64,16 @@ interface AgentInfo {
     };
 }
 
+const POD_TYPE_ORDER = ['chat', 'project', 'study', 'games', 'agent-ensemble', 'team', 'agent-room'];
+const CREATEABLE_POD_TYPE_OPTIONS = [
+    { value: 0, label: 'Chat' },
+    { value: 1, label: 'Project' },
+    { value: 2, label: 'Study' },
+    { value: 3, label: 'Games' },
+    { value: 4, label: 'Agent Ensemble' },
+    { value: 5, label: 'Team' },
+];
+
 const isLikelyAgentUsername = (username: string | undefined): boolean => {
     const normalized = String(username || '').trim().toLowerCase();
     if (!normalized) return false;
@@ -117,28 +127,13 @@ const Pod = () => {
         if (podType) {
             return podType;
         }
-        switch (tabValue) {
-            case 0: return 'chat';
-            case 1: return 'study';
-            case 2: return 'games';
-            case 3: return 'agent-ensemble';
-            case 4: return 'team';
-            case 5: return 'agent-room';
-            default: return 'chat';
-        }
+        return POD_TYPE_ORDER[tabValue] || 'chat';
     }, [podType, tabValue]);
 
     useEffect(() => {
         if (podType) {
-            switch (podType) {
-                case 'chat': setTabValue(0); break;
-                case 'study': setTabValue(1); break;
-                case 'games': setTabValue(2); break;
-                case 'agent-ensemble': setTabValue(3); break;
-                case 'team': setTabValue(4); break;
-                case 'agent-room': setTabValue(5); break;
-                default: setTabValue(0);
-            }
+            const nextIndex = POD_TYPE_ORDER.indexOf(podType);
+            setTabValue(nextIndex >= 0 ? nextIndex : 0);
         }
     }, [podType]);
 
@@ -326,13 +321,18 @@ const Pod = () => {
     const handleCreateRoom = async () => {
         try {
             if (!roomName.trim()) { setError('Pod name is required'); return; }
-            const podTypes = ['chat', 'study', 'games', 'agent-ensemble', 'team', 'agent-room'];
-            const newPodType = podTypes[tabValue] || 'chat';
+            const newPodType = POD_TYPE_ORDER[tabValue] || 'chat';
             const response = await axios.post('/api/pods', {
                 name: roomName,
                 description: roomDescription,
                 type: newPodType,
                 joinPolicy: inviteOnly ? 'invite-only' : 'open',
+                ...(newPodType === 'project' ? {
+                    projectMeta: {
+                        goal: roomDescription,
+                        status: 'planning',
+                    },
+                } : {}),
                 ...(parentPodId ? { parentPod: parentPodId } : {}),
             }, {
                 headers: { 'Authorization': `Bearer ${localStorage.getItem('token')}` }
@@ -413,8 +413,7 @@ const Pod = () => {
 
     const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
         setTabValue(newValue);
-        const podTypes = ['chat', 'study', 'games', 'agent-ensemble', 'team', 'agent-room'];
-        navigate(`/pods/${podTypes[newValue]}`);
+        navigate(`/pods/${POD_TYPE_ORDER[newValue] || 'chat'}`);
     };
 
     const isAgentAdminView = getPodType() === 'agent-admin';
@@ -492,6 +491,7 @@ const Pod = () => {
                             className="pod-tabs"
                         >
                             <Tab label="Chat" className="pod-tab" />
+                            <Tab label="Project" className="pod-tab" />
                             <Tab label="Study" className="pod-tab" />
                             <Tab label="Games" className="pod-tab" />
                             <Tab label="Ensemble" className="pod-tab" />
@@ -528,6 +528,8 @@ const Pod = () => {
                                 <Typography variant="body1" color="textSecondary" paragraph>
                                     {isAgentAdminView
                                         ? 'Open a DM from the Agents page.'
+                                        : getPodType() === 'project'
+                                        ? 'Create a project pod to coordinate work between people and agents.'
                                         : getPodType() === 'agent-ensemble'
                                         ? 'Create a new agent ensemble pod to orchestrate multi-agent conversations.'
                                         : 'Create a new pod to start chatting with others!'}
@@ -654,23 +656,23 @@ const Pod = () => {
                 <DialogTitle>
                     <Box display="flex" alignItems="center">
                         <AddIcon sx={{ mr: 1, color: 'primary.main' }} />
-                        Create a New Pod
+                        {tabValue === 1 ? 'Create a New Project Pod' : 'Create a New Pod'}
                     </Box>
                 </DialogTitle>
                 <DialogContent>
                     <Typography variant="body2" color="textSecondary" sx={{ mb: 2 }}>
-                        Create a new pod to chat with others. Pods are spaces where you can discuss topics, share ideas, and connect with people.
+                        {tabValue === 1
+                            ? 'Create a project pod to coordinate work between people and agents with shared chat, structured tasks, and project context.'
+                            : 'Create a new pod to chat with others. Pods are spaces where you can discuss topics, share ideas, and connect with people.'}
                     </Typography>
-                    <TextField autoFocus margin="dense" label="Pod Name" type="text" fullWidth value={roomName} onChange={(e) => setRoomName(e.target.value)} sx={{ mb: 2 }} placeholder="E.g., JavaScript Developers, Book Club, etc." />
-                    <TextField margin="dense" label="Description" type="text" fullWidth multiline rows={3} value={roomDescription} onChange={(e) => setRoomDescription(e.target.value)} sx={{ mb: 2 }} placeholder="Describe what this pod is about..." />
+                    <TextField autoFocus margin="dense" label="Pod Name" type="text" fullWidth value={roomName} onChange={(e) => setRoomName(e.target.value)} sx={{ mb: 2 }} placeholder={tabValue === 1 ? 'E.g., Website Relaunch, Q2 Launch Plan, API Migration' : 'E.g., JavaScript Developers, Book Club, etc.'} />
+                    <TextField margin="dense" label="Description" type="text" fullWidth multiline rows={3} value={roomDescription} onChange={(e) => setRoomDescription(e.target.value)} sx={{ mb: 2 }} placeholder={tabValue === 1 ? 'Describe the project goal, scope, or execution context...' : 'Describe what this pod is about...'} />
                     <FormControl fullWidth sx={{ mb: 2 }}>
                         <InputLabel>Pod Type</InputLabel>
                         <Select value={tabValue} onChange={(e) => setTabValue(Number(e.target.value))}>
-                            <MenuItem value={0}>Chat</MenuItem>
-                            <MenuItem value={1}>Study</MenuItem>
-                            <MenuItem value={2}>Games</MenuItem>
-                            <MenuItem value={3}>Agent Ensemble</MenuItem>
-                            <MenuItem value={4}>Team</MenuItem>
+                            {CREATEABLE_POD_TYPE_OPTIONS.map((option) => (
+                                <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
+                            ))}
                         </Select>
                     </FormControl>
                     <FormControl fullWidth sx={{ mb: 2 }}>

--- a/frontend/src/components/PodRedirect.test.tsx
+++ b/frontend/src/components/PodRedirect.test.tsx
@@ -49,6 +49,13 @@ describe('PodRedirect', () => {
     });
     expect(navigate).toHaveBeenCalledWith('/pods/chat');
 
+    const projectButton = buttons.find((btn) => btn.textContent === 'Project Pods');
+    expect(projectButton).toBeTruthy();
+    act(() => {
+      TestUtils.Simulate.click(projectButton);
+    });
+    expect(navigate).toHaveBeenCalledWith('/pods/project');
+
     const ensembleButton = buttons.find((btn) => btn.textContent === 'Agent Ensemble Pods');
     expect(ensembleButton).toBeTruthy();
     act(() => {

--- a/frontend/src/components/PodRedirect.tsx
+++ b/frontend/src/components/PodRedirect.tsx
@@ -7,6 +7,7 @@ import SchoolIcon from '@mui/icons-material/School';
 import SportsEsportsIcon from '@mui/icons-material/SportsEsports';
 import PsychologyIcon from '@mui/icons-material/Psychology';
 import GroupsIcon from '@mui/icons-material/Groups';
+import WorkspacesIcon from '@mui/icons-material/Workspaces';
 
 const PodRedirect: React.FC = () => {
   const navigate = useNavigate();
@@ -60,6 +61,17 @@ const PodRedirect: React.FC = () => {
             sx={{ py: 2, px: 4, borderRadius: 2, flex: 1 }}
           >
             Chat Pods
+          </Button>
+
+          <Button
+            variant="contained"
+            color="secondary"
+            size="large"
+            startIcon={<WorkspacesIcon />}
+            onClick={() => handleNavigate('project')}
+            sx={{ py: 2, px: 4, borderRadius: 2, flex: 1, backgroundColor: '#f59e0b', '&:hover': { backgroundColor: '#d97706' } }}
+          >
+            Project Pods
           </Button>
 
           <Button

--- a/frontend/src/components/PodRoomRouter.test.tsx
+++ b/frontend/src/components/PodRoomRouter.test.tsx
@@ -1,0 +1,39 @@
+// @ts-nocheck
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useParams } from 'react-router-dom';
+import PodRoomRouter from './PodRoomRouter';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}));
+
+jest.mock('./ChatRoom', () => {
+  const MockChatRoom = () => <div>chat-room-view</div>;
+  MockChatRoom.displayName = 'MockChatRoom';
+  return MockChatRoom;
+});
+jest.mock('./ProjectPodRoom', () => {
+  const MockProjectPodRoom = () => <div>project-pod-view</div>;
+  MockProjectPodRoom.displayName = 'MockProjectPodRoom';
+  return MockProjectPodRoom;
+});
+
+describe('PodRoomRouter', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('routes project pods to the dedicated project room', () => {
+    useParams.mockReturnValue({ podType: 'project' });
+    render(<PodRoomRouter />);
+    expect(screen.getByText('project-pod-view')).toBeInTheDocument();
+  });
+
+  test('routes non-project pods to the legacy chat room', () => {
+    useParams.mockReturnValue({ podType: 'chat' });
+    render(<PodRoomRouter />);
+    expect(screen.getByText('chat-room-view')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/PodRoomRouter.tsx
+++ b/frontend/src/components/PodRoomRouter.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import ChatRoom from './ChatRoom';
+import ProjectPodRoom from './ProjectPodRoom';
+
+export default function PodRoomRouter(): React.ReactElement {
+  const { podType } = useParams<{ podType?: string }>();
+
+  if (podType === 'project') {
+    return <ProjectPodRoom />;
+  }
+
+  return <ChatRoom />;
+}

--- a/frontend/src/components/ProjectPodRoom.tsx
+++ b/frontend/src/components/ProjectPodRoom.tsx
@@ -1,0 +1,1108 @@
+// @ts-nocheck
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  MenuItem,
+  Paper,
+  Stack,
+  Tab,
+  Tabs,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import {
+  Add as AddIcon,
+  AssignmentTurnedIn as CompleteIcon,
+  Edit as EditIcon,
+  Flag as FlagIcon,
+  Handyman as TaskIcon,
+  PlayArrow as TakeTaskIcon,
+} from '@mui/icons-material';
+import axios from 'axios';
+import { useParams } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { useSocket } from '../context/SocketContext';
+import { getAvatarColor, getAvatarSrc } from '../utils/avatarUtils';
+import MessageContent from './common/MessageContent';
+import UnifiedComposer from './common/UnifiedComposer';
+
+const PROJECT_TAB_CHAT = 'chat';
+const PROJECT_TAB_TASKS = 'tasks';
+const TASK_FILTERS = ['all', 'mine', 'human', 'agent', 'blocked', 'done'];
+
+const normalizeIdentityKey = (value) => String(value || '').trim().toLowerCase();
+const normalizeAgentSegment = (value) => String(value || '').trim().toLowerCase().replace(/[^a-z0-9-]/g, '');
+const buildAgentUsername = (agentName, instanceId) => {
+  const base = normalizeAgentSegment(agentName);
+  const instance = normalizeAgentSegment(instanceId);
+  if (!instance || instance === 'default' || instance === base) return base || 'agent';
+  return `${base}-${instance}`;
+};
+const formatShortDate = (value) => {
+  if (!value) return 'No due date';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'No due date';
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+};
+const formatDateTime = (value) => {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+};
+const taskStatusLabel = (status) => {
+  switch (status) {
+    case 'claimed': return 'In Progress';
+    case 'blocked': return 'Blocked';
+    case 'done': return 'Done';
+    default: return 'Todo';
+  }
+};
+const taskStatusColor = (status) => {
+  switch (status) {
+    case 'claimed': return 'info';
+    case 'blocked': return 'warning';
+    case 'done': return 'success';
+    default: return 'default';
+  }
+};
+const projectStatusColor = (status) => {
+  switch (status) {
+    case 'on-track': return 'success';
+    case 'at-risk': return 'warning';
+    case 'blocked': return 'error';
+    case 'complete': return 'primary';
+    default: return 'default';
+  }
+};
+
+const ProjectPodRoom = () => {
+  const { roomId } = useParams();
+  const { currentUser } = useAuth();
+  const { socket, connected, joinPod, leavePod, sendMessage } = useSocket();
+  const [activeTab, setActiveTab] = useState(PROJECT_TAB_CHAT);
+  const [room, setRoom] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [tasks, setTasks] = useState([]);
+  const [podAgents, setPodAgents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [taskFilter, setTaskFilter] = useState('all');
+  const [taskSearch, setTaskSearch] = useState('');
+  const [selectedTaskId, setSelectedTaskId] = useState(null);
+  const [projectDialogOpen, setProjectDialogOpen] = useState(false);
+  const [newTaskOpen, setNewTaskOpen] = useState(false);
+  const [assignOpen, setAssignOpen] = useState(false);
+  const [progressOpen, setProgressOpen] = useState(false);
+  const [blockerOpen, setBlockerOpen] = useState(false);
+  const [completeOpen, setCompleteOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [projectForm, setProjectForm] = useState({
+    name: '',
+    description: '',
+    goal: '',
+    scope: '',
+    successCriteriaText: '',
+    status: 'planning',
+    dueDate: '',
+    keyLinksText: '',
+  });
+  const [newTaskForm, setNewTaskForm] = useState({
+    title: '',
+    description: '',
+    assigneeKey: '',
+    priority: 'medium',
+    dueDate: '',
+  });
+  const [assignKey, setAssignKey] = useState('');
+  const [progressForm, setProgressForm] = useState({
+    text: '',
+    progressPercent: '',
+    nextStep: '',
+  });
+  const [blockerForm, setBlockerForm] = useState({
+    reason: '',
+    waitingOn: '',
+    severity: 'medium',
+  });
+  const [completeNotes, setCompleteNotes] = useState('');
+  const messagesEndRef = useRef(null);
+
+  const token = localStorage.getItem('token');
+  const authHeaders = useMemo(() => ({
+    headers: { Authorization: `Bearer ${token}` },
+  }), [token]);
+
+  const agentIdentityMap = useMemo(() => {
+    const displayMap = new Map();
+    const avatarMap = new Map();
+    (podAgents || []).forEach((agent) => {
+      const display = agent?.profile?.displayName || agent?.displayName || agent?.instanceId || agent?.name;
+      const avatar = agent?.profile?.iconUrl || agent?.profile?.avatarUrl || agent?.iconUrl || '';
+      const username = buildAgentUsername(agent?.name, agent?.instanceId);
+      const keys = [
+        username,
+        agent?.name,
+        display,
+        agent?.instanceId,
+        `${agent?.name || ''}-${agent?.instanceId || 'default'}`,
+      ];
+      keys.forEach((key) => {
+        const normalized = normalizeIdentityKey(key);
+        if (!normalized) return;
+        displayMap.set(normalized, display);
+        if (avatar) avatarMap.set(normalized, avatar);
+      });
+    });
+    return { displayMap, avatarMap };
+  }, [podAgents]);
+
+  const assignmentOptions = useMemo(() => {
+    const humans = (room?.members || [])
+      .filter((member) => member && typeof member === 'object' && member._id && member.username)
+      .map((member) => ({
+        key: `human:${member._id}`,
+        label: member.username,
+        type: 'human',
+        assignee: member.username,
+        assigneeRef: member._id,
+      }));
+    const agents = (podAgents || []).map((agent) => ({
+      key: `agent:${agent.instanceId || 'default'}`,
+      label: agent.profile?.displayName || agent.displayName || agent.instanceId || agent.name,
+      type: 'agent',
+      assignee: agent.profile?.displayName || agent.displayName || agent.instanceId || agent.name,
+      assigneeRef: agent.instanceId || 'default',
+    }));
+    return [...humans, ...agents];
+  }, [podAgents, room?.members]);
+
+  const selectedTask = useMemo(
+    () => tasks.find((task) => task.taskId === selectedTaskId) || null,
+    [tasks, selectedTaskId],
+  );
+
+  const openTaskCount = useMemo(
+    () => tasks.filter((task) => task.status !== 'done').length,
+    [tasks],
+  );
+  const blockedTaskCount = useMemo(
+    () => tasks.filter((task) => task.status === 'blocked' || task.blocker?.open).length,
+    [tasks],
+  );
+
+  const filteredTasks = useMemo(() => {
+    const normalizedQuery = taskSearch.trim().toLowerCase();
+    return tasks.filter((task) => {
+      const matchesQuery = !normalizedQuery
+        || String(task.title || '').toLowerCase().includes(normalizedQuery)
+        || String(task.description || '').toLowerCase().includes(normalizedQuery)
+        || String(task.assignee || '').toLowerCase().includes(normalizedQuery)
+        || String(task.taskId || '').toLowerCase().includes(normalizedQuery);
+      if (!matchesQuery) return false;
+      switch (taskFilter) {
+        case 'mine':
+          return task.assigneeRef === currentUser?._id || normalizeIdentityKey(task.assignee) === normalizeIdentityKey(currentUser?.username);
+        case 'human':
+          return task.assigneeType === 'human';
+        case 'agent':
+          return task.assigneeType === 'agent';
+        case 'blocked':
+          return task.status === 'blocked' || task.blocker?.open;
+        case 'done':
+          return task.status === 'done';
+        default:
+          return true;
+      }
+    });
+  }, [currentUser?._id, currentUser?.username, taskFilter, taskSearch, tasks]);
+
+  const projectOwners = useMemo(() => {
+    const ownerIds = new Set((room?.projectMeta?.ownerIds || []).map((id) => String(id)));
+    return (room?.members || []).filter((member) => ownerIds.has(String(member?._id)));
+  }, [room?.members, room?.projectMeta?.ownerIds]);
+
+  const syncTask = useCallback((incomingTask) => {
+    if (!incomingTask) return;
+    setTasks((prev) => {
+      const existingIndex = prev.findIndex((task) => task.taskId === incomingTask.taskId);
+      if (existingIndex === -1) return [...prev, incomingTask];
+      const next = prev.slice();
+      next[existingIndex] = incomingTask;
+      return next;
+    });
+    setSelectedTaskId((prev) => prev || incomingTask.taskId);
+  }, []);
+
+  const loadRoom = useCallback(async () => {
+    if (!roomId || !token) return;
+    setLoading(true);
+    try {
+      const [podRes, messageRes, tasksRes, agentsRes] = await Promise.all([
+        axios.get(`/api/pods/project/${roomId}`, authHeaders),
+        axios.get(`/api/messages/${roomId}?limit=100`, authHeaders),
+        axios.get(`/api/v1/tasks/${roomId}`, authHeaders),
+        axios.get(`/api/registry/pods/${roomId}/agents`, authHeaders),
+      ]);
+      setRoom(podRes.data);
+      setMessages(messageRes.data || []);
+      setTasks(tasksRes.data?.tasks || []);
+      setPodAgents(agentsRes.data?.agents || []);
+      setSelectedTaskId((tasksRes.data?.tasks || [])[0]?.taskId || null);
+      setError('');
+    } catch (err) {
+      console.error('Failed to load project pod:', err);
+      setError('Failed to load project pod.');
+    } finally {
+      setLoading(false);
+    }
+  }, [authHeaders, roomId, token]);
+
+  useEffect(() => {
+    loadRoom();
+  }, [loadRoom]);
+
+  useEffect(() => {
+    if (!selectedTaskId && filteredTasks.length > 0) {
+      setSelectedTaskId(filteredTasks[0].taskId);
+      return;
+    }
+    if (selectedTaskId && filteredTasks.length > 0 && !filteredTasks.some((task) => task.taskId === selectedTaskId)) {
+      setSelectedTaskId(filteredTasks[0].taskId);
+    }
+  }, [filteredTasks, selectedTaskId]);
+
+  useEffect(() => {
+    if (!connected || !roomId) return undefined;
+    joinPod(roomId);
+
+    const handleNewMessage = (incomingMessage) => {
+      if (incomingMessage?.podId && String(incomingMessage.podId) !== String(roomId)) return;
+      setMessages((prev) => {
+        const optimisticIndex = prev.findIndex((message) => !message._id && message.content === incomingMessage.content);
+        if (optimisticIndex >= 0) {
+          const next = prev.slice();
+          next[optimisticIndex] = incomingMessage;
+          return next;
+        }
+        return [...prev, incomingMessage];
+      });
+    };
+
+    const handleTaskUpdated = (payload) => {
+      if (!payload?.task) return;
+      if (payload.podId && String(payload.podId) !== String(roomId)) return;
+      syncTask(payload.task);
+    };
+
+    socket?.on('newMessage', handleNewMessage);
+    socket?.on('task_updated', handleTaskUpdated);
+
+    return () => {
+      leavePod(roomId);
+      socket?.off('newMessage', handleNewMessage);
+      socket?.off('task_updated', handleTaskUpdated);
+    };
+  }, [connected, joinPod, leavePod, roomId, socket, syncTask]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const handleSendProjectMessage = useCallback((payload) => {
+    if (!payload?.content?.trim() || !roomId) return;
+    const optimisticMessage = {
+      id: Date.now(),
+      content: payload.content,
+      messageType: 'text',
+      userId: {
+        _id: currentUser?._id,
+        username: currentUser?.username,
+        profilePicture: currentUser?.profilePicture,
+      },
+      createdAt: new Date().toISOString(),
+    };
+    setMessages((prev) => [...prev, optimisticMessage]);
+    sendMessage(roomId, payload.content, 'text');
+  }, [currentUser?._id, currentUser?.profilePicture, currentUser?.username, roomId, sendMessage]);
+
+  const openProjectDialog = () => {
+    setProjectForm({
+      name: room?.name || '',
+      description: room?.description || '',
+      goal: room?.projectMeta?.goal || '',
+      scope: room?.projectMeta?.scope || '',
+      successCriteriaText: (room?.projectMeta?.successCriteria || []).join('\n'),
+      status: room?.projectMeta?.status || 'planning',
+      dueDate: room?.projectMeta?.dueDate ? new Date(room.projectMeta.dueDate).toISOString().slice(0, 10) : '',
+      keyLinksText: (room?.projectMeta?.keyLinks || []).map((link) => `${link.label || ''} | ${link.url || ''}`.trim()).join('\n'),
+    });
+    setProjectDialogOpen(true);
+  };
+
+  const handleSaveProject = async () => {
+    if (!roomId) return;
+    setSaving(true);
+    try {
+      const keyLinks = projectForm.keyLinksText
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => {
+          const [label, url] = line.includes('|') ? line.split('|') : [line, line];
+          return { label: String(label || '').trim(), url: String(url || '').trim() };
+        });
+      const response = await axios.patch(`/api/pods/${roomId}`, {
+        name: projectForm.name,
+        description: projectForm.description,
+        projectMeta: {
+          goal: projectForm.goal,
+          scope: projectForm.scope,
+          successCriteria: projectForm.successCriteriaText.split('\n').map((item) => item.trim()).filter(Boolean),
+          status: projectForm.status,
+          dueDate: projectForm.dueDate || null,
+          keyLinks,
+          ownerIds: room?.projectMeta?.ownerIds || [],
+        },
+      }, authHeaders);
+      setRoom(response.data);
+      setProjectDialogOpen(false);
+    } catch (err) {
+      console.error('Failed to save project:', err);
+      setError('Failed to save project details.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCreateTask = async () => {
+    if (!roomId || !newTaskForm.title.trim()) return;
+    setSaving(true);
+    try {
+      const assigneeOption = assignmentOptions.find((option) => option.key === newTaskForm.assigneeKey);
+      const response = await axios.post(`/api/v1/tasks/${roomId}`, {
+        title: newTaskForm.title.trim(),
+        description: newTaskForm.description.trim(),
+        assignee: assigneeOption?.assignee || undefined,
+        assigneeType: assigneeOption?.type || null,
+        assigneeRef: assigneeOption?.assigneeRef || null,
+        priority: newTaskForm.priority,
+        dueDate: newTaskForm.dueDate || null,
+      }, authHeaders);
+      syncTask(response.data.task);
+      setNewTaskOpen(false);
+      setNewTaskForm({ title: '', description: '', assigneeKey: '', priority: 'medium', dueDate: '' });
+    } catch (err) {
+      console.error('Failed to create task:', err);
+      setError('Failed to create task.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTakeTask = async () => {
+    if (!roomId || !selectedTask) return;
+    setSaving(true);
+    try {
+      const response = await axios.patch(`/api/v1/tasks/${roomId}/${selectedTask.taskId}`, {
+        assignee: currentUser?.username,
+        assigneeType: 'human',
+        assigneeRef: currentUser?._id,
+        status: selectedTask.status === 'done' ? 'done' : 'claimed',
+      }, authHeaders);
+      syncTask(response.data.task);
+    } catch (err) {
+      console.error('Failed to take task:', err);
+      setError('Failed to take task.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAssignTask = async () => {
+    if (!roomId || !selectedTask) return;
+    const assigneeOption = assignmentOptions.find((option) => option.key === assignKey);
+    if (!assigneeOption) return;
+    setSaving(true);
+    try {
+      const response = await axios.patch(`/api/v1/tasks/${roomId}/${selectedTask.taskId}`, {
+        assignee: assigneeOption.assignee,
+        assigneeType: assigneeOption.type,
+        assigneeRef: assigneeOption.assigneeRef,
+      }, authHeaders);
+      syncTask(response.data.task);
+      setAssignOpen(false);
+      setAssignKey('');
+    } catch (err) {
+      console.error('Failed to assign task:', err);
+      setError('Failed to assign task.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handlePostProgress = async () => {
+    if (!roomId || !selectedTask || !progressForm.text.trim()) return;
+    setSaving(true);
+    try {
+      const progressPercent = progressForm.progressPercent === '' ? undefined : Number(progressForm.progressPercent);
+      const response = await axios.post(`/api/v1/tasks/${roomId}/${selectedTask.taskId}/updates`, {
+        text: progressForm.text.trim(),
+        kind: 'progress',
+        progressPercent,
+        nextStep: progressForm.nextStep.trim() || undefined,
+      }, authHeaders);
+      syncTask(response.data.task);
+      if (selectedTask.status === 'pending') {
+        const patchResponse = await axios.patch(`/api/v1/tasks/${roomId}/${selectedTask.taskId}`, { status: 'claimed' }, authHeaders);
+        syncTask(patchResponse.data.task);
+      }
+      setProgressOpen(false);
+      setProgressForm({ text: '', progressPercent: '', nextStep: '' });
+    } catch (err) {
+      console.error('Failed to post progress:', err);
+      setError('Failed to post progress.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSaveBlocker = async () => {
+    if (!roomId || !selectedTask || !blockerForm.reason.trim()) return;
+    setSaving(true);
+    try {
+      const blocker = {
+        open: true,
+        reason: blockerForm.reason.trim(),
+        waitingOn: blockerForm.waitingOn.trim() || null,
+        severity: blockerForm.severity,
+        openedAt: new Date().toISOString(),
+        openedBy: currentUser?.username || currentUser?._id || 'unknown',
+        resolvedAt: null,
+      };
+      const [patchResponse] = await Promise.all([
+        axios.patch(`/api/v1/tasks/${roomId}/${selectedTask.taskId}`, {
+          status: 'blocked',
+          blocker,
+        }, authHeaders),
+        axios.post(`/api/v1/tasks/${roomId}/${selectedTask.taskId}/updates`, {
+          text: blockerForm.reason.trim(),
+          kind: 'blocker',
+          nextStep: blockerForm.waitingOn.trim() || undefined,
+        }, authHeaders),
+      ]);
+      syncTask(patchResponse.data.task);
+      setBlockerOpen(false);
+      setBlockerForm({ reason: '', waitingOn: '', severity: 'medium' });
+    } catch (err) {
+      console.error('Failed to save blocker:', err);
+      setError('Failed to raise blocker.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClearBlocker = async () => {
+    if (!roomId || !selectedTask) return;
+    setSaving(true);
+    try {
+      const response = await axios.patch(`/api/v1/tasks/${roomId}/${selectedTask.taskId}`, {
+        status: 'claimed',
+        blocker: {
+          open: false,
+          reason: null,
+          waitingOn: null,
+          severity: selectedTask?.blocker?.severity || 'medium',
+          openedAt: selectedTask?.blocker?.openedAt || null,
+          openedBy: selectedTask?.blocker?.openedBy || null,
+          resolvedAt: new Date().toISOString(),
+        },
+      }, authHeaders);
+      syncTask(response.data.task);
+    } catch (err) {
+      console.error('Failed to clear blocker:', err);
+      setError('Failed to clear blocker.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCompleteTask = async () => {
+    if (!roomId || !selectedTask) return;
+    setSaving(true);
+    try {
+      const response = await axios.post(`/api/v1/tasks/${roomId}/${selectedTask.taskId}/complete`, {
+        notes: completeNotes.trim() || undefined,
+      }, authHeaders);
+      syncTask(response.data.task);
+      setCompleteOpen(false);
+      setCompleteNotes('');
+    } catch (err) {
+      console.error('Failed to complete task:', err);
+      setError('Failed to complete task.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const renderMessageAuthor = (message) => {
+    const username = message?.userId?.username || message?.username || 'unknown';
+    return agentIdentityMap.displayMap.get(normalizeIdentityKey(username)) || username;
+  };
+
+  const renderMessageAvatar = (message) => {
+    const username = message?.userId?.username || message?.username || '';
+    return agentIdentityMap.avatarMap.get(normalizeIdentityKey(username))
+      || message?.userId?.profilePicture
+      || message?.profilePicture
+      || '';
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ minHeight: '70vh', display: 'grid', placeItems: 'center' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error && !room) {
+    return <Alert severity="error">{error}</Alert>;
+  }
+
+  return (
+    <Box sx={{ px: { xs: 2, md: 3 }, py: { xs: 2, md: 3 }, minHeight: '100vh', background: 'linear-gradient(180deg, #0f172a 0%, #111827 100%)' }}>
+      <Paper sx={{ p: { xs: 2, md: 3 }, borderRadius: 4, backgroundColor: '#101826', border: '1px solid rgba(148,163,184,0.18)' }}>
+        <Stack spacing={2.5}>
+          <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" spacing={2}>
+            <Box>
+              <Typography variant="overline" sx={{ color: '#93c5fd', letterSpacing: 1.4 }}>
+                Project Pod
+              </Typography>
+              <Typography variant="h3" sx={{ fontSize: { xs: '1.8rem', md: '2.6rem' }, fontWeight: 800, color: '#f8fafc' }}>
+                {room?.name}
+              </Typography>
+              <Typography sx={{ mt: 1, maxWidth: 820, color: '#cbd5e1', fontSize: '1rem' }}>
+                {room?.description || room?.projectMeta?.goal || 'Project workspace for people and agents.'}
+              </Typography>
+            </Box>
+            <Stack direction={{ xs: 'row', md: 'column' }} spacing={1} justifyContent="flex-start" alignItems={{ xs: 'stretch', md: 'flex-end' }}>
+              <Button variant="contained" startIcon={<AddIcon />} onClick={() => setNewTaskOpen(true)}>
+                New Task
+              </Button>
+              <Button variant="outlined" startIcon={<EditIcon />} onClick={openProjectDialog}>
+                Edit Project
+              </Button>
+            </Stack>
+          </Stack>
+
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            <Chip color={projectStatusColor(room?.projectMeta?.status)} label={`Status: ${room?.projectMeta?.status || 'planning'}`} />
+            <Chip label={`Due: ${formatShortDate(room?.projectMeta?.dueDate)}`} />
+            <Chip label={`Open tasks: ${openTaskCount}`} />
+            <Chip label={`Blocked: ${blockedTaskCount}`} color={blockedTaskCount > 0 ? 'warning' : 'default'} />
+            <Chip label={`Members: ${room?.members?.length || 0}`} />
+            <Chip label={`Agents: ${podAgents.length}`} />
+          </Stack>
+
+          {error ? <Alert severity="error" onClose={() => setError('')}>{error}</Alert> : null}
+
+          <Tabs
+            value={activeTab}
+            onChange={(_event, nextValue) => setActiveTab(nextValue)}
+            sx={{
+              '& .MuiTabs-indicator': { backgroundColor: '#f59e0b', height: 3 },
+              '& .MuiTab-root': { color: '#cbd5e1', textTransform: 'none', fontWeight: 700 },
+              '& .Mui-selected': { color: '#f8fafc !important' },
+            }}
+          >
+            <Tab value={PROJECT_TAB_CHAT} label="Chat" />
+            <Tab value={PROJECT_TAB_TASKS} label="Tasks" />
+          </Tabs>
+
+          {activeTab === PROJECT_TAB_CHAT ? (
+            <Box sx={{ display: 'grid', gap: 2, gridTemplateColumns: { xs: '1fr', lg: 'minmax(0, 1.7fr) 360px' } }}>
+              <Paper sx={{ p: 0, borderRadius: 4, overflow: 'hidden', backgroundColor: '#0b1322', border: '1px solid rgba(148,163,184,0.12)' }}>
+                <Box sx={{ px: 2.5, py: 1.75, borderBottom: '1px solid rgba(148,163,184,0.12)' }}>
+                  <Typography variant="h6" sx={{ color: '#f8fafc', fontWeight: 700 }}>
+                    Team Chat
+                  </Typography>
+                  <Typography variant="body2" sx={{ color: '#94a3b8' }}>
+                    Discussion stays live here. Project truth stays in the task system and sidebar.
+                  </Typography>
+                </Box>
+                <Box sx={{ px: 2, py: 2, height: { xs: '50vh', lg: '62vh' }, overflowY: 'auto' }}>
+                  <Stack spacing={1.5}>
+                    {(messages || []).map((message) => {
+                      const author = renderMessageAuthor(message);
+                      const avatarValue = renderMessageAvatar(message);
+                      return (
+                        <Paper
+                          key={message._id || message.id}
+                          sx={{
+                            p: 1.5,
+                            borderRadius: 3,
+                            backgroundColor: message.messageType === 'system' ? 'rgba(248,250,252,0.06)' : 'rgba(15,23,42,0.78)',
+                            border: '1px solid rgba(148,163,184,0.08)',
+                          }}
+                        >
+                          <Stack direction="row" spacing={1.25} alignItems="flex-start">
+                            <Avatar
+                              src={getAvatarSrc(avatarValue) || undefined}
+                              sx={{ bgcolor: getAvatarColor(avatarValue || author), width: 34, height: 34 }}
+                            >
+                              {String(author || '?').charAt(0).toUpperCase()}
+                            </Avatar>
+                            <Box sx={{ minWidth: 0, flex: 1 }}>
+                              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+                                <Typography sx={{ color: '#f8fafc', fontWeight: 700 }}>
+                                  {author}
+                                </Typography>
+                                <Typography variant="caption" sx={{ color: '#94a3b8' }}>
+                                  {formatDateTime(message.createdAt || message.created_at)}
+                                </Typography>
+                              </Stack>
+                              <Box sx={{ color: '#e2e8f0', mt: 0.5, wordBreak: 'break-word' }}>
+                                <MessageContent>{message.content || message.text || ''}</MessageContent>
+                              </Box>
+                            </Box>
+                          </Stack>
+                        </Paper>
+                      );
+                    })}
+                    <div ref={messagesEndRef} />
+                  </Stack>
+                </Box>
+                <Box sx={{ p: 2, borderTop: '1px solid rgba(148,163,184,0.12)' }}>
+                  <UnifiedComposer
+                    members={room?.members || []}
+                    agents={podAgents || []}
+                    placeholder="Message the team, mention an agent, or log quick context..."
+                    onSend={handleSendProjectMessage}
+                    showFileUpload={false}
+                    showEmoji={false}
+                  />
+                </Box>
+              </Paper>
+
+              <Stack spacing={2}>
+                <Paper sx={{ p: 2, borderRadius: 4, backgroundColor: '#111827', border: '1px solid rgba(148,163,184,0.12)' }}>
+                  <Typography variant="subtitle2" sx={{ color: '#93c5fd', textTransform: 'uppercase', letterSpacing: 1.1 }}>
+                    Brief
+                  </Typography>
+                  <Typography sx={{ mt: 1, color: '#f8fafc', fontWeight: 700 }}>
+                    {room?.projectMeta?.goal || room?.description || 'Add a clear project brief.'}
+                  </Typography>
+                  <Typography sx={{ mt: 1, color: '#cbd5e1', whiteSpace: 'pre-wrap' }}>
+                    {room?.projectMeta?.scope || 'Scope is not defined yet.'}
+                  </Typography>
+                </Paper>
+
+                <Paper sx={{ p: 2, borderRadius: 4, backgroundColor: '#111827', border: '1px solid rgba(148,163,184,0.12)' }}>
+                  <Typography variant="subtitle2" sx={{ color: '#93c5fd', textTransform: 'uppercase', letterSpacing: 1.1 }}>
+                    Success Criteria
+                  </Typography>
+                  <Stack spacing={1} sx={{ mt: 1.25 }}>
+                    {(room?.projectMeta?.successCriteria || []).length ? (
+                      room.projectMeta.successCriteria.map((criterion, index) => (
+                        <Box key={`${criterion}-${index}`} sx={{ color: '#e2e8f0' }}>
+                          • {criterion}
+                        </Box>
+                      ))
+                    ) : (
+                      <Typography sx={{ color: '#94a3b8' }}>No success criteria captured yet.</Typography>
+                    )}
+                  </Stack>
+                </Paper>
+
+                <Paper sx={{ p: 2, borderRadius: 4, backgroundColor: '#111827', border: '1px solid rgba(148,163,184,0.12)' }}>
+                  <Typography variant="subtitle2" sx={{ color: '#93c5fd', textTransform: 'uppercase', letterSpacing: 1.1 }}>
+                    Key Information
+                  </Typography>
+                  <Stack spacing={1.25} sx={{ mt: 1.25 }}>
+                    <Typography sx={{ color: '#e2e8f0' }}>Owners: {projectOwners.length ? projectOwners.map((owner) => owner.username).join(', ') : 'Not assigned'}</Typography>
+                    <Typography sx={{ color: '#e2e8f0' }}>Due date: {formatShortDate(room?.projectMeta?.dueDate)}</Typography>
+                    <Typography sx={{ color: '#e2e8f0' }}>Open blockers: {blockedTaskCount}</Typography>
+                    <Typography sx={{ color: '#e2e8f0' }}>Active tasks: {openTaskCount}</Typography>
+                  </Stack>
+                </Paper>
+
+                <Paper sx={{ p: 2, borderRadius: 4, backgroundColor: '#111827', border: '1px solid rgba(148,163,184,0.12)' }}>
+                  <Typography variant="subtitle2" sx={{ color: '#93c5fd', textTransform: 'uppercase', letterSpacing: 1.1 }}>
+                    Key Links
+                  </Typography>
+                  <Stack spacing={1.1} sx={{ mt: 1.25 }}>
+                    {(room?.projectMeta?.keyLinks || []).length ? (
+                      room.projectMeta.keyLinks.map((link, index) => (
+                        <a key={`${link.url}-${index}`} href={link.url} target="_blank" rel="noreferrer" style={{ color: '#f8fafc', textDecoration: 'none' }}>
+                          {link.label || link.url}
+                        </a>
+                      ))
+                    ) : (
+                      <Typography sx={{ color: '#94a3b8' }}>No linked resources yet.</Typography>
+                    )}
+                  </Stack>
+                </Paper>
+
+                <Paper sx={{ p: 2, borderRadius: 4, backgroundColor: '#111827', border: '1px solid rgba(148,163,184,0.12)' }}>
+                  <Typography variant="subtitle2" sx={{ color: '#93c5fd', textTransform: 'uppercase', letterSpacing: 1.1 }}>
+                    Members & Agents
+                  </Typography>
+                  <Stack spacing={1.2} sx={{ mt: 1.25 }}>
+                    {(room?.members || []).slice(0, 6).map((member) => (
+                      <Stack key={member._id || member.username} direction="row" spacing={1} alignItems="center">
+                        <Avatar src={getAvatarSrc(member.profilePicture) || undefined} sx={{ bgcolor: getAvatarColor(member.profilePicture || member.username), width: 28, height: 28 }}>
+                          {member.username?.charAt(0)?.toUpperCase()}
+                        </Avatar>
+                        <Typography sx={{ color: '#e2e8f0' }}>{member.username}</Typography>
+                      </Stack>
+                    ))}
+                    {(podAgents || []).slice(0, 6).map((agent) => (
+                      <Stack key={`${agent.name}-${agent.instanceId}`} direction="row" spacing={1} alignItems="center">
+                        <Avatar src={agent.profile?.iconUrl || agent.profile?.avatarUrl || agent.iconUrl || undefined} sx={{ width: 28, height: 28 }}>
+                          {(agent.displayName || agent.instanceId || agent.name || 'A').charAt(0).toUpperCase()}
+                        </Avatar>
+                        <Typography sx={{ color: '#e2e8f0' }}>
+                          {agent.profile?.displayName || agent.displayName || agent.instanceId || agent.name}
+                        </Typography>
+                      </Stack>
+                    ))}
+                  </Stack>
+                </Paper>
+              </Stack>
+            </Box>
+          ) : (
+            <Box sx={{ display: 'grid', gap: 2, gridTemplateColumns: { xs: '1fr', xl: '340px minmax(0, 1fr)' } }}>
+              <Paper sx={{ p: 2, borderRadius: 4, backgroundColor: '#0b1322', border: '1px solid rgba(148,163,184,0.12)' }}>
+                <Stack spacing={1.5}>
+                  <TextField
+                    value={taskSearch}
+                    onChange={(event) => setTaskSearch(event.target.value)}
+                    placeholder="Search tasks..."
+                    fullWidth
+                    size="small"
+                  />
+                  <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                    {TASK_FILTERS.map((filterKey) => (
+                      <Button
+                        key={filterKey}
+                        size="small"
+                        variant={taskFilter === filterKey ? 'contained' : 'outlined'}
+                        onClick={() => setTaskFilter(filterKey)}
+                      >
+                        {filterKey === 'mine' ? 'My work' : filterKey}
+                      </Button>
+                    ))}
+                  </Stack>
+                  <Divider />
+                  <Stack spacing={1}>
+                    {filteredTasks.length ? filteredTasks.map((task) => (
+                      <Paper
+                        key={task.taskId}
+                        onClick={() => setSelectedTaskId(task.taskId)}
+                        sx={{
+                          p: 1.4,
+                          cursor: 'pointer',
+                          borderRadius: 3,
+                          backgroundColor: selectedTaskId === task.taskId ? 'rgba(59,130,246,0.16)' : 'rgba(15,23,42,0.88)',
+                          border: selectedTaskId === task.taskId ? '1px solid rgba(96,165,250,0.55)' : '1px solid rgba(148,163,184,0.08)',
+                        }}
+                      >
+                        <Stack spacing={0.8}>
+                          <Stack direction="row" justifyContent="space-between" spacing={1}>
+                            <Typography sx={{ color: '#f8fafc', fontWeight: 700 }}>
+                              {task.taskId}
+                            </Typography>
+                            <Chip size="small" label={taskStatusLabel(task.status)} color={taskStatusColor(task.status)} />
+                          </Stack>
+                          <Typography sx={{ color: '#e2e8f0', fontWeight: 600 }}>
+                            {task.title}
+                          </Typography>
+                          <Typography variant="body2" sx={{ color: '#94a3b8' }}>
+                            {task.assignee ? `Assigned to ${task.assignee}` : 'Unassigned'}
+                          </Typography>
+                          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                            <Chip size="small" label={`Progress ${task.progressPercent || 0}%`} />
+                            {task.priority ? <Chip size="small" label={task.priority} /> : null}
+                            {task.dueDate ? <Chip size="small" label={formatShortDate(task.dueDate)} /> : null}
+                          </Stack>
+                        </Stack>
+                      </Paper>
+                    )) : (
+                      <Typography sx={{ color: '#94a3b8' }}>
+                        No tasks match the current filter.
+                      </Typography>
+                    )}
+                  </Stack>
+                </Stack>
+              </Paper>
+
+              <Paper sx={{ p: 2.5, borderRadius: 4, backgroundColor: '#111827', border: '1px solid rgba(148,163,184,0.12)' }}>
+                {selectedTask ? (
+                  <Stack spacing={2}>
+                    <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" spacing={1.5}>
+                      <Box>
+                        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+                          <Typography variant="h5" sx={{ color: '#f8fafc', fontWeight: 800 }}>
+                            {selectedTask.taskId}
+                          </Typography>
+                          <Chip label={taskStatusLabel(selectedTask.status)} color={taskStatusColor(selectedTask.status)} />
+                          {selectedTask.priority ? <Chip label={selectedTask.priority} /> : null}
+                        </Stack>
+                        <Typography variant="h4" sx={{ mt: 1, color: '#f8fafc', fontSize: { xs: '1.5rem', md: '2rem' }, fontWeight: 800 }}>
+                          {selectedTask.title}
+                        </Typography>
+                      </Box>
+                      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                        <Tooltip title="Take task">
+                          <span>
+                            <IconButton color="primary" onClick={handleTakeTask} disabled={saving}>
+                              <TakeTaskIcon />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                        <Tooltip title="Assign task">
+                          <span>
+                            <IconButton color="primary" onClick={() => { setAssignKey(''); setAssignOpen(true); }} disabled={saving}>
+                              <TaskIcon />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                        <Tooltip title="Post progress">
+                          <span>
+                            <IconButton color="primary" onClick={() => setProgressOpen(true)} disabled={saving}>
+                              <EditIcon />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                        <Tooltip title="Raise blocker">
+                          <span>
+                            <IconButton color="warning" onClick={() => setBlockerOpen(true)} disabled={saving}>
+                              <FlagIcon />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                        <Tooltip title="Complete task">
+                          <span>
+                            <IconButton color="success" onClick={() => setCompleteOpen(true)} disabled={saving}>
+                              <CompleteIcon />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      </Stack>
+                    </Stack>
+
+                    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                      <Chip label={`Assignee: ${selectedTask.assignee || 'Unassigned'}`} />
+                      <Chip label={`Progress: ${selectedTask.progressPercent || 0}%`} />
+                      <Chip label={`Due: ${formatShortDate(selectedTask.dueDate)}`} />
+                      {selectedTask.dep ? <Chip label={`Depends on ${selectedTask.dep}`} /> : null}
+                    </Stack>
+
+                    <Paper sx={{ p: 2, borderRadius: 3, backgroundColor: 'rgba(15,23,42,0.85)' }}>
+                      <Typography variant="subtitle2" sx={{ color: '#93c5fd', textTransform: 'uppercase', letterSpacing: 1.1 }}>
+                        Description
+                      </Typography>
+                      <Typography sx={{ mt: 1, color: '#e2e8f0', whiteSpace: 'pre-wrap' }}>
+                        {selectedTask.description || selectedTask.notes || 'No detailed task brief yet.'}
+                      </Typography>
+                    </Paper>
+
+                    <Paper sx={{ p: 2, borderRadius: 3, backgroundColor: 'rgba(15,23,42,0.85)' }}>
+                      <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={1}>
+                        <Typography variant="subtitle2" sx={{ color: '#93c5fd', textTransform: 'uppercase', letterSpacing: 1.1 }}>
+                          Blocker
+                        </Typography>
+                        {selectedTask.blocker?.open ? (
+                          <Button color="warning" size="small" onClick={handleClearBlocker} disabled={saving}>
+                            Clear blocker
+                          </Button>
+                        ) : null}
+                      </Stack>
+                      {selectedTask.blocker?.open ? (
+                        <Stack spacing={0.7} sx={{ mt: 1 }}>
+                          <Typography sx={{ color: '#f8fafc', fontWeight: 700 }}>{selectedTask.blocker.reason}</Typography>
+                          <Typography sx={{ color: '#cbd5e1' }}>Waiting on: {selectedTask.blocker.waitingOn || 'Not specified'}</Typography>
+                          <Typography sx={{ color: '#cbd5e1' }}>Severity: {selectedTask.blocker.severity || 'medium'}</Typography>
+                          <Typography sx={{ color: '#94a3b8' }}>Opened {formatDateTime(selectedTask.blocker.openedAt)}</Typography>
+                        </Stack>
+                      ) : (
+                        <Typography sx={{ mt: 1, color: '#94a3b8' }}>
+                          No active blocker.
+                        </Typography>
+                      )}
+                    </Paper>
+
+                    <Paper sx={{ p: 2, borderRadius: 3, backgroundColor: 'rgba(15,23,42,0.85)' }}>
+                      <Typography variant="subtitle2" sx={{ color: '#93c5fd', textTransform: 'uppercase', letterSpacing: 1.1 }}>
+                        Updates
+                      </Typography>
+                      <Stack spacing={1.2} sx={{ mt: 1.25 }}>
+                        {(selectedTask.updates || []).length ? selectedTask.updates.slice().reverse().map((update, index) => (
+                          <Box key={`${update.createdAt}-${index}`} sx={{ pb: 1.2, borderBottom: index === (selectedTask.updates.length - 1) ? 'none' : '1px solid rgba(148,163,184,0.12)' }}>
+                            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+                              <Typography sx={{ color: '#f8fafc', fontWeight: 700 }}>
+                                {update.author || 'system'}
+                              </Typography>
+                              {update.kind ? <Chip size="small" label={update.kind} /> : null}
+                              <Typography variant="caption" sx={{ color: '#94a3b8' }}>
+                                {formatDateTime(update.createdAt)}
+                              </Typography>
+                            </Stack>
+                            <Typography sx={{ mt: 0.5, color: '#e2e8f0', whiteSpace: 'pre-wrap' }}>
+                              {update.text}
+                            </Typography>
+                            {update.progressPercent !== undefined && update.progressPercent !== null ? (
+                              <Typography variant="body2" sx={{ mt: 0.4, color: '#cbd5e1' }}>
+                                Progress: {update.progressPercent}%
+                              </Typography>
+                            ) : null}
+                            {update.nextStep ? (
+                              <Typography variant="body2" sx={{ mt: 0.4, color: '#cbd5e1' }}>
+                                Next step: {update.nextStep}
+                              </Typography>
+                            ) : null}
+                          </Box>
+                        )) : (
+                          <Typography sx={{ color: '#94a3b8' }}>No task updates yet.</Typography>
+                        )}
+                      </Stack>
+                    </Paper>
+                  </Stack>
+                ) : (
+                  <Typography sx={{ color: '#94a3b8' }}>
+                    Select a task to inspect its full details.
+                  </Typography>
+                )}
+              </Paper>
+            </Box>
+          )}
+        </Stack>
+      </Paper>
+
+      <Dialog open={projectDialogOpen} onClose={() => setProjectDialogOpen(false)} fullWidth maxWidth="md">
+        <DialogTitle>Edit Project</DialogTitle>
+        <DialogContent sx={{ display: 'grid', gap: 1.5, pt: '10px !important' }}>
+          <TextField label="Project name" value={projectForm.name} onChange={(event) => setProjectForm((prev) => ({ ...prev, name: event.target.value }))} fullWidth />
+          <TextField label="Description" value={projectForm.description} onChange={(event) => setProjectForm((prev) => ({ ...prev, description: event.target.value }))} fullWidth multiline minRows={2} />
+          <TextField label="Goal" value={projectForm.goal} onChange={(event) => setProjectForm((prev) => ({ ...prev, goal: event.target.value }))} fullWidth multiline minRows={2} />
+          <TextField label="Scope" value={projectForm.scope} onChange={(event) => setProjectForm((prev) => ({ ...prev, scope: event.target.value }))} fullWidth multiline minRows={3} />
+          <TextField label="Success criteria (one per line)" value={projectForm.successCriteriaText} onChange={(event) => setProjectForm((prev) => ({ ...prev, successCriteriaText: event.target.value }))} fullWidth multiline minRows={3} />
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+            <TextField select label="Status" value={projectForm.status} onChange={(event) => setProjectForm((prev) => ({ ...prev, status: event.target.value }))} fullWidth>
+              <MenuItem value="planning">Planning</MenuItem>
+              <MenuItem value="on-track">On track</MenuItem>
+              <MenuItem value="at-risk">At risk</MenuItem>
+              <MenuItem value="blocked">Blocked</MenuItem>
+              <MenuItem value="complete">Complete</MenuItem>
+            </TextField>
+            <TextField label="Due date" type="date" value={projectForm.dueDate} onChange={(event) => setProjectForm((prev) => ({ ...prev, dueDate: event.target.value }))} fullWidth InputLabelProps={{ shrink: true }} />
+          </Stack>
+          <TextField label="Key links (Label | URL per line)" value={projectForm.keyLinksText} onChange={(event) => setProjectForm((prev) => ({ ...prev, keyLinksText: event.target.value }))} fullWidth multiline minRows={3} />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setProjectDialogOpen(false)}>Cancel</Button>
+          <Button onClick={handleSaveProject} variant="contained" disabled={saving}>Save</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={newTaskOpen} onClose={() => setNewTaskOpen(false)} fullWidth maxWidth="sm">
+        <DialogTitle>New Task</DialogTitle>
+        <DialogContent sx={{ display: 'grid', gap: 1.5, pt: '10px !important' }}>
+          <TextField label="Title" value={newTaskForm.title} onChange={(event) => setNewTaskForm((prev) => ({ ...prev, title: event.target.value }))} fullWidth />
+          <TextField label="Description" value={newTaskForm.description} onChange={(event) => setNewTaskForm((prev) => ({ ...prev, description: event.target.value }))} fullWidth multiline minRows={3} />
+          <TextField select label="Assign to" value={newTaskForm.assigneeKey} onChange={(event) => setNewTaskForm((prev) => ({ ...prev, assigneeKey: event.target.value }))} fullWidth>
+            <MenuItem value="">Unassigned</MenuItem>
+            {assignmentOptions.map((option) => (
+              <MenuItem key={option.key} value={option.key}>{option.label}</MenuItem>
+            ))}
+          </TextField>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+            <TextField select label="Priority" value={newTaskForm.priority} onChange={(event) => setNewTaskForm((prev) => ({ ...prev, priority: event.target.value }))} fullWidth>
+              <MenuItem value="low">Low</MenuItem>
+              <MenuItem value="medium">Medium</MenuItem>
+              <MenuItem value="high">High</MenuItem>
+            </TextField>
+            <TextField label="Due date" type="date" value={newTaskForm.dueDate} onChange={(event) => setNewTaskForm((prev) => ({ ...prev, dueDate: event.target.value }))} fullWidth InputLabelProps={{ shrink: true }} />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setNewTaskOpen(false)}>Cancel</Button>
+          <Button onClick={handleCreateTask} variant="contained" disabled={saving}>Create task</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={assignOpen} onClose={() => setAssignOpen(false)} fullWidth maxWidth="xs">
+        <DialogTitle>Assign Task</DialogTitle>
+        <DialogContent sx={{ pt: '10px !important' }}>
+          <TextField select label="Assignee" value={assignKey} onChange={(event) => setAssignKey(event.target.value)} fullWidth>
+            {assignmentOptions.map((option) => (
+              <MenuItem key={option.key} value={option.key}>{option.label}</MenuItem>
+            ))}
+          </TextField>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setAssignOpen(false)}>Cancel</Button>
+          <Button onClick={handleAssignTask} variant="contained" disabled={saving || !assignKey}>Save</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={progressOpen} onClose={() => setProgressOpen(false)} fullWidth maxWidth="sm">
+        <DialogTitle>Post Progress</DialogTitle>
+        <DialogContent sx={{ display: 'grid', gap: 1.5, pt: '10px !important' }}>
+          <TextField label="Update" value={progressForm.text} onChange={(event) => setProgressForm((prev) => ({ ...prev, text: event.target.value }))} fullWidth multiline minRows={3} />
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+            <TextField label="Progress %" type="number" value={progressForm.progressPercent} onChange={(event) => setProgressForm((prev) => ({ ...prev, progressPercent: event.target.value }))} fullWidth inputProps={{ min: 0, max: 100 }} />
+            <TextField label="Next step" value={progressForm.nextStep} onChange={(event) => setProgressForm((prev) => ({ ...prev, nextStep: event.target.value }))} fullWidth />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setProgressOpen(false)}>Cancel</Button>
+          <Button onClick={handlePostProgress} variant="contained" disabled={saving}>Post update</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={blockerOpen} onClose={() => setBlockerOpen(false)} fullWidth maxWidth="sm">
+        <DialogTitle>Raise Blocker</DialogTitle>
+        <DialogContent sx={{ display: 'grid', gap: 1.5, pt: '10px !important' }}>
+          <TextField label="Reason" value={blockerForm.reason} onChange={(event) => setBlockerForm((prev) => ({ ...prev, reason: event.target.value }))} fullWidth multiline minRows={3} />
+          <TextField label="Waiting on" value={blockerForm.waitingOn} onChange={(event) => setBlockerForm((prev) => ({ ...prev, waitingOn: event.target.value }))} fullWidth />
+          <TextField select label="Severity" value={blockerForm.severity} onChange={(event) => setBlockerForm((prev) => ({ ...prev, severity: event.target.value }))} fullWidth>
+            <MenuItem value="low">Low</MenuItem>
+            <MenuItem value="medium">Medium</MenuItem>
+            <MenuItem value="high">High</MenuItem>
+          </TextField>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setBlockerOpen(false)}>Cancel</Button>
+          <Button onClick={handleSaveBlocker} color="warning" variant="contained" disabled={saving}>Raise blocker</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={completeOpen} onClose={() => setCompleteOpen(false)} fullWidth maxWidth="sm">
+        <DialogTitle>Complete Task</DialogTitle>
+        <DialogContent sx={{ pt: '10px !important' }}>
+          <TextField label="Completion notes" value={completeNotes} onChange={(event) => setCompleteNotes(event.target.value)} fullWidth multiline minRows={3} />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setCompleteOpen(false)}>Cancel</Button>
+          <Button onClick={handleCompleteTask} color="success" variant="contained" disabled={saving}>Complete</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default ProjectPodRoom;

--- a/frontend/start-dev.sh
+++ b/frontend/start-dev.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Starting Commonly Frontend (dev)..."
+
+if [ ! -d "/app/node_modules" ] \
+    || [ -z "$(ls -A /app/node_modules 2>/dev/null)" ] \
+    || [ ! -d "/app/node_modules/react" ] \
+    || [ ! -f "/app/node_modules/.bin/vite" ] \
+    || [ ! -f "/app/node_modules/.bin/jest" ] \
+    || [ ! -f "/app/node_modules/.bin/eslint" ]; then
+    echo "Installing frontend dependencies (dev)..."
+    npm ci --only=production=false --prefer-offline --no-audit
+else
+    echo "Dependencies already present, skipping install"
+fi
+
+echo "Starting dev server..."
+exec npm start

--- a/packages/types/src/pod.ts
+++ b/packages/types/src/pod.ts
@@ -1,4 +1,4 @@
-export type PodType = 'chat' | 'team' | 'study' | 'games' | 'agent-admin' | 'dm';
+export type PodType = 'chat' | 'team' | 'study' | 'games' | 'project' | 'agent-admin' | 'dm';
 export type PodJoinPolicy = 'open' | 'invite-only' | 'request';
 
 export interface IPod {
@@ -7,6 +7,15 @@ export interface IPod {
   description?: string;
   type: PodType;
   joinPolicy: PodJoinPolicy;
+  projectMeta?: {
+    goal?: string;
+    scope?: string;
+    successCriteria?: string[];
+    status?: 'planning' | 'on-track' | 'at-risk' | 'blocked' | 'complete';
+    dueDate?: string | Date | null;
+    ownerIds?: string[];
+    keyLinks?: Array<{ label: string; url: string }>;
+  };
   members: string[];
   createdBy: string;
   isPrivate?: boolean;


### PR DESCRIPTION
This PR introduces a first-pass project pod workspace.

What is included:
- new `project` pod type in backend and shared types
- dedicated project pod room with `Chat` and `Tasks` tabs
- project metadata on pods (`projectMeta`)
- richer task fields and structured updates/blockers
- project pod creation/category entry points in the UI
- dev-container self-healing for missing frontend/backend dev dependencies

Still pending:
- dedicated Create Project Pod wizard
- milestone model and milestone sidebar UI
- task workflow cleanup to user-facing states like `todo`, `in_progress`, `blocked`, `in_review`, `done`
- richer task detail actions for handoff/review/blockers
- agent tool/runtime expansion for task progress and blocker updates
- project timeline/activity view and stronger sidebar context
- DB/index tuning once task volume and query patterns settle
- documentation follow-up for the remaining rollout items

Verification:
- targeted frontend tests for pod routing and pod creation UI
- frontend test run for `Pod.test.tsx` after the dropdown fix