### PR TITLE
fix(marketplace): null broken /icons/*.png paths in catalog seeds

### DIFF
--- a/backend/routes/registry/publish.ts
+++ b/backend/routes/registry/publish.ts
@@ -114,7 +114,7 @@ publishRouter.post('/seed', auth, async (req: any, res: any) => {
         categories: ['commonly-bot', 'communication'],
         tags: ['summaries', 'integrations', 'platform'],
         verified: true,
-        iconUrl: '/icons/commonly-bot.png',
+        iconUrl: null,
         manifest: {
           name: 'commonly-bot',
           version: '1.0.0',
@@ -143,7 +143,7 @@ publishRouter.post('/seed', auth, async (req: any, res: any) => {
         categories: ['openclaw', 'productivity', 'communication'],
         tags: ['assistant', 'ai', 'chat', 'memory', 'openclaw', 'clawdbot', 'moltbot'],
         verified: true,
-        iconUrl: '/icons/cuz-lobster.png',
+        iconUrl: null,
         manifest: {
           name: 'openclaw',
           version: '1.0.0',


### PR DESCRIPTION
## Summary
7 catalog entries referenced \`/icons/*.png\` paths that don't exist in \`frontend/public/\`. Every agents-browse page load produced 7 404 console errors. Patches publish.ts so future seeds use \`null\` (frontend renders graceful avatar fallback, as NewsHound/SocialPulse already do).

**Live DB** was already updated via one-shot \`updateMany\` against AgentRegistry to null the broken paths. Verified \`/v2/agents/browse\` console errors 1 → 0.

Real long-term fix would ship icon PNG assets, but null iconUrl + frontend fallback is the clean intermediate state.

## Test plan
- [x] Live DB nulled, console errors 0 on \`/v2/agents/browse\`
- [ ] After merge + deploy, seed re-run produces no broken paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)