### PR TITLE
fix: use CF-Connecting-IP for public rate-limit keys

### DIFF
--- a/backend/__tests__/unit/middleware/ipRateLimit.test.js
+++ b/backend/__tests__/unit/middleware/ipRateLimit.test.js
@@ -1,0 +1,32 @@
+// @ts-nocheck
+
+const { ipKeyGenerator } = require('express-rate-limit');
+const { cloudflareIpRateLimitKeyGenerator } = require('../../../middleware/ipRateLimit');
+
+describe('cloudflareIpRateLimitKeyGenerator', () => {
+  it('prefers CF-Connecting-IP over req.ip', () => {
+    const key = cloudflareIpRateLimitKeyGenerator({
+      headers: { 'cf-connecting-ip': '198.51.100.10' },
+      ip: '203.0.113.7',
+    });
+
+    expect(key).toBe(ipKeyGenerator('198.51.100.10'));
+  });
+
+  it('falls back to req.ip when the Cloudflare header is absent', () => {
+    const key = cloudflareIpRateLimitKeyGenerator({
+      headers: {},
+      ip: '203.0.113.7',
+    });
+
+    expect(key).toBe(ipKeyGenerator('203.0.113.7'));
+  });
+
+  it('returns anon when neither header nor req.ip is present', () => {
+    const key = cloudflareIpRateLimitKeyGenerator({
+      headers: {},
+    });
+
+    expect(key).toBe('anon');
+  });
+});

--- a/backend/middleware/ipRateLimit.ts
+++ b/backend/middleware/ipRateLimit.ts
@@ -1,0 +1,19 @@
+import type { Request } from 'express';
+import { ipKeyGenerator } from 'express-rate-limit';
+
+const firstHeaderValue = (value: string | string[] | undefined): string | undefined => {
+  if (Array.isArray(value)) return value[0];
+  return value;
+};
+
+export const cloudflareIpRateLimitKeyGenerator = (req: Request): string => {
+  const cfConnectingIp = firstHeaderValue(req.headers?.['cf-connecting-ip']);
+  if (typeof cfConnectingIp === 'string' && cfConnectingIp.trim().length > 0) {
+    return ipKeyGenerator(cfConnectingIp.trim());
+  }
+  return req.ip ? ipKeyGenerator(req.ip) : 'anon';
+};
+
+// CJS compat for the require()-style imports used elsewhere in backend/.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = { cloudflareIpRateLimitKeyGenerator };

--- a/backend/routes/auth.ts
+++ b/backend/routes/auth.ts
@@ -2,10 +2,7 @@
 const express = require('express');
 // eslint-disable-next-line global-require
 const rateLimit = require('express-rate-limit');
-// `ipKeyGenerator` normalises IPv6 addresses into a stable /64 bucket so a
-// single client can't dodge the limiter by rotating low-order v6 bits. Same
-// helper the uploads mint limiter uses (routes/uploads.ts).
-const { ipKeyGenerator } = rateLimit;
+const { cloudflareIpRateLimitKeyGenerator } = require('../middleware/ipRateLimit');
 // eslint-disable-next-line global-require
 const auth = require('../middleware/auth');
 // eslint-disable-next-line global-require
@@ -32,13 +29,11 @@ interface Res {
 }
 
 // Abuse rate-limiters for the unauthenticated public auth surface — added as a
-// pre-flight gate before open registration. IP-keyed (NAT'd users share a
-// bucket; acceptable for these low ceilings) and applied as the FIRST
-// middleware on each route so CodeQL's `js/missing-rate-limiting` query
-// recognises the guard. Skipped under NODE_ENV=test so the suites that hammer
-// these endpoints in tight loops don't get throttled. Mirrors the
-// install/uploads limiter shape (skip + ipKeyGenerator key + 429 handler).
-const ipKey = (req: { ip?: string }) => (req.ip ? ipKeyGenerator(req.ip) : 'anon');
+// pre-flight gate before open registration. Cloudflare sets
+// `CF-Connecting-IP` at the edge, so this avoids trusting a client-supplied
+// `X-Forwarded-For` once `app.set('trust proxy', true)` is enabled. Skipped
+// under NODE_ENV=test so the suites that hammer these endpoints in tight loops
+// don't get throttled.
 const rateLimitHandler = (message: string) => (_req: unknown, res: Res) =>
   res.status(429).json({ message, code: 'rate_limited' });
 
@@ -50,7 +45,7 @@ const registerLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   skip: () => process.env.NODE_ENV === 'test',
-  keyGenerator: ipKey,
+  keyGenerator: cloudflareIpRateLimitKeyGenerator,
   handler: rateLimitHandler('rate limit exceeded: 10 registrations per hour'),
 });
 
@@ -62,7 +57,7 @@ const loginLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   skip: () => process.env.NODE_ENV === 'test',
-  keyGenerator: ipKey,
+  keyGenerator: cloudflareIpRateLimitKeyGenerator,
   handler: rateLimitHandler('rate limit exceeded: 20 login attempts per 15 minutes'),
 });
 
