### PR TITLE
feat(landing): rotating-term hero + decrowd + slower motion

### DIFF
--- a/frontend/design-system/README.md
+++ b/frontend/design-system/README.md
@@ -136,10 +136,16 @@ entrance and scroll-reveal animation is allowed within these limits:
 - ≤ 560ms, `ease-out`, runs **once** (reveal, then inert — no loops).
 - Stagger ≤ 5 steps at ≤ 80ms apart.
 - **Word-level stagger is allowed on at most the hero H1 and the wedge
-  thesis line** — ≤ 40ms per word, full settle under ~900ms, words only
+  thesis line** — ≤ 60ms per word, full settle under ~900ms, words only
   (never per-character, never body copy), `aria-hidden` words with the
   full sentence on the parent's `aria-label`. Typewriter, shimmer, and
   gradient text effects stay banned.
+- **One rotating-term slot, hero only.** The single exception to
+  "runs once": the hero H1 may rotate one term (the "all your AI tools"
+  enumeration) at a cadence ≥ 2.5s with a ≤ 500ms rise transition, in the
+  accent color. Grid-stacked so the line never reflows; reduced-motion and
+  no-JS get a static term that reads correctly alone. Never a second
+  rotating element anywhere.
 - Still no bounces or springs.
 - `prefers-reduced-motion: reduce` disables all of it, and the hidden
   pre-reveal state must only exist when JS has confirmed motion is safe

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -64,7 +64,7 @@ describe('V2 routing', () => {
     // full sentence) — this also pins the screen-reader contract.
     expect(await screen.findByRole('heading', {
       level: 1,
-      name: /the open-source workspace where your agents/i,
+      name: /one memory for claude code, cursor, codex/i,
     })).toBeInTheDocument();
   });
 

