### PR TITLE
fix(auth): IP rate-limit /register /login /waitlist + lock #529 cloud gate with a test

### DIFF
--- a/backend/__tests__/service/install-cloud-gate.test.js
+++ b/backend/__tests__/service/install-cloud-gate.test.js
@@ -1,0 +1,176 @@
+/**
+ * #529 hosted-agent entitlement gate — regression lock.
+ *
+ * The open-registration prerequisite: installing a CLOUD (Commonly-hosted)
+ * runtime requires the installer to be an admin OR carry the `cloudAgents`
+ * entitlement. BYO runtimes (host:'byo', webhook, claude-code) stay open to
+ * every authenticated pod member.
+ *
+ * This test locks both halves of the gate so a future refactor can't silently
+ * either (a) start charging compute to every new signup or (b) lock legit
+ * BYO installs behind the entitlement.
+ *
+ * Gate lives in routes/registry/install.ts (~284) and consults
+ * agentIdentityService.isCloudRuntime.
+ */
+
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+const { setupMongoDb, closeMongoDb } = require('../utils/testUtils');
+
+const User = require('../../models/User');
+const Pod = require('../../models/Pod');
+const { AgentRegistry, AgentInstallation } = require('../../models/AgentRegistry');
+const AgentProfile = require('../../models/AgentProfile').default || require('../../models/AgentProfile');
+
+const registryRoutes = require('../../routes/registry');
+
+const JWT_SECRET = 'test-jwt-secret-cloud-gate';
+
+jest.setTimeout(60000);
+
+describe('#529 hosted-agent entitlement gate', () => {
+  let app;
+  let plainUser; // non-admin, non-entitled
+  let adminUser;
+  let entitledUser;
+  let plainToken;
+  let adminToken;
+  let entitledToken;
+  let pod;
+
+  const installAs = (token, body) => request(app)
+    .post('/api/registry/install')
+    .set('Authorization', `Bearer ${token}`)
+    .send(body);
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = JWT_SECRET;
+    await setupMongoDb();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/registry', registryRoutes);
+
+    plainUser = await User.create({
+      username: 'gate-plain',
+      email: 'gate-plain@test.com',
+      password: 'password123',
+    });
+    adminUser = await User.create({
+      username: 'gate-admin',
+      email: 'gate-admin@test.com',
+      password: 'password123',
+      role: 'admin',
+    });
+    entitledUser = await User.create({
+      username: 'gate-entitled',
+      email: 'gate-entitled@test.com',
+      password: 'password123',
+      entitlements: { cloudAgents: true },
+    });
+
+    plainToken = jwt.sign({ id: plainUser._id.toString() }, JWT_SECRET);
+    adminToken = jwt.sign({ id: adminUser._id.toString() }, JWT_SECRET);
+    entitledToken = jwt.sign({ id: entitledUser._id.toString() }, JWT_SECRET);
+
+    // All three are members so the pod-membership check passes and we exercise
+    // the entitlement gate specifically (not the 403 from non-membership).
+    pod = await Pod.create({
+      name: 'Cloud Gate Test Pod',
+      type: 'chat',
+      createdBy: plainUser._id,
+      members: [plainUser._id, adminUser._id, entitledUser._id],
+    });
+
+    // A published agent so getByName resolves (a non-webhook install with no
+    // manifest 404s before reaching the gate). The effective runtimeType is
+    // driven by the per-install config.runtime, not this manifest.
+    await AgentRegistry.create({
+      agentName: 'cloud-gate-bot',
+      displayName: 'Cloud Gate Bot',
+      description: 'Fixture agent for the entitlement-gate regression test.',
+      registry: 'commonly-community',
+      manifest: {
+        name: 'cloud-gate-bot',
+        version: '1.0.0',
+        capabilities: [],
+        context: { required: [] },
+        runtime: { type: 'standalone', connection: 'rest' },
+      },
+      latestVersion: '1.0.0',
+      versions: [{ version: '1.0.0', publishedAt: new Date() }],
+    });
+  });
+
+  afterAll(async () => {
+    await closeMongoDb();
+  });
+
+  beforeEach(async () => {
+    // Clear installs/profiles between cases so each can install into the same
+    // pod without tripping the "already installed" guard.
+    await AgentInstallation.deleteMany({});
+    await AgentProfile.deleteMany({});
+  });
+
+  it('blocks a non-admin, non-entitled user from installing a CLOUD runtime', async () => {
+    const res = await installAs(plainToken, {
+      agentName: 'cloud-gate-bot',
+      podId: pod._id.toString(),
+      config: { runtime: { runtimeType: 'internal' } },
+      scopes: [],
+    });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('cloud_agents_not_entitled');
+    // Gate fires before any install row is written.
+    const inst = await AgentInstallation.findOne({ agentName: 'cloud-gate-bot', podId: pod._id });
+    expect(inst).toBeNull();
+  });
+
+  it('allows the same user to install a BYO (host:byo) runtime', async () => {
+    const res = await installAs(plainToken, {
+      agentName: 'cloud-gate-bot',
+      podId: pod._id.toString(),
+      config: { runtime: { runtimeType: 'codex', host: 'byo' } },
+      scopes: [],
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('allows a non-entitled user to self-serve install a webhook (BYO) runtime', async () => {
+    const res = await installAs(plainToken, {
+      agentName: 'my-webhook-bot',
+      podId: pod._id.toString(),
+      config: { runtime: { runtimeType: 'webhook' } },
+      scopes: [],
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('allows an admin to install a CLOUD runtime', async () => {
+    const res = await installAs(adminToken, {
+      agentName: 'cloud-gate-bot',
+      podId: pod._id.toString(),
+      config: { runtime: { runtimeType: 'internal' } },
+      scopes: [],
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('allows an entitled (cloudAgents) user to install a CLOUD runtime', async () => {
+    const res = await installAs(entitledToken, {
+      agentName: 'cloud-gate-bot',
+      podId: pod._id.toString(),
+      config: { runtime: { runtimeType: 'moltbot' } },
+      scopes: [],
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});

--- a/backend/routes/auth.ts
+++ b/backend/routes/auth.ts
@@ -1,6 +1,12 @@
 // eslint-disable-next-line global-require
 const express = require('express');
 // eslint-disable-next-line global-require
+const rateLimit = require('express-rate-limit');
+// `ipKeyGenerator` normalises IPv6 addresses into a stable /64 bucket so a
+// single client can't dodge the limiter by rotating low-order v6 bits. Same
+// helper the uploads mint limiter uses (routes/uploads.ts).
+const { ipKeyGenerator } = rateLimit;
+// eslint-disable-next-line global-require
 const auth = require('../middleware/auth');
 // eslint-disable-next-line global-require
 const adminAuth = require('../middleware/adminAuth');
@@ -25,12 +31,58 @@ interface Res {
   json: (d: unknown) => void;
 }
 
+// Abuse rate-limiters for the unauthenticated public auth surface — added as a
+// pre-flight gate before open registration. IP-keyed (NAT'd users share a
+// bucket; acceptable for these low ceilings) and applied as the FIRST
+// middleware on each route so CodeQL's `js/missing-rate-limiting` query
+// recognises the guard. Skipped under NODE_ENV=test so the suites that hammer
+// these endpoints in tight loops don't get throttled. Mirrors the
+// install/uploads limiter shape (skip + ipKeyGenerator key + 429 handler).
+const ipKey = (req: { ip?: string }) => (req.ip ? ipKeyGenerator(req.ip) : 'anon');
+const rateLimitHandler = (message: string) => (_req: unknown, res: Res) =>
+  res.status(429).json({ message, code: 'rate_limited' });
+
+// Account creation is rare — 10/hour/IP blocks signup-spam while leaving room
+// for shared-IP households and the odd retry.
+const registerLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  keyGenerator: ipKey,
+  handler: rateLimitHandler('rate limit exceeded: 10 registrations per hour'),
+});
+
+// Credential-stuffing protection — 20/15min/IP is loose enough that a legit
+// user fat-fingering their password a few times isn't locked out.
+const loginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  keyGenerator: ipKey,
+  handler: rateLimitHandler('rate limit exceeded: 20 login attempts per 15 minutes'),
+});
+
+// Waitlist is a one-shot action per person — 5/hour/IP.
+const waitlistLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  keyGenerator: ipKey,
+  handler: rateLimitHandler('rate limit exceeded: 5 waitlist requests per hour'),
+});
+
 const router: ReturnType<typeof express.Router> = express.Router();
 
-router.post('/register', register);
+router.post('/register', registerLimiter, register);
 router.get('/registration-policy', getRegistrationPolicy);
-router.post('/waitlist', requestWaitlist);
-router.post('/login', login);
+router.post('/waitlist', waitlistLimiter, requestWaitlist);
+router.post('/login', loginLimiter, login);
 router.post('/refresh', auth, refresh);
 router.get('/user', auth, getCurrentUser);
 router.get('/verify-email', verifyEmail);


### PR DESCRIPTION
Pre-flight gate before opening public registration. Adds IP-keyed express-rate-limit (ipKeyGenerator, IPv6-safe) on the unauthenticated auth surface: register 10/hr, login 20/15min, waitlist 5/hr — each skipped under NODE_ENV=test, applied as first middleware (CodeQL-recognised), 429 `{code:rate_limited}`. Plus a service-tier regression test locking the #529 hosted-agent entitlement gate (non-admin/non-entitled → 403 cloud_agents_not_entitled on cloud install, 200 on BYO/webhook). Verified express-rate-limit v8 CJS exports ipKeyGenerator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)