### PR TITLE
feat(v2): file uploads — non-image types, agent uploads, inspector artifacts

### DIFF
--- a/backend/__tests__/unit/routes/uploads.post.test.js
+++ b/backend/__tests__/unit/routes/uploads.post.test.js
@@ -72,11 +72,48 @@ describe('uploads POST / (ADR-002 Phase 1)', () => {
     expect(mockStore.put).not.toHaveBeenCalled();
   });
 
-  it('rejects disallowed extensions before reaching the driver', async () => {
+  it('rejects disallowed extensions with a 400 (not a 500)', async () => {
+    const res = await request(app)
+      .post('/api/uploads')
+      .attach('image', Buffer.from('data'), 'malware.exe')
+      .expect(400);
+    expect(res.body.msg).toMatch(/not allowed/i);
+    expect(mockStore.put).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['brief.pdf', 'document'],
+    ['notes.md', 'document'],
+    ['notes.txt', 'document'],
+    ['data.csv', 'data'],
+    ['payload.json', 'data'],
+    ['photo.png', 'image'],
+  ])('accepts %s and reports kind=%s', async (filename, expectedKind) => {
+    const res = await request(app)
+      .post('/api/uploads')
+      .attach('image', Buffer.from('data'), filename)
+      .expect(200);
+    expect(res.body.kind).toBe(expectedKind);
+    expect(res.body.originalName).toBe(filename);
+    expect(mockStore.put).toHaveBeenCalled();
+  });
+
+  it('persists podId on the File row when supplied', async () => {
     await request(app)
       .post('/api/uploads')
-      .attach('image', Buffer.from('data'), 'text.txt')
-      .expect(500); // multer surfaces the filter error as 500
-    expect(mockStore.put).not.toHaveBeenCalled();
+      .field('podId', 'pod-123')
+      .attach('image', Buffer.from('data'), 'brief.pdf')
+      .expect(200);
+    const fileArgs = File.mock.calls[File.mock.calls.length - 1][0];
+    expect(fileArgs.podId).toBe('pod-123');
+  });
+
+  it('leaves podId null when not supplied', async () => {
+    await request(app)
+      .post('/api/uploads')
+      .attach('image', Buffer.from('data'), 'photo.png')
+      .expect(200);
+    const fileArgs = File.mock.calls[File.mock.calls.length - 1][0];
+    expect(fileArgs.podId).toBeNull();
   });
 });

--- a/backend/models/File.ts
+++ b/backend/models/File.ts
@@ -13,6 +13,13 @@ export interface IFile extends Document {
    */
   data?: Buffer;
   uploadedBy: Types.ObjectId;
+  /**
+   * Pod the file was uploaded into, if any. Populated when a member or agent
+   * uploads via the pod composer / agent runtime; left null for profile-
+   * picture and other personal uploads. Used to surface uploaded files in
+   * the pod inspector's Artifacts section without joining through messages.
+   */
+  podId?: Types.ObjectId | null;
   createdAt: Date;
 }
 
@@ -27,10 +34,12 @@ const fileSchema = new Schema<IFile>({
   size: { type: Number, required: true },
   data: { type: Buffer, required: false },
   uploadedBy: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  podId: { type: Schema.Types.ObjectId, ref: 'Pod', required: false, default: null },
   createdAt: { type: Date, default: Date.now },
 });
 
 fileSchema.index({ fileName: 1 });
+fileSchema.index({ podId: 1, createdAt: -1 });
 
 fileSchema.statics.findByFileName = function (fileName: string) {
   return this.findOne({ fileName });

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -2502,4 +2502,31 @@ router.post('/asks/:requestId/respond', agentRuntimeAuth, phase4RateLimit, async
   }
 });
 
