### PR TITLE
feat: deliver daily digest emails

### DIFF
--- a/backend/__tests__/unit/routes/email.unsubscribe.test.js
+++ b/backend/__tests__/unit/routes/email.unsubscribe.test.js
@@ -1,0 +1,61 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../models/User', () => ({
+  findOneAndUpdate: jest.fn(),
+}));
+
+const User = require('../../../models/User');
+const emailRoutes = require('../../../routes/email');
+
+const app = express();
+app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
+app.use('/api/email', emailRoutes);
+
+describe('GET /api/email/unsubscribe/:token', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('turns daily digest email off for a valid token and returns confirmation HTML', async () => {
+    const token = 'a'.repeat(48);
+    User.findOneAndUpdate.mockResolvedValue({ _id: 'user-1' });
+
+    const response = await request(app)
+      .get(`/api/email/unsubscribe/${token}`)
+      .set('CF-Connecting-IP', '203.0.113.10');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toMatch(/text\/html/);
+    expect(response.text).toContain('Daily digests are off');
+    expect(User.findOneAndUpdate).toHaveBeenCalledWith(
+      { digestUnsubscribeToken: token },
+      { $set: { 'emailPreferences.dailyDigest': false } },
+      { new: true },
+    );
+  });
+
+  it('returns 404 for an invalid token without querying MongoDB', async () => {
+    const response = await request(app)
+      .get('/api/email/unsubscribe/not-a-token')
+      .set('CF-Connecting-IP', '203.0.113.11');
+
+    expect(response.status).toBe(404);
+    expect(User.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rate-limits repeated anonymous unsubscribe lookups', async () => {
+    User.findOneAndUpdate.mockResolvedValue(null);
+    const token = 'b'.repeat(48);
+    const responses = await Promise.all(Array.from({ length: 31 }, () => (
+      request(app)
+        .get(`/api/email/unsubscribe/${token}`)
+        .set('CF-Connecting-IP', '203.0.113.12')
+    )));
+    const rateLimited = responses.filter((response) => response.status === 429);
+
+    expect(rateLimited).toHaveLength(1);
+    expect(rateLimited[0].body).toEqual(expect.objectContaining({ code: 'rate_limited' }));
+    expect(User.findOneAndUpdate).toHaveBeenCalledTimes(30);
+  });
+});

--- a/backend/__tests__/unit/services/digestEmailService.test.js
+++ b/backend/__tests__/unit/services/digestEmailService.test.js
@@ -139,7 +139,7 @@ describe('digestEmailService', () => {
     expect((await Summary.findById(currentDigest._id)).metadata.emailedAt).toBeInstanceOf(Date);
   });
 
