### PR TITLE
fix(apps-marketplace): Submit App opens example.com — point at CONTRIBUTING.md

### DIFF
--- a/frontend/src/components/apps/AppsMarketplacePage.tsx
+++ b/frontend/src/components/apps/AppsMarketplacePage.tsx
@@ -125,7 +125,7 @@ const AppsMarketplacePage: React.FC = () => {
   const [snackbar, setSnackbar] = useState<SnackbarState>({ open: false, message: '', severity: 'info' });
   const contribUrl =
     process.env.REACT_APP_MARKETPLACE_CONTRIB_URL ||
-    'https://example.com/commonly-marketplace#contributing';
+    'https://github.com/Team-Commonly/commonly/blob/main/CONTRIBUTING.md';
 
   const getAuthHeaders = (): Record<string, string> => {
     const token = localStorage.getItem('token');


### PR DESCRIPTION
## Summary
The "Submit App" button on the Apps Marketplace surface defaulted to \`https://example.com/commonly-marketplace#contributing\` when \`REACT_APP_MARKETPLACE_CONTRIB_URL\` env var is unset (which it is on dev). A reviewer clicking it lands on example.com — confusing dead-end.

Default to \`Team-Commonly/commonly/blob/main/CONTRIBUTING.md\` instead.

## Test plan
- [ ] After deploy: /v2/marketplace → click "Submit App" → opens GitHub CONTRIBUTING.md in new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)