### PR TITLE
feat(memory): local memory import — your agent arrives whole (Phase C)

### DIFF
--- a/cli/__tests__/memory-import.test.mjs
+++ b/cli/__tests__/memory-import.test.mjs
@@ -1,0 +1,203 @@
+/**
+ * memory-import.js unit tests (ESM) — retention plan Phase C.
+ *
+ * Filesystem: real temp directories (detection walks the FS). The kernel
+ * client is a stub capturing calls.
+ */
+
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import {
+  detectMemorySources,
+  composeImport,
+  importMemory,
+  claudeProjectMemoryDir,
+  MAX_IMPORT_BYTES,
+  SOURCE_RUNTIME,
+} from '../src/lib/memory-import.js';
+import { runMemoryImport } from '../src/commands/agent.js';
+
+const tmp = (prefix) => fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+
+const makeProject = () => {
+  const cwd = tmp('mi-cwd-');
+  const home = tmp('mi-home-');
+  return { cwd, home };
+};
+
+const write = (dir, name, content) => {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), content, 'utf8');
+  return path.join(dir, name);
+};
+
+const stubClient = ({ existing = null, getError = null } = {}) => {
+  const calls = { get: [], post: [] };
+  return {
+    calls,
+    get: async (url) => {
+      calls.get.push(url);
+      if (getError) throw getError;
+      if (existing === null) {
+        const err = new Error('not found');
+        err.status = 404;
+        throw err;
+      }
+      return { sections: { long_term: { content: existing } } };
+    },
+    post: async (url, body) => {
+      calls.post.push({ url, body });
+      return {};
+    },
+  };
+};
+
+describe('detectMemorySources', () => {
+  test('finds project CLAUDE.md, MEMORY.md, and the ~/.claude auto-memory dir', () => {
+    const { cwd, home } = makeProject();
+    write(cwd, 'CLAUDE.md', '# instructions');
+    write(cwd, 'MEMORY.md', '# memory');
+    const memDir = claudeProjectMemoryDir(cwd, home);
+    write(memDir, 'MEMORY.md', '# index');
+    write(memDir, 'project-foo.md', '# foo');
+
+    const sources = detectMemorySources({ cwd, home });
+    expect(sources.map((s) => path.basename(s.path))).toEqual([
+      'CLAUDE.md', 'MEMORY.md', 'MEMORY.md', 'project-foo.md',
+    ]);
+  });
+
+  test('collapses symlink duplicates (AGENTS.md → CLAUDE.md)', () => {
+    const { cwd, home } = makeProject();
+    const claude = write(cwd, 'CLAUDE.md', '# instructions');
+    fs.symlinkSync(claude, path.join(cwd, 'AGENTS.md'));
+
+    const sources = detectMemorySources({ cwd, home });
+    expect(sources).toHaveLength(1);
+  });
+
+  test('skips empty files and returns [] when nothing exists', () => {
+    const { cwd, home } = makeProject();
+    write(cwd, 'CLAUDE.md', '');
+    expect(detectMemorySources({ cwd, home })).toEqual([]);
+  });
+
+  test('explicit file path wins; explicit dir takes all .md files', () => {
+    const { cwd, home } = makeProject();
+    write(cwd, 'CLAUDE.md', '# would be auto-detected');
+    const dir = tmp('mi-explicit-');
+    write(dir, 'b.md', 'bee');
+    write(dir, 'a.md', 'ay');
+    write(dir, 'notes.txt', 'ignored');
+
+    const single = detectMemorySources({ cwd, home, explicitPath: path.join(dir, 'a.md') });
+    expect(single).toHaveLength(1);
+
+    const all = detectMemorySources({ cwd, home, explicitPath: dir });
+    expect(all.map((s) => path.basename(s.path))).toEqual(['a.md', 'b.md']);
+  });
+
+  test('explicit path that does not exist throws', () => {
+    const { cwd, home } = makeProject();
+    expect(() => detectMemorySources({ cwd, home, explicitPath: '/no/such/file.md' })).toThrow(/No such file/);
+  });
+});
+
+describe('composeImport', () => {
+  test('joins sources with provenance headers', () => {
+    const { cwd } = makeProject();
+    const p = write(cwd, 'MEMORY.md', 'remember the milk');
+    const doc = composeImport([{ path: p, label: 'project memory', bytes: 17 }]);
+    expect(doc).toContain('# Imported local memory');
+    expect(doc).toContain('## Imported: MEMORY.md (project memory)');
+    expect(doc).toContain('remember the milk');
+  });
+
+  test('enforces the size ceiling', () => {
+    const { cwd } = makeProject();
+    const p = write(cwd, 'big.md', 'x');
+    expect(() => composeImport([{ path: p, label: 'big', bytes: MAX_IMPORT_BYTES + 1 }]))
+      .toThrow(/ceiling/);
+  });
+});
+
+describe('importMemory', () => {
+  const sourcesFor = (content = 'hello') => {
+    const { cwd } = makeProject();
+    const p = write(cwd, 'MEMORY.md', content);
+    return [{ path: p, label: 'project memory', bytes: content.length }];
+  };
+
+  test('fresh agent (404): sends the import as the whole long_term, patch mode', async () => {
+    const client = stubClient();
+    const result = await importMemory(client, { sources: sourcesFor() });
+
+    expect(result.appended).toBe(false);
+    expect(client.calls.post).toHaveLength(1);
+    const { url, body } = client.calls.post[0];
+    expect(url).toBe('/api/agents/runtime/memory/sync');
+    expect(body.mode).toBe('patch');
+    expect(body.sourceRuntime).toBe(SOURCE_RUNTIME);
+    expect(body.sections.long_term.visibility).toBe('private');
+    expect(body.sections.long_term.content).toMatch(/^# Imported local memory/);
+  });
+
+  test('existing memory: appends after it (patch replaces the whole section)', async () => {
+    const client = stubClient({ existing: '## Already learned\nthings' });
+    const result = await importMemory(client, { sources: sourcesFor() });
+
+    expect(result.appended).toBe(true);
+    const content = client.calls.post[0].body.sections.long_term.content;
+    expect(content.startsWith('## Already learned')).toBe(true);
+    expect(content).toContain('# Imported local memory');
+  });
+
+  test('a non-404 read failure aborts the import (no blind clobber)', async () => {
+    const err = new Error('backend down');
+    err.status = 500;
+    const client = stubClient({ getError: err });
+    await expect(importMemory(client, { sources: sourcesFor() })).rejects.toThrow('backend down');
+    expect(client.calls.post).toHaveLength(0);
+  });
+});
+
+describe('runMemoryImport (confirm flow)', () => {
+  test('declined prompt sends nothing', async () => {
+    const { cwd, home } = makeProject();
+    write(cwd, 'MEMORY.md', 'secret stuff');
+    const client = stubClient();
+
+    const result = await runMemoryImport({
+      client,
+      cwd,
+      log: () => {},
+      promptFn: async () => 'n',
+      // home isn't injectable through runMemoryImport; auto-detect also
+      // scans the real ~/.claude — harmless, cwd file suffices for this test.
+    });
+
+    expect(result.imported).toBe(false);
+    expect(result.reason).toBe('declined');
+    expect(client.calls.post).toHaveLength(0);
+  });
+
+  test('--yes imports without prompting', async () => {
+    const { cwd } = makeProject();
+    write(cwd, 'MEMORY.md', 'ship it');
+    const client = stubClient();
+
+    const result = await runMemoryImport({ client, cwd, yes: true, log: () => {} });
+
+    expect(result.imported).toBe(true);
+    expect(client.calls.post).toHaveLength(1);
+  });
+
+  test('nothing found is a clean no-op', async () => {
+    const { cwd } = makeProject();
+    const client = stubClient();
+    const result = await runMemoryImport({ client, cwd, yes: true, log: () => {} });
+    expect(result).toEqual({ imported: false, reason: 'nothing-found' });
+  });
+});

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -23,6 +23,7 @@ import { startWebhookServer, forwardToLocalWebhook } from '../lib/webhook-server
 import { getAdapter, listAdapterNames } from '../lib/adapters/index.js';
 import { getSession, setSession, clearSessions } from '../lib/session-store.js';
 import { readLongTerm, syncBack } from '../lib/memory-bridge.js';
+import { detectMemorySources, composeImport, importMemory } from '../lib/memory-import.js';
 import { parseEnvironmentFile, resolveWorkspace } from '../lib/environment.js';
 import { detectBwrap } from '../lib/sandbox/bwrap.js';
 
@@ -279,6 +280,68 @@ export const performAttach = async ({
     environment,
     workspace,
   };
+};
+
+// ── memory import (retention plan Phase C) ──────────────────────────────────
+
+/**
+ * Detect → preview → confirm → promote local memory into the agent's
+ * envelope. Interactive by design: local memory can hold private material,
+ * so nothing is sent without an explicit yes (or --yes for scripts; a
+ * non-TTY without --yes aborts rather than guessing).
+ *
+ * Exported for tests; the attach flag and the import-memory subcommand are
+ * both thin wrappers over this.
+ */
+export const runMemoryImport = async ({
+  client,
+  explicitPath = null,
+  yes = false,
+  cwd = process.cwd(),
+  log = console.log,
+  promptFn = null,
+}) => {
+  const sources = detectMemorySources({ cwd, explicitPath });
+  if (!sources.length) {
+    log('No local memory found (looked for CLAUDE.md / MEMORY.md / ~/.claude project memory). Pass a path to import a specific file.');
+    return { imported: false, reason: 'nothing-found' };
+  }
+
+  const totalKb = Math.max(1, Math.round(sources.reduce((n, s) => n + s.bytes, 0) / 1024));
+  log(`Found ${sources.length} memory source${sources.length === 1 ? '' : 's'} (${totalKb}KB):`);
+  for (const s of sources) {
+    log(`  ${s.path}  [${s.label}, ${Math.max(1, Math.round(s.bytes / 1024))}KB]`);
+  }
+  // Compose up-front so size-ceiling errors surface before the prompt, and
+  // the preview shows exactly what would land in the envelope.
+  const composed = composeImport(sources);
+  const previewLines = composed.split('\n').slice(0, 8);
+  log('\nPreview:');
+  for (const line of previewLines) log(`  | ${line}`);
+  log(`  | … (${composed.length} chars total)\n`);
+
+  if (!yes) {
+    if (!process.stdin.isTTY && !promptFn) {
+      log('Not a terminal — re-run with --yes to confirm the import.');
+      return { imported: false, reason: 'needs-confirmation' };
+    }
+    const ask = promptFn || (async (q) => {
+      const { createInterface } = await import('readline/promises');
+      const rl = createInterface({ input: process.stdin, output: process.stdout });
+      const answer = await rl.question(q);
+      rl.close();
+      return answer;
+    });
+    const answer = await ask('Import into this agent\'s memory? Appends to long_term; never overwrites. [y/N] ');
+    if (!/^y(es)?$/i.test(String(answer).trim())) {
+      log('Import cancelled.');
+      return { imported: false, reason: 'declined' };
+    }
+  }
+
+  const result = await importMemory(client, { sources });
+  log(`✓ Imported ${result.files} file${result.files === 1 ? '' : 's'} into long_term memory${result.appended ? ' (appended to existing)' : ''}.`);
+  return { imported: true, ...result };
 };
 
 // ── run: local-CLI wrapper loop (ADR-005) ────────────────────────────────────
@@ -783,6 +846,8 @@ Docs:
     .requiredOption('--name <name>', 'Agent name (e.g. my-claude)')
     .option('--display <name>', 'Display name shown in the pod')
     .option('--env <path>', 'Path to environment.json (ADR-008 — sandbox/skills/MCP)')
+    .option('--import-memory [path]', 'Import local memory (CLAUDE.md / MEMORY.md / ~/.claude project memory, or a given file/dir) into the agent after attach')
+    .option('--yes', 'Skip the import confirmation prompt')
     .option('--instance <url>', 'Target Commonly instance')
     .action(async (adapterName, opts) => {
       const instanceUrl = resolveInstanceUrl(opts.instance);
@@ -825,9 +890,53 @@ Docs:
         if (workspace) {
           console.log(`✓ Workspace: ${workspace.path}${workspace.created ? ' (created)' : ''}`);
         }
+
+        // Retention plan Phase C: the agent arrives whole. Import failure is
+        // a warning, never an attach failure — the attach already succeeded
+        // and `commonly agent import-memory` can retry later.
+        if (opts.importMemory) {
+          try {
+            const runtimeClient = createClient({ instance: instanceUrl, token: runtimeToken });
+            await runMemoryImport({
+              client: runtimeClient,
+              explicitPath: typeof opts.importMemory === 'string' ? pathResolve(opts.importMemory) : null,
+              yes: Boolean(opts.yes),
+            });
+          } catch (err) {
+            console.warn(`Memory import failed (agent is still attached): ${err.message}`);
+            console.warn(`Retry with: commonly agent import-memory ${opts.name}`);
+          }
+        }
+
         console.log(`\n  Run with: commonly agent run ${opts.name}`);
       } catch (err) {
         console.error(`Attach failed: ${err.message}`);
+        process.exit(1);
+      }
+    });
+
+  // ── import-memory (retention plan Phase C) ────────────────────────────────
+  agent
+    .command('import-memory <name>')
+    .description("Import local memory (CLAUDE.md / MEMORY.md / ~/.claude project memory) into an attached agent's long_term memory")
+    .option('--path <path>', 'Import a specific file or directory of .md files instead of auto-detecting')
+    .option('--yes', 'Skip the confirmation prompt')
+    .action(async (name, opts) => {
+      const record = loadAgentToken(name);
+      if (!record) {
+        console.error(`No token for '${name}'. Attach it first: commonly agent attach <adapter> --pod <podId> --name ${name}`);
+        process.exit(1);
+      }
+      try {
+        const client = createClient({ instance: record.instanceUrl, token: record.runtimeToken });
+        const result = await runMemoryImport({
+          client,
+          explicitPath: opts.path ? pathResolve(opts.path) : null,
+          yes: Boolean(opts.yes),
+        });
+        if (!result.imported && result.reason === 'needs-confirmation') process.exit(1);
+      } catch (err) {
+        console.error(`Import failed: ${err.message}`);
         process.exit(1);
       }
     });

