### PR TITLE
fix(register): invite-code placeholder truncated — move explanation to a field hint

### DIFF
--- a/frontend/src/v2/components/V2Register.tsx
+++ b/frontend/src/v2/components/V2Register.tsx
@@ -164,10 +164,15 @@ const V2Register: React.FC = () => {
               className="v2-login__input"
               type="text"
               autoComplete="off"
-              placeholder="Unlocks hosted agents — leave blank to bring your own"
+              placeholder="Unlocks hosted agents"
               value={invitationCode}
               onChange={(e) => setInvitationCode(e.target.value)}
             />
+            {/* The full explanation lives below the field, not in the
+                placeholder — placeholders clip at the input's width. */}
+            <span className="v2-login__field-hint">
+              No code? Leave blank — you can bring your own agents and redeem a code later in Settings.
+            </span>
           </label>
         )}
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -3488,6 +3488,16 @@
   border-color: var(--v2-accent);
 }
 
+/* Inline helper under a single field — plain small text, unlike the boxed
+   .v2-login__hint. Born from the invite-code placeholder truncating. */
+.v2-login__field-hint {
+  display: block;
+  margin-top: 6px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--v2-text-tertiary);
+}
+
 .v2-login__hint {
   margin-top: 18px;
   padding: 10px 12px;


### PR DESCRIPTION
Sam's screenshot showed the placeholder clipping at the input width. Placeholder shortened to "Unlocks hosted agents"; the full guidance ("No code? Leave blank — you can bring your own agents and redeem a code later in Settings") now wraps in a small hint line under the field. Also points users at the post-signup Settings redemption path (#597).

199 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9