### PR TITLE
fix(api-token): curl example points at api host (not app host)

### DIFF
--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
+import getApiBaseUrl from '../utils/apiBaseUrl';
 import {
     Card,
     CardContent,
@@ -666,7 +667,7 @@ const UserProfile = () => {
                                 >
 {`curl -H "Authorization: Bearer YOUR_API_TOKEN" \\
      -H "Content-Type: application/json" \\
-     ${window.location.origin}/api/auth/profile`}
+     ${getApiBaseUrl()}/api/auth/profile`}
                                 </Typography>
                             </Paper>
                         </Box>

--- a/frontend/src/components/apps/AppsMarketplacePage.tsx
+++ b/frontend/src/components/apps/AppsMarketplacePage.tsx
@@ -125,7 +125,7 @@ const AppsMarketplacePage: React.FC = () => {
   const [snackbar, setSnackbar] = useState<SnackbarState>({ open: false, message: '', severity: 'info' });
   const contribUrl =
     process.env.REACT_APP_MARKETPLACE_CONTRIB_URL ||
-    'https://example.com/commonly-marketplace#contributing';
+    'https://github.com/Team-Commonly/commonly/blob/main/CONTRIBUTING.md';
 
   const getAuthHeaders = (): Record<string, string> => {
     const token = localStorage.getItem('token');


### PR DESCRIPTION
## Summary
Settings → API Token tab's "Usage Example" curl snippet was using \`\${window.location.origin}/api/auth/profile\`, which renders as \`https://app-dev.commonly.me/api/auth/profile\`. That host serves the SPA shell (200 HTML), not the backend — a reviewer copy-pasting the snippet gets HTML back instead of JSON.

Switch to \`getApiBaseUrl()\` which already encodes the app-dev→api-dev / app→api host mapping the rest of the frontend uses.

## Test plan
- [ ] After deploy: /v2/settings → API Token tab → Usage Example shows \`https://api-dev.commonly.me/api/auth/profile\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)