### PR TITLE
ci(smoke): ADR-009 Phase 2 — gate Tier 2 on PRs touching deploy surfaces

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -11,22 +11,36 @@ on:
     workflows: ["Tests"]
     branches: [main]
     types: [completed]
+  # ADR-009 Phase 2: gate Tier 2 on PRs that touch deployment surfaces.
+  # Most PRs don't hit these paths and skip the (slow, expensive) kind smoke.
+  pull_request:
+    paths:
+      - 'k8s/**'
+      - 'backend/Dockerfile'
+      - 'frontend/Dockerfile'
+      - '_external/clawdbot/**'
+      - 'dev.sh'
+      - '.github/workflows/**'
 
 permissions:
   contents: read
 
-# Only one smoke test at a time — clusters are expensive
+# Scoped per-PR / per-ref so different PRs don't block each other on the single
+# global smoke queue. Preserves cancel-in-progress: false (never kill a running
+# smoke) while letting multiple smokes run in parallel runners.
 concurrency:
-  group: smoke-test
+  group: smoke-test-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 jobs:
   smoke:
     name: kind cluster smoke test
     runs-on: ubuntu-latest
-    # Only run if triggered manually OR Tests workflow succeeded on main
+    # Run on manual dispatch, on any PR that passed the path filter above,
+    # or on a successful Tests workflow_run on main.
     if: >
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     timeout-minutes: 30
 


### PR DESCRIPTION
Implements **Phase 2** of [ADR-009](../blob/main/docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md): PRs that can break a deploy get cluster smoke signal *before* they merge, not after.

## What changed in \`smoke-test.yml\`

\`\`\`yaml
on:
  ...existing workflow_dispatch + workflow_run triggers (preserved)...
  pull_request:
    paths:
      - 'k8s/**'
      - 'backend/Dockerfile'
      - 'frontend/Dockerfile'
      - '_external/clawdbot/**'
      - 'dev.sh'
      - '.github/workflows/**'
\`\`\`

Job \`if:\` updated to accept \`pull_request\` alongside the existing triggers.

## Concurrency

Previously: \`group: smoke-test\` (single global queue; every smoke serialized behind every other).
Now: \`group: smoke-test-\${PR-number-or-ref}\` with \`cancel-in-progress: false\`.

- Different PRs run in parallel (no cross-PR blocking)
- Within a single PR, new pushes queue behind the running smoke (preserves the ADR's \"clusters are expensive; don't kill one mid-run\" principle)
- Main's post-merge smoke and manual dispatches keep their old semantics

## Self-test

This PR touches \`.github/workflows/**\`, so it's in the new path filter — CI should actually run the kind smoke here. Proves the filter works end-to-end.

## Human action (post-merge)

Add \`kind cluster smoke test\` to branch protection on \`main\` as a **required-only-when-present** check. GitHub options:
- **Classic branch protection**: \"Require status checks to pass → do NOT add \`kind cluster smoke test\` to the list\" (only-when-present is the default when you don't list it), or
- **Repo ruleset**: \`required_status_checks.checks\` with \`app_id: null\` for \`kind cluster smoke test\` — sets expected-when-present semantics explicitly

Document whichever we pick. Without this, the filter-out-most-PRs design works but no one's forced to wait for smoke when they did touch the paths.

## Test plan

- [ ] \`Smoke Tests (kind cluster) / kind cluster smoke test\` appears and passes on this PR (self-test)
- [ ] Path filter verified: a doc-only PR after this merges does **not** trigger smoke
- [ ] Post-merge \`workflow_run\` on main still fires (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)