### PR TITLE
docs: 2026-04-29 state update + scrub infra identifiers from public docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ Commonly is collapsing the legacy `App` + `AgentRegistry` split into a single `I
 
 | Track | Status | What it builds | Why it matters |
 |-------|--------|---------------|----------------|
-| 🟢 **Shell polish** | #62, #64, #65 — top of queue | Rich media, activity indicators, onboarding, empty/error states, mobile | Makes humans want to be there |
+| 🟢 **Shell polish** | Phase 1 shipped 2026-04-29 (v2 mount on main, nav-rail trim, Plan/Execute pill, Your Team page, displayName-overrides for chat author render) — #62, #64, #65 still queue for next polish pass | Rich media, activity indicators, onboarding, empty/error states, mobile | Makes humans want to be there |
 | 🟢 **Agent install + first-DM flow** | Top of queue | Hero path: install your first agent → talk to it. Agent Hub UX, install confirmation, first-message coaching | The 60-second value prop |
 | 🟢 **Marketplace frontend** | Mid-queue (backend already shipped: PR #215 + #230, `/api/marketplace/*` 9 endpoints) | Browse page, manifest detail, publish flow, fork button — wiring on top of existing API. Pre-flight: end-to-end verify backend on dev. | Makes "discover an agent" real, not just "talk to the one we installed for you" |
 | 🟢 **Landing + demo** | #71, #72 — mid-queue | Live stats API, public demo loop, landing page, README front-door | Gates external traffic |
@@ -163,10 +163,8 @@ Commonly is collapsing the legacy `App` + `AgentRegistry` split into a single `I
 ### CURRENT STATE (April 2026)
 - **Repository**: Team-Commonly/commonly, branch: `main`
 - **Live**: `app-dev.commonly.me` / `api-dev.commonly.me`
-- **Latest image tags**: see `k8s/helm/commonly/values-dev.yaml`
-- **GKE context**: `gke_commonly-493005_us-central1_commonly-dev`
-- **GCP account**: `lilyshen20021002@gmail.com`, project `commonly-493005`
-- **Image registry**: `us-central1-docker.pkg.dev/commonly-493005/docker/`
+- **Live image tags**: `kubectl get deploy -n commonly-dev -o custom-columns=NAME:.metadata.name,IMAGE:.spec.template.spec.containers[0].image` (the file `values-dev.yaml` lags reality between deploys — trust the cluster, not the chart).
+- **GKE context, project ID, image registry, ops account**: not committed (operator-private, see `feedback-no-infra-leak-in-public-repo` memory + `.dev/values-private.yaml` / `.dev/ops-credentials.md` locally). Anything that needs a project-scoped identifier is supplied at deploy time via GitHub Actions secrets (`DEV_GCP_PROJECT_ID`, `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`) or via ExternalSecrets.
 - **UI verification**: Use MCP Playwright (`mcp__playwright__*`)
 
 ### 📁 Key Documentation Files
@@ -231,45 +229,46 @@ npm run lint                                  # 0 errors
 
 ### Kubernetes (GKE — commonly-dev)
 
-**ALWAYS use three `-f` flags — NEVER `--reuse-values`:**
-```bash
-helm upgrade commonly-dev k8s/helm/commonly -n commonly-dev \
-  -f k8s/helm/commonly/values.yaml \
-  -f k8s/helm/commonly/values-dev.yaml \
-  -f /home/xcjam/workspace/commonly/.dev/values-private.yaml
-```
-
-- `values.yaml` — base defaults (OSS-safe placeholders)
-- `values-dev.yaml` — dev overrides; **update image tag here before every upgrade**
-- `values-private.yaml` — not committed; real GCP project ID, PG host, image repos
-
 ```bash
 kubectl get pods -n commonly-dev
 kubectl logs -n commonly-dev -l app=backend
+helm history commonly-dev -n commonly-dev    # rollback target
+kubectl rollout undo deploy/<name> -n commonly-dev --to-revision=<N>
 ```
+
+Helm chart layout:
+- `values.yaml` — base defaults, OSS-safe placeholders.
+- `values-dev.yaml` — dev overrides (image tags, replica counts, public hostnames).
+- `.dev/values-private.yaml` — operator-local, NOT committed; project ID + PG host + AR repo. Materialized inside the deploy-dev workflow from GitHub Actions secrets.
+
+`Deploy Dev` is the supported path; the local manual `helm upgrade -f -f -f` invocation works as an escape hatch but stays out of normal rotation.
 
 ### Build & Deploy
+
+**Primary path: GitHub Actions `Deploy Dev` workflow** (`.github/workflows/deploy-dev.yml`, ADR-009 Phase 3).
+
 ```bash
-# NOTE: Cloud Build org policy blocks AR uploads — use local Docker instead
-# Backend
-BACKEND_TAG=$(date +%Y%m%d%H%M%S)
-docker build backend -t us-central1-docker.pkg.dev/commonly-493005/docker/commonly-backend:${BACKEND_TAG}
-docker push us-central1-docker.pkg.dev/commonly-493005/docker/commonly-backend:${BACKEND_TAG}
+gh workflow run deploy-dev.yml --ref main --repo Team-Commonly/commonly
+gh run list --workflow=deploy-dev.yml -L 1 --repo Team-Commonly/commonly   # most-recent run
+```
 
-# Frontend (must bake REACT_APP_API_URL at build time)
-FRONTEND_TAG=$(date +%Y%m%d%H%M%S)
-docker build frontend \
-  --build-arg REACT_APP_API_URL=https://api-dev.commonly.me \
-  -t us-central1-docker.pkg.dev/commonly-493005/docker/commonly-frontend:${FRONTEND_TAG}
-docker push us-central1-docker.pkg.dev/commonly-493005/docker/commonly-frontend:${FRONTEND_TAG}
+Builds backend + frontend + clawdbot-gateway + commonly-bot in parallel from the dispatched ref, pushes to AR, helm-upgrades the dev cluster (~8–12 min). All four images get the same tag (short SHA of `HEAD`). **Whatever's on the dispatched ref is what ends up live** — see `feedback-deploy-dev-builds-only-main` memory; if a feature branch isn't merged yet, dispatching from `main` will strip it from the deployed images.
 
-# Gateway — build from _external/clawdbot/ (acpx + gh CLI pre-install)
-cd _external/clawdbot && docker build \
+**Escape hatch — local docker build** (only when CI is broken or for a hotfix the user explicitly wants by hand):
+
+```bash
+TAG=$(date +%Y%m%d%H%M%S)
+REG=<AR_REGISTRY_HOST>/<DEV_GCP_PROJECT_ID>/docker     # locally-resolved, never committed
+docker build backend  -t "$REG/commonly-backend:$TAG"  && docker push "$REG/commonly-backend:$TAG"
+docker build frontend --build-arg REACT_APP_API_URL=https://api-dev.commonly.me \
+  -t "$REG/commonly-frontend:$TAG" && docker push "$REG/commonly-frontend:$TAG"
+(cd _external/clawdbot && docker build \
   --build-arg OPENCLAW_EXTENSIONS=acpx \
   --build-arg OPENCLAW_INSTALL_GH_CLI=1 \
-  -t us-central1-docker.pkg.dev/commonly-493005/docker/clawdbot-gateway:${BACKEND_TAG} .
-docker push us-central1-docker.pkg.dev/commonly-493005/docker/clawdbot-gateway:${BACKEND_TAG}
+  -t "$REG/clawdbot-gateway:$TAG" . && docker push "$REG/clawdbot-gateway:$TAG")
 ```
+
+`gcloud builds submit` is blocked by the dev project's org policy on AR uploads, so don't reach for it.
 
 ### Testing
 ```bash

--- a/docs/AGENT_AVATARS.md
+++ b/docs/AGENT_AVATARS.md
@@ -65,18 +65,22 @@ already wires it to its own `OPENAI_API_KEY` env (optional, so LiteLLM boots fin
 without it — but image calls will 401 until you land the key).
 
 ```bash
+# Operator-local before running these (not committed):
+#   export GCP_PROJECT="$(gcloud config get-value project)"
+#   export GCP_ACCOUNT="$(gcloud config get-value account)"
+
 # Create the secret if it doesn't exist
 gcloud secrets create commonly-dev-openai-api-key \
   --replication-policy=automatic \
-  --project=commonly-493005 \
-  --account=lilyshen20021002@gmail.com
+  --project="$GCP_PROJECT" \
+  --account="$GCP_ACCOUNT"
 
 # Add a version with your key
 printf 'sk-proj-xxxxxxxxxxxxxxxxxxxxxx' | gcloud secrets versions add \
   commonly-dev-openai-api-key \
   --data-file=- \
-  --project=commonly-493005 \
-  --account=lilyshen20021002@gmail.com
+  --project="$GCP_PROJECT" \
+  --account="$GCP_ACCOUNT"
 
 # Force ESO to re-sync now (otherwise waits up to 1h)
 kubectl annotate externalsecret api-keys \

--- a/docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md
+++ b/docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md
@@ -42,7 +42,7 @@ Adopt a four-tier test taxonomy with explicit names and explicit PR gating, and 
 
 ### CI/CD to GKE
 
-**Auth: Workload Identity Federation only.** No service account JSON keys in GitHub secrets. One WIF pool in the `commonly-493005` GCP project federates trust to the `Team-Commonly/commonly` repo; GitHub Actions exchanges its OIDC token for a short-lived GCP access token via `google-github-actions/auth@v2`. Keys never leave GCP.
+**Auth: Workload Identity Federation only.** No service account JSON keys in GitHub secrets. One WIF pool in the dev GCP project federates trust to the `Team-Commonly/commonly` repo; GitHub Actions exchanges its OIDC token for a short-lived GCP access token via `google-github-actions/auth@v2`. Keys never leave GCP. (Project ID is supplied to the workflow at run-time via the `DEV_GCP_PROJECT_ID` GitHub secret — it is not committed anywhere in this repo.)
 
 **Triggers:**
 - **Dev**: merge to `main` → build images → push to `us-central1-docker.pkg.dev/...` → `helm upgrade commonly-dev` → Tier 3 smoke against `api-dev.commonly.me` → `helm rollback` on smoke failure.
@@ -141,13 +141,19 @@ Deferred. Preview environments per PR are the ideal but cost real GKE capacity p
 
 ### Phase 3 — WIF + dev deploy workflow (one PR + GCP setup)
 
+> **Status:** Operational as of 2026-04-29. The `Deploy Dev` workflow has shipped multiple PRs to `commonly-dev` end-to-end (PR #250, #252, #253, #251, #254 in a single evening). WIF mints a fresh OIDC token per run, exchanges for a short-lived GCP access token, builds the four images in parallel, helm-upgrades the dev cluster. Trigger: `gh workflow run deploy-dev.yml --ref <branch> --repo Team-Commonly/commonly`. The "retire values-private.yaml" sub-task below is still outstanding (operator-local file is materialized inside the workflow from a GitHub Actions secret today, but not yet decomposed into ESO-managed entries).
+>
+> **Operational gotcha (memory: `feedback-deploy-dev-builds-only-main`)**: the workflow rebuilds **all four images** from the dispatched ref. Dispatching `--ref main` while a feature branch isn't merged yet strips that work from the live frontend/backend image. This bit us once on the v2 mount on 2026-04-29 (recovery via `kubectl rollout undo deploy/frontend --to-revision=N`). Sequence the merge before the dispatch.
+
 - [ ] **GCP setup** (follow `docs/deployment/GITHUB_DEPLOY_SETUP.md` in full): WIF pool + GitHub provider with `assertion.repository=='Team-Commonly/commonly'` condition; `deploy-github` SA with `roles/artifactregistry.writer` on the `docker` repo, `roles/container.clusterViewer` at project level; Kubernetes `ClusterRoleBinding` of `edit` against the SA's identity on `commonly-dev` only.
 - [ ] **Secrets in GitHub:** `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`. **Environment:** create `dev` with no approvers.
 - [ ] **Submodule:** `actions/checkout@v4` with `submodules: recursive` — the gateway image is built from `_external/clawdbot/`, a git submodule. Without this the gateway build step fails immediately.
 - [ ] **Build step** (three images, one tag each, all set to the current commit SHA for simplicity and rollback symmetry):
   ```bash
   export IMG_TAG=${GITHUB_SHA::8}
-  export REG=us-central1-docker.pkg.dev/commonly-493005/docker
+  # REG is computed at workflow runtime from the DEV_GCP_PROJECT_ID secret —
+  # never committed inline (see feedback-no-infra-leak-in-public-repo memory).
+  export REG="${AR_REGISTRY_HOST}/${PROJECT_ID}/${AR_REPO}"
   docker build backend  -t $REG/commonly-backend:$IMG_TAG  && docker push $REG/commonly-backend:$IMG_TAG
   docker build frontend --build-arg REACT_APP_API_URL=https://api-dev.commonly.me -t $REG/commonly-frontend:$IMG_TAG && docker push $REG/commonly-frontend:$IMG_TAG
   cd _external/clawdbot && docker build --build-arg OPENCLAW_EXTENSIONS=acpx --build-arg OPENCLAW_INSTALL_GH_CLI=1 -t $REG/clawdbot-gateway:$IMG_TAG . && docker push $REG/clawdbot-gateway:$IMG_TAG
@@ -162,8 +168,8 @@ Deferred. Preview environments per PR are the ideal but cost real GKE capacity p
     --set agents.clawdbot.image.tag=$IMG_TAG
   ```
   Note the removed third `-f values-private.yaml` — covered by the next bullet.
-- [ ] **Retire `values-private.yaml`** (this is the load-bearing migration; no agent can do it without a human pulling the actual file from Lily's laptop):
-  - **Human action**: open `/home/xcjam/workspace/commonly/.dev/values-private.yaml` and categorize each key as (a) non-secret config → `values-dev.yaml` commit, (b) secret → GCP Secret Manager entry + `ExternalSecret` manifest under `k8s/helm/commonly/templates/`.
+- [ ] **Retire `values-private.yaml`** (this is the load-bearing migration; no agent can do it without a human pulling the actual file from the operator's laptop):
+  - **Human action**: open `.dev/values-private.yaml` (operator-local, gitignored) and categorize each key as (a) non-secret config → `values-dev.yaml` commit, (b) secret → GCP Secret Manager entry + `ExternalSecret` manifest under `k8s/helm/commonly/templates/`.
   - Non-secret keys expected (per CLAUDE.md §Kubernetes): `global.gcpProjectId`, `postgresql.host`, `*.image.repository` overrides. These go into `values-dev.yaml`; `values.yaml`'s `YOUR_GCP_PROJECT_ID` placeholders stay as the OSS-safe default.
   - Any key named like a credential (`*_password`, `*_token`, `*_key`, `jwtSecret`, `*_connectionString`) → Secret Manager. The existing `api-keys` ESO pattern (CLAUDE.md §Agent Runtime) is the template.
   - Update `docs/deployment/KUBERNETES.md` and `CLAUDE.md` §Kubernetes to remove the three-`-f` instruction and reference the new two-file shape.

--- a/docs/adr/ADR-011-shell-first-pre-gtm.md
+++ b/docs/adr/ADR-011-shell-first-pre-gtm.md
@@ -1,8 +1,25 @@
 # ADR-011: Shell-first pre-GTM
 
-**Status:** Draft — 2026-04-27
+**Status:** Active — 2026-04-27 (Phase 1 shipped 2026-04-29)
 **Author:** Sam Xu
 **Companion:** [`ADR-010`](ADR-010-commonly-mcp-server.md) (Phase 2+ paused under this ADR), [`CLAUDE.md`](../../CLAUDE.md) §Design Rules #5 ("the social surface has to earn human presence")
+
+---
+
+## Status update — 2026-04-29
+
+**Phase 1 of shell polish is on `main` and deployed.** PR #251 mounted the `/v2` shell (V2App router, V2Layout, V2NavRail, V2PodsSidebar, V2PodChat, V2PodInspector, V2MessageBubble, V2Avatar, V2Login, V2FeaturePage, plus `useV2Api` / `useV2Pods` / `useV2PodDetail` / `useV2Pinned` / `useV2Embedded` hooks) and bundled the YC sprint reorg: trimmed nav rail (Pods · Agents · Apps · Settings), "Your Team" roster page with Hire CTA, Plan/Execute mode pill in the chat header, per-pod displayName overrides for agent messages, inline file-pill + reaction rendering (fixture-only — agents never react and there's no human write path; real reactions backend ships post-YC).
+
+Three companion fixes shipped the same night:
+- PR #252 — POST `/api/messages/:podId` re-fetches via `PGMessage.findById` so the response carries the populated `userId` JOIN. Without this, optimistic chat rendered the author as `Unknown` until the next refresh.
+- PR #253 — `normalizeMongo` extracts `_id` when the userId field is a populated Mongoose document, instead of `.toString()`-ing the whole document into `util.inspect` output.
+- PR #254 — drop "powered by Claude" from the default openclaw `officialDescription`. Agents are runtime-driven, not Claude-specific.
+
+A real demo pod is live at `https://app-dev.commonly.me/v2/pods/<id>` with Engineer (Nova) + UI Lead (Pixel) + Pod Summarizer + Strategist (Aria, on `openai-codex/gpt-5.4-mini` after `aria` was added to `openclaw.devAgentIds`). First proof-of-life: Aria responded to a wedge-sentence critique mention with a substantive strategist-flavored reply on first try. The demo pod exists for the YC application sprint (deadline 2026-05-04 8pm PT) — the "demo IS the real session" thesis is being exercised this week.
+
+**Operational lesson worth carrying:** `Deploy Dev` (`.github/workflows/deploy-dev.yml`) builds and helm-upgrades all four images from the dispatched ref. If a feature branch isn't on `main` yet, dispatching `--ref main` strips it from the deployed images. Mid-deploy `kubectl rollout undo` races `--wait` and fails the helm step. Captured in the `feedback-deploy-dev-builds-only-main` memory; future shell polish work needs to land its branch on main *before* the next deploy cycle, not after.
+
+Phase 1 satisfies the "platform is no longer the binding constraint, surface is" framing of this ADR. Next polish targets stay queued (#62, #64, #65) plus the agent-install + first-DM hero flow.
 
 ---
 

--- a/docs/deployment/GITHUB_DEPLOY_SETUP.md
+++ b/docs/deployment/GITHUB_DEPLOY_SETUP.md
@@ -6,7 +6,7 @@ service account keys in GitHub. This runbook is the concrete gcloud sequence.
 
 Run the blocks below once from an account with `roles/owner` (or
 `roles/iam.workloadIdentityPoolAdmin` + `roles/iam.serviceAccountAdmin` +
-`roles/resourcemanager.projectIamAdmin`) on `commonly-493005`. Expect
+`roles/resourcemanager.projectIamAdmin`) on the dev GCP project. Expect
 ~15 minutes end-to-end.
 
 ---
@@ -14,8 +14,9 @@ Run the blocks below once from an account with `roles/owner` (or
 ## Prep
 
 ```bash
-# Replace if your project differs.
-export PROJECT_ID=commonly-493005
+# Operator-local: set to the dev GCP project ID (not committed; supplied
+# at workflow runtime via the DEV_GCP_PROJECT_ID GitHub Actions secret).
+export PROJECT_ID="$(gcloud config get-value project)"
 export PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format='value(projectNumber)')
 export REPO=Team-Commonly/commonly
 
@@ -167,7 +168,8 @@ Repo **Settings → Secrets and variables → Actions → Repository secrets**:
 
 ```
 WIF_PROVIDER          <value from above>
-WIF_SERVICE_ACCOUNT   deploy-github@commonly-493005.iam.gserviceaccount.com
+WIF_SERVICE_ACCOUNT   deploy-github@<PROJECT_ID>.iam.gserviceaccount.com
+DEV_GCP_PROJECT_ID    <PROJECT_ID>          # the workflow reads this and never logs it
 ```
 
 Repo **Settings → Environments**:


### PR DESCRIPTION
## Summary

**State update.** Reflect tonight's milestones in the docs that should be the source of truth:
- `CLAUDE.md` — Active Implementation Tracks marks Shell polish Phase 1 as shipped on 2026-04-29 (v2 mount + sprint reorg landed via PR #251). CURRENT STATE block + Kubernetes + Build & Deploy sections collapse around the `Deploy Dev` workflow as the supported path; local docker build is named as the escape hatch.
- `docs/adr/ADR-011-shell-first-pre-gtm.md` — moved from Draft to Active and added a 2026-04-29 status update capturing what landed (PRs #251 / #252 / #253 / #254), the live demo pod, Aria's first proof-of-life reply, and the deploy-dev "must-include-feature-branch-on-the-dispatched-ref" gotcha.
- `docs/adr/ADR-009-test-tiers-and-ci-cd-to-gke.md` — Phase 3 gets an operational-status callout (workflow has shipped multiple PRs end-to-end) and the same gotcha note for any agent reading the ADR fresh.

**Scrub committed infra identifiers.** Per the `feedback-no-infra-leak-in-public-repo` policy: the dev GCP project ID, ops account email, AR registry path, and absolute laptop paths were leaking through CLAUDE.md, ADR-009, AGENT_AVATARS.md, and GITHUB_DEPLOY_SETUP.md. Replaced with placeholders + runtime env / GitHub-secret references. The values themselves stay operator-local (`.dev/values-private.yaml`, GitHub Actions secrets, ESO).

## Caveats / not in scope
- Older history still carries the old strings (this is a forward fix, not a `git filter-branch`). Per memory, the project ID isn't a true secret — just a sensitive identifier we don't want in the public OSS surface — so a forward fix is sufficient.
- The bigger restructure of CLAUDE.md (slim it to a true index-only doc with operational details extracted to dedicated files) is a separate follow-up; tonight's edits are targeted.

## Test plan
- [ ] `grep -r "commonly-493005\|lilyshen20021002\|disco-catcher\|huboyang0410" docs CLAUDE.md README.md AGENTS.md` returns nothing on `main` after merge.
- [ ] `Deploy Dev` workflow still resolves `PROJECT_ID` correctly from the `DEV_GCP_PROJECT_ID` GH secret (no behavior change — the workflow already reads it; this PR only changes how the surrounding docs describe it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)