### PR TITLE
fix(landing): route signed-out CTAs to /v2/register (request access), not the sign-in dead-end

### DIFF
--- a/frontend/src/v2/landing/V2ComparePage.tsx
+++ b/frontend/src/v2/landing/V2ComparePage.tsx
@@ -41,7 +41,10 @@ const ROWS: Row[] = [
 
 const V2ComparePage: React.FC = () => {
   const { isAuthenticated } = useAuth();
-  const appHref = isAuthenticated ? '/v2' : '/v2/login';
+  // Signed-out visitors get routed to /v2/register (invite-code + waitlist),
+  // not the /v2/login dead-end. Returning users use the "Sign in" nav link.
+  const appHref = isAuthenticated ? '/v2' : '/v2/register';
+  const primaryLabel = isAuthenticated ? 'Open the app' : 'Request access';
   return (
   <div className="v2-root v2-landing">
     <header className="v2-landing__bar">
@@ -100,7 +103,7 @@ const V2ComparePage: React.FC = () => {
         </p>
 
         <div className="v2-landing__cta-row v2-compare__cta">
-          <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>Open the app</Link>
+          <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>{primaryLabel}</Link>
           <a className="v2-landing__btn v2-landing__btn--ghost" href={REPO} target="_blank" rel="noreferrer">
             <span className="v2-landing__btn-mark"><Mark size={18} /></span>
             Star on GitHub
@@ -122,7 +125,7 @@ const V2ComparePage: React.FC = () => {
         <div className="v2-landing__footer-col">
           <div className="v2-landing__footer-title">Product</div>
           <Link className="v2-landing__footer-link" to="/v2/landing">Home</Link>
-          <Link className="v2-landing__footer-link" to={appHref}>Open the app</Link>
+          <Link className="v2-landing__footer-link" to={appHref}>{primaryLabel}</Link>
         </div>
         <div className="v2-landing__footer-col">
           <div className="v2-landing__footer-title">Open source</div>

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -66,10 +66,13 @@ const V2LandingPage: React.FC = () => {
   const { isAuthenticated } = useAuth();
   const [stats, setStats] = useState<Stats | null>(null);
 
-  // "Open the app" must take you INTO the app: signed-in → the shell; signed-out
-  // → the sign-in portal (registration is invite-only, so never dump a visitor
-  // at /v2/register). V2Home then routes an authed /v2 to the shell.
-  const appHref = isAuthenticated ? '/v2' : '/v2/login';
+  // Primary CTA: signed-in → the shell; signed-out → /v2/register, which under
+  // invite-only lands on the invite-code + waitlist form so a brand-new visitor
+  // can actually request access. (Previously every CTA pointed at /v2/login — a
+  // dead end for someone who has no account yet. Returning users still have the
+  // dedicated "Sign in" nav link below.)
+  const appHref = isAuthenticated ? '/v2' : '/v2/register';
+  const primaryLabel = isAuthenticated ? 'Open the app' : 'Request access';
 
   useEffect(() => {
     let cancelled = false;
@@ -127,7 +130,7 @@ const V2LandingPage: React.FC = () => {
             </div>
 
             <div className="v2-landing__cta-row">
-              <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>Open the app</Link>
+              <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>{primaryLabel}</Link>
               <a className="v2-landing__btn v2-landing__btn--ghost" href={REPO} target="_blank" rel="noreferrer">
                 <span className="v2-landing__btn-mark"><Mark size={18} /></span>
                 Star on GitHub
@@ -390,7 +393,7 @@ const V2LandingPage: React.FC = () => {
                 <li>Your infra, your data</li>
               </ul>
               <div className="v2-landing__cta-row">
-                <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>Open the app</Link>
+                <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>{primaryLabel}</Link>
                 <a className="v2-landing__btn v2-landing__btn--ghost" href={REPO} target="_blank" rel="noreferrer">Self-host it</a>
               </div>
             </div>
@@ -402,7 +405,7 @@ const V2LandingPage: React.FC = () => {
           <h2 className="v2-landing__cta-title">Give your agents one place to remember.</h2>
           <p className="v2-landing__cta-sub">Open the hosted app, or clone the repo and self-host in one command. It&apos;s all open.</p>
           <div className="v2-landing__cta-row">
-            <Link className="v2-landing__btn v2-landing__btn--onaccent" to={appHref}>Open the app</Link>
+            <Link className="v2-landing__btn v2-landing__btn--onaccent" to={appHref}>{primaryLabel}</Link>
             <a className="v2-landing__btn v2-landing__btn--onaccent-ghost" href={REPO} target="_blank" rel="noreferrer">Star on GitHub</a>
             <Link className="v2-landing__btn v2-landing__btn--onaccent-ghost" to="/compare">Compare to Raft</Link>
           </div>
@@ -418,7 +421,7 @@ const V2LandingPage: React.FC = () => {
         <div className="v2-landing__footer-cols">
           <div className="v2-landing__footer-col">
             <div className="v2-landing__footer-title">Product</div>
-            <Link className="v2-landing__footer-link" to={appHref}>Open the app</Link>
+            <Link className="v2-landing__footer-link" to={appHref}>{primaryLabel}</Link>
             <Link className="v2-landing__footer-link" to="/v2/marketplace">Marketplace</Link>
             <Link className="v2-landing__footer-link" to="/v2/agents/browse">Hire an agent</Link>
             <Link className="v2-landing__footer-link" to="/compare">Compare to Raft</Link>


### PR DESCRIPTION
**Found while smoke-testing the live funnel as a first-time visitor.** Every CTA on the landing *and* /compare ("Get started", "Open the app" ×4) pointed at `/v2/login` — a dead end for someone with no account under invite-only. There was no "Request access"/waitlist CTA anywhere, so an interested visitor had nowhere to go.

Primary CTAs now route signed-out users to `/v2/register` (which under invite-only lands on the invite-code + waitlist form), labeled "Request access". Returning users keep the dedicated "Sign in" nav link. Same fix applied to V2ComparePage.

Complements #520 (which fixed the v1 `/login` link + `useCase` field on the invite-required page). Pairs with the broader open-registration staging work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)