### PR TITLE
feat(cli): claude wrapper attach auto-wires @commonlyai/mcp by default (closes #440)

### DIFF
--- a/cli/__tests__/attach.test.mjs
+++ b/cli/__tests__/attach.test.mjs
@@ -29,6 +29,7 @@ const {
   performAttach,
   saveAgentToken,
   loadAgentToken,
+  buildDefaultEnvironment,
 } = await import('../src/commands/agent.js');
 
 const makeClient = ({ publishOk = true, runtimeToken = null } = {}) => {
@@ -76,12 +77,16 @@ describe('performAttach', () => {
     expect(result.instanceId).toBe('default');
     expect(result.detected.path).toBe('(builtin)');
 
+    // Post-refactor: runtimeType is per-adapter (e.g. 'stub', 'claude-code',
+    // 'codex'); the legacy `wrappedCli` slot is folded into `runtimeType` and
+    // 'host: byo' distinguishes a CLI-attached agent from a hosted one of the
+    // same identity. The stub adapter declares runtimeType='stub'.
     expect(client.post).toHaveBeenCalledWith(
       '/api/registry/publish',
       expect.objectContaining({
         manifest: expect.objectContaining({
           name: 'my-stub',
-          runtimeType: 'local-cli',
+          runtimeType: 'stub',
         }),
       }),
     );
@@ -92,8 +97,8 @@ describe('performAttach', () => {
         podId: 'pod-1',
         config: expect.objectContaining({
           runtime: expect.objectContaining({
-            runtimeType: 'local-cli',
-            wrappedCli: 'stub',
+            runtimeType: 'stub',
+            host: 'byo',
           }),
         }),
       }),
@@ -147,6 +152,70 @@ describe('performAttach', () => {
       podId: 'p',
     })).rejects.toThrow(/Unknown adapter/);
     expect(client.post).not.toHaveBeenCalled();
+  });
+
+  test('claude attach without --env installs with default commonly-mcp environment (#440)', async () => {
+    const client = makeClient({ runtimeToken: 'cm_agent_ok' });
+    await performAttach({
+      client,
+      adapterName: 'claude',
+      agentName: 'my-claude',
+      podId: 'pod-mcp',
+    });
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/registry/install',
+      expect.objectContaining({
+        config: expect.objectContaining({
+          environment: expect.objectContaining({
+            mcp: expect.arrayContaining([
+              expect.objectContaining({
+                name: 'commonly',
+                command: ['npx', '-y', '@commonlyai/mcp@latest'],
+                env: expect.objectContaining({
+                  COMMONLY_API_URL: '${COMMONLY_API_URL}',
+                  COMMONLY_AGENT_TOKEN: '${COMMONLY_AGENT_TOKEN}',
+                }),
+              }),
+            ]),
+          }),
+        }),
+      }),
+    );
+  });
+
+  test('stub adapter (no MCP support) attaches without a default environment', async () => {
+    const client = makeClient({ runtimeToken: 'cm_agent_stub' });
+    await performAttach({
+      client,
+      adapterName: 'stub',
+      agentName: 'my-stub-no-mcp',
+      podId: 'pod-stub',
+    });
+
+    const installCall = client.post.mock.calls.find(([route]) => route === '/api/registry/install');
+    expect(installCall).toBeDefined();
+    // Default env is gated to adapters that read --mcp-config; stub omits it.
+    expect(installCall[1].config.environment).toBeUndefined();
+  });
+});
+
+describe('buildDefaultEnvironment', () => {
+  test('returns null for adapters that do not consume --mcp-config (codex, stub)', () => {
+    expect(buildDefaultEnvironment('codex')).toBeNull();
+    expect(buildDefaultEnvironment('stub')).toBeNull();
+    expect(buildDefaultEnvironment('does-not-exist')).toBeNull();
+  });
+
+  test('returns a single mcp entry for claude with placeholder env values', () => {
+    const env = buildDefaultEnvironment('claude');
+    expect(env.mcp).toHaveLength(1);
+    expect(env.mcp[0].name).toBe('commonly');
+    expect(env.mcp[0].transport).toBe('stdio');
+    // Placeholders are substituted at spawn-time by the adapter; the env file
+    // itself MUST stay free of secrets so it can be checked in.
+    expect(env.mcp[0].env.COMMONLY_AGENT_TOKEN).toBe('${COMMONLY_AGENT_TOKEN}');
+    expect(env.mcp[0].env.COMMONLY_API_URL).toBe('${COMMONLY_API_URL}');
   });
 });
 

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -103,6 +103,38 @@ export const listLocalAgents = () => {
 // as no_action even if they happen to carry `content` in their payload.
 const CHAT_EVENT_TYPES = new Set(['chat.mention', 'message.posted', 'dm.message']);
 
+// ── default environment for adapters that benefit from auto-MCP wiring ─────
+
+// Adapters that can consume `mcp[]` from the resolved environment spec.
+// `claude` reads it via --mcp-config (see adapters/claude.js). `codex` and
+// `stub` do not (codex uses ~/.codex/config.toml at boot, set up server-side
+// for cloud-codex; the local codex wrapper doesn't ship MCP wiring yet —
+// follow-up after #440). Returning null means "no default" — the wrapper
+// proceeds with environment=null exactly like before this change.
+const ADAPTERS_WITH_DEFAULT_MCP = new Set(['claude']);
+
+// Minimum-viable environment for fresh attach: wire @commonlyai/mcp so the
+// agent gets commonly_* kernel tools out of the box. ${COMMONLY_API_URL} and
+// ${COMMONLY_AGENT_TOKEN} are substituted at spawn-time by the adapter
+// (cli/src/lib/adapters/claude.js §substitutePlaceholders) so the env file
+// stays free of per-attach secrets.
+export const buildDefaultEnvironment = (adapterName) => {
+  if (!ADAPTERS_WITH_DEFAULT_MCP.has(adapterName)) return null;
+  return {
+    mcp: [
+      {
+        name: 'commonly',
+        transport: 'stdio',
+        command: ['npx', '-y', '@commonlyai/mcp@latest'],
+        env: {
+          COMMONLY_API_URL: '${COMMONLY_API_URL}',
+          COMMONLY_AGENT_TOKEN: '${COMMONLY_AGENT_TOKEN}',
+        },
+      },
+    ],
+  };
+};
+
 // ── attach: register a local-CLI-wrapped agent (ADR-005) ────────────────────
 
 /**
@@ -157,6 +189,17 @@ export const performAttach = async ({
         `sandbox.mode=${sandboxMode} is not yet implemented in the local-CLI driver. `
         + `Phase 1 supports: none, bwrap.`,
       );
+    }
+  } else {
+    // No --env provided. Apply a sensible default if the adapter supports MCP
+    // so a fresh `commonly agent attach claude` gives the agent commonly_*
+    // kernel tools out of the box (parity with cloud-codex, which boots with
+    // @commonlyai/mcp pre-wired in ~/.codex/config.toml). Operators can still
+    // opt out by passing an explicit --env that omits the MCP block.
+    // See #440 for the gap that motivated this default.
+    environment = buildDefaultEnvironment(adapterName);
+    if (environment) {
+      log(`environment: applied default with @commonlyai/mcp wired (pass --env to override)`);
     }
   }
 


### PR DESCRIPTION
## Summary

`commonly agent attach claude` without `--env` now installs a sensible default environment that wires up `@commonlyai/mcp` via stdio. Agents get `commonly_*` kernel tools out of the box — parity with cloud-codex, which boots with the same MCP server pre-wired in `~/.codex/config.toml`.

## Why

Before this, a fresh `commonly agent attach claude --pod X` produced an agent that couldn't call any `commonly_*` tool (no `commonly_post_message`, no `commonly_read_context`, etc.) — the agent would receive `chat.mention` events and respond purely through text output piped back via the runtime token's `/messages` POST. That's fine for pure chat agents but blocks any agent that needs to attach a file, react, open a DM, or write memory mid-turn. Cloud-codex doesn't have this gap because its deployment template seeds `~/.codex/config.toml` with the MCP server. The local CLI wrapper was the odd one out.

## Changes

- `buildDefaultEnvironment(adapterName)` in `cli/src/commands/agent.js` — returns a minimal env spec with one MCP entry (`name: commonly`, `command: ['npx', '-y', '@commonlyai/mcp@latest']`, env placeholders for the per-attach token + instance URL).
- Wired into `performAttach` — applied only when `--env` is omitted, so explicit user configs are respected as-is.
- `ADAPTERS_WITH_DEFAULT_MCP = new Set(['claude'])` — codex wrapper doesn't read `--mcp-config` (it uses `~/.codex/config.toml`, which the local wrapper doesn't write yet); stub doesn't run a real CLI. Both return `null` from `buildDefaultEnvironment`.
- Tests: 2 new performAttach cases (claude gets default, stub doesn't) + 2 buildDefaultEnvironment unit tests.
- Drive-by fix: stale pre-existing attach.test case asserting the legacy `runtimeType='local-cli'` + `wrappedCli='stub'` pair — `runtimeType` is per-adapter post-refactor.

## Test plan

- [x] Local: `cd cli && NODE_OPTIONS=--experimental-vm-modules npx jest __tests__/attach.test.mjs` — 10/10 pass.
- [x] Local: claude environment + adapter tests still green (20 passed, 1 skipped).
- [ ] CI: backend type-check + unit suite passes. CLI tests are not run by CI today (separate gap; filing follow-up).
- [ ] Manual: after deploy + token rotation, fresh `commonly agent attach claude --pod X` should produce an agent that can call `commonly_post_message` on its first turn without `--env`.

## Follow-ups

- Codex CLI wrapper MCP wiring — same end goal, different mechanism (`~/.codex/config.toml`).
- CI gap — `cli/__tests__/*.test.mjs` are not part of `Test & Coverage`. Worth surfacing.

Closes #440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)