### PR TITLE
docs: add Tuning Engines LiteLLM route example

### DIFF
--- a/docs/development/LITELLM.md
+++ b/docs/development/LITELLM.md
@@ -173,6 +173,15 @@ model_list:
       model: openrouter/nvidia/nemotron-3-super-120b-a12b:free
       api_key: os.environ/OPENROUTER_API_KEY
 
+  # Optional: route through Tuning Engines for governed access, policy,
+  # request traces, and tenant-level usage reporting while Commonly still
+  # owns the agent runtime, pods, tasks, and memory.
+  - model_name: te-gpt-5.4-mini
+    litellm_params:
+      model: openai/gpt-5.4-mini
+      api_base: https://api.tuningengines.com/v1
+      api_key: os.environ/TUNING_ENGINES_API_KEY
+
 router_settings:
   routing_strategy: least-busy
   enable_pre_call_checks: true
@@ -215,6 +224,7 @@ kubectl exec -n commonly-dev deployment/backend -- sh -c 'echo "LITELLM_BASE_URL
 | `DATABASE_URL` | built from `pgUser/pgHost/pgPort/pgDatabase` + `PG_PASSWORD` secret |
 | `GEMINI_API_KEY` | `api-keys` secret (optional) |
 | `OPENROUTER_API_KEY` | `api-keys` secret (optional) |
+| `TUNING_ENGINES_API_KEY` | `api-keys` secret (optional, for governed OpenAI-compatible routes) |
 | `OPENAI_API_KEY` | `api-keys` secret (optional) |
 | `CHATGPT_TOKEN_DIR` | `/chatgpt-auth` (emptyDir, written by init container) |
 | `OPENAI_CODEX_ACCESS_TOKEN` | `api-keys` secret (read by init container) |


### PR DESCRIPTION
## Summary
- add an optional Tuning Engines route to the existing LiteLLM model gateway docs
- show the OpenAI-compatible base URL and environment variable for the virtual key
- clarify that Commonly still owns the agent runtime, pods, tasks, and memory while Tuning Engines can provide governed model access, policy, traces, and usage reporting

## Why
We are an AI infrastructure team using agent runtimes with governed OpenAI-compatible endpoints. Since this doc already explains LiteLLM routing for Commonly agents, this gives teams a copy-paste setup path for adding governance and traces without changing Commonly's agent model.

It would mean a lot to us if you are open to including this. Happy to adjust wording or placement to match the docs style.

## Validation
- git diff --check