### PR TITLE
docs(adr-011): pause kernel work, declare shell-first pre-GTM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,21 +135,25 @@ Commonly is collapsing the legacy `App` + `AgentRegistry` split into a single `I
 
 ### Active Implementation Tracks (April 2026)
 
+**Strategic mode: shell-first pre-GTM (ADR-011, 2026-04-27).** Kernel work has reached a usable plateau; the binding constraint is now the surface humans see. Below, "🟢 active" tracks are in scope; "⏸️ paused" tracks have stated reactivation triggers in ADR-011 and should not be extended without lifting the pause.
+
 | Track | Status | What it builds | Why it matters |
 |-------|--------|---------------|----------------|
-| **Installable taxonomy refactor** | Phase 1.5 done; 2–6 pending | Unified `Installable` table (source + components[] + kind), `Skill` 8th component type. See ADR-001. | Kills the v1 split; every plugin goes through one model |
-| **Agent DMs** | Shipped | Personal 1:1 agent chat (`Pod.type: 'agent-room'`). "Talk to" button in Agent Hub, "Agent DMs" pod tab, privacy-filtered. | Primary human↔agent interaction surface |
-| **Native runtime (Tier 1)** | Shipped | In-process agent runtime via LiteLLM with `AgentRun` turn/tool/cost tracking | Zero-setup agents; powers first-party apps |
-| **First-party apps** | 3 shipped | `pod-welcomer`, `task-clerk`, `pod-summarizer` — installed in Team Orchestration Demo pod | Reference implementations for the Installable model |
-| **Cloud sandbox runtime (Tier 2)** | Pending | Anthropic Managed Agents + Commonly-hosted container adapter | Heavy-compute agents without BYO infra |
-| **Slash command infrastructure** | Pending (Phase 4 of taxonomy refactor) | `/command` addressing mode, command registry, UI autocomplete | Second addressing mode alongside `@mention` |
-| **Kernel / CAP spec** | #61, #46 | OpenAPI spec + coupling reduction | Defines the join protocol |
-| **Driver layer** | #69, #70 | Webhook API + Agent SDK (npm) | Universal connector — any agent from anywhere |
-| **Marketplace** | #66, #67, #68 | Manifest format, registry, browse UI | Agents are discoverable + installable |
-| **Self-hosting** | #60 | Docker Compose + Helm one-liner | Commonly as a protocol, not just a product |
-| **Shell polish** | #62, #64, #65 | Rich media, activity indicators, onboarding | Makes humans want to be there |
-| **OSS launch** | #57–#59, #63 | README, community files, landing page | Ecosystem growth |
-| **YC demo** | #71, #72 | Live stats API, demo infrastructure | Shows the vision working end-to-end |
+| 🟢 **Shell polish** | #62, #64, #65 — top of queue | Rich media, activity indicators, onboarding, empty/error states, mobile | Makes humans want to be there |
+| 🟢 **Agent install + first-DM flow** | Top of queue | Hero path: install your first agent → talk to it. Agent Hub UX, install confirmation, first-message coaching | The 60-second value prop |
+| 🟢 **Landing + demo** | #71, #72 — mid-queue | Live stats API, public demo loop, landing page, README front-door | Gates external traffic |
+| 🟢 **OSS launch prep** | #57–#59, #63 — tail of queue | README, community files, contribution path, self-hosting one-liner | Ecosystem growth |
+| 🟢 **Agent DMs** | Shipped (stays) | Personal 1:1 agent chat (`Pod.type: 'agent-room'`). "Talk to" in Agent Hub, "Agent DMs" pod tab. | Primary human↔agent interaction surface |
+| 🟢 **Native runtime (Tier 1)** | Shipped (stays) | In-process agent runtime via LiteLLM with `AgentRun` turn/tool/cost tracking | Zero-setup agents; powers first-party apps |
+| 🟢 **First-party apps** | 3 shipped (stays) | `pod-welcomer`, `task-clerk`, `pod-summarizer` in Team Orchestration Demo pod | Reference implementations for the Installable model |
+| ⏸️ **ADR-010 Phase 2+** | Paused (Phase 1 shipped) | OpenClaw → MCP migration, extension `commonly_*` retirement | Re-activates when a second runtime needs `commonly_*` mid-turn |
+| ⏸️ **Installable taxonomy refactor** | Paused (Phase 1.5 done; 2–6 hold) | Unified `Installable` table evolution beyond Phase 1.5 | Re-activates when marketplace UI build needs the unified query path |
+| ⏸️ **Cloud sandbox runtime (Tier 2)** | Paused | Anthropic Managed Agents + Commonly-hosted container adapter | Re-activates on real demand from a heavy-compute agent |
+| ⏸️ **Slash command infrastructure** | Paused (taxonomy Phase 4) | `/command` addressing mode, command registry, UI autocomplete | Re-activates when an app/marketplace listing needs `/command` primary |
+| ⏸️ **Kernel / CAP spec** | Paused — #61, #46 | OpenAPI spec + coupling reduction | Re-activates when federation work begins or a second instance comes online |
+| ⏸️ **Driver layer expansion** | Paused — #69, #70 | Webhook SDK Phase 2 (OAuth, signatures), Agent SDK npm publish | Re-activates on real external developer demand |
+| ⏸️ **Marketplace** | Paused — #66, #67, #68 | Manifest format, registry, browse UI | Re-activates when audit shows install flow needs marketplace browse |
+| ⏸️ **Self-hosting one-liner** | Paused — #60 | Docker Compose + Helm one-liner polish | Re-activates if OSS launch credibility demands it |
 
 ---
 
@@ -175,7 +179,8 @@ Commonly is collapsing the legacy `App` + `AgentRegistry` split into a single `I
 - **ADR-006 Webhook SDK + Self-Serve Install**: `/docs/adr/ADR-006-webhook-sdk-and-self-serve-install.md` — reference SDK + self-serve webhook install
 - **ADR-008 Agent Environment Primitive**: `/docs/adr/ADR-008-agent-environment-primitive.md` — driver-agnostic env spec (workspace / sandbox / skills / MCP declarations)
 - **ADR-009 Test tiers + CI/CD to GKE**: `/docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md` — four-tier test taxonomy (unit / service / cluster / dev-env) and workflow-triggered GKE deploys via WIF
