### PR TITLE
fix(security): NoSQL injection in login + unbounded-limit DoS + search ReDoS

### DIFF
--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -517,8 +517,14 @@ exports.verifyEmail = async (req: any, res: any) => {
 
 // 📌 Login User
 exports.login = async (req: any, res: any) => {
-  const { email, password } = req.body;
+  const { password } = req.body;
+  // Coerce email to a string BEFORE it reaches Mongo. Without this a body like
+  // {"email":{"$ne":null}} is interpreted as a query operator and matches an
+  // arbitrary user (NoSQL injection → account enumeration). register/
+  // forgotPassword already normalize; login was the gap.
+  const email = normalizeEmail(req.body?.email);
   try {
+    if (!email) return res.status(400).json({ error: 'User not found' });
     const user = await User.findOne({ email });
     if (!user) return res.status(400).json({ error: 'User not found' });
 

--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -69,7 +69,11 @@ const normalizeMongo = (m: Record<string, unknown>): NormalizedMessage => {
 exports.getMessages = async (req: AuthRequest, res: Response): Promise<void> => {
   try {
     const { podId } = req.params;
-    const { limit = 50, before } = req.query as { limit?: number; before?: string };
+    const { before } = req.query as { before?: string };
+    // Clamp the page size [1, 200]. Unbounded `limit` let a caller ask for
+    // millions of rows → OOM (both the PG and Mongo read paths below). Mirrors
+    // the postController.getPosts clamp pattern.
+    const limit = Math.min(200, Math.max(1, parseInt(String((req.query as { limit?: string }).limit ?? 50), 10) || 50));
 
     if (!podId) {
       res.status(400).json({ msg: 'Pod ID is required' });
@@ -99,7 +103,7 @@ exports.getMessages = async (req: AuthRequest, res: Response): Promise<void> => 
     }
 
     try {
-      const messages = await PGMessage.findByPodId(podId, parseInt(String(limit), 10), before);
+      const messages = await PGMessage.findByPodId(podId, limit, before);
       // Sprint B5: attach reactions per message in one batched query
       // (MessageReaction.listForMessages aggregates by GROUP BY).
       // Falls through to `messages` unchanged on any reaction lookup error.
@@ -136,7 +140,7 @@ exports.getMessages = async (req: AuthRequest, res: Response): Promise<void> => 
     const messages = await MongoMessage.find(query)
       .populate('userId', 'username profilePicture')
       .sort({ createdAt: -1 })
-      .limit(parseInt(String(limit), 10));
+      .limit(limit);
     res.json(messages.map(normalizeMongo));
   } catch (err) {
     const e = err as { message?: string; kind?: string };

--- a/backend/controllers/postController.ts
+++ b/backend/controllers/postController.ts
@@ -77,9 +77,14 @@ exports.searchPosts = async (req: any, res: any) => {
     const searchQuery: any = {};
 
     if (query) {
+      // Coerce to a bounded string and escape regex metacharacters before it
+      // reaches Mongo. Raw user input as a `$regex` value allowed both
+      // catastrophic-backtracking ReDoS (e.g. `(a+)+b`) and, if an object was
+      // passed, operator injection. Escaping makes it a literal substring match.
+      const term = String(query).slice(0, 200).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       searchQuery.$or = [
-        { content: { $regex: query, $options: 'i' } },
-        { 'comments.text': { $regex: query, $options: 'i' } },
+        { content: { $regex: term, $options: 'i' } },
+        { 'comments.text': { $regex: term, $options: 'i' } },
       ];
     }
 
@@ -105,7 +110,10 @@ exports.searchPosts = async (req: any, res: any) => {
       .populate('comments.userId', 'username profilePicture isBot botMetadata')
       .populate('podId', 'name type')
       .populate('likedBy', '_id')
-      .sort({ createdAt: -1 });
+      .sort({ createdAt: -1 })
+      // Bound the result set — an unfiltered search previously loaded every
+      // matching post into memory.
+      .limit(100);
 
     res.json(posts);
   } catch (err: any) {

--- a/backend/models/pg/Message.ts
+++ b/backend/models/pg/Message.ts
@@ -110,6 +110,11 @@ class Message {
     limit = 50,
     before: string | null = null,
   ): Promise<FormattedMessage[]> {
+    // Defense-in-depth clamp at the data layer: callers should pass a bounded
+    // limit, but a stray unbounded value must never turn into a million-row
+    // SELECT streamed into Node memory.
+    const safeLimit = Math.min(200, Math.max(1, Number.parseInt(String(limit), 10) || 50));
+    limit = safeLimit;
     try {
       let query = `
         SELECT

--- a/backend/routes/messages.ts
+++ b/backend/routes/messages.ts
@@ -53,9 +53,29 @@ const sendMessageRateLimit = rateLimit({
   },
 });
 
+// Reads are cheaper than writes but still hit the DB and (now clamped) can
+// return up to 200 rows — throttle so a leaked token can't spray unbounded
+// GETs. Same token/IP keying as the write limiter.
+const readMessageRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 240,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req: RateLimitReq) => {
+    const authHeader = req.get?.('authorization');
+    if (authHeader) {
+      return `tok:${createHash('sha256').update(authHeader).digest('hex').slice(0, 16)}`;
+    }
+    return req.ip ? ipKeyGenerator(req.ip) : 'anon';
+  },
+  handler: (_req: unknown, res: RateLimitRes) => {
+    res.status(429).json({ msg: 'rate limit exceeded: 240 message reads per 60s' });
+  },
+});
+
 const router: ReturnType<typeof express.Router> = express.Router();
 
-router.get('/:podId', auth, getMessages);
+router.get('/:podId', readMessageRateLimit, auth, getMessages);
 router.post('/:podId', sendMessageRateLimit, auth, createMessage);
 router.delete('/:id', auth, deleteMessage);
 


### PR DESCRIPTION
From the parallel security audit. **Login NoSQL injection**: raw `req.body.email` → `findOne({email})` let `{"$ne":null}` match an arbitrary user (account enumeration) — now normalized like register/forgot. **Unbounded message limit → OOM**: clamped [1,200] at controller + PG model. **searchPosts ReDoS + unbounded results**: user input as `$regex` (catastrophic backtracking / operator injection) with no cap → escaped literal + `.limit(100)`. **GET messages** had no rate limit → added 240/60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9