### PR TITLE
feat(positioning): 'Chat with your [rotating tools]' — job-led hero, memory as the wedge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 
 # Commonly
 
-**The open-source workspace where your agents and team share one memory.**
+**Chat with your agents. Ship real work.**
 
-Your AI tools each keep their own context — so you end up carrying it between them. Commonly gives
-every agent and teammate **one shared memory and identity** to work from. Any runtime, your infra.
-Self-host in one command — no per-agent fees, no lock-in.
+Commonly is the open-source workspace where you get things done by talking to your agents —
+Claude Code, Cursor, Codex, OpenClaw, or your own — and they all share **one project memory**,
+so nothing gets re-explained. Any runtime, your infra. Self-host in one command —
+no per-agent fees, no lock-in.
 
 [![Tests](https://github.com/Team-Commonly/commonly/actions/workflows/tests.yml/badge.svg)](https://github.com/Team-Commonly/commonly/actions/workflows/tests.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#2f6feb" />
     <meta name="description" content="The open-source workspace where agents and teammates share one project memory — any runtime, your infra, no per-agent fees." />
-    <title>Commonly — one project memory shared by all your AI tools</title>
+    <title>Commonly — chat with your agents, ship real work</title>
 
     <!-- Social link previews. Crawlers (X, Slack, Discord, iMessage) read this
          static HTML only — the SPA never runs for them — so the tags live here,
@@ -14,15 +14,15 @@
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Commonly" />
     <meta property="og:url" content="https://commonly.me/" />
-    <meta property="og:title" content="Commonly — one project memory shared by all your AI tools" />
-    <meta property="og:description" content="The open-source workspace where agents and teammates share one project memory — any runtime, your infra, no per-agent fees." />
+    <meta property="og:title" content="Commonly — chat with your agents, ship real work" />
+    <meta property="og:description" content="The open-source workspace where you and your agents share one project memory — so nothing gets re-explained. Any runtime, your infra, no per-agent fees." />
     <meta property="og:image" content="https://commonly.me/og-card.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@sam_commonly" />
-    <meta name="twitter:title" content="Commonly — one project memory shared by all your AI tools" />
-    <meta name="twitter:description" content="The open-source workspace where agents and teammates share one project memory — any runtime, your infra, no per-agent fees." />
+    <meta name="twitter:title" content="Commonly — chat with your agents, ship real work" />
+    <meta name="twitter:description" content="The open-source workspace where you and your agents share one project memory — so nothing gets re-explained. Any runtime, your infra, no per-agent fees." />
     <meta name="twitter:image" content="https://commonly.me/og-card.png" />
     <script>
       // Force re-render on navigation

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -51,7 +51,9 @@ const fmt = (n?: number): string => (typeof n === 'number' ? n.toLocaleString() 
 // widest term, so the line never reflows), slides the active one up on a
 // brisk 1.4s cadence (slow felt like an assertion, not an enumeration). Reduced-motion / no-JS visitors get the static last
 // term ("your whole team"), which reads correctly on its own.
-const ROTATING_TERMS = ['Claude Code', 'Cursor', 'Codex', 'OpenClaw', 'your whole team'];
+// Completes "Chat with your …" — tools first, then the payoff. The last term
+// is the static/reduced-motion fallback, so it must read as the full claim.
+const ROTATING_TERMS = ['Claude Code', 'Cursor', 'Codex', 'OpenClaw', 'whole team'];
 
 const RotatingTerm: React.FC = () => {
   const [active, setActive] = useState(0);
@@ -242,14 +244,15 @@ const V2LandingPage: React.FC = () => {
         <section className="v2-landing__hero">
           <div className="v2-landing__hero-inner">
             <div className="v2-landing__eyebrow">Open-source · Apache 2.0</div>
-            <h1 className="v2-landing__title" aria-label="One memory for Claude Code, Cursor, Codex — your whole team.">
-              <StaggerWords text="One memory for" />
+            <h1 className="v2-landing__title" aria-label="Chat with your Claude Code, Cursor, Codex — your whole team.">
+              <StaggerWords text="Chat with your" />
               <br />
               <RotatingTerm />
             </h1>
             <p className="v2-landing__lede">
-              The open-source workspace where agents and teammates share one project
-              memory — any runtime, your infra, no per-agent fees.
+              Get real work done by talking to your agents — in an open-source
+              workspace where they all share one project memory, so nothing gets
+              re-explained. Any runtime, your infra, no per-agent fees.
             </p>
 
             <div className="v2-landing__cta-row">


### PR DESCRIPTION
Per Sam's positioning call: **stack the claims** — category/job first ("get real work done by chatting with your agents"), memory as the differentiator ("they all share one project memory, so nothing gets re-explained"). Raft has a workspace; tools have per-tool memory files; only Commonly has a workspace where the work compounds because every agent shares the brain.

- **Hero keeps the beloved rotation animation**: "One memory for [X]" → **"Chat with your [Claude Code → Cursor → Codex → OpenClaw → whole team]"**. Last term adjusted (`your whole team` → `whole team`) so the static fallback reads "Chat with your whole team", not "your your".
- Lede: job-led with the wedge folded in. The wedge section h2 ("One project memory shared by all your AI tools") stays as **beat two**.
- `<title>`/OG/Twitter → "chat with your agents, ship real work".
- README H1 tagline + opening: same stack.

Will browser-verify the rotation after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9