### PR TITLE
feat(agentMentionService): unified inline cue composition (supersedes #416 + #417)

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -481,4 +481,113 @@ describe('AgentMentionService', () => {
     expect(AgentEventService.enqueue).not.toHaveBeenCalled();
     expect(result).toEqual({ enqueued: false, reason: 'sender_is_bot' });
   });
+
+  // ------------------------------------------------------------------
+  // Inline-cue composition (consultation + reply-mechanics) — verifies
+  // the 4-way matrix: chat-vs-thread × specialist-vs-not.
+  //   chat.mention + non-specialist  → [Pod] [Collab] [Reply] body
+  //   chat.mention + specialist      → [Pod] [Reply] body
+  //   thread.mention + non-specialist→ [Pod] [Collab] body
+  //   thread.mention + specialist    → [Pod] body
+  // See buildContentForTarget in agentMentionService.ts for full
+  // rationale + invariants.
+  // ------------------------------------------------------------------
+  describe('inline cue composition (consultation + reply-mechanics)', () => {
+    const setupForAgent = ({ agentName, instanceId, displayName }) => {
+      AgentInstallation.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([{ agentName, instanceId, displayName }]),
+      });
+      AgentProfile.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
+    };
+    const lastPayload = () => AgentEventService.enqueue.mock.calls[0][0];
+
+    test('chat.mention + openclaw (non-specialist) → pod + consultation + reply-mechanics', async () => {
+      setupForAgent({ agentName: 'openclaw', instanceId: 'nova', displayName: 'Nova' });
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-mention-1',
+        message: { content: 'Hi @nova', id: 'msg-1' },
+        userId: 'user-1',
+        username: 'sam',
+      });
+      const ev = lastPayload();
+      expect(ev.type).toBe('chat.mention');
+      expect(ev.payload.content).toContain('[Pod context:');
+      expect(ev.payload.content).toContain('[Collaboration:');
+      expect(ev.payload.content).toContain('[Reply mechanics:');
+      expect(ev.payload.content).toContain('Hi @nova');
+    });
+
+    test('chat.mention + codex (specialist) → pod + reply-mechanics, NO consultation', async () => {
+      setupForAgent({ agentName: 'codex', instanceId: 'cody', displayName: 'Cody' });
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-mention-2',
+        message: { content: 'Hi @cody', id: 'msg-2' },
+        userId: 'user-1',
+        username: 'sam',
+      });
+      const ev = lastPayload();
+      expect(ev.type).toBe('chat.mention');
+      expect(ev.payload.content).toContain('[Pod context:');
+      expect(ev.payload.content).not.toContain('[Collaboration:');
+      // chat.mention always gets reply-mechanics regardless of specialist
+      // status — heartbeat-clobber affects all openclaw event paths; cloud-
+      // codex runs codex CLI which posts via the same path, so the rule
+      // is fine to apply uniformly to chat.mention.
+      expect(ev.payload.content).toContain('[Reply mechanics:');
+    });
+
+    test('thread.mention + openclaw (non-specialist) → pod + consultation, NO reply-mechanics', async () => {
+      setupForAgent({ agentName: 'openclaw', instanceId: 'theo', displayName: 'Theo' });
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-thread-1',
+        message: {
+          content: 'Hi @theo',
+          id: 'msg-3',
+          source: 'thread',
+          thread: { postId: 'thread-99', postContent: 'parent post' },
+        },
+        userId: 'user-1',
+        username: 'sam',
+      });
+      const ev = lastPayload();
+      expect(ev.type).toBe('thread.mention');
+      expect(ev.payload.content).toContain('[Pod context:');
+      expect(ev.payload.content).toContain('[Collaboration:');
+      // Thread replies post via a different openclaw path — no clobber race.
+      expect(ev.payload.content).not.toContain('[Reply mechanics:');
+    });
+
+    test('thread.mention + codex (specialist) → pod only, no consultation or reply-mechanics', async () => {
+      setupForAgent({ agentName: 'codex', instanceId: 'cody', displayName: 'Cody' });
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-thread-2',
+        message: {
+          content: 'Hi @cody',
+          id: 'msg-4',
+          source: 'thread',
+          thread: { postId: 'thread-100', postContent: 'parent post' },
+        },
+        userId: 'user-1',
+        username: 'sam',
+      });
+      const ev = lastPayload();
+      expect(ev.type).toBe('thread.mention');
+      expect(ev.payload.content).toContain('[Pod context:');
+      expect(ev.payload.content).not.toContain('[Collaboration:');
+      expect(ev.payload.content).not.toContain('[Reply mechanics:');
+    });
+
+    test('claude-code is also treated as a specialist (cross-runtime parity)', async () => {
+      setupForAgent({ agentName: 'claude-code', instanceId: 'default', displayName: 'Claude Code' });
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-cc-1',
+        message: { content: 'Hi @claude-code', id: 'msg-5' },
+        userId: 'user-1',
+        username: 'sam',
+      });
+      expect(lastPayload().payload.content).not.toContain('[Collaboration:');
+    });
+  });
 });

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -350,6 +350,93 @@ const formatPodContextFrame = (podId: string): string =>
   `When reading files referenced via [[upload:fileName|...]] in this thread, call ` +
   `commonly_read_attachment({ fileName }) — it returns the extracted text in one shot.]`;
 
