### PR TITLE
chore(legal): copyright notices — footer © line, NOTICE file, package license fields

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+Commonly
+Copyright 2026 Commonly (Team-Commonly) and contributors
+
+This product is licensed under the Apache License, Version 2.0.
+The Commonly name, logo, and brand assets are trademarks of the
+Commonly project and are not licensed under the Apache License.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "backend",
   "version": "1.1.0",
+  "license": "Apache-2.0",
   "main": "server.js",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@commonly/cli",
   "version": "0.1.0",
-  "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
+  "license": "Apache-2.0",
+  "description": "The Commonly CLI \u2014 connect agents, manage pods, iterate fast",
   "type": "module",
   "bin": {
     "commonly": "./src/index.js"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,92 +1,93 @@
 {
-    "name": "frontend",
-    "version": "1.1.0",
-    "private": true,
-    "dependencies": {
-        "@dnd-kit/core": "^6.3.1",
-        "@dnd-kit/sortable": "^8.0.0",
-        "@emotion/react": "^11.10.6",
-        "@emotion/styled": "^11.10.6",
-        "@mui/icons-material": "^5.11.16",
-        "@mui/material": "^5.12.1",
-        "axios": "^1.3.4",
-        "chart.js": "^4.5.0",
-        "d3": "^7.9.0",
-        "date-fns": "^2.30.0",
-        "emoji-picker-react": "^4.4.9",
-        "mammoth": "^1.12.0",
-        "node-emoji": "^2.2.0",
-        "papaparse": "^5.5.3",
-        "react": "^18.2.0",
-        "react-chartjs-2": "^5.3.0",
-        "react-dom": "^18.2.0",
-        "react-markdown": "^10.1.0",
-        "react-router-dom": "^6.11.0",
-        "socket.io-client": "^4.7.2",
-        "xlsx": "^0.18.5"
+  "name": "frontend",
+  "version": "1.1.0",
+  "license": "Apache-2.0",
+  "private": true,
+  "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@emotion/react": "^11.10.6",
+    "@emotion/styled": "^11.10.6",
+    "@mui/icons-material": "^5.11.16",
+    "@mui/material": "^5.12.1",
+    "axios": "^1.3.4",
+    "chart.js": "^4.5.0",
+    "d3": "^7.9.0",
+    "date-fns": "^2.30.0",
+    "emoji-picker-react": "^4.4.9",
+    "mammoth": "^1.12.0",
+    "node-emoji": "^2.2.0",
+    "papaparse": "^5.5.3",
+    "react": "^18.2.0",
+    "react-chartjs-2": "^5.3.0",
+    "react-dom": "^18.2.0",
+    "react-markdown": "^10.1.0",
+    "react-router-dom": "^6.11.0",
+    "socket.io-client": "^4.7.2",
+    "xlsx": "^0.18.5"
+  },
+  "scripts": {
+    "start": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "jest --watchAll=false --forceExit",
+    "test:coverage": "jest --coverage --watchAll=false --forceExit",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
+    "lint:fix": "eslint src --ext .js,.jsx,.ts,.tsx --fix"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.0",
+    "@babel/preset-env": "^7.24.0",
+    "@babel/preset-react": "^7.24.0",
+    "@babel/preset-typescript": "^7.24.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^30.0.0",
+    "@types/papaparse": "^5.5.2",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "babel-jest": "^29.7.0",
+    "eslint": "^8.56.0",
+    "eslint-config-react-app": "^7.0.1",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.19"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "transform": {
+      "^.+\\.(js|jsx|ts|tsx)$": "babel-jest"
     },
-    "scripts": {
-        "start": "vite",
-        "build": "vite build",
-        "preview": "vite preview",
-        "test": "jest --watchAll=false --forceExit",
-        "test:coverage": "jest --coverage --watchAll=false --forceExit",
-        "typecheck": "tsc --noEmit",
-        "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
-        "lint:fix": "eslint src --ext .js,.jsx,.ts,.tsx --fix"
+    "moduleNameMapper": {
+      "^react-markdown$": "<rootDir>/src/__mocks__/react-markdown.js",
+      "^d3$": "<rootDir>/src/__mocks__/d3.js",
+      "\\.(css|less|scss|sass)$": "<rootDir>/src/__mocks__/fileMock.js",
+      "\\.(jpg|jpeg|png|gif|svg|ttf|woff|woff2)$": "<rootDir>/src/__mocks__/fileMock.js"
     },
-    "devDependencies": {
-        "@babel/core": "^7.24.0",
-        "@babel/preset-env": "^7.24.0",
-        "@babel/preset-react": "^7.24.0",
-        "@babel/preset-typescript": "^7.24.0",
-        "@testing-library/dom": "^10.4.1",
-        "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.3.0",
-        "@testing-library/user-event": "^14.6.1",
-        "@types/jest": "^30.0.0",
-        "@types/papaparse": "^5.5.2",
-        "@types/react": "^18.2.0",
-        "@types/react-dom": "^18.2.0",
-        "@vitejs/plugin-react": "^4.3.4",
-        "babel-jest": "^29.7.0",
-        "eslint": "^8.56.0",
-        "eslint-config-react-app": "^7.0.1",
-        "eslint-plugin-react": "^7.33.2",
-        "eslint-plugin-react-hooks": "^4.6.0",
-        "jest": "^29.7.0",
-        "jest-environment-jsdom": "^29.7.0",
-        "typescript": "^5.6.3",
-        "vite": "^5.4.19"
-    },
-    "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
-    },
-    "jest": {
-        "testEnvironment": "jsdom",
-        "transform": {
-            "^.+\\.(js|jsx|ts|tsx)$": "babel-jest"
-        },
-        "moduleNameMapper": {
-            "^react-markdown$": "<rootDir>/src/__mocks__/react-markdown.js",
-            "^d3$": "<rootDir>/src/__mocks__/d3.js",
-            "\\.(css|less|scss|sass)$": "<rootDir>/src/__mocks__/fileMock.js",
-            "\\.(jpg|jpeg|png|gif|svg|ttf|woff|woff2)$": "<rootDir>/src/__mocks__/fileMock.js"
-        },
-        "transformIgnorePatterns": [
-            "node_modules/(?!(axios)/)"
-        ],
-        "setupFilesAfterEnv": [
-            "<rootDir>/src/setupTests.ts"
-        ]
-    }
+    "transformIgnorePatterns": [
+      "node_modules/(?!(axios)/)"
+    ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/src/setupTests.ts"
+    ]
+  }
 }

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -659,6 +659,14 @@ const V2LandingPage: React.FC = () => {
             <a className="v2-landing__footer-link" href={`${REPO}/blob/main/LICENSE`} target="_blank" rel="noreferrer">License (Apache-2.0)</a>
           </div>
         </div>
+        {/* Copyright is retained under Apache-2.0 — the license grants
+            rights, it doesn't abandon them. Deliberately NOT "all rights
+            reserved": that phrasing reads as contradicting the grant. The
+            name/logo stay trademarks (see NOTICE). */}
+        <div className="v2-landing__footer-legal">
+          © {new Date().getFullYear()} Commonly. Code licensed under Apache-2.0;
+          the Commonly name and logo are trademarks of the Commonly project.
+        </div>
       </footer>
     </div>
   );

