### PR TITLE
fix(agents): tell users the @mention handle (instanceId, not agentName)

### DIFF
--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -518,9 +518,16 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
         const isMeaninglessBlurb = !blurb
           || normalizedBlurb === displayName.toLowerCase()
           || normalizedBlurb === agent.agentName.toLowerCase();
+        // The mention handle is the instanceId (what the UI dropdown inserts),
+        // NOT the registry agentName — a BYO user is told their agent's *name*
+        // is e.g. "sam-agent" but the way to mention it is "@scout". Say it in
+        // the intro so nobody has to guess (GH smoke finding 2026-07-05).
+        const handle = normalizedInstanceId && normalizedInstanceId !== 'default'
+          ? normalizedInstanceId
+          : safeAgentName;
         const intro = isMeaninglessBlurb
-          ? `Hi all — I'm ${displayName}, just joined the pod.`
-          : `Hi all — I'm ${displayName}. ${blurb} Ping me when you need it.`;
+          ? `Hi all — I'm ${displayName}, just joined the pod. Mention me with @${handle}.`
+          : `Hi all — I'm ${displayName}. ${blurb} Mention me with @${handle} when you need me.`;
         await AgentMessageService.postMessage({
           agentName: agent.agentName,
           instanceId: normalizedInstanceId,

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -971,7 +971,11 @@ Docs:
           }
         }
 
-        console.log(`\n  Run with: commonly agent run ${opts.name}`);
+        // The mention handle is the instanceId (what the UI dropdown inserts),
+        // not the registry agentName — say it here so users know how to ping it.
+        const handle = instanceId && instanceId !== 'default' ? instanceId : installation.agentName;
+        console.log(`\n  Run with:    commonly agent run ${opts.name}`);
+        console.log(`  Mention as:  @${handle}`);
       } catch (err) {
         console.error(`Attach failed: ${err.message}`);
         process.exit(1);


### PR DESCRIPTION
Smoke finding (Sam): BYO agents have agentName ('sam-agent'), instanceId ('scout' — what the mention dropdown inserts), and displayName ('Scout') — users see the agentName everywhere but must mention by instanceId, and nothing says so. Join intro + CLI attach output now state the handle. Verified live that the UI-canonical form routes (@quill → event → daemon → answer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9