### PR TITLE
feat(demo): cutoff-based reset + smoke self-cleanup + file-preview

### DIFF
--- a/scripts/reset-demo-account.sh
+++ b/scripts/reset-demo-account.sh
@@ -4,15 +4,19 @@
 # state. Run after a smoke sweep or before a YC reviewer trial session.
 #
 # What this script does (in order):
-#   1. Uninstall every byo-smoke-* AgentInstallation in the demo pod
-#      (smoke leaves one per run; this cleans them up).
+#   1. Uninstall every byo-* AgentInstallation in the demo pod (smoke
+#      and Playwright trial flows leave byo-smoke-*, byo-handoff-probe,
+#      byo-playwright-test-*; this catches them all).
 #   2. Mark any non-nova-demo openclaw installations in the demo pod as
 #      `uninstalled` (cluster Nova / Liz / whoever else got installed mid-
 #      session). The nova-demo concierge stays — it's the demo's
 #      responsive identity per Sprint C0.
 #   3. Clear stale agent sessions for the demo's openclaw runtime so the
 #      next heartbeat re-reads HEARTBEAT.md cleanly.
-#   4. Smoke-test the result. The script exits non-zero if smoke goes red.
+#   4. Hard-delete chat residue from PG: install-intro messages from
+#      byo-* users, smoke @-mention prompts, nova-demo acks of those
+#      prompts. Keeps the storyboard scrollback (May 3-4) intact.
+#   5. Smoke-test the result. The script exits non-zero if smoke goes red.
 #
 # What it does NOT do:
 #   - Reseed scrollback. The 17 storyboard messages (May 3–4) are intact
@@ -84,9 +88,36 @@ kubectl exec -n "$NAMESPACE" deployment/clawdbot-gateway -- bash -c \
   xargs -I{} echo "[reset]     {} session file(s) remaining"
 
 # ──────────────────────────────────────────────────────────────────────────
-# 4. Re-run smoke to verify the reset didn't break anything.
+# 4. Hard-delete every demo-pod message created after the storyboard
+#    cutoff (2026-05-05 00:00 UTC). The storyboard is May 3–4, 2026 —
+#    16 messages, hand-curated. Anything later is sprint test residue:
+#    byo-* install intros, @nova smoke prompts, model-failure replies,
+#    Nova acks. A single date cutoff is the cleanest discriminator —
+#    pattern matching kept missing variants ("smoke" vs "smoke-test-"
+#    vs "Hi all", etc.). Override CUTOFF_UTC if the storyboard ever
+#    gets re-seeded forward.
 # ──────────────────────────────────────────────────────────────────────────
