### PR TITLE
feat(v2): subtle inspector entry + tabbed content (drop chevron)

### DIFF
--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -58,23 +58,27 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   const selectedPodId = paramPodId || null;
   const detail = useV2PodDetail(selectedPodId);
 
-  const shellClass = [
-    'v2-shell',
-    selectedPodId ? '' : 'v2-shell--no-inspector',
-    selectedPodId && inspectorCollapsed ? 'v2-shell--inspector-collapsed' : '',
-  ].filter(Boolean).join(' ');
+  // The inspector is a separate column only when expanded. When collapsed,
+  // it's not rendered at all and the chat extends to the right edge — the
+  // entry point is the avatar group in the chat header (see V2PodChat).
+  const showInspector = Boolean(selectedPodId && !inspectorCollapsed);
+  const shellClass = ['v2-shell', !showInspector ? 'v2-shell--no-inspector' : ''].filter(Boolean).join(' ');
 
   return (
     <div className={shellClass}>
       <V2NavRail />
       <V2PodsSidebar selectedPodId={selectedPodId} podsState={podsState} />
-      <V2PodChat detail={detail} podsState={podsState} />
-      {selectedPodId && (
+      <V2PodChat
+        detail={detail}
+        podsState={podsState}
+        inspectorCollapsed={inspectorCollapsed}
+        onToggleInspector={selectedPodId ? toggleInspector : undefined}
+      />
+      {selectedPodId && !inspectorCollapsed && (
         <V2PodInspector
           detail={detail}
           podsState={podsState}
-          collapsed={inspectorCollapsed}
-          onToggle={toggleInspector}
+          onClose={toggleInspector}
         />
       )}
     </div>

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -124,6 +124,11 @@ const writeMode = (podId: string, mode: PodMode) => {
 interface V2PodChatProps {
   detail: UseV2PodDetailResult;
   podsState?: UseV2PodsResult;
+  // Inspector wiring — when present, the avatar group becomes the "show team"
+  // entry. Inspector itself is rendered by V2Layout so this is just the
+  // hand-off point.
+  inspectorCollapsed?: boolean;
+  onToggleInspector?: () => void;
 }
 
 const Icon = ({ d }: { d: string }) => (
@@ -241,7 +246,7 @@ const V2SummaryView: React.FC<{ podId: string; description?: string }> = ({ podI
   );
 };
 
-const V2PodChat: React.FC<V2PodChatProps> = ({ detail }) => {
+const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onToggleInspector }) => {
   const { pod, members, messages, agents, sendMessage, loading, error } = detail;
   const navigate = useNavigate();
   const api = useV2Api();
@@ -614,14 +619,32 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail }) => {
               </button>
             </div>
 
-            <div className="v2-chat__avatars">
-              {visibleMembers.map((m) => (
-                <V2Avatar key={m._id || m.username} name={m.username} src={m.profilePicture || undefined} size="md" />
-              ))}
-              {memberCountExtra > 0 && (
-                <span className="v2-chat__avatars-more">+{memberCountExtra}</span>
-              )}
-            </div>
+            {onToggleInspector ? (
+              <button
+                type="button"
+                className={`v2-chat__avatars v2-chat__avatars--button${inspectorCollapsed ? '' : ' v2-chat__avatars--active'}`}
+                onClick={onToggleInspector}
+                title={inspectorCollapsed ? 'View pod team' : 'Hide pod team'}
+                aria-label={inspectorCollapsed ? 'View pod team' : 'Hide pod team'}
+                aria-pressed={!inspectorCollapsed}
+              >
+                {visibleMembers.map((m) => (
+                  <V2Avatar key={m._id || m.username} name={m.username} src={m.profilePicture || undefined} size="md" />
+                ))}
+                {memberCountExtra > 0 && (
+                  <span className="v2-chat__avatars-more">+{memberCountExtra}</span>
+                )}
+              </button>
+            ) : (
+              <div className="v2-chat__avatars">
+                {visibleMembers.map((m) => (
+                  <V2Avatar key={m._id || m.username} name={m.username} src={m.profilePicture || undefined} size="md" />
+                ))}
+                {memberCountExtra > 0 && (
+                  <span className="v2-chat__avatars-more">+{memberCountExtra}</span>
+                )}
+              </div>
+            )}
 
             <div className={`v2-chat__mode-toggle v2-chat__mode-toggle--header v2-chat__mode-toggle--${mode}`} role="group" aria-label="Pod mode preference">
               <button

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -10,9 +10,25 @@ import { formatRelativeTime } from '../utils/grouping';
 interface V2PodInspectorProps {
   detail: UseV2PodDetailResult;
   podsState?: UseV2PodsResult;
-  collapsed?: boolean;
-  onToggle?: () => void;
+  // V2Layout decides whether to mount this at all; collapsed-state used to
+  // be rendered as a thin chevron column, but the entry is now the chat
+  // header avatar group (see V2PodChat). onClose dismisses it.
+  onClose?: () => void;
 }
+
+type InspectorTab = 'people' | 'activity' | 'settings';
+const INSPECTOR_TAB_KEY = 'v2.inspectorTab';
+const readInspectorTab = (): InspectorTab => {
+  try {
+    const v = localStorage.getItem(INSPECTOR_TAB_KEY);
+    return v === 'activity' || v === 'settings' ? v : 'people';
+  } catch {
+    return 'people';
+  }
+};
+const writeInspectorTab = (tab: InspectorTab) => {
+  try { localStorage.setItem(INSPECTOR_TAB_KEY, tab); } catch { /* ignore */ }
+};
 
 // Only openclaw-runtime agents can hold a real DM session — they have a chat
 // runtime that responds. commonly-bot is the internal Tier 1 summarizer (no
@@ -65,7 +81,7 @@ const Icon = ({ d, size = 14 }: { d: string; size?: number }) => (
 );
 
 const V2PodInspector: React.FC<V2PodInspectorProps> = ({
-  detail, podsState, collapsed = false, onToggle,
+  detail, podsState, onClose,
 }) => {
   const { pod, members, agents } = detail;
   const api = useV2Api();
@@ -75,6 +91,11 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   const [privateError, setPrivateError] = useState<string | null>(null);
   const [announcements, setAnnouncements] = useState<AnnouncementItem[]>([]);
   const [externalLinks, setExternalLinks] = useState<ExternalLinkItem[]>([]);
+  const [tab, setTab] = useState<InspectorTab>(() => readInspectorTab());
+  const handleSetTab = (next: InspectorTab) => {
+    setTab(next);
+    writeInspectorTab(next);
+  };
 
   // For each agent, find their most recent active task. This is our best
   // approximation of "Working on X" since the backend doesn't track a
@@ -132,24 +153,6 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
 
   if (!pod) return <aside className="v2-pane v2-pane--inspector" />;
 
-  if (collapsed) {
-    return (
-      <aside className="v2-pane v2-pane--inspector v2-pane--inspector-collapsed">
-        <button
-          type="button"
-          className="v2-inspector__toggle v2-inspector__toggle--expand"
-          onClick={onToggle}
-          title="Show pod inspector"
-          aria-label="Show pod inspector"
-        >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <polyline points="15 6 9 12 15 18" />
-          </svg>
-        </button>
-      </aside>
-    );
-  }
-
   const isPrivatePod = pod.type === 'agent-room';
   const humanCount = members.filter((member) => !member.isBot).length;
   const agentCount = agents.length;
@@ -186,139 +189,105 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
     if (deleted) navigate('/v2', { replace: true });
   };
 
-  return (
-    <aside className="v2-pane v2-pane--inspector">
-      <div className="v2-inspector">
+  const podOverview = (
+    <section className="v2-inspector__card">
+      <div className="v2-inspector__pod-card">
+        <div className="v2-inspector__pod-head">
+          <V2Avatar name={pod.name} size="md" />
+          <div className="v2-inspector__pod-name">{pod.name}</div>
+        </div>
+        <div className="v2-inspector__pod-meta">
+          Created by {pod.createdBy?.username || 'unknown'} · {created}
+        </div>
+        <div className="v2-inspector__pod-counts">
+          {!isPrivatePod && <span>{agentCount} agent{agentCount === 1 ? '' : 's'}</span>}
+          {!isPrivatePod && <span>·</span>}
+          <span>{humanCount} human{humanCount === 1 ? '' : 's'}</span>
+        </div>
+        {pod.description && <div className="v2-inspector__objective">{pod.description}</div>}
+      </div>
+    </section>
+  );
+
+  const peopleSection = !isPrivatePod && (
+    <section className="v2-inspector__card">
+      <div className="v2-inspector__section-head">
+        <span className="v2-inspector__section-title">Team ({agentCount + humanCount})</span>
         <button
           type="button"
-          className="v2-inspector__toggle v2-inspector__toggle--collapse"
-          onClick={onToggle}
-          title="Hide pod inspector"
-          aria-label="Hide pod inspector"
+          className="v2-inspector__section-action"
+          onClick={() => navigate(`/v2/agents?podId=${pod._id}`)}
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <polyline points="9 6 15 12 9 18" />
-          </svg>
+          Manage
         </button>
-        <section className="v2-inspector__now">
-          <div className="v2-inspector__now-kicker">Now</div>
-          <div className="v2-inspector__now-state">
-            <span className={`v2-inspector__now-dot v2-inspector__now-dot--${onlineAgentCount > 0 ? 'running' : 'idle'}`} />
-            {liveState}
-          </div>
-          <div className="v2-inspector__now-copy">
-            {onlineAgentCount > 0
-              ? `${onlineAgentCount} agent${onlineAgentCount === 1 ? '' : 's'} recently active in this pod.`
-              : 'No agent heartbeat was detected in the recent activity window.'}
-          </div>
-        </section>
-
-        <section className="v2-inspector__card">
-          <div className="v2-inspector__section-head">
-            <span className="v2-inspector__section-title">Overview</span>
-            <button
-              type="button"
-              className="v2-inspector__section-action"
-              onClick={() => navigate(`/v2/pods/${pod.type || 'chat'}/${pod._id}`)}
-            >
-              Edit
-            </button>
-          </div>
-          <div className="v2-inspector__pod-card">
-            <div className="v2-inspector__pod-head">
-              <V2Avatar name={pod.name} size="md" />
-              <div className="v2-inspector__pod-name">{pod.name}</div>
-            </div>
-            <div className="v2-inspector__pod-meta">
-              Created by {pod.createdBy?.username || 'unknown'} · {created}
-            </div>
-            <div className="v2-inspector__pod-counts">
-              {!isPrivatePod && <span>{agentCount} agent{agentCount === 1 ? '' : 's'}</span>}
-              {!isPrivatePod && <span>·</span>}
-              <span>{humanCount} human{humanCount === 1 ? '' : 's'}</span>
-            </div>
-            {pod.description && <div className="v2-inspector__objective">{pod.description}</div>}
-          </div>
-        </section>
-
-        {!isPrivatePod && (
-        <section className="v2-inspector__card">
-          <div className="v2-inspector__section-head">
-            <span className="v2-inspector__section-title">People & Agents ({agentCount + humanCount})</span>
-            <button
-              type="button"
-              className="v2-inspector__section-action"
-              onClick={() => navigate(`/v2/agents?podId=${pod._id}`)}
-            >
-              Manage
-            </button>
-          </div>
-          {agents.length === 0 && (
-            <div className="v2-mute" style={{ fontSize: 12 }}>
-              No agents installed in this pod.
-            </div>
-          )}
-          {privateError && <div className="v2-chat__error">{privateError}</div>}
-          {agents.map((agent: V2Agent) => {
-            const name = agent.profile?.displayName || agent.displayName || agent.agentName;
-            const key = agent.instanceId || agent.agentName;
-            const isOnline = !!agent.lastHeartbeatAt
-              && Date.now() - new Date(agent.lastHeartbeatAt).getTime() < 10 * 60 * 1000;
-            const task = agentTasks[key];
-            return (
-              <div key={key} className="v2-inspector__agent-row">
-                <V2Avatar
-                  name={name}
-                  src={agent.profile?.avatarUrl || agent.profile?.iconUrl || agent.iconUrl || undefined}
-                  size="md"
-                  online={isOnline}
-                />
-                <div className="v2-inspector__agent-info">
-                  <div className="v2-inspector__agent-head">
-                    <span className="v2-inspector__agent-name">{name}</span>
-                  </div>
-                  <div className="v2-inspector__agent-status">
-                    <span className="v2-online-dot" style={{ background: isOnline ? 'var(--v2-success)' : 'var(--v2-text-muted)' }} />
-                    {isOnline ? 'Online' : 'Idle'}
-                  </div>
-                  <div className="v2-inspector__agent-task">
-                    {task ? (
-                      <>
-                        <span className="v2-inspector__agent-task-label">Working on </span>
-                        <span className="v2-inspector__agent-task-value">{task.title}</span>
-                      </>
-                    ) : (
-                      <span className="v2-inspector__agent-task-label">No active task</span>
-                    )}
-                  </div>
-                </div>
-                {isAgentDmable(agent) && (
-                  <button
-                    type="button"
-                    className="v2-inspector__more-btn"
-                    title="Open private pod"
-                    onClick={() => openPrivatePod(agent)}
-                  >
-                    DM
-                  </button>
-                )}
+      </div>
+      {agents.length === 0 && (
+        <div className="v2-mute" style={{ fontSize: 12 }}>No agents installed in this pod.</div>
+      )}
+      {privateError && <div className="v2-chat__error">{privateError}</div>}
+      {agents.map((agent: V2Agent) => {
+        const name = agent.profile?.displayName || agent.displayName || agent.agentName;
+        const key = agent.instanceId || agent.agentName;
+        const isOnline = !!agent.lastHeartbeatAt
+          && Date.now() - new Date(agent.lastHeartbeatAt).getTime() < 10 * 60 * 1000;
+        const task = agentTasks[key];
+        return (
+          <div key={key} className="v2-inspector__agent-row">
+            <V2Avatar
+              name={name}
+              src={agent.profile?.avatarUrl || agent.profile?.iconUrl || agent.iconUrl || undefined}
+              size="md"
+              online={isOnline}
+            />
+            <div className="v2-inspector__agent-info">
+              <div className="v2-inspector__agent-head">
+                <span className="v2-inspector__agent-name">{name}</span>
               </div>
-            );
-          })}
-        </section>
-        )}
+              <div className="v2-inspector__agent-status">
+                <span className="v2-online-dot" style={{ background: isOnline ? 'var(--v2-success)' : 'var(--v2-text-muted)' }} />
+                {isOnline ? 'Online' : 'Idle'}
+              </div>
+              {task && (
+                <div className="v2-inspector__agent-task">
+                  <span className="v2-inspector__agent-task-label">Working on </span>
+                  <span className="v2-inspector__agent-task-value">{task.title}</span>
+                </div>
+              )}
+            </div>
+            {isAgentDmable(agent) && (
+              <button
+                type="button"
+                className="v2-inspector__more-btn"
+                title="Open private pod"
+                onClick={() => openPrivatePod(agent)}
+              >
+                DM
+              </button>
+            )}
+          </div>
+        );
+      })}
+    </section>
+  );
 
-        {!isPrivatePod && (
+  const activitySection = (
+    <>
+      <section className="v2-inspector__card">
+        <div className="v2-inspector__now-state">
+          <span className={`v2-inspector__now-dot v2-inspector__now-dot--${onlineAgentCount > 0 ? 'running' : 'idle'}`} />
+          {liveState}
+        </div>
+        <div className="v2-inspector__now-copy">
+          {onlineAgentCount > 0
+            ? `${onlineAgentCount} agent${onlineAgentCount === 1 ? '' : 's'} recently active in this pod.`
+            : 'No agent heartbeat was detected in the recent activity window.'}
+        </div>
+      </section>
+      {!isPrivatePod && (
         <section className="v2-inspector__card">
           <div className="v2-inspector__section-head">
             <span className="v2-inspector__section-title">Direct Threads</span>
-            <button
-              type="button"
-              className="v2-inspector__section-action"
-              onClick={() => navigate('/v2')}
-            >
-              See all
-            </button>
+            <button type="button" className="v2-inspector__section-action" onClick={() => navigate('/v2')}>See all</button>
           </div>
           <AgentConversations
             podMembers={members.map((m) => m.username || '').filter(Boolean)}
@@ -326,9 +295,13 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
             currentUserId={currentUser?._id || null}
           />
         </section>
-        )}
+      )}
+    </>
+  );
 
-        {!isPrivatePod && (announcements.length > 0 || externalLinks.length > 0) && (
+  const settingsSection = (
+    <>
+      {!isPrivatePod && (announcements.length > 0 || externalLinks.length > 0) && (
         <section className="v2-inspector__card">
           <div className="v2-inspector__section-head">
             <span className="v2-inspector__section-title">Resources</span>
@@ -352,41 +325,79 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
             </a>
           ))}
         </section>
-        )}
+      )}
+      <section className="v2-inspector__card">
+        <div className="v2-inspector__settings-menu">
+          <button
+            type="button"
+            className="v2-inspector__settings-chip"
+            onClick={() => navigate(`/v2/agents?podId=${pod._id}`)}
+          >
+            <Icon d="M12 5v14M5 12h14" />
+            Add agents
+          </button>
+          <button
+            type="button"
+            className="v2-inspector__settings-chip"
+            onClick={() => navigate(`/v2/pods/${pod.type || 'chat'}/${pod._id}`)}
+          >
+            <Icon d="M12 15a3 3 0 100-6 3 3 0 000 6z" />
+            Pod settings
+          </button>
+          {podsState && (
+            <button
+              type="button"
+              className="v2-inspector__settings-chip v2-inspector__settings-chip--danger"
+              onClick={handleDeletePod}
+            >
+              <Icon d="M3 6h18M8 6V4h8v2M10 11v6M14 11v6M5 6l1 14h12l1-14" />
+              Delete pod
+            </button>
+          )}
+        </div>
+      </section>
+    </>
+  );
 
-        <section className="v2-inspector__card">
-          <div className="v2-inspector__section-head">
-            <span className="v2-inspector__section-title">Settings</span>
-          </div>
-          <div className="v2-inspector__settings-menu">
+  return (
+    <aside className="v2-pane v2-pane--inspector">
+      <div className="v2-inspector">
+        <header className="v2-inspector__header">
+          {podOverview}
+          {onClose && (
             <button
               type="button"
-              className="v2-inspector__settings-chip"
-              onClick={() => navigate(`/v2/agents?podId=${pod._id}`)}
+              className="v2-inspector__close"
+              onClick={onClose}
+              title="Hide pod team"
+              aria-label="Hide pod team"
             >
-              <Icon d="M12 5v14M5 12h14" />
-              Add agents
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="6" y1="6" x2="18" y2="18" />
+                <line x1="18" y1="6" x2="6" y2="18" />
+              </svg>
             </button>
+          )}
+        </header>
+        <nav className="v2-inspector__tabs" role="tablist">
+          {(['people', 'activity', 'settings'] as const).map((key) => (
             <button
+              key={key}
               type="button"
-              className="v2-inspector__settings-chip"
-              onClick={() => navigate(`/v2/pods/${pod.type || 'chat'}/${pod._id}`)}
+              role="tab"
+              aria-selected={tab === key}
+              className={`v2-inspector__tab${tab === key ? ' v2-inspector__tab--active' : ''}`}
+              onClick={() => handleSetTab(key)}
             >
-              <Icon d="M12 15a3 3 0 100-6 3 3 0 000 6z" />
-              Pod settings
+              {key === 'people' ? 'People' : key === 'activity' ? 'Activity' : 'Settings'}
             </button>
-            {podsState && (
-              <button
-                type="button"
-                className="v2-inspector__settings-chip v2-inspector__settings-chip--danger"
-                onClick={handleDeletePod}
-              >
-                <Icon d="M3 6h18M8 6V4h8v2M10 11v6M14 11v6M5 6l1 14h12l1-14" />
-                Delete pod
-              </button>
-            )}
-          </div>
-        </section>
+          ))}
+        </nav>
+        <div className="v2-inspector__body">
+          {tab === 'people' && peopleSection}
+          {tab === 'activity' && activitySection}
+          {tab === 'settings' && settingsSection}
+        </div>
       </div>
     </aside>
   );

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -212,13 +212,6 @@
   grid-template-columns: var(--v2-rail-w) var(--v2-pods-w) 1fr;
 }
 
-/* Collapsed inspector keeps a thin column with just a chevron toggle, so the
- * "expand inspector" affordance stays discoverable without the full panel
- * eating chat width. Width matches the rail so the visual rhythm holds. */
-.v2-shell--inspector-collapsed {
-  grid-template-columns: var(--v2-rail-w) var(--v2-pods-w) 1fr 32px;
-}
-
 .v2-shell--feature {
   grid-template-columns: var(--v2-rail-w) var(--v2-pods-w) minmax(0, 1fr);
 }
@@ -249,45 +242,6 @@
   border-right: none;
   border-left: 1px solid var(--v2-border-soft);
   background: var(--v2-surface-tint);
-}
-
-.v2-pane--inspector-collapsed {
-  background: var(--v2-bg-subtle);
-  align-items: center;
-  padding-top: 10px;
-}
-
-/* Toggle chevrons — one for "collapse" inside the full inspector header, one
- * for "expand" in the slim collapsed inspector. Both are subtle so they read
- * as utility, not destination. */
-.v2-inspector__toggle {
-  width: 22px;
-  height: 22px;
-  border-radius: 6px;
-  border: 1px solid var(--v2-border-soft);
-  background: var(--v2-surface);
-  color: var(--v2-text-tertiary);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
-}
-
-.v2-inspector__toggle:hover {
-  background: var(--v2-surface-hover);
-  color: var(--v2-text-primary);
-  border-color: var(--v2-border-strong);
-}
-
-.v2-inspector__toggle--collapse {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-}
-
-.v2-inspector__toggle--expand {
-  margin: 4px 0 0 0;
 }
 
 /* ---------- Nav rail ---------- */
