### PR TITLE
chore(deploy-dev): bump helm --timeout 5m → 10m

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -142,7 +142,7 @@ jobs:
             --set agents.clawdbot.image.tag="$TAG" \
             --set agents.commonlyBot.image.tag="$TAG" \
             --wait \
-            --timeout 5m
+            --timeout 10m
 
       - name: Report deploy outcome
         if: always()


### PR DESCRIPTION
## Summary

Documented HANDOFF follow-up: \`Deploy Dev\` shows red cosmetically when \`helm --wait --timeout 5m\` is exceeded by a rolling update that's still in progress. Hit again on the ADR-010 Phase 1 deploy (5m13s, all four deployments rolled out cleanly per kubectl, but workflow exited red).

10 minutes is enough margin for a four-deployment rolling update without masking real failures (a genuinely stuck rollout still times out comfortably within the 30m job ceiling).

## Test plan

- [ ] CI green
- [ ] Next \`workflow_dispatch\` of Deploy Dev exits clean even on a four-deployment rolling update

🤖 Generated with [Claude Code](https://claude.com/claude-code)