### PR TITLE
fix(v2-inspector): hide 'View run board' when 0 tasks

### DIFF
--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -1327,13 +1327,22 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
           <span className="v2-inspector__pill v2-inspector__pill--complete">Complete</span>
         </div>
       </div>
-      <button
-        type="button"
-        className="v2-inspector__link v2-inspector__link--block"
-        onClick={() => navigate(`/v2/pods/${pod.type || 'chat'}/${pod._id}`)}
-      >
-        View run board
-      </button>
+      {(runState.blocked + runState.inProgress + runState.pending + runState.complete) > 0 && (
+        // Hide the run-board link when there are no tasks. Today the
+        // target route falls back to `/v2/pods/chat/<id>` (v1 chat view
+        // under the v2 prefix) since v2 has no dedicated tasks-board
+        // route. A reviewer clicking this on a fresh demo pod with
+        // 0/0/0 tasks lands in a confusing legacy view with raw
+        // `[[file:...]]` tokens. Until v2 grows a real tasks surface,
+        // only show the link when there's actually something to view.
+        <button
+          type="button"
+          className="v2-inspector__link v2-inspector__link--block"
+          onClick={() => navigate(`/v2/pods/${pod.type || 'chat'}/${pod._id}`)}
+        >
+          View run board
+        </button>
+      )}
     </section>
   );
 


### PR DESCRIPTION
## Summary
Demo pod inspector Tasks tab shows 0 blocked / 0 in progress / 0 complete + a "View run board" button. Clicking the button navigates to \`/v2/pods/chat/<id>\` — which is the v1 legacy chat view under the v2 prefix. Raw \`[[file:...]]\` tokens, no v2 chrome, very confusing for a YC reviewer.

Hide the button when there are no tasks. Run-state numbers still surface the empty state. Until v2 grows a real tasks-board route, this is the clean intermediate.

Found in iter 8 surface audit (Playwright walkthrough of Tasks tab → View run board).

## Test plan
- [x] Manual: demo pod inspector Tasks tab no longer shows the broken link
- [ ] Confirm on deployed dev post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)