### PR TITLE
fix(litellm): anti-pattern circuit-breakers for public exposure (per-key limits, request_timeout, bounded summarizer fan-out)

### DIFF
--- a/backend/services/agentProvisionerServiceK8s.ts
+++ b/backend/services/agentProvisionerServiceK8s.ts
@@ -42,6 +42,14 @@ const AGENT_TOLERATIONS = (() => {
   }];
 })();
 
+// LiteLLM per-key abuse circuit-breakers, stamped onto every issued virtual key.
+// These are NOT usage quotas — an agent's heartbeat makes sequential LLM calls, so
+// 4 parallel requests / 120 rpm is generous headroom for legitimate use. The caps
+// only trip on runaway flooding (e.g. a tight loop hammering the proxy), so a single
+// misbehaving agent can't monopolize the single-replica LiteLLM proxy.
+const LITELLM_KEY_MAX_PARALLEL_REQUESTS = 4;
+const LITELLM_KEY_RPM_LIMIT = 120;
+
 /**
  * Resolve OpenClaw account ID from agent name and instance ID
  */
@@ -1572,6 +1580,10 @@ const issueLiteLLMVirtualKey = async (agentId: any) => {
           'openrouter/nvidia/nemotron-3-super-120b-a12b:free',
           'nvidia/nemotron-3-super-120b-a12b:free',
         ],
+        // Abuse circuit-breakers — generous for legit sequential heartbeat use,
+        // trips only on runaway flooding (see constant comment).
+        max_parallel_requests: LITELLM_KEY_MAX_PARALLEL_REQUESTS,
+        rpm_limit: LITELLM_KEY_RPM_LIMIT,
         metadata: { agent_id: agentId, provisioned_at: new Date().toISOString() },
       },
       { headers },
@@ -1664,6 +1676,10 @@ const issueLiteLLMOpenRouterKey = async (agentId: any) => {
           'google/gemini-2.0-flash',
           'gemini-2.5-flash',
         ],
+        // Abuse circuit-breakers — generous for legit sequential heartbeat use,
+        // trips only on runaway flooding (see constant comment).
+        max_parallel_requests: LITELLM_KEY_MAX_PARALLEL_REQUESTS,
+        rpm_limit: LITELLM_KEY_RPM_LIMIT,
         metadata: { agent_id: agentId, key_type: 'openrouter', provisioned_at: new Date().toISOString() },
       },
       { headers },

--- a/backend/services/chatSummarizerService.ts
+++ b/backend/services/chatSummarizerService.ts
@@ -371,12 +371,25 @@ Focus on extracting meaningful insights, notable quotes, discussion pivots, and 
 
       console.log(`Found ${activePodIds.length} active chat pods`);
 
-      const summaryPromises = activePodIds.map((podId) => this.summarizePodMessages(podId).catch((error) => {
-        console.error(`Failed to summarize pod ${podId}:`, error);
-        return null;
-      }));
-
-      const summaries = await Promise.all(summaryPromises);
+      // Bounded fan-out. Each summary runs through LiteLLM on the shared master
+      // key (no per-key concurrency cap), and this previously fired Promise.all
+      // over EVERY active pod at once — the same unbounded fan-out that saturated
+      // the PG pool in the 2026-05-26 incident and floods the single-replica
+      // LiteLLM proxy. Process in fixed-size batches so all pods are still
+      // summarized, just rate-bounded.
+      const SUMMARY_CONCURRENCY = 5;
+      const summaries: unknown[] = [];
+      for (let i = 0; i < activePodIds.length; i += SUMMARY_CONCURRENCY) {
+        const batch = activePodIds.slice(i, i + SUMMARY_CONCURRENCY);
+        // eslint-disable-next-line no-await-in-loop
+        const batchResults = await Promise.all(
+          batch.map((podId) => this.summarizePodMessages(podId).catch((error) => {
+            console.error(`Failed to summarize pod ${podId}:`, error);
+            return null;
+          })),
+        );
+        summaries.push(...batchResults);
+      }
       const successfulSummaries = summaries.filter((summary) => summary !== null);
 
       console.log(`Successfully created ${successfulSummaries.length} chat summaries`);

--- a/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
+++ b/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
@@ -305,6 +305,12 @@ data:
     litellm_settings:
       # Drop unsupported params instead of erroring (important for OpenRouter quirks)
       drop_params: true
+      # Global upstream request timeout (seconds). Only the codex model entries set a
+      # per-model `timeout`; nemotron/gemini/openai/anthropic entries have none, so a
+      # hung non-codex upstream could otherwise pin a worker on this single-replica
+      # proxy indefinitely. This global cap bounds every request lacking a per-model
+      # timeout; it matches the codex per-model value (120s).
+      request_timeout: 120
       # Custom callback that writes /chatgpt-auth/rotate-now when any request hits a
       # rate limit. The codex-auth-rotator sidecar polls that file and rotates
       # accounts immediately (instead of waiting for its next scheduled tick).


### PR DESCRIPTION
Anti-pattern guardrails (circuit-breakers against runaway/flooding callers — NOT billing quotas) for opening to the public. Loop guards (#508) and the failover circuit-breaker (#527/#509) already exist; this closes the three real gaps a discovery pass found:

- **G1 — per-key circuit-breaker**: every issued LiteLLM virtual key now carries `max_parallel_requests: 4` + `rpm_limit: 120`, so one runaway agent can't monopolize the single-replica proxy. Generous for legit sequential heartbeat use; trips only on flooding. (Applies to newly issued keys; existing dev-agent keys backfill on next re-issue.)
- **G4 — global `request_timeout: 120`**: only codex models had a per-model timeout; a hung nemotron/gemini/openai/anthropic upstream could pin a worker indefinitely. Now bounded globally.
- **G2 — bounded summarizer fan-out**: the summarizer fired `Promise.all` over EVERY active pod at once (master key, no cap) — the 2026-05-26 PG-pool incident vector. Now batched (concurrency 5); all pods still summarized.

Follow-ups (deferred): dedicated capped platform key replacing master-key use (deeper G2), scale-gated aggregate-heartbeat cap (G3), content guardrails (G5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)