### PR TITLE
feat(litellm): Claude Code OAuth pass-through via x-litellm-api-key (replaces #430)

### DIFF
--- a/docs/runbooks/litellm-claude-code.md
+++ b/docs/runbooks/litellm-claude-code.md
@@ -1,54 +1,68 @@
-# LiteLLM Claude Code via Virtual Key
+# LiteLLM Claude Code — OAuth Pass-Through
 
 How both cluster-side (`cloud-claude-code`, future) and operator-laptop
 Claude Code use the Commonly LiteLLM as a stable proxy to
-`api.anthropic.com`, authenticated with a LiteLLM virtual key — the
-same auth pattern every other LiteLLM caller in the cluster uses
-(`cloud-codex`, backend services, dev/community moltbots).
+`api.anthropic.com`, with the caller's OAuth bearer (Max
+subscription) passed through unchanged. Follows the official LiteLLM
+pattern from
+<https://docs.litellm.ai/docs/tutorials/claude_code_max_subscription>.
 
 ## Architecture
 
 ```
 laptop Claude Code ─┐                              ┌─► api.anthropic.com
-                    ├─► litellm-dev.commonly.me ─► LiteLLM ─► (uses cluster's
-cloud-claude-code ──┘  (or http://litellm:4000          ANTHROPIC_API_KEY)
+                    ├─► litellm-dev.commonly.me ─► LiteLLM ─► (forwards caller's
+cloud-claude-code ──┘  (or http://litellm:4000          OAuth bearer unchanged)
                        from inside cluster)
 ```
 
-Caller sends:
+Two headers on the inbound request:
 
-- `Authorization: Bearer sk-<litellm-virtual-key>` — the caller's
-  per-identity LiteLLM virtual key (issued via `/key/generate`,
-  validated against `LiteLLM_VerificationTokenTable`)
-- Standard Anthropic request body (`{"model": "claude-opus-4-7", ...}`)
+- `x-litellm-api-key: Bearer sk-<litellm-virtual-key>` — proxy auth,
+  validated against `LiteLLM_VerificationTokenTable`, applies per-key
+  limits (rpm/tpm/spend, allowed models, etc.). Set client-side via
+  `ANTHROPIC_CUSTOM_HEADERS`.
+- `Authorization: Bearer sk-ant-oat01-*` — the caller's own Claude
+  Code OAuth bearer. Forwarded unchanged to `api.anthropic.com` via
+  `general_settings.forward_client_headers_to_llm_api: true` so the
+  call bills against the caller's Max subscription, not against any
+  cluster-owned key.
 
-LiteLLM validates the key, applies any per-key limits (rpm/tpm/spend,
-allowed models, etc.), then forwards the request to
-`api.anthropic.com` using the cluster's own `ANTHROPIC_API_KEY` (set
-on the litellm Deployment env, populated from the `api-keys` secret
-via ESO).
+The split-header pattern is what makes `master_key` + OAuth
+coexist: proxy auth lives in `x-litellm-api-key`, leaving
+`Authorization` free for the upstream OAuth bearer. (PR #428 tried
+to put both in `Authorization` and master_key consumed the bearer
+before it could be forwarded — fixed by switching to the
+custom-header pattern.)
 
 The four `claude-*` model entries in
 `k8s/helm/commonly/templates/configmaps/litellm-config.yaml` declare
-the routing. No `forward_*_headers` flags — the proxy substitutes its
-own upstream credential, which is the standard LiteLLM operating
-mode.
+the routing. They have **no `api_key` fallback** — every caller must
+bring its own credential (OAuth bearer or `x-api-key` for BYOK
+mode). A global fallback would mask credential bugs as silent
+upstream 401s and defeat per-caller billing attribution.
 
 ## Configuration
 
 ### Operator-laptop Claude Code
 
-Point local Claude Code at the cluster proxy with a virtual key.
+Claude Code reads its OAuth bearer from `~/.claude/.credentials.json`
+(or macOS Keychain — version-dependent). Point it at the cluster
+proxy with the virtual key in the custom header:
 
 ```bash
 export ANTHROPIC_BASE_URL=https://litellm-dev.commonly.me
-export ANTHROPIC_API_KEY=sk-<your-virtual-key>
+export ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: Bearer sk-<your-virtual-key>"
+# Claude Code's OAuth bearer lands in Authorization automatically
 claude
 ```
 
