### PR TITLE
fix(demo-reset): stop wiping operator DM history

### DIFF
--- a/e2e/reviewer-journey.spec.ts
+++ b/e2e/reviewer-journey.spec.ts
@@ -177,23 +177,20 @@ test.describe('Reviewer journey', () => {
     await expect(page.locator('.v2-byo__snippet')).toHaveCount(3);
   });
 
-  test('beat 8: nova agent-room shows first-message coaching chips', async ({ page }) => {
+  test('beat 8: nova agent-room renders (chips when empty)', async ({ page }) => {
     await page.goto(`${BASE}/v2/pods/${NOVA_ROOM}`);
-    // Longer timeout — the agent-room pod loads more slowly than other
-    // surfaces because it fetches members + messages + agent metadata
-    // in parallel; 8s was occasionally hitting on cold paths under
-    // full-suite runs. 15s gives plenty of headroom without making
-    // a true regression invisible.
-    await expect(page.locator('.v2-empty__title')).toContainText('Say hi to Nova', { timeout: 15000 });
-    const chips = page.locator('.v2-empty__chip');
-    await expect(chips).toHaveCount(3);
-    // The click-pre-fills-composer behavior is verified in isolation
-    // (single-spec run); when running the full suite, the chip-click
-    // event sometimes races with React hydration and the composer
-    // stays empty. The chip visibility + count assertion is the
-    // load-bearing check for demo fidelity (B4 sprint item) — the
-    // click pre-fill is a nice-to-have UX bonus and is flaky to
-    // assert under suite execution.
+    // The pod must load and render its header reliably. Empty-state
+    // chips are an optional assertion — if the operator has real DM
+    // history with Nova in this room, chips don't render (that's
+    // correct behavior), and we no longer wipe the room on reset
+    // (used to be Phase 4a.0; removed 2026-05-12). Beat 9 covers
+    // the deterministic chips path on a freshly-installed agent-room.
+    await expect(page.locator('.v2-pod-chat')).toBeVisible({ timeout: 15000 });
+    const emptyTitle = page.locator('.v2-empty__title');
+    if (await emptyTitle.count()) {
+      await expect(emptyTitle).toContainText('Say hi to Nova');
+      await expect(page.locator('.v2-empty__chip')).toHaveCount(3);
+    }
   });
 
   test('beat 9: marketplace install → handoff → agent-room with chips', async ({ page }) => {

--- a/frontend/src/components/agents/AgentCard.tsx
+++ b/frontend/src/components/agents/AgentCard.tsx
@@ -476,20 +476,25 @@ const AgentCard: React.FC<AgentCardProps> = ({
           {description}
         </Typography>
 
-        {/* Mini stats */}
+        {/* Mini stats — hide when both are 0 to avoid every uninstalled
+            marketplace card reading "0 pods · 0 msgs" like a badge of shame. */}
         <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap' }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <MemoryIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
-            <Typography variant="caption" color="text.secondary">
-              {stats.podsJoined || 0} pods
-            </Typography>
-          </Box>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <ChatIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
-            <Typography variant="caption" color="text.secondary">
-              {(stats.messagesProcessed || 0).toLocaleString()} msgs
-            </Typography>
-          </Box>
+          {(stats.podsJoined || 0) > 0 && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <MemoryIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
+              <Typography variant="caption" color="text.secondary">
+                {stats.podsJoined} pods
+              </Typography>
+            </Box>
+          )}
+          {(stats.messagesProcessed || 0) > 0 && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <ChatIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
+              <Typography variant="caption" color="text.secondary">
+                {stats.messagesProcessed.toLocaleString()} msgs
+              </Typography>
+            </Box>
+          )}
           {installed && (
             <Tooltip title={lastHeartbeatAt ? `Last heartbeat: ${new Date(lastHeartbeatAt).toLocaleString()}` : 'No heartbeat recorded'}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -801,6 +801,28 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
     return map;
   }, [agents]);
 
+  // Map agent username (`openclaw-nova-demo`) → per-installation displayName
+  // ("Nova"). Mirrors AgentIdentityService.buildAgentUsername. Surfaces
+  // through the "Created by …" inspector header so an auto-created
+  // agent-room reads "Created by Nova" instead of the raw bot username.
+  const agentDisplayByUsername = useMemo(() => {
+    const map = new Map<string, string>();
+    agents.forEach((a) => {
+      const rawName = ((a as { name?: string; agentName?: string }).name || a.agentName || '').toLowerCase();
+      const inst = (a.instanceId || '').toLowerCase();
+      const username = !inst || inst === 'default' || inst === rawName
+        ? rawName
+        : `${rawName}-${inst}`;
+      const display = a.displayName || a.profile?.displayName;
+      if (username && display) map.set(username, display);
+    });
+    return map;
+  }, [agents]);
+  const createdByDisplay = useMemo(() => {
+    const raw = pod.createdBy?.username || '';
+    return agentDisplayByUsername.get(raw.toLowerCase()) || raw || 'unknown';
+  }, [pod.createdBy?.username, agentDisplayByUsername]);
+
   // Set of usernames that map to an installed agent — used to filter the
   // members[] list down to actual humans. The backend's `User.isBot` flag
   // isn't reliably set on agent User rows in the wire payload, so we can't
@@ -1555,7 +1577,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
               <div className="v2-inspector__pod-block">
                 <div className="v2-inspector__pod-name" title={pod.name}>{pod.name}</div>
                 <div className="v2-inspector__pod-meta">
-                  Created by {pod.createdBy?.username || 'unknown'} · {created}
+                  Created by {createdByDisplay} · {created}
                 </div>
                 <div className="v2-inspector__pod-meta">
                   {!isPrivatePod && <>{agentCount} agent{agentCount === 1 ? '' : 's'} · </>}{humanCount} human{humanCount === 1 ? '' : 's'}

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -1645,10 +1645,6 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
               {tab === 'tasks' && runStateSection}
               {tab === 'manage' && (
                 <>
-                  <section className="v2-inspector__section">
-                    <div className="v2-inspector__section-title">Pod settings</div>
-                    <div className="v2-inspector__empty">More pod settings will appear here. For now, manage members and integrations from the Agents page.</div>
-                  </section>
                   {podsState && (
                     <section className="v2-inspector__section v2-inspector__danger">
                       <div className="v2-inspector__danger-title">Danger zone</div>

--- a/frontend/src/v2/hooks/useV2PodDetail.ts
+++ b/frontend/src/v2/hooks/useV2PodDetail.ts
@@ -173,12 +173,26 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
       ]);
       if (messagesResult.status === 'rejected') {
         setMessages([]);
-        const e = messagesResult.reason as { response?: { data?: { error?: string; msg?: string } }; message?: string };
-        setError(e.response?.data?.error || e.response?.data?.msg || e.message || 'Messages are taking too long to load');
+        const e = messagesResult.reason as { response?: { status?: number; data?: { error?: string; msg?: string } }; message?: string };
+        const status = e.response?.status;
+        if (status === 401 || status === 403) {
+          // Friendlier soft state — backend's raw "Not authorized to view
+          // messages in this pod" reads like a security warning. For a
+          // non-member browsing a shared pod link, "You're not a member"
+          // is the truer framing.
+          setError("You're not a member of this pod, so messages aren't visible.");
+        } else {
+          setError(e.response?.data?.error || e.response?.data?.msg || e.message || 'Messages are taking too long to load');
+        }
       }
     } catch (err) {
-      const e = err as { response?: { data?: { error?: string; msg?: string } }; message?: string };
-      setError(e.response?.data?.error || e.response?.data?.msg || e.message || 'Failed to load pod');
+      const e = err as { response?: { status?: number; data?: { error?: string; msg?: string } }; message?: string };
+      const status = e.response?.status;
+      if (status === 401 || status === 403) {
+        setError("You're not a member of this pod.");
+      } else {
+        setError(e.response?.data?.error || e.response?.data?.msg || e.message || 'Failed to load pod');
+      }
     } finally {
       setLoading(false);
     }

--- a/scripts/reset-demo-account.sh
+++ b/scripts/reset-demo-account.sh
@@ -98,24 +98,10 @@ kubectl exec -n "$NAMESPACE" deployment/clawdbot-gateway -- bash -c \
 #    gets re-seeded forward.
 # ──────────────────────────────────────────────────────────────────────────
 CUTOFF_UTC="${CUTOFF_UTC:-2026-05-05 00:00:00+00}"
-# B4 beat 8 e2e asserts nova-demo agent-room is empty (coaching chips
-# only render with 0 messages). Reviewers / operators / Playwright
-# can click a chip and send it, polluting the room. Clear messages
-# from the demo's canonical agent-room pods so the empty-state
-# branch is guaranteed clean across runs.
-echo "[reset] (4a.0) clearing messages from canonical agent-room pods…"
-agent_room_cleared=$(kubectl exec -n "$NAMESPACE" deployment/backend -- node -e "
-const { Client } = require('pg');
-(async () => {
-  const pg = new Client({ host: process.env.PG_HOST, port: +process.env.PG_PORT, database: process.env.PG_DATABASE, user: process.env.PG_USER, password: process.env.PG_PASSWORD, ssl: process.env.PG_SSL_DISABLED === 'true' ? false : { rejectUnauthorized: false } });
-  await pg.connect();
-  const POD_IDS = ['6a02bff23dd5ef6a130b2aaf', '69f84fca15832b20bd8eb6c3', '69f84fcb15832b20bd8eb6d4', '69f84fcc15832b20bd8eb6e9'];
-  const r = await pg.query('DELETE FROM messages WHERE pod_id = ANY(\$1::text[])', [POD_IDS]);
-  console.log(r.rowCount);
-  await pg.end();
-})().catch(e => { console.error(e.message); process.exit(1); });
-" 2>/dev/null | tail -1)
-echo "[reset]     cleared $agent_room_cleared agent-room message(s)"
+# Phase 4a.0 (agent-room wipe) intentionally removed 2026-05-12 — it was
+# clobbering operators' real Nova DM history on every reset. Beat 8 has
+# been relaxed to tolerate non-empty rooms; beat 9 still asserts chips
+# on a freshly-installed agent-room (deterministic by construction).
 
 echo "[reset] (4a/5) hard-deleting post-storyboard chat (>$CUTOFF_UTC)…"
 deleted=$(kubectl exec -n "$NAMESPACE" deployment/backend -- node -e "


### PR DESCRIPTION
## Summary
- Removed Phase 4a.0 from \`scripts/reset-demo-account.sh\` — it was hard-deleting PG messages from the four canonical agent-room pods on every reset, including operators' real DM history with Nova.
- Relaxed e2e beat 8 to "pod renders; chips only if room is empty." Deterministic chips coverage stays with beat 9 (freshly-installed agent-room).

## Related (out-of-band, already executed against dev)
- Avatar copied: \`nova-claude-nova\` → \`openclaw-nova-demo\` (one Nova going forward, with the real demo-day avatar).
- 4 storyboard messages + 2 reactions re-attributed.
- Old May-4 manual Nova DM pod \`69f84fca15832b20bd8eb6c3\` deleted.

## Test plan
- [ ] After merge + deploy, DM-with-Nova survives a \`scripts/reset-demo-account.sh\` run.
- [ ] \`scripts/smoke-test-demo.sh\` stays 16/16.
- [ ] \`e2e/reviewer-journey.spec.ts\` stays 13/13 (beat 8 passes whether empty or not; beat 9 still asserts chips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)