### PR TITLE
fix(landing): imperative video autoplay for iOS + README mobile-app fallback link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Self-host in one command — no per-agent fees, no lock-in.
 
 https://github.com/user-attachments/assets/003c949c-d33f-4b83-8fd4-61894240b849
 
-*▶ Sam and three agents — Nova, Cody, Pixel — spec a signup flow, open the PR, and review it together in one pod, all working from the same project memory.*
+*▶ Sam and three agents — Nova, Cody, Pixel — spec a signup flow, open the PR, and review it together in one pod, all working from the same project memory. Player not showing (GitHub mobile app)? [Watch it here](https://commonly.me/media/demo-2x.mp4).*
 
 **▶ Or watch a live room — [commonly.me/v2/showcase](https://commonly.me/v2/showcase)** — a real, read-only Commonly pod where agents and a human collaborate on actual work. No signup to look.
 

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
 import { useAuth } from '../../context/AuthContext';
@@ -129,6 +129,15 @@ const V2LandingPage: React.FC = () => {
   // hasn't asked for reduced motion — so no-JS, old browsers, and
   // reduced-motion users always get fully visible content.
   const [motion, setMotion] = useState(false);
+  // Hero demo video. Autoplay is driven imperatively, NOT via the autoPlay
+  // prop: React never renders the `muted` attribute into the DOM
+  // (facebook/react#10389), and iOS Safari refuses autoplay for any video
+  // it doesn't see as muted — so the prop-only version silently showed the
+  // poster on iPhones (2026-07-03 field report). Setting muted via the ref
+  // and calling play() explicitly satisfies the mobile autoplay policy;
+  // the rejection catch keeps the poster for Low Power Mode / data-saver
+  // visitors, which is the correct fallback anyway.
+  const demoVideoRef = useRef<HTMLVideoElement | null>(null);
 
   // Primary CTA: signed-in → the shell; signed-out → /v2/register. Since
   // registration opened (2026-07-03: invite codes gate cloud agents, not
@@ -173,6 +182,15 @@ const V2LandingPage: React.FC = () => {
     nodes.forEach((n) => io.observe(n));
     return () => io.disconnect();
   }, [motion, stats]);
+
+  useEffect(() => {
+    const v = demoVideoRef.current;
+    if (!v || !motion) return;
+    v.muted = true;
+    v.defaultMuted = true;
+    const p = v.play();
+    if (p && typeof p.catch === 'function') p.catch(() => { /* poster stays */ });
+  }, [motion]);
 
   const hasStats = Boolean(stats && (stats.activePods || stats.activeAgents || stats.registeredUsers));
 
@@ -242,10 +260,10 @@ const V2LandingPage: React.FC = () => {
                   <span className="v2-landing__shot-dot" />
                 </div>
                 <video
+                  ref={demoVideoRef}
                   className="v2-landing__shot-img"
                   src="/media/demo-2x.mp4"
                   poster="/media/demo-poster.jpg"
-                  autoPlay={motion}
                   muted
                   loop
                   playsInline


### PR DESCRIPTION
Field report from Sam's phone: hero demo stuck on the poster; README showing a URL instead of the player.

## Landing (real bug, fixed)

React never renders the `muted` **attribute** into the DOM (facebook/react#10389) and iOS Safari refuses autoplay for any video it doesn't see as muted — plus our `autoPlay={motion}` flipped on after mount, which iOS ignores without an explicit `play()`. Autoplay is now imperative via a ref (`muted`/`defaultMuted` + `play()` with the rejection swallowed — Low Power Mode keeps the poster, the right fallback). Verified locally at 390px: muted attribute present in the DOM, playback starts.

## README (app limitation, mitigated)

The served HTML **does** contain the inline `<video>` player — desktop and mobile *web* render it. The GitHub **mobile app** never renders markdown video players; the caption now carries a "watch it here" link to `commonly.me/media/demo-2x.mp4` for app users.

Frontend suite 199 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9