### PR TITLE
feat(v2): v2-native marketplace browse page

### DIFF
--- a/frontend/src/v2/V2App.tsx
+++ b/frontend/src/v2/V2App.tsx
@@ -17,7 +17,7 @@ import Thread from '../components/Thread';
 import UserProfile from '../components/UserProfile';
 import Dashboard from '../components/Dashboard';
 import DailyDigest from '../components/DailyDigest';
-import AppsMarketplacePage from '../components/apps/AppsMarketplacePage';
+import V2MarketplacePage from './marketplace/V2MarketplacePage';
 import V2MarketplaceDetailPage from './marketplace/V2MarketplaceDetailPage';
 import './marketplace/V2MarketplaceDetailPage.css';
 import AgentsHub from '../components/agents/AgentsHub';
@@ -194,7 +194,7 @@ const V2App: React.FC = () => {
                 />
                 <Route
                   path="marketplace"
-                  element={feature('Marketplace', 'Browse apps, integrations, official listings, and installed apps.', <AppsMarketplacePage />)}
+                  element={feature('Marketplace', 'Browse and install agents, apps, and integrations.', <V2MarketplacePage />, false, false)}
                 />
                 <Route
                   path="marketplace/:installableId"

--- a/frontend/src/v2/marketplace/V2MarketplacePage.css
+++ b/frontend/src/v2/marketplace/V2MarketplacePage.css
@@ -1,0 +1,330 @@
+/* V2 marketplace browse — token-aligned, single-accent, borders not shadows.
+ * Mirrors V2MarketplaceDetailPage.css discipline. Button rules are prefixed
+ * with `.v2-root button.X` to beat the global v2 button reset (0,0,2,1).
+ */
+
+.v2-mkt {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px;
+  color: var(--v2-text-primary);
+  font-family: var(--v2-font);
+}
+
+.v2-mkt__header {
+  margin-bottom: 20px;
+}
+.v2-mkt__title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--v2-text-primary);
+}
+.v2-mkt__subtitle {
+  margin: 4px 0 0;
+  font-size: 14px;
+  color: var(--v2-text-secondary);
+}
+
+/* Filter bar */
+.v2-mkt__filterbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+.v2-mkt__search {
+  flex: 1 1 280px;
+  min-width: 0;
+  height: 38px;
+  padding: 0 12px;
+  font-size: 14px;
+  font-family: var(--v2-font);
+  color: var(--v2-text-primary);
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius);
+  outline: none;
+}
+.v2-mkt__search:focus {
+  border-color: var(--v2-accent);
+}
+.v2-mkt__control {
+  flex: 0 1 170px;
+  height: 38px;
+  padding: 0 10px;
+  font-size: 14px;
+  font-family: var(--v2-font);
+  color: var(--v2-text-primary);
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius);
+  cursor: pointer;
+  outline: none;
+}
+.v2-mkt__control:focus {
+  border-color: var(--v2-accent);
+}
+
+/* Tabs — accent underline on active, per design system */
+.v2-mkt__tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--v2-border-soft);
+  margin-bottom: 16px;
+}
+.v2-root button.v2-mkt__tab {
+  height: 38px;
+  padding: 0 14px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--v2-text-secondary);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  cursor: pointer;
+  transition: color 80ms ease, border-color 80ms ease;
+}
+.v2-root button.v2-mkt__tab:hover {
+  color: var(--v2-text-primary);
+}
+.v2-root button.v2-mkt__tab--active {
+  color: var(--v2-accent-text);
+  border-bottom-color: var(--v2-accent);
+}
+
+/* Status + error banners */
+.v2-mkt__status,
+.v2-mkt__error {
+  padding: 8px 12px;
+  border-radius: var(--v2-radius);
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+.v2-mkt__status {
+  background: var(--v2-accent-soft);
+  color: var(--v2-accent-text);
+}
+.v2-mkt__error {
+  background: var(--v2-danger-soft, rgba(239, 68, 68, 0.1));
+  color: var(--v2-danger);
+}
+
+/* Sections */
+.v2-mkt__section {
+  margin-bottom: 32px;
+}
+.v2-mkt__section-title {
+  margin: 0 0 4px;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--v2-text-secondary);
+}
+.v2-mkt__section-sub {
+  margin: 0 0 14px;
+  font-size: 13px;
+  color: var(--v2-text-tertiary, var(--v2-text-secondary));
+}
+
+/* Grid */
+.v2-mkt__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+/* Empty state */
+.v2-mkt__empty {
+  padding: 48px 24px;
+  text-align: center;
+  border: 1px dashed var(--v2-border);
+  border-radius: var(--v2-radius-lg);
+}
+.v2-mkt__empty-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--v2-text-primary);
+  margin-bottom: 4px;
+}
+.v2-mkt__empty-text {
+  font-size: 13px;
+  color: var(--v2-text-secondary);
+}
+
+/* Card */
+.v2-mkt-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-border-soft);
+  border-radius: var(--v2-radius-lg);
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.v2-mkt-card:hover {
+  border-color: var(--v2-border);
+  background: var(--v2-surface-hover);
+}
+.v2-mkt-card:focus-visible {
+  outline: 2px solid var(--v2-accent);
+  outline-offset: 2px;
+}
+.v2-mkt-card--static {
+  cursor: default;
+}
+.v2-mkt-card--static:hover {
+  border-color: var(--v2-border-soft);
+  background: var(--v2-surface);
+}
+.v2-mkt-card--skeleton {
+  height: 168px;
+  background: var(--v2-bg-subtle);
+  border-style: solid;
+  cursor: default;
+}
+
+.v2-mkt-card__head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.v2-mkt-card__logo {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--v2-radius);
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--v2-bg-subtle);
+}
+.v2-mkt-card__logo--placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--v2-text-secondary);
+  border: 1px solid var(--v2-border-soft);
+}
+.v2-mkt-card__id {
+  flex: 1;
+  min-width: 0;
+}
+.v2-mkt-card__name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.v2-mkt-card__name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--v2-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.v2-mkt-card__badge {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  background: var(--v2-accent-soft);
+  color: var(--v2-accent-text);
+  border-radius: var(--v2-radius-pill);
+}
+.v2-mkt-card__handle {
+  display: block;
+  font-size: 12px;
+  color: var(--v2-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.v2-mkt-card__desc {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--v2-text-secondary);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  flex: 1;
+}
+.v2-mkt-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+.v2-mkt-card__chip {
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: capitalize;
+  padding: 2px 8px;
+  background: var(--v2-bg-subtle);
+  color: var(--v2-text-secondary);
+  border-radius: var(--v2-radius-sm);
+}
+.v2-mkt-card__stat {
+  font-size: 12px;
+  color: var(--v2-text-secondary);
+  margin-left: auto;
+}
+.v2-mkt-card__actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+/* Card buttons — prefixed to beat the global v2 button reset */
+.v2-root button.v2-mkt-card__btn,
+.v2-root a.v2-mkt-card__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  padding: 0 14px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v2-bg);
+  background: var(--v2-accent);
+  border: 1px solid var(--v2-accent);
+  border-radius: var(--v2-radius-sm);
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background 80ms ease, color 80ms ease, border-color 80ms ease;
+}
+.v2-root button.v2-mkt-card__btn:hover,
+.v2-root a.v2-mkt-card__btn:hover {
+  background: var(--v2-accent-strong);
+  border-color: var(--v2-accent-strong);
+}
+.v2-root button.v2-mkt-card__btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.v2-root button.v2-mkt-card__btn--ghost,
+.v2-root a.v2-mkt-card__btn--ghost {
+  color: var(--v2-text-secondary);
+  background: transparent;
+  border: 1px solid var(--v2-border);
+}
+.v2-root button.v2-mkt-card__btn--ghost:hover,
+.v2-root a.v2-mkt-card__btn--ghost:hover {
+  color: var(--v2-text-primary);
+  background: var(--v2-surface-hover);
+  border-color: var(--v2-border-strong, var(--v2-border));
+}
+
+@media (max-width: 760px) {
+  .v2-mkt { padding: 20px 16px 48px; }
+  .v2-mkt__control { flex: 1 1 calc(50% - 5px); }
+}

