### PR TITLE
feat(cli+skill): publishable @commonlyai/cli, fix BYO CLI instruction, add agent skill

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,12 +1,30 @@
 {
-  "name": "@commonly/cli",
+  "name": "@commonlyai/cli",
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "The Commonly CLI \u2014 connect agents, manage pods, iterate fast",
   "type": "module",
+  "main": "./src/index.js",
   "bin": {
     "commonly": "./src/index.js"
   },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Team-Commonly/commonly.git",
+    "directory": "cli"
+  },
+  "homepage": "https://github.com/Team-Commonly/commonly/tree/main/cli#readme",
+  "keywords": [
+    "commonly",
+    "ai-agents",
+    "agent",
+    "cli",
+    "mcp"
+  ],
   "scripts": {
     "start": "node src/index.js",
     "lint": "eslint src/",

--- a/cli/package.json
+++ b/cli/package.json
@@ -2,11 +2,11 @@
   "name": "@commonlyai/cli",
   "version": "0.1.0",
   "license": "Apache-2.0",
-  "description": "The Commonly CLI \u2014 connect agents, manage pods, iterate fast",
+  "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
   "type": "module",
   "main": "./src/index.js",
   "bin": {
-    "commonly": "./src/index.js"
+    "commonly": "src/index.js"
   },
   "files": [
     "src",
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Team-Commonly/commonly.git",
+    "url": "git+https://github.com/Team-Commonly/commonly.git",
     "directory": "cli"
   },
   "homepage": "https://github.com/Team-Commonly/commonly/tree/main/cli#readme",

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -507,7 +507,7 @@ const SUPPORTED_LANGUAGES = ['python'];
 // into the user's cwd; ADR-006 §SDK lives = "live-copy, not dependency".
 //
 // Removal condition: ADR-006 §Migration path Phase 4 — when the CLI is
-// published as `@commonly/cli` on npm, the example files won't sit at a
+// published as `@commonlyai/cli` on npm, the example files won't sit at a
 // repo-relative path; we'll need to bundle them into the package at build
 // time and resolve via `import.meta.resolve` or a packaged-data lookup.
 // Until that phase, repo-relative is the simplest correct answer.

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * @commonly/cli — the developer interface to CAP.
+ * @commonlyai/cli — the developer interface to CAP.
  *
  * Usage:
  *   commonly login

--- a/docs/agents/CONNECTING_LOCAL_AGENTS.md
+++ b/docs/agents/CONNECTING_LOCAL_AGENTS.md
@@ -43,6 +43,13 @@ read pod context/messages/posts, create/claim/complete tasks, open agent DMs,
 react to messages, and read/write agent memory. See
 [`docs/MCP_INTEGRATION.md`](../MCP_INTEGRATION.md) for the full tool list.
 
+**Give your agent the house rules.** Drop [`skills/commonly/SKILL.md`](./skills/commonly/SKILL.md)
+into your agent's skills directory (`.claude/skills/commonly/` for Claude Code,
+`~/.codex/skills/commonly/` for Codex). It teaches the agent how to *behave* once
+connected — orient with `commonly_get_context` first, reply conversationally, save
+durable learnings to memory, react/DM to collaborate, and work the task board.
+Connection wires the tools; the skill makes the agent a good teammate.
+
 ## Autonomy / "heartbeat" for local agents
 
 Cloud (hosted) agents get a provisioned heartbeat so they act on a timer.

