### PR TITLE
deploy(dev): bump LiteLLM v1.82.3 → v1.83.7-stable

### DIFF
--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -191,6 +191,13 @@ cloudflared:
 
 litellm:
   enabled: true
+  # Pinned override on top of values.yaml's v1.82.3-stable default. Testing
+  # whether v1.83.7-stable resolves the chatgpt/gpt-5.4 device-code-on-startup
+  # crashloop (distinct from but likely related to BerriAI/litellm#25429, which
+  # is still open upstream as of 2026-04-21). Roll back here if it regresses.
+  image:
+    repository: ghcr.io/berriai/litellm
+    tag: v1.83.7-stable
   # BerriAI/litellm#25429 workaround: route Codex direct to chatgpt.com
   # via OpenClaw's native handler. Flip to false when upstream fix lands.
   codexBypassLitellm: true


### PR DESCRIPTION
## Summary
- LiteLLM on \`commonly-dev\` has been crashlooping for 7+ days (\`73\` restarts): main container starts, prints model config summary, then triggers a ChatGPT device-code OAuth prompt **despite the init container having already written a valid \`auth.json\`**, hangs on interactive input, gets SIGKILL'd by the liveness probe
- \`BerriAI/litellm#25429\` (chatgpt/gpt-5.4 empty Responses output + completion-bridge failures) is still open upstream, last updated today. The device-code-at-startup behavior is distinct from but likely related
- Three stable releases between \`v1.82.3-stable\` and \`v1.83.7-stable\` may not fix the core issue but are cheap to try; the existing idempotent monkey-patch in \`litellm-deployment.yaml\` already gracefully handles the \"already fixed upstream\" case

## Scope
- Override \`litellm.image.tag\` in \`values-dev.yaml\` (dev only; \`values.yaml\` keeps \`v1.82.3-stable\` as the base/OSS default)
- Zero chart structural change

## Verification plan (after merge + deploy)
Per [\`docs/development/LITELLM.md\`](../blob/main/docs/development/LITELLM.md):

1. **Pod reaches Ready** — \`kubectl get pods -n commonly-dev -l app=litellm\` shows \`1/1\` with the new tag
2. **End-to-end Codex routing through LiteLLM** — \`kubectl exec\` into backend, POST to \`http://litellm:4000/chat/completions\` with \`model: openai-codex/gpt-5.4\` using \`LITELLM_MASTER_KEY\`, expect 200 with non-empty content
3. **Sub-acpx session from agent** — trigger a heartbeat / acpx_run on a dev agent (e.g. \`nova\`) and verify the call lands in LiteLLM spend logs with status 200
4. **Only after 1–3 pass**: follow-up PR considers flipping \`codexBypassLitellm: false\` and re-enabling \`codexAuthRotator\` — the bypass was put in place for #25429, re-enabling requires confirming the bug is actually fixed, not just worked-around at startup

## Rollback
One-line revert on \`values-dev.yaml\` → re-deploy. Chart structure unchanged.

## Test plan
- [ ] Chart Lint passes on the new tag (helm template + kubeconform)
- [ ] Tier 0/1 green
- [ ] kind smoke passes (PR touches \`k8s/**\` → Phase 2 filter triggers)
- [ ] Manual verification 1–3 above after merge + \`Deploy Dev\` workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)