### PR TITLE
feat(backup): add GCS database backup and restore

### DIFF
--- a/docs/runbooks/db-backup-restore.md
+++ b/docs/runbooks/db-backup-restore.md
@@ -1,0 +1,274 @@
+# Database backup and restore
+
+Commonly can back up MongoDB and PostgreSQL to Google Cloud Storage with
+Helm-managed CronJobs. The jobs are disabled by default. Enabling them before
+the bucket, IAM role, and Workload Identity binding exist will only produce
+failed Jobs, so complete the operator setup in order.
+
+The jobs reuse the existing `database-credentials` Secret managed by External
+Secrets Operator. They do not introduce another Kubernetes Secret.
+
+## Backup layout and retention
+
+Each database writes timestamped objects under its configured GCS path:
+
+```text
+gs://<bucket>/mongodb/daily/backup-YYYYMMDD-HHMMSS.archive.gz
+gs://<bucket>/mongodb/weekly/backup-YYYYMMDD-HHMMSS.archive.gz
+gs://<bucket>/postgresql/daily/backup-YYYYMMDD-HHMMSS.sql.gz
+gs://<bucket>/postgresql/weekly/backup-YYYYMMDD-HHMMSS.sql.gz
+```
+
+Every successful run keeps the newest seven daily objects. A Sunday run also
+copies that run's daily object into `weekly/` and keeps the newest four weekly
+objects. Retention is enforced independently for MongoDB and PostgreSQL.
+
+## One-time GCP setup
+
+Choose the project, bucket, cluster namespace, and service account. The bucket
+name must be globally unique.
+
+```bash
+export GCP_PROJECT="<gcp-project>"
+export BACKUP_BUCKET="<globally-unique-backup-bucket>"
+export GSA_NAME="commonly-backup-sa"
+export GSA_EMAIL="${GSA_NAME}@${GCP_PROJECT}.iam.gserviceaccount.com"
+export K8S_NAMESPACE="commonly-dev"
+```
+
+Create a uniform-access bucket:
+
+```bash
+gcloud storage buckets create "gs://${BACKUP_BUCKET}" \
+  --project="${GCP_PROJECT}" \
+  --location=us-central1 \
+  --uniform-bucket-level-access
+```
+
+Create the Google service account and grant bucket-scoped object management.
+`roles/storage.objectAdmin` is required because the jobs upload, list, copy,
+and delete objects during retention pruning.
+
+```bash
+gcloud iam service-accounts create "${GSA_NAME}" \
+  --project="${GCP_PROJECT}" \
+  --display-name="Commonly database backups"
+
+gcloud storage buckets add-iam-policy-binding "gs://${BACKUP_BUCKET}" \
+  --member="serviceAccount:${GSA_EMAIL}" \
+  --role="roles/storage.objectAdmin"
+```
+
+Bind the Kubernetes `backup-sa` ServiceAccount to the Google service account
+through GKE Workload Identity:
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding "${GSA_EMAIL}" \
+  --project="${GCP_PROJECT}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="serviceAccount:${GCP_PROJECT}.svc.id.goog[${K8S_NAMESPACE}/backup-sa]"
+```
+
+Confirm that Workload Identity is enabled on the target GKE cluster before
+continuing. No service-account key file is needed or expected.
+
+## Configure and enable in order
+
+Keep real bucket and service-account values in the operator-only
+`.dev/values-private.yaml` file:
+
+```yaml
+backup:
+  gcpServiceAccount: commonly-backup-sa@<gcp-project>.iam.gserviceaccount.com
+  mongodb:
+    gcs:
+      bucket: <globally-unique-backup-bucket>
+  postgresql:
+    gcs:
+      bucket: <globally-unique-backup-bucket>
+```
+
+Before enabling either job, verify the rendered resources with temporary
+command-line overrides:
+
+```bash
+helm template commonly-dev k8s/helm/commonly \
+  -f k8s/helm/commonly/values.yaml \
+  -f k8s/helm/commonly/values-dev.yaml \
+  -f .dev/values-private.yaml \
+  --set backup.mongodb.enabled=true \
+  --set backup.postgresql.enabled=true \
+  --show-only templates/backup/backup-sa.yaml \
+  --show-only templates/backup/mongodb-backup-cronjob.yaml \
+  --show-only templates/backup/postgres-backup-cronjob.yaml
+```
+
+Only after the bucket, storage role, Workload Identity binding, and render are
+verified, add the enablement flags to `.dev/values-private.yaml`:
+
+```yaml
+backup:
+  mongodb:
+    enabled: true
+  postgresql:
+    enabled: true
+```
+
+Deploy through the normal `Deploy Dev` workflow. Both committed values files
+keep backup enablement `false`; the operator-private overlay is the only place
+that flips the flags.
+
+Verify the CronJobs and their on-demand scheduling constraints:
+
+```bash
+kubectl get cronjob mongodb-backup postgres-backup -n "${K8S_NAMESPACE}"
+kubectl get serviceaccount backup-sa -n "${K8S_NAMESPACE}" \
+  -o jsonpath='{.metadata.annotations.iam\.gke\.io/gcp-service-account}{"\n"}'
+kubectl get cronjob mongodb-backup -n "${K8S_NAMESPACE}" \
+  -o jsonpath='{.spec.jobTemplate.spec.template.spec.nodeSelector}{"\n"}'
+kubectl get cronjob mongodb-backup -n "${K8S_NAMESPACE}" \
+  -o jsonpath='{.spec.jobTemplate.spec.template.spec.tolerations}{"\n"}'
+```
+
+The dev jobs must select `pool: dev` and tolerate only
+`pool=dev:NoSchedule`. They must not tolerate the spot pool: ADR-015 permits
+spot preemption with 30 seconds' notice, which can terminate a dump before a
+usable artifact exists.
+
+## Manual backup drill
+
+Create one-off Jobs from the deployed CronJobs:
+
+```bash
+MONGO_JOB="mongodb-backup-$(date +%Y%m%d%H%M%S)"
+kubectl create job --from=cronjob/mongodb-backup "${MONGO_JOB}" \
+  -n "${K8S_NAMESPACE}"
+kubectl wait --for=condition=complete --timeout=3600s \
+  "job/${MONGO_JOB}" -n "${K8S_NAMESPACE}"
+kubectl logs "job/${MONGO_JOB}" -n "${K8S_NAMESPACE}" -c mongodb-dump
+kubectl logs "job/${MONGO_JOB}" -n "${K8S_NAMESPACE}" -c backup-uploader
+
+POSTGRES_JOB="postgres-backup-$(date +%Y%m%d%H%M%S)"
+kubectl create job --from=cronjob/postgres-backup "${POSTGRES_JOB}" \
+  -n "${K8S_NAMESPACE}"
+kubectl wait --for=condition=complete --timeout=3600s \
+  "job/${POSTGRES_JOB}" -n "${K8S_NAMESPACE}"
+kubectl logs "job/${POSTGRES_JOB}" -n "${K8S_NAMESPACE}" -c postgresql-dump
+kubectl logs "job/${POSTGRES_JOB}" -n "${K8S_NAMESPACE}" -c backup-uploader
+```
+
+Confirm that both new daily objects are non-empty:
+
+```bash
+gsutil ls -l "gs://${BACKUP_BUCKET}/mongodb/daily/"
+gsutil ls -l "gs://${BACKUP_BUCKET}/postgresql/daily/"
+```
+
+## Restore drill
+
+Always restore into isolated databases first. The MongoDB command uses
+`--drop`, and PostgreSQL plain SQL should be loaded into an empty target
+database. Do not point either command at the live databases until the chosen
+backup has passed the isolated restore and verification steps.
+
+Download the selected objects:
+
+```bash
+gsutil cp \
+  "gs://${BACKUP_BUCKET}/mongodb/daily/backup-<timestamp>.archive.gz" \
+  /tmp/mongodb-backup.archive.gz
+gsutil cp \
+  "gs://${BACKUP_BUCKET}/postgresql/daily/backup-<timestamp>.sql.gz" \
+  /tmp/postgresql-backup.sql.gz
+```
+
+### MongoDB
+
+Start a temporary client pod from the same MongoDB image configured in Helm,
+copy the archive into it, and point the restore URI at an isolated database:
+
+```bash
+export MONGO_IMAGE="mongo:latest"
+kubectl run mongodb-restore -n "${K8S_NAMESPACE}" \
+  --image="${MONGO_IMAGE}" --restart=Never --command -- sleep 3600
+kubectl wait --for=condition=Ready --timeout=120s \
+  pod/mongodb-restore -n "${K8S_NAMESPACE}"
+kubectl cp /tmp/mongodb-backup.archive.gz \
+  "${K8S_NAMESPACE}/mongodb-restore:/tmp/backup.archive.gz"
+
+export MONGO_RESTORE_URI="<isolated-mongodb-uri-ending-in/commonly_restore>"
+kubectl exec mongodb-restore -n "${K8S_NAMESPACE}" -- \
+  env MONGO_URI="${MONGO_RESTORE_URI}" bash -c \
+  'mongorestore --uri="$MONGO_URI" --archive=/tmp/backup.archive.gz --gzip --drop'
+```
+
+Inspect the restored collections, then delete the client pod:
+
+```bash
+kubectl exec mongodb-restore -n "${K8S_NAMESPACE}" -- \
+  mongosh "${MONGO_RESTORE_URI}" --quiet \
+  --eval 'db.getCollectionNames().sort()'
+unset MONGO_RESTORE_URI
+kubectl delete pod mongodb-restore -n "${K8S_NAMESPACE}"
+```
+
+### PostgreSQL
+
+Start a temporary PostgreSQL client pod, copy the SQL archive, and load it into
+an empty isolated database:
+
+```bash
+export POSTGRES_IMAGE="postgres:15"
+export PG_RESTORE_HOST="postgres.${K8S_NAMESPACE}.svc.cluster.local"
+export PG_RESTORE_USER="postgres"
+export PG_RESTORE_DATABASE="commonly_restore"
+
+kubectl run postgresql-restore -n "${K8S_NAMESPACE}" \
+  --image="${POSTGRES_IMAGE}" --restart=Never --command -- sleep 3600
+kubectl wait --for=condition=Ready --timeout=120s \
+  pod/postgresql-restore -n "${K8S_NAMESPACE}"
+kubectl cp /tmp/postgresql-backup.sql.gz \
+  "${K8S_NAMESPACE}/postgresql-restore:/tmp/backup.sql.gz"
+
+PGPASSWORD="$(kubectl get secret database-credentials \
+  -n "${K8S_NAMESPACE}" -o jsonpath='{.data.postgres-password}' | base64 --decode)"
+kubectl exec postgresql-restore -n "${K8S_NAMESPACE}" -- \
+  env PGPASSWORD="${PGPASSWORD}" \
+  createdb -h "${PG_RESTORE_HOST}" -U "${PG_RESTORE_USER}" \
+  "${PG_RESTORE_DATABASE}"
+kubectl exec postgresql-restore -n "${K8S_NAMESPACE}" -- \
+  env PGPASSWORD="${PGPASSWORD}" \
+  PG_HOST="${PG_RESTORE_HOST}" \
+  PG_USER="${PG_RESTORE_USER}" \
+  PG_DATABASE="${PG_RESTORE_DATABASE}" \
+  bash -c \
+  'set -euo pipefail; gunzip -c /tmp/backup.sql.gz | psql -v ON_ERROR_STOP=1 -h "$PG_HOST" -U "$PG_USER" -d "$PG_DATABASE"'
+```
+
+Inspect the restored schema and representative row counts, then remove the
+client pod:
+
+```bash
+kubectl exec postgresql-restore -n "${K8S_NAMESPACE}" -- \
+  env PGPASSWORD="${PGPASSWORD}" \
+  psql -h "${PG_RESTORE_HOST}" -U "${PG_RESTORE_USER}" \
+  -d "${PG_RESTORE_DATABASE}" -c '\\dt'
+unset PGPASSWORD
+kubectl delete pod postgresql-restore -n "${K8S_NAMESPACE}"
+```
+
+## Verification checklist
+
+For every backup drill:
+
+1. The Job reaches `Complete` before its one-hour deadline.
+2. The dump initContainer and `backup-uploader` both exit with code 0.
+3. The new GCS object has a non-zero size and the expected timestamped name.
+4. Daily object count is at most seven; after a Sunday run, weekly count is at
+   most four.
+5. An isolated MongoDB restore exposes the expected collections and sample
+   documents.
+6. An isolated PostgreSQL restore exposes the expected tables and
+   representative row counts.
+7. Application smoke checks against restored databases can read users, pods,
+   and recent messages before any production recovery is attempted.

--- a/docs/runbooks/db-backup-restore.md
+++ b/docs/runbooks/db-backup-restore.md
@@ -188,7 +188,9 @@ Start a temporary client pod from the same MongoDB image configured in Helm,
 copy the archive into it, and point the restore URI at an isolated database:
 
 ```bash
