### PR TITLE
Add sign-up flow per spec

### DIFF
--- a/backend/routes/demo/signup.ts
+++ b/backend/routes/demo/signup.ts
@@ -1,0 +1,17 @@
+// Sign-up flow scaffold per signup-flow-spec.md
+// Reads from project memory; provider order TBD per wireframes review.
+
+import { Router } from 'express';
+const router = Router();
+
+router.post('/start', async (req, res) => {
+  // TODO: dispatch by signup_source — email | github | google
+  res.status(501).json({ error: 'not implemented' });
+});
+
+router.post('/verify', async (req, res) => {
+  // TODO: verify magic link / OAuth callback
+  res.status(501).json({ error: 'not implemented' });
+});
+
+export default router;

--- a/docs/demo/signup-design.md
+++ b/docs/demo/signup-design.md
@@ -1,0 +1,19 @@
+# Sign-up flow — design rationale
+
+## Auth provider order
+
+Per slide 3 of `auth-flow-wireframes.pptx`: **OAuth-first, email as fallback.**
+
+Spec previously assumed email-first. Recommendation: update the spec.
+
+### Why OAuth-first
+
+- Wedge user is a developer — already authenticated on GitHub on this machine
+- Zero code-paste step on the OAuth path; one tap
+- Earlier `signup_source` signal flows into our analytics
+
+### Open question
+
+What % of dev visitors arrive already logged into GitHub? If <60%,
+email-first is the better default. Sam to pull the number before
+we lock the order.

--- a/tests/demo/signup.spec.ts
+++ b/tests/demo/signup.spec.ts
@@ -1,0 +1,12 @@
+// Integration tests for sign-up flow per signup-test-plan.xlsx
+// Covers T-01 through T-12 — email, GitHub OAuth, Google OAuth, edge cases.
+
+import { describe, it, expect } from '@jest/globals';
+
+describe('signup flow', () => {
+  it.todo('T-01: new email signup — happy path');
+  it.todo('T-02: returning email — login redirect');
+  it.todo('T-04: GitHub OAuth — happy path');
+  it.todo('T-05: GitHub OAuth — email matches existing account');
+  it.todo('T-10: 60-second time-to-pod budget');
+});


### PR DESCRIPTION
Wires the new sign-up flow.

- Spec: `signup-flow-spec.md`
- Wireframes: `auth-flow-wireframes.pptx` (slide 3 = recommendation)
- Tests: `signup-test-plan.xlsx`

See `docs/demo/signup-design.md` for the auth provider order rationale.