### PR TITLE
ci: allowlist the public community invite token in gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -13,6 +13,10 @@ regexes = [
   '''<your[_-]''',
   # nip.io test/local URLs (not secrets)
   '''\.nip\.io''',
+  # The Commonly HQ community invite token — a DELIBERATELY PUBLIC value
+  # (shared on the landing page, README, and Discord). Tests pin it as the
+  # REACT_APP_COMMUNITY_INVITE_TOKEN fixture; it is not a secret.
+  '''7b91255f18ae3c0ae3721707a6613731''',
 ]
 
 paths = [


### PR DESCRIPTION
Main's Secret Scan went red on `957d215c`: three generic-api-key hits, all the **deliberately-public HQ community invite token** pinned as a test fixture (`REACT_APP_COMMUNITY_INVITE_TOKEN`). PR-level scans only cover PR commits, so it surfaced only on main's full-history scan post-squash.

Adds the literal token to the gitleaks allowlist with a comment explaining it is public by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMeWzgFxsfBcjoLVLewEES