### PR TITLE
feat(auth): forgot/reset password + invite redemption in Settings

### DIFF
--- a/backend/__tests__/unit/controllers/invitationEntitlement.test.js
+++ b/backend/__tests__/unit/controllers/invitationEntitlement.test.js
@@ -145,6 +145,71 @@ describe('Invitation → cloudAgents entitlement', () => {
     });
   });
 
+  describe('password reset', () => {
+    // These use the REAL jwt (unmocked would be ideal, but the file-level
+    // mock returns static values) — so exercise the flow via the controller
+    // with the mock steering decode/verify.
+    const jwt = require('jsonwebtoken');
+
+    const makeUser = () => User.create({
+      username: 'resetter',
+      email: 'resetter@example.com',
+      password: 'old-hashed',
+      verified: false,
+    });
+
+    it('forgot-password always answers generically (no account enumeration)', async () => {
+      const res = mockRes();
+      await authController.forgotPassword({ body: { email: 'nobody@example.com' } }, res);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        message: expect.stringContaining('If that email has an account'),
+      }));
+    });
+
+    it('reset with a valid token updates the password and marks verified', async () => {
+      const user = await makeUser();
+      jwt.decode = jest.fn().mockReturnValue({ id: String(user._id), purpose: 'password-reset' });
+      jwt.verify = jest.fn().mockReturnValue({ id: String(user._id) });
+
+      const res = mockRes();
+      await authController.resetPassword({ body: { token: 't', password: 'brand-new-pass-1' } }, res);
+
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        message: expect.stringContaining('Password updated'),
+      }));
+      const fresh = await User.findById(user._id);
+      expect(fresh.verified).toBe(true);
+      expect(fresh.password).not.toBe('old-hashed');
+    });
+
+    it('rejects tokens with the wrong purpose and short passwords', async () => {
+      const user = await makeUser();
+      jwt.decode = jest.fn().mockReturnValue({ id: String(user._id), purpose: 'email-verify' });
+      const res = mockRes();
+      await authController.resetPassword({ body: { token: 't', password: 'brand-new-pass-1' } }, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      const res2 = mockRes();
+      await authController.resetPassword({ body: { token: 't', password: 'short' } }, res2);
+      expect(res2.status).toHaveBeenCalledWith(400);
+    });
+
+    it('rejects when signature verification fails (used/expired token)', async () => {
+      const user = await makeUser();
+      // The pre-save hook hashed the seed password; capture the stored hash
+      // as the unchanged-baseline rather than the raw seed string.
+      const storedHash = (await User.findById(user._id)).password;
+      jwt.decode = jest.fn().mockReturnValue({ id: String(user._id), purpose: 'password-reset' });
+      jwt.verify = jest.fn().mockImplementation(() => { throw new Error('invalid signature'); });
+
+      const res = mockRes();
+      await authController.resetPassword({ body: { token: 't', password: 'brand-new-pass-1' } }, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      const fresh = await User.findById(user._id);
+      expect(fresh.password).toBe(storedHash);
+    });
+  });
+
   describe('redeemInvitation (post-signup upgrade)', () => {
     const makeUser = (entitled = false) => User.create({
       username: 'byo-user',

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -398,6 +398,99 @@ exports.requestWaitlist = async (req: any, res: any) => {
   }
 };
 
+// ── Password reset ───────────────────────────────────────────────────────────
+// Reset tokens are JWTs signed with JWT_SECRET + the user's current password
+// hash: no server-side token state, yet the token self-invalidates the moment
+// the password changes (single-use in effect). OAuth-only accounts (no
+// password) can use this flow to ADD a password — they've proven control of
+// the email, which is the same bar signup uses.
+
+const resetTokenSecret = (user: any) => `${process.env.JWT_SECRET}:${user.password || 'oauth-only'}`;
+
+// 📌 Forgot password — always 200 (no account enumeration)
+exports.forgotPassword = async (req: any, res: any) => {
+  const genericResponse = {
+    message: 'If that email has an account, a reset link is on its way.',
+  };
+  try {
+    const email = normalizeEmail(req.body?.email);
+    if (!email || !isValidEmail(email)) return res.json(genericResponse);
+
+    const user = await User.findOne({ email, isBot: { $ne: true } });
+    const hasEmailConfig = Boolean(process.env.SMTP2GO_API_KEY)
+      && Boolean(process.env.SMTP2GO_FROM_EMAIL)
+      && Boolean(process.env.FRONTEND_URL);
+    if (!user || !hasEmailConfig) {
+      if (user && !hasEmailConfig) {
+        console.warn('[forgot-password] email delivery not configured; reset link not sent for', email);
+      }
+      return res.json(genericResponse);
+    }
+
+    const token = jwt.sign(
+      { id: user._id, purpose: 'password-reset' },
+      resetTokenSecret(user),
+      { expiresIn: '1h' },
+    );
+    const resetUrl = `${process.env.FRONTEND_URL}/v2/reset-password?token=${token}`;
+    try {
+      await axios.post(SMTP2GO_SEND_URL, {
+        api_key: process.env.SMTP2GO_API_KEY,
+        to: [user.email],
+        sender: process.env.SMTP2GO_FROM_EMAIL,
+        from_name: process.env.SMTP2GO_FROM_NAME || 'Commonly',
+        subject: 'Reset your password - Commonly',
+        text_body: `Reset your Commonly password (link valid for 1 hour): ${resetUrl}\n\nIf you didn't request this, ignore this email — your password is unchanged.`,
+        html_body: `<p>Reset your Commonly password (link valid for 1 hour):</p><a href="${resetUrl}">Reset password</a><p>If you didn't request this, ignore this email — your password is unchanged.</p>`,
+      }, { timeout: 30000 });
+    } catch (sendError: any) {
+      console.error('SMTP2GO error during password reset:', sendError?.response?.data || sendError.message);
+    }
+    return res.json(genericResponse);
+  } catch (err: any) {
+    console.error('forgot-password failed:', err.message);
+    return res.json(genericResponse);
+  }
+};
+
+// 📌 Reset password — consumes the emailed token
+exports.resetPassword = async (req: any, res: any) => {
+  try {
+    const token = String(req.body?.token || '');
+    const password = String(req.body?.password || '');
+    if (!token || password.length < 8) {
+      return res.status(400).json({ error: 'A reset token and a password of at least 8 characters are required.' });
+    }
+
+    // Decode (unverified) to find the user, then verify against the
+    // per-user secret — this is what makes a used token dead: the password
+    // hash it was signed against no longer exists.
+    const decoded: any = jwt.decode(token);
+    if (!decoded?.id || decoded.purpose !== 'password-reset') {
+      return res.status(400).json({ error: 'Invalid or expired reset link.' });
+    }
+    const user = await User.findById(decoded.id);
+    if (!user) return res.status(400).json({ error: 'Invalid or expired reset link.' });
+
+    try {
+      jwt.verify(token, resetTokenSecret(user));
+    } catch {
+      return res.status(400).json({ error: 'Invalid or expired reset link.' });
+    }
+
+    user.password = password; // pre-save hook hashes
+    // Resetting via email proves address ownership — unblock login for
+    // accounts that never finished the signup verification email.
+    user.verified = true;
+    await user.save();
+
+    return res.json({ message: 'Password updated. You can sign in now.' });
+  } catch (err: any) {
+    console.error('reset-password failed:', err.message);
+    return res.status(500).json({ error: 'Server error' });
+  }
+};
+
 // 📌 Verify Email
 exports.verifyEmail = async (req: any, res: any) => {
   try {

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -58,7 +58,12 @@ const consumeDbInvitationCode = async (code: any) => {
   );
 };
 
-const isValidEmail = (email: any) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+// Length cap first: the pattern backtracks polynomially on adversarial
+// long inputs (CodeQL js/polynomial-redos), and RFC 5321 caps addresses at
+// 254 chars anyway — nothing longer is a deliverable email.
+const isValidEmail = (email: any) => typeof email === 'string'
+  && email.length <= 254
+  && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
 // Give every new signup a default private workspace pod so the BYO
 // onboarding flow has a target to install/talk-to an agent in. Matches

--- a/backend/routes/auth.ts
+++ b/backend/routes/auth.ts
@@ -19,6 +19,8 @@ const {
   getRegistrationPolicy,
   requestWaitlist,
   redeemInvitation,
+  forgotPassword,
+  resetPassword,
 } = require('../controllers/authController');
 // eslint-disable-next-line global-require
 const {
@@ -80,6 +82,18 @@ const waitlistLimiter = rateLimit({
   handler: rateLimitHandler('rate limit exceeded: 5 waitlist requests per hour'),
 });
 
+// Forgot-password sends outbound mail on every plausible hit — keep it as
+// tight as the waitlist (its own bucket so the two don't starve each other).
+const forgotLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  keyGenerator: cloudflareIpRateLimitKeyGenerator,
+  handler: rateLimitHandler('rate limit exceeded: 5 password-reset requests per hour'),
+});
+
 // Social login shares the credential-stuffing posture of /login: each attempt
 // is one provider round-trip, so 30/15min/IP leaves room for retries without
 // letting a bot farm state rows.
@@ -106,6 +120,11 @@ router.post('/login', loginLimiter, login);
 // Invitation redemption is authed and rare — the login limiter's
 // credential-stuffing posture (20/15min/IP) also bounds code-guessing here.
 router.post('/redeem-invitation', loginLimiter, auth, redeemInvitation);
+// Password reset: forgot is deliberately tight (5/hour/IP — it sends email
+// and always 200s, so it's an outbound-mail amplifier); reset consumes a
+// signed token so the login limiter's posture suffices.
+router.post('/forgot-password', forgotLimiter, forgotPassword);
+router.post('/reset-password', loginLimiter, resetPassword);
 router.post('/refresh', auth, refresh);
 router.get('/user', auth, getCurrentUser);
 router.get('/verify-email', verifyEmail);

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -54,6 +54,7 @@ interface ProfileUser {
     isFollowing?: boolean;
     followersCount?: number;
     followingCount?: number;
+    entitlements?: { cloudAgents?: boolean };
 }
 
 interface UserStats {
@@ -105,6 +106,30 @@ const UserProfile = () => {
     const [currentTab, setCurrentTab] = useState('overview');
     const [apiToken, setApiToken] = useState<string | null>(null);
     const [apiTokenCreatedAt, setApiTokenCreatedAt] = useState<string | null>(null);
+    // Hosted-agent invitation redemption (settings-surface twin of the Your
+    // Team strip — same POST /api/auth/redeem-invitation).
+    const [redeemCode, setRedeemCode] = useState('');
+    const [redeeming, setRedeeming] = useState(false);
+    const [redeemDone, setRedeemDone] = useState(false);
+    const [redeemError, setRedeemError] = useState<string | null>(null);
+
+    const handleRedeemInvitation = async () => {
+        if (!redeemCode.trim() || redeeming) return;
+        setRedeeming(true);
+        setRedeemError(null);
+        try {
+            const token = localStorage.getItem('token');
+            await axios.post('/api/auth/redeem-invitation', { invitationCode: redeemCode.trim() }, {
+                headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+            });
+            setRedeemDone(true);
+        } catch (err) {
+            const e = err as { response?: { data?: { error?: string } } };
+            setRedeemError(e.response?.data?.error || 'Could not redeem that code.');
+        } finally {
+            setRedeeming(false);
+        }
+    };
     const [isGeneratingToken, setIsGeneratingToken] = useState(false);
     const [isRevokingToken, setIsRevokingToken] = useState(false);
     const [isFollowLoading, setIsFollowLoading] = useState(false);
@@ -580,6 +605,46 @@ const UserProfile = () => {
                             <Typography variant="body2" color="text.secondary">
                                 View your account statistics and recent activity here.
                             </Typography>
+
+                            {isOwnProfile && (
+                                <Box sx={{ mt: 3 }}>
+                                    <Typography variant="h6" gutterBottom>
+                                        Hosted agents
+                                    </Typography>
+                                    {(user.entitlements?.cloudAgents || user.role === 'admin' || redeemDone) ? (
+                                        <Alert severity="success">
+                                            Hosted (cloud) agents are unlocked for this account — hire from
+                                            the agent catalog any time.
+                                        </Alert>
+                                    ) : (
+                                        <>
+                                            <Typography variant="body2" color="text.secondary" gutterBottom>
+                                                Hosted agents are invite-gated during beta. Bring-your-own
+                                                agents are always free — an invitation code unlocks
+                                                Commonly-hosted ones too.
+                                            </Typography>
+                                            <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', mt: 1, flexWrap: 'wrap' }}>
+                                                <TextField
+                                                    label="Invitation code"
+                                                    size="small"
+                                                    value={redeemCode}
+                                                    onChange={(e) => setRedeemCode(e.target.value)}
+                                                />
+                                                <Button
+                                                    variant="contained"
+                                                    disabled={redeeming || !redeemCode.trim()}
+                                                    onClick={handleRedeemInvitation}
+                                                >
+                                                    {redeeming ? 'Unlocking…' : 'Unlock'}
+                                                </Button>
+                                            </Box>
+                                            {redeemError && (
+                                                <Alert severity="error" sx={{ mt: 2 }}>{redeemError}</Alert>
+                                            )}
+                                        </>
+                                    )}
+                                </Box>
+                            )}
                         </Box>
                     )}
 

--- a/frontend/src/v2/V2App.tsx
+++ b/frontend/src/v2/V2App.tsx
@@ -8,6 +8,8 @@ import V2InviteRedeem from './components/V2InviteRedeem';
 import { useAuth } from '../context/AuthContext';
 import V2Register from './components/V2Register';
 import V2OAuthComplete from './components/V2OAuthComplete';
+import V2ForgotPassword from './components/V2ForgotPassword';
+import V2ResetPassword from './components/V2ResetPassword';
 import RegistrationInviteRequired from '../components/RegistrationInviteRequired';
 import VerifyEmail from '../components/VerifyEmail';
 import DiscordCallback from '../components/DiscordCallback';
@@ -165,6 +167,8 @@ const V2App: React.FC = () => {
           <Route path="register" element={<V2Register />} />
           <Route path="register/invite-required" element={<RegistrationInviteRequired />} />
           <Route path="oauth/complete" element={<V2OAuthComplete />} />
+          <Route path="forgot-password" element={<V2ForgotPassword />} />
+          <Route path="reset-password" element={<V2ResetPassword />} />
           <Route path="verify-email" element={<VerifyEmail />} />
           <Route path="discord/callback" element={<DiscordCallback />} />
           <Route path="discord/success" element={<DiscordCallback type="success" />} />

--- a/frontend/src/v2/components/V2ForgotPassword.tsx
+++ b/frontend/src/v2/components/V2ForgotPassword.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import axios from '../../utils/axiosConfig';
+
+// Forgot-password request form. The backend always answers generically
+// (no account enumeration), so the success state is unconditional once
+// the request lands.
+const V2ForgotPassword: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      await axios.post('/api/auth/forgot-password', { email: email.trim() });
+      setDone(true);
+    } catch (err) {
+      const e1 = err as { response?: { data?: { message?: string; error?: string } } };
+      setError(e1.response?.data?.error || e1.response?.data?.message || 'Something went wrong — try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="v2-login">
+      <form className="v2-login__card" onSubmit={handleSubmit}>
+        <div className="v2-login__brand">
+          <span className="v2-rail__brand-icon">c</span>
+          commonly
+        </div>
+        <h1 className="v2-login__title">Reset your password</h1>
+        {done ? (
+          <>
+            <p className="v2-login__subtitle">
+              If that email has an account, a reset link is on its way. The link
+              is valid for one hour.
+            </p>
+            <div className="v2-login__hint">
+              Back to <Link to="/v2/login" className="v2-login__link">sign in</Link>
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="v2-login__subtitle">
+              Enter your account email and we&apos;ll send you a reset link. If you
+              signed up with Google or GitHub, you can also just sign in with them.
+            </p>
+            <label className="v2-login__field">
+              <span className="v2-login__label">Email</span>
+              <input
+                className="v2-login__input"
+                type="email"
+                autoComplete="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </label>
+            <button type="submit" className="v2-login__submit" disabled={submitting}>
+              {submitting ? 'Sending…' : 'Send reset link'}
+            </button>
+            {error && <div className="v2-login__error">{error}</div>}
+            <div className="v2-login__hint">
+              Remembered it? <Link to="/v2/login" className="v2-login__link">Sign in</Link>
+            </div>
+          </>
+        )}
+      </form>
+    </div>
+  );
+};
+
+export default V2ForgotPassword;

--- a/frontend/src/v2/components/V2Login.tsx
+++ b/frontend/src/v2/components/V2Login.tsx
@@ -106,6 +106,10 @@ const V2Login: React.FC = () => {
           {submitting ? 'Signing in...' : 'Sign in'}
         </button>
 
+        <div className="v2-login__forgot">
+          <Link to="/v2/forgot-password" className="v2-login__link">Forgot password?</Link>
+        </div>
+
         {errorMessage && <div className="v2-login__error">{errorMessage}</div>}
 
         <V2OAuthButtons next={nextPath} />

--- a/frontend/src/v2/components/V2ResetPassword.tsx
+++ b/frontend/src/v2/components/V2ResetPassword.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import axios from '../../utils/axiosConfig';
+
+// Landing pad for the emailed reset link (/v2/reset-password?token=...).
+// Token consumption is server-side; a used or expired token surfaces the
+// backend's "Invalid or expired reset link" with a path back to /forgot.
+const V2ResetPassword: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token') || '';
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters.');
+      return;
+    }
+    if (password !== confirm) {
+      setError('Passwords do not match.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await axios.post('/api/auth/reset-password', { token, password });
+      setDone(true);
+    } catch (err) {
+      const e1 = err as { response?: { data?: { error?: string } } };
+      setError(e1.response?.data?.error || 'Reset failed — the link may have expired.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="v2-login">
+      <form className="v2-login__card" onSubmit={handleSubmit}>
+        <div className="v2-login__brand">
+          <span className="v2-rail__brand-icon">c</span>
+          commonly
+        </div>
+        <h1 className="v2-login__title">Choose a new password</h1>
+        {done ? (
+          <>
+            <p className="v2-login__subtitle">Password updated. You can sign in now.</p>
+            <Link to="/v2/login" className="v2-login__submit" style={{ textAlign: 'center', textDecoration: 'none', display: 'block' }}>
+              Go to sign in
+            </Link>
+          </>
+        ) : !token ? (
+          <>
+            <p className="v2-login__subtitle">
+              This page needs the reset link from your email. Request a new one below.
+            </p>
+            <div className="v2-login__hint">
+              <Link to="/v2/forgot-password" className="v2-login__link">Send me a reset link</Link>
+            </div>
+          </>
+        ) : (
+          <>
+            <label className="v2-login__field">
+              <span className="v2-login__label">New password</span>
+              <input
+                className="v2-login__input"
+                type="password"
+                autoComplete="new-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+            </label>
+            <label className="v2-login__field">
+              <span className="v2-login__label">Confirm password</span>
+              <input
+                className="v2-login__input"
+                type="password"
+                autoComplete="new-password"
+                value={confirm}
+                onChange={(e) => setConfirm(e.target.value)}
+                required
+              />
+            </label>
+            <button type="submit" className="v2-login__submit" disabled={submitting}>
+              {submitting ? 'Updating…' : 'Update password'}
+            </button>
+            {error && (
+              <div className="v2-login__error">
+                {error}
+                {' '}
+                <Link to="/v2/forgot-password" className="v2-login__link">Request a new link</Link>
+              </div>
+            )}
+          </>
+        )}
+      </form>
+    </div>
+  );
+};
+
+export default V2ResetPassword;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -3431,6 +3431,12 @@
   font-size: 12px;
 }
 
+.v2-login__forgot {
+  margin-top: 8px;
+  font-size: 12px;
+  text-align: right;
+}
+
 /* "or" separator between password form and social buttons. NOT
    .v2-login__divider — that name is already taken by the invite-required
    page's bordered section break (defined later in this file, so it would


### PR DESCRIPTION
Two pre-launch gaps:

## Password reset (didn't exist)

- `POST /api/auth/forgot-password`: generic response always (no account enumeration), tight 5/hour/IP limiter (it's an outbound-mail amplifier), SMTP2GO email with a 1-hour link.
- `POST /api/auth/reset-password`: the token is a JWT signed with `JWT_SECRET + current password hash` — **self-invalidating on use** with zero server-side token state. Reset also marks the account verified (email ownership proven), and OAuth-only accounts can use it to *add* a password.
- `/v2/forgot-password` + `/v2/reset-password` pages in the login visual language; "Forgot password?" link on the sign-in card.

## Invite redemption in Settings

The post-signup redemption already existed on Your Team (live-verified during the smoke) — but it wasn't found when looked for, which is a discoverability bug. Settings → Overview now carries a **Hosted agents** section: unlocked confirmation for entitled accounts, or an invitation-code field hitting the same `POST /api/auth/redeem-invitation`.

## Proof

4 new reset tests (no-enumeration, happy path + verified flip, wrong-purpose/short-password rejection, signature-failure leaves the stored hash untouched); controller suites 98 green, frontend 199 green. Browser-verified all four surfaces. Will e2e the real email loop (Gmail inbox → link → new password → login) post-deploy, same as the verification-email smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9