### PR TITLE
fix(install): preserve curated displayName on AgentProfile + AgentInstallation

### DIFF
--- a/backend/__tests__/service/install.preserves-displayname.test.js
+++ b/backend/__tests__/service/install.preserves-displayname.test.js
@@ -1,0 +1,194 @@
+/**
+ * Regression test for the install endpoint preserving curated displayName
+ * across both seams it writes to.
+ *
+ * Surfaced 2026-05-20 in the dev-agent smoke pod: PR #408 fixed the
+ * AgentInstallation.displayName seam, but the AgentProfile.name seam (read
+ * FIRST by the V2 member list) still got `agent.displayName` ("Cuz 🦞" for
+ * openclaw, "Codex" for codex), so every member row in a fresh pod showed
+ * "Cuz" even though the underlying User identity was correct.
+ *
+ * Contract: when an admin/installer POSTs /install for an EXISTING agent
+ * identity (same agentName + instanceId, User row already has a curated
+ * botMetadata.displayName) with NO explicit `displayName` in the body, the
+ * curated User displayName must propagate to BOTH AgentInstallation AND
+ * AgentProfile, not the registry-wide default.
+ */
+
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+const { setupMongoDb, closeMongoDb } = require('../utils/testUtils');
+
+const User = require('../../models/User');
+const Pod = require('../../models/Pod');
+const { AgentRegistry, AgentInstallation } = require('../../models/AgentRegistry');
+const AgentProfile = require('../../models/AgentProfile').default || require('../../models/AgentProfile');
+
+const registryRoutes = require('../../routes/registry');
+
+const JWT_SECRET = 'test-jwt-secret-install-displayname';
+
+jest.setTimeout(60000);
+
+describe('Install endpoint preserves curated displayName (cycle-of-Aria regression)', () => {
+  let app;
+  let installer;
+  let installerToken;
+  let pod;
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = JWT_SECRET;
+    await setupMongoDb();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/registry', registryRoutes);
+
+    installer = await User.create({
+      username: 'installer',
+      email: 'installer@test.com',
+      password: 'password123',
+    });
+    installerToken = jwt.sign({ id: installer._id.toString() }, JWT_SECRET);
+
+    pod = await Pod.create({
+      name: 'Install-DisplayName Test Pod',
+      type: 'chat',
+      createdBy: installer._id,
+      members: [installer._id],
+    });
+
+    // Registry-wide manifest with the "ugly" default name — mirror the
+    // production shape where openclaw → "Cuz 🦞" and codex → "Codex".
+    await AgentRegistry.create({
+      agentName: 'openclaw',
+      displayName: 'Cuz 🦞',
+      description: 'OpenClaw test',
+      manifest: {
+        name: 'openclaw',
+        version: '1.0.0',
+        capabilities: [],
+        context: { required: [], optional: [] },
+      },
+      latestVersion: '1.0.0',
+      versions: [{ version: '1.0.0', manifest: { name: 'openclaw', version: '1.0.0', capabilities: [], context: { required: [], optional: [] } }, publishedAt: new Date() }],
+      registry: 'private',
+    });
+
+    // Pre-existing curated agent identity. This is the "Aria" / "Nova" /
+    // "Pixel" case — the User row has the right name, we're just installing
+    // her into a NEW pod.
+    await User.create({
+      username: 'openclaw-aria',
+      email: 'openclaw-aria@bot.local',
+      password: 'bot-no-login',
+      isBot: true,
+      botMetadata: {
+        agentName: 'openclaw',
+        instanceId: 'aria',
+        displayName: 'Aria',
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await closeMongoDb();
+  });
+
+  beforeEach(async () => {
+    await AgentInstallation.deleteMany({});
+    await AgentProfile.deleteMany({});
+  });
+
+  it('writes curated User.botMetadata.displayName to AgentInstallation AND AgentProfile when no explicit displayName', async () => {
+    const res = await request(app)
+      .post('/api/registry/install')
+      .set('Authorization', `Bearer ${installerToken}`)
+      .send({
+        agentName: 'openclaw',
+        instanceId: 'aria',
+        podId: pod._id.toString(),
+        version: '1.0.0',
+        scopes: ['context:read', 'summaries:read', 'messages:write'],
+        // Deliberately NO displayName — must NOT fall back to registry default.
+      });
+
+    expect(res.status).toBe(200);
+
+    const installation = await AgentInstallation.findOne({
+      podId: pod._id,
+      agentName: 'openclaw',
+      instanceId: 'aria',
+    }).lean();
+    expect(installation).toBeTruthy();
+    expect(installation.displayName).toBe('Aria');
+    expect(installation.displayName).not.toBe('Cuz 🦞');
+
+    const profile = await AgentProfile.findOne({
+      podId: pod._id,
+      agentName: 'openclaw',
+      instanceId: 'aria',
+    }).lean();
+    expect(profile).toBeTruthy();
+    expect(profile.name).toBe('Aria');
+    expect(profile.name).not.toBe('Cuz 🦞');
+  });
+
+  it('respects explicit displayName in request body over both registry default AND existing User row', async () => {
+    const res = await request(app)
+      .post('/api/registry/install')
+      .set('Authorization', `Bearer ${installerToken}`)
+      .send({
+        agentName: 'openclaw',
+        instanceId: 'aria',
+        podId: pod._id.toString(),
+        version: '1.0.0',
+        scopes: ['context:read', 'summaries:read', 'messages:write'],
+        displayName: 'Aria Prime',
+      });
+
+    expect(res.status).toBe(200);
+
+    const installation = await AgentInstallation.findOne({
+      podId: pod._id,
+      agentName: 'openclaw',
+      instanceId: 'aria',
+    }).lean();
+    expect(installation.displayName).toBe('Aria Prime');
+
+    const profile = await AgentProfile.findOne({
+      podId: pod._id,
+      agentName: 'openclaw',
+      instanceId: 'aria',
+    }).lean();
+    expect(profile.name).toBe('Aria Prime');
+  });
+
+  it('falls back to registry displayName when no User row exists yet (fresh agent identity)', async () => {
+    // A brand-new instanceId with no prior User row — the only signal is
+    // the registry default, so we must use it rather than crashing or
+    // writing an empty string.
+    const res = await request(app)
+      .post('/api/registry/install')
+      .set('Authorization', `Bearer ${installerToken}`)
+      .send({
+        agentName: 'openclaw',
+        instanceId: 'fresh-agent',
+        podId: pod._id.toString(),
+        version: '1.0.0',
+        scopes: ['context:read', 'summaries:read', 'messages:write'],
+      });
+
+    expect(res.status).toBe(200);
+
+    const installation = await AgentInstallation.findOne({
+      podId: pod._id,
+      agentName: 'openclaw',
+      instanceId: 'fresh-agent',
+    }).lean();
+    // Registry default is acceptable when there's no curated identity to preserve.
+    expect(installation.displayName).toBe('Cuz 🦞');
+  });
+});

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -258,13 +258,43 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
       ...AUTO_GRANTED_INTEGRATION_SCOPES,
     ]));
 
