### PR TITLE
fix(auth): use the real brand mark on auth pages (was a letter 'c')

### DIFF
--- a/frontend/src/v2/components/V2AuthBrand.tsx
+++ b/frontend/src/v2/components/V2AuthBrand.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+// The one brand row for auth-card pages (login / register / forgot / reset /
+// oauth-complete). Same mark as the nav rail and the landing page — the
+// open-C with three dots — NOT a letter "c" (the old auth pages drifted to a
+// plain letter, which read as a different logo next to every other surface).
+// Wordmark stays lowercase to match the rail (app chrome, not marketing).
+const V2AuthBrand: React.FC = () => (
+  <div className="v2-login__brand">
+    <span className="v2-rail__brand-icon" aria-label="Commonly">
+      <svg width="18" height="18" viewBox="0 0 64 64" fill="none" aria-hidden="true">
+        <path d="M 50 17.7 A 22 22 0 1 0 50 46.3" stroke="currentColor" strokeWidth="9" strokeLinecap="round" />
+        <circle cx="25" cy="32" r="2.4" fill="currentColor" />
+        <circle cx="32" cy="32" r="2.4" fill="currentColor" />
+        <circle cx="39" cy="32" r="2.4" fill="currentColor" />
+      </svg>
+    </span>
+    commonly
+  </div>
+);
+
+export default V2AuthBrand;

--- a/frontend/src/v2/components/V2ForgotPassword.tsx
+++ b/frontend/src/v2/components/V2ForgotPassword.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import axios from '../../utils/axiosConfig';
+import V2AuthBrand from './V2AuthBrand';
 
 // Forgot-password request form. The backend always answers generically
 // (no account enumeration), so the success state is unconditional once
@@ -29,10 +30,7 @@ const V2ForgotPassword: React.FC = () => {
   return (
     <div className="v2-login">
       <form className="v2-login__card" onSubmit={handleSubmit}>
-        <div className="v2-login__brand">
-          <span className="v2-rail__brand-icon">c</span>
-          commonly
-        </div>
+        <V2AuthBrand />
         <h1 className="v2-login__title">Reset your password</h1>
         {done ? (
           <>

--- a/frontend/src/v2/components/V2Login.tsx
+++ b/frontend/src/v2/components/V2Login.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import V2OAuthButtons from './V2OAuthButtons';
+import V2AuthBrand from './V2AuthBrand';
 
 interface LocationState {
   from?: { pathname?: string };
@@ -65,10 +66,7 @@ const V2Login: React.FC = () => {
   return (
     <div className="v2-login">
       <form className="v2-login__card" onSubmit={handleSubmit}>
-        <div className="v2-login__brand">
-          <span className="v2-rail__brand-icon">c</span>
-          commonly
-        </div>
+        <V2AuthBrand />
         <h1 className="v2-login__title">Sign in</h1>
         <p className="v2-login__subtitle">
           Commonly is the shared space where agents and humans collaborate.

--- a/frontend/src/v2/components/V2OAuthComplete.tsx
+++ b/frontend/src/v2/components/V2OAuthComplete.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import axios from '../../utils/axiosConfig';
+import V2AuthBrand from './V2AuthBrand';
 
 // Landing pad for the OAuth redirect chain. The backend callback hands us a
 // short-lived one-time code (never the JWT itself — it would end up in
@@ -40,10 +41,7 @@ const V2OAuthComplete: React.FC = () => {
   return (
     <div className="v2-login">
       <div className="v2-login__card">
-        <div className="v2-login__brand">
-          <span className="v2-rail__brand-icon">c</span>
-          commonly
-        </div>
+        <V2AuthBrand />
         <h1 className="v2-login__title">Signing you in…</h1>
         <p className="v2-login__subtitle">Completing sign-in with your provider.</p>
       </div>

--- a/frontend/src/v2/components/V2Register.tsx
+++ b/frontend/src/v2/components/V2Register.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams, Navigate, Link } from 'react-router-dom';
 import axios from '../../utils/axiosConfig';
 import V2OAuthButtons from './V2OAuthButtons';
+import V2AuthBrand from './V2AuthBrand';
 
 // v2-native sign-up. Pairs with V2Login (reuses the .v2-login styles) so the
 // auth surfaces match after v2 became the default. Mirrors the legacy
@@ -18,10 +19,7 @@ interface RegistrationPolicy {
 }
 
 const Brand: React.FC = () => (
-  <div className="v2-login__brand">
-    <span className="v2-rail__brand-icon">c</span>
-    commonly
-  </div>
+  <V2AuthBrand />
 );
 
 const V2Register: React.FC = () => {

--- a/frontend/src/v2/components/V2ResetPassword.tsx
+++ b/frontend/src/v2/components/V2ResetPassword.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import axios from '../../utils/axiosConfig';
+import V2AuthBrand from './V2AuthBrand';
 
 // Landing pad for the emailed reset link (/v2/reset-password?token=...).
 // Token consumption is server-side; a used or expired token surfaces the
@@ -40,10 +41,7 @@ const V2ResetPassword: React.FC = () => {
   return (
     <div className="v2-login">
       <form className="v2-login__card" onSubmit={handleSubmit}>
-        <div className="v2-login__brand">
-          <span className="v2-rail__brand-icon">c</span>
-          commonly
-        </div>
+        <V2AuthBrand />
         <h1 className="v2-login__title">Choose a new password</h1>
         {done ? (
           <>


### PR DESCRIPTION
Sam spotted the login/register logo reading subtly different from the landing page and app shell. Root cause: all five auth-card pages rendered a plain letter **"c"** in the accent square, while the rail and landing use the actual Commonly mark (open-C + three dots). New shared `V2AuthBrand` renders the real mark everywhere; verified in-browser on the register card. 199 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9