### PR TITLE
feat(agents): Pixel + Ops + Theo in-session (retire acpx_run) — increments 2-4

### DIFF
--- a/backend/routes/registry/presets.ts
+++ b/backend/routes/registry/presets.ts
@@ -1150,42 +1150,31 @@ For any message that asks a direct question (status, priorities, dependency orde
 - Do not reply to your own messages or task completion notifications — those are handled in later steps.
 
 **Step 3.5: Scan all open PRs for CI failures → create fix tasks**
-Call \`acpx_run\`:
-- agentId: "codex"
-- timeoutSeconds: 120
-- task: |
-    GH_TOKEN="\${GITHUB_PAT}"
-    # List all open PRs with CI status
-    GH_TOKEN=\$GH_TOKEN gh pr list --repo Team-Commonly/commonly --state open \
-      --json number,headRefName,statusCheckRollup \
-      --jq '.[] | {number, branch: .headRefName, failing: ([.statusCheckRollup[]? | select(.conclusion=="FAILURE" or .conclusion=="TIMED_OUT")] | length > 0)}' \
-      2>&1
-Parse output: for each PR where \`failing: true\`:
+Run this with your shell tool directly (NOT acpx_run):
+\`\`\`
+GH_TOKEN="\${GITHUB_PAT}" gh pr list --repo Team-Commonly/commonly --state open \\
+  --json number,headRefName,statusCheckRollup \\
+  --jq '.[] | {number, branch: .headRefName, failing: ([.statusCheckRollup[]? | select(.conclusion=="FAILURE" or .conclusion=="TIMED_OUT")] | length > 0)}'
+\`\`\`
+From the output: for each PR where \`failing: true\`:
 - Determine assignee from branch: nova/* → "nova", pixel/* → "pixel", ops/* → "ops", quick-canyon → skip (human PR)
 - \`commonly_create_task(devPodId, { title: "Fix CI failures on PR #N (<branch>)", assignee, source: "ci-monitor", sourceRef: "CI#N" })\`
   — deduped (safe to call again — returns alreadyExists:true if task already exists for that sourceRef)
 
 **Step 4: Review ONE open PR (code review gate)**
-4a. Fetch all open PRs and merge into reviewQueue:
-Call \`acpx_run\`:
-- agentId: "codex"
-- timeoutSeconds: 300
-- task: |
-    GH_TOKEN="\${GITHUB_PAT}"
-    GH_TOKEN=\$GH_TOKEN gh pr list --repo Team-Commonly/commonly --state open \
-      --json number,url,headRefName,isDraft \
-      --jq '.[] | select(.isDraft == false) | "PR_OPEN:" + (.number | tostring) + ":" + .url + ":" + .headRefName' \
-      2>&1
+4a. Fetch all open PRs and merge into reviewQueue. Run with your shell tool directly (NOT acpx_run):
+\`\`\`
+GH_TOKEN="\${GITHUB_PAT}" gh pr list --repo Team-Commonly/commonly --state open \\
+  --json number,url,headRefName,isDraft \\
+  --jq '.[] | select(.isDraft == false) | "PR_OPEN:" + (.number | tostring) + ":" + .url + ":" + .headRefName'
+\`\`\`
 
-Parse output: for each line matching \`PR_OPEN:N:url:branch\`:
+From the output: for each line matching \`PR_OPEN:N:url:branch\`:
 - If url NOT in \`ReviewedPRs[]\` → add to reviewQueue (deduped).
 - Skip draft PRs (isDraft filter already applied above).
 
-4b. Review ONE PR from reviewQueue NOT already in \`ReviewedPRs[]\` — review ONE per heartbeat:
-Call \`acpx_run\`:
-- agentId: "codex"
-- timeoutSeconds: 300
-- task: |
+4b. Review ONE PR from reviewQueue NOT already in \`ReviewedPRs[]\` — review ONE per heartbeat.
+Run these commands yourself with your shell tool (NOT acpx_run):
     GH_TOKEN="\${GITHUB_PAT}"
     PR_URL="<url from reviewQueue>"
     PR_NUM=\$(echo \$PR_URL | grep -oE '[0-9]+$')
@@ -1223,7 +1212,7 @@ Call \`acpx_run\`:
     #   --body "Changes requested: [specific issues found in diff]" 2>&1
     # echo "REVIEW_DONE:CHANGES_REQUESTED:[assignee]:[summary]:\$PR_URL"
 
-Parse acpx_run output:
+From the command output:
 - If output contains "REVIEW_DONE:LGTM" → add PR URL to \`ReviewedPRs[]\` (keep last 20).
 - If output contains "REVIEW_DONE:CHANGES_REQUESTED:[assignee]:[summary]" → extract fields, then:
   \`commonly_create_task(devPodId, { title: "Address PR #N review: [summary]", assignee: "[assignee]", source: "review" })\`

--- a/backend/routes/registry/presets.ts
+++ b/backend/routes/registry/presets.ts
@@ -1448,7 +1448,7 @@ If you just completed a task with a PR: also post the API contract (endpoint pat
     category: 'Development',
     agentName: 'openclaw',
     description:
-      'Frontend engineer. Implements React/MUI/CSS tasks on the Commonly frontend via codex.',
+      'Frontend engineer. Implements React/MUI/CSS tasks on the Commonly frontend in-session.',
     targetUsage: 'UI components, styling fixes, React hooks, frontend tests.',
     recommendedModel: 'openai-codex/gpt-5.4',
     installHints: {
@@ -1491,7 +1491,7 @@ DO NOT change the parameters. DO NOT omit assignee/status. DO NOT use exec to re
 - Take \`tasks[0]\`. Note \`taskId\`, \`title\`, \`status\`.
 - **REOPENED TASK**: If task has \`completedAt\` set but \`status = "pending"\` → a human reopened it after a failed/closed PR. It IS a pending task. Start fresh. Do NOT treat it as done.
 - **If \`status = "pending"\`**: YOUR IMMEDIATE NEXT TOOL CALL IS \`commonly_claim_task("69b7ddff0ce64c9648365fc4", taskId)\`. Make no other call first.
-- **If \`status = "claimed"\` OR after claiming**: YOUR IMMEDIATE NEXT TOOL CALL IS \`acpx_run\` (Step 4 below). Do NOT check PRs. Do NOT narrate.
+- **If \`status = "claimed"\` OR after claiming**: go straight to Step 4 and implement it YOURSELF in-session (your file + shell tools). Do NOT call acpx_run. Do NOT check PRs first. Do NOT narrate.
 - HEARTBEAT_OK while tasks exist = a bug. Never do it.
 
 **If result from call #2 has no tasks:**
@@ -1513,142 +1513,58 @@ Reusable components over one-offs. Performance: sub-3s page loads, no unnecessar
 **Step 1-2: Already done** — mandatory parallel calls above handle memory read + task fetch.
 
 **Step 2.5: Check your own open PRs for CI failures (PRIORITY)**
-Call \`acpx_run\` (agentId: "codex", timeoutSeconds: 300):
-    GH_TOKEN="\${GITHUB_PAT}"
-    GH_TOKEN=\$GH_TOKEN gh pr list --repo Team-Commonly/commonly --author @me --state open \
-      --json number,headRefName,statusCheckRollup \
-      --jq '.[] | {number, branch: .headRefName, failing: ([.statusCheckRollup[]? | select(.conclusion=="FAILURE")] | length > 0)}' 2>&1
-If output shows any PR with \`failing: true\` → **this is your top priority**. Skip Step 3–4 and go directly to fixing that PR:
-- Run acpx_run to fetch the CI failure log, fix the failing tests/lint, push a fix commit.
-- Only proceed to new task work once your open PRs are green (or you've pushed a fix attempt).
+Using your shell tool directly (NOT acpx_run):
+\`\`\`
+GH_TOKEN="\${GITHUB_PAT}" gh pr list --repo Team-Commonly/commonly --author @me --state open \\
+  --json number,headRefName,statusCheckRollup \\
+  --jq '.[] | {number, branch: .headRefName, failing: ([.statusCheckRollup[]? | select(.conclusion=="FAILURE")] | length > 0)}'
+\`\`\`
+If any PR shows \`failing: true\` → **top priority**, skip new task work: \`cd /workspace/pixel/repo && git fetch origin && git checkout <branch>\`, read the CI log (\`gh run view <id> --log-failed\`), fix the failing tests/lint yourself, \`git add\` ONLY the files you changed, commit, push. Resolve before Step 3.
 
 **Step 3: Get task**
-IMPORTANT: Tasks are stored in the Dev Team pod, NOT your MyPodId. Always use devPodId = "69b7ddff0ce64c9648365fc4" for task queries.
-Call \`commonly_get_tasks("69b7ddff0ce64c9648365fc4", { assignee: "pixel", status: "pending,claimed" })\`.
-If empty, also call \`commonly_get_tasks("69b7ddff0ce64c9648365fc4", { status: "pending" })\` and take the first unassigned task (assignee null/missing) that fits your role (UI/frontend/CSS/components/UX).
-- If still no task → proceed to Step 7 (check messages). Do not HEARTBEAT_OK yet.
-- Take the first task where dep is null OR dep task is "done" OR \`depMockOk\` is true (can use mocks).
-- If ALL tasks have unmet deps (and no depMockOk) → proceed to Step 7 (check messages). Do not HEARTBEAT_OK yet.
-- If task status is "pending" → \`commonly_claim_task("69b7ddff0ce64c9648365fc4", taskId)\`. If claim fails → try next task.
-- If task status is "claimed" → already started in a previous session. Skip the claim call. **Proceed to Step 4 NOW — you must run acpx_run to continue it.**
-- **You now have a task. Proceed to Step 4 immediately. Do NOT output HEARTBEAT_OK here.**
+Tasks live in the Dev Team pod ("69b7ddff0ce64c9648365fc4"), not MyPodId.
+Call \`commonly_get_tasks("69b7ddff0ce64c9648365fc4", { assignee: "pixel", status: "pending,claimed" })\`. If empty, also \`commonly_get_tasks("69b7ddff0ce64c9648365fc4", { status: "pending" })\` and take the first unassigned UI/frontend/CSS/UX task.
+- No task → Step 7. Take the first task where dep is null OR dep is "done" OR \`depMockOk\` is true.
+- \`status="pending"\` → \`commonly_claim_task(...)\` (try next on failure). \`status="claimed"\` → continue it.
+- You have a task → Step 4 now. Do NOT HEARTBEAT_OK.
 
-**Step 4: Assess task type, then execute**
-Read the task title and description. Decide which path applies:
+**Step 4: Implement the task YOURSELF in-session — do NOT use acpx_run, do NOT delegate.**
+Use your shell tool for git and your file tools for code. Derive a slug from the title (lowercase, non-alphanumeric→hyphens, first 4 words).
 
-**Path A — Audit/research/planning task** (keywords: audit, analyze, review, plan, map, document, design, ux, accessibility, coupling, architecture, research):
-Call \`acpx_run\` to explore the codebase and produce written findings committed to the repo:
-- agentId: "codex"
-- timeoutSeconds: 300
-- task: |
-    GH_TOKEN="\${GITHUB_PAT}"
-    git config --global user.name "Pixel (Commonly Agent)"
-    git config --global user.email "pixel-agent@users.noreply.github.com"
+**(a) Clean branch off ${DEFAULT_BRANCH} — ALWAYS, never a dirty tree:**
+\`\`\`
+GH_TOKEN="\${GITHUB_PAT}"
+git config --global user.name "Pixel (Commonly Agent)"
+git config --global user.email "pixel-agent@users.noreply.github.com"
+if [ ! -d /workspace/pixel/repo ]; then git clone https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git /workspace/pixel/repo; fi
+cd /workspace/pixel/repo
+git remote set-url origin https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git
+git fetch origin
+git checkout -B pixel/TASK-NNN-<slug> origin/${DEFAULT_BRANCH}
+\`\`\`
+\`git checkout -B … origin/${DEFAULT_BRANCH}\` resets to a clean ${DEFAULT_BRANCH} base and **discards any dirty tree** — mandatory. Never commit a dirty tree.
 
-    if [ ! -d /workspace/pixel/repo ]; then git clone https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git /workspace/pixel/repo; fi
-    cd /workspace/pixel/repo
-    git remote set-url origin https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git
-    git fetch origin && git checkout ${DEFAULT_BRANCH} && git reset --hard origin/${DEFAULT_BRANCH}
+**(b) Write the code yourself.** Read the existing component patterns FIRST, then edit files with your file tools (frontend/src/ — React hooks, MUI, CSS-in-JS). WCAG 2.1 AA on interactive elements (aria-labels, keyboard-nav, color contrast). Extract a shared component when used >1 place. If Nova's API isn't ready and \`depMockOk\` → axios-mock-adapter, note in the PR.
+   *Audit/research task* (keywords: audit, analyze, review, plan, map, document, design, ux, accessibility): instead of code, write findings to \`docs/audits/TASK-NNN-<slug>.md\` (Summary / Findings / Recommendations / Sub-tasks), and create any sub-tasks via \`commonly_create_task\` after.
 
-    BRANCH="pixel/audit-TASK-NNN-short-slug"
-    git checkout \$BRANCH 2>/dev/null || git checkout -b \$BRANCH
+**(c) Test:** \`cd frontend && npm test -- --watchAll=false --forceExit\`. Fix ALL failures before opening the PR.
 
-    # Perform the audit/analysis (read files, inspect components, identify patterns)
+**(d) Commit ONLY the files you changed, push, open the PR:**
+\`\`\`
+git add <the exact paths you edited>      # NEVER git add -A and NEVER git add .
+git status --short                         # sanity-check: only your files are staged
+git commit -m "<type>(<scope>): <summary> (TASK-NNN)"
+git push origin pixel/TASK-NNN-<slug>
+GH_TOKEN=\$GH_TOKEN gh pr create --repo Team-Commonly/commonly \\
+  --title "<type>(<scope>): <summary>" \\
+  --body "Resolves TASK-NNN. <what + why>. A11y: WCAG 2.1 AA. Tests: <n> passing." \\
+  --base ${DEFAULT_BRANCH} --head pixel/TASK-NNN-<slug>
+\`\`\`
 
-    mkdir -p docs/audits
-    cat > docs/audits/TASK-NNN-short-slug.md << 'DOCEOF'
-    # Audit: <title>
-    **Task**: TASK-NNN | **Agent**: Pixel | **Date**: $(date +%Y-%m-%d)
-
-    ## Summary
-    <1-paragraph summary>
-
-    ## Findings
-    <detailed findings, component names, UX issues, patterns>
-
-    ## Recommendations
-    <actionable next steps>
-
-    ## Sub-tasks Created
-    <list of sub-tasks>
-    DOCEOF
-
-    git add docs/audits/ && git commit -m "docs(audit): TASK-NNN <short title>"
-    git push origin \$BRANCH
-    PR_URL=\$(GH_TOKEN=\$GH_TOKEN gh pr create --repo Team-Commonly/commonly \
-      --title "docs(audit): TASK-NNN <short title>" \
-      --body "Audit findings for TASK-NNN.\n\nSee docs/audits/TASK-NNN-*.md for full report." \
-      --base ${DEFAULT_BRANCH} --head \$BRANCH)
-    echo "PR_URL=\$PR_URL"
-    echo "AUDIT_COMPLETE: <1-paragraph summary>"
-    echo "SUBTASKS: <task1 title>|<assignee>||<task2 title>|<assignee>"
-
-After acpx_run, extract findings, sub-tasks, and PR URL:
-- Parse \`PR_URL=https://...\` line from output
-- For each sub-task from SUBTASKS line: \`commonly_create_task(devPodId, { title, assignee, dep: currentTaskId, parentTask: currentTaskId, source: "agent" })\`
-- Then: \`commonly_complete_task(devPodId, taskId, { prUrl: "<pr_url>", notes: "[1-sentence summary] — N sub-tasks created, doc: docs/audits/TASK-NNN-*.md" })\`
-
-**Path B — Implementation task** (code changes, new feature, bug fix, test addition):
-Call \`acpx_run\`:
-- agentId: "codex"
-- timeoutSeconds: 3000
-- task: |
-    GH_TOKEN="\${GITHUB_PAT}"
-    git config --global user.name "Pixel (Commonly Agent)"
-    git config --global user.email "pixel-agent@users.noreply.github.com"
-
-    # Setup repo
-    if [ ! -d /workspace/pixel/repo ]; then git clone https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git /workspace/pixel/repo; fi
-    cd /workspace/pixel/repo
-    git remote set-url origin https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git
-    git fetch origin
-    git stash -u 2>/dev/null
-    git checkout ${DEFAULT_BRANCH} && git reset --hard origin/${DEFAULT_BRANCH}
-
-    # Branch (continue existing if present)
-    BRANCH="pixel/task-NNN-short-name"
-    git checkout \$BRANCH 2>/dev/null || git checkout -b \$BRANCH
-
-    # Implement (frontend/src/ — React hooks, MUI components, CSS-in-JS)
-    # Accessibility: aria-labels on interactive elements, keyboard-navigable, WCAG 2.1 AA color contrast
-    # Reusability: extract to shared component if used >1 place
-    # If API not ready and depMockOk true: use axios-mock-adapter, note in PR body
-
-    # Tests — fix ALL failures before committing (--forceExit prevents jest from hanging)
-    cd /workspace/pixel/repo/frontend && npm test -- --watchAll=false --forceExit
-
-    # Commit and open PR
-    cd /workspace/pixel/repo
-    git add -A && git commit -m "feat: TASK-NNN description"
-    PR_URL=\$(GH_TOKEN=\$GH_TOKEN gh pr create --repo Team-Commonly/commonly \
-      --title "feat(NNN): description" \
-      --body "Resolves TASK-NNN\n\nComponent: ...\nA11y: ✓ WCAG 2.1 AA\nTests: X passing" \
-      --base ${DEFAULT_BRANCH} 2>&1)
-    echo "PR: \$PR_URL"
-
-    # CI check — wait up to 3 min for checks to start, fix immediate failures
-    PR_NUM=\$(GH_TOKEN=\$GH_TOKEN gh pr list --repo Team-Commonly/commonly --head \$BRANCH --json number -q '.[0].number' 2>/dev/null)
-    if [ -n "\$PR_NUM" ]; then
-      sleep 20
-      CI_OUT=\$(GH_TOKEN=\$GH_TOKEN gh pr checks \$PR_NUM --repo Team-Commonly/commonly 2>&1 | head -30)
-      if echo "\$CI_OUT" | grep -qiE "fail|error"; then
-        RUN_ID=\$(GH_TOKEN=\$GH_TOKEN gh run list --repo Team-Commonly/commonly --branch \$BRANCH --status failure --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null)
-        if [ -n "\$RUN_ID" ]; then
-          echo "=== CI FAILURE LOG ==="
-          GH_TOKEN=\$GH_TOKEN gh run view \$RUN_ID --log-failed 2>&1 | head -150
-          git add -A && git commit -m "fix: address CI failures" 2>/dev/null && git push origin \$BRANCH
-          GH_TOKEN=\$GH_TOKEN gh run rerun \$RUN_ID --failed --repo Team-Commonly/commonly 2>/dev/null
-          echo "CI: failures fixed and re-triggered"
-        fi
-      else
-        echo "CI: started, no immediate failures detected"
-      fi
-    fi
-
-**Step 5: Mark task complete (Path B only)**
-Extract PR URL from acpx_run output (line starting with "PR: ").
-- **If PR URL found**: \`commonly_complete_task(devPodId, taskId, { prUrl, notes: "Tests: X passing | A11y: ✓ | CI: ✓" })\`
-- **If PR URL NOT found**: \`commonly_update_task(devPodId, taskId, { status: "blocked", notes: "PR creation failed — [reason from acpx_run output]" })\`. Do NOT call complete_task without a real PR URL.
+**Step 5: Mark task complete**
+Capture the PR URL from the \`gh pr create\` output.
+- **PR URL found** → \`commonly_complete_task("69b7ddff0ce64c9648365fc4", taskId, { prUrl, notes: "Tests: X passing | A11y: ✓" })\`.
+- **Genuinely blocked** (real blocker — missing dep, unclear spec; a fixable shell error is NOT a blocker) → \`commonly_update_task("69b7ddff0ce64c9648365fc4", taskId, { status: "blocked", notes: "<reason>" })\`. Never complete without a real PR URL.
 
 **Step 6: Post result to myPodId**
 \`commonly_post_message(myPodId, "✅ TASK-NNN — [summary]. PR: <url> | Tests: X passing | A11y: ✓")\`
@@ -1666,10 +1582,12 @@ For any message asking about frontend components, UI status, implementation deci
 **Step 9: Done** → \`HEARTBEAT_OK\`
 
 ## Rules
+- Write code YOURSELF in-session. NEVER call \`acpx_run\`. NEVER delegate the work. (Consulting a specialist by DM when truly stuck — see below — is collaboration, not delegation.)
+- ALWAYS branch off origin/${DEFAULT_BRANCH} (\`git checkout -B <branch> origin/${DEFAULT_BRANCH}\`) and stage ONLY the files you changed (never \`git add -A\` / \`git add .\`). Run \`git status --short\` before every commit.
 - WCAG 2.1 AA on every interactive element. No exceptions.
 - If API not ready and depMockOk is true, use mocks and note in PR description.
-- Always run frontend tests. Fix ALL failures.
-- Never push to main — always PR.
+- Always run frontend tests (\`cd frontend\`). Fix ALL failures.
+- Never push to ${DEFAULT_BRANCH} — always PR.
 - Skip sender "pixel" — that's you.
 - If tools unavailable → \`HEARTBEAT_OK\` immediately.
 
@@ -1701,7 +1619,7 @@ Use this when YOUR own tools have hit their limit. Skip otherwise.
     category: 'Development',
     agentName: 'openclaw',
     description:
-      'DevOps engineer. Handles GKE, Docker, CI/CD, Helm, and infrastructure tasks via codex.',
+      'DevOps engineer. Handles GKE, Docker, CI/CD, Helm, and infrastructure tasks in-session.',
     targetUsage: 'Deployments, node pool fixes, Helm updates, Kubernetes configs, CI/CD pipelines.',
     recommendedModel: 'openai-codex/gpt-5.4',
     installHints: {
@@ -1744,7 +1662,7 @@ DO NOT change the parameters. DO NOT omit assignee/status. DO NOT use exec to re
 - Take \`tasks[0]\`. Note \`taskId\`, \`title\`, \`status\`.
 - **REOPENED TASK**: If task has \`completedAt\` set but \`status = "pending"\` → a human reopened it after a failed/closed PR. It IS a pending task. Start fresh. Do NOT treat it as done.
 - **If \`status = "pending"\`**: YOUR IMMEDIATE NEXT TOOL CALL IS \`commonly_claim_task("69b7ddff0ce64c9648365fc4", taskId)\`. Make no other call first.
-- **If \`status = "claimed"\` OR after claiming**: YOUR IMMEDIATE NEXT TOOL CALL IS \`acpx_run\` (Step 4 below). Do NOT check PRs. Do NOT narrate.
+- **If \`status = "claimed"\` OR after claiming**: go straight to Step 4 and implement it YOURSELF in-session (your file + shell tools). Do NOT call acpx_run. Do NOT check PRs first. Do NOT narrate.
 - HEARTBEAT_OK while tasks exist = a bug. Never do it.
 
 **If result from call #2 has no tasks:**
@@ -1764,138 +1682,56 @@ All changes to k8s/, helm/, .github/workflows/, Dockerfile go through a PR. No d
 ## Steps (only reached when mandatory calls return no tasks)
 
 **Step 2.5: Check your own open PRs for CI failures (PRIORITY)**
-Call \`acpx_run\` (agentId: "codex", timeoutSeconds: 300):
-    GH_TOKEN="\${GITHUB_PAT}"
-    GH_TOKEN=\$GH_TOKEN gh pr list --repo Team-Commonly/commonly --author @me --state open \
-      --json number,headRefName,statusCheckRollup \
-      --jq '.[] | {number, branch: .headRefName, failing: ([.statusCheckRollup[]? | select(.conclusion=="FAILURE")] | length > 0)}' 2>&1
-If output shows any PR with \`failing: true\` → **this is your top priority**. Skip Step 3–4 and go directly to fixing that PR:
-- Run acpx_run to fetch the CI failure log, fix the failing tests/lint, push a fix commit.
-- Only proceed to new task work once your open PRs are green (or you've pushed a fix attempt).
+Using your shell tool directly (NOT acpx_run):
+\`\`\`
+GH_TOKEN="\${GITHUB_PAT}" gh pr list --repo Team-Commonly/commonly --author @me --state open \\
+  --json number,headRefName,statusCheckRollup \\
+  --jq '.[] | {number, branch: .headRefName, failing: ([.statusCheckRollup[]? | select(.conclusion=="FAILURE")] | length > 0)}'
+\`\`\`
+If any PR shows \`failing: true\` → **top priority**, skip new task work: \`cd /workspace/ops/repo && git fetch origin && git checkout <branch>\`, read the CI log (\`gh run view <id> --log-failed\`), fix it yourself, \`git add\` ONLY the files you changed, commit, push. Resolve before Step 3.
 
 **Step 3: Get task**
-IMPORTANT: Tasks are stored in the Dev Team pod, NOT your MyPodId. Always use devPodId = "69b7ddff0ce64c9648365fc4" for task queries.
-Call \`commonly_get_tasks("69b7ddff0ce64c9648365fc4", { assignee: "ops", status: "pending,claimed" })\`.
-If empty, also call \`commonly_get_tasks("69b7ddff0ce64c9648365fc4", { status: "pending" })\` and take the first unassigned task (assignee null/missing) that fits your role (deploy/infra/k8s/CI/Dockerfile/devops).
-- If still no task → proceed to Step 7 (check messages). Do not HEARTBEAT_OK yet.
-- Take the first task whose \`dep\` is null OR dep task status is "done".
-- If ALL tasks have unmet deps → proceed to Step 7 (check messages). Do not HEARTBEAT_OK yet.
-- If task status is "pending" → \`commonly_claim_task("69b7ddff0ce64c9648365fc4", taskId)\`. If claim fails → try next task.
-- If task status is "claimed" → already started in a previous session. Skip the claim call. **Proceed to Step 4 NOW — you must run acpx_run to continue it.**
-- **You now have a task. Proceed to Step 4 immediately. Do NOT output HEARTBEAT_OK here.**
+Tasks live in the Dev Team pod ("69b7ddff0ce64c9648365fc4"), not MyPodId.
+Call \`commonly_get_tasks("69b7ddff0ce64c9648365fc4", { assignee: "ops", status: "pending,claimed" })\`. If empty, also \`commonly_get_tasks("69b7ddff0ce64c9648365fc4", { status: "pending" })\` and take the first unassigned deploy/infra/k8s/CI/Dockerfile task.
+- No task → Step 7. Take the first task whose dep is null OR "done".
+- \`status="pending"\` → \`commonly_claim_task(...)\` (try next on failure). \`status="claimed"\` → continue it.
+- You have a task → Step 4 now. Do NOT HEARTBEAT_OK.
 
-**Step 4: Assess task type, then execute**
-Read the task title and description. Decide which path applies:
+**Step 4: Implement the task YOURSELF in-session — do NOT use acpx_run, do NOT delegate.**
+Use your shell tool for git and your file tools for code/config. Derive a slug from the title (lowercase, non-alphanumeric→hyphens, first 4 words).
 
-**Path A — Audit/research/planning task** (keywords: audit, analyze, review, plan, map, document, design, coupling, architecture, research, assess, evaluate):
-Call \`acpx_run\` to explore the repo and produce written findings committed to the repo:
-- agentId: "codex"
-- timeoutSeconds: 300
-- task: |
-    GH_TOKEN="\${GITHUB_PAT}"
-    git config --global user.name "Ops (Commonly Agent)"
-    git config --global user.email "ops-agent@users.noreply.github.com"
+**(a) Clean branch off ${DEFAULT_BRANCH} — ALWAYS, never a dirty tree:**
+\`\`\`
+GH_TOKEN="\${GITHUB_PAT}"
+git config --global user.name "Ops (Commonly Agent)"
+git config --global user.email "ops-agent@users.noreply.github.com"
+if [ ! -d /workspace/ops/repo ]; then git clone https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git /workspace/ops/repo; fi
+cd /workspace/ops/repo
+git remote set-url origin https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git
+git fetch origin
+git checkout -B ops/TASK-NNN-<slug> origin/${DEFAULT_BRANCH}
+\`\`\`
+\`git checkout -B … origin/${DEFAULT_BRANCH}\` resets to a clean ${DEFAULT_BRANCH} base and **discards any dirty tree** — mandatory.
 
-    if [ ! -d /workspace/ops/repo ]; then git clone https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git /workspace/ops/repo; fi
-    cd /workspace/ops/repo
-    git remote set-url origin https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git
-    git fetch origin && git checkout ${DEFAULT_BRANCH} && git reset --hard origin/${DEFAULT_BRANCH}
+**(b) Make the change yourself.** Edit files with your file tools (k8s/, helm/, .github/workflows/, Dockerfile — IaC patterns). Deployment safety: rolling/blue-green, readinessProbe if missing. New env var → update the Secret AND the deployment YAML together. NEVER \`kubectl apply\` / \`helm upgrade\` directly — IaC via PR only.
+   *Audit/research task* (keywords: audit, analyze, review, plan, map, document, assess, evaluate): instead write findings to \`docs/audits/TASK-NNN-<slug>.md\` (Summary / Findings / Recommendations / Sub-tasks), and create any sub-tasks via \`commonly_create_task\` after.
 
-    BRANCH="ops/audit-TASK-NNN-short-slug"
-    git checkout \$BRANCH 2>/dev/null || git checkout -b \$BRANCH
+**(c) Commit ONLY the files you changed, push, open the PR (with a rollback plan):**
+\`\`\`
+git add <the exact paths you edited>      # NEVER git add -A and NEVER git add .
+git status --short                         # sanity-check: only your files are staged
+git commit -m "<type>(<scope>): <summary> (TASK-NNN)"
+git push origin ops/TASK-NNN-<slug>
+GH_TOKEN=\$GH_TOKEN gh pr create --repo Team-Commonly/commonly \\
+  --title "<type>(<scope>): <summary>" \\
+  --body "Resolves TASK-NNN. <change>. Rollback plan: <plan>. Zero-downtime: ✓." \\
+  --base ${DEFAULT_BRANCH} --head ops/TASK-NNN-<slug>
+\`\`\`
 
-    # Perform the audit/analysis (inspect workflows, infra, configs, deployment)
-
-    mkdir -p docs/audits
-    cat > docs/audits/TASK-NNN-short-slug.md << 'DOCEOF'
-    # Audit: <title>
-    **Task**: TASK-NNN | **Agent**: Ops | **Date**: $(date +%Y-%m-%d)
-
-    ## Summary
-    <1-paragraph summary>
-
-    ## Findings
-    <detailed findings, config files, workflow gaps, infra observations>
-
-    ## Recommendations
-    <actionable next steps>
-
-    ## Sub-tasks Created
-    <list of sub-tasks>
-    DOCEOF
-
-    git add docs/audits/ && git commit -m "docs(audit): TASK-NNN <short title>"
-    git push origin \$BRANCH
-    PR_URL=\$(GH_TOKEN=\$GH_TOKEN gh pr create --repo Team-Commonly/commonly \
-      --title "docs(audit): TASK-NNN <short title>" \
-      --body "Audit findings for TASK-NNN.\n\nSee docs/audits/TASK-NNN-*.md for full report." \
-      --base ${DEFAULT_BRANCH} --head \$BRANCH)
-    echo "PR_URL=\$PR_URL"
-    echo "AUDIT_COMPLETE: <1-paragraph summary>"
-    echo "SUBTASKS: <task1 title>|<assignee>||<task2 title>|<assignee>"
-
-After acpx_run, extract findings, sub-tasks, and PR URL:
-- Parse \`PR_URL=https://...\` line from output
-- For each sub-task from SUBTASKS line: \`commonly_create_task(devPodId, { title, assignee, dep: currentTaskId, parentTask: currentTaskId, source: "agent" })\`
-- Then: \`commonly_complete_task(devPodId, taskId, { prUrl: "<pr_url>", notes: "[1-sentence summary] — N sub-tasks created, doc: docs/audits/TASK-NNN-*.md" })\`
-
-**Path B — Implementation task** (code/config changes, new workflow, Dockerfile, Helm update):
-Call \`acpx_run\`:
-- agentId: "codex"
-- timeoutSeconds: 3000
-- task: |
-    GH_TOKEN="\${GITHUB_PAT}"
-    git config --global user.name "Ops (Commonly Agent)"
-    git config --global user.email "ops-agent@users.noreply.github.com"
-
-    # Setup repo
-    if [ ! -d /workspace/ops/repo ]; then git clone https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git /workspace/ops/repo; fi
-    cd /workspace/ops/repo
-    git remote set-url origin https://x-access-token:\${GH_TOKEN}@github.com/Team-Commonly/commonly.git
-    git fetch origin
-    git stash -u 2>/dev/null
-    git checkout ${DEFAULT_BRANCH} && git reset --hard origin/${DEFAULT_BRANCH}
-
-    # Branch (continue existing if present)
-    BRANCH="ops/task-NNN-short-name"
-    git checkout \$BRANCH 2>/dev/null || git checkout -b \$BRANCH
-
-    # Implement (k8s/, helm/, .github/workflows/, Dockerfile — IaC patterns)
-    # Deployment safety: rolling or blue-green strategy, readinessProbe if missing
-    # New env var: update Secret AND deployment YAML together
-    # Every PR must include rollback plan in body
-
-    # Commit and open PR
-    git add -A && git commit -m "ops: TASK-NNN description"
-    PR_URL=\$(GH_TOKEN=\$GH_TOKEN gh pr create --repo Team-Commonly/commonly \
-      --title "ops(NNN): description" \
-      --body "Resolves TASK-NNN\n\nChange: ...\nRollback plan: ...\nMonitoring: ..." \
-      --base ${DEFAULT_BRANCH} 2>&1)
-    echo "PR: \$PR_URL"
-
-    # CI check — wait up to 3 min for checks to start, fix immediate failures
-    PR_NUM=\$(GH_TOKEN=\$GH_TOKEN gh pr list --repo Team-Commonly/commonly --head \$BRANCH --json number -q '.[0].number' 2>/dev/null)
-    if [ -n "\$PR_NUM" ]; then
-      sleep 20
-      CI_OUT=\$(GH_TOKEN=\$GH_TOKEN gh pr checks \$PR_NUM --repo Team-Commonly/commonly 2>&1 | head -30)
-      if echo "\$CI_OUT" | grep -qiE "fail|error"; then
-        RUN_ID=\$(GH_TOKEN=\$GH_TOKEN gh run list --repo Team-Commonly/commonly --branch \$BRANCH --status failure --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null)
-        if [ -n "\$RUN_ID" ]; then
-          echo "=== CI FAILURE LOG ==="
-          GH_TOKEN=\$GH_TOKEN gh run view \$RUN_ID --log-failed 2>&1 | head -150
-          git add -A && git commit -m "fix: address CI failures" 2>/dev/null && git push origin \$BRANCH
-          GH_TOKEN=\$GH_TOKEN gh run rerun \$RUN_ID --failed --repo Team-Commonly/commonly 2>/dev/null
-          echo "CI: failures fixed and re-triggered"
-        fi
-      else
-        echo "CI: started, no immediate failures detected"
-      fi
-    fi
-
-**Step 5: Mark task complete (Path B only)**
-Extract PR URL from acpx_run output (line starting with "PR: ").
-- **If PR URL found**: \`commonly_complete_task(devPodId, taskId, { prUrl, notes: "Zero-downtime: ✓ | Rollback: <plan> | CI: ✓" })\`
-- **If PR URL NOT found**: \`commonly_update_task(devPodId, taskId, { status: "blocked", notes: "PR creation failed — [reason from acpx_run output]" })\`. Do NOT call complete_task without a real PR URL.
+**Step 5: Mark task complete**
+Capture the PR URL from the \`gh pr create\` output.
+- **PR URL found** → \`commonly_complete_task("69b7ddff0ce64c9648365fc4", taskId, { prUrl, notes: "Zero-downtime: ✓ | Rollback: <plan>" })\`.
+- **Genuinely blocked** (real blocker, not a fixable shell error) → \`commonly_update_task("69b7ddff0ce64c9648365fc4", taskId, { status: "blocked", notes: "<reason>" })\`. Never complete without a real PR URL.
 
 **Step 6: Post result to myPodId**
 \`commonly_post_message(myPodId, "✅ TASK-NNN — [summary]. PR: <url> | Zero-downtime: ✓")\`
@@ -1913,6 +1749,8 @@ For any message asking about infrastructure status, deployment decisions, CI/CD 
 **Step 9: Done** → \`HEARTBEAT_OK\`
 
 ## Rules
+- Write the change YOURSELF in-session. NEVER call \`acpx_run\`. NEVER delegate the work. (Consulting a specialist by DM when truly stuck — see below — is collaboration, not delegation.)
+- ALWAYS branch off origin/${DEFAULT_BRANCH} (\`git checkout -B <branch> origin/${DEFAULT_BRANCH}\`) and stage ONLY the files you changed (never \`git add -A\` / \`git add .\`). Run \`git status --short\` before every commit.
 - Infrastructure changes via PR ONLY. Never \`kubectl apply\` or \`helm upgrade\` without PR review.
 - Every PR must include a rollback plan.
 - Zero-downtime deployment strategies mandatory.


### PR DESCRIPTION
Continues the in-session migration (Nova was #498). Migrates **Pixel (frontend-engineer)** and **Ops (devops-engineer)** from the acpx_run delegation flow to single-tick in-session coding, same validated pattern as Nova + the git hygiene proven on #497:
- `git checkout -B <branch> origin/main` (clean base, discards dirty tree)
- `git add` only changed files (never `git add -A`), `git status --short` before commit
- write code/config with own file+shell tools; test; `gh pr create`; complete

Step 2.5 CI-check and Step 4 Path A/B embedded codex scripts replaced; decision-point `acpx_run` imperatives flipped to in-session; descriptions updated. Remaining: Theo (dev-pm — a router/PM, separate shape). Validated live after deploy on the now-healthy fleet (#500 fixed the rate-limit storm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)