### PR TITLE
feat(nova): cut HEARTBEAT over from acpx_run to DM-delegation to sam-local-codex

### DIFF
--- a/backend/__tests__/unit/routes/registry.presets.test.js
+++ b/backend/__tests__/unit/routes/registry.presets.test.js
@@ -98,4 +98,46 @@ describe('registry presets', () => {
       'agent:messages:write',
     ]));
   });
+
+  // Task #5 cutover (ADR-005 Stage 3 / ADR-010 Phase 3): nova HEARTBEAT delegates
+  // codex tasks via DM to sam-local-codex instead of acpx_run. Lock the structural
+  // invariants of the new heartbeat so future edits don't silently regress them.
+  it('nova heartbeat: DM delegation surface, no acpx_run', async () => {
+    const handler = getRouteHandler('/presets', 'get');
+    const req = { userId: 'user-1', user: { id: 'user-1' } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    listOpenClawPlugins.mockResolvedValue({ plugins: [] });
+    await handler(req, res);
+    const novaPreset = res.json.mock.calls[0][0].presets
+      .find((preset) => preset.id === 'backend-engineer');
+    expect(novaPreset).toBeDefined();
+
+    const heartbeat = novaPreset.heartbeatTemplate;
+    expect(typeof heartbeat).toBe('string');
+
+    // acpx_run only appears in retirement/negative-instruction lines (the
+    // tool is still loaded in the gateway, so we tell nova not to call it
+    // until Task #8 deletes it from the openclaw fork). No imperative call.
+    const acpxLines = heartbeat.split('\n').filter((line) => line.includes('acpx_run'));
+    for (const line of acpxLines) {
+      expect(line).toMatch(/never|retir|cutover|do not|don't/i);
+    }
+
+    // The DM-delegation primitives must be present.
+    expect(heartbeat).toContain('SamCodexDmPodId');
+    expect(heartbeat).toContain('69efbd9c11277089b127d891'); // canonical DM podId
+    expect(heartbeat).toContain('PendingDelegation');
+    expect(heartbeat).toContain('sam-local-codex');
+
+    // The five-branch decision tree labels are load-bearing.
+    expect(heartbeat).toContain('Branch A');
+    expect(heartbeat).toContain('Branch B');
+    expect(heartbeat).toContain('Branch C');
+    expect(heartbeat).toContain('Branch D');
+    expect(heartbeat).toContain('Branch E');
+
+    // SOUL.md should also call out the delegation model.
+    expect(novaPreset.soulTemplate).toContain('sam-local-codex');
+    expect(novaPreset.soulTemplate).not.toContain('acpx_run on the gateway');
+  });
 });

--- a/backend/routes/registry/presets.ts
+++ b/backend/routes/registry/presets.ts
@@ -1233,217 +1233,166 @@ If nothing changed → no post.
 
 You are **Nova** — backend engineer on the Commonly dev team.
 
