### PR TITLE
feat(mcp): commonly_attach_file — agents can upload files (0.1.7)

### DIFF
--- a/commonly-mcp/__tests__/tools.test.mjs
+++ b/commonly-mcp/__tests__/tools.test.mjs
@@ -22,7 +22,8 @@ describe('tool registry shape', () => {
     // + 1 added by PR #389 (commonly_react_to_message).
     // + 2 added for PR code review (commonly_pr_diff, commonly_pr_review, #441).
     // + 2 added for agent file access (commonly_list_files, commonly_read_file).
-    expect(tools).toHaveLength(21);
+    // + 1 added for agent file upload (commonly_attach_file).
+    expect(tools).toHaveLength(22);
   });
 
   it('every tool has name, description, inputSchema, call', () => {

--- a/commonly-mcp/package.json
+++ b/commonly-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Commonly MCP Server \u2014 exposes the kernel HTTP surface (CAP per ADR-004) as standard MCP tools so any MCP-capable runtime can consume `commonly_*` tools without driver-specific code.",
   "type": "module",
   "bin": {

--- a/commonly-mcp/src/client.js
+++ b/commonly-mcp/src/client.js
@@ -98,3 +98,42 @@ export const request = async (config, { method, path, query, body, _fetchImpl = 
   }
   return parsed;
 };
+
+/**
+ * Multipart upload — for attaching a local file to a pod. Node 18+ has global
+ * FormData / Blob, so no runtime deps. `fileField` is the multipart field name
+ * the backend's multer middleware expects. Same response handling as `request`.
+ */
+export const requestUpload = async (config, {
+  path, fileBuffer, fileName, contentType, fileField = 'file', fields = {}, _fetchImpl = fetch,
+} = {}) => {
+  const url = `${config.baseUrl}${path}`;
+  const form = new FormData();
+  form.append(
+    fileField,
+    new Blob([fileBuffer], { type: contentType || 'application/octet-stream' }),
+    fileName,
+  );
+  for (const [k, v] of Object.entries(fields)) {
+    if (v !== undefined && v !== null) form.append(k, String(v));
+  }
+  // Do NOT set Content-Type — fetch sets the multipart boundary itself.
+  const res = await _fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${config.token}`,
+      'User-Agent': USER_AGENT,
+      Accept: 'application/json',
+    },
+    body: form,
+  });
+  const raw = await res.text();
+  let parsed;
+  try { parsed = raw ? JSON.parse(raw) : null; } catch { parsed = raw; }
+  if (!res.ok) {
+    const message = (parsed && typeof parsed === 'object' && parsed.message)
+      || (typeof parsed === 'string' ? parsed.slice(0, 500) : `HTTP ${res.status}`);
+    throw new HttpError(res.status, parsed, message);
+  }
+  return parsed;
+};

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -18,7 +18,21 @@
  * human-JWT-only route.
  */
 
-import { request, HttpError } from './client.js';
+import { readFileSync } from 'fs';
+import { basename, extname } from 'path';
+import { request, requestUpload, HttpError } from './client.js';
+
+// Minimal content-type guess for attach — the backend re-derives `kind`, this
+// just sets a sensible multipart type. Keep the map small; default is generic.
+const CONTENT_TYPES = {
+  '.txt': 'text/plain', '.md': 'text/markdown', '.csv': 'text/csv',
+  '.json': 'application/json', '.pdf': 'application/pdf', '.png': 'image/png',
+  '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.gif': 'image/gif',
+  '.html': 'text/html', '.xml': 'application/xml', '.log': 'text/plain',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+};
 
 // Convert a successful response into the MCP `content` shape. Strings and
 // JSON-serialisable values both go through `JSON.stringify` so the model
@@ -116,6 +130,35 @@ export const buildTools = (config) => {
         method: 'GET',
         path: `/api/agents/runtime/pods/${encodeURIComponent(podId)}/files/${encodeURIComponent(fileName)}/content`,
       })),
+    },
+    {
+      name: 'commonly_attach_file',
+      description: 'Attach a file from THIS machine into a pod so humans and other agents can see and read it — a report you wrote, a diff, a generated CSV/deck, etc. Pass `filePath` (a path on the local filesystem). It uploads the file and posts it into the pod as a file card; add `message` for a line of context alongside it. Returns the uploaded file metadata (its `fileName` is what commonly_read_file takes).',
+      inputSchema: reqWith({ podId: STRING, filePath: STRING, message: STRING }, ['podId', 'filePath']),
+      call: wrap(async ({ podId, filePath, message }) => {
+        const buffer = readFileSync(filePath);
+        const name = basename(filePath);
+        const contentType = CONTENT_TYPES[extname(name).toLowerCase()] || 'application/octet-stream';
+        const uploaded = await requestUpload(config, {
+          path: `/api/agents/runtime/pods/${encodeURIComponent(podId)}/uploads`,
+          fileBuffer: buffer,
+          fileName: name,
+          contentType,
+          fileField: 'file',
+          fields: { podId },
+        });
+        // Post a message with the [[upload:…]] directive so it renders as a
+        // file pill in the thread (same shape the human composer emits).
+        const u = uploaded || {};
+        const directive = `[[upload:${u.fileName || name}|${u.originalName || name}|${u.size || buffer.length}|${u.kind || 'document'}]]`;
+        const content = message ? `${message} ${directive}` : directive;
+        await request(config, {
+          method: 'POST',
+          path: `/api/agents/runtime/pods/${encodeURIComponent(podId)}/messages`,
+          body: { content },
+        });
+        return uploaded;
+      }),
     },
     {
       name: 'commonly_get_posts',


### PR DESCRIPTION
Completes the file loop. Agents could **read** human-uploaded files (0.1.6) but had no way to **attach** one they made. Adds `requestUpload` (multipart via Node's global FormData/Blob, no deps) + `commonly_attach_file(podId, filePath, message?)`: reads a local file, uploads to the agent upload endpoint, posts a `[[upload:…]]` directive so it renders as a file pill. Verified the multipart path live with an agent token. 22 tools.

Needs an npm publish (0.1.7) for external users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9