### PR TITLE
feat(admin): activation-funnel analytics endpoint (Wave 0, #661)

### DIFF
--- a/backend/__tests__/unit/routes/admin.analytics.funnel.test.js
+++ b/backend/__tests__/unit/routes/admin.analytics.funnel.test.js
@@ -1,0 +1,113 @@
+const request = require('supertest');
+const express = require('express');
+
+// Wave 0 (GH#661): activation-funnel endpoint. Verifies cohort math, bot
+// exclusion, the PG-backed sentMessage source, the lastActive return proxy,
+// and that non-admins are refused.
+
+let mockRole = 'admin';
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.user = { id: 'admin1' };
+  req.userId = 'admin1';
+  next();
+});
+jest.mock('../../../middleware/adminAuth', () => (req, res, next) => {
+  if (mockRole !== 'admin') return res.status(403).json({ message: 'Admin access required' });
+  return next();
+});
+jest.mock('../../../middleware/ipRateLimit', () => ({
+  cloudflareIpRateLimitKeyGenerator: () => 'test-key',
+}));
+
+const mockUserFind = jest.fn();
+jest.mock('../../../models/User', () => ({
+  find: (...args) => mockUserFind(...args),
+}));
+
+const mockDistinct = jest.fn();
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { distinct: (...args) => mockDistinct(...args) },
+}));
+
+const mockPgQuery = jest.fn();
+jest.mock('../../../config/db-pg', () => ({
+  pool: { query: (...args) => mockPgQuery(...args) },
+}));
+
+const routes = require('../../../routes/admin/analytics');
+
+const DAY = 24 * 60 * 60 * 1000;
+const daysAgo = (n) => new Date(Date.now() - n * DAY);
+
+const userDoc = (id, createdDaysAgo, lastActiveDaysAgo) => ({
+  _id: id,
+  createdAt: daysAgo(createdDaysAgo),
+  lastActive: lastActiveDaysAgo != null ? daysAgo(lastActiveDaysAgo) : undefined,
+});
+
+describe('GET /api/admin/analytics/funnel', () => {
+  let app;
+  beforeEach(() => {
+    app = express();
+    app.use('/api/admin/analytics', routes);
+    jest.clearAllMocks();
+    mockRole = 'admin';
+  });
+
+  const chain = (docs) => ({ select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(docs) }) });
+
+  it('computes cohorts, totals and rates from the three sources', async () => {
+    // u1: signed up 10d ago, attached agent, messaged, still active (D1+D7 return)
+    // u2: signed up 10d ago, no agent, no message, never came back
+    // u3: signed up 2d ago, attached, messaged, active yesterday (D1 return, no D7 yet)
+    mockUserFind.mockReturnValue(chain([
+      userDoc('u1', 10, 0),
+      userDoc('u2', 10, 10),
+      userDoc('u3', 2, 1),
+    ]));
+    mockDistinct.mockResolvedValue(['u1', 'u3']);
+    mockPgQuery.mockResolvedValue({ rows: [{ user_id: 'u1' }, { user_id: 'u3' }] });
+
+    const res = await request(app).get('/api/admin/analytics/funnel?days=30').expect(200);
+
+    expect(res.body.totals).toMatchObject({
+      signups: 3,
+      attachedAgent: 2,
+      sentMessage: 2,
+      returnedD1: 2,
+      returnedD7: 1,
+      attachRatePct: 67,
+      messageRatePct: 67,
+      d1ReturnPct: 67,
+      d7ReturnPct: 33,
+    });
+    // PG queried with the cohort's user ids
+    expect(mockPgQuery).toHaveBeenCalledWith(expect.stringContaining('DISTINCT user_id'), [['u1', 'u2', 'u3']]);
+    // Bot exclusion is part of the User query itself
+    const q = mockUserFind.mock.calls[0][0];
+    expect(JSON.stringify(q)).toContain('botMetadata.agentName');
+    // Every day in range is present (zeros, not gaps)
+    expect(res.body.cohorts.length).toBeGreaterThanOrEqual(30);
+  });
+
+  it('clamps days to [7, 90]', async () => {
+    mockUserFind.mockReturnValue(chain([]));
+    mockDistinct.mockResolvedValue([]);
+    const r1 = await request(app).get('/api/admin/analytics/funnel?days=2').expect(200);
+    expect(r1.body.days).toBe(7);
+    const r2 = await request(app).get('/api/admin/analytics/funnel?days=500').expect(200);
+    expect(r2.body.days).toBe(90);
+  });
+
+  it('skips the PG query entirely for an empty cohort', async () => {
+    mockUserFind.mockReturnValue(chain([]));
+    mockDistinct.mockResolvedValue([]);
+    await request(app).get('/api/admin/analytics/funnel').expect(200);
+    expect(mockPgQuery).not.toHaveBeenCalled();
+  });
+
+  it('403s non-admins', async () => {
+    mockRole = 'user';
+    await request(app).get('/api/admin/analytics/funnel').expect(403);
+  });
+});