-To revert, `unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY` — Claude Code
-falls back to `~/.claude/.credentials.json` (OAuth) against
-`api.anthropic.com` direct.
+To revert: `unset ANTHROPIC_BASE_URL ANTHROPIC_CUSTOM_HEADERS` —
+Claude Code goes back to hitting `api.anthropic.com` direct.
+
+**Do NOT also set `ANTHROPIC_API_KEY`** — that would replace the
+OAuth bearer with an API key and you'd be in BYOK mode (calls bill
+against that API key, not your subscription).
 
 ### Cluster-side `cloud-claude-code` Deployment (future)
 
@@ -58,97 +72,141 @@ Parallel to `cloud-codex` — every per-pod Deployment gets:
 env:
   - name: ANTHROPIC_BASE_URL
     value: "http://litellm:4000"
-  - name: ANTHROPIC_API_KEY
+  - name: ANTHROPIC_CUSTOM_HEADERS
     valueFrom:
       secretKeyRef:
         name: claude-code-litellm-keys
-        key: <pod-name>   # one virtual key per pod, scoped + rate-limited
+        key: <pod-name>   # "x-litellm-api-key: Bearer sk-<vk>"
+  # No ANTHROPIC_API_KEY — Claude Code uses its mounted OAuth credentials
+  # for the Authorization header
 ```
 
 The cluster-side runtime Deployment template doesn't exist yet — it
 will be added when the first `cloud-claude-code` agent is
-provisioned.
+provisioned, alongside its OAuth seeding strategy (see
+"OAuth seeding" below).
+
+### BYOK mode (alternative)
+
+For callers that prefer to supply their own Anthropic API key
+instead of an OAuth bearer:
+
+```bash
+export ANTHROPIC_BASE_URL=https://litellm-dev.commonly.me
+export ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: Bearer sk-<virtual-key>"
+export ANTHROPIC_API_KEY="sk-ant-..."  # Anthropic API key
+```
+
+`general_settings.forward_llm_provider_auth_headers: true` forwards
+the `x-api-key` header (which Claude Code sends when
+`ANTHROPIC_API_KEY` is set) to `api.anthropic.com`. Calls bill
+against that API key. Useful for testing or for callers who don't
+want subscription attribution.
 
 ## Issuing a virtual key
 
-Authenticated to the running LiteLLM with `LITELLM_MASTER_KEY` (set
-in the `litellm` deployment env from the `api-keys` secret). Example:
-generate a key for laptop Claude Code, scoped to the four Anthropic
-models only, with a sensible monthly spend cap.
+Authenticated to the running LiteLLM with `LITELLM_MASTER_KEY` (in
+the `api-keys` secret as `litellm-master-key`, kebab-case). The
+LiteLLM container has no `curl`, so port-forward and call from your
+laptop.
 
 ```bash
 LITELLM_MASTER_KEY=$(kubectl get secret api-keys -n commonly-dev \
-  -o jsonpath='{.data.LITELLM_MASTER_KEY}' | base64 -d)
+  -o jsonpath='{.data.litellm-master-key}' | base64 -d)
 