--- a/cli/src/lib/memory-import.js
+++ b/cli/src/lib/memory-import.js
@@ -1,0 +1,156 @@
+/**
+ * Local memory import — Phase C of the retention plan ("your agent arrives
+ * whole"). Detects the memory a local agent already has on this machine
+ * (project CLAUDE.md / MEMORY.md, Claude Code's per-project auto-memory
+ * directory), composes it into one document, and promotes it into the
+ * kernel envelope's `long_term` section via POST /memory/sync.
+ *
+ * Design constraints:
+ *   - Explicitly opt-in with preview (plan D3) — local memory files can
+ *     contain private material; callers must confirm before anything is
+ *     sent. This module only detects/composes/sends; the command layer
+ *     owns the prompt.
+ *   - APPEND, never clobber: `mode: 'patch'` replaces a section wholesale
+ *     (mergePatchSections is section-level), so we read the existing
+ *     long_term and append the import after it.
+ *   - Server stamps byteSize/updatedAt/schemaVersion (ADR-003 invariant
+ *     #9); we send content + visibility only.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync, realpathSync } from 'fs';
+import { homedir } from 'os';
+import { join, basename } from 'path';
+
+export const SOURCE_RUNTIME = 'import-local';
+
+// Envelope sections are curated context, not dumps. The auto-clearer story
+// on the agent side starts caring around 400KB of session; a quarter of
+// that is a generous ceiling for a one-shot import.
+export const MAX_IMPORT_BYTES = 256 * 1024;
+
+// Claude Code keeps per-project auto-memory under
+// ~/.claude/projects/<slug>/memory where <slug> is the project path with
+// every '/' replaced by '-'.
+export const claudeProjectMemoryDir = (cwd, home) => join(
+  home,
+  '.claude',
+  'projects',
+  cwd.replaceAll('/', '-'),
+  'memory',
+);
+
+const fileCandidate = (path, label) => {
+  if (!existsSync(path)) return null;
+  const stat = statSync(path);
+  if (!stat.isFile() || stat.size === 0) return null;
+  return { path, label, bytes: stat.size };
+};
+
+/**
+ * Find importable memory sources. An explicit path wins outright (file, or
+ * directory whose *.md files are all taken); otherwise auto-detect the
+ * well-known locations. Duplicates are collapsed by realpath — this repo,
+ * for instance, symlinks AGENTS.md → CLAUDE.md.
+ */
+export const detectMemorySources = ({
+  cwd = process.cwd(),
+  home = homedir(),
+  explicitPath = null,
+} = {}) => {
+  const candidates = [];
+
+  if (explicitPath) {
+    if (!existsSync(explicitPath)) {
+      throw new Error(`No such file or directory: ${explicitPath}`);
+    }
+    if (statSync(explicitPath).isDirectory()) {
+      for (const f of readdirSync(explicitPath).filter((n) => n.endsWith('.md')).sort()) {
+        const c = fileCandidate(join(explicitPath, f), `from ${basename(explicitPath)}/`);
+        if (c) candidates.push(c);
+      }
+      if (!candidates.length) {
+        throw new Error(`No .md files found in ${explicitPath}`);
+      }
+    } else {
+      const c = fileCandidate(explicitPath, 'explicit');
+      if (!c) throw new Error(`${explicitPath} is empty or not a regular file`);
+      candidates.push(c);
+    }
+  } else {
+    const projectInstructions = fileCandidate(join(cwd, 'CLAUDE.md'), 'project instructions');
+    if (projectInstructions) candidates.push(projectInstructions);
+    const agentsMd = fileCandidate(join(cwd, 'AGENTS.md'), 'project instructions');
+    if (agentsMd) candidates.push(agentsMd);
+    const projectMemory = fileCandidate(join(cwd, 'MEMORY.md'), 'project memory');
+    if (projectMemory) candidates.push(projectMemory);
+
+    const memDir = claudeProjectMemoryDir(cwd, home);
+    if (existsSync(memDir) && statSync(memDir).isDirectory()) {
+      for (const f of readdirSync(memDir).filter((n) => n.endsWith('.md')).sort()) {
+        const c = fileCandidate(join(memDir, f), 'auto-memory');
+        if (c) candidates.push(c);
+      }
+    }
+  }
+
+  // Collapse symlink duplicates (first mention wins its label).
+  const seen = new Set();
+  return candidates.filter((c) => {
+    let real;
+    try {
+      real = realpathSync(c.path);
+    } catch {
+      real = c.path;
+    }
+    if (seen.has(real)) return false;
+    seen.add(real);
+    return true;
+  });
+};
+
+/** Compose the sources into one markdown document with per-file provenance. */
+export const composeImport = (sources) => {
+  if (!sources.length) throw new Error('Nothing to import');
+  const total = sources.reduce((n, s) => n + s.bytes, 0);
+  if (total > MAX_IMPORT_BYTES) {
+    throw new Error(
+      `Import is ${Math.round(total / 1024)}KB — over the ${MAX_IMPORT_BYTES / 1024}KB ceiling. `
+      + 'Pass an explicit --path to a smaller file, or trim the sources.',
+    );
+  }
+  const parts = sources.map((s) => {
+    const content = readFileSync(s.path, 'utf8').trim();
+    return `## Imported: ${basename(s.path)} (${s.label})\n\n${content}`;
+  });
+  return `# Imported local memory\n\n${parts.join('\n\n---\n\n')}`;
+};
+
+/**
+ * Promote the composed document into the agent's long_term section,
+ * appending after any existing content. `client` is an api.js client
+ * authenticated with the agent's runtime token.
+ */
+export const importMemory = async (client, { sources }) => {
+  const imported = composeImport(sources);
+
+  let existing = '';
+  try {
+    const body = await client.get('/api/agents/runtime/memory');
+    existing = body?.sections?.long_term?.content || '';
+  } catch (err) {
+    // Fresh agents 404 — that's the common case. Anything else should stop
+    // the import: appending to memory we couldn't read risks clobbering it.
+    if (err?.status && err.status !== 404) throw err;
+  }
+
+  const content = existing ? `${existing.trimEnd()}\n\n${imported}` : imported;
+  await client.post('/api/agents/runtime/memory/sync', {
+    mode: 'patch',
+    sourceRuntime: SOURCE_RUNTIME,
+    sections: {
+      long_term: { content, visibility: 'private' },
+    },
+  });
+
+  return { files: sources.length, bytes: content.length, appended: Boolean(existing) };
+};

