### PR TITLE
feat(github): PR diff + review capability — commonly_pr_diff/commonly_pr_review + agent review (#441)

### DIFF
--- a/backend/commonly-bundled-skills/github/SKILL.md
+++ b/backend/commonly-bundled-skills/github/SKILL.md
@@ -12,6 +12,16 @@ which `gh` picks up automatically as `GH_TOKEN`.
 The active GitHub identity is **Team-Commonly bot identity** — anything you
 push, comment, or open will be attributed to that account.
 
+> **No shell? Don't use `gh`.** The `gh` examples below assume a real shell
+> (codex / claude-code runtimes). OpenClaw runtimes (theo/nova/pixel/ops) have
+> **no shell** and cannot run `gh` at all. For those agents:
+> - Read a PR diff: `web.fetch` the raw public diff at
+>   `https://patch-diff.githubusercontent.com/raw/Team-Commonly/commonly/pull/<N>.diff`.
+> - Post a review verdict: write it into the dev pod chat (read-only review).
+> - codex / claude-code runtimes should instead use the `commonly_pr_diff` /
+>   `commonly_pr_review` MCP tools, which read the diff and post the review
+>   **onto the PR**.
+
 ## Common operations
 
 ### Issues

--- a/backend/routes/github.ts
+++ b/backend/routes/github.ts
@@ -1,6 +1,8 @@
 // eslint-disable-next-line global-require
 const express = require('express');
 // eslint-disable-next-line global-require
+const rateLimit = require('express-rate-limit');
+// eslint-disable-next-line global-require
 const agentRuntimeAuth = require('../middleware/agentRuntimeAuth');
 // eslint-disable-next-line global-require
 const auth = require('../middleware/auth');
@@ -21,6 +23,22 @@ interface Res {
 
 const VALID_NAME = /^[a-zA-Z0-9_.-]+$/;
 const VALID_REVIEW_EVENTS = ['APPROVE', 'REQUEST_CHANGES', 'COMMENT'];
+
+// Per-route limiter on the PR endpoints — they proxy to the GitHub API (which
+// has its own abuse limits on our shared PAT), so bound callers here. Inlined so
+// CodeQL's js/missing-rate-limiting query recognises the guard; skipped under
+// NODE_ENV=test. Mirrors installRateLimit (routes/registry/install.ts).
+const githubPrRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  handler: (_req: unknown, res: Res) => res.status(429).json({
+    message: 'rate limit exceeded: 30 GitHub PR requests per 60s',
+    code: 'rate_limited',
+  }),
+});
 
 function anyAuth(req: AuthReq, res: Res, next: () => void) {
   const token = ((req.header?.('Authorization') || '').replace('Bearer ', ''));
@@ -133,7 +151,7 @@ router.post('/issues/:number/close', anyAuth, async (req: AuthReq, res: Res) => 
 
 // ─── Pull Requests ───────────────────────────────────────────────────────
 
-router.get('/pulls/:number/diff', anyAuth, async (req: AuthReq, res: Res) => {
+router.get('/pulls/:number/diff', githubPrRateLimit, anyAuth, async (req: AuthReq, res: Res) => {
   try {
     if (!GitHubAppService.isPatConfigured() && !GitHubAppService.isConfigured()) {
       return res.status(503).json({ error: 'No GitHub credentials configured' });
@@ -152,7 +170,7 @@ router.get('/pulls/:number/diff', anyAuth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.post('/pulls/:number/review', anyAuth, async (req: AuthReq, res: Res) => {
+router.post('/pulls/:number/review', githubPrRateLimit, anyAuth, async (req: AuthReq, res: Res) => {
   try {
     if (!GitHubAppService.isPatConfigured() && !GitHubAppService.isConfigured()) {
       return res.status(503).json({ error: 'No GitHub credentials configured' });

--- a/backend/routes/github.ts
+++ b/backend/routes/github.ts
@@ -20,6 +20,7 @@ interface Res {
 }
 
 const VALID_NAME = /^[a-zA-Z0-9_.-]+$/;
+const VALID_REVIEW_EVENTS = ['APPROVE', 'REQUEST_CHANGES', 'COMMENT'];
 
 function anyAuth(req: AuthReq, res: Res, next: () => void) {
   const token = ((req.header?.('Authorization') || '').replace('Bearer ', ''));
@@ -127,6 +128,49 @@ router.post('/issues/:number/close', anyAuth, async (req: AuthReq, res: Res) => 
     const e = err as { message?: string };
     console.error('POST /github/issues/close error:', e.message);
     return res.status(500).json({ error: 'Failed to close issue', detail: e.message });
+  }
+});
+
+// ─── Pull Requests ───────────────────────────────────────────────────────
+
+router.get('/pulls/:number/diff', anyAuth, async (req: AuthReq, res: Res) => {
+  try {
+    if (!GitHubAppService.isPatConfigured() && !GitHubAppService.isConfigured()) {
+      return res.status(503).json({ error: 'No GitHub credentials configured' });
+    }
+    const pullNumber = Number(req.params?.number);
+    if (!Number.isInteger(pullNumber) || pullNumber <= 0) return res.status(400).json({ error: 'Invalid pull number' });
+    const { owner = 'Team-Commonly', repo = 'commonly' } = (req.query || {}) as { owner?: string; repo?: string };
+    if (!VALID_NAME.test(owner) || !VALID_NAME.test(repo)) return res.status(400).json({ error: 'Invalid owner or repo' });
+    const diff = await GitHubAppService.getPullDiff({ owner, repo, pullNumber });
+    return res.json({ number: pullNumber, diff });
+  } catch (err) {
+    const e = err as { response?: { status?: number }; message?: string };
+    if (e.response?.status === 404) return res.status(404).json({ error: 'Pull request not found' });
+    console.error('GET /github/pulls/diff error:', e.message);
+    return res.status(500).json({ error: 'Failed to fetch pull diff', detail: e.message });
+  }
+});
+
+router.post('/pulls/:number/review', anyAuth, async (req: AuthReq, res: Res) => {
+  try {
+    if (!GitHubAppService.isPatConfigured() && !GitHubAppService.isConfigured()) {
+      return res.status(503).json({ error: 'No GitHub credentials configured' });
+    }
+    const pullNumber = Number(req.params?.number);
+    if (!Number.isInteger(pullNumber) || pullNumber <= 0) return res.status(400).json({ error: 'Invalid pull number' });
+    const { event, body, owner = 'Team-Commonly', repo = 'commonly' } = (req.body || {}) as { event?: string; body?: string; owner?: string; repo?: string };
+    if (!VALID_NAME.test(owner) || !VALID_NAME.test(repo)) return res.status(400).json({ error: 'Invalid owner or repo' });
+    if (!event || !VALID_REVIEW_EVENTS.includes(event)) return res.status(400).json({ error: 'event must be one of APPROVE, REQUEST_CHANGES, COMMENT' });
+    if (event !== 'APPROVE' && !body) return res.status(400).json({ error: 'body is required for REQUEST_CHANGES and COMMENT reviews' });
+    const review = await GitHubAppService.createPullReview({ owner, repo, pullNumber, event: event as 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT', body });
+    const r = review as { id?: number; state?: string; html_url?: string };
+    return res.status(201).json({ ok: true, id: r?.id, state: r?.state, url: r?.html_url });
+  } catch (err) {
+    const e = err as { response?: { status?: number }; message?: string };
+    if (e.response?.status === 404) return res.status(404).json({ error: 'Pull request not found' });
+    console.error('POST /github/pulls/review error:', e.message);
+    return res.status(500).json({ error: 'Failed to submit review', detail: e.message });
   }
 });
 

--- a/backend/routes/registry/presets.ts
+++ b/backend/routes/registry/presets.ts
@@ -1196,10 +1196,13 @@ Pick the highest-priority unblocked task (dep null or "done") that is NOT alread
 \`@codex Please implement TASK-NNN: <title>. <one-paragraph spec: files/area, acceptance criteria, tests expected>. Branch off ${DEFAULT_BRANCH}, run the tests, open a PR against ${DEFAULT_BRANCH}, and reply here with the PR URL.\`
 Add taskId to \`## DelegatedTasks\`. Cody (cloud-codex) is the only dev agent with a real shell — it clones, edits, tests, and opens the PR. Max 1 delegation per heartbeat.
 
-**Step 7: Review ONE delegated PR + track completions**
-For a "PR: <url>" Cody posted for a delegated task NOT yet reviewed:
-- Review at a coordination level: does it match the spec, is the scope tight, does the description show tests passing? Post a verdict + next step (1-3 sentences).
-- When a change needs deeper code-quality review, @mention \`@codex\` to review it or to address the specific concerns you raise.
+**Step 7: Review ONE delegated PR (read the REAL diff) + track completions**
+For a "PR: <url>" Cody posted for a delegated task NOT yet reviewed (extract the PR number N from the URL):
+- Fetch the ACTUAL changes — do NOT review from Cody's description alone:
+  - OpenClaw (you): \`web.fetch\` the raw public diff at \`https://patch-diff.githubusercontent.com/raw/Team-Commonly/commonly/pull/<N>.diff\` (the repo is public; this raw host avoids the github.com login redirect). Read-only — you post your verdict to the dev pod.
+  - codex / claude-code runtimes: prefer the \`commonly_pr_diff({ number: <N> })\` tool to read the diff, then \`commonly_pr_review({ number: <N>, event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT", body })\` to post the review directly ONTO the PR.
+- Review the real diff: does it match the spec, is the scope tight (no unrelated churn), are there obvious correctness/security issues, does the description show tests passing? Post a concrete verdict to the dev pod — ship / revise / specific issues found (cite file + line where you can), 1-4 sentences.
+- When a change needs deeper code-quality work, @mention \`@codex\` to address the specific concerns you raise.
 - Record the prUrl on the task's \`## DelegatedTasks\` entry.
 For child pod "✅ TASK-NNN" completions: note any unblocked dependents and reply briefly. For "❌ TASK-NNN blocked": reply with a suggested next step.
 

--- a/backend/services/githubAppService.ts
+++ b/backend/services/githubAppService.ts
@@ -49,6 +49,22 @@ interface CloseIssueOptions {
   comment?: string;
 }
 
+type PullReviewEvent = 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT';
+
+interface PullDiffOptions {
+  owner?: string;
+  repo?: string;
+  pullNumber: number;
+}
+
+interface PullReviewOptions {
+  owner?: string;
+  repo?: string;
+  pullNumber: number;
+  event: PullReviewEvent;
+  body?: string;
+}
+
 /**
  * GitHubAppService — generates short-lived installation access tokens
  * using a GitHub App's private key (RS256 JWT).
@@ -192,6 +208,40 @@ class GitHubAppService {
     const res = await axios.patch(
       `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}`,
       { state: 'closed' },
+      { headers },
+    );
+    return res.data;
+  }
+
+  // ─── Pull Requests API ─────────────────────────────────────────────────────
+
+  /**
+   * Fetch the raw unified diff for a pull request.
+   * Uses the `application/vnd.github.v3.diff` media type, which makes the
+   * `GET /repos/.../pulls/{n}` endpoint return the diff text instead of JSON.
+   */
+  static async getPullDiff({ owner = 'Team-Commonly', repo = 'commonly', pullNumber }: PullDiffOptions): Promise<string> {
+    const headers = await this._apiHeaders();
+    headers.Accept = 'application/vnd.github.v3.diff';
+    const res = await axios.get(
+      `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}`,
+      { headers },
+    );
+    return res.data as string;
+  }
+
+  /**
+   * Submit a review on a pull request.
+   * `event` is one of APPROVE | REQUEST_CHANGES | COMMENT. GitHub requires a
+   * non-empty `body` for REQUEST_CHANGES and COMMENT (the route enforces this).
+   */
+  static async createPullReview({ owner = 'Team-Commonly', repo = 'commonly', pullNumber, event, body }: PullReviewOptions): Promise<unknown> {
+    const headers = await this._apiHeaders();
+    const payload: Record<string, unknown> = { event };
+    if (body) payload.body = body;
+    const res = await axios.post(
+      `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/reviews`,
+      payload,
       { headers },
     );
     return res.data;

--- a/commonly-mcp/README.md
+++ b/commonly-mcp/README.md
@@ -53,12 +53,13 @@ Add to `~/.cursor/mcp.json` or `.cursor/mcp.json`:
 
 ## Tools
 
-16 `commonly_*` tools, grouped:
+19 `commonly_*` tools, grouped:
 
-- **Messaging** — `commonly_post_message`, `commonly_get_messages`, `commonly_get_context`, `commonly_get_posts`, `commonly_post_thread_comment`
+- **Messaging** — `commonly_post_message`, `commonly_get_messages`, `commonly_get_context`, `commonly_get_posts`, `commonly_post_thread_comment`, `commonly_react_to_message`
 - **Tasks** — `commonly_get_tasks`, `commonly_create_task`, `commonly_claim_task`, `commonly_complete_task`, `commonly_update_task`
 - **Pods + DMs** — `commonly_create_pod`, `commonly_dm_agent`
 - **Memory** — `commonly_read_agent_memory`, `commonly_write_agent_memory`, `commonly_save_my_memory`, `commonly_log_cycle`
+- **Code review** — `commonly_pr_diff`, `commonly_pr_review`
 
 Memory is pulled on demand — never injected as a prompt prefix. When a Commonly event delivers a mention with a memory delta, a one-line cue is prepended to the message body inviting the agent to call `commonly_read_agent_memory` if relevant. The agent decides. See [ADR-012](https://github.com/Team-Commonly/commonly/blob/main/docs/adr/ADR-012-memory-propagation.md).
 

--- a/commonly-mcp/__tests__/tools.test.mjs
+++ b/commonly-mcp/__tests__/tools.test.mjs
@@ -15,12 +15,13 @@ const tools = buildTools(cfg);
 const byName = Object.fromEntries(tools.map((t) => [t.name, t]));
 
 describe('tool registry shape', () => {
-  it('ships exactly the v1 surface (17 tools)', () => {
+  it('ships exactly the v1 surface (19 tools)', () => {
     // 14 tools (ADR-010 Phase 1) + 2 added in Phase 4 (commonly_save_my_memory,
     // commonly_log_cycle) so MCP-capable runtimes (Claude Code, Cursor, Codex
     // via wrapper) have the same memory write surface as the openclaw extension.
     // + 1 added by PR #389 (commonly_react_to_message).
-    expect(tools).toHaveLength(17);
+    // + 2 added for PR code review (commonly_pr_diff, commonly_pr_review, #441).
+    expect(tools).toHaveLength(19);
   });
 
   it('every tool has name, description, inputSchema, call', () => {
@@ -219,6 +220,47 @@ describe('commonly_dm_agent', () => {
     const result = await byName.commonly_dm_agent.call({ agentName: 'self' });
     expect(result.isError).toBe(true);
     expect(JSON.parse(result.content[0].text).message).toBe('Cannot DM yourself');
+  });
+});
+
+describe('commonly_pr_diff / commonly_pr_review', () => {
+  it('pr_diff GETs /api/github/pulls/:number/diff (number in path)', async () => {
+    const fetchSpy = installFetch(async () => okResponse({ number: 503, diff: 'diff --git ...' }));
+    const result = await byName.commonly_pr_diff.call({ number: 503 });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://x.example/api/github/pulls/503/diff');
+    expect(init.method).toBe('GET');
+    expect(JSON.parse(result.content[0].text).diff).toBe('diff --git ...');
+  });
+
+  it('pr_diff forwards owner/repo as query params', async () => {
+    const fetchSpy = installFetch(async () => okResponse({ number: 7, diff: '' }));
+    await byName.commonly_pr_diff.call({ number: 7, owner: 'acme', repo: 'widgets' });
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toContain('/api/github/pulls/7/diff?');
+    expect(url).toContain('owner=acme');
+    expect(url).toContain('repo=widgets');
+  });
+
+  it('pr_review POSTs event + body to /api/github/pulls/:number/review', async () => {
+    const fetchSpy = installFetch(async () => okResponse({ ok: true, state: 'COMMENTED' }));
+    await byName.commonly_pr_review.call({ number: 503, event: 'COMMENT', body: 'looks good' });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://x.example/api/github/pulls/503/review');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({
+      event: 'COMMENT', body: 'looks good', owner: undefined, repo: undefined,
+    });
+  });
+
+  it('pr_review surfaces a backend 400 as MCP isError', async () => {
+    installFetch(async () => ({
+      ok: false, status: 400,
+      text: async () => JSON.stringify({ message: 'event must be one of APPROVE, REQUEST_CHANGES, COMMENT' }),
+    }));
+    const result = await byName.commonly_pr_review.call({ number: 1, event: 'NOPE' });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).status).toBe(400);
   });
 });
 

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -12,8 +12,10 @@
  * isn't a 1:1 wrap of one CAP / dual-auth route.
  *
  * Invariant #2: every route here accepts `cm_agent_*` runtime tokens. CAP
- * routes (`/api/agents/runtime/*`) plus the dual-auth tasks surface
- * (`/api/v1/tasks/*`). NEVER target a human-JWT-only route.
+ * routes (`/api/agents/runtime/*`), the dual-auth tasks surface
+ * (`/api/v1/tasks/*`), and the dual-auth github surface (`/api/github/*`,
+ * which routes `cm_agent_*` through agentRuntimeAuth). NEVER target a
+ * human-JWT-only route.
  */
 
 import { request, HttpError } from './client.js';
@@ -296,6 +298,36 @@ export const buildTools = (config) => {
           body: { emoji },
         });
       }),
+    },
+    {
+      name: 'commonly_pr_diff',
+      description: 'Fetch the unified diff of a pull request (defaults to the Team-Commonly/commonly repo). Returns `{ number, diff }` where `diff` is the raw unified diff text. Use this to review the ACTUAL changes before posting a verdict — never review from the PR title/description alone. Pass `owner`/`repo` to target a different repo.',
+      inputSchema: reqWith({
+        number: INT,
+        owner: STRING,
+        repo: STRING,
+      }, ['number']),
+      call: wrap(async ({ number, owner, repo }) => request(config, {
+        method: 'GET',
+        path: `/api/github/pulls/${encodeURIComponent(number)}/diff`,
+        query: { owner, repo },
+      })),
+    },
+    {
+      name: 'commonly_pr_review',
+      description: 'Submit a code review ONTO a pull request — it posts to GitHub and is visible on the PR (defaults to Team-Commonly/commonly). `event` is APPROVE | REQUEST_CHANGES | COMMENT; `body` is the review markdown and is required for REQUEST_CHANGES and COMMENT. Fetch the diff with commonly_pr_diff first and base the review on the real changes. Pass `owner`/`repo` to target a different repo.',
+      inputSchema: reqWith({
+        number: INT,
+        event: STRING,
+        body: STRING,
+        owner: STRING,
+        repo: STRING,
+      }, ['number', 'event']),
+      call: wrap(async ({ number, event, body, owner, repo }) => request(config, {
+        method: 'POST',
+        path: `/api/github/pulls/${encodeURIComponent(number)}/review`,
+        body: { event, body, owner, repo },
+      })),
     },
   ];
 };


### PR DESCRIPTION
Closes #441. Gives agents real diff-level PR review. Backend: GitHubAppService.getPullDiff (vnd.github.v3.diff) + createPullReview (APPROVE/REQUEST_CHANGES/COMMENT) + auth-gated routes GET /github/pulls/:n/diff and POST /github/pulls/:n/review (event-enum + body-required validation, 503/404 handling, owner/repo sanitized). Shipping MCP gets commonly_pr_diff + commonly_pr_review (with tests) so codex/Claude-Code runtimes can review onto the PR. Presets: Theo now fetches the public .diff via web.fetch and posts a real verdict (OpenClaw has no shell). Corrected the bundled github skill.

Follow-up: add commonly_pr_diff/commonly_pr_review to the Team-Commonly/openclaw fork so OpenClaw agents post reviews onto the PR (currently verdict-to-chat via web.fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)