### PR TITLE
fix(frontend): apex domain (commonly.me) can't reach backend — honor REACT_APP_API_URL

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,7 +12,18 @@ export default defineConfig({
     outDir: 'build', // match CRA output dir for deployment compatibility
   },
   define: {
-    // CRA used process.env.REACT_APP_* — keep compatibility
+    // CRA used process.env.REACT_APP_* — keep compatibility. The bare
+    // `process.env: {}` replacement clobbers ALL process.env access at build
+    // time, which silently zeroed out the API base: getApiBaseUrl() reads
+    // `process.env.REACT_APP_API_URL` first, got undefined, and fell back to
+    // same-origin — fine on app.* hosts but broken on the apex (commonly.me),
+    // where the frontend host serves the SPA and does NOT proxy /api, so every
+    // logged-in API call hit the SPA instead of the backend. The Dockerfile +
+    // CI already pass REACT_APP_API_URL=https://api.commonly.me as a build ENV;
+    // pass it through explicitly (a longer define key wins over `process.env`)
+    // so the app actually reads it. Empty string when unset keeps self-hosted
+    // same-origin builds on their existing fallback path.
+    'process.env.REACT_APP_API_URL': JSON.stringify(process.env.REACT_APP_API_URL || ''),
     'process.env': {},
   },
 });


### PR DESCRIPTION
## Bug

The logged-in v2 app on **commonly.me** can't load pods/agents — `commonly.me/api/*` returns the SPA's index.html (200), not the backend. 'Open the app' lands on an empty shell.

## Root cause

`vite.config.ts` has `define: { 'process.env': {} }`, which clobbers **all** build-time `process.env` access. `getApiBaseUrl()` reads `process.env.REACT_APP_API_URL` first → got `undefined` → fell through to a same-origin base. The app./app-dev. hostname rules cover those subdomains, but the bare apex `commonly.me` has no rule and the frontend host doesn't proxy `/api`, so every API call hit the SPA.

## Fix

The Dockerfile + CI already pass `REACT_APP_API_URL=https://api.commonly.me` as a build ENV — but Vite was eating it. Add an explicit, more-specific define key so it survives; the broad `process.env: {}` still covers everything else. Unset → `''`, so self-hosted same-origin builds are unaffected.

## Verified

- esbuild define precedence confirmed: `process.env.REACT_APP_API_URL` → the URL, `process.env.X` → `{}.X`.
- Live repro: `commonly.me/api/pods` returns SPA HTML; the app only loaded data when I rerouted `/api` → `api.commonly.me` in the browser. Post-deploy I'll confirm it works natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)