### PR TITLE
fix(messages): pull _id from populated User in normalizeMongo

### DIFF
--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -35,21 +35,31 @@ const pgAvailable = (): boolean => {
   }
 };
 
-const normalizeMongo = (m: Record<string, unknown>): NormalizedMessage => ({
-  id: (m._id as { toString(): string }).toString(),
-  pod_id: (m.podId as { toString(): string }).toString(),
-  user_id: (m.userId as { toString(): string }).toString(),
-  content: m.content as string,
-  message_type: (m.messageType as string) || 'text',
-  created_at: m.createdAt,
-  updated_at: m.updatedAt,
-  user: (m.userId as { username?: string } | undefined)?.username
-    ? {
-        username: (m.userId as { username: string }).username,
-        profile_picture: (m.userId as { profilePicture?: string }).profilePicture,
-      }
-    : undefined,
-});
+const normalizeMongo = (m: Record<string, unknown>): NormalizedMessage => {
+  // When .populate('userId') ran, m.userId is a populated User document. Calling
+  // .toString() on a Mongoose document returns util.inspect output
+  // ("{\n  _id: new ObjectId(\"...\"),\n  username: '...'\n}"), which then leaks
+  // into the user_id field of the response. Pull just the _id when populated.
+  const rawUserId = m.userId as { _id?: { toString(): string }; toString(): string; username?: string; profilePicture?: string } | string | null | undefined;
+  const idSource = rawUserId && typeof rawUserId === 'object' && rawUserId._id ? rawUserId._id : rawUserId;
+  const populatedUsername = (typeof rawUserId === 'object' && rawUserId) ? rawUserId.username : undefined;
+  const populatedProfilePicture = (typeof rawUserId === 'object' && rawUserId) ? rawUserId.profilePicture : undefined;
+  return {
+    id: (m._id as { toString(): string }).toString(),
+    pod_id: (m.podId as { toString(): string }).toString(),
+    user_id: idSource ? (idSource as { toString(): string }).toString() : '',
+    content: m.content as string,
+    message_type: (m.messageType as string) || 'text',
+    created_at: m.createdAt,
+    updated_at: m.updatedAt,
+    user: populatedUsername
+      ? {
+          username: populatedUsername,
+          profile_picture: populatedProfilePicture,
+        }
+      : undefined,
+  };
+};
 
 exports.getMessages = async (req: AuthRequest, res: Response): Promise<void> => {
   try {


### PR DESCRIPTION
## Summary
- When a Mongo message has its `userId` populated, calling `.toString()` on the Mongoose User document returns `util.inspect` output (`{\n  _id: new ObjectId("..."), username: '...', ...}`) instead of the ObjectId string. That string leaked into the `user_id` field of every API response that hit the Mongo fallback path.
- Real impact: the dev cluster's PG host has been unreachable for some time (Aiven host returns NXDOMAIN), so every message read goes through this fallback. The v2 chat renders author + avatar correctly via the populated `user` field, but the `user_id` field is malformed everywhere it's read.
- Fix: when `m.userId` is an object with `_id`, extract that `_id`; otherwise use the raw value. Pull `username`/`profilePicture` from the same object in one pass.

## Test plan
- [ ] Existing `messageController.test.js` cases still pass (PGMessage path is untouched).
- [ ] After deploy, GET `/api/messages/:podId` for any pod returns `user_id` as a 24-char hex ObjectId string, not the inspect-format blob.
- [ ] Spot-check on app-dev: messages render with the correct author and avatar (no behavior change there — only `user_id` is now well-formed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)