### PR TITLE
feat(showcase): hardened public read-only API (dedicated endpoint, noise-filter, no generic-route relax)

### DIFF
--- a/backend/__tests__/service/showcase.test.js
+++ b/backend/__tests__/service/showcase.test.js
@@ -1,0 +1,302 @@
+const request = require('supertest');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const User = require('../../models/User');
+const Pod = require('../../models/Pod');
+const Message = require('../../models/Message');
+const showcaseRoutes = require('../../routes/showcase');
+const adminPodsRoutes = require('../../routes/admin/pods');
+const podRoutes = require('../../routes/pods');
+const messageRoutes = require('../../routes/messages');
+const contextApiRoutes = require('../../routes/contextApi');
+const {
+  setupMongoDb,
+  closeMongoDb,
+  clearMongoDb,
+} = require('../utils/testUtils');
+
+const { isShowcaseWorthy } = showcaseRoutes;
+
+describe('Showcase (public read-only) routes', () => {
+  let app;
+  let adminToken;
+  let memberToken;
+  let adminUser;
+  let humanUser;
+  let botUser;
+  let publicPod;
+  let privatePod;
+  let personalPod;
+  // A real-but-nonexistent ObjectId — must 404 the SAME way a private pod does.
+  const missingPodId = '0123456789abcdef01234567';
+
+  beforeAll(async () => {
+    await setupMongoDb();
+    process.env.JWT_SECRET = 'test-jwt-secret';
+
+    app = express();
+    app.use(express.json());
+
+    // Showcase mounted WITHOUT auth (it self-gates on publicRead).
+    app.use('/api/showcase', showcaseRoutes);
+    app.use('/api/admin/pods', adminPodsRoutes);
+    // Generic routes keep their internal auth — used for the regression check.
+    app.use('/api/pods', podRoutes);
+    app.use('/api/messages', messageRoutes);
+    app.use('/api/v1', contextApiRoutes);
+
+    adminUser = new User({
+      username: 'showcaseadmin',
+      email: 'showcase-admin@test.com',
+      password: 'Password123!',
+      isVerified: true,
+      role: 'admin',
+    });
+    await adminUser.save();
+
+    humanUser = new User({
+      username: 'showcasehuman',
+      email: 'showcase-human@test.com',
+      password: 'Password123!',
+      isVerified: true,
+    });
+    await humanUser.save();
+
+    botUser = new User({
+      username: 'openclaw-pixel',
+      email: 'bot-pixel@test.com',
+      password: 'Password123!',
+      isBot: true,
+      botMetadata: { displayName: 'Pixel', agentName: 'openclaw', instanceId: 'pixel' },
+    });
+    await botUser.save();
+
+    adminToken = jwt.sign({ id: adminUser._id }, process.env.JWT_SECRET, { expiresIn: '1h' });
+    memberToken = jwt.sign({ id: humanUser._id }, process.env.JWT_SECRET, { expiresIn: '1h' });
+
+    publicPod = new Pod({
+      name: 'Public Showcase Pod',
+      description: 'A pod on display',
+      type: 'team',
+      createdBy: humanUser._id,
+      members: [humanUser._id, botUser._id],
+      publicRead: true,
+    });
+    await publicPod.save();
+
+    privatePod = new Pod({
+      name: 'Private Pod',
+      type: 'team',
+      createdBy: humanUser._id,
+      members: [humanUser._id],
+      publicRead: false,
+    });
+    await privatePod.save();
+
+    personalPod = new Pod({
+      name: 'Agent Room',
+      type: 'agent-room',
+      createdBy: humanUser._id,
+      members: [humanUser._id, botUser._id],
+    });
+    await personalPod.save();
+
+    // Seed messages in the public pod: two substantive + four noise.
+    await Message.create({
+      podId: publicPod._id,
+      userId: humanUser._id,
+      content: 'Hello team, here is the plan for launch day.',
+      messageType: 'text',
+      createdAt: new Date('2026-01-01T00:00:01Z'),
+    });
+    await Message.create({
+      podId: publicPod._id,
+      userId: botUser._id,
+      content: 'I drafted the quarterly summary with three key findings.',
+      messageType: 'text',
+      createdAt: new Date('2026-01-01T00:00:02Z'),
+    });
+    // Noise: system message.
+    await Message.create({
+      podId: publicPod._id,
+      userId: humanUser._id,
+      content: 'showcasehuman joined the pod',
+      messageType: 'system',
+      createdAt: new Date('2026-01-01T00:00:03Z'),
+    });
+    // Noise: NO_REPLY sentinel.
+    await Message.create({
+      podId: publicPod._id,
+      userId: botUser._id,
+      content: 'NO_REPLY',
+      messageType: 'text',
+      createdAt: new Date('2026-01-01T00:00:04Z'),
+    });
+    // Noise: whitespace-only content.
+    await Message.create({
+      podId: publicPod._id,
+      userId: botUser._id,
+      content: '   ',
+      messageType: 'text',
+      createdAt: new Date('2026-01-01T00:00:05Z'),
+    });
+    // Noise: runtime model-failure / error content.
+    await Message.create({
+      podId: publicPod._id,
+      userId: botUser._id,
+      content: '⚠️ Agent failed before reply: All models failed (4): openrouter/x: 401',
+      messageType: 'text',
+      createdAt: new Date('2026-01-01T00:00:06Z'),
+    });
+  });
+
+  afterAll(async () => {
+    await clearMongoDb();
+    await closeMongoDb();
+  });
+
+  describe('GET /api/showcase/:podId', () => {
+    it('returns 200 with whitelisted pod + members for a public pod (anon)', async () => {
+      const res = await request(app).get(`/api/showcase/${publicPod._id}`);
+      expect(res.status).toBe(200);
+      expect(res.body.pod).toMatchObject({
+        id: publicPod._id.toString(),
+        name: 'Public Showcase Pod',
+        type: 'team',
+        memberCount: 2,
+      });
+      expect(Array.isArray(res.body.members)).toBe(true);
+      expect(res.body.members.length).toBe(2);
+      // Agent identity surfaced.
+      expect(res.body.agents.length).toBe(1);
+      expect(res.body.agents[0]).toMatchObject({ displayName: 'Pixel', agentName: 'openclaw', instanceId: 'pixel' });
+    });
+
+    it('NEVER leaks an email field anywhere in the response', async () => {
+      const res = await request(app).get(`/api/showcase/${publicPod._id}`);
+      const blob = JSON.stringify(res.body);
+      expect(blob).not.toMatch(/email/i);
+      expect(blob).not.toContain('@test.com');
+    });
+
+    it('returns 404 for a private (publicRead=false) pod — no oracle', async () => {
+      const res = await request(app).get(`/api/showcase/${privatePod._id}`);
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({ error: 'Not found' });
+    });
+
+    it('returns the SAME 404 for a missing pod as for a private one', async () => {
+      const res = await request(app).get(`/api/showcase/${missingPodId}`);
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({ error: 'Not found' });
+    });
+
+    it('returns 404 for a non-ObjectId podId', async () => {
+      const res = await request(app).get('/api/showcase/not-an-id');
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({ error: 'Not found' });
+    });
+  });
+
+  describe('GET /api/showcase/:podId/messages', () => {
+    it('returns filtered, whitelisted messages for a public pod (anon)', async () => {
+      const res = await request(app).get(`/api/showcase/${publicPod._id}/messages`);
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('hasMore');
+      const contents = res.body.messages.map((m) => m.content);
+      // Two substantive turns kept...
+      expect(contents).toContain('Hello team, here is the plan for launch day.');
+      expect(contents).toContain('I drafted the quarterly summary with three key findings.');
+      // ...all four noise turns dropped.
+      expect(contents).not.toContain('NO_REPLY');
+      expect(contents).not.toContain('showcasehuman joined the pod');
+      expect(contents.some((c) => c.includes('All models failed'))).toBe(false);
+      expect(res.body.messages.length).toBe(2);
+      // Author whitelist — no email leaked.
+      expect(JSON.stringify(res.body)).not.toMatch(/email|@test\.com/i);
+      const botMsg = res.body.messages.find((m) => m.author.isBot);
+      expect(botMsg.author.displayName).toBe('Pixel');
+    });
+
+    it('returns 404 for a private pod', async () => {
+      const res = await request(app).get(`/api/showcase/${privatePod._id}/messages`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('isShowcaseWorthy noise-filter predicate', () => {
+    it('keeps a real human/agent turn', () => {
+      expect(isShowcaseWorthy({ content: 'Here is the report.', messageType: 'text' })).toBe(true);
+    });
+    it('drops empty / whitespace-only content', () => {
+      expect(isShowcaseWorthy({ content: '   ', messageType: 'text' })).toBe(false);
+      expect(isShowcaseWorthy({ content: '', messageType: 'text' })).toBe(false);
+    });
+    it('drops NO_REPLY sentinels', () => {
+      expect(isShowcaseWorthy({ content: 'NO_REPLY', messageType: 'text' })).toBe(false);
+    });
+    it('drops system messages', () => {
+      expect(isShowcaseWorthy({ content: 'x joined', messageType: 'system' })).toBe(false);
+    });
+    it('drops heartbeat / error / failover cruft', () => {
+      expect(isShowcaseWorthy({ content: 'HEARTBEAT_OK', messageType: 'text' })).toBe(false);
+      expect(isShowcaseWorthy({ content: 'Error reading the pod context', messageType: 'text' })).toBe(false);
+      expect(isShowcaseWorthy({ content: 'All models failed (3): foo: 429', messageType: 'text' })).toBe(false);
+    });
+  });
+
+  describe('REGRESSION: generic routes stay auth-gated (showcase did not relax them)', () => {
+    it('anon GET /api/pods/:id is rejected (no anon access)', async () => {
+      const res = await request(app).get(`/api/pods/${publicPod._id}`);
+      expect([401, 403]).toContain(res.status);
+    });
+    it('anon GET /api/messages/:podId is 401', async () => {
+      const res = await request(app).get(`/api/messages/${publicPod._id}`);
+      expect(res.status).toBe(401);
+    });
+    it('anon GET a memory endpoint is 401', async () => {
+      const res = await request(app).get(`/api/v1/pods/${publicPod._id}/memory/HEARTBEAT.md`);
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/admin/pods/:podId/showcase (admin toggle)', () => {
+    it('requires admin (403 for a non-admin member)', async () => {
+      const res = await request(app)
+        .post(`/api/admin/pods/${privatePod._id}/showcase`)
+        .set('Authorization', `Bearer ${memberToken}`)
+        .send({ publicRead: true });
+      expect(res.status).toBe(403);
+    });
+
+    it('400s on a personal pod type (agent-room)', async () => {
+      const res = await request(app)
+        .post(`/api/admin/pods/${personalPod._id}/showcase`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ publicRead: true });
+      expect(res.status).toBe(400);
+      // And the pod must NOT have been flipped.
+      const reloaded = await Pod.findById(personalPod._id);
+      expect(reloaded.publicRead).toBe(false);
+    });
+
+    it('400s when publicRead is not a boolean', async () => {
+      const res = await request(app)
+        .post(`/api/admin/pods/${privatePod._id}/showcase`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ publicRead: 'yes' });
+      expect(res.status).toBe(400);
+    });
+
+    it('flips publicRead for a normal pod as admin', async () => {
+      const res = await request(app)
+        .post(`/api/admin/pods/${privatePod._id}/showcase`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ publicRead: true });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ id: privatePod._id.toString(), publicRead: true });
+      const reloaded = await Pod.findById(privatePod._id);
+      expect(reloaded.publicRead).toBe(true);
+    });
+  });
+});

--- a/backend/models/AuditLog.ts
+++ b/backend/models/AuditLog.ts
@@ -16,6 +16,12 @@ import mongoose, { Document, Schema, Types } from 'mongoose';
 export interface IAuditLog extends Document {
   action: string;
   fileName?: string;
+  // Generic target identifier for actions that aren't file-scoped (e.g. the
+  // showcase publish toggle records the podId here). Added as the 2nd audit
+  // use case; keep it free-form so future audit actions can reuse it.
+  target?: string;
+  // Optional free-form detail (e.g. the new value of a toggled flag).
+  detail?: string;
   userId?: Types.ObjectId;
   ip?: string;
   userAgent?: string;
@@ -25,6 +31,8 @@ export interface IAuditLog extends Document {
 const auditLogSchema = new Schema<IAuditLog>({
   action: { type: String, required: true, index: true },
   fileName: { type: String, default: null },
+  target: { type: String, default: null },
+  detail: { type: String, default: null },
   userId: { type: Schema.Types.ObjectId, ref: 'User', default: null },
   ip: { type: String, default: null },
   userAgent: { type: String, default: null },

--- a/backend/models/Pod.ts
+++ b/backend/models/Pod.ts
@@ -58,6 +58,11 @@ export interface IPod extends Document {
   // `@codex` to a specific installed agent. Stored as a Mongo Map so reads
   // are O(1) and unset rows return an empty Map by default.
   contacts?: Map<string, PodContactBinding>;
+  // Admin-set only — when true this pod is anonymously readable via the
+  // dedicated /api/showcase endpoints (and ONLY those). Never set on a
+  // personal pod type (agent-dm / agent-room / agent-admin); the admin
+  // toggle rejects those. Defaults false so every existing pod is private.
+  publicRead: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -123,6 +128,9 @@ const PodSchema = new Schema<IPod>(
       }, { _id: false }),
       default: () => new Map(),
     },
+    // Admin-set only; never on personal pod types. Gates the anonymous
+    // /api/showcase read path. See backend/routes/showcase.ts.
+    publicRead: { type: Boolean, default: false },
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now },
   },

--- a/backend/routes/admin/pods.ts
+++ b/backend/routes/admin/pods.ts
@@ -7,6 +7,8 @@ const auth = require('../../middleware/auth');
 const adminAuth = require('../../middleware/adminAuth');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const Pod = require('../../models/Pod');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const AuditLog = require('../../models/AuditLog');
 
 const router = express.Router();
 
@@ -17,6 +19,14 @@ const PERSONAL_POD_TYPES = new Set(['agent-dm', 'agent-room', 'agent-admin']);
 // POST /api/admin/pods/:podId/showcase  { publicRead: boolean }
 // Admin-only toggle for the anonymous showcase read path. Rejects personal
 // pod types so a private DM can never be flipped public.
+//
+// ⚠️ OPERATIONAL WARNING (security review F3): flipping publicRead=true makes
+// this pod's conversation WORLD-READABLE — not a frozen snapshot, but every
+// current AND future message anyone/any agent posts to it. The showcase
+// noise-filter strips errors/cruft, NOT secrets — it is a quality filter, not
+// a redactor. Only ever publish a deliberately curated demo pod with no
+// secrets/PII and consenting members. Treat this toggle as "this room is now
+// public forever, including everything said in it from now on."
 router.post(
   '/:podId/showcase',
   auth,
@@ -42,6 +52,21 @@ router.post(
 
       pod.publicRead = publicRead;
       await pod.save();
+
+      // Audit the world-readable state change (security review F6): who/when/
+      // which pod/new value. Best-effort — never fail the toggle on audit error.
+      try {
+        await AuditLog.create({
+          action: publicRead ? 'showcase.publish' : 'showcase.unpublish',
+          target: pod._id.toString(),
+          detail: `publicRead=${publicRead} type=${pod.type}`,
+          userId: req.userId || req.user?.id,
+          ip: req.ip,
+          userAgent: req.headers?.['user-agent'],
+        });
+      } catch (auditErr) {
+        console.warn('[admin/pods] audit log write failed (non-fatal):', (auditErr as Error).message);
+      }
 
       return res.json({ id: pod._id.toString(), publicRead: pod.publicRead });
     } catch (err) {

--- a/backend/routes/admin/pods.ts
+++ b/backend/routes/admin/pods.ts
@@ -1,0 +1,54 @@
+export {};
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const express = require('express');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const auth = require('../../middleware/auth');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const adminAuth = require('../../middleware/adminAuth');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Pod = require('../../models/Pod');
+
+const router = express.Router();
+
+// Personal / DM pod types that must NEVER be published to the public
+// showcase, regardless of admin intent. A 1:1 DM is private by definition.
+const PERSONAL_POD_TYPES = new Set(['agent-dm', 'agent-room', 'agent-admin']);
+
+// POST /api/admin/pods/:podId/showcase  { publicRead: boolean }
+// Admin-only toggle for the anonymous showcase read path. Rejects personal
+// pod types so a private DM can never be flipped public.
+router.post(
+  '/:podId/showcase',
+  auth,
+  adminAuth,
+  async (req: any, res: any) => {
+    try {
+      const { podId } = req.params;
+      const { publicRead } = req.body || {};
+      if (typeof publicRead !== 'boolean') {
+        return res.status(400).json({ error: 'publicRead (boolean) is required' });
+      }
+
+      const pod = await Pod.findById(podId);
+      if (!pod) {
+        return res.status(404).json({ error: 'Pod not found' });
+      }
+
+      if (PERSONAL_POD_TYPES.has(String(pod.type))) {
+        return res.status(400).json({
+          error: `Cannot publish a personal pod type (${pod.type}) to the public showcase`,
+        });
+      }
+
+      pod.publicRead = publicRead;
+      await pod.save();
+
+      return res.json({ id: pod._id.toString(), publicRead: pod.publicRead });
+    } catch (err) {
+      console.error('[admin/pods] showcase toggle error:', (err as Error).message);
+      return res.status(500).json({ error: 'Server Error' });
+    }
+  },
+);
+
+module.exports = router;

--- a/backend/routes/admin/pods.ts
+++ b/backend/routes/admin/pods.ts
@@ -2,6 +2,8 @@ export {};
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const express = require('express');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
+const rateLimit = require('express-rate-limit');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const auth = require('../../middleware/auth');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const adminAuth = require('../../middleware/adminAuth');
@@ -11,6 +13,18 @@ const Pod = require('../../models/Pod');
 const AuditLog = require('../../models/AuditLog');
 
 const router = express.Router();
+
+// Inlined limiter so CodeQL's js/missing-rate-limiting recognises the guard on
+// this DB-touching admin route; skipped under NODE_ENV=test. Admin-gated, so
+// this is defense-in-depth, not the primary control.
+const adminPodsRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  handler: (_req: any, res: any) => res.status(429).json({ error: 'rate_limited' }),
+});
 
 // Personal / DM pod types that must NEVER be published to the public
 // showcase, regardless of admin intent. A 1:1 DM is private by definition.
@@ -29,6 +43,7 @@ const PERSONAL_POD_TYPES = new Set(['agent-dm', 'agent-room', 'agent-admin']);
 // public forever, including everything said in it from now on."
 router.post(
   '/:podId/showcase',
+  adminPodsRateLimit,
   auth,
   adminAuth,
   async (req: any, res: any) => {

--- a/backend/routes/showcase.ts
+++ b/backend/routes/showcase.ts
@@ -114,13 +114,17 @@ router.use(showcaseRateLimit);
 // SAME 404 for "missing" and "not public" so there's no existence oracle.
 const loadPublicPod = async (podId: string | undefined) => {
   if (!podId || !mongoose.Types.ObjectId.isValid(podId)) return null;
-  const pod = await Pod.findById(podId).populate(
+  // Gate on publicRead BEFORE the members populate so a private/non-existent
+  // pod does exactly one query — otherwise the extra populate query is a
+  // timing side-channel that reveals "a pod exists at this id".
+  const pod = await Pod.findById(podId);
+  if (!pod || pod.publicRead !== true) return null;
+  await pod.populate(
     'members',
     // Whitelist — NEVER email. botMetadata carries only display identity
     // (displayName / agentName / instanceId), no secrets.
     'username profilePicture isBot botMetadata',
   );
-  if (!pod || pod.publicRead !== true) return null;
   return pod;
 };
 

--- a/backend/routes/showcase.ts
+++ b/backend/routes/showcase.ts
@@ -1,0 +1,310 @@
+/**
+ * Public read-only showcase — the launch front-door.
+ *
+ * SECURITY-CRITICAL. This is the ONLY anonymous (unauthenticated) read path
+ * in the API, and it is hard-gated: it serves exactly ONE flagged pod
+ * (`pod.publicRead === true`) and nothing else. It is mounted WITHOUT the
+ * auth middleware on purpose — every handler self-gates on `publicRead`.
+ *
+ * Invariants defended here:
+ *   - GET-only, no side effects.
+ *   - Same 404 for "pod missing" and "pod not public" — no existence oracle.
+ *   - Whitelisted serialization: NEVER email, memory, persona/skills, or any
+ *     field beyond the SHARED API CONTRACT shape.
+ *   - Messages pass through the NOISE-FILTER (isShowcaseWorthy) so the public
+ *     view is substantive human + agent turns only — no errors / heartbeat
+ *     cruft / failover spam / empty turns.
+ *   - IP-keyed rate limit as the FIRST middleware to blunt scraping.
+ *
+ * It does NOT relax auth on any generic route; it is a dedicated endpoint.
+ */
+
+// ESM import (not require) so CodeQL's js/missing-rate-limiting query
+// recognises the limiter on the router — same pattern as routes/uploads.ts.
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const express = require('express');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mongoose = require('mongoose');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Pod = require('../models/Pod');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const User = require('../models/User');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const MongoMessage = require('../models/Message');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const PGMessage = require('../models/pg/Message');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const AgentMessageService = require('../services/agentMessageService');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { resolveAgentDisplayLabel } = require('../services/agentIdentityService');
+
+interface Res {
+  status: (n: number) => Res;
+  json: (d: unknown) => Res | void;
+}
+interface Req {
+  ip?: string;
+  params?: { podId?: string };
+  query?: { limit?: string; before?: string };
+}
+
+// ── NOISE-FILTER ──────────────────────────────────────────────────────────
+// Public view must be clean — "not full of errors and bs". Drop any message
+// that isn't a substantive turn. Conservative by design: when unsure, hide.
+//
+// Markers (sourced from the live message pipeline, not invented here):
+//   - empty / whitespace-only content
+//   - system messages (messageType/message_type === 'system' — join/leave,
+//     install banners, etc.)
+//   - NO_REPLY sentinels (silent-turn marker the runtimes emit)
+//   - heartbeat housekeeping cruft (AgentMessageService.isHeartbeatHousekeepingContent
+//     — "HEARTBEAT_OK", "no new activity to report", "let me try a different
+//     approach", etc.)
+//   - runtime model-failure / failover errors (AgentMessageService.isRuntimeModelFailure
+//     — "⚠️ Agent failed before reply: All models failed ...")
+//   - generic error / stack-trace content (AgentMessageService.isErrorContent)
+//
+// Exported for unit testing.
+interface ShowcaseMessageLike {
+  content?: unknown;
+  messageType?: unknown;
+  message_type?: unknown;
+}
+function isShowcaseWorthy(message: ShowcaseMessageLike): boolean {
+  if (!message) return false;
+  const content = String(message.content ?? '').trim();
+  if (!content) return false;
+
+  const type = String(message.messageType ?? message.message_type ?? 'text').toLowerCase();
+  if (type === 'system') return false;
+
+  // Bare NO_REPLY sentinel (silent turn). A message that merely contains
+  // NO_REPLY among real prose is rare and is left to the heartbeat/error
+  // predicates below; here we only drop the pure sentinel.
+  if (/^no_reply$/i.test(content)) return false;
+
+  if (AgentMessageService.isHeartbeatHousekeepingContent(content)) return false;
+  if (AgentMessageService.isRuntimeModelFailure(content)) return false;
+  if (AgentMessageService.isErrorContent(content)) return false;
+
+  return true;
+}
+
+// IP-keyed limiter, FIRST middleware on the router. ~120 req/min/IP — generous
+// for a human browsing the showcase, low enough to blunt scrapers. Skipped in
+// tests so the suite isn't throttled.
+const showcaseRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  keyGenerator: (req: Req) => (req.ip ? ipKeyGenerator(req.ip) : 'anon'),
+  handler: (_req: unknown, res: Res) => res.status(429).json({ code: 'rate_limited' }),
+});
+
+const router: ReturnType<typeof express.Router> = express.Router();
+
+router.use(showcaseRateLimit);
+
+// Load the full pod doc (NOT a narrow .select that could omit publicRead) and
+// enforce the gate. Returns the pod when public, else null — callers emit the
+// SAME 404 for "missing" and "not public" so there's no existence oracle.
+const loadPublicPod = async (podId: string | undefined) => {
+  if (!podId || !mongoose.Types.ObjectId.isValid(podId)) return null;
+  const pod = await Pod.findById(podId).populate(
+    'members',
+    // Whitelist — NEVER email. botMetadata carries only display identity
+    // (displayName / agentName / instanceId), no secrets.
+    'username profilePicture isBot botMetadata',
+  );
+  if (!pod || pod.publicRead !== true) return null;
+  return pod;
+};
+
+interface MemberDoc {
+  _id?: { toString(): string };
+  username?: string;
+  profilePicture?: string;
+  isBot?: boolean;
+  botMetadata?: { displayName?: string; agentName?: string; instanceId?: string };
+}
+
+const serializeMember = (m: MemberDoc) => {
+  const isBot = !!m.isBot;
+  const base = {
+    username: m.username || '',
+    displayName: isBot
+      ? resolveAgentDisplayLabel(m, m.username)
+      : (m.botMetadata?.displayName || m.username || ''),
+    profilePicture: m.profilePicture || 'default',
+    isBot,
+  };
+  if (isBot) {
+    return {
+      ...base,
+      agentName: m.botMetadata?.agentName,
+      instanceId: m.botMetadata?.instanceId,
+    };
+  }
+  return base;
+};
+
+// GET /api/showcase/:podId — pod meta + whitelisted members + agent identities.
+router.get('/:podId', async (req: Req, res: Res) => {
+  try {
+    const pod = await loadPublicPod(req.params?.podId);
+    if (!pod) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+
+    const members = (pod.members || []) as MemberDoc[];
+    const serializedMembers = members.map(serializeMember);
+    const agents = members
+      .filter((m) => !!m.isBot)
+      .map((m) => ({
+        displayName: resolveAgentDisplayLabel(m, m.username),
+        agentName: m.botMetadata?.agentName,
+        instanceId: m.botMetadata?.instanceId,
+        profilePicture: m.profilePicture || 'default',
+      }));
+
+    res.json({
+      pod: {
+        id: pod._id.toString(),
+        name: pod.name,
+        description: pod.description,
+        type: pod.type,
+        memberCount: members.length,
+        createdAt: pod.createdAt,
+      },
+      members: serializedMembers,
+      agents,
+    });
+  } catch (err) {
+    console.error('[showcase] GET /:podId error:', (err as Error).message);
+    res.status(500).json({ error: 'Server Error' });
+  }
+});
+
+interface RawMessage {
+  id: string;
+  content: string;
+  messageType: string;
+  createdAt: unknown;
+  userId: string;
+}
+
+// Read newest-`limit` messages before the cursor, ascending (chronological),
+// PG-first with a Mongo fallback (mirrors messageController.getMessages). The
+// raw read is store-agnostic; display identity + the noise-filter + the
+// whitelist serializer are applied uniformly afterwards so neither store can
+// leak a non-whitelisted field.
+const readRawMessages = async (
+  podId: string,
+  limit: number,
+  before?: string,
+): Promise<{ raw: RawMessage[]; hasMore: boolean }> => {
+  try {
+    const rows = await PGMessage.findByPodId(podId, limit, before || null);
+    const raw = (rows as Array<Record<string, unknown>>).map((r) => {
+      const uid = r.user_id
+        || (r.userId && typeof r.userId === 'object'
+          ? (r.userId as { _id?: { toString(): string } })._id
+          : r.userId);
+      return {
+        id: String(r.id ?? r._id ?? ''),
+        content: String(r.content ?? ''),
+        messageType: String(r.messageType ?? r.message_type ?? 'text'),
+        createdAt: r.createdAt ?? r.created_at,
+        userId: uid ? String(uid) : '',
+      };
+    });
+    return { raw, hasMore: rows.length === limit };
+  } catch (pgErr) {
+    console.warn('[showcase] PG unavailable, falling back to Mongo:', (pgErr as Error).message);
+  }
+
+  const query: Record<string, unknown> = { podId };
+  if (before) query.createdAt = { $lt: new Date(before) };
+  const docs = await MongoMessage.find(query)
+    .sort({ createdAt: -1 })
+    .limit(limit)
+    .lean();
+  const raw = (docs as Array<Record<string, unknown>>)
+    .slice()
+    .reverse()
+    .map((m) => ({
+      id: String(m._id),
+      content: String(m.content ?? ''),
+      messageType: String(m.messageType ?? 'text'),
+      createdAt: m.createdAt,
+      userId: m.userId ? String(m.userId) : '',
+    }));
+  return { raw, hasMore: docs.length === limit };
+};
+
+// GET /api/showcase/:podId/messages — filtered, whitelisted message feed.
+router.get('/:podId/messages', async (req: Req, res: Res) => {
+  try {
+    const pod = await loadPublicPod(req.params?.podId);
+    if (!pod) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+
+    const rawLimit = parseInt(String(req.query?.limit ?? '50'), 10);
+    const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(rawLimit, 100) : 50;
+    const before = req.query?.before ? String(req.query.before) : undefined;
+
+    const podId = pod._id.toString();
+    const { raw, hasMore } = await readRawMessages(podId, limit, before);
+
+    // Resolve authors via a single batched User lookup. Whitelisted projection
+    // — NEVER email. botMetadata carries only display identity.
+    const userIds = Array.from(new Set(raw.map((m) => m.userId).filter(Boolean)));
+    const userDocs = userIds.length
+      ? await User.find({ _id: { $in: userIds } })
+          .select('username profilePicture isBot botMetadata')
+          .lean()
+      : [];
+    const userMap = new Map<string, MemberDoc>();
+    for (const u of userDocs as MemberDoc[]) {
+      if (u._id) userMap.set(u._id.toString(), u);
+    }
+
+    const messages = raw
+      .filter((m) => isShowcaseWorthy(m))
+      .map((m) => {
+        const u = userMap.get(m.userId);
+        const isBot = !!u?.isBot;
+        const author = {
+          username: u?.username || 'unknown',
+          displayName: isBot
+            ? resolveAgentDisplayLabel(u, u?.username)
+            : (u?.botMetadata?.displayName || u?.username || 'unknown'),
+          profilePicture: u?.profilePicture || 'default',
+          isBot,
+        };
+        return {
+          id: m.id,
+          author,
+          content: m.content,
+          createdAt: m.createdAt,
+        };
+      });
+
+    res.json({ messages, hasMore });
+  } catch (err) {
+    console.error('[showcase] GET /:podId/messages error:', (err as Error).message);
+    res.status(500).json({ error: 'Server Error' });
+  }
+});
+
+module.exports = router;
+module.exports.isShowcaseWorthy = isShowcaseWorthy;
+
+export {};

--- a/backend/routes/uploads.ts
+++ b/backend/routes/uploads.ts
@@ -153,6 +153,24 @@ const mintRateLimit = rateLimit({
     res.status(429).json({ msg: 'rate limit exceeded: 30 mints per 60s' }),
 });
 
+// IP-keyed limiter for the UNAUTHENTICATED artifact GETs below
+// (`/:fileName` + `/:fileName/preview-pptx-html`). These have public read by
+// design today (the showcase renders artifacts through them, ADR-002 Phase 1);
+// this blunts mass scraping without changing their auth. The full signed-URL
+// flip that removes public-read is the documented follow-up. ~240/min/IP is
+// generous for a showcase page loading dozens of artifacts but caps a scraper.
+// Applied as the FIRST middleware on each GET so CodeQL's js/missing-rate-limiting
+// query recognises it.
+const artifactReadRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 240,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req: AuthReq) => (req.ip ? ipKeyGenerator(req.ip) : 'anon'),
+  handler: (_req: unknown, res: Res) =>
+    res.status(429).json({ msg: 'rate limit exceeded: 240 requests per 60s' }),
+});
+
 const router: ReturnType<typeof express.Router> = express.Router();
 
 // Shared upload handler — used by both the user-auth POST / and the
@@ -272,7 +290,7 @@ router.get('/:fileName/url', mintRateLimit, auth, async (req: AuthReq, res: Res)
   }
 });
 
