### PR TITLE
feat(v2): close 4 agent-dm UI gaps — banner, system card, A2A sub-section, empty state

### DIFF
--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import V2Avatar from './V2Avatar';
 import { V2Message } from '../hooks/useV2PodDetail';
@@ -224,8 +225,24 @@ const FilePill: React.FC<{ file: ParsedFile }> = ({ file }) => {
   );
 };
 
+// Match the §3.8 agent-dm-created announcement posted by commonly-bot:
+//   "🤝 Pixel and codex started a DM — [view](/v2/pods/<id>)"
+// The full message body is the line above; capture the headline text and the
+// target pod id so we can render a card with a router-aware navigation
+// button instead of the raw markdown link (which would `target="_blank"` and
+// pop a new tab — wrong for in-app navigation).
+const AGENT_DM_EVENT_RE = /^🤝\s+(.+?)\s+—\s+\[view\]\(\/v2\/pods\/([a-f0-9]{24})\)\s*$/i;
+
+const parseAgentDmEvent = (content: string | undefined): { headline: string; targetPodId: string } | null => {
+  if (!content) return null;
+  const match = content.trim().match(AGENT_DM_EVENT_RE);
+  if (!match) return null;
+  return { headline: match[1], targetPodId: match[2] };
+};
+
 const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agentDisplayNames, agentAuthorKeys, onAuthorClick }) => {
   const { currentUser } = useAuth();
+  const navigate = useNavigate();
   const rawUsername = message.user?.username || 'Unknown';
   const overriddenDisplay = agentDisplayNames?.get(rawUsername);
   const author = overriddenDisplay || rawUsername;
@@ -234,6 +251,40 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
   const isClickable = !!onAuthorClick && !!agentAuthorKeys?.has(rawUsername.toLowerCase());
   const handleAuthorClick = isClickable ? () => onAuthorClick?.(rawUsername) : undefined;
   const time = formatRelativeTime(message.created_at);
+
+  // §3.8 system event card. Detected by content shape (commonly-bot only
+  // posts this exact form), so we don't depend on a metadata column the PG
+  // messages table doesn't have. Render a chrome-light card with a
+  // router-aware "Open conversation" button — never a new tab.
+  const dmEvent = parseAgentDmEvent(message.content);
+  if (dmEvent) {
+    return (
+      <div className="v2-msg v2-msg--system">
+        <div className="v2-syscard">
+          <div className="v2-syscard__icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
+              <circle cx="9" cy="7" r="4" />
+              <path d="M23 21v-2a4 4 0 00-3-3.87" />
+              <path d="M16 3.13a4 4 0 010 7.75" />
+            </svg>
+          </div>
+          <div className="v2-syscard__body">
+            <div className="v2-syscard__headline">{dmEvent.headline}</div>
+            {time && <div className="v2-syscard__time">{time}</div>}
+          </div>
+          <button
+            type="button"
+            className="v2-syscard__cta"
+            onClick={() => navigate(`/v2/pods/${dmEvent.targetPodId}`)}
+          >
+            Open conversation
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   // Two-pass parse: reactions first (they live anywhere in the body), then
   // files. Order matters — files leave a trimmed body that we then read for
   // image rendering.

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -9,6 +9,7 @@ import {
 import { useV2Api } from '../hooks/useV2Api';
 import { UseV2PodsResult, V2PodMember } from '../hooks/useV2Pods';
 import { useSocket } from '../../context/SocketContext';
+import { useAuth } from '../../context/AuthContext';
 import { initialsFor } from '../utils/avatars';
 
 const PLAN_MODE_KEY = 'v2.podMode';
@@ -135,6 +136,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
   const navigate = useNavigate();
   const api = useV2Api();
   const { socket, connected } = useSocket();
+  const { currentUser } = useAuth();
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
   const [uploading, setUploading] = useState(false);
@@ -443,6 +445,26 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
     );
   }
 
+  // §3.7 read-access: humans can VIEW agent-dm rooms when they share a pod
+  // with one of the bots, but they cannot post unless they're a formal member
+  // (which they never are for bot↔bot rooms). Detect that case so we can
+  // swap the composer for an explanatory banner instead of letting the user
+  // type and silently 401.
+  const currentUserId = currentUser?._id || null;
+  const isPodMember = !!currentUserId && (members || []).some(
+    (m) => m && m._id === currentUserId,
+  );
+  const isAgentDm = pod.type === 'agent-dm';
+  const isReadOnly = isAgentDm && !isPodMember;
+
+  // Bot-bot agent-dm — used to choose the "X and Y haven't talked yet" empty
+  // state and to phrase the read-only banner appropriately.
+  const botMembers = (members || []).filter((m) => m?.isBot);
+  const isBotToBot = isAgentDm && botMembers.length >= 2 && botMembers.length === (members || []).length;
+  const botPair = isBotToBot
+    ? botMembers.slice(0, 2).map((m) => m.username || 'Agent')
+    : null;
+
   const handleSend = async () => {
     if (!draft.trim() || sending) return;
     setSending(true);
@@ -600,8 +622,22 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
               )}
               {!loading && messages.length === 0 && (
                 <div className="v2-empty">
-                  <div className="v2-empty__title">Talk to your team</div>
-                  <div className="v2-empty__text">Type a message, or @-mention an agent to direct your first task.</div>
+                  {isBotToBot && botPair ? (
+                    <>
+                      <div className="v2-empty__title">{botPair[0]} and {botPair[1]} haven&apos;t talked yet</div>
+                      <div className="v2-empty__text">They&apos;ll DM each other when one of them needs the other&apos;s help.</div>
+                    </>
+                  ) : isAgentDm ? (
+                    <>
+                      <div className="v2-empty__title">No messages yet</div>
+                      <div className="v2-empty__text">This is a private 1:1 conversation. Say hello to get started.</div>
+                    </>
+                  ) : (
+                    <>
+                      <div className="v2-empty__title">Talk to your team</div>
+                      <div className="v2-empty__text">Type a message, or @-mention an agent to direct your first task.</div>
+                    </>
+                  )}
                 </div>
               )}
               {messages.map((m) => (
@@ -618,6 +654,24 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
 
             <TypingIndicator agents={typingAgents} />
 
+            {isReadOnly ? (
+              <div className="v2-chat__readonly" role="note" aria-label="Read-only conversation">
+                <div className="v2-chat__readonly-icon" aria-hidden="true">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                    <path d="M7 11V7a5 5 0 0110 0v4" />
+                  </svg>
+                </div>
+                <div className="v2-chat__readonly-body">
+                  <div className="v2-chat__readonly-title">Read-only — you&apos;re observing this conversation</div>
+                  <div className="v2-chat__readonly-text">
+                    {isBotToBot && botPair
+                      ? `${botPair[0]} and ${botPair[1]} are talking directly. To engage them, @-mention either in a shared team pod.`
+                      : 'You can read this 1:1 but not post. To engage, @-mention the agent in a shared team pod.'}
+                  </div>
+                </div>
+              </div>
+            ) : (
             <div className="v2-chat__composer">
               <div className="v2-chat__composer-input-wrap">
                 <textarea
@@ -732,6 +786,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
                 <span><kbd>⌘</kbd><kbd>↵</kbd> to send</span>
               </div>
             </div>
+            )}
       </div>
     </main>
   );

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -232,7 +232,32 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({ selectedPodId, podsState 
     }, { all: 0, team: 0, private: 0 })
   ), [pods]);
 
-  const grouped = useMemo(() => groupPods(filtered, pinned), [filtered, pinned]);
+  // Default grouping is chronological (Pinned / Today / Yesterday / This week
+  // / Earlier). When the user filters down to Private, recency buckets stop
+  // adding signal — DMs are already a tight list — and the meaningful split
+  // is human↔agent vs agent↔agent. Bot-bot rooms are observer-only (§3.7),
+  // so a section header makes the relationship explicit at a glance and
+  // doubles as a count of how many a2a conversations are happening.
+  const grouped = useMemo(() => {
+    if (filter !== 'private') return groupPods(filtered, pinned);
+    const sortByRecency = <T extends { lastMessage?: { createdAt?: string | Date | null } | null; updatedAt?: string | Date; createdAt?: string | Date }>(items: T[]): T[] => {
+      const ts = (it: T) => {
+        const raw = it.lastMessage?.createdAt || it.updatedAt || it.createdAt;
+        const n = raw ? new Date(raw).getTime() : 0;
+        return Number.isNaN(n) ? 0 : n;
+      };
+      return [...items].sort((a, b) => ts(b) - ts(a));
+    };
+    const pinnedItems = filtered.filter((p) => pinned.has(p._id));
+    const rest = filtered.filter((p) => !pinned.has(p._id));
+    const a2a = rest.filter((p) => isAgentToAgent(p));
+    const dms = rest.filter((p) => !isAgentToAgent(p));
+    const buckets: Array<{ label: string; items: typeof filtered }> = [];
+    if (pinnedItems.length) buckets.push({ label: 'Pinned', items: sortByRecency(pinnedItems) });
+    if (dms.length) buckets.push({ label: 'Direct messages', items: sortByRecency(dms) });
+    if (a2a.length) buckets.push({ label: `Between agents · ${a2a.length}`, items: sortByRecency(a2a) });
+    return buckets;
+  }, [filter, filtered, pinned]);
 
   const handleCreatePod = async (event: React.FormEvent) => {
     event.preventDefault();

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -1404,6 +1404,121 @@
   margin: 0 2px;
 }
 
+/* Read-only banner shown in place of the composer when the viewer can read
+   an agent-dm pod (§3.7) but isn't a formal member. Styled as a soft note,
+   not an error — being a read-only observer is the intended state. */
+.v2-chat__readonly {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  margin: 12px 16px 16px;
+  background: var(--v2-bg-subtle);
+  border: 1px solid var(--v2-border-soft);
+  border-radius: var(--v2-radius);
+}
+
+.v2-chat__readonly-icon {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--v2-radius-pill);
+  background: var(--v2-accent-soft);
+  color: var(--v2-accent-text);
+}
+
+.v2-chat__readonly-body {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.v2-chat__readonly-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v2-text-primary);
+}
+
+.v2-chat__readonly-text {
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--v2-text-secondary);
+}
+
+/* §3.8 system event card — replaces the regular author/avatar bubble for
+   commonly-bot announcements like "Pixel and codex started a DM". One-row,
+   chrome-light, with a primary CTA that navigates internally. */
+.v2-msg--system {
+  padding: 6px 0;
+}
+
+.v2-syscard {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  background: var(--v2-accent-soft);
+  border: 1px solid var(--v2-border-soft);
+  border-radius: var(--v2-radius);
+}
+
+.v2-syscard__icon {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--v2-radius-pill);
+  background: var(--v2-surface);
+  color: var(--v2-accent-text);
+}
+
+.v2-syscard__body {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.v2-syscard__headline {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v2-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.v2-syscard__time {
+  font-size: 11.5px;
+  color: var(--v2-text-secondary);
+}
+
+.v2-root button.v2-syscard__cta,
+.v2-syscard__cta {
+  flex: 0 0 auto;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: #fff;
+  background: var(--v2-accent);
+  border: 1px solid var(--v2-accent-strong);
+  border-radius: var(--v2-radius-pill);
+  padding: 6px 14px;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.v2-root button.v2-syscard__cta:hover,
+.v2-syscard__cta:hover {
+  background: var(--v2-accent-strong);
+}
+
 /* @-mention dropdown anchored to the composer input wrap. Sits above the
    composer in DOM order but renders above-and-out via absolute positioning. */
 .v2-mention-dropdown {


### PR DESCRIPTION
## Summary

Four small UX cuts to make agent-dm rooms feel intentional rather than half-built. All four are independent, all four are scoped to v2.

| # | Gap | Component |
|---|---|---|
| 1 | Read-only banner + composer disable for non-members | \`V2PodChat\` |
| 2 | System event card for \"🤝 X and Y started a DM\" | \`V2MessageBubble\` + \`v2.css\` |
| 3 | \"Between agents · N\" sub-section in Private filter | \`V2PodsSidebar\` |
| 4 | Fresh-room empty state for agent-dm | \`V2PodChat\` |

### #1 — Read-only banner

When the viewer can read an agent-dm pod via §3.7 (shares a pod with one of the bots) but isn't a formal member, today the composer is enabled and \`send\` 401s silently. Replace the composer with a \`.v2-chat__readonly\` banner: \"Read-only — these two agents are talking. To engage, @-mention either in a shared team pod.\"

### #2 — System event card

§3.8 already posts \"🤝 X and Y started a DM — [view](/v2/pods/<id>)\" via commonly-bot when an agent-dm is created with \`originPodId\`. The existing \`<a target=_blank>\` markdown anchor rendered the internal route as a new-tab link — wrong UX for in-app navigation. \`V2MessageBubble\` now detects the announcement by content shape and renders a \`.v2-syscard\` row with a router-aware \"Open conversation\" button.

### #3 — \"Between agents · N\" sub-section

Agent-dm rooms (bot↔bot, observer-only) used to fold under the Private filter next to user↔agent rooms with only the AA icon as differentiator. Top-level tab would overstate it (humans don't own these rooms — they're observers). Sub-section catches the eye and the count badge ticks up live during the demo. Override grouping when \`filter === 'private'\`: three buckets — Pinned, Direct messages, Between agents.

### #4 — Empty state copy

Generic \"Talk to your team\" replaced for bot↔bot rooms with \"{Bot A} and {Bot B} haven't talked yet — they'll DM each other when one of them needs the other's help.\" Mixed / one-bot agent-dm gets a softer \"No messages yet — say hello to get started.\"

## Test plan

- [x] \`tsc --noEmit\` clean on touched files
- [x] \`react-scripts build\` clean
- [ ] Browser-verify on dev: navigate to a bot↔bot agent-dm pod as a non-member → confirm read-only banner shows + composer is gone
- [ ] Browser-verify on dev: create an agent-dm with \`originPodId\` → confirm \"Open conversation\" card appears in the origin pod's chat and clicking it navigates internally (no new tab)
- [ ] Browser-verify on dev: filter sidebar to \"Private\" with at least one A2A room → confirm \"Between agents · N\" header appears
- [ ] Browser-verify on dev: open a fresh empty agent-dm → confirm new empty-state copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)