### PR TITLE
feat(reactions): real backend + interactive chips (Sprint B5)

### DIFF
--- a/backend/config/schema.sql
+++ b/backend/config/schema.sql
@@ -43,6 +43,19 @@ CREATE TABLE IF NOT EXISTS users (
 -- Migration: add is_bot column to existing tables (safe to run repeatedly)
 ALTER TABLE users ADD COLUMN IF NOT EXISTS is_bot BOOLEAN DEFAULT false;
 
+-- Sprint B5: message reactions. One row per (message, user, emoji) — a user
+-- can stack different emojis on the same message but each emoji is binary
+-- (toggle on/off). PG-only; Mongo fallback path doesn't get reactions in v1.
+CREATE TABLE IF NOT EXISTS message_reactions (
+  id SERIAL PRIMARY KEY,
+  message_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+  user_id VARCHAR(24) NOT NULL,
+  emoji VARCHAR(32) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (message_id, user_id, emoji)
+);
+CREATE INDEX IF NOT EXISTS idx_message_reactions_message_id ON message_reactions(message_id);
+
 -- Create indexes for better performance
 CREATE INDEX IF NOT EXISTS idx_messages_pod_id ON messages(pod_id);
 CREATE INDEX IF NOT EXISTS idx_messages_created_at ON messages(created_at);

--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -100,6 +100,27 @@ exports.getMessages = async (req: AuthRequest, res: Response): Promise<void> => 
 
     try {
       const messages = await PGMessage.findByPodId(podId, parseInt(String(limit), 10), before);
+      // Sprint B5: attach reactions per message in one batched query
+      // (MessageReaction.listForMessages aggregates by GROUP BY).
+      // Falls through to `messages` unchanged on any reaction lookup error.
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+        const MessageReaction = require('../models/pg/MessageReaction').default;
+        const ids = (messages as Array<{ id?: string; _id?: string }>)
+          .map((m) => m.id || m._id)
+          .filter(Boolean);
+        if (ids.length > 0) {
+          const reactionsMap = await MessageReaction.listForMessages(ids, String(userId));
+          for (const m of messages as Array<{ id?: string; _id?: string; reactions?: unknown }>) {
+            const key = String(m.id || m._id || '');
+            m.reactions = reactionsMap.get(key) || [];
+          }
+        }
+      } catch (rxnErr) {
+        // Non-fatal: reactions are a render enhancement.
+        // eslint-disable-next-line no-console
+        console.warn('[messages] reaction enrichment skipped:', (rxnErr as Error).message);
+      }
       res.json(messages);
       return;
     } catch (pgErr) {

--- a/backend/controllers/reactionController.ts
+++ b/backend/controllers/reactionController.ts
@@ -1,0 +1,138 @@
+// Sprint B5: reaction add / remove controller. Per-message toggle —
+// adding a reaction the user already left is a no-op (idempotent via
+// the unique constraint); removing one they don't have is also a no-op.
+// Both endpoints emit a `messageReaction` Socket.io event into
+// `pod_${podId}` so other clients animate the chip without polling.
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const MessageReaction = require('../models/pg/MessageReaction').default;
+
+interface AuthedReq {
+  params: { messageId?: string; emoji?: string };
+  body: { emoji?: string };
+  user?: { _id?: unknown };
+  userId?: unknown;
+}
+interface AuthedRes {
+  status: (n: number) => AuthedRes;
+  json: (d: unknown) => void;
+}
+
+const SAFE_EMOJI_RE = /^[\p{Emoji}‍]{1,8}$/u;
+
+function getUserId(req: AuthedReq): string {
+  return String(req.user?._id || req.userId || '');
+}
+
+async function emitReactionChange(messageId: string | number, podId: string, reactions: unknown): Promise<void> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+    const socketConfig = require('../config/socket');
+    const io = socketConfig.getIO?.();
+    if (io && podId) {
+      io.to(`pod_${podId}`).emit('messageReaction', {
+        messageId: String(messageId),
+        podId,
+        reactions,
+      });
+    }
+  } catch (err) {
+    // Socket failure is never fatal — the DB write succeeded; clients
+    // will see the new state on next refresh.
+    // eslint-disable-next-line no-console
+    console.warn('[reactionController] socket emit failed:', (err as Error).message);
+  }
+}
+
+async function loadPodIdForMessage(messageId: string | number): Promise<string | null> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  const { pool } = require('../config/db-pg');
+  const result = await pool.query(
+    'SELECT pod_id FROM messages WHERE id = $1 LIMIT 1',
+    [Number(messageId)],
+  );
+  const row = result.rows[0];
+  return row ? String(row.pod_id) : null;
+}
+
+async function userHasPodMembership(podId: string, userId: string): Promise<boolean> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  const { pool } = require('../config/db-pg');
+  const result = await pool.query(
+    'SELECT 1 FROM pod_members WHERE pod_id = $1 AND user_id = $2 LIMIT 1',
+    [podId, userId],
+  );
+  return (result.rowCount || 0) > 0;
+}
+
+export async function addReaction(req: AuthedReq, res: AuthedRes): Promise<void> {
+  try {
+    const userId = getUserId(req);
+    if (!userId) {
+      res.status(401).json({ msg: 'Unauthorized' });
+      return;
+    }
+    const messageId = req.params.messageId;
+    const emoji = String(req.body.emoji || '').trim();
+    if (!messageId || !emoji) {
+      res.status(400).json({ msg: 'messageId and emoji are required' });
+      return;
+    }
+    if (!SAFE_EMOJI_RE.test(emoji)) {
+      res.status(400).json({ msg: 'emoji must be 1–8 emoji characters' });
+      return;
+    }
+    const podId = await loadPodIdForMessage(messageId);
+    if (!podId) {
+      res.status(404).json({ msg: 'Message not found' });
+      return;
+    }
+    if (!(await userHasPodMembership(podId, userId))) {
+      res.status(403).json({ msg: 'Not a member of this pod' });
+      return;
+    }
+    await MessageReaction.add(messageId, userId, emoji);
+    const reactions = await MessageReaction.listForMessage(messageId, userId);
+    void emitReactionChange(messageId, podId, reactions);
+    res.json({ ok: true, reactions });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('Error in addReaction:', (err as Error).message);
+    res.status(500).json({ msg: 'Server Error' });
+  }
+}
+
+export async function removeReaction(req: AuthedReq, res: AuthedRes): Promise<void> {
+  try {
+    const userId = getUserId(req);
+    if (!userId) {
+      res.status(401).json({ msg: 'Unauthorized' });
+      return;
+    }
+    const messageId = req.params.messageId;
+    const emoji = String(req.params.emoji || '').trim();
+    if (!messageId || !emoji) {
+      res.status(400).json({ msg: 'messageId and emoji are required' });
+      return;
+    }
+    const podId = await loadPodIdForMessage(messageId);
+    if (!podId) {
+      res.status(404).json({ msg: 'Message not found' });
+      return;
+    }
+    if (!(await userHasPodMembership(podId, userId))) {
+      res.status(403).json({ msg: 'Not a member of this pod' });
+      return;
+    }
+    await MessageReaction.remove(messageId, userId, emoji);
+    const reactions = await MessageReaction.listForMessage(messageId, userId);
+    void emitReactionChange(messageId, podId, reactions);
+    res.json({ ok: true, reactions });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('Error in removeReaction:', (err as Error).message);
+    res.status(500).json({ msg: 'Server Error' });
+  }
+}
+
+module.exports = { addReaction, removeReaction };

