### PR TITLE
feat(agentMentionService): inline reply-mechanics cue (heartbeat-clobber mitigation)

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -481,4 +481,79 @@ describe('AgentMentionService', () => {
     expect(AgentEventService.enqueue).not.toHaveBeenCalled();
     expect(result).toEqual({ enqueued: false, reason: 'sender_is_bot' });
   });
+
+  // ------------------------------------------------------------------
+  // Reply-mechanics cue (heartbeat-clobber-mention mitigation; see
+  // formatMentionReplyCue in agentMentionService.ts for full rationale).
+  // Cue added to chat.mention payload ONLY — thread.mention uses a
+  // different reply-posting path and doesn't have the race.
+  // ------------------------------------------------------------------
+  describe('reply-mechanics cue (heartbeat-clobber mitigation)', () => {
+    test('chat.mention payload includes the reply-mechanics cue', async () => {
+      AgentInstallation.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            agentName: 'openclaw',
+            instanceId: 'nova',
+            displayName: 'Nova',
+          },
+        ]),
+      });
+      AgentProfile.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
+
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-mention-1',
+        message: { content: 'Hi @nova', id: 'msg-mention-1' },
+        userId: 'user-1',
+        username: 'sam',
+      });
+
+      const enqueuedEvent = AgentEventService.enqueue.mock.calls[0][0];
+      expect(enqueuedEvent.type).toBe('chat.mention');
+      expect(enqueuedEvent.payload.content).toContain('[Reply mechanics:');
+      expect(enqueuedEvent.payload.content).toContain('commonly_post_message');
+      expect(enqueuedEvent.payload.content).toContain('pod-mention-1');
+      expect(enqueuedEvent.payload.content).toContain('Post-then-stop');
+      // Pod-context cue still present.
+      expect(enqueuedEvent.payload.content).toContain('[Pod context: this conversation is in pod `pod-mention-1`');
+      // Original message preserved.
+      expect(enqueuedEvent.payload.content).toContain('Hi @nova');
+    });
+
+    test('thread.mention payload does NOT include the reply-mechanics cue', async () => {
+      AgentInstallation.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            agentName: 'openclaw',
+            instanceId: 'theo',
+            displayName: 'Theo',
+          },
+        ]),
+      });
+      AgentProfile.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
+
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-thread-1',
+        message: {
+          content: 'Hi @theo',
+          id: 'msg-thread-1',
+          source: 'thread',
+          thread: { postId: 'thread-99', postContent: 'parent post' },
+        },
+        userId: 'user-1',
+        username: 'sam',
+      });
+
+      const enqueuedEvent = AgentEventService.enqueue.mock.calls[0][0];
+      expect(enqueuedEvent.type).toBe('thread.mention');
+      // Reply-mechanics cue omitted for thread.mention — different reply path.
+      expect(enqueuedEvent.payload.content).not.toContain('[Reply mechanics:');
+      // Pod-context cue still present.
+      expect(enqueuedEvent.payload.content).toContain('[Pod context: this conversation is in pod `pod-thread-1`');
+    });
+  });
 });

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -350,6 +350,38 @@ const formatPodContextFrame = (podId: string): string =>
   `When reading files referenced via [[upload:fileName|...]] in this thread, call ` +
   `commonly_read_attachment({ fileName }) — it returns the extracted text in one shot.]`;
 
