### PR TITLE
ci(deploy): include commonly-bot build + tag in deploy-dev

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -100,6 +100,14 @@ jobs:
             -t "$REPO:$TAG"
           docker push "$REPO:$TAG"
 
+      - name: Build + push commonly-bot image
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          REPO=${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/commonly-bot
+          docker build external/commonly-agent-services -t "$REPO:$TAG"
+          docker push "$REPO:$TAG"
+
       - name: Get GKE credentials
         uses: google-github-actions/get-gke-credentials@v2
         with:
@@ -132,6 +140,7 @@ jobs:
             --set backend.image.tag="$TAG" \
             --set frontend.image.tag="$TAG" \
             --set agents.clawdbot.image.tag="$TAG" \
+            --set agents.commonlyBot.image.tag="$TAG" \
             --wait \
             --timeout 5m
 


### PR DESCRIPTION
## Summary
- Phase 3b's \`deploy-dev.yml\` originally built backend/frontend/clawdbot-gateway only
- Live dev had a 5-day-old \`commonly-bot\` ImagePullBackOff: \`values-dev.yaml\` declares \`tag: 20260411055334\` but no tagged \`commonly-bot\` images exist in AR at all (only untagged digests kept alive by the Running pod's node-local cache — any node reschedule would kill it)
- Adding \`commonly-bot\` to the pipeline rotates its image on every deploy, so the ImagePullBackOff clears on next run and dev returns to a fully-Ready state (which also unblocks \`--wait\` for the \`Deploy Dev\` workflow)

## Scope
- Single new build step: \`docker build external/commonly-agent-services -t … && docker push\`
- One extra \`--set agents.commonlyBot.image.tag=\$TAG\` on the helm upgrade

No other change to the workflow shape.

Orthogonal issue: \`litellm\` CrashLoopBackOff (7+ days, Codex OAuth device-code prompt) tracked separately — needs an interactive re-auth Claude can't perform.

## Test plan
- [ ] Chart Lint, Tier 0/1, kind smoke all pass on this PR (workflow file change triggers smoke)
- [ ] After merge: re-run \`Deploy Dev\` → commonly-bot lands on the new tag, old zombie pod terminates

🤖 Generated with [Claude Code](https://claude.com/claude-code)