### PR TITLE
fix(litellm): route chatgpt codex via /responses to dodge Cloudflare challenge

### DIFF
--- a/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
+++ b/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
@@ -69,6 +69,12 @@ data:
       # paired entry alongside nemotron above.
 
       # --- Codex (chatgpt/ provider) ---
+      # The `responses/` in `chatgpt/responses/gpt-5.4*` is LOAD-BEARING. Plain
+      # `chatgpt/gpt-5.4*` routes to /backend-api/codex/chat/completions, which Cloudflare
+      # serves a JS bot-challenge for (HTML, not JSON) -> the call fails and silently falls
+      # back to OpenRouter Nemotron. The /responses endpoint is NOT challenged. OAuth tokens
+      # are valid; this is a LiteLLM endpoint-routing bug, not an auth/IP/OpenAI block.
+      # See BerriAI/litellm#27175 (workaround) + openclaw#68033 (2026-06).
       # NOTE: LiteLLM's chatgpt/ provider reads tokens from auth.json (written by the
       # codex-auth-seed init + codex-auth-rotator sidecar). The Authenticator ignores
       # api_key in litellm_params, so duplicate deployments per account are useless.
@@ -85,7 +91,7 @@ data:
         model_info:
           mode: responses
         litellm_params:
-          model: chatgpt/gpt-5.4
+          model: chatgpt/responses/gpt-5.4
           timeout: 120
           input_cost_per_token: 0.0000025
           output_cost_per_token: 0.000015
@@ -94,7 +100,7 @@ data:
         model_info:
           mode: responses
         litellm_params:
-          model: chatgpt/gpt-5.4
+          model: chatgpt/responses/gpt-5.4
           timeout: 120
           input_cost_per_token: 0.0000025
           output_cost_per_token: 0.000015
@@ -104,7 +110,7 @@ data:
         model_info:
           mode: responses
         litellm_params:
-          model: chatgpt/gpt-5.4-mini
+          model: chatgpt/responses/gpt-5.4-mini
           timeout: 120
           input_cost_per_token: 0.00000075
           output_cost_per_token: 0.0000045
@@ -113,7 +119,7 @@ data:
         model_info:
           mode: responses
         litellm_params:
-          model: chatgpt/gpt-5.4-mini
+          model: chatgpt/responses/gpt-5.4-mini
           timeout: 120
           input_cost_per_token: 0.00000075
           output_cost_per_token: 0.0000045
@@ -123,7 +129,7 @@ data:
         model_info:
           mode: responses
         litellm_params:
-          model: chatgpt/gpt-5.4-nano
+          model: chatgpt/responses/gpt-5.4-nano
           timeout: 120
           input_cost_per_token: 0.0000002
           output_cost_per_token: 0.00000125
@@ -132,7 +138,7 @@ data:
         model_info:
           mode: responses
         litellm_params:
-          model: chatgpt/gpt-5.4-nano
+          model: chatgpt/responses/gpt-5.4-nano
           timeout: 120
           input_cost_per_token: 0.0000002
           output_cost_per_token: 0.00000125
@@ -143,7 +149,7 @@ data:
         model_info:
           mode: responses
         litellm_params:
-          model: chatgpt/gpt-5.4-mini
+          model: chatgpt/responses/gpt-5.4-mini
           input_cost_per_token: 0.00000075
           output_cost_per_token: 0.0000045
 
@@ -151,7 +157,7 @@ data:
         model_info:
           mode: responses
         litellm_params:
-          model: chatgpt/gpt-5.4-mini
+          model: chatgpt/responses/gpt-5.4-mini
           input_cost_per_token: 0.00000075
           output_cost_per_token: 0.0000045
 


### PR DESCRIPTION
## Summary
Dev agents (theo/nova/pixel/ops/aria + Cody) have been **silently running on OpenRouter Nemotron instead of codex** for days. Root cause is a LiteLLM endpoint-routing bug — **not** an OpenAI block, not auth, not the IP.

- With `model: chatgpt/gpt-5.4*`, LiteLLM hits `/backend-api/codex/chat/completions` → Cloudflare returns a **JS bot-challenge page** (HTML, not JSON) → call fails → router **silently falls back to Nemotron** (no error logged, so it hid).
- The **`/responses`** endpoint is not challenged. Prefixing the model with `responses/` forces it.

## Change
All 8 `chatgpt/` model entries: `chatgpt/gpt-5.4*` → `chatgpt/responses/gpt-5.4*`.

## Verification (in-cluster, before the change)
- `chatgpt/responses/gpt-5.4-mini` → **5/5 real completions, 0 Cloudflare challenges**; `gpt-5.4` also works.
- `chatgpt/gpt-5.4-mini` (old) → Cloudflare challenge every time.

## Why this is the right fix
- Keeps everything on the existing **ChatGPT-OAuth + rotator** — no paid OpenAI API key needed.
- Restores real codex for **all** dev agents (openclaw via LiteLLM + Cody) on one config change.
- OAuth tokens were valid throughout (confirmed: official Codex CLI worked from the same pod). This matches **BerriAI/litellm#27175** (open bug + this exact workaround) and **openclaw#68033** (same issue, fixed in their transport).

## Post-deploy check
- [ ] `litellm` pod picks up the new configmap (may need `kubectl rollout restart deploy/litellm` if no config checksum annotation)
- [ ] Proxy call to `openai-codex/gpt-5.4-mini` returns `returned_model: gpt-5.4-mini` (not nemotron)
- [ ] Rotator signals start referencing codex models (not just Nemotron)

🤖 Generated with [Claude Code](https://claude.com/claude-code)