### PR TITLE
feat(agent-profile): pods list (sorted by last active) + compact memory

### DIFF
--- a/backend/models/pg/Message.ts
+++ b/backend/models/pg/Message.ts
@@ -273,6 +273,36 @@ class Message {
       return [];
     }
   }
+
+  // One row per pod: the given user's most-recent non-system message in each pod.
+  // Powers the agent-profile "pods" list (their last message + when, per pod).
+  static async findLastMessageByUserPerPod(
+    userId: unknown,
+    podIds: unknown[],
+  ): Promise<Array<{ podId: string; content: string; createdAt: unknown }>> {
+    if (!userId || !podIds || !podIds.length) return [];
+    try {
+      const uid = (userId as { toString(): string }).toString();
+      const podIdStrs = podIds.map((id) => (id as { toString(): string } | undefined)?.toString()).filter(Boolean);
+      if (!podIdStrs.length) return [];
+      const result = await (pool as PgPool).query(
+        `SELECT DISTINCT ON (pod_id) pod_id, content, created_at
+         FROM messages
+         WHERE user_id = $1 AND pod_id = ANY($2) AND message_type != 'system'
+         ORDER BY pod_id, created_at DESC`,
+        [uid, podIdStrs],
+      );
+      return (result.rows as Array<{ pod_id: string; content: string; created_at: unknown }>).map((r) => ({
+        podId: r.pod_id,
+        content: r.content,
+        createdAt: r.created_at,
+      }));
+    } catch (error) {
+      const e = error as { message?: string };
+      console.error('Error in findLastMessageByUserPerPod:', e.message);
+      return [];
+    }
+  }
 }
 
 export default Message;

