### PR TITLE
fix(marketplace-api): close dual-write drift gaps from PR #215 review

### DIFF
--- a/backend/__tests__/unit/routes/marketplace-api.dual-write.test.js
+++ b/backend/__tests__/unit/routes/marketplace-api.dual-write.test.js
@@ -1,0 +1,161 @@
+// Dual-write drift-warning paths in backend/routes/marketplace-api.ts.
+// Covers the two review-comment fixes from PR #215: update path
+// (existing.save failure after AR succeeded) and fork path
+// (Installable.create failure after AR succeeded).
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => next());
+
+jest.mock('../../../models/User', () => ({}));
+
+jest.mock('../../../models/Installable', () => ({
+  findOne: jest.fn(),
+  create: jest.fn(),
+  updateOne: jest.fn(),
+  deleteOne: jest.fn(),
+  countDocuments: jest.fn(),
+  find: jest.fn(),
+}));
+
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentRegistry: {
+    findOneAndUpdate: jest.fn(),
+    deleteOne: jest.fn(),
+    updateOne: jest.fn(),
+  },
+  AgentInstallation: {
+    countDocuments: jest.fn(),
+  },
+}));
+
+const Installable = require('../../../models/Installable');
+const { AgentRegistry } = require('../../../models/AgentRegistry');
+const router = require('../../../routes/marketplace-api');
+
+const getRouteHandler = (path, method) => {
+  const layer = router.stack.find((entry) => (
+    entry.route
+    && entry.route.path === path
+    && entry.route.methods[method]
+  ));
+  if (!layer) throw new Error(`Route not found: ${method.toUpperCase()} ${path}`);
+  return layer.route.stack[layer.route.stack.length - 1].handle;
+};
+
+describe('marketplace-api dual-write drift warnings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('update path: returns drift warning when AR sync succeeds but Installable.save throws', async () => {
+    const handler = getRouteHandler('/publish', 'post');
+
+    // Existing manifest owned by the requesting user. save() rejects to
+    // simulate a transient mongo error after AR sync has already committed.
+    const saveError = new Error('duplicate key on versions.version index');
+    const existing = {
+      installableId: '@nova/my-agent',
+      publisher: { userId: 'user-1' },
+      status: 'active',
+      versions: [{ version: '1.0.0' }],
+      components: [],
+      save: jest.fn().mockRejectedValue(saveError),
+    };
+
+    Installable.findOne.mockResolvedValue(existing);
+    AgentRegistry.findOneAndUpdate.mockResolvedValue({ agentName: '@nova/my-agent' });
+
+    const req = {
+      userId: 'user-1',
+      user: { id: 'user-1', username: 'nova' },
+      body: {
+        installableId: '@nova/my-agent',
+        name: 'My Agent',
+        version: '2.0.0',
+        kind: 'agent',
+        scope: 'pod',
+      },
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await handler(req, res);
+
+    // AR sync fired, save was attempted
+    expect(AgentRegistry.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    expect(existing.save).toHaveBeenCalledTimes(1);
+
+    // Drift warning path: 201 with an explicit warnings array so the client
+    // doesn't assume full success when the catalog is behind the registry.
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      success: true,
+      warnings: expect.arrayContaining([
+        expect.stringMatching(/Installable catalog write failed/i),
+      ]),
+      manifest: expect.objectContaining({
+        installableId: '@nova/my-agent',
+        version: '2.0.0',
+        isNew: false,
+      }),
+    }));
+  });
+
+  it('fork path: returns drift warning and skips forkCount bump when Installable.create throws', async () => {
+    const handler = getRouteHandler('/fork', 'post');
+
+    const source = {
+      installableId: '@alice/legal-agent',
+      name: 'Legal Agent',
+      description: 'Finds case law',
+      version: '1.2.0',
+      kind: 'agent',
+      scope: 'user',
+      requires: ['chat:write'],
+      components: [],
+      marketplace: { category: 'professional', tags: ['legal'] },
+      status: 'active',
+    };
+
+    // First Installable.findOne: source lookup → returns the source.
+    // Second: existence check on newInstallableId → returns null (no collision).
+    Installable.findOne
+      .mockResolvedValueOnce(source)
+      .mockResolvedValueOnce(null);
+    AgentRegistry.findOneAndUpdate.mockResolvedValue({ agentName: '@nova/legal-fork' });
+    const createError = new Error('E11000 duplicate key on installableId');
+    Installable.create.mockRejectedValue(createError);
+
+    const req = {
+      userId: 'user-1',
+      user: { id: 'user-1', username: 'nova' },
+      body: {
+        sourceInstallableId: '@alice/legal-agent',
+        newInstallableId: '@nova/legal-fork',
+      },
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await handler(req, res);
+
+    expect(AgentRegistry.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    expect(Installable.create).toHaveBeenCalledTimes(1);
+
+    // forkCount bump must be skipped — otherwise a retry would double-count.
+    expect(Installable.updateOne).not.toHaveBeenCalled();
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      success: true,
+      warnings: expect.arrayContaining([
+        expect.stringMatching(/fork is registered but not yet browsable/i),
+      ]),
+      manifest: expect.objectContaining({
+        installableId: '@nova/legal-fork',
+        version: '1.0.0',
+        forkedFrom: expect.objectContaining({
+          installableId: '@alice/legal-agent',
+          version: '1.2.0',
+        }),
+      }),
+    }));
+  });
+});

