### PR TITLE
feat(cloud-codex): wire @commonlyai/mcp into codex CLI for kernel tools

### DIFF
--- a/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
@@ -90,7 +90,8 @@ spec:
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
             git ca-certificates >/dev/null 2>&1
           npm install --global --no-audit --no-fund \
-            "@openai/codex@{{ $.Values.agents.cloudCodex.codexVersion | default "0.125.0" }}"
+            "@openai/codex@{{ $.Values.agents.cloudCodex.codexVersion | default "0.125.0" }}" \
+            "@commonlyai/mcp@{{ $.Values.agents.cloudCodex.commonlyMcpVersion | default "0.1.1" }}"
           git clone --depth 1 --branch "{{ $.Values.agents.cloudCodex.commonlyCliRef | default "main" }}" \
             https://github.com/Team-Commonly/commonly.git /tmp/commonly-src
           mkdir -p /tools/lib
@@ -169,6 +170,20 @@ spec:
           base_url = "${COMMONLY_LITELLM_BASE_URL}"
           wire_api = "responses"
           env_key = "LITELLM_API_KEY"
+
+          # Wire the @commonlyai/mcp server as a stdio MCP for this codex
+          # instance. Gives Cody the kernel tools (commonly_react_to_message,
+          # commonly_post_message_cap, commonly_open_dm, memory verbs, ...)
+          # without us having to hand-roll them in the codex prompt. The
+          # commonly-mcp binary picks up COMMONLY_AGENT_TOKEN + COMMONLY_API_URL
+          # from env (already set on this container).
+          # Without this block, codex sees no kernel tools and ends up posting
+          # an emoji as a literal message instead of calling the reaction
+          # endpoint — verified empirically 2026-05-15 (Nova/Cody both did this
+          # in the Sign-up flow pod before this PR landed).
+          [mcp_servers.commonly]
+          command = "/tools/bin/commonly-mcp"
+          args = []
           EOF
 
           # Codex CLI looks for LITELLM_API_KEY at call time. The virtual


### PR DESCRIPTION
Without an MCP server in codex's config.toml, Cody has no \`commonly_react_to_message\` / \`commonly_post_message_cap\` / \`commonly_open_dm\` tool. When Sam @-mentioned "react 👍", she posted "👍" as a literal message body instead of calling the reaction endpoint (verified live in dev pod, 2026-05-15).

This PR:
- Installs \`@commonlyai/mcp@0.1.1\` in the cloud-codex init container.
- Adds a \`[mcp_servers.commonly]\` block to the boot script's \`config.toml\` seed pointing at \`/tools/bin/commonly-mcp\` (stdio).
- The mcp binary reads \`COMMONLY_AGENT_TOKEN\` + \`COMMONLY_API_URL\` from the container env (already wired by the deployment).

## Test plan
- [x] helm template renders.
- [ ] Post-deploy: \`@cody react 👍 to message X\` in the dev pod produces a reaction badge (not a message body with 👍 in it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)