### PR TITLE
fix(dev.sh): bash 3.2 uyumlu lowercase — macOS'ta './dev.sh up' bad substitution ile açılmıyor

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -53,7 +53,10 @@ read_env_value() {
 }
 
 is_truthy_env_value() {
-    local value="${1,,}"
+    # NOTE: ${1,,} is a bash 4+ expansion; macOS ships bash 3.2 as /bin/bash,
+    # where it fails at runtime with "bad substitution". tr keeps this portable.
+    local value
+    value="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
     case "$value" in
         1|true|yes|on)
             return 0


### PR DESCRIPTION
## Sorun
`is_truthy_env_value()` `${1,,}` (bash 4+ lowercase expansion) kullanıyor. **macOS'un `/bin/bash`'i hâlâ 3.2.57** (Apple lisans nedeniyle güncellemiyor) ve `dev.sh` shebang'i `#!/bin/bash`. Sonuç: temiz bir macOS'ta `./dev.sh up` runtime'da `${1,,}: bad substitution` verip çıkıyor, **backend hiç ayağa kalkmıyor**.

Yeni bir makinede kurulum sırasında yakalandı (parse temiz olduğu için sadece `up` yolunda, fonksiyon çağrılınca patlıyor — bu yüzden fark edilmemiş).

## Fix
Dosyadaki **tek** bash4-izm buydu (`grep` ile doğrulandı). `tr` ile taşınabilir hale getirildi.

`#!/usr/bin/env bash` **yeterli değil** — Homebrew bash'i olmayan makinede `env` yine 3.2'yi bulur. Bu fix stock macOS bash'te de çalışır, PATH/shebang'e bağımlı değil.

## Kanıt (bash 3.2.57)
```
eski:  ${1,,}  ->  bad substitution
yeni:  TRUE/true/YES/On/1 -> truthy · false/NO/0/boş -> falsy   (davranış korundu)
bash -n dev.sh -> parse OK
```