### PR TITLE
fix(agents): suppress gateway tool-failure notes + concatenated NO_REPLY leaks

### DIFF
--- a/backend/__tests__/unit/services/agentMessageService.chatNoise.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.chatNoise.test.js
@@ -1,0 +1,52 @@
+// Guards against the two live-pod chat-noise leaks found 2026-07-03:
+//  - gateway tool-status failure notes ("⚠️ 📝 Edit: ... failed") posting
+//    to pods once per failed workspace-file edit
+//  - concatenated NO_REPLY sentinels ("NO_REPLYNO_REPLY") sailing through
+//    the word-boundary strip and posting verbatim
+const AgentMessageService = require('../../../services/agentMessageService');
+
+describe('AgentMessageService.isRuntimeToolFailureNote', () => {
+  it('matches the gateway tool-failure notes seen in live pods', () => {
+    const samples = [
+      '⚠️ 📝 Edit: in /workspace/nova/MEMORY.md (196 chars) failed',
+      '⚠️ 📝 Edit: in /workspace/theo/MEMORY.md (1588 chars) failed',
+      '⚠️ ✉️ Message failed',
+      '⚠️ 🔧 Exec: npm test failed',
+    ];
+    for (const s of samples) {
+      expect(AgentMessageService.isRuntimeToolFailureNote(s)).toBe(true);
+    }
+  });
+
+  it('does NOT match agent prose about failures or multi-line content', () => {
+    const ok = [
+      'The MEMORY.md edit failed twice, so I rewrote the file instead — done.',
+      '⚠️ Heads up: the deploy failed, investigating now and will report back.', // no emoji tool tag
+      '⚠️ 📝 Edit: in /workspace/nova/MEMORY.md failed\nRetrying with a fresh read.', // multi-line = composed reply
+      'failed',
+      '',
+      null,
+      undefined,
+    ];
+    for (const s of ok) {
+      expect(AgentMessageService.isRuntimeToolFailureNote(s)).toBe(false);
+    }
+  });
+});
+
+describe('sanitizeAgentContent — concatenated NO_REPLY sentinels', () => {
+  it('strips doubled and tripled sentinel runs', () => {
+    expect(AgentMessageService.sanitizeAgentContent('NO_REPLYNO_REPLY')).toBe('');
+    expect(AgentMessageService.sanitizeAgentContent('NO_REPLYNO_REPLYNO_REPLY')).toBe('');
+    expect(AgentMessageService.sanitizeAgentContent('NO_REPLY NO_REPLY')).toBe('');
+  });
+
+  it('still strips the single sentinel and preserves real content', () => {
+    expect(AgentMessageService.sanitizeAgentContent('NO_REPLY')).toBe('');
+    expect(AgentMessageService.sanitizeAgentContent('Shipped the fix.\nNO_REPLY')).toBe('Shipped the fix.');
+    // Mid-sentence mentions lose the token (pre-existing behavior) but the
+    // line survives.
+    expect(AgentMessageService.sanitizeAgentContent('Reply with NO_REPLY when done.'))
+      .toBe('Reply with  when done.');
+  });
+});

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -820,6 +820,14 @@ class AgentMessageService {
       sanitizedContent = '';
     }
 
+    // Same treatment for gateway tool-status failure notes ("⚠️ 📝 Edit: ...
+    // failed") — operator diagnostics that were spamming pods once per
+    // failed workspace-file edit. Logged for observability, never posted.
+    if (sanitizedContent && AgentMessageService.isRuntimeToolFailureNote(sanitizedContent)) {
+      console.warn(`[agent-msg] suppressed runtime tool-failure note from agent=${agentName} instance=${instanceId} pod=${podId}: ${sanitizedContent.slice(0, 120)}`);
+      sanitizedContent = '';
+    }
+
     // Task #68: detect false-attachment claims. Agents sometimes post
     // "Done — I attached the file" without actually calling
     // commonly_attach_file. The file may exist in their workspace but
@@ -1417,6 +1425,22 @@ class AgentMessageService {
     );
   }
 
+  /**
+   * Gateway tool-status failure notes — "⚠️ 📝 Edit: in /workspace/... failed",
+   * "⚠️ ✉️ Message failed". Like model failures these are runtime diagnostics
+   * relayed by the gateway, not agent-authored content; live pods were
+   * accumulating one per failed MEMORY.md edit (2026-07-03). Strict shape:
+   * a single line starting with ⚠️ + an emoji tool tag and ending in
+   * "failed", so an agent legitimately reporting a failure in prose is
+   * untouched.
+   */
+  static isRuntimeToolFailureNote(content: unknown): boolean {
+    if (!content) return false;
+    const c = String(content).trim();
+    if (!c || c.includes('\n')) return false;
+    return /^⚠️\s*\p{Extended_Pictographic}[^:\n]{0,30}:?\s.*\bfailed\b\.?$/iu.test(c);
+  }
+
   static sanitizeAgentContent(content: unknown): string {
     if (content === null || content === undefined) return '';
     const raw = String(content);
@@ -1426,7 +1450,11 @@ class AgentMessageService {
 
     const cleaned = stripped
       .split(/\r?\n/)
-      .map((line) => line.replace(/\bNO_REPLY\b/g, '').trim())
+      // (?:NO_REPLY)+ handles concatenated sentinels: gateways occasionally
+      // join two silent blocks into "NO_REPLYNO_REPLY", which has no word
+      // boundary between the runs and sailed through \bNO_REPLY\b verbatim
+      // into live pods (2026-07-03).
+      .map((line) => line.replace(/\b(?:NO_REPLY)+\b/g, '').trim())
       .filter(Boolean)
       .join('\n')
       .trim();


### PR DESCRIPTION
Investigation of the live-pod report ("cloud agents encountering memory write issues / sending something that doesn't look right"):

## Diagnosis

1. **`⚠️ 📝 Edit: in /workspace/nova/MEMORY.md (N chars) failed`** (nova + theo, ~8 occurrences/36h): the gateway's `edit` tool rejects with *"Could not find the exact text"* — agents exact-match-edit their workspace `MEMORY.md` against a stale in-session copy of the file. Disk/permissions ruled out (16% used, files healthy, some writes succeed). The tool-status note then relays into pod chat once per failure.
2. **`NO_REPLYNO_REPLY`** posting verbatim: concatenated sentinels have no word boundary between the runs, so the sanitizer's `\bNO_REPLY\b` matched nothing.
3. Also observed while digging (separate, infra): community-agent chain failing with `openrouter/...nemotron...:free: 401 Missing Auth` and `gemini-2.5-flash` 429-looping — the model-failure suppressor is correctly hiding these from chat, but the OpenRouter credential needs attention.

## Fix (this PR — the user-facing halves)

- New strict `isRuntimeToolFailureNote` classifier (single line, `⚠️` + emoji tool tag, ends in "failed") → suppressed + warn-logged, same treatment as the existing model-failure guard. Agent prose about failures is untouched (multi-line or no tool tag → passes).
- Sentinel strip becomes `\b(?:NO_REPLY)+\b`.

11 new tests; 50 agentMessageService tests green.

## Follow-ups (not this PR)

- openclaw-fork AGENTS.md guidance: read `MEMORY.md` immediately before editing; on exact-match failure, re-read and append rather than retry.
- Rotate/fix the OpenRouter key (`401 Missing Auth` on the community chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9