### PR TITLE
fix(privacy): summarizer out of user pods by default + membership-gated summaries API

### DIFF
--- a/backend/__tests__/unit/controllers/podController.test.js
+++ b/backend/__tests__/unit/controllers/podController.test.js
@@ -81,6 +81,8 @@ describe('podController', () => {
   });
 
   it('createPod accepts agent-ensemble type', async () => {
+    // Opt in to the default-agent auto-install for this test.
+    process.env.AUTO_INSTALL_DEFAULT_AGENT = '1';
     const savedPod = { _id: 'p1', populate: jest.fn().mockResolvedValue() };
     const save = jest.fn().mockResolvedValue(savedPod);
     Pod.mockImplementation(() => ({ save }));
@@ -104,7 +106,11 @@ describe('podController', () => {
     };
     const res = { json: jest.fn(), status: jest.fn().mockReturnThis(), send: jest.fn() };
 
-    await podController.createPod(req, res);
+    try {
+      await podController.createPod(req, res);
+    } finally {
+      delete process.env.AUTO_INSTALL_DEFAULT_AGENT;
+    }
 
     expect(save).toHaveBeenCalled();
     expect(savedPod.populate).toHaveBeenCalledWith('createdBy', 'username profilePicture');
@@ -114,6 +120,28 @@ describe('podController', () => {
       instanceId: 'default',
     }));
     expect(AgentProfile.updateOne).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(savedPod);
+  });
+
+  it('createPod does NOT auto-install commonly-bot by default (opt-in via AUTO_INSTALL_DEFAULT_AGENT=1)', async () => {
+    // Regression: pre-beta this defaulted ON, which put the summarizer bot
+    // into the member list of every UI-created pod — including real users'
+    // private pods — with a posting-authorized AgentInstallation.
+    delete process.env.AUTO_INSTALL_DEFAULT_AGENT;
+    const savedPod = { _id: 'p1', populate: jest.fn().mockResolvedValue() };
+    const save = jest.fn().mockResolvedValue(savedPod);
+    Pod.mockImplementation(() => ({ save }));
+
+    const req = {
+      body: { name: 'User Pod', description: 'private', type: 'chat' },
+      userId: 'creator',
+    };
+    const res = { json: jest.fn(), status: jest.fn().mockReturnThis(), send: jest.fn() };
+
+    await podController.createPod(req, res);
+
+    expect(AgentInstallation.install).not.toHaveBeenCalled();
+    expect(AgentIdentityService.ensureAgentInPod).not.toHaveBeenCalled();
     expect(res.json).toHaveBeenCalledWith(savedPod);
   });
 