-echo "[reset] (4/4) running smoke-test-demo.sh…"
+CUTOFF_UTC="${CUTOFF_UTC:-2026-05-05 00:00:00+00}"
+echo "[reset] (4/5) hard-deleting post-storyboard chat (>$CUTOFF_UTC)…"
+deleted=$(kubectl exec -n "$NAMESPACE" deployment/backend -- node -e "
+const { Client } = require('pg');
+(async () => {
+  const pg = new Client({ host: process.env.PG_HOST, port: +process.env.PG_PORT, database: process.env.PG_DATABASE, user: process.env.PG_USER, password: process.env.PG_PASSWORD, ssl: process.env.PG_SSL_DISABLED === 'true' ? false : { rejectUnauthorized: false } });
+  await pg.connect();
+  const r = await pg.query(
+    \`DELETE FROM messages WHERE pod_id = \$1 AND created_at > \$2::timestamptz\`,
+    ['$DEMO_POD', '$CUTOFF_UTC']
+  );
+  console.log(r.rowCount);
+  await pg.end();
+})().catch(e => { console.error(e.message); process.exit(1); });
+" 2>/dev/null | tail -1)
+echo "[reset]     deleted $deleted post-cutoff message(s)"
+
+# ──────────────────────────────────────────────────────────────────────────
+# 5. Re-run smoke to verify the reset didn't break anything.
+# ──────────────────────────────────────────────────────────────────────────
+echo "[reset] (5/5) running smoke-test-demo.sh…"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if bash "$SCRIPT_DIR/smoke-test-demo.sh"; then
   echo "[reset] ✅ reset complete, smoke green"

--- a/scripts/smoke-test-demo.sh
+++ b/scripts/smoke-test-demo.sh
@@ -98,22 +98,32 @@ else
   red scrollback "HTTP=$HTTP_CODE"
 fi
 
-# file-preview — sample asset must be reachable
-# TODO: parameterize asset path; for now grep an asset URL from the scrollback
-asset_path=$(echo "$HTTP_BODY" | python3 -c '
-import sys, re, json
-msgs = json.load(sys.stdin)
-msgs = msgs if isinstance(msgs, list) else msgs.get("messages", [])
-for m in msgs:
-  content = m.get("content","") or ""
-  m_re = re.search(r"\[\[file:([^|\]]+)", content)
-  if m_re:
-    print(m_re.group(1)); break
-' 2>/dev/null || true)
-if [ -n "$asset_path" ]; then
-  todo file-preview "found asset token '$asset_path' (route check not yet implemented)"
+# file-preview — confirm pod context surfaces ≥1 asset AND that
+# asset's excerpt route is reachable. The file token in scrollback
+# (e.g. [[file:signup-implementation.md|2.1 KB]]) is the user-facing
+# entry to this — clicking it eventually resolves to an asset id. The
+# smoke approximates that round-trip via the context API (which is
+# what the inspector calls).
+http GET "/api/pods/$DEMO_POD/context?assetLimit=5"
+if [ "$HTTP_CODE" = "200" ]; then
+  first_asset=$(echo "$HTTP_BODY" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+a=d.get('assets') or []
+print(str((a[0] or {}).get('id') or (a[0] or {}).get('_id') or '') if a else '')
+" 2>/dev/null)
+  if [ -n "$first_asset" ]; then
+    http GET "/api/pods/$DEMO_POD/context/assets/$first_asset?lines=4"
+    if [ "$HTTP_CODE" = "200" ]; then
+      green file-preview "asset $first_asset excerpt reachable"
+    else
+      red file-preview "asset excerpt HTTP=$HTTP_CODE"
+    fi
+  else
+    red file-preview "no assets in pod context"
+  fi
 else
-  todo file-preview "no file tokens in scrollback"
+  red file-preview "pod context HTTP=$HTTP_CODE"
 fi
 
 # --- mention-response — checks that the wired agents are actually alive --
@@ -209,9 +219,10 @@ fi
 rm -f /tmp/.byo-page.html
 
 # B3 — backend round-trip for BYO MCP install. Uses a unique name per
-# smoke run so re-runs don't trip the "already installed" path. Cleanup
-# happens via the next-cycle reset script (C1) — until then the smoke
-# leaves an ephemeral webhook AgentInstallation in the demo pod.
+# smoke run because the install path 500s when re-installing over an
+# `uninstalled` row (the AgentInstallation upsert key collision is
+# real). reset-demo-account.sh sweeps these on the next cycle along
+# with byo-handoff-probe.
 b3_name="byo-smoke-$(date +%s)"
 http POST "/api/registry/install" "{\"agentName\":\"$b3_name\",\"podId\":\"$DEMO_POD\",\"scopes\":[\"context:read\",\"messages:write\"],\"config\":{\"runtime\":{\"runtimeType\":\"webhook\"}}}"
 if [ "$HTTP_CODE" = "200" ]; then
@@ -351,6 +362,51 @@ else
   todo runtime-badges "$distinct_rt distinct runtimes ($rt_keys) — needs C2 BYO replace"
 fi
 todo talk-to-cli         "depends on agent runtime token issuance; defer"
+
+# --- self-cleanup ---------------------------------------------------------
+# Leave no demo-pod residue. We:
+#  - Mark the byo-handoff-probe + byo-smoke-* AgentInstallations
+#    inactive (status=uninstalled) via the DELETE registry route — keeps
+#    the User rows for identity continuity (ADR-001 §3).
+#  - Delete the install-intro messages + the smoke @nova prompt + the
+#    Nova ack reply that this smoke run wrote into the demo pod chat.
+# The cleanup is best-effort: if any DELETE 404s we ignore (a future
+# smoke harness change may rename or omit one of these artifacts; the
+# reset script's belt-and-braces sweep stays as the backstop).
+http DELETE "/api/registry/agents/$b3_name/pods/$DEMO_POD?instanceId=default" || true
+http DELETE "/api/registry/agents/byo-handoff-probe/pods/$DEMO_POD?instanceId=default" || true
+
+# Chat-residue cleanup runs through the same /api/messages route the UI
+# uses. Identify messages by author (the byo-* User IDs we just created)
+# and by content marker ("smoke smoke-test-${ts}" / "Ack —"/"smoke
+# received") and DELETE them one by one. The smoke runs before this loop
+# created at most ~4 messages so the cleanup is bounded and cheap.
+cleanup_deleted=0
+cleanup_failed=0
+http GET "/api/messages/$DEMO_POD?limit=30"
+echo "$HTTP_BODY" | python3 -c "
+import sys, json, re
+d = json.load(sys.stdin)
+msgs = d if isinstance(d, list) else d.get('messages', [])
+marker = '$marker'
+for m in msgs:
+  c = m.get('content','') or ''
+  u = (m.get('username') or (m.get('user') or {}).get('username') or '').lower()
+  mid = m.get('id') or m.get('_id')
+  if not mid: continue
+  if (u.startswith('byo-')
+      or marker in c
+      or (u.startswith('nova') and re.search(r'^(ack[\s—-]|smoke received|acknowledged|i.{0,3}m here)', c.strip(), re.I))):
+    print(mid)
+" 2>/dev/null | while IFS= read -r msg_id; do
+  [ -z "$msg_id" ] && continue
+  if http DELETE "/api/messages/$msg_id" >/dev/null 2>&1 && [ "$HTTP_CODE" = "200" ]; then
+    cleanup_deleted=$((cleanup_deleted+1))
+  else
+    cleanup_failed=$((cleanup_failed+1))
+    echo "[cleanup] DELETE /api/messages/$msg_id HTTP=$HTTP_CODE" >&2
+  fi
+done
 
 # --- summary --------------------------------------------------------------
 echo


### PR DESCRIPTION
## Summary
Demo pod is now reviewer-ready end-to-end after one \`reset-demo-account.sh\` run. Smoke 12g/0r/2todo → **13g / 0r / 1todo**.

**reset Phase 4** — replaced pattern-matching chat cleanup with a date cutoff (default \`2026-05-05 00:00 UTC\`). Hard-deletes all PG messages newer than the storyboard. Pattern matching kept missing variants; date is the cleanest discriminator.

**smoke file-preview** — converted last TODO to real check via \`/api/pods/:id/context\` → \`/context/assets/:id\` excerpt route.

**smoke self-cleanup** — DELETE this run's byo-* installs + chat messages at end; counts + stderr-logs failures so silent residue can't accumulate.

## Verification
Sidebar now reads \"Pixel: OAuth-first is right for our wedge\" (real storyboard) instead of \"byo-smoke-XXX: Hi all\". Inspector header: \"2 agents · 2 humans\" (was 3+ with byo cruft). Scrollback count = 16, exact storyboard length.

Playwright screenshot: \`iter3-clean-demo-sidebar.png\` (worktree-local).

## Test plan
- [x] \`bash scripts/reset-demo-account.sh\` → 10 post-cutoff messages deleted, smoke 13g/0r/1todo
- [x] \`bash scripts/smoke-test-demo.sh\` standalone → smoke self-cleanup leaves zero residue
- [x] Playwright demo pod view — clean sidebar, real storyboard tail visible
- [x] Code-reviewer agent: approve with suggestions (cleanup-counter recommendation applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)