--- a/backend/routes/marketplace-api.ts
+++ b/backend/routes/marketplace-api.ts
@@ -35,6 +35,7 @@ const RUNTIME_MAP: Record<string, string> = {
   'claude-code': 'standalone',
   moltbot: 'standalone',
   remote: 'standalone',
+  'local-cli': 'standalone', // ADR-005 local CLI wrapper driver
 };
 
 const syncToAgentRegistry = async (installable: any, action: 'publish' | 'unpublish' | 'delete' | 'deprecate') => {
@@ -201,7 +202,29 @@ router.post('/publish', auth, async (req: any, res: any) => {
         });
       }
 
-      await existing.save();
+      try {
+        await existing.save();
+      } catch (saveError) {
+        // AR succeeded but Installable save failed. Mirror the new-manifest
+        // drift-warning path so the caller knows to retry rather than
+        // assuming publish fully succeeded.
+        console.warn(
+          '[marketplace] Installable save failed on update (AR succeeded):',
+          (saveError as any).message,
+        );
+        return res.status(201).json({
+          success: true,
+          warnings: [
+            'Installable catalog write failed; manifest is installable but not yet browsable. Retry publish to sync.',
+          ],
+          manifest: {
+            installableId: existing.installableId,
+            version,
+            status: existing.status,
+            isNew: false,
+          },
+        });
+      }
 
       return res.json({
         success: true,
@@ -340,7 +363,10 @@ router.delete('/manifests/:installableId(*)', auth, async (req: any, res: any) =
       });
     }
 
-    // Delete AR first, then Installable
+    // ADR-001 invariant #5: Agent User rows, memory, and pod memberships
+    // are intentionally NOT cascade-deleted here — identity outlives the
+    // manifest. Uninstall-time teardown runs via the AgentInstallation
+    // lifecycle elsewhere. Do not add a User / memory cascade to this path.
     try { await AgentRegistry.deleteOne({ agentName: installableId.toLowerCase() }); } catch (e) {
       console.warn('[marketplace] AR delete failed:', (e as any).message);
     }
