### PR TITLE
feat(agent-collab): Phase 1 + early Phase 2 — agent-dm pod type, sharePod auth, codex preset

### DIFF
--- a/backend/__tests__/services/dmService.agentDm.test.ts
+++ b/backend/__tests__/services/dmService.agentDm.test.ts
@@ -1,0 +1,235 @@
+// @ts-nocheck
+/**
+ * DMService — agent-dm + sharePod tests (Phase 1 of agent collaboration plan).
+ *
+ * Verifies:
+ * - sharePod returns true/false on co-pod-member relationships across
+ *   bot/bot, bot/human, human/human pairs and self.
+ * - getOrCreateAgentDmRoom creates an agent-dm pod on first call,
+ *   returns the same pod on second call regardless of arg order.
+ * - Both bot members get an AgentInstallation row (heartbeat off) so
+ *   outbound posting works (the e78b5df241 invariant for the new
+ *   pod type).
+ * - AgentInstallation.upsert is idempotent: re-firing the autoJoin
+ *   path on an existing row produces no duplicates and never throws.
+ */
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+jest.mock('../../models/pg/Pod', () => null);
+
+const DMService = require('../../services/dmService');
+const Pod = require('../../models/Pod');
+const User = require('../../models/User');
+const { AgentInstallation } = require('../../models/AgentRegistry');
+
+describe('DMService — agent-dm + sharePod', () => {
+  let mongoServer;
+  let aria;
+  let codex;
+  let alice;
+  let bob;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create({
+      binary: { version: '7.0.11', skipMD5: true },
+      instance: { dbName: 'dm-service-agent-dm-test' },
+    });
+    await mongoose.connect(mongoServer.getUri());
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    if (mongoServer) {
+      try { await mongoServer.stop(); } catch (_) { /* ignore */ }
+    }
+  });
+
+  beforeEach(async () => {
+    await Promise.all([
+      Pod.deleteMany({}),
+      User.deleteMany({}),
+      AgentInstallation.deleteMany({}),
+    ]);
+    aria = await User.create({
+      username: 'aria-default',
+      email: 'aria@agent.local',
+      password: 'placeholder',
+      isBot: true,
+      botMetadata: { agentName: 'aria', instanceId: 'default' },
+    });
+    codex = await User.create({
+      username: 'codex-default',
+      email: 'codex@agent.local',
+      password: 'placeholder',
+      isBot: true,
+      botMetadata: { agentName: 'codex', instanceId: 'default' },
+    });
+    alice = await User.create({
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'placeholder',
+    });
+    bob = await User.create({
+      username: 'bob',
+      email: 'bob@example.com',
+      password: 'placeholder',
+    });
+  });
+
+  describe('sharePod', () => {
+    it('returns false when users have no shared pod', async () => {
+      const result = await DMService.sharePod(alice._id, bob._id);
+      expect(result).toBe(false);
+    });
+
+    it('returns true when users share at least one pod', async () => {
+      await Pod.create({
+        name: 'Backend Tasks',
+        type: 'team',
+        createdBy: alice._id,
+        members: [alice._id, bob._id],
+      });
+      const result = await DMService.sharePod(alice._id, bob._id);
+      expect(result).toBe(true);
+    });
+
+    it('returns true for bot↔bot in shared pod', async () => {
+      await Pod.create({
+        name: 'Demo',
+        type: 'team',
+        createdBy: alice._id,
+        members: [alice._id, aria._id, codex._id],
+      });
+      const result = await DMService.sharePod(aria._id, codex._id);
+      expect(result).toBe(true);
+    });
+
+    it('returns true for bot↔human in shared pod', async () => {
+      await Pod.create({
+        name: 'Demo',
+        type: 'team',
+        createdBy: alice._id,
+        members: [alice._id, aria._id],
+      });
+      const result = await DMService.sharePod(alice._id, aria._id);
+      expect(result).toBe(true);
+    });
+
+    it('returns false on self', async () => {
+      await Pod.create({
+        name: 'Demo',
+        type: 'team',
+        createdBy: alice._id,
+        members: [alice._id],
+      });
+      const result = await DMService.sharePod(alice._id, alice._id);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getOrCreateAgentDmRoom', () => {
+    const memberFor = (user) => ({
+      userId: user._id,
+      isBot: !!user.isBot,
+      agentName: user.botMetadata?.agentName,
+      instanceId: user.botMetadata?.instanceId,
+      displayName: user.botMetadata?.agentName || user.username,
+    });
+
+    it('creates a new agent-dm pod on first call', async () => {
+      const room = await DMService.getOrCreateAgentDmRoom(
+        memberFor(aria),
+        memberFor(codex),
+      );
+
+      expect(room).toBeDefined();
+      expect(room.type).toBe('agent-dm');
+      expect(room.joinPolicy).toBe('invite-only');
+      const memberIds = room.members.map((m) => m.toString());
+      expect(memberIds).toContain(aria._id.toString());
+      expect(memberIds).toContain(codex._id.toString());
+      expect(memberIds).toHaveLength(2);
+    });
+
+    it('idempotent on the unordered pair', async () => {
+      const room1 = await DMService.getOrCreateAgentDmRoom(memberFor(aria), memberFor(codex));
+      const room2 = await DMService.getOrCreateAgentDmRoom(memberFor(codex), memberFor(aria));
+      expect(room1._id.toString()).toBe(room2._id.toString());
+      const all = await Pod.find({ type: 'agent-dm' });
+      expect(all).toHaveLength(1);
+    });
+
+    it('creates AgentInstallation rows for both bot members', async () => {
+      const room = await DMService.getOrCreateAgentDmRoom(memberFor(aria), memberFor(codex));
+      const installs = await AgentInstallation.find({ podId: room._id });
+      const names = installs.map((i) => i.agentName).sort();
+      expect(names).toEqual(['aria', 'codex']);
+      installs.forEach((i) => {
+        // heartbeat MUST be off for agent-dm rooms (reactive only).
+        expect(i.config.get('heartbeat')).toEqual({ enabled: false });
+        expect(i.status).toBe('active');
+      });
+    });
+
+    it('refuses self-DM', async () => {
+      await expect(
+        DMService.getOrCreateAgentDmRoom(memberFor(aria), memberFor(aria)),
+      ).rejects.toThrow(/distinct/);
+    });
+
+    it('names the pod with the ↔ separator', async () => {
+      const room = await DMService.getOrCreateAgentDmRoom(memberFor(aria), memberFor(codex));
+      expect(room.name).toContain('↔');
+      expect(room.name.toLowerCase()).toContain('aria');
+      expect(room.name.toLowerCase()).toContain('codex');
+    });
+  });
+
+  describe('AgentInstallation.upsert idempotency', () => {
+    let pod;
+    beforeEach(async () => {
+      pod = await Pod.create({
+        name: 'Demo',
+        type: 'agent-dm',
+        createdBy: aria._id,
+        members: [aria._id, codex._id],
+      });
+    });
+
+    it('does not throw on a second upsert for the same triple', async () => {
+      const opts = {
+        version: '1.0.0',
+        config: { heartbeat: { enabled: false } },
+        scopes: ['messages:write'],
+        installedBy: aria._id,
+        instanceId: 'default',
+        displayName: 'codex',
+      };
+      const a = await AgentInstallation.upsert('codex', pod._id, opts);
+      const b = await AgentInstallation.upsert('codex', pod._id, opts);
+      expect(a._id.toString()).toBe(b._id.toString());
+      const all = await AgentInstallation.find({ agentName: 'codex', podId: pod._id });
+      expect(all).toHaveLength(1);
+    });
+
+    it('reactivates an uninstalled row instead of creating a new one', async () => {
+      const opts = {
+        version: '1.0.0',
+        config: { heartbeat: { enabled: false } },
+        scopes: ['messages:write'],
+        installedBy: aria._id,
+        instanceId: 'default',
+        displayName: 'codex',
+      };
+      const installed = await AgentInstallation.upsert('codex', pod._id, opts);
+      installed.status = 'uninstalled';
+      await installed.save();
+
+      const reupserted = await AgentInstallation.upsert('codex', pod._id, opts);
+      expect(reupserted._id.toString()).toBe(installed._id.toString());
+      expect(reupserted.status).toBe('active');
+    });
+  });
+});

--- a/backend/__tests__/services/dmService.agentDm.test.ts
+++ b/backend/__tests__/services/dmService.agentDm.test.ts
@@ -228,8 +228,15 @@ describe('DMService — agent-dm + sharePod', () => {
       await installed.save();
 
       const reupserted = await AgentInstallation.upsert('codex', pod._id, opts);
+      // Same row (unique-index filter matched, not a new row with a
+      // coincidentally matching ObjectId) AND identity unchanged.
       expect(reupserted._id.toString()).toBe(installed._id.toString());
+      expect(reupserted.agentName).toBe('codex');
+      expect(reupserted.podId.toString()).toBe(pod._id.toString());
+      expect(reupserted.instanceId).toBe('default');
       expect(reupserted.status).toBe('active');
+      const all = await AgentInstallation.find({ agentName: 'codex', podId: pod._id });
+      expect(all).toHaveLength(1);
     });
   });
 });

--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -328,4 +328,145 @@ describe('AgentMentionService', () => {
     expect(AgentEventService.enqueue).not.toHaveBeenCalled();
     expect(result).toEqual({ enqueued: false, reason: 'not_dm_pod' });
   });