+// Cross-runtime consultation cue. Companion to the pod-context frame
+// above; same rationale (inline cue beats structured metadata per
+// ADR-012 §9 + pod-context-cue precedent + smoke 2026-05-20 evidence
+// that openclaw agents won't autonomously discover collaboration
+// affordances — Pixel's cycle-2 "exec tool is unavailable" was an
+// agent failing to consult anyone for code work she couldn't do alone).
+//
+// Openclaw agents stay first-class; the heavy-coding runtime lives on
+// cloud-codex / claude-code adapters. For non-trivial code work
+// (writing, debugging, refactoring, repo ops), openclaw agents should
+// consult a specialist via 1:1 DM instead of refusing capability.
+// commonly_open_dm already exists in the openclaw extension; this cue
+// makes the call shape impossible to overlook.
+//
+// Token cost: ~70 per mention. Skipped for events going TO a
+// code specialist (recursive consult is noise + loop risk).
+const formatConsultationCue = (): string =>
+  `[Collaboration: for code-heavy work (writing/debugging/refactoring/repo ops) ` +
+  `you can consult a coding specialist via 1:1 DM. Call ` +
+  `commonly_open_dm({ agentName: "codex" }) — returns a podId — then ` +
+  `commonly_post_message(podId, question). Works when the specialist ` +
+  `is already a peer in one of your shared pods (if you get a 403, ` +
+  `they're not — skip). Skip for non-code asks.]`;
+
+// Reply-mechanics cue against the openclaw heartbeat-clobbers-mention
+// bug. Smoke 2026-05-20 produced 3 reproductions (Nova c3, Pixel c7,
+// Ops c7): when an agent processes a chat.mention AND a heartbeat
+// trigger fires in the same model session before the mention reply is
+// committed, the openclaw run-loop's final-turn auto-post emits
+// HEARTBEAT_OK (the LAST assistant turn) and CLOBBERS the in-flight
+// mention answer. Nova's session log proves it — she produced a 7-row
+// table in assistant content, her next assistant turn was
+// HEARTBEAT_OK, and the table never landed in pod chat.
+//
+// Upstream fix in the openclaw fork is a larger change. This kernel-
+// side mitigation: tell the model NOT to rely on the implicit final-
+// turn auto-post; instead, EXPLICITLY call commonly_post_message as
+// soon as the mention answer is ready. Once committed via tool call,
+// any subsequent heartbeat trigger is harmless.
+//
+// chat.mention only — thread.mention replies post via a different
+// path (thread comments aren't subject to the same final-turn auto-
+// post race), so the cue would be noise there.
+const formatMentionReplyCue = (podId: string): string =>
+  `[Reply mechanics: post your reply by calling commonly_post_message(` +
+  `{ podId: "${podId}", content: <your-reply> }) as soon as it's ready, ` +
+  `BEFORE returning your final assistant turn. Do NOT rely on the implicit ` +
+  `final-turn auto-post — a heartbeat trigger arriving mid-session can ` +
+  `overwrite your final turn with HEARTBEAT_OK and your reply will never ` +
+  `reach the pod (openclaw heartbeat-clobber-mention bug, 3 reproductions ` +
+  `2026-05-20). Post-then-stop is the safe sequence.]`;
+
+// Agents whose runtime IS a code specialist shouldn't be told to consult
+// themselves — would be noise + risk loop-forming.
+const isCodeSpecialistAgent = (agentName: string | undefined | null): boolean => {
+  const a = String(agentName || '').toLowerCase();
+  return a === 'codex' || a === 'cloud-codex' || a === 'claude-code';
+};
+
+// Compose the payload.content prefix per event type AND target runtime.
+// All chat.mention events get a reply-mechanics cue (heartbeat-clobber
+// mitigation); thread.mention events skip it. All non-specialist targets
+// get a consultation cue (cross-runtime collab nudge); specialists skip
+// it. Both pieces compose with the pod-context cue that fires for
+// every mention.
+//
+// Final shapes:
+//   chat.mention + non-specialist  → [Pod] [Collab] [Reply] body
+//   chat.mention + specialist      → [Pod] [Reply] body
+//   thread.mention + non-specialist→ [Pod] [Collab] body
+//   thread.mention + specialist    → [Pod] body
+const buildContentForTarget = (
+  podId: string,
+  rawContent: string,
+  eventType: 'chat.mention' | 'thread.mention',
+  targetAgentName: string,
+): string => {
+  const frames: string[] = [formatPodContextFrame(podId)];
+  if (!isCodeSpecialistAgent(targetAgentName)) {
+    frames.push(formatConsultationCue());
+  }
+  if (eventType === 'chat.mention') {
+    frames.push(formatMentionReplyCue(podId));
+  }
+  return `${frames.join('\n')}\n\n${rawContent}`;
+};
+
 const enqueueMentions = async ({
   podId,
   message,
@@ -357,13 +444,12 @@ const enqueueMentions = async ({
   username,
 }: EnqueueMentionsOptions): Promise<EnqueueResult> => {
   const rawContent = message?.content || message?.text || '';
-  // Prepend the pod-context cue so the model sees the podId inline
-  // (envelope `podId` field alone is insufficient — see frame doc above).
-  // Keep the un-framed `rawContent` for the autoJoin path below where we
-  // need to scan the original mentions; the frame is added at enqueue time.
-  const content = `${formatPodContextFrame(podId)}\n\n${rawContent}`;
   const source = message?.source || 'chat';
-  const eventType = source === 'thread' ? 'thread.mention' : 'chat.mention';
+  const eventType: 'chat.mention' | 'thread.mention' = source === 'thread' ? 'thread.mention' : 'chat.mention';
+  // Per-target content composition: see buildContentForTarget above for
+  // the four-case matrix (chat-vs-thread × specialist-vs-not). Each
+  // enqueue site below passes its own `targetAgentName` so the cue
+  // composition is correct for that target's runtime.
   const rawMentions = extractMentions(rawContent);
   if (!podId || rawMentions.length === 0) {
     return { enqueued: [], skipped: [] };
@@ -442,7 +528,7 @@ const enqueueMentions = async ({
               messageId: message?._id || message?.id
                 ? String(message?._id || message?.id)
                 : undefined,
-              content,
+              content: buildContentForTarget(podId, rawContent, eventType, directMatch.agentName),
               userId,
               username,
               mentions: rawMentions,
@@ -490,7 +576,7 @@ const enqueueMentions = async ({
                   messageId: message?._id || message?.id
                     ? String(message?._id || message?.id)
                     : undefined,
-                  content,
+                  content: buildContentForTarget(podId, rawContent, eventType, resolved.agentName),
                   userId,
                   username,
                   mentions: rawMentions,
@@ -550,7 +636,7 @@ const enqueueMentions = async ({
                   messageId: message?._id || message?.id
                     ? String(message?._id || message?.id)
                     : undefined,
-                  content,
+                  content: buildContentForTarget(podId, rawContent, eventType, agentType),
                   userId,
                   username,
                   mentions: rawMentions,


### PR DESCRIPTION
## Summary
Supersedes [#416](https://github.com/Team-Commonly/commonly/pull/416) (consultation cue) and [#417](https://github.com/Team-Commonly/commonly/pull/417) (reply-mechanics cue) per code-review feedback. Those two PRs both replaced the same `const content = ...` line in `enqueueMentions` — whichever landed second would hit a guaranteed merge conflict. Plus #416 didn't gate on `eventType`, so `thread.mention` events erroneously got the consultation cue.

This PR composes both cues in one place with explicit per-event-type gating.

## Composition matrix (the cue layering rules)
| Event type | Target | Cues prepended |
|------------|--------|-----------------|
| `chat.mention` | non-specialist (openclaw, etc.) | Pod-context + Consultation + Reply-mechanics |
| `chat.mention` | specialist (codex / cloud-codex / claude-code) | Pod-context + Reply-mechanics (skip consultation — recursive self-consult is noise + loop risk) |
| `thread.mention` | non-specialist | Pod-context + Consultation (skip reply-mechanics — thread replies post via a different openclaw path with no clobber race) |
| `thread.mention` | specialist | Pod-context only |

## API
```ts
buildContentForTarget(podId, rawContent, eventType, targetAgentName)
```
Single helper called from all 3 `enqueueMentions` enqueue sites (direct-match, agentName fallback, mention-autoJoin).

## Tests
5 cases in `agentMentionService.test.js`:
- chat.mention + openclaw → all three cues present
- chat.mention + codex → pod + reply, NO consultation
- thread.mention + openclaw → pod + consultation, NO reply-mechanics
- thread.mention + codex → pod only
- claude-code parity (specialist gating works for claude-code too)

## What's borrowed from #416 / #417 (now superseded)
- `formatConsultationCue()` and `isCodeSpecialistAgent()` from #416
- `formatMentionReplyCue(podId)` from #417
- Both PRs' rationale text preserved in inline comments
- Reviewer's softening of the 403 case ("if you get a 403, they're not [a peer] — skip") is incorporated

## Token cost
Per-event:
- chat.mention + non-specialist: ~150 tokens (3 cues × ~50)
- chat.mention + specialist: ~120 tokens (2 cues)
- thread.mention + non-specialist: ~120 tokens (2 cues)
- thread.mention + specialist: ~70 tokens (1 cue, unchanged)

## Action for #416 + #417
Once this PR is reviewed + merged, close #416 and #417 with a "superseded by #420" comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)