### PR TITLE
feat(litellm): prompt-injection + enforce-moderation guardrails (boot-validated)

### DIFF
--- a/backend/services/llmService.ts
+++ b/backend/services/llmService.ts
@@ -124,6 +124,14 @@ const generateViaLiteLLM = async (prompt: string, options: GenerateOptions = {})
       messages: [{ role: 'user', content: prompt }],
       temperature: options.temperature ?? 0.4,
       max_tokens: options.maxTokens || DEFAULT_MAX_OUTPUT_TOKENS,
+      // Per-request guardrail opt-in (LiteLLM). This is the shared LLM path for
+      // PLATFORM features (summarizer / daily digest / skills / avatars) which
+      // ingest untrusted pod content — the indirect-prompt-injection surface once
+      // registration is public. These enforce guardrails are default_on:false in
+      // litellm-config, so ONLY these platform calls get them; dev-agent per-agent-
+      // key traffic never sends the field and is never blocked (no false-positives
+      // on coding prompts). See docs/runbooks/litellm-guardrails.md.
+      guardrails: ['openai-moderation-enforce', 'injection-guard'],
     },
     {
       headers: {

--- a/docs/runbooks/litellm-guardrails.md
+++ b/docs/runbooks/litellm-guardrails.md
@@ -1,0 +1,87 @@
+# LiteLLM Guardrails (anti-pattern detection)
+
+How Commonly detects/blocks anti-pattern content on the LiteLLM proxy for the
+public-launch exposure, and how the scoping keeps dev agents unaffected.
+
+## What's configured
+
+Two guardrails in `k8s/helm/commonly/templates/configmaps/litellm-config.yaml`
+(`guardrails:` block):
+
+| Guardrail | Provider | Mode | Scope | Purpose |
+|---|---|---|---|---|
+| `openai-moderation-enforce` | `openai_moderation` (free, uses `OPENAI_API_KEY`) | `during_call` (blocks) | `default_on: false` (opt-in) | **Block** policy-violating content. |
+| `injection-guard` | custom `prompt_injection_guard.PromptInjectionGuard` (heuristic, no external dep) | `during_call` (blocks) | `default_on: false` (opt-in) | **Block** obvious prompt-injection / jailbreak / prompt-exfiltration patterns. |
+
+The custom injection guardrail module is written to `/app/prompt_injection_guard.py`
+by the litellm container startup script (same mechanism as `rate_limit_signal.py`),
+so it loads without an image rebuild.
+
+## The scoping (why dev agents aren't blocked)
+
+Both guardrails are `default_on: false`, so they run **only when a caller opts in**.
+Opt-in is per-request via the `guardrails: [...]` field in the request body.
+
+**Only the platform features opt in.** `backend/services/llmService.ts`
+(`generateViaLiteLLM`) — the shared LLM path for the summarizer, daily digest,
+skills, avatars, etc., which ingest **untrusted pod content** — sends
+`guardrails: ['openai-moderation-enforce', 'injection-guard']` on every request.
+
+Dev agents (Cody/Theo/…) call LiteLLM through their **own per-agent virtual keys**,
+never through `llmService`, and never send the opt-in field — so their coding
+prompts (which can look injection-y) are never blocked. This is the deliberate
+"scope to the platform key / indirect-injection surface" design: the genuinely new
+public-launch exposure is a poisoned pod message hijacking a platform LLM call, not
+arbitrary user prompts (public users bring their own compute).
+
+## ⚠️ Validate before deploying — the 2026-06-29 crash-loop
+
+An earlier version added a third guardrail, `openai-moderation-monitor`, with
+`mode: "logging_only"`. **`logging_only` is NOT a supported event hook on the pinned
+image (litellm v1.88.0-rc.1)** — litellm raised at startup, the pod crash-looped, and
+because it never bound `:4000` the platform features that opt in got `ECONNREFUSED`.
+
+The only supported modes are `pre_call`, `during_call`, `post_call`. **Before shipping
+any guardrails change, boot-test the exact config in a throwaway litellm pod** and
+confirm it logs `Application startup complete` with no `not in the supported event
+hooks` error:
+
+```bash
+# 1. put the candidate config.yaml + prompt_injection_guard.py in a dir, then:
+kubectl create configmap gtest-litellm -n commonly-dev \
+  --from-file=config.yaml --from-file=prompt_injection_guard.py
+# 2. run a throwaway litellm with them mounted at /app, PYTHONPATH=/app,
+#    args: --config /app/config.yaml. Then:
+kubectl logs gtest-litellm-pod -n commonly-dev | grep -iE \
+  "Application startup complete|not in the supported event hooks|Traceback"
+# 3. clean up: kubectl delete pod gtest-litellm-pod configmap gtest-litellm -n commonly-dev
+```
+
+Green = `Application startup complete`. Anything else = do not deploy.
+
+## Posture + tuning
+
+- Watch the litellm logs for `[injection-guard] blocked` and moderation flags to
+  gauge the false-positive rate on platform traffic.
+- If the injection heuristic over-blocks a platform feature, tighten `_PATTERNS`
+  in the startup module, or drop the offending guardrail from the `llmService`
+  opt-in array (that alone disables it — no config change needed).
+- **Upgrade path**: replace the heuristic with a self-hosted **PromptGuard**
+  (Meta Prompt-Guard-86M) model sidecar the guardrail calls, for real ML-based
+  injection detection. Paid providers (Lakera/Aporia) are the other option.
+
+## What this does NOT cover
+
+- **Malicious agent *actions*** (running commands, exfiltration) — not a content
+  guardrail; handled by tool/exec gating (OpenClaw = no shell; codex = isolated),
+  the cloud-agent entitlement gate (#529), and rate limits. Public users' BYO
+  agents run on their own compute and never touch our proxy.
+- **Broad user-post moderation** — pod posts only hit the proxy when a platform
+  feature re-processes them; general UGC moderation belongs at the app/ingestion
+  layer, not here.
+
+Applying changes requires a litellm pod restart (the config is a ConfigMap; the
+startup script writes the guardrail module) —
+`kubectl rollout restart deploy/litellm -n commonly-dev`. A `Deploy Dev` run that
+touches the litellm **deployment template** (not just the configmap) rolls the pod
+automatically.

--- a/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
@@ -168,6 +168,52 @@ spec:
             proxy_handler_instance = RateLimitSignaler()
             PYEOF
             echo "rate-limit-signaler callback installed at /app/rate_limit_signal.py"
+            # Custom prompt-injection guardrail. LiteLLM resolves `guardrail:
+            # prompt_injection_guard.PromptInjectionGuard` relative to the config
+            # dir (/app/), same as the rate-limit callback above. Heuristic only,
+            # no external dependency. default_on:false in litellm-config.yaml, so it
+            # runs ONLY for platform features that opt in via the request body.
+            cat > /app/prompt_injection_guard.py <<'PYEOF'
+            """LiteLLM custom guardrail: heuristic prompt-injection detector.
+            Blocks obvious injection / jailbreak / prompt-exfiltration patterns.
+            Extends CustomGuardrail; async_moderation_hook runs on `during_call`."""
+            import re
+            from litellm.integrations.custom_guardrail import CustomGuardrail
+
+            _PATTERNS = [
+                r"ignore (?:all |the |your )?(?:previous|prior|above|earlier) (?:instructions|prompts?|messages?)",
+                r"disregard (?:all |the |your )?(?:previous|prior|above|earlier)",
+                r"forget (?:all |everything |the )?(?:previous|prior|above)",
+                r"you are now (?:a |an |no longer)",
+                r"new (?:system )?(?:instructions?|prompt|rules?)\s*:",
+                r"(?:reveal|print|show|repeat|leak|expose) (?:your|the) (?:system )?(?:prompt|instructions?)",
+                r"(?:developer|jailbreak|dan) mode",
+                r"override (?:your |the )?(?:instructions?|rules?|safety|guardrails?)",
+                r"</?(?:system|assistant)>",
+            ]
+            _COMPILED = [re.compile(p, re.IGNORECASE) for p in _PATTERNS]
+
+            def _looks_injected(text):
+                if not isinstance(text, str) or not text:
+                    return None
+                for rx in _COMPILED:
+                    m = rx.search(text)
+                    if m:
+                        return m.group(0)[:80]
+                return None
+
+            class PromptInjectionGuard(CustomGuardrail):
+                async def async_moderation_hook(self, data, user_api_key_dict, call_type):
+                    for msg in (data.get("messages") or []):
+                        content = msg.get("content")
+                        if isinstance(content, list):
+                            content = " ".join(p.get("text", "") for p in content if isinstance(p, dict))
+                        hit = _looks_injected(content)
+                        if hit:
+                            print(f"[injection-guard] blocked (matched {hit!r})", flush=True)
+                            raise ValueError("Request blocked by the prompt-injection guardrail.")
+            PYEOF
+            echo "prompt-injection guardrail installed at /app/prompt_injection_guard.py"
             # Hard-disable ChatGPT interactive device-login in this headless pod so a dead
             # codex auth degrades gracefully (router codex->nemotron fallback) instead of
             # hanging startup.

--- a/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
+++ b/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
@@ -318,6 +318,37 @@ data:
       # the container startup script; PYTHONPATH is set accordingly.
       callbacks: rate_limit_signal.proxy_handler_instance
 
+    guardrails:
+      # Anti-pattern content guardrails for the public-launch exposure. Both are
+      # ENFORCE (block) + default_on:false, so they run ONLY when a caller opts in
+      # via the request-body `guardrails:[...]` field. The ONLY opt-in caller is
+      # backend/services/llmService.ts (platform features — summarizer / daily digest
+      # / skills / avatars — which ingest UNTRUSTED pod content: the indirect-prompt-
+      # injection surface once registration is public). Dev-agent per-agent-key
+      # traffic never sends the field, so coding prompts are never blocked.
+      #
+      # INCIDENT NOTE (2026-06-29): an `openai-moderation-monitor` guardrail with
+      # `mode: "logging_only"` was added here and crash-looped the litellm pod —
+      # logging_only is NOT a supported event hook on v1.88.0-rc.1. Only during_call
+      # (and pre_call/post_call) validate at startup. This block was boot-tested in a
+      # throwaway litellm pod (Application startup complete, 0 errors) before shipping.
+      # Do NOT reintroduce logging_only without re-validating against the pinned image.
+      - guardrail_name: "openai-moderation-enforce"
+        litellm_params:
+          guardrail: openai_moderation
+          mode: "during_call"
+          model: "omni-moderation-latest"
+          api_key: os.environ/OPENAI_API_KEY
+          default_on: false
+      - guardrail_name: "injection-guard"
+        litellm_params:
+          # Heuristic prompt-injection / jailbreak / prompt-exfiltration detector.
+          # Custom module written to /app/prompt_injection_guard.py by the container
+          # startup script (same mechanism as rate_limit_signal.py). No external dep.
+          guardrail: prompt_injection_guard.PromptInjectionGuard
+          mode: "during_call"
+          default_on: false
+
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY
       database_url: os.environ/DATABASE_URL


### PR DESCRIPTION
Re-introduces the two anti-pattern guardrails for the public-launch exposure, with the crash-loop root cause fixed and a **boot-validation step** baked in. This is the validated re-do of the reverted #544 (which crash-looped litellm via an unsupported `logging_only` mode).

## What ships
- **`openai-moderation-enforce`** — `openai_moderation`, `during_call`, `default_on: false`
- **`injection-guard`** — custom heuristic `PromptInjectionGuard`, `during_call`, `default_on: false`
- Both are **opt-in** via the request body. **Only** `backend/services/llmService.ts` (summarizer / digest / skills / avatars — the untrusted-pod-content path) opts in, so **dev-agent per-agent-key traffic is never blocked** (no false-positives on coding prompts).
- Custom module written to `/app/prompt_injection_guard.py` by the litellm startup script (same mechanism as `rate_limit_signal.py` — no image rebuild).
- `docs/runbooks/litellm-guardrails.md` documents the design + the **mandatory boot-test-before-deploy** step.

## Why this is safe now (vs the 2026-06-29 incident)
The earlier attempt (#544) added a third `logging_only` monitor guardrail — an **unsupported event hook** on litellm v1.88.0-rc.1 — which crash-looped the pod (and, because it never bound `:4000`, `ECONNREFUSED`'d the platform features that opt in). This change uses **only `during_call`**, and the exact config was **boot-tested in a throwaway litellm pod before touching the fleet**:

- Isolated guardrails config → `Application startup complete`, 0 errors.
- **Full real config** (complete `model_list` + `router_settings` + `litellm_settings` + the new `guardrails` block + the custom module, device-login patched) → `Application startup complete` + `Uvicorn running`, **zero guardrail/config errors** (the only tracebacks were expected dummy-key/auth failures).

## Scope guardrail (the design invariant)
Enforcement is scoped to the indirect-prompt-injection surface — a poisoned pod message hijacking a *platform* LLM call — not arbitrary user prompts (public users bring their own compute and never hit our proxy for their own agents).

Refs #541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)