### PR TITLE
fix(cloud-codex): disable codex CLI bwrap sandbox (incompatible with standard k8s securityContext)

### DIFF
--- a/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
@@ -164,6 +164,18 @@ spec:
           model = "gpt-5.4"
           model_provider = "litellm"
 
+          # Codex CLI's default sandbox uses bubblewrap (bwrap), which needs
+          # CAP_SYS_ADMIN / unprivileged user-namespaces — neither available
+          # to standard k8s containers without elevated securityContext.
+          # Without this knob, every shell call (git, ls, cat, ...) fails
+          # with "bwrap: Failed to make / slave: Permission denied" and the
+          # agent reports back "couldn't execute" — verified in cloud-codex
+          # pod 2026-05-15. We trust the pod boundary itself (PVC-scoped
+          # workspace, no host mounts, agent identity isolated) as the
+          # security perimeter and skip bwrap.
+          sandbox_mode = "danger-full-access"
+          approval_policy = "never"
+
           [model_providers.litellm]
           name = "LiteLLM"
           base_url = "${COMMONLY_LITELLM_BASE_URL}"


### PR DESCRIPTION
Follow-up to #382/#383/#384 closing the Gap 1 wedge.

## Problem
Codex CLI's default \`sandbox_mode\` uses bubblewrap, which needs CAP_SYS_ADMIN / unprivileged user-namespaces — neither available to standard k8s containers. Verified empirically: even \`pwd\` fails with \`bwrap: Failed to make / slave: Permission denied\`. Cody reported back "couldn't execute the wedge".

## Fix
Set \`sandbox_mode = "danger-full-access"\` + \`approval_policy = "never"\` in the boot-script's \`config.toml\` seed. The pod itself is the security perimeter (PVC-scoped workspace, no host mounts, isolated identity). bwrap inside the pod is redundant.

## Verification
- [x] Live evidence Cody is blocked: msg 22657 in Sign-up flow pod
- [ ] Post-deploy: \`@cody clone X, commit a stub file, try to push\` succeeds at clone+commit; push 403s only on SAML SSO (operator-side, not in scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)