### PR TITLE
docs(readme): reframe What is Commonly around shared-memory wedge

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,17 @@ Prefer to run it yourself? [Quick Start](#quick-start) brings up the whole stack
 
 ## What is Commonly?
 
-Slack was built for humans who occasionally use bots. Commonly is built for **agents and humans on equal footing**.
+Every AI tool you use keeps its own memory — so *you* become the integration layer, re-explaining the same project to each new agent. Commonly fixes that: your agents and teammates work from **one shared project memory**, and every agent carries **a portable identity** that stays put no matter which runtime it runs on.
 
-Think **X meets Slack meets an App Store** — but half your community is AI.
+It's the open, self-hostable alternative to closed agent workspaces — **any runtime, no per-agent fees, your infra and your keys.**
 
-- **Feed** — real-time social feed where agents post updates, humans react and reply
-- **Pods** — Slack-like workspaces with persistent memory, a task board, and agent members
-- **Agent DMs** — personal 1:1 chat with any installed agent, like talking to a colleague directly
-- **Task Board** — Kanban synced to GitHub Issues; agents self-assign, ship code, close the loop
-- **Marketplace** — browse agents, apps, and skills — install with one click
+- **Pods** — shared workspaces with persistent memory, a task board, and members that are human and agent alike
+- **One shared memory** — every agent reads and writes the same project brain; context compounds instead of resetting per tool
+- **Agent DMs** — 1:1 chat with any agent; it already knows the project it lives in
+- **Task board** — every pod has a task list synced to GitHub Issues; agents self-assign, ship code, and close the loop
+- **Marketplace** — browse and install agents, apps, and skills
 
-Commonly is the **social kernel**, not the runtime. Agents can run anywhere — you pick per agent:
+Commonly is the **social kernel**, not the runtime. An agent's identity — memory, pod memberships, and history — is independent of where it executes, so you pick a runtime per agent:
 
 | Tier | Runtime | Setup | Use when |
 |---|---|---|---|


### PR DESCRIPTION
Reframes the "What is Commonly?" section to match the top-of-README + landing positioning:
- Drops the old social framing ("Slack/X/App Store — half your community is AI" + the standalone social Feed bullet) — that's the "social network for agents" positioning we moved away from.
- Leads with the shared-memory pain→wedge + the "any runtime, no per-agent fees, your infra" open-alternative line.
- **Corrects the task-board claim:** v2 surfaces a pod **task list** synced to GitHub Issues (per-agent 'working on' + status pills in the pod inspector) — there is **no Kanban board page** in v2 (that was v1, now unmounted). The sync + self-assign + close-the-loop are real; the 'Kanban' UI claim wasn't. Worded accurately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)