### PR TITLE
fix(registry): preserve displayName on reinstall (#62) + surface all installs to legacy token (#66)

### DIFF
--- a/backend/__tests__/unit/middleware/agentRuntimeAuth.test.js
+++ b/backend/__tests__/unit/middleware/agentRuntimeAuth.test.js
@@ -1,0 +1,105 @@
+// agentRuntimeAuth path 2 (legacy installation-token) needs to surface ALL
+// active AgentInstallation rows for the same (agentName, instanceId), not
+// just the one whose runtimeTokens.tokenHash matches. Otherwise the /events
+// endpoint silently filters out events for pods the token wasn't originally
+// minted for — exact bug we hit when Cody's token from her old install
+// couldn't see events from a new pod she'd been freshly installed into.
+
+const cryptoMock = { hash: jest.fn(), randomSecret: jest.fn() };
+jest.mock('../../../utils/crypto', () => cryptoMock);
+
+const userFindOneMock = jest.fn();
+const installationFindOneMock = jest.fn();
+const installationFindMock = jest.fn();
+const installationUpdateOneMock = jest.fn();
+
+jest.mock('../../../models/User', () => {
+  function User() {}
+  User.findOne = (...args) => userFindOneMock(...args);
+  return User;
+});
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: {
+    findOne: (...args) => installationFindOneMock(...args),
+    find: (...args) => installationFindMock(...args),
+    updateOne: (...args) => installationUpdateOneMock(...args),
+  },
+}));
+jest.mock('../../../models/Pod', () => ({
+  find: () => ({ select: () => ({ lean: async () => [] }) }),
+}));
+
+const agentRuntimeAuth = require('../../../middleware/agentRuntimeAuth').default;
+
+const mockReq = (token) => ({
+  headers: { authorization: `Bearer ${token}` },
+});
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+beforeEach(() => {
+  cryptoMock.hash.mockReset();
+  cryptoMock.hash.mockReturnValue('hashed-token');
+  userFindOneMock.mockReset();
+  installationFindOneMock.mockReset();
+  installationFindMock.mockReset();
+  installationUpdateOneMock.mockReset();
+});
+
+describe('agentRuntimeAuth path 2 (install-bound token) — #66 fix', () => {
+  test('surfaces ALL active installations for the same (agentName, instanceId), not just the matched one', async () => {
+    // No User-row token match → path 2 fires
+    userFindOneMock.mockResolvedValue(null);
+    const matchedInstall = {
+      _id: 'install-a',
+      agentName: 'codex',
+      instanceId: 'cody',
+      podId: { toString: () => 'pod-a' },
+      runtimeTokens: [{ tokenHash: 'hashed-token' }],
+    };
+    const otherInstall = {
+      _id: 'install-b',
+      agentName: 'codex',
+      instanceId: 'cody',
+      podId: { toString: () => 'pod-b' },
+      runtimeTokens: [{ tokenHash: 'different-hash' }],
+    };
+    installationFindOneMock.mockResolvedValue(matchedInstall);
+    installationFindMock.mockResolvedValue([matchedInstall, otherInstall]);
+    installationUpdateOneMock.mockResolvedValue({});
+
+    const req = mockReq('cm_agent_test');
+    const res = mockRes();
+    const next = jest.fn();
+
+    await agentRuntimeAuth(req, res, next);
+
+    expect(installationFindMock).toHaveBeenCalledWith({
+      agentName: 'codex',
+      instanceId: 'cody',
+      status: 'active',
+    });
+    expect(req.agentInstallations).toHaveLength(2);
+    expect(req.agentAuthorizedPodIds).toEqual(['pod-a', 'pod-b']);
+    expect(req.agentInstallation).toBe(matchedInstall);
+    expect(next).toHaveBeenCalled();
+  });
+
+  test('returns 401 when token doesnt match any install OR user', async () => {
+    userFindOneMock.mockResolvedValue(null);
+    installationFindOneMock.mockResolvedValue(null);
+
+    const req = mockReq('cm_agent_bogus');
+    const res = mockRes();
+    const next = jest.fn();
+
+    await agentRuntimeAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/middleware/agentRuntimeAuth.ts
+++ b/backend/middleware/agentRuntimeAuth.ts
@@ -116,9 +116,27 @@ export default async function agentRuntimeAuth(req: Request, res: Response, next
       console.warn('Failed to update agent token usage:', (err as Error).message);
     }
 
+    // Task #66: a token may be bound to one AgentInstallation row, but the
+    // agent identity (agentName + instanceId) can have multiple active
+    // installations across pods. Surface ALL of them so the /events
+    // endpoint's podIds-from-installations filter doesn't silently drop
+    // events for the pods this token wasn't originally minted for.
+    // Path 1 (User-row tokens) already enumerates all installations the
+    // same way — this just makes path 2 (install-bound legacy tokens)
+    // match. Hit empirically 2026-05-18 when Cody's token from her old
+    // Codex Hub install couldn't see events from a new pod she'd been
+    // freshly installed into.
+    const allActiveInstallations = await AgentInstallation.find({
+      agentName: installation.agentName,
+      instanceId: installation.instanceId || 'default',
+      status: 'active',
+    });
+
     req.agentInstallation = installation as never;
-    req.agentInstallations = [installation] as never[];
-    req.agentAuthorizedPodIds = [installation?.podId?.toString()].filter(Boolean) as string[];
+    req.agentInstallations = allActiveInstallations as never[];
+    req.agentAuthorizedPodIds = allActiveInstallations
+      .map((inst: { podId?: { toString: () => string } }) => inst?.podId?.toString())
+      .filter(Boolean) as string[];
 
     // Also resolve and attach the bot User so downstream routes that derive
     // `req.agentUser._id` (file-upload uploaderId, message authorship) work

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -303,9 +303,23 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
     );
 
     try {
+      // Task #62: don't clobber a curated per-instance displayName with the
+      // AgentRegistry's default. When installing a NEW pod for an EXISTING
+      // agent identity (e.g. installing Aria into a new pod when she's
+      // already Aria-named via prior install), `agent.displayName` is the
+      // registry-wide fallback ("Cuz 🦞" for openclaw, "Codex" for codex).
+      // Passing that into getOrCreateAgentUser overwrites the User row's
+      // curated displayName ("Aria"). Caller intent: install in pod, NOT
+      // rename. So: only pass `displayName` to identity service when the
+      // caller explicitly set one in the request body (truthy displayName
+      // from req.body); otherwise leave it undefined and let
+      // getOrCreateAgentUser preserve the existing User row's displayName.
+      const explicitDisplayName = typeof displayName === 'string' && displayName.trim()
+        ? displayName.trim()
+        : undefined;
       const agentUser = await AgentIdentityService.getOrCreateAgentUser(agent.agentName, {
         instanceId: normalizedInstanceId,
-        displayName: displayName || agent.displayName,
+        ...(explicitDisplayName ? { displayName: explicitDisplayName } : {}),
       });
       await AgentIdentityService.ensureAgentInPod(agentUser, podId);
     } catch (identityError: unknown) {


### PR DESCRIPTION
Closes #62 and #66. See commit message for the full diagnosis. 2 unit tests added on agentRuntimeAuth.test.js.