--- a/backend/__tests__/unit/routes/summaries.visibility.test.js
+++ b/backend/__tests__/unit/routes/summaries.visibility.test.js
@@ -1,0 +1,160 @@
+const request = require('supertest');
+const express = require('express');
+
+// Regression for the summaries-router membership gates: GET /pods and
+// POST /pod/:podId/refresh were readable by ANY authed user for ANY podId
+// (IDOR — same class as the uploads bug), and GET / leaked other users'
+// daily digests + private-pod chat summaries. Every read here must run
+// through DMService.canViewPod, mirroring GET /pod/:podId.
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.user = { id: 'user1' };
+  req.userId = 'user1';
+  next();
+});
+
+const mockGetRecentSummaries = jest.fn();
+jest.mock('../../../services/summarizerService', () => ({
+  summarizeAllPosts: jest.fn().mockResolvedValue(null),
+  constructor: { getRecentSummaries: (...args) => mockGetRecentSummaries(...args), garbageCollectForDigest: jest.fn() },
+}));
+
+const mockGetRecentChatSummariesByPodType = jest.fn();
+const mockGetMultiplePodSummaries = jest.fn();
+const mockSummarizePodMessages = jest.fn();
+jest.mock('../../../services/chatSummarizerService', () => ({
+  getMultiplePodSummaries: (...args) => mockGetMultiplePodSummaries(...args),
+  summarizePodMessages: (...args) => mockSummarizePodMessages(...args),
+  constructor: {
+    getRecentChatSummariesByPodType: (...args) => mockGetRecentChatSummariesByPodType(...args),
+    getLatestPodSummary: jest.fn(),
+  },
+}));
+
+jest.mock('../../../services/schedulerService', () => ({
+  getStatus: jest.fn(),
+  constructor: { triggerSummarizer: jest.fn(), summarizeIntegrationBuffers: jest.fn(), dispatchPodSummaryRequests: jest.fn() },
+}));
+jest.mock('../../../services/dailyDigestService', () => ({
+  generateUserDailyDigest: jest.fn(),
+  generateAllDailyDigests: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../../../services/agentEventService', () => ({ enqueue: jest.fn() }));
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { find: jest.fn().mockReturnValue({ select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }) }) },
+}));
+
+const mockCanViewPod = jest.fn();
+jest.mock('../../../services/dmService', () => ({ canViewPod: (...args) => mockCanViewPod(...args) }));
+
+const Pod = require('../../../models/Pod');
+const User = require('../../../models/User');
+
+jest.mock('../../../models/Pod');
+jest.mock('../../../models/User');
+jest.mock('../../../models/Summary');
+
+const routes = require('../../../routes/summaries');
+
+const leanChain = (value) => ({ select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(value) }) });
+
+describe('summaries routes - pod visibility gates', () => {
+  let app;
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/summaries', routes);
+    jest.clearAllMocks();
+    // Non-admin caller by default (isGlobalAdminUser → false).
+    User.findById.mockReturnValue(leanChain({ role: 'user' }));
+  });
+
+  describe('GET /pods', () => {
+    it('only queries summaries for pods the caller can view', async () => {
+      Pod.find.mockReturnValue(leanChain([
+        { _id: 'p1', members: ['user1'], type: 'chat' },
+        { _id: 'p2', members: ['other'], type: 'chat' },
+      ]));
+      mockCanViewPod.mockImplementation(async (uid, pod) => pod._id === 'p1');
+      mockGetMultiplePodSummaries.mockResolvedValue({ p1: { content: 's1' } });
+
+      const res = await request(app).get('/api/summaries/pods?podIds=p1,p2').expect(200);
+
+      expect(mockGetMultiplePodSummaries).toHaveBeenCalledWith(['p1']);
+      expect(res.body).toEqual({ p1: { content: 's1' } });
+    });
+
+    it('returns an empty object without querying when nothing is viewable', async () => {
+      Pod.find.mockReturnValue(leanChain([{ _id: 'p2', members: ['other'], type: 'chat' }]));
+      mockCanViewPod.mockResolvedValue(false);
+
+      const res = await request(app).get('/api/summaries/pods?podIds=p2').expect(200);
+
+      expect(res.body).toEqual({});
+      expect(mockGetMultiplePodSummaries).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /pod/:podId/refresh', () => {
+    it('404s when the pod does not exist', async () => {
+      Pod.findById.mockReturnValue(leanChain(null));
+      await request(app).post('/api/summaries/pod/p1/refresh').send({}).expect(404);
+    });
+
+    it('403s non-members and never summarizes the pod', async () => {
+      Pod.findById.mockReturnValue(leanChain({ _id: 'p1', members: ['other'], type: 'chat' }));
+      mockCanViewPod.mockResolvedValue(false);
+
+      await request(app).post('/api/summaries/pod/p1/refresh').send({}).expect(403);
+      expect(mockSummarizePodMessages).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET / (recent summaries)', () => {
+    it('drops private-pod summaries and other users\' digests, keeps own + global', async () => {
+      mockGetRecentSummaries.mockResolvedValue([
+        { _id: 's1', type: 'chats', podId: 'p1', content: 'mine' },
+        { _id: 's2', type: 'chats', podId: 'p2', content: 'private' },
+        { _id: 's3', type: 'daily-digest', metadata: { userId: 'user1' }, content: 'my digest' },
+        { _id: 's4', type: 'daily-digest', metadata: { userId: 'other' }, content: 'their digest' },
+        { _id: 's5', type: 'posts', content: 'global' },
+      ]);
+      Pod.find.mockReturnValue(leanChain([
+        { _id: 'p1', members: ['user1'], type: 'chat' },
+        { _id: 'p2', members: ['other'], type: 'chat' },
+      ]));
+      mockCanViewPod.mockImplementation(async (uid, pod) => pod._id === 'p1');
+
+      const res = await request(app).get('/api/summaries/').expect(200);
+
+      expect(res.body.map((s) => s._id)).toEqual(['s1', 's3', 's5']);
+    });
+  });
+
+  describe('GET /chat-rooms', () => {
+    it('filters out summaries of pods the caller cannot view', async () => {
+      mockGetRecentChatSummariesByPodType.mockResolvedValue([
+        { _id: 's1', type: 'chats', podId: 'p1' },
+        { _id: 's2', type: 'chats', podId: 'p2' },
+      ]);
+      Pod.find.mockReturnValue(leanChain([
+        { _id: 'p1', members: ['user1'], type: 'chat' },
+        { _id: 'p2', members: ['other'], type: 'chat' },
+      ]));
+      mockCanViewPod.mockImplementation(async (uid, pod) => pod._id === 'p1');
+
+      const res = await request(app).get('/api/summaries/chat-rooms').expect(200);
+      expect(res.body.map((s) => s._id)).toEqual(['s1']);
+    });
+  });
+
+  describe('admin-only triggers', () => {
+    it('403s POST /debug for non-admins', async () => {
+      await request(app).post('/api/summaries/debug').send({}).expect(403);
+    });
+
+    it('403s POST /daily-digest/trigger-all for non-admins', async () => {
+      await request(app).post('/api/summaries/daily-digest/trigger-all').send({}).expect(403);
+    });
+  });
+});

--- a/backend/controllers/podController.ts
+++ b/backend/controllers/podController.ts
@@ -86,7 +86,11 @@ const ensureDefaultAgentRegistryEntry = async (agentName: any) => {
 
 const installDefaultAgentForPod = async ({ pod, userId }: { pod: any; userId: any }) => {
   if (!pod?._id || !userId) return;
-  if (process.env.AUTO_INSTALL_DEFAULT_AGENT === '0') return;
+  // Opt-in only. Real users' pods must not get the summarizer bot in their
+  // member list (or a posting-authorized AgentInstallation) unless the
+  // instance explicitly turns this on. Default was ON pre-beta, which put
+  // commonly-bot into every UI-created pod.
+  if (process.env.AUTO_INSTALL_DEFAULT_AGENT !== '1') return;
 
   const agent = await ensureDefaultAgentRegistryEntry(DEFAULT_POD_AGENT);
   if (!agent) {

--- a/backend/routes/summaries.ts
+++ b/backend/routes/summaries.ts
@@ -17,6 +17,10 @@ const { AgentInstallation } = require('../models/AgentRegistry');
 // eslint-disable-next-line global-require
 const dailyDigestService = require('../services/dailyDigestService');
 // eslint-disable-next-line global-require
+const { rateLimit, ipKeyGenerator } = require('express-rate-limit');
+// eslint-disable-next-line global-require
+const { createHash } = require('crypto');
+// eslint-disable-next-line global-require
 const auth = require('../middleware/auth');
 // eslint-disable-next-line global-require
 const Pod = require('../models/Pod');
@@ -36,6 +40,43 @@ interface Res {
 }
 
 const router: ReturnType<typeof express.Router> = express.Router();
+
+// Same token/IP keying as the messages-router limiters (#614): key on the
+// hashed auth token when present so NATed users don't share a bucket, fall
+// back to the IPv6-safe IP key.
+const summariesRateLimitKey = (req: { get?: (h: string) => string | undefined; ip?: string }) => {
+  const authHeader = req.get?.('authorization');
+  if (authHeader) {
+    return `tok:${createHash('sha256').update(authHeader).digest('hex').slice(0, 16)}`;
+  }
+  return req.ip ? ipKeyGenerator(req.ip) : 'anon';
+};
+
+// Reads hit Mongo (and canViewPod adds per-pod lookups) — throttle so a
+// leaked token can't spray unbounded GETs.
+const summariesReadRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 240,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: summariesRateLimitKey,
+  handler: (_req: unknown, res: Res) => {
+    res.status(429).json({ error: 'rate limit exceeded: 240 summary reads per 60s' });
+  },
+});
+
+// Trigger endpoints fan out LLM calls / regenerate summaries — much tighter.
+const summariesTriggerRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: summariesRateLimitKey,
+  handler: (_req: unknown, res: Res) => {
+    res.status(429).json({ error: 'rate limit exceeded: 10 summary triggers per 60s' });
+  },
+});
+
 
 const SummarizerService = summarizerService.constructor;
 const ChatSummarizerService = chatSummarizerService.constructor;
@@ -95,7 +136,7 @@ const filterSummariesToViewable = async (
   });
 };
 
