### PR TITLE
feat(agentMentionService): inline cross-runtime consultation cue

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -481,4 +481,95 @@ describe('AgentMentionService', () => {
     expect(AgentEventService.enqueue).not.toHaveBeenCalled();
     expect(result).toEqual({ enqueued: false, reason: 'sender_is_bot' });
   });
+
+  // ------------------------------------------------------------------
+  // Cross-runtime consultation cue (inline-cue pattern; see service file
+  // for full rationale). Cue is added to chat.mention payload.content for
+  // every NON-specialist agent; specialists (codex/cloud-codex/claude-code)
+  // do not get the cue (recursive consult is noise + loop risk).
+  // ------------------------------------------------------------------
+  describe('cross-runtime consultation cue', () => {
+    test('enqueueMentions adds the consultation cue for an openclaw target', async () => {
+      AgentInstallation.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            agentName: 'openclaw',
+            instanceId: 'aria',
+            displayName: 'Aria',
+          },
+        ]),
+      });
+      AgentProfile.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
+
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-1',
+        message: { content: 'Hi @aria can you help?', id: 'msg-1' },
+        userId: 'user-1',
+        username: 'sam',
+      });
+
+      const enqueuedPayload = AgentEventService.enqueue.mock.calls[0][0].payload;
+      expect(enqueuedPayload.content).toContain('[Pod context: this conversation is in pod `pod-1`');
+      expect(enqueuedPayload.content).toContain('[Collaboration:');
+      expect(enqueuedPayload.content).toContain('commonly_open_dm({ agentName: "codex" })');
+      // Original message body is still present after the cues.
+      expect(enqueuedPayload.content).toContain('Hi @aria can you help?');
+    });
+
+    test('enqueueMentions OMITS the consultation cue for a codex target (recursive consult guard)', async () => {
+      AgentInstallation.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            agentName: 'codex',
+            instanceId: 'cody',
+            displayName: 'Cody',
+          },
+        ]),
+      });
+      AgentProfile.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
+
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-2',
+        message: { content: 'Hi @cody can you debug?', id: 'msg-2' },
+        userId: 'user-1',
+        username: 'sam',
+      });
+
+      const enqueuedPayload = AgentEventService.enqueue.mock.calls[0][0].payload;
+      // Pod context cue still present (every chat.mention gets it).
+      expect(enqueuedPayload.content).toContain('[Pod context: this conversation is in pod `pod-2`');
+      // Consultation cue NOT present — codex is the specialist; would be self-recurse noise.
+      expect(enqueuedPayload.content).not.toContain('[Collaboration:');
+      expect(enqueuedPayload.content).not.toContain('commonly_open_dm');
+    });
+
+    test('enqueueMentions OMITS the consultation cue for a claude-code target', async () => {
+      AgentInstallation.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            agentName: 'claude-code',
+            instanceId: 'default',
+            displayName: 'Claude Code',
+          },
+        ]),
+      });
+      AgentProfile.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
+
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-3',
+        message: { content: 'Hi @claude-code', id: 'msg-3' },
+        userId: 'user-1',
+        username: 'sam',
+      });
+
+      const enqueuedPayload = AgentEventService.enqueue.mock.calls[0][0].payload;
+      expect(enqueuedPayload.content).not.toContain('[Collaboration:');
+    });
+  });
 });

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -350,6 +350,40 @@ const formatPodContextFrame = (podId: string): string =>
   `When reading files referenced via [[upload:fileName|...]] in this thread, call ` +
   `commonly_read_attachment({ fileName }) — it returns the extracted text in one shot.]`;
 
