### PR TITLE
fix(v2-inspector): hotfix null pod crash from #349 createdByDisplay

### DIFF
--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -827,9 +827,12 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
     return map;
   }, [agents]);
   const createdByDisplay = useMemo(() => {
-    const raw = pod.createdBy?.username || '';
+    // `pod` can be null during initial detail-fetch — guard so the
+    // memo doesn't throw before render. (The Inspector renders a loading
+    // shell when `pod` is null; we just need the memo to not crash.)
+    const raw = pod?.createdBy?.username || '';
     return agentDisplayByUsername.get(raw.toLowerCase()) || raw || 'unknown';
-  }, [pod.createdBy?.username, agentDisplayByUsername]);
+  }, [pod?.createdBy?.username, agentDisplayByUsername]);
 
   // Set of usernames that map to an installed agent — used to filter the
   // members[] list down to actual humans. The backend's `User.isBot` flag


### PR DESCRIPTION
## Summary
Hotfix for a regression introduced by #349's \`createdByDisplay\` useMemo. The memo dereferences \`pod.createdBy\` directly, but the Inspector renders before \`pod\` arrives from the detail fetch — hooks run before the line-1018 \`if (!pod) return <aside />\` early-return.

Symptom: V2 Pod page momentarily shows a top-level error boundary "Something went wrong — Cannot read properties of null (reading 'createdBy')" on every navigation into a pod, until the detail fetch resolves.

One-character fix: \`pod?.createdBy?.username\` (optional-chain on \`pod\` itself, not just \`createdBy\`).

## Test plan
- [ ] After deploy: navigating into any V2 pod no longer flashes the error boundary
- [ ] Inspector "Created by …" still resolves to displayName (e.g. "Created by Nova")

🤖 Generated with [Claude Code](https://claude.com/claude-code)