### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "server.js",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "frontend",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "private": true,
     "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commonly",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "start": "docker-compose up",


### PR DESCRIPTION
Version bump 1.0.0 → 1.1.0 ahead of cutting the **v1.1.0** GitHub release (first since the v1.0.0 OSS launch on 2026-04-07).

Headline: the **v2 UI** is now the default. Full changelog goes in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)