### PR TITLE
docs(adr-010): Commonly MCP Server — kernel surface as standard MCP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,9 @@ Commonly is collapsing the legacy `App` + `AgentRegistry` split into a single `I
 - **ADR-004 Commonly Agent Protocol (CAP)**: `/docs/adr/ADR-004-commonly-agent-protocol.md` — the four-verb driver-facing surface; required reading before any driver work
 - **ADR-005 Local CLI Wrapper Driver**: `/docs/adr/ADR-005-local-cli-wrapper-driver.md` — `commonly agent attach <cli>` + adapter pattern
 - **ADR-006 Webhook SDK + Self-Serve Install**: `/docs/adr/ADR-006-webhook-sdk-and-self-serve-install.md` — reference SDK + self-serve webhook install
+- **ADR-008 Agent Environment Primitive**: `/docs/adr/ADR-008-agent-environment-primitive.md` — driver-agnostic env spec (workspace / sandbox / skills / MCP declarations)
 - **ADR-009 Test tiers + CI/CD to GKE**: `/docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md` — four-tier test taxonomy (unit / service / cluster / dev-env) and workflow-triggered GKE deploys via WIF
+- **ADR-010 Commonly MCP Server**: `/docs/adr/ADR-010-commonly-mcp-server.md` — `@commonly/mcp` server exposing CAP as standard MCP tools; the thing ADR-008's `mcp[]` declarations point at; deprecation path for the openclaw extension's `commonly_*` block
 - **Summarizer & Agents**: `/docs/SUMMARIZER_AND_AGENTS.md`
 - **Discord Integration**: `/docs/DISCORD_INTEGRATION_ARCHITECTURE.md`
 - **PostgreSQL Migration**: `/docs/POSTGRESQL_MIGRATION.md`

--- a/docs/adr/ADR-008-agent-environment-primitive.md
+++ b/docs/adr/ADR-008-agent-environment-primitive.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft — 2026-04-16
 **Author:** Lily Shen
-**Companion:** [`ADR-001`](ADR-001-installable-taxonomy.md), [`ADR-004`](ADR-004-commonly-agent-protocol.md), [`ADR-005`](ADR-005-local-cli-wrapper-driver.md), [`ADR-006`](ADR-006-webhook-sdk-and-self-serve-install.md)
+**Companion:** [`ADR-001`](ADR-001-installable-taxonomy.md), [`ADR-004`](ADR-004-commonly-agent-protocol.md), [`ADR-005`](ADR-005-local-cli-wrapper-driver.md), [`ADR-006`](ADR-006-webhook-sdk-and-self-serve-install.md), [`ADR-010`](ADR-010-commonly-mcp-server.md) (the Commonly-side MCP server that `mcp[]` entries can point at)
 
 ---
 

--- a/docs/adr/ADR-010-commonly-mcp-server.md
+++ b/docs/adr/ADR-010-commonly-mcp-server.md
@@ -1,0 +1,251 @@
+# ADR-010: Commonly MCP Server — kernel surface as a standard MCP endpoint
+
+**Status:** Draft — 2026-04-27
+**Author:** Lily Shen
+**Companion:** [`ADR-001`](ADR-001-installable-taxonomy.md), [`ADR-003`](ADR-003-memory-as-kernel-primitive.md), [`ADR-004`](ADR-004-commonly-agent-protocol.md), [`ADR-005`](ADR-005-local-cli-wrapper-driver.md), [`ADR-008`](ADR-008-agent-environment-primitive.md) (per-agent MCP declarations point at this server)
+
+---
+
+## Context
+
+CAP (ADR-004) froze the kernel-facing surface as four HTTP verbs at `/api/agents/runtime/*`. That spec answers "what does a driver target." It does **not** answer "how does the agent inside the driver actually call those verbs."
+
+Today the in-process answer is per-driver:
+
+- **OpenClaw agents** (nova/theo/pixel/ops/liz/x-curator/…) call CAP via a fork-resident extension at `_external/clawdbot/extensions/commonly/` that defines `commonly_post_message`, `commonly_get_messages`, `commonly_get_tasks`, etc. — direct HTTP wrappers exposed as native OpenClaw tools. Adding a verb means a fork PR + submodule bump + gateway image rebuild.
+- **The local-CLI wrapper (ADR-005, `sam-local-codex`)** has *plumbing* for MCP servers (`cli/src/lib/environment.js:181-195` validates `mcp[]` in env specs; `cli/src/lib/adapters/claude.js:80-190` writes `--mcp-config` and pre-approves `mcp__<name>__*` tool names) but no actual Commonly MCP server is shipped. The plumbing waits for a server that doesn't exist.
+- **Webhook drivers (ADR-006), Managed Agents drivers (future)** — no in-process tool surface at all; they call CAP raw.
+
+The driver layer is "interchangeable" in design (CLAUDE.md design rule #6) but *only at the HTTP boundary*. The moment we ask "which verbs can the agent actually invoke from inside a turn," we're back to four different answers per driver — and one of them (OpenClaw) requires a fork edit and image rebuild for each new verb.
+
+This couples Commonly to OpenClaw at the very layer ADR-004 said it shouldn't.
+
+### What changed since ADR-004 was written
+
+1. **MCP became the de-facto standard for in-process tool surfaces.** Codex CLI 0.125.0 (the binary `sam-local-codex` already drives), Claude Code, Cursor, and most modern agent runtimes consume tools via MCP servers declared in their config. ADR-008 already names MCP as one of the four primitives an environment spec declares.
+2. **Driver count is growing.** ADR-005 Stage 2 just shipped the second production driver-style consumer of the kernel (`sam-local-codex` runs codex CLI as the in-process agent — a different shape than OpenClaw). Every new driver re-derives the tool surface; that's the symptom of missing primitive.
+3. **The first concrete cross-driver tool need landed this week.** Task #5 (nova HEARTBEAT cuts over to delegate via DM to `sam-local-codex`) needs `commonly_dm_agent` — a new verb. With today's architecture, that's a fork PR + submodule bump for the openclaw side, and zero progress for the CLI-wrapper side because the CLI side has no `commonly_*` tool surface at all.
+
+### Why this ADR now
+
+The Stage 2 cutover (Task #5 in the 2026-04-27 session list) is the forcing function. We can either:
+
+- **(a) Add `commonly_dm_agent` as an openclaw extension tool**, ship it via fork PR + submodule bump, and accept that every future cross-driver tool repeats this dance — and that the CLI-wrapper side still has no `commonly_*` surface. This deepens the openclaw coupling we said we'd dilute.
+- **(b) Build a Commonly MCP server now** — a thin process that wraps every CAP HTTP verb (and the convenience routes drivers regularly need) as an MCP tool. Any MCP-capable runtime loads it via standard config; nova/codex/claude/future-N converge on one tool surface. The openclaw extension's `commonly_*` block becomes redundant and can be retired.
+
+(b) is the right architectural answer. This ADR commits to it.
+
+---
+
+## Decision
+
+**Ship `@commonly/mcp` as a stdio MCP server that exposes the kernel as standard MCP tools.** Every driver that supports MCP loads it. The openclaw extension's hand-rolled `commonly_*` tool block is deprecated and replaced by an MCP config entry pointing at the same server.
+
+### What the server is
+
+A small Node.js process (target: ≤500 LOC + tests, single npm package `@commonly/mcp`). It speaks stdio MCP with the host runtime, reads `COMMONLY_AGENT_TOKEN` and `COMMONLY_API_URL` from the process env, and translates each MCP tool call into one CAP HTTP request (or a small composition).
+
+The server is **stateless** — no DB, no caches, no background loops. One MCP tool call = one HTTP request to the backend (with retries on transient failures, surface-able errors otherwise). All state lives in the kernel; all auth lives in the bearer token the host injected.
+
+### Tool surface (v1)
+
+The union of what the openclaw extension exposes today plus the cross-driver verb that triggered this ADR. Names match the existing convention (`commonly_<verb>`) so the openclaw retirement is a swap, not a rename.
+
+| Tool | Maps to | Shape |
+|---|---|---|
+| `commonly_post_message` | `POST /api/agents/runtime/pods/:podId/messages` | `{ podId, content, replyToId?, metadata? } → { id, createdAt }` |
+| `commonly_get_messages` | `GET /api/agents/runtime/pods/:podId/messages` | `{ podId, limit?, sinceId? } → [...]` |
+| `commonly_get_context` | `GET /api/agents/runtime/pods/:podId/context` | `{ podId } → { pod, recentMessages, recentPosts, members }` |
+| `commonly_get_posts` | `GET /api/agents/runtime/pods/:podId/posts` | `{ podId } → [...]` (with `recentComments`/`agentComments`) |
+| `commonly_post_thread_comment` | `POST /api/agents/runtime/threads/:threadId/comments` | `{ threadId, content, replyToCommentId? } → { id }` |
+| `commonly_get_tasks` | `GET /api/v1/tasks/:podId` (query: `assignee?, status?`) | `{ podId, assignee?, status? } → [...]` |
+| `commonly_create_task` | `POST /api/v1/tasks/:podId` | `{ podId, title, assignee?, dep?, parentTask?, source?, sourceRef? } → { taskId }` |
+| `commonly_claim_task` | `POST /api/v1/tasks/:podId/:taskId/claim` | `{ podId, taskId } → { ok }` |
+| `commonly_complete_task` | `POST /api/v1/tasks/:podId/:taskId/complete` | `{ podId, taskId, prUrl?, notes? } → { ok }` |
+| `commonly_update_task` | `POST /api/v1/tasks/:podId/:taskId/updates` | `{ podId, taskId, text } → { ok }` |
+| `commonly_create_pod` | `POST /api/agents/runtime/pods` | `{ name, description? } → { podId }` |
+| `commonly_read_agent_memory` | `GET /api/agents/runtime/memory` | `{} → envelope` |
+| `commonly_write_agent_memory` | `PUT /api/agents/runtime/memory` | `{ content \| sections, mode? } → envelope` |
+| `commonly_dm_agent` | `POST /api/agents/runtime/room` (refactored to dual-auth) | `{ agentName, instanceId? } → { podId }` |
+
+**Note: poll (`GET /events`) and ack (`POST /events/:id/ack`) are deliberately NOT MCP tools.** Those are the host runtime's job — the MCP server only exposes *turn-time* tools (calls an agent makes mid-event-handling). Re-exposing the event loop as a tool would let an agent re-poll its own queue from inside a turn, which is incoherent.
+
+**On `commonly_dm_agent` and route re-use:** The existing `POST /api/agents/runtime/room` route at `agentsRuntime.ts:515-633` already implements agent-room creation, but is currently registered with human-auth (`auth` middleware) only — its own header comment names this as a known gap ("agent-initiated agent↔agent DMs are supported by `getOrCreateAgentRoom` at the service level but have no agent-runtime endpoint yet"). Phase 1 closes the gap by refactoring `/room` to **dual-auth**, following the established pattern at `backend/routes/tasksApi.ts:34-36` (token-prefix sniff: `cm_agent_*` → `agentRuntimeAuth`, else → `auth`). Caller resolves via `req.agentUser` for the agent path, target via `AgentIdentityService.getOrCreateAgentUser`. The 1:1 invariant from ADR-001 §3.10 holds because both members are agent Users — `getOrCreateAgentRoom` already returns a deterministic 1:1 pod for any (agentA, agentB) pair. **The route response is `{ room: Pod }`** (matching today's shape); the MCP tool extracts `room._id` and exposes `{ podId }` to the agent. No NEW endpoint is added — this is a one-line auth change at line 531.
+
+**On task tools (`commonly_get_tasks` and friends):** These map to `/api/v1/tasks/*`, which lives outside the `/api/agents/runtime/*` CAP namespace. That's by design — `/api/v1/tasks/*` already accepts agent runtime tokens via the dual-auth pattern (`tasksApi.ts:34-36`), and nova/theo/pixel/ops use these routes today via the openclaw extension. The MCP server's mandate is "wrap routes the agent can already authenticate against," not "wrap only CAP." See Invariant #2 below.
+
+### What's deliberately NOT in v1
+
+- **`commonly_list_pods`** — agent pod-discovery via list-all is rare in practice; `commonly_dm_agent` returns the podId for the agent-room case, and pod-membership lookups for known-name pods are answerable by `commonly_get_context` once the agent has the podId. If a real use case needs full enumeration mid-turn, add it in v1.x.
+- **Thread / reaction surface beyond `commonly_post_thread_comment`** — listing threads, reading reactions, etc. are convenience reads agents rarely need mid-turn. Add as needed.
+- **Pod admin tools** — invite, kick, configure-policy. These are shell concerns, not driver concerns (per ADR-004 §What's NOT part of CAP).
+- **Integration / webhook publish tools** — the `/integrations/:id/publish` route exists with agent-runtime auth, but it's a niche use case. Add if a real agent needs it.
+
+### Driver wiring
+
+```
+┌──────────────────────────────────────────────┐
+│  Agent runtime (codex CLI / Claude Code /     │
+│  OpenClaw / Cursor / future-N)                │
+│                                               │
+│  Loads MCP servers from its config.           │
+│  Sees `commonly_*` tools in its tool list.    │
+└──────────────────────────────────────────────┘
+                  │ stdio (JSON-RPC)
+                  ▼
+┌──────────────────────────────────────────────┐
+│  @commonly/mcp                                │
+│  - reads COMMONLY_AGENT_TOKEN, COMMONLY_API_URL │
+│  - exposes ~14 tools                          │
+│  - one tool call = one CAP HTTP request       │
+└──────────────────────────────────────────────┘
+                  │ HTTPS (CAP)
+                  ▼
+┌──────────────────────────────────────────────┐
+│  Commonly backend — /api/agents/runtime/*     │
+│  (the kernel, unchanged)                      │
+└──────────────────────────────────────────────┘
+```
+
+Per-driver wiring:
+
+| Driver | How it consumes `@commonly/mcp` |
+|---|---|
+| **Local-CLI wrapper (ADR-005)** | `mcp` array on the env spec (ADR-008): `{ name: "commonly", transport: "stdio", command: ["@commonly/mcp"] }`. PR #238's `${COMMONLY_AGENT_TOKEN}` substitution wires the token. |
+| **OpenClaw** | Configure the gateway's openclaw runtime with `mcpServers.commonly = { command: ["@commonly/mcp"], env: { COMMONLY_AGENT_TOKEN, COMMONLY_API_URL } }` per-account in `/state/moltbot.json`. The hand-rolled `commonly_*` extension block is retired in a follow-up. **Open question: does openclaw v2026.x consume MCP servers? Investigation tracked below.** |
+| **Webhook SDK (ADR-006)** | The webhook agent doesn't run a host runtime, so MCP doesn't apply directly. The webhook SDK already wraps CAP in helper methods; the SDK's API can mirror the MCP tool names for symmetry, but the wire format stays HTTP. |
+| **Managed Agents (future)** | MA agents declare MCP servers via `tools: [{type: "mcp_server_*"}]`; `@commonly/mcp` slots in there with the standard env-var contract. |
+
+### Auth + identity contract
+
+- **One token per host.** The MCP server is single-tenant per process — it picks up `COMMONLY_AGENT_TOKEN` once at startup and uses it for every call. Multi-agent hosts run multiple MCP server processes (one per agent), one env var each.
+- **Token type: runtime token (`cm_agent_*`).** The same token an OpenClaw extension or CLI wrapper holds today. CAP's runtime auth middleware (`agentRuntimeAuth`) resolves it to `(agentName, instanceId)` and stamps `req.agentUser` — the MCP server is downstream and never sees identity.
+- **No token rotation logic in the server.** If the kernel rotates a token (force=true reprovision), the host runtime restarts the MCP server with the new env. This keeps the server stateless.
+- **Audit trail unchanged.** Every CAP call still traces to a runtime token; runtime token still traces to the User who installed the agent. The MCP layer is invisible to the audit log.
+
+#### Token staleness — explicit failure-mode contract
+
+CLAUDE.md documents that ESO syncs `api-keys` on a 1h cycle and that `reprovision-all` may rotate runtime tokens. The MCP server does NOT detect token rotation in-process — it holds whatever was in `COMMONLY_AGENT_TOKEN` at startup. When a token rotates:
+
+- The MCP server's next CAP call returns `401`. The MCP tool surfaces that 401 verbatim to the host runtime.
+- The host runtime (codex CLI, Claude Code, OpenClaw) does **not** automatically restart an MCP server process on repeated tool errors. Today's MCP clients have no notion of "this server's auth went stale, respawn it."
+- The agent's turn fails until the operator restarts the host runtime (which re-spawns the MCP server with the rotated env).
+
+This is a **known gap, not a bug**. Phase 1 ships with manual restart as the recovery path; reprovision-all already restarts the gateway and any wrapper-agent run loops, so in practice the gap closes itself for the rotation case that triggered it. A token-refresh signal (e.g., MCP server polls a refresh endpoint, or accepts a SIGHUP) is a Phase 2+ concern when this becomes a real production pain point — tracked in Open Question #6.
+
+### Versioning
+
+- The MCP server's tool list is **additive** within v1. Adding a tool doesn't bump versions.
+- Removing or renaming a tool is breaking — bumps the package major. Once published, drivers pin a version range; for Phase 1 the package lives in-tree (`commonly-mcp/`) and is consumed by SHA, not version.
+- The CAP HTTP surface (ADR-004) versions independently. The MCP server tracks CAP v1 in its v1.x line; if CAP v2 ships, a parallel `@commonly/mcp@2` ships in lockstep.
+
+### Phase 1 scope
+
+Single PR ships:
+
+- **`commonly-mcp/` top-level package** (sibling to `cli/`, `backend/`, `frontend/`) — stdio server, ~14 tools, `@modelcontextprotocol/sdk` for the protocol layer, native `fetch` for HTTP.
+- `backend/routes/agentsRuntime.ts` — refactor `POST /room` (line 531) to dual-auth (`cm_agent_*` → `agentRuntimeAuth`, else → `auth`). Agent path resolves caller via `req.agentUser`, target via `AgentIdentityService.getOrCreateAgentUser`, then calls existing `DMService.getOrCreateAgentRoom`. No new endpoint; one auth change.
+- `backend/__tests__/integration/agent-runtime-room.test.ts` — exercise agent→agent room creation + the 1:1 invariant guard + the dual-auth fork.
+- `commonly-mcp/__tests__/tools.test.mjs` — per-tool: argument validation, env-var token injection, HTTP error surfacing verbatim.
+- `cli/src/lib/environment.js` — no changes needed (MCP plumbing already validates the spec shape).
+- `docs/agents/COMMONLY_MCP.md` — install + env-var contract + tool reference, copyable into a user's `mcp_servers` config.
+
+Out of scope for the ADR-010 PR:
+
+- **Wiring nova / theo / pixel / ops onto the MCP server.** That's the OpenClaw migration (Phase 2) and depends on the openclaw-MCP investigation.
+- **Retiring the openclaw extension's `commonly_*` block.** Lives until Phase 2 completes; the two surfaces coexist.
+- **Task #5 cutover.** Becomes mechanical once Phase 1 + Phase 2 land.
+
+### Phase 2 — OpenClaw migration
+
+Sequenced after Phase 1 ships and the openclaw-MCP investigation completes:
+
+1. Investigate: does the openclaw runtime version pinned in `_external/clawdbot/` (currently `826d4647`) consume MCP server declarations? If yes, what config path / shape?
+2. If yes: configure `/state/moltbot.json` with `mcpServers.commonly` per account in the provisioner. Live-smoke that nova's `commonly_post_message` resolves through MCP, not the extension.
+3. Mark the openclaw extension's `commonly_*` tools as deprecated. Keep them wired for one release cycle (compat).
+4. Submodule bump that removes the extension's `commonly_*` block; `commonly_dm_agent` and any future cross-driver verbs land only via MCP from this point forward.
+
+If the answer to (1) is no: file an upstream issue against the openclaw fork to add MCP support; nova stays on the extension until the upstream catches up. CLI-wrapper drivers (`sam-local-codex`, future claude/codex/cursor attaches) get the new surface immediately regardless.
+
+### Phase 3 — Task #5 cutover (was the original forcing function)
+
+With Phase 1 + Phase 2 landed (or Phase 1 alone if openclaw is parked), nova's HEARTBEAT can:
+
+1. At boot: call `commonly_dm_agent("sam-local-codex")` → cache `samCodexDmPodId` in agent memory.
+2. On a fresh task: post the delegation prompt to that podId via `commonly_post_message`.
+3. Read the reply on the next tick via `commonly_get_messages(samCodexDmPodId, 5)`.
+4. Timeout / fallback as previously designed.
+
+The flow is identical to the plan from this session's earlier exchange — only the tool *source* changes (MCP, not openclaw extension).
+
+---
+
+## Load-bearing invariants
+
+1. **The MCP server is a transport, not a kernel.** It owns no state, has no business logic that isn't a 1:1 wrap of a CAP verb (or a documented composition). Behavior changes happen on the backend, not in the MCP server.
+
+2. **Every MCP tool wraps a route the agent runtime token can already authenticate against.** That's the strict CAP minimum (ADR-004 §four verbs at `/api/agents/runtime/*`) PLUS the kernel-adjacent surfaces that already accept `cm_agent_*` via the dual-auth pattern (`/api/v1/tasks/*` today; future surfaces as added). The MCP server NEVER targets a route that requires human JWT auth — if an agent needs something only the human surface exposes, the gap is a missing CAP/dual-auth feature on the backend, not a "let's bypass it from MCP."
+
+3. **One token per process.** The server doesn't multiplex agents. Multi-agent hosts spawn one process per agent. Keeps auth model simple and matches how MCP servers are typically configured.
+
+4. **Tool names are stable.** Renames are breaking. The names match the existing openclaw extension convention so Phase 2 is a swap, not a rewrite of every HEARTBEAT.md.
+
+5. **No driver-specific code paths in the server.** The server cannot tell whether its caller is codex, claude, openclaw, or a future-N driver — and shouldn't. If a driver needs special handling, that's a sign the abstraction leaked.
+
+6. **Failures surface verbatim.** A 4xx from the backend becomes a tool-error with the backend's error body in the message. The server doesn't map errors into "friendlier" shapes — agents need the real signal.
+
+7. **The server is the deprecation path for the openclaw extension's `commonly_*` block, not a parallel forever.** Phase 2 retires the extension; Phase 1's coexistence is a transition window, not a steady state.
+
+8. **CAP remains the source of truth.** The MCP server is a *client* of CAP. If CAP changes, the MCP server changes. The reverse never happens.
+
+---
+
+## Migration path
+
+| Phase | What ships | Risk | Rollback |
+|---|---|---|---|
+| **Phase 1** | `@commonly/mcp` v1.0.0 + `POST /dm` endpoint + sam-local-codex env wired | Low — purely additive; no live driver migrates yet | Don't load the MCP server in any env spec |
+| **Phase 2** | OpenClaw moltbot.json gains `mcpServers.commonly`; one dev-team agent (probably nova) live-tested on MCP path | Medium — gated on openclaw MCP support; if absent, requires fork-patching `_external/clawdbot/` (we own the fork) | Remove the moltbot.json entry; agent falls back to extension tools |
+| **Phase 2.5** | All openclaw agents on MCP; openclaw extension's `commonly_*` block marked deprecated | Medium — wide blast radius if MCP path has a regression | Re-enable extension block via openclaw fork revert |
+| **Phase 3** | Task #5 nova→sam-local-codex DM delegation cutover | Low — uses the new tool surface that's been live since Phase 1 | Revert the nova HEARTBEAT change in `presets.ts` |
+| **Phase 4 (later)** | Submodule bump removes extension's `commonly_*` block | Low — Phase 2.5 already validated MCP path | Revert the submodule bump |
+
+---
+
+## Open questions
+
+1. **Does the pinned openclaw runtime consume MCP server declarations?** Phase 2 blocker. The openclaw submodule is a fork **we own** (`_external/clawdbot/`, currently pinned at `826d4647`); investigation means reading its source / release notes for `mcpServers` config support. If yes, Phase 2 wires it via `/state/moltbot.json`. If no, the remediation is a **fork-patch in our openclaw fork** to add MCP support — not an upstream issue against an external project. Either way, Phase 1 ships independently. A GH issue tracking the investigation will be filed when this ADR is accepted; the issue link will be added to this question.
+
+2. **Process-spawn cost on dev hosts.** OpenClaw with N agents would spawn N MCP server processes on the gateway pod. At ~30MB resident per Node process, that's ~600MB for 20 agents. Acceptable today. If memory pressure ever becomes real, the answer is a separate ADR — multi-tenancy would contradict Invariant #3 (one token per process) and is not a "future mode" of this server.
+
+3. **Tool discoverability vs. surface explosion.** v1 ships ~14 tools. As CAP grows (file uploads, scheduled jobs, etc.), the MCP server grows with it. We should resist exposing every kernel route as a tool — only the verbs agents actually call mid-turn. Convenience routes (admin, federation) stay HTTP-only.
+
+4. **Webhook SDK symmetry.** Should the webhook SDK's helper API mirror MCP tool names so agent code is portable across drivers? Probably yes, but it's a separate ADR for the SDK shape; out of scope here.
+
+5. **Skill / Memory composition.** ADR-008 governs MCP declarations as one of four primitives in an environment spec. The skills/memory/sandbox primitives don't need MCP exposure — they're driver-side concerns. But the ADR-010 server MUST not break when an env declares both `commonly-mcp` and other MCP servers (e.g., a github MCP). Phase 1 verifies this end-to-end with at least one second MCP server loaded alongside.
+
+6. **Token refresh.** If a runtime token rotates (force=true reprovision), the host needs to restart the MCP server. Today that's "restart the agent runtime"; for Phase 1 we accept manual restart. A future token-refresh signal in the MCP spec would be cleaner.
+
+---
+
+## Rejected alternatives
+
+**"Add `commonly_dm_agent` as an openclaw extension tool, defer MCP indefinitely."** This was the plan before this ADR. It deepens the very driver-coupling we're trying to dilute and gives the CLI-wrapper drivers nothing. Each new cross-driver verb would repeat the fork-PR/submodule-bump dance, and `sam-local-codex` would still have no `commonly_*` surface at all — defeating the kernel-first goal.
+
+**"Build a custom Commonly tool protocol."** We'd be re-inventing MCP. The whole industry has converged on it; agent runtimes already speak it; ADR-008 already references it as a primitive. Inventing parallel infra for no gain.
+
+**"Provisioner-side template substitution (B1) so nova learns the DM podId at heartbeat boot."** Real and viable in the short term, and the path the prior plan converged on. It works, but it makes provisioner the keeper of inter-agent topology — which is exactly the "agents shouldn't depend on the provisioner" concern that triggered this ADR. ADR-010's path lets agents discover topology themselves at runtime, which is the kernel-first answer.
+
+**"Fold this into ADR-008 as another phase."** ADR-008 governs *per-agent declarations* of MCP servers (what the agent points to). ADR-010 governs *the Commonly-side MCP server* (what those declarations point at). They're two different primitives — declaration vs. implementation — and conflating them muddies both. ADR-008 explicitly references ADR-010 (this doc) as the canonical thing the `mcp[]` array entries reference.
+
+**"Wait for CAP v2 and bake MCP into the protocol."** CAP v1 is HTTP and frozen for the right reason — it's deliberately small. The MCP server is a client of CAP; bundling it into the protocol breaks the layering and forces every CAP-conforming driver to understand MCP even if it has its own native shape (webhook drivers, future federated drivers).
+
+---
+
+## What this unlocks
+
+- **Task #5 cutover** becomes mechanical: nova uses `commonly_dm_agent` like any other tool, no fork edit needed.
+- **Every future cross-driver tool** (e.g., `commonly_ask_agent`, `commonly_subscribe_to_pod`) ships in one place — `@commonly/mcp` — and reaches every driver simultaneously.
+- **Openclaw extension's `commonly_*` block becomes retirable**, dropping ~hundreds of lines of fork-resident code that mirror backend routes.
+- **The "any agent runtime" promise** in CLAUDE.md becomes concretely demoable — `commonly agent attach claude --pod X --env env.yaml` (where env.yaml declares `@commonly/mcp` in `mcp[]`) gets a Claude Code instance with full kernel access, zero custom code.
+- **Federation prep**: when ADR-003 Phase 5 (federated memory + remote-runtime drivers) lands, those drivers consume the same MCP surface — federation doesn't reinvent the tool layer.


### PR DESCRIPTION
## Summary

- **New ADR-010**: defines `@commonly/mcp` as a stdio MCP server that exposes CAP (`/api/agents/runtime/*` per ADR-004) plus dual-auth kernel-adjacent routes (`/api/v1/tasks/*`) as standard MCP tools. Any MCP-capable runtime loads one config entry and gets the standard `commonly_*` surface — replacing today's hand-rolled extension at `_external/clawdbot/extensions/commonly/`.
- **Forcing function**: Task #5 (nova HEARTBEAT cuts over to delegate via DM to `sam-local-codex`) needs a new `commonly_dm_agent` verb. Before this ADR, the only path was a fork PR + submodule bump on OpenClaw + nothing for the CLI-wrapper side. This ADR makes future cross-driver verbs land in one place and reach every driver.
- **Cross-refs**: ADR-008 updated (per-agent `mcp[]` declarations point at this server). CLAUDE.md doc index gains ADR-008 + ADR-010 entries.

## What's in the ADR (251 lines)

- **Tool surface (v1)**: 14 tools — message/post/thread, tasks (mapping `/api/v1/tasks/:podId` correctly), pod context, memory, `commonly_dm_agent`. Poll/ack deliberately omitted (turn-time tools only — host runtime owns the event loop).
- **One new HTTP change** (Phase 1): refactor existing `POST /room` (line 531 of `agentsRuntime.ts`) to dual-auth using the established `tasksApi.ts:34-36` pattern. No new endpoint; reuses `DMService.getOrCreateAgentRoom`. The route's own header comment already named this as a known gap.
- **Auth contract**: one token per process (env var `COMMONLY_AGENT_TOKEN`). Token-staleness failure mode and recovery (operator restart) explicitly documented under Auth — not buried as an open question.
- **Phase split**: Phase 1 ships server + endpoint refactor + sam-local-codex wired (no live driver migrates). Phase 2 = OpenClaw migration, gated on openclaw-MCP support investigation (we own the fork; remediation is fork-patching, not an external dependency). Phase 3 = the Task #5 cutover, mechanical once Phase 1 lands.
- **8 load-bearing invariants**, **6 open questions** (including the openclaw-MCP investigation), **5 rejected alternatives** (each with concrete reasoning).

## Why it landed in this shape

Reviewer found three correctness bugs in the first draft (route-collision on `/dm`; wrong URL for thread comments; invariant #2 contradicting the tool table by claiming CAP-only while listing `/api/v1/tasks/*` tools). Fixed by verifying every route against `agentsRuntime.ts` and `tasksApi.ts` and reframing invariant #2 to honestly cover both CAP and dual-auth kernel-adjacent surfaces. Token-rotation and OpenClaw fork ownership also tightened from the review.

## Out of scope (tracked, not in this PR)

- Phase 1 implementation — separate PR, will land `commonly-mcp/` package + the dual-auth refactor + sam-local-codex env wiring.
- Phase 2 OpenClaw migration — separate PR after the openclaw-MCP investigation completes.
- Task #5 nova HEARTBEAT cutover — separate PR after Phase 1 (and ideally Phase 2) ship.

## Test plan

Docs-only — no tests, no CI impact, no runtime change.
- [ ] Reviewer reads ADR-010 end-to-end and challenges the phase split / tool surface
- [ ] Spot-check ADR-008 + CLAUDE.md cross-reference adds render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)