### PR TITLE
fix(cloud-codex): tokens/<name>.json + drop --instance + ca-certificates

### DIFF
--- a/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
@@ -1,0 +1,191 @@
+{{- if .Values.agents.cloudCodex.enabled }}
+{{- /*
+  cloud-codex — runs `commonly agent run <name>` + the codex CLI inside the
+  cluster, as an alternative to `sam-local-codex` (which runs the same pair
+  on an operator's laptop).
+
+  Why cluster-side codex matters:
+    ChatGPT binds OAuth sessions to the IP/device that completed device-auth.
+    A session device-auth'd on a laptop and then used by LiteLLM from the
+    cluster's IP gets `token_invalidated` immediately on first use. That's
+    why dev's LiteLLM Codex path has been flapping despite fresh tokens.
+    When `codex login --device-auth` runs INSIDE this pod, the cluster IP
+    is what ChatGPT sees both for the device-auth AND for subsequent CLI
+    calls — no mismatch, no anti-abuse revoke.
+
+  Operator flow (one-time per agent install):
+    1. Pre-create the AgentInstallation via `POST /api/registry/install`
+       and obtain a runtime token (cm_agent_*). Stash it in the secret
+       referenced by COMMONLY_AGENT_TOKEN below.
+    2. `helm upgrade` — pod boots; init container installs codex + commonly
+       CLIs to /tools; main container waits for ~/.codex/auth.json.
+    3. `kubectl exec -n commonly-dev deploy/cloud-codex-<agent> -- codex login --device-auth`
+       — operator completes device-auth in their browser; auth.json lands
+       on the PVC at /root/.codex/auth.json.
+    4. Main container picks up auth.json, runs `commonly agent run <name>`
+       in poll mode against CAP. Replies use codex CLI executing inside
+       this pod, so OpenAI sees one stable client = one stable session.
+
+  Identity continuity (ADR-001 §3):
+    The AgentInstallation row + the agent's User row predate this pod and
+    survive its restart/redeploy. The pod is just runtime — no identity
+    state lives here that isn't recoverable.
+*/}}
+{{- range $name, $cfg := .Values.agents.cloudCodex.agents }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cloud-codex-{{ $name }}
+  namespace: {{ include "commonly.namespace" $ }}
+  labels:
+    {{- include "commonly.labels" $ | nindent 4 }}
+    app: cloud-codex
+    agent: {{ $name }}
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: {{ $cfg.storage | default "1Gi" }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud-codex-{{ $name }}
+  namespace: {{ include "commonly.namespace" $ }}
+  labels:
+    {{- include "commonly.labels" $ | nindent 4 }}
+    app: cloud-codex
+    agent: {{ $name }}
+spec:
+  replicas: 1
+  # Recreate so the PVC (single-writer RWO) reattaches cleanly on update.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "commonly.selectorLabels" $ | nindent 6 }}
+      app: cloud-codex
+      agent: {{ $name }}
+  template:
+    metadata:
+      labels:
+        {{- include "commonly.selectorLabels" $ | nindent 8 }}
+        app: cloud-codex
+        agent: {{ $name }}
+    spec:
+      initContainers:
+      # Mirror of clawdbot-deployment's codex-tools-installer init —
+      # installs the pinned codex + commonly CLIs into the shared
+      # /tools volume so the main container has the binaries available.
+      - name: codex-tools-installer
+        image: node:22-bookworm-slim
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          export NPM_CONFIG_PREFIX=/tools
+          apt-get update >/dev/null 2>&1
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            git ca-certificates >/dev/null 2>&1
+          npm install --global --no-audit --no-fund \
+            "@openai/codex@{{ $.Values.agents.cloudCodex.codexVersion | default "0.125.0" }}"
+          git clone --depth 1 --branch "{{ $.Values.agents.cloudCodex.commonlyCliRef | default "main" }}" \
+            https://github.com/Team-Commonly/commonly.git /tmp/commonly-src
+          mkdir -p /tools/lib
+          cp -r /tmp/commonly-src/cli /tools/lib/commonly-cli
+          cd /tools/lib/commonly-cli
+          npm install --omit=dev --no-audit --no-fund
+          ln -sf /tools/lib/commonly-cli/src/index.js /tools/bin/commonly
+          chmod +x /tools/lib/commonly-cli/src/index.js
+          /tools/bin/codex --version || true
+          /tools/bin/commonly --version || true
+        volumeMounts:
+        - name: tools
+          mountPath: /tools
+      containers:
+      - name: agent
+        image: node:22-bookworm-slim
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          export PATH="/tools/bin:$PATH"
+          export HOME=/state
+          mkdir -p /state/.codex /state/.commonly
+
+          # Seed ~/.commonly/config.json from injected env so `commonly`
+          # CLI knows which instance + which agent token to use. Re-writing
+          # on every boot is intentional — keeps the source of truth as the
+          # mounted secret, not the PVC.
+          cat > /state/.commonly/config.json <<EOF
+          {
+            "instances": {
+              "${COMMONLY_INSTANCE_KEY:-dev}": {
+                "url": "${COMMONLY_API_URL}",
+                "token": "${COMMONLY_USER_TOKEN:-}",
+                "agentTokens": {
+                  "${COMMONLY_AGENT_NAME}": "${COMMONLY_AGENT_TOKEN}"
+                }
+              }
+            },
+            "active": "${COMMONLY_INSTANCE_KEY:-dev}"
+          }
+          EOF
+          chmod 600 /state/.commonly/config.json
+
+          # Wait for codex auth.json. ChatGPT binds OAuth to the IP that
+          # ran device-auth; running `codex login --device-auth` INSIDE
+          # this pod is the whole point. If auth.json is missing, sit
+          # idle and log clear instructions so the operator's first
+          # `kubectl exec` shows them exactly what to do.
+          if [ ! -s /state/.codex/auth.json ]; then
+            echo "[cloud-codex] no codex auth.json on PVC — waiting for device-auth"
+            echo "[cloud-codex] run this once to bind the cluster session:"
+            echo "[cloud-codex]   kubectl exec -n {{ include "commonly.namespace" $ }} -it deploy/cloud-codex-{{ $name }} -- codex login --device-auth"
+            echo "[cloud-codex] (after completing in browser, the pod will resume on next reboot)"
+            # Sleep loop so operator can exec in. Restart-on-success is the
+            # cleanest UX — when auth.json appears, we want to re-enter the
+            # main path, and the simplest way to do that is a fresh boot.
+            while [ ! -s /state/.codex/auth.json ]; do sleep 10; done
+            echo "[cloud-codex] auth.json present — restarting to enter run loop"
+            exit 0
+          fi
+
+          echo "[cloud-codex] auth.json found, starting commonly agent run ${COMMONLY_AGENT_NAME}"
+          exec /tools/bin/commonly agent run "${COMMONLY_AGENT_NAME}" --instance "${COMMONLY_INSTANCE_KEY:-dev}"
+        env:
+        - name: COMMONLY_AGENT_NAME
+          value: {{ $name | quote }}
+        - name: COMMONLY_INSTANCE_KEY
+          value: {{ $cfg.instanceKey | default "dev" | quote }}
+        - name: COMMONLY_API_URL
+          value: {{ $cfg.apiUrl | default $.Values.agents.cloudCodex.apiUrl | quote }}
+        - name: COMMONLY_AGENT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ $cfg.tokenSecret | default (printf "cloud-codex-%s-token" $name) }}
+              key: token
+        volumeMounts:
+        - name: tools
+          mountPath: /tools
+          readOnly: true
+        - name: state
+          mountPath: /state
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+      volumes:
+      - name: tools
+        emptyDir: {}
+      - name: state
+        persistentVolumeClaim:
+          claimName: cloud-codex-{{ $name }}
+{{- end }}
+{{- end }}

