### PR TITLE
fix(security): bounded trust proxy + IPv6-safe rate-limit keys (#652)

### DIFF
--- a/backend/__tests__/unit/middleware/agentRateLimit.test.js
+++ b/backend/__tests__/unit/middleware/agentRateLimit.test.js
@@ -38,6 +38,22 @@ describe('agentRateLimitKeyGenerator', () => {
     expect(k).toBe('ip:203.0.113.7');
   });
 
+  // #652 ERR_ERL_KEY_GEN_IPV6: two addresses inside the same IPv6 prefix must
+  // share one bucket, or a client rotating within its allocation bypasses the
+  // limit entirely.
+  it('collapses IPv6 addresses in the same prefix to one key', () => {
+    const a = agentRateLimitKeyGenerator({
+      headers: {},
+      ip: '2001:db8:85a3:8d3:1319:8a2e:370:7348',
+    });
+    const b = agentRateLimitKeyGenerator({
+      headers: {},
+      ip: '2001:db8:85a3:8d3:aaaa:bbbb:cccc:dddd',
+    });
+    expect(a).toBe(b);
+    expect(a).not.toBe('ip:2001:db8:85a3:8d3:1319:8a2e:370:7348');
+  });
+
   it('returns the same key for two requests with the same token', () => {
     const req = {
       agentTokenHash: 'same-hash',

--- a/backend/middleware/agentRateLimit.ts
+++ b/backend/middleware/agentRateLimit.ts
@@ -15,6 +15,7 @@
 
 import type { Request } from 'express';
 import { createHash } from 'crypto';
+import { ipKeyGenerator } from 'express-rate-limit';
 
 export const agentRateLimitKeyGenerator = (req: Request): string => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -24,7 +25,9 @@ export const agentRateLimitKeyGenerator = (req: Request): string => {
   if (typeof auth === 'string' && auth.length > 0) {
     return `hdr:${createHash('sha256').update(auth).digest('hex')}`;
   }
-  return `ip:${req.ip || 'unknown'}`;
+  // ipKeyGenerator collapses IPv6 to its prefix so a client can't rotate
+  // through its /64 to bypass the limit (ERR_ERL_KEY_GEN_IPV6, #652).
+  return `ip:${req.ip ? ipKeyGenerator(req.ip) : 'unknown'}`;
 };
 
 // CJS compat for the require()-style imports used elsewhere in backend/.

--- a/backend/routes/registry/files.ts
+++ b/backend/routes/registry/files.ts
@@ -4,7 +4,7 @@
 // query only recognises the middleware on the SAME file as the route
 // registration (per the note in agentsRuntime.ts). Inlined here, with a
 // userId-keyed generator so per-user limits stay isolated.
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 
 const express = require('express');
 const auth = require('../../middleware/auth');
@@ -35,14 +35,16 @@ const {
 const filesRouter = express.Router({ mergeParams: true });
 
 // Inline rate limiter for the inspector a2a-DM read surface. Per-user
-// (after auth middleware sets req.userId); IPv6-safe key generator using
-// `${req.userId || req.ip}`. 120/min mirrors the agentsRuntime phase4 cap.
+// (after auth middleware sets req.userId); the unauth fallback goes through
+// ipKeyGenerator so IPv6 clients can't rotate within their prefix
+// (ERR_ERL_KEY_GEN_IPV6, #652). 120/min mirrors the agentsRuntime phase4 cap.
 const inspectorRateLimit = rateLimit({
   windowMs: 60_000,
   max: 120,
   standardHeaders: true,
   legacyHeaders: false,
-  keyGenerator: (req: any) => String(req.userId || req.user?._id || req.ip || 'anon'),
+  keyGenerator: (req: any) =>
+    String(req.userId || req.user?._id || (req.ip ? ipKeyGenerator(req.ip) : 'anon')),
   handler: (_req: any, res: any) => res.status(429).json({
     message: 'rate limit exceeded: 120 requests per 60s',
     code: 'rate_limited',

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -82,7 +82,17 @@ const app = express();
 // pod attachments) gets emitted as `http://api.commonly.me/...` and
 // triggers Mixed Content warnings in every page load. Trusting the proxy
 // makes Express honor X-Forwarded-Proto.
-app.set('trust proxy', true);
+//
+// Bounded, not `true` (#652): `true` trusts every hop in X-Forwarded-For, so
+// any client can spoof req.ip and bypass the IP-keyed rate limiters
+// (express-rate-limit ERR_ERL_PERMISSIVE_TRUST_PROXY). Every real hop in
+// front of us — cloudflared pod, nginx, docker-compose bridge, local dev —
+// sits on a loopback/private address, so trusting only those ranges walks
+// X-Forwarded-For from the right past our own infra and stops at the first
+// public address: the client IP as recorded by Cloudflare. A spoofed header
+// just gets the real client IP appended after it by the edge, so spoofing
+// can't reach req.ip.
+app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
 const buildAllowedOrigins = () => {
   const raw = process.env.FRONTEND_URL;
   if (raw && raw.trim()) {


### PR DESCRIPTION
## Summary
Fixes #652 — both `express-rate-limit` ValidationErrors on the GA auth endpoints.

**`ERR_ERL_PERMISSIVE_TRUST_PROXY`:** `trust proxy: true` let any client spoof `X-Forwarded-For` and bypass the IP-keyed limiters (partially undoing the #614/#617 hardening). Now bounded to `['loopback', 'linklocal', 'uniquelocal']` — every real hop in front of the backend (cloudflared pod, nginx, compose bridge, local dev) sits on a loopback/private address, so Express walks `X-Forwarded-For` from the right past our infra and stops at the first public address: the client as recorded by Cloudflare. A spoofed header just gets the real client IP appended after it by the edge. `X-Forwarded-Proto` handling (the reason `true` was set — avatar/attachment URL scheme, OAuth callback base) is unchanged since the immediate hop stays trusted.

**`ERR_ERL_KEY_GEN_IPV6`:** `agentRateLimitKeyGenerator` and the registry/files inspector limiter keyed raw `req.ip`, so IPv6 clients could rotate within their /64 to reset their bucket. Both now go through `ipKeyGenerator` (collapses IPv6 to its /56). Repo-wide sweep found no other raw-IP key generators — the rest already use `cloudflareIpRateLimitKeyGenerator` or token-hash keys.

## Test plan
- New regression test: two same-prefix IPv6 addresses map to one bucket (and not to the raw address).
- Existing `agentRateLimit` / `ipRateLimit` suites green; full backend suite unchanged vs. main (only the known Node-26 local drift, #649).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X66EccQVb9282gAoPbUkDY