### PR TITLE
test(e2e): beat 9 install handoff + agent-room reset cleanup

### DIFF
--- a/e2e/reviewer-journey.spec.ts
+++ b/e2e/reviewer-journey.spec.ts
@@ -119,4 +119,25 @@ test.describe('Reviewer journey', () => {
     const composer = page.locator('.v2-composer__input, textarea[placeholder*="Message"]').first();
     await expect(composer).not.toHaveValue('');
   });
+
+  test('beat 9: marketplace install → handoff → agent-room with chips', async ({ page }) => {
+    // The 60-second wedge: pick an agent from /v2/agents/browse, install it,
+    // land in its 1:1 agent-room with coaching chips. Picks the first
+    // catalog card with a visible Install button; the dialog's pre-selected
+    // "Install to Pod" defaults to the operator's last-touched pod which
+    // for the demo account is Sign-up flow. Leaves residue — the smoke +
+    // reset script cleans it up.
+    await page.goto(`${BASE}/v2/agents/browse`);
+    await expect(page.locator('button', { hasText: 'Install' }).first()).toBeVisible({ timeout: 8000 });
+    await page.locator('button', { hasText: 'Install' }).first().click();
+    // Dialog appears
+    await expect(page.locator('text=Select pods for install')).toBeVisible({ timeout: 5000 });
+    // Confirm install in dialog
+    await page.locator('[role="dialog"] button', { hasText: 'Install' }).click();
+    // Wait for navigation to the new agent-room
+    await page.waitForURL(/\/v2\/pods\/[a-f0-9]{24}/, { timeout: 20_000 });
+    // Empty-state chips render with the installed agent's displayName
+    await expect(page.locator('.v2-empty__title')).toContainText(/Say hi to /, { timeout: 8000 });
+    await expect(page.locator('.v2-empty__chip')).toHaveCount(3);
+  });
 });

--- a/scripts/reset-demo-account.sh
+++ b/scripts/reset-demo-account.sh
@@ -98,7 +98,7 @@ kubectl exec -n "$NAMESPACE" deployment/clawdbot-gateway -- bash -c \
 #    gets re-seeded forward.
 # ──────────────────────────────────────────────────────────────────────────
 CUTOFF_UTC="${CUTOFF_UTC:-2026-05-05 00:00:00+00}"
-echo "[reset] (4/5) hard-deleting post-storyboard chat (>$CUTOFF_UTC)…"
+echo "[reset] (4a/5) hard-deleting post-storyboard chat (>$CUTOFF_UTC)…"
 deleted=$(kubectl exec -n "$NAMESPACE" deployment/backend -- node -e "
 const { Client } = require('pg');
 (async () => {
@@ -113,6 +113,23 @@ const { Client } = require('pg');
 })().catch(e => { console.error(e.message); process.exit(1); });
 " 2>/dev/null | tail -1)
 echo "[reset]     deleted $deleted post-cutoff message(s)"
+
+# Marketplace-install Playwright walkthroughs create agent-room pods.
+# Sidebar pollution: each test install leaves a "Talk to <agent>" room
+# in the sam-demo Today/Yesterday list. Delete agent-rooms created
+# after the cutoff EXCEPT the canonical Nova/Pixel/Cody storyboard
+# rooms (those are pre-seeded baseline).
+echo "[reset] (4b/5) deleting test-residue agent-room pods…"
+deleted_rooms=$(kubectl exec -n "$NAMESPACE" deployment/backend -- node -e "
+const m=require('mongoose');
+m.connect(process.env.MONGO_URI).then(async ()=>{
+  const Pod=m.connection.db.collection('pods');
+  const cutoff = new Date('$CUTOFF_UTC');
+  const r=await Pod.deleteMany({ type: 'agent-room', createdAt: { \$gt: cutoff }, name: { \$nin: ['Nova', 'Pixel', 'Cody'] } });
+  console.log(r.deletedCount);
+  process.exit(0);
+})" 2>/dev/null | tail -1)
+echo "[reset]     deleted $deleted_rooms test agent-room pod(s)"
 
 # ──────────────────────────────────────────────────────────────────────────
 # 5. Re-run smoke to verify the reset didn't break anything.


### PR DESCRIPTION
## Summary
**Beat 9** — codify the marketplace install handoff (60-second wedge) as a Playwright beat in reviewer-journey.spec.ts: \`/v2/agents/browse\` → click Install → confirm dialog → land on agent-room → \"Say hi to <agent>\" + 3 chips. Manually verified iter 7 with NewsHound.

**Reset Phase 4b** — delete agent-room pods created after storyboard cutoff (2026-05-05 UTC), excluding canonical Nova/Pixel/Cody rooms. Marketplace install walkthroughs leave test residue ("NewsHound 🐕 2:07 AM" etc.) in sam-demo's sidebar; reviewer would notice.

## Test plan
- [x] Manual install flow: NewsHound install → handoff to agent-room → chips ✓
- [x] Reset deletes test agent-room residue (1 deleted after this iter's run)
- [ ] Beat 9 runs green when DEMO_TOKEN is wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)