--- a/frontend/src/v2/landing/v2-landing.css
+++ b/frontend/src/v2/landing/v2-landing.css
@@ -945,3 +945,12 @@
     transition: opacity 350ms ease-out, transform 350ms ease-out;
   }
 }
+
+/* Footer legal line — © + license + trademark note. */
+.v2-landing__footer-legal {
+  margin-top: 28px;
+  padding-top: 20px;
+  border-top: 1px solid var(--v2-border-soft);
+  font-size: 12px;
+  color: var(--v2-text-tertiary);
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "commonly",
   "version": "1.1.0",
+  "license": "Apache-2.0",
   "private": true,
   "scripts": {
     "start": "docker-compose up",


### PR DESCRIPTION
Sam's pre-launch check surfaced real gaps: **no © line anywhere, no NOTICE file, and all four `package.json` files missing the `license` field** (npm treats that as unlicensed — contradicting the OSS story).

- **Footer**: `© 2026 Commonly. Code licensed under Apache-2.0; the Commonly name and logo are trademarks of the Commonly project.` — deliberately *not* "all rights reserved": copyright is retained automatically (the license grants rights, it doesn't abandon them), and that phrase reads as contradicting the Apache grant. The trademark note is the assertion actually worth making: **code open, brand not**.
- **NOTICE** file (Apache-conventional home for the copyright/trademark statement).
- `"license": "Apache-2.0"` in root/backend/frontend/cli package.json.

Frontend suite 199 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9