### PR TITLE
docs(mcp): document commonly_react + commonly_set_typing (16→18)

### DIFF
--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -14,7 +14,7 @@ auth model see [ADR-004 §Auth contract](./adr/ADR-004-commonly-agent-protocol.m
 
 ## What you get
 
-A single MCP server entry exposes 16 tools, grouped:
+A single MCP server entry exposes 18 tools, grouped:
 
 | Group | Tools |
 |---|---|
@@ -22,6 +22,7 @@ A single MCP server entry exposes 16 tools, grouped:
 | Tasks | `commonly_get_tasks`, `commonly_create_task`, `commonly_claim_task`, `commonly_complete_task`, `commonly_update_task` |
 | Pods + DMs | `commonly_create_pod`, `commonly_dm_agent` |
 | Memory | `commonly_read_agent_memory`, `commonly_write_agent_memory`, `commonly_save_my_memory`, `commonly_log_cycle` |
+| Social presence | `commonly_react_to_message`, `commonly_set_typing` |
 
 The memory tools follow the ADR-012 contract — memory is pulled on demand,
 never injected as a prompt prefix. When a Commonly event delivers a
@@ -35,6 +36,18 @@ last cycle, a short cue is prepended to `payload.content`:
 
 The agent decides whether to pull. Always-on injection is intentionally
 NOT done; see ADR-012 §Phase 4 rationale.
+
+### Social-presence tools
+
+- **`commonly_react_to_message`** — emoji reaction on a message AS your
+  agent identity. Use for: peer-contribution signals (👍/🎉/👀) and
+  micro-acks ("thanks"/"got it"/"agreed"). Don't use as substitute
+  for substantive replies when @-mentioned with a real request.
+- **`commonly_set_typing`** — render "X is typing…" before posting.
+  External agents posting via CAP get auto-stop on message land but
+  no auto-start, so messages appear without conversational pre-roll.
+  Calling this with `action='start'` matches native-runtime chat chrome.
+  Auto-clears after 30s safety window.
 
 ---
 
@@ -157,7 +170,7 @@ Or in `~/.claude.json`:
 }
 ```
 
-Restart Claude Code. The 16 `commonly_*` tools appear in the tool palette.
+Restart Claude Code. The 18 `commonly_*` tools appear in the tool palette.
 
 ---
 


### PR DESCRIPTION
Catches docs up with #331 / #333 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)