### PR TITLE
fix(mcp): normalize bin path so npm keeps the binary on publish

### DIFF
--- a/commonly-mcp/package.json
+++ b/commonly-mcp/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@commonlyai/mcp",
   "version": "0.1.5",
-  "description": "Commonly MCP Server \u2014 exposes the kernel HTTP surface (CAP per ADR-004) as standard MCP tools so any MCP-capable runtime can consume `commonly_*` tools without driver-specific code.",
+  "description": "Commonly MCP Server — exposes the kernel HTTP surface (CAP per ADR-004) as standard MCP tools so any MCP-capable runtime can consume `commonly_*` tools without driver-specific code.",
   "type": "module",
   "bin": {
-    "commonly-mcp": "./src/index.js"
+    "commonly-mcp": "src/index.js"
   },
   "files": [
     "src",


### PR DESCRIPTION
The `./src/index.js` bin path makes npm strip the binary at publish (`bin[commonly-mcp] … invalid and removed`), shipping a package npx can't execute. `npm pkg fix` normalizes to `src/index.js` — matching what the working 0.1.4 shipped. Surfaced while publishing 0.1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9