### PR TITLE
revert: roll back rotator scope changes (#357 #358 #359)

### DIFF
--- a/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
@@ -59,29 +59,6 @@ spec:
                     'ratelimiterror',
                 ))
 
-            def _is_codex_auth_failure(exc_str: str) -> bool:
-                # ChatGPT/Codex returns 401 (ChatgptException) when the
-                # access_token's underlying session has been invalidated
-                # server-side (logout, password change, session timeout).
-                # The JWT itself can still claim a future exp — the API
-                # rejection is independent. Rotating to a different
-                # account lets us keep serving. We narrow to 401 + the
-                # ChatgptException marker so we don't rotate on a generic
-                # 401 from some other provider.
-                s = exc_str.lower()
-                return ('chatgptexception' in s or 'chatgpt exception' in s) and '401' in s
-
-            def _is_codex_model(model: str) -> bool:
-                # The rotator's job is to swap Codex auth on 429s. Rate-limit
-                # signals from other providers (OpenRouter free tier, Gemini)
-                # are not actionable here — rotating in response only burns
-                # in-flight Codex requests with 401s and doesn't help the
-                # rate-limited model. Filter so signals only fire for the
-                # provider the rotator can actually do something about.
-                if not model: return False
-                m = model.lower()
-                return m.startswith('openai-codex/') or m.startswith('chatgpt/')
-
             def _write_signal(model: str, exc_str: str):
                 try:
                     tmp = SIGNAL_FILE + '.tmp'
@@ -104,53 +81,21 @@ spec:
                     pass
 
                 def log_failure_event(self, kwargs, response_obj, start_time, end_time):
-                    # Pull the exception from any common slot. LiteLLM's
-                    # callback API shifted these across versions
-                    # (`exception` / `original_exception`; sometimes the
-                    # auth detail only lives on response_obj).
-                    exc = kwargs.get('exception') or kwargs.get('original_exception')
-                    parts = []
-                    if exc: parts.append(str(exc))
-                    if response_obj is not None:
-                        try: parts.append(str(response_obj))
-                        except Exception: pass
-                    sc = kwargs.get('status_code') or kwargs.get('response_status_code')
-                    if sc: parts.append(str(sc))
-                    exc_str = ' | '.join(parts)
-                    if not exc_str: return
-                    model = kwargs.get('model', 'unknown')
-                    # Diagnostic — one log line per failure so we can verify
-                    # the callback fires and what shape it sees.
-                    print(f'[rate-limit-signaler] failure model={model} exc_preview={exc_str[:200]}', flush=True)
-                    is_codex = _is_codex_model(model)
-                    if (_is_rate_limit(exc_str) and is_codex) or _is_codex_auth_failure(exc_str):
-                        _write_signal(model, exc_str)
+                    exc = kwargs.get('exception')
+                    if not exc: return
+                    exc_str = str(exc)
+                    if _is_rate_limit(exc_str):
+                        _write_signal(kwargs.get('model', 'unknown'), exc_str)
 
                 async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
                     pass
 
                 async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
-                    # Pull the exception from any common slot. LiteLLM's
-                    # callback API shifted these across versions
-                    # (`exception` / `original_exception`; sometimes the
-                    # auth detail only lives on response_obj).
-                    exc = kwargs.get('exception') or kwargs.get('original_exception')
-                    parts = []
-                    if exc: parts.append(str(exc))
-                    if response_obj is not None:
-                        try: parts.append(str(response_obj))
-                        except Exception: pass
-                    sc = kwargs.get('status_code') or kwargs.get('response_status_code')
-                    if sc: parts.append(str(sc))
-                    exc_str = ' | '.join(parts)
-                    if not exc_str: return
-                    model = kwargs.get('model', 'unknown')
-                    # Diagnostic — one log line per failure so we can verify
-                    # the callback fires and what shape it sees.
-                    print(f'[rate-limit-signaler] failure model={model} exc_preview={exc_str[:200]}', flush=True)
-                    is_codex = _is_codex_model(model)
-                    if (_is_rate_limit(exc_str) and is_codex) or _is_codex_auth_failure(exc_str):
-                        _write_signal(model, exc_str)
+                    exc = kwargs.get('exception')
+                    if not exc: return
+                    exc_str = str(exc)
+                    if _is_rate_limit(exc_str):
+                        _write_signal(kwargs.get('model', 'unknown'), exc_str)
 
             proxy_handler_instance = RateLimitSignaler()
             PYEOF


### PR DESCRIPTION
## Summary
Reverts #357, #358, #359 in a single commit.

The rotator's \`RateLimitSignaler\` callback was previously firing on every model 429 — including OR-free-tier nemotron — which kept the rotator constantly cycling Codex auth.

I treated that as a bug (#357 narrowed the filter to Codex models only) and stacked #358 / #359 trying to handle the resulting Codex 401 leak. After three iterations the pipeline is still 1/3 → 2/3 → 3/3 failing on \`mention-response\`.

**Diagnostic from #359 confirms** the LiteLLM \`log_failure_event\` callback never sees per-model Codex failures inside the failover chain — only the outermost fallback (Gemini) raises a callback. Fixing it properly needs an out-of-band probe (log-tail the LiteLLM container, or active health-probe Codex from the rotator) and is out of scope for the shell-polish sprint.

Reverting restores the "noisy but pragmatic" baseline: OR-free-tier 429s drive rotation, which incidentally keeps Codex auth fresh enough for Nova mentions to land. \`mention-response\` was reliably green at SHA \`7596a26879\` (pre-#357).

Memory \`feedback-litellm-retry-doubles-rotation-burn\` already documents this finicky interaction; leaving the real fix for a dedicated pipeline sprint.

## Test plan
- [ ] After deploy: \`scripts/smoke-test-demo.sh\` returns 16/16 (mention-response green again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)