### PR TITLE
feat(skills): register local skills as profile metadata — content stays local

### DIFF
--- a/cli/__tests__/skills-import.test.mjs
+++ b/cli/__tests__/skills-import.test.mjs
@@ -1,0 +1,97 @@
+/**
+ * skills-import.js unit tests — the metadata-only half of "your agent
+ * arrives whole". Real temp dirs for detection; stub client for the wire.
+ */
+
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+import {
+  detectSkills,
+  parseSkillMeta,
+  skillStub,
+  importSkills,
+  MAX_SKILLS,
+} from '../src/lib/skills-import.js';
+
+const tmp = (p) => fs.mkdtempSync(path.join(os.tmpdir(), p));
+
+const writeSkill = (root, dir, frontmatter) => {
+  const d = path.join(root, dir);
+  fs.mkdirSync(d, { recursive: true });
+  fs.writeFileSync(path.join(d, 'SKILL.md'), frontmatter, 'utf8');
+};
+
+describe('parseSkillMeta', () => {
+  test('reads name + description from frontmatter, strips quotes', () => {
+    const meta = parseSkillMeta('---\nname: pod-manager\ndescription: "Manage pods end to end"\nextra: ignored\n---\n\n# Body', 'fallback');
+    expect(meta).toEqual({ name: 'pod-manager', description: 'Manage pods end to end' });
+  });
+
+  test('falls back to the directory name without frontmatter', () => {
+    expect(parseSkillMeta('# Just a doc', 'my-dir').name).toBe('my-dir');
+  });
+});
+
+describe('detectSkills', () => {
+  test('finds skills in cwd .claude/skills and dedupes by name across roots', () => {
+    const cwd = tmp('sk-cwd-');
+    const home = tmp('sk-home-');
+    writeSkill(path.join(cwd, '.claude', 'skills'), 'alpha', '---\nname: alpha\ndescription: first\n---');
+    writeSkill(path.join(home, '.claude', 'skills'), 'alpha', '---\nname: alpha\ndescription: shadowed\n---');
+    writeSkill(path.join(home, '.claude', 'skills'), 'beta', '---\nname: beta\ndescription: second\n---');
+
+    const skills = detectSkills({ cwd, home });
+    expect(skills.map((s) => `${s.name}:${s.description}`)).toEqual(['alpha:first', 'beta:second']);
+  });
+
+  test('explicit dir wins; missing dir throws', () => {
+    const cwd = tmp('sk-cwd2-');
+    const dir = tmp('sk-explicit-');
+    writeSkill(dir, 'gamma', '---\nname: gamma\ndescription: g\n---');
+    expect(detectSkills({ cwd, home: tmp('sk-home2-'), explicitDir: dir })).toHaveLength(1);
+    expect(() => detectSkills({ explicitDir: '/no/such/dir' })).toThrow(/No such directory/);
+  });
+
+  test(`caps at ${MAX_SKILLS}`, () => {
+    const dir = tmp('sk-many-');
+    for (let i = 0; i < MAX_SKILLS + 5; i += 1) {
+      writeSkill(dir, `s${String(i).padStart(3, '0')}`, `---\nname: s${i}\ndescription: d\n---`);
+    }
+    expect(detectSkills({ explicitDir: dir })).toHaveLength(MAX_SKILLS);
+  });
+});
+
+describe('importSkills', () => {
+  test('posts one agent-scoped metadata stub per skill — never the content', async () => {
+    const calls = [];
+    const client = { post: async (url, body) => { calls.push({ url, body }); return {}; } };
+
+    const result = await importSkills(client, {
+      skills: [
+        { name: 'alpha', description: 'first' },
+        { name: 'beta', description: '' },
+      ],
+      podId: 'p1',
+      agentName: 'my-claude',
+      instanceId: 'default',
+    });
+
+    expect(result).toEqual({ imported: 2, names: ['alpha', 'beta'] });
+    expect(calls).toHaveLength(2);
+    const [a] = calls;
+    expect(a.url).toBe('/api/skills/import');
+    expect(a.body.scope).toBe('agent');
+    expect(a.body.agentName).toBe('my-claude');
+    expect(a.body.content).toContain('name: alpha');
+    expect(a.body.content).toContain('intentionally not uploaded');
+  });
+
+  test('skillStub is frontmatter + provenance note only', () => {
+    const stub = skillStub({ name: 'x', description: 'does x' });
+    expect(stub).toContain('name: x');
+    expect(stub).toContain('description: does x');
+    expect(stub).not.toContain('```');
+  });
+});

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -24,6 +24,7 @@ import { getAdapter, listAdapterNames } from '../lib/adapters/index.js';
 import { getSession, setSession, clearSessions } from '../lib/session-store.js';
 import { readLongTerm, syncBack } from '../lib/memory-bridge.js';
 import { detectMemorySources, composeImport, importMemory } from '../lib/memory-import.js';
