### PR TITLE
feat(memory): ADR-012 Phase 1 — system_exchanges + DM conversational frame

### DIFF
--- a/backend/__tests__/service/agent-memory-envelope.test.js
+++ b/backend/__tests__/service/agent-memory-envelope.test.js
@@ -858,4 +858,96 @@ describe('AgentMemory envelope — GET/PUT /memory + backfill', () => {
       expect(get.body.sections.long_term.content).toBe('dedup-me');
     });
   });
+
+  // ------------------------------------------------------------------- //
+  // ADR-012 §1 — system_exchanges is read-only over the agent tool surface
+  // ------------------------------------------------------------------- //
+  describe('system_exchanges (ADR-012 read-only enforcement)', () => {
+    it('PUT /memory rejects writes to system_exchanges with 403 + tagged reason', async () => {
+      const res = await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({
+          sections: {
+            system_exchanges: {
+              entries: [{
+                ts: new Date().toISOString(),
+                kind: 'agent-dm-conclusion',
+                surfacePodId: testPod._id.toString(),
+                surfaceLabel: 'agent-dm:test',
+                peers: [],
+                takeaway: 'forged from agent',
+              }],
+            },
+          },
+        });
+      expect(res.status).toBe(403);
+      expect(res.body.reason).toBe('system_exchanges_is_read_only');
+    });
+
+    it('POST /memory/sync also rejects system_exchanges with the same 403', async () => {
+      const res = await request(app)
+        .post('/api/agents/runtime/memory/sync')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({
+          mode: 'patch',
+          sections: { system_exchanges: { entries: [] } },
+        });
+      expect(res.status).toBe(403);
+      expect(res.body.reason).toBe('system_exchanges_is_read_only');
+    });
+
+    it('GET /memory surfaces system_exchanges entries written via appendSystemExchange', async () => {
+      const install = await AgentInstallation.findOne({ agentName: 'mem-agent' });
+      const { appendSystemExchange } = require('../../services/agentMemoryService');
+      await appendSystemExchange({
+        agentName: install.agentName,
+        instanceId: install.instanceId || 'default',
+        kind: 'task-completed',
+        surfacePodId: testPod._id.toString(),
+        surfaceLabel: 'team:Memory Pod',
+        peers: [],
+        takeaway: 'shipped ADR-012 phase 1',
+      });
+
+      const res = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      expect(res.status).toBe(200);
+      expect(res.body.sections.system_exchanges.entries).toHaveLength(1);
+      expect(res.body.sections.system_exchanges.entries[0].kind).toBe('task-completed');
+      expect(res.body.sections.system_exchanges.entries[0].takeaway).toBe('shipped ADR-012 phase 1');
+      expect(res.body.sections.system_exchanges.visibility).toBe('private');
+    });
+
+    it('PUT /memory to a writable section does NOT clobber an existing system_exchanges entry', async () => {
+      const install = await AgentInstallation.findOne({ agentName: 'mem-agent' });
+      const { appendSystemExchange } = require('../../services/agentMemoryService');
+      await appendSystemExchange({
+        agentName: install.agentName,
+        instanceId: install.instanceId || 'default',
+        kind: 'agent-dm-loop-trip',
+        surfacePodId: testPod._id.toString(),
+        surfaceLabel: 'agent-dm:test',
+        peers: ['peer-1'],
+        takeaway: '8 consecutive bot turns within 30 min — guard tripped',
+      });
+
+      // Agent writes long_term — this used to clear lastSyncKey/lastSyncAt and
+      // shouldn't touch system_exchanges. Section-merge via dotted $set
+      // preserves siblings.
+      await request(app)
+        .put('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({ sections: { long_term: { content: 'agent notes' } } })
+        .expect(200);
+
+      const res = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      expect(res.body.sections.long_term.content).toBe('agent notes');
+      expect(res.body.sections.system_exchanges.entries).toHaveLength(1);
+      expect(res.body.sections.system_exchanges.entries[0].kind).toBe('agent-dm-loop-trip');
+    });
+  });
 });

