### PR TITLE
feat(community): official Discord — invite in feedback menu + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ Issues tagged [`good first issue`](https://github.com/Team-Commonly/commonly/iss
 
 ## Community & Support
 
+- **Discord:** [join the community](https://discord.gg/NsS3fzsJDw)
 - **Issues & features:** [GitHub Issues](https://github.com/Team-Commonly/commonly/issues)
 - **Security:** [SECURITY.md](SECURITY.md)
 - **Discussions:** [GitHub Discussions](https://github.com/Team-Commonly/commonly/discussions)

--- a/frontend/src/v2/components/V2FeedbackMenu.tsx
+++ b/frontend/src/v2/components/V2FeedbackMenu.tsx
@@ -3,12 +3,14 @@ import { Popover } from '@mui/material';
 import BugReportOutlinedIcon from '@mui/icons-material/BugReportOutlined';
 import FeedbackOutlinedIcon from '@mui/icons-material/FeedbackOutlined';
 import LightbulbOutlinedIcon from '@mui/icons-material/LightbulbOutlined';
+import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
 import QuestionAnswerOutlinedIcon from '@mui/icons-material/QuestionAnswerOutlined';
 import { useLocation } from 'react-router-dom';
 import {
   buildBugReportUrl,
   buildFeatureRequestUrl,
   DISCUSSIONS_QA_URL,
+  DISCORD_INVITE_URL,
 } from '../utils/feedbackLinks';
 
 const V2FeedbackMenu: React.FC = () => {
@@ -77,6 +79,16 @@ const V2FeedbackMenu: React.FC = () => {
           >
             <QuestionAnswerOutlinedIcon aria-hidden="true" />
             <span>Ask a question</span>
+          </a>
+          <a
+            className="v2-feedback-menu__item"
+            href={DISCORD_INVITE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleClose}
+          >
+            <ForumOutlinedIcon aria-hidden="true" />
+            <span>Join our Discord</span>
           </a>
         </nav>
       </Popover>

--- a/frontend/src/v2/utils/feedbackLinks.ts
+++ b/frontend/src/v2/utils/feedbackLinks.ts
@@ -15,3 +15,6 @@ export const buildFeatureRequestUrl = (): string => {
   url.searchParams.set('template', 'feature_request.yml');
   return url.toString();
 };
+
+// Official community Discord (permanent invite, created 2026-07-19).
+export const DISCORD_INVITE_URL = 'https://discord.gg/NsS3fzsJDw';


### PR DESCRIPTION
Community server is live (built via computer-use on Sam's account): #welcome/#announcements/#general/#show-your-agents/#support/#self-hosting, permanent invite discord.gg/NsS3fzsJDw. This PR surfaces it in the in-app feedback menu ('Join our Discord') and the README Community & Support section. 30/30 v2 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9