### PR TITLE
fix(cloud-codex): pin codex CLI to 0.116.0 (workaround openai/codex#19871)

### DIFF
--- a/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
@@ -89,8 +89,17 @@ spec:
           apt-get update >/dev/null 2>&1
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
             git ca-certificates >/dev/null 2>&1
+          # codex 0.116.0 is the last known-good version for MCP-server tool
+          # exposure under a custom model provider. From v0.117.0 onward
+          # `codex exec` stops surfacing `commonly_*` tools (and any
+          # MCP-server tools) to the model when `model_provider != native`
+          # — verified empirically against 0.125.0 and tracked upstream at
+          # openai/codex#19871, #19363, #17904 (all OPEN). We route codex
+          # through LiteLLM (custom provider) for the single-auth-surface
+          # invariant, so we need this pin until upstream lands a fix.
+          # Bump only after verifying MCP tools are surfaced again.
           npm install --global --no-audit --no-fund \
-            "@openai/codex@{{ $.Values.agents.cloudCodex.codexVersion | default "0.125.0" }}" \
+            "@openai/codex@{{ $.Values.agents.cloudCodex.codexVersion | default "0.116.0" }}" \
             "@commonlyai/mcp@{{ $.Values.agents.cloudCodex.commonlyMcpVersion | default "0.1.2" }}"
           git clone --depth 1 --branch "{{ $.Values.agents.cloudCodex.commonlyCliRef | default "main" }}" \
             https://github.com/Team-Commonly/commonly.git /tmp/commonly-src


### PR DESCRIPTION
## Summary

Pins the cloud-codex pod's codex CLI to **0.116.0** so MCP-server tools (incl. `commonly_react_to_message`, memory verbs, DM verbs, attach-file) are surfaced to the model when codex routes through LiteLLM.

## Why

Upstream regression [openai/codex#19871](https://github.com/openai/codex/issues/19871) — "MCP tool invocation regressed for custom/local providers in v0.117.0+" — bisected by the reporter to 0.115.0 / 0.116.0 as the last known-good versions. Related: [#19363](https://github.com/openai/codex/issues/19363), [#17904](https://github.com/openai/codex/issues/17904). All three remain OPEN with no upstream patch.

We use LiteLLM as the model provider for cloud-codex (single auth surface, rotator, observability) — exactly the trigger path. Verified empirically yesterday on 0.125.0: codex exec returned only built-in tools + MCP *resource* introspection helpers (`list_mcp_resources`, etc.) — no `commonly_*` tools — even though `codex mcp list` showed the server enabled.

Pin gets Cody (and any future cluster-side codex agent) the same MCP tool surface that Claude Code / Cursor hosts already get.

## Changes

Single line in `cloud-codex-deployment.yaml` plus a comment explaining the rationale and bump-condition. Default `agents.cloudCodex.codexVersion` changes `0.125.0` → `0.116.0`. Override per-instance via Helm values if needed.

## Test plan

- [ ] Deploy Dev rebuilds the codex-tools-installer init container with the new pin
- [ ] Cody pod restarts → `kubectl exec -it cloud-codex-cody-... -- codex --version` reports `0.116.0`
- [ ] Reaction smoke: @-mention Cody in a pod asking her to react with 🎉 to a target message; verify the badge lands with `mine: True` attribution (4-layer verification rule) in a non-admin browser
- [ ] Open follow-up: subscribe to openai/codex#19871; bump pin past 0.116.0 once upstream lands a fix and re-verify