### PR TITLE
chore(cloud-codex): unpin codexVersion 0.116.0 → 0.125.0 (misdiagnosis cleanup)

### DIFF
--- a/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
@@ -89,17 +89,16 @@ spec:
           apt-get update >/dev/null 2>&1
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
             git ca-certificates >/dev/null 2>&1
-          # codex 0.116.0 is the last known-good version for MCP-server tool
-          # exposure under a custom model provider. From v0.117.0 onward
-          # `codex exec` stops surfacing `commonly_*` tools (and any
-          # MCP-server tools) to the model when `model_provider != native`
-          # — verified empirically against 0.125.0 and tracked upstream at
-          # openai/codex#19871, #19363, #17904 (all OPEN). We route codex
-          # through LiteLLM (custom provider) for the single-auth-surface
-          # invariant, so we need this pin until upstream lands a fix.
-          # Bump only after verifying MCP tools are surfaced again.
+          # Pin via values.yaml (agents.cloudCodex.codexVersion). The
+          # earlier 0.116.0 attempt was based on a misdiagnosis: codex
+          # was crashing the MCP subprocess at startup because we never
+          # declared the env table on [mcp_servers.commonly] (codex
+          # sandboxes spawned MCP children and does not inherit parent
+          # env). PR #398 fixes that. End-to-end smoke on 0.125.0
+          # confirms MCP tools surfaced and Cody calls them
+          # successfully — see PR #400 for the unpin write-up.
           npm install --global --no-audit --no-fund \
-            "@openai/codex@{{ $.Values.agents.cloudCodex.codexVersion | default "0.116.0" }}" \
+            "@openai/codex@{{ $.Values.agents.cloudCodex.codexVersion | default "0.125.0" }}" \
             "@commonlyai/mcp@{{ $.Values.agents.cloudCodex.commonlyMcpVersion | default "0.1.2" }}"
           git clone --depth 1 --branch "{{ $.Values.agents.cloudCodex.commonlyCliRef | default "main" }}" \
             https://github.com/Team-Commonly/commonly.git /tmp/commonly-src

--- a/k8s/helm/commonly/values.yaml
+++ b/k8s/helm/commonly/values.yaml
@@ -250,12 +250,14 @@ agents:
   # in cloud-codex-deployment.yaml for full operator flow.
   cloudCodex:
     enabled: false
-    # Pinned to 0.116.0 — last known-good for MCP-server tool exposure under
-    # a custom model provider (we route codex through LiteLLM). v0.117.0+
-    # silently drops MCP tools from the model's callable surface. Tracked
-    # upstream at openai/codex#19871, #19363, #17904 (all OPEN). Bump only
-    # after verifying MCP tools are surfaced again in a newer codex release.
-    codexVersion: "0.116.0"
+    # codex CLI version. The earlier 0.116.0 pin (PR #395 / #397) was
+    # based on a misdiagnosis — symptoms matched openai/codex#19871 but
+    # the real bug was our own boot script not declaring `env` on the
+    # `[mcp_servers.commonly]` block, which made the MCP subprocess
+    # crash at startup. PR #398 fixes that, and 0.125.0 surfaces all
+    # commonly_* MCP tools to the model end-to-end (verified live
+    # 2026-05-17). Bump freely going forward.
+    codexVersion: "0.125.0"
     commonlyCliRef: "main"
     apiUrl: http://backend.commonly-dev.svc.cluster.local:5000
     # All cloud-codex agents proxy their model calls through LiteLLM


### PR DESCRIPTION
## Summary

Reverts the 0.116.0 pin landed in PR #395 + #397. That pin was based on a misdiagnosis — the symptom (no \`commonly_*\` tools surfaced to the model) was actually caused by our boot script not declaring the env table on \`[mcp_servers.commonly]\`, which made codex's spawned MCP subprocess crash at startup with \`fatal: COMMONLY_API_URL is required\`. PR #398 fixed the real bug.

## Verification

End-to-end smoke on 0.125.0 after PR #398 + #399 landed (live 2026-05-17):
- All 17 \`commonly_*\` tools enumerated by the model
- Cody autonomously called \`commonly_get_messages\` + \`commonly_react_to_message\`
- Reaction badge with attribution \`Cody reacted with 🚀\` lands live via socket
- Three different emojis (🚀, 🎉, 👍) on msg 23765 in pod 69f841a9

## Changes

- \`values.yaml\` — \`agents.cloudCodex.codexVersion: 0.116.0 → 0.125.0\`
- \`cloud-codex-deployment.yaml\` template — bump the \`default\` fallback to match and replace the now-stale upstream-bug rationale with a pointer to PR #398

## Test plan

- [ ] Deploy Dev rolls cody on 0.125.0
- [ ] \`kubectl exec cloud-codex-cody -- /tools/bin/codex --version\` → \`0.125.0\`
- [ ] Reaction smoke: Cody calls \`commonly_react_to_message\` end-to-end (the same one we just verified on 0.116)