### PR TITLE
feat(mcp): commonly_set_typing — typing-indicator MCP tool

### DIFF
--- a/packages/commonly-mcp/src/client.ts
+++ b/packages/commonly-mcp/src/client.ts
@@ -562,6 +562,20 @@ export class CommonlyClient {
    * purpose so end users can pick which auth mode they want exposed.
    */
   /**
+   * Start or stop the typing indicator for the calling agent in
+   * a pod. Backend route lives under /api/agents/runtime/* so we
+   * reuse _capRequest. Action defaults to 'start' server-side too.
+   */
+  async setTyping(podId: string, action: "start" | "stop"): Promise<void> {
+    if (!podId) throw new MCPClientError("setTyping requires podId");
+    await this._capRequest<{ ok: boolean }>(
+      "post",
+      `/pods/${encodeURIComponent(podId)}/typing`,
+      { action },
+    );
+  }
+
+  /**
    * Add or remove a reaction emoji on a message via agent auth. The
    * reaction route (`POST /api/messages/:id/reactions`) lives outside
    * `/api/agents/runtime/*` but accepts agent runtime tokens since

--- a/packages/commonly-mcp/src/tools/cap-typing.ts
+++ b/packages/commonly-mcp/src/tools/cap-typing.ts
@@ -1,0 +1,66 @@
+/**
+ * Agent-side typing-indicator tool. Maps to POST
+ * /api/agents/runtime/pods/:podId/typing.
+ *
+ * Why this matters: external agents posting via the CAP `post`
+ * verb get an automatic typing_stop event when their message
+ * lands, but no auto-start. Result: their messages appear without
+ * the conversational "typing…" pre-roll that humans see for native
+ * runtime agents.
+ *
+ * Calling this with `action: 'start'` BEFORE you compute and post
+ * your reply makes the chat chrome render "Nova is typing…" while
+ * the LLM works. Agents using Claude Code / Cursor / Codex over
+ * MCP should call this as soon as they decide to reply.
+ *
+ * Backend auto-clears after 30s safety window so stuck indicators
+ * are bounded even on dropped sessions (see agentTypingService).
+ */
+
+import { CommonlyClient } from "../client.js";
+import type { Config } from "../index.js";
+
+export const definition = {
+  name: "commonly_set_typing",
+  description:
+    "Start or stop the typing indicator for your agent identity in a " +
+    "pod. Call with action='start' BEFORE you begin composing a reply " +
+    "so the chat shows 'X is typing…' while you think. Auto-clears " +
+    "after 30s but call action='stop' if you change your mind about " +
+    "replying. Requires COMMONLY_AGENT_TOKEN.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      podId: {
+        type: "string",
+        description:
+          "Target pod id. If omitted, falls back to COMMONLY_DEFAULT_POD.",
+      },
+      action: {
+        type: "string",
+        enum: ["start", "stop"],
+        description: "Whether to start showing the indicator or stop it. Defaults to 'start'.",
+      },
+    },
+  },
+};
+
+export interface CapTypingArgs {
+  podId?: string;
+  action?: "start" | "stop";
+}
+
+export async function handler(
+  client: CommonlyClient,
+  args: CapTypingArgs,
+  config: Config
+): Promise<{ ok: true }> {
+  const podId = args.podId || config.defaultPodId;
+  if (!podId) {
+    throw new Error(
+      "podId is required for commonly_set_typing (or set COMMONLY_DEFAULT_POD)"
+    );
+  }
+  await client.setTyping(podId, args.action || "start");
+  return { ok: true };
+}

--- a/packages/commonly-mcp/src/tools/index.ts
+++ b/packages/commonly-mcp/src/tools/index.ts
@@ -14,6 +14,7 @@ import * as CapMemorySync from "./cap-memory-sync.js";
 import * as CapAsk from "./cap-ask.js";
 import * as CapRespond from "./cap-respond.js";
 import * as CapReact from "./cap-react.js";
+import * as CapTyping from "./cap-typing.js";
 
 export interface Tool {
   name: string;
@@ -226,6 +227,11 @@ export const tools: Tool[] = [
   // Reactions — emoji-on-message social-presence primitive. Agents
   // should use sparingly (not as ack for direct mentions).
   CapReact.definition,
+  // Typing indicator — render "X is typing…" before posting. Optional
+  // chrome polish for MCP-driven external agents (Claude Code, Cursor,
+  // Codex) so their messages don't appear "cold" without the pre-roll
+  // humans get for native runtime agents.
+  CapTyping.definition,
 ];
 
 /**
@@ -437,6 +443,17 @@ export async function handleToolCall(
         emoji: args.emoji as string,
         remove: args.remove as boolean | undefined,
       });
+    }
+
+    case CapTyping.definition.name: {
+      return CapTyping.handler(
+        client,
+        {
+          podId: args.podId as string | undefined,
+          action: args.action as "start" | "stop" | undefined,
+        },
+        config
+      );
     }
 
     default:


### PR DESCRIPTION
Wraps the existing backend typing route in an MCP tool. Pairs with #331 (reactions) to complete agent chat-chrome parity with native runtime agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)