+import { detectSkills, importSkills } from '../lib/skills-import.js';
 import { parseEnvironmentFile, resolveWorkspace } from '../lib/environment.js';
 import { detectBwrap } from '../lib/sandbox/bwrap.js';
 
@@ -937,6 +938,65 @@ Docs:
         if (!result.imported && result.reason === 'needs-confirmation') process.exit(1);
       } catch (err) {
         console.error(`Import failed: ${err.message}`);
+        process.exit(1);
+      }
+    });
+
+  // ── import-skills (retention plan Phase C — metadata only) ────────────────
+  agent
+    .command('import-skills <name>')
+    .description("Register a local agent's skills (names + descriptions only) on its Commonly profile — content stays on your machine")
+    .option('--dir <path>', 'Skills directory (default: <cwd>/.claude/skills, then ~/.claude/skills)')
+    .option('--yes', 'Skip the confirmation prompt')
+    .option('--instance <url>', 'Target Commonly instance')
+    .action(async (name, opts) => {
+      const record = loadAgentToken(name);
+      if (!record) {
+        console.error(`No token for '${name}'. Attach it first: commonly agent attach <adapter> --pod <podId> --name ${name}`);
+        process.exit(1);
+      }
+      // Skill registration is a USER action (pod-membership-checked route),
+      // unlike memory import which authenticates as the agent.
+      const userToken = getToken(opts.instance);
+      if (!userToken) { console.error('Not logged in. Run: commonly login'); process.exit(1); }
+
+      try {
+        const skills = detectSkills({ explicitDir: opts.dir ? pathResolve(opts.dir) : null });
+        if (!skills.length) {
+          console.log('No skills found (looked for */SKILL.md under .claude/skills). Pass --dir to point at a skills directory.');
+          return;
+        }
+        console.log(`Found ${skills.length} skill${skills.length === 1 ? '' : 's'}:`);
+        for (const s of skills) {
+          console.log(`  ${s.name}${s.description ? ` — ${s.description.slice(0, 80)}` : ''}`);
+        }
+        console.log('\nOnly names + descriptions are uploaded — skill content stays on this machine.');
+
+        if (!opts.yes) {
+          if (!process.stdin.isTTY) {
+            console.log('Not a terminal — re-run with --yes to confirm.');
+            process.exit(1);
+          }
+          const { createInterface } = await import('readline/promises');
+          const rl = createInterface({ input: process.stdin, output: process.stdout });
+          const answer = await rl.question(`Register on ${record.agentName}'s profile? [y/N] `);
+          rl.close();
+          if (!/^y(es)?$/i.test(answer.trim())) {
+            console.log('Cancelled.');
+            return;
+          }
+        }
+
+        const client = createClient({ instance: record.instanceUrl, token: userToken });
+        const result = await importSkills(client, {
+          skills,
+          podId: record.podId,
+          agentName: record.agentName,
+          instanceId: record.instanceId || 'default',
+        });
+        console.log(`✓ Registered ${result.imported} skill${result.imported === 1 ? '' : 's'} on ${record.agentName}'s profile.`);
+      } catch (err) {
+        console.error(`Skills import failed: ${err.message}`);
         process.exit(1);
       }
     });

