### PR TITLE
fix(v2): skin legacy MUI admin forms to v2 + drop vestigial profile stats

### DIFF
--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -375,7 +375,7 @@ const UserProfile = () => {
             <Card sx={{ mb: 4, borderRadius: 3 }}>
                 <CardContent sx={{ p: { xs: 2, md: 3 } }}>
                     <Grid container spacing={3} alignItems="center">
-                        <Grid item xs={12} md={4}>
+                        <Grid item xs={12} md={v2Embedded ? 12 : 4}>
                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
                                 <Box sx={{ position: 'relative' }}>
                                     <Avatar
@@ -442,6 +442,10 @@ const UserProfile = () => {
                                 </Box>
                             </Box>
                         </Grid>
+                        {/* Vestigial social metrics (posts/comments/followers/following)
+                            are hidden on the v2 surface — meaningless for a dev-agent
+                            workspace. Kept for any non-v2 usage. */}
+                        {!v2Embedded && (
                         <Grid item xs={12} md={8}>
                             <Grid container spacing={2}>
                                 <Grid item xs={6} sm={3}>
@@ -486,6 +490,7 @@ const UserProfile = () => {
                                 </Grid>
                             </Grid>
                         </Grid>
+                        )}
                     </Grid>
 
                     <Divider sx={{ my: 3 }} />

--- a/frontend/src/components/admin/GlobalIntegrations.tsx
+++ b/frontend/src/components/admin/GlobalIntegrations.tsx
@@ -702,12 +702,14 @@ const GlobalIntegrations = () => {
                     Save X Configuration
                   </Button>
                   <Tooltip title="Test connection">
-                    <IconButton
-                      onClick={() => testConnection('x')}
-                      disabled={xConfig.status !== 'connected'}
-                    >
-                      <RefreshIcon />
-                    </IconButton>
+                    <span>
+                      <IconButton
+                        onClick={() => testConnection('x')}
+                        disabled={xConfig.status !== 'connected'}
+                      >
+                        <RefreshIcon />
+                      </IconButton>
+                    </span>
                   </Tooltip>
                 </Box>
               </Box>
@@ -811,12 +813,14 @@ const GlobalIntegrations = () => {
                     Save Instagram Configuration
                   </Button>
                   <Tooltip title="Test connection">
-                    <IconButton
-                      onClick={() => testConnection('instagram')}
-                      disabled={instagramConfig.status !== 'connected'}
-                    >
-                      <RefreshIcon />
-                    </IconButton>
+                    <span>
+                      <IconButton
+                        onClick={() => testConnection('instagram')}
+                        disabled={instagramConfig.status !== 'connected'}
+                      >
+                        <RefreshIcon />
+                      </IconButton>
+                    </span>
                   </Tooltip>
                 </Box>
               </Box>

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -3686,6 +3686,33 @@
   color: var(--v2-text-secondary);
 }
 
+/* Flatten MUI outlined form controls to the v2 look. The recolor above kept the
+   MUI signature — a floated label sitting in a notched border. Here we finish the
+   job: continuous border (kill the notch legend), v2 radius, and lift the label
+   to a static v2-style label ABOVE the field. One block skins every legacy admin
+   form (Global Integrations model policy, etc.) without a component rewrite. */
+.v2-feature__legacy .MuiFormControl-root { margin-top: 20px; }
+.v2-feature__legacy .MuiOutlinedInput-root { border-radius: var(--v2-radius); }
+.v2-feature__legacy .MuiOutlinedInput-notchedOutline legend { max-width: 0.01px; }
+.v2-feature__legacy .MuiInputLabel-outlined {
+  position: static;
+  transform: none;
+  margin-bottom: 6px;
+  max-width: 100%;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v2-text-secondary);
+  pointer-events: auto;
+  overflow: visible;
+}
+.v2-feature__legacy .MuiInputBase-input,
+.v2-feature__legacy .MuiSelect-select {
+  padding: 10px 12px;
+  font-size: 14px;
+  min-height: 20px;
+  box-sizing: border-box;
+}
+
 .v2-feature__legacy .MuiDivider-root {
   border-color: var(--v2-border-soft);
 }


### PR DESCRIPTION
Makes the admin/config surfaces read as v2 — the "v1 mess" flagged for launch — **without** a risky rewrite of the 1200+-line MUI `GlobalIntegrations` component (59 form controls) or the legacy `UserProfile`.

## Changes
1. **MUI form skin (v2.css).** The existing `.v2-feature__legacy` skin recolored MUI inputs but kept the MUI signature — a floated label in a notched border. Extended it to flatten them: continuous border (kill the notch legend), v2 radius, and a **static label above the field** like v2's own form controls. One CSS block skins every legacy admin form (Global Integrations model policy, and the other admin pages) at once.
2. **4 console errors → 0** on Global Integrations. Two `<Tooltip><IconButton disabled>` pairs — a disabled element can't fire the events Tooltip listens for. Wrapped them in `<span>` (the MUI-recommended fix).
3. **Vestigial social metrics gone.** The v2 Settings page is the legacy `UserProfile`, which showed **Posts / Comments / Followers / Following** — meaningless for a dev-agent workspace. Hidden behind the existing `v2Embedded` flag (non-v2 usage untouched); the profile takes full width when they're hidden.

## Why skin, not rewrite
59 MUI controls in this file + two more legacy MUI admin pages. A per-control migration isn't justified for admin-only surfaces; the skin is the codebase's established `.v2-feature__legacy` pattern and fixes them all consistently.

## Verified
Live against the seeded local stack: admin model-policy form now shows flat v2 dropdowns/inputs with labels above; Settings shows no stat boxes; admin console is clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)