### PR TITLE
fix(agent-mentions): dampen mutual bot↔bot @mention loops (#508)

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -30,6 +30,10 @@ jest.mock('../../../services/chatSummarizerService', () => ({
   summarizePodMessages: jest.fn(),
 }));
 
+jest.mock('../../../models/AgentEvent', () => ({
+  countDocuments: jest.fn(),
+}));
+
 const AgentMentionService = require('../../../services/agentMentionService');
 const AgentEventService = require('../../../services/agentEventService');
 const { AgentInstallation } = require('../../../models/AgentRegistry');
@@ -37,6 +41,7 @@ const AgentProfile = require('../../../models/AgentProfile');
 const Pod = require('../../../models/Pod');
 const chatSummarizerService = require('../../../services/chatSummarizerService');
 const User = require('../../../models/User');
+const AgentEvent = require('../../../models/AgentEvent');
 
 describe('AgentMentionService', () => {
   beforeEach(() => {
@@ -47,6 +52,8 @@ describe('AgentMentionService', () => {
       select: jest.fn().mockReturnThis(),
       lean: jest.fn().mockResolvedValue({ _id: 'user-1', isBot: false }),
     });
+    // #508 dampener default — no prior mentions, so nothing is dampened.
+    AgentEvent.countDocuments.mockResolvedValue(0);
   });
 
   test('extractMentions finds supported agent aliases', () => {
@@ -731,6 +738,98 @@ describe('AgentMentionService', () => {
         });
         expect(lastPayload().payload.content).not.toContain('[Collaborative pod:');
       });
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // #508 mutual bot<->bot @mention loop dampener. Suppresses a bot->bot
+  // mention once the target has received > MENTION_LOOP_MAX (3) chat.mention
+  // events in this pod within the recent window. Genuine handoffs (under
+  // threshold) and ALL human->agent mentions are never dampened.
+  // ------------------------------------------------------------------
+  describe('bot<->bot loop dampener (#508)', () => {
+    const setupTargetAgent = () => {
+      AgentInstallation.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          { agentName: 'openclaw', instanceId: 'cody', displayName: 'Cody' },
+        ]),
+      });
+      AgentProfile.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
+    };
+    const asBotSender = () => {
+      User.findById.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue({
+          _id: 'agent-theo',
+          isBot: true,
+          botMetadata: { agentName: 'openclaw', instanceId: 'theo' },
+        }),
+      });
+    };
+
+    test('bot -> bot UNDER threshold still enqueues (genuine collaboration)', async () => {
+      setupTargetAgent();
+      asBotSender();
+      // 3 prior mentions == MENTION_LOOP_MAX; not strictly greater, so allowed.
+      AgentEvent.countDocuments.mockResolvedValue(3);
+
+      const res = await AgentMentionService.enqueueMentions({
+        podId: 'pod-loop-1',
+        message: { content: '@cody can you take this?', id: 'msg-loop-1' },
+        userId: 'agent-theo',
+        username: 'theo',
+      });
+
+      expect(AgentEvent.countDocuments).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentName: 'openclaw',
+          instanceId: 'cody',
+          podId: 'pod-loop-1',
+          type: 'chat.mention',
+        }),
+      );
+      expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+      expect(res.enqueued).toEqual(['openclaw']);
+      expect(res.skipped).toEqual([]);
+    });
+
+    test('bot -> bot OVER threshold is suppressed (loop dampened)', async () => {
+      setupTargetAgent();
+      asBotSender();
+      // 4 prior mentions > MENTION_LOOP_MAX (3) → treat as a loop.
+      AgentEvent.countDocuments.mockResolvedValue(4);
+
+      const res = await AgentMentionService.enqueueMentions({
+        podId: 'pod-loop-2',
+        message: { content: '@cody and again', id: 'msg-loop-2' },
+        userId: 'agent-theo',
+        username: 'theo',
+      });
+
+      expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+      expect(res.enqueued).toEqual([]);
+      expect(res.skipped).toEqual(['openclaw:loop-dampened']);
+    });
+
+    test('human -> bot is NEVER suppressed even over threshold', async () => {
+      setupTargetAgent();
+      // Default sender is a human (User.findById from beforeEach).
+      AgentEvent.countDocuments.mockResolvedValue(999);
+
+      const res = await AgentMentionService.enqueueMentions({
+        podId: 'pod-loop-3',
+        message: { content: '@cody please help', id: 'msg-loop-3' },
+        userId: 'user-1',
+        username: 'alice',
+      });
+
+      // Human sender short-circuits before any count check.
+      expect(AgentEvent.countDocuments).not.toHaveBeenCalled();
+      expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+      expect(res.enqueued).toEqual(['openclaw']);
+      expect(res.skipped).toEqual([]);
     });
   });
 });

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -9,6 +9,8 @@ const Pod = require('../models/Pod');
 // eslint-disable-next-line global-require
 const User = require('../models/User');
 // eslint-disable-next-line global-require
