### PR TITLE
fix(v2): de-purple the avatar palette (blue-forward, on-brand)

### DIFF
--- a/frontend/src/v2/utils/avatars.ts
+++ b/frontend/src/v2/utils/avatars.ts
@@ -1,13 +1,17 @@
+// Avatar background tints. Blue-forward and cohesive with the design system's
+// single accent (#2f6feb) — deliberately purple-free (the old palette led with
+// two bright violets, #6d5dfc/#7367c7, and defaulted un-seeded avatars to purple,
+// which read as "the app is purple"). All values are dark enough for legible white
+// initials. The brand blue is first, so it is also the default for an empty seed.
 const AVATAR_PALETTE = [
-  '#6d5dfc',
-  '#64748b',
-  '#2f9e8f',
-  '#b7791f',
-  '#3b82a0',
-  '#a8556f',
-  '#6b7280',
-  '#7367c7',
-  '#4b8b73',
+  '#2f6feb', // brand blue
+  '#0e7490', // cyan
+  '#0f766e', // teal
+  '#15803d', // green
+  '#b45309', // amber
+  '#be123c', // rose
+  '#3b82a0', // steel blue
+  '#475569', // slate
 ];
 
 const hashString = (input: string): number => {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4561,8 +4561,8 @@
   font-variant-emoji: emoji;
 }
 .v2-msg__reaction:hover {
-  background: #eef2ff;
-  border-color: #c7d2fe;
+  background: var(--v2-accent-soft);
+  border-color: var(--v2-accent-soft);
 }
 .v2-msg__reaction-emoji {
   font-size: 13px;
@@ -4591,13 +4591,13 @@
   line-height: 1;
 }
 .v2-root button.v2-msg__reaction--mine {
-  background: #eef2ff;
-  border-color: #c7d2fe;
-  color: #4338ca;
+  background: var(--v2-accent-soft);
+  border-color: var(--v2-accent-soft);
+  color: var(--v2-accent-text);
 }
 .v2-root button.v2-msg__reaction:hover:not(:disabled) {
-  background: #e0e7ff;
-  border-color: #a5b4fc;
+  background: var(--v2-accent-soft);
+  border-color: var(--v2-accent);
 }
 .v2-root button.v2-msg__reaction:disabled {
   cursor: default;
@@ -4677,12 +4677,12 @@
   background: #f3f4f6;
 }
 .v2-root button.v2-msg__reaction-picker-item--mine {
-  background: #eef2ff;
+  background: var(--v2-accent-soft);
 }
 
 /* Sprint B3 — Bring-your-own MCP agent onboarding page. Lives at
  * /v2/agents/byo. Single-column form + result. Aligned with v2's
- * border-not-shadow aesthetic; copy buttons use the indigo accent. */
+ * border-not-shadow aesthetic; accent-blue for interactive controls. */
 .v2-byo__form, .v2-byo__result {
   display: flex;
   flex-direction: column;
@@ -4715,8 +4715,8 @@
   transition: border-color 0.15s ease;
 }
 .v2-byo__input:focus {
-  border-color: #6366f1;
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+  border-color: var(--v2-accent);
+  box-shadow: var(--v2-focus-ring);
 }
 .v2-byo__hint {
   font-size: 12px;
@@ -4734,16 +4734,16 @@
   align-self: flex-start;
   padding: 10px 18px;
   border-radius: 8px;
-  background: #4338ca;
+  background: var(--v2-accent);
   color: #fff;
-  border: 1px solid #4338ca;
+  border: 1px solid var(--v2-accent);
   font-weight: 600;
   font-size: 14px;
   cursor: pointer;
 }
 .v2-root button.v2-byo__submit:hover:not(:disabled) {
-  background: #3730a3;
-  border-color: #3730a3;
+  background: var(--v2-accent-strong);
+  border-color: var(--v2-accent-strong);
 }
 .v2-root button.v2-byo__submit:disabled {
   opacity: 0.6;
@@ -4790,9 +4790,9 @@
   cursor: pointer;
 }
 .v2-root button.v2-byo__copy:hover {
-  background: #eef2ff;
-  border-color: #c7d2fe;
-  color: #4338ca;
+  background: var(--v2-accent-soft);
+  border-color: var(--v2-accent-soft);
+  color: var(--v2-accent-text);
 }
 .v2-byo__pre {
   margin: 0;


### PR DESCRIPTION
Addresses the loudest visual complaint — "the app is purple." Traced it to the avatar tint palette, which led with **two bright violets** (`#6d5dfc`, `#7367c7`) and defaulted every un-seeded avatar to `#6d5dfc` (purple). It also didn't derive from the design system at all (the system mandates one accent, `#2f6feb`).

## Change
Replaced `AVATAR_PALETTE` in `frontend/src/v2/utils/avatars.ts` with a blue-forward, **purple-free**, cohesive set (brand blue → cyan → teal → green → amber → rose → steel → slate). Brand blue is first, so it's also the empty-seed default. All values stay dark enough for legible white initials. `colorFor()` hashing is unchanged, so a given name is still deterministic.

## Verified live
Against the seeded local stack (smoke-admin): chat message avatars, the pods rail, and the member stack now render blue/teal/slate/rose instead of purple. One util → every `V2Avatar` app-wide.

**Before:** violet "Cuz Local" / "SA" avatars everywhere · **After:** cool, on-brand, no purple.

Part of the pre-launch UI hardening pass (palette increment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)