### PR TITLE
fix(litellm): disable unbounded SpendLogToolIndex population

### DIFF
--- a/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
@@ -63,6 +63,28 @@ spec:
             else:
                 print('LiteLLM patch: pattern not found, may already be fixed upstream')
             "
+            # Disable LiteLLM_SpendLogToolIndex population. LiteLLM (1.88.0) inserts one
+            # row per tool-call into this table but provides NO retention, cleanup, or
+            # disable flag for it, so it grows unbounded (hit 6.4M rows / ~4 GB on dev,
+            # 2026-06). SpendLogs itself is still pruned by LiteLLM's own
+            # maximum_spend_logs_retention_period; only this un-prunable sibling is disabled
+            # (we don't use the tool-usage dashboard). Path resolved via litellm.__file__
+            # (the server imports from /app/litellm, not site-packages). No-ops cleanly if
+            # the upstream signature changes.
+            python3 -c "
+            import litellm, os
+            f=os.path.join(os.path.dirname(litellm.__file__),'proxy','db','spend_log_tool_index.py')
+            s=open(f).read()
+            old='async def process_spend_logs_tool_usage(\n    prisma_client: PrismaClient,\n    logs_to_process: List[Dict[str, Any]],\n) -> None:'
+            new=old+'\n    return  # commonly: disabled (LiteLLM never prunes SpendLogToolIndex; unbounded)'
+            if 'commonly: disabled' in s:
+                print('LiteLLM tool-index patch: already applied')
+            elif old in s:
+                open(f,'w').write(s.replace(old,new,1))
+                print('LiteLLM tool-index patch applied: SpendLogToolIndex population disabled')
+            else:
+                print('LiteLLM tool-index patch: pattern not found (version changed?) - review needed')
+            "
             # Write the custom callback that signals the rotator on 429s.
             # LiteLLM's get_instance_fn resolves callbacks via spec_from_file_location
             # relative to the config file's directory (/app/), NOT via importlib.


### PR DESCRIPTION
## Summary
- LiteLLM 1.88.0 inserts one row per tool-call into `LiteLLM_SpendLogToolIndex` but has **no retention, cleanup, or disable flag** for it — its `maximum_spend_logs_retention_period` only covers `LiteLLM_SpendLogs`. On dev (Aiven) it grew to **6.4M rows / ~4 GB**, the dominant driver of PG disk exhaustion (DB hit 5.8 GB; chat messages were only 26 MB).
- We don't use the tool-usage dashboard, so this no-ops `process_spend_logs_tool_usage` at startup via the **same source-patch mechanism** already used for the chatgpt-responses fix.
- Path resolved via `litellm.__file__` (server imports from `/app/litellm`, not site-packages). No-ops cleanly if the upstream signature changes.

## Why infra, not backend
LiteLLM is a driver/infra concern, not the Commonly product. This stays gated on `litellm.enabled`, so self-hosters on a different LLM proxy are unaffected. The backend's `pgRetentionService` is untouched (it only manages Commonly's own `messages` table).

## Already handled operationally (no deploy needed)
- Reclaimed disk: truncated both LiteLLM log tables → DB went **5.8 GB → 57 MB**.
- Paused heartbeats on 12 noisy community agents (separate, reversible — they had no working model).

## Separate finding (NOT in this PR)
The existing chatgpt-responses patch targets `/usr/lib/python3.13/site-packages/litellm/...`, which **does not exist** (server imports from `/app/litellm`) — so that patch has been silently no-oping. Worth a separate, careful fix since it touches codex/chatgpt routing.

## Test plan
- [x] Dry-ran the patch against the live pod: `signature found: True`, targets `/app/litellm/proxy/db/spend_log_tool_index.py`
- [ ] After deploy: confirm startup log `LiteLLM tool-index patch applied`, and `LiteLLM_SpendLogToolIndex` row count stays ~0

🤖 Generated with [Claude Code](https://claude.com/claude-code)