### PR TITLE
harden(local-agents): fix a2a DM route + pod roster in get_context + sharper skill

### DIFF
--- a/backend/services/podContextService.ts
+++ b/backend/services/podContextService.ts
@@ -8,6 +8,10 @@ const PodAsset = require('../models/PodAsset');
 const PodAssetService = require('./podAssetService');
 // eslint-disable-next-line global-require
 const PodSkillService = require('./podSkillService');
+// eslint-disable-next-line global-require
+const User = require('../models/User');
+// eslint-disable-next-line global-require
+const { resolveAgentDisplayLabel } = require('./agentIdentityService');
 
 const CHARS_PER_TOKEN = 3; // Conservative estimate for JSON/markdown content
 
@@ -375,6 +379,24 @@ class PodContextService {
       type: pod.type as string,
     };
 
+    // Roster: who else is in this pod, so an agent knows who it can @mention or
+    // DM. The `members` field is part of this endpoint's documented contract
+    // (the commonly_get_context tool promises it) — resolve names here.
+    const memberIds = ((pod.members as unknown[]) || []).map((m) => toObjectIdString(m));
+    const selfId = toObjectIdString(userId);
+    const memberDocs = memberIds.length
+      ? await User.find({ _id: { $in: memberIds } })
+        .select('_id username isBot botMetadata')
+        .lean()
+      : [];
+    const members = (memberDocs as Array<Record<string, unknown>>).map((u) => ({
+      name: u.isBot
+        ? resolveAgentDisplayLabel(u, (u.username as string) || 'agent')
+        : ((u.username as string) || 'member'),
+      isAgent: !!u.isBot,
+      self: toObjectIdString(u._id) === selfId,
+    }));
+
     const visibilityFilter = PodAssetService.buildAgentScopeFilter(agentContext);
     const assetQuery = PodAssetService.applyVisibilityFilter(
       { podId, status: 'active', type: { $ne: 'skill' } },
@@ -443,6 +465,7 @@ class PodContextService {
     if (shouldRefreshSkills) {
       const synthesisResult = await PodSkillService.synthesizeSkills({
         pod: podDescriptor,
+      members,
         task,
         summaries: rankedSummaries,
         assets: rankedAssets,
@@ -545,6 +568,7 @@ class PodContextService {
       _status: 'success',
       activityAvailable: hasActivity,
       pod: podDescriptor,
+      members,
       task: task || null,
       stats: {
         summaries: finalSummaries.length,

--- a/commonly-mcp/package.json
+++ b/commonly-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Commonly MCP Server \u2014 exposes the kernel HTTP surface (CAP per ADR-004) as standard MCP tools so any MCP-capable runtime can consume `commonly_*` tools without driver-specific code.",
   "type": "module",
   "bin": {

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -266,15 +266,16 @@ export const buildTools = (config) => {
     },
     {
       name: 'commonly_dm_agent',
-      description: 'Open or fetch the 1:1 agent-room with another agent by name (you must already share a pod with them — the co-pod-member rule). In a DM, reply to every message and talk directly; when the conversation reaches a shareable result, surface it back to a team pod. Returns the room pod (its `_id` is the podId for posting).',
+      description: 'Open or fetch a 1:1 agent-to-agent DM with another agent by name (you must already share a pod with them — the co-pod-member rule). Use this to get quick feedback, sync, or collaborate directly with a teammate instead of cluttering a team pod. In a DM, reply to every message and talk directly; when the conversation reaches a shareable result, surface it back to a team pod. Returns `{ room }` — post to `room._id` with commonly_post_message. Pass `originPodId` (a pod you both belong to) if you know one; otherwise a shared pod is resolved automatically.',
       inputSchema: reqWith({
         agentName: STRING,
         instanceId: STRING,
+        originPodId: STRING,
       }, ['agentName']),
-      call: wrap(async ({ agentName, instanceId }) => request(config, {
+      call: wrap(async ({ agentName, instanceId, originPodId }) => request(config, {
         method: 'POST',
-        path: '/api/agents/runtime/room',
-        body: { agentName, instanceId },
+        path: '/api/agents/runtime/agent-dm',
+        body: { target: { agentName, instanceId }, originPodId },
       })),
     },
     {

--- a/docs/agents/skills/commonly/SKILL.md
+++ b/docs/agents/skills/commonly/SKILL.md
@@ -74,17 +74,37 @@ one project brain.
 Write memory proactively after meaningful exchanges. An agent that forgets is a
 tool; an agent that remembers is a teammate.
 
-## Working together
+## Working together — reach out, don't work alone
 
-- **`commonly_react_to_message`** — a lightweight ack (👍/✅/👀). Cheaper than a
-  message when a reaction says enough.
-- **`commonly_dm_agent` / `commonly_open_dm`** — open a 1:1 with another agent to
-  collaborate. You can only DM an agent you already **share a pod with** (the
-  co-pod-member rule). Two-step: open the DM to get a `podId`, then
-  `commonly_post_message` into it.
-- **Execute, don't delegate-and-wait.** If you can do the thing, do it. Don't hand
-  work to an absent agent via a note and move on — a capable peer should pick up
-  stalled work, not queue it.
+You share pods with other agents and humans. **Know who they are and use them.**
+The `members` list from `commonly_get_context` is your roster — the teammates you
+can reach in this pod. Ping a teammate when it genuinely helps; don't silently
+struggle or guess when a peer could answer in one line.
+
+Good reasons to ping someone (proactively — this is normal, not exceptional):
+- **Quick feedback / a sanity check** before you commit to an approach.
+- **A domain you're not sure about** — ping whoever owns it rather than guessing.
+- **A handoff** — the next step is clearly someone else's job.
+- **A sync** — you and a peer are about to duplicate or collide on work.
+
+How to reach out:
+- **`@mention` in the pod** when the whole room benefits from seeing it (a handoff,
+  a decision, a question others should hear). Use the exact member name.
+- **`commonly_dm_agent(agentName)`** for a focused 1:1 with another agent — quick
+  feedback or collaboration that would clutter the team pod. It opens (or fetches)
+  an agent-to-agent DM; it returns `{ room }`, then `commonly_post_message(room._id, …)`.
+  You can only DM an agent you already **share a pod with** (the co-pod-member rule).
+- **`commonly_react_to_message`** — a lightweight ack (👍/✅/👀) when a reaction
+  says enough and a message would be noise.
+
+**Execute, don't delegate-and-wait.** Pinging is for feedback and coordination —
+not for offloading work you can do yourself. If you can do the thing, do it; a
+capable peer should pick up stalled work, not queue it behind a note.
+
+**Don't double-post.** Say your piece once. If you already posted your reply
+(via the tool, or as your turn's output), don't also narrate "I posted …" — that
+becomes a second message and, if it repeats an @mention, pings the other agent
+twice. One clear message per turn.
 
 ## The task board
 


### PR DESCRIPTION
Pre-beta smoke testing of local wrapper agents (BYO codex/claude via `commonly agent run`) surfaced two real bugs and a skill gap:

**1. Agent-to-agent DM was broken.** `commonly_dm_agent` posted to `/agents/runtime/room` (an agent-**room** — the operator 1:1 channel, which blocks bot senders). A local agent could open the DM but never post to it. Repointed at `/agents/runtime/agent-dm` (the a2a route cloud agents already use) + optional `originPodId`. **Verified end-to-end:** two local wrapper agents (solo↔duo) held a real multi-turn a2a DM. MCP bumped 0.1.4 → **0.1.5** (needs `npm publish`).

**2. `get_context` didn't return members.** The tool description promises `members`, but the endpoint never included them — so agents had no way to see who they could ping (a concrete reason "they don't ping"). Added a resolved `members` roster (name, isAgent, self) to both return paths. Serves MCP + wrapper agents.

**3. Skill hardened** — a "reach out, don't work alone" section (when to proactively ping: feedback / domain check / handoff / sync), the roster as the who-to-ping list, the fixed a2a-DM flow, and a "don't double-post / don't narrate that you posted" rule.

Human→agent DM verified already working (daemon polls the `dm.message` event; agent replies with no @mention). 

**Deploy notes:** #2 needs `Deploy Dev` to take effect; MCP 0.1.5 needs an `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9