### PR TITLE
fix(litellm): strip CR/LF from provider API keys at startup (defense-in-depth for the nemotron-fallback break)

### DIFF
--- a/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
@@ -196,6 +196,20 @@ spec:
             else:
                 print('LiteLLM chatgpt fail-fast patch: pattern not found (version changed?) - review needed')
             "
+            # Defensive: strip stray CR/LF from provider API keys before litellm reads them.
+            # A trailing newline in OPENROUTER_API_KEY (the GCP SM secret had been stored
+            # with one) made httpx reject the outgoing Authorization header ("Newline,
+            # carriage return, or null byte detected in headers. Potential header injection
+            # attack."), silently breaking ~half of the codex->nemotron fallback (2026-06-24).
+            # The source secret was fixed, but a malformed key from ANY source must never be
+            # able to break routing again — so sanitize here too. litellm inherits this env
+            # via exec below.
+            for _k in OPENROUTER_API_KEY OPENROUTER_API_KEY_2 OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY; do
+              eval "_orig=\${$_k:-}"
+              _clean=$(printf '%s' "$_orig" | tr -d '\r\n')
+              [ "$_orig" != "$_clean" ] && echo "sanitized $_k (stripped CR/LF)"
+              eval "export $_k=\"\$_clean\""
+            done
             exec litellm --config /app/config.yaml
         ports:
         - name: http


### PR DESCRIPTION
Defensive follow-up to the 2026-06-24 incident. A trailing newline in `OPENROUTER_API_KEY` (the GCP SM secret was stored with one) made `httpx` reject the outgoing `Authorization` header (*"Newline … detected in headers. Potential header injection attack."*), silently breaking ~half of the `codex → nemotron` fallback. Combined with the startup device-login crash loop, that meant a codex-auth lapse had **no working path at all**.

The source secret is already fixed (newline stripped at the GCP SM source + ESO re-synced; nemotron verified 4/4). This adds **defense-in-depth**: the litellm startup script now strips CR/LF from the provider key env vars before `exec litellm`, so a malformed key from any source can never break routing again. Logs which keys it sanitized. Validated in POSIX sh (newline key → cleaned, clean key → untouched, empty → safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)