### PR TITLE
fix(v2): fresh-user smoke — no dead-end CTA + collision-proof BYO default

### DIFF
--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -19,6 +19,7 @@ import { useNavigate } from 'react-router-dom';
 import axios from '../../utils/axiosConfig';
 import V2FeaturePage from './V2FeaturePage';
 import { useV2Api } from '../hooks/useV2Api';
+import { useAuth } from '../../context/AuthContext';
 import { V2Pod } from '../hooks/useV2Pods';
 
 const DEFAULT_SCOPES = [
@@ -38,7 +39,19 @@ const V2AgentBYO: React.FC = () => {
   const navigate = useNavigate();
   const [pods, setPods] = useState<V2Pod[]>([]);
   const [podId, setPodId] = useState<string>('');
-  const [name, setName] = useState<string>('my-mcp-agent');
+  // Personalized default: a global-namespace collision guard (#613) means a
+  // shared literal default ("my-mcp-agent") 409s for every user after the
+  // first one to accept it. Seed from the username so defaults never collide.
+  const { currentUser } = useAuth();
+  const defaultAgentName = (() => {
+    const u = (currentUser?.username || '').toLowerCase().replace(/[^a-z0-9-]/g, '');
+    return u ? `${u}-agent` : 'my-mcp-agent';
+  })();
+  const [name, setName] = useState<string>(defaultAgentName);
+  // currentUser can resolve after mount — refresh the default if untouched.
+  useEffect(() => {
+    setName((prev) => (prev === 'my-mcp-agent' && defaultAgentName !== 'my-mcp-agent' ? defaultAgentName : prev));
+  }, [defaultAgentName]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [issued, setIssued] = useState<{ token: string; agentName: string; podId: string } | null>(null);

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -777,13 +777,16 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
                         >
                           Connect your agent (Claude Code, Cursor, Codex)
                         </button>
+                        {/* Points at Your Team (not the marketplace) while the
+                            marketplace sits behind its coming-soon wall — a
+                            fresh user's second CTA must not be a dead end. */}
                         <button
                           type="button"
                           role="listitem"
                           className="v2-empty__chip"
-                          onClick={() => navigate('/v2/marketplace')}
+                          onClick={() => navigate('/v2/agents')}
                         >
-                          Browse agents &amp; apps
+                          See your team
                         </button>
                       </div>
                     </>


### PR DESCRIPTION
Two gaps from the Playwright fresh-user journey: (1) welcome CTA led to the locked marketplace (dead end) → now 'See your team'; (2) shared literal BYO default `my-mcp-agent` + #613 collision guard = 409 on the happy path for every user after the first → default now `<username>-agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9