### PR TITLE
chore(provisioner): restrict openai-codex to dev agents only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,7 +380,7 @@ These are prescriptive rules not derivable from reading the code:
 
 - **Global Integrations UI changes require `reprovision-all`** to take effect — UI writes to DB, provisioner reads DB on each reprovision and writes to `/state/moltbot.json`.
 
-- **Dev agents** (theo/nova/pixel/ops) use `openai-codex/gpt-5.4-mini` for heartbeats. **Community agents** use `openai-codex/gpt-5.4-nano`. Fallback chain: OpenRouter (nemotron → trinity). Gemini disabled (key revoked).
+- **Dev agents** (theo/nova/pixel/ops) use `openai-codex/gpt-5.4-mini` for heartbeats via an explicit per-agent override. **Community agents** use `openrouter/nvidia/nemotron-3-super-120b-a12b:free` as primary (trinity as fallback) — no Codex credentials are issued to them, so `openai-codex/*` is gated to dev agents only. Gemini fallbacks remain in the chain as placeholders but are inert today (`GEMINI_API_KEY` revoked).
 
 - **`registry.js` is the permanent source of truth** for heartbeat templates. PVC HEARTBEAT.md edits are overwritten on `reprovision-all`.
 

--- a/backend/__tests__/unit/services/agentProvisionerServiceK8s.test.js
+++ b/backend/__tests__/unit/services/agentProvisionerServiceK8s.test.js
@@ -275,9 +275,14 @@ describe('agentProvisionerServiceK8s', () => {
     expect(config.agents.defaults.contextPruning.mode).toBe('cache-ttl');
     expect(config.agents.defaults.contextPruning.ttl).toBe('90m');
     expect(config.agents.defaults.contextPruning.keepLastAssistants).toBe(2);
-    expect(config.agents.defaults.model.primary).toBe('openai-codex/gpt-5.4-mini');
+    // Community agents (cuz is not in DEFAULT_DEV_AGENT_IDS) inherit the
+    // gateway-level default — nemotron, no openai-codex. Codex is gated to
+    // dev agents via the per-agent override in provisionOpenClawAccount.
+    expect(config.agents.defaults.model.primary).toBe('openrouter/nvidia/nemotron-3-super-120b-a12b:free');
     expect(config.agents.defaults.model.fallbacks).toEqual(
-      expect.arrayContaining(['openrouter/nvidia/nemotron-3-super-120b-a12b:free', 'google/gemini-2.5-flash']),
+      expect.arrayContaining(['openrouter/arcee-ai/trinity-large-preview:free', 'google/gemini-2.5-flash']),
     );
+    expect(config.agents.defaults.model.fallbacks).not.toContain('openai-codex/gpt-5.4-mini');
+    expect(config.agents.defaults.model.fallbacks).not.toContain('openai-codex/gpt-5.4');
   });
 });

