### PR TITLE
fix(agent-message): validate [[upload:X]] directives against File collection

### DIFF
--- a/backend/__tests__/unit/services/agentMessageService.phantom-directive.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.phantom-directive.test.js
@@ -1,0 +1,238 @@
+/**
+ * Regression test for the phantom-upload-directive defence
+ * (smoke 2026-05-20 cycle 11, P0).
+ *
+ * The original false-attach footer (PR #68) caught past-tense narration
+ * with NO `[[upload:` directive. It does NOT catch an agent who TYPES a
+ * `[[upload:X]]` directive as plain text without actually calling
+ * `commonly_attach_file`. Aria did this — her message contained the
+ * directive substring but the pod had zero File rows, so the directive
+ * was completely fake but the safety chain treated it as valid.
+ *
+ * This second-layer check validates the first segment of every
+ * `[[upload:X|...]]` directive against the File collection scoped to the
+ * podId. Anything not matching gets a different system note so the two
+ * failure modes (narration-with-no-directive vs typed-fake-directive)
+ * can be told apart in logs and UI.
+ */
+
+const AgentMessageService = require('../../../services/agentMessageService');
+const Message = require('../../../models/Message');
+const Summary = require('../../../models/Summary');
+const AgentIdentityService = require('../../../services/agentIdentityService');
+const PodAssetService = require('../../../services/podAssetService');
+const socketConfig = require('../../../config/socket');
+const DMService = require('../../../services/dmService');
+const { AgentInstallation } = require('../../../models/AgentRegistry');
+const User = require('../../../models/User');
+const Pod = require('../../../models/Pod');
+const File = require('../../../models/File');
+
+jest.mock('../../../models/Message');
+jest.mock('../../../models/Summary', () => ({
+  findOne: jest.fn().mockResolvedValue(null),
+  create: jest.fn(),
+}));
+jest.mock('../../../services/agentIdentityService', () => ({
+  getOrCreateAgentUser: jest.fn(),
+  ensureAgentInPod: jest.fn(),
+}));
+jest.mock('../../../services/podAssetService', () => ({
+  createChatSummaryAsset: jest.fn(),
+}));
+jest.mock('../../../config/socket', () => ({
+  getIO: jest.fn(),
+}));
+jest.mock('../../../services/dmService', () => ({
+  resolveAgentOwner: jest.fn(),
+  getOrCreateAdminDMPod: jest.fn(),
+}));
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: {
+    find: jest.fn(() => ({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([]),
+    })),
+  },
+}));
+jest.mock('../../../models/User', () => ({
+  find: jest.fn(() => ({
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue([]),
+  })),
+}));
+jest.mock('../../../models/Pod', () => ({
+  findById: jest.fn(() => ({
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue({ type: 'chat' }),
+  })),
+}));
+jest.mock('../../../models/File', () => ({
+  find: jest.fn(),
+}));
+
+// Capture the persisted Message doc so we can assert what content actually
+// landed (with or without the footer appended).
+let persistedDoc;
+beforeEach(() => {
+  jest.clearAllMocks();
+  persistedDoc = null;
+  jest.spyOn(AgentMessageService, 'getRecentMessages').mockResolvedValue([]);
+  AgentIdentityService.getOrCreateAgentUser.mockResolvedValue({
+    _id: 'agent-user-1',
+    username: 'openclaw-aria',
+    profilePicture: 'default',
+  });
+  AgentIdentityService.ensureAgentInPod.mockResolvedValue({ _id: 'pod-1' });
+  socketConfig.getIO.mockReturnValue({
+    to: () => ({ emit: jest.fn() }),
+  });
+  Message.mockImplementation(function MockMessage(doc) {
+    persistedDoc = doc;
+    return {
+      ...doc,
+      _id: 'msg-1',
+      createdAt: new Date(),
+      save: jest.fn().mockResolvedValue(true),
+      populate: jest.fn().mockResolvedValue({ ...doc, _id: 'msg-1' }),
+    };
+  });
+  DMService.resolveAgentOwner.mockResolvedValue(null);
+  DMService.getOrCreateAdminDMPod.mockResolvedValue({ _id: 'dm-pod-1' });
+});
+
+afterEach(() => {
+  if (AgentMessageService.getRecentMessages.mockRestore) {
+    AgentMessageService.getRecentMessages.mockRestore();
+  }
+});
+
+describe('AgentMessageService phantom-upload-directive footer', () => {
+  it('appends a phantom-directive footer when [[upload:X]] references no File row', async () => {
+    // No File row matches the directive → phantom.
+    File.find.mockReturnValueOnce({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([]),
+    });
+
+    await AgentMessageService.postMessage({
+      agentName: 'openclaw',
+      instanceId: 'aria',
+      podId: '6a0da39bae757028b39f87a6',
+      content: '[[upload:smoke-postmortem-2026-05-20-v2.md]]',
+    });
+
+    expect(persistedDoc).toBeTruthy();
+    expect(persistedDoc.content).toContain('no matching attachment was found');
+    expect(persistedDoc.content).toContain('smoke-postmortem-2026-05-20-v2.md');
+    // The original directive must STILL be preserved so the existing
+    // false-attach footer (which gates on `[[upload:` presence) doesn't
+    // double-fire.
+    expect(persistedDoc.content).toContain('[[upload:smoke-postmortem-2026-05-20-v2.md]]');
+  });
+
+  it('does NOT append a footer when a File row matches the directive', async () => {
+    // Real upload exists → no phantom.
+    File.find.mockReturnValueOnce({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([
+        { fileName: 'storage-key-abc', originalName: 'real-doc.md' },
+      ]),
+    });
+
+    await AgentMessageService.postMessage({
+      agentName: 'openclaw',
+      instanceId: 'aria',
+      podId: '6a0da39bae757028b39f87a6',
+      content: 'Here is the file: [[upload:storage-key-abc|real-doc.md|1234|file]]',
+    });
+
+    expect(persistedDoc).toBeTruthy();
+    expect(persistedDoc.content).not.toContain('no matching attachment was found');
+    expect(persistedDoc.content).toContain('[[upload:storage-key-abc');
+  });
+
+  it('matches when the directive references originalName instead of fileName', async () => {
+    // Agents sometimes put the human-readable name in the first slot; that
+    // should still resolve.
+    File.find.mockReturnValueOnce({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([
+        { fileName: 'opaque-storage-key', originalName: 'pitch.pptx' },
+      ]),
+    });
+
+    await AgentMessageService.postMessage({
+      agentName: 'openclaw',
+      instanceId: 'pixel',
+      podId: '6a0da39bae757028b39f87a6',
+      content: '[[upload:pitch.pptx]]',
+    });
+
+    expect(persistedDoc).toBeTruthy();
+    expect(persistedDoc.content).not.toContain('no matching attachment was found');
+  });
+
+  it('flags only the phantom directive when multiple are present and some are real', async () => {
+    // Mixed message: one real (real-storage-key), one phantom (made-up.md).
+    File.find.mockReturnValueOnce({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([
+        { fileName: 'real-storage-key', originalName: 'real.md' },
+      ]),
+    });
+
+    await AgentMessageService.postMessage({
+      agentName: 'openclaw',
+      instanceId: 'nova',
+      podId: '6a0da39bae757028b39f87a6',
+      content: 'Two files: [[upload:real-storage-key|real.md]] and [[upload:made-up.md]]',
+    });
+
+    expect(persistedDoc.content).toContain('no matching attachment was found');
+    expect(persistedDoc.content).toContain('made-up.md');
+    // The real one should not be flagged in the phantom list.
+    const phantomLine = persistedDoc.content.split('\n').find((l) => l.includes('no matching attachment'));
+    expect(phantomLine).toBeTruthy();
+    expect(phantomLine).not.toContain('real-storage-key');
+  });
+
+  it('does not append a footer when there is no upload directive at all', async () => {
+    // No directive at all → phantom check skipped. (The earlier narration
+    // footer is a separate code path tested elsewhere.)
+    File.find.mockReturnValueOnce({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([]),
+    });
+
+    await AgentMessageService.postMessage({
+      agentName: 'openclaw',
+      instanceId: 'theo',
+      podId: '6a0da39bae757028b39f87a6',
+      content: 'Just a regular chat message with no upload reference.',
+    });
+
+    expect(persistedDoc.content).not.toContain('no matching attachment was found');
+    // File lookup should not even fire when no directive is present.
+    expect(File.find).not.toHaveBeenCalled();
+  });
+
+  it('does not block the message when the File lookup throws', async () => {
+    File.find.mockImplementationOnce(() => {
+      throw new Error('mongo connection lost');
+    });
+
+    const result = await AgentMessageService.postMessage({
+      agentName: 'openclaw',
+      instanceId: 'aria',
+      podId: '6a0da39bae757028b39f87a6',
+      content: '[[upload:something.md]]',
+    });
+
+    expect(persistedDoc).toBeTruthy();
+    expect(persistedDoc.content).toContain('[[upload:something.md]]');
+    // Lookup failure must NOT corrupt the message with a footer.
+    expect(persistedDoc.content).not.toContain('no matching attachment was found');
+    expect(result).toBeTruthy();
+  });
+});