--- a/frontend/src/v2/__tests__/V2AgentBYOMemory.test.tsx
+++ b/frontend/src/v2/__tests__/V2AgentBYOMemory.test.tsx
@@ -1,0 +1,123 @@
+// @ts-nocheck
+// Retention plan Phase C: the optional "bring its memory" step on the BYO
+// page. Pins the wire contract: the import uses the freshly issued
+// cm_agent_* runtime token (NOT the user JWT), patch mode, sourceRuntime
+// 'import-web', and read-then-append semantics.
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2AgentBYO from '../components/V2AgentBYO';
+import { AuthContext } from '../../context/AuthContext';
+
+jest.mock('axios', () => {
+  const mock = {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  };
+  return { __esModule: true, default: mock, ...mock };
+});
+
+const axios = jest.requireMock('axios').default;
+
+const authValue = {
+  currentUser: { _id: 'u1', username: 'sam' },
+  user: { _id: 'u1', username: 'sam' },
+  token: 'user-jwt',
+  loading: false,
+  error: null,
+  isAuthenticated: true,
+  register: jest.fn(),
+  login: jest.fn(),
+  logout: jest.fn(),
+  updateProfile: jest.fn(),
+};
+
+const AGENT_TOKEN = 'cm_agent_test_token';
+
+const renderPage = () => render(
+  <AuthContext.Provider value={authValue}>
+    <MemoryRouter>
+      <V2AgentBYO />
+    </MemoryRouter>
+  </AuthContext.Provider>,
+);
+
+const issueToken = async () => {
+  axios.get.mockResolvedValueOnce({ data: [{ _id: 'p1', name: 'Workspace', type: 'chat' }] });
+  axios.post
+    .mockResolvedValueOnce({ data: { ok: true } }) // /api/registry/install
+    .mockResolvedValueOnce({ data: { token: AGENT_TOKEN } }); // runtime-tokens
+
+  renderPage();
+  await waitFor(() => expect(screen.getByText('Workspace (chat)')).toBeInTheDocument());
+  fireEvent.click(screen.getByRole('button', { name: /install \+ generate token/i }));
+  await screen.findByText(/token issued for/i);
+};
+
+afterEach(() => jest.clearAllMocks());
+
+describe('V2AgentBYO memory import', () => {
+  test('imports pasted memory with the runtime token, patch mode, append semantics', async () => {
+    await issueToken();
+
+    // Fresh agent: memory read 404s.
+    axios.get.mockRejectedValueOnce({ response: { status: 404 } });
+    axios.post.mockResolvedValueOnce({ data: {} }); // memory/sync
+
+    fireEvent.change(screen.getByPlaceholderText(/paste memory\.md/i), {
+      target: { value: '## Learned\nthe repo layout' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /import memory/i }));
+    });
+
+    await screen.findByText(/memory imported/i);
+
+    const readCall = axios.get.mock.calls.find(([url]) => url === '/api/agents/runtime/memory');
+    expect(readCall[1].headers.Authorization).toBe(`Bearer ${AGENT_TOKEN}`);
+
+    const syncCall = axios.post.mock.calls.find(([url]) => url === '/api/agents/runtime/memory/sync');
+    const [, body, config] = syncCall;
+    expect(config.headers.Authorization).toBe(`Bearer ${AGENT_TOKEN}`);
+    expect(body.mode).toBe('patch');
+    expect(body.sourceRuntime).toBe('import-web');
+    expect(body.sections.long_term.visibility).toBe('private');
+    expect(body.sections.long_term.content).toMatch(/^# Imported local memory/);
+    expect(body.sections.long_term.content).toContain('the repo layout');
+  });
+
+  test('appends after existing long_term content instead of clobbering', async () => {
+    await issueToken();
+
+    axios.get.mockResolvedValueOnce({
+      data: { sections: { long_term: { content: '## Prior knowledge' } } },
+    });
+    axios.post.mockResolvedValueOnce({ data: {} });
+
+    fireEvent.change(screen.getByPlaceholderText(/paste memory\.md/i), {
+      target: { value: 'new facts' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /import memory/i }));
+    });
+    await screen.findByText(/memory imported/i);
+
+    const syncCall = axios.post.mock.calls.find(([url]) => url === '/api/agents/runtime/memory/sync');
+    expect(syncCall[1].sections.long_term.content.startsWith('## Prior knowledge')).toBe(true);
+    expect(syncCall[1].sections.long_term.content).toContain('new facts');
+  });
+
+  test('import button stays disabled with nothing pasted; nothing is sent on render', async () => {
+    await issueToken();
+
+    expect(screen.getByRole('button', { name: /import memory/i })).toBeDisabled();
+    expect(axios.post.mock.calls.some(([url]) => url === '/api/agents/runtime/memory/sync')).toBe(false);
+  });
+});

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -16,6 +16,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import axios from '../../utils/axiosConfig';
 import V2FeaturePage from './V2FeaturePage';
 import { useV2Api } from '../hooks/useV2Api';
 import { V2Pod } from '../hooks/useV2Pods';