@@ -872,6 +826,31 @@
 
 .v2-chat__avatars > * + * {
   margin-left: -8px;
+}
+
+/* When the avatar group is the inspector entry, treat it like a button:
+   subtle hover shadow that hints "this is clickable" without an explicit
+   chevron. Active state means the inspector is open. */
+.v2-chat__avatars--button {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--v2-radius-pill);
+  padding: 3px 6px;
+  cursor: pointer;
+  transition: background 80ms ease, border-color 80ms ease;
+}
+
+.v2-chat__avatars--button:hover {
+  background: var(--v2-surface-hover);
+}
+
+.v2-chat__avatars--active {
+  background: var(--v2-accent-soft);
+  border-color: var(--v2-accent-soft);
+}
+
+.v2-chat__avatars--active:hover {
+  background: var(--v2-accent-soft);
 }
 
 .v2-chat__avatars-more {
@@ -1653,11 +1632,75 @@
 .v2-inspector {
   height: 100%;
   overflow-y: auto;
-  padding: 24px 18px 20px;
   display: flex;
   flex-direction: column;
   gap: 0;
   position: relative;
+}
+
+.v2-inspector__header {
+  position: relative;
+  padding: 18px 18px 8px;
+  border-bottom: 1px solid var(--v2-border-soft);
+}
+
+.v2-inspector__close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--v2-radius-sm);
+  color: var(--v2-text-tertiary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background 80ms ease, color 80ms ease;
+}
+
+.v2-inspector__close:hover {
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
+}
+
+.v2-inspector__tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 14px 0;
+  border-bottom: 1px solid var(--v2-border-soft);
+  flex-shrink: 0;
+}
+
+.v2-inspector__tab {
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 8px 12px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--v2-text-tertiary);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  cursor: pointer;
+  transition: color 80ms ease, border-color 80ms ease;
+}
+
+.v2-inspector__tab:hover {
+  color: var(--v2-text-primary);
+}
+
+.v2-inspector__tab--active {
+  color: var(--v2-text-primary);
+  border-bottom-color: var(--v2-accent);
+}
+
+.v2-inspector__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 18px 20px;
 }
 
 .v2-inspector__now {


### PR DESCRIPTION
## Summary

The third column had two problems on the YC demo path:
1. Entry was a chevron in the corner — read like "settings panel" not "this is your team."
2. When expanded it dumped 5 stacked sections (Now / Overview / People & Agents / Direct Threads / Resources / Settings) all visible at once — felt like a control surface, not an at-a-glance roster.

Two changes addressing both:

1. **Entry redesign — drop the chevron entirely.** The chat-header avatar group (already shows the top 3 members + "+N more") becomes the click target. Click to reveal the inspector, click again to hide. Active state is a subtle accent-tinted pill on the avatar group — no chevron, no explicit label, just affordance. When collapsed, the inspector is not rendered at all (no thin sliver column) and chat extends full-width.

2. **Tabbed content** — three tabs at the top: **People** (default) · **Activity** · **Settings**. Pod overview always pinned to the inspector header above the tabs (it's the "what is this pod" anchor).
   - **People** — team roster (agents + DM affordance), the demo-relevant view.
   - **Activity** — Now (recent heartbeat) + Direct Threads.
   - **Settings** — Resources + add/edit/delete chips.

Tab choice persists in localStorage (\`v2.inspectorTab\`).

Layout-side cleanup: \`V2Layout\` decides whether to mount the inspector (only when expanded), passes \`onToggleInspector\` down to \`V2PodChat\`, and drops the now-dead \`v2-shell--inspector-collapsed\` modifier in favor of the existing \`v2-shell--no-inspector\` 3-column grid. Obsolete chevron CSS (\`.v2-inspector__toggle*\`, \`.v2-pane--inspector-collapsed\`) removed.

## Test plan

- [ ] Open \`/v2/pods/<demo-pod-id>\` — chat extends full-width by default, no chevron column.
- [ ] Click the chat-header avatar group — inspector slides into view with the People tab active. Avatar pill turns accent-tinted.
- [ ] Click the avatar group again — inspector hides, chat extends back. Tab choice remembered.
- [ ] Click Activity / Settings — content swaps cleanly, no scrollbars from old card stack.
- [ ] Click the × in the inspector header — same as clicking the avatar group: hides inspector.
- [ ] Refresh the page after picking a non-People tab — tab is remembered.
- [ ] No regression on Plan/Execute toggle, Invite button, or pod chat scroll behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)