### PR TITLE
test(ci): repair 3 pre-existing test failures on main

### DIFF
--- a/backend/__tests__/services/dmService.test.ts
+++ b/backend/__tests__/services/dmService.test.ts
@@ -48,7 +48,9 @@ describe('DMService — agent rooms', () => {
       email: 'task-clerk@agent.local',
       password: 'placeholder',
       isBot: true,
-      botMetadata: { agentName: 'task-clerk', instanceId: 'default' },
+      // displayName is the canonical room-label source per
+      // f9ff990c23 (dmService no longer constructs "<runtime> (<instance>)").
+      botMetadata: { agentName: 'task-clerk', instanceId: 'default', displayName: 'task-clerk' },
     });
     humanUser = await User.create({
       username: 'alice',
@@ -106,13 +108,45 @@ describe('DMService — agent rooms', () => {
     expect(allRooms).toHaveLength(2);
   });
 
-  it('names the room with instanceId suffix for non-default instances', async () => {
+  it('uses the agent user displayName for the room label, not function args', async () => {
+    // f9ff990c23 made room labels read from User.botMetadata.displayName so an
+    // agent's heartbeat doesn't render confusing "openclaw (aria)"-style names
+    // back into chat. The function-arg agentName is only the last-resort
+    // fallback when the agent user has no botMetadata at all.
+    const liz = await User.create({
+      username: 'liz-research',
+      email: 'liz@agent.local',
+      password: 'placeholder',
+      isBot: true,
+      botMetadata: { agentName: 'openclaw', instanceId: 'research', displayName: 'Liz' },
+    });
+
     const room = await DMService.getOrCreateAgentRoom(
-      agentUser._id,
+      liz._id,
       humanUser._id,
       { agentName: 'liz', instanceId: 'research' },
     );
 
-    expect(room.name).toBe('liz (research)');
+    // displayName wins over agentName/instanceId function args.
+    expect(room.name).toBe('Liz');
+  });
+
+  it('falls back to instanceId when displayName missing and instanceId is non-default', async () => {
+    const tarik = await User.create({
+      username: 'tarik-prod',
+      email: 'tarik@agent.local',
+      password: 'placeholder',
+      isBot: true,
+      // No displayName — resolution falls through to instanceId since it's not 'default'.
+      botMetadata: { agentName: 'openclaw', instanceId: 'tarik' },
+    });
+
+    const room = await DMService.getOrCreateAgentRoom(
+      tarik._id,
+      humanUser._id,
+      { agentName: 'openclaw', instanceId: 'tarik' },
+    );
+
+    expect(room.name).toBe('tarik');
   });
 });

--- a/backend/__tests__/unit/controllers/podController.test.js
+++ b/backend/__tests__/unit/controllers/podController.test.js
@@ -38,6 +38,10 @@ jest.mock('../../../services/agentIdentityService', () => ({
   getAgentTypeConfig: jest.fn(),
   getOrCreateAgentUser: jest.fn(),
   ensureAgentInPod: jest.fn(),
+  // joinPod does `require('../services/agentIdentityService').DM_POD_TYPES_GUARD`
+  // at runtime to enforce ADR-001 §3.10 (no third-party joins on DM pods).
+  // Mirror the production set so the test exercises the real guard.
+  DM_POD_TYPES_GUARD: new Set(['agent-room', 'agent-dm']),
 }));
 
 describe('podController', () => {
@@ -100,7 +104,7 @@ describe('podController', () => {
 
     expect(save).toHaveBeenCalled();
     expect(savedPod.populate).toHaveBeenCalledWith('createdBy', 'username profilePicture');
-    expect(savedPod.populate).toHaveBeenCalledWith('members', 'username profilePicture');
+    expect(savedPod.populate).toHaveBeenCalledWith('members', 'username profilePicture isBot');
     expect(AgentInstallation.install).toHaveBeenCalledWith('commonly-bot', 'p1', expect.objectContaining({
       installedBy: 'creator',
       instanceId: 'default',
@@ -187,7 +191,7 @@ describe('podController', () => {
     expect(pod.members).toEqual(['creator']);
     expect(pod.save).toHaveBeenCalled();
     expect(pod.populate).toHaveBeenCalledWith('createdBy', 'username profilePicture');
-    expect(pod.populate).toHaveBeenCalledWith('members', 'username profilePicture');
+    expect(pod.populate).toHaveBeenCalledWith('members', 'username profilePicture isBot');
     expect(res.json).toHaveBeenCalledWith(pod);
   });
 

--- a/backend/__tests__/unit/routes/registry.list-agents-config.test.js
+++ b/backend/__tests__/unit/routes/registry.list-agents-config.test.js
@@ -32,6 +32,32 @@ jest.mock('../../../models/AgentEvent', () => ({
   aggregate: jest.fn().mockResolvedValue([]),
 }));
 
+// User.find is called inside the GET /pods/:podId/agents handler to resolve
+// botMetadata.displayName for each install. Without a mock the handler waits
+// on the real Mongoose model (no DB connection in this unit test) and times
+// out at 10s.
+jest.mock('../../../models/User', () => ({
+  find: jest.fn().mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue([]),
+    }),
+  }),
+}));
+
+// dmService.canViewPod is required at runtime via require(); the handler's
+// first call is `await DMService.canViewPod(userId, pod)`. The real
+// implementation reads `Pod.countDocuments` which isn't on our jest mock —
+// stub the whole service so the test exercises the route, not auth fan-out.
+jest.mock('../../../services/dmService', () => ({
+  canViewPod: jest.fn().mockResolvedValue(true),
+}));
+
+// AgentIdentityService.buildAgentUsername is called to compose the user lookup
+// keys; stub it so the un-mocked module's deps don't load.
+jest.mock('../../../services/agentIdentityService', () => ({
+  buildAgentUsername: jest.fn((agentName, instanceId) => `${agentName}-${instanceId}`),
+}));
+
 const Pod = require('../../../models/Pod');
 const AgentProfile = require('../../../models/AgentProfile');
 const AgentTemplate = require('../../../models/AgentTemplate');


### PR DESCRIPTION
## Why

\`Test & Coverage\` has red-barred every PR since #275 due to three test files that drifted from legitimate production refactors:

| Test file | Tests failing | Root cause |
|---|---|---|
| \`podController.test.js\` | 4 | Controller added \`isBot\` to populate signature; \`joinPod\` requires \`DM_POD_TYPES_GUARD\` at runtime |
| \`dmService.test.ts\` | 2 | \`f9ff990c23\` changed agent-room naming to displayName chain; tests still asserted old \`<runtime> (<instance>)\` format |
| \`registry.list-agents-config.test.js\` | 1 (timeout) | Route added User/DMService/AgentIdentityService deps; test didn't mock them, real Mongoose User.find queued forever |

## What

**podController.test.js**
- Update populate expectations to \`'username profilePicture isBot'\`
- Add \`DM_POD_TYPES_GUARD: new Set(['agent-room', 'agent-dm'])\` to the agentIdentityService jest mock so \`joinPod\`'s runtime require returns the guard rather than \`{}\`

**dmService.test.ts**
- Fixture: add \`botMetadata.displayName: 'task-clerk'\` so the resolution chain returns the expected label
- Replace \`names the room with instanceId suffix\` (asserts dead format) with two intent-aligned tests: displayName overrides function args, instanceId is the fallback when displayName missing and instanceId is non-default

**registry.list-agents-config.test.js**
- Add jest mocks for \`models/User\`, \`services/dmService\`, \`services/agentIdentityService\` (the route's other deps)

## Test plan

- [ ] \`Test & Coverage\` job goes green for the 7 previously-failing tests
- [ ] No new failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)