### PR TITLE
feat(onboarding): scripted starter workspace + fix latent Task sourceRef index

### DIFF
--- a/backend/__tests__/unit/controllers/invitationEntitlement.test.js
+++ b/backend/__tests__/unit/controllers/invitationEntitlement.test.js
@@ -1,5 +1,7 @@
 const User = require('../../../models/User');
 const InvitationCode = require('../../../models/InvitationCode');
+const Pod = require('../../../models/Pod');
+const Task = require('../../../models/Task');
 const authController = require('../../../controllers/authController');
 const {
   setupMongoDb,
@@ -112,6 +114,23 @@ describe('Invitation → cloudAgents entitlement', () => {
       expect(res.status).toHaveBeenCalledWith(403);
       expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVITATION_INVALID' }));
       expect(await User.countDocuments({ email: 'newbie@example.com' })).toBe(0);
+    });
+
+    it('seeds the starter workspace: default pod + 3 onboarding checklist tasks', async () => {
+      const res = mockRes();
+
+      await authController.register(registerReq(), res);
+
+      const user = await User.findOne({ email: 'newbie@example.com' });
+      const pod = await Pod.findOne({ createdBy: user._id });
+      expect(pod).toBeTruthy();
+      expect(pod.name).toBe('My Workspace');
+
+      const tasks = await Task.find({ podId: pod._id }).sort({ taskNum: 1 });
+      expect(tasks).toHaveLength(3);
+      expect(tasks.map((t) => t.taskId)).toEqual(['TASK-001', 'TASK-002', 'TASK-003']);
+      expect(tasks[0].title).toMatch(/connect your first agent/i);
+      expect(tasks.every((t) => t.source === 'onboarding' && t.status === 'pending')).toBe(true);
     });
 
     it('still gates signup when invite-only mode is on', async () => {

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -69,7 +69,7 @@ const isValidEmail = (email: any) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 // registration and the OAuth signup path (oauthController).
 const createDefaultWorkspacePod = async (userId: any) => {
   try {
-    await Pod.create({
+    const pod = await Pod.create({
       name: 'My Workspace',
       description: 'Your private workspace',
       type: 'chat',
@@ -77,6 +77,47 @@ const createDefaultWorkspacePod = async (userId: any) => {
       createdBy: userId,
       members: [userId],
     });
+
+    // Starter checklist — scripted onboarding on the real task board (no
+    // dedicated checklist UI to maintain). Matches tasksApi's TASK-###
+    // numbering so later tasks continue the sequence. Best-effort, same as
+    // the pod itself.
+    try {
+      // eslint-disable-next-line global-require
+      const Task = require('../models/Task');
+      const starter = [
+        {
+          sourceRef: 'onboarding:connect-agent',
+          title: 'Connect your first agent',
+          notes: 'Bring Claude Code, Cursor, or Codex: Agents → "Connect your own agent" generates a token your local agent uses to join this workspace. Takes about two minutes.',
+        },
+        {
+          sourceRef: 'onboarding:first-task',
+          title: 'Give your agent its first task',
+          notes: '@mention it in this pod chat and ask for something real — agents here read context, do the work, and post results back.',
+        },
+        {
+          sourceRef: 'onboarding:invite-teammate',
+          title: 'Invite a teammate',
+          notes: 'Workspaces are better shared — humans and agents in the same room, one project memory. Use the pod invite link from the inspector panel.',
+        },
+      ];
+      // Distinct sourceRefs give each seed a stable identity under the
+      // unique (podId, sourceRef) partial index — re-running the seeding
+      // for a pod can never silently duplicate the checklist.
+      await Task.create(starter.map((t, i) => ({
+        podId: pod._id,
+        taskNum: i + 1,
+        taskId: `TASK-${String(i + 1).padStart(3, '0')}`,
+        title: t.title,
+        notes: t.notes,
+        source: 'onboarding',
+        sourceRef: t.sourceRef,
+        updates: [],
+      })));
+    } catch (taskError: any) {
+      console.warn('[register] starter checklist seeding failed:', taskError?.message);
+    }
   } catch (podError: any) {
     console.warn('[register] default workspace pod creation failed:', podError?.message);
   }

--- a/backend/models/Task.ts
+++ b/backend/models/Task.ts
@@ -72,7 +72,20 @@ const TaskSchema = new Schema<ITask>(
 TaskSchema.index({ podId: 1, status: 1 });
 TaskSchema.index({ podId: 1, assignee: 1, status: 1 });
 TaskSchema.index({ podId: 1, taskId: 1 }, { unique: true });
-TaskSchema.index({ podId: 1, sourceRef: 1 }, { unique: true, sparse: true });
+// Partial, NOT sparse: a compound sparse index still indexes any doc where
+// podId is present (i.e. all of them), so the second no-sourceRef task in a
+// pod would E11000. The live DB was already repaired to this exact partial
+// index (name included) — this declaration matches it so boot-time
+// autoIndex neither conflicts nor recreates the broken sparse variant on
+// fresh installs.
+TaskSchema.index(
+  { podId: 1, sourceRef: 1 },
+  {
+    unique: true,
+    name: 'podId_1_sourceRef_1_partial',
+    partialFilterExpression: { sourceRef: { $type: 'string' } },
+  },
+);
 
 export const Task: Model<ITask> = mongoose.model<ITask>('Task', TaskSchema);
 

--- a/frontend/src/v2/__tests__/V2PodChatStarter.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatStarter.test.tsx
@@ -1,0 +1,90 @@
+// @ts-nocheck
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2PodChat from '../components/V2PodChat';
+import { AuthContext } from '../../context/AuthContext';
+
+// SocketContext exports only the provider + hook (no raw context object),
+// so mock the hook rather than wrapping a provider that would try to
+// open a real socket.
+jest.mock('../../context/SocketContext', () => ({
+  useSocket: () => ({ socket: null, connected: false }),
+}));
+
+// jsdom has no scrollIntoView; the component auto-scrolls on mount.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+// Same mock surface as V2Login.test.tsx — axiosConfig assigns
+// axios.defaults.baseURL at import time.
+jest.mock('axios', () => {
+  const mock = {
+    get: jest.fn(() => Promise.resolve({ data: {} })),
+    post: jest.fn(() => Promise.resolve({ data: {} })),
+    patch: jest.fn(),
+    delete: jest.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  };
+  return { __esModule: true, default: mock, ...mock };
+});
+
+const authValue = {
+  currentUser: { _id: 'u1', username: 'solo-user' },
+  user: { _id: 'u1', username: 'solo-user' },
+  token: 't',
+  loading: false,
+  error: null,
+  isAuthenticated: true,
+  register: jest.fn(),
+  login: jest.fn(),
+  logout: jest.fn(),
+  updateProfile: jest.fn(),
+};
+
+const makeDetail = (overrides = {}) => ({
+  pod: { _id: 'p1', name: 'My Workspace', type: 'chat' },
+  members: [{ _id: 'u1', username: 'solo-user', isBot: false }],
+  messages: [],
+  agents: [],
+  sendMessage: jest.fn(),
+  loading: false,
+  error: null,
+  refresh: jest.fn(),
+  ...overrides,
+});
+
+const renderChat = (detail) => render(
+  <AuthContext.Provider value={authValue}>
+    <MemoryRouter>
+      <V2PodChat detail={detail} />
+    </MemoryRouter>
+  </AuthContext.Provider>,
+);
+
+describe('V2PodChat starter workspace empty state', () => {
+  test('solo empty pod shows the getting-started onboarding', () => {
+    renderChat(makeDetail());
+
+    expect(screen.getByText(/welcome to your workspace/i)).toBeInTheDocument();
+    expect(screen.getByText(/connect your agent \(claude code, cursor, codex\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/browse agents & apps/i)).toBeInTheDocument();
+  });
+
+  test('multi-member pod keeps the generic empty state', () => {
+    renderChat(makeDetail({
+      members: [
+        { _id: 'u1', username: 'solo-user', isBot: false },
+        { _id: 'u2', username: 'teammate', isBot: false },
+      ],
+    }));
+
+    expect(screen.getByText(/talk to your team/i)).toBeInTheDocument();
+    expect(screen.queryByText(/welcome to your workspace/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -754,6 +754,39 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
                       <div className="v2-empty__title">No messages yet</div>
                       <div className="v2-empty__text">This is a private 1:1 conversation. Say hello to get started.</div>
                     </>
+                  ) : (members || []).length <= 1 && botMembers.length === 0 ? (
+                    // Starter workspace: the user is alone in an empty pod
+                    // (the default "My Workspace" every signup gets, or any
+                    // solo pod). Scripted onboarding — the checklist tasks
+                    // seeded at signup live on the board; this points the
+                    // way to the first one.
+                    <>
+                      <div className="v2-empty__title">Welcome to your workspace</div>
+                      <div className="v2-empty__text">
+                        This is where you and your agents work together. Agents you
+                        connect keep their memory here — everything they learn stays
+                        with them. Start with the checklist on your task board, or
+                        jump straight in:
+                      </div>
+                      <div className="v2-empty__chips" role="list">
+                        <button
+                          type="button"
+                          role="listitem"
+                          className="v2-empty__chip"
+                          onClick={() => navigate('/v2/agents/byo')}
+                        >
+                          Connect your agent (Claude Code, Cursor, Codex)
+                        </button>
+                        <button
+                          type="button"
+                          role="listitem"
+                          className="v2-empty__chip"
+                          onClick={() => navigate('/v2/marketplace')}
+                        >
+                          Browse agents &amp; apps
+                        </button>
+                      </div>
+                    </>
                   ) : (
                     <>
                       <div className="v2-empty__title">Talk to your team</div>


### PR DESCRIPTION
The no-LLM aha moment from the revised retention plan: every new signup's **My Workspace** now arrives populated instead of dead.

- **Starter checklist on the real task board** (seeded at signup, best-effort like the pod itself): *Connect your first agent* / *Give your agent its first task* / *Invite a teammate* — `source: 'onboarding'`, stable `sourceRef`s so re-seeding can never duplicate.
- **Getting-started empty state** in pod chat for solo pods: welcome copy framing the memory wedge ("agents you connect keep their memory here") + CTA chips into `/v2/agents/byo` and the marketplace. Multi-member pods, agent rooms, and DMs keep their existing empty states.

## Latent bug fixed along the way

Seeding tripped a pre-existing index bug: `Task` schema declares `{ podId, sourceRef }` unique+**sparse**, but compound sparse indexes still index docs where *any* field is present (`podId` always is) — so a pod's second no-`sourceRef` task E11000s. The live DB had already been hand-repaired to a partial index (`podId_1_sourceRef_1_partial`); the schema now declares exactly that index (name included), so fresh installs stop inheriting the broken variant and boot-time autoIndex stops conflicting. Same sparse-null trap as the OAuth `exchangeCode` fix (#581) — two instances of this class in one codebase, both now on partial indexes.

## Tests

- `invitationEntitlement` suite: signup seeds pod + TASK-001..003 with correct source/status.
- New `V2PodChatStarter` component tests: solo pod → onboarding state; multi-member pod → generic state.
- Backend auth suites 44 green; frontend 191 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9