### PR TITLE
fix(clawdbot): wire GITHUB_PAT into git credential.helper at postStart

### DIFF
--- a/k8s/helm/commonly/templates/agents/clawdbot-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/clawdbot-deployment.yaml
@@ -538,7 +538,46 @@ spec:
               command:
               - /bin/sh
               - -c
-              - mkdir -p /home/node/.codex && cp /state/.codex/auth.json /home/node/.codex/auth.json 2>/dev/null || true
+              # Two unrelated bootstrap steps bundled into one postStart hook
+              # because k8s only allows ONE exec command per lifecycle phase:
+              #
+              # 1. Copy codex auth.json into node user's HOME so the CLI
+              #    can find it on `kubectl exec` invocations.
+              #
+              # 2. Wire GITHUB_PAT into git credential.helper so subagents
+              #    (acpx_run sub-codex invocations, ad-hoc operator
+              #    `kubectl exec ... git clone`) can authenticate against
+              #    private repos. PR #382 plumbed the env var but never
+              #    wired the credential helper — surfaced in smoke
+              #    2026-05-20 when Theo tried `git clone` and got
+              #    `could not read Username for 'https://github.com'`.
+              #    The cloud-codex boot script does the same wiring; this
+              #    is the moltbot-side equivalent so both runtimes are
+              #    consistent. Idempotent — repeated postStart invocations
+              #    (on container restart) rewrite the same file.
+              #    Silent no-op when GITHUB_PAT is empty to keep the hook
+              #    safe across community-tier deployments that ship no
+              #    PAT by design.
+              - |
+                set +e
+                mkdir -p /home/node/.codex
+                cp /state/.codex/auth.json /home/node/.codex/auth.json 2>/dev/null || true
+                if [ -n "${GITHUB_PAT:-}" ]; then
+                  # Trim trailing newline / CR from the PAT — base64-decoded
+                  # secret values often carry a trailing newline that git's
+                  # libcurl refuses to parse ("credential url cannot be
+                  # parsed"), verified empirically on cloud-codex 2026-05-15.
+                  TRIMMED_PAT=$(printf '%s' "${GITHUB_PAT}" | tr -d '\n\r')
+                  printf 'https://x-access-token:%s@github.com\n' "${TRIMMED_PAT}" > /state/.git-credentials
+                  chmod 600 /state/.git-credentials
+                  git config --global credential.helper "store --file=/state/.git-credentials"
+                  git config --global user.name "${GIT_AUTHOR_NAME:-Clawdbot Agent}"
+                  git config --global user.email "${GIT_AUTHOR_EMAIL:-clawdbot@commonly.me}"
+                  echo "[clawdbot postStart] git credentials seeded from GITHUB_PAT"
+                else
+                  echo "[clawdbot postStart] GITHUB_PAT empty — git/gh operations will require interactive auth"
+                fi
+                exit 0
         env:
         # ADR-005 Stage 2: prepend the codex-tools volume to PATH so
         # `codex` and `commonly` are on PATH for operator `kubectl exec`


### PR DESCRIPTION
## Summary
PR #382 plumbed `GITHUB_PAT` into the clawdbot-gateway env var but never wired it into `git`. The env is present (verified: 93 chars), but every `git clone https://...` from inside the pod (subagents, acpx_run, operator `kubectl exec`) fails with:
```
fatal: could not read Username for 'https://github.com'
```

## Repro (from 2026-05-20 smoke cycle 10)
Theo (`openclaw:theo`) was asked to clone `Team-Commonly/clawdbot` to investigate the heartbeat-clobber bug. Got the unauthenticated-clone error. Without git credentials, openclaw agents can never `git clone` / `git push` / `gh` against private repos — blocks any agent-driven repo metadata work.

## Fix
Extend the existing `lifecycle.postStart` hook (already used for the codex auth.json copy) to ALSO write a git credential.helper config when `GITHUB_PAT` is set. Mirrors the cloud-codex boot script's wiring (both runtimes consistent):
- trim trailing newline/CR (libcurl rejects PATs with newlines — verified empirically on cloud-codex 2026-05-15)
- write `/state/.git-credentials` (0600, persists on PVC)
- point `git config --global credential.helper` at that file
- set author identity to `Clawdbot Agent <clawdbot@commonly.me>`

**Silent no-op when `GITHUB_PAT` is empty** — keeps community-tier deployments safe.

**Idempotent** — repeated postStart invocations rewrite the same content.

## Test plan
- [ ] Chart Lint passes (CI)
- [ ] After deploy: `kubectl exec -n commonly-dev deploy/clawdbot-gateway -- git clone https://github.com/Team-Commonly/commonly /tmp/t` succeeds without prompting
- [ ] Manual: ask a moltbot agent (e.g. Nova) to do an `acpx_run -> gh issue list --repo Team-Commonly/commonly` and verify real output (not auth error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)