--- a/backend/routes/admin/analytics.ts
+++ b/backend/routes/admin/analytics.ts
@@ -1,0 +1,135 @@
+// Admin activation-funnel analytics (Wave 0 "See & Hear", GH#661).
+// Everything is DERIVED from existing collections — no new tracking, no
+// third-party analytics, nothing leaves the instance. Human users only
+// (bot User rows are excluded by botMetadata.agentName absence).
+//
+// Honest approximations, documented:
+// - "returned D1/D7" uses User.lastActive >= createdAt + 1d/7d — i.e. "was
+//   active at some point ≥N days after signup". lastActive only stores the
+//   most recent activity, so intermediate visits are invisible; this is a
+//   floor-accurate proxy, not an event-grade cohort metric.
+// - "sent a message" reads PostgreSQL (the primary message store). The Mongo
+//   Message collection is a fallback path and would undercount ~everything.
+const express = require('express');
+const rateLimit = require('express-rate-limit');
+const auth = require('../../middleware/auth');
+const adminAuth = require('../../middleware/adminAuth');
+const User = require('../../models/User');
+const { AgentInstallation } = require('../../models/AgentRegistry');
+const { cloudflareIpRateLimitKeyGenerator } = require('../../middleware/ipRateLimit');
+
+const router = express.Router();
+
+// Read-only admin analytics — generous for a human operator, bounded for
+// abuse (CodeQL js/missing-rate-limiting).
+const adminReadLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  keyGenerator: cloudflareIpRateLimitKeyGenerator,
+  handler: (_req: any, res: any) => res.status(429).json({ message: 'rate limit exceeded: 60 analytics reads per 60s' }),
+});
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const dayKey = (d: Date) => d.toISOString().slice(0, 10);
+
+// Distinct PG user_ids with at least one message, within the candidate set.
+// Isolated so tests can run without a live PostgreSQL (mocked module).
+const pgUserIdsWithMessages = async (userIds: string[]): Promise<Set<string>> => {
+  if (userIds.length === 0) return new Set();
+  // eslint-disable-next-line global-require
+  const { pool } = require('../../config/db-pg');
+  const result = await pool.query(
+    'SELECT DISTINCT user_id FROM messages WHERE user_id = ANY($1)',
+    [userIds],
+  );
+  return new Set(result.rows.map((r: { user_id: string }) => String(r.user_id)));
+};
+
+// GET /api/admin/analytics/funnel?days=30
+// Daily signup cohorts with: signups, attached ≥1 agent, sent ≥1 message,
+// returned D1/D7 (proxy), plus a totals row with rates.
+router.get('/funnel', adminReadLimiter, auth, adminAuth, async (req: any, res: any) => {
+  try {
+    const days = Math.max(7, Math.min(90, parseInt(req.query.days, 10) || 30));
+    const since = new Date(Date.now() - days * DAY_MS);
+
+    const users = await User.find({
+      createdAt: { $gte: since },
+      $or: [
+        { botMetadata: { $exists: false } },
+        { 'botMetadata.agentName': { $exists: false } },
+      ],
+    }).select('_id createdAt lastActive').lean();
+
+    const ids = users.map((u: any) => String(u._id));
+    const [attachedIds, messagedIds] = await Promise.all([
+      AgentInstallation.distinct('installedBy', { installedBy: { $in: ids } })
+        .then((list: unknown[]) => new Set(list.map(String))),
+      pgUserIdsWithMessages(ids),
+    ]);
+
+    const byDay = new Map<string, {
+      date: string; signups: number; attachedAgent: number;
+      sentMessage: number; returnedD1: number; returnedD7: number;
+    }>();
+    // Pre-seed every day in range so quiet days render as zeros, not gaps.
+    for (let t = since.getTime(); t <= Date.now(); t += DAY_MS) {
+      const key = dayKey(new Date(t));
+      byDay.set(key, { date: key, signups: 0, attachedAgent: 0, sentMessage: 0, returnedD1: 0, returnedD7: 0 });
+    }
+
+    for (const u of users as any[]) {
+      const key = dayKey(new Date(u.createdAt));
+      const row = byDay.get(key);
+      if (!row) continue;
+      const id = String(u._id);
+      const created = new Date(u.createdAt).getTime();
+      const last = u.lastActive ? new Date(u.lastActive).getTime() : created;
+      row.signups += 1;
+      if (attachedIds.has(id)) row.attachedAgent += 1;
+      if (messagedIds.has(id)) row.sentMessage += 1;
+      if (last >= created + DAY_MS) row.returnedD1 += 1;
+      if (last >= created + 7 * DAY_MS) row.returnedD7 += 1;
+    }
+
+    const cohorts = [...byDay.values()].sort((a, b) => (a.date < b.date ? -1 : 1));
+    const totals = cohorts.reduce(
+      (acc, r) => ({
+        signups: acc.signups + r.signups,
+        attachedAgent: acc.attachedAgent + r.attachedAgent,
+        sentMessage: acc.sentMessage + r.sentMessage,
+        returnedD1: acc.returnedD1 + r.returnedD1,
+        returnedD7: acc.returnedD7 + r.returnedD7,
+      }),
+      { signups: 0, attachedAgent: 0, sentMessage: 0, returnedD1: 0, returnedD7: 0 },
+    );
+    const rate = (n: number) => (totals.signups ? Math.round((n / totals.signups) * 100) : 0);
+
+    return res.json({
+      days,
+      since: since.toISOString(),
+      cohorts,
+      totals: {
+        ...totals,
+        attachRatePct: rate(totals.attachedAgent),
+        messageRatePct: rate(totals.sentMessage),
+        d1ReturnPct: rate(totals.returnedD1),
+        d7ReturnPct: rate(totals.returnedD7),
+      },
+      notes: [
+        'returnedD1/D7 are lastActive-based proxies (active at some point ≥N days after signup)',
+        'sentMessage reads PostgreSQL, the primary message store',
+        'bot User rows excluded',
+      ],
+    });
+  } catch (err: any) {
+    console.error('Funnel analytics failed:', err.message);
+    return res.status(500).json({ message: 'Failed to compute funnel' });
+  }
+});
+
+module.exports = router;
+export {};

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -48,6 +48,7 @@ const globalIntegrationsRoutes = require('./routes/admin/globalIntegrations');
 const agentAutonomyAdminRoutes = require('./routes/admin/agentAutonomy');
 const agentEventsAdminRoutes = require('./routes/admin/agentEvents');
 const adminUsersRoutes = require('./routes/admin/users');
