### PR TITLE
fix(auth): harden registration path (SMTP lockout, dead helper, v2 paths, waitlist field)

### DIFF
--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -126,7 +126,16 @@ exports.register = async (req: any, res: any) => {
     const hasEmailConfig = Boolean(process.env.SMTP2GO_API_KEY)
       && Boolean(process.env.SMTP2GO_FROM_EMAIL)
       && Boolean(process.env.FRONTEND_URL);
-    const shouldAutoVerify = !hasEmailConfig && process.env.NODE_ENV !== 'production';
+    // When email is not configured there is no way to deliver a verification
+    // link, so auto-verify regardless of NODE_ENV — otherwise a prod deploy
+    // without SMTP would create verified=false accounts that login() permanently
+    // blocks (no email ever arrives to unblock them).
+    const shouldAutoVerify = !hasEmailConfig;
+    if (shouldAutoVerify) {
+      console.warn(
+        'Auto-verifying new account because email delivery is not configured (SMTP2GO_API_KEY/SMTP2GO_FROM_EMAIL/FRONTEND_URL missing).',
+      );
+    }
 
     // Create new user instance
     const user = new User({
@@ -179,7 +188,7 @@ exports.register = async (req: any, res: any) => {
       .json({
         message: hasEmailConfig
           ? 'User registered successfully. Check your email for verification.'
-          : 'User registered successfully. Email verification skipped in development.',
+          : 'User registered successfully. Email verification is not required.',
       });
   } catch (err: any) {
     console.error(err.message);

--- a/backend/routes/admin/users.ts
+++ b/backend/routes/admin/users.ts
@@ -446,7 +446,7 @@ router.post('/waitlist/:requestId/send-invitation', auth, adminAuth, async (req:
     }
 
     const frontendUrl = getPrimaryFrontendUrl();
-    const registerUrl = `${frontendUrl.replace(/\/$/, '')}/register?invite=${encodeURIComponent(invitation.code)}`;
+    const registerUrl = `${frontendUrl.replace(/\/$/, '')}/v2/register?invite=${encodeURIComponent(invitation.code)}`;
     const recipientName = waitlistRequest.name || 'there';
     const subject = 'Your Commonly invitation code';
     const textBody = [

--- a/frontend/src/components/RegistrationInviteRequired.tsx
+++ b/frontend/src/components/RegistrationInviteRequired.tsx
@@ -27,7 +27,7 @@ const RegistrationInviteRequired: React.FC = () => {
     e.preventDefault();
     const trimmed = invitationCode.trim();
     if (!trimmed) return;
-    navigate(`/register?invite=${encodeURIComponent(trimmed)}`);
+    navigate(`/v2/register?invite=${encodeURIComponent(trimmed)}`);
   };
 
   const onWaitlistSubmit = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
@@ -39,7 +39,7 @@ const RegistrationInviteRequired: React.FC = () => {
       const res = await axios.post<{ message?: string }>('/api/auth/waitlist', {
         email: waitlistEmail,
         name: waitlistName,
-        note: waitlistNote,
+        useCase: waitlistNote,
       });
       setWaitlistSuccess(res.data?.message || 'Waitlist request submitted.');
       setWaitlistName('');
@@ -165,7 +165,7 @@ const RegistrationInviteRequired: React.FC = () => {
           </Box>
           <Typography variant="body2" sx={{ mt: 2.5, color: 'rgba(226, 232, 240, 0.85)' }}>
             Already have an account?{' '}
-            <Link to="/login" style={{ color: '#93c5fd' }}>Login here</Link>
+            <Link to="/v2/login" style={{ color: '#93c5fd' }}>Login here</Link>
           </Typography>
         </Paper>
       </Container>

--- a/frontend/src/context/AuthContext.test.tsx
+++ b/frontend/src/context/AuthContext.test.tsx
@@ -42,13 +42,17 @@ afterEach(() => {
   delete global.testAuth;
 });
 
-test('register stores token and user', async () => {
-  axios.post.mockResolvedValue({ data: { token: 'abc', user: { name: 'Bob' } } });
+test('register does not store a token and returns the response message', async () => {
+  const message = 'User registered successfully. Check your email for verification.';
+  axios.post.mockResolvedValue({ data: { message } });
+  let result;
   await act(async () => {
-    await global.testAuth.register({});
+    result = await global.testAuth.register({});
   });
-  expect(localStorage.getItem('token')).toBe('abc');
-  expect(global.testAuth.currentUser).toEqual({ name: 'Bob' });
+  // Registration returns no session — the user must sign in afterward.
+  expect(localStorage.getItem('token')).toBeNull();
+  expect(global.testAuth.currentUser).toBeNull();
+  expect(result).toEqual({ message });
   expect(axios.post).toHaveBeenCalledWith('/api/auth/register', {});
 });
 

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -104,15 +104,16 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const register = async (formData: unknown): Promise<unknown> => {
     try {
       setLoading(true);
-      const res = await axios.post<{ token: string; user: User }>('/api/auth/register', formData);
-      localStorage.setItem('token', res.data.token);
-      setToken(res.data.token);
-      setCurrentUser(res.data.user);
+      // Registration does NOT return a session token — the backend either sends
+      // a verification email or auto-verifies, then expects the user to sign in.
+      // Return the response data (e.g. { message }) so callers can route to
+      // /v2/login.
+      const res = await axios.post<{ message?: string }>('/api/auth/register', formData);
       setError(null);
       return res.data;
     } catch (err: unknown) {
-      const e = err as { response?: { data?: { msg?: string } } };
-      setError(e.response?.data?.msg || 'Registration failed');
+      const e = err as { response?: { data?: { error?: string; msg?: string } } };
+      setError(e.response?.data?.error || e.response?.data?.msg || 'Registration failed');
       throw err;
     } finally {
       setLoading(false);

--- a/frontend/src/v2/components/V2Register.tsx
+++ b/frontend/src/v2/components/V2Register.tsx
@@ -33,6 +33,7 @@ const V2Register: React.FC = () => {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState<string | null>(null);
+  const [verifyPending, setVerifyPending] = useState(false);
   const [policy, setPolicy] = useState<RegistrationPolicy>({ loaded: false, inviteOnly: false });
 
   useEffect(() => {
@@ -61,7 +62,15 @@ const V2Register: React.FC = () => {
         invitationCode: invitationCode.trim(),
       });
       const data = res.data as { message?: string };
-      setDone(data?.message || 'Your account is ready. Sign in to continue.');
+      const message = data?.message || 'Your account is ready. Sign in to continue.';
+      // The backend only sends a verification email (and withholds a usable
+      // session) when SMTP is configured — its message says to check email in
+      // that case. When auto-verified, no email is sent and sign-in works
+      // immediately. Branch the success screen on that signal so we never tell
+      // a still-unverified user to "Continue to sign in" (which yields
+      // "Email not verified" at login).
+      setVerifyPending(message.toLowerCase().includes('check your email'));
+      setDone(message);
     } catch (err) {
       const e1 = err as { response?: { data?: { error?: string; msg?: string } } };
       setError(e1.response?.data?.error || e1.response?.data?.msg || 'Registration failed.');
@@ -75,15 +84,25 @@ const V2Register: React.FC = () => {
       <div className="v2-login">
         <div className="v2-login__card">
           <Brand />
-          <h1 className="v2-login__title">Account created</h1>
+          <h1 className="v2-login__title">
+            {verifyPending ? 'Check your email' : 'Account created'}
+          </h1>
           <p className="v2-login__subtitle">{done}</p>
-          <button
-            type="button"
-            className="v2-login__submit"
-            onClick={() => navigate('/v2/login')}
-          >
-            Continue to sign in
-          </button>
+          {verifyPending ? (
+            <p className="v2-login__hint">
+              We sent a verification link to your email. Verify your address,
+              then{' '}
+              <Link to="/v2/login" className="v2-login__link">sign in</Link>.
+            </p>
+          ) : (
+            <button
+              type="button"
+              className="v2-login__submit"
+              onClick={() => navigate('/v2/login')}
+            >
+              Continue to sign in
+            </button>
+          )}
         </div>
       </div>
     );


### PR DESCRIPTION
Five fixes on the sign-up path found while verifying it end to end:

1. **Prod-without-SMTP lockout** — `shouldAutoVerify = !hasEmailConfig` (was also gated on NODE_ENV≠production). A prod deploy without SMTP was silently creating `verified=false` accounts that login() permanently blocks. Now auto-verifies (with a warn) when no email delivery is configured.
2. **Dead `AuthContext.register`** — it set a token register never returns; now matches the real API (returns the message, no bogus token).
3. **Waitlist 'Use case' field** — was POSTed as `note`; now sent as `useCase` so admins see it in the right column.
4. **v2 paths on the invite-redeem critical path** — invite-required nav + invitation-email `registerUrl` now point at `/v2/register` / `/v2/login` instead of relying on the legacy redirect shim.
5. **Verify-pending success screen** — V2Register now shows 'Check your email' guidance instead of a 'Continue to sign in' button when verification is pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)