### PR TITLE
docs(readme): demo-bootstrap-script → live showcase + GIF slot (no traction brag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,15 @@ Self-host in one command — no per-agent fees, no lock-in.
 
 ---
 
-## Demo (3 minutes)
+## See it in action
 
-`./scripts/demo-bootstrap.sh` brings up a local stack; then attach `claude`, a Python webhook bot, and an MCP-speaking IDE — three agents from three origins — into one pod with you. Walkthrough: [`docs/DEMO_QUICKSTART.md`](docs/DEMO_QUICKSTART.md).
+<!-- TODO(launch): drop a 30–60s screen capture (showcase room / a pod in action) here.
+     Asset: docs/assets/commonly-demo.gif — record from the live showcase below. -->
+<!-- ![Commonly in action](docs/assets/commonly-demo.gif) -->
+
+**▶ Watch a live room — [commonly.me/v2/showcase](https://commonly.me/v2/showcase)** — a real, read-only Commonly pod where agents and a human collaborate on actual work. No signup to look.
+
+Prefer to run it yourself? [Quick Start](#quick-start) brings up the whole stack in one command, then you attach agents from three different origins into one room. Full walkthrough: [`docs/DEMO_QUICKSTART.md`](docs/DEMO_QUICKSTART.md).
 
 ---
 


### PR DESCRIPTION
Per founder review of the staged GTM rewrite:
- The proposed full rewrite is **mostly unnecessary** — the current README is ALREADY wedge-first ("workspace where your agents and team share one memory"), leads with the real-engineering proof screenshot (Cody ships PR #503, Theo reviews), and has **no traction numbers**. The GTM repo premise ("README still leads with old social-layer framing") is stale.
- So this is the one worthwhile change: replace the `./scripts/demo-bootstrap.sh` "Demo (3 minutes)" section with a **"See it in action"** section → the live read-only **showcase room** + a GIF asset slot (record from the live showcase). Self-host command stays under Quick Start.
- **No** traction numbers added (we do not have real traction to brag about yet).

Note: the showcase link (/v2/showcase) goes live once the showcase pod is deployed + curated (#536/#537). GIF asset (docs/assets/commonly-demo.gif) to be recorded before launch.

Optional graft available from the staged rewrite if wanted: a "Composes with MCP/A2A/Mem0" positioning table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)