### PR TITLE
fix(security): authorize pod-scoped file reads (IDOR on GET /api/uploads/:fileName)

### DIFF
--- a/backend/__tests__/unit/routes/uploads.signedurl.test.js
+++ b/backend/__tests__/unit/routes/uploads.signedurl.test.js
@@ -15,7 +15,12 @@ jest.mock('../../../services/objectStore', () => ({
   __resetObjectStoreForTests: jest.fn(),
 }));
 
-jest.mock('../../../models/File', () => ({ findByFileName: jest.fn() }));
+// findByFileName(...).lean() resolves whatever mockFileMeta holds (null =
+// unknown/un-scoped file → public read).
+let mockFileMeta = null;
+jest.mock('../../../models/File', () => ({
+  findByFileName: jest.fn(() => ({ lean: () => Promise.resolve(mockFileMeta) })),
+}));
 
 // Auth middleware stub — writes userId if the header is present.
 jest.mock('../../../middleware/auth', () => (req, res, next) => {
@@ -29,11 +34,16 @@ jest.mock('../../../middleware/auth', () => (req, res, next) => {
 
 const mockCanRead = jest.fn();
 const mockSignToken = jest.fn().mockReturnValue('signed-token');
+const mockVerifyToken = jest.fn();
 jest.mock('../../../services/attachmentAccess', () => ({
   DEFAULT_TOKEN_TTL_SECONDS: 300,
   canReadAttachment: (...args) => mockCanRead(...args),
   signAttachmentToken: (...args) => mockSignToken(...args),
+  verifyAttachmentToken: (...args) => mockVerifyToken(...args),
 }));
+
+const mockJwtVerify = jest.fn();
+jest.mock('jsonwebtoken', () => ({ verify: (...args) => mockJwtVerify(...args) }));
 
 const mockLog = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../../services/auditService', () => ({
@@ -102,9 +112,59 @@ describe('GET /api/uploads/:fileName/url (ADR-002 Phase 1b mint)', () => {
 
   it('does not shadow the bare GET — `/api/uploads/foo` still routes to the fetcher', async () => {
     mockStore.get.mockResolvedValue(null);
-    const File = require('../../../models/File');
-    File.findByFileName.mockResolvedValue(null);
+    mockFileMeta = null; // un-scoped → public read path
     await request(app).get('/api/uploads/foo').expect(404);
     expect(mockCanRead).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/uploads/:fileName pod-scoped authorization (ADR-002 Phase 1b flip / #IDOR)', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/uploads', routes);
+    mockFileMeta = null;
+    mockCanRead.mockReset();
+    mockVerifyToken.mockReset();
+    mockJwtVerify.mockReset();
+    mockStore.get.mockReset().mockResolvedValue({ mime: 'image/png', stream: { pipe: (res) => res.end('bytes') } });
+    process.env.JWT_SECRET = 'test-secret';
+  });
+
+  it('serves an UN-SCOPED file publicly (no podId — e.g. an avatar)', async () => {
+    mockFileMeta = { podId: null };
+    await request(app).get('/api/uploads/avatar.png').expect(200);
+  });
+
+  it('403s a POD-SCOPED file with no token and no auth (the IDOR fix)', async () => {
+    mockFileMeta = { podId: 'pod-1' };
+    const res = await request(app).get('/api/uploads/secret.pdf').expect(403);
+    expect(res.body.msg).toMatch(/not authorized/i);
+  });
+
+  it('serves a POD-SCOPED file with a valid ?t= token', async () => {
+    mockFileMeta = { podId: 'pod-1' };
+    mockVerifyToken.mockReturnValue({ userId: 'user-1' });
+    await request(app).get('/api/uploads/secret.pdf?t=good-token').expect(200);
+    expect(mockVerifyToken).toHaveBeenCalledWith('good-token', 'secret.pdf');
+  });
+
+  it('serves a POD-SCOPED file to a Bearer user who canReadAttachment', async () => {
+    mockFileMeta = { podId: 'pod-1' };
+    mockVerifyToken.mockReturnValue(null);
+    mockJwtVerify.mockReturnValue({ id: 'member-1' });
+    mockCanRead.mockResolvedValue(true);
+    await request(app).get('/api/uploads/secret.pdf').set('Authorization', 'Bearer jwt').expect(200);
+    expect(mockCanRead).toHaveBeenCalledWith('secret.pdf', 'member-1');
+  });
+
+  it('403s a POD-SCOPED file when the Bearer user cannot read it', async () => {
+    mockFileMeta = { podId: 'pod-1' };
+    mockVerifyToken.mockReturnValue(null);
+    mockJwtVerify.mockReturnValue({ id: 'outsider' });
+    mockCanRead.mockResolvedValue(false);
+    await request(app).get('/api/uploads/secret.pdf').set('Authorization', 'Bearer jwt').expect(403);
   });
 });

--- a/backend/__tests__/unit/routes/uploads.test.js
+++ b/backend/__tests__/unit/routes/uploads.test.js
@@ -21,6 +21,8 @@ jest.mock('../../../models/File', () => ({
   findByFileName: jest.fn(),
 }));
 
+jest.mock('jsonwebtoken', () => ({ verify: jest.fn() }));
+
 jest.mock('../../../middleware/auth', () => (req, res, next) => next());
 
 const File = require('../../../models/File');
@@ -59,7 +61,10 @@ describe('uploads GET /:fileName (ADR-002 Phase 1)', () => {
       Buffer.from('hello'),
     );
     expect(mockStore.get).toHaveBeenCalledWith('new.png');
-    expect(File.findByFileName).not.toHaveBeenCalled();
+    // authorizePodFile now consults File.findByFileName to decide whether the
+    // file is pod-scoped (requires auth) or public (un-scoped — served as here,
+    // since the mock returns no record → no podId → public).
+    expect(File.findByFileName).toHaveBeenCalledWith('new.png');
   });
 
   it('falls back to legacy File.data when the driver returns null', async () => {

--- a/backend/routes/uploads.ts
+++ b/backend/routes/uploads.ts
@@ -21,10 +21,12 @@
 import rateLimit from 'express-rate-limit';
 import { createHash } from 'crypto';
 import path from 'path';
+import jwt from 'jsonwebtoken';
 import {
   DEFAULT_TOKEN_TTL_SECONDS,
   canReadAttachment,
   signAttachmentToken,
+  verifyAttachmentToken,
 } from '../services/attachmentAccess';
 import { logAttachmentTokenMint } from '../services/auditService';
 import { cloudflareIpRateLimitKeyGenerator } from '../middleware/ipRateLimit';
@@ -291,15 +293,45 @@ router.get('/:fileName/url', mintRateLimit, auth, async (req: AuthReq, res: Res)
   }
 });
 
+// ADR-002 Phase 1b "flip" — authorize reads of a POD-SCOPED file. Previously
+// ANY caller who knew a filename could read a file bound to a private pod
+// (IDOR). A file with a podId now requires one of:
+//   (a) a valid `?t=<token>` minted by GET /:fileName/url (the frontend
+//       already mints these via getSignedAttachmentUrl before rendering), or
+//   (b) a Bearer token whose user canReadAttachment (owner / pod member).
+// Un-scoped files (avatars, profile pictures — File.podId null) are always
+// allowed, matching how they render in public post feeds. Returns true when
+// the read is permitted.
+const authorizePodFile = async (req: AuthReq, fileName: string): Promise<boolean> => {
+  const meta = await File.findByFileName(fileName).lean();
+  if (!meta?.podId) return true; // un-scoped: public (avatars etc.)
+
+  const token = typeof req.query?.t === 'string' ? req.query.t : '';
+  if (token && verifyAttachmentToken(token, fileName)) return true;
+
+  const bearer = req.get?.('Authorization')?.replace('Bearer ', '');
+  if (bearer) {
+    try {
+      const decoded = jwt.verify(bearer, process.env.JWT_SECRET as string) as Record<string, unknown>;
+      const uid = (decoded.id || (decoded.user as Record<string, unknown>)?.id) as string | undefined;
+      if (uid && await canReadAttachment(fileName, uid)) return true;
+    } catch {
+      // invalid bearer — fall through to unauthorized
+    }
+  }
+  return false;
+};
+
 router.get('/:fileName', artifactReadRateLimit, async (req: AuthReq, res: Res) => {
   try {
     const fileName = req.params?.fileName;
     if (!fileName) return res.status(400).json({ msg: 'fileName required' });
 
-    // The `?t=<token>` query param minted by `GET /:fileName/url` is passed
-    // through harmlessly; Express ignores unknown query params. Validation +
-    // enforcement land in the follow-up PR that removes public-read. See
-    // ADR-002 Phase 1b "flip" note at the top of this file.
+    // ADR-002 Phase 1b "flip" — authorize POD-SCOPED files (see
+    // authorizePodFile). Un-scoped files (avatars) stay publicly readable.
+    if (!(await authorizePodFile(req, fileName))) {
+      return res.status(403).json({ msg: 'Not authorized to read this file' });
+    }
 
     const store = getObjectStore();
     const obj = await store.get(fileName);
@@ -402,6 +434,12 @@ router.get('/:fileName/preview-pptx-html', artifactReadRateLimit, async (req: Au
     if (!fileName) return res.status(400).json({ msg: 'fileName required' });
     if (!/\.pptx$/i.test(String(fileName))) {
       return res.status(400).json({ msg: 'fileName must end in .pptx' });
+    }
+
+    // Same pod-scoped authorization as the raw file fetch — a private deck
+    // must not be renderable by anyone who knows its filename.
+    if (!(await authorizePodFile(req, fileName))) {
+      return res.status(403).json({ msg: 'Not authorized to read this file' });
     }
 
     // Fetch the binary from object storage (or legacy MongoDB inline bytes).

--- a/backend/routes/uploads.ts
+++ b/backend/routes/uploads.ts
@@ -303,7 +303,10 @@ router.get('/:fileName/url', mintRateLimit, auth, async (req: AuthReq, res: Res)
 // allowed, matching how they render in public post feeds. Returns true when
 // the read is permitted.
 const authorizePodFile = async (req: AuthReq, fileName: string): Promise<boolean> => {
-  const meta = await File.findByFileName(fileName).lean();
+  // findByFileName returns a Mongoose query (.lean() → plain object); some
+  // callers/tests resolve it directly, so handle both shapes.
+  const q = File.findByFileName(fileName);
+  const meta = q && typeof q.lean === 'function' ? await q.lean() : await q;
   if (!meta?.podId) return true; // un-scoped: public (avatars etc.)
 
   const token = typeof req.query?.t === 'string' ? req.query.t : '';

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -624,7 +624,13 @@ const PptxPreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
     setBusy(true); setError(null); setHtml(null);
     (async () => {
       try {
-        const r = await fetch(`${getApiBaseUrl()}/api/uploads/${encodeURIComponent(artifact.fileName!)}/preview-pptx-html`);
+        // Send the auth token — pod-scoped files now require authorization
+        // (ADR-002 Phase 1b flip). The backend accepts a Bearer token whose
+        // user can read the file.
+        const authToken = localStorage.getItem('token');
+        const r = await fetch(`${getApiBaseUrl()}/api/uploads/${encodeURIComponent(artifact.fileName!)}/preview-pptx-html`, {
+          headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
+        });
         if (cancelled) return;
         if (!r.ok) {
           // Surface a useful error from the JSON body if available


### PR DESCRIPTION
**CRITICAL (audit).** `GET /api/uploads/:fileName` + the pptx-preview endpoint served **any** file to **any** caller who knew the filename — no membership check — while files are bound to pods. A non-member who learned/guessed a filename could read a private pod's documents. The signed-URL mint endpoint gated correctly; the raw GET bypassed it (the deferred ADR-002 "Phase 1b flip").

- `authorizePodFile()`: files **with a podId** require a valid `?t=` token (frontend already mints these via `getSignedAttachmentUrl`) OR a Bearer whose user `canReadAttachment`. Un-scoped files (avatars) stay public. Applied to both the raw fetch and pptx-preview.
- Frontend: the inspector's pptx-preview fetch now sends the auth token.

5 regression cases, all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9