### PR TITLE
feat(showcase): logged-out read-only showcase view + landing CTA

### DIFF
--- a/frontend/src/v2/V2App.tsx
+++ b/frontend/src/v2/V2App.tsx
@@ -11,6 +11,7 @@ import RegistrationInviteRequired from '../components/RegistrationInviteRequired
 import VerifyEmail from '../components/VerifyEmail';
 import DiscordCallback from '../components/DiscordCallback';
 import V2LandingPage from './landing/V2LandingPage';
+import V2Showcase from './showcase/V2Showcase';
 import UseCasePage from '../components/landing/UseCasePage';
 import PostFeed from '../components/PostFeed';
 import Thread from '../components/Thread';
@@ -147,6 +148,11 @@ const V2App: React.FC = () => {
         <Routes>
           <Route index element={<V2Home />} />
           <Route path="landing" element={<V2LandingPage />} />
+          {/* Public read-only showcase — a logged-out visitor's window onto a
+              real room. MUST sit OUTSIDE V2RequireAuth (the `*` branch below)
+              so anonymous visitors reach it without bouncing to /v2/login. */}
+          <Route path="showcase" element={<V2Showcase />} />
+          <Route path="showcase/:podId" element={<V2Showcase />} />
           <Route path="use-cases/:useCaseId" element={<UseCasePage />} />
           <Route path="login" element={<V2Login />} />
           <Route path="register" element={<V2Register />} />

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -131,6 +131,7 @@ const V2LandingPage: React.FC = () => {
 
             <div className="v2-landing__cta-row">
               <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>{primaryLabel}</Link>
+              <Link className="v2-landing__btn v2-landing__btn--ghost" to="/v2/showcase">Watch a live room</Link>
               <a className="v2-landing__btn v2-landing__btn--ghost" href={REPO} target="_blank" rel="noreferrer">
                 <span className="v2-landing__btn-mark"><Mark size={18} /></span>
                 Star on GitHub
@@ -406,6 +407,7 @@ const V2LandingPage: React.FC = () => {
           <p className="v2-landing__cta-sub">Open the hosted app, or clone the repo and self-host in one command. It&apos;s all open.</p>
           <div className="v2-landing__cta-row">
             <Link className="v2-landing__btn v2-landing__btn--onaccent" to={appHref}>{primaryLabel}</Link>
+            <Link className="v2-landing__btn v2-landing__btn--onaccent-ghost" to="/v2/showcase">Watch a live room</Link>
             <a className="v2-landing__btn v2-landing__btn--onaccent-ghost" href={REPO} target="_blank" rel="noreferrer">Star on GitHub</a>
             <Link className="v2-landing__btn v2-landing__btn--onaccent-ghost" to="/compare">Compare to Raft</Link>
           </div>

--- a/frontend/src/v2/showcase/V2Showcase.tsx
+++ b/frontend/src/v2/showcase/V2Showcase.tsx
@@ -23,7 +23,16 @@ import './v2-showcase.css';
 // call — a logged-in viewer would leak Authorization to this public endpoint.
 // A dedicated instance skips that interceptor entirely, so showcase fetches are
 // always anonymous regardless of the viewer's auth state.
-const showcaseClient = axios.create({ baseURL: getApiBaseUrl() });
+//
+// Created lazily (NOT at module scope): V2App imports this module for routing,
+// and calling axios.create() at import time would force every test that loads
+// the app shell to provide a `create`-capable axios mock. The lazy singleton
+// defers creation to the first fetch.
+let _showcaseClient: ReturnType<typeof axios.create> | null = null;
+const getShowcaseClient = () => {
+  if (!_showcaseClient) _showcaseClient = axios.create({ baseURL: getApiBaseUrl() });
+  return _showcaseClient;
+};
 
 // Refresh cadence for the conversation. Anonymous sockets are intentionally not
 // supported, so freshness comes from a light poll rather than a live socket.
@@ -152,7 +161,7 @@ const V2Showcase: React.FC = () => {
   // for both — no oracle), which we render as the friendly "not public" state.
   const fetchInfo = useCallback(async (): Promise<boolean> => {
     try {
-      const res = await showcaseClient.get<ShowcaseInfo>(`/api/showcase/${podId}`);
+      const res = await getShowcaseClient().get<ShowcaseInfo>(`/api/showcase/${podId}`);
       setInfo(res.data);
       return true;
     } catch (err) {
@@ -164,7 +173,7 @@ const V2Showcase: React.FC = () => {
 
   const fetchMessages = useCallback(async (): Promise<void> => {
     try {
-      const res = await showcaseClient.get<ShowcaseMessagesResponse>(
+      const res = await getShowcaseClient().get<ShowcaseMessagesResponse>(
         `/api/showcase/${podId}/messages`,
         { params: { limit: MESSAGE_LIMIT } },
       );

--- a/frontend/src/v2/showcase/V2Showcase.tsx
+++ b/frontend/src/v2/showcase/V2Showcase.tsx
@@ -1,0 +1,364 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import axios from 'axios';
+import getApiBaseUrl from '../../utils/apiBaseUrl';
+import V2Avatar from '../components/V2Avatar';
+import V2MessageBubble from '../components/V2MessageBubble';
+import { V2Message } from '../hooks/useV2PodDetail';
+import '../v2.css';
+import './v2-showcase.css';
+
+// Public, logged-out, read-only window into a real Commonly room. A first-time
+// visitor with NO account sees a live conversation between humans and agents and
+// a "sign up to join" conversion path. This route sits OUTSIDE the V2RequireAuth
+// gate (see V2App), so every fetch here MUST be token-less.
+//
+// Contract (shared with the backend showcase route):
+//   GET /api/showcase/:podId           → { pod, members, agents }   (404 if not publicRead)
+//   GET /api/showcase/:podId/messages  → { messages, hasMore }      (404 if not publicRead)
+// Both endpoints serve ONLY publicRead pods and strip email / memory / persona.
+
+// Token-less client. The default axios instance (utils/axiosConfig) carries a
+// request interceptor that injects the bearer token from localStorage on every
+// call — a logged-in viewer would leak Authorization to this public endpoint.
+// A dedicated instance skips that interceptor entirely, so showcase fetches are
+// always anonymous regardless of the viewer's auth state.
+const showcaseClient = axios.create({ baseURL: getApiBaseUrl() });
+
+// Refresh cadence for the conversation. Anonymous sockets are intentionally not
+// supported, so freshness comes from a light poll rather than a live socket.
+const POLL_INTERVAL_MS = 12000;
+const MESSAGE_LIMIT = 50;
+
+// TODO(showcase): point this at the curated public demo pod once it is seeded
+// and toggled publicRead on each instance. Overridable per-deploy via
+// REACT_APP_SHOWCASE_POD_ID; the placeholder simply renders the not-public
+// state until a real id is supplied.
+const DEFAULT_SHOWCASE_POD_ID =
+  process.env.REACT_APP_SHOWCASE_POD_ID || '__SHOWCASE_POD_ID__';
+
+interface ShowcasePod {
+  id: string;
+  name: string;
+  description?: string;
+  type: string;
+  memberCount: number;
+  createdAt: string;
+}
+
+interface ShowcaseMember {
+  username: string;
+  displayName?: string;
+  profilePicture?: string | null;
+  isBot: boolean;
+  agentName?: string;
+  instanceId?: string;
+}
+
+interface ShowcaseAgent {
+  displayName: string;
+  agentName: string;
+  instanceId?: string;
+  profilePicture?: string | null;
+}
+
+interface ShowcaseInfo {
+  pod: ShowcasePod;
+  members: ShowcaseMember[];
+  agents: ShowcaseAgent[];
+}
+
+interface ShowcaseAttachment {
+  fileName: string;
+  kind: string;
+}
+
+interface ShowcaseMessage {
+  id: string;
+  author: {
+    username: string;
+    displayName?: string;
+    profilePicture?: string | null;
+    isBot: boolean;
+  };
+  content: string;
+  createdAt: string;
+  attachments?: ShowcaseAttachment[];
+}
+
+interface ShowcaseMessagesResponse {
+  messages: ShowcaseMessage[];
+  hasMore: boolean;
+}
+
+// Brand mark, mirrored from the landing page so the showcase front-door reads
+// as the same product. Kept inline to avoid a shared-component dependency for a
+// single 64×64 glyph.
+const Mark: React.FC<{ size?: number }> = ({ size = 24 }) => (
+  <svg width={size} height={size} viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+    <path d="M 50 17.7 A 22 22 0 1 0 50 46.3" fill="none" stroke="currentColor" strokeWidth="9" strokeLinecap="round" />
+    <circle cx="25" cy="32" r="2.4" fill="currentColor" />
+    <circle cx="32" cy="32" r="2.4" fill="currentColor" />
+    <circle cx="39" cy="32" r="2.4" fill="currentColor" />
+  </svg>
+);
+
+// Adapt a showcase message to the V2Message shape so we can reuse V2MessageBubble
+// verbatim — same avatar, displayName, markdown, and file-pill rendering as the
+// authenticated chat. Attachments arrive as a structured array here (no inline
+// tokens), so we re-encode them as [[file:…]] tokens the bubble already knows how
+// to render. No handlers are passed, so the bubble is inert: no author click, no
+// file open, no reactions — read-only by construction.
+const toV2Message = (m: ShowcaseMessage): V2Message => {
+  let content = m.content || '';
+  if (Array.isArray(m.attachments) && m.attachments.length > 0) {
+    const tokens = m.attachments
+      .filter((a) => a && a.fileName)
+      .map((a) => `[[file:${a.fileName}]]`)
+      .join(' ');
+    if (tokens) content = content ? `${content}\n\n${tokens}` : tokens;
+  }
+  return {
+    id: m.id,
+    pod_id: '',
+    user_id: '',
+    content,
+    message_type: 'text',
+    created_at: m.createdAt,
+    createdAt: m.createdAt,
+    user: {
+      username: m.author.displayName || m.author.username,
+      profile_picture: m.author.profilePicture || null,
+    },
+  };
+};
+
+type LoadState = 'loading' | 'ready' | 'not-public' | 'error';
+
+const V2Showcase: React.FC = () => {
+  const { podId: podIdParam } = useParams<{ podId: string }>();
+  const podId = podIdParam || DEFAULT_SHOWCASE_POD_ID;
+
+  const [state, setState] = useState<LoadState>('loading');
+  const [info, setInfo] = useState<ShowcaseInfo | null>(null);
+  const [messages, setMessages] = useState<ShowcaseMessage[]>([]);
+  const [hasMore, setHasMore] = useState(false);
+
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  const didInitialScrollRef = useRef(false);
+
+  // Fetch the pod info + member/agent roster. Drives the load state: a 404 here
+  // means the pod is missing OR not publicRead (the backend returns the same 404
+  // for both — no oracle), which we render as the friendly "not public" state.
+  const fetchInfo = useCallback(async (): Promise<boolean> => {
+    try {
+      const res = await showcaseClient.get<ShowcaseInfo>(`/api/showcase/${podId}`);
+      setInfo(res.data);
+      return true;
+    } catch (err) {
+      const status = (err as { response?: { status?: number } }).response?.status;
+      setState(status === 404 ? 'not-public' : 'error');
+      return false;
+    }
+  }, [podId]);
+
+  const fetchMessages = useCallback(async (): Promise<void> => {
+    try {
+      const res = await showcaseClient.get<ShowcaseMessagesResponse>(
+        `/api/showcase/${podId}/messages`,
+        { params: { limit: MESSAGE_LIMIT } },
+      );
+      setMessages(Array.isArray(res.data?.messages) ? res.data.messages : []);
+      setHasMore(Boolean(res.data?.hasMore));
+    } catch {
+      // A transient message-fetch failure shouldn't blow away a room that
+      // already loaded — keep the last good list and let the next poll retry.
+    }
+  }, [podId]);
+
+  // Initial load: info first (gates everything), then the conversation.
+  useEffect(() => {
+    let cancelled = false;
+    setState('loading');
+    setInfo(null);
+    setMessages([]);
+    didInitialScrollRef.current = false;
+    (async () => {
+      const ok = await fetchInfo();
+      if (cancelled || !ok) return;
+      await fetchMessages();
+      if (!cancelled) setState('ready');
+    })();
+    return () => { cancelled = true; };
+  }, [fetchInfo, fetchMessages]);
+
+  // Poll for freshness once the room is live. Cleaned up on unmount / pod change.
+  useEffect(() => {
+    if (state !== 'ready') return undefined;
+    const id = window.setInterval(() => { fetchMessages(); }, POLL_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [state, fetchMessages]);
+
+  // Drop to the latest message once, on first successful render, so the visitor
+  // lands on the freshest part of the conversation. Subsequent polls don't yank
+  // the scroll position.
+  useEffect(() => {
+    if (state !== 'ready' || didInitialScrollRef.current || messages.length === 0) return;
+    didInitialScrollRef.current = true;
+    messagesEndRef.current?.scrollIntoView({ block: 'end' });
+  }, [state, messages.length]);
+
+  const topBar = (
+    <header className="v2-showcase__bar">
+      <Link className="v2-showcase__brand" to="/v2/landing" aria-label="Commonly home">
+        <span className="v2-showcase__mark"><Mark size={24} /></span>
+        <span className="v2-showcase__brand-name">Commonly</span>
+      </Link>
+      <nav className="v2-showcase__nav" aria-label="Primary">
+        <Link className="v2-showcase__navlink" to="/v2/landing">What is Commonly?</Link>
+        <Link className="v2-showcase__navlink" to="/v2/login">Sign in</Link>
+        <Link className="v2-showcase__btn v2-showcase__btn--primary v2-showcase__btn--sm" to="/v2/register">
+          Sign up to join
+        </Link>
+      </nav>
+    </header>
+  );
+
+  if (state === 'loading') {
+    return (
+      <div className="v2-root v2-showcase">
+        {topBar}
+        <div className="v2-showcase__center">
+          <span className="v2-spinner" />
+        </div>
+      </div>
+    );
+  }
+
+  if (state === 'not-public' || state === 'error') {
+    const isError = state === 'error';
+    return (
+      <div className="v2-root v2-showcase">
+        {topBar}
+        <div className="v2-showcase__center">
+          <div className="v2-showcase__empty">
+            <div className="v2-showcase__empty-title">
+              {isError ? "This room couldn't be loaded" : "This room isn't public"}
+            </div>
+            <div className="v2-showcase__empty-text">
+              {isError
+                ? 'Something went wrong loading this conversation. Try again in a moment.'
+                : 'It may have been made private or removed. Explore what Commonly is, or start your own room.'}
+            </div>
+            <div className="v2-showcase__empty-cta">
+              <Link className="v2-showcase__btn v2-showcase__btn--primary" to="/v2/register">Start your own room</Link>
+              <Link className="v2-showcase__btn v2-showcase__btn--ghost" to="/v2/landing">What is Commonly?</Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const pod = info?.pod;
+  const agents = info?.agents || [];
+
+  return (
+    <div className="v2-root v2-showcase">
+      {topBar}
+
+      {/* Sticky conversion banner — the load-bearing CTA. Makes it obvious this
+          is a real, live room and that the visitor can have one too. */}
+      <div className="v2-showcase__banner" role="region" aria-label="Sign up to join Commonly">
+        <span className="v2-showcase__banner-text">
+          <span aria-hidden="true">👀 </span>
+          A live look inside a Commonly room — sign up to start your own.
+        </span>
+        <span className="v2-showcase__banner-cta">
+          <Link className="v2-showcase__btn v2-showcase__btn--primary v2-showcase__btn--sm" to="/v2/register">
+            Sign up to join
+          </Link>
+          <Link className="v2-showcase__btn v2-showcase__btn--ghost v2-showcase__btn--sm" to="/v2/landing">
+            What is Commonly?
+          </Link>
+        </span>
+      </div>
+
+      <main className="v2-showcase__main">
+        {/* Room header — proves it's a real room with real members + agents. */}
+        <section className="v2-showcase__room-head">
+          <div className="v2-showcase__room-title">
+            <span className="v2-showcase__room-mark" aria-hidden="true">
+              {(pod?.name || '?').slice(0, 2).toUpperCase()}
+            </span>
+            <div>
+              <h1 className="v2-showcase__room-name">{pod?.name || 'Commonly room'}</h1>
+              <div className="v2-showcase__room-meta">
+                {typeof pod?.memberCount === 'number' && (
+                  <span>{pod.memberCount} member{pod.memberCount === 1 ? '' : 's'}</span>
+                )}
+                {agents.length > 0 && (
+                  <span>· {agents.length} agent{agents.length === 1 ? '' : 's'}</span>
+                )}
+                <span className="v2-showcase__room-live">· Read-only view</span>
+              </div>
+            </div>
+          </div>
+          {agents.length > 0 && (
+            <div className="v2-showcase__agents" aria-label="Agents in this room">
+              {agents.slice(0, 6).map((a) => (
+                <V2Avatar
+                  key={`${a.agentName}:${a.instanceId || ''}`}
+                  name={a.displayName || a.agentName}
+                  src={a.profilePicture || undefined}
+                  size="sm"
+                  title={a.displayName || a.agentName}
+                />
+              ))}
+              {agents.length > 6 && (
+                <span className="v2-showcase__agents-more">+{agents.length - 6}</span>
+              )}
+            </div>
+          )}
+        </section>
+
+        {pod?.description && (
+          <p className="v2-showcase__room-desc">{pod.description}</p>
+        )}
+
+        {/* Conversation — read-only. No composer, no react/@mention controls,
+            no identity inspector. V2MessageBubble with no handlers is inert. */}
+        <section className="v2-showcase__messages">
+          {hasMore && (
+            <div className="v2-showcase__older-note">Earlier messages are hidden in this public view.</div>
+          )}
+          {messages.length === 0 ? (
+            <div className="v2-showcase__empty">
+              <div className="v2-showcase__empty-title">No messages yet</div>
+              <div className="v2-showcase__empty-text">This room is quiet right now. Check back soon.</div>
+            </div>
+          ) : (
+            messages.map((m) => (
+              <V2MessageBubble key={m.id} message={toV2Message(m)} />
+            ))
+          )}
+          <div ref={messagesEndRef} />
+        </section>
+
+        {/* Footer conversion card — reinforce that this is a real, ownable room. */}
+        <section className="v2-showcase__footer-cta">
+          <div className="v2-showcase__footer-title">This is a real Commonly room.</div>
+          <div className="v2-showcase__footer-text">
+            Bring your team and your agents into one shared memory. Start your own in minutes — it&apos;s open-source and free.
+          </div>
+          <div className="v2-showcase__empty-cta">
+            <Link className="v2-showcase__btn v2-showcase__btn--primary" to="/v2/register">Sign up to join</Link>
+            <Link className="v2-showcase__btn v2-showcase__btn--ghost" to="/v2/landing">What is Commonly?</Link>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default V2Showcase;

--- a/frontend/src/v2/showcase/V2Showcase.tsx
+++ b/frontend/src/v2/showcase/V2Showcase.tsx
@@ -205,7 +205,11 @@ const V2Showcase: React.FC = () => {
   useEffect(() => {
     if (state !== 'ready' || didInitialScrollRef.current || messages.length === 0) return;
     didInitialScrollRef.current = true;
-    messagesEndRef.current?.scrollIntoView({ block: 'end' });
+    // Guard: jsdom (tests) and some non-DOM environments don't implement
+    // scrollIntoView, so calling it unguarded throws inside this effect.
+    if (typeof messagesEndRef.current?.scrollIntoView === 'function') {
+      messagesEndRef.current.scrollIntoView({ block: 'end' });
+    }
   }, [state, messages.length]);
 
   const topBar = (

--- a/frontend/src/v2/showcase/__tests__/V2Showcase.test.tsx
+++ b/frontend/src/v2/showcase/__tests__/V2Showcase.test.tsx
@@ -1,0 +1,114 @@
+// @ts-nocheck
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import V2Showcase from '../V2Showcase';
+
+// The showcase fetches through a dedicated token-less axios instance created
+// via axios.create(). Route every `.get` on that instance through mockGet so we
+// can drive both the info and messages endpoints. The default-instance shape
+// mirrors V2MarketplaceDetailPage.test.tsx so transitive axios.defaults /
+// interceptor access during import doesn't throw.
+const mockGet = jest.fn();
+jest.mock('axios', () => {
+  const instance = {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: jest.fn(),
+  };
+  const mock = {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+    create: jest.fn(() => instance),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  };
+  return { __esModule: true, default: mock, ...mock };
+});
+
+// V2MessageBubble (reused for read-only rendering) pulls the current user via
+// useAuth — anonymous here, so token/currentUser are null.
+jest.mock('../../../context/AuthContext', () => ({
+  __esModule: true,
+  useAuth: () => ({ token: null, currentUser: null, isAuthenticated: false }),
+}));
+
+const renderAt = (podId: string) => render(
+  <MemoryRouter initialEntries={[`/v2/showcase/${podId}`]}>
+    <Routes>
+      <Route path="/v2/showcase/:podId" element={<V2Showcase />} />
+      <Route path="/v2/landing" element={<div>landing-page</div>} />
+      <Route path="/v2/register" element={<div>register-page</div>} />
+    </Routes>
+  </MemoryRouter>,
+);
+
+describe('V2Showcase', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  test('renders the room, agents, and read-only messages on success', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.endsWith('/messages')) {
+        return Promise.resolve({
+          data: {
+            messages: [
+              {
+                id: '1',
+                author: { username: 'sam', displayName: 'Sam', profilePicture: null, isBot: false },
+                content: 'Welcome to the room',
+                createdAt: new Date().toISOString(),
+              },
+              {
+                id: '2',
+                author: { username: 'openclaw-nova', displayName: 'Nova', profilePicture: null, isBot: true },
+                content: 'On it — shipping a PR now',
+                createdAt: new Date().toISOString(),
+              },
+            ],
+            hasMore: false,
+          },
+        });
+      }
+      return Promise.resolve({
+        data: {
+          pod: {
+            id: 'pod123',
+            name: 'Engineering Pod',
+            description: 'Where humans and agents ship together.',
+            type: 'standard',
+            memberCount: 4,
+            createdAt: new Date().toISOString(),
+          },
+          members: [],
+          agents: [
+            { displayName: 'Nova', agentName: 'openclaw', instanceId: 'nova', profilePicture: null },
+          ],
+        },
+      });
+    });
+
+    renderAt('pod123');
+
+    await waitFor(() => expect(screen.getByText('Engineering Pod')).toBeInTheDocument());
+    expect(screen.getByText('Welcome to the room')).toBeInTheDocument();
+    expect(screen.getByText('On it — shipping a PR now')).toBeInTheDocument();
+    // Conversion CTA is present and there is no composer / send affordance.
+    expect(screen.getAllByText('Sign up to join').length).toBeGreaterThan(0);
+    expect(screen.queryByPlaceholderText(/Message/i)).not.toBeInTheDocument();
+  });
+
+  test('renders the not-public state on a 404', async () => {
+    mockGet.mockRejectedValue({ response: { status: 404 } });
+
+    renderAt('private-pod');
+
+    await waitFor(() => expect(screen.getByText("This room isn't public")).toBeInTheDocument());
+    expect(screen.getByText('Start your own room')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/v2/showcase/__tests__/V2Showcase.test.tsx
+++ b/frontend/src/v2/showcase/__tests__/V2Showcase.test.tsx
@@ -50,6 +50,9 @@ const renderAt = (podId: string) => render(
 describe('V2Showcase', () => {
   beforeEach(() => {
     mockGet.mockReset();
+    // jsdom has no scrollIntoView; the showcase auto-scroll effect calls it.
+    // Polyfill so the effect can't throw mid-render during assertions.
+    (window.HTMLElement.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView = jest.fn();
   });
 
   test('renders the room, agents, and read-only messages on success', async () => {

--- a/frontend/src/v2/showcase/v2-showcase.css
+++ b/frontend/src/v2/showcase/v2-showcase.css
@@ -1,0 +1,231 @@
+/* Public read-only showcase view. Logged-out front-door onto a real Commonly
+   room. Strictly v2 design language — tokens from v2.css, one accent, borders,
+   sentence case. Mobile-safe down to 390px (no fixed widths, no horizontal
+   overflow). Self-wraps in .v2-root so tokens apply wherever it mounts. */
+
+.v2-showcase {
+  min-height: 100vh;
+  background: var(--v2-bg);
+  color: var(--v2-text-primary);
+  display: flex;
+  flex-direction: column;
+}
+
+/* ---- Top bar ---- */
+.v2-showcase__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--v2-border);
+  background: var(--v2-surface);
+}
+.v2-showcase__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+  color: var(--v2-text-primary);
+}
+.v2-showcase__mark { display: inline-flex; color: var(--v2-accent); }
+.v2-showcase__brand-name { font-weight: 700; font-size: 17px; letter-spacing: -0.01em; }
+.v2-showcase__nav { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+.v2-showcase__navlink {
+  color: var(--v2-text-secondary);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+}
+.v2-showcase__navlink:hover { color: var(--v2-text-primary); }
+
+/* ---- Buttons (mirror landing button language) ---- */
+.v2-showcase__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 42px;
+  padding: 0 20px;
+  border-radius: var(--v2-radius);
+  font-size: 15px;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.v2-showcase__btn--sm { height: 36px; padding: 0 16px; font-size: 14px; }
+.v2-showcase__btn--primary {
+  color: #fff;
+  background: var(--v2-accent);
+  border-color: var(--v2-accent);
+}
+.v2-showcase__btn--primary:hover {
+  background: var(--v2-accent-strong);
+  border-color: var(--v2-accent-strong);
+}
+.v2-showcase__btn--ghost {
+  color: var(--v2-text-primary);
+  background: var(--v2-surface);
+  border-color: var(--v2-border-strong, var(--v2-border));
+}
+.v2-showcase__btn--ghost:hover {
+  background: var(--v2-surface-hover);
+}
+
+/* ---- Sticky conversion banner ---- */
+.v2-showcase__banner {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 12px 20px;
+  background: var(--v2-accent-soft);
+  border-bottom: 1px solid var(--v2-accent);
+}
+.v2-showcase__banner-text {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--v2-accent-deep, var(--v2-accent-text));
+}
+.v2-showcase__banner-cta { display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+
+/* ---- Main column ---- */
+.v2-showcase__main {
+  width: 100%;
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 24px 20px 64px;
+  box-sizing: border-box;
+}
+.v2-showcase__center {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 20px;
+}
+
+/* ---- Room header ---- */
+.v2-showcase__room-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.v2-showcase__room-title { display: flex; align-items: center; gap: 12px; min-width: 0; }
+.v2-showcase__room-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  flex: none;
+  border-radius: var(--v2-radius);
+  background: var(--v2-accent-soft);
+  color: var(--v2-accent-text);
+  font-weight: 700;
+  font-size: 15px;
+}
+.v2-showcase__room-name {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  overflow-wrap: anywhere;
+}
+.v2-showcase__room-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--v2-text-tertiary);
+  margin-top: 2px;
+}
+.v2-showcase__room-live { color: var(--v2-text-muted); }
+.v2-showcase__agents { display: inline-flex; align-items: center; gap: 4px; }
+.v2-showcase__agents-more {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v2-text-tertiary);
+  margin-left: 2px;
+}
+.v2-showcase__room-desc {
+  margin: 14px 0 0;
+  color: var(--v2-text-secondary);
+  font-size: 15px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+/* ---- Messages (read-only) ---- */
+.v2-showcase__messages {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.v2-showcase__older-note {
+  text-align: center;
+  font-size: 12px;
+  color: var(--v2-text-muted);
+  padding: 8px 0 12px;
+}
+
+/* ---- Empty / not-public states ---- */
+.v2-showcase__empty {
+  text-align: center;
+  max-width: 440px;
+  margin: 0 auto;
+  padding: 40px 8px;
+}
+.v2-showcase__empty-title { font-size: 18px; font-weight: 700; }
+.v2-showcase__empty-text {
+  margin-top: 8px;
+  color: var(--v2-text-secondary);
+  font-size: 15px;
+  line-height: 1.5;
+}
+.v2-showcase__empty-cta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+/* ---- Footer conversion card ---- */
+.v2-showcase__footer-cta {
+  margin-top: 40px;
+  padding: 28px 24px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-lg);
+  background: var(--v2-surface-tint);
+  text-align: center;
+}
+.v2-showcase__footer-title { font-size: 18px; font-weight: 700; }
+.v2-showcase__footer-text {
+  margin-top: 8px;
+  color: var(--v2-text-secondary);
+  font-size: 15px;
+  line-height: 1.5;
+}
+.v2-showcase__footer-cta .v2-showcase__empty-cta { margin-top: 20px; }
+
+/* ---- Mobile (<= 480px) ---- */
+@media (max-width: 480px) {
+  .v2-showcase__bar { padding: 12px 16px; }
+  .v2-showcase__nav { gap: 12px; }
+  .v2-showcase__banner { padding: 10px 16px; }
+  .v2-showcase__banner-text { font-size: 13px; }
+  .v2-showcase__main { padding: 20px 16px 56px; }
+  .v2-showcase__room-name { font-size: 18px; }
+}


### PR DESCRIPTION
The public read-only front-end for the showcase. Anonymous visitors see a real Commonly room and a sign-up CTA.

- /v2/showcase + /v2/showcase/:podId registered OUTSIDE the auth gate. Fetches /api/showcase/* via a token-less axios instance (bypasses the bearer interceptor) — anonymous regardless of viewer state.
- Read-only: reuses V2MessageBubble with NO handlers (no composer/react/@mention/inspector). Sticky "sign up to join" conversion banner + footer card.
- Polls every 12s (no anonymous socket). Loading / not-public-404 / error states. Mobile-safe.
- Landing CTA "Watch a live room" → /v2/showcase.

Default showcase podId via REACT_APP_SHOWCASE_POD_ID (set at deploy once the curated pod is chosen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)