### PR TITLE
test(e2e): beat 9 — check pod checkbox; full suite 9/9 green

### DIFF
--- a/docs/demo-verification.md
+++ b/docs/demo-verification.md
@@ -39,20 +39,19 @@ the printed tag.
 8. Agent-room empty-state shows "Say hi to <DisplayName>" + 3 chips
 9. Marketplace Install → handoff to agent-room with chips
 
-## Known flakes
+## Inter-test residue
 
-The Playwright suite is order-sensitive: beats 2 / 8 / 9 sometimes
-fail when run as part of the full suite due to inter-test state
-shared across the live demo pod. Each beat passes individually
-(`npx playwright test e2e/reviewer-journey.spec.ts -g "beat N"`).
-Use isolation runs to debug regressions; the full-suite signal is
-"≥7 / 9 green" rather than 9/9.
+Beats run sequentially against the shared sam-demo pod. Beats 5 + 7 +
+9 each mutate live state (enqueue mention, install webhook agent,
+install marketplace agent). An `afterEach` hook deletes the installed
+`byo-*` / `newshound` rows after each test, but `pod.members[]` retains
+them until the next `reset-demo-account.sh` run. After ~5 full-suite
+runs, run reset to keep the demo pod tidy.
 
-Root cause: beats run sequentially against the shared sam-demo
-pod. Beat 5 enqueues a real `@nova` mention that lingers as
-nova-demo gateway state. Beats 7 + 9 install ephemeral webhook
-agents; the `afterEach` cleanup deletes them but pod.members[]
-retains them until the next `reset-demo-account.sh` run.
+Per-beat isolation is always available for debugging:
+```
+npx playwright test e2e/reviewer-journey.spec.ts -g "beat N"
+```
 
 ## How to run on a different instance
 

--- a/e2e/reviewer-journey.spec.ts
+++ b/e2e/reviewer-journey.spec.ts
@@ -207,12 +207,20 @@ test.describe('Reviewer journey', () => {
     const installButton = page.locator('button').filter({ hasText: /^Install$/ }).first();
     await expect(installButton).toBeVisible({ timeout: 8000 });
     await installButton.click();
-    // Dialog appears — match by role rather than title text (the title
-    // varies across MUI versions and may be rendered as h2/h6/etc).
-    const dialog = page.locator('[role="dialog"]');
-    await expect(dialog).toBeVisible({ timeout: 5000 });
-    // Confirm install in dialog
-    await dialog.locator('button', { hasText: 'Install' }).click();
+    // Dialog appears — match by role; MUI sometimes uses
+    // role=presentation on the backdrop wrapper, with role=dialog
+    // on the inner Paper. Wait for the Install button specifically
+    // since that's what we'll click next.
+    // The dialog renders a FormGroup of pod checkboxes — at least one
+    // must be checked before the Install button enables. Pick the
+    // first checkbox (the demo account's accessible pods are
+    // pre-sorted; Sign-up flow lands first).
+    const dialogScope = page.locator('[role="dialog"], [role="presentation"]');
+    await dialogScope.locator('input[type="checkbox"]').first().check();
+    const dialogInstall = dialogScope
+      .locator('button').filter({ hasText: /^Install$/ }).first();
+    await expect(dialogInstall).toBeEnabled({ timeout: 5000 });
+    await dialogInstall.click();
     // Wait for navigation to the new agent-room
     await page.waitForURL(/\/v2\/pods\/[a-f0-9]{24}/, { timeout: 20_000 });
     // Empty-state chips render with the installed agent's displayName


### PR DESCRIPTION
## Summary
**Full reviewer-journey suite now 9/9 green against deployed dev.** (Was 8/9.)

Root cause of beat 9 flake: the AgentsHub install dialog renders a FormGroup of pod checkboxes (AgentsHub.tsx:4742-4762); the Install button is \`disabled\` until at least one checkbox is checked (line 4770). The earlier test clicked the disabled button and timed out.

Fix: check the first pod checkbox before clicking dialog Install. The demo account's accessible pods land Sign-up flow first, which is exactly what we want (the install handoff then navigates to the new agent-room).

## Test plan
- [x] \`bash scripts/reset-demo-account.sh\` → smoke green
- [x] \`npx playwright test e2e/reviewer-journey.spec.ts\` → 9/9 green
- [x] Beat 9 in isolation → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)