### PR TITLE
fix(litellm): correct GetAccessTokenError(status_code, message) in #479 fail-fast patch

### DIFF
--- a/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
@@ -187,7 +187,7 @@ spec:
             f=os.path.join(os.path.dirname(litellm.__file__),'llms','chatgpt','authenticator.py')
             s=open(f).read()
             old='        cooldown_remaining = self._get_device_code_cooldown_remaining(auth_data)'
-            new='        if os.getenv(\"CHATGPT_DISABLE_DEVICE_LOGIN\"):  # commonly: fail-fast headless\n            raise GetAccessTokenError(\"ChatGPT auth invalid/expired and interactive device-login is disabled (CHATGPT_DISABLE_DEVICE_LOGIN); re-auth out-of-band via the codex-cli sidecar. Requests fall back per router fallbacks.\")\n' + old
+            new='        if os.getenv(\"CHATGPT_DISABLE_DEVICE_LOGIN\"):  # commonly: fail-fast headless\n            raise GetAccessTokenError(401, \"ChatGPT auth invalid/expired and interactive device-login is disabled (CHATGPT_DISABLE_DEVICE_LOGIN); re-auth out-of-band via the codex-cli sidecar. Requests fall back per router fallbacks.\")\n' + old
             if 'commonly: fail-fast headless' in s:
                 print('LiteLLM chatgpt fail-fast patch: already applied')
             elif old in s:


### PR DESCRIPTION
Follow-up to #479. The fail-fast guard called `GetAccessTokenError("msg")`, but the constructor is `GetAccessTokenError(status_code, message)` — so a single positional arg raises `TypeError` instead of the clean auth error the fallback path expects. It only fires on dead auth (never on valid auth), so #479 looked fine in the regression check; I caught this by **unit-testing the patched authenticator in-container** (`GetAccessTokenError("x")` → TypeError; `GetAccessTokenError(401, "x")` → clean raise).

Fix: pass `401` as `status_code`, matching litellm's own `GetAccessTokenError` call sites in the same file. Patch re-validated: applies once + `py_compile`-clean against stock `authenticator.py`.

After merge I'll redeploy and run the full live test (simulate dead auth → confirm litellm boots + degrades to Nemotron instead of crash-looping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)