### PR TITLE
fix(agents): drop "powered by Claude" from default openclaw description

### DIFF
--- a/backend/routes/registry/publish.ts
+++ b/backend/routes/registry/publish.ts
@@ -138,10 +138,10 @@ publishRouter.post('/seed', auth, async (req: any, res: any) => {
         agentName: 'openclaw',
         displayName: agentTypes.openclaw?.officialDisplayName || 'Cuz 🦞',
         description: agentTypes.openclaw?.officialDescription
-          || 'Your friendly AI assistant powered by Claude - ready to chat, help, and remember!',
+          || 'OpenClaw cloud agent — chat, remember, take real actions when you need it.',
         registry: 'commonly-official',
         categories: ['openclaw', 'productivity', 'communication'],
-        tags: ['assistant', 'claude', 'ai', 'chat', 'memory', 'openclaw', 'clawdbot', 'moltbot'],
+        tags: ['assistant', 'ai', 'chat', 'memory', 'openclaw', 'clawdbot', 'moltbot'],
         verified: true,
         iconUrl: '/icons/cuz-lobster.png',
         manifest: {
@@ -151,8 +151,11 @@ publishRouter.post('/seed', auth, async (req: any, res: any) => {
             .map((c: any) => ({ name: c, description: c })),
           context: { required: ['context:read', 'summaries:read', 'messages:write'] },
           models: {
-            supported: ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-1.5-pro'],
-            recommended: 'gemini-2.5-pro',
+            // Listed here for the marketplace catalog only. Runtime model selection
+            // happens per-agent in agentProvisionerServiceK8s.ts (dev agents on
+            // openai-codex/gpt-5.4, community agents on OpenRouter free tier).
+            supported: ['openai-codex/gpt-5.4', 'openrouter/nvidia/nemotron-3-super-120b-a12b:free'],
+            recommended: 'openai-codex/gpt-5.4',
           },
           runtime: {
             type: 'standalone',

--- a/backend/services/agentIdentityService.ts
+++ b/backend/services/agentIdentityService.ts
@@ -69,7 +69,14 @@ interface AgentTypeConfig {
 const AGENT_TYPES: Record<string, AgentTypeConfig> = {
   openclaw: {
     officialDisplayName: 'Cuz 🦞',
-    officialDescription: 'Your friendly AI assistant powered by Claude - ready to chat, help, and remember!',
+    // Don't claim a model here. OpenClaw agents route through LiteLLM and the
+    // active model depends on per-agent overrides (dev agents on
+    // openai-codex/gpt-5.4, community agents on OpenRouter free tier, etc.).
+    // The previous "powered by Claude" string was both wrong (we are not
+    // Anthropic) and misleading (community agents aren't on Claude). Keep the
+    // description capability-flavored so it still fits the no-blurb fallback
+    // template in registry/install.ts.
+    officialDescription: 'OpenClaw cloud agent — chat, remember, take real actions when you need it.',
     icon: '🦞',
     botType: 'agent',
     capabilities: ['chat', 'memory', 'context', 'summarize', 'code'],


### PR DESCRIPTION
## Summary
- The default openclaw `officialDescription` was "Your friendly AI assistant powered by Claude - ready to chat, help, and remember!" — wrong on two counts: (1) we are not Anthropic, (2) most agents aren't on Claude under the hood (dev agents run `openai-codex/gpt-5.4`, community agents run OpenRouter free-tier Nemotron).
- The string leaks through to the install-time intro message (`Hi all — I'm <name>. <description> Ping me when you need it.`) — visible in every pod that installs an openclaw agent and a credibility hit for the upcoming YC demo recording.
- Replace with a runtime-honest, capability-flavored description. Also update `publish.ts`'s seeded marketplace metadata to drop the `claude` tag and align the recommended-model field with what the provisioner actually picks.

## Caveats
- Existing AgentRegistry rows in dev/prod still carry the old copy. This only fixes the default for new registry seeds and the runtime fallback in `registry/install.ts:307`. A re-seed (publish-defaults) or one-time DB update is needed to refresh existing rows.
- The YC demo pod's already-posted install-intro messages still show the old copy; they'll be re-sent or deleted ahead of recording.

## Test plan
- [ ] After deploy, install a fresh openclaw agent into a test pod — confirm intro reads the new copy, not "powered by Claude."
- [ ] Existing pods + agents are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)