### PR TITLE
feat: gate cloud agents behind entitlement + default workspace pod (open-registration staging)

### DIFF
--- a/backend/__tests__/service/auth.test.js
+++ b/backend/__tests__/service/auth.test.js
@@ -3,6 +3,7 @@ const express = require('express');
 // eslint-disable-next-line no-unused-vars
 const mongoose = require('mongoose');
 const User = require('../../models/User');
+const Pod = require('../../models/Pod');
 const authRoutes = require('../../routes/auth');
 const {
   setupMongoDb,
@@ -68,6 +69,45 @@ describe('Auth Routes Integration Tests', () => {
       expect(user).toBeTruthy();
       expect(user.username).toBe(userData.username);
       expect(typeof user.verified).toBe('boolean');
+    });
+
+    it('creates a default private workspace pod owned by the new user', async () => {
+      const userData = {
+        username: 'workspaceowner',
+        email: 'workspace@example.com',
+        password: 'Password123!',
+      };
+
+      await request(app)
+        .post('/api/auth/register')
+        .send(userData)
+        .expect(201);
+
+      const user = await User.findOne({ email: userData.email });
+      expect(user).toBeTruthy();
+
+      const pods = await Pod.find({ createdBy: user._id });
+      expect(pods).toHaveLength(1);
+      const pod = pods[0];
+      expect(pod.name).toBe('My Workspace');
+      expect(pod.type).toBe('chat');
+      expect(pod.joinPolicy).toBe('invite-only');
+      // Creator is the sole member.
+      expect(pod.members.map((m) => m.toString())).toEqual([user._id.toString()]);
+    });
+
+    it('defaults entitlements.cloudAgents to false for new signups', async () => {
+      await request(app)
+        .post('/api/auth/register')
+        .send({
+          username: 'gateduser',
+          email: 'gated@example.com',
+          password: 'Password123!',
+        })
+        .expect(201);
+
+      const user = await User.findOne({ email: 'gated@example.com' });
+      expect(user.entitlements.cloudAgents).toBe(false);
     });
 
     it('should return 400 for existing user', async () => {

--- a/backend/__tests__/service/clawdbot-e2e.test.js
+++ b/backend/__tests__/service/clawdbot-e2e.test.js
@@ -64,11 +64,14 @@ describe('Clawdbot E2E Integration Tests', () => {
     app.use('/api/registry', registryRoutes);
     app.use('/api/agents/runtime', agentsRuntimeRoutes);
 
-    // Create test users
+    // Create test users. The pod owner installs commonly-bot (a cloud
+    // 'internal' agent), so they need the cloudAgents entitlement to pass the
+    // hosted-agent gate.
     testUser = await User.create({
       username: 'podadmin',
       email: 'podadmin@test.com',
       password: 'password123',
+      entitlements: { cloudAgents: true },
     });
 
     testUser2 = await User.create({

--- a/backend/__tests__/service/install.preserves-displayname.test.js
+++ b/backend/__tests__/service/install.preserves-displayname.test.js
@@ -50,6 +50,9 @@ describe('Install endpoint preserves curated displayName (cycle-of-Aria regressi
       username: 'installer',
       email: 'installer@test.com',
       password: 'password123',
+      // openclaw is a cloud (moltbot) agent — entitle the installer so the
+      // hosted-agent gate passes; this test asserts displayName preservation.
+      entitlements: { cloudAgents: true },
     });
     installerToken = jwt.sign({ id: installer._id.toString() }, JWT_SECRET);
 

--- a/backend/__tests__/service/integrations-e2e.test.js
+++ b/backend/__tests__/service/integrations-e2e.test.js
@@ -94,6 +94,9 @@ describe('Integrations E2E Tests', () => {
       username: 'integrationadmin',
       email: 'integrationadmin@test.com',
       password: 'password123',
+      // commonly-bot is a cloud (internal) agent — entitle the installer so the
+      // hosted-agent gate passes.
+      entitlements: { cloudAgents: true },
     });
 
     authToken = jwt.sign({ id: testUser._id.toString() }, JWT_SECRET);

--- a/backend/__tests__/unit/routes/registry.cloud-entitlement-gate.test.js
+++ b/backend/__tests__/unit/routes/registry.cloud-entitlement-gate.test.js
@@ -1,0 +1,227 @@
+// Gate test: cloud (hosted) agent installs require admin OR the cloudAgents
+// entitlement; BYO/webhook installs stay open. Mirrors the harness in
+// registry.install-runtime-type.test.js.
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentRegistry: {
+    getByName: jest.fn(),
+    incrementInstalls: jest.fn(),
+  },
+  AgentInstallation: {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    install: jest.fn(),
+  },
+}));
+
+jest.mock('../../../models/Pod', () => ({
+  findById: jest.fn(),
+}));
+
+jest.mock('../../../models/User', () => ({
+  findOne: jest.fn(),
+  findById: jest.fn(),
+}));
+
+jest.mock('../../../models/AgentProfile', () => ({
+  findOneAndUpdate: jest.fn(),
+}));
+
+jest.mock('../../../models/Activity', () => ({
+  create: jest.fn(),
+}));
+
+// Real-ish taxonomy so the gate exercises the actual decision logic; only the
+// AGENT_TYPES lookup is stubbed (openclaw → moltbot, others unknown).
+jest.mock('../../../services/agentIdentityService', () => ({
+  buildAgentUsername: jest.fn((agentName, instanceId = 'default') => (
+    instanceId === 'default' ? agentName : `${agentName}-${instanceId}`
+  )),
+  getOrCreateAgentUser: jest.fn().mockResolvedValue({ _id: 'bot-1' }),
+  ensureAgentInPod: jest.fn().mockResolvedValue(true),
+  getAgentTypeConfig: jest.fn((name) => (
+    String(name).toLowerCase() === 'openclaw' ? { runtime: 'moltbot' } : null
+  )),
+  isCloudRuntime: jest.fn(({ runtimeType, host } = {}) => {
+    const rt = String(runtimeType || '').toLowerCase();
+    const h = String(host || '').toLowerCase();
+    if (h === 'byo') return false;
+    if (rt === 'webhook' || rt === 'claude-code') return false;
+    if (['moltbot', 'internal', 'native', 'managed-agents'].includes(rt)) return true;
+    if (rt === 'codex') return true;
+    return false;
+  }),
+}));
+
+jest.mock('../../../services/agentMessageService', () => ({
+  postMessage: jest.fn().mockResolvedValue(true),
+}));
+
+const { AgentRegistry, AgentInstallation } = require('../../../models/AgentRegistry');
+const Pod = require('../../../models/Pod');
+const User = require('../../../models/User');
+const AgentProfile = require('../../../models/AgentProfile');
+const Activity = require('../../../models/Activity');
+const installRouter = require('../../../routes/registry/install');
+
+const getInstallHandler = () => {
+  const layer = installRouter.stack.find((entry) => (
+    entry.route
+    && entry.route.path === '/install'
+    && entry.route.methods.post
+  ));
+  if (!layer) throw new Error('Install route handler not found');
+  return layer.route.stack[layer.route.stack.length - 1].handle;
+};
+
+const buildLeanChain = (result) => ({ lean: jest.fn().mockResolvedValue(result) });
+const buildSelectLeanChain = (result) => ({
+  select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(result) }),
+});
+
+const makeRes = () => ({ status: jest.fn().mockReturnThis(), json: jest.fn() });
+
+describe('registry install — cloud-agent entitlement gate', () => {
+  const installHandler = getInstallHandler();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    Pod.findById.mockReturnValue(buildLeanChain({
+      _id: 'pod-1',
+      createdBy: 'user-1',
+      members: ['user-1'],
+      type: 'chat',
+    }));
+
+    AgentInstallation.findOne.mockResolvedValue(null);
+    AgentInstallation.find.mockReturnValue(buildLeanChain([]));
+    AgentInstallation.install.mockImplementation(async (_agentName, _podId, options) => ({
+      _id: { toString: () => 'install-1' },
+      agentName: _agentName,
+      instanceId: options.instanceId || 'default',
+      displayName: options.displayName || 'Agent',
+      version: options.version,
+      status: 'active',
+      scopes: options.scopes || [],
+    }));
+    AgentRegistry.incrementInstalls.mockResolvedValue({ acknowledged: true });
+
+    // botMetadata displayName lookup → none.
+    User.findOne.mockImplementation(() => buildSelectLeanChain(null));
+
+    AgentProfile.findOneAndUpdate.mockResolvedValue(true);
+    Activity.create.mockResolvedValue(true);
+  });
+
+  it('403s a non-admin, non-entitled installer on a cloud (moltbot) agent', async () => {
+    AgentRegistry.getByName.mockResolvedValue({
+      agentName: 'openclaw',
+      displayName: 'Cuz',
+      description: 'OpenClaw',
+      latestVersion: '1.0.0',
+      manifest: { context: { required: [] }, runtime: { type: 'standalone' } },
+    });
+    // Installer: plain user, no entitlement.
+    User.findById.mockReturnValue(buildSelectLeanChain({
+      username: 'installer', role: 'user', entitlements: { cloudAgents: false },
+    }));
+
+    const req = {
+      body: {
+        agentName: 'openclaw', podId: 'pod-1', version: '1.0.0', config: {}, scopes: [],
+      },
+      user: { id: 'user-1', username: 'installer' },
+      userId: 'user-1',
+    };
+    const res = makeRes();
+    await installHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      code: 'cloud_agents_not_entitled',
+    }));
+    expect(AgentInstallation.install).not.toHaveBeenCalled();
+  });
+
+  it('allows an entitled (non-admin) installer on a cloud (moltbot) agent', async () => {
+    AgentRegistry.getByName.mockResolvedValue({
+      agentName: 'openclaw',
+      displayName: 'Cuz',
+      description: 'OpenClaw',
+      latestVersion: '1.0.0',
+      manifest: { context: { required: [] }, runtime: { type: 'standalone' } },
+    });
+    User.findById.mockReturnValue(buildSelectLeanChain({
+      username: 'installer', role: 'user', entitlements: { cloudAgents: true },
+    }));
+
+    const req = {
+      body: {
+        agentName: 'openclaw', podId: 'pod-1', version: '1.0.0', config: {}, scopes: [],
+      },
+      user: { id: 'user-1', username: 'installer' },
+      userId: 'user-1',
+    };
+    const res = makeRes();
+    await installHandler(req, res);
+
+    expect(res.status).not.toHaveBeenCalledWith(403);
+    expect(AgentInstallation.install).toHaveBeenCalled();
+  });
+
+  it('allows an admin installer on a cloud (moltbot) agent', async () => {
+    AgentRegistry.getByName.mockResolvedValue({
+      agentName: 'openclaw',
+      displayName: 'Cuz',
+      description: 'OpenClaw',
+      latestVersion: '1.0.0',
+      manifest: { context: { required: [] }, runtime: { type: 'standalone' } },
+    });
+    User.findById.mockReturnValue(buildSelectLeanChain({
+      username: 'admin', role: 'admin',
+    }));
+
+    const req = {
+      body: {
+        agentName: 'openclaw', podId: 'pod-1', version: '1.0.0', config: {}, scopes: [],
+      },
+      user: { id: 'user-1', username: 'admin' },
+      userId: 'user-1',
+    };
+    const res = makeRes();
+    await installHandler(req, res);
+
+    expect(res.status).not.toHaveBeenCalledWith(403);
+    expect(AgentInstallation.install).toHaveBeenCalled();
+  });
+
+  it('does NOT gate a BYO/webhook install for a non-admin, non-entitled user', async () => {
+    AgentRegistry.getByName.mockResolvedValue({
+      agentName: 'my-bot',
+      displayName: 'My Bot',
+      description: 'BYO webhook bot',
+      latestVersion: '1.0.0',
+      manifest: { context: { required: [] }, runtime: { type: 'standalone' } },
+    });
+    // No entitlement — but webhook is BYO, so the gate must not fire and
+    // User.findById must not even be consulted for the gate.
+    User.findById.mockReturnValue(buildSelectLeanChain({ username: 'installer', role: 'user' }));
+
+    const req = {
+      body: {
+        agentName: 'my-bot',
+        podId: 'pod-1',
+        version: '1.0.0',
+        config: { runtime: { runtimeType: 'webhook' } },
+        scopes: [],
+      },
+      user: { id: 'user-1', username: 'installer' },
+      userId: 'user-1',
+    };
+    const res = makeRes();
+    await installHandler(req, res);
+
+    expect(res.status).not.toHaveBeenCalledWith(403);
+    expect(AgentInstallation.install).toHaveBeenCalled();
+  });
+});

