### PR TITLE
fix(provisioner): state-sync silently failing — Python NameError on JSON booleans

### DIFF
--- a/backend/services/agentProvisionerServiceK8s.ts
+++ b/backend/services/agentProvisionerServiceK8s.ts
@@ -217,8 +217,18 @@ const execInPod = async ({ podName, containerName = 'clawdbot-gateway', command 
       false,
       (status: any) => {
         const success = status?.status === 'Success' || !status || !status?.status;
-        if (success) resolve();
-        else reject(new Error(status?.message || `Pod exec failed with status: ${status?.status}`));
+        if (success) {
+          resolve();
+        } else {
+          // Include captured stderr in the error message — kubelet's "command
+          // terminated with non-zero exit code" alone is useless for debugging
+          // (lost an hour to a Python NameError that was sitting in stderr the
+          // whole time). Truncate to keep log lines reasonable.
+          const stderrTail = err.trim().slice(-2000);
+          const baseMsg = status?.message || `Pod exec failed with status: ${status?.status}`;
+          const msg = stderrTail ? `${baseMsg}\nstderr: ${stderrTail}` : baseMsg;
+          reject(new Error(msg));
+        }
       },
     ).catch(reject);
   });
@@ -467,6 +477,15 @@ const syncAccountToStateMoltbot = async (accountId: any, accountEntry: any, agen
     return;
   }
 
+  // Embed structured data as JSON strings, then parse with json.loads at
+  // runtime. Direct JSON.stringify(...) interpolation produces lowercase
+  // `true`/`false`/`null` which are valid JSON but NOT valid Python literals
+  // (Python wants `True`/`False`/`None`) — so any embedded boolean (e.g.
+  // `memorySearch.enabled: true`) raised NameError, the script exited 1, and
+  // every state-sync silently failed. Double-encoding through JSON.stringify
+  // yields a valid Python string literal that json.loads parses back.
+  const pyJsonLiteral = (value: any) => JSON.stringify(JSON.stringify(value ?? null));
+
   const script = [
     'set -eu',
     'STATE=/state/moltbot.json',
@@ -474,11 +493,11 @@ const syncAccountToStateMoltbot = async (accountId: any, accountEntry: any, agen
     `python3 - <<'PYEOF'`,
     'import json, sys',
     'with open("/state/moltbot.json") as f: d = json.load(f)',
-    `account_id = ${JSON.stringify(accountId)}`,
-    `account_entry = ${JSON.stringify(accountEntry)}`,
-    `agent_entry = ${JSON.stringify(agentEntry)}`,
-    `binding = ${JSON.stringify(binding)}`,
-    `agents_defaults = ${JSON.stringify(agentsDefaults || null)}`,
+    `account_id = json.loads(${pyJsonLiteral(accountId)})`,
+    `account_entry = json.loads(${pyJsonLiteral(accountEntry)})`,
+    `agent_entry = json.loads(${pyJsonLiteral(agentEntry)})`,
+    `binding = json.loads(${pyJsonLiteral(binding)})`,
+    `agents_defaults = json.loads(${pyJsonLiteral(agentsDefaults || null)})`,
     // Global agents.defaults — overwrite on every sync. Without this the
     // gateway carries forward whatever was written on first provision,
     // even after applyOpenClawModelDefaults changes the desired default.


### PR DESCRIPTION
## Root cause

Every \`syncAccountToStateMoltbot\` call from the JS provisioner has been silently failing since \`2a4bc1314d\` (2026-05-02). Result: the gateway PVC \`/state/moltbot.json\` ignored every config update — including the new \`defaults.model.primary = nemotron\` that should have stopped the Codex burn at the source.

The bug:
\`\`\`ts
\`agents_defaults = \${JSON.stringify(agentsDefaults)}\`,   // emits Python source
\`\`\`
produces lowercase \`true\` / \`false\` / \`null\` — valid JSON, **not valid Python** (Python wants \`True\`/\`False\`/\`None\`). The first embedded boolean (\`memorySearch.enabled: true\`) raised \`NameError: name 'true' is not defined\`, python exited 1, the kubelet returned \"command terminated with non-zero exit code\", and \`execInPod\` rejected without surfacing the python stderr that explained why.

## Why it took so long to find

\`execInPod\` only included the kubelet's generic message in the rejected error. Python's NameError sat in the captured stderr buffer but was thrown away. So the user saw 250+ \"Failed to sync account\" log lines with no clue what python actually did. Hour-long debugging chased every wrong direction (websocket flake, race conditions, set-eu) before noticing the lowercase booleans.

## Fix

1. **Double-encode JSON through \`JSON.stringify\`** — the result is a valid Python string literal, parsed at runtime via \`json.loads\`. Works for booleans, null, nested objects, unicode without manual escaping.
2. **Include captured stderr in \`execInPod\` error messages.** Truncate to last 2KB. Next time a python-in-a-pod script breaks, the actual error will show up in backend logs instead of being silently swallowed.

## Test plan

- [ ] Deploy Dev runs green
- [ ] After deploy: trigger \`reprovision-all\`. Backend logs show \`[k8s-provisioner] synced X to /state/moltbot.json\` for every account, **zero** \"Failed to sync account\" lines.
- [ ] PVC \`/state/moltbot.json\`:
  - \`agents.defaults.model.primary == openrouter/nvidia/nemotron-3-super-120b-a12b:free\` (currently sticky from manual patch — this PR proves it lands automatically)
  - \`models.providers.openrouter\` populated
  - No trinity references anywhere
- [ ] Trigger a community-agent heartbeat (fakesam/liz/x-curator). LiteLLM logs show nemotron call succeeding. Codex weekly counters do not advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)