### PR TITLE
chore(domain): migrate public hosts to commonly.me (config + runbook) — DO NOT DEPLOY until DNS ready

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           REPO=${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/commonly-frontend
           docker build frontend \
-            --build-arg REACT_APP_API_URL=https://api-dev.commonly.me \
+            --build-arg REACT_APP_API_URL=https://api.commonly.me \
             -t "$REPO:$TAG"
           docker push "$REPO:$TAG"
 

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -77,7 +77,7 @@ const app = express();
 // `req.protocol` returns 'http' even when the public URL is HTTPS, because
 // the cluster-internal hop is plain HTTP. The downstream effect: any URL
 // we build with `${req.protocol}://...` (avatar uploads, profile pictures,
-// pod attachments) gets emitted as `http://api-dev.commonly.me/...` and
+// pod attachments) gets emitted as `http://api.commonly.me/...` and
 // triggers Mixed Content warnings in every page load. Trusting the proxy
 // makes Express honor X-Forwarded-Proto.
 app.set('trust proxy', true);
@@ -89,7 +89,7 @@ const buildAllowedOrigins = () => {
       .map((value) => value.trim())
       .filter(Boolean);
   }
-  return ['http://localhost:3000', 'https://app-dev.commonly.me'];
+  return ['http://localhost:3000', 'https://commonly.me'];
 };
 
 const allowedOrigins = buildAllowedOrigins();

--- a/cloudbuild.frontend.yaml
+++ b/cloudbuild.frontend.yaml
@@ -15,5 +15,5 @@ images:
   - '${_IMAGE}'
 
 substitutions:
-  _REACT_APP_API_URL: 'https://api-dev.commonly.me'
+  _REACT_APP_API_URL: 'https://api.commonly.me'
   _IMAGE: 'us-central1-docker.pkg.dev/commonly-493005/docker/commonly-frontend:latest'

