### PR TITLE
fix(pod-skills): stop retrying a permanently-rejected LLM credential (#651)

### DIFF
--- a/backend/__tests__/unit/services/podSkillService.test.js
+++ b/backend/__tests__/unit/services/podSkillService.test.js
@@ -1,3 +1,9 @@
+// Hoisted mock — podSkillService destructures generateText at require time,
+// so a post-require spy on the module object would never be seen.
+jest.mock('../../../services/llmService', () => ({
+  generateText: jest.fn(),
+}));
+
 jest.mock('../../../services/podAssetService', () => ({
   extractKeywords: (text = '') => text
     .toLowerCase()
@@ -8,6 +14,7 @@ jest.mock('../../../services/podAssetService', () => ({
 
 const PodAssetService = require('../../../services/podAssetService');
 const PodSkillService = require('../../../services/podSkillService');
+const llmService = require('../../../services/llmService');
 
 describe('PodSkillService', () => {
   afterEach(() => {
@@ -78,5 +85,64 @@ describe('PodSkillService', () => {
     );
     expect(result.skills).toHaveLength(1);
     expect(result.warnings).toEqual([]);
+  });
+
+  // #651: a permanently-dead credential (Gemini 401) used to be retried on
+  // every context poll (~1,600 log lines/day). A 401/403 must disable
+  // synthesis for the process lifetime; transient errors must not.
+  describe('permanent credential failure guard', () => {
+    const baseArgs = {
+      pod: { id: 'pod-1', name: 'Pod', description: '' },
+      referenceEntries: [{
+        refId: 'S1', type: 'summary', id: 's1', title: 'T', createdAt: new Date(), tags: [], content: 'c',
+      }],
+      skillLimit: 4,
+    };
+
+    beforeEach(() => {
+      // The singleton's availability was computed from env at require time;
+      // force it on so the guard (not missing config) is what we exercise.
+      PodSkillService.available = true;
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      PodSkillService.available = true;
+    });
+
+    it('disables synthesis for the process lifetime after a Gemini-style 401', async () => {
+      llmService.generateText.mockRejectedValue(
+        new Error('[GoogleGenerativeAI Error]: Error fetching from https://...: [401 Unauthorized] API key not valid'),
+      );
+
+      const first = await PodSkillService.generateSkillsWithLLM(baseArgs);
+      expect(first.warnings).toEqual(['LLM skill synthesis disabled: credential rejected (401/403).']);
+      expect(PodSkillService.isAvailable()).toBe(false);
+
+      await PodSkillService.generateSkillsWithLLM(baseArgs);
+      expect(llmService.generateText).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables synthesis on a structured 401/403 status', async () => {
+      llmService.generateText.mockRejectedValue(
+        Object.assign(new Error('Request failed'), { response: { status: 401 } }),
+      );
+
+      await PodSkillService.generateSkillsWithLLM(baseArgs);
+      expect(PodSkillService.isAvailable()).toBe(false);
+    });
+
+    it('stays available after a transient (non-auth) failure', async () => {
+      llmService.generateText.mockRejectedValue(
+        new Error('timeout of 30000ms exceeded'),
+      );
+
+      const first = await PodSkillService.generateSkillsWithLLM(baseArgs);
+      expect(first.warnings).toEqual(['LLM skill synthesis failed.']);
+      expect(PodSkillService.isAvailable()).toBe(true);
+
+      await PodSkillService.generateSkillsWithLLM(baseArgs);
+      expect(llmService.generateText).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/backend/services/podContextService.ts
+++ b/backend/services/podContextService.ts
@@ -507,7 +507,7 @@ class PodContextService {
       && (taskTokens.size > 0 || skillAgeHours > refreshHours);
 
     if (skillModeUsed === 'llm' && !PodSkillService.isAvailable()) {
-      skillWarnings.push('LLM skill synthesis is unavailable (missing GEMINI_API_KEY).');
+      skillWarnings.push('LLM skill synthesis is unavailable (not configured, or disabled after a credential failure).');
       skillModeUsed = 'none';
     }
 

--- a/backend/services/podSkillService.ts
+++ b/backend/services/podSkillService.ts
@@ -280,6 +280,18 @@ function buildSkillMarkdown(
   ].join('\n');
 }
 
+// A 401/403 from the LLM means the credential itself is rejected — retrying
+// won't change the answer until the key is fixed and the process restarts.
+// Matches both structured HTTP errors (axios-style status) and the
+// GoogleGenerativeAIError shape, whose message embeds "[401 Unauthorized]".
+const isPermanentAuthError = (error: unknown): boolean => {
+  const err = error as { status?: number; response?: { status?: number }; message?: unknown };
+  const status = err?.status ?? err?.response?.status;
+  if (status === 401 || status === 403) return true;
+  const message = typeof err?.message === 'string' ? err.message : String(error);
+  return /\b40[13]\b/.test(message) && /unauthorized|forbidden|api.?key/i.test(message);
+};
+
 class PodSkillService {
   private available: boolean;
 
@@ -315,6 +327,17 @@ class PodSkillService {
       }
       return { skills: parsed.skills as RawSkill[], warnings: [] };
     } catch (error) {
+      // #651: a dead credential used to be retried on every context poll
+      // (~1,600 log lines/day). Disable synthesis for the process lifetime
+      // and log once; a key fix + restart re-enables it.
+      if (isPermanentAuthError(error)) {
+        this.available = false;
+        console.error(
+          'Pod-skill synthesis LLM rejected its credential (401/403) — disabling synthesis until restart:',
+          error,
+        );
+        return { skills: [], warnings: ['LLM skill synthesis disabled: credential rejected (401/403).'] };
+      }
       console.error('Failed to synthesize pod skills with LLM:', error);
       return { skills: [], warnings: ['LLM skill synthesis failed.'] };
     }


### PR DESCRIPTION
## Summary
Fixes #651 — pod-skill synthesis was the single largest log-noise source (~1,600 Gemini 401 lines/day, ~once/min), burying real errors during triage.

**Why it looped:** a failed synthesis writes no skill asset, so `skillAgeHours` stays infinite and the next context poll (agents hit `get_context` about once a minute) re-fires the same dead-credential call forever.

**Fix (option 2 from the issue, the minimal one):** a 401/403 from the LLM — structured HTTP status or the `GoogleGenerativeAIError` message shape (`[401 Unauthorized]`) — marks the credential permanently rejected: synthesis is disabled for the process lifetime, logged once. Transient failures (timeouts, 5xx, 429) keep retrying exactly as before. Fixing the key + restart re-enables. `podContextService` already degrades gracefully when `isAvailable()` is false; its warning text updated to cover the new disabled state.

Routing synthesis through LiteLLM (option 1) stays open as the real fix for making the feature *work*; this PR stops the bleeding either way.

## Test plan
New regression tests: Gemini-style 401 message disables synthesis and stops further `generateText` calls; structured 401 status disables; transient timeout does NOT disable and keeps retrying. Existing podSkill/podContext suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X66EccQVb9282gAoPbUkDY