### PR TITLE
fix(v2-login): give "Create an account" link accent color

### DIFF
--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -3379,12 +3379,14 @@
   color: var(--v2-text-primary);
 }
 
-.v2-login__link {
+/* `.v2-root a { color: inherit }` (0,1,1) beats a single-class rule
+   on specificity, so prefix to win. Same pattern as the v2-button reset. */
+.v2-root a.v2-login__link {
   color: var(--v2-accent);
   text-decoration: none;
   font-weight: 500;
 }
-.v2-login__link:hover {
+.v2-root a.v2-login__link:hover {
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Summary
The new "Create an account" CTA (added in #350) is rendering gray instead of accent-blue because \`.v2-root a { color: inherit }\` (0,1,1) outranks the bare \`.v2-login__link\` rule (0,1,0). The link inherits the surrounding hint's \`text-tertiary\` color.

Fix: prefix selector with \`.v2-root a\` to bump specificity. Same pattern as the v2-button reset workaround documented in \`feedback-v2-button-reset-specificity\`.

## Test plan
- [ ] After deploy: /v2/login → "Create an account" link is blue/accent, hover underlines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)