### PR TITLE
Show only agent and activity stats publicly

### DIFF
--- a/backend/__tests__/unit/routes/stats.public.test.js
+++ b/backend/__tests__/unit/routes/stats.public.test.js
@@ -3,7 +3,7 @@ const express = require('express');
 
 const mockPgQuery = jest.fn();
 const mockMessageCountDocuments = jest.fn().mockResolvedValue(88);
-const mockUserCountDocuments = jest.fn();
+const mockUserCountDocuments = jest.fn().mockResolvedValue(262);
 
 jest.mock('../../../models/Pod', () => ({
   countDocuments: jest.fn().mockResolvedValue(12),
@@ -13,11 +13,6 @@ jest.mock('../../../models/User', () => ({
 }));
 jest.mock('../../../models/Message', () => ({
   countDocuments: mockMessageCountDocuments,
-}));
-jest.mock('../../../models/AgentRegistry', () => ({
-  AgentInstallation: {
-    distinct: jest.fn().mockResolvedValue(['openclaw', 'moltbot', 'clawdbot']),
-  },
 }));
 jest.mock('../../../config/db-pg', () => ({
   pool: { query: mockPgQuery },
@@ -34,11 +29,6 @@ describe('GET /api/stats/public', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockPgQuery.mockResolvedValue({ rows: [{ count: 1234 }] });
-    mockUserCountDocuments.mockImplementation((filter) => {
-      if (filter?.['botMetadata.agentName']?.$exists === true) return Promise.resolve(32);
-      if (filter?.$or) return Promise.resolve(10);
-      return Promise.resolve(42);
-    });
   });
 
   it('uses PostgreSQL for the 24-hour message count', async () => {
@@ -46,11 +36,8 @@ describe('GET /api/stats/public', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       activePods: 12,
-      activeAgents: 3,
       messageCount24h: 1234,
-      registeredUsers: 42,
-      humanCount: 10,
-      agentCount: 32,
+      agents: 262,
     });
     expect(mockPgQuery).toHaveBeenCalledWith(
       'SELECT COUNT(*)::int AS count FROM messages WHERE created_at >= $1',
@@ -58,14 +45,11 @@ describe('GET /api/stats/public', () => {
     );
     expect(mockMessageCountDocuments).not.toHaveBeenCalled();
     expect(mockUserCountDocuments).toHaveBeenCalledWith({
-      $or: [
-        { botMetadata: { $exists: false } },
-        { 'botMetadata.agentName': { $exists: false } },
-      ],
-    });
-    expect(mockUserCountDocuments).toHaveBeenCalledWith({
       'botMetadata.agentName': { $exists: true },
     });
+    expect(mockUserCountDocuments).toHaveBeenCalledTimes(1);
+    expect(res.body).not.toHaveProperty('humanCount');
+    expect(res.body).not.toHaveProperty('registeredUsers');
   });
 
   it('falls back to MongoDB when the PostgreSQL count fails', async () => {
@@ -76,11 +60,8 @@ describe('GET /api/stats/public', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       activePods: 12,
-      activeAgents: 3,
       messageCount24h: 88,
-      registeredUsers: 42,
-      humanCount: 10,
-      agentCount: 32,
+      agents: 262,
     });
     expect(mockMessageCountDocuments).toHaveBeenCalledWith({
       createdAt: { $gte: expect.any(Date) },

--- a/backend/__tests__/unit/routes/stats.public.test.js
+++ b/backend/__tests__/unit/routes/stats.public.test.js
@@ -3,12 +3,13 @@ const express = require('express');
 
 const mockPgQuery = jest.fn();
 const mockMessageCountDocuments = jest.fn().mockResolvedValue(88);
+const mockUserCountDocuments = jest.fn();
 
 jest.mock('../../../models/Pod', () => ({
   countDocuments: jest.fn().mockResolvedValue(12),
 }));
 jest.mock('../../../models/User', () => ({
-  countDocuments: jest.fn().mockResolvedValue(42),
+  countDocuments: mockUserCountDocuments,
 }));
 jest.mock('../../../models/Message', () => ({
   countDocuments: mockMessageCountDocuments,
@@ -33,6 +34,11 @@ describe('GET /api/stats/public', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockPgQuery.mockResolvedValue({ rows: [{ count: 1234 }] });
+    mockUserCountDocuments.mockImplementation((filter) => {
+      if (filter?.['botMetadata.agentName']?.$exists === true) return Promise.resolve(32);
+      if (filter?.$or) return Promise.resolve(10);
+      return Promise.resolve(42);
+    });
   });
 
   it('uses PostgreSQL for the 24-hour message count', async () => {
@@ -43,12 +49,23 @@ describe('GET /api/stats/public', () => {
       activeAgents: 3,
       messageCount24h: 1234,
       registeredUsers: 42,
+      humanCount: 10,
+      agentCount: 32,
     });
     expect(mockPgQuery).toHaveBeenCalledWith(
       'SELECT COUNT(*)::int AS count FROM messages WHERE created_at >= $1',
       [expect.any(Date)],
     );
     expect(mockMessageCountDocuments).not.toHaveBeenCalled();
+    expect(mockUserCountDocuments).toHaveBeenCalledWith({
+      $or: [
+        { botMetadata: { $exists: false } },
+        { 'botMetadata.agentName': { $exists: false } },
+      ],
+    });
+    expect(mockUserCountDocuments).toHaveBeenCalledWith({
+      'botMetadata.agentName': { $exists: true },
+    });
   });
 
   it('falls back to MongoDB when the PostgreSQL count fails', async () => {
@@ -62,6 +79,8 @@ describe('GET /api/stats/public', () => {
       activeAgents: 3,
       messageCount24h: 88,
       registeredUsers: 42,
+      humanCount: 10,
+      agentCount: 32,
     });
     expect(mockMessageCountDocuments).toHaveBeenCalledWith({
       createdAt: { $gte: expect.any(Date) },

--- a/backend/__tests__/unit/routes/stats.public.test.js
+++ b/backend/__tests__/unit/routes/stats.public.test.js
@@ -14,6 +14,11 @@ jest.mock('../../../models/User', () => ({
 jest.mock('../../../models/Message', () => ({
   countDocuments: mockMessageCountDocuments,
 }));
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: {
+    distinct: jest.fn().mockResolvedValue(['openclaw', 'moltbot', 'clawdbot']),
+  },
+}));
 jest.mock('../../../config/db-pg', () => ({
   pool: { query: mockPgQuery },
 }));
@@ -36,8 +41,9 @@ describe('GET /api/stats/public', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       activePods: 12,
+      activeAgents: 3,
       messageCount24h: 1234,
-      agents: 262,
+      agentCount: 262,
     });
     expect(mockPgQuery).toHaveBeenCalledWith(
       'SELECT COUNT(*)::int AS count FROM messages WHERE created_at >= $1',
@@ -60,8 +66,9 @@ describe('GET /api/stats/public', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       activePods: 12,
+      activeAgents: 3,
       messageCount24h: 88,
-      agents: 262,
+      agentCount: 262,
     });
     expect(mockMessageCountDocuments).toHaveBeenCalledWith({
       createdAt: { $gte: expect.any(Date) },

--- a/backend/routes/stats.ts
+++ b/backend/routes/stats.ts
@@ -6,6 +6,9 @@ const Pod = require('../models/Pod');
 const User = require('../models/User');
 // eslint-disable-next-line global-require
 const Message = require('../models/Message');
+// eslint-disable-next-line global-require
+const { AgentInstallation } = require('../models/AgentRegistry');
+
 const router: ReturnType<typeof express.Router> = express.Router();
 
 const pgMessageCount24h = async (since: Date): Promise<number> => {
@@ -25,10 +28,12 @@ router.get('/public', async (_req: unknown, res: { json: (d: unknown) => void; s
 
     const [
       activePods,
+      activeAgents,
       messageCount24h,
-      agents,
+      agentCount,
     ] = await Promise.all([
       Pod.countDocuments({ updatedAt: { $gte: sevenDaysAgo } }),
+      AgentInstallation.distinct('agentName').then((names: string[]) => names.length),
       pgMessageCount24h(oneDayAgo).catch((err: { message?: string }) => {
         console.warn('stats: PG message count failed, falling back to Mongo:', err?.message);
         return Message.countDocuments({ createdAt: { $gte: oneDayAgo } });
@@ -38,8 +43,9 @@ router.get('/public', async (_req: unknown, res: { json: (d: unknown) => void; s
 
     res.json({
       activePods,
+      activeAgents,
       messageCount24h,
-      agents,
+      agentCount,
     });
   } catch {
     res.status(500).json({ error: 'Failed to fetch stats' });

--- a/backend/routes/stats.ts
+++ b/backend/routes/stats.ts
@@ -26,7 +26,14 @@ router.get('/public', async (_req: unknown, res: { json: (d: unknown) => void; s
     const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
 
-    const [activePods, activeAgents, messageCount24h, registeredUsers] = await Promise.all([
+    const [
+      activePods,
+      activeAgents,
+      messageCount24h,
+      registeredUsers,
+      humanCount,
+      agentCount,
+    ] = await Promise.all([
       Pod.countDocuments({ updatedAt: { $gte: sevenDaysAgo } }),
       AgentInstallation.distinct('agentName').then((names: string[]) => names.length),
       pgMessageCount24h(oneDayAgo).catch((err: { message?: string }) => {
@@ -34,9 +41,23 @@ router.get('/public', async (_req: unknown, res: { json: (d: unknown) => void; s
         return Message.countDocuments({ createdAt: { $gte: oneDayAgo } });
       }),
       User.countDocuments(),
+      User.countDocuments({
+        $or: [
+          { botMetadata: { $exists: false } },
+          { 'botMetadata.agentName': { $exists: false } },
+        ],
+      }),
+      User.countDocuments({ 'botMetadata.agentName': { $exists: true } }),
     ]);
 
-    res.json({ activePods, activeAgents, messageCount24h, registeredUsers });
+    res.json({
+      activePods,
+      activeAgents,
+      messageCount24h,
+      registeredUsers,
+      humanCount,
+      agentCount,
+    });
   } catch {
     res.status(500).json({ error: 'Failed to fetch stats' });
   }

--- a/backend/routes/stats.ts
+++ b/backend/routes/stats.ts
@@ -6,9 +6,6 @@ const Pod = require('../models/Pod');
 const User = require('../models/User');
 // eslint-disable-next-line global-require
 const Message = require('../models/Message');
-// eslint-disable-next-line global-require
-const { AgentInstallation } = require('../models/AgentRegistry');
-
 const router: ReturnType<typeof express.Router> = express.Router();
 
 const pgMessageCount24h = async (since: Date): Promise<number> => {
@@ -28,35 +25,21 @@ router.get('/public', async (_req: unknown, res: { json: (d: unknown) => void; s
 
     const [
       activePods,
-      activeAgents,
       messageCount24h,
-      registeredUsers,
-      humanCount,
-      agentCount,
+      agents,
     ] = await Promise.all([
       Pod.countDocuments({ updatedAt: { $gte: sevenDaysAgo } }),
-      AgentInstallation.distinct('agentName').then((names: string[]) => names.length),
       pgMessageCount24h(oneDayAgo).catch((err: { message?: string }) => {
         console.warn('stats: PG message count failed, falling back to Mongo:', err?.message);
         return Message.countDocuments({ createdAt: { $gte: oneDayAgo } });
-      }),
-      User.countDocuments(),
-      User.countDocuments({
-        $or: [
-          { botMetadata: { $exists: false } },
-          { 'botMetadata.agentName': { $exists: false } },
-        ],
       }),
       User.countDocuments({ 'botMetadata.agentName': { $exists: true } }),
     ]);
 
     res.json({
       activePods,
-      activeAgents,
       messageCount24h,
-      registeredUsers,
-      humanCount,
-      agentCount,
+      agents,
     });
   } catch {
     res.status(500).json({ error: 'Failed to fetch stats' });

--- a/frontend/src/v2/__tests__/V2LandingPage.stats.test.tsx
+++ b/frontend/src/v2/__tests__/V2LandingPage.stats.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
 import { useAuth } from '../../context/AuthContext';
@@ -36,24 +36,24 @@ describe('V2LandingPage proof stats', () => {
     mockUseAuth.mockReturnValue({ isAuthenticated: false });
   });
 
-  it('renders separate human and agent identity counts', async () => {
-    mockAxiosGet.mockResolvedValue({ data: { humanCount: 75, agentCount: 262 } });
+  it('renders only agent and activity stats', async () => {
+    mockAxiosGet.mockResolvedValue({
+      data: { agents: 262, messageCount24h: 1234, activePods: 12 },
+    });
 
     renderLanding();
 
-    expect(await screen.findByText('75')).toBeInTheDocument();
-    expect(screen.getByText('builders')).toBeInTheDocument();
-    expect(screen.getByText('262')).toBeInTheDocument();
-    expect(screen.getByText('agents')).toBeInTheDocument();
-  });
+    const agentsLabel = await screen.findByText('agents');
+    const statsRow = agentsLabel.closest('.v2-landing__proof-stats');
+    expect(statsRow).not.toBeNull();
 
-  it('falls back to dashes when the new counts are absent', async () => {
-    mockAxiosGet.mockResolvedValue({ data: { activePods: 4 } });
-
-    renderLanding();
-
-    expect(await screen.findByText('active pods')).toBeInTheDocument();
-    expect(screen.getByText('builders').previousElementSibling).toHaveTextContent('—');
-    expect(screen.getByText('agents').previousElementSibling).toHaveTextContent('—');
+    const stats = within(statsRow as HTMLElement);
+    expect(agentsLabel.previousElementSibling).toHaveTextContent('262');
+    expect(stats.getByText('messages / 24h').previousElementSibling).toHaveTextContent('1,234');
+    expect(stats.getByText('active pods').previousElementSibling).toHaveTextContent('12');
+    expect(stats.queryByText('builders')).not.toBeInTheDocument();
+    expect(stats.queryByText('people')).not.toBeInTheDocument();
+    expect(stats.queryByText('ADRs')).not.toBeInTheDocument();
+    expect(statsRow?.children).toHaveLength(3);
   });
 });

--- a/frontend/src/v2/__tests__/V2LandingPage.stats.test.tsx
+++ b/frontend/src/v2/__tests__/V2LandingPage.stats.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import axios from 'axios';
+import { useAuth } from '../../context/AuthContext';
+import V2LandingPage from '../landing/V2LandingPage';
+
+jest.mock('axios');
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+const mockAxiosGet = axios.get as jest.Mock;
+const mockUseAuth = useAuth as jest.Mock;
+
+const renderLanding = () => render(
+  <MemoryRouter>
+    <V2LandingPage />
+  </MemoryRouter>,
+);
+
+describe('V2LandingPage proof stats', () => {
+  let playSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    playSpy = jest.spyOn(window.HTMLMediaElement.prototype, 'play')
+      .mockResolvedValue(undefined);
+  });
+
+  afterAll(() => {
+    playSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({ isAuthenticated: false });
+  });
+
+  it('renders separate human and agent identity counts', async () => {
+    mockAxiosGet.mockResolvedValue({ data: { humanCount: 75, agentCount: 262 } });
+
+    renderLanding();
+
+    expect(await screen.findByText('75')).toBeInTheDocument();
+    expect(screen.getByText('builders')).toBeInTheDocument();
+    expect(screen.getByText('262')).toBeInTheDocument();
+    expect(screen.getByText('agents')).toBeInTheDocument();
+  });
+
+  it('falls back to dashes when the new counts are absent', async () => {
+    mockAxiosGet.mockResolvedValue({ data: { activePods: 4 } });
+
+    renderLanding();
+
+    expect(await screen.findByText('active pods')).toBeInTheDocument();
+    expect(screen.getByText('builders').previousElementSibling).toHaveTextContent('—');
+    expect(screen.getByText('agents').previousElementSibling).toHaveTextContent('—');
+  });
+});

--- a/frontend/src/v2/__tests__/V2LandingPage.stats.test.tsx
+++ b/frontend/src/v2/__tests__/V2LandingPage.stats.test.tsx
@@ -38,7 +38,12 @@ describe('V2LandingPage proof stats', () => {
 
   it('renders only agent and activity stats', async () => {
     mockAxiosGet.mockResolvedValue({
-      data: { agents: 262, messageCount24h: 1234, activePods: 12 },
+      data: {
+        activePods: 12,
+        activeAgents: 3,
+        messageCount24h: 1234,
+        agentCount: 262,
+      },
     });
 
     renderLanding();

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -42,6 +42,8 @@ interface Stats {
   activePods?: number;
   activeAgents?: number;
   registeredUsers?: number;
+  humanCount?: number;
+  agentCount?: number;
 }
 
 const fmt = (n?: number): string => (typeof n === 'number' ? n.toLocaleString() : '—');
@@ -214,7 +216,13 @@ const V2LandingPage: React.FC = () => {
     if (p && typeof p.catch === 'function') p.catch(() => { /* poster stays */ });
   }, [motion]);
 
-  const hasStats = Boolean(stats && (stats.activePods || stats.activeAgents || stats.registeredUsers));
+  const hasStats = Boolean(stats && (
+    stats.activePods
+    || stats.activeAgents
+    || stats.registeredUsers
+    || stats.humanCount
+    || stats.agentCount
+  ));
 
   return (
     <div className={`v2-root v2-landing${motion ? ' v2-landing--motion' : ''}`}>
@@ -545,8 +553,8 @@ const V2LandingPage: React.FC = () => {
             {hasStats && (
               <div className="v2-landing__proof-stats">
                 <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{fmt(stats?.activePods)}</span><span className="v2-landing__proof-label">active pods</span></div>
-                <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{fmt(stats?.activeAgents)}</span><span className="v2-landing__proof-label">agents connected</span></div>
-                <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{fmt(stats?.registeredUsers)}</span><span className="v2-landing__proof-label">people</span></div>
+                <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{fmt(stats?.agentCount)}</span><span className="v2-landing__proof-label">agents</span></div>
+                <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{fmt(stats?.humanCount)}</span><span className="v2-landing__proof-label">builders</span></div>
                 <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{ADR_COUNT}</span><span className="v2-landing__proof-label">ADRs</span></div>
               </div>
             )}

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -40,10 +40,8 @@ const Mark: React.FC<{ size?: number }> = ({ size = 26 }) => (
 
 interface Stats {
   activePods?: number;
-  activeAgents?: number;
-  registeredUsers?: number;
-  humanCount?: number;
-  agentCount?: number;
+  messageCount24h?: number;
+  agents?: number;
 }
 
 const fmt = (n?: number): string => (typeof n === 'number' ? n.toLocaleString() : '—');
@@ -218,10 +216,8 @@ const V2LandingPage: React.FC = () => {
 
   const hasStats = Boolean(stats && (
     stats.activePods
-    || stats.activeAgents
-    || stats.registeredUsers
-    || stats.humanCount
-    || stats.agentCount
+    || stats.messageCount24h
+    || stats.agents
   ));
 
   return (
@@ -552,10 +548,9 @@ const V2LandingPage: React.FC = () => {
             </p>
             {hasStats && (
               <div className="v2-landing__proof-stats">
+                <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{fmt(stats?.agents)}</span><span className="v2-landing__proof-label">agents</span></div>
+                <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{fmt(stats?.messageCount24h)}</span><span className="v2-landing__proof-label">messages / 24h</span></div>
                 <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{fmt(stats?.activePods)}</span><span className="v2-landing__proof-label">active pods</span></div>
-                <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{fmt(stats?.agentCount)}</span><span className="v2-landing__proof-label">agents</span></div>
-                <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{fmt(stats?.humanCount)}</span><span className="v2-landing__proof-label">builders</span></div>
-                <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{ADR_COUNT}</span><span className="v2-landing__proof-label">ADRs</span></div>
               </div>
             )}
           </div>

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -40,8 +40,9 @@ const Mark: React.FC<{ size?: number }> = ({ size = 26 }) => (
 
 interface Stats {
   activePods?: number;
+  activeAgents?: number;
   messageCount24h?: number;
-  agents?: number;
+  agentCount?: number;
 }
 
 const fmt = (n?: number): string => (typeof n === 'number' ? n.toLocaleString() : '—');
@@ -217,7 +218,7 @@ const V2LandingPage: React.FC = () => {
   const hasStats = Boolean(stats && (
     stats.activePods
     || stats.messageCount24h
-    || stats.agents
+    || stats.agentCount
   ));
 
   return (
@@ -548,7 +549,7 @@ const V2LandingPage: React.FC = () => {
             </p>
             {hasStats && (
               <div className="v2-landing__proof-stats">
-                <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{fmt(stats?.agents)}</span><span className="v2-landing__proof-label">agents</span></div>
+                <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{fmt(stats?.agentCount)}</span><span className="v2-landing__proof-label">agents</span></div>
                 <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{fmt(stats?.messageCount24h)}</span><span className="v2-landing__proof-label">messages / 24h</span></div>
                 <div className="v2-landing__proof-stat"><span className="v2-landing__proof-num">{fmt(stats?.activePods)}</span><span className="v2-landing__proof-label">active pods</span></div>
               </div>


### PR DESCRIPTION
## Summary
- expose agent identities as `agentCount` while retaining package-level `activeAgents` for existing activity consumers
- narrow `/api/stats/public` to exactly `{ activePods, activeAgents, messageCount24h, agentCount }`
- omit both `humanCount` and `registeredUsers`, preventing recovery of a human total by subtracting agents from total users
- render only agent identities, messages per 24 hours, and active pods on the landing proof strip
- preserve the PostgreSQL-primary message count and Mongo fallback behavior

## Privacy / omission invariant
Human counts stay admin-only. The route test pins the exact four-field response and explicitly asserts that `humanCount` and `registeredUsers` are absent. `activeAgents` is a distinct-package activity count and does not expose or enable derivation of the human total.

## Deliberate API change
A repository-wide consumer scan found the v2 landing page is the only in-repo consumer of `/api/stats/public`. Removing `registeredUsers` is an intentional pre-GTM breaking change; self-hosted tooling that consumed the undocumented public field will need to stop doing so. Keeping it for compatibility would defeat the omission decision because `registeredUsers - agentCount` reveals the human count.

## Verification
- backend stats route: 3/3 tests passed
- landing proof stats: 1/1 render test passed
- backend `tsc:check`: passed
- focused ESLint: 0 errors
- `git diff --check`: passed
- real browser at 1280×900 and 390×844: exactly three tiles visible, no horizontal overflow

## Existing repository check debt
- repository-wide backend lint still reports the pre-existing baseline; no changed JS file has a lint error, and the changed TypeScript route passes `tsc:check`
- full frontend typecheck still reports three current-main errors in `V2GithubPrCard.tsx` and `V2MessageBubble.tsx`; this PR adds no type errors

Fixes #689