--- a/backend/__tests__/unit/routes/registry.install-runtime-type.test.js
+++ b/backend/__tests__/unit/routes/registry.install-runtime-type.test.js
@@ -33,6 +33,18 @@ jest.mock('../../../services/agentIdentityService', () => ({
   )),
   getOrCreateAgentUser: jest.fn().mockResolvedValue({ _id: 'bot-1' }),
   ensureAgentInPod: jest.fn().mockResolvedValue(true),
+  // Unknown agentName in these tests → no AGENT_TYPES runtime fallback.
+  getAgentTypeConfig: jest.fn(() => null),
+  // Faithful mirror of the real taxonomy so the entitlement gate behaves.
+  isCloudRuntime: jest.fn(({ runtimeType, host } = {}) => {
+    const rt = String(runtimeType || '').toLowerCase();
+    const h = String(host || '').toLowerCase();
+    if (h === 'byo') return false;
+    if (rt === 'webhook' || rt === 'claude-code') return false;
+    if (['moltbot', 'internal', 'native', 'managed-agents'].includes(rt)) return true;
+    if (rt === 'codex') return true;
+    return false;
+  }),
 }));
 
 jest.mock('../../../services/agentMessageService', () => ({
@@ -97,7 +109,10 @@ describe('registry install runtimeType fallback', () => {
     AgentRegistry.incrementInstalls.mockResolvedValue({ acknowledged: true });
 
     User.findOne.mockImplementation(() => buildSelectLeanChain(null));
-    User.findById.mockReturnValue(buildSelectLeanChain({ username: 'installer' }));
+    // Installer is an admin so the cloud-agent entitlement gate passes — these
+    // tests install a 'native' runtime (a cloud runtime) and assert the
+    // runtimeType fallback, not the gate.
+    User.findById.mockReturnValue(buildSelectLeanChain({ username: 'installer', role: 'admin' }));
 
     AgentProfile.findOneAndUpdate.mockResolvedValue(true);
     Activity.create.mockResolvedValue(true);

--- a/backend/__tests__/unit/routes/registry.provision-entitlement-gate.test.js
+++ b/backend/__tests__/unit/routes/registry.provision-entitlement-gate.test.js
@@ -1,0 +1,108 @@
+// Gate test: provisioning a cloud (hosted) runtime requires admin OR the
+// cloudAgents entitlement. Exercises the early-return 403 path on the provision
+// route before any runtime provisioning work runs.
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.user = { _id: 'user-1', id: 'user-1' };
+  req.userId = 'user-1';
+  next();
+});
+
+jest.mock('../../../models/Pod', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { findOne: jest.fn(), install: jest.fn(), updateOne: jest.fn() },
+}));
+
+jest.mock('../../../services/agentIdentityService', () => ({
+  resolveAgentType: jest.fn((name) => String(name).toLowerCase()),
+  getAgentTypeConfig: jest.fn((name) => (
+    String(name).toLowerCase() === 'openclaw' ? { runtime: 'moltbot' } : null
+  )),
+  isCloudRuntime: jest.fn(({ runtimeType, host } = {}) => {
+    const rt = String(runtimeType || '').toLowerCase();
+    const h = String(host || '').toLowerCase();
+    if (h === 'byo') return false;
+    if (rt === 'webhook' || rt === 'claude-code') return false;
+    if (['moltbot', 'internal', 'native', 'managed-agents'].includes(rt)) return true;
+    if (rt === 'codex') return true;
+    return false;
+  }),
+  getOrCreateAgentUser: jest.fn(),
+  ensureAgentInPod: jest.fn(),
+}));
+
+jest.mock('../../../routes/registry/helpers', () => ({
+  getUserId: jest.fn((req) => req.userId),
+  isGlobalAdminUser: jest.fn().mockResolvedValue(false),
+  resolveInstallation: jest.fn().mockResolvedValue({
+    installation: {
+      status: 'active',
+      config: { runtime: {} },
+      runtimeTokens: [],
+    },
+    instanceId: 'default',
+  }),
+  resolveRuntimeInstanceId: jest.fn().mockReturnValue('default'),
+  // Remaining helpers are only reached after the gate; stub as no-ops.
+  normalizeConfigMap: jest.fn((c) => c),
+  normalizeRuntimeAuthProfiles: jest.fn(),
+  normalizeSkillEnvEntries: jest.fn(),
+  buildOpenClawIntegrationChannels: jest.fn(),
+  userHasPodAccess: jest.fn(),
+  resolveGatewayForRequest: jest.fn(),
+  resolveGatewayForInstallation: jest.fn(),
+}));
+
+const Pod = require('../../../models/Pod');
+const User = require('../../../models/User');
+const { isGlobalAdminUser } = require('../../../routes/registry/helpers');
+const provisionRouter = require('../../../routes/registry/provision');
+
+const buildLeanChain = (result) => ({ lean: jest.fn().mockResolvedValue(result) });
+const buildSelectLeanChain = (result) => ({
+  select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(result) }),
+});
+
+const app = express();
+app.use(express.json());
+app.use('/api/registry', provisionRouter);
+
+describe('registry provision — cloud-agent entitlement gate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Pod.findById.mockReturnValue(buildLeanChain({
+      _id: 'pod-1', createdBy: 'user-1', members: ['user-1'],
+    }));
+    isGlobalAdminUser.mockResolvedValue(false);
+  });
+
+  it('403s a non-admin, non-entitled user provisioning a cloud (moltbot) agent', async () => {
+    User.findById.mockReturnValue(buildSelectLeanChain({
+      entitlements: { cloudAgents: false },
+    }));
+
+    const res = await request(app)
+      .post('/api/registry/pods/pod-1/agents/openclaw/provision')
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('cloud_agents_not_entitled');
+  });
+
+  it('does not 403 an entitled user (gate passes, proceeds past the check)', async () => {
+    User.findById.mockReturnValue(buildSelectLeanChain({
+      entitlements: { cloudAgents: true },
+    }));
+
+    const res = await request(app)
+      .post('/api/registry/pods/pod-1/agents/openclaw/provision')
+      .send({});
+
+    // Past the gate the handler does real provisioning work against stubbed
+    // deps, which may error — but it must NOT be the entitlement 403.
+    expect(res.body.code).not.toBe('cloud_agents_not_entitled');
+  });
+});

