### PR TITLE
fix(cloud-codex): apt-install git at boot so GITHUB_PAT actually usable

### DIFF
--- a/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
@@ -120,10 +120,14 @@ spec:
           # but codex CLI needs them for TLS to api.openai.com /
           # auth.openai.com. Install once at boot (idempotent — apt skips
           # what's already there) so the run loop's outbound HTTPS works.
-          if [ ! -d /etc/ssl/certs ] || [ -z "$(ls -A /etc/ssl/certs 2>/dev/null)" ]; then
-            echo "[cloud-codex] installing ca-certificates for TLS"
+          # git is also missing from the slim base; the agent shells out to
+          # `git clone`, `git push`, etc. during an agent run, so install
+          # it here alongside ca-certs. Boot delay is one-off (apt cache
+          # warm from ca-certs install above) and the binary is tiny.
+          if [ ! -d /etc/ssl/certs ] || [ -z "$(ls -A /etc/ssl/certs 2>/dev/null)" ] || ! command -v git >/dev/null 2>&1; then
+            echo "[cloud-codex] installing ca-certificates + git for TLS / VCS"
             apt-get update >/dev/null 2>&1 || true
-            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates >/dev/null 2>&1 || true
+            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates git >/dev/null 2>&1 || true
             update-ca-certificates >/dev/null 2>&1 || true
           fi
 


### PR DESCRIPTION
## Summary
Follow-up to PR #382: the GITHUB_PAT/GH_TOKEN env vars are now correctly injected into the cloud-codex pod (verified live: 94 chars each), BUT the slim base image (\`node:22-bookworm-slim\`) doesn't ship \`git\`, so the boot-script's \`git config credential.helper store\` line silently failed (\`sh: git: not found\`) and the \`/state/.git-credentials\` file was never written.

This patch extends the existing ca-certificates idempotent-install branch to also apt-install \`git\` when missing.

\`gh\` CLI is intentionally NOT installed — agents can use the GitHub REST API via curl/octokit; the gh apt-repo bootstrap is heavy for a slim base.

## Test plan
- [x] \`helm template\` renders without syntax error.
- [ ] Post-deploy: \`kubectl exec deploy/cloud-codex-cody -c agent -- git --version\` returns a version.
- [ ] \`kubectl exec deploy/cloud-codex-cody -c agent -- ls -la /state/.git-credentials\` shows the 0600 file.
- [ ] Pod logs include \`[cloud-codex] git credentials seeded from GITHUB_PAT\`.

## Related
- Follow-up to #382 (closes the Gap 1 acceptance loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)