### PR TITLE
fix(byo): already-installed agents can reissue their runtime token

### DIFF
--- a/frontend/src/v2/__tests__/V2AgentBYOMemory.test.tsx
+++ b/frontend/src/v2/__tests__/V2AgentBYOMemory.test.tsx
@@ -120,4 +120,18 @@ describe('V2AgentBYO memory import', () => {
     expect(screen.getByRole('button', { name: /import memory/i })).toBeDisabled();
     expect(axios.post.mock.calls.some(([url]) => url === '/api/agents/runtime/memory/sync')).toBe(false);
   });
+
+  test('already-installed agent still reissues a token (lost-token recovery)', async () => {
+    axios.get.mockResolvedValueOnce({ data: [{ _id: 'p1', name: 'Workspace', type: 'chat' }] });
+    axios.post
+      .mockRejectedValueOnce({ response: { data: { error: 'Agent already installed in this pod' } } })
+      .mockResolvedValueOnce({ data: { token: AGENT_TOKEN } });
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Workspace (chat)')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /install \+ generate token/i }));
+
+    await screen.findByText(/token issued for/i);
+    expect(screen.getByText(AGENT_TOKEN)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -79,13 +79,25 @@ const V2AgentBYO: React.FC = () => {
     }
     setSubmitting(true);
     try {
-      await api.post('/api/registry/install', {
-        agentName: cleanName,
-        podId,
-        scopes: DEFAULT_SCOPES,
-        config: { runtime: { runtimeType: 'webhook' } },
-        displayName: cleanName,
-      });
+      try {
+        await api.post('/api/registry/install', {
+          agentName: cleanName,
+          podId,
+          scopes: DEFAULT_SCOPES,
+          config: { runtime: { runtimeType: 'webhook' } },
+          displayName: cleanName,
+        });
+      } catch (installErr) {
+        // "Already installed" is identity continuity (ADR-001), not a
+        // failure — this is exactly the lost-token recovery path the copy
+        // below promises ("come back here and rotate"). Fall through to
+        // force-reissue; anything else is a real error. Caught in the
+        // 2026-07-03 live smoke: the hard-fail here made token recovery
+        // impossible from the UI.
+        const msg = (installErr as { response?: { data?: { error?: string } } })
+          ?.response?.data?.error || '';
+        if (!/already installed/i.test(msg)) throw installErr;
+      }
       // Force-issue a fresh runtime token — guarantees we get the raw
       // `cm_agent_*` value (subsequent calls return `existing:true` with
       // no plaintext; `force:true` rotates).


### PR DESCRIPTION
Live-smoke find #2: the BYO page promises lost-token recovery ("re-running install with the same name is idempotent on identity; the token is reissued fresh") but the install call hard-fails on `Agent already installed in this pod` before reaching token issuance — so a user who lost their one-time token had no recovery path from the UI.

Fix: treat already-installed as identity continuity (ADR-001) and fall through to the `force: true` token reissue; every other install error still surfaces. Regression test covers the recovery path. Frontend suite 198 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9