### PR TITLE
fix(auth): per-request Authorization wins over the ambient user JWT

### DIFF
--- a/frontend/src/utils/axiosConfig.test.tsx
+++ b/frontend/src/utils/axiosConfig.test.tsx
@@ -21,10 +21,37 @@ describe('axiosConfig', () => {
   beforeEach(() => {
     // Mock the axios instance
     jest.clearAllMocks();
+    localStorage.clear();
   });
 
   test('creates axios instance with default config', () => {
     expect(axiosConfig).toBeDefined();
     expect(axiosConfig.defaults.baseURL).toBe(getApiBaseUrl());
+  });
+
+  describe('request interceptor auth injection', () => {
+    // The interceptor was registered at import time; pull the actual
+    // function out of the mock so we can exercise it directly.
+    const interceptor = axiosConfig.interceptors.request.use.mock.calls[0][0];
+
+    test('injects the user JWT when no Authorization is set', () => {
+      localStorage.setItem('token', 'user-jwt');
+      const config = interceptor({ headers: {} });
+      expect(config.headers.Authorization).toBe('Bearer user-jwt');
+    });
+
+    test('respects an explicit per-request Authorization (runtime tokens)', () => {
+      // Regression: the BYO memory import authenticates with the agent's
+      // cm_agent_* runtime token; overwriting it with the user JWT made the
+      // kernel 401 (2026-07-03 live smoke).
+      localStorage.setItem('token', 'user-jwt');
+      const config = interceptor({ headers: { Authorization: 'Bearer cm_agent_runtime' } });
+      expect(config.headers.Authorization).toBe('Bearer cm_agent_runtime');
+    });
+
+    test('leaves headers alone when no token is stored', () => {
+      const config = interceptor({ headers: {} });
+      expect(config.headers.Authorization).toBeUndefined();
+    });
   });
 });

--- a/frontend/src/utils/axiosConfig.ts
+++ b/frontend/src/utils/axiosConfig.ts
@@ -4,11 +4,16 @@ import getApiBaseUrl from './apiBaseUrl';
 // Set the base URL for all axios requests
 axios.defaults.baseURL = getApiBaseUrl();
 
-// Add a request interceptor to include the token in all requests
+// Add a request interceptor to include the token in all requests.
+// An explicit per-request Authorization header WINS over the ambient user
+// JWT — the BYO memory import authenticates with the agent's cm_agent_*
+// runtime token, and unconditionally overwriting it made the kernel see a
+// user JWT and 401 (caught in the 2026-07-03 live smoke; mocks and a
+// non-auth-enforcing stub both missed it).
 axios.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
     const token = localStorage.getItem('token');
-    if (token) {
+    if (token && !config.headers.Authorization) {
       config.headers['Authorization'] = `Bearer ${token}`;
     }
     return config;


### PR DESCRIPTION
Caught by the pre-launch live smoke (this is why we're doing it): the BYO memory import 401'd in production. The global axios interceptor unconditionally overwrote `Authorization` with the user JWT, clobbering the `cm_agent_*` runtime token the import sends — an `agentRuntimeAuth` route received a user JWT.

Invisible to both prior proof tiers: the component test mocks axios entirely (interceptor never runs), and the local verification stub didn't enforce auth. Second instance of the "stubs must reproduce production conditions" lesson in two days — first data shape, now auth enforcement.

Fix: inject the ambient JWT only when the request doesn't already carry an `Authorization` header. Three new interceptor unit tests pin the contract (inject / respect-explicit / no-token). Frontend suite 197 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9