### PR TITLE
docs(adr-011): correct marketplace status — backend already shipped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,18 +141,19 @@ Commonly is collapsing the legacy `App` + `AgentRegistry` split into a single `I
 |-------|--------|---------------|----------------|
 | 🟢 **Shell polish** | #62, #64, #65 — top of queue | Rich media, activity indicators, onboarding, empty/error states, mobile | Makes humans want to be there |
 | 🟢 **Agent install + first-DM flow** | Top of queue | Hero path: install your first agent → talk to it. Agent Hub UX, install confirmation, first-message coaching | The 60-second value prop |
+| 🟢 **Marketplace frontend** | Mid-queue (backend already shipped: PR #215 + #230, `/api/marketplace/*` 9 endpoints) | Browse page, manifest detail, publish flow, fork button — wiring on top of existing API. Pre-flight: end-to-end verify backend on dev. | Makes "discover an agent" real, not just "talk to the one we installed for you" |
 | 🟢 **Landing + demo** | #71, #72 — mid-queue | Live stats API, public demo loop, landing page, README front-door | Gates external traffic |
 | 🟢 **OSS launch prep** | #57–#59, #63 — tail of queue | README, community files, contribution path, self-hosting one-liner | Ecosystem growth |
 | 🟢 **Agent DMs** | Shipped (stays) | Personal 1:1 agent chat (`Pod.type: 'agent-room'`). "Talk to" in Agent Hub, "Agent DMs" pod tab. | Primary human↔agent interaction surface |
 | 🟢 **Native runtime (Tier 1)** | Shipped (stays) | In-process agent runtime via LiteLLM with `AgentRun` turn/tool/cost tracking | Zero-setup agents; powers first-party apps |
 | 🟢 **First-party apps** | 3 shipped (stays) | `pod-welcomer`, `task-clerk`, `pod-summarizer` in Team Orchestration Demo pod | Reference implementations for the Installable model |
 | ⏸️ **ADR-010 Phase 2+** | Paused (Phase 1 shipped) | OpenClaw → MCP migration, extension `commonly_*` retirement | Re-activates when a second runtime needs `commonly_*` mid-turn |
-| ⏸️ **Installable taxonomy refactor** | Paused (Phase 1.5 done; 2–6 hold) | Unified `Installable` table evolution beyond Phase 1.5 | Re-activates when marketplace UI build needs the unified query path |
+| ⏸️ **Installable taxonomy refactor** | Paused (Phase 1.5 + Phase 2 marketplace-ops shipped via PR #215 + #230; 2-remainder + 3–6 hold) | ADR-001 Phase 3 read-path switch (install reads from Installable, not AR), reconciliation cron, semver/runtime validation | Re-activates when marketplace frontend reveals a drift bug or a new Installable shape needs the read-path switch |
 | ⏸️ **Cloud sandbox runtime (Tier 2)** | Paused | Anthropic Managed Agents + Commonly-hosted container adapter | Re-activates on real demand from a heavy-compute agent |
 | ⏸️ **Slash command infrastructure** | Paused (taxonomy Phase 4) | `/command` addressing mode, command registry, UI autocomplete | Re-activates when an app/marketplace listing needs `/command` primary |
 | ⏸️ **Kernel / CAP spec** | Paused — #61, #46 | OpenAPI spec + coupling reduction | Re-activates when federation work begins or a second instance comes online |
 | ⏸️ **Driver layer expansion** | Paused — #69, #70 | Webhook SDK Phase 2 (OAuth, signatures), Agent SDK npm publish | Re-activates on real external developer demand |
-| ⏸️ **Marketplace** | Paused — #66, #67, #68 | Manifest format, registry, browse UI | Re-activates when audit shows install flow needs marketplace browse |
+| ⏸️ **Marketplace backend extensions** | Paused (9 publish/fork/browse endpoints already shipped via PR #215 + #230) | New endpoints, new manifest fields, recon cron | Re-activates when frontend or live use reveals a missing capability |
 | ⏸️ **Self-hosting one-liner** | Paused — #60 | Docker Compose + Helm one-liner polish | Re-activates if OSS launch credibility demands it |
 
 ---

--- a/docs/adr/ADR-011-shell-first-pre-gtm.md
+++ b/docs/adr/ADR-011-shell-first-pre-gtm.md
@@ -40,7 +40,8 @@ The forcing function is GTM. We can't ship the platform vision without humans on
 | **Driver layer expansion** (#69, #70 — Webhook API + Agent SDK npm publish) | ADR-006 Phase 1 substrate stays; no Phase 2 features (OAuth, webhook signatures, npm publish) | Real external developer asking to build against it |
 | **CAP OpenAPI spec** (#61, #46) | No formal OpenAPI generation, no coupling-reduction refactor | Federation work begins (ADR-003 Phase 5) or a second instance comes online |
 | **Self-hosting one-liner** (#60) | No Docker Compose / Helm chart polish for OSS contributors | OSS launch is the active track (see Active below — this re-activates) |
-| **Installable taxonomy refactor** Phase 2-6 | Schema work pauses except where it unblocks shell features | Marketplace UI build needs the unified `Installable` query path |
+| **Installable taxonomy refactor** Phase 2-6 | Phase 2's marketplace-operations slice already shipped (PR #215 + #230 — `marketplace-api.ts`, dual-write to `Installable` + `AgentRegistry`). Remaining Phase 2-6 work pauses: ADR-001 Phase 3 read-path switch, reconciliation cron for Installable ↔ AR drift, semver validation, per-component runtime validation. | Marketplace frontend (active below) reveals a drift bug, OR a new Installable shape lands that requires the read-path switch |
+| **Marketplace backend extensions** | The 9 endpoints under `/api/marketplace` are shipped but unverified end-to-end on dev. No new endpoints, no schema additions, until the shipped ones have user traffic. | Frontend reveals a missing capability in real use |
 
 ### What's active
 
@@ -48,6 +49,7 @@ The forcing function is GTM. We can't ship the platform vision without humans on
 |---|---|---|
 | **Shell polish** (#62, #64, #65) | Onboarding flow, rich media in chat, activity indicators, empty/error states, mobile responsiveness | Top of queue; iterate weekly |
 | **Agent install + first-DM flow** | The "install your first agent → talk to it" hero path: Agent Hub UX, install confirmation, first-message coaching, identity polish | Top of queue |
+| **Marketplace frontend** | Browse page, manifest detail page, publish flow, fork button — all wiring on top of the already-shipped `/api/marketplace/*` endpoints (PR #215 + #230). Pre-flight: end-to-end verify the 9 endpoints on `api-dev.commonly.me` before frontend work begins. | Mid-queue; promotes to top once Agent Hub install flow lands |
 | **Landing + demo** (#71, #72) | Live stats API, public demo loop, landing page, README front-door | Mid-queue; gates external traffic |
 | **OSS launch prep** (#57–#59, #63) | README polish, community files, contribution path, self-hosting one-liner if needed for credibility | Tail of queue but reuses self-hosting work above |
 
@@ -84,7 +86,7 @@ The forcing function is GTM. We can't ship the platform vision without humans on
 1. **What's the GTM target?** "OSS launch," "YC demo," and "first 100 users on commonly.me" are different bars and would prioritize different shell work. Sub-decision needed before the audit converges into a feature plan.
 2. **Mobile-first or desktop-first audit?** The current shell renders on both but isn't optimized for either. The first-impression audit needs to pick one to go deep on first; the other gets a triage pass.
 3. **First-party agent showcase.** The three first-party apps (`pod-welcomer`, `task-clerk`, `pod-summarizer`) live in the Team Orchestration Demo pod. Are they the demo loop, or do we need a different shape (e.g., a single hero agent with a richer interaction) to anchor first-impression?
-4. **Marketplace before or after audit?** Marketplace UI (#66, #67, #68) is paused, but Agent Hub *is* the proto-marketplace UX. Audit may surface that we need marketplace browse to make agent install feel real.
+4. **Marketplace frontend sequencing.** Backend is shipped (PR #215 + #230); the question is no longer "build the marketplace?" but "where in the queue does it land?" Two reads: (a) frontend follows Agent Hub install polish, since marketplace browse is meaningless if install itself feels rough; (b) marketplace browse and Agent Hub install are the same surface from a user's POV, so build them as one push. The audit should resolve this by surfacing whether install-without-browse is coherent or whether users immediately ask "where do I find more agents?"
 
 ---
 


### PR DESCRIPTION
## Summary
Follow-up to #248 correcting an incomplete picture: Randy's PR #215 and Lily's PR #230 already shipped the marketplace backend (9 endpoints under `/api/marketplace`, dual-write to `Installable` + `AgentRegistry`). #248 marked Marketplace as paused, which under-described what's actually in main.

## Changes
- **ADR-011 §What's paused** — split "Marketplace" row: backend extensions stay paused (no new endpoints/fields/recon cron), but Installable taxonomy row now acknowledges Phase 2's marketplace-ops slice shipped via #215 + #230.
- **ADR-011 §What's active** — new "Marketplace frontend" row (mid-queue): browse / detail / publish / fork UI wires on top of the existing API. Pre-flight is end-to-end verify on dev before frontend work.
- **ADR-011 §Open questions #4** — reframed from "marketplace before or after audit?" to "where in the queue does the frontend land?" — audit resolves it.
- **CLAUDE.md** — Active Implementation Tracks table updated with same corrections.

## Why now
Without this correction, the next session would look at the active-tracks table and treat marketplace as "don't touch" — but the backend is shipped, has 0 user traffic, and the frontend is the natural shell-active surface that makes it real.

## Test plan
- [ ] Read ADR-011 §What's active — confirm Marketplace frontend row reads correctly
- [ ] Confirm CLAUDE.md track table matches ADR-011
- [ ] (next session) Verify the 9 `/api/marketplace/*` endpoints actually work on `api-dev.commonly.me` before any frontend work begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)