### PR TITLE
chore(security): scrub GCP project id + registry paths from the public tree

### DIFF
--- a/backend/services/gatewayProvisionerServiceK8s.ts
+++ b/backend/services/gatewayProvisionerServiceK8s.ts
@@ -11,7 +11,11 @@ kc.loadFromDefault();
 const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 const k8sAppsApi = kc.makeApiClient(k8s.AppsV1Api);
 
-const DEFAULT_GATEWAY_IMAGE = 'gcr.io/commonly-test/clawdbot-gateway:latest';
+// Resolved from env so no project-scoped registry path is committed to the
+// public tree (operator-private, supplied at deploy time — same rule as the
+// GCP project id). The placeholder is intentionally generic; a real deploy
+// sets GATEWAY_IMAGE, and gateway.metadata.image overrides per-gateway.
+const DEFAULT_GATEWAY_IMAGE = process.env.GATEWAY_IMAGE || 'gcr.io/PROJECT_ID/clawdbot-gateway:latest';
 const DEFAULT_GATEWAY_PORT = 18789;
 
 interface GatewayMetadata {

--- a/cloudbuild.backend.yaml
+++ b/cloudbuild.backend.yaml
@@ -11,4 +11,4 @@ images:
   - '${_IMAGE}'
 
 substitutions:
-  _IMAGE: 'us-central1-docker.pkg.dev/commonly-493005/docker/commonly-backend:latest'
+  _IMAGE: '${_AR_HOST}/${PROJECT_ID}/docker/commonly-backend:latest'

--- a/cloudbuild.frontend.yaml
+++ b/cloudbuild.frontend.yaml
@@ -16,4 +16,4 @@ images:
 
 substitutions:
   _REACT_APP_API_URL: 'https://api.commonly.me'
-  _IMAGE: 'us-central1-docker.pkg.dev/commonly-493005/docker/commonly-frontend:latest'
+  _IMAGE: '${_AR_HOST}/${PROJECT_ID}/docker/commonly-frontend:latest'

--- a/docs/CODEX_OAUTH_SETUP.md
+++ b/docs/CODEX_OAUTH_SETUP.md
@@ -3,7 +3,7 @@
 > ⚠️ **Outdated for the current dev cluster.** The flow below describes a
 > manual `kubectl cp` of `docs/scripts/codex-oauth.js` into the gateway pod —
 > it predates the LiteLLM-mediated routing and the `codex-auth-rotator`
-> sidecar. For the dev cluster (`commonly-493005`), use the modern flow in
+> sidecar. For the dev cluster (`<DEV_GCP_PROJECT_ID>`), use the modern flow in
 > [`docs/development/LITELLM.md`](development/LITELLM.md) "Refreshing a
 > Codex account's tokens": `npx -y @openai/codex login` locally, push tokens
 > to GCP Secret Manager, force ESO sync, restart LiteLLM. The init container

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -222,20 +222,20 @@ Build backend + frontend images with Cloud Build:
 BACKEND_TAG=$(date +%Y%m%d%H%M%S)
 FRONTEND_TAG=$(date +%Y%m%d%H%M%S)
 
-gcloud builds submit backend --tag gcr.io/commonly-test/commonly-backend:${BACKEND_TAG}
-gcloud builds submit frontend --tag gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG}
+gcloud builds submit backend --tag gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG}
+gcloud builds submit frontend --tag gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG}
 ```
 
 Update backend + frontend images in the cluster:
 
 ```bash
 # Default pool (production)
-kubectl set image deployment/backend backend=gcr.io/commonly-test/commonly-backend:${BACKEND_TAG} -n commonly
-kubectl set image deployment/frontend frontend=gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG} -n commonly
+kubectl set image deployment/backend backend=gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG} -n commonly
+kubectl set image deployment/frontend frontend=gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG} -n commonly
 
 # Dev pool
