### PR TITLE
fix(v2): restore DM button on openclaw agents (wire shape mismatch)

### DIFF
--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -18,10 +18,15 @@ interface V2PodInspectorProps {
 // runtime that responds. commonly-bot is the internal Tier 1 summarizer (no
 // chat runtime); pod-summarizer is Tier 1 native (also no DM). Future native
 // agents that want to show up here should declare a chat-capable runtime; the
-// frontend gates on agentName so we don't paper over a missing capability.
-const isAgentDmable = (agent: { agentName?: string }): boolean => (
-  agent.agentName === 'openclaw'
-);
+// frontend gates on the agent name so we don't paper over a missing capability.
+//
+// The wire payload (per buildAgentInstallationPayload) returns `name`, but the
+// V2Agent type also declares `agentName`. Read both — same shape mismatch as
+// V2PodChat works around for the displayName map.
+const isAgentDmable = (agent: { name?: string; agentName?: string }): boolean => {
+  const n = agent.name || agent.agentName;
+  return n === 'openclaw';
+};
 
 // Direct-thread room names that should never appear in the user's "Direct
 // Threads" list, regardless of who's a member. Mirrors isAgentDmable above —


### PR DESCRIPTION
## Summary
Hot follow-up to PR #257. The `isAgentDmable` helper introduced there checked `agent.agentName === 'openclaw'`, but `/api/registry/pods/:id/agents` returns the agent type as `name` on the wire — the same shape mismatch V2PodChat already works around for the displayName map. Net effect: the DM button disappeared from every agent row in the right rail (Nova / Pixel / Aria included), because `agent.agentName` was undefined.

Read both `agent.name` (wire) and `agent.agentName` (V2Agent type), match the existing pattern in V2PodChat:233.

## Test plan
- [ ] After deploy: `Engineer (Nova)`, `UI Lead (Pixel)`, `Strategist (Aria)` show their `DM` button again.
- [ ] `Pod Summarizer` still has no DM button (correct — it's Tier 1 native, not openclaw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)