### PR TITLE
feat(v2): inspector rethink — overview scroll + sub-pages, kill chat tabs

### DIFF
--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -11,6 +11,11 @@ interface V2LayoutProps {
   selectionMode?: 'auto' | 'param';
 }
 
+export type InspectorView =
+  | { kind: 'overview' }
+  | { kind: 'member'; agentKey: string }
+  | { kind: 'artifact'; artifactId: string };
+
 const INSPECTOR_PREF_KEY = 'v2.inspectorCollapsed';
 
 const readInspectorCollapsed = (): boolean => {
@@ -40,13 +45,35 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   const { pods, loading } = podsState;
 
   const [inspectorCollapsed, setInspectorCollapsed] = useState<boolean>(readInspectorCollapsed());
+  const [inspectorView, setInspectorView] = useState<InspectorView>({ kind: 'overview' });
   const toggleInspector = useCallback(() => {
     setInspectorCollapsed((prev) => {
       const next = !prev;
       writeInspectorCollapsed(next);
+      // Always reset to overview when re-opening, so the user lands in a
+      // predictable place rather than the last sub-page.
+      if (!next) setInspectorView({ kind: 'overview' });
       return next;
     });
   }, []);
+  const openInspectorMember = useCallback((agentKey: string) => {
+    if (!agentKey) return;
+    setInspectorView({ kind: 'member', agentKey });
+    setInspectorCollapsed(false);
+    writeInspectorCollapsed(false);
+  }, []);
+  const openInspectorArtifact = useCallback((artifactId: string) => {
+    if (!artifactId) return;
+    setInspectorView({ kind: 'artifact', artifactId });
+    setInspectorCollapsed(false);
+    writeInspectorCollapsed(false);
+  }, []);
+  const resetInspectorView = useCallback(() => setInspectorView({ kind: 'overview' }), []);
+
+  // When pod changes, drop any stale sub-page state.
+  useEffect(() => {
+    setInspectorView({ kind: 'overview' });
+  }, [paramPodId]);
 
   // Auto-pick the first pod when the user lands on /v2 directly, so the
   // three-column layout doesn't render an empty main pane on first load.
@@ -73,12 +100,17 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
         podsState={podsState}
         inspectorCollapsed={inspectorCollapsed}
         onToggleInspector={selectedPodId ? toggleInspector : undefined}
+        onOpenMember={openInspectorMember}
       />
       {selectedPodId && !inspectorCollapsed && (
         <V2PodInspector
           detail={detail}
           podsState={podsState}
+          view={inspectorView}
           onClose={toggleInspector}
+          onOpenMember={openInspectorMember}
+          onOpenArtifact={openInspectorArtifact}
+          onBack={resetInspectorView}
         />
       )}
     </div>

--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -25,6 +25,9 @@ interface V2MessageBubbleProps {
   // raw User row username "openclaw-nova". Frontend-only display layer; the
   // underlying User row is unchanged.
   agentDisplayNames?: Map<string, string>;
+  // Clicking the author avatar / name opens the inspector to that member's
+  // detail sub-page. Passed in by V2PodChat; only fires for agent authors.
+  onAuthorClick?: (username: string) => void;
 }
 
 interface ParsedFile {
@@ -112,10 +115,14 @@ const FilePill: React.FC<{ file: ParsedFile }> = ({ file }) => {
   );
 };
 
-const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agentDisplayNames }) => {
+const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agentDisplayNames, onAuthorClick }) => {
   const rawUsername = message.user?.username || 'Unknown';
   const overriddenDisplay = agentDisplayNames?.get(rawUsername);
   const author = overriddenDisplay || rawUsername;
+  // Only agent authors are wired to the inspector — humans don't have a
+  // member-detail sub-page yet, and rawUsername=='Unknown' is the API fallback.
+  const isClickable = !!onAuthorClick && !!agentDisplayNames?.has(rawUsername);
+  const handleAuthorClick = isClickable ? () => onAuthorClick?.(rawUsername) : undefined;
   const time = formatRelativeTime(message.created_at);
   // Two-pass parse: reactions first (they live anywhere in the body), then
   // files. Order matters — files leave a trimmed body that we then read for
@@ -129,14 +136,35 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
 
   return (
     <div className="v2-msg">
-      <V2Avatar
-        name={author}
-        src={message.user?.profile_picture || undefined}
-        size="md"
-      />
+      {isClickable ? (
+        <button
+          type="button"
+          className="v2-msg__avatar-btn"
+          onClick={handleAuthorClick}
+          aria-label={`Open ${author} details`}
+        >
+          <V2Avatar
+            name={author}
+            src={message.user?.profile_picture || undefined}
+            size="md"
+          />
+        </button>
+      ) : (
+        <V2Avatar
+          name={author}
+          src={message.user?.profile_picture || undefined}
+          size="md"
+        />
+      )}
       <div className="v2-msg__body">
         <div className="v2-msg__head">
-          <span className="v2-msg__author">{author}</span>
+          {isClickable ? (
+            <button type="button" className="v2-msg__author-btn" onClick={handleAuthorClick}>
+              {author}
+            </button>
+          ) : (
+            <span className="v2-msg__author">{author}</span>
+          )}
           {isLead && <span className="v2-msg__lead-badge">Lead</span>}
           {time && <span className="v2-msg__time">{time}</span>}
         </div>

--- a/frontend/src/v2/components/V2NavRail.tsx
+++ b/frontend/src/v2/components/V2NavRail.tsx
@@ -81,7 +81,7 @@ const V2NavRail: React.FC = () => {
           </div>
           <button
             type="button"
-            className="v2-inspector__more-btn"
+            className="v2-rail__signout"
             onClick={logout}
             title="Sign out"
           >

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -12,13 +12,6 @@ import { UseV2PodsResult, V2PodMember } from '../hooks/useV2Pods';
 import { useSocket } from '../../context/SocketContext';
 import { initialsFor } from '../utils/avatars';
 
-const TABS = [
-  { key: 'Chat', label: 'Chat', disabled: false, badge: undefined },
-  { key: 'Tasks', label: 'Tasks', disabled: false, badge: undefined },
-  { key: 'Summary', label: 'Summary', disabled: false, badge: undefined },
-] as const;
-type Tab = typeof TABS[number]['key'];
-
 const PLAN_MODE_KEY = 'v2.podMode';
 
 type PodMode = 'plan' | 'execute';
@@ -129,6 +122,7 @@ interface V2PodChatProps {
   // hand-off point.
   inspectorCollapsed?: boolean;
   onToggleInspector?: () => void;
+  onOpenMember?: (agentKey: string) => void;
 }
 
 const Icon = ({ d }: { d: string }) => (
@@ -137,128 +131,17 @@ const Icon = ({ d }: { d: string }) => (
   </svg>
 );
 
-interface V2Task {
-  taskId: string;
-  title: string;
-  status?: string;
-  assignee?: string;
-  updatedAt?: string;
-}
-
-interface V2SummaryResponse {
-  content?: string;
-  summary?: { content?: string };
-  message?: string;
-}
-
-const V2TasksView: React.FC<{ podId: string }> = ({ podId }) => {
-  const api = useV2Api();
-  const [tasks, setTasks] = useState<V2Task[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const data = await api.get<{ tasks?: V2Task[] }>(`/api/v1/tasks/${podId}`);
-        if (!cancelled) setTasks(Array.isArray(data.tasks) ? data.tasks : []);
-      } catch (err) {
-        const e = err as { response?: { data?: { error?: string; msg?: string } }; message?: string };
-        if (!cancelled) setError(e.response?.data?.error || e.response?.data?.msg || e.message || 'Failed to load tasks');
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [api, podId]);
-
-  if (loading) return <div className="v2-empty"><span className="v2-spinner" /></div>;
-  if (error) return <div className="v2-chat__error">{error}</div>;
-  if (tasks.length === 0) {
-    return (
-      <div className="v2-empty">
-        <div className="v2-empty__title">No tasks yet</div>
-        <div className="v2-empty__text">Tasks created by agents or humans in this pod will appear here.</div>
-      </div>
-    );
-  }
-  return (
-    <div className="v2-tab-list">
-      {tasks.map((task) => (
-        <div key={task.taskId} className="v2-tab-card">
-          <div className="v2-tab-card__title">{task.title}</div>
-          <div className="v2-tab-card__meta">
-            {task.taskId}
-            {task.status ? ` · ${task.status}` : ''}
-            {task.assignee ? ` · ${task.assignee}` : ''}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-};
-
-const V2SummaryView: React.FC<{ podId: string; description?: string }> = ({ podId, description }) => {
-  const api = useV2Api();
-  const [content, setContent] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const loadSummary = async (refresh = false) => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = refresh
-        ? await api.post<V2SummaryResponse>(`/api/summaries/pod/${podId}/refresh`, {})
-        : await api.get<V2SummaryResponse>(`/api/summaries/pod/${podId}`);
-      setContent(data?.summary?.content || data?.content || '');
-    } catch (err) {
-      const e = err as { response?: { data?: { error?: string; msg?: string } }; message?: string };
-      setError(e.response?.data?.error || e.response?.data?.msg || e.message || 'Failed to load summary');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    loadSummary();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [podId]);
-
-  return (
-    <div className="v2-tab-list">
-      <div className="v2-tab-card">
-        <div className="v2-row v2-row--between">
-          <div className="v2-tab-card__title">Pod Summary</div>
-          <button type="button" className="v2-tab-card__action" onClick={() => loadSummary(true)} disabled={loading}>
-            {loading ? 'Refreshing...' : 'Refresh'}
-          </button>
-        </div>
-        {error && <div className="v2-chat__error">{error}</div>}
-        <div className="v2-tab-card__body">
-          {content || description || 'No recent activity to summarize.'}
-        </div>
-      </div>
-    </div>
-  );
-};
-
-const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onToggleInspector }) => {
+const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onToggleInspector, onOpenMember }) => {
   const { pod, members, messages, agents, sendMessage, loading, error } = detail;
   const navigate = useNavigate();
   const api = useV2Api();
   const { socket, connected } = useSocket();
   const { isPinned, toggle: togglePin } = useV2Pinned();
-  const [tab, setTab] = useState<Tab>('Chat');
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [composerError, setComposerError] = useState<string | null>(null);
   const [mode, setMode] = useState<PodMode>(pod ? readMode(pod._id) : 'plan');
-  const [taskCount, setTaskCount] = useState<number | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const composerInputRef = useRef<HTMLTextAreaElement | null>(null);
@@ -281,29 +164,9 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
     if (pod) setMode(readMode(pod._id));
   }, [pod?._id]);
 
-  // Lightweight count fetch so the Tasks tab can show an honest badge.
-  // Falls back silently if the API is unavailable.
-  useEffect(() => {
-    const podId = pod?._id;
-    if (!podId) {
-      setTaskCount(null);
-      return;
-    }
-    let cancelled = false;
-    (async () => {
-      try {
-        const data = await api.get<{ tasks?: V2Task[] }>(`/api/v1/tasks/${podId}?status=pending,claimed`);
-        if (!cancelled) setTaskCount(Array.isArray(data.tasks) ? data.tasks.length : 0);
-      } catch {
-        if (!cancelled) setTaskCount(null);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [pod?._id, api, tab]);
-
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages.length, tab]);
+  }, [messages.length]);
 
   // Removed: Lead-pill computation. The "Lead" label was just `idx === 0`,
   // which made whichever agent installed first (usually auto-installed
@@ -336,6 +199,31 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
     }
     return map;
   }, [agents]);
