### PR TITLE
feat(agent-mention): collaborative-pod cue auto-replicates execute-not-handoff posture

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -589,5 +589,148 @@ describe('AgentMentionService', () => {
       });
       expect(lastPayload().payload.content).not.toContain('[Collaboration:');
     });
+
+    // ----------------------------------------------------------------
+    // Collaborative-pod cue (Phase 3.A — auto-replicates the
+    // execute-not-handoff principle established in the 2026-05-23
+    // huddle). Fires when:
+    //   1. Pod has ≥2 active non-utility agent installations
+    //   2. Pod.type is NOT agent-room or agent-dm (1:1 by design)
+    //   3. Target is a non-specialist (specialists self-execute already)
+    //   4. Event is chat.mention (not thread.mention)
+    //
+    // Reference incidents in docs/audits/ui-smoke-2026-05-23/
+    // huddle-observations.md and the memory entries
+    // feedback-agents-collab-execute-not-handoff +
+    // feedback-claim-the-orphan-stalled-peer-work.
+    // ----------------------------------------------------------------
+    describe('collaborative-pod cue', () => {
+      const setupForMultipleAgents = (installs, { podType = 'team' } = {}) => {
+        AgentInstallation.find.mockReturnValue({
+          lean: jest.fn().mockResolvedValue(installs),
+        });
+        AgentProfile.find.mockReturnValue({
+          lean: jest.fn().mockResolvedValue([]),
+        });
+        // Pod.findById(podId).select('type').lean() — the chained mock the
+        // collaborative-pod detection consults. Falls back to count-only
+        // heuristic if this rejects, so the test stays useful even if the
+        // mock shape drifts.
+        Pod.findById.mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            lean: jest.fn().mockResolvedValue({ type: podType }),
+          }),
+        });
+      };
+
+      test('chat.mention + ≥2 non-utility agents + non-specialist target → [Collaborative pod:] cue present', async () => {
+        setupForMultipleAgents([
+          { agentName: 'openclaw', instanceId: 'theo', displayName: 'Theo' },
+          { agentName: 'openclaw', instanceId: 'nova', displayName: 'Nova' },
+          { agentName: 'codex', instanceId: 'cody', displayName: 'Cody' },
+        ]);
+        await AgentMentionService.enqueueMentions({
+          podId: 'pod-collab-1',
+          message: { content: 'Hi @nova please review', id: 'msg-collab-1' },
+          userId: 'user-1',
+          username: 'sam',
+        });
+        const ev = lastPayload();
+        expect(ev.type).toBe('chat.mention');
+        expect(ev.payload.content).toContain('[Collaborative pod:');
+        expect(ev.payload.content).toContain('EXECUTE it yourself');
+        // Composes with the other cues — collab-pod doesn't displace them.
+        expect(ev.payload.content).toContain('[Pod context:');
+        expect(ev.payload.content).toContain('[Collaboration:');
+        expect(ev.payload.content).toContain('[Reply mechanics:');
+      });
+
+      test('chat.mention + single agent in pod → NO [Collaborative pod:] cue (solo pod)', async () => {
+        // Single-agent pod: not a huddle, don't add the cue.
+        setupForMultipleAgents([
+          { agentName: 'openclaw', instanceId: 'theo', displayName: 'Theo' },
+        ]);
+        await AgentMentionService.enqueueMentions({
+          podId: 'pod-collab-2',
+          message: { content: 'Hi @theo', id: 'msg-collab-2' },
+          userId: 'user-1',
+          username: 'sam',
+        });
+        expect(lastPayload().payload.content).not.toContain('[Collaborative pod:');
+      });
+
+      test('chat.mention + ≥2 agents but target IS specialist → NO collab cue (noise for codex)', async () => {
+        setupForMultipleAgents([
+          { agentName: 'openclaw', instanceId: 'nova', displayName: 'Nova' },
+          { agentName: 'codex', instanceId: 'cody', displayName: 'Cody' },
+        ]);
+        await AgentMentionService.enqueueMentions({
+          podId: 'pod-collab-3',
+          message: { content: 'Hi @cody build this', id: 'msg-collab-3' },
+          userId: 'user-1',
+          username: 'sam',
+        });
+        const ev = lastPayload();
+        expect(ev.payload.content).not.toContain('[Collaborative pod:');
+        // Specialist still gets pod-context + reply-mechanics
+        expect(ev.payload.content).toContain('[Pod context:');
+        expect(ev.payload.content).toContain('[Reply mechanics:');
+      });
+
+      test('chat.mention + 2 agents but BOTH are utility helpers → NO collab cue (helpers don\'t count as peers)', async () => {
+        // pod-welcomer + task-clerk are utility helpers, not collab peers
+        setupForMultipleAgents([
+          { agentName: 'pod-welcomer', instanceId: 'default', displayName: 'Welcomer' },
+          { agentName: 'task-clerk', instanceId: 'default', displayName: 'Clerk' },
+          { agentName: 'openclaw', instanceId: 'nova', displayName: 'Nova' },
+        ]);
+        await AgentMentionService.enqueueMentions({
+          podId: 'pod-collab-4',
+          message: { content: 'Hi @nova', id: 'msg-collab-4' },
+          userId: 'user-1',
+          username: 'sam',
+        });
+        // Only 1 non-utility peer (nova), so collab cue should NOT fire
+        expect(lastPayload().payload.content).not.toContain('[Collaborative pod:');
+      });
+
+      test('chat.mention + agent-room pod type → NO collab cue regardless of agent count', async () => {
+        // agent-room is explicitly 1:1 user↔agent; even with 2 agents installed
+        // (edge case), the cue is wrong for this pod type.
+        setupForMultipleAgents(
+          [
+            { agentName: 'openclaw', instanceId: 'theo', displayName: 'Theo' },
+            { agentName: 'openclaw', instanceId: 'nova', displayName: 'Nova' },
+          ],
+          { podType: 'agent-room' },
+        );
+        await AgentMentionService.enqueueMentions({
+          podId: 'pod-collab-5',
+          message: { content: 'Hi @nova', id: 'msg-collab-5' },
+          userId: 'user-1',
+          username: 'sam',
+        });
+        expect(lastPayload().payload.content).not.toContain('[Collaborative pod:');
+      });
+
+      test('thread.mention + ≥2 agents → NO collab cue (threads are different posture)', async () => {
+        setupForMultipleAgents([
+          { agentName: 'openclaw', instanceId: 'theo', displayName: 'Theo' },
+          { agentName: 'openclaw', instanceId: 'nova', displayName: 'Nova' },
+        ]);
+        await AgentMentionService.enqueueMentions({
+          podId: 'pod-collab-6',
+          message: {
+            content: 'Hi @theo',
+            id: 'msg-collab-6',
+            source: 'thread',
+            thread: { postId: 'thread-1', postContent: 'parent' },
+          },
+          userId: 'user-1',
+          username: 'sam',
+        });
+        expect(lastPayload().payload.content).not.toContain('[Collaborative pod:');
+      });
+    });
   });
 });

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -409,25 +409,118 @@ const isCodeSpecialistAgent = (agentName: string | undefined | null): boolean =>
   return a === 'codex' || a === 'cloud-codex' || a === 'claude-code';
 };
 
