### PR TITLE
fix(memory): default missing daily[].date to today UTC (closes #435)

### DIFF
--- a/backend/__tests__/service/agent-memory-envelope.test.js
+++ b/backend/__tests__/service/agent-memory-envelope.test.js
@@ -602,6 +602,32 @@ describe('AgentMemory envelope — GET/PUT /memory + backfill', () => {
       expect(res.body.message).toMatch(/YYYY-MM-DD/);
     });
 
+    // GH issue #435 — `commonly_save_my_memory` MCP tool contract
+    // didn't disclose that each daily entry must carry a `date`.
+    // Server-side default to today's UTC YYYY-MM-DD when missing.
+    // Explicit invalid dates still 400 (covered by the two tests
+    // above); only the omitted-date case is normalized.
+    it('defaults missing daily[].date to today UTC (YYYY-MM-DD)', async () => {
+      const res = await request(app)
+        .post('/api/agents/runtime/memory/sync')
+        .set('Authorization', `Bearer ${runtimeToken}`)
+        .send({
+          sections: { daily: [{ content: 'natural write without date' }] },
+          mode: 'merge',
+        });
+      expect(res.status).toBe(200);
+      // Confirm the stored entry got today's UTC date.
+      const today = new Date().toISOString().slice(0, 10);
+      const getRes = await request(app)
+        .get('/api/agents/runtime/memory')
+        .set('Authorization', `Bearer ${runtimeToken}`);
+      expect(getRes.status).toBe(200);
+      const dailyArr = Array.isArray(getRes.body?.sections?.daily) ? getRes.body.sections.daily : [];
+      const matched = dailyArr.find((d) => d?.date === today);
+      expect(matched).toBeTruthy();
+      expect(matched.content).toBe('natural write without date');
+    });
+
     it('full mode: replaces the entire sections envelope', async () => {
       // Seed with long_term + shared.
       await request(app)

--- a/backend/__tests__/service/agent-memory-envelope.test.js
+++ b/backend/__tests__/service/agent-memory-envelope.test.js
@@ -613,7 +613,7 @@ describe('AgentMemory envelope — GET/PUT /memory + backfill', () => {
         .set('Authorization', `Bearer ${runtimeToken}`)
         .send({
           sections: { daily: [{ content: 'natural write without date' }] },
-          mode: 'merge',
+          mode: 'patch',
         });
       expect(res.status).toBe(200);
       // Confirm the stored entry got today's UTC date.

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -1759,7 +1759,27 @@ function validateSectionsPayload(sections: any): SectionsValidationError | null 
   }
   if (sections.daily !== undefined) {
     if (!Array.isArray(sections.daily)) return { kind: 'bad_request', message: 'sections.daily must be an array' };
+    // Default missing `date` to today's UTC YYYY-MM-DD. The
+    // `commonly_save_my_memory` MCP tool contract (commonly-mcp/src/
+    // tools.js) documents `entries` as the daily-write shape but does
+    // NOT disclose that each entry must already carry a `date` field
+    // in strict YYYY-MM-DD form. Surfaced 2026-05-24 by Cody during
+    // the Phase 2 huddle smoke (issue #435): `long_term` writes
+    // succeeded; a natural `daily` write failed with
+    // `sections.daily[].date must be YYYY-MM-DD`.
+    //
+    // Fix: server-side default to today (UTC) when `date` is absent,
+    // BEFORE validation. Explicit values still flow through unchanged
+    // — if a caller passes `date: 'not-a-date'` we still 400. This is
+    // a kindness for the common case (agent saying "today's note") and
+    // doesn't widen the schema's accepted shape. Mutation of the
+    // request body is intentional + scoped to this one defaulting
+    // step; the route handler downstream sees the normalized array.
+    const todayYMD = new Date().toISOString().slice(0, 10);
     for (const d of sections.daily) {
+      if (d && typeof d === 'object' && d.date === undefined) {
+        d.date = todayYMD;
+      }
       if (!isValidYMD(d?.date)) return { kind: 'bad_request', message: 'sections.daily[].date must be YYYY-MM-DD' };
       if (d.visibility !== undefined && !VALID_VISIBILITIES.has(d.visibility)) {
         return { kind: 'bad_request', message: 'sections.daily[].visibility must be one of private|pod|public' };


### PR DESCRIPTION
## Summary
- Server-side default for `sections.daily[].date` when omitted — fills in today's UTC `YYYY-MM-DD` before validation.
- Closes Team-Commonly/commonly#435 (contract drift between `commonly_save_my_memory` MCP tool and backend YYYY-MM-DD validator).

## Why
Surfaced 2026-05-24 by Cody (cloud-codex) during the Phase 2 huddle smoke. The MCP tool advertises `section: 'daily'` with `entries` as input but doesn't tell callers each entry must already carry a `date: YYYY-MM-DD`. Natural writes fail:

```
sections.daily[].date must be YYYY-MM-DD
```

Cody's `long_term` writes worked; his `daily` write didn't. Same bug for any agent calling the tool naturally.

## Fix
In `backend/routes/agentsRuntime.ts`'s `validateSectionsPayload`, before checking `isValidYMD(d?.date)`, default `d.date` to today's UTC `YYYY-MM-DD` if missing. Explicit values still flow through unchanged:

- `date: '2026/04/14'` (wrong format) — still 400 (existing test passes)
- `date: '2026-02-30'` (calendar-invalid) — still 400 (existing test passes)
- `date` omitted — fills in today (new test added)

This is the kindest fix for the common caller: doesn't widen the schema, just normalizes one absent field.

## Test plan
- [x] New test in `backend/__tests__/service/agent-memory-envelope.test.js`: `defaults missing daily[].date to today UTC (YYYY-MM-DD)` — POSTs `{ daily: [{ content: 'x' }] }` (no date), expects 200, then GETs the memory and verifies today's date is on the stored entry.
- [x] Existing tests preserved (rejects-wrong-format + rejects-calendar-invalid + rejects-invalid-visibility).
- [ ] CI green
- [ ] After merge + deploy: Cody (or any agent) calls `commonly_save_my_memory({ section: 'daily', entries: [{ content: '...' }] })` without specifying date, confirms 200 + entry lands.

## Companion
- Issue #435 — original report from Cody with the MCP-tool seam pointer at `commonly-mcp/src/tools.js:230`.
- Phase-4 finding #12 in `docs/audits/ui-smoke-2026-05-23/huddle-observations.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)