### PR TITLE
fix(v2): collapse pod inspector by default + filter Direct Threads to user's DMable rooms

### DIFF
--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import V2NavRail from './V2NavRail';
 import V2PodsSidebar from './V2PodsSidebar';
@@ -11,11 +11,42 @@ interface V2LayoutProps {
   selectionMode?: 'auto' | 'param';
 }
 
+const INSPECTOR_PREF_KEY = 'v2.inspectorCollapsed';
+
+const readInspectorCollapsed = (): boolean => {
+  try {
+    const v = localStorage.getItem(INSPECTOR_PREF_KEY);
+    // Default to collapsed — pod chat reads better when the third column is
+    // out of the way until you ask for it. See user feedback 2026-04-30.
+    if (v === null) return true;
+    return v === '1';
+  } catch {
+    return true;
+  }
+};
+
+const writeInspectorCollapsed = (next: boolean) => {
+  try {
+    localStorage.setItem(INSPECTOR_PREF_KEY, next ? '1' : '0');
+  } catch {
+    // localStorage unavailable; revert to default on next render.
+  }
+};
+
 const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   const { podId: paramPodId } = useParams<{ podId: string }>();
   const navigate = useNavigate();
   const podsState = useV2Pods();
   const { pods, loading } = podsState;
+
+  const [inspectorCollapsed, setInspectorCollapsed] = useState<boolean>(readInspectorCollapsed());
+  const toggleInspector = useCallback(() => {
+    setInspectorCollapsed((prev) => {
+      const next = !prev;
+      writeInspectorCollapsed(next);
+      return next;
+    });
+  }, []);
 
   // Auto-pick the first pod when the user lands on /v2 directly, so the
   // three-column layout doesn't render an empty main pane on first load.
@@ -27,12 +58,25 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   const selectedPodId = paramPodId || null;
   const detail = useV2PodDetail(selectedPodId);
 
+  const shellClass = [
+    'v2-shell',
+    selectedPodId ? '' : 'v2-shell--no-inspector',
+    selectedPodId && inspectorCollapsed ? 'v2-shell--inspector-collapsed' : '',
+  ].filter(Boolean).join(' ');
+
   return (
-    <div className={`v2-shell${selectedPodId ? '' : ' v2-shell--no-inspector'}`}>
+    <div className={shellClass}>
       <V2NavRail />
       <V2PodsSidebar selectedPodId={selectedPodId} podsState={podsState} />
       <V2PodChat detail={detail} podsState={podsState} />
-      {selectedPodId && <V2PodInspector detail={detail} podsState={podsState} />}
+      {selectedPodId && (
+        <V2PodInspector
+          detail={detail}
+          podsState={podsState}
+          collapsed={inspectorCollapsed}
+          onToggle={toggleInspector}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -4,12 +4,32 @@ import V2Avatar from './V2Avatar';
 import { UseV2PodDetailResult, V2Agent } from '../hooks/useV2PodDetail';
 import { UseV2PodsResult } from '../hooks/useV2Pods';
 import { useV2Api } from '../hooks/useV2Api';
+import { useAuth } from '../../context/AuthContext';
 import { formatRelativeTime } from '../utils/grouping';
 
 interface V2PodInspectorProps {
   detail: UseV2PodDetailResult;
   podsState?: UseV2PodsResult;
+  collapsed?: boolean;
+  onToggle?: () => void;
 }
+
+// Only openclaw-runtime agents can hold a real DM session — they have a chat
+// runtime that responds. commonly-bot is the internal Tier 1 summarizer (no
+// chat runtime); pod-summarizer is Tier 1 native (also no DM). Future native
+// agents that want to show up here should declare a chat-capable runtime; the
+// frontend gates on agentName so we don't paper over a missing capability.
+const isAgentDmable = (agent: { agentName?: string }): boolean => (
+  agent.agentName === 'openclaw'
+);
+
+// Direct-thread room names that should never appear in the user's "Direct
+// Threads" list, regardless of who's a member. Mirrors isAgentDmable above —
+// these agents have no chat runtime, so a DM room would just sit there empty.
+const NON_DMABLE_ROOM_NAME_PREFIXES = ['commonly-bot', 'pod-summarizer'];
+const isRoomDmable = (name: string): boolean => (
+  !NON_DMABLE_ROOM_NAME_PREFIXES.some((prefix) => name === prefix || name.startsWith(`${prefix} `))
+);
 
 interface AgentTaskMap {
   [agentName: string]: { taskId: string; title: string } | null;
@@ -39,10 +59,13 @@ const Icon = ({ d, size = 14 }: { d: string; size?: number }) => (
   </svg>
 );
 
-const V2PodInspector: React.FC<V2PodInspectorProps> = ({ detail, podsState }) => {
+const V2PodInspector: React.FC<V2PodInspectorProps> = ({
+  detail, podsState, collapsed = false, onToggle,
+}) => {
   const { pod, members, agents } = detail;
   const api = useV2Api();
   const navigate = useNavigate();
+  const { currentUser } = useAuth();
   const [agentTasks, setAgentTasks] = useState<AgentTaskMap>({});
   const [privateError, setPrivateError] = useState<string | null>(null);
   const [announcements, setAnnouncements] = useState<AnnouncementItem[]>([]);
@@ -104,6 +127,24 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({ detail, podsState }) =>
 
   if (!pod) return <aside className="v2-pane v2-pane--inspector" />;
 
+  if (collapsed) {
+    return (
+      <aside className="v2-pane v2-pane--inspector v2-pane--inspector-collapsed">
+        <button
+          type="button"
+          className="v2-inspector__toggle v2-inspector__toggle--expand"
+          onClick={onToggle}
+          title="Show pod inspector"
+          aria-label="Show pod inspector"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="15 6 9 12 15 18" />
+          </svg>
+        </button>
+      </aside>
+    );
+  }
+
   const isPrivatePod = pod.type === 'agent-room';
   const humanCount = members.filter((member) => !member.isBot).length;
   const agentCount = agents.length;
@@ -143,6 +184,17 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({ detail, podsState }) =>
   return (
     <aside className="v2-pane v2-pane--inspector">
       <div className="v2-inspector">
+        <button
+          type="button"
+          className="v2-inspector__toggle v2-inspector__toggle--collapse"
+          onClick={onToggle}
+          title="Hide pod inspector"
+          aria-label="Hide pod inspector"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="9 6 15 12 9 18" />
+          </svg>
+        </button>
         <section className="v2-inspector__now">
           <div className="v2-inspector__now-kicker">Now</div>
           <div className="v2-inspector__now-state">
@@ -235,14 +287,16 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({ detail, podsState }) =>
                     )}
                   </div>
                 </div>
-                <button
-                  type="button"
-                  className="v2-inspector__more-btn"
-                  title="Open private pod"
-                  onClick={() => openPrivatePod(agent)}
-                >
-                  DM
-                </button>
+                {isAgentDmable(agent) && (
+                  <button
+                    type="button"
+                    className="v2-inspector__more-btn"
+                    title="Open private pod"
+                    onClick={() => openPrivatePod(agent)}
+                  >
+                    DM
+                  </button>
+                )}
               </div>
             );
           })}
@@ -264,6 +318,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({ detail, podsState }) =>
           <AgentConversations
             podMembers={members.map((m) => m.username || '').filter(Boolean)}
             podCreatedAt={pod.updatedAt}
+            currentUserId={currentUser?._id || null}
           />
         </section>
         )}
