### PR TITLE
fix(v2): sweep remaining indigo drift (Your Team + Marketplace CTAs)

### DIFF
--- a/frontend/src/v2/marketplace/V2MarketplacePage.css
+++ b/frontend/src/v2/marketplace/V2MarketplacePage.css
@@ -125,14 +125,14 @@
   margin-bottom: 16px;
   background: var(--v2-accent-soft);
   color: var(--v2-accent-text);
-  border: 1px solid var(--v2-accent, #4c52d8);
+  border: 1px solid var(--v2-accent);
 }
 .v2-mkt__gate-text { flex: 1 1 240px; }
 .v2-mkt__gate .v2-mkt__gate-btn {
   flex: 0 0 auto;
   padding: 8px 14px;
   border-radius: 8px;
-  background: var(--v2-accent, #4c52d8);
+  background: var(--v2-accent);
   color: #fff;
   border: none;
   font-weight: 600;
@@ -140,7 +140,7 @@
   cursor: pointer;
   white-space: nowrap;
 }
-.v2-mkt__gate .v2-mkt__gate-btn:hover { background: var(--v2-accent-hover, #3d43c4); }
+.v2-mkt__gate .v2-mkt__gate-btn:hover { background: var(--v2-accent-strong); }
 
 /* Sections */
 .v2-mkt__section {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4349,7 +4349,7 @@
 }
 
 .v2-root button.v2-team__hire-cta {
-  background: #4c52d8;
+  background: var(--v2-accent);
   color: #fff;
   border: none;
   padding: 10px 16px;
@@ -4360,8 +4360,8 @@
   white-space: nowrap;
   transition: background 0.12s ease;
 }
-.v2-root button.v2-team__hire-cta:hover { background: #3d43c4; }
-.v2-root button.v2-team__hire-cta:focus-visible { outline: 2px solid #4c52d8; outline-offset: 2px; }
+.v2-root button.v2-team__hire-cta:hover { background: var(--v2-accent-strong); }
+.v2-root button.v2-team__hire-cta:focus-visible { outline: 2px solid var(--v2-accent); outline-offset: 2px; }
 
 .v2-team__actions {
   display: flex;
@@ -4377,8 +4377,8 @@
 }
 .v2-root button.v2-team__byo-cta {
   background: transparent;
-  color: #4c52d8;
-  border: 1px solid #c7c9d4;
+  color: var(--v2-accent);
+  border: 1px solid var(--v2-border);
   padding: 10px 16px;
   border-radius: 8px;
   font-weight: 600;
@@ -4387,8 +4387,8 @@
   white-space: nowrap;
   transition: background 0.12s ease, border-color 0.12s ease;
 }
-.v2-root button.v2-team__byo-cta:hover { background: #f0f1fb; border-color: #4c52d8; }
-.v2-root button.v2-team__byo-cta:focus-visible { outline: 2px solid #4c52d8; outline-offset: 2px; }
+.v2-root button.v2-team__byo-cta:hover { background: var(--v2-accent-soft); border-color: var(--v2-accent); }
+.v2-root button.v2-team__byo-cta:focus-visible { outline: 2px solid var(--v2-accent); outline-offset: 2px; }
 
 .v2-team__error {
   padding: 12px 14px;
@@ -4443,7 +4443,7 @@
   transform: translateY(-1px);
 }
 .v2-team-card:focus-visible {
-  outline: 2px solid #4c52d8;
+  outline: 2px solid var(--v2-accent);
   outline-offset: 2px;
 }
 


### PR DESCRIPTION
Second palette-drift pass, found while auditing the authed app:

- **Your Team CTAs** — "Hire an agent" / "Connect your own agent" used indigo `#4c52d8`/`#3d43c4` → accent tokens.
- **Marketplace gate button** — used `var(--v2-accent-hover, #3d43c4)`, but `--v2-accent-hover` **isn't a real token**, so it *always* fell back to indigo on hover. Fixed to `--v2-accent-strong` (+ corrected the dead `#4c52d8` fallbacks).
- `.v2-team-card` focus outline → `--v2-accent`.

Verified live: the CTAs compute `rgb(47,111,235)` (brand blue). A full-repo sweep for the indigo hexes is now empty — the "one accent" cleanup is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)