### PR TITLE
fix(v2): invite-required page → v2 + compare-table parity polish

### DIFF
--- a/frontend/src/components/RegistrationInviteRequired.tsx
+++ b/frontend/src/components/RegistrationInviteRequired.tsx
@@ -1,17 +1,19 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import {
-  Alert,
-  Box,
-  Button,
-  Container,
-  Paper,
-  Stack,
-  TextField,
-  Typography,
-} from '@mui/material';
 import axios from '../utils/axiosConfig';
-import commonlyLogo from '../assets/commonly-logo.png';
+
+// v2-native invite-required gate. Pairs with V2Login / V2Register (reuses the
+// .v2-login card styles) so every auth surface matches after v2 became the
+// default. Two forms in one card: enter an invite code → hand off to
+// /v2/register, or submit a waitlist request for admin review. Logic is
+// unchanged from the legacy MUI version — only the presentation is v2.
+
+const Brand: React.FC = () => (
+  <div className="v2-login__brand">
+    <span className="v2-rail__brand-icon">c</span>
+    commonly
+  </div>
+);
 
 const RegistrationInviteRequired: React.FC = () => {
   const navigate = useNavigate();
@@ -53,123 +55,81 @@ const RegistrationInviteRequired: React.FC = () => {
   };
 
   return (
-    <Box
-      sx={{
-        minHeight: '100vh',
-        background: 'radial-gradient(circle at top, rgba(46, 64, 110, 0.15), transparent 55%), linear-gradient(135deg, #0f172a 0%, #111827 45%, #0b1220 100%)',
-        display: 'flex',
-        alignItems: 'center',
-        py: { xs: 6, md: 10 },
-      }}
-    >
-      <Container maxWidth="sm">
-        <Paper
-          elevation={6}
-          sx={{
-            borderRadius: 3,
-            background: '#0b1220',
-            border: '1px solid rgba(148, 163, 184, 0.15)',
-            p: { xs: 4, md: 5 },
-            textAlign: 'center',
-          }}
-        >
-          <Box
-            component="img"
-            src={commonlyLogo}
-            alt="Commonly logo"
-            sx={{
-              width: 52,
-              height: 52,
-              borderRadius: 2,
-              backgroundColor: '#0f172a',
-              border: '1px solid rgba(148, 163, 184, 0.2)',
-              p: 0.75,
-              mb: 2,
-            }}
-          />
-          <Typography variant="h4" sx={{ color: '#f8fafc', fontWeight: 700, mb: 1.5 }}>
-            Invitation Required
-          </Typography>
-          <Typography variant="body1" sx={{ color: '#cbd5e1', mb: 3 }}>
-            New account registration is currently invite-only. Enter your invitation code to continue,
-            or submit a waitlist request for admin review.
-          </Typography>
-          <Box component="form" onSubmit={onContinue}>
-            <TextField
-              fullWidth
-              label="Invitation Code"
+    <div className="v2-login">
+      <div className="v2-login__card">
+        <Brand />
+        <h1 className="v2-login__title">Invitation required</h1>
+        <p className="v2-login__subtitle">
+          New account registration is invite-only right now. Enter your invitation code to continue,
+          or join the waitlist for admin review.
+        </p>
+
+        <form onSubmit={onContinue}>
+          <label className="v2-login__field">
+            <span className="v2-login__label">Invitation code</span>
+            <input
+              className="v2-login__input"
+              type="text"
               value={invitationCode}
               onChange={(e) => setInvitationCode(e.target.value)}
               required
-              sx={{
-                input: { color: '#f8fafc' },
-                '& .MuiOutlinedInput-root': {
-                  backgroundColor: 'rgba(15, 23, 42, 0.8)',
-                  '& fieldset': { borderColor: 'rgba(148, 163, 184, 0.3)' },
-                  '&:hover fieldset': { borderColor: 'rgba(148, 163, 184, 0.5)' },
-                  '&.Mui-focused fieldset': { borderColor: '#60a5fa' },
-                },
-                '& .MuiInputLabel-root': { color: 'rgba(226, 232, 240, 0.9)' },
-              }}
             />
-            <Button
-              type="submit"
-              fullWidth
-              variant="contained"
-              sx={{
-                mt: 3,
-                py: 1.2,
-                fontWeight: 600,
-                background: 'linear-gradient(135deg, #3b82f6, #1d4ed8)',
-              }}
-            >
-              Continue to Registration
-            </Button>
-          </Box>
-          <Box sx={{ mt: 3, textAlign: 'left' }}>
-            <Typography variant="subtitle2" sx={{ color: '#e2e8f0', mb: 1 }}>
-              Need access? Join the waitlist
-            </Typography>
-            {waitlistError && <Alert severity="error" sx={{ mb: 1.25 }}>{waitlistError}</Alert>}
-            {waitlistSuccess && <Alert severity="success" sx={{ mb: 1.25 }}>{waitlistSuccess}</Alert>}
-            <Box component="form" onSubmit={onWaitlistSubmit}>
-              <Stack spacing={1.25}>
-                <TextField
-                  fullWidth
-                  size="small"
-                  label="Email"
-                  type="email"
-                  value={waitlistEmail}
-                  onChange={(e) => setWaitlistEmail(e.target.value)}
-                  required
-                />
-                <TextField
-                  fullWidth
-                  size="small"
-                  label="Name (optional)"
-                  value={waitlistName}
-                  onChange={(e) => setWaitlistName(e.target.value)}
-                />
-                <TextField
-                  fullWidth
-                  size="small"
-                  label="Use case (optional)"
-                  value={waitlistNote}
-                  onChange={(e) => setWaitlistNote(e.target.value)}
-                />
-                <Button type="submit" variant="outlined" disabled={waitlistLoading}>
-                  {waitlistLoading ? 'Submitting...' : 'Request Waitlist Access'}
-                </Button>
-              </Stack>
-            </Box>
-          </Box>
-          <Typography variant="body2" sx={{ mt: 2.5, color: 'rgba(226, 232, 240, 0.85)' }}>
-            Already have an account?{' '}
-            <Link to="/v2/login" style={{ color: '#93c5fd' }}>Login here</Link>
-          </Typography>
-        </Paper>
-      </Container>
-    </Box>
+          </label>
+          <button type="submit" className="v2-login__submit">
+            Continue to registration
+          </button>
+        </form>
+
+        <div className="v2-login__divider">Need access? Join the waitlist</div>
+
+        <form onSubmit={onWaitlistSubmit}>
+          <label className="v2-login__field">
+            <span className="v2-login__label">Email</span>
+            <input
+              className="v2-login__input"
+              type="email"
+              autoComplete="email"
+              value={waitlistEmail}
+              onChange={(e) => setWaitlistEmail(e.target.value)}
+              required
+            />
+          </label>
+          <label className="v2-login__field">
+            <span className="v2-login__label">Name (optional)</span>
+            <input
+              className="v2-login__input"
+              type="text"
+              value={waitlistName}
+              onChange={(e) => setWaitlistName(e.target.value)}
+            />
+          </label>
+          <label className="v2-login__field">
+            <span className="v2-login__label">Use case (optional)</span>
+            <input
+              className="v2-login__input"
+              type="text"
+              value={waitlistNote}
+              onChange={(e) => setWaitlistNote(e.target.value)}
+            />
+          </label>
+          <button
+            type="submit"
+            className="v2-login__submit v2-login__submit--ghost"
+            disabled={waitlistLoading}
+          >
+            {waitlistLoading ? 'Submitting…' : 'Request waitlist access'}
+          </button>
+          {waitlistError && <div className="v2-login__error">{waitlistError}</div>}
+          {waitlistSuccess && <div className="v2-login__success">{waitlistSuccess}</div>}
+        </form>
+
+        <div className="v2-login__hint">
+          Already have an account?
+          {' '}
+          <Link to="/v2/login" className="v2-login__link">Sign in</Link>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/frontend/src/v2/landing/V2ComparePage.tsx
+++ b/frontend/src/v2/landing/V2ComparePage.tsx
@@ -27,6 +27,10 @@ interface Row {
   commonly: string;
   commonlyWin: boolean;
   raft: string;
+  // Parity dimensions — both products offer it. Rendered as a check on BOTH sides
+  // (Raft's in a neutral tone) rather than a misleading dash, keeping the page
+  // "generous + factual".
+  parity?: boolean;
 }
 
 const ROWS: Row[] = [
@@ -35,8 +39,8 @@ const ROWS: Row[] = [
   { dim: 'Per-agent cost', commonly: '$0 — run one agent or fifty', commonlyWin: true, raft: 'Per-seat + per-agent pricing' },
   { dim: 'Your data', commonly: 'On your machines when self-hosted', commonlyWin: true, raft: 'On their cloud' },
   { dim: 'Federation', commonly: 'On the roadmap — agents across instances', commonlyWin: true, raft: 'Single hosted instance' },
-  { dim: 'Shared workspace', commonly: 'Humans + agents in one set of pods', commonlyWin: false, raft: 'Humans + agents in one workspace' },
-  { dim: 'Bring your own runtime', commonly: 'Native, OpenClaw, Codex, Claude Code, webhook', commonlyWin: false, raft: 'Bring your own agent daemon' },
+  { dim: 'Shared workspace', commonly: 'Humans + agents in one set of pods', commonlyWin: false, parity: true, raft: 'Humans + agents in one workspace' },
+  { dim: 'Bring your own runtime', commonly: 'Native, OpenClaw, Codex, Claude Code, webhook', commonlyWin: false, parity: true, raft: 'Bring your own agent daemon' },
 ];
 
 const V2ComparePage: React.FC = () => {
@@ -86,11 +90,13 @@ const V2ComparePage: React.FC = () => {
             <div className="v2-compare__row" role="row" key={r.dim}>
               <div className="v2-compare__cell v2-compare__cell--dim" role="rowheader">{r.dim}</div>
               <div className="v2-compare__cell v2-compare__cell--us" role="cell">
-                {r.commonlyWin && <CheckCircleOutlineIcon className="v2-compare__ic v2-compare__ic--yes" fontSize="inherit" />}
+                {(r.commonlyWin || r.parity) && <CheckCircleOutlineIcon className="v2-compare__ic v2-compare__ic--yes" fontSize="inherit" />}
                 <span>{r.commonly}</span>
               </div>
               <div className="v2-compare__cell" role="cell">
-                <RemoveCircleOutlineIcon className="v2-compare__ic v2-compare__ic--muted" fontSize="inherit" />
+                {r.parity
+                  ? <CheckCircleOutlineIcon className="v2-compare__ic v2-compare__ic--muted" fontSize="inherit" />
+                  : <RemoveCircleOutlineIcon className="v2-compare__ic v2-compare__ic--muted" fontSize="inherit" />}
                 <span>{r.raft}</span>
               </div>
             </div>

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -3460,6 +3460,45 @@
   text-decoration: underline;
 }
 
+/* Extra login-card affordances — used by the invite-required page, which stacks
+   two forms (invite code + waitlist) in one card. A bare <form> picks up the
+   dark global form background (V2Login/V2Register dodge this by putting the card
+   class ON the single form); here the card is a <div> with two <form>s inside, so
+   neutralize the form background/box explicitly. */
+.v2-login__card form {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  box-shadow: none;
+}
+.v2-login__success {
+  margin-top: 10px;
+  padding: 8px 12px;
+  border-radius: var(--v2-radius);
+  background: var(--v2-success-soft);
+  color: var(--v2-success);
+  font-size: 12px;
+}
+.v2-root button.v2-login__submit--ghost {
+  background: transparent;
+  color: var(--v2-text-primary);
+  border: 1px solid var(--v2-border);
+}
+.v2-root button.v2-login__submit--ghost:hover:not(:disabled) {
+  background: var(--v2-surface-hover);
+  border-color: var(--v2-border-strong);
+}
+.v2-login__divider {
+  margin: 22px 0 14px;
+  padding-top: 18px;
+  border-top: 1px solid var(--v2-border-soft);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v2-text-secondary);
+  text-align: left;
+}
+
 /* ---------- Empty / loading states ---------- */
 
 .v2-feature {


### PR DESCRIPTION
The `/register/invite-required` gate was the last v1 surface — full MUI (Container/Paper/TextField) on a dark navy gradient that clashed with every other auth screen (and was part of the "dark render that doesn't make sense"). Rebuilt with the v2 login-card language, matching V2Login/V2Register.

**Before:** MUI dark-gradient card · **After:** white v2 card, static labels, brand mark, primary "Continue to registration" + ghost "Request waitlist access".

- All logic preserved: invite code → `/v2/register`, waitlist → `POST /api/auth/waitlist`, sign-in link.
- Added three small login-card classes (success message, ghost submit, section divider) + a `.v2-login__card form` background reset (two forms in one card would otherwise pick up the dark global form background — the trap V2Register's comment documents).

Verified live on the local stack. Completes the v1→v2 page migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)