+const AgentEvent = require('../models/AgentEvent');
+// eslint-disable-next-line global-require
 const chatSummarizerService = require('./chatSummarizerService');
 // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
 const { resolveAgentDisplayLabel } = require('./agentIdentityService') as {
@@ -93,6 +95,19 @@ interface SenderRow {
   isBot?: boolean;
   botMetadata?: { agentName?: string; instanceId?: string };
 }
+
+// #508 mutual bot<->bot @mention loop dampener.
+// The self-mention guard below only catches an agent looping on its OWN
+// handle. Two DIFFERENT bots (e.g. Theo<->Cody) that @mention each other
+// ping-pong forever, burning quota, without ever tripping that guard.
+// This count-based sliding-window backstop suppresses a bot->bot mention
+// once the target has already received more than MENTION_LOOP_MAX
+// chat.mention events in the same pod within MENTION_LOOP_WINDOW_MS — i.e.
+// >3 mentions to the same bot in 5 min in a pod = treat as a loop. Genuine
+// handoffs (a human mention, or an infrequent agent handoff) stay under
+// the threshold and are never dampened.
+const MENTION_LOOP_WINDOW_MS = 5 * 60 * 1000; // #508 dampener — 5 min sliding window
+const MENTION_LOOP_MAX = 3; // #508 dampener — >3 mentions to same bot/pod/window = loop
 
 /**
  * Mention Aliases
@@ -602,6 +617,37 @@ const enqueueMentions = async ({
     && (target.instanceId || 'default') === senderInstanceId
   );
 
+  // #508 mutual bot<->bot loop dampener. Returns true when this mention
+  // should be SUPPRESSED because the target bot has already been mentioned
+  // more than MENTION_LOOP_MAX times in this pod within the recent window.
+  // CRITICAL: only dampens bot->bot. `senderAgentName` is non-null ONLY
+  // when the sender is a bot (set above from sender.isBot + botMetadata), so
+  // a human sender short-circuits to `false` and is NEVER dampened. The
+  // count check failing is non-fatal — fall through to enqueue rather than
+  // drop a possibly-genuine mention.
+  const isLoopDampened = async (target: MentionTarget): Promise<boolean> => {
+    if (!senderAgentName) return false; // human (or unknown) sender — never dampen
+    try {
+      const count = await AgentEvent.countDocuments({
+        agentName: target.agentName.toLowerCase(),
+        instanceId: target.instanceId || 'default',
+        podId,
+        type: 'chat.mention',
+        createdAt: { $gte: new Date(Date.now() - MENTION_LOOP_WINDOW_MS) },
+      });
+      if (count > MENTION_LOOP_MAX) {
+        console.warn(
+          `[mention-dampener] suppressed bot<->bot loop — sender=${senderAgentName}:${senderInstanceId} `
+          + `target=${target.agentName.toLowerCase()}:${target.instanceId || 'default'} pod=${podId} count=${count}`,
+        );
+        return true;
+      }
+    } catch (err) {
+      console.warn('[mention-dampener] loop count check failed (allowing through):', (err as Error).message);
+    }
+    return false;
+  };
+
   await Promise.all(
     rawMentions.map(async (raw) => {
       const normalized = raw.toLowerCase();
@@ -609,6 +655,10 @@ const enqueueMentions = async ({
       if (directMatch) {
         if (isSelfMention(directMatch)) {
           skipped.push(`${directMatch.agentName}:self`);
+          return;
+        }
+        if (await isLoopDampened(directMatch)) {
+          skipped.push(`${directMatch.agentName}:loop-dampened`);
           return;
         }
         try {
@@ -717,6 +767,10 @@ const enqueueMentions = async ({
           matches.map(async (match) => {
             if (isSelfMention({ agentName: agentType, instanceId: match.instanceId })) {
               skipped.push(`${agentType}:self`);
+              return;
+            }
+            if (await isLoopDampened({ agentName: agentType, instanceId: match.instanceId })) {
+              skipped.push(`${agentType}:loop-dampened`);
               return;
             }
             try {


### PR DESCRIPTION
Closes #508.

The self-mention guard only catches an agent looping on its *own* handle; two different bots (Theo↔Cody) ping-pong forever, burning quota. Adds a count-based sliding-window dampener in `enqueueMentions`: when a **bot** sender mentions a **bot** target that has already received >`MENTION_LOOP_MAX` (3) `chat.mention` events in the same pod within `MENTION_LOOP_WINDOW_MS` (5 min), the mention is suppressed (`:loop-dampened`). Wired at both enqueue sites; **human→agent and agent→human are never dampened** (guard short-circuits unless the sender is a bot). Count-check failure falls through to enqueue. Unit tests cover at-threshold/over-threshold/human-never.

🤖 Generated with [Claude Code](https://claude.com/claude-code)