### PR TITLE
fix(scripts): byo-* test pods leak past cutoff filter (a2a-DM list pollution)

### DIFF
--- a/scripts/reset-demo-account.sh
+++ b/scripts/reset-demo-account.sh
@@ -141,7 +141,17 @@ m.connect(process.env.MONGO_URI).then(async ()=>{
   const KEEP_DM_IDS = ['6a01a1ffcf199a9aed01d9d1'];
   const roomRes = await Pod.deleteMany({ type: 'agent-room', createdAt: { \$gt: cutoff }, name: { \$nin: ['Nova', 'Pixel', 'Cody'] } });
   const dmRes = await Pod.deleteMany({ type: 'agent-dm', createdAt: { \$gt: cutoff }, _id: { \$nin: KEEP_DM_IDS.map(id => m.Types.ObjectId.createFromHexString(id)) } });
-  console.log(roomRes.deletedCount + dmRes.deletedCount);
+  // Belt-and-braces: a name-pattern sweep that runs INDEPENDENT of the
+  // cutoff. Catches byo-* test residue that pre-dates cutoff (the
+  // 2026-05-13 BYO smoke run leaked 18 agent-dm pods named
+  // \`byo-smoke-<unix-ts>\` that the cutoff-only filter never touched,
+  // surfaced 2026-05-21 in the V2 inspector's a2a-DMs panel). These
+  // pods are always test artifacts regardless of age — the byo-*
+  // username prefix is reserved for the self-serve install smoke
+  // (scripts/smoke-test-demo.sh:252 b3_name="byo-smoke-\$(date +%s)").
+  const byoRoomRes = await Pod.deleteMany({ type: 'agent-room', name: /^byo-/ });
+  const byoDmRes = await Pod.deleteMany({ type: 'agent-dm', name: /^byo-/, _id: { \$nin: KEEP_DM_IDS.map(id => m.Types.ObjectId.createFromHexString(id)) } });
+  console.log(roomRes.deletedCount + dmRes.deletedCount + byoRoomRes.deletedCount + byoDmRes.deletedCount);
   process.exit(0);
 })" 2>/dev/null | tail -1)
 echo "[reset]     deleted $deleted_rooms test pod(s)"


### PR DESCRIPTION
## Summary
User-reported bug 2026-05-21: opening an agent's panel in the V2 inspector showed **18 stale byo-smoke-* agent-dm pods** polluting Cody's Direct Messages list. None of them were real a2a conversations.

## Root cause
- The BYO self-serve install smoke at `scripts/smoke-test-demo.sh:252` creates an agent named `byo-smoke-$(date +%s)`.
- That smoke flow then exercises `/api/agents/runtime/agent-dm`, which spawns an **agent-dm pod** containing the byo agent + Cody.
- The smoke's self-cleanup at the end only DELETEs the AgentInstallation, NOT the separate agent-dm pod.
- The reset script's step 4b sweep filters by `createdAt > cutoff` only — anything older than the May 4 cutoff (the 2026-05-13 leak batch was a good 9 days past) was never touched.

## Backend code is fine
The `/api/registry/pods/:podId/agents/:name/a2a-dms` handler (files.ts:366) correctly filters by `type: 'agent-dm'` and `members: agentUser._id`. The bug is stale data, not query logic.

## Fix (this PR)
Add a **name-pattern sweep that runs independent of cutoff** for `agent-room` AND `agent-dm` pods matching `/^byo-/`. The byo-* prefix is reserved for the self-serve install smoke, so anything matching is always test residue regardless of age. KEEP_DM_IDS stays honored (the canonical Nova-Demo↔Cody fixture doesn't match anyway but the guard stays).

## Already done in mongo (operator action, not in this PR)
The 18 live stale pods + 36 orphaned AgentInstallations were deleted via mongo directly (verified zero events/messages referenced them first). This PR ensures future leaks get caught by the next reset run instead.

## Test plan
- [ ] CI green
- [ ] Operator runs `bash scripts/reset-demo-account.sh` against dev next time and observes the deleted-count includes any new byo-* residue
- [ ] V2 inspector → Cody's Direct Messages list stays clean

## Follow-up (separate PR, out of scope here)
Longer-term fix should make the smoke script self-clean its own agent-dm pods on exit (the script knows the agent's identity; one extra DELETE per smoke run avoids the leak entirely). For now the reset script's belt-and-braces sweep is the backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)