### PR TITLE
fix(memory): normalize agent identity casing at HTTP memory boundary

### DIFF
--- a/backend/__tests__/service/agent-memory-identity-casing.test.js
+++ b/backend/__tests__/service/agent-memory-identity-casing.test.js
@@ -1,0 +1,165 @@
+/**
+ * ADR-003 convergence regression — agent-memory identity-casing split.
+ *
+ * The bug: `resolveMemoryIdentity` (routes/agentsRuntime.ts) keys the
+ * AgentMemory document for every GET/PUT/sync over the HTTP memory boundary.
+ * It used to return agentName WITHOUT normalization, while EVERY platform-side
+ * writer/reader lowercases agentName:
+ *   - systemExchangeTriggers.ts  -> String(agentName).toLowerCase()
+ *   - agentEventService.ts       -> agentName.toLowerCase()
+ *   - nativeRuntimeService.ts    -> String(installation.agentName || '').toLowerCase()
+ *   - agentMemoryService.appendSystemExchange keys { agentName, instanceId } verbatim.
+ *
+ * The split only surfaces in the identity-continuity case: the bot's
+ * AgentInstallation rows are gone (uninstalled / removed) but the User row +
+ * its runtime token survive (ADR-001 identity-continuity invariant). With no
+ * installation, resolveMemoryIdentity falls through the chain to
+ * `botMetadata.agentName` / `username`, which can be mixed-case. A mixed-case
+ * key on the agent's GET/PUT diverges from the platform's lowercased key —
+ * silent read-after-write split: the agent reads a DIFFERENT doc than the
+ * platform writes.
+ *
+ * This test reproduces exactly that case (mixed-case bot, NO active
+ * AgentInstallation) and asserts the agent's PUT and the platform's
+ * system_exchange write converge on ONE AgentMemory document.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+const { setupMongoDb, closeMongoDb, clearMongoDb } = require('../utils/testUtils');
+
+const User = require('../../models/User');
+const AgentMemory = require('../../models/AgentMemory');
+const { AgentInstallation } = require('../../models/AgentRegistry');
+const { appendSystemExchange } = require('../../services/agentMemoryService');
+
+// eslint-disable-next-line global-require
+const { hash } = require('../../utils/secret');
+
+const agentsRuntimeRoutes = require('../../routes/agentsRuntime');
+
+jest.setTimeout(60000);
+
+// Mixed-case identity — the username is what resolveMemoryIdentity falls back
+// to when there's no installation, and the casing is the whole point.
+const MIXED_AGENT_NAME = 'MixedCase-Agent';
+const RAW_TOKEN = 'cm_agent_mixedcase_identity_regression_token';
+
+describe('AgentMemory — identity-casing convergence (no installation)', () => {
+  let app;
+
+  beforeAll(async () => {
+    await setupMongoDb();
+    app = express();
+    app.use(express.json());
+    app.use('/api/agents/runtime', agentsRuntimeRoutes);
+  });
+
+  afterAll(async () => {
+    await closeMongoDb();
+  });
+
+  beforeEach(async () => {
+    await clearMongoDb();
+  });
+
+  // Create a bot User with a mixed-case identity + a runtime token minted
+  // directly on the User row (the bot-user-token auth path), and crucially NO
+  // AgentInstallation — the identity-continuity case the bug lives in.
+  async function seedMixedCaseBotWithoutInstallation() {
+    const botUser = await User.create({
+      username: MIXED_AGENT_NAME,
+      email: 'mixedcase-agent@agents.commonly.local',
+      password: 'agent-password',
+      verified: true,
+      isBot: true,
+      botType: 'agent',
+      botMetadata: {
+        displayName: 'Mixed Case Agent',
+        agentName: MIXED_AGENT_NAME,
+        instanceId: 'default',
+      },
+      agentRuntimeTokens: [
+        { tokenHash: hash(RAW_TOKEN), label: 'casing-regression', createdAt: new Date() },
+      ],
+    });
+    // Belt-and-suspenders: assert the precondition this whole test relies on.
+    const installCount = await AgentInstallation.countDocuments({
+      agentName: MIXED_AGENT_NAME.toLowerCase(),
+    });
+    expect(installCount).toBe(0);
+    return botUser;
+  }
+
+  it('agent PUT and platform system_exchange write converge on ONE doc (lowercased key)', async () => {
+    await seedMixedCaseBotWithoutInstallation();
+
+    // 1) The agent writes its own memory over the HTTP boundary. With the fix,
+    //    resolveMemoryIdentity lowercases the username-derived agentName.
+    const put = await request(app)
+      .put('/api/agents/runtime/memory')
+      .set('Authorization', `Bearer ${RAW_TOKEN}`)
+      .send({ content: '# MEMORY.md\nproject brain notes' });
+    expect(put.status).toBe(200);
+    expect(put.body.ok).toBe(true);
+
+    // 2) The platform writes a system_exchange. This mirrors EXACTLY how the
+    //    platform writers key the doc (systemExchangeTriggers.resolveAgentMembers):
+    //    agentName lowercased, instanceId from botMetadata (default 'default').
+    const platformAgentName = String(MIXED_AGENT_NAME).toLowerCase();
+    const platformInstanceId = 'default';
+    const appendResult = await appendSystemExchange({
+      agentName: platformAgentName,
+      instanceId: platformInstanceId,
+      kind: 'task-completed',
+      surfacePodId: '507f1f77bcf86cd799439011',
+      surfaceLabel: 'pod:demo',
+      peers: [],
+      takeaway: 'shipped the casing fix',
+    });
+    expect(appendResult).not.toBeNull();
+
+    // 3) Exactly ONE AgentMemory document exists for this identity — the agent's
+    //    PUT and the platform's append did NOT split into two casing variants.
+    const allDocs = await AgentMemory.find({}).lean();
+    expect(allDocs).toHaveLength(1);
+    expect(allDocs[0].agentName).toBe(platformAgentName);
+    expect(allDocs[0].instanceId).toBe(platformInstanceId);
+
+    // The single doc holds BOTH the agent's content and the platform's entry.
+    expect(allDocs[0].content).toBe('# MEMORY.md\nproject brain notes');
+    expect(allDocs[0].sections.system_exchanges.entries).toHaveLength(1);
+    expect(allDocs[0].sections.system_exchanges.entries[0].takeaway)
+      .toContain('casing fix');
+
+    // No mixed-case ghost doc exists.
+    const ghost = await AgentMemory.findOne({ agentName: MIXED_AGENT_NAME }).lean();
+    expect(ghost).toBeNull();
+  });
+
+  it('agent GET reads back the platform-written system_exchange (read-after-write across the boundary)', async () => {
+    await seedMixedCaseBotWithoutInstallation();
+
+    // Platform writes first, keyed the platform way (lowercased agentName).
+    await appendSystemExchange({
+      agentName: String(MIXED_AGENT_NAME).toLowerCase(),
+      instanceId: 'default',
+      kind: 'agent-dm-conclusion',
+      surfacePodId: '507f1f77bcf86cd799439011',
+      surfaceLabel: 'agent-dm:demo',
+      peers: ['peer'],
+      takeaway: 'concluded the dm',
+    });
+
+    // The agent reads its memory over the HTTP boundary and sees the platform's
+    // write — proving both sides resolved the SAME envelope.
+    const get = await request(app)
+      .get('/api/agents/runtime/memory')
+      .set('Authorization', `Bearer ${RAW_TOKEN}`);
+    expect(get.status).toBe(200);
+    expect(get.body.sections.system_exchanges.entries).toHaveLength(1);
+    expect(get.body.sections.system_exchanges.entries[0].takeaway)
+      .toContain('concluded the dm');
+  });
+});

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -1666,16 +1666,39 @@ export interface CyclesAppendPayload {
   podId?: string;
 }
 
+// ADR-003 convergence: the (agentName, instanceId) tuple this returns is the
+// AgentMemory document key for every GET/PUT/sync over the HTTP memory boundary.
+// It MUST match what platform-side writers/readers key on, or an agent reads a
+// DIFFERENT doc than the platform writes (silent read-after-write split).
+//
+// Every platform writer normalizes agentName to lowercase and leaves instanceId
+// as a plain string defaulting to 'default':
+//   - systemExchangeTriggers.ts (resolveAgentMembers): `String(agentName).toLowerCase()`
+//   - agentEventService.ts (prependMemoryCue / list): `agentName.toLowerCase()` + `String(instanceId || 'default')`
+//   - nativeRuntimeService.ts: `String(installation.agentName || '').toLowerCase()` + `String(installation.instanceId || 'default')`
+//   - agentMemoryService.appendSystemExchange keys `{ agentName, instanceId }` verbatim.
+//
+// The bug this guards against: when `req.agentInstallation` is null (identity-
+// continuity case — installations removed but the bot User row survives) the
+// chain falls through to `username`, which can be mixed-case. Without the
+// lowercase here, the agent's own GET/PUT keys a different doc than the platform.
+// Instance IDs are intentionally NOT lowercased — platform writers keep them raw
+// (e.g. read straight off `botMetadata.instanceId`), so lowercasing here would
+// itself introduce a mismatch. Preserve the fallback chain; only add normalization.
 function resolveMemoryIdentity(req: any): { agentName?: string; instanceId: string } {
   const agentInstallation = req.agentInstallation;
-  const agentName =
+  const rawAgentName =
     agentInstallation?.agentName ||
     req.agentUser?.botMetadata?.agentName ||
     req.agentUser?.username;
-  const instanceId =
+  const rawInstanceId =
     agentInstallation?.instanceId ||
     req.agentUser?.botMetadata?.instanceId ||
     'default';
+  const agentName = rawAgentName
+    ? String(rawAgentName).trim().toLowerCase()
+    : undefined;
+  const instanceId = String(rawInstanceId || 'default').trim() || 'default';
   return { agentName, instanceId };
 }
 

--- a/backend/services/systemExchangeTriggers.ts
+++ b/backend/services/systemExchangeTriggers.ts
@@ -222,7 +222,7 @@ export async function recordAgentDmConclusion(args: RecordAgentDmConclusionArgs)
     // Speaker gets the verbatim takeaway; listener(s) get a `@peer:`-prefixed
     // version so the entry reads as "what the other side said" — eliminates
     // the "why does my memory say I shipped X when I didn't?" failure mode.
-    const writes = agents.map((a) => {
+    const writes = agents.map(async (a) => {
       const isSpeaker = a.agentName === senderName && a.instanceId === senderInst;
       const peers = agents
         .filter((p) => !(p.agentName === a.agentName && p.instanceId === a.instanceId))
@@ -231,7 +231,7 @@ export async function recordAgentDmConclusion(args: RecordAgentDmConclusionArgs)
       const takeaway = isSpeaker
         ? speakerTakeaway
         : truncateTakeaway(`@${speakerLabel}: ${speakerTakeaway}`);
-      return appendSystemExchange({
+      const result = await appendSystemExchange({
         agentName: a.agentName,
         instanceId: a.instanceId,
         kind: 'agent-dm-conclusion',
@@ -241,10 +241,23 @@ export async function recordAgentDmConclusion(args: RecordAgentDmConclusionArgs)
         takeaway,
         ts,
       });
+      // appendSystemExchange returns null (it does NOT throw) on a rejected
+      // input (missing identity, unknown kind, bad surfacePodId). A null here
+      // is a silently-dropped memory write — make it visible.
+      if (result === null) {
+        console.error(
+          '[system-exchange] append dropped (appendSystemExchange returned null) '
+          + `kind=agent-dm-conclusion agentName=${a.agentName} instanceId=${a.instanceId} podId=${String(podId)}`,
+        );
+      }
     });
     await Promise.all(writes);
   } catch (err) {
-    console.warn('[system-exchange] recordAgentDmConclusion failed:', (err as Error).message);
+    console.error(
+      '[system-exchange] append dropped: recordAgentDmConclusion threw '
+      + `kind=agent-dm-conclusion agentName=${String(senderAgentName || '').toLowerCase()} `
+      + `instanceId=${String(senderInstanceId || 'default')} podId=${String(podId)}: ${(err as Error).message}`,
+    );
   }
 }
 
@@ -269,11 +282,11 @@ export async function recordAgentDmLoopTrip(args: RecordAgentDmLoopTripArgs): Pr
     const surfaceLabel = surfaceLabelFor(podType, podName, podId);
     const takeaway = '8 consecutive bot turns within 30 min — guard tripped';
 
-    const writes = agents.map((a) => {
+    const writes = agents.map(async (a) => {
       const peers = agents
         .filter((p) => !(p.agentName === a.agentName && p.instanceId === a.instanceId))
         .map((p) => p.instanceId);
-      return appendSystemExchange({
+      const result = await appendSystemExchange({
         agentName: a.agentName,
         instanceId: a.instanceId,
         kind: 'agent-dm-loop-trip',
@@ -283,10 +296,19 @@ export async function recordAgentDmLoopTrip(args: RecordAgentDmLoopTripArgs): Pr
         takeaway,
         ts,
       });
+      if (result === null) {
+        console.error(
+          '[system-exchange] append dropped (appendSystemExchange returned null) '
+          + `kind=agent-dm-loop-trip agentName=${a.agentName} instanceId=${a.instanceId} podId=${String(podId)}`,
+        );
+      }
     });
     await Promise.all(writes);
   } catch (err) {
-    console.warn('[system-exchange] recordAgentDmLoopTrip failed:', (err as Error).message);
+    console.error(
+      '[system-exchange] append dropped: recordAgentDmLoopTrip threw '
+      + `kind=agent-dm-loop-trip podId=${String(podId)}: ${(err as Error).message}`,
+    );
   }
 }
 
@@ -366,7 +388,7 @@ export async function recordTaskCompleted(args: RecordTaskCompletedArgs): Promis
       : '';
     const takeaway = truncateTakeaway(`${titlePart}${tailPart}`);
 
-    await appendSystemExchange({
+    const result = await appendSystemExchange({
       agentName: assigneeLower,
       instanceId,
       kind: 'task-completed',
@@ -376,7 +398,16 @@ export async function recordTaskCompleted(args: RecordTaskCompletedArgs): Promis
       takeaway,
       ts,
     });
+    if (result === null) {
+      console.error(
+        '[system-exchange] append dropped (appendSystemExchange returned null) '
+        + `kind=task-completed agentName=${assigneeLower} instanceId=${instanceId} podId=${String(podId)}`,
+      );
+    }
   } catch (err) {
-    console.warn('[system-exchange] recordTaskCompleted failed:', (err as Error).message);
+    console.error(
+      '[system-exchange] append dropped: recordTaskCompleted threw '
+      + `kind=task-completed agentName=${String(assignee || '').toLowerCase()} podId=${String(podId)}: ${(err as Error).message}`,
+    );
   }
 }

--- a/packages/commonly-mcp/README.md
+++ b/packages/commonly-mcp/README.md
@@ -1,5 +1,8 @@
 # @commonly/mcp-server
 
+> 🚫 **ABANDONED — do not use or publish.** Marked `"private": true` so it can never be
+> published by mistake. The shipping package is **`@commonlyai/mcp`** (repo root `commonly-mcp/`).
+
 > ⚠️ **NOT the published package.** The MCP server that actually ships — installed by the
 > cluster (cloud-codex), `npx @commonlyai/mcp`, and every external dev tool — is
 > **`@commonlyai/mcp`** (repo root `commonly-mcp/`), currently v0.1.2.

--- a/packages/commonly-mcp/package.json
+++ b/packages/commonly-mcp/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@commonly/mcp-server",
+  "private": true,
   "version": "0.1.0",
   "description": "MCP server for Commonly context hub - connect any AI agent to team knowledge",
   "main": "dist/index.js",


### PR DESCRIPTION
Fixes the ADR-003 read-after-write convergence bug (the product wedge).

**Bug:** `resolveMemoryIdentity` (agentsRuntime.ts) returned `agentName` un-normalized, while every platform writer (systemExchangeTriggers, agentEventService, nativeRuntimeService) lowercases it. In the identity-continuity case (installation removed but bot User row survives → fallback to mixed-case `username`), the agent's own GET/PUT/sync keyed a *different* AgentMemory doc than the platform wrote → silent split, memory looks empty/incoherent. Observed live: newest write had empty `content`.

**Fix:** lowercase the resolved `agentName` (instanceId intentionally left raw to match platform writers — documented inline). Fallback chain preserved.

Also: route-level regression test (mixed-case bot, no installation → asserts single converged doc); `private:true` + ABANDONED banner on `packages/commonly-mcp` (the dead @commonly/mcp-server; shipping pkg is @commonlyai/mcp); upgraded swallowed system_exchange append failures to `console.error` so silent memory-write drops are visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)