### PR TITLE
Track Claude skills source symlink

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../../commonly-skills

--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,10 @@ external/commonly-bot-state/
 _external/*/
 !_external/clawdbot
 
-# Claude Code — local dev tooling, not for OSS contributors
-.claude/
+# Claude Code — local dev tooling, not for OSS contributors.
+# Keep the shared skills symlink tracked so .agents/skills can point at it.
+.claude/*
+!.claude/skills
 
 # Local-only dev materials: values-private.yaml (Helm overrides with real
 # GCP project ID / PG host / image repos) and git worktrees under .dev/worktree/.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,7 @@ npm run lint                                  # 0 errors
 2. **Backend issues**: Check `backend/TESTING.md` — likely static method calls
 
 ### Local Skill Paths
-- `.claude/skills` is the source path for local development skills.
+- `.claude/skills` is the tracked source-path symlink for local development skills.
 - `.agents/skills` is the OpenAI/Codex agent-facing symlink and should point to `../.claude/skills`.
 - Do not recreate `.codex/skills`; it was replaced by `.agents/skills`.
 


### PR DESCRIPTION
## Summary
- Track `.claude/skills -> ../../commonly-skills` so the `.agents/skills` symlink from #233 resolves in fresh checkouts that have the sibling skills repo
- Keep other `.claude` local state ignored
- Clarify that `.claude/skills` is the tracked source-path symlink

## Verification
- `git diff --check origin/main...HEAD`
- `realpath .agents/skills/backend-dev/SKILL.md`
- `find -L .agents/skills -maxdepth 2 -name SKILL.md | wc -l` returned `26`