### PR TITLE
feat(provisioner): moltbot /workspace is a git repo + TOOLS.md notes (closes #437)

### DIFF
--- a/backend/services/agentProvisionerServiceK8s.ts
+++ b/backend/services/agentProvisionerServiceK8s.ts
@@ -646,7 +646,12 @@ const normalizeWorkspaceDocs = async (accountId: any, { gateway } : any = {}) =>
     `  if grep -q "## Git workflow" "${toolsPath}"; then`,
     `    sed -i "s|Default PR target branch: \`[^${'`'}]*\`|Default PR target branch: \`${DEFAULT_BRANCH}\`|g" "${toolsPath}" || true`,
     `  else`,
-    `    printf '\\n## Git workflow\\n\\n- Default PR target branch: \`${DEFAULT_BRANCH}\`\\n- All PRs must target this branch. Update when the release branch changes.\\n' >> "${toolsPath}"`,
+    `    printf '\\n## Git workflow\\n\\n- Your workspace at \`/workspace/${accountId}\` is a git repository — \`git status\`, \`git add\`, \`git commit\`, \`git push\`, and \`gh pr create\` all work non-interactively. Credentials are wired globally via \`/state/.git-credentials\`.\\n- For new clones, prefer \`/tmp\` over your workspace to keep the PVC small.\\n- Default PR target branch: \`${DEFAULT_BRANCH}\`\\n- All PRs must target this branch. Update when the release branch changes.\\n' >> "${toolsPath}"`,
+    `  fi`,
+    // Ensure the workspace-is-a-git-repo line is present even on TOOLS.md
+    // files that pre-date the workspace-git-init change (#437).
+    `  if ! grep -q "workspace at \\\`/workspace/${accountId}\\\` is a git repository" "${toolsPath}"; then`,
+    `    sed -i "/^## Git workflow$/a - Your workspace at \\\`/workspace/${accountId}\\\` is a git repository — \\\`git status\\\`, \\\`git add\\\`, \\\`git commit\\\`, \\\`git push\\\`, and \\\`gh pr create\\\` all work non-interactively. Credentials are wired globally via \\\`/state/.git-credentials\\\`." "${toolsPath}" || true`,
     `  fi`,
     `fi`,
     `if [ -f "${commonlySkillPath}" ]; then`,
@@ -732,6 +737,40 @@ const normalizeWorkspaceDocs = async (accountId: any, { gateway } : any = {}) =>
     command: ['sh', '-lc', script],
   });
   return result.stdout.trim() || agentPath;
+};
+
+// Sprint follow-up (#437): moltbot workspace = git worktree.
+// Idempotently `git init` the agent's `/workspace/<accountId>/` directory
+// and stamp a workspace-local user.name / user.email so any agent that
+// wants to `git commit && git push` against a real GitHub repo can do so
+// without a manual bootstrap step. Credential helper is wired globally
+// in the clawdbot postStart hook (see k8s/helm/.../clawdbot-deployment.yaml),
+// so `git push` against `https://github.com/...` already auths via
+// `/state/.git-credentials`. Cloud-codex pods get the equivalent treatment
+// from their boot script — this brings moltbot to parity.
+const ensureWorkspaceGitRepo = async (accountId: any, { gateway } : any = {}) => {
+  const podName = await resolveGatewayPodNameWithRetry(gateway);
+  const agentPath = `/workspace/${accountId}`;
+  const script = [
+    'set -eu',
+    `mkdir -p "${agentPath}"`,
+    `cd "${agentPath}"`,
+    'if [ ! -d .git ]; then',
+    '  git init -q .',
+    `  git config user.name "Clawdbot Agent (${accountId})"`,
+    `  git config user.email "clawdbot+${accountId}@commonly.me"`,
+    `  echo "[provisioner] git init at ${agentPath}"`,
+    'else',
+    `  echo "[provisioner] git already initialized at ${agentPath}"`,
+    'fi',
+    `echo "${agentPath}"`,
+  ].join('\n');
+  const result = await execInPod({
+    podName,
+    containerName: 'clawdbot-gateway',
+    command: ['sh', '-lc', script],
+  });
+  return result.stdout.trim().split('\n').pop() || agentPath;
 };
 
 const ensureWorkspaceMemoryFiles = async (accountId: any, { gateway } : any = {}) => {
@@ -2492,6 +2531,14 @@ const provisionOpenClawAccount = async ({
     }
   } catch (error: any) {
     console.warn('[k8s-provisioner] Failed to ensure workspace memory files:', (error as Error).message);
+  }
+  try {
+    const gitPath = await ensureWorkspaceGitRepo(accountId, { gateway });
+    if (gitPath) {
+      console.log(`[k8s-provisioner] ensured git repo for ${accountId}: ${gitPath}`);
+    }
+  } catch (error: any) {
+    console.warn('[k8s-provisioner] Failed to ensure workspace git repo:', (error as Error).message);
   }
 
   return {


### PR DESCRIPTION
## Summary

Brings moltbot agents (theo / nova / pixel / ops / aria) to parity with cloud-codex on git operations. Before this, `/workspace/<accountId>/` was a plain directory — agents could not `git status`, `git commit`, or `git push` without a manual bootstrap. With the global credential helper already wired in the clawdbot postStart hook, all that was missing was `git init` on the workspace itself.

## Changes

- `ensureWorkspaceGitRepo(accountId, { gateway })` helper — idempotent `git init` + workspace-local `user.name` / `user.email` stamped with the accountId so commits attribute per-agent (`Clawdbot Agent (nova)`) rather than the generic pod-global identity.
- Called from `provisionOpenClawAccount` after `normalizeWorkspaceDocs` and `ensureWorkspaceMemoryFiles`. Wrapped in try/catch with non-fatal warning, matching the sibling workspace-setup steps.
- `TOOLS.md` "Git workflow" section extended so agents discover the workspace-is-a-repo fact + credential wiring. Both new-file and existing-file paths handled (sed-injects the new line on TOOLS.md from before this change).

## Audit deltas

The pre-existing audit (`docs/audits/2026-05-24-phase-3/openclaw-moltbot-workspace-audit.md`) called for `apt-get install -y git` as part of the fix. NOT needed — `git` was already on PATH in the clawdbot image (verified via `kubectl exec deploy/clawdbot-gateway -- which git` → `/usr/bin/git 2.39.5`). Scope is ~50 LOC across one file instead of the audit's 75 across three.

## Test plan

- [ ] CI: backend type-check + unit suite passes
- [ ] Post-Deploy: pick a dev agent (e.g. nova), trigger `reprovision-all`, then `kubectl exec deploy/clawdbot-gateway -- ls /workspace/nova/.git` — should exist after the next provision cycle.
- [ ] Manual: have nova run `cd /workspace/nova && git status` in an `acpx_run` shell — should report a clean tree, not "fatal: not a git repository".

Closes #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)