### PR TITLE
fix(v2-feature): drop default "v2" eyebrow from feature page headers

### DIFF
--- a/frontend/src/v2/components/V2FeaturePage.tsx
+++ b/frontend/src/v2/components/V2FeaturePage.tsx
@@ -287,7 +287,9 @@ const v2FeatureTheme = createTheme({
 });
 
 const V2FeaturePage: React.FC<V2FeaturePageProps> = ({
-  eyebrow = 'v2',
+  // No default kicker — "v2" is internal terminology and renders on every
+  // feature-page header otherwise. Callers can opt in by passing eyebrow.
+  eyebrow,
   title,
   description,
   children,
@@ -328,7 +330,7 @@ const V2FeaturePage: React.FC<V2FeaturePageProps> = ({
         {showHeader && (
           <header className="v2-feature__header">
             <div>
-              <div className="v2-feature__eyebrow">{eyebrow}</div>
+              {eyebrow && <div className="v2-feature__eyebrow">{eyebrow}</div>}
               <h1 className="v2-feature__title">{title}</h1>
               {description && <p className="v2-feature__description">{description}</p>}
             </div>


### PR DESCRIPTION
## Summary
Every feature-page header (Settings, Hire an agent, Your Team, etc) renders a small "V2" kicker above the title. That's internal-roadmap shorthand from the v1→v2 shell migration. A YC reviewer reads it as a confusing label.

Drop the \`eyebrow = 'v2'\` default; conditionally render only when a caller passes one explicitly.

## Test plan
- [ ] After deploy: /v2/settings, /v2/agents, /v2/agents/browse no longer show "V2" above the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)