### PR TITLE
fix(cloudflared): GSM-managed credentials.json via ExternalSecret

### DIFF
--- a/k8s/helm/commonly/templates/cloudflared/external-secret.yaml
+++ b/k8s/helm/commonly/templates/cloudflared/external-secret.yaml
@@ -1,0 +1,73 @@
+{{- /*
+ExternalSecret for the cloudflared tunnel credentials.
+
+Pulls `commonly-cloudflare-tunnel-token` from GSM (the canonical Cloudflare
+tunnel-token form, which is base64-encoded JSON `{a,t,s}`) and emits the
+chart's expected `credentials.json` shape `{AccountTag,TunnelID,TunnelSecret}`
+into the `cloudflared-commonly-k8s` Secret in the cloudflared namespace.
+
+Without this, the cloudflared deployment is stuck waiting for a secret that
+no chart template creates. Pre-2026-04-27 the secret was set up manually post-
+GKE-migration; this template makes it reproducible across cluster rebuilds.
+See `project-cloudflared-helm-fix.md` for the diagnosis history.
+
+Auth model: uses ClusterSecretStore (cluster-scoped) because the namespace-
+scoped SecretStore at `templates/secrets/secretstore.yaml` lives in
+commonly-dev and ESO's namespace-scoped SecretStore requires same-namespace
+auth, but the cloudflared deployment is in ingress-nginx. The
+ClusterSecretStore references `gcpsm-secret` in commonly-dev via an explicit
+secretRef.namespace, which the cluster-scoped variant supports.
+
+Helm template + ESO go template double-escape: backtick-literal blocks
+preserve the ESO template intact through Helm rendering.
+*/ -}}
+{{- if and .Values.cloudflared.enabled .Values.externalSecrets.enabled -}}
+{{- $cloudflaredNs := .Values.cloudflared.namespace | default (include "commonly.namespace" .) -}}
+{{- $clusterStoreName := printf "%s-cluster" .Values.externalSecrets.secretStore.name -}}
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: {{ $clusterStoreName }}
+spec:
+  provider:
+    gcpsm:
+      projectID: {{ .Values.externalSecrets.secretStore.projectId | quote }}
+      auth:
+        {{- if .Values.externalSecrets.workloadIdentity.enabled }}
+        workloadIdentity:
+          serviceAccountRef:
+            name: {{ .Values.externalSecrets.workloadIdentity.serviceAccountName }}
+            namespace: {{ include "commonly.namespace" . }}
+        {{- else }}
+        secretRef:
+          secretAccessKeySecretRef:
+            name: gcpsm-secret
+            key: secret-access-credentials
+            namespace: {{ include "commonly.namespace" . }}
+        {{- end }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.cloudflared.credentialsSecretName }}
+  namespace: {{ $cloudflaredNs }}
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: {{ $clusterStoreName }}
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Values.cloudflared.credentialsSecretName }}
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        credentials.json: |
+          {{ `{{- $t := .raw | b64dec | fromJson -}}` }}
+          {{ `{"AccountTag":"{{ $t.a }}","TunnelID":"{{ $t.t }}","TunnelSecret":"{{ $t.s }}"}` }}
+  data:
+    - secretKey: raw
+      remoteRef:
+        key: commonly-cloudflare-tunnel-token
+{{- end }}


### PR DESCRIPTION
## Summary

Closes the long-standing gap where the chart's cloudflared deployment references a secret (\`cloudflared-commonly-k8s\` with key \`credentials.json\`) that no chart template creates. Pre-2026-04-27 this had to be done manually post-GKE migration; in practice it never happened, the deployment was stuck at 1/2 ready for 16 days, and helm \`--wait\` timed out every Deploy Dev run since rev 67 (Apr 21).

## What this template adds

- **ClusterSecretStore** \`gcpsm-secretstore-cluster\` — cluster-scoped because cloudflared lives in \`ingress-nginx\` namespace, not \`commonly-dev\`. Namespace-scoped SecretStores require same-namespace auth, but the GSM auth secret (\`gcpsm-secret\`) lives in \`commonly-dev\`. The cluster-scoped variant references it via \`secretRef.namespace\`.
- **ExternalSecret** in \`ingress-nginx\` that pulls \`commonly-cloudflare-tunnel-token\` from GSM and uses ESO v2 sprig templating to transform \`{a,t,s}\` (Cloudflare's abbreviated tunnel-token form, base64-encoded JSON) into the chart-expected \`{AccountTag,TunnelID,TunnelSecret}\` shape and emit it as \`credentials.json\`.

## Sequencing

This pairs with the manual one-time fix applied 2026-04-27. After this lands:

1. \`commonly-dev\` namespace already has all required dependencies (\`gcpsm-secret\`, the existing SecretStore for \`commonly-dev\` proves auth works).
2. Helm upgrade creates the ClusterSecretStore + the ExternalSecret in \`ingress-nginx\`.
3. ESO with \`creationPolicy: Owner\` will conflict with the manual secret. **Before deploy:** delete the manual secret OR transfer ownership via annotation. The new secret will be functionally identical.
   \`\`\`bash
   kubectl delete secret cloudflared-commonly-k8s -n ingress-nginx
   # then helm upgrade — ESO recreates with credentials.json on first sync (≤24h, manual force-sync below)
   kubectl annotate externalsecret cloudflared-commonly-k8s force-sync=\$(date +%s) -n ingress-nginx --overwrite
   \`\`\`

## Test plan

- [ ] CI: Chart Lint (Tier 1.5) renders + kubeconforms cleanly
- [ ] Post-merge: pre-deploy step (delete manual secret), then Deploy Dev runs cleanly
- [ ] Post-deploy: \`kubectl get externalsecret cloudflared-commonly-k8s -n ingress-nginx\` → STATUS \`SecretSynced\`, READY \`True\`
- [ ] Cloudflared deployment stays 2/2 ready
- [ ] Once verified, the legacy \`cloudflared-token\` secret in \`ingress-nginx\` can be deleted (no chart resources reference it)

## Background

See \`project-cloudflared-helm-fix.md\` (memory) for the full diagnosis: this issue caused 4 rounds of wrong-theory chasing (timeout #244, RBAC manual rolebinding, helm QPS #245) before being identified as a missing-secret blocker, not a cosmetic helm timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)