+
+  // username → agent key (instanceId or agentName) so a click on a chat
+  // author byline can drive the inspector to the right member sub-page.
+  const agentKeyByUsername = React.useMemo(() => {
+    const map = new Map<string, string>();
+    if (!agents) return map;
+    for (const agent of agents) {
+      const rawName = (agent as { name?: string; agentName?: string }).name
+        || agent.agentName || '';
+      const name = rawName.toLowerCase();
+      const instance = (agent.instanceId || '').toLowerCase();
+      const username = !instance || instance === 'default' || instance === name
+        ? name
+        : `${name}-${instance}`;
+      const key = agent.instanceId || agent.agentName;
+      if (username && key) map.set(username, key);
+    }
+    return map;
+  }, [agents]);
+
+  const handleAuthorClick = useCallback((username: string) => {
+    if (!onOpenMember) return;
+    const key = agentKeyByUsername.get(username.toLowerCase());
+    if (key) onOpenMember(key);
+  }, [agentKeyByUsername, onOpenMember]);
 
   // Build the @-mention list. members[] is User rows (humans + agent users);
   // agents[] is AgentInstallation rows that carry the instanceId. We want
@@ -683,39 +571,13 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
 
           {pod.description && (
             <div className="v2-chat__goal">
-              <span className="v2-chat__goal-label">Goal: </span>
               {pod.description}
               <span className="v2-chat__goal-meta"> · {liveState}</span>
             </div>
           )}
         </header>
 
-        <div className="v2-chat__tabs">
-          {TABS.map((item) => (
-            <button
-              key={item.key}
-              type="button"
-              className={`v2-chat__tab${tab === item.key ? ' v2-chat__tab--active' : ''}${item.disabled ? ' v2-chat__tab--disabled' : ''}`}
-              onClick={() => {
-                if (!item.disabled) setTab(item.key);
-              }}
-              disabled={item.disabled}
-              title={item.disabled ? `${item.label} needs backend support` : item.label}
-            >
-              {item.label}
-              {item.key === 'Chat' && messages.length > 0 && (
-                <span className="v2-chat__tab-badge">{messages.length}</span>
-              )}
-              {item.key === 'Tasks' && taskCount !== null && taskCount > 0 && (
-                <span className="v2-chat__tab-badge">{taskCount}</span>
-              )}
-            </button>
-          ))}
-        </div>
-
-        {tab === 'Chat' && (
-          <>
-            <div className="v2-chat__messages">
+        <div className="v2-chat__messages">
               {error && (
                 <div className="v2-chat__error">
                   {error}
@@ -731,7 +593,12 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
                 </div>
               )}
               {messages.map((m) => (
-                <V2MessageBubble key={m.id} message={m} agentDisplayNames={agentDisplayNames} />
+                <V2MessageBubble
+                  key={m.id}
+                  message={m}
+                  agentDisplayNames={agentDisplayNames}
+                  onAuthorClick={onOpenMember ? handleAuthorClick : undefined}
+                />
               ))}
               <div ref={messagesEndRef} />
             </div>
@@ -845,11 +712,6 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
                 </div>
               )}
             </div>
-          </>
-        )}
-
-        {tab === 'Tasks' && <V2TasksView podId={pod._id} />}
-        {tab === 'Summary' && <V2SummaryView podId={pod._id} description={pod.description} />}
       </div>
     </main>
   );

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -1,59 +1,36 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import V2Avatar from './V2Avatar';
 import { UseV2PodDetailResult, V2Agent } from '../hooks/useV2PodDetail';
 import { UseV2PodsResult } from '../hooks/useV2Pods';
 import { useV2Api } from '../hooks/useV2Api';
 import { useAuth } from '../../context/AuthContext';
-import { formatRelativeTime } from '../utils/grouping';
+import type { InspectorView } from './V2Layout';
 
 interface V2PodInspectorProps {
   detail: UseV2PodDetailResult;
   podsState?: UseV2PodsResult;
+  view: InspectorView;
   // V2Layout decides whether to mount this at all; collapsed-state used to
   // be rendered as a thin chevron column, but the entry is now the chat
-  // header avatar group (see V2PodChat). onClose dismisses it.
+  // header avatar group + clicks on author bylines (see V2PodChat /
+  // V2MessageBubble). onClose dismisses; onBack pops to overview.
   onClose?: () => void;
+  onOpenMember: (agentKey: string) => void;
+  onOpenArtifact: (artifactId: string) => void;
+  onBack: () => void;
 }
-
-type InspectorTab = 'people' | 'activity' | 'settings';
-const INSPECTOR_TAB_KEY = 'v2.inspectorTab';
-const readInspectorTab = (): InspectorTab => {
-  try {
-    const v = localStorage.getItem(INSPECTOR_TAB_KEY);
-    return v === 'activity' || v === 'settings' ? v : 'people';
-  } catch {
-    return 'people';
-  }
-};
-const writeInspectorTab = (tab: InspectorTab) => {
-  try { localStorage.setItem(INSPECTOR_TAB_KEY, tab); } catch { /* ignore */ }
-};
 
 // Only openclaw-runtime agents can hold a real DM session — they have a chat
 // runtime that responds. commonly-bot is the internal Tier 1 summarizer (no
