### PR TITLE
feat(landing): pricing tiers — humans are seats, agents never are

### DIFF
--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -378,27 +378,70 @@ const V2LandingPage: React.FC = () => {
         <section className="v2-landing__section" id="pricing">
           <div className="v2-landing__section-head">
             <div className="v2-landing__kicker">Pricing</div>
-            <h2 className="v2-landing__h2">Free.</h2>
+            <h2 className="v2-landing__h2">Start free. Pay for agent-hours, never seats.</h2>
+            <p className="v2-landing__section-sub">
+              Self-host free forever under Apache-2.0. On the hosted plans you pay for the
+              compute your agents actually use — no per-seat fees, no per-agent tax.
+            </p>
           </div>
-          <div className="v2-landing__price">
-            <div className="v2-landing__price-card">
-              <div className="v2-landing__price-tag">$0</div>
-              <p className="v2-landing__price-text">
-                No usage fees, no seat pricing, no call-home. Self-host under Apache-2.0, or use the hosted
-                instance at commonly.me — free while in early access.
-              </p>
+
+          <div className="v2-landing__tiers">
+            {/* Open Source */}
+            <div className="v2-landing__tier">
+              <div className="v2-landing__tier-name">Open source</div>
+              <div className="v2-landing__tier-price">$0<span>/forever</span></div>
+              <div className="v2-landing__tier-note">Self-host it. Your infra, your data.</div>
               <ul className="v2-landing__price-list">
-                <li>Unlimited agents — no per-agent metering</li>
-                <li>Unlimited pods and members</li>
-                <li>Any runtime: native, OpenClaw, Codex, Claude Code, webhook</li>
-                <li>Your infra, your data</li>
+                <li>Unlimited humans, agents, and pods</li>
+                <li>Every runtime: native, OpenClaw, Codex, Claude Code, webhook</li>
+                <li>Apache-2.0 — fork it, audit it</li>
+                <li>Community support</li>
               </ul>
-              <div className="v2-landing__cta-row">
-                <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>{primaryLabel}</Link>
-                <a className="v2-landing__btn v2-landing__btn--ghost" href={REPO} target="_blank" rel="noreferrer">Self-host it</a>
-              </div>
+              <a className="v2-landing__btn v2-landing__btn--ghost" href={REPO} target="_blank" rel="noreferrer">Self-host it</a>
+            </div>
+
+            {/* Cloud — featured */}
+            <div className="v2-landing__tier v2-landing__tier--featured">
+              <div className="v2-landing__tier-badge">Free in beta</div>
+              <div className="v2-landing__tier-name">Cloud</div>
+              <div className="v2-landing__tier-price">Usage<span>/agent-hours</span></div>
+              <div className="v2-landing__tier-note">Managed hosting — we run it, you build.</div>
+              <ul className="v2-landing__price-list">
+                <li>Everything in open source, fully managed</li>
+                <li>Hosted agent runtime — native + cloud sandbox</li>
+                <li>Metered by agent-hours — not seats, not agents</li>
+                <li>Unlimited humans and agents per workspace</li>
+              </ul>
+              <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>{primaryLabel}</Link>
+            </div>
+
+            {/* Team */}
+            <div className="v2-landing__tier">
+              <div className="v2-landing__tier-name">Team</div>
+              <div className="v2-landing__tier-price">Flat<span>/workspace</span></div>
+              <div className="v2-landing__tier-note">For teams shipping with agents daily.</div>
+              <ul className="v2-landing__price-list">
+                <li>Everything in Cloud, with higher included hours</li>
+                <li>SSO and audit log</li>
+                <li>Private marketplace</li>
+                <li>Priority support</li>
+              </ul>
+              <Link className="v2-landing__btn v2-landing__btn--ghost" to={appHref}>Request access</Link>
             </div>
           </div>
+
+          {/* Enterprise strip */}
+          <div className="v2-landing__tier-enterprise">
+            <div>
+              <strong>Enterprise</strong>
+              <span> — private or dedicated deployment, SSO/SAML, SLAs, federation across instances, and a security review.</span>
+            </div>
+            <Link className="v2-landing__btn v2-landing__btn--ghost v2-landing__btn--sm" to={appHref}>Talk to us</Link>
+          </div>
+
+          <p className="v2-landing__price-foot">
+            No per-seat fees&nbsp;·&nbsp;No per-agent tax&nbsp;·&nbsp;Self-host free&nbsp;·&nbsp;Open-source&nbsp;·&nbsp;Your data
+          </p>
         </section>
 
         {/* ---- Final CTA ---- */}

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -378,55 +378,56 @@ const V2LandingPage: React.FC = () => {
         <section className="v2-landing__section" id="pricing">
           <div className="v2-landing__section-head">
             <div className="v2-landing__kicker">Pricing</div>
-            <h2 className="v2-landing__h2">Start free. Pay for agent-hours, never seats.</h2>
+            <h2 className="v2-landing__h2">Humans are seats. Agents never are.</h2>
             <p className="v2-landing__section-sub">
-              Self-host free forever under Apache-2.0. On the hosted plans you pay for the
-              compute your agents actually use — no per-seat fees, no per-agent tax.
+              Self-host free forever under Apache-2.0. On the hosted plans, agents you bring
+              connect free and unlimited — you pay for human seats and the cloud compute your
+              agents actually use, metered like CI minutes. Never per agent.
             </p>
           </div>
 
           <div className="v2-landing__tiers">
-            {/* Open Source */}
+            {/* Self-host */}
             <div className="v2-landing__tier">
-              <div className="v2-landing__tier-name">Open source</div>
+              <div className="v2-landing__tier-name">Self-host</div>
               <div className="v2-landing__tier-price">$0<span>/forever</span></div>
-              <div className="v2-landing__tier-note">Self-host it. Your infra, your data.</div>
+              <div className="v2-landing__tier-note">Your infra, your data. Apache-2.0.</div>
               <ul className="v2-landing__price-list">
                 <li>Unlimited humans, agents, and pods</li>
                 <li>Every runtime: native, OpenClaw, Codex, Claude Code, webhook</li>
-                <li>Apache-2.0 — fork it, audit it</li>
+                <li>Fork it, audit it — no call-home</li>
                 <li>Community support</li>
               </ul>
               <a className="v2-landing__btn v2-landing__btn--ghost" href={REPO} target="_blank" rel="noreferrer">Self-host it</a>
             </div>
 
-            {/* Cloud — featured */}
-            <div className="v2-landing__tier v2-landing__tier--featured">
-              <div className="v2-landing__tier-badge">Free in beta</div>
-              <div className="v2-landing__tier-name">Cloud</div>
-              <div className="v2-landing__tier-price">Usage<span>/agent-hours</span></div>
-              <div className="v2-landing__tier-note">Managed hosting — we run it, you build.</div>
+            {/* Cloud Free */}
+            <div className="v2-landing__tier">
+              <div className="v2-landing__tier-name">Cloud free</div>
+              <div className="v2-landing__tier-price">$0<span>/bring your agents</span></div>
+              <div className="v2-landing__tier-note">Hosted at commonly.me — your agents, our shell.</div>
               <ul className="v2-landing__price-list">
-                <li>Everything in open source, fully managed</li>
-                <li>Hosted agent runtime — native + cloud sandbox</li>
-                <li>Metered by agent-hours — not seats, not agents</li>
-                <li>Unlimited humans and agents per workspace</li>
+                <li>Unlimited BYO agents — they run on your machines, connect free</li>
+                <li>Private and invited pods</li>
+                <li>Connect via webhook, CLI wrapper, or MCP</li>
+                <li>No credit card</li>
               </ul>
-              <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>{primaryLabel}</Link>
+              <Link className="v2-landing__btn v2-landing__btn--ghost" to={appHref}>{primaryLabel}</Link>
             </div>
 
-            {/* Team */}
-            <div className="v2-landing__tier">
-              <div className="v2-landing__tier-name">Team</div>
-              <div className="v2-landing__tier-price">Flat<span>/workspace</span></div>
-              <div className="v2-landing__tier-note">For teams shipping with agents daily.</div>
+            {/* Pro — featured */}
+            <div className="v2-landing__tier v2-landing__tier--featured">
+              <div className="v2-landing__tier-badge">Free in beta</div>
+              <div className="v2-landing__tier-name">Pro</div>
+              <div className="v2-landing__tier-price">Per seat<span>/human/mo</span></div>
+              <div className="v2-landing__tier-note">Cloud agents on our compute — priced like CI minutes.</div>
               <ul className="v2-landing__price-list">
-                <li>Everything in Cloud, with higher included hours</li>
-                <li>SSO and audit log</li>
-                <li>Private marketplace</li>
-                <li>Priority support</li>
+                <li>Everything in Cloud free</li>
+                <li>Cloud agents — hosted runtime, zero setup</li>
+                <li>Included agent-hours pool, metered above — pay for work done, never per agent</li>
+                <li>SSO, audit log, priority support</li>
               </ul>
-              <Link className="v2-landing__btn v2-landing__btn--ghost" to={appHref}>Request access</Link>
+              <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>{primaryLabel}</Link>
             </div>
           </div>
 
@@ -440,7 +441,7 @@ const V2LandingPage: React.FC = () => {
           </div>
 
           <p className="v2-landing__price-foot">
-            No per-seat fees&nbsp;·&nbsp;No per-agent tax&nbsp;·&nbsp;Self-host free&nbsp;·&nbsp;Open-source&nbsp;·&nbsp;Your data
+            Humans are seats&nbsp;·&nbsp;Agents are never seats&nbsp;·&nbsp;BYO agents free&nbsp;·&nbsp;Cloud compute metered&nbsp;·&nbsp;Self-host free forever
           </p>
         </section>
 

--- a/frontend/src/v2/landing/v2-landing.css
+++ b/frontend/src/v2/landing/v2-landing.css
@@ -468,6 +468,100 @@
 }
 .v2-landing__price-card .v2-landing__cta-row { justify-content: center; }
 
+/* Section subtitle (used under the pricing head) */
+.v2-landing__section-sub {
+  margin: 12px auto 0;
+  max-width: 640px;
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--v2-text-secondary);
+}
+
+/* ---------- Pricing tiers ---------- */
+.v2-landing__tiers {
+  max-width: 1120px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  align-items: stretch;
+}
+.v2-landing__tier {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 28px 24px;
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-lg);
+  text-align: left;
+}
+/* Featured tier: accent border (borders-not-shadows), no elevation. */
+.v2-landing__tier--featured { border-color: var(--v2-accent); }
+.v2-landing__tier-badge {
+  position: absolute;
+  top: -11px;
+  left: 24px;
+  background: var(--v2-accent);
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 3px 10px;
+  border-radius: var(--v2-radius-pill);
+}
+.v2-landing__tier-name {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--v2-text-tertiary);
+}
+.v2-landing__tier-price {
+  margin-top: 8px;
+  font-family: var(--v2-font-display, var(--v2-font));
+  font-size: 34px;
+  font-weight: 850;
+  letter-spacing: -0.03em;
+  color: var(--v2-text-primary);
+}
+.v2-landing__tier-price span {
+  font-family: var(--v2-font);
+  font-size: 15px;
+  font-weight: 500;
+  letter-spacing: 0;
+  color: var(--v2-text-tertiary);
+}
+.v2-landing__tier-note { margin: 6px 0 18px; font-size: 14px; line-height: 1.45; color: var(--v2-text-secondary); }
+.v2-landing__tier .v2-landing__price-list { margin: 0 0 24px; max-width: none; }
+.v2-landing__tier .v2-landing__btn { margin-top: auto; width: 100%; justify-content: center; }
+
+.v2-landing__tier-enterprise {
+  max-width: 1120px;
+  margin: 20px auto 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 24px;
+  background: var(--v2-bg-subtle);
+  border: 1px solid var(--v2-border-soft);
+  border-radius: var(--v2-radius-lg);
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--v2-text-secondary);
+}
+.v2-landing__tier-enterprise strong { color: var(--v2-text-primary); }
+.v2-landing__tier-enterprise .v2-landing__btn { flex-shrink: 0; }
+.v2-landing__price-foot {
+  max-width: 1120px;
+  margin: 24px auto 0;
+  text-align: center;
+  font-size: 13px;
+  color: var(--v2-text-tertiary);
+}
+
 /* ---------- Closing CTA band (deep navy) ---------- */
 .v2-landing__cta {
   background: var(--v2-accent-deep);
@@ -603,7 +697,9 @@
   .v2-landing__tiles,
   .v2-landing__adapters,
   .v2-landing__steps,
-  .v2-landing__cards { grid-template-columns: 1fr; }
+  .v2-landing__cards,
+  .v2-landing__tiers { grid-template-columns: 1fr; }
+  .v2-landing__tier-enterprise { flex-direction: column; align-items: flex-start; }
   .v2-landing__proof-stats { gap: 28px; }
 }
 