+
+  // Agent-dm allow-list — without this, every message into the new pod
+  // type is silent-dropped on the way to the agent runtime. Same bug
+  // class as e78b5df241; documented in AGENT_RUNTIME.md Routing Invariants.
+  test('enqueueDmEvent enqueues for agent-dm pods (allow-list)', async () => {
+    Pod.findById.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({
+        _id: 'pod-dm-2',
+        type: 'agent-dm',
+        members: ['user-1', 'agent-user-1'],
+      }),
+    });
+    User.find.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([
+        {
+          _id: 'agent-user-1',
+          username: 'codex-default',
+          botMetadata: { agentName: 'codex', instanceId: 'default' },
+        },
+      ]),
+    });
+    AgentInstallation.find.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([{
+        _id: 'inst-2',
+        podId: 'pod-dm-2',
+        installedBy: 'user-1',
+        agentName: 'codex',
+        instanceId: 'default',
+        status: 'active',
+      }]),
+    });
+    Pod.find.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([{ _id: 'pod-dm-2' }]),
+    });
+    User.findById.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue({ _id: 'user-1', isBot: false }),
+    });
+
+    const result = await AgentMentionService.enqueueDmEvent({
+      podId: 'pod-dm-2',
+      message: { id: 99, content: 'cut a hot-fix' },
+      userId: 'user-1',
+      username: 'alice',
+    });
+
+    expect(AgentEventService.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentName: 'codex',
+        podId: 'pod-dm-2',
+        type: 'chat.mention',
+      }),
+    );
+    expect(result.enqueued).toEqual(['codex']);
+  });
+
+  // Bot senders are allowed in agent-dm rooms (the whole point — agent ↔
+  // agent collaboration). They're still blocked in agent-admin/agent-room.
+  test('enqueueDmEvent allows bot sender in agent-dm', async () => {
+    Pod.findById.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({
+        _id: 'pod-dm-3',
+        type: 'agent-dm',
+        members: ['aria-user', 'codex-user'],
+      }),
+    });
+    User.find.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([
+        {
+          _id: 'codex-user',
+          username: 'codex-default',
+          botMetadata: { agentName: 'codex', instanceId: 'default' },
+        },
+      ]),
+    });
+    AgentInstallation.find.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([{
+        _id: 'inst-3',
+        podId: 'pod-dm-3',
+        installedBy: 'aria-user',
+        agentName: 'codex',
+        instanceId: 'default',
+        status: 'active',
+      }]),
+    });
+    Pod.find.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([{ _id: 'pod-dm-3' }]),
+    });
+    User.findById.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue({
+        _id: 'aria-user',
+        isBot: true,
+        botMetadata: { agentName: 'aria', instanceId: 'default' },
+      }),
+    });
+
+    const result = await AgentMentionService.enqueueDmEvent({
+      podId: 'pod-dm-3',
+      message: { id: 100, content: 'can you review this PR?' },
+      userId: 'aria-user',
+      username: 'aria',
+    });
+
+    expect(AgentEventService.enqueue).toHaveBeenCalled();
+    expect(result.enqueued).toEqual(['codex']);
+  });
+
+  test('enqueueDmEvent still blocks bot sender in legacy agent-admin', async () => {
+    Pod.findById.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({
+        _id: 'pod-admin-1',
+        type: 'agent-admin',
+        members: ['aria-user', 'human-1'],
+      }),
+    });
+    User.findById.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue({
+        _id: 'aria-user',
+        isBot: true,
+        botMetadata: { agentName: 'aria', instanceId: 'default' },
+      }),
+    });
+
+    const result = await AgentMentionService.enqueueDmEvent({
+      podId: 'pod-admin-1',
+      message: { content: 'hi' },
+      userId: 'aria-user',
+      username: 'aria',
+    });
+
+    expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+    expect(result).toEqual({ enqueued: false, reason: 'sender_is_bot' });
+  });
 });

--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -215,10 +215,14 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
     }
 
     const username = req.user?.username;
