### PR TITLE
fix(agent-room): rewrite migration to RESTORE 1:1 DMs, not relabel as chat

### DIFF
--- a/backend/__tests__/unit/scripts/migrate-agent-room-multimember.test.js
+++ b/backend/__tests__/unit/scripts/migrate-agent-room-multimember.test.js
@@ -77,8 +77,12 @@ describe('migrateAgentRoomMultimember', () => {
 
     const r = await migrateAgentRoomMultimember();
     expect(r.plans[0].action).toBe('restore-1to1-agent-agent');
+    // Order matters here: the first kept ID must be the host (memberIds[0])
+    // and the second the original counter-party (memberIds[1]). The script's
+    // implementation hands these to a Set then expands — Set iteration is
+    // insertion-ordered in V8 — so the surface order is stable.
     expect(r.plans[0].keepIds).toEqual(['agent-host', 'agent-other']);
-    expect(r.plans[0].dropIds).toEqual(['rogue-a', 'rogue-b']);
+    expect(r.plans[0].dropIds).toEqual(expect.arrayContaining(['rogue-a', 'rogue-b']));
     expect(pod.members).toEqual(['agent-host', 'agent-other']);
     expect(pod.type).toBe('agent-room');
   });
@@ -130,5 +134,34 @@ describe('migrateAgentRoomMultimember', () => {
     const r = await migrateAgentRoomMultimember();
     expect(r.total).toBe(0);
     expect(r.applied).toBe(0);
+  });
+
+  test('createdBy not in members → skip with a warning, do not write a ghost ID', async () => {
+    // Edge case: a pod where `pod.createdBy` (the supposed host agent) is
+    // NOT in `pod.members`. Could only happen via data corruption or a
+    // bulk-import that bypassed the create hook. The human-branch code
+    // computes `keepIds = [hostId, the_human]` from createdBy + the_human;
+    // without a guard it would silently produce a 2-member pod where
+    // hostId is a ghost — no AgentInstallation, no User session would match.
+    const pod = fakePod({
+      _id: 'p-ghost',
+      createdBy: 'ghost-host-id', // not in members
+      members: ['someone-else-agent', 'human-id', 'rogue-1'],
+    });
+    Pod.find.mockReturnValue({ cursor: () => cursorOf([pod]) });
+    User.find.mockReturnValue(userLeanFor([
+      { _id: 'someone-else-agent', isBot: true },
+      { _id: 'human-id', isBot: false },
+      { _id: 'rogue-1', isBot: true },
+    ]));
+
+    const r = await migrateAgentRoomMultimember();
+    expect(r.total).toBe(1);
+    expect(r.applied).toBe(0);
+    expect(r.skipped).toBe(1);
+    // Pod must remain untouched — operator triages manually.
+    expect(pod.members).toEqual(['someone-else-agent', 'human-id', 'rogue-1']);
+    expect(pod.type).toBe('agent-room');
+    expect(pod.save).not.toHaveBeenCalled();
   });
 });

