### PR TITLE
fix(v2-login): remove dev credential leak from public-facing login

### DIFF
--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -49,13 +49,13 @@ const renderAt = (path: string, auth = baseAuth) => render(
 describe('V2 routing', () => {
   test('login route renders v2 login form', () => {
     renderAt('/v2/login');
-    expect(screen.getByRole('heading', { name: /Sign in to v2/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /^Sign in$/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
   });
 
   test('protected route redirects to login when not authenticated', () => {
     renderAt('/v2');
-    expect(screen.getByRole('heading', { name: /Sign in to v2/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /^Sign in$/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/v2/components/V2Login.tsx
+++ b/frontend/src/v2/components/V2Login.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 
 interface LocationState {
@@ -10,8 +10,8 @@ const V2Login: React.FC = () => {
   const { login, error: authError, loading } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const [email, setEmail] = useState('dev@commonly.local');
-  const [password, setPassword] = useState('password123');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
 
@@ -48,9 +48,9 @@ const V2Login: React.FC = () => {
           <span className="v2-rail__brand-icon">c</span>
           commonly
         </div>
-        <h1 className="v2-login__title">Sign in to v2</h1>
+        <h1 className="v2-login__title">Sign in</h1>
         <p className="v2-login__subtitle">
-          Use your Commonly credentials. v2 is a preview build that runs alongside the existing app.
+          Commonly is the shared space where agents and humans collaborate.
         </p>
 
         <label className="v2-login__field">
@@ -88,11 +88,9 @@ const V2Login: React.FC = () => {
         {errorMessage && <div className="v2-login__error">{errorMessage}</div>}
 
         <div className="v2-login__hint">
-          Local dev login is seeded automatically. Default:
+          New to Commonly?
           {' '}
-          <code>dev@commonly.local</code>
-          {' / '}
-          <code>password123</code>
+          <Link to="/v2/register" className="v2-login__link">Create an account</Link>
         </div>
       </form>
     </div>

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -3334,6 +3334,15 @@
   color: var(--v2-text-primary);
 }
 
+.v2-login__link {
+  color: var(--v2-accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+.v2-login__link:hover {
+  text-decoration: underline;
+}
+
 /* ---------- Empty / loading states ---------- */
 
 .v2-feature {


### PR DESCRIPTION
## Summary
- Removed dev credential leak from \`/v2/login\` (email + password fields no longer pre-fill with \`dev@commonly.local\` / \`password123\`; the helper text that documented those defaults is gone).
- Replaced "v2 is a preview build that runs alongside the existing app" with a one-line product framing.
- Added "New to Commonly? Create an account" CTA pointing at /v2/register.
- Updated V2Login routing test to match new heading.

## Why
A YC reviewer landing on app-dev.commonly.me sees the login page first. Until this PR, that page actively showed working credentials for the dev instance — a security smell and a UX miss. The "Create an account" CTA also gives an anonymous visitor a forward path rather than just a sign-in form they can't use.

## Test plan
- [ ] After deploy: \`/v2/login\` shows empty email/password, new tagline, "Create an account" link.
- [ ] Clicking "Create an account" routes to /v2/register.
- [ ] Existing login flow (typed credentials) still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)