--- a/backend/services/agentProvisionerServiceK8s.ts
+++ b/backend/services/agentProvisionerServiceK8s.ts
@@ -1334,9 +1334,14 @@ const issueLiteLLMVirtualKey = async (agentId: any) => {
 };
 
 /**
- * Issue a LiteLLM virtual key scoped to community models (nano + OpenRouter fallbacks).
- * Community agents use gpt-5.4-nano as primary (same Codex OAuth, lowest quota cost)
- * with nemotron/trinity as fallbacks — without granting access to full gpt-5.4/mini (dev-only).
+ * Issue a LiteLLM virtual key for a community agent. Community agents'
+ * runtime primary is `openrouter/nvidia/nemotron-3-super-120b-a12b:free`
+ * (set as the gateway default in applyOpenClawModelDefaults); they never
+ * get openai-codex credentials injected. The allowlist on this key still
+ * permits the gpt-5.4-{nano,mini,full} model names as a safety net so the
+ * default can be flipped back without per-key re-issuance — calls to
+ * those models will fail at the auth layer (no Codex creds), not at
+ * LiteLLM's allowlist check.
  */
 const issueLiteLLMOpenRouterKey = async (agentId: any) => {
   const baseUrl = process.env.LITELLM_BASE_URL;
@@ -1373,9 +1378,11 @@ const issueLiteLLMOpenRouterKey = async (agentId: any) => {
         const check = await axios.get(`${baseUrl}/key/info?key=${existingKey}`, { headers });
         const info = check.data?.info;
         const ownedByAgent = info && (info.metadata?.agent_id === agentId || info.user_id === agentId);
-        // Model allowlist on the key must contain gpt-5.4-mini — that's the
-        // current default primary. Keys issued before the nano→mini switch
-        // still have the old allowlist and 401 on every call; force re-issue.
+        // Sentinel for "key was issued with the current allowlist." We use
+        // gpt-5.4-mini as the marker because it joined the allowlist in the
+        // nano→mini switch and stayed in for the codex-restricted-to-dev
+        // change; pre-switch keys lack it and would 401 on any retry, so
+        // we force re-issue.
         const allowsMini = Array.isArray(info?.models) && info.models.includes('gpt-5.4-mini');
         if (ownedByAgent && allowsMini) {
           return existingKey;
@@ -1730,20 +1737,23 @@ const applyOpenClawModelDefaults = async (config: any) => {
     'openrouter/arcee-ai/trinity-large-preview:free',
   ];
 
-  // Global default: gpt-5.4-mini for all agents. ChatGPT Team accounts
-  // don't accept gpt-5.4-nano via the Codex OAuth path (400 "not supported
-  // when using Codex with a ChatGPT account"), so we use mini — cheap
-  // enough for community agents and actually accepted by the endpoint.
-  // When CODEX_BYPASS_LITELLM=true, this routes direct to chatgpt.com
-  // through OpenClaw's native openai-codex-responses handler instead of
-  // the broken LiteLLM chatgpt/ bridge (BerriAI/litellm#25429).
-  config.agents.defaults.model.primary = 'openai-codex/gpt-5.4-mini';
+  // Global default for non-dev (community) agents: free OpenRouter models
+  // only. Codex quota is finite and shared; reserving it for dev agents
+  // keeps heartbeat orchestration responsive without burning weekly quota
+  // on community agents that would just fall back to OpenRouter on auth
+  // failure anyway (community agents aren't issued openai-codex
+  // credentials — see provisionOpenClawAccount). Dev agents bypass this
+  // default via the per-agent override (see devAgentModel below) — they
+  // still get openai-codex/gpt-5.4-mini.
+  config.agents.defaults.model.primary = 'openrouter/nvidia/nemotron-3-super-120b-a12b:free';
+  // Gemini entries are kept as a placeholder — current GEMINI_API_KEY is
+  // revoked so they're inert today; reinstating the key restores the chain
+  // without a code change.
   config.agents.defaults.model.fallbacks = Array.from(new Set([
+    'openrouter/arcee-ai/trinity-large-preview:free',
     'google/gemini-2.5-flash',
     'google/gemini-2.5-flash-lite',
     'google/gemini-2.0-flash',
-    'openrouter/nvidia/nemotron-3-super-120b-a12b:free',
-    'openrouter/arcee-ai/trinity-large-preview:free',
   ]));
 
   // Always set up Codex provider config so dev agents can use it via per-agent override.


### PR DESCRIPTION
## Summary
- Switch the gateway-level `agents.defaults.model.primary` from `openai-codex/gpt-5.4-mini` to `openrouter/nvidia/nemotron-3-super-120b-a12b:free`.
- Community agents (everything except dev agents `theo`/`nova`/`pixel`/`ops`) inherit this default; they were never issued openai-codex credentials anyway, so every prior call burned a refresh attempt that 401'd before falling back to OpenRouter.
- Dev agents are unaffected: their explicit per-agent override (`devAgentModel`) keeps `openai-codex/gpt-5.4-mini` as their primary.
- Reorder fallbacks: `openrouter/arcee-ai/trinity-large-preview:free` first, then the three `google/gemini-*` entries (which are inert today — `GEMINI_API_KEY` is revoked per CLAUDE.md — but kept as a placeholder).

## Why
With ~20 community agents heartbeating at 30 min cadence, the wasted Codex auth traffic was non-trivial. We hit OAuth-endpoint rate limits during today's outage; this PR is the structural fix so we don't recreate the problem the next time we re-auth Codex.

## Stale comments swept in the same diff
- Docstring on `issueLiteLLMOpenRouterKey` claimed community agents use `gpt-5.4-nano` as primary — corrected to nemotron.
- The `allowsMini` sentinel inside the function had a comment about gpt-5.4-mini being "the current default primary" — clarified it's now a safety-net entry in the allowlist (kept so the global default can be flipped back without per-key re-issuance).

## Pre-merge checklist
- [x] Self-reviewed via `code-reviewer` subagent — verdict: Approve with suggestions; both important suggestions addressed in the same commit.
- [x] TypeScript check clean.
- [x] Walked the dev-agent path: `applyOpenClawModelDefaults` only mutates `config.agents.defaults.model`; the per-agent `devAgentModel` is applied later in `provisionOpenClawAccount` (line ~2014) and overrides the default for dev agents specifically.
- [x] Confirmed `recommendedModel` in `presets.ts` is metadata-only — not consumed by provisioner logic, so presets that still say `recommendedModel: 'openai-codex/gpt-5.4'` will silently route to nemotron at runtime. Cosmetic mismatch only; filed as out-of-scope follow-up.

## Test plan
- [ ] `helm upgrade` + `reprovision-all` after merge → verify `kubectl exec deployment/clawdbot-gateway -- jq '.agents.defaults.model.primary' /state/moltbot.json` reads the new value.
- [ ] Spot-check a community agent (e.g. ai-citation-strategist) heartbeat after reprovision: should route via OpenRouter, NO `[openai-codex]` provider attempts in gateway logs.
- [ ] Spot-check a dev agent (nova) heartbeat: should still route to `openai-codex/gpt-5.4-mini` per the per-agent override.

## Out of scope (follow-ups)
- `presets.ts` `recommendedModel` cleanup — purely cosmetic, separate PR.
- `nativeRuntimeService.ts` `DEFAULT_MODEL` — different code path (Tier 1 in-process apps); leaving alone unless explicitly asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)