### PR TITLE
Fire a first-contact event after initial agent attach

### DIFF
--- a/backend/__tests__/service/two-way-integration-e2e.test.js
+++ b/backend/__tests__/service/two-way-integration-e2e.test.js
@@ -489,6 +489,7 @@ describe('Two-Way Integration E2E Tests', () => {
       const events = await AgentEvent.find({
         agentName: 'commonly-bot',
         podId: testPod._id,
+        type: 'integration.summary',
       });
 
       expect(events.length).toBe(1);
@@ -551,6 +552,7 @@ describe('Two-Way Integration E2E Tests', () => {
       const events = await AgentEvent.find({
         agentName: 'commonly-bot',
         podId: testPod._id,
+        type: 'discord.summary',
       });
 
       expect(events.length).toBe(1);
@@ -760,7 +762,10 @@ describe('Two-Way Integration E2E Tests', () => {
       await SchedulerService.summarizeIntegrationBuffers();
 
       // 5. Verify agent event created
-      const events = await AgentEvent.find({ agentName: 'commonly-bot' });
+      const events = await AgentEvent.find({
+        agentName: 'commonly-bot',
+        type: 'integration.summary',
+      });
       expect(events.length).toBe(1);
       expect(events[0].payload.summary.messageCount).toBe(3);
 
@@ -873,7 +878,10 @@ describe('Two-Way Integration E2E Tests', () => {
       await SchedulerService.summarizeIntegrationBuffers();
 
       // 5. Verify event created
-      const events = await AgentEvent.find({ agentName: 'commonly-bot' });
+      const events = await AgentEvent.find({
+        agentName: 'commonly-bot',
+        type: 'discord.summary',
+      });
       expect(events.length).toBe(1);
       expect(events[0].payload.source).toBe('discord');
 
@@ -1134,9 +1142,11 @@ describe('Two-Way Integration E2E Tests', () => {
           .set('Authorization', `Bearer ${clawdbotToken}`);
 
         expect(pollRes.status).toBe(200);
-        expect(pollRes.body.events.length).toBe(1);
-        expect(pollRes.body.events[0].type).toBe('integration.summary');
-        expect(pollRes.body.events[0].payload.source).toBe('groupme');
+        const summaryEvent = pollRes.body.events.find(
+          (event) => event.type === 'integration.summary',
+        );
+        expect(summaryEvent).toBeDefined();
+        expect(summaryEvent.payload.source).toBe('groupme');
       });
 
       test('should allow clawdbot to post AI-generated response to pod', async () => {
@@ -1272,12 +1282,15 @@ Based on the GroupMe activity, the team is discussing a PR review for the auth f
           .get('/api/agents/runtime/events')
           .set('Authorization', `Bearer ${clawdbotTokenRes.body.token}`);
 
-        expect(commonlyPoll.body.events.length).toBe(1);
-        expect(commonlyPoll.body.events[0].type).toBe('discord.summary');
-
-        expect(clawdbotPoll.body.events.length).toBe(1);
-        expect(clawdbotPoll.body.events[0].type).toBe('integration.summary');
-        expect(clawdbotPoll.body.events[0].payload.requiresAIResponse).toBe(true);
+        const commonlySummary = commonlyPoll.body.events.find(
+          (event) => event.type === 'discord.summary',
+        );
+        const clawdbotSummary = clawdbotPoll.body.events.find(
+          (event) => event.type === 'integration.summary',
+        );
+        expect(commonlySummary).toBeDefined();
+        expect(clawdbotSummary).toBeDefined();
+        expect(clawdbotSummary.payload.requiresAIResponse).toBe(true);
       });
 
       test('should allow agents to post different types of responses', async () => {
@@ -1386,9 +1399,11 @@ Would you like me to help debug this further?`,
           .get('/api/agents/runtime/events')
           .set('Authorization', `Bearer ${tokenRes.body.token}`);
 
-        expect(pollRes.body.events.length).toBe(1);
-        expect(pollRes.body.events[0].type).toBe('code.shared');
-        expect(pollRes.body.events[0].payload.language).toBe('javascript');
+        const codeEvent = pollRes.body.events.find(
+          (event) => event.type === 'code.shared',
+        );
+        expect(codeEvent).toBeDefined();
+        expect(codeEvent.payload.language).toBe('javascript');
       });
 
       test('should allow custom agent to post review feedback to pod', async () => {
@@ -1501,9 +1516,11 @@ const foo = (bar = 'default') => { return bar; }
           .get('/api/agents/runtime/events')
           .set('Authorization', `Bearer ${clawdbotToken}`);
 
-        expect(clawdbotPoll.body.events.length).toBe(1);
-        expect(clawdbotPoll.body.events[0].type).toBe('ai.analysis.request');
-        expect(clawdbotPoll.body.events[0].payload.triggeredBy).toBe('commonly-bot');
+        const analysisRequest = clawdbotPoll.body.events.find(
+          (event) => event.type === 'ai.analysis.request',
+        );
+        expect(analysisRequest).toBeDefined();
+        expect(analysisRequest.payload.triggeredBy).toBe('commonly-bot');
       });
     });
   });

--- a/backend/__tests__/unit/models/AgentFirstContact.test.js
+++ b/backend/__tests__/unit/models/AgentFirstContact.test.js
@@ -1,12 +1,17 @@
 const AgentFirstContact = require('../../../models/AgentFirstContact');
 
 describe('AgentFirstContact model', () => {
-  test('enforces one durable marker per user and agent', () => {
+  test('enforces one durable marker per user and agent identity', () => {
     const relationshipIndex = AgentFirstContact.schema.indexes().find(([fields]) => (
-      fields.userId === 1 && fields.agentName === 1
+      fields.userId === 1 && fields.agentName === 1 && fields.instanceId === 1
     ));
 
     expect(relationshipIndex).toBeDefined();
     expect(relationshipIndex[1]).toEqual(expect.objectContaining({ unique: true }));
+    expect(AgentFirstContact.schema.path('instanceId').options).toEqual(expect.objectContaining({
+      required: true,
+      lowercase: true,
+      trim: true,
+    }));
   });
 });

--- a/backend/__tests__/unit/models/AgentFirstContact.test.js
+++ b/backend/__tests__/unit/models/AgentFirstContact.test.js
@@ -1,0 +1,12 @@
+const AgentFirstContact = require('../../../models/AgentFirstContact');
+
+describe('AgentFirstContact model', () => {
+  test('enforces one durable marker per user and agent', () => {
+    const relationshipIndex = AgentFirstContact.schema.indexes().find(([fields]) => (
+      fields.userId === 1 && fields.agentName === 1
+    ));
+
+    expect(relationshipIndex).toBeDefined();
+    expect(relationshipIndex[1]).toEqual(expect.objectContaining({ unique: true }));
+  });
+});

--- a/backend/__tests__/unit/routes/registry.cloud-entitlement-gate.test.js
+++ b/backend/__tests__/unit/routes/registry.cloud-entitlement-gate.test.js
@@ -56,6 +56,10 @@ jest.mock('../../../services/agentMessageService', () => ({
   postMessage: jest.fn().mockResolvedValue(true),
 }));
 
+jest.mock('../../../services/firstContactService', () => ({
+  maybeFireFirstContact: jest.fn().mockResolvedValue(undefined),
+}));
+
 const { AgentRegistry, AgentInstallation } = require('../../../models/AgentRegistry');
 const Pod = require('../../../models/Pod');
 const User = require('../../../models/User');

--- a/backend/__tests__/unit/routes/registry.install-runtime-type.test.js
+++ b/backend/__tests__/unit/routes/registry.install-runtime-type.test.js
@@ -51,12 +51,17 @@ jest.mock('../../../services/agentMessageService', () => ({
   postMessage: jest.fn().mockResolvedValue(true),
 }));
 
+jest.mock('../../../services/firstContactService', () => ({
+  maybeFireFirstContact: jest.fn().mockResolvedValue(undefined),
+}));
+
 const { AgentRegistry, AgentInstallation } = require('../../../models/AgentRegistry');
 const Pod = require('../../../models/Pod');
 const User = require('../../../models/User');
 const AgentProfile = require('../../../models/AgentProfile');
 const Activity = require('../../../models/Activity');
 const AgentIdentityService = require('../../../services/agentIdentityService');
+const FirstContactService = require('../../../services/firstContactService');
 const installRouter = require('../../../routes/registry/install');
 
 const getInstallHandler = () => {
@@ -205,5 +210,48 @@ describe('registry install runtimeType fallback', () => {
       }),
     );
     expect(res.status).not.toHaveBeenCalledWith(500);
+  });
+
+  it('keeps install successful when the first-contact trigger fails', async () => {
+    AgentRegistry.getByName.mockResolvedValue({
+      agentName: 'sample-agent',
+      displayName: 'Sample Agent',
+      description: 'Community marketplace app',
+      latestVersion: '1.0.0',
+      manifest: {
+        context: { required: [] },
+        runtime: { type: 'standalone' },
+      },
+    });
+    FirstContactService.maybeFireFirstContact.mockRejectedValueOnce(new Error('marker unavailable'));
+
+    const req = {
+      body: {
+        agentName: 'sample-agent',
+        podId: 'pod-1',
+        version: '1.0.0',
+        config: {},
+        scopes: [],
+      },
+      user: { id: 'user-1', username: 'installer' },
+      userId: 'user-1',
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await installHandler(req, res);
+    await Promise.resolve();
+
+    expect(FirstContactService.maybeFireFirstContact).toHaveBeenCalledWith({
+      agentName: 'sample-agent',
+      instanceId: 'default',
+      podId: 'pod-1',
+      installedByUserId: 'user-1',
+      installerIsAgent: false,
+    });
+    expect(res.status).not.toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
   });
 });

--- a/backend/__tests__/unit/services/firstContactService.test.js
+++ b/backend/__tests__/unit/services/firstContactService.test.js
@@ -1,0 +1,134 @@
+const mongoose = require('mongoose');
+
+jest.mock('../../../models/AgentFirstContact', () => ({
+  findOneAndUpdate: jest.fn(),
+}));
+
+jest.mock('../../../services/agentEventService', () => ({
+  enqueue: jest.fn(),
+}));
+
+const AgentFirstContact = require('../../../models/AgentFirstContact');
+const AgentEventService = require('../../../services/agentEventService');
+const { maybeFireFirstContact } = require('../../../services/firstContactService');
+
+const USER_ID = new mongoose.Types.ObjectId().toString();
+const POD_ID = new mongoose.Types.ObjectId().toString();
+const OTHER_POD_ID = new mongoose.Types.ObjectId().toString();
+
+const firstInsert = () => ({
+  value: null,
+  lastErrorObject: { updatedExisting: false },
+});
+
+const existingMarker = () => ({
+  value: { _id: 'marker-1' },
+  lastErrorObject: { updatedExisting: true },
+});
+
+const baseOptions = (overrides = {}) => ({
+  agentName: 'OpenClaw',
+  instanceId: 'nova',
+  podId: POD_ID,
+  installedByUserId: USER_ID,
+  installerIsAgent: false,
+  ...overrides,
+});
+
+describe('firstContactService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    AgentFirstContact.findOneAndUpdate.mockResolvedValue(firstInsert());
+    AgentEventService.enqueue.mockResolvedValue({ _id: 'event-1' });
+  });
+
+  test('first install creates the durable marker and enqueues first_contact once', async () => {
+    await maybeFireFirstContact(baseOptions());
+
+    expect(AgentFirstContact.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    const [filter, update, options] = AgentFirstContact.findOneAndUpdate.mock.calls[0];
+    expect(String(filter.userId)).toBe(USER_ID);
+    expect(filter.agentName).toBe('openclaw');
+    expect(String(update.$setOnInsert.firstPodId)).toBe(POD_ID);
+    expect(update.$setOnInsert.createdAt).toBeInstanceOf(Date);
+    expect(options).toEqual(expect.objectContaining({
+      upsert: true,
+      new: false,
+      includeResultMetadata: true,
+    }));
+
+    expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+    expect(AgentEventService.enqueue).toHaveBeenCalledWith({
+      agentName: 'openclaw',
+      instanceId: 'nova',
+      podId: expect.any(mongoose.Types.ObjectId),
+      type: 'first_contact',
+      payload: {
+        content: expect.stringMatching(/exactly ONE specific, answerable question.*One question mark, at the end\./s),
+        userId: USER_ID,
+        kind: 'first-contact',
+      },
+    });
+  });
+
+  test('reinstall with an existing marker does not enqueue or create a duplicate', async () => {
+    AgentFirstContact.findOneAndUpdate.mockResolvedValue(existingMarker());
+
+    await expect(maybeFireFirstContact(baseOptions())).resolves.toBeUndefined();
+
+    expect(AgentFirstContact.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+  });
+
+  test('concurrent installs enqueue exactly once when only one atomic upsert inserts', async () => {
+    AgentFirstContact.findOneAndUpdate
+      .mockResolvedValueOnce(firstInsert())
+      .mockResolvedValueOnce(existingMarker());
+
+    await Promise.all([
+      maybeFireFirstContact(baseOptions()),
+      maybeFireFirstContact(baseOptions()),
+    ]);
+
+    expect(AgentFirstContact.findOneAndUpdate).toHaveBeenCalledTimes(2);
+    expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  test('agent-to-agent install returns before marker write or enqueue', async () => {
+    await maybeFireFirstContact(baseOptions({ installerIsAgent: true }));
+
+    expect(AgentFirstContact.findOneAndUpdate).not.toHaveBeenCalled();
+    expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+  });
+
+  test('installing the same agent in a different pod does not re-fire', async () => {
+    AgentFirstContact.findOneAndUpdate
+      .mockResolvedValueOnce(firstInsert())
+      .mockResolvedValueOnce(existingMarker());
+
+    await maybeFireFirstContact(baseOptions());
+    await maybeFireFirstContact(baseOptions({ podId: OTHER_POD_ID }));
+
+    expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+    const secondFilter = AgentFirstContact.findOneAndUpdate.mock.calls[1][0];
+    expect(String(secondFilter.userId)).toBe(USER_ID);
+    expect(secondFilter.agentName).toBe('openclaw');
+    expect(secondFilter).not.toHaveProperty('firstPodId');
+  });
+
+  test('enqueue failure is logged and swallowed after the marker wins', async () => {
+    AgentEventService.enqueue.mockRejectedValue(new Error('queue unavailable'));
+
+    await expect(maybeFireFirstContact(baseOptions())).resolves.toBeUndefined();
+
+    expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      '[first-contact] event enqueue failed',
+      expect.objectContaining({
+        agent: 'openclaw',
+        instance: 'nova',
+        error: 'queue unavailable',
+      }),
+    );
+  });
+});

--- a/backend/__tests__/unit/services/firstContactService.test.js
+++ b/backend/__tests__/unit/services/firstContactService.test.js
@@ -49,6 +49,8 @@ describe('firstContactService', () => {
     const [filter, update, options] = AgentFirstContact.findOneAndUpdate.mock.calls[0];
     expect(String(filter.userId)).toBe(USER_ID);
     expect(filter.agentName).toBe('openclaw');
+    expect(filter.instanceId).toBe('nova');
+    expect(update.$setOnInsert.instanceId).toBe('nova');
     expect(String(update.$setOnInsert.firstPodId)).toBe(POD_ID);
     expect(update.$setOnInsert.createdAt).toBeInstanceOf(Date);
     expect(options).toEqual(expect.objectContaining({
@@ -94,6 +96,17 @@ describe('firstContactService', () => {
     expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
   });
 
+  test('concurrent upsert loser treats E11000 as an expected no-op', async () => {
+    AgentFirstContact.findOneAndUpdate.mockRejectedValue(
+      Object.assign(new Error('duplicate key'), { code: 11000 }),
+    );
+
+    await expect(maybeFireFirstContact(baseOptions())).resolves.toBeUndefined();
+
+    expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
   test('agent-to-agent install returns before marker write or enqueue', async () => {
     await maybeFireFirstContact(baseOptions({ installerIsAgent: true }));
 
@@ -113,7 +126,27 @@ describe('firstContactService', () => {
     const secondFilter = AgentFirstContact.findOneAndUpdate.mock.calls[1][0];
     expect(String(secondFilter.userId)).toBe(USER_ID);
     expect(secondFilter.agentName).toBe('openclaw');
+    expect(secondFilter.instanceId).toBe('nova');
     expect(secondFilter).not.toHaveProperty('firstPodId');
+  });
+
+  test('same user and agentName with different instanceIds both fire', async () => {
+    AgentFirstContact.findOneAndUpdate
+      .mockResolvedValueOnce(firstInsert())
+      .mockResolvedValueOnce(firstInsert());
+
+    await maybeFireFirstContact(baseOptions({ instanceId: 'Aria' }));
+    await maybeFireFirstContact(baseOptions({ instanceId: 'Pixel' }));
+
+    expect(AgentFirstContact.findOneAndUpdate).toHaveBeenCalledTimes(2);
+    expect(AgentFirstContact.findOneAndUpdate.mock.calls.map(([filter]) => filter.instanceId))
+      .toEqual(['aria', 'pixel']);
+    expect(AgentFirstContact.findOneAndUpdate.mock.calls.map(([, update]) => (
+      update.$setOnInsert.instanceId
+    ))).toEqual(['aria', 'pixel']);
+    expect(AgentEventService.enqueue).toHaveBeenCalledTimes(2);
+    expect(AgentEventService.enqueue.mock.calls.map(([event]) => event.instanceId))
+      .toEqual(['aria', 'pixel']);
   });
 
   test('enqueue failure is logged and swallowed after the marker wins', async () => {

--- a/backend/__tests__/unit/services/nativeRuntimeService.firstContact.test.js
+++ b/backend/__tests__/unit/services/nativeRuntimeService.firstContact.test.js
@@ -1,0 +1,103 @@
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+jest.mock('../../../models/Pod', () => ({
+  findById: jest.fn(() => ({
+    lean: jest.fn().mockResolvedValue({ name: 'Launch Room' }),
+  })),
+}));
+
+jest.mock('../../../models/AgentRun', () => ({
+  create: jest.fn(),
+}));
+
+jest.mock('../../../services/agentTypingService', () => ({
+  emitAgentTypingStart: jest.fn(),
+  emitAgentTypingStop: jest.fn(),
+}));
+
+jest.mock('../../../services/agentMessageService', () => ({
+  postMessage: jest.fn().mockResolvedValue({ success: true }),
+}));
+
+const axios = require('axios').default;
+const AgentRun = require('../../../models/AgentRun');
+const AgentMessageService = require('../../../services/agentMessageService');
+const { runAgent } = require('../../../services/nativeRuntimeService');
+
+describe('nativeRuntimeService first_contact', () => {
+  const previousEnv = {
+    baseUrl: process.env.LITELLM_BASE_URL,
+    masterKey: process.env.LITELLM_MASTER_KEY,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.LITELLM_BASE_URL = 'http://litellm.test';
+    process.env.LITELLM_MASTER_KEY = 'test-key';
+
+    AgentRun.create.mockImplementation(async (doc) => ({
+      _id: 'run-1',
+      ...doc,
+      save: jest.fn().mockResolvedValue(undefined),
+    }));
+    axios.post.mockResolvedValue({
+      status: 200,
+      data: {
+        choices: [{ message: { role: 'assistant', content: 'Hi! What would you like help with?' } }],
+        usage: { prompt_tokens: 10, completion_tokens: 8, total_tokens: 18 },
+      },
+      headers: {},
+    });
+  });
+
+  afterAll(() => {
+    if (previousEnv.baseUrl === undefined) delete process.env.LITELLM_BASE_URL;
+    else process.env.LITELLM_BASE_URL = previousEnv.baseUrl;
+    if (previousEnv.masterKey === undefined) delete process.env.LITELLM_MASTER_KEY;
+    else process.env.LITELLM_MASTER_KEY = previousEnv.masterKey;
+  });
+
+  test('passes the inline first-contact cue to the model and records the trigger', async () => {
+    const cue = 'Post a SHORT greeting that ends with exactly ONE answerable question.';
+
+    const result = await runAgent(
+      {
+        podId: '507f1f77bcf86cd799439011',
+        agentName: 'native-helper',
+        instanceId: 'default',
+        displayName: 'Native Helper',
+        config: { runtime: { runtimeType: 'native' } },
+      },
+      {
+        type: 'first_contact',
+        eventId: '507f1f77bcf86cd799439012',
+        payload: { content: cue },
+      },
+    );
+
+    expect(AgentRun.create).toHaveBeenCalledWith(expect.objectContaining({
+      trigger: 'first_contact',
+    }));
+    expect(axios.post).toHaveBeenCalledWith(
+      'http://litellm.test/chat/completions',
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          { role: 'user', content: cue },
+        ]),
+      }),
+      expect.any(Object),
+    );
+    expect(AgentMessageService.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      content: 'Hi! What would you like help with?',
+    }));
+    expect(result).toEqual(expect.objectContaining({
+      status: 'succeeded',
+      finalMessage: 'Hi! What would you like help with?',
+    }));
+  });
+});

--- a/backend/models/AgentFirstContact.ts
+++ b/backend/models/AgentFirstContact.ts
@@ -1,0 +1,37 @@
+import mongoose, { Document, Model, Schema, Types } from 'mongoose';
+
+/**
+ * Durable, append-only record that a human and an agent have already met.
+ * It intentionally outlives AgentInstallation rows so uninstall/reinstall
+ * cannot replay onboarding for an existing relationship (ADR-001 identity
+ * continuity).
+ */
+export interface IAgentFirstContact extends Document {
+  userId: Types.ObjectId;
+  agentName: string;
+  firstPodId: Types.ObjectId;
+  createdAt: Date;
+}
+
+const AgentFirstContactSchema = new Schema<IAgentFirstContact>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    agentName: { type: String, required: true, lowercase: true, trim: true },
+    firstPodId: { type: Schema.Types.ObjectId, ref: 'Pod', required: true },
+  },
+  {
+    timestamps: { createdAt: true, updatedAt: false },
+    versionKey: false,
+  },
+);
+
+AgentFirstContactSchema.index({ userId: 1, agentName: 1 }, { unique: true });
+
+const AgentFirstContact: Model<IAgentFirstContact> =
+  (mongoose.models.AgentFirstContact as Model<IAgentFirstContact>)
+  || mongoose.model<IAgentFirstContact>('AgentFirstContact', AgentFirstContactSchema);
+
+export default AgentFirstContact;
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/models/AgentFirstContact.ts
+++ b/backend/models/AgentFirstContact.ts
@@ -9,6 +9,7 @@ import mongoose, { Document, Model, Schema, Types } from 'mongoose';
 export interface IAgentFirstContact extends Document {
   userId: Types.ObjectId;
   agentName: string;
+  instanceId: string;
   firstPodId: Types.ObjectId;
   createdAt: Date;
 }
@@ -17,6 +18,7 @@ const AgentFirstContactSchema = new Schema<IAgentFirstContact>(
   {
     userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
     agentName: { type: String, required: true, lowercase: true, trim: true },
+    instanceId: { type: String, required: true, lowercase: true, trim: true },
     firstPodId: { type: Schema.Types.ObjectId, ref: 'Pod', required: true },
   },
   {
@@ -25,7 +27,10 @@ const AgentFirstContactSchema = new Schema<IAgentFirstContact>(
   },
 );
 
-AgentFirstContactSchema.index({ userId: 1, agentName: 1 }, { unique: true });
+AgentFirstContactSchema.index(
+  { userId: 1, agentName: 1, instanceId: 1 },
+  { unique: true },
+);
 
 const AgentFirstContact: Model<IAgentFirstContact> =
   (mongoose.models.AgentFirstContact as Model<IAgentFirstContact>)

--- a/backend/models/AgentRun.ts
+++ b/backend/models/AgentRun.ts
@@ -25,6 +25,7 @@ export type AgentRunTrigger =
   | 'task.assigned'
   | 'chat.message'
   | 'pod.join'
+  | 'first_contact'
   | 'manual';
 
 export type AgentRunErrorKind =
@@ -107,7 +108,7 @@ const AgentRunSchema = new Schema<IAgentRun>(
     instanceId: { type: String, default: 'default' },
     trigger: {
       type: String,
-      enum: ['mention', 'heartbeat', 'task.assigned', 'chat.message', 'pod.join', 'manual'],
+      enum: ['mention', 'heartbeat', 'task.assigned', 'chat.message', 'pod.join', 'first_contact', 'manual'],
       required: true,
     },
     triggerEventId: { type: Schema.Types.ObjectId, ref: 'AgentEvent' },

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -10,6 +10,7 @@ const Pod = require('../../models/Pod');
 const User = require('../../models/User');
 const AgentIdentityService = require('../../services/agentIdentityService');
 const AgentMessageService = require('../../services/agentMessageService');
+const FirstContactService = require('../../services/firstContactService');
 const {
   getUserId,
   normalizeInstanceId,
@@ -121,7 +122,7 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
 
     // Fetched once and reused for the #609 owner-scoping decision below and
     // the cloud-entitlement gate further down.
-    const installerUser = await User.findById(userId).select('role entitlements').lean();
+    const installerUser = await User.findById(userId).select('role entitlements isBot').lean();
     const isAdminInstaller = installerUser?.role === 'admin';
 
     const pod = await Pod.findById(podId).lean();
@@ -444,6 +445,24 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
     } catch (identityError: unknown) {
       console.warn('Failed to provision agent user identity:', (identityError as Error).message);
     }
+
+    // First contact belongs to the durable human↔agent relationship, not the
+    // replaceable installation row. Best-effort by design: neither a marker
+    // write nor event enqueue failure may turn a successful install into 500.
+    void FirstContactService.maybeFireFirstContact({
+      agentName: agent.agentName,
+      instanceId: normalizedInstanceId,
+      podId,
+      installedByUserId: userId,
+      installerIsAgent: installerUser?.isBot === true,
+    }).catch((firstContactError: unknown) => {
+      console.warn('[first-contact] trigger failed after install', {
+        agent: agent.agentName,
+        instance: normalizedInstanceId,
+        pod: String(podId),
+        error: (firstContactError as Error).message,
+      });
+    });
 
     await AgentRegistry.incrementInstalls(agentName);
 

--- a/backend/services/firstContactService.ts
+++ b/backend/services/firstContactService.ts
@@ -1,0 +1,106 @@
+import mongoose, { Types } from 'mongoose';
+import AgentFirstContact from '../models/AgentFirstContact';
+import AgentEventService from './agentEventService';
+
+interface FirstContactOptions {
+  agentName: string;
+  instanceId: string;
+  podId: string | Types.ObjectId;
+  installedByUserId: string | Types.ObjectId;
+  installerIsAgent: boolean;
+}
+
+interface RawUpsertResult {
+  value?: unknown;
+  lastErrorObject?: {
+    updatedExisting?: boolean;
+  };
+}
+
+const FIRST_CONTACT_CUE =
+  'A human just added you to this workspace and is seeing you for the first time. '
+  + 'This is your one first impression. Do NOT list your capabilities. Post a SHORT, '
+  + 'warm greeting that ends with exactly ONE specific, answerable question that invites '
+  + 'them to reply — something that gets them talking about what they want help with. '
+  + 'One question mark, at the end.';
+
+/**
+ * Enqueue onboarding exactly once for the lifetime of a human/agent
+ * relationship. AgentFirstContact, rather than AgentInstallation, owns the
+ * idempotency marker because installation rows can be recreated after an
+ * uninstall.
+ */
+export async function maybeFireFirstContact({
+  agentName,
+  instanceId,
+  podId,
+  installedByUserId,
+  installerIsAgent,
+}: FirstContactOptions): Promise<void> {
+  if (installerIsAgent) return;
+
+  const safeAgentName = String(agentName || '').trim().toLowerCase();
+  if (!safeAgentName || !/^(@[a-z0-9-]+\/)?[a-z0-9-]+$/.test(safeAgentName)) {
+    throw new Error('Invalid agentName for first contact');
+  }
+
+  if (!mongoose.Types.ObjectId.isValid(String(installedByUserId))) {
+    throw new Error('Invalid installedByUserId for first contact');
+  }
+  if (!mongoose.Types.ObjectId.isValid(String(podId))) {
+    throw new Error('Invalid podId for first contact');
+  }
+
+  const safeUserId = new mongoose.Types.ObjectId(String(installedByUserId));
+  const safePodId = new mongoose.Types.ObjectId(String(podId));
+  const safeInstanceId = String(instanceId || 'default').trim() || 'default';
+
+  const result = await AgentFirstContact.findOneAndUpdate(
+    { userId: safeUserId, agentName: safeAgentName },
+    {
+      $setOnInsert: {
+        userId: safeUserId,
+        agentName: safeAgentName,
+        firstPodId: safePodId,
+        createdAt: new Date(),
+      },
+    },
+    {
+      upsert: true,
+      new: false,
+      // Mongoose 7 replacement for deprecated rawResult: true. We need the
+      // driver's updatedExisting flag to distinguish the winning insert.
+      includeResultMetadata: true,
+      setDefaultsOnInsert: true,
+    },
+  ) as unknown as RawUpsertResult;
+
+  if (result?.lastErrorObject?.updatedExisting === true || result?.value != null) {
+    return;
+  }
+
+  try {
+    await AgentEventService.enqueue({
+      agentName: safeAgentName,
+      instanceId: safeInstanceId,
+      podId: safePodId,
+      type: 'first_contact',
+      payload: {
+        content: FIRST_CONTACT_CUE,
+        userId: String(safeUserId),
+        kind: 'first-contact',
+      },
+    });
+  } catch (error) {
+    // The durable marker already exists. Surface the lost best-effort event,
+    // but never turn onboarding into an install failure.
+    console.warn('[first-contact] event enqueue failed', {
+      agent: safeAgentName,
+      instance: safeInstanceId,
+      pod: String(safePodId),
+      error: (error as Error).message,
+    });
+  }
+}
+
+export default { maybeFireFirstContact };

--- a/backend/services/firstContactService.ts
+++ b/backend/services/firstContactService.ts
@@ -25,7 +25,7 @@ const FIRST_CONTACT_CUE =
   + 'One question mark, at the end.';
 
 /**
- * Enqueue onboarding exactly once for the lifetime of a human/agent
+ * Enqueue onboarding exactly once for the lifetime of a human/agent-identity
  * relationship. AgentFirstContact, rather than AgentInstallation, owns the
  * idempotency marker because installation rows can be recreated after an
  * uninstall.
@@ -53,27 +53,36 @@ export async function maybeFireFirstContact({
 
   const safeUserId = new mongoose.Types.ObjectId(String(installedByUserId));
   const safePodId = new mongoose.Types.ObjectId(String(podId));
-  const safeInstanceId = String(instanceId || 'default').trim() || 'default';
+  const safeInstanceId = String(instanceId || 'default').trim().toLowerCase() || 'default';
 
-  const result = await AgentFirstContact.findOneAndUpdate(
-    { userId: safeUserId, agentName: safeAgentName },
-    {
-      $setOnInsert: {
-        userId: safeUserId,
-        agentName: safeAgentName,
-        firstPodId: safePodId,
-        createdAt: new Date(),
+  let result: RawUpsertResult;
+  try {
+    result = await AgentFirstContact.findOneAndUpdate(
+      { userId: safeUserId, agentName: safeAgentName, instanceId: safeInstanceId },
+      {
+        $setOnInsert: {
+          userId: safeUserId,
+          agentName: safeAgentName,
+          instanceId: safeInstanceId,
+          firstPodId: safePodId,
+          createdAt: new Date(),
+        },
       },
-    },
-    {
-      upsert: true,
-      new: false,
-      // Mongoose 7 replacement for deprecated rawResult: true. We need the
-      // driver's updatedExisting flag to distinguish the winning insert.
-      includeResultMetadata: true,
-      setDefaultsOnInsert: true,
-    },
-  ) as unknown as RawUpsertResult;
+      {
+        upsert: true,
+        new: false,
+        // Mongoose 7 replacement for deprecated rawResult: true. We need the
+        // driver's updatedExisting flag to distinguish the winning insert.
+        includeResultMetadata: true,
+        setDefaultsOnInsert: true,
+      },
+    ) as unknown as RawUpsertResult;
+  } catch (error) {
+    // Two concurrent upserts can both miss before the unique index picks a
+    // winner. The loser is an expected no-op, not an install error.
+    if ((error as { code?: number })?.code === 11000) return;
+    throw error;
+  }
 
   if (result?.lastErrorObject?.updatedExisting === true || result?.value != null) {
     return;

--- a/backend/services/nativeRuntimeService.ts
+++ b/backend/services/nativeRuntimeService.ts
@@ -30,7 +30,7 @@ import axios, { AxiosError } from 'axios';
 // --- public surface --------------------------------------------------------
 
 export interface NativeRunTrigger {
-  type: 'mention' | 'heartbeat' | 'task.assigned' | 'chat.message' | 'pod.join' | 'manual';
+  type: 'mention' | 'heartbeat' | 'task.assigned' | 'chat.message' | 'pod.join' | 'first_contact' | 'manual';
   eventId?: string;
   payload?: unknown;
 }
@@ -378,6 +378,11 @@ function buildUserMessage(
     );
   }
 
+  if (trigger.type === 'first_contact') {
+    const content = String(payload.content || '').trim();
+    return content || 'A human just added you to this workspace. Post a short, warm greeting that ends with one specific question.';
+  }
+
   return (
     `Trigger: ${trigger.type}. Use commonly_read_context to understand what's happening, `
     + 'then respond or act as appropriate.'
@@ -424,6 +429,7 @@ function mapTriggerType(raw: string): NativeRunTrigger['type'] {
   if (raw === 'task.assigned') return 'task.assigned';
   if (raw === 'chat.message') return 'chat.message';
   if (raw === 'pod.join') return 'pod.join';
+  if (raw === 'first_contact') return 'first_contact';
   return 'manual';
 }
 

--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -109,6 +109,43 @@ describe('performRun', () => {
     );
   });
 
+  test('first_contact event is forwarded to the adapter like a mention', async () => {
+    const events = [makeEvent({
+      _id: 'evt-first-contact',
+      type: 'first_contact',
+      payload: { content: 'Make a warm first impression.' },
+    })];
+    const mockGet = jest.fn().mockResolvedValue({ events });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn(async () => ({ text: 'Hi! What are you working on today?' }));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).toHaveBeenCalledWith(
+      'Make a warm first impression.',
+      expect.objectContaining({ metadata: { event: events[0] } }),
+    );
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/pods/pod-abc/messages',
+      { content: 'Hi! What are you working on today?' },
+    );
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-first-contact/ack',
+      { result: { outcome: 'posted' } },
+    );
+  });
+
   test('ensures adapter cwd exists before spawning — avoids confusing spawn ENOENT on missing dir', async () => {
     const agentCwd = path.join(os.tmpdir(), 'commonly-agents', 'cwd-fresh-agent');
     fs.rmSync(agentCwd, { recursive: true, force: true });
@@ -138,7 +175,7 @@ describe('performRun', () => {
 
   test('heartbeat event with payload.content is suppressed — chat-only events spawn', async () => {
     // Regression: a heartbeat with a stray `content` field must NOT trigger
-    // a spawn. Only CHAT_EVENT_TYPES are forwarded to the CLI.
+    // a spawn. Only PROMPT_EVENT_TYPES are forwarded to the CLI.
     const events = [makeEvent({
       _id: 'evt-hb',
       type: 'heartbeat',

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -100,10 +100,15 @@ export const listLocalAgents = () => {
     .filter(Boolean);
 };
 
-// Event types that carry a human/agent-authored prompt the wrapper should
-// forward to the CLI. Other event types (heartbeat, delivery, etc.) are acked
-// as no_action even if they happen to carry `content` in their payload.
-const CHAT_EVENT_TYPES = new Set(['chat.mention', 'message.posted', 'dm.message']);
+// Event types that carry a prompt the wrapper should forward to the CLI.
+// Other event types (heartbeat, delivery, etc.) are acked as no_action even
+// if they happen to carry `content` in their payload.
+const PROMPT_EVENT_TYPES = new Set([
+  'chat.mention',
+  'message.posted',
+  'dm.message',
+  'first_contact',
+]);
 
 // ── default environment for adapters that benefit from auto-MCP wiring ─────
 
@@ -366,7 +371,7 @@ export const runMemoryImport = async ({
 // ── run: local-CLI wrapper loop (ADR-005) ────────────────────────────────────
 
 const extractPrompt = (event) => {
-  if (!CHAT_EVENT_TYPES.has(event.type)) return null;
+  if (!PROMPT_EVENT_TYPES.has(event.type)) return null;
   const p = event.payload || {};
   return p.content || p.prompt || p.text || null;
 };


### PR DESCRIPTION
Closes #686.

## Summary

- add an append-only AgentFirstContact marker with a unique (userId, agentName, instanceId) index, independent of replaceable AgentInstallation rows
- atomically enqueue first_contact only for the first human-to-agent-identity relationship install; reinstall, concurrent install, second-pod install, and agent-to-agent install do not replay it
- treat duplicate-key losers in a concurrent upsert race as the expected no-op instead of logging a false install error
- deliver the exact inline first-impression cue through AgentEvent, with install remaining best-effort if marker/event work fails
- teach both the native runtime and local CLI wrapper to consume first_contact as a model prompt; the OpenClaw and webhook poll paths are already type-generic
- make existing integration tests select the event type they exercise now that a fresh install also queues first_contact

## Identity semantics

- First contact is once per durable agent identity: human userId + agentName + instanceId. Aria and Pixel each greet once even though both use the openclaw runtime.
- Installing the same identity into another pod does not replay the greeting; uninstall/reinstall also remains silent because the marker outlives AgentInstallation.
- The existing deterministic team-pod install intro is unchanged. A first attach in a team pod can therefore produce that system-authored intro plus the agent-authored first-contact greeting. I left this visible rather than silently changing the older flow in this PR.

## Verification

- focused correction set: 4/4 suites, 13/13 tests passed
- backend full suite on the original head: 172/172 suites, 1,235/1,235 tests passed (Jest printed its known open-handle warning after the green summary; the idle container was then stopped)
- affected integration suite: 23/23 passed
- CLI full suite: 15/15 suites, 156 passed, 8 skipped
- backend TypeScript check and production build passed after the identity-key correction
- real Mongo probes after the correction:
  - 8 simultaneous calls for the same identity produced 1 marker and 1 event
  - Aria + Pixel for the same human produced 2 markers and 2 events
- git diff --check passed
- new JS test files pass ESLint when the repository's broken TS import-resolution rules are disabled

Known repository baseline: backend npm run lint currently reports 1,318 existing parser/import-resolution/style problems across the tree, and the CLI lint script has no eslint dependency/config. This PR does not attempt that unrelated lint migration.
