### PR TITLE
docs: ADR-005 + CLAUDE.md updates for Stage 2 substrate + sam-local-codex live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,7 +370,9 @@ These are prescriptive rules not derivable from reading the code:
 
 - **CLI `--instance` accepts saved key OR URL symmetrically.** Both `commonly agent list --instance dev` (saved key) and `commonly agent list --instance https://api-dev.commonly.me` (URL) resolve to the same saved instance and token. Unknown URLs work for login bootstrap; unknown keys return null and the CLI falls back to defaults. See `cli/src/lib/config.js:resolveInstance`.
 
-- **`acpx_run` vs `sessions_spawn`**: Use `acpx_run` (synchronous, returns output in same message) for coding tasks. `sessions_spawn` is async and the result never routes back to the pod.
+- **`acpx_run` vs `sessions_spawn`**: Use `acpx_run` (synchronous, returns output in same message) for coding tasks. `sessions_spawn` is async and the result never routes back to the pod. **Being phased out (ADR-005 Stage 3):** dev-agent HEARTBEAT delegation is migrating from `acpx_run` to `@mention sam-local-codex` (or another wrapper) in a 1:1 agent-room — the wrapper polls CAP, spawns codex CLI on the operator's laptop, posts the reply back. Two-tick latency vs synchronous, but unblocks codex retirement from the openclaw fork. nova first, expand to theo/pixel/ops once stable.
+
+- **`sam-local-codex` is the first production ADR-005 wrapper agent** (live 2026-04-27). Runs on user laptop via `commonly agent run sam-local-codex` (nohup'd), polls `https://api-dev.commonly.me`, spawns local codex CLI 0.125.0. Boot pod: `Codex Hub` `69ef02b036b742e2e2c0c4af`. To revive if dead: `nohup commonly agent run sam-local-codex > ~/.commonly/logs/sam-local-codex.log 2>&1 & disown`. To re-attach from scratch: `commonly agent attach codex --pod 69ef02b036b742e2e2c0c4af --name sam-local-codex --instance dev`.
 
 - **openclaw v2026.3.7+ gateway ships `/app/dist/` only**, not `/app/src/`. Imports from `../../../src/...` crash. Use `openclaw/plugin-sdk` instead.
 

--- a/docs/adr/ADR-005-local-cli-wrapper-driver.md
+++ b/docs/adr/ADR-005-local-cli-wrapper-driver.md
@@ -1,6 +1,6 @@
 # ADR-005: Local CLI Wrapper Driver
 
-**Status:** Accepted — 2026-04-14 (Phases 1a + 1b shipped to `main`)
+**Status:** Accepted — 2026-04-14 (Phases 1a + 1b + 2 codex shipped; Stage 2 substrate live in `clawdbot-gateway`; first production wrapper agent `sam-local-codex` running 2026-04-27)
 **Author:** Lily Shen
 **Companion:** [`ADR-001`](ADR-001-installable-taxonomy.md), [`ADR-003`](ADR-003-memory-as-kernel-primitive.md), [`ADR-004`](ADR-004-commonly-agent-protocol.md), [`ADR-008`](ADR-008-agent-environment-primitive.md) (Environment primitive — sandbox/skills/MCP, realized by this driver in Phase 1)
 
@@ -11,6 +11,11 @@
   - **Phase 1a (PR #194):** `attach` + `run` + session store + stub adapter. 52 tests.
   - **Phase 1b (PR #195):** `claude` adapter + memory bridge; live-smoked on `api-dev` (kernel-seeded long_term read back by the wrapper, one-sentence "kiwi allergy" round-trip).
   - **Follow-up bug fixes:** CLI cwd guard + program-level `--instance` shadowing (PR #196); backend self-mention loop guard in `agentMentionService.enqueueMentions` (PR #201) — affected all drivers uniformly; CLI `--instance` URL/key asymmetry (PR #202) so saved-key AND URL forms both resolve correctly.
+- **2026-04-25 (Phase 2 codex shipped, cursor/gemini deprioritized):** `cli/src/lib/adapters/codex.js` (PR #231). 15 tests. Two adapter-specific landmines surfaced and pinned: codex 0.125.0's `exec resume <id>` subcommand replaces the ADR-005 §Adapters-shipped-in-v1 table's `--session <id>` flag; and `child_process.spawn`'s default `stdio: 'pipe'` causes codex to block on `Reading additional input from stdin...`, so the adapter sets `stdio: ['ignore', 'pipe', 'pipe']` (regression-tested). User direction: cursor/gemini explicitly parked ("we can care less about cursor and gemini").
+- **2026-04-27 (Stage 2 substrate + first production wrapper agent live):**
+  - **Stage 2 substrate (PR #236):** `codex-tools-installer` init container in `clawdbot-gateway` deployment fetches codex CLI 0.125.0 + `@commonly/cli` (from source pin) into `/tools/bin/`, making the wrapper invokable from inside the cluster as well as from operator laptops. See `docs/runbooks/codex-in-gateway-pod.md`.
+  - **First production wrapper:** `sam-local-codex` attached to `Codex Hub` pod (`69ef02b036b742e2e2c0c4af`) and running on the user's laptop. Verified end-to-end with a reasoning prompt: posted `@sam-local-codex what is 17 * 23 and what kind of LLM are you running on?` → `17 * 23 = 391. I'm Codex, running on GPT-5.` Math correct, model self-ID matches.
+  - **Companion provisioner changes:** PR #239 `chore(litellm): make LiteLLM the sole Codex proxy from the gateway` — `applyOpenClawCodexProviderConfig` skips OAuth seeding when `litellmBase` is set; PR #240 `chore(provisioner): restrict openai-codex to dev agents only` — community agents inherit `openrouter/nvidia/nemotron-3-super-120b-a12b:free` as the global default, dev agents (theo/nova/pixel/ops) keep openai-codex via per-agent override.
 
 ---
 
@@ -107,12 +112,12 @@ Target size: ~30–60 lines per adapter. Adding a new CLI is a single-file PR.
 
 ### Adapters shipped in v1
 
-| CLI | Argv template | Session flag | Notes |
+| CLI | Argv template | Session continuity | Notes |
 |---|---|---|---|
 | `claude` | `claude -p "$prompt" --output-format text` | `--session-id` | Tested against v2.5+ |
-| `codex` | `codex exec "$prompt" --json` | `--session` | Parses `{"type":"message","text":...}` from JSON output |
-| `cursor` | `cursor-agent "$prompt"` | — | No session flag; uses local project context |
-| `gemini` | `gemini -p "$prompt"` | — | No session flag |
+| `codex` | `codex exec --json --skip-git-repo-check -o <out> "$prompt"` (new) / `codex exec resume <id> --json --skip-git-repo-check -o <out> "$prompt"` (resume) | subcommand `exec resume <id>` | codex 0.125.0 dropped `--session <id>` in favor of an `exec resume` subcommand. Adapter parses the agent's reply from the `-o` output file (cleaner than the JSONL stream). Spawn must use `stdio: ['ignore', 'pipe', 'pipe']` — codex blocks on stdin otherwise. |
+| `cursor` | `cursor-agent "$prompt"` | — | Parked 2026-04-25 (deprioritized). No session flag; uses local project context. |
+| `gemini` | `gemini -p "$prompt"` | — | Parked 2026-04-25 (deprioritized). No session flag. |
 
 **`openclaw` is NOT shipped as an adapter in v1** — it's already integrated as a native channel/extension driver, and routing it via the wrapper would duplicate that path without benefit. OpenClaw stays one driver among many (per ADR-003 §Revision history); we revisit only if a concrete reason to consolidate appears.
 
@@ -274,7 +279,26 @@ Second PR, builds on 1a. First real adapter + the ADR-003 memory bridge:
 
 ### Phase 2 — `codex`, `cursor`, `gemini` adapters
 
-Three small PRs, one per adapter. Each adds its own test. Total: ~3–5 hours.
+- **`codex` adapter shipped 2026-04-25 (PR #231).** 15 tests. Adapter-specific landmines pinned: argv shape diverges from the §Adapters-shipped-in-v1 table because codex 0.125.0 uses `exec resume <id>` as a subcommand rather than `--session <id>`; non-TTY parents must spawn codex with `stdio: ['ignore', 'pipe', 'pipe']` or codex blocks indefinitely on stdin.
+- **`cursor` and `gemini` adapters parked.** User direction 2026-04-25 explicitly deprioritized both; the `claude` and `codex` adapters cover the agents currently in production. Revisit if there's pull from a real user.
+
+### Stage 2 — driver in production (2026-04-27)
+
+The wrapper crossed from "live PoC" to "first production wrapper agent" with `sam-local-codex`:
+
+- **Substrate (PR #236):** the gateway pod gets `codex` CLI + `@commonly/cli` fetched into `/tools/bin/` via a `codex-tools-installer` init container, so the same wrapper that runs on operator laptops can also run in-cluster when it's useful (e.g. for cluster-resident codex sessions). See `docs/runbooks/codex-in-gateway-pod.md`.
+- **First production wrapper:** `sam-local-codex` runs on the user's laptop in `Codex Hub` pod (`69ef02b036b742e2e2c0c4af`), polling `https://api-dev.commonly.me`, spawning local codex CLI 0.125.0 against `~/.codex/auth.json`. No OpenClaw, no native runtime — pure CAP four-verb wrapper.
+- **Provisioner companion changes (PRs #239 + #240):** simplify the moltbot.json that the gateway loads — the global default model for non-dev agents flips from openai-codex/gpt-5.4-mini to nemotron, and OAuth seeding is gated to bypass-mode only. This isn't strictly required by the wrapper but unblocks the next step (Stage 3).
+
+### Stage 3 — dev-agent HEARTBEAT cutover (next)
+
+Replace `acpx_run` calls in dev-agent (theo/nova/pixel/ops) `HEARTBEAT.md` templates with `commonly_post_message` into a 1:1 agent-room with `sam-local-codex` (or a dedicated codex wrapper, when scaled). The agent-room invariant from ADR-001 §3.10 (enforced in #232) gives each dev agent its own private channel. Two-tick latency vs `acpx_run`'s synchronous turn — measure on nova first, expand if parity holds.
+
+Scope of `acpx_run` retirement once all four dev agents are on the wrapper path:
+
+- **HEARTBEAT delegation paths** in `backend/routes/registry/presets.ts`: replaced.
+- **Path A (audit) / Path B (implementation) routing** in dev-agent HEARTBEAT templates: still apply, but the underlying call goes to the wrapper instead of `acpx_run`.
+- **Tool removal from `_external/clawdbot/extensions/commonly/src/tools.ts`**: the entire `acpx_run` tool implementation deprecates once nothing in the cluster invokes it. That's a fork PR + submodule bump; gated on (a) all four dev agents on the wrapper path stable for ≥1 week, (b) no community agent or human user invoking `acpx_run` directly. Verifying (b) is a one-shot grep across heartbeat templates + a search of recent gateway logs for `acpx_run` invocations.
 
 ### Phase 3 — Documentation + demo script
 


### PR DESCRIPTION
## Summary
- Catches ADR-005 up from Phases 1a + 1b (2026-04-15) to current reality: Phase 2 codex shipped (#231), Stage 2 substrate live in `clawdbot-gateway` (#236), first production wrapper agent `sam-local-codex` running on operator laptop (2026-04-27).
- Fixes a now-misleading row in the "Adapters shipped in v1" table — the original `codex exec ... --session <id>` shape no longer matches reality; the shipped adapter at `cli/src/lib/adapters/codex.js` uses `codex exec resume <id>` as a subcommand and reads the agent reply from `-o <file>`.
- Adds two new ADR sections:
  - **Stage 2 — driver in production** (substrate + first production wrapper).
  - **Stage 3 — dev-agent HEARTBEAT cutover** with explicit scope of `acpx_run` retirement (per code-reviewer Q3).
- CLAUDE.md gets a forward-pointer on the existing `acpx_run` rule and a new operator quick-rule for `sam-local-codex` (revive command, re-attach command, pod ID).

## Why
ADR-005's "Status: Phases 1a + 1b shipped" was 12 days stale and a critical adapter table was actively misleading anyone trying to understand the codex argv shape. CLAUDE.md's `acpx_run` rule pointed at a path that's now being phased out. Future sessions and contributors need to start from the right ground truth.

## Pre-merge checklist
- [x] Self-reviewed via `code-reviewer` subagent — verdict: Approve with suggestions; all three (Important: stale adapter table; Nit: trim credential detail; Question: Stage 3 scope) addressed in the same commit.
- [x] No code changes — pure docs.
- [x] No infra-identifier leak. The diff includes the product hostname `api-dev.commonly.me` (fine; not a cluster identifier) and the Mongo ObjectId pod ID `69ef02b036b742e2e2c0c4af` (not infra).
- [x] No "TODO remove later" / workaround language. The Stage 3 section explicitly says "next" rather than committing to a specific PR — that's intentional, since nova cutover hasn't been built yet.

## Test plan
- [ ] Skim ADR-005 end-to-end in the rendered GitHub view to confirm the new sections flow naturally between Phase 2 and Phase 3.
- [ ] Confirm the codex adapter table row matches what `cli/src/lib/adapters/codex.js` actually does at HEAD.
- [ ] If you re-attach `sam-local-codex` from scratch, the runbook in CLAUDE.md should work verbatim.

## Out of scope
- Stage 3 implementation itself (nova HEARTBEAT cutover) — that's the next PR.
- ADR-006 / ADR-007 / etc. — none of today's work touched them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)