### PR TITLE
fix(health): fail readiness fast on PG pool saturation

### DIFF
--- a/backend/__tests__/unit/routes/health.ready.test.js
+++ b/backend/__tests__/unit/routes/health.ready.test.js
@@ -1,0 +1,90 @@
+const request = require('supertest');
+const express = require('express');
+
+const mockMongoose = {
+  connection: {
+    readyState: 1,
+    db: {
+      admin: () => ({
+        ping: jest.fn().mockResolvedValue({ ok: 1 }),
+      }),
+    },
+  },
+};
+
+const mockPool = {
+  options: { max: 50, connectionTimeoutMillis: 5000, idleTimeoutMillis: 10000 },
+  totalCount: 0,
+  idleCount: 0,
+  waitingCount: 0,
+  query: jest.fn().mockResolvedValue({ rows: [{ ok: 1 }] }),
+  on: jest.fn(),
+};
+
+jest.mock('../../../config/db-pg', () => ({
+  pool: mockPool,
+  connectPG: jest.fn(),
+}));
+
+jest.mock('mongoose', () => mockMongoose);
+
+process.env.PG_HOST = process.env.PG_HOST || 'localhost-test';
+
+const healthRoutes = require('../../../routes/health');
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/health', healthRoutes);
+  return app;
+};
+
+describe('GET /api/health/ready', () => {
+  const originalAgentProvisioner = process.env.AGENT_PROVISIONER_K8S;
+
+  beforeEach(() => {
+    mockPool.totalCount = 0;
+    mockPool.idleCount = 0;
+    mockPool.waitingCount = 0;
+    mockPool.query.mockClear();
+    process.env.AGENT_PROVISIONER_K8S = '0';
+  });
+
+  afterAll(() => {
+    process.env.AGENT_PROVISIONER_K8S = originalAgentProvisioner;
+  });
+
+  it('returns 503 immediately when the PG pool is saturated', async () => {
+    mockPool.totalCount = 50;
+    mockPool.idleCount = 0;
+    mockPool.waitingCount = 4;
+
+    const res = await request(buildApp()).get('/api/health/ready').expect(503);
+
+    expect(res.body).toEqual(expect.objectContaining({
+      status: 'not_ready',
+      reason: 'PostgreSQL pool saturated',
+      pg: expect.objectContaining({
+        max: 50,
+        total: 50,
+        idle: 0,
+        waiting: 4,
+        connectionTimeoutMillis: 5000,
+      }),
+    }));
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it('checks PostgreSQL normally when the pool is not saturated', async () => {
+    mockPool.totalCount = 10;
+    mockPool.idleCount = 2;
+    mockPool.waitingCount = 0;
+
+    const res = await request(buildApp()).get('/api/health/ready').expect(200);
+
+    expect(mockPool.query).toHaveBeenCalledWith('SELECT 1');
+    expect(res.body).toEqual(expect.objectContaining({
+      status: 'ready',
+    }));
+  });
+});

--- a/backend/routes/health.ts
+++ b/backend/routes/health.ts
@@ -12,6 +12,37 @@ interface Res {
 
 const router: ReturnType<typeof express.Router> = express.Router();
 
+const getPgPoolSnapshot = (): null | {
+  max: number;
+  total: number;
+  idle: number;
+  waiting: number;
+  connectionTimeoutMillis: number;
+  idleTimeoutMillis: number;
+  saturated: boolean;
+} => {
+  if (!process.env.PG_HOST || !pgPool) return null;
+
+  const p = pgPool as {
+    options?: { max?: number; connectionTimeoutMillis?: number; idleTimeoutMillis?: number };
+    totalCount?: number;
+    idleCount?: number;
+    waitingCount?: number;
+  };
+  const idle = p.idleCount ?? 0;
+  const waiting = p.waitingCount ?? 0;
+
+  return {
+    max: p.options?.max ?? 0,
+    total: p.totalCount ?? 0,
+    idle,
+    waiting,
+    connectionTimeoutMillis: p.options?.connectionTimeoutMillis ?? 0,
+    idleTimeoutMillis: p.options?.idleTimeoutMillis ?? 0,
+    saturated: waiting > 0 && idle === 0,
+  };
+};
+
 router.get('/', async (_req: unknown, res: Res) => {
   const startTime = Date.now();
   const health: Record<string, unknown> = {
@@ -131,34 +162,23 @@ router.get('/db', (_req: unknown, res: Res) => {
     return res.status(200).json(stats);
   }
 
-  const p = pgPool as {
-    options?: { max?: number; connectionTimeoutMillis?: number; idleTimeoutMillis?: number };
-    totalCount?: number;
-    idleCount?: number;
-    waitingCount?: number;
-  };
-  const idle = p.idleCount ?? 0;
-  const waiting = p.waitingCount ?? 0;
-  const total = p.totalCount ?? 0;
-  const max = p.options?.max ?? 0;
-
-  // Saturation signal: waiting callers AND zero idle connections.
-  // waiting > 0 with idle > 0 just means clients ask in bursts faster
-  // than they release — pool will catch up. Both being non-zero is
-  // when actual queueing happens and latency stacks up.
-  const saturated = waiting > 0 && idle === 0;
+  const snapshot = getPgPoolSnapshot();
+  if (!snapshot) {
+    stats.pg = { status: 'not_configured' };
+    return res.status(200).json(stats);
+  }
 
   stats.pg = {
-    status: saturated ? 'saturated' : 'ok',
-    max,
-    total,
-    idle,
-    waiting,
-    connectionTimeoutMillis: p.options?.connectionTimeoutMillis ?? 0,
-    idleTimeoutMillis: p.options?.idleTimeoutMillis ?? 0,
+    status: snapshot.saturated ? 'saturated' : 'ok',
+    max: snapshot.max,
+    total: snapshot.total,
+    idle: snapshot.idle,
+    waiting: snapshot.waiting,
+    connectionTimeoutMillis: snapshot.connectionTimeoutMillis,
+    idleTimeoutMillis: snapshot.idleTimeoutMillis,
   };
 
-  return res.status(saturated ? 503 : 200).json(stats);
+  return res.status(snapshot.saturated ? 503 : 200).json(stats);
 });
 
 router.get('/ready', async (_req: unknown, res: Res) => {
@@ -168,6 +188,20 @@ router.get('/ready', async (_req: unknown, res: Res) => {
     }
 
     if (process.env.PG_HOST && pgPool) {
+      const snapshot = getPgPoolSnapshot();
+      if (snapshot?.saturated) {
+        return res.status(503).json({
+          status: 'not_ready',
+          reason: 'PostgreSQL pool saturated',
+          pg: {
+            max: snapshot.max,
+            total: snapshot.total,
+            idle: snapshot.idle,
+            waiting: snapshot.waiting,
+            connectionTimeoutMillis: snapshot.connectionTimeoutMillis,
+          },
+        });
+      }
       try {
         await (pgPool as { query: (q: string) => Promise<unknown> }).query('SELECT 1');
       } catch {

--- a/backend/routes/health.ts
+++ b/backend/routes/health.ts
@@ -43,6 +43,16 @@ const getPgPoolSnapshot = (): null | {
   };
 };
 
+// Shared PG-pool detail block surfaced by both /db and /ready, so the two
+// probes can't drift in what they report. (Theo review on PR #503.)
+const pgPoolDetail = (s: NonNullable<ReturnType<typeof getPgPoolSnapshot>>) => ({
+  max: s.max,
+  total: s.total,
+  idle: s.idle,
+  waiting: s.waiting,
+  connectionTimeoutMillis: s.connectionTimeoutMillis,
+});
+
 router.get('/', async (_req: unknown, res: Res) => {
   const startTime = Date.now();
   const health: Record<string, unknown> = {
@@ -170,11 +180,7 @@ router.get('/db', (_req: unknown, res: Res) => {
 
   stats.pg = {
     status: snapshot.saturated ? 'saturated' : 'ok',
-    max: snapshot.max,
-    total: snapshot.total,
-    idle: snapshot.idle,
-    waiting: snapshot.waiting,
-    connectionTimeoutMillis: snapshot.connectionTimeoutMillis,
+    ...pgPoolDetail(snapshot),
     idleTimeoutMillis: snapshot.idleTimeoutMillis,
   };
 
@@ -193,13 +199,7 @@ router.get('/ready', async (_req: unknown, res: Res) => {
         return res.status(503).json({
           status: 'not_ready',
           reason: 'PostgreSQL pool saturated',
-          pg: {
-            max: snapshot.max,
-            total: snapshot.total,
-            idle: snapshot.idle,
-            waiting: snapshot.waiting,
-            connectionTimeoutMillis: snapshot.connectionTimeoutMillis,
-          },
+          pg: pgPoolDetail(snapshot),
         });
       }
       try {

--- a/backend/routes/health.ts
+++ b/backend/routes/health.ts
@@ -53,6 +53,25 @@ const pgPoolDetail = (s: NonNullable<ReturnType<typeof getPgPoolSnapshot>>) => (
   connectionTimeoutMillis: s.connectionTimeoutMillis,
 });
 
+const getPgSaturationStatus = (): null | {
+  httpStatus: 200 | 503;
+  body: Record<string, unknown>;
+  saturated: boolean;
+} => {
+  const snapshot = getPgPoolSnapshot();
+  if (!snapshot) return null;
+
+  return {
+    httpStatus: snapshot.saturated ? 503 : 200,
+    body: {
+      status: snapshot.saturated ? 'saturated' : 'ok',
+      ...pgPoolDetail(snapshot),
+      idleTimeoutMillis: snapshot.idleTimeoutMillis,
+    },
+    saturated: snapshot.saturated,
+  };
+};
+
 router.get('/', async (_req: unknown, res: Res) => {
   const startTime = Date.now();
   const health: Record<string, unknown> = {
@@ -172,19 +191,15 @@ router.get('/db', (_req: unknown, res: Res) => {
     return res.status(200).json(stats);
   }
 
-  const snapshot = getPgPoolSnapshot();
-  if (!snapshot) {
+  const pgStatus = getPgSaturationStatus();
+  if (!pgStatus) {
     stats.pg = { status: 'not_configured' };
     return res.status(200).json(stats);
   }
 
-  stats.pg = {
-    status: snapshot.saturated ? 'saturated' : 'ok',
-    ...pgPoolDetail(snapshot),
-    idleTimeoutMillis: snapshot.idleTimeoutMillis,
-  };
+  stats.pg = pgStatus.body;
 
-  return res.status(snapshot.saturated ? 503 : 200).json(stats);
+  return res.status(pgStatus.httpStatus).json(stats);
 });
 
 router.get('/ready', async (_req: unknown, res: Res) => {
@@ -194,12 +209,12 @@ router.get('/ready', async (_req: unknown, res: Res) => {
     }
 
     if (process.env.PG_HOST && pgPool) {
-      const snapshot = getPgPoolSnapshot();
-      if (snapshot?.saturated) {
+      const pgStatus = getPgSaturationStatus();
+      if (pgStatus?.saturated) {
         return res.status(503).json({
           status: 'not_ready',
           reason: 'PostgreSQL pool saturated',
-          pg: pgPoolDetail(snapshot),
+          pg: pgStatus.body,
         });
       }
       try {


### PR DESCRIPTION
## What changed
- fail  immediately when the PostgreSQL pool is already saturated instead of waiting on a timed-out 
- reuse a shared pool snapshot helper between  and 
- add regression coverage for the new readiness behavior

## Why
GH#454 is already fixed on  by PR #455 plus the later summarizer/db-health follow-up. This PR addresses a smaller current gap next to that work: readiness should fail fast from pool state during saturation so Kubernetes can react immediately.

## Test
- 
- 
[41m                                                                               [0m
[41m[37m                This is not the tsc command you are looking for                [0m
[41m                                                                               [0m

To get access to the TypeScript compiler, [34mtsc[0m, from the command line either:

- Use [1mnpm install typescript[0m to first add TypeScript to your project [1mbefore[0m using npx
- Use [1myarn[0m to avoid accidentally running code from un-installed packages
