### PR TITLE
feat(landing): word-level entrance on the hero H1 and wedge thesis line

### DIFF
--- a/frontend/design-system/README.md
+++ b/frontend/design-system/README.md
@@ -135,6 +135,11 @@ entrance and scroll-reveal animation is allowed within these limits:
 - Opacity + `translateY` ≤ 16px only. No scale, no rotation, no parallax.
 - ≤ 560ms, `ease-out`, runs **once** (reveal, then inert — no loops).
 - Stagger ≤ 5 steps at ≤ 80ms apart.
+- **Word-level stagger is allowed on at most the hero H1 and the wedge
+  thesis line** — ≤ 40ms per word, full settle under ~900ms, words only
+  (never per-character, never body copy), `aria-hidden` words with the
+  full sentence on the parent's `aria-label`. Typewriter, shimmer, and
+  gradient text effects stay banned.
 - Still no bounces or springs.
 - `prefers-reduced-motion: reduce` disables all of it, and the hidden
   pre-reveal state must only exist when JS has confirmed motion is safe

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -59,8 +59,13 @@ describe('V2 routing', () => {
   test('index route shows the public landing when not authenticated', async () => {
     renderAt('/v2');
     // V2Home sends logged-out visitors to /v2/landing (the public front door),
-    // not the login wall.
-    expect(await screen.findByText(/the open-source workspace where your agents/i)).toBeInTheDocument();
+    // not the login wall. The hero H1 is word-split for the entrance stagger,
+    // so match on the heading's accessible name (the aria-label carries the
+    // full sentence) — this also pins the screen-reader contract.
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: /the open-source workspace where your agents/i,
+    })).toBeInTheDocument();
   });
 
   test('deep protected route redirects to login when not authenticated', () => {

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -46,6 +46,27 @@ interface Stats {
 
 const fmt = (n?: number): string => (typeof n === 'number' ? n.toLocaleString() : '—');
 
+// Word-level entrance for the two highest-persuasion lines (hero H1, wedge
+// thesis). Each word rises once with a small per-word delay — see the
+// marketing-motion carve-out in frontend/design-system/README.md. Words are
+// aria-hidden with the full sentence on the parent's aria-label so screen
+// readers get one sentence, not fragments; the text stays in the DOM for SEO.
+const StaggerWords: React.FC<{ text: string }> = ({ text }) => (
+  <>
+    {text.split(' ').map((word, i) => (
+      // The joining space lives OUTSIDE the span: trailing whitespace inside
+      // an inline-block is trimmed at layout, which glues the words together.
+      // eslint-disable-next-line react/no-array-index-key
+      <React.Fragment key={`${word}-${i}`}>
+        <span className="v2-landing__word" style={{ '--word-i': i } as React.CSSProperties} aria-hidden="true">
+          {word}
+        </span>
+        {' '}
+      </React.Fragment>
+    ))}
+  </>
+);
+
 // A framed product screenshot — browser chrome + the one allowed soft shadow
 // (marketing surface). Captions carry the message; the image proves it.
 const Shot: React.FC<{ src: string; alt: string; caption: string; wide?: boolean }> = ({ src, alt, caption, wide }) => (
@@ -146,8 +167,8 @@ const V2LandingPage: React.FC = () => {
         <section className="v2-landing__hero">
           <div className="v2-landing__hero-inner">
             <div className="v2-landing__eyebrow">Open-source · the open alternative to Raft</div>
-            <h1 className="v2-landing__title">
-              The open-source workspace where your agents and team share one memory.
+            <h1 className="v2-landing__title" aria-label="The open-source workspace where your agents and team share one memory.">
+              <StaggerWords text="The open-source workspace where your agents and team share one memory." />
             </h1>
             <p className="v2-landing__lede">
               Your AI tools each keep their own context — so you end up carrying it between them. Commonly
@@ -193,7 +214,9 @@ const V2LandingPage: React.FC = () => {
 
         {/* ---- Wedge band ---- */}
         <section className="v2-landing__wedge">
-          <p className="v2-landing__wedge-line" data-reveal>One project memory shared by all your AI tools.</p>
+          <p className="v2-landing__wedge-line" data-reveal aria-label="One project memory shared by all your AI tools.">
+            <StaggerWords text="One project memory shared by all your AI tools." />
+          </p>
           <p className="v2-landing__wedge-sub" data-reveal>
             &ldquo;I am the router.&rdquo; &ldquo;I&apos;m human middleware.&rdquo; &ldquo;The agent forgot my
             codebase.&rdquo; — the tax you pay for tools that each remember alone.

--- a/frontend/src/v2/landing/v2-landing.css
+++ b/frontend/src/v2/landing/v2-landing.css
@@ -821,3 +821,38 @@
     transform: translateY(14px);
   }
 }
+
+/* Word-level entrance — hero H1 + wedge thesis line only (see the
+   marketing-motion carve-out in the design-system README). Words are
+   inline-block so translateY applies; --word-i comes from StaggerWords. */
+.v2-landing__word {
+  display: inline-block;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  /* Hero: word cascade replaces the block-level rise on the title (the
+     two would compound). Load-time keyframes, once, backwards-fill. */
+  .v2-landing__hero-inner > .v2-landing__title {
+    animation: none;
+  }
+
+  .v2-landing__hero-inner .v2-landing__word {
+    animation: v2-landing-rise 380ms ease-out backwards;
+    animation-delay: calc(120ms + var(--word-i, 0) * 28ms);
+  }
+}
+
+/* Wedge line: words cascade when the block's scroll-reveal fires. Hidden
+   state only under .v2-landing--motion (same JS-confirmed gate as all
+   reveals — no-JS and reduced-motion get static text). */
+.v2-landing--motion .v2-landing__wedge-line .v2-landing__word {
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 360ms ease-out, transform 360ms ease-out;
+  transition-delay: calc(var(--word-i, 0) * 30ms);
+}
+
+.v2-landing--motion .v2-landing__wedge-line.is-revealed .v2-landing__word {
+  opacity: 1;
+  transform: none;
+}


### PR DESCRIPTION
Follow-up to #585/#586 answering "is text-level animation worth it": yes, in exactly two places — the hero H1 and the wedge thesis line, the two lines doing the page's persuasive work. Everything else stays block-level.

- **Hero**: per-word rise on load (380ms ease-out, 28ms/word — settles ~780ms; replaces the title's block-level rise so the two don't compound).
- **Wedge line**: words cascade when its scroll-reveal fires (360ms, 30ms/word), same JS-confirmed motion gate as all reveals.
- **A11y contract**: words are `aria-hidden` spans, the parent carries the full sentence via `aria-label` — the routing test now matches the heading's accessible name, pinning this.
- **Rejected on brand grounds** (documented in the README carve-out): per-character stagger, typewriter, shimmer/gradient text, body-copy animation.
- **Bug caught by the screenshot check**: trailing whitespace inside an inline-block is trimmed at layout, so the first cut rendered "Theopen-source workspacewhereyour…" — joining spaces now live outside the spans.

Frontend suite: 191 green. Browser-verified spacing, cascade timings, and reduced-motion/no-JS fallbacks (static fully-visible text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9