### PR TITLE
feat(litellm): anti-pattern guardrail — OpenAI moderation (monitor-only)

### DIFF
--- a/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
+++ b/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
@@ -318,6 +318,30 @@ data:
       # the container startup script; PYTHONPATH is set accordingly.
       callbacks: rate_limit_signal.proxy_handler_instance
 
+    # Content/behavioral guardrails — anti-pattern DETECTION on proxy traffic.
+    # Posture: MONITOR-ONLY for now (logging_only ⇒ flag, never block), so we
+    # measure policy-violating / anomalous content flowing through the proxy
+    # (platform features + hosted agents) before deciding whether to enforce.
+    # Uses the free OpenAI moderation endpoint via the already-present
+    # OPENAI_API_KEY (no new secret, no new infra). default_on runs it on every
+    # request. NOTE: the genuine public-launch exposure is INDIRECT PROMPT
+    # INJECTION of platform features (summarizer/digest/native apps) that ingest
+    # untrusted pod content on the master key — once we have flag data, the next
+    # step is to enforce on a scoped platform key, not globally. Broad user-post
+    # moderation belongs at the app/ingestion layer, NOT here. Presidio PII +
+    # prompt-injection detectors are documented fast-follows (need a sidecar /
+    # are block-only). If this adds latency/failures on the proxy, set
+    # default_on:false to disable instantly. See issue #538-adjacent + the
+    # guardrails research note.
+    guardrails:
+      - guardrail_name: "openai-moderation-monitor"
+        litellm_params:
+          guardrail: openai_moderation
+          mode: "logging_only"
+          model: "omni-moderation-latest"
+          api_key: os.environ/OPENAI_API_KEY
+          default_on: true
+
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY
       database_url: os.environ/DATABASE_URL


### PR DESCRIPTION
Addresses the LiteLLM **Guardrails feature** ask (detect human/agent anti-patterns), distinct from the rate-limit circuit-breakers already shipped in #531.

Adds a top-level `guardrails:` block with OpenAI moderation in **logging_only / default_on** — flags policy-violating content on every proxy request without blocking, using the existing OPENAI_API_KEY (no new secret, no new infra, free moderation endpoint). The point is to start *measuring* before enforcing.

**Honest scoping** (from the research): this is mostly a fast-follow, not a launch blocker. Public users bring their own compute, so their agent traffic never hits our proxy — the one genuinely new public-launch exposure is **indirect prompt injection of platform features** (summarizer/digest/native apps ingesting untrusted pod content on the master key). Next step after flag data: enforce on a scoped platform key, not globally. Broad user-post moderation belongs at the app/ingestion layer, not the LLM proxy.

Revertible: set `default_on: false` to disable instantly if it adds latency on the proxy. Fast-follows tracked separately (Presidio PII sidecar; scoped-enforce; prompt-injection detector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)