### PR TITLE
feat(commonly-mcp): add commonly_react_to_message tool + bump to 0.1.2

### DIFF
--- a/commonly-mcp/package.json
+++ b/commonly-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.1.1",
-  "description": "Commonly MCP Server — exposes the kernel HTTP surface (CAP per ADR-004) as standard MCP tools so any MCP-capable runtime can consume `commonly_*` tools without driver-specific code.",
+  "version": "0.1.2",
+  "description": "Commonly MCP Server \u2014 exposes the kernel HTTP surface (CAP per ADR-004) as standard MCP tools so any MCP-capable runtime can consume `commonly_*` tools without driver-specific code.",
   "type": "module",
   "bin": {
     "commonly-mcp": "./src/index.js"

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -275,6 +275,28 @@ export const buildTools = (config) => {
         body: { agentName, instanceId },
       })),
     },
+    {
+      name: 'commonly_react_to_message',
+      description: "React to a chat message with an emoji AS the agent identity. Use for social-presence signal on a peer's contribution (👍 / 🎉 / 👀) or as a micro-ack for a one-liner that doesn't need a worded reply ('thanks' / 'got it' / 'agreed'). DON'T use as a substitute for a substantive reply when @-mentioned with a real request — post words then (or NO_REPLY when there's truly nothing to add). Reactions are bounded social presence, not bulk noise. Pass remove=true to remove a previously-added reaction of the same emoji. Same kernel endpoint humans use; observers see the badge appear live via socket.",
+      inputSchema: reqWith({
+        messageId: STRING,
+        emoji: STRING,
+        remove: { type: 'boolean' },
+      }, ['messageId', 'emoji']),
+      call: wrap(async ({ messageId, emoji, remove }) => {
+        if (remove) {
+          return request(config, {
+            method: 'DELETE',
+            path: `/api/messages/${encodeURIComponent(messageId)}/reactions/${encodeURIComponent(emoji)}`,
+          });
+        }
+        return request(config, {
+          method: 'POST',
+          path: `/api/messages/${encodeURIComponent(messageId)}/reactions`,
+          body: { emoji },
+        });
+      }),
+    },
   ];
 };
 


### PR DESCRIPTION
Adds the reaction MCP tool that the kernel (PR #380) has been waiting for. Without it, MCP-driven agents (Cody on codex, Claude Code, Cursor) have no way to call \`POST /api/messages/:id/reactions\` and end up posting the emoji as a literal message body when @-mentioned to react.

## Change
- \`commonly_react_to_message\` tool: wraps POST/DELETE \`/api/messages/:messageId/reactions\`.
- Bump 0.1.1 → 0.1.2.

## Verification
\`\`\`bash
cd commonly-mcp
(echo init...; echo tools/list) | COMMONLY_AGENT_TOKEN=dummy COMMONLY_API_URL=https://api-dev.commonly.me node src/index.js
\`\`\`
Returns 17 tools incl. \`commonly_react_to_message\`.

## Publish steps (operator)
\`\`\`bash
cd commonly-mcp
npm publish --access public --otp=\$OTP
\`\`\`
After publish: bump \`agents.cloudCodex.commonlyMcpVersion\` to 0.1.2 in values, redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)