### PR TITLE
fix(v2-inspector): make 'Talk to' gate runtime-based, not name-hardcoded

### DIFF
--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -29,12 +29,25 @@ interface V2PodInspectorProps {
   onOpenInvite?: () => void;
 }
 
-// Only openclaw-runtime agents can hold a real DM session — they have a chat
-// runtime that responds. commonly-bot is the internal Tier 1 summarizer (no
-// chat runtime); pod-summarizer is Tier 1 native (also no DM).
-const isAgentDmable = (agent: { name?: string; agentName?: string }): boolean => {
-  const n = agent.name || agent.agentName;
-  return n === 'openclaw';
+// Any agent with a real chat runtime can hold a DM session. The Tier 1
+// internal services (commonly-bot summarizer, pod-summarizer) don't have a
+// runtime that responds to chat — they're cron / event-driven only.
+//
+// Previously this was hardcoded to `agent.name === 'openclaw'`, which
+// silently excluded every other runtime — Claude Code wrappers, Codex
+// wrappers, stub adapters, webhook bots, native runtime agents. Anyone
+// installing an agent via `commonly agent attach <claude|codex|...>`
+// got an agent that worked end-to-end EXCEPT that the inspector's
+// "Talk to" button never appeared.
+//
+// Gate now reads from the resolved runtime: any non-internal runtime
+// is dmable. Falls back to `false` for unknown payload shapes.
+const isAgentDmable = (agent: { runtime?: { runtimeType?: string } | null }): boolean => {
+  const t = agent?.runtime?.runtimeType;
+  if (!t) return false;
+  // Tier 1 native services — no chat runtime, no DM target.
+  if (t === 'internal') return false;
+  return true;
 };
 
 interface AgentTaskMap {


### PR DESCRIPTION
## Summary

The V2 inspector's `isAgentDmable` check was hardcoded to `agent.name === 'openclaw'`. That silently hid the **Talk to** button for every other runtime — Claude Code wrappers, Codex wrappers, stub adapters, webhook bots, native-runtime agents.

Anyone installing an agent via `commonly agent attach <adapter>` got something that worked end-to-end (auth, posting, mentions, memory) **except** that the inspector never offered a Talk-to entry point to start a 1:1 with it.

## After

Gate now reads from the resolved runtime payload:

```ts
const isAgentDmable = (agent: { runtime?: { runtimeType?: string } | null }): boolean => {
  const t = agent?.runtime?.runtimeType;
  if (!t) return false;
  if (t === 'internal') return false;
  return true;
};
```

| Runtime | Before | After |
|---|---|---|
| `claude-code` | ❌ | ✅ |
| `codex` | ❌ | ✅ |
| `moltbot` (OpenClaw) | ❌* | ✅ |
| `webhook` | ❌ | ✅ |
| `internal` (Tier 1 — commonly-bot, pod-summarizer) | ❌ | ❌ (correct — no chat runtime) |

*The previous check matched on `agent.name === 'openclaw'`; an OpenClaw-runtime agent with any other name (Liz, Nova, Theo, etc.) was also locked out.

## Surfaced by
Staging local-CLI agents for a YC demo (`commonly agent attach claude/codex/stub`). All three were missing Talk-to buttons in the inspector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)