### PR TITLE
feat(mcp): commonly_memory_read — close the read-back gap for the shared-memory wedge

### DIFF
--- a/backend/__tests__/service/shared-identity-memory-smoke.test.js
+++ b/backend/__tests__/service/shared-identity-memory-smoke.test.js
@@ -1,0 +1,211 @@
+/**
+ * WEDGE SMOKE — "one project memory shared by all your AI tools".
+ *
+ * The complement of two-driver-memory-cross-check.test.js (which proves
+ * ISOLATION: different agent identities never see each other). This proves
+ * CONVERGENCE: when every tool a developer uses authenticates with the SAME
+ * agent identity (one COMMONLY_AGENT_TOKEN), they all read and write ONE shared
+ * memory envelope — regardless of the tool shape used to reach the kernel.
+ *
+ * This is the "shared identity = the project's brain" framing: the schema is
+ * keyed (agentName, instanceId), so pointing Claude Code + Cursor + Codex +
+ * a webhook agent at the same token makes that envelope the shared store.
+ *
+ * Tool shapes exercised against ONE token:
+ *   - Claude Code / Cursor / Codex (via @commonlyai/mcp) -> POST /memory/sync
+ *     (the shipped MCP server's commonly_memory_sync verb) + GET /memory
+ *   - Webhook SDK / CLI-wrapper -> direct CAP HTTP to the same endpoints
+ *
+ * If this passes, the wedge mechanic holds at the kernel: all tools converge.
+ */
+
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+const { setupMongoDb, closeMongoDb } = require('../utils/testUtils');
+
+const User = require('../../models/User');
+const Pod = require('../../models/Pod');
+const { AgentRegistry, AgentInstallation } = require('../../models/AgentRegistry');
+const AgentMemory = require('../../models/AgentMemory');
+const AgentProfile = require('../../models/AgentProfile');
+
+const registryRoutes = require('../../routes/registry');
+const agentsRuntimeRoutes = require('../../routes/agentsRuntime');
+
+const JWT_SECRET = 'test-jwt-secret-shared-identity';
+
+jest.setTimeout(60000);
+
+describe('WEDGE — shared identity converges memory across tools', () => {
+  let app;
+  let user;
+  let authToken;
+  let pod;
+  let projectToken; // the ONE token every tool points at
+  let secondToken; // a different identity, for the negative control
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = JWT_SECRET;
+    await setupMongoDb();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/registry', registryRoutes);
+    app.use('/api/agents/runtime', agentsRuntimeRoutes);
+
+    user = await User.create({
+      username: 'wedge-admin',
+      email: 'wedge@test.com',
+      password: 'password123',
+    });
+    authToken = jwt.sign({ id: user._id.toString() }, JWT_SECRET);
+
+    pod = await Pod.create({
+      name: 'Project Pod',
+      type: 'chat',
+      createdBy: user._id,
+      members: [user._id],
+    });
+  });
+
+  afterAll(async () => {
+    await closeMongoDb();
+  });
+
+  beforeEach(async () => {
+    await AgentInstallation.deleteMany({});
+    await AgentMemory.deleteMany({});
+    await AgentProfile.deleteMany({});
+    await AgentRegistry.deleteMany({ ephemeral: true });
+    await User.updateMany({ isBot: true }, { $set: { agentRuntimeTokens: [] } });
+
+    // The project's shared brain — one agent identity, webhook-installed so it
+    // needs no pre-published manifest (ADR-006 self-serve).
+    await request(app)
+      .post('/api/registry/install')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        agentName: 'project-brain',
+        podId: pod._id.toString(),
+        config: { runtime: { runtimeType: 'webhook' } },
+        scopes: ['context:read', 'messages:write'],
+      })
+      .expect(200);
+    const t1 = await request(app)
+      .post(`/api/registry/pods/${pod._id}/agents/project-brain/runtime-tokens`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({});
+    projectToken = t1.body.token;
+
+    // A second, unrelated identity — negative control for the isolation guard.
+    await request(app)
+      .post('/api/registry/install')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        agentName: 'other-brain',
+        podId: pod._id.toString(),
+        config: { runtime: { runtimeType: 'webhook' } },
+        scopes: ['context:read'],
+      })
+      .expect(200);
+    const t2 = await request(app)
+      .post(`/api/registry/pods/${pod._id}/agents/other-brain/runtime-tokens`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({});
+    secondToken = t2.body.token;
+
+    expect(projectToken).toMatch(/^cm_agent_/);
+    expect(secondToken).toMatch(/^cm_agent_/);
+  });
+
+  // Helpers mirroring how each tool reaches the kernel. They differ ONLY in the
+  // sourceRuntime tag — the endpoint + token are identical, which is the point.
+  const writeAs = (token, sourceRuntime, sections, mode = 'patch') =>
+    request(app)
+      .post('/api/agents/runtime/memory/sync')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ mode, sourceRuntime, sections });
+
+  const readAs = (token) =>
+    request(app)
+      .get('/api/agents/runtime/memory')
+      .set('Authorization', `Bearer ${token}`);
+
+  it('Claude Code writes, Cursor (same token) reads it back', async () => {
+    // Tool A = Claude Code via MCP commonly_memory_sync
+    const w = await writeAs(projectToken, 'mcp-claude-code', {
+      long_term: {
+        content: 'Project uses pnpm workspaces. Deploy via Deploy Dev workflow.',
+        visibility: 'private',
+      },
+    });
+    expect(w.status).toBe(200);
+    expect(w.body.ok).toBe(true);
+
+    // Tool B = Cursor via MCP, SAME token
+    const r = await readAs(projectToken);
+    expect(r.status).toBe(200);
+    expect(r.body.sections.long_term.content).toContain('pnpm workspaces');
+  });
+
+  it('three tools writing different sections all land in ONE envelope', async () => {
+    // Claude Code -> long_term
+    await writeAs(projectToken, 'mcp-claude-code', {
+      long_term: { content: 'Architecture notes live in docs/adr.', visibility: 'private' },
+    }).expect(200);
+    // Codex CLI (via MCP on 0.133+) -> shared
+    await writeAs(projectToken, 'mcp-codex', {
+      shared: { content: 'Public project summary for teammates.', visibility: 'pod' },
+    }).expect(200);
+    // Webhook agent (HTTP-direct) -> dedup_state
+    await writeAs(projectToken, 'webhook-sdk-py', {
+      dedup_state: { content: 'last-indexed-commit: 5a05c421', visibility: 'private' },
+    }).expect(200);
+
+    // Any tool reading the shared identity sees ALL three sections converge.
+    const r = await readAs(projectToken);
+    expect(r.body.sections.long_term.content).toContain('docs/adr');
+    expect(r.body.sections.shared.content).toContain('teammates');
+    expect(r.body.sections.dedup_state.content).toContain('5a05c421');
+
+    // Exactly ONE envelope exists for the shared identity — not one per tool.
+    const docs = await AgentMemory.find({ agentName: 'project-brain' }).lean();
+    expect(docs).toHaveLength(1);
+  });
+
+  it('a later tool sees an earlier tool\'s update (read-after-write across tools)', async () => {
+    await writeAs(projectToken, 'mcp-claude-code', {
+      long_term: { content: 'v1: initial setup', visibility: 'private' },
+    }).expect(200);
+
+    // A different tool (Codex) updates the same section on the shared identity.
+    await writeAs(projectToken, 'mcp-codex', {
+      long_term: { content: 'v2: added auth module', visibility: 'private' },
+    }).expect(200);
+
+    // Cursor reading later sees the latest, and the server records who wrote last.
+    const r = await readAs(projectToken);
+    expect(r.body.sections.long_term.content).toBe('v2: added auth module');
+    expect(r.body.sourceRuntime).toBe('mcp-codex');
+  });
+
+  it('negative control: a DIFFERENT identity does NOT share the envelope', async () => {
+    await writeAs(projectToken, 'mcp-claude-code', {
+      long_term: { content: 'SECRET project context', visibility: 'private' },
+    }).expect(200);
+
+    // Same pod, different agent token -> separate envelope, no leakage.
+    const r = await readAs(secondToken);
+    expect(r.status).toBe(200);
+    const otherContent = r.body.sections?.long_term?.content || '';
+    expect(otherContent).not.toContain('SECRET project context');
+
+    // The wedge requires SAME token. Different tokens => different brains.
+    const names = (await AgentMemory.find({}).select('agentName').lean())
+      .map((m) => m.agentName)
+      .sort();
+    expect(names).toContain('project-brain');
+  });
+});

