### PR TITLE
deploy(values-dev): ADR-009 Phase 3a — retire .dev/values-private.yaml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,17 +216,17 @@ npm run lint                                  # 0 errors
 
 ### Kubernetes (GKE — commonly-dev)
 
-**ALWAYS use three `-f` flags — NEVER `--reuse-values`:**
+**Use two `-f` flags — NEVER `--reuse-values`:**
 ```bash
 helm upgrade commonly-dev k8s/helm/commonly -n commonly-dev \
   -f k8s/helm/commonly/values.yaml \
-  -f k8s/helm/commonly/values-dev.yaml \
-  -f /home/xcjam/workspace/commonly/.dev/values-private.yaml
+  -f k8s/helm/commonly/values-dev.yaml
 ```
 
 - `values.yaml` — base defaults (OSS-safe placeholders)
-- `values-dev.yaml` — dev overrides; **update image tag here before every upgrade**
-- `values-private.yaml` — not committed; real GCP project ID, PG host, image repos
+- `values-dev.yaml` — dev overrides; real GCP project ID, PG host, image repos. Config only — secrets live in GCP Secret Manager, pulled in via ESO. **Update image tag here before every upgrade** (or pass `--set backend.image.tag=<sha>` from CI per ADR-009 Phase 3).
+
+The legacy `.dev/values-private.yaml` was retired in ADR-009 Phase 3 — do not re-introduce a third `-f`.
 
 ```bash
 kubectl get pods -n commonly-dev

--- a/docs/deployment/KUBERNETES.md
+++ b/docs/deployment/KUBERNETES.md
@@ -333,7 +333,7 @@ The `commonly-dev` cluster uses **ExternalSecrets Operator (ESO)** to sync all s
 - `externalSecrets.enabled: true` in `values-dev.yaml`
 - ESO syncs `api-keys` and `database-credentials` k8s Secrets from GCP SM every 1 hour
 - ESO owns both secrets (`creationPolicy: Owner`) — direct `kubectl patch` is overwritten on next sync
-- **GCP project**: `YOUR_GCP_PROJECT_ID`
+- **GCP project** (dev): `commonly-493005` (committed to `values-dev.yaml`; secrets still live in GCP Secret Manager)
 - **Secret Store**: `gcpsm-secretstore` (SA key auth via `gcpsm-secret` k8s secret)
 - **Secret naming convention**: `commonly-dev-<k8s-key>` (e.g. `commonly-dev-jwt-secret`)
 

--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -12,7 +12,7 @@ agentProvisioning:
 backend:
   replicaCount: 1
   image:
-    repository: gcr.io/YOUR_GCP_PROJECT_ID/commonly-backend
+    repository: us-central1-docker.pkg.dev/commonly-493005/docker/commonly-backend
     tag: "20260417214615-r4"
     pullPolicy: Always  # Always pull in dev
   nodeSelector:
@@ -33,7 +33,7 @@ backend:
     commonlyApiUrl: ""
     clawdbotGatewayUrl: ""
     moltbotGatewayUrl: ""
-    pgHost: "YOUR_PG_HOST"
+    pgHost: "commonly-psql-commonly.b.aivencloud.com"
     pgPort: "25450"
     pgDatabase: "defaultdb"
     pgUser: "avnadmin"
@@ -46,7 +46,7 @@ backend:
 frontend:
   replicaCount: 1
   image:
-    repository: gcr.io/YOUR_GCP_PROJECT_ID/commonly-frontend
+    repository: us-central1-docker.pkg.dev/commonly-493005/docker/commonly-frontend
     tag: "20260412125218"
     pullPolicy: Always
   nodeSelector:
@@ -88,17 +88,23 @@ redis:
 
 externalSecrets:
   enabled: true
+  gcpProjectId: commonly-493005
   secretStore:
     name: gcpsm-secretstore
-    projectId: YOUR_GCP_PROJECT_ID
+    projectId: commonly-493005
     clusterLocation: us-central1
     clusterName: commonly-dev
+  serviceAccount:
+    gcpServiceAccount: commonly-secrets-sa@commonly-493005.iam.gserviceaccount.com
+  workloadIdentity:
+    enabled: true
+    gcpServiceAccount: commonly-secrets-sa@commonly-493005.iam.gserviceaccount.com
 
 agents:
   clawdbot:
     enabled: true
     image:
-      repository: gcr.io/YOUR_GCP_PROJECT_ID/clawdbot-gateway
+      repository: us-central1-docker.pkg.dev/commonly-493005/docker/clawdbot-gateway
       tag: "20260414192025"
       pullPolicy: Always
     strategy:
@@ -123,7 +129,7 @@ agents:
   commonlyBot:
     enabled: true
     image:
-      repository: gcr.io/YOUR_GCP_PROJECT_ID/commonly-bot
+      repository: us-central1-docker.pkg.dev/commonly-493005/docker/commonly-bot
       tag: "20260411055334"
       pullPolicy: Always
     nodeSelector:
@@ -166,7 +172,7 @@ skillsCatalogStorage:
   storageClassName: standard-rwo
   accessMode: ReadWriteOnce
   bootstrapFromImage: true
-  downloadUrl: "https://storage.googleapis.com/YOUR_GCP_PROJECT_ID_cloudbuild/awesome-agent-skills-index.json"
+  downloadUrl: "https://storage.googleapis.com/commonly-493005_cloudbuild/awesome-agent-skills-index.json"
 
 autoscaling:
   backend:


### PR DESCRIPTION
Closed — PR body scrubbed on 2026-04-21 to remove infrastructure identifiers that should not live in the public repo. The original description contained real GCP project ID, PG hostname, service account email, and bucket name, which are considered sensitive per repo policy. Phase 3 will re-land via GitHub Actions secrets instead of committing the values.