--- a/backend/__tests__/unit/services/agentMessageService.phantom-directive.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.phantom-directive.test.js
@@ -200,10 +200,10 @@ describe('AgentMessageService phantom-upload-directive footer', () => {
   it('does not append a footer when there is no upload directive at all', async () => {
     // No directive at all → phantom check skipped. (The earlier narration
     // footer is a separate code path tested elsewhere.)
-    File.find.mockReturnValueOnce({
-      select: jest.fn().mockReturnThis(),
-      lean: jest.fn().mockResolvedValue([]),
-    });
+    // Do NOT set up a File.find mockReturnValueOnce here — when the impl
+    // correctly skips the lookup, an unconsumed `Once` mock leaks into the
+    // next test's queue and silently overrides its setup. The assertion
+    // below proves the lookup is skipped.
 
     await AgentMessageService.postMessage({
       agentName: 'openclaw',

--- a/backend/__tests__/unit/services/agentMessageService.phantom-directive.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.phantom-directive.test.js
@@ -165,13 +165,16 @@ describe('AgentMessageService phantom-upload-directive footer', () => {
   });
 
   it('matches when the directive references originalName instead of fileName', async () => {
-    // The findOne query checks BOTH fileName and originalName via $or. As
-    // long as the impl includes originalName as an alternative, the lookup
-    // resolves. Mock returns a hit when queried with 'pitch.pptx' as
-    // either field. Tested by having the mock return a row for any name
-    // we configure.
+    // Real scenario: agents sometimes put the human-readable name (the
+    // file's `originalName`) in the directive's first segment instead of
+    // the storage-key `fileName`. The impl's Set comparison must accept
+    // both. Configure the mock to return a row where the storage key
+    // and the human name DIFFER, then make the directive reference the
+    // human name — only the originalName branch can resolve this.
     mockFindAgainst({
-      'pitch.pptx': { _id: 'file-2' },
+      // key is just a label for the test map; the explicit row sets the
+      // two fields independently so we know which one the impl matched.
+      stored: { fileName: 'opaque-storage-key-xyz', originalName: 'pitch.pptx' },
     });
 
     await AgentMessageService.postMessage({

--- a/backend/__tests__/unit/services/agentMessageService.phantom-directive.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.phantom-directive.test.js
@@ -68,20 +68,24 @@ jest.mock('../../../models/Pod', () => ({
   })),
 }));
 jest.mock('../../../models/File', () => ({
-  findOne: jest.fn(),
+  find: jest.fn(),
 }));
 
-// Build a File.findOne mock that resolves to the matching row when the
-// directive name is in `present`, otherwise null. Pass an object keyed by
-// directive name to fileName (so the test reads naturally).
-const mockFindOneAgainst = (present) => {
-  File.findOne.mockImplementation((query) => {
-    const orClauses = query?.$or || [];
-    const candidate = orClauses[0]?.fileName || orClauses[1]?.originalName;
-    return {
-      select: jest.fn().mockReturnThis(),
-      lean: jest.fn().mockResolvedValue(present[candidate] || null),
-    };
+// Configure File.find to return the rows whose fileName/originalName are
+// in the `present` map. The implementation does a single `File.find({podId})`
+// then builds an in-memory Set from the result. Test by handing back a
+// canned list whose fileName/originalName cover the legitimate directives.
+const mockFindAgainst = (present) => {
+  // `present` is { canonicalName: rowOrAlias } — produce rows where
+  // fileName === canonical (and optionally originalName === alias).
+  const rows = Object.entries(present).map(([name, row]) => ({
+    fileName: row?.fileName || name,
+    originalName: row?.originalName || null,
+  }));
+  File.find.mockReturnValue({
+    select: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue(rows),
   });
 };
 
@@ -124,7 +128,7 @@ afterEach(() => {
 describe('AgentMessageService phantom-upload-directive footer', () => {
   it('appends a phantom-directive footer when [[upload:X]] references no File row', async () => {
     // No File row matches any directive → phantom.
-    mockFindOneAgainst({});
+    mockFindAgainst({});
 
     await AgentMessageService.postMessage({
       agentName: 'openclaw',
@@ -144,7 +148,7 @@ describe('AgentMessageService phantom-upload-directive footer', () => {
 
   it('does NOT append a footer when a File row matches the directive', async () => {
     // Real upload exists → no phantom.
-    mockFindOneAgainst({
+    mockFindAgainst({
       'storage-key-abc': { _id: 'file-1' },
     });
 
@@ -166,7 +170,7 @@ describe('AgentMessageService phantom-upload-directive footer', () => {
     // resolves. Mock returns a hit when queried with 'pitch.pptx' as
     // either field. Tested by having the mock return a row for any name
     // we configure.
-    mockFindOneAgainst({
+    mockFindAgainst({
       'pitch.pptx': { _id: 'file-2' },
     });
 
@@ -183,7 +187,7 @@ describe('AgentMessageService phantom-upload-directive footer', () => {
 
   it('flags only the phantom directive when multiple are present and some are real', async () => {
     // 'real-storage-key' resolves, 'made-up.md' does not.
-    mockFindOneAgainst({
+    mockFindAgainst({
       'real-storage-key': { _id: 'file-3' },
     });
 
@@ -213,11 +217,11 @@ describe('AgentMessageService phantom-upload-directive footer', () => {
 
     expect(persistedDoc.content).not.toContain('no matching attachment was found');
     // File lookup should not even fire when no directive is present.
-    expect(File.findOne).not.toHaveBeenCalled();
+    expect(File.find).not.toHaveBeenCalled();
   });
 
   it('does not block the message when the File lookup throws', async () => {
-    File.findOne.mockImplementationOnce(() => {
+    File.find.mockImplementationOnce(() => {
       throw new Error('mongo connection lost');
     });
 

--- a/backend/__tests__/unit/services/agentMessageService.phantom-directive.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.phantom-directive.test.js
@@ -9,11 +9,11 @@
  * directive substring but the pod had zero File rows, so the directive
  * was completely fake but the safety chain treated it as valid.
  *
- * This second-layer check validates the first segment of every
- * `[[upload:X|...]]` directive against the File collection scoped to the
- * podId. Anything not matching gets a different system note so the two
- * failure modes (narration-with-no-directive vs typed-fake-directive)
- * can be told apart in logs and UI.
+ * This second-layer check validates each `[[upload:X|...]]` directive's
+ * first segment against the File collection scoped to the podId.
+ * Anything not matching gets a different system note so the two failure
+ * modes (narration-with-no-directive vs typed-fake-directive) can be
+ * told apart in logs and UI.
  */
 
 const AgentMessageService = require('../../../services/agentMessageService');
@@ -68,8 +68,22 @@ jest.mock('../../../models/Pod', () => ({
   })),
 }));
 jest.mock('../../../models/File', () => ({
-  find: jest.fn(),
+  findOne: jest.fn(),
 }));
+
+// Build a File.findOne mock that resolves to the matching row when the
+// directive name is in `present`, otherwise null. Pass an object keyed by
+// directive name to fileName (so the test reads naturally).
+const mockFindOneAgainst = (present) => {
+  File.findOne.mockImplementation((query) => {
+    const orClauses = query?.$or || [];
+    const candidate = orClauses[0]?.fileName || orClauses[1]?.originalName;
+    return {
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue(present[candidate] || null),
+    };
+  });
+};
 
 // Capture the persisted Message doc so we can assert what content actually
 // landed (with or without the footer appended).
@@ -109,11 +123,8 @@ afterEach(() => {
 
 describe('AgentMessageService phantom-upload-directive footer', () => {
   it('appends a phantom-directive footer when [[upload:X]] references no File row', async () => {
-    // No File row matches the directive → phantom.
-    File.find.mockReturnValueOnce({
-      select: jest.fn().mockReturnThis(),
-      lean: jest.fn().mockResolvedValue([]),
-    });
+    // No File row matches any directive → phantom.
+    mockFindOneAgainst({});
 
     await AgentMessageService.postMessage({
       agentName: 'openclaw',
@@ -133,11 +144,8 @@ describe('AgentMessageService phantom-upload-directive footer', () => {
 
   it('does NOT append a footer when a File row matches the directive', async () => {
     // Real upload exists → no phantom.
-    File.find.mockReturnValueOnce({
-      select: jest.fn().mockReturnThis(),
-      lean: jest.fn().mockResolvedValue([
-        { fileName: 'storage-key-abc', originalName: 'real-doc.md' },
-      ]),
+    mockFindOneAgainst({
+      'storage-key-abc': { _id: 'file-1' },
     });
 
     await AgentMessageService.postMessage({
@@ -153,13 +161,13 @@ describe('AgentMessageService phantom-upload-directive footer', () => {
   });
 
   it('matches when the directive references originalName instead of fileName', async () => {
-    // Agents sometimes put the human-readable name in the first slot; that
-    // should still resolve.
-    File.find.mockReturnValueOnce({
-      select: jest.fn().mockReturnThis(),
-      lean: jest.fn().mockResolvedValue([
-        { fileName: 'opaque-storage-key', originalName: 'pitch.pptx' },
-      ]),
+    // The findOne query checks BOTH fileName and originalName via $or. As
+    // long as the impl includes originalName as an alternative, the lookup
+    // resolves. Mock returns a hit when queried with 'pitch.pptx' as
+    // either field. Tested by having the mock return a row for any name
+    // we configure.
+    mockFindOneAgainst({
+      'pitch.pptx': { _id: 'file-2' },
     });
 
     await AgentMessageService.postMessage({
@@ -174,12 +182,9 @@ describe('AgentMessageService phantom-upload-directive footer', () => {
   });
 
   it('flags only the phantom directive when multiple are present and some are real', async () => {
-    // Mixed message: one real (real-storage-key), one phantom (made-up.md).
-    File.find.mockReturnValueOnce({
-      select: jest.fn().mockReturnThis(),
-      lean: jest.fn().mockResolvedValue([
-        { fileName: 'real-storage-key', originalName: 'real.md' },
-      ]),
+    // 'real-storage-key' resolves, 'made-up.md' does not.
+    mockFindOneAgainst({
+      'real-storage-key': { _id: 'file-3' },
     });
 
     await AgentMessageService.postMessage({
@@ -198,13 +203,7 @@ describe('AgentMessageService phantom-upload-directive footer', () => {
   });
 
   it('does not append a footer when there is no upload directive at all', async () => {
-    // No directive at all → phantom check skipped. (The earlier narration
-    // footer is a separate code path tested elsewhere.)
-    // Do NOT set up a File.find mockReturnValueOnce here — when the impl
-    // correctly skips the lookup, an unconsumed `Once` mock leaks into the
-    // next test's queue and silently overrides its setup. The assertion
-    // below proves the lookup is skipped.
-
+    // No directive → impl should skip the lookup entirely.
     await AgentMessageService.postMessage({
       agentName: 'openclaw',
       instanceId: 'theo',
@@ -214,11 +213,11 @@ describe('AgentMessageService phantom-upload-directive footer', () => {
 
     expect(persistedDoc.content).not.toContain('no matching attachment was found');
     // File lookup should not even fire when no directive is present.
-    expect(File.find).not.toHaveBeenCalled();
+    expect(File.findOne).not.toHaveBeenCalled();
   });
 
   it('does not block the message when the File lookup throws', async () => {
-    File.find.mockImplementationOnce(() => {
+    File.findOne.mockImplementationOnce(() => {
       throw new Error('mongo connection lost');
     });
 

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -826,8 +826,23 @@ class AgentMessageService {
           const referencedNames: string[] = [];
           let match;
           while ((match = directivePattern.exec(sanitizedContent)) !== null) {
-            const name = (match[1] || '').trim();
-            if (name && !referencedNames.includes(name)) referencedNames.push(name);
+            // Coerce + sanitize each captured name before it reaches the
+            // Mongoose query — CodeQL doesn't trust regex output as a
+            // SqlSanitizer for the NoSQL-injection query, so we apply the
+            // same String().replace() pattern documented at
+            // routes/registry/install.ts:114-116. The pattern strips
+            // anything that isn't a filename-safe char, which also blocks
+            // the `{$ne: null}` / array-injection vectors the rule guards
+            // against. We also bound length to keep a malformed directive
+            // from blowing up the query.
+            const captured = match[1] === undefined ? '' : String(match[1]);
+            const sanitized = captured
+              .trim()
+              .replace(/[^A-Za-z0-9._\-/+ ]/g, '')
+              .slice(0, 256);
+            if (sanitized && !referencedNames.includes(sanitized)) {
+              referencedNames.push(sanitized);
+            }
           }
           if (referencedNames.length > 0) {
             const existingFiles = await File.find({

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -845,19 +845,29 @@ class AgentMessageService {
             }
           }
           if (referencedNames.length > 0) {
-            const existingFiles = await File.find({
-              podId,
-              $or: [
-                { fileName: { $in: referencedNames } },
-                { originalName: { $in: referencedNames } },
-              ],
-            }).select('fileName originalName').lean();
-            const known = new Set<string>();
-            for (const f of existingFiles) {
-              if (f.fileName) known.add(String(f.fileName));
-              if (f.originalName) known.add(String(f.originalName));
+            // Per-name findOne loop rather than a single $in batch. The
+            // batched-$in form is faster (one round-trip), but CodeQL's
+            // js/nosql-injection rule flags any user-tainted array inserted
+            // into a Mongoose `$in` even when each element has been
+            // String()+replace()-sanitized — the analyzer doesn't track
+            // through regex-capture + array.filter + array.push. Looping
+            // here makes the query value at each call site obviously a
+            // single sanitized scalar string, which the rule does accept.
+            // Typical message has 0–1 directive; the perf delta is
+            // negligible against the LLM call cost upstream.
+            const phantoms: string[] = [];
+            for (const name of referencedNames) {
+              if (typeof name !== 'string' || !name) continue;
+              const safeName: string = String(name);
+              const hit = await File.findOne({
+                podId,
+                $or: [
+                  { fileName: safeName },
+                  { originalName: safeName },
+                ],
+              }).select('_id').lean();
+              if (!hit) phantoms.push(safeName);
             }
-            const phantoms = referencedNames.filter((n) => !known.has(n));
             if (phantoms.length > 0) {
               const phantomList = phantoms.map((n) => `\`${n}\``).join(', ');
               sanitizedContent += `\n\n⚠️ _(system note: this message references ${phantoms.length === 1 ? 'an upload directive' : 'upload directives'} for ${phantomList} but no matching attachment was found in this pod. The agent may have typed the directive without actually calling \`commonly_attach_file\`. Check the agent's workspace.)_`;

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -845,42 +845,41 @@ class AgentMessageService {
             }
           }
           if (referencedNames.length > 0) {
-            // Per-name findOne loop rather than a single $in batch. The
-            // batched-$in form is faster (one round-trip), but CodeQL's
-            // js/nosql-injection rule flags any user-tainted array inserted
-            // into a Mongoose `$in` even when each element has been
-            // String()+replace()-sanitized — the analyzer doesn't track
-            // through regex-capture + array.filter + array.push. Looping
-            // here makes the query value at each call site obviously a
-            // single sanitized scalar string, which the rule does accept.
-            // Typical message has 0–1 directive; the perf delta is
-            // negligible against the LLM call cost upstream.
-            // Strict 4-gate sanitizer at the call site — the exact shape
-            // CodeQL's js/nosql-injection rule recognises as a
-            // SqlSanitizer (mirrors backend/routes/registry/install.ts:114-119):
-            //   1. String() coerce
-            //   2. .replace() strip non-allowlist chars
-            //   3. non-empty check (rejects if stripped to empty)
-            //   4. roundtrip check (rejects if stripping CHANGED anything)
-            //   5. .test() final allowlist assertion (belt + suspenders,
-            //      also the CodeQL-recognised SanitizingRegex shape)
-            // Any value that survives all five gates is provably a string
-            // of [A-Za-z0-9._\-/+ ] chars, length 1-256, untainted.
-            const SAFE_NAME_RE = /^[A-Za-z0-9._\-/+ ]{1,256}$/;
-            const phantoms: string[] = [];
-            for (const rawName of referencedNames) {
-              if (typeof rawName !== 'string' || !rawName) continue;
-              const stripped = String(rawName).replace(/[^A-Za-z0-9._\-/+ ]/g, '');
-              if (!stripped || stripped !== rawName || !SAFE_NAME_RE.test(stripped)) continue;
-              const hit = await File.findOne({
-                podId,
-                $or: [
-                  { fileName: stripped },
-                  { originalName: stripped },
-                ],
-              }).select('_id').lean();
-              if (!hit) phantoms.push(stripped);
+            // Single-query, in-memory set comparison.
+            //
+            // History on this hot path: tried `$in` and per-name findOne
+            // with progressively stricter sanitizers (String+replace+
+            // roundtrip+regex.test, 5 gates). CodeQL's js/nosql-injection
+            // analyzer kept flagging the query value as user-tainted
+            // because the source ultimately traces back to a regex
+            // capture from message content — the analyzer doesn't trust
+            // the .replace() chain on regex captures the way it does on
+            // direct String() of req.body.
+            //
+            // The cleaner refactor — and the one the analyzer can't
+            // object to: fetch ALL of this pod's files in one query
+            // keyed ONLY by `podId` (which is the validated route/
+            // session pod, not user content), build an in-memory Set
+            // of the legitimate names, then do the phantom check
+            // purely in JS. The user-tainted directive names never
+            // enter a Mongoose filter.
+            //
+            // Perf: a single round-trip per message instead of N
+            // per-directive lookups. Bound the fetch with .limit(500)
+            // so a pathologically large pod can't blow up the message
+            // pipeline — 500 is well above any realistic pod-file
+            // count (typical: 10-100; even Nova's YC pitch pod after
+            // a heavy artifact day had ~30).
+            const podFiles = await File.find({ podId })
+              .select('fileName originalName')
+              .limit(500)
+              .lean();
+            const knownNames = new Set<string>();
+            for (const f of podFiles) {
+              if (f.fileName) knownNames.add(String(f.fileName));
+              if (f.originalName) knownNames.add(String(f.originalName));
             }
+            const phantoms = referencedNames.filter((n) => typeof n === 'string' && n && !knownNames.has(n));
             if (phantoms.length > 0) {
               const phantomList = phantoms.map((n) => `\`${n}\``).join(', ');
               sanitizedContent += `\n\n⚠️ _(system note: this message references ${phantoms.length === 1 ? 'an upload directive' : 'upload directives'} for ${phantomList} but no matching attachment was found in this pod. The agent may have typed the directive without actually calling \`commonly_attach_file\`. Check the agent's workspace.)_`;

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -23,6 +23,8 @@ const Pod = require('../models/Pod');
 
 const File = require('../models/File');
 
+const mongoose = require('mongoose');
+
 let PGMessage: unknown = null;
 try {
   // eslint-disable-next-line global-require
@@ -844,7 +846,7 @@ class AgentMessageService {
               referencedNames.push(sanitized);
             }
           }
-          if (referencedNames.length > 0) {
+          if (referencedNames.length > 0 && mongoose.Types.ObjectId.isValid(podId)) {
             // Single-query, in-memory set comparison.
             //
             // History on this hot path: tried `$in` and per-name findOne
@@ -870,7 +872,13 @@ class AgentMessageService {
             // pipeline — 500 is well above any realistic pod-file
             // count (typical: 10-100; even Nova's YC pitch pod after
             // a heavy artifact day had ~30).
-            const podFiles = await File.find({ podId })
+            // podId is guarded by the `mongoose.Types.ObjectId.isValid(podId)`
+            // check at the outer `if` above — that's the canonical CodeQL
+            // SqlSanitizer pattern for Mongo ObjectId fields. Cast through
+            // `new ObjectId(...)` here so the analyzer sees a definitely-
+            // safe ObjectId in the query, not a passed-in string.
+            const safePodId = new mongoose.Types.ObjectId(String(podId));
+            const podFiles = await File.find({ podId: safePodId })
               .select('fileName originalName')
               .limit(500)
               .lean();

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -855,26 +855,31 @@ class AgentMessageService {
             // single sanitized scalar string, which the rule does accept.
             // Typical message has 0–1 directive; the perf delta is
             // negligible against the LLM call cost upstream.
+            // Strict 4-gate sanitizer at the call site — the exact shape
+            // CodeQL's js/nosql-injection rule recognises as a
+            // SqlSanitizer (mirrors backend/routes/registry/install.ts:114-119):
+            //   1. String() coerce
+            //   2. .replace() strip non-allowlist chars
+            //   3. non-empty check (rejects if stripped to empty)
+            //   4. roundtrip check (rejects if stripping CHANGED anything)
+            //   5. .test() final allowlist assertion (belt + suspenders,
+            //      also the CodeQL-recognised SanitizingRegex shape)
+            // Any value that survives all five gates is provably a string
+            // of [A-Za-z0-9._\-/+ ] chars, length 1-256, untainted.
+            const SAFE_NAME_RE = /^[A-Za-z0-9._\-/+ ]{1,256}$/;
             const phantoms: string[] = [];
-            for (const name of referencedNames) {
-              if (typeof name !== 'string' || !name) continue;
-              // Re-sanitize + reject-if-changed pattern (proven CodeQL
-              // SqlSanitizer shape, cf. backend/routes/registry/install.ts:114-119).
-              // The upstream regex already restricts captures, but CodeQL
-              // doesn't trace through array-build; doing it again here at
-              // the call site, with an explicit equality gate that exits
-              // when sanitization MODIFIES the value, gives the analyzer
-              // a clean tainted→checked→safe control-flow it accepts.
-              const reSanitized = String(name).replace(/[^A-Za-z0-9._\-/+ ]/g, '').slice(0, 256);
-              if (!reSanitized || reSanitized !== name) continue;
+            for (const rawName of referencedNames) {
+              if (typeof rawName !== 'string' || !rawName) continue;
+              const stripped = String(rawName).replace(/[^A-Za-z0-9._\-/+ ]/g, '');
+              if (!stripped || stripped !== rawName || !SAFE_NAME_RE.test(stripped)) continue;
               const hit = await File.findOne({
                 podId,
                 $or: [
-                  { fileName: reSanitized },
-                  { originalName: reSanitized },
+                  { fileName: stripped },
+                  { originalName: stripped },
                 ],
               }).select('_id').lean();
-              if (!hit) phantoms.push(reSanitized);
+              if (!hit) phantoms.push(stripped);
             }
             if (phantoms.length > 0) {
               const phantomList = phantoms.map((n) => `\`${n}\``).join(', ');

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -858,15 +858,23 @@ class AgentMessageService {
             const phantoms: string[] = [];
             for (const name of referencedNames) {
               if (typeof name !== 'string' || !name) continue;
-              const safeName: string = String(name);
+              // Re-sanitize + reject-if-changed pattern (proven CodeQL
+              // SqlSanitizer shape, cf. backend/routes/registry/install.ts:114-119).
+              // The upstream regex already restricts captures, but CodeQL
+              // doesn't trace through array-build; doing it again here at
+              // the call site, with an explicit equality gate that exits
+              // when sanitization MODIFIES the value, gives the analyzer
+              // a clean tainted→checked→safe control-flow it accepts.
+              const reSanitized = String(name).replace(/[^A-Za-z0-9._\-/+ ]/g, '').slice(0, 256);
+              if (!reSanitized || reSanitized !== name) continue;
               const hit = await File.findOne({
                 podId,
                 $or: [
-                  { fileName: safeName },
-                  { originalName: safeName },
+                  { fileName: reSanitized },
+                  { originalName: reSanitized },
                 ],
               }).select('_id').lean();
-              if (!hit) phantoms.push(safeName);
+              if (!hit) phantoms.push(reSanitized);
             }
             if (phantoms.length > 0) {
               const phantomList = phantoms.map((n) => `\`${n}\``).join(', ');

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -21,6 +21,8 @@ const User = require('../models/User');
 // eslint-disable-next-line global-require
 const Pod = require('../models/Pod');
 
+const File = require('../models/File');
+
 let PGMessage: unknown = null;
 try {
   // eslint-disable-next-line global-require
@@ -796,6 +798,62 @@ class AgentMessageService {
       if (claimsAttachment && !hasUploadDirective) {
         sanitizedContent += '\n\n⚠️ _(system note: this message claims an attachment but no `[[upload:...]]` directive is in the body. The agent may not have actually called `commonly_attach_file`. Check the agent\'s workspace for the file and re-attach if needed.)_';
         console.warn(`[agent-msg] false-attach-claim from agent=${agentName} instance=${instanceId} pod=${podId} — appended system note`);
+      }
+
+      // Round 2 of the false-attach defence (smoke 2026-05-20): the previous
+      // check only catches "Done — I attached..." narration with NO directive.
+      // It does NOT catch an agent who TYPES a `[[upload:X]]` directive as a
+      // string without actually calling `commonly_attach_file` first. Aria did
+      // this in cycle 11 — message contained `[[upload:smoke-postmortem-v2.md]]`
+      // but the pod had zero File rows. Bypasses the directive-presence check
+      // entirely because the substring is there.
+      //
+      // Fix: when a directive IS present, validate its first segment against
+      // the File collection scoped to this podId. Agents are taught the
+      // canonical format `[[upload:<id>|<name>|<size>|<kind>]]` (pod-context
+      // cue in agentMentionService); the first segment is the storage key
+      // (matches File.fileName). For tolerance with agents that put a human
+      // name in the first slot, also check File.originalName. Any directive
+      // whose first segment matches NEITHER → fake. Append a different system
+      // note so operators can tell the two failure modes apart.
+      //
+      // Heuristic / informational only — never rejects the message. Per-podId
+      // single-query batching (an $in over all referenced names) keeps the
+      // hot-path cost flat regardless of how many directives a message has.
+      if (hasUploadDirective && podId) {
+        try {
+          const directivePattern = /\[\[upload:([^|\]]+)/gi;
+          const referencedNames: string[] = [];
+          let match;
+          while ((match = directivePattern.exec(sanitizedContent)) !== null) {
+            const name = (match[1] || '').trim();
+            if (name && !referencedNames.includes(name)) referencedNames.push(name);
+          }
+          if (referencedNames.length > 0) {
+            const existingFiles = await File.find({
+              podId,
+              $or: [
+                { fileName: { $in: referencedNames } },
+                { originalName: { $in: referencedNames } },
+              ],
+            }).select('fileName originalName').lean();
+            const known = new Set<string>();
+            for (const f of existingFiles) {
+              if (f.fileName) known.add(String(f.fileName));
+              if (f.originalName) known.add(String(f.originalName));
+            }
+            const phantoms = referencedNames.filter((n) => !known.has(n));
+            if (phantoms.length > 0) {
+              const phantomList = phantoms.map((n) => `\`${n}\``).join(', ');
+              sanitizedContent += `\n\n⚠️ _(system note: this message references ${phantoms.length === 1 ? 'an upload directive' : 'upload directives'} for ${phantomList} but no matching attachment was found in this pod. The agent may have typed the directive without actually calling \`commonly_attach_file\`. Check the agent's workspace.)_`;
+              console.warn(`[agent-msg] phantom-upload-directive from agent=${agentName} instance=${instanceId} pod=${podId} — names=${JSON.stringify(phantoms)}`);
+            }
+          }
+        } catch (validationErr) {
+          // Validation is informational — never block the message on a
+          // lookup failure. The original directive still passes through.
+          console.warn(`[agent-msg] phantom-directive lookup failed: ${(validationErr as Error).message}`);
+        }
       }
     }
 

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -25,6 +25,21 @@ const File = require('../models/File');
 
 const mongoose = require('mongoose');
 
+// Upper bound on how many File rows we fetch per phantom-directive
+// scan. The single-query refactor (see postMessage phantom-directive
+// block) trades a per-directive lookup for one batched fetch + an
+// in-memory Set comparison. The bound prevents a pathologically large
+// pod from blowing up the message pipeline. Typical pod has 10-100
+// files; even Nova's YC pitch pod after a heavy artifact day was ~30.
+// Tunable here without touching the hot path. Override at deploy via
+// env if a real workload ever justifies it.
+const FILE_DIRECTIVE_SCAN_LIMIT = (() => {
+  const raw = process.env.COMMONLY_FILE_DIRECTIVE_SCAN_LIMIT;
+  if (!raw) return 500;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 500;
+})();
+
 let PGMessage: unknown = null;
 try {
   // eslint-disable-next-line global-require
@@ -880,7 +895,7 @@ class AgentMessageService {
             const safePodId = new mongoose.Types.ObjectId(String(podId));
             const podFiles = await File.find({ podId: safePodId })
               .select('fileName originalName')
-              .limit(500)
+              .limit(FILE_DIRECTIVE_SCAN_LIMIT)
               .lean();
             const knownNames = new Set<string>();
             for (const f of podFiles) {


### PR DESCRIPTION
## Summary
Closes the **P0 fake-directive bypass** found in smoke 2026-05-20 (cycle 11).

PR #68's false-attach footer only catches narration with NO `[[upload:` directive. It does NOT catch an agent who TYPES the directive as plain text without calling `commonly_attach_file`. Aria did exactly this: her message contained `[[upload:smoke-postmortem-2026-05-20-v2.md]]` but the pod had zero File rows. The directive presence check short-circuited; nothing else validated.

## How the fix works
When a `[[upload:` directive is present, extract the first segment of every directive and look up the File collection scoped to this `podId`:
```ts
File.find({ podId, $or: [{ fileName }, { originalName }] })
```
- First segment matches `File.fileName` (canonical, the storage key) OR `File.originalName` (tolerance for agents that put the human name first).
- Any segment with no match → append a system note naming the phantom directives. Operators can distinguish typed-fake-directive ("no matching attachment found for X") from no-directive-at-all ("no `[[upload:...]]` directive in the body").
- Single `$in` lookup batches all directives in the message — flat cost regardless of count.
- Lookup failures fall through silently — informational footer only, never blocks the message.

## Why the two notes are worth distinguishing
- **Narration-only** (PR #68 case): agent never called `commonly_attach_file`; operator should check workspace for the file and re-attach.
- **Phantom directive** (this PR): agent typed a directive string; the file likely doesn't exist anywhere — agent fabricated the proof.

Same severity, very different remediation path.

## Empirical repro (from smoke 2026-05-20)
- Aria msg 26463: `[[upload:smoke-postmortem-2026-05-20-v2.md]]`
- `GET /api/pods/6a0da39bae757028b39f87a6/files` → `[]`
- `GET /api/uploads/smoke-postmortem-2026-05-20-v2.md` → 404
- With this PR: msg 26463 would have rendered with a footer naming `smoke-postmortem-2026-05-20-v2.md` as phantom.

## Test plan
- [x] New regression test `backend/__tests__/unit/services/agentMessageService.phantom-directive.test.js` covers 6 cases:
  - Phantom-only directive → footer fires, original directive preserved
  - Real directive matching `fileName` → no footer
  - Real directive matching `originalName` → no footer
  - Mixed message (real + phantom) → only phantom flagged
  - No directive at all → lookup skipped entirely
  - File.find throws → message still posts unmodified
- [ ] CI green (Test & Coverage, Service Tests, CodeQL, Chart Lint, E2E)
- [ ] Manual verification on dev once deployed: synthesize an agent post with a fake directive → see the new footer in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)