### PR TITLE
fix(v2/chat): send button click was a no-op — MouseEvent passed as handleSend override

### DIFF
--- a/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
@@ -1,0 +1,90 @@
+// @ts-nocheck
+// Regression for the send-button click: handleSend(override?: string) was
+// wired as onClick={handleSend}, so the MouseEvent arrived as `override` and
+// (override ?? draft).trim() threw — the button silently did nothing while
+// Enter-to-send kept working (regressed in 45380a50).
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2PodChat from '../components/V2PodChat';
+import { AuthContext } from '../../context/AuthContext';
+
+jest.mock('../../context/SocketContext', () => ({
+  useSocket: () => ({ socket: null, connected: false }),
+}));
+
+// jsdom has no scrollIntoView; the component auto-scrolls on mount.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+// Same mock surface as V2Login.test.tsx — axiosConfig assigns
+// axios.defaults.baseURL at import time.
+jest.mock('axios', () => {
+  const mock = {
+    get: jest.fn(() => Promise.resolve({ data: {} })),
+    post: jest.fn(() => Promise.resolve({ data: {} })),
+    patch: jest.fn(),
+    delete: jest.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  };
+  return { __esModule: true, default: mock, ...mock };
+});
+
+const authValue = {
+  currentUser: { _id: 'u1', username: 'solo-user' },
+  user: { _id: 'u1', username: 'solo-user' },
+  token: 't',
+  loading: false,
+  error: null,
+  isAuthenticated: true,
+  register: jest.fn(),
+  login: jest.fn(),
+  logout: jest.fn(),
+  updateProfile: jest.fn(),
+};
+
+const makeDetail = (overrides = {}) => ({
+  pod: { _id: 'p1', name: 'My Workspace', type: 'chat' },
+  members: [{ _id: 'u1', username: 'solo-user', isBot: false }],
+  messages: [],
+  agents: [],
+  sendMessage: jest.fn(() => Promise.resolve({ _id: 'm1' })),
+  loading: false,
+  error: null,
+  refresh: jest.fn(),
+  ...overrides,
+});
+
+const renderChat = (detail) => render(
+  <AuthContext.Provider value={authValue}>
+    <MemoryRouter>
+      <V2PodChat detail={detail} />
+    </MemoryRouter>
+  </AuthContext.Provider>,
+);
+
+describe('V2PodChat composer send button', () => {
+  test('clicking the send button sends the drafted text', async () => {
+    const detail = makeDetail();
+    renderChat(detail);
+
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+      target: { value: 'hello team' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    await waitFor(() => {
+      expect(detail.sendMessage).toHaveBeenCalledWith('hello team', 'text', undefined);
+    });
+  });
+
+  test('send button is disabled while the draft is empty', () => {
+    renderChat(makeDetail());
+    expect(screen.getByRole('button', { name: /send message/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -952,7 +952,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
                 <button
                   type="button"
                   className={`v2-chat__send v2-chat__send--${mode}`}
-                  onClick={handleSend}
+                  onClick={() => handleSend()}
                   disabled={sending || !draft.trim()}
                   title={sending ? 'Sending…' : 'Send message'}
                   aria-label={sending ? 'Sending…' : 'Send message'}


### PR DESCRIPTION
## Summary
User-reported: clicking the blue send button in any chatroom does nothing — the message stays in the composer. (The report mentioned right-click, which is normal browser behavior, but left-click turned out to be broken too.)

**Root cause:** since `45380a50` (chip autosend), `handleSend` takes `override?: string`, but the send button stayed wired as `onClick={handleSend}` — so the click passed the MouseEvent as `override`, and `(override ?? draft).trim()` threw a TypeError before anything was sent. Enter-to-send calls `handleSend()` with no args, which is why this went unnoticed.

**Fix:** wrap in an arrow — `onClick={() => handleSend()}`. Audited the repo for other bare `onClick={handleSend}` usages: the only other one (`UnifiedComposer`) takes no params, so it's safe.

## Test plan
- New RTL regression test (`V2PodChatComposer.test.tsx`): types a draft, clicks the send button, asserts `sendMessage` is called with the text; verified it **fails** against the pre-fix code and passes with the fix. Also pins the disabled-while-empty state.
- Full frontend suite: 205/205 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X66EccQVb9282gAoPbUkDY