### PR TITLE
fix(memory): rollback cycle-reflection trailer — DM regression

### DIFF
--- a/backend/routes/registry/presets.ts
+++ b/backend/routes/registry/presets.ts
@@ -2974,16 +2974,30 @@ Rules:
 - After this call (or skip), return \`HEARTBEAT_OK\`.
 `;
 
-// Defensive helper: append the cycle-reflection trailer to a template.
-// No-op when the template already contains the trailer (idempotent across
-// reprovisions). Applied at the provision/reprovision callsite — keeping the
-// 25 individual template strings untouched and preserving the
-// `customizations.heartbeat` flag's "user edited the template" semantics.
+// Defensive helper: would append the cycle-reflection trailer to a template.
+//
+// **2026-05-04 ROLLBACK — currently a NO-OP.** The trailer instructs agents
+// to call `commonly_save_my_memory({sections:{cycles:{append:...}}})`, but no
+// openclaw extension tool with that name exists today — agents waste 3+
+// tool-call turns per heartbeat hunting for it before falling back to the
+// real `commonly_write_agent_memory`, which exhausts their turn budget and
+// causes them to skip DM responses. Verified on Nova: silent on Sam's "hey
+// Nova" 2026-05-04 06:01 UTC and "hey" 06:21 UTC, immediately after the
+// trailer rolled out via reprovision-all (Phase 2.J).
+//
+// Forward fix path (separate branch): add `commonly_log_cycle(content,
+// podId?)` to the openclaw extension (Team-Commonly/openclaw fork), build
+// + push gateway image, then re-enable this helper to instruct agents to
+// call the new tool name. Until that lands, the helper returns the template
+// unchanged so HEARTBEAT.md reverts to its pre-Phase-2.J shape on the next
+// reprovision-all.
+//
+// The helper signature stays exported so the four call-sites in provision.ts
+// + reprovision.ts continue to compile without churn — flipping back to the
+// real implementation is a one-line change once the openclaw tool ships.
 function withCyclesDirective(template: string | null | undefined): string {
   const t = typeof template === 'string' ? template : '';
-  if (!t) return t;
-  if (t.includes('## Memory cycle reflection')) return t;
-  return t.replace(/\s*$/, '') + CYCLES_REFLECTION_TRAILER;
+  return t;
 }
 
 module.exports = { PRESET_DEFINITIONS, DEFAULT_BRANCH, withCyclesDirective };


### PR DESCRIPTION
## Summary

Phase 2.J's \`withCyclesDirective\` trailer (PR #295) is causing live agents to skip DM responses. Rolling back ASAP — the trailer instructs agents to call \`commonly_save_my_memory({sections:{cycles:{append:...}}})\`, but no openclaw extension tool with that name exists. Agents waste 3+ turn-budget tool calls per heartbeat hunting for it before falling back to the real \`commonly_write_agent_memory\`, which exhausts their budget before they can post a chat reply.

## Evidence

Nova went silent on Sam immediately after Phase 2.J reprovision-all rolled the trailer to the gateway PVC at ~05:30 UTC:

| Time (UTC) | Sender | Message | Nova reply |
|---|---|---|---|
| 2026-05-03 22:43 | xcjsam | hey | \"hey\" (~6 min later) ✅ |
| 2026-05-04 00:34 | xcjsam | hey | reply 13 min later ✅ |
| 2026-05-04 01:05 | xcjsam | what up | reply 1 min later ✅ |
| **2026-05-04 06:01** | xcjsam | hey Nova | (silent) ❌ |
| **2026-05-04 06:21** | xcjsam | hey | (silent) ❌ |

Reprovision-all completed ~05:30 UTC. First missed DM was 06:01 UTC.

Session log \`/state/agents/nova/sessions/*.jsonl\` confirms: **3× attempted** \`commonly_save_my_memory\` (the missing tool name from the trailer), **1× successful** \`commonly_write_agent_memory\` fallback.

## Fix

\`withCyclesDirective\` is now a no-op. HEARTBEAT.md will revert to its pre-Phase-2.J shape on the next reprovision-all. The helper + the four call-sites stay in place so re-enabling is a one-line flip once the openclaw extension exposes a real cycles-write tool.

## Forward path (separate branch)

1. Add \`commonly_log_cycle(content, podId?)\` to \`Team-Commonly/openclaw\` extension (\`extensions/commonly/src/{tools,client}.ts\`)
2. Build + push gateway image, helm upgrade clawdbot-gateway
3. Update trailer to call \`commonly_log_cycle(...)\` instead of the dotted-section shape
4. Flip this no-op back to the real implementation
5. Reprovision-all + observe

## Test plan
- [x] tsc:check clean
- [ ] Merge → Deploy Dev → reprovision-all → DM Nova → confirm she replies again

🤖 Generated with [Claude Code](https://claude.com/claude-code)