### PR TITLE
fix(v2): SSO buttons no longer vanish on a transient providers-fetch blip

### DIFF
--- a/frontend/src/v2/__tests__/V2OAuth.test.tsx
+++ b/frontend/src/v2/__tests__/V2OAuth.test.tsx
@@ -74,6 +74,40 @@ describe('V2OAuthButtons', () => {
     await waitFor(() => expect(axios.get).toHaveBeenCalledWith('/api/auth/oauth/providers'));
     expect(container).toBeEmptyDOMElement();
   });
+
+  test('falls back to cached providers when the fetch fails (no blank SSO on a blip)', async () => {
+    // Prior successful load cached the providers; this mount's fetch fails.
+    localStorage.setItem('v2:oauth-providers', JSON.stringify([{ id: 'github', label: 'GitHub' }]));
+    axios.get.mockRejectedValueOnce(new Error('network blip'));
+
+    render(
+      <MemoryRouter>
+        <V2OAuthButtons />
+      </MemoryRouter>,
+    );
+
+    // The button shows immediately from cache and is NOT blanked by the failure.
+    expect(await screen.findByRole('link', { name: /continue with github/i })).toBeInTheDocument();
+  });
+
+  test('retries a transient failure and shows buttons once it recovers', async () => {
+    localStorage.clear();
+    axios.get
+      .mockRejectedValueOnce(new Error('blip'))
+      .mockResolvedValue({ data: { providers: [{ id: 'google', label: 'Google' }] } });
+
+    render(
+      <MemoryRouter>
+        <V2OAuthButtons />
+      </MemoryRouter>,
+    );
+
+    // First attempt fails (no cache → nothing yet); the backoff retry (~800ms)
+    // succeeds. Allow headroom for the backoff delay.
+    expect(await screen.findByRole('link', { name: /continue with google/i }, { timeout: 3000 }))
+      .toBeInTheDocument();
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('V2OAuthComplete', () => {

--- a/frontend/src/v2/components/V2OAuthButtons.tsx
+++ b/frontend/src/v2/components/V2OAuthButtons.tsx
@@ -37,17 +37,46 @@ const PROVIDER_ICONS: Record<string, React.ReactNode> = {
   ),
 };
 
+// Last-known-good cache. The providers list is effectively static config
+// (which OAuth apps the instance has), so a stale value is safe and far better
+// than a blank login: a single failed /providers fetch used to set [] and
+// hide the buttons with no retry, so any transient (a deploy blip, a spot
+// reclaim, the user's own wifi) blanked SSO until a manual reload.
+const OAUTH_CACHE_KEY = 'v2:oauth-providers';
+const readProviderCache = (): OAuthProvider[] => {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(OAUTH_CACHE_KEY) || 'null');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch { return []; }
+};
+
 const V2OAuthButtons: React.FC<V2OAuthButtonsProps> = ({ invite, next }) => {
-  const [providers, setProviders] = useState<OAuthProvider[]>([]);
+  // Seed from cache so repeat visitors see the buttons instantly; the fetch
+  // below reconciles. A *successful* empty response (self-hosted w/o OAuth)
+  // correctly clears; only network failures fall back to the cached value.
+  const [providers, setProviders] = useState<OAuthProvider[]>(readProviderCache);
 
   useEffect(() => {
     let active = true;
-    axios.get('/api/auth/oauth/providers')
-      .then((res) => {
-        if (active) setProviders(Array.isArray(res.data?.providers) ? res.data.providers : []);
-      })
-      .catch(() => { if (active) setProviders([]); });
-    return () => { active = false; };
+    let attempt = 0;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    const load = () => {
+      if (!active) return;
+      axios.get('/api/auth/oauth/providers')
+        .then((res) => {
+          if (!active) return;
+          const list = Array.isArray(res.data?.providers) ? res.data.providers : [];
+          setProviders(list);
+          try { localStorage.setItem(OAUTH_CACHE_KEY, JSON.stringify(list)); } catch { /* private mode */ }
+        })
+        .catch(() => {
+          // Transient failure: keep last-known-good (already in state), retry a
+          // few times with backoff. Never blank the buttons on a network blip.
+          if (active && attempt < 3) { attempt += 1; retryTimer = setTimeout(load, 800 * attempt); }
+        });
+    };
+    load();
+    return () => { active = false; if (retryTimer) clearTimeout(retryTimer); };
   }, []);
 
   if (!providers.length) return null;


### PR DESCRIPTION
**Root cause** of the recurring "I can't see the SSO option, sometimes after a while I can" reports. `V2OAuthButtons` did:

```js
axios.get('/api/auth/oauth/providers')
  .then(res => setProviders(res.data?.providers ?? []))
  .catch(() => setProviders([]));   // ANY failure → empty
if (!providers.length) return null; // empty → nothing, no retry
```

So a single failed/slow fetch — a deploy blip, a spot reclaim, or the user's own network hiccup — set providers to empty and hid the buttons **with no retry**, until a manual reload ("after a while I can see it"). It turned every brief transient into a sticky, visible broken-login state, and it's specifically the SSO buttons because they're the only login element gated on a fragile fetch. (The underlying backend blips themselves are separately fixed by #676/#679; this is the frontend amplifier.)

**Fix:**
- Seed state from a `localStorage` last-known-good cache → repeat visitors see buttons instantly, and a transient failure falls back to the cached list instead of blanking.
- Retry the fetch 3× with backoff.
- Only clear on a **successful** empty response (genuine self-hosted-without-OAuth) — never on a network error.
- Cancel the pending retry timer on unmount (no stray request after navigating away).

**Tests:** added fall-back-to-cache-on-failure and retry-until-recovery; 6/6 in V2OAuth.test.tsx, 40/40 v2 suite green.

Zero-downtime deployable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9