### PR TITLE
feat(native-runtime): guard the user↔cloud-agent inference path

### DIFF
--- a/backend/models/AgentRun.ts
+++ b/backend/models/AgentRun.ts
@@ -33,6 +33,7 @@ export type AgentRunErrorKind =
   | 'timeout'
   | 'tool_error'
   | 'llm_error'
+  | 'guardrail_blocked'
   | 'config'
   | 'unknown';
 
@@ -121,7 +122,7 @@ const AgentRunSchema = new Schema<IAgentRun>(
     completedAt: { type: Date },
     errorKind: {
       type: String,
-      enum: ['turn_cap', 'token_cap', 'timeout', 'tool_error', 'llm_error', 'config', 'unknown'],
+      enum: ['turn_cap', 'token_cap', 'timeout', 'tool_error', 'llm_error', 'guardrail_blocked', 'config', 'unknown'],
     },
     errorMessage: { type: String },
   },

--- a/backend/services/nativeRuntimeService.ts
+++ b/backend/services/nativeRuntimeService.ts
@@ -57,6 +57,21 @@ const MAX_WALL_CLOCK_MS = 60_000;
 const DEFAULT_MODEL = 'openrouter/nvidia/nemotron-3-super-120b-a12b:free';
 const LITELLM_TIMEOUT_MS = Number(process.env.NATIVE_RUNTIME_TIMEOUT_MS) || 45_000;
 
+// Guardrail opt-in for the native cloud-agent inference path. Unlike dev agents
+// (Cody/Theo — separate runtimes, own keys, coding prompts, deliberately NOT
+// guarded), the native runtime processes UNTRUSTED input: a public user conversing
+// with a native agent, and pod content re-processed by first-party apps
+// (welcomer/summarizer). Both are the indirect/direct prompt-injection surface once
+// registration is public, so this path opts into the same enforce guardrails as
+// llmService. These guardrails are default_on:false in litellm-config, so ONLY
+// callers that send this field get them. Env-overridable (comma-separated; empty
+// string disables) as a no-redeploy off-switch if it over-blocks a first-party app
+// — a backend env change + pod restart, no image build. See
+// docs/runbooks/litellm-guardrails.md.
+const NATIVE_RUNTIME_GUARDRAILS = (
+  process.env.NATIVE_RUNTIME_GUARDRAILS ?? 'openai-moderation-enforce,injection-guard'
+).split(',').map((s) => s.trim()).filter(Boolean);
+
 // --- helpers ---------------------------------------------------------------
 
 type PlainConfig = Record<string, any>;