-- **ADR-010 Commonly MCP Server**: `/docs/adr/ADR-010-commonly-mcp-server.md` — `@commonly/mcp` server exposing CAP as standard MCP tools; the thing ADR-008's `mcp[]` declarations point at; deprecation path for the openclaw extension's `commonly_*` block
+- **ADR-010 Commonly MCP Server**: `/docs/adr/ADR-010-commonly-mcp-server.md` — `@commonly/mcp` server exposing CAP as standard MCP tools; the thing ADR-008's `mcp[]` declarations point at; deprecation path for the openclaw extension's `commonly_*` block. **Phase 1 shipped; Phase 2+ paused under ADR-011.**
+- **ADR-011 Shell-first pre-GTM**: `/docs/adr/ADR-011-shell-first-pre-gtm.md` — **active strategic track as of 2026-04-27.** Pauses ADR-010 Phase 2+, cloud sandbox, slash-commands, driver-layer expansion, CAP OpenAPI, and Installable refactor Phase 2-6. Active: shell polish, agent install flow, landing/demo, OSS launch prep. Read before starting any kernel feature work.
 - **Summarizer & Agents**: `/docs/SUMMARIZER_AND_AGENTS.md`
 - **Discord Integration**: `/docs/DISCORD_INTEGRATION_ARCHITECTURE.md`
 - **PostgreSQL Migration**: `/docs/POSTGRESQL_MIGRATION.md`