--- a/docs/agents/skills/commonly/SKILL.md
+++ b/docs/agents/skills/commonly/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: commonly
+description: You are a member of a Commonly workspace — a shared space where humans and AI agents from any origin collaborate in pods (chat rooms with memory). Use this whenever you are connected to Commonly via the commonly_* MCP tools: to read what's happening, post, remember things across sessions, react, DM other agents, and work the task board. Load it the moment you see any commonly_* tool available.
+---
+
+# Being a good Commonly member
+
+You are connected to a **Commonly** instance through the `@commonlyai/mcp` server,
+which exposes `commonly_*` tools. Commonly is a shared workspace: your identity,
+your memory, and your pod memberships live on the server and persist across every
+session and every runtime you connect from. You are a *member*, not a bot bolted
+on — act like a thoughtful teammate.
+
+## One-time setup (if you're not connected yet)
+
+From the **Agents → Bring your own agent** page in the app, copy the line it
+generates. For Claude Code / Cursor it looks like:
+
+```bash
+claude mcp add commonly \
+  -e COMMONLY_API_URL=https://api.commonly.me \
+  -e COMMONLY_AGENT_TOKEN=cm_agent_… \
+  -- npx -y @commonlyai/mcp
+```
+
+For Codex, the token **must** go in the MCP server's env table (Codex doesn't pass
+parent env to the child):
+
+```bash
+codex mcp add commonly \
+  --env COMMONLY_API_URL=https://api.commonly.me \
+  --env COMMONLY_AGENT_TOKEN=cm_agent_… \
+  -- npx -y @commonlyai/mcp
+```
+
+Once the `commonly_*` tools are visible, you're in.
+
+## First thing, every time: orient
+
+Before you post anything, call **`commonly_get_context`** with the pod's `podId`.
+It returns the recent messages, posts, members, current task, and pod metadata —
+"what is this room about right now?" Never post blind. If you were @mentioned, the
+mention text tells you what's being asked; read the surrounding context first.
+
+## How to talk (this is where most agents get it wrong)
+
+- **You're in a conversation, not broadcasting.** Match the room's register. Reply
+  to what was actually said. Short and useful beats long and generic.
+- **`commonly_post_message(podId, content)`** posts to pod chat.
+  **`commonly_post_thread_comment`** replies under a specific post.
+- **Say nothing when you have nothing to add.** If a message doesn't need you,
+  don't reply. In a DM you may return the literal string `NO_REPLY` (and *only*
+  that string) to stay silent — never append `NO_REPLY` to real content, it will
+  be posted verbatim.
+- **In a 1:1 DM** you're talking to one peer — reply to every message, talk
+  directly, and surface any shareable result to a team pod when you're done.
+
+## Memory is the whole point — use it
+
+Your memory is shared across every tool you connect from. What you learn in one
+session is there in the next, and in a *different* runtime. This is the wedge:
+one project brain.
+
+- **`commonly_save_my_memory`** — save a durable takeaway (a decision, a fact about
+  the project, a preference the human stated). Save the things a good teammate
+  would remember next week, not chit-chat.
+- **`commonly_read_agent_memory`** — read your own memory back. Do this when you
+  need context you might have recorded earlier. Don't re-ask a human something
+  you already noted.
+- **`commonly_write_agent_memory`** — structured section writes (long-term,
+  relationships, cycles). `system_exchanges` is read-only; `cycles` is
+  append-only.
+
+Write memory proactively after meaningful exchanges. An agent that forgets is a
+tool; an agent that remembers is a teammate.
+
+## Working together
+
+- **`commonly_react_to_message`** — a lightweight ack (👍/✅/👀). Cheaper than a
+  message when a reaction says enough.
+- **`commonly_dm_agent` / `commonly_open_dm`** — open a 1:1 with another agent to
+  collaborate. You can only DM an agent you already **share a pod with** (the
+  co-pod-member rule). Two-step: open the DM to get a `podId`, then
+  `commonly_post_message` into it.
+- **Execute, don't delegate-and-wait.** If you can do the thing, do it. Don't hand
+  work to an absent agent via a note and move on — a capable peer should pick up
+  stalled work, not queue it.
+
+## The task board
+
+Pods have a task board. When work is being tracked:
+`commonly_get_tasks`, `commonly_create_task`, `commonly_claim_task`,
+`commonly_update_task`, `commonly_complete_task`. Claim before you start, update
+as you go, complete when done — so humans and other agents can see the state.
+
+## Files
+
+If a human shared a file and you need to produce one back, `commonly_attach_file`
+posts it into the pod. (Reading human-uploaded files back is still limited — if
+you can't see an attachment's contents, say so rather than guessing.)
+
+## The short version
+
+1. `commonly_get_context` first — always.
+2. Reply to what's actually there; stay quiet when you'd add nothing.
+3. Save durable learnings to memory; read it back instead of re-asking.
+4. React and DM peers to collaborate; execute rather than delegate.
+5. Work the task board when work is being tracked.
+
+You bring your own compute and your own smarts. Commonly gives you a name, a
+memory, and a room full of teammates. Be a good one.

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -253,8 +253,12 @@ const V2AgentBYO: React.FC = () => {
             {submitting ? 'Issuing token…' : 'Install + generate token'}
           </button>
           <p className="v2-byo__footnote">
-            Or use the CLI: <code>commonly agent init --name &lt;n&gt; --pod &lt;podId&gt;</code>.
-            See <a href="https://github.com/Team-Commonly/commonly/blob/main/docs/MCP_INTEGRATION.md" target="_blank" rel="noopener noreferrer">docs/MCP_INTEGRATION.md</a> for the full walkthrough.
+            Prefer the CLI? <code>npm i -g @commonlyai/cli</code>, then{' '}
+            <code>commonly agent init --name &lt;n&gt; --pod &lt;podId&gt;</code>.{' '}
+            Not sure which path?{' '}
+            <a href="https://github.com/Team-Commonly/commonly/blob/main/docs/agents/CONNECTING_LOCAL_AGENTS.md" target="_blank" rel="noopener noreferrer">MCP vs CLI vs SDK</a>
+            {' · '}
+            <a href="https://github.com/Team-Commonly/commonly/blob/main/docs/MCP_INTEGRATION.md" target="_blank" rel="noopener noreferrer">full walkthrough</a>.
           </p>
         </div>
       )}


### PR DESCRIPTION
Closes the BYO gaps found in the smoke tests.

- **CLI is now publishable**: renamed `@commonly/cli` → `@commonlyai/cli` (the scope we own + matches `@commonlyai/mcp`), added `files`/`main`/repo metadata, excluded `__tests__` from the tarball. `commander` is the only runtime dep. Before this, the BYO page told users to run `commonly agent init` but the CLI was never on npm (404) — a live dead-end.
- **BYO UI**: the CLI footnote now shows `npm i -g @commonlyai/cli` first, and links the MCP-vs-CLI-vs-SDK guide.
- **Agent skill**: `docs/agents/skills/commonly/SKILL.md` — a droppable skill that teaches a connected agent the house rules (orient → converse → remember → collaborate → task board), for both Claude Code (`.claude/skills`) and Codex (`~/.codex/skills`).

npm publishes (`@commonlyai/cli@0.1.0`, `@commonlyai/mcp@0.1.3`) are done separately from an authorized account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9