-export MONGO_IMAGE="mongo:latest"
+export MONGO_IMAGE="$(kubectl get cronjob mongodb-backup \
+  -n "${K8S_NAMESPACE}" \
+  -o jsonpath='{.spec.jobTemplate.spec.template.spec.initContainers[?(@.name=="mongodb-dump")].image}')"
 kubectl run mongodb-restore -n "${K8S_NAMESPACE}" \
   --image="${MONGO_IMAGE}" --restart=Never --command -- sleep 3600
 kubectl wait --for=condition=Ready --timeout=120s \
@@ -196,11 +198,39 @@ kubectl wait --for=condition=Ready --timeout=120s \
 kubectl cp /tmp/mongodb-backup.archive.gz \
   "${K8S_NAMESPACE}/mongodb-restore:/tmp/backup.archive.gz"
 
+MONGO_SOURCE_URI="$(kubectl get secret database-credentials \
+  -n "${K8S_NAMESPACE}" -o jsonpath='{.data.mongo-uri}' | base64 --decode)"
+MONGO_SOURCE_DB="${MONGO_SOURCE_URI%%\?*}"
+MONGO_SOURCE_DB="${MONGO_SOURCE_DB##*/}"
+unset MONGO_SOURCE_URI
+if [[ ! "${MONGO_SOURCE_DB}" =~ ^[A-Za-z0-9_-]+$ ]]; then
+  echo "Could not derive a safe source database name from mongo-uri" >&2
+  exit 1
+fi
+export MONGO_SOURCE_DB
+export MONGO_RESTORE_DB="commonly_restore"
 export MONGO_RESTORE_URI="<isolated-mongodb-uri-ending-in/commonly_restore>"
 kubectl exec mongodb-restore -n "${K8S_NAMESPACE}" -- \