@@ -423,7 +449,30 @@ router.post('/fork', auth, async (req: any, res: any) => {
       return res.status(500).json({ error: 'Failed to fork manifest' });
     }
 
-    const created = await Installable.create(forkDoc);
+    let created;
+    try {
+      created = await Installable.create(forkDoc);
+    } catch (installableError) {
+      // AR succeeded but the Installable row didn't land. Mirror the publish
+      // path: return 201 with a drift warning so the caller knows to retry.
+      // Skip the source forkCount increment — we'll bump it on the retry
+      // that actually creates the Installable row.
+      console.warn(
+        '[marketplace] Installable create failed on fork (AR succeeded):',
+        (installableError as any).message,
+      );
+      return res.status(201).json({
+        success: true,
+        warnings: [
+          'Installable catalog write failed; fork is registered but not yet browsable. Retry fork to sync.',
+        ],
+        manifest: {
+          installableId: forkDoc.installableId,
+          version: '1.0.0',
+          forkedFrom: forkDoc.forkedFrom,
+        },
+      });
+    }
 
     // Increment fork count on source (atomic)
     await Installable.updateOne(


### PR DESCRIPTION
## Summary

Follow-up to PR #215 addressing the 4 review comments that landed after merge. All changes are localized to `backend/routes/marketplace-api.ts`; the 5th review comment (ESM harmonization) was retracted — every `.ts` route in `backend/routes/` uses the same CJS-in-TS pattern, so `marketplace-api.ts` is already conforming.

### Fixes

| # | Path | Severity | Fix |
|---|------|----------|-----|
| 1 | `POST /publish` (update) | P1 | Wrap `existing.save()` in try/catch so an AR-succeeds + save-fails race returns 201 + drift warning instead of a generic 500 that hides the partial commit |
| 2 | `POST /fork` | P1 | Wrap `Installable.create(forkDoc)` the same way; skip source `stats.forkCount` bump on failure so a retry doesn't double-count |
| 3 | `DELETE /manifests/:id` | P2 | Add ADR-001 invariant #5 comment so a future refactor doesn't "helpfully" cascade-delete User rows / memory |
| 4 | `RUNTIME_MAP` | P2 | Add explicit `'local-cli': 'standalone'` entry for ADR-005 (was falling through the `\|\| 'standalone'` default silently) |

### Review comments addressed

- https://github.com/Team-Commonly/commonly/pull/215#discussion_r... (line 204 — update-path save)
- https://github.com/Team-Commonly/commonly/pull/215#discussion_r... (line 426 — fork-path create)
- https://github.com/Team-Commonly/commonly/pull/215#discussion_r... (line 347 — identity-continuity comment)
- https://github.com/Team-Commonly/commonly/pull/215#discussion_r... (line 37 — RUNTIME_MAP local-cli)

### Tests

New: `backend/__tests__/unit/routes/marketplace-api.dual-write.test.js`
- update path: AR sync succeeds, `existing.save()` throws → 201 + warnings + `isNew: false`
- fork path: AR sync succeeds, `Installable.create` throws → 201 + warnings + `forkedFrom` preserved + `forkCount` bump skipped

Full run:
```
__tests__/unit/routes/marketplace-api.dual-write.test.js     2/2 ✓
__tests__/unit/routes/marketplace.official.test.js           1/1 ✓
__tests__/unit/routes/registry.publish.test.js               2/2 ✓
__tests__/unit/models/installable.test.ts                  11/11 ✓
```

### Scope notes

- Happy paths are unchanged — diff only adds error branches + a comment + a map entry.
- No schema changes, no migration, no API surface change.
- Does not touch the legacy `/api/marketplace/official` router or the `/api/registry/*` install routes.

## Test plan

- [x] `npx jest __tests__/unit/routes/marketplace-api.dual-write.test.js` — 2/2 pass
- [x] `npx jest __tests__/unit/routes/marketplace.official.test.js __tests__/unit/routes/registry.publish.test.js __tests__/unit/models/installable.test.ts` — 14/14 pass, no regression
- [x] `npm run lint` on changed file — no new errors
- [ ] Manual smoke on dev after merge: publish v2 of an existing manifest, fork an active manifest, confirm 201 responses match shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)