### PR TITLE
fix(cloud-codex): backticks in heredoc comment leaked env into config.toml (PR #398 followup)

### DIFF
--- a/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
@@ -197,8 +197,15 @@ spec:
           # codex sees no kernel tools and ends up posting emoji as a
           # literal message body when @-mentioned to "react".
           #
-          # The `env` table is REQUIRED — codex does NOT inherit the
-          # parent container's env when it spawns the MCP subprocess
+          # The env table is REQUIRED — codex does NOT inherit the
+          # parent container env when it spawns the MCP subprocess
+          #
+          # NOTE: keep this comment free of backticks. The heredoc is
+          # unquoted (<<EOF) so backticks command-substitute — a previous
+          # version wrapped 'env' in backticks here, which ran the env
+          # command and dumped every container env var (incl. the
+          # GitHub PAT) literally into the deployed config.toml on the
+          # pod PVC. See PR #399.
           # (verified empirically 2026-05-17 against codex 0.116.0
           # AND 0.125.0). Without these two vars, the subprocess
           # crashes at startup with "fatal: COMMONLY_API_URL is


### PR DESCRIPTION
## Summary

PR #398's added comment wrapped \`env\` in backticks (markdown-style). The boot script uses an **unquoted** heredoc (\`<<EOF\`), so the shell command-substituted the backtick'd \`env\` as the \`env\` shell command — dumping the entire container env (incl. \`GITHUB_PAT\`, \`COMMONLY_AGENT_TOKEN\`, \`COMMONLY_LITELLM_KEY\`) into the middle of the deployed \`config.toml\` on the cody pod PVC.

Functionally the bottom \`[mcp_servers.commonly]\` block still substitutes correctly and MCP tools work; the leak is the comment-zone pollution.

## Changes

Strip backticks from the comment + add an inline warning to keep this from being re-introduced.

## Risk + mitigation

- **Scope**: leaked PAT was written to one file on one pod's PVC. Not in git, image, or external logs. Only readable by processes in the agent container (cody + codex).
- **Mitigation**: this deploy rewrites \`config.toml\` without the leak; pod restart clears the PVC copy.
- **Follow-up**: rotate \`commonly-github-pat\` as defense-in-depth (operator-side).

## Test plan

- [ ] Deploy rolls; verify \`grep GITHUB_PAT /state/.codex/config.toml\` returns no match
- [ ] Verify \`[mcp_servers.commonly]\` block still includes the \`env = {...}\` line with substituted values
- [ ] Re-run Cody reaction smoke from Playwright