+// Agent runtime upload endpoint — agents post non-image files (briefs,
+// notes, generated docs) into a pod they're installed in. Reuses the
+// shared multer wrapper + handleUpload helper from routes/uploads.ts so
+// the byte path, allowlist, and error shape match the user route.
+//
+// The CAP pattern is `POST /pods/:podId/<thing>`; the body is multipart
+// (field name `file`) so SDKs can stream from local disk without buffering.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { handleUpload, uploadSingle } = require('./uploads');
+router.post('/pods/:podId/uploads', agentRuntimeAuth, uploadSingle('file'), async (req: any, res: any) => {
+  try {
+    const { podId } = req.params;
+    if (!ensurePodMatch(req.agentInstallations || req.agentInstallation, podId, req.agentAuthorizedPodIds)) {
+      return res.status(403).json({ message: 'Agent token not authorized for this pod' });
+    }
+    if (!req.agentUser?._id) {
+      return res.status(401).json({ message: 'Agent identity required' });
+    }
+    // Pin the upload to this pod regardless of what was in the form body.
+    req.body = { ...(req.body || {}), podId };
+    return await handleUpload(req, res, req.agentUser._id.toString());
+  } catch (error: any) {
+    console.error('Agent upload error:', error);
+    return res.status(500).json({ message: 'Failed to upload file' });
+  }
+});
+
 module.exports = router;

--- a/backend/routes/pods.ts
+++ b/backend/routes/pods.ts
@@ -15,6 +15,8 @@ const Announcement = require('../models/Announcement');
 // eslint-disable-next-line global-require
 const ExternalLink = require('../models/ExternalLink');
 // eslint-disable-next-line global-require
+const File = require('../models/File');
+// eslint-disable-next-line global-require
 const PodContextService = require('../services/podContextService');
 // eslint-disable-next-line global-require
 const PodMemorySearchService = require('../services/podMemorySearchService');
@@ -292,6 +294,28 @@ router.get('/:podId/announcements', auth, async (req: AuthReq, res: Res) => {
     return res.status(200).json(announcements);
   } catch (error) {
     console.error('Error retrieving pod announcements:', error);
+    return res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/:podId/files', auth, async (req: AuthReq, res: Res) => {
+  try {
+    const { podId } = req.params || {};
+    const pod = await Pod.findById(podId) as { members?: Array<{ toString: () => string }> } | null;
+    if (!pod) return res.status(404).json({ message: 'Pod not found' });
+    const userId = req.user?.id;
+    const isMember = pod.members?.some((m) => m.toString() === userId);
+    if (!isMember) return res.status(403).json({ message: 'Not authorized to view pod files' });
+    // Most recent 100 — file lists in the inspector are bounded by what the
+    // user can scan visually; pagination can come later if pods get heavy.
+    const files = await File.find({ podId })
+      .sort({ createdAt: -1 })
+      .limit(100)
+      .select('fileName originalName contentType size uploadedBy createdAt')
+      .populate('uploadedBy', 'username profilePicture');
+    return res.status(200).json(files);
+  } catch (error) {
+    console.error('Error fetching pod files:', error);
     return res.status(500).json({ message: 'Server error' });
   }
 });

--- a/backend/routes/uploads.ts
+++ b/backend/routes/uploads.ts
@@ -45,6 +45,9 @@ interface AuthReq {
   file?: { originalname: string; mimetype: string; size: number; buffer: Buffer };
   params?: { fileName?: string };
   query?: { t?: string };
+  body?: { podId?: string };
+  agentUser?: { _id: { toString: () => string } };
+  agentAuthorizedPodIds?: string[];
 }
 interface Res {
   status: (n: number) => Res;
@@ -53,7 +56,29 @@ interface Res {
   send: (d: unknown) => void;
 }
 
-const ALLOWED_EXT_REGEX = /\.(jpg|jpeg|png|gif|webp|svg)$/i;
+// Per-kind extension allowlist. Replaces the original image-only regex.
+// Office docs (doc/docx/xls/xlsx/ppt/pptx) and AV media (mp4/mov/mp3/wav)
+// were considered for v1 but deferred until we have ClamAV in front of the
+// non-image upload path (ADR-002 Phase 6). For demo + beta the doc/text
+// kinds below are sufficient: agents posting briefs, users dropping notes.
+const KIND_EXTENSIONS: Record<string, string[]> = {
+  image: ['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg'],
+  document: ['pdf', 'md', 'txt'],
+  data: ['csv', 'json'],
+};
+const ALLOWED_EXT_REGEX = new RegExp(
+  `\\.(${Object.values(KIND_EXTENSIONS).flat().join('|')})$`,
+  'i',
+);
+const kindFromName = (originalName: string): string => {
+  const dot = originalName.lastIndexOf('.');
+  if (dot < 0) return 'other';
+  const ext = originalName.slice(dot + 1).toLowerCase();
+  for (const [kind, exts] of Object.entries(KIND_EXTENSIONS)) {
+    if (exts.includes(ext)) return kind;
+  }
+  return 'other';
+};
 
 // Size cap is driven by the driver's declared max. multer returns 413 itself
 // when the multipart exceeds it, so the route doesn't need a secondary check.
@@ -74,11 +99,27 @@ const upload = multer({
     cb: (err: Error | null, accept: boolean) => void,
   ) {
     if (!ALLOWED_EXT_REGEX.test(file.originalname)) {
-      return cb(new Error('Only image files are allowed!'), false);
+      return cb(new Error('File type not allowed'), false);
     }
     cb(null, true);
   },
 });
