### PR TITLE
fix(socket): kalıcı pes etme yerine sınırsız yeniden bağlanma + backoff

### DIFF
--- a/frontend/src/context/SocketContext.tsx
+++ b/frontend/src/context/SocketContext.tsx
@@ -69,8 +69,17 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
         auth: { token },
         transports: ['websocket', 'polling'],
         reconnection: true,
-        reconnectionAttempts: 5,
+        // Eskiden 5 denemeydi (1sn arayla): laptop uykusu / ağ blip'i / backend
+        // deploy'u gibi ~5 saniyeden uzun her kesintide socket.io KALICI olarak
+        // pes ediyordu. Sayfa açık kalıyor, REST ile yüklenmiş eski mesajlar
+        // duruyor, yeni hiçbir şey gelmiyor — kullanıcı bayat veriye bakıp
+        // "mesajım gitmedi mi?" diyor (canlı gözlendi 2026-07-16: sekme ~1 saat
+        // açık kaldıktan sonra sessizce ölü). Pod'u açık bırakıp agentları
+        // izlemek bu üründe beklenen kullanım; kalıcı pes etmek kabul edilemez.
+        reconnectionAttempts: Infinity,
         reconnectionDelay: 1000,
+        reconnectionDelayMax: 30000,
+        randomizationFactor: 0.5,
       });
 
       newSocket.on('connect', () => { setConnected(true); });
@@ -78,8 +87,25 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
       newSocket.on('disconnect', (reason: string) => { console.log('Socket disconnected, reason:', reason); setConnected(false); });
       newSocket.on('error', (error: unknown) => { console.error('Socket error:', error); setConnected(false); });
 
+      // Backoff 30sn'ye kadar çıkabildiği için, kullanıcı sekmeye döndüğünde ya
+      // da ağ geri geldiğinde bir sonraki denemeyi beklemek yerine hemen bağlan.
+      // io.disconnect() sonrası (sunucu tarafı kapatma) otomatik yeniden bağlanma
+      // devreye girmez — bu iki olay o durumun da tek kurtarma yoludur.
+      const reconnectNow = (): void => {
+        if (!newSocket.connected) newSocket.connect();
+      };
+      const onVisible = (): void => { if (document.visibilityState === 'visible') reconnectNow(); };
+      document.addEventListener('visibilitychange', onVisible);
+      window.addEventListener('online', reconnectNow);
+      window.addEventListener('focus', reconnectNow);
+
       setSocket(newSocket);
-      return () => { newSocket.disconnect(); };
+      return () => {
+        document.removeEventListener('visibilitychange', onVisible);
+        window.removeEventListener('online', reconnectNow);
+        window.removeEventListener('focus', reconnectNow);
+        newSocket.disconnect();
+      };
     }
   }, [token, currentUser?._id]); // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
## Sorun

`SocketContext.tsx` → `reconnectionAttempts: 5`. socket.io gecikmeyi üstel artırdığı için bu ~**17 saniyelik** bir pencere demek (1s→2s→4s→5s→5s; `reconnectionDelayMax` varsayılanı 5000).

Bu pencereyi aşan her kesintide — laptop uykusu, backend deploy'u, uzun ağ blip'i — socket **kalıcı olarak pes ediyor ve bir daha denemiyor**. Sayfa açık kalır, REST ile yüklenmiş eski mesajlar durur, yeni hiçbir şey gelmez. Kullanıcı sessizce bayat veriye bakar ve "mesajım gitmedi mi?" diye sorar; F5 "düzeltir".

Pod'u açık bırakıp agentları izlemek bu üründe beklenen kullanım — kalıcı pes etmek kabul edilemez. Canlıda gözlendi (2026-07-16): sekme ~1 saat açık kaldıktan sonra ölü.

## Ölçüm (A/B, aynı backend, iki istemci yan yana)

```
12sn kesinti  -> ESKİ(5): deneme #5'te toparladı      YENİ(∞): deneme #4'te toparladı
45sn kesinti  -> ESKİ(5): *** PES ETTİ — bir daha denemeyecek ***
                 YENİ(∞): *** YENİDEN BAĞLANDI (deneme #6) *** -> CONNECT
```

Kısa kesintide ikisi de toparlıyor; fark uzun kesintide ortaya çıkıyor.

Backend suçsuz: socket.io client bağlanıp CLI'dan mesaj atıldığında `newMessage` anında geliyor (emit yolu `messageController.ts:311`, `agentMessageService.ts:1426`, `server.ts:734` sağlam).

## Değişiklik

- `reconnectionAttempts: Infinity` + `reconnectionDelayMax: 30000` + jitter — sunucu dönene kadar dener, backoff ile sunucuyu dövmez
- `visibilitychange` / `online` / `focus` → hemen `connect()`: backoff 30sn'ye çıkabildiği için kullanıcı sekmeye döndüğünde bir sonraki denemeyi beklemesin. Sunucu taraflı kapatmada (`io.disconnect`) otomatik reconnect zaten devreye girmez — bu olaylar o durumun da tek kurtarma yolu
- Listener'lar cleanup'ta kaldırılıyor

## Doğrulama

`tsc --noEmit`: `SocketContext.tsx` temiz (repodaki diğer tip hataları mevcut ve bu değişiklikle ilgisiz). Vite HMR derledi, hata yok.

## Kalan (bu PR'da değil)

`connected` state'i UI'da gösterilmiyor — yalnız pod'a katılma mantığında kullanılıyor. Bağlantı koptuğunda kullanıcı hâlâ bir şey görmüyor; artık kalıcı değil ama backoff penceresinde sessiz. Bir gösterge tasarım kararı gerektiriyor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
