### PR TITLE
fix(agents): backfill PG pod row before agent message insert (BYO hero-path blocker)

### DIFF
--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -1269,6 +1269,28 @@ class AgentMessageService {
     if (PGMessage && process.env.PG_HOST) {
       try {
         await AgentIdentityService.syncUserToPostgreSQL(agentUser);
+        // Best-effort PG pod backfill — same heal the human message paths
+        // do (messageController/pgMessageController via syncPodFromMongo).
+        // Mongo-only pods (e.g. the default "My Workspace" every signup
+        // gets from createDefaultWorkspacePod) have no row in PG `pods`,
+        // so without this the insert below FK-fails on messages_pod_id_fkey
+        // and the agent's message strands in the Mongo fallback — invisible
+        // to pod chat, which reads PG. Found in the 2026-07-03 live smoke:
+        // the BYO hero path ("install agent → talk to it") broke at the
+        // agent's first reply. Swallow errors: if PG is truly down the
+        // create below throws and the existing Mongo fallback handles it.
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+          const PGPod = require('../models/pg/Pod');
+          const pgPodExists = await PGPod.findById(String(podId));
+          if (!pgPodExists) {
+            // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+            const { syncPodFromMongo } = require('./pgPodSyncService');
+            await syncPodFromMongo(String(podId), String(agentUser._id));
+          }
+        } catch (syncErr) {
+          console.warn('[agent-msg] PG pod backfill skipped:', (syncErr as Error).message);
+        }
         const newMessage = await (PGMessage as {
           create(podId: string, userId: string, content: string, type: string, replyToMessageId?: string | null): Promise<Record<string, unknown>>;
         }).create(


### PR DESCRIPTION
**The biggest live-smoke find**: the BYO hero path ("install your agent → talk to it") breaks at the agent's first reply on any fresh account.

## Diagnosis (verified live, step by step)

1. Every signup's default **My Workspace** pod is created in **Mongo only** (`createDefaultWorkspacePod`).
2. A BYO agent posting via the runtime route hits `PGMessage.create` → **FK violation on `messages_pod_id_fkey`** (backend log confirmed) → silent Mongo fallback.
3. Pod chat reads **PG** → the agent's message never renders. The human's messages DO render because the human message paths already heal the PG pod row via `syncPodFromMongo` — producing a split-brain where the human sees their own side of a conversation and none of the agent's.

Live proof: `lily-smoke-agent`'s CAP post returned 200 (Mongo-shaped doc), pod stayed on the empty state; the human's message on the same pod healed PG and rendered; PG store had only the human message, Mongo had only the agent's.

## Fix

Mirror the exact heal the human paths use — existence check + `syncPodFromMongo`, errors swallowed so a genuine PG outage still lands in the Mongo fallback — in `agentMessageService._postToTarget`.

50 agentMessageService tests green; typecheck clean. Post-deploy I'll re-run the live hero path end-to-end (agent post → renders in chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9