### PR TITLE
feat(invites): shareable pod links — anonymous preview + signup funnel

### DIFF
--- a/backend/__tests__/unit/routes/podInvites.preview.test.js
+++ b/backend/__tests__/unit/routes/podInvites.preview.test.js
@@ -1,0 +1,83 @@
+const request = require('supertest');
+const express = require('express');
+
+// Regression for the anonymous invite PREVIEW endpoint (share-pod funnel):
+// logged-out visitors may see pod NAME + member count for a valid invite —
+// and nothing else. No podId, no description, no member identities. Invalid,
+// expired, and DM-pod invites all collapse to the same 404 so the endpoint
+// can't probe which tokens exist for what.
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.user = { id: 'user1' };
+  req.userId = 'user1';
+  next();
+});
+
+const mockFindOne = jest.fn();
+jest.mock('../../../models/PodInvite', () => ({
+  PodInvite: { findOne: (...args) => mockFindOne(...args), create: jest.fn() },
+}));
+
+const Pod = require('../../../models/Pod');
+jest.mock('../../../models/Pod');
+
+jest.mock('../../../services/agentIdentityService', () => ({
+  DM_POD_TYPES_GUARD: new Set(['agent-room', 'agent-dm', 'agent-admin']),
+}));
+
+const routes = require('../../../routes/podInvites');
+
+const leanChain = (value) => ({ select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(value) }) });
+const usableInvite = (overrides = {}) => ({
+  token: 'tok123',
+  podId: 'p1',
+  expiresAt: null,
+  isUsable: () => true,
+  ...overrides,
+});
+
+describe('GET /api/invites/:token/preview (anonymous)', () => {
+  let app;
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api', routes);
+    jest.clearAllMocks();
+  });
+
+  it('returns name + member count only for a valid invite', async () => {
+    mockFindOne.mockResolvedValue(usableInvite());
+    Pod.findById.mockReturnValue(leanChain({
+      _id: 'p1',
+      name: 'Launch Prep',
+      description: 'secret internal notes',
+      type: 'chat',
+      members: ['a', 'b', 'c'],
+    }));
+
+    const res = await request(app).get('/api/invites/tok123/preview').expect(200);
+
+    expect(res.body.pod).toEqual({ name: 'Launch Prep', memberCount: 3 });
+    // Minimal disclosure: nothing beyond name + count leaks to anonymous.
+    expect(JSON.stringify(res.body)).not.toContain('p1');
+    expect(JSON.stringify(res.body)).not.toContain('secret internal notes');
+  });
+
+  it('404s an unknown token', async () => {
+    mockFindOne.mockResolvedValue(null);
+    await request(app).get('/api/invites/nope/preview').expect(404);
+  });
+
+  it('404s an expired/exhausted invite', async () => {
+    mockFindOne.mockResolvedValue(usableInvite({ isUsable: () => false }));
+    await request(app).get('/api/invites/tok123/preview').expect(404);
+  });
+
+  it('404s DM-pod invites with the same message as unknown tokens', async () => {
+    mockFindOne.mockResolvedValue(usableInvite());
+    Pod.findById.mockReturnValue(leanChain({ _id: 'p1', name: 'Admin: solo', type: 'agent-admin', members: ['a', 'b'] }));
+
+    const res = await request(app).get('/api/invites/tok123/preview').expect(404);
+    expect(res.body.msg).toBe('Invite invalid or expired');
+  });
+});

--- a/backend/routes/podInvites.ts
+++ b/backend/routes/podInvites.ts
@@ -1,15 +1,47 @@
-// Pod invite tokens — shareable URLs that let a logged-in user join a pod
-// without going through the invite-only joinPolicy gate. Tokens are random
+// Pod invite tokens — shareable URLs that let a user join a pod without
+// going through the invite-only joinPolicy gate. Tokens are random
 // (16-byte hex), DB-backed (PodInvite), and bound to a single pod by their
-// creator. Logged-in users only — no guest registration via invite.
+// creator. Authenticated users resolve + redeem; anonymous visitors get a
+// minimal PREVIEW (pod name + member count only) so a shared link can show
+// "you've been invited to X — sign up to join" instead of a blank login wall.
 import express from 'express';
