### PR TITLE
chore(deploy-dev): bump helm --burst-limit 200 --qps 100

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -142,7 +142,9 @@ jobs:
             --set agents.clawdbot.image.tag="$TAG" \
             --set agents.commonlyBot.image.tag="$TAG" \
             --wait \
-            --timeout 10m
+            --timeout 10m \
+            --burst-limit 200 \
+            --qps 100
 
       - name: Report deploy outcome
         if: always()


### PR DESCRIPTION
## Summary

Helm \`--wait\` has been hitting its **own client QPS limiter** during readiness polling — not pod-rollout-time, not API server throttling. Defaults (qps=50, burst=100 since helm 3.10) are insufficient for a chart with 30+ resources. Bumping to 200/100 doubles the polling budget without taxing the API server.

This is a pragmatic try at fixing the recurring \`client rate limiter Wait returned an error: context deadline exceeded\` that's been present on every helm upgrade since rev 67 (Apr 21). Earlier attempts to fix this by bumping the timeout (#244) or granting the deploy SA RBAC perms (out-of-band manual rolebinding) helped marginally but didn't address the root cause.

## What this is NOT

Not a guaranteed fix — if the QPS theory is wrong we're back to one of: drop \`--wait\` entirely, accept the cosmetic failure, or dig deeper. Either way this is a low-risk one-line change worth trying first.

## Test plan

- [ ] CI green
- [ ] Re-trigger Deploy Dev after merge; helm step completes < 10m without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)