--- a/backend/__tests__/unit/services/agentIdentityService.cloudRuntime.test.js
+++ b/backend/__tests__/unit/services/agentIdentityService.cloudRuntime.test.js
@@ -1,0 +1,61 @@
+// Taxonomy unit test for the hosted-agent entitlement gate's single source of
+// truth: agentIdentityService.isCloudRuntime + CLOUD_RUNTIME_TYPES.
+const AgentIdentityService = require('../../../services/agentIdentityService');
+
+const { isCloudRuntime, CLOUD_RUNTIME_TYPES } = AgentIdentityService;
+
+describe('agentIdentityService cloud-runtime taxonomy', () => {
+  it('exposes the helper + set off the service module', () => {
+    expect(typeof isCloudRuntime).toBe('function');
+    expect(CLOUD_RUNTIME_TYPES).toBeInstanceOf(Set);
+  });
+
+  it('CLOUD_RUNTIME_TYPES is exactly the hosted runtime set', () => {
+    expect([...CLOUD_RUNTIME_TYPES].sort()).toEqual(
+      ['internal', 'managed-agents', 'moltbot', 'native'],
+    );
+  });
+
+  describe('cloud runtimes (gated)', () => {
+    it.each([
+      ['moltbot'],
+      ['internal'],
+      ['native'],
+      ['managed-agents'],
+    ])('%s is cloud', (runtimeType) => {
+      expect(isCloudRuntime({ runtimeType })).toBe(true);
+    });
+
+    it('codex with no host is cloud (LiteLLM-proxied default)', () => {
+      expect(isCloudRuntime({ runtimeType: 'codex' })).toBe(true);
+      expect(isCloudRuntime({ runtimeType: 'codex', host: 'cloud' })).toBe(true);
+    });
+
+    it('is case-insensitive on runtimeType', () => {
+      expect(isCloudRuntime({ runtimeType: 'MOLTBOT' })).toBe(true);
+    });
+  });
+
+  describe('BYO runtimes (open)', () => {
+    it.each([
+      ['webhook'],
+      ['claude-code'],
+    ])('%s is BYO', (runtimeType) => {
+      expect(isCloudRuntime({ runtimeType })).toBe(false);
+    });
+
+    it("host:'byo' always wins, even for an otherwise-cloud runtimeType", () => {
+      expect(isCloudRuntime({ runtimeType: 'moltbot', host: 'byo' })).toBe(false);
+      expect(isCloudRuntime({ runtimeType: 'codex', host: 'byo' })).toBe(false);
+      expect(isCloudRuntime({ runtimeType: 'native', host: 'byo' })).toBe(false);
+    });
+
+    it('unknown / unspecified runtimeType defaults to NON-cloud (open)', () => {
+      expect(isCloudRuntime({ runtimeType: '' })).toBe(false);
+      expect(isCloudRuntime({ runtimeType: 'something-new' })).toBe(false);
+      expect(isCloudRuntime({})).toBe(false);
+      expect(isCloudRuntime(null)).toBe(false);
+      expect(isCloudRuntime(undefined)).toBe(false);
+    });
+  });
+});

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -2,6 +2,7 @@ const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const axios = require('axios');
 const User = require('../models/User');