--- a/backend/routes/agentMemoryView.ts
+++ b/backend/routes/agentMemoryView.ts
@@ -28,6 +28,10 @@ const AgentMemory = require('../models/AgentMemory');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { AgentInstallation } = require('../models/AgentRegistry');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
+const Pod = require('../models/Pod');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const PGMessage = require('../models/pg/Message');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { resolveAgentDisplayLabel } = require('../services/agentIdentityService');
 
 interface AuthReq {
@@ -132,6 +136,41 @@ router.get('/:agentName/:instanceId?', auth, async (req: AuthReq, res: Res) => {
       'botMetadata.instanceId': instanceId,
     }).select('username botMetadata').lean();
 
+    // ── Pods this agent is in — ALL pods (owner/admin view), each with last
+    // activity + the agent's own last message there, sorted most-active first. ──
+    const installs = await AgentInstallation.find({ agentName, instanceId, status: 'active' })
+      .select('podId').lean();
+    const podIds = Array.from(new Set((installs as Array<{ podId?: unknown }>)
+      .map((i) => (i?.podId ? String(i.podId) : '')).filter(Boolean)));
+    let pods: unknown[] = [];
+    if (podIds.length) {
+      const podDocs = await Pod.find({ _id: { $in: podIds } }).select('name type').lean();
+      const nameById = new Map((podDocs as Array<{ _id: unknown; name?: string; type?: string }>)
+        .map((p) => [String(p._id), { name: p.name || 'pod', type: p.type || '' }]));
+      let lastActiveById = new Map<string, unknown>();
+      let lastMsgById = new Map<string, { content: string; createdAt: unknown }>();
+      try {
+        const acts = await PGMessage.findMostRecentPodActivity(podIds, new Date(0));
+        lastActiveById = new Map((acts as Array<{ podId: string; lastAt: unknown }>).map((a) => [String(a.podId), a.lastAt]));
+        if (agentUser?._id) {
+          const msgs = await PGMessage.findLastMessageByUserPerPod(agentUser._id, podIds);
+          lastMsgById = new Map((msgs as Array<{ podId: string; content: string; createdAt: unknown }>)
+            .map((mm) => [String(mm.podId), { content: mm.content, createdAt: mm.createdAt }]));
+        }
+      } catch { /* PG unavailable — still list pods, just without activity/message */ }
+      pods = podIds.map((pid) => {
+        const meta = nameById.get(pid) || { name: 'pod', type: '' };
+        const lm = lastMsgById.get(pid);
+        return {
+          id: pid,
+          name: meta.name,
+          type: meta.type,
+          lastActive: lastActiveById.get(pid) || null,
+          lastMessage: lm ? { snippet: snip(lm.content), at: lm.createdAt } : null,
+        };
+      }).sort((a: any, b: any) => new Date((b.lastActive as string) || 0).getTime() - new Date((a.lastActive as string) || 0).getTime());
+    }
+
     const record = await AgentMemory.findOne({ agentName, instanceId })
       .select('sections updatedAt')
       .lean();
@@ -175,6 +214,7 @@ router.get('/:agentName/:instanceId?', auth, async (req: AuthReq, res: Res) => {
       updatedAt: (record as Record<string, unknown>)?.updatedAt || null,
       totalEntries,
       sections,
+      pods,
     });
   } catch (err) {
     console.error('[agent-memory] error:', (err as Error).message);

--- a/backend/routes/agentProfile.ts
+++ b/backend/routes/agentProfile.ts
@@ -37,6 +37,8 @@ const AgentRun = require('../models/AgentRun');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const PodAsset = require('../models/PodAsset');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
+const PGMessage = require('../models/pg/Message');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { resolveAgentDisplayLabel } = require('../services/agentIdentityService');
 
 interface Res {
@@ -126,12 +128,22 @@ router.get('/:agentName/:instanceId?', async (req: Req, res: Res) => {
     const ownerPodIds = (installs as Array<{ podId?: { toString(): string } }>)
       .map((i) => (i?.podId ? String(i.podId) : ''))
       .filter(Boolean);
-    const publicPods = ownerPodIds.length
+    const publicPodDocs = ownerPodIds.length
       ? await Pod.find({ _id: { $in: ownerPodIds }, publicRead: true }).select('name').lean()
       : [];
-    const publicPodNames = (publicPods as Array<{ name?: string }>)
-      .map((p) => p.name)
-      .filter(Boolean);
+    // Enrich public pods with last-activity so the list can sort by "most active".
+    // Only publicRead pods here — private pod names never leak on the public view.
+    const publicPodIds = (publicPodDocs as Array<{ _id?: unknown }>).map((p) => String(p._id));
+    let activityByPod = new Map<string, unknown>();
+    if (publicPodIds.length) {
+      try {
+        const acts = await PGMessage.findMostRecentPodActivity(publicPodIds, new Date(0));
+        activityByPod = new Map((acts as Array<{ podId: string; lastAt: unknown }>).map((a) => [String(a.podId), a.lastAt]));
+      } catch { /* PG unavailable — pods still list, just unsorted by activity */ }
+    }
+    const publicPods = (publicPodDocs as Array<{ _id?: unknown; name?: string }>)
+      .map((p) => ({ id: String(p._id), name: p.name || 'pod', lastActive: activityByPod.get(String(p._id)) || null }))
+      .sort((a, b) => (new Date((b.lastActive as string) || 0).getTime()) - (new Date((a.lastActive as string) || 0).getTime()));
 
     // ── Memory (public sections only) ───────────────────────────────────────
     // Empty requester-pods ⇒ filterSectionsByVisibility returns ONLY public
@@ -195,7 +207,7 @@ router.get('/:agentName/:instanceId?', async (req: Req, res: Res) => {
         createdAt: user.createdAt,
       },
       skills,
-      pods: { count: ownerPodIds.length, publicNames: publicPodNames },
+      pods: { count: ownerPodIds.length, public: publicPods },
       memory: {
         has: hasMemory,
         entryCount: memoryEntryCount,

--- a/frontend/src/v2/agents/V2AgentProfile.tsx
+++ b/frontend/src/v2/agents/V2AgentProfile.tsx
@@ -37,18 +37,26 @@ interface AgentProfile {
     createdAt?: string;
   };
   skills: Array<{ name: string; description?: string }>;
-  pods: { count: number; publicNames: string[] };
+  pods: { count: number; public: Array<{ id: string; name: string; lastActive?: string | null }> };
   memory: { has: boolean; entryCount: number; updatedAt?: string | null };
   activity: Array<{ status: string; trigger?: string; startedAt?: string; turns: number; errorKind?: string }>;
 }
 
 // Owner/admin-only memory index (fetched with the viewer's token; 401/403 for
 // everyone else → public count is shown instead).
+interface PodEntry {
+  id: string;
+  name: string;
+  type?: string;
+  lastActive?: string | null;
+  lastMessage?: { snippet: string; at?: string | null } | null;
+}
 interface MemoryIndex {
   viewerRole: 'owner' | 'admin';
   totalEntries: number;
   updatedAt?: string | null;
   sections: Array<{ key: string; label: string; kind: string; notes: Array<{ header: string; snippet: string }> }>;
+  pods?: PodEntry[];
 }
 
 const timeAgo = (iso?: string | null): string => {
@@ -181,6 +189,33 @@ const V2AgentProfile: React.FC = () => {
             </section>
           )}
 
+          {/* Pods — owner/admin see ALL pods + the agent's last message there;
+              the public sees only publicRead pods. Sorted by last active. */}
+          {(() => {
+            const ownerPods = memIndex?.pods && memIndex.pods.length > 0 ? memIndex.pods : null;
+            const publicPods: PodEntry[] = pods.public || [];
+            const list: PodEntry[] = ownerPods || publicPods;
+            if (list.length === 0) return null;
+            return (
+              <section className="v2-aprofile__card">
+                <h2 className="v2-aprofile__card-title">
+                  {ownerPods ? 'Pods' : 'Public pods'} <span className="v2-aprofile__count">{ownerPods ? pods.count : list.length}</span>
+                  {ownerPods && pods.count > list.length && <span className="v2-aprofile__owner-tag">all pods</span>}
+                </h2>
+                <ul className="v2-aprofile__list">
+                  {list.slice(0, 8).map((p) => (
+                    <li key={p.id} className="v2-aprofile__pod">
+                      <Link className="v2-aprofile__pod-name" to={`/v2/pods/${p.id}`}>{p.name}</Link>
+                      {p.lastMessage?.snippet && <span className="v2-aprofile__pod-msg">“{p.lastMessage.snippet}”</span>}
+                      {p.lastActive && <span className="v2-aprofile__pod-when">active {timeAgo(p.lastActive)}</span>}
+                    </li>
+                  ))}
+                </ul>
+                {list.length > 8 && <span className="v2-aprofile__more">+{list.length - 8} more</span>}
+              </section>
+            );
+          })()}
+
           {/* Installed skills — only when the agent genuinely has agent-scoped
               skills (rare today; skills are mostly pod-scoped). Capabilities above
               carry the "what it does" story otherwise. */}
@@ -216,13 +251,14 @@ const V2AgentProfile: React.FC = () => {
                     <div key={sec.key} className="v2-aprofile__memsec">
                       <h3 className="v2-aprofile__memsec-title">{sec.label} <span className="v2-aprofile__count">{sec.notes.length}</span></h3>
                       <ul className="v2-aprofile__list">
-                        {sec.notes.map((n, i) => (
+                        {sec.notes.slice(0, 5).map((n, i) => (
                           <li key={i} className="v2-aprofile__memnote">
                             <span className="v2-aprofile__memnote-h">{n.header}</span>
                             {n.snippet && <span className="v2-aprofile__memnote-s">{n.snippet}</span>}
                           </li>
                         ))}
                       </ul>
+                      {sec.notes.length > 5 && <span className="v2-aprofile__more">+{sec.notes.length - 5} more</span>}
                     </div>
                   ))}
                 </div>
@@ -242,16 +278,6 @@ const V2AgentProfile: React.FC = () => {
               <p className="v2-aprofile__muted">No memory recorded yet.</p>
             )}
           </section>
-
-          {/* Pods */}
-          {pods.publicNames.length > 0 && (
-            <section className="v2-aprofile__card">
-              <h2 className="v2-aprofile__card-title">Public pods</h2>
-              <div className="v2-aprofile__chips">
-                {pods.publicNames.map((n) => <span key={n} className="v2-aprofile__chip">{n}</span>)}
-              </div>
-            </section>
-          )}
 
           {/* Recent activity */}
           {activity.length > 0 && (

--- a/frontend/src/v2/agents/v2-agent-profile.css
+++ b/frontend/src/v2/agents/v2-agent-profile.css
@@ -159,6 +159,16 @@
 .v2-aprofile__memnote-h { font-size: 13px; font-weight: 600; color: var(--v2-text-primary); }
 .v2-aprofile__memnote-s { font-size: 12px; color: var(--v2-text-tertiary); line-height: 1.45; }
 
+.v2-aprofile__more { font-size: 12px; color: var(--v2-text-tertiary); margin-top: 8px; display: inline-block; }
+
+/* Pods list */
+.v2-aprofile__pod { display: flex; flex-direction: column; gap: 2px; padding: 8px 0; border-top: 1px solid var(--v2-border-soft); }
+.v2-aprofile__pod:first-child { border-top: none; padding-top: 0; }
+.v2-root .v2-aprofile__pod-name { font-size: 14px; font-weight: 600; color: var(--v2-accent); text-decoration: none; }
+.v2-root .v2-aprofile__pod-name:hover { text-decoration: underline; }
+.v2-aprofile__pod-msg { font-size: 12.5px; color: var(--v2-text-tertiary); line-height: 1.4; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+.v2-aprofile__pod-when { font-size: 11.5px; color: var(--v2-text-muted, var(--v2-text-tertiary)); }
+
 .v2-aprofile__run { display: flex; align-items: center; gap: 8px; font-size: 13px; }
 .v2-aprofile__run-label { font-weight: 500; color: var(--v2-text-primary); }
 .v2-aprofile__run-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; background: var(--v2-text-muted); }


### PR DESCRIPTION
Profile UX pass on the agent profile.

## Pods section (new)
The pods an agent is in, **sorted by last activity**, each linking to `/v2/pods/:id`:
- **Public** visitors → only `publicRead` pods (name + last active).
- **Owner/admin** → **all** pods + the agent's **own last message there** (snippet + when).
- Private pod names & messages never leak publicly. New PG helper `findLastMessageByUserPerPod`; last-active reuses `findMostRecentPodActivity`.

## Memory card compacted
Caps to 5 notes per section with a "+N more" affordance — the index no longer dominates the page.

## Layout
Pods sits next to Specialties at the top; the wide memory card drops below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)