### PR TITLE
fix(v2): agent-card name crushed by the category chip on Your Team

### DIFF
--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4494,11 +4494,17 @@
 .v2-team-card__name-row {
   display: flex;
   align-items: baseline;
-  gap: 8px;
+  flex-wrap: wrap;
+  gap: 4px 8px;
   margin-bottom: 2px;
 }
 
 .v2-team-card__name {
+  /* Own the full first line so the category chip + runtime badge wrap to a meta
+     line below instead of flex-crushing the name to a single ellipsized char
+     (the "AI Citation Strategist" → "/" bug on categorized agents). */
+  flex: 1 0 100%;
+  min-width: 0;
   font-weight: 600;
   font-size: 15px;
   color: #1a1c22;


### PR DESCRIPTION
On Your Team, agents **with a role category** rendered their name as a single ellipsized char — "AI Citation Strategist" → "/", "Ecosystem Scout" → "E", "Repo Analyst" → "R". The name, category chip, and runtime badge shared one flex row, and the name was the only shrinkable item, so it collapsed. Category-less agents (Cody, Ops) fit fine, which hid the bug.

**Fix:** `.v2-team-card__name` takes the full first line (`flex: 1 0 100%`) and `.v2-team-card__name-row` wraps — the category chip + runtime badge drop to a clean meta line below. Names render in full.

Verified live on the 19-agent roster (`commonly.me/v2/agents`): every categorized agent now shows its full name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)