### PR TITLE
fix(dm): use botMetadata.displayName for agent-dm labels (not runtime agentName)

### DIFF
--- a/backend/__tests__/unit/services/agentIdentityService.resolveAgentDisplayLabel.test.js
+++ b/backend/__tests__/unit/services/agentIdentityService.resolveAgentDisplayLabel.test.js
@@ -1,0 +1,60 @@
+// Display-label resolution for agent User rows. Load-bearing for any
+// surface that renders agent identity (agent-dm pod names, sidebar member
+// list, system "DM started" announcement). Bug PR: agent-dm pods were
+// rendering as "openclaw ↔ openclaw" because the runtime-leaning agentName
+// was used as the fallback instead of botMetadata.displayName.
+
+jest.mock('../../../models/Pod', () => ({}));
+jest.mock('../../../models/User', () => ({}));
+
+const { resolveAgentDisplayLabel } = require('../../../services/agentIdentityService');
+
+describe('resolveAgentDisplayLabel', () => {
+  it('returns botMetadata.displayName when set (most-preferred)', () => {
+    const user = {
+      username: 'openclaw-pixel',
+      botMetadata: { displayName: 'Pixel', agentName: 'openclaw', instanceId: 'pixel' },
+    };
+    expect(resolveAgentDisplayLabel(user)).toBe('Pixel');
+  });
+
+  it('falls back to instanceId when displayName is missing — never to agentName runtime', () => {
+    // The exact bug: agentName='openclaw' is the runtime, instanceId is the
+    // identity. Falling back to instanceId beats falling back to agentName.
+    const user = {
+      username: 'openclaw-aria',
+      botMetadata: { agentName: 'openclaw', instanceId: 'aria' },
+    };
+    expect(resolveAgentDisplayLabel(user)).toBe('aria');
+  });
+
+  it('skips an instanceId of "default" (no identity in it) and uses username', () => {
+    const user = {
+      username: 'commonly-bot',
+      botMetadata: { agentName: 'commonly-bot', instanceId: 'default' },
+    };
+    expect(resolveAgentDisplayLabel(user)).toBe('commonly-bot');
+  });
+
+  it('uses username when botMetadata is empty (humans)', () => {
+    const user = { username: 'sam', botMetadata: undefined };
+    expect(resolveAgentDisplayLabel(user)).toBe('sam');
+  });
+
+  it('uses the supplied fallback when even username is missing', () => {
+    const user = {};
+    expect(resolveAgentDisplayLabel(user, 'unknown-agent')).toBe('unknown-agent');
+  });
+
+  it('returns the fallback for null user (resolved-by-alias before User load)', () => {
+    expect(resolveAgentDisplayLabel(null, 'aria')).toBe('aria');
+  });
+
+  it('treats a whitespace-only displayName as absent', () => {
+    const user = {
+      username: 'openclaw-pixel',
+      botMetadata: { displayName: '   ', agentName: 'openclaw', instanceId: 'pixel' },
+    };
+    expect(resolveAgentDisplayLabel(user)).toBe('pixel');
+  });
+});

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -784,16 +784,33 @@ router.post('/agent-dm', agentRuntimeAuth, phase4RateLimit, async (req: any, res
       // Resolve via the identity service so the User row is in canonical
       // shape (handles legacy bot rows that pre-date botMetadata).
       targetUser = await AgentIdentityService.getOrCreateAgentUser(agentName, { instanceId });
-      targetMeta = { agentName, instanceId, displayName: agentName, isBot: true };
+      // displayName resolution prefers the curated `botMetadata.displayName`
+      // ("Pixel", "Strategist (Aria)") over the runtime-leaning agentName.
+      // See `resolveAgentDisplayLabel` — same fallback every agent-display
+      // surface should use to avoid "openclaw ↔ openclaw" pod names.
+      targetMeta = {
+        agentName,
+        instanceId,
+        displayName: AgentIdentityService.resolveAgentDisplayLabel(
+          targetUser as { username?: string; botMetadata?: { displayName?: string; instanceId?: string; agentName?: string } } | null,
+          agentName,
+        ),
+        isBot: true,
+      };
     } else if (target.userId) {
       const lookup = await User.findById(String(target.userId)).select('_id isBot username botMetadata').lean();
       if (!lookup) return res.status(404).json({ message: 'target user not found' });
       targetUser = lookup as { _id: unknown; isBot?: boolean; username?: string; botMetadata?: { agentName?: string; instanceId?: string } };
+      // For human targets `botMetadata` is empty — resolveAgentDisplayLabel
+      // falls through to `username`, the right answer.
       targetMeta = {
         isBot: !!lookup.isBot,
         agentName: lookup.botMetadata?.agentName || undefined,
         instanceId: lookup.botMetadata?.instanceId || 'default',
-        displayName: lookup.botMetadata?.agentName || lookup.username,
+        displayName: AgentIdentityService.resolveAgentDisplayLabel(
+          lookup,
+          lookup.username,
+        ),
       };
     } else if (target.alias) {
       // §3.2: resolve via caller's own contacts. Pod-level binding takes
@@ -818,7 +835,15 @@ router.post('/agent-dm', agentRuntimeAuth, phase4RateLimit, async (req: any, res
         return res.status(404).json({ message: `No contact bound to alias "${alias}"`, alias });
       }
       targetUser = await AgentIdentityService.getOrCreateAgentUser(bound.agentName, { instanceId: bound.instanceId });
-      targetMeta = { agentName: bound.agentName, instanceId: bound.instanceId, displayName: bound.agentName, isBot: true };
+      targetMeta = {
+        agentName: bound.agentName,
+        instanceId: bound.instanceId,
+        displayName: AgentIdentityService.resolveAgentDisplayLabel(
+          targetUser as { username?: string; botMetadata?: { displayName?: string; instanceId?: string; agentName?: string } } | null,
+          bound.agentName,
+        ),
+        isBot: true,
+      };
     } else {
       return res.status(400).json({ message: 'target must specify agentName, userId, or alias' });
     }
@@ -855,7 +880,13 @@ router.post('/agent-dm', agentRuntimeAuth, phase4RateLimit, async (req: any, res
       agentName: callerAgentUser.botMetadata?.agentName || (req.agentInstallation?.agentName as string),
       instanceId: callerAgentUser.botMetadata?.instanceId || (req.agentInstallation?.instanceId as string) || 'default',
       isBot: true,
-      displayName: callerAgentUser.botMetadata?.agentName || callerAgentUser.username,
+      // resolveAgentDisplayLabel prefers `botMetadata.displayName`, then the
+      // identity-bearing instanceId, then username — never the runtime-leaning
+      // `botMetadata.agentName` ('openclaw' for OpenClaw-driven agents).
+      displayName: AgentIdentityService.resolveAgentDisplayLabel(
+        callerAgentUser as { username?: string; botMetadata?: { displayName?: string; instanceId?: string; agentName?: string } } | null,
+        callerAgentUser.username,
+      ),
     };
     const peerMeta = {
       userId: targetUser._id,

--- a/backend/scripts/rename-agent-dm-pods.ts
+++ b/backend/scripts/rename-agent-dm-pods.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/*
+ * Rename existing `agent-dm` pods whose name was generated from the
+ * runtime-leaning `botMetadata.agentName` ('openclaw' for every OpenClaw-
+ * driven agent) instead of the curated `botMetadata.displayName`.
+ *
+ * Symptom on dev: pod named "openclaw ↔ openclaw" with members aria + pixel
+ * (both stored as `agentName: 'openclaw', instanceId: 'aria' | 'pixel'`).
+ * The runtime fix in this PR makes new pods compute the right name, but
+ * existing pods keep their broken name until we re-derive it.
+ *
+ * Strategy:
+ *   For each agent-dm pod:
+ *     1. Pull the bot User rows for both members.
+ *     2. Compute the desired name from each member's display label using
+ *        the same fallback as `dmService.getOrCreateAgentDmRoom`:
+ *          botMetadata.displayName → instanceId (if != 'default') → username.
+ *     3. If the desired name differs from the stored name, update Mongo.
+ *        Best-effort sync the PG `pods` row's name too (optional cosmetic).
+ *
+ * Idempotent. Run with `--dry` to preview.
+ *
+ * Usage (from /app inside the backend pod):
+ *   node dist/scripts/rename-agent-dm-pods.js --dry
+ *   node dist/scripts/rename-agent-dm-pods.js
+ */
+
+import mongoose from 'mongoose';
+import Pod from '../models/Pod';
+import User from '../models/User';
+
+let dbPg: { pool: { query: (sql: string, params?: unknown[]) => Promise<unknown> } } | null = null;
+try {
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  dbPg = require('../config/db-pg');
+} catch {
+  dbPg = null;
+}
+
+interface Plan {
+  podId: string;
+  before: string;
+  after: string;
+  members: Array<{ id: string; label: string }>;
+}
+
+interface RenameResult {
+  total: number;
+  applied: number;
+  skipped: number;
+  pgSynced: number;
+  plans: Plan[];
+}
+
+interface BotMetadata {
+  displayName?: string;
+  instanceId?: string;
+  agentName?: string;
+}
+
+function labelFor(user: { username?: string; botMetadata?: BotMetadata } | null): string {
+  if (!user) return 'unknown';
+  const meta = user.botMetadata;
+  const display = meta?.displayName?.trim();
+  if (display) return display;
+  const instanceId = meta?.instanceId?.trim();
+  if (instanceId && instanceId !== 'default') return instanceId;
+  return user.username || 'unknown';
+}
+
+export async function renameAgentDmPods(
+  options: { dryRun?: boolean } = {},
+): Promise<RenameResult> {
+  const dryRun = options.dryRun === true;
+  const result: RenameResult = { total: 0, applied: 0, skipped: 0, pgSynced: 0, plans: [] };
+
+  const cursor = Pod.find({ type: 'agent-dm' }).cursor();
+
+  for await (const pod of cursor) {
+    result.total += 1;
+    const memberIds: string[] = (pod.members || []).map((m: any) => String(m?._id || m));
+    if (memberIds.length !== 2) {
+      // Out of scope — the dedup migration handles non-2-member rooms.
+      result.skipped += 1;
+      continue;
+    }
+
+    const users = await User.find({ _id: { $in: memberIds } })
+      .select('_id username botMetadata')
+      .lean<Array<{ _id: unknown; username?: string; botMetadata?: BotMetadata }>>();
+    // Preserve member order when computing the label so the name reflects
+    // the insertion-time pair (memberA ↔ memberB).
+    const userById = new Map<string, { username?: string; botMetadata?: BotMetadata }>();
+    for (const u of users) {
+      userById.set(String(u._id), { username: u.username, botMetadata: u.botMetadata });
+    }
+    const labels = memberIds.map((id) => labelFor(userById.get(id) || null));
+    const desiredName = `${labels[0]} ↔ ${labels[1]}`;
+    const currentName = String(pod.name || '');
+
+    if (currentName === desiredName) {
+      result.skipped += 1;
+      continue;
+    }
+
+    const plan: Plan = {
+      podId: String(pod._id),
+      before: currentName,
+      after: desiredName,
+      members: memberIds.map((id, i) => ({ id, label: labels[i] })),
+    };
+    result.plans.push(plan);
+
+    if (dryRun) continue;
+
+    pod.name = desiredName;
+    // Description tracks the same identities; cheap to refresh.
+    const isBotPair = users.every((u) => u.botMetadata?.agentName);
+    pod.description = isBotPair
+      ? `Agent-to-agent DM — ${labels[0]} and ${labels[1]}`
+      : `Direct message — ${labels[0]} and ${labels[1]}`;
+    await pod.save();
+    result.applied += 1;
+
+    // PG cosmetic sync — `pods.name` is a display copy, not load-bearing
+    // for routing. Best-effort; failures don't roll back Mongo.
+    if (dbPg && process.env.PG_HOST) {
+      try {
+        await dbPg.pool.query(
+          'UPDATE pods SET name = $1 WHERE _id = $2',
+          [desiredName, String(pod._id)],
+        );
+        result.pgSynced += 1;
+      } catch (pgErr) {
+        console.warn(
+          `[rename-agent-dm] PG name update failed for pod=${pod._id}:`,
+          (pgErr as Error).message,
+        );
+      }
+    }
+  }
+
+  return result;
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes('--dry');
+  const mongoUri = process.env.MONGO_URI;
+  if (!mongoUri) {
+    console.error('MONGO_URI not set');
+    process.exit(1);
+  }
+
+  await mongoose.connect(mongoUri);
+  try {
+    const r = await renameAgentDmPods({ dryRun });
+    console.log(`[rename-agent-dm] ${dryRun ? 'DRY-RUN' : 'APPLIED'}`);
+    console.log(`  pods scanned          : ${r.total}`);
+    console.log(`  renamed               : ${r.applied}`);
+    console.log(`  skipped (already ok)  : ${r.skipped}`);
+    console.log(`  pg names synced       : ${r.pgSynced}`);
+    if (r.plans.length > 0) {
+      console.log('  changes:');
+      for (const p of r.plans) {
+        console.log(`    - ${p.podId}`);
+        console.log(`        before: ${JSON.stringify(p.before)}`);
+        console.log(`        after : ${JSON.stringify(p.after)}`);
+      }
+    }
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/backend/services/agentIdentityService.ts
+++ b/backend/services/agentIdentityService.ts
@@ -39,6 +39,44 @@ try {
 // invariant keeps the rule visible to anyone reading that function.
 export const DM_POD_TYPES_GUARD = new Set<string>(['agent-room', 'agent-dm']);
 
+// Resolve the human-readable label for an agent User row. The fallback
+// chain is intentional and load-bearing for any UI / pod-naming surface
+// that shows agent identity (agent-dm pod names, sidebar member rows):
+//
+//   1. `botMetadata.displayName`  — the curated label the registry/preset
+//      sets ("Pixel", "Strategist (Aria)"). This is what humans actually
+//      recognize.
+//   2. `botMetadata.instanceId`   — when displayName is missing AND the
+//      instanceId carries identity (i.e. != 'default'). For OpenClaw-driven
+//      agents the User row stores `agentName: 'openclaw'` (the RUNTIME) +
+//      `instanceId: 'aria' | 'pixel' | ...` (the identity), so falling back
+//      to instanceId here beats falling back to the runtime label.
+//   3. `username`                 — last-resort identifier; always set.
+//   4. fallback string            — for the non-User case (e.g. resolved-
+//      by-alias before the User row is loaded).
+//
+// Why NOT fall back to `botMetadata.agentName`: that field can be the
+// runtime name ('openclaw') rather than the agent's identity. Falling
+// back to it produces "openclaw ↔ openclaw" pod names where what we want
+// is "Pixel ↔ Strategist (Aria)".
+export function resolveAgentDisplayLabel(
+  user: {
+    username?: string;
+    botMetadata?: { displayName?: string; instanceId?: string; agentName?: string };
+  } | null | undefined,
+  fallback?: string,
+): string {
+  const safeFallback = fallback || 'agent';
+  if (!user) return safeFallback;
+  const meta = user.botMetadata;
+  const display = meta?.displayName?.trim();
+  if (display) return display;
+  const instanceId = meta?.instanceId?.trim();
+  if (instanceId && instanceId !== 'default') return instanceId;
+  if (user.username) return user.username;
+  return safeFallback;
+}
+
 const normalizeSegment = (value: unknown): string => (
   (String(value || '')).toLowerCase().replace(/[^a-z0-9-]/g, '').slice(0, 40)
 );

--- a/backend/services/dmService.ts
+++ b/backend/services/dmService.ts
@@ -443,8 +443,19 @@ class DMService {
     });
     if (existing) return existing;
 
-    const aLabel = memberA.displayName || memberA.agentName || 'a';
-    const bLabel = memberB.displayName || memberB.agentName || 'b';
+    // Defense-in-depth: if a caller forgot to populate `displayName` we
+    // fall through to the instanceId (identity-bearing) before agentName
+    // (runtime-leaning). Avoids "openclaw ↔ openclaw" when callerMeta /
+    // peerMeta are partially built.
+    const labelOf = (m: { displayName?: string; instanceId?: string; agentName?: string }, fallback: string): string => {
+      const d = m.displayName?.trim();
+      if (d) return d;
+      const i = m.instanceId?.trim();
+      if (i && i !== 'default') return i;
+      return m.agentName?.trim() || fallback;
+    };
+    const aLabel = labelOf(memberA, 'a');
+    const bLabel = labelOf(memberB, 'b');
     const name = `${aLabel} ↔ ${bLabel}`;
     const description = memberA.isBot && memberB.isBot
       ? `Agent-to-agent DM — ${aLabel} and ${bLabel}`


### PR DESCRIPTION
## Summary

Reported by Sam: an a2a DM showed both members as \"openclaw\" — pod name was \`openclaw ↔ openclaw\` with members aria + pixel. The data was correct in the User rows (\`botMetadata.displayName = \"Pixel\"\` / \`\"Strategist (Aria)\"\`; \`instanceId = \"pixel\"\` / \`\"aria\"\`); the platform just wasn't reading the right field.

For OpenClaw-driven agents the User row stores:

| field | value | meaning |
|---|---|---|
| \`botMetadata.agentName\` | \`'openclaw'\` | the **runtime** |
| \`botMetadata.instanceId\` | \`'aria' \| 'pixel'\` | the **identity** |
| \`botMetadata.displayName\` | \`'Pixel' \| 'Strategist (Aria)'\` | the **curated label** |

Four call sites in \`agentsRuntime.ts /agent-dm\` were building \`targetMeta\` / \`callerMeta\` with \`displayName: agentName\`, falling back to \`'openclaw'\` for everyone.

### Changes
- \`resolveAgentDisplayLabel(user, fallback)\` in \`agentIdentityService\` — fallback chain: \`botMetadata.displayName → instanceId (if not 'default') → username → fallback\`. Explicitly never falls back to \`botMetadata.agentName\` (runtime-leaning).
- Patches the four \`/agent-dm\` call sites to use the helper.
- Hardens \`dmService.getOrCreateAgentDmRoom\` with an inline \`labelOf\` (belt-and-suspenders against future callers).
- New script \`backend/scripts/rename-agent-dm-pods.ts\` — idempotent, \`--dry\` to preview, re-derives names for pods that were created under the bug.
- Unit tests for the resolution helper.

**The openclaw extension does NOT need updating.** The kernel already has the right data; the platform just wasn't consulting it.

## Test plan
- [ ] Unit tests pass: \`agentIdentityService.resolveAgentDisplayLabel.test.js\`
- [ ] After deploy: \`kubectl exec -n commonly-dev deploy/backend -- node dist/scripts/rename-agent-dm-pods.js --dry\` — verify the existing \`openclaw ↔ openclaw\` pod will become \`Pixel ↔ Strategist (Aria)\`
- [ ] Apply, then re-dry to confirm 0 changes pending
- [ ] New a2a DM (e.g. via the agent-dm endpoint) → confirm pod name uses display labels, not 'openclaw'

🤖 Generated with [Claude Code](https://claude.com/claude-code)