### PR TITLE
feat(agents): public read-only agent profile — identity showcase

### DIFF
--- a/backend/routes/agentProfile.ts
+++ b/backend/routes/agentProfile.ts
@@ -1,0 +1,208 @@
+/**
+ * Public read-only agent PROFILE — the identity showcase (the "meet the agent"
+ * surface, as opposed to the owner-only Configuration control panel).
+ *
+ * SECURITY-CRITICAL, same posture as routes/showcase.ts. Anonymous read path,
+ * mounted WITHOUT auth; every field is whitelisted. Invariants:
+ *   - GET-only, no side effects.
+ *   - Serves ONLY agent (isBot) identities; humans 404 (no user-profile oracle).
+ *   - Whitelisted serialization: NEVER email, tokens, credentials, private pod
+ *     names, or private/pod-scoped memory.
+ *   - Memory: reuses filterSectionsByVisibility with an EMPTY requester-pods set,
+ *     so ONLY `public` sections are ever returned (pod-scoped needs an
+ *     intersection that is empty here; private is never returned). The raw v1
+ *     `content` blob is intentionally NOT read — only the filtered sections.
+ *   - Pods: only publicRead pod NAMES are listed; everything else is a count, so
+ *     private pod names never leak.
+ *   - IP-keyed rate limit as the FIRST middleware to blunt scraping.
+ */
+
+// ESM import so CodeQL's js/missing-rate-limiting query sees the limiter.
+import rateLimit from 'express-rate-limit';
+import { cloudflareIpRateLimitKeyGenerator } from '../middleware/ipRateLimit';
+import { filterSectionsByVisibility } from '../services/agentMemoryService';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const express = require('express');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const User = require('../models/User');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Pod = require('../models/Pod');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { AgentInstallation } = require('../models/AgentRegistry');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const AgentMemory = require('../models/AgentMemory');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const AgentRun = require('../models/AgentRun');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const PodAsset = require('../models/PodAsset');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { resolveAgentDisplayLabel } = require('../services/agentIdentityService');
+
+interface Res {
+  status: (n: number) => Res;
+  json: (d: unknown) => Res | void;
+}
+interface Req {
+  ip?: string;
+  params?: { agentName?: string; instanceId?: string };
+}
+
+// ~120 req/min/IP — generous for a human, low enough to blunt scrapers. Skipped
+// in tests. FIRST middleware on the router.
+const profileRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  keyGenerator: (req: Req) => cloudflareIpRateLimitKeyGenerator(req as never),
+  handler: (_req: unknown, res: Res) => res.status(429).json({ code: 'rate_limited' }),
+});
+
+const router: ReturnType<typeof express.Router> = express.Router();
+router.use(profileRateLimit);
+
+// GET /api/agent-profile/:agentName/:instanceId? — public identity card.
+router.get('/:agentName/:instanceId?', async (req: Req, res: Res) => {
+  try {
+    const agentName = String(req.params?.agentName || '').trim().toLowerCase();
+    const instanceId = String(req.params?.instanceId || 'default').trim() || 'default';
+    if (!agentName) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+
+    // Resolve the agent's User row (bots only — humans 404, no oracle). Whitelist
+    // projection: identity + persona fields, NEVER email/password/tokens.
+    const user = await User.findOne({
+      isBot: true,
+      'botMetadata.agentName': agentName,
+      'botMetadata.instanceId': instanceId,
+    })
+      .select('username profilePicture isBot botMetadata agentConfig createdAt')
+      .lean();
+    if (!user) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+
+    const bm = (user.botMetadata || {}) as Record<string, unknown>;
+    const persona = ((user.agentConfig || {}) as Record<string, unknown>).personality as
+      | Record<string, unknown>
+      | undefined;
+
+    // ── Installed skills (scope=agent) ──────────────────────────────────────
+    const skillDocs = await PodAsset.find({
+      'metadata.scope': 'agent',
+      'metadata.agentName': agentName,
+      'metadata.instanceId': instanceId,
+    })
+      .select('title metadata.skillName metadata.description')
+      .lean();
+    const skills = (skillDocs as Array<Record<string, unknown>>).map((s) => {
+      const meta = (s.metadata || {}) as Record<string, unknown>;
+      return {
+        name: String(meta.skillName || s.title || 'skill'),
+        description: meta.description ? String(meta.description) : undefined,
+      };
+    });
+
+    // ── Pod memberships ─────────────────────────────────────────────────────
+    // Count everything; list only publicRead pod NAMES (never leak private pods).
+    const installs = await AgentInstallation.find({
+      agentName,
+      instanceId,
+      status: 'active',
+    })
+      .select('podId')
+      .lean();
+    const ownerPodIds = (installs as Array<{ podId?: { toString(): string } }>)
+      .map((i) => (i?.podId ? String(i.podId) : ''))
+      .filter(Boolean);
+    const publicPods = ownerPodIds.length
+      ? await Pod.find({ _id: { $in: ownerPodIds }, publicRead: true }).select('name').lean()
+      : [];
+    const publicPodNames = (publicPods as Array<{ name?: string }>)
+      .map((p) => p.name)
+      .filter(Boolean);
+
+    // ── Memory (public sections only) ───────────────────────────────────────
+    // Empty requester-pods ⇒ filterSectionsByVisibility returns ONLY public
+    // sections. Never read record.content (the unfiltered v1 blob).
+    // The profile is public, so it shows the memory LAYER as a stat (entry count
+    // + last-updated — safe, non-content) plus any explicitly-public sections.
+    // Entry counts reveal size, never content. Private/pod memory never leaks.
+    let publicMemory: unknown = {};
+    let hasMemory = false;
+    let memoryUpdatedAt: unknown = null;
+    let memoryEntryCount = 0;
+    const memRecord = await AgentMemory.findOne({ agentName, instanceId })
+      .select('sections updatedAt')
+      .lean();
+    if (memRecord) {
+      const sections = (memRecord as Record<string, unknown>).sections;
+      hasMemory = true;
+      memoryUpdatedAt = (memRecord as Record<string, unknown>).updatedAt || null;
+      // Count entries across sections (size only — never content).
+      for (const v of Object.values((sections || {}) as Record<string, unknown>)) {
+        if (Array.isArray(v)) memoryEntryCount += v.length;
+        else if (v && typeof v === 'object') memoryEntryCount += 1;
+      }
+      publicMemory = filterSectionsByVisibility(
+        sections,
+        [], // requester has no shared pods → public-only
+        ownerPodIds,
+      );
+    }
+
+    // ── Recent activity (outcome-level, no message content) ─────────────────
+    const runs = await AgentRun.find({ agentName, instanceId })
+      .sort({ startedAt: -1 })
+      .limit(6)
+      .select('status trigger startedAt turns errorKind')
+      .lean();
+    const activity = (runs as Array<Record<string, unknown>>).map((r) => ({
+      status: String(r.status || 'unknown'),
+      trigger: r.trigger ? String(r.trigger) : undefined,
+      startedAt: r.startedAt,
+      turns: Array.isArray(r.turns) ? (r.turns as unknown[]).length : 0,
+      errorKind: r.errorKind ? String(r.errorKind) : undefined,
+    }));
+
+    res.json({
+      agent: {
+        agentName,
+        instanceId,
+        displayName: resolveAgentDisplayLabel(user, user.username),
+        profilePicture: user.profilePicture || 'default',
+        runtime: bm.runtimeId ? String(bm.runtimeId) : (bm.agentName ? String(bm.agentName) : null),
+        officialAgent: !!bm.officialAgent,
+        description: bm.description ? String(bm.description) : undefined,
+        capabilities: Array.isArray(bm.capabilities) ? (bm.capabilities as string[]) : [],
+        personality: persona
+          ? {
+            tone: persona.tone ? String(persona.tone) : undefined,
+            interests: Array.isArray(persona.interests) ? (persona.interests as string[]) : [],
+          }
+          : undefined,
+        createdAt: user.createdAt,
+      },
+      skills,
+      pods: { count: ownerPodIds.length, publicNames: publicPodNames },
+      memory: {
+        has: hasMemory,
+        entryCount: memoryEntryCount,
+        updatedAt: memoryUpdatedAt,
+        sections: publicMemory,
+      },
+      activity,
+    });
+  } catch (err) {
+    console.error('[agent-profile] error:', (err as Error).message);
+    res.status(500).json({ error: 'Server Error' });
+  }
+});
+
+module.exports = router;
+export {};

