### PR TITLE
chore(showcase): set REACT_APP_SHOWCASE_POD_ID for the live showcase pod

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -86,6 +86,7 @@ jobs:
           REPO=${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/commonly-frontend
           docker build frontend \
             --build-arg REACT_APP_API_URL=https://api.commonly.me \
+            --build-arg REACT_APP_SHOWCASE_POD_ID=6a4394e5dd52c8ec8425ad69 \
             -t "$REPO:$TAG"
           docker push "$REPO:$TAG"
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,8 +11,10 @@ COPY . .
 # Add build arguments for environment variables
 ARG VITE_API_URL
 ARG REACT_APP_API_URL
+ARG REACT_APP_SHOWCASE_POD_ID
 ENV VITE_API_URL=${VITE_API_URL}
 ENV REACT_APP_API_URL=${REACT_APP_API_URL}
+ENV REACT_APP_SHOWCASE_POD_ID=${REACT_APP_SHOWCASE_POD_ID}
 # Ensure ESLint warnings don't fail the build
 ENV CI=false
 


### PR DESCRIPTION
Wires the frontend build-time `REACT_APP_SHOWCASE_POD_ID` (Dockerfile ARG + deploy-dev build-arg) to the live curated showcase pod (`6a4394e5dd52c8ec8425ad69`, "Commonly Engineering"), so `/v2/showcase` (default, incl. the landing "Watch a live room" CTA) resolves to it instead of the placeholder. Direct `/v2/showcase/:podId` already works; this makes the default/landing path work too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)