### PR TITLE
fix(cloud-codex): trim trailing newline from GITHUB_PAT before embedding in git creds

### DIFF
--- a/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
@@ -187,9 +187,16 @@ spec:
           # which keeps non-dev tiers safe if the env ever lands without
           # the secret.
           if [ -n "${GITHUB_PAT:-}" ]; then
+            # Trim any trailing newline/carriage-return baked into the
+            # secret value (often present when the PAT was minted via
+            # `cat token | base64`). git's libcurl refuses to parse a URL
+            # whose password component contains a newline ("credential
+            # url cannot be parsed") — verified empirically against the
+            # live `commonly-github-pat` 2026-05-15.
+            TRIMMED_GITHUB_PAT=$(printf '%s' "${GITHUB_PAT}" | tr -d '\n\r')
             git config --global credential.helper store
             mkdir -p /state
-            printf 'https://x-access-token:%s@github.com\n' "${GITHUB_PAT}" > /state/.git-credentials
+            printf 'https://x-access-token:%s@github.com\n' "${TRIMMED_GITHUB_PAT}" > /state/.git-credentials
             chmod 600 /state/.git-credentials
             git config --global credential.helper "store --file=/state/.git-credentials"
             git config --global user.name "${GIT_AUTHOR_NAME:-Cody}"


### PR DESCRIPTION
Follow-up to PR #382/#383 closing the Gap 1 verification loop. The shared `commonly-github-pat` secret value carries a trailing newline. PR #382's boot script embedded it verbatim into `/state/.git-credentials`, producing a multi-line URL that git refuses to parse:

\`\`\`
fatal: credential url cannot be parsed: https://x-access-token:<pat>
@github.com/Team-Commonly/commonly.git/
\`\`\`

Adds a \`tr -d '\n\r'\` strip before the printf interpolation. Verified by hand-patching the running cloud-codex-cody pod: with the trim applied, \`git clone https://github.com/Team-Commonly/commonly.git\` of the private repo succeeds via the PAT.

## Test plan
- [x] Manual repro on live pod after hand-applying the trim → clone succeeds.
- [ ] Post-deploy: \`kubectl exec deploy/cloud-codex-cody -c agent -- sh -c 'cd /tmp && git clone https://github.com/Team-Commonly/commonly.git testc && echo OK || echo FAIL'\` returns OK.

## Notes
The `git push` 403 observed during verification is separate — the PAT (lilyshen0722, admin perms on repo per API) appears to lack SAML SSO authorization for the org. That's an operator-side authorize step, not in scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)