--- a/frontend/src/v2/landing/V2ComparePage.tsx
+++ b/frontend/src/v2/landing/V2ComparePage.tsx
@@ -48,7 +48,7 @@ const V2ComparePage: React.FC = () => {
   // Signed-out visitors get routed to /v2/register (invite-code + waitlist),
   // not the /v2/login dead-end. Returning users use the "Sign in" nav link.
   const appHref = isAuthenticated ? '/v2' : '/v2/register';
-  const primaryLabel = isAuthenticated ? 'Open the app' : 'Request access';
+  const primaryLabel = isAuthenticated ? 'Open the app' : 'Get started';
   return (
   <div className="v2-root v2-landing">
     <header className="v2-landing__bar">

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -130,13 +130,14 @@ const V2LandingPage: React.FC = () => {
   // reduced-motion users always get fully visible content.
   const [motion, setMotion] = useState(false);
 
-  // Primary CTA: signed-in → the shell; signed-out → /v2/register, which under
-  // invite-only lands on the invite-code + waitlist form so a brand-new visitor
-  // can actually request access. (Previously every CTA pointed at /v2/login — a
-  // dead end for someone who has no account yet. Returning users still have the
-  // dedicated "Sign in" nav link below.)
+  // Primary CTA: signed-in → the shell; signed-out → /v2/register. Since
+  // registration opened (2026-07-03: invite codes gate cloud agents, not
+  // signup) the label is "Get started", not "Request access" — the old copy
+  // told visitors the door was locked when it isn't. If the instance ever
+  // re-enables invite-only, the register page's policy check still routes to
+  // the invite-required form automatically.
   const appHref = isAuthenticated ? '/v2' : '/v2/register';
-  const primaryLabel = isAuthenticated ? 'Open the app' : 'Request access';
+  const primaryLabel = isAuthenticated ? 'Open the app' : 'Get started';
 
   useEffect(() => {
     let cancelled = false;
@@ -209,8 +210,8 @@ const V2LandingPage: React.FC = () => {
               <RotatingTerm />
             </h1>
             <p className="v2-landing__lede">
-              Agents and teammates work from one shared project memory — any runtime,
-              your infra, no per-agent fees.
+              The open-source workspace where agents and teammates share one project
+              memory — any runtime, your infra, no per-agent fees.
             </p>
 
             <div className="v2-landing__cta-row">

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -46,6 +46,42 @@ interface Stats {
 
 const fmt = (n?: number): string => (typeof n === 'number' ? n.toLocaleString() : '—');
 
+// The rotating hero term — enumerates "all your AI tools" instead of
+// asserting it. Grid-stacks every term in one cell (the slot sizes to the
+// widest term, so the line never reflows), slides the active one up on a
+// calm 2.6s cadence. Reduced-motion / no-JS visitors get the static last
+// term ("your whole team"), which reads correctly on its own.
+const ROTATING_TERMS = ['Claude Code', 'Cursor', 'Codex', 'your whole team'];
+
+const RotatingTerm: React.FC = () => {
+  const [active, setActive] = useState(0);
+  const [rotating, setRotating] = useState(false);
+
+  useEffect(() => {
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches) return undefined;
+    setRotating(true);
+    const t = setInterval(() => {
+      setActive((i) => (i + 1) % ROTATING_TERMS.length);
+    }, 2600);
+    return () => clearInterval(t);
+  }, []);
+
+  // Static fallback shows the closing term — the sentence must stand alone.
+  const staticIndex = ROTATING_TERMS.length - 1;
+  return (
+    <span className="v2-landing__rotator" aria-hidden="true">
+      {ROTATING_TERMS.map((term, i) => (
+        <span
+          key={term}
+          className={`v2-landing__rotator-term${(rotating ? i === active : i === staticIndex) ? ' v2-landing__rotator-term--active' : ''}`}
+        >
+          {term}
+        </span>
+      ))}
+    </span>
+  );
+};
+
 // Word-level entrance for the two highest-persuasion lines (hero H1, wedge
 // thesis). Each word rises once with a small per-word delay — see the
 // marketing-motion carve-out in frontend/design-system/README.md. Words are
@@ -166,31 +202,20 @@ const V2LandingPage: React.FC = () => {
         {/* ---- Hero ---- */}
         <section className="v2-landing__hero">
           <div className="v2-landing__hero-inner">
-            <div className="v2-landing__eyebrow">Open-source · the open alternative to Raft</div>
-            <h1 className="v2-landing__title" aria-label="The open-source workspace where your agents and team share one memory.">
-              <StaggerWords text="The open-source workspace where your agents and team share one memory." />
+            <div className="v2-landing__eyebrow">Open-source · Apache 2.0</div>
+            <h1 className="v2-landing__title" aria-label="One memory for Claude Code, Cursor, Codex — your whole team.">
+              <StaggerWords text="One memory for" />
+              <br />
+              <RotatingTerm />
             </h1>
             <p className="v2-landing__lede">
-              Your AI tools each keep their own context — so you end up carrying it between them. Commonly
-              gives every agent and teammate one shared memory and identity to work from. Any runtime, your
-              infra. Self-host in <code className="v2-landing__inline-code">docker compose up</code> — no
-              per-agent fees, no lock-in.
+              Agents and teammates work from one shared project memory — any runtime,
+              your infra, no per-agent fees.
             </p>
-
-            <div className="v2-landing__badges">
-              <span className="v2-landing__badge"><LockOpenOutlinedIcon fontSize="inherit" /> Open-source (Apache 2.0)</span>
-              <span className="v2-landing__badge"><DnsOutlinedIcon fontSize="inherit" /> Self-host in one command</span>
-              <span className="v2-landing__badge"><HubOutlinedIcon fontSize="inherit" /> Any runtime</span>
-              <span className="v2-landing__badge"><PaymentsOutlinedIcon fontSize="inherit" /> No per-agent fees</span>
-            </div>
 
             <div className="v2-landing__cta-row">
               <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>{primaryLabel}</Link>
               <Link className="v2-landing__btn v2-landing__btn--ghost" to="/v2/showcase">Watch a live room</Link>
-              <a className="v2-landing__btn v2-landing__btn--ghost" href={REPO} target="_blank" rel="noreferrer">
-                <span className="v2-landing__btn-mark"><Mark size={18} /></span>
-                Star on GitHub
-              </a>
             </div>
 
             <div className="v2-landing__install" aria-label="Self-host install">
@@ -199,7 +224,7 @@ const V2LandingPage: React.FC = () => {
             </div>
 
             <div className="v2-landing__hero-by">
-              Built in the open by <a href={X_HANDLE} target="_blank" rel="noreferrer">@sam_commonly</a> · already in sign-in.
+              Built in the open by <a href={X_HANDLE} target="_blank" rel="noreferrer">@sam_commonly</a>
             </div>
           </div>
 

--- a/frontend/src/v2/landing/v2-landing.css
+++ b/frontend/src/v2/landing/v2-landing.css
@@ -752,7 +752,7 @@
 .v2-landing--motion [data-reveal]:not([data-reveal-stagger]) {
   opacity: 0;
   transform: translateY(14px);
-  transition: opacity 480ms ease-out, transform 480ms ease-out;
+  transition: opacity 640ms ease-out, transform 640ms ease-out;
 }
 
 .v2-landing--motion [data-reveal]:not([data-reveal-stagger]).is-revealed {
@@ -765,7 +765,7 @@
 .v2-landing--motion [data-reveal][data-reveal-stagger] > * {
   opacity: 0;
   transform: translateY(14px);
-  transition: opacity 480ms ease-out, transform 480ms ease-out;
+  transition: opacity 640ms ease-out, transform 640ms ease-out;
 }
 
 .v2-landing--motion [data-reveal][data-reveal-stagger].is-revealed > * {
@@ -773,11 +773,11 @@
   transform: none;
 }
 
-.v2-landing--motion [data-reveal-stagger].is-revealed > :nth-child(2) { transition-delay: 80ms; }
-.v2-landing--motion [data-reveal-stagger].is-revealed > :nth-child(3) { transition-delay: 160ms; }
-.v2-landing--motion [data-reveal-stagger].is-revealed > :nth-child(4) { transition-delay: 240ms; }
-.v2-landing--motion [data-reveal-stagger].is-revealed > :nth-child(5) { transition-delay: 320ms; }
-.v2-landing--motion [data-reveal-stagger].is-revealed > :nth-child(n+6) { transition-delay: 400ms; }
+.v2-landing--motion [data-reveal-stagger].is-revealed > :nth-child(2) { transition-delay: 110ms; }
+.v2-landing--motion [data-reveal-stagger].is-revealed > :nth-child(3) { transition-delay: 220ms; }
+.v2-landing--motion [data-reveal-stagger].is-revealed > :nth-child(4) { transition-delay: 330ms; }
+.v2-landing--motion [data-reveal-stagger].is-revealed > :nth-child(5) { transition-delay: 440ms; }
+.v2-landing--motion [data-reveal-stagger].is-revealed > :nth-child(n+6) { transition-delay: 550ms; }
 
 /* Hero entrance: pure CSS, runs once on load. Gated by the media
    query (not the JS class) so it also respects reduced motion when
@@ -837,8 +837,8 @@
   }
 
   .v2-landing__hero-inner .v2-landing__word {
-    animation: v2-landing-rise 380ms ease-out backwards;
-    animation-delay: calc(120ms + var(--word-i, 0) * 28ms);
+    animation: v2-landing-rise 560ms ease-out backwards;
+    animation-delay: calc(140ms + var(--word-i, 0) * 60ms);
   }
 }
 
@@ -848,11 +848,41 @@
 .v2-landing--motion .v2-landing__wedge-line .v2-landing__word {
   opacity: 0;
   transform: translateY(10px);
-  transition: opacity 360ms ease-out, transform 360ms ease-out;
-  transition-delay: calc(var(--word-i, 0) * 30ms);
+  transition: opacity 480ms ease-out, transform 480ms ease-out;
+  transition-delay: calc(var(--word-i, 0) * 45ms);
 }
 
 .v2-landing--motion .v2-landing__wedge-line.is-revealed .v2-landing__word {
   opacity: 1;
   transform: none;
+}
+
+/* Rotating hero term — the slot grid-stacks every term in one cell so it
+   sizes to the widest and the line never reflows; the active term rises in
+   at a calm 2.6s cadence (see the marketing-motion carve-out). Cobalt is
+   the page's one accent; the rotating term is the hero's one accent use. */
+.v2-landing__rotator {
+  display: inline-grid;
+  overflow: hidden;
+  vertical-align: bottom;
+  color: var(--v2-accent);
+  padding-bottom: 0.06em; /* keep descenders (y, p) out of the clip */
+}
+
+.v2-landing__rotator-term {
+  grid-area: 1 / 1;
+  opacity: 0;
+  transform: translateY(0.55em);
+  white-space: nowrap;
+}
+
+.v2-landing__rotator-term--active {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .v2-landing__rotator-term {
+    transition: opacity 450ms ease-out, transform 450ms ease-out;
+  }
 }


### PR DESCRIPTION
**Held for Sam's copy sign-off before merge** — this changes hero positioning copy.

Responds to design feedback (animation too fast; hero too crowded) with research backing: best-in-class dev-tool heroes run 4–8 word headlines with 1–2 CTAs (Raycast: "Your shortcut to everything." — 4 words, Linear: 8 words + one CTA). Ours was an 11-word H1 + 45-word lede + 4 badges + 3 CTAs + competitor-first eyebrow.

## Changes

- **H1**: "One memory for ⟨**Claude Code → Cursor → Codex → your whole team**⟩" — the rotating cobalt term *enumerates* the canonical wedge instead of asserting it. Grid-stacked slot (no line reflow across term widths), 2.6s cadence, 450ms rise. Reduced-motion / no-JS get the static closing term. The canonical wedge sentence is untouched in the band below.
- **Decrowd**: lede 45 → 19 words; badges 4 → 0; CTAs 3 → 2; Raft moves off the first line of the page (Compare stays in nav); byline fixed ("already in sign-in." removed).
- **Slower motion everywhere**: hero words 60ms/word @ 560ms; scroll reveals 640ms; stagger steps 110ms.
- **Spec**: marketing carve-out gains the one rotating-term exception (hero only, cadence ≥2.5s, never a second rotating element).

Frontend suite 191 green; browser-verified rotation, no-reflow, spacing, fallbacks. Screenshots in the session thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9