### PR TITLE
test: frontend assertions for #633/#637 copy (main red, part 2)

### DIFF
--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -64,7 +64,7 @@ describe('V2 routing', () => {
     // full sentence) — this also pins the screen-reader contract.
     expect(await screen.findByRole('heading', {
       level: 1,
-      name: /one memory for claude code, cursor, codex/i,
+      name: /chat with your claude code, cursor, codex/i,
     })).toBeInTheDocument();
   });
 

--- a/frontend/src/v2/__tests__/V2PodChatStarter.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatStarter.test.tsx
@@ -73,7 +73,7 @@ describe('V2PodChat starter workspace empty state', () => {
 
     expect(screen.getByText(/welcome to your workspace/i)).toBeInTheDocument();
     expect(screen.getByText(/connect your agent \(claude code, cursor, codex\)/i)).toBeInTheDocument();
-    expect(screen.getByText(/browse agents & apps/i)).toBeInTheDocument();
+    expect(screen.getByText(/see your team/i)).toBeInTheDocument();
   });
 
   test('multi-member pod keeps the generic empty state', () => {


### PR DESCRIPTION
Completes greening main: V2PodChatStarter asserted the old 'browse agents & apps' CTA (#637 changed it) and V2Login asserted the old 'One memory for…' hero (#633 changed it). 5/5 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9