+    // Task #62 (round 2): prefer the curated User.botMetadata.displayName
+    // for the SAME agentName + instanceId over the registry-default
+    // (`agent.displayName` e.g. "Cuz 🦞" / "Codex"). PR #408 fixed this
+    // seam on the intro-post path; this is the install-path equivalent.
+    // Without this, installing an existing agent identity (e.g. openclaw:nova)
+    // into a NEW pod writes "Cuz 🦞" to both AgentInstallation.displayName
+    // AND AgentProfile.name — and the V2 member list reads AgentProfile FIRST,
+    // so users see "Cuz" on every member row even though the underlying
+    // identity has the right name. Order: explicit caller intent > existing
+    // identity > registry default.
+    let effectiveDisplayName: string = displayName || '';
+    if (!effectiveDisplayName) {
+      try {
+        const existingAgentUser = await User.findOne({
+          'botMetadata.agentName': agent.agentName,
+          'botMetadata.instanceId': normalizedInstanceId,
+          isBot: true,
+        }).select('botMetadata.displayName').lean();
+        if (existingAgentUser?.botMetadata?.displayName) {
+          effectiveDisplayName = String(existingAgentUser.botMetadata.displayName);
+        }
+      } catch (lookupErr) {
+        // Non-fatal — fall through to registry default below.
+        console.warn('[install] displayName lookup failed:', (lookupErr as Error).message);
+      }
+    }
+    if (!effectiveDisplayName) {
+      effectiveDisplayName = agent.displayName;
+    }
+
     const installation = await AgentInstallation.install(agentName, podId, {
       version: version || agent.latestVersion,
       config: installConfig,
       scopes: grantedScopes,
       installedBy: userId,
       instanceId: normalizedInstanceId,
-      displayName: displayName || agent.displayName,
+      displayName: effectiveDisplayName,
     });
 
     // Use upsert by the natural key (podId + agentId) so reinstalling
@@ -281,7 +311,7 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
         $set: {
           agentName: safeAgentName,
           instanceId: normalizedInstanceId,
-          name: displayName || agent.displayName,
+          name: effectiveDisplayName,
           purpose: agent.description,
           instructions: agent.manifest.configSchema?.defaultInstructions || '',
           persona: {


### PR DESCRIPTION
## Summary
- Closes the install-path equivalent of PR #408 — that fix preserved curated displayName on the intro-post path but missed the install-time write to `AgentProfile.name`.
- Resolution order now: explicit `req.body.displayName` → existing `User.botMetadata.displayName` for the same `(agentName, instanceId)` → registry default (e.g. `"Cuz 🦞"` / `"Codex"`).
- Both write seams (`AgentInstallation.install` + `AgentProfile.findOneAndUpdate`) read the same resolved value, so they can't drift.

## Repro (from 2026-05-20 smoke test)
Installed six pre-existing dev-agent identities (openclaw:theo/nova/pixel/aria/ops + codex:cody) into a fresh pod via `POST /api/registry/install`:
```
{ agentName: "openclaw", instanceId: "aria", podId: "...", version: "1.0.0", scopes: [...] }
```
Before: `AgentInstallation.displayName = "Cuz 🦞"`, `AgentProfile.name = "Cuz 🦞"` for all five openclaw agents. Member list rendered "Cuz" everywhere even though `User.botMetadata.displayName` was "Aria"/"Nova"/etc.
After: both seams write "Aria" (etc.) via the lookup.

## Why the V2 member list shows "Cuz"
`AgentProfile.name` is the per-pod display layer read FIRST by the inspector (per `feedback-displayname-role-leak-three-sources`). User-row fixes alone aren't enough — every pod-scoped render layer downstream reads AgentProfile.

## Test plan
- [x] New regression test `backend/__tests__/service/install.preserves-displayname.test.js` covers 3 cases:
  - existing curated identity beats registry default (the main bug)
  - explicit `displayName` in body beats both
  - registry default still wins when no curated identity exists (fresh install)
- [ ] CI green (Test & Coverage, Service Tests, CodeQL, Chart Lint)
- [ ] Manual verification on dev once deployed: install one openclaw agent into a fresh test pod → member list shows curated name, not "Cuz"

🤖 Generated with [Claude Code](https://claude.com/claude-code)