### PR TITLE
chore(clawdbot): document GIT_AUTHOR_NAME/EMAIL fallback intent

### DIFF
--- a/k8s/helm/commonly/templates/agents/clawdbot-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/clawdbot-deployment.yaml
@@ -571,6 +571,19 @@ spec:
                   printf 'https://x-access-token:%s@github.com\n' "${TRIMMED_PAT}" > /state/.git-credentials
                   chmod 600 /state/.git-credentials
                   git config --global credential.helper "store --file=/state/.git-credentials"
+                  # GIT_AUTHOR_NAME / GIT_AUTHOR_EMAIL are read from the
+                  # container env if present, otherwise default to the
+                  # generic Clawdbot identity. They're NOT declared in the
+                  # `env:` block below by design — there's currently no per-
+                  # agent author override flowing through Helm values. If
+                  # operators ever want to override (e.g. per-instanceId
+                  # author for clearer commit attribution), add them to
+                  # the env: block as plain `value:` entries OR wire them
+                  # through `values.yaml` -> `.Values.agents.clawdbot.git.authorName`.
+                  # The fallbacks below keep the generic identity as the
+                  # safe default — git commits + PR opens attribute to
+                  # "Clawdbot Agent <clawdbot@commonly.me>" without
+                  # additional configuration.
                   git config --global user.name "${GIT_AUTHOR_NAME:-Clawdbot Agent}"
                   git config --global user.email "${GIT_AUTHOR_EMAIL:-clawdbot@commonly.me}"
                   echo "[clawdbot postStart] git credentials seeded from GITHUB_PAT"


### PR DESCRIPTION
## Summary
Code-reviewer follow-up on PR #414. The reviewer asked whether `GIT_AUTHOR_NAME` and `GIT_AUTHOR_EMAIL` (referenced in the postStart hook as `${GIT_AUTHOR_NAME:-Clawdbot Agent}`) are expected to be set externally, or wired through the deployment template.

**Answer**: there's currently no per-agent author override path. The shell fallbacks (`Clawdbot Agent` / `clawdbot@commonly.me`) are the intended default — every clawdbot pod commits as the generic Clawdbot identity.

This PR adds an inline comment documenting that:
- The two vars are deliberately NOT in the deployment template's `env:` block.
- Operators who want per-agent overrides have two paths spelled out (env: literal, or wire through `values.yaml`).
- No behavioral change in this PR.

## Test plan
- [ ] CI green (comment-only change, no logic touched)
- [ ] Helm `chart-lint` happy (it should be — just YAML comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)