### PR TITLE
feat: guide first agent connection

### DIFF
--- a/backend/__tests__/unit/routes/users.agent-connection.test.js
+++ b/backend/__tests__/unit/routes/users.agent-connection.test.js
@@ -1,0 +1,146 @@
+const request = require('supertest');
+const express = require('express');
+
+const mockInstallationFind = jest.fn();
+const mockUserFind = jest.fn();
+
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { find: mockInstallationFind },
+}));
+
+jest.mock('../../../models/User', () => ({
+  find: mockUserFind,
+}));
+
+jest.mock('../../../services/agentIdentityService', () => ({
+  resolveAgentType: jest.fn((agentName) => agentName.toLowerCase()),
+}));
+
+jest.mock('../../../controllers/userController', () => ({
+  getCurrentProfile: jest.fn(),
+  updateProfile: jest.fn(),
+  getUserById: jest.fn(),
+  getUserPublicActivity: jest.fn(),
+  followUser: jest.fn(),
+  unfollowUser: jest.fn(),
+}));
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  if (req.header('Authorization') !== 'Bearer human-token') {
+    return res.status(401).json({ msg: 'No token, authorization denied' });
+  }
+  req.userId = 'human-1';
+  return next();
+});
+
+// eslint-disable-next-line import/no-unresolved, import/extensions
+const routes = require('../../../routes/users');
+
+const query = (value) => ({
+  select: jest.fn().mockReturnValue({
+    lean: jest.fn().mockResolvedValue(value),
+  }),
+});
+
+describe('GET /api/users/me/agent-connection', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/users', routes);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInstallationFind.mockReturnValue(query([]));
+    mockUserFind.mockReturnValue(query([]));
+  });
+
+  it('requires human authentication', async () => {
+    const res = await request(app).get('/api/users/me/agent-connection');
+
+    expect(res.status).toBe(401);
+    expect(mockInstallationFind).not.toHaveBeenCalled();
+  });
+
+  it('reports an unissued connection when the user has no active agent installations', async () => {
+    const res = await request(app)
+      .get('/api/users/me/agent-connection')
+      .set('Authorization', 'Bearer human-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      issued: false,
+      connected: false,
+      lastUsedAt: null,
+      connectedAgent: null,
+    });
+    expect(res.headers).toHaveProperty('ratelimit-policy');
+    expect(mockInstallationFind).toHaveBeenCalledWith({ installedBy: 'human-1', status: 'active' });
+    expect(mockUserFind).not.toHaveBeenCalled();
+  });
+
+  it('reports an owned active installation that has not connected yet', async () => {
+    mockInstallationFind.mockReturnValue(query([
+      { agentName: 'OpenClaw', instanceId: 'Aria', podId: 'workspace-1' },
+    ]));
+    mockUserFind.mockReturnValue(query([
+      { agentRuntimeTokens: [{ createdAt: new Date('2026-07-21T10:00:00.000Z') }] },
+    ]));
+
+    const res = await request(app)
+      .get('/api/users/me/agent-connection')
+      .set('Authorization', 'Bearer human-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      issued: true,
+      connected: false,
+      lastUsedAt: null,
+      connectedAgent: null,
+    });
+    expect(mockUserFind).toHaveBeenCalledWith({
+      isBot: true,
+      $or: [{
+        'botMetadata.agentName': 'openclaw',
+        'botMetadata.instanceId': 'aria',
+      }],
+    });
+  });
+
+  it('reports the most recent connection without returning token material', async () => {
+    mockInstallationFind.mockReturnValue(query([
+      { agentName: 'openclaw', instanceId: 'aria', podId: 'workspace-1' },
+      { agentName: 'codex', instanceId: 'default', podId: 'workspace-2' },
+    ]));
+    mockUserFind.mockReturnValue(query([
+      {
+        botMetadata: { agentName: 'openclaw', instanceId: 'aria' },
+        agentRuntimeTokens: [
+          { tokenHash: 'never-return-this', lastUsedAt: new Date('2026-07-21T10:00:00.000Z') },
+        ],
+      },
+      {
+        botMetadata: { agentName: 'codex', instanceId: 'default' },
+        agentRuntimeTokens: [
+          { tokenHash: 'or-this', lastUsedAt: new Date('2026-07-21T12:00:00.000Z') },
+        ],
+      },
+    ]));
+
+    const res = await request(app)
+      .get('/api/users/me/agent-connection')
+      .set('Authorization', 'Bearer human-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      issued: true,
+      connected: true,
+      lastUsedAt: '2026-07-21T12:00:00.000Z',
+      connectedAgent: {
+        agentName: 'codex',
+        instanceId: 'default',
+        podId: 'workspace-2',
+      },
+    });
+    expect(JSON.stringify(res.body)).not.toContain('token');
+    expect(JSON.stringify(res.body)).not.toContain('hash');
+  });
+});

