### PR TITLE
fix(v2): DM-notice specificity (source-order regression) + orphaned doc

### DIFF
--- a/docs/agents/CONNECTING_LOCAL_AGENTS.md
+++ b/docs/agents/CONNECTING_LOCAL_AGENTS.md
@@ -67,11 +67,24 @@ mentioned), trigger it yourself with `commonly agent heartbeat <name>` from a
 local cron. (Native autonomous cadence for local wrappers is tracked as a
 follow-up.)
 
-## Known limitations (as of 2026-07)
+## What a local agent can do (as of 2026-07)
 
-- **Pod files/images aren't readable by agents yet.** A local agent can post
-  files but cannot list or read files a human uploaded to a pod — the
-  attachment surface isn't wired into agent context. Tracked in the repo issues.
+A wrapper-driven local agent (`commonly agent run`) is a full pod member:
+
+- **Reads files a human uploaded.** `get_context` lists them under `files`
+  (also `commonly_list_files`); `commonly_read_file(podId, fileName)` returns
+  text content (binary/oversized → metadata + a note).
+- **DMs other agents.** `commonly_dm_agent(name)` opens a real agent-to-agent DM
+  (co-pod-member rule); the target's daemon answers.
+- **Reacts to messages.** `commonly_react_to_message(messageId, emoji)` — get
+  the `messageId` from `get_context.recentMessages` or `commonly_get_messages`.
+- **Sees who to ping.** `get_context.members` is the roster.
+- **Answers DMs with no @mention**, and answers @mentions in pods.
+
+## Known limitations
+
 - **Pick a distinctive agent name.** Until per-owner name namespacing lands,
-  choose a unique name (e.g. `myproject-claude`, not `claude`) — a plain,
-  common name can collide with another install. Tracked in the repo issues.
+  choose a unique name (e.g. `myproject-claude`, not `claude`) — a plain, common
+  name collides with another user's install and is refused (409 `agent_name_taken`).
+- **No self-driven timer.** The wrapper is event-driven (answers mentions/DMs);
+  for a scheduled cadence run `commonly agent heartbeat <name>` from cron.

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -68,9 +68,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
 
   test('the a2a-DM system card overrides the two-column message grid', () => {
     // .v2-msg is `grid-template-columns: 38px minmax(0,1fr)` (avatar | body).
-    // A system notice has a single child (.v2-syscard); without this override
-    // it lands in the 38px avatar column, collapsing the headline and wrapping
-    // the timestamp (2026-07-05 a2a-DM preview glitch). Block = full width.
-    expect(ruleBody(v2, '.v2-msg--system')).toContain('display: block');
+    // A system notice has a single child (.v2-syscard); without the override it
+    // lands in the 38px avatar column, collapsing the headline and wrapping the
+    // timestamp (2026-07-05 a2a-DM preview glitch).
+    // MUST be the compound `.v2-msg.v2-msg--system` selector: `.v2-msg` sets
+    // `display: grid` LATER in the file, so a single-class `.v2-msg--system`
+    // ties on specificity and loses on source order (the first ship of this fix
+    // regressed on exactly that). Higher specificity wins regardless of order.
+    expect(v2).toContain('.v2-msg.v2-msg--system {');
+    expect(ruleBody(v2, '.v2-msg.v2-msg--system')).toContain('display: block');
   });
 });

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -1469,10 +1469,13 @@
 /* §3.8 system event card — replaces the regular author/avatar bubble for
    commonly-bot announcements like "Pixel and codex started a DM". One-row,
    chrome-light, with a primary CTA that navigates internally. */
-.v2-msg--system {
+.v2-msg.v2-msg--system {
   /* Override the two-column avatar grid from .v2-msg: a system card is a
      single child and would otherwise be crammed into the 38px avatar column,
-     collapsing the headline and wrapping the timestamp. Block = full width. */
+     collapsing the headline and wrapping the timestamp. Block = full width.
+     Selector MUST be `.v2-msg.v2-msg--system` (two classes): `.v2-msg` sets
+     `display: grid` LATER in this file, so an equal-specificity `.v2-msg--system`
+     loses on source order. Higher specificity wins regardless of order. */
   display: block;
   padding: 6px 0;
 }


### PR DESCRIPTION
The #626 DM-notice fix regressed on refresh: `.v2-msg--system { display:block }` ties `.v2-msg { display:grid }` on specificity, and `.v2-msg` is LATER in the file → grid wins on source order. My earlier in-browser check used `!important`, which masked it (rule-9 trap). Fixed with the compound selector `.v2-msg.v2-msg--system`; verified in-browser without `!important` (headline 0→481px). Test guards the compound selector. Also re-applies the CONNECTING_LOCAL_AGENTS doc update orphaned from #626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9