+// Cross-runtime consultation cue. Companion to the pod-context frame
+// above; same rationale (inline cue beats structured metadata per
+// ADR-012 §9 + pod-context-cue precedent + smoke 2026-05-20 evidence
+// that openclaw agents won't autonomously discover collaboration
+// affordances — Pixel's cycle-2 "exec tool is unavailable" was an agent
+// failing to consult anyone for code work she couldn't do alone).
+//
+// Why: openclaw agents stay first-class for routine work, but the
+// heavy-coding runtime (codex CLI + cluster-side shell) lives on
+// cloud-codex / claude-code adapters. For non-trivial code work
+// (writing, debugging, refactoring, repo ops), openclaw agents should
+// consult a specialist in a 1:1 DM rather than refusing capability.
+// `commonly_open_dm` already exists; this cue makes the call shape
+// impossible to overlook.
+//
+// Kept tight (~280 chars / ~70 tokens). Tradeoff: marginal token cost
+// vs. silent under-use of cross-runtime collab.
+//
+// Skipped for events going TO a codex/claude-code agent — they ARE the
+// specialist; telling them to consult themselves is noise + risks loops.
+const formatConsultationCue = (): string =>
+  `[Collaboration: for code-heavy work (writing/debugging/refactoring/repo ops) ` +
+  `you can consult a coding specialist via 1:1 DM. Call ` +
+  `commonly_open_dm({ agentName: "codex" }) — returns a podId — then ` +
+  `commonly_post_message(podId, question). Works when the specialist ` +
+  `is already a peer in one of your shared pods. Skip for non-code asks.]`;
+
+// Agents whose runtime IS a code specialist shouldn't be told to consult
+// themselves — would be noise + risk loop-forming.
+const isCodeSpecialistAgent = (agentName: string | undefined | null): boolean => {
+  const a = String(agentName || '').toLowerCase();
+  return a === 'codex' || a === 'cloud-codex' || a === 'claude-code';
+};
+
 const enqueueMentions = async ({
   podId,
   message,
@@ -361,7 +395,17 @@ const enqueueMentions = async ({
   // (envelope `podId` field alone is insufficient — see frame doc above).
   // Keep the un-framed `rawContent` for the autoJoin path below where we
   // need to scan the original mentions; the frame is added at enqueue time.
-  const content = `${formatPodContextFrame(podId)}\n\n${rawContent}`;
+  //
+  // The consultation cue is target-runtime-aware: code-specialist agents
+  // (codex/cloud-codex/claude-code) don't get it (they ARE the specialist
+  // and recursing would be noise/loop-risk). All others — including every
+  // openclaw moltbot — get it so they know cross-runtime collaboration is
+  // a real option, not a missing capability.
+  const buildContentForTarget = (targetAgentName: string): string => {
+    const base = `${formatPodContextFrame(podId)}\n\n${rawContent}`;
+    if (isCodeSpecialistAgent(targetAgentName)) return base;
+    return `${formatPodContextFrame(podId)}\n${formatConsultationCue()}\n\n${rawContent}`;
+  };
   const source = message?.source || 'chat';
   const eventType = source === 'thread' ? 'thread.mention' : 'chat.mention';
   const rawMentions = extractMentions(rawContent);
@@ -442,7 +486,7 @@ const enqueueMentions = async ({
               messageId: message?._id || message?.id
                 ? String(message?._id || message?.id)
                 : undefined,
-              content,
+              content: buildContentForTarget(directMatch.agentName),
               userId,
               username,
               mentions: rawMentions,
@@ -490,7 +534,7 @@ const enqueueMentions = async ({
                   messageId: message?._id || message?.id
                     ? String(message?._id || message?.id)
                     : undefined,
-                  content,
+                  content: buildContentForTarget(resolved.agentName),
                   userId,
                   username,
                   mentions: rawMentions,
@@ -550,7 +594,7 @@ const enqueueMentions = async ({
                   messageId: message?._id || message?.id
                     ? String(message?._id || message?.id)
                     : undefined,
-                  content,
+                  content: buildContentForTarget(agentType),
                   userId,
                   username,
                   mentions: rawMentions,


### PR DESCRIPTION
## Summary
Adds a tight inline cue to every `chat.mention` payload.content that surfaces the cross-runtime consultation path to non-specialist agents. Pattern follows the reinforced "**inline-cue beats structured metadata**" rule (ADR-012 §9 + the pod-context-cue precedent).

## The cue
```
[Collaboration: for code-heavy work (writing/debugging/refactoring/repo ops)
 you can consult a coding specialist via 1:1 DM. Call
 commonly_open_dm({ agentName: "codex" }) — returns a podId — then
 commonly_post_message(podId, question). Works when the specialist
 is already a peer in one of your shared pods. Skip for non-code asks.]
```

## Why
Smoke 2026-05-20 cycle 2: Pixel refused a real task with *"the local exec tool is unavailable in this session"* — capability denial, not infrastructure missing. The `commonly_open_dm` tool already exists in the openclaw extension; agents just didn't know to reach for it. Without an inline cue, openclaw moltbots either deny capability or struggle alone. Openclaw agents stay first-class — they just now know when to phone a friend.

## Target gating
The cue is **omitted** when the target IS a code specialist (`codex` / `cloud-codex` / `claude-code`). Telling Cody to consult codex is noise and risks self-DM loops. All other agent types (openclaw moltbots, commonly-bot, webhook agents, ad-hoc community agents) get the cue.

Applied at all 3 `enqueueMentions` enqueue paths:
1. Direct match
2. agentName fallback
3. mention-autoJoin

## Token cost
~70 tokens per non-specialist mention. Acceptable trade against silent under-use of cross-runtime collab.

## Test plan
- [x] 3 new tests in `agentMentionService.test.js`:
  - openclaw target → both pod-context AND consultation cues present
  - codex target → pod-context present, consultation cue OMITTED
  - claude-code target → same gating as codex
- [ ] CI green
- [ ] Manual smoke: post `@nova` task in a pod where she shares membership with Cody; check her session shows the cue inline; see if she actually uses `commonly_open_dm` for code work

🤖 Generated with [Claude Code](https://claude.com/claude-code)