--- a/backend/models/AgentRegistry.ts
+++ b/backend/models/AgentRegistry.ts
@@ -257,6 +257,10 @@ const AgentInstallationSchema = new Schema<IAgentInstallationRegistry>(
 
 AgentInstallationSchema.index({ agentName: 1, podId: 1, instanceId: 1 }, { unique: true });
 AgentInstallationSchema.index({ podId: 1, status: 1 });
+// First-run connection status polls active installs by their human owner.
+// Keep that ownership lookup indexed so the 3s UI poll never scans the full
+// installation collection as the marketplace grows.
+AgentInstallationSchema.index({ installedBy: 1, status: 1 });
 
 AgentInstallationSchema.statics.getInstalledAgents = function (podId: Types.ObjectId) {
   return this.find({ podId, status: 'active' }).lean();

--- a/backend/routes/users.ts
+++ b/backend/routes/users.ts
@@ -1,7 +1,17 @@
+// ESM imports keep CodeQL's missing-rate-limiting dataflow connected to the
+// DB-backed polling route below (same established pattern as messages.ts).
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import { createHash } from 'crypto';
 // eslint-disable-next-line global-require
 const express = require('express');
 // eslint-disable-next-line global-require
 const auth = require('../middleware/auth');
+// eslint-disable-next-line global-require
+const User = require('../models/User');
+// eslint-disable-next-line global-require
+const { AgentInstallation } = require('../models/AgentRegistry');
+// eslint-disable-next-line global-require
+const AgentIdentityService = require('../services/agentIdentityService');
 // eslint-disable-next-line global-require
 const {
   getCurrentProfile,
@@ -13,6 +23,107 @@ const {
 } = require('../controllers/userController');
 
 const router: ReturnType<typeof express.Router> = express.Router();
+
+const agentConnectionReadLimit = rateLimit({
+  windowMs: 60_000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req: { get?: (header: string) => string | undefined; ip?: string }) => {
+    const authHeader = req.get?.('authorization');
+    if (authHeader) {
+      return `agent-connection:${createHash('sha256').update(authHeader).digest('hex').slice(0, 16)}`;
+    }
+    return req.ip ? ipKeyGenerator(req.ip) : 'anon';
+  },
+  handler: (_req: unknown, res: any) => res.status(429).json({
+    msg: 'rate limit exceeded: 60 agent connection reads per 60s',
+  }),
+});
+
+router.get('/me/agent-connection', agentConnectionReadLimit, auth, async (req: any, res: any) => {
+  try {
+    const userId = req.userId || req.user?.id || req.user?._id;
+    if (!userId) return res.status(401).json({ msg: 'Unauthorized' });
+
+    // Runtime tokens belong to durable agent User identities, not to the
+    // installing human. Restrict the lookup through installations owned by
+    // this caller so the endpoint can never disclose another user's agent
+    // activity (or any token material).
+    const installations = await AgentInstallation.find({
+      installedBy: userId,
+      status: 'active',
+    })
+      .select('agentName instanceId podId')
+      .lean();
+
+    const installationsByIdentity = new Map((installations || []).map((installation: any) => {
+      const agentName = String(installation.agentName || '').trim().toLowerCase();
+      const instanceId = String(installation.instanceId || 'default').trim().toLowerCase();
+      const identityAgentName = AgentIdentityService.resolveAgentType(agentName);
+      return [`${identityAgentName}:${instanceId}`, {
+        agentName,
+        instanceId,
+        podId: String(installation.podId || ''),
+        identityAgentName,
+      }];
+    }));
+    const identities = Array.from(installationsByIdentity.values())
+      .filter((identity: any) => identity.agentName);
+
+    if (identities.length === 0) {
+      return res.json({
+        issued: false,
+        connected: false,
+        lastUsedAt: null,
+        connectedAgent: null,
+      });
+    }
+
+    const agentUsers = await User.find({
+      isBot: true,
+      $or: identities.map((identity: any) => ({
+        'botMetadata.agentName': identity.identityAgentName,
+        'botMetadata.instanceId': identity.instanceId,
+      })),
+    })
+      .select('botMetadata.agentName botMetadata.instanceId agentRuntimeTokens.lastUsedAt')
+      .lean();
+
+    let latestConnection: { usedAt: Date; identity: any } | null = null;
+    for (const agentUser of agentUsers || []) {
+      const agentName = String(agentUser.botMetadata?.agentName || '').trim().toLowerCase();
+      const instanceId = String(agentUser.botMetadata?.instanceId || 'default').trim().toLowerCase();
+      const identity = installationsByIdentity.get(`${agentName}:${instanceId}`);
+      if (!identity) continue;
+      for (const token of agentUser.agentRuntimeTokens || []) {
+        if (!token?.lastUsedAt) continue;
+        const usedAt = new Date(token.lastUsedAt);
+        if (Number.isNaN(usedAt.getTime())) continue;
+        if (!latestConnection || usedAt > latestConnection.usedAt) {
+          latestConnection = { usedAt, identity };
+        }
+      }
+    }
+
+    return res.json({
+      // "Issued" is deliberately installation ownership, not pod membership
+      // or token presence. Joining an agent-rich community pod must not make a
+      // newcomer look onboarded when they have attached nothing themselves.
+      issued: true,
+      connected: latestConnection !== null,
+      lastUsedAt: latestConnection ? latestConnection.usedAt.toISOString() : null,
+      connectedAgent: latestConnection ? {
+        agentName: latestConnection.identity.agentName,
+        instanceId: latestConnection.identity.instanceId,
+        podId: latestConnection.identity.podId,
+      } : null,
+    });
+  } catch (error) {
+    console.error('Error reading agent connection status:', error);
+    return res.status(500).json({ error: 'Failed to read agent connection status' });
+  }
+});
 
 router.get('/profile', auth, getCurrentProfile);
 router.put('/profile', auth, updateProfile);

--- a/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
+++ b/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
@@ -1,0 +1,249 @@
+/* eslint-disable react/display-name */
+import React from 'react';
+import {
+  act, fireEvent, render, screen, waitFor,
+} from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import V2FirstRunHero, {
+  FIRST_RUN_DISMISSED_KEY,
+  FIRST_RUN_STARTED_KEY,
+} from '../components/V2FirstRunHero';
+import V2Layout from '../components/V2Layout';
+
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+const mockNavigate = jest.fn();
+const mockPodsState = {
+  pods: [],
+  loading: false,
+  error: null,
+  refresh: jest.fn(),
+  createPod: jest.fn(),
+  deletePod: jest.fn(),
+  patchLastMessage: jest.fn(),
+};
+
+jest.mock('../hooks/useV2Api', () => ({
+  useV2Api: () => ({
+    get: mockGet,
+    post: mockPost,
+    patch: jest.fn(),
+    del: jest.fn(),
+  }),
+}));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+jest.mock('../hooks/useV2Pods', () => ({
+  useV2Pods: () => mockPodsState,
+}));
+
+jest.mock('../hooks/useV2PodDetail', () => ({
+  useV2PodDetail: () => ({
+    pod: { _id: 'hq', name: 'Commonly HQ' },
+    members: [],
+    messages: [],
+    agents: [],
+    loading: false,
+    error: null,
+  }),
+}));
+
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ currentUser: { _id: 'human-1', username: 'new-human' } }),
+}));
+
+jest.mock('../components/V2NavRail', () => () => <nav>Rail</nav>);
+jest.mock('../components/V2PodsSidebar', () => () => <aside>Pods</aside>);
+jest.mock('../components/V2PodInspector', () => () => <aside>Inspector</aside>);
+jest.mock('../components/V2InviteModal', () => () => null);
+jest.mock('../components/V2PodChat', () => ({ firstRunHero }: { firstRunHero?: React.ReactNode }) => (
+  <main>
+    <span>Normal pod view</span>
+    {firstRunHero}
+  </main>
+));
+
+const unissued = {
+  issued: false,
+  connected: false,
+  lastUsedAt: null,
+  connectedAgent: null,
+};
+
+const connected = {
+  issued: true,
+  connected: true,
+  lastUsedAt: '2026-07-21T12:00:00.000Z',
+  connectedAgent: {
+    agentName: 'claude-code',
+    instanceId: 'my-claude',
+    podId: 'workspace-1',
+  },
+};
+
+const renderHero = () => render(
+  <MemoryRouter>
+    <V2FirstRunHero />
+  </MemoryRouter>,
+);
+
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+describe('V2FirstRunHero', () => {
+  const originalVisibility = Object.getOwnPropertyDescriptor(document, 'visibilityState');
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    localStorage.clear();
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+    mockGet.mockResolvedValue(unissued);
+    mockPost.mockResolvedValue({ room: { _id: 'room-1' } });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    if (originalVisibility) Object.defineProperty(document, 'visibilityState', originalVisibility);
+  });
+
+  test('keeps the setup visible while polling from waiting to connected, then opens the agent room', async () => {
+    mockGet
+      .mockResolvedValueOnce(unissued)
+      .mockResolvedValueOnce(connected);
+
+    renderHero();
+    await flush();
+
+    expect(screen.getByText('Waiting for your agent to connect…')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open connection setup/i })).toHaveAttribute('target', '_blank');
+
+    await act(async () => {
+      jest.advanceTimersByTime(3_000);
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText('✓ Connected')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Say hello' }));
+    await flush();
+
+    expect(mockPost).toHaveBeenCalledWith('/api/agents/runtime/room', {
+      agentName: 'claude-code',
+      instanceId: 'my-claude',
+      podId: 'workspace-1',
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('/v2/pods/room-1');
+    expect(localStorage.getItem(FIRST_RUN_DISMISSED_KEY)).toBe('1');
+  });
+
+  test('stops polling after unmount', async () => {
+    const view = renderHero();
+    await flush();
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+    await act(async () => {
+      jest.advanceTimersByTime(9_000);
+      await Promise.resolve();
+    });
+
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
+  test('pauses polling while the tab is hidden and resumes when visible', async () => {
+    renderHero();
+    await flush();
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await act(async () => {
+      jest.advanceTimersByTime(6_000);
+      await Promise.resolve();
+    });
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await flush();
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+
+  test('an established owner does not see first-run again unless setup was already started', async () => {
+    mockGet.mockResolvedValue({ ...connected, connected: false, connectedAgent: null });
+    renderHero();
+
+    // The ownership probe must not flash the onboarding card while it resolves.
+    expect(screen.queryByRole('heading', { name: 'Bring your agent into the room' })).not.toBeInTheDocument();
+    await flush();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: 'Bring your agent into the room' })).not.toBeInTheDocument();
+    });
+  });
+
+  test('dismissal persists and avoids starting the poll', async () => {
+    localStorage.setItem(FIRST_RUN_DISMISSED_KEY, '1');
+    renderHero();
+    await flush();
+
+    expect(screen.queryByRole('heading', { name: 'Bring your agent into the room' })).not.toBeInTheDocument();
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  test('the started latch survives a reload until the connected CTA is used', async () => {
+    localStorage.setItem(FIRST_RUN_STARTED_KEY, '1');
+    mockGet.mockResolvedValue(connected);
+    renderHero();
+    await flush();
+
+    expect(await screen.findByRole('button', { name: 'Say hello' })).toBeInTheDocument();
+  });
+});
+
+describe('V2Layout first-run placement', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    localStorage.clear();
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+    mockGet.mockResolvedValue(unissued);
+    mockPodsState.pods = [{
+      _id: 'hq',
+      name: 'Commonly HQ',
+      members: [
+        { _id: 'human-1', username: 'new-human' },
+        { _id: 'someone-elses-agent', username: 'support', isBot: true },
+      ],
+    }];
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('shows onboarding inside an agent-rich pod when the human owns no installation', async () => {
+    render(
+      <MemoryRouter initialEntries={['/v2/pods/hq']}>
+        <Routes>
+          <Route path="/v2/pods/:podId" element={<V2Layout selectionMode="param" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await flush();
+
+    expect(screen.getByText('Normal pod view')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Bring your agent into the room' })).toBeInTheDocument();
+    expect(mockGet).toHaveBeenCalledWith('/api/users/me/agent-connection');
+  });
+});

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -95,4 +95,24 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(rule).toContain('background: var(--v2-surface)');
     expect(rule).toContain('border: 1px solid var(--v2-border)');
   });
+
+  test('the first-run card and message pane shrink to the mobile content width', () => {
+    // The rail remains visible on phones, leaving ~326px at a 390px viewport.
+    // A fixed-width onboarding card would overflow behind the rail; both the
+    // card cap and reduced transcript gutter are load-bearing for that layout.
+    expect(ruleBody(v2, '.v2-first-run')).toContain('width: min(720px, 100%)');
+    expect(v2).toContain('.v2-chat__messages {\n    padding-inline: 14px');
+  });
+
+  test('the first-run setup CTA beats the global inherited anchor color', () => {
+    // `.v2-root a { color: inherit }` outranks a bare class selector. The
+    // first browser pass rendered blue text on the blue CTA until this
+    // compound selector matched/exceeded the reset specificity.
+    const rule = ruleBody(
+      v2,
+      '.v2-root a.v2-first-run__setup,\n.v2-root button.v2-first-run__hello',
+    );
+    expect(rule).toContain('background: var(--v2-accent)');
+    expect(rule).toContain('color: #fff');
+  });
 });

