### PR TITLE
feat: add pod invite management (#690)

### DIFF
--- a/backend/__tests__/unit/routes/podInvites.management.test.js
+++ b/backend/__tests__/unit/routes/podInvites.management.test.js
@@ -1,0 +1,153 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.user = { id: 'user1' };
+  req.userId = 'user1';
+  next();
+});
+
+const mockFind = jest.fn();
+const mockFindOne = jest.fn();
+jest.mock('../../../models/PodInvite', () => ({
+  PodInvite: {
+    find: (...args) => mockFind(...args),
+    findOne: (...args) => mockFindOne(...args),
+    create: jest.fn(),
+  },
+}));
+
+// eslint-disable-next-line import/no-unresolved, import/extensions
+const Pod = require('../../../models/Pod');
+
+jest.mock('../../../models/Pod');
+
+jest.mock('../../../services/agentIdentityService', () => ({
+  DM_POD_TYPES_GUARD: new Set(['agent-room', 'agent-dm']),
+}));
+
+// eslint-disable-next-line import/no-unresolved, import/extensions
+const routes = require('../../../routes/podInvites');
+
+const POD_ID = '507f1f77bcf86cd799439011';
+const TOKEN = 'a'.repeat(32);
+const OTHER_TOKEN = 'b'.repeat(32);
+
+const memberPod = (overrides = {}) => ({
+  _id: POD_ID,
+  type: 'chat',
+  createdBy: 'owner',
+  members: ['user1'],
+  ...overrides,
+});
+
+const listChain = (rows) => ({
+  sort: jest.fn().mockReturnValue({
+    populate: jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue(rows),
+    }),
+  }),
+});
+
+describe('pod invite management routes', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api', routes);
+    jest.clearAllMocks();
+  });
+
+  it('lists non-revoked invites for a pod member', async () => {
+    Pod.findById.mockResolvedValue(memberPod());
+    mockFind.mockReturnValue(listChain([{
+      token: TOKEN,
+      createdBy: { _id: 'creator1', username: 'Aria' },
+      createdAt: new Date('2026-07-21T10:00:00Z'),
+      expiresAt: null,
+      maxUses: 10,
+      useCount: 2,
+      revokedAt: null,
+    }]));
+
+    const res = await request(app).get(`/api/pods/${POD_ID}/invites`).expect(200);
+
+    expect(String(Pod.findById.mock.calls[0][0])).toBe(POD_ID);
+    expect(mockFind).toHaveBeenCalledWith({ podId: POD_ID, revokedAt: null });
+    expect(res.body).toEqual([expect.objectContaining({
+      token: TOKEN,
+      createdBy: { _id: 'creator1', username: 'Aria' },
+      maxUses: 10,
+      uses: 2,
+    })]);
+    expect(res.body).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ token: OTHER_TOKEN }),
+    ]));
+  });
+
+  it('refuses to list invites for a non-member', async () => {
+    Pod.findById.mockResolvedValue(memberPod({ members: ['someone-else'] }));
+
+    await request(app).get(`/api/pods/${POD_ID}/invites`).expect(403);
+
+    expect(mockFind).not.toHaveBeenCalled();
+  });
+
+  it('soft-revokes an invite for a pod member', async () => {
+    const invite = {
+      token: TOKEN,
+      podId: POD_ID,
+      revokedAt: null,
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+    mockFindOne.mockResolvedValue(invite);
+    Pod.findById.mockResolvedValue(memberPod());
+
+    const res = await request(app).delete(`/api/invites/${TOKEN}`).expect(200);
+
+    expect(mockFindOne).toHaveBeenCalledWith({ token: TOKEN });
+    expect(invite.revokedAt).toBeInstanceOf(Date);
+    expect(invite.save).toHaveBeenCalledTimes(1);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('refuses to revoke an invite for a non-member', async () => {
+    const invite = {
+      token: TOKEN,
+      podId: POD_ID,
+      revokedAt: null,
+      save: jest.fn(),
+    };
+    mockFindOne.mockResolvedValue(invite);
+    Pod.findById.mockResolvedValue(memberPod({ members: ['someone-else'] }));
+
+    await request(app).delete(`/api/invites/${TOKEN}`).expect(403);
+
+    expect(invite.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects a revoked invite on redemption', async () => {
+    mockFindOne.mockResolvedValue({
+      token: TOKEN,
+      isUsable: () => false,
+    });
+
+    await request(app).post(`/api/invites/${TOKEN}/redeem`).send({}).expect(404);
+
+    expect(Pod.findById).not.toHaveBeenCalled();
+  });
+
+  it('returns the stable refusal code when a personal DM invite is redeemed', async () => {
+    mockFindOne.mockResolvedValue({
+      token: TOKEN,
+      podId: POD_ID,
+      isUsable: () => true,
+    });
+    Pod.findById.mockResolvedValue(memberPod({ type: 'agent-dm' }));
+
+    const res = await request(app).post(`/api/invites/${TOKEN}/redeem`).send({}).expect(403);
+
+    expect(res.body.code).toBe('dm_membership_refused');
+  });
+});

--- a/backend/__tests__/unit/routes/podInvites.preview.test.js
+++ b/backend/__tests__/unit/routes/podInvites.preview.test.js
@@ -18,13 +18,16 @@ jest.mock('../../../models/PodInvite', () => ({
   PodInvite: { findOne: (...args) => mockFindOne(...args), create: jest.fn() },
 }));
 
+// eslint-disable-next-line import/no-unresolved, import/extensions
 const Pod = require('../../../models/Pod');
+
 jest.mock('../../../models/Pod');
 
 jest.mock('../../../services/agentIdentityService', () => ({
-  DM_POD_TYPES_GUARD: new Set(['agent-room', 'agent-dm', 'agent-admin']),
+  DM_POD_TYPES_GUARD: new Set(['agent-room', 'agent-dm']),
 }));
 
+// eslint-disable-next-line import/no-unresolved, import/extensions
 const routes = require('../../../routes/podInvites');
 
 const leanChain = (value) => ({ select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(value) }) });
