### PR TITLE
feat(community): Discord on the landing footer + README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ no per-agent fees, no lock-in.
 [![Tests](https://github.com/Team-Commonly/commonly/actions/workflows/tests.yml/badge.svg)](https://github.com/Team-Commonly/commonly/actions/workflows/tests.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/NsS3fzsJDw)
 
 `Open-source (Apache 2.0)` · `Self-host in one command` · `Any runtime` · `No per-agent fees`
 

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -26,6 +26,7 @@ import agentIdentityImg from '../../assets/landing/agent-identity.png';
 // bounds. Self-wraps in .v2-root so tokens apply wherever it mounts.
 
 const REPO = 'https://github.com/Team-Commonly/commonly';
+const DISCORD_INVITE_URL = 'https://discord.gg/NsS3fzsJDw';
 const X_HANDLE = 'https://x.com/sam_commonly';
 const ADR_COUNT = 15;
 
@@ -664,6 +665,12 @@ const V2LandingPage: React.FC = () => {
             <a className="v2-landing__footer-link" href={REPO} target="_blank" rel="noreferrer">GitHub</a>
             <a className="v2-landing__footer-link" href={`${REPO}/tree/main/docs/adr`} target="_blank" rel="noreferrer">ADRs</a>
             <a className="v2-landing__footer-link" href={`${REPO}/blob/main/CONTRIBUTING.md`} target="_blank" rel="noreferrer">Contributing</a>
+          </div>
+          <div className="v2-landing__footer-col">
+            <div className="v2-landing__footer-title">Community</div>
+            <a className="v2-landing__footer-link" href={DISCORD_INVITE_URL} target="_blank" rel="noreferrer">Discord</a>
+            <a className="v2-landing__footer-link" href={`${REPO}/discussions`} target="_blank" rel="noreferrer">Discussions</a>
+            <a className="v2-landing__footer-link" href="https://x.com/sam_commonly" target="_blank" rel="noreferrer">X / Twitter</a>
           </div>
           <div className="v2-landing__footer-col">
             <div className="v2-landing__footer-title">Legal</div>


### PR DESCRIPTION
Follow-up to #694 per Sam: the invite shouldn't live only in the authed feedback menu. Adds a Community column to the landing footer (Discord · Discussions · X) and the Discord badge to the README badge row. 30/30 v2 tests, 0 lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9