### PR TITLE
feat(mcp): add commonly_create_task tool (closes #442 part 1)

### DIFF
--- a/packages/commonly-mcp/src/__tests__/cap-tools.test.ts
+++ b/packages/commonly-mcp/src/__tests__/cap-tools.test.ts
@@ -295,3 +295,125 @@ describe("commonly_memory_sync", () => {
     ).rejects.toThrow(/400/);
   });
 });
+
+describe("commonly_create_task", () => {
+  it("creates a task with title only", async () => {
+    const client = {
+      createTask: vi.fn().mockResolvedValue({
+        task: { taskId: "TASK-001", taskNum: 1, title: "Test task" },
+        alreadyExists: false,
+      }),
+    } as unknown as CommonlyClient;
+
+    const result = await handleToolCall(
+      client,
+      "commonly_create_task",
+      { podId: "pod-1", title: "Test task" },
+      baseConfig()
+    );
+
+    expect(client.createTask).toHaveBeenCalledWith("pod-1", expect.objectContaining({
+      title: "Test task",
+    }));
+    expect(result).toEqual(expect.objectContaining({
+      taskId: "TASK-001",
+      title: "Test task",
+      alreadyExists: false,
+      podId: "pod-1",
+    }));
+  });
+
+  it("falls back to COMMONLY_DEFAULT_POD when podId omitted", async () => {
+    const client = {
+      createTask: vi.fn().mockResolvedValue({
+        task: { taskId: "TASK-002", taskNum: 2 },
+      }),
+    } as unknown as CommonlyClient;
+
+    await handleToolCall(
+      client,
+      "commonly_create_task",
+      { title: "Defaults to env-default pod" },
+      baseConfig({ defaultPodId: "pod-default" })
+    );
+
+    expect(client.createTask).toHaveBeenCalledWith("pod-default", expect.any(Object));
+  });
+
+  it("rejects when no podId and no default", async () => {
+    const client = { createTask: vi.fn() } as unknown as CommonlyClient;
+    await expect(
+      handleToolCall(
+        client,
+        "commonly_create_task",
+        { title: "x" },
+        baseConfig({ defaultPodId: undefined })
+      )
+    ).rejects.toThrow(/podId is required/);
+    expect(client.createTask).not.toHaveBeenCalled();
+  });
+
+  it("rejects when title is missing", async () => {
+    const client = { createTask: vi.fn() } as unknown as CommonlyClient;
+    await expect(
+      handleToolCall(
+        client,
+        "commonly_create_task",
+        { podId: "pod-1" },
+        baseConfig()
+      )
+    ).rejects.toThrow(/title is required/);
+    expect(client.createTask).not.toHaveBeenCalled();
+  });
+
+  it("surfaces alreadyExists when sourceRef matches an existing task", async () => {
+    const client = {
+      createTask: vi.fn().mockResolvedValue({
+        task: { taskId: "TASK-003", taskNum: 3 },
+        alreadyExists: true,
+      }),
+    } as unknown as CommonlyClient;
+
+    const result = await handleToolCall(
+      client,
+      "commonly_create_task",
+      { podId: "pod-1", title: "Same as existing", sourceRef: "GH#42" },
+      baseConfig()
+    );
+
+    expect(result).toEqual(expect.objectContaining({
+      alreadyExists: true,
+      taskId: "TASK-003",
+    }));
+  });
+
+  it("forwards optional fields verbatim", async () => {
+    const client = {
+      createTask: vi.fn().mockResolvedValue({ task: { taskId: "TASK-004" } }),
+    } as unknown as CommonlyClient;
+
+    await handleToolCall(
+      client,
+      "commonly_create_task",
+      {
+        podId: "pod-1",
+        title: "Sub-task",
+        assignee: "nova",
+        dep: "TASK-003",
+        parentTask: "TASK-002",
+        source: "huddle",
+        sourceRef: "huddle-2026-05-24",
+      },
+      baseConfig()
+    );
+
+    expect(client.createTask).toHaveBeenCalledWith("pod-1", {
+      title: "Sub-task",
+      assignee: "nova",
+      dep: "TASK-003",
+      parentTask: "TASK-002",
+      source: "huddle",
+      sourceRef: "huddle-2026-05-24",
+    });
+  });
+});

--- a/packages/commonly-mcp/src/client.ts
+++ b/packages/commonly-mcp/src/client.ts
@@ -608,6 +608,41 @@ export class CommonlyClient {
     return response.data;
   }
 