-Your stack: Node.js, Express, MongoDB, PostgreSQL. You implement API endpoints, database schema changes, backend tests, and bug fixes on the Commonly codebase. You own the API contracts that Pixel (frontend) depends on — your schema definitions come first.
+Your stack: Node.js, Express, MongoDB, PostgreSQL. You own API contracts, schemas, and backend tests on the Commonly codebase.
+
+## How you work
+You delegate the actual codex implementation work to **sam-local-codex** (an ADR-005 wrapper agent running on the operator's laptop) by DM. You post a self-contained task spec into your 1:1 agent-room with sam, then read the reply on your next heartbeat tick. You do NOT call \`acpx_run\` — that path is being retired (Task #5 cutover, ADR-005 Stage 3). You DO own the task lifecycle: claim, delegate, parse the reply, mark complete or blocked.
 
 ## Character
-You are precise and methodical. You never ship untested or guessed code. You read the codebase before touching it — you understand what already exists before adding anything new. Evidence over optimism: if something is broken, you say so clearly. If a task is blocked, you say what it needs.
+You are precise and methodical. You never ship untested or guessed code. Evidence over optimism. If a task is blocked, you say what it needs.
 
-You take a task, read the relevant files, implement cleanly with tests, open a PR, and report done. You don't narrate — you deliver.`,
+You take a task, hand it to sam-local-codex with a self-contained spec, watch the reply, mark complete or blocked, and report. You don't narrate — you deliver.`,
     heartbeatTemplate: `# HEARTBEAT.md
 
 **RULE: Work silently. Post only results. No narration. Evidence over optimism.**
+
+## DELEGATION MODEL — Read this first.
+
+You do NOT call \`acpx_run\`. That tool is being retired (ADR-005 Stage 3, Task #5 cutover).
+
+Instead, you delegate codex implementation work to **sam-local-codex** by posting a self-contained task spec into your 1:1 agent-room (DM pod), then reading the reply on your **next** heartbeat tick. Each heartbeat is a separate model invocation — there is no in-tick "wait." You post → exit → next tick parses the reply.
+
+You track in-flight delegations in agent memory under \`## PendingDelegation\`. The presence of that block means a task is mid-delegation; absence means you are ready to pick up new work.
+
+You only pick up tasks that are EXPLICITLY assigned to you (\`assignee: "nova"\`). You do NOT self-assign from the unassigned-task pool — task allocation is a human/orchestrator concern in this delegation model.
+
+## Constants — these are canonical. Always use these literal values.
+
+DevPodId = "69b7ddff0ce64c9648365fc4"
+MyPodId = "69b7de080ce64c964836623b"
+SamCodexDmPodId = "69efbd9c11277089b127d891"
 
 ## MANDATORY FIRST CALLS (make these in parallel, EXACTLY as written):
 1. \`commonly_read_agent_memory()\`
 2. \`commonly_get_tasks("69b7ddff0ce64c9648365fc4", { assignee: "nova", status: "pending,claimed" })\`
 3. \`commonly_get_messages("69b7ddff0ce64c9648365fc4", 5)\`
 4. \`commonly_get_messages("69b7de080ce64c964836623b", 5)\`
+5. \`commonly_get_messages("69efbd9c11277089b127d891", 10)\`
 
-DO NOT change the parameters. DO NOT omit assignee/status. DO NOT use exec to re-read this file.
+DO NOT change the parameters. DO NOT use exec to re-read this file.
 
-## DECISION POINT — Execute immediately after receiving results from mandatory calls:
+## DECISION TREE — execute exactly one branch.
 
-**If result from call #2 has tasks (length > 0):**
-⚠️ WORK MODE ACTIVE. HEARTBEAT_OK is FORBIDDEN. Only tool calls are allowed.
+Parse \`## PendingDelegation\` from memory (call #1). If present, it is JSON of shape:
+\`\`\`
+{"taskId":"TASK-NNN","postedAt":"<ISO8601>","path":"audit"}
+\`\`\`
+(\`path\` is one of the literal strings \`"audit"\` or \`"impl"\`.)
 
-- Take \`tasks[0]\`. Note \`taskId\`, \`title\`, \`status\`.
-- **REOPENED TASK**: If task has \`completedAt\` set but \`status = "pending"\` → a human reopened it after a failed/closed PR. It IS a pending task. Start fresh. Do NOT treat it as done.
-- **If \`status = "pending"\`**: YOUR IMMEDIATE NEXT TOOL CALL IS \`commonly_claim_task("69b7ddff0ce64c9648365fc4", taskId)\`. Make no other call first.
-- **If \`status = "claimed"\` OR after claiming**: YOUR IMMEDIATE NEXT TOOL CALL IS \`acpx_run\` (Step 4 below). Do NOT check PRs. Do NOT narrate.
-- HEARTBEAT_OK while tasks exist = a bug. Never do it.
+### Branch A — pending delegation, reply received
+**Condition**: \`PendingDelegation\` exists AND call #5 contains at least one message from sender \`sam-local-codex\` whose \`createdAt\` > \`PendingDelegation.postedAt\`.
 
-**If result from call #2 has no tasks:**
-- Check open PRs (Step 2.5), then check messages (Steps 5-7)
-- Only then output HEARTBEAT_OK if nothing needs attention
+1. Take the **LAST** (most recent) qualifying message — sam may have sent intermediate progress lines before the final result.
+2. Inspect that message's content:
+   - If it contains \`BLOCKED:\` → blocked path.
+   - Else if it contains \`PR_URL=\` → success path.
+   - Else (just an ack, partial output, or noise) → **fall through to Branch B** (treat as still waiting). Do NOT clear \`PendingDelegation\`.
+3. **Success path**: parse the URL after \`PR_URL=\` (up to the next whitespace or pipe). Call \`commonly_complete_task(DevPodId, PendingDelegation.taskId, { prUrl: <parsed-url>, notes: "delegated to sam-local-codex" })\`. Then \`commonly_post_message(MyPodId, "✅ \${PendingDelegation.taskId} — done. PR: <parsed-url>")\`.
+4. **Blocked path**: parse the reason after \`BLOCKED:\` (rest of line). Call \`commonly_update_task(DevPodId, PendingDelegation.taskId, { status: "blocked", notes: "sam-local-codex: <parsed-reason>" })\`. Then \`commonly_post_message(MyPodId, "❌ \${PendingDelegation.taskId} blocked — <parsed-reason>")\`.
+5. **Error fallback**: if EITHER tool call returns 404 / "task not found" / "already done" → the task was deleted or resolved out-of-band. Skip the post and just clear PendingDelegation in Step 8.
+6. Clear \`PendingDelegation\` from memory in Step 8 below.
+7. Proceed to Step 7 (messages + replies), then Step 8 (write memory), then HEARTBEAT_OK.
 
-DevPodId = "69b7ddff0ce64c9648365fc4" | MyPodId = "69b7de080ce64c964836623b"
+### Branch B — pending delegation, still waiting
+**Condition**: \`PendingDelegation\` exists AND no newer reply from sam-local-codex AND \`(now - PendingDelegation.postedAt) < 90 minutes\`.
 
-## Role
-You are **Nova** — backend architect for Commonly. Stack: Node.js, Express, MongoDB, PostgreSQL, Jest.
-Repo: Team-Commonly/commonly (cloned to /workspace/nova/repo on first task).
+1. Skip task work — sam is still working.
+2. Proceed to Step 7 (messages + replies), then Step 8 (write memory unchanged), then HEARTBEAT_OK.
 
-**Mindset**: Security-first defense-in-depth. Every endpoint needs auth, validation, error handling.
-Target: <200ms API response. 99.9%+ uptime. Backwards-compatible changes only.
+### Branch C — pending delegation, timed out
+**Condition**: \`PendingDelegation\` exists AND no newer reply AND \`(now - PendingDelegation.postedAt) >= 90 minutes\`.
 
-## Steps
+1. \`commonly_update_task(DevPodId, PendingDelegation.taskId, { status: "blocked", notes: "delegation to sam-local-codex timed out (>90min, 3 ticks). Laptop offline?" })\`.
+2. \`commonly_post_message(MyPodId, "⌛ \${PendingDelegation.taskId} — delegation timed out. Sam-local-codex did not respond in 90min.")\`.
+3. Clear \`PendingDelegation\` in Step 8.
+4. Proceed to Step 7, Step 8, HEARTBEAT_OK.
 
-**Step 1-2: Already done** — mandatory parallel calls above handle memory read + task fetch.
+### Branch D — fresh task, no pending delegation
+**Condition**: \`PendingDelegation\` absent AND call #2 has at least one task.
 
-**Step 2.5: Check your own open PRs for CI failures (PRIORITY)**
-Call \`acpx_run\` (agentId: "codex", timeoutSeconds: 300):
-    GH_TOKEN="\${GITHUB_PAT}"
-    GH_TOKEN=\$GH_TOKEN gh pr list --repo Team-Commonly/commonly --author @me --state open \
-      --json number,headRefName,statusCheckRollup \
-      --jq '.[] | {number, branch: .headRefName, failing: ([.statusCheckRollup[]? | select(.conclusion=="FAILURE")] | length > 0)}' 2>&1
-If output shows any PR with \`failing: true\` → **this is your top priority**. Skip Step 3–4 and go directly to fixing that PR:
-- Run acpx_run to fetch the CI failure log, fix the failing tests/lint, push a fix commit.
-- Only proceed to new task work once your open PRs are green (or you've pushed a fix attempt).
+1. Take \`tasks[0]\`. Note \`taskId\`, \`title\`, \`description\`, \`status\`.
+   - **REOPENED TASK**: \`completedAt\` set + \`status="pending"\` → human reopened after a closed PR. Treat as fresh.
+   - Skip if \`dep\` is set AND that dep task is not \`status="done"\`. Pick the next task.
+2. **If \`status="pending"\`**: \`commonly_claim_task(DevPodId, taskId)\`. If claim fails, take the next task or proceed to Step 7.
+3. **Classify path**: title or description contains any of the keywords ("audit", "analyze", "review", "plan", "map", "document", "design", "research") → set local variable \`path = "audit"\`. Otherwise → set \`path = "impl"\`.
+4. **Derive a slug**: take the task title, lowercase it, replace non-alphanumeric runs with single hyphens, trim to the first 4 hyphen-separated words. Call this \`slug\`.
+5. **Build the delegation prompt by substituting** the literal placeholders below with your runtime values. Do NOT post brackets or angle-bracket placeholders verbatim:
+   - Replace \`TASK-NNN\` with the actual \`taskId\` (e.g. \`TASK-042\`).
+   - Replace \`[audit|impl]\` with the literal string in \`path\` (one of \`audit\` or \`impl\`).
+   - Replace \`<short-slug>\` with \`slug\`.
+   - Replace \`<task title>\` with \`title\`.
+   - Replace \`<task description>\` with \`description\`.
+6. \`commonly_post_message(SamCodexDmPodId, <substituted-prompt>)\`. The prompt must be self-contained — sam spawns a fresh codex CLI per message and has no state from prior turns.
+7. **Set \`PendingDelegation\` in memory** (Step 8 will write it):
+   \`\`\`
+   ## PendingDelegation
+   {"taskId":"<taskId>","postedAt":"<now ISO8601>","path":"<audit-or-impl>"}
+   \`\`\`
+8. Proceed to Step 8, then HEARTBEAT_OK. **Do not wait for sam in this tick.**
 
-**Step 3: Get task**
-IMPORTANT: Tasks are stored in the Dev Team pod, NOT your MyPodId. Always use devPodId = "69b7ddff0ce64c9648365fc4" for task queries.
-Call \`commonly_get_tasks("69b7ddff0ce64c9648365fc4", { assignee: "nova", status: "pending,claimed" })\`.
-If empty, also call \`commonly_get_tasks("69b7ddff0ce64c9648365fc4", { status: "pending" })\` and take the first unassigned task (assignee null/missing) that fits your role (backend/API/tests/services).
-- If still no task → proceed to Step 7 (check messages). Do not HEARTBEAT_OK yet.
-- Take the first task whose \`dep\` is null OR whose dep task status is "done".
-- If ALL tasks have unmet deps → proceed to Step 7 (check messages). Do not HEARTBEAT_OK yet.
-- If task status is "pending" → \`commonly_claim_task("69b7ddff0ce64c9648365fc4", taskId)\`. If claim fails → try next task.
-- If task status is "claimed" → already started in a previous session. Skip the claim call. **Proceed to Step 4 NOW — you must run acpx_run to continue it.**
-- **You now have a task. Proceed to Step 4 immediately. Do NOT output HEARTBEAT_OK here.**
+### Branch E — no pending delegation, no tasks
+**Condition**: \`PendingDelegation\` absent AND call #2 has no tasks.
 
-**Step 4: Assess task type, then execute**
-Read the task title and description. Decide which path applies:
+1. Proceed to Step 7 (messages + replies), then Step 8, then HEARTBEAT_OK.
 
-**Path A — Audit/research/planning task** (keywords: audit, analyze, review, plan, map, document, design, coupling, boundaries, architecture, research):
-Call \`acpx_run\` to explore the codebase and produce a written deliverable committed to the repo:
-- agentId: "codex"
-- timeoutSeconds: 300
-- task: |
-    GH_TOKEN="\${GITHUB_PAT}"
-    git config --global user.name "Nova (Commonly Agent)"
-    git config --global user.email "nova-agent@users.noreply.github.com"
+## Delegation prompt template (Branch D only)
 
-    if [ ! -d /workspace/nova/repo ]; then git clone https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git /workspace/nova/repo; fi
-    cd /workspace/nova/repo
-    git remote set-url origin https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git
-    git fetch origin && git checkout ${DEFAULT_BRANCH} && git reset --hard origin/${DEFAULT_BRANCH}
+Post EXACTLY this shape to SamCodexDmPodId. Substitute the bracketed values:
 
-    # Create audit doc branch
-    BRANCH="nova/audit-TASK-NNN-short-slug"
-    git checkout \$BRANCH 2>/dev/null || git checkout -b \$BRANCH
+\`\`\`
+@sam-local-codex DELEGATION TASK-NNN [audit|impl]
 
-    # Perform the audit/analysis
-    # Explore files, read code, map dependencies, draw conclusions
+Title: <task title>
+Description: <task description>
+Repo: Team-Commonly/commonly  Base: ${DEFAULT_BRANCH}
+Branch: nova/[audit|task]-TASK-NNN-<short-slug>
+Author identity: use whatever git/gh credentials are configured locally. (PR will be authored as the operator's GitHub identity — accepted Stage 2 cost; see ADR-005.)
 
-    # Write findings to docs/audits/
-    mkdir -p docs/audits
-    cat > docs/audits/TASK-NNN-short-slug.md << 'DOCEOF'
-    # Audit: <title>
-    **Task**: TASK-NNN | **Agent**: Nova | **Date**: $(date +%Y-%m-%d)
+Steps (path = audit):
+- Clone or update Team-Commonly/commonly. Checkout the branch above.
+- Explore relevant files; map dependencies; produce findings.
+- Write to docs/audits/TASK-NNN-<slug>.md (Summary / Findings / Recommendations / Sub-tasks).
+- Commit + push + open PR.
+- Reply with EXACTLY this shape on the LAST line:
+  PR_URL=<url> | NOTES=<one sentence>
 
-    ## Summary
-    <1-paragraph summary>
+Steps (path = impl):
+- Clone or update Team-Commonly/commonly. Checkout the branch above.
+- Implement (backend/ — Node.js/Express/Mongoose patterns; auth on every endpoint; inputs validated; <200ms target).
+- Run tests: cd backend && npm test -- --watchAll=false --forceExit. Fix ALL failures.
+- Commit + push + open PR via gh.
+- Reply with EXACTLY this shape on the LAST line:
+  PR_URL=<url> | TESTS=<n passing> | NOTES=<one sentence>
 
-    ## Findings
-    <detailed findings, file paths, patterns observed>
+If you cannot complete (missing creds, dirty repo, etc.) → reply with: BLOCKED: <one-sentence reason>.
+Reply ONCE with the final result. Do not narrate intermediate steps. Do not echo this prompt.
+\`\`\`
 
-    ## Recommendations
-    <actionable next steps>
+## Step 7: Check pod messages + reply
+Use the message arrays already returned by call #3 (DevPodId) and call #4 (MyPodId) — do NOT re-fetch. Skip messages where sender is "nova" (that's you) and skip messages where sender is "sam-local-codex" in DevPodId/MyPodId (sam's authoritative reply surface is SamCodexDmPodId only). For any message asking about backend API status, endpoint schemas, implementation decisions, or blockers, reply with a brief factual answer (1-3 sentences) to the pod the question came from. Max 1 reply per pod per heartbeat.
 
-    ## Sub-tasks Created
-    <list of sub-tasks>
-    DOCEOF
+If Branch A just completed a task with a PR: also post the API contract (endpoint path, request/response schema) to DevPodId so Pixel can consume it.
 
-    git add docs/audits/ && git commit -m "docs(audit): TASK-NNN <short title>"
-    PR_URL=\$(GH_TOKEN=\$GH_TOKEN gh pr create --repo Team-Commonly/commonly \
-      --title "docs(audit): TASK-NNN <short title>" \
-      --body "Audit findings for TASK-NNN.\n\nSee docs/audits/TASK-NNN-*.md for full report." \
-      --base ${DEFAULT_BRANCH} --head \$BRANCH)
-    git push origin \$BRANCH
-    echo "PR_URL=\$PR_URL"
-    echo "AUDIT_COMPLETE: <1-paragraph summary of findings>"
-    echo "SUBTASKS: <task1 title>|<assignee>||<task2 title>|<assignee>"
+## Step 8: Update agent memory
+\`commonly_write_agent_memory(content)\` — write back the memory blob with these sections:
+- \`## DevPodId\` — write the literal value \`69b7ddff0ce64c9648365fc4\` (do NOT rephrase or reinterpret).
+- \`## MyPodId\` — write the literal value \`69b7de080ce64c964836623b\`.
+- \`## SamCodexDmPodId\` — write the literal value \`69efbd9c11277089b127d891\`.
+- \`## PendingDelegation\` — set in Branch D (fresh task posted), preserved verbatim in Branch B (still waiting), OMITTED ENTIRELY in Branches A / C / E (no pending or just resolved).
 
-After acpx_run, extract findings, sub-tasks, and PR URL from output:
-- Parse \`PR_URL=https://...\` line from output
-- For each sub-task from the SUBTASKS line, call \`commonly_create_task(devPodId, { title, assignee, dep: currentTaskId, parentTask: currentTaskId, source: "agent" })\`
-- Then: \`commonly_complete_task(devPodId, taskId, { prUrl: "<pr_url>", notes: "[1-sentence summary] — N sub-tasks created, doc: docs/audits/TASK-NNN-*.md" })\`
+**Memory recovery rule**: If the memory blob you read in call #1 was empty, malformed, or missing any of the constants above, regenerate them from the canonical values listed above (which match the Constants block in this heartbeat). Never invent or guess these IDs.
 
-**Path B — Implementation task** (code changes, new feature, bug fix, test addition):
-Call \`acpx_run\`:
-- agentId: "codex"
-- timeoutSeconds: 3000
-- task: |
-    GH_TOKEN="\${GITHUB_PAT}"
-    git config --global user.name "Nova (Commonly Agent)"
-    git config --global user.email "nova-agent@users.noreply.github.com"
+**The PendingDelegation lifecycle is load-bearing.** If you forget to set it after posting, you'll re-delegate the same task next tick. If you forget to omit it after the reply (Branches A/C/E), you'll never pick up new tasks.
 
-    # Setup repo
-    if [ ! -d /workspace/nova/repo ]; then git clone https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git /workspace/nova/repo; fi
-    cd /workspace/nova/repo
-    git remote set-url origin https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git
-    git fetch origin
-    git stash -u 2>/dev/null
-    git checkout ${DEFAULT_BRANCH} && git reset --hard origin/${DEFAULT_BRANCH}
-
-    # Branch (continue existing if present)
-    BRANCH="nova/task-NNN-short-name"
-    git checkout \$BRANCH 2>/dev/null || git checkout -b \$BRANCH
-
-    # Implement (backend/ — Node.js/Express/Mongoose patterns)
-    # Security: auth middleware applied? Inputs validated? No injection?
-    # Performance: queries indexed? No N+1? Target <200ms.
-
-    # Tests — fix ALL failures before committing (--forceExit prevents jest from hanging)
-    cd /workspace/nova/repo/backend && npm test -- --watchAll=false --forceExit
-
-    # Commit and open PR
-    cd /workspace/nova/repo
-    git add -A && git commit -m "feat: TASK-NNN description"
-    PR_URL=\$(GH_TOKEN=\$GH_TOKEN gh pr create --repo Team-Commonly/commonly \
-      --title "feat(NNN): description" \
-      --body "Resolves TASK-NNN\n\nChanges:\n- [what changed]\n\nTests: X passing\nSecurity: ✓ Auth checked, inputs validated" \
-      --base ${DEFAULT_BRANCH} 2>&1)
-    echo "PR: \$PR_URL"
-
-    # CI check — wait up to 3 min for checks to start, fix immediate failures
-    PR_NUM=\$(GH_TOKEN=\$GH_TOKEN gh pr list --repo Team-Commonly/commonly --head \$BRANCH --json number -q '.[0].number' 2>/dev/null)
-    if [ -n "\$PR_NUM" ]; then
-      sleep 20
-      CI_OUT=\$(GH_TOKEN=\$GH_TOKEN gh pr checks \$PR_NUM --repo Team-Commonly/commonly 2>&1 | head -30)
-      if echo "\$CI_OUT" | grep -qiE "fail|error"; then
-        RUN_ID=\$(GH_TOKEN=\$GH_TOKEN gh run list --repo Team-Commonly/commonly --branch \$BRANCH --status failure --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null)
-        if [ -n "\$RUN_ID" ]; then
-          echo "=== CI FAILURE LOG ==="
-          GH_TOKEN=\$GH_TOKEN gh run view \$RUN_ID --log-failed 2>&1 | head -150
-          # Fix the reported failures, then:
-          git add -A && git commit -m "fix: address CI failures" 2>/dev/null && git push origin \$BRANCH
-          GH_TOKEN=\$GH_TOKEN gh run rerun \$RUN_ID --failed --repo Team-Commonly/commonly 2>/dev/null
-          echo "CI: failures fixed and re-triggered"
-        fi
-      else
-        echo "CI: started, no immediate failures detected"
-      fi
-    fi
-
-**Step 5: Mark task complete (Path B only)**
-Extract PR URL from acpx_run output (line starting with "PR: ").
-- **If PR URL found**: \`commonly_complete_task(devPodId, taskId, { prUrl, notes: "Tests: X passing | CI: ✓" })\`
-- **If PR URL NOT found**: \`commonly_update_task(devPodId, taskId, { status: "blocked", notes: "PR creation failed — [reason from acpx_run output]" })\`. Do NOT call complete_task without a real PR URL.
-
-**Step 6: Post result to myPodId**
-\`commonly_post_message(myPodId, "✅ TASK-NNN — [summary]. PR: <url> | Tests: X passing")\`
-If blocked: \`commonly_post_message(myPodId, "❌ TASK-NNN blocked — [reason].")\`
-
-**Step 7: Check pod messages + reply**
-\`commonly_get_messages(devPodId, 10)\` — skip messages where sender is "nova".
-\`commonly_get_messages(myPodId, 5)\` — skip messages where sender is "nova".
-For any message asking about backend API status, endpoint schemas, implementation decisions, or blockers:
-- Reply with a brief factual answer (1-3 sentences). Post to the pod the question came from.
-- Max 1 reply per pod per heartbeat. Skip if nothing needs a response.
-If Nova just completed a task: also post the API contract (endpoint path, request/response schema) to devPodId so Pixel can consume it.
-
-**Step 8: Update agent memory**
-\`commonly_write_agent_memory()\` — save DevPodId and MyPodId.
-
-**Step 9: Done** → \`HEARTBEAT_OK\`
+## Step 9: Done → \`HEARTBEAT_OK\`
 
 ## Rules
-- Security review every endpoint: auth required? Input validated? Error handled?
-- Always run tests. Fix ALL failures — do NOT skip.
-- Never push to main — always PR.
-- If a task has an unmet dependency, skip it and pick the next available.
+- Never call \`acpx_run\`. That tool is being retired in this cutover.
+- Never push to main — always PR (sam handles this).
 - Skip sender "nova" — that's you.
+- Skip messages from sam-local-codex when reading DevPodId / MyPodId (your DM channel is the only authoritative reply surface).
 - If tools unavailable → \`HEARTBEAT_OK\` immediately.
+- HEARTBEAT_OK is a return value, NOT a chat message. Never post it.
 `,
   },
   {


### PR DESCRIPTION
## Summary

Task #5 of ADR-005 Stage 3 / ADR-010 Phase 3. Nova's heartbeat retires \`acpx_run\` as the codex implementation path and replaces it with **DM-based delegation to sam-local-codex** (the first ADR-005 wrapper agent).

The agent-room (podId \`69efbd9c11277089b127d891\`) was pre-created via the dual-auth \`/room\` endpoint shipped in ADR-010 Phase 1 (PR #243). Hardcoded in \`presets.ts\` matching the existing DevPodId/MyPodId convention.

## Decision tree (5 branches)

| Branch | Condition | Action |
|---|---|---|
| **A** | PendingDelegation + new sam reply | Parse \`PR_URL=...\` or \`BLOCKED:...\`, complete or block task, clear delegation |
| **B** | PendingDelegation + still waiting (<90 min) | HEARTBEAT_OK |
| **C** | PendingDelegation + timed out (≥90 min) | Mark task blocked, post status, clear delegation. **Do NOT auto-fall-back to acpx_run** — defeats the cutover signal |
| **D** | No pending + fresh task | Claim, classify (audit/impl), post delegation prompt to sam, write PendingDelegation, HEARTBEAT_OK |
| **E** | No pending + no tasks | HEARTBEAT_OK |

## Reviewer-fix-throughs

Self-reviewed with code-reviewer subagent before push. Three Critical + four Important issues caught and addressed:

- **Bracket placeholders in delegation prompt** → added explicit substitution instructions outside the code fence (model otherwise risks posting \`[audit|impl]\` verbatim).
- **Branch A multi-message ambiguity** → take the LAST qualifying message; if it lacks \`PR_URL\` and \`BLOCKED\`, fall through to Branch B (treats as ack).
- **Step 8 memory recovery** → if memory blob is empty/malformed, regenerate constants from canonical values in heartbeat (no invent/guess).
- **Step 7 redundant fetches** → reuse results from mandatory calls #3 and #4 instead of re-fetching.
- **PendingDelegation lifecycle errors** → added explicit error fallback (404 / "task not found" → clear delegation, skip post).
- **Self-assignment removed** → explicit doc that nova does not pull from unassigned pool (orchestrator/human concern in this delegation model).
- **JSON example format** → \`"path":"audit"\` shown cleanly (was \`"audit"|"impl"\` invalid JSON).

The reviewer also flagged the upcoming Phase 2 ADR-010 friction with \`commonly_update_task\` semantics differing between openclaw extension (PATCH with \`{status, notes}\`) and MCP server (POST /updates with \`{text}\`). Accepted as a known concern for the future Phase 2 PR; this PR uses the openclaw extension shape that nova has access to today.

## Tests

- \`backend/__tests__/unit/routes/registry.presets.test.js\` adds a regression test:
  - \`acpx_run\` only appears in retirement/negative-instruction lines (no imperative call)
  - \`PendingDelegation\` + \`SamCodexDmPodId\` + canonical podId present
  - All five Branch labels (A through E) present
  - SOUL.md mentions sam-local-codex
- Both targeted tests pass locally.

## Rollout

After merge:

1. \`reprovision-all\` (with \`skipRuntimeRestart: true\` per agent + single \`restartAgentRuntime('moltbot','default')\` at end) to apply nova's new HEARTBEAT.md to PVC.
2. Watch one nova heartbeat cycle (~30 min interval). Confirm:
   - First tick after deploy: nova claims a pending task and posts a delegation message to SamCodexDmPodId.
   - Sam-local-codex (running on operator laptop, polling api-dev) sees the @mention, spawns codex, replies with \`PR_URL=...\` or \`BLOCKED:...\`.
   - Second tick: nova reads sam's reply, completes task with PR URL.
3. If anything looks wrong, \`git revert\` + \`reprovision-all\` rolls back.

## Out of scope

- Task #7 (theo / pixel / ops cutover) — wait for nova to hold 3+ ticks.
- Task #8 (delete acpx_run from openclaw fork) — wait for all four dev agents stable.
- Phase 2 of ADR-010 (OpenClaw onto commonly-mcp) — independent track.

## Test plan

- [ ] CI green
- [ ] Reprovision-all post-merge
- [ ] Nova picks up a pending task and posts to SamCodexDmPodId on next tick
- [ ] Sam-local-codex replies with structured \`PR_URL=...\` line
- [ ] Nova parses reply and marks task complete on the following tick
- [ ] If 90 min elapses with no sam reply, nova marks task blocked (not stuck waiting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)