@@ -73,7 +68,7 @@ const waitlistLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   skip: () => process.env.NODE_ENV === 'test',
-  keyGenerator: ipKey,
+  keyGenerator: cloudflareIpRateLimitKeyGenerator,
   handler: rateLimitHandler('rate limit exceeded: 5 waitlist requests per hour'),
 });
 

--- a/backend/routes/showcase.ts
+++ b/backend/routes/showcase.ts
@@ -21,7 +21,8 @@
 
 // ESM import (not require) so CodeQL's js/missing-rate-limiting query
 // recognises the limiter on the router — same pattern as routes/uploads.ts.
-import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import rateLimit from 'express-rate-limit';
+import { cloudflareIpRateLimitKeyGenerator } from '../middleware/ipRateLimit';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const express = require('express');
@@ -101,7 +102,7 @@ const showcaseRateLimit = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   skip: () => process.env.NODE_ENV === 'test',
-  keyGenerator: (req: Req) => (req.ip ? ipKeyGenerator(req.ip) : 'anon'),
+  keyGenerator: (req: Req) => cloudflareIpRateLimitKeyGenerator(req as never),
   handler: (_req: unknown, res: Res) => res.status(429).json({ code: 'rate_limited' }),
 });
 

--- a/backend/routes/uploads.ts
+++ b/backend/routes/uploads.ts
@@ -18,7 +18,7 @@
 
 // ADR-002 Phase 1b: ESM import (not require) so CodeQL's js/missing-rate-limiting
 // query recognises the middleware on the mint route.
-import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import rateLimit from 'express-rate-limit';
 import { createHash } from 'crypto';
 import path from 'path';
 import {
@@ -27,6 +27,7 @@ import {
   signAttachmentToken,
 } from '../services/attachmentAccess';
 import { logAttachmentTokenMint } from '../services/auditService';
+import { cloudflareIpRateLimitKeyGenerator } from '../middleware/ipRateLimit';
 // eslint-disable-next-line global-require
 const express = require('express');
 // eslint-disable-next-line global-require
@@ -133,10 +134,10 @@ const uploadSingle = (field: string) => (req: AuthReq, res: Res, next: (err?: un
 // images (clients cache until TTL expiry) and low enough that a compromised
 // JWT can't scrape attachments en masse. Keyed on the Authorization header
 // (hashed) so each user's bearer token gets its own bucket — NAT'd users
-// sharing one office IP don't collide. Falling back to `req.ip` covers the
-// unauth path. Inlined in this file and applied as the FIRST middleware on
-// the route so CodeQL's `js/missing-rate-limiting` query sees it (the query
-// only recognises the limiter when it precedes other middleware).
+// sharing one office IP don't collide. Falling back to the Cloudflare edge IP
+// covers the unauth path. Inlined in this file and applied as the FIRST
+// middleware on the route so CodeQL's `js/missing-rate-limiting` query sees it
+// (the query only recognises the limiter when it precedes other middleware).
 const mintRateLimit = rateLimit({
   windowMs: 60_000,
   max: 30,
@@ -147,7 +148,7 @@ const mintRateLimit = rateLimit({
     if (authHeader) {
       return `tok:${createHash('sha256').update(authHeader).digest('hex').slice(0, 16)}`;
     }
-    return req.ip ? ipKeyGenerator(req.ip) : 'anon';
+    return cloudflareIpRateLimitKeyGenerator(req as never);
   },
   handler: (_req: unknown, res: Res) =>
     res.status(429).json({ msg: 'rate limit exceeded: 30 mints per 60s' }),
@@ -166,7 +167,7 @@ const artifactReadRateLimit = rateLimit({
   max: 240,
   standardHeaders: true,
   legacyHeaders: false,
-  keyGenerator: (req: AuthReq) => (req.ip ? ipKeyGenerator(req.ip) : 'anon'),
+  keyGenerator: (req: AuthReq) => cloudflareIpRateLimitKeyGenerator(req as never),
   handler: (_req: unknown, res: Res) =>
     res.status(429).json({ msg: 'rate limit exceeded: 240 requests per 60s' }),
 });


### PR DESCRIPTION
## What
- add a shared rate-limit key generator that prefers Cloudflare's `CF-Connecting-IP` and falls back to `ipKeyGenerator(req.ip)`
- apply it to the public auth limiters and the uploads showcase/public-read limiters
- add a unit test covering Cloudflare-header preference and fallback behavior

## Testing
- `npm test -- --runInBand __tests__/unit/middleware/ipRateLimit.test.js`
- `npm test -- --runInBand __tests__/unit/routes/uploads.signedurl.test.js`
- `npm test -- --runInBand __tests__/service/uploads.signedurl.integration.test.js` *(fails in this environment: `mongodb-memory-server` cannot start because `libcurl.so.4` is missing)*
- `npm test -- --runInBand __tests__/service/auth.test.js` *(blocked in the same Mongo-backed harness path in this environment)*