+  /**
+   * Create a task on the pod board via agent auth. Hits `POST /api/v1/tasks/:podId`,
+   * which accepts agent runtime tokens (same `auth` middleware that powers
+   * the human-facing task surface; `req.agentUser._id` falls in for `userId`).
+   * Mid-turn task creation parity with the heartbeat-cycle `commonly_create_task`
+   * available to moltbots — closes #442 part 1.
+   */
+  async createTask(
+    podId: string,
+    options: {
+      title: string;
+      assignee?: string;
+      dep?: string;
+      parentTask?: string;
+      source?: string;
+      sourceRef?: string;
+    }
+  ): Promise<{ task: Record<string, unknown>; alreadyExists?: boolean }> {
+    const http = this.requireAgentHttp();
+    if (!podId) throw new MCPClientError("createTask requires a non-empty podId");
+    if (!options?.title) throw new MCPClientError("createTask requires title");
+    const response = await http.post<{ task: Record<string, unknown>; alreadyExists?: boolean }>(
+      `/api/v1/tasks/${encodeURIComponent(podId)}`,
+      {
+        title: options.title,
+        assignee: options.assignee,
+        dep: options.dep,
+        parentTask: options.parentTask,
+        source: options.source,
+        sourceRef: options.sourceRef,
+      }
+    );
+    return response.data;
+  }
+
   async postMessageCAP(
     podId: string,
     options: CAPPostMessageOptions

--- a/packages/commonly-mcp/src/tools/cap-create-task.ts
+++ b/packages/commonly-mcp/src/tools/cap-create-task.ts
@@ -1,0 +1,123 @@
+/**
+ * commonly_create_task — create a task on the pod board mid-turn.
+ *
+ * Hits `POST /api/v1/tasks/:podId` via agent auth. Moltbots already get
+ * this via the openclaw extension's `commonly_*` block during heartbeat,
+ * but MCP-driven agents (claude-code, codex, cursor) had no way to create
+ * a task during a chat.mention turn — they could only describe the work
+ * in chat. Closes #442 part 1.
+ *
+ * Idempotent on `sourceRef`: the backend returns the existing task with
+ * `alreadyExists: true` if a task with the same `sourceRef` already lives
+ * in the pod. Title-fuzzy dedup is intentionally NOT in the backend (it
+ * was a prompt-judgment convention in task-clerk; never enforced in the
+ * route). Callers who want title-level dedup should query first via
+ * commonly_pods + a future commonly_list_tasks tool.
+ */
+
+import { CommonlyClient } from "../client.js";
+import type { Config } from "../index.js";
+
+export const definition = {
+  name: "commonly_create_task",
+  description:
+    "Create a task on a pod's board mid-turn. Use this when a user " +
+    "asks for a task to be captured, or when an agent needs to spawn " +
+    "follow-up work. Requires COMMONLY_AGENT_TOKEN. Idempotent on " +
+    "`sourceRef` — re-passing the same sourceRef returns the existing " +
+    "task with `alreadyExists: true` rather than creating a duplicate. " +
+    "Does NOT title-fuzzy-dedup; query first if duplicate-prevention " +
+    "matters for your use case.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      podId: {
+        type: "string",
+        description:
+          "Target pod id. If omitted, falls back to COMMONLY_DEFAULT_POD.",
+      },
+      title: {
+        type: "string",
+        description: "Task title. Required.",
+      },
+      assignee: {
+        type: "string",
+        description:
+          "Optional assignee handle (instanceId or @-mention without the @).",
+      },
+      dep: {
+        type: "string",
+        description:
+          "Optional task id this task blocks on (e.g. 'TASK-055').",
+      },
+      parentTask: {
+        type: "string",
+        description:
+          "Optional parent task id — creates this as a sub-task.",
+      },
+      source: {
+        type: "string",
+        description:
+          "Optional origin tag — e.g. 'chat', 'github', 'huddle'. " +
+          "Default 'human' (set by backend).",
+      },
+      sourceRef: {
+        type: "string",
+        description:
+          "Optional dedup key — re-passing the same sourceRef in the " +
+          "same pod returns the existing task with `alreadyExists: true` " +
+          "(and reopens it if previously completed).",
+      },
+    },
+    required: ["title"],
+  },
+};
+
+export interface CapCreateTaskArgs {
+  podId?: string;
+  title: string;
+  assignee?: string;
+  dep?: string;
+  parentTask?: string;
+  source?: string;
+  sourceRef?: string;
+}
+
+export interface CapCreateTaskResult {
+  taskId: string | undefined;
+  taskNum: number | undefined;
+  title: string;
+  alreadyExists: boolean;
+  podId: string;
+}
+
+export async function handler(
+  client: CommonlyClient,
+  args: CapCreateTaskArgs,
+  config: Config
+): Promise<CapCreateTaskResult> {
+  const podId = args.podId || config.defaultPodId;
+  if (!podId) {
+    throw new Error(
+      "podId is required for commonly_create_task (or set COMMONLY_DEFAULT_POD)"
+    );
+  }
+  const response = await client.createTask(podId, {
+    title: args.title,
+    assignee: args.assignee,
+    dep: args.dep,
+    parentTask: args.parentTask,
+    source: args.source,
+    sourceRef: args.sourceRef,
+  });
+  const task: Record<string, unknown> = (response.task ?? {}) as Record<string, unknown>;
+  const rawTaskId = task.taskId;
+  const rawTaskNum = task.taskNum;
+  return {
+    taskId: typeof rawTaskId === "string" ? rawTaskId : undefined,
+    taskNum: typeof rawTaskNum === "number" ? rawTaskNum : undefined,
+    title: args.title,
+    alreadyExists: response.alreadyExists === true,
+    podId,
+  };
+}

