### PR TITLE
fix(frontend): never browser-cache index.html (fixes post-deploy stale bundles)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -11,13 +11,25 @@ server {
         try_files $uri /index.html;
     }
 
+    # index.html must NEVER be browser-cached. It's the only file that names the
+    # current hashed bundles; if a browser serves a stale copy it loads an old
+    # (or now-404) bundle and the user is stranded on pre-deploy code until their
+    # cache expires. Vite emits a fresh index every build, so always revalidate.
+    # (Without this, index.html had no Cache-Control at all → heuristic caching.)
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        expires -1;
+    }
+
     # Error handling for 404
     error_page 404 /index.html;
 
-    # Static file caching (optional)
+    # Hashed static assets are content-addressed and immutable — a given URL's
+    # bytes never change, so cache hard and skip revalidation. A new build emits
+    # new filenames, which index.html (above) points at.
     location ~* \.(?:ico|css|js|gif|jpe?g|png|woff2?|eot|ttf|svg|mp4|webm|ogg|ogv|json)$ {
         expires 6M;
         access_log off;
-        add_header Cache-Control "public";
+        add_header Cache-Control "public, immutable";
     }
 }


### PR DESCRIPTION
**This is why shipped fixes keep appearing not to land for users** (e.g. the SSO-button fix #681 — verified live in a clean browser, but a user on a stale bundle still saw the old bug).

`index.html` was served by `location /` with **no `Cache-Control` header at all**. Per RFC 7234, a response with `Last-Modified` but no `Cache-Control` gets *heuristic caching* — the browser may serve a stale `index.html` without revalidating. Since index.html is the only file naming the current hashed bundles, a stale copy loads an **old (or now-404) JS bundle**, stranding the user on pre-deploy code until their browser cache happens to expire. This silently affected **every** deploy.

**Fix:**
- `location = /index.html` → `Cache-Control: no-cache, no-store, must-revalidate` + `expires -1`, so the entry point is always revalidated and picks up new bundle hashes immediately.
- Hashed assets → `public, immutable` (they're content-addressed; a given URL never changes), so they still cache hard with no revalidation cost.

`nginx -t` validated in an nginx:alpine container. Verification after deploy: `curl -I https://commonly.me/` shows `cache-control: no-cache…` on the HTML, assets still `immutable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9