-kubectl exec -n commonly-dev deploy/litellm -c litellm -- \
-  curl -s -X POST http://localhost:4000/key/generate \
-    -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
-    -H "Content-Type: application/json" \
-    -d '{
-      "key_alias": "claude-code-laptop-<operator>",
-      "models": [
-        "claude-opus-4-7",
-        "claude-sonnet-4-6",
-        "claude-haiku-4-5",
-        "claude-haiku-4-5-20251001"
-      ],
-      "max_budget": 50,
-      "budget_duration": "30d",
-      "metadata": {"purpose": "laptop-claude-code", "operator": "<name>"}
-    }'
+kubectl port-forward -n commonly-dev deploy/litellm 14000:4000 &
+PF_PID=$!
+
+curl -s -X POST http://localhost:14000/key/generate \
+  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key_alias": "claude-code-laptop-<operator>",
+    "models": [
+      "claude-opus-4-7",
+      "claude-sonnet-4-6",
+      "claude-haiku-4-5",
+      "claude-haiku-4-5-20251001"
+    ],
+    "max_budget": 50,
+    "budget_duration": "30d",
+    "metadata": {"purpose": "laptop-claude-code", "operator": "<name>"}
+  }'
+
+kill $PF_PID
 ```
 
 The response includes `"key": "sk-..."` — store it in your laptop's
-shell rc or secrets manager. Lost keys are revocable via
-`/key/delete` and re-issuable; the key string itself is not
-recoverable after generation.
+shell rc or secrets manager, then set `ANTHROPIC_CUSTOM_HEADERS` per
+the laptop config above. Lost keys are revocable via `/key/delete`
+and re-issuable; the key string itself is not recoverable after
+generation.
 
 Per-pod keys for future `cloud-claude-code` Deployments follow the
 same recipe — one `/key/generate` per pod at provision time, written
 into the per-pod secret the Deployment env mounts.
 
-## Why not OAuth pass-through?
+## Verification
 
-We tried it. PR #428 shipped `forward_client_headers_to_llm_api: true`
-+ `forward_llm_provider_auth_headers: true`, intending to pass the
-caller's Claude Code OAuth bearer through to `api.anthropic.com` so
-the call would bill against the caller's Max subscription. The live
-test from a laptop returned:
+End-to-end smoke from operator laptop, after issuing a virtual key
++ confirming `~/.claude/.credentials.json` (or Keychain) has a
+valid OAuth bearer:
 
+```bash
+export ANTHROPIC_BASE_URL=https://litellm-dev.commonly.me
+export ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: Bearer sk-<vk>"
+claude -p "reply with exactly: pong"
 ```
-401 Authentication Error, Invalid proxy server token passed.
-... Unable to find token in cache or LiteLLM_VerificationTokenTable
-```
 