@@ -335,11 +390,26 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({ detail, podsState }) =>
 interface AgentConversationsProps {
   podMembers: string[];
   podCreatedAt?: string;
+  currentUserId: string | null;
+}
+
+interface RoomMember { _id?: string; username?: string }
+interface AgentRoomPayload {
+  _id: string;
+  name: string;
+  updatedAt?: string;
+  members?: RoomMember[];
 }
 
 // Best-effort: list this user's agent-room DM pods. Backend currently exposes
 // 1:1 human↔agent DMs; this view only renders rooms returned by the API.
-const AgentConversations: React.FC<AgentConversationsProps> = ({ podMembers, podCreatedAt }) => {
+//
+// /api/pods?type=agent-room returns ALL agent-rooms instance-wide for global
+// admins (intentional, for moderation per ADR-001 §3.10), so we filter to
+// rooms the current user is a member of before rendering. We also drop rooms
+// for agents that don't actually hold DMs (commonly-bot, pod-summarizer —
+// see isRoomDmable above), and dedupe by id as a defensive measure.
+const AgentConversations: React.FC<AgentConversationsProps> = ({ podMembers, podCreatedAt, currentUserId }) => {
   const api = useV2Api();
   const navigate = useNavigate();
   const [rooms, setRooms] = useState<Array<{ id: string; name: string; updatedAt?: string }>>([]);
@@ -348,16 +418,29 @@ const AgentConversations: React.FC<AgentConversationsProps> = ({ podMembers, pod
     let cancelled = false;
     (async () => {
       try {
-        const data = await api.get<Array<{ _id: string; name: string; updatedAt?: string }>>('/api/pods?type=agent-room');
+        const data = await api.get<AgentRoomPayload[]>('/api/pods?type=agent-room');
         if (cancelled) return;
         const list = Array.isArray(data) ? data : [];
-        setRooms(list.slice(0, 5).map((r) => ({ id: r._id, name: r.name, updatedAt: r.updatedAt })));
+        const seen = new Set<string>();
+        const filtered: Array<{ id: string; name: string; updatedAt?: string }> = [];
+        for (const r of list) {
+          if (!r || !r._id || seen.has(r._id)) continue;
+          if (!isRoomDmable(r.name || '')) continue;
+          if (currentUserId) {
+            const isMember = (r.members || []).some((m) => m && m._id === currentUserId);
+            if (!isMember) continue;
+          }
+          seen.add(r._id);
+          filtered.push({ id: r._id, name: r.name, updatedAt: r.updatedAt });
+          if (filtered.length >= 5) break;
+        }
+        setRooms(filtered);
       } catch {
         if (!cancelled) setRooms([]);
       }
     })();
     return () => { cancelled = true; };
-  }, [api]);
+  }, [api, currentUserId]);
 
   if (rooms.length === 0) {
     return (

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -212,6 +212,13 @@
   grid-template-columns: var(--v2-rail-w) var(--v2-pods-w) 1fr;
 }
 
+/* Collapsed inspector keeps a thin column with just a chevron toggle, so the
+ * "expand inspector" affordance stays discoverable without the full panel
+ * eating chat width. Width matches the rail so the visual rhythm holds. */
+.v2-shell--inspector-collapsed {
+  grid-template-columns: var(--v2-rail-w) var(--v2-pods-w) 1fr 32px;
+}
+
 .v2-shell--feature {
   grid-template-columns: var(--v2-rail-w) var(--v2-pods-w) minmax(0, 1fr);
 }
@@ -242,6 +249,45 @@
   border-right: none;
   border-left: 1px solid var(--v2-border-soft);
   background: var(--v2-surface-tint);
+}
+
+.v2-pane--inspector-collapsed {
+  background: var(--v2-bg-subtle);
+  align-items: center;
+  padding-top: 10px;
+}
+
+/* Toggle chevrons — one for "collapse" inside the full inspector header, one
+ * for "expand" in the slim collapsed inspector. Both are subtle so they read
+ * as utility, not destination. */
+.v2-inspector__toggle {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  border: 1px solid var(--v2-border-soft);
+  background: var(--v2-surface);
+  color: var(--v2-text-tertiary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.v2-inspector__toggle:hover {
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
+  border-color: var(--v2-border-strong);
+}
+
+.v2-inspector__toggle--collapse {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+.v2-inspector__toggle--expand {
+  margin: 4px 0 0 0;
 }
 
 /* ---------- Nav rail ---------- */
@@ -1427,6 +1473,7 @@
   display: flex;
   flex-direction: column;
   gap: 0;
+  position: relative;
 }
 
 .v2-inspector__now {


### PR DESCRIPTION
## Summary
Two related inspector cleanups, surfaced while screen-recording the demo pod:

1. **Collapse-by-default for the right inspector column.** The People & Agents + Direct Threads + Settings panel was eating chat width by default. Default to a thin chevron-only column; persist the user's preference in `localStorage`. Full panel re-opens on chevron click; slim collapsed column keeps the affordance discoverable.

2. **Direct Threads + DM affordance filtering.**
   - Drop rooms whose agent has no chat runtime (`commonly-bot` Tier 1 summarizer, `pod-summarizer` Tier 1 native). The People & Agents row's `DM` button is gated by the same rule — only `agentName === 'openclaw'` agents get the affordance.
   - Filter to rooms the current user is actually a member of. `/api/pods?type=agent-room` hands global admins the full instance-wide list (intentional for moderation per ADR-001 §3.10) but the inspector wants the personal list. Read `currentUser` from `AuthContext` and filter client-side by membership.
   - Dedupe by id as a defensive measure. The original bug report ("commonly-bot shows twice") turned out to be two separate users' DM rooms with commonly-bot leaking through the admin view — both filters above resolve it.

## What this isn't
- Not a backend change. `/api/pods?type=agent-room` still returns the admin-bypassed instance-wide list. A `?mine=true` flag would be cleaner long-term but isn't required for this fix.
- Not a removal of commonly-bot or pod-summarizer from the pod. They're still installed; we're just not pretending they hold DMs.

## Test plan
- [ ] Existing V2Login tests still pass (V2Layout signature change is additive — only new optional props on the inspector).
- [ ] After deploy: open `/v2/pods/<podId>`, confirm right column collapsed-by-default with a chevron tab. Click the tab; full inspector expands; collapse chevron in inspector header collapses it back. Reload the page; preference persists.
- [ ] Direct Threads list shows only Sam's own rooms, no commonly-bot or pod-summarizer entries.
- [ ] People & Agents list: `DM` button visible on Engineer (Nova) / UI Lead (Pixel) / Strategist (Aria); absent on Pod Summarizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)