@@ -75,9 +78,21 @@ describe('GET /api/invites/:token/preview (anonymous)', () => {
 
   it('404s DM-pod invites with the same message as unknown tokens', async () => {
     mockFindOne.mockResolvedValue(usableInvite());
-    Pod.findById.mockReturnValue(leanChain({ _id: 'p1', name: 'Admin: solo', type: 'agent-admin', members: ['a', 'b'] }));
+    Pod.findById.mockReturnValue(leanChain({
+      _id: 'p1', name: 'Aria and Pixel', type: 'agent-dm', members: ['a', 'b'],
+    }));
 
     const res = await request(app).get('/api/invites/tok123/preview').expect(404);
     expect(res.body.msg).toBe('Invite invalid or expired');
+  });
+
+  it('keeps agent-admin pods invitable because they are N:1, not personal DMs', async () => {
+    mockFindOne.mockResolvedValue(usableInvite());
+    Pod.findById.mockReturnValue(leanChain({
+      _id: 'p1', name: 'Admin room', type: 'agent-admin', members: ['a', 'b'],
+    }));
+
+    const res = await request(app).get('/api/invites/tok123/preview').expect(200);
+    expect(res.body.pod.name).toBe('Admin room');
   });
 });

--- a/backend/routes/podInvites.ts
+++ b/backend/routes/podInvites.ts
@@ -6,6 +6,7 @@
 // "you've been invited to X — sign up to join" instead of a blank login wall.
 import express from 'express';
 import crypto, { createHash } from 'crypto';
+import mongoose from 'mongoose';
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 const router = express.Router();
 const auth = require('../middleware/auth');
@@ -88,6 +89,74 @@ router.post('/pods/:podId/invites', inviteWriteRateLimit, auth, async (req: any,
   }
 });
 
+// GET /api/pods/:podId/invites — list the active invite links a pod member
+// can manage. Revoked rows stay in the database for auditability but never
+// return to the shell.
+router.get('/pods/:podId/invites', inviteReadRateLimit, auth, async (req: any, res: any) => {
+  try {
+    const userId = getUserId(req);
+    if (!userId) return res.status(401).json({ msg: 'Unauthorized' });
+    const rawPodId = String(req.params.podId || '');
+    if (!mongoose.Types.ObjectId.isValid(rawPodId)) {
+      return res.status(404).json({ msg: 'Pod not found' });
+    }
+    const podId = new mongoose.Types.ObjectId(rawPodId);
+    const pod = await Pod.findById(podId);
+    if (!pod) return res.status(404).json({ msg: 'Pod not found' });
+    if (!isPodMember(pod, userId)) {
+      return res.status(403).json({ msg: 'Only pod members can manage invites' });
+    }
+    const invites = await PodInvite.find({ podId: pod._id, revokedAt: null })
+      .sort({ createdAt: -1 })
+      .populate('createdBy', 'username profilePicture')
+      .lean();
+    return res.json(invites.map((invite: any) => ({
+      token: invite.token,
+      createdBy: invite.createdBy,
+      createdAt: invite.createdAt,
+      expiresAt: invite.expiresAt,
+      maxUses: invite.maxUses,
+      uses: Number(invite.useCount) || 0,
+    })));
+  } catch (err: any) {
+    console.error('List invites failed:', err.message);
+    return res.status(500).json({ msg: err.message || 'Failed to list invites' });
+  }
+});
+
+// DELETE /api/invites/:token — revoke an invite without deleting its audit
+// row. Any pod member may revoke any link, matching the existing member-level
+// permission to create links for that pod.
+router.delete('/invites/:token', inviteWriteRateLimit, auth, async (req: any, res: any) => {
+  try {
+    const userId = getUserId(req);
+    if (!userId) return res.status(401).json({ msg: 'Unauthorized' });
+    const rawToken = req.params.token;
+    if (typeof rawToken !== 'string') {
+      return res.status(404).json({ msg: 'Invite not found' });
+    }
+    const safeToken = String(rawToken).toLowerCase().replace(/[^a-f0-9]/g, '');
+    if (!safeToken || safeToken !== rawToken.toLowerCase() || !/^[a-f0-9]{32}$/.test(safeToken)) {
+      return res.status(404).json({ msg: 'Invite not found' });
+    }
+    const invite = await PodInvite.findOne({ token: safeToken });
+    if (!invite) return res.status(404).json({ msg: 'Invite not found' });
+    const pod = await Pod.findById(invite.podId);
+    if (!pod) return res.status(404).json({ msg: 'Pod not found' });
+    if (!isPodMember(pod, userId)) {
+      return res.status(403).json({ msg: 'Only pod members can manage invites' });
+    }
+    if (!invite.revokedAt) {
+      invite.revokedAt = new Date();
+      await invite.save();
+    }
+    return res.json({ ok: true });
+  } catch (err: any) {
+    console.error('Revoke invite failed:', err.message);
+    return res.status(500).json({ msg: err.message || 'Failed to revoke invite' });
+  }
+});
+
 // GET /api/invites/:token/preview — ANONYMOUS, minimal disclosure. Lets the
 // redeem page show "you've been invited to <pod>" to logged-out visitors so
 // a shared link funnels into signup instead of a context-free login wall.
