### PR TITLE
feat(demo): post-YC sprint — smoke + a2a-DM inspector surface

### DIFF
--- a/backend/routes/registry/files.ts
+++ b/backend/routes/registry/files.ts
@@ -1,5 +1,11 @@
 // Agent file routes — extracted from registry.js (GH#112)
 // Handles: persona/generate, heartbeat-file (R/W), identity-file (R/W)
+// ESM import for express-rate-limit — CodeQL's `js/missing-rate-limiting`
+// query only recognises the middleware on the SAME file as the route
+// registration (per the note in agentsRuntime.ts). Inlined here, with a
+// userId-keyed generator so per-user limits stay isolated.
+import rateLimit from 'express-rate-limit';
+
 const express = require('express');
 const auth = require('../../middleware/auth');
 const Pod = require('../../models/Pod');
@@ -27,6 +33,21 @@ const {
 } = require('./helpers');
 
 const filesRouter = express.Router({ mergeParams: true });
+
+// Inline rate limiter for the inspector a2a-DM read surface. Per-user
+// (after auth middleware sets req.userId); IPv6-safe key generator using
+// `${req.userId || req.ip}`. 120/min mirrors the agentsRuntime phase4 cap.
+const inspectorRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req: any) => String(req.userId || req.user?._id || req.ip || 'anon'),
+  handler: (_req: any, res: any) => res.status(429).json({
+    message: 'rate limit exceeded: 120 requests per 60s',
+    code: 'rate_limited',
+  }),
+});
 
 filesRouter.post('/pods/:podId/agents/:name/persona/generate', auth, async (req: any, res: any) => {
   try {
@@ -342,7 +363,7 @@ filesRouter.post('/pods/:podId/agents/:name/identity-file', auth, async (req: an
  * `DMService.canViewPod` (the §3.7 co-pod-member rule) — humans see DMs
  * where they share at least one pod with both members.
  */
-filesRouter.get('/pods/:podId/agents/:name/a2a-dms', auth, async (req: any, res: any) => {
+filesRouter.get('/pods/:podId/agents/:name/a2a-dms', auth, inspectorRateLimit, async (req: any, res: any) => {
   try {
     const { podId, name } = req.params;
     const { instanceId } = req.query;

--- a/backend/routes/registry/files.ts
+++ b/backend/routes/registry/files.ts
@@ -6,6 +6,8 @@ const Pod = require('../../models/Pod');
 const { AgentInstallation } = require('../../models/AgentRegistry');
 const AgentProfile = require('../../models/AgentProfile');
 const AgentIdentityService = require('../../services/agentIdentityService');
+const DMService = require('../../services/dmService').default;
+const User = require('../../models/User');
 const { generateText } = require('../../services/llmService');
 const {
   writeOpenClawHeartbeatFile,
@@ -324,6 +326,121 @@ filesRouter.post('/pods/:podId/agents/:name/identity-file', auth, async (req: an
   } catch (error) {
     console.error('Error updating identity file:', error);
     return res.status(500).json({ error: 'Failed to update identity file' });
+  }
+});
+
+/**
+ * GET /api/registry/pods/:podId/agents/:name/a2a-dms?instanceId=...
+ *
+ * List `agent-dm` pods involving the (name, instanceId) agent. Sprint B1
+ * surface — used by V2 pod inspector member-detail to render clickable
+ * "Direct messages" links so humans can observe agent ↔ agent
+ * conversations happening between agents in their team pods.
+ *
+ * Auth: caller must be a member of :podId (to scope the surface to "the
+ * agent that's in this pod"). Each returned DM is then filtered through
+ * `DMService.canViewPod` (the §3.7 co-pod-member rule) — humans see DMs
+ * where they share at least one pod with both members.
+ */
+filesRouter.get('/pods/:podId/agents/:name/a2a-dms', auth, async (req: any, res: any) => {
+  try {
+    const { podId, name } = req.params;
+    const { instanceId } = req.query;
+    const userId = getUserId(req);
+    if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+    const pod = await Pod.findById(podId).lean();
+    if (!pod) return res.status(404).json({ error: 'Pod not found' });
+    if (!(await userHasPodAccess(pod, userId))) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
+    // Resolve the (agentName, instanceId) agent to its User row. READ-ONLY
+    // lookup — we never mint a User on this inspector surface (read-path
+    // upserts violate identity continuity per CLAUDE.md). If the User row
+    // doesn't exist yet, return empty.
+    const resolved = await resolveInstallation({ agentName: name, podId, instanceId });
+    if (!resolved.installation) return res.json({ a2aDms: [] });
+
+    const agentUsername = AgentIdentityService.buildAgentUsername(name, resolved.instanceId);
+    const agentUser = await User.findOne({ username: agentUsername }).select('_id username').lean();
+    if (!agentUser) return res.json({ a2aDms: [] });
+
+    // Find every agent-dm pod containing this User. Members are stored as
+    // ObjectId references in lean results; match against the User's _id
+    // directly. `canViewPod` accepts the same shape so the filter loop is
+    // consistent.
+    const dms = await Pod.find({
+      type: 'agent-dm',
+      members: agentUser._id,
+    })
+      .select('_id name members type updatedAt latestSummary')
+      .lean() as Array<{ _id: unknown; name?: string; members?: unknown[]; type?: string; updatedAt?: Date; latestSummary?: unknown }>;
+
+    // Batched lookup of every "other" member across all DMs — avoids the
+    // N+1 User.find pattern. agent-dm pods are strictly 1:1 per ADR-001
+    // §3.10 so we expect at most one other per DM, but we don't enforce
+    // that here; the loop below picks the first non-self member.
+    const allOtherIds = new Set<string>();
+    const selfId = String(agentUser._id);
+    for (const dm of dms) {
+      for (const m of dm.members || []) {
+        const id = String((m as { _id?: unknown })?._id || m || '');
+        if (id && id !== selfId) allOtherIds.add(id);
+      }
+    }
+    const otherUserMap = new Map<string, { _id: unknown; username?: string; botMetadata?: { displayName?: string; instanceId?: string; agentName?: string }; isBot?: boolean }>();
+    if (allOtherIds.size > 0) {
+      const otherUsers = await User.find({ _id: { $in: Array.from(allOtherIds) } })
+        .select('username botMetadata isBot')
+        .lean() as Array<{ _id: unknown; username?: string; botMetadata?: { displayName?: string; instanceId?: string; agentName?: string }; isBot?: boolean }>;
+      for (const u of otherUsers) otherUserMap.set(String(u._id), u);
+    }
+
+    const a2aDms: Array<Record<string, unknown>> = [];
+    for (const dm of dms) {
+      // §3.7 viewer-access gate. canViewPod's countDocuments is one round
+      // trip per DM; for the demo surface (bounded DM count per agent)
+      // this is fine. If this becomes a paginated surface, batch via a
+      // single aggregation against the viewer's shared-pods set.
+      // eslint-disable-next-line no-await-in-loop
+      const canView = await DMService.canViewPod(userId, dm);
+      if (!canView) continue;
+
+      const otherId = (dm.members || [])
+        .map((m: any) => String(m?._id || m || ''))
+        .find((id: string) => id && id !== selfId) || '';
+      const otherMember = otherUserMap.get(otherId) || null;
+      const otherDisplay = otherMember
+        ? AgentIdentityService.resolveAgentDisplayLabel(otherMember, otherMember.username || 'peer')
+        : 'peer';
+
+      a2aDms.push({
+        podId: String(dm._id),
+        name: dm.name || `${agentUser.username || name} ↔ ${otherDisplay}`,
+        // NOTE: `botMetadata.agentName` is the runtime tag (per
+        // `feedback-runtime-leak-in-display-paths`), not a display
+        // surface. We intentionally do NOT include `agentName` /
+        // `instanceId` in the response — frontend renders via
+        // `displayName` only. Future callers should add fields with
+        // care if they need them.
+        otherMember: otherMember
+          ? {
+            userId: String(otherMember._id),
+            displayName: otherDisplay,
+            isBot: Boolean(otherMember.isBot),
+          }
+          : null,
+        memberCount: Array.isArray(dm.members) ? dm.members.length : 0,
+        updatedAt: dm.updatedAt,
+        latestSummary: dm.latestSummary || null,
+      });
+    }
+
+    return res.json({ a2aDms });
+  } catch (error) {
+    console.error('Error listing a2a-dms:', error);
+    return res.status(500).json({ error: 'Failed to list agent-DM pods' });
   }
 });
 

--- a/frontend/src/components/agents/AgentsHub.tsx
+++ b/frontend/src/components/agents/AgentsHub.tsx
@@ -1137,6 +1137,40 @@ const AgentsHub = ({ currentPodId: propPodId = null }) => {
       if (installPodIds.includes(selectedPodId)) {
         fetchInstalledAgents();
       }
+
+      // Sprint B2 — Post-install handoff. The 60-second wedge is
+      // "install your first agent → talk to it." On successful install
+      // (≥1 pod succeeded), open the agent-room (1:1 DM) for the first
+      // installed pod so the user lands in a conversation surface, not
+      // back on the catalog. Detect v2 context by URL prefix; v1 uses
+      // its own `/pods/agent-room/:id` route. Failures degrade gracefully
+      // — we close the dialog and let the user navigate manually.
+      const successPodIds = results
+        .map((r, i) => (r.status === 'fulfilled' ? installPodIds[i] : null))
+        .filter((id) => id);
+      const handoffPodId = successPodIds[0];
+      const isV2Context = typeof window !== 'undefined' && window.location.pathname.startsWith('/v2');
+      if (handoffPodId && !installAgent?.skipHandoff) {
+        try {
+          const roomRes = await axios.post('/api/agents/runtime/room', {
+            agentName,
+            instanceId: resolvedInstanceId || undefined,
+            podId: handoffPodId,
+          }, {
+            headers: getAuthHeaders(),
+          });
+          const roomPodId = roomRes.data?.room?._id;
+          if (roomPodId) {
+            closeInstallDialog();
+            navigate(isV2Context ? `/v2/pods/${roomPodId}` : `/pods/agent-room/${roomPodId}`);
+            return;
+          }
+        } catch (handoffErr) {
+          console.warn('[install] post-install agent-room handoff failed:', handoffErr);
+          // Fall through to closeInstallDialog without navigation.
+        }
+      }
+
       closeInstallDialog();
     } catch (err) {
       console.error('Error installing agent:', err);

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -463,6 +463,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
     (m) => m && m._id === currentUserId,
   );
   const isAgentDm = pod.type === 'agent-dm';
+  const isAgentRoom = pod.type === 'agent-room';
   const isReadOnly = isAgentDm && !isPodMember;
 
   // Bot-bot agent-dm — used to choose the "X and Y haven't talked yet" empty
@@ -645,6 +646,41 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
                       <div className="v2-empty__title">{botPair[0]} and {botPair[1]} haven&apos;t talked yet</div>
                       <div className="v2-empty__text">They&apos;ll DM each other when one of them needs the other&apos;s help.</div>
                     </>
+                  ) : isAgentRoom && botMembers.length === 1 ? (
+                    // Sprint B4: first-message coaching for the 60s "install
+                    // your first agent → talk to it" wedge. Shows the agent's
+                    // display name + 3 generic suggestion chips that pre-fill
+                    // the composer. Pod-summarizer agent-rooms ride this same
+                    // branch — generic chips degrade gracefully for those.
+                    (() => {
+                      const agentName = botMembers[0]?.username || 'agent';
+                      const suggestions = [
+                        `Hey ${agentName}, what can you do for me?`,
+                        'What are you working on right now?',
+                        'Help me get started — what should I try first?',
+                      ];
+                      return (
+                        <>
+                          <div className="v2-empty__title">Say hi to {agentName}</div>
+                          <div className="v2-empty__text">
+                            This is your 1:1 with {agentName}. Try one of these, or write your own:
+                          </div>
+                          <div className="v2-empty__chips" role="list">
+                            {suggestions.map((s) => (
+                              <button
+                                key={s}
+                                type="button"
+                                role="listitem"
+                                className="v2-empty__chip"
+                                onClick={() => setDraft(s)}
+                              >
+                                {s}
+                              </button>
+                            ))}
+                          </div>
+                        </>
+                      );
+                    })()
                   ) : isAgentDm ? (
                     <>
                       <div className="v2-empty__title">No messages yet</div>

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import Papa from 'papaparse';
 import { useNavigate } from 'react-router-dom';
@@ -770,6 +770,12 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   const [agentTasks, setAgentTasks] = useState<AgentTaskMap>({});
   const [runState, setRunState] = useState<RunStateCounts>({ blocked: 0, inProgress: 0, complete: 0, pending: 0 });
   const [privateError, setPrivateError] = useState<string | null>(null);
+  // ADR-001 §3.10 + Sprint B1: agent-DM pods involving the currently-inspected
+  // agent. Surfaces clickable links so humans can observe agent↔agent
+  // conversations happening between agents in their team pods (the §3.7
+  // co-pod-member rule lets the viewer see those DMs even though they're
+  // not a member). Keyed by agentKey to avoid stale state across selections.
+  const [a2aDmsByAgent, setA2aDmsByAgent] = useState<Record<string, Array<{ podId: string; name: string; otherMember: { displayName: string; isBot: boolean } | null; updatedAt?: string }>>>({});
   const [announcements, setAnnouncements] = useState<AnnouncementItem[]>([]);
   const [externalLinks, setExternalLinks] = useState<ExternalLinkItem[]>([]);
   const [podFiles, setPodFiles] = useState<PodFileItem[]>([]);
@@ -1299,6 +1305,43 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   // ------------------------------------------------------------------
   // MEMBER DETAIL sub-page
   // ------------------------------------------------------------------
+  // Fetch the agent's a2a-DM list when a member is selected. Cached by
+  // agentKey; the list is small (DMs are bounded per agent). We track
+  // already-fetched keys in a ref (not state) so the effect's dep array
+  // doesn't include the cache itself — setA2aDmsByAgent updates the
+  // state object every load, and including that ref in deps would
+  // re-run the effect on every change (harmless given the in-effect
+  // guard, but wasteful).
+  const a2aDmsFetchedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (view.kind !== 'member') return;
+    const agent = agentByKey.get(view.agentKey);
+    if (!agent) return;
+    const key = `${pod._id}:${agentKeyOf(agent)}`;
+    if (a2aDmsFetchedRef.current.has(key)) return;
+    a2aDmsFetchedRef.current.add(key);
+    let cancelled = false;
+    (async () => {
+      try {
+        const url = `/api/registry/pods/${pod._id}/agents/${encodeURIComponent(agent.agentName)}/a2a-dms?instanceId=${encodeURIComponent(agent.instanceId || 'default')}`;
+        const data = await api.get<{ a2aDms?: Array<{ podId: string; name: string; otherMember: { displayName: string; isBot: boolean } | null; updatedAt?: string }> }>(url);
+        const list = data?.a2aDms || [];
+        if (!cancelled) {
+          setA2aDmsByAgent((prev) => ({ ...prev, [key]: list }));
+        }
+      } catch (err) {
+        // Defensive: any error renders the section empty rather than
+        // blocking the detail panel. Allow retry by clearing the ref
+        // entry so a subsequent re-select re-attempts the fetch.
+        if (!cancelled) {
+          a2aDmsFetchedRef.current.delete(key);
+          setA2aDmsByAgent((prev) => ({ ...prev, [key]: [] }));
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [view, pod._id, agentByKey, api]);
+
   const renderMemberDetail = (agentKey: string) => {
     const agent = agentByKey.get(agentKey);
     if (!agent) {
@@ -1381,6 +1424,33 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
             </div>
           </div>
         )}
+        {(() => {
+          const dmKey = `${pod._id}:${agentKeyOf(agent)}`;
+          const list = a2aDmsByAgent[dmKey] || [];
+          if (list.length === 0) return null;
+          return (
+            <div className="v2-inspector__detail-card">
+              <div className="v2-inspector__detail-kicker">Direct messages</div>
+              <div className="v2-inspector__dm-list">
+                {list.map((dm) => {
+                  const peer = dm.otherMember?.displayName || 'peer';
+                  return (
+                    <button
+                      key={dm.podId}
+                      type="button"
+                      className="v2-inspector__dm-row"
+                      onClick={() => navigate(`/v2/pods/${dm.podId}`)}
+                      title={`Open ${name} ↔ ${peer}`}
+                    >
+                      <span className="v2-inspector__dm-name">{name} ↔ {peer}</span>
+                      <span className="v2-inspector__dm-arrow" aria-hidden="true">→</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })()}
       </div>
     );
   };

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4008,6 +4008,37 @@
   max-width: 360px;
 }
 
+/* Sprint B4 — first-message coaching chips in agent-room empty state.
+ * Clickable suggestions that pre-fill the composer; same border-not-shadow
+ * aesthetic as the rest of the v2 inspector cards. Wraps so the row fits
+ * narrow side-panel layouts. */
+.v2-empty__chips {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 12px;
+  max-width: 480px;
+}
+
+.v2-root button.v2-empty__chip {
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--v2-border);
+  background: var(--v2-surface);
+  color: var(--v2-text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+}
+
+.v2-root button.v2-empty__chip:hover {
+  background: var(--v2-surface-hover);
+  border-color: var(--v2-accent-subtle);
+  color: var(--v2-text-primary);
+}
+
 .v2-spinner {
   width: 18px;
   height: 18px;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -2737,6 +2737,51 @@
   align-items: center;
 }
 
+/* Sprint B1: agent-DM list under member-detail. Clickable rows that
+ * navigate to the DM pod (read-only for the human via the §3.7
+ * co-pod-member rule). Same visual rhythm as detail-card content; the
+ * arrow glyph signals "this is interactive." */
+.v2-inspector__dm-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.v2-root button.v2-inspector__dm-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--v2-border-subtle);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+
+.v2-root button.v2-inspector__dm-row:hover {
+  background: var(--v2-surface-hover);
+  border-color: var(--v2-border);
+}
+
+.v2-inspector__dm-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-inspector__dm-arrow {
+  color: var(--v2-text-tertiary);
+  font-weight: 500;
+  margin-left: 8px;
+}
+
 /* ---------- Runtime badge (driver tag — OC, CX, CC, WH, NA) ----------
  * Identity (runtimeType) renders as the main pill; host=byo adds a small
  * "BYO" tag alongside. Cloud is the implicit default and stays unmarked

--- a/scripts/smoke-test-demo.sh
+++ b/scripts/smoke-test-demo.sh
@@ -152,8 +152,21 @@ fi
 
 # --- sprint-item checks (TODOs first, fill in as items land) -------------
 
-todo a2a-dm-listable     "depends on B1"
-todo a2a-dm-load         "depends on B1"
+# B1: a2a-dm-listable — backend route GET /api/registry/pods/:podId/agents/:name/a2a-dms
+http GET "/api/registry/pods/$DEMO_POD/agents/openclaw/a2a-dms?instanceId=nova-demo"
+if [ "$HTTP_CODE" = "200" ]; then
+  has_array=$(echo "$HTTP_BODY" | python3 -c 'import sys,json; d=json.load(sys.stdin); print("yes" if isinstance(d.get("a2aDms"), list) else "no")' 2>/dev/null || echo no)
+  if [ "$has_array" = "yes" ]; then
+    count=$(echo "$HTTP_BODY" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(len(d.get("a2aDms",[])))' 2>/dev/null || echo 0)
+    green a2a-dm-listable "a2aDms array returned, count=$count"
+  else
+    red a2a-dm-listable "response missing a2aDms array"
+  fi
+else
+  red a2a-dm-listable "HTTP=$HTTP_CODE"
+fi
+
+todo a2a-dm-load         "depends on B1 frontend deploy + Playwright verification"
 todo byo-page            "depends on B3"
 todo byo-token-issue     "depends on B3"
 todo install-handoff     "depends on B2"

--- a/scripts/smoke-test-demo.sh
+++ b/scripts/smoke-test-demo.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Smoke test for the post-YC demo-fidelity sprint.
+#
+# Asserts every demo-critical flow end-to-end against the configured Commonly
+# instance using the demo account's runtime token. A sprint item is "done"
+# only when its tag in this script asserts green. See
+# `.dev/yc-application/SPRINT_POST_YC.md` for the tag → sprint-item map.
+#
+# Usage:
+#   bash scripts/smoke-test-demo.sh                # use .dev/yc-application/.smoke-env
+#   API=https://api-dev.commonly.me TOKEN=... DEMO_POD=... bash scripts/smoke-test-demo.sh
+#
+# Exits non-zero if any check fails. Each check prints `[tag] green|red[ note]`.
+
+set -uo pipefail
+HTTP_CODE=000
+
+# --- config ---------------------------------------------------------------
+SMOKE_ENV="${SMOKE_ENV:-.dev/yc-application/.smoke-env}"
+if [ -f "$SMOKE_ENV" ]; then
+  # shellcheck disable=SC1090
+  set -a; source "$SMOKE_ENV"; set +a
+fi
+API="${API:-https://api-dev.commonly.me}"
+TOKEN="${TOKEN:-}"
+DEMO_POD="${DEMO_POD:-}"
+NOVA_AGENT="${NOVA_AGENT:-nova-claude-nova}"
+CODY_AGENT="${CODY_AGENT:-codex-bot-codex}"
+PIXEL_AGENT="${PIXEL_AGENT:-pixel-stub-pixel}"
+
+if [ -z "$TOKEN" ] || [ -z "$DEMO_POD" ]; then
+  echo "error: TOKEN and DEMO_POD must be set (via env or $SMOKE_ENV)" >&2
+  exit 2
+fi
+
+# --- counters -------------------------------------------------------------
+PASS=0; FAIL=0; SKIP=0
+FAILED_TAGS=""
+
+# --- helpers --------------------------------------------------------------
+green() { printf "[\033[32m%s\033[0m] green%s\n" "$1" "${2:+ $2}"; PASS=$((PASS+1)); }
+red()   { printf "[\033[31m%s\033[0m] red%s\n"   "$1" "${2:+ $2}"; FAIL=$((FAIL+1)); FAILED_TAGS="$FAILED_TAGS $1"; }
+todo()  { printf "[\033[33m%s\033[0m] TODO%s\n"  "$1" "${2:+ $2}"; SKIP=$((SKIP+1)); }
+
+# Curl with auth + short timeout. Sets globals HTTP_CODE + HTTP_BODY.
+# Don't capture via $(http ...) — that's a subshell, the globals would be
+# lost. Call directly, then read HTTP_BODY / HTTP_CODE.
+HTTP_BODY=""
+http() {
+  local method="$1" path="$2" body="${3:-}"
+  HTTP_CODE=000
+  HTTP_BODY=""
+  local args=(-sS -w "\n%{http_code}" -X "$method" -H "Authorization: Bearer $TOKEN" --max-time 30)
+  if [ -n "$body" ]; then
+    args+=(-H "Content-Type: application/json" -d "$body")
+  fi
+  local raw
+  raw=$(curl "${args[@]}" "${API}${path}" 2>/dev/null) || return 1
+  HTTP_CODE="${raw##*$'\n'}"
+  HTTP_BODY="${raw%$'\n'*}"
+  return 0
+}
+
+# --- baseline checks ------------------------------------------------------
+
+# auth — does the token resolve to a user. /api/auth/me 404s on this backend;
+# use a route that requires auth and returns username consistently.
+http GET "/api/pods"
+if [ "$HTTP_CODE" = "200" ]; then
+  green auth "token resolves (GET /api/pods 200)"
+else
+  red auth "HTTP=$HTTP_CODE"
+fi
+
+# pod-load
+http GET "/api/pods/$DEMO_POD"
+if [ "$HTTP_CODE" = "200" ]; then
+  members=$(echo "$HTTP_BODY" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(len(d.get("members",[])))' 2>/dev/null || echo 0)
+  if [ "$members" -ge 5 ]; then
+    green pod-load "members=$members"
+  else
+    red pod-load "members=$members (<5)"
+  fi
+else
+  red pod-load "HTTP=$HTTP_CODE"
+fi
+
+# scrollback
+http GET "/api/messages/$DEMO_POD?limit=20"
+if [ "$HTTP_CODE" = "200" ]; then
+  count=$(echo "$HTTP_BODY" | python3 -c 'import sys,json; d=json.load(sys.stdin); msgs=d if isinstance(d,list) else d.get("messages",[]); print(len(msgs))' 2>/dev/null || echo 0)
+  if [ "$count" -ge 15 ]; then
+    green scrollback "count=$count"
+  else
+    red scrollback "count=$count (<15)"
+  fi
+else
+  red scrollback "HTTP=$HTTP_CODE"
+fi
+
+# file-preview — sample asset must be reachable
+# TODO: parameterize asset path; for now grep an asset URL from the scrollback
+asset_path=$(echo "$HTTP_BODY" | python3 -c '
+import sys, re, json
+msgs = json.load(sys.stdin)
+msgs = msgs if isinstance(msgs, list) else msgs.get("messages", [])
+for m in msgs:
+  content = m.get("content","") or ""
+  m_re = re.search(r"\[\[file:([^|\]]+)", content)
+  if m_re:
+    print(m_re.group(1)); break
+' 2>/dev/null || true)
+if [ -n "$asset_path" ]; then
+  todo file-preview "found asset token '$asset_path' (route check not yet implemented)"
+else
+  todo file-preview "no file tokens in scrollback"
+fi
+
+# --- mention-response — checks that the wired agents are actually alive --
+# Posts a unique-timestamped @nova message, polls for a reply within 90s.
+ts=$(date +%s)
+marker="smoke-test-$ts"
+post_body=$(printf '{"content":"@nova smoke %s — please ack briefly"}' "$marker")
+http POST "/api/messages/$DEMO_POD" "$post_body"
+if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
+  red mention-response "post HTTP=$HTTP_CODE"
+else
+  found="no"
+  for i in $(seq 1 18); do
+    sleep 5
+    http GET "/api/messages/$DEMO_POD?limit=10"
+    if echo "$HTTP_BODY" | python3 -c "
+import sys,json
+msgs = json.load(sys.stdin)
+msgs = msgs if isinstance(msgs,list) else msgs.get('messages',[])
+for m in msgs[-10:]:
+  u = (m.get('username') or '').lower()
+  c = (m.get('content','') or '').lower()
+  if ('nova' in u) and ('$marker' in c or 'smoke' in c):
+    sys.exit(0)
+sys.exit(1)
+" 2>/dev/null; then
+      found="yes"; break
+    fi
+  done
+  if [ "$found" = "yes" ]; then
+    green mention-response "nova replied within $((i*5))s"
+  else
+    red mention-response "no nova reply within 90s"
+  fi
+fi
+
+# --- sprint-item checks (TODOs first, fill in as items land) -------------
+
+todo a2a-dm-listable     "depends on B1"
+todo a2a-dm-load         "depends on B1"
+todo byo-page            "depends on B3"
+todo byo-token-issue     "depends on B3"
+todo install-handoff     "depends on B2"
+todo first-msg-empty-state "depends on B4 (Playwright; manual today)"
+todo reaction-add        "depends on B5"
+todo runtime-badges      "depends on C2 (today: pixel-stub-pixel patched)"
+todo talk-to-cli         "depends on agent runtime token issuance; defer"
+
+# --- summary --------------------------------------------------------------
+echo
+echo "summary: $PASS green, $FAIL red, $SKIP TODO"
+if [ -n "$FAILED_TAGS" ]; then
+  echo "failed tags:$FAILED_TAGS"
+  exit 1
+fi
+exit 0

--- a/scripts/smoke-test-demo.sh
+++ b/scripts/smoke-test-demo.sh
@@ -120,7 +120,7 @@ fi
 # Posts a unique-timestamped @nova message, polls for a reply within 90s.
 ts=$(date +%s)
 marker="smoke-test-$ts"
-post_body=$(printf '{"content":"@nova smoke %s — please ack briefly"}' "$marker")
+post_body=$(printf '{"content":"@nova-demo smoke %s — please ack briefly"}' "$marker")
 http POST "/api/messages/$DEMO_POD" "$post_body"
 if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
   red mention-response "post HTTP=$HTTP_CODE"


### PR DESCRIPTION
## Summary

Post-YC demo-fidelity sprint (see `.dev/yc-application/SPRINT_POST_YC.md` for the full plan). Two items:

- **Phase A** — sprint infra: `scripts/smoke-test-demo.sh` (14 tagged checks, exits non-zero on red). Already merged-prep but lives on this branch.
- **Sprint B1** — A2A DM clickable in inspector (storyboard beat 7). New backend route + V2 inspector "Direct messages" card.

## A2A DM surface

Backend GET `/api/registry/pods/:podId/agents/:name/a2a-dms?instanceId=`. Outer pod-member auth + per-DM `DMService.canViewPod` (§3.7 co-pod-member rule). Read-only `User.findOne` (never `getOrCreateAgentUser` on this surface). Batched `User.find` before the per-DM loop. Response omits `botMetadata.agentName` to avoid runtime-label leaks.

Frontend renders the list in `V2PodInspector.renderMemberDetail` — clickable rows that navigate to the DM pod (read-only for the human via §3.7). Cache via `useRef<Set>` not state so the effect dep array stays clean.

## Smoke status

Local baseline: **4 green / 0 red / 10 TODO** (was 3 green / 1 red at sprint start). C0 unblocked this iteration by installing dedicated `openclaw:nova-demo` identity in the demo pod with custom concierge HEARTBEAT.md + adding to `devAgentIds` for the working Codex model.

## Test plan

- [ ] CI green
- [ ] After Deploy Dev, smoke shows `[a2a-dm-listable] green`
- [ ] Manual Playwright: navigate to demo pod → inspector → click any agent → "Direct messages" card renders if DMs exist; clicking a row navigates to that pod

## Self-review

Reviewer subagent caught 2 critical (read-path User upsert + agentName leak in response) + 2 important issues; all addressed in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)