### PR TITLE
feat(presets): add cross-runtime consultation section to dev-agent heartbeat templates

### DIFF
--- a/backend/routes/registry/presets.ts
+++ b/backend/routes/registry/presets.ts
@@ -1281,6 +1281,19 @@ If nothing changed → no post.
 - Skip sender "theo" — that's you.
 - Auto-source from GitHub when idle — don't wait for humans to assign work.
 - If tools unavailable → \`HEARTBEAT_OK\` immediately.
+
+## Consultation — when to phone a code specialist
+
+You're a first-class agent for routine work. When something needs heavy
+code reasoning (deep repo investigation, multi-file refactor, niche
+language tooling), CONSULT a codex/claude-code specialist via 1:1 DM.
+This is collaboration, NOT delegation — you stay the task owner.
+
+Flow: \`commonly_open_dm({ agentName: "codex" })\` returns a podId, then
+\`commonly_post_message(podId, "<self-contained question>")\`. The
+specialist replies in the DM; you'll see it on a later heartbeat tick.
+
+Use this when YOUR own tools have hit their limit. Skip otherwise.
 `,
     defaultSkills: [
       { id: 'github', reason: 'PR/repo operations and source control context.' },
@@ -1713,6 +1726,19 @@ For any message asking about frontend components, UI status, implementation deci
 - Never push to main — always PR.
 - Skip sender "pixel" — that's you.
 - If tools unavailable → \`HEARTBEAT_OK\` immediately.
+
+## Consultation — when to phone a code specialist
+
+You're a first-class agent for routine work. When something needs heavy
+code reasoning (deep repo investigation, multi-file refactor, niche
+language tooling), CONSULT a codex/claude-code specialist via 1:1 DM.
+This is collaboration, NOT delegation — you stay the task owner.
+
+Flow: \`commonly_open_dm({ agentName: "codex" })\` returns a podId, then
+\`commonly_post_message(podId, "<self-contained question>")\`. The
+specialist replies in the DM; you'll see it on a later heartbeat tick.
+
+Use this when YOUR own tools have hit their limit. Skip otherwise.
 `,
     defaultSkills: [
       { id: 'github', reason: 'PR/repo operations, issue context, source control.' },
@@ -1946,6 +1972,19 @@ For any message asking about infrastructure status, deployment decisions, CI/CD 
 - Zero-downtime deployment strategies mandatory.
 - Skip sender "ops" — that's you.
 - If tools unavailable → \`HEARTBEAT_OK\` immediately.
+
+## Consultation — when to phone a code specialist
+
+You're a first-class agent for routine work. When something needs heavy
+code reasoning (deep repo investigation, multi-file refactor, niche
+language tooling), CONSULT a codex/claude-code specialist via 1:1 DM.
+This is collaboration, NOT delegation — you stay the task owner.
+
+Flow: \`commonly_open_dm({ agentName: "codex" })\` returns a podId, then
+\`commonly_post_message(podId, "<self-contained question>")\`. The
+specialist replies in the DM; you'll see it on a later heartbeat tick.
+
+Use this when YOUR own tools have hit their limit. Skip otherwise.
 `,
     defaultSkills: [
       { id: 'github', reason: 'PR/repo operations, issue context, source control.' },


### PR DESCRIPTION
## Summary
Adds a tight **Consultation — when to phone a code specialist** section to the heartbeat templates of theo (dev-pm), pixel (frontend-engineer), and ops (devops-engineer). Nova (backend-engineer) already has an elaborate delegation pattern via `sam-local-codex`, untouched here.

## Why this framing matters
Per the user-reinforced strategic frame: openclaw agents stay **first-class** for routine work. They **consult** codex/claude-code specialists via 1:1 DM only when their own tools hit a limit. This is **collaboration, NOT delegation** — the openclaw agent stays the task owner.

## The added section
```
## Consultation — when to phone a code specialist

You're a first-class agent for routine work. When something needs heavy
code reasoning (deep repo investigation, multi-file refactor, niche
language tooling), CONSULT a codex/claude-code specialist via 1:1 DM.
This is collaboration, NOT delegation — you stay the task owner.

Flow: `commonly_open_dm({ agentName: "codex" })` returns a podId, then
`commonly_post_message(podId, "<self-contained question>")`. The
specialist replies in the DM; you'll see it on a later heartbeat tick.

Use this when YOUR own tools have hit their limit. Skip otherwise.
```

## Composes with PR #416
[PR #416](https://github.com/Team-Commonly/commonly/pull/416) adds the same flow as an inline cue in `chat.mention.payload.content` (covering the @-mention case). This PR covers the autonomous-heartbeat case via HEARTBEAT.md template. Together they surface the same `commonly_open_dm` → `commonly_post_message` pattern across both trigger types.

## Propagation
Per `registry.js`-is-source-of-truth: fresh installs pick this up immediately on next install; `reprovision-all` propagates to existing installs whose `config.customizations.heartbeat` is not set. Existing dev agents with curated HEARTBEAT.md (e.g. live theo/pixel/ops on dev) keep their version unless force-overridden.

## Why Nova is untouched
Her current `soulTemplate` + `heartbeatTemplate` describe an elaborate sam-local-codex delegation flow (claim → DM → next-tick parse → mark complete/blocked). Rewriting that wholesale would conflict with the smaller scope here. A future PR can either align Nova to the consultation framing OR keep her as the documented delegation reference — that's a separate strategic call.

## Test plan
- [ ] CI green (no test changes needed — pure template content)
- [ ] After deploy + reprovision: verify a heartbeat-triggered Theo/Pixel/Ops session sees the new section in its HEARTBEAT.md
- [ ] Manual smoke: observe whether agents start invoking `commonly_open_dm` for code questions vs. silently refusing

🤖 Generated with [Claude Code](https://claude.com/claude-code)