### PR TITLE
fix(litellm): route codex CLI (cloud-codex) through /responses (single auth surface)

### DIFF
--- a/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
@@ -193,7 +193,10 @@ spec:
           # Runtime stays codex: codex CLI still spawns, still sandboxes,
           # still owns tool use and sessions. Only the HTTPS layer is proxied.
           cat > /state/.codex/config.toml <<EOF
-          model = "gpt-5.4"
+          # wire_api=responses below -> LiteLLM /v1/responses. Must use the unprefixed
+          # codex-cli/* alias (maps to chatgpt/gpt-5.4); the prefixed chat-path aliases
+          # 400 with "model not supported" on /responses. See litellm-config.yaml.
+          model = "codex-cli/gpt-5.4"
           model_provider = "litellm"
 
           # Codex CLI's default sandbox uses bubblewrap (bwrap), which

--- a/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
@@ -52,16 +52,25 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            # Patch litellm's OpenAI responses-input transform to wrap a bare string
+            # `input` into a [{"role":"user","content":...}] list. OpenAI's Codex /responses
+            # backend rejects a raw string ("Input must be a list"); the chatgpt provider
+            # inherits this openai transform. Path resolved via litellm.__file__ (the server
+            # imports from /app/litellm — an earlier hardcoded /usr/lib path made this a
+            # silent no-op). Idempotent; no-ops cleanly if the upstream signature changes.
             python3 -c "
-            f='/usr/lib/python3.13/site-packages/litellm/llms/openai/responses/transformation.py'
+            import litellm, os
+            f=os.path.join(os.path.dirname(litellm.__file__),'llms','openai','responses','transformation.py')
             s=open(f).read()
             old='        # Input is expected to be either str or List, no single BaseModel expected\n        return input'
-            new='        # Input is expected to be either str or List, no single BaseModel expected\n        if isinstance(input, str):\n            return [{\"role\": \"user\", \"content\": input}]\n        return input'
-            if old in s:
-                open(f,'w').write(s.replace(old,new))
-                print('LiteLLM patch applied: string input -> list for chatgpt responses API')
+            new='        # Input is expected to be either str or List, no single BaseModel expected\n        if isinstance(input, str):  # commonly: wrap bare str for chatgpt /responses\n            return [{\"role\": \"user\", \"content\": input}]\n        return input'
+            if 'commonly: wrap bare str' in s:
+                print('LiteLLM responses-input patch: already applied')
+            elif old in s:
+                open(f,'w').write(s.replace(old,new,1))
+                print('LiteLLM responses-input patch applied: bare-str input -> list for chatgpt /responses')
             else:
-                print('LiteLLM patch: pattern not found, may already be fixed upstream')
+                print('LiteLLM responses-input patch: pattern not found (version changed?) - review needed')
             "
             # Disable LiteLLM_SpendLogToolIndex population. LiteLLM (1.88.0) inserts one
             # row per tool-call into this table but provides NO retention, cleanup, or

--- a/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
+++ b/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
@@ -150,6 +150,23 @@ data:
           input_cost_per_token: 0.00000075
           output_cost_per_token: 0.0000045
 
+      # --- Codex CLI native /responses path (cloud-codex / Cody, wire_api="responses") ---
+      # Unlike the chat-path aliases above, the codex CLI hits LiteLLM's /v1/responses
+      # endpoint directly. There the chatgpt provider's get_complete_url already targets
+      # /responses, so the `responses/` prefix is redundant AND breaks: it gets sent
+      # literally to OpenAI as `responses/gpt-5.4` -> 400 "model not supported". These
+      # aliases map to plain `chatgpt/gpt-5.4*` (NO prefix) so /v1/responses sends the
+      # bare model name. Verified end-to-end via litellm.aresponses: real codex (served=
+      # gpt-5.4 / gpt-5.4-mini-2026-03-17). Do NOT point chat-path (/chat/completions)
+      # callers here — plain chatgpt/gpt-5.4* on the chat path hits the Cloudflare-
+      # challenged /backend-api/codex/chat/completions (see the chat-path note above).
+      - model_name: codex-cli/gpt-5.4
+        litellm_params:
+          model: chatgpt/gpt-5.4
+          timeout: 120
+          input_cost_per_token: 0.0000025
+          output_cost_per_token: 0.000015
+
       # --- OpenAI (optional, for embeddings) ---
       - model_name: text-embedding-3-large
         litellm_params:
@@ -253,6 +270,7 @@ data:
         - {"openai-codex/gpt-5.4-mini": ["openrouter/nvidia/nemotron-3-super-120b-a12b:free"]}
         - {"gpt-5.4-nano":            ["openrouter/nvidia/nemotron-3-super-120b-a12b:free"]}
         - {"openai-codex/gpt-5.4-nano": ["openrouter/nvidia/nemotron-3-super-120b-a12b:free"]}
+        - {"codex-cli/gpt-5.4":        ["openrouter/nvidia/nemotron-3-super-120b-a12b:free"]}
         # No fallback for nemotron itself — fail fast rather than chain through
         # dead endpoints. The rotator + next-request path will pick a fresh
         # Codex account on the subsequent call.


### PR DESCRIPTION
## Summary
Enables the **codex CLI (cloud-codex / Cody) to run through LiteLLM** — the single auth surface (one rotator, one quota pool, one observability) that cloud-codex exists for. Previously Cody silently fell back to Nemotron.

The codex CLI speaks `wire_api="responses"` and hits LiteLLM's `/v1/responses` endpoint, **not** `/chat/completions`. Two bugs blocked it on that path (both confirmed live with valid tokens):

1. **Model-prefix bug.** The `responses/` prefix the chat-path aliases carry (load-bearing there to dodge a Cloudflare challenge) is redundant on `/responses` — the chatgpt provider's `get_complete_url` already targets `/responses`. It gets sent literally to OpenAI as `responses/gpt-5.4` → `400 "model not supported"`.
2. **String-input bug.** OpenAI's Codex `/responses` rejects a bare-string `input` (`"Input must be a list"`). LiteLLM has a startup patch to wrap it — but it targeted `/usr/lib/python3.13/...`, which doesn't exist in this image (litellm loads from `/app/litellm`), so it **silently no-op'd**.

## Changes
- **`litellm-config.yaml`**: add `codex-cli/gpt-5.4` → `chatgpt/gpt-5.4` (no `responses/` prefix) for the `/responses` path, plus its Nemotron fallback. Chat-path aliases (dev agents) untouched.
- **`cloud-codex-deployment.yaml`**: point Cody's `config.toml` `model` at `codex-cli/gpt-5.4`.
- **`litellm-deployment.yaml`**: re-path the responses-input patch to `litellm.__file__` (`/app/litellm`) so it actually applies; idempotent + clear no-op-on-version-change.

## Verification
- `litellm.aresponses(model="chatgpt/gpt-5.4", input=[{...}])` → **real codex** (`served=gpt-5.4`, `gpt-5.4-mini-2026-03-17`)
- Re-pathed patch dry-run against the live pod: `litellm.__file__` resolves to `/app/litellm/...`, target pattern present → applies
- Patched `transformation.py` compiles clean (applied to the real deployed file locally)
- [ ] Post-deploy: re-auth codex (deploy rolls litellm → IP-bound token invalidation) + confirm Cody serves codex via `/responses`

🤖 Generated with [Claude Code](https://claude.com/claude-code)