### PR TITLE
feat(memory): provenance + capped version history on section writes (#632 foundation)

### DIFF
--- a/backend/__tests__/unit/services/agentMemoryProvenance.test.js
+++ b/backend/__tests__/unit/services/agentMemoryProvenance.test.js
@@ -1,0 +1,84 @@
+/**
+ * GH#632 Tier-1 foundation: provenance stamp + capped version history on
+ * memory section writes (decorateSectionsWithProvenance).
+ */
+const {
+  decorateSectionsWithProvenance,
+  stampSectionsForWrite,
+} = require('../../../services/agentMemoryService');
+const { MEMORY_HISTORY_CAP } = require('../../../models/AgentMemory');
+
+const now = new Date('2026-07-05T12:00:00Z');
+const src = { runtime: 'claude-code', via: 'memory-put' };
+
+describe('decorateSectionsWithProvenance', () => {
+  it('stamps source (with writtenAt) on every blob section write', () => {
+    const stamped = stampSectionsForWrite({ long_term: { content: 'v1' } }, now);
+    const out = decorateSectionsWithProvenance(undefined, stamped, src, now);
+    expect(out.long_term.source).toMatchObject({ runtime: 'claude-code', via: 'memory-put' });
+    expect(out.long_term.source.writtenAt).toEqual(now);
+    expect(out.long_term.history).toBeUndefined(); // fresh doc — nothing replaced
+  });
+
+  it('pushes the replaced content into history, newest first, carrying its source', () => {
+    const prior = {
+      long_term: {
+        content: 'old fact',
+        visibility: 'private',
+        updatedAt: new Date('2026-07-01T00:00:00Z'),
+        byteSize: 8,
+        source: { runtime: 'codex', via: 'memory-sync' },
+      },
+    };
+    const stamped = stampSectionsForWrite({ long_term: { content: 'new fact' } }, now);
+    const out = decorateSectionsWithProvenance(prior, stamped, src, now);
+    expect(out.long_term.content).toBe('new fact');
+    expect(out.long_term.history).toHaveLength(1);
+    expect(out.long_term.history[0]).toMatchObject({
+      content: 'old fact',
+      source: { runtime: 'codex', via: 'memory-sync' },
+    });
+  });
+
+  it('is idempotent: unchanged content does not grow history but carries it forward', () => {
+    const prior = {
+      long_term: {
+        content: 'same',
+        visibility: 'private',
+        updatedAt: now,
+        byteSize: 4,
+        history: [{ content: 'older', replacedAt: now }],
+      },
+    };
+    const stamped = stampSectionsForWrite({ long_term: { content: 'same' } }, now);
+    const out = decorateSectionsWithProvenance(prior, stamped, src, now);
+    expect(out.long_term.history).toHaveLength(1);
+    expect(out.long_term.history[0].content).toBe('older');
+  });
+
+  it('caps history at MEMORY_HISTORY_CAP', () => {
+    const bigHistory = Array.from({ length: MEMORY_HISTORY_CAP }, (_, i) => ({
+      content: `v${i}`, replacedAt: now,
+    }));
+    const prior = {
+      long_term: {
+        content: 'current', visibility: 'private', updatedAt: now, byteSize: 7,
+        history: bigHistory,
+      },
+    };
+    const stamped = stampSectionsForWrite({ long_term: { content: 'newest' } }, now);
+    const out = decorateSectionsWithProvenance(prior, stamped, src, now);
+    expect(out.long_term.history).toHaveLength(MEMORY_HISTORY_CAP);
+    expect(out.long_term.history[0].content).toBe('current'); // newest first
+    expect(out.long_term.history[MEMORY_HISTORY_CAP - 1].content).toBe(`v${MEMORY_HISTORY_CAP - 2}`); // oldest dropped
+  });
+
+  it('leaves array sections (daily/relationships) untouched', () => {
+    const stamped = stampSectionsForWrite({
+      daily: [{ date: '2026-07-05', content: 'today' }],
+    }, now);
+    const out = decorateSectionsWithProvenance(undefined, stamped, src, now);
+    expect(out.daily).toEqual(stamped.daily);
+    expect(out.daily.source).toBeUndefined();
+  });
+});

--- a/backend/models/AgentMemory.ts
+++ b/backend/models/AgentMemory.ts
@@ -6,11 +6,37 @@ import mongoose, { Document, Model, Schema } from 'mongoose';
 
 export type MemoryVisibility = 'private' | 'pod' | 'public';
 
+// Provenance stamp — where a section write came from. Captured AT WRITE TIME
+// (GH#632): back-trace / replay / audit can never be retrofitted onto writes
+// that didn't record their source. `runtime` mirrors the write's
+// sourceRuntime; `via` is the API surface ('memory-put' | 'memory-sync').
+export interface IMemoryWriteSource {
+  runtime?: string;
+  via?: string;
+  writtenAt?: Date;
+}
+
+// One superseded version of a section (GH#632 soft-delete / versioning
+// foundation). Newest first; capped at MEMORY_HISTORY_CAP per section so a
+// chatty agent can't grow the doc unboundedly.
+export interface IMemorySectionVersion {
+  content: string;
+  replacedAt: Date;
+  source?: IMemoryWriteSource;
+}
+
+// Versions kept per section. 10 balances undo / back-trace depth against doc
+// growth (sections are ≤ tens of KB; 10 versions stays well under Mongo's
+// 16MB doc cap even for the largest long_term blobs).
+export const MEMORY_HISTORY_CAP = 10;
+
 export interface IMemorySection {
   content: string;
   visibility: MemoryVisibility;
   updatedAt: Date;
   byteSize: number;
+  source?: IMemoryWriteSource;
+  history?: IMemorySectionVersion[];
 }
 
 export interface IDailySection {
@@ -146,12 +172,32 @@ export type AgentWritableSection = typeof AGENT_WRITABLE_SECTIONS[number];
 // small for fresh records and makes "section missing" distinguishable from
 // "section set to empty."
 
+const memoryWriteSourceSchema = new Schema<IMemoryWriteSource>(
+  {
+    runtime: { type: String },
+    via: { type: String },
+    writtenAt: { type: Date },
+  },
+  { _id: false },
+);
+
+const memorySectionVersionSchema = new Schema<IMemorySectionVersion>(
+  {
+    content: { type: String, default: '' },
+    replacedAt: { type: Date, default: Date.now },
+    source: { type: memoryWriteSourceSchema, required: false },
+  },
+  { _id: false },
+);
+
 const memorySectionSchema = new Schema<IMemorySection>(
   {
     content: { type: String, default: '' },
     visibility: { type: String, enum: VISIBILITY_VALUES, default: 'private' },
     updatedAt: { type: Date, default: Date.now },
     byteSize: { type: Number, default: 0 },
+    source: { type: memoryWriteSourceSchema, required: false },
+    history: { type: [memorySectionVersionSchema], required: false, default: undefined },
   },
   { _id: false },
 );

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -76,6 +76,7 @@ const AgentMemory = require('../models/AgentMemory');
 const {
   mirrorContentFromSections,
   stampSectionsForWrite,
+  decorateSectionsWithProvenance,
   mergePatchSections,
   computeSyncDedupKey,
   isValidYMD,
@@ -2077,7 +2078,17 @@ router.put('/memory', agentRuntimeAuth, phase4RateLimit, async (req: any, res: a
     const hasOtherSections = sections !== undefined && Object.keys(sections).length > 0;
     if (hasOtherSections) {
       // Server-stamp byteSize + updatedAt so clients can't fabricate them.
-      const stamped = stampSectionsForWrite(sections);
+      let stamped = stampSectionsForWrite(sections);
+      // GH#632: stamp provenance + push the replaced version into the capped
+      // per-section history. Needs the prior doc — one indexed read on a
+      // low-frequency write path.
+      const priorDoc = await AgentMemory.findOne({ agentName, instanceId })
+        .select('sections').lean() as { sections?: any } | null;
+      stamped = decorateSectionsWithProvenance(
+        priorDoc?.sections,
+        stamped,
+        { runtime: sourceRuntime, via: 'memory-put' },
+      );
       // Per-key merge via dotted $set paths — preserves sibling sections the
       // caller didn't include in this write.
       for (const key of Object.keys(stamped)) {
@@ -2210,7 +2221,14 @@ router.post('/memory/sync', agentRuntimeAuth, phase4RateLimit, async (req: any, 
       return res.json({ ok: true, deduped: true });
     }
 
-    const stamped = stampSectionsForWrite(sections, now);
+    // GH#632: stamp provenance + capped version history against the existing
+    // sections (already fetched above for the dedup check — no extra read).
+    const stamped = decorateSectionsWithProvenance(
+      existing?.sections as any,
+      stampSectionsForWrite(sections, now),
+      { runtime: sourceRuntime, via: 'memory-sync' },
+      now,
+    );
 
     let finalSections: any;
     if (mode === 'full') {

--- a/backend/services/agentMemoryService.ts
+++ b/backend/services/agentMemoryService.ts
@@ -7,6 +7,7 @@ import AgentMemory, {
   SYSTEM_EXCHANGE_KINDS,
   CYCLE_CONTENT_MAX,
   CYCLE_ENTRY_CAP,
+  MEMORY_HISTORY_CAP,
 } from '../models/AgentMemory';
 import type {
   AgentWritableSection,
@@ -14,6 +15,7 @@ import type {
   ICycleEntry,
   IDailySection,
   IMemorySection,
+  IMemoryWriteSource,
   IRelationshipNote,
   ISystemExchangeEntry,
   MemoryVisibility,
@@ -219,6 +221,49 @@ export function stampSectionsForWrite(
       s.visibility ?? 'private',
       now,
     );
+  }
+  return out;
+}
+
+// GH#632 Tier-1 foundation: provenance + capped version history on section
+// writes. For each incoming BLOB section (soul / long_term / dedup_state /
+// shared — array sections are element-keyed and versioned separately later),
+// stamp WHERE the write came from and, when it replaces different existing
+// content, prepend the old version to a capped history. This is the piece
+// that can never be retrofitted: back-trace / replay / undo only work for
+// writes that recorded their past. Pure function — callers pass the existing
+// sections (may be undefined for a fresh doc) and get decorated sections back.
+export function decorateSectionsWithProvenance(
+  existingSections: IAgentMemorySections | undefined,
+  stampedSections: IAgentMemorySections,
+  source: IMemoryWriteSource,
+  now: Date = new Date(),
+): IAgentMemorySections {
+  const out: IAgentMemorySections = { ...stampedSections };
+  for (const key of Object.keys(stampedSections) as (keyof IAgentMemorySections)[]) {
+    if (key === 'daily' || key === 'relationships' || key === 'cycles' || key === 'system_exchanges') continue;
+    const incoming = stampedSections[key] as IMemorySection | undefined;
+    if (!incoming) continue;
+    const prior = existingSections?.[key] as IMemorySection | undefined;
+    const decorated: IMemorySection = {
+      ...incoming,
+      source: { ...source, writtenAt: now },
+    };
+    if (prior && typeof prior.content === 'string' && prior.content !== incoming.content) {
+      decorated.history = [
+        {
+          content: prior.content,
+          replacedAt: now,
+          ...(prior.source ? { source: prior.source } : {}),
+        },
+        ...(prior.history || []),
+      ].slice(0, MEMORY_HISTORY_CAP);
+    } else if (prior?.history) {
+      // Content unchanged (idempotent rewrite) — carry the history forward so
+      // a no-op write never drops versions.
+      decorated.history = prior.history;
+    }
+    (out as Record<string, IMemorySection>)[key] = decorated;
   }
   return out;
 }


### PR DESCRIPTION
The unretrofittable piece of #632: back-trace/replay/undo only work for writes that recorded their past — so this lands first, before the management UI/tools.

- `IMemorySection` gains `source` ({runtime, via, writtenAt}) + `history[]` (superseded versions, newest-first, cap 10). Additive — existing docs unaffected.
- `decorateSectionsWithProvenance`: stamps every blob-section write; on content change, prepends the replaced version (with *its* source) to the capped history; idempotent rewrites carry history forward.
- Wired into PUT /memory + POST /memory/sync ('memory-put' / 'memory-sync').
- 5 unit tests. Local suite-load failures on 2 pre-existing .ts suites are the known Node-26 jsonwebtoken drift (all 60 tests pass); CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9