### PR TITLE
fix(agents): stop emitting heartbeat.global — it crash-loops the gateway

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -411,7 +411,7 @@ browser_evaluate: () => { localStorage.setItem('token', 'eyJ...'); location.relo
 
 These are prescriptive rules not derivable from reading the code:
 
-- **`heartbeat.global: true` is REQUIRED** for all agents. `global=false` fires once *per pod* — with 18–20 pods per agent × 3 community agents = 57+ LLM calls per 30 min → rate-limit cascade.
+- **NEVER set `heartbeat.global` (or `fixedPod`) in `moltbot.json`.** openclaw v2026.3.7's `HeartbeatSchema` is `.strict()` and has no `global` key — emitting it fails config validation and crash-loops the gateway (`Unrecognized key: "global"`), taking the whole fleet offline (2026-06-28 incident, PR #502). The heartbeat runner already fires **once per agent** (`for (const agent of state.agents.values())`); there is no per-pod fan-out to suppress. A prior rule claimed `global:true` was required to avoid per-pod firing — that was true of an older openclaw and is now false + dangerous. `normalizeHeartbeat` in both provisioners must emit only `{every, prompt, target, session}`; the provisioner has a regression test asserting `global`/`fixedPod` never appear.
 
 - **`NO_REPLY` is only silent when it is the entire reply.** Do not append it to normal content — it will be sent verbatim.
 

--- a/backend/__tests__/unit/services/agentProvisionerServiceK8s.test.js
+++ b/backend/__tests__/unit/services/agentProvisionerServiceK8s.test.js
@@ -126,6 +126,33 @@ describe('agentProvisionerServiceK8s', () => {
     expect(config.channels.commonly.accounts.cuz.authProfiles).toEqual(authProfiles);
   });
 
+  it('never emits heartbeat.global/fixedPod (openclaw HeartbeatSchema is strict)', async () => {
+    // Regression for the 2026-06-28 fleet outage: emitting `global` made the
+    // gateway fail openclaw's strict HeartbeatSchema validation and crash-loop
+    // ("Unrecognized key: global"). The provisioner must translate everyMinutes
+    // into `every` and drop global/fixedPod entirely.
+    await provisionAgentRuntime({
+      runtimeType: 'moltbot',
+      agentName: 'openclaw',
+      instanceId: 'cuz',
+      runtimeToken: 'cm_agent_test',
+      userToken: 'cm_user_test',
+      baseUrl: 'http://backend',
+      displayName: 'Cuz',
+      heartbeat: { global: true, fixedPod: true, everyMinutes: 30, prompt: 'hb', session: 'heartbeat' },
+    });
+
+    const calls = k8s.__mock.replaceNamespacedConfigMap.mock.calls;
+    const configMapPayload = calls[calls.length - 1][2];
+    const config = JSON.parse(configMapPayload.data['moltbot.json']);
+    const agent = config.agents.list.find((a) => a.id === 'cuz');
+    expect(agent).toBeTruthy();
+    expect(agent.heartbeat).toBeTruthy();
+    expect(agent.heartbeat.every).toBe('30m');
+    expect(agent.heartbeat).not.toHaveProperty('global');
+    expect(agent.heartbeat).not.toHaveProperty('fixedPod');
+  });
+
   it('stores connected integration channel accounts in gateway config map', async () => {
     await provisionAgentRuntime({
       runtimeType: 'moltbot',

--- a/backend/routes/registry/reprovision.ts
+++ b/backend/routes/registry/reprovision.ts
@@ -127,9 +127,10 @@ const reprovisionInstallation = async ({
   const explicitPresetId = configPayload?.presetId || null;
   const matchedPreset = PRESET_DEFINITIONS.find((p: any) => p.id === (explicitPresetId || normalizedInstanceId));
   const heartbeatForProvision = {
-    // Presets with a heartbeat template default to global=true: the agent iterates
-    // its own pods during the heartbeat rather than firing once per pod.
-    ...(matchedPreset?.heartbeatTemplate ? { global: true, everyMinutes: 30 } : {}),
+    // Presets with a heartbeat template fire on a 30m cadence. (Heartbeats fire
+    // once per agent regardless — do NOT set a `global` flag here: openclaw's
+    // HeartbeatSchema is strict and rejects it, crash-looping the gateway.)
+    ...(matchedPreset?.heartbeatTemplate ? { everyMinutes: 30 } : {}),
     ...(matchedPreset?.defaultHeartbeat || {}),
     ...(configPayload.heartbeat || {}),
     ...(matchedPreset?.heartbeatTemplate ? {

--- a/backend/services/agentProvisionerService.ts
+++ b/backend/services/agentProvisionerService.ts
@@ -1043,10 +1043,10 @@ const provisionOpenClawAccount = async ({
       prompt: payload.prompt || DEFAULT_HEARTBEAT_PROMPT,
       target: payload.target || 'commonly', // Default to Commonly for Commonly-installed agents
       session,
-      // Carry `global` through — dropping it makes openclaw fire a heartbeat
-      // per pod (rate-limit cascade). See agentProvisionerServiceK8s.normalizeHeartbeat.
-      ...(payload.global === true ? { global: true } : {}),
-      ...(payload.fixedPod === true ? { fixedPod: true } : {}),
+      // NOTE: do NOT emit `global`/`fixedPod` here — openclaw's HeartbeatSchema
+      // is `.strict()` with no `global` key, so emitting it crash-loops the
+      // gateway. Heartbeats already fire once per agent. See the K8s provisioner
+      // note and the reverted commit b3f0fb5c.
     };
   };
 

--- a/backend/services/agentProvisionerServiceK8s.ts
+++ b/backend/services/agentProvisionerServiceK8s.ts
@@ -2415,15 +2415,13 @@ const provisionOpenClawAccount = async ({
       prompt: payload.prompt || DEFAULT_HEARTBEAT_PROMPT,
       target: payload.target || 'commonly',
       session,
-      // Carry `global` through. Without it openclaw fires a heartbeat PER POD
-      // the agent belongs to — with ~20 agents in many pods each, that is
-      // hundreds of LLM calls per interval (each retrying on 429), which
-      // cascades into provider rate limits. Presets with a heartbeat template
-      // default to global=true (one heartbeat per interval; the agent iterates
-      // its own pods inside HEARTBEAT.md). Dropping it here silently re-enabled
-      // per-pod firing and caused the 2026-06-27 codex rate-limit storm.
-      ...(payload.global === true ? { global: true } : {}),
-      ...(payload.fixedPod === true ? { fixedPod: true } : {}),
+      // NOTE: do NOT emit `global`/`fixedPod` here. openclaw's HeartbeatSchema
+      // (v2026.3.7) is `.strict()` and has no `global` key — emitting it makes
+      // the gateway fail config validation and crash-loop ("Unrecognized key:
+      // global"). The heartbeat runner already fires once per agent
+      // (`for (const agent of state.agents.values())`), so there is no per-pod
+      // fan-out to suppress; the earlier carry-through (commit b3f0fb5c) was
+      // based on a false premise and took the whole fleet down on 2026-06-28.
     };
   };
 


### PR DESCRIPTION
## Incident
On 2026-06-28 the entire dev-agent fleet went offline: `clawdbot-gateway` crash-looped with `Config invalid … agents.list[*].heartbeat: Unrecognized key: "global"`.

## Root cause
openclaw v2026.3.7's `HeartbeatSchema` is `.strict()` and has **no `global` key**. Commit `b3f0fb5c` ("don't drop heartbeat.global") added a `global`/`fixedPod` carry-through to `normalizeHeartbeat` in both provisioners + `global:true` in `reprovision.ts`, on the premise that dropping `global` made openclaw fire a heartbeat *per pod*.

That premise is false for this openclaw version — the heartbeat runner fires **once per agent** (`for (const agent of state.agents.values())`) and never reads a `global` flag. So the carry-through only wrote an invalid key into `moltbot.json`, failing config validation on boot. Every reprovision re-injected it, deadlocking against the down gateway (provisioner exec → 500).

The actual 2026-06-27 rate-limit storm was the litellm/codex-auth 429 lockout (recovered separately), not per-pod firing.

## Fix
- Remove the `global`/`fixedPod` carry-through from `agentProvisionerServiceK8s.ts` + `agentProvisionerService.ts`.
- Drop `global:true` from `reprovision.ts` (keep `everyMinutes:30` → `every:'30m'`).
- Regression test: provisioner never emits `global`/`fixedPod`.

## Live mitigation already applied
Stripped `global` from the PVC `moltbot.json` + restarted the gateway (now healthy). This PR makes it durable so the next reprovision doesn't reintroduce the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)