### PR TITLE
feat(reactions): Google-Chat-style "who reacted with what" attribution

### DIFF
--- a/backend/__tests__/unit/controllers/reactionController.test.js
+++ b/backend/__tests__/unit/controllers/reactionController.test.js
@@ -10,10 +10,30 @@ jest.mock('../../../models/pg/MessageReaction', () => ({
   default: {
     add: jest.fn().mockResolvedValue(undefined),
     remove: jest.fn().mockResolvedValue(undefined),
+    // Raw shape from the model post-attribution wire-up: includes the
+    // ordered userIds the controller hands to reactionAttributionService.
     listForMessage: jest
       .fn()
-      .mockResolvedValue([{ emoji: '👍', count: 1, mine: true }]),
+      .mockResolvedValue([
+        { emoji: '👍', count: 1, mine: true, userIds: ['caller-1'] },
+      ]),
   },
+}));
+
+// reactionAttributionService is a thin User-lookup decorator. We mock it
+// to a deterministic decorated shape so the test stays focused on the
+// controller wire-up (membership gate + socket fan-out). Per-decorator
+// behavior — User resolution, displayName fallbacks — is tested
+// separately in reactionAttributionService.test.js.
+jest.mock('../../../services/reactionAttributionService', () => ({
+  decorateReactionSummaries: jest.fn(async (summaries) =>
+    summaries.map((s) => ({
+      emoji: s.emoji,
+      count: s.count,
+      mine: s.mine,
+      users: s.userIds.map((id) => ({ id, username: `u-${id}` })),
+    })),
+  ),
 }));
 
 jest.mock('../../../config/db-pg', () => {

--- a/backend/__tests__/unit/services/reactionAttributionService.test.js
+++ b/backend/__tests__/unit/services/reactionAttributionService.test.js
@@ -1,0 +1,126 @@
+// Tests for reactionAttributionService — the bridge between
+// MessageReaction's raw {emoji, count, mine, userIds[]} aggregates and
+// the public {emoji, count, mine, users[{id, username, displayName?}]}
+// shape consumed by clients. Verifies the bot-vs-human display fallback
+// and the bulk-decorate batching invariant (one User lookup regardless
+// of how many messages or emoji buckets are passed).
+
+const userFindMock = jest.fn();
+const resolveAgentDisplayLabelMock = jest.fn();
+
+jest.mock('../../../models/User', () => {
+  function User() {}
+  User.find = (...args) => userFindMock(...args);
+  return User;
+});
+
+jest.mock('../../../services/agentIdentityService', () => ({
+  resolveAgentDisplayLabel: (...args) => resolveAgentDisplayLabelMock(...args),
+}));
+
+const {
+  decorateReactionSummaries,
+  decorateReactionMap,
+} = require('../../../services/reactionAttributionService');
+
+const mockUsersLean = (users) => {
+  userFindMock.mockReturnValue({
+    select: () => ({
+      lean: () => Promise.resolve(users),
+    }),
+  });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: resolveAgentDisplayLabel returns the curated bot label;
+  // the service tests use it as a black box. Individual tests override.
+  resolveAgentDisplayLabelMock.mockImplementation((user, fallback) => {
+    const dn = user?.botMetadata?.displayName;
+    return dn || fallback;
+  });
+});
+
+describe('decorateReactionSummaries', () => {
+  test('human reactor gets {id, username} only (no displayName)', async () => {
+    mockUsersLean([{ _id: 'u-human-1', username: 'sam' }]);
+    const out = await decorateReactionSummaries([
+      { emoji: '🎉', count: 1, mine: false, userIds: ['u-human-1'] },
+    ]);
+    expect(out).toEqual([
+      {
+        emoji: '🎉',
+        count: 1,
+        mine: false,
+        users: [{ id: 'u-human-1', username: 'sam' }],
+      },
+    ]);
+  });
+
+  test('bot reactor gets {id, username, displayName} via resolveAgentDisplayLabel', async () => {
+    mockUsersLean([
+      {
+        _id: 'u-bot-1',
+        username: 'openclaw-nova-demo',
+        botMetadata: { displayName: 'Nova', instanceId: 'nova-demo', agentName: 'openclaw' },
+      },
+    ]);
+    const out = await decorateReactionSummaries([
+      { emoji: '🎉', count: 1, mine: true, userIds: ['u-bot-1'] },
+    ]);
+    expect(out[0].users[0]).toEqual({
+      id: 'u-bot-1',
+      username: 'openclaw-nova-demo',
+      displayName: 'Nova',
+    });
+    expect(resolveAgentDisplayLabelMock).toHaveBeenCalled();
+  });
+
+  test('preserves userIds order — earliest reactor first', async () => {
+    mockUsersLean([
+      { _id: 'u-a', username: 'first' },
+      { _id: 'u-b', username: 'second' },
+    ]);
+    const out = await decorateReactionSummaries([
+      { emoji: '👍', count: 2, mine: false, userIds: ['u-a', 'u-b'] },
+    ]);
+    expect(out[0].users.map((u) => u.username)).toEqual(['first', 'second']);
+  });
+
+  test('unknown user_id (deleted account) renders as "unknown" rather than crashing', async () => {
+    mockUsersLean([]); // none of the IDs resolve
+    const out = await decorateReactionSummaries([
+      { emoji: '👀', count: 1, mine: false, userIds: ['u-ghost'] },
+    ]);
+    expect(out[0].users).toEqual([{ id: 'u-ghost', username: 'unknown' }]);
+  });
+
+  test('empty input → empty output, no User lookup', async () => {
+    const out = await decorateReactionSummaries([]);
+    expect(out).toEqual([]);
+    expect(userFindMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('decorateReactionMap (bulk path)', () => {
+  test('one User.find for many messages — N+1 guard', async () => {
+    mockUsersLean([
+      { _id: 'u-1', username: 'alice' },
+      { _id: 'u-2', username: 'bob' },
+    ]);
+    const map = new Map([
+      ['msg-1', [{ emoji: '🎉', count: 1, mine: false, userIds: ['u-1'] }]],
+      [
+        'msg-2',
+        [
+          { emoji: '👍', count: 1, mine: false, userIds: ['u-2'] },
+          { emoji: '👀', count: 2, mine: true, userIds: ['u-1', 'u-2'] },
+        ],
+      ],
+    ]);
+    const out = await decorateReactionMap(map);
+    expect(userFindMock).toHaveBeenCalledTimes(1);
+    expect(out.get('msg-1')[0].users).toEqual([{ id: 'u-1', username: 'alice' }]);
+    expect(out.get('msg-2')[1].users.map((u) => u.username)).toEqual(['alice', 'bob']);
+  });
+});

--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -111,9 +111,12 @@ exports.getMessages = async (req: AuthRequest, res: Response): Promise<void> => 
           .filter(Boolean);
         if (ids.length > 0) {
           const reactionsMap = await MessageReaction.listForMessages(ids, String(userId));
+          // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+          const { decorateReactionMap } = require('../services/reactionAttributionService');
+          const decorated = await decorateReactionMap(reactionsMap);
           for (const m of messages as Array<{ id?: string; _id?: string; reactions?: unknown }>) {
             const key = String(m.id || m._id || '');
-            m.reactions = reactionsMap.get(key) || [];
+            m.reactions = decorated.get(key) || [];
           }
         }
       } catch (rxnErr) {

--- a/backend/controllers/reactionController.ts
+++ b/backend/controllers/reactionController.ts
@@ -6,6 +6,8 @@
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const MessageReaction = require('../models/pg/MessageReaction').default;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { decorateReactionSummaries } = require('../services/reactionAttributionService');
 
 interface AuthedReq {
   params: { messageId?: string; emoji?: string };
@@ -121,7 +123,8 @@ export async function addReaction(req: AuthedReq, res: AuthedRes): Promise<void>
       return;
     }
     await MessageReaction.add(messageId, userId, emoji);
-    const reactions = await MessageReaction.listForMessage(messageId, userId);
+    const rawSummaries = await MessageReaction.listForMessage(messageId, userId);
+    const reactions = await decorateReactionSummaries(rawSummaries);
     void emitReactionChange(messageId, podId, reactions);
     res.json({ ok: true, reactions });
   } catch (err) {
@@ -154,7 +157,8 @@ export async function removeReaction(req: AuthedReq, res: AuthedRes): Promise<vo
       return;
     }
     await MessageReaction.remove(messageId, userId, emoji);
-    const reactions = await MessageReaction.listForMessage(messageId, userId);
+    const rawSummaries = await MessageReaction.listForMessage(messageId, userId);
+    const reactions = await decorateReactionSummaries(rawSummaries);
     void emitReactionChange(messageId, podId, reactions);
     res.json({ ok: true, reactions });
   } catch (err) {

--- a/backend/models/pg/MessageReaction.ts
+++ b/backend/models/pg/MessageReaction.ts
@@ -17,6 +17,10 @@ export interface ReactionSummary {
   emoji: string;
   count: number;
   mine: boolean;
+  // Reactor user IDs in insertion order (earliest first). Resolved to
+  // {username, displayName} downstream by reactionAttributionService —
+  // this model stays a thin DB wrapper and doesn't touch the User model.
+  userIds: string[];
 }
 
 class MessageReaction {
@@ -48,7 +52,8 @@ class MessageReaction {
     const result = await pool.query(
       `SELECT emoji,
               COUNT(*)::int AS count,
-              BOOL_OR(user_id = $2) AS mine
+              BOOL_OR(user_id = $2) AS mine,
+              ARRAY_AGG(user_id ORDER BY created_at) AS user_ids
        FROM message_reactions
        WHERE message_id = $1
        GROUP BY emoji
@@ -59,6 +64,7 @@ class MessageReaction {
       emoji: String(r.emoji),
       count: Number(r.count) || 0,
       mine: Boolean(r.mine),
+      userIds: Array.isArray(r.user_ids) ? r.user_ids.map(String) : [],
     }));
   }
 
@@ -78,7 +84,8 @@ class MessageReaction {
       `SELECT message_id,
               emoji,
               COUNT(*)::int AS count,
-              BOOL_OR(user_id = $2) AS mine
+              BOOL_OR(user_id = $2) AS mine,
+              ARRAY_AGG(user_id ORDER BY created_at) AS user_ids
        FROM message_reactions
        WHERE message_id = ANY($1::int[])
        GROUP BY message_id, emoji
@@ -92,6 +99,7 @@ class MessageReaction {
         emoji: String(r.emoji),
         count: Number(r.count) || 0,
         mine: Boolean(r.mine),
+        userIds: Array.isArray(r.user_ids) ? r.user_ids.map(String) : [],
       });
       out.set(key, list);
     }

--- a/backend/services/reactionAttributionService.ts
+++ b/backend/services/reactionAttributionService.ts
@@ -1,0 +1,139 @@
+// Decorates ReactionSummary[] (from MessageReaction.listForMessage[s])
+// with the reactor's username + displayName so the kernel response
+// carries enough attribution for the UI to render "Nova, Sam (you)
+// reacted with 🎉" tooltips. Same shape served on add/remove HTTP
+// responses, the messageReaction socket fan-out, and the bulk messages
+// list path — one source of truth here.
+//
+// For bot reactors, displayName is resolved via
+// agentIdentityService.resolveAgentDisplayLabel so the UI gets "Nova"
+// rather than the raw "openclaw-nova-demo" username. Humans get
+// botMetadata.displayName when set (rare) or their username.
+//
+// Performance: one MongoDB User.find({_id: {$in: ids}}) lookup per
+// call, even for the bulk path (we collect all reactor IDs across all
+// messages and de-dup before the query). For a 50-message pod page
+// with reactions on ~10 messages averaging 2 reactors each, that's
+// at most 20 distinct user IDs — well under any latency budget.
+
+import type { ReactionSummary } from '../models/pg/MessageReaction';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const User = require('../models/User');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { resolveAgentDisplayLabel } = require('./agentIdentityService');
+
+export interface ReactionUser {
+  id: string;
+  username: string;
+  displayName?: string;
+}
+
+// Decorated summary keeps the original count + mine flag and adds the
+// resolved reactor list. We intentionally STRIP userIds from the
+// outbound shape so the response is a flat consumer surface (the raw
+// IDs leak nothing useful to clients and would force them to do their
+// own lookup). Callers that need the raw IDs can still use the model
+// directly.
+export interface DecoratedReactionSummary {
+  emoji: string;
+  count: number;
+  mine: boolean;
+  users: ReactionUser[];
+}
+
+interface BotMeta {
+  displayName?: string;
+  instanceId?: string;
+  agentName?: string;
+}
+
+interface LeanUser {
+  _id: unknown;
+  username?: string;
+  botMetadata?: BotMeta;
+}
+
+function uniqueIds(summaries: ReactionSummary[]): string[] {
+  const set = new Set<string>();
+  for (const s of summaries) {
+    for (const id of s.userIds) set.add(id);
+  }
+  return Array.from(set);
+}
+
+function loadUserMap(ids: string[]): Promise<Map<string, LeanUser>> {
+  if (ids.length === 0) return Promise.resolve(new Map());
+  return User.find({ _id: { $in: ids } })
+    .select('username botMetadata')
+    .lean()
+    .then((rows: LeanUser[]) => {
+      const map = new Map<string, LeanUser>();
+      for (const u of rows) map.set(String(u._id), u);
+      return map;
+    });
+}
+
+function resolveDisplay(user: LeanUser | undefined, username: string): string | undefined {
+  if (!user) return undefined;
+  // For bots, prefer the curated agent-identity label (catches displayName
+  // first, then humanized instanceId, with the runtime-leak guard inside
+  // resolveAgentDisplayLabel). For humans, fall back to a plain displayName
+  // when present — username already lives in the response shape.
+  if (user.botMetadata) {
+    const label: string = resolveAgentDisplayLabel(user, username);
+    return label === username ? undefined : label;
+  }
+  return undefined;
+}
+
+export async function decorateReactionSummaries(
+  summaries: ReactionSummary[],
+): Promise<DecoratedReactionSummary[]> {
+  const ids = uniqueIds(summaries);
+  const userMap = await loadUserMap(ids);
+  return summaries.map((s) => ({
+    emoji: s.emoji,
+    count: s.count,
+    mine: s.mine,
+    users: s.userIds.map((id) => {
+      const u = userMap.get(id);
+      const username = u?.username || 'unknown';
+      const displayName = resolveDisplay(u, username);
+      return displayName ? { id, username, displayName } : { id, username };
+    }),
+  }));
+}
+
+// Bulk path: decorate a Map<messageId, ReactionSummary[]> in-place.
+// Single User lookup across all messages.
+export async function decorateReactionMap(
+  map: Map<string, ReactionSummary[]>,
+): Promise<Map<string, DecoratedReactionSummary[]>> {
+  const allSummaries: ReactionSummary[] = [];
+  for (const list of map.values()) allSummaries.push(...list);
+  const ids = uniqueIds(allSummaries);
+  const userMap = await loadUserMap(ids);
+  const out = new Map<string, DecoratedReactionSummary[]>();
+  for (const [mid, summaries] of map) {
+    out.set(
+      mid,
+      summaries.map((s) => ({
+        emoji: s.emoji,
+        count: s.count,
+        mine: s.mine,
+        users: s.userIds.map((id) => {
+          const u = userMap.get(id);
+          const username = u?.username || 'unknown';
+          const displayName = resolveDisplay(u, username);
+          return displayName ? { id, username, displayName } : { id, username };
+        }),
+      })),
+    );
+  }
+  return out;
+}
+
+module.exports = { decorateReactionSummaries, decorateReactionMap };
+module.exports.decorateReactionSummaries = decorateReactionSummaries;
+module.exports.decorateReactionMap = decorateReactionMap;

--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -468,6 +468,25 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
 
           if (renderList.length === 0 && !canInteract) return null;
 
+          // Google-Chat-style attribution: build a names-line for the
+          // reaction-chip tooltip from the decorated `users` array when
+          // the backend includes it (reactionAttributionService). Falls
+          // back to count-only on older servers / fixtures.
+          const formatReactionTitle = (r: typeof renderList[number]): string => {
+            const live = r as { users?: Array<{ username: string; displayName?: string }> };
+            const users = Array.isArray(live.users) ? live.users : [];
+            if (!users.length) {
+              return `${r.count} ${r.emoji}${r.mine ? ' (you)' : ''}`;
+            }
+            const names = users.map((u) => u.displayName || u.username);
+            // Caller's user ID isn't threaded down here; rather than
+            // guessing which entry in `users` is the caller, append a
+            // single "(you)" suffix to the whole line when r.mine —
+            // matches Google Chat's behavior on its own reaction
+            // tooltips and avoids mis-labelling an arbitrary entry.
+            return `${names.join(', ')} reacted with ${r.emoji}${r.mine ? ' (you)' : ''}`;
+          };
+
           return (
             <div className="v2-msg__reactions" aria-label="Reactions">
               {renderList.map((r, idx) => (
@@ -475,7 +494,7 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
                   key={`${r.emoji}-${idx}`}
                   type="button"
                   className={`v2-msg__reaction${r.mine ? ' v2-msg__reaction--mine' : ''}`}
-                  title={`${r.count} ${r.emoji}${r.mine ? ' (you)' : ''}`}
+                  title={formatReactionTitle(r)}
                   onClick={() => toggle(r.emoji, !!r.mine)}
                   disabled={!canInteract}
                 >

--- a/frontend/src/v2/hooks/useV2PodDetail.ts
+++ b/frontend/src/v2/hooks/useV2PodDetail.ts
@@ -21,10 +21,20 @@ export interface V2Message {
     username?: string;
     profilePicture?: string | null;
   };
-  // Sprint B5: per-message reactions, aggregated server-side. Each entry
-  // is {emoji, count, mine}. Absent in legacy fixtures + on Mongo fallback;
-  // bubbles fall back to the token-parsed `[[reactions:...]]` shape if so.
-  reactions?: Array<{ emoji: string; count: number; mine: boolean }>;
+  // Sprint B5: per-message reactions, aggregated server-side.
+  // Each entry is `{emoji, count, mine, users?}` — `users` is the
+  // Google-Chat-style attribution list decorated by
+  // backend/services/reactionAttributionService (resolves bot
+  // displayName via agentIdentityService.resolveAgentDisplayLabel).
+  // Absent in legacy fixtures + on Mongo fallback; bubbles fall back
+  // to the token-parsed `[[reactions:...]]` shape if so. Older servers
+  // omit `users` entirely — tooltips degrade to count-only.
+  reactions?: Array<{
+    emoji: string;
+    count: number;
+    mine: boolean;
+    users?: Array<{ id: string; username: string; displayName?: string }>;
+  }>;
 }
 
 export interface V2Agent {


### PR DESCRIPTION
## Summary

Hover a reaction chip → tooltip shows the names of everyone who reacted ("Nova, Sam reacted with 🎉 (you)") instead of just the count + emoji. Bot reactors render with their curated `displayName` ("Nova") rather than raw username ("openclaw-nova-demo").

## Backend

- `MessageReaction.listForMessage[s]` returns `userIds` per emoji bucket via `ARRAY_AGG(user_id ORDER BY created_at)`. Model stays a thin DB wrapper.
- New `reactionAttributionService` decorates raw summaries with `users: [{id, username, displayName?}]`. Single `User.find()` per call — bulk path de-dups reactor IDs across all messages on the page (N+1 guard). Bot `displayName` resolved via `agentIdentityService.resolveAgentDisplayLabel` so we keep "Nova", not "openclaw-nova-demo", and not "openclaw" (the runtime).
- `reactionController` (add + remove) and `messageController` (bulk list) call the decorator before responding / socket-emitting. Same shape on all three surfaces.
- Raw `userIds` is stripped from the public response — only the resolved `users` ships to clients.

## Frontend

- `V2Message.reactions[].users` type added (optional — older servers omit it; tooltip degrades to count-only string).
- `V2MessageBubble.tsx` builds a Google-Chat-style title string from the `users` array. "(you)" suffix appended once at line end when `r.mine` (matches Google Chat's own tooltip — avoids the bug of trying to position "(you)" against an arbitrary entry without the caller's user ID at hand).

## Tests

- 5 new unit tests in `reactionAttributionService.test.js`: human-only, bot-with-displayName, ordering preservation, unknown-user fallback, empty-input no-lookup, bulk-path single-User.find batching invariant.
- Updated `reactionController.test.js` to mock the decorator and verify wire-up.

## Migration impact

- DB schema unchanged.
- API response shape: additive (`users` is new). Older clients ignore it.
- Socket payload: same additive shape on `messageReaction` events.

## Test plan

- [ ] CI: unit tests pass
- [ ] Deploy Dev rolls backend+frontend
- [ ] Open the Nova DM pod, react to a message with two emojis from two different users; verify chip tooltips show both names
- [ ] Verify "(you)" appears when the caller reacted
- [ ] Verify bot reactor renders as displayName ("Nova") not username ("openclaw-nova-demo")