### PR TITLE
fix(agent-message): false-attach regex catches sentence-initial past participle

### DIFF
--- a/backend/__tests__/unit/services/agentMessageService.summary.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.summary.test.js
@@ -883,4 +883,32 @@ describe('AgentMessageService summary persistence', () => {
     expect(result.skipped).toBeUndefined();
     expect(Message).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    ['Attached the runbook.', true],
+    ['I attached the deck.', true],
+    ['Posted the artifact.', true],
+    ['Pixel attached the file.', false],
+  ])('flags false attachment claim footer for %p => %p', async (content, shouldFlag) => {
+    const result = await AgentMessageService.postMessage({
+      agentName: 'commonly-bot',
+      instanceId: 'default',
+      podId: 'pod-1',
+      content,
+      metadata: { sourceEventId: `evt-false-attach-${content.replace(/[^a-z]+/gi, '-').toLowerCase()}` },
+      messageType: 'text',
+      installationConfig: { errorRouting: { ownerDm: false } },
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      success: true,
+    }));
+
+    if (shouldFlag) {
+      expect(result.message.content).toContain('system note: this message claims an attachment');
+      expect(result.message.content).toContain('`[[upload:...]]` directive');
+    } else {
+      expect(result.message.content).not.toContain('system note: this message claims an attachment');
+    }
+  });
 });

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -806,12 +806,13 @@ class AgentMessageService {
     // never lands in pod chat. Annotate the message so humans can see
     // the discrepancy at a glance rather than wonder where the file went.
     // Heuristic only — false positives are tolerable (footer is
-    // informational, doesn't reject). Pattern: past-tense declarative
-    // ("attached" / "uploaded" / "posted") with a file-object noun
-    // nearby AND no `[[upload:` directive in the body.
+    // informational, doesn't reject). Pattern: first-person or
+    // sentence-initial past-tense declarative ("attached" /
+    // "uploaded" / "posted") with a file-object noun nearby AND no
+    // `[[upload:` directive in the body.
     if (sanitizedContent && typeof sanitizedContent === 'string') {
       const hasUploadDirective = /\[\[upload:/i.test(sanitizedContent);
-      const claimsAttachment = /\b(?:i(?:'ve| have)?|done\s*[—-]?\s*i|i\s+just|just\s+attached|i\s+already)\s+(?:attached|uploaded|posted)\b[^.\n]{0,80}\b(?:file|deck|attachment|pptx|docx|xlsx|pdf|csv|image|artifact)\b/i.test(sanitizedContent);
+      const claimsAttachment = /(?:\b(?:i(?:'ve| have)?|done\s*[—-]?\s*i|i\s+just|i\s+already)\s+|(?:^|[.!?]\s+|[\r\n]+)(?:done\s*[—-]?\s*)?(?:just\s+)?)(?:attached|uploaded|posted)\b[^.\n]{0,80}\b(?:file|deck|attachment|runbook|pptx|docx|xlsx|pdf|csv|image|artifact)\b/i.test(sanitizedContent);
       if (claimsAttachment && !hasUploadDirective) {
         sanitizedContent += '\n\n⚠️ _(system note: this message claims an attachment but no `[[upload:...]]` directive is in the body. The agent may not have actually called `commonly_attach_file`. Check the agent\'s workspace for the file and re-attach if needed.)_';
         console.warn(`[agent-msg] false-attach-claim from agent=${agentName} instance=${instanceId} pod=${podId} — appended system note`);


### PR DESCRIPTION
## Why
- Cycle-1 / Aria repro: pod message `26336` posted `Attached the runbook as a downloadable artifact: ...md`.
- The false-attach footer did not fire because the heuristic only matched first-person phrasing like `I attached`, `I've uploaded`, `Done - I posted`, or similar.
- This patch expands the detection to sentence-initial bare past participles so the footer also fires for `Attached the ...`, `Uploaded the ...`, and `Posted the ...` when there is still no `[[upload:...]]` directive in the body.

## What changed
- Keep the existing first-person matches intact.
- Add a sentence-start branch for bare `attached|uploaded|posted`, including after punctuation or a newline.
- Add `runbook` to the nearby object whitelist so the explicit repro and the requested regression case both match.

## Regression coverage
- `Attached the runbook.` => matches and appends the footer.
- `I attached the deck.` => still matches and appends the footer.
- `Posted the artifact.` => matches and appends the footer.
- `Pixel attached the file.` => does not match, avoiding the third-party-reference false positive.

## Local verification
- Regex smoke-tested locally against the cases above with a tiny `node` one-liner.
- Added focused Jest regression cases in `backend/__tests__/unit/services/agentMessageService.summary.test.js`.
- Do not run the full test suite locally — laptop is underpowered.