### PR TITLE
feat(v2): reply-to-message UI (human side of reply threading)

### DIFF
--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -85,6 +85,9 @@ interface V2MessageBubbleProps {
   // Clicking a file pill routes to the inspector artifact preview by
   // ObjectStore filename (or originalName for static demo tokens).
   onOpenFile?: (fileName: string) => void;
+  // Sets this message as the composer's reply target (reply threading —
+  // backend replyToMessageId; agents already use it, this is the human side).
+  onReply?: (message: V2Message) => void;
 }
 
 interface ParsedFile {
@@ -282,7 +285,7 @@ const parseAgentDmEvent = (content: string | undefined): { headline: string; tar
 // columns in mobile shells.
 const REACTION_PALETTE = ['👍', '❤️', '🔥', '🤔', '👀', '🚀'];
 
-const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agentDisplayNames, agentAuthorKeys, onAuthorClick, onOpenFile }) => {
+const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agentDisplayNames, agentAuthorKeys, onAuthorClick, onOpenFile, onReply }) => {
   const { currentUser } = useAuth();
   const navigate = useNavigate();
   const api = useV2Api();
@@ -403,7 +406,30 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
           )}
           {isLead && <span className="v2-msg__lead-badge">Lead</span>}
           {time && <span className="v2-msg__time">{time}</span>}
+          {onReply && (
+            <button
+              type="button"
+              className="v2-msg__reply-btn"
+              aria-label={`Reply to ${author}`}
+              onClick={() => onReply(message)}
+            >
+              Reply
+            </button>
+          )}
         </div>
+        {(() => {
+          // Quoted context for replies. POST responses carry a normalized
+          // `replyTo` object; list rows may carry raw reply_* columns instead.
+          const quoteContent = message.replyTo?.content ?? message.reply_content;
+          const quoteAuthor = message.replyTo?.username ?? message.reply_username;
+          if (!quoteContent) return null;
+          return (
+            <div className="v2-msg__quote">
+              <span className="v2-msg__quote-author">{quoteAuthor || 'earlier message'}</span>
+              <span className="v2-msg__quote-text">{String(quoteContent).slice(0, 140)}</span>
+            </div>
+          );
+        })()}
         {imageUrl ? (
           <a href={imageUrl} target="_blank" rel="noreferrer" className="v2-msg__image-link">
             <img src={imageUrl} alt="Uploaded attachment" className="v2-msg__image" />

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -532,14 +532,21 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
     ? botMembers.slice(0, 2).map((m) => m.username || 'Agent')
     : null;
 
+  // Reply threading: the message the next send responds to (backend
+  // replyToMessageId — agents already thread replies; this is the human side).
+  const [replyTarget, setReplyTarget] = useState<import('../hooks/useV2PodDetail').V2Message | null>(null);
+
   const handleSend = async (override?: string) => {
     const text = (override ?? draft).trim();
     if (!text || sending) return;
     setSending(true);
     setComposerError(null);
     try {
-      const created = await sendMessage(text);
-      if (created) setDraft('');
+      const created = await sendMessage(text, 'text', replyTarget?.id || undefined);
+      if (created) {
+        setDraft('');
+        setReplyTarget(null);
+      }
     } finally {
       setSending(false);
     }
@@ -806,6 +813,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
                   agentAuthorKeys={agentAuthorKeys}
                   onAuthorClick={onOpenMember ? handleAuthorClick : undefined}
                   onOpenFile={onOpenFile}
+                  onReply={setReplyTarget}
                 />
               ))}
               <div ref={messagesEndRef} />
@@ -832,6 +840,22 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
               </div>
             ) : (
             <div className="v2-chat__composer">
+              {replyTarget && (
+                <div className="v2-chat__reply-chip" role="status">
+                  <span className="v2-chat__reply-chip-label">
+                    Replying to <strong>{replyTarget.user?.username || 'message'}</strong>:{' '}
+                    {String(replyTarget.content || '').replace(/\[\[upload:[^\]]*\]\]/g, '📎').slice(0, 80)}
+                  </span>
+                  <button
+                    type="button"
+                    className="v2-chat__reply-chip-cancel"
+                    aria-label="Cancel reply"
+                    onClick={() => setReplyTarget(null)}
+                  >
+                    ×
+                  </button>
+                </div>
+              )}
               <div className="v2-chat__composer-input-wrap">
                 <textarea
                   ref={composerInputRef}

