### PR TITLE
fix(agents): keep runtime model-failure errors out of pod chat

### DIFF
--- a/backend/__tests__/unit/services/agentMessageService.modelFailure.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.modelFailure.test.js
@@ -1,0 +1,33 @@
+// Unit tests for AgentMessageService.isRuntimeModelFailure — the guard that
+// keeps runtime model-failure errors (posted by the gateway when the model
+// chain is exhausted) out of user-facing pod chat.
+const AgentMessageService = require('../../../services/agentMessageService');
+
+describe('AgentMessageService.isRuntimeModelFailure', () => {
+  it('matches the gateway failover-error shapes that spam chat', () => {
+    const samples = [
+      '⚠️ Agent failed before reply: All models failed (4): openrouter/nvidia/nemotron-3-super-120b-a12b:free: 401 Missing Authentication header (auth)',
+      'Embedded agent failed before reply: All models failed (4): openrouter/...: 401',
+      'Agent failed before reply: model timed out',
+      'Heartbeat ran but All models failed (2): google/gemini-2.5-flash: LLM error',
+    ];
+    for (const s of samples) {
+      expect(AgentMessageService.isRuntimeModelFailure(s)).toBe(true);
+    }
+  });
+
+  it('does NOT match legitimate agent prose that mentions errors/failures', () => {
+    const ok = [
+      'I hit an error running the build — the test for the auth header failed, here is the fix.',
+      'All the models we evaluated failed the eval differently; here is the comparison.',
+      'The deployment failed before the health check passed; I rolled it back.',
+      'Done — attached the report.',
+      '',
+      null,
+      undefined,
+    ];
+    for (const s of ok) {
+      expect(AgentMessageService.isRuntimeModelFailure(s)).toBe(false);
+    }
+  });
+});

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -807,6 +807,19 @@ class AgentMessageService {
     }
     let sanitizedContent = AgentMessageService.sanitizeAgentContent(content);
 
+    // Suppress runtime model-failure errors. When a runtime's model chain is
+    // exhausted (bad/missing provider auth, 429s, all fallbacks down) the
+    // gateway posts the raw failover error AS the agent's "reply" — e.g.
+    // "⚠️ Agent failed before reply: All models failed (4): openrouter/...: 401".
+    // Those are operator diagnostics, never user-facing content; left alone they
+    // spam every pod the agent heartbeats in (~every 30 min). Treat them like a
+    // silent reply (empty → skipped below) and log instead, so a degraded
+    // community agent fails quietly rather than flooding chat.
+    if (sanitizedContent && AgentMessageService.isRuntimeModelFailure(sanitizedContent)) {
+      console.warn(`[agent-msg] suppressed runtime model-failure from agent=${agentName} instance=${instanceId} pod=${podId}: ${sanitizedContent.slice(0, 120)}`);
+      sanitizedContent = '';
+    }
+
     // Task #68: detect false-attachment claims. Agents sometimes post
     // "Done — I attached the file" without actually calling
     // commonly_attach_file. The file may exist in their workspace but
@@ -1384,6 +1397,24 @@ class AgentMessageService {
       }) => Promise<void>;
     };
     return triggers.recordAgentDmConclusion(args);
+  }
+
+  /**
+   * True when the content IS a runtime-generated model-failure error (not
+   * legitimate agent prose that happens to mention an error). These are posted
+   * by the gateway when the model chain is exhausted and must never reach
+   * user-facing chat. Strict signatures only — the runtime prefix
+   * ("[Embedded ]Agent failed before reply:") or the "All models failed (N):"
+   * failover summary — so an agent legitimately discussing an error is untouched.
+   */
+  static isRuntimeModelFailure(content: unknown): boolean {
+    if (!content) return false;
+    const c = String(content).trim();
+    if (!c) return false;
+    return (
+      /^(?:⚠️\s*)?(?:embedded\s+)?agent failed before reply\s*:/i.test(c)
+      || /\ball models failed\s*\(\d+\)\s*:/i.test(c)
+    );
   }
 
   static sanitizeAgentContent(content: unknown): string {


### PR DESCRIPTION
## Bug

When a runtime's model chain is exhausted (bad/missing provider auth, 429s, all fallbacks down), the gateway posts the raw failover error **as the agent's reply** — e.g. `⚠️ Agent failed before reply: All models failed (4): openrouter/nvidia/nemotron-...:free: 401 Missing Authentication header`. A degraded agent floods every pod it heartbeats in (~every 30 min), cluttering the pods and the sidebar. (Surfaced live: several community/demo agents on a broken OpenRouter free-tier auth.)

## Fix

`agentMessageService.postMessage` now detects the **strict** gateway failover signatures — the `[Embedded ]Agent failed before reply:` prefix or the `All models failed (N):` summary — and treats them like a silent reply (empty content → already skipped, not persisted), logging instead. Patterns are strict so an agent legitimately discussing an error/failure in prose is untouched.

## Tests

`agentMessageService.modelFailure.test.js` — failover shapes match; legitimate error-prose does not.

## Note

This stops the *symptom* (chat spam) regardless of model health. The *root cause* (community agents' OpenRouter provider not routing through LiteLLM → 401) is a separate provisioner fix, diagnosed but not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)