@@ -97,12 +98,68 @@ const V2AgentBYO: React.FC = () => {
         setError('Install succeeded but token issuance returned empty. Retry, or contact ops.');
       } else {
         setIssued({ token: tok, agentName: cleanName, podId });
+        setMemoryText('');
+        setMemoryDone(false);
+        setMemoryError(null);
       }
     } catch (err) {
       const e = err as { response?: { data?: { error?: string; message?: string } }; message?: string };
       setError(e.response?.data?.error || e.response?.data?.message || e.message || 'Install failed.');
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  // Retention plan Phase C — "your agent arrives whole". Optional paste /
+  // upload of the agent's local memory (MEMORY.md / CLAUDE.md), promoted
+  // into the kernel envelope with the just-issued runtime token. Explicitly
+  // opt-in: nothing is read or sent until the user pastes or picks a file
+  // and clicks import. Appends to any existing long_term (patch mode
+  // replaces sections wholesale, so read-then-append — same contract as
+  // `commonly agent import-memory`).
+  const [memoryText, setMemoryText] = useState('');
+  const [memoryBusy, setMemoryBusy] = useState(false);
+  const [memoryDone, setMemoryDone] = useState(false);
+  const [memoryError, setMemoryError] = useState<string | null>(null);
+
+  const onMemoryFile = async (file: File | undefined) => {
+    if (!file) return;
+    if (file.size > 256 * 1024) {
+      setMemoryError('That file is over the 256KB import ceiling — trim it or paste the relevant part.');
+      return;
+    }
+    setMemoryError(null);
+    setMemoryText(await file.text());
+  };
+
+  const importMemory = async () => {
+    if (!issued || !memoryText.trim() || memoryBusy) return;
+    setMemoryBusy(true);
+    setMemoryError(null);
+    try {
+      const runtimeAuth = { headers: { Authorization: `Bearer ${issued.token}` } };
+      let existing = '';
+      try {
+        const res = await axios.get('/api/agents/runtime/memory', runtimeAuth);
+        existing = (res.data as { sections?: { long_term?: { content?: string } } })
+          ?.sections?.long_term?.content || '';
+      } catch (err) {
+        const status = (err as { response?: { status?: number } })?.response?.status;
+        if (status !== 404) throw err;
+      }
+      const imported = `# Imported local memory\n\n${memoryText.trim()}`;
+      const content = existing ? `${existing.trimEnd()}\n\n${imported}` : imported;
+      await axios.post('/api/agents/runtime/memory/sync', {
+        mode: 'patch',
+        sourceRuntime: 'import-web',
+        sections: { long_term: { content, visibility: 'private' } },
+      }, runtimeAuth);
+      setMemoryDone(true);
+    } catch (err) {
+      const e = err as { response?: { data?: { error?: string } }; message?: string };
+      setMemoryError(e.response?.data?.error || e.message || 'Import failed.');
+    } finally {
+      setMemoryBusy(false);
     }
   };
 
@@ -227,6 +284,50 @@ const V2AgentBYO: React.FC = () => {
               </button>
             </div>
             <pre className="v2-byo__pre">{cursorSnippet}</pre>
+          </div>
+
+          <div className="v2-byo__snippet">
+            <div className="v2-byo__snippet-head">
+              <span>Bring its memory (optional)</span>
+            </div>
+            {memoryDone ? (
+              <p className="v2-byo__memory-done">
+                ✓ Memory imported — <code>{issued.agentName}</code> arrives knowing your project.
+                It shows up in the agent&apos;s profile under long-term memory.
+              </p>
+            ) : (
+              <div className="v2-byo__memory">
+                <p className="v2-byo__hint">
+                  Paste your agent&apos;s local <code>MEMORY.md</code> or <code>CLAUDE.md</code> (or
+                  pick the file) and it starts here with everything it already knows. Appends to its
+                  long-term memory; never overwrites. Nothing is sent until you click import.
+                </p>
+                <textarea
+                  className="v2-byo__input v2-byo__memory-text"
+                  rows={6}
+                  placeholder="# Paste MEMORY.md / CLAUDE.md content here…"
+                  value={memoryText}
+                  onChange={(e) => setMemoryText(e.target.value)}
+                />
+                <div className="v2-byo__memory-row">
+                  <input
+                    type="file"
+                    accept=".md,text/markdown,text/plain"
+                    aria-label="Choose a memory file"
+                    onChange={(e) => onMemoryFile(e.target.files?.[0])}
+                  />
+                  <button
+                    type="button"
+                    className="v2-byo__secondary"
+                    disabled={memoryBusy || !memoryText.trim()}
+                    onClick={importMemory}
+                  >
+                    {memoryBusy ? 'Importing…' : 'Import memory'}
+                  </button>
+                </div>
+                {memoryError && <div className="v2-byo__error">{memoryError}</div>}
+              </div>
+            )}
           </div>
 
           <div className="v2-byo__cta-row">

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4897,6 +4897,36 @@
   color: #991b1b;
   font-size: 13px;
 }
+
+/* Optional memory import (retention plan Phase C) — lives inside the
+   post-issue snippet card. */
+.v2-byo__memory {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+}
+
+.v2-byo__memory-text {
+  font-family: 'SF Mono', Menlo, monospace;
+  font-size: 12px;
+  resize: vertical;
+}
+
+.v2-byo__memory-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.v2-byo__memory-done {
+  padding: 12px;
+  margin: 0;
+  color: #1e6b2a;
+  font-size: 13px;
+}
 .v2-root button.v2-byo__submit {
   align-self: flex-start;
   padding: 10px 18px;


### PR DESCRIPTION
Phase C of the retention plan (docs/plans/retention-traction-onboarding-2026-07.md) — the wedge feature. An agent connecting to Commonly brings the memory it already accumulated on the user's machine, so it arrives knowing the project instead of amnesiac.

## CLI

```
commonly agent attach claude --pod <id> --name my-claude --import-memory
commonly agent import-memory my-claude [--path <file-or-dir>] [--yes]
```

- Auto-detects project `CLAUDE.md`/`AGENTS.md`/`MEMORY.md` + Claude Code's `~/.claude/projects/<slug>/memory/` dir; symlink duplicates collapse (this repo's AGENTS.md → CLAUDE.md); explicit path overrides.
- **Opt-in with preview** (plan D3 — local memory can hold private material): source list + sizes + composed-doc head, then y/N (or `--yes`; non-TTY without it aborts). Attach never fails on import failure.
- **Append, never clobber**: `mode:'patch'` replaces sections wholesale, so the importer reads existing `long_term` and appends; a non-404 read error aborts rather than blind-overwrite. 256KB ceiling. `sourceRuntime: 'import-local'`.

## Web

`/v2/agents/byo` gains an optional **"Bring its memory"** card after token issuance — paste or file-pick, imported with the freshly issued `cm_agent_*` runtime token (no new backend surface; the existing dual contract does the work). Same append semantics, `sourceRuntime: 'import-web'`.

## Proof

16 new tests (13 CLI + 3 web) pinning detection, provenance, ceiling, the append/abort semantics, and the runtime-token wire contract. CLI suite 148 green, frontend 194 green, full BYO flow browser-verified (install → token → paste → import → success).

Remaining Phase C item (separate PR): skills-as-metadata on agent profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9