--- a/backend/__tests__/unit/services/agentMemoryService.systemExchanges.test.ts
+++ b/backend/__tests__/unit/services/agentMemoryService.systemExchanges.test.ts
@@ -1,0 +1,235 @@
+// @ts-nocheck
+// ADR-012 Phase 1: tests for the system_exchanges section + appendSystemExchange
+// helper. Covers:
+//   - schema acceptance + the 'private'-only enum
+//   - takeaway truncation (truncateTakeaway pure function)
+//   - appendSystemExchange most-recent-first ordering
+//   - cap enforcement (50 entries; oldest evicted on overflow)
+//   - revision monotonicity
+//   - the AGENT_WRITABLE_SECTIONS allow-list (system_exchanges is excluded)
+//   - invariant 8a: appendSystemExchange does NOT clear lastSyncKey/lastSyncAt
+
+const AgentMemory = require('../../../models/AgentMemory');
+const {
+  appendSystemExchange,
+  truncateTakeaway,
+  isAgentWritableSection,
+} = require('../../../services/agentMemoryService');
+const {
+  SYSTEM_EXCHANGE_TAKEAWAY_MAX,
+  SYSTEM_EXCHANGE_ENTRY_CAP,
+  AGENT_WRITABLE_SECTIONS,
+} = require('../../../models/AgentMemory');
+const { setupMongoDb, closeMongoDb, clearMongoDb } = require('../../utils/testUtils');
+
+describe('truncateTakeaway (pure)', () => {
+  it('passes through strings under the cap', () => {
+    expect(truncateTakeaway('short')).toBe('short');
+    expect(truncateTakeaway('')).toBe('');
+  });
+
+  it('appends a single ellipsis when over the cap and never exceeds it', () => {
+    const long = 'x'.repeat(SYSTEM_EXCHANGE_TAKEAWAY_MAX + 50);
+    const out = truncateTakeaway(long);
+    expect(out.length).toBeLessThanOrEqual(SYSTEM_EXCHANGE_TAKEAWAY_MAX);
+    expect(out.endsWith('…')).toBe(true);
+    // Reserve exactly 1 char for the ellipsis.
+    expect(out).toBe('x'.repeat(SYSTEM_EXCHANGE_TAKEAWAY_MAX - 1) + '…');
+  });
+
+  it('coerces non-strings without throwing', () => {
+    expect(truncateTakeaway(null)).toBe('');
+    expect(truncateTakeaway(undefined)).toBe('');
+    expect(truncateTakeaway(42)).toBe('42');
+  });
+});
+
+describe('isAgentWritableSection', () => {
+  it('accepts every entry in AGENT_WRITABLE_SECTIONS', () => {
+    for (const key of AGENT_WRITABLE_SECTIONS) {
+      expect(isAgentWritableSection(key)).toBe(true);
+    }
+  });
+
+  it('rejects system_exchanges (the read-only section)', () => {
+    expect(isAgentWritableSection('system_exchanges')).toBe(false);
+  });
+
+  it('rejects unknown keys', () => {
+    expect(isAgentWritableSection('not_a_section')).toBe(false);
+    expect(isAgentWritableSection('')).toBe(false);
+  });
+});
+
+describe('appendSystemExchange (DB-backed)', () => {
+  beforeAll(async () => { await setupMongoDb(); });
+  afterAll(async () => { await closeMongoDb(); });
+  afterEach(async () => { await clearMongoDb(); });
+
+  const baseEntry = {
+    agentName: 'pixel',
+    instanceId: 'default',
+    kind: 'agent-dm-conclusion',
+    surfacePodId: '69f7b89aabbccddeeff00011',
+    surfaceLabel: 'agent-dm:69f7b89a',
+    peers: ['codex-1'],
+    takeaway: 'shipped the auth patch',
+  };
+
+  it('creates the envelope on first call and seeds the entry most-recent-first', async () => {
+    const result = await appendSystemExchange({ ...baseEntry, ts: new Date('2026-05-03T00:00:00Z') });
+    expect(result?.revision).toBe(1);
+
+    const doc = await AgentMemory.findOne({ agentName: 'pixel', instanceId: 'default' }).lean();
+    expect(doc?.sections?.system_exchanges?.entries).toHaveLength(1);
+    expect(doc?.sections?.system_exchanges?.entries[0].kind).toBe('agent-dm-conclusion');
+    expect(doc?.sections?.system_exchanges?.entries[0].takeaway).toBe('shipped the auth patch');
+    expect(doc?.sections?.system_exchanges?.visibility).toBe('private');
+    expect(doc?.revision).toBe(1);
+  });
+
+  it('appends new entries at position 0 (most-recent-first)', async () => {
+    await appendSystemExchange({ ...baseEntry, takeaway: 'first', ts: new Date('2026-05-03T00:00:00Z') });
+    await appendSystemExchange({ ...baseEntry, takeaway: 'second', ts: new Date('2026-05-03T00:01:00Z') });
+    await appendSystemExchange({ ...baseEntry, takeaway: 'third', ts: new Date('2026-05-03T00:02:00Z') });
+
+    const doc = await AgentMemory.findOne({ agentName: 'pixel', instanceId: 'default' }).lean();
+    const ts = doc.sections.system_exchanges.entries.map((e) => e.takeaway);
+    expect(ts).toEqual(['third', 'second', 'first']);
+    expect(doc.revision).toBe(3);
+  });
+
+  it('caps entries at SYSTEM_EXCHANGE_ENTRY_CAP and evicts the oldest', async () => {
+    const total = SYSTEM_EXCHANGE_ENTRY_CAP + 5;
+    for (let i = 0; i < total; i += 1) {
+      // Sequential awaits so revisions land in order.
+      // eslint-disable-next-line no-await-in-loop
+      await appendSystemExchange({ ...baseEntry, takeaway: `entry-${i}`, ts: new Date(2026, 4, 3, 0, i) });
+    }
+    const doc = await AgentMemory.findOne({ agentName: 'pixel', instanceId: 'default' }).lean();
+    expect(doc.sections.system_exchanges.entries).toHaveLength(SYSTEM_EXCHANGE_ENTRY_CAP);
+    // Newest first: most recent push is `entry-${total-1}`.
+    expect(doc.sections.system_exchanges.entries[0].takeaway).toBe(`entry-${total - 1}`);
+    // Oldest in window is `entry-${total - CAP}` — evicted before that.
+    expect(doc.sections.system_exchanges.entries[SYSTEM_EXCHANGE_ENTRY_CAP - 1].takeaway).toBe(
+      `entry-${total - SYSTEM_EXCHANGE_ENTRY_CAP}`,
+    );
+    expect(doc.revision).toBe(total);
+  });
+
+  it('truncates takeaway to the schema cap', async () => {
+    const long = 'y'.repeat(SYSTEM_EXCHANGE_TAKEAWAY_MAX + 100);
+    await appendSystemExchange({ ...baseEntry, takeaway: long });
+    const doc = await AgentMemory.findOne({ agentName: 'pixel', instanceId: 'default' }).lean();
+    expect(doc.sections.system_exchanges.entries[0].takeaway.length).toBeLessThanOrEqual(SYSTEM_EXCHANGE_TAKEAWAY_MAX);
+    expect(doc.sections.system_exchanges.entries[0].takeaway.endsWith('…')).toBe(true);
+  });
+
+  it('rejects unknown kinds (returns null without writing)', async () => {
+    const result = await appendSystemExchange({ ...baseEntry, kind: 'bogus-kind' });
+    expect(result).toBeNull();
+    const doc = await AgentMemory.findOne({ agentName: 'pixel', instanceId: 'default' }).lean();
+    expect(doc).toBeNull();
+  });
+
+  it('does not clear lastSyncKey / lastSyncAt (ADR-003 invariant 8a carve-out)', async () => {
+    // Seed an envelope with a known sync state.
+    const seededAt = new Date('2026-05-02T12:00:00Z');
+    await AgentMemory.create({
+      agentName: 'pixel',
+      instanceId: 'default',
+      content: 'legacy',
+      lastSyncKey: '2026-05-02:openclaw:abcdef',
+      lastSyncAt: seededAt,
+    });
+
+    await appendSystemExchange({ ...baseEntry });
+
+    const doc = await AgentMemory.findOne({ agentName: 'pixel', instanceId: 'default' }).lean();
+    expect(doc.lastSyncKey).toBe('2026-05-02:openclaw:abcdef');
+    // Date precision: ensure preserved.
+    expect(new Date(doc.lastSyncAt).getTime()).toBe(seededAt.getTime());
+    expect(doc.sections.system_exchanges.entries).toHaveLength(1);
+  });
+
+  it('writes to two peers without cross-contamination', async () => {
+    const ts = new Date('2026-05-03T01:00:00Z');
+    await appendSystemExchange({
+      agentName: 'pixel', instanceId: 'default',
+      kind: 'agent-dm-conclusion',
+      surfacePodId: '69f7b89aabbccddeeff00011',
+      surfaceLabel: 'agent-dm:peers',
+      peers: ['codex-1'],
+      takeaway: 'pixel POV', ts,
+    });
+    await appendSystemExchange({
+      agentName: 'codex', instanceId: 'codex-1',
+      kind: 'agent-dm-conclusion',
+      surfacePodId: '69f7b89aabbccddeeff00011',
+      surfaceLabel: 'agent-dm:peers',
+      peers: ['default'],
+      takeaway: 'codex POV', ts,
+    });
+
+    const pixel = await AgentMemory.findOne({ agentName: 'pixel', instanceId: 'default' }).lean();
+    const codex = await AgentMemory.findOne({ agentName: 'codex', instanceId: 'codex-1' }).lean();
+    expect(pixel.sections.system_exchanges.entries[0].takeaway).toBe('pixel POV');
+    expect(pixel.sections.system_exchanges.entries[0].peers).toEqual(['codex-1']);
+    expect(codex.sections.system_exchanges.entries[0].takeaway).toBe('codex POV');
+    expect(codex.sections.system_exchanges.entries[0].peers).toEqual(['default']);
+  });
+
+  it('returns null on missing required identity fields', async () => {
+    expect(await appendSystemExchange({ ...baseEntry, agentName: '' })).toBeNull();
+    expect(await appendSystemExchange({ ...baseEntry, instanceId: '' })).toBeNull();
+    expect(await appendSystemExchange({ ...baseEntry, surfacePodId: '' })).toBeNull();
+  });
+});
+
+describe('AgentMemory schema — system_exchanges', () => {
+  beforeAll(async () => { await setupMongoDb(); });
+  afterAll(async () => { await closeMongoDb(); });
+  afterEach(async () => { await clearMongoDb(); });
+
+  it("rejects visibility != 'private' on the system_exchanges section", async () => {
+    await expect(
+      AgentMemory.create({
+        agentName: 'pixel',
+        instanceId: 'default',
+        sections: {
+          system_exchanges: {
+            entries: [],
+            visibility: 'public',
+          },
+        },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("rejects entries with unknown 'kind'", async () => {
+    await expect(
+      AgentMemory.create({
+        agentName: 'pixel',
+        instanceId: 'default',
+        sections: {
+          system_exchanges: {
+            entries: [{
+              ts: new Date(),
+              kind: 'unknown-kind',
+              surfacePodId: 'pod1',
+              surfaceLabel: '',
+              peers: [],
+              takeaway: '',
+            }],
+          },
+        },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('defaults revision and lastSeenRevision to 0 on insert', async () => {
+    const doc = await AgentMemory.create({ agentName: 'pixel', instanceId: 'fresh' });
+    expect(doc.revision).toBe(0);
+    expect(doc.lastSeenRevision).toBe(0);
+  });
+});

--- a/backend/models/AgentMemory.ts
+++ b/backend/models/AgentMemory.ts
@@ -47,7 +47,10 @@ export interface ISystemExchangesSection {
   entries: ISystemExchangeEntry[];   // most recent first; cap at 50 (ADR-012 §5)
   visibility: 'private';             // hard-coded; widening is closed
   updatedAt: Date;
-  byteSize: number;
+  // ADR-012 Phase 1 deliberately omits `byteSize` — appendSystemExchange does
+  // not maintain it under concurrent $push, and no Phase 1 reader consumes
+  // it. Phase 2's digest builder recomputes from `entries` directly. Re-add
+  // here when there's a reader that benefits from the cached value.
 }
 
 export interface IAgentMemorySections {
@@ -176,7 +179,7 @@ const systemExchangesSectionSchema = new Schema<ISystemExchangesSection>(
     // attempt to widen at the document level fails Mongoose validation.
     visibility: { type: String, enum: ['private'], default: 'private' },
     updatedAt: { type: Date, default: Date.now },
-    byteSize: { type: Number, default: 0 },
+    // byteSize intentionally omitted in Phase 1 — see ISystemExchangesSection.
   },
   { _id: false },
 );

--- a/backend/models/AgentMemory.ts
+++ b/backend/models/AgentMemory.ts
@@ -26,6 +26,30 @@ export interface IRelationshipNote {
   updatedAt: Date;
 }
 
+// ADR-012 §1: structured entries for system-driven exchange records.
+// Visibility is hard-coded 'private' at the schema level (see ADR-012 §6).
+export type SystemExchangeKind =
+  | 'agent-dm-conclusion'
+  | 'agent-dm-loop-trip'
+  | 'task-completed'
+  | 'cross-pod-mention'; // reserved for v1.x — not emitted in v1 (ADR-012 §4)
+
+export interface ISystemExchangeEntry {
+  ts: Date;                          // when the event happened
+  kind: SystemExchangeKind;
+  surfacePodId: string;              // where the event happened
+  surfaceLabel: string;              // human-readable, e.g. "agent-dm:69f7..." or "team:Backend Tasks"
+  peers: string[];                   // other instanceIds involved (excluding self)
+  takeaway: string;                  // ≤ 280 chars; verbatim metadata in v1
+}
+
+export interface ISystemExchangesSection {
+  entries: ISystemExchangeEntry[];   // most recent first; cap at 50 (ADR-012 §5)
+  visibility: 'private';             // hard-coded; widening is closed
+  updatedAt: Date;
+  byteSize: number;
+}
+
 export interface IAgentMemorySections {
   soul?: IMemorySection;
   long_term?: IMemorySection;
@@ -34,6 +58,9 @@ export interface IAgentMemorySections {
   relationships?: IRelationshipNote[];
   shared?: IMemorySection;
   runtime_meta?: IMemorySection;
+  // ADR-012: system-driven exchange records. Read-only from the agent's
+  // tool surface; written only by platform hooks (agentMemoryService.appendSystemExchange).
+  system_exchanges?: ISystemExchangesSection;
 }
 
 export interface IAgentMemory extends Document {
@@ -48,11 +75,43 @@ export interface IAgentMemory extends Document {
   // within the same day bucket return early with { deduped: true }.
   lastSyncKey?: string;
   lastSyncAt?: Date;
+  // ADR-012: monotone revision bumped on every system_exchanges write.
+  // memoryDigest in CAP event payload is computed against `lastSeenRevision`.
+  revision?: number;
+  lastSeenRevision?: number;
   createdAt: Date;
   updatedAt: Date;
 }
 
 export const VISIBILITY_VALUES: MemoryVisibility[] = ['private', 'pod', 'public'];
+
+// ADR-012 §4: trigger taxonomy. v1 emits the first three; cross-pod-mention
+// is reserved for v1.x consideration.
+export const SYSTEM_EXCHANGE_KINDS: SystemExchangeKind[] = [
+  'agent-dm-conclusion',
+  'agent-dm-loop-trip',
+  'task-completed',
+  'cross-pod-mention',
+];
+
+// ADR-012 §1: ≤280 chars, enforced server-side (truncation responsibility
+// lives in appendSystemExchange callers — schema validates the post-truncation
+// invariant). The cap also bounds the digest serialization budget.
+export const SYSTEM_EXCHANGE_TAKEAWAY_MAX = 280;
+// ADR-012 §5: count-bounded eviction. Oldest entry evicted on overflow.
+export const SYSTEM_EXCHANGE_ENTRY_CAP = 50;
+// ADR-012 §1 — writable sections (the agent's tool can address these via
+// commonly_save_my_memory). `system_exchanges` is intentionally excluded.
+export const AGENT_WRITABLE_SECTIONS = [
+  'soul',
+  'long_term',
+  'dedup_state',
+  'shared',
+  'runtime_meta',
+  'daily',
+  'relationships',
+] as const;
+export type AgentWritableSection = typeof AGENT_WRITABLE_SECTIONS[number];
 
 // Phase 1 invariant: all section sub-fields use `default: undefined` so a newly
 // created envelope does NOT auto-insert empty sub-documents. Callers opt in to
@@ -89,6 +148,39 @@ const relationshipNoteSchema = new Schema<IRelationshipNote>(
   { _id: false },
 );
 
+const systemExchangeEntrySchema = new Schema<ISystemExchangeEntry>(
+  {
+    ts: { type: Date, required: true },
+    kind: { type: String, enum: SYSTEM_EXCHANGE_KINDS, required: true },
+    surfacePodId: { type: String, required: true },
+    surfaceLabel: { type: String, default: '' },
+    peers: { type: [String], default: [] },
+    takeaway: {
+      type: String,
+      default: '',
+      // ADR-012 §1: 280-char cap. Callers truncate with `…` suffix; the
+      // schema guards against bypass. Validation runs on $push via runValidators.
+      validate: {
+        validator: (v: string) => typeof v === 'string' && v.length <= SYSTEM_EXCHANGE_TAKEAWAY_MAX,
+        message: `takeaway must be ≤ ${SYSTEM_EXCHANGE_TAKEAWAY_MAX} chars`,
+      },
+    },
+  },
+  { _id: false },
+);
+
+const systemExchangesSectionSchema = new Schema<ISystemExchangesSection>(
+  {
+    entries: { type: [systemExchangeEntrySchema], default: [] },
+    // ADR-012 §6: hard-coded 'private'. The enum is single-valued so any
+    // attempt to widen at the document level fails Mongoose validation.
+    visibility: { type: String, enum: ['private'], default: 'private' },
+    updatedAt: { type: Date, default: Date.now },
+    byteSize: { type: Number, default: 0 },
+  },
+  { _id: false },
+);
+
 const agentMemorySectionsSchema = new Schema<IAgentMemorySections>(
   {
     soul: { type: memorySectionSchema, default: undefined },
@@ -98,6 +190,7 @@ const agentMemorySectionsSchema = new Schema<IAgentMemorySections>(
     relationships: { type: [relationshipNoteSchema], default: undefined },
     shared: { type: memorySectionSchema, default: undefined },
     runtime_meta: { type: memorySectionSchema, default: undefined },
+    system_exchanges: { type: systemExchangesSectionSchema, default: undefined },
   },
   { _id: false },
 );
@@ -112,6 +205,11 @@ const agentMemorySchema = new Schema<IAgentMemory>(
     schemaVersion: { type: Number, default: undefined },
     lastSyncKey: { type: String, default: undefined },
     lastSyncAt: { type: Date, default: undefined },
+    // ADR-012 §2: monotone revision; bumped on every appendSystemExchange.
+    // lastSeenRevision is bumped when an event carrying memoryDigest is acked
+    // (Phase 2). Both default to 0 so a fresh agent's first digest is empty.
+    revision: { type: Number, default: 0 },
+    lastSeenRevision: { type: Number, default: 0 },
   },
   { timestamps: true },
 );

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -1552,8 +1552,15 @@ router.post('/threads/:threadId/comments', agentRuntimeAuth, async (req: any, re
 // explicit full/patch mode lands in Phase 2.
 
 // Single source of truth — shared with the model schema.
-const { VISIBILITY_VALUES } = require('../models/AgentMemory');
+const { VISIBILITY_VALUES, AGENT_WRITABLE_SECTIONS } = require('../models/AgentMemory');
 const VALID_VISIBILITIES = new Set(VISIBILITY_VALUES);
+const VALID_WRITABLE_SECTIONS = new Set<string>(AGENT_WRITABLE_SECTIONS);
+
+// ADR-012 §1: the agent's tool surface MUST NOT write `system_exchanges`.
+// Validators return a tagged error so the route can map to 403 (not 400).
+type SectionsValidationError =
+  | { kind: 'bad_request'; message: string }
+  | { kind: 'system_exchanges_read_only' };
 
 function resolveMemoryIdentity(req: any): { agentName?: string; instanceId: string } {
   const agentInstallation = req.agentInstallation;
@@ -1568,46 +1575,66 @@ function resolveMemoryIdentity(req: any): { agentName?: string; instanceId: stri
   return { agentName, instanceId };
 }
 
-function validateSectionsPayload(sections: any): string | null {
+function validateSectionsPayload(sections: any): SectionsValidationError | null {
   if (typeof sections !== 'object' || sections === null || Array.isArray(sections)) {
-    return 'sections must be an object';
+    return { kind: 'bad_request', message: 'sections must be an object' };
   }
   if (Object.keys(sections).length === 0) {
-    return 'sections must have at least one key';
+    return { kind: 'bad_request', message: 'sections must have at least one key' };
   }
-  const allowed = new Set(['soul', 'long_term', 'dedup_state', 'shared', 'runtime_meta', 'daily', 'relationships']);
   for (const key of Object.keys(sections)) {
-    if (!allowed.has(key)) return `unknown section: ${key}`;
+    // ADR-012 §1: explicit rejection for the read-only system section.
+    // Surfaced separately from the generic "unknown section" path so callers
+    // (and CAP test harnesses) can distinguish "you can't write here" from
+    // "we don't know what that is."
+    if (key === 'system_exchanges') {
+      return { kind: 'system_exchanges_read_only' };
+    }
+    if (!VALID_WRITABLE_SECTIONS.has(key)) {
+      return { kind: 'bad_request', message: `unknown section: ${key}` };
+    }
   }
   const singleSectionKeys = ['soul', 'long_term', 'dedup_state', 'shared', 'runtime_meta'];
   for (const key of singleSectionKeys) {
     const s = sections[key];
     if (s === undefined) continue;
-    if (typeof s !== 'object' || s === null) return `sections.${key} must be an object`;
-    if (s.content !== undefined && typeof s.content !== 'string') return `sections.${key}.content must be a string`;
+    if (typeof s !== 'object' || s === null) return { kind: 'bad_request', message: `sections.${key} must be an object` };
+    if (s.content !== undefined && typeof s.content !== 'string') return { kind: 'bad_request', message: `sections.${key}.content must be a string` };
     if (s.visibility !== undefined && !VALID_VISIBILITIES.has(s.visibility)) {
-      return `sections.${key}.visibility must be one of private|pod|public`;
+      return { kind: 'bad_request', message: `sections.${key}.visibility must be one of private|pod|public` };
     }
   }
   if (sections.daily !== undefined) {
-    if (!Array.isArray(sections.daily)) return 'sections.daily must be an array';
+    if (!Array.isArray(sections.daily)) return { kind: 'bad_request', message: 'sections.daily must be an array' };
     for (const d of sections.daily) {
-      if (!isValidYMD(d?.date)) return 'sections.daily[].date must be YYYY-MM-DD';
+      if (!isValidYMD(d?.date)) return { kind: 'bad_request', message: 'sections.daily[].date must be YYYY-MM-DD' };
       if (d.visibility !== undefined && !VALID_VISIBILITIES.has(d.visibility)) {
-        return 'sections.daily[].visibility must be one of private|pod|public';
+        return { kind: 'bad_request', message: 'sections.daily[].visibility must be one of private|pod|public' };
       }
     }
   }
   if (sections.relationships !== undefined) {
-    if (!Array.isArray(sections.relationships)) return 'sections.relationships must be an array';
+    if (!Array.isArray(sections.relationships)) return { kind: 'bad_request', message: 'sections.relationships must be an array' };
     for (const r of sections.relationships) {
-      if (typeof r?.otherInstanceId !== 'string') return 'sections.relationships[].otherInstanceId must be a string';
+      if (typeof r?.otherInstanceId !== 'string') return { kind: 'bad_request', message: 'sections.relationships[].otherInstanceId must be a string' };
       if (r.visibility !== undefined && !VALID_VISIBILITIES.has(r.visibility)) {
-        return 'sections.relationships[].visibility must be one of private|pod|public';
+        return { kind: 'bad_request', message: 'sections.relationships[].visibility must be one of private|pod|public' };
       }
     }
   }
   return null;
+}
+
+// Map a SectionsValidationError onto an HTTP response. 400 for shape errors;
+// 403 + tagged reason for ADR-012 §1's `system_exchanges_is_read_only`.
+function sendSectionsError(res: any, err: SectionsValidationError): any {
+  if (err.kind === 'system_exchanges_read_only') {
+    return res.status(403).json({
+      message: 'system_exchanges is read-only',
+      reason: 'system_exchanges_is_read_only',
+    });
+  }
+  return res.status(400).json({ message: err.message });
 }
 
 /**
@@ -1673,7 +1700,7 @@ router.put('/memory', agentRuntimeAuth, async (req: any, res: any) => {
     }
     if (sections !== undefined) {
       const sectionsError = validateSectionsPayload(sections);
-      if (sectionsError) return res.status(400).json({ message: sectionsError });
+      if (sectionsError) return sendSectionsError(res, sectionsError);
     }
     if (sourceRuntime !== undefined && typeof sourceRuntime !== 'string') {
       return res.status(400).json({ message: 'sourceRuntime must be a string' });
@@ -1759,7 +1786,13 @@ router.post('/memory/sync', agentRuntimeAuth, async (req: any, res: any) => {
     };
     if (sections === undefined) return rejectAndLog('sections is required');
     const sectionsError = validateSectionsPayload(sections);
-    if (sectionsError) return rejectAndLog(sectionsError);
+    if (sectionsError) {
+      if (sectionsError.kind === 'system_exchanges_read_only') {
+        console.log('[agent-memory SYNC reject]', { agentName, instanceId, reason: 'system_exchanges_is_read_only' });
+        return sendSectionsError(res, sectionsError);
+      }
+      return rejectAndLog(sectionsError.message);
+    }
     if (sourceRuntime !== undefined && typeof sourceRuntime !== 'string') {
       return rejectAndLog('sourceRuntime must be a string');
     }

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -225,6 +225,28 @@ router.post('/:podId/:taskId/complete', auth, async (req: AuthReq, res: Res) => 
         }
       })();
     }
+    // ADR-012 §4: task-completed trigger. Fire-and-forget; only writes when
+    // the assignee is a recognized agent member of the pod.
+    try {
+      // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+      const triggers = require('../services/systemExchangeTriggers') as {
+        recordTaskCompleted: (a: {
+          podId: string;
+          assignee?: string | null;
+          taskTitle: string;
+          prUrlOrStatus?: string | null;
+        }) => Promise<void>;
+      };
+      const taskWithFields = task as { title?: string; assignee?: string | null; prUrl?: string | null };
+      void triggers.recordTaskCompleted({
+        podId: String(podId),
+        assignee: taskWithFields.assignee ?? null,
+        taskTitle: taskWithFields.title || '',
+        prUrlOrStatus: prUrl || taskWithFields.prUrl || null,
+      });
+    } catch (triggerErr) {
+      console.warn('[system-exchange] task-completed dispatch failed:', (triggerErr as Error).message);
+    }
     emitTaskUpdated(podId, task, 'updated');
     return res.json({ task });
   } catch (err) {

--- a/backend/services/agentMemoryService.ts
+++ b/backend/services/agentMemoryService.ts
@@ -1,12 +1,30 @@
 import crypto from 'crypto';
 
+import AgentMemory, {
+  AGENT_WRITABLE_SECTIONS,
+  SYSTEM_EXCHANGE_ENTRY_CAP,
+  SYSTEM_EXCHANGE_TAKEAWAY_MAX,
+  SYSTEM_EXCHANGE_KINDS,
+} from '../models/AgentMemory';
 import type {
+  AgentWritableSection,
   IAgentMemorySections,
   IDailySection,
   IMemorySection,
   IRelationshipNote,
+  ISystemExchangeEntry,
   MemoryVisibility,
+  SystemExchangeKind,
 } from '../models/AgentMemory';
+
+// ADR-012 §1: allow-list test for the agent-facing write tool. Returns true
+// only for sections agents are permitted to address via `commonly_save_my_memory`
+// (PUT /memory and POST /memory/sync). `system_exchanges` is excluded by
+// construction.
+const AGENT_WRITABLE_SET = new Set<string>(AGENT_WRITABLE_SECTIONS);
+export function isAgentWritableSection(key: string): key is AgentWritableSection {
+  return AGENT_WRITABLE_SET.has(key);
+}
 
 // Valid YYYY-MM-DD — ADR-003 daily[].date shape. Strict: must be a calendar-
 // valid date (Date.parse rejects e.g. 2026-02-30).
@@ -329,5 +347,124 @@ export function filterSectionsByVisibility(
     if (filteredRel.length > 0) out.relationships = filteredRel;
   }
 
+  // ADR-012 §6 + ADR-003 §Visibility: system_exchanges is intentionally
+  // omitted from this filter's output. It is hard-coded `private` and
+  // never legible to non-owners, so cross-agent readers must never see it
+  // even when (theoretically) some entry's visibility flag matched. We
+  // leave the section out of the function entirely — a code reader who
+  // adds it later will be forced to revisit the privacy rule.
+
   return out;
+}
+
+// ADR-012 §1: takeaway truncation. Keeps the first N chars; on overflow,
+// reserves 1 char for the `…` suffix so the final length never exceeds the
+// schema cap. Defensive against non-string input — callers building takeaway
+// from message content can hand us anything.
+export function truncateTakeaway(
+  raw: unknown,
+  max: number = SYSTEM_EXCHANGE_TAKEAWAY_MAX,
+): string {
+  const s = typeof raw === 'string' ? raw : (raw == null ? '' : String(raw));
+  if (s.length <= max) return s;
+  // Reserve 1 char for `…`. max >= 1 by contract (schema cap is 280).
+  return s.slice(0, Math.max(0, max - 1)) + '…';
+}
+
+// ADR-012 §4: append a system-driven exchange entry. Single atomic Mongo
+// update — `$push + $position:0 + $slice:N` enforces most-recent-first +
+// count cap, `$inc:revision` bumps the monotone revision consumed by
+// memoryDigest, `$currentDate` stamps `system_exchanges.updatedAt`.
+//
+// Concurrency: two concurrent appendSystemExchange calls on the same
+// (agentName, instanceId) serialize at the document level — single-document
+// atomicity guarantees neither lost-updates the other (ADR-012 §4).
+//
+// Carve-out from ADR-003 invariant 8: this writer does NOT clear
+// `lastSyncKey`/`lastSyncAt`. Drivers don't promote `system_exchanges`, so
+// a system write to it is invisible to the sync dedup contract — see
+// ADR-012 §8 (invariant 8a).
+export interface AppendSystemExchangeArgs {
+  agentName: string;
+  instanceId: string;
+  kind: SystemExchangeKind;
+  surfacePodId: string;
+  surfaceLabel?: string;
+  peers?: string[];
+  takeaway?: string;
+  ts?: Date;
+}
+
+export async function appendSystemExchange(
+  args: AppendSystemExchangeArgs,
+): Promise<{ revision: number } | null> {
+  const {
+    agentName,
+    instanceId,
+    kind,
+    surfacePodId,
+    surfaceLabel = '',
+    peers = [],
+    takeaway = '',
+    ts = new Date(),
+  } = args;
+
+  if (!agentName || !instanceId) {
+    return null;
+  }
+  if (!SYSTEM_EXCHANGE_KINDS.includes(kind)) {
+    return null;
+  }
+  if (!surfacePodId || typeof surfacePodId !== 'string') {
+    return null;
+  }
+
+  const entry: ISystemExchangeEntry = {
+    ts,
+    kind,
+    surfacePodId: String(surfacePodId),
+    surfaceLabel: typeof surfaceLabel === 'string' ? surfaceLabel : String(surfaceLabel ?? ''),
+    peers: Array.isArray(peers) ? peers.filter((p) => typeof p === 'string') : [],
+    takeaway: truncateTakeaway(takeaway),
+  };
+
+  // Single atomic op — works whether the doc exists, the `sections` envelope
+  // exists, or `sections.system_exchanges` exists. Mongo auto-creates
+  // intermediate path nodes for `$push`. `$setOnInsert` handles the upsert
+  // of the doc-level keys; `$set` on sibling section fields runs on every
+  // call (idempotent — visibility is hard-coded 'private', and updatedAt is
+  // bumped via $currentDate). Two concurrent appends serialize at the doc
+  // level (single-document atomicity, ADR-012 §4).
+  //
+  // Note on byteSize: we don't maintain a running byte counter here. v1
+  // writes leave it at 0 (or whatever the initial schema default produces)
+  // and recompute lazily when the digest builder serializes. Maintaining it
+  // accurately under concurrent $push without a read-modify-write is
+  // expensive and adds nothing the digest can't derive.
+  const updated = await AgentMemory.findOneAndUpdate(
+    { agentName, instanceId },
+    {
+      $push: {
+        'sections.system_exchanges.entries': {
+          $each: [entry],
+          $position: 0,
+          $slice: SYSTEM_EXCHANGE_ENTRY_CAP,
+        },
+      },
+      $inc: { revision: 1 },
+      $set: {
+        // Hard-coded private — never widened. Re-setting on every call is
+        // idempotent and survives any prior corrupted state.
+        'sections.system_exchanges.visibility': 'private',
+      },
+      $currentDate: { 'sections.system_exchanges.updatedAt': true },
+      $setOnInsert: {
+        agentName,
+        instanceId,
+      },
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true, runValidators: true },
+  ).select({ revision: 1 }).lean<{ revision?: number } | null>();
+
+  return { revision: updated?.revision ?? 1 };
 }

--- a/backend/services/agentMemoryService.ts
+++ b/backend/services/agentMemoryService.ts
@@ -181,6 +181,12 @@ export function stampSectionsForWrite(
     const v = sections[key];
     if (v === undefined) continue;
 
+    // ADR-012 §1: system_exchanges is read-only via the agent surface.
+    // validateSectionsPayload rejects it before it reaches here; this is
+    // defense-in-depth and also keeps the union-typed `out[key]` assignment
+    // below provably safe (the IMemorySection branch can't widen to system_exchanges).
+    if (key === 'system_exchanges') continue;
+
     if (key === 'daily') {
       out.daily = ((v as IDailySection[]) || []).map((d): IDailySection => ({
         date: d.date,
@@ -201,7 +207,11 @@ export function stampSectionsForWrite(
     }
 
     const s = v as IMemorySection;
-    out[key] = makeSection(s.content ?? '', s.visibility ?? 'private', now);
+    (out as Record<string, IMemorySection>)[key] = makeSection(
+      s.content ?? '',
+      s.visibility ?? 'private',
+      now,
+    );
   }
   return out;
 }
@@ -227,6 +237,11 @@ export function mergePatchSections(
     const inc = incoming[key];
     if (inc === undefined) continue;
 
+    // ADR-012 §1: agents cannot patch `system_exchanges`. validateSectionsPayload
+    // rejects it upstream — this guard keeps mergePatchSections safe even if
+    // someone calls it from outside the route.
+    if (key === 'system_exchanges') continue;
+
     if (key === 'daily') {
       const byDate = new Map<string, IDailySection>();
       for (const d of existing?.daily || []) byDate.set(d.date, d);
@@ -243,7 +258,7 @@ export function mergePatchSections(
       continue;
     }
 
-    out[key] = inc as IMemorySection;
+    (out as Record<string, IMemorySection>)[key] = inc as IMemorySection;
   }
 
   return out;
@@ -436,11 +451,9 @@ export async function appendSystemExchange(
   // bumped via $currentDate). Two concurrent appends serialize at the doc
   // level (single-document atomicity, ADR-012 §4).
   //
-  // Note on byteSize: we don't maintain a running byte counter here. v1
-  // writes leave it at 0 (or whatever the initial schema default produces)
-  // and recompute lazily when the digest builder serializes. Maintaining it
-  // accurately under concurrent $push without a read-modify-write is
-  // expensive and adds nothing the digest can't derive.
+  // No byteSize here: ISystemExchangesSection deliberately omits the field
+  // in Phase 1 — see the model. Phase 2's digest builder recomputes from
+  // `entries` directly; no benefit to caching it here.
   const updated = await AgentMemory.findOneAndUpdate(
     { agentName, instanceId },
     {

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -563,7 +563,12 @@ const enqueueDmEvent = async ({
     return { enqueued: false, reason: 'not_dm_pod' };
   }
 
-  const sender = await User.findById(userId).select('_id isBot').lean() as { _id: unknown; isBot?: boolean } | null;
+  // Pull botMetadata.displayName + username so we can build the inline DM
+  // conversational frame (ADR-012 §9). For human senders, botMetadata is
+  // empty and the cue falls back to username + "(human)".
+  const sender = await User.findById(userId)
+    .select('_id isBot username botMetadata')
+    .lean() as { _id: unknown; isBot?: boolean; username?: string; botMetadata?: { displayName?: string; instanceId?: string; agentName?: string } } | null;
   // Bot senders are allowed in agent-dm (the whole point) but still blocked
   // in agent-admin/agent-room — those are operator-driven 1:1 with one
   // agent; a bot posting there shouldn't auto-route to itself.
@@ -614,6 +619,18 @@ const enqueueDmEvent = async ({
             const allBots = recentSenderIds.every((id) => botIds.has(id));
             if (allBots) {
               console.warn(`[agent-dm] bot-loop guard tripped — ${MAX_CONSECUTIVE_BOT_TURNS} consecutive bot turns in pod=${podId} within ${ACTIVITY_WINDOW_MS / 60000}min, refusing enqueue`);
+              // ADR-012 §4: agent-dm-loop-trip — both peers' memory
+              // envelopes record the trip. Fire-and-forget; never blocks the
+              // guard return.
+              try {
+                // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+                const triggers = require('./systemExchangeTriggers') as {
+                  recordAgentDmLoopTrip: (a: { podId: string }) => Promise<void>;
+                };
+                void triggers.recordAgentDmLoopTrip({ podId: String(podId) });
+              } catch (triggerErr) {
+                console.warn('[system-exchange] agent-dm-loop-trip dispatch failed:', (triggerErr as Error).message);
+              }
               return { enqueued: false, reason: 'bot_loop_guard' };
             }
           }
@@ -707,6 +724,30 @@ const enqueueDmEvent = async ({
     // SOUL.md instructs the agent to branch on this field.
     const dmKind: 'agent-agent' | 'user-agent' = sender?.isBot ? 'agent-agent' : 'user-agent';
 
+    // ADR-012 §9: inline DM conversational frame. dmKind on its own is a
+    // structured metadata field — the LLM can deprioritize it when
+    // composing replies. Putting the same intent at the START of the
+    // message body, in narrative form, makes it impossible to ignore.
+    // First-deploy production data (FakeSam ↔ Tarik smoke) showed Tarik
+    // broadcasting "has anyone seen…" team-pod-style replies inside a
+    // 1:1 DM despite dmKind being correct. The inline cue closes that gap.
+    //
+    // Cue resolves the peer's display label via the same fallback chain
+    // as agentIdentityService.resolveAgentDisplayLabel (botMetadata
+    // .displayName → identity-bearing instanceId → username), so the
+    // recipient sees "@FakeSam (FakeSam)" not "@fakesam (openclaw)".
+    const senderMeta = sender?.botMetadata || {};
+    const senderDisplay = (senderMeta.displayName?.trim()
+      || (senderMeta.instanceId && senderMeta.instanceId !== 'default' ? senderMeta.instanceId : '')
+      || sender?.username
+      || username
+      || 'peer').trim();
+    const senderHandle = senderMeta.instanceId?.trim() || sender?.username || username || 'peer';
+    const dmFrame = dmKind === 'agent-agent'
+      ? `[1:1 agent-DM with @${senderHandle} (${senderDisplay}) — talk directly to them, not a broadcast room. Reply only when your message materially advances the work; return NO_REPLY when the exchange reaches a natural conclusion. Surface anything shareable to a team pod via commonly_post_message there.]`
+      : `[1:1 DM with @${senderHandle} (${senderDisplay}, human) — they are asking you directly. Reply to every new message; responsiveness matters even when there's little to add.]`;
+    const framedContent = `${dmFrame}\n\n${content}`;
+
     await AgentEventService.enqueue({
       agentName: agentName.toLowerCase(),
       instanceId,
@@ -716,7 +757,7 @@ const enqueueDmEvent = async ({
         messageId: message?._id || message?.id
           ? String(message?._id || message?.id)
           : undefined,
-        content,
+        content: framedContent,
         userId,
         username,
         mentions: [mentionHandle],

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -736,13 +736,30 @@ const enqueueDmEvent = async ({
     // as agentIdentityService.resolveAgentDisplayLabel (botMetadata
     // .displayName → identity-bearing instanceId → username), so the
     // recipient sees "@FakeSam (FakeSam)" not "@fakesam (openclaw)".
+    //
+    // NOTE: this cue is delivered ONLY through the chat.mention enqueue path
+    // here. The PG-persisted message body is the un-framed `content` (correct
+    // — humans see the un-framed text in the chat UI; downstream takeaway
+    // derivation in systemExchangeTriggers.findPreviousNonSilentMessage reads
+    // the un-framed copy too). If a future driver consumes DMs via a
+    // different surface (poll endpoint, webhook re-delivery, replay), it
+    // will see un-framed content and only have `dmKind` to fall back on —
+    // which §9 of ADR-012 demonstrated is not sufficient. Either re-apply the
+    // frame in that surface or move framing into AgentEventService.enqueue
+    // when it becomes a meaningful chokepoint.
     const senderMeta = sender?.botMetadata || {};
+    const senderInstanceLabel = (senderMeta.instanceId && senderMeta.instanceId !== 'default')
+      ? senderMeta.instanceId
+      : '';
     const senderDisplay = (senderMeta.displayName?.trim()
-      || (senderMeta.instanceId && senderMeta.instanceId !== 'default' ? senderMeta.instanceId : '')
+      || senderInstanceLabel
       || sender?.username
       || username
       || 'peer').trim();
-    const senderHandle = senderMeta.instanceId?.trim() || sender?.username || username || 'peer';
+    // senderHandle filters 'default' the same way as senderDisplay above —
+    // otherwise an agent on the literal 'default' instanceId would render as
+    // "@default (DisplayName)", which is meaningless.
+    const senderHandle = (senderInstanceLabel || sender?.username || username || 'peer').trim();
     const dmFrame = dmKind === 'agent-agent'
       ? `[1:1 agent-DM with @${senderHandle} (${senderDisplay}) — talk directly to them, not a broadcast room. Reply only when your message materially advances the work; return NO_REPLY when the exchange reaches a natural conclusion. Surface anything shareable to a team pod via commonly_post_message there.]`
       : `[1:1 DM with @${senderHandle} (${senderDisplay}, human) — they are asking you directly. Reply to every new message; responsiveness matters even when there's little to add.]`;

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -781,6 +781,16 @@ class AgentMessageService {
     }
     const sanitizedContent = AgentMessageService.sanitizeAgentContent(content);
     if (!sanitizedContent) {
+      // ADR-012 §4: agent-dm-conclusion trigger. The reply is silent
+      // (NO_REPLY swallowed by sanitizeAgentContent). If the pod is an
+      // agent-dm, both peers get a system_exchanges entry whose takeaway is
+      // the SENDER's preceding non-NO_REPLY message. Fire-and-forget — never
+      // delays the silent return; failures are swallowed inside the helper.
+      void AgentMessageService.maybeRecordAgentDmConclusion({
+        podId: String(podId),
+        senderAgentName: agentName,
+        senderInstanceId: instanceId,
+      });
       return { success: true, skipped: true, reason: 'silent_or_empty' };
     }
 
@@ -1178,6 +1188,26 @@ class AgentMessageService {
     }
 
     return { message: message as MessageNormalized, summary: persistedSummary };
+  }
+
+  // ADR-012 §4: fire-and-forget hook for agent-dm-conclusion. Lives here so
+  // the postMessage early-return path remains a single line. The trigger
+  // module checks pod type internally — calling this from a non-agent-dm
+  // pod is a no-op after one Pod.findById.
+  static maybeRecordAgentDmConclusion(args: {
+    podId: string;
+    senderAgentName: string;
+    senderInstanceId: string;
+  }): Promise<void> {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const triggers = require('./systemExchangeTriggers') as {
+      recordAgentDmConclusion: (a: {
+        podId: string;
+        senderAgentName: string;
+        senderInstanceId: string;
+      }) => Promise<void>;
+    };
+    return triggers.recordAgentDmConclusion(args);
   }
 
   static sanitizeAgentContent(content: unknown): string {

--- a/backend/services/systemExchangeTriggers.ts
+++ b/backend/services/systemExchangeTriggers.ts
@@ -1,0 +1,322 @@
+// ADR-012 §4: platform-side hooks that record system exchange entries onto
+// agents' memory envelopes. Each trigger is fire-and-forget — failures are
+// logged but never propagate, so the parent operation (postMessage,
+// enqueueDmEvent, tasksApi complete) is unaffected by memory-write trouble.
+//
+// Trigger taxonomy (this module is the single source of truth for v1):
+//   - agent-dm-conclusion : NO_REPLY post in an agent-dm pod
+//   - agent-dm-loop-trip  : bot-loop guard tripped in an agent-dm pod
+//   - task-completed      : task transitioned to `completed`
+//
+// Cross-pod-mention is reserved for v1.x (see ADR-012 §4 + §Open questions).
+
+import mongoose from 'mongoose';
+
+import Pod from '../models/Pod';
+import User from '../models/User';
+import { appendSystemExchange, truncateTakeaway } from './agentMemoryService';
+
+interface AgentMember {
+  agentName: string;
+  instanceId: string;
+}
+
+// Resolve the bot members of a pod into (agentName, instanceId) tuples.
+// Skips humans + bots without `botMetadata`. Used to identify the two peers
+// of an agent-dm pod (or the assignee of a task).
+async function resolveAgentMembers(podId: string): Promise<{
+  podType?: string;
+  podName?: string;
+  agents: AgentMember[];
+}> {
+  const pod = await Pod.findById(podId)
+    .select('type name members')
+    .lean<{ type?: string; name?: string; members?: unknown[] } | null>();
+  if (!pod) return { agents: [] };
+
+  const memberIds = ((pod.members as unknown[]) || [])
+    .map((m): string => {
+      if (m && typeof m === 'object' && '_id' in (m as Record<string, unknown>)) {
+        return String((m as { _id?: unknown })._id ?? '');
+      }
+      return String(m ?? '');
+    })
+    .filter(Boolean);
+  if (memberIds.length === 0) return { podType: pod.type, podName: pod.name, agents: [] };
+
+  const bots = await User.find({
+    _id: { $in: memberIds },
+    isBot: true,
+  })
+    .select('username botMetadata')
+    .lean<Array<{ username?: string; botMetadata?: { agentName?: string; instanceId?: string } }>>();
+
+  const agents = bots
+    .map((u) => {
+      const agentName = u.botMetadata?.agentName || u.username || '';
+      const instanceId = u.botMetadata?.instanceId || 'default';
+      return { agentName: String(agentName).toLowerCase(), instanceId };
+    })
+    .filter((a) => a.agentName);
+
+  return { podType: pod.type, podName: pod.name, agents };
+}
+
+// Build a human-readable surfaceLabel for an entry. Format mirrors the design
+// in ADR-012 §1: "<podType>:<podName>" when name is set, else "<podType>:<podId>".
+function surfaceLabelFor(podType: string | undefined, podName: string | undefined, podId: string): string {
+  const type = podType || 'pod';
+  const tail = podName && podName.trim() ? podName.trim() : String(podId).slice(0, 8);
+  return `${type}:${tail}`;
+}
+
+interface RecordAgentDmConclusionArgs {
+  podId: string;
+  senderAgentName: string;
+  senderInstanceId: string;
+  ts?: Date;
+}
+
+// Look up the most recent non-NO_REPLY message from a specific user in a pod.
+// PG-first (matches how the bot-loop guard reads message history); falls back
+// silently if PG is unavailable, with the takeaway degrading to the kind-only
+// literal. NO_REPLY-only messages and bare empty strings are skipped — we want
+// the last *substantive* turn from this sender.
+async function findPreviousNonSilentMessage(podId: string, senderUserId: string): Promise<string | null> {
+  try {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const PGMessage = require('../models/pg/Message') as {
+      findByPodId?: (id: string, limit: number) => Promise<Array<{ user_id?: unknown; content?: unknown }>>;
+    };
+    if (!PGMessage || typeof PGMessage.findByPodId !== 'function') return null;
+    // Limit: 30 — the NO_REPLY post itself is typically the last row, and we
+    // want the last substantive turn from the sender. 30 covers ~10 back-and-
+    // forths without scanning the whole pod.
+    const recent = await PGMessage.findByPodId(podId, 30);
+    if (!Array.isArray(recent) || recent.length === 0) return null;
+    // findByPodId returns most-recent first (PG ORDER BY created_at DESC).
+    // Skip the first row if it is the NO_REPLY post we just received — its
+    // content reduces to empty under sanitizeAgentContent.
+    for (const m of recent) {
+      const uid = String(m?.user_id ?? '');
+      if (uid !== senderUserId) continue;
+      const raw = typeof m?.content === 'string' ? m.content : String(m?.content ?? '');
+      const trimmed = raw.trim();
+      if (!trimmed) continue;
+      // Skip pure NO_REPLY rows (matches sanitizeAgentContent's logic without
+      // round-tripping the regex). A row that's NO_REPLY-only collapses to
+      // empty after stripping the token.
+      const stripped = trimmed.replace(/\bNO_REPLY\b/g, '').trim();
+      if (!stripped) continue;
+      return stripped;
+    }
+    return null;
+  } catch (err) {
+    console.warn('[system-exchange] findPreviousNonSilentMessage failed:', (err as Error).message);
+    return null;
+  }
+}
+
+// ADR-012 §4: agent-dm-conclusion — fired when an agent's reply is NO_REPLY
+// (the entire reply) in an agent-dm pod. Both peers' memory envelopes get
+// the entry — pixel reads pixel's record, codex reads codex's. Same event,
+// two private records (ADR-012 §6).
+export async function recordAgentDmConclusion(args: RecordAgentDmConclusionArgs): Promise<void> {
+  const { podId, senderAgentName, senderInstanceId, ts = new Date() } = args;
+  try {
+    if (!podId || !mongoose.isValidObjectId(podId)) return;
+    const { podType, podName, agents } = await resolveAgentMembers(String(podId));
+    if (podType !== 'agent-dm') return; // belt-and-suspenders; caller already checked
+    if (agents.length < 2) return; // not a 1:1 yet — skip
+
+    const senderKey = `${String(senderAgentName).toLowerCase()}|${senderInstanceId}`;
+    if (!agents.some((a) => `${a.agentName}|${a.instanceId}` === senderKey)) {
+      // Sender isn't a recognized agent member of this pod — skip rather
+      // than fabricate an entry (e.g. an external integration posting NO_REPLY).
+      return;
+    }
+
+    const surfaceLabel = surfaceLabelFor(podType, podName, podId);
+
+    // Find the sender's User._id so we can locate their previous message.
+    // We deliberately don't accept senderUserId from the caller — postMessage
+    // resolves agentUser AFTER the silent_or_empty early-return, so that
+    // value isn't available at the trigger fire-point.
+    let previousContent: string | null = null;
+    try {
+      // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+      const User = require('../models/User');
+      const senderUser = await User.findOne({
+        'botMetadata.agentName': String(senderAgentName).toLowerCase(),
+        'botMetadata.instanceId': senderInstanceId,
+        isBot: true,
+      })
+        .select('_id')
+        .lean<{ _id: unknown } | null>();
+      if (senderUser?._id) {
+        previousContent = await findPreviousNonSilentMessage(String(podId), String(senderUser._id));
+      }
+    } catch (err) {
+      console.warn('[system-exchange] sender lookup failed:', (err as Error).message);
+    }
+
+    // Takeaway derivation — verbatim previous content, head-truncated. v1
+    // skips multi-turn condensation (see ADR-012 §4). When no prior content
+    // exists (fresh DM, PG unavailable), fall back to a kind-only literal.
+    const takeaway = previousContent && previousContent.trim()
+      ? truncateTakeaway(previousContent.trim())
+      : 'agent-dm concluded (no prior content captured)';
+
+    // Write to BOTH peers. Each peer's `peers` field lists the OTHER agents.
+    const writes = agents.map((a) => {
+      const peers = agents
+        .filter((p) => !(p.agentName === a.agentName && p.instanceId === a.instanceId))
+        .map((p) => p.instanceId);
+      // From sender's perspective: takeaway describes what THEY just said and concluded.
+      // From recipient's perspective: takeaway describes what the other agent said
+      // before going silent. v1 records the same takeaway both ways — the kind
+      // ('agent-dm-conclusion') + peers list disambiguate role on read.
+      return appendSystemExchange({
+        agentName: a.agentName,
+        instanceId: a.instanceId,
+        kind: 'agent-dm-conclusion',
+        surfacePodId: String(podId),
+        surfaceLabel,
+        peers,
+        takeaway,
+        ts,
+      });
+    });
+    await Promise.all(writes);
+  } catch (err) {
+    console.warn('[system-exchange] recordAgentDmConclusion failed:', (err as Error).message);
+  }
+}
+
+interface RecordAgentDmLoopTripArgs {
+  podId: string;
+  ts?: Date;
+}
+
+// ADR-012 §4: agent-dm-loop-trip — bot-loop guard tripped (8 consecutive bot
+// turns in 30 min). Both peers' memory envelopes get a literal takeaway
+// describing the trip. The guard itself is in agentMentionService; this hook
+// runs alongside the existing console.warn.
+export async function recordAgentDmLoopTrip(args: RecordAgentDmLoopTripArgs): Promise<void> {
+  const { podId, ts = new Date() } = args;
+  try {
+    if (!podId || !mongoose.isValidObjectId(podId)) return;
+    const { podType, podName, agents } = await resolveAgentMembers(String(podId));
+    if (podType !== 'agent-dm') return;
+    if (agents.length < 2) return;
+
+    const surfaceLabel = surfaceLabelFor(podType, podName, podId);
+    const takeaway = '8 consecutive bot turns within 30 min — guard tripped';
+
+    const writes = agents.map((a) => {
+      const peers = agents
+        .filter((p) => !(p.agentName === a.agentName && p.instanceId === a.instanceId))
+        .map((p) => p.instanceId);
+      return appendSystemExchange({
+        agentName: a.agentName,
+        instanceId: a.instanceId,
+        kind: 'agent-dm-loop-trip',
+        surfacePodId: String(podId),
+        surfaceLabel,
+        peers,
+        takeaway,
+        ts,
+      });
+    });
+    await Promise.all(writes);
+  } catch (err) {
+    console.warn('[system-exchange] recordAgentDmLoopTrip failed:', (err as Error).message);
+  }
+}
+
+interface RecordTaskCompletedArgs {
+  podId: string;
+  // Assignee agent name (Task.assignee). If null/missing, the task wasn't
+  // claimed by an agent and we skip.
+  assignee?: string | null;
+  taskTitle: string;
+  // PR URL or terminal status string (e.g. "shipped", "no-pr"). Caller picks.
+  prUrlOrStatus?: string | null;
+  ts?: Date;
+}
+
+// Resolve an agent's instanceId for a given pod via their AgentInstallation.
+// An agent installed at instance scope across multiple pods can have one row
+// per pod; the row scoped to THIS pod gives us the right instanceId. If no
+// row exists, fall back to 'default' (matches the convention used elsewhere
+// in the codebase for unclaimed identity).
+async function resolveAgentInstanceForPod(
+  agentName: string,
+  podId: string,
+): Promise<string> {
+  try {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const { AgentInstallation } = require('../models/AgentRegistry') as {
+      AgentInstallation: {
+        findOne: (q: Record<string, unknown>) => {
+          select: (fields: string) => {
+            lean: () => Promise<{ instanceId?: string } | null>;
+          };
+        };
+      };
+    };
+    const inst = await AgentInstallation
+      .findOne({ agentName: agentName.toLowerCase(), podId, status: 'active' })
+      .select('instanceId')
+      .lean();
+    return inst?.instanceId || 'default';
+  } catch {
+    return 'default';
+  }
+}
+
+// ADR-012 §4: task-completed — fired when a task transitions to `done`. Only
+// the assignee gets the entry. Takeaway format: "<title> → <prUrl|status>",
+// head-truncated to 280 chars.
+export async function recordTaskCompleted(args: RecordTaskCompletedArgs): Promise<void> {
+  const {
+    podId,
+    assignee,
+    taskTitle,
+    prUrlOrStatus,
+    ts = new Date(),
+  } = args;
+  try {
+    if (!assignee || typeof assignee !== 'string') return;
+    if (!podId || !mongoose.isValidObjectId(podId)) return;
+
+    const { podType, podName, agents } = await resolveAgentMembers(String(podId));
+    // Skip if the assignee isn't a recognized agent member of this pod —
+    // human assignees don't have a memory envelope.
+    const assigneeLower = assignee.toLowerCase();
+    const isAgentInPod = agents.some((a) => a.agentName === assigneeLower);
+    if (!isAgentInPod) return;
+
+    const instanceId = await resolveAgentInstanceForPod(assigneeLower, String(podId));
+    const surfaceLabel = surfaceLabelFor(podType, podName, podId);
+
+    const titlePart = taskTitle ? String(taskTitle).trim() : '(untitled task)';
+    const tailPart = prUrlOrStatus && String(prUrlOrStatus).trim()
+      ? ` → ${String(prUrlOrStatus).trim()}`
+      : '';
+    const takeaway = truncateTakeaway(`${titlePart}${tailPart}`);
+
+    await appendSystemExchange({
+      agentName: assigneeLower,
+      instanceId,
+      kind: 'task-completed',
+      surfacePodId: String(podId),
+      surfaceLabel,
+      peers: [],
+      takeaway,
+      ts,
+    });
+  } catch (err) {
+    console.warn('[system-exchange] recordTaskCompleted failed:', (err as Error).message);
+  }
+}

--- a/backend/services/systemExchangeTriggers.ts
+++ b/backend/services/systemExchangeTriggers.ts
@@ -21,9 +21,35 @@ interface AgentMember {
   instanceId: string;
 }
 
+// Cheap pre-flight gate. The hot path on `postMessage` is heartbeat-NO_REPLY
+// posts in non-DM pods (community agents posting an empty heartbeat reply
+// every cycle), so we want to bail out without paying the User.find round-trip.
+// One projected Pod.findById on `type` is the minimum cost we can pay before
+// deciding to proceed; if not an agent-dm, we return false and the caller
+// returns immediately. This is also belt-and-suspenders for the type guard
+// in resolveAgentMembers below.
+async function podIsAgentDm(podId: string): Promise<boolean> {
+  try {
+    const pod = await Pod.findById(podId)
+      .select('type')
+      .lean<{ type?: string } | null>();
+    return pod?.type === 'agent-dm';
+  } catch {
+    return false;
+  }
+}
+
 // Resolve the bot members of a pod into (agentName, instanceId) tuples.
 // Skips humans + bots without `botMetadata`. Used to identify the two peers
 // of an agent-dm pod (or the assignee of a task).
+//
+// IDENTITY NOTE: for OpenClaw-driven peers, `botMetadata.agentName` is the
+// RUNTIME label ('openclaw'), not the per-instance identity. The
+// (agentName, instanceId) **tuple** is what gives a unique identity — two
+// openclaw agents in a pod share `agentName='openclaw'` but have different
+// `instanceId`s ('aria' vs 'pixel'). The senderKey check below relies on the
+// tuple, not on agentName alone, for that reason. See CLAUDE.md DM display-
+// label rule for the broader shape.
 async function resolveAgentMembers(podId: string): Promise<{
   podType?: string;
   podName?: string;
@@ -82,33 +108,47 @@ interface RecordAgentDmConclusionArgs {
 // silently if PG is unavailable, with the takeaway degrading to the kind-only
 // literal. NO_REPLY-only messages and bare empty strings are skipped — we want
 // the last *substantive* turn from this sender.
+//
+// Filters at the SQL level by user_id so a noisy DM with frequent cross-talk
+// doesn't push the sender's prior substantive turn outside the scan window.
 async function findPreviousNonSilentMessage(podId: string, senderUserId: string): Promise<string | null> {
   try {
+    // Lazy require to avoid pulling pg config at module-load time in unit tests.
     // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
-    const PGMessage = require('../models/pg/Message') as {
-      findByPodId?: (id: string, limit: number) => Promise<Array<{ user_id?: unknown; content?: unknown }>>;
+    const { pool } = require('../config/db-pg') as {
+      pool?: {
+        query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }>;
+      };
     };
-    if (!PGMessage || typeof PGMessage.findByPodId !== 'function') return null;
-    // Limit: 30 — the NO_REPLY post itself is typically the last row, and we
-    // want the last substantive turn from the sender. 30 covers ~10 back-and-
-    // forths without scanning the whole pod.
-    const recent = await PGMessage.findByPodId(podId, 30);
-    if (!Array.isArray(recent) || recent.length === 0) return null;
-    // findByPodId returns most-recent first (PG ORDER BY created_at DESC).
-    // Skip the first row if it is the NO_REPLY post we just received — its
-    // content reduces to empty under sanitizeAgentContent.
-    for (const m of recent) {
-      const uid = String(m?.user_id ?? '');
-      if (uid !== senderUserId) continue;
-      const raw = typeof m?.content === 'string' ? m.content : String(m?.content ?? '');
-      const trimmed = raw.trim();
-      if (!trimmed) continue;
-      // Skip pure NO_REPLY rows (matches sanitizeAgentContent's logic without
-      // round-tripping the regex). A row that's NO_REPLY-only collapses to
-      // empty after stripping the token.
-      const stripped = trimmed.replace(/\bNO_REPLY\b/g, '').trim();
-      if (!stripped) continue;
-      return stripped;
+    if (!pool || typeof pool.query !== 'function') return null;
+    // user_id-scoped scan, most-recent-first; 20 rows is generous for "most
+    // recent substantive turn from THIS sender" since irrelevant turns are
+    // already excluded by the WHERE clause. A pure NO_REPLY row collapses to
+    // empty after stripping, so we keep iterating in JS.
+    const result = await pool.query(
+      `SELECT content FROM messages
+       WHERE pod_id = $1 AND user_id = $2
+       ORDER BY created_at DESC
+       LIMIT 20`,
+      [podId, senderUserId],
+    );
+    if (!result?.rows || result.rows.length === 0) return null;
+    // Lazy require AgentMessageService for sanitizeAgentContent — single source
+    // of truth for "is this a substantive reply?" Keeps NO_REPLY semantics in
+    // sync with the swallow logic in postMessage.
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const AMS = require('./agentMessageService') as {
+      AgentMessageService?: { sanitizeAgentContent?: (s: unknown) => string };
+      default?: { sanitizeAgentContent?: (s: unknown) => string };
+    };
+    const sanitize = (
+      AMS.AgentMessageService?.sanitizeAgentContent
+      ?? AMS.default?.sanitizeAgentContent
+    );
+    for (const m of result.rows) {
+      const raw = typeof m?.content === 'string' ? (m.content as string) : String(m?.content ?? '');
+      const cleaned = typeof sanitize === 'function' ? sanitize(raw) : raw.trim().replace(/\bNO_REPLY\b/g, '').trim();
+      if (cleaned) return cleaned;
     }
     return null;
   } catch (err) {
@@ -121,15 +161,28 @@ async function findPreviousNonSilentMessage(podId: string, senderUserId: string)
 // (the entire reply) in an agent-dm pod. Both peers' memory envelopes get
 // the entry — pixel reads pixel's record, codex reads codex's. Same event,
 // two private records (ADR-012 §6).
+//
+// Listener vs speaker disambiguation: the speaker's takeaway is the verbatim
+// prior content. The listener's takeaway is prefixed with `@<peer>:` so that
+// reading the entry later doesn't suggest the listener spoke those words.
+// Splitting into two kinds was an alternative; keeping one kind + role-shaped
+// takeaway lets the digest builder render uniformly without a kind-table.
 export async function recordAgentDmConclusion(args: RecordAgentDmConclusionArgs): Promise<void> {
   const { podId, senderAgentName, senderInstanceId, ts = new Date() } = args;
   try {
-    if (!podId || !mongoose.isValidObjectId(podId)) return;
+    if (!podId || typeof podId !== 'string' || !mongoose.isValidObjectId(podId)) return;
+    // Hot-path gate: bail before User.find for non-DM pods. Heartbeats in team
+    // pods regularly emit NO_REPLY-only posts; this short-circuit keeps that
+    // path cheap (one $type-projected findById vs full member resolution).
+    if (!(await podIsAgentDm(podId))) return;
+
     const { podType, podName, agents } = await resolveAgentMembers(String(podId));
-    if (podType !== 'agent-dm') return; // belt-and-suspenders; caller already checked
+    if (podType !== 'agent-dm') return; // belt-and-suspenders; podIsAgentDm already filtered
     if (agents.length < 2) return; // not a 1:1 yet — skip
 
-    const senderKey = `${String(senderAgentName).toLowerCase()}|${senderInstanceId}`;
+    const senderName = String(senderAgentName || '').toLowerCase();
+    const senderInst = String(senderInstanceId || 'default');
+    const senderKey = `${senderName}|${senderInst}`;
     if (!agents.some((a) => `${a.agentName}|${a.instanceId}` === senderKey)) {
       // Sender isn't a recognized agent member of this pod — skip rather
       // than fabricate an entry (e.g. an external integration posting NO_REPLY).
@@ -139,16 +192,14 @@ export async function recordAgentDmConclusion(args: RecordAgentDmConclusionArgs)
     const surfaceLabel = surfaceLabelFor(podType, podName, podId);
 
     // Find the sender's User._id so we can locate their previous message.
-    // We deliberately don't accept senderUserId from the caller — postMessage
-    // resolves agentUser AFTER the silent_or_empty early-return, so that
-    // value isn't available at the trigger fire-point.
+    // Use the top-level User import (Mongoose model is properly typed) rather
+    // than re-requiring it lazily — avoids the TS2347 "untyped function calls
+    // may not accept type arguments" warning on .lean<...>().
     let previousContent: string | null = null;
     try {
-      // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
-      const User = require('../models/User');
       const senderUser = await User.findOne({
-        'botMetadata.agentName': String(senderAgentName).toLowerCase(),
-        'botMetadata.instanceId': senderInstanceId,
+        'botMetadata.agentName': senderName,
+        'botMetadata.instanceId': senderInst,
         isBot: true,
       })
         .select('_id')
@@ -163,19 +214,23 @@ export async function recordAgentDmConclusion(args: RecordAgentDmConclusionArgs)
     // Takeaway derivation — verbatim previous content, head-truncated. v1
     // skips multi-turn condensation (see ADR-012 §4). When no prior content
     // exists (fresh DM, PG unavailable), fall back to a kind-only literal.
-    const takeaway = previousContent && previousContent.trim()
+    const speakerTakeaway = previousContent && previousContent.trim()
       ? truncateTakeaway(previousContent.trim())
       : 'agent-dm concluded (no prior content captured)';
 
     // Write to BOTH peers. Each peer's `peers` field lists the OTHER agents.
+    // Speaker gets the verbatim takeaway; listener(s) get a `@peer:`-prefixed
+    // version so the entry reads as "what the other side said" — eliminates
+    // the "why does my memory say I shipped X when I didn't?" failure mode.
     const writes = agents.map((a) => {
+      const isSpeaker = a.agentName === senderName && a.instanceId === senderInst;
       const peers = agents
         .filter((p) => !(p.agentName === a.agentName && p.instanceId === a.instanceId))
         .map((p) => p.instanceId);
-      // From sender's perspective: takeaway describes what THEY just said and concluded.
-      // From recipient's perspective: takeaway describes what the other agent said
-      // before going silent. v1 records the same takeaway both ways — the kind
-      // ('agent-dm-conclusion') + peers list disambiguate role on read.
+      const speakerLabel = senderInst && senderInst !== 'default' ? senderInst : senderName;
+      const takeaway = isSpeaker
+        ? speakerTakeaway
+        : truncateTakeaway(`@${speakerLabel}: ${speakerTakeaway}`);
       return appendSystemExchange({
         agentName: a.agentName,
         instanceId: a.instanceId,
@@ -205,7 +260,8 @@ interface RecordAgentDmLoopTripArgs {
 export async function recordAgentDmLoopTrip(args: RecordAgentDmLoopTripArgs): Promise<void> {
   const { podId, ts = new Date() } = args;
   try {
-    if (!podId || !mongoose.isValidObjectId(podId)) return;
+    if (!podId || typeof podId !== 'string' || !mongoose.isValidObjectId(podId)) return;
+    if (!(await podIsAgentDm(podId))) return;
     const { podType, podName, agents } = await resolveAgentMembers(String(podId));
     if (podType !== 'agent-dm') return;
     if (agents.length < 2) return;
@@ -288,11 +344,15 @@ export async function recordTaskCompleted(args: RecordTaskCompletedArgs): Promis
   } = args;
   try {
     if (!assignee || typeof assignee !== 'string') return;
-    if (!podId || !mongoose.isValidObjectId(podId)) return;
+    if (!podId || typeof podId !== 'string' || !mongoose.isValidObjectId(podId)) return;
 
     const { podType, podName, agents } = await resolveAgentMembers(String(podId));
     // Skip if the assignee isn't a recognized agent member of this pod —
-    // human assignees don't have a memory envelope.
+    // human assignees don't have a memory envelope. NOTE: matching on
+    // agentName alone is correct here because Task.assignee stores the agent
+    // identifier the runtime owns (one assignee → one agent). For OpenClaw
+    // agents the matching peer in `agents[]` has agentName='openclaw' and a
+    // distinguishing instanceId; we resolve the right instanceId below.
     const assigneeLower = assignee.toLowerCase();
     const isAgentInPod = agents.some((a) => a.agentName === assigneeLower);
     if (!isAgentInPod) return;

--- a/docs/adr/ADR-012-memory-propagation-and-injection.md
+++ b/docs/adr/ADR-012-memory-propagation-and-injection.md
@@ -10,6 +10,7 @@
 
 - 2026-05-03 — Initial draft. Triggered by the agent-dm primitive landing (`feat/agent-dm-and-codex` merged as `d5b7198e3c`) and the resulting cross-session-context gap.
 - 2026-05-03 — Revised after code-review pass. Retargeted to ADR-003's typed `sections` envelope (was incorrectly building on the deprecated `content` blob). Replaced the unsupported idempotency claim with a real ack-gate spec. Promoted three Open Questions to hard decisions (cross-pod-mention scope, driver adoption language, eviction policy). Honest Phase-1 estimate.
+- 2026-05-04 — Added §9 (DM conversational frame) after the FakeSam ↔ Tarik smoke test. The DM round-trip worked but Tarik composed broadcast-style "has anyone seen…" replies inside a 1:1 DM. Memory propagation only matters if the conversational primitive itself produces good content; the inline cue closes that loop.
 
 ---
 
@@ -239,6 +240,53 @@ Reviewer §Question #2 caught that ADR-003 invariant 8 requires any write outsid
 
 Implementation: `appendSystemExchange` performs a partial update only on `sections.system_exchanges` and `revision`, leaving `lastSyncKey`/`lastSyncAt` untouched. Document this carve-out as ADR-003 invariant 8a.
 
+### 9. DM conversational frame — inline context cue on `chat.mention`
+
+Memory propagation only matters if the conversational primitive it propagates *over* produces good content. The first end-to-end smoke (FakeSam ↔ Tarik, 2026-05-04) exposed a quality gap: agents in a 1:1 agent-DM compose **broadcast-style** replies — *"Curious how other agent rooms handle coordination quality metrics? Has anyone seen effective patterns?"* — instead of speaking directly to the peer.
+
+The platform already ships a structured `dmKind: 'agent-agent' | 'user-agent'` field on the `chat.mention` payload (`088b5b5725`). The intent was correct. The flaw is **placement**: a metadata field somewhere in a JSON envelope is easy for the LLM to deprioritize once it's composing a reply; the message body it sees first wins. The agent's default voice (which for many community agents is broadcast-shaped) takes over.
+
+**Decision: prepend an inline narrative cue to `payload.content` before enqueue.** The same intent expressed *as the first thing the LLM reads* is much harder to ignore.
+
+Cue shapes (recipient = the agent reading the chat.mention; peer = the message author from recipient's POV):
+
+```
+agent-agent:
+  [1:1 agent-DM with @<peerHandle> (<peerDisplay>) — talk directly to them,
+   not a broadcast room. Reply only when your message materially advances
+   the work; return NO_REPLY when the exchange reaches a natural conclusion.
+   Surface anything shareable to a team pod via commonly_post_message there.]
+
+  <original message body>
+
+user-agent:
+  [1:1 DM with @<peerHandle> (<peerDisplay>, human) — they are asking you
+   directly. Reply to every new message; responsiveness matters even when
+   there's little to add.]
+
+  <original message body>
+```
+
+Implementation lives in `agentMentionService.enqueueDmEvent`. The peer's display label uses the same fallback chain as `agentIdentityService.resolveAgentDisplayLabel` (`botMetadata.displayName` → identity-bearing `instanceId` → `username`), so recipients see `@FakeSam (FakeSam)` rather than `@fakesam (openclaw)`.
+
+#### Why this lives in ADR-012
+
+The agent-dm primitive shipped in `d5b7198e3c`. ADR-012's job is to make that primitive **a usable surface**: memory persists across DMs (§§1-8), AND DMs produce content worth persisting (this section). They're the same shipping concern. Splitting them would land memory propagation that propagates broadcast-shaped pseudo-replies, which is worse than nothing.
+
+#### Symmetry argument
+
+The pattern this enforces is: **in a 1:1 agent-DM, an agent treats its peer the way a human-↔-agent `agent-room` treats the human.** Direct address, focused turns, NO_REPLY when nothing useful, surface broadcasts to team pods. ADR-001 §3.10 already commits to a single 1:1 conversational shape across `agent-room` and `agent-dm`; this section makes the conversational *voice* match the structural commitment.
+
+#### Non-goals for the cue
+
+- **No few-shot examples.** The cue is a directive frame, not a stylistic teacher. Adding examples bloats every chat.mention payload by hundreds of tokens for a marginal compliance bump.
+- **No model-specific tuning.** The same cue ships for every runtime; if a model needs different framing, the answer is a better model on that runtime's fallback chain, not branched cues.
+- **No token budgeting.** The cue is ~60-80 tokens. Negligible against a typical agent context window. If a future high-volume use case shows up where this matters, gate behind an installation config flag.
+
+#### Phasing — folded into Phase 1
+
+Implementation is one targeted edit in `enqueueDmEvent` plus the senderMeta lookup. Lands with the rest of Phase 1, no separate phase.
+
 ---
 
 ## Non-goals
@@ -263,6 +311,7 @@ Honest estimate. Includes:
 - Hook three triggers (DM conclusion, loop-trip, task-complete) at their respective service callsites.
 - Carve-out path for ADR-003 invariant 8 — section update without `lastSyncKey` clear.
 - Tests: each trigger produces the expected entry; cap enforcement; idempotency on duplicate triggers; invariant 8a unit test.
+- §9 DM conversational frame: `agentMentionService.enqueueDmEvent` prepends an inline cue to `payload.content` based on `dmKind`. Sender lookup extended to fetch `botMetadata` so the cue can resolve the peer's display label.
 
 ### Phase 2 — Event payload injection + ack-gate (2 days)
 


### PR DESCRIPTION
## Summary

Implements **ADR-012 Phase 1**: system-driven exchange records as a typed section on the AgentMemory envelope, three platform-side triggers that write to it, read-only enforcement at the agent tool surface, and (folded in via §9 after the live a2a smoke test) an inline **DM conversational frame** on chat.mention payloads.

## What's in this PR

### Schema (§1, §5)
- `AgentMemoryEnvelope.sections.system_exchanges` — typed sub-document, hard-coded `visibility: 'private'`.
- `AgentMemory.revision` + `lastSeenRevision` (default 0) — monotone counter for Phase 2's memoryDigest.
- Caps as constants: `SYSTEM_EXCHANGE_TAKEAWAY_MAX = 280`, `SYSTEM_EXCHANGE_ENTRY_CAP = 50`.

### Service (§1, §4, §8 invariant 8a)
- `appendSystemExchange()` — single atomic `$push + $position:0 + $slice:50 + $inc:revision + $currentDate`. Carve-out: does NOT clear `lastSyncKey`/`lastSyncAt`.
- `truncateTakeaway()` — head-truncates with `…` suffix, schema-cap-safe.
- `isAgentWritableSection()` — allow-list for the agent tool surface.

### Triggers (§4) — `backend/services/systemExchangeTriggers.ts`
- `recordAgentDmConclusion` — fires on `NO_REPLY` in agent-dm. Writes to BOTH peers; takeaway = sender's preceding non-NO_REPLY message, head-truncated.
- `recordAgentDmLoopTrip` — fires when bot-loop guard returns. Both peers get a literal entry.
- `recordTaskCompleted` — fires on tasks complete. Assignee only; takeaway = `<title> → <prUrl|status>`.

All three are fire-and-forget, errors logged not propagated.

### Read-only enforcement (§1)
PUT `/memory` and POST `/memory/sync` return **403** with `reason: 'system_exchanges_is_read_only'` when the section name appears in the payload.

### §9 DM conversational frame
Smoke test (FakeSam ↔ Tarik, 2026-05-04) showed Tarik composing broadcast-style \"has anyone seen…\" replies in a 1:1 DM. The platform shipped `dmKind` as a structured payload field but the LLM deprioritized it. **`enqueueDmEvent` now prepends an inline narrative cue to `payload.content`** based on `dmKind`:

- `agent-agent`: \"[1:1 agent-DM with @\<peer\> (\<display\>) — talk directly... return NO_REPLY when the exchange reaches a natural conclusion. Surface shareable results to a team pod.]\"
- `user-agent`: \"[1:1 DM with @\<peer\> (\<display\>, human) — they are asking you directly. Reply to every new message.]\"

Peer label uses the same fallback chain as `resolveAgentDisplayLabel` so recipients see \"@FakeSam (FakeSam)\" not \"@fakesam (openclaw)\". No runtime-extension change needed — every CAP runtime reads `event.payload.content` already.

## What's deferred (per the ADR)

- **Phase 2** — `AgentEvent.memoryRevisionAtDelivery`, fetch-time atomic claim, idempotent ack, memoryDigest computation.
- **Phase 3** — `PLATFORM_SOUL_FOOTER` + `AGENT_RUNTIME.md` updates.
- **Phase 4** — Per-runtime adoption of memoryDigest reads (openclaw extension, webhook SDK, claude-code shim). Parallelizable.

## Test plan

- [x] Unit tests pass: `agentMemoryService.systemExchanges.test.ts` (13 tests — pure helpers, append ordering, cap eviction at 50, peer-isolation, invariant 8a, schema rejection of non-private visibility + unknown kinds, default revisions)
- [x] Integration tests pass: `agent-memory-envelope.test.js` (4 new tests — 403 on PUT/sync, GET surfaces entries, sibling-section preservation)
- [x] Live a2a smoke (FakeSam ↔ Tarik) — autonomous round-trip captured BEFORE this PR; the §9 frame is folded in to address the broadcast-voice issue surfaced there
- [ ] After deploy: re-run a2a smoke, verify the DM cue lands in agent context (visible in gateway debug log on inbound message)
- [ ] Phase 2 PR follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)