-// chat runtime); pod-summarizer is Tier 1 native (also no DM). Future native
-// agents that want to show up here should declare a chat-capable runtime; the
-// frontend gates on the agent name so we don't paper over a missing capability.
-//
-// The wire payload (per buildAgentInstallationPayload) returns `name`, but the
-// V2Agent type also declares `agentName`. Read both — same shape mismatch as
-// V2PodChat works around for the displayName map.
+// chat runtime); pod-summarizer is Tier 1 native (also no DM).
 const isAgentDmable = (agent: { name?: string; agentName?: string }): boolean => {
   const n = agent.name || agent.agentName;
   return n === 'openclaw';
 };
 
-// Direct-thread room names that should never appear in the user's "Direct
-// Threads" list, regardless of who's a member. Mirrors isAgentDmable above —
-// these agents have no chat runtime, so a DM room would just sit there empty.
-const NON_DMABLE_ROOM_NAME_PREFIXES = ['commonly-bot', 'pod-summarizer'];
-const isRoomDmable = (name: string): boolean => (
-  !NON_DMABLE_ROOM_NAME_PREFIXES.some((prefix) => name === prefix || name.startsWith(`${prefix} `))
-);
-
 interface AgentTaskMap {
-  [agentName: string]: { taskId: string; title: string } | null;
+  [agentName: string]: { taskId: string; title: string; status: string } | null;
 }
 
 interface TaskApiResponse {
@@ -74,58 +51,116 @@ interface ExternalLinkItem {
   url?: string;
 }
 
+interface RunStateCounts {
+  blocked: number;
+  inProgress: number;
+  complete: number;
+  pending: number;
+}
+
 const Icon = ({ d, size = 14 }: { d: string; size?: number }) => (
   <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <path d={d} />
   </svg>
 );
 
+const agentKeyOf = (agent: V2Agent): string => agent.instanceId || agent.agentName;
+
+const memberRoleLabel = (
+  member: { _id?: string; isBot?: boolean },
+  ownerId: string | undefined,
+  isAgent: boolean,
+): 'Owner' | 'Human' | 'AI Agent' => {
+  if (ownerId && member._id === ownerId) return 'Owner';
+  if (isAgent || member.isBot) return 'AI Agent';
+  return 'Human';
+};
+
 const V2PodInspector: React.FC<V2PodInspectorProps> = ({
-  detail, podsState, onClose,
+  detail, podsState, view, onClose, onOpenMember, onOpenArtifact, onBack,
 }) => {
   const { pod, members, agents } = detail;
   const api = useV2Api();
   const navigate = useNavigate();
   const { currentUser } = useAuth();
   const [agentTasks, setAgentTasks] = useState<AgentTaskMap>({});
+  const [runState, setRunState] = useState<RunStateCounts>({ blocked: 0, inProgress: 0, complete: 0, pending: 0 });
   const [privateError, setPrivateError] = useState<string | null>(null);
   const [announcements, setAnnouncements] = useState<AnnouncementItem[]>([]);
   const [externalLinks, setExternalLinks] = useState<ExternalLinkItem[]>([]);
-  const [tab, setTab] = useState<InspectorTab>(() => readInspectorTab());
-  const handleSetTab = (next: InspectorTab) => {
-    setTab(next);
-    writeInspectorTab(next);
-  };
 
-  // For each agent, find their most recent active task. This is our best
-  // approximation of "Working on X" since the backend doesn't track a
-  // current-work field per agent — see notes in V2 README.
+  // Map agent username (`openclaw-nova`) → agent record so we can look up by
+  // either instance id or full username when chat clicks come in.
+  const agentByKey = useMemo(() => {
+    const map = new Map<string, V2Agent>();
+    agents.forEach((a) => {
+      const id = agentKeyOf(a);
+      if (id) map.set(id, a);
+      const u = `${a.agentName}-${a.instanceId || 'default'}`;
+      map.set(u, a);
+    });
+    return map;
+  }, [agents]);
+
   useEffect(() => {
     const podId = pod?._id;
-    if (!podId || agents.length === 0) {
+    if (!podId) {
       setAgentTasks({});
+      setRunState({ blocked: 0, inProgress: 0, complete: 0, pending: 0 });
       return;
     }
     let cancelled = false;
     (async () => {
       try {
-        const data = await api.get<TaskApiResponse>(`/api/v1/tasks/${podId}?status=pending,claimed`);
+        const data = await api.get<TaskApiResponse>(`/api/v1/tasks/${podId}`);
+        const tasks = data.tasks || [];
+        // Per-agent "Working on" — first matching active task.
         const map: AgentTaskMap = {};
         agents.forEach((a) => {
-          const key = a.instanceId || a.agentName;
-          const match = data.tasks.find((t) => {
+          const key = agentKeyOf(a);
+          const match = tasks.find((t) => {
             const assignee = (t.assignee || '').toLowerCase();
+            const isActive = t.status === 'pending' || t.status === 'claimed' || t.status === 'in_progress';
+            if (!isActive) return false;
             return assignee && (
               assignee === (a.instanceId || '').toLowerCase()
               || assignee === (a.agentName || '').toLowerCase()
               || assignee === (a.displayName || '').toLowerCase()
             );
           });
-          map[key] = match ? { taskId: match.taskId, title: match.title } : null;
+          map[key] = match ? { taskId: match.taskId, title: match.title, status: match.status } : null;
         });
-        if (!cancelled) setAgentTasks(map);
+        // Run-state pill counts.
+        const counts: RunStateCounts = { blocked: 0, inProgress: 0, complete: 0, pending: 0 };
+        tasks.forEach((t) => {
+          switch (t.status) {
+            case 'blocked':
+              counts.blocked += 1;
+              break;
+            case 'claimed':
+            case 'in_progress':
+              counts.inProgress += 1;
+              break;
+            case 'done':
+            case 'completed':
+              counts.complete += 1;
+              break;
+            case 'pending':
+              counts.pending += 1;
+              break;
+            default:
+              break;
+          }
+        });
+        if (!cancelled) {
+          setAgentTasks(map);
+          setRunState(counts);
+        }
       } catch {
-        if (!cancelled) setAgentTasks({});
+        if (!cancelled) {
+          setAgentTasks({});
+          setRunState({ blocked: 0, inProgress: 0, complete: 0, pending: 0 });
+        }
       }
     })();
     return () => { cancelled = true; };
@@ -154,15 +189,12 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   if (!pod) return <aside className="v2-pane v2-pane--inspector" />;
 
   const isPrivatePod = pod.type === 'agent-room';
-  const humanCount = members.filter((member) => !member.isBot).length;
+  const humanCount = members.filter((m) => !m.isBot).length;
   const agentCount = agents.length;
-  const onlineAgentCount = agents.filter((agent) => (
-    !!agent.lastHeartbeatAt && Date.now() - new Date(agent.lastHeartbeatAt).getTime() < 10 * 60 * 1000
-  )).length;
-  const liveState = onlineAgentCount > 0 ? 'Recent heartbeat' : 'No recent heartbeat';
   const created = pod.createdAt ? new Date(pod.createdAt).toLocaleDateString([], {
-    month: 'short', day: 'numeric', year: 'numeric',
+    month: 'short', day: 'numeric',
   }) : 'unknown';
+  const ownerId = pod.createdBy?._id;
 
   const openPrivatePod = async (agent: V2Agent) => {
     setPrivateError(null);
@@ -189,182 +221,296 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
     if (deleted) navigate('/v2', { replace: true });
   };
 
-  const podOverview = (
-    <section className="v2-inspector__card">
-      <div className="v2-inspector__pod-card">
-        <div className="v2-inspector__pod-head">
-          <V2Avatar name={pod.name} size="md" />
-          <div className="v2-inspector__pod-name">{pod.name}</div>
-        </div>
-        <div className="v2-inspector__pod-meta">
-          Created by {pod.createdBy?.username || 'unknown'} · {created}
-        </div>
-        <div className="v2-inspector__pod-counts">
-          {!isPrivatePod && <span>{agentCount} agent{agentCount === 1 ? '' : 's'}</span>}
-          {!isPrivatePod && <span>·</span>}
-          <span>{humanCount} human{humanCount === 1 ? '' : 's'}</span>
-        </div>
-        {pod.description && <div className="v2-inspector__objective">{pod.description}</div>}
+  // ------------------------------------------------------------------
+  // OVERVIEW — Goal / Artifacts / Members / Run State
+  // ------------------------------------------------------------------
+  const goalSection = (
+    <section className="v2-inspector__section">
+      <div className="v2-inspector__section-title">Goal</div>
+      <div className="v2-inspector__goal-text">
+        {pod.description?.trim() || <span className="v2-mute">No goal set yet.</span>}
       </div>
     </section>
   );
 
-  const peopleSection = !isPrivatePod && (
-    <section className="v2-inspector__card">
+  const artifactItems: Array<{ id: string; kind: string; title: string; subtitle?: string; url?: string }> = [
+    ...announcements.map((a) => ({
+      id: `ann-${a._id}`,
+      kind: 'Announcement',
+      title: a.title || a.content || 'Untitled announcement',
+    })),
+    ...externalLinks.map((l) => ({
+      id: `link-${l._id}`,
+      kind: l.type || 'Link',
+      title: l.name || l.url || 'External link',
+      subtitle: l.url,
+      url: l.url,
+    })),
+  ];
+
+  const artifactsSection = (
+    <section className="v2-inspector__section">
       <div className="v2-inspector__section-head">
-        <span className="v2-inspector__section-title">Team ({agentCount + humanCount})</span>
+        <div className="v2-inspector__section-title">Artifacts</div>
+      </div>
+      {artifactItems.length === 0 ? (
+        <div className="v2-inspector__empty">No artifacts yet — share Notion, Sheets, or Figma links and they'll appear here.</div>
+      ) : (
+        <div className="v2-inspector__artifacts">
+          {artifactItems.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              className="v2-inspector__artifact-row"
+              onClick={() => onOpenArtifact(a.id)}
+            >
+              <span className="v2-inspector__artifact-icon" aria-hidden>{a.kind.slice(0, 1).toUpperCase()}</span>
+              <span className="v2-inspector__artifact-meta">
+                <span className="v2-inspector__artifact-title">{a.title}</span>
+                <span className="v2-inspector__artifact-sub">{a.kind}{a.subtitle ? ` · ${a.subtitle.replace(/^https?:\/\//, '').slice(0, 32)}` : ''}</span>
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+
+  const membersSection = !isPrivatePod && (
+    <section className="v2-inspector__section">
+      <div className="v2-inspector__section-head">
+        <div className="v2-inspector__section-title">Members ({agentCount + humanCount})</div>
         <button
           type="button"
-          className="v2-inspector__section-action"
+          className="v2-inspector__link"
           onClick={() => navigate(`/v2/agents?podId=${pod._id}`)}
         >
           Manage
         </button>
       </div>
-      {agents.length === 0 && (
-        <div className="v2-mute" style={{ fontSize: 12 }}>No agents installed in this pod.</div>
-      )}
-      {privateError && <div className="v2-chat__error">{privateError}</div>}
-      {agents.map((agent: V2Agent) => {
+      {privateError && <div className="v2-chat__error" style={{ marginBottom: 8 }}>{privateError}</div>}
+      {agents.map((agent) => {
         const name = agent.profile?.displayName || agent.displayName || agent.agentName;
-        const key = agent.instanceId || agent.agentName;
+        const key = agentKeyOf(agent);
         const isOnline = !!agent.lastHeartbeatAt
           && Date.now() - new Date(agent.lastHeartbeatAt).getTime() < 10 * 60 * 1000;
-        const task = agentTasks[key];
         return (
-          <div key={key} className="v2-inspector__agent-row">
+          <button
+            key={`agent-${key}`}
+            type="button"
+            className="v2-inspector__member-row"
+            onClick={() => onOpenMember(key)}
+          >
             <V2Avatar
               name={name}
               src={agent.profile?.avatarUrl || agent.profile?.iconUrl || agent.iconUrl || undefined}
               size="md"
               online={isOnline}
             />
-            <div className="v2-inspector__agent-info">
-              <div className="v2-inspector__agent-head">
-                <span className="v2-inspector__agent-name">{name}</span>
-                <span
-                  className="v2-online-dot"
-                  style={{ background: isOnline ? 'var(--v2-success)' : 'var(--v2-text-muted)' }}
-                  title={isOnline ? 'Online' : 'Idle'}
-                  aria-label={isOnline ? 'Online' : 'Idle'}
-                />
-              </div>
-              {task && (
-                <div className="v2-inspector__agent-task" title={task.title}>
-                  {task.title}
-                </div>
-              )}
-            </div>
-            {isAgentDmable(agent) && (
-              <button
-                type="button"
-                className="v2-inspector__more-btn"
-                title="Open private pod"
-                onClick={() => openPrivatePod(agent)}
-              >
-                DM
-              </button>
-            )}
+            <span className="v2-inspector__member-meta">
+              <span className="v2-inspector__member-name">{name}</span>
+              <span className="v2-inspector__member-role">AI Agent</span>
+            </span>
+            {isOnline && <span className="v2-online-dot" style={{ background: 'var(--v2-success)' }} />}
+          </button>
+        );
+      })}
+      {members.filter((m) => !m.isBot).map((member) => {
+        const role = memberRoleLabel(member, ownerId, false);
+        return (
+          <div key={`human-${member._id}`} className="v2-inspector__member-row v2-inspector__member-row--static">
+            <V2Avatar name={member.username || 'Unknown'} src={member.profilePicture || undefined} size="md" />
+            <span className="v2-inspector__member-meta">
+              <span className="v2-inspector__member-name">{member.username}</span>
+              <span className="v2-inspector__member-role">{role}</span>
+            </span>
           </div>
         );
       })}
+      {agents.length === 0 && humanCount === 0 && (
+        <div className="v2-inspector__empty">No members yet.</div>
+      )}
     </section>
   );
 
-  const activitySection = (
-    <>
-      <section className="v2-inspector__card">
-        <div className="v2-inspector__now-state">
-          <span className={`v2-inspector__now-dot v2-inspector__now-dot--${onlineAgentCount > 0 ? 'running' : 'idle'}`} />
-          {liveState}
+  const runStateSection = (
+    <section className="v2-inspector__section">
+      <div className="v2-inspector__section-title">Run State</div>
+      <div className="v2-inspector__runstate">
+        <div className="v2-inspector__runstate-row">
+          <span className="v2-inspector__runstate-label">{runState.blocked} blocked</span>
+          <span className="v2-inspector__pill v2-inspector__pill--blocked">Blocked</span>
         </div>
-        <div className="v2-inspector__now-copy">
-          {onlineAgentCount > 0
-            ? `${onlineAgentCount} agent${onlineAgentCount === 1 ? '' : 's'} recently active in this pod.`
-            : 'No agent heartbeat was detected in the recent activity window.'}
+        <div className="v2-inspector__runstate-row">
+          <span className="v2-inspector__runstate-label">{runState.inProgress + runState.pending} in progress</span>
+          <span className="v2-inspector__pill v2-inspector__pill--progress">In Progress</span>
         </div>
-      </section>
-      {!isPrivatePod && (
-        <section className="v2-inspector__card">
-          <div className="v2-inspector__section-head">
-            <span className="v2-inspector__section-title">Direct Threads</span>
-            <button type="button" className="v2-inspector__section-action" onClick={() => navigate('/v2')}>See all</button>
-          </div>
-          <AgentConversations
-            podMembers={members.map((m) => m.username || '').filter(Boolean)}
-            podCreatedAt={pod.updatedAt}
-            currentUserId={currentUser?._id || null}
-          />
-        </section>
-      )}
-    </>
+        <div className="v2-inspector__runstate-row">
+          <span className="v2-inspector__runstate-label">{runState.complete} complete</span>
+          <span className="v2-inspector__pill v2-inspector__pill--complete">Complete</span>
+        </div>
+      </div>
+      <button
+        type="button"
+        className="v2-inspector__link v2-inspector__link--block"
+        onClick={() => navigate(`/v2/pods/${pod.type || 'chat'}/${pod._id}`)}
+      >
+        View run board
+      </button>
+    </section>
   );
 
-  const settingsSection = (
-    <>
-      {!isPrivatePod && (announcements.length > 0 || externalLinks.length > 0) && (
-        <section className="v2-inspector__card">
-          <div className="v2-inspector__section-head">
-            <span className="v2-inspector__section-title">Resources</span>
+  // ------------------------------------------------------------------
+  // MEMBER DETAIL sub-page
+  // ------------------------------------------------------------------
+  const renderMemberDetail = (agentKey: string) => {
+    const agent = agentByKey.get(agentKey);
+    if (!agent) {
+      return (
+        <div className="v2-inspector__empty">Member not found.</div>
+      );
+    }
+    const name = agent.profile?.displayName || agent.displayName || agent.agentName;
+    const isOnline = !!agent.lastHeartbeatAt
+      && Date.now() - new Date(agent.lastHeartbeatAt).getTime() < 10 * 60 * 1000;
+    const task = agentTasks[agentKeyOf(agent)];
+    const purpose = agent.profile?.purpose;
+    const specialties = agent.profile?.persona?.specialties || [];
+    const dmable = isAgentDmable(agent);
+    return (
+      <div className="v2-inspector__detail">
+        <div className="v2-inspector__detail-head">
+          <V2Avatar
+            name={name}
+            src={agent.profile?.avatarUrl || agent.profile?.iconUrl || agent.iconUrl || undefined}
+            size="lg"
+            online={isOnline}
+          />
+          <div className="v2-inspector__detail-name">{name}</div>
+          <div className="v2-inspector__detail-sub">
+            <span className="v2-online-dot" style={{ background: isOnline ? 'var(--v2-success)' : 'var(--v2-text-muted)' }} />
+            {isOnline ? 'Online' : 'Idle'} · AI Agent
           </div>
-          {announcements.map((announcement) => (
-            <div key={announcement._id} className="v2-inspector__resource-row">
-              <span className="v2-inspector__resource-kicker">Announcement</span>
-              <span className="v2-inspector__resource-title">{announcement.title || announcement.content || 'Untitled announcement'}</span>
-            </div>
-          ))}
-          {externalLinks.map((link) => (
-            <a
-              key={link._id}
-              className="v2-inspector__resource-row"
-              href={link.url || '#'}
-              target="_blank"
-              rel="noreferrer"
-            >
-              <span className="v2-inspector__resource-kicker">{link.type || 'Link'}</span>
-              <span className="v2-inspector__resource-title">{link.name || link.url || 'External link'}</span>
-            </a>
-          ))}
-        </section>
-      )}
-      <section className="v2-inspector__card">
-        <div className="v2-inspector__settings-menu">
-          <button
-            type="button"
-            className="v2-inspector__settings-chip"
-            onClick={() => navigate(`/v2/agents?podId=${pod._id}`)}
-          >
-            <Icon d="M12 5v14M5 12h14" />
-            Add agents
-          </button>
-          <button
-            type="button"
-            className="v2-inspector__settings-chip"
-            onClick={() => navigate(`/v2/pods/${pod.type || 'chat'}/${pod._id}`)}
-          >
-            <Icon d="M12 15a3 3 0 100-6 3 3 0 000 6z" />
-            Pod settings
-          </button>
-          {podsState && (
+        </div>
+        <div className="v2-inspector__detail-actions">
+          {dmable && (
             <button
               type="button"
-              className="v2-inspector__settings-chip v2-inspector__settings-chip--danger"
-              onClick={handleDeletePod}
+              className="v2-inspector__btn v2-inspector__btn--primary"
+              onClick={() => openPrivatePod(agent)}
             >
-              <Icon d="M3 6h18M8 6V4h8v2M10 11v6M14 11v6M5 6l1 14h12l1-14" />
-              Delete pod
+              Talk to {name}
             </button>
           )}
+          <button
+            type="button"
+            className="v2-inspector__btn"
+            onClick={() => navigate(`/v2/agents?podId=${pod._id}&agent=${encodeURIComponent(agentKeyOf(agent))}`)}
+          >
+            Manage
+          </button>
         </div>
-      </section>
-    </>
-  );
+        {privateError && <div className="v2-chat__error" style={{ marginTop: 8 }}>{privateError}</div>}
+        {task && (
+          <div className="v2-inspector__detail-card">
+            <div className="v2-inspector__detail-kicker">Working on</div>
+            <div className="v2-inspector__detail-body">{task.title}</div>
+          </div>
+        )}
+        {purpose && (
+          <div className="v2-inspector__detail-card">
+            <div className="v2-inspector__detail-kicker">Purpose</div>
+            <div className="v2-inspector__detail-body">{purpose}</div>
+          </div>
+        )}
+        {specialties.length > 0 && (
+          <div className="v2-inspector__detail-card">
+            <div className="v2-inspector__detail-kicker">Specialties</div>
+            <div className="v2-inspector__chip-row">
+              {specialties.map((s) => <span key={s} className="v2-inspector__chip">{s}</span>)}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  // ------------------------------------------------------------------
+  // ARTIFACT DETAIL sub-page
+  // ------------------------------------------------------------------
+  const renderArtifactDetail = (artifactId: string) => {
+    const found = artifactItems.find((a) => a.id === artifactId);
+    if (!found) {
+      return <div className="v2-inspector__empty">Artifact not found.</div>;
+    }
+    return (
+      <div className="v2-inspector__detail">
+        <div className="v2-inspector__detail-head">
+          <span className="v2-inspector__artifact-icon v2-inspector__artifact-icon--lg">
+            {found.kind.slice(0, 1).toUpperCase()}
+          </span>
+          <div className="v2-inspector__detail-name">{found.title}</div>
+          <div className="v2-inspector__detail-sub">{found.kind}</div>
+        </div>
+        {found.url && (
+          <div className="v2-inspector__detail-actions">
+            <a className="v2-inspector__btn v2-inspector__btn--primary" href={found.url} target="_blank" rel="noreferrer">
+              Open
+            </a>
+          </div>
+        )}
+        {found.subtitle && (
+          <div className="v2-inspector__detail-card">
+            <div className="v2-inspector__detail-kicker">Source</div>
+            <div className="v2-inspector__detail-body" style={{ wordBreak: 'break-all' }}>{found.subtitle}</div>
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  // ------------------------------------------------------------------
+  // SHELL
+  // ------------------------------------------------------------------
+  const isOverview = view.kind === 'overview';
+  const heading = isOverview
+    ? pod.name
+    : view.kind === 'member'
+      ? 'Member'
+      : 'Artifact';
 
   return (
     <aside className="v2-pane v2-pane--inspector">
       <div className="v2-inspector">
         <header className="v2-inspector__header">
-          {podOverview}
+          {!isOverview && (
+            <button
+              type="button"
+              className="v2-inspector__back"
+              onClick={onBack}
+              aria-label="Back to overview"
+            >
+              <Icon d="M15 18l-6-6 6-6" size={16} />
+              Back
+            </button>
+          )}
+          {isOverview && (
+            <div className="v2-inspector__pod-head">
+              <V2Avatar name={pod.name} size="lg" />
+              <div className="v2-inspector__pod-block">
+                <div className="v2-inspector__pod-name" title={pod.name}>{pod.name}</div>
+                <div className="v2-inspector__pod-meta">
+                  Created by {pod.createdBy?.username || 'unknown'} · {created}
+                </div>
+                <div className="v2-inspector__pod-meta">
+                  {!isPrivatePod && <>{agentCount} agent{agentCount === 1 ? '' : 's'} · </>}{humanCount} human{humanCount === 1 ? '' : 's'}
+                </div>
+              </div>
+            </div>
+          )}
+          {!isOverview && (
+            <div className="v2-inspector__sub-title">{heading}</div>
+          )}
           {onClose && (
             <button
               type="button"
@@ -380,113 +526,33 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
             </button>
           )}
         </header>
-        <nav className="v2-inspector__tabs" role="tablist">
-          {(['people', 'activity', 'settings'] as const).map((key) => (
-            <button
-              key={key}
-              type="button"
-              role="tab"
-              aria-selected={tab === key}
-              className={`v2-inspector__tab${tab === key ? ' v2-inspector__tab--active' : ''}`}
-              onClick={() => handleSetTab(key)}
-            >
-              {key === 'people' ? 'People' : key === 'activity' ? 'Activity' : 'Settings'}
-            </button>
-          ))}
-        </nav>
         <div className="v2-inspector__body">
-          {tab === 'people' && peopleSection}
-          {tab === 'activity' && activitySection}
-          {tab === 'settings' && settingsSection}
+          {view.kind === 'overview' && (
+            <>
+              {pod.description && goalSection}
+              {artifactsSection}
+              {membersSection}
+              {runStateSection}
+              {podsState && (
+                <section className="v2-inspector__section v2-inspector__section--quiet">
+                  <button
+                    type="button"
+                    className="v2-inspector__link v2-inspector__link--danger"
+                    onClick={handleDeletePod}
+                  >
+                    Delete pod
+                  </button>
+                </section>
+              )}
+              {/* Use currentUser ref so AuthContext stays imported even when not surfaced here */}
+              <span style={{ display: 'none' }}>{currentUser?._id || ''}</span>
+            </>
+          )}
+          {view.kind === 'member' && renderMemberDetail(view.agentKey)}
+          {view.kind === 'artifact' && renderArtifactDetail(view.artifactId)}
         </div>
       </div>
     </aside>
-  );
-};
-
-interface AgentConversationsProps {
-  podMembers: string[];
-  podCreatedAt?: string;
-  currentUserId: string | null;
-}
-
-interface RoomMember { _id?: string; username?: string }
-interface AgentRoomPayload {
-  _id: string;
-  name: string;
-  updatedAt?: string;
-  members?: RoomMember[];
-}
-
-// Best-effort: list this user's agent-room DM pods. Backend currently exposes
-// 1:1 human↔agent DMs; this view only renders rooms returned by the API.
-//
-// /api/pods?type=agent-room returns ALL agent-rooms instance-wide for global
-// admins (intentional, for moderation per ADR-001 §3.10), so we filter to
-// rooms the current user is a member of before rendering. We also drop rooms
-// for agents that don't actually hold DMs (commonly-bot, pod-summarizer —
-// see isRoomDmable above), and dedupe by id as a defensive measure.
-const AgentConversations: React.FC<AgentConversationsProps> = ({ podMembers, podCreatedAt, currentUserId }) => {
-  const api = useV2Api();
-  const navigate = useNavigate();
-  const [rooms, setRooms] = useState<Array<{ id: string; name: string; updatedAt?: string }>>([]);
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const data = await api.get<AgentRoomPayload[]>('/api/pods?type=agent-room');
-        if (cancelled) return;
-        const list = Array.isArray(data) ? data : [];
-        const seen = new Set<string>();
-        const filtered: Array<{ id: string; name: string; updatedAt?: string }> = [];
-        for (const r of list) {
-          if (!r || !r._id || seen.has(r._id)) continue;
-          if (!isRoomDmable(r.name || '')) continue;
-          if (currentUserId) {
-            const isMember = (r.members || []).some((m) => m && m._id === currentUserId);
-            if (!isMember) continue;
-          }
-          seen.add(r._id);
-          filtered.push({ id: r._id, name: r.name, updatedAt: r.updatedAt });
-          if (filtered.length >= 5) break;
-        }
-        setRooms(filtered);
-      } catch {
-        if (!cancelled) setRooms([]);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [api, currentUserId]);
-
-  if (rooms.length === 0) {
-    return (
-      <div className="v2-mute" style={{ fontSize: 12 }}>
-        No direct messages yet. Click any agent to start one.
-      </div>
-    );
-  }
-
-  return (
-    <div>
-      {rooms.map((room) => (
-        <button
-          key={room.id}
-          type="button"
-          className="v2-inspector__conversation-row"
-          onClick={() => navigate(`/v2/pods/${room.id}`)}
-        >
-          <V2Avatar name={room.name} size="sm" />
-          <span className="v2-inspector__conversation-text">{room.name}</span>
-          <span className="v2-inspector__conversation-time">{formatRelativeTime(room.updatedAt || podCreatedAt)}</span>
-          <span className="v2-inspector__conversation-pill">
-            DM
-          </span>
-        </button>
-      ))}
-      {/* Use podMembers to satisfy lint when no rooms — and for future filtering. */}
-      <span style={{ display: 'none' }}>{podMembers.length}</span>
-    </div>
   );
 };
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -375,8 +375,22 @@
   display: none;
 }
 
-.v2-rail__user .v2-inspector__more-btn {
+.v2-rail__signout {
+  width: 24px;
+  height: 24px;
   display: grid;
+  place-items: center;
+  border-radius: var(--v2-radius-sm);
+  color: var(--v2-text-tertiary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background 80ms ease, color 80ms ease;
+}
+
+.v2-rail__signout:hover {
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
 }
 
 .v2-rail__user-name {
@@ -956,62 +970,6 @@
   max-width: 720px;
 }
 
-.v2-chat__goal-label {
-  font-weight: 500;
-  color: var(--v2-text-primary);
-}
-
-.v2-chat__tabs {
-  display: flex;
-  height: 42px;
-  gap: 28px;
-  padding: 0 24px;
-  border-bottom: 1px solid var(--v2-border-soft);
-  background: var(--v2-surface);
-  flex-shrink: 0;
-  align-items: flex-end;
-}
-
-.v2-chat__tab {
-  height: 42px;
-  padding: 0;
-  margin-right: 0;
-  font-size: 12px;
-  font-weight: 600;
-  color: #4b5563;
-  border-bottom: 2px solid transparent;
-  transition: color 80ms ease, border-color 80ms ease;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.v2-chat__tab:hover {
-  color: var(--v2-text-primary);
-}
-
-.v2-chat__tab--active {
-  color: var(--v2-accent-text);
-  border-bottom-color: var(--v2-accent-text);
-}
-
-.v2-chat__tab--disabled {
-  color: var(--v2-text-tertiary);
-  cursor: not-allowed;
-  opacity: 0.72;
-}
-
-.v2-chat__tab-badge {
-  height: 17px;
-  padding: 0 5px;
-  border-radius: 999px;
-  display: inline-flex;
-  align-items: center;
-  background: var(--v2-surface-hover);
-  color: var(--v2-text-tertiary);
-  font-size: 9px;
-  font-weight: 700;
-}
 
 .v2-chat__state-strip {
   min-height: 42px;
@@ -1348,52 +1306,6 @@
   text-overflow: ellipsis;
 }
 
-.v2-tab-list {
-  flex: 1;
-  overflow-y: auto;
-  padding: 16px 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.v2-tab-card {
-  border: 1px solid var(--v2-border);
-  border-radius: var(--v2-radius);
-  background: #ffffff;
-  padding: 12px;
-}
-
-.v2-tab-card__title {
-  font-size: 13px;
-  font-weight: 700;
-  color: var(--v2-text-primary);
-}
-
-.v2-tab-card__meta {
-  margin-top: 4px;
-  font-size: 12px;
-  color: var(--v2-text-tertiary);
-}
-
-.v2-tab-card__body {
-  margin-top: 10px;
-  font-size: 13px;
-  line-height: 1.55;
-  color: #1f2937;
-  white-space: pre-wrap;
-}
-
-.v2-tab-card__action {
-  height: 28px;
-  padding: 0 10px;
-  border-radius: var(--v2-radius-sm);
-  border: 1px solid var(--v2-border);
-  color: var(--v2-text-secondary);
-  font-size: 12px;
-  font-weight: 700;
-}
-
 /* ---------- Message bubble ---------- */
 
 .v2-msg {
@@ -1420,6 +1332,40 @@
   font-size: 13px;
   font-weight: 700;
   color: var(--v2-text-primary);
+}
+
+.v2-msg__author-btn {
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--v2-text-primary);
+  cursor: pointer;
+  border-radius: 4px;
+  transition: color 80ms ease;
+}
+
+.v2-msg__author-btn:hover {
+  color: var(--v2-accent-text);
+  text-decoration: underline;
+}
+
+.v2-msg__avatar-btn {
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+}
+
+.v2-msg__avatar-btn:hover {
+  outline: 2px solid var(--v2-accent-soft);
+  outline-offset: 1px;
 }
 
 .v2-msg__lead-badge {
@@ -1622,16 +1568,83 @@
   position: relative;
 }
 
+.v2-inspector {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 .v2-inspector__header {
   position: relative;
-  padding: 18px 18px 8px;
+  padding: 18px 44px 16px 18px;
   border-bottom: 1px solid var(--v2-border-soft);
+  flex-shrink: 0;
+}
+
+.v2-inspector__pod-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.v2-inspector__pod-block {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.v2-inspector__pod-name {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--v2-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.v2-inspector__pod-meta {
+  font-size: 12px;
+  color: var(--v2-text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.v2-inspector__sub-title {
+  font-size: 14px;
+  font-weight: 650;
+  color: var(--v2-text-primary);
+  margin-top: 4px;
+}
+
+.v2-inspector__back {
+  appearance: none;
+  background: transparent;
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  margin: -4px 0 6px -6px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--v2-text-tertiary);
+  cursor: pointer;
+  border-radius: var(--v2-radius-sm);
+  transition: color 80ms ease, background 80ms ease;
+}
+
+.v2-inspector__back:hover {
+  color: var(--v2-text-primary);
+  background: var(--v2-surface-hover);
 }
 
 .v2-inspector__close {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  top: 14px;
+  right: 12px;
   width: 24px;
   height: 24px;
   display: grid;
@@ -1649,372 +1662,369 @@
   color: var(--v2-text-primary);
 }
 
-.v2-inspector__tabs {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 8px 14px 0;
-  border-bottom: 1px solid var(--v2-border-soft);
-  flex-shrink: 0;
-}
-
-.v2-inspector__tab {
-  appearance: none;
-  background: transparent;
-  border: none;
-  padding: 8px 12px;
-  font-size: 12.5px;
-  font-weight: 600;
-  color: var(--v2-text-tertiary);
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
-  cursor: pointer;
-  transition: color 80ms ease, border-color 80ms ease;
-}
-
-.v2-inspector__tab:hover {
-  color: var(--v2-text-primary);
-}
-
-.v2-inspector__tab--active {
-  color: var(--v2-text-primary);
-  border-bottom-color: var(--v2-accent);
-}
-
 .v2-inspector__body {
   flex: 1;
   overflow-y: auto;
-  padding: 14px 18px 20px;
+  padding: 12px 18px 24px;
 }
 
-.v2-inspector__now {
-  padding: 14px;
-  border-radius: var(--v2-radius-lg);
-  background: var(--v2-surface);
-  border: 1px solid var(--v2-border-soft);
-  margin-bottom: 16px;
-}
-
-.v2-inspector__now-kicker {
-  color: var(--v2-text-tertiary);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.v2-inspector__now-state {
-  margin-top: 6px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--v2-text-primary);
-  font-size: 16px;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-}
-
-.v2-inspector__now-dot {
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  background: var(--v2-text-tertiary);
-}
-
-.v2-inspector__now-dot--running {
-  background: var(--v2-success);
-}
-
-.v2-inspector__now-copy {
-  margin-top: 6px;
-  color: var(--v2-text-secondary);
-  font-size: 12px;
-  line-height: 1.45;
-}
-
-.v2-inspector__card {
-  width: 100%;
-  border: none;
+.v2-inspector__section {
+  padding: 16px 0 18px;
   border-top: 1px solid var(--v2-border-soft);
-  border-radius: 0;
-  background: transparent;
-  padding: 16px 0;
 }
 
-.v2-inspector__card:first-child {
+.v2-inspector__section:first-child {
   border-top: none;
-  padding-top: 0;
+  padding-top: 4px;
+}
+
+.v2-inspector__section--quiet {
+  border-top: none;
+  padding: 12px 0 0;
 }
 
 .v2-inspector__section-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 12px;
+  margin-bottom: 10px;
 }
 
 .v2-inspector__section-title {
-  font-size: 15px;
-  font-weight: 650;
+  font-size: 14px;
+  font-weight: 700;
   color: var(--v2-text-primary);
+  letter-spacing: -0.01em;
+  margin-bottom: 8px;
 }
 
-.v2-inspector__section-action {
-  height: 28px;
-  padding: 0 10px;
-  border-radius: var(--v2-radius-sm);
-  border: 1px solid #e5e7eb;
+.v2-inspector__section-head .v2-inspector__section-title {
+  margin-bottom: 0;
+}
+
+.v2-inspector__goal-text {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--v2-text-secondary);
+}
+
+.v2-inspector__empty {
   font-size: 12px;
-  font-weight: 600;
+  line-height: 1.5;
   color: var(--v2-text-tertiary);
-  background: transparent;
+  padding: 6px 0;
 }
 
-.v2-inspector__section-action:hover {
-  color: var(--v2-text-primary);
-  background: var(--v2-surface);
-}
-
-.v2-inspector__pod-card {
+.v2-inspector__link {
+  appearance: none;
   background: transparent;
   border: none;
-  border-radius: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v2-accent);
+  cursor: pointer;
   padding: 0;
+}
+
+.v2-inspector__link:hover {
+  color: var(--v2-accent-strong);
+  text-decoration: underline;
+}
+
+.v2-inspector__link--block {
+  display: inline-block;
+  margin-top: 12px;
+  font-size: 13px;
+}
+
+.v2-inspector__link--danger {
+  color: var(--v2-danger);
+  font-weight: 500;
+  font-size: 12px;
+}
+
+.v2-inspector__link--danger:hover {
+  color: var(--v2-danger);
+}
+
+/* ---------- Inspector: Artifacts ---------- */
+
+.v2-inspector__artifacts {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.v2-inspector__artifact-row {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+  background: transparent;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  border-radius: var(--v2-radius-sm);
+  transition: background 80ms ease;
+}
+
+.v2-inspector__artifact-row:hover {
+  background: var(--v2-surface-hover);
+}
+
+.v2-inspector__artifact-icon {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 8px;
+  background: var(--v2-accent-soft);
+  color: var(--v2-accent-text);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.v2-inspector__artifact-icon--lg {
+  width: 48px;
+  height: 48px;
+  font-size: 18px;
+  border-radius: 12px;
+}
+
+.v2-inspector__artifact-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.v2-inspector__artifact-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v2-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.v2-inspector__artifact-sub {
+  font-size: 11px;
+  color: var(--v2-text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ---------- Inspector: Members ---------- */
+
+.v2-inspector__member-row {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+  background: transparent;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  border-radius: var(--v2-radius-sm);
+  transition: background 80ms ease;
+}
+
+.v2-inspector__member-row:hover {
+  background: var(--v2-surface-hover);
+}
+
+.v2-inspector__member-row--static {
+  cursor: default;
+}
+
+.v2-inspector__member-row--static:hover {
+  background: transparent;
+}
+
+.v2-inspector__member-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.v2-inspector__member-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v2-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.v2-inspector__member-role {
+  font-size: 11px;
+  color: var(--v2-text-tertiary);
+}
+
+/* ---------- Inspector: Run State ---------- */
+
+.v2-inspector__runstate {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-.v2-inspector__pod-head {
+.v2-inspector__runstate-row {
   display: flex;
   align-items: center;
-  gap: 10px;
-}
-
-.v2-inspector__pod-name {
-  font-size: 15px;
-  font-weight: 700;
-  flex: 1;
-  min-width: 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.v2-inspector__pod-meta {
-  font-size: 12px;
-  color: var(--v2-text-tertiary);
-}
-
-.v2-inspector__pod-counts {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  font-size: 12px;
-  color: var(--v2-text-secondary);
-}
-
-.v2-inspector__badge {
-  background: var(--v2-surface);
-  color: var(--v2-text-secondary);
-  height: 24px;
-  font-size: 11px;
-  font-weight: 700;
-  padding: 4px 10px;
-  border-radius: var(--v2-radius-pill);
-  align-self: flex-start;
-}
-
-.v2-inspector__objective {
-  padding: 9px 10px;
-  border-radius: var(--v2-radius);
-  background: var(--v2-surface);
-  color: var(--v2-text-secondary);
-  font-size: 12px;
-  line-height: 1.4;
-}
-
-.v2-inspector__agent-row {
-  display: grid;
-  grid-template-columns: 34px minmax(0, 1fr) 28px;
-  align-items: center;
-  gap: 9px;
-  padding: 8px 0;
-  border-bottom: none;
-}
-
-.v2-inspector__agent-row:last-child {
-  border-bottom: none;
-}
-
-.v2-inspector__agent-info {
-  flex: 1;
-  min-width: 0;
-}
-
-.v2-inspector__agent-head {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.v2-inspector__agent-name {
-  font-size: 12.5px;
-  font-weight: 700;
-  color: var(--v2-text-primary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.v2-inspector__agent-task {
-  font-size: 11px;
-  color: var(--v2-text-tertiary);
-  margin-top: 2px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.v2-inspector__more-btn {
-  min-width: 24px;
-  height: 24px;
-  padding: 0 5px;
-  display: grid;
-  place-items: center;
-  border-radius: var(--v2-radius-sm);
-  color: var(--v2-text-tertiary);
-  font-size: 10px;
-  font-weight: 700;
-}
-
-.v2-inspector__more-btn:hover {
-  background: var(--v2-bg-subtle);
-  color: var(--v2-text-primary);
-}
-
-.v2-inspector__settings-row {
-  display: flex;
-  align-items: center;
-  height: 38px;
-  gap: 10px;
-  padding: 0;
+  justify-content: space-between;
   font-size: 13px;
-  font-weight: 500;
   color: var(--v2-text-secondary);
-  border-bottom: 1px solid var(--v2-border);
 }
 
-.v2-inspector__settings-menu {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+.v2-inspector__runstate-label {
+  font-weight: 500;
 }
 
-.v2-inspector__settings-chip {
-  min-height: 30px;
+.v2-inspector__pill {
+  height: 22px;
   padding: 0 10px;
-  border: 1px solid var(--v2-border);
-  border-radius: 999px;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  background: var(--v2-surface);
-  color: var(--v2-text-secondary);
-  font-size: 12px;
+  border-radius: 999px;
+  font-size: 11px;
   font-weight: 600;
+  letter-spacing: 0.01em;
 }
 
-.v2-inspector__settings-chip:hover {
+.v2-inspector__pill--blocked {
+  background: rgba(239, 68, 68, 0.10);
+  color: #b91c1c;
+}
+
+.v2-inspector__pill--progress {
+  background: rgba(79, 70, 229, 0.10);
+  color: var(--v2-accent-text);
+}
+
+.v2-inspector__pill--complete {
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+}
+
+/* ---------- Inspector: Detail sub-page ---------- */
+
+.v2-inspector__detail {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-top: 4px;
+}
+
+.v2-inspector__detail-head {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--v2-border-soft);
+}
+
+.v2-inspector__detail-name {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--v2-text-primary);
+  letter-spacing: -0.01em;
+  margin-top: 4px;
+}
+
+.v2-inspector__detail-sub {
+  font-size: 12px;
+  color: var(--v2-text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.v2-inspector__detail-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.v2-inspector__btn {
+  appearance: none;
+  height: 32px;
+  padding: 0 14px;
+  border-radius: var(--v2-radius-sm);
+  border: 1px solid var(--v2-border);
+  background: var(--v2-surface);
+  color: var(--v2-text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  transition: background 80ms ease, color 80ms ease, border-color 80ms ease;
+}
+
+.v2-inspector__btn:hover {
   color: var(--v2-text-primary);
   background: var(--v2-surface-hover);
 }
 
-.v2-inspector__settings-chip--danger {
-  color: var(--v2-danger);
-  border-color: rgba(239, 68, 68, 0.24);
+.v2-inspector__btn--primary {
+  background: var(--v2-accent);
+  color: #fff;
+  border-color: var(--v2-accent);
 }
 
-.v2-inspector__settings-chip--danger:hover {
-  color: var(--v2-danger);
-  background: rgba(239, 68, 68, 0.08);
+.v2-inspector__btn--primary:hover {
+  background: var(--v2-accent-strong);
+  color: #fff;
 }
 
-.v2-inspector__conversation-row {
-  width: 100%;
-  height: 34px;
-  display: grid;
-  grid-template-columns: 22px minmax(0, 1fr) auto 28px;
-  gap: 8px;
-  align-items: center;
-  font-size: 12px;
-  text-align: left;
-}
-
-.v2-inspector__conversation-text {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: #374151;
-}
-
-.v2-inspector__conversation-time {
-  font-size: 11px;
-  color: #6b7280;
-}
-
-.v2-inspector__conversation-pill {
-  height: 20px;
-  padding: 0 6px;
-  border-radius: 6px;
-  background: #f3f4f6;
-  font-size: 10px;
-  font-weight: 700;
-  color: #6b7280;
-  display: grid;
-  place-items: center;
-}
-
-.v2-inspector__resource-row {
+.v2-inspector__detail-card {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  padding: 8px 0;
-  border-top: 1px solid var(--v2-border);
+  gap: 4px;
 }
 
-.v2-inspector__resource-row:first-of-type {
-  border-top: none;
-}
-
-.v2-inspector__resource-kicker {
+.v2-inspector__detail-kicker {
   font-size: 10px;
   font-weight: 700;
   color: var(--v2-text-tertiary);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
 }
 
-.v2-inspector__resource-title {
-  font-size: 12px;
-  font-weight: 700;
-  color: var(--v2-text-primary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.v2-inspector__detail-body {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--v2-text-secondary);
 }
 
-.v2-inspector__settings-row:last-child {
-  border-bottom: none;
+.v2-inspector__chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 2px;
 }
 
-.v2-inspector__settings-row:hover {
-  color: var(--v2-text-primary);
-}
-
-.v2-inspector__settings-chev {
-  margin-left: auto;
-  color: var(--v2-text-muted);
+.v2-inspector__chip {
+  height: 22px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
 }
 
 /* ---------- Avatar ---------- */


### PR DESCRIPTION
## Summary
Replaces the People/Activity/Settings tab strip with a continuous-scroll **overview**, plus two **sub-pages** that open from chat clicks. Inspector remains collapsible — the new structure only kicks in once it's expanded. Drops the Chat / Tasks / Summary tab row in chat.

This ports the visual direction from the v2 design refs (image 1 + image 2 in conversation).

### Overview scroll
- **Goal** — pod description, no \`Goal:\` kicker
- **Artifacts** — announcements + external-links rendered as compact rows; polished empty state when none
- **Members** — agents + humans with role pills (Owner / Human / AI Agent), each row clickable → member detail
- **Run State** — task counts grouped into Blocked / In Progress / Complete pills, with a \"View run board\" link

### Sub-pages
- **Member detail** — avatar + status + Talk to (existing DM flow) + Manage; Working-on / Purpose / Specialties cards if available
- **Artifact detail** — title + source + Open button

### Click wiring
- Chat header **avatar group** → expand to Overview (existing behavior, kept)
- Message **author avatar/name** in V2MessageBubble → expand to Member detail for that agent (humans not yet wired)
- **Member row** in inspector → Member detail
- **Artifact row** → Artifact detail
- \`← Back\` button on sub-pages returns to Overview; \`× close\` collapses

### Chat surface trim
- Killed Chat / Tasks / Summary tab strip + V2TasksView/V2SummaryView (Tasks now visible as Run State pills; full board reachable via inspector link)
- Dropped the \`Goal:\` kicker text (just the description + meta now)

Removes ~170 lines of dead CSS (tab strip, inspector cards, settings-chip menu, conversation-row, pod-card stack). Replaced with cleaner section / member-row / artifact-row / runstate / detail blocks.

Stacks on PR #262 (already merged as e59cc5c3cd).

## Test plan
- [ ] Land on a pod, inspector default-collapsed (sticky)
- [ ] Click avatar group → inspector expands to Overview, shows Goal / Artifacts / Members / Run State
- [ ] Click an agent row → inspector switches to Member detail with Talk to + Manage
- [ ] Click \`← Back\` → returns to Overview
- [ ] Click \`× close\` → inspector collapses (and re-opens to Overview, not last sub-page)
- [ ] Click an agent's avatar/name in a chat message → inspector opens to that member's detail
- [ ] Run State pills reflect real task counts on a pod with tasks
- [ ] Empty Artifacts on a fresh pod shows the polished empty state
- [ ] Switching pods resets sub-page state

🤖 Generated with [Claude Code](https://claude.com/claude-code)