-    // agent-admin (legacy 1:1 admin DM) and agent-room (1:1 user↔agent DM)
-    // both auto-route every human message to the agent — no @mention needed.
-    // Other pod types only fire on explicit @mentions.
-    if (pod.type === 'agent-admin' || pod.type === 'agent-room') {
+    // agent-admin (legacy 1:1 admin DM), agent-room (1:1 user↔agent DM), and
+    // agent-dm (any 2-member DM, including agent↔agent) all auto-route every
+    // human message to the agent — no @mention needed. Other pod types only
+    // fire on explicit @mentions. Adding a new private 1:1 pod type without
+    // updating this allow-list silently drops every message; see
+    // docs/agents/AGENT_RUNTIME.md "Routing Invariants" for the canonical
+    // version of this rule.
+    if (pod.type === 'agent-admin' || pod.type === 'agent-room' || pod.type === 'agent-dm') {
       await AgentMentionService.enqueueDmEvent({ podId, message, userId, username });
     } else {
       await AgentMentionService.enqueueMentions({ podId, message, userId, username });

--- a/backend/controllers/podController.ts
+++ b/backend/controllers/podController.ts
@@ -164,9 +164,9 @@ exports.getAllPods = async (req: any, res: any) => {
 
     // Personal pod types: only return pods the requester belongs to.
     // Global admins bypass the membership filter so they can audit every
-    // agent-room / agent-admin in the instance — the moderation surface
-    // for the 1:1 invariant on agent-rooms (ADR-001 §3.10).
-    if ((type === 'agent-admin' || type === 'agent-room') && req.userId) {
+    // agent-room / agent-admin / agent-dm in the instance — the moderation
+    // surface for the 1:1 invariant on agent-rooms (ADR-001 §3.10).
+    if ((type === 'agent-admin' || type === 'agent-room' || type === 'agent-dm') && req.userId) {
       const isAdmin = await isGlobalAdminRequest(req);
       if (!isAdmin) {
         const uid = String(req.userId);

--- a/backend/models/AgentRegistry.ts
+++ b/backend/models/AgentRegistry.ts
@@ -221,6 +221,7 @@ export interface IAgentInstallationRegistryModel extends Model<IAgentInstallatio
   getInstalledAgents(podId: Types.ObjectId): mongoose.Query<IAgentInstallationRegistry[], IAgentInstallationRegistry>;
   isInstalled(agentName: string, podId: Types.ObjectId, instanceId?: string): Promise<boolean>;
   install(agentName: string, podId: Types.ObjectId, options: { version: string; config?: Map<string, unknown>; scopes?: string[]; installedBy: Types.ObjectId; instanceId?: string; displayName?: string }): Promise<IAgentInstallationRegistry>;
+  upsert(agentName: string, podId: Types.ObjectId, options: { version: string; config?: Map<string, unknown>; scopes?: string[]; installedBy: Types.ObjectId; instanceId?: string; displayName?: string }): Promise<IAgentInstallationRegistry>;
   uninstall(agentName: string, podId: Types.ObjectId, instanceId?: string): Promise<mongoose.UpdateWriteOpResult>;
 }
 
@@ -285,6 +286,39 @@ AgentInstallationSchema.statics.install = async function (agentName: string, pod
     return existing.save();
   }
   return this.create({ agentName: agentName.toLowerCase(), podId, instanceId, displayName, version, config, scopes, installedBy });
+};
+
+/**
+ * Idempotent variant of `install`. Re-fires (e.g. mention-driven autoJoin
+ * on a row that already exists) MUST NOT throw or create duplicates. The
+ * existing `install` throws when an active row exists; that's the right
+ * behavior for an admin-driven first install but wrong for a runtime path
+ * that may fire many times. Use this whenever the call site doesn't want
+ * to care if it's the first attempt.
+ *
+ * Atomically created via findOneAndUpdate with upsert+setOnInsert so
+ * concurrent autoJoin attempts can't race a duplicate row past the
+ * unique index on (agentName, podId, instanceId).
+ */
+AgentInstallationSchema.statics.upsert = async function (agentName: string, podId: Types.ObjectId, options: {
+  version: string;
+  config?: Map<string, unknown>;
+  scopes?: string[];
+  installedBy: Types.ObjectId;
+  instanceId?: string;
+  displayName?: string;
+}) {
+  const { version, config, scopes, installedBy, instanceId = 'default', displayName } = options;
+  const filter = { agentName: agentName.toLowerCase(), podId, instanceId };
+  const update = {
+    $setOnInsert: { agentName: agentName.toLowerCase(), podId, instanceId, installedBy, version, displayName },
+    $set: {
+      ...(config ? { config } : {}),
+      ...(scopes ? { scopes } : {}),
+      status: 'active',
+    },
+  };
+  return this.findOneAndUpdate(filter, update, { new: true, upsert: true, setDefaultsOnInsert: true });
 };
 
 AgentInstallationSchema.statics.uninstall = async function (agentName: string, podId: Types.ObjectId, instanceId = 'default') {

--- a/backend/models/Pod.ts
+++ b/backend/models/Pod.ts
@@ -1,6 +1,22 @@
 import mongoose, { Document, Schema, Types } from 'mongoose';
 
-export type PodType = 'chat' | 'study' | 'games' | 'agent-ensemble' | 'agent-admin' | 'agent-room' | 'team';
+export type PodType =
+  | 'chat'
+  | 'study'
+  | 'games'
+  | 'agent-ensemble'
+  | 'agent-admin'
+  | 'agent-room'
+  | 'agent-dm'
+  | 'team';
+
+// Per-pod alias → agent binding (e.g. "codex" → sam-local-codex). Empty by
+// default; lookups fall through to the agent's own contact list per the
+// agent collaboration plan §3.2.
+export interface PodContactBinding {
+  agentName: string;
+  instanceId: string;
+}
 export type PodJoinPolicy = 'open' | 'invite-only';
 export type EnsembleParticipantRole = 'starter' | 'responder' | 'synthesizer' | 'observer';
 export type HumanParticipation = 'none' | 'read-only' | 'participate';
@@ -38,6 +54,10 @@ export interface IPod extends Document {
   messages: Types.ObjectId[];
   announcements: Types.ObjectId[];
   externalLinks: Types.ObjectId[];
+  // Optional alias → agent map for resolving cross-pod mentions like
+  // `@codex` to a specific installed agent. Stored as a Mongo Map so reads
+  // are O(1) and unset rows return an empty Map by default.
+  contacts?: Map<string, PodContactBinding>;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -48,7 +68,7 @@ const PodSchema = new Schema<IPod>(
     description: { type: String, trim: true },
     type: {
       type: String,
-      enum: ['chat', 'study', 'games', 'agent-ensemble', 'agent-admin', 'agent-room', 'team'],
+      enum: ['chat', 'study', 'games', 'agent-ensemble', 'agent-admin', 'agent-room', 'agent-dm', 'team'],
       default: 'chat',
     },
     joinPolicy: {
@@ -92,6 +112,17 @@ const PodSchema = new Schema<IPod>(
     messages: [{ type: Schema.Types.ObjectId, ref: 'Message' }],
     announcements: [{ type: Schema.Types.ObjectId, ref: 'Announcement' }],
     externalLinks: [{ type: Schema.Types.ObjectId, ref: 'ExternalLink' }],
+    // Per-pod alias → agent binding. Defaults to an empty Map so existing
+    // documents return `pod.contacts.get(alias) === undefined` cleanly
+    // without throwing on legacy rows that never set the field.
+    contacts: {
+      type: Map,
+      of: new Schema<PodContactBinding>({
+        agentName: { type: String, required: true },
+        instanceId: { type: String, required: true },
+      }, { _id: false }),
+      default: () => new Map(),
+    },
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now },
   },

--- a/backend/models/User.ts
+++ b/backend/models/User.ts
@@ -27,6 +27,23 @@ export interface IFollowedThread {
   followedAt: Date;
 }
 
+// User-level alias → agent (or human) binding. Both human and bot users
+// carry this list; for bots it's the agent's "contacts" — who they go to
+// for codex review, planning, etc. For humans it's the people they DM
+// most. Aliases must be lowercase URL-safe.
+export type ContactSource = 'user' | 'pod' | 'system';
+
+export interface IContactEntry {
+  alias: string;
+  agentName?: string;
+  instanceId?: string;
+  targetUserId?: Types.ObjectId;
+  role?: string;
+  source: ContactSource;
+  pinned?: boolean;
+  addedAt: Date;
+}
+
 export interface IUser extends Document {
   username: string;
   email: string;
@@ -70,6 +87,7 @@ export interface IUser extends Document {
     capabilities: AgentCapability[];
   };
   agentRuntimeTokens: IAgentRuntimeToken[];
+  contacts: IContactEntry[];
   subscribedPods: Types.ObjectId[];
   followers: Types.ObjectId[];
   following: Types.ObjectId[];
@@ -181,6 +199,23 @@ const userSchema = new Schema<IUser>({
       expiresAt: { type: Date },
     },
   ],
+  // Alias-driven contact list — see IContactEntry above. Default empty so
+  // existing user rows return `[]` on read (never throws on `.find(...)`).
+  contacts: {
+    type: [
+      new Schema<IContactEntry>({
+        alias: { type: String, required: true, lowercase: true, trim: true },
+        agentName: { type: String, default: null },
+        instanceId: { type: String, default: null },
+        targetUserId: { type: Schema.Types.ObjectId, ref: 'User', default: null },
+        role: { type: String, default: null },
+        source: { type: String, enum: ['user', 'pod', 'system'], default: 'user' },
+        pinned: { type: Boolean, default: false },
+        addedAt: { type: Date, default: Date.now },
+      }, { _id: false }),
+    ],
+    default: [],
+  },
   subscribedPods: [{ type: Schema.Types.ObjectId, ref: 'Pod' }],
   followers: [{ type: Schema.Types.ObjectId, ref: 'User' }],
   following: [{ type: Schema.Types.ObjectId, ref: 'User' }],

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -723,6 +723,153 @@ router.post('/room', dualAuth, phase4RateLimit, async (req: any, res: any) => {
 });
 
 /**
+ * POST /agent-dm
+ *
+ * Open or fetch a 2-member `agent-dm` pod between the caller (an agent
+ * runtime token) and a target agent. Generalization of `/room` for the
+ * bot ↔ bot case; the §3.7 co-pod-member rule gates creation so we
+ * don't grant arbitrary fan-out reach.
+ *
+ * Request: { target: { agentName, instanceId? } | { userId } | { alias }, originPodId? }
+ * Response: { room, autoJoined: bool }
+ */
+router.post('/agent-dm', agentRuntimeAuth, async (req: any, res: any) => {
+  try {
+    // Caller is the agent owning the runtime token.
+    let callerAgentUser = req.agentUser;
+    if (!callerAgentUser && req.agentInstallation) {
+      callerAgentUser = await AgentIdentityService.getOrCreateAgentUser(
+        req.agentInstallation.agentName,
+        { instanceId: req.agentInstallation.instanceId || 'default' },
+      );
+    }
+    if (!callerAgentUser) {
+      return res.status(401).json({ message: 'Agent runtime token required' });
+    }
+
+    const { target, originPodId } = req.body || {};
+    if (!target || typeof target !== 'object') {
+      return res.status(400).json({ message: 'target is required' });
+    }
+
+    // Resolve the target User row. Accept three shapes:
+    //   { agentName, instanceId? } → look up the bot User row directly.
+    //   { userId }                 → human or already-resolved bot.
+    //   { alias }                  → resolve via caller's contact list.
+    let targetUser: { _id: unknown; isBot?: boolean; username?: string; botMetadata?: { agentName?: string; instanceId?: string } } | null = null;
+    let targetMeta: { agentName?: string; instanceId?: string; displayName?: string; isBot: boolean } = { isBot: false };
+
+    if (target.agentName) {
+      const agentName = String(target.agentName).trim().toLowerCase();
+      const instanceId = String(target.instanceId || 'default').trim();
+      if (!agentName) return res.status(400).json({ message: 'target.agentName is empty' });
+      targetUser = await AgentIdentityService.getOrCreateAgentUser(agentName, { instanceId });
+      targetMeta = { agentName, instanceId, displayName: agentName, isBot: true };
+    } else if (target.userId) {
+      const lookup = await User.findById(String(target.userId)).select('_id isBot username botMetadata').lean();
+      if (!lookup) return res.status(404).json({ message: 'target user not found' });
+      targetUser = lookup as { _id: unknown; isBot?: boolean; username?: string; botMetadata?: { agentName?: string; instanceId?: string } };
+      targetMeta = {
+        isBot: !!lookup.isBot,
+        agentName: lookup.botMetadata?.agentName || undefined,
+        instanceId: lookup.botMetadata?.instanceId || 'default',
+        displayName: lookup.botMetadata?.agentName || lookup.username,
+      };
+    } else if (target.alias) {
+      // §3.2: resolve via caller's own contacts. Pod-level binding takes
+      // priority but only when an originPodId is given.
+      const alias = String(target.alias).trim().toLowerCase();
+      let bound: { agentName: string; instanceId: string } | null = null;
+      if (originPodId) {
+        const originPod = await Pod.findById(originPodId).select('contacts members').lean();
+        const fromPod = originPod?.contacts?.[alias];
+        if (fromPod && fromPod.agentName) bound = { agentName: fromPod.agentName, instanceId: fromPod.instanceId || 'default' };
+      }
+      if (!bound) {
+        const callerContacts = (callerAgentUser as { contacts?: Array<{ alias: string; agentName?: string; instanceId?: string }> }).contacts || [];
+        const match = callerContacts.find((c) => (c.alias || '').toLowerCase() === alias && c.agentName);
+        if (match?.agentName) bound = { agentName: match.agentName, instanceId: match.instanceId || 'default' };
+      }
+      if (!bound) {
+        return res.status(404).json({ message: `No contact bound to alias "${alias}"`, alias });
+      }
+      targetUser = await AgentIdentityService.getOrCreateAgentUser(bound.agentName, { instanceId: bound.instanceId });
+      targetMeta = { agentName: bound.agentName, instanceId: bound.instanceId, displayName: bound.agentName, isBot: true };
+    } else {
+      return res.status(400).json({ message: 'target must specify agentName, userId, or alias' });
+    }
+
+    if (!targetUser?._id) {
+      return res.status(404).json({ message: 'target user could not be resolved' });
+    }
+    if (String(targetUser._id) === String(callerAgentUser._id)) {
+      return res.status(400).json({ message: 'Cannot DM yourself' });
+    }
+
+    // §3.7 co-pod-member rule. Bypass when an admin has pinned the
+    // target via originPodId's pod.contacts (admin-binding carve-out).
+    let authorizedByPodBinding = false;
+    if (originPodId && target.alias) {
+      const originPod = await Pod.findById(originPodId).select('contacts').lean();
+      authorizedByPodBinding = !!originPod?.contacts?.[String(target.alias).toLowerCase()];
+    }
+    if (!authorizedByPodBinding) {
+      const shared = await DMService.sharePod(callerAgentUser._id, targetUser._id);
+      if (!shared) {
+        return res.status(403).json({
+          message: 'No shared pod with target — refused per co-pod-member rule',
+          rule: 'sharePod',
+        });
+      }
+    }
+
+    // Build member metadata for both sides so AgentInstallation upserts
+    // know which ones need bot-side scaffolding.
+    const callerMeta = {
+      userId: callerAgentUser._id,
+      agentName: callerAgentUser.botMetadata?.agentName || (req.agentInstallation?.agentName as string),
+      instanceId: callerAgentUser.botMetadata?.instanceId || (req.agentInstallation?.instanceId as string) || 'default',
+      isBot: true,
+      displayName: callerAgentUser.botMetadata?.agentName || callerAgentUser.username,
+    };
+    const peerMeta = {
+      userId: targetUser._id,
+      agentName: targetMeta.agentName,
+      instanceId: targetMeta.instanceId || 'default',
+      isBot: targetMeta.isBot,
+      displayName: targetMeta.displayName,
+    };
+
+    const room = await DMService.getOrCreateAgentDmRoom(callerMeta, peerMeta, {
+      creatorUserId: callerAgentUser._id,
+    });
+
+    // §3.8 — drop a "DM started" system event in the originating pod
+    // so humans see the link without the conversation polluting the
+    // pod chat. Posted via commonly-bot (auto-installed in every pod
+    // already), so we don't need extra membership scaffolding. Best-
+    // effort: failure to write the event must not fail the DM creation.
+    if (originPodId) {
+      try {
+        await AgentMessageService.postMessage({
+          agentName: 'commonly-bot',
+          podId: String(originPodId),
+          content: `🤝 ${callerMeta.displayName} and ${peerMeta.displayName} started a DM — [view](/v2/pods/${room._id})`,
+          metadata: { systemEventType: 'agent-dm-created', dmPodId: String(room._id) },
+        });
+      } catch (sysErr) {
+        console.warn('[agent-dm] system-message post failed:', (sysErr as Error).message);
+      }
+    }
+
+    return res.json({ room, autoJoined: false });
+  } catch (error: any) {
+    console.error('Error creating/fetching agent-dm:', error);
+    return res.status(500).json({ message: 'Failed to create/fetch agent-dm' });
+  }
+});
+
+/**
  * POST /bot/events/:id/ack (user API token auth)
  * For bot users to acknowledge events
  */

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -733,7 +733,7 @@ router.post('/room', dualAuth, phase4RateLimit, async (req: any, res: any) => {
  * Request: { target: { agentName, instanceId? } | { userId } | { alias }, originPodId? }
  * Response: { room, autoJoined: bool }
  */
-router.post('/agent-dm', agentRuntimeAuth, async (req: any, res: any) => {
+router.post('/agent-dm', agentRuntimeAuth, phase4RateLimit, async (req: any, res: any) => {
   try {
     // Caller is the agent owning the runtime token.
     let callerAgentUser = req.agentUser;
@@ -800,8 +800,12 @@ router.post('/agent-dm', agentRuntimeAuth, async (req: any, res: any) => {
       // priority but only when an originPodId is given.
       const alias = String(target.alias).trim().toLowerCase();
       let bound: { agentName: string; instanceId: string } | null = null;
-      if (originPodId) {
-        const originPod = await Pod.findById(originPodId).select('contacts members').lean();
+      // Coerce to string before findById so a malicious request body of
+      // `{ originPodId: { $gt: '' } }` can't slip through Mongoose's
+      // implicit object-as-query interpretation. CodeQL flagged this.
+      const originPodIdStr = originPodId ? String(originPodId) : '';
+      if (originPodIdStr) {
+        const originPod = await Pod.findById(originPodIdStr).select('contacts members').lean();
         const fromPod = originPod?.contacts?.[alias];
         if (fromPod && fromPod.agentName) bound = { agentName: fromPod.agentName, instanceId: fromPod.instanceId || 'default' };
       }
@@ -829,8 +833,9 @@ router.post('/agent-dm', agentRuntimeAuth, async (req: any, res: any) => {
     // §3.7 co-pod-member rule. Bypass when an admin has pinned the
     // target via originPodId's pod.contacts (admin-binding carve-out).
     let authorizedByPodBinding = false;
-    if (originPodId && target.alias) {
-      const originPod = await Pod.findById(originPodId).select('contacts').lean();
+    const originPodIdSafe = originPodId ? String(originPodId) : '';
+    if (originPodIdSafe && target.alias) {
+      const originPod = await Pod.findById(originPodIdSafe).select('contacts').lean();
       authorizedByPodBinding = !!originPod?.contacts?.[String(target.alias).toLowerCase()];
     }
     if (!authorizedByPodBinding) {
@@ -869,11 +874,11 @@ router.post('/agent-dm', agentRuntimeAuth, async (req: any, res: any) => {
     // pod chat. Posted via commonly-bot (auto-installed in every pod
     // already), so we don't need extra membership scaffolding. Best-
     // effort: failure to write the event must not fail the DM creation.
-    if (originPodId) {
+    if (originPodIdSafe) {
       try {
         await AgentMessageService.postMessage({
           agentName: 'commonly-bot',
-          podId: String(originPodId),
+          podId: originPodIdSafe,
           content: `🤝 ${callerMeta.displayName} and ${peerMeta.displayName} started a DM — [view](/v2/pods/${room._id})`,
           metadata: { systemEventType: 'agent-dm-created', dmPodId: String(room._id) },
         });

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -763,6 +763,26 @@ router.post('/agent-dm', agentRuntimeAuth, async (req: any, res: any) => {
       const agentName = String(target.agentName).trim().toLowerCase();
       const instanceId = String(target.instanceId || 'default').trim();
       if (!agentName) return res.status(400).json({ message: 'target.agentName is empty' });
+      // Probe before upsert. Without this, a typo materializes a permanent
+      // ghost bot User row via getOrCreateAgentUser. Existence-check first
+      // and 404 on miss; the legacy /room endpoint had the same pattern
+      // and we explicitly choose stricter behavior on the new endpoint.
+      const expectedUsername = AgentIdentityService.buildAgentUsername(agentName, instanceId);
+      const existing = await User.findOne({
+        $or: [
+          { 'botMetadata.agentName': agentName, 'botMetadata.instanceId': instanceId },
+          { username: expectedUsername },
+        ],
+      }).select('_id isBot username botMetadata').lean();
+      if (!existing) {
+        return res.status(404).json({
+          message: `No agent found for ${agentName} (instance "${instanceId}"). Install the agent first.`,
+          agentName,
+          instanceId,
+        });
+      }
+      // Resolve via the identity service so the User row is in canonical
+      // shape (handles legacy bot rows that pre-date botMetadata).
       targetUser = await AgentIdentityService.getOrCreateAgentUser(agentName, { instanceId });
       targetMeta = { agentName, instanceId, displayName: agentName, isBot: true };
     } else if (target.userId) {

--- a/backend/routes/pods.ts
+++ b/backend/routes/pods.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs';
+import rateLimit from 'express-rate-limit';
 // eslint-disable-next-line global-require
 const express = require('express');
 // eslint-disable-next-line global-require
@@ -285,6 +286,16 @@ router.post('/:id/join', auth, joinPod);
 router.post('/:id/leave', auth, leavePod);
 router.delete('/:id/members/:memberId', auth, removeMember);
 
+// Pod admin actions hit Mongo on every call but don't need much volume.
+// Capping per-IP keeps a stuck client from re-pinging contacts at full
+// loop speed without adding code complexity.
+const podAdminRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 60,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+});
+
 /**
  * PATCH /api/pods/:id/contacts
  *
@@ -302,7 +313,7 @@ router.delete('/:id/members/:memberId', auth, removeMember);
  * contact list — a member-scoped pin trivially defeats the
  * co-pod-member rule. Reviewer 2baa52d266 flagged this; fix here.
  */
-router.patch('/:id/contacts', auth, async (req: AuthReq, res: Res) => {
+router.patch('/:id/contacts', podAdminRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const { id: podId } = req.params || {};
     const userId = req.user?.id;

--- a/backend/routes/pods.ts
+++ b/backend/routes/pods.ts
@@ -284,6 +284,62 @@ router.post('/:id/join', auth, joinPod);
 router.post('/:id/leave', auth, leavePod);
 router.delete('/:id/members/:memberId', auth, removeMember);
 
+/**
+ * PATCH /api/pods/:id/contacts
+ *
+ * Pin (or clear) per-pod alias bindings — see ADR / agent-collaboration
+ * plan §3.3. Body shape:
+ *   { contacts: { codex: { agentName, instanceId } | null, ... } }
+ *
+ * Setting an alias to `null` removes the binding. Pod members can edit;
+ * non-members 403. Bindings live on `pod.contacts` (Map default empty,
+ * so existing pods read cleanly).
+ */
+router.patch('/:id/contacts', auth, async (req: AuthReq, res: Res) => {
+  try {
+    const { id: podId } = req.params || {};
+    const userId = req.user?.id;
+    if (!podId) return res.status(400).json({ message: 'pod id is required' });
+    const pod = await Pod.findById(podId) as {
+      members?: Array<{ toString: () => string }>;
+      contacts?: Map<string, unknown>;
+      save: () => Promise<unknown>;
+    } | null;
+    if (!pod) return res.status(404).json({ message: 'Pod not found' });
+    const isMember = pod.members?.some((m) => m.toString() === userId);
+    if (!isMember) return res.status(403).json({ message: 'Not authorized to edit pod contacts' });
+
+    const incoming = (req.body && typeof req.body.contacts === 'object' && req.body.contacts) || {};
+    if (!pod.contacts) pod.contacts = new Map();
+
+    for (const [rawAlias, binding] of Object.entries(incoming)) {
+      const alias = String(rawAlias || '').trim().toLowerCase();
+      if (!alias) continue;
+      if (binding === null) {
+        pod.contacts.delete(alias);
+        continue;
+      }
+      const b = binding as { agentName?: unknown; instanceId?: unknown };
+      const agentName = String(b.agentName || '').trim().toLowerCase();
+      const instanceId = String(b.instanceId || 'default').trim();
+      if (!agentName) {
+        return res.status(400).json({ message: `contacts.${alias}.agentName is required` });
+      }
+      pod.contacts.set(alias, { agentName, instanceId });
+    }
+
+    await pod.save();
+    const flattened: Record<string, { agentName: string; instanceId: string }> = {};
+    pod.contacts.forEach((value, key) => {
+      flattened[key] = value as { agentName: string; instanceId: string };
+    });
+    return res.status(200).json({ contacts: flattened });
+  } catch (error) {
+    console.error('Error updating pod contacts:', error);
+    return res.status(500).json({ message: 'Server error' });
+  }
+});
+
 router.get('/:podId/announcements', auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId } = req.params || {};

--- a/backend/routes/pods.ts
+++ b/backend/routes/pods.ts
@@ -10,6 +10,7 @@ const auth = require('../middleware/auth');
 const { getAllPods, getPodsByType, getPodById, createPod, joinPod, leavePod, removeMember, deletePod } = require('../controllers/podController');
 // eslint-disable-next-line global-require
 const Pod = require('../models/Pod');
+const User = require('../models/User');
 // eslint-disable-next-line global-require
 const Announcement = require('../models/Announcement');
 // eslint-disable-next-line global-require
@@ -291,9 +292,15 @@ router.delete('/:id/members/:memberId', auth, removeMember);
  * plan §3.3. Body shape:
  *   { contacts: { codex: { agentName, instanceId } | null, ... } }
  *
- * Setting an alias to `null` removes the binding. Pod members can edit;
- * non-members 403. Bindings live on `pod.contacts` (Map default empty,
- * so existing pods read cleanly).
+ * Setting an alias to `null` removes the binding. Bindings live on
+ * `pod.contacts` (Map default empty, so existing pods read cleanly).
+ *
+ * Auth: pod creator OR global admin only. The contacts map is the
+ * "admin-binding carve-out" that lets `@codex` resolve outside
+ * `sharePod` for mention-driven autoJoin (§3.4). Member-only writes
+ * would let any pod member autoJoin an arbitrary agent in their own
+ * contact list — a member-scoped pin trivially defeats the
+ * co-pod-member rule. Reviewer 2baa52d266 flagged this; fix here.
  */
 router.patch('/:id/contacts', auth, async (req: AuthReq, res: Res) => {
   try {
@@ -303,11 +310,21 @@ router.patch('/:id/contacts', auth, async (req: AuthReq, res: Res) => {
     const pod = await Pod.findById(podId) as {
       members?: Array<{ toString: () => string }>;
       contacts?: Map<string, unknown>;
+      createdBy?: { toString: () => string };
       save: () => Promise<unknown>;
     } | null;
     if (!pod) return res.status(404).json({ message: 'Pod not found' });
-    const isMember = pod.members?.some((m) => m.toString() === userId);
-    if (!isMember) return res.status(403).json({ message: 'Not authorized to edit pod contacts' });
+    const isCreator = pod.createdBy && userId && pod.createdBy.toString() === String(userId);
+    let isGlobalAdmin = false;
+    if (!isCreator && userId) {
+      const userRow = await User.findById(userId).select('role').lean() as { role?: string } | null;
+      isGlobalAdmin = userRow?.role === 'admin';
+    }
+    if (!isCreator && !isGlobalAdmin) {
+      return res.status(403).json({
+        message: 'Only the pod creator or a global admin may edit pod contacts',
+      });
+    }
 
     const incoming = (req.body && typeof req.body.contacts === 'object' && req.body.contacts) || {};
     if (!pod.contacts) pod.contacts = new Map();

--- a/backend/routes/registry/presets.ts
+++ b/backend/routes/registry/presets.ts
@@ -105,6 +105,79 @@ You are **Research Analyst** — a deep-research specialist who turns raw inform
     ],
   },
   {
+    // First-party "codex" agent — what other agents on the platform call when
+    // they want code work done. Provisioned on the clawdbot gateway like any
+    // other openclaw-runtime agent; LiteLLM-backed via the codex-auth-rotator
+    // sidecar so all 3 ChatGPT accounts cycle naturally. Replaces the
+    // sam-local-codex stop-gap that broke when account-2/3 tokens were
+    // refreshed for the rotator. Pod admins can pin this agent to
+    // `pod.contacts.codex` so any agent in that pod that mentions `@codex`
+    // resolves here.
+    id: 'codex',
+    title: 'Codex',
+    category: 'Development',
+    agentName: 'openclaw',
+    description: 'Code-quality-focused collaborator. Reviews diffs, suggests refactors, drafts implementations on request. Reacts to @mentions; no heartbeat.',
+    targetUsage: 'Other agents (Pixel/Theo/Ops) DMing for code work; humans wanting a code-quality second opinion.',
+    recommendedModel: 'openai-codex/gpt-5.4-mini',
+    requiredTools: [
+      { id: 'pod-context', label: 'Commonly pod context + memory', type: 'core' },
+    ],
+    apiRequirements: [
+      {
+        key: 'OPENAI_CODEX_ACCESS_TOKEN',
+        purpose: 'Codex access via LiteLLM rotator',
+        envAny: ['OPENAI_CODEX_ACCESS_TOKEN', 'OPENAI_CODEX_REFRESH_TOKEN'],
+      },
+    ],
+    installHints: {
+      scopes: ['agent:context:read', 'agent:messages:read', 'agent:messages:write'],
+      runtime: 'openclaw',
+    },
+    soulTemplate: `# SOUL.md
+
+You are **Codex** — a code-quality-focused collaborator on the platform.
+
+You exist so other agents can ask for code work without burning their
+own tokens or context. When mentioned (\`@codex\`) or DMed by another
+agent, you read the request, do the work, and reply with a tight,
+self-contained answer.
+
+## Identity
+- You are a peer to the other agents — not a tool, not a subordinate.
+- You are precise. You quote exact filenames, line numbers, error
+  messages. You don't paraphrase the codebase; you reference it.
+- You are honest about uncertainty. If you don't know, you say "I'd
+  need to read X to be sure" and stop. You don't invent.
+- You're a reviewer, not a typist. Smaller surface area > larger.
+
+## How you work
+- You're reactive. You don't poll. You wait for @mentions or DM
+  messages and respond inline in the same conversation.
+- For implementation tasks, you produce: a self-contained diff or
+  patch, a one-paragraph "why," and any caveats. You never narrate
+  the work in flight.
+- For review tasks, you produce: verdict (ship / revise / rework),
+  a numbered list of concrete issues with file/line refs, and one
+  sentence on the overall design quality.
+
+## Critical rules
+1. Quote, don't paraphrase. Always file:line.
+2. Smaller patches > bigger.
+3. Tests changed = required mention. Don't sneak past CI.
+4. If asked to design, propose 2-3 options with tradeoffs before
+   implementing.
+5. If a request is ambiguous, ask one clarifying question; if it's
+   blocked on missing context, say what context you'd need and stop.
+
+## Boundaries
+- You don't pretend to be a human, a CLI, or a runtime. You are
+  Codex, the agent.
+- You don't run tasks proactively. You respond when called.
+- You don't claim PRs as authorship. The agent who delegated to you
+  ships under their own name; you just do the work.`,
+  },
+  {
     id: 'integration-operator',
     title: 'Integration Operator',
     category: 'Operations',

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -209,6 +209,115 @@ const enqueueSummarizerEvent = async ({
   });
 };
 
+// Feature gate for the §3.4 mention-driven autoJoin path. When OFF, this
+// service behaves exactly as it did before: unresolved mentions are
+// pushed to `skipped`. When ON, an unresolved alias falls through to
+// pod.contacts → sender.contacts and may install an agent into the pod.
+// Default OFF so the new pod type can ship without flipping autoJoin
+// behavior in the same release if rollout demands a smaller blast
+// radius.
+const isMentionAutoJoinEnabled = (): boolean => (
+  String(process.env.ENABLE_MENTION_AUTOJOIN || '').toLowerCase() === 'true'
+);
+
+// Try the alias against pod-level binding first, then sender's contact
+// list. Returns the resolved (agentName, instanceId) or null. The
+// pod-binding takes priority per the §3.2 resolution order.
+const resolveContactAlias = async (
+  alias: string,
+  podId: string,
+  senderUserId: string,
+): Promise<{ agentName: string; instanceId: string } | null> => {
+  const lower = alias.toLowerCase();
+  try {
+    const pod = await Pod.findById(podId).select('contacts').lean() as { contacts?: Record<string, { agentName?: string; instanceId?: string }> } | null;
+    const fromPod = pod?.contacts?.[lower];
+    if (fromPod?.agentName) {
+      return { agentName: fromPod.agentName.toLowerCase(), instanceId: fromPod.instanceId || 'default' };
+    }
+  } catch (err) {
+    console.warn('[mention-autojoin] pod.contacts lookup failed:', (err as Error).message);
+  }
+  try {
+    const sender = await User.findById(senderUserId).select('contacts').lean() as { contacts?: Array<{ alias?: string; agentName?: string; instanceId?: string }> } | null;
+    const fromSender = (sender?.contacts || []).find((c) => (c.alias || '').toLowerCase() === lower && c.agentName);
+    if (fromSender?.agentName) {
+      return { agentName: fromSender.agentName.toLowerCase(), instanceId: fromSender.instanceId || 'default' };
+    }
+  } catch (err) {
+    console.warn('[mention-autojoin] sender contacts lookup failed:', (err as Error).message);
+  }
+  return null;
+};
+
+// Pull a non-member agent into the pod via mention-driven autoJoin.
+// Runs the §3.7 co-pod-member rule (with the §3.2 admin-binding carve-
+// out — i.e. if the resolution came from pod.contacts, that's the
+// authorization signal). Idempotent on (agentName, instanceId, podId).
+// Returns true on success, false on auth-refused.
+const autoJoinAgentToPod = async (
+  agentName: string,
+  instanceId: string,
+  podId: string,
+  senderUserId: string,
+  resolvedFromPodBinding: boolean,
+): Promise<boolean> => {
+  // eslint-disable-next-line global-require
+  const AgentIdentityService = require('./agentIdentityService');
+  // eslint-disable-next-line global-require
+  const DMService = require('./dmService');
+  // eslint-disable-next-line global-require
+  const AgentMessageService = require('./agentMessageService');
+
+  const targetUser = await AgentIdentityService.getOrCreateAgentUser(agentName, { instanceId });
+  if (!targetUser?._id) return false;
+
+  // Authorization: pod-binding is itself the admin signal; otherwise
+  // require sharePod between sender and target.
+  if (!resolvedFromPodBinding) {
+    const shared = await DMService.sharePod(senderUserId, targetUser._id);
+    if (!shared) {
+      console.warn(`[mention-autojoin] refused — no shared pod between sender=${senderUserId} target=${agentName}:${instanceId}`);
+      return false;
+    }
+  }
+
+  // Upsert the AgentInstallation (heartbeat off — agent-dm and pulled-
+  // in agents are reactive, not scheduled). Idempotent.
+  await AgentInstallation.upsert(agentName, podId, {
+    version: '1.0.0',
+    config: {
+      heartbeat: { enabled: false },
+      autoJoinSource: 'mention-resolution',
+    } as unknown as Map<string, unknown>,
+    scopes: ['context:read', 'summaries:read', 'messages:write'],
+    installedBy: senderUserId,
+    instanceId,
+    displayName: agentName,
+  });
+
+  // Add to pod.members if not already.
+  try {
+    await Pod.updateOne({ _id: podId }, { $addToSet: { members: targetUser._id } });
+  } catch (err) {
+    console.warn('[mention-autojoin] pod.members $addToSet failed:', (err as Error).message);
+  }
+
+  // Drop a system event so humans see what happened.
+  try {
+    await AgentMessageService.postMessage({
+      agentName: 'commonly-bot',
+      podId,
+      content: `↗︎ pulled in @${agentName} via @-mention resolution`,
+      metadata: { systemEventType: 'mention-autojoin', agentName, instanceId },
+    });
+  } catch (err) {
+    console.warn('[mention-autojoin] system event post failed:', (err as Error).message);
+  }
+
+  return true;
+};
+
 const enqueueMentions = async ({
   podId,
   message,
@@ -313,6 +422,57 @@ const enqueueMentions = async ({
         return;
       }
 
+      // §3.4 mention-driven autoJoin — resolve unresolved aliases via
+      // pod.contacts then sender.contacts, then upsert + add to pod and
+      // proceed to enqueue. Behind ENABLE_MENTION_AUTOJOIN so the new
+      // pod type can ship without flipping this in the same release.
+      if (isMentionAutoJoinEnabled()) {
+        try {
+          // Detect whether the resolution came from a pod binding so the
+          // autoJoin auth check can fall back to the admin-binding carve-out.
+          const podRow = await Pod.findById(podId).select('contacts').lean() as { contacts?: Record<string, { agentName?: string; instanceId?: string }> } | null;
+          const fromPodBinding = !!podRow?.contacts?.[normalized]?.agentName;
+          const resolved = await resolveContactAlias(normalized, podId, userId);
+          if (resolved) {
+            const joined = await autoJoinAgentToPod(
+              resolved.agentName,
+              resolved.instanceId,
+              podId,
+              userId,
+              fromPodBinding,
+            );
+            if (joined) {
+              await AgentEventService.enqueue({
+                agentName: resolved.agentName,
+                instanceId: resolved.instanceId,
+                podId,
+                type: eventType,
+                payload: {
+                  messageId: message?._id || message?.id
+                    ? String(message?._id || message?.id)
+                    : undefined,
+                  content,
+                  userId,
+                  username,
+                  mentions: rawMentions,
+                  source,
+                  messageType: message?.messageType || message?.message_type || 'text',
+                  createdAt: message?.createdAt || message?.created_at || new Date(),
+                  thread: message?.thread || null,
+                  autoJoined: true,
+                },
+              });
+              enqueued.push(`${resolved.agentName}:autoJoined`);
+              return;
+            }
+            skipped.push(`${normalized}:auth-refused`);
+            return;
+          }
+        } catch (err) {
+          console.warn('[mention-autojoin] resolution path failed:', (err as Error).message);
+        }
+      }
+
       const agentType = aliasMap.get(normalized);
       if (agentType) {
         const matches = byAgent.get(agentType) || [];
@@ -377,21 +537,33 @@ const enqueueMentions = async ({
   return { enqueued, skipped };
 };
 
+// Pod types that auto-route every message to non-sender members as a
+// chat.mention event. Adding a new private 1:1 type without listing it
+// here silently drops every message; mirrored in
+// `messageController.createMessage` and called out in
+// docs/agents/AGENT_RUNTIME.md "Routing Invariants".
+const DM_POD_TYPES = new Set(['agent-admin', 'agent-room', 'agent-dm']);
+
 /**
- * Auto-enqueue a DM-origin chat.mention event for every user message in an
- * agent-admin pod. Unlike regular mentions, no explicit @mention is required
- * because this is already a 1:1 human <-> agent channel.
+ * Auto-enqueue a DM-origin chat.mention event for every user message in a
+ * DM-shaped pod (agent-admin / agent-room / agent-dm). Unlike regular
+ * mentions, no explicit @mention is required — the pod itself is the
+ * routing primitive. For agent-dm with two bot members, the sender check
+ * below allows bot-to-bot DMs to enqueue against the non-sender.
  */
 const enqueueDmEvent = async ({
   podId, message, userId, username,
 }: EnqueueDmOptions): Promise<EnqueueDmResult> => {
   const pod = await Pod.findById(podId).lean() as Record<string, unknown> | null;
-  if (!pod || (pod.type !== 'agent-admin' && pod.type !== 'agent-room')) {
+  if (!pod || !DM_POD_TYPES.has(pod.type as string)) {
     return { enqueued: false, reason: 'not_dm_pod' };
   }
 
   const sender = await User.findById(userId).select('_id isBot').lean() as { _id: unknown; isBot?: boolean } | null;
-  if (sender?.isBot) {
+  // Bot senders are allowed in agent-dm (the whole point) but still blocked
+  // in agent-admin/agent-room — those are operator-driven 1:1 with one
+  // agent; a bot posting there shouldn't auto-route to itself.
+  if (sender?.isBot && pod.type !== 'agent-dm') {
     return { enqueued: false, reason: 'sender_is_bot' };
   }
 

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -221,28 +221,30 @@ const isMentionAutoJoinEnabled = (): boolean => (
 );
 
 // Try the alias against pod-level binding first, then sender's contact
-// list. Returns the resolved (agentName, instanceId) or null. The
-// pod-binding takes priority per the §3.2 resolution order.
+// list. Returns the resolved binding *and the source* so the autoJoin
+// gate can apply the §3.2 admin-binding carve-out without re-reading
+// `pod.contacts` (which would open a TOCTOU window if an admin removed
+// the binding mid-resolution). Caller passes the already-fetched
+// pod.contacts row so we don't re-query.
+type ResolvedAlias =
+  | { agentName: string; instanceId: string; source: 'pod' | 'sender' }
+  | null;
+
 const resolveContactAlias = async (
   alias: string,
-  podId: string,
+  podContacts: Record<string, { agentName?: string; instanceId?: string }> | null | undefined,
   senderUserId: string,
-): Promise<{ agentName: string; instanceId: string } | null> => {
+): Promise<ResolvedAlias> => {
   const lower = alias.toLowerCase();
-  try {
-    const pod = await Pod.findById(podId).select('contacts').lean() as { contacts?: Record<string, { agentName?: string; instanceId?: string }> } | null;
-    const fromPod = pod?.contacts?.[lower];
-    if (fromPod?.agentName) {
-      return { agentName: fromPod.agentName.toLowerCase(), instanceId: fromPod.instanceId || 'default' };
-    }
-  } catch (err) {
-    console.warn('[mention-autojoin] pod.contacts lookup failed:', (err as Error).message);
+  const fromPod = podContacts?.[lower];
+  if (fromPod?.agentName) {
+    return { agentName: fromPod.agentName.toLowerCase(), instanceId: fromPod.instanceId || 'default', source: 'pod' };
   }
   try {
     const sender = await User.findById(senderUserId).select('contacts').lean() as { contacts?: Array<{ alias?: string; agentName?: string; instanceId?: string }> } | null;
     const fromSender = (sender?.contacts || []).find((c) => (c.alias || '').toLowerCase() === lower && c.agentName);
     if (fromSender?.agentName) {
-      return { agentName: fromSender.agentName.toLowerCase(), instanceId: fromSender.instanceId || 'default' };
+      return { agentName: fromSender.agentName.toLowerCase(), instanceId: fromSender.instanceId || 'default', source: 'sender' };
     }
   } catch (err) {
     console.warn('[mention-autojoin] sender contacts lookup failed:', (err as Error).message);
@@ -428,18 +430,20 @@ const enqueueMentions = async ({
       // pod type can ship without flipping this in the same release.
       if (isMentionAutoJoinEnabled()) {
         try {
-          // Detect whether the resolution came from a pod binding so the
-          // autoJoin auth check can fall back to the admin-binding carve-out.
+          // Single fetch of pod.contacts; both the resolver and the
+          // admin-binding carve-out read from this snapshot so a binding
+          // can't be removed between resolution and authorization (the
+          // TOCTOU window the v1 implementation had).
           const podRow = await Pod.findById(podId).select('contacts').lean() as { contacts?: Record<string, { agentName?: string; instanceId?: string }> } | null;
-          const fromPodBinding = !!podRow?.contacts?.[normalized]?.agentName;
-          const resolved = await resolveContactAlias(normalized, podId, userId);
+          const podContacts = podRow?.contacts || null;
+          const resolved = await resolveContactAlias(normalized, podContacts, userId);
           if (resolved) {
             const joined = await autoJoinAgentToPod(
               resolved.agentName,
               resolved.instanceId,
               podId,
               userId,
-              fromPodBinding,
+              resolved.source === 'pod',
             );
             if (joined) {
               await AgentEventService.enqueue({

--- a/backend/services/dmService.ts
+++ b/backend/services/dmService.ts
@@ -452,9 +452,12 @@ class DMService {
           displayName: member.displayName || member.agentName,
         });
       } catch (installErr) {
+        // Pass values as separate console args (not interpolated into the
+        // format string) so user-controlled `member.agentName` can't be
+        // used as a format spec — CodeQL flagged the previous shape.
         console.error(
-          `[dm-service] AgentInstallation.upsert failed for agent-dm pod=${dmPod._id} agent=${member.agentName}:`,
-          (installErr as Error).message,
+          '[dm-service] AgentInstallation.upsert failed for agent-dm',
+          { podId: String(dmPod._id), agentName: member.agentName, error: (installErr as Error).message },
         );
       }
     }

--- a/backend/services/dmService.ts
+++ b/backend/services/dmService.ts
@@ -344,6 +344,128 @@ class DMService {
 
     return roomPod;
   }
+
+  /**
+   * Returns true iff users `a` and `b` share at least one pod. Single
+   * source of truth for the §3.7 "co-pod-member" rule used by both
+   * `getOrCreateAgentDmRoom` and the mention-driven autoJoin gate.
+   *
+   * Both args may be Mongoose ObjectIds or strings; works on any
+   * combination of human + bot users.
+   */
+  static async sharePod(a: unknown, b: unknown): Promise<boolean> {
+    const aId = String(a);
+    const bId = String(b);
+    if (!aId || !bId || aId === bId) return false;
+    const count = await Pod.countDocuments({
+      members: { $all: [aId, bId] },
+    });
+    return count > 0;
+  }
+
+  /**
+   * Find or create a 2-member `agent-dm` pod. Generalization of
+   * `getOrCreateAgentRoom` — both members can be agents (the bot ↔ bot
+   * case), agent ↔ human (parallel to legacy agent-room), or even
+   * human ↔ human in the future. Idempotent on the unordered pair
+   * (aId, bId).
+   *
+   * For each bot member, AgentInstallation is upserted with
+   * heartbeat:false so the agent can post outbound (the
+   * pod.members-vs-AgentInstallation invariant — see e78b5df241).
+   *
+   * Caller is responsible for the §3.7 co-pod-member auth check
+   * before calling this; we don't enforce it here so service-level
+   * tests + admin tooling can bypass cleanly.
+   */
+  static async getOrCreateAgentDmRoom(
+    memberA: { userId: unknown; agentName?: string; instanceId?: string; isBot: boolean; displayName?: string },
+    memberB: { userId: unknown; agentName?: string; instanceId?: string; isBot: boolean; displayName?: string },
+    options: { creatorUserId?: unknown } = {},
+  ): Promise<InstanceType<typeof Pod>> {
+    const aId = String(memberA.userId);
+    const bId = String(memberB.userId);
+    if (!aId || !bId || aId === bId) {
+      throw new Error('getOrCreateAgentDmRoom requires two distinct user ids');
+    }
+
+    // Idempotent on the unordered pair: $all matches regardless of order
+    // and the index path `members` already exists for any pod query.
+    const existing = await Pod.findOne({
+      type: 'agent-dm',
+      members: { $all: [aId, bId] },
+    });
+    if (existing) return existing;
+
+    const aLabel = memberA.displayName || memberA.agentName || 'a';
+    const bLabel = memberB.displayName || memberB.agentName || 'b';
+    const name = `${aLabel} ↔ ${bLabel}`;
+    const description = memberA.isBot && memberB.isBot
+      ? `Agent-to-agent DM — ${aLabel} and ${bLabel}`
+      : `Direct message — ${aLabel} and ${bLabel}`;
+
+    const creatorId = String(options.creatorUserId || aId);
+
+    const dmPod = new Pod({
+      name,
+      description,
+      type: 'agent-dm',
+      joinPolicy: 'invite-only',
+      createdBy: creatorId,
+      members: [aId, bId],
+    });
+    await dmPod.save();
+
+    // Sync to PG so chat queries don't 404 on the new room.
+    try {
+      if (process.env.PG_HOST && PGPod) {
+        await PGPod.create(
+          dmPod.name,
+          dmPod.description || '',
+          'agent-dm',
+          creatorId,
+          dmPod._id.toString(),
+        );
+        await PGPod.addMember(dmPod._id.toString(), aId);
+        await PGPod.addMember(dmPod._id.toString(), bId);
+      }
+    } catch (pgError) {
+      console.error('Failed to sync agent-dm pod to PostgreSQL:', (pgError as Error).message);
+    }
+
+    // Install both bot members so outbound posts succeed. Heartbeat off:
+    // agent-dm pods are reactive (fire on incoming messages), never
+    // scheduled. We use the new `upsert` static so re-fires (and the
+    // §3.4 mention-driven autoJoin path) don't throw on existing rows.
+    for (const member of [memberA, memberB]) {
+      if (!member.isBot || !member.agentName) continue;
+      try {
+        await AgentInstallation.upsert(member.agentName.toLowerCase(), dmPod._id, {
+          version: '1.0.0',
+          config: {
+            heartbeat: { enabled: false },
+            autoJoinSource: 'agent-dm-create',
+          } as unknown as Map<string, unknown>,
+          scopes: ['context:read', 'summaries:read', 'messages:write'],
+          installedBy: creatorId as unknown as import('mongoose').Types.ObjectId,
+          instanceId: member.instanceId || 'default',
+          displayName: member.displayName || member.agentName,
+        });
+      } catch (installErr) {
+        console.error(
+          `[dm-service] AgentInstallation.upsert failed for agent-dm pod=${dmPod._id} agent=${member.agentName}:`,
+          (installErr as Error).message,
+        );
+      }
+    }
+
+    console.log(
+      `[dm-service] Created agent-dm pod=${dmPod._id}`
+      + ` a=${aLabel} b=${bLabel}`,
+    );
+
+    return dmPod;
+  }
 }
 
 export default DMService;

--- a/docs/agents/AGENT_RUNTIME.md
+++ b/docs/agents/AGENT_RUNTIME.md
@@ -33,22 +33,35 @@ and easy to break — keep them in mind whenever touching `messageController`,
 
 ### DMs auto-route without `@mention`
 
-For pods where `pod.type === 'agent-admin'` (legacy admin DM) **or**
-`pod.type === 'agent-room'` (new 1:1 user↔agent DM), every human message
-fires a `chat.mention` event for the resident agent — no textual
-`@<handle>` required. `messageController.createMessage` calls
-`agentMentionService.enqueueDmEvent`. Other pod types still require an
-explicit `@mention` and go through `enqueueMentions`.
+For pods where `pod.type` is one of:
+- `agent-admin` (legacy multi-admin debug DM)
+- `agent-room` (1:1 user↔agent DM)
+- `agent-dm` (any 2-member DM, including bot↔bot)
+
+every message fires a `chat.mention` event for the non-sender member —
+no textual `@<handle>` required. `messageController.createMessage`
+calls `agentMentionService.enqueueDmEvent`. Other pod types still
+require an explicit `@mention` and go through `enqueueMentions`.
 
 Both paths emit the same `chat.mention` event type into the same queue,
 so the gateway sees one uniform shape regardless of origin.
+
+**Bot senders** are blocked in `agent-admin` and `agent-room` (those
+are operator-driven 1:1 with one agent — a bot posting there shouldn't
+auto-route to itself). They're allowed in `agent-dm` because that's
+the whole point: bot↔bot collaboration.
 
 If you add a new "private 1:1" pod type, allow-list it in **both**
 sites:
 - `backend/controllers/messageController.ts` — branch that picks
   `enqueueDmEvent` vs `enqueueMentions`
-- `backend/services/agentMentionService.ts` — the `pod.type` guard
-  inside `enqueueDmEvent`
+- `backend/services/agentMentionService.ts` — the `DM_POD_TYPES`
+  set inside `enqueueDmEvent`
+
+Skipping either makes every message in the new room silently drop on
+the way to the agent runtime. Same bug class as `e78b5df241` — covered
+by tests in `__tests__/unit/services/agentMentionService.test.js`
+(`enqueueDmEvent enqueues for agent-dm pods (allow-list)`).
 
 ### Clawdbot inbound `From` is always `commonly:<podId>`
 
@@ -131,8 +144,20 @@ The known creation paths and their status:
 |------|----------------|-----------------|
 | `getOrCreateAdminDMPod` (legacy `agent-admin`) | yes | yes — admin DM provisioning calls `install` |
 | `getOrCreateAgentRoom` (1:1 `agent-room`) | yes | yes (since `e78b5df241`) |
+| `getOrCreateAgentDmRoom` (any 2-member `agent-dm`) | yes | yes — uses `AgentInstallation.upsert` for both bot members |
 | `agentAutoJoinService.autoJoin` (heartbeat-driven) | yes | yes |
+| Mention-driven autoJoin (`agentMentionService`, behind `ENABLE_MENTION_AUTOJOIN`) | yes | yes — `AgentInstallation.upsert` |
 | `Pod.create` for team pods + agent member added later | yes | **no — must call `install` explicitly** |
+
+**`AgentInstallation.install` vs `upsert`.** The legacy `install` static
+throws when an active row already exists for the `(agentName, podId, instanceId)`
+triple — that's the right behavior for an admin-driven first install
+that should fail if the operator clicks "install" twice. Runtime paths
+that may fire many times (mention-driven autoJoin, agent-dm creation)
+use the new `upsert` static instead — atomic `findOneAndUpdate(upsert+
+setOnInsert)` so re-fires converge on the same row, and the unique
+index race-protects concurrent calls. `upsert` also reactivates an
+`uninstalled` row instead of creating a new one.
 
 Recipe — fresh agent-room install (heartbeat off because rooms are
 reactive, not scheduled):

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -16,12 +16,24 @@ const FILTERS: Array<{ key: Filter; label: string }> = [
   { key: 'private', label: 'Private' },
 ];
 
-const isDmPod = (pod: V2Pod): boolean => pod.type === 'agent-room';
+// Both agent-room (user↔agent) and agent-dm (any 2-member combo) show
+// up under the Private filter. agent-dm with two bot members gets a
+// distinct icon ("AA" — agent ↔ agent) so users can tell at a glance
+// that no human is in the conversation.
+const isDmPod = (pod: V2Pod): boolean => pod.type === 'agent-room' || pod.type === 'agent-dm';
 const podKind = (pod: V2Pod): 'team' | 'private' => (isDmPod(pod) ? 'private' : 'team');
 
-const podMarkFor = (pod: V2Pod): string => (
-  podKind(pod) === 'private' ? 'DM' : initialsFor(pod.name).slice(0, 2)
-);
+const isAgentToAgent = (pod: V2Pod): boolean => {
+  if (pod.type !== 'agent-dm') return false;
+  const members = pod.members || [];
+  if (members.length < 2) return false;
+  return members.every((m) => typeof m === 'object' && !!m?.isBot);
+};
+
+const podMarkFor = (pod: V2Pod): string => {
+  if (isAgentToAgent(pod)) return 'AA';
+  return podKind(pod) === 'private' ? 'DM' : initialsFor(pod.name).slice(0, 2);
+};
 
 const podMarkClass = (pod: V2Pod): string => (
   `v2-pods__item-icon v2-pods__item-icon--${podKind(pod)}`


### PR DESCRIPTION
Implements Phase 1 + early Phase 2 of `docs/plans/agent-collaboration-surfaces.md`.

## Summary

**Phase 1 (the demo blocker)**
- `agent-dm` Pod.type — any 2-member DM (any combination of user/bot).
- Allow-list patches in `messageController.ts` and `agentMentionService.ts:enqueueDmEvent` so the new pod type doesn't silent-drop. Bot senders are intentionally allowed in `agent-dm` (the whole point) but still blocked in legacy `agent-admin`.
- `dmService.sharePod(a, b)` — single source of truth for the §3.7 co-pod-member rule.
- `dmService.getOrCreateAgentDmRoom(memberA, memberB)` — idempotent on the unordered pair, AgentInstallation upserts for any bot members (heartbeat off).
- `AgentInstallation.upsert(...)` — new static via `findOneAndUpdate(upsert+setOnInsert)`. Re-fires + later admin installs converge on a single row instead of throwing or duplicating.
- `POST /api/agents/runtime/agent-dm` — accepts target = `{agentName,instanceId}` | `{userId}` | `{alias}`; resolves alias against `pod.contacts` then caller's contacts; runs `sharePod` auth (bypassed only when resolution came from pod.contacts — admin-binding carve-out); drops "DM started" system event in `originPodId`.
- Mention-driven autoJoin in `agentMentionService` behind `ENABLE_MENTION_AUTOJOIN` env flag (default off): unresolved aliases fall through to pod.contacts → sender.contacts; if resolved outside `pod.members`, runs sharePod (same admin-binding carve-out) + AgentInstallation.upsert + adds to pod.members + drops system event + fires chat.mention.
- Schema additions, all with safe defaults (existing rows return empty, never throw on read):
  - `User.contacts: [ContactEntry]` for both human and bot users.
  - `Pod.contacts: Map<alias, {agentName, instanceId}>` for per-pod bindings.
  - `AgentInstallation.config.role` reuses existing free-form config map.
- V2 sidebar treats `agent-dm` as Private; agent↔agent (both bot members) gets an "AA" icon to distinguish from human DMs.
- `getAllPods` extends membership filter to `agent-dm` so personal pod types stay user-scoped.

**Phase 2 substrate**
- `codex` agent preset on the openclaw clawdbot gateway — code-quality-focused, reactive (no heartbeat), routes through LiteLLM via the codex-auth-rotator already live. Replaces the operator-specific `sam-local-codex` stop-gap that broke when account-2/3 tokens were refreshed for the rotator.
- `PATCH /api/pods/:id/contacts` — pod creator OR global admin only (intentionally tighter than member-only; see Self-review #1 below). One endpoint for all aliases (codex/claude/reviewer/…).

**Out of scope for this PR:**
- Manage-tab UI to expose the PATCH endpoint (frontend follow-up; the API is shipped).
- Pixel/Theo/Ops heartbeat-template cutover (registry.ts) — depends on the codex agent being installed in the demo pods, which is a runtime-config step.

## Self-review pass

Ran the code-reviewer agent on `2baa52d266`. Three Important findings, all addressed in `a186406855`:

1. **PATCH /pods/:id/contacts was member-gated** — would let any pod member pin an arbitrary agent and bypass `sharePod`. Tightened to creator OR global admin (db lookup; we don't trust JWT-only role claims).
2. **TOCTOU on the admin-binding carve-out** — pod.contacts was fetched twice. Now fetched once and the source is propagated (`'pod' | 'sender'`) through `resolveContactAlias`.
3. **Ghost-User materialization on `target.agentName`** — typos would create permanent bot User rows. Probe via `User.findOne` first; 404 on miss.

Reviewer also flagged a Question about backfilling existing `agent-room` rows missing AgentInstallation — that's a runtime fix using the existing kubectl-exec script from `e78b5df241`, not blocked by this PR.

## Test plan

- [x] 25 unit + service tests passing (`dmService.agentDm.test.ts` + extended `agentMentionService.test.js`).
- [x] `tsc:check` clean.
- [ ] Browser-verify on dev once merged: open `/v2/pods` (no socket-auth flood), POST to `/api/agents/runtime/agent-dm` with valid + invalid agentName (404 on miss, no ghost row), confirm allow-list lets messages route to the agent in an `agent-dm` pod.
- [ ] After merge, install `codex` preset in a demo pod and pin via `PATCH /pods/:id/contacts` to verify the resolution chain end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)