### PR TITLE
test(ci): unbreak Tests workflow on main

### DIFF
--- a/backend/__tests__/service/uploads.signedurl.integration.test.js
+++ b/backend/__tests__/service/uploads.signedurl.integration.test.js
@@ -199,12 +199,16 @@ describe('ADR-002 Phase 1b-a — signed-URL mint (integration)', () => {
       .expect(200);
     expect(res.body.url).toMatch(/^\/api\/uploads\/chat-attachment\.png\?t=/);
 
-    // Audit log is fire-and-forget — give the microtask a beat, then verify.
-    await new Promise((r) => setImmediate(r));
-    const log = await AuditLog.findOne({
-      action: 'attachment.token.mint',
-      fileName: 'chat-attachment.png',
-    });
+    // Audit log is fire-and-forget. setImmediate only flushes microtasks —
+    // the Mongo write itself is async I/O, so poll briefly until it lands.
+    let log = null;
+    for (let i = 0; i < 50 && !log; i++) {
+      log = await AuditLog.findOne({
+        action: 'attachment.token.mint',
+        fileName: 'chat-attachment.png',
+      });
+      if (!log) await new Promise((r) => setTimeout(r, 20));
+    }
     expect(log).toBeTruthy();
     expect(String(log.userId)).toBe(String(viewer._id));
   });

--- a/backend/__tests__/unit/middleware/agentRuntimeAuth.test.js
+++ b/backend/__tests__/unit/middleware/agentRuntimeAuth.test.js
@@ -9,8 +9,8 @@
 // `mock` (Jest's hoisting-safety allow-list), so every mock binding here is
 // prefixed accordingly.
 
-const mockCrypto = { hash: jest.fn(), randomSecret: jest.fn() };
-jest.mock('../../../utils/crypto', () => mockCrypto);
+const mockSecret = { hash: jest.fn(), randomSecret: jest.fn() };
+jest.mock('../../../utils/secret', () => mockSecret);
 
 const mockUserFindOne = jest.fn();
 const mockInstallationFindOne = jest.fn();
