### PR TITLE
fix: prevent pod invite route shadowing

### DIFF
--- a/backend/__tests__/unit/server.test.js
+++ b/backend/__tests__/unit/server.test.js
@@ -6,6 +6,20 @@ jest.mock('../../config/db', () => jest.fn());
 jest.mock('../../models/Pod', () => ({
   findById: jest.fn(),
 }));
+jest.mock('../../middleware/auth', () => (req, res, next) => {
+  req.user = { id: 'user1' };
+  req.userId = 'user1';
+  next();
+});
+
+const mockInviteFind = jest.fn();
+jest.mock('../../models/PodInvite', () => ({
+  PodInvite: {
+    find: (...args) => mockInviteFind(...args),
+    findOne: jest.fn(),
+    create: jest.fn(),
+  },
+}));
 
 const mockConnectPG = jest.fn().mockResolvedValue(null);
 jest.mock('../../config/db-pg', () => ({ connectPG: mockConnectPG }));
@@ -93,6 +107,50 @@ describe('server pg status route', () => {
     });
     const res = await request(app).get('/api/pg/status');
     expect(res.body).toEqual({ available: false });
+  });
+});
+
+describe('server route precedence', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('routes pod invite lists before the pods catch-all route', async () => {
+    const podId = '507f1f77bcf86cd799439011';
+    const token = 'a'.repeat(32);
+    // eslint-disable-next-line global-require, import/no-unresolved, import/extensions
+    const Pod = require('../../models/Pod');
+    Pod.findById.mockResolvedValue({
+      _id: podId,
+      createdBy: 'owner',
+      members: ['user1'],
+    });
+    mockInviteFind.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        populate: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue([{
+            token,
+            createdBy: { _id: 'user1', username: 'member' },
+            createdAt: new Date('2026-07-22T12:00:00Z'),
+            expiresAt: null,
+            maxUses: null,
+            useCount: 0,
+          }]),
+        }),
+      }),
+    });
+
+    // Requiring the real app is load-bearing: both pod routers are mounted in
+    // server.ts order, so this test catches the production-only shadowing bug.
+    // eslint-disable-next-line global-require, import/no-unresolved, import/extensions
+    const { app } = require('../../server');
+    const res = await request(app).get(`/api/pods/${podId}/invites`).expect(200);
+
+    expect(mockInviteFind).toHaveBeenCalledWith({ podId, revokedAt: null });
+    expect(res.body).toEqual([
+      expect.objectContaining({ token, uses: 0 }),
+    ]);
   });
 });
 

--- a/backend/__tests__/unit/server.test.js
+++ b/backend/__tests__/unit/server.test.js
@@ -11,6 +11,16 @@ jest.mock('../../middleware/auth', () => (req, res, next) => {
   req.userId = 'user1';
   next();
 });
+jest.mock('../../controllers/podController', () => ({
+  getAllPods: jest.fn((req, res) => res.status(200).end()),
+  getPodsByType: jest.fn((req, res) => res.status(200).end()),
+  getPodById: jest.fn((req, res) => res.status(404).json({ error: 'Pod not found' })),
+  createPod: jest.fn((req, res) => res.status(201).end()),
+  joinPod: jest.fn((req, res) => res.status(200).end()),
+  leavePod: jest.fn((req, res) => res.status(200).end()),
+  removeMember: jest.fn((req, res) => res.status(200).end()),
+  deletePod: jest.fn((req, res) => res.status(200).end()),
+}));
 
 const mockInviteFind = jest.fn();
 jest.mock('../../models/PodInvite', () => ({
@@ -121,6 +131,8 @@ describe('server route precedence', () => {
     const token = 'a'.repeat(32);
     // eslint-disable-next-line global-require, import/no-unresolved, import/extensions
     const Pod = require('../../models/Pod');
+    // eslint-disable-next-line global-require, import/no-unresolved, import/extensions
+    const { getPodById } = require('../../controllers/podController');
     Pod.findById.mockResolvedValue({
       _id: podId,
       createdBy: 'owner',
@@ -148,6 +160,7 @@ describe('server route precedence', () => {
     const res = await request(app).get(`/api/pods/${podId}/invites`).expect(200);
 
     expect(mockInviteFind).toHaveBeenCalledWith({ podId, revokedAt: null });
+    expect(getPodById).not.toHaveBeenCalled();
     expect(res.body).toEqual([
       expect.objectContaining({ token, uses: 0 }),
     ]);

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -183,8 +183,9 @@ app.use('/api/posts', postRoutes);
 app.use('/api/users', userRoutes);
 // Pod invite tokens — both `/api/pods/:podId/invites` (create) and
 // `/api/invites/:token` (resolve / redeem) live in the same router.
-// Keep this before `/api/pods`: that router's `/:type/:id` catch-all would
-// otherwise consume `/api/pods/:podId/invites` as a pod lookup.
+// Route-order hazard: any bare-`/api` router with a two-segment `/pods/*`
+// GET must mount before `/api/pods`. Its `/:type/:id` catch-all would
+// otherwise consume that request as a pod lookup.
 app.use('/api', podInvitesRoutes);
 app.use('/api/pods', podRoutes);
 app.use('/api/messages', messageRoutes);

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -181,10 +181,12 @@ app.use(express.json());
 app.use('/api/auth', authRoutes);
 app.use('/api/posts', postRoutes);
 app.use('/api/users', userRoutes);
-app.use('/api/pods', podRoutes);
 // Pod invite tokens — both `/api/pods/:podId/invites` (create) and
 // `/api/invites/:token` (resolve / redeem) live in the same router.
+// Keep this before `/api/pods`: that router's `/:type/:id` catch-all would
+// otherwise consume `/api/pods/:podId/invites` as a pod lookup.
 app.use('/api', podInvitesRoutes);
+app.use('/api/pods', podRoutes);
 app.use('/api/messages', messageRoutes);
 app.use('/api/uploads', uploadsRoutes);
 app.use('/api/docs', docsRoutes);


### PR DESCRIPTION
## Summary
- mount the pod-invites router before the pods router so `GET /api/pods/:podId/invites` cannot be consumed by the `/:type/:id` catch-all
- document the load-bearing route precedence in `server.ts`
- add a production-shaped regression through the real server app, with both routers mounted exactly as production mounts them

## Verification
- `npx --yes -p node@20 node ./node_modules/jest/bin/jest.js __tests__/unit/server.test.js __tests__/unit/routes/podInvites.management.test.js --runInBand --forceExit` — 15/15 passed
- `npx eslint __tests__/unit/server.test.js` — passed
- `npm run build` — passed
- `npm run tsc:check` — passed
- `git diff --check` — passed

## Lint note
The repository-wide backend `npm run lint` still reports its pre-existing legacy baseline (1,300 errors across untouched files); the changed JavaScript test file is clean, and TypeScript is covered by both build and strict type-check.

## Production regression
This fixes the live 404 introduced by #710. `DELETE /api/invites/:token` is unchanged and was not affected by the collision.