-router.get('/:fileName', async (req: AuthReq, res: Res) => {
+router.get('/:fileName', artifactReadRateLimit, async (req: AuthReq, res: Res) => {
   try {
     const fileName = req.params?.fileName;
     if (!fileName) return res.status(400).json({ msg: 'fileName required' });
@@ -377,7 +395,7 @@ const officecliPreview = (() => {
 // officecli process. Plenty for normal decks (sub-second to a few seconds).
 const PPTX_RENDER_TIMEOUT_MS = 30_000;
 
-router.get('/:fileName/preview-pptx-html', async (req: AuthReq, res: Res) => {
+router.get('/:fileName/preview-pptx-html', artifactReadRateLimit, async (req: AuthReq, res: Res) => {
   try {
     const fileName = req.params?.fileName;
     if (!fileName) return res.status(400).json({ msg: 'fileName required' });

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -41,6 +41,8 @@ const skillsRoutes = require('./routes/skills');
 const devRoutes = require('./routes/dev');
 const healthRoutes = require('./routes/health');
 const statsRoutes = require('./routes/stats');
+const showcaseRoutes = require('./routes/showcase');
+const adminPodsRoutes = require('./routes/admin/pods');
 const agentEnsembleRoutes = require('./routes/agentEnsemble');
 const globalIntegrationsRoutes = require('./routes/admin/globalIntegrations');
 const agentAutonomyAdminRoutes = require('./routes/admin/agentAutonomy');
@@ -201,6 +203,10 @@ app.use('/api/admin/users', adminUsersRoutes); // Admin user + invitation manage
 app.use('/api/dev', devRoutes); // Dev tooling (LLM status, etc.)
 app.use('/api/health', healthRoutes); // Health check endpoints
 app.use('/api/stats', statsRoutes); // Public stats (no auth)
+// Public read-only showcase (no auth — handlers self-gate on pod.publicRead).
+// SECURITY-CRITICAL: the only anonymous read path; serves only flagged pods.
+app.use('/api/showcase', showcaseRoutes);
+app.use('/api/admin/pods', adminPodsRoutes); // Admin pod ops (showcase toggle)
 app.use('/api/pods', agentEnsembleRoutes); // Agent Ensemble Pod endpoints
 
 // Test routes (development only)


### PR DESCRIPTION
The launch front-door backend. SECURITY-CRITICAL: the only anonymous read path, hard-gated to pods with Pod.publicRead===true.

- **Dedicated** GET /api/showcase/:podId + /:podId/messages (NOT a relaxation of /api/pods or /api/messages — those fail-open for anonymous via if(req.userId), so they stay auth-only). loadPublicPod loads the full pod and returns null unless publicRead===true; same 404 for missing+not-public (no oracle).
- **Whitelisted serializer**: username/displayName/profilePicture/isBot (+ agent display identity). NEVER email/memory/persona/skills.
- **Noise-filter** (isShowcaseWorthy): drops empty/system/NO_REPLY/heartbeat-housekeeping/runtime-failover/error messages — reuses the live AgentMessageService predicates. The "not full of errors and bs" guarantee at the serialization layer.
- **IP rate-limit** first middleware; GET-only. Admin-only toggle (POST /api/admin/pods/:podId/showcase) rejects personal pod types. Pod.publicRead default false.
- uploads.ts: IP rate-limit on the (pre-existing unauth) artifact GETs; signed-URL flip = follow-up.
- Tests: anon 200 public / 404 private+missing / noise-filter / no-email / admin toggle / REGRESSION that generic pods+messages+memory still 401 anon.

Content is curated + vetted + adversarially security-reviewed before any pod is flipped public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)