### PR TITLE
feat(reactions): agents can react autonomously via cm_agent_* token

### DIFF
--- a/backend/controllers/reactionController.ts
+++ b/backend/controllers/reactionController.ts
@@ -12,6 +12,10 @@ interface AuthedReq {
   body: { emoji?: string };
   user?: { _id?: unknown };
   userId?: unknown;
+  // Set by agentRuntimeAuth — present when caller used a cm_agent_*
+  // token instead of a human JWT. Both paths populate _id on the
+  // resolved bot User row (per agent-runtime memory note 2026-05-08).
+  agentUser?: { _id?: unknown };
 }
 interface AuthedRes {
   status: (n: number) => AuthedRes;
@@ -21,7 +25,42 @@ interface AuthedRes {
 const SAFE_EMOJI_RE = /^[\p{Emoji}‍]{1,8}$/u;
 
 function getUserId(req: AuthedReq): string {
-  return String(req.user?._id || req.userId || '');
+  return String(req.user?._id || req.userId || req.agentUser?._id || '');
+}
+
+// Returns true when the caller is a member of the pod. For human
+// callers we check pg pod_members (same as posting). For agent
+// callers (req.agentUser populated by agentRuntimeAuth) we check
+// AgentInstallation since agents may not have a pod_members row —
+// per the agent-runtime memory rule "AgentInstallation required for
+// posting", we mirror that gate for reacting.
+async function callerHasPodAccess(podId: string, userId: string, req: AuthedReq): Promise<boolean> {
+  if (req.agentUser?._id) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+    const { AgentInstallation } = require('../models/AgentRegistry');
+    const installation = await AgentInstallation.findOne({
+      podId,
+      installedBy: req.agentUser._id,
+      status: 'active',
+    }).lean();
+    if (installation) return true;
+    // Fallback: the agent's bot User may be a member via Pod.members
+    // (e.g. installed via /agents/runtime/room handoff). Check that path too.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+    const Pod = require('../models/Pod');
+    const pod = await Pod.findById(podId).select('members').lean();
+    if (pod?.members?.some((m: any) => String(m?.userId?.toString?.() || m) === userId)) {
+      return true;
+    }
+    return false;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  const { pool } = require('../config/db-pg');
+  const result = await pool.query(
+    'SELECT 1 FROM pod_members WHERE pod_id = $1 AND user_id = $2 LIMIT 1',
+    [podId, userId],
+  );
+  return (result.rowCount || 0) > 0;
 }
 
 async function emitReactionChange(messageId: string | number, podId: string, reactions: unknown): Promise<void> {
@@ -55,16 +94,6 @@ async function loadPodIdForMessage(messageId: string | number): Promise<string |
   return row ? String(row.pod_id) : null;
 }
 
-async function userHasPodMembership(podId: string, userId: string): Promise<boolean> {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
-  const { pool } = require('../config/db-pg');
-  const result = await pool.query(
-    'SELECT 1 FROM pod_members WHERE pod_id = $1 AND user_id = $2 LIMIT 1',
-    [podId, userId],
-  );
-  return (result.rowCount || 0) > 0;
-}
-
 export async function addReaction(req: AuthedReq, res: AuthedRes): Promise<void> {
   try {
     const userId = getUserId(req);
@@ -87,7 +116,7 @@ export async function addReaction(req: AuthedReq, res: AuthedRes): Promise<void>
       res.status(404).json({ msg: 'Message not found' });
       return;
     }
-    if (!(await userHasPodMembership(podId, userId))) {
+    if (!(await callerHasPodAccess(podId, userId, req))) {
       res.status(403).json({ msg: 'Not a member of this pod' });
       return;
     }
@@ -120,7 +149,7 @@ export async function removeReaction(req: AuthedReq, res: AuthedRes): Promise<vo
       res.status(404).json({ msg: 'Message not found' });
       return;
     }
-    if (!(await userHasPodMembership(podId, userId))) {
+    if (!(await callerHasPodAccess(podId, userId, req))) {
       res.status(403).json({ msg: 'Not a member of this pod' });
       return;
     }

--- a/backend/routes/messages.ts
+++ b/backend/routes/messages.ts
@@ -7,6 +7,8 @@ const express = require('express');
 // eslint-disable-next-line global-require
 const auth = require('../middleware/auth');
 // eslint-disable-next-line global-require
+const agentRuntimeAuth = require('../middleware/agentRuntimeAuth');
+// eslint-disable-next-line global-require
 const {
   getMessages,
   createMessage,
@@ -77,8 +79,21 @@ const reactionRateLimit = rateLimit({
     res.status(429).json({ msg: 'rate limit exceeded: 120 reactions per 60s' });
   },
 });
-router.post('/:messageId/reactions', reactionRateLimit, auth, addReaction);
-router.delete('/:messageId/reactions/:emoji', reactionRateLimit, auth, removeReaction);
+// dualAuth: accept human JWT OR agent runtime token (cm_agent_*).
+// Inlined here so the route reads its auth wire from the same file
+// CodeQL scans for the rate-limit middleware (same-file detection).
+// Agents reacting is first-class — see ADR-006 + reactionController's
+// agentUser fallback. Production tip: react sparingly per heartbeat
+// template guidance; only for genuine social signal, not as ack.
+const dualAuth = (req: any, res: any, next: any) => {
+  const bearer = ((req.header?.('Authorization') || '').replace('Bearer ', '')).trim();
+  const altHeader = (req.header?.('x-commonly-agent-token') || '').trim();
+  const token = bearer || altHeader;
+  if (token.startsWith('cm_agent_')) return agentRuntimeAuth(req, res, next);
+  return auth(req, res, next);
+};
+router.post('/:messageId/reactions', reactionRateLimit, dualAuth, addReaction);
+router.delete('/:messageId/reactions/:emoji', reactionRateLimit, dualAuth, removeReaction);
 
 // Backdate a message's `created_at`. Pod-creator-only (or message author);
 // no general-purpose user authorization for editing other people's chronology.

--- a/packages/commonly-mcp/src/client.ts
+++ b/packages/commonly-mcp/src/client.ts
@@ -561,6 +561,39 @@ export class CommonlyClient {
    * which uses user-auth and a different backend route. Both exist on
    * purpose so end users can pick which auth mode they want exposed.
    */
+  /**
+   * Add or remove a reaction emoji on a message via agent auth. The
+   * reaction route (`POST /api/messages/:id/reactions`) lives outside
+   * `/api/agents/runtime/*` but accepts agent runtime tokens since
+   * the same-author react-as-yourself contract applies to bots too.
+   */
+  async reactToMessage(
+    messageId: string,
+    emoji: string
+  ): Promise<{ ok: true; reactions: unknown[] }> {
+    const http = this.requireAgentHttp();
+    if (!messageId) throw new MCPClientError("reactToMessage requires messageId");
+    if (!emoji) throw new MCPClientError("reactToMessage requires emoji");
+    const response = await http.post<{ ok: true; reactions: unknown[] }>(
+      `/api/messages/${encodeURIComponent(messageId)}/reactions`,
+      { emoji },
+    );
+    return response.data;
+  }
+
+  async unreactToMessage(
+    messageId: string,
+    emoji: string
+  ): Promise<{ ok: true; reactions: unknown[] }> {
+    const http = this.requireAgentHttp();
+    if (!messageId) throw new MCPClientError("unreactToMessage requires messageId");
+    if (!emoji) throw new MCPClientError("unreactToMessage requires emoji");
+    const response = await http.delete<{ ok: true; reactions: unknown[] }>(
+      `/api/messages/${encodeURIComponent(messageId)}/reactions/${encodeURIComponent(emoji)}`,
+    );
+    return response.data;
+  }
+
   async postMessageCAP(
     podId: string,
     options: CAPPostMessageOptions

--- a/packages/commonly-mcp/src/tools/cap-react.ts
+++ b/packages/commonly-mcp/src/tools/cap-react.ts
@@ -1,0 +1,58 @@
+/**
+ * Agent-side reaction tool. Maps to POST/DELETE
+ * /api/messages/:messageId/reactions/[:emoji] via agent auth.
+ *
+ * Reactions are first-class social-presence primitives for agents.
+ * Use sparingly: only when content is genuinely worth signaling
+ * (peer's PR landing, surprising finding, a teammate's good call).
+ * Agents should NOT react as a substitute for a substantive reply
+ * when they were @-mentioned — that should still be a posted message
+ * (or NO_REPLY when truly nothing to add). Reactions are for
+ * incidental engagement, not acknowledgement of direct requests.
+ */
+
+import { CommonlyClient } from "../client.js";
+
+export const definition = {
+  name: "commonly_react_to_message",
+  description:
+    "React to a message with an emoji AS the agent identity. Requires " +
+    "COMMONLY_AGENT_TOKEN. Use sparingly — only for genuine social " +
+    "signal (peer milestone, surprising data, a good call by a teammate). " +
+    "If you were @-mentioned and have something to say, post a message " +
+    "instead; reactions don't substitute for substantive replies.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      messageId: {
+        type: "string",
+        description: "The integer id of the target message (returned by commonly_post_message_cap or fetched via context).",
+      },
+      emoji: {
+        type: "string",
+        description: "A single emoji to add. 1–8 characters, must be valid emoji.",
+      },
+      remove: {
+        type: "boolean",
+        description: "If true, removes your existing reaction with this emoji instead of adding one. Defaults to false.",
+      },
+    },
+    required: ["messageId", "emoji"],
+  },
+};
+
+export interface CapReactArgs {
+  messageId: string;
+  emoji: string;
+  remove?: boolean;
+}
+
+export async function handler(
+  client: CommonlyClient,
+  args: CapReactArgs
+): Promise<{ ok: true; reactions: unknown[] }> {
+  if (args.remove) {
+    return client.unreactToMessage(args.messageId, args.emoji);
+  }
+  return client.reactToMessage(args.messageId, args.emoji);
+}

--- a/packages/commonly-mcp/src/tools/index.ts
+++ b/packages/commonly-mcp/src/tools/index.ts
@@ -13,6 +13,7 @@ import * as CapPost from "./cap-post.js";
 import * as CapMemorySync from "./cap-memory-sync.js";
 import * as CapAsk from "./cap-ask.js";
 import * as CapRespond from "./cap-respond.js";
+import * as CapReact from "./cap-react.js";
 
 export interface Tool {
   name: string;
@@ -222,6 +223,9 @@ export const tools: Tool[] = [
   // these are silent peer-to-peer (no human-visible message in the pod).
   CapAsk.definition,
   CapRespond.definition,
+  // Reactions — emoji-on-message social-presence primitive. Agents
+  // should use sparingly (not as ack for direct mentions).
+  CapReact.definition,
 ];
 
 /**
@@ -424,6 +428,14 @@ export async function handleToolCall(
       return CapRespond.handler(client, {
         requestId: args.requestId as string,
         content: args.content as string,
+      });
+    }
+
+    case CapReact.definition.name: {
+      return CapReact.handler(client, {
+        messageId: args.messageId as string,
+        emoji: args.emoji as string,
+        remove: args.remove as boolean | undefined,
       });
     }
 

--- a/scripts/smoke-test-demo.sh
+++ b/scripts/smoke-test-demo.sh
@@ -417,6 +417,33 @@ else
   todo talk-to-cli "byo-token-issue did not surface a runtime_token"
 fi
 
+# agent-react — exercise dualAuth on the reactions route. Use the same
+# cm_agent_* token to POST a 👍 reaction on a recent demo-pod message,
+# verify the response includes mine:true, then DELETE it. Closes the
+# loop "agents can react autonomously (ADR-007 follow-up)".
+if [ -n "${runtime_token:-}" ] && [ -n "${rxn_msg_id:-}" ]; then
+  agent_react_resp=$(curl -sS -H "Authorization: Bearer $runtime_token" -H "Content-Type: application/json" --max-time 15 -X POST "${API}/api/messages/${rxn_msg_id}/reactions" -d '{"emoji":"👀"}' 2>/dev/null)
+  agent_mine=$(echo "$agent_react_resp" | python3 -c "
+import sys,json
+try:
+  d=json.load(sys.stdin)
+  arr=d.get('reactions') or []
+  ok = any(r.get('emoji')=='👀' for r in arr)
+  print('yes' if ok else 'no')
+except Exception:
+  print('parse_err')
+" 2>/dev/null)
+  if [ "$agent_mine" = "yes" ]; then
+    # Cleanup: agent removes its own reaction
+    curl -sS -H "Authorization: Bearer $runtime_token" --max-time 15 -X DELETE "${API}/api/messages/${rxn_msg_id}/reactions/%F0%9F%91%80" >/dev/null 2>&1 || true
+    green agent-react "cm_agent_* token → POST 👀 + reactions array; cleaned up"
+  else
+    red agent-react "agent reaction not recorded ($agent_mine)"
+  fi
+else
+  todo agent-react "missing runtime_token or message id"
+fi
+
 # --- self-cleanup ---------------------------------------------------------
 # Leave no demo-pod residue. We:
 #  - Mark the byo-handoff-probe + byo-smoke-* AgentInstallations


### PR DESCRIPTION
## Summary
Closes the agent-autonomy gap on reactions identified in operator review. Agents can now React to messages using their runtime token, with explicit heuristic guidance (don't use as ack for direct mentions).

**Backend**: dualAuth on \`POST/DELETE /api/messages/:id/reactions/*\`. \`callerHasPodAccess\` checks \`AgentInstallation\` for agent callers (mirrors the posting invariant) with \`Pod.members\` fallback for agent-room installs.

**MCP**: new \`commonly_react_to_message\` tool in \`@commonlyai/mcp\`. Description warns agents not to use reactions as substitute for substantive replies to direct mentions.

**Smoke**: new \`agent-react\` check exercises the full dualAuth path end-to-end using an issued \`cm_agent_*\` token.

Per-author tracking was already there at the model — no schema changes.

## Test plan
- [x] TypeScript clean (\`npx tsc --noEmit\` in packages/commonly-mcp)
- [x] Smoke check added; will turn green post-deploy
- [ ] Operator verification: agent posts a 👍 on a chat message via MCP tool → UI updates via Socket.io with attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)