### PR TITLE
feat(agents): let local agents read human-uploaded pod files

### DIFF
--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -23,6 +23,8 @@ const User = require('../models/User');
 const Post = require('../models/Post');
 const Pod = require('../models/Pod');
 const { AgentInstallation } = require('../models/AgentRegistry');
+const File = require('../models/File');
+const { getObjectStore } = require('../services/objectStore');
 const { requireApiTokenScopes } = require('../middleware/apiTokenScopes');
 const { isGlobalAdminUser } = require('./registry/helpers');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -1319,6 +1321,105 @@ router.get('/pods/:podId/messages', agentRuntimeAuth, async (req: any, res: any)
   } catch (error: any) {
     console.error('Error fetching pod messages:', error);
     return res.status(500).json({ message: 'Failed to fetch messages' });
+  }
+});
+
+/**
+ * GET /pods/:podId/files
+ * List files uploaded into this pod so an agent can discover what a human
+ * shared (metadata only). Content is fetched via .../files/:fileName/content.
+ */
+router.get('/pods/:podId/files', agentRuntimeAuth, async (req: any, res: any) => {
+  try {
+    const { podId } = req.params;
+    if (!ensurePodMatch(req.agentInstallations || req.agentInstallation, podId, req.agentAuthorizedPodIds)) {
+      return res.status(403).json({ message: 'Agent token not authorized for this pod' });
+    }
+    const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 25, 1), 50);
+    const files = await File.find({ podId })
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .select('fileName originalName contentType size createdAt')
+      .lean();
+    return res.json({
+      files: (files || []).map((f: any) => ({
+        fileName: f.fileName,
+        name: f.originalName,
+        contentType: f.contentType,
+        size: f.size,
+        uploadedAt: f.createdAt,
+      })),
+    });
+  } catch (error: any) {
+    console.error('Error listing pod files:', error);
+    return res.status(500).json({ message: 'Failed to list files' });
+  }
+});
+
+/**
+ * GET /pods/:podId/files/:fileName/content
+ * Return a pod file's content so an agent can read what a human uploaded.
+ * Text-like files come back as UTF-8 in `content`; binary/oversized files
+ * return metadata + a note (no bytes). The file must belong to THIS pod —
+ * this prevents cross-pod reads via a guessed fileName.
+ */
+const AGENT_FILE_TEXT_MAX = 256 * 1024; // 256 KB cap on inlined text
+router.get('/pods/:podId/files/:fileName/content', agentRuntimeAuth, async (req: any, res: any) => {
+  try {
+    const { podId, fileName } = req.params;
+    if (!ensurePodMatch(req.agentInstallations || req.agentInstallation, podId, req.agentAuthorizedPodIds)) {
+      return res.status(403).json({ message: 'Agent token not authorized for this pod' });
+    }
+    const file = await File.findOne({ fileName, podId })
+      .select('fileName originalName contentType size')
+      .lean() as any;
+    if (!file) {
+      return res.status(404).json({ message: 'File not found in this pod' });
+    }
+
+    // Fetch bytes: object store first, legacy inline data as fallback.
+    let buffer: Buffer | null = null;
+    const store = getObjectStore();
+    const obj = await store.get(fileName);
+    if (obj && obj.stream) {
+      buffer = await new Promise<Buffer>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        obj.stream.on('data', (c: Buffer) => chunks.push(c));
+        obj.stream.on('end', () => resolve(Buffer.concat(chunks)));
+        obj.stream.on('error', reject);
+      });
+    } else {
+      const legacy = await File.findByFileName(fileName);
+      if (legacy && legacy.data && legacy.data.length > 0) buffer = legacy.data;
+    }
+    if (!buffer) {
+      return res.status(404).json({ message: 'File content not found' });
+    }
+
+    const ct = String(file.contentType || '');
+    const isText = /^text\/|json|csv|xml|javascript|markdown|yaml|x-sh|html/.test(ct);
+    if (isText && buffer.length <= AGENT_FILE_TEXT_MAX) {
+      return res.json({
+        fileName: file.fileName,
+        name: file.originalName,
+        contentType: file.contentType,
+        size: file.size,
+        content: buffer.toString('utf8'),
+      });
+    }
+    return res.json({
+      fileName: file.fileName,
+      name: file.originalName,
+      contentType: file.contentType,
+      size: file.size,
+      content: null,
+      note: isText
+        ? `File is ${buffer.length} bytes, over the ${AGENT_FILE_TEXT_MAX}-byte inline text limit.`
+        : 'Binary file — content is not returned as text.',
+    });
+  } catch (error: any) {
+    console.error('Error reading pod file:', error);
+    return res.status(500).json({ message: 'Failed to read file' });
   }
 });
 

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -1329,7 +1329,7 @@ router.get('/pods/:podId/messages', agentRuntimeAuth, async (req: any, res: any)
  * List files uploaded into this pod so an agent can discover what a human
  * shared (metadata only). Content is fetched via .../files/:fileName/content.
  */
-router.get('/pods/:podId/files', agentRuntimeAuth, async (req: any, res: any) => {
+router.get('/pods/:podId/files', phase4RateLimit, agentRuntimeAuth, async (req: any, res: any) => {
   try {
     const { podId } = req.params;
     if (!ensurePodMatch(req.agentInstallations || req.agentInstallation, podId, req.agentAuthorizedPodIds)) {
@@ -1364,9 +1364,16 @@ router.get('/pods/:podId/files', agentRuntimeAuth, async (req: any, res: any) =>
  * this prevents cross-pod reads via a guessed fileName.
  */
 const AGENT_FILE_TEXT_MAX = 256 * 1024; // 256 KB cap on inlined text
-router.get('/pods/:podId/files/:fileName/content', agentRuntimeAuth, async (req: any, res: any) => {
+router.get('/pods/:podId/files/:fileName/content', phase4RateLimit, agentRuntimeAuth, async (req: any, res: any) => {
   try {
-    const { podId, fileName } = req.params;
+    const { podId } = req.params;
+    // Reject any fileName that isn't a plain stored name — no path separators
+    // or traversal reaches the object store (defense in depth beyond the
+    // pod-scoped File.findOne gate below).
+    const fileName = String(req.params.fileName || '');
+    if (!/^[A-Za-z0-9._-]+$/.test(fileName)) {
+      return res.status(400).json({ message: 'Invalid file name' });
+    }
     if (!ensurePodMatch(req.agentInstallations || req.agentInstallation, podId, req.agentAuthorizedPodIds)) {
       return res.status(403).json({ message: 'Agent token not authorized for this pod' });
     }

--- a/backend/services/podContextService.ts
+++ b/backend/services/podContextService.ts
@@ -11,6 +11,8 @@ const PodSkillService = require('./podSkillService');
 // eslint-disable-next-line global-require
 const User = require('../models/User');
 // eslint-disable-next-line global-require
+const File = require('../models/File');
+// eslint-disable-next-line global-require
 const { resolveAgentDisplayLabel } = require('./agentIdentityService');
 
 const CHARS_PER_TOKEN = 3; // Conservative estimate for JSON/markdown content
@@ -403,6 +405,26 @@ class PodContextService {
       }));
     }
 
+    // Files a human uploaded into this pod, so an agent orienting via
+    // get_context discovers them (and can read one with commonly_read_file).
+    // Metadata only — content is fetched on demand.
+    let files: Array<{ fileName: string; name: string; contentType: string; size: number }> = [];
+    try {
+      const fileDocs = await File.find({ podId })
+        .sort({ createdAt: -1 })
+        .limit(20)
+        .select('fileName originalName contentType size')
+        .lean();
+      files = (fileDocs as Array<Record<string, unknown>>).map((f) => ({
+        fileName: f.fileName as string,
+        name: (f.originalName as string) || (f.fileName as string),
+        contentType: (f.contentType as string) || 'application/octet-stream',
+        size: (f.size as number) || 0,
+      }));
+    } catch {
+      files = [];
+    }
+
     const visibilityFilter = PodAssetService.buildAgentScopeFilter(agentContext);
     const assetQuery = PodAssetService.applyVisibilityFilter(
       { podId, status: 'active', type: { $ne: 'skill' } },
@@ -472,6 +494,7 @@ class PodContextService {
       const synthesisResult = await PodSkillService.synthesizeSkills({
         pod: podDescriptor,
       members,
+      files,
         task,
         summaries: rankedSummaries,
         assets: rankedAssets,
@@ -575,6 +598,7 @@ class PodContextService {
       activityAvailable: hasActivity,
       pod: podDescriptor,
       members,
+      files,
       task: task || null,
       stats: {
         summaries: finalSummaries.length,

--- a/cli/skills/commonly/SKILL.md
+++ b/cli/skills/commonly/SKILL.md
@@ -124,9 +124,15 @@ as you go, complete when done — so humans and other agents can see the state.
 
 ## Files
 
-If a human shared a file and you need to produce one back, `commonly_attach_file`
-posts it into the pod. (Reading human-uploaded files back is still limited — if
-you can't see an attachment's contents, say so rather than guessing.)
+- **Reading what a human shared.** `commonly_get_context` lists uploaded files
+  under `files` (and `commonly_list_files` lists them explicitly). When someone
+  references a file — "read the brief", "check the CSV" — call
+  **`commonly_read_file(podId, fileName)`** and answer from its actual contents.
+  Don't guess. Text files come back as `content`; for a binary or oversized file
+  you'll get a `note` instead of bytes — say so plainly rather than inventing an
+  answer.
+- **Producing one back.** `commonly_attach_file` posts a file you created into
+  the pod.
 
 ## The short version
 

--- a/commonly-mcp/__tests__/tools.test.mjs
+++ b/commonly-mcp/__tests__/tools.test.mjs
@@ -15,13 +15,14 @@ const tools = buildTools(cfg);
 const byName = Object.fromEntries(tools.map((t) => [t.name, t]));
 
 describe('tool registry shape', () => {
-  it('ships exactly the v1 surface (19 tools)', () => {
+  it('ships exactly the v1 surface (21 tools)', () => {
     // 14 tools (ADR-010 Phase 1) + 2 added in Phase 4 (commonly_save_my_memory,
     // commonly_log_cycle) so MCP-capable runtimes (Claude Code, Cursor, Codex
     // via wrapper) have the same memory write surface as the openclaw extension.
     // + 1 added by PR #389 (commonly_react_to_message).
     // + 2 added for PR code review (commonly_pr_diff, commonly_pr_review, #441).
-    expect(tools).toHaveLength(19);
+    // + 2 added for agent file access (commonly_list_files, commonly_read_file).
+    expect(tools).toHaveLength(21);
   });
 
   it('every tool has name, description, inputSchema, call', () => {
@@ -98,6 +99,25 @@ describe('commonly_get_context', () => {
     const [url, init] = fetchSpy.mock.calls[0];
     expect(url).toBe('https://x.example/api/agents/runtime/pods/POD/context');
     expect(init.method).toBe('GET');
+  });
+});
+
+describe('commonly_list_files / commonly_read_file', () => {
+  it('list_files GETs the pod files endpoint', async () => {
+    const fetchSpy = installFetch(async () => okResponse({ files: [] }));
+    await byName.commonly_list_files.call({ podId: 'POD' });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://x.example/api/agents/runtime/pods/POD/files');
+    expect(init.method).toBe('GET');
+  });
+
+  it('read_file GETs the file content endpoint with an encoded fileName', async () => {
+    const fetchSpy = installFetch(async () => okResponse({ content: 'BANANA-42' }));
+    const result = await byName.commonly_read_file.call({ podId: 'POD', fileName: 'a b.txt' });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://x.example/api/agents/runtime/pods/POD/files/a%20b.txt/content');
+    expect(init.method).toBe('GET');
+    expect(JSON.parse(result.content[0].text)).toEqual({ content: 'BANANA-42' });
   });
 });
 

--- a/commonly-mcp/package.json
+++ b/commonly-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.1.5",
-  "description": "Commonly MCP Server — exposes the kernel HTTP surface (CAP per ADR-004) as standard MCP tools so any MCP-capable runtime can consume `commonly_*` tools without driver-specific code.",
+  "version": "0.1.6",
+  "description": "Commonly MCP Server \u2014 exposes the kernel HTTP surface (CAP per ADR-004) as standard MCP tools so any MCP-capable runtime can consume `commonly_*` tools without driver-specific code.",
   "type": "module",
   "bin": {
     "commonly-mcp": "src/index.js"

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -92,11 +92,29 @@ export const buildTools = (config) => {
     },
     {
       name: 'commonly_get_context',
-      description: 'Read pod context — recent messages, recent posts, members, pod metadata. Call this FIRST, before you post — never reply blind. The right tool for "what is this pod about right now?".',
+      description: 'Read pod context — recent messages, recent posts, members (who you can @mention/DM), files a human shared, and pod metadata. Call this FIRST, before you post — never reply blind. The right tool for "what is this pod about right now?". If `files` is non-empty and someone references one, read it with commonly_read_file before answering.',
       inputSchema: reqWith({ podId: STRING }, ['podId']),
       call: wrap(async ({ podId }) => request(config, {
         method: 'GET',
         path: `/api/agents/runtime/pods/${encodeURIComponent(podId)}/context`,
+      })),
+    },
+    {
+      name: 'commonly_list_files',
+      description: 'List the files a human uploaded into a pod (name, type, size) — metadata only. Use this to discover what has been shared, then read one with commonly_read_file. get_context also surfaces these under `files`.',
+      inputSchema: reqWith({ podId: STRING }, ['podId']),
+      call: wrap(async ({ podId }) => request(config, {
+        method: 'GET',
+        path: `/api/agents/runtime/pods/${encodeURIComponent(podId)}/files`,
+      })),
+    },
+    {
+      name: 'commonly_read_file',
+      description: 'Read the content of a file a human uploaded into a pod. Pass the `fileName` from commonly_list_files or the context `files` list. Text files (txt/md/csv/json/etc.) come back as `content`; binary or oversized files return metadata + a `note` instead of bytes. Read the shared file before answering a question about it — do not guess at its contents.',
+      inputSchema: reqWith({ podId: STRING, fileName: STRING }, ['podId', 'fileName']),
+      call: wrap(async ({ podId, fileName }) => request(config, {
+        method: 'GET',
+        path: `/api/agents/runtime/pods/${encodeURIComponent(podId)}/files/${encodeURIComponent(fileName)}/content`,
       })),
     },
     {

--- a/docs/agents/skills/commonly/SKILL.md
+++ b/docs/agents/skills/commonly/SKILL.md
@@ -124,9 +124,15 @@ as you go, complete when done — so humans and other agents can see the state.
 
 ## Files
 
-If a human shared a file and you need to produce one back, `commonly_attach_file`
-posts it into the pod. (Reading human-uploaded files back is still limited — if
-you can't see an attachment's contents, say so rather than guessing.)
+- **Reading what a human shared.** `commonly_get_context` lists uploaded files
+  under `files` (and `commonly_list_files` lists them explicitly). When someone
+  references a file — "read the brief", "check the CSV" — call
+  **`commonly_read_file(podId, fileName)`** and answer from its actual contents.
+  Don't guess. Text files come back as `content`; for a binary or oversized file
+  you'll get a `note` instead of bytes — say so plainly rather than inventing an
+  answer.
+- **Producing one back.** `commonly_attach_file` posts a file you created into
+  the pod.
 
 ## The short version
 


### PR DESCRIPTION
Smoke testing found a local agent had **zero visibility** into a file a human uploaded — `get_context` showed no files, message attachments were dropped on write, and no read tool existed. Files *are* persisted (File rows bound to `podId`), just never surfaced. This wires the read path (no message-schema change):

- **Backend**: `GET /pods/:podId/files` (list) + `/pods/:podId/files/:fileName/content` (read). Both gate on `ensurePodMatch`; the content route also requires the file to belong to *that* pod (no cross-pod read via a guessed name). Text → UTF-8 `content` (256 KB cap); binary/oversized → metadata + `note`. Object store first, legacy inline bytes fallback.
- **Context**: `get_context` now includes a `files` array so agents discover shared files while orienting.
- **MCP (0.1.6)**: `commonly_list_files` + `commonly_read_file`.
- **Skill**: read a referenced file before answering.

Deploying from this branch to dev to prove it live (agent reads the known `BANANA-42` test file) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9