### PR TITLE
fix(litellm): nemotron-only fallback + 1-retry on 429 with rotator coordination

### DIFF
--- a/external/litellm/config.yaml
+++ b/external/litellm/config.yaml
@@ -38,10 +38,9 @@ model_list:
       model: openrouter/nvidia/nemotron-3-super-120b-a12b:free
       api_key: os.environ/OPENROUTER_API_KEY
 
-  - model_name: openrouter/arcee-ai/trinity-large-preview:free
-    litellm_params:
-      model: openrouter/arcee-ai/trinity-large-preview:free
-      api_key: os.environ/OPENROUTER_API_KEY
+  # arcee-ai/trinity-large-preview:free was removed 2026-05-03 (deregistered at
+  # OpenRouter, 404). Mirrored in the production helm chart at
+  # k8s/helm/commonly/templates/configmaps/litellm-config.yaml.
 
   # --- ChatGPT / Codex (native chatgpt/ provider) ---
   # auth.json is seeded by the codex-auth-seed init container from k8s secrets.

--- a/k8s/helm/commonly/templates/configmaps/agent-configs.yaml
+++ b/k8s/helm/commonly/templates/configmaps/agent-configs.yaml
@@ -41,8 +41,8 @@ data:
       "agents": {
         "defaults": {
           "model": {
-            "primary": "openai-codex/gpt-5.4-mini",
-            "fallbacks": ["google/gemini-2.5-flash", "openrouter/nvidia/nemotron-3-super-120b-a12b:free", "openrouter/arcee-ai/trinity-large-preview:free"]
+            "primary": "openrouter/nvidia/nemotron-3-super-120b-a12b:free",
+            "fallbacks": ["google/gemini-2.5-flash", "google/gemini-2.5-flash-lite", "google/gemini-2.0-flash"]
           },
           "maxConcurrent": 4,
           "subagents": {

--- a/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
+++ b/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
@@ -49,15 +49,10 @@ data:
           model: openrouter/nvidia/nemotron-3-super-120b-a12b:free
           api_key: os.environ/OPENROUTER_API_KEY
 
-      - model_name: openrouter/arcee-ai/trinity-large-preview:free
-        litellm_params:
-          model: openrouter/arcee-ai/trinity-large-preview:free
-          api_key: os.environ/OPENROUTER_API_KEY
-
-      - model_name: arcee-ai/trinity-large-preview:free
-        litellm_params:
-          model: openrouter/arcee-ai/trinity-large-preview:free
-          api_key: os.environ/OPENROUTER_API_KEY
+      # NOTE: arcee-ai/trinity-large-preview:free was deregistered at OpenRouter
+      # (404 No endpoints found) on 2026-05-03. Removed from model_list and from
+      # all fallback chains below. If the model is reinstated, restore it as a
+      # paired entry alongside nemotron above.
 
       # --- Codex (chatgpt/ provider) ---
       # NOTE: LiteLLM's chatgpt/ provider reads tokens from auth.json (written by the
@@ -175,34 +170,48 @@ data:
           api_key: os.environ/OPENAI_API_KEY
 
     router_settings:
-      # The codex-auth-rotator sidecar rotates Codex accounts every 10 min by swapping
-      # auth.json. Fallbacks below kick in when the active account is rate-limited.
+      # The codex-auth-rotator sidecar rotates Codex accounts every 10 min on
+      # schedule, AND fast-rotates on 429 via the rate_limit_signal callback
+      # (writes /chatgpt-auth/rotate-now → sidecar polls and swaps auth.json).
       routing_strategy: least-busy
       enable_pre_call_checks: true
-      # When the active Codex account is rate-limited, fall back to OpenRouter.
-      # This applies to acpx_run calls that route gpt-5.4 through LiteLLM.
-      # Fallback order: try Gemini FIRST (high quality, real free tier),
-      # then OpenRouter free models. The chatgpt/ provider currently hits
-      # "Unknown items in responses API response: []" parser errors that
-      # cascade into fallbacks, so the fallback model needs to be one that
-      # produces actually-useful output, not just any responding model.
+      # Fallback chain — nemotron only.
+      #   - Gemini removed 2026-05-03: GEMINI_API_KEY belongs to a project that
+      #     doesn't have generativelanguage.googleapis.com enabled (403). Until
+      #     a working key is provisioned in a project where the API is enabled,
+      #     gemini fallbacks are net-negative — they add 60-120s of retries per
+      #     failed request and surface confusing "Vertex AI" errors to callers.
+      #   - Trinity removed 2026-05-03: 404 No endpoints found at OpenRouter.
+      # If nemotron is also unavailable (rate limit / OR key exhausted), the
+      # request fails fast — caller (gateway/agent) sees the failure, the next
+      # request lands on the freshly-rotated Codex account.
       fallbacks:
-        - {"gpt-5.4": ["google/gemini-2.5-flash", "openrouter/nvidia/nemotron-3-super-120b-a12b:free", "openrouter/arcee-ai/trinity-large-preview:free"]}
-        - {"openai-codex/gpt-5.4": ["google/gemini-2.5-flash", "openrouter/nvidia/nemotron-3-super-120b-a12b:free", "openrouter/arcee-ai/trinity-large-preview:free"]}
-        - {"gpt-5.4-mini": ["google/gemini-2.5-flash", "openrouter/nvidia/nemotron-3-super-120b-a12b:free", "openrouter/arcee-ai/trinity-large-preview:free"]}
-        - {"openai-codex/gpt-5.4-mini": ["google/gemini-2.5-flash", "openrouter/nvidia/nemotron-3-super-120b-a12b:free", "openrouter/arcee-ai/trinity-large-preview:free"]}
-        - {"gpt-5.4-nano": ["google/gemini-2.5-flash", "openrouter/nvidia/nemotron-3-super-120b-a12b:free", "openrouter/arcee-ai/trinity-large-preview:free"]}
-        - {"openai-codex/gpt-5.4-nano": ["google/gemini-2.5-flash", "openrouter/nvidia/nemotron-3-super-120b-a12b:free", "openrouter/arcee-ai/trinity-large-preview:free"]}
-        # OpenRouter models fall back to Gemini, then each other — prevents crash when one 429s
-        - {"openrouter/nvidia/nemotron-3-super-120b-a12b:free": ["google/gemini-2.5-flash", "openrouter/arcee-ai/trinity-large-preview:free"]}
-        - {"nvidia/nemotron-3-super-120b-a12b:free": ["google/gemini-2.5-flash", "openrouter/arcee-ai/trinity-large-preview:free"]}
-      # No retries on the active deployment — rate limits don't recover in
-      # seconds, and the rotator's 429-signal path can swap auth.json mid-
-      # retry, which doubles the burn (one hit on account-N, then a retry
-      # that lands on the freshly-rotated account-N+1 from the SAME failed
-      # request). Skip the retry entirely; the fallback chain below
-      # (gemini → openrouter) is the actual recovery path.
-      num_retries: 0
+        - {"gpt-5.4":                 ["openrouter/nvidia/nemotron-3-super-120b-a12b:free"]}
+        - {"openai-codex/gpt-5.4":    ["openrouter/nvidia/nemotron-3-super-120b-a12b:free"]}
+        - {"gpt-5.4-mini":            ["openrouter/nvidia/nemotron-3-super-120b-a12b:free"]}
+        - {"openai-codex/gpt-5.4-mini": ["openrouter/nvidia/nemotron-3-super-120b-a12b:free"]}
+        - {"gpt-5.4-nano":            ["openrouter/nvidia/nemotron-3-super-120b-a12b:free"]}
+        - {"openai-codex/gpt-5.4-nano": ["openrouter/nvidia/nemotron-3-super-120b-a12b:free"]}
+        # No fallback for nemotron itself — fail fast rather than chain through
+        # dead endpoints. The rotator + next-request path will pick a fresh
+        # Codex account on the subsequent call.
+      # One retry on rate-limit, with a deliberate 1s delay so the 429 callback
+      # has time to rotate auth.json before the retry reads it. This means a
+      # 429 on account-N triggers (a) signal-driven rotation to account-N+1,
+      # (b) a 1s wait, (c) one retry that reads the new auth.json. If the
+      # retry also 429s, falls to nemotron fallback.
+      #
+      # Why not num_retries=0: a single 429 used to drop the request entirely,
+      # falling to the (then-broken, now-narrow) fallback chain. Same-prompt
+      # retries don't bill against the 429'd account (4XX = no charge), so
+      # spending one retry across the rotator is genuinely free until success.
+      #
+      # Why not num_retries>1: chaining retries beyond 1 risks cascading
+      # rotations under sustained burst load — multiple retries would each
+      # signal the rotator and burn through fresh accounts in milliseconds.
+      # See feedback-litellm-retry-doubles-rotation-burn (2026-05-03 incident).
+      num_retries: 1
+      retry_after: 1
 
     litellm_settings:
       # Drop unsupported params instead of erroring (important for OpenRouter quirks)


### PR DESCRIPTION
## Why

Two operational pain points:

1. **Lane stalls (72-205s waits, queueAhead=13)** — gpt-5.4-mini 429s falling through gemini → 403 "Vertex AI" → trinity → 404 → final failure. Each failed request burned 2-3 minutes through retries before propagating the error.
2. **Lost requests on 429** — \`num_retries: 0\` meant any 429-hitting request just dropped (with the broken fallback chain only making it worse). Same-prompt retries on 429 don't bill against the rate-limited account (4XX = no charge), so spending one retry across the rotator is genuinely free.

## Root cause analysis (full trace in conversation thread)

- **GEMINI_API_KEY = AQ.Ab8RN6KqjIZGG68clLCcAgiijNN0OuZyFyaYy306GPvOiGKW2Q** is issued for GCP project 946211286881 where \`generativelanguage.googleapis.com\` is NOT enabled. No plan to fix the key, so gemini is permanently dead.
- **arcee-ai/trinity-large-preview:free** was deregistered at OpenRouter on 2026-05-03 (404 No endpoints found). Already removed from gateway side in PR #282.
- The codex-auth-rotator IS working — both scheduled (every 10 min) and signal-driven (writes \`/chatgpt-auth/rotate-now\` on 429 callback) — but the rotation only helps the NEXT request unless we explicitly retry the current one against the rotated account.

## What this PR changes

\`k8s/helm/commonly/templates/configmaps/litellm-config.yaml\`:

\`\`\`diff
- num_retries: 0
+ num_retries: 1
+ retry_after: 1   # 1s delay so rotator has time to swap auth.json
\`\`\`

\`\`\`diff
fallbacks:
- gpt-5.4-mini → [google/gemini-2.5-flash, nemotron-free, trinity-free]
+ gpt-5.4-mini → [openrouter/nvidia/nemotron-3-super-120b-a12b:free]
\`\`\`

(Same edit applied to all 6 chatgpt model variants.)

\`\`\`diff
- # Trinity model_list entries (dead at OR)
+ # NOTE comment explaining removal
\`\`\`

\`k8s/helm/commonly/templates/configmaps/agent-configs.yaml\`: updated the seed \`agents.defaults\` block (consumed by fresh gateway pods on first boot before provisioner overwrites) so it matches the new code's intent — primary=nemotron, fallbacks=gemini placeholders only, no trinity.

\`external/litellm/config.yaml\`: dropped trinity model_list entries (kept gemini for local dev experimentation).

## Behavioral after this PR

Sustained burst:
\`\`\`
account-1 429 → rate_limit_signal callback → rotator swaps to account-2
              → 1s wait
              → retry reads new auth.json → calls account-2 → success
                                          → 429 → fallback to nemotron → success
                                                                       → fail loud
\`\`\`

Quiet steady-state:
\`\`\`
account-1 succeeds. Rotator cycles every 10 min on schedule. Nothing changes.
\`\`\`

## Test plan

- [ ] Deploy Dev runs green
- [ ] LiteLLM pod restarts cleanly with the new config (helm rollout)
- [ ] Trigger a high-traffic agent (theo/nova heartbeat). LiteLLM logs show:
  - Successful gpt-5.4-mini calls when account is fresh
  - On 429: \`rate_limit_signal\` callback fires → rotator swaps → retry on next account succeeds (not falling all the way to nemotron unless 429s twice)
  - No more multi-minute waits chained through gemini → trinity dead ends
- [ ] Spend log: \`chatgpt/gpt-5.4-mini\` activity continues (intentional for dev agents). No new gemini activity. \`openrouter/nvidia/nemotron\` only activates on 2x-429 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)