--- a/backend/models/pg/MessageReaction.ts
+++ b/backend/models/pg/MessageReaction.ts
@@ -1,0 +1,104 @@
+// Sprint B5: message reactions backend model. Toggle-style (one row per
+// (message, user, emoji), unique constraint enforces no duplicates).
+// Aggregation for read happens at the SQL level — clients get
+// `{emoji: count, mine: emoji[]}` shapes.
+
+interface PgPool {
+  query: (sql: string, params?: unknown[]) => Promise<{
+    rows: Record<string, unknown>[];
+    rowCount?: number;
+  }>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { pool } = require('../../config/db-pg') as { pool: PgPool };
+
+export interface ReactionSummary {
+  emoji: string;
+  count: number;
+  mine: boolean;
+}
+
+class MessageReaction {
+  /** Add (idempotent on the unique constraint — INSERT…ON CONFLICT DO NOTHING). */
+  static async add(messageId: string | number, userId: string, emoji: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO message_reactions (message_id, user_id, emoji)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (message_id, user_id, emoji) DO NOTHING`,
+      [Number(messageId), userId, emoji],
+    );
+  }
+
+  /** Remove (idempotent — DELETE matches at most one row per the unique key). */
+  static async remove(messageId: string | number, userId: string, emoji: string): Promise<void> {
+    await pool.query(
+      `DELETE FROM message_reactions
+       WHERE message_id = $1 AND user_id = $2 AND emoji = $3`,
+      [Number(messageId), userId, emoji],
+    );
+  }
+
+  /**
+   * Aggregated reactions for a single message keyed by emoji. Includes a
+   * `mine` flag so frontend can highlight the user's own reactions
+   * without a second query.
+   */
+  static async listForMessage(messageId: string | number, userId: string): Promise<ReactionSummary[]> {
+    const result = await pool.query(
+      `SELECT emoji,
+              COUNT(*)::int AS count,
+              BOOL_OR(user_id = $2) AS mine
+       FROM message_reactions
+       WHERE message_id = $1
+       GROUP BY emoji
+       ORDER BY COUNT(*) DESC, emoji ASC`,
+      [Number(messageId), userId],
+    );
+    return result.rows.map((r) => ({
+      emoji: String(r.emoji),
+      count: Number(r.count) || 0,
+      mine: Boolean(r.mine),
+    }));
+  }
+
+  /**
+   * Bulk fetch reactions for a batch of message IDs — used by the
+   * messages list path to avoid N+1. Returns a Map keyed by message id.
+   */
+  static async listForMessages(
+    messageIds: Array<string | number>,
+    userId: string,
+  ): Promise<Map<string, ReactionSummary[]>> {
+    const out = new Map<string, ReactionSummary[]>();
+    if (!messageIds.length) return out;
+    const ids = messageIds.map((id) => Number(id)).filter((n) => Number.isFinite(n));
+    if (!ids.length) return out;
+    const result = await pool.query(
+      `SELECT message_id,
+              emoji,
+              COUNT(*)::int AS count,
+              BOOL_OR(user_id = $2) AS mine
+       FROM message_reactions
+       WHERE message_id = ANY($1::int[])
+       GROUP BY message_id, emoji
+       ORDER BY message_id, COUNT(*) DESC, emoji ASC`,
+      [ids, userId],
+    );
+    for (const r of result.rows) {
+      const key = String(r.message_id);
+      const list = out.get(key) || [];
+      list.push({
+        emoji: String(r.emoji),
+        count: Number(r.count) || 0,
+        mine: Boolean(r.mine),
+      });
+      out.set(key, list);
+    }
+    return out;
+  }
+}
+
+export default MessageReaction;
+module.exports = MessageReaction;
+module.exports.default = MessageReaction;

--- a/backend/routes/messages.ts
+++ b/backend/routes/messages.ts
@@ -12,6 +12,11 @@ const {
   createMessage,
   deleteMessage,
 } = require('../controllers/messageController');
+// eslint-disable-next-line global-require
+const {
+  addReaction,
+  removeReaction,
+} = require('../controllers/reactionController');
 
 interface RateLimitReq {
   ip?: string;
@@ -51,6 +56,29 @@ const router: ReturnType<typeof express.Router> = express.Router();
 router.get('/:podId', auth, getMessages);
 router.post('/:podId', sendMessageRateLimit, auth, createMessage);
 router.delete('/:id', auth, deleteMessage);
+
+// Sprint B5 — reactions. Lives under /:messageId/reactions so the
+// `:podId` route above doesn't shadow it (Express routes by order +
+// specificity). reactionRateLimit shares the same shape as the
+// send-message limiter; CodeQL recognises it inline on each route.
+const reactionRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req: RateLimitReq) => {
+    const authHeader = req.get?.('authorization');
+    if (authHeader) {
+      return `rxn:${createHash('sha256').update(authHeader).digest('hex').slice(0, 16)}`;
+    }
+    return req.ip ? ipKeyGenerator(req.ip) : 'anon';
+  },
+  handler: (_req: unknown, res: RateLimitRes) => {
+    res.status(429).json({ msg: 'rate limit exceeded: 120 reactions per 60s' });
+  },
+});
+router.post('/:messageId/reactions', reactionRateLimit, auth, addReaction);
+router.delete('/:messageId/reactions/:emoji', reactionRateLimit, auth, removeReaction);
 
 // Backdate a message's `created_at`. Pod-creator-only (or message author);
 // no general-purpose user authorization for editing other people's chronology.

--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import V2Avatar from './V2Avatar';
@@ -6,6 +6,7 @@ import V2GithubPrCard, { parseGithubPrUrls } from './V2GithubPrCard';
 import { V2Message } from '../hooks/useV2PodDetail';
 import { formatRelativeTime } from '../utils/grouping';
 import { useAuth } from '../../context/AuthContext';
+import { useV2Api } from '../hooks/useV2Api';
 import { getSignedAttachmentUrl } from '../../utils/signedAttachmentUrl';
 
 // Minimal v2-scoped markdown renderer. Plain HTML elements (no MUI), so
@@ -275,9 +276,19 @@ const parseAgentDmEvent = (content: string | undefined): { headline: string; tar
   return { headline: match[1], targetPodId: match[2] };
 };
 
+// Sprint B5: shared picker palette. 6 emojis chosen to span the common
+// reaction intents: agree / love / fire / brain / eyes / launch. Keep
+// small so the popover stays compact and doesn't overflow narrow chat
+// columns in mobile shells.
+const REACTION_PALETTE = ['👍', '❤️', '🔥', '🤔', '👀', '🚀'];
+
 const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agentDisplayNames, agentAuthorKeys, onAuthorClick, onOpenFile }) => {
   const { currentUser } = useAuth();
   const navigate = useNavigate();
+  const api = useV2Api();
+  // Picker state per message. Open via "+ react"; close on first click
+  // (no need for outside-click handling — the picker hides after action).
+  const [pickerOpen, setPickerOpen] = useState(false);
   const rawUsername = message.user?.username || 'Unknown';
   const overriddenDisplay = agentDisplayNames?.get(rawUsername);
   const author = overriddenDisplay || rawUsername;
@@ -415,16 +426,97 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
             number={pr.number}
           />
         ))}
-        {reactions.length > 0 && (
-          <div className="v2-msg__reactions" aria-label="Reactions">
-            {reactions.map((r, idx) => (
-              <span key={`${r.emoji}-${idx}`} className="v2-msg__reaction" title={`${r.count} ${r.emoji}`}>
-                <span className="v2-msg__reaction-emoji">{r.emoji}</span>
-                <span className="v2-msg__reaction-count">{r.count}</span>
-              </span>
-            ))}
-          </div>
-        )}
+        {(() => {
+          // Sprint B5: real reactions come from message.reactions (server-
+          // aggregated `[{emoji, count, mine}]`). Legacy fixtures use the
+          // token-parsed `reactions` from parseReactions above. Real wins
+          // when present; tokens are the demo-recording stand-in.
+          const liveReactions = message.reactions;
+          const hasLive = Array.isArray(liveReactions);
+          const messageId = String(message.id || message._id || '');
+          const canInteract = hasLive && messageId && /^\d+$/.test(messageId);
+
+          const toggle = async (emoji: string, mine: boolean) => {
+            if (!canInteract) return;
+            try {
+              if (mine) {
+                await api.del(`/api/messages/${messageId}/reactions/${encodeURIComponent(emoji)}`);
+              } else {
+                await api.post(`/api/messages/${messageId}/reactions`, { emoji });
+              }
+              // Optimistic update is unnecessary — the socket `messageReaction`
+              // event from the backend updates the message list in place.
+            } catch (err) {
+              // Defensive: ignore (likely 429 or 403); next list refresh corrects.
+              // eslint-disable-next-line no-console
+              console.warn('[reactions] toggle failed:', (err as Error).message);
+            } finally {
+              setPickerOpen(false);
+            }
+          };
+
+          if (hasLive && liveReactions!.length === 0 && !canInteract) {
+            // Token-fixture path with no parsed entries: render nothing.
+            if (reactions.length === 0) return null;
+          }
+
+          // Decide which list to render. If the server gave us a real
+          // reactions array (even empty) use it; else fall back to tokens.
+          const renderList = hasLive
+            ? liveReactions!
+            : reactions.map((r) => ({ emoji: r.emoji, count: r.count, mine: false }));
+
+          if (renderList.length === 0 && !canInteract) return null;
+
+          return (
+            <div className="v2-msg__reactions" aria-label="Reactions">
+              {renderList.map((r, idx) => (
+                <button
+                  key={`${r.emoji}-${idx}`}
+                  type="button"
+                  className={`v2-msg__reaction${r.mine ? ' v2-msg__reaction--mine' : ''}`}
+                  title={`${r.count} ${r.emoji}${r.mine ? ' (you)' : ''}`}
+                  onClick={() => toggle(r.emoji, !!r.mine)}
+                  disabled={!canInteract}
+                >
+                  <span className="v2-msg__reaction-emoji">{r.emoji}</span>
+                  <span className="v2-msg__reaction-count">{r.count}</span>
+                </button>
+              ))}
+              {canInteract && (
+                <span className="v2-msg__reaction-add-wrap">
+                  <button
+                    type="button"
+                    className="v2-msg__reaction-add"
+                    aria-label="Add reaction"
+                    onClick={() => setPickerOpen((v) => !v)}
+                  >
+                    +
+                  </button>
+                  {pickerOpen && (
+                    <span className="v2-msg__reaction-picker" role="menu">
+                      {REACTION_PALETTE.map((e) => {
+                        const existing = renderList.find((x) => x.emoji === e);
+                        const mine = !!existing?.mine;
+                        return (
+                          <button
+                            key={e}
+                            type="button"
+                            role="menuitem"
+                            className={`v2-msg__reaction-picker-item${mine ? ' v2-msg__reaction-picker-item--mine' : ''}`}
+                            onClick={() => toggle(e, mine)}
+                          >
+                            {e}
+                          </button>
+                        );
+                      })}
+                    </span>
+                  )}
+                </span>
+              )}
+            </div>
+          );
+        })()}
       </div>
     </div>
   );

--- a/frontend/src/v2/hooks/useV2PodDetail.ts
+++ b/frontend/src/v2/hooks/useV2PodDetail.ts
@@ -21,6 +21,10 @@ export interface V2Message {
     username?: string;
     profilePicture?: string | null;
   };
+  // Sprint B5: per-message reactions, aggregated server-side. Each entry
+  // is {emoji, count, mine}. Absent in legacy fixtures + on Mongo fallback;
+  // bubbles fall back to the token-parsed `[[reactions:...]]` shape if so.
+  reactions?: Array<{ emoji: string; count: number; mine: boolean }>;
 }
 
 export interface V2Agent {
@@ -195,9 +199,24 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
         return chronologicalMessages([...prev, normalized]);
       });
     };
+    // Sprint B5: socket-driven reaction updates. Backend emits
+    // `messageReaction` with the new aggregated list after every add/remove
+    // by any user. We patch only the matching message's `reactions` array
+    // — no other state churn.
+    const handleReactionChange = (payload: { messageId: string; podId?: string; reactions: Array<{ emoji: string; count: number; mine: boolean }> }) => {
+      if (!payload || !payload.messageId) return;
+      if (payload.podId && payload.podId !== podId) return;
+      setMessages((prev) => prev.map((m) => (
+        String(m.id) === String(payload.messageId)
+          ? { ...m, reactions: payload.reactions }
+          : m
+      )));
+    };
     socket.on('newMessage', handleNewMessage);
+    socket.on('messageReaction', handleReactionChange);
     return () => {
       socket.off('newMessage', handleNewMessage);
+      socket.off('messageReaction', handleReactionChange);
       leavePod(podId);
     };
   }, [podId, socket, connected, joinPod, leavePod]);

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4356,3 +4356,89 @@
   font-weight: 600;
   font-size: 11px;
 }
+
+/* Sprint B5 — interactive reaction chips + picker. Mine = filled
+ * indigo; not-mine = subtle gray (existing rule above). Same
+ * specificity workaround as other v2 buttons. */
+.v2-root button.v2-msg__reaction {
+  cursor: pointer;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  color: #4b5563;
+  height: 24px;
+  padding: 0 8px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  line-height: 1;
+}
+.v2-root button.v2-msg__reaction--mine {
+  background: #eef2ff;
+  border-color: #c7d2fe;
+  color: #4338ca;
+}
+.v2-root button.v2-msg__reaction:hover:not(:disabled) {
+  background: #e0e7ff;
+  border-color: #a5b4fc;
+}
+.v2-root button.v2-msg__reaction:disabled {
+  cursor: default;
+  opacity: 0.8;
+}
+
+.v2-msg__reaction-add-wrap {
+  position: relative;
+  display: inline-flex;
+}
+.v2-root button.v2-msg__reaction-add {
+  height: 24px;
+  width: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px dashed #d1d5db;
+  border-radius: 999px;
+  font-size: 14px;
+  color: #6b7280;
+  cursor: pointer;
+}
+.v2-root button.v2-msg__reaction-add:hover {
+  background: #f9fafb;
+  border-color: #9ca3af;
+  color: #111827;
+}
+.v2-msg__reaction-picker {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  display: flex;
+  gap: 2px;
+  padding: 4px;
+  background: var(--v2-surface, #fff);
+  border: 1px solid var(--v2-border, #e5e7eb);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  z-index: 10;
+}
+.v2-root button.v2-msg__reaction-picker-item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  font-size: 16px;
+  cursor: pointer;
+  transition: background 0.1s ease;
+}
+.v2-root button.v2-msg__reaction-picker-item:hover {
+  background: #f3f4f6;
+}
+.v2-root button.v2-msg__reaction-picker-item--mine {
+  background: #eef2ff;
+}

--- a/scripts/smoke-test-demo.sh
+++ b/scripts/smoke-test-demo.sh
@@ -171,7 +171,34 @@ todo byo-page            "depends on B3"
 todo byo-token-issue     "depends on B3"
 todo install-handoff     "depends on B2"
 todo first-msg-empty-state "depends on B4 (Playwright; manual today)"
-todo reaction-add        "depends on B5"
+# B5: reactions roundtrip — pick any message from scrollback, add 👍, verify, delete, verify.
+http GET "/api/messages/$DEMO_POD?limit=5"
+rxn_msg_id=$(echo "$HTTP_BODY" | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+msgs = d if isinstance(d, list) else d.get("messages", [])
+for m in msgs[-5:]:
+  mid = m.get("id") or m.get("_id")
+  if mid and str(mid).isdigit():
+    print(mid); break
+' 2>/dev/null)
+if [ -z "$rxn_msg_id" ]; then
+  red reaction-add "no integer-id message in scrollback"
+else
+  http POST "/api/messages/$rxn_msg_id/reactions" '{"emoji":"👍"}'
+  if [ "$HTTP_CODE" = "200" ]; then
+    has_thumbsup=$(echo "$HTTP_BODY" | python3 -c 'import sys,json; d=json.load(sys.stdin); print("yes" if any(r.get("emoji")=="👍" and r.get("mine") for r in (d.get("reactions") or [])) else "no")' 2>/dev/null || echo no)
+    if [ "$has_thumbsup" = "yes" ]; then
+      # Cleanup so the smoke is idempotent.
+      http DELETE "/api/messages/$rxn_msg_id/reactions/%F0%9F%91%8D"
+      green reaction-add "POST 200 + 👍 mine=true; cleaned up"
+    else
+      red reaction-add "POST 200 but reaction not visible as mine"
+    fi
+  else
+    red reaction-add "POST HTTP=$HTTP_CODE"
+  fi
+fi
 todo runtime-badges      "depends on C2 (today: pixel-stub-pixel patched)"
 todo talk-to-cli         "depends on agent runtime token issuance; defer"
 


### PR DESCRIPTION
## Summary

Sprint B5 of the post-YC demo-fidelity sprint. Reactions until now were a pure token-rendered fixture (`[[reactions:👍 3]]` in message content). This ships the real product surface: PG table, REST endpoints, Socket.io broadcasts, interactive bubble UI with chip toggle + emoji picker.

## Schema

`message_reactions(message_id, user_id, emoji)` with a unique key. Idempotent migration in `backend/config/schema.sql`.

## API

- `POST /api/messages/:id/reactions { emoji }` — add
- `DELETE /api/messages/:id/reactions/:emoji` — remove
- Both: auth + pod-member gated, emoji validated to 1–8 emoji chars (`\\p{Emoji}`)
- `GET /api/messages/:podId` now enriches each message with `reactions: [{emoji, count, mine}]` via a bulk PG aggregate

## Realtime

Socket.io `messageReaction` event broadcasts the new aggregated list into `pod_${podId}` after every write. `useV2PodDetail` subscribes and patches the matching message in place.

## UI

`V2MessageBubble` renders real reactions when present (`mine` highlighted), falls back to the token-parsed fixtures for messages from the Mongo fallback path. Chip click toggles via POST/DELETE; new "+ react" button opens a 6-emoji palette popover.

## Smoke

`[reaction-add]` flips green when the full round-trip works: POST on a demo pod message → response includes `reactions[] with mine:true` for 👍 → cleanup DELETE.

## Test plan

- [ ] CI green
- [ ] After Deploy Dev, smoke shows `[reaction-add] green`
- [ ] Open a demo pod message in V2 → click 👍 chip on any prior message → see count tick + chip highlight → click again → unreact

🤖 Generated with [Claude Code](https://claude.com/claude-code)