### PR TITLE
ops(dev): pin backend to dev-pool, off spot (closes #678)

### DIFF
--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -18,15 +18,18 @@ backend:
     repository: gcr.io/YOUR_GCP_PROJECT_ID/commonly-backend
     tag: "20260417214615-r4"
     pullPolicy: Always  # Always pull in dev
-  # ADR-015: backend is stateless and tolerates a 30s reschedule on spot
-  # reclaim — socket.io reconnects automatically, mid-flight HTTP gets one
-  # 502. Keeps the larger always-on cost off the dev cluster.
+  # ADR-015 amendment (2026-07-12): the backend serves the user-facing API and
+  # is the one workload a spot reclamation must never interrupt. It requests
+  # only 200m/512Mi and fits in existing dev-pool headroom, so pinning it to the
+  # on-demand pool closes the abrupt-reclamation gap for ~$0 (cheaper than a 2nd
+  # replica, which would also stay on spot). Spot stays for restartable/batch
+  # workloads (agents, LiteLLM); the user-facing API + Redis belong on dev-pool.
   nodeSelector:
-    workload-tier: spot
+    pool: dev
   tolerations:
-    - key: "workload-tier"
+    - key: "pool"
       operator: "Equal"
-      value: "spot"
+      value: "dev"
       effect: "NoSchedule"
   env:
     nodeEnv: development


### PR DESCRIPTION
Last piece of "routine cluster events never cause user-visible downtime," and the cheap alternative to replicas=2 (which Sam correctly flagged as expensive).

**What:** backend Deployment gets `pool: dev` nodeSelector + `pool=dev:NoSchedule` toleration in values-dev — same shape Redis got in #676. `replicaCount` stays 1.

**Why ~$0:** backend requests only 200m CPU / 512Mi and the dev-pool node has ~1150m free, so it fits on hardware already paid for — no new node. Removes the user-facing API from preemptible hardware entirely, so an abrupt spot reclamation (the trigger for two 503s on 2026-07-12) can't touch it. Cheaper and simpler than a 2nd replica, which would stay on spot and need anti-affinity + a PDB to get the same resilience.

**Principle (ADR-015 amendment):** spot is right for restartable/batch workloads (agents, LiteLLM). The user-facing API and Redis belong on the stable pool. Redis moved in #676; this finishes the job.

Zero-downtime deployable thanks to #676's RollingUpdate. Verification after merge+deploy: confirm the backend pod lands on a dev-pool node and health stays 200 through the reschedule.

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9