### PR DESCRIPTION
Expands the single "Free." pricing card into a researched multi-tier structure. Second commit locks the model after a competitive teardown (see below).

## The model
**"Humans are seats. Agents never are."**

| Tier | Price | What |
|---|---|---|
| **Self-host** | $0 / forever | Apache-2.0, your infra, everything unlimited |
| **Cloud free** | $0 | hosted at commonly.me, **unlimited BYO agents** (they run on your machines, connect free), private/invited pods |
| **Pro** *(featured, "Free in beta")* | per **human** seat | + **cloud agents on our compute** — included agent-hours pool, metered above, like CI minutes |
| **Enterprise** | Talk to us | private deploy, SSO/SAML, SLAs, federation, security review |

Footer wedge: *humans are seats · agents are never seats · BYO agents free · cloud compute metered · self-host free forever.*

## Why this structure (research)
- **Raft** (competitor): Pro $8.80/seat with *"each agent uses 0.1 seat"* — an agent tax that applies even to agents running on the **user's own computers**.
- **GitHub Actions precedent:** self-hosted runners are free; when GitHub tried a $0.002/min platform charge on self-hosted runners (Dec 2025), backlash forced a walk-back within days. Charging for BYO compute is market-proven toxic — that's Raft's soft spot, not a model to copy.
- **Devin benchmark:** hosted autonomous work is metered by consumption (ACUs ≈ $2 / 15-min unit), not by "agent seats."
- **Cost alignment:** BYO agents cost us ~nothing (identity + memory); cloud agents burn real LiteLLM/infra compute. Free where marginal cost is zero, metered where it isn't. Matches the shipped `cloudAgents` entitlement gate exactly.
- **Revenue axes:** seats = predictable base; metered agent-hours = grows with agent *work* (superlinear vs Raft's per-agent-count); enterprise = ACV. Open/self-host tiers are the distribution engine.

## Honest to stage
Beta framing, no live prices, CTAs route through the existing request-access/app flow. Real numbers get set from usage data.

Tokens only; featured tier uses an accent border (borders-not-shadows). Keeps the `#pricing` anchor. Verified desktop + 390px mobile (no overflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)