--- a/frontend/src/v2/marketplace/V2MarketplacePage.tsx
+++ b/frontend/src/v2/marketplace/V2MarketplacePage.tsx
@@ -1,0 +1,450 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import './V2MarketplacePage.css';
+
+// Fresh v2-native marketplace browse page. Routed at /v2/marketplace. The
+// legacy AppsMarketplacePage stays on the v1 /apps mount; this one owns the
+// v2 shell. Reuses the shipped /api/marketplace/* + /api/registry/* endpoints
+// and the install→detail wiring (card body → detail page; Install → inline
+// install into the selected pod, matching the legacy marketplace behavior).
+
+interface App {
+  id: string;
+  installableId?: string;
+  name?: string;
+  displayName?: string;
+  description?: string;
+  installationId?: string;
+  instanceId?: string;
+  installBackend?: 'apps' | 'registry';
+  [key: string]: unknown;
+}
+
+interface Pod {
+  _id: string;
+  name: string;
+}
+
+const CATEGORIES = [
+  { id: 'all', label: 'All categories' },
+  { id: 'productivity', label: 'Productivity' },
+  { id: 'development', label: 'Development' },
+  { id: 'analytics', label: 'Analytics' },
+  { id: 'support', label: 'Support' },
+  { id: 'communication', label: 'Communication' },
+  { id: 'other', label: 'Other' },
+];
+
+const KINDS = [
+  { id: 'all', label: 'All kinds' },
+  { id: 'agent', label: 'Agents' },
+  { id: 'app', label: 'Apps' },
+  { id: 'skill', label: 'Skills' },
+  { id: 'bundle', label: 'Bundles' },
+];
+
+const authHeaders = (): Record<string, string> => ({
+  'x-auth-token': localStorage.getItem('token') || '',
+});
+
+const toMarketplaceApp = (item: any): App => {
+  const installableId = String(item?.installableId ?? item?._id ?? item?.id ?? '');
+  const handle = installableId.replace(/^@/, '');
+  const stats = item?.stats && typeof item.stats === 'object' ? item.stats : {};
+  const marketplace = item?.marketplace && typeof item.marketplace === 'object' ? item.marketplace : {};
+  const requires = Array.isArray(item?.requires) ? item.requires : [];
+  return {
+    ...item,
+    id: installableId,
+    installableId,
+    name: handle || String(item?.name || ''),
+    displayName: String(item?.name || installableId || 'Unknown'),
+    description: String(item?.description || ''),
+    kind: String(item?.kind || 'app'),
+    category: String(marketplace.category || 'other'),
+    verified: Boolean(marketplace.verified),
+    rating: Number(marketplace.rating || 0),
+    installs: Number(stats.totalInstalls || marketplace.installCount || 0),
+    logo: marketplace.logoUrl || marketplace.logo || null,
+    scopes: requires,
+    installBackend: 'registry',
+  };
+};
+
+const toInstalledRegistryApp = (agent: any): App => {
+  const installableId = String(agent?.name || '');
+  const profile = agent?.profile && typeof agent.profile === 'object' ? agent.profile : {};
+  return {
+    ...agent,
+    id: installableId,
+    installableId,
+    name: installableId.replace(/^@/, ''),
+    displayName: String(agent?.displayName || installableId || 'Unknown'),
+    description: String(profile.purpose || ''),
+    kind: 'agent',
+    category: String(agent?.category || 'other'),
+    logo: agent?.iconUrl || null,
+    instanceId: String(agent?.instanceId || 'default'),
+    installBackend: 'registry',
+  };
+};
+
+const toInstalledLegacyApp = (app: any): App => ({
+  ...app,
+  id: String(app?.id || ''),
+  installBackend: 'apps',
+});
+
+const initial = (s?: string): string => (s || '?').trim().charAt(0).toUpperCase() || '?';
+
+const V2MarketplacePage: React.FC = () => {
+  const navigate = useNavigate();
+  const [apps, setApps] = useState<App[]>([]);
+  const [official, setOfficial] = useState<any[]>([]);
+  const [integrations, setIntegrations] = useState<any[]>([]);
+  const [installed, setInstalled] = useState<App[]>([]);
+  const [pods, setPods] = useState<Pod[]>([]);
+  const [selectedPodId, setSelectedPodId] = useState('');
+  const [tab, setTab] = useState<'discover' | 'installed'>('discover');
+  const [search, setSearch] = useState('');
+  const [kind, setKind] = useState('all');
+  const [category, setCategory] = useState('all');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await axios.get('/api/pods', { headers: authHeaders() });
+        const list = (res.data as Pod[]) || [];
+        setPods(list);
+        setSelectedPodId((prev) => prev || list[0]?._id || '');
+      } catch {
+        /* pods are optional for browsing */
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams();
+        if (search) params.append('q', search);
+        if (category !== 'all') params.append('category', category);
+        if (kind !== 'all') params.append('kind', kind);
+        const res = await axios.get(`/api/marketplace/browse?${params.toString()}`);
+        if (cancelled) return;
+        setApps((((res.data as any)?.items) || []).map(toMarketplaceApp));
+      } catch {
+        if (cancelled) return;
+        setError('Failed to load the marketplace.');
+        setApps([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [search, category, kind]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await axios.get('/api/marketplace/official');
+        setOfficial((((res.data as any)?.entries) || []));
+      } catch {
+        /* official listings are best-effort */
+      }
+      if (!localStorage.getItem('token')) return;
+      try {
+        const res = await axios.get('/api/integrations/catalog', { headers: authHeaders() });
+        setIntegrations((((res.data as any)?.entries) || []));
+      } catch {
+        /* integration stats are best-effort */
+      }
+    })();
+  }, []);
+
+  const fetchInstalled = useCallback(async () => {
+    if (!selectedPodId) return;
+    try {
+      const [legacy, registry] = await Promise.allSettled([
+        axios.get(`/api/apps/pods/${selectedPodId}/apps`, { headers: authHeaders() }),
+        axios.get(`/api/registry/pods/${selectedPodId}/agents`, { headers: authHeaders() }),
+      ]);
+      const legacyApps = legacy.status === 'fulfilled'
+        ? ((((legacy.value.data as any).apps) || []).map(toInstalledLegacyApp)) : [];
+      const registryApps = registry.status === 'fulfilled'
+        ? ((((registry.value.data as any).agents) || []).map(toInstalledRegistryApp)) : [];
+      setInstalled([...legacyApps, ...registryApps]);
+    } catch {
+      /* leave installed list as-is on transient error */
+    }
+  }, [selectedPodId]);
+
+  useEffect(() => { fetchInstalled(); }, [fetchInstalled]);
+
+  const isInstalled = (id: string): boolean => installed.some((a) => a.id === id);
+
+  const integrationsById = useMemo(() => integrations.reduce((acc: Record<string, any>, e: any) => {
+    acc[e.id] = e; return acc;
+  }, {}), [integrations]);
+
+  const officialListings = useMemo(() => official.map((e: any) => ({
+    ...e,
+    capabilities: integrationsById[e.id]?.catalog?.capabilities || e.capabilities || [],
+    activeCount: integrationsById[e.id]?.stats?.activeIntegrations,
+  })), [official, integrationsById]);
+
+  const officialIntegrations = officialListings.filter((e: any) => e.type !== 'mcp-app');
+  const mcpListings = officialListings.filter((e: any) => e.type === 'mcp-app');
+
+  const openDetail = (app: App) => {
+    const id = String(app.installableId || app.id || '');
+    if (id) navigate(`/v2/marketplace/${encodeURIComponent(id)}`);
+  };
+
+  const install = async (app: App, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!selectedPodId) { setStatus('Pick a pod above to install into.'); return; }
+    setBusyId(app.id);
+    setStatus(null);
+    try {
+      await axios.post('/api/registry/install', {
+        agentName: String(app.installableId || app.id || ''),
+        podId: selectedPodId,
+        version: typeof app.version === 'string' ? app.version : undefined,
+        displayName: app.displayName || undefined,
+        scopes: Array.isArray(app.scopes) ? app.scopes : [],
+      }, { headers: authHeaders() });
+      setStatus(`Installed ${app.displayName || app.name} into ${pods.find((p) => p._id === selectedPodId)?.name || 'pod'}.`);
+      fetchInstalled();
+    } catch (err: any) {
+      setStatus(err?.response?.data?.error || 'Could not install — try again.');
+    } finally {
+      setBusyId('');
+    }
+  };
+
+  const remove = async (app: App, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!selectedPodId) return;
+    setBusyId(app.id);
+    try {
+      if (app.installBackend === 'registry') {
+        const id = encodeURIComponent(String(app.installableId || app.id || ''));
+        const params = new URLSearchParams();
+        if (app.instanceId && app.instanceId !== 'default') params.append('instanceId', app.instanceId);
+        const suffix = params.toString() ? `?${params.toString()}` : '';
+        await axios.delete(`/api/registry/agents/${id}/pods/${selectedPodId}${suffix}`, { headers: authHeaders() });
+      } else {
+        await axios.delete(`/api/apps/pods/${selectedPodId}/apps/${app.installationId}`, { headers: authHeaders() });
+      }
+      setStatus(`Removed ${app.displayName || app.name}.`);
+      fetchInstalled();
+    } catch {
+      setStatus('Could not remove — try again.');
+    } finally {
+      setBusyId('');
+    }
+  };
+
+  const connect = (entry: any) => {
+    setStatus(`Open a pod to connect ${entry.name}.`);
+    navigate('/v2');
+  };
+
+  const renderListingCard = (app: App) => {
+    const installedNow = isInstalled(app.id);
+    const busy = busyId === app.id;
+    return (
+      <article
+        key={app.id}
+        className="v2-mkt-card"
+        role="button"
+        tabIndex={0}
+        onClick={() => openDetail(app)}
+        onKeyDown={(ev) => { if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); openDetail(app); } }}
+      >
+        <div className="v2-mkt-card__head">
+          {app.logo ? (
+            <img className="v2-mkt-card__logo" src={String(app.logo)} alt="" aria-hidden="true" />
+          ) : (
+            <div className="v2-mkt-card__logo v2-mkt-card__logo--placeholder">{initial(app.displayName)}</div>
+          )}
+          <div className="v2-mkt-card__id">
+            <div className="v2-mkt-card__name-row">
+              <span className="v2-mkt-card__name">{app.displayName}</span>
+              {app.verified ? <span className="v2-mkt-card__badge" title="Verified by Commonly">Verified</span> : null}
+            </div>
+            <span className="v2-mkt-card__handle">@{app.name}</span>
+          </div>
+        </div>
+        <p className="v2-mkt-card__desc">{app.description || 'No description provided.'}</p>
+        <div className="v2-mkt-card__meta">
+          <span className="v2-mkt-card__chip">{String(app.kind || 'app')}</span>
+          <span className="v2-mkt-card__stat">{Number(app.installs || 0)} installs</span>
+        </div>
+        <div className="v2-mkt-card__actions">
+          {installedNow ? (
+            <button
+              type="button"
+              className="v2-mkt-card__btn v2-mkt-card__btn--ghost"
+              disabled={busy}
+              onClick={(ev) => remove(app, ev)}
+            >
+              {busy ? 'Removing…' : 'Remove'}
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="v2-mkt-card__btn"
+              disabled={busy}
+              onClick={(ev) => install(app, ev)}
+            >
+              {busy ? 'Installing…' : 'Install'}
+            </button>
+          )}
+        </div>
+      </article>
+    );
+  };
+
+  const renderOfficialCard = (entry: any) => {
+    const isMcp = entry.type === 'mcp-app';
+    const caps: string[] = Array.isArray(entry.capabilities) ? entry.capabilities : [];
+    return (
+      <article key={entry.id} className="v2-mkt-card v2-mkt-card--static">
+        <div className="v2-mkt-card__head">
+          {entry.logoUrl ? (
+            <img className="v2-mkt-card__logo" src={entry.logoUrl} alt="" aria-hidden="true" />
+          ) : (
+            <div className="v2-mkt-card__logo v2-mkt-card__logo--placeholder">{initial(entry.name)}</div>
+          )}
+          <div className="v2-mkt-card__id">
+            <span className="v2-mkt-card__name">{entry.name}</span>
+            <span className="v2-mkt-card__handle">{isMcp ? 'MCP app' : entry.type || 'integration'}{entry.category ? ` · ${entry.category}` : ''}</span>
+          </div>
+        </div>
+        <p className="v2-mkt-card__desc">{entry.description || ''}</p>
+        {caps.length > 0 && (
+          <div className="v2-mkt-card__meta">
+            {caps.slice(0, 4).map((c) => <span key={c} className="v2-mkt-card__chip">{c}</span>)}
+          </div>
+        )}
+        <div className="v2-mkt-card__actions">
+          <button
+            type="button"
+            className="v2-mkt-card__btn"
+            disabled={isMcp}
+            onClick={() => (isMcp ? undefined : connect(entry))}
+          >
+            {isMcp ? 'MCP host required' : 'Connect in pod'}
+          </button>
+          {entry.docsUrl && (
+            <a className="v2-mkt-card__btn v2-mkt-card__btn--ghost" href={entry.docsUrl} target="_blank" rel="noreferrer">Docs</a>
+          )}
+        </div>
+      </article>
+    );
+  };
+
+  return (
+    <div className="v2-mkt">
+      <header className="v2-mkt__header">
+        <h1 className="v2-mkt__title">Marketplace</h1>
+        <p className="v2-mkt__subtitle">Browse and install agents, apps, and integrations.</p>
+      </header>
+
+      <div className="v2-mkt__filterbar">
+        <input
+          className="v2-mkt__search"
+          type="search"
+          placeholder="Search agents, apps, integrations…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select className="v2-mkt__control" value={kind} onChange={(e) => setKind(e.target.value)} aria-label="Kind">
+          {KINDS.map((k) => <option key={k.id} value={k.id}>{k.label}</option>)}
+        </select>
+        <select className="v2-mkt__control" value={category} onChange={(e) => setCategory(e.target.value)} aria-label="Category">
+          {CATEGORIES.map((c) => <option key={c.id} value={c.id}>{c.label}</option>)}
+        </select>
+        {pods.length > 0 && (
+          <select className="v2-mkt__control" value={selectedPodId} onChange={(e) => setSelectedPodId(e.target.value)} aria-label="Install to pod">
+            {pods.map((p) => <option key={p._id} value={p._id}>{p.name}</option>)}
+          </select>
+        )}
+      </div>
+
+      <div className="v2-mkt__tabs" role="tablist">
+        <button type="button" role="tab" aria-selected={tab === 'discover'} className={`v2-mkt__tab${tab === 'discover' ? ' v2-mkt__tab--active' : ''}`} onClick={() => setTab('discover')}>
+          Discover
+        </button>
+        <button type="button" role="tab" aria-selected={tab === 'installed'} className={`v2-mkt__tab${tab === 'installed' ? ' v2-mkt__tab--active' : ''}`} onClick={() => setTab('installed')}>
+          Installed{installed.length ? ` (${installed.length})` : ''}
+        </button>
+      </div>
+
+      {status && <div className="v2-mkt__status" role="status">{status}</div>}
+      {error && <div className="v2-mkt__error">{error}</div>}
+
+      {tab === 'discover' ? (
+        <>
+          <section className="v2-mkt__section">
+            <h2 className="v2-mkt__section-title">{search || kind !== 'all' || category !== 'all' ? 'Results' : 'All listings'}</h2>
+            {loading ? (
+              <div className="v2-mkt__grid">
+                {[0, 1, 2, 3].map((i) => <div key={i} className="v2-mkt-card v2-mkt-card--skeleton" />)}
+              </div>
+            ) : apps.length === 0 ? (
+              <div className="v2-mkt__empty">
+                <div className="v2-mkt__empty-title">No listings yet</div>
+                <div className="v2-mkt__empty-text">Nothing matches your filters. Try a broader search, or publish the first one.</div>
+              </div>
+            ) : (
+              <div className="v2-mkt__grid">{apps.map(renderListingCard)}</div>
+            )}
+          </section>
+
+          {officialIntegrations.length > 0 && (
+            <section className="v2-mkt__section">
+              <h2 className="v2-mkt__section-title">Official integrations</h2>
+              <p className="v2-mkt__section-sub">Curated by Commonly — connect from a pod.</p>
+              <div className="v2-mkt__grid">{officialIntegrations.map(renderOfficialCard)}</div>
+            </section>
+          )}
+
+          {mcpListings.length > 0 && (
+            <section className="v2-mkt__section">
+              <h2 className="v2-mkt__section-title">MCP apps (preview)</h2>
+              <p className="v2-mkt__section-sub">Interactive UI rendered inside MCP-compatible hosts.</p>
+              <div className="v2-mkt__grid">{mcpListings.map(renderOfficialCard)}</div>
+            </section>
+          )}
+        </>
+      ) : (
+        <section className="v2-mkt__section">
+          {!selectedPodId ? (
+            <div className="v2-mkt__empty"><div className="v2-mkt__empty-text">Pick a pod to see what&apos;s installed.</div></div>
+          ) : installed.length === 0 ? (
+            <div className="v2-mkt__empty">
+              <div className="v2-mkt__empty-title">Nothing installed here yet</div>
+              <div className="v2-mkt__empty-text">Browse Discover and install your first one.</div>
+            </div>
+          ) : (
+            <div className="v2-mkt__grid">{installed.map(renderListingCard)}</div>
+          )}
+        </section>
+      )}
+    </div>
+  );
+};
+
+export default V2MarketplacePage;


