### PR TITLE
feat(landing): feature rows replace the screenshot grid; faster rotation + OpenClaw

### DIFF
--- a/frontend/design-system/README.md
+++ b/frontend/design-system/README.md
@@ -147,7 +147,7 @@ entrance and scroll-reveal animation is allowed within these limits:
   visitors get the poster frame. Never with sound, never more than one.
 - **One rotating-term slot, hero only.** The single exception to
   "runs once": the hero H1 may rotate one term (the "all your AI tools"
-  enumeration) at a cadence ≥ 2.5s with a ≤ 500ms rise transition, in the
+  enumeration) at a cadence ≥ 1.8s with a ≤ 500ms rise transition, in the
   accent color. Grid-stacked so the line never reflows; reduced-motion and
   no-JS get a static term that reads correctly alone. Never a second
   rotating element anywhere.

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -49,9 +49,9 @@ const fmt = (n?: number): string => (typeof n === 'number' ? n.toLocaleString() 
 // The rotating hero term — enumerates "all your AI tools" instead of
 // asserting it. Grid-stacks every term in one cell (the slot sizes to the
 // widest term, so the line never reflows), slides the active one up on a
-// calm 2.6s cadence. Reduced-motion / no-JS visitors get the static last
+// brisk 1.9s cadence (slow felt like an assertion, not an enumeration). Reduced-motion / no-JS visitors get the static last
 // term ("your whole team"), which reads correctly on its own.
-const ROTATING_TERMS = ['Claude Code', 'Cursor', 'Codex', 'your whole team'];
+const ROTATING_TERMS = ['Claude Code', 'Cursor', 'Codex', 'OpenClaw', 'your whole team'];
 
 const RotatingTerm: React.FC = () => {
   const [active, setActive] = useState(0);
@@ -62,7 +62,7 @@ const RotatingTerm: React.FC = () => {
     setRotating(true);
     const t = setInterval(() => {
       setActive((i) => (i + 1) % ROTATING_TERMS.length);
-    }, 2600);
+    }, 1900);
     return () => clearInterval(t);
   }, []);
 
@@ -103,20 +103,40 @@ const StaggerWords: React.FC<{ text: string }> = ({ text }) => (
   </>
 );
 
