### PR TITLE
fix(chat): reply quote renders live — replyTo rides the newMessage broadcast (#646)

### DIFF
--- a/backend/__tests__/unit/controllers/messageController.test.js
+++ b/backend/__tests__/unit/controllers/messageController.test.js
@@ -9,6 +9,11 @@ jest.mock('../../../services/agentMentionService', () => ({
   enqueueMentions: jest.fn().mockResolvedValue({ enqueued: [], skipped: [] }),
   enqueueDmEvent: jest.fn().mockResolvedValue({ enqueued: [], skipped: [] }),
 }));
+jest.mock('../../../config/socket', () => ({
+  getIO: jest.fn(),
+}));
+
+const socketConfig = require('../../../config/socket');
 
 describe('messageController', () => {
   afterEach(() => {
@@ -94,6 +99,30 @@ describe('messageController', () => {
           userId: 'u1',
         }),
       );
+    });
+
+    // #646: the newMessage broadcast dropped replyTo, so live viewers saw
+    // replies without their quoted context until a reload re-fetched the
+    // joined row.
+    it('broadcasts replyTo on the newMessage socket emit', async () => {
+      const replyTo = {
+        id: 'm1', content: 'original message', username: 'bob', userId: 'u2',
+      };
+      Pod.findById.mockResolvedValue({ members: ['u1'], type: 'chat' });
+      PGMessage.create.mockResolvedValue({ id: 'm9' });
+      PGMessage.findById.mockResolvedValue({ id: 'm9', content: 'a reply', replyTo });
+      const emit = jest.fn();
+      socketConfig.getIO.mockReturnValue({ to: jest.fn(() => ({ emit })) });
+
+      const req = {
+        params: { podId: 'p1' },
+        body: { content: 'a reply', replyToMessageId: 'm1' },
+        user: { id: 'u1', username: 'alice' },
+      };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+      await messageController.createMessage(req, res);
+
+      expect(emit).toHaveBeenCalledWith('newMessage', expect.objectContaining({ replyTo }));
     });
   });
 

--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -290,6 +290,7 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
           profile_picture?: string;
           createdAt?: string;
           messageType?: string;
+          replyTo?: { id: string; content: string; username: string; userId: string } | null;
         };
         const formattedMessage = {
           _id: m._id || m.id,
@@ -302,6 +303,10 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
           username: m.username,
           profile_picture: m.profile_picture,
           createdAt: m.createdAt,
+          // Reply quote must ride the broadcast too — without it every live
+          // viewer renders the reply without its quoted context until a
+          // reload re-fetches the joined row (#646).
+          replyTo: m.replyTo ?? null,
         };
         io.to(`pod_${podId}`).emit('newMessage', formattedMessage);
       }

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -149,6 +149,7 @@ interface MessageNormalized {
   createdAt: Date | string;
   metadata?: MetadataDoc;
   profile_picture?: string;
+  replyTo?: { id: string; content: string; username: string; userId: string } | null;
 }
 
 interface StructuredSummary {
@@ -1301,11 +1302,29 @@ class AgentMessageService {
           replyToMessageId,
         );
 
+        // The raw INSERT row carries no reply JOIN, so a replying agent's
+        // broadcast would lack the quoted context until reload (#646).
+        // Re-fetch only when this is actually a reply; never let a failed
+        // re-fetch fall through to the Mongo path (that would duplicate the
+        // already-created PG row).
+        let replyTo: { id: string; content: string; username: string; userId: string } | null = null;
+        if (replyToMessageId && newMessage.id) {
+          try {
+            const joined = await (PGMessage as {
+              findById(id: string): Promise<{ replyTo?: typeof replyTo } | null>;
+            }).findById(String(newMessage.id));
+            replyTo = joined?.replyTo ?? null;
+          } catch (joinErr) {
+            console.warn('[agent-msg] reply join re-fetch failed:', (joinErr as Error).message);
+          }
+        }
+
         message = {
           _id: newMessage.id,
           id: newMessage.id,
           content: newMessage.content as string,
           messageType: (newMessage.message_type as string) || messageType,
+          replyTo,
           userId: {
             _id: agentUser._id,
             username: senderDisplayName || 'Unknown',
@@ -1399,6 +1418,9 @@ class AgentMessageService {
         profile_picture: (message as MessageNormalized).profile_picture || agentUser.profilePicture,
         createdAt: (message as MessageNormalized).createdAt,
         metadata: (message as MessageNormalized).metadata || metadata,
+        // Reply quote rides the broadcast so live viewers see the quoted
+        // context without a reload (#646).
+        replyTo: (message as MessageNormalized).replyTo ?? null,
       };
 
       io.to(`pod_${podId}`).emit('newMessage', formattedMessage);

--- a/frontend/src/v2/__tests__/useV2PodDetailReply.test.tsx
+++ b/frontend/src/v2/__tests__/useV2PodDetailReply.test.tsx
@@ -1,0 +1,96 @@
+// @ts-nocheck
+// Regression for #646: the Socket.io newMessage copy of a just-sent reply
+// can arrive before the POST response and used to win the dedupe wholesale.
+// Older-backend broadcasts omit replyTo, so the reply rendered without its
+// quoted context until reload. The dedupe must graft the POST copy's
+// replyTo onto an already-present socket copy.
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useV2PodDetail } from '../hooks/useV2PodDetail';
+
+const mockApi = {
+  get: jest.fn(),
+  post: jest.fn(),
+};
+jest.mock('../hooks/useV2Api', () => ({
+  useV2Api: () => mockApi,
+}));
+
+const socketHandlers = {};
+const mockSocket = {
+  on: jest.fn((event, handler) => { socketHandlers[event] = handler; }),
+  off: jest.fn((event) => { delete socketHandlers[event]; }),
+};
+jest.mock('../../context/SocketContext', () => ({
+  useSocket: () => ({
+    socket: mockSocket,
+    connected: true,
+    joinPod: jest.fn(),
+    leavePod: jest.fn(),
+  }),
+}));
+
+describe('useV2PodDetail reply threading (#646)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApi.get.mockImplementation((url) => {
+      if (url.startsWith('/api/messages/')) return Promise.resolve([]);
+      if (url.includes('/agents')) return Promise.resolve({ agents: [] });
+      return Promise.resolve({ _id: 'p1', name: 'Pod', members: [] });
+    });
+  });
+
+  it('grafts the POST copy replyTo onto a socket copy that won the dedupe race', async () => {
+    const replyTo = { id: 'm1', content: 'original', username: 'bob' };
+    let resolvePost;
+    mockApi.post.mockReturnValue(new Promise((resolve) => { resolvePost = resolve; }));
+
+    const { result } = renderHook(() => useV2PodDetail('p1'));
+    await waitFor(() => expect(socketHandlers.newMessage).toBeDefined());
+
+    let sendPromise;
+    act(() => {
+      sendPromise = result.current.sendMessage('a reply', 'text', 'm1');
+    });
+
+    // Socket broadcast (older-backend shape: no replyTo) lands first.
+    act(() => {
+      socketHandlers.newMessage({
+        id: 'm9', pod_id: 'p1', content: 'a reply', created_at: '2026-07-07T00:00:00Z',
+      });
+    });
+    // POST response (carries replyTo) resolves second.
+    await act(async () => {
+      resolvePost({
+        id: 'm9', pod_id: 'p1', content: 'a reply', created_at: '2026-07-07T00:00:00Z', replyTo,
+      });
+      await sendPromise;
+    });
+
+    const sent = result.current.messages.filter((m) => m.id === 'm9');
+    expect(sent).toHaveLength(1);
+    expect(sent[0].replyTo).toEqual(replyTo);
+  });
+
+  it('keeps a single copy when the POST response wins the race', async () => {
+    const replyTo = { id: 'm1', content: 'original', username: 'bob' };
+    mockApi.post.mockResolvedValue({
+      id: 'm9', pod_id: 'p1', content: 'a reply', created_at: '2026-07-07T00:00:00Z', replyTo,
+    });
+
+    const { result } = renderHook(() => useV2PodDetail('p1'));
+    await waitFor(() => expect(socketHandlers.newMessage).toBeDefined());
+
+    await act(async () => {
+      await result.current.sendMessage('a reply', 'text', 'm1');
+    });
+    act(() => {
+      socketHandlers.newMessage({
+        id: 'm9', pod_id: 'p1', content: 'a reply', created_at: '2026-07-07T00:00:00Z',
+      });
+    });
+
+    const sent = result.current.messages.filter((m) => m.id === 'm9');
+    expect(sent).toHaveLength(1);
+    expect(sent[0].replyTo).toEqual(replyTo);
+  });
+});

