### PR TITLE
fix(litellm-rotator): only fire rate-limit signal on Codex 429s

### DIFF
--- a/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
@@ -59,6 +59,17 @@ spec:
                     'ratelimiterror',
                 ))
 
+            def _is_codex_model(model: str) -> bool:
+                # The rotator's job is to swap Codex auth on 429s. Rate-limit
+                # signals from other providers (OpenRouter free tier, Gemini)
+                # are not actionable here — rotating in response only burns
+                # in-flight Codex requests with 401s and doesn't help the
+                # rate-limited model. Filter so signals only fire for the
+                # provider the rotator can actually do something about.
+                if not model: return False
+                m = model.lower()
+                return m.startswith('openai-codex/') or m.startswith('chatgpt/')
+
             def _write_signal(model: str, exc_str: str):
                 try:
                     tmp = SIGNAL_FILE + '.tmp'
@@ -84,8 +95,9 @@ spec:
                     exc = kwargs.get('exception')
                     if not exc: return
                     exc_str = str(exc)
-                    if _is_rate_limit(exc_str):
-                        _write_signal(kwargs.get('model', 'unknown'), exc_str)
+                    model = kwargs.get('model', 'unknown')
+                    if _is_rate_limit(exc_str) and _is_codex_model(model):
+                        _write_signal(model, exc_str)
 
                 async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
                     pass
@@ -94,8 +106,9 @@ spec:
                     exc = kwargs.get('exception')
                     if not exc: return
                     exc_str = str(exc)
-                    if _is_rate_limit(exc_str):
-                        _write_signal(kwargs.get('model', 'unknown'), exc_str)
+                    model = kwargs.get('model', 'unknown')
+                    if _is_rate_limit(exc_str) and _is_codex_model(model):
+                        _write_signal(model, exc_str)
 
             proxy_handler_instance = RateLimitSignaler()
             PYEOF


### PR DESCRIPTION
## Summary
The Codex auth rotator's \`RateLimitSignaler\` callback was firing rotate-now on **any** LiteLLM-routed model 429, including community-agent traffic to OpenRouter free-tier models (\`nvidia/nemotron-3-super-120b-a12b:free\`) which hit OR quotas constantly.

Each spurious rotation swapped Codex \`auth.json\` mid-flight, which 401-ed any in-progress Codex request. Result: Nova mention-response intermittently fails with \`401 litellm.BadRequestError: ChatgptException\` even though rotator-health smoke reports all 3 Codex accounts healthy.

The rotator's job is to swap Codex auth on **Codex** 429s. Filter signals so only \`openai-codex/*\` and \`chatgpt/*\` model failures fire. Other provider rate limits are not actionable here.

Documented in \`feedback-litellm-retry-doubles-rotation-burn\` memory; this is the long-form fix.

## Test plan
- [ ] After deploy: \`scripts/smoke-test-demo.sh\` returns 16/16 green consistently (mention-response no longer intermittently 90s timeout).
- [ ] LiteLLM logs: no \`SIGNALED rotate-now\` for non-Codex models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)