@@ -157,8 +226,8 @@ router.get('/invites/:token', inviteReadRateLimit, auth, async (req: any, res: a
 
 // POST /api/invites/:token/redeem — add caller to pod members (idempotent).
 // Increments useCount. Bypasses the pod's invite-only joinPolicy because
-// the token IS the invite. DM pods (agent-room/agent-dm/agent-admin) are
-// strictly 1:1 and refuse — start a fresh DM instead, same rule as joinPod.
+// the token IS the invite. Personal DM pods (agent-room/agent-dm) are
+// strictly 1:1 and refuse — agent-admin stays invitable by design.
 router.post('/invites/:token/redeem', inviteWriteRateLimit, auth, async (req: any, res: any) => {
   try {
     const userId = getUserId(req);
@@ -172,6 +241,7 @@ router.post('/invites/:token/redeem', inviteWriteRateLimit, auth, async (req: an
     const { DM_POD_TYPES_GUARD } = require('../services/agentIdentityService');
     if (DM_POD_TYPES_GUARD.has(String(pod.type))) {
       return res.status(403).json({
+        code: 'dm_membership_refused',
         msg: 'DM pods are 1:1 — invite links cannot grant third-party access. Start a new DM instead.',
       });
     }

--- a/frontend/src/v2/__tests__/V2InviteDmGate.test.tsx
+++ b/frontend/src/v2/__tests__/V2InviteDmGate.test.tsx
@@ -1,0 +1,67 @@
+// @ts-nocheck
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import V2Layout from '../components/V2Layout';
+
+let mockPodType = 'chat';
+
+jest.mock('../hooks/useV2Pods', () => ({
+  useV2Pods: () => ({
+    pods: [{ _id: 'pod-1', name: 'Room', type: mockPodType }],
+    loading: false,
+    error: null,
+    refresh: jest.fn(),
+    createPod: jest.fn(),
+    deletePod: jest.fn(),
+    patchLastMessage: jest.fn(),
+  }),
+}));
+
+jest.mock('../hooks/useV2PodDetail', () => ({
+  useV2PodDetail: () => ({
+    pod: { _id: 'pod-1', name: 'Room', type: mockPodType },
+    members: [],
+    messages: [],
+    agents: [],
+    loading: false,
+    error: null,
+    refresh: jest.fn(),
+    sendMessage: jest.fn(),
+  }),
+}));
+
+jest.mock('../components/V2NavRail', () => () => null);
+jest.mock('../components/V2PodsSidebar', () => () => null);
+jest.mock('../components/V2PodInspector', () => () => null);
+jest.mock('../components/V2InviteModal', () => () => null);
+jest.mock('../components/V2FirstRunHero', () => () => null);
+jest.mock('../components/V2PodChat', () => function MockV2PodChat({ onOpenInvite }) {
+  return <div>{onOpenInvite && <button type="button">Invite</button>}</div>;
+});
+
+const renderLayout = () => render(
+  <MemoryRouter initialEntries={['/v2/pods/pod-1']}>
+    <Routes>
+      <Route path="/v2/pods/:podId" element={<V2Layout selectionMode="param" />} />
+    </Routes>
+  </MemoryRouter>,
+);
+
+describe('V2 invite affordance gating', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test.each(['agent-room', 'agent-dm'])('hides Invite for %s pods', (podType) => {
+    mockPodType = podType;
+    renderLayout();
+    expect(screen.queryByRole('button', { name: 'Invite' })).not.toBeInTheDocument();
+  });
+
+  test.each(['chat', 'agent-admin'])('keeps Invite available for %s pods', (podType) => {
+    mockPodType = podType;
+    renderLayout();
+    expect(screen.getByRole('button', { name: 'Invite' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/v2/__tests__/V2InviteModal.test.tsx
+++ b/frontend/src/v2/__tests__/V2InviteModal.test.tsx
@@ -1,0 +1,76 @@
+// @ts-nocheck
+import React from 'react';
+import {
+  fireEvent, render, screen, waitFor,
+} from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2InviteModal from '../components/V2InviteModal';
+
+const mockApi = {
+  get: jest.fn(),
+  post: jest.fn(),
+  patch: jest.fn(),
+  del: jest.fn(),
+};
+
+jest.mock('../hooks/useV2Api', () => ({
+  useV2Api: () => mockApi,
+}));
+
+const renderModal = () => render(
+  <MemoryRouter>
+    <div className="v2-root">
+      <V2InviteModal open podId="pod-1" podName="Launch room" onClose={jest.fn()} />
+    </div>
+  </MemoryRouter>,
+);
+
+describe('V2InviteModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApi.get.mockResolvedValue([]);
+    mockApi.post.mockResolvedValue({ token: 'c'.repeat(32) });
+    mockApi.del.mockResolvedValue({ ok: true });
+  });
+
+  test('sends the selected expiry and max-use presets when creating a link', async () => {
+    renderModal();
+    await waitFor(() => expect(mockApi.get).toHaveBeenCalledWith('/api/pods/pod-1/invites'));
+
+    fireEvent.change(screen.getByLabelText('Invite expiry'), { target: { value: '720' } });
+    fireEvent.change(screen.getByLabelText('Invite maximum uses'), { target: { value: '10' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Generate invite link' }));
+
+    await waitFor(() => {
+      expect(mockApi.post).toHaveBeenCalledWith('/api/pods/pod-1/invites', {
+        expiresInHours: 720,
+        maxUses: 10,
+      });
+    });
+    expect(await screen.findByLabelText('New invite link')).toHaveValue(
+      `${window.location.origin}/v2/invite/${'c'.repeat(32)}`,
+    );
+  });
+
+  test('renders existing links and removes a row after revoke', async () => {
+    const token = 'a'.repeat(32);
+    mockApi.get.mockResolvedValue([{
+      token,
+      createdBy: { _id: 'user-2', username: 'Aria' },
+      createdAt: new Date(Date.now() - 120_000).toISOString(),
+      expiresAt: null,
+      maxUses: 10,
+      uses: 2,
+    }]);
+    renderModal();
+
+    expect(await screen.findByText('Aria')).toBeInTheDocument();
+    expect(screen.getByText('2 of 10 uses')).toBeInTheDocument();
+    expect(screen.getByText('Never expires')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke invite created by Aria' }));
+
+    await waitFor(() => expect(mockApi.del).toHaveBeenCalledWith(`/api/invites/${token}`));
+    await waitFor(() => expect(screen.queryByText('Aria')).not.toBeInTheDocument());
+  });
+});

--- a/frontend/src/v2/__tests__/V2InviteRedeem.test.tsx
+++ b/frontend/src/v2/__tests__/V2InviteRedeem.test.tsx
@@ -1,0 +1,69 @@
+// @ts-nocheck
+import React from 'react';
+import {
+  fireEvent, render, screen, waitFor,
+} from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import V2InviteRedeem from '../components/V2InviteRedeem';
+
+const mockApi = {
+  get: jest.fn(),
+  post: jest.fn(),
+  patch: jest.fn(),
+  del: jest.fn(),
+};
+
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    loading: false,
+    token: 'jwt',
+    currentUser: { _id: 'user-1', username: 'Sam' },
+  }),
+}));
+
+jest.mock('../hooks/useV2Api', () => ({
+  useV2Api: () => mockApi,
+}));
+
+describe('V2InviteRedeem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApi.get.mockResolvedValue({
+      token: 'a'.repeat(32),
+      pod: {
+        _id: 'private-1',
+        name: 'Private room',
+        type: 'agent-dm',
+        memberCount: 2,
+      },
+      alreadyMember: false,
+      expiresAt: null,
+    });
+  });
+
+  test('explains that a private 1:1 conversation cannot accept invite redemption', async () => {
+    mockApi.post.mockRejectedValue({
+      response: {
+        status: 403,
+        data: {
+          code: 'dm_membership_refused',
+          msg: 'server detail',
+        },
+      },
+    });
+    render(
+      <MemoryRouter initialEntries={[`/v2/invite/${'a'.repeat(32)}`]}>
+        <Routes>
+          <Route path="/v2/invite/:token" element={<V2InviteRedeem />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Join Private room' }));
+
+    await waitFor(() => {
+      expect(screen.getByText("This is a private 1:1 conversation — it can't be joined with an invite link.")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -134,4 +134,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(chip).toContain('max-width: 100%');
     expect(chip).toContain('white-space: normal');
   });
+
+  test('invite management controls collapse to one column on phones', () => {
+    // The modal is wider than the mobile shell and carries two selects plus a
+    // URL/copy row. At <=480px both must wrap or the link input pushes the
+    // Copy action beyond the viewport.
+    expect(ruleBody(v2, '.v2-invite-options')).toContain('repeat(2, minmax(0, 1fr))');
+    expect(v2).toContain('.v2-invite-options {\n    grid-template-columns: minmax(0, 1fr)');
+    expect(v2).toContain('.v2-invite-link-row {\n    flex-wrap: wrap');
+    expect(v2).toContain('.v2-root .v2-invite-link-row button.v2-invite-card__cta,');
+  });
 });

--- a/frontend/src/v2/components/V2InviteModal.tsx
+++ b/frontend/src/v2/components/V2InviteModal.tsx
@@ -1,7 +1,7 @@
 // V2InviteModal — shared invite UI mounted at V2Layout level so both the
 // chat header invite icon (V2PodChat) and the inspector "+ Invite" button
-// (V2PodInspector) can open the same modal. Two tabs: shareable link
-// (people) and an agent install shortcut (browse → install).
+// can open the same modal. Two tabs: shareable links (people) and an agent
+// install shortcut (browse → install).
 import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useV2Api } from '../hooks/useV2Api';
@@ -13,56 +13,147 @@ interface V2InviteModalProps {
   onClose: () => void;
 }
 
+interface ManagedInvite {
+  token: string;
+  createdBy?: string | { _id?: string; username?: string };
+  createdAt: string;
+  expiresAt?: string | null;
+  maxUses?: number | null;
+  uses: number;
+}
+
+type ExpiryPreset = 'never' | '24' | '168' | '720';
+type MaxUsesPreset = 'unlimited' | '1' | '10' | '25';
+
+const inviteUrlFor = (token: string): string => (
+  `${window.location.origin}/v2/invite/${token}`
+);
+
+const creatorName = (invite: ManagedInvite): string => (
+  typeof invite.createdBy === 'object' && invite.createdBy?.username
+    ? invite.createdBy.username
+    : 'Pod member'
+);
+
+const relativeCreatedAt = (value: string): string => {
+  const created = new Date(value).getTime();
+  const elapsed = Date.now() - created;
+  if (!Number.isFinite(created) || elapsed < 0) return 'Recently';
+  const minutes = Math.floor(elapsed / 60_000);
+  if (minutes < 1) return 'Just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(value).toLocaleDateString();
+};
+
+const expiryLabel = (value?: string | null): string => {
+  if (!value) return 'Never expires';
+  const expiry = new Date(value);
+  if (!Number.isFinite(expiry.getTime())) return 'Expiry unavailable';
+  return `Expires ${expiry.toLocaleDateString()}`;
+};
+
 const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onClose }) => {
   const api = useV2Api();
   const navigate = useNavigate();
   const [tab, setTab] = useState<'people' | 'agent'>('people');
   const [url, setUrl] = useState<string>('');
+  const [expiry, setExpiry] = useState<ExpiryPreset>('168');
+  const [maxUses, setMaxUses] = useState<MaxUsesPreset>('unlimited');
+  const [invites, setInvites] = useState<ManagedInvite[]>([]);
   const [busy, setBusy] = useState(false);
+  const [listLoading, setListLoading] = useState(false);
+  const [revokingToken, setRevokingToken] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+  const [copiedToken, setCopiedToken] = useState<string | null>(null);
 
-  // Reset transient state when the modal closes/reopens for a different
-  // pod — otherwise an old invite URL flashes for a beat before regen.
-  useEffect(() => {
-    if (!open) {
-      setTab('people');
-      setUrl('');
-      setError(null);
-      setCopied(false);
-      setBusy(false);
+  const loadInvites = useCallback(async () => {
+    if (!podId) return;
+    setListLoading(true);
+    setListError(null);
+    try {
+      const data = await api.get<ManagedInvite[]>(`/api/pods/${podId}/invites`);
+      setInvites(Array.isArray(data) ? data : []);
+    } catch (err) {
+      const e = err as { response?: { data?: { msg?: string } }; message?: string };
+      setListError(e.response?.data?.msg || e.message || 'Could not load invite links.');
+    } finally {
+      setListLoading(false);
     }
+  }, [api, podId]);
+
+  // Reset transient state when the modal closes or switches pods — otherwise
+  // an old invite URL can flash before the next pod's links load.
+  useEffect(() => {
+    setTab('people');
+    setUrl('');
+    setExpiry('168');
+    setMaxUses('unlimited');
+    setError(null);
+    setListError(null);
+    setCopiedToken(null);
+    setBusy(false);
+    setRevokingToken(null);
+    if (!open) setInvites([]);
   }, [open, podId]);
+
+  useEffect(() => {
+    if (!open || !podId) return;
+    void loadInvites();
+  }, [open, podId, loadInvites]);
 
   const handleGenerate = useCallback(async () => {
     if (!podId) return;
     setBusy(true);
     setError(null);
-    setCopied(false);
+    setCopiedToken(null);
     try {
+      const expiresInHours = expiry === 'never' ? null : Number(expiry);
+      const useLimit = maxUses === 'unlimited' ? null : Number(maxUses);
       const data = await api.post<{ token: string }>(`/api/pods/${podId}/invites`, {
-        expiresInHours: 24 * 7,
+        expiresInHours,
+        maxUses: useLimit,
       });
-      setUrl(`${window.location.origin}/v2/invite/${data.token}`);
+      setUrl(inviteUrlFor(data.token));
+      await loadInvites();
     } catch (err) {
       const e = err as { response?: { data?: { msg?: string } }; message?: string };
       setError(e.response?.data?.msg || e.message || 'Could not generate invite.');
     } finally {
       setBusy(false);
     }
-  }, [api, podId]);
+  }, [api, expiry, loadInvites, maxUses, podId]);
 
-  const handleCopy = useCallback(async () => {
-    if (!url) return;
+  const handleCopy = useCallback(async (link: string, token: string) => {
+    if (!link) return;
     try {
-      await navigator.clipboard.writeText(url);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      await navigator.clipboard.writeText(link);
+      setCopiedToken(token);
+      setTimeout(() => setCopiedToken((current) => (current === token ? null : current)), 1500);
     } catch {
-      // Clipboard unavailable in non-secure contexts — leave the URL
-      // selectable so the user can copy manually.
+      // The generated URL and managed-link inputs stay selectable when the
+      // Clipboard API is unavailable, so manual copy remains possible.
     }
-  }, [url]);
+  }, []);
+
+  const handleRevoke = useCallback(async (token: string) => {
+    setRevokingToken(token);
+    setListError(null);
+    try {
+      await api.del(`/api/invites/${encodeURIComponent(token)}`);
+      setInvites((current) => current.filter((invite) => invite.token !== token));
+      if (url === inviteUrlFor(token)) setUrl('');
+    } catch (err) {
+      const e = err as { response?: { data?: { msg?: string } }; message?: string };
+      setListError(e.response?.data?.msg || e.message || 'Could not revoke invite.');
+    } finally {
+      setRevokingToken(null);
+    }
+  }, [api, url]);
 
   if (!open) return null;
 
@@ -103,14 +194,53 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
           {tab === 'people' && (
             <>
               <p className="v2-modal__hint">
-                Generate a shareable link. Anyone with a Commonly account can use it to join this pod.
+                Create a link anyone with a Commonly account can use to join this pod.
               </p>
-              {url ? (
+              <div className="v2-invite-options">
+                <label className="v2-invite-options__field">
+                  <span>Expires after</span>
+                  <select
+                    className="v2-invite-options__select"
+                    aria-label="Invite expiry"
+                    value={expiry}
+                    onChange={(event) => setExpiry(event.target.value as ExpiryPreset)}
+                  >
+                    <option value="never">Never</option>
+                    <option value="24">24 hours</option>
+                    <option value="168">7 days</option>
+                    <option value="720">30 days</option>
+                  </select>
+                </label>
+                <label className="v2-invite-options__field">
+                  <span>Maximum uses</span>
+                  <select
+                    className="v2-invite-options__select"
+                    aria-label="Invite maximum uses"
+                    value={maxUses}
+                    onChange={(event) => setMaxUses(event.target.value as MaxUsesPreset)}
+                  >
+                    <option value="unlimited">Unlimited</option>
+                    <option value="1">1 use</option>
+                    <option value="10">10 uses</option>
+                    <option value="25">25 uses</option>
+                  </select>
+                </label>
+              </div>
+              <button
+                type="button"
+                className="v2-invite-card__cta"
+                onClick={handleGenerate}
+                disabled={busy}
+              >
+                {busy ? 'Generating…' : 'Generate invite link'}
+              </button>
+              {url && (
                 <>
                   <div className="v2-invite-link-row">
                     <input
                       type="text"
                       className="v2-invite-link"
+                      aria-label="New invite link"
                       readOnly
                       value={url}
                       onFocus={(e) => e.currentTarget.select()}
@@ -118,35 +248,72 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
                     <button
                       type="button"
                       className="v2-invite-card__cta v2-invite-card__cta--secondary"
-                      onClick={handleCopy}
+                      onClick={() => handleCopy(url, 'new')}
                     >
-                      {copied ? 'Copied!' : 'Copy'}
+                      {copiedToken === 'new' ? 'Copied!' : 'Copy'}
                     </button>
                   </div>
                   <p className="v2-modal__hint v2-modal__hint--muted">
-                    Link expires in 7 days. Generate a fresh link any time.
+                    The new link also appears under Active links below.
                   </p>
-                  <button
-                    type="button"
-                    className="v2-invite-card__cta v2-invite-card__cta--secondary"
-                    onClick={handleGenerate}
-                    disabled={busy}
-                    style={{ marginTop: 8 }}
-                  >
-                    {busy ? 'Generating…' : 'Generate new link'}
-                  </button>
                 </>
-              ) : (
-                <button
-                  type="button"
-                  className="v2-invite-card__cta"
-                  onClick={handleGenerate}
-                  disabled={busy}
-                >
-                  {busy ? 'Generating…' : 'Generate invite link'}
-                </button>
               )}
               {error && <div className="v2-modal__error">{error}</div>}
+
+              <section className="v2-invite-manage" aria-labelledby="active-invite-links">
+                <div className="v2-modal__section-title" id="active-invite-links">Active links</div>
+                {listLoading && <div className="v2-invite-manage__empty">Loading links…</div>}
+                {!listLoading && invites.length === 0 && !listError && (
+                  <div className="v2-invite-manage__empty">No active invite links.</div>
+                )}
+                {!listLoading && invites.length > 0 && (
+                  <div className="v2-invite-manage__list">
+                    {invites.map((invite) => {
+                      const link = inviteUrlFor(invite.token);
+                      const creator = creatorName(invite);
+                      return (
+                        <div className="v2-invite-manage__item" key={invite.token}>
+                          <div className="v2-invite-manage__summary">
+                            <strong>{creator}</strong>
+                            <span>{relativeCreatedAt(invite.createdAt)}</span>
+                          </div>
+                          <div className="v2-invite-manage__meta">
+                            <span>{invite.maxUses == null ? `${invite.uses} uses · unlimited` : `${invite.uses} of ${invite.maxUses} uses`}</span>
+                            <span>{expiryLabel(invite.expiresAt)}</span>
+                          </div>
+                          <input
+                            type="text"
+                            className="v2-invite-manage__url"
+                            aria-label={`Invite link created by ${creator}`}
+                            readOnly
+                            value={link}
+                            onFocus={(event) => event.currentTarget.select()}
+                          />
+                          <div className="v2-invite-manage__actions">
+                            <button
+                              type="button"
+                              className="v2-invite-manage__action"
+                              onClick={() => handleCopy(link, invite.token)}
+                            >
+                              {copiedToken === invite.token ? 'Copied!' : 'Copy'}
+                            </button>
+                            <button
+                              type="button"
+                              className="v2-invite-manage__action v2-invite-manage__action--danger"
+                              onClick={() => handleRevoke(invite.token)}
+                              disabled={revokingToken === invite.token}
+                              aria-label={`Revoke invite created by ${creator}`}
+                            >
+                              {revokingToken === invite.token ? 'Revoking…' : 'Revoke'}
+                            </button>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+                {listError && <div className="v2-modal__error">{listError}</div>}
+              </section>
             </>
           )}
           {tab === 'agent' && (

--- a/frontend/src/v2/components/V2InviteRedeem.tsx
+++ b/frontend/src/v2/components/V2InviteRedeem.tsx
@@ -30,6 +30,8 @@ interface InvitePreviewResponse {
   expiresAt?: string | null;
 }
 
+const DM_INVITE_REFUSAL = 'This is a private 1:1 conversation — it can\'t be joined with an invite link.';
+
 const V2InviteRedeem: React.FC = () => {
   const { token } = useParams<{ token: string }>();
   const navigate = useNavigate();
@@ -98,8 +100,12 @@ const V2InviteRedeem: React.FC = () => {
       );
       if (data?.pod?._id) navigate(`/v2/pods/${data.pod._id}`, { replace: true });
     } catch (err) {
-      const e = err as { response?: { data?: { msg?: string } }; message?: string };
-      setError(e.response?.data?.msg || e.message || 'Could not join — try again.');
+      const e = err as { response?: { data?: { code?: string; msg?: string } }; message?: string };
+      setError(
+        e.response?.data?.code === 'dm_membership_refused'
+          ? DM_INVITE_REFUSAL
+          : (e.response?.data?.msg || e.message || 'Could not join — try again.'),
+      );
     } finally {
       setRedeeming(false);
     }

--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -20,6 +20,7 @@ export type InspectorView =
   | { kind: 'artifact'; artifactId: string };
 
 const INSPECTOR_PREF_KEY = 'v2.inspectorCollapsed';
+const INVITE_BLOCKED_POD_TYPES = new Set(['agent-room', 'agent-dm']);
 
 const readInspectorCollapsed = (): boolean => {
   try {
@@ -128,6 +129,13 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
 
   const selectedPodId = paramPodId || null;
   const detail = useV2PodDetail(selectedPodId);
+  // Personal DMs are strictly 1:1. Keep agent-admin out of this set: it is
+  // intentionally N:1 and remains invitable (ADR-001 §3.10).
+  const inviteEnabled = Boolean(
+    selectedPodId
+    && detail.pod
+    && !INVITE_BLOCKED_POD_TYPES.has(String(detail.pod.type)),
+  );
 
   // The inspector is a separate column only when expanded. When collapsed,
   // it's not rendered at all and the chat extends to the right edge — the
@@ -160,7 +168,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
         inspectorCollapsed={inspectorCollapsed}
         onToggleInspector={selectedPodId ? toggleInspector : undefined}
         onOpenMember={openInspectorMember}
-        onOpenInvite={selectedPodId ? openInvite : undefined}
+        onOpenInvite={inviteEnabled ? openInvite : undefined}
         onOpenFile={openInspectorByFileName}
         onOpenMobileNav={openMobileNav}
       />
@@ -173,12 +181,12 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
           onOpenMember={openInspectorMember}
           onOpenArtifact={openInspectorArtifact}
           onBack={resetInspectorView}
-          onOpenInvite={openInvite}
+          onOpenInvite={inviteEnabled ? openInvite : undefined}
           pendingOpenFileName={pendingOpenFileName}
           onPendingOpenFileNameConsumed={clearPendingOpenFileName}
         />
       )}
-      {selectedPodId && detail.pod && (
+      {inviteEnabled && detail.pod && (
         <V2InviteModal
           open={inviteOpen}
           podId={detail.pod._id}

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -33,6 +33,7 @@
   --v2-info: #0891b2;
   --v2-info-soft: #dff4f8;
   --v2-danger: #ef4444;
+  --v2-danger-soft: rgba(239, 68, 68, 0.10);
 
   /* Agent role colors */
   --v2-pink: #f472b6;
@@ -3354,7 +3355,7 @@
 }
 
 .v2-modal {
-  width: min(440px, 100%);
+  width: min(560px, 100%);
   max-height: calc(100vh - 48px);
   overflow: auto;
   background: var(--v2-surface);
@@ -3455,6 +3456,46 @@
   margin-top: 4px;
 }
 
+.v2-modal__section-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--v2-text-primary);
+}
+
+.v2-invite-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.v2-invite-options__field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--v2-text-secondary);
+}
+
+.v2-invite-options__select {
+  width: 100%;
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  font: inherit;
+  font-weight: 500;
+  outline: none;
+}
+
+.v2-invite-options__select:focus {
+  border-color: var(--v2-accent);
+  box-shadow: var(--v2-focus-ring);
+}
+
 .v2-invite-link-row {
   display: flex;
   gap: 6px;
@@ -3466,6 +3507,7 @@
  * primary CTAs). Inside the row it needs to stay sized to its content so
  * the URL input gets the remaining flex space. Without this override the
  * input collapses to ~20px and the URL is invisible. */
+.v2-root .v2-invite-link-row button.v2-invite-card__cta,
 .v2-invite-link-row .v2-invite-card__cta {
   width: auto;
   flex-shrink: 0;
@@ -3488,6 +3530,148 @@
 
 .v2-invite-link:focus {
   border-color: var(--v2-accent);
+}
+
+.v2-invite-manage {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 14px;
+  margin-top: 4px;
+  border-top: 1px solid var(--v2-border-soft);
+}
+
+.v2-invite-manage__empty {
+  padding: 12px;
+  border: 1px dashed var(--v2-border);
+  border-radius: var(--v2-radius-sm);
+  color: var(--v2-text-tertiary);
+  font-size: 11px;
+  text-align: center;
+}
+
+.v2-invite-manage__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.v2-invite-manage__item {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--v2-border-soft);
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-surface);
+}
+
+.v2-invite-manage__summary,
+.v2-invite-manage__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.v2-invite-manage__summary {
+  align-items: baseline;
+  font-size: 11px;
+  color: var(--v2-text-tertiary);
+}
+
+.v2-invite-manage__summary strong {
+  overflow: hidden;
+  color: var(--v2-text-primary);
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-invite-manage__meta {
+  flex-wrap: wrap;
+  margin-top: 3px;
+  color: var(--v2-text-secondary);
+  font-size: 10px;
+}
+
+.v2-invite-manage__url {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  margin-top: 8px;
+  padding: 7px 9px;
+  border: 1px solid var(--v2-border-soft);
+  border-radius: 6px;
+  background: var(--v2-bg-subtle);
+  color: var(--v2-text-secondary);
+  font-family: var(--v2-font-mono);
+  font-size: 10px;
+  outline: none;
+}
+
+.v2-invite-manage__url:focus {
+  border-color: var(--v2-accent);
+}
+
+.v2-invite-manage__actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.v2-root button.v2-invite-manage__action,
+.v2-invite-manage__action {
+  min-width: 0;
+  height: 30px;
+  border: 1px solid var(--v2-border);
+  border-radius: 6px;
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.v2-root button.v2-invite-manage__action:hover,
+.v2-invite-manage__action:hover {
+  background: var(--v2-surface-hover);
+}
+
+.v2-root button.v2-invite-manage__action--danger,
+.v2-invite-manage__action--danger {
+  border-color: var(--v2-danger-soft);
+  color: var(--v2-danger);
+}
+
+.v2-root button.v2-invite-manage__action--danger:hover,
+.v2-invite-manage__action--danger:hover {
+  background: var(--v2-danger-soft);
+}
+
+.v2-root button.v2-invite-manage__action:disabled,
+.v2-invite-manage__action:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 480px) {
+  .v2-modal__overlay {
+    padding: 12px;
+  }
+
+  .v2-invite-options {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .v2-invite-link-row {
+    flex-wrap: wrap;
+  }
+
+  .v2-root .v2-invite-link-row button.v2-invite-card__cta,
+  .v2-invite-link-row .v2-invite-card__cta {
+    width: 100%;
+    height: 34px;
+  }
 }
 
 /* Standalone redeem page — `/v2/invite/:token`. Centered card so the


### PR DESCRIPTION
## Summary
- add member-scoped invite listing and soft revocation, reusing the existing revokedAt/useCount model and redemption guard
- add expiry/max-use presets plus active-link copy/revoke management to the v2 invite modal
- hide invite actions for agent-room/agent-dm while keeping agent-admin invitable, with a friendly DM redemption refusal

## Product decisions
- any pod member may revoke any invite link, symmetric with the existing member-level create permission
- publicRead owner controls remain held and are not part of this PR

## Verification
- backend full suite: 179 suites / 1275 tests passed (Node 20)
- backend focused invite suites: 2 suites / 11 tests passed
- frontend full suite: 58 suites / 253 tests passed
- frontend focused invite/layout suites after final CSS fix: 4 suites / 19 tests passed
- backend TypeScript check and build passed
- frontend production build passed
- changed backend and frontend files pass targeted ESLint; git diff --check passed
- Playwright Chromium passed at 1280x900 and 390x844 with no horizontal overflow; the pass caught and fixed a desktop invite-URL row specificity issue

## Existing baseline notes
- root npm run lint still reports the repository baseline backend JS/TS resolver failures (1,341 errors); changed files pass targeted lint
- frontend npm run typecheck still reports three pre-existing errors in V2GithubPrCard/V2MessageBubble, untouched here

Closes #690