### PR TITLE
chore(gitignore): ignore .dev/ to prevent committing local secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,11 @@ _external/*/
 # Claude Code — local dev tooling, not for OSS contributors
 .claude/
 
+# Local-only dev materials: values-private.yaml (Helm overrides with real
+# GCP project ID / PG host / image repos) and git worktrees under .dev/worktree/.
+# Never commit — contents include credentials and embedded git repos.
+.dev/
+
 # Codex skills backup after migration to commonly-skills repo (2026-04-12)
 .codex/skills.bak.*
 


### PR DESCRIPTION
## Summary
- \`.dev/\` is the canonical location for local-only dev materials: \`values-private.yaml\` (real GCP project ID, PG host, image repos), git worktrees for parallel work, and similar
- It was not in \`.gitignore\`, so \`git add -A\` at repo root silently staged \`.dev/values-private.yaml\` (a secrets file) and three embedded worktree git repos
- Caught before commit in the ADR-009 Phase 1 work, but the footgun should go away

## Test plan
- [x] \`git check-ignore\` confirms \`.dev/values-private.yaml\` and \`.dev/worktree/*\` are now ignored
- [x] \`git status\` at the root no longer lists \`.dev/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)