### PR TITLE
fix(digest): empty daily digest fails Summary enum validation for every quiet-day user

### DIFF
--- a/backend/__tests__/unit/services/dailyDigestService.emptyDigest.test.ts
+++ b/backend/__tests__/unit/services/dailyDigestService.emptyDigest.test.ts
@@ -1,0 +1,27 @@
+// @ts-nocheck
+// Regression for the empty-digest path: createEmptyDigest used to emit
+// engagement_quality: 'low', which is not in the Summary schema enum
+// (superficial/moderate/deep/intense) — every quiet-day digest failed
+// Summary validation and no digest was saved for the user.
+
+const Summary = require('../../../models/Summary').default;
+const { DailyDigestService } = require('../../../services/dailyDigestService');
+
+describe('DailyDigestService.createEmptyDigest', () => {
+  it('produces analytics that pass Summary schema validation', () => {
+    const start = new Date('2026-07-05T00:00:00Z');
+    const end = new Date('2026-07-06T00:00:00Z');
+    const empty = DailyDigestService.createEmptyDigest({ username: 'quiet-user' }, start, end);
+
+    const doc = new Summary({
+      type: 'daily-digest',
+      title: empty.title,
+      content: empty.content,
+      timeRange: { start, end },
+      metadata: { userId: 'test-user-id' },
+      analytics: empty.analytics,
+    });
+
+    expect(doc.validateSync()).toBeUndefined();
+  });
+});

--- a/backend/services/dailyDigestService.ts
+++ b/backend/services/dailyDigestService.ts
@@ -66,7 +66,7 @@ interface DigestResult {
   error?: string;
 }
 
-class DailyDigestService {
+export class DailyDigestService {
   async generateUserDailyDigest(userId: unknown): Promise<unknown> {
     try {
       console.log(`Generating daily digest for user ${userId}`);
@@ -354,7 +354,7 @@ This might be a great time to start a new conversation or share something intere
         atmosphere: {
           overall_sentiment: 'neutral',
           energy_level: 'low',
-          engagement_quality: 'low',
+          engagement_quality: 'superficial',
           community_cohesion: 0.5,
           topics_diversity: 0.2,
           dominant_emotions: ['calm'],


### PR DESCRIPTION
## Problem
`DailyDigestService.createEmptyDigest` sets `analytics.atmosphere.engagement_quality: 'low'`, but the Summary schema enum only allows `superficial | moderate | deep | intense`. Every user whose day was quiet gets **no digest at all** — `Summary.create` throws `ValidationError`. Backend logs show 26 `Failed to generate digest for user …` failures in the last 24h, i.e. it's failing for essentially every active user.

## Fix
- `'low'` → `'superficial'` (the low end of the actual enum). `energy_level: 'low'` is untouched — its enum includes it.
- Export the `DailyDigestService` class by name (previously only the singleton default export).
- Regression test: builds the empty digest and asserts the resulting `Summary` doc passes `validateSync()`, so any future value outside the schema enum fails CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9