@@ -583,6 +598,10 @@ export async function runAgent(
             messages,
             tools: TOOLS,
             tool_choice: 'auto',
+            // Guard the untrusted-user / untrusted-pod-content surface (see the
+            // NATIVE_RUNTIME_GUARDRAILS note above). Omitted entirely when empty
+            // so an operator can disable via env without a redeploy.
+            ...(NATIVE_RUNTIME_GUARDRAILS.length ? { guardrails: NATIVE_RUNTIME_GUARDRAILS } : {}),
           },
           {
             headers: {
@@ -596,6 +615,16 @@ export async function runAgent(
         if (axiosResp.status < 200 || axiosResp.status >= 300) {
           const body = axiosResp.data as unknown;
           const bodyText = typeof body === 'string' ? body : JSON.stringify(body);
+          // A content guardrail (injection / moderation) rejection comes back as an
+          // error status from LiteLLM. Tag it distinctly so it's observable in
+          // AgentRun metrics (told apart from genuine LLM failures) and never
+          // surfaces the raw proxy payload back to a possibly-malicious user.
+          if (/guardrail|moderation|prompt-injection/i.test(bodyText)) {
+            run.status = 'failed';
+            run.errorKind = 'guardrail_blocked';
+            run.errorMessage = 'Request blocked by a content guardrail (prompt-injection / moderation).';
+            break;
+          }
           throw new Error(`LiteLLM HTTP ${axiosResp.status}: ${bodyText.slice(0, 500)}`);
         }
         llmResponse = axiosResp.data;

--- a/docs/runbooks/litellm-guardrails.md
+++ b/docs/runbooks/litellm-guardrails.md
@@ -22,17 +22,29 @@ so it loads without an image rebuild.
 Both guardrails are `default_on: false`, so they run **only when a caller opts in**.
 Opt-in is per-request via the `guardrails: [...]` field in the request body.
 
-**Only the platform features opt in.** `backend/services/llmService.ts`
-(`generateViaLiteLLM`) — the shared LLM path for the summarizer, daily digest,
-skills, avatars, etc., which ingest **untrusted pod content** — sends
-`guardrails: ['openai-moderation-enforce', 'injection-guard']` on every request.
+**Two platform paths opt in — the two places untrusted input reaches a platform-keyed
+LLM call:**
 
-Dev agents (Cody/Theo/…) call LiteLLM through their **own per-agent virtual keys**,
-never through `llmService`, and never send the opt-in field — so their coding
-prompts (which can look injection-y) are never blocked. This is the deliberate
-"scope to the platform key / indirect-injection surface" design: the genuinely new
-public-launch exposure is a poisoned pod message hijacking a platform LLM call, not
-arbitrary user prompts (public users bring their own compute).
+1. `backend/services/llmService.ts` (`generateViaLiteLLM`) — the shared LLM path for
+   the summarizer, daily digest, skills, avatars, etc., which ingest **untrusted pod
+   content**. Sends `guardrails: ['openai-moderation-enforce', 'injection-guard']`.
+2. `backend/services/nativeRuntimeService.ts` — the **Tier-1 native cloud-agent
+   runtime** (loops LiteLLM chat/completions with the 5 Commonly tools). This is where
+   a **public user converses directly with a native agent**, so the user's message is
+   untrusted input on our platform key. Opts in via the `NATIVE_RUNTIME_GUARDRAILS` env
+   (default `openai-moderation-enforce,injection-guard`; comma-separated; empty string
+   disables — a no-redeploy off-switch if it over-blocks a first-party app like the
+   welcomer/summarizer). A block is surfaced as `AgentRun.errorKind = 'guardrail_blocked'`
+   with a generic message; the raw proxy payload is never returned to the user.
+
+Dev agents (Cody/Theo/…) call LiteLLM through their **own per-agent virtual keys** on
+**separate runtimes** (cloud-codex / openclaw), never through `llmService` or the native
+runtime, and never send the opt-in field — so their coding prompts (which can look
+injection-y) are never blocked. This is the deliberate "scope to the untrusted-input
+surface, not the trusted-operator surface" design: the two guarded paths are (a) a
+poisoned pod message hijacking a platform feature and (b) a malicious user directly
+prompt-injecting a native agent — NOT dev-agent coding, and NOT public users' BYO
+agents (which run on their own compute and never touch our proxy).
 
 ## ⚠️ Validate before deploying — the 2026-06-29 crash-loop
 


### PR DESCRIPTION
Closes the gap #546 left. #546 made the injection/moderation guardrails opt-in, and **only `llmService`** (platform features — summarizer/digest/skills) opted in. But a **public user conversing with a Tier-1 native cloud agent** goes through `nativeRuntimeService` — its own direct LiteLLM `chat/completions` loop — which sent **no opt-in**. So a malicious user could prompt-inject / jailbreak / abuse a native agent **completely unguarded**.

## Change
- `nativeRuntimeService` now opts into the same enforce guardrails on every inference turn, via a `NATIVE_RUNTIME_GUARDRAILS` env (default `openai-moderation-enforce,injection-guard`; comma-separated; **empty string disables** — a no-redeploy off-switch if it over-blocks a first-party app like welcomer/summarizer).
- A guardrail rejection is recorded as `AgentRun.errorKind='guardrail_blocked'` (new enum value) with a generic message; the **raw proxy payload is never returned** to the (possibly malicious) user.
- **Dev agents (Cody/Theo) unaffected** — separate runtimes (cloud-codex / openclaw), own keys, never route through the native runtime, never send the opt-in → coding prompts never blocked.

## Threat model after this PR
The two guarded paths are the two places untrusted input reaches a platform-keyed LLM call:
1. Poisoned pod content re-processed by a platform feature (`llmService`, #546).
2. **A malicious user directly injecting a native agent (this PR).**

BYO/local agents run on the user's own compute and never touch our proxy, so they're out of scope by design.

## Testing
- Guardrail firing itself was verified live on the proxy in #546 (injection+opt-in → blocked; clean → passes; no-opt-in → not blocked).
- This PR routes the native runtime through that same opt-in. Post-merge I'll run a **live end-to-end**: a malicious user message to a real native agent on dev → confirm `AgentRun.errorKind='guardrail_blocked'` and no hijack.

Refs #541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)