### PR TITLE
fix(agents): touch lastActive on runtime-token auth — agents no longer show 'never active'

### DIFF
--- a/backend/__tests__/unit/middleware/agentRuntimeAuth.test.js
+++ b/backend/__tests__/unit/middleware/agentRuntimeAuth.test.js
@@ -9,6 +9,7 @@
 // `mock` (Jest's hoisting-safety allow-list), so every mock binding here is
 // prefixed accordingly.
 
+jest.mock('../../../middleware/auth', () => ({ touchLastActive: jest.fn() }));
 const mockSecret = { hash: jest.fn(), randomSecret: jest.fn() };
 jest.mock('../../../utils/secret', () => mockSecret);
 

--- a/backend/middleware/agentRuntimeAuth.ts
+++ b/backend/middleware/agentRuntimeAuth.ts
@@ -1,6 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
 import { AgentInstallation } from '../models/AgentRegistry';
 import User, { IUser } from '../models/User';
+// Throttled fail-open lastActive writer (shared with human auth — see #668).
+// Without this, every runtime-token agent's User.lastActive stays frozen at
+// its creation date, so profiles/rosters show working agents as never active.
+import { touchLastActive } from './auth';
 import Pod from '../models/Pod';
 
 // eslint-disable-next-line global-require
@@ -92,6 +96,7 @@ export default async function agentRuntimeAuth(req: Request, res: Response, next
       const authorizedPodIds = Array.from(new Set([...installationPodIds, ...dmPodIds]));
 
       req.agentUser = agentUser;
+      touchLastActive(String(agentUser._id));
       req.agentInstallations = installations as never[];
       req.agentAuthorizedPodIds = authorizedPodIds;
       req.agentInstallation = (installations[0] as never) || null;
@@ -157,6 +162,7 @@ export default async function agentRuntimeAuth(req: Request, res: Response, next
       });
       if (botUser) {
         req.agentUser = botUser;
+        touchLastActive(String(botUser._id));
       }
     } catch (err: unknown) {
       console.warn('[agentRuntimeAuth] failed to resolve bot user for legacy token path:', (err as Error).message);


### PR DESCRIPTION
Sam noticed codex-impl showing 'never live' while it was actively shipping PRs. Root cause: `agentRuntimeAuth` (the path every runtime-token request takes) never updates `User.lastActive`, so all BYO/runtime agents stay frozen at their creation date on every surface that renders activity. Fix reuses #668's throttled fail-open `touchLastActive` at both agentUser assignment points. Tests mock the writer; 2/2 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnRCAFgjrrGZxo9VRCmCm9