### PR TITLE
fix(litellm): only rotate codex accounts on codex 429s (stop Nemotron-driven thrash)

### DIFF
--- a/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
@@ -107,6 +107,15 @@ spec:
                     'ratelimiterror',
                 ))
 
+            def _is_codex_model(model: str) -> bool:
+                # Only codex rotates the ChatGPT account pool. Nemotron (the codex
+                # fallback) and every other provider also throw 429s under load, but
+                # rotating codex accounts can't help them — it only thrashes the
+                # active-account pointer and burns refresh_tokens. Codex surfaces as
+                # 'openai-codex/*' (public alias) or 'chatgpt/*' (litellm_params.model).
+                m = (model or '').lower()
+                return 'codex' in m or 'chatgpt' in m
+
             def _write_signal(model: str, exc_str: str):
                 try:
                     tmp = SIGNAL_FILE + '.tmp'
@@ -132,8 +141,9 @@ spec:
                     exc = kwargs.get('exception')
                     if not exc: return
                     exc_str = str(exc)
-                    if _is_rate_limit(exc_str):
-                        _write_signal(kwargs.get('model', 'unknown'), exc_str)
+                    model = kwargs.get('model', 'unknown')
+                    if _is_rate_limit(exc_str) and _is_codex_model(model):
+                        _write_signal(model, exc_str)
 
                 async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
                     pass
@@ -142,8 +152,9 @@ spec:
                     exc = kwargs.get('exception')
                     if not exc: return
                     exc_str = str(exc)
-                    if _is_rate_limit(exc_str):
-                        _write_signal(kwargs.get('model', 'unknown'), exc_str)
+                    model = kwargs.get('model', 'unknown')
+                    if _is_rate_limit(exc_str) and _is_codex_model(model):
+                        _write_signal(model, exc_str)
 
             proxy_handler_instance = RateLimitSignaler()
             PYEOF


### PR DESCRIPTION
## Summary
The codex-auth-rotator's rate-limit signaler wrote `/chatgpt-auth/rotate-now` on **any** 429 — including Nemotron's. Nemotron is the codex *fallback*, so whenever codex was degraded and traffic fell back to Nemotron, Nemotron's load 429s thrashed the rotator's active-account pointer and churned refresh_tokens. Rotating the codex account pool can't relieve a Nemotron rate limit, so this was pure waste.

This gates the rotate signal on codex/chatgpt models only:
- codex deployments surface as `openai-codex/*` (public alias) or `chatgpt/*` (underlying `litellm_params.model`)
- nemotron / openrouter / anthropic / gpt-4o / unknown → no signal

## Surfaced during
The 2026-06 codex-auth recovery — after re-authing both ChatGPT accounts, the rotator was still observed swapping on Nemotron 429s.

## Test plan
- [x] Embedded heredoc module compiles clean (`py_compile` after 12-space YAML-block dedent)
- [x] Discriminator validated against real model names (codex/chatgpt → signal; nemotron/anthropic/gpt-4o/unknown/empty → no signal)
- [ ] Post-deploy: confirm rotator no longer logs `rate-limit signal consumed — model=...nemotron...` swaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)