-Root cause: when `general_settings.master_key` is set, LiteLLM
-validates the inbound `Authorization` header against its own virtual
-key table **before** the forward flags run. Claude Code CLI sends
-exactly one `Authorization` header per request (its OAuth bearer) —
-there's no way to supply a separate proxy key alongside it. So
-`master_key` + `forward_llm_provider_auth_headers` are mutually
-exclusive from a single-Authorization-header client's perspective.
+Expected: `pong` in the response. Verify in LiteLLM Logs UI
+(<https://litellm-dev.commonly.me/ui/>) that the request landed,
+with the `key_alias` matching your laptop key — confirms proxy auth
+worked. Verify on Anthropic's usage page
+(<https://www.anthropic.com/account/usage>) that the call landed in
+the subscription pool — confirms OAuth was forwarded upstream and
+honored.
 
-Three resolutions were considered:
+If `pong` came back but the Anthropic usage page shows the call in
+`extra_usage` instead of the subscription pool, see "Why might the
+call still bill `extra_usage`?" below.
 
-1. **Drop `master_key` on a dedicated route.** Public exposure of an
-   unauthenticated proxy is unacceptable; cluster-internal-only
-   routing would work but adds a second LiteLLM instance for one
-   caller class.
-2. **Rewriting front-proxy** (envoyproxy filter or Cloudflare Worker)
-   that swaps `Authorization` ↔ a passthrough header. Most flexible
-   but most code, and the upside is still speculative — per
-   Anthropic's 2026-04-04 policy change, third-party tools using
-   Claude Code OAuth tokens get routed to `extra_usage` regardless
-   of whether the proxy is transparent.
-3. **Use the standard LiteLLM virtual-key pattern.** Predictable
-   per-token cost at API rates, no proxy/auth gymnastics, matches
-   how every other caller in the cluster works. Trade-off: calls bill
-   against the cluster's `ANTHROPIC_API_KEY` rather than the
-   operator's Max subscription.
+## Why might the call still bill `extra_usage`?
 
-We picked (3). The forward flags were removed; this runbook
-documents the virtual-key path as the supported way to use LiteLLM
-for Claude Code.
+Anthropic's 2026-04-04 policy routes third-party-tool Claude Code
+OAuth use to a separate paid `extra_usage` pool, NOT the user's Max
+subscription quota. Whether a LiteLLM-proxied call counts as
+"Claude Code itself" (subscription) or "third-party tool"
+(extra_usage) depends on how Anthropic fingerprints the request:
+User-Agent, anthropic-version, client_id in the OAuth token scope,
+etc.
+
+`forward_client_headers_to_llm_api: true` forwards User-Agent +
+`anthropic-version` + `anthropic-beta` headers verbatim, so a
+proxied call looks structurally identical to a direct one. But if
+Anthropic ever ties classification to TLS fingerprint, source IP,
+or other transport-layer signal we can't impersonate from a
+different host, proxied calls will land in `extra_usage`.
+
+Empirical: if your test call lands in `extra_usage`, the proxy still
+works — it just costs per-token at API rates. Decide whether to
+keep the path for centralized observability/quota or fall back to
+BYOK mode with a real API key.
+
+## OAuth seeding (cluster-side, future)
+
+When the first `cloud-claude-code` Deployment lands, Claude Code
+OAuth tokens for the cluster-side identity will need to be device-
+auth'd **from inside the cluster** IF Anthropic implements IP-binding
+the way ChatGPT does. As of 2026-05-22 there's no public evidence
+that Anthropic IP-binds Claude Code OAuth tokens (claude-code#44587
+is an open feature *request* for this exact behavior), so a
+laptop-auth'd token can probably be uploaded directly. Re-verify
+before the first production deploy.
+
+If IP-binding turns out to apply, mirror the cluster-side device-
+auth pattern from `cloud-codex` (`litellm-deployment.yaml` already
+has a `codex-cli` sidecar for the same purpose — a `claude-code-cli`
+sidecar would be the parallel).
 
 ## Operational notes
 
@@ -161,17 +219,39 @@ for Claude Code.
   helm upgrades, and (soft-deleted) `helm uninstall`. To wipe them,
   truncate `LiteLLM_VerificationTokenTable` in the litellm postgres
   schema or delete keys via the `/key/delete` API.
+- **Secret keys in `api-keys` are kebab-case**
+  (`anthropic-api-key`, `litellm-master-key`), but the pod env vars
+  they map to are UPPER_SNAKE_CASE. When pulling a value via
+  `kubectl get secret -o jsonpath`, use the kebab name.
+- **LiteLLM container has no `curl`.** Use `kubectl port-forward
+  deploy/litellm 14000:4000` and curl from the laptop for any
+  admin-key API call (`/key/generate`, `/key/delete`, etc.).
 - **Spend tracking** lands in `LiteLLM_SpendLogs` (retention capped
   at 7d via `maximum_spend_logs_retention_period` to keep the table
   from growing unbounded — see config comment).
+- **`ANTHROPIC_API_KEY` in the cluster's `api-keys` secret is
+  currently `placeholder`** (verified 2026-05-22) and that's OK
+  for the OAuth path — the model entries no longer carry an
+  `api_key` fallback, so the env var is unreferenced for these
+  routes. BYOK callers supply their own key per request.
 
 ## References
 
+- LiteLLM Claude Code Max OAuth tutorial:
+  <https://docs.litellm.ai/docs/tutorials/claude_code_max_subscription>
+- LiteLLM Claude Code BYOK tutorial:
+  <https://docs.litellm.ai/docs/tutorials/claude_code_byok>
 - LiteLLM virtual key docs:
   <https://docs.litellm.ai/docs/proxy/virtual_keys>
 - `/key/generate` API:
   <https://docs.litellm.ai/docs/proxy/key_management>
 - Parallel pattern in this repo: `cloud-codex` (uses
-  `LITELLM_API_KEY` env var as the virtual-key bearer when calling
-  `http://litellm:4000/v1` from inside the cluster — see
-  `k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml`)
+  `LITELLM_API_KEY` env var as the virtual-key bearer in
+  `Authorization` when calling `http://litellm:4000/v1` from inside
+  the cluster — different from this path because codex CLI has no
+  OAuth, so the virtual key takes Authorization directly).
+- Why `forward_*_headers` + `master_key` need the split-header
+  pattern: the `x-litellm-api-key` header was added by LiteLLM
+  specifically to give proxy auth its own header lane so OAuth
+  bearers in Authorization can be forwarded — see the Max tutorial
+  link above.

--- a/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
+++ b/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
@@ -183,52 +183,50 @@ data:
           model: openai/gpt-image-1
           api_key: os.environ/OPENAI_API_KEY
 
-      # --- Anthropic (Claude Code via virtual key + cluster ANTHROPIC_API_KEY) ---
+      # --- Anthropic (Claude Code OAuth pass-through OR BYOK) ---
       # Two consumers will point at these entries:
       #   1. cluster-side `cloud-claude-code` runtime pods (Deployment templated
       #      parallel to cloud-codex) — set ANTHROPIC_BASE_URL=http://litellm:4000
-      #      and ANTHROPIC_API_KEY=<per-pod virtual key>
-      #   2. operator-laptop Claude Code via litellm-dev.commonly.me — sets
-      #      ANTHROPIC_BASE_URL=https://litellm-dev.commonly.me and
-      #      ANTHROPIC_API_KEY=<operator virtual key>
+      #      and ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: Bearer sk-<vk>"
+      #      (per-pod virtual key for proxy auth); Claude Code's own OAuth
+      #      bearer goes in Authorization and is forwarded upstream
+      #   2. operator-laptop Claude Code via litellm-dev.commonly.me — same:
+      #      ANTHROPIC_BASE_URL + ANTHROPIC_CUSTOM_HEADERS for the virtual key
       #
-      # Auth model matches every other LiteLLM caller in the cluster (codex CLI,
-      # backend services, dev/community moltbots): caller sends its LiteLLM
-      # virtual key as the `Authorization` bearer; LiteLLM validates it against
-      # LiteLLM_VerificationTokenTable; on hit, LiteLLM forwards the request
-      # upstream using the cluster's own ANTHROPIC_API_KEY (api_key below).
+      # Auth model follows the official LiteLLM Claude Code Max OAuth pattern
+      # (docs.litellm.ai/docs/tutorials/claude_code_max_subscription):
+      #   - x-litellm-api-key header carries the LiteLLM virtual key (proxy
+      #     auth, validated against LiteLLM_VerificationTokenTable)
+      #   - Authorization header carries the caller's OAuth bearer
+      #     (sk-ant-oat01-*) and is forwarded to api.anthropic.com via
+      #     general_settings.forward_client_headers_to_llm_api below
+      #   - BYOK fallback: caller sends x-api-key with their own Anthropic
+      #     key; forwarded upstream via forward_llm_provider_auth_headers
+      #
+      # NO api_key fallback on these entries — the caller MUST bring its own
+      # credential (OAuth bearer or x-api-key). This is deliberate: a global
+      # ANTHROPIC_API_KEY fallback would (a) mask placeholder/invalid keys
+      # behind silent upstream 401s and (b) defeat the per-caller billing
+      # attribution that's the whole point of the OAuth path.
       #
       # Per-key scoping (models[], rpm/tpm/spend limits, key_alias) is set at
       # `/key/generate` time — see docs/runbooks/litellm-claude-code.md.
-      #
-      # Claude Code OAuth pass-through was considered (forward_client_headers
-      # + forward_llm_provider_auth_headers) but the proxy's master_key gate
-      # consumes the inbound Authorization header before the forward flags
-      # can act, and that's fundamentally incompatible with Claude Code CLI's
-      # single-Authorization-header model. Virtual key is the standard pattern
-      # the rest of the cluster uses; we use it here too. Trade-off accepted:
-      # calls bill against the cluster's ANTHROPIC_API_KEY at API rates rather
-      # than the operator's Max subscription.
       - model_name: claude-opus-4-7
         litellm_params:
           model: anthropic/claude-opus-4-7
-          api_key: os.environ/ANTHROPIC_API_KEY
 
       - model_name: claude-sonnet-4-6
         litellm_params:
           model: anthropic/claude-sonnet-4-6
-          api_key: os.environ/ANTHROPIC_API_KEY
 
       - model_name: claude-haiku-4-5
         litellm_params:
           model: anthropic/claude-haiku-4-5-20251001
-          api_key: os.environ/ANTHROPIC_API_KEY
 
       # Versioned alias — Claude Code sometimes sends date-suffixed IDs
       - model_name: claude-haiku-4-5-20251001
         litellm_params:
           model: anthropic/claude-haiku-4-5-20251001
-          api_key: os.environ/ANTHROPIC_API_KEY
 
     router_settings:
       # The codex-auth-rotator sidecar rotates Codex accounts every 10 min on
@@ -290,6 +288,23 @@ data:
       store_model_in_db: true
       # Allow UI access
       ui_access_mode: "all"
+      # Forward client request headers (User-Agent, anthropic-version,
+      # anthropic-beta, AND Authorization) to the upstream LLM provider.
+      # Required for the official Claude Code Max OAuth pass-through path
+      # (docs.litellm.ai/docs/tutorials/claude_code_max_subscription):
+      # caller's OAuth bearer rides in Authorization and is forwarded to
+      # api.anthropic.com so the call bills against their Max subscription.
+      # Proxy auth lives in x-litellm-api-key (set client-side via
+      # ANTHROPIC_CUSTOM_HEADERS) so it does NOT collide with the
+      # Authorization header — that's how master_key + OAuth coexist.
+      forward_client_headers_to_llm_api: true
+      # Forward the client's x-api-key header through to the provider
+      # instead of substituting the proxy's own. Required for BYOK mode
+      # (caller supplies their own Anthropic key via x-api-key); harmless
+      # for the OAuth-only path. Distinct flag from forward_client_headers
+      # above because LiteLLM's x-api-key handling lives in a separate code
+      # path inside the proxy.
+      forward_llm_provider_auth_headers: true
       # Spend log retention — without these, LiteLLM_SpendLogs grows unbounded
       # (prod dev observed 5+ GB on the 8 GiB Cloud SQL tier before this cap).
       # STORE_PROMPTS_IN_SPEND_LOGS=true is set in the deployment env, so each


### PR DESCRIPTION
## Summary

Implements the official LiteLLM Claude Code Max OAuth pattern — split-header trick I missed in PR #428/#430.

**The mechanism:**
- Proxy auth: virtual key in \`x-litellm-api-key\` header (set client-side via \`ANTHROPIC_CUSTOM_HEADERS\`)
- Upstream auth: caller's OAuth bearer in \`Authorization\` — forwarded to \`api.anthropic.com\` via \`forward_client_headers_to_llm_api\`
- The two headers don't collide → \`master_key\` and OAuth pass-through can coexist

**Config changes:**
- Restore both \`forward_*_headers\` flags (PR #430 dropped them on the wrong premise)
- Drop \`api_key: os.environ/ANTHROPIC_API_KEY\` from all 4 \`claude-*\` model entries — callers must BYO credential (OAuth or x-api-key). No silent fallback to placeholder.
- Rewrite \`docs/runbooks/litellm-claude-code.md\` around the official pattern with the \`ANTHROPIC_CUSTOM_HEADERS\` recipe + BYOK alternative + extra_usage caveat

**Why this is the right shape:**
- Matches Anthropic's expectation (Authorization carries the user's bearer)
- Per-caller billing attribution preserved (calls hit the operator's Max subscription)
- Virtual key still gates proxy access + per-key rate/spend limits
- Also moots PR #431 — \`ANTHROPIC_API_KEY=placeholder\` is now intentionally unreferenced for Anthropic routes

Reference: <https://docs.litellm.ai/docs/tutorials/claude_code_max_subscription>

## Test plan

- [ ] CI: chart-lint + detect-secrets pass
- [ ] Merge + Deploy Dev + rollout-restart litellm
- [ ] Issue laptop virtual key via \`/key/generate\` per runbook
- [ ] Set \`ANTHROPIC_BASE_URL\` + \`ANTHROPIC_CUSTOM_HEADERS=\"x-litellm-api-key: Bearer sk-<vk>\"\` on laptop
- [ ] \`claude -p 'reply with exactly: pong'\` succeeds
- [ ] Confirm in LiteLLM Logs UI that the request landed with the expected \`key_alias\`
- [ ] Confirm on Anthropic usage page that the call hit the subscription pool (or document if it lands in \`extra_usage\` per the post-2026-04-04 policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)