@@ -46,8 +46,8 @@ const buildRes = () => {
 };
 
 beforeEach(() => {
-  mockCrypto.hash.mockReset();
-  mockCrypto.hash.mockReturnValue('hashed-token');
+  mockSecret.hash.mockReset();
+  mockSecret.hash.mockReturnValue('hashed-token');
   mockUserFindOne.mockReset();
   mockInstallationFindOne.mockReset();
   mockInstallationFind.mockReset();

--- a/backend/__tests__/unit/middleware/agentRuntimeAuth.test.js
+++ b/backend/__tests__/unit/middleware/agentRuntimeAuth.test.js
@@ -35,9 +35,13 @@ jest.mock('../../../models/Pod', () => ({
 
 const agentRuntimeAuth = require('../../../middleware/agentRuntimeAuth').default;
 
-const buildReq = (token) => ({
-  headers: { authorization: `Bearer ${token}` },
-});
+const buildReq = (token) => {
+  const headers = { authorization: `Bearer ${token}` };
+  return {
+    headers,
+    header: (name) => headers[String(name).toLowerCase()],
+  };
+};
 const buildRes = () => {
   const res = {};
   res.status = jest.fn().mockReturnValue(res);

--- a/backend/__tests__/unit/middleware/agentRuntimeAuth.test.js
+++ b/backend/__tests__/unit/middleware/agentRuntimeAuth.test.js
@@ -4,25 +4,29 @@
 // endpoint silently filters out events for pods the token wasn't originally
 // minted for — exact bug we hit when Cody's token from her old install
 // couldn't see events from a new pod she'd been freshly installed into.
+//
+// jest.mock() factories may only reference variables whose name starts with
+// `mock` (Jest's hoisting-safety allow-list), so every mock binding here is
+// prefixed accordingly.
 
-const cryptoMock = { hash: jest.fn(), randomSecret: jest.fn() };
-jest.mock('../../../utils/crypto', () => cryptoMock);
+const mockCrypto = { hash: jest.fn(), randomSecret: jest.fn() };
+jest.mock('../../../utils/crypto', () => mockCrypto);
 
-const userFindOneMock = jest.fn();
-const installationFindOneMock = jest.fn();
-const installationFindMock = jest.fn();
-const installationUpdateOneMock = jest.fn();
+const mockUserFindOne = jest.fn();
+const mockInstallationFindOne = jest.fn();
+const mockInstallationFind = jest.fn();
+const mockInstallationUpdateOne = jest.fn();
 
 jest.mock('../../../models/User', () => {
   function User() {}
-  User.findOne = (...args) => userFindOneMock(...args);
+  User.findOne = (...args) => mockUserFindOne(...args);
   return User;
 });
 jest.mock('../../../models/AgentRegistry', () => ({
   AgentInstallation: {
-    findOne: (...args) => installationFindOneMock(...args),
-    find: (...args) => installationFindMock(...args),
-    updateOne: (...args) => installationUpdateOneMock(...args),
+    findOne: (...args) => mockInstallationFindOne(...args),
+    find: (...args) => mockInstallationFind(...args),
+    updateOne: (...args) => mockInstallationUpdateOne(...args),
   },
 }));
 jest.mock('../../../models/Pod', () => ({
@@ -31,10 +35,10 @@ jest.mock('../../../models/Pod', () => ({
 
 const agentRuntimeAuth = require('../../../middleware/agentRuntimeAuth').default;
 
-const mockReq = (token) => ({
+const buildReq = (token) => ({
   headers: { authorization: `Bearer ${token}` },
 });
-const mockRes = () => {
+const buildRes = () => {
   const res = {};
   res.status = jest.fn().mockReturnValue(res);
   res.json = jest.fn().mockReturnValue(res);
@@ -42,18 +46,17 @@ const mockRes = () => {
 };
 
 beforeEach(() => {
-  cryptoMock.hash.mockReset();
-  cryptoMock.hash.mockReturnValue('hashed-token');
-  userFindOneMock.mockReset();
-  installationFindOneMock.mockReset();
-  installationFindMock.mockReset();
-  installationUpdateOneMock.mockReset();
+  mockCrypto.hash.mockReset();
+  mockCrypto.hash.mockReturnValue('hashed-token');
+  mockUserFindOne.mockReset();
+  mockInstallationFindOne.mockReset();
+  mockInstallationFind.mockReset();
+  mockInstallationUpdateOne.mockReset();
 });
 
 describe('agentRuntimeAuth path 2 (install-bound token) — #66 fix', () => {
   test('surfaces ALL active installations for the same (agentName, instanceId), not just the matched one', async () => {
-    // No User-row token match → path 2 fires
-    userFindOneMock.mockResolvedValue(null);
+    mockUserFindOne.mockResolvedValue(null);
     const matchedInstall = {
       _id: 'install-a',
       agentName: 'codex',
@@ -68,17 +71,17 @@ describe('agentRuntimeAuth path 2 (install-bound token) — #66 fix', () => {
       podId: { toString: () => 'pod-b' },
       runtimeTokens: [{ tokenHash: 'different-hash' }],
     };
-    installationFindOneMock.mockResolvedValue(matchedInstall);
-    installationFindMock.mockResolvedValue([matchedInstall, otherInstall]);
-    installationUpdateOneMock.mockResolvedValue({});
+    mockInstallationFindOne.mockResolvedValue(matchedInstall);
+    mockInstallationFind.mockResolvedValue([matchedInstall, otherInstall]);
+    mockInstallationUpdateOne.mockResolvedValue({});
 
-    const req = mockReq('cm_agent_test');
-    const res = mockRes();
+    const req = buildReq('cm_agent_test');
+    const res = buildRes();
     const next = jest.fn();
 
     await agentRuntimeAuth(req, res, next);
 
-    expect(installationFindMock).toHaveBeenCalledWith({
+    expect(mockInstallationFind).toHaveBeenCalledWith({
       agentName: 'codex',
       instanceId: 'cody',
       status: 'active',
@@ -90,11 +93,11 @@ describe('agentRuntimeAuth path 2 (install-bound token) — #66 fix', () => {
   });
 
   test('returns 401 when token doesnt match any install OR user', async () => {
-    userFindOneMock.mockResolvedValue(null);
-    installationFindOneMock.mockResolvedValue(null);
+    mockUserFindOne.mockResolvedValue(null);
+    mockInstallationFindOne.mockResolvedValue(null);
 
-    const req = mockReq('cm_agent_bogus');
-    const res = mockRes();
+    const req = buildReq('cm_agent_bogus');
+    const res = buildRes();
     const next = jest.fn();
 
     await agentRuntimeAuth(req, res, next);

--- a/backend/__tests__/unit/services/agentIdentityService.collisionResolver.test.js
+++ b/backend/__tests__/unit/services/agentIdentityService.collisionResolver.test.js
@@ -12,26 +12,29 @@ jest.mock('../../../models/Pod', () => ({}));
 
 // Mongo User mock — minimal save() + find() shape sufficient for the
 // three branches in getOrCreateAgentUser. Each test seeds state into
-// `peers` (other bot Users with potential displayName collisions) and
-// `existing` (the user the caller is trying to get-or-create).
-let peers = [];
-let existing = null;
-const saved = [];
+// `mockPeers` (other bot Users with potential displayName collisions) and
+// `mockExisting` (the user the caller is trying to get-or-create).
+//
+// All mutable state is prefixed with `mock` so the jest.mock() factory can
+// reference it — Jest's hoisting-safety allow-list only permits names
+// starting with `mock`.
+let mockPeers = [];
+let mockExisting = null;
+const mockSaved = [];
 
 jest.mock('../../../models/User', () => {
   function User(doc) {
     Object.assign(this, doc);
   }
   User.prototype.save = async function save() {
-    saved.push(JSON.parse(JSON.stringify(this)));
+    mockSaved.push(JSON.parse(JSON.stringify(this)));
     return this;
   };
   User.findOne = jest.fn(async (query) => {
-    if (existing && query.username === existing.username) {
-      // Return a mongoose-like doc with save()
-      const doc = JSON.parse(JSON.stringify(existing));
+    if (mockExisting && query.username === mockExisting.username) {
+      const doc = JSON.parse(JSON.stringify(mockExisting));
       doc.save = async function save() {
-        saved.push(JSON.parse(JSON.stringify(this)));
+        mockSaved.push(JSON.parse(JSON.stringify(this)));
         return this;
       };
       return doc;
@@ -41,9 +44,8 @@ jest.mock('../../../models/User', () => {
   User.find = (query) => ({
     select: () => ({
       lean: async () => {
-        // Match `'botMetadata.displayName': '<name>'`
         const dn = query['botMetadata.displayName'];
-        return peers
+        return mockPeers
           .filter((p) => p.botMetadata?.displayName === dn)
           .filter((p) => {
             if (!query._id || !query._id.$ne) return true;
@@ -58,9 +60,9 @@ jest.mock('../../../models/User', () => {
 const { default: AgentIdentityService } = require('../../../services/agentIdentityService');
 
 const reset = () => {
-  peers = [];
-  existing = null;
-  saved.length = 0;
+  mockPeers = [];
+  mockExisting = null;
+  mockSaved.length = 0;
 };
 
 describe('inline displayName collision resolver (sticky dedup)', () => {
@@ -71,13 +73,13 @@ describe('inline displayName collision resolver (sticky dedup)', () => {
       instanceId: 'pixel',
       displayName: 'Pixel',
     });
-    expect(saved.length).toBe(1);
-    expect(saved[0].botMetadata.displayName).toBe('Pixel');
+    expect(mockSaved.length).toBe(1);
+    expect(mockSaved[0].botMetadata.displayName).toBe('Pixel');
   });
 
   test('new install collides with an existing canonical — gets suffix', async () => {
     // openclaw-pixel already has displayName="Pixel" with instanceId "pixel" (shorter)
-    peers = [
+    mockPeers = [
       {
         _id: 'canonical-id',
         botMetadata: { displayName: 'Pixel', instanceId: 'pixel' },
@@ -87,13 +89,13 @@ describe('inline displayName collision resolver (sticky dedup)', () => {
       instanceId: 'pixel-demo',
       displayName: 'Pixel',
     });
-    expect(saved.length).toBe(1);
-    expect(saved[0].botMetadata.displayName).toBe('Pixel (Pixel-Demo)');
+    expect(mockSaved.length).toBe(1);
+    expect(mockSaved[0].botMetadata.displayName).toBe('Pixel (Pixel-Demo)');
   });
 
   test('new install IS canonical (shorter instanceId than existing peer) — keeps bare name', async () => {
     // pixel-stub-x already has displayName="Pixel" with longer instanceId
-    peers = [
+    mockPeers = [
       {
         _id: 'longer-instance',
         botMetadata: { displayName: 'Pixel', instanceId: 'pixel-stub-x' },
@@ -103,12 +105,12 @@ describe('inline displayName collision resolver (sticky dedup)', () => {
       instanceId: 'pixel',
       displayName: 'Pixel',
     });
-    expect(saved.length).toBe(1);
-    expect(saved[0].botMetadata.displayName).toBe('Pixel');
+    expect(mockSaved.length).toBe(1);
+    expect(mockSaved[0].botMetadata.displayName).toBe('Pixel');
   });
 
   test('refresh (reprovision) on existing collision-suffixed name does NOT double-suffix', async () => {
-    existing = {
+    mockExisting = {
       _id: 'reprovision-id',
       username: 'openclaw-pixel-demo',
       isBot: true,
@@ -129,11 +131,11 @@ describe('inline displayName collision resolver (sticky dedup)', () => {
     // self-excluded, but there are still no OTHER peers in this test, so
     // the bare "Pixel" passes through. This is fine: in production the
     // canonical openclaw-pixel exists as a peer and the suffix is re-applied.
-    expect(saved.length).toBe(1);
+    expect(mockSaved.length).toBe(1);
   });
 
   test('already-disambiguated name passes through unchanged', async () => {
-    peers = [
+    mockPeers = [
       {
         _id: 'canonical-id',
         botMetadata: { displayName: 'Pixel', instanceId: 'pixel' },
@@ -143,11 +145,11 @@ describe('inline displayName collision resolver (sticky dedup)', () => {
       instanceId: 'pixel-demo',
       displayName: 'Pixel (Pixel-Demo)',
     });
-    expect(saved[0].botMetadata.displayName).toBe('Pixel (Pixel-Demo)');
+    expect(mockSaved[0].botMetadata.displayName).toBe('Pixel (Pixel-Demo)');
   });
 
   test('humanizes multi-segment instanceId — underscore / dash boundaries capitalized', async () => {
-    peers = [
+    mockPeers = [
       {
         _id: 'canonical-id',
         botMetadata: { displayName: 'Cody', instanceId: 'cody' },
@@ -157,6 +159,6 @@ describe('inline displayName collision resolver (sticky dedup)', () => {
       instanceId: 'cody-bot',
       displayName: 'Cody',
     });
-    expect(saved[0].botMetadata.displayName).toBe('Cody (Cody-Bot)');
+    expect(mockSaved[0].botMetadata.displayName).toBe('Cody (Cody-Bot)');
   });
 });

--- a/commonly-mcp/__tests__/tools.test.mjs
+++ b/commonly-mcp/__tests__/tools.test.mjs
@@ -15,11 +15,12 @@ const tools = buildTools(cfg);
 const byName = Object.fromEntries(tools.map((t) => [t.name, t]));
 
 describe('tool registry shape', () => {
-  it('ships exactly the v1 surface (16 tools)', () => {
+  it('ships exactly the v1 surface (17 tools)', () => {
     // 14 tools (ADR-010 Phase 1) + 2 added in Phase 4 (commonly_save_my_memory,
     // commonly_log_cycle) so MCP-capable runtimes (Claude Code, Cursor, Codex
     // via wrapper) have the same memory write surface as the openclaw extension.
-    expect(tools).toHaveLength(16);
+    // + 1 added by PR #389 (commonly_react_to_message).
+    expect(tools).toHaveLength(17);
   });
 
   it('every tool has name, description, inputSchema, call', () => {


### PR DESCRIPTION
## Summary
- **agentRuntimeAuth.test.js** (#66): jest.mock() factories referenced bindings (`cryptoMock`, `userFindOneMock`, …) not prefixed with `mock` → Jest hoisting allow-list ReferenceError. Renamed all bindings to `mock*`.
- **agentIdentityService.collisionResolver.test.js** (sprint PR #403): same hoisting issue with `peers` / `existing` / `saved`. Renamed.
- **uploads.signedurl.integration.test.js** (failing on every main run since 2026-05-16 02:39 UTC, 19 in a row): `Promise(setImmediate)` only flushes microtasks but the fire-and-forget audit log is async Mongo I/O. Replaced with a short polling loop (≤1s total).

The Tests workflow on main has been red for ~2 days. After this lands main should be green.

## Test plan
- [ ] CI Tests workflow on this PR turns green
- [ ] All three previously-failing files pass on the PR run