### PR TITLE
feat(helm): wire social-login OAuth env into backend deployment

### DIFF
--- a/k8s/helm/commonly/templates/core/backend-deployment.yaml
+++ b/k8s/helm/commonly/templates/core/backend-deployment.yaml
@@ -211,31 +211,42 @@ spec:
               key: discord-guild-id
               optional: true
 
-        # OAuth Providers
-        - name: GOOGLE_CLIENT_ID
+        # Social login (OAuth) providers — names match what
+        # controllers/oauthController.ts reads. The old GITHUB_CLIENT_ID /
+        # GOOGLE_CLIENT_ID names were scaffold nothing consumed. Buttons only
+        # render when a provider's pair is present, so `optional: true` keeps
+        # instances without OAuth configured fully functional.
+        - name: GOOGLE_OAUTH_CLIENT_ID
           valueFrom:
             secretKeyRef:
               name: api-keys
               key: google-client-id
               optional: true
-        - name: GOOGLE_CLIENT_SECRET
+        - name: GOOGLE_OAUTH_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
               name: api-keys
               key: google-client-secret
               optional: true
-        - name: GITHUB_CLIENT_ID
+        - name: GITHUB_OAUTH_CLIENT_ID
           valueFrom:
             secretKeyRef:
               name: api-keys
               key: github-client-id
               optional: true
-        - name: GITHUB_CLIENT_SECRET
+        - name: GITHUB_OAUTH_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
               name: api-keys
               key: github-client-secret
               optional: true
+        {{- if .Values.backend.env.oauthCallbackBaseUrl }}
+        # Public base URL of this API, presented to providers as the
+        # redirect_uri origin — must match the URL registered on the OAuth
+        # app regardless of which ingress hostname the request arrived on.
+        - name: OAUTH_CALLBACK_BASE_URL
+          value: {{ .Values.backend.env.oauthCallbackBaseUrl | quote }}
+        {{- end }}
         - name: GITHUB_PAT
           valueFrom:
             secretKeyRef:

--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -33,6 +33,8 @@ backend:
     agentProvisionerNodePool: "dev"
     frontendUrl: "https://commonly.me"
     backendUrl: "https://api.commonly.me"
+    # Must match the callback URL registered on the GitHub/Google OAuth apps.
+    oauthCallbackBaseUrl: "https://api.commonly.me"
     commonlyApiUrl: ""
     clawdbotGatewayUrl: ""
     moltbotGatewayUrl: ""

--- a/k8s/helm/commonly/values.yaml
+++ b/k8s/helm/commonly/values.yaml
@@ -58,6 +58,9 @@ backend:
     agentProvisionerNodePool: ""
     frontendUrl: "https://commonly.me"
     backendUrl: "https://api.commonly.me"
+    # Base URL presented to OAuth providers as the redirect_uri origin.
+    # Empty = derive from the request host (fine when the API has one host).
+    oauthCallbackBaseUrl: ""
     commonlyApiUrl: ""
     clawdbotGatewayUrl: ""
     moltbotGatewayUrl: ""


### PR DESCRIPTION
Companion to #578 — makes GitHub sign-in actually configurable on the live instance.

- Renames the dead-scaffold `GOOGLE/GITHUB_CLIENT_ID/SECRET` env names (verified: nothing in backend/ reads them) to the `GITHUB_OAUTH_*` / `GOOGLE_OAUTH_*` names the OAuth controller reads. The `api-keys` secret keys and ExternalSecret mapping are untouched — they already existed.
- Adds `OAUTH_CALLBACK_BASE_URL` (dev: `https://api.commonly.me`) so the `redirect_uri` presented to providers always matches the registered callback.

Out-of-band (already done): org-owned GitHub OAuth app "Commonly" registered under Team-Commonly (callback `https://api.commonly.me/api/auth/oauth/github/callback`); real client id/secret pushed to GCP SM (`commonly-dev-github-client-*` v3) and force-synced into the cluster. After this merges + Deploy Dev, GitHub sign-in goes live; Google follows once its OAuth client exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9