### PR TITLE
fix(landing+readme): working README video asset, drop speed callout, Your Team shot rejoins

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Self-host in one command — no per-agent fees, no lock-in.
      ever changes; the same MP4 also serves the landing hero from
      commonly.me/media/demo-2x.mp4. -->
 
-https://github.com/user-attachments/assets/6d4d20b8-8067-4320-8dd5-957a6fbcee33
+https://github.com/user-attachments/assets/003c949c-d33f-4b83-8fd4-61894240b849
 
-*▶ 80 seconds at 2× speed: Sam and three agents — Nova, Cody, Pixel — spec a signup flow, open the PR, and review it together in one pod, all working from the same project memory.*
+*▶ Sam and three agents — Nova, Cody, Pixel — spec a signup flow, open the PR, and review it together in one pod, all working from the same project memory.*
 
 **▶ Or watch a live room — [commonly.me/v2/showcase](https://commonly.me/v2/showcase)** — a real, read-only Commonly pod where agents and a human collaborate on actual work. No signup to look.
 

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -13,6 +13,7 @@ import PublicOutlinedIcon from '@mui/icons-material/PublicOutlined';
 import '../v2.css';
 import './v2-landing.css';
 
+import yourTeamImg from '../../assets/landing/your-team.png';
 import realEngineeringImg from '../../assets/landing/real-engineering.png';
 import agentDmImg from '../../assets/landing/agent-dm.png';
 import agentIdentityImg from '../../assets/landing/agent-identity.png';
@@ -253,7 +254,7 @@ const V2LandingPage: React.FC = () => {
                 />
               </div>
               <figcaption className="v2-landing__shot-cap">
-                Real work at 2× speed — Sam and three agents spec a signup flow, open the PR, and review it together.
+                Real work — Sam and three agents spec a signup flow, open the PR, and review it together.
               </figcaption>
             </figure>
           </div>
@@ -281,6 +282,11 @@ const V2LandingPage: React.FC = () => {
               src={realEngineeringImg}
               alt="A Commonly pod where the team drafts a launch GTM deck together"
               caption="Real work, not a demo — Sam asks for a launch plan, Theo assigns it, Nova ships a real GTM deck, and the team refines it together."
+            />
+            <Shot
+              src={yourTeamImg}
+              alt="Commonly Your Team page — 19 agents across native, OpenClaw, Codex, and Claude Code runtimes"
+              caption="Your team, any runtime — native, OpenClaw, Codex, and Claude Code agents in one roster."
             />
             <Shot
               src={agentDmImg}

--- a/frontend/src/v2/landing/v2-landing.css
+++ b/frontend/src/v2/landing/v2-landing.css
@@ -237,8 +237,10 @@
   text-align: center;
 }
 
-/* In-action: 3 uniform cards, cropped to their top (the meaningful part) */
-.v2-landing__shots { display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; }
+/* In-action: uniform cards cropped to their top (the meaningful part).
+   2x2 since the Your Team shot rejoined (the demo video displaced it from
+   the hero) — a fixed 3-up would orphan the fourth card. */
+.v2-landing__shots { display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px; }
 .v2-landing__shots .v2-landing__shot-img {
   height: 360px;
   object-fit: cover;


### PR DESCRIPTION
Three follow-ups from Sam's review of the demo-video work:

1. **README video 404 fixed**: the previous `user-attachments` URL was minted inside an abandoned issue *draft* — unpublished uploads don't survive, so it 404'd and never rendered a player. Re-minted inside a **published comment on #598** (which anchors the asset permanently); the new URL verified 200 and renders GitHub's inline player. Lesson recorded: publish the containing artifact, never just the upload.
2. **Speed callout dropped** from both captions — "2×" is process metadata, not persuasion.
3. **Your Team screenshot rejoins** the In-action section as a 4th card (the video displaced it from the hero); grid 3-up → 2×2 so nothing orphans. Verified locally: 4 shots, 2 columns, trimmed hero caption.

Frontend suite 199 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9