-kubectl set image deployment/backend backend=gcr.io/commonly-test/commonly-backend:${BACKEND_TAG} -n commonly-dev
-kubectl set image deployment/frontend frontend=gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG} -n commonly-dev
+kubectl set image deployment/backend backend=gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG} -n commonly-dev
+kubectl set image deployment/frontend frontend=gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG} -n commonly-dev
 
 kubectl rollout status deployment/backend -n commonly
 kubectl rollout status deployment/frontend -n commonly
@@ -297,17 +297,17 @@ Backend + frontend images are built with Cloud Build:
 BACKEND_TAG=$(date +%Y%m%d%H%M%S)
 FRONTEND_TAG=$(date +%Y%m%d%H%M%S)
 
-gcloud builds submit backend --tag gcr.io/commonly-test/commonly-backend:${BACKEND_TAG}
-gcloud builds submit frontend --tag gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG}
+gcloud builds submit backend --tag gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG}
+gcloud builds submit frontend --tag gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG}
 ```
 
 Then deploy/rollout:
 
 ```bash
-kubectl set image deployment/backend backend=gcr.io/commonly-test/commonly-backend:${BACKEND_TAG} -n commonly
-kubectl set image deployment/frontend frontend=gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG} -n commonly
-kubectl set image deployment/backend backend=gcr.io/commonly-test/commonly-backend:${BACKEND_TAG} -n commonly-dev
-kubectl set image deployment/frontend frontend=gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG} -n commonly-dev
+kubectl set image deployment/backend backend=gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG} -n commonly
+kubectl set image deployment/frontend frontend=gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG} -n commonly
+kubectl set image deployment/backend backend=gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG} -n commonly-dev
+kubectl set image deployment/frontend frontend=gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG} -n commonly-dev
 
 kubectl rollout status deployment/backend -n commonly
 kubectl rollout status deployment/frontend -n commonly
@@ -339,7 +339,7 @@ K8s provisioning is enabled by default:
 The Helm chart deploys a native gateway (`clawdbot-gateway`) in each namespace.
 It requires:
 - `CLAWDBOT_GATEWAY_TOKEN` in the `api-keys` secret
-- Image: `gcr.io/commonly-test/clawdbot-gateway:latest`
+- Image: `gcr.io/<GCP_PROJECT_ID>/clawdbot-gateway:latest`
 - `GEMINI_API_KEY` in the `api-keys` secret (for default OpenClaw model auth)
 - Optional `gemini-api-key-2` in the `api-keys` secret (seeds `google:backup` auth profile for rate-limit failover)
 - Deployment strategy: `Recreate` (required because gateway config/workspace PVCs are `ReadWriteOnce`; rolling updates can deadlock on volume multi-attach)

--- a/docs/deployment/K8S_DEPLOYMENT_CHECKLIST.md
+++ b/docs/deployment/K8S_DEPLOYMENT_CHECKLIST.md
@@ -36,8 +36,8 @@ docker push ${REGISTRY}/commonly-frontend:latest
 BACKEND_TAG=$(date +%Y%m%d%H%M%S)
 FRONTEND_TAG=$(date +%Y%m%d%H%M%S)
 