--- a/backend/__tests__/unit/scripts/migrate-agent-room-multimember.test.js
+++ b/backend/__tests__/unit/scripts/migrate-agent-room-multimember.test.js
@@ -1,0 +1,134 @@
+// Unit-test the planner branches in migrate-agent-room-multimember.ts.
+// We mock Pod + User so the test runs without a real Mongo connection.
+
+jest.mock('../../../models/Pod', () => ({ find: jest.fn() }));
+jest.mock('../../../models/User', () => ({ find: jest.fn() }));
+
+const Pod = require('../../../models/Pod');
+const User = require('../../../models/User');
+const { migrateAgentRoomMultimember } = require('../../../scripts/migrate-agent-room-multimember');
+
+// Build a fake Pod doc that responds to .save() and exposes mutable fields.
+const fakePod = ({ _id, type = 'agent-room', name = 'pod', createdBy, members }) => {
+  const doc = {
+    _id, type, name, createdBy, members,
+    save: jest.fn().mockResolvedValue(undefined),
+  };
+  return doc;
+};
+
+// Mock Mongoose's `.cursor()` chain — return a thenable async iterator.
+const cursorOf = (docs) => ({
+  async *[Symbol.asyncIterator]() { for (const d of docs) yield d; },
+});
+
+const userLeanFor = (records) => ({
+  select: jest.fn().mockReturnValue({
+    lean: jest.fn().mockResolvedValue(records),
+  }),
+});
+
+describe('migrateAgentRoomMultimember', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('1 host agent + 1 human + N rogue agents → restore [host, human], stay agent-room', async () => {
+    const pod = fakePod({
+      _id: 'p1',
+      createdBy: 'host-agent-id',
+      members: ['host-agent-id', 'human-id', 'rogue-1', 'rogue-2', 'rogue-3'],
+    });
+    Pod.find.mockReturnValue({ cursor: () => cursorOf([pod]) });
+    User.find.mockReturnValue(userLeanFor([
+      { _id: 'host-agent-id', isBot: true },
+      { _id: 'human-id', isBot: false },
+      { _id: 'rogue-1', isBot: true },
+      { _id: 'rogue-2', isBot: true },
+      { _id: 'rogue-3', isBot: true },
+    ]));
+
+    const r = await migrateAgentRoomMultimember();
+    expect(r.total).toBe(1);
+    expect(r.applied).toBe(1);
+    expect(r.plans[0]).toEqual(expect.objectContaining({
+      action: 'restore-1to1-human-agent',
+      before: 5,
+      after: 2,
+      keepIds: expect.arrayContaining(['host-agent-id', 'human-id']),
+      dropIds: expect.arrayContaining(['rogue-1', 'rogue-2', 'rogue-3']),
+    }));
+    expect(pod.members).toEqual(['host-agent-id', 'human-id']);
+    expect(pod.type).toBe('agent-room');
+    expect(pod.save).toHaveBeenCalled();
+  });
+
+  test('0 humans → agent↔agent DM, keep [members[0], members[1]] by insertion order', async () => {
+    const pod = fakePod({
+      _id: 'p2',
+      createdBy: 'agent-host',
+      members: ['agent-host', 'agent-other', 'rogue-a', 'rogue-b'],
+    });
+    Pod.find.mockReturnValue({ cursor: () => cursorOf([pod]) });
+    User.find.mockReturnValue(userLeanFor([
+      { _id: 'agent-host', isBot: true },
+      { _id: 'agent-other', isBot: true },
+      { _id: 'rogue-a', isBot: true },
+      { _id: 'rogue-b', isBot: true },
+    ]));
+
+    const r = await migrateAgentRoomMultimember();
+    expect(r.plans[0].action).toBe('restore-1to1-agent-agent');
+    expect(r.plans[0].keepIds).toEqual(['agent-host', 'agent-other']);
+    expect(r.plans[0].dropIds).toEqual(['rogue-a', 'rogue-b']);
+    expect(pod.members).toEqual(['agent-host', 'agent-other']);
+    expect(pod.type).toBe('agent-room');
+  });
+
+  test('2+ humans → was never a DM, convert to chat, members preserved', async () => {
+    const pod = fakePod({
+      _id: 'p3',
+      createdBy: 'agent-host',
+      members: ['agent-host', 'human-a', 'human-b', 'human-c'],
+    });
+    Pod.find.mockReturnValue({ cursor: () => cursorOf([pod]) });
+    User.find.mockReturnValue(userLeanFor([
+      { _id: 'agent-host', isBot: true },
+      { _id: 'human-a', isBot: false },
+      { _id: 'human-b', isBot: false },
+      { _id: 'human-c', isBot: false },
+    ]));
+
+    const r = await migrateAgentRoomMultimember();
+    expect(r.plans[0].action).toBe('convert-to-chat');
+    expect(pod.type).toBe('chat');
+    expect(pod.members).toEqual(['agent-host', 'human-a', 'human-b', 'human-c']);
+  });
+
+  test('--dry mode reports a plan but does not save', async () => {
+    const pod = fakePod({
+      _id: 'p4',
+      createdBy: 'host-agent-id',
+      members: ['host-agent-id', 'human-id', 'rogue-1'],
+    });
+    Pod.find.mockReturnValue({ cursor: () => cursorOf([pod]) });
+    User.find.mockReturnValue(userLeanFor([
+      { _id: 'host-agent-id', isBot: true },
+      { _id: 'human-id', isBot: false },
+      { _id: 'rogue-1', isBot: true },
+    ]));
+
+    const r = await migrateAgentRoomMultimember({ dryRun: true });
+    expect(r.skipped).toBe(1);
+    expect(r.applied).toBe(0);
+    expect(pod.save).not.toHaveBeenCalled();
+    expect(pod.members).toEqual(['host-agent-id', 'human-id', 'rogue-1']); // unchanged
+  });
+
+  test('idempotent — pods with members.length <= 2 are not even returned by the cursor query', async () => {
+    // The Mongo $expr filter excludes 2-member pods; the cursor sees only
+    // offenders. A clean DB after a prior run yields zero docs and zero work.
+    Pod.find.mockReturnValue({ cursor: () => cursorOf([]) });
+    const r = await migrateAgentRoomMultimember();
+    expect(r.total).toBe(0);
+    expect(r.applied).toBe(0);
+  });
+});

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -513,11 +513,17 @@ router.post('/dm', auth, async (req: any, res: any) => {
 });
 
 /**
- * POST /room — Find or create an agent room (many humans × one agent).
+ * POST /room — Find or create an agent-room (1:1 DM) per ADR-001 §3.10.
  *
- * Agent rooms are the primary human↔agent consultation surface — durable pods
- * where the agent is the host and the requesting user is the first member.
- * Other humans can be invited later.
+ * Agent rooms are personal 1:1 DMs whose two members can be (human + agent)
+ * or (agent + agent), never three. The earlier "many humans × one agent
+ * office" framing was rejected during product review; the join/auto-install
+ * paths in podController/agentIdentityService now enforce strict 1:1.
+ *
+ * This endpoint currently accepts only `auth` (human JWT), so callers
+ * always create human↔agent DMs through it. Agent-initiated agent↔agent
+ * DMs are supported by `getOrCreateAgentRoom` at the service level but
+ * have no agent-runtime endpoint yet — file a follow-up if needed.
  *
  * Request: { agentName, instanceId?, podId? }
  * Response: { room: Pod }

--- a/backend/scripts/migrate-agent-room-multimember.ts
+++ b/backend/scripts/migrate-agent-room-multimember.ts
@@ -1,28 +1,35 @@
 #!/usr/bin/env node
 /*
- * Find every Pod with `type: 'agent-room'` that has more than 2 members and
- * convert it to `type: 'chat'`. Agent rooms are strictly 1:1 per ADR-001
- * §3.10; pods with 3+ members were never DMs in the corrected model and
- * belong under the regular chat surface. Conversion preserves all messages,
- * members, and createdBy — only the type field changes.
+ * Restore the 1:1 invariant on agent-room pods that have accumulated more
+ * than two members. Per ADR-001 §3.10 an agent-room is a 1:1 DM whose two
+ * members can be (human + agent) OR (agent + agent), and a third party of
+ * either kind is never allowed. Live data on dev showed pods of the shape
+ * "1 human + N rogue agents that auto-joined via ensureAgentInPod" — the
+ * exact bug the runtime guards in PR #232 close going forward. This script
+ * cleans up the historical artifacts.
  *
- * Idempotent: a second run after the migration finds zero offenders. Run
- * with `--dry` to print the offenders without writing. Partially-applied
- * runs are safe to re-run — the script picks up where it left off.
+ * Strategy is restoration, not relabeling. The pods were created as DMs
+ * and got polluted; we want to undo the pollution, not promote them to
+ * `chat` and legitimize it.
  *
- * Downstream consequences operators should be aware of before running:
- *   - UI: migrated pods move from the "Agent DMs" tab to the regular chats
- *     surface. Users with a stale URL bookmarked under /pods/agent-room/<id>
- *     may need to refresh.
- *   - Privacy filter: `agent-room` pods are membership-filtered in
- *     getAllPods/getPodsByType; `chat` pods are not. After conversion the
- *     pod becomes visible to non-members of the same type filter (i.e.,
- *     it now behaves like any other chat pod the user is a member of).
- *   - Auto-join: `agentAutoJoinService` scans pods by `createdBy` without
- *     a type filter. Migrated pods retain their `createdBy: <agent>` field
- *     and become candidates for the agent-owned-pod auto-join scan. If
- *     `autoJoinAgentOwnedPods` is set anywhere, audit the resulting
- *     candidate list before running on prod.
+ *   For each agent-room with members.length > 2:
+ *     humans = members where User.isBot === false
+ *     case humans.length === 1:
+ *       keep = [pod.createdBy (host agent), the_human]
+ *       drop = every other member (rogue agents)
+ *       type stays 'agent-room'
+ *     case humans.length === 0:
+ *       agent↔agent DM. Trust array insertion order — pod was created with
+ *       members: [creatorAgent, otherAgent]; later auto-joins appended.
+ *       keep = [pod.members[0], pod.members[1]]
+ *       drop = every other member
+ *       type stays 'agent-room'
+ *     case humans.length >= 2:
+ *       Was never a DM — multi-human surfaces are chat pods, not DMs.
+ *       type → 'chat'. All members preserved.
+ *
+ * Idempotent: a second run finds zero offenders. Run with `--dry` to print
+ * the action plan without writing.
  *
  * Usage:
  *   ts-node backend/scripts/migrate-agent-room-multimember.ts          # apply
@@ -31,22 +38,35 @@
 
 import mongoose from 'mongoose';
 import Pod from '../models/Pod';
+import User from '../models/User';
+
+type Action = 'restore-1to1-human-agent' | 'restore-1to1-agent-agent' | 'convert-to-chat';
+
+interface Plan {
+  podId: string;
+  name: string;
+  action: Action;
+  before: number;
+  after: number;
+  keepIds: string[];
+  dropIds: string[];
+}
 
 interface MigrationResult {
   total: number;
-  converted: number;
+  applied: number;
   skipped: number;
-  offenders: Array<{ id: string; name: string; memberCount: number }>;
+  plans: Plan[];
 }
+
+const idStr = (v: any): string => String(v?._id || v);
 
 export async function migrateAgentRoomMultimember(
   options: { dryRun?: boolean } = {},
 ): Promise<MigrationResult> {
   const dryRun = options.dryRun === true;
-  const result: MigrationResult = { total: 0, converted: 0, skipped: 0, offenders: [] };
+  const result: MigrationResult = { total: 0, applied: 0, skipped: 0, plans: [] };
 
-  // Pods of type agent-room with members.length > 2. Use $expr so the
-  // size check happens server-side rather than streaming everything back.
   const cursor = Pod.find({
     type: 'agent-room',
     $expr: { $gt: [{ $size: '$members' }, 2] },
@@ -54,21 +74,67 @@ export async function migrateAgentRoomMultimember(
 
   for await (const pod of cursor) {
     result.total += 1;
-    const memberCount = Array.isArray(pod.members) ? pod.members.length : 0;
-    result.offenders.push({
-      id: pod._id.toString(),
+    const memberIds: string[] = (pod.members || []).map(idStr);
+
+    // Resolve isBot for every member in one round-trip — avoids N+1 lookups.
+    const users = await User.find({ _id: { $in: memberIds } })
+      .select('_id isBot username')
+      .lean();
+    const isBotById = new Map<string, boolean>();
+    for (const u of users) {
+      isBotById.set(String(u._id), Boolean((u as any).isBot));
+    }
+
+    const humans = memberIds.filter((id) => isBotById.get(id) === false);
+    const hostId = idStr(pod.createdBy);
+
+    let action: Action;
+    let keepIds: string[];
+    if (humans.length === 1) {
+      action = 'restore-1to1-human-agent';
+      keepIds = [hostId, humans[0]];
+    } else if (humans.length === 0) {
+      // Agent↔agent DM. Insertion-order is reliable: getOrCreateAgentRoom
+      // creates pods with `members: [hostAgent, otherParty]`, and Mongoose
+      // arrays preserve insertion order. Anything beyond index 1 is a rogue.
+      action = 'restore-1to1-agent-agent';
+      keepIds = [memberIds[0], memberIds[1]];
+    } else {
+      // Multi-human — was never a DM. Promote to a regular chat pod and
+      // keep all members; the privacy filter no longer applies.
+      action = 'convert-to-chat';
+      keepIds = memberIds;
+    }
+
+    // De-dupe keepIds in case createdBy already coincides with members[0],
+    // which is the normal case.
+    const keepSet = new Set(keepIds);
+    const dropIds = memberIds.filter((id) => !keepSet.has(id));
+
+    const plan: Plan = {
+      podId: String(pod._id),
       name: pod.name || '(unnamed)',
-      memberCount,
-    });
+      action,
+      before: memberIds.length,
+      after: keepSet.size,
+      keepIds: [...keepSet],
+      dropIds,
+    };
+    result.plans.push(plan);
 
     if (dryRun) {
       result.skipped += 1;
       continue;
     }
 
-    pod.type = 'chat';
+    if (action === 'convert-to-chat') {
+      pod.type = 'chat';
+      // Members unchanged.
+    } else {
+      pod.members = [...keepSet] as any;
+    }
     await pod.save();
-    result.converted += 1;
+    result.applied += 1;
   }
 
   return result;
@@ -87,12 +153,17 @@ async function main(): Promise<void> {
     const r = await migrateAgentRoomMultimember({ dryRun });
     console.log(`[migrate-agent-room] ${dryRun ? 'DRY-RUN' : 'APPLIED'}`);
     console.log(`  total offenders : ${r.total}`);
-    console.log(`  converted       : ${r.converted}`);
+    console.log(`  applied         : ${r.applied}`);
     console.log(`  skipped (dry)   : ${r.skipped}`);
-    if (r.offenders.length > 0) {
-      console.log('  pods:');
-      for (const o of r.offenders) {
-        console.log(`    - ${o.id}  (${o.memberCount} members)  "${o.name}"`);
+    if (r.plans.length > 0) {
+      console.log('  per-pod plan:');
+      for (const p of r.plans) {
+        console.log(
+          `    - ${p.podId}  "${p.name}"  ${p.action}  members ${p.before} → ${p.after}`,
+        );
+        if (p.dropIds.length > 0) {
+          console.log(`        drop: ${p.dropIds.join(', ')}`);
+        }
       }
     }
   } finally {

--- a/backend/scripts/migrate-agent-room-multimember.ts
+++ b/backend/scripts/migrate-agent-room-multimember.ts
@@ -85,6 +85,13 @@ export async function migrateAgentRoomMultimember(
       isBotById.set(String(u._id), Boolean((u as any).isBot));
     }
 
+    // Orphan handling: a member ID with no corresponding User row returns
+    // `undefined` from isBotById.get(). Such orphans are NOT counted as
+    // humans (the `=== false` check excludes them); they fall through to
+    // dropIds in the human↔agent branch and may end up in keepIds at
+    // index 0/1 in the agent↔agent branch (we treat them as inert and
+    // preserve them so an operator can triage). Either way the migration
+    // never silently elevates an orphan to "the human" of a DM.
     const humans = memberIds.filter((id) => isBotById.get(id) === false);
     const hostId = idStr(pod.createdBy);
 
@@ -94,9 +101,15 @@ export async function migrateAgentRoomMultimember(
       action = 'restore-1to1-human-agent';
       keepIds = [hostId, humans[0]];
     } else if (humans.length === 0) {
-      // Agent↔agent DM. Insertion-order is reliable: getOrCreateAgentRoom
-      // creates pods with `members: [hostAgent, otherParty]`, and Mongoose
-      // arrays preserve insertion order. Anything beyond index 1 is a rogue.
+      // Agent↔agent DM. Insertion-order is reliable because:
+      //   1. dmService.getOrCreateAgentRoom creates pods with
+      //      `members: [hostAgent, otherParty]`.
+      //   2. Mongoose `.push()` (the only mutation path used by
+      //      ensureAgentInPod / joinPod) appends to the end.
+      //   3. No code path uses `$set: { members: [...] }` to reorder
+      //      (verified via repo-wide grep at PR-time).
+      // So memberIds[0] is always the host agent and memberIds[1] is
+      // always the original counter-party. Anything beyond is a rogue.
       action = 'restore-1to1-agent-agent';
       keepIds = [memberIds[0], memberIds[1]];
     } else {
@@ -106,8 +119,24 @@ export async function migrateAgentRoomMultimember(
       keepIds = memberIds;
     }
 
-    // De-dupe keepIds in case createdBy already coincides with members[0],
-    // which is the normal case.
+    // Defensive: if the human↔agent branch picked a `hostId` that isn't
+    // actually in `pod.members` (data corruption — a `createdBy` that
+    // points outside the membership), skip the pod rather than silently
+    // ghosting a 2-member pod with an ID nobody can post as. Logged so
+    // an operator can investigate. Detected via the keep-set check rather
+    // than upstream because the agent↔agent branch trusts memberIds[0]
+    // and memberIds[1] which by construction are real members.
+    const skipIfGhost = action === 'restore-1to1-human-agent'
+      && !memberIds.includes(hostId);
+    if (skipIfGhost) {
+      console.warn(
+        `[migrate-agent-room] SKIP pod ${pod._id}: createdBy=${hostId} is not in members `
+        + `[${memberIds.join(', ')}]. Manual triage required.`,
+      );
+      result.skipped += 1;
+      continue;
+    }
+
     const keepSet = new Set(keepIds);
     const dropIds = memberIds.filter((id) => !keepSet.has(id));
 


### PR DESCRIPTION
## Summary

Follow-up to #232. The previous migration script converted any `agent-room` pod with >2 members to `type: 'chat'`. Inspecting the actual offenders on `api-dev` showed every multi-member agent-room was an originally-1:1 DM polluted with rogue agents that auto-joined via `ensureAgentInPod` — exactly the bug PR #232's runtime guards close going forward. Relabel-to-chat legitimized the pollution; restoration is the correct action.

## Live data that informed this

The three offending pods on dev all had the same shape: 1 host agent + 1 human + N rogue agents.

| Pod | Host agent | Human | Rogue agents that auto-joined |
|---|---|---|---|
| `commonly-bot` (1) | `commonly-bot` | `ls111` | `openclaw-{fakesam, tarik, ai-citation-strategist, tom}` |
| `commonly-bot` (2) | `commonly-bot` | `xcjsam` | same 4 |
| `openclaw (fakesam)` | `openclaw-fakesam` | `xcjsam` | `openclaw-{ai-citation-strategist, tom, tarik}` |

None of these were ever multi-party chats. They were 1:1 DMs with intruders. Promoting them to `chat` would have made the bug permanent.

## New migration logic

```
for each agent-room with members.length > 2:
  humans = members where User.isBot === false
  case humans.length === 1:
    keep [createdBy, the_human]; drop rogue agents
    stays type='agent-room'
  case humans.length === 0:
    agent↔agent DM. Trust insertion order — getOrCreateAgentRoom creates
    pods with [hostAgent, otherParty]; later auto-joins append.
    keep [members[0], members[1]]; drop the rest.
    stays type='agent-room'
  case humans.length >= 2:
    Was never a DM (multi-human surfaces are chat pods, not DMs).
    type → 'chat'. All members preserved.
```

Per ADR-001 §3.10, agent-room is exactly 2 members; the pair can be `human + agent` OR `agent + agent`, never 3+.

## Also fixed

`backend/routes/agentsRuntime.ts:516` — stale comment on `POST /api/agents/runtime/room` was still documenting the rejected "many humans × one agent office" framing. Now matches §3.10 and notes that the endpoint accepts only human JWT (agent↔agent DM creation has no agent-runtime endpoint yet — file a follow-up if needed).

## Tests

`backend/__tests__/unit/scripts/migrate-agent-room-multimember.test.js` — 5 tests covering all three branches + dry-run + idempotency. Pod + User mocks so no real Mongo connection needed.

```
PASS __tests__/unit/scripts/migrate-agent-room-multimember.test.js
  ✓ 1 host agent + 1 human + N rogue agents → restore [host, human], stay agent-room
  ✓ 0 humans → agent↔agent DM, keep [members[0], members[1]] by insertion order
  ✓ 2+ humans → was never a DM, convert to chat, members preserved
  ✓ --dry mode reports a plan but does not save
  ✓ idempotent — pods with members.length <= 2 are not even returned by the cursor query
```

21/21 across the migration test + the inherited podController + ensureAgentInPod suites from #232.

## Rollback safety

The previous migration script (#232) was never run on `dev`, so swapping in this rewrite doesn't require any rollback or compensating action. The runtime guards in #232 already prevent new pollution.

## Test plan

- [x] Unit tests for all three planner branches + dry-run + idempotency
- [ ] Manual `kubectl exec ... migrate-agent-room-multimember.ts --dry` against dev — review the plan against the live data before committing
- [ ] Re-run without `--dry`, verify `commonly pod list --instance dev` shows the three offending pods now have 2 members each and stayed `agent-room` type
- [ ] Verify the host agent can still post into its own DM (i.e. the ObjectId-equality fix from #232 plus this restored membership both hold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)