### PR TITLE
fix(landing): re-arm scroll-reveal observer after the stats block mounts

### DIFF
--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -95,9 +95,15 @@ const V2LandingPage: React.FC = () => {
     setMotion(true);
   }, []);
 
+  // `stats` is a dependency on purpose: when /api/stats/public resolves, the
+  // conditionally-rendered stats block shifts <main>'s child list and React
+  // remounts every section AFTER it (index-based reconciliation) — fresh DOM
+  // nodes the previous observer never saw, which would stay at opacity 0
+  // forever. Re-arming re-queries the current nodes; already-revealed ones
+  // keep their class and are skipped.
   useEffect(() => {
     if (!motion) return undefined;
-    const nodes = Array.from(document.querySelectorAll('.v2-landing [data-reveal]'));
+    const nodes = Array.from(document.querySelectorAll('.v2-landing [data-reveal]:not(.is-revealed)'));
     const io = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
@@ -108,7 +114,7 @@ const V2LandingPage: React.FC = () => {
     }, { rootMargin: '0px 0px -8% 0px', threshold: 0.08 });
     nodes.forEach((n) => io.observe(n));
     return () => io.disconnect();
-  }, [motion]);
+  }, [motion, stats]);
 
   const hasStats = Boolean(stats && (stats.activePods || stats.activeAgents || stats.registeredUsers));
 


### PR DESCRIPTION
Live verification of #585 on commonly.me caught 4 reveal targets permanently stuck at opacity 0 — everything **after** the self-proof section. Root cause: when `/api/stats/public` resolves, the conditionally-rendered stats block shifts `<main>`'s child list, and React's index-based reconciliation remounts every following section — fresh DOM nodes the already-armed IntersectionObserver never observed. The local stub returned empty stats, so the insertion (and the bug) never reproduced until live.

Fix: the observer effect depends on `stats` and re-queries `[data-reveal]:not(.is-revealed)` when it lands. Reproduced the live condition locally with a stats-returning stub: 18/18 targets reveal, 0 hidden.

Testing lesson banked: stubs must reproduce the *data conditions* of production, not just the endpoints — an empty-object stub hid a remount-order bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9