### PR DESCRIPTION
## Summary

Replaces the legacy Material-UI `AppsMarketplacePage` on the `/v2/marketplace` mount with a fresh **v2-native `V2MarketplacePage`** (`src/v2/marketplace/`), matching the detail page's token discipline (one accent, borders not shadows, no gradients/transforms, 80–120ms transitions, sentence case). The legacy `AppsMarketplacePage` stays on the v1 `/apps` mount, **untouched** — zero v1 regression risk.

This is the design fast-follow to the marketplace funnel (#463) — the browse surface now matches the v2-native detail page it links to.

- **Filter bar**: search + kind + category + install-to-pod selector
- **Discover tab**: listings grid (v2 cards → detail page on click, inline Install/Remove), official integrations section, MCP-apps preview
- **Installed tab**: installed items for the selected pod with Remove
- Loading skeletons, empty states, inline status/error banners
- Reuses the shipped `/api/marketplace/*` + `/api/registry/*` endpoints and the `?installable` detail/install wiring

## Test plan

- [ ] CI: lint + tsc + jest
- [ ] Local/dev browser: `/v2/marketplace` renders v2-native listings; filters work; card → detail; Install installs into the selected pod; Installed tab lists/removes
- [ ] v1 `/apps` mount unchanged (still legacy MUI)