--- a/frontend/src/v2/hooks/useV2PodDetail.ts
+++ b/frontend/src/v2/hooks/useV2PodDetail.ts
@@ -21,6 +21,13 @@ export interface V2Message {
     username?: string;
     profilePicture?: string | null;
   };
+  // Reply threading (PG reply_to_message_id). POST/GET responses carry either
+  // the normalized `replyTo` object or the raw reply_* columns; the bubble
+  // renders whichever is present.
+  replyTo?: { id: string; content: string; username: string; userId?: string } | null;
+  reply_msg_id?: string | null;
+  reply_content?: string | null;
+  reply_username?: string | null;
   // Sprint B5: per-message reactions, aggregated server-side.
   // Each entry is `{emoji, count, mine, users?}` — `users` is the
   // Google-Chat-style attribution list decorated by
@@ -89,7 +96,7 @@ export interface UseV2PodDetailResult {
   loading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
-  sendMessage: (content: string, messageType?: string) => Promise<V2Message | null>;
+  sendMessage: (content: string, messageType?: string, replyToMessageId?: string) => Promise<V2Message | null>;
 }
 
 const REQUEST_TIMEOUT_MS = 8000;
@@ -245,13 +252,13 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
     };
   }, [podId, socket, connected, joinPod, leavePod]);
 
-  const sendMessage = useCallback(async (content: string, messageType = 'text'): Promise<V2Message | null> => {
+  const sendMessage = useCallback(async (content: string, messageType = 'text', replyToMessageId?: string): Promise<V2Message | null> => {
     if (!podId || !content.trim()) return null;
     try {
       setError(null);
       const created = await api.post<V2Message>(
         `/api/messages/${podId}`,
-        { content: content.trim(), messageType },
+        { content: content.trim(), messageType, ...(replyToMessageId ? { replyToMessageId } : {}) },
         { timeout: SEND_TIMEOUT_MS },
       );
       const normalized = normalizeMessage(created);

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -5417,3 +5417,60 @@
     margin-top: 4px;
   }
 }
+
+/* Reply threading (human side of replyToMessageId). */
+.v2-root button.v2-msg__reply-btn {
+  margin-left: 4px;
+  padding: 0 6px;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--v2-text-secondary);
+  background: transparent;
+  border: none;
+  border-radius: var(--v2-radius-sm);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+.v2-msg:hover .v2-msg__reply-btn,
+.v2-msg__reply-btn:focus-visible {
+  opacity: 1;
+}
+.v2-root button.v2-msg__reply-btn:hover { color: var(--v2-accent); }
+
+.v2-msg__quote {
+  display: flex;
+  gap: 6px;
+  margin: 2px 0 4px;
+  padding: 4px 10px;
+  border-left: 3px solid var(--v2-border);
+  font-size: 12.5px;
+  color: var(--v2-text-secondary);
+  overflow: hidden;
+}
+.v2-msg__quote-author { font-weight: 600; flex-shrink: 0; }
+.v2-msg__quote-text { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+.v2-chat__reply-chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+  padding: 6px 12px;
+  font-size: 12.5px;
+  color: var(--v2-text-secondary);
+  background: var(--v2-accent-soft);
+  border: 1px solid var(--v2-border-soft);
+  border-radius: var(--v2-radius-sm);
+}
+.v2-chat__reply-chip-label { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+.v2-root button.v2-chat__reply-chip-cancel {
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  font-size: 16px;
+  line-height: 1;
+  color: var(--v2-text-secondary);
+  cursor: pointer;
+}


### PR DESCRIPTION
Closes the smoke-round-B gap: backend + agents already thread with `replyToMessageId`; humans had no UI. Hover-reveal **Reply** on each message → cancelable composer chip → send threads the reply; bubbles render quoted context (both `replyTo` object and raw `reply_*` shapes). Will browser-verify after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9
EOF