+// Collaborative-pod posture cue.
+//
+// Why this exists: the 2026-05-23 multi-agent huddle smoke surfaced a
+// reflexive delegation posture on openclaw moltbots — when @-mentioned
+// with a concrete spec they reflexively reach for "create a board task,
+// wait for orchestrator to assign, hand off to specialist via heartbeat"
+// instead of executing themselves or collaborating sync. The full
+// pattern (with reference incident + a 2-hour-latency triple-hop chain
+// observed) is captured in two memory entries:
+//   feedback-agents-collab-execute-not-handoff
+//   feedback-claim-the-orphan-stalled-peer-work
+//
+// During the huddle, Sam (the human) corrected the posture with an
+// in-pod message that landed in 2 minutes — all 4 agents pivoted. That
+// proved the posture IS in-context-correctable; the missing piece is
+// auto-injecting the same correction so future huddles don't need
+// manual intervention. Same shape as the §9 DM cue + pod-context cue
+// established pattern: structured metadata is deprioritized; inline
+// cue is not.
+//
+// Gating:
+//   - Pod must look "collaborative" — heuristic: ≥2 active non-utility
+//     agent installations in the pod (excludes pod-welcomer, task-clerk,
+//     pod-summarizer, commonly-bot which are single-purpose helpers,
+//     not collab peers). 1:1 agent-room and agent-dm pods explicitly
+//     don't qualify even if they hit the count.
+//   - Target must be a non-specialist — code specialists (codex,
+//     cloud-codex, claude-code) already self-execute; the cue is
+//     noise + loop risk for them.
+//   - chat.mention only — thread.mention is a different posture
+//     (threaded conversation, not the primary "do this work" channel).
+//
+// Token cost: ~110 per qualifying mention. Equivalent to a single
+// memory-cue write at ADR-012 Phase 4; cheap relative to the unblock
+// it produces.
+const formatCollaborativePodCue = (): string =>
+  `[Collaborative pod: this huddle has multiple agent peers + a human ` +
+  `in one place. If the spec is concrete and you have the tools, ` +
+  `EXECUTE it yourself and post the result — don't wait for a board ` +
+  `task to assign you, and don't enqueue work for an absent agent via ` +
+  `heartbeat handoff. If a peer claimed work but hasn't shipped in ` +
+  `~30 min, you can race them by picking it up directly — say so in ` +
+  `the pod when you do. Delegate only when the work genuinely exceeds ` +
+  `your capability or scope; in that case @-mention a peer in this pod ` +
+  `for sync turnaround, or open a 1:1 DM with commonly_open_dm.]`;
+
+// Pod types that are explicitly NOT collaborative huddles (1:1 by
+// design). The collab cue is skipped for these regardless of member
+// count.
+const NON_COLLAB_POD_TYPES = new Set(['agent-room', 'agent-dm']);
+
+// Utility/single-purpose agents that don't count toward the
+// "≥2 collab peers" heuristic. These are first-party helpers
+// (welcomer/clerk/summarizer/bot), not collab peers a human would
+// huddle with.
+const NON_COLLAB_PEER_AGENTS = new Set([
+  'commonly-bot',
+  'pod-welcomer',
+  'task-clerk',
+  'pod-summarizer',
+]);
+
+// Decide whether a pod qualifies as a "collaborative huddle" for
+// inline-cue purposes. Centralized here so the heuristic is easy to
+// audit and tune.
+//
+// Inputs come from data the caller already has loaded:
+//   podType: pod.type ('team' / 'chat' / 'agent-room' / 'agent-dm' / ...)
+//   installations: AgentInstallation rows for the pod (already fetched
+//                  by enqueueMentions before this function runs)
+const isCollaborativePod = (
+  podType: string | undefined | null,
+  installations: Array<Record<string, unknown>>,
+): boolean => {
+  if (podType && NON_COLLAB_POD_TYPES.has(podType)) return false;
+  const peerCount = installations.reduce((acc, inst) => {
+    const name = String((inst as { agentName?: string })?.agentName || '').toLowerCase();
+    return NON_COLLAB_PEER_AGENTS.has(name) ? acc : acc + 1;
+  }, 0);
+  return peerCount >= 2;
+};
+
 // Compose the payload.content prefix per event type AND target runtime.
 // All chat.mention events get a reply-mechanics cue (heartbeat-clobber
 // mitigation); thread.mention events skip it. All non-specialist targets
 // get a consultation cue (cross-runtime collab nudge); specialists skip
 // it. Both pieces compose with the pod-context cue that fires for
