### PR TITLE
fix(v2): reaction "+" trigger hover-only on pointer devices

### DIFF
--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4471,6 +4471,27 @@
   border-color: #9ca3af;
   color: #111827;
 }
+
+/* Hover-only "+" reaction trigger on devices with a pointer.
+ * Fade the wrapper (not display:none) so layout stays stable and the
+ * picker keeps anchoring correctly. :focus-within keeps the wrap visible
+ * while the emoji-picker popover is open (picker buttons inside hold
+ * focus). Mobile (hover: none) keeps the trigger always visible — there's
+ * no hover affordance to lean on. Reaction count badges
+ * (.v2-msg__reaction) are unaffected and always render when count > 0. */
+@media (hover: hover) {
+  .v2-msg .v2-msg__reaction-add-wrap {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.12s ease;
+  }
+  .v2-msg:hover .v2-msg__reaction-add-wrap,
+  .v2-msg__reaction-add-wrap:focus-within {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
 .v2-msg__reaction-picker {
   position: absolute;
   bottom: calc(100% + 6px);


### PR DESCRIPTION
## Summary
- `.v2-msg__reaction-add-wrap` was always visible next to every message — visual noise in long chat threads.
- Gate visibility on `.v2-msg:hover` for pointer devices via `@media (hover: hover)`.
- `:focus-within` keeps the wrap visible while the emoji-picker popover is open (picker buttons inside hold focus).
- Mobile / touch (`@media (hover: none)`) keeps the trigger always-visible — no hover affordance to lean on.
- Reaction count badges (`.v2-msg__reaction`, rendered when count > 0) are unaffected and always visible.

Closes 1 of 4 gaps from the "make collab bulletproof" goal.

## Test plan
- [ ] Desktop: hover a message row → "+" fades in; mouse out → fades out (~120ms).
- [ ] Click "+" → picker opens, "+" stays visible while picker open (`:focus-within`).
- [ ] Click an emoji → reaction posts, picker closes, "+" fades back when hover ends.
- [ ] Mobile (resize 390×844 or DevTools touch emulation): "+" always visible, tap to react still works.
- [ ] Existing reaction badges with count > 0 always visible regardless of hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)