### PR TITLE
feat(agents): private memory index (owner/admin) + honor per-agent skill scope

### DIFF
--- a/backend/routes/agentMemoryView.ts
+++ b/backend/routes/agentMemoryView.ts
@@ -13,6 +13,10 @@
  * housekeeping sections (dedup_state, runtime_meta) are excluded.
  */
 
+// ESM import so CodeQL's js/missing-rate-limiting query sees the limiter.
+import rateLimit from 'express-rate-limit';
+import { cloudflareIpRateLimitKeyGenerator } from '../middleware/ipRateLimit';
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const express = require('express');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -74,7 +78,20 @@ const indexMarkdown = (content: string): Array<{ header: string; snippet: string
   return notes.slice(0, 20);
 };
 
+// IP-keyed limiter, FIRST middleware on the router — blunts scraping/enumeration
+// even though the route is auth-gated. Skipped in tests. (CodeQL js/missing-rate-limiting.)
+const memoryRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  keyGenerator: (req: unknown) => cloudflareIpRateLimitKeyGenerator(req as never),
+  handler: (_req: unknown, res: Res) => res.status(429).json({ code: 'rate_limited' }),
+});
+
 const router: ReturnType<typeof express.Router> = express.Router();
+router.use(memoryRateLimit);
 
 // GET /api/agent-memory/:agentName/:instanceId? — owner/admin memory index.
 router.get('/:agentName/:instanceId?', auth, async (req: AuthReq, res: Res) => {

--- a/backend/routes/agentMemoryView.ts
+++ b/backend/routes/agentMemoryView.ts
@@ -1,0 +1,169 @@
+/**
+ * Authed, owner/admin-only agent MEMORY view — the private counterpart to the
+ * public agent profile. Where the public profile shows only a count, this
+ * returns an INDEX of the agent's memory (section headers + short snippets) so
+ * an owner or admin can see what their agent actually remembers.
+ *
+ * Access:
+ *   - admin (role === 'admin') → any agent
+ *   - owner (installed this agent: AgentInstallation.installedBy === viewer) → their agent
+ *   - everyone else → 403
+ *
+ * Returns snippets, never full raw content — "a fraction of memory". Internal
+ * housekeeping sections (dedup_state, runtime_meta) are excluded.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const express = require('express');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const auth = require('../middleware/auth');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const User = require('../models/User');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const AgentMemory = require('../models/AgentMemory');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { AgentInstallation } = require('../models/AgentRegistry');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { resolveAgentDisplayLabel } = require('../services/agentIdentityService');
+
+interface AuthReq {
+  user?: { id?: string };
+  userId?: string;
+  params?: { agentName?: string; instanceId?: string };
+}
+interface Res {
+  status: (n: number) => Res;
+  json: (d: unknown) => Res | void;
+}
+
+const getUserId = (req: AuthReq): string | undefined => req.user?.id || req.userId;
+const SNIPPET = 180;
+const snip = (s: unknown): string => {
+  const t = String(s ?? '').replace(/\s+/g, ' ').trim();
+  return t.length > SNIPPET ? `${t.slice(0, SNIPPET)}…` : t;
+};
+
+// Sections that are internal housekeeping, never shown as "memory".
+const INTERNAL_SECTIONS = new Set(['dedup_state', 'runtime_meta']);
+
+// Parse a markdown blob into an index of its `#`/`##` headers + the snippet of
+// text that follows each. Falls back to one untitled note if there are no
+// headers. Returns [] for empty content.
+const indexMarkdown = (content: string): Array<{ header: string; snippet: string }> => {
+  const text = String(content || '').trim();
+  if (!text) return [];
+  const lines = text.split('\n');
+  const notes: Array<{ header: string; snippet: string }> = [];
+  let current: { header: string; body: string[] } | null = null;
+  const flush = () => {
+    if (current) notes.push({ header: current.header, snippet: snip(current.body.join(' ')) });
+  };
+  for (const line of lines) {
+    const h = line.match(/^#{1,3}\s+(.*)$/);
+    if (h) {
+      flush();
+      current = { header: h[1].trim(), body: [] };
+    } else if (current) {
+      current.body.push(line);
+    } else if (line.trim()) {
+      // Preamble before any header → an "Overview" note.
+      current = { header: 'Overview', body: [line] };
+    }
+  }
+  flush();
+  return notes.slice(0, 20);
+};
+
+const router: ReturnType<typeof express.Router> = express.Router();
+
+// GET /api/agent-memory/:agentName/:instanceId? — owner/admin memory index.
+router.get('/:agentName/:instanceId?', auth, async (req: AuthReq, res: Res) => {
+  try {
+    const userId = getUserId(req);
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const agentName = String(req.params?.agentName || '').trim().toLowerCase();
+    const instanceId = String(req.params?.instanceId || 'default').trim() || 'default';
+    if (!agentName) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+
+    // Access gate: admin OR owner (installed this agent).
+    const viewer = await User.findById(userId).select('role').lean();
+    const isAdmin = viewer?.role === 'admin';
+    let role: 'admin' | 'owner' | null = isAdmin ? 'admin' : null;
+    if (!isAdmin) {
+      const owns = await AgentInstallation.findOne({
+        agentName,
+        instanceId,
+        installedBy: userId,
+        status: 'active',
+      }).select('_id').lean();
+      if (owns) role = 'owner';
+    }
+    if (!role) {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+
+    const agentUser = await User.findOne({
+      isBot: true,
+      'botMetadata.agentName': agentName,
+      'botMetadata.instanceId': instanceId,
+    }).select('username botMetadata').lean();
+
+    const record = await AgentMemory.findOne({ agentName, instanceId })
+      .select('sections updatedAt')
+      .lean();
+
+    const sections: Array<{ key: string; label: string; kind: string; notes: unknown[] }> = [];
+    let totalEntries = 0;
+    const raw = ((record as Record<string, unknown>)?.sections || {}) as Record<string, unknown>;
+
+    for (const [key, value] of Object.entries(raw)) {
+      if (INTERNAL_SECTIONS.has(key)) continue;
+
+      if (key === 'daily' && Array.isArray(value)) {
+        const notes = value
+          .slice(-12)
+          .reverse()
+          .map((d: Record<string, unknown>) => ({ header: String(d.date || ''), snippet: snip(d.content) }))
+          .filter((n) => n.header || n.snippet);
+        if (notes.length) { sections.push({ key, label: 'Daily journal', kind: 'log', notes }); totalEntries += notes.length; }
+      } else if (key === 'cycles' && value && typeof value === 'object') {
+        const entries = Array.isArray((value as Record<string, unknown>).entries)
+          ? ((value as Record<string, unknown>).entries as Array<Record<string, unknown>>)
+          : [];
+        const notes = entries.slice(0, 8).map((e) => ({
+          header: e.ts ? String(e.ts).slice(0, 10) : 'cycle',
+          snippet: snip(e.content),
+        }));
+        if (notes.length) { sections.push({ key, label: 'Heartbeat cycles', kind: 'log', notes }); totalEntries += notes.length; }
+      } else if (value && typeof value === 'object' && 'content' in (value as Record<string, unknown>)) {
+        // long_term (and any future doc-shaped section) → index its headers.
+        const notes = indexMarkdown(String((value as Record<string, unknown>).content || ''));
+        const label = key === 'long_term' ? 'Long-term memory' : key.replace(/_/g, ' ');
+        if (notes.length) { sections.push({ key, label, kind: 'doc', notes }); totalEntries += notes.length; }
+      }
+    }
+
+    res.json({
+      agentName,
+      instanceId,
+      displayName: agentUser ? resolveAgentDisplayLabel(agentUser, agentUser.username) : instanceId,
+      viewerRole: role,
+      updatedAt: (record as Record<string, unknown>)?.updatedAt || null,
+      totalEntries,
+      sections,
+    });
+  } catch (err) {
+    console.error('[agent-memory] error:', (err as Error).message);
+    res.status(500).json({ error: 'Server Error' });
+  }
+});
+
+module.exports = router;
+export {};

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -210,6 +210,9 @@ app.use('/api/showcase', showcaseRoutes);
 // SECURITY-CRITICAL: anonymous read path; serves only agent identities, never
 // private memory / pod names / credentials. See routes/agentProfile.ts.
 app.use('/api/agent-profile', require('./routes/agentProfile'));
+// Authed owner/admin-only agent memory index (private counterpart to the public
+// profile). Self-gates via auth middleware + owner/admin check inside the route.
+app.use('/api/agent-memory', require('./routes/agentMemoryView'));
 app.use('/api/admin/pods', adminPodsRoutes); // Admin pod ops (showcase toggle)
 app.use('/api/pods', agentEnsembleRoutes); // Agent Ensemble Pod endpoints
 

--- a/backend/services/agentProvisionerServiceK8s.ts
+++ b/backend/services/agentProvisionerServiceK8s.ts
@@ -941,11 +941,19 @@ const syncOpenClawSkills = async ({
     ? podIds.map((id) => String(id)).filter(Boolean)
     : [];
   if (normalizedPods.length) {
-    const query = {
+    const query: any = {
       podId: { $in: normalizedPods },
       type: 'skill',
       status: 'active',
       sourceType: 'imported-skill',
+      // Honor skill scope at delivery: pod-scoped / unscoped skills go to every
+      // agent in the pod; agent-scoped skills go ONLY to their target agent.
+      // accountId === instanceId for the openclaw agents this provisioner serves,
+      // which is what agent-scoped skill assets key on (metadata.instanceId).
+      $or: [
+        { 'metadata.scope': { $ne: 'agent' } },
+        { 'metadata.scope': 'agent', 'metadata.instanceId': accountId },
+      ],
     };
     const normalizedSkillNames = Array.isArray(skillNames)
       ? skillNames.map((name) => String(name).trim()).filter(Boolean)

--- a/frontend/src/v2/agents/V2AgentProfile.tsx
+++ b/frontend/src/v2/agents/V2AgentProfile.tsx
@@ -42,6 +42,15 @@ interface AgentProfile {
   activity: Array<{ status: string; trigger?: string; startedAt?: string; turns: number; errorKind?: string }>;
 }
 
+// Owner/admin-only memory index (fetched with the viewer's token; 401/403 for
+// everyone else → public count is shown instead).
+interface MemoryIndex {
+  viewerRole: 'owner' | 'admin';
+  totalEntries: number;
+  updatedAt?: string | null;
+  sections: Array<{ key: string; label: string; kind: string; notes: Array<{ header: string; snippet: string }> }>;
+}
+
 const timeAgo = (iso?: string | null): string => {
   if (!iso) return '';
   const then = new Date(iso).getTime();
@@ -74,6 +83,7 @@ const V2AgentProfile: React.FC = () => {
   const { agentName, instanceId } = useParams<{ agentName: string; instanceId?: string }>();
   const [data, setData] = useState<AgentProfile | null>(null);
   const [state, setState] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [memIndex, setMemIndex] = useState<MemoryIndex | null>(null);
 
   const fetchProfile = useCallback(async () => {
     setState('loading');
@@ -89,7 +99,25 @@ const V2AgentProfile: React.FC = () => {
     }
   }, [agentName, instanceId]);
 
-  useEffect(() => { fetchProfile(); }, [fetchProfile]);
+  // Progressive enhancement: if the viewer is signed in AND owns this agent (or
+  // is an admin), pull the private memory index. Public visitors 401/403 here and
+  // just see the count. Token passed explicitly since getClient() is token-less.
+  const fetchMemoryIndex = useCallback(async () => {
+    const token = typeof window !== 'undefined' ? window.localStorage.getItem('token') : null;
+    if (!token || !agentName) { setMemIndex(null); return; }
+    try {
+      const id = instanceId || 'default';
+      const res = await getClient().get<MemoryIndex>(
+        `/api/agent-memory/${encodeURIComponent(agentName)}/${encodeURIComponent(id)}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      setMemIndex(res.data);
+    } catch {
+      setMemIndex(null);
+    }
+  }, [agentName, instanceId]);
+
+  useEffect(() => { fetchProfile(); fetchMemoryIndex(); }, [fetchProfile, fetchMemoryIndex]);
 
   if (state === 'loading') {
     return (
@@ -170,10 +198,36 @@ const V2AgentProfile: React.FC = () => {
             </section>
           )}
 
-          {/* Memory layer (stat — never private content) */}
-          <section className="v2-aprofile__card">
-            <h2 className="v2-aprofile__card-title">Memory layer</h2>
-            {memory.has ? (
+          {/* Memory layer — public sees a count; owner/admin see the private
+              index (section headers + snippets), fetched with their token. */}
+          <section className={`v2-aprofile__card${memIndex && memIndex.sections.length > 0 ? ' v2-aprofile__card--wide' : ''}`}>
+            <h2 className="v2-aprofile__card-title">
+              Memory layer
+              {memIndex && <span className="v2-aprofile__owner-tag">{memIndex.viewerRole} view · private</span>}
+            </h2>
+            {memIndex && memIndex.sections.length > 0 ? (
+              <div className="v2-aprofile__memidx">
+                <p className="v2-aprofile__muted">
+                  {memIndex.totalEntries} notes across {memIndex.sections.length} section{memIndex.sections.length === 1 ? '' : 's'}
+                  {memIndex.updatedAt ? ` · updated ${timeAgo(memIndex.updatedAt)}` : ''}. Visible to you; hidden from the public profile.
+                </p>
+                <div className="v2-aprofile__memcols">
+                  {memIndex.sections.map((sec) => (
+                    <div key={sec.key} className="v2-aprofile__memsec">
+                      <h3 className="v2-aprofile__memsec-title">{sec.label} <span className="v2-aprofile__count">{sec.notes.length}</span></h3>
+                      <ul className="v2-aprofile__list">
+                        {sec.notes.map((n, i) => (
+                          <li key={i} className="v2-aprofile__memnote">
+                            <span className="v2-aprofile__memnote-h">{n.header}</span>
+                            {n.snippet && <span className="v2-aprofile__memnote-s">{n.snippet}</span>}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : memory.has ? (
               <div className="v2-aprofile__memory">
                 <div className="v2-aprofile__stat">
                   <span className="v2-aprofile__stat-num">{memory.entryCount}</span>

--- a/frontend/src/v2/agents/v2-agent-profile.css
+++ b/frontend/src/v2/agents/v2-agent-profile.css
@@ -134,6 +134,31 @@
 .v2-aprofile__stat-num { font-size: 34px; font-weight: 850; letter-spacing: -0.03em; color: var(--v2-accent); }
 .v2-aprofile__stat-label { font-size: 13px; color: var(--v2-text-secondary); }
 
+/* Memory index (owner/admin private view) */
+.v2-aprofile__card--wide { grid-column: 1 / -1; }
+.v2-aprofile__owner-tag {
+  margin-left: auto; font-size: 10.5px; font-weight: 600; letter-spacing: 0.02em;
+  text-transform: uppercase; color: var(--v2-accent-text);
+  background: var(--v2-accent-soft); padding: 2px 8px; border-radius: var(--v2-radius-pill);
+}
+.v2-aprofile__memidx { display: flex; flex-direction: column; gap: 14px; }
+.v2-aprofile__memcols {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 16px;
+}
+.v2-aprofile__memsec {
+  border: 1px solid var(--v2-border-soft); border-radius: var(--v2-radius);
+  padding: 14px; background: var(--v2-bg-subtle);
+}
+.v2-aprofile__memsec-title {
+  margin: 0 0 10px; font-size: 12px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.05em; color: var(--v2-text-secondary);
+  display: flex; align-items: center; gap: 6px;
+}
+.v2-aprofile__memnote { display: flex; flex-direction: column; gap: 2px; padding: 6px 0; border-top: 1px solid var(--v2-border-soft); }
+.v2-aprofile__memnote:first-child { border-top: none; padding-top: 0; }
+.v2-aprofile__memnote-h { font-size: 13px; font-weight: 600; color: var(--v2-text-primary); }
+.v2-aprofile__memnote-s { font-size: 12px; color: var(--v2-text-tertiary); line-height: 1.45; }
+
 .v2-aprofile__run { display: flex; align-items: center; gap: 8px; font-size: 13px; }
 .v2-aprofile__run-label { font-weight: 500; color: var(--v2-text-primary); }
 .v2-aprofile__run-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; background: var(--v2-text-muted); }


### PR DESCRIPTION
Two related fixes so the agent profile's skills/memory are genuinely real.

## 1. Per-agent skill scope — close the provisioner gap
`syncOpenClawSkills` synced **all** imported pod skills into every agent's workspace, ignoring `metadata.scope` — so an "agent-scoped" skill wasn't actually isolated to its target agent (the scoping was nominal, only in the DB key). Added a scope-aware filter:
- pod / unscoped skills → every agent in the pod (unchanged)
- **agent-scoped skills → only the matching agent** (`accountId === instanceId` for the openclaw agents this serves)

Per-agent skills are now end-to-end: import one skill "for Theo" and it shows as *his* on the profile.

## 2. Private memory view (owner/admin)
Memory stays **hidden on the public profile** (count only). The **owner** (installed the agent) or an **admin** now sees an **index** — section headers + short snippets:
- New authed endpoint `GET /api/agent-memory/:agentName/:instanceId` — admin (role) OR owner (`AgentInstallation.installedBy`); everyone else **403**.
- Parses sections into an index: `long_term` markdown `##` headers, `daily` journal by date, heartbeat `cycles` by timestamp. **Snippets only (≤180 chars) — never full raw content.** Internal sections (`dedup_state`, `runtime_meta`) excluded.
- Frontend: profile fetches the index with the viewer's token (progressive enhancement). Public → count; owner/admin → the full index card (wide).

Memory notes already carry natural headers (`long_term` markdown `##`; `daily` dates), so the index is real, not synthetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)