### PR TITLE
fix(agents): heartbeat.global dropped → per-pod firing → codex rate-limit storm

### DIFF
--- a/backend/services/agentProvisionerService.ts
+++ b/backend/services/agentProvisionerService.ts
@@ -1043,6 +1043,10 @@ const provisionOpenClawAccount = async ({
       prompt: payload.prompt || DEFAULT_HEARTBEAT_PROMPT,
       target: payload.target || 'commonly', // Default to Commonly for Commonly-installed agents
       session,
+      // Carry `global` through — dropping it makes openclaw fire a heartbeat
+      // per pod (rate-limit cascade). See agentProvisionerServiceK8s.normalizeHeartbeat.
+      ...(payload.global === true ? { global: true } : {}),
+      ...(payload.fixedPod === true ? { fixedPod: true } : {}),
     };
   };
 

--- a/backend/services/agentProvisionerServiceK8s.ts
+++ b/backend/services/agentProvisionerServiceK8s.ts
@@ -2415,6 +2415,15 @@ const provisionOpenClawAccount = async ({
       prompt: payload.prompt || DEFAULT_HEARTBEAT_PROMPT,
       target: payload.target || 'commonly',
       session,
+      // Carry `global` through. Without it openclaw fires a heartbeat PER POD
+      // the agent belongs to — with ~20 agents in many pods each, that is
+      // hundreds of LLM calls per interval (each retrying on 429), which
+      // cascades into provider rate limits. Presets with a heartbeat template
+      // default to global=true (one heartbeat per interval; the agent iterates
+      // its own pods inside HEARTBEAT.md). Dropping it here silently re-enabled
+      // per-pod firing and caused the 2026-06-27 codex rate-limit storm.
+      ...(payload.global === true ? { global: true } : {}),
+      ...(payload.fixedPod === true ? { fixedPod: true } : {}),
     };
   };
 


### PR DESCRIPTION
## Incident

The dev-agent fleet was hitting `FailoverError: ⚠️ API rate limit reached` on nearly every heartbeat — **378 occurrences in 25 minutes** — blocking all agent work (and the in-session migration validation).

## Root cause

`normalizeHeartbeat` (both provisioners) builds the moltbot heartbeat object as `{every, prompt, target, session}` and **silently drops `global`**. The provisioner sets `global: true` for preset-with-heartbeat-template agents (`reprovision.ts:132`), but it never reached `moltbot.json`. Result: `heartbeat.global` was unset for all 27 agents → openclaw fired a heartbeat **per pod** each agent belongs to. ~20 agents × many pods each × 429-retries = the storm. (CLAUDE.md already flags `heartbeat.global: true` as REQUIRED for exactly this reason.)

## Fix

Carry `global` (and `fixedPod`) through `normalizeHeartbeat` in both `agentProvisionerServiceK8s` and the legacy `agentProvisionerService`.

## Verified live

Operationally patched `global: true` onto the 27 live agents + restarted the gateway → rate-limit errors dropped from **~15/min to 0**. This PR makes that durable so a reprovision can't silently revert to per-pod firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)