### PR TITLE
docs(litellm): chat-vs-responses prefix rule + cloud-codex key allowlist

### DIFF
--- a/docs/adr/ADR-014-cloud-codex-runtime-and-shared-auth-surface.md
+++ b/docs/adr/ADR-014-cloud-codex-runtime-and-shared-auth-surface.md
@@ -5,6 +5,19 @@
 **Supersedes:** none
 **Relates to:** [ADR-004 CAP](ADR-004-commonly-agent-protocol.md), [ADR-005 Local CLI Wrapper Driver](ADR-005-local-cli-wrapper-driver.md), [ADR-008 Agent Environment Primitive](ADR-008-agent-environment-primitive.md)
 
+> **Amendment (2026-06-08, PR #472):** the `config.toml` snippet in the Decision section below
+> is now STALE. cloud-codex agents must set `model = "codex-cli/gpt-5.4"` (→ unprefixed
+> `chatgpt/gpt-5.4`), NOT `gpt-5.4`. Because `wire_api="responses"` hits LiteLLM `/v1/responses`,
+> the `responses/` prefix that the shared `gpt-5.4` / `openai-codex/gpt-5.4` aliases carry (added
+> by PR #469 to dodge Cloudflare on the `/chat/completions` path) leaks to OpenAI as
+> `responses/gpt-5.4` → 400 "model not supported" → silent Nemotron fallback. The new
+> `codex-cli/*` alias decouples the responses path from the chat path. The agent's LiteLLM
+> virtual key allowlist must also include `codex-cli/gpt-5.4` (cloud-codex keys are
+> operator-managed; update via `/key/update`). This also revises the Negative consequence
+> *"If LiteLLM drops or breaks `wire_api=responses`…"* — the real fragility was this
+> model-name/endpoint mismatch, not LiteLLM dropping responses support. Full detail:
+> `docs/development/LITELLM.md` → "Codex: chat path vs responses path".
+
 ## Context
 
 ADR-005 introduced the local-CLI wrapper driver: `commonly agent attach codex --pod ... --instance dev` on an operator laptop polls CAP and shells out to the local `codex` binary. The first production wrapper agent — `sam-local-codex` — proved the pattern but exposed a structural limit: it required an operator's laptop to be online. Anyone wanting a "real" cloud agent on the codex runtime had no path.
@@ -32,7 +45,7 @@ The naive options each failed:
 2. **Codex CLI does NOT call chatgpt.com directly.** Each cloud-codex pod's `~/.codex/config.toml` declares LiteLLM as the model provider:
 
    ```toml
-   model = "gpt-5.4"
+   model = "codex-cli/gpt-5.4"   # 2026-06-08 (PR #472): was "gpt-5.4" — see Amendment at top
    model_provider = "litellm"
    [model_providers.litellm]
    name = "LiteLLM"

--- a/docs/development/LITELLM.md
+++ b/docs/development/LITELLM.md
@@ -3,7 +3,7 @@
 LiteLLM provides an OpenAI-compatible proxy for multiple LLM providers.
 In Commonly it serves two roles:
 
-_last_updated: 2026-05-02_
+_last_updated: 2026-06-08_
 
 1. **Agent gateway** — all OpenClaw (dev + community) agent LLM calls route through it, including Codex OAuth traffic and OpenRouter traffic
 2. **Backend gateway** — `llmService.js` uses it for summarization, digest, and embedding calls
@@ -142,22 +142,66 @@ to LiteLLM. LiteLLM then attaches the real Codex OAuth token when forwarding to 
 
 This decouples agent auth from raw OAuth tokens — agents never hold OAuth credentials directly.
 
+**Keys are model-restricted (allowlist).** A virtual key only works for the models in its
+allowlist; anything else returns `403 "key not allowed to access model"`. Most keys are
+issued by the backend provisioner (`issueLiteLLMVirtualKey` / `issueLiteLLMOpenRouterKey` in
+`backend/services/agentProvisionerServiceK8s.ts`, which set `metadata.agent_id`). **cloud-codex
+keys are different — they are operator-provisioned manually** (`/key/generate` with
+`user_id: cloud-codex-<name>`, empty metadata) and stored in the `cloud-codex-<name>-litellm-key`
+secret. When you add a model alias that a cloud-codex / codex-CLI agent must call (e.g.
+`codex-cli/gpt-5.4`), you MUST add it to that agent's key allowlist or the call 403s:
+
+```bash
+# inspect:  GET  /key/info?key=<sk-...>                                  (master-key auth)
+# update:   POST /key/update  {"key":"<sk-...>","models":[...,"codex-cli/gpt-5.4"]}
+```
+
+This allowlist lives only in LiteLLM's Postgres (`LiteLLM_VerificationToken`), **not in IaC** —
+if a cloud-codex key is ever regenerated, re-add `codex-cli/*`. (Verified gap, 2026-06-08, PR #472.)
+
+---
+
+## Codex: chat path vs responses path (the `responses/` prefix rule)
+
+LiteLLM exposes the chatgpt/ provider on TWO endpoints, and the codex model name must match
+the endpoint the caller uses:
+
+| Caller | LiteLLM endpoint | Model alias | `litellm_params.model` |
+|---|---|---|---|
+| OpenClaw dev agents | `/chat/completions` | `gpt-5.4*`, `openai-codex/gpt-5.4*` | `chatgpt/responses/gpt-5.4*` (**prefixed**) |
+| codex CLI / cloud-codex (`wire_api="responses"`) | `/v1/responses` | `codex-cli/gpt-5.4` | `chatgpt/gpt-5.4` (**unprefixed**) |
+
+- On `/chat/completions`, the `responses/` prefix is **load-bearing**: plain `chatgpt/gpt-5.4*`
+  routes to `/backend-api/codex/chat/completions`, which Cloudflare serves a bot-challenge for
+  (HTML, not JSON) → silent Nemotron fallback. Do NOT add `model_info: mode: responses` to these
+  — it strips `chatgpt/` and sends the invalid model `responses/gpt-5.4` (400).
+- On `/v1/responses`, the chatgpt provider's `get_complete_url` already targets `/responses`, so
+  the `responses/` prefix is redundant and **leaks** to OpenAI as `responses/gpt-5.4` →
+  400 "model not supported". This path needs the UNPREFIXED `codex-cli/*` alias.
+- A single model name can't serve both — the endpoint is chosen by which LiteLLM URL the caller
+  hits, not by the model name. Keep the two alias families separate. (PR #469 added the chat-path
+  prefix; PR #472 added the responses-path `codex-cli/*` alias after the prefix change silently
+  broke cloud-codex on `/responses`.)
+
 ---
 
 ## Config (`litellm-config.yaml`)
 
 ```yaml
 model_list:
-  # Codex — chatgpt/ provider reads auth.json from CHATGPT_TOKEN_DIR
+  # Codex — chatgpt/ provider reads auth.json from the chatgpt-auth PVC.
+  # CHAT path: responses/ prefix is load-bearing; NO `model_info: mode: responses`.
+  # See "Codex: chat path vs responses path" above for why.
   - model_name: gpt-5.4
-    model_info:
-      mode: responses
     litellm_params:
-      model: chatgpt/gpt-5.4
+      model: chatgpt/responses/gpt-5.4
 
   - model_name: openai-codex/gpt-5.4
-    model_info:
-      mode: responses
+    litellm_params:
+      model: chatgpt/responses/gpt-5.4
+
+  # RESPONSES path (codex CLI / cloud-codex, wire_api="responses"): UNPREFIXED alias.
+  - model_name: codex-cli/gpt-5.4
     litellm_params:
       model: chatgpt/gpt-5.4
 


### PR DESCRIPTION
## Summary
Documents the findings from PR #472 (codex CLI via LiteLLM) so the next reader doesn't re-learn them the hard way:

- **`docs/development/LITELLM.md`** — new **"Codex: chat path vs responses path"** section (the `responses/` prefix is load-bearing on `/chat/completions` but leaks to OpenAI on `/v1/responses` → 400; the two need separate alias families). New **virtual-key allowlist** note: cloud-codex keys are operator-managed + model-restricted, so a new alias must be added via `/key/update` or it 403s — and that allowlist isn't in IaC. Corrected the `model_list` example (dropped the stale `model_info: mode: responses`, prefixed the chat aliases, added the `codex-cli/gpt-5.4` alias). Bumped `_last_updated`.
- **ADR-014** — top amendment flagging that the Decision-section `config.toml` snippet (`model = "gpt-5.4"`) is stale (must be `codex-cli/gpt-5.4`), and revising the Negative consequence that mischaracterized the fragility axis.

Pairs with corrected memory entries (`project-codex-cli-via-litellm`, `project-cloud-codex-runtime`).

## Test plan
- [x] Docs-only; `model_list` example matches the live config shape (verified against deployed config)
- [x] No stray `mode: responses` left in the example

🤖 Generated with [Claude Code](https://claude.com/claude-code)