### PR TITLE
feat(v2): lock marketplace (coming soon) + friendly agent intros + profile entry

### DIFF
--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -179,7 +179,7 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
       const synthManifest = {
         name: String(agentName).toLowerCase(),
         version: String(version || '1.0.0'),
-        description: 'Self-serve agent installed via CAP (ADR-006).',
+        description: 'A connected agent.',
         capabilities: [],
         context: { required: [], optional: [] },
         runtime: { type: 'standalone', connection: 'rest' },

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -239,7 +239,7 @@ export const performAttach = async ({
       manifest: {
         name: agentName,
         version: '1.0.0',
-        description: `${adapter.name} CLI wrapped as a Commonly agent (ADR-005).`,
+        description: `A local ${adapter.name} agent.`,
         runtimeType,
       },
       displayName: displayName || agentName,
@@ -777,7 +777,7 @@ Docs:
           manifest: {
             name: opts.name,
             version: '1.0.0',
-            description: `Webhook-driven Commonly agent (ADR-006) at ${opts.webhook}.`,
+            description: 'A webhook-connected agent.',
             runtimeType: 'webhook',
           },
           displayName: opts.display || opts.name,

--- a/frontend/src/v2/components/V2YourTeamPage.tsx
+++ b/frontend/src/v2/components/V2YourTeamPage.tsx
@@ -385,15 +385,28 @@ const V2YourTeamPage: React.FC = () => {
                   {lastSeen}
                 </div>
               </div>
-              <button
-                type="button"
-                className="v2-team-card__talk"
-                onClick={(e) => handleTalkTo(a, e)}
-                disabled={isOpening}
-                aria-label={`Talk to ${display} one-to-one`}
-              >
-                {isOpening ? 'Opening…' : 'Talk to'}
-              </button>
+              <div className="v2-team-card__actions">
+                <button
+                  type="button"
+                  className="v2-team-card__profile"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    navigate(`/v2/agent/${encodeURIComponent(a.name)}/${encodeURIComponent(a.instanceId || 'default')}`);
+                  }}
+                  aria-label={`View ${display}'s profile`}
+                >
+                  Profile
+                </button>
+                <button
+                  type="button"
+                  className="v2-team-card__talk"
+                  onClick={(e) => handleTalkTo(a, e)}
+                  disabled={isOpening}
+                  aria-label={`Talk to ${display} one-to-one`}
+                >
+                  {isOpening ? 'Opening…' : 'Talk to'}
+                </button>
+              </div>
             </article>
           );
         })}

--- a/frontend/src/v2/marketplace/V2MarketplacePage.css
+++ b/frontend/src/v2/marketplace/V2MarketplacePage.css
@@ -358,3 +358,53 @@
   .v2-mkt { padding: 20px 16px 48px; }
   .v2-mkt__control { flex: 1 1 calc(50% - 5px); }
 }
+
+/* Pre-beta "coming soon" lock (V2MarketplacePage MARKETPLACE_LOCKED). */
+.v2-mkt__comingsoon {
+  max-width: 520px;
+  margin: 48px auto;
+  padding: 40px 32px;
+  text-align: center;
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-border-soft);
+  border-radius: var(--v2-radius-lg, 16px);
+}
+.v2-mkt__comingsoon-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: var(--v2-radius-pill, 999px);
+  background: var(--v2-accent-soft);
+  color: var(--v2-accent-text);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.v2-mkt__comingsoon-title {
+  margin: 16px 0 8px;
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--v2-text-primary);
+}
+.v2-mkt__comingsoon-text {
+  margin: 0 auto 24px;
+  max-width: 420px;
+  font-size: 14.5px;
+  line-height: 1.55;
+  color: var(--v2-text-secondary);
+}
+.v2-root button.v2-mkt__comingsoon-cta,
+.v2-mkt__comingsoon-cta {
+  padding: 10px 20px;
+  border: none;
+  border-radius: var(--v2-radius-pill, 999px);
+  background: var(--v2-accent);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.v2-root button.v2-mkt__comingsoon-cta:hover,
+.v2-mkt__comingsoon-cta:hover {
+  background: var(--v2-accent-hover, var(--v2-accent));
+}

--- a/frontend/src/v2/marketplace/V2MarketplacePage.tsx
+++ b/frontend/src/v2/marketplace/V2MarketplacePage.tsx
@@ -365,6 +365,39 @@ const V2MarketplacePage: React.FC = () => {
     );
   };
 
+  // Pre-beta lock: the catalog still surfaces raw integrations + entitlement-
+  // gated cloud agents that a new user can't cleanly install, so we hold the
+  // marketplace behind a "coming soon" wall and point people at the ready path
+  // (bring your own agent). Flip MARKETPLACE_LOCKED to false to restore the
+  // full catalog once it's curated + install-flows are entitlement-aware.
+  const MARKETPLACE_LOCKED = true;
+  if (MARKETPLACE_LOCKED) {
+    return (
+      <div className="v2-mkt">
+        <header className="v2-mkt__header">
+          <h1 className="v2-mkt__title">Marketplace</h1>
+          <p className="v2-mkt__subtitle">Install agents and apps like packages.</p>
+        </header>
+        <div className="v2-mkt__comingsoon">
+          <div className="v2-mkt__comingsoon-badge">Coming soon</div>
+          <h2 className="v2-mkt__comingsoon-title">A marketplace of installable agents</h2>
+          <p className="v2-mkt__comingsoon-text">
+            We&apos;re curating agents you can install in one click. In the meantime,
+            you can already bring your own — connect Claude Code, Cursor, or Codex and
+            it becomes a full member of your pods.
+          </p>
+          <button
+            type="button"
+            className="v2-mkt__comingsoon-cta"
+            onClick={() => navigate('/v2/agents/byo')}
+          >
+            Bring your own agent
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="v2-mkt">
       <header className="v2-mkt__header">

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4698,6 +4698,30 @@
   white-space: nowrap;
   transition: background 80ms ease, color 80ms ease;
 }
+
+.v2-team-card__actions {
+  align-self: center;
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.v2-root button.v2-team-card__profile {
+  display: inline-flex;
+  align-items: center;
+  height: 32px;
+  padding: 0 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v2-text-secondary);
+  background: transparent;
+  border: 1px solid var(--v2-border-soft);
+  border-radius: var(--v2-radius-sm);
+  cursor: pointer;
+}
+.v2-root button.v2-team-card__profile:hover {
+  color: var(--v2-text-primary);
+  border-color: var(--v2-border);
+}
 .v2-root button.v2-team-card__talk:hover {
   background: var(--v2-accent);
   color: #fff;


### PR DESCRIPTION
Pre-beta polish from a live walk-through:

**1. Marketplace → "coming soon".** The catalog surfaces raw integrations (Discord) + entitlement-gated cloud agents a new user can't cleanly install — a broken first impression. Held behind a coming-soon wall pointing at the ready path (bring your own agent). `MARKETPLACE_LOCKED` flag flips it back when the catalog is curated + entitlement-aware.

**2. Friendlier agent intros.** Installs described themselves with internal ADR refs in the join message ("…wrapped as a Commonly agent (ADR-005)" / "installed via CAP (ADR-006)"). Now "A local <adapter> agent." / "A connected agent." (new installs; existing agents keep their stored description).

**3. Agent profile reachable.** `/v2/agent/:name/:instanceId` had no entry point — added a "Profile" button on each Your Team card.

File access re-verified live post-deploy (a fresh agent read the brief → BANANA-42 + go-live date); the earlier "no files" was pre-deploy. Marketplace lock + profile entry will get a real-browser check after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9