### PR TITLE
fix(agent-profile): scrollable pods/memory so cards stay compact

### DIFF
--- a/frontend/src/v2/agents/V2AgentProfile.tsx
+++ b/frontend/src/v2/agents/V2AgentProfile.tsx
@@ -202,8 +202,8 @@ const V2AgentProfile: React.FC = () => {
                   {ownerPods ? 'Pods' : 'Public pods'} <span className="v2-aprofile__count">{ownerPods ? pods.count : list.length}</span>
                   {ownerPods && pods.count > list.length && <span className="v2-aprofile__owner-tag">all pods</span>}
                 </h2>
-                <ul className="v2-aprofile__list">
-                  {list.slice(0, 8).map((p) => (
+                <ul className="v2-aprofile__list v2-aprofile__scroll">
+                  {list.map((p) => (
                     <li key={p.id} className="v2-aprofile__pod">
                       <Link className="v2-aprofile__pod-name" to={`/v2/pods/${p.id}`}>{p.name}</Link>
                       {p.lastMessage?.snippet && <span className="v2-aprofile__pod-msg">“{p.lastMessage.snippet}”</span>}
@@ -211,7 +211,6 @@ const V2AgentProfile: React.FC = () => {
                     </li>
                   ))}
                 </ul>
-                {list.length > 8 && <span className="v2-aprofile__more">+{list.length - 8} more</span>}
               </section>
             );
           })()}
@@ -246,7 +245,7 @@ const V2AgentProfile: React.FC = () => {
                   {memIndex.totalEntries} notes across {memIndex.sections.length} section{memIndex.sections.length === 1 ? '' : 's'}
                   {memIndex.updatedAt ? ` · updated ${timeAgo(memIndex.updatedAt)}` : ''}. Visible to you; hidden from the public profile.
                 </p>
-                <div className="v2-aprofile__memcols">
+                <div className="v2-aprofile__memcols v2-aprofile__scroll">
                   {memIndex.sections.map((sec) => (
                     <div key={sec.key} className="v2-aprofile__memsec">
                       <h3 className="v2-aprofile__memsec-title">{sec.label} <span className="v2-aprofile__count">{sec.notes.length}</span></h3>

--- a/frontend/src/v2/agents/v2-agent-profile.css
+++ b/frontend/src/v2/agents/v2-agent-profile.css
@@ -161,6 +161,13 @@
 
 .v2-aprofile__more { font-size: 12px; color: var(--v2-text-tertiary); margin-top: 8px; display: inline-block; }
 
+/* Bounded, scrollable section bodies so a long pods/memory list keeps the card
+   compact and the sections below it visible at first glance. */
+.v2-aprofile__scroll { max-height: 300px; overflow-y: auto; padding-right: 6px; }
+.v2-aprofile__scroll::-webkit-scrollbar { width: 8px; }
+.v2-aprofile__scroll::-webkit-scrollbar-thumb { background: var(--v2-border-strong, var(--v2-border)); border-radius: 4px; }
+.v2-aprofile__scroll::-webkit-scrollbar-track { background: transparent; }
+
 /* Pods list */
 .v2-aprofile__pod { display: flex; flex-direction: column; gap: 2px; padding: 8px 0; border-top: 1px solid var(--v2-border-soft); }
 .v2-aprofile__pod:first-child { border-top: none; padding-top: 0; }


### PR DESCRIPTION
The pods list (12) and memory index made the cards tall enough to push **Installed Skills** + **Memory** below the fold. Bound both bodies to `max-height:300px` with internal scroll; show all pods in the scroll (no "+N more" cap). Cards stay compact; sections below are visible at first glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)