### PR TITLE
fix(cloud-codex): pass COMMONLY_API_URL/TOKEN env to MCP subprocess (real root cause)

### DIFF
--- a/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
@@ -195,15 +195,21 @@ spec:
           # surface (commonly_react_to_message, commonly_post_message,
           # memory verbs, dm verbs, ...) via stdio MCP. Without this block,
           # codex sees no kernel tools and ends up posting emoji as a
-          # literal message body when @-mentioned to "react" — verified
-          # empirically before npm @commonlyai/mcp@0.1.2 shipped the
-          # reaction tool (2026-05-15).
+          # literal message body when @-mentioned to "react".
           #
-          # commonly-mcp picks up COMMONLY_AGENT_TOKEN + COMMONLY_API_URL
-          # from the container env (already wired by this deployment).
+          # The `env` table is REQUIRED — codex does NOT inherit the
+          # parent container's env when it spawns the MCP subprocess
+          # (verified empirically 2026-05-17 against codex 0.116.0
+          # AND 0.125.0). Without these two vars, the subprocess
+          # crashes at startup with "fatal: COMMONLY_API_URL is
+          # required" and the model sees no commonly_* tools. The bug
+          # mimicked openai/codex#19871 but was actually our own
+          # bootstrap omission — bisecting codex versions never moved
+          # the needle.
           [mcp_servers.commonly]
           command = "/tools/bin/commonly-mcp"
           args = []
+          env = { COMMONLY_API_URL = "${COMMONLY_API_URL}", COMMONLY_AGENT_TOKEN = "${COMMONLY_AGENT_TOKEN}" }
           EOF
 
           # Codex CLI looks for LITELLM_API_KEY at call time. The virtual


### PR DESCRIPTION
## Summary

The cloud-codex MCP-tools-not-surfaced symptom was never an upstream codex bug — it was **our own boot script omission**. Codex sandboxes spawned MCP subprocesses and does NOT inherit the parent container's env. Our \`commonly-mcp\` subprocess was therefore crashing at startup with \`fatal: COMMONLY_API_URL is required\`, and the model saw zero \`commonly_*\` tools.

## Root cause trace

\`RUST_LOG=debug\` on codex exec, captured live in the cody pod:

\`\`\`
INFO codex_rmcp_client::rmcp_client: MCP server stderr (/tools/bin/commonly-mcp):
  [commonly-mcp] fatal: COMMONLY_API_URL is required (e.g. https://api-dev.commonly.me)
\`\`\`

The symptom matched openai/codex#19871 / #19363 / #17904 perfectly, which led us down the 0.116.0 pin path (#395 + #397). Empirically: pin had zero effect — codex 0.116.0 also returned \"no such tool\" on \`commonly_react_to_message\`. That's because the bug wasn't upstream — the MCP server was crashing before codex could enumerate its tools.

## Fix

Declare the env table on the \`[mcp_servers.commonly]\` block in the config.toml the boot script writes:

\`\`\`toml
[mcp_servers.commonly]
command = \"/tools/bin/commonly-mcp\"
args = []
env = { COMMONLY_API_URL = \"\${COMMONLY_API_URL}\", COMMONLY_AGENT_TOKEN = \"\${COMMONLY_AGENT_TOKEN}\" }
\`\`\`

The heredoc is unquoted (\`<<EOF\`), so \`\${VAR}\` expands to the pod env at boot time — no Helm-side templating needed; existing container env vars (\`COMMONLY_API_URL\`, \`COMMONLY_AGENT_TOKEN\`) flow through automatically.

## Verified live in the pod

Patched config.toml in-place inside cody's pod and re-probed:
- **Before**: model lists 16 built-in tools, zero \`commonly_*\`. Calling \`commonly_react_to_message\` → \"no such tool\".
- **After**: model enumerates 17 \`commonly_*\` tools — \`commonly_react_to_message\`, \`commonly_post_message\`, memory verbs, DM verbs, all surfaced.

## Pin status (#395 + #397)

The 0.116.0 pin is unnecessary for this issue; reconsidering whether to revert it is a separate follow-up. Keeping it for now (no harm).

## Test plan

- [ ] Deploy Dev rolls cloud-codex pod with new config.toml
- [ ] \`kubectl exec cloud-codex-cody -- bash -c 'CODEX_HOME=/state/.codex /tools/bin/codex mcp list'\` shows \`enabled\`
- [ ] Ask Cody via @mention to react with 🎉 to a target message; verify the \`mine: True\` reaction badge lands via socket on a non-admin browser