-router.get('/', auth, async (req: AuthReq, res: Res) => {
+router.get('/', summariesReadRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const { type, limit = '10' } = req.query || {};
     const cappedLimit = Math.max(1, Math.min(50, parseInt(limit, 10) || 10));
@@ -108,7 +149,7 @@ router.get('/', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.get('/latest', auth, async (req: AuthReq, res: Res) => {
+router.get('/latest', summariesReadRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const userId = req.userId || req.user?.id;
     const [postSummaries, chatSummaries] = await Promise.all([SummarizerService.getRecentSummaries('posts', 1), SummarizerService.getRecentSummaries('chats', 20)]);
@@ -126,7 +167,7 @@ router.get('/latest', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.post('/trigger', auth, async (req: AuthReq, res: Res) => {
+router.post('/trigger', summariesTriggerRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const userId = req.user?.id || req.userId;
     if (!(await isGlobalAdminUser(userId))) return res.status(403).json({ error: 'Global admin access required' });
@@ -139,7 +180,7 @@ router.post('/trigger', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.post('/debug', auth, async (req: AuthReq, res: Res) => {
+router.post('/debug', summariesTriggerRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     // Admin-only: the live cluster runs with NODE_ENV=development, so an
     // env check alone leaves this trigger open to every authed user.
@@ -153,7 +194,7 @@ router.post('/debug', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.get('/status', auth, (_req: AuthReq, res: Res) => {
+router.get('/status', summariesReadRateLimit, auth, (_req: AuthReq, res: Res) => {
   try {
     const status = schedulerService.getStatus();
     res.json(status);
@@ -163,7 +204,7 @@ router.get('/status', auth, (_req: AuthReq, res: Res) => {
   }
 });
 
-router.get('/chat-rooms', auth, async (req: AuthReq, res: Res) => {
+router.get('/chat-rooms', summariesReadRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const { limit = '5' } = req.query || {};
     const userId = req.userId || req.user?.id;
@@ -175,7 +216,7 @@ router.get('/chat-rooms', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.get('/chat-rooms/latest', auth, async (req: AuthReq, res: Res) => {
+router.get('/chat-rooms/latest', summariesReadRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const userId = req.userId || req.user?.id;
     const recentChatSummaries = await ChatSummarizerService.getRecentChatSummariesByPodType('chat', 20);
@@ -187,7 +228,7 @@ router.get('/chat-rooms/latest', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.get('/study-rooms', auth, async (req: AuthReq, res: Res) => {
+router.get('/study-rooms', summariesReadRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const { limit = '5' } = req.query || {};
     const userId = req.userId || req.user?.id;
@@ -199,7 +240,7 @@ router.get('/study-rooms', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.get('/game-rooms', auth, async (req: AuthReq, res: Res) => {
+router.get('/game-rooms', summariesReadRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const { limit = '5' } = req.query || {};
     const userId = req.userId || req.user?.id;
@@ -211,7 +252,7 @@ router.get('/game-rooms', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.get('/all-posts', auth, async (_req: AuthReq, res: Res) => {
+router.get('/all-posts', summariesReadRateLimit, auth, async (_req: AuthReq, res: Res) => {
   try {
     const allPostsSummary = await summarizerService.summarizeAllPosts();
     res.json(allPostsSummary);
@@ -221,7 +262,7 @@ router.get('/all-posts', auth, async (_req: AuthReq, res: Res) => {
   }
 });
 
-router.get('/pod/:podId', auth, async (req: AuthReq, res: Res) => {
+router.get('/pod/:podId', summariesReadRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId } = req.params || {};
     // Pod-scoped summaries inherit pod visibility — non-members of personal
@@ -241,7 +282,7 @@ router.get('/pod/:podId', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.get('/pods', auth, async (req: AuthReq, res: Res) => {
+router.get('/pods', summariesReadRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const { podIds } = req.query || {};
     if (!podIds) return res.status(400).json({ error: 'podIds parameter is required' });
@@ -264,7 +305,7 @@ router.get('/pods', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.post('/pod/:podId/refresh', auth, async (req: AuthReq, res: Res) => {
+router.post('/pod/:podId/refresh', summariesTriggerRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId } = req.params || {};
     // Refresh both reads pod content (the generated summary is returned
@@ -302,7 +343,7 @@ router.post('/pod/:podId/refresh', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.get('/daily-digest', auth, async (req: AuthReq, res: Res) => {
+router.get('/daily-digest', summariesReadRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const userId = req.user?.id;
     const dailyDigest = await Summary.findOne({ type: 'daily-digest', 'metadata.userId': userId }).sort({ createdAt: -1 }).lean();
@@ -314,7 +355,7 @@ router.get('/daily-digest', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.post('/daily-digest/generate', auth, async (req: AuthReq, res: Res) => {
+router.post('/daily-digest/generate', summariesTriggerRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const userId = req.user?.id;
     await SummarizerService.garbageCollectForDigest();
@@ -326,7 +367,7 @@ router.post('/daily-digest/generate', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.get('/daily-digest/history', auth, async (req: AuthReq, res: Res) => {
+router.get('/daily-digest/history', summariesReadRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const userId = req.user?.id;
     const { limit = '7' } = req.query || {};
@@ -338,7 +379,7 @@ router.get('/daily-digest/history', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.post('/daily-digest/trigger-all', auth, async (req: AuthReq, res: Res) => {
+router.post('/daily-digest/trigger-all', summariesTriggerRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     // Fans out digest generation (and LLM calls) for every user — admin-only.
     if (!(await isGlobalAdminUser(req.user?.id || req.userId))) return res.status(403).json({ error: 'Global admin access required' });

--- a/backend/routes/summaries.ts
+++ b/backend/routes/summaries.ts
@@ -64,27 +64,62 @@ const isGlobalAdminUser = async (userId: unknown): Promise<boolean> => {
   return Boolean(user && user.role === 'admin');
 };
 
+// Summaries inherit the visibility of the pod they describe (parity with
+// the /announcements + /files + /external-links gates on the pods router
+// and the canViewPod gate on GET /pod/:podId below). Given a mixed list
+// of Summary docs, keep only:
+//   - pod-scoped summaries whose pod the caller can view,
+//   - the caller's own daily-digest summaries,
+//   - global summaries (no podId, not a digest — e.g. all-posts).
+const filterSummariesToViewable = async (
+  userId: unknown,
+  summaries: unknown[],
+): Promise<unknown[]> => {
+  const list = (summaries || []).filter(Boolean) as Array<{
+    podId?: unknown;
+    type?: string;
+    metadata?: { userId?: string };
+  }>;
+  const podIds = [...new Set(list.filter((s) => s.podId).map((s) => String(s.podId)))];
+  const allowed = new Set<string>();
+  if (podIds.length > 0) {
+    const pods = await Pod.find({ _id: { $in: podIds } }).select('_id members type').lean() as Array<{ _id: unknown; members?: unknown[]; type?: string }>;
+    await Promise.all(pods.map(async (pod) => {
+      if (await DMService.canViewPod(userId, pod)) allowed.add(String(pod._id));
+    }));
+  }
+  return list.filter((s) => {
+    if (s.podId) return allowed.has(String(s.podId));
+    if (s.type === 'daily-digest') return String(s.metadata?.userId || '') === String(userId);
+    return true;
+  });
+};
+
 router.get('/', auth, async (req: AuthReq, res: Res) => {
   try {
     const { type, limit = '10' } = req.query || {};
-    const summaries = await SummarizerService.getRecentSummaries(type, parseInt(limit, 10));
-    res.json(summaries);
+    const cappedLimit = Math.max(1, Math.min(50, parseInt(limit, 10) || 10));
+    const userId = req.userId || req.user?.id;
+    const summaries = await SummarizerService.getRecentSummaries(type, cappedLimit);
+    res.json(await filterSummariesToViewable(userId, summaries));
   } catch (error) {
     console.error('Error fetching summaries:', error);
     res.status(500).json({ error: 'Failed to fetch summaries' });
   }
 });
 
-router.get('/latest', auth, async (_req: AuthReq, res: Res) => {
+router.get('/latest', auth, async (req: AuthReq, res: Res) => {
   try {
-    const [postSummaries, chatSummaries] = await Promise.all([SummarizerService.getRecentSummaries('posts', 1), SummarizerService.getRecentSummaries('chats', 1)]);
+    const userId = req.userId || req.user?.id;
+    const [postSummaries, chatSummaries] = await Promise.all([SummarizerService.getRecentSummaries('posts', 1), SummarizerService.getRecentSummaries('chats', 20)]);
     let posts = postSummaries[0] || null;
     if (!posts) {
       try { posts = await summarizerService.summarizeAllPosts(); } catch (allPostsError) {
         console.warn('Failed to build on-demand all-posts summary:', (allPostsError as Error).message);
       }
     }
-    res.json({ posts, chats: chatSummaries[0] || null });
+    const viewableChats = await filterSummariesToViewable(userId, chatSummaries);
+    res.json({ posts, chats: viewableChats[0] || null });
   } catch (error) {
     console.error('Error fetching latest summaries:', error);
     res.status(500).json({ error: 'Failed to fetch latest summaries' });
@@ -104,8 +139,11 @@ router.post('/trigger', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.post('/debug', auth, async (_req: AuthReq, res: Res) => {
+router.post('/debug', auth, async (req: AuthReq, res: Res) => {
   try {
+    // Admin-only: the live cluster runs with NODE_ENV=development, so an
+    // env check alone leaves this trigger open to every authed user.
+    if (!(await isGlobalAdminUser(req.user?.id || req.userId))) return res.status(403).json({ error: 'Global admin access required' });
     if (process.env.NODE_ENV === 'production') return res.status(403).json({ error: 'Debug endpoints not available in production' });
     const result = await SchedulerService.triggerSummarizer();
     res.json({ message: 'Debug summarizer triggered successfully', result, timestamp: new Date().toISOString() });
@@ -128,18 +166,21 @@ router.get('/status', auth, (_req: AuthReq, res: Res) => {
 router.get('/chat-rooms', auth, async (req: AuthReq, res: Res) => {
   try {
     const { limit = '5' } = req.query || {};
-    const chatRoomSummaries = await ChatSummarizerService.getRecentChatSummariesByPodType('chat', parseInt(limit, 10));
-    res.json(chatRoomSummaries);
+    const userId = req.userId || req.user?.id;
+    const chatRoomSummaries = await ChatSummarizerService.getRecentChatSummariesByPodType('chat', Math.max(1, Math.min(50, parseInt(limit, 10) || 5)));
+    res.json(await filterSummariesToViewable(userId, chatRoomSummaries));
   } catch (error) {
     console.error('Error fetching chat room summaries:', error);
     res.status(500).json({ error: 'Failed to fetch chat room summaries' });
   }
 });
 
-router.get('/chat-rooms/latest', auth, async (_req: AuthReq, res: Res) => {
+router.get('/chat-rooms/latest', auth, async (req: AuthReq, res: Res) => {
   try {
-    const latestChatSummary = await ChatSummarizerService.getLatestChatSummary();
-    res.json(latestChatSummary);
+    const userId = req.userId || req.user?.id;
+    const recentChatSummaries = await ChatSummarizerService.getRecentChatSummariesByPodType('chat', 20);
+    const viewable = await filterSummariesToViewable(userId, recentChatSummaries);
+    res.json(viewable[0] || null);
   } catch (error) {
     console.error('Error fetching latest chat room summary:', error);
     res.status(500).json({ error: 'Failed to fetch latest chat room summary' });
@@ -149,8 +190,9 @@ router.get('/chat-rooms/latest', auth, async (_req: AuthReq, res: Res) => {
 router.get('/study-rooms', auth, async (req: AuthReq, res: Res) => {
   try {
     const { limit = '5' } = req.query || {};
-    const studyRoomSummaries = await ChatSummarizerService.getRecentChatSummariesByPodType('study', parseInt(limit, 10));
-    res.json(studyRoomSummaries);
+    const userId = req.userId || req.user?.id;
+    const studyRoomSummaries = await ChatSummarizerService.getRecentChatSummariesByPodType('study', Math.max(1, Math.min(50, parseInt(limit, 10) || 5)));
+    res.json(await filterSummariesToViewable(userId, studyRoomSummaries));
   } catch (error) {
     console.error('Error fetching study room summaries:', error);
     res.status(500).json({ error: 'Failed to fetch study room summaries' });
@@ -160,8 +202,9 @@ router.get('/study-rooms', auth, async (req: AuthReq, res: Res) => {
 router.get('/game-rooms', auth, async (req: AuthReq, res: Res) => {
   try {
     const { limit = '5' } = req.query || {};
-    const gameRoomSummaries = await ChatSummarizerService.getRecentChatSummariesByPodType('games', parseInt(limit, 10));
-    res.json(gameRoomSummaries);
+    const userId = req.userId || req.user?.id;
+    const gameRoomSummaries = await ChatSummarizerService.getRecentChatSummariesByPodType('games', Math.max(1, Math.min(50, parseInt(limit, 10) || 5)));
+    res.json(await filterSummariesToViewable(userId, gameRoomSummaries));
   } catch (error) {
     console.error('Error fetching game room summaries:', error);
     res.status(500).json({ error: 'Failed to fetch game room summaries' });
@@ -202,8 +245,18 @@ router.get('/pods', auth, async (req: AuthReq, res: Res) => {
   try {
     const { podIds } = req.query || {};
     if (!podIds) return res.status(400).json({ error: 'podIds parameter is required' });
-    const podIdArray = podIds.split(',').map((id) => id.trim());
-    const podSummaries = await chatSummarizerService.getMultiplePodSummaries(podIdArray);
+    const podIdArray = [...new Set(podIds.split(',').map((id) => id.trim()).filter(Boolean))].slice(0, 50);
+    // Same visibility rule as GET /pod/:podId — silently drop pods the
+    // caller can't view rather than 403ing the whole batch, so a mixed
+    // sidebar request still resolves for the viewable subset.
+    const userId = req.userId || req.user?.id;
+    const pods = await Pod.find({ _id: { $in: podIdArray } }).select('_id members type').lean() as Array<{ _id: unknown; members?: unknown[]; type?: string }>;
+    const viewablePodIds: string[] = [];
+    await Promise.all(pods.map(async (pod) => {
+      if (await DMService.canViewPod(userId, pod)) viewablePodIds.push(String(pod._id));
+    }));
+    if (viewablePodIds.length === 0) return res.json({});
+    const podSummaries = await chatSummarizerService.getMultiplePodSummaries(viewablePodIds);
     res.json(podSummaries);
   } catch (error) {
     console.error('Error fetching pod summaries:', error);
@@ -214,6 +267,13 @@ router.get('/pods', auth, async (req: AuthReq, res: Res) => {
 router.post('/pod/:podId/refresh', auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId } = req.params || {};
+    // Refresh both reads pod content (the generated summary is returned
+    // in the response) and burns LLM budget — gate it exactly like the
+    // GET /pod/:podId read above.
+    const pod = await Pod.findById(podId).select('_id members type').lean();
+    if (!pod) return res.status(404).json({ error: 'Pod not found' });
+    const callerId = req.userId || req.user?.id;
+    if (!(await DMService.canViewPod(callerId, pod))) return res.status(403).json({ error: 'Not authorized to refresh this pod summary' });
     const windowMinutes = Math.max(5, Math.min(240, parseInt((req.body?.windowMinutes as string) || '60', 10) || 60));
     const installations = await getActiveSummaryInstallationsForPod(podId || '') as Array<{ instanceId?: string }>;
     if (!installations.length) {
@@ -278,8 +338,10 @@ router.get('/daily-digest/history', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.post('/daily-digest/trigger-all', auth, async (_req: AuthReq, res: Res) => {
+router.post('/daily-digest/trigger-all', auth, async (req: AuthReq, res: Res) => {
   try {
+    // Fans out digest generation (and LLM calls) for every user — admin-only.
+    if (!(await isGlobalAdminUser(req.user?.id || req.userId))) return res.status(403).json({ error: 'Global admin access required' });
     await SummarizerService.garbageCollectForDigest();
     const results = await dailyDigestService.generateAllDailyDigests() as Array<{ success: boolean }>;
     const successful = results.filter((r) => r.success).length;

--- a/backend/services/summarizerService.ts
+++ b/backend/services/summarizerService.ts
@@ -361,7 +361,10 @@ Focus on what people are actually talking about rather than just activity levels
         return cache.summary;
       }
 
-      const posts = await Post.find({})
+      // Global digest = global-feed posts only. Pod-scoped posts inherit
+      // pod visibility (canViewPod on the posts routes) and must not leak
+      // into an instance-wide summary any authed user can read.
+      const posts = await Post.find({ podId: null })
         .populate('userId', 'username')
         .sort({ createdAt: -1 })
         .limit(10)


### PR DESCRIPTION
Pre-Show-HN privacy hardening, driven by Sam's question: *did we expose the summary bot to users' private pods?*

## Findings (live data, 2026-07-06)
- Registration workspaces are clean — that path never installed commonly-bot. All 10 launch-night users' pods contain only themselves + their own BYO agents.
- **But `createPod` (UI "New Pod") auto-installs commonly-bot into every new pod** — visible in the member list, posting-authorized. No external user has hit this path yet, so there's nothing to migrate — this PR disarms it before anyone does.
- The summaries router had ungated reads that bypassed the `canViewPod` gate on `GET /pod/:podId` (details in the commit message), including an any-pod on-demand summarize+return in `/refresh` — same IDOR class as #616.

## Changes
1. `AUTO_INSTALL_DEFAULT_AGENT` now opt-in (`=1`), default off.
2. Every summaries read runs through `DMService.canViewPod`; digest lists are caller-scoped; `/debug` + `/daily-digest/trigger-all` admin-only; `summarizeAllPosts` restricted to global-feed posts.

## Tests
- `summaries.visibility.test.js` (new, 8 cases): IDOR gates, digest scoping, admin gates.
- `podController.test.js`: default-off regression + opt-in path both covered.
- Existing service-tier `summaries.test.js` unaffected (its user is a member of every pod it reads; its posts are global-feed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9