### PR TITLE
fix(stats): count recent messages from PostgreSQL

### DIFF
--- a/backend/__tests__/unit/routes/stats.public.test.js
+++ b/backend/__tests__/unit/routes/stats.public.test.js
@@ -1,6 +1,9 @@
 const request = require('supertest');
 const express = require('express');
 
+const mockPgQuery = jest.fn();
+const mockMessageCountDocuments = jest.fn().mockResolvedValue(88);
+
 jest.mock('../../../models/Pod', () => ({
   countDocuments: jest.fn().mockResolvedValue(12),
 }));
@@ -8,14 +11,18 @@ jest.mock('../../../models/User', () => ({
   countDocuments: jest.fn().mockResolvedValue(42),
 }));
 jest.mock('../../../models/Message', () => ({
-  countDocuments: jest.fn().mockResolvedValue(88),
+  countDocuments: mockMessageCountDocuments,
 }));
 jest.mock('../../../models/AgentRegistry', () => ({
   AgentInstallation: {
     distinct: jest.fn().mockResolvedValue(['openclaw', 'moltbot', 'clawdbot']),
   },
 }));
+jest.mock('../../../config/db-pg', () => ({
+  pool: { query: mockPgQuery },
+}));
 
+// eslint-disable-next-line import/no-unresolved, import/extensions
 const statsRoutes = require('../../../routes/stats');
 
 describe('GET /api/stats/public', () => {
@@ -23,14 +30,41 @@ describe('GET /api/stats/public', () => {
   app.use(express.json());
   app.use('/api/stats', statsRoutes);
 
-  it('returns public stats with correct shape', async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPgQuery.mockResolvedValue({ rows: [{ count: 1234 }] });
+  });
+
+  it('uses PostgreSQL for the 24-hour message count', async () => {
     const res = await request(app).get('/api/stats/public');
     expect(res.status).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body).toEqual({
+      activePods: 12,
+      activeAgents: 3,
+      messageCount24h: 1234,
+      registeredUsers: 42,
+    });
+    expect(mockPgQuery).toHaveBeenCalledWith(
+      'SELECT COUNT(*)::int AS count FROM messages WHERE created_at >= $1',
+      [expect.any(Date)],
+    );
+    expect(mockMessageCountDocuments).not.toHaveBeenCalled();
+  });
+
+  it('falls back to MongoDB when the PostgreSQL count fails', async () => {
+    mockPgQuery.mockRejectedValue(new Error('PostgreSQL unavailable'));
+
+    const res = await request(app).get('/api/stats/public');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
       activePods: 12,
       activeAgents: 3,
       messageCount24h: 88,
       registeredUsers: 42,
+    });
+    expect(mockMessageCountDocuments).toHaveBeenCalledWith({
+      createdAt: { $gte: expect.any(Date) },
     });
   });
 

--- a/backend/routes/stats.ts
+++ b/backend/routes/stats.ts
@@ -29,9 +29,10 @@ router.get('/public', async (_req: unknown, res: { json: (d: unknown) => void; s
     const [activePods, activeAgents, messageCount24h, registeredUsers] = await Promise.all([
       Pod.countDocuments({ updatedAt: { $gte: sevenDaysAgo } }),
       AgentInstallation.distinct('agentName').then((names: string[]) => names.length),
-      pgMessageCount24h(oneDayAgo).catch(() =>
-        Message.countDocuments({ createdAt: { $gte: oneDayAgo } }),
-      ),
+      pgMessageCount24h(oneDayAgo).catch((err: { message?: string }) => {
+        console.warn('stats: PG message count failed, falling back to Mongo:', err?.message);
+        return Message.countDocuments({ createdAt: { $gte: oneDayAgo } });
+      }),
       User.countDocuments(),
     ]);
 

--- a/backend/routes/stats.ts
+++ b/backend/routes/stats.ts
@@ -11,6 +11,16 @@ const { AgentInstallation } = require('../models/AgentRegistry');
 
 const router: ReturnType<typeof express.Router> = express.Router();
 
+const pgMessageCount24h = async (since: Date): Promise<number> => {
+  // eslint-disable-next-line global-require
+  const { pool } = require('../config/db-pg');
+  const result = await pool.query(
+    'SELECT COUNT(*)::int AS count FROM messages WHERE created_at >= $1',
+    [since],
+  );
+  return result.rows[0].count;
+};
+
 router.get('/public', async (_req: unknown, res: { json: (d: unknown) => void; status: (n: number) => { json: (d: unknown) => void } }) => {
   try {
     const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
@@ -19,7 +29,9 @@ router.get('/public', async (_req: unknown, res: { json: (d: unknown) => void; s
     const [activePods, activeAgents, messageCount24h, registeredUsers] = await Promise.all([
       Pod.countDocuments({ updatedAt: { $gte: sevenDaysAgo } }),
       AgentInstallation.distinct('agentName').then((names: string[]) => names.length),
-      Message.countDocuments({ createdAt: { $gte: oneDayAgo } }),
+      pgMessageCount24h(oneDayAgo).catch(() =>
+        Message.countDocuments({ createdAt: { $gte: oneDayAgo } }),
+      ),
       User.countDocuments(),
     ]);
 


### PR DESCRIPTION
## Summary

- count public 24-hour messages from the primary PostgreSQL messages table
- fall back to the existing MongoDB count when PostgreSQL is unavailable
- cover the PostgreSQL-primary, MongoDB-fallback, and no-auth paths

## Root cause

The public stats route counted the MongoDB fallback collection, which only receives writes during PostgreSQL outages, instead of the primary PostgreSQL messages table.

## Validation

- full backend suite: 167 suites / 1,220 tests passed
- focused stats route suite: 3 tests passed
- backend TypeScript check: passed
- backend production build: passed
- changed test ESLint: passed
- git diff check: passed
- GitHub CI: all required checks passed, including Test & Coverage, Playwright E2E, CodeQL, and Tier 1 real-DB service tests

Closes #667