### PR TITLE
feat(v2): owner can remove an agent from a pod (profile management)

### DIFF
--- a/frontend/src/v2/agents/V2AgentProfile.tsx
+++ b/frontend/src/v2/agents/V2AgentProfile.tsx
@@ -137,6 +137,30 @@ const V2AgentProfile: React.FC = () => {
     }
   }, [agentName, instanceId]);
 
+  // Owner management: detach the agent from a pod. Identity + memory are kept
+  // (ADR-001 identity continuity) — it just leaves the pod. Owner-only; the
+  // remove control renders only when the private memory index loaded.
+  const [removing, setRemoving] = useState<string | null>(null);
+  const handleRemoveFromPod = useCallback(async (podId: string, podName: string) => {
+    const token = typeof window !== 'undefined' ? window.localStorage.getItem('token') : null;
+    if (!token || !agentName) return;
+    // eslint-disable-next-line no-alert
+    if (!window.confirm(`Remove ${agentName} from "${podName}"? Its memory and identity are kept — it just leaves this pod.`)) return;
+    setRemoving(podId);
+    try {
+      await getClient().delete(
+        `/api/registry/agents/${encodeURIComponent(agentName)}/pods/${encodeURIComponent(podId)}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      await Promise.all([fetchProfile(), fetchMemoryIndex()]);
+    } catch {
+      // eslint-disable-next-line no-alert
+      window.alert('Could not remove the agent from that pod.');
+    } finally {
+      setRemoving(null);
+    }
+  }, [agentName, fetchProfile, fetchMemoryIndex]);
+
   useEffect(() => { fetchProfile(); fetchMemoryIndex(); }, [fetchProfile, fetchMemoryIndex]);
 
   if (state === 'loading') {
@@ -218,6 +242,17 @@ const V2AgentProfile: React.FC = () => {
                       <Link className="v2-aprofile__pod-name" to={`/v2/pods/${p.id}`}>{p.name}</Link>
                       {p.lastMessage?.snippet && <span className="v2-aprofile__pod-msg">“{p.lastMessage.snippet}”</span>}
                       {p.lastActive && <span className="v2-aprofile__pod-when">active {timeAgo(p.lastActive)}</span>}
+                      {ownerPods && (
+                        <button
+                          type="button"
+                          className="v2-aprofile__pod-remove"
+                          onClick={() => handleRemoveFromPod(p.id, p.name)}
+                          disabled={removing === p.id}
+                          aria-label={`Remove ${agentName} from ${p.name}`}
+                        >
+                          {removing === p.id ? 'Removing…' : 'Remove'}
+                        </button>
+                      )}
                     </li>
                   ))}
                 </ul>

--- a/frontend/src/v2/agents/v2-agent-profile.css
+++ b/frontend/src/v2/agents/v2-agent-profile.css
@@ -197,3 +197,24 @@
   .v2-aprofile__grid { grid-template-columns: 1fr; }
   .v2-aprofile__nav .v2-aprofile__navlink { display: none; }
 }
+
+/* Owner-only detach control on each pod row (V2AgentProfile). */
+.v2-aprofile__pod { position: relative; padding-right: 84px; }
+.v2-root button.v2-aprofile__pod-remove {
+  position: absolute;
+  top: 8px;
+  right: 0;
+  padding: 3px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v2-text-secondary);
+  background: transparent;
+  border: 1px solid var(--v2-border-soft);
+  border-radius: var(--v2-radius-sm);
+  cursor: pointer;
+}
+.v2-root button.v2-aprofile__pod-remove:hover:not(:disabled) {
+  color: #c0392b;
+  border-color: #c0392b;
+}
+.v2-root button.v2-aprofile__pod-remove:disabled { opacity: 0.6; cursor: default; }


### PR DESCRIPTION
First UI agent-management action, per your 'we don't give users much freedom to manage agents' point. Owner-only **Remove** on each pod row of the agent profile → `DELETE /api/registry/agents/:name/pods/:podId`. Detach only — identity + memory kept (ADR-001), the confirm says so. Gated on the owner memory-index view.

Rationale: local agents run on the user's machine, so start/stop/model/env stay CLI by nature; the app owns the *server-side* management (detach, status, tokens). This is the highest-value piece of that. Will browser-verify after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9