### PR TITLE
feat(auth): global admins can talk to + read any pod

### DIFF
--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -24,6 +24,7 @@ const Post = require('../models/Post');
 const Pod = require('../models/Pod');
 const { AgentInstallation } = require('../models/AgentRegistry');
 const { requireApiTokenScopes } = require('../middleware/apiTokenScopes');
+const { isGlobalAdminUser } = require('./registry/helpers');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { agentRateLimitKeyGenerator } = require('../middleware/agentRateLimit');
 
@@ -662,7 +663,11 @@ router.post('/room', dualAuth, phase4RateLimit, async (req: any, res: any) => {
       return res.status(404).json({ message: 'No active installation found for that agent' });
     }
 
-    // Authorization: user must be installer or a member of an installed pod.
+    // Authorization: user must be installer or a member of an installed
+    // pod. Global admins bypass — they can DM any agent for ops/debug
+    // (the resulting agent-room is still strictly 1:1 between admin
+    // and agent per ADR-001 §3.10, just as for regular pod members).
+    const isAdmin = await isGlobalAdminUser(userId);
     const candidatePodIds = installations
       .map((i: any) => i.podId).filter(Boolean);
     const accessiblePods = await Pod.find({
@@ -671,10 +676,12 @@ router.post('/room', dualAuth, phase4RateLimit, async (req: any, res: any) => {
     }).select('_id').lean();
     const accessibleSet = new Set(accessiblePods.map((p: any) => p._id.toString()));
 
-    const authorized = installations.filter((i: any) => (
-      String(i.installedBy || '') === String(userId)
-      || accessibleSet.has(String(i.podId))
-    ));
+    const authorized = isAdmin
+      ? installations
+      : installations.filter((i: any) => (
+        String(i.installedBy || '') === String(userId)
+        || accessibleSet.has(String(i.podId))
+      ));
 
     if (!authorized.length) {
       return res.status(403).json({ message: 'Not authorized to talk to this agent' });

--- a/backend/services/dmService.ts
+++ b/backend/services/dmService.ts
@@ -430,6 +430,15 @@ class DMService {
       return String(m);
     });
     if (memberIds.includes(uid)) return true;
+    // Global admins get read access to any pod (ops/debug observability).
+    // They remain non-members — read-only. Write paths (post message,
+    // remove member, etc.) enforce their own admin/membership rules.
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+      const User = require('../models/User');
+      const u = await User.findById(uid).select('role').lean();
+      if (u?.role === 'admin') return true;
+    } catch { /* role lookup failure is non-fatal — fall through */ }
     if (pod.type !== 'agent-dm') return false;
     // §3.7 fan-out: if viewer shares any pod with any DM member, allow.
     // Single Mongo query: find a pod whose members contain uid AND any


### PR DESCRIPTION
Per operator feedback — global admins should bypass the 'not authorized to talk to this agent' error and have read-only access to any pod regardless of membership.

* /api/agents/runtime/room: admin bypass on installer-or-member gate
* DMService.canViewPod: admin bypass on members-only gate

Write paths unchanged — admin still needs to follow normal posting / membership rules. This is read + DM-initiation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)