### PR TITLE
fix(uploads): IPv6 key generator for express-rate-limit v8

### DIFF
--- a/backend/routes/uploads.ts
+++ b/backend/routes/uploads.ts
@@ -18,7 +18,7 @@
 
 // ADR-002 Phase 1b: ESM import (not require) so CodeQL's js/missing-rate-limiting
 // query recognises the middleware on the mint route.
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import { createHash } from 'crypto';
 import path from 'path';
 import {
@@ -98,7 +98,7 @@ const mintRateLimit = rateLimit({
     if (authHeader) {
       return `tok:${createHash('sha256').update(authHeader).digest('hex').slice(0, 16)}`;
     }
-    return req.ip || 'anon';
+    return req.ip ? ipKeyGenerator(req.ip) : 'anon';
   },
   handler: (_req: unknown, res: Res) =>
     res.status(429).json({ msg: 'rate limit exceeded: 30 mints per 60s' }),


### PR DESCRIPTION
## Summary

express-rate-limit v8 strictly validates IPv6 address handling in custom `keyGenerator` functions and rejects `req.ip` passthrough with `ERR_ERL_KEY_GEN_IPV6` when no `Authorization` header is present. The `mintRateLimit` middleware on `/api/uploads/:fileName/url` was crashing the backend on first hit under v8.

This PR uses the library's exported `ipKeyGenerator()` helper for the unauth fallback path so the IPv6 validation passes.

## Changes

- `import rateLimit, { ipKeyGenerator } from 'express-rate-limit'` (was default-only)
- `return req.ip ? ipKeyGenerator(req.ip) : 'anon'` in the keyGenerator's fallback (was raw `req.ip || 'anon'`)

## Test plan

- [ ] Build clean
- [ ] On dev cluster: hit `GET /api/uploads/<any-fileName>/url` without `Authorization` header — expect 429 after rate limit, not the IPv6 crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)
