### PR TITLE
test: fix auth + pgMessages suites for the #636 ban check (main red)

### DIFF
--- a/backend/__tests__/service/pgMessages.test.js
+++ b/backend/__tests__/service/pgMessages.test.js
@@ -3,6 +3,16 @@ const express = require('express');
 const pgMessageRoutes = require('../../routes/pg-messages');
 const { generateTestToken } = require('../utils/testUtils');
 
+// #636 ban enforcement: auth middleware consults the Mongo User model per
+// request; these tests use tokens for ids ('user1') with no backing row, so
+// mock a live un-banned user to keep the middleware on its happy path.
+jest.mock('../../models/User', () => ({
+  findOne: jest.fn(),
+  findById: jest.fn(() => ({
+    select: () => ({ lean: async () => ({ banned: false }) }),
+  })),
+}));
+
 // Mock PG models
 jest.mock('../../models/pg/Pod', () => ({
   findById: jest.fn(),

--- a/backend/__tests__/unit/middleware/auth.test.js
+++ b/backend/__tests__/unit/middleware/auth.test.js
@@ -1,5 +1,17 @@
 const jwt = require('jsonwebtoken');
 const mongoose = require('mongoose');
+
+// #636 ban enforcement: the middleware does one indexed User read per request
+// (banned users / deleted accounts are refused on the NEXT request, not at JWT
+// expiry). Mock a live, un-banned user so the happy-path tests still pass;
+// individual tests override to simulate banned/deleted.
+jest.mock('../../../models/User', () => ({
+  findOne: jest.fn(),
+  findById: jest.fn(() => ({
+    select: () => ({ lean: async () => ({ banned: false }) }),
+  })),
+}));
+const User = require('../../../models/User');
 const authMiddleware = require('../../../middleware/auth');
 const { generateTestToken } = require('../../utils/testUtils');
 
@@ -9,7 +21,7 @@ describe('Auth Middleware Tests', () => {
     process.env.JWT_SECRET = 'test-jwt-secret';
   });
 
-  it('should add userId to request when valid token is provided in Authorization header', () => {
+  it('should add userId to request when valid token is provided in Authorization header', async () => {
     // Create a mock user ID
     const userId = new mongoose.Types.ObjectId();
 
@@ -32,7 +44,7 @@ describe('Auth Middleware Tests', () => {
     const next = jest.fn();
 
     // Call the middleware
-    authMiddleware(req, res, next);
+    await authMiddleware(req, res, next);
 
     // Verify that userId was added to request
     expect(req.userId).toBe(userId.toString());
@@ -46,7 +58,7 @@ describe('Auth Middleware Tests', () => {
     expect(res.json).not.toHaveBeenCalled();
   });
 
-  it('should add userId to request when valid token is provided in x-auth-token header', () => {
+  it('should add userId to request when valid token is provided in x-auth-token header', async () => {
     // Create a mock user ID
     const userId = new mongoose.Types.ObjectId();
 
@@ -69,7 +81,7 @@ describe('Auth Middleware Tests', () => {
     const next = jest.fn();
 
     // Call the middleware
-    authMiddleware(req, res, next);
+    await authMiddleware(req, res, next);
 
     // Verify that userId was added to request
     expect(req.userId).toBe(userId.toString());
@@ -83,7 +95,7 @@ describe('Auth Middleware Tests', () => {
     expect(res.json).not.toHaveBeenCalled();
   });
 
-  it('should return 401 when no token is provided', () => {
+  it('should return 401 when no token is provided', async () => {
     // Mock request, response, and next function
     const req = {
       header: jest.fn().mockReturnValue(null),
@@ -97,7 +109,7 @@ describe('Auth Middleware Tests', () => {
     const next = jest.fn();
 
     // Call the middleware
-    authMiddleware(req, res, next);
+    await authMiddleware(req, res, next);
 
     // Verify that res.status and res.json were called with correct arguments
     expect(res.status).toHaveBeenCalledWith(401);
@@ -111,7 +123,7 @@ describe('Auth Middleware Tests', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('should return 401 when invalid token is provided', () => {
+  it('should return 401 when invalid token is provided', async () => {
     // Mock request, response, and next function
     const req = {
       header: jest.fn().mockReturnValue('Bearer invalid-token'),
@@ -125,7 +137,7 @@ describe('Auth Middleware Tests', () => {
     const next = jest.fn();
 
     // Call the middleware
-    authMiddleware(req, res, next);
+    await authMiddleware(req, res, next);
 
     // Verify that res.status and res.json were called with correct arguments
     expect(res.status).toHaveBeenCalledWith(401);
@@ -139,7 +151,7 @@ describe('Auth Middleware Tests', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('should return 401 when token with invalid structure is provided', () => {
+  it('should return 401 when token with invalid structure is provided', async () => {
     // Generate a token with invalid structure (no id field)
     const invalidToken = jwt.sign({ foo: 'bar' }, process.env.JWT_SECRET);
 
@@ -156,7 +168,7 @@ describe('Auth Middleware Tests', () => {
     const next = jest.fn();
 
     // Call the middleware
-    authMiddleware(req, res, next);
+    await authMiddleware(req, res, next);
 
     // Verify that res.status and res.json were called with correct arguments
     expect(res.status).toHaveBeenCalledWith(401);
@@ -170,7 +182,7 @@ describe('Auth Middleware Tests', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('should handle alternative token format with user object', () => {
+  it('should handle alternative token format with user object', async () => {
     // Create a mock user ID
     const userId = new mongoose.Types.ObjectId();
 
@@ -190,7 +202,7 @@ describe('Auth Middleware Tests', () => {
     const next = jest.fn();
 
     // Call the middleware
-    authMiddleware(req, res, next);
+    await authMiddleware(req, res, next);
 
     // Verify that userId was added to request
     expect(req.userId).toBe(userId.toString());
@@ -203,4 +215,37 @@ describe('Auth Middleware Tests', () => {
     expect(res.status).not.toHaveBeenCalled();
     expect(res.json).not.toHaveBeenCalled();
   });
+
+  it('returns 403 when the account is banned (ban bites on next request)', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const token = generateTestToken(userId);
+    User.findById.mockReturnValueOnce({
+      select: () => ({ lean: async () => ({ banned: true }) }),
+    });
+    const req = { header: jest.fn((h) => (h === 'Authorization' ? `Bearer ${token}` : null)) };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+
+    await authMiddleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when the account no longer exists (deleted user, live JWT)', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const token = generateTestToken(userId);
+    User.findById.mockReturnValueOnce({
+      select: () => ({ lean: async () => null }),
+    });
+    const req = { header: jest.fn((h) => (h === 'Authorization' ? `Bearer ${token}` : null)) };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+
+    await authMiddleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
 });


### PR DESCRIPTION
Main's push-side **Tests** workflow has been red since #636: the now-async auth middleware (per-request ban/deletion check) broke two suites that called it synchronously with no User rows. Mock a live user, await the middleware, and add the two missing coverage cases (banned→403, deleted→401). Also flags that the PR gate was green while these fail deterministically on push — PR/push scope mismatch to investigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9