### PR TITLE
feat(demo): talk-to-cli smoke + Nova-Demo↔Cody reseed → 14/14 green

### DIFF
--- a/scripts/reset-demo-account.sh
+++ b/scripts/reset-demo-account.sh
@@ -119,17 +119,66 @@ echo "[reset]     deleted $deleted post-cutoff message(s)"
 # in the sam-demo Today/Yesterday list. Delete agent-rooms created
 # after the cutoff EXCEPT the canonical Nova/Pixel/Cody storyboard
 # rooms (those are pre-seeded baseline).
-echo "[reset] (4b/5) deleting test-residue agent-room pods…"
+echo "[reset] (4b/5) deleting test-residue agent-room + agent-dm pods…"
 deleted_rooms=$(kubectl exec -n "$NAMESPACE" deployment/backend -- node -e "
 const m=require('mongoose');
 m.connect(process.env.MONGO_URI).then(async ()=>{
   const Pod=m.connection.db.collection('pods');
   const cutoff = new Date('$CUTOFF_UTC');
-  const r=await Pod.deleteMany({ type: 'agent-room', createdAt: { \$gt: cutoff }, name: { \$nin: ['Nova', 'Pixel', 'Cody'] } });
-  console.log(r.deletedCount);
+  // agent-room: \"Talk to <agent>\" pods from install-handoff or
+  // marketplace install flows. Preserve the canonical Nova/Pixel/Cody
+  // storyboard rooms.
+  // agent-dm: bot-to-bot 2-member pods created by talk-to-cli smoke
+  // (byo-smoke-XXX ↔ codex-bot-codex). Anything created after cutoff
+  // is test residue EXCEPT the canonical Nova-Demo↔Cody seed
+  // (6a01a1ffcf199a9aed01d9d1) — that's the B1 fixture so the
+  // inspector's Direct Messages card has live data to surface.
+  const KEEP_DM_IDS = ['6a01a1ffcf199a9aed01d9d1'];
+  const roomRes = await Pod.deleteMany({ type: 'agent-room', createdAt: { \$gt: cutoff }, name: { \$nin: ['Nova', 'Pixel', 'Cody'] } });
+  const dmRes = await Pod.deleteMany({ type: 'agent-dm', createdAt: { \$gt: cutoff }, _id: { \$nin: KEEP_DM_IDS.map(id => m.Types.ObjectId.createFromHexString(id)) } });
+  console.log(roomRes.deletedCount + dmRes.deletedCount);
   process.exit(0);
 })" 2>/dev/null | tail -1)
-echo "[reset]     deleted $deleted_rooms test agent-room pod(s)"
+echo "[reset]     deleted $deleted_rooms test pod(s)"
+
+# Re-seed the canonical Nova-Demo ↔ Cody a2a-dm if missing. The B1
+# fixture (inspector "Direct messages" card) needs at least one live
+# A2A DM involving nova-demo to render. Talk-to-cli smoke creates
+# byo-smoke-* ↔ codex DMs but those aren't surfaced under the
+# instanceId=nova-demo query the inspector uses.
+echo "[reset] (4c/5) reseeding Nova-Demo↔Cody A2A DM if absent…"
+seeded=$(kubectl exec -n "$NAMESPACE" deployment/backend -- node -e "
+const m=require('mongoose');
+m.connect(process.env.MONGO_URI).then(async ()=>{
+  const Pod=m.connection.db.collection('pods');
+  const SEED_ID='6a01a1ffcf199a9aed01d9d1';
+  const NOVA_DEMO_ID='6a0197d1deeccd27ced8c175';
+  const CODY_ID='69f841c3063269526de047d4';
+  const existing=await Pod.findOne({_id:m.Types.ObjectId.createFromHexString(SEED_ID)});
+  if (existing) { console.log(0); process.exit(0); }
+  await Pod.insertOne({
+    _id: m.Types.ObjectId.createFromHexString(SEED_ID),
+    name: 'Nova-Demo ↔ Cody',
+    description: 'Seeded a2a DM — B1 inspector fixture',
+    type: 'agent-dm',
+    createdBy: m.Types.ObjectId.createFromHexString(NOVA_DEMO_ID),
+    members: [
+      m.Types.ObjectId.createFromHexString(NOVA_DEMO_ID),
+      m.Types.ObjectId.createFromHexString(CODY_ID),
+    ],
+    joinPolicy: 'invite-only',
+    messages: [],
+    announcements: [],
+    externalLinks: [],
+    contacts: {},
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    __v: 0,
+  });
+  console.log(1);
+  process.exit(0);
+})" 2>/dev/null | tail -1)
+echo "[reset]     seeded $seeded Nova-Demo↔Cody pod(s)"
 
 # ──────────────────────────────────────────────────────────────────────────
 # 5. Re-run smoke to verify the reset didn't break anything.

--- a/scripts/smoke-test-demo.sh
+++ b/scripts/smoke-test-demo.sh
@@ -254,6 +254,10 @@ http POST "/api/registry/install" "{\"agentName\":\"$b3_name\",\"podId\":\"$DEMO
 if [ "$HTTP_CODE" = "200" ]; then
   http POST "/api/registry/pods/$DEMO_POD/agents/$b3_name/runtime-tokens" '{"label":"smoke","force":true}'
   if [ "$HTTP_CODE" = "200" ]; then
+    # Capture the cm_agent_* token so the later talk-to-cli smoke can
+    # exercise the runtime endpoints (POST /agent-dm) using this same
+    # token.
+    runtime_token=$(echo "$HTTP_BODY" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("token",""))' 2>/dev/null)
     has_tok=$(echo "$HTTP_BODY" | python3 -c 'import sys,json; d=json.load(sys.stdin); t=d.get("token",""); print("yes" if t.startswith("cm_agent_") else "no")' 2>/dev/null || echo no)
     if [ "$has_tok" = "yes" ]; then
       green byo-token-issue "POST install + runtime-token returned cm_agent_*"
@@ -387,7 +391,31 @@ if [ "$distinct_rt" -ge 3 ]; then
 else
   todo runtime-badges "$distinct_rt distinct runtimes ($rt_keys) — needs C2 BYO replace"
 fi
-todo talk-to-cli         "depends on agent runtime token issuance; defer"
+# talk-to-cli — exercise the runtime-token agent surface end-to-end.
+# Use the cm_agent_* token issued for the byo-smoke-* row above to POST
+# /agent-dm targeting cody (codex-bot-codex) — both are in the demo
+# pod so the §3.7 co-pod-member rule is satisfied. Response must
+# include a room with type=agent-dm and an _id.
+if [ -n "${runtime_token:-}" ]; then
+  agentdm_resp=$(curl -sS -H "Authorization: Bearer $runtime_token" -H "Content-Type: application/json" --max-time 15 -X POST "${API}/api/agents/runtime/agent-dm" -d '{"target":{"agentName":"codex-bot","instanceId":"codex"}}' 2>/dev/null)
+  dm_pod_id=$(echo "$agentdm_resp" | python3 -c "
+import sys,json
+try:
+  d=json.load(sys.stdin)
+  r=d.get('room') or {}
+  print(str(r.get('_id') or '')+','+str(r.get('type') or ''))
+except Exception:
+  print(',')
+" 2>/dev/null)
+  dm_id="${dm_pod_id%,*}"; dm_type="${dm_pod_id#*,}"
+  if [ -n "$dm_id" ] && [ "$dm_type" = "agent-dm" ]; then
+    green talk-to-cli "agent-dm room=$dm_id type=agent-dm (via cm_agent_* token)"
+  else
+    todo talk-to-cli "agent-dm did not return a 2-member pod (resp=${dm_pod_id})"
+  fi
+else
+  todo talk-to-cli "byo-token-issue did not surface a runtime_token"
+fi
 
 # --- self-cleanup ---------------------------------------------------------
 # Leave no demo-pod residue. We:


### PR DESCRIPTION
## Summary
**Smoke: 14/14 green, 0 TODO.** Last deferred check closed.

**talk-to-cli** — exercises the runtime-token agent surface. Issues a \`cm_agent_*\` token, POSTs \`/api/agents/runtime/agent-dm\` targeting codex-bot:codex (co-pod member, satisfies §3.7), asserts room.\_id + type=agent-dm. This is the bot-side analog of the human install-handoff flow.

**reset Phase 4b** — also sweeps test-residue \`agent-dm\` pods (talk-to-cli leaves byo-smoke-XXX ↔ codex DMs). Excludes the canonical Nova-Demo↔Cody seed (\`6a01a1ffcf199a9aed01d9d1\`) so B1 inspector fixture survives.

**reset Phase 4c** — reseeds Nova-Demo↔Cody pod if missing (idempotent upsert). The B1 a2a-dm-listable smoke needs ≥1 DM involving nova-demo to render; earlier residue cleanup could nuke the seed. Phase 4c restores it.

## Test plan
- [x] \`bash scripts/smoke-test-demo.sh\` → 14g/0r/0todo
- [x] \`bash scripts/reset-demo-account.sh\` → idempotent across runs; reseed happens once
- [x] Reset destroys then restores Nova-Demo↔Cody → a2a-dm-listable green

🤖 Generated with [Claude Code](https://claude.com/claude-code)