+// Reply-mechanics cue against the heartbeat-clobbers-mention bug.
+//
+// Smoke 2026-05-20 produced 3 reproductions (Nova c3, Pixel c7, Ops c7):
+// when an openclaw agent processes a chat.mention AND a heartbeat trigger
+// fires in the same model session before the mention reply is committed,
+// the openclaw run-loop's final-turn auto-post emits the heartbeat's
+// HEARTBEAT_OK (the LAST assistant turn) and CLOBBERS the in-flight
+// mention answer. Nova's session log proves this: she produced a 7-row
+// table in assistant content, then her next assistant turn was
+// HEARTBEAT_OK, and the table never landed in pod chat.
+//
+// Upstream fix in the openclaw fork is a larger change (session-key
+// per-event-type, or final-turn selector that prefers mention-reply over
+// heartbeat-reply when both produced output). This inline cue is the
+// kernel-side mitigation: tell the model NOT to rely on the implicit
+// final-turn auto-post; instead, EXPLICITLY call commonly_post_message
+// as soon as the mention answer is ready. Once the reply is committed
+// via tool call, any subsequent heartbeat trigger is harmless.
+//
+// Follows the inline-cue manifest pattern (ADR-012 §9 + pod-context
+// cue precedent). Only added to chat.mention events — heartbeats
+// themselves and thread.mentions don't have the same race shape (the
+// run-loop posts thread.mention replies via a different path).
+const formatMentionReplyCue = (podId: string): string =>
+  `[Reply mechanics: post your reply by calling commonly_post_message(` +
+  `{ podId: "${podId}", content: <your-reply> }) as soon as it's ready, ` +
+  `BEFORE returning your final assistant turn. Do NOT rely on the implicit ` +
+  `final-turn auto-post — a heartbeat trigger arriving mid-session can ` +
+  `overwrite your final turn with HEARTBEAT_OK and your reply will never ` +
+  `reach the pod (openclaw heartbeat-clobber-mention bug, 3 reproductions ` +
+  `2026-05-20). Post-then-stop is the safe sequence.]`;
+
 const enqueueMentions = async ({
   podId,
   message,
@@ -357,13 +389,21 @@ const enqueueMentions = async ({
   username,
 }: EnqueueMentionsOptions): Promise<EnqueueResult> => {
   const rawContent = message?.content || message?.text || '';
-  // Prepend the pod-context cue so the model sees the podId inline
-  // (envelope `podId` field alone is insufficient — see frame doc above).
-  // Keep the un-framed `rawContent` for the autoJoin path below where we
-  // need to scan the original mentions; the frame is added at enqueue time.
-  const content = `${formatPodContextFrame(podId)}\n\n${rawContent}`;
   const source = message?.source || 'chat';
   const eventType = source === 'thread' ? 'thread.mention' : 'chat.mention';
+  // Prepend the pod-context cue so the model sees the podId inline
+  // (envelope `podId` field alone is insufficient — see frame doc above).
+  // For chat.mention events ALSO prepend the reply-mechanics cue to
+  // mitigate the heartbeat-clobbers-mention bug (see frame doc above).
+  // thread.mention replies go through a different posting path on the
+  // openclaw side (thread comments aren't subject to the same final-turn
+  // auto-post race), so the cue would just be noise there.
+  // Keep the un-framed `rawContent` for the autoJoin path below where we
+  // need to scan the original mentions; the frame is added at enqueue time.
+  const replyCue = eventType === 'chat.mention'
+    ? `${formatMentionReplyCue(podId)}\n`
+    : '';
+  const content = `${formatPodContextFrame(podId)}\n${replyCue}\n${rawContent}`;
   const rawMentions = extractMentions(rawContent);
   if (!podId || rawMentions.length === 0) {
     return { enqueued: [], skipped: [] };


### PR DESCRIPTION
## Summary
Kernel-side mitigation for the **openclaw heartbeat-clobbers-mention bug** (3 reproductions in smoke 2026-05-20: Nova c3, Pixel c7, Ops c7). Adds a tight inline cue to every `chat.mention` payload.content telling the model to commit its reply via explicit `commonly_post_message` BEFORE returning its final assistant turn.

## The bug
When an openclaw agent processes a `chat.mention` AND a heartbeat trigger fires in the same model session before the mention reply is committed, the openclaw run-loop's final-turn auto-post emits the heartbeat's `HEARTBEAT_OK` (the LAST assistant turn) and **clobbers the in-flight mention answer**. Nova's session log proves it: she produced a 7-row table in assistant content, her next assistant turn was `HEARTBEAT_OK`, and the table never landed in chat.

## The cue
```
[Reply mechanics: post your reply by calling commonly_post_message(
 { podId: "...", content: <your-reply> }) as soon as it's ready,
 BEFORE returning your final assistant turn. Do NOT rely on the
 implicit final-turn auto-post — a heartbeat trigger arriving
 mid-session can overwrite your final turn with HEARTBEAT_OK and
 your reply will never reach the pod (openclaw heartbeat-clobber-
 mention bug, 3 reproductions 2026-05-20). Post-then-stop is the
 safe sequence.]
```

## Scoping
Added ONLY to `chat.mention` events. `thread.mention` replies post via a different path on the openclaw side (thread comments aren't subject to the same final-turn auto-post race), so the cue would be noise there.

## Why not upstream fix
Upstream fix in the openclaw fork is a larger change (session-key per-event-type, OR a final-turn selector that prefers mention-reply over heartbeat-reply when both produced output). That's worth doing, but this kernel-side mitigation is independent — it works even if the model is the only thing that changes behavior. Once committed via tool call, the heartbeat trigger is harmless.

## Token cost
~80 tokens per chat.mention. Tradeoff is acceptable against silent-loss of mention replies — the smoke had 3 cases where good answers vanished.

## Test plan
- [x] 2 new tests in `agentMentionService.test.js`:
  - `chat.mention` payload includes both pod-context AND reply-mechanics cues, original message preserved
  - `thread.mention` payload includes pod-context only (reply-mechanics OMITTED)
- [ ] CI green
- [ ] Manual smoke: after deploy, post `@nova` task; check her session log for the cue inline; verify she calls `commonly_post_message` explicitly (not relying on auto-post)

## Merge-order note
Textually overlaps with PR #416 (cross-runtime consultation cue, same function file). Both touch the content-build expression in `enqueueMentions`. Whichever lands second needs a small rebase to compose both cues — they're independent in intent and can stack cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)