### PR TITLE
feat(auth): open registration — invitation codes gate cloud agents, not signup

### DIFF
--- a/backend/__tests__/unit/controllers/invitationEntitlement.test.js
+++ b/backend/__tests__/unit/controllers/invitationEntitlement.test.js
@@ -1,0 +1,186 @@
+const User = require('../../../models/User');
+const InvitationCode = require('../../../models/InvitationCode');
+const authController = require('../../../controllers/authController');
+const {
+  setupMongoDb,
+  closeMongoDb,
+  clearMongoDb,
+} = require('../../utils/testUtils');
+
+// Invitation codes stopped gating signup and started granting the
+// hosted-agent entitlement (2026-07-03 plan revision). These tests pin the
+// new semantics across password registration and post-signup redemption.
+
+jest.mock('jsonwebtoken', () => ({
+  sign: jest.fn().mockReturnValue('test-jwt-token'),
+  verify: jest.fn(),
+}));
+
+const mockRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn(),
+});
+
+const seedDbCode = async (code = 'BETA1', maxUses = 1) => {
+  const admin = await User.findOne({ username: 'seed-admin' })
+    || await User.create({
+      username: 'seed-admin',
+      email: 'seed-admin@example.com',
+      password: 'hashed',
+      role: 'admin',
+    });
+  return InvitationCode.create({
+    code,
+    isActive: true,
+    maxUses,
+    useCount: 0,
+    createdBy: admin._id,
+  });
+};
+
+describe('Invitation → cloudAgents entitlement', () => {
+  beforeAll(async () => {
+    await setupMongoDb();
+  });
+
+  afterAll(async () => {
+    await closeMongoDb();
+  });
+
+  beforeEach(() => {
+    // Open registration; no SMTP → auto-verify path.
+    process.env.REGISTRATION_INVITE_ONLY = 'false';
+    delete process.env.REGISTRATION_INVITE_CODES;
+    delete process.env.SMTP2GO_API_KEY;
+  });
+
+  afterEach(async () => {
+    await clearMongoDb();
+    jest.clearAllMocks();
+    delete process.env.REGISTRATION_INVITE_ONLY;
+    delete process.env.REGISTRATION_INVITE_CODES;
+  });
+
+  describe('register (open registration)', () => {
+    const registerReq = (overrides = {}) => ({
+      body: {
+        username: 'newbie',
+        email: 'newbie@example.com',
+        password: 'Password123!',
+        ...overrides,
+      },
+    });
+
+    it('grants cloudAgents when a valid DB code is provided, and consumes it', async () => {
+      await seedDbCode('BETA1');
+      const res = mockRes();
+
+      await authController.register(registerReq({ invitationCode: 'BETA1' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      const user = await User.findOne({ email: 'newbie@example.com' });
+      expect(user.entitlements.cloudAgents).toBe(true);
+      const invite = await InvitationCode.findOne({ code: 'BETA1' });
+      expect(invite.useCount).toBe(1);
+    });
+
+    it('grants cloudAgents via a reusable env code', async () => {
+      process.env.REGISTRATION_INVITE_CODES = 'LAUNCH-CREW';
+      const res = mockRes();
+
+      await authController.register(registerReq({ invitationCode: 'LAUNCH-CREW' }), res);
+
+      const user = await User.findOne({ email: 'newbie@example.com' });
+      expect(user.entitlements.cloudAgents).toBe(true);
+    });
+
+    it('creates a BYO-only account when no code is given', async () => {
+      const res = mockRes();
+
+      await authController.register(registerReq(), res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      const user = await User.findOne({ email: 'newbie@example.com' });
+      expect(user.entitlements.cloudAgents).toBe(false);
+    });
+
+    it('fails loudly on a provided-but-invalid code even though registration is open', async () => {
+      const res = mockRes();
+
+      await authController.register(registerReq({ invitationCode: 'NOPE' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVITATION_INVALID' }));
+      expect(await User.countDocuments({ email: 'newbie@example.com' })).toBe(0);
+    });
+
+    it('still gates signup when invite-only mode is on', async () => {
+      process.env.REGISTRATION_INVITE_ONLY = 'true';
+      await seedDbCode('BETA1');
+      const res = mockRes();
+
+      await authController.register(registerReq(), res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVITATION_REQUIRED' }));
+    });
+  });
+
+  describe('redeemInvitation (post-signup upgrade)', () => {
+    const makeUser = (entitled = false) => User.create({
+      username: 'byo-user',
+      email: 'byo@example.com',
+      password: 'hashed',
+      verified: true,
+      entitlements: { cloudAgents: entitled },
+    });
+
+    it('flips cloudAgents on a valid code', async () => {
+      const user = await makeUser();
+      await seedDbCode('UPGRADE1');
+      const res = mockRes();
+
+      await authController.redeemInvitation(
+        { userId: user._id, body: { invitationCode: 'UPGRADE1' } },
+        res,
+      );
+
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        entitlements: expect.objectContaining({ cloudAgents: true }),
+      }));
+      const fresh = await User.findById(user._id);
+      expect(fresh.entitlements.cloudAgents).toBe(true);
+    });
+
+    it('rejects an invalid code', async () => {
+      const user = await makeUser();
+      const res = mockRes();
+
+      await authController.redeemInvitation(
+        { userId: user._id, body: { invitationCode: 'BOGUS' } },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      const fresh = await User.findById(user._id);
+      expect(fresh.entitlements.cloudAgents).toBe(false);
+    });
+
+    it('does not burn a code use on an already-entitled account', async () => {
+      const user = await makeUser(true);
+      await seedDbCode('PRECIOUS', 1);
+      const res = mockRes();
+
+      await authController.redeemInvitation(
+        { userId: user._id, body: { invitationCode: 'PRECIOUS' } },
+        res,
+      );
+
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        message: expect.stringContaining('already unlocked'),
+      }));
+      const invite = await InvitationCode.findOne({ code: 'PRECIOUS' });
+      expect(invite.useCount).toBe(0);
+    });
+  });
+});

--- a/backend/__tests__/unit/controllers/oauthController.test.js
+++ b/backend/__tests__/unit/controllers/oauthController.test.js
@@ -237,6 +237,31 @@ describe('OAuth Controller', () => {
       expect(invite.useCount).toBe(1);
     });
 
+    it('grants cloudAgents when an invite code rides through /start under open registration', async () => {
+      process.env.REGISTRATION_INVITE_ONLY = 'false';
+      process.env.REGISTRATION_INVITE_CODES = 'LAUNCH-CREW';
+      await seedState({ invitationCode: 'LAUNCH-CREW' });
+      mockGithubProfile();
+      const res = mockRes();
+
+      await oauthController.oauthCallback(callbackReq(), res);
+
+      const user = await User.findOne({ email: 'octo@example.com' });
+      expect(user.entitlements.cloudAgents).toBe(true);
+    });
+
+    it('creates a BYO-only account under open registration with no code', async () => {
+      process.env.REGISTRATION_INVITE_ONLY = 'false';
+      await seedState();
+      mockGithubProfile();
+      const res = mockRes();
+
+      await oauthController.oauthCallback(callbackReq(), res);
+
+      const user = await User.findOne({ email: 'octo@example.com' });
+      expect(user.entitlements.cloudAgents).toBe(false);
+    });
+
     it('rejects a replayed state (single-use)', async () => {
       await seedState({ usedAt: new Date() });
       const res = mockRes();

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -82,10 +82,22 @@ const createDefaultWorkspacePod = async (userId: any) => {
   }
 };
 
+// Redeem an invitation code: env codes are reusable (marketing links), DB
+// codes consume a use. Since registration opened up (2026-07-03), a code no
+// longer gates signup — it grants the hosted-agent entitlement
+// (entitlements.cloudAgents). Returns true when the code is good.
+const redeemInvitationCode = async (code: any) => {
+  const normalized = normalizeInviteCode(code);
+  if (!normalized) return false;
+  if (isEnvInvitationCodeValid(normalized)) return true;
+  return Boolean(await consumeDbInvitationCode(normalized));
+};
+
 // Reused by oauthController so social signups honor the same invite gate.
 exports.isInviteOnlyRegistrationEnabled = isInviteOnlyRegistrationEnabled;
 exports.isEnvInvitationCodeValid = isEnvInvitationCodeValid;
 exports.consumeDbInvitationCode = consumeDbInvitationCode;
+exports.redeemInvitationCode = redeemInvitationCode;
 exports.createDefaultWorkspacePod = createDefaultWorkspacePod;
 
 // 📌 Register User
@@ -120,36 +132,38 @@ exports.register = async (req: any, res: any) => {
       return res.status(400).json({ error: 'Username already exists' });
     }
 
-    if (isInviteOnlyRegistrationEnabled()) {
-      const normalizedInvitation = normalizeInviteCode(invitationCode);
-      if (!normalizedInvitation) {
-        const codes = getInvitationCodes();
-        const activeDbCodeExists = await InvitationCode.exists({
-          isActive: true,
-          $or: [{ expiresAt: null }, { expiresAt: { $gt: new Date() } }],
-        });
-        if (!codes.length && !activeDbCodeExists) {
-          return res.status(503).json({
-            error: 'Registration is currently invite-only and invitation codes are not configured.',
-            code: 'INVITATION_CONFIG_MISSING',
-          });
-        }
+    // Invitation codes grant the hosted-agent entitlement. When the instance
+    // still runs invite-only registration they additionally gate signup.
+    // A provided-but-invalid code always fails loudly — the user typed it
+    // expecting cloud access; silently dropping it would be worse.
+    const normalizedInvitation = normalizeInviteCode(invitationCode);
+    let invitationRedeemed = false;
+    if (normalizedInvitation) {
+      invitationRedeemed = await redeemInvitationCode(normalizedInvitation);
+      if (!invitationRedeemed) {
         return res.status(403).json({
-          error: 'Invitation code is required before registration.',
-          code: 'INVITATION_REQUIRED',
+          error: 'Invalid invitation code.',
+          code: 'INVITATION_INVALID',
         });
       }
+    }
 
-      const envCodeValid = isEnvInvitationCodeValid(normalizedInvitation);
-      if (!envCodeValid) {
-        const consumed = await consumeDbInvitationCode(normalizedInvitation);
-        if (!consumed) {
-          return res.status(403).json({
-            error: 'Invalid invitation code.',
-            code: 'INVITATION_INVALID',
-          });
-        }
+    if (isInviteOnlyRegistrationEnabled() && !invitationRedeemed) {
+      const codes = getInvitationCodes();
+      const activeDbCodeExists = await InvitationCode.exists({
+        isActive: true,
+        $or: [{ expiresAt: null }, { expiresAt: { $gt: new Date() } }],
+      });
+      if (!codes.length && !activeDbCodeExists) {
+        return res.status(503).json({
+          error: 'Registration is currently invite-only and invitation codes are not configured.',
+          code: 'INVITATION_CONFIG_MISSING',
+        });
       }
+      return res.status(403).json({
+        error: 'Invitation code is required before registration.',
+        code: 'INVITATION_REQUIRED',
+      });
     }
 
     const hasEmailConfig = Boolean(process.env.SMTP2GO_API_KEY)
@@ -166,12 +180,14 @@ exports.register = async (req: any, res: any) => {
       );
     }
 
-    // Create new user instance
+    // Create new user instance. A redeemed invitation grants hosted-agent
+    // access from day one; everyone else starts BYO-only.
     const user = new User({
       username: normalizedUsername,
       email: normalizedEmail,
       password: rawPassword,
       verified: shouldAutoVerify,
+      entitlements: { cloudAgents: invitationRedeemed },
     });
 
     // Save user to database
@@ -233,6 +249,43 @@ exports.register = async (req: any, res: any) => {
       }
       return res.status(400).json({ error: 'Duplicate user record.' });
     }
+    return res.status(500).json({ error: 'Server error' });
+  }
+};
+
+// 📌 Redeem an invitation code on an existing account → grants the
+// hosted-agent entitlement. The post-signup counterpart of the optional
+// code field at registration: BYO users upgrade whenever they get a code.
+exports.redeemInvitation = async (req: any, res: any) => {
+  try {
+    const user = await User.findById(req.userId);
+    if (!user) return res.status(404).json({ error: 'User not found' });
+
+    if (user.entitlements?.cloudAgents) {
+      // Don't burn a use on an account that already has access.
+      return res.json({
+        message: 'Hosted agents are already unlocked for this account.',
+        entitlements: user.entitlements,
+      });
+    }
+
+    const redeemed = await redeemInvitationCode(req.body?.invitationCode);
+    if (!redeemed) {
+      return res.status(403).json({
+        error: 'Invalid invitation code.',
+        code: 'INVITATION_INVALID',
+      });
+    }
+
+    user.entitlements = { ...(user.entitlements || {}), cloudAgents: true };
+    await user.save();
+
+    return res.json({
+      message: 'Hosted agents unlocked.',
+      entitlements: user.entitlements,
+    });
+  } catch (err: any) {
+    console.error('Failed to redeem invitation:', err.message);
     return res.status(500).json({ error: 'Server error' });
   }
 };

--- a/backend/controllers/oauthController.ts
+++ b/backend/controllers/oauthController.ts
@@ -5,8 +5,7 @@ const User = require('../models/User');
 const OAuthLoginState = require('../models/OAuthLoginState');
 const {
   isInviteOnlyRegistrationEnabled,
-  isEnvInvitationCodeValid,
-  consumeDbInvitationCode,
+  redeemInvitationCode,
   createDefaultWorkspacePod,
 } = require('./authController');
 
@@ -268,20 +267,25 @@ exports.oauthCallback = async (req: any, res: any) => {
     }
 
     if (!user) {
-      // Brand-new signup — honor the same invite gate as password registration.
-      if (isInviteOnlyRegistrationEnabled()) {
-        const code = String(stateRow.invitationCode || '').trim();
-        if (!code) return loginErrorRedirect(res, 'invitation_required');
-        if (!isEnvInvitationCodeValid(code)) {
-          const consumed = await consumeDbInvitationCode(code);
-          if (!consumed) return loginErrorRedirect(res, 'invitation_invalid');
-        }
+      // Brand-new signup. An invitation code carried through /start grants
+      // the hosted-agent entitlement; when the instance is invite-only it
+      // additionally gates the signup itself (same semantics as password
+      // registration — a provided-but-invalid code always fails loudly).
+      const code = String(stateRow.invitationCode || '').trim();
+      let invitationRedeemed = false;
+      if (code) {
+        invitationRedeemed = await redeemInvitationCode(code);
+        if (!invitationRedeemed) return loginErrorRedirect(res, 'invitation_invalid');
+      }
+      if (isInviteOnlyRegistrationEnabled() && !invitationRedeemed) {
+        return loginErrorRedirect(res, 'invitation_required');
       }
 
       user = new User({
         username: await generateUsername(profile.usernameHint, profile.email),
         email: profile.email,
         verified: true, // provider-asserted
+        entitlements: { cloudAgents: invitationRedeemed },
         authProviders: [{
           provider,
           providerId: profile.providerId,

--- a/backend/routes/auth.ts
+++ b/backend/routes/auth.ts
@@ -18,6 +18,7 @@ const {
   getProfile,
   getRegistrationPolicy,
   requestWaitlist,
+  redeemInvitation,
 } = require('../controllers/authController');
 // eslint-disable-next-line global-require
 const {
@@ -102,6 +103,9 @@ router.post('/oauth/exchange', oauthLimiter, exchangeOAuthCode);
 router.get('/registration-policy', getRegistrationPolicy);
 router.post('/waitlist', waitlistLimiter, requestWaitlist);
 router.post('/login', loginLimiter, login);
+// Invitation redemption is authed and rare — the login limiter's
+// credential-stuffing posture (20/15min/IP) also bounds code-guessing here.
+router.post('/redeem-invitation', loginLimiter, auth, redeemInvitation);
 router.post('/refresh', auth, refresh);
 router.get('/user', auth, getCurrentUser);
 router.get('/verify-email', verifyEmail);

--- a/docs/plans/retention-traction-onboarding-2026-07.md
+++ b/docs/plans/retention-traction-onboarding-2026-07.md
@@ -1,6 +1,30 @@
 # Retention & Traction Hardening — OAuth, Open Registration, Local-Agent Migration, Aha Moment
 
-**Status:** Proposed — 2026-07-02
+**Status:** Active — 2026-07-02 (revised 2026-07-03 after Phase A shipped)
+
+> **Revision 2026-07-03** (Sam's calls, after Phase A went live):
+> - **D2 superseded:** registration opens NOW — the invitation code is
+>   repurposed as the **cloud-agent entitlement grant** instead of a signup
+>   gate. BYO/local agents stay open to everyone; a valid invite code (at
+>   signup or redeemed later) flips `entitlements.cloudAgents`. No
+>   launch-signal wait needed since compute cost stays protected.
+> - **D4 descoped:** no LLM guide agent in v1 — a **scripted starter
+>   workspace** (pinned welcome + 3 seed checklist tasks + existing coached
+>   empty states) ships instead. The conversational guide is a later upgrade
+>   (cap decision when it comes: ~30 msgs/user/day, paid model only).
+> - **New: landing-page motion** — better animations/transitions on
+>   /v2/landing. CSS-first (no heavy animation lib), scroll-reveal +
+>   hero motion, `prefers-reduced-motion` respected, MCP-Playwright
+>   verification per Design Rule 9.
+> - **Deferred explicitly: Google Drive / GitHub repo sync.** Drive scope is
+>   sensitive → triggers Google OAuth verification review (+ possible CASA
+>   security assessment) — heavy for pre-GTM; our app is verification-free
+>   only while scopes stay non-sensitive. GitHub repo linking is closer to
+>   the wedge but belongs to a future GitHub App with incremental scopes when
+>   a concrete agent feature needs it. Phase C memory import covers "bring
+>   your context" with zero new scopes.
+> - Phase A (OAuth + entitlements endpoint) shipped and human-verified live:
+>   PRs #578 #579 #580 #581.
 **Owner:** Sam Xu
 **Companion:** ADR-011 (shell-first pre-GTM — this is the funnel half of that track), ADR-003 (memory envelope — migration target), ADR-005/006 (BYO attach paths), pricing model (humans are seats, agents never are)
 

--- a/frontend/src/v2/components/V2Register.tsx
+++ b/frontend/src/v2/components/V2Register.tsx
@@ -30,7 +30,7 @@ const V2Register: React.FC = () => {
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [invitationCode] = useState(searchParams.get('invite') || '');
+  const [invitationCode, setInvitationCode] = useState(searchParams.get('invite') || '');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState<string | null>(null);
@@ -153,6 +153,23 @@ const V2Register: React.FC = () => {
             required
           />
         </label>
+
+        {/* With open registration the code is optional — it unlocks hosted
+            (cloud) agents. Under invite-only the page already redirected
+            unless a code arrived via the URL, so the field stays hidden. */}
+        {policy.loaded && !policy.inviteOnly && (
+          <label className="v2-login__field">
+            <span className="v2-login__label">Invitation code (optional)</span>
+            <input
+              className="v2-login__input"
+              type="text"
+              autoComplete="off"
+              placeholder="Unlocks hosted agents — leave blank to bring your own"
+              value={invitationCode}
+              onChange={(e) => setInvitationCode(e.target.value)}
+            />
+          </label>
+        )}
 
         <button
           type="submit"

--- a/frontend/src/v2/components/V2YourTeamPage.tsx
+++ b/frontend/src/v2/components/V2YourTeamPage.tsx
@@ -75,11 +75,10 @@ const V2YourTeamPage: React.FC = () => {
   // flag we proxy on role==='admin' (see followups). Entitled users get the
   // cloud catalog as their primary hire path; everyone else is routed to the
   // BYO flow, which works for any account.
-  const isEntitled = useMemo(() => {
+  const entitledFromUser = useMemo(() => {
     const entitlements = (user as { entitlements?: { cloudAgents?: boolean } } | null)?.entitlements;
     return Boolean(entitlements?.cloudAgents) || user?.role === 'admin';
   }, [user]);
-  const primaryHirePath = isEntitled ? '/v2/agents/browse' : '/v2/agents/byo';
   const [agents, setAgents] = useState<AgentInstallationSummary[]>([]);
   const [pods, setPods] = useState<PodSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -91,6 +90,39 @@ const V2YourTeamPage: React.FC = () => {
   // Key (`name:instanceId`) of the agent whose 1:1 room is currently opening,
   // so its "Talk to" button can show progress and block a double-submit.
   const [opening, setOpening] = useState<string | null>(null);
+  // Invite-code redemption for BYO-tier users — a valid code flips the
+  // hosted-agent entitlement server-side (POST /api/auth/redeem-invitation).
+  // `redeemed` overrides isEntitled locally so the CTA updates without a
+  // full user-payload refetch.
+  const [redeemOpen, setRedeemOpen] = useState(false);
+  const [redeemCode, setRedeemCode] = useState('');
+  const [redeeming, setRedeeming] = useState(false);
+  const [redeemError, setRedeemError] = useState<string | null>(null);
+  const [redeemed, setRedeemed] = useState(false);
+  const isEntitled = entitledFromUser || redeemed;
+  const primaryHirePath = isEntitled ? '/v2/agents/browse' : '/v2/agents/byo';
+
+  const handleRedeem = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!redeemCode.trim() || redeeming) return;
+    setRedeeming(true);
+    setRedeemError(null);
+    try {
+      const token = localStorage.getItem('token');
+      await axios.post(
+        '/api/auth/redeem-invitation',
+        { invitationCode: redeemCode.trim() },
+        { headers: token ? { Authorization: `Bearer ${token}` } : undefined },
+      );
+      setRedeemed(true);
+      setRedeemOpen(false);
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      setRedeemError(msg || 'Could not redeem that code.');
+    } finally {
+      setRedeeming(false);
+    }
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -216,6 +248,43 @@ const V2YourTeamPage: React.FC = () => {
           </button>
         </div>
       </header>
+
+      {!isEntitled && (
+        <div className="v2-team__redeem">
+          {redeemOpen ? (
+            <form className="v2-team__redeem-form" onSubmit={handleRedeem}>
+              <input
+                className="v2-login__input"
+                type="text"
+                placeholder="Invitation code"
+                value={redeemCode}
+                onChange={(e) => setRedeemCode(e.target.value)}
+                autoFocus
+              />
+              <button type="submit" className="v2-team__hire-cta" disabled={redeeming || !redeemCode.trim()}>
+                {redeeming ? 'Unlocking…' : 'Unlock'}
+              </button>
+              <button type="button" className="v2-team__byo-cta" onClick={() => { setRedeemOpen(false); setRedeemError(null); }}>
+                Cancel
+              </button>
+              {redeemError && <span className="v2-team__redeem-error">{redeemError}</span>}
+            </form>
+          ) : (
+            <span>
+              Hosted agents are invite-gated during beta.
+              {' '}
+              <button type="button" className="v2-team__redeem-link" onClick={() => setRedeemOpen(true)}>
+                Have an invitation code?
+              </button>
+            </span>
+          )}
+        </div>
+      )}
+      {redeemed && (
+        <div className="v2-team__redeem v2-team__redeem--success">
+          Hosted agents unlocked — hire your first one from the catalog.
+        </div>
+      )}
 
       {error && (
         <div className="v2-team__error">{error}</div>

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4490,6 +4490,49 @@
   margin-bottom: 20px;
 }
 
+/* Invite-code redemption strip — shown to BYO-tier users; a valid code
+   unlocks hosted agents (entitlements.cloudAgents). */
+.v2-team__redeem {
+  padding: 10px 14px;
+  background: var(--v2-bg-subtle);
+  border: 1px solid var(--v2-border);
+  border-radius: 8px;
+  font-size: 13px;
+  color: var(--v2-text-secondary);
+  margin-bottom: 20px;
+}
+
+.v2-team__redeem--success {
+  background: #f0f9f1;
+  border-color: #c4e6c9;
+  color: #1e6b2a;
+}
+
+.v2-root button.v2-team__redeem-link {
+  color: var(--v2-accent);
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: underline;
+  background: none;
+  padding: 0;
+}
+
+.v2-team__redeem-form {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.v2-team__redeem-form .v2-login__input {
+  max-width: 240px;
+}
+
+.v2-team__redeem-error {
+  color: var(--v2-danger);
+  font-size: 12px;
+}
+
 .v2-team__empty {
   border: 1px dashed #d9dce3;
   border-radius: 12px;

--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -27,7 +27,10 @@ backend:
       effect: "NoSchedule"
   env:
     nodeEnv: development
-    registrationInviteOnly: "1"
+    # Registration opened 2026-07-03 — the invitation code now gates the
+    # hosted-agent entitlement (redeemed at signup or later), not signup
+    # itself. BYO/local agents are open to every account.
+    registrationInviteOnly: "0"
     agentProvisionerK8s: "1"
     agentProvisionerDocker: "0"
     agentProvisionerNodePool: "dev"


### PR DESCRIPTION
Implements the 2026-07-03 plan revision (Sam's call): **registration opens; the invitation code is repurposed as the hosted-agent entitlement grant.** BYO/local agents stay open to everyone; cloud compute stays invite-gated during beta.

## Semantics

| Scenario | Before | After |
|---|---|---|
| Signup, no code | Blocked (invite-only) | Account created, BYO-only |
| Signup, valid code | Account created | Account created **+ `cloudAgents: true`** |
| Signup, invalid code | Blocked | 403 `INVITATION_INVALID` (loud failure — user expected cloud access) |
| Existing BYO account gets a code | — | `POST /api/auth/redeem-invitation` flips the entitlement (no code burn if already entitled) |
| OAuth signup | Gate enforced | Same new semantics — code rides through `/start` |

`REGISTRATION_INVITE_ONLY=1` still behaves as a full signup gate for instances that want it; dev values flip it to `0`.

## UX

- **V2Register**: optional "Invitation code" field (only when registration is open) — "Unlocks hosted agents — leave blank to bring your own".
- **V2YourTeamPage**: "Hosted agents are invite-gated during beta. *Have an invitation code?*" strip for BYO-tier users → inline redeem form → success flips the hire CTA to the cloud catalog.

## Tests / proof

- New `invitationEntitlement` suite (8 tests: signup grant env+DB, no-code BYO default, loud invalid failure, invite-only regression, redeem grant/invalid/no-burn) + 2 OAuth-grant cases. 43 auth-related backend tests green; frontend 189 green.
- Browser-verified (MCP Playwright vs stubbed API): register field renders, full redeem interaction strip → form → unlock → success state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9