### PR TITLE
refactor(litellm): native content-filter guardrail, drop custom regex module

### DIFF
--- a/backend/services/llmService.ts
+++ b/backend/services/llmService.ts
@@ -7,6 +7,19 @@ const DEFAULT_OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 const DEFAULT_MAX_OUTPUT_TOKENS = 2048;
 const DEFAULT_LLM_TIMEOUT_MS = Number(process.env.LLM_REQUEST_TIMEOUT_MS) || 120000;
 
+// Per-request guardrail opt-in for the shared PLATFORM LLM path (summarizer /
+// daily digest / skills / avatars), which ingest untrusted pod content — the
+// indirect-prompt-injection surface once registration is public. These enforce
+// guardrails are default_on:false in litellm-config, so ONLY these platform calls
+// get them; dev-agent per-agent-key traffic never sends the field and is never
+// blocked (no false-positives on coding prompts). Env-overridable (comma-separated;
+// empty string disables) as a no-redeploy off-switch if the injection filter's
+// keyword matching over-blocks legitimate pod content. Symmetric with
+// NATIVE_RUNTIME_GUARDRAILS. See docs/runbooks/litellm-guardrails.md.
+const LLMSERVICE_GUARDRAILS = (
+  process.env.LLMSERVICE_GUARDRAILS ?? 'openai-moderation-enforce,injection-guard'
+).split(',').map((s) => s.trim()).filter(Boolean);
+
 export interface GenerateOptions {
   model?: string;
   temperature?: number;
@@ -124,14 +137,10 @@ const generateViaLiteLLM = async (prompt: string, options: GenerateOptions = {})
       messages: [{ role: 'user', content: prompt }],
       temperature: options.temperature ?? 0.4,
       max_tokens: options.maxTokens || DEFAULT_MAX_OUTPUT_TOKENS,
-      // Per-request guardrail opt-in (LiteLLM). This is the shared LLM path for
-      // PLATFORM features (summarizer / daily digest / skills / avatars) which
-      // ingest untrusted pod content — the indirect-prompt-injection surface once
-      // registration is public. These enforce guardrails are default_on:false in
-      // litellm-config, so ONLY these platform calls get them; dev-agent per-agent-
-      // key traffic never sends the field and is never blocked (no false-positives
-      // on coding prompts). See docs/runbooks/litellm-guardrails.md.
-      guardrails: ['openai-moderation-enforce', 'injection-guard'],
+      // Guardrail opt-in for the untrusted-pod-content surface (see the
+      // LLMSERVICE_GUARDRAILS note above). Omitted entirely when empty so an
+      // operator can disable via env without a redeploy.
+      ...(LLMSERVICE_GUARDRAILS.length ? { guardrails: LLMSERVICE_GUARDRAILS } : {}),
     },
     {
       headers: {

--- a/docs/runbooks/litellm-guardrails.md
+++ b/docs/runbooks/litellm-guardrails.md
@@ -11,11 +11,25 @@ Two guardrails in `k8s/helm/commonly/templates/configmaps/litellm-config.yaml`
 | Guardrail | Provider | Mode | Scope | Purpose |
 |---|---|---|---|---|
 | `openai-moderation-enforce` | `openai_moderation` (free, uses `OPENAI_API_KEY`) | `during_call` (blocks) | `default_on: false` (opt-in) | **Block** policy-violating content. |
-| `injection-guard` | custom `prompt_injection_guard.PromptInjectionGuard` (heuristic, no external dep) | `during_call` (blocks) | `default_on: false` (opt-in) | **Block** obvious prompt-injection / jailbreak / prompt-exfiltration patterns. |
+| `injection-guard` | **native `litellm_content_filter`** (first-party, local keyword + conditional matching — no external service/key/license) | `pre_call` (blocks with HTTP 400) | `default_on: false` (opt-in) | **Block** prompt-injection / jailbreak / prompt-exfiltration. |
 
-The custom injection guardrail module is written to `/app/prompt_injection_guard.py`
-by the litellm container startup script (same mechanism as `rate_limit_signal.py`),
-so it loads without an image rebuild.
+Both are **first-party LiteLLM guardrails** — there is no custom module to maintain.
+`injection-guard` uses the built-in content-filter categories
+`prompt_injection_jailbreak`, `prompt_injection_system_prompt`, and
+`prompt_injection_data_exfiltration` at `severity_threshold: high`. The `sql` and
+`malicious_code` categories are intentionally **off** — Commonly is a dev-agent
+platform, so blocking SQL/code discussion would be all false-positives.
+
+> **History:** `injection-guard` was originally a hand-rolled regex module
+> (`prompt_injection_guard.PromptInjectionGuard`, written to `/app/` by the startup
+> script). It was replaced by the native `litellm_content_filter` — more attack-shape
+> coverage, a clean HTTP 400 (vs the custom module's 500), and no code to maintain.
+
+**Known residual false-positive:** the jailbreak category has a standalone
+`you are now` keyword, so "you are now assigned to X" in pod content can be blocked.
+Bounded by the opt-in scoping + the per-path env off-switches below. If it bites,
+either flip the env off-switch or override that category with a trimmed
+`category_file`.
 
 ## The scoping (why dev agents aren't blocked)
 
@@ -27,7 +41,9 @@ LLM call:**
 
 1. `backend/services/llmService.ts` (`generateViaLiteLLM`) — the shared LLM path for
    the summarizer, daily digest, skills, avatars, etc., which ingest **untrusted pod
-   content**. Sends `guardrails: ['openai-moderation-enforce', 'injection-guard']`.
+   content**. Opts in via the `LLMSERVICE_GUARDRAILS` env (default
+   `openai-moderation-enforce,injection-guard`; comma-separated; empty string disables
+   — a no-redeploy off-switch, symmetric with `NATIVE_RUNTIME_GUARDRAILS`).
 2. `backend/services/nativeRuntimeService.ts` — the **Tier-1 native cloud-agent
    runtime** (loops LiteLLM chat/completions with the 5 Commonly tools). This is where
    a **public user converses directly with a native agent**, so the user's message is

--- a/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
@@ -168,52 +168,10 @@ spec:
             proxy_handler_instance = RateLimitSignaler()
             PYEOF
             echo "rate-limit-signaler callback installed at /app/rate_limit_signal.py"
-            # Custom prompt-injection guardrail. LiteLLM resolves `guardrail:
-            # prompt_injection_guard.PromptInjectionGuard` relative to the config
-            # dir (/app/), same as the rate-limit callback above. Heuristic only,
-            # no external dependency. default_on:false in litellm-config.yaml, so it
-            # runs ONLY for platform features that opt in via the request body.
-            cat > /app/prompt_injection_guard.py <<'PYEOF'
-            """LiteLLM custom guardrail: heuristic prompt-injection detector.
-            Blocks obvious injection / jailbreak / prompt-exfiltration patterns.
-            Extends CustomGuardrail; async_moderation_hook runs on `during_call`."""
-            import re
-            from litellm.integrations.custom_guardrail import CustomGuardrail
-
-            _PATTERNS = [
-                r"ignore (?:all |the |your )?(?:previous|prior|above|earlier) (?:instructions|prompts?|messages?)",
-                r"disregard (?:all |the |your )?(?:previous|prior|above|earlier)",
-                r"forget (?:all |everything |the )?(?:previous|prior|above)",
-                r"you are now (?:a |an |no longer)",
-                r"new (?:system )?(?:instructions?|prompt|rules?)\s*:",
-                r"(?:reveal|print|show|repeat|leak|expose) (?:your|the) (?:system )?(?:prompt|instructions?)",
-                r"(?:developer|jailbreak|dan) mode",
-                r"override (?:your |the )?(?:instructions?|rules?|safety|guardrails?)",
-                r"</?(?:system|assistant)>",
-            ]
-            _COMPILED = [re.compile(p, re.IGNORECASE) for p in _PATTERNS]
-
-            def _looks_injected(text):
-                if not isinstance(text, str) or not text:
-                    return None
-                for rx in _COMPILED:
-                    m = rx.search(text)
-                    if m:
-                        return m.group(0)[:80]
-                return None
-
-            class PromptInjectionGuard(CustomGuardrail):
-                async def async_moderation_hook(self, data, user_api_key_dict, call_type):
-                    for msg in (data.get("messages") or []):
-                        content = msg.get("content")
-                        if isinstance(content, list):
-                            content = " ".join(p.get("text", "") for p in content if isinstance(p, dict))
-                        hit = _looks_injected(content)
-                        if hit:
-                            print(f"[injection-guard] blocked (matched {hit!r})", flush=True)
-                            raise ValueError("Request blocked by the prompt-injection guardrail.")
-            PYEOF
-            echo "prompt-injection guardrail installed at /app/prompt_injection_guard.py"
+            # NOTE: the prompt-injection guardrail no longer needs a custom module
+            # written here — it now uses the NATIVE `litellm_content_filter` guardrail
+            # (configured in litellm-config.yaml) which ships with LiteLLM. The old
+            # hand-rolled /app/prompt_injection_guard.py was removed.
             # Hard-disable ChatGPT interactive device-login in this headless pod so a dead
             # codex auth degrades gracefully (router codex->nemotron fallback) instead of
             # hanging startup.

--- a/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
+++ b/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
@@ -342,12 +342,30 @@ data:
           default_on: false
       - guardrail_name: "injection-guard"
         litellm_params:
-          # Heuristic prompt-injection / jailbreak / prompt-exfiltration detector.
-          # Custom module written to /app/prompt_injection_guard.py by the container
-          # startup script (same mechanism as rate_limit_signal.py). No external dep.
-          guardrail: prompt_injection_guard.PromptInjectionGuard
-          mode: "during_call"
+          # NATIVE LiteLLM content-filter guardrail (first-party, local keyword +
+          # conditional matching — no external service, key, or license, and no
+          # custom module to maintain). Replaced the hand-rolled regex module
+          # (prompt_injection_guard.PromptInjectionGuard) — the built-in categories
+          # cover more attack shapes and it blocks with a clean HTTP 400.
+          # pre_call = reject BEFORE the upstream LLM call (saves the spend + latency).
+          # severity_threshold=high keeps false-positives low: boot- + functionally
+          # tested in a throwaway litellm — all injection attacks (ignore+reveal
+          # system prompt / print original instructions / disregard-safety+DAN)
+          # block; normal chat ("act as if the demo works", "sql query for users",
+          # "reveal the winner") passes. Known residual FP: the jailbreak category's
+          # standalone "you are now" keyword. Mitigated by default_on:false (opt-in
+          # only, same callers as above) + the per-path env off-switches
+          # (NATIVE_RUNTIME_GUARDRAILS / LLMSERVICE_GUARDRAILS). sql + malicious_code
+          # categories are intentionally OFF — this is a dev-agent platform; blocking
+          # SQL/code discussion would be absurd. See docs/runbooks/litellm-guardrails.md.
+          guardrail: litellm_content_filter
+          mode: "pre_call"
           default_on: false
+          severity_threshold: "high"
+          categories:
+            - { category: "prompt_injection_jailbreak", action: "BLOCK" }
+            - { category: "prompt_injection_system_prompt", action: "BLOCK" }
+            - { category: "prompt_injection_data_exfiltration", action: "BLOCK" }
 
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY


### PR DESCRIPTION
Per request — use **LiteLLM's own guardrail** for injection detection instead of the hand-rolled regex module we shipped in #546.

## Change
- `injection-guard` now uses the **native `litellm_content_filter`** guardrail (first-party, local keyword + conditional matching — **no external service, key, or license**), with built-in categories `prompt_injection_{jailbreak,system_prompt,data_exfiltration}` at `severity_threshold: high`.
- **Removed** the custom `PromptInjectionGuard` module write from the litellm deployment startup script (−~45 lines of maintained Python).
- `mode: pre_call` — rejects **before** the upstream LLM call, and blocks with a clean **HTTP 400** (the custom module surfaced a 500).
- `sql` + `malicious_code` categories intentionally **OFF** — Commonly is a dev-agent platform; blocking SQL/code discussion would be all false-positives.
- `llmService` opt-in is now env-gated (`LLMSERVICE_GUARDRAILS`), symmetric with `NATIVE_RUNTIME_GUARDRAILS` — a no-redeploy off-switch on both untrusted-input paths.
- `guardrail_name` stays `injection-guard`, so the opt-in arrays (llmService + nativeRuntimeService) are unchanged.

## Validated in a throwaway litellm before shipping
- **Isolated native config** → `Application startup complete`; injection payloads blocked (HTTP 400), clean chat passes, no-opt-in traffic unaffected.
- **`severity_threshold: high`** — all injection attacks block (`ignore+reveal system prompt`, `print original instructions`, `disregard-safety+DAN`); normal chat passes ("act as if the demo works", "sql query for users", "reveal the winner", "deploy status").
- **Full real config** with the swap → `Application startup complete`, 0 config errors.

## Known residual false-positive
The jailbreak category has a standalone `you are now` keyword, so "you are now assigned to X" in pod content can trip it. Bounded by: opt-in scoping (platform paths only) + the two env off-switches. If it bites, flip the env off or override that category with a trimmed `category_file`. Documented in the runbook.

Refs #541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)