### PR TITLE
fix(reads): gate pod-scoped post + external-links reads behind canViewPod

### DIFF
--- a/backend/controllers/postController.ts
+++ b/backend/controllers/postController.ts
@@ -3,6 +3,7 @@ const Pod = require('../models/Pod');
 const User = require('../models/User');
 const Activity = require('../models/Activity');
 const AgentMentionService = require('../services/agentMentionService');
+const DMService = require('../services/dmService');
 
 exports.createPost = async (req: any, res: any) => {
   const {
@@ -124,6 +125,20 @@ exports.getPosts = async (req: any, res: any) => {
       if (podId === 'global' || podId === 'none') {
         filter.podId = null;
       } else {
+        // Pod-scoped post listing must respect pod visibility. The
+        // global feed (`podId=global`/`none`) stays anonymous-readable;
+        // pod-scoped queries require auth and pass through
+        // `canViewPod` (members + admins + agent-dm §3.7 fan-out).
+        const userId = req.userId || req.user?.id;
+        if (!userId) {
+          return res.status(401).json({ error: 'Authentication required to view pod posts' });
+        }
+        const pod = await Pod.findById(podId).select('_id members type').lean();
+        if (!pod) return res.status(404).json({ error: 'Pod not found' });
+        const canView = await DMService.canViewPod(userId, pod);
+        if (!canView) {
+          return res.status(403).json({ error: 'Not authorized to view posts in this pod' });
+        }
         filter.podId = podId;
       }
     }
@@ -188,9 +203,21 @@ exports.getPostById = async (req: any, res: any) => {
     const post = await Post.findById(req.params.id)
       .populate('userId', 'username profilePicture isBot botMetadata')
       .populate('comments.userId', 'username profilePicture isBot botMetadata')
-      .populate('podId', 'name type')
+      .populate('podId', 'name type members')
       .populate('likedBy', '_id');
     if (!post) return res.status(404).json({ error: 'Post not found' });
+    // If the post is pod-scoped, mirror the same visibility rule as
+    // `getPosts` — global posts (no pod) remain anonymous-readable.
+    if (post.podId) {
+      const userId = req.userId || req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ error: 'Authentication required to view this post' });
+      }
+      const canView = await DMService.canViewPod(userId, post.podId);
+      if (!canView) {
+        return res.status(403).json({ error: 'Not authorized to view this post' });
+      }
+    }
     res.json(post);
   } catch (err: any) {
     res.status(400).json({ error: err.message });

--- a/backend/routes/pods.ts
+++ b/backend/routes/pods.ts
@@ -409,8 +409,13 @@ router.get('/:podId/files', auth, async (req: AuthReq, res: Res) => {
 router.get('/:podId/external-links', auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId } = req.params || {};
-    const pod = await Pod.findById(podId) as Record<string, unknown> | null;
+    const pod = await Pod.findById(podId) as { type?: string; members?: Array<{ toString: () => string }> } | null;
     if (!pod) return res.status(404).json({ message: 'Pod not found' });
+    // Parity with /announcements and /files above — external-links are
+    // pod-scoped artifacts and must respect the same visibility rule, not
+    // be openly readable by any authenticated user.
+    const canView = await DMService.canViewPod(req.user?.id, pod);
+    if (!canView) return res.status(403).json({ message: 'Not authorized to view pod external links' });
     const externalLinks = await ExternalLink.find({ podId }).sort({ createdAt: -1 }).populate('createdBy', 'username');
     return res.status(200).json(externalLinks);
   } catch (error) {

--- a/backend/routes/posts.ts
+++ b/backend/routes/posts.ts
@@ -21,10 +21,13 @@ const auth = require('../middleware/auth');
 const router: ReturnType<typeof express.Router> = express.Router();
 
 router.post('/', auth, createPost);
-router.get('/', getPosts);
-router.get('/search', searchPosts);
+// Posts read paths require auth so pod-scoped queries can resolve the
+// caller's identity for the canViewPod gate in getPosts / getPostById.
+// Landing / marketing pages don't fetch posts, so this is a safe upgrade.
+router.get('/', auth, getPosts);
+router.get('/search', auth, searchPosts);
 router.get('/following/threads', auth, getFollowedThreads);
-router.get('/:id', getPostById);
+router.get('/:id', auth, getPostById);
 router.post('/:id/comments', auth, addComment);
 router.post('/:id/follow', auth, followThread);
 router.delete('/:id/follow', auth, unfollowThread);


### PR DESCRIPTION
Closes #376. Follow-up to PR #375 (now live on dev).

## Summary
- `GET /api/posts?podId=<x>` now requires auth + runs the same `canViewPod` gate already used by `/announcements` and `/files` (members + admins + agent-dm §3.7 fan-out). Global feed (`podId=global`/`none`/unset) stays open to any authenticated user.
- `GET /api/posts/:id` mirrors the same gate when the post is pod-scoped.
- `GET /api/pods/:podId/external-links` adds the missing `canViewPod` check (parity with the routes 30 lines above it).

## Why
Same admin-leak shape that PR #375 fixed on `/api/pods/*`. Without these gates, any authenticated user — admin or not — could read posts and external-links of pods they're not a member of, including agent-rooms.

## Verification (post-PR-375 deploy)
- `GET /api/pods` for xcjsam: 83 → 42 (membership-filtered)
- `GET /api/pods/<sam-demo's room>`: 200 → 404
- `?scope=all` admin moderation view: returns 83 ✓
- Talk-to still creates fresh per-user agent-rooms ✓

## Test plan
- [x] `npx jest __tests__/unit/controllers/postController` — 4/4 passing
- [x] `npx jest __tests__/unit/routes/posts` — 4/4 passing
- [x] `npx jest __tests__/unit/routes/pods` — 45/45 passing (external-links list test still passes via the existing member-mock path)
- [ ] Post-deploy: confirm `GET /api/posts?podId=<other-user's-room>` returns 403 for xcjsam (was 200)