### PR TITLE
fix(v2-landing): auth-aware CTAs + sign-in entry + unify blue accent

### DIFF
--- a/frontend/src/v2/landing/V2ComparePage.tsx
+++ b/frontend/src/v2/landing/V2ComparePage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
 import '../v2.css';
@@ -38,7 +39,10 @@ const ROWS: Row[] = [
   { dim: 'Bring your own runtime', commonly: 'Native, OpenClaw, Codex, Claude Code, webhook', commonlyWin: false, raft: 'Bring your own agent daemon' },
 ];
 
-const V2ComparePage: React.FC = () => (
+const V2ComparePage: React.FC = () => {
+  const { isAuthenticated } = useAuth();
+  const appHref = isAuthenticated ? '/v2' : '/v2/login';
+  return (
   <div className="v2-root v2-landing">
     <header className="v2-landing__bar">
       <Link className="v2-landing__brand" to="/v2/landing" style={{ textDecoration: 'none' }}>
@@ -48,7 +52,12 @@ const V2ComparePage: React.FC = () => (
       <nav className="v2-landing__nav" aria-label="Primary">
         <Link className="v2-landing__navlink" to="/v2/landing">Home</Link>
         <a className="v2-landing__navlink" href={REPO} target="_blank" rel="noreferrer">GitHub</a>
-        <Link className="v2-landing__btn v2-landing__btn--primary v2-landing__btn--sm" to="/v2/register">Open the app</Link>
+        {!isAuthenticated && (
+          <Link className="v2-landing__navlink" to="/v2/login">Sign in</Link>
+        )}
+        <Link className="v2-landing__btn v2-landing__btn--primary v2-landing__btn--sm" to={appHref}>
+          {isAuthenticated ? 'Open the app' : 'Get started'}
+        </Link>
       </nav>
     </header>
 
@@ -91,7 +100,7 @@ const V2ComparePage: React.FC = () => (
         </p>
 
         <div className="v2-landing__cta-row v2-compare__cta">
-          <Link className="v2-landing__btn v2-landing__btn--primary" to="/v2/register">Open the app</Link>
+          <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>Open the app</Link>
           <a className="v2-landing__btn v2-landing__btn--ghost" href={REPO} target="_blank" rel="noreferrer">
             <span className="v2-landing__btn-mark"><Mark size={18} /></span>
             Star on GitHub
@@ -113,7 +122,7 @@ const V2ComparePage: React.FC = () => (
         <div className="v2-landing__footer-col">
           <div className="v2-landing__footer-title">Product</div>
           <Link className="v2-landing__footer-link" to="/v2/landing">Home</Link>
-          <Link className="v2-landing__footer-link" to="/v2/register">Open the app</Link>
+          <Link className="v2-landing__footer-link" to={appHref}>Open the app</Link>
         </div>
         <div className="v2-landing__footer-col">
           <div className="v2-landing__footer-title">Open source</div>
@@ -123,6 +132,7 @@ const V2ComparePage: React.FC = () => (
       </div>
     </footer>
   </div>
-);
+  );
+};
 
 export default V2ComparePage;

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
+import { useAuth } from '../../context/AuthContext';
 import BadgeOutlinedIcon from '@mui/icons-material/BadgeOutlined';
 import LayersOutlinedIcon from '@mui/icons-material/LayersOutlined';
 import AlternateEmailOutlinedIcon from '@mui/icons-material/AlternateEmailOutlined';
@@ -62,7 +63,13 @@ const Shot: React.FC<{ src: string; alt: string; caption: string; wide?: boolean
 );
 
 const V2LandingPage: React.FC = () => {
+  const { isAuthenticated } = useAuth();
   const [stats, setStats] = useState<Stats | null>(null);
+
+  // "Open the app" must take you INTO the app: signed-in → the shell; signed-out
+  // → the sign-in portal (registration is invite-only, so never dump a visitor
+  // at /v2/register). V2Home then routes an authed /v2 to the shell.
+  const appHref = isAuthenticated ? '/v2' : '/v2/login';
 
   useEffect(() => {
     let cancelled = false;
@@ -88,7 +95,12 @@ const V2LandingPage: React.FC = () => {
           <a className="v2-landing__navlink" href="#pricing">Pricing</a>
           <Link className="v2-landing__navlink" to="/compare">Compare</Link>
           <a className="v2-landing__navlink" href={REPO} target="_blank" rel="noreferrer">GitHub</a>
-          <Link className="v2-landing__btn v2-landing__btn--primary v2-landing__btn--sm" to="/v2/register">Open the app</Link>
+          {!isAuthenticated && (
+            <Link className="v2-landing__navlink" to="/v2/login">Sign in</Link>
+          )}
+          <Link className="v2-landing__btn v2-landing__btn--primary v2-landing__btn--sm" to={appHref}>
+            {isAuthenticated ? 'Open the app' : 'Get started'}
+          </Link>
         </nav>
       </header>
 
@@ -115,7 +127,7 @@ const V2LandingPage: React.FC = () => {
             </div>
 
             <div className="v2-landing__cta-row">
-              <Link className="v2-landing__btn v2-landing__btn--primary" to="/v2/register">Open the app</Link>
+              <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>Open the app</Link>
               <a className="v2-landing__btn v2-landing__btn--ghost" href={REPO} target="_blank" rel="noreferrer">
                 <span className="v2-landing__btn-mark"><Mark size={18} /></span>
                 Star on GitHub
@@ -378,7 +390,7 @@ const V2LandingPage: React.FC = () => {
                 <li>Your infra, your data</li>
               </ul>
               <div className="v2-landing__cta-row">
-                <Link className="v2-landing__btn v2-landing__btn--primary" to="/v2/register">Open the app</Link>
+                <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>Open the app</Link>
                 <a className="v2-landing__btn v2-landing__btn--ghost" href={REPO} target="_blank" rel="noreferrer">Self-host it</a>
               </div>
             </div>
@@ -390,7 +402,7 @@ const V2LandingPage: React.FC = () => {
           <h2 className="v2-landing__cta-title">Give your agents one place to remember.</h2>
           <p className="v2-landing__cta-sub">Open the hosted app, or clone the repo and self-host in one command. It&apos;s all open.</p>
           <div className="v2-landing__cta-row">
-            <Link className="v2-landing__btn v2-landing__btn--onaccent" to="/v2/register">Open the app</Link>
+            <Link className="v2-landing__btn v2-landing__btn--onaccent" to={appHref}>Open the app</Link>
             <a className="v2-landing__btn v2-landing__btn--onaccent-ghost" href={REPO} target="_blank" rel="noreferrer">Star on GitHub</a>
             <Link className="v2-landing__btn v2-landing__btn--onaccent-ghost" to="/compare">Compare to Raft</Link>
           </div>
@@ -406,7 +418,7 @@ const V2LandingPage: React.FC = () => {
         <div className="v2-landing__footer-cols">
           <div className="v2-landing__footer-col">
             <div className="v2-landing__footer-title">Product</div>
-            <Link className="v2-landing__footer-link" to="/v2/register">Open the app</Link>
+            <Link className="v2-landing__footer-link" to={appHref}>Open the app</Link>
             <Link className="v2-landing__footer-link" to="/v2/marketplace">Marketplace</Link>
             <Link className="v2-landing__footer-link" to="/v2/agents/browse">Hire an agent</Link>
             <Link className="v2-landing__footer-link" to="/compare">Compare to Raft</Link>

--- a/frontend/src/v2/landing/v2-landing.css
+++ b/frontend/src/v2/landing/v2-landing.css
@@ -92,7 +92,7 @@
 }
 .v2-landing__btn--ghost:hover { background: var(--v2-surface-hover); border-color: var(--v2-border-strong, var(--v2-border)); }
 .v2-landing__btn--onaccent {
-  color: var(--v2-accent-text);
+  color: var(--v2-accent);
   background: #ffffff;
   border: 1px solid #ffffff;
 }
@@ -120,7 +120,7 @@
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--v2-accent-text);
+  color: var(--v2-accent);
   margin-bottom: 16px;
 }
 .v2-landing__title {
@@ -146,7 +146,7 @@
   border-radius: 6px;
   background: var(--v2-surface-tint);
   border: 1px solid var(--v2-border-soft);
-  color: var(--v2-accent-text);
+  color: var(--v2-accent);
 }
 
 /* Hero stat badges (light surface) */
@@ -177,7 +177,7 @@
   border-radius: var(--v2-radius);
   overflow-x: auto;
 }
-.v2-landing__install-prompt { color: var(--v2-accent-text); font-family: var(--v2-font-mono); font-weight: 700; }
+.v2-landing__install-prompt { color: var(--v2-accent); font-family: var(--v2-font-mono); font-weight: 700; }
 .v2-landing__install-cmd {
   font-family: var(--v2-font-mono);
   font-size: 13px;
@@ -185,7 +185,7 @@
   white-space: nowrap;
 }
 .v2-landing__hero-by { margin-top: 20px; font-size: 13px; color: var(--v2-text-tertiary); }
-.v2-landing__hero-by a { color: var(--v2-accent-text); text-decoration: none; }
+.v2-landing__hero-by a { color: var(--v2-accent); text-decoration: none; }
 .v2-landing__hero-by a:hover { text-decoration: underline; }
 
 .v2-landing__hero-art { display: flex; justify-content: center; }
@@ -261,7 +261,7 @@
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--v2-accent-text);
+  color: var(--v2-accent);
   margin-bottom: 8px;
 }
 .v2-landing__kicker--light { color: rgba(255, 255, 255, 0.6); }
@@ -298,7 +298,7 @@
   height: 28px;
   border-radius: var(--v2-radius-pill);
   background: var(--v2-accent-soft);
-  color: var(--v2-accent-text);
+  color: var(--v2-accent);
   font-size: 14px;
   font-weight: 700;
   margin-bottom: 14px;
@@ -402,7 +402,7 @@
   font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.06em;
-  color: var(--v2-accent-text);
+  color: var(--v2-accent);
   margin-bottom: 12px;
 }
 .v2-landing__tile-title { font-size: 17px; font-weight: 700; color: var(--v2-text-primary); margin-bottom: 8px; }
@@ -521,7 +521,7 @@
   text-decoration: none;
   transition: color 80ms ease;
 }
-.v2-landing__footer-link:hover { color: var(--v2-accent-text); }
+.v2-landing__footer-link:hover { color: var(--v2-accent); }
 
 /* ---------- Compare page (/compare) ---------- */
 .v2-compare__head { max-width: 920px; margin: 0 auto; padding-top: 56px; }
@@ -568,7 +568,7 @@
 .v2-compare__cell--dim { font-weight: 650; color: var(--v2-text-primary); }
 .v2-compare__row--head .v2-compare__cell { font-weight: 700; color: var(--v2-text-primary); font-size: 15px; }
 .v2-compare__cell--us { background: var(--v2-accent-soft); }
-.v2-compare__row--head .v2-compare__cell--us { color: var(--v2-accent-text); }
+.v2-compare__row--head .v2-compare__cell--us { color: var(--v2-accent); }
 .v2-compare__cell--us .v2-landing__mark { color: var(--v2-accent); display: inline-flex; }
 .v2-compare__ic { font-size: 18px; flex-shrink: 0; }
 .v2-compare__ic--yes { color: var(--v2-accent); }


### PR DESCRIPTION
Fixes the landing entry flow + design alignment reported after the domain went live.

## Entry flow
- **Bug:** "Open the app" was hardcoded to `/v2/register` (registration is invite-only), so even a **signed-in** user landed on a registration form instead of the app. Now auth-aware: signed-in → `/v2` (V2Home → shell), signed-out → `/v2/login`. Applied to hero, nav, pricing, final CTA, footer, and `/compare`.
- **Sign-in portal:** added a visible **"Sign in"** link to the nav (signed-out). Primary button reads **"Get started"** signed-out, **"Open the app"** signed-in.

## Design alignment
- Collapsed the two foreground blues (`--v2-accent` `#2f6feb` + `--v2-accent-text` `#2456c8`) to the **single cobalt accent** per the `commonly-design` rule. `accent-soft` (chips), `accent-deep` (navy bands), `accent-strong` (hover) unchanged. No hardcoded hex.

Verified locally (Vite + Playwright): nav shows Sign in + Get started, blue unified, lint/types clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)