### PR TITLE
fix(helm): backend strategy=Recreate (#64) + cloud-codex boot rewrites config.json (#65)

### DIFF
--- a/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
@@ -160,6 +160,29 @@ spec:
           EOF
           chmod 600 /state/.commonly/tokens/${COMMONLY_AGENT_NAME}.json
 
+          # Task #65: ALSO rewrite /state/.commonly/config.json on every
+          # boot so `commonly agent run` resolves the dev instance + the
+          # current runtime token instead of falling back to its stale
+          # PVC copy or the public https://api.commonly.me default. Without
+          # this the CLI hits "fetch failed" forever after a token rotation
+          # or pod move (verified empirically 2026-05-18 — Cody silently
+          # polled the wrong URL for hours).
+          cat > /state/.commonly/config.json <<EOF
+          {
+            "instances": {
+              "dev": {
+                "url": "${COMMONLY_API_URL}",
+                "token": "",
+                "agentTokens": {
+                  "${COMMONLY_AGENT_NAME}": "${COMMONLY_AGENT_TOKEN}"
+                }
+              }
+            },
+            "active": "dev"
+          }
+          EOF
+          chmod 600 /state/.commonly/config.json
+
           # Seed ~/.codex/config.toml so codex CLI routes its model calls
           # through LiteLLM instead of straight to chatgpt.com. The LiteLLM
           # pod already holds cluster-IP-bound auth.json (rotator-managed,

--- a/k8s/helm/commonly/templates/core/backend-deployment.yaml
+++ b/k8s/helm/commonly/templates/core/backend-deployment.yaml
@@ -8,6 +8,15 @@ metadata:
     {{- include "commonly.backend.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.backend.replicaCount }}
+  # ADR-015 + task #64: backend mounts skills-catalog-pvc as ReadWriteOnce.
+  # The default RollingUpdate strategy tries to bring up the new pod before
+  # the old one terminates, but RWO disks can't bind to two nodes — the new
+  # pod hangs in Init:0/1 indefinitely with `Multi-Attach error`. Recreate
+  # forces the old pod to die first, then the new one mounts cleanly. Cost
+  # is ~30s of downtime per deploy. Acceptable for dev; if prod ever wants
+  # zero-downtime, the underlying PVC needs to be RWX (filestore).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "commonly.backend.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
Closes #64 and #65 — both small dev-cluster correctness fixes hit during yesterday's smoke.