-gcloud builds submit backend --tag gcr.io/commonly-test/commonly-backend:${BACKEND_TAG}
-gcloud builds submit frontend --tag gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG}
+gcloud builds submit backend --tag gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG}
+gcloud builds submit frontend --tag gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG}
 ```
 
 ## Values Files
@@ -226,14 +226,14 @@ mongoose.connect(process.env.MONGO_URI).then(async () => {
 # After code changes, rebuild and push images (Cloud Build)
 BACKEND_TAG=$(date +%Y%m%d%H%M%S)
 FRONTEND_TAG=$(date +%Y%m%d%H%M%S)
-gcloud builds submit backend --tag gcr.io/commonly-test/commonly-backend:${BACKEND_TAG}
-gcloud builds submit frontend --tag gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG}
+gcloud builds submit backend --tag gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG}
+gcloud builds submit frontend --tag gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG}
 
 # Roll out both components to both namespaces
-kubectl set image deployment/backend backend=gcr.io/commonly-test/commonly-backend:${BACKEND_TAG} -n commonly
-kubectl set image deployment/frontend frontend=gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG} -n commonly
-kubectl set image deployment/backend backend=gcr.io/commonly-test/commonly-backend:${BACKEND_TAG} -n commonly-dev
-kubectl set image deployment/frontend frontend=gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG} -n commonly-dev
+kubectl set image deployment/backend backend=gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG} -n commonly
+kubectl set image deployment/frontend frontend=gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG} -n commonly
+kubectl set image deployment/backend backend=gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG} -n commonly-dev
+kubectl set image deployment/frontend frontend=gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG} -n commonly-dev
 
 kubectl rollout status deployment/backend -n commonly
 kubectl rollout status deployment/frontend -n commonly

--- a/docs/deployment/KUBERNETES.md
+++ b/docs/deployment/KUBERNETES.md
@@ -125,16 +125,16 @@ Backend + frontend build + rollout:
 BACKEND_TAG=$(date +%Y%m%d%H%M%S)
 FRONTEND_TAG=$(date +%Y%m%d%H%M%S)
 
-gcloud builds submit backend --tag gcr.io/commonly-test/commonly-backend:${BACKEND_TAG}
-gcloud builds submit frontend --tag gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG}
+gcloud builds submit backend --tag gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG}
+gcloud builds submit frontend --tag gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG}
 
 # Production pool
-kubectl set image deployment/backend backend=gcr.io/commonly-test/commonly-backend:${BACKEND_TAG} -n commonly
-kubectl set image deployment/frontend frontend=gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG} -n commonly
+kubectl set image deployment/backend backend=gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG} -n commonly
+kubectl set image deployment/frontend frontend=gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG} -n commonly
 
 # Dev pool
-kubectl set image deployment/backend backend=gcr.io/commonly-test/commonly-backend:${BACKEND_TAG} -n commonly-dev
-kubectl set image deployment/frontend frontend=gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG} -n commonly-dev
+kubectl set image deployment/backend backend=gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG} -n commonly-dev
+kubectl set image deployment/frontend frontend=gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG} -n commonly-dev
 
 kubectl rollout status deployment/backend -n commonly
 kubectl rollout status deployment/frontend -n commonly
@@ -309,14 +309,14 @@ To upgrade an existing deployment:
 # Rebuild and push new images (Cloud Build)
 BACKEND_TAG=$(date +%Y%m%d%H%M%S)
 FRONTEND_TAG=$(date +%Y%m%d%H%M%S)
-gcloud builds submit backend --tag gcr.io/commonly-test/commonly-backend:${BACKEND_TAG}
-gcloud builds submit frontend --tag gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG}
+gcloud builds submit backend --tag gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG}
+gcloud builds submit frontend --tag gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG}
 
 # Roll out to both namespaces
-kubectl set image deployment/backend backend=gcr.io/commonly-test/commonly-backend:${BACKEND_TAG} -n commonly
-kubectl set image deployment/frontend frontend=gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG} -n commonly
-kubectl set image deployment/backend backend=gcr.io/commonly-test/commonly-backend:${BACKEND_TAG} -n commonly-dev
-kubectl set image deployment/frontend frontend=gcr.io/commonly-test/commonly-frontend:${FRONTEND_TAG} -n commonly-dev
+kubectl set image deployment/backend backend=gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG} -n commonly
+kubectl set image deployment/frontend frontend=gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG} -n commonly
+kubectl set image deployment/backend backend=gcr.io/<GCP_PROJECT_ID>/commonly-backend:${BACKEND_TAG} -n commonly-dev
+kubectl set image deployment/frontend frontend=gcr.io/<GCP_PROJECT_ID>/commonly-frontend:${FRONTEND_TAG} -n commonly-dev
 
 kubectl rollout status deployment/backend -n commonly
 kubectl rollout status deployment/frontend -n commonly

--- a/docs/runbooks/gcp-cost-optimization.md
+++ b/docs/runbooks/gcp-cost-optimization.md
@@ -83,7 +83,7 @@ Apply via:
 
 ```bash
 gcloud artifacts repositories set-cleanup-policies docker \
