### PR TITLE
fix(agent-profile): fold Specialties into the identity card

### DIFF
--- a/frontend/src/v2/agents/V2AgentProfile.tsx
+++ b/frontend/src/v2/agents/V2AgentProfile.tsx
@@ -173,21 +173,17 @@ const V2AgentProfile: React.FC = () => {
               {memory.has && <span>· {memory.entryCount} memories</span>}
               {agent.personality?.tone && <span>· {agent.personality.tone}</span>}
             </div>
+            {(agent.capabilities.length > 0 || (agent.personality?.interests?.length || 0) > 0) && (
+              <div className="v2-aprofile__hero-chips">
+                {agent.capabilities.map((c) => <span key={c} className="v2-aprofile__chip">{c}</span>)}
+                {(agent.personality?.interests || []).map((i) => <span key={i} className="v2-aprofile__chip v2-aprofile__chip--soft">{i}</span>)}
+              </div>
+            )}
           </div>
           <Link className="v2-aprofile__btn v2-aprofile__btn--primary" to="/v2/register">Talk to {agent.displayName.split(' ')[0]}</Link>
         </section>
 
         <div className="v2-aprofile__grid">
-          {/* Capabilities + specialties */}
-          {(agent.capabilities.length > 0 || (agent.personality?.interests?.length || 0) > 0) && (
-            <section className="v2-aprofile__card">
-              <h2 className="v2-aprofile__card-title">Specialties</h2>
-              <div className="v2-aprofile__chips">
-                {agent.capabilities.map((c) => <span key={c} className="v2-aprofile__chip">{c}</span>)}
-                {(agent.personality?.interests || []).map((i) => <span key={i} className="v2-aprofile__chip v2-aprofile__chip--soft">{i}</span>)}
-              </div>
-            </section>
-          )}
 
           {/* Pods — owner/admin see ALL pods + the agent's last message there;
               the public sees only publicRead pods. Sorted by last active. */}

--- a/frontend/src/v2/agents/v2-agent-profile.css
+++ b/frontend/src/v2/agents/v2-agent-profile.css
@@ -72,7 +72,7 @@
 /* Identity hero */
 .v2-aprofile__hero {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 20px;
   padding: 24px;
   background: var(--v2-surface);
@@ -80,6 +80,7 @@
   border-radius: var(--v2-radius-lg);
   margin-bottom: 20px;
 }
+.v2-aprofile__hero-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 14px; }
 .v2-aprofile__hero-text { flex: 1 1 auto; min-width: 0; }
 .v2-aprofile__name-row { display: flex; align-items: center; flex-wrap: wrap; gap: 10px; }
 .v2-aprofile__name { margin: 0; font-size: 24px; font-weight: 850; letter-spacing: -0.02em; color: var(--v2-text-primary); }


### PR DESCRIPTION
Specialties (capabilities + interests) now render as chips **inside the identity/hero card** instead of a separate grid card — so the grid leads with Pods and the identity card holds "who + what it's good at" together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)