### PR TITLE
fix(v2-inspector): #310 React hook-order — a2a-dm useRef above pod early return

### DIFF
--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -931,6 +931,41 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
     onPendingOpenFileNameConsumed?.();
   }, [pendingOpenFileName, podFiles, onOpenArtifact, onPendingOpenFileNameConsumed]);
 
+  // Sprint B1 — fetch the agent's a2a-DM list when a member is selected.
+  // MUST live above the `if (!pod) return` early return below; otherwise
+  // hooks order shifts when pod transitions null→loaded and React errors
+  // out with #310 ("Rendered fewer hooks than expected"). The ref-backed
+  // cache key includes pod._id so cross-pod inspector loads re-fetch.
+  const a2aDmsFetchedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (!pod || view.kind !== 'member') return;
+    const agent = agentByKey.get(view.agentKey);
+    if (!agent) return;
+    const key = `${pod._id}:${agentKeyOf(agent)}`;
+    if (a2aDmsFetchedRef.current.has(key)) return;
+    a2aDmsFetchedRef.current.add(key);
+    let cancelled = false;
+    (async () => {
+      try {
+        const url = `/api/registry/pods/${pod._id}/agents/${encodeURIComponent(agent.agentName)}/a2a-dms?instanceId=${encodeURIComponent(agent.instanceId || 'default')}`;
+        const data = await api.get<{ a2aDms?: Array<{ podId: string; name: string; otherMember: { displayName: string; isBot: boolean } | null; updatedAt?: string }> }>(url);
+        const list = data?.a2aDms || [];
+        if (!cancelled) {
+          setA2aDmsByAgent((prev) => ({ ...prev, [key]: list }));
+        }
+      } catch (err) {
+        // Defensive: any error renders the section empty rather than
+        // blocking the detail panel. Allow retry by clearing the ref
+        // entry so a subsequent re-select re-attempts the fetch.
+        if (!cancelled) {
+          a2aDmsFetchedRef.current.delete(key);
+          setA2aDmsByAgent((prev) => ({ ...prev, [key]: [] }));
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [view, pod, agentByKey, api]);
+
   if (!pod) return <aside className="v2-pane v2-pane--inspector" />;
 
   const isPrivatePod = pod.type === 'agent-room';
@@ -1305,42 +1340,6 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   // ------------------------------------------------------------------
   // MEMBER DETAIL sub-page
   // ------------------------------------------------------------------
-  // Fetch the agent's a2a-DM list when a member is selected. Cached by
-  // agentKey; the list is small (DMs are bounded per agent). We track
-  // already-fetched keys in a ref (not state) so the effect's dep array
-  // doesn't include the cache itself — setA2aDmsByAgent updates the
-  // state object every load, and including that ref in deps would
-  // re-run the effect on every change (harmless given the in-effect
-  // guard, but wasteful).
-  const a2aDmsFetchedRef = useRef<Set<string>>(new Set());
-  useEffect(() => {
-    if (view.kind !== 'member') return;
-    const agent = agentByKey.get(view.agentKey);
-    if (!agent) return;
-    const key = `${pod._id}:${agentKeyOf(agent)}`;
-    if (a2aDmsFetchedRef.current.has(key)) return;
-    a2aDmsFetchedRef.current.add(key);
-    let cancelled = false;
-    (async () => {
-      try {
-        const url = `/api/registry/pods/${pod._id}/agents/${encodeURIComponent(agent.agentName)}/a2a-dms?instanceId=${encodeURIComponent(agent.instanceId || 'default')}`;
-        const data = await api.get<{ a2aDms?: Array<{ podId: string; name: string; otherMember: { displayName: string; isBot: boolean } | null; updatedAt?: string }> }>(url);
-        const list = data?.a2aDms || [];
-        if (!cancelled) {
-          setA2aDmsByAgent((prev) => ({ ...prev, [key]: list }));
-        }
-      } catch (err) {
-        // Defensive: any error renders the section empty rather than
-        // blocking the detail panel. Allow retry by clearing the ref
-        // entry so a subsequent re-select re-attempts the fetch.
-        if (!cancelled) {
-          a2aDmsFetchedRef.current.delete(key);
-          setA2aDmsByAgent((prev) => ({ ...prev, [key]: [] }));
-        }
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [view, pod._id, agentByKey, api]);
 
   const renderMemberDetail = (agentKey: string) => {
     const agent = agentByKey.get(agentKey);


### PR DESCRIPTION
## Summary

Hotfix for production. React error #310 (\"Rendered fewer hooks than expected\") fires on every agent-room page load because my Sprint B1 \`useRef\` + \`useEffect\` were declared **below** the \`if (!pod) return <aside />\` early return in V2PodInspector. When pod transitions null→loaded between renders, hook count shifts, tripping React's invariant.

Fix: hoist the useRef + useEffect above the early return. Effect guards with \`if (!pod || view.kind !== 'member') return\` so it no-ops during the loading window.

## Repro

Pre-fix: navigate to \`/v2/pods/69f84fca15832b20bd8eb6c3\` (Nova agent-room) → page shows \"Something went wrong\" with React #310.

Post-fix: agent-room page renders normally; B4 empty-state chips visible.

## Test plan

- [ ] CI green (TS compile + tests pass — no logic change)
- [ ] After Deploy Dev, /v2/pods/69f84fca15832b20bd8eb6c3 renders the B4 first-message coaching empty-state with 3 chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)