### PR TITLE
fix(agent-messages): sentinel temizliği girintiyi yok etmesin

### DIFF
--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -1498,9 +1498,27 @@ class AgentMessageService {
       // join two silent blocks into "NO_REPLYNO_REPLY", which has no word
       // boundary between the runs and sailed through \bNO_REPLY\b verbatim
       // into live pods (2026-07-03).
-      .map((line) => line.replace(/\b(?:NO_REPLY)+\b/g, '').trim())
-      .filter(Boolean)
+      //
+      // Only the sentinel is removed — indentation and blank lines are NOT.
+      // The old form was `.map(l => l.replace(...).trim()).filter(Boolean)`,
+      // which per-line-trimmed every message and dropped every empty line.
+      // That is sentinel cleanup with a whitespace bulldozer attached: Python
+      // sent through an agent lost its indentation (`    y = x + 1` arrived as
+      // `y = x + 1`), so a task with one missing `:` reached the agent as code
+      // that also raised IndentationError, and agent-authored code blocks came
+      // out flattened. Whitespace-sensitive payloads (Python, YAML, diffs,
+      // markdown nesting) are normal traffic in an agent pod — verified live
+      // 2026-07-16 by posting identical text through both paths: the user path
+      // (messageController) kept indentation, this one destroyed it.
+      .map((line) => {
+        const withoutSentinel = line.replace(/\b(?:NO_REPLY)+\b/g, '');
+        // A line that was ONLY a sentinel (plus padding) becomes blank rather
+        // than lingering as stray spaces; genuine content keeps its indent.
+        return withoutSentinel.trim() ? withoutSentinel : '';
+      })
       .join('\n')
+      // Leading/trailing blank lines are still cosmetic noise — but interior
+      // structure now survives.
       .trim();
 
     return cleaned;


### PR DESCRIPTION
## Sorun

`AgentMessageService.sanitizeAgentContent` her satıra `.trim()` uygulayıp `.filter(Boolean)` ile boş satırları atıyordu. Amaç `NO_REPLY` sentinel temizliğiydi; yan etkisi **agentların yazdığı her mesajın girintisini ve paragraf yapısını düzleştirmek**.

Bir agent pod'unda girintiye duyarlı içerik normal trafiktir: Python, YAML, diff, iç içe markdown.

## Etki (canlı gözlem, 2026-07-16)

Kullanıcı `@auto-router`'a tek hatası eksik `:` olan bir Python bloğu gönderdi. Agent'a ulaşan metinde girintiler silinmişti — yani agent, **ayrıca `IndentationError` üreten** bambaşka bir kod gördü. Router, çözülmesi istenen problemi bozuyordu. Agentların cevaplarındaki kod blokları da düzleşiyordu.

Aynı metin iki yoldan yazılıp karşılaştırıldı:

```
messageController (kullanıcı yolu):  'def f(x)' / '    y = x + 1'   girinti VAR
agent runtime (bu yol):              'def f(x)' / 'y = x + 1'       girinti YOK
```

## Değişiklik

Yalnız sentinel çıkarılır; satır içi girinti ve boş satırlar korunur. Yalnızca sentinel'dan ibaret satırlar boşa indirgenir (başıboş boşluk kalmasın), baş/son boş satırlar hâlâ kırpılır.

## Doğrulama

Backend restart sonrası, agent runtime endpoint'inden POST:

- girintili mesaj → girinti + boş satır **korunuyor** ✓
- `NO_REPLYNO_REPLY` → pod'da `NO_REPLY` izi yok ✓ (sentinel temizliği bozulmadı)

Not: birim testi (`agentMessageService.chatNoise.test.js`) bu ortamda çalıştırılamadı — `mongodb-memory-server` kurulum sırasında binary indirmeye çalışıyor, ağ kapalıydı. Doğrulama canlı uçtan uca yapıldı; test beklentileri değişmiyor (sentinel davranışı aynı).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
