### PR TITLE
fix(showcase): resolve pod id at build (dead 'Watch a live room' CTA) + button contrast

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Self-host in one command — no per-agent fees, no lock-in.
 
 <img src="screenshots/real-engineering.png" alt="Commonly pod — an agent ships a real PR and the team reviews it" width="100%" />
 
-*Real work, not a mockup. Cody ships [PR #503](https://github.com/Team-Commonly/commonly/pull/503) with a passing test; Theo reviews it and flags real code duplication — humans and agents working from one shared project memory.*
+*Real work, not a mockup. Cody extends a Cloudflare-aware rate-limit fix to `routes/showcase.ts` and pushes it to [PR #542](https://github.com/Team-Commonly/commonly/pull/542); Theo reviews and confirms it now covers the auth, uploads, and showcase routes — humans and agents working from one shared project memory.*
 
 ---
 
@@ -246,7 +246,7 @@ Commonly works with any agent runtime. If it can make HTTP calls or authenticate
 
 Role-specialized agents and a solo founder work this project on one shared memory. The proof is in the commit history.
 
-Code authorship runs through **Cody**, a Codex-runtime agent that clones the repo, edits files, runs tests, and opens real labeled PRs with its own hands — for example [PR #503](https://github.com/Team-Commonly/commonly/pull/503), shipped with a passing test. The OpenClaw agents work the rest of the loop on the same project memory: **Theo** triages the backlog, assigns work, and reviews PRs (he flagged real code duplication on #503); **Nova**, **Pixel**, and **Ops** weigh in on approach, sanity-check changes, and do non-coding research across backend, frontend, and infra. (Why OpenClaw agents don't author code directly: [`docs/agents/AGENT_CODING_CAPABILITY.md`](docs/agents/AGENT_CODING_CAPABILITY.md).)
+Code authorship runs through **Cody**, a Codex-runtime agent that clones the repo, edits files, runs tests, and opens real labeled PRs with its own hands — for example [PR #542](https://github.com/Team-Commonly/commonly/pull/542), where he extended a Cloudflare-aware rate-limit fix across the auth, uploads, and showcase routes. The OpenClaw agents work the rest of the loop on the same project memory: **Theo** triages the backlog, assigns work, and reviews PRs (on #542 he nudged Cody to cover the remaining route, then confirmed the coverage); **Nova**, **Pixel**, and **Ops** weigh in on approach, sanity-check changes, and do non-coding research across backend, frontend, and infra. (Why OpenClaw agents don't author code directly: [`docs/agents/AGENT_CODING_CAPABILITY.md`](docs/agents/AGENT_CODING_CAPABILITY.md).)
 
 Browse the [commit history](https://github.com/Team-Commonly/commonly/commits/main) — every agent-authored PR is labeled with the agent name and task ID.
 

--- a/docs/agents/AGENT_CODING_CAPABILITY.md
+++ b/docs/agents/AGENT_CODING_CAPABILITY.md
@@ -71,11 +71,11 @@ will stall.
   changes, and do non-coding research. They are genuinely useful here — e.g. Theo
   verifying an issue is stale, or catching real code duplication in a review.
 
-A real run of this shape: Theo triaged GH#454 → Cody verified it was already
-fixed and pivoted to a current improvement → Cody shipped
-[PR #503](https://github.com/Team-Commonly/commonly/pull/503) with a passing test
-→ Theo reviewed it and flagged real `/api/health/db` ↔ `/api/health/ready`
-duplication.
+A real run of this shape: the founder flagged that the Cloudflare-aware rate-limit
+fix hadn't reached `routes/showcase.ts` → Theo nudged Cody to extend it → Cody
+patched `backend/routes/showcase.ts` and pushed `8e484cdc` to
+[PR #542](https://github.com/Team-Commonly/commonly/pull/542) → Theo reviewed and
+confirmed it now covers the auth, uploads, and showcase routes.
 
 ### Footguns when driving Cody
 

--- a/frontend/src/v2/showcase/v2-showcase.css
+++ b/frontend/src/v2/showcase/v2-showcase.css
@@ -76,6 +76,13 @@
   background: var(--v2-surface-hover);
 }
 
+/* `.v2-root a { color: inherit }` (0,1,1) outranks the single-class button color
+   rules above (0,1,0) — the showcase root is `.v2-root .v2-showcase`, so its
+   <Link> buttons inherited dark body text and rendered dark-on-blue (unreadable).
+   Re-assert with a `.v2-root` prefix (0,2,0). Same trap the landing/login fix. */
+.v2-root .v2-showcase__btn--primary { color: #fff; }
+.v2-root .v2-showcase__btn--ghost { color: var(--v2-text-primary); }
+
 /* ---- Sticky conversion banner ---- */
 .v2-showcase__banner {
   position: sticky;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -24,6 +24,12 @@ export default defineConfig({
     // so the app actually reads it. Empty string when unset keeps self-hosted
     // same-origin builds on their existing fallback path.
     'process.env.REACT_APP_API_URL': JSON.stringify(process.env.REACT_APP_API_URL || ''),
+    // Same `process.env: {}` clobber trap as REACT_APP_API_URL above: without an
+    // explicit define, the showcase pod id fell back to the literal
+    // '__SHOWCASE_POD_ID__' placeholder, so /api/showcase/__SHOWCASE_POD_ID__ 404s
+    // and the public "Watch a live room" CTA renders "This room isn't public".
+    // CI passes REACT_APP_SHOWCASE_POD_ID as a build ENV; pass it through here.
+    'process.env.REACT_APP_SHOWCASE_POD_ID': JSON.stringify(process.env.REACT_APP_SHOWCASE_POD_ID || ''),
     'process.env': {},
   },
 });


### PR DESCRIPTION
**The public showcase was dead in production** — "Watch a live room" rendered *"This room isn't public"*. Found while auditing for a screenshot refresh.

## Root cause
The deployed frontend requested `/api/showcase/__SHOWCASE_POD_ID__` — the **literal placeholder**. `V2Showcase` reads `process.env.REACT_APP_SHOWCASE_POD_ID`, but vite's `define: { 'process.env': {} }` clobbers all `process.env` reads; only `REACT_APP_API_URL` had an explicit passthrough (the documented apex-domain fix), so the showcase id fell through to its `'__SHOWCASE_POD_ID__'` sentinel. The API + pod are healthy (`publicRead:true`, 4 members) — only the client-side id substitution was broken.

## Fix
- **vite.config.ts** — add `'process.env.REACT_APP_SHOWCASE_POD_ID'` to `define` (Dockerfile + CI already pass it as a build arg/env; line 14/17 of the Dockerfile).
- **v2-showcase.css** — `.v2-showcase__btn--primary` rendered **dark text on blue** (the `.v2-root a { color: inherit }` specificity trap, same as landing/login). Re-asserted with a `.v2-root` prefix → "Sign up to join" / "Start your own room" compute white (verified live).

Post-deploy I'll confirm `commonly.me/v2/showcase` resolves the real "Commonly Engineering" room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)