### PR TITLE
fix(dm): enforce 1:1 invariant on agent-dm + cleanup script

### DIFF
--- a/backend/__tests__/unit/services/agentIdentityService.ensureAgentInPod.test.js
+++ b/backend/__tests__/unit/services/agentIdentityService.ensureAgentInPod.test.js
@@ -48,6 +48,46 @@ describe('AgentIdentityService.ensureAgentInPod — agent-room 1:1 invariant', (
     expect(pod.members).toContain('agent-1');
   });
 
+  it('refuses to add a third agent to an existing agent-dm (same 1:1 invariant)', async () => {
+    // ADR-001 §3.10 — agent-dm is the type for any 1:1 DM (agent↔agent or
+    // human↔agent). Same rule as agent-room: a third party always spawns
+    // a NEW DM pod, never widens the existing one.
+    const pod = {
+      _id: 'p-dm',
+      type: 'agent-dm',
+      members: ['agent-pixel-id', 'agent-codex-id'],
+      save: jest.fn(),
+    };
+    Pod.findById.mockResolvedValue(pod);
+
+    const newAgent = { _id: 'agent-rogue-id' };
+    const result = await AgentIdentityService.ensureAgentInPod(newAgent, 'p-dm');
+
+    expect(result).toBeNull();
+    expect(pod.save).not.toHaveBeenCalled();
+    expect(pod.members).toEqual(['agent-pixel-id', 'agent-codex-id']);
+  });
+
+  it('does NOT block adds to agent-admin (admin pods can have multiple admins)', async () => {
+    // agent-admin is N:1 (multiple admins ↔ one agent), not strictly 1:1.
+    // The DM_POD_TYPES_GUARD intentionally excludes it. Adding admins on
+    // top of an existing agent-admin pod is legitimate.
+    const pod = {
+      _id: 'p-admin',
+      type: 'agent-admin',
+      members: ['admin-a', 'agent-host'],
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+    Pod.findById.mockResolvedValue(pod);
+
+    const secondAdmin = { _id: 'admin-b' };
+    const result = await AgentIdentityService.ensureAgentInPod(secondAdmin, 'p-admin');
+
+    expect(result).toBe(pod);
+    expect(pod.save).toHaveBeenCalled();
+    expect(pod.members).toContain('admin-b');
+  });
+
   it('is a no-op when the agent is already a member of an agent-room (Mongoose ObjectId equality)', async () => {
     // Regression for the .includes()-vs-ObjectId bug: production stores
     // pod.members as ObjectId instances whose `===` always differs even

--- a/backend/controllers/podController.ts
+++ b/backend/controllers/podController.ts
@@ -401,9 +401,15 @@ exports.joinPod = async (req: any, res: any) => {
     // effectively dead for agent-rooms because `pod.createdBy` is the
     // host *agent*, not a human user. For multi-party human↔agent
     // surfaces, use `type: 'chat'` instead.
-    if (pod.type === 'agent-room') {
+    // DM pods (agent-room / agent-dm / agent-admin) are strictly 1:1.
+    // ADR-001 §3.10. Third-party joins must spawn a NEW DM pod with the
+    // requesting party + the relevant agent — see dmService
+    // .getOrCreateAgentDmRoom. Same invariant lives in
+    // agentIdentityService.DM_POD_TYPES_GUARD.
+    const { DM_POD_TYPES_GUARD } = require('../services/agentIdentityService');
+    if (DM_POD_TYPES_GUARD.has(String(pod.type))) {
       return res.status(403).json({
-        msg: 'Agent DMs are 1:1 — third-person joins are not allowed. Use a chat pod for multi-party conversations.',
+        msg: 'DM pods are 1:1 — third-person joins are not allowed. Start a new DM with the agent for a private conversation, or use a chat pod for multi-party.',
       });
     }
 

--- a/backend/routes/registry/admin.ts
+++ b/backend/routes/registry/admin.ts
@@ -335,9 +335,20 @@ adminRouter.post('/admin/agents/claude-code/session-token', auth, adminAuth, asy
       displayName: finalDisplayName,
     });
 
-    // Ensure pod membership — plain ObjectId array per Pod.members invariant
+    // Ensure pod membership — plain ObjectId array per Pod.members invariant.
+    // ADR-001 §3.10: DM pods are strictly 1:1, so an admin attaching a
+    // claude-code session into an existing DM is rejected. The admin should
+    // either pick a non-DM pod or spawn a fresh agent-dm/agent-room with the
+    // claude-code agent as one of the two members.
     const isMember = pod.members?.some((m: any) => m.toString() === agentUser._id.toString());
     if (!isMember) {
+      // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+      const { DM_POD_TYPES_GUARD } = require('../../services/agentIdentityService');
+      if (DM_POD_TYPES_GUARD.has(String(pod.type))) {
+        return res.status(403).json({
+          error: 'DM pods are 1:1 — cannot attach a third agent. Use a chat pod or create a new DM.',
+        });
+      }
       pod.members.push(agentUser._id);
       await pod.save();
     }

--- a/backend/scripts/migrate-agent-dm-multimember.ts
+++ b/backend/scripts/migrate-agent-dm-multimember.ts
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+/*
+ * Restore the 1:1 invariant on `agent-dm` pods that have accumulated more
+ * than two members. Sibling to `migrate-agent-room-multimember.ts` — same
+ * rationale, different pod type. Per ADR-001 §3.10 an `agent-dm` is a 1:1
+ * DM whose two members can be (human + agent) OR (agent + agent), and a
+ * third party of either kind is never allowed. The runtime guard expansion
+ * in `agentIdentityService.DM_POD_TYPES_GUARD` closes the bug going
+ * forward; this script cleans up the historical artifacts (live data
+ * showed agent-dm pods with 3 bot members where a stray
+ * `ensureAgentInPod` had silently appended a third agent).
+ *
+ * Strategy is restoration, not relabeling. Pods were created as 2-member
+ * DMs and got polluted; we want to undo the pollution.
+ *
+ *   For each agent-dm with members.length > 2:
+ *     humans = members where User.isBot === false
+ *     case humans.length >= 2:
+ *       Was never a DM (multi-human). Promote to `chat`. All members preserved.
+ *     case humans.length === 1:
+ *       keep = [the_human, pod.members[0|1] whichever is the bot peer the
+ *               creator wired in]. The 1-human-+-N-bots shape didn't exist
+ *               in agent-dm by design, but defend symmetrically with
+ *               agent-room: keep the human + the FIRST bot in member order
+ *               (mirrors getOrCreateAgentDmRoom's `members: [aId, bId]`).
+ *     case humans.length === 0:
+ *       Agent↔agent DM. Trust array insertion order:
+ *         1. dmService.getOrCreateAgentDmRoom creates pods with
+ *            `members: [aId, bId]`.
+ *         2. ensureAgentInPod / joinPod append via `.push()`.
+ *         3. No code path reorders via `$set: { members: [...] }`
+ *            (verified via repo-wide grep at PR-time).
+ *       So memberIds[0] + memberIds[1] are the original peers; anything
+ *       beyond is a rogue.
+ *
+ * Idempotent: a second run finds zero offenders. Run with `--dry` to see
+ * the action plan without writing.
+ *
+ * Side effects:
+ *   - PG `pod_members` is synced for each removed member (best-effort;
+ *     if PG is unreachable, MongoDB is the source of truth and the next
+ *     PG sync will reconcile via dmService).
+ *   - `AgentInstallation` rows for removed bot members in this pod are
+ *     marked `status: 'removed'` so `agentRuntimeAuth` no longer
+ *     authorizes them. We don't `deleteMany` because identity continuity
+ *     (the agent's User row) survives package reinstall — see
+ *     CLAUDE.md "Identity is separate from package."
+ *
+ * Usage:
+ *   ts-node backend/scripts/migrate-agent-dm-multimember.ts          # apply
+ *   ts-node backend/scripts/migrate-agent-dm-multimember.ts --dry    # report
+ */
+
+import mongoose from 'mongoose';
+import Pod from '../models/Pod';
+import User from '../models/User';
+import { AgentInstallation } from '../models/AgentRegistry';
+
+let PGPod: { removeMember?: (podId: string, userId: string) => Promise<unknown> } | null = null;
+try {
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  PGPod = require('../models/pg/Pod');
+} catch {
+  PGPod = null;
+}
+
+type Action = 'restore-1to1-agent-agent' | 'restore-1to1-human-agent' | 'convert-to-chat';
+
+interface Plan {
+  podId: string;
+  name: string;
+  action: Action;
+  before: number;
+  after: number;
+  keepIds: string[];
+  dropIds: string[];
+}
+
+interface MigrationResult {
+  total: number;
+  applied: number;
+  skipped: number;
+  plans: Plan[];
+  pgSynced: number;
+  installationsDeactivated: number;
+}
+
+const idStr = (v: any): string => String(v?._id || v);
+
+export async function migrateAgentDmMultimember(
+  options: { dryRun?: boolean } = {},
+): Promise<MigrationResult> {
+  const dryRun = options.dryRun === true;
+  const result: MigrationResult = {
+    total: 0,
+    applied: 0,
+    skipped: 0,
+    plans: [],
+    pgSynced: 0,
+    installationsDeactivated: 0,
+  };
+
+  const cursor = Pod.find({
+    type: 'agent-dm',
+    $expr: { $gt: [{ $size: '$members' }, 2] },
+  }).cursor();
+
+  for await (const pod of cursor) {
+    result.total += 1;
+    const memberIds: string[] = (pod.members || []).map(idStr);
+
+    const users = await User.find({ _id: { $in: memberIds } })
+      .select('_id isBot username')
+      .lean();
+    const isBotById = new Map<string, boolean>();
+    for (const u of users) {
+      isBotById.set(String(u._id), Boolean((u as any).isBot));
+    }
+
+    const humans = memberIds.filter((id) => isBotById.get(id) === false);
+    const bots = memberIds.filter((id) => isBotById.get(id) === true);
+
+    let action: Action;
+    let keepIds: string[];
+
+    if (humans.length >= 2) {
+      action = 'convert-to-chat';
+      keepIds = memberIds; // promote, preserve everyone
+    } else if (humans.length === 1) {
+      // Defensive shape: agent-dm wasn't designed to ever hold a single
+      // human (that's agent-room's role), but if it shows up, restore as
+      // human + first bot in member order — same idea as agent-room migrator.
+      action = 'restore-1to1-human-agent';
+      const firstBot = bots[0];
+      if (!firstBot) {
+        console.warn(`[migrate-agent-dm] SKIP pod ${pod._id}: 1 human, 0 bots — degenerate shape`);
+        result.skipped += 1;
+        continue;
+      }
+      keepIds = [humans[0], firstBot];
+    } else {
+      // Agent↔agent — keep the original two by insertion order.
+      action = 'restore-1to1-agent-agent';
+      keepIds = [memberIds[0], memberIds[1]];
+    }
+
+    const keepSet = new Set(keepIds);
+    const dropIds = memberIds.filter((id) => !keepSet.has(id));
+
+    const plan: Plan = {
+      podId: String(pod._id),
+      name: pod.name || '(unnamed)',
+      action,
+      before: memberIds.length,
+      after: keepSet.size,
+      keepIds: [...keepSet],
+      dropIds,
+    };
+    result.plans.push(plan);
+
+    if (dryRun) {
+      result.skipped += 1;
+      continue;
+    }
+
+    if (action === 'convert-to-chat') {
+      pod.type = 'chat';
+    } else {
+      pod.members = [...keepSet] as any;
+    }
+    await pod.save();
+    result.applied += 1;
+
+    // Sync PG and clean up AgentInstallation only for the trim cases —
+    // a chat-promotion preserves all members, so neither cleanup applies.
+    if (action !== 'convert-to-chat' && dropIds.length > 0) {
+      // PG pod_members — best-effort; failures don't roll back Mongo.
+      if (PGPod && typeof PGPod.removeMember === 'function' && process.env.PG_HOST) {
+        for (const dropId of dropIds) {
+          try {
+            await PGPod.removeMember(String(pod._id), dropId);
+            result.pgSynced += 1;
+          } catch (pgErr) {
+            console.warn(
+              `[migrate-agent-dm] PG removeMember failed for pod=${pod._id} user=${dropId}:`,
+              (pgErr as Error).message,
+            );
+          }
+        }
+      }
+
+      // Deactivate AgentInstallation rows for dropped bot members so
+      // their runtime tokens stop authorizing this pod. User rows stay —
+      // identity is separate from package.
+      const droppedBotUserIds = dropIds.filter((id) => isBotById.get(id) === true);
+      if (droppedBotUserIds.length > 0) {
+        try {
+          // Map User._id -> agentName + instanceId via botMetadata so the
+          // (agentName, podId, instanceId) AgentInstallation key resolves.
+          const droppedBots = await User.find({ _id: { $in: droppedBotUserIds } })
+            .select('_id username botMetadata')
+            .lean<Array<{ _id: unknown; username?: string; botMetadata?: { agentName?: string; instanceId?: string } }>>();
+
+          for (const bot of droppedBots) {
+            const agentName = (bot.botMetadata?.agentName || bot.username || '').toLowerCase();
+            const instanceId = bot.botMetadata?.instanceId || 'default';
+            if (!agentName) continue;
+            const updateRes = await AgentInstallation.updateMany(
+              { agentName, podId: pod._id, instanceId, status: { $ne: 'removed' } },
+              { $set: { status: 'removed' } },
+            );
+            result.installationsDeactivated += (updateRes as { modifiedCount?: number }).modifiedCount || 0;
+          }
+        } catch (instErr) {
+          console.warn(
+            `[migrate-agent-dm] AgentInstallation cleanup failed for pod=${pod._id}:`,
+            (instErr as Error).message,
+          );
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes('--dry');
+  const mongoUri = process.env.MONGO_URI;
+  if (!mongoUri) {
+    console.error('MONGO_URI not set');
+    process.exit(1);
+  }
+
+  await mongoose.connect(mongoUri);
+  try {
+    const r = await migrateAgentDmMultimember({ dryRun });
+    console.log(`[migrate-agent-dm] ${dryRun ? 'DRY-RUN' : 'APPLIED'}`);
+    console.log(`  total offenders          : ${r.total}`);
+    console.log(`  applied                  : ${r.applied}`);
+    console.log(`  skipped (dry / degen)    : ${r.skipped}`);
+    console.log(`  pg member rows removed   : ${r.pgSynced}`);
+    console.log(`  installations deactivated: ${r.installationsDeactivated}`);
+    if (r.plans.length > 0) {
+      console.log('  per-pod plan:');
+      for (const p of r.plans) {
+        console.log(
+          `    - ${p.podId}  "${p.name}"  ${p.action}  members ${p.before} → ${p.after}`,
+        );
+        if (p.dropIds.length > 0) {
+          console.log(`        drop: ${p.dropIds.join(', ')}`);
+        }
+      }
+    }
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/backend/services/agentIdentityService.ts
+++ b/backend/services/agentIdentityService.ts
@@ -25,6 +25,20 @@ try {
   PGPod = null;
 }
 
+// Pod types that are strictly 1:1 — exactly two members, no joinable widen.
+// Adding a third party to one of these is a bug; a new conversation always
+// spawns a fresh DM pod (see dmService.getOrCreateAgentDmRoom). Single source
+// of truth for ALL membership-add paths (ensureAgentInPod, joinPod controller,
+// claude-code attach in registry/admin, any future code).
+//
+// `agent-admin` is intentionally NOT in this set — multiple admins can share
+// an admin↔agent pod (it's an N:1 admin-team DM, not a strict 1:1).
+//
+// Why it lives here: agentIdentityService.ensureAgentInPod is the most-called
+// add-path and the original site of the agent-room guard, so co-locating the
+// invariant keeps the rule visible to anyone reading that function.
+export const DM_POD_TYPES_GUARD = new Set<string>(['agent-room', 'agent-dm']);
+
 const normalizeSegment = (value: unknown): string => (
   (String(value || '')).toLowerCase().replace(/[^a-z0-9-]/g, '').slice(0, 40)
 );
@@ -287,15 +301,17 @@ class AgentIdentityService {
     ));
 
     if (!isAlreadyMember) {
-      // Agent DMs are 1:1 (ADR-001 §3.10). Auto-install paths must not
-      // sneak a third member into someone else's agent-room — the room
-      // already has exactly its host agent + one human. If the requested
-      // agent isn't already in this room, refuse to add. Caller should
-      // create a NEW agent-room for this agent + user pair instead.
-      if (pod.type === 'agent-room') {
+      // DM pods are strictly 1:1 (ADR-001 §3.10): exactly two members,
+      // human or agent. Auto-install paths MUST NOT sneak a third member
+      // into an existing DM. A new conversation between a third party and
+      // either of the two existing members spawns a NEW DM pod via
+      // dmService.getOrCreateAgentDmRoom — never widens the existing one.
+      // The same rule applies symmetrically to agent-room (1:1 user↔agent)
+      // and agent-admin (1:1 admin↔agent).
+      if (DM_POD_TYPES_GUARD.has(String(pod.type))) {
         console.warn(
-          `[ensureAgentInPod] refused: pod ${pod._id} is an agent-room (1:1) `
-          + `and agent ${agentId} is not already a member. ADR-001 §3.10.`,
+          `[ensureAgentInPod] refused: pod ${pod._id} is type=${pod.type} (1:1 DM) `
+          + `and ${agentId} is not already a member. ADR-001 §3.10.`,
         );
         return null;
       }


### PR DESCRIPTION
## Summary

ADR-001 §3.10 says DM pods are strictly 1:1 — exactly two members, human or agent. The original guard in `ensureAgentInPod` only covered `agent-room`, so any path calling it on an `agent-dm` with a non-member silently `.push()`-ed a third member. Live data on dev showed agent-dm pods with 3 bot members.

- Centralize as `DM_POD_TYPES_GUARD = {'agent-room','agent-dm'}` exported from `agentIdentityService`. `agent-admin` is intentionally excluded (multiple admins ↔ one agent is N:1, not strictly 1:1).
- Patch all three call sites: `ensureAgentInPod` refuses + returns null; `podController.joinPod` 403; `registry/admin.ts` claude-code attach 403.
- Add `backend/scripts/migrate-agent-dm-multimember.ts` — sibling to the existing agent-room migrator. Trims polluted DMs to the original 2 peers; promotes multi-human pods to `chat`; syncs PG `pod_members`; deactivates orphan AgentInstallation rows. Idempotent. `--dry` to preview.
- Tests: extend existing guard suite — refuse 3rd agent on `agent-dm`; explicit regression guard that `agent-admin` adds still succeed.

## Test plan

- [ ] Unit tests pass: `agentIdentityService.ensureAgentInPod.test.js`
- [ ] After deploy: `kubectl exec -n commonly-dev deploy/backend -- npx ts-node backend/scripts/migrate-agent-dm-multimember.ts --dry` — eyeball the action plan
- [ ] Apply (drop `--dry`); re-run dry-run and confirm 0 offenders
- [ ] Sanity-check the runtime guard: pick an agent-dm pod, attempt `POST /api/pods/:id/join` from a 3rd-party token → expect 403
- [ ] Confirm `AgentInstallation` rows for dropped bots are now `status: 'removed'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)