-  --location=us-central1 --project=commonly-493005 \
+  --location=us-central1 --project=<DEV_GCP_PROJECT_ID> \
   --policy=/tmp/ar-cleanup-policy.json
 ```
 
@@ -110,7 +110,7 @@ Apply via:
 
 ```bash
 gcloud container clusters update commonly-dev \
-  --region us-central1 --project commonly-493005 \
+  --region us-central1 --project <DEV_GCP_PROJECT_ID> \
   --enable-autoscaling --node-pool <pool> --min-nodes <m> --max-nodes <M>
 ```
 
@@ -148,16 +148,16 @@ gcloud command for the export-switch.
    ```bash
    bq --location=us-central1 mk --dataset \
      --description="Cloud Billing daily export for cost visibility" \
-     commonly-493005:billing_export
+     <DEV_GCP_PROJECT_ID>:billing_export
    ```
-2. Cloud Console UI (manual): visit `https://console.cloud.google.com/billing/<ACCOUNT_ID>/export`, pick `Daily cost detail → Edit settings`, choose project `commonly-493005`, dataset `billing_export`, save.
+2. Cloud Console UI (manual): visit `https://console.cloud.google.com/billing/<ACCOUNT_ID>/export`, pick `Daily cost detail → Edit settings`, choose project `<DEV_GCP_PROJECT_ID>`, dataset `billing_export`, save.
 3. First data lands ~24h later. Tables auto-created: `gcp_billing_export_v1_<ACCOUNT_ID>`.
 
 Sample query for daily $ by service:
 
 ```sql
 SELECT service.description, SUM(cost) AS cost_usd, currency
-FROM `commonly-493005.billing_export.gcp_billing_export_v1_*`
+FROM `<DEV_GCP_PROJECT_ID>.billing_export.gcp_billing_export_v1_*`
 WHERE _PARTITIONTIME >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
 GROUP BY service.description, currency
 ORDER BY cost_usd DESC
@@ -190,7 +190,7 @@ Drop-in script to capture the current state in one go:
 ```bash
 echo "=== pool sizing + autoscaling ==="
 gcloud container node-pools list --cluster commonly-dev --location us-central1 \
-  --project commonly-493005 \
+  --project <DEV_GCP_PROJECT_ID> \
   --format='table(name,config.machineType,config.spot,autoscaling.enabled,autoscaling.minNodeCount,autoscaling.maxNodeCount)'
 
 echo "=== workload placement (verifies ADR-015 invariant) ==="
@@ -198,7 +198,7 @@ kubectl get pods -n commonly-dev -o custom-columns='NAME:.metadata.name,NODE:.sp
 
 echo "=== AR repo size + cleanup policy ==="
 gcloud artifacts repositories describe docker --location=us-central1 \
-  --project=commonly-493005 --format='yaml(sizeBytes,cleanupPolicies)'
+  --project=<DEV_GCP_PROJECT_ID> --format='yaml(sizeBytes,cleanupPolicies)'
 
 echo "=== node usage vs requested ==="
 kubectl top nodes


### PR DESCRIPTION
Public repo — infra identifiers must not be committed. Audit + sweep found the GCP project id and registry paths in cloudbuild.{backend,frontend}.yaml, gatewayProvisionerServiceK8s.ts, and three docs. Parameterized to `${PROJECT_ID}`/`<DEV_GCP_PROJECT_ID>` placeholders. Local test DB names (`commonly-test` as a Mongo/PG db) left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9