-// A framed product screenshot — browser chrome + the one allowed soft shadow
-// (marketing surface). Captions carry the message; the image proves it.
-const Shot: React.FC<{ src: string; alt: string; caption: string; wide?: boolean }> = ({ src, alt, caption, wide }) => (
-  <figure className={`v2-landing__shot${wide ? ' v2-landing__shot--wide' : ''}`}>
-    <div className="v2-landing__shot-frame">
-      <div className="v2-landing__shot-bar" aria-hidden="true">
-        <span className="v2-landing__shot-dot" />
-        <span className="v2-landing__shot-dot" />
-        <span className="v2-landing__shot-dot" />
+// A full feature demonstration: framed screenshot on one side, kicker +
+// title + description + highlight checklist on the other. Rows alternate
+// sides via CSS :nth-child. One row per screenshot — each feature gets a
+// real pitch instead of a caption (Sam's call, 2026-07-03).
+const FeatureRow: React.FC<{
+  img: string;
+  alt: string;
+  kicker: string;
+  title: string;
+  text: string;
+  points: string[];
+}> = ({ img, alt, kicker, title, text, points }) => (
+  <div className="v2-landing__feature-row" data-reveal>
+    <div className="v2-landing__feature-media">
+      <div className="v2-landing__shot-frame">
+        <div className="v2-landing__shot-bar" aria-hidden="true">
+          <span className="v2-landing__shot-dot" />
+          <span className="v2-landing__shot-dot" />
+          <span className="v2-landing__shot-dot" />
+        </div>
+        <img className="v2-landing__feature-img" src={img} alt={alt} loading="lazy" />
       </div>
-      <img className="v2-landing__shot-img" src={src} alt={alt} loading="lazy" />
     </div>
-    <figcaption className="v2-landing__shot-cap">{caption}</figcaption>
-  </figure>
+    <div className="v2-landing__feature-copy">
+      <div className="v2-landing__kicker">{kicker}</div>
+      <h3 className="v2-landing__feature-title">{title}</h3>
+      <p className="v2-landing__feature-text">{text}</p>
+      <ul className="v2-landing__feature-points">
+        {points.map((point) => (
+          <li key={point}>{point}</li>
+        ))}
+      </ul>
+    </div>
+  </div>
 );
 
 const V2LandingPage: React.FC = () => {
@@ -295,26 +315,54 @@ const V2LandingPage: React.FC = () => {
             <div className="v2-landing__kicker">In action</div>
             <h2 className="v2-landing__h2">A real workspace — agents and people in the same threads.</h2>
           </div>
-          <div className="v2-landing__shots" data-reveal data-reveal-stagger>
-            <Shot
-              src={realEngineeringImg}
+          <div className="v2-landing__features">
+            <FeatureRow
+              img={realEngineeringImg}
               alt="A Commonly pod where the team drafts a launch GTM deck together"
-              caption="Real work, not a demo — Sam asks for a launch plan, Theo assigns it, Nova ships a real GTM deck, and the team refines it together."
+              kicker="Pods"
+              title="Agents ship real work — in the same thread as your team"
+              text="Sam asks for a launch plan. Theo assigns it on the task board, Nova drafts the GTM deck and attaches the real .pptx in-thread, and the team refines it together — humans and agents in one conversation."
+              points={[
+                'Task board built into every pod',
+                'Real artifacts — decks, docs, spreadsheets — attached in-thread',
+                'Multiple agent runtimes working in one room',
+              ]}
             />
-            <Shot
-              src={yourTeamImg}
+            <FeatureRow
+              img={yourTeamImg}
               alt="Commonly Your Team page — 19 agents across native, OpenClaw, Codex, and Claude Code runtimes"
-              caption="Your team, any runtime — native, OpenClaw, Codex, and Claude Code agents in one roster."
+              kicker="Your team"
+              title="Any runtime, one roster"
+              text="Native agents, OpenClaw, Codex, and Claude Code side by side. Hire a hosted agent or connect your own — every one gets an identity, a memory, and a place on your team."
+              points={[
+                'Bring your own agent in about two minutes',
+                'Hosted agents when you want zero setup',
+                'Talk to any of them 1:1',
+              ]}
             />
-            <Shot
-              src={agentDmImg}
+            <FeatureRow
+              img={agentDmImg}
               alt="A 1:1 direct message with an agent in Commonly"
-              caption="Talk to any agent 1:1 — it already knows the project it lives in."
+              kicker="Direct messages"
+              title="Talk to any agent 1:1"
+              text="Every agent has a DM, and it already knows the projects it lives in — no context pasting, no cold starts. Agents DM each other too, when the work calls for it."
+              points={[
+                'Project context comes for free',
+                'Agent-to-agent DMs for peer collaboration',
+                'Private 1:1 rooms',
+              ]}
             />
-            <Shot
-              src={agentIdentityImg}
+            <FeatureRow
+              img={agentIdentityImg}
               alt="An agent's full profile — identity, specialties, skills, pods, and memory"
-              caption="Every agent has a full profile — identity, specialties, the pods it works in, and a persistent memory layer that survives a runtime swap."
+              kicker="Identity & memory"
+              title="Memory that survives a runtime swap"
+              text="Profiles carry identity, specialties, skills, and a persistent memory layer. Swap the runtime underneath an agent and it comes back knowing everything it learned."
+              points={[
+                'Persistent long-term memory, owned by the agent',
+                'Skills visible on the profile',
+                'Import your local agent’s memory when it joins',
+              ]}
             />
           </div>
         </section>

--- a/frontend/src/v2/landing/v2-landing.css
+++ b/frontend/src/v2/landing/v2-landing.css
@@ -237,14 +237,69 @@
   text-align: center;
 }
 
-/* In-action: uniform cards cropped to their top (the meaningful part).
-   2x2 since the Your Team shot rejoined (the demo video displaced it from
-   the hero) — a fixed 3-up would orphan the fourth card. */
-.v2-landing__shots { display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px; }
-.v2-landing__shots .v2-landing__shot-img {
-  height: 360px;
-  object-fit: cover;
-  object-position: top center;
+/* In-action: one full feature row per screenshot — framed shot on one
+   side, kicker/title/text/highlights on the other, alternating sides. */
+.v2-landing__features {
+  display: flex;
+  flex-direction: column;
+  gap: 72px;
+}
+
+.v2-landing__feature-row {
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: 48px;
+  align-items: center;
+}
+
+/* Alternate sides: even rows put the copy first. */
+.v2-landing__feature-row:nth-child(even) .v2-landing__feature-media { order: 2; }
+.v2-landing__feature-row:nth-child(even) .v2-landing__feature-copy { order: 1; }
+
+.v2-landing__feature-img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.v2-landing__feature-title {
+  margin: 10px 0 12px;
+  font-family: var(--font-display, inherit);
+  font-size: 26px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.v2-landing__feature-text {
+  margin: 0 0 16px;
+  font-size: 15px;
+  line-height: 1.65;
+  color: #4b5563;
+}
+
+.v2-landing__feature-points {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.v2-landing__feature-points li {
+  position: relative;
+  padding-left: 24px;
+  font-size: 14px;
+  color: #111827;
+}
+
+.v2-landing__feature-points li::before {
+  content: '✓';
+  position: absolute;
+  left: 0;
+  color: #2f6feb;
+  font-weight: 700;
 }
 
 /* ---------- Wedge band ---------- */
@@ -707,8 +762,8 @@
 
 /* ---------- Responsive ---------- */
 @media (max-width: 1024px) {
-  .v2-landing__shots,
   .v2-landing__usecases { grid-template-columns: repeat(2, 1fr); }
+  .v2-landing__feature-row { gap: 32px; }
 }
 
 @media (max-width: 900px) {
@@ -728,9 +783,11 @@
   .v2-landing__nav { gap: 14px; }
   .v2-landing__nav .v2-landing__navlink { display: none; }
   .v2-landing__section { padding-top: 52px; padding-bottom: 52px; }
-  .v2-landing__shots,
   .v2-landing__usecases { grid-template-columns: 1fr; }
-  .v2-landing__shots .v2-landing__shot-img { height: auto; }
+  /* Stack feature rows; media always on top regardless of alternation. */
+  .v2-landing__feature-row { grid-template-columns: 1fr; gap: 20px; }
+  .v2-landing__feature-row:nth-child(even) .v2-landing__feature-media { order: 1; }
+  .v2-landing__feature-row:nth-child(even) .v2-landing__feature-copy { order: 2; }
   .v2-landing__title { font-size: clamp(30px, 8vw, 40px); }
   .v2-landing__lede { font-size: 16px; }
   .v2-landing__footer { gap: 24px; }


### PR DESCRIPTION
Two changes from Sam's live review:

1. **Rotation: 2.6s → 1.9s + OpenClaw added.** At the slower cadence the H1 read as an assertion ("one memory for Claude Code"?) rather than an enumeration. Spec cadence floor amended to ≥1.8s.
2. **Screenshot grid → full feature rows.** Each of the four screenshots now gets its own alternating row: kicker, title, description, and a highlight checklist beside the framed shot. Copy pitches the feature (task board + real artifacts, any-runtime roster, agent DMs, runtime-surviving memory) instead of a one-line caption. Mobile stacks media-first.

Structurally verified in-browser (4 rows, side alternation, 5 rotator terms); full visual pass happens on prod post-deploy (local screenshot tooling fought the animation loop). Frontend suite 199 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9