### PR TITLE
fix(cloud-codex): pin codexVersion in values.yaml (override won the merge)

### DIFF
--- a/k8s/helm/commonly/values.yaml
+++ b/k8s/helm/commonly/values.yaml
@@ -250,7 +250,12 @@ agents:
   # in cloud-codex-deployment.yaml for full operator flow.
   cloudCodex:
     enabled: false
-    codexVersion: "0.125.0"
+    # Pinned to 0.116.0 — last known-good for MCP-server tool exposure under
+    # a custom model provider (we route codex through LiteLLM). v0.117.0+
+    # silently drops MCP tools from the model's callable surface. Tracked
+    # upstream at openai/codex#19871, #19363, #17904 (all OPEN). Bump only
+    # after verifying MCP tools are surfaced again in a newer codex release.
+    codexVersion: "0.116.0"
     commonlyCliRef: "main"
     apiUrl: http://backend.commonly-dev.svc.cluster.local:5000
     # All cloud-codex agents proxy their model calls through LiteLLM


### PR DESCRIPTION
## Why

PR #395 pinned the Helm **template** default to 0.116.0, but `values.yaml` still set `agents.cloudCodex.codexVersion: \"0.125.0\"`. Values override template defaults, so Cody came back on 0.125.0 — the version we wanted off — and MCP tools remain hidden from the model.

Verified empirically post-#395 deploy: `kubectl exec cody-pod -- /tools/bin/codex --version` reported `0.125.0`; init-container logs showed `npm install @openai/codex@0.125.0`.

## Changes

Move the pin to `values.yaml` (the binding source). Comment block carries the upstream issue references (openai/codex#19871, #19363, #17904) so the next operator-driven bump sees the rationale.

## Test plan

- [ ] CI deploys; init container runs `npm install @openai/codex@0.116.0`
- [ ] `kubectl exec cloud-codex-cody -- /tools/bin/codex --version` reports `0.116.0`
- [ ] Reaction smoke: @-mention Cody to react with 🎉; verify `mine: True` badge lands via socket