--- a/packages/commonly-mcp/src/tools/index.ts
+++ b/packages/commonly-mcp/src/tools/index.ts
@@ -15,6 +15,7 @@ import * as CapAsk from "./cap-ask.js";
 import * as CapRespond from "./cap-respond.js";
 import * as CapReact from "./cap-react.js";
 import * as CapTyping from "./cap-typing.js";
+import * as CapCreateTask from "./cap-create-task.js";
 
 export interface Tool {
   name: string;
@@ -232,6 +233,9 @@ export const tools: Tool[] = [
   // Codex) so their messages don't appear "cold" without the pre-roll
   // humans get for native runtime agents.
   CapTyping.definition,
+  // Mid-turn task creation. Moltbots already had this via the openclaw
+  // extension's commonly_* block; MCP-driven agents didn't (#442 part 1).
+  CapCreateTask.definition,
 ];
 
 /**
@@ -451,6 +455,24 @@ export async function handleToolCall(
         {
           podId: args.podId as string | undefined,
           action: args.action as "start" | "stop" | undefined,
+        },
+        config
+      );
+    }
+
+    case CapCreateTask.definition.name: {
+      const title = args.title as string | undefined;
+      if (!title) throw new Error("title is required");
+      return CapCreateTask.handler(
+        client,
+        {
+          podId: args.podId as string | undefined,
+          title,
+          assignee: args.assignee as string | undefined,
+          dep: args.dep as string | undefined,
+          parentTask: args.parentTask as string | undefined,
+          source: args.source as string | undefined,
+          sourceRef: args.sourceRef as string | undefined,
         },
         config
       );


### PR DESCRIPTION
## Summary

MCP-driven agents (claude-code, codex, cursor, the future native-MCP-tools runtime) had no way to create a pod-board task mid-turn — they could only describe the work in chat. Moltbots already had this via the openclaw extension's `commonly_*` block; this brings MCP to parity.

## Changes

- `CommonlyClient.createTask(podId, options)` — wraps `POST /api/v1/tasks/:podId` via `agentHttp` (route accepts agent runtime tokens via the same `auth` middleware that powers the human surface).
- `packages/commonly-mcp/src/tools/cap-create-task.ts` exposes it as `commonly_create_task`. Args: `{ podId, title, assignee?, dep?, parentTask?, source?, sourceRef? }`. Returns `{ taskId, taskNum, title, alreadyExists, podId }`.
- Idempotent on `sourceRef`: re-passing the same sourceRef returns the existing task with `alreadyExists: true` (and reopens it if previously completed) — matches existing backend semantics.

## Scope-Cut Notice

The original #442 issue described two gaps:

1. ✅ **No `commonly_create_task` MCP tool** — fixed here.
2. ❌ **Fuzzy-match dedup refuses duplicates without disambiguation** — investigated and **does not actually exist as a backend constraint**. Verified by reading `backend/routes/tasksApi.ts`: the only dedup is on `sourceRef` (exact match). The "fuzzy refuses duplicates" behavior the issue describes was a **task-clerk LLM prompt judgment** (`backend/config/native-agents/task-clerk.ts` says "DO NOT create a task if recent context shows an identical task was already created"), not a routing constraint.

I'll surface this distinction on the issue and close it as part-1-done + part-2-misframed.

## Test plan

- [x] Local: `cd packages/commonly-mcp && npx vitest run src/__tests__/cap-tools.test.ts` — 23/23 pass.
- [x] Local: `npm run build` produces a clean TSC compile.
- [ ] CI: backend test + lint passes.
- [ ] Post-publish (Phase 2): bump `@commonlyai/mcp` minor; cloud-codex auto-pulls on next pod restart (configured via `agents.cloudCodex.commonlyMcpVersion` in values).
- [ ] Manual: have Cody (cloud-codex on dev) call `commonly_create_task` from a chat-turn — task should appear in `/v2/board`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)