--- a/backend/routes/agentProfile.ts
+++ b/backend/routes/agentProfile.ts
@@ -150,7 +150,7 @@ router.get('/:agentName/:instanceId?', async (req: Req, res: Res) => {
         else if (v && typeof v === 'object') memoryEntryCount += 1;
       }
       publicMemory = filterSectionsByVisibility(
-        sections,
+        sections as Parameters<typeof filterSectionsByVisibility>[0],
         [], // requester has no shared pods → public-only
         ownerPodIds,
       );

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -206,6 +206,10 @@ app.use('/api/stats', statsRoutes); // Public stats (no auth)
 // Public read-only showcase (no auth — handlers self-gate on pod.publicRead).
 // SECURITY-CRITICAL: the only anonymous read path; serves only flagged pods.
 app.use('/api/showcase', showcaseRoutes);
+// Public read-only agent profile (no auth — self-gates on isBot, whitelist-only).
+// SECURITY-CRITICAL: anonymous read path; serves only agent identities, never
+// private memory / pod names / credentials. See routes/agentProfile.ts.
+app.use('/api/agent-profile', require('./routes/agentProfile'));
 app.use('/api/admin/pods', adminPodsRoutes); // Admin pod ops (showcase toggle)
 app.use('/api/pods', agentEnsembleRoutes); // Agent Ensemble Pod endpoints
 

--- a/frontend/src/v2/V2App.tsx
+++ b/frontend/src/v2/V2App.tsx
@@ -12,6 +12,7 @@ import VerifyEmail from '../components/VerifyEmail';
 import DiscordCallback from '../components/DiscordCallback';
 import V2LandingPage from './landing/V2LandingPage';
 import V2Showcase from './showcase/V2Showcase';
+import V2AgentProfile from './agents/V2AgentProfile';
 import UseCasePage from '../components/landing/UseCasePage';
 import PostFeed from '../components/PostFeed';
 import Thread from '../components/Thread';
@@ -153,6 +154,11 @@ const V2App: React.FC = () => {
               so anonymous visitors reach it without bouncing to /v2/login. */}
           <Route path="showcase" element={<V2Showcase />} />
           <Route path="showcase/:podId" element={<V2Showcase />} />
+          {/* Public read-only agent profile — the "meet the agent" identity card.
+              Singular /v2/agent/... so it never collides with the authed plural
+              /v2/agents (Your Team). Outside V2RequireAuth, like the showcase. */}
+          <Route path="agent/:agentName" element={<V2AgentProfile />} />
+          <Route path="agent/:agentName/:instanceId" element={<V2AgentProfile />} />
           <Route path="use-cases/:useCaseId" element={<UseCasePage />} />
           <Route path="login" element={<V2Login />} />
           <Route path="register" element={<V2Register />} />

--- a/frontend/src/v2/agents/V2AgentProfile.tsx
+++ b/frontend/src/v2/agents/V2AgentProfile.tsx
@@ -1,0 +1,228 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import axios from 'axios';
+import getApiBaseUrl from '../../utils/apiBaseUrl';
+import V2Avatar from '../components/V2Avatar';
+import '../v2.css';
+import './v2-agent-profile.css';
+
+// Public, logged-out, read-only agent PROFILE — the "meet the agent" identity
+// card, distinct from the owner-only Configuration control panel. Sits OUTSIDE
+// the auth gate (see V2App), so every fetch MUST be token-less.
+//
+// Contract (shared with backend routes/agentProfile.ts):
+//   GET /api/agent-profile/:agentName/:instanceId → { agent, skills, pods, memory, activity }
+// Whitelisted: never email / tokens / private memory / private pod names.
+
+// Lazy token-less client (see V2Showcase for the full rationale): the default
+// axios instance injects the viewer's bearer token; a dedicated instance keeps
+// this public endpoint anonymous regardless of auth state.
+let _client: ReturnType<typeof axios.create> | null = null;
+const getClient = () => {
+  if (!_client) _client = axios.create({ baseURL: getApiBaseUrl() });
+  return _client;
+};
+
+interface AgentProfile {
+  agent: {
+    agentName: string;
+    instanceId: string;
+    displayName: string;
+    profilePicture: string;
+    runtime: string | null;
+    officialAgent: boolean;
+    description?: string;
+    capabilities: string[];
+    personality?: { tone?: string; interests?: string[] };
+    createdAt?: string;
+  };
+  skills: Array<{ name: string; description?: string }>;
+  pods: { count: number; publicNames: string[] };
+  memory: { has: boolean; entryCount: number; updatedAt?: string | null };
+  activity: Array<{ status: string; trigger?: string; startedAt?: string; turns: number; errorKind?: string }>;
+}
+
+const timeAgo = (iso?: string | null): string => {
+  if (!iso) return '';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const s = Math.max(1, Math.floor((Date.now() - then) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+};
+
+const TopBar: React.FC = () => (
+  <header className="v2-aprofile__bar">
+    <Link className="v2-aprofile__brand" to="/v2/landing">
+      <span className="v2-rail__brand-icon">c</span>
+      Commonly
+    </Link>
+    <nav className="v2-aprofile__nav">
+      <Link className="v2-aprofile__navlink" to="/v2/landing">What is Commonly?</Link>
+      <Link className="v2-aprofile__navlink" to="/v2/login">Sign in</Link>
+      <Link className="v2-aprofile__btn v2-aprofile__btn--primary" to="/v2/register">Sign up</Link>
+    </nav>
+  </header>
+);
+
+const V2AgentProfile: React.FC = () => {
+  const { agentName, instanceId } = useParams<{ agentName: string; instanceId?: string }>();
+  const [data, setData] = useState<AgentProfile | null>(null);
+  const [state, setState] = useState<'loading' | 'ready' | 'error'>('loading');
+
+  const fetchProfile = useCallback(async () => {
+    setState('loading');
+    try {
+      const id = instanceId || 'default';
+      const res = await getClient().get<AgentProfile>(
+        `/api/agent-profile/${encodeURIComponent(agentName || '')}/${encodeURIComponent(id)}`,
+      );
+      setData(res.data);
+      setState('ready');
+    } catch {
+      setState('error');
+    }
+  }, [agentName, instanceId]);
+
+  useEffect(() => { fetchProfile(); }, [fetchProfile]);
+
+  if (state === 'loading') {
+    return (
+      <div className="v2-root v2-aprofile">
+        <TopBar />
+        <div className="v2-aprofile__center"><div className="v2-aprofile__muted">Loading…</div></div>
+      </div>
+    );
+  }
+  if (state === 'error' || !data) {
+    return (
+      <div className="v2-root v2-aprofile">
+        <TopBar />
+        <div className="v2-aprofile__center">
+          <h1 className="v2-aprofile__empty-title">Agent not found</h1>
+          <p className="v2-aprofile__muted">This agent may not exist. Explore what Commonly is, or start your own team.</p>
+          <div className="v2-aprofile__cta-row">
+            <Link className="v2-aprofile__btn v2-aprofile__btn--primary" to="/v2/register">Start your own team</Link>
+            <Link className="v2-aprofile__btn v2-aprofile__btn--ghost" to="/v2/landing">What is Commonly?</Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const { agent, skills, pods, memory, activity } = data;
+  const runtimeLabel = (agent.runtime || '').toUpperCase();
+
+  return (
+    <div className="v2-root v2-aprofile">
+      <TopBar />
+      <main className="v2-aprofile__main">
+        {/* Identity header */}
+        <section className="v2-aprofile__hero">
+          <V2Avatar name={agent.displayName} src={agent.profilePicture} size="lg" />
+          <div className="v2-aprofile__hero-text">
+            <div className="v2-aprofile__name-row">
+              <h1 className="v2-aprofile__name">{agent.displayName}</h1>
+              {runtimeLabel && <span className="v2-aprofile__runtime">{runtimeLabel}</span>}
+              {agent.officialAgent && <span className="v2-aprofile__badge">Official</span>}
+            </div>
+            {agent.description && <p className="v2-aprofile__desc">{agent.description}</p>}
+            <div className="v2-aprofile__meta">
+              <span>Active in {pods.count} pod{pods.count === 1 ? '' : 's'}</span>
+              {memory.has && <span>· {memory.entryCount} memories</span>}
+              {agent.personality?.tone && <span>· {agent.personality.tone}</span>}
+            </div>
+          </div>
+          <Link className="v2-aprofile__btn v2-aprofile__btn--primary" to="/v2/register">Talk to {agent.displayName.split(' ')[0]}</Link>
+        </section>
+
+        <div className="v2-aprofile__grid">
+          {/* Capabilities + specialties */}
+          {(agent.capabilities.length > 0 || (agent.personality?.interests?.length || 0) > 0) && (
+            <section className="v2-aprofile__card">
+              <h2 className="v2-aprofile__card-title">Specialties</h2>
+              <div className="v2-aprofile__chips">
+                {agent.capabilities.map((c) => <span key={c} className="v2-aprofile__chip">{c}</span>)}
+                {(agent.personality?.interests || []).map((i) => <span key={i} className="v2-aprofile__chip v2-aprofile__chip--soft">{i}</span>)}
+              </div>
+            </section>
+          )}
+
+          {/* Installed skills */}
+          <section className="v2-aprofile__card">
+            <h2 className="v2-aprofile__card-title">Installed skills <span className="v2-aprofile__count">{skills.length}</span></h2>
+            {skills.length === 0 ? (
+              <p className="v2-aprofile__muted">No skills attached yet.</p>
+            ) : (
+              <ul className="v2-aprofile__list">
+                {skills.slice(0, 12).map((s) => (
+                  <li key={s.name} className="v2-aprofile__skill">
+                    <span className="v2-aprofile__skill-name">{s.name}</span>
+                    {s.description && <span className="v2-aprofile__skill-desc">{s.description}</span>}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {/* Memory layer (stat — never private content) */}
+          <section className="v2-aprofile__card">
+            <h2 className="v2-aprofile__card-title">Memory layer</h2>
+            {memory.has ? (
+              <div className="v2-aprofile__memory">
+                <div className="v2-aprofile__stat">
+                  <span className="v2-aprofile__stat-num">{memory.entryCount}</span>
+                  <span className="v2-aprofile__stat-label">entries remembered</span>
+                </div>
+                <p className="v2-aprofile__muted">
+                  Persistent memory carried across every pod and runtime this agent joins.
+                  {memory.updatedAt && ` Last updated ${timeAgo(memory.updatedAt)}.`}
+                </p>
+              </div>
+            ) : (
+              <p className="v2-aprofile__muted">No memory recorded yet.</p>
+            )}
+          </section>
+
+          {/* Pods */}
+          {pods.publicNames.length > 0 && (
+            <section className="v2-aprofile__card">
+              <h2 className="v2-aprofile__card-title">Public pods</h2>
+              <div className="v2-aprofile__chips">
+                {pods.publicNames.map((n) => <span key={n} className="v2-aprofile__chip">{n}</span>)}
+              </div>
+            </section>
+          )}
+
+          {/* Recent activity */}
+          {activity.length > 0 && (
+            <section className="v2-aprofile__card">
+              <h2 className="v2-aprofile__card-title">Recent activity</h2>
+              <ul className="v2-aprofile__list">
+                {activity.map((a, i) => (
+                  <li key={i} className="v2-aprofile__run">
+                    <span className={`v2-aprofile__run-dot v2-aprofile__run-dot--${a.errorKind ? 'err' : a.status}`} />
+                    <span className="v2-aprofile__run-label">{a.trigger || a.status}</span>
+                    <span className="v2-aprofile__muted">{a.turns} turn{a.turns === 1 ? '' : 's'} · {timeAgo(a.startedAt)}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </div>
+
+        <div className="v2-aprofile__footer-cta">
+          <span>Every agent on Commonly keeps one identity and memory — across any runtime.</span>
+          <Link className="v2-aprofile__btn v2-aprofile__btn--primary" to="/v2/register">Start your own team</Link>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default V2AgentProfile;

--- a/frontend/src/v2/agents/v2-agent-profile.css
+++ b/frontend/src/v2/agents/v2-agent-profile.css
@@ -1,0 +1,156 @@
+/* Public agent profile — token-aligned, single accent, borders not shadows.
+ * Mirrors the showcase/landing surfaces (own scroll container over the app shell). */
+.v2-root.v2-aprofile {
+  display: block;
+  height: 100vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: var(--v2-page-bg, #f8f8fb);
+  color: var(--v2-text-primary);
+  font-family: var(--v2-font);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Top bar */
+.v2-aprofile__bar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 60px;
+  padding: 0 max(24px, calc((100% - 1040px) / 2));
+  background: rgba(255, 255, 255, 0.86);
+  backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid var(--v2-border-soft);
+}
+.v2-aprofile__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  font-size: 16px;
+  color: var(--v2-text-primary);
+  text-decoration: none;
+}
+.v2-aprofile__nav { display: flex; align-items: center; gap: 18px; }
+.v2-aprofile__navlink { font-size: 14px; font-weight: 500; color: var(--v2-text-secondary); text-decoration: none; }
+.v2-aprofile__navlink:hover { color: var(--v2-text-primary); }
+
+.v2-aprofile__btn {
+  display: inline-flex;
+  align-items: center;
+  height: 38px;
+  padding: 0 18px;
+  border-radius: var(--v2-radius);
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.v2-aprofile__btn--primary { background: var(--v2-accent); border-color: var(--v2-accent); }
+.v2-aprofile__btn--primary:hover { background: var(--v2-accent-strong); border-color: var(--v2-accent-strong); }
+.v2-aprofile__btn--ghost { background: var(--v2-surface); border-color: var(--v2-border-strong, var(--v2-border)); }
+.v2-aprofile__btn--ghost:hover { background: var(--v2-surface-hover); }
+/* `.v2-root a { color: inherit }` (0,1,1) beats the single-class rules — re-assert. */
+.v2-root .v2-aprofile__btn--primary { color: #ffffff; }
+.v2-root .v2-aprofile__btn--ghost { color: var(--v2-text-primary); }
+
+/* Main + centered states */
+.v2-aprofile__main { max-width: 1040px; margin: 0 auto; padding: 32px 24px 64px; }
+.v2-aprofile__center {
+  max-width: 1040px; margin: 0 auto; padding: 120px 24px;
+  display: flex; flex-direction: column; align-items: center; text-align: center; gap: 12px;
+}
+.v2-aprofile__empty-title { font-size: 24px; font-weight: 850; letter-spacing: -0.02em; margin: 0; }
+.v2-aprofile__muted { color: var(--v2-text-tertiary); font-size: 14px; line-height: 1.5; }
+.v2-aprofile__cta-row { display: flex; gap: 10px; margin-top: 8px; flex-wrap: wrap; justify-content: center; }
+
+/* Identity hero */
+.v2-aprofile__hero {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 24px;
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-lg);
+  margin-bottom: 20px;
+}
+.v2-aprofile__hero-text { flex: 1 1 auto; min-width: 0; }
+.v2-aprofile__name-row { display: flex; align-items: center; flex-wrap: wrap; gap: 10px; }
+.v2-aprofile__name { margin: 0; font-size: 24px; font-weight: 850; letter-spacing: -0.02em; color: var(--v2-text-primary); }
+.v2-aprofile__runtime {
+  font-size: 11px; font-weight: 600; letter-spacing: 0.03em; text-transform: uppercase;
+  color: var(--v2-text-secondary); background: var(--v2-bg-subtle);
+  padding: 2px 8px; border-radius: 4px;
+}
+.v2-aprofile__badge {
+  font-size: 11px; font-weight: 600; color: var(--v2-accent-text);
+  background: var(--v2-accent-soft); padding: 2px 8px; border-radius: var(--v2-radius-pill);
+}
+.v2-aprofile__desc { margin: 8px 0 0; font-size: 15px; line-height: 1.5; color: var(--v2-text-secondary); }
+.v2-aprofile__meta { margin-top: 10px; font-size: 13px; color: var(--v2-text-tertiary); display: flex; gap: 6px; flex-wrap: wrap; }
+
+/* Cards grid */
+.v2-aprofile__grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+.v2-aprofile__card {
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-lg);
+  padding: 20px;
+}
+.v2-aprofile__card-title {
+  margin: 0 0 14px; font-size: 13px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--v2-text-tertiary);
+  display: flex; align-items: center; gap: 8px;
+}
+.v2-aprofile__count {
+  font-size: 11px; color: var(--v2-text-secondary); background: var(--v2-bg-subtle);
+  padding: 1px 7px; border-radius: var(--v2-radius-pill); letter-spacing: 0;
+}
+.v2-aprofile__chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.v2-aprofile__chip {
+  font-size: 12px; font-weight: 500; color: var(--v2-text-secondary);
+  background: var(--v2-bg-subtle); border: 1px solid var(--v2-border-soft);
+  padding: 4px 10px; border-radius: var(--v2-radius-pill);
+}
+.v2-aprofile__chip--soft { background: var(--v2-surface); color: var(--v2-text-tertiary); }
+
+.v2-aprofile__list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+.v2-aprofile__skill { display: flex; flex-direction: column; gap: 2px; }
+.v2-aprofile__skill-name { font-size: 14px; font-weight: 600; color: var(--v2-text-primary); }
+.v2-aprofile__skill-desc { font-size: 12.5px; color: var(--v2-text-tertiary); line-height: 1.4; }
+
+.v2-aprofile__memory { display: flex; flex-direction: column; gap: 10px; }
+.v2-aprofile__stat { display: flex; align-items: baseline; gap: 8px; }
+.v2-aprofile__stat-num { font-size: 34px; font-weight: 850; letter-spacing: -0.03em; color: var(--v2-accent); }
+.v2-aprofile__stat-label { font-size: 13px; color: var(--v2-text-secondary); }
+
+.v2-aprofile__run { display: flex; align-items: center; gap: 8px; font-size: 13px; }
+.v2-aprofile__run-label { font-weight: 500; color: var(--v2-text-primary); }
+.v2-aprofile__run-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; background: var(--v2-text-muted); }
+.v2-aprofile__run-dot--succeeded { background: var(--v2-success); }
+.v2-aprofile__run-dot--failed, .v2-aprofile__run-dot--err { background: var(--v2-danger); }
+
+.v2-aprofile__footer-cta {
+  margin-top: 24px; padding: 20px 24px;
+  display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap;
+  background: var(--v2-accent-deep); border-radius: var(--v2-radius-lg);
+  color: rgba(255, 255, 255, 0.85); font-size: 15px;
+}
+.v2-root .v2-aprofile__footer-cta .v2-aprofile__btn--primary { background: #fff; color: var(--v2-accent); border-color: #fff; }
+.v2-root .v2-aprofile__footer-cta .v2-aprofile__btn--primary:hover { background: rgba(255,255,255,0.9); }
+
+@media (max-width: 760px) {
+  .v2-aprofile__hero { flex-direction: column; align-items: flex-start; }
+  .v2-aprofile__grid { grid-template-columns: 1fr; }
+  .v2-aprofile__nav .v2-aprofile__navlink { display: none; }
+}


### PR DESCRIPTION
Adds the **"meet the agent"** surface you asked for — the identity home for an agent, distinct from the owner-only **Configuration** control panel.

## The profile vs config line
**Config = the private control panel (knobs you turn). Profile = the public identity card (state you observe).** Same nouns, opposite verbs: config *attaches/clears* skills+memory (write); profile *displays* them (read). Credentials/tokens/model stay config-only.

## Backend — `GET /api/agent-profile/:agentName/:instanceId`
Public, no auth, rate-limited — same hardened posture as `routes/showcase.ts`:
- Serves **only** agent (`isBot`) identities; humans 404 (no user oracle).
- Composes existing sources, **whitelist-only**: identity (`botMetadata` + `agentConfig` personality), installed skills (`PodAsset` scope=agent), pod memberships (**count + only `publicRead` pod names**), memory as a **size stat** (entry count + `updatedAt` — never content; reuses `filterSectionsByVisibility` with empty requester-pods so only `public` sections could ever surface), recent activity (`AgentRun` outcomes, no message content).
- **Never** email / tokens / credentials / private memory / private pod names.

## Frontend — `V2AgentProfile` at `/v2/agent/:agentName/:instanceId`
Public, token-less, read-only. Singular `/v2/agent/...` so it never collides with the authed plural `/v2/agents` (Your Team). Identity hero → specialties → skills → memory-layer stat → public pods → recent activity → sign-up CTA.

## Data reality (honest)
No agent has *public* memory today (all private/pod-scoped), so the memory section shows the layer as a **size stat** ("N entries remembered · updated X"), not content — safe, and still communicates the feature. Activity is rich for native agents (task-clerk etc.), sparse for dev agents. Verified locally: component mounts, routes, error state + button contrast correct. Happy path verified live post-deploy.

This becomes the real `agent-identity.png` screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)