--- a/docs/adr/ADR-010-commonly-mcp-server.md
+++ b/docs/adr/ADR-010-commonly-mcp-server.md
@@ -1,8 +1,41 @@
 # ADR-010: Commonly MCP Server — kernel surface as a standard MCP endpoint
 
-**Status:** Draft — 2026-04-27
+**Status:** Phase 1 shipped (PR #243, 2026-04-27); **Phase 2+ deferred** 2026-04-27 — see [ADR-011](ADR-011-shell-first-pre-gtm.md).
 **Author:** Lily Shen
-**Companion:** [`ADR-001`](ADR-001-installable-taxonomy.md), [`ADR-003`](ADR-003-memory-as-kernel-primitive.md), [`ADR-004`](ADR-004-commonly-agent-protocol.md), [`ADR-005`](ADR-005-local-cli-wrapper-driver.md), [`ADR-008`](ADR-008-agent-environment-primitive.md) (per-agent MCP declarations point at this server)
+**Companion:** [`ADR-001`](ADR-001-installable-taxonomy.md), [`ADR-003`](ADR-003-memory-as-kernel-primitive.md), [`ADR-004`](ADR-004-commonly-agent-protocol.md), [`ADR-005`](ADR-005-local-cli-wrapper-driver.md), [`ADR-008`](ADR-008-agent-environment-primitive.md) (per-agent MCP declarations point at this server), [`ADR-011`](ADR-011-shell-first-pre-gtm.md) (track pause)
+
+---
+
+## Status update — 2026-04-27 — Phase 2+ deferred
+
+Phase 1 is in main: `@commonly/mcp` ships as a stdio MCP server with ~14 tools, the `POST /room` endpoint is dual-auth, and `sam-local-codex` is the live consumer. Task #5 (nova HEARTBEAT cutover via DM delegation) merged on top in PR #247 using the openclaw extension's `commonly_*` block — *not* the MCP server — so the architectural cutover remains pending.
+
+**Phase 2 (OpenClaw → MCP migration), Phase 2.5 (extension `commonly_*` deprecation), and Phase 4 (extension block removal) are paused** under [ADR-011](ADR-011-shell-first-pre-gtm.md). Phase 3 (Task #5 cutover) is technically complete via the extension path; re-routing it onto MCP is part of Phase 2 and is paused with it.
+
+### Why deferred (not abandoned)
+
+Two unresolved concerns from the original ADR are real engineering — not blockers Phase 1 closed:
+
+1. **Per-agent token wiring through acpx is unsolved.** acpx loads `pluginConfig.mcpServers` plugin-globally; every agent on the gateway sees the same MCP server with the same token. Per-agent identity requires a wrapper script that injects per-agent tokens at acpx startup, an upstream feature added to our openclaw fork for per-agent `mcpServers`, or one acpx process per agent. Each option is real work, not a one-line config.
+2. **Two `commonly_update_task` shapes coexist.** The extension's PATCH `{status, notes}` and the MCP server's POST `/updates {text}` are not interchangeable. Migrating an agent's HEARTBEAT.md from one to the other requires either tool-shape reconciliation on the server, or a second MCP tool with the PATCH semantics, or rewriting every HEARTBEAT call site. Open question, no decided answer.
+
+Both are tractable. Neither is urgent enough to do before the shell work that gates GTM.
+
+### What's still in effect from Phase 1
+
+- `@commonly/mcp` package remains shipped and consumable. The CLI-wrapper driver (sam-local-codex and any future `commonly agent attach <cli>` invocations) keeps using it.
+- The `/room` dual-auth refactor stays — it's load-bearing for any agent→agent DM flow, MCP or not.
+- Load-bearing invariants (§Load-bearing invariants below) remain authoritative for any future Phase 2 work.
+
+### Reactivation triggers
+
+Lift the pause when any of these become true:
+
+- A second runtime needs `commonly_*` tools mid-turn and the openclaw extension can't serve it (forcing function returns).
+- The per-agent token wiring story converges on a chosen approach (wrapper script designed, or acpx fork patch landed).
+- Post-GTM, when shell quality is no longer the binding constraint.
+
+Until then: do not extend the openclaw extension's `commonly_*` block with new verbs, but do not remove it either. The two surfaces coexist as documented in §Migration path.
 
 ---
 

--- a/docs/adr/ADR-011-shell-first-pre-gtm.md
+++ b/docs/adr/ADR-011-shell-first-pre-gtm.md
@@ -1,0 +1,108 @@
+# ADR-011: Shell-first pre-GTM
+
+**Status:** Draft — 2026-04-27
+**Author:** Sam Xu
+**Companion:** [`ADR-010`](ADR-010-commonly-mcp-server.md) (Phase 2+ paused under this ADR), [`CLAUDE.md`](../../CLAUDE.md) §Design Rules #5 ("the social surface has to earn human presence")
+
+---
+
+## Context
+
+The kernel work has reached a natural pause. Through April 2026 we shipped:
+
+- ADR-004 (CAP) — the four-verb driver-facing surface, frozen.
+- ADR-005 Stage 2 — `sam-local-codex` live as the first production CLI-wrapper agent.
+- ADR-006 Phase 1 — webhook SDK + self-serve install.
+- ADR-008 — agent environment primitive (workspace / sandbox / skills / MCP).
+- ADR-009 Phases 1/1.5/2 — test tiers + CI/CD substrate.
+- ADR-010 Phase 1 — `@commonly/mcp` stdio server + `/room` dual-auth.
+- Native runtime (Tier 1), Agent DMs, three first-party apps, `Skill` as the 8th component type.
+
+The kernel can host agents from any origin. Local CLI wrappers join. Webhook agents join. The MCP surface exists for any runtime that wants it. CAP is stable. **The platform is no longer the binding constraint on adoption.**
+
+What *is* the binding constraint: the surface a human sees in the first 60 seconds. Right now we don't have a confident answer to "what does a new user do on landing." Onboarding, agent-install flow, mobile, demo loop, landing page — all are the work between "the platform exists" and "someone wants to use it." Per CLAUDE.md design rule #5, *the social surface has to earn human presence* — and that earning hasn't been built yet.
+
+The forcing function is GTM. We can't ship the platform vision without humans on it; humans don't stay without a shell that earns their presence; the shell isn't there yet. Continuing to build kernel primitives doesn't move that needle.
+
+---
+
+## Decision
+
+**Pause new kernel work. Make shell quality, user experience, and GTM readiness the active track until the shell earns presence.**
+
+### What's paused
+
+| Track | What pauses | Reactivation trigger |
+|---|---|---|
+| **ADR-010 Phase 2+** (OpenClaw → MCP migration, extension deprecation) | No further fork PRs to retire `commonly_*`; no new mcpServers wiring in `/state/moltbot.json` | A second runtime needs `commonly_*` mid-turn and the extension can't serve it; or per-agent token wiring story converges; or post-GTM |
+| **Cloud sandbox runtime (Tier 2)** | No Anthropic Managed Agents adapter, no Commonly-hosted container driver | Real demand from a heavy-compute agent that can't run on Tier 1 |
+| **Slash command infrastructure** (Phase 4 of taxonomy refactor) | No `/command` registry, no autocomplete UI | A first-party app or marketplace listing needs `/command` as its primary addressing mode |
+| **Driver layer expansion** (#69, #70 — Webhook API + Agent SDK npm publish) | ADR-006 Phase 1 substrate stays; no Phase 2 features (OAuth, webhook signatures, npm publish) | Real external developer asking to build against it |
+| **CAP OpenAPI spec** (#61, #46) | No formal OpenAPI generation, no coupling-reduction refactor | Federation work begins (ADR-003 Phase 5) or a second instance comes online |
+| **Self-hosting one-liner** (#60) | No Docker Compose / Helm chart polish for OSS contributors | OSS launch is the active track (see Active below — this re-activates) |
+| **Installable taxonomy refactor** Phase 2-6 | Schema work pauses except where it unblocks shell features | Marketplace UI build needs the unified `Installable` query path |
+
+### What's active
+
+| Track | What ships | Owner / cadence |
+|---|---|---|
+| **Shell polish** (#62, #64, #65) | Onboarding flow, rich media in chat, activity indicators, empty/error states, mobile responsiveness | Top of queue; iterate weekly |
+| **Agent install + first-DM flow** | The "install your first agent → talk to it" hero path: Agent Hub UX, install confirmation, first-message coaching, identity polish | Top of queue |
+| **Landing + demo** (#71, #72) | Live stats API, public demo loop, landing page, README front-door | Mid-queue; gates external traffic |
+| **OSS launch prep** (#57–#59, #63) | README polish, community files, contribution path, self-hosting one-liner if needed for credibility | Tail of queue but reuses self-hosting work above |
+
+### What stays load-bearing regardless
+
+- **Kernel stability.** CAP doesn't change, ADR-001/004/008 invariants hold, agent identity continuity is preserved across reinstalls. Shell work cannot break the kernel.
+- **CI/CD pipeline (ADR-009).** The deploy path stays green; the test tiers don't regress.
+- **Live agents.** sam-local-codex, Liz, x-curator, the dev agents — all remain operational. Shell work is additive, not destructive (per CLAUDE.md design rule #2).
+- **Critical bug fixes.** Production breakage on the kernel is fixed when it happens; this ADR doesn't gate emergency repair.
+
+---
+
+## Load-bearing invariants
+
+1. **Shell-first does not mean kernel-broken.** Any shell change that requires a kernel change goes through normal ADR review. The kernel doesn't bend to make a shell flow easier — the shell uses what the kernel exposes.
+2. **No new driver-coupling debt while paused.** The openclaw extension's `commonly_*` block is frozen at its current verb set. New cross-driver verbs do not get added to the extension during the pause; they wait for ADR-010 Phase 2 or get scoped out.
+3. **Pauses are reversible.** Every paused track has a stated reactivation trigger above. When a trigger fires, the track resumes — not "starts a debate about whether to resume."
+4. **Audit before commit.** The first concrete deliverable under this ADR is a first-impression UX audit (Playwright walk-through, screenshots, paper-cut list). The audit's output drives what we actually build; we do not commit to specific features without seeing the surface.
+5. **Don't rewrite to refactor.** Shell polish is polish — onboarding, microcopy, empty states, mobile, animation, error messages. Not "rewrite the chat module." If a polish task uncovers a real architectural issue, file an ADR; don't expand the shell work to swallow it.
+
+---
+
+## What this is not
+
+- Not a freeze on all engineering. CI, deploys, and bug fixes continue.
+- Not a deprecation of the kernel. ADR-010's load-bearing invariants remain in effect; Phase 1 stays consumed by sam-local-codex.
+- Not a dismissal of the paused tracks. They have stated reactivation triggers; when triggers fire, work resumes.
+- Not a marketing-driven feature schedule. GTM here means making the existing platform usable enough that someone who lands on it stays — not building features to chase a launch press cycle.
+
+---
+
+## Open questions
+
+1. **What's the GTM target?** "OSS launch," "YC demo," and "first 100 users on commonly.me" are different bars and would prioritize different shell work. Sub-decision needed before the audit converges into a feature plan.
+2. **Mobile-first or desktop-first audit?** The current shell renders on both but isn't optimized for either. The first-impression audit needs to pick one to go deep on first; the other gets a triage pass.
+3. **First-party agent showcase.** The three first-party apps (`pod-welcomer`, `task-clerk`, `pod-summarizer`) live in the Team Orchestration Demo pod. Are they the demo loop, or do we need a different shape (e.g., a single hero agent with a richer interaction) to anchor first-impression?
+4. **Marketplace before or after audit?** Marketplace UI (#66, #67, #68) is paused, but Agent Hub *is* the proto-marketplace UX. Audit may surface that we need marketplace browse to make agent install feel real.
+
+---
+
+## Rejected alternatives
+
+**"Keep going on ADR-010 Phase 2 because it's almost done."** It isn't almost done. Per-agent token wiring is unsolved and the two `commonly_update_task` shapes need reconciliation. Finishing it would be 1–2 more weeks of real work, with the live exercise gated on whether dev agents pick up tasks (which they currently don't reliably). The marginal return on that work is lower than the return on a shell that earns first-impression presence.
+
+**"Do shell + kernel in parallel."** The team is small enough that parallel tracks fragment focus. The kernel work has reached a usable plateau; a focused shell sprint is higher-leverage than splitting attention.
+
+**"Skip the audit, build the obvious wins."** "Obvious wins" is wishful — we don't know which paper cuts matter most without walking the surface. A 30-min audit costs almost nothing and produces a triaged backlog that's hard to argue with. Building before auditing risks polishing the wrong thing.
+
+**"Wait for users to tell us what's broken."** Users will tell us what's broken by leaving. The audit is a cheap stand-in for the user-feedback loop we don't have yet.
+
+---
+
+## What this unlocks
+
+- **A confident first-impression flow.** Someone landing on `app-dev.commonly.me` can install an agent and talk to it within 60 seconds.
+- **A demoable hero loop.** YC demo, OSS launch, or any external pitch has a concrete artifact: "go here, do this, see the agent come alive."
+- **Honest GTM.** We stop shipping platform features that no human exercises, and start shipping the surface humans see. When kernel work resumes (per the reactivation triggers above), it does so against a real user base instead of into a vacuum.
+- **A real reactivation signal for paused tracks.** Each paused track has a stated trigger — when it fires, we know the platform work is being pulled by demand, not pushed on speculation.


### PR DESCRIPTION
## Summary
- **New ADR-011** (`docs/adr/ADR-011-shell-first-pre-gtm.md`) declares shell-first pre-GTM as the active strategic track. Pauses ADR-010 Phase 2+, cloud sandbox, slash-commands, driver-layer expansion, CAP OpenAPI, marketplace, and Installable refactor Phase 2-6 — each with a stated reactivation trigger.
- **ADR-010 status updated**: Phase 1 shipped (PR #243); Phase 2+ deferred with rationale (per-agent token wiring through acpx unsolved; two `commonly_update_task` shapes need reconciliation).
- **CLAUDE.md** key-docs list + Active Implementation Tracks table reflect the pause: 🟢 active rows on top, ⏸️ paused rows below with reactivation triggers, plus a one-line strategic-mode banner.

## Why
Kernel reached a usable plateau in April 2026 (CAP frozen, Tier 1 runtime live, sam-local-codex live, MCP Phase 1 shipped). The binding constraint on adoption is no longer the platform — it's the surface humans see in the first 60 seconds. ADR-011 makes that pivot explicit so future sessions don't re-derive "next thing to build" from the old pending list.

## What this is not
- Not a freeze on engineering (CI, deploys, bug fixes continue).
- Not a deprecation of ADR-010 (Phase 1 stays consumed by sam-local-codex; load-bearing invariants stay authoritative).
- Not a marketing-driven feature schedule.

## Open questions for the next phase (called out in ADR-011)
- GTM target (OSS launch / YC demo / first 100 users) — different bars prioritize different shell work.
- Mobile-first or desktop-first audit.
- First-party agent showcase shape.
- Whether marketplace browse needs to come before Agent Hub install polish.

## Test plan
- [ ] Read ADR-011 §Decision + §Load-bearing invariants
- [ ] Read ADR-010 §Status update (top of file)
- [ ] Confirm CLAUDE.md track table reads correctly to a fresh session
- [ ] Decide ADR-011 open question #1 (GTM target) before audit phase begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)