### PR TITLE
chore(demo-reset): broaden cleanup pattern; close C2 by stub-patch revert

### DIFF
--- a/scripts/reset-demo-account.sh
+++ b/scripts/reset-demo-account.sh
@@ -35,21 +35,23 @@ DEMO_POD="${DEMO_POD:-69f841a9063269526de0437c}"
 NAMESPACE="${NAMESPACE:-commonly-dev}"
 
 # ──────────────────────────────────────────────────────────────────────────
-# 1. Clean ephemeral byo-smoke-* installs.
+# 1. Clean ephemeral byo-* installs (anything created by smoke runs or
+#    Playwright trial flows leaves a byo-<purpose>-<ts> AgentInstallation).
+#    Catches byo-smoke-*, byo-handoff-probe, byo-playwright-test-*, etc.
 # ──────────────────────────────────────────────────────────────────────────
-echo "[reset] (1/4) uninstalling byo-smoke-* AgentInstallations from $DEMO_POD…"
+echo "[reset] (1/4) uninstalling byo-* AgentInstallations from $DEMO_POD…"
 removed=$(kubectl exec -n "$NAMESPACE" deployment/backend -- node -e "
 const m=require('mongoose');
 m.connect(process.env.MONGO_URI).then(async ()=>{
   const AI=m.connection.db.collection('agentinstallations');
   const r=await AI.updateMany(
-    {podId: m.Types.ObjectId.createFromHexString('$DEMO_POD'), agentName: {\$regex: '^byo-smoke-'}, status: 'active'},
+    {podId: m.Types.ObjectId.createFromHexString('$DEMO_POD'), agentName: {\$regex: '^byo-'}, status: 'active'},
     {\$set: {status: 'uninstalled', updatedAt: new Date()}}
   );
   console.log(r.modifiedCount);
   process.exit(0);
 })" 2>/dev/null | tail -1)
-echo "[reset]     uninstalled $removed byo-smoke-* row(s)"
+echo "[reset]     uninstalled $removed byo-* row(s)"
 
 # ──────────────────────────────────────────────────────────────────────────
 # 2. Demote any non-demo openclaw installations in the demo pod.


### PR DESCRIPTION
## Summary
Closes Sprint C2 by reversion + tightens the demo-reset script.

**C2 closed not by adding a 3rd-runtime agent, but by reverting the stub.js DEMO OVERRIDE patch** in the linked `_external/clawdbot-cli` worktree (`cli/src/lib/adapters/stub.js`). Rationale: building a sustainable 3rd runtime into the platform would violate the kernel rule \"we are NOT building agents\" (memory: feedback-not-building-agents.md / CLAUDE.md \"Kernel first, shell second\"). pixel-stub-pixel was already silenced by C0, so the revert is zero-impact on the running demo. If we later want a 3rd live runtime for visual punch, the right path is an `examples/` reference webhook agent, not a stub patch — filed as follow-up, not blocking.

**Reset script** — broadened cleanup from `^byo-smoke-` → `^byo-` so it sweeps handoff-probe and playwright-test residue too. Verified against dev: 6 byo-* rows uninstalled on first post-change run.

## Test plan
- [x] `bash scripts/reset-demo-account.sh` → 6 rows uninstalled
- [x] Re-run reset → 0 rows (idempotent)
- [x] Smoke after reset → 12 green / 0 red / 2 TODO

🤖 Generated with [Claude Code](https://claude.com/claude-code)