-  it('continues to later users when one email fails', async () => {
+  it('claims before SMTP and continues when one email fails without retrying it', async () => {
     const firstUser = await createUser();
     const secondUser = await createUser();
     const firstDigest = await createDigest(firstUser);
@@ -157,8 +157,14 @@ describe('digestEmailService', () => {
 
     expect(result).toEqual(expect.objectContaining({ sent: 1, failed: 1 }));
     expect(mockSendEmail).toHaveBeenCalledTimes(2);
-    expect((await Summary.findById(firstDigest._id)).metadata.emailedAt).toBeUndefined();
+    expect((await Summary.findById(firstDigest._id)).metadata.emailedAt).toBeInstanceOf(Date);
     expect((await Summary.findById(secondDigest._id)).metadata.emailedAt).toBeInstanceOf(Date);
+
+    await digestEmailService.sendDigestEmails([
+      runEntry(firstDigest),
+      runEntry(secondDigest),
+    ]);
+    expect(mockSendEmail).toHaveBeenCalledTimes(2);
   });
 
   it('logs once and skips the entire run when SMTP is unconfigured', async () => {

--- a/backend/__tests__/unit/services/digestEmailService.test.js
+++ b/backend/__tests__/unit/services/digestEmailService.test.js
@@ -1,0 +1,187 @@
+const mockSendEmail = jest.fn();
+jest.mock('../../../services/emailService', () => ({
+  sendEmail: mockSendEmail,
+}));
+// testUtils imports jsonwebtoken, whose transitive constant-time package is
+// incompatible with Node 26's removed SlowBuffer. No JWT behavior is used here.
+jest.mock('jsonwebtoken', () => ({}));
+
+const User = require('../../../models/User');
+const Summary = require('../../../models/Summary');
+const digestEmailService = require('../../../services/digestEmailService');
+const {
+  setupMongoDb,
+  closeMongoDb,
+  clearMongoDb,
+} = require('../../utils/testUtils');
+
+let sequence = 0;
+
+const createUser = async ({ verified = true, dailyDigest } = {}) => {
+  sequence += 1;
+  const values = {
+    username: `digest-user-${sequence}`,
+    email: `digest-${sequence}@example.com`,
+    password: 'Password123!',
+    verified,
+  };
+  if (dailyDigest !== undefined) {
+    values.emailPreferences = { dailyDigest };
+  }
+  return User.create(values);
+};
+
+const createDigest = (user, totalItems = 3, content = '- First update\n- Second update') => Summary.create({
+  type: 'daily-digest',
+  title: `Daily Digest for ${user.username}`,
+  content,
+  timeRange: { start: new Date(Date.now() - 3600000), end: new Date() },
+  metadata: { totalItems, userId: String(user._id) },
+});
+
+const runEntry = (digest) => ({ success: true, digest });
+
+describe('digestEmailService', () => {
+  const originalEnv = process.env;
+
+  beforeAll(async () => {
+    await setupMongoDb();
+  });
+
+  afterAll(async () => {
+    process.env = originalEnv;
+    await closeMongoDb();
+  });
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      SMTP2GO_API_KEY: 'smtp-key',
+      SMTP2GO_FROM_EMAIL: 'hello@commonly.me',
+      FRONTEND_URL: 'https://commonly.me',
+      BACKEND_URL: 'https://api.commonly.me',
+    };
+    mockSendEmail.mockReset().mockResolvedValue({ data: { data: { succeeded: 1 } } });
+  });
+
+  afterEach(async () => {
+    await clearMongoDb();
+    jest.clearAllMocks();
+  });
+
+  it('emails a non-empty digest to a verified default-on user and stamps it', async () => {
+    const user = await createUser();
+    const digest = await createDigest(user, 2, '- <script>alert(1)</script>\n- A useful update');
+
+    const result = await digestEmailService.sendDigestEmails([runEntry(digest)]);
+
+    expect(result).toEqual(expect.objectContaining({ eligible: 1, sent: 1, failed: 0 }));
+    expect(mockSendEmail).toHaveBeenCalledWith(expect.objectContaining({
+      to: user.email,
+      subject: digest.title,
+      textBody: expect.stringContaining('https://commonly.me/v2'),
+      htmlBody: expect.stringContaining('https://api.commonly.me/api/email/unsubscribe/'),
+    }));
+    expect(mockSendEmail.mock.calls[0][0].htmlBody).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(mockSendEmail.mock.calls[0][0].htmlBody).not.toContain('<script>alert(1)</script>');
+
+    const freshDigest = await Summary.findById(digest._id);
+    expect(freshDigest.metadata.emailedAt).toBeInstanceOf(Date);
+    const freshUser = await User.findById(user._id).select('+digestUnsubscribeToken');
+    expect(freshUser.emailPreferences.dailyDigest).toBe(true);
+    expect(freshUser.digestUnsubscribeToken).toMatch(/^[a-f0-9]{48}$/);
+  });
+
+  it('never sends an empty digest', async () => {
+    const user = await createUser();
+    const digest = await createDigest(user, 0);
+
+    const result = await digestEmailService.sendDigestEmails([runEntry(digest)]);
+
+    expect(result).toEqual(expect.objectContaining({ eligible: 0, sent: 0 }));
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it('skips unverified and unsubscribed users', async () => {
+    const unverified = await createUser({ verified: false });
+    const unsubscribed = await createUser({ dailyDigest: false });
+    const digests = await Promise.all([
+      createDigest(unverified),
+      createDigest(unsubscribed),
+    ]);
+
+    const result = await digestEmailService.sendDigestEmails(digests.map(runEntry));
+
+    expect(result).toEqual(expect.objectContaining({ eligible: 2, sent: 0, skipped: 2 }));
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it('does not send a stamped digest again when the same run is retried', async () => {
+    const user = await createUser();
+    const digest = await createDigest(user);
+    const currentRun = [runEntry(digest)];
+
+    await digestEmailService.sendDigestEmails(currentRun);
+    await digestEmailService.sendDigestEmails(currentRun);
+
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not sweep an older unemailed digest outside the current run', async () => {
+    const user = await createUser();
+    const historicalDigest = await createDigest(user, 2, '- Yesterday');
+    const currentDigest = await createDigest(user, 2, '- Today');
+
+    await digestEmailService.sendDigestEmails([runEntry(currentDigest)]);
+
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect((await Summary.findById(historicalDigest._id)).metadata.emailedAt).toBeUndefined();
+    expect((await Summary.findById(currentDigest._id)).metadata.emailedAt).toBeInstanceOf(Date);
+  });
+
+  it('continues to later users when one email fails', async () => {
+    const firstUser = await createUser();
+    const secondUser = await createUser();
+    const firstDigest = await createDigest(firstUser);
+    const secondDigest = await createDigest(secondUser);
+    mockSendEmail.mockImplementation(({ to }) => (
+      to === firstUser.email
+        ? Promise.reject(new Error('SMTP rejected recipient'))
+        : Promise.resolve({ data: { data: { succeeded: 1 } } })
+    ));
+
+    const result = await digestEmailService.sendDigestEmails([
+      runEntry(firstDigest),
+      runEntry(secondDigest),
+    ]);
+
+    expect(result).toEqual(expect.objectContaining({ sent: 1, failed: 1 }));
+    expect(mockSendEmail).toHaveBeenCalledTimes(2);
+    expect((await Summary.findById(firstDigest._id)).metadata.emailedAt).toBeUndefined();
+    expect((await Summary.findById(secondDigest._id)).metadata.emailedAt).toBeInstanceOf(Date);
+  });
+
+  it('logs once and skips the entire run when SMTP is unconfigured', async () => {
+    delete process.env.SMTP2GO_API_KEY;
+    const user = await createUser();
+    const digest = await createDigest(user);
+
+    await expect(digestEmailService.sendDigestEmails([runEntry(digest)]))
+      .resolves.toEqual(expect.objectContaining({ unconfigured: true, sent: 0 }));
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('also treats a missing sender address as unconfigured', async () => {
+    delete process.env.SMTP2GO_FROM_EMAIL;
+    const user = await createUser();
+    const digest = await createDigest(user);
+
+    await expect(digestEmailService.sendDigestEmails([runEntry(digest)]))
+      .resolves.toEqual(expect.objectContaining({ unconfigured: true, sent: 0 }));
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/__tests__/unit/services/emailService.test.js
+++ b/backend/__tests__/unit/services/emailService.test.js
@@ -1,0 +1,61 @@
+jest.mock('axios', () => ({ post: jest.fn() }));
+
+const axios = require('axios');
+const {
+  EmailNotConfiguredError,
+  sendEmail,
+} = require('../../../services/emailService');
+
+describe('emailService', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.SMTP2GO_API_KEY;
+    delete process.env.SMTP2GO_BASE_URL;
+    process.env.SMTP2GO_FROM_EMAIL = 'hello@commonly.me';
+    process.env.SMTP2GO_FROM_NAME = 'Commonly';
+    axios.post.mockReset();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('throws a typed error without an SMTP2GO API key and makes no network call', async () => {
+    await expect(sendEmail({
+      to: 'person@example.com',
+      subject: 'Hello',
+      textBody: 'Plain text',
+      htmlBody: '<p>Plain text</p>',
+    })).rejects.toBeInstanceOf(EmailNotConfiguredError);
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  it('sends the shared SMTP2GO payload with the configured endpoint', async () => {
+    process.env.SMTP2GO_API_KEY = 'smtp-key';
+    process.env.SMTP2GO_BASE_URL = 'https://smtp.example/v3/';
+    axios.post.mockResolvedValue({ data: { data: { succeeded: 1 } } });
+
+    await sendEmail({
+      to: 'person@example.com',
+      subject: 'Daily digest',
+      textBody: 'Plain text',
+      htmlBody: '<p>Plain text</p>',
+    });
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://smtp.example/v3/email/send',
+      {
+        api_key: 'smtp-key',
+        to: ['person@example.com'],
+        sender: 'hello@commonly.me',
+        from_name: 'Commonly',
+        subject: 'Daily digest',
+        text_body: 'Plain text',
+        html_body: '<p>Plain text</p>',
+      },
+      { timeout: 30000 },
+    );
+  });
+});

--- a/backend/__tests__/unit/services/schedulerService.digestEmail.test.js
+++ b/backend/__tests__/unit/services/schedulerService.digestEmail.test.js
@@ -1,0 +1,69 @@
+const mockScheduledCallbacks = new Map();
+
+jest.mock('node-cron', () => ({
+  schedule: jest.fn((expression, callback) => {
+    mockScheduledCallbacks.set(expression, callback);
+    return { start: jest.fn(), stop: jest.fn() };
+  }),
+}));
+jest.mock('../../../services/agentProvisionerServiceK8s', () => ({
+  refreshCodexOAuthTokenIfNeeded: jest.fn(),
+}));
+jest.mock('../../../services/summarizerService', () => ({}));
+jest.mock('../../../models/Integration', () => ({}));
+jest.mock('../../../services/integrationSummaryService', () => ({}));
+jest.mock('../../../services/agentEventService', () => ({
+  getSessionResetIntervalHours: jest.fn(() => 24),
+}));
+jest.mock('../../../services/podAssetService', () => ({}));
+jest.mock('../../../services/externalFeedService', () => ({ syncExternalFeeds: jest.fn() }));
+jest.mock('../../../models/AgentRegistry', () => ({ AgentInstallation: {} }));
+jest.mock('../../../models/AgentEvent', () => ({}));
+jest.mock('../../../services/agentEnsembleService', () => ({}));
+jest.mock('../../../services/podCurationService', () => ({}));
+jest.mock('../../../services/agentAutoJoinService', () => ({}));
+jest.mock('../../../models/pg/Message', () => ({}));
+jest.mock('../../../models/Post', () => ({}));
+jest.mock('../../../services/skillsRefreshService', () => ({ refreshSkillsIndex: jest.fn() }));
+jest.mock('../../../services/chatSummarizerService', () => ({}));
+jest.mock('../../../services/dailyDigestService', () => ({
+  generateAllDailyDigests: jest.fn(),
+}));
+jest.mock('../../../services/digestEmailService', () => ({
+  sendDigestEmails: jest.fn(),
+}));
+
+const dailyDigestService = require('../../../services/dailyDigestService');
+const digestEmailService = require('../../../services/digestEmailService');
+const schedulerService = require('../../../services/schedulerService');
+
+describe('scheduler daily digest delivery', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockScheduledCallbacks.clear();
+    jest.clearAllMocks();
+    schedulerService.isRunning = false;
+    schedulerService.jobs = [];
+  });
+
+  afterEach(() => {
+    schedulerService.stop();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('delivers only the summaries returned by the current generation run', async () => {
+    const currentRun = [{ success: true, digest: { _id: 'digest-1' } }];
+    dailyDigestService.generateAllDailyDigests.mockResolvedValue(currentRun);
+    digestEmailService.sendDigestEmails.mockResolvedValue({ sent: 1 });
+    schedulerService.start();
+
+    const dailyDigestCallback = mockScheduledCallbacks.get('0 6 * * *');
+    await dailyDigestCallback();
+
+    expect(dailyDigestService.generateAllDailyDigests).toHaveBeenCalledTimes(1);
+    expect(digestEmailService.sendDigestEmails).toHaveBeenCalledWith(currentRun);
+    expect(dailyDigestService.generateAllDailyDigests.mock.invocationCallOrder[0])
+      .toBeLessThan(digestEmailService.sendDigestEmails.mock.invocationCallOrder[0]);
+  });
+});

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -1,14 +1,11 @@
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
-const axios = require('axios');
 const User = require('../models/User');
 const Pod = require('../models/Pod');
 const InvitationCode = require('../models/InvitationCode');
 const WaitlistRequest = require('../models/WaitlistRequest');
 const AgentIdentityService = require('../services/agentIdentityService');
-
-const SMTP2GO_BASE_URL = process.env.SMTP2GO_BASE_URL || 'https://api.smtp2go.com/v3';
-const SMTP2GO_SEND_URL = `${SMTP2GO_BASE_URL.replace(/\/$/, '')}/email/send`;
+const { sendEmail } = require('../services/emailService');
 
 const parseBooleanEnv = (value: any) => {
   if (value === undefined || value === null || value === '') return null;
@@ -258,15 +255,12 @@ exports.register = async (req: any, res: any) => {
           sender: process.env.SMTP2GO_FROM_EMAIL,
           fromName: process.env.SMTP2GO_FROM_NAME,
         });
-        const smtpRes = await axios.post(SMTP2GO_SEND_URL, {
-          api_key: process.env.SMTP2GO_API_KEY,
-          to: [email],
-          sender: process.env.SMTP2GO_FROM_EMAIL,
-          from_name: process.env.SMTP2GO_FROM_NAME || 'Commonly',
+        const smtpRes = await sendEmail({
+          to: email,
           subject: 'Verify Your Email - Commonly',
-          text_body: text,
-          html_body: html,
-        }, { timeout: 30000 });
+          textBody: text,
+          htmlBody: html,
+        });
         console.log('SMTP2GO send response:', smtpRes?.data);
       } catch (sendError: any) {
         console.error('SMTP2GO error during registration:', sendError?.response?.data || sendError.message);
@@ -439,15 +433,12 @@ exports.forgotPassword = async (req: any, res: any) => {
     );
     const resetUrl = `${process.env.FRONTEND_URL}/v2/reset-password?token=${token}`;
     try {
-      await axios.post(SMTP2GO_SEND_URL, {
-        api_key: process.env.SMTP2GO_API_KEY,
-        to: [user.email],
-        sender: process.env.SMTP2GO_FROM_EMAIL,
-        from_name: process.env.SMTP2GO_FROM_NAME || 'Commonly',
+      await sendEmail({
+        to: user.email,
         subject: 'Reset your password - Commonly',
-        text_body: `Reset your Commonly password (link valid for 1 hour): ${resetUrl}\n\nIf you didn't request this, ignore this email — your password is unchanged.`,
-        html_body: `<p>Reset your Commonly password (link valid for 1 hour):</p><a href="${resetUrl}">Reset password</a><p>If you didn't request this, ignore this email — your password is unchanged.</p>`,
-      }, { timeout: 30000 });
+        textBody: `Reset your Commonly password (link valid for 1 hour): ${resetUrl}\n\nIf you didn't request this, ignore this email — your password is unchanged.`,
+        htmlBody: `<p>Reset your Commonly password (link valid for 1 hour):</p><a href="${resetUrl}">Reset password</a><p>If you didn't request this, ignore this email — your password is unchanged.</p>`,
+      });
     } catch (sendError: any) {
       console.error('SMTP2GO error during password reset:', sendError?.response?.data || sendError.message);
     }

--- a/backend/models/Summary.ts
+++ b/backend/models/Summary.ts
@@ -27,6 +27,7 @@ export interface ISummary extends Document {
     source?: string;
     sources?: string[];
     eventId?: string;
+    emailedAt?: Date;
   };
   analytics: {
     timeline: Array<{
@@ -96,6 +97,7 @@ const summarySchema = new Schema<ISummary>({
     source: { type: String },
     sources: [{ type: String }],
     eventId: { type: String },
+    emailedAt: { type: Date },
   },
   analytics: {
     timeline: [

--- a/backend/models/User.ts
+++ b/backend/models/User.ts
@@ -132,6 +132,10 @@ export interface IUser extends Document {
     includeTimeline: boolean;
     minActivityLevel: ActivityLevel;
   };
+  emailPreferences: {
+    dailyDigest: boolean;
+  };
+  digestUnsubscribeToken?: string;
   lastActive: Date;
   lastDigestSent?: Date;
   createdAt: Date;
@@ -139,6 +143,7 @@ export interface IUser extends Document {
   comparePassword(password: string): Promise<boolean>;
   generateApiToken(): string;
   revokeApiToken(): void;
+  getOrCreateDigestUnsubscribeToken(): string;
 }
 
 export interface IUserModel extends Model<IUser> {}
@@ -291,6 +296,12 @@ const userSchema = new Schema<IUser>({
     includeTimeline: { type: Boolean, default: true },
     minActivityLevel: { type: String, enum: ['low', 'medium', 'high'], default: 'low' },
   },
+  emailPreferences: {
+    dailyDigest: { type: Boolean, default: true },
+  },
+  // Capability token: it can only disable digest mail. Hidden from normal
+  // User projections and generated lazily when the first email is sent.
+  digestUnsubscribeToken: { type: String, select: false },
   lastActive: { type: Date, default: Date.now },
   lastDigestSent: { type: Date },
   createdAt: { type: Date, default: Date.now },
@@ -298,6 +309,13 @@ const userSchema = new Schema<IUser>({
 
 // OAuth callback looks users up by (provider, providerId) on every social login.
 userSchema.index({ 'authProviders.provider': 1, 'authProviders.providerId': 1 });
+userSchema.index(
+  { digestUnsubscribeToken: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { digestUnsubscribeToken: { $type: 'string' } },
+  },
+);
 
 userSchema.pre<IUser>('save', async function (next) {
   if (!this.isModified('password') || !this.password) return next();
@@ -319,6 +337,13 @@ userSchema.methods.generateApiToken = function (): string {
 userSchema.methods.revokeApiToken = function (): void {
   this.apiToken = undefined;
   this.apiTokenCreatedAt = undefined;
+};
+
+userSchema.methods.getOrCreateDigestUnsubscribeToken = function (): string {
+  if (!this.digestUnsubscribeToken) {
+    this.digestUnsubscribeToken = crypto.randomBytes(24).toString('hex');
+  }
+  return this.digestUnsubscribeToken;
 };
 
 export default mongoose.model<IUser, IUserModel>('User', userSchema);

--- a/backend/routes/admin/users.ts
+++ b/backend/routes/admin/users.ts
@@ -1,7 +1,6 @@
 export {};
 const express = require('express');
 const crypto = require('crypto');
-const axios = require('axios');
 const rateLimit = require('express-rate-limit');
 const auth = require('../../middleware/auth');
 const adminAuth = require('../../middleware/adminAuth');
@@ -9,6 +8,7 @@ const User = require('../../models/User');
 const InvitationCode = require('../../models/InvitationCode');
 const WaitlistRequest = require('../../models/WaitlistRequest');
 const { cloudflareIpRateLimitKeyGenerator } = require('../../middleware/ipRateLimit');
+const { sendEmail } = require('../../services/emailService');
 
 const router = express.Router();
 
@@ -88,8 +88,6 @@ const sanitizeWaitlist = (request: any) => ({
 });
 
 const generateInvitationCode = () => `CM-${(crypto as any).randomBytes(4).toString('hex').toUpperCase()}`;
-const SMTP2GO_BASE_URL = process.env.SMTP2GO_BASE_URL || 'https://api.smtp2go.com/v3';
-const SMTP2GO_SEND_URL = `${SMTP2GO_BASE_URL.replace(/\/$/, '')}/email/send`;
 
 const getPrimaryFrontendUrl = () => {
   const raw = String(process.env.FRONTEND_URL || '').trim();
@@ -557,15 +555,12 @@ router.post('/waitlist/:requestId/send-invitation', auth, adminAuth, async (req:
       `<p><a href="${registerUrl}">Complete registration</a></p>`,
     ].join('');
 
-    await axios.post(SMTP2GO_SEND_URL, {
-      api_key: process.env.SMTP2GO_API_KEY,
-      to: [waitlistRequest.email],
-      sender: process.env.SMTP2GO_FROM_EMAIL,
-      from_name: process.env.SMTP2GO_FROM_NAME || 'Commonly',
+    await sendEmail({
+      to: waitlistRequest.email,
       subject,
-      text_body: textBody,
-      html_body: htmlBody,
-    }, { timeout: 30000 });
+      textBody,
+      htmlBody,
+    });
 
     waitlistRequest.status = 'invited';
     waitlistRequest.invitationCode = invitation._id;

--- a/backend/routes/email.ts
+++ b/backend/routes/email.ts
@@ -1,0 +1,52 @@
+import rateLimit from 'express-rate-limit';
+// eslint-disable-next-line global-require
+const express = require('express');
+// eslint-disable-next-line global-require
+const User = require('../models/User');
+// eslint-disable-next-line global-require
+const { cloudflareIpRateLimitKeyGenerator } = require('../middleware/ipRateLimit');
+
+const router: ReturnType<typeof express.Router> = express.Router();
+
+const unsubscribeRateLimit = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: cloudflareIpRateLimitKeyGenerator,
+  handler: (_req: unknown, res: any) => res.status(429).json({
+    message: 'rate limit exceeded: 30 email preference updates per hour',
+    code: 'rate_limited',
+  }),
+});
+
+const confirmationPage = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Digest emails disabled</title></head><body style="margin:0;background:#f8f8fb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#111827;"><main style="max-width:560px;margin:64px auto;padding:0 20px;"><section style="background:#ffffff;border:1px solid #e5e7eb;border-radius:12px;padding:24px;"><h1 style="margin:0 0 12px;font-size:24px;letter-spacing:-0.03em;">Daily digests are off</h1><p style="margin:0;color:#4b5563;line-height:1.55;">You will no longer receive Commonly daily digest emails.</p></section></main></body></html>`;
+
+router.get('/unsubscribe/:token', unsubscribeRateLimit, async (req: any, res: any) => {
+  try {
+    const rawToken = req.params?.token;
+    if (typeof rawToken !== 'string') return res.status(404).send('Unsubscribe link not found');
+    const safeToken = String(rawToken).replace(/[^a-f0-9]/g, '');
+    if (safeToken.length !== 48 || safeToken !== rawToken || !/^[a-f0-9]{48}$/.test(safeToken)) {
+      return res.status(404).send('Unsubscribe link not found');
+    }
+
+    const user = await User.findOneAndUpdate(
+      { digestUnsubscribeToken: safeToken },
+      { $set: { 'emailPreferences.dailyDigest': false } },
+      { new: true },
+    );
+    if (!user) return res.status(404).send('Unsubscribe link not found');
+
+    return res.status(200).type('html').send(confirmationPage);
+  } catch (error) {
+    console.error('Email unsubscribe failed:', (error as Error)?.message || error);
+    return res.status(500).send('Unable to update email preferences');
+  }
+});
+
+export default router;
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);
+

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -42,6 +42,7 @@ const skillsRoutes = require('./routes/skills');
 const devRoutes = require('./routes/dev');
 const healthRoutes = require('./routes/health');
 const statsRoutes = require('./routes/stats');
+const emailRoutes = require('./routes/email');
 const showcaseRoutes = require('./routes/showcase');
 const adminPodsRoutes = require('./routes/admin/pods');
 const agentEnsembleRoutes = require('./routes/agentEnsemble');
@@ -216,6 +217,7 @@ app.use('/api/admin/analytics', adminAnalyticsRoutes); // Admin activation-funne
 app.use('/api/dev', devRoutes); // Dev tooling (LLM status, etc.)
 app.use('/api/health', healthRoutes); // Health check endpoints
 app.use('/api/stats', statsRoutes); // Public stats (no auth)
+app.use('/api/email', emailRoutes); // Public digest unsubscribe links
 // Public read-only showcase (no auth — handlers self-gate on pod.publicRead).
 // SECURITY-CRITICAL: the only anonymous read path; serves only flagged pods.
 app.use('/api/showcase', showcaseRoutes);

--- a/backend/services/digestEmailService.ts
+++ b/backend/services/digestEmailService.ts
@@ -146,6 +146,22 @@ export class DigestEmailService {
           await user.save();
         }
 
+        // Claim before crossing the SMTP boundary. Email has no transactional
+        // acknowledgement we can coordinate with MongoDB, so at-most-once is
+        // the safer failure mode: a crash can drop one digest, but can never
+        // deliver the same digest twice on a retry or concurrent cron run.
+        const emailedAt = new Date();
+        const claim = await Summary.updateOne(
+          { _id: summary._id, 'metadata.emailedAt': { $exists: false } },
+          { $set: { 'metadata.emailedAt': emailedAt } },
+        );
+        const claimed = Number(claim?.modifiedCount ?? claim?.nModified ?? 0) === 1;
+        if (!claimed) {
+          result.skipped += 1;
+          continue;
+        }
+        if (summary.metadata) summary.metadata.emailedAt = emailedAt;
+
         const bodies = buildEmailBodies(summary, unsubscribeToken);
         await sendEmail({
           to: user.email,
@@ -154,12 +170,6 @@ export class DigestEmailService {
           htmlBody: bodies.htmlBody,
         });
 
-        const emailedAt = new Date();
-        await Summary.updateOne(
-          { _id: summary._id, 'metadata.emailedAt': { $exists: false } },
-          { $set: { 'metadata.emailedAt': emailedAt } },
-        );
-        if (summary.metadata) summary.metadata.emailedAt = emailedAt;
         result.sent += 1;
       } catch (error) {
         result.failed += 1;

--- a/backend/services/digestEmailService.ts
+++ b/backend/services/digestEmailService.ts
@@ -1,0 +1,181 @@
+// eslint-disable-next-line global-require
+const Summary = require('../models/Summary');
+// eslint-disable-next-line global-require
+const User = require('../models/User');
+// eslint-disable-next-line global-require
+const { sendEmail } = require('./emailService');
+
+interface DigestRunResult {
+  success?: boolean;
+  digest?: { _id?: unknown };
+}
+
+interface DigestSummary {
+  _id: unknown;
+  title?: string;
+  content?: string;
+  metadata?: {
+    totalItems?: number;
+    userId?: string;
+    emailedAt?: Date;
+  };
+}
+
+interface DigestUser {
+  _id: unknown;
+  email?: string;
+  verified?: boolean;
+  isBot?: boolean;
+  emailPreferences?: { dailyDigest?: boolean };
+  digestUnsubscribeToken?: string;
+  getOrCreateDigestUnsubscribeToken: () => string;
+  save: () => Promise<unknown>;
+}
+
+export interface DigestEmailResult {
+  eligible: number;
+  sent: number;
+  skipped: number;
+  failed: number;
+  unconfigured: boolean;
+}
+
+const primaryUrl = (raw: string | undefined, fallback: string): string => {
+  const configured = String(raw || '').split(',').map((value) => value.trim()).filter(Boolean)[0];
+  return (configured || fallback).replace(/\/$/, '');
+};
+
+const escapeHtml = (value: unknown): string => String(value || '')
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#39;');
+
+const cleanMarkdownLine = (line: string): string => line
+  .replace(/^[-*]\s+/, '')
+  .replace(/^#+\s*/, '')
+  .replace(/^>\s*/, '')
+  .replace(/[*_`]/g, '')
+  .trim();
+
+export const extractTopItems = (content: string | undefined, limit = 5): string[] => {
+  const lines = String(content || '').split('\n').map((line) => line.trim()).filter(Boolean);
+  const bullets = lines.filter((line) => /^[-*]\s+/.test(line));
+  const candidates = bullets.length > 0
+    ? bullets
+    : lines.filter((line) => !/^#|^>|^---+$/.test(line));
+  return candidates.map(cleanMarkdownLine).filter(Boolean).slice(0, limit);
+};
+
+const buildEmailBodies = (summary: DigestSummary, unsubscribeToken: string) => {
+  const title = summary.title || 'Your Commonly daily digest';
+  const items = extractTopItems(summary.content);
+  const frontendUrl = primaryUrl(process.env.FRONTEND_URL, 'http://localhost:3000');
+  const backendUrl = primaryUrl(
+    process.env.BACKEND_URL || process.env.COMMONLY_API_URL,
+    'http://localhost:5000',
+  );
+  const appUrl = `${frontendUrl}/v2`;
+  const unsubscribeUrl = `${backendUrl}/api/email/unsubscribe/${encodeURIComponent(unsubscribeToken)}`;
+  const textItems = items.length > 0
+    ? items.map((item) => `- ${item}`).join('\n')
+    : 'Open Commonly to catch up on today\'s activity.';
+  const htmlItems = items.length > 0
+    ? `<ul style="margin:16px 0;padding-left:22px;color:#111827;line-height:1.55;">${items.map((item) => `<li style="margin:0 0 8px;">${escapeHtml(item)}</li>`).join('')}</ul>`
+    : '<p style="margin:16px 0;color:#4b5563;line-height:1.55;">Open Commonly to catch up on today&#39;s activity.</p>';
+
+  return {
+    subject: title,
+    textBody: `${title}\n\n${textItems}\n\nOpen Commonly: ${appUrl}\n\nUnsubscribe from daily digests: ${unsubscribeUrl}`,
+    // Email clients cannot reliably consume the app's CSS variables, so these
+    // inline values mirror the canonical Commonly tokens: accent, text,
+    // border, and system-font stack. Digest content is escaped above.
+    htmlBody: `<!doctype html><html><body style="margin:0;background:#f8f8fb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#111827;"><main style="max-width:600px;margin:0 auto;padding:32px 20px;"><section style="background:#ffffff;border:1px solid #e5e7eb;border-radius:12px;padding:24px;"><h1 style="margin:0 0 16px;font-size:24px;line-height:1.25;letter-spacing:-0.03em;">${escapeHtml(title)}</h1>${htmlItems}<p style="margin:24px 0 0;"><a href="${escapeHtml(appUrl)}" style="display:inline-block;background:#2f6feb;color:#ffffff;text-decoration:none;font-weight:600;border-radius:8px;padding:10px 16px;">Open Commonly</a></p></section><p style="margin:16px 0 0;text-align:center;color:#7b8494;font-size:12px;line-height:1.45;">You receive this because daily digests are enabled for your Commonly account. <a href="${escapeHtml(unsubscribeUrl)}" style="color:#2456c8;">Unsubscribe</a></p></main></body></html>`,
+  };
+};
+
+export class DigestEmailService {
+  async sendDigestEmails(currentRun: DigestRunResult[] = []): Promise<DigestEmailResult> {
+    const result: DigestEmailResult = {
+      eligible: 0,
+      sent: 0,
+      skipped: 0,
+      failed: 0,
+      unconfigured: false,
+    };
+
+    if (!process.env.SMTP2GO_API_KEY || !process.env.SMTP2GO_FROM_EMAIL) {
+      console.warn('Digest email delivery skipped: SMTP2GO is not configured.');
+      result.unconfigured = true;
+      return result;
+    }
+
+    const summaryIds = currentRun
+      .filter((entry) => entry?.success && entry.digest?._id)
+      .map((entry) => entry.digest?._id);
+    if (summaryIds.length === 0) return result;
+
+    const summaries = await Summary.find({
+      _id: { $in: summaryIds },
+      type: 'daily-digest',
+      'metadata.totalItems': { $gt: 0 },
+      'metadata.emailedAt': { $exists: false },
+    }) as DigestSummary[];
+    result.eligible = summaries.length;
+
+    for (const summary of summaries) {
+      const userId = summary.metadata?.userId;
+      try {
+        if (!userId) {
+          result.skipped += 1;
+          continue;
+        }
+
+        const user = await User.findById(userId)
+          .select('+digestUnsubscribeToken email verified isBot emailPreferences') as DigestUser | null;
+        if (!user?.email || user.verified !== true || user.isBot === true
+          || user.emailPreferences?.dailyDigest === false) {
+          result.skipped += 1;
+          continue;
+        }
+
+        let unsubscribeToken = user.digestUnsubscribeToken;
+        if (!unsubscribeToken) {
+          unsubscribeToken = user.getOrCreateDigestUnsubscribeToken();
+          await user.save();
+        }
+
+        const bodies = buildEmailBodies(summary, unsubscribeToken);
+        await sendEmail({
+          to: user.email,
+          subject: bodies.subject,
+          textBody: bodies.textBody,
+          htmlBody: bodies.htmlBody,
+        });
+
+        const emailedAt = new Date();
+        await Summary.updateOne(
+          { _id: summary._id, 'metadata.emailedAt': { $exists: false } },
+          { $set: { 'metadata.emailedAt': emailedAt } },
+        );
+        if (summary.metadata) summary.metadata.emailedAt = emailedAt;
+        result.sent += 1;
+      } catch (error) {
+        result.failed += 1;
+        console.error('Digest email delivery failed:', {
+          summaryId: String(summary._id || ''),
+          userId: String(userId || ''),
+          error: (error as Error)?.message || String(error),
+        });
+      }
+    }
+
+    return result;
+  }
+}
+
+export default new DigestEmailService();
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/services/emailService.ts
+++ b/backend/services/emailService.ts
@@ -1,0 +1,43 @@
+// eslint-disable-next-line global-require
+const axios = require('axios');
+
+export interface SendEmailOptions {
+  to: string;
+  subject: string;
+  textBody: string;
+  htmlBody: string;
+}
+
+export class EmailNotConfiguredError extends Error {
+  code: string;
+
+  constructor() {
+    super('SMTP2GO email delivery is not configured');
+    this.name = 'EmailNotConfiguredError';
+    this.code = 'EMAIL_NOT_CONFIGURED';
+  }
+}
+
+export const sendEmail = async ({
+  to,
+  subject,
+  textBody,
+  htmlBody,
+}: SendEmailOptions): Promise<any> => {
+  const apiKey = process.env.SMTP2GO_API_KEY;
+  if (!apiKey) throw new EmailNotConfiguredError();
+
+  const baseUrl = String(process.env.SMTP2GO_BASE_URL || 'https://api.smtp2go.com/v3')
+    .replace(/\/$/, '');
+
+  return axios.post(`${baseUrl}/email/send`, {
+    api_key: apiKey,
+    to: [to],
+    sender: process.env.SMTP2GO_FROM_EMAIL,
+    from_name: process.env.SMTP2GO_FROM_NAME || 'Commonly',
+    subject,
+    text_body: textBody,
+    html_body: htmlBody,
+  }, { timeout: 30000 });
+};
+

--- a/backend/services/schedulerService.ts
+++ b/backend/services/schedulerService.ts
@@ -38,6 +38,8 @@ const SummarizerService = summarizerService.constructor;
 const chatSummarizerService = require('./chatSummarizerService');
 // eslint-disable-next-line global-require
 const dailyDigestService = require('./dailyDigestService');
+// eslint-disable-next-line global-require
+const digestEmailService = require('./digestEmailService');
 
 interface CronJob {
   start(): void;
@@ -170,7 +172,8 @@ class SchedulerService {
       async () => {
         console.log('Running daily digest generation...');
         try {
-          await dailyDigestService.generateAllDailyDigests();
+          const digestResults = await dailyDigestService.generateAllDailyDigests();
+          await digestEmailService.sendDigestEmails(digestResults);
         } catch (error) {
           console.error('Error in scheduled daily digest generation:', error);
         }


### PR DESCRIPTION
## Summary
- centralize SMTP2GO delivery in a shared email service and preserve registration, password-reset, and waitlist invitation behavior
- deliver only non-empty current-run daily digests to verified, opted-in humans; stamp emailedAt for retry idempotency and isolate per-user failures
- add default-on digest email preferences, lazy CSPRNG unsubscribe tokens, and a public rate-limited unsubscribe route
- invoke email delivery directly after the existing digest-generation cron; self-hosters without SMTP configuration remain inert

## Product decisions
- existing and new users default to daily digest email enabled
- empty digests never send
- unsubscribe link is the opt-out surface in this PR; settings UI remains follow-up work

## Verification
- Full backend: 178 suites / 1,260 tests passed under Node 20; Jest printed the existing open-handle warning after the completed summary and the idle process was then stopped
- Focused new coverage: 4 suites / 14 tests passed
- Existing auth/admin mail regression coverage: 4 suites / 60 tests passed in the full run
- npm run tsc:check: passed
- npm run build: passed
- git diff --check: passed
- Full repository lint remains baseline-red before this change due the JS ESLint configuration resolving TypeScript modules; changed test files pass focused lint with those two baseline resolver rules disabled

Closes #688