### PR TITLE
ci(gitleaks): allowlist uploads signed-URL integration test

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -42,6 +42,7 @@ paths = [
   '''frontend/src/components/ApiDevPage\.js''',
   # Integration test with hardcoded test constant (not a real key)
   '''backend/__tests__/integration/integrations-e2e\.test\.js''',
+  '''backend/__tests__/integration/uploads\.signedurl\.integration\.test\.js''',
 ]
 
 [[rules]]


### PR DESCRIPTION
## Summary
- Secret Scan has been failing on `main` since `dd1b310918` (PR #216, ADR-002 Phase 1b-a)
- Gitleaks flags `process.env.JWT_SECRET = 'test-jwt-secret-adr002-integration'` at `backend/__tests__/integration/uploads.signedurl.integration.test.js:47` as a `generic-api-key` leak
- It's a test fixture constant, not a real secret — same situation as `integrations-e2e.test.js`, which is already in the allowlist
- Fix: add the new integration test file to the existing `[allowlist] paths` block in `.gitleaks.toml`

## Why not delete the line
The gitleaks workflow scans full branch history (`--log-opts="--branches --remotes=origin/main ..."`), so deleting the line in a follow-up commit doesn't clear the finding — the commit it was introduced in would still hit. An allowlist entry is the standard fix for test fixtures and matches existing convention in this file.

## Test plan
- [ ] Secret Scan passes on this PR
- [ ] Secret Scan passes on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)