### PR TITLE
feat: add trusted-by landing strip (#708)

### DIFF
--- a/frontend/src/v2/__tests__/V2LandingPage.stats.test.tsx
+++ b/frontend/src/v2/__tests__/V2LandingPage.stats.test.tsx
@@ -19,7 +19,7 @@ const renderLanding = () => render(
   </MemoryRouter>,
 );
 
-describe('V2LandingPage proof stats', () => {
+describe('V2LandingPage public proof', () => {
   let playSpy: jest.SpyInstance;
 
   beforeAll(() => {
@@ -60,5 +60,31 @@ describe('V2LandingPage proof stats', () => {
     expect(stats.queryByText('people')).not.toBeInTheDocument();
     expect(stats.queryByText('ADRs')).not.toBeInTheDocument();
     expect(statsRow?.children).toHaveLength(3);
+  });
+
+  it('renders the provenance-backed trusted-by affiliations', () => {
+    mockAxiosGet.mockResolvedValue({ data: {} });
+
+    const { container } = renderLanding();
+
+    expect(screen.getByText('Trusted by users from')).toBeInTheDocument();
+    expect(screen.getByText('Arista')).toBeInTheDocument();
+    expect(screen.getByText('Peking University')).toBeInTheDocument();
+    expect(screen.getByText('Ajaib')).toBeInTheDocument();
+    expect(Array.from(container.querySelectorAll('.v2-landing__trusted-item')).map(
+      (node) => node.textContent?.replace('·', '').trim(),
+    )).toEqual([
+      'Arista',
+      'UCLA',
+      'Rice University',
+      'Peking University',
+      'University of Pennsylvania',
+      'Yale University',
+      'Columbia University',
+      'McMaster University',
+      'ByteDance',
+      'Microsoft',
+      'Ajaib',
+    ]);
   });
 });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -40,6 +40,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
   const v2 = read('../v2.css');
   const showcase = read('../showcase/v2-showcase.css');
   const aprofile = read('../agents/v2-agent-profile.css');
+  const landing = read('../landing/v2-landing.css');
 
   test('Your Team card name owns its line so the category chip cannot crush it', () => {
     const rule = ruleBody(v2, '.v2-team-card__name');
@@ -143,5 +144,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).toContain('.v2-invite-options {\n    grid-template-columns: minmax(0, 1fr)');
     expect(v2).toContain('.v2-invite-link-row {\n    flex-wrap: wrap');
     expect(v2).toContain('.v2-root .v2-invite-link-row button.v2-invite-card__cta,');
+  });
+
+  test('landing trusted-by affiliations wrap instead of overflowing on phones', () => {
+    // Eleven provenance-backed names fit one line on desktop but need several
+    // lines at 390px. The flex-wrap rule is the load-bearing overflow guard.
+    const trusted = ruleBody(landing, '.v2-landing__trusted');
+    expect(trusted).toContain('display: flex');
+    expect(trusted).toContain('flex-wrap: wrap');
+    expect(trusted).toContain('justify-content: center');
   });
 });

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -29,6 +29,21 @@ const REPO = 'https://github.com/Team-Commonly/commonly';
 const DISCORD_INVITE_URL = 'https://discord.gg/NsS3fzsJDw';
 const X_HANDLE = 'https://x.com/sam_commonly';
 const ADR_COUNT = 15;
+// Issue #708 records the provenance for every affiliation. Keep this ordered
+// list config-shaped so additions require an explicit, reviewable data change.
+const TRUSTED_AFFILIATIONS = [
+  'Arista',
+  'UCLA',
+  'Rice University',
+  'Peking University',
+  'University of Pennsylvania',
+  'Yale University',
+  'Columbia University',
+  'McMaster University',
+  'ByteDance',
+  'Microsoft',
+  'Ajaib',
+] as const;
 
 const Mark: React.FC<{ size?: number }> = ({ size = 26 }) => (
   <svg width={size} height={size} viewBox="0 0 64 64" aria-hidden="true" focusable="false">
@@ -305,6 +320,24 @@ const V2LandingPage: React.FC = () => {
               </figcaption>
             </figure>
           </div>
+        </section>
+
+        {/* Individual affiliations, not organizational endorsements. The
+            provenance for every entry is recorded in issue #708. */}
+        <section
+          className="v2-landing__trusted"
+          data-reveal
+          aria-label={`Trusted by users from ${TRUSTED_AFFILIATIONS.join(', ')}`}
+        >
+          <span className="v2-landing__trusted-label">Trusted by users from</span>
+          {TRUSTED_AFFILIATIONS.map((affiliation, index) => (
+            <span className="v2-landing__trusted-item" key={affiliation}>
+              {affiliation}
+              {index < TRUSTED_AFFILIATIONS.length - 1 && (
+                <span className="v2-landing__trusted-separator" aria-hidden="true">·</span>
+              )}
+            </span>
+          ))}
         </section>
 
         {/* ---- Wedge band ---- */}

--- a/frontend/src/v2/landing/v2-landing.css
+++ b/frontend/src/v2/landing/v2-landing.css
@@ -22,6 +22,7 @@
 
 .v2-landing__bar,
 .v2-landing__hero,
+.v2-landing__trusted,
 .v2-landing__section,
 .v2-landing__wedge,
 .v2-landing__proof,
@@ -235,6 +236,43 @@
   line-height: 1.45;
   color: var(--v2-text-tertiary);
   text-align: center;
+}
+
+/* ---------- Affiliation proof strip ---------- */
+.v2-landing__trusted {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: center;
+  gap: 5px;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  background: var(--v2-bg-subtle);
+  color: var(--v2-text-tertiary);
+  text-align: center;
+}
+
+.v2-landing__trusted-label {
+  flex: 0 0 auto;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--v2-text-muted);
+}
+
+.v2-landing__trusted-item {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: baseline;
+  gap: 5px;
+  white-space: nowrap;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.v2-landing__trusted-separator {
+  color: var(--v2-border-strong);
 }
 
 /* In-action: one full feature row per screenshot — framed shot on one


### PR DESCRIPTION
## Summary
- add the ordered, config-driven 11-name trusted-by strip directly below the landing hero
- keep the claim at individual-affiliation level with the final copy: “Trusted by users from”
- add muted token-based styling that stays one row at 1280px and wraps cleanly at 390px
- pin the exact list/order in the render test and the flex-wrap rule in the layout-invariants test

## Provenance verification
Every entry has an issue-recorded provenance tag; no names were dropped or reordered:
- DB-verified domains: UCLA, Rice University, Peking University, Ajaib
- team/collaborator affiliation: Arista, ByteDance, Microsoft
- founder-vouched: University of Pennsylvania, Yale University, Columbia University, McMaster University

## Honesty rules from #708
> Users from, never org endorsement. Text-only styled names — no trademarked logo images.
>
> List is config-driven; add a name only with a real user behind it. NO Google (sensitive/not-yet), NO unnamed teams.
>
> Muted styling per the design system (small-caps label + gray names, one row on desktop, wraps on mobile — with 11 entries the mobile wrap needs a real-browser check).

## Verification
- full frontend suite: 58 suites / 255 tests passed
- focused landing/layout suites: 2 suites / 15 tests passed
- frontend production build passed
- changed files pass targeted ESLint; git diff --check passed
- Playwright Chromium at 1280×900: all 11 affiliations on one row, correct hero→strip→wedge order, no overflow
- Playwright Chromium at 390×844: multiple centered rows, every item inside the viewport, no strip/page horizontal overflow
- first browser pass exposed Microsoft/Ajaib wrapping on desktop; separator spacing was tightened and the final pass is green

## Existing baseline notes
- full frontend lint still stops on the pre-existing PersonalityBuilder unescaped-apostrophe error; changed files pass targeted lint
- frontend typecheck still reports the three pre-existing V2GithubPrCard/V2MessageBubble errors

Closes #708