--- a/frontend/src/v2/hooks/useV2PodDetail.ts
+++ b/frontend/src/v2/hooks/useV2PodDetail.ts
@@ -266,9 +266,16 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
       // optimistic add both come from the same DB row and race after
       // backend PR #304 (which added the user-message broadcast). Whichever
       // arrives first wins; the second is a no-op. Without this, sending
-      // a message renders it twice in the sender's tab.
+      // a message renders it twice in the sender's tab. When the socket copy
+      // won the race, still graft this POST copy's reply fields onto it —
+      // an older backend's broadcast omits replyTo, which dropped the reply
+      // quote until reload (#646).
       setMessages((prev) => {
-        if (prev.some((m) => m.id && m.id === normalized.id)) return prev;
+        if (prev.some((m) => m.id && m.id === normalized.id)) {
+          return prev.map((m) => (
+            m.id === normalized.id ? { ...m, replyTo: m.replyTo ?? normalized.replyTo ?? null } : m
+          ));
+        }
         return chronologicalMessages([...prev, normalized]);
       });
       return normalized;


### PR DESCRIPTION
## Summary
Fixes #646 — sending a reply showed the message immediately but WITHOUT the quoted-context block until a page reload.

Both causes from the issue were real:
- **Broadcast gap:** the `newMessage` socket payloads from `messageController` (human sends) and `agentMessageService` (agent sends) omitted `replyTo`, so every live viewer got a quote-less copy. The controller already had the joined row in hand (its `findById` re-fetch) — it now forwards `replyTo`. The agent path's raw INSERT row has no reply JOIN, so it re-fetches the joined row only when the message is actually a reply — carefully NOT letting a failed re-fetch fall through to the Mongo fallback, which would have duplicated the already-created PG row. (`server.ts`'s legacy socket path already forwarded `replyTo`.)
- **Dedupe race:** in the sender's tab the socket copy usually beats the POST response and won the dedupe wholesale. `useV2PodDetail.sendMessage` now grafts the POST copy's `replyTo` onto an already-present socket copy — which also covers broadcasts from a not-yet-redeployed backend.

## Test plan
- Backend: controller emit carries `replyTo` on a reply send.
- Frontend: hook test covers both race orders — socket-first (grafts `replyTo`, no duplicate) and POST-first (socket copy is a no-op); the socket-first test verified to fail against the pre-fix hook.
- Full frontend suite 205/205; backend suite unchanged vs. main (known Node-26 local drift, #649).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X66EccQVb9282gAoPbUkDY