### PR TITLE
fix(messages): backfill PG pod row on first message via shared sync service

### DIFF
--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -7,7 +7,11 @@ const MongoMessage = require('../models/Message');
 // eslint-disable-next-line global-require
 const PGMessage = require('../models/pg/Message');
 // eslint-disable-next-line global-require
+const PGPod = require('../models/pg/Pod');
+// eslint-disable-next-line global-require
 const AgentMentionService = require('../services/agentMentionService');
+// eslint-disable-next-line global-require
+const { syncPodFromMongo } = require('../services/pgPodSyncService');
 
 interface AuthRequest extends Request {
   userId?: string;
@@ -162,6 +166,24 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
     }
 
     let message: NormalizedMessage;
+
+    // Best-effort backfill: pods created via the Mongo-only POST /api/pods
+    // path (podController) have no row in the PG `pods` table, so the
+    // subsequent PGMessage.create fails the messages.pod_id foreign key
+    // and the message lands in the Mongo fallback indefinitely.
+    // pgMessageController already does this; mirror it here so the dual-DB
+    // path stays consistent with the PG-primary path. Swallow errors —
+    // if PG is unreachable, PGMessage.create below will throw and the
+    // existing Mongo fallback handles it.
+    try {
+      const pgPodExists = await PGPod.findById(podId);
+      if (!pgPodExists) {
+        await syncPodFromMongo(podId, userId);
+      }
+    } catch (syncErr) {
+      const e = syncErr as { message?: string };
+      console.warn('[messageController] PG pod backfill skipped:', e.message);
+    }
 
     try {
       const created = await PGMessage.create(

--- a/backend/controllers/pgMessageController.ts
+++ b/backend/controllers/pgMessageController.ts
@@ -6,34 +6,12 @@ const PGPod = require('../models/pg/Pod');
 const PGMessage = require('../models/pg/Message');
 // eslint-disable-next-line global-require
 const MongoPod = require('../models/Pod');
+// eslint-disable-next-line global-require
+const { syncPodFromMongo } = require('../services/pgPodSyncService');
 
 interface AuthRequest extends Request {
   userId?: string;
   user?: { id: string };
-}
-
-async function syncPodFromMongo(podId: string, requestingUserId: string): Promise<unknown> {
-  const mongoPod = await MongoPod.findById(podId).lean() as {
-    name?: string;
-    description?: string;
-    type?: string;
-    members?: Array<{ toString(): string }>;
-  } | null;
-  if (!mongoPod) return null;
-  const pod = await PGPod.create(
-    mongoPod.name,
-    mongoPod.description || '',
-    mongoPod.type || 'chat',
-    requestingUserId,
-    podId,
-  );
-  // Sync all MongoDB members to PG pod_members
-  if (Array.isArray(mongoPod.members)) {
-    await Promise.allSettled(
-      mongoPod.members.map((m) => PGPod.addMember(podId, m.toString())),
-    );
-  }
-  return pod;
 }
 
 // Check if user is a member via PG, falling back to MongoDB as source of truth

--- a/backend/services/pgPodSyncService.ts
+++ b/backend/services/pgPodSyncService.ts
@@ -1,0 +1,61 @@
+// Lazy backfill helper that syncs a Mongo pod row into PG on first
+// PG-touching operation. Mirrors what pgMessageController has been doing
+// inline since the dual-DB split — extracted here so messageController
+// can use the same path. Without this, a pod created via the Mongo-only
+// path (POST /api/pods → podController) is missing from PG, and any
+// PGMessage.create against it fails the messages.pod_id FK, dropping
+// the message into the Mongo fallback path indefinitely.
+//
+// Why a service instead of a util: the function reaches into both PG
+// (PGPod.create + addMember) and Mongo (Pod.findById), so it lives at
+// the service tier rather than as a pure helper.
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const PGPod = require('../models/pg/Pod');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const MongoPod = require('../models/Pod');
+
+interface MongoPodLean {
+  name?: string;
+  description?: string;
+  type?: string;
+  members?: Array<{ toString(): string }>;
+}
+
+/**
+ * Backfill a single Mongo pod into PG. Idempotent in spirit (caller should
+ * have already checked PGPod.findById and missed); if PGPod.create races
+ * with another caller it surfaces as a unique-key error and the caller
+ * gets to handle it.
+ *
+ * Returns the PG row on success, null when the Mongo pod itself is
+ * missing (caller should treat this like 404).
+ */
+export async function syncPodFromMongo(
+  podId: string,
+  requestingUserId: string,
+): Promise<unknown> {
+  const mongoPod = await MongoPod.findById(podId).lean() as MongoPodLean | null;
+  if (!mongoPod) return null;
+  const pod = await PGPod.create(
+    mongoPod.name,
+    mongoPod.description || '',
+    mongoPod.type || 'chat',
+    requestingUserId,
+    podId,
+  );
+  if (Array.isArray(mongoPod.members)) {
+    await Promise.allSettled(
+      mongoPod.members.map((m) => PGPod.addMember(podId, m.toString())),
+    );
+  }
+  return pod;
+}
+
+// CJS compat: let `const { syncPodFromMongo } = require('...')` work
+// alongside the named ESM export above. Without this dual export the
+// dual-DB messageController (which uses CJS require()) can't pick up
+// the named export from the compiled .js.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = { syncPodFromMongo };
+module.exports.syncPodFromMongo = syncPodFromMongo;


### PR DESCRIPTION
## Summary
- Pods created via the Mongo-only `POST /api/pods` path (`podController`) have no row in the PG `pods` table. The subsequent `PGMessage.create` from the dual-DB `messageController` fails the `messages.pod_id` foreign key, so the message silently lands in the Mongo fallback indefinitely — leaving the pod in a degraded "single-DB" state that breaks reply threading, `findActivityHint`, and the agent activity-hint injection.
- `pgMessageController` already had an inline `syncPodFromMongo` for the PG-primary path. Extract it to `backend/services/pgPodSyncService.ts` (so both controllers consume the same helper) and call it from `messageController.createMessage` when `PGPod.findById` returns nothing.
- The backfill is best-effort and wrapped in its own `try`/`catch` — if PG is genuinely unreachable, the existing `PGMessage.create` fallback to Mongo still kicks in unchanged.

## Background
Surfaced tonight while recovering the YC sprint demo pod after Aiven (PG host) came back from a billing-related outage. The pod existed in Mongo but wasn't in PG, so every new message stuck on the Mongo path. Manually patched the live pod with `kubectl exec ... PGPod.create(...)` to unblock the demo; this PR is the permanent fix.

## Test plan
- [ ] Existing `messageController.test.js` cases still pass (the new sync block is wrapped in `try`/`catch` and swallows failures, so unmocked PG calls in the unit test don't break the happy path).
- [ ] After deploy, create a pod via `POST /api/pods`, send a message via `POST /api/messages/:podId`, and verify the response carries `id` as a numeric PG row id (not a Mongo ObjectId), confirming the message landed in PG.
- [ ] Existing pods with PG rows continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)