### PR TITLE
feat(litellm): prompt-injection guardrail + enforce-moderation (scoped to platform features)

### DIFF
--- a/backend/services/llmService.ts
+++ b/backend/services/llmService.ts
@@ -124,6 +124,13 @@ const generateViaLiteLLM = async (prompt: string, options: GenerateOptions = {})
       messages: [{ role: 'user', content: prompt }],
       temperature: options.temperature ?? 0.4,
       max_tokens: options.maxTokens || DEFAULT_MAX_OUTPUT_TOKENS,
+      // Per-request guardrail opt-in (LiteLLM). This is the shared LLM path for
+      // PLATFORM features (summarizer / daily digest / skills / avatars) which
+      // ingest untrusted pod content — the indirect-prompt-injection surface
+      // once registration is public. These enforce guardrails are default_on:false
+      // in litellm-config, so ONLY these platform calls get them; dev-agent
+      // per-agent-key traffic is never blocked (avoids false-positives on code).
+      guardrails: ['openai-moderation-enforce', 'injection-guard'],
     },
     {
       headers: {

--- a/docs/runbooks/litellm-guardrails.md
+++ b/docs/runbooks/litellm-guardrails.md
@@ -1,0 +1,59 @@
+# LiteLLM Guardrails (anti-pattern detection)
+
+How Commonly detects/blocks anti-pattern content on the LiteLLM proxy, and how the
+scoping works so dev agents aren't affected.
+
+## What's configured
+
+Three guardrails in `k8s/helm/commonly/templates/configmaps/litellm-config.yaml`
+(`guardrails:` block):
+
+| Guardrail | Provider | Mode | Scope | Purpose |
+|---|---|---|---|---|
+| `openai-moderation-monitor` | `openai_moderation` (free, uses `OPENAI_API_KEY`) | `logging_only` | `default_on: true` (global) | **Measure** policy-violating content on ALL proxy traffic. Never blocks. |
+| `openai-moderation-enforce` | `openai_moderation` | `during_call` (blocks) | `default_on: false` (opt-in) | **Block** harmful content — platform features only. |
+| `injection-guard` | custom `prompt_injection_guard.PromptInjectionGuard` (heuristic, no external dep) | `during_call` (blocks) | `default_on: false` (opt-in) | **Block** obvious prompt-injection / jailbreak / prompt-exfiltration patterns — platform features only. |
+
+The custom injection guardrail module is written to `/app/prompt_injection_guard.py`
+by the litellm container startup script (same mechanism as `rate_limit_signal.py`),
+so it loads without a rebuild.
+
+## The scoping (why dev agents aren't blocked)
+
+The two ENFORCE guardrails are `default_on: false`, so they run **only when a caller
+opts in**. Opt-in is per-request via the `guardrails: [...]` field in the request body.
+
+**Only the platform features opt in.** `backend/services/llmService.ts`
+(`generateViaLiteLLM`) — the shared LLM path for the summarizer, daily digest,
+skills, avatars, etc., which ingest **untrusted pod content** — sends
+`guardrails: ['openai-moderation-enforce', 'injection-guard']` on every request.
+
+Dev agents (Cody/Theo/…) call LiteLLM through their **own per-agent virtual keys**,
+never through `llmService`, and never send the opt-in field — so their coding
+prompts (which can look injection-y) are never blocked. This is the deliberate
+"scope to the platform key / indirect-injection surface" design: the genuinely new
+public-launch exposure is a poisoned pod message hijacking a platform LLM call, not
+arbitrary user prompts (public users bring their own compute).
+
+## Posture + tuning
+
+- Global moderation is **monitor-only** — watch the litellm logs for
+  `[injection-guard] blocked` and moderation flags to gauge false-positive rate.
+- If the injection heuristic over-blocks a platform feature, tighten `_PATTERNS`
+  in the startup module, or set the two enforce guardrails' `default_on`/opt-in off.
+- **Upgrade path**: replace the heuristic with a self-hosted **PromptGuard**
+  (Meta Prompt-Guard-86M) model sidecar the guardrail calls, for real ML-based
+  injection detection. Paid providers (Lakera/Aporia) are the other option.
+
+## What this does NOT cover
+
+- **Malicious agent *actions*** (running commands, exfiltration) — not a content
+  guardrail; handled by tool/exec gating (OpenClaw = no shell; codex = isolated),
+  the cloud-agent entitlement gate (#529), and rate limits. Public users' BYO
+  agents run on their own compute and never touch our proxy.
+- **Broad user-post moderation** — pod posts only hit the proxy when a platform
+  feature re-processes them; general UGC moderation belongs at the app/ingestion
+  layer, not here.
+
+Applying changes requires a litellm pod restart (the config is a ConfigMap; the
+startup script writes the guardrail module) — `kubectl rollout restart deploy/litellm -n commonly-dev`.

--- a/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
@@ -168,6 +168,58 @@ spec:
             proxy_handler_instance = RateLimitSignaler()
             PYEOF
             echo "rate-limit-signaler callback installed at /app/rate_limit_signal.py"
+            # Custom prompt-injection guardrail (heuristic). Registered in
+            # config.yaml under `guardrails:` as `prompt_injection_guard.PromptInjectionGuard`
+            # with default_on:false, so it runs ONLY for the platform virtual key
+            # (LITELLM_API_KEY) that opts in — i.e. the platform features
+            # (summarizer/digest/native/vector) which ingest untrusted pod content.
+            # Dev-agent per-agent keys are unaffected (no false-positives on code).
+            # Heuristic first pass; upgrade path is a PromptGuard model sidecar.
+            cat > /app/prompt_injection_guard.py <<'PYEOF'
+            """LiteLLM custom guardrail: heuristic prompt-injection detector.
+            Blocks obvious instruction-override / jailbreak / prompt-exfiltration
+            patterns in request input. Conservative to minimize false-positives."""
+            import re
+            from litellm.integrations.custom_guardrail import CustomGuardrail
+
+            _PATTERNS = [
+                r"ignore (?:all |the |your )?(?:previous|prior|above|earlier) (?:instructions|prompts?|messages?)",
+                r"disregard (?:all |the |your )?(?:previous|prior|above|earlier)",
+                r"forget (?:all |everything |the )?(?:previous|prior|above)",
+                r"you are now (?:a |an |no longer)",
+                r"new (?:system )?(?:instructions?|prompt|rules?)\s*:",
+                r"(?:reveal|print|show|repeat|leak|expose) (?:your|the) (?:system )?(?:prompt|instructions?)",
+                r"(?:developer|jailbreak|dan) mode",
+                r"override (?:your |the )?(?:instructions?|rules?|safety|guardrails?)",
+                r"</?(?:system|assistant)>",
+            ]
+            _COMPILED = [re.compile(p, re.IGNORECASE) for p in _PATTERNS]
+
+            def _looks_injected(text):
+                if not isinstance(text, str) or not text:
+                    return None
+                for rx in _COMPILED:
+                    m = rx.search(text)
+                    if m:
+                        return m.group(0)[:80]
+                return None
+
+            class PromptInjectionGuard(CustomGuardrail):
+                async def async_moderation_hook(self, data, user_api_key_dict, call_type):
+                    for msg in (data.get("messages") or []):
+                        content = msg.get("content")
+                        if isinstance(content, list):
+                            content = " ".join(
+                                p.get("text", "") for p in content if isinstance(p, dict)
+                            )
+                        hit = _looks_injected(content)
+                        if hit:
+                            print(f"[injection-guard] blocked (matched {hit!r})", flush=True)
+                            raise ValueError(
+                                "Request blocked by the prompt-injection guardrail."
+                            )
+            PYEOF
+            echo "prompt-injection guardrail installed at /app/prompt_injection_guard.py"
             # Hard-disable ChatGPT interactive device-login in this headless pod so a dead
             # codex auth degrades gracefully (router codex->nemotron fallback) instead of
             # hanging startup.

--- a/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
+++ b/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
@@ -341,6 +341,25 @@ data:
           model: "omni-moderation-latest"
           api_key: os.environ/OPENAI_API_KEY
           default_on: true
+      # ── ENFORCE guardrails — BLOCK, but attached ONLY to the platform virtual
+      # key (LITELLM_API_KEY) via its /key/generate guardrails:[...] list. They
+      # are default_on:false so they NEVER touch dev-agent per-agent keys (whose
+      # coding prompts would false-positive). The platform key is what the
+      # platform features (summarizer/digest/native runtime/vector embeddings)
+      # use — the indirect-prompt-injection surface that ingests untrusted pod
+      # content once registration is public. See docs/runbooks/litellm-guardrails.md.
+      - guardrail_name: "openai-moderation-enforce"
+        litellm_params:
+          guardrail: openai_moderation
+          mode: "during_call"          # blocks (raises) on a policy hit, in parallel with the call
+          model: "omni-moderation-latest"
+          api_key: os.environ/OPENAI_API_KEY
+          default_on: false
+      - guardrail_name: "injection-guard"
+        litellm_params:
+          guardrail: prompt_injection_guard.PromptInjectionGuard
+          mode: "during_call"
+          default_on: false
 
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY


### PR DESCRIPTION
Completes the guardrail hardening requested before opening registration: **prompt-injection detection + moderation ENFORCE**, scoped so dev agents are never blocked.

- **injection-guard** — a custom heuristic guardrail (`prompt_injection_guard.PromptInjectionGuard`, written on boot like the rate-limit callback) that blocks obvious instruction-override / jailbreak / prompt-exfiltration patterns.
- **openai-moderation-enforce** — `openai_moderation` in blocking (`during_call`) mode.
- Both are `default_on: false`. Only the **platform features** opt in: `llmService.generateViaLiteLLM` (summarizer/digest/skills/avatars — which ingest untrusted pod content) sends `guardrails:[...]` per-request. Dev agents call via their own per-agent keys → never blocked (no false-positives on coding prompts). Global moderation stays **monitor-only** (#540).

This is the right scope: the genuine public exposure is indirect prompt-injection of platform features, not arbitrary user prompts (public users bring their own compute). Runbook: `docs/runbooks/litellm-guardrails.md`. Upgrade path: PromptGuard model sidecar for ML-based injection detection.

Deploy restarts litellm (loads the config + writes the guardrail module); I will verify the pod boots + the guardrail blocks a test injection on the platform path while dev-agent traffic is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)