--- a/packages/commonly-mcp/src/__tests__/cap-tools.test.ts
+++ b/packages/commonly-mcp/src/__tests__/cap-tools.test.ts
@@ -296,6 +296,80 @@ describe("commonly_memory_sync", () => {
   });
 });
 
+describe("commonly_memory_read", () => {
+  const envelope = {
+    content: "long term mirror",
+    sections: {
+      long_term: { content: "long term mirror", visibility: "private" },
+      shared: { content: "public bio", visibility: "pod" },
+    },
+    sourceRuntime: "mcp-claude-code",
+    schemaVersion: 2,
+  };
+
+  it("returns the full envelope when no section is given", async () => {
+    const client = {
+      readMemory: vi.fn().mockResolvedValue(envelope),
+    } as unknown as CommonlyClient;
+
+    const result = await handleToolCall(
+      client,
+      "commonly_memory_read",
+      {},
+      baseConfig()
+    );
+
+    expect(client.readMemory).toHaveBeenCalled();
+    expect(result).toEqual({
+      content: "long term mirror",
+      sections: envelope.sections,
+      sourceRuntime: "mcp-claude-code",
+      schemaVersion: 2,
+    });
+  });
+
+  it("returns just the requested section", async () => {
+    const client = {
+      readMemory: vi.fn().mockResolvedValue(envelope),
+    } as unknown as CommonlyClient;
+
+    const result = (await handleToolCall(
+      client,
+      "commonly_memory_read",
+      { section: "shared" },
+      baseConfig()
+    )) as { section?: unknown };
+
+    expect(result.section).toEqual({ content: "public bio", visibility: "pod" });
+  });
+
+  it("returns null for a section that is not set", async () => {
+    const client = {
+      readMemory: vi.fn().mockResolvedValue(envelope),
+    } as unknown as CommonlyClient;
+
+    const result = (await handleToolCall(
+      client,
+      "commonly_memory_read",
+      { section: "soul" },
+      baseConfig()
+    )) as { section?: unknown };
+
+    expect(result.section).toBeNull();
+  });
+
+  it("propagates errors from the backend", async () => {
+    const client = {
+      readMemory: vi
+        .fn()
+        .mockRejectedValue(new Error("Commonly CAP Error (401): no token")),
+    } as unknown as CommonlyClient;
+    await expect(
+      handleToolCall(client, "commonly_memory_read", {}, baseConfig())
+    ).rejects.toThrow(/401/);
+  });
+});
+
 describe("commonly_create_task", () => {
   it("creates a task with title only", async () => {
     const client = {

--- a/packages/commonly-mcp/src/tools/cap-memory-read.ts
+++ b/packages/commonly-mcp/src/tools/cap-memory-read.ts
@@ -1,0 +1,68 @@
+/**
+ * CAP verb #4a — memory read. Maps to GET /api/agents/runtime/memory.
+ *
+ * The read complement to commonly_memory_sync. Returns this agent identity's
+ * kernel memory envelope (sections + the v1 `content` mirror).
+ *
+ * Why this exists: the envelope is keyed by agent identity, so every tool
+ * authenticated with the SAME COMMONLY_AGENT_TOKEN reads the SAME envelope.
+ * That is how "one project memory shared by all your AI tools" works in
+ * practice — point Claude Code, Cursor, and Codex at one identity, then
+ * tool A writes via commonly_memory_sync and tool B recalls it here. Before
+ * this tool the MCP surface could WRITE the envelope but had no way to READ
+ * it back (commonly_read / commonly_context are pod-asset operations, not the
+ * agent envelope), which silently broke read-after-write across tools.
+ */
+
+import { CommonlyClient, type CAPMemoryResponse } from "../client.js";
+
+export const definition = {
+  name: "commonly_memory_read",
+  description:
+    "CAP verb (memory). Read this agent's kernel memory envelope (ADR-003) — " +
+    "the read complement to commonly_memory_sync. Requires COMMONLY_AGENT_TOKEN. " +
+    "Returns all sections (soul, long_term, daily, relationships, dedup_state, " +
+    "shared, runtime_meta) plus the v1 `content` field. Memory is keyed by agent " +
+    "identity, so any tool using the same token reads the same envelope — use " +
+    "this to recall what you (or another tool sharing this identity) saved. Pass " +
+    "`section` to return just one section instead of the whole envelope.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      section: {
+        type: "string",
+        description:
+          "Optional. Return only this section (e.g. 'long_term'). Omit to read the full envelope.",
+      },
+    },
+  },
+};
+
+export interface CapMemoryReadArgs {
+  section?: string;
+}
+
+export interface CapMemoryReadResult extends CAPMemoryResponse {
+  // Populated only when a specific `section` was requested. `null` distinguishes
+  // "you asked for a section that isn't set" from "you didn't ask for one".
+  section?: unknown;
+}
+
+export async function handler(
+  client: CommonlyClient,
+  args: CapMemoryReadArgs = {}
+): Promise<CapMemoryReadResult> {
+  const env = await client.readMemory();
+  const result: CapMemoryReadResult = {
+    content: env.content,
+    sections: env.sections,
+    sourceRuntime: env.sourceRuntime,
+    schemaVersion: env.schemaVersion,
+  };
+  if (args.section) {
+    const key = String(args.section);
+    const sections = (env.sections ?? {}) as Record<string, unknown>;
+    result.section = key in sections ? sections[key] : null;
+  }
+  return result;
+}

--- a/packages/commonly-mcp/src/tools/index.ts
+++ b/packages/commonly-mcp/src/tools/index.ts
@@ -11,6 +11,7 @@ import * as CapPoll from "./cap-poll.js";
 import * as CapAck from "./cap-ack.js";
 import * as CapPost from "./cap-post.js";
 import * as CapMemorySync from "./cap-memory-sync.js";
+import * as CapMemoryRead from "./cap-memory-read.js";
 import * as CapAsk from "./cap-ask.js";
 import * as CapRespond from "./cap-respond.js";
 import * as CapReact from "./cap-react.js";
@@ -221,6 +222,7 @@ export const tools: Tool[] = [
   CapAck.definition,
   CapPost.definition,
   CapMemorySync.definition,
+  CapMemoryRead.definition,
   // ADR-003 Phase 4 — cross-agent ask/respond. Distinct from chat.mention:
   // these are silent peer-to-peer (no human-visible message in the pod).
   CapAsk.definition,
@@ -417,6 +419,14 @@ export async function handleToolCall(
         sections: args.sections as Record<string, unknown>,
         mode: args.mode as "full" | "patch",
         sourceRuntime: args.sourceRuntime as string | undefined,
+      });
+    }
+
+    case CapMemoryRead.definition.name: {
+      // Read complement to commonly_memory_sync — the missing half that lets a
+      // second tool recall what the first wrote under the same identity.
+      return CapMemoryRead.handler(client, {
+        section: args.section as string | undefined,
       });
     }
 


### PR DESCRIPTION
## Why

The wedge — *"one project memory shared by all your AI tools"* — works by pointing every tool (Claude Code, Cursor, Codex) at **one agent identity**: the memory envelope is keyed by identity, so a shared token = a shared brain. Smoke-testing that mechanic surfaced a real gap.

The shipped `@commonlyai/mcp` server could **write** the agent envelope (`commonly_memory_sync` → `POST /memory/sync`) but had **no tool to read it back**. `commonly_read` / `commonly_context` are pod-*asset* operations, not the agent envelope (`GET /api/agents/runtime/memory`). So read-after-write across tools was silently broken: tool B couldn't recall what tool A saved.

## What

- **`commonly_memory_read`** — surfaces the existing `client.readMemory()` (CAP verb 4a) as an MCP tool, with an optional `section` filter. Mirrors `cap-memory-sync.ts`. The missing read half.
- 4 unit tests (full envelope / section filter / missing-section `null` / error propagation). Full package suite: **42 passing**, `tsc` clean.
- **`shared-identity-memory-smoke.test.js`** — the convergence proof (one identity, many tool shapes, one envelope), complement of the existing two-driver *isolation* cross-check. _Node 26 locally breaks the jsonwebtoken→buffer-equal-constant-time dep, so this is CI-verified (Node 20) only._

## Related finding (not in this PR)

While smoke-testing I re-verified the long-standing "codex `exec` doesn't surface MCP tools" gap (`CLAUDE.md:428`, `MCP_INTEGRATION.md`): **it's fixed in codex 0.133.0.** Captured the model-request payload — codex now forwards the full `commonly_*` namespace (incl. memory tools). The docs are stale; follow-up to correct them + bump Cody's codex CLI.

## Rollout note

`dist/` is gitignored; the cluster + dev tools consume the **published** `@commonlyai/mcp`. This tool reaches Cody / Claude Code only after a version bump + republish (separate operator step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)