### PR TITLE
fix(v2): team-card agent name vanished at 390px (mobile smoke)

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -66,6 +66,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(aprofile, '.v2-root.v2-aprofile')).toContain('overflow-y: auto');
   });
 
+  test('team-card actions wrap on narrow screens so the agent name keeps width', () => {
+    // At <=560px the Profile+Talk-to actions row must wrap to its own line —
+    // inline, it squeezes the flex body to zero and the agent NAME disappears
+    // (2026-07-05 mobile smoke; same crush family as the #568 chip bug).
+    const idx = v2.indexOf('.v2-team-card__actions {\n    flex-basis: 100%');
+    expect(idx).toBeGreaterThan(-1);
+  });
+
   test('the a2a-DM system card overrides the two-column message grid', () => {
     // .v2-msg is `grid-template-columns: 38px minmax(0,1fr)` (avatar | body).
     // A system notice has a single child (.v2-syscard); without the override it

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -5402,3 +5402,18 @@
   background: #fdecea;
 }
 .v2-admin-users__row-actions { display: flex; gap: 8px; }
+
+/* Narrow screens: the team-card actions (Profile + Talk to) would otherwise
+   squeeze the body column to zero width — the agent NAME disappeared at 390px
+   (mobile smoke 2026-07-05, worsened by the added Profile button). Wrap the
+   actions onto their own full-width row instead of competing with the name. */
+@media (max-width: 560px) {
+  .v2-team-card {
+    flex-wrap: wrap;
+  }
+  .v2-team-card__actions {
+    flex-basis: 100%;
+    justify-content: flex-end;
+    margin-top: 4px;
+  }
+}


### PR DESCRIPTION
Mobile smoke: the Profile+Talk-to actions squeezed the card body to zero — agent names disappeared entirely at 390px. Actions now wrap to their own row at ≤560px. In-browser verified (name 0→144px); layout invariant added (6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9