--- a/docs/runbooks/domain-migration-commonly-me.md
+++ b/docs/runbooks/domain-migration-commonly-me.md
@@ -1,0 +1,82 @@
+# Domain migration → commonly.me
+
+Move the dev cluster's public surface from `app-dev` / `api-dev` to the apex
+`commonly.me` (frontend) + `api.commonly.me` (backend) + `litellm.commonly.me`
+(model gateway), **replacing** the old hosts.
+
+> **Branch:** `domain-commonly-me` holds the code/config side. It is **not
+> deployed**. Deploying it flips the dev ingress to the new hosts, so it must
+> only ship **after** DNS for the new hosts is live (step 1), or the app goes
+> dark. Do the steps in order.
+
+## Host mapping
+
+| Was | Now |
+|---|---|
+| `app-dev.commonly.me` | `commonly.me` (apex) |
+| `api-dev.commonly.me` | `api.commonly.me` |
+| `litellm-dev.commonly.me` | `litellm.commonly.me` |
+
+## What the branch already changes (code/config)
+
+- `k8s/helm/commonly/values.yaml` + `values-dev.yaml` — `backend.env.frontendUrl`,
+  `backendUrl`, ingress `hosts.{frontend,backend,litellm}.host`, and
+  `cloudflared.hostnames` (also deduped a repeated `api-dev` entry and dropped a
+  stray `app.commonly.me`).
+- `.github/workflows/deploy-dev.yml` + `cloudbuild.frontend.yaml` —
+  `REACT_APP_API_URL=https://api.commonly.me` (frontend build arg).
+- `backend/server.ts` — CORS fallback default + a doc comment.
+- `frontend/src/v2/components/V2AgentBYO.tsx` — BYO snippet API-URL fallback.
+  (The hostname-derivation regex correctly falls through to this fallback for
+  the apex `commonly.me`, which has no `app` prefix to swap.)
+
+## Operator steps (in order) — only you can do 1, 3, 4
+
+### 1. DNS + Cloudflare tunnel (BEFORE deploying the branch)
+- Point `commonly.me` (apex — use CNAME-flattening / Cloudflare proxied),
+  `api.commonly.me`, and `litellm.commonly.me` at the **same cloudflared tunnel**
+  the old hosts use.
+- In the tunnel's public-hostname config, add the three new hostnames routed to
+  the ingress controller service (same target as the old hosts today).
+- Verify each resolves and the tunnel accepts it (a 404/redirect from the
+  ingress is fine at this stage — it proves the tunnel + ingress are reachable).
+
+### 2. Merge + deploy the branch
+- Merge `domain-commonly-me` to `main` (squash, then `git push origin <branch>:main`).
+- `gh workflow run deploy-dev.yml --ref main` — rebuilds the frontend with
+  `REACT_APP_API_URL=https://api.commonly.me` and helm-upgrades the dev cluster
+  so the ingress now serves the new hosts. **At this point the old hosts stop
+  being served** (clean replacement).
+
+### 3. OAuth callback URLs (after deploy, before announcing)
+- **Discord** developer portal → add redirect `https://api.commonly.me/api/discord/callback`.
+- **X** app settings → add callback
+  `https://api.commonly.me/api/admin/integrations/global/x/oauth/callback`.
+- (Remove the old `api-dev` callbacks once verified.)
+
+### 4. Verify
+- `curl -I https://commonly.me` → 200 (frontend).
+- `curl -I https://api.commonly.me/api/health/live` → 200 (backend).
+- Load `https://commonly.me` logged-out → the new landing renders; log in → app shell.
+- No CORS errors in the browser console; Discord + X OAuth round-trip on the new callbacks.
+
+### 5. Cleanup (after a stable day)
+- Drop the old `app-dev` / `api-dev` / `litellm-dev` DNS + tunnel hostnames.
+- **Doc sweep:** ~24 markdown files (CLAUDE.md, READMEs, ADRs, runbooks) still
+  reference the old hosts. Sweep them *now* (not before the flip — until the flip
+  they accurately describe the live URL). They are non-functional references.
+
+## Rollback
+- `kubectl rollout undo deploy/<name> -n commonly-dev` per deployment, or
+  `helm rollback commonly-dev -n commonly-dev <revision>` (see `helm history`).
+- DNS/tunnel: re-add the old hostnames (kept until step 5) to restore `app-dev`.
+
+## Notes / open items for review
+- **Hard cutover vs overlap:** this branch does a clean replacement (matches
+  "replace app-dev entirely"). If you'd rather run both during a transition,
+  add the old hosts back as ingress `aliases` on each service and keep them in
+  `cloudflared.hostnames` until step 5 — say the word and I'll prepare that shape.
+- **Pre-existing (not from this branch):** `cloudbuild.frontend.yaml` line 19
+  hard-codes a GCP project id + AR path in the public repo. Flagging per the
+  no-infra-leak-in-public-repo rule — worth moving to a substitution/secret in a
+  separate cleanup, independent of this migration.

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -118,7 +118,7 @@ const V2AgentBYO: React.FC = () => {
 
   const apiUrl = typeof window !== 'undefined' && /api-dev|api\./.test(window.location.hostname)
     ? `https://${window.location.hostname.replace(/^app/, 'api')}`
-    : 'https://api-dev.commonly.me';
+    : 'https://api.commonly.me';
 
   const claudeSnippet = issued
     ? `claude mcp add commonly \\\n  -e COMMONLY_API_URL=${apiUrl} \\\n  -e COMMONLY_AGENT_TOKEN=${issued.token} \\\n  -- npx -y @commonlyai/mcp`

--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -31,8 +31,8 @@ backend:
     agentProvisionerK8s: "1"
     agentProvisionerDocker: "0"
     agentProvisionerNodePool: "dev"
-    frontendUrl: "https://app-dev.commonly.me"
-    backendUrl: "https://api-dev.commonly.me"
+    frontendUrl: "https://commonly.me"
+    backendUrl: "https://api.commonly.me"
     commonlyApiUrl: ""
     clawdbotGatewayUrl: ""
     moltbotGatewayUrl: ""
@@ -182,11 +182,11 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-body-size: "10m"
   hosts:
     frontend:
-      host: app-dev.commonly.me
+      host: commonly.me
     backend:
-      host: api-dev.commonly.me
+      host: api.commonly.me
     litellm:
-      host: litellm-dev.commonly.me
+      host: litellm.commonly.me
   tls:
     enabled: false  # Enable after setting up cert-manager
 

--- a/k8s/helm/commonly/values.yaml
+++ b/k8s/helm/commonly/values.yaml
@@ -56,8 +56,8 @@ backend:
     agentProvisionerK8s: "1"
     agentProvisionerDocker: "0"
     agentProvisionerNodePool: ""
-    frontendUrl: "https://app-dev.commonly.me"
-    backendUrl: "https://api-dev.commonly.me"
+    frontendUrl: "https://commonly.me"
+    backendUrl: "https://api.commonly.me"
     commonlyApiUrl: ""
     clawdbotGatewayUrl: ""
     moltbotGatewayUrl: ""
@@ -297,17 +297,17 @@ ingress:
     nginx.ingress.kubernetes.io/session-cookie-name: "commonly-backend"
   hosts:
     frontend:
-      host: app-dev.commonly.me
+      host: commonly.me
       path: /
       pathType: Prefix
       aliases: []
     backend:
-      host: api-dev.commonly.me
+      host: api.commonly.me
       path: /
       pathType: Prefix
       aliases: []
     litellm:
-      host: litellm-dev.commonly.me
+      host: litellm.commonly.me
       path: /
       pathType: Prefix
   tls:
@@ -362,11 +362,9 @@ cloudflared:
   ingressPort: 80
   metricsPort: 2000
   hostnames:
-    - app.commonly.me
-    - api-dev.commonly.me
-    - app-dev.commonly.me
-    - api-dev.commonly.me
-    - litellm-dev.commonly.me
+    - commonly.me
+    - api.commonly.me
+    - litellm.commonly.me
 
 # LiteLLM proxy (model gateway + request logging)
 litellm:


### PR DESCRIPTION
## What

Migrates the dev cluster's public surface from `app-dev`/`api-dev`/`litellm-dev` to the apex **`commonly.me`** + **`api.commonly.me`** + **`litellm.commonly.me`**, replacing the old hosts.

Functional config swapped (6 files): Helm `values.yaml` + `values-dev.yaml` (`frontendUrl`, `backendUrl`, ingress hosts, `cloudflared.hostnames` — deduped a repeated `api-dev` entry + dropped a stray `app.commonly.me`), `.github/workflows/deploy-dev.yml` + `cloudbuild.frontend.yaml` (`REACT_APP_API_URL`), `backend/server.ts` CORS fallback, `V2AgentBYO.tsx` snippet fallback.

Adds `docs/runbooks/domain-migration-commonly-me.md` — the exact operator sequence.

## ⚠️ DO NOT MERGE+DEPLOY until DNS is live

This flips the dev ingress to the new hosts. Sequence (see runbook):
1. **DNS + Cloudflare tunnel** for the 3 new hosts → same tunnel/ingress as today. Verify they resolve.
2. Merge + `Deploy Dev`.
3. Update **Discord** + **X** OAuth callback URLs to `api.commonly.me`.
4. Verify (`curl -I https://commonly.me`, `https://api.commonly.me/api/health/live`, OAuth round-trip).
5. Drop old hosts + sweep ~24 doc references.

## Flagged (pre-existing, not this PR)
`cloudbuild.frontend.yaml:19` hard-codes a GCP project id + AR path in the public repo — worth moving to a substitution/secret separately (no-infra-leak rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)