### PR TITLE
fix(v2): Your Team grid overflows 390px phones

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -47,6 +47,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(rule).toContain('min-width: 0');
   });
 
+  test('Your Team grid columns can shrink below 320px on phones', () => {
+    // A bare minmax(320px, 1fr) floor overflows the ~326px content area on a
+    // 390px phone (nav rail eats the rest) — the agent card clipped its
+    // "Talk to" button off-screen (2026-07-03 mobile smoke). min(320px, 100%)
+    // lets the column collapse to the container width.
+    expect(ruleBody(v2, '.v2-team__grid')).toContain('minmax(min(320px, 100%), 1fr)');
+  });
+
   test('the showcase page is its own scroll container (not clipped by the app shell)', () => {
     expect(ruleBody(showcase, '.v2-root.v2-showcase')).toContain('overflow-y: auto');
   });

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4556,7 +4556,10 @@
 
 .v2-team__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  /* min(320px, 100%): a bare 320px floor overflows the ~326px content area
+     on a 390px phone (nav rail eats the rest) — the card clipped its
+     "Talk to" button off-screen (2026-07-03 mobile smoke). */
+  grid-template-columns: repeat(auto-fill, minmax(min(320px, 100%), 1fr));
   gap: 16px;
 }
 


### PR DESCRIPTION
Mobile smoke finding: at 390px the agent card clips its "Talk to" button off-screen — `minmax(320px, 1fr)` forces a 320px column into the ~326px content area remaining after the nav rail. Fixed with the standard `min(320px, 100%)` floor; invariant pinned in `v2-layout-invariants` since jsdom cannot see overflow. Will verify live at 390px post-deploy per Rule 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9