### PR TITLE
feat(v2): auto-send file as a message on attach (no draft staging)

### DIFF
--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -455,19 +455,22 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
     }
   };
 
-  // Composer attach: handles both images (sends as standalone image message,
-  // legacy v2 behavior) and other file kinds (PDF / md / txt / csv / json,
-  // inserts an [[upload:fileName|originalName|size|kind]] directive into the
-  // draft so the user can add accompanying text and send when ready). Both
-  // paths POST to /api/uploads with the active podId so the file shows up in
-  // the inspector's Artifacts section.
+  // Composer attach: pick a file → upload → send a message containing just
+  // the [[upload:fileName|originalName|size|kind]] directive (or the raw
+  // image URL for image kinds, which the bubble renders inline). Drafts the
+  // user is composing are preserved untouched — they can keep typing and
+  // hit Send when ready, and the file lands as its own message.
+  //
+  // Drag-and-drop in chat clients (Slack, Discord, Linear) all match this
+  // shape: pick → goes-now. Inserting a directive token into the textarea
+  // showed raw `[[upload:…]]` text as the user typed and felt off.
   const handleAttachFile = async (file: File | null) => {
     if (!file || uploading) return;
     setUploading(true);
     setComposerError(null);
     try {
       const formData = new FormData();
-      formData.append('image', file); // legacy multer field name
+      formData.append('image', file); // legacy multer field name; route accepts non-images
       formData.append('podId', pod._id);
       const uploaded = await api.post<{
         url?: string;
@@ -484,7 +487,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
       }
       if (uploaded.fileName) {
         const directive = `[[upload:${uploaded.fileName}|${uploaded.originalName || file.name}|${uploaded.size || file.size}|${uploaded.kind || 'file'}]]`;
-        setDraft((prev) => (prev ? `${prev.replace(/\s+$/, '')} ${directive}` : directive));
+        await sendMessage(directive);
       }
     } catch (err) {
       const e = err as { response?: { data?: { msg?: string } } };


### PR DESCRIPTION
Second of three "artifact polish" PRs. Will not auto-merge.

## What this changes

Picking a file from the composer now **uploads + sends a message containing the upload directive in one shot** instead of inserting raw \`[[upload:fileName|…]]\` into the textarea.

**Why:** the previous flow showed raw directive tokens as the user typed, which felt off. Drag-and-drop in Slack, Discord, and Linear all match the new shape: pick → goes now. The user's existing draft text is preserved — they can keep typing and hit Send when ready, and the file lands as its own message.

Images keep the existing inline-image-message behavior (URL-as-content, \`messageType: 'image'\`).

## Diff

\`V2PodChat.tsx\` — \`handleAttachFile\` calls \`sendMessage(directive)\` instead of mutating \`draft\` with \`setDraft\`.

## Test plan

- [ ] Deploy dev: \`gh workflow run deploy-dev.yml --ref feat/v2-attach-auto-send\`
- [ ] Open a pod, type some text in the composer (\"hey, see this\") **but don't send**
- [ ] Attach a PDF — confirm a separate message appears with the file pill, and the typed text stays in the composer
- [ ] Attach a PNG — confirm legacy inline-image behavior (image message lands)
- [ ] Confirm no \`[[upload:…]]\` raw text ever appears in the textarea

🤖 Generated with [Claude Code](https://claude.com/claude-code)