### PR TITLE
fix(native-agents): stop burning Codex quota on first-party utility apps

### DIFF
--- a/backend/config/native-agents/pod-summarizer.ts
+++ b/backend/config/native-agents/pod-summarizer.ts
@@ -59,7 +59,9 @@ export const podSummarizerApp = {
     + '- If the pod has zero new human messages and no prior memory, write memory '
     + "`first run, empty pod` and stop. Do not post.\n"
     + '- DO NOT call commonly_create_task. You are not here to create work.',
-  model: 'openai-codex/gpt-5.4-mini',
+  // See pod-welcomer.ts for the rationale — utility apps run on the
+  // OpenRouter free tier, not paid Codex.
+  model: 'openrouter/nvidia/nemotron-3-super-120b-a12b:free',
   triggers: ['heartbeat'],
   heartbeatIntervalMinutes: 360,
   tools: [

--- a/backend/config/native-agents/pod-welcomer.ts
+++ b/backend/config/native-agents/pod-welcomer.ts
@@ -51,7 +51,12 @@ export const podWelcomerApp = {
     + 'treat the pod as new and welcome them anyway.\n'
     + '- Never welcome the same user twice. If recent context shows you already '
     + 'welcomed this exact user, post nothing and end.',
-  model: 'openai-codex/gpt-5.4-mini',
+  // Free-tier OpenRouter model. Native first-party apps are utility surfaces
+  // (welcome / parse / summarize) — they don't need Codex paid quota and
+  // burning it for these heavy-traffic event handlers exhausts dev agents'
+  // accounts. Same default community agents use; if quality drops, reach for
+  // gemini-2.5-flash (paid but cheap) before paid Codex.
+  model: 'openrouter/nvidia/nemotron-3-super-120b-a12b:free',
   triggers: ['pod.join'],
   tools: ['commonly_read_context', 'commonly_post_message'],
   iconUrl: '',

--- a/backend/config/native-agents/task-clerk.ts
+++ b/backend/config/native-agents/task-clerk.ts
@@ -54,7 +54,9 @@ export const taskClerkApp = {
     + '- DO NOT call commonly_read_memory or commonly_write_memory. You do not have '
     + 'access to those tools.\n'
     + '- Keep all replies under 2 lines. You are a clerk, not a conversationalist.',
-  model: 'openai-codex/gpt-5.4-mini',
+  // See pod-welcomer.ts for the rationale — utility apps run on the
+  // OpenRouter free tier, not paid Codex.
+  model: 'openrouter/nvidia/nemotron-3-super-120b-a12b:free',
   triggers: ['mention'],
   tools: [
     'commonly_read_context',

--- a/backend/services/nativeRuntimeService.ts
+++ b/backend/services/nativeRuntimeService.ts
@@ -50,7 +50,11 @@ export interface NativeRunResult {
 const MAX_TURNS = 10;
 const MAX_TOKENS = 50_000;
 const MAX_WALL_CLOCK_MS = 60_000;
-const DEFAULT_MODEL = 'openai-codex/gpt-5.4-mini';
+// Free-tier default for the native runtime. Per-installation config can
+// override (`installation.config.model`) for dev agents that legitimately
+// need paid Codex — but the platform-wide default never burns Codex quota
+// just because someone forgot to set the field.
+const DEFAULT_MODEL = 'openrouter/nvidia/nemotron-3-super-120b-a12b:free';
 const LITELLM_TIMEOUT_MS = Number(process.env.NATIVE_RUNTIME_TIMEOUT_MS) || 45_000;
 
 // --- helpers ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Pod-welcomer (event handler), task-clerk (mention), and pod-summarizer (6h heartbeat) all hardcoded \`openai-codex/gpt-5.4-mini\` — so every pod-join, every \`/task\` mention, every 6-hour summarizer cycle was burning paid Codex weekly quota that the dev agents (Pixel/Theo/Ops/Nova) need for actual code work.
- Switch all three native first-party app manifests + the \`nativeRuntimeService\` \`DEFAULT_MODEL\` fallback to the same OpenRouter free-tier model community agents already use: \`openrouter/nvidia/nemotron-3-super-120b-a12b:free\`.
- **Intentionally left on Codex:** the dev-agent provisioner override in \`agentProvisionerServiceK8s.ts:2014\` (Pixel/Theo/Ops heartbeats) and the \`codex\` preset in \`registry/presets.ts:122\` (the agent that does code review). LiteLLM virtual-key allow-lists are unchanged.

## How the rollout works

No DB migration needed. \`backend/scripts/seed-native-agents.ts\` runs on every backend boot and does \`\$set: { config: configObj }\` on each \`AgentInstallation\` from the manifest — so the next deploy rewrites the persisted \`config.model\` field for every existing install of these three apps automatically.

## Test plan

- [x] \`tsc --noEmit\` clean on touched files
- [ ] After merge + Deploy Dev, verify the three native apps' \`AgentInstallation.config.model\` reflects the new model (mongo query against commonly-dev)
- [ ] Trigger a pod-join in a pod with pod-welcomer installed; confirm the LiteLLM call uses nemotron, not chatgpt/gpt-5.4-mini (LiteLLM proxy logs)
- [ ] Confirm Codex weekly account-1/2/3 burn rate drops measurably over the next heartbeat window

🤖 Generated with [Claude Code](https://claude.com/claude-code)