-  env MONGO_URI="${MONGO_RESTORE_URI}" bash -c \
-  'mongorestore --uri="$MONGO_URI" --archive=/tmp/backup.archive.gz --gzip --drop'
+  env MONGO_URI="${MONGO_RESTORE_URI}" \
+  MONGO_SOURCE_DB="${MONGO_SOURCE_DB}" \
+  MONGO_RESTORE_DB="${MONGO_RESTORE_DB}" \
+  bash -c '
+    mongorestore \
+      --uri="$MONGO_URI" \
+      --archive=/tmp/backup.archive.gz \
+      --gzip \
+      --drop \
+      --nsInclude="${MONGO_SOURCE_DB}.*" \
+      --nsFrom="${MONGO_SOURCE_DB}.*" \
+      --nsTo="${MONGO_RESTORE_DB}.*"
+  '
 ```
+
+**Load-bearing safety warning:** an archive records its original namespaces,
+and `mongorestore --archive` ignores the database path in `--uri`. The
+`--nsInclude` / `--nsFrom` / `--nsTo` mapping above is mandatory. Removing it
+would make `--drop` target the live source database when the restore host is
+the in-cluster MongoDB.
 
 Inspect the restored collections, then delete the client pod:
 
@@ -208,7 +238,7 @@ Inspect the restored collections, then delete the client pod:
 kubectl exec mongodb-restore -n "${K8S_NAMESPACE}" -- \
   mongosh "${MONGO_RESTORE_URI}" --quiet \
   --eval 'db.getCollectionNames().sort()'
-unset MONGO_RESTORE_URI
+unset MONGO_RESTORE_URI MONGO_RESTORE_DB MONGO_SOURCE_DB MONGO_IMAGE
 kubectl delete pod mongodb-restore -n "${K8S_NAMESPACE}"
 ```
 
