### PR TITLE
fix(install): enrich displayName-lookup log with agentName/instanceId

### DIFF
--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -281,7 +281,14 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
         }
       } catch (lookupErr) {
         // Non-fatal — fall through to registry default below.
-        console.warn('[install] displayName lookup failed:', (lookupErr as Error).message);
+        // Log with agent identity so an operator chasing "wrong
+        // displayName on reinstall" can correlate the install attempt
+        // to the agent it failed for, instead of just seeing a bare
+        // Mongoose error.
+        console.warn(
+          `[install] displayName lookup failed for ${agent.agentName}:${normalizedInstanceId}:`,
+          (lookupErr as Error).message,
+        );
       }
     }
     if (!effectiveDisplayName) {
@@ -410,7 +417,11 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
         } catch (lookupErr: unknown) {
           // Fall back to the legacy chain if the identity lookup blew up —
           // don't take down the intro flow on a transient mongo hiccup.
-          console.warn('[install] intro displayName lookup failed:', (lookupErr as Error).message);
+          // Log with agent identity for operator correlation.
+          console.warn(
+            `[install] intro displayName lookup failed for ${agent.agentName}:${normalizedInstanceId}:`,
+            (lookupErr as Error).message,
+          );
           displayName = installation.displayName || agent.displayName;
         }
         const blurb = (agent.description || '').trim().replace(/\s+/g, ' ');

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -285,10 +285,15 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
         // displayName on reinstall" can correlate the install attempt
         // to the agent it failed for, instead of just seeing a bare
         // Mongoose error.
-        console.warn(
-          `[install] displayName lookup failed for ${agent.agentName}:${normalizedInstanceId}:`,
-          (lookupErr as Error).message,
-        );
+        // Structured args (object) instead of template-literal in the
+        // format string — CodeQL's js/format-string-injection flags
+        // user-tainted values in the format-string slot. Same diagnostic
+        // payload, just shaped to keep the analyzer happy.
+        console.warn('[install] displayName lookup failed', {
+          agent: agent.agentName,
+          instance: normalizedInstanceId,
+          error: (lookupErr as Error).message,
+        });
       }
     }
     if (!effectiveDisplayName) {
@@ -418,10 +423,12 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
           // Fall back to the legacy chain if the identity lookup blew up —
           // don't take down the intro flow on a transient mongo hiccup.
           // Log with agent identity for operator correlation.
-          console.warn(
-            `[install] intro displayName lookup failed for ${agent.agentName}:${normalizedInstanceId}:`,
-            (lookupErr as Error).message,
-          );
+          // Same CodeQL-safe shape as the install-path log above.
+          console.warn('[install] intro displayName lookup failed', {
+            agent: agent.agentName,
+            instance: normalizedInstanceId,
+            error: (lookupErr as Error).message,
+          });
           displayName = installation.displayName || agent.displayName;
         }
         const blurb = (agent.description || '').trim().replace(/\s+/g, ' ');


### PR DESCRIPTION
## Summary
Code-reviewer follow-up on PR #412.

Both `console.warn` lines in the displayName-lookup catch branches logged a bare Mongoose error message with no hint about WHICH agent the lookup was attempting. An operator diagnosing a 'wrong displayName on reinstall' incident has to cross-reference timestamps to figure out the install path.

Now both lines append `${agent.agentName}:${normalizedInstanceId}`:
- install-path lookup (line ~284 — the path #412 added)
- intro-path lookup (line ~420 — the path PR #408 added; reused for symmetry)

No behavioral change — strictly diagnostic enrichment.

## Test plan
- [ ] CI green (no logic touched; existing tests still cover both code paths)
- [ ] Manual: trigger a `User.findOne` failure on the install path; verify log line includes the agent identifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)