### PR TITLE
Fix dead rooms with agent delivery feedback

### DIFF
--- a/backend/__tests__/unit/controllers/messageController.test.js
+++ b/backend/__tests__/unit/controllers/messageController.test.js
@@ -2,12 +2,16 @@ const messageController = require('../../../controllers/messageController');
 const Pod = require('../../../models/Pod');
 const PGMessage = require('../../../models/pg/Message');
 const AgentMentionService = require('../../../services/agentMentionService');
+const { AgentInstallation } = require('../../../models/AgentRegistry');
 
 jest.mock('../../../models/Pod');
 jest.mock('../../../models/pg/Message');
 jest.mock('../../../services/agentMentionService', () => ({
-  enqueueMentions: jest.fn().mockResolvedValue({ enqueued: [], skipped: [] }),
+  enqueueMentions: jest.fn().mockResolvedValue({ enqueued: [], implicit: [], skipped: [] }),
   enqueueDmEvent: jest.fn().mockResolvedValue({ enqueued: [], skipped: [] }),
+}));
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { countDocuments: jest.fn() },
 }));
 jest.mock('../../../config/socket', () => ({
   getIO: jest.fn(),
@@ -16,6 +20,10 @@ jest.mock('../../../config/socket', () => ({
 const socketConfig = require('../../../config/socket');
 
 describe('messageController', () => {
+  beforeEach(() => {
+    AgentInstallation.countDocuments.mockResolvedValue(0);
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -67,6 +75,7 @@ describe('messageController', () => {
       const mockMessage = { id: 1, content: 'test' };
       Pod.findById.mockResolvedValue({ members: ['u1'], type: 'chat' });
       PGMessage.create.mockResolvedValue(mockMessage);
+      AgentInstallation.countDocuments.mockResolvedValueOnce(2);
       const req = {
         params: { podId: 'p1' },
         body: { content: 'test' },
@@ -74,9 +83,41 @@ describe('messageController', () => {
       };
       const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
       await messageController.createMessage(req, res);
-      expect(res.json).toHaveBeenCalledWith(mockMessage);
+      expect(res.json).toHaveBeenCalledWith({
+        ...mockMessage,
+        agentDelivery: { enqueued: 0, implicit: [], agentsInPod: 2 },
+      });
       expect(AgentMentionService.enqueueMentions).toHaveBeenCalled();
       expect(AgentMentionService.enqueueDmEvent).not.toHaveBeenCalled();
+    });
+
+    it('reports mention delivery and active-agent count for a regular pod', async () => {
+      const mockMessage = { id: 3, content: '@aria can you help?' };
+      Pod.findById.mockResolvedValue({ members: ['u1'], type: 'chat' });
+      PGMessage.create.mockResolvedValue(mockMessage);
+      AgentMentionService.enqueueMentions.mockResolvedValueOnce({
+        enqueued: ['openclaw'], implicit: [], skipped: [],
+      });
+      AgentInstallation.countDocuments.mockResolvedValueOnce(2);
+      const req = {
+        params: { podId: 'p1' },
+        body: { content: '@aria can you help?', replyToMessageId: 'm1' },
+        user: { id: 'u1', username: 'alice' },
+      };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await messageController.createMessage(req, res);
+
+      expect(AgentMentionService.enqueueMentions).toHaveBeenCalledWith(expect.objectContaining({
+        replyToMessageId: 'm1',
+      }));
+      expect(AgentInstallation.countDocuments).toHaveBeenCalledWith({
+        podId: 'p1', status: 'active',
+      });
+      expect(res.json).toHaveBeenCalledWith({
+        ...mockMessage,
+        agentDelivery: { enqueued: 1, implicit: [], agentsInPod: 2 },
+      });
     });
 
     it('enqueues dm.message events for agent-admin pods', async () => {
@@ -99,6 +140,26 @@ describe('messageController', () => {
           userId: 'u1',
         }),
       );
+      const response = res.json.mock.calls[0][0];
+      expect(response).not.toHaveProperty('agentDelivery');
+      expect(AgentInstallation.countDocuments).not.toHaveBeenCalled();
+    });
+
+    it.each(['agent-room', 'agent-dm'])('omits agentDelivery for %s pods', async (type) => {
+      const mockMessage = { id: 4, content: 'hello dm' };
+      Pod.findById.mockResolvedValue({ members: ['u1'], type });
+      PGMessage.create.mockResolvedValue(mockMessage);
+      const req = {
+        params: { podId: 'p2' },
+        body: { content: 'hello dm' },
+        user: { id: 'u1', username: 'alice' },
+      };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await messageController.createMessage(req, res);
+
+      expect(res.json.mock.calls[0][0]).not.toHaveProperty('agentDelivery');
+      expect(AgentInstallation.countDocuments).not.toHaveBeenCalled();
     });
 
     // #646: the newMessage broadcast dropped replyTo, so live viewers saw

--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -166,6 +166,167 @@ describe('AgentMentionService', () => {
     expect(res.enqueued).toEqual(['openclaw']);
   });
 
+  describe('implicit reply mentions', () => {
+    const setupReplyTarget = ({ installed = true } = {}) => {
+      AgentInstallation.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(installed ? [
+          { agentName: 'openclaw', instanceId: 'aria', displayName: 'Aria' },
+        ] : []),
+      });
+      AgentProfile.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
+      Pod.findById.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue({ _id: 'pod-reply', type: 'chat' }),
+      });
+    };
+
+    const asHumanReplyingTo = (replyAuthor) => {
+      User.findById.mockImplementation((id) => ({
+        select: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue(
+          id === 'reply-author'
+            ? replyAuthor
+            : { _id: 'human-1', isBot: false },
+        ),
+      }));
+    };
+
+    test('bot sender replying to an agent does not implicitly enqueue (loop guard)', async () => {
+      setupReplyTarget();
+      User.findById.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue({
+          _id: 'agent-sender',
+          isBot: true,
+          botMetadata: { agentName: 'openclaw', instanceId: 'theo' },
+        }),
+      });
+
+      const result = await AgentMentionService.enqueueMentions({
+        podId: 'pod-reply',
+        replyToMessageId: 'message-from-aria',
+        message: {
+          id: 'bot-reply',
+          content: 'Following up',
+          replyTo: { userId: 'reply-author' },
+        },
+        userId: 'agent-sender',
+        username: 'theo',
+      });
+
+      expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+      expect(User.findById).toHaveBeenCalledTimes(1);
+      expect(result.implicit).toEqual([]);
+    });
+
+    test('human reply to an active agent enqueues exactly one implicit mention', async () => {
+      setupReplyTarget();
+      asHumanReplyingTo({
+        _id: 'reply-author',
+        isBot: true,
+        botMetadata: { agentName: 'openclaw', instanceId: 'aria' },
+      });
+
+      const result = await AgentMentionService.enqueueMentions({
+        podId: 'pod-reply',
+        replyToMessageId: 'message-from-aria',
+        message: {
+          id: 'human-reply',
+          content: 'That sounds good',
+          replyTo: { userId: 'reply-author' },
+        },
+        userId: 'human-1',
+        username: 'alice',
+      });
+
+      expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+      expect(AgentEventService.enqueue).toHaveBeenCalledWith(expect.objectContaining({
+        agentName: 'openclaw',
+        instanceId: 'aria',
+        podId: 'pod-reply',
+        type: 'chat.mention',
+        payload: expect.objectContaining({
+          messageId: 'human-reply',
+          replyToMessageId: 'message-from-aria',
+          implicitReply: true,
+        }),
+      }));
+      expect(result.enqueued).toEqual(['openclaw']);
+      expect(result.implicit).toEqual(['openclaw']);
+    });
+
+    test('explicit mention plus reply to the same agent enqueues only once', async () => {
+      setupReplyTarget();
+      asHumanReplyingTo({
+        _id: 'reply-author',
+        isBot: true,
+        botMetadata: { agentName: 'openclaw', instanceId: 'aria' },
+      });
+
+      const result = await AgentMentionService.enqueueMentions({
+        podId: 'pod-reply',
+        replyToMessageId: 'message-from-aria',
+        message: {
+          id: 'human-reply',
+          content: '@aria thanks',
+          replyTo: { userId: 'reply-author' },
+        },
+        userId: 'human-1',
+        username: 'alice',
+      });
+
+      expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+      expect(result.enqueued).toEqual(['openclaw']);
+      expect(result.implicit).toEqual([]);
+    });
+
+    test('reply to a human does not enqueue an implicit mention', async () => {
+      setupReplyTarget();
+      asHumanReplyingTo({ _id: 'reply-author', isBot: false });
+
+      const result = await AgentMentionService.enqueueMentions({
+        podId: 'pod-reply',
+        replyToMessageId: 'human-message',
+        message: {
+          id: 'human-reply',
+          content: 'Thanks',
+          replyTo: { userId: 'reply-author' },
+        },
+        userId: 'human-1',
+        username: 'alice',
+      });
+
+      expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+      expect(result.implicit).toEqual([]);
+    });
+
+    test('reply to an uninstalled agent does not enqueue an implicit mention', async () => {
+      setupReplyTarget({ installed: false });
+      asHumanReplyingTo({
+        _id: 'reply-author',
+        isBot: true,
+        botMetadata: { agentName: 'openclaw', instanceId: 'aria' },
+      });
+
+      const result = await AgentMentionService.enqueueMentions({
+        podId: 'pod-reply',
+        replyToMessageId: 'message-from-aria',
+        message: {
+          id: 'human-reply',
+          content: 'Are you there?',
+          replyTo: { userId: 'reply-author' },
+        },
+        userId: 'human-1',
+        username: 'alice',
+      });
+
+      expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+      expect(result.implicit).toEqual([]);
+    });
+  });
+
   test('enqueueDmEvent enqueues dm.message for bot members in agent-admin pod', async () => {
     Pod.findById.mockReturnValue({
       lean: jest.fn().mockResolvedValue({

--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -10,6 +10,8 @@ const PGMessage = require('../models/pg/Message');
 const PGPod = require('../models/pg/Pod');
 // eslint-disable-next-line global-require
 const AgentMentionService = require('../services/agentMentionService');
+// eslint-disable-next-line global-require
+const { AgentInstallation } = require('../models/AgentRegistry');
 const DMService = require('../services/dmService');
 // eslint-disable-next-line global-require
 const { syncPodFromMongo } = require('../services/pgPodSyncService');
@@ -262,10 +264,36 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
     // updating this allow-list silently drops every message; see
     // docs/agents/AGENT_RUNTIME.md "Routing Invariants" for the canonical
     // version of this rule.
-    if (pod.type === 'agent-admin' || pod.type === 'agent-room' || pod.type === 'agent-dm') {
+    const isDmPod = pod.type === 'agent-admin' || pod.type === 'agent-room' || pod.type === 'agent-dm';
+    let responseMessage: NormalizedMessage | (NormalizedMessage & {
+      agentDelivery: { enqueued: number; implicit: string[]; agentsInPod: number };
+    }) = message;
+    if (isDmPod) {
       await AgentMentionService.enqueueDmEvent({ podId, message, userId, username });
     } else {
-      await AgentMentionService.enqueueMentions({ podId, message, userId, username });
+      const mentionResult = await AgentMentionService.enqueueMentions({
+        podId,
+        message,
+        userId,
+        username,
+        replyToMessageId: replyToMessageId || null,
+      });
+      let agentsInPod = 0;
+      try {
+        agentsInPod = await AgentInstallation.countDocuments({ podId, status: 'active' });
+      } catch (countErr) {
+        // Delivery metadata is advisory UI feedback. A count failure must
+        // never turn an already-persisted message into a failed send.
+        console.warn('[messageController] active-agent delivery count failed:', (countErr as Error).message);
+      }
+      responseMessage = {
+        ...message,
+        agentDelivery: {
+          enqueued: mentionResult.enqueued.length,
+          implicit: mentionResult.implicit || [],
+          agentsInPod,
+        },
+      };
     }
 
     // Live-broadcast the new message to every connected client in this pod's
@@ -314,7 +342,7 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
       console.warn('[messageController] socket emit failed:', (socketErr as Error).message);
     }
 
-    res.json(message);
+    res.json(responseMessage);
   } catch (err) {
     const e = err as { message?: string; kind?: string };
     console.error('Error in createMessage:', e.message);

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -38,6 +38,7 @@ interface MentionMapEntry {
 
 interface EnqueueMentionsOptions {
   podId: string;
+  replyToMessageId?: string | null;
   message: {
     content?: string;
     text?: string;
@@ -49,6 +50,7 @@ interface EnqueueMentionsOptions {
     createdAt?: unknown;
     created_at?: unknown;
     thread?: unknown;
+    replyTo?: { userId?: unknown } | null;
   };
   userId: string;
   username: string;
@@ -63,6 +65,7 @@ interface EnqueueDmOptions {
 
 interface EnqueueResult {
   enqueued: string[];
+  implicit: string[];
   skipped: string[];
 }
 
@@ -549,11 +552,63 @@ const buildContentForTarget = (
   return `${frames.join('\n')}\n\n${rawContent}`;
 };
 
+const normalizeUserId = (value: unknown): string | null => {
+  if (!value) return null;
+  if (typeof value === 'object') {
+    const nestedId = (value as { _id?: unknown })._id;
+    return nestedId ? String(nestedId) : null;
+  }
+  return String(value);
+};
+
+const resolveImplicitReplyTarget = async (
+  replyToMessageId: string,
+  message: EnqueueMentionsOptions['message'],
+  installations: Array<Record<string, unknown>>,
+): Promise<MentionTarget | null> => {
+  let replyAuthorUserId = normalizeUserId(message.replyTo?.userId);
+
+  // The controller normally passes the populated PG row, whose replyTo
+  // already carries the author id. Keep a lookup fallback for other callers
+  // and older response shapes that only pass replyToMessageId.
+  if (!replyAuthorUserId) {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const PGMessage = require('../models/pg/Message') as {
+      findById: (id: string) => Promise<{ user_id?: unknown; userId?: unknown } | null>;
+    };
+    const repliedMessage = await PGMessage.findById(replyToMessageId);
+    replyAuthorUserId = normalizeUserId(repliedMessage?.user_id || repliedMessage?.userId);
+  }
+  if (!replyAuthorUserId) return null;
+
+  const replyAuthor = await User.findById(replyAuthorUserId)
+    .select('isBot botMetadata')
+    .lean() as SenderRow | null;
+  const agentName = replyAuthor?.isBot
+    ? replyAuthor.botMetadata?.agentName?.toLowerCase()
+    : null;
+  const instanceId = replyAuthor?.isBot
+    ? (replyAuthor.botMetadata?.instanceId || 'default').toLowerCase()
+    : null;
+  if (!agentName || !instanceId) return null;
+
+  const activeInstallation = installations.find((installation) => (
+    String(installation.agentName || '').toLowerCase() === agentName
+    && String(installation.instanceId || 'default').toLowerCase() === instanceId
+  ));
+  if (!activeInstallation) return null;
+  return {
+    agentName: String(activeInstallation.agentName || agentName),
+    instanceId: String(activeInstallation.instanceId || instanceId),
+  };
+};
+
 const enqueueMentions = async ({
   podId,
   message,
   userId,
   username,
+  replyToMessageId,
 }: EnqueueMentionsOptions): Promise<EnqueueResult> => {
   const rawContent = message?.content || message?.text || '';
   const source = message?.source || 'chat';
@@ -563,12 +618,21 @@ const enqueueMentions = async ({
   // enqueue site below passes its own `targetAgentName` so the cue
   // composition is correct for that target's runtime.
   const rawMentions = extractMentions(rawContent);
-  if (!podId || rawMentions.length === 0) {
-    return { enqueued: [], skipped: [] };
+  if (!podId || (rawMentions.length === 0 && !replyToMessageId)) {
+    return { enqueued: [], implicit: [], skipped: [] };
   }
 
   const enqueued: string[] = [];
+  const implicit: string[] = [];
   const skipped: string[] = [];
+  const enqueuedIdentityKeys = new Set<string>();
+  const identityKey = (target: MentionTarget): string => (
+    `${target.agentName.toLowerCase()}:${(target.instanceId || 'default').toLowerCase()}`
+  );
+  const recordEnqueued = (target: MentionTarget, resultLabel = target.agentName): void => {
+    enqueuedIdentityKeys.add(identityKey(target));
+    enqueued.push(resultLabel);
+  };
 
   let installations: Array<Record<string, unknown>> = [];
   let profiles: Array<Record<string, unknown>> = [];
@@ -678,7 +742,7 @@ const enqueueMentions = async ({
               summary: summary as Record<string, unknown> | null,
               pod: pod as Record<string, unknown> | null,
             });
-            enqueued.push(directMatch.agentName);
+            recordEnqueued(directMatch);
             return;
           }
           await AgentEventService.enqueue({
@@ -700,7 +764,7 @@ const enqueueMentions = async ({
               thread: message?.thread || null,
             },
           });
-          enqueued.push(directMatch.agentName);
+          recordEnqueued(directMatch);
         } catch (error) {
           console.warn('Failed to enqueue agent mention:', (error as Error).message);
         }
@@ -749,7 +813,10 @@ const enqueueMentions = async ({
                   autoJoined: true,
                 },
               });
-              enqueued.push(`${resolved.agentName}:autoJoined`);
+              recordEnqueued(
+                { agentName: resolved.agentName, instanceId: resolved.instanceId },
+                `${resolved.agentName}:autoJoined`,
+              );
               return;
             }
             skipped.push(`${normalized}:auth-refused`);
@@ -790,7 +857,7 @@ const enqueueMentions = async ({
                   summary: summary as Record<string, unknown> | null,
                   pod: pod as Record<string, unknown> | null,
                 });
-                enqueued.push(agentType);
+                recordEnqueued({ agentName: agentType, instanceId: match.instanceId || 'default' });
                 return;
               }
               await AgentEventService.enqueue({
@@ -812,7 +879,7 @@ const enqueueMentions = async ({
                   thread: message?.thread || null,
                 },
               });
-              enqueued.push(agentType);
+              recordEnqueued({ agentName: agentType, instanceId: match.instanceId || 'default' });
             } catch (error) {
               console.warn('Failed to enqueue agent mention:', (error as Error).message);
             }
@@ -825,7 +892,53 @@ const enqueueMentions = async ({
     }),
   );
 
-  return { enqueued, skipped };
+  // Human replies to an agent are an addressing signal even when the human
+  // does not repeat an @mention. Bot replies are deliberately excluded: if
+  // A's reply to B implicitly notified B (and vice versa), two agents could
+  // ping-pong forever despite the existing self-mention guard.
+  if (replyToMessageId && sender?.isBot === false) {
+    try {
+      const target = await resolveImplicitReplyTarget(replyToMessageId, message, installations);
+      if (target && !enqueuedIdentityKeys.has(identityKey(target))) {
+        await AgentEventService.enqueue({
+          agentName: target.agentName,
+          instanceId: target.instanceId || 'default',
+          podId,
+          type: 'chat.mention',
+          payload: {
+            messageId: message?._id || message?.id
+              ? String(message?._id || message?.id)
+              : undefined,
+            content: buildContentForTarget(
+              podId,
+              rawContent,
+              'chat.mention',
+              target.agentName,
+              collaborativePod,
+            ),
+            userId,
+            username,
+            mentions: rawMentions,
+            source,
+            messageType: message?.messageType || message?.message_type || 'text',
+            createdAt: message?.createdAt || message?.created_at || new Date(),
+            thread: message?.thread || null,
+            replyToMessageId,
+            implicitReply: true,
+          },
+        });
+        recordEnqueued(target);
+        implicit.push(target.agentName);
+      }
+    } catch (error) {
+      // Reply routing is best-effort, like explicit mention routing. The
+      // message is already persisted, so lookup/enqueue failure must not
+      // turn a successful human send into a 500.
+      console.warn('Failed to enqueue implicit reply mention:', (error as Error).message);
+    }
+  }
+
+  return { enqueued, implicit, skipped };
 };
 
 // Pod types that auto-route every message to non-sender members as a

--- a/docs/agents/AGENT_RUNTIME.md
+++ b/docs/agents/AGENT_RUNTIME.md
@@ -41,7 +41,12 @@ For pods where `pod.type` is one of:
 every message fires a `chat.mention` event for the non-sender member —
 no textual `@<handle>` required. `messageController.createMessage`
 calls `agentMentionService.enqueueDmEvent`. Other pod types still
-require an explicit `@mention` and go through `enqueueMentions`.
+go through `enqueueMentions`: an explicit `@mention` routes normally,
+and a **human** reply to an active installed agent implicitly routes one
+`chat.mention` to that agent. Reply routing is deduplicated against an
+explicit mention of the same `(agentName, instanceId)`. Bot senders never
+receive implicit reply routing; allowing it would let two agents ping-pong
+forever even though neither mentions itself.
 
 Both paths emit the same `chat.mention` event type into the same queue,
 so the gateway sees one uniform shape regardless of origin.
@@ -325,16 +330,22 @@ topic taxonomy:
 
 These have been load-bearing since 2026-03-03 and are tested.
 
-### Reply-to threading (no event, just a quote bubble)
+### Reply-to threading and human implicit routing
 
-Two mechanisms with strict separation:
+Reply threading always produces the visual quote. In team pods, a human
+reply to an active installed agent also acts as an addressing signal so the
+agent does not silently miss the response. Bot-authored replies remain visual
+threading only — this is the loop-prevention invariant.
 
 | Mechanism | Fires `chat.mention`? | Purpose |
 |-----------|-----------------------|---------|
 | `@mention` (in content) | Yes — fresh agent session | "Respond to me" |
-| `replyToId` (param) or `[[reply_to:ID]]` (inline tag) | No | Threading + visual quote bubble only |
+| Human `replyToMessageId` targeting an active installed agent | Yes — deduped with any explicit mention | Threading + "continue this exchange" |
+| Bot `replyToId` / reply to a human or uninstalled agent | No | Threading + visual quote bubble only |
 
-Combine both when an agent wants to thread AND demand a response.
+Agents must still combine an explicit `@mention` with reply threading when
+they need to demand a response; bot replies never gain the human-only
+implicit route.
 
 The reply pipeline:
 

--- a/frontend/src/v2/__tests__/V2PodChatDeliveryHint.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatDeliveryHint.test.tsx
@@ -1,0 +1,142 @@
+// @ts-nocheck
+import React, { useState } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2PodChat from '../components/V2PodChat';
+import { AuthContext } from '../../context/AuthContext';
+
+jest.mock('../../context/SocketContext', () => ({
+  useSocket: () => ({ socket: null, connected: false }),
+}));
+
+jest.mock('axios', () => {
+  const mock = {
+    get: jest.fn(() => Promise.resolve({ data: {} })),
+    post: jest.fn(() => Promise.resolve({ data: {} })),
+    patch: jest.fn(),
+    delete: jest.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  };
+  return { __esModule: true, default: mock, ...mock };
+});
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+const authValue = {
+  currentUser: { _id: 'u1', username: 'alice' },
+  user: { _id: 'u1', username: 'alice' },
+  token: 't',
+  loading: false,
+  error: null,
+  isAuthenticated: true,
+  register: jest.fn(),
+  login: jest.fn(),
+  logout: jest.fn(),
+  updateProfile: jest.fn(),
+};
+
+const makeMessage = (content, agentDelivery) => ({
+  id: `message-${content}`,
+  pod_id: 'pod-1',
+  user_id: 'u1',
+  content,
+  message_type: 'text',
+  created_at: '2026-07-22T12:00:00.000Z',
+  user: { username: 'alice' },
+  ...(agentDelivery ? { agentDelivery } : {}),
+});
+
+const DeliveryHarness = ({ response, sendSpy }) => {
+  const [messages, setMessages] = useState([]);
+  const sendMessage = async (...args) => {
+    sendSpy(...args);
+    setMessages((current) => [...current, response]);
+    return response;
+  };
+  const detail = {
+    pod: { _id: 'pod-1', name: 'Launch Room', type: 'chat' },
+    members: [{ _id: 'u1', username: 'alice', isBot: false }],
+    messages,
+    agents: [{
+      agentName: 'openclaw', instanceId: 'aria', displayName: 'Aria', status: 'active',
+    }],
+    sendMessage,
+    loading: false,
+    error: null,
+    refresh: jest.fn(),
+  };
+  return <V2PodChat detail={detail} />;
+};
+
+const renderHarness = (response, sendSpy = jest.fn()) => render(
+  <AuthContext.Provider value={authValue}>
+    <MemoryRouter>
+      <DeliveryHarness response={response} sendSpy={sendSpy} />
+    </MemoryRouter>
+  </AuthContext.Provider>,
+);
+
+const sendDraft = (content) => {
+  fireEvent.change(screen.getByPlaceholderText(/message launch room/i), {
+    target: { value: content },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+};
+
+describe('V2PodChat agent delivery hint', () => {
+  test('shows a real-agent example after a zero-enqueued send', async () => {
+    const response = makeMessage('hello room', {
+      enqueued: 0, implicit: [], agentsInPod: 1,
+    });
+    renderHarness(response);
+
+    sendDraft('hello room');
+
+    const hint = await screen.findByRole('status');
+    expect(hint).toHaveTextContent('No agent was notified');
+    expect(hint).toHaveTextContent('@aria');
+    expect(sessionStorage.getItem('v2.agentDeliveryHint.pod-1')).toBe('1');
+  });
+
+  test('shows at most once per pod per browser session', async () => {
+    const first = renderHarness(makeMessage('first send', {
+      enqueued: 0, implicit: [], agentsInPod: 1,
+    }));
+    sendDraft('first send');
+    await screen.findByRole('status');
+    first.unmount();
+
+    renderHarness(makeMessage('second send', {
+      enqueued: 0, implicit: [], agentsInPod: 1,
+    }));
+    sendDraft('second send');
+    await screen.findByText('second send');
+
+    expect(screen.queryByText(/No agent was notified/i)).not.toBeInTheDocument();
+  });
+
+  test.each([
+    ['an agent was enqueued', { enqueued: 1, implicit: [], agentsInPod: 1 }],
+    ['the backend omits delivery metadata', undefined],
+  ])('stays hidden when %s', async (_label, agentDelivery) => {
+    const response = makeMessage('ordinary send', agentDelivery);
+    const sendSpy = jest.fn();
+    renderHarness(response, sendSpy);
+
+    sendDraft('ordinary send');
+    await waitFor(() => expect(sendSpy).toHaveBeenCalledTimes(1));
+    await screen.findByText('ordinary send');
+
+    expect(screen.queryByText(/No agent was notified/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '../../context/AuthContext';
 import { initialsFor } from '../utils/avatars';
 
 const PLAN_MODE_KEY = 'v2.podMode';
+const AGENT_DELIVERY_HINT_KEY = 'v2.agentDeliveryHint';
 
 const STARTER_PROMPTS = [
   'Introduce yourself — what are you best at?',
@@ -162,6 +163,11 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
   const [sending, setSending] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [composerError, setComposerError] = useState<string | null>(null);
+  const [agentDeliveryHint, setAgentDeliveryHint] = useState<{
+    messageId: string;
+    mentionHandle: string;
+  } | null>(null);
+  const deliveryHintShownPodsRef = useRef<Set<string>>(new Set());
   const [mode, setMode] = useState<PodMode>(pod ? readMode(pod._id) : 'plan');
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -190,6 +196,10 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
 
   useEffect(() => {
     if (pod) setMode(readMode(pod._id));
+  }, [pod?._id]);
+
+  useEffect(() => {
+    setAgentDeliveryHint(null);
   }, [pod?._id]);
 
   useEffect(() => {
@@ -556,6 +566,36 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
     try {
       const created = await sendMessage(text, 'text', replyTarget?.id || undefined);
       if (created) {
+        const delivery = created.agentDelivery;
+        const exampleAgent = agents.find((agent) => agent.status === 'active') || agents[0];
+        const rawMentionHandle = exampleAgent?.instanceId
+          && exampleAgent.instanceId.toLowerCase() !== 'default'
+          ? exampleAgent.instanceId
+          : exampleAgent?.agentName;
+        const mentionHandle = normalizeAgentSegment(rawMentionHandle);
+        if (
+          delivery
+          && delivery.enqueued === 0
+          && delivery.agentsInPod > 0
+          && mentionHandle
+        ) {
+          const storageKey = `${AGENT_DELIVERY_HINT_KEY}.${pod._id}`;
+          let alreadyShown = deliveryHintShownPodsRef.current.has(pod._id);
+          try {
+            alreadyShown = alreadyShown || sessionStorage.getItem(storageKey) === '1';
+          } catch {
+            // In-memory guard still prevents repeat hints in this mount.
+          }
+          if (!alreadyShown) {
+            deliveryHintShownPodsRef.current.add(pod._id);
+            try {
+              sessionStorage.setItem(storageKey, '1');
+            } catch {
+              // sessionStorage unavailable; the in-memory guard still works.
+            }
+            setAgentDeliveryHint({ messageId: created.id, mentionHandle });
+          }
+        }
         setDraft('');
         setReplyTarget(null);
       }
@@ -773,15 +813,22 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
                 </div>
               )}
               {messages.map((m) => (
-                <V2MessageBubble
-                  key={m.id}
-                  message={m}
-                  agentDisplayNames={agentDisplayNames}
-                  agentAuthorKeys={agentAuthorKeys}
-                  onAuthorClick={onOpenMember ? handleAuthorClick : undefined}
-                  onOpenFile={onOpenFile}
-                  onReply={setReplyTarget}
-                />
+                <React.Fragment key={m.id}>
+                  <V2MessageBubble
+                    message={m}
+                    agentDisplayNames={agentDisplayNames}
+                    agentAuthorKeys={agentAuthorKeys}
+                    onAuthorClick={onOpenMember ? handleAuthorClick : undefined}
+                    onOpenFile={onOpenFile}
+                    onReply={setReplyTarget}
+                  />
+                  {agentDeliveryHint?.messageId === m.id && (
+                    <div className="v2-chat__delivery-hint" role="status">
+                      No agent was notified — @mention one to get a reply. Try{' '}
+                      <strong>@{agentDeliveryHint.mentionHandle}</strong>.
+                    </div>
+                  )}
+                </React.Fragment>
               ))}
               <div ref={messagesEndRef} />
             </div>

--- a/frontend/src/v2/hooks/useV2PodDetail.ts
+++ b/frontend/src/v2/hooks/useV2PodDetail.ts
@@ -28,6 +28,13 @@ export interface V2Message {
   reply_msg_id?: string | null;
   reply_content?: string | null;
   reply_username?: string | null;
+  // Sender-only delivery feedback. Present on POST responses for regular
+  // pods; omitted for DM-shaped pods and older backends.
+  agentDelivery?: {
+    enqueued: number;
+    implicit: string[];
+    agentsInPod: number;
+  };
   // Sprint B5: per-message reactions, aggregated server-side.
   // Each entry is `{emoji, count, mine, users?}` — `users` is the
   // Google-Chat-style attribution list decorated by

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -1279,6 +1279,21 @@
   gap: 0;
 }
 
+/* Sender-only teaching cue shown once per pod/session when a message reaches
+   a pod with agents but addresses none of them. Aligns with message text,
+   stays quiet/secondary, and disappears naturally with transcript scroll. */
+.v2-chat__delivery-hint {
+  margin: -4px 0 8px 50px;
+  color: var(--v2-text-tertiary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.v2-chat__delivery-hint strong {
+  color: var(--v2-accent-text);
+  font-weight: 650;
+}
+
 /* First-run attach card lives inside the selected pod transcript instead of
    replacing the pod shell. That keeps the workspace, composer, and mobile
    drawer reachable while the agent connection status updates live. */


### PR DESCRIPTION
## Summary
- Treat a human reply to an active installed agent as an implicit chat mention, deduped by agent identity against explicit mentions.
- Keep bot-authored replies implicit-routing-free so agent pairs cannot enter reply ping-pong loops.
- Return sender-only delivery metadata for regular pods and show a subtle, once-per-pod/session v2 hint when no agent was notified.
- Preserve DM auto-delivery behavior and document the routing invariant.

Closes #704 (PR 1 scope).

## Safety invariants
- Implicit reply routing is human-only.
- Reply targets must be bots with an active installation in the same pod.
- Explicit plus implicit addressing of the same agent identity produces one event.
- agent-room, agent-dm, and agent-admin responses omit the advisory delivery field.

## Verification
- Backend focused: 2 suites, 45 tests passed.
- Backend typecheck and production build passed.
- Frontend full suite: 55 suites, 245 tests passed.
- Frontend production build passed; targeted lint reports 0 errors.
- Real Chromium check at 1280x900 and 390x844: hint renders under the sent message, names the real @aria handle, and produces no horizontal overflow.

## Local environment note
The repository-wide backend run cannot complete under this workstation's Node 26: jsonwebtoken fails at module load because buffer-equal-constant-time reads the removed SlowBuffer.prototype. This reproduces with a bare require of jsonwebtoken and is unrelated to the branch; the focused affected suites pass, and CI's supported Node version remains the merge gate.