-import crypto from 'crypto';
+import crypto, { createHash } from 'crypto';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 const router = express.Router();
 const auth = require('../middleware/auth');
 const Pod = require('../models/Pod');
 const { PodInvite } = require('../models/PodInvite');
 
 const getUserId = (req: any) => req.userId || req.user?.id || req.user?._id;
+
+// Same token/IP keying as the messages-router limiters (#614). The preview
+// endpoint is anonymous and DB-backed, so it gets a tight IP bucket — it's
+// also the token-enumeration surface, and the limiter is the brake on that.
+const inviteRateLimitKey = (req: any) => {
+  const authHeader = req.get?.('authorization') || req.get?.('x-auth-token');
+  if (authHeader) {
+    return `tok:${createHash('sha256').update(authHeader).digest('hex').slice(0, 16)}`;
+  }
+  return req.ip ? ipKeyGenerator(req.ip) : 'anon';
+};
+
+const inviteReadRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: inviteRateLimitKey,
+  handler: (_req: any, res: any) => res.status(429).json({ msg: 'rate limit exceeded: 60 invite reads per 60s' }),
+});
+
+const inviteWriteRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: inviteRateLimitKey,
+  handler: (_req: any, res: any) => res.status(429).json({ msg: 'rate limit exceeded: 20 invite writes per 60s' }),
+});
 
 const isPodMember = (pod: any, userId: string) => {
   if (!pod || !userId) return false;
@@ -22,7 +54,7 @@ const isPodMember = (pod: any, userId: string) => {
 // POST /api/pods/:podId/invites — issue a fresh invite token. Caller must
 // be a member or creator. Body: { expiresInHours?, maxUses? } — both
 // optional; null = unlimited.
-router.post('/pods/:podId/invites', auth, async (req: any, res: any) => {
+router.post('/pods/:podId/invites', inviteWriteRateLimit, auth, async (req: any, res: any) => {
   try {
     const userId = getUserId(req);
     if (!userId) return res.status(401).json({ msg: 'Unauthorized' });
@@ -56,9 +88,41 @@ router.post('/pods/:podId/invites', auth, async (req: any, res: any) => {
   }
 });
 
+// GET /api/invites/:token/preview — ANONYMOUS, minimal disclosure. Lets the
+// redeem page show "you've been invited to <pod>" to logged-out visitors so
+// a shared link funnels into signup instead of a context-free login wall.
+// Returns pod NAME + member count only: no podId, no description, no member
+// identities. Invalid/expired/DM-pod invites all collapse to the same 404 so
+// the endpoint can't be used to probe which tokens exist for what.
+router.get('/invites/:token/preview', inviteReadRateLimit, async (req: any, res: any) => {
+  try {
+    const invite = await PodInvite.findOne({ token: req.params.token });
+    if (!invite || !invite.isUsable()) {
+      return res.status(404).json({ msg: 'Invite invalid or expired' });
+    }
+    const pod = await Pod.findById(invite.podId).select('_id name type members').lean();
+    if (!pod) return res.status(404).json({ msg: 'Invite invalid or expired' });
+    const { DM_POD_TYPES_GUARD } = require('../services/agentIdentityService');
+    if (DM_POD_TYPES_GUARD.has(String(pod.type))) {
+      // Not redeemable anyway — don't advertise the pod's existence.
+      return res.status(404).json({ msg: 'Invite invalid or expired' });
+    }
+    return res.json({
+      pod: {
+        name: pod.name,
+        memberCount: (pod.members || []).length,
+      },
+      expiresAt: invite.expiresAt,
+    });
+  } catch (err: any) {
+    console.error('Preview invite failed:', err.message);
+    return res.status(500).json({ msg: 'Failed to preview invite' });
+  }
+});
+
 // GET /api/invites/:token — resolve token to public pod info. Auth required
 // (we don't reveal pod existence to anonymous callers).
-router.get('/invites/:token', auth, async (req: any, res: any) => {
+router.get('/invites/:token', inviteReadRateLimit, auth, async (req: any, res: any) => {
   try {
     const userId = getUserId(req);
     if (!userId) return res.status(401).json({ msg: 'Unauthorized' });
@@ -95,7 +159,7 @@ router.get('/invites/:token', auth, async (req: any, res: any) => {
 // Increments useCount. Bypasses the pod's invite-only joinPolicy because
 // the token IS the invite. DM pods (agent-room/agent-dm/agent-admin) are
 // strictly 1:1 and refuse — start a fresh DM instead, same rule as joinPod.
-router.post('/invites/:token/redeem', auth, async (req: any, res: any) => {
+router.post('/invites/:token/redeem', inviteWriteRateLimit, auth, async (req: any, res: any) => {
   try {
     const userId = getUserId(req);
     if (!userId) return res.status(401).json({ msg: 'Unauthorized' });

--- a/frontend/src/v2/components/V2InviteRedeem.tsx
+++ b/frontend/src/v2/components/V2InviteRedeem.tsx
@@ -1,8 +1,11 @@
 // Public-facing redeem page for pod invite links. Lives at
-// `/v2/invite/:token`. Logged-in users only — anonymous visitors are
-// redirected to login with the invite URL preserved as `?next=`.
+// `/v2/invite/:token`. Logged-in users resolve + join in one click.
+// Anonymous visitors see a minimal preview ("you've been invited to X")
+// with sign-up / log-in CTAs that carry this URL as `?next=`, so the
+// shared link is a registration funnel instead of a blank login wall.
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { useNavigate, useParams, useLocation, Link } from 'react-router-dom';
+import axios from 'axios';
 import { useAuth } from '../../context/AuthContext';
 import { useV2Api } from '../hooks/useV2Api';
 import V2Avatar from './V2Avatar';
@@ -22,6 +25,11 @@ interface InviteResolveResponse {
   expiresAt?: string | null;
 }
 
+interface InvitePreviewResponse {
+  pod: { name?: string; memberCount?: number };
+  expiresAt?: string | null;
+}
+
 const V2InviteRedeem: React.FC = () => {
   const { token } = useParams<{ token: string }>();
   const navigate = useNavigate();
@@ -29,20 +37,33 @@ const V2InviteRedeem: React.FC = () => {
   const { isAuthenticated, loading: authLoading } = useAuth();
   const api = useV2Api();
   const [invite, setInvite] = useState<InviteResolveResponse | null>(null);
+  const [preview, setPreview] = useState<InvitePreviewResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [redeeming, setRedeeming] = useState(false);
 
-  // Anonymous visitor → bounce through login, preserving the invite URL
-  // so they land back here after auth. Login page reads `?next=` and
-  // navigates there on success.
+  const nextParam = encodeURIComponent(location.pathname + location.search);
+
+  // Anonymous visitor → fetch the minimal preview (no auth required) so we
+  // can show what they were invited to before asking them to sign up.
   useEffect(() => {
-    if (authLoading) return;
-    if (!isAuthenticated) {
-      const next = encodeURIComponent(location.pathname + location.search);
-      navigate(`/v2/login?next=${next}`, { replace: true });
-    }
-  }, [authLoading, isAuthenticated, location, navigate]);
+    if (authLoading || isAuthenticated || !token) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoading(true);
+        const res = await axios.get<InvitePreviewResponse>(
+          `/api/invites/${encodeURIComponent(token)}/preview`,
+        );
+        if (!cancelled) setPreview(res.data);
+      } catch {
+        if (!cancelled) setError('This invite is no longer valid.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [authLoading, isAuthenticated, token]);
 
   // Resolve the invite once auth is confirmed. Idempotent — server returns
   // alreadyMember=true if the user already belongs to the pod, and the UI
@@ -84,11 +105,50 @@ const V2InviteRedeem: React.FC = () => {
     }
   };
 
-  if (authLoading || (loading && isAuthenticated)) {
+  if (authLoading || loading) {
     return <div className="v2-invite-page"><div className="v2-invite-card v2-invite-card--loading">Loading invite…</div></div>;
   }
-  if (!isAuthenticated) return null; // redirect already in flight
 
+  // ---- anonymous: preview + signup funnel ----
+  if (!isAuthenticated) {
+    if (error || !preview) {
+      return (
+        <div className="v2-invite-page">
+          <div className="v2-invite-card">
+            <div className="v2-invite-card__title">Invite unavailable</div>
+            <div className="v2-invite-card__error">{error || 'This invite is no longer valid.'}</div>
+            <Link to="/v2" className="v2-invite-card__cta">What is Commonly?</Link>
+          </div>
+        </div>
+      );
+    }
+    const podName = preview.pod?.name || 'a pod';
+    const count = preview.pod?.memberCount ?? 0;
+    return (
+      <div className="v2-invite-page">
+        <div className="v2-invite-card">
+          <V2Avatar name={podName} size="lg" />
+          <div className="v2-invite-card__title">You&rsquo;ve been invited to {podName}</div>
+          <div className="v2-invite-card__meta">
+            {count} member{count === 1 ? '' : 's'} · humans and agents working together on Commonly
+          </div>
+          <button
+            type="button"
+            className="v2-invite-card__cta"
+            onClick={() => navigate(`/v2/register?next=${nextParam}`)}
+          >
+            Sign up to join
+          </button>
+          <div className="v2-invite-card__meta">
+            Already have an account?{' '}
+            <Link to={`/v2/login?next=${nextParam}`} className="v2-login__link">Log in</Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ---- authenticated ----
   if (error && !invite) {
     return (
       <div className="v2-invite-page">

--- a/frontend/src/v2/components/V2Register.tsx
+++ b/frontend/src/v2/components/V2Register.tsx
@@ -29,6 +29,11 @@ const V2Register: React.FC = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [invitationCode, setInvitationCode] = useState(searchParams.get('invite') || '');
+  // Deep-link context (e.g. a pod invite URL): thread through the whole
+  // signup flow so the user lands back where the share link pointed.
+  const rawNext = searchParams.get('next');
+  const nextPath = rawNext && rawNext.startsWith('/') ? rawNext : undefined;
+  const loginHref = nextPath ? `/v2/login?next=${encodeURIComponent(nextPath)}` : '/v2/login';
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState<string | null>(null);
@@ -91,13 +96,13 @@ const V2Register: React.FC = () => {
             <p className="v2-login__hint">
               We sent a verification link to your email. Verify your address,
               then{' '}
-              <Link to="/v2/login" className="v2-login__link">sign in</Link>.
+              <Link to={loginHref} className="v2-login__link">sign in</Link>.
             </p>
           ) : (
             <button
               type="button"
               className="v2-login__submit"
-              onClick={() => navigate('/v2/login')}
+              onClick={() => navigate(loginHref)}
             >
               Continue to sign in
             </button>
@@ -184,7 +189,7 @@ const V2Register: React.FC = () => {
 
         {error && <div className="v2-login__error">{error}</div>}
 
-        <V2OAuthButtons invite={invitationCode || undefined} />
+        <V2OAuthButtons invite={invitationCode || undefined} next={nextPath} />
 
         <div className="v2-login__hint">
           Already have an account?


### PR DESCRIPTION
## What
A shared pod invite link now works for people who don't have an account yet — the core of the share-pod growth loop.

**Before:** anonymous click on `/v2/invite/:token` → blind redirect to a context-free login page. Funnel dead.
**After:** anonymous click → "You've been invited to **Launch Prep** · 9 members" → Sign up to join → registration (with `?next=` threaded through success screen, email-verify path, and OAuth) → lands back on the invite → one-click join.

## Security posture
- New anonymous endpoint is **minimal-disclosure**: pod name + member count only — no podId, no description, no member identities (unit test asserts this).
- Invalid / expired / DM-pod invites return an identical 404 (no token probing).
- IP-keyed rate limit (60/min) on the anonymous surface — it's the token-enumeration vector; existing invite routes gain token-keyed limiters per the #614 pattern.
- DM pods (agent-room/agent-dm/agent-admin) remain un-joinable via links, same 404 shape.

## Why now
Launch week: every shared pod is an acquisition channel, and multi-user-plus-shareable is the concrete form of our structural advantage over Tutti's single-user OSS tier.

## Tests
- `podInvites.preview.test.js` — 4 cases incl. the minimal-disclosure assertion.
- Full frontend suite: 205/205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9