### PR TITLE
fix(landing): rotator cadence 1.9s → 1.4s

### DIFF
--- a/frontend/design-system/README.md
+++ b/frontend/design-system/README.md
@@ -147,7 +147,7 @@ entrance and scroll-reveal animation is allowed within these limits:
   visitors get the poster frame. Never with sound, never more than one.
 - **One rotating-term slot, hero only.** The single exception to
   "runs once": the hero H1 may rotate one term (the "all your AI tools"
-  enumeration) at a cadence ≥ 1.8s with a ≤ 500ms rise transition, in the
+  enumeration) at a cadence ≥ 1.2s with a ≤ 500ms rise transition, in the
   accent color. Grid-stacked so the line never reflows; reduced-motion and
   no-JS get a static term that reads correctly alone. Never a second
   rotating element anywhere.

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -49,7 +49,7 @@ const fmt = (n?: number): string => (typeof n === 'number' ? n.toLocaleString() 
 // The rotating hero term — enumerates "all your AI tools" instead of
 // asserting it. Grid-stacks every term in one cell (the slot sizes to the
 // widest term, so the line never reflows), slides the active one up on a
-// brisk 1.9s cadence (slow felt like an assertion, not an enumeration). Reduced-motion / no-JS visitors get the static last
+// brisk 1.4s cadence (slow felt like an assertion, not an enumeration). Reduced-motion / no-JS visitors get the static last
 // term ("your whole team"), which reads correctly on its own.
 const ROTATING_TERMS = ['Claude Code', 'Cursor', 'Codex', 'OpenClaw', 'your whole team'];
 
@@ -62,7 +62,7 @@ const RotatingTerm: React.FC = () => {
     setRotating(true);
     const t = setInterval(() => {
       setActive((i) => (i + 1) % ROTATING_TERMS.length);
-    }, 1900);
+    }, 1400);
     return () => clearInterval(t);
   }, []);
 

--- a/frontend/src/v2/landing/v2-landing.css
+++ b/frontend/src/v2/landing/v2-landing.css
@@ -942,6 +942,6 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .v2-landing__rotator-term {
-    transition: opacity 450ms ease-out, transform 450ms ease-out;
+    transition: opacity 350ms ease-out, transform 350ms ease-out;
   }
 }


### PR DESCRIPTION
Faster enumeration per Sam's review — each term now holds ~1s fully visible (rise trimmed 450→350ms to keep motion proportionate). Spec floor amended to ≥1.2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9