### PR TITLE
feat(auth): GitHub + Google OAuth login, admin entitlements endpoint

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -32,6 +32,17 @@ SENDGRID_FROM_EMAIL=your_email@example.com
 FRONTEND_URL=http://localhost:3000
 
 # ===========================
+# ✅ Social login (optional — buttons appear only when a provider is configured)
+# ===========================
+# GITHUB_OAUTH_CLIENT_ID=your_github_oauth_app_client_id
+# GITHUB_OAUTH_CLIENT_SECRET=your_github_oauth_app_client_secret
+# GOOGLE_OAUTH_CLIENT_ID=your_google_oauth_client_id
+# GOOGLE_OAUTH_CLIENT_SECRET=your_google_oauth_client_secret
+# Public base URL of THIS API for provider redirect_uri (defaults to the
+# request host — set explicitly when behind a proxy):
+# OAUTH_CALLBACK_BASE_URL=https://api.example.com
+
+# ===========================
 # ✅ AI Configuration
 # ===========================
 GEMINI_API_KEY=your_gemini_api_key

--- a/backend/__tests__/unit/controllers/oauthController.test.js
+++ b/backend/__tests__/unit/controllers/oauthController.test.js
@@ -1,0 +1,339 @@
+const axios = require('axios');
+const jwt = require('jsonwebtoken');
+const User = require('../../../models/User');
+const OAuthLoginState = require('../../../models/OAuthLoginState');
+const InvitationCode = require('../../../models/InvitationCode');
+const oauthController = require('../../../controllers/oauthController');
+const authController = require('../../../controllers/authController');
+const {
+  setupMongoDb,
+  closeMongoDb,
+  clearMongoDb,
+} = require('../../utils/testUtils');
+
+jest.mock('axios', () => ({
+  post: jest.fn(),
+  get: jest.fn(),
+}));
+
+jest.mock('jsonwebtoken', () => ({
+  sign: jest.fn().mockReturnValue('test-jwt-token'),
+  verify: jest.fn(),
+}));
+
+const mockRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn(),
+  redirect: jest.fn(),
+});
+
+const startReq = (provider, query = {}) => ({
+  params: { provider },
+  query,
+  protocol: 'https',
+  get: () => 'api.test.local',
+});
+
+// Wire axios mocks for a successful GitHub round-trip.
+const mockGithubProfile = ({ id = 4242, login = 'octo-dev', email = 'octo@example.com' } = {}) => {
+  axios.post.mockResolvedValueOnce({ data: { access_token: 'gh-access-token' } });
+  axios.get.mockImplementation((url) => {
+    if (url.includes('/user/emails')) {
+      return Promise.resolve({ data: [{ email, primary: true, verified: true }] });
+    }
+    return Promise.resolve({ data: { id, login } });
+  });
+};
+
+describe('OAuth Controller', () => {
+  beforeAll(async () => {
+    await setupMongoDb();
+  });
+
+  afterAll(async () => {
+    await closeMongoDb();
+  });
+
+  beforeEach(() => {
+    process.env.GITHUB_OAUTH_CLIENT_ID = 'gh-client';
+    process.env.GITHUB_OAUTH_CLIENT_SECRET = 'gh-secret';
+    process.env.FRONTEND_URL = 'https://app.test.local';
+    process.env.JWT_SECRET = 'test-secret';
+    delete process.env.GOOGLE_OAUTH_CLIENT_ID;
+    delete process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+    delete process.env.REGISTRATION_INVITE_ONLY;
+    delete process.env.REGISTRATION_INVITE_CODES;
+  });
+
+  afterEach(async () => {
+    await clearMongoDb();
+    jest.clearAllMocks();
+    delete process.env.GITHUB_OAUTH_CLIENT_ID;
+    delete process.env.GITHUB_OAUTH_CLIENT_SECRET;
+  });
+
+  describe('getOAuthProviders', () => {
+    it('lists only configured providers', () => {
+      const res = mockRes();
+      oauthController.getOAuthProviders({}, res);
+      expect(res.json).toHaveBeenCalledWith({
+        providers: [{ id: 'github', label: 'GitHub' }],
+      });
+    });
+
+    it('returns empty list when nothing is configured', () => {
+      delete process.env.GITHUB_OAUTH_CLIENT_ID;
+      const res = mockRes();
+      oauthController.getOAuthProviders({}, res);
+      expect(res.json).toHaveBeenCalledWith({ providers: [] });
+    });
+  });
+
+  describe('startOAuth', () => {
+    it('mints a state row and redirects to the provider', async () => {
+      const res = mockRes();
+      await oauthController.startOAuth(startReq('github', { next: '/v2/pods/abc', invite: 'CODE1' }), res);
+
+      expect(res.redirect).toHaveBeenCalledTimes(1);
+      const url = new URL(res.redirect.mock.calls[0][0]);
+      expect(url.origin + url.pathname).toBe('https://github.com/login/oauth/authorize');
+      expect(url.searchParams.get('client_id')).toBe('gh-client');
+      expect(url.searchParams.get('redirect_uri')).toBe('https://api.test.local/api/auth/oauth/github/callback');
+
+      const state = await OAuthLoginState.findOne({ state: url.searchParams.get('state') });
+      expect(state).toBeTruthy();
+      expect(state.next).toBe('/v2/pods/abc');
+      expect(state.invitationCode).toBe('CODE1');
+    });
+
+    it('rejects absolute next URLs (open-redirect guard)', async () => {
+      const res = mockRes();
+      await oauthController.startOAuth(startReq('github', { next: 'https://evil.example' }), res);
+      const url = new URL(res.redirect.mock.calls[0][0]);
+      const state = await OAuthLoginState.findOne({ state: url.searchParams.get('state') });
+      expect(state.next).toBe('/v2');
+    });
+
+    it('404s an unconfigured provider', async () => {
+      const res = mockRes();
+      await oauthController.startOAuth(startReq('google'), res);
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+
+  describe('oauthCallback', () => {
+    const seedState = (overrides = {}) => OAuthLoginState.create({
+      provider: 'github',
+      state: 'state-1',
+      expiresAt: new Date(Date.now() + 60000),
+      ...overrides,
+    });
+
+    const callbackReq = (query = {}) => ({
+      params: { provider: 'github' },
+      query: { code: 'gh-code', state: 'state-1', ...query },
+      protocol: 'https',
+      get: () => 'api.test.local',
+    });
+
+    it('creates a new verified passwordless user and redirects with an exchange code', async () => {
+      await seedState();
+      mockGithubProfile();
+      const res = mockRes();
+
+      await oauthController.oauthCallback(callbackReq(), res);
+
+      const user = await User.findOne({ email: 'octo@example.com' });
+      expect(user).toBeTruthy();
+      expect(user.verified).toBe(true);
+      expect(user.password).toBeUndefined();
+      expect(user.username).toBe('octo-dev');
+      expect(user.authProviders).toHaveLength(1);
+      expect(user.authProviders[0]).toMatchObject({ provider: 'github', providerId: '4242' });
+
+      const redirectUrl = new URL(res.redirect.mock.calls[0][0]);
+      expect(redirectUrl.origin).toBe('https://app.test.local');
+      expect(redirectUrl.pathname).toBe('/v2/oauth/complete');
+      expect(redirectUrl.searchParams.get('code')).toBeTruthy();
+
+      const state = await OAuthLoginState.findOne({ state: 'state-1' });
+      expect(String(state.userId)).toBe(String(user._id));
+      expect(state.usedAt).toBeTruthy();
+    });
+
+    it('links to an existing account with the same verified email', async () => {
+      const existing = await User.create({
+        username: 'octo-human',
+        email: 'octo@example.com',
+        password: 'hashed-pass',
+        verified: false,
+      });
+      await seedState();
+      mockGithubProfile();
+      const res = mockRes();
+
+      await oauthController.oauthCallback(callbackReq(), res);
+
+      const user = await User.findById(existing._id);
+      expect(user.authProviders).toHaveLength(1);
+      expect(user.authProviders[0].providerId).toBe('4242');
+      expect(user.verified).toBe(true); // provider-asserted
+      expect(await User.countDocuments({})).toBe(1); // linked, not duplicated
+    });
+
+    it('enforces the invite gate for brand-new signups', async () => {
+      process.env.REGISTRATION_INVITE_ONLY = 'true';
+      await seedState(); // no invitationCode captured at /start
+      mockGithubProfile();
+      const res = mockRes();
+
+      await oauthController.oauthCallback(callbackReq(), res);
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('oauthError=invitation_required'),
+      );
+      expect(await User.countDocuments({})).toBe(0);
+    });
+
+    it('consumes a DB invitation code captured at /start', async () => {
+      process.env.REGISTRATION_INVITE_ONLY = 'true';
+      const admin = await User.create({
+        username: 'admin-user',
+        email: 'admin@example.com',
+        password: 'hashed-pass',
+        role: 'admin',
+      });
+      await InvitationCode.create({
+        code: 'WELCOME1',
+        isActive: true,
+        maxUses: 1,
+        useCount: 0,
+        createdBy: admin._id,
+      });
+      await seedState({ invitationCode: 'WELCOME1' });
+      mockGithubProfile();
+      const res = mockRes();
+
+      await oauthController.oauthCallback(callbackReq(), res);
+
+      expect(await User.countDocuments({ email: 'octo@example.com' })).toBe(1);
+      const invite = await InvitationCode.findOne({ code: 'WELCOME1' });
+      expect(invite.useCount).toBe(1);
+    });
+
+    it('rejects a replayed state (single-use)', async () => {
+      await seedState({ usedAt: new Date() });
+      const res = mockRes();
+      await oauthController.oauthCallback(callbackReq(), res);
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('oauthError=state_invalid'),
+      );
+    });
+
+    it('rejects a profile without a verified email', async () => {
+      await seedState();
+      axios.post.mockResolvedValueOnce({ data: { access_token: 'gh-access-token' } });
+      axios.get.mockImplementation((url) => {
+        if (url.includes('/user/emails')) {
+          return Promise.resolve({ data: [{ email: 'octo@example.com', primary: true, verified: false }] });
+        }
+        return Promise.resolve({ data: { id: 4242, login: 'octo-dev' } });
+      });
+      const res = mockRes();
+
+      await oauthController.oauthCallback(callbackReq(), res);
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('oauthError=email_unverified'),
+      );
+      expect(await User.countDocuments({})).toBe(0);
+    });
+
+    it('suffixes the username when the provider handle is taken', async () => {
+      await User.create({
+        username: 'octo-dev',
+        email: 'other@example.com',
+        password: 'hashed-pass',
+      });
+      await seedState();
+      mockGithubProfile();
+      const res = mockRes();
+
+      await oauthController.oauthCallback(callbackReq(), res);
+
+      const user = await User.findOne({ email: 'octo@example.com' });
+      expect(user.username).toMatch(/^octo-dev-[0-9a-f]{4}$/);
+    });
+  });
+
+  describe('exchangeOAuthCode', () => {
+    it('issues a session once and only once per code', async () => {
+      const user = await User.create({
+        username: 'octo-dev',
+        email: 'octo@example.com',
+        verified: true,
+        authProviders: [{ provider: 'github', providerId: '4242', email: 'octo@example.com' }],
+      });
+      await OAuthLoginState.create({
+        provider: 'github',
+        state: 'state-2',
+        userId: user._id,
+        exchangeCode: 'one-time-code',
+        exchangeExpiresAt: new Date(Date.now() + 60000),
+        usedAt: new Date(),
+        expiresAt: new Date(Date.now() + 60000),
+      });
+
+      const res1 = mockRes();
+      await oauthController.exchangeOAuthCode({ body: { code: 'one-time-code' } }, res1);
+      expect(res1.json).toHaveBeenCalledWith(expect.objectContaining({
+        token: 'test-jwt-token',
+        user: expect.objectContaining({ username: 'octo-dev' }),
+      }));
+
+      const res2 = mockRes();
+      await oauthController.exchangeOAuthCode({ body: { code: 'one-time-code' } }, res2);
+      expect(res2.status).toHaveBeenCalledWith(400);
+    });
+
+    it('rejects an expired exchange code', async () => {
+      const user = await User.create({
+        username: 'octo-dev',
+        email: 'octo@example.com',
+        verified: true,
+        authProviders: [{ provider: 'github', providerId: '4242' }],
+      });
+      await OAuthLoginState.create({
+        provider: 'github',
+        state: 'state-3',
+        userId: user._id,
+        exchangeCode: 'stale-code',
+        exchangeExpiresAt: new Date(Date.now() - 1000),
+        expiresAt: new Date(Date.now() + 60000),
+      });
+
+      const res = mockRes();
+      await oauthController.exchangeOAuthCode({ body: { code: 'stale-code' } }, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe('login guard for OAuth-only accounts', () => {
+    it('tells a passwordless user to use their provider instead of throwing', async () => {
+      await User.create({
+        username: 'octo-dev',
+        email: 'octo@example.com',
+        verified: true,
+        authProviders: [{ provider: 'github', providerId: '4242' }],
+      });
+
+      const res = mockRes();
+      await authController.login({ body: { email: 'octo@example.com', password: 'whatever' } }, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        code: 'OAUTH_ONLY_ACCOUNT',
+      }));
+    });
+  });
+});

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -60,6 +60,34 @@ const consumeDbInvitationCode = async (code: any) => {
 
 const isValidEmail = (email: any) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
+// Give every new signup a default private workspace pod so the BYO
+// onboarding flow has a target to install/talk-to an agent in. Matches
+// the Mongo Pod shape created by podController.createPod (type 'chat',
+// creator = sole member); joinPolicy 'invite-only' keeps it private.
+// Best-effort: a pod-create hiccup must never fail signup — the user
+// can always create a pod from the UI later. Shared by password
+// registration and the OAuth signup path (oauthController).
+const createDefaultWorkspacePod = async (userId: any) => {
+  try {
+    await Pod.create({
+      name: 'My Workspace',
+      description: 'Your private workspace',
+      type: 'chat',
+      joinPolicy: 'invite-only',
+      createdBy: userId,
+      members: [userId],
+    });
+  } catch (podError: any) {
+    console.warn('[register] default workspace pod creation failed:', podError?.message);
+  }
+};
+
+// Reused by oauthController so social signups honor the same invite gate.
+exports.isInviteOnlyRegistrationEnabled = isInviteOnlyRegistrationEnabled;
+exports.isEnvInvitationCodeValid = isEnvInvitationCodeValid;
+exports.consumeDbInvitationCode = consumeDbInvitationCode;
+exports.createDefaultWorkspacePod = createDefaultWorkspacePod;
+
 // 📌 Register User
 exports.register = async (req: any, res: any) => {
   try {
@@ -149,24 +177,7 @@ exports.register = async (req: any, res: any) => {
     // Save user to database
     await user.save();
 
-    // Give every new signup a default private workspace pod so the BYO
-    // onboarding flow has a target to install/talk-to an agent in. Matches
-    // the Mongo Pod shape created by podController.createPod (type 'chat',
-    // creator = sole member); joinPolicy 'invite-only' keeps it private.
-    // Best-effort: a pod-create hiccup must never fail registration — the user
-    // can always create a pod from the UI later.
-    try {
-      await Pod.create({
-        name: 'My Workspace',
-        description: 'Your private workspace',
-        type: 'chat',
-        joinPolicy: 'invite-only',
-        createdBy: user._id,
-        members: [user._id],
-      });
-    } catch (podError: any) {
-      console.warn('[register] default workspace pod creation failed:', podError?.message);
-    }
+    await createDefaultWorkspacePod(user._id);
 
     if (hasEmailConfig) {
       // Generate email verification token
@@ -324,6 +335,16 @@ exports.login = async (req: any, res: any) => {
       return res
         .status(400)
         .json({ error: 'Email not verified. Please check your inbox.' });
+    }
+
+    // OAuth-only accounts have no password hash — send them to their provider
+    // instead of letting bcrypt throw on an undefined hash.
+    if (!user.password) {
+      const providers = (user.authProviders || []).map((p: any) => p.provider).join(' or ');
+      return res.status(400).json({
+        error: `This account signs in with ${providers || 'a linked provider'}. Use the social sign-in button.`,
+        code: 'OAUTH_ONLY_ACCOUNT',
+      });
     }
 
     const isMatch = await bcrypt.compare(password, user.password);

--- a/backend/controllers/oauthController.ts
+++ b/backend/controllers/oauthController.ts
@@ -1,0 +1,340 @@
+const crypto = require('crypto');
+const jwt = require('jsonwebtoken');
+const axios = require('axios');
+const User = require('../models/User');
+const OAuthLoginState = require('../models/OAuthLoginState');
+const {
+  isInviteOnlyRegistrationEnabled,
+  isEnvInvitationCodeValid,
+  consumeDbInvitationCode,
+  createDefaultWorkspacePod,
+} = require('./authController');
+
+// Social login (GitHub + Google) for HUMAN accounts. Deliberately framework-
+// free: two provider entries, an authorization-code flow, and a one-time
+// exchange code handed to the frontend. The X/Twitter OAuth code under
+// backend/integrations is a separate concern (agent integrations) and is
+// intentionally untouched.
+//
+// Flow (frontend on a different origin than the API, so no cookies):
+//   GET  /api/auth/oauth/providers            → which providers are configured
+//   GET  /api/auth/oauth/:provider/start      → 302 to provider (state row minted)
+//   GET  /api/auth/oauth/:provider/callback   → link-or-create user, then 302 to
+//        ${FRONTEND_URL}/v2/oauth/complete?code=<one-time>&next=<path>
+//   POST /api/auth/oauth/exchange { code }    → { token, user } (same shape as login)
+//
+// The JWT never appears in a URL — only the short-lived one-time code does.
+
+const STATE_TTL_MS = 10 * 60 * 1000; // full provider round-trip budget
+const EXCHANGE_TTL_MS = 2 * 60 * 1000; // frontend picks this up immediately
+
+interface ProviderProfile {
+  providerId: string;
+  email: string;
+  emailVerified: boolean;
+  usernameHint: string;
+}
+
+const PROVIDERS: Record<string, {
+  label: string;
+  clientId: () => string | undefined;
+  clientSecret: () => string | undefined;
+  authorizeUrl: string;
+  scope: string;
+  fetchProfile: (code: string, redirectUri: string) => Promise<ProviderProfile>;
+}> = {
+  github: {
+    label: 'GitHub',
+    clientId: () => process.env.GITHUB_OAUTH_CLIENT_ID,
+    clientSecret: () => process.env.GITHUB_OAUTH_CLIENT_SECRET,
+    authorizeUrl: 'https://github.com/login/oauth/authorize',
+    scope: 'read:user user:email',
+    async fetchProfile(code: string, redirectUri: string): Promise<ProviderProfile> {
+      const tokenRes = await axios.post(
+        'https://github.com/login/oauth/access_token',
+        {
+          client_id: process.env.GITHUB_OAUTH_CLIENT_ID,
+          client_secret: process.env.GITHUB_OAUTH_CLIENT_SECRET,
+          code,
+          redirect_uri: redirectUri,
+        },
+        { headers: { Accept: 'application/json' }, timeout: 15000 },
+      );
+      const accessToken = tokenRes.data?.access_token;
+      if (!accessToken) throw new Error(`GitHub token exchange failed: ${tokenRes.data?.error || 'no access_token'}`);
+
+      // GitHub rejects requests without a User-Agent.
+      const ghHeaders = {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'commonly-oauth/0.1',
+      };
+      const [userRes, emailsRes] = await Promise.all([
+        axios.get('https://api.github.com/user', { headers: ghHeaders, timeout: 15000 }),
+        axios.get('https://api.github.com/user/emails', { headers: ghHeaders, timeout: 15000 }),
+      ]);
+      const emails = Array.isArray(emailsRes.data) ? emailsRes.data : [];
+      const best = emails.find((e: any) => e.primary && e.verified)
+        || emails.find((e: any) => e.verified);
+      return {
+        providerId: String(userRes.data?.id || ''),
+        email: String(best?.email || '').toLowerCase(),
+        emailVerified: Boolean(best),
+        usernameHint: String(userRes.data?.login || ''),
+      };
+    },
+  },
+  google: {
+    label: 'Google',
+    clientId: () => process.env.GOOGLE_OAUTH_CLIENT_ID,
+    clientSecret: () => process.env.GOOGLE_OAUTH_CLIENT_SECRET,
+    authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+    scope: 'openid email profile',
+    async fetchProfile(code: string, redirectUri: string): Promise<ProviderProfile> {
+      const tokenRes = await axios.post(
+        'https://oauth2.googleapis.com/token',
+        new URLSearchParams({
+          client_id: process.env.GOOGLE_OAUTH_CLIENT_ID || '',
+          client_secret: process.env.GOOGLE_OAUTH_CLIENT_SECRET || '',
+          code,
+          grant_type: 'authorization_code',
+          redirect_uri: redirectUri,
+        }).toString(),
+        { headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, timeout: 15000 },
+      );
+      const accessToken = tokenRes.data?.access_token;
+      if (!accessToken) throw new Error('Google token exchange failed: no access_token');
+
+      const infoRes = await axios.get('https://openidconnect.googleapis.com/v1/userinfo', {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        timeout: 15000,
+      });
+      const email = String(infoRes.data?.email || '').toLowerCase();
+      return {
+        providerId: String(infoRes.data?.sub || ''),
+        email,
+        emailVerified: infoRes.data?.email_verified === true || infoRes.data?.email_verified === 'true',
+        usernameHint: String(infoRes.data?.name || email.split('@')[0] || ''),
+      };
+    },
+  },
+};
+
+const isProviderConfigured = (name: string) => {
+  const p = PROVIDERS[name];
+  return Boolean(p && p.clientId() && p.clientSecret());
+};
+
+const frontendUrl = () => String(process.env.FRONTEND_URL || 'http://localhost:3000').replace(/\/$/, '');
+
+const callbackUrl = (provider: string, req: any) => {
+  const base = String(
+    process.env.OAUTH_CALLBACK_BASE_URL || `${req.protocol}://${req.get('host')}`,
+  ).replace(/\/$/, '');
+  return `${base}/api/auth/oauth/${provider}/callback`;
+};
+
+// Only ever redirect back into the app — never to an absolute URL an
+// attacker put in ?next= (open-redirect guard).
+const safeNextPath = (value: any) => {
+  const next = String(value || '');
+  return next.startsWith('/') && !next.startsWith('//') ? next : '/v2';
+};
+
+const loginErrorRedirect = (res: any, code: string) =>
+  res.redirect(`${frontendUrl()}/v2/login?oauthError=${encodeURIComponent(code)}`);
+
+// Derive a unique username from the provider handle. Existing usernames have
+// no charset constraint server-side, but keep these URL/mention-friendly.
+const generateUsername = async (hint: string, email: string) => {
+  const base = (hint || email.split('@')[0] || 'user')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '')
+    .slice(0, 30) || 'user';
+  if (!await User.exists({ username: base })) return base;
+  for (let i = 0; i < 5; i += 1) {
+    const candidate = `${base}-${crypto.randomBytes(2).toString('hex')}`;
+    // eslint-disable-next-line no-await-in-loop
+    if (!await User.exists({ username: candidate })) return candidate;
+  }
+  return `${base}-${crypto.randomBytes(6).toString('hex')}`;
+};
+
+const issueSession = (user: any) => {
+  const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, { expiresIn: '7d' });
+  return {
+    token,
+    verified: user.verified,
+    user: {
+      id: user.id,
+      username: user.username,
+      email: user.email,
+      profilePicture: user.profilePicture,
+      role: user.role,
+    },
+  };
+};
+
+// GET /api/auth/oauth/providers
+exports.getOAuthProviders = (_req: any, res: any) => {
+  const providers = Object.entries(PROVIDERS)
+    .filter(([name]) => isProviderConfigured(name))
+    .map(([name, p]) => ({ id: name, label: p.label }));
+  return res.json({ providers });
+};
+
+// GET /api/auth/oauth/:provider/start?next=/v2&invite=CODE
+exports.startOAuth = async (req: any, res: any) => {
+  try {
+    const provider = String(req.params.provider || '').toLowerCase();
+    if (!isProviderConfigured(provider)) {
+      return res.status(404).json({ error: 'Unknown or unconfigured OAuth provider.' });
+    }
+
+    const state = crypto.randomBytes(24).toString('hex');
+    await OAuthLoginState.create({
+      provider,
+      state,
+      invitationCode: String(req.query.invite || '').trim(),
+      next: safeNextPath(req.query.next),
+      expiresAt: new Date(Date.now() + STATE_TTL_MS),
+    });
+
+    const p = PROVIDERS[provider];
+    const params = new URLSearchParams({
+      client_id: p.clientId() || '',
+      redirect_uri: callbackUrl(provider, req),
+      scope: p.scope,
+      state,
+    });
+    if (provider === 'google') params.set('response_type', 'code');
+    return res.redirect(`${p.authorizeUrl}?${params.toString()}`);
+  } catch (err: any) {
+    console.error('OAuth start failed:', err.message);
+    return res.status(500).json({ error: 'Failed to start OAuth flow' });
+  }
+};
+
+// GET /api/auth/oauth/:provider/callback?code=...&state=...
+exports.oauthCallback = async (req: any, res: any) => {
+  const provider = String(req.params.provider || '').toLowerCase();
+  try {
+    if (!isProviderConfigured(provider)) return loginErrorRedirect(res, 'provider_error');
+    if (req.query.error) return loginErrorRedirect(res, 'provider_denied');
+
+    // One-time state: atomically claim it so a replayed callback URL can't
+    // mint a second session.
+    const stateRow = await OAuthLoginState.findOneAndUpdate(
+      {
+        provider,
+        state: String(req.query.state || ''),
+        usedAt: null,
+        expiresAt: { $gt: new Date() },
+      },
+      { $set: { usedAt: new Date() } },
+      { new: true },
+    );
+    if (!stateRow) return loginErrorRedirect(res, 'state_invalid');
+
+    const profile = await PROVIDERS[provider].fetchProfile(
+      String(req.query.code || ''),
+      callbackUrl(provider, req),
+    );
+    if (!profile.providerId) return loginErrorRedirect(res, 'provider_error');
+    // Linking by email is only safe when the provider vouches for it.
+    if (!profile.email || !profile.emailVerified) return loginErrorRedirect(res, 'email_unverified');
+
+    let user = await User.findOne({
+      'authProviders.provider': provider,
+      'authProviders.providerId': profile.providerId,
+    });
+
+    if (!user) {
+      user = await User.findOne({ email: profile.email });
+      if (user && user.isBot) return loginErrorRedirect(res, 'bot_account');
+      if (user) {
+        // Existing password account with the same verified email → link.
+        user.authProviders.push({
+          provider,
+          providerId: profile.providerId,
+          email: profile.email,
+          linkedAt: new Date(),
+        });
+        // The provider verified this email even if our SMTP loop never did.
+        user.verified = true;
+        await user.save();
+      }
+    }
+
+    if (!user) {
+      // Brand-new signup — honor the same invite gate as password registration.
+      if (isInviteOnlyRegistrationEnabled()) {
+        const code = String(stateRow.invitationCode || '').trim();
+        if (!code) return loginErrorRedirect(res, 'invitation_required');
+        if (!isEnvInvitationCodeValid(code)) {
+          const consumed = await consumeDbInvitationCode(code);
+          if (!consumed) return loginErrorRedirect(res, 'invitation_invalid');
+        }
+      }
+
+      user = new User({
+        username: await generateUsername(profile.usernameHint, profile.email),
+        email: profile.email,
+        verified: true, // provider-asserted
+        authProviders: [{
+          provider,
+          providerId: profile.providerId,
+          email: profile.email,
+          linkedAt: new Date(),
+        }],
+      });
+      await user.save();
+      await createDefaultWorkspacePod(user._id);
+    }
+
+    const exchangeCode = crypto.randomBytes(24).toString('hex');
+    stateRow.userId = user._id;
+    stateRow.exchangeCode = exchangeCode;
+    stateRow.exchangeExpiresAt = new Date(Date.now() + EXCHANGE_TTL_MS);
+    await stateRow.save();
+
+    const dest = new URLSearchParams({ code: exchangeCode, next: stateRow.next || '/v2' });
+    return res.redirect(`${frontendUrl()}/v2/oauth/complete?${dest.toString()}`);
+  } catch (err: any) {
+    console.error(`OAuth ${provider} callback failed:`, err?.response?.data || err.message);
+    return loginErrorRedirect(res, 'provider_error');
+  }
+};
+
+// POST /api/auth/oauth/exchange { code }
+exports.exchangeOAuthCode = async (req: any, res: any) => {
+  try {
+    const code = String(req.body?.code || '');
+    if (!code) return res.status(400).json({ error: 'Missing exchange code.' });
+
+    // Atomic claim — the code is single-use.
+    const stateRow = await OAuthLoginState.findOneAndUpdate(
+      {
+        exchangeCode: code,
+        exchangedAt: null,
+        exchangeExpiresAt: { $gt: new Date() },
+      },
+      { $set: { exchangedAt: new Date() } },
+      { new: true },
+    );
+    if (!stateRow || !stateRow.userId) {
+      return res.status(400).json({ error: 'Invalid or expired exchange code.', code: 'EXCHANGE_INVALID' });
+    }
+
+    const user = await User.findById(stateRow.userId);
+    if (!user) return res.status(400).json({ error: 'User not found.' });
+
+    return res.json(issueSession(user));
+  } catch (err: any) {
+    console.error('OAuth exchange failed:', err.message);
+    return res.status(500).json({ error: 'Server error' });
+  }
+};
+
+export {};

--- a/backend/controllers/oauthController.ts
+++ b/backend/controllers/oauthController.ts
@@ -302,7 +302,9 @@ exports.oauthCallback = async (req: any, res: any) => {
     const dest = new URLSearchParams({ code: exchangeCode, next: stateRow.next || '/v2' });
     return res.redirect(`${frontendUrl()}/v2/oauth/complete?${dest.toString()}`);
   } catch (err: any) {
-    console.error(`OAuth ${provider} callback failed:`, err?.response?.data || err.message);
+    // provider is user-controlled (req.params) — keep it out of the format
+    // string (CodeQL js/tainted-format-string).
+    console.error('OAuth callback failed for provider:', provider, err?.response?.data || err.message);
     return loginErrorRedirect(res, 'provider_error');
   }
 };

--- a/backend/models/OAuthLoginState.ts
+++ b/backend/models/OAuthLoginState.ts
@@ -1,0 +1,52 @@
+import mongoose, { Document, Schema, Types } from 'mongoose';
+
+// One row per social-login attempt. Lives for the length of the OAuth
+// round-trip and is deliberately separate from OAuthState (the X/Twitter
+// integration model) — that flow authorizes an existing user's integration,
+// this one authenticates a possibly-not-yet-existing user.
+//
+// Lifecycle: created at /oauth/:provider/start (state minted) → validated +
+// marked used at /oauth/:provider/callback (userId + one-time exchangeCode
+// stamped) → consumed at /oauth/exchange (JWT issued, exchangedAt stamped).
+// The TTL index reaps abandoned attempts.
+
+export type OAuthLoginProvider = 'github' | 'google';
+
+export interface IOAuthLoginState extends Document {
+  provider: OAuthLoginProvider;
+  state: string;
+  // Optional invite code captured at /start so an OAuth signup can satisfy
+  // the invite-only gate without a form round-trip.
+  invitationCode?: string;
+  // Frontend path to land on after login completes. Must be app-relative.
+  next?: string;
+  userId?: Types.ObjectId | null;
+  exchangeCode?: string | null;
+  exchangeExpiresAt?: Date | null;
+  usedAt?: Date | null;
+  exchangedAt?: Date | null;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const OAuthLoginStateSchema = new Schema<IOAuthLoginState>(
+  {
+    provider: { type: String, required: true, enum: ['github', 'google'], index: true },
+    state: { type: String, required: true, unique: true, index: true },
+    invitationCode: { type: String, default: '' },
+    next: { type: String, default: '/v2' },
+    userId: { type: Schema.Types.ObjectId, ref: 'User', default: null },
+    exchangeCode: { type: String, default: null, unique: true, sparse: true },
+    exchangeExpiresAt: { type: Date, default: null },
+    usedAt: { type: Date, default: null },
+    exchangedAt: { type: Date, default: null },
+    expiresAt: { type: Date, required: true, index: { expires: 0 } },
+  },
+  { timestamps: true, collection: 'oauth_login_states' },
+);
+
+export default mongoose.model<IOAuthLoginState>('OAuthLoginState', OAuthLoginStateSchema);
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/models/User.ts
+++ b/backend/models/User.ts
@@ -27,6 +27,19 @@ export interface IFollowedThread {
   followedAt: Date;
 }
 
+// Social-login identities linked to this account. A user may have zero
+// (password-only), one, or several (GitHub + Google linked by verified
+// email). Accounts created via OAuth have no password — see the
+// conditional `required` on the password path below.
+export type AuthProviderName = 'github' | 'google';
+
+export interface IAuthProvider {
+  provider: AuthProviderName;
+  providerId: string;
+  email?: string;
+  linkedAt: Date;
+}
+
 // User-level alias → agent (or human) binding. Both human and bot users
 // carry this list; for bots it's the agent's "contacts" — who they go to
 // for codex review, planning, etc. For humans it's the people they DM
@@ -47,7 +60,8 @@ export interface IContactEntry {
 export interface IUser extends Document {
   username: string;
   email: string;
-  password: string;
+  password?: string;
+  authProviders: IAuthProvider[];
   verified: boolean;
   profilePicture: string;
   role: UserRole;
@@ -127,7 +141,25 @@ export interface IUserModel extends Model<IUser> {}
 const userSchema = new Schema<IUser>({
   username: { type: String, required: true, unique: true },
   email: { type: String, required: true, unique: true },
-  password: { type: String, required: true },
+  // Password is only required for accounts with no linked OAuth identity —
+  // OAuth-created accounts authenticate via provider and have no password.
+  password: {
+    type: String,
+    required: function (this: IUser) {
+      return !(Array.isArray(this.authProviders) && this.authProviders.length > 0);
+    },
+  },
+  authProviders: {
+    type: [
+      new Schema<IAuthProvider>({
+        provider: { type: String, enum: ['github', 'google'], required: true },
+        providerId: { type: String, required: true },
+        email: { type: String },
+        linkedAt: { type: Date, default: Date.now },
+      }, { _id: false }),
+    ],
+    default: [],
+  },
   verified: { type: Boolean, default: false },
   profilePicture: { type: String, default: 'default' },
   role: { type: String, enum: ['user', 'admin'], default: 'user' },
@@ -256,13 +288,17 @@ const userSchema = new Schema<IUser>({
   createdAt: { type: Date, default: Date.now },
 });
 
+// OAuth callback looks users up by (provider, providerId) on every social login.
+userSchema.index({ 'authProviders.provider': 1, 'authProviders.providerId': 1 });
+
 userSchema.pre<IUser>('save', async function (next) {
-  if (!this.isModified('password')) return next();
+  if (!this.isModified('password') || !this.password) return next();
   this.password = await bcrypt.hash(this.password, 10);
   next();
 });
 
 userSchema.methods.comparePassword = async function (password: string): Promise<boolean> {
+  if (!this.password) return false; // OAuth-only account — no password to compare
   return bcrypt.compare(password, this.password);
 };
 

--- a/backend/routes/admin/users.ts
+++ b/backend/routes/admin/users.ts
@@ -2,13 +2,31 @@ export {};
 const express = require('express');
 const crypto = require('crypto');
 const axios = require('axios');
+const rateLimit = require('express-rate-limit');
 const auth = require('../../middleware/auth');
 const adminAuth = require('../../middleware/adminAuth');
 const User = require('../../models/User');
 const InvitationCode = require('../../models/InvitationCode');
 const WaitlistRequest = require('../../models/WaitlistRequest');
+const { cloudflareIpRateLimitKeyGenerator } = require('../../middleware/ipRateLimit');
 
 const router = express.Router();
+
+// Admin mutations are rare, deliberate actions — 60/15min/IP is generous for
+// a human operator while still bounding token-stuffing against the admin
+// surface (CodeQL js/missing-rate-limiting).
+const adminWriteLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  keyGenerator: cloudflareIpRateLimitKeyGenerator,
+  handler: (_req: any, res: any) => res.status(429).json({
+    message: 'rate limit exceeded: 60 admin writes per 15 minutes',
+    code: 'rate_limited',
+  }),
+});
 
 const sanitizeUser = (user: any) => ({
   id: user._id?.toString?.() || user.id,
@@ -156,7 +174,7 @@ router.patch('/:userId/role', auth, adminAuth, async (req: any, res: any) => {
 // flags (today just cloudAgents, the hosted-agent gate; see User.entitlements).
 // This is the missing admin lever for the staged open-registration plan:
 // new signups default to BYO-only, and an admin flips cloudAgents here.
-router.patch('/:userId/entitlements', auth, adminAuth, async (req: any, res: any) => {
+router.patch('/:userId/entitlements', adminWriteLimiter, auth, adminAuth, async (req: any, res: any) => {
   try {
     const { userId } = req.params;
     const { cloudAgents } = req.body || {};

--- a/backend/routes/admin/users.ts
+++ b/backend/routes/admin/users.ts
@@ -152,6 +152,39 @@ router.patch('/:userId/role', auth, adminAuth, async (req: any, res: any) => {
   }
 });
 
+// PATCH /api/admin/users/:userId/entitlements — grant/revoke capability
+// flags (today just cloudAgents, the hosted-agent gate; see User.entitlements).
+// This is the missing admin lever for the staged open-registration plan:
+// new signups default to BYO-only, and an admin flips cloudAgents here.
+router.patch('/:userId/entitlements', auth, adminAuth, async (req: any, res: any) => {
+  try {
+    const { userId } = req.params;
+    const { cloudAgents } = req.body || {};
+    if (typeof cloudAgents !== 'boolean') {
+      return res.status(400).json({ error: 'cloudAgents must be a boolean' });
+    }
+
+    const target = await User.findById(userId);
+    if (!target) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    if (target.isBot) {
+      return res.status(400).json({ error: 'Entitlements apply to human accounts, not bots' });
+    }
+
+    target.entitlements = { ...(target.entitlements || {}), cloudAgents };
+    await target.save();
+
+    return res.json({
+      message: 'User entitlements updated successfully',
+      user: { ...sanitizeUser(target), entitlements: target.entitlements },
+    });
+  } catch (error) {
+    console.error('Failed to update user entitlements:', error);
+    return res.status(500).json({ error: 'Failed to update user entitlements' });
+  }
+});
+
 // DELETE /api/admin/users/:userId
 router.delete('/:userId', auth, adminAuth, async (req: any, res: any) => {
   try {

--- a/backend/routes/auth.ts
+++ b/backend/routes/auth.ts
@@ -19,6 +19,13 @@ const {
   getRegistrationPolicy,
   requestWaitlist,
 } = require('../controllers/authController');
+// eslint-disable-next-line global-require
+const {
+  getOAuthProviders,
+  startOAuth,
+  oauthCallback,
+  exchangeOAuthCode,
+} = require('../controllers/oauthController');
 
 interface AuthReq {
   user?: { id: string };
@@ -72,9 +79,26 @@ const waitlistLimiter = rateLimit({
   handler: rateLimitHandler('rate limit exceeded: 5 waitlist requests per hour'),
 });
 
+// Social login shares the credential-stuffing posture of /login: each attempt
+// is one provider round-trip, so 30/15min/IP leaves room for retries without
+// letting a bot farm state rows.
+const oauthLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  keyGenerator: cloudflareIpRateLimitKeyGenerator,
+  handler: rateLimitHandler('rate limit exceeded: 30 OAuth attempts per 15 minutes'),
+});
+
 const router: ReturnType<typeof express.Router> = express.Router();
 
 router.post('/register', registerLimiter, register);
+router.get('/oauth/providers', getOAuthProviders);
+router.get('/oauth/:provider/start', oauthLimiter, startOAuth);
+router.get('/oauth/:provider/callback', oauthLimiter, oauthCallback);
+router.post('/oauth/exchange', oauthLimiter, exchangeOAuthCode);
 router.get('/registration-policy', getRegistrationPolicy);
 router.post('/waitlist', waitlistLimiter, requestWaitlist);
 router.post('/login', loginLimiter, login);

--- a/docs/plans/retention-traction-onboarding-2026-07.md
+++ b/docs/plans/retention-traction-onboarding-2026-07.md
@@ -1,0 +1,181 @@
+# Retention & Traction Hardening — OAuth, Open Registration, Local-Agent Migration, Aha Moment
+
+**Status:** Proposed — 2026-07-02
+**Owner:** Sam Xu
+**Companion:** ADR-011 (shell-first pre-GTM — this is the funnel half of that track), ADR-003 (memory envelope — migration target), ADR-005/006 (BYO attach paths), pricing model (humans are seats, agents never are)
+
+---
+
+## The retention thesis
+
+Commonly's durable retention mechanic is **memory accrual**. Every day an agent
+works inside Commonly, its memory envelope gets more valuable and the cost of
+leaving grows. Everything in this plan serves one funnel:
+
+```
+land → sign up (seconds, OAuth) → meet an agent (<60s, bundled guide)
+     → attach YOUR agent (BYO, coached) → import its memory (arrives whole)
+     → memory accrues → switching cost → retention
+```
+
+The current funnel breaks at three places:
+
+1. **Signup friction** — username + password + email verification + invite code.
+2. **Dead first minute** — new users land in an empty "My Workspace" pod with
+   nobody to talk to; `entitlements.cloudAgents` defaults `false`, so the only
+   path to a live agent requires leaving the browser for a terminal.
+3. **Cold-start agent** — even after `commonly agent attach`, the agent arrives
+   amnesiac. There is no memory or skill import path at all today.
+
+---
+
+## Current state (verified 2026-07-02)
+
+| Piece | State |
+|---|---|
+| Invite gate | `REGISTRATION_INVITE_ONLY` env flag (`authController.ts:21`), defaults ON in production. Dual-track codes (env + `InvitationCode` DB rows), waitlist model, admin CRUD routes — all built. Lifting = one env flip. |
+| Cloud-agent gate | `User.entitlements.cloudAgents` (default `false`) enforced in `routes/registry/install.ts:284` + `provision.ts:154` via `agentIdentityService.isCloudRuntime`. `webhook`, `claude-code`, `host==='byo'` are always open. |
+| Default pod | Every signup gets a private "My Workspace" pod (`authController.ts:158`). Blank — no seed content, no agents. |
+| OAuth | **None for login.** `OAuthState` model is X-integration only. No passport, no social buttons on `V2Login`/`V2Register`. |
+| BYO flow | `/v2/agents/byo` (web, mints MCP token) and `commonly agent attach claude --pod <id>` (CLI, 3 commands) both work. |
+| First-message coaching | Exists — "Say hi to {agent}" + 3 suggestion chips in agent-rooms (`V2PodChat.tsx:707`). |
+| Onboarding guide/tour/checklist | None. |
+| Memory import | **None.** Envelope + `POST /api/agents/runtime/memory/sync` (patch mode, `sourceRuntime` tag) exist; no CLI/UI ingestion of a local `MEMORY.md`/memory dir. |
+| Skill import for local agents | **None.** `POST /api/skills/import` is pod-scoped; `syncOpenClawSkills` is OpenClaw-workspace-specific. Local agents' skills live and execute on the user's machine. |
+
+---
+
+## Decisions & recommendations
+
+### D1 — OAuth: GitHub first, Google second, no passport.js
+
+**Do both, GitHub leading.** The ICP is a developer with a local CLI agent;
+GitHub identity is native to them and sets up later affordances (repo-linked
+pods, skill discovery). Google widens the top for teammates/PMs.
+
+Implementation shape (small, no framework):
+
+- `GET /api/auth/oauth/:provider/start` → 302 to provider with signed `state`
+  (extend the existing `OAuthState` pattern with `provider: 'github' | 'google'`).
+- `GET /api/auth/oauth/:provider/callback` → exchange code, fetch
+  verified email + profile, then **link-or-create**:
+  - Existing user with same verified email → link (`authProviders[]` entry), issue JWT.
+  - New user → create with auto-generated username (provider handle, collision
+    suffix), `verified: true` (provider asserts email), **no password**
+    (`password` becomes optional when `authProviders` is non-empty), `isBot: false`.
+  - Same default-workspace-pod + (D4) starter seeding path as password signup.
+- Callback lands on `api.commonly.me`, redirects to
+  `app.commonly.me/v2/oauth/complete#token=<one-time-code>`; frontend swaps the
+  one-time code for the JWT (avoid putting the long-lived JWT in a URL).
+- **OAuth respects the invite gate** until D2 flips it: an OAuth signup without
+  a valid invite lands on the waitlist screen with identity pre-filled — this
+  actually improves the waitlist (verified emails, zero-friction conversion later).
+
+User model deltas: `authProviders: [{ provider, providerId, email, linkedAt }]`,
+password optional-if-OAuth. Existing JWT issuance/middleware unchanged.
+
+### D2 — Invite gate: keep held, flip AT the launch moment, not before
+
+Lifting is one env flip, so the question is purely **when**. Traffic today is
+~zero; the gate is not what's blocking traction — the funnel behind it is.
+First impressions are non-renewable: flip **after** D1 + D4 land, timed with
+the launch signal (Show HN / launch day) so the first real cohort hits the
+good funnel. Pre-work to do now:
+
+- Admin entitlement endpoint (`PATCH /api/admin/users/:id/entitlements`) — missing.
+- Graceful 403 UX for `cloud_agents_not_entitled` (PR #533 follow-up) —
+  upsell copy, not an error toast.
+- Waitlist → one-click approve+invite email (routes exist; wire the loop).
+- Basic abuse guards on open signup (rate limits exist; add disposable-email
+  denylist only if abuse actually shows up — don't pre-build).
+
+### D3 — Migration: memory YES (the wedge), skills as metadata only
+
+**Memory import is the differentiator and directly feeds the retention
+mechanic — build it.** It maps 1:1 onto the existing envelope:
+
+- **CLI:** `commonly agent attach claude --import-memory [path]` — auto-detect
+  `~/.claude/` project memory / `MEMORY.md` / `CLAUDE.md`, show a preview,
+  confirm, then `POST /memory/sync` `{ sections: { long_term }, mode: 'patch',
+  sourceRuntime: 'import-local' }`. Also offer interactively during plain `attach`.
+- **Web BYO flow:** optional "bring its memory" step in `/v2/agents/byo` —
+  paste or upload `MEMORY.md`, same sync call. The agent's profile then shows
+  a populated memory index on day one.
+- **Explicitly opt-in with preview** — local memory files can contain private
+  material; never slurp silently.
+
+**Skill migration: do NOT sync skill content.** Local agents execute their
+skills locally — Commonly doesn't need the content for the agent to function,
+and skill files carry the same privacy risk. What boosts willingness-to-use is
+**visibility**: import skill *names + descriptions* (SKILL.md frontmatter) as
+agent-profile metadata — "Theo arrives with 12 skills" — via a small
+`capabilities` section on the profile. Content sync remains an OpenClaw/cloud-
+runtime concern (`syncOpenClawSkills`), untouched. Revisit full sync only when
+a cloud-runtime migration path ("promote my local agent to hosted") exists —
+that's the natural upsell moment, not signup.
+
+Framing for landing + docs: **"Your agent arrives whole — identity, memory,
+skills — and everything it learns here goes with it."** (Portability is the
+trust side of the switching-cost coin; ADR-003 already promises it.)
+
+### D4 — Aha moment: one bundled first-party guide agent per user + seeded starter workspace; the agent IS the guider UI
+
+**Recommendation: yes to "at least 1 cloud agent per user" — as a first-party
+native-runtime (Tier 1) guide agent, auto-installed into My Workspace at
+signup.** Rationale:
+
+- The empty-pod first minute is the biggest hole. A guide agent gives a live
+  "talk to an agent in a shared space" moment in <60 seconds, in-browser,
+  no terminal.
+- It **replaces the tour/wizard**: conversational onboarding is on-brand (the
+  product demos itself). The guide welcomes you, asks what tools you use, and
+  hands you the *exact* `commonly agent attach` commands with your real podId
+  + token — coaching the BYO conversion, which is the activation step.
+- It does **not** break the pricing story or the entitlement gate: the gate is
+  on user-initiated install/provision; this is platform-installed, like
+  `pod-welcomer` (which is the reference implementation to evolve). Free tier =
+  our guide + unlimited BYO; Pro = *your own* cloud agents. Unchanged.
+- Cost control: native runtime already has `AgentRun` cost tracking + guardrails
+  (`NATIVE_RUNTIME_GUARDRAILS`). Cap the guide at N messages/user/day; scope its
+  tools to read-only + task-create.
+- **Known blocker to resolve first:** native agents were dark on the free
+  OpenRouter model (#510 — welcomer/summarizer llm_error). The guide needs a
+  reliable cheap paid model with a hard budget, or it will embarrass us at the
+  exact moment it matters most. This is the one real cost decision in the plan.
+
+**Starter workspace seeding** (at signup, alongside pod creation):
+- Guide agent installed + a pinned welcome message from it.
+- 3 seed tasks on the existing task board as the "checklist" — *Attach your
+  local agent*, *Import its memory*, *Invite a teammate* — reusing task
+  primitives instead of building a checklist component. The guide references
+  and completes them with the user.
+
+**Landing page:** skip an interactive playground (expensive, fragile). Elevate
+the existing read-only **showcase** room to a hero-adjacent "watch a live room"
+CTA, and let the post-signup guide agent be the interactive moment. Revisit
+only if analytics show hero dropoff.
+
+**Skip for now:** dedicated tour/wizard/checklist UI component, progressive
+disclosure of the 3-column shell. Coached empty states + guide agent cover it;
+build UI chrome only if funnel data shows the conversational path failing.
+
+---
+
+## Build order
+
+| Phase | Scope | Why this order |
+|---|---|---|
+| **A — Funnel plumbing** | GitHub OAuth end-to-end (backend flow + login/register buttons + link-or-create), then Google. Admin entitlements endpoint. Graceful cloud-gate 403 UX. | Smallest well-understood surface; everything later benefits. |
+| **B — Aha** | Guide agent (evolve `pod-welcomer`; pick model + budget) + starter-workspace seeding + guide-driven BYO coaching. | The retention lever; needs the #510 model decision resolved. |
+| **C — Arrive whole** | `--import-memory` in CLI attach + memory step in web BYO + skills-as-metadata on agent profile. | The wedge feature; builds on B's coached attach path. |
+| **D — Open the doors** | Flip `REGISTRATION_INVITE_ONLY=false`, waitlist auto-convert, timed with launch signal. | Non-renewable first impressions; flip when A–C are live. |
+
+Each phase is independently shippable and reversible; D is deliberately last
+and deliberately just an env flip + comms.
+
+## Open forks (need Sam's call)
+
+1. **Guide-agent model + budget** — which paid model, what per-user cap (the #510 free-model failure makes "free" a non-option).
+2. **Flip timing** — this plan says hold for the launch signal; flipping earlier only makes sense if we want a quiet-beta cohort to test the funnel.
+3. **Skill migration scope** — this plan says metadata-only; full content sync deferred to a future "promote to hosted" upsell.
+4. **OAuth rollout** — GitHub-only first is fine to ship alone; Google can trail by a sprint.

--- a/frontend/src/v2/V2App.tsx
+++ b/frontend/src/v2/V2App.tsx
@@ -7,6 +7,7 @@ import V2YourTeamPage from './components/V2YourTeamPage';
 import V2InviteRedeem from './components/V2InviteRedeem';
 import { useAuth } from '../context/AuthContext';
 import V2Register from './components/V2Register';
+import V2OAuthComplete from './components/V2OAuthComplete';
 import RegistrationInviteRequired from '../components/RegistrationInviteRequired';
 import VerifyEmail from '../components/VerifyEmail';
 import DiscordCallback from '../components/DiscordCallback';
@@ -163,6 +164,7 @@ const V2App: React.FC = () => {
           <Route path="login" element={<V2Login />} />
           <Route path="register" element={<V2Register />} />
           <Route path="register/invite-required" element={<RegistrationInviteRequired />} />
+          <Route path="oauth/complete" element={<V2OAuthComplete />} />
           <Route path="verify-email" element={<VerifyEmail />} />
           <Route path="discord/callback" element={<DiscordCallback />} />
           <Route path="discord/success" element={<DiscordCallback type="success" />} />

--- a/frontend/src/v2/__tests__/V2OAuth.test.tsx
+++ b/frontend/src/v2/__tests__/V2OAuth.test.tsx
@@ -1,0 +1,125 @@
+// @ts-nocheck
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import V2OAuthButtons from '../components/V2OAuthButtons';
+import V2OAuthComplete from '../components/V2OAuthComplete';
+import V2Login from '../components/V2Login';
+import { AuthContext } from '../../context/AuthContext';
+
+// Same mock surface as V2Login.test.tsx — axiosConfig assigns
+// axios.defaults.baseURL at import time.
+jest.mock('axios', () => {
+  const mock = {
+    get: jest.fn(() => Promise.resolve({ data: {} })),
+    post: jest.fn(() => Promise.resolve({ data: {} })),
+    patch: jest.fn(),
+    delete: jest.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  };
+  return { __esModule: true, default: mock, ...mock };
+});
+
+const axios = jest.requireMock('axios').default;
+
+const baseAuth = {
+  currentUser: null,
+  user: null,
+  token: null,
+  loading: false,
+  error: null,
+  isAuthenticated: false,
+  register: jest.fn(),
+  login: jest.fn(),
+  logout: jest.fn(),
+  updateProfile: jest.fn(),
+};
+
+afterEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+});
+
+describe('V2OAuthButtons', () => {
+  test('renders a button per configured provider with invite carried through', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: { providers: [{ id: 'github', label: 'GitHub' }, { id: 'google', label: 'Google' }] },
+    });
+
+    render(
+      <MemoryRouter>
+        <V2OAuthButtons invite="CODE1" />
+      </MemoryRouter>,
+    );
+
+    const github = await screen.findByRole('link', { name: /continue with github/i });
+    expect(github).toHaveAttribute('href', expect.stringContaining('/api/auth/oauth/github/start'));
+    expect(github).toHaveAttribute('href', expect.stringContaining('invite=CODE1'));
+    expect(screen.getByRole('link', { name: /continue with google/i })).toBeInTheDocument();
+  });
+
+  test('renders nothing when no provider is configured', async () => {
+    axios.get.mockResolvedValueOnce({ data: { providers: [] } });
+
+    const { container } = render(
+      <MemoryRouter>
+        <V2OAuthButtons />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(axios.get).toHaveBeenCalledWith('/api/auth/oauth/providers'));
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('V2OAuthComplete', () => {
+  const renderComplete = (search: string) => render(
+    <AuthContext.Provider value={baseAuth}>
+      <MemoryRouter initialEntries={[`/v2/oauth/complete${search}`]}>
+        <Routes>
+          <Route path="/v2/oauth/complete" element={<V2OAuthComplete />} />
+          <Route path="/v2/login" element={<V2Login />} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>,
+  );
+
+  test('exchanges the one-time code and stores the session token', async () => {
+    axios.post.mockResolvedValueOnce({ data: { token: 'session-jwt' } });
+    const replaceSpy = jest.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, replace: replaceSpy },
+    });
+
+    await act(async () => {
+      renderComplete('?code=one-time&next=/v2/pods/abc');
+    });
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith('/api/auth/oauth/exchange', { code: 'one-time' });
+      expect(localStorage.getItem('token')).toBe('session-jwt');
+      expect(replaceSpy).toHaveBeenCalledWith('/v2/pods/abc');
+    });
+
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+  });
+
+  test('bounces to login with an error when the exchange fails', async () => {
+    axios.post.mockRejectedValueOnce(new Error('bad code'));
+    // The login page fetches providers on mount after the bounce.
+    axios.get.mockResolvedValue({ data: { providers: [] } });
+
+    await act(async () => {
+      renderComplete('?code=stale');
+    });
+
+    expect(await screen.findByText(/sign-in could not be completed/i)).toBeInTheDocument();
+    expect(localStorage.getItem('token')).toBeNull();
+  });
+});

--- a/frontend/src/v2/components/V2Login.tsx
+++ b/frontend/src/v2/components/V2Login.tsx
@@ -1,10 +1,24 @@
 import React, { useState } from 'react';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
+import V2OAuthButtons from './V2OAuthButtons';
 
 interface LocationState {
   from?: { pathname?: string };
 }
+
+// Error codes the backend OAuth callback can bounce back with (as
+// ?oauthError=). Anything unlisted falls through to the generic line.
+const OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  invitation_required: 'Registration is invite-only right now. Use an invitation link to sign up, or join the waitlist.',
+  invitation_invalid: 'That invitation code is invalid or used up.',
+  email_unverified: 'Your provider account has no verified email address, so we can\'t link it safely.',
+  provider_denied: 'Sign-in was cancelled at the provider.',
+  state_invalid: 'That sign-in attempt expired. Please try again.',
+  exchange_failed: 'Sign-in could not be completed. Please try again.',
+  provider_error: 'Something went wrong talking to the sign-in provider. Please try again.',
+  bot_account: 'This email belongs to an agent account and can\'t be used for social sign-in.',
+};
 
 const V2Login: React.FC = () => {
   const { login, error: authError, loading } = useAuth();
@@ -39,7 +53,14 @@ const V2Login: React.FC = () => {
     }
   };
 
-  const errorMessage = localError || authError;
+  const params = new URLSearchParams(location.search);
+  const oauthErrorCode = params.get('oauthError');
+  const oauthError = oauthErrorCode
+    ? (OAUTH_ERROR_MESSAGES[oauthErrorCode] || OAUTH_ERROR_MESSAGES.provider_error)
+    : null;
+  const nextPath = params.get('next') || undefined;
+
+  const errorMessage = localError || authError || oauthError;
 
   return (
     <div className="v2-login">
@@ -86,6 +107,8 @@ const V2Login: React.FC = () => {
         </button>
 
         {errorMessage && <div className="v2-login__error">{errorMessage}</div>}
+
+        <V2OAuthButtons next={nextPath} />
 
         <div className="v2-login__hint">
           New to Commonly?

--- a/frontend/src/v2/components/V2OAuthButtons.tsx
+++ b/frontend/src/v2/components/V2OAuthButtons.tsx
@@ -62,7 +62,7 @@ const V2OAuthButtons: React.FC<V2OAuthButtonsProps> = ({ invite, next }) => {
 
   return (
     <>
-      <div className="v2-login__divider"><span>or</span></div>
+      <div className="v2-login__or"><span>or</span></div>
       <div className="v2-login__oauth">
         {providers.map((p) => (
           <a key={p.id} className="v2-login__oauth-btn" href={startUrl(p.id)}>

--- a/frontend/src/v2/components/V2OAuthButtons.tsx
+++ b/frontend/src/v2/components/V2OAuthButtons.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from 'react';
+import axios from '../../utils/axiosConfig';
+import getApiBaseUrl from '../../utils/apiBaseUrl';
+
+// Social sign-in buttons shared by V2Login and V2Register. Renders nothing
+// until /api/auth/oauth/providers confirms a provider is configured, so
+// self-hosted instances without OAuth credentials see no dead buttons.
+// The buttons are full-page navigations (not XHR) — the OAuth dance is a
+// server-side redirect chain that ends back on /v2/oauth/complete.
+
+interface OAuthProvider {
+  id: string;
+  label: string;
+}
+
+interface V2OAuthButtonsProps {
+  // Invite code to carry through the redirect chain so OAuth signups can
+  // satisfy the invite-only gate (register page passes it; login omits it).
+  invite?: string;
+  // App-relative path to land on after the session is established.
+  next?: string;
+}
+
+const PROVIDER_ICONS: Record<string, React.ReactNode> = {
+  github: (
+    <svg viewBox="0 0 16 16" width="18" height="18" fill="currentColor" aria-hidden="true">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+    </svg>
+  ),
+  google: (
+    <svg viewBox="0 0 18 18" width="18" height="18" aria-hidden="true">
+      <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.57 2.68-3.88 2.68-6.62Z" />
+      <path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18Z" />
+      <path fill="#FBBC05" d="M3.97 10.72a5.41 5.41 0 0 1 0-3.44V4.95H.96a9 9 0 0 0 0 8.1l3.01-2.33Z" />
+      <path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58C13.46.9 11.42 0 9 0A9 9 0 0 0 .96 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58Z" />
+    </svg>
+  ),
+};
+
+const V2OAuthButtons: React.FC<V2OAuthButtonsProps> = ({ invite, next }) => {
+  const [providers, setProviders] = useState<OAuthProvider[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    axios.get('/api/auth/oauth/providers')
+      .then((res) => {
+        if (active) setProviders(Array.isArray(res.data?.providers) ? res.data.providers : []);
+      })
+      .catch(() => { if (active) setProviders([]); });
+    return () => { active = false; };
+  }, []);
+
+  if (!providers.length) return null;
+
+  const startUrl = (id: string) => {
+    const params = new URLSearchParams();
+    if (next) params.set('next', next);
+    if (invite) params.set('invite', invite);
+    const qs = params.toString();
+    return `${getApiBaseUrl()}/api/auth/oauth/${id}/start${qs ? `?${qs}` : ''}`;
+  };
+
+  return (
+    <>
+      <div className="v2-login__divider"><span>or</span></div>
+      <div className="v2-login__oauth">
+        {providers.map((p) => (
+          <a key={p.id} className="v2-login__oauth-btn" href={startUrl(p.id)}>
+            {PROVIDER_ICONS[p.id]}
+            Continue with {p.label}
+          </a>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default V2OAuthButtons;

--- a/frontend/src/v2/components/V2OAuthComplete.tsx
+++ b/frontend/src/v2/components/V2OAuthComplete.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useRef } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import axios from '../../utils/axiosConfig';
+
+// Landing pad for the OAuth redirect chain. The backend callback hands us a
+// short-lived one-time code (never the JWT itself — it would end up in
+// browser history and server logs); we swap it for a session here, then do
+// a full-page navigation so AuthContext rehydrates from localStorage the
+// same way every other login path does.
+const V2OAuthComplete: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const fired = useRef(false); // StrictMode double-mount guard — the code is single-use
+
+  useEffect(() => {
+    if (fired.current) return;
+    fired.current = true;
+
+    const code = searchParams.get('code') || '';
+    const nextParam = searchParams.get('next') || '/v2';
+    const next = nextParam.startsWith('/') && !nextParam.startsWith('//') ? nextParam : '/v2';
+
+    if (!code) {
+      navigate('/v2/login?oauthError=exchange_failed', { replace: true });
+      return;
+    }
+
+    axios.post('/api/auth/oauth/exchange', { code })
+      .then((res) => {
+        const token = (res.data as { token?: string })?.token;
+        if (!token) throw new Error('no token');
+        localStorage.setItem('token', token);
+        window.location.replace(next);
+      })
+      .catch(() => {
+        navigate('/v2/login?oauthError=exchange_failed', { replace: true });
+      });
+  }, [searchParams, navigate]);
+
+  return (
+    <div className="v2-login">
+      <div className="v2-login__card">
+        <div className="v2-login__brand">
+          <span className="v2-rail__brand-icon">c</span>
+          commonly
+        </div>
+        <h1 className="v2-login__title">Signing you in…</h1>
+        <p className="v2-login__subtitle">Completing sign-in with your provider.</p>
+      </div>
+    </div>
+  );
+};
+
+export default V2OAuthComplete;

--- a/frontend/src/v2/components/V2Register.tsx
+++ b/frontend/src/v2/components/V2Register.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams, Navigate, Link } from 'react-router-dom';
 import axios from '../../utils/axiosConfig';
+import V2OAuthButtons from './V2OAuthButtons';
 
 // v2-native sign-up. Pairs with V2Login (reuses the .v2-login styles) so the
 // auth surfaces match after v2 became the default. Mirrors the legacy
@@ -162,6 +163,8 @@ const V2Register: React.FC = () => {
         </button>
 
         {error && <div className="v2-login__error">{error}</div>}
+
+        <V2OAuthButtons invite={invitationCode || undefined} />
 
         <div className="v2-login__hint">
           Already have an account?

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -3431,7 +3431,11 @@
   font-size: 12px;
 }
 
-.v2-login__divider {
+/* "or" separator between password form and social buttons. NOT
+   .v2-login__divider — that name is already taken by the invite-required
+   page's bordered section break (defined later in this file, so it would
+   win the cascade and stack a second hairline on top of this one). */
+.v2-login__or {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -3440,8 +3444,8 @@
   font-size: 12px;
 }
 
-.v2-login__divider::before,
-.v2-login__divider::after {
+.v2-login__or::before,
+.v2-login__or::after {
   content: '';
   flex: 1;
   height: 1px;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -3431,6 +3431,53 @@
   font-size: 12px;
 }
 
+.v2-login__divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 16px;
+  color: var(--v2-text-tertiary);
+  font-size: 12px;
+}
+
+.v2-login__divider::before,
+.v2-login__divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--v2-border);
+}
+
+.v2-login__oauth {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+/* Anchor styled as a button — prefixed with .v2-root a to beat the global
+   `.v2-root a { color: inherit }` rule, same trap as .v2-login__link. */
+.v2-root a.v2-login__oauth-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: var(--v2-radius);
+  border: 1px solid var(--v2-border-strong);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  font-weight: 600;
+  font-size: 14px;
+  text-decoration: none;
+  transition: background 80ms ease, border-color 80ms ease;
+}
+
+.v2-root a.v2-login__oauth-btn:hover {
+  background: var(--v2-bg-subtle);
+  border-color: var(--v2-accent);
+}
+
 .v2-login__hint {
   margin-top: 18px;
   padding: 10px 12px;


### PR DESCRIPTION
## What

Phase A of the retention/traction hardening plan (`docs/plans/retention-traction-onboarding-2026-07.md`, included in this PR):

- **Social login (GitHub + Google)** — framework-free authorization-code flow:
  - `GET /api/auth/oauth/providers` — which providers are configured (frontend renders buttons only for these; unconfigured self-hosted instances see no dead UI)
  - `GET /api/auth/oauth/:provider/start` — mints a single-use state row, 302 to provider
  - `GET /api/auth/oauth/:provider/callback` — link-or-create, then redirects to `/v2/oauth/complete` with a **2-minute one-time code** (the JWT never appears in a URL)
  - `POST /api/auth/oauth/exchange` — swaps the code for a session (same response shape as `/login`)
- **Link-or-create semantics**: match by `(provider, providerId)` first, then link by provider-verified email to an existing account; new signups honor the same `REGISTRATION_INVITE_ONLY` gate (invite code carried through `/start`→state row) and get the default My Workspace pod.
- **User model**: `authProviders[]`; `password` conditionally required (OAuth-only accounts have none); `login()` returns `OAUTH_ONLY_ACCOUNT` for them instead of a bcrypt throw.
- **Admin entitlements lever**: `PATCH /api/admin/users/:userId/entitlements` to grant/revoke `cloudAgents` — the missing piece of the staged open-registration work (#529).

Security notes: state + exchange codes are atomically claimed single-use rows with TTL indexes; `?next=` is confined to app-relative paths (open-redirect guard); email linking requires the provider to assert the email is verified.

## Config

`GITHUB_OAUTH_CLIENT_ID/SECRET`, `GOOGLE_OAUTH_CLIENT_ID/SECRET`, optional `OAUTH_CALLBACK_BASE_URL` (documented in `backend/.env.example`). Zero config change = zero behavior change.

## Tests

- 15 backend unit tests (`oauthController.test.js`): provider gating, state mint + open-redirect guard, new-user signup, email linking, invite-gate enforcement + DB-code consumption, state replay, unverified-email rejection, username collision suffix, one-time exchange semantics, OAuth-only login guard.
- 4 frontend tests (`V2OAuth.test.tsx`): buttons render per provider / hide when unconfigured, exchange success stores session, failure bounces to login with error.
- Full frontend suite: 189 passing. Backend suite green except pre-existing Node-26 `SlowBuffer` require failures (fail identically on a clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9