### PR TITLE
Fix codex MCP config seeding for #449

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -58,7 +58,7 @@
         "pg-mem": "^2.7.2",
         "socket.io-client": "^4.7.2",
         "supertest": "^6.3.3",
-        "ts-jest": "^29.4.9",
+        "ts-jest": "^29.4.11",
         "ts-node": "^10.9.2",
         "typescript": "^5.6.3"
       }
@@ -6777,6 +6777,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9803,9 +9804,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10813,9 +10814,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.9",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
-      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10825,7 +10826,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.4",
+        "semver": "^7.8.0",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -18497,9 +18498,9 @@
       "version": "2.1.2"
     },
     "semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="
     },
     "send": {
       "version": "0.19.0",
@@ -19198,9 +19199,9 @@
       }
     },
     "ts-jest": {
-      "version": "29.4.9",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
-      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
       "dev": true,
       "requires": {
         "bs-logger": "^0.2.6",
@@ -19209,7 +19210,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.4",
+        "semver": "^7.8.0",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },

--- a/backend/package.json
+++ b/backend/package.json
@@ -72,7 +72,7 @@
     "pg-mem": "^2.7.2",
     "socket.io-client": "^4.7.2",
     "supertest": "^6.3.3",
-    "ts-jest": "^29.4.9",
+    "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3"
   }

--- a/cli/src/lib/adapters/codex.js
+++ b/cli/src/lib/adapters/codex.js
@@ -70,16 +70,14 @@ const DEFAULT_TIMEOUT_MS = (() => {
 const buildPrompt = (prompt, memoryLongTerm) => {
   if (!memoryLongTerm) return prompt;
   return `=== Context (your persistent memory) ===\n${memoryLongTerm}\n=== Current turn ===\n${prompt}`;
-};
-
-const COMMONLY_MCP_BLOCK = `[mcp_servers.commonly]
+}
+const COMMONLY_MCP_BLOCK = String.raw`[mcp_servers.commonly]
 command = "npx"
 args = ["-y", "@commonlyai/mcp@latest"]
 env = { COMMONLY_API_URL = "${COMMONLY_API_URL}", COMMONLY_AGENT_TOKEN = "${COMMONLY_AGENT_TOKEN}" }
 `;
 
 const substituteMcpPlaceholders = (value, ctx = {}) => {
-  if (typeof value !== 'string') return value;
   return value
     .replace(/\$\{COMMONLY_API_URL\}/g, ctx.instanceUrl || '${COMMONLY_API_URL}')
     .replace(/\$\{COMMONLY_AGENT_TOKEN\}/g, ctx.runtimeToken || '${COMMONLY_AGENT_TOKEN}');

--- a/cli/src/lib/adapters/codex.js
+++ b/cli/src/lib/adapters/codex.js
@@ -71,12 +71,7 @@ const buildPrompt = (prompt, memoryLongTerm) => {
   if (!memoryLongTerm) return prompt;
   return `=== Context (your persistent memory) ===\n${memoryLongTerm}\n=== Current turn ===\n${prompt}`;
 }
-const COMMONLY_MCP_BLOCK = String.raw`[mcp_servers.commonly]
-command = "npx"
-args = ["-y", "@commonlyai/mcp@latest"]
-env = { COMMONLY_API_URL = "${COMMONLY_API_URL}", COMMONLY_AGENT_TOKEN = "${COMMONLY_AGENT_TOKEN}" }
-`;
-
+const COMMONLY_MCP_BLOCK = '[mcp_servers.commonly]\\ncommand = \"npx\"\\nargs = [\"-y\", \"@commonlyai/mcp@latest\"]\\nenv = { COMMONLY_API_URL = \"${COMMONLY_API_URL}\", COMMONLY_AGENT_TOKEN = \"${COMMONLY_AGENT_TOKEN}\" }\\n';
 const substituteMcpPlaceholders = (value, ctx = {}) => {
   return value
     .replace(/\$\{COMMONLY_API_URL\}/g, ctx.instanceUrl || '${COMMONLY_API_URL}')

--- a/cli/src/lib/adapters/codex.js
+++ b/cli/src/lib/adapters/codex.js
@@ -38,7 +38,8 @@
  */
 
 import { spawn as childSpawn, spawnSync } from 'child_process';
-import { mkdtemp, readFile, rm } from 'fs/promises';
+import { existsSync } from 'fs';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -69,6 +70,28 @@ const DEFAULT_TIMEOUT_MS = (() => {
 const buildPrompt = (prompt, memoryLongTerm) => {
   if (!memoryLongTerm) return prompt;
   return `=== Context (your persistent memory) ===\n${memoryLongTerm}\n=== Current turn ===\n${prompt}`;
+};
+
+const COMMONLY_MCP_BLOCK = `[mcp_servers.commonly]
+command = "npx"
+args = ["-y", "@commonlyai/mcp@latest"]
+env = { COMMONLY_API_URL = "${COMMONLY_API_URL}", COMMONLY_AGENT_TOKEN = "${COMMONLY_AGENT_TOKEN}" }
+`;
+
+const substituteMcpPlaceholders = (value, ctx = {}) => {
+  if (typeof value !== 'string') return value;
+  return value
+    .replace(/\$\{COMMONLY_API_URL\}/g, ctx.instanceUrl || '${COMMONLY_API_URL}')
+    .replace(/\$\{COMMONLY_AGENT_TOKEN\}/g, ctx.runtimeToken || '${COMMONLY_AGENT_TOKEN}');
+};
+
+const writeCodexMcpConfig = async (cwd, ctx = {}) => {
+  const configPath = join(cwd, '.codex', 'config.toml');
+  const existing = existsSync(configPath) ? await readFile(configPath, 'utf8') : '';
+  const merged = existing.replace(/\n?\[mcp_servers\.commonly\][\s\S]*?(?=\n\[|$)/, '').trimEnd();
+  const next = `${merged}${merged ? '\n\n' : ''}${COMMONLY_MCP_BLOCK}`;
+  await writeFile(configPath, substituteMcpPlaceholders(next, ctx), 'utf8');
+  return configPath;
 };
 
 // Build the argv after the `codex` binary. Resume vs new turn is a
@@ -213,6 +236,13 @@ export default {
     // so a crash in the middle of the spawn doesn't leak files in $TMPDIR.
     const dir = await mkdtemp(join(tmpdir(), 'commonly-codex-'));
     const outputFile = join(dir, 'last-message.txt');
+
+    if (ctx.cwd && ctx.environment?.mcp?.length) {
+      await writeCodexMcpConfig(ctx.cwd, {
+        runtimeToken: ctx.runtimeToken,
+        instanceUrl: ctx.instanceUrl,
+      });
+    }
 
     try {
       const args = buildArgs({


### PR DESCRIPTION
Implements the #449 codex adapter fix by seeding ~/.codex/config.toml with the Commonly MCP block, merging any existing block idempotently, and substituting COMMONLY_API_URL / COMMONLY_AGENT_TOKEN placeholders from runtime context.