--- a/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
@@ -114,27 +114,38 @@ spec:
           set -e
           export PATH="/tools/bin:$PATH"
           export HOME=/state
-          mkdir -p /state/.codex /state/.commonly
+          mkdir -p /state/.codex /state/.commonly/tokens
 
-          # Seed ~/.commonly/config.json from injected env so `commonly`
-          # CLI knows which instance + which agent token to use. Re-writing
-          # on every boot is intentional — keeps the source of truth as the
-          # mounted secret, not the PVC.
-          cat > /state/.commonly/config.json <<EOF
+          # ca-certificates aren't included in node:22-bookworm-slim base,
+          # but codex CLI needs them for TLS to api.openai.com /
+          # auth.openai.com. Install once at boot (idempotent — apt skips
+          # what's already there) so the run loop's outbound HTTPS works.
+          if [ ! -d /etc/ssl/certs ] || [ -z "$(ls -A /etc/ssl/certs 2>/dev/null)" ]; then
+            echo "[cloud-codex] installing ca-certificates for TLS"
+            apt-get update >/dev/null 2>&1 || true
+            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates >/dev/null 2>&1 || true
+            update-ca-certificates >/dev/null 2>&1 || true
+          fi
+
+          # Seed ~/.commonly/tokens/<name>.json — `commonly agent run`
+          # uses loadAgentToken() to find the runtime credentials for this
+          # agent name. The record shape mirrors what `commonly agent
+          # attach` would write on a laptop.
+          # Token-file name uses the local wrapper alias (COMMONLY_AGENT_NAME);
+          # `agentName` and `instanceId` INSIDE the file are the registry-side
+          # identifiers the poller passes to /api/agents/runtime/events.
+          cat > /state/.commonly/tokens/${COMMONLY_AGENT_NAME}.json <<EOF
           {
-            "instances": {
-              "${COMMONLY_INSTANCE_KEY:-dev}": {
-                "url": "${COMMONLY_API_URL}",
-                "token": "${COMMONLY_USER_TOKEN:-}",
-                "agentTokens": {
-                  "${COMMONLY_AGENT_NAME}": "${COMMONLY_AGENT_TOKEN}"
-                }
-              }
-            },
-            "active": "${COMMONLY_INSTANCE_KEY:-dev}"
+            "agentName": "${COMMONLY_REGISTRY_AGENT_NAME}",
+            "instanceId": "${COMMONLY_AGENT_INSTANCE_ID:-$COMMONLY_AGENT_NAME}",
+            "podId": "${COMMONLY_POD_ID}",
+            "instanceUrl": "${COMMONLY_API_URL}",
+            "runtimeToken": "${COMMONLY_AGENT_TOKEN}",
+            "adapter": "${COMMONLY_ADAPTER:-codex}",
+            "savedAt": "$(date -u +%FT%TZ)"
           }
           EOF
