### PR TITLE
ci(deploy): ADR-009 Phase 3b — GitHub Actions dev deploy via WIF

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,139 @@
+name: Deploy Dev
+
+# ADR-009 Phase 3: GitHub Actions → GKE commonly-dev via Workload Identity Federation.
+# No long-lived service account JSON in repo secrets; a fresh OIDC token is minted
+# per run and exchanged for a short-lived GCP access token.
+#
+# Trigger is intentionally workflow_dispatch only for the first rollout — once one
+# successful run lands, a follow-up PR flips to `push: branches: [main]` for
+# auto-deploy-on-merge. Phase 4 layers on post-deploy smoke probes + rollback.
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag override (defaults to short SHA of HEAD)'
+        required: false
+        default: ''
+
+permissions:
+  id-token: write     # required to mint the OIDC token for google-github-actions/auth
+  contents: read
+
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: false
+
+env:
+  PROJECT_ID: commonly-493005
+  REGION: us-central1
+  AR_REPO: docker
+  CLUSTER: commonly-dev
+  NAMESPACE: commonly-dev
+
+jobs:
+  deploy:
+    name: Build + push + helm upgrade
+    runs-on: ubuntu-latest
+    environment: dev
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout (with submodules for _external/clawdbot)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          if [ -n "${{ inputs.image_tag }}" ]; then
+            echo "tag=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${REGION}-docker.pkg.dev --quiet
+
+      - name: Build + push backend image
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          REPO=${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/commonly-backend
+          docker build backend -t "$REPO:$TAG"
+          docker push "$REPO:$TAG"
+
+      - name: Build + push frontend image
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          REPO=${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/commonly-frontend
+          docker build frontend \
+            --build-arg REACT_APP_API_URL=https://api-dev.commonly.me \
+            -t "$REPO:$TAG"
+          docker push "$REPO:$TAG"
+
+      - name: Build + push clawdbot-gateway image
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          REPO=${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/clawdbot-gateway
+          docker build _external/clawdbot \
+            --build-arg OPENCLAW_EXTENSIONS=acpx \
+            --build-arg OPENCLAW_INSTALL_GH_CLI=1 \
+            -t "$REPO:$TAG"
+          docker push "$REPO:$TAG"
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ env.CLUSTER }}
+          location: ${{ env.REGION }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Materialize private values overlay (runner-only)
+        # DEV_HELM_VALUES_PRIVATE holds real GCP project ID / PG host / AR repos
+        # / ESO SA email. Kept out of the OSS repo per sensitive-data policy.
+        # Written to $RUNNER_TEMP, auto-cleaned when the runner teardowns.
+        run: |
+          printf '%s\n' "${DEV_HELM_VALUES_PRIVATE}" > "$RUNNER_TEMP/values-private.yaml"
+          echo "Wrote $(wc -l < "$RUNNER_TEMP/values-private.yaml") lines to $RUNNER_TEMP/values-private.yaml"
+        env:
+          DEV_HELM_VALUES_PRIVATE: ${{ secrets.DEV_HELM_VALUES_PRIVATE }}
+
+      - name: Helm upgrade commonly-dev
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          helm upgrade commonly-dev k8s/helm/commonly -n "$NAMESPACE" \
+            -f k8s/helm/commonly/values.yaml \
+            -f k8s/helm/commonly/values-dev.yaml \
+            -f "$RUNNER_TEMP/values-private.yaml" \
+            --set backend.image.tag="$TAG" \
+            --set frontend.image.tag="$TAG" \
+            --set agents.clawdbot.image.tag="$TAG" \
+            --wait \
+            --timeout 5m
+
+      - name: Report deploy outcome
+        if: always()
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          STATUS: ${{ job.status }}
+        run: |
+          HELM_REV=$(helm history commonly-dev -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.[-1].revision // "unknown"')
+          echo "::notice title=Dev deploy::status=$STATUS tag=$TAG helm_revision=$HELM_REV"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -25,7 +25,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  PROJECT_ID: commonly-493005
+  # PROJECT_ID read from DEV_GCP_PROJECT_ID secret (not committed per sensitive-data policy).
+  # Exported per-job via a setup step below.
   REGION: us-central1
   AR_REPO: docker
   CLUSTER: commonly-dev
@@ -52,6 +53,11 @@ jobs:
           else
             echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Export PROJECT_ID from secret
+        env:
+          DEV_GCP_PROJECT_ID: ${{ secrets.DEV_GCP_PROJECT_ID }}
+        run: echo "PROJECT_ID=${DEV_GCP_PROJECT_ID}" >> "$GITHUB_ENV"
 
       - name: Authenticate to GCP via WIF
         uses: google-github-actions/auth@v2


### PR DESCRIPTION
Second and final PR for ADR-009 Phase 3. Adds `.github/workflows/deploy-dev.yml` — the WIF-backed, cloud-agent-compatible dev deploy pipeline.

Phase 3a (the values-private.yaml migration) is replaced by a **runner-only overlay** approach per the sensitive-data policy: `values-dev.yaml` in the repo keeps `YOUR_*` placeholders, real values live in GitHub Actions secrets and are materialized into `$RUNNER_TEMP` at deploy time, never committed.

## Prereqs (all landed before this PR)

- WIF pool + provider (condition: `assertion.repository=='Team-Commonly/commonly'`, branch scope: `refs/heads/main`)
- `deploy-github` SA with scoped IAM (AR writer on `docker` repo, project-level `clusterViewer`) + K8s `ClusterRoleBinding` → `edit` on `commonly-dev` only
- Repo secrets: `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`, `DEV_HELM_VALUES_PRIVATE`, `DEV_GCP_PROJECT_ID`
- GitHub environment `dev` (no approvers)

## Pipeline shape

1. `actions/checkout@v4` with `submodules: recursive` (the gateway image builds from `_external/clawdbot/`, a submodule — omitting this was called out in the ADR as a step-1 foot-gun)
2. Compute tag = short SHA (or `workflow_dispatch` override)
3. Export `PROJECT_ID` from the `DEV_GCP_PROJECT_ID` secret into `GITHUB_ENV`
4. `google-github-actions/auth@v2` via WIF → `setup-gcloud@v2`
5. `docker build && docker push` for backend, frontend, clawdbot-gateway (one tag each)
6. `get-gke-credentials@v2` for `commonly-dev`
7. Materialize `DEV_HELM_VALUES_PRIVATE` → `$RUNNER_TEMP/values-private.yaml`
8. `helm upgrade` with three `-f` flags + `--set {backend,frontend,agents.clawdbot}.image.tag=$TAG --wait --timeout 5m`
9. `::notice` status report (tag + helm revision + outcome)

## Why workflow_dispatch only for this PR

Rolling out a deploy pipeline that can actually break dev deserves one manual verification run before we flip on `push: branches: [main]`. After a successful manual dispatch, a one-line follow-up PR adds the push trigger.

Phase 4 (Tier 3 smoke + auto-rollback) layers on top — without that safety net, push-on-merge is only fine once a manual run proves the pipeline.

## Rollback if manual run breaks dev

`helm history commonly-dev -n commonly-dev` + `helm rollback commonly-dev <revision>`. No auto-rollback in this phase — that's what Phase 4 adds.

## Sensitive-data check

Grepped the workflow file for `commonly-493005`, `commonly-psql`, `commonly-secrets-sa` → all clean. First-pass commit on this branch had `PROJECT_ID` hardcoded; caught it before CI and moved to `DEV_GCP_PROJECT_ID` repo secret. Squash-merge combines both commits into one clean commit on main.

## Test plan

- [ ] Chart Lint, Tier 0/1, kind smoke all pass on this PR (workflow file change triggers smoke per Phase 2 filter)
- [ ] After merge: run `Deploy Dev` manually via the Actions tab, verify all three image pushes succeed and helm upgrade completes
- [ ] Follow-up PR flips the trigger to auto-deploy-on-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)