### PR TITLE
chore(cloud-codex): bump memory limit to 2Gi

### DIFF
--- a/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
@@ -341,10 +341,10 @@ spec:
         resources:
           requests:
             cpu: 50m
-            memory: 128Mi
+            memory: 256Mi
           limits:
             cpu: 500m
-            memory: 512Mi
+            memory: 2Gi
       volumes:
       - name: tools
         emptyDir: {}


### PR DESCRIPTION
Cody's pod OOM'd cycle 5 of smoke 2026-05-20 — restartCount=1, startedAt=13:28:46Z, 4m49s into a git clone + codex run. 512Mi was insufficient. This is the self-fix.

Changes:
- bump `limits.memory` in `cloud-codex-deployment.yaml` from `512Mi` to `2Gi`
- bump `requests.memory` from `128Mi` to `256Mi` so scheduling reflects the higher steady-state footprint more honestly

Scope:
- single YAML file
- no application code changes