### PR TITLE
feat(admin): registered-users moderation — list, ban, remove

### DIFF
--- a/backend/__tests__/unit/routes/admin.users.test.js
+++ b/backend/__tests__/unit/routes/admin.users.test.js
@@ -339,4 +339,63 @@ describe('admin users routes', () => {
     delete process.env.SMTP2GO_FROM_EMAIL;
     delete process.env.FRONTEND_URL;
   });
+
+  describe('PATCH /:userId/ban', () => {
+    it('bans a non-admin user with a reason', async () => {
+      const handler = getRouteHandler('/:userId/ban', 'patch');
+      const save = jest.fn().mockResolvedValue(undefined);
+      const target = { _id: 'u2', username: 'mallory', role: 'user', isBot: false, save };
+      User.findById.mockResolvedValue(target);
+      const req = { params: { userId: 'u2' }, body: { banned: true, reason: 'spam' }, user: { id: 'admin1' } };
+      const res = createRes();
+
+      await handler(req, res);
+
+      expect(target.banned).toBe(true);
+      expect(target.banReason).toBe('spam');
+      expect(target.bannedAt).toBeInstanceOf(Date);
+      expect(save).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ ok: true, user: expect.objectContaining({ banned: true }) }),
+      );
+    });
+
+    it('unbans and clears the reason', async () => {
+      const handler = getRouteHandler('/:userId/ban', 'patch');
+      const save = jest.fn().mockResolvedValue(undefined);
+      const target = { _id: 'u2', username: 'mallory', role: 'user', isBot: false, banned: true, banReason: 'spam', save };
+      User.findById.mockResolvedValue(target);
+      const req = { params: { userId: 'u2' }, body: { banned: false }, user: { id: 'admin1' } };
+      const res = createRes();
+
+      await handler(req, res);
+
+      expect(target.banned).toBe(false);
+      expect(target.banReason).toBeUndefined();
+      expect(save).toHaveBeenCalled();
+    });
+
+    it('refuses to ban an admin account', async () => {
+      const handler = getRouteHandler('/:userId/ban', 'patch');
+      User.findById.mockResolvedValue({ _id: 'a2', role: 'admin', isBot: false, save: jest.fn() });
+      const req = { params: { userId: 'a2' }, body: { banned: true }, user: { id: 'admin1' } };
+      const res = createRes();
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('refuses self-ban', async () => {
+      const handler = getRouteHandler('/:userId/ban', 'patch');
+      const req = { params: { userId: 'admin1' }, body: { banned: true }, user: { id: 'admin1' } };
+      const res = createRes();
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(User.findById).not.toHaveBeenCalled();
+    });
+  });
+
 });

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -528,6 +528,11 @@ exports.login = async (req: any, res: any) => {
     const user = await User.findOne({ email });
     if (!user) return res.status(400).json({ error: 'User not found' });
 
+    // Admin moderation: banned accounts cannot start a session.
+    if (user.banned) {
+      return res.status(403).json({ error: 'This account has been suspended.' });
+    }
+
     // Check if the email is verified
     if (!user.verified) {
       return res

--- a/backend/middleware/auth.ts
+++ b/backend/middleware/auth.ts
@@ -13,10 +13,13 @@ export default async function auth(req: Request, res: Response, next: NextFuncti
   if (token.startsWith('cm_')) {
     try {
       const user = await User.findOne({ apiToken: token }).select(
-        '_id username email role apiTokenScopes apiTokenCreatedAt',
+        '_id username email role apiTokenScopes apiTokenCreatedAt banned',
       );
 
       if (!user) return res.status(401).json({ msg: 'Invalid API token' });
+      if ((user as unknown as { banned?: boolean }).banned) {
+        return res.status(403).json({ msg: 'This account has been suspended.' });
+      }
 
       req.userId = user._id.toString();
       req.user = {
@@ -40,6 +43,12 @@ export default async function auth(req: Request, res: Response, next: NextFuncti
     const id = (decoded.id || (decoded.user as Record<string, unknown>)?.id) as string | undefined;
 
     if (!id) return res.status(401).json({ msg: 'Invalid token structure' });
+
+    // Admin moderation: one indexed read so a ban (or account deletion) takes
+    // effect on the NEXT request, not at JWT expiry days later.
+    const live = await User.findById(id).select('banned').lean() as { banned?: boolean } | null;
+    if (!live) return res.status(401).json({ msg: 'Account no longer exists' });
+    if (live.banned) return res.status(403).json({ msg: 'This account has been suspended.' });
 
     req.userId = id;
     req.user = { id };

--- a/backend/models/User.ts
+++ b/backend/models/User.ts
@@ -63,6 +63,11 @@ export interface IUser extends Document {
   password?: string;
   authProviders: IAuthProvider[];
   verified: boolean;
+  // Admin moderation (GH: admin user management). banned users cannot log in
+  // and existing sessions are refused by the auth middleware on next request.
+  banned: boolean;
+  bannedAt?: Date;
+  banReason?: string;
   profilePicture: string;
   role: UserRole;
   // Capability gate for hosted (cloud) agents. Defaults to false so opening
@@ -161,6 +166,9 @@ const userSchema = new Schema<IUser>({
     default: [],
   },
   verified: { type: Boolean, default: false },
+  banned: { type: Boolean, default: false },
+  bannedAt: { type: Date },
+  banReason: { type: String },
   profilePicture: { type: String, default: 'default' },
   role: { type: String, enum: ['user', 'admin'], default: 'user' },
   // Hosted-agent entitlement gate (see IUser.entitlements). Default false;

--- a/backend/routes/admin/users.ts
+++ b/backend/routes/admin/users.ts
@@ -34,6 +34,9 @@ const sanitizeUser = (user: any) => ({
   email: user.email,
   role: user.role,
   verified: Boolean(user.verified),
+  banned: Boolean(user.banned),
+  bannedAt: user.bannedAt || null,
+  banReason: user.banReason || null,
   createdAt: user.createdAt,
   updatedAt: user.updatedAt,
 });
@@ -118,7 +121,7 @@ router.get('/', auth, adminAuth, async (req: any, res: any) => {
     }
 
     const users = await User.find(query)
-      .select('username email role verified createdAt updatedAt')
+      .select('username email role verified banned bannedAt banReason createdAt updatedAt')
       .sort({ createdAt: -1 })
       .lean();
 
@@ -204,6 +207,45 @@ router.patch('/:userId/entitlements', adminWriteLimiter, auth, adminAuth, async 
 });
 
 // DELETE /api/admin/users/:userId
+// PATCH /api/admin/users/:userId/ban — suspend / unsuspend an account
+// (malicious-flagging moderation). Banned users cannot log in, and existing
+// sessions are refused by the auth middleware on their next request. Guards
+// mirror DELETE: no self-ban, no bot accounts, no banning admins (demote
+// first — prevents an admin-vs-admin lockout war).
+router.patch('/:userId/ban', adminWriteLimiter, auth, adminAuth, async (req: any, res: any) => {
+  try {
+    const { userId } = req.params;
+    const { banned, reason } = req.body || {};
+    if (typeof banned !== 'boolean') {
+      return res.status(400).json({ error: 'banned (boolean) is required' });
+    }
+    if (reason !== undefined && typeof reason !== 'string') {
+      return res.status(400).json({ error: 'reason must be a string' });
+    }
+    if (req.user?.id && String(req.user.id) === String(userId)) {
+      return res.status(400).json({ error: 'You cannot ban your own account' });
+    }
+    const target = await User.findById(userId);
+    if (!target) return res.status(404).json({ error: 'User not found' });
+    if (target.isBot) {
+      return res.status(400).json({ error: 'Bot accounts cannot be banned from this endpoint' });
+    }
+    if (target.role === 'admin' && banned) {
+      return res.status(400).json({ error: 'Demote the admin role before banning this account' });
+    }
+
+    target.banned = banned;
+    target.bannedAt = banned ? new Date() : undefined;
+    target.banReason = banned ? (reason || '').slice(0, 500) : undefined;
+    await target.save();
+
+    return res.json({ ok: true, user: sanitizeUser(target) });
+  } catch (error) {
+    console.error('Failed to update ban state:', error);
+    return res.status(500).json({ error: 'Failed to update ban state' });
+  }
+});
+
 router.delete('/:userId', auth, adminAuth, async (req: any, res: any) => {
   try {
     const { userId } = req.params;

--- a/frontend/src/v2/components/V2AdminUsers.tsx
+++ b/frontend/src/v2/components/V2AdminUsers.tsx
@@ -108,8 +108,79 @@ const errStatus = (err: unknown): number | undefined => {
   return e?.response?.status;
 };
 
+type RegisteredUser = {
+  id: string;
+  username: string;
+  email: string;
+  role: string;
+  verified: boolean;
+  banned: boolean;
+  banReason?: string | null;
+  createdAt?: string;
+};
+
 const V2AdminUsers: React.FC = () => {
   const api = useV2Api();
+
+  // ---- Registered users state (moderation: ban / remove) ----
+  const [users, setUsers] = useState<RegisteredUser[]>([]);
+  const [usersLoading, setUsersLoading] = useState(true);
+  const [usersError, setUsersError] = useState<string | null>(null);
+  const [userSearch, setUserSearch] = useState('');
+  const [userBusy, setUserBusy] = useState<string | null>(null);
+
+  const fetchUsers = useCallback(async (q: string) => {
+    setUsersLoading(true);
+    setUsersError(null);
+    try {
+      const params = new URLSearchParams();
+      if (q.trim()) params.set('q', q.trim());
+      const data = await api.get<{ users?: RegisteredUser[] }>(`/api/admin/users?${params.toString()}`);
+      setUsers(data.users || []);
+    } catch (err: unknown) {
+      setUsersError(errMessage(err, 'Failed to load users.'));
+    } finally {
+      setUsersLoading(false);
+    }
+  }, [api]);
+
+  useEffect(() => {
+    const handle = setTimeout(() => { fetchUsers(userSearch); }, 250);
+    return () => clearTimeout(handle);
+  }, [fetchUsers, userSearch]);
+
+  const handleBanToggle = async (u: RegisteredUser) => {
+    const banning = !u.banned;
+    // eslint-disable-next-line no-alert
+    const reason = banning ? window.prompt(`Ban ${u.username}? Optional reason:`, '') : null;
+    if (banning && reason === null) return; // prompt cancelled
+    setUserBusy(u.id);
+    try {
+      await api.patch(`/api/admin/users/${encodeURIComponent(u.id)}/ban`, {
+        banned: banning,
+        ...(banning && reason ? { reason } : {}),
+      });
+      await fetchUsers(userSearch);
+    } catch (err: unknown) {
+      setUsersError(errMessage(err, 'Failed to update ban state.'));
+    } finally {
+      setUserBusy(null);
+    }
+  };
+
+  const handleDeleteUser = async (u: RegisteredUser) => {
+    // eslint-disable-next-line no-alert
+    if (!window.confirm(`Permanently delete ${u.username} (${u.email})? This cannot be undone.`)) return;
+    setUserBusy(u.id);
+    try {
+      await api.del(`/api/admin/users/${encodeURIComponent(u.id)}`);
+      await fetchUsers(userSearch);
+    } catch (err: unknown) {
+      setUsersError(errMessage(err, 'Failed to delete user.'));
+    } finally {
+      setUserBusy(null);
+    }
+  };
 
   // ---- Waitlist state ----
   const [waitlist, setWaitlist] = useState<WaitlistRow[]>([]);
@@ -292,6 +363,84 @@ const V2AdminUsers: React.FC = () => {
 
   return (
     <div className="v2-admin-users">
+      {/* ---------------- Registered users ---------------- */}
+      <section className="v2-admin-users__section">
+        <div className="v2-admin-users__section-head">
+          <div>
+            <h2 className="v2-admin-users__section-title">Registered users</h2>
+            <p className="v2-admin-users__section-sub">
+              Everyone with an account on this instance. Ban stops logins immediately; delete is permanent.
+            </p>
+          </div>
+          <input
+            className="v2-admin-users__search"
+            type="search"
+            placeholder="Search username or email…"
+            value={userSearch}
+            onChange={(e) => setUserSearch(e.target.value)}
+          />
+        </div>
+        {usersError && <div className="v2-admin-users__error" role="alert">{usersError}</div>}
+        {usersLoading ? (
+          <div className="v2-admin-users__empty">Loading users…</div>
+        ) : users.length === 0 ? (
+          <div className="v2-admin-users__empty">No users match.</div>
+        ) : (
+          <div className="v2-admin-users__table-wrap">
+            <table className="v2-admin-users__table">
+              <thead>
+                <tr>
+                  <th>Username</th>
+                  <th>Email</th>
+                  <th>Role</th>
+                  <th>Status</th>
+                  <th>Joined</th>
+                  <th aria-label="Actions" />
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((u) => {
+                  const busy = userBusy === u.id;
+                  return (
+                    <tr key={u.id}>
+                      <td>{u.username}</td>
+                      <td>{u.email}</td>
+                      <td>{u.role}</td>
+                      <td>
+                        {u.banned
+                          ? <span className="v2-admin-users__badge v2-admin-users__badge--banned" title={u.banReason || undefined}>banned</span>
+                          : (u.verified ? 'active' : 'unverified')}
+                      </td>
+                      <td>{u.createdAt ? new Date(u.createdAt).toLocaleDateString() : '—'}</td>
+                      <td className="v2-admin-users__row-actions">
+                        <button
+                          type="button"
+                          className="v2-admin-users__btn"
+                          disabled={busy || u.role === 'admin'}
+                          title={u.role === 'admin' ? 'Demote the admin role first' : undefined}
+                          onClick={() => handleBanToggle(u)}
+                        >
+                          {busy ? '…' : (u.banned ? 'Unban' : 'Ban')}
+                        </button>
+                        <button
+                          type="button"
+                          className="v2-admin-users__btn v2-admin-users__btn--danger"
+                          disabled={busy || u.role === 'admin'}
+                          title={u.role === 'admin' ? 'Demote the admin role first' : undefined}
+                          onClick={() => handleDeleteUser(u)}
+                        >
+                          Delete
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
       {/* ---------------- Waitlist ---------------- */}
       <section className="v2-admin-users__section">
         <div className="v2-admin-users__section-head">

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -5378,3 +5378,27 @@
   background: var(--v2-surface-hover);
   color: var(--v2-text-primary);
 }
+
+/* Registered-users moderation (V2AdminUsers users section). */
+.v2-admin-users__search {
+  height: 34px;
+  padding: 0 12px;
+  min-width: 240px;
+  font-size: 13.5px;
+  border: 1px solid var(--v2-border-soft);
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+}
+.v2-admin-users__badge--banned {
+  background: #fdecea;
+  color: #c0392b;
+}
+.v2-root button.v2-admin-users__btn--danger {
+  color: #c0392b;
+  border-color: #e5b4ae;
+}
+.v2-root button.v2-admin-users__btn--danger:hover:not(:disabled) {
+  background: #fdecea;
+}
+.v2-admin-users__row-actions { display: flex; gap: 8px; }


### PR DESCRIPTION
Per Sam: the admin page was waitlist-only, but the waitlist is optional now — what's missing is moderation of *registered* users (malicious flagging).

- **Model**: `banned`/`bannedAt`/`banReason` (default false).
- **PATCH `/:userId/ban`** with guards (no self-ban, no bots, no banning admins — demote first).
- **Enforcement**: login 403s banned accounts; auth middleware does one indexed read per request so bans (and deletions) bite on the NEXT request, not at JWT expiry. API-token path covered.
- **UI**: 'Registered users' is now the first section (search, status, Ban/Unban + reason, Delete + confirm); waitlist demoted below.
- 12/12 route tests green (4 new).

Will browser-verify after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9