+const adminAnalyticsRoutes = require('./routes/admin/analytics');
 // Conditionally load PostgreSQL routes and models
 let pgPodRoutes: any;
 let pgMessageRoutes: any;
@@ -210,6 +211,7 @@ app.use('/api/admin/integrations/global', globalIntegrationsRoutes); // Admin gl
 app.use('/api/admin/agents/autonomy', agentAutonomyAdminRoutes); // Admin manual autonomy triggers
 app.use('/api/admin/agents/events', agentEventsAdminRoutes); // Admin agent event debug/queue visibility
 app.use('/api/admin/users', adminUsersRoutes); // Admin user + invitation management
+app.use('/api/admin/analytics', adminAnalyticsRoutes); // Admin activation-funnel analytics (GH#661)
 app.use('/api/dev', devRoutes); // Dev tooling (LLM status, etc.)
 app.use('/api/health', healthRoutes); // Health check endpoints
 app.use('/api/stats', statsRoutes); // Public stats (no auth)


### PR DESCRIPTION
First item of the **Wave 0 — See & Hear** milestone: we can finally answer *"of the people who signed up, how many attached an agent, sent a message, and came back?"*

## What
`GET /api/admin/analytics/funnel?days=N` (admin-only, rate-limited, days clamped 7–90): daily signup cohorts × {signups, attachedAgent, sentMessage, returnedD1, returnedD7} + totals with rates. Every day in range renders (zeros, not gaps).

## Design choices
- **Derived, not tracked**: computed from User/AgentInstallation/PG-messages. No new instrumentation, no third-party analytics, nothing leaves the instance — the privacy stance for an OSS product.
- **PG is the message source of truth** — the Mongo `Message` collection is a fallback path (~3 rows in the last 7 days in prod) and would undercount everything. (Separate issue incoming: `/api/stats/public` currently reads Mongo for `messageCount24h` and has this exact bug.)
- **Honest proxies, documented in-code**: D1/D7 'returned' uses `lastActive >= createdAt + N days` — a floor-accurate proxy, not event-grade cohorting.

## Tests
4-case unit spec: cohort/total/rate math, bot-exclusion in the query, PG queried with cohort ids (and skipped for empty cohorts), non-admin 403.

Next up in the milestone: #662 (admin dashboard tab rendering this endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9