### PR TITLE
fix(oauth): pending state rows collided on the exchangeCode unique index

### DIFF
--- a/backend/__tests__/unit/controllers/oauthController.test.js
+++ b/backend/__tests__/unit/controllers/oauthController.test.js
@@ -106,6 +106,22 @@ describe('OAuth Controller', () => {
       expect(state.invitationCode).toBe('CODE1');
     });
 
+    it('serves consecutive starts — pending rows must not collide on the exchangeCode index', async () => {
+      // Regression: exchangeCode had `default: null` + a sparse unique index.
+      // Sparse skips MISSING fields but still indexes explicit nulls, so the
+      // SECOND /start ever served threw E11000 and 500'd (2026-07-03 live
+      // incident — GitHub worked once, then every provider start failed).
+      const res1 = mockRes();
+      const res2 = mockRes();
+      await oauthController.startOAuth(startReq('github'), res1);
+      await oauthController.startOAuth(startReq('github'), res2);
+
+      expect(res1.redirect).toHaveBeenCalledTimes(1);
+      expect(res2.redirect).toHaveBeenCalledTimes(1);
+      expect(res2.status).not.toHaveBeenCalledWith(500);
+      expect(await OAuthLoginState.countDocuments({})).toBe(2);
+    });
+
     it('rejects absolute next URLs (open-redirect guard)', async () => {
       const res = mockRes();
       await oauthController.startOAuth(startReq('github', { next: 'https://evil.example' }), res);

--- a/backend/models/OAuthLoginState.ts
+++ b/backend/models/OAuthLoginState.ts
@@ -37,13 +37,26 @@ const OAuthLoginStateSchema = new Schema<IOAuthLoginState>(
     invitationCode: { type: String, default: '' },
     next: { type: String, default: '/v2' },
     userId: { type: Schema.Types.ObjectId, ref: 'User', default: null },
-    exchangeCode: { type: String, default: null, unique: true, sparse: true },
+    // NO default here — a sparse unique index skips MISSING fields but still
+    // indexes explicit nulls, so `default: null` made every pending state row
+    // collide on exchangeCode:null and 500'd the second /start ever served
+    // (2026-07-03 incident). The field stays absent until the callback stamps
+    // it; uniqueness is enforced by the partial index below.
+    exchangeCode: { type: String },
     exchangeExpiresAt: { type: Date, default: null },
     usedAt: { type: Date, default: null },
     exchangedAt: { type: Date, default: null },
     expiresAt: { type: Date, required: true, index: { expires: 0 } },
   },
   { timestamps: true, collection: 'oauth_login_states' },
+);
+
+// Unique only over rows that actually carry a code (post-callback). If this
+// index shape ever changes, drop the old `exchangeCode_1` index in Mongo by
+// hand — createIndex won't replace an existing index with different options.
+OAuthLoginStateSchema.index(
+  { exchangeCode: 1 },
+  { unique: true, partialFilterExpression: { exchangeCode: { $type: 'string' } } },
 );
 
 export default mongoose.model<IOAuthLoginState>('OAuthLoginState', OAuthLoginStateSchema);


### PR DESCRIPTION
Caught during live verification of #578/#580: `exchangeCode` had `default: null` **and** a `unique, sparse` index. Sparse indexes skip *missing* fields but still index explicit `null`s — so the first `/oauth/:provider/start` inserted `exchangeCode: null`, and the second ever served threw `E11000 dup key { exchangeCode: null }` and 500'd. GitHub sign-in worked exactly once, then every provider start failed.

Fix: no default — the field stays absent until the callback stamps the one-time code; uniqueness moves to a partial index (`$type: 'string'`). Regression test added: two consecutive starts must both redirect and persist rows.

Live remediation already applied out-of-band: dropped `exchangeCode_1` + cleared the transient state rows (10-min TTL scratch); verified 3× consecutive starts on both providers now 302. Mongoose recreates the corrected index on next boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9