### PR TITLE
fix(v2): mobile pod-navigation drawer (phones could not switch pods)

### DIFF
--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -54,6 +54,12 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   const [inviteOpen, setInviteOpen] = useState(false);
   const openInvite = useCallback(() => setInviteOpen(true), []);
   const closeInvite = useCallback(() => setInviteOpen(false), []);
+  // Mobile (<=760px) pods drawer. The sidebar is a fixed slide-over on phones
+  // instead of a grid column; this owns its open/closed state. Desktop ignores
+  // it entirely (the sidebar is always a visible column there).
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const openMobileNav = useCallback(() => setMobileNavOpen(true), []);
+  const closeMobileNav = useCallback(() => setMobileNavOpen(false), []);
   const toggleInspector = useCallback(() => {
     setInspectorCollapsed((prev) => {
       const next = !prev;
@@ -101,9 +107,11 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   const clearPendingOpenFileName = useCallback(() => setPendingOpenFileName(null), []);
   const resetInspectorView = useCallback(() => setInspectorView({ kind: 'overview' }), []);
 
-  // When pod changes, drop any stale sub-page state.
+  // When pod changes, drop any stale sub-page state and close the mobile
+  // drawer (in case navigation came from somewhere other than a drawer tap).
   useEffect(() => {
     setInspectorView({ kind: 'overview' });
+    setMobileNavOpen(false);
   }, [paramPodId]);
 
   // Auto-pick the first pod when the user lands on /v2 directly, so the
@@ -124,8 +132,21 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
 
   return (
     <div className={shellClass}>
-      <V2NavRail />
-      <V2PodsSidebar selectedPodId={selectedPodId} podsState={podsState} />
+      <V2NavRail onPodsMobileNav={openMobileNav} />
+      {mobileNavOpen && (
+        <button
+          type="button"
+          className="v2-mobile-backdrop"
+          aria-label="Close pods list"
+          onClick={closeMobileNav}
+        />
+      )}
+      <V2PodsSidebar
+        selectedPodId={selectedPodId}
+        podsState={podsState}
+        mobileOpen={mobileNavOpen}
+        onMobileClose={closeMobileNav}
+      />
       <V2PodChat
         detail={detail}
         podsState={podsState}
@@ -134,6 +155,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
         onOpenMember={openInspectorMember}
         onOpenInvite={selectedPodId ? openInvite : undefined}
         onOpenFile={openInspectorByFileName}
+        onOpenMobileNav={openMobileNav}
       />
       {selectedPodId && !inspectorCollapsed && (
         <V2PodInspector

--- a/frontend/src/v2/components/V2NavRail.tsx
+++ b/frontend/src/v2/components/V2NavRail.tsx
@@ -27,7 +27,20 @@ const NAV_ITEMS: NavItem[] = [
   { key: 'settings', label: 'Settings', path: '/v2/settings', icon: <Icon d="M12 15a3 3 0 100-6 3 3 0 000 6zM19 12a7 7 0 00-.1-1.2l2-1.6-2-3.4-2.4 1a7 7 0 00-2-1.2L14 3h-4l-.5 2.6a7 7 0 00-2 1.2l-2.4-1-2 3.4 2 1.6A7 7 0 005 12c0 .4 0 .8.1 1.2l-2 1.6 2 3.4 2.4-1a7 7 0 002 1.2L10 21h4l.5-2.6a7 7 0 002-1.2l2.4 1 2-3.4-2-1.6c.1-.4.1-.8.1-1.2z" /> },
 ];
 
-const V2NavRail: React.FC = () => {
+interface V2NavRailProps {
+  // On phones (<=760px) the pods sidebar collapses to a slide-over drawer.
+  // When provided, tapping "Pods" opens that drawer instead of navigating to
+  // /v2 (which auto-redirects into the first pod and dead-ends the user in a
+  // single chat with no way back to the list). Undefined on surfaces without a
+  // drawer (feature pages) — those fall back to plain navigation.
+  onPodsMobileNav?: () => void;
+}
+
+const isMobileViewport = (): boolean => (
+  typeof window !== 'undefined' && !!window.matchMedia?.('(max-width: 760px)').matches
+);
+
+const V2NavRail: React.FC<V2NavRailProps> = ({ onPodsMobileNav }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { currentUser, logout } = useAuth();
@@ -37,6 +50,14 @@ const V2NavRail: React.FC = () => {
       return location.pathname === '/v2' || location.pathname.startsWith('/v2/pods');
     }
     return location.pathname.startsWith(item.path);
+  };
+
+  const handleNavClick = (item: NavItem) => {
+    if (item.key === 'pods' && onPodsMobileNav && isMobileViewport()) {
+      onPodsMobileNav();
+      return;
+    }
+    navigate(item.path);
   };
 
   return (
@@ -60,7 +81,7 @@ const V2NavRail: React.FC = () => {
               <button
                 type="button"
                 className={`v2-rail__item${isActive(item) ? ' v2-rail__item--active' : ''}`}
-                onClick={() => navigate(item.path)}
+                onClick={() => handleNavClick(item)}
                 title={item.label}
                 data-label={item.label}
               >

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -131,6 +131,10 @@ interface V2PodChatProps {
   // to V2MessageBubble → FilePill so the click opens the inspector
   // artifact preview instead of window.open()'ing a raw file in a new tab.
   onOpenFile?: (fileName: string) => void;
+  // Opens the mobile pods drawer (<=760px). The hamburger in the chat header
+  // is the primary way back to the pod list on phones, where the sidebar is
+  // an overlay rather than a visible column. Hidden via CSS on desktop.
+  onOpenMobileNav?: () => void;
 }
 
 const Icon = ({ d }: { d: string }) => (
@@ -139,7 +143,7 @@ const Icon = ({ d }: { d: string }) => (
   </svg>
 );
 
-const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onToggleInspector, onOpenMember, onOpenInvite, onOpenFile }) => {
+const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onToggleInspector, onOpenMember, onOpenInvite, onOpenFile, onOpenMobileNav }) => {
   const { pod, members, messages, agents, sendMessage, loading, error } = detail;
   const navigate = useNavigate();
   const api = useV2Api();
@@ -474,9 +478,31 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
     return [...humans, ...activeAgentMembers];
   }, [members, activeMemberAgentUsernames]);
 
+  // Mobile-only hamburger: opens the pods slide-over drawer. CSS hides it on
+  // desktop (>=761px) where the sidebar is a permanent column. Without it a
+  // phone user who lands in a pod chat has no way back to the pod list.
+  const mobileNavButton = onOpenMobileNav ? (
+    <button
+      type="button"
+      className="v2-chat__mobile-nav-btn"
+      onClick={onOpenMobileNav}
+      title="Show pods"
+      aria-label="Show pods list"
+    >
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M3 6h18M3 12h18M3 18h18" />
+      </svg>
+    </button>
+  ) : null;
+
   if (!pod) {
     return (
       <main className="v2-pane v2-pane--main">
+        {mobileNavButton && (
+          <div className="v2-chat__header">
+            <div className="v2-chat__header-row">{mobileNavButton}</div>
+          </div>
+        )}
         <div className="v2-empty">
           <div className="v2-empty__title">No pod selected</div>
           <div className="v2-empty__text">Pick a pod from the sidebar, or create a new one to get started.</div>
@@ -583,6 +609,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
       <div className="v2-chat">
         <header className="v2-chat__header">
           <div className="v2-chat__header-row">
+            {mobileNavButton}
             <div className="v2-chat__title">
               <span className="v2-chat__title-mark">{podMarkFor(pod.name, pod.type)}</span>
               <span className="v2-chat__title-text">{pod.name}</span>

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -72,9 +72,17 @@ const matchesFilter = (pod: V2Pod, filter: Filter): boolean => {
 interface V2PodsSidebarProps {
   selectedPodId: string | null;
   podsState?: UseV2PodsResult;
+  // Mobile (<=760px) slide-over drawer state. On phones the sidebar is a
+  // fixed overlay rather than a grid column; `mobileOpen` drives the
+  // open/closed transform and `onMobileClose` dismisses it (selecting a pod,
+  // creating one). Both no-ops on desktop where the sidebar is always visible.
+  mobileOpen?: boolean;
+  onMobileClose?: () => void;
 }
 
-const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({ selectedPodId, podsState }) => {
+const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
+  selectedPodId, podsState, mobileOpen = false, onMobileClose,
+}) => {
   const navigate = useNavigate();
   const ownPodsState = useV2Pods();
   const { pods, loading, error, createPod, patchLastMessage } = podsState || ownPodsState;
@@ -259,6 +267,13 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({ selectedPodId, podsState 
     return buckets;
   }, [filter, filtered, pinned]);
 
+  // Navigate to a pod and, on mobile, dismiss the slide-over drawer so the
+  // user lands directly in the chat instead of behind the overlay.
+  const selectPod = (podId: string) => {
+    navigate(`/v2/pods/${podId}`);
+    onMobileClose?.();
+  };
+
   const handleCreatePod = async (event: React.FormEvent) => {
     event.preventDefault();
     const name = newPodName.trim();
@@ -271,7 +286,7 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({ selectedPodId, podsState 
         setNewPodName('');
         setNewPodGoal('');
         setShowCreate(false);
-        navigate(`/v2/pods/${pod._id}`);
+        selectPod(pod._id);
       } else {
         setCreateError('Unable to create pod. Check that you are signed in and try again.');
       }
@@ -281,10 +296,23 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({ selectedPodId, podsState 
   };
 
   return (
-    <aside className="v2-pane">
+    <aside className={`v2-pane v2-pods-aside${mobileOpen ? ' v2-pods-aside--open' : ''}`}>
       <div className="v2-pods">
         <div className="v2-pods__header">
-          <div className="v2-pods__title">Pods</div>
+          <div className="v2-pods__title">
+            Pods
+            <button
+              type="button"
+              className="v2-pods__mobile-close"
+              onClick={() => onMobileClose?.()}
+              title="Close pods"
+              aria-label="Close pods list"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 6L6 18M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
           <button
             type="button"
             className="v2-pods__new-btn"
@@ -416,7 +444,7 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({ selectedPodId, podsState 
                     <button
                       type="button"
                       className={`v2-pods__item${active ? ' v2-pods__item--active' : ''}${unread ? ' v2-pods__item--unread' : ''}`}
-                      onClick={() => navigate(`/v2/pods/${pod._id}`)}
+                      onClick={() => selectPod(pod._id)}
                     >
                       <span className={podMarkClass(pod)}>
                         {podMarkFor(pod)}

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -282,6 +282,23 @@
   background: var(--v2-surface-tint);
 }
 
+/* Mobile pods-drawer affordances — hidden on desktop, where the pods sidebar
+   is a permanent grid column. The <=760px media query (bottom of file) turns
+   these on and converts .v2-pods-aside into a slide-over overlay. Declared
+   here so resizing a phone-open drawer up to desktop can't leak the overlay
+   or backdrop into the normal multi-column layout. */
+.v2-mobile-backdrop {
+  display: none;
+}
+
+.v2-chat__mobile-nav-btn {
+  display: none;
+}
+
+.v2-pods__mobile-close {
+  display: none;
+}
+
 /* ---------- Nav rail ---------- */
 
 .v2-rail {
@@ -4178,8 +4195,88 @@
     grid-template-columns: var(--v2-rail-w) minmax(0, 1fr);
   }
 
-  .v2-pane:not(.v2-pane--rail):not(.v2-pane--main) {
+  /* Hide secondary panes (e.g. the inspector) — but NOT the pods sidebar,
+     which becomes a slide-over drawer below. The extra :not() keeps the
+     drawer reachable instead of dead-ending the user in a single pod. */
+  .v2-pane:not(.v2-pane--rail):not(.v2-pane--main):not(.v2-pods-aside) {
     display: none;
+  }
+
+  /* Pods sidebar → slide-over drawer. Off-canvas by default; .--open slides
+     it in. Sits above the backdrop (z 60 vs 55). */
+  .v2-pods-aside {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 60;
+    width: min(86vw, 320px);
+    height: 100vh;
+    transform: translateX(-100%);
+    transition: transform 0.22s ease;
+    box-shadow: 2px 0 24px rgba(15, 17, 21, 0.18);
+    border-right: 1px solid var(--v2-border-soft);
+  }
+
+  .v2-pods-aside--open {
+    transform: translateX(0);
+  }
+
+  .v2-mobile-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 55;
+    border: none;
+    margin: 0;
+    padding: 0;
+    background: rgba(15, 17, 21, 0.42);
+    cursor: pointer;
+  }
+
+  /* Hamburger in the chat header — primary way back to the pod list. */
+  .v2-chat__mobile-nav-btn {
+    display: inline-grid;
+    place-items: center;
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    color: var(--v2-text-secondary);
+    border: 1px solid var(--v2-border);
+    border-radius: var(--v2-radius-sm);
+    background: var(--v2-surface);
+  }
+
+  .v2-chat__mobile-nav-btn:hover {
+    background: var(--v2-surface-hover);
+    color: var(--v2-text-primary);
+  }
+
+  /* Close (X) inside the drawer header. Title row becomes a flex row so the
+     X sits at the far end. Drop the fixed 32px height so the 44px tap target
+     fits. */
+  .v2-pods__title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: auto;
+    min-height: 44px;
+  }
+
+  .v2-pods__mobile-close {
+    display: inline-grid;
+    place-items: center;
+    width: 44px;
+    height: 44px;
+    margin-right: -8px;
+    color: var(--v2-text-secondary);
+    border: none;
+    background: transparent;
+    border-radius: var(--v2-radius-sm);
+  }
+
+  .v2-pods__mobile-close:hover {
+    background: var(--v2-surface-hover);
+    color: var(--v2-text-primary);
   }
 
   .v2-chat__header-row {


### PR DESCRIPTION
Fixes the critical mobile bug: at ≤760px the pods sidebar was display:none with no drawer/hamburger, and "Pods" auto-redirects into the first pod — so a phone user was stuck in one pod with no way to see/switch. Adds a slide-over pods drawer (backdrop-dismiss) toggled by a chat-header hamburger and by the rail "Pods" item on mobile (matchMedia-gated). All new styles are scoped under @media(max-width:760px) and the hamburger/backdrop default to display:none — desktop layout is unchanged by construction. ciTestHint: verify at 390px the drawer opens/closes + pod switch works; confirm desktop ≥761px unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)