-          chmod 600 /state/.commonly/config.json
+          chmod 600 /state/.commonly/tokens/${COMMONLY_AGENT_NAME}.json
 
           # Wait for codex auth.json. ChatGPT binds OAuth to the IP that
           # ran device-auth; running `codex login --device-auth` INSIDE
@@ -155,12 +166,21 @@ spec:
           fi
 
           echo "[cloud-codex] auth.json found, starting commonly agent run ${COMMONLY_AGENT_NAME}"
-          exec /tools/bin/commonly agent run "${COMMONLY_AGENT_NAME}" --instance "${COMMONLY_INSTANCE_KEY:-dev}"
+          exec /tools/bin/commonly agent run "${COMMONLY_AGENT_NAME}"
         env:
         - name: COMMONLY_AGENT_NAME
           value: {{ $name | quote }}
-        - name: COMMONLY_INSTANCE_KEY
-          value: {{ $cfg.instanceKey | default "dev" | quote }}
+        - name: COMMONLY_REGISTRY_AGENT_NAME
+          # The registry-side agentName (matches AgentInstallation.agentName).
+          # Defaults to "cloud-codex" since that's what this Helm template is
+          # for; override if you ever install under a different name.
+          value: {{ $cfg.registryAgentName | default "cloud-codex" | quote }}
+        - name: COMMONLY_AGENT_INSTANCE_ID
+          value: {{ $cfg.agentInstanceId | default $name | quote }}
+        - name: COMMONLY_POD_ID
+          value: {{ $cfg.podId | quote }}
+        - name: COMMONLY_ADAPTER
+          value: {{ $cfg.adapter | default "codex" | quote }}
         - name: COMMONLY_API_URL
           value: {{ $cfg.apiUrl | default $.Values.agents.cloudCodex.apiUrl | quote }}
         - name: COMMONLY_AGENT_TOKEN