-// every mention.
+// every mention. When the pod looks like a collaborative huddle AND
+// the target is a non-specialist, the collab-pod cue is added too —
+// see formatCollaborativePodCue above.
 //
-// Final shapes:
-//   chat.mention + non-specialist  → [Pod] [Collab] [Reply] body
-//   chat.mention + specialist      → [Pod] [Reply] body
-//   thread.mention + non-specialist→ [Pod] [Collab] body
-//   thread.mention + specialist    → [Pod] body
+// Final shapes (collab denotes the collaborative-pod cue):
+//   chat.mention + non-specialist + collab → [Pod] [CollabPod] [Collab] [Reply] body
+//   chat.mention + non-specialist + solo   → [Pod] [Collab] [Reply] body
+//   chat.mention + specialist              → [Pod] [Reply] body
+//   thread.mention + non-specialist        → [Pod] [Collab] body
+//   thread.mention + specialist            → [Pod] body
 const buildContentForTarget = (
   podId: string,
   rawContent: string,
   eventType: 'chat.mention' | 'thread.mention',
   targetAgentName: string,
+  collaborativePod: boolean = false,
 ): string => {
   const frames: string[] = [formatPodContextFrame(podId)];
+  if (
+    eventType === 'chat.mention'
+    && collaborativePod
+    && !isCodeSpecialistAgent(targetAgentName)
+  ) {
+    frames.push(formatCollaborativePodCue());
+  }
   if (!isCodeSpecialistAgent(targetAgentName)) {
     frames.push(formatConsultationCue());
   }
@@ -472,6 +565,21 @@ const enqueueMentions = async ({
 
   const { map: mentionMap, byAgent } = buildMentionMap(installations, profiles);
   let pod: Record<string, unknown> | null = null;
+
+  // Resolve "collaborative pod" once per enqueueMentions call so all
+  // mention targets see a consistent cue surface for the same pod.
+  // Pod.type lookup is fire-and-forget — if it fails, the heuristic
+  // falls back to "installations-only" which still correctly excludes
+  // 1:1 utility-agent pods (≥2 non-utility peers required).
+  let podType: string | null = null;
+  try {
+    const podRow = await Pod.findById(podId).select('type').lean() as { type?: string } | null;
+    podType = podRow?.type || null;
+  } catch (error) {
+    // Non-fatal — collab detection falls back to count-only heuristic.
+    console.warn('[mention-collab-cue] pod.type lookup failed:', (error as Error).message);
+  }
+  const collaborativePod = isCollaborativePod(podType, installations);
 
   // Self-mention guard: if the sender is a bot, resolve their own
   // (agentName, instanceId) so we can skip re-enqueuing an event on themselves.
@@ -528,7 +636,7 @@ const enqueueMentions = async ({
               messageId: message?._id || message?.id
                 ? String(message?._id || message?.id)
                 : undefined,
-              content: buildContentForTarget(podId, rawContent, eventType, directMatch.agentName),
+              content: buildContentForTarget(podId, rawContent, eventType, directMatch.agentName, collaborativePod),
               userId,
               username,
               mentions: rawMentions,
@@ -576,7 +684,7 @@ const enqueueMentions = async ({
                   messageId: message?._id || message?.id
                     ? String(message?._id || message?.id)
                     : undefined,
-                  content: buildContentForTarget(podId, rawContent, eventType, resolved.agentName),
+                  content: buildContentForTarget(podId, rawContent, eventType, resolved.agentName, collaborativePod),
                   userId,
                   username,
                   mentions: rawMentions,
@@ -636,7 +744,7 @@ const enqueueMentions = async ({
                   messageId: message?._id || message?.id
                     ? String(message?._id || message?.id)
                     : undefined,
-                  content: buildContentForTarget(podId, rawContent, eventType, agentType),
+                  content: buildContentForTarget(podId, rawContent, eventType, agentType, collaborativePod),
                   userId,
                   username,
                   mentions: rawMentions,

--- a/docs/audits/2026-05-24-phase-3/openclaw-moltbot-workspace-audit.md
+++ b/docs/audits/2026-05-24-phase-3/openclaw-moltbot-workspace-audit.md
@@ -1,0 +1,35 @@
+# OpenClaw moltbot workspace = git worktree — audit
+
+Source: read-only subagent audit (2026-05-24) against current main.
+
+## Gap
+
+Moltbot agents (theo / nova / pixel / ops / aria) can't `git commit && git push` from `/workspace/<agentId>` because the workspace is a plain directory, not a git worktree. Cloud-codex pods are fine because the boot script wires `git config credential.helper store` + clones into `/state` on demand.
+
+## Concrete fix (~75 LOC across 3 files)
+
+1. **`backend/services/agentProvisionerServiceK8s.ts`** — add `ensureWorkspaceGitRepo(accountId, { gateway })` helper, call it after `normalizeWorkspaceDocs()` (~line 735). Body runs `git init /workspace/<accountId> && git config user.name "Clawdbot Agent" + email`. Idempotent (skips if `.git/` exists).
+2. **`k8s/helm/commonly/templates/agents/clawdbot-deployment.yaml`** — postStart hook (lines 561–593): move `apt-get install -y git` outside the `if [ -n "${GITHUB_PAT:-}" ]` guard so `git` is on PATH unconditionally. Credential wiring stays gated on PAT.
+3. **TOOLS.md injection** in provisioner — add a "Git Workflows" section so agents see git is available + the credential.helper is wired.
+
+## Already in place
+
+- `GITHUB_PAT` env injected runtime-tier (per CLAUDE.md memory).
+- Credential helper wired globally in postStart (lines 561–593 of clawdbot-deployment.yaml).
+- Workspace path per-agent already isolated at `/workspace/<accountId>/`.
+
+## Open decisions (defaults captured in plan)
+
+- Don't pre-clone the repo — `git init` + clone-on-demand keeps the PVC small.
+- Workspace-local git config (not global) for agent-attribution clarity.
+- Idempotent — skip init if `.git/` exists, preserves any local history across reprovisions.
+
+## Risk
+
+- Git init on every provision: low (idempotent guard).
+- PAT exposure: PAT lives in `/state/.git-credentials` (shared volume), referenced by `credential.helper`, never written to workspace `.git/config`.
+- Workspace bloat: agents may clone into `/workspace/<id>` instead of `/tmp`; document in TOOLS.md to prefer `/tmp` for large clones.
+
+## Companion principle
+
+Per CLAUDE.md: any new dev-tier runtime adapter needs the same env block — gating is at the deployment-template tier (which pods exist), NOT per-pod.


### PR DESCRIPTION
## Summary

When a multi-agent collaborative pod receives a `chat.mention`, prepend an inline cue to `payload.content` telling the target agent to **execute the work themselves** (or collaborate sync via @-mention/DM) rather than enqueueing a board task for an absent agent via heartbeat handoff.

Auto-replicates the in-pod correction Sam had to make manually during the 2026-05-23 multi-agent huddle. Same pattern as the established ADR-012 §9 DM cue and pod-context cue — inline cue beats structured metadata per `feedback-llm-inline-cue-beats-metadata`.

## Reference incident

In the 2026-05-23 huddle (`docs/audits/ui-smoke-2026-05-23/huddle-observations.md`, finding #8), Nova (openclaw moltbot, gpt-5.4-mini, full capability) chose a ~2-hour-latency triple-hop chain for a ~10-line install.ts fix:

> human → board task → Nova claim heartbeat (≤60min) → DM sam-local-codex → sam-local-codex heartbeat (≤60min) → diff lands

Sam corrected the posture with one in-pod message; all 4 agents pivoted within 2 minutes. That proved the behavior IS in-context-correctable; this PR auto-injects the same correction.

## When the cue fires

```
pod has ≥2 active non-utility agent installations
  AND pod.type is NOT 'agent-room' or 'agent-dm'
  AND target agent is NOT a code specialist (codex/cloud-codex/claude-code)
  AND event type is 'chat.mention' (not thread.mention)
```

Utility helpers (commonly-bot, pod-welcomer, task-clerk, pod-summarizer) don't count toward the ≥2 peer threshold. Code specialists already self-execute; the cue is noise for them. Thread mentions are a different posture.

## Cue body (final shape)

```
[Collaborative pod: this huddle has multiple agent peers + a human in one place.
If the spec is concrete and you have the tools, EXECUTE it yourself and post the result —
don't wait for a board task to assign you, and don't enqueue work for an absent agent via
heartbeat handoff. If a peer claimed work but hasn't shipped in ~30 min, you can race them
by picking it up directly — say so in the pod when you do. Delegate only when the work
genuinely exceeds your capability or scope; in that case @-mention a peer in this pod for
sync turnaround, or open a 1:1 DM with commonly_open_dm.]
```

~110 tokens per qualifying mention. Cheap relative to the multi-hour delegation chains it prevents.

## Composes with existing cues

Final cue composition for chat.mention + non-specialist + collaborative pod:

```
[Pod context: ...]   ← formatPodContextFrame (existing)
[Collaborative pod: ...]   ← NEW
[Collaboration: ...]   ← formatConsultationCue (existing, code-handoff to specialists)
[Reply mechanics: ...]   ← formatMentionReplyCue (existing, heartbeat-clobber mitigation)

<original message>
```

## Tests

`backend/__tests__/unit/services/agentMentionService.test.js` — six new test cases under `describe('collaborative-pod cue')`:

- [x] chat.mention + ≥2 non-utility agents + non-specialist → cue PRESENT
- [x] chat.mention + single agent → cue NOT present (solo pod)
- [x] chat.mention + specialist target → cue NOT present (noise for codex)
- [x] chat.mention + 2 agents but both utility helpers → cue NOT present
- [x] chat.mention + pod.type='agent-room' → cue NOT present
- [x] thread.mention + ≥2 agents → cue NOT present (wrong posture)

## Related

- Memory entries: `commonly-skills/memory/feedback-agents-collab-execute-not-handoff.md` + `feedback-claim-the-orphan-stalled-peer-work.md`
- Audit: `docs/audits/ui-smoke-2026-05-23/huddle-observations.md` (Phase-4 finding #8 + #9)
- Companion Phase 3.B (next PR): openclaw moltbot workspace = git worktree, so theo/nova/pixel/ops can actually ship code. Audit in `docs/audits/2026-05-24-phase-3/openclaw-moltbot-workspace-audit.md` (also included in this commit).

## Test plan

- [ ] CI green (agentMentionService.test.js + full backend suite)
- [ ] After merge + deploy: trigger a multi-agent huddle on app-dev, send @-mention to an openclaw moltbot, confirm `[Collaborative pod:` appears in the chat.mention event content (via mongo `agentevents.payload.content`)
- [ ] Behavioral verification: dev-agent (theo/nova) responds with execution rather than delegation in a follow-up huddle session

🤖 Generated with [Claude Code](https://claude.com/claude-code)