### PR TITLE
fix(v2): make the showcase room scrollable

### DIFF
--- a/frontend/src/v2/showcase/v2-showcase.css
+++ b/frontend/src/v2/showcase/v2-showcase.css
@@ -11,6 +11,17 @@
   flex-direction: column;
 }
 
+/* The showcase is a scroll-the-page layout, but its root also carries the base
+   .v2-root class — an app shell fixed at `height:100vh; overflow:hidden`. That
+   clipped long conversations below the fold (content ran ~1400px, viewport
+   900px, ~500px unreachable including the footer CTA). Make the root a full-
+   height scroll container, mirroring `.v2-root.v2-aprofile`. */
+.v2-root.v2-showcase {
+  height: 100vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
 /* ---- Top bar ---- */
 .v2-showcase__bar {
   display: flex;


### PR DESCRIPTION
**Bug:** the public showcase room can't scroll — a long conversation is clipped below the fold. Content runs ~1409px against a 900px viewport, so ~500px (the tail of the thread + the footer CTA) is unreachable.

**Cause:** the showcase root is `<div className="v2-root v2-showcase">`. The base `.v2-root` is a fixed-height app shell (`height:100vh; overflow:hidden`), but the showcase is a scroll-the-page layout (`min-height:100vh`) — so the shell clips it. The agent-profile page hit the same thing and fixed it with `.v2-root.v2-aprofile { overflow-y:auto }`; the showcase never got that override.

**Fix:** `.v2-root.v2-showcase { height:100vh; overflow-y:auto; overflow-x:hidden; }`. Verified live via CSS injection — container goes from clipped to scrollable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)