--- a/frontend/src/v2/components/V2FirstRunHero.tsx
+++ b/frontend/src/v2/components/V2FirstRunHero.tsx
@@ -1,0 +1,225 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useV2Api } from '../hooks/useV2Api';
+
+const POLL_INTERVAL_MS = 3_000;
+export const FIRST_RUN_DISMISSED_KEY = 'v2.firstRun.dismissed';
+export const FIRST_RUN_STARTED_KEY = 'v2.firstRun.started';
+
+interface ConnectedAgent {
+  agentName: string;
+  instanceId: string;
+  podId: string;
+}
+
+export interface AgentConnectionStatus {
+  issued: boolean;
+  connected: boolean;
+  lastUsedAt: string | null;
+  connectedAgent: ConnectedAgent | null;
+}
+
+const readFlag = (key: string): boolean => {
+  try {
+    return localStorage.getItem(key) === '1';
+  } catch {
+    return false;
+  }
+};
+
+const writeFlag = (key: string, value: boolean): void => {
+  try {
+    if (value) localStorage.setItem(key, '1');
+    else localStorage.removeItem(key);
+  } catch {
+    // Storage can be unavailable in private/sandboxed contexts. The current
+    // render still behaves correctly; only persistence is lost.
+  }
+};
+
+const StepMark: React.FC<{ done: boolean; children: React.ReactNode }> = ({ done, children }) => (
+  <span className={`v2-first-run__step-mark${done ? ' v2-first-run__step-mark--done' : ''}`} aria-hidden="true">
+    {done ? '✓' : children}
+  </span>
+);
+
+interface V2FirstRunHeroProps {
+  onVisibilityChange?: (visible: boolean) => void;
+}
+
+const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) => {
+  const api = useV2Api();
+  const navigate = useNavigate();
+  const [dismissed, setDismissed] = useState(() => readFlag(FIRST_RUN_DISMISSED_KEY));
+  // `engaged` is a session latch. Once a zero-install user sees the hero, an
+  // install appearing during the poll must advance the card to Waiting / Say
+  // hello rather than make it disappear mid-flow. The persisted started flag
+  // carries that latch across the BYO setup tab and a page reload.
+  const [engaged, setEngaged] = useState(() => readFlag(FIRST_RUN_STARTED_KEY));
+  const [status, setStatus] = useState<AgentConnectionStatus | null>(null);
+  const [statusError, setStatusError] = useState<string | null>(null);
+  const [openingRoom, setOpeningRoom] = useState(false);
+  const [roomError, setRoomError] = useState<string | null>(null);
+
+  const pollStatus = useCallback(async () => {
+    try {
+      const next = await api.get<AgentConnectionStatus>('/api/users/me/agent-connection');
+      setStatus(next);
+      setStatusError(null);
+      if (!next.issued) setEngaged(true);
+    } catch {
+      setStatusError('Connection status is temporarily unavailable. We’ll keep checking.');
+    }
+  }, [api]);
+
+  // Reserve the empty-state slot while the ownership probe is unresolved,
+  // but do not flash the full onboarding card for an established user.
+  const shouldProbe = !dismissed && (engaged || status === null || status.issued === false);
+  const visible = !dismissed && (engaged || status?.issued === false);
+
+  useEffect(() => {
+    onVisibilityChange?.(shouldProbe);
+  }, [onVisibilityChange, shouldProbe]);
+
+  useEffect(() => {
+    if (!shouldProbe || status?.connected) return undefined;
+
+    let active = true;
+    let timer: ReturnType<typeof setInterval> | null = null;
+    const run = () => {
+      if (!active) return;
+      void pollStatus();
+    };
+    const stop = () => {
+      if (timer) clearInterval(timer);
+      timer = null;
+    };
+    const start = (immediate: boolean) => {
+      stop();
+      if (document.visibilityState === 'hidden') return;
+      if (immediate) run();
+      timer = setInterval(run, POLL_INTERVAL_MS);
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') stop();
+      else start(true);
+    };
+
+    // The first mount checks immediately. A state-driven effect restart (for
+    // example issued:false arriving) only replaces the interval; firing again
+    // here would duplicate every initial status request.
+    start(status === null);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      active = false;
+      stop();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [pollStatus, shouldProbe, status?.connected]);
+
+  if (!visible) return null;
+
+  const openSetup = () => {
+    writeFlag(FIRST_RUN_STARTED_KEY, true);
+    setEngaged(true);
+  };
+
+  const dismiss = () => {
+    writeFlag(FIRST_RUN_DISMISSED_KEY, true);
+    writeFlag(FIRST_RUN_STARTED_KEY, false);
+    setDismissed(true);
+  };
+
+  const sayHello = async () => {
+    const agent = status?.connectedAgent;
+    if (!agent || openingRoom) return;
+    setOpeningRoom(true);
+    setRoomError(null);
+    try {
+      const data = await api.post<{ room?: { _id?: string } }>('/api/agents/runtime/room', {
+        agentName: agent.agentName,
+        instanceId: agent.instanceId,
+        podId: agent.podId,
+      });
+      const roomId = data.room?._id;
+      if (!roomId) throw new Error('Agent room not returned');
+      writeFlag(FIRST_RUN_DISMISSED_KEY, true);
+      writeFlag(FIRST_RUN_STARTED_KEY, false);
+      navigate(`/v2/pods/${roomId}`);
+    } catch (error) {
+      const message = (error as { response?: { data?: { message?: string } } })
+        ?.response?.data?.message;
+      setRoomError(message || 'Could not open your 1:1 yet. Try again.');
+      setOpeningRoom(false);
+    }
+  };
+
+  return (
+    <section className="v2-first-run" aria-labelledby="v2-first-run-title">
+      <div className="v2-first-run__eyebrow">Your first five minutes</div>
+      <div className="v2-first-run__heading-row">
+        <div>
+          <h2 id="v2-first-run-title" className="v2-first-run__title">Bring your agent into the room</h2>
+          <p className="v2-first-run__lede">
+            Connect Claude Code, Cursor, or Codex, then start a private conversation without leaving your workspace.
+          </p>
+        </div>
+        <button type="button" className="v2-first-run__skip" onClick={dismiss}>Skip for now</button>
+      </div>
+
+      <ol className="v2-first-run__steps">
+        <li className="v2-first-run__step">
+          <StepMark done={Boolean(status?.issued)}>1</StepMark>
+          <div className="v2-first-run__step-body">
+            <strong>Connect your agent</strong>
+            <span>Generate its private runtime token and copy the setup command for your tool.</span>
+            {!status?.issued && (
+              <a
+                className="v2-first-run__setup"
+                href="/v2/agents/byo"
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={openSetup}
+              >
+                Open connection setup
+                <span aria-hidden="true">↗</span>
+              </a>
+            )}
+          </div>
+        </li>
+
+        <li className="v2-first-run__step">
+          <StepMark done={Boolean(status?.connected)}>2</StepMark>
+          <div className="v2-first-run__step-body">
+            <strong>{status?.connected ? 'Connected' : 'Start your agent'}</strong>
+            <span className={status?.connected ? 'v2-first-run__connected' : ''} role="status" aria-live="polite">
+              {status?.connected ? '✓ Connected' : 'Waiting for your agent to connect…'}
+            </span>
+            {statusError && <span className="v2-first-run__error">{statusError}</span>}
+          </div>
+        </li>
+
+        <li className="v2-first-run__step">
+          <StepMark done={false}>3</StepMark>
+          <div className="v2-first-run__step-body">
+            <strong>Start with one hello</strong>
+            <span>Your agent gets its own durable identity and private 1:1 with you.</span>
+            {status?.connected && status.connectedAgent && (
+              <button
+                type="button"
+                className="v2-first-run__hello"
+                onClick={sayHello}
+                disabled={openingRoom}
+              >
+                {openingRoom ? 'Opening…' : 'Say hello'}
+              </button>
+            )}
+            {roomError && <span className="v2-first-run__error">{roomError}</span>}
+          </div>
+        </li>
+      </ol>
+    </section>
+  );
+};
+
+export default V2FirstRunHero;

--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -5,6 +5,7 @@ import V2PodsSidebar from './V2PodsSidebar';
 import V2PodChat from './V2PodChat';
 import V2PodInspector from './V2PodInspector';
 import V2InviteModal from './V2InviteModal';
+import V2FirstRunHero from './V2FirstRunHero';
 import { useV2Pods } from '../hooks/useV2Pods';
 import { useV2PodDetail } from '../hooks/useV2PodDetail';
 import { getSignedAttachmentUrl } from '../../utils/signedAttachmentUrl';
@@ -58,6 +59,10 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   // instead of a grid column; this owns its open/closed state. Desktop ignores
   // it entirely (the sidebar is always a visible column there).
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  // Assume visible until the ownership-status probe resolves. This prevents
+  // the legacy empty-state copy flashing underneath the onboarding card; an
+  // established/dismissed user flips it off as soon as the hero resolves.
+  const [firstRunVisible, setFirstRunVisible] = useState(true);
   const openMobileNav = useCallback(() => setMobileNavOpen(true), []);
   const closeMobileNav = useCallback(() => setMobileNavOpen(false), []);
   const toggleInspector = useCallback(() => {
@@ -150,6 +155,8 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
       <V2PodChat
         detail={detail}
         podsState={podsState}
+        firstRunHero={<V2FirstRunHero onVisibilityChange={setFirstRunVisible} />}
+        firstRunVisible={firstRunVisible}
         inspectorCollapsed={inspectorCollapsed}
         onToggleInspector={selectedPodId ? toggleInspector : undefined}
         onOpenMember={openInspectorMember}

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -117,6 +117,11 @@ const writeMode = (podId: string, mode: PodMode) => {
 interface V2PodChatProps {
   detail: UseV2PodDetailResult;
   podsState?: UseV2PodsResult;
+  // A status-gated onboarding card supplied by V2Layout. It sits inside the
+  // pod transcript rather than replacing the pod, so the workspace header,
+  // composer, task board, and mobile navigation remain reachable.
+  firstRunHero?: React.ReactNode;
+  firstRunVisible?: boolean;
   // Inspector wiring — when present, the avatar group becomes the "show team"
   // entry. Inspector itself is rendered by V2Layout so this is just the
   // hand-off point.
@@ -143,7 +148,7 @@ const Icon = ({ d }: { d: string }) => (
   </svg>
 );
 
-const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onToggleInspector, onOpenMember, onOpenInvite, onOpenFile, onOpenMobileNav }) => {
+const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVisible = false, inspectorCollapsed, onToggleInspector, onOpenMember, onOpenInvite, onOpenFile, onOpenMobileNav }) => {
   const { pod, members, messages, agents, sendMessage, loading, error } = detail;
   const navigate = useNavigate();
   const api = useV2Api();
@@ -711,10 +716,11 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, inspectorCollapsed, onTog
                   {error}
                 </div>
               )}
+              {firstRunHero}
               {loading && messages.length === 0 && (
                 <div className="v2-empty"><span className="v2-spinner" /></div>
               )}
-              {!loading && messages.length === 0 && (
+              {!firstRunVisible && !loading && messages.length === 0 && (
                 <div className="v2-empty">
                   {isBotToBot && botPair ? (
                     <>

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -1240,6 +1240,152 @@
   gap: 0;
 }
 
+/* First-run attach card lives inside the selected pod transcript instead of
+   replacing the pod shell. That keeps the workspace, composer, and mobile
+   drawer reachable while the agent connection status updates live. */
+.v2-first-run {
+  width: min(720px, 100%);
+  margin: 24px auto 16px;
+  padding: 28px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-lg);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+}
+
+.v2-first-run__eyebrow {
+  margin-bottom: 8px;
+  color: var(--v2-accent);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.v2-first-run__heading-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.v2-first-run__title {
+  margin: 0;
+  font-size: clamp(22px, 3vw, 30px);
+  line-height: 1.15;
+  letter-spacing: -0.025em;
+}
+
+.v2-first-run__lede {
+  max-width: 560px;
+  margin: 10px 0 0;
+  color: var(--v2-text-secondary);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.v2-root button.v2-first-run__skip {
+  flex-shrink: 0;
+  padding: 4px 0;
+  color: var(--v2-text-tertiary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.v2-root button.v2-first-run__skip:hover {
+  color: var(--v2-text-primary);
+}
+
+.v2-first-run__steps {
+  display: grid;
+  gap: 14px;
+  margin: 24px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.v2-first-run__step {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+  padding: 14px;
+  border-radius: var(--v2-radius);
+  background: var(--v2-bg-subtle);
+}
+
+.v2-first-run__step-mark {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--v2-border);
+  border-radius: 50%;
+  background: var(--v2-surface);
+  color: var(--v2-text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.v2-first-run__step-mark--done {
+  border-color: var(--v2-accent-soft);
+  background: var(--v2-accent-soft);
+  color: var(--v2-accent);
+}
+
+.v2-first-run__step-body {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+  color: var(--v2-text-secondary);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.v2-first-run__step-body strong {
+  color: var(--v2-text-primary);
+  font-size: 14px;
+}
+
+.v2-root a.v2-first-run__setup,
+.v2-root button.v2-first-run__hello {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  margin-top: 6px;
+  padding: 8px 12px;
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-accent);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.v2-root a.v2-first-run__setup:hover,
+.v2-root button.v2-first-run__hello:hover:not(:disabled) {
+  background: var(--v2-accent-strong);
+  color: #fff;
+}
+
+.v2-root button.v2-first-run__hello:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.v2-first-run__connected {
+  color: var(--v2-success);
+  font-weight: 700;
+}
+
+.v2-first-run__error {
+  color: var(--v2-danger);
+  font-size: 12px;
+}
+
 .v2-chat__error {
   padding: 9px 12px;
   border-radius: 8px;
@@ -4391,6 +4537,24 @@
   .v2-shell--no-inspector,
   .v2-shell--feature {
     grid-template-columns: var(--v2-rail-w) minmax(0, 1fr);
+  }
+
+  .v2-chat__messages {
+    padding-inline: 14px;
+  }
+
+  .v2-first-run {
+    margin-top: 14px;
+    padding: 20px 16px;
+  }
+
+  .v2-first-run__heading-row {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .v2-root button.v2-first-run__skip {
+    align-self: flex-start;
   }
 
   /* Hide secondary panes (e.g. the inspector) — but NOT the pods sidebar,


### PR DESCRIPTION
## Summary
- add an authenticated, token-safe agent connection status endpoint keyed to active installations owned by the current human
- add a dismissible three-step first-run guide inside the workspace chat, with visibility-aware polling and a Say hello handoff to the existing durable agent-room flow
- add responsive styling and layout invariants for desktop/mobile

## Design corrections
- Normal signup already creates My Workspace, so pod membership cannot identify the attach cliff. issued means the human owns at least one active AgentInstallation; membership in another user agent-rich pod does not count.
- Runtime tokens live on bot User identities, so the endpoint resolves the humans installations to those users without returning any token material. connectedAgent is included so Say hello can call the existing room endpoint.
- The guide stays inside the workspace pod instead of replacing it, keeping the composer, task board, and navigation reachable. The setup step links to the existing BYO flow because its command requires user-selected pod and agent name.

## Verification
- backend focused route suites: 7/7 passing
- backend TypeScript check: passing
- frontend focused onboarding/chat/layout suites: 20/20 passing
- frontend full suite: 53 suites, 232 tests passing
- frontend production build: passing
- focused ESLint: 0 errors (existing TSX filename warnings only)
- real-browser: 1280x900 and 390x844; no horizontal overflow, composer remains visible, CTA contrast verified

Part of #687 (PR 1: attach hero + live status). PR 2 will add the teaching empty states, HQ offer, and starter prompt chips.