--- a/cli/src/lib/skills-import.js
+++ b/cli/src/lib/skills-import.js
@@ -1,0 +1,112 @@
+/**
+ * Local skills import — the metadata half of "your agent arrives whole"
+ * (retention plan Phase C, D3). Scans a local skills directory
+ * (<cwd>/.claude/skills or ~/.claude/skills) for SKILL.md files, parses
+ * NAME + DESCRIPTION out of the frontmatter, and registers agent-scoped
+ * skill entries so the agent's profile shows what it can do.
+ *
+ * Deliberately metadata-only (plan D3): skill *content* stays on the
+ * user's machine — local agents execute their skills locally, Commonly
+ * doesn't need the body, and skill files can carry private material. The
+ * uploaded SKILL.md is a frontmatter-only stub that says exactly that.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+export const MAX_SKILLS = 50;
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+/** Parse `name:` and `description:` out of SKILL.md frontmatter. */
+export const parseSkillMeta = (markdown, fallbackName) => {
+  const fm = FRONTMATTER_RE.exec(markdown);
+  if (!fm) return { name: fallbackName, description: '' };
+  const fields = {};
+  for (const line of fm[1].split(/\r?\n/)) {
+    const m = /^(name|description):\s*(.+)$/.exec(line.trim());
+    if (m && !fields[m[1]]) fields[m[1]] = m[2].trim().replace(/^['"]|['"]$/g, '');
+  }
+  return {
+    name: fields.name || fallbackName,
+    description: (fields.description || '').slice(0, 500),
+  };
+};
+
+/**
+ * Find skill directories. Explicit dir wins; otherwise check the two
+ * well-known locations. Each candidate is a directory whose subdirs
+ * contain a SKILL.md.
+ */
+export const detectSkills = ({ cwd = process.cwd(), home = homedir(), explicitDir = null } = {}) => {
+  const roots = [];
+  if (explicitDir) {
+    if (!existsSync(explicitDir) || !statSync(explicitDir).isDirectory()) {
+      throw new Error(`No such directory: ${explicitDir}`);
+    }
+    roots.push(explicitDir);
+  } else {
+    for (const candidate of [join(cwd, '.claude', 'skills'), join(home, '.claude', 'skills')]) {
+      try {
+        if (existsSync(candidate) && statSync(candidate).isDirectory()) roots.push(candidate);
+      } catch {
+        // symlinked skill roots can dangle; skip quietly
+      }
+    }
+  }
+
+  const skills = [];
+  const seen = new Set();
+  for (const root of roots) {
+    for (const entry of readdirSync(root).sort()) {
+      const skillFile = join(root, entry, 'SKILL.md');
+      try {
+        if (!existsSync(skillFile) || !statSync(skillFile).isFile()) continue;
+      } catch {
+        continue;
+      }
+      const meta = parseSkillMeta(readFileSync(skillFile, 'utf8'), entry);
+      if (seen.has(meta.name)) continue;
+      seen.add(meta.name);
+      skills.push({ ...meta, path: skillFile });
+      if (skills.length >= MAX_SKILLS) return skills;
+    }
+  }
+  return skills;
+};
+
+/** The frontmatter-only stub that gets uploaded in place of skill content. */
+export const skillStub = ({ name, description }) => [
+  '---',
+  `name: ${name}`,
+  `description: ${description || name}`,
+  '---',
+  '',
+  'Imported as metadata from a local agent — the skill itself runs on the',
+  "agent's own machine; its content was intentionally not uploaded.",
+  '',
+].join('\n');
+
+/**
+ * Register the skills as agent-scoped entries via POST /api/skills/import.
+ * `client` must be authenticated as the USER (pod membership is checked),
+ * not the agent runtime token.
+ */
+export const importSkills = async (client, { skills, podId, agentName, instanceId = 'default' }) => {
+  const results = [];
+  for (const skill of skills) {
+    // eslint-disable-next-line no-await-in-loop
+    await client.post('/api/skills/import', {
+      podId,
+      name: skill.name,
+      content: skillStub(skill),
+      description: skill.description || undefined,
+      scope: 'agent',
+      agentName,
+      instanceId,
+    });
+    results.push(skill.name);
+  }
+  return { imported: results.length, names: results };
+};


### PR DESCRIPTION
The final Phase C item (plan D3): a local agent's skills surface on its Commonly profile as **metadata only** — names + descriptions from SKILL.md frontmatter, never content (privacy + the skills execute locally anyway).

```
commonly agent import-skills my-claude [--dir <skills-dir>] [--yes]
```

- Auto-detects `<cwd>/.claude/skills` then `~/.claude/skills`; dedupes by name across roots; caps at 50; preview + confirm before anything is sent.
- Each skill uploads as a frontmatter-only stub through the existing `POST /api/skills/import` (`scope: 'agent'`) — the stub body states the content was intentionally not uploaded. The agent-profile page already renders agent-scoped skill assets (name + description), so this ships with **zero backend or frontend changes**.
- User-token authenticated (the route checks pod membership) — deliberately different from memory import, which authenticates as the agent.

7 new tests (frontmatter parsing, multi-root dedupe, cap, wire contract incl. never-content). CLI suite 155 green.

With this merged, the retention plan is fully shipped: OAuth → open registration with invite-gated cloud → starter workspace → landing redesign → memory + skills migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9