### PR TITLE
feat(v2,chat): trim composer hints + icon-only buttons + tighter inspector

### DIFF
--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -671,12 +671,12 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
 
             <button
               type="button"
-              className="v2-chat__btn"
+              className="v2-chat__icon-btn"
               onClick={() => navigate(`/v2/pods/${pod.type || 'chat'}/${pod._id}`)}
-              title="Open full pod member tools"
+              title="Invite people"
+              aria-label="Invite people"
             >
               <Icon d="M16 21v-2a4 4 0 00-4-4H6a4 4 0 00-4 4v2M9 11a4 4 0 100-8 4 4 0 000 8zM20 8v6M17 11h6" />
-              Invite
             </button>
 
           </div>
@@ -739,18 +739,11 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
             <TypingIndicator agents={typingAgents} />
 
             <div className="v2-chat__composer">
-              <div className="v2-chat__composer-kicker">
-                <span className={`v2-chat__composer-mode v2-chat__composer-mode--${mode}`}>
-                  {mode === 'plan' ? 'Plan mode' : 'Execute mode'}
-                </span>
-                <span>Send to pod</span>
-                <span className="v2-chat__composer-hint">Enter sends, Shift+Enter adds a line</span>
-              </div>
               <div className="v2-chat__composer-input-wrap">
                 <textarea
                   ref={composerInputRef}
                   className="v2-chat__composer-input"
-                  placeholder={mode === 'plan' ? `Message ${pod.name} in plan preference...` : `Message ${pod.name} in execute preference...`}
+                  placeholder={`Message ${pod.name}…`}
                   value={draft}
                   onChange={(e) => {
                     const next = e.target.value;
@@ -840,19 +833,17 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
                   className={`v2-chat__send v2-chat__send--${mode}`}
                   onClick={handleSend}
                   disabled={sending || !draft.trim()}
-                  title={sending ? 'Sending...' : 'Send message'}
+                  title={sending ? 'Sending…' : 'Send message'}
+                  aria-label={sending ? 'Sending…' : 'Send message'}
                 >
                   <Icon d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z" />
-                  <span>Send</span>
                 </button>
               </div>
-              <div className="v2-chat__composer-footer">
-                {composerError ? (
+              {composerError && (
+                <div className="v2-chat__composer-footer">
                   <span className="v2-chat__composer-error">{composerError}</span>
-                ) : (
-                  <span>Attach files with the paperclip. @-mention an agent to direct your message.</span>
-                )}
-              </div>
+                </div>
+              )}
             </div>
           </>
         )}

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -242,15 +242,16 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
             <div className="v2-inspector__agent-info">
               <div className="v2-inspector__agent-head">
                 <span className="v2-inspector__agent-name">{name}</span>
-              </div>
-              <div className="v2-inspector__agent-status">
-                <span className="v2-online-dot" style={{ background: isOnline ? 'var(--v2-success)' : 'var(--v2-text-muted)' }} />
-                {isOnline ? 'Online' : 'Idle'}
+                <span
+                  className="v2-online-dot"
+                  style={{ background: isOnline ? 'var(--v2-success)' : 'var(--v2-text-muted)' }}
+                  title={isOnline ? 'Online' : 'Idle'}
+                  aria-label={isOnline ? 'Online' : 'Idle'}
+                />
               </div>
               {task && (
-                <div className="v2-inspector__agent-task">
-                  <span className="v2-inspector__agent-task-label">Working on </span>
-                  <span className="v2-inspector__agent-task-value">{task.title}</span>
+                <div className="v2-inspector__agent-task" title={task.title}>
+                  {task.title}
                 </div>
               )}
             </div>

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -897,6 +897,23 @@
   color: #ffffff;
 }
 
+.v2-chat__icon-btn {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  color: #6b7280;
+  border: 1px solid #e5e7eb;
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-surface);
+  transition: background 80ms ease, color 80ms ease;
+}
+
+.v2-chat__icon-btn:hover {
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
+}
+
 .v2-chat__mode-toggle {
   display: inline-flex;
   align-items: center;
@@ -1143,40 +1160,10 @@
 }
 
 .v2-chat__composer {
-  min-height: 108px;
-  padding: 12px 24px 10px;
+  padding: 12px 24px 14px;
   border-top: 1px solid var(--v2-border-soft);
   background: var(--v2-surface);
   flex-shrink: 0;
-}
-
-.v2-chat__composer-kicker {
-  height: 22px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--v2-text-tertiary);
-  font-size: 11px;
-}
-
-.v2-chat__composer-mode {
-  height: 18px;
-  padding: 0 7px;
-  border-radius: 999px;
-  display: inline-flex;
-  align-items: center;
-  background: var(--v2-accent-soft);
-  color: var(--v2-accent-text);
-  font-weight: 700;
-}
-
-.v2-chat__composer-mode--execute {
-  background: var(--v2-surface-hover);
-  color: var(--v2-text-secondary);
-}
-
-.v2-chat__composer-hint {
-  margin-left: auto;
 }
 
 .v2-chat__composer-input-wrap {
@@ -1241,13 +1228,10 @@
 }
 
 .v2-chat__send {
-  min-width: 76px;
+  width: 34px;
   height: 34px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 0 12px;
+  display: grid;
+  place-items: center;
   border-radius: var(--v2-radius-sm);
   background: var(--v2-accent);
   color: #fff;
@@ -1883,30 +1867,13 @@
   text-overflow: ellipsis;
 }
 
-.v2-inspector__agent-status {
-  font-size: 11px;
-  color: var(--v2-success);
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
 .v2-inspector__agent-task {
   font-size: 11px;
   color: var(--v2-text-tertiary);
-  margin-top: 1px;
+  margin-top: 2px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.v2-inspector__agent-task-label {
-  color: var(--v2-text-tertiary);
-}
-
-.v2-inspector__agent-task-value {
-  color: var(--v2-text-secondary);
-  font-weight: 500;
 }
 
 .v2-inspector__more-btn {


### PR DESCRIPTION
## Summary
- Composer drops the kicker row (Plan/Execute pill, "Send to pod", Enter-sends hint) and the chatty footer. The mode pill already lives in the header; the icons are intuitive.
- Placeholder shortened from "Message {pod} in plan preference…" → "Message {pod}…".
- **Send** and **Invite** buttons go icon-only with proper `title` + `aria-label`. Recovers header space and makes the composer feel like a chat box, not a form.
- Inspector agent rows: status dot moves inline with the name (one line), and the "Working on " kicker is dropped so the task title becomes the only secondary line.
- Prunes ~80 lines of dead CSS (`composer-kicker`, `composer-mode`, `composer-hint`, `agent-status`, `agent-task-label/value`).

Path A of the design polish ask. Path B (image-gen prompts for full visual redesign) is queued separately.

## Test plan
- [ ] Open `/v2/pods/<podId>` on app-dev; composer area is one band (no kicker, no footer banner).
- [ ] Placeholder reads `Message <Pod>…`.
- [ ] Send + Invite render as 34×34 icon buttons; tooltips appear on hover; aria-label set.
- [ ] Open inspector; each agent row is two lines max (name + dot inline; task title below if present).
- [ ] Tab key navigates the composer + send + attach buttons in a sensible order.
- [ ] Plan/Execute pill still in header still toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)