@@ -218,9 +248,13 @@ Start a temporary PostgreSQL client pod, copy the SQL archive, and load it into
 an empty isolated database:
 
 ```bash
-export POSTGRES_IMAGE="postgres:15"
+export POSTGRES_IMAGE="$(kubectl get cronjob postgres-backup \
+  -n "${K8S_NAMESPACE}" \
+  -o jsonpath='{.spec.jobTemplate.spec.template.spec.initContainers[?(@.name=="postgresql-dump")].image}')"
 export PG_RESTORE_HOST="postgres.${K8S_NAMESPACE}.svc.cluster.local"
-export PG_RESTORE_USER="postgres"
+export PG_RESTORE_USER="$(kubectl get cronjob postgres-backup \
+  -n "${K8S_NAMESPACE}" \
+  -o jsonpath='{.spec.jobTemplate.spec.template.spec.initContainers[?(@.name=="postgresql-dump")].env[?(@.name=="PG_USER")].value}')"
 export PG_RESTORE_DATABASE="commonly_restore"
 
 kubectl run postgresql-restore -n "${K8S_NAMESPACE}" \

--- a/k8s/helm/commonly/templates/backup/backup-sa.yaml
+++ b/k8s/helm/commonly/templates/backup/backup-sa.yaml
@@ -8,7 +8,8 @@ metadata:
   labels:
     {{- include "commonly.labels" . | nindent 4 }}
     component: backup
+  {{- with .Values.backup.gcpServiceAccount }}
   annotations:
-    # Workload Identity annotation for GCS access
-    iam.gke.io/gcp-service-account: commonly-backup-sa@PROJECT_ID.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: {{ . | quote }}
+  {{- end }}
 {{- end }}

--- a/k8s/helm/commonly/templates/backup/mongodb-backup-cronjob.yaml
+++ b/k8s/helm/commonly/templates/backup/mongodb-backup-cronjob.yaml
@@ -10,10 +10,14 @@ metadata:
     database: mongodb
 spec:
   schedule: {{ .Values.backup.mongodb.schedule | quote }}
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 600
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 3600
       template:
         metadata:
           labels:
@@ -23,32 +27,28 @@ spec:
         spec:
           serviceAccountName: backup-sa
           restartPolicy: OnFailure
-          containers:
-          - name: mongodb-backup
-            image: mongo:latest
+          initContainers:
+          - name: mongodb-dump
+            image: "{{ .Values.mongodb.image.repository }}:{{ .Values.mongodb.image.tag }}"
+            imagePullPolicy: {{ .Values.mongodb.image.pullPolicy }}
             command:
             - /bin/bash
             - -c
             - |
-              set -e
-              BACKUP_FILE="/tmp/backup-$(date +%Y%m%d-%H%M%S).archive.gz"
+              set -euo pipefail
+              BACKUP_FILE="/backup/backup.archive.gz"
               echo "Starting MongoDB backup to $BACKUP_FILE"
-
               mongodump --uri="$MONGO_URI" --archive="$BACKUP_FILE" --gzip
-
-              GCS_PATH="gs://{{ .Values.backup.mongodb.gcs.bucket }}/{{ .Values.backup.mongodb.gcs.path }}/backup-$(date +%Y%m%d-%H%M%S).archive.gz"
-              echo "Uploading to $GCS_PATH"
-
-              gsutil cp "$BACKUP_FILE" "$GCS_PATH"
-
-              echo "Backup completed successfully"
-              rm "$BACKUP_FILE"
+              echo "MongoDB dump completed"
             env:
             - name: MONGO_URI
               valueFrom:
                 secretKeyRef:
                   name: database-credentials
                   key: mongo-uri
+            volumeMounts:
+            - name: backup-data
+              mountPath: /backup
             resources:
               requests:
                 memory: "256Mi"
@@ -56,4 +56,71 @@ spec:
               limits:
                 memory: "1Gi"
                 cpu: "500m"
+          containers:
+          - name: backup-uploader
+            image: gcr.io/google.com/cloudsdktool/google-cloud-cli:slim
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+
+              prune_backups() {
+                local prefix="$1"
+                local keep="$2"
+                local backups
+                local stale
+
+                backups="$(gsutil ls "${prefix}/backup-*" 2>/dev/null || true)"
+                if [ -z "$backups" ]; then
+                  return
+                fi
+
+                stale="$(printf '%s\n' "$backups" | sort | head -n "-${keep}")"
+                if [ -n "$stale" ]; then
+                  printf '%s\n' "$stale" | gsutil -m rm -I
+                fi
+              }
+
+              BACKUP_FILE="/backup/backup.archive.gz"
+              TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
+              GCS_BASE="gs://{{ .Values.backup.mongodb.gcs.bucket }}/{{ .Values.backup.mongodb.gcs.path }}"
+              DAILY_PREFIX="${GCS_BASE}/daily"
+              DAILY_OBJECT="${DAILY_PREFIX}/backup-${TIMESTAMP}.archive.gz"
+
+              echo "Uploading MongoDB backup to $DAILY_OBJECT"
+              gsutil cp "$BACKUP_FILE" "$DAILY_OBJECT"
+              prune_backups "$DAILY_PREFIX" 7
+
+              if [ "$(date +%u)" = "7" ]; then
+                WEEKLY_PREFIX="${GCS_BASE}/weekly"
+                WEEKLY_OBJECT="${WEEKLY_PREFIX}/backup-${TIMESTAMP}.archive.gz"
+                gsutil cp "$DAILY_OBJECT" "$WEEKLY_OBJECT"
+                prune_backups "$WEEKLY_PREFIX" 4
+              fi
+
+              echo "MongoDB backup completed successfully"
+              rm -f "$BACKUP_FILE"
+            volumeMounts:
+            - name: backup-data
+              mountPath: /backup
+            resources:
+              requests:
+                memory: "256Mi"
+                cpu: "100m"
+              limits:
+                memory: "1Gi"
+                cpu: "500m"
+          {{- if and .Values.backup.nodeSelector (gt (len .Values.backup.nodeSelector) 0) }}
+          nodeSelector:
+            {{- toYaml .Values.backup.nodeSelector | nindent 12 }}
+          {{- end }}
+          {{- if and .Values.backup.tolerations (gt (len .Values.backup.tolerations) 0) }}
+          tolerations:
+            {{- toYaml .Values.backup.tolerations | nindent 12 }}
+          {{- end }}
+          volumes:
+          - name: backup-data
+            emptyDir: {}
 {{- end }}

--- a/k8s/helm/commonly/templates/backup/postgres-backup-cronjob.yaml
+++ b/k8s/helm/commonly/templates/backup/postgres-backup-cronjob.yaml
@@ -10,10 +10,14 @@ metadata:
     database: postgresql
 spec:
   schedule: {{ .Values.backup.postgresql.schedule | quote }}
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 600
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 3600
       template:
         metadata:
           labels:
@@ -23,26 +27,19 @@ spec:
         spec:
           serviceAccountName: backup-sa
           restartPolicy: OnFailure
-          containers:
-          - name: postgres-backup
-            image: postgres:15
+          initContainers:
+          - name: postgresql-dump
+            image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+            imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
             command:
             - /bin/bash
             - -c
             - |
-              set -e
-              BACKUP_FILE="/tmp/backup-$(date +%Y%m%d-%H%M%S).sql.gz"
+              set -euo pipefail
+              BACKUP_FILE="/backup/backup.sql.gz"
               echo "Starting PostgreSQL backup to $BACKUP_FILE"
-
               pg_dump -h "$PG_HOST" -U "$PG_USER" -d "$PG_DATABASE" | gzip > "$BACKUP_FILE"
-
-              GCS_PATH="gs://{{ .Values.backup.postgresql.gcs.bucket }}/{{ .Values.backup.postgresql.gcs.path }}/backup-$(date +%Y%m%d-%H%M%S).sql.gz"
-              echo "Uploading to $GCS_PATH"
-
-              gsutil cp "$BACKUP_FILE" "$GCS_PATH"
-
-              echo "Backup completed successfully"
-              rm "$BACKUP_FILE"
+              echo "PostgreSQL dump completed"
             env:
             - name: PG_HOST
               value: postgres.{{ include "commonly.namespace" . }}.svc.cluster.local
@@ -55,6 +52,9 @@ spec:
                 secretKeyRef:
                   name: database-credentials
                   key: postgres-password
+            volumeMounts:
+            - name: backup-data
+              mountPath: /backup
             resources:
               requests:
                 memory: "256Mi"
@@ -62,4 +62,71 @@ spec:
               limits:
                 memory: "1Gi"
                 cpu: "500m"
+          containers:
+          - name: backup-uploader
+            image: gcr.io/google.com/cloudsdktool/google-cloud-cli:slim
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+
+              prune_backups() {
+                local prefix="$1"
+                local keep="$2"
+                local backups
+                local stale
+
+                backups="$(gsutil ls "${prefix}/backup-*" 2>/dev/null || true)"
+                if [ -z "$backups" ]; then
+                  return
+                fi
+
+                stale="$(printf '%s\n' "$backups" | sort | head -n "-${keep}")"
+                if [ -n "$stale" ]; then
+                  printf '%s\n' "$stale" | gsutil -m rm -I
+                fi
+              }
+
+              BACKUP_FILE="/backup/backup.sql.gz"
+              TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
+              GCS_BASE="gs://{{ .Values.backup.postgresql.gcs.bucket }}/{{ .Values.backup.postgresql.gcs.path }}"
+              DAILY_PREFIX="${GCS_BASE}/daily"
+              DAILY_OBJECT="${DAILY_PREFIX}/backup-${TIMESTAMP}.sql.gz"
+
+              echo "Uploading PostgreSQL backup to $DAILY_OBJECT"
+              gsutil cp "$BACKUP_FILE" "$DAILY_OBJECT"
+              prune_backups "$DAILY_PREFIX" 7
+
+              if [ "$(date +%u)" = "7" ]; then
+                WEEKLY_PREFIX="${GCS_BASE}/weekly"
+                WEEKLY_OBJECT="${WEEKLY_PREFIX}/backup-${TIMESTAMP}.sql.gz"
+                gsutil cp "$DAILY_OBJECT" "$WEEKLY_OBJECT"
+                prune_backups "$WEEKLY_PREFIX" 4
+              fi
+
+              echo "PostgreSQL backup completed successfully"
+              rm -f "$BACKUP_FILE"
+            volumeMounts:
+            - name: backup-data
+              mountPath: /backup
+            resources:
+              requests:
+                memory: "256Mi"
+                cpu: "100m"
+              limits:
+                memory: "1Gi"
+                cpu: "500m"
+          {{- if and .Values.backup.nodeSelector (gt (len .Values.backup.nodeSelector) 0) }}
+          nodeSelector:
+            {{- toYaml .Values.backup.nodeSelector | nindent 12 }}
+          {{- end }}
+          {{- if and .Values.backup.tolerations (gt (len .Values.backup.tolerations) 0) }}
+          tolerations:
+            {{- toYaml .Values.backup.tolerations | nindent 12 }}
+          {{- end }}
+          volumes:
+          - name: backup-data
+            emptyDir: {}
 {{- end }}

--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -284,7 +284,16 @@ litellm:
       effect: "NoSchedule"
 
 backup:
+  # ADR-015: database dumps must stay on the on-demand pool; spot
+  # preemption can terminate a backup mid-dump and leave no usable artifact.
+  nodeSelector:
+    pool: dev
+  tolerations:
+    - key: "pool"
+      operator: "Equal"
+      value: "dev"
+      effect: "NoSchedule"
   mongodb:
-    enabled: false  # Enable after Phase 3
+    enabled: false  # Operator-private flag; enable only after bucket + WI setup.
   postgresql:
-    enabled: false  # Enable after Phase 3
+    enabled: false  # Operator-private flag; enable only after bucket + WI setup.

--- a/k8s/helm/commonly/values.yaml
+++ b/k8s/helm/commonly/values.yaml
@@ -422,15 +422,18 @@ litellm:
 
 # Backup configuration
 backup:
+  gcpServiceAccount: ""
+  nodeSelector: {}
+  tolerations: []
   mongodb:
     enabled: false
     schedule: "0 2 * * *"
     gcs:
-      bucket: commonly-dev-backups
+      bucket: ""
       path: mongodb
   postgresql:
     enabled: false
     schedule: "0 2 * * *"
     gcs:
-      bucket: commonly-dev-backups
+      bucket: ""
       path: postgresql


### PR DESCRIPTION
## Summary

- split each database backup CronJob into a values-pinned dump initContainer and a Cloud SDK uploader sharing an emptyDir
- upload timestamped daily backups, retain 7 daily copies, and create/retain 4 Sunday weekly copies
- add CronJob overlap/deadline limits and pin dev backups to the on-demand dev pool per ADR-015
- replace the hardcoded Workload Identity placeholder with an operator-supplied service-account email
- keep backup flags, bucket names, and service-account defaults inert in committed values
- add the complete GCP setup, manual backup, restore, retention, and verification runbook

## Root cause

The dormant backup jobs used database images that do not contain gsutil, so their first upload would fail. They also hardcoded a project placeholder, had no retention policy, and could schedule without protection from overlap or spot preemption.

## Validation

- full enabled Helm render: 38 resources valid, 0 invalid via strict kubeconform
- Helm lint: 1 chart linted, 0 failures
- embedded CronJob scripts: 4/4 passed bash -n
- runbook shell blocks: 13/13 passed bash -n
- rendered backup assertions: values-pinned mongo/postgres dump images, Cloud SDK slim uploader, dev-pool selector/toleration, no spot toleration, correct deadlines, and no PROJECT_ID placeholder
- committed defaults assertion: MongoDB/PostgreSQL backup flags remain false; bucket and GSA defaults remain empty
- git diff check: passed
- GitHub CI: all checks passed, including Test & Coverage, Tier 1 real-DB service tests, kind-cluster smoke, chart lint, CodeQL, secret scan, and stale-base guard

This is the repository half of #665. Bucket creation, IAM/Workload Identity binding, operator-private values, and enablement remain intentionally post-merge operations.