+
+// Wrap multer.single so filter / size errors become 400s instead of bubbling
+// as 500. Multer's default error path is the route's try/catch, which can't
+// distinguish "user sent a bad type" from "driver crashed".
+const uploadSingle = (field: string) => (req: AuthReq, res: Res, next: (err?: unknown) => void) => {
+  upload.single(field)(req as never, res as never, (err: unknown) => {
+    if (err) {
+      const e = err as { code?: string; message?: string };
+      if (e?.code === 'LIMIT_FILE_SIZE') {
+        return res.status(413).json({ msg: 'File too large' });
+      }
+      return res.status(400).json({ msg: e?.message || 'Invalid upload' });
+    }
+    next();
+  });
+};
 
 // 30 mints/min/bucket is generous for a page loading dozens of avatars +
 // images (clients cache until TTL expiry) and low enough that a compromised
@@ -106,15 +147,31 @@ const mintRateLimit = rateLimit({
 
 const router: ReturnType<typeof express.Router> = express.Router();
 
-router.post('/', auth, upload.single('image'), async (req: AuthReq, res: Res) => {
+// Shared upload handler — used by both the user-auth POST / and the
+// agent-runtime POST /agent. Caller passes the resolved uploader id and
+// (optionally) the podId scope to bind the File row to.
+//
+// Upload routes accept a `podId` form field; populating it surfaces the
+// file in the pod inspector's Artifacts section. Agent uploads must
+// supply a podId they're installed in (enforced in the agent route).
+const handleUpload = async (
+  req: AuthReq,
+  res: Res,
+  uploaderId: string,
+): Promise<void> => {
   try {
-    if (!req.file) return res.status(400).json({ msg: 'No file uploaded' });
+    if (!req.file) {
+      res.status(400).json({ msg: 'No file uploaded' });
+      return;
+    }
 
     const store = getObjectStore();
 
     const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
     const ext = path.extname(req.file.originalname);
     const fileName = `${uniqueSuffix}${ext}`;
+    const kind = kindFromName(req.file.originalname);
+    const podId = req.body?.podId?.toString().trim() || null;
 
     await store.put(fileName, req.file.buffer, req.file.mimetype);
 
@@ -126,7 +183,8 @@ router.post('/', auth, upload.single('image'), async (req: AuthReq, res: Res) =>
       originalName: req.file.originalname,
       contentType: req.file.mimetype,
       size: req.file.size,
-      uploadedBy: req.userId,
+      uploadedBy: uploaderId,
+      podId,
     });
     await newFile.save();
 
@@ -134,12 +192,28 @@ router.post('/', auth, upload.single('image'), async (req: AuthReq, res: Res) =>
     const host = req.get?.('host');
     const url = `${protocol}://${host}/api/uploads/${fileName}`;
 
-    return res.json({ url, fileName, contentType: req.file.mimetype, size: req.file.size });
+    res.json({
+      url,
+      fileName,
+      originalName: req.file.originalname,
+      contentType: req.file.mimetype,
+      size: req.file.size,
+      kind,
+      podId,
+    });
   } catch (err) {
     const e = err as { message?: string };
     console.error('Upload error:', e.message);
-    return res.status(500).json({ msg: 'Server Error' });
+    res.status(500).json({ msg: 'Server Error' });
   }
+};
+
+router.post('/', auth, uploadSingle('image'), async (req: AuthReq, res: Res) => {
+  if (!req.userId) {
+    res.status(401).json({ msg: 'auth required' });
+    return;
+  }
+  await handleUpload(req, res, req.userId);
 });
 
 // ADR-002 Phase 1b: signed-URL mint endpoint. Declared before the bare
@@ -210,6 +284,11 @@ router.get('/:fileName', async (req: AuthReq, res: Res) => {
   }
 });
 
-module.exports = router;
+// Exported so the agent-runtime upload route can reuse the shared helpers
+// without going through HTTP. The route file mounts `handleUpload` behind
+// agentRuntimeAuth and gates podId against the agent's authorized pods.
+export { handleUpload, uploadSingle };
 
-export {};
+module.exports = router;
+module.exports.handleUpload = handleUpload;
+module.exports.uploadSingle = uploadSingle;

--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -4,6 +4,7 @@ import V2Avatar from './V2Avatar';
 import { V2Message } from '../hooks/useV2PodDetail';
 import { formatRelativeTime } from '../utils/grouping';
 import { useAuth } from '../../context/AuthContext';
+import { getSignedAttachmentUrl } from '../../utils/signedAttachmentUrl';
 
 // Minimal v2-scoped markdown renderer. Plain HTML elements (no MUI), so
 // styling stays in v2.css under `.v2-msg__content`. The body comes pre-stripped
@@ -84,6 +85,10 @@ interface ParsedFile {
   name: string;
   ext: string;
   size?: string;
+  // Set when the pill came from an [[upload:...]] directive backed by a real
+  // ObjectStore record. Click → mint signed URL → open. Plain [[file:...]]
+  // pills (used by demo fixtures) leave this undefined and render as static.
+  fileName?: string;
 }
 
 interface ParsedReaction {
@@ -111,6 +116,21 @@ const FILE_EXT_COLORS: Record<string, string> = {
 // This is a v2-only convention so we can preview file pills until the backend
 // Message model gains a real `attachments[]` field.
 const FILE_TOKEN_RE = /\[\[file:([^\]|]+)(?:\|([^\]]+))?\]\]/g;
+// Match a real upload directive emitted by the composer / agent SDK after a
+// successful POST /api/uploads:
+//   [[upload:<fileName>|<originalName>|<size>|<kind>]]
+// fileName is the ObjectStore key (e.g. `1714678910-712345678.pdf`); the pill
+// click handler exchanges it for a short-TTL signed URL via getSignedAttachmentUrl.
+const UPLOAD_TOKEN_RE = /\[\[upload:([^\]|]+)\|([^\]|]+)\|([^\]|]+)(?:\|([^\]]+))?\]\]/g;
+const formatBytes = (raw: string | number): string => {
+  const n = typeof raw === 'number' ? raw : parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return '';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let v = n;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i += 1; }
+  return `${v.toFixed(v < 10 && i > 0 ? 1 : 0)} ${units[i]}`;
+};
 // Match a v2 reactions token: [[reactions:👍 3, 💬 2, 🔥 1]]. Pure render —
 // no write path tonight; the YC demo seed populates this from fixtures.
 // Real reactions backend ships post-YC.
