### PR TITLE
test(provisioner): drop trinity from fallback assertion (matches PR #282)

### DIFF
--- a/backend/__tests__/unit/services/agentProvisionerServiceK8s.test.js
+++ b/backend/__tests__/unit/services/agentProvisionerServiceK8s.test.js
@@ -279,9 +279,12 @@ describe('agentProvisionerServiceK8s', () => {
     // gateway-level default — nemotron, no openai-codex. Codex is gated to
     // dev agents via the per-agent override in provisionOpenClawAccount.
     expect(config.agents.defaults.model.primary).toBe('openrouter/nvidia/nemotron-3-super-120b-a12b:free');
+    // Trinity removed 2026-05-03 (deregistered at OpenRouter, 404). Gemini
+    // entries remain as inert placeholders until GEMINI_API_KEY is reinstated.
     expect(config.agents.defaults.model.fallbacks).toEqual(
-      expect.arrayContaining(['openrouter/arcee-ai/trinity-large-preview:free', 'google/gemini-2.5-flash']),
+      expect.arrayContaining(['google/gemini-2.5-flash']),
     );
+    expect(config.agents.defaults.model.fallbacks).not.toContain('openrouter/arcee-ai/trinity-large-preview:free');
     expect(config.agents.defaults.model.fallbacks).not.toContain('openai-codex/gpt-5.4-mini');
     expect(config.agents.defaults.model.fallbacks).not.toContain('openai-codex/gpt-5.4');
   });


### PR DESCRIPTION
## Why

PR #282 dropped \`arcee-ai/trinity-large-preview:free\` from the community fallback chain (model is dead at OpenRouter, 404 No endpoints found). Test in \`agentProvisionerServiceK8s.test.js\` was still asserting trinity must be present, so it now red-bars on every PR.

This was the only \"Test & Coverage\" failure caused by PR #282. There are two **pre-existing** failures on main I'm flagging separately:
- \`__tests__/unit/controllers/podController.test.js\` — 4 tests broken (populate signature drift, joinPod 403 expectation)
- \`__tests__/services/dmService.test.ts\` — 2 tests broken (agent-room name expectation drifted)

Those are unrelated to the burn fix and need their own investigation.

## What

- Update assertion to require \`gemini-2.5-flash\` present (still inert until GEMINI_API_KEY restored)
- Add explicit \`not.toContain('trinity')\` regression guard
- Preserve the existing openai-codex/* exclusion checks

## Test plan

- [ ] CI \"Test & Coverage\" now passes for the provisioner test (other failures persist; tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)