### PR TITLE
fix(ci): pre-cache mongod binary once to kill mongodb-memory-server lock race (#517)

### DIFF
--- a/backend/__tests__/utils/globalSetup.js
+++ b/backend/__tests__/utils/globalSetup.js
@@ -1,0 +1,45 @@
+const { MongoBinary } = require('mongodb-memory-server');
+const { MONGO_BINARY_VERSION, MONGOMS_DOWNLOAD_DIR } = require('./mongoBinaryConfig');
+
+const sleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+// Runs ONCE before any Jest worker spins up (configured via jest.config.js
+// `globalSetup`). Pre-downloads/caches the mongod binary a single time so the
+// per-file MongoMemoryServer.create() calls in parallel workers all reuse the
+// cached binary and never race the download lock — the root cause of the flaky
+// "Cannot unlock file ... .lock" failures in CI.
+module.exports = async () => {
+  // Integration runs use a real Mongo (MONGO_URI); no in-memory binary needed.
+  if (process.env.INTEGRATION_TEST === 'true') return;
+
+  // Pin the version + cache dir for this process AND for the child workers,
+  // which inherit process.env. This keeps globalSetup and the per-file create()
+  // pointed at the exact same cached binary.
+  process.env.MONGOMS_VERSION = MONGO_BINARY_VERSION;
+  process.env.MONGOMS_DOWNLOAD_DIR = MONGOMS_DOWNLOAD_DIR;
+
+  const maxAttempts = 3;
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const binaryPath = await MongoBinary.getPath({
+        version: MONGO_BINARY_VERSION,
+        downloadDir: MONGOMS_DOWNLOAD_DIR,
+      });
+      // eslint-disable-next-line no-console
+      console.log(`[globalSetup] mongod ${MONGO_BINARY_VERSION} cached at ${binaryPath}`);
+      return;
+    } catch (error) {
+      lastError = error;
+      // eslint-disable-next-line no-console
+      console.warn(`[globalSetup] mongod download attempt ${attempt}/${maxAttempts} failed: ${error.message}`);
+      if (attempt < maxAttempts) {
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(attempt * 2000);
+      }
+    }
+  }
+
+  throw lastError;
+};

--- a/backend/__tests__/utils/mongoBinaryConfig.js
+++ b/backend/__tests__/utils/mongoBinaryConfig.js
@@ -1,0 +1,17 @@
+const path = require('path');
+
+// Single source of truth for the mongod binary version used by BOTH the Jest
+// globalSetup pre-download and the per-file MongoMemoryServer.create() call.
+// Keep these in lock-step so parallel workers all resolve the SAME cached
+// binary and never race each other downloading/locking a different version.
+const MONGO_BINARY_VERSION = '7.0.14';
+
+// Stable, shared cache dir so every worker reuses one binary instead of each
+// resolving its own download/lock. Lives under node_modules so it is gitignored
+// and survives across test runs in CI cache.
+const MONGOMS_DOWNLOAD_DIR = path.resolve(__dirname, '..', '..', 'node_modules', '.cache', 'mongodb-binaries');
+
+module.exports = {
+  MONGO_BINARY_VERSION,
+  MONGOMS_DOWNLOAD_DIR,
+};

--- a/backend/__tests__/utils/testUtils.js
+++ b/backend/__tests__/utils/testUtils.js
@@ -4,11 +4,43 @@ const mongoose = require('mongoose');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 const { newDb } = require('pg-mem');
 const jwt = require('jsonwebtoken');
+const { MONGO_BINARY_VERSION, MONGOMS_DOWNLOAD_DIR } = require('./mongoBinaryConfig');
 
 const useRealServices = () => process.env.INTEGRATION_TEST === 'true';
 
 // MongoDB setup — Tier 1 (real services) or Tier 0 (in-memory)
 let mongoServer;
+
+const sleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+// Defense-in-depth: globalSetup pre-caches the binary once, but retry the
+// create() anyway to absorb any residual lock/CDN hiccup in parallel workers.
+const createMongoServer = async () => {
+  const maxAttempts = 3;
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      return await MongoMemoryServer.create({
+        binary: {
+          version: MONGO_BINARY_VERSION,
+          downloadDir: MONGOMS_DOWNLOAD_DIR,
+          skipMD5: true,
+        },
+        instance: {
+          dbName: 'jest-test-db',
+        },
+      });
+    } catch (error) {
+      lastError = error;
+      if (attempt < maxAttempts) {
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(attempt * 1000);
+      }
+    }
+  }
+  throw lastError;
+};
 
 const setupMongoDb = async () => {
   try {
@@ -24,15 +56,7 @@ const setupMongoDb = async () => {
       return;
     }
 
-    mongoServer = await MongoMemoryServer.create({
-      binary: {
-        version: '7.0.11',
-        skipMD5: true,
-      },
-      instance: {
-        dbName: 'jest-test-db',
-      },
-    });
+    mongoServer = await createMongoServer();
 
     await mongoose.connect(mongoServer.getUri());
     console.log('Connected to in-memory MongoDB');

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -3,8 +3,13 @@ module.exports = {
   testPathIgnorePatterns: [
     '/node_modules/',
     '__tests__/utils/testUtils.js',
+    '__tests__/utils/globalSetup.js',
+    '__tests__/utils/mongoBinaryConfig.js',
     '__tests__/setup.js',
   ],
+  // Pre-download/cache the mongod binary ONCE before any worker starts so
+  // parallel workers never race the download lock (the CI flake root cause).
+  globalSetup: '<rootDir>/__tests__/utils/globalSetup.js',
   transform: {
     '^.+\\.tsx?$': ['ts-jest', { tsconfig: { allowJs: true, checkJs: false } }],
     '^.+\\.jsx?$': 'babel-jest',


### PR DESCRIPTION
Closes #517.

Each test file called `MongoMemoryServer.create({binary:{version:'7.0.11'}})`, so parallel Jest workers raced the shared binary download/lock → 'Cannot unlock file …' → mongoose buffering timeouts → ~23 false-red tests in two-way-integration-e2e. Adds a jest `globalSetup` that downloads/caches the mongod binary **once** (stable MONGOMS_DOWNLOAD_DIR + retry) before workers start, a shared version constant (no more 7.0.11-vs-^9 drift), and a retry wrapper around `create`. Wired `globalSetup` into jest.config.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)