@@ -120,14 +140,24 @@ const IMAGE_URL_RE = /^https?:\/\/.+\.(png|jpe?g|gif|webp)(\?.*)?$/i;
 
 const parseFiles = (content: string): { stripped: string; files: ParsedFile[] } => {
   const files: ParsedFile[] = [];
-  const stripped = content.replace(FILE_TOKEN_RE, (_match, rawName, rawSize) => {
+  // Real uploads first — they carry a fileName and resolve to a signed URL on
+  // click. Then static file tokens (demo fixtures, no backend reference).
+  let working = content.replace(UPLOAD_TOKEN_RE, (_match, rawFileName, rawOriginal, rawSize) => {
+    const fileName = String(rawFileName).trim();
+    const name = String(rawOriginal).trim();
+    const dot = name.lastIndexOf('.');
+    const ext = dot >= 0 ? name.slice(dot + 1).toLowerCase() : 'file';
+    files.push({ fileName, name, ext, size: formatBytes(String(rawSize).trim()) || undefined });
+    return '';
+  });
+  working = working.replace(FILE_TOKEN_RE, (_match, rawName, rawSize) => {
     const name = String(rawName).trim();
     const dot = name.lastIndexOf('.');
     const ext = dot >= 0 ? name.slice(dot + 1).toLowerCase() : 'file';
     files.push({ name, ext, size: rawSize ? String(rawSize).trim() : undefined });
     return '';
-  }).trim();
-  return { stripped, files };
+  });
+  return { stripped: working.trim(), files };
 };
 
 const parseReactions = (content: string): { stripped: string; reactions: ParsedReaction[] } => {
@@ -152,8 +182,8 @@ const parseReactions = (content: string): { stripped: string; reactions: ParsedR
 
 const FilePill: React.FC<{ file: ParsedFile }> = ({ file }) => {
   const color = FILE_EXT_COLORS[file.ext] || '#94a3b8';
-  return (
-    <span className="v2-msg__file">
+  const inner = (
+    <>
       <span className="v2-msg__file-icon" style={{ background: color }}>
         {file.ext.slice(0, 4).toUpperCase()}
       </span>
@@ -161,7 +191,31 @@ const FilePill: React.FC<{ file: ParsedFile }> = ({ file }) => {
         <span className="v2-msg__file-name">{file.name}</span>
         {file.size && <span className="v2-msg__file-size">{file.size}</span>}
       </span>
-    </span>
+    </>
+  );
+  // Static demo file (no backend reference) — render as a div, no click.
+  if (!file.fileName) {
+    return <span className="v2-msg__file">{inner}</span>;
+  }
+  // Real upload — mint signed URL on click. Don't fetch eagerly: a chat with
+  // 50 file messages would mint 50 tokens on render. Mint on demand keeps the
+  // 30/min/user rate limit comfortable.
+  const handleClick = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    const signed = await getSignedAttachmentUrl(`/api/uploads/${file.fileName}`);
+    if (signed) {
+      window.open(signed, '_blank', 'noopener,noreferrer');
+    }
+  };
+  return (
+    <button
+      type="button"
+      className="v2-msg__file v2-msg__file--clickable"
+      onClick={handleClick}
+      aria-label={`Open ${file.name}`}
+    >
+      {inner}
+    </button>
   );
 };
 

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -455,25 +455,40 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
     }
   };
 
-  const handleAttachImage = async (file: File | null) => {
+  // Composer attach: handles both images (sends as standalone image message,
+  // legacy v2 behavior) and other file kinds (PDF / md / txt / csv / json,
+  // inserts an [[upload:fileName|originalName|size|kind]] directive into the
+  // draft so the user can add accompanying text and send when ready). Both
+  // paths POST to /api/uploads with the active podId so the file shows up in
+  // the inspector's Artifacts section.
+  const handleAttachFile = async (file: File | null) => {
     if (!file || uploading) return;
-    if (!file.type.startsWith('image/')) {
-      setComposerError('Only image files are supported here.');
-      return;
-    }
     setUploading(true);
     setComposerError(null);
     try {
       const formData = new FormData();
-      formData.append('image', file);
-      const uploaded = await api.post<{ url?: string }>('/api/uploads', formData, {
+      formData.append('image', file); // legacy multer field name
+      formData.append('podId', pod._id);
+      const uploaded = await api.post<{
+        url?: string;
+        fileName?: string;
+        originalName?: string;
+        size?: number;
+        kind?: string;
+      }>('/api/uploads', formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
       });
-      if (uploaded.url) {
+      if (uploaded.kind === 'image' && uploaded.url) {
         await sendMessage(uploaded.url, 'image');
+        return;
       }
-    } catch {
-      setComposerError('Failed to upload image. Please try again.');
+      if (uploaded.fileName) {
+        const directive = `[[upload:${uploaded.fileName}|${uploaded.originalName || file.name}|${uploaded.size || file.size}|${uploaded.kind || 'file'}]]`;
+        setDraft((prev) => (prev ? `${prev.replace(/\s+$/, '')} ${directive}` : directive));
+      }
+    } catch (err) {
+      const e = err as { response?: { data?: { msg?: string } } };
+      setComposerError(e.response?.data?.msg || 'Failed to upload file. Please try again.');
     } finally {
       setUploading(false);
       if (fileInputRef.current) fileInputRef.current.value = '';
@@ -679,8 +694,9 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
                   <input
                     ref={fileInputRef}
                     type="file"
+                    accept="image/*,.pdf,.md,.txt,.csv,.json"
                     style={{ display: 'none' }}
-                    onChange={(e) => handleAttachImage(e.target.files?.[0] || null)}
+                    onChange={(e) => handleAttachFile(e.target.files?.[0] || null)}
                   />
                   <button
                     type="button"

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -5,6 +5,7 @@ import { UseV2PodDetailResult, V2Agent } from '../hooks/useV2PodDetail';
 import { UseV2PodsResult } from '../hooks/useV2Pods';
 import { useV2Api } from '../hooks/useV2Api';
 import { useAuth } from '../../context/AuthContext';
+import { getSignedAttachmentUrl } from '../../utils/signedAttachmentUrl';
 import type { InspectorView } from './V2Layout';
 
 interface V2PodInspectorProps {
@@ -51,6 +52,15 @@ interface ExternalLinkItem {
   url?: string;
 }
 
+interface PodFileItem {
+  _id: string;
+  fileName: string;
+  originalName: string;
+  contentType?: string;
+  size?: number;
+  createdAt?: string;
+}
+
 // Per-type label for the Artifacts row icon (1-2 char glyph) and the
 // human-readable kind shown under the title. Keep aligned with the enum in
 // `backend/models/ExternalLink.ts`. Unknown kinds fall back to "L" / "Link".
@@ -75,6 +85,26 @@ const ARTIFACT_KIND_META: Record<string, { icon: string; label: string }> = {
   groupme: { icon: 'GR', label: 'GroupMe' },
   other: { icon: 'L', label: 'Link' },
   other_link: { icon: 'L', label: 'Link' },
+  // Uploaded-file kinds — derived from extension by `fileKind()` below. Same
+  // visual treatment as URL artifacts so the inspector list stays uniform.
+  pdf: { icon: 'PDF', label: 'PDF' },
+  md: { icon: 'MD', label: 'Markdown' },
+  txt: { icon: 'TXT', label: 'Text' },
+  csv: { icon: 'CSV', label: 'CSV' },
+  json: { icon: 'JS', label: 'JSON' },
+  image: { icon: 'IMG', label: 'Image' },
+  file: { icon: 'F', label: 'File' },
+};
+
+// Map a file's extension to one of the keys in ARTIFACT_KIND_META so the
+// uploaded-file rows pick up the right icon/label without re-deriving in JSX.
+const fileKind = (originalName: string, contentType?: string): string => {
+  const dot = originalName.lastIndexOf('.');
+  const ext = dot >= 0 ? originalName.slice(dot + 1).toLowerCase() : '';
+  if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg'].includes(ext)) return 'image';
+  if (['pdf', 'md', 'txt', 'csv', 'json'].includes(ext)) return ext;
+  if (contentType?.startsWith('image/')) return 'image';
+  return 'file';
 };
 
 const artifactMeta = (kind: string): { icon: string; label: string } =>
@@ -131,6 +161,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   const [privateError, setPrivateError] = useState<string | null>(null);
   const [announcements, setAnnouncements] = useState<AnnouncementItem[]>([]);
   const [externalLinks, setExternalLinks] = useState<ExternalLinkItem[]>([]);
+  const [podFiles, setPodFiles] = useState<PodFileItem[]>([]);
   const [tab, setTab] = useState<'overview' | 'members' | 'tasks' | 'manage'>('overview');
   const [addLinkOpen, setAddLinkOpen] = useState(false);
   const [addLinkUrl, setAddLinkUrl] = useState('');
@@ -245,17 +276,20 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
     if (!podId) {
       setAnnouncements([]);
       setExternalLinks([]);
+      setPodFiles([]);
       return;
     }
     let cancelled = false;
     (async () => {
-      const [announcementResult, linksResult] = await Promise.allSettled([
+      const [announcementResult, linksResult, filesResult] = await Promise.allSettled([
         api.get<AnnouncementItem[]>(`/api/pods/${podId}/announcements`),
         api.get<ExternalLinkItem[]>(`/api/pods/${podId}/external-links`),
+        api.get<PodFileItem[]>(`/api/pods/${podId}/files`),
       ]);
       if (cancelled) return;
       setAnnouncements(announcementResult.status === 'fulfilled' && Array.isArray(announcementResult.value) ? announcementResult.value : []);
       setExternalLinks(linksResult.status === 'fulfilled' && Array.isArray(linksResult.value) ? linksResult.value : []);
+      setPodFiles(filesResult.status === 'fulfilled' && Array.isArray(filesResult.value) ? filesResult.value : []);
     })();
     return () => { cancelled = true; };
   }, [pod?._id, api]);
@@ -353,7 +387,11 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
     </section>
   );
 
-  const artifactItems: Array<{ id: string; kind: string; title: string; subtitle?: string; url?: string }> = [
+  // Files come last so the freshest URL artifact (added via "+ Add") still
+  // sits at the top — matches the user's expectation that the row they just
+  // pasted is visible without scrolling. Within each source, server returns
+  // newest-first.
+  const artifactItems: Array<{ id: string; kind: string; title: string; subtitle?: string; url?: string; fileName?: string }> = [
     ...announcements.map((a) => ({
       id: `ann-${a._id}`,
       kind: 'Announcement',
@@ -365,6 +403,15 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
       title: l.name || l.url || 'External link',
       subtitle: l.url,
       url: l.url,
+    })),
+    ...podFiles.map((f) => ({
+      id: `file-${f._id}`,
+      kind: fileKind(f.originalName, f.contentType),
+      title: f.originalName || f.fileName,
+      subtitle: f.contentType,
+      // No `url` here — files require a signed-URL mint. The detail view's
+      // Open button calls getSignedAttachmentUrl(`/api/uploads/${fileName}`).
+      fileName: f.fileName,
     })),
   ];
 
@@ -665,12 +712,26 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   // ------------------------------------------------------------------
   // ARTIFACT DETAIL sub-page
   // ------------------------------------------------------------------
+  // File artifacts open via a signed-URL mint (no plain href to embed). URL
+  // artifacts use safeHref. Click handler always preventDefault so we can
+  // route both kinds through one button.
+  const handleOpenArtifact = async (item: typeof artifactItems[0]) => {
+    if (item.fileName) {
+      const signed = await getSignedAttachmentUrl(`/api/uploads/${item.fileName}`);
+      if (signed) window.open(signed, '_blank', 'noopener,noreferrer');
+      return;
+    }
+    const href = safeHref(item.url);
+    if (href) window.open(href, '_blank', 'noopener,noreferrer');
+  };
+
   const renderArtifactDetail = (artifactId: string) => {
     const found = artifactItems.find((a) => a.id === artifactId);
     if (!found) {
       return <div className="v2-inspector__empty">Artifact not found.</div>;
     }
     const meta = artifactMeta(found.kind);
+    const openable = !!found.fileName || !!safeHref(found.url);
     return (
       <div className="v2-inspector__detail">
         <div className="v2-inspector__detail-head">
@@ -680,16 +741,20 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
           <div className="v2-inspector__detail-name">{found.title}</div>
           <div className="v2-inspector__detail-sub">{meta.label}</div>
         </div>
-        {safeHref(found.url) && (
+        {openable && (
           <div className="v2-inspector__detail-actions">
-            <a className="v2-inspector__btn v2-inspector__btn--primary" href={safeHref(found.url)} target="_blank" rel="noreferrer">
+            <button
+              type="button"
+              className="v2-inspector__btn v2-inspector__btn--primary"
+              onClick={() => { void handleOpenArtifact(found); }}
+            >
               Open
-            </a>
+            </button>
           </div>
         )}
         {found.subtitle && (
           <div className="v2-inspector__detail-card">
-            <div className="v2-inspector__detail-kicker">Source</div>
+            <div className="v2-inspector__detail-kicker">{found.fileName ? 'Type' : 'Source'}</div>
             <div className="v2-inspector__detail-body" style={{ wordBreak: 'break-all' }}>{found.subtitle}</div>
           </div>
         )}


### PR DESCRIPTION
**Stacked on #266.** Review #266 first; this PR rebases automatically when it merges.

## Summary
- **Non-image uploads:** allowlist extended from images only to image / document (pdf/md/txt) / data (csv/json). New kinds + ClamAV-gated formats (office, AV, archive) are deferred to ADR-002 Phase 6.
- **Agent uploads:** `POST /api/agents/runtime/pods/:podId/uploads` (multipart, field `file`). agentRuntimeAuth + ensurePodMatch; delegates to the same `handleUpload` helper as the user route. Resolves ADR-002 §Open Questions ("Should agent runtimes upload?") with yes-for-hosted-driver.
- **Pod-scoped files:** `File.podId` (optional) lets uploads bind to a pod at write time. Inspector reads via new `GET /api/pods/:podId/files` (member-only, populated uploader).
- **Composer attach:** `V2PodChat` accepts non-image files; non-images insert a `[[upload:fileName|originalName|size|kind]]` directive into the draft so the user can add accompanying text. Images keep their existing inline-message behavior.
- **Bubble file pill:** `V2MessageBubble` parses the upload directive and renders a clickable pill that mints a signed URL on click (no eager fetch — chats with many file messages don't blow the 30/min rate limit).
- **Inspector artifacts:** Files appear alongside URL links and announcements. Per-extension icons (PDF, MD, TXT, CSV, JS, IMG). Detail view "Open" routes through the signed-URL mint.

Multer filter and size errors now surface as 400 / 413 instead of bubbling as 500.

## Why
PR #266 covered URL artifacts (Notion / Drive / Figma / GitHub / Zoom). This PR covers actual byte uploads — the demo path where an agent generates a brief.pdf and drops it into the pod, plus the human user attaching a file the same way. Same `ObjectStore` driver, same signed-URL flow, just unblocked for non-image MIMEs and pod-scoped.

## What I did NOT do
- ADR-002 Phase 2 (attachment registry / ULID / sha256 / ref counting / GC) — `File` model still does the job for now.
- Phase 1b-b auth flip on `GET /api/uploads/:fileName` — out of scope, separate PR.
- Office docs / video / audio — pending ClamAV (ADR-002 Phase 6).
- File previews beyond click-to-open. PDF embed / markdown render is a Phase E nicety.

## Tests
- `uploads.post.test.js` — 11 cases (was 3). Multi-extension acceptance with kind derivation, podId persistence, 400-not-500 on disallowed extension.
- 65/65 across uploads + external-links + model files.
- New routes (`/api/pods/:podId/files`, `/api/agents/runtime/pods/:podId/uploads`) covered by the shared `handleUpload` test path; route-level integration tests deferred to a follow-up since they need the agent runtime token harness.

## Test plan
- [ ] Deploy to dev: `gh workflow run deploy-dev.yml --ref feat/v2-file-attachments`
- [ ] Open Sam's YC Sprint pod, click attach in composer, pick a `.pdf` — confirm a file pill appears in the draft, send, confirm pill renders in the bubble and clicking it opens the PDF in a new tab
- [ ] Same flow with a `.png` — should still send as the inline image (legacy behavior preserved)
- [ ] Try uploading a `.exe` — confirm 400 with "File type not allowed"
- [ ] Open the inspector → Artifacts. Confirm the uploaded PDF appears with the "PDF" icon
- [ ] Click the artifact → detail view → "Open" — confirms signed-URL flow works for files
- [ ] Agent path (manual via curl):
      `curl -X POST -H "Authorization: Bearer cm_agent_..." -F file=@brief.pdf https://api-dev.commonly.me/api/agents/runtime/pods/<podId>/uploads`
      Confirm 200 with `{ url, fileName, kind: 'document', podId }`. Confirm the file then shows in the inspector's Artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)