### PR TITLE
fix(agent-profile): query real skills, hide section when empty

### DIFF
--- a/backend/routes/agentProfile.ts
+++ b/backend/routes/agentProfile.ts
@@ -92,8 +92,14 @@ router.get('/:agentName/:instanceId?', async (req: Req, res: Res) => {
       | Record<string, unknown>
       | undefined;
 
-    // ── Installed skills (scope=agent) ──────────────────────────────────────
+    // ── Installed skills (agent-scoped skill assets) ────────────────────────
+    // MUST filter type:'skill' — scope:'agent' alone also matches the agent's
+    // memory / daily-log PodAssets, which are NOT skills. Agent-scoped skills are
+    // rare today (skills are mostly pod-scoped), so this is usually empty and the
+    // frontend hides the section; capabilities carry the "what it does" story.
     const skillDocs = await PodAsset.find({
+      type: 'skill',
+      status: 'active',
       'metadata.scope': 'agent',
       'metadata.agentName': agentName,
       'metadata.instanceId': instanceId,

--- a/frontend/src/v2/agents/V2AgentProfile.tsx
+++ b/frontend/src/v2/agents/V2AgentProfile.tsx
@@ -153,12 +153,12 @@ const V2AgentProfile: React.FC = () => {
             </section>
           )}
 
-          {/* Installed skills */}
-          <section className="v2-aprofile__card">
-            <h2 className="v2-aprofile__card-title">Installed skills <span className="v2-aprofile__count">{skills.length}</span></h2>
-            {skills.length === 0 ? (
-              <p className="v2-aprofile__muted">No skills attached yet.</p>
-            ) : (
+          {/* Installed skills — only when the agent genuinely has agent-scoped
+              skills (rare today; skills are mostly pod-scoped). Capabilities above
+              carry the "what it does" story otherwise. */}
+          {skills.length > 0 && (
+            <section className="v2-aprofile__card">
+              <h2 className="v2-aprofile__card-title">Installed skills <span className="v2-aprofile__count">{skills.length}</span></h2>
               <ul className="v2-aprofile__list">
                 {skills.slice(0, 12).map((s) => (
                   <li key={s.name} className="v2-aprofile__skill">
@@ -167,8 +167,8 @@ const V2AgentProfile: React.FC = () => {
                   </li>
                 ))}
               </ul>
-            )}
-          </section>
+            </section>
+          )}
 
           {/* Memory layer (stat — never private content) */}
           <section className="v2-aprofile__card">


### PR DESCRIPTION
The agent profile's **Installed skills** list showed date-named memory files (`2026-05-20.md`…) — the query matched `metadata.scope:'agent'` **without** `type:'skill'`, so it grabbed the agent's memory + daily-log `PodAsset`s, not skills.

Reality: **zero agent-scoped skill assets exist** (all 6488 skills are pod-scoped). Fix:
- **backend**: add `type:'skill', status:'active'` to the query (correct source)
- **frontend**: render the Installed-skills card only when the agent has ≥1 agent-scoped skill

Capabilities (Specialties) already convey what the agent does; the skills card stays hidden until an agent genuinely has agent-scoped skills attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)