### PR TITLE
fix(backend): serialize mongodb-memory-server startup

### DIFF
--- a/backend/__tests__/utils/testUtils.js
+++ b/backend/__tests__/utils/testUtils.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const mongoose = require('mongoose');
 const { MongoMemoryServer } = require('mongodb-memory-server');
+const { Mutex } = require('async-mutex');
 const { newDb } = require('pg-mem');
 const jwt = require('jsonwebtoken');
 
@@ -9,6 +10,7 @@ const useRealServices = () => process.env.INTEGRATION_TEST === 'true';
 
 // MongoDB setup — Tier 1 (real services) or Tier 0 (in-memory)
 let mongoServer;
+const mongoCreateMutex = new Mutex();
 
 const setupMongoDb = async () => {
   try {
@@ -24,14 +26,18 @@ const setupMongoDb = async () => {
       return;
     }
 
-    mongoServer = await MongoMemoryServer.create({
-      binary: {
-        version: '7.0.11',
-        skipMD5: true,
-      },
-      instance: {
-        dbName: 'jest-test-db',
-      },
+    await mongoCreateMutex.runExclusive(async () => {
+      if (!mongoServer) {
+        mongoServer = await MongoMemoryServer.create({
+          binary: {
+            version: '7.0.11',
+            skipMD5: true,
+          },
+          instance: {
+            dbName: 'jest-test-db',
+          },
+        });
+      }
     });
 
     await mongoose.connect(mongoServer.getUri());

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@google-cloud/secret-manager": "^6.1.1",
         "@google/generative-ai": "^0.2.1",
@@ -49,6 +49,7 @@
         "@types/node": "^22.10.2",
         "@types/pg": "^8.11.10",
         "@types/socket.io": "^3.0.2",
+        "async-mutex": "^0.5.0",
         "eslint": "^8.56.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.29.1",
@@ -2857,10 +2858,11 @@
       }
     },
     "node_modules/async-mutex": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
-      "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -7962,6 +7964,16 @@
       "dependencies": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/async-mutex": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
+      "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/mongodb-memory-server-core/node_modules/camelcase": {
@@ -13720,9 +13732,9 @@
       "dev": true
     },
     "async-mutex": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
-      "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
       "dev": true,
       "requires": {
         "tslib": "^2.4.0"
@@ -17297,6 +17309,15 @@
           "requires": {
             "@types/node": "*",
             "@types/webidl-conversions": "*"
+          }
+        },
+        "async-mutex": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
+          "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.4.0"
           }
         },
         "camelcase": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -63,6 +63,7 @@
     "@types/node": "^22.10.2",
     "@types/pg": "^8.11.10",
     "@types/socket.io": "^3.0.2",
+    "async-mutex": "^0.5.0",
     "eslint": "^8.56.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.29.1",


### PR DESCRIPTION
Resolves TASK-080. Serializes in-memory MongoDB startup in backend test utilities so concurrent suite setup cannot race MongoMemoryServer.create. Adds async-mutex to backend devDependencies. Rollback plan: revert the test utility guard and package dependency if follow-up validation shows no longer needed. Zero-downtime: ✓.