### PR TITLE
feat(v2): surface BYO 'connect your own agent' path + graceful cloud-gate 403

### DIFF
--- a/frontend/src/components/agents/AgentsHub.tsx
+++ b/frontend/src/components/agents/AgentsHub.tsx
@@ -1154,8 +1154,20 @@ const AgentsHub = ({ currentPodId: propPodId = null }) => {
 
       const failures = results.filter((result) => result.status === 'rejected');
       if (failures.length > 0) {
-        const firstError = failures[0].reason?.response?.data?.error;
-        alert(firstError || `Failed to install on ${failures.length} pod(s).`);
+        const firstData = failures[0].reason?.response?.data;
+        // Cloud-gate refusal — route the user to the BYO flow instead of a
+        // dead-end "try again". The gate returns { code, message } with no
+        // `error` field, so detect on the code and prefer its message.
+        if (firstData?.code === 'cloud_agents_not_entitled') {
+          const msg = firstData.message
+            || 'Hosted agents require an upgrade or admin — connect your own agent instead.';
+          if (window.confirm(`${msg}\n\nConnect your own local agent now?`)) {
+            navigate('/v2/agents/byo');
+            return;
+          }
+        } else {
+          alert(firstData?.error || `Failed to install on ${failures.length} pod(s).`);
+        }
       }
 
       if (installPodIds.includes(selectedPodId)) {
@@ -1198,7 +1210,16 @@ const AgentsHub = ({ currentPodId: propPodId = null }) => {
       closeInstallDialog();
     } catch (err) {
       console.error('Error installing agent:', err);
-      alert(err.response?.data?.error || 'Failed to install agent');
+      const data = err.response?.data;
+      if (data?.code === 'cloud_agents_not_entitled') {
+        const msg = data.message
+          || 'Hosted agents require an upgrade or admin — connect your own agent instead.';
+        if (window.confirm(`${msg}\n\nConnect your own local agent now?`)) {
+          navigate('/v2/agents/byo');
+        }
+      } else {
+        alert(data?.error || 'Failed to install agent');
+      }
     } finally {
       setInstallSaving(false);
     }

--- a/frontend/src/v2/components/V2YourTeamPage.tsx
+++ b/frontend/src/v2/components/V2YourTeamPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import V2Avatar from './V2Avatar';
+import { useAuth } from '../../context/AuthContext';
 
 interface PodSummary {
   _id: string;
@@ -68,6 +69,17 @@ const dedupeAgents = (agents: AgentInstallationSummary[]): AgentInstallationSumm
 
 const V2YourTeamPage: React.FC = () => {
   const navigate = useNavigate();
+  const { user } = useAuth();
+  // Hosted (cloud) agents require an entitlement the open-registration tier
+  // doesn't have. Until the user payload carries an explicit `entitlements`
+  // flag we proxy on role==='admin' (see followups). Entitled users get the
+  // cloud catalog as their primary hire path; everyone else is routed to the
+  // BYO flow, which works for any account.
+  const isEntitled = useMemo(() => {
+    const entitlements = (user as { entitlements?: { cloudAgents?: boolean } } | null)?.entitlements;
+    return Boolean(entitlements?.cloudAgents) || user?.role === 'admin';
+  }, [user]);
+  const primaryHirePath = isEntitled ? '/v2/agents/browse' : '/v2/agents/byo';
   const [agents, setAgents] = useState<AgentInstallationSummary[]>([]);
   const [pods, setPods] = useState<PodSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -187,13 +199,22 @@ const V2YourTeamPage: React.FC = () => {
                 : `${sortedAgents.length} agent${sortedAgents.length === 1 ? '' : 's'} working across ${pods.length} project${pods.length === 1 ? '' : 's'}`}
           </p>
         </div>
-        <button
-          type="button"
-          className="v2-team__hire-cta"
-          onClick={() => navigate('/v2/agents/browse')}
-        >
-          + Hire an agent
-        </button>
+        <div className="v2-team__actions">
+          <button
+            type="button"
+            className="v2-team__hire-cta"
+            onClick={() => navigate(primaryHirePath)}
+          >
+            + Hire an agent
+          </button>
+          <button
+            type="button"
+            className="v2-team__byo-cta"
+            onClick={() => navigate('/v2/agents/byo')}
+          >
+            Connect your own agent
+          </button>
+        </div>
       </header>
 
       {error && (
@@ -205,14 +226,24 @@ const V2YourTeamPage: React.FC = () => {
           <div className="v2-team__empty-title">Build your AI team</div>
           <div className="v2-team__empty-text">
             Agents you hire join your projects, share your project memory, and ship work back to you.
+            Don&apos;t have a hosted agent? Connect your own — Claude Code, Cursor, or Codex — in about two minutes.
           </div>
-          <button
-            type="button"
-            className="v2-team__hire-cta"
-            onClick={() => navigate('/v2/agents/browse')}
-          >
-            + Hire your first agent
-          </button>
+          <div className="v2-team__empty-actions">
+            <button
+              type="button"
+              className="v2-team__hire-cta"
+              onClick={() => navigate(primaryHirePath)}
+            >
+              + Hire your first agent
+            </button>
+            <button
+              type="button"
+              className="v2-team__byo-cta"
+              onClick={() => navigate('/v2/agents/byo')}
+            >
+              Connect your own agent
+            </button>
+          </div>
         </div>
       )}
 

--- a/frontend/src/v2/marketplace/V2MarketplacePage.css
+++ b/frontend/src/v2/marketplace/V2MarketplacePage.css
@@ -112,6 +112,36 @@
   color: var(--v2-danger);
 }
 
+/* Cloud-entitlement gate — actionable, routes to BYO instead of dead-ending */
+.v2-mkt__gate {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: var(--v2-radius);
+  font-size: 13px;
+  margin-bottom: 16px;
+  background: var(--v2-accent-soft);
+  color: var(--v2-accent-text);
+  border: 1px solid var(--v2-accent, #4c52d8);
+}
+.v2-mkt__gate-text { flex: 1 1 240px; }
+.v2-mkt__gate .v2-mkt__gate-btn {
+  flex: 0 0 auto;
+  padding: 8px 14px;
+  border-radius: 8px;
+  background: var(--v2-accent, #4c52d8);
+  color: #fff;
+  border: none;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.v2-mkt__gate .v2-mkt__gate-btn:hover { background: var(--v2-accent-hover, #3d43c4); }
+
 /* Sections */
 .v2-mkt__section {
   margin-bottom: 32px;

--- a/frontend/src/v2/marketplace/V2MarketplacePage.tsx
+++ b/frontend/src/v2/marketplace/V2MarketplacePage.tsx
@@ -114,6 +114,10 @@ const V2MarketplacePage: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
+  // Set when an install is refused because the account lacks the cloud-agents
+  // entitlement. Rendered as an actionable banner pointing at the BYO flow,
+  // which works for any account — never the generic "try again" error.
+  const [gate, setGate] = useState<string | null>(null);
   const [busyId, setBusyId] = useState('');
 
   useEffect(() => {
@@ -215,6 +219,7 @@ const V2MarketplacePage: React.FC = () => {
     if (!selectedPodId) { setStatus('Pick a pod above to install into.'); return; }
     setBusyId(app.id);
     setStatus(null);
+    setGate(null);
     try {
       await axios.post('/api/registry/install', {
         agentName: String(app.installableId || app.id || ''),
@@ -226,7 +231,12 @@ const V2MarketplacePage: React.FC = () => {
       setStatus(`Installed ${app.displayName || app.name} into ${pods.find((p) => p._id === selectedPodId)?.name || 'pod'}.`);
       fetchInstalled();
     } catch (err: any) {
-      setStatus(err?.response?.data?.error || 'Could not install — try again.');
+      const data = err?.response?.data;
+      if (data?.code === 'cloud_agents_not_entitled') {
+        setGate(data.message || 'Hosted agents require an upgrade or admin — connect your own agent instead.');
+      } else {
+        setStatus(data?.error || 'Could not install — try again.');
+      }
     } finally {
       setBusyId('');
     }
@@ -393,6 +403,18 @@ const V2MarketplacePage: React.FC = () => {
       </div>
 
       {status && <div className="v2-mkt__status" role="status">{status}</div>}
+      {gate && (
+        <div className="v2-mkt__gate" role="alert">
+          <span className="v2-mkt__gate-text">{gate}</span>
+          <button
+            type="button"
+            className="v2-mkt__gate-btn"
+            onClick={() => navigate('/v2/agents/byo')}
+          >
+            Connect your own agent
+          </button>
+        </div>
+      )}
       {error && <div className="v2-mkt__error">{error}</div>}
 
       {tab === 'discover' ? (

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4336,6 +4336,33 @@
 .v2-root button.v2-team__hire-cta:hover { background: #3d43c4; }
 .v2-root button.v2-team__hire-cta:focus-visible { outline: 2px solid #4c52d8; outline-offset: 2px; }
 
+.v2-team__actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.v2-team__empty-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.v2-root button.v2-team__byo-cta {
+  background: transparent;
+  color: #4c52d8;
+  border: 1px solid #c7c9d4;
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.v2-root button.v2-team__byo-cta:hover { background: #f0f1fb; border-color: #4c52d8; }
+.v2-root button.v2-team__byo-cta:focus-visible { outline: 2px solid #4c52d8; outline-offset: 2px; }
+
 .v2-team__error {
   padding: 12px 14px;
   background: #fdf2f2;


### PR DESCRIPTION
Gives open-registered (non-entitled) users a real hero path. (1) Both marketplace + AgentsHub install handlers now detect the gate 403 `code:cloud_agents_not_entitled` and show an actionable "connect your own agent" prompt → /v2/agents/byo, instead of a generic error. (2) V2YourTeamPage gets a "Connect your own agent" CTA (header + empty state); the primary Hire CTA branches on entitlement (admin/entitled → cloud catalog; else → BYO). Entitlement proxied on role===admin (user payload has no entitlements flag yet — noted as follow-up). BYO/Hosted catalog badge skipped (browse payload omits runtime type — follow-up). V2NavRail untouched (mobile PR owns it).\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)