+const Pod = require('../models/Pod');
 const InvitationCode = require('../models/InvitationCode');
 const WaitlistRequest = require('../models/WaitlistRequest');
 const AgentIdentityService = require('../services/agentIdentityService');
@@ -147,6 +148,25 @@ exports.register = async (req: any, res: any) => {
 
     // Save user to database
     await user.save();
+
+    // Give every new signup a default private workspace pod so the BYO
+    // onboarding flow has a target to install/talk-to an agent in. Matches
+    // the Mongo Pod shape created by podController.createPod (type 'chat',
+    // creator = sole member); joinPolicy 'invite-only' keeps it private.
+    // Best-effort: a pod-create hiccup must never fail registration — the user
+    // can always create a pod from the UI later.
+    try {
+      await Pod.create({
+        name: 'My Workspace',
+        description: 'Your private workspace',
+        type: 'chat',
+        joinPolicy: 'invite-only',
+        createdBy: user._id,
+        members: [user._id],
+      });
+    } catch (podError: any) {
+      console.warn('[register] default workspace pod creation failed:', podError?.message);
+    }
 
     if (hasEmailConfig) {
       // Generate email verification token

--- a/backend/models/User.ts
+++ b/backend/models/User.ts
@@ -51,6 +51,14 @@ export interface IUser extends Document {
   verified: boolean;
   profilePicture: string;
   role: UserRole;
+  // Capability gate for hosted (cloud) agents. Defaults to false so opening
+  // registration doesn't hand every new signup free Commonly-managed compute.
+  // Admins are implicitly allowed (the gate checks role === 'admin' OR this
+  // flag). BYO / self-hosted agents are never gated by this field — see
+  // agentIdentityService.isCloudRuntime + routes/registry/{install,provision}.
+  entitlements: {
+    cloudAgents: boolean;
+  };
   apiToken?: string;
   apiTokenCreatedAt?: Date;
   apiTokenScopes: string[];
@@ -123,6 +131,11 @@ const userSchema = new Schema<IUser>({
   verified: { type: Boolean, default: false },
   profilePicture: { type: String, default: 'default' },
   role: { type: String, enum: ['user', 'admin'], default: 'user' },
+  // Hosted-agent entitlement gate (see IUser.entitlements). Default false;
+  // admins bypass it. Nested object so future entitlements slot in here.
+  entitlements: {
+    cloudAgents: { type: Boolean, default: false },
+  },
   apiToken: { type: String, unique: true, sparse: true },
   apiTokenCreatedAt: { type: Date },
   apiTokenScopes: [{ type: String }],

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -270,6 +270,32 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
       installConfig.runtime = runtimeConfig;
     }
 
+    // Hosted-agent entitlement gate (open-registration prerequisite). A cloud
+    // (Commonly-hosted) runtime requires the installer to be an admin OR to
+    // carry the `cloudAgents` entitlement. BYO / self-serve installs (webhook,
+    // claude-code, or host:'byo') are intentionally NOT gated — connecting your
+    // own local agent stays open to all authenticated users. Resolve the
+    // effective runtimeType from the same place we just stored it
+    // (config.runtime), falling back to the agent's AGENT_TYPES runtime so a
+    // built-in cloud agent (openclaw→moltbot, commonly-bot→internal) is caught
+    // even when the caller omits an explicit runtimeType.
+    const effectiveRuntimeType = String(runtimeConfig.runtimeType || '').trim().toLowerCase()
+      || String(AgentIdentityService.getAgentTypeConfig(safeAgentName)?.runtime || '').trim().toLowerCase();
+    if (AgentIdentityService.isCloudRuntime({
+      runtimeType: effectiveRuntimeType,
+      host: runtimeConfig.host,
+    })) {
+      const installerUser = await User.findById(userId).select('role entitlements').lean();
+      const isAdmin = installerUser?.role === 'admin';
+      const isEntitled = installerUser?.entitlements?.cloudAgents === true;
+      if (!isAdmin && !isEntitled) {
+        return res.status(403).json({
+          code: 'cloud_agents_not_entitled',
+          message: 'Hosted (cloud) agents require entitlement; you can connect your own local/BYO agent instead.',
+        });
+      }
+    }
+
     const grantedScopes = Array.from(new Set([
       ...requiredScopes,
       ...scopes,

--- a/backend/routes/registry/provision.ts
+++ b/backend/routes/registry/provision.ts
@@ -6,6 +6,7 @@ const auth = require('../../middleware/auth');
 const { AgentInstallation } = require('../../models/AgentRegistry');
 const AgentProfile = require('../../models/AgentProfile');
 const Pod = require('../../models/Pod');
+const User = require('../../models/User');
 const Integration = require('../../models/Integration');
 const AgentIdentityService = require('../../services/agentIdentityService');
 const DMService = require('../../services/dmService');
@@ -123,6 +124,30 @@ provisionRouter.post('/pods/:podId/agents/:name/provision', auth, async (req: an
     const runtimeType = typeConfig?.runtime;
     if (!runtimeType) {
       return res.status(400).json({ error: 'Unknown agent runtime type' });
+    }
+
+    // Hosted-agent entitlement gate (mirrors routes/registry/install.ts). A
+    // cloud (Commonly-hosted) runtime requires admin OR the cloudAgents
+    // entitlement. BYO provisions (host:'byo') and external runtimes
+    // (webhook / claude-code) stay open to all pod members. runtimeType comes
+    // from AGENT_TYPES (typeConfig.runtime); host from the stored install
+    // config. Placed after the membership check above so non-members still 403
+    // first. commonly-bot is additionally admin-gated above — this is additive.
+    if (AgentIdentityService.isCloudRuntime({
+      runtimeType,
+      host: installation.config?.runtime?.host,
+    })) {
+      const isGlobalAdmin = await isGlobalAdminUser(userId);
+      if (!isGlobalAdmin) {
+        const provisionerUser = await User.findById(userId).select('entitlements').lean();
+        const isEntitled = provisionerUser?.entitlements?.cloudAgents === true;
+        if (!isEntitled) {
+          return res.status(403).json({
+            code: 'cloud_agents_not_entitled',
+            message: 'Hosted (cloud) agents require entitlement; you can connect your own local/BYO agent instead.',
+          });
+        }
+      }
     }
 
     const agentUser = await AgentIdentityService.getOrCreateAgentUser(name.toLowerCase(), {

--- a/backend/routes/registry/provision.ts
+++ b/backend/routes/registry/provision.ts
@@ -2,6 +2,7 @@
 // Handles: POST /pods/:podId/agents/:name/provision
 export {};
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const auth = require('../../middleware/auth');
 const { AgentInstallation } = require('../../models/AgentRegistry');
 const AgentProfile = require('../../models/AgentProfile');
@@ -36,13 +37,30 @@ const {
 const { PRESET_DEFINITIONS, withCyclesDirective } = require('./presets');
 const { applyPresetDefaultSkills } = require('../../services/presetSkillsAutoImport');
 
+// Inlined per-route limiter so CodeQL's `js/missing-rate-limiting` query
+// (which only recognises express-rate-limit calls in the same file as the
+// route registration) sees the guard on this DB-touching handler. Mirrors
+// installRateLimit in install.ts. Skipped under NODE_ENV=test so the
+// integration suite's reinstall/reprovision loops don't get throttled.
+const provisionRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  handler: (_req: any, res: any) => res.status(429).json({
+    message: 'rate limit exceeded: 30 provision requests per 60s',
+    code: 'rate_limited',
+  }),
+});
+
 const provisionRouter = express.Router();
 
 /**
  * POST /api/registry/pods/:podId/agents/:name/provision
  * Provision an external runtime config for an agent instance (local dev).
  */
-provisionRouter.post('/pods/:podId/agents/:name/provision', auth, async (req: any, res: any) => {
+provisionRouter.post('/pods/:podId/agents/:name/provision', provisionRateLimit, auth, async (req: any, res: any) => {
   try {
     const { podId, name } = req.params;
     const {

--- a/backend/services/agentIdentityService.ts
+++ b/backend/services/agentIdentityService.ts
@@ -220,6 +220,59 @@ const AGENT_TYPES: Record<string, AgentTypeConfig> = {
   },
 };
 
+// Cloud-hosted runtime types — the ones that consume Commonly-managed compute
+// (shared k8s gateway, in-process native runtime, Anthropic managed-agents).
+// This is the single source of truth for the hosted-agent entitlement gate
+// (see routes/registry/install.ts + provision.ts). Installing/provisioning any
+// runtime in this set requires `user.entitlements.cloudAgents` (or admin) so
+// that open registration can be turned on later without handing every new
+// signup free hosted compute. BYO / self-hosted runtimes (webhook, claude-code,
+// or anything carrying `host: 'byo'`) are intentionally NOT gated — connecting
+// your own agent stays open to all authenticated users.
+//
+// `codex` is deliberately absent: a codex install is cloud-hosted by default
+// (LiteLLM-proxied) but flips to BYO when `host === 'byo'` (sam-local-codex et
+// al.), so it's classified in isCloudRuntime() rather than by set membership.
+export const CLOUD_RUNTIME_TYPES = new Set<string>([
+  'moltbot',
+  'internal',
+  'native',
+  'managed-agents',
+]);
+
+/**
+ * Classify an install/provision runtime as cloud-hosted (gated) vs BYO (open).
+ * Pure function over the two fields the install record stores on
+ * `config.runtime`: `runtimeType` and `host`.
+ *
+ * Decision order is load-bearing:
+ *   1. `host: 'byo'` ALWAYS wins → NON-cloud. When a user points Commonly at
+ *      their own compute (laptop CLI wrapper, their own server polling CAP) the
+ *      install record carries `host: 'byo'`. That path must stay open to every
+ *      authenticated user regardless of `runtimeType`, so this is checked first.
+ *   2. `webhook` / `claude-code` are pure BYO runtime types (no Commonly-hosted
+ *      variant exists) → NON-cloud.
+ *   3. Anything in CLOUD_RUNTIME_TYPES (moltbot/internal/native/managed-agents)
+ *      → cloud.
+ *   4. `codex` with no `host: 'byo'` (handled in step 1) → cloud (LiteLLM-proxied).
+ *   5. Everything else (unknown / unspecified runtimeType, e.g. a generic
+ *      standalone marketplace agent that brings its own compute) → NON-cloud.
+ *      Callers that want a built-in cloud agent caught even when the install
+ *      omits an explicit runtimeType should resolve the effective runtimeType
+ *      from AGENT_TYPES first (getAgentTypeConfig(name)?.runtime).
+ */
+export function isCloudRuntime(
+  runtime: { runtimeType?: string | null; host?: string | null } | null | undefined,
+): boolean {
+  const runtimeType = String(runtime?.runtimeType || '').trim().toLowerCase();
+  const host = String(runtime?.host || '').trim().toLowerCase();
+  if (host === 'byo') return false;
+  if (runtimeType === 'webhook' || runtimeType === 'claude-code') return false;
+  if (CLOUD_RUNTIME_TYPES.has(runtimeType)) return true;
+  if (runtimeType === 'codex') return true;
+  return false;
+}
+
 // Legacy agent name mapping is intentionally disabled to avoid alias collisions.
 const LEGACY_AGENT_MAP: Record<string, string> = {
   'commonly-summarizer': 'commonly-bot',


### PR DESCRIPTION
Prerequisites to safely open registration later (you chose **stage it**). `registrationInviteOnly` is **unchanged** — this only builds the gate so open signup won't hand every new user free hosted compute. The BYO/local-agent path stays open to all authenticated users.

- **Taxonomy** (`agentIdentityService.isCloudRuntime` + `CLOUD_RUNTIME_TYPES`): single source of truth. `host:'byo'` always wins → non-cloud; webhook/claude-code are BYO; moltbot/internal/native/managed-agents + codex(non-byo) are cloud; unknown → non-cloud (open).
- **Entitlement**: `User.entitlements.cloudAgents` (default false); admins implicitly allowed.
- **Gates** (install.ts + provision.ts): cloud runtime ⇒ require admin OR entitlement, else `403 { code: 'cloud_agents_not_entitled' }`. install resolves effective runtimeType from `config.runtime` then falls back to `AGENT_TYPES[name].runtime` so built-in cloud agents are caught. BYO/webhook/claude-code/host:byo never gated.
- **Default pod on signup**: every new user gets a private 'My Workspace' pod so BYO onboarding has a target (best-effort; never fails registration).
- 4 test files (taxonomy, install-gate, provision-gate, default-pod) — 599 lines.

Follow-up: frontend marketplace cloud-vs-BYO visual distinction + 403 handling (#525-adjacent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)