--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -145,6 +145,15 @@ agents:
         value: "dev"
         effect: "NoSchedule"
 
+  cloudCodex:
+    enabled: true
+    apiUrl: http://backend.commonly-dev.svc.cluster.local:5000
+    agents:
+      cody:
+        instanceKey: dev
+        storage: 1Gi
+        tokenSecret: cloud-codex-cody-token
+
 rbac:
   create: true
 

--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -150,7 +150,11 @@ agents:
     apiUrl: http://backend.commonly-dev.svc.cluster.local:5000
     agents:
       cody:
-        instanceKey: dev
+        # The AgentInstallation row this pod's runtime token is bound to.
+        # podId = Team Orchestration Demo pod (where Cody lives).
+        podId: 69f841a9063269526de0437c
+        agentInstanceId: cody
+        adapter: codex
         storage: 1Gi
         tokenSecret: cloud-codex-cody-token
 

--- a/k8s/helm/commonly/values.yaml
+++ b/k8s/helm/commonly/values.yaml
@@ -243,6 +243,28 @@ agents:
     nodeSelector: {}
     tolerations: []
 
+  # Cloud-side codex CLI agents (ADR-005 variant). Mirror of sam-local-codex
+  # but the codex CLI runs in this pod (not on an operator's laptop), which
+  # avoids ChatGPT's OAuth-IP binding from invalidating sessions when they
+  # cross between operator's machine and the cluster. See template comment
+  # in cloud-codex-deployment.yaml for full operator flow.
+  cloudCodex:
+    enabled: false
+    codexVersion: "0.125.0"
+    commonlyCliRef: "main"
+    apiUrl: http://backend.commonly-dev.svc.cluster.local:5000
+    # Per-agent map. Each key is the agent name that maps to an
+    # AgentInstallation already created via /api/registry/install. The
+    # token secret should be pre-populated with the cm_agent_* runtime
+    # token for that install (default secret name: cloud-codex-<name>-token).
+    agents: {}
+    # Example:
+    # agents:
+    #   cody:
+    #     instanceKey: dev
+    #     storage: 1Gi
+    #     tokenSecret: cloud-codex-cody-token  # k8s secret, key: token
+
 # RBAC configuration
 rbac:
   create: true


### PR DESCRIPTION
## Summary
Three boot-time issues caught running the first cloud-codex-cody pod:

1. **\`commonly agent run\` doesn't take \`--instance\`** — exit "unknown option". The token+instance resolution happens via per-agent token file, not flags on \`run\`.
2. **Wrong token file path** — was writing \`~/.commonly/config.json\` with \`agentTokens\` block; CLI's \`loadAgentToken()\` reads \`~/.commonly/tokens/<name>.json\`.
3. **Missing ca-certificates** — \`node:22-bookworm-slim\` ships without TLS roots, so codex CLI's HTTPS to auth.openai.com / api.openai.com fails ("error sending request"). Install at boot (idempotent).

Also splits \`COMMONLY_REGISTRY_AGENT_NAME\` from \`COMMONLY_AGENT_NAME\` so the local file alias and the server-side registry agentName can diverge (Cody's local alias is "cody"; her registry install is "cloud-codex").

## Test plan
- [ ] After deploy: \`kubectl logs deploy/cloud-codex-cody\` shows ca-certificates installed → token file written → "auth.json found, starting commonly agent run cody" → poller running
- [ ] @cody mention in the demo pod gets a reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)