### PR TITLE
feat(v2-agents): BYO via MCP onboarding page (Sprint B3)

### DIFF
--- a/frontend/src/v2/V2App.tsx
+++ b/frontend/src/v2/V2App.tsx
@@ -19,6 +19,7 @@ import Dashboard from '../components/Dashboard';
 import DailyDigest from '../components/DailyDigest';
 import AppsMarketplacePage from '../components/apps/AppsMarketplacePage';
 import AgentsHub from '../components/agents/AgentsHub';
+import V2AgentBYO from './components/V2AgentBYO';
 import SkillsCatalogPage from '../components/skills/SkillsCatalogPage';
 import ActivityFeedPage from '../components/activity/ActivityFeedPage';
 import AnalyticsDashboard from '../components/analytics/AnalyticsDashboard';
@@ -184,6 +185,10 @@ const V2App: React.FC = () => {
                 <Route
                   path="agents/browse"
                   element={feature('Hire an agent', 'Browse and install agents from the catalog.', <AgentsHub />)}
+                />
+                <Route
+                  path="agents/byo"
+                  element={<V2AgentBYO />}
                 />
                 <Route
                   path="marketplace"

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -1,0 +1,254 @@
+// Sprint B3: "Bring your own agent (Claude Code / Cursor / Codex via MCP)"
+// onboarding page. Replaces the pixel-stub adapter hack from the YC video
+// with a real install path — anyone with a Commonly account can wire up
+// their own MCP-capable runtime in <2 minutes by following the steps here.
+//
+// The page collects {name, pod} → POSTs `/api/registry/install` with
+// `config.runtime.runtimeType: 'webhook'` to synthesize an ephemeral
+// AgentRegistry row + AgentInstallation (per ADR-006 §Self-serve install).
+// Then POSTs `/api/registry/pods/:podId/agents/:name/runtime-tokens`
+// with `force: true` to retrieve the raw `cm_agent_*` token.
+//
+// The token is displayed once + the `claude mcp add` snippet, copy-button
+// next to each. Token is NOT persisted by Commonly's UI — the user is
+// expected to paste into their MCP host config immediately. They can
+// reissue if lost (re-install + force-issue is idempotent on identity).
+
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import V2FeaturePage from './V2FeaturePage';
+import { useV2Api } from '../hooks/useV2Api';
+import { V2Pod } from '../hooks/useV2Pods';
+
+const DEFAULT_SCOPES = [
+  'context:read', 'summaries:read', 'messages:write', 'messages:read',
+  'posts:write', 'posts:read', 'memory:read', 'memory:write',
+];
+
+const sanitizeAgentName = (raw: string): string => raw
+  .toLowerCase()
+  .replace(/[^a-z0-9-]/g, '-')
+  .replace(/-+/g, '-')
+  .replace(/^-+|-+$/g, '')
+  .slice(0, 64);
+
+const V2AgentBYO: React.FC = () => {
+  const api = useV2Api();
+  const navigate = useNavigate();
+  const [pods, setPods] = useState<V2Pod[]>([]);
+  const [podId, setPodId] = useState<string>('');
+  const [name, setName] = useState<string>('my-mcp-agent');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [issued, setIssued] = useState<{ token: string; agentName: string; podId: string } | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+
+  // Load the user's pods so they can pick which one to install into.
+  // We only show pods they're a member of — install requires membership
+  // per the backend's `userHasPodAccess` check.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await api.get<V2Pod[]>('/api/pods');
+        if (cancelled) return;
+        const list = Array.isArray(data) ? data : [];
+        // Filter to non-DM pods — agent-room/agent-dm/agent-admin are
+        // strict-1:1 surfaces and refuse third-party installs.
+        const installablePods = list.filter((p) => !['agent-room', 'agent-dm', 'agent-admin'].includes(p.type || ''));
+        setPods(installablePods);
+        if (installablePods.length > 0 && !podId) setPodId(installablePods[0]._id);
+      } catch {
+        // Defensive: keep the form usable; user will see the error on submit.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [api, podId]);
+
+  const submit = async () => {
+    setError(null);
+    const cleanName = sanitizeAgentName(name);
+    if (!cleanName) {
+      setError('Agent name must contain at least one letter or digit.');
+      return;
+    }
+    if (!podId) {
+      setError('Pick a pod to install into.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await api.post('/api/registry/install', {
+        agentName: cleanName,
+        podId,
+        scopes: DEFAULT_SCOPES,
+        config: { runtime: { runtimeType: 'webhook' } },
+        displayName: cleanName,
+      });
+      // Force-issue a fresh runtime token — guarantees we get the raw
+      // `cm_agent_*` value (subsequent calls return `existing:true` with
+      // no plaintext; `force:true` rotates).
+      const tokenRes = await api.post<{ token?: string }>(
+        `/api/registry/pods/${encodeURIComponent(podId)}/agents/${encodeURIComponent(cleanName)}/runtime-tokens`,
+        { label: 'BYO MCP — initial issue', force: true },
+      );
+      const tok = tokenRes?.token;
+      if (!tok) {
+        setError('Install succeeded but token issuance returned empty. Retry, or contact ops.');
+      } else {
+        setIssued({ token: tok, agentName: cleanName, podId });
+      }
+    } catch (err) {
+      const e = err as { response?: { data?: { error?: string; message?: string } }; message?: string };
+      setError(e.response?.data?.error || e.response?.data?.message || e.message || 'Install failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const copy = async (key: string, value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(key);
+      setTimeout(() => setCopied((c) => (c === key ? null : c)), 1500);
+    } catch {
+      // Clipboard may be unavailable (non-HTTPS, sandbox); user can select manually.
+    }
+  };
+
+  const apiUrl = typeof window !== 'undefined' && /api-dev|api\./.test(window.location.hostname)
+    ? `https://${window.location.hostname.replace(/^app/, 'api')}`
+    : 'https://api-dev.commonly.me';
+
+  const claudeSnippet = issued
+    ? `claude mcp add commonly \\\n  -e COMMONLY_API_URL=${apiUrl} \\\n  -e COMMONLY_AGENT_TOKEN=${issued.token} \\\n  -- npx -y @commonlyai/mcp`
+    : '';
+
+  const cursorSnippet = issued
+    ? JSON.stringify({
+      mcpServers: {
+        commonly: {
+          command: 'npx',
+          args: ['-y', '@commonlyai/mcp'],
+          env: { COMMONLY_API_URL: apiUrl, COMMONLY_AGENT_TOKEN: issued.token },
+        },
+      },
+    }, null, 2)
+    : '';
+
+  return (
+    <V2FeaturePage
+      eyebrow="Connect any runtime"
+      title="Bring your own agent"
+      description="Connect Claude Code, Cursor, or Codex to your Commonly pods via MCP. ~2 minutes."
+      showPodsSidebar={false}
+    >
+      {!issued && (
+        <div className="v2-byo__form">
+          <label className="v2-byo__field">
+            <span className="v2-byo__label">Agent name</span>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="my-mcp-agent"
+              className="v2-byo__input"
+            />
+            <span className="v2-byo__hint">
+              Lower-case letters, digits, and dashes. This is the identity your agent posts as.
+            </span>
+          </label>
+          <label className="v2-byo__field">
+            <span className="v2-byo__label">Install into pod</span>
+            <select
+              value={podId}
+              onChange={(e) => setPodId(e.target.value)}
+              className="v2-byo__input"
+            >
+              {pods.length === 0 && <option value="">Loading pods…</option>}
+              {pods.map((p) => (
+                <option key={p._id} value={p._id}>{p.name} ({p.type || 'chat'})</option>
+              ))}
+            </select>
+            <span className="v2-byo__hint">
+              Your agent will be installed here. You can install it into more pods later.
+            </span>
+          </label>
+          {error && <div className="v2-byo__error">{error}</div>}
+          <button
+            type="button"
+            onClick={submit}
+            disabled={submitting || !podId}
+            className="v2-byo__submit"
+          >
+            {submitting ? 'Issuing token…' : 'Install + generate token'}
+          </button>
+          <p className="v2-byo__footnote">
+            Or use the CLI: <code>commonly agent init --name &lt;n&gt; --pod &lt;podId&gt;</code>.
+            See <a href="https://github.com/Team-Commonly/commonly/blob/main/docs/MCP_INTEGRATION.md" target="_blank" rel="noopener noreferrer">docs/MCP_INTEGRATION.md</a> for the full walkthrough.
+          </p>
+        </div>
+      )}
+
+      {issued && (
+        <div className="v2-byo__result">
+          <h2>Token issued for <code>{issued.agentName}</code></h2>
+          <p>
+            Copy this <strong>once</strong>. Commonly hashes the token after issuance — if you lose
+            it, come back here and rotate (re-running install with the same name is idempotent on
+            identity; the token is reissued fresh).
+          </p>
+
+          <div className="v2-byo__snippet">
+            <div className="v2-byo__snippet-head">
+              <span>Runtime token</span>
+              <button type="button" onClick={() => copy('tok', issued.token)} className="v2-byo__copy">
+                {copied === 'tok' ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+            <pre className="v2-byo__pre">{issued.token}</pre>
+          </div>
+
+          <div className="v2-byo__snippet">
+            <div className="v2-byo__snippet-head">
+              <span>Claude Code</span>
+              <button type="button" onClick={() => copy('claude', claudeSnippet)} className="v2-byo__copy">
+                {copied === 'claude' ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+            <pre className="v2-byo__pre">{claudeSnippet}</pre>
+          </div>
+
+          <div className="v2-byo__snippet">
+            <div className="v2-byo__snippet-head">
+              <span>Cursor — add to ~/.cursor/mcp.json</span>
+              <button type="button" onClick={() => copy('cursor', cursorSnippet)} className="v2-byo__copy">
+                {copied === 'cursor' ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+            <pre className="v2-byo__pre">{cursorSnippet}</pre>
+          </div>
+
+          <div className="v2-byo__cta-row">
+            <button
+              type="button"
+              onClick={() => navigate(`/v2/pods/${issued.podId}`)}
+              className="v2-byo__submit"
+            >
+              Go to your pod
+            </button>
+            <button
+              type="button"
+              onClick={() => { setIssued(null); }}
+              className="v2-byo__secondary"
+            >
+              Install another
+            </button>
+          </div>
+        </div>
+      )}
+    </V2FeaturePage>
+  );
+};
+
+export default V2AgentBYO;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4442,3 +4442,144 @@
 .v2-root button.v2-msg__reaction-picker-item--mine {
   background: #eef2ff;
 }
+
+/* Sprint B3 — Bring-your-own MCP agent onboarding page. Lives at
+ * /v2/agents/byo. Single-column form + result. Aligned with v2's
+ * border-not-shadow aesthetic; copy buttons use the indigo accent. */
+.v2-byo__form, .v2-byo__result {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  max-width: 640px;
+  margin: 24px 0;
+}
+.v2-byo__result h2 {
+  font-size: 20px;
+  margin: 0 0 4px 0;
+}
+.v2-byo__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.v2-byo__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v2-text-primary);
+}
+.v2-byo__input {
+  padding: 10px 12px;
+  border: 1px solid var(--v2-border);
+  border-radius: 8px;
+  background: var(--v2-surface, #fff);
+  font-size: 14px;
+  color: var(--v2-text-primary);
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+.v2-byo__input:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+.v2-byo__hint {
+  font-size: 12px;
+  color: var(--v2-text-tertiary);
+}
+.v2-byo__error {
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+  color: #991b1b;
+  font-size: 13px;
+}
+.v2-root button.v2-byo__submit {
+  align-self: flex-start;
+  padding: 10px 18px;
+  border-radius: 8px;
+  background: #4338ca;
+  color: #fff;
+  border: 1px solid #4338ca;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+}
+.v2-root button.v2-byo__submit:hover:not(:disabled) {
+  background: #3730a3;
+  border-color: #3730a3;
+}
+.v2-root button.v2-byo__submit:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.v2-root button.v2-byo__secondary {
+  align-self: flex-start;
+  padding: 10px 18px;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--v2-text-secondary);
+  border: 1px solid var(--v2-border);
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+}
+.v2-root button.v2-byo__secondary:hover {
+  background: var(--v2-surface-hover);
+}
+.v2-byo__snippet {
+  border: 1px solid var(--v2-border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--v2-surface);
+}
+.v2-byo__snippet-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background: var(--v2-surface-hover, #f9fafb);
+  border-bottom: 1px solid var(--v2-border);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v2-text-secondary);
+}
+.v2-root button.v2-byo__copy {
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: var(--v2-surface, #fff);
+  border: 1px solid var(--v2-border);
+  color: var(--v2-text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+}
+.v2-root button.v2-byo__copy:hover {
+  background: #eef2ff;
+  border-color: #c7d2fe;
+  color: #4338ca;
+}
+.v2-byo__pre {
+  margin: 0;
+  padding: 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  color: var(--v2-text-primary);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.v2-byo__cta-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+.v2-byo__footnote {
+  font-size: 13px;
+  color: var(--v2-text-tertiary);
+}
+.v2-byo__footnote code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  padding: 2px 6px;
+  background: var(--v2-surface-hover);
+  border-radius: 4px;
+}

--- a/scripts/smoke-test-demo.sh
+++ b/scripts/smoke-test-demo.sh
@@ -167,8 +167,29 @@ else
 fi
 
 todo a2a-dm-load         "depends on B1 frontend deploy + Playwright verification"
-todo byo-page            "depends on B3"
-todo byo-token-issue     "depends on B3"
+todo byo-page            "depends on B3 frontend deploy (route added, Playwright check)"
+
+# B3 — backend round-trip for BYO MCP install. Uses a unique name per
+# smoke run so re-runs don't trip the "already installed" path. Cleanup
+# happens via the next-cycle reset script (C1) — until then the smoke
+# leaves an ephemeral webhook AgentInstallation in the demo pod.
+b3_name="byo-smoke-$(date +%s)"
+http POST "/api/registry/install" "{\"agentName\":\"$b3_name\",\"podId\":\"$DEMO_POD\",\"scopes\":[\"context:read\",\"messages:write\"],\"config\":{\"runtime\":{\"runtimeType\":\"webhook\"}}}"
+if [ "$HTTP_CODE" = "200" ]; then
+  http POST "/api/registry/pods/$DEMO_POD/agents/$b3_name/runtime-tokens" '{"label":"smoke","force":true}'
+  if [ "$HTTP_CODE" = "200" ]; then
+    has_tok=$(echo "$HTTP_BODY" | python3 -c 'import sys,json; d=json.load(sys.stdin); t=d.get("token",""); print("yes" if t.startswith("cm_agent_") else "no")' 2>/dev/null || echo no)
+    if [ "$has_tok" = "yes" ]; then
+      green byo-token-issue "POST install + runtime-token returned cm_agent_*"
+    else
+      red byo-token-issue "token didn't start with cm_agent_"
+    fi
+  else
+    red byo-token-issue "runtime-tokens HTTP=$HTTP_CODE"
+  fi
+else
+  red byo-token-issue "install HTTP=$HTTP_CODE"
+fi
 todo install-handoff     "depends on B2"
 todo first-msg-empty-state "depends on B4 (Playwright; manual today)"
 # B5: reactions roundtrip — pick any message from scrollback, add 👍, verify, delete, verify.


### PR DESCRIPTION
## Summary

Sprint B3 — Bring-your-own MCP agent onboarding. New page at \`/v2/agents/byo\`.

Replaces the pixel-stub adapter hack from the YC video recording with a real install path. Any pod member can wire up a Claude Code / Cursor / Codex agent in ~2 minutes.

## Flow

1. Form: agent name + pod selector
2. POST \`/api/registry/install\` with \`config.runtime.runtimeType: 'webhook'\` (ADR-006 §Self-serve install — synthesizes ephemeral AgentRegistry)
3. POST \`/api/registry/pods/:podId/agents/:name/runtime-tokens {force:true}\` → raw \`cm_agent_*\` token
4. Result screen: token + Claude Code \`claude mcp add\` snippet + Cursor \`mcp.json\` snippet, each with a copy button

## Smoke

\`[byo-token-issue]\` green: install + token issue round-trip returns \`cm_agent_*\`. Total: **7 green / 0 red / 7 TODO**.

## Test plan

- [ ] CI green
- [ ] After Deploy Dev, \`/v2/agents/byo\` renders + form submission issues a token
- [ ] Smoke continues green

🤖 Generated with [Claude Code](https://claude.com/claude-code)