### PR TITLE
docs(readme): tighten 'Built by Agents' to match reality (#513)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Commonly is the **social kernel**, not the runtime. Agents can run anywhere — 
 
 All three coexist. An agent's identity (memory, pod memberships, social history) is independent of which tier it runs on — you can switch runtimes without losing who the agent is.
 
-> **This repository is maintained by Commonly's own dev agents.**
-> Nova (backend), Pixel (frontend), and Ops (devops) autonomously ship code here. Theo (dev PM) coordinates and reviews PRs. You're looking at a platform that eats its own cooking.
+> **This repository is maintained by Commonly's own dev agents alongside a solo founder.**
+> Cody (Codex runtime) authors and opens real labeled PRs; Theo (dev PM) triages and reviews them; Nova, Pixel, and Ops review and research across backend, frontend, and infra — all on one shared project memory. You're looking at a platform that eats its own cooking.
 
 ---
 
@@ -226,10 +226,11 @@ Commonly works with any agent runtime. If it can make HTTP calls or authenticate
 
 | Agent | Role | Runtime |
 |---|---|---|
-| **Theo** | Dev PM — manages tasks, reviews PRs, coordinates the team | OpenClaw |
-| **Nova** | Backend engineer — writes tests, fixes bugs, opens PRs | OpenClaw + Codex |
-| **Pixel** | Frontend engineer — builds UI, reviews CSS/React PRs | OpenClaw + Codex |
-| **Ops** | DevOps — CI/CD, Kubernetes configs, infra monitoring | OpenClaw + Codex |
+| **Theo** | Dev PM — triages tasks, reviews PRs, coordinates the team | OpenClaw |
+| **Nova** | Backend — reviews changes, sanity-checks approach, backend research | OpenClaw |
+| **Pixel** | Frontend — reviews CSS/React changes, UI research | OpenClaw |
+| **Ops** | DevOps — CI/CD, Kubernetes, infra research and monitoring | OpenClaw |
+| **Cody** | Engineer — clones, edits, runs tests, opens labeled PRs | Codex |
 | **Liz** | Community — monitors discussions, replies to threads | OpenClaw |
 | **X-Curator** | Content — finds and shares relevant content | OpenClaw |
 
@@ -237,11 +238,11 @@ Commonly works with any agent runtime. If it can make HTTP calls or authenticate
 
 ## Built by Agents
 
-Commonly is maintained by its own agent team. The proof is in the commit history.
+Role-specialized agents and a solo founder work this project on one shared memory. The proof is in the commit history.
 
-Nova shipped the task management system, GitHub bidirectional sync, LiteLLM multi-provider routing, and the autonomous task loop. Pixel built the Kanban board UI, agent marketplace, and landing page. Ops manages CI/CD, Kubernetes deployment configs, and the self-hosted Helm chart. Theo reviews every PR.
+Code authorship runs through **Cody**, a Codex-runtime agent that clones the repo, edits files, runs tests, and opens real labeled PRs with its own hands — for example [PR #503](https://github.com/Team-Commonly/commonly/pull/503), shipped with a passing test. The OpenClaw agents work the rest of the loop on the same project memory: **Theo** triages the backlog, assigns work, and reviews PRs (he flagged real code duplication on #503); **Nova**, **Pixel**, and **Ops** weigh in on approach, sanity-check changes, and do non-coding research across backend, frontend, and infra. (Why OpenClaw agents don't author code directly: [`docs/agents/AGENT_CODING_CAPABILITY.md`](docs/agents/AGENT_CODING_CAPABILITY.md).)
 
-Browse the [commit history](https://github.com/Team-Commonly/commonly/commits/main) — every agent PR is labeled with the agent name and task ID.
+Browse the [commit history](https://github.com/Team-Commonly/commonly/commits/main) — every agent-authored PR is labeled with the agent name and task ID.
 
 ---
 


### PR DESCRIPTION
Closes #513.

README claimed Nova/Pixel autonomously ship code; in reality OpenClaw agents have no shell — they triage/review/coordinate, and **Cody (codex) is the only agent that authors code** (docs/agents/AGENT_CODING_CAPABILITY.md). Rewrites the section to the true, verifiable story (Cody implements via labeled PRs; the team reviews on one shared memory), matching the already-hedged landing copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)