### PR TITLE
feat(i18n): zh-CN Phase 1B — auth and first-run shell chrome

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -35,13 +35,26 @@ module.exports = {
       version: 'detect',
     },
   },
-  // Phase 1A zh-CN manifest. Later phases extend this exact list as each
-  // surface migrates, so translated components cannot regress to JSX literals.
+  // Phase 1 zh-CN manifest. Extend this exact list only as each surface
+  // migrates, so translated components cannot regress to JSX literals.
   overrides: [
     {
       files: [
         'src/v2/landing/V2LandingPage.tsx',
         'src/v2/components/V2LangSwitch.tsx',
+        'src/v2/components/V2AuthBrand.tsx',
+        'src/v2/components/V2Login.tsx',
+        'src/v2/components/V2Register.tsx',
+        'src/v2/components/V2ForgotPassword.tsx',
+        'src/v2/components/V2ResetPassword.tsx',
+        'src/v2/components/V2OAuthButtons.tsx',
+        'src/v2/components/V2OAuthComplete.tsx',
+        'src/v2/components/V2InviteRedeem.tsx',
+        'src/components/RegistrationInviteRequired.tsx',
+        'src/components/VerifyEmail.tsx',
+        'src/v2/components/V2PodChat.tsx',
+        'src/v2/components/V2FirstRunHero.tsx',
+        'src/v2/components/V2InviteModal.tsx',
       ],
       rules: {
         'i18next/no-literal-string': ['error', {

--- a/frontend/src/components/RegistrationInviteRequired.tsx
+++ b/frontend/src/components/RegistrationInviteRequired.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import axios from '../utils/axiosConfig';
+import { useTranslation } from 'react-i18next';
+import V2AuthBrand from '../v2/components/V2AuthBrand';
 
 // v2-native invite-required gate. Pairs with V2Login / V2Register (reuses the
 // .v2-login card styles) so every auth surface matches after v2 became the
@@ -8,14 +10,8 @@ import axios from '../utils/axiosConfig';
 // /v2/register, or submit a waitlist request for admin review. Logic is
 // unchanged from the legacy MUI version — only the presentation is v2.
 
-const Brand: React.FC = () => (
-  <div className="v2-login__brand">
-    <span className="v2-rail__brand-icon">c</span>
-    commonly
-  </div>
-);
-
 const RegistrationInviteRequired: React.FC = () => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [invitationCode, setInvitationCode] = useState('');
   const [waitlistEmail, setWaitlistEmail] = useState('');
@@ -43,12 +39,12 @@ const RegistrationInviteRequired: React.FC = () => {
         name: waitlistName,
         useCase: waitlistNote,
       });
-      setWaitlistSuccess(res.data?.message || 'Waitlist request submitted.');
+      setWaitlistSuccess(res.data?.message || t('auth.inviteRequired.waitlistSubmitted'));
       setWaitlistName('');
       setWaitlistNote('');
     } catch (err: unknown) {
       const e = err as { response?: { data?: { error?: string } } };
-      setWaitlistError(e.response?.data?.error || 'Failed to submit waitlist request');
+      setWaitlistError(e.response?.data?.error || t('auth.inviteRequired.errors.waitlistFailed'));
     } finally {
       setWaitlistLoading(false);
     }
@@ -57,16 +53,15 @@ const RegistrationInviteRequired: React.FC = () => {
   return (
     <div className="v2-login">
       <div className="v2-login__card">
-        <Brand />
-        <h1 className="v2-login__title">Invitation required</h1>
+        <V2AuthBrand />
+        <h1 className="v2-login__title">{t('auth.inviteRequired.title')}</h1>
         <p className="v2-login__subtitle">
-          New account registration is invite-only right now. Enter your invitation code to continue,
-          or join the waitlist for admin review.
+          {t('auth.inviteRequired.subtitle')}
         </p>
 
         <form onSubmit={onContinue}>
           <label className="v2-login__field">
-            <span className="v2-login__label">Invitation code</span>
+            <span className="v2-login__label">{t('auth.inviteRequired.code')}</span>
             <input
               className="v2-login__input"
               type="text"
@@ -76,15 +71,15 @@ const RegistrationInviteRequired: React.FC = () => {
             />
           </label>
           <button type="submit" className="v2-login__submit">
-            Continue to registration
+            {t('auth.inviteRequired.continue')}
           </button>
         </form>
 
-        <div className="v2-login__divider">Need access? Join the waitlist</div>
+        <div className="v2-login__divider">{t('auth.inviteRequired.joinWaitlist')}</div>
 
         <form onSubmit={onWaitlistSubmit}>
           <label className="v2-login__field">
-            <span className="v2-login__label">Email</span>
+            <span className="v2-login__label">{t('auth.fields.email')}</span>
             <input
               className="v2-login__input"
               type="email"
@@ -95,7 +90,7 @@ const RegistrationInviteRequired: React.FC = () => {
             />
           </label>
           <label className="v2-login__field">
-            <span className="v2-login__label">Name (optional)</span>
+            <span className="v2-login__label">{t('auth.inviteRequired.nameOptional')}</span>
             <input
               className="v2-login__input"
               type="text"
@@ -104,7 +99,7 @@ const RegistrationInviteRequired: React.FC = () => {
             />
           </label>
           <label className="v2-login__field">
-            <span className="v2-login__label">Use case (optional)</span>
+            <span className="v2-login__label">{t('auth.inviteRequired.useCaseOptional')}</span>
             <input
               className="v2-login__input"
               type="text"
@@ -117,16 +112,16 @@ const RegistrationInviteRequired: React.FC = () => {
             className="v2-login__submit v2-login__submit--ghost"
             disabled={waitlistLoading}
           >
-            {waitlistLoading ? 'Submitting…' : 'Request waitlist access'}
+            {waitlistLoading ? t('auth.inviteRequired.submitting') : t('auth.inviteRequired.requestAccess')}
           </button>
           {waitlistError && <div className="v2-login__error">{waitlistError}</div>}
           {waitlistSuccess && <div className="v2-login__success">{waitlistSuccess}</div>}
         </form>
 
         <div className="v2-login__hint">
-          Already have an account?
+          {t('auth.register.alreadyHaveAccount')}
           {' '}
-          <Link to="/v2/login" className="v2-login__link">Sign in</Link>
+          <Link to="/v2/login" className="v2-login__link">{t('auth.login.submit')}</Link>
         </div>
       </div>
     </div>

--- a/frontend/src/components/VerifyEmail.tsx
+++ b/frontend/src/components/VerifyEmail.tsx
@@ -2,8 +2,10 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { useSearchParams } from 'react-router-dom';
 import { Box, Button, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 
 const VerifyEmail: React.FC = () => {
+  const { t } = useTranslation();
   const [message, setMessage] = useState('');
   const [searchParams] = useSearchParams();
   const token = searchParams.get('token');
@@ -15,10 +17,10 @@ const VerifyEmail: React.FC = () => {
         .then((res) => setMessage(res.data.message))
         .catch((err: unknown) => {
           const e = err as { response?: { data?: { error?: string } } };
-          setMessage(e.response?.data?.error || 'Verification failed.');
+          setMessage(e.response?.data?.error || t('auth.verify.errors.failed'));
         });
     }
-  }, [token]);
+  }, [t, token]);
 
   return (
     <Box
@@ -43,14 +45,14 @@ const VerifyEmail: React.FC = () => {
         }}
       >
         <Typography variant="h5" sx={{ color: '#e2e8f0', mb: 2, fontWeight: 700 }}>
-          Email Verification
+          {t('auth.verify.title')}
         </Typography>
         <Typography variant="body1" sx={{ color: '#cbd5e1', mb: 3 }}>
-          {message || 'Verifying your email...'}
+          {message || t('auth.verify.verifying')}
         </Typography>
         {Boolean(message) && (
           <Button component="a" href="/login" variant="contained" sx={{ fontWeight: 600 }}>
-            Go to Login
+            {t('auth.verify.goToLogin')}
           </Button>
         )}
       </Box>

--- a/frontend/src/i18n/__tests__/i18n.test.ts
+++ b/frontend/src/i18n/__tests__/i18n.test.ts
@@ -37,4 +37,19 @@ describe('i18n configuration', () => {
     languages.mockRestore();
     language.mockRestore();
   });
+
+  it('interpolates Phase 1B auth and invite chrome in both locales', () => {
+    expect(i18n.t('auth.oauth.continueWith', {
+      lng: 'en',
+      provider: 'GitHub',
+    })).toBe('Continue with GitHub');
+    expect(i18n.t('auth.oauth.continueWith', {
+      lng: 'zh-CN',
+      provider: 'GitHub',
+    })).toBe('使用 GitHub 继续');
+    expect(i18n.t('inviteRedeem.invitedTo', {
+      lng: 'zh-CN',
+      podName: 'Commonly HQ',
+    })).toBe('你受邀加入 Commonly HQ');
+  });
 });

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,10 +1,312 @@
 {
   "common": {
     "brandName": "Commonly",
+    "brandWordmark": "commonly",
+    "agent": "Agent",
+    "close": "Close",
+    "copy": "Copy",
+    "copied": "Copied!",
     "language": {
       "label": "Language",
       "switchToEnglish": "Switch to English",
       "switchToChinese": "Switch to Simplified Chinese"
+    }
+  },
+  "auth": {
+    "fields": {
+      "username": "Username",
+      "email": "Email",
+      "password": "Password"
+    },
+    "login": {
+      "title": "Sign in",
+      "subtitle": "Commonly is the shared space where agents and humans collaborate.",
+      "submit": "Sign in",
+      "signingIn": "Signing in...",
+      "forgotPassword": "Forgot password?",
+      "newToCommonly": "New to Commonly?",
+      "createAccount": "Create an account",
+      "errors": {
+        "failed": "Login failed"
+      },
+      "oauthErrors": {
+        "invitationRequired": "Registration is invite-only right now. Use an invitation link to sign up, or join the waitlist.",
+        "invitationInvalid": "That invitation code is invalid or used up.",
+        "emailUnverified": "Your provider account has no verified email address, so we can't link it safely.",
+        "providerDenied": "Sign-in was cancelled at the provider.",
+        "stateInvalid": "That sign-in attempt expired. Please try again.",
+        "exchangeFailed": "Sign-in could not be completed. Please try again.",
+        "providerError": "Something went wrong talking to the sign-in provider. Please try again.",
+        "botAccount": "This email belongs to an agent account and can't be used for social sign-in."
+      }
+    },
+    "register": {
+      "title": "Create your account",
+      "subtitle": "Join the shared space where agents and humans collaborate.",
+      "invitationCode": "Invitation code (optional)",
+      "invitationPlaceholder": "Unlocks hosted agents",
+      "invitationHint": "No code? Leave blank — you can bring your own agents and redeem a code later in Settings.",
+      "submit": "Create account",
+      "creating": "Creating account...",
+      "alreadyHaveAccount": "Already have an account?",
+      "errors": {
+        "failed": "Registration failed."
+      },
+      "success": {
+        "ready": "Your account is ready. Sign in to continue.",
+        "checkEmailTitle": "Check your email",
+        "createdTitle": "Account created",
+        "checkEmailMessage": "Your account is almost ready. Verify your email to continue.",
+        "verifyThenSignIn": "We sent a verification link to your email. Verify your address, then <signIn>sign in</signIn>.",
+        "continue": "Continue to sign in"
+      }
+    },
+    "oauth": {
+      "or": "or",
+      "continueWith": "Continue with {{provider}}"
+    },
+    "oauthComplete": {
+      "title": "Signing you in…",
+      "subtitle": "Completing sign-in with your provider."
+    },
+    "forgot": {
+      "title": "Reset your password",
+      "instructions": "Enter your account email and we'll send you a reset link. If you signed up with Google or GitHub, you can also just sign in with them.",
+      "sent": "If that email has an account, a reset link is on its way. The link is valid for one hour.",
+      "submit": "Send reset link",
+      "sending": "Sending…",
+      "backToSignIn": "Back to <signIn>sign in</signIn>",
+      "remembered": "Remembered it? <signIn>Sign in</signIn>",
+      "errors": {
+        "failed": "Something went wrong — try again."
+      }
+    },
+    "reset": {
+      "title": "Choose a new password",
+      "updated": "Password updated. You can sign in now.",
+      "goToSignIn": "Go to sign in",
+      "missingToken": "This page needs the reset link from your email. Request a new one below.",
+      "sendNewLink": "Send me a reset link",
+      "newPassword": "New password",
+      "confirmPassword": "Confirm password",
+      "submit": "Update password",
+      "updating": "Updating…",
+      "requestNewLink": "<request>Request a new link</request>",
+      "errors": {
+        "tooShort": "Password must be at least 8 characters.",
+        "mismatch": "Passwords do not match.",
+        "failed": "Reset failed — the link may have expired."
+      }
+    },
+    "inviteRequired": {
+      "title": "Invitation required",
+      "subtitle": "New account registration is invite-only right now. Enter your invitation code to continue, or join the waitlist for admin review.",
+      "code": "Invitation code",
+      "continue": "Continue to registration",
+      "joinWaitlist": "Need access? Join the waitlist",
+      "nameOptional": "Name (optional)",
+      "useCaseOptional": "Use case (optional)",
+      "submitting": "Submitting…",
+      "requestAccess": "Request waitlist access",
+      "waitlistSubmitted": "Waitlist request submitted.",
+      "errors": {
+        "waitlistFailed": "Failed to submit waitlist request"
+      }
+    },
+    "verify": {
+      "title": "Email Verification",
+      "verifying": "Verifying your email...",
+      "goToLogin": "Go to Login",
+      "errors": {
+        "failed": "Verification failed."
+      }
+    }
+  },
+  "inviteRedeem": {
+    "loading": "Loading invite…",
+    "unavailable": "Invite unavailable",
+    "whatIsCommonly": "What is Commonly?",
+    "fallbackPod": "a pod",
+    "untitledPod": "Untitled pod",
+    "invitedTo": "You've been invited to {{podName}}",
+    "previewMeta_one": "{{formattedCount}} member · humans and agents working together on Commonly",
+    "previewMeta_other": "{{formattedCount}} members · humans and agents working together on Commonly",
+    "memberCount_one": "{{formattedCount}} member",
+    "memberCount_other": "{{formattedCount}} members",
+    "signUpToJoin": "Sign up to join",
+    "alreadyHaveAccount": "Already have an account? <login>Log in</login>",
+    "goToPods": "Go to your pods",
+    "goToPod": "Go to pod →",
+    "joining": "Joining…",
+    "joinPod": "Join {{podName}}",
+    "errors": {
+      "invalid": "This invite is no longer valid.",
+      "dmRefused": "This is a private 1:1 conversation — it can't be joined with an invite link.",
+      "joinFailed": "Could not join — try again."
+    }
+  },
+  "firstRun": {
+    "eyebrow": "Your first five minutes",
+    "title": "Bring your agent into the room",
+    "lede": "Connect Claude Code, Cursor, or Codex, then start a private conversation without leaving your workspace.",
+    "skip": "Skip for now",
+    "steps": {
+      "connect": {
+        "title": "Connect your agent",
+        "text": "Generate its private runtime token and copy the setup command for your tool.",
+        "openSetup": "Open connection setup"
+      },
+      "start": {
+        "title": "Start your agent",
+        "connected": "Connected",
+        "connectedStatus": "✓ Connected",
+        "waiting": "Waiting for your agent to connect…"
+      },
+      "hello": {
+        "title": "Start with one hello",
+        "text": "Your agent gets its own durable identity and private 1:1 with you.",
+        "opening": "Opening…",
+        "cta": "Say hello"
+      }
+    },
+    "errors": {
+      "statusUnavailable": "Connection status is temporarily unavailable. We'll keep checking.",
+      "roomFailed": "Could not open your 1:1 yet. Try again."
+    }
+  },
+  "inviteModal": {
+    "dialogLabel": "Invite to pod",
+    "title": "Invite to {{podName}}",
+    "tabs": {
+      "people": "Invite people",
+      "agent": "Add agent"
+    },
+    "peopleHint": "Create a link anyone with a Commonly account can use to join this pod.",
+    "podMember": "Pod member",
+    "options": {
+      "expiresAfter": "Expires after",
+      "expiryLabel": "Invite expiry",
+      "never": "Never",
+      "hours24": "24 hours",
+      "days7": "7 days",
+      "days30": "30 days",
+      "maximumUses": "Maximum uses",
+      "maximumUsesLabel": "Invite maximum uses",
+      "unlimited": "Unlimited",
+      "uses_one": "{{formattedCount}} use",
+      "uses_other": "{{formattedCount}} uses"
+    },
+    "generate": "Generate invite link",
+    "generating": "Generating…",
+    "newLinkLabel": "New invite link",
+    "newLinkHint": "The new link also appears under Active links below.",
+    "activeLinks": "Active links",
+    "loadingLinks": "Loading links…",
+    "noActiveLinks": "No active invite links.",
+    "createdByLabel": "Invite link created by {{creator}}",
+    "revokeLabel": "Revoke invite created by {{creator}}",
+    "revoke": "Revoke",
+    "revoking": "Revoking…",
+    "usage": {
+      "unlimited_one": "{{formattedCount}} use · unlimited",
+      "unlimited_other": "{{formattedCount}} uses · unlimited",
+      "limited": "{{uses}} of {{maxUses}} uses"
+    },
+    "time": {
+      "recently": "Recently",
+      "justNow": "Just now",
+      "minutesAgo_one": "{{formattedCount}}m ago",
+      "minutesAgo_other": "{{formattedCount}}m ago",
+      "hoursAgo_one": "{{formattedCount}}h ago",
+      "hoursAgo_other": "{{formattedCount}}h ago",
+      "daysAgo_one": "{{formattedCount}}d ago",
+      "daysAgo_other": "{{formattedCount}}d ago"
+    },
+    "expiry": {
+      "neverExpires": "Never expires",
+      "unavailable": "Expiry unavailable",
+      "expiresOn": "Expires {{date}}"
+    },
+    "agentHint": "Pick an agent from the catalog to install into this pod.",
+    "browseAgents": "Browse agents →",
+    "errors": {
+      "loadFailed": "Could not load invite links.",
+      "generateFailed": "Could not generate invite.",
+      "revokeFailed": "Could not revoke invite."
+    }
+  },
+  "podChat": {
+    "dmMark": "DM",
+    "invite": "Invite to this pod",
+    "messageFallback": "message",
+    "cancelReply": "Cancel reply",
+    "replyingTo": "Replying to <author>{{author}}</author>:",
+    "deliveryHint": "No agent was notified — @mention one to get a reply. Try <handle>@{{handle}}</handle>.",
+    "typing": {
+      "one": "{{name}} is thinking…",
+      "two": "{{first}} and {{second}} are thinking…",
+      "many_one": "{{first}}, {{second}} and {{formattedCount}} other are thinking…",
+      "many_other": "{{first}}, {{second}} and {{formattedCount}} others are thinking…"
+    },
+    "mentions": {
+      "agentSubtitle": "Agent · @{{handle}}",
+      "member": "Member"
+    },
+    "mobile": {
+      "showPods": "Show pods",
+      "showPodsList": "Show pods list"
+    },
+    "empty": {
+      "noPodTitle": "No pod selected",
+      "noPodText": "Pick a pod from the sidebar, or create a new one to get started.",
+      "botPairTitle": "{{first}} and {{second}} haven't talked yet",
+      "botPairText": "They'll DM each other when one of them needs the other's help.",
+      "agentRoomTitle": "Say hi to {{agentName}}",
+      "agentRoomText": "This is your private 1:1. Choose a prompt below, or write your own.",
+      "noMessagesTitle": "No messages yet",
+      "agentDmText": "This is a private 1:1 conversation. Say hello to get started.",
+      "quietTitle": "This pod is quiet",
+      "quietText": "Use @ to mention an agent or teammate—everyone in the member list can see and reply."
+    },
+    "heartbeat": {
+      "recent_one": "{{formattedCount}} recent heartbeat",
+      "recent_other": "{{formattedCount}} recent heartbeats",
+      "none": "No recent heartbeats"
+    },
+    "team": {
+      "view": "View pod team",
+      "hide": "Hide pod team"
+    },
+    "mode": {
+      "preference": "Pod mode preference",
+      "plan": "Plan",
+      "execute": "Execute",
+      "planDescription": "Discuss and plan with your agents — no actions are run.",
+      "executeDescription": "Agents can take actions and ship work."
+    },
+    "starters": {
+      "label": "Conversation starters",
+      "introduce": "Introduce yourself — what are you best at?",
+      "help": "Here's what I'm working on — where can you help?",
+      "firstQuestion": "What should I ask you first?"
+    },
+    "readOnly": {
+      "label": "Read-only conversation",
+      "title": "Read-only — you're observing this conversation",
+      "botPair": "{{first}} and {{second}} are talking directly. To engage them, @-mention either in a shared team pod.",
+      "agentDm": "You can read this 1:1 but not post. To engage, @-mention the agent in a shared team pod."
+    },
+    "composer": {
+      "placeholder": "Message {{podName}}…",
+      "uploading": "Uploading…",
+      "attachFile": "Attach file",
+      "sending": "Sending…",
+      "send": "Send message",
+      "mentionAgent": "mention an agent",
+      "toSend": "to send"
+    },
+    "errors": {
+      "uploadFailed": "Failed to upload file. Please try again."
     }
   },
   "landing": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1,10 +1,303 @@
 {
   "common": {
     "brandName": "Commonly",
+    "brandWordmark": "commonly",
+    "agent": "智能体",
+    "close": "关闭",
+    "copy": "复制",
+    "copied": "已复制",
     "language": {
       "label": "语言",
       "switchToEnglish": "切换到英文",
       "switchToChinese": "切换到简体中文"
+    }
+  },
+  "auth": {
+    "fields": {
+      "username": "用户名",
+      "email": "邮箱",
+      "password": "密码"
+    },
+    "login": {
+      "title": "登录",
+      "subtitle": "Commonly 是智能体与人共同协作的空间。",
+      "submit": "登录",
+      "signingIn": "正在登录…",
+      "forgotPassword": "忘记密码？",
+      "newToCommonly": "第一次使用 Commonly？",
+      "createAccount": "创建账号",
+      "errors": {
+        "failed": "登录失败"
+      },
+      "oauthErrors": {
+        "invitationRequired": "目前仅限受邀用户注册。请使用邀请链接注册，或加入候补名单。",
+        "invitationInvalid": "邀请码无效或已用完。",
+        "emailUnverified": "第三方账号没有已验证的邮箱，暂时无法安全关联。",
+        "providerDenied": "你已在第三方平台取消登录。",
+        "stateInvalid": "本次登录请求已过期，请重试。",
+        "exchangeFailed": "未能完成登录，请重试。",
+        "providerError": "连接第三方登录平台时出错，请重试。",
+        "botAccount": "该邮箱属于智能体账号，不能用于社交登录。"
+      }
+    },
+    "register": {
+      "title": "创建账号",
+      "subtitle": "加入这个让智能体与人共同协作的空间。",
+      "invitationCode": "邀请码（选填）",
+      "invitationPlaceholder": "解锁托管智能体",
+      "invitationHint": "没有邀请码？可以留空——你仍可接入自己的智能体，之后再到设置中兑换邀请码。",
+      "submit": "创建账号",
+      "creating": "正在创建账号…",
+      "alreadyHaveAccount": "已有账号？",
+      "errors": {
+        "failed": "注册失败。"
+      },
+      "success": {
+        "ready": "账号已创建，可以登录了。",
+        "checkEmailTitle": "查看邮箱",
+        "createdTitle": "账号已创建",
+        "checkEmailMessage": "账号即将就绪，请先验证邮箱。",
+        "verifyThenSignIn": "验证链接已发送到你的邮箱。验证邮箱后即可<signIn>登录</signIn>。",
+        "continue": "继续登录"
+      }
+    },
+    "oauth": {
+      "or": "或",
+      "continueWith": "使用 {{provider}} 继续"
+    },
+    "oauthComplete": {
+      "title": "正在登录…",
+      "subtitle": "正在完成第三方账号登录。"
+    },
+    "forgot": {
+      "title": "重置密码",
+      "instructions": "输入账号邮箱，我们会发送密码重置链接。如果你使用 Google 或 GitHub 注册，也可以直接用相应账号登录。",
+      "sent": "如果该邮箱已注册，密码重置链接很快就会送达。链接有效期为一小时。",
+      "submit": "发送重置链接",
+      "sending": "正在发送…",
+      "backToSignIn": "返回<signIn>登录</signIn>",
+      "remembered": "想起密码了？<signIn>登录</signIn>",
+      "errors": {
+        "failed": "出了点问题，请重试。"
+      }
+    },
+    "reset": {
+      "title": "设置新密码",
+      "updated": "密码已更新，现在可以登录了。",
+      "goToSignIn": "前往登录",
+      "missingToken": "请使用邮件中的密码重置链接打开此页面，也可以在下方申请新链接。",
+      "sendNewLink": "发送新的重置链接",
+      "newPassword": "新密码",
+      "confirmPassword": "确认密码",
+      "submit": "更新密码",
+      "updating": "正在更新…",
+      "requestNewLink": "<request>申请新链接</request>",
+      "errors": {
+        "tooShort": "密码至少需要 8 个字符。",
+        "mismatch": "两次输入的密码不一致。",
+        "failed": "重置失败，链接可能已过期。"
+      }
+    },
+    "inviteRequired": {
+      "title": "需要邀请",
+      "subtitle": "目前仅限受邀用户注册。输入邀请码即可继续，或加入候补名单等待管理员审核。",
+      "code": "邀请码",
+      "continue": "继续注册",
+      "joinWaitlist": "没有邀请？加入候补名单",
+      "nameOptional": "姓名（选填）",
+      "useCaseOptional": "使用场景（选填）",
+      "submitting": "正在提交…",
+      "requestAccess": "申请候补资格",
+      "waitlistSubmitted": "候补申请已提交。",
+      "errors": {
+        "waitlistFailed": "候补申请提交失败"
+      }
+    },
+    "verify": {
+      "title": "邮箱验证",
+      "verifying": "正在验证邮箱…",
+      "goToLogin": "前往登录",
+      "errors": {
+        "failed": "验证失败。"
+      }
+    }
+  },
+  "inviteRedeem": {
+    "loading": "正在加载邀请…",
+    "unavailable": "邀请不可用",
+    "whatIsCommonly": "Commonly 是什么？",
+    "fallbackPod": "一个 Pod",
+    "untitledPod": "未命名 Pod",
+    "invitedTo": "你受邀加入 {{podName}}",
+    "previewMeta": "{{formattedCount}} 位成员 · 人与智能体在 Commonly 中共同协作",
+    "memberCount": "{{formattedCount}} 位成员",
+    "signUpToJoin": "注册并加入",
+    "alreadyHaveAccount": "已有账号？<login>登录</login>",
+    "goToPods": "前往你的 Pod",
+    "goToPod": "前往 Pod →",
+    "joining": "正在加入…",
+    "joinPod": "加入 {{podName}}",
+    "errors": {
+      "invalid": "该邀请已失效。",
+      "dmRefused": "这是一对一私密对话，无法使用邀请链接加入。",
+      "joinFailed": "加入失败，请重试。"
+    }
+  },
+  "firstRun": {
+    "eyebrow": "开始使用的前五分钟",
+    "title": "把你的智能体带进来",
+    "lede": "接入 Claude Code、Cursor 或 Codex，然后直接在工作空间中开始一对一私聊。",
+    "skip": "暂时跳过",
+    "steps": {
+      "connect": {
+        "title": "接入你的智能体",
+        "text": "生成私密运行时令牌，再复制适合你所用工具的设置命令。",
+        "openSetup": "打开接入设置"
+      },
+      "start": {
+        "title": "启动智能体",
+        "connected": "已连接",
+        "connectedStatus": "✓ 已连接",
+        "waiting": "正在等待智能体连接…"
+      },
+      "hello": {
+        "title": "先打声招呼",
+        "text": "你的智能体会获得持久身份，并拥有与你的一对一私聊。",
+        "opening": "正在打开…",
+        "cta": "打个招呼"
+      }
+    },
+    "errors": {
+      "statusUnavailable": "暂时无法查看连接状态，我们会继续检查。",
+      "roomFailed": "暂时无法打开一对一私聊，请重试。"
+    }
+  },
+  "inviteModal": {
+    "dialogLabel": "邀请成员加入 Pod",
+    "title": "邀请成员加入 {{podName}}",
+    "tabs": {
+      "people": "邀请成员",
+      "agent": "添加智能体"
+    },
+    "peopleHint": "创建邀请链接，拥有 Commonly 账号的人都能用它加入这个 Pod。",
+    "podMember": "Pod 成员",
+    "options": {
+      "expiresAfter": "有效期",
+      "expiryLabel": "邀请有效期",
+      "never": "永不过期",
+      "hours24": "24 小时",
+      "days7": "7 天",
+      "days30": "30 天",
+      "maximumUses": "最多使用次数",
+      "maximumUsesLabel": "邀请最多使用次数",
+      "unlimited": "不限次数",
+      "uses": "{{formattedCount}} 次"
+    },
+    "generate": "生成邀请链接",
+    "generating": "正在生成…",
+    "newLinkLabel": "新邀请链接",
+    "newLinkHint": "新链接也会出现在下方的有效链接中。",
+    "activeLinks": "有效链接",
+    "loadingLinks": "正在加载链接…",
+    "noActiveLinks": "暂无有效邀请链接。",
+    "createdByLabel": "{{creator}} 创建的邀请链接",
+    "revokeLabel": "撤销 {{creator}} 创建的邀请",
+    "revoke": "撤销",
+    "revoking": "正在撤销…",
+    "usage": {
+      "unlimited": "已使用 {{formattedCount}} 次 · 不限次数",
+      "limited": "已使用 {{uses}} / {{maxUses}} 次"
+    },
+    "time": {
+      "recently": "最近创建",
+      "justNow": "刚刚",
+      "minutesAgo": "{{formattedCount}} 分钟前",
+      "hoursAgo": "{{formattedCount}} 小时前",
+      "daysAgo": "{{formattedCount}} 天前"
+    },
+    "expiry": {
+      "neverExpires": "永不过期",
+      "unavailable": "无法查看有效期",
+      "expiresOn": "{{date}} 到期"
+    },
+    "agentHint": "从目录中选择要安装到这个 Pod 的智能体。",
+    "browseAgents": "浏览智能体 →",
+    "errors": {
+      "loadFailed": "邀请链接加载失败。",
+      "generateFailed": "邀请链接生成失败。",
+      "revokeFailed": "邀请撤销失败。"
+    }
+  },
+  "podChat": {
+    "dmMark": "私信",
+    "invite": "邀请成员加入这个 Pod",
+    "messageFallback": "消息",
+    "cancelReply": "取消回复",
+    "replyingTo": "回复 <author>{{author}}</author>：",
+    "deliveryHint": "尚未通知任何智能体。@提及一个智能体即可让它回复，例如 <handle>@{{handle}}</handle>。",
+    "typing": {
+      "one": "{{name}} 正在思考…",
+      "two": "{{first}} 和 {{second}} 正在思考…",
+      "many": "{{first}}、{{second}} 和另外 {{formattedCount}} 个智能体正在思考…"
+    },
+    "mentions": {
+      "agentSubtitle": "智能体 · @{{handle}}",
+      "member": "成员"
+    },
+    "mobile": {
+      "showPods": "显示 Pod",
+      "showPodsList": "显示 Pod 列表"
+    },
+    "empty": {
+      "noPodTitle": "尚未选择 Pod",
+      "noPodText": "从侧边栏选择一个 Pod，或新建 Pod 开始使用。",
+      "botPairTitle": "{{first}} 和 {{second}} 还没有聊过",
+      "botPairText": "需要彼此协助时，它们会互发私信。",
+      "agentRoomTitle": "向 {{agentName}} 打个招呼",
+      "agentRoomText": "这是你们的一对一私聊。选择下方提示语，或自己输入消息。",
+      "noMessagesTitle": "暂无消息",
+      "agentDmText": "这是一对一私聊。打个招呼，开始对话。",
+      "quietTitle": "这个 Pod 还很安静",
+      "quietText": "用 @ 提及智能体或队友，成员列表中的所有人都能看到并回复。"
+    },
+    "heartbeat": {
+      "recent": "最近收到 {{formattedCount}} 次心跳",
+      "none": "最近没有收到心跳"
+    },
+    "team": {
+      "view": "查看 Pod 团队",
+      "hide": "隐藏 Pod 团队"
+    },
+    "mode": {
+      "preference": "Pod 模式偏好",
+      "plan": "规划",
+      "execute": "执行",
+      "planDescription": "与智能体讨论并制定计划，不执行任何操作。",
+      "executeDescription": "智能体可以执行操作并交付成果。"
+    },
+    "starters": {
+      "label": "对话开场提示",
+      "introduce": "介绍一下自己——你最擅长什么？",
+      "help": "这是我正在做的事——你能在哪里帮上忙？",
+      "firstQuestion": "我应该先问你什么？"
+    },
+    "readOnly": {
+      "label": "只读对话",
+      "title": "只读模式——你正在旁观这场对话",
+      "botPair": "{{first}} 和 {{second}} 正在直接对话。若要与它们交流，请在共享团队 Pod 中 @提及其中一个。",
+      "agentDm": "你可以阅读这场一对一对话，但不能发消息。若要与该智能体交流，请在共享团队 Pod 中 @提及它。"
+    },
+    "composer": {
+      "placeholder": "发消息到 {{podName}}…",
+      "uploading": "正在上传…",
+      "attachFile": "添加文件",
+      "sending": "正在发送…",
+      "send": "发送消息",
+      "mentionAgent": "提及智能体",
+      "toSend": "发送"
+    },
+    "errors": {
+      "uploadFailed": "文件上传失败，请重试。"
     }
   },
   "landing": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -24,8 +24,8 @@
       "submit": "登录",
       "signingIn": "正在登录…",
       "forgotPassword": "忘记密码？",
-      "newToCommonly": "第一次使用 Commonly？",
-      "createAccount": "创建账号",
+      "newToCommonly": "还没有 Commonly 账号？",
+      "createAccount": "注册",
       "errors": {
         "failed": "登录失败"
       },
@@ -33,7 +33,7 @@
         "invitationRequired": "目前仅限受邀用户注册。请使用邀请链接注册，或加入候补名单。",
         "invitationInvalid": "邀请码无效或已用完。",
         "emailUnverified": "第三方账号没有已验证的邮箱，暂时无法安全关联。",
-        "providerDenied": "你已在第三方平台取消登录。",
+        "providerDenied": "登录已在第三方平台取消。",
         "stateInvalid": "本次登录请求已过期，请重试。",
         "exchangeFailed": "未能完成登录，请重试。",
         "providerError": "连接第三方登录平台时出错，请重试。",
@@ -41,21 +41,21 @@
       }
     },
     "register": {
-      "title": "创建账号",
+      "title": "注册",
       "subtitle": "加入这个让智能体与人共同协作的空间。",
       "invitationCode": "邀请码（选填）",
       "invitationPlaceholder": "解锁托管智能体",
       "invitationHint": "没有邀请码？可以留空——你仍可接入自己的智能体，之后再到设置中兑换邀请码。",
-      "submit": "创建账号",
-      "creating": "正在创建账号…",
+      "submit": "注册",
+      "creating": "正在注册…",
       "alreadyHaveAccount": "已有账号？",
       "errors": {
         "failed": "注册失败。"
       },
       "success": {
-        "ready": "账号已创建，可以登录了。",
+        "ready": "注册完成，可以登录了。",
         "checkEmailTitle": "查看邮箱",
-        "createdTitle": "账号已创建",
+        "createdTitle": "注册完成",
         "checkEmailMessage": "账号即将就绪，请先验证邮箱。",
         "verifyThenSignIn": "验证链接已发送到你的邮箱。验证邮箱后即可<signIn>登录</signIn>。",
         "continue": "继续登录"
@@ -78,7 +78,7 @@
       "backToSignIn": "返回<signIn>登录</signIn>",
       "remembered": "想起密码了？<signIn>登录</signIn>",
       "errors": {
-        "failed": "出了点问题，请重试。"
+        "failed": "出错了，请重试。"
       }
     },
     "reset": {
@@ -129,8 +129,6 @@
     "fallbackPod": "一个 Pod",
     "untitledPod": "未命名 Pod",
     "invitedTo": "你受邀加入 {{podName}}",
-    "previewMeta": "{{formattedCount}} 位成员 · 人与智能体在 Commonly 中共同协作",
-    "memberCount": "{{formattedCount}} 位成员",
     "signUpToJoin": "注册并加入",
     "alreadyHaveAccount": "已有账号？<login>登录</login>",
     "goToPods": "前往你的 Pod",
@@ -139,14 +137,18 @@
     "joinPod": "加入 {{podName}}",
     "errors": {
       "invalid": "该邀请已失效。",
-      "dmRefused": "这是一对一私密对话，无法使用邀请链接加入。",
+      "dmRefused": "这是一对一私信，无法使用邀请链接加入。",
       "joinFailed": "加入失败，请重试。"
-    }
+    },
+    "memberCount_one": "{{formattedCount}} 位成员",
+    "memberCount_other": "{{formattedCount}} 位成员",
+    "previewMeta_one": "{{formattedCount}} 位成员 · 人与智能体在 Commonly 中共同协作",
+    "previewMeta_other": "{{formattedCount}} 位成员 · 人与智能体在 Commonly 中共同协作"
   },
   "firstRun": {
-    "eyebrow": "开始使用的前五分钟",
-    "title": "把你的智能体带进来",
-    "lede": "接入 Claude Code、Cursor 或 Codex，然后直接在工作空间中开始一对一私聊。",
+    "eyebrow": "最初的五分钟",
+    "title": "把你的智能体请进房间",
+    "lede": "接入 Claude Code、Cursor 或 Codex，然后直接在工作空间中开始一对一私信。",
     "skip": "暂时跳过",
     "steps": {
       "connect": {
@@ -162,14 +164,14 @@
       },
       "hello": {
         "title": "先打声招呼",
-        "text": "你的智能体会获得持久身份，并拥有与你的一对一私聊。",
+        "text": "你的智能体会获得持久身份，并拥有与你的一对一私信。",
         "opening": "正在打开…",
         "cta": "打个招呼"
       }
     },
     "errors": {
       "statusUnavailable": "暂时无法查看连接状态，我们会继续检查。",
-      "roomFailed": "暂时无法打开一对一私聊，请重试。"
+      "roomFailed": "暂时无法打开一对一私信，请重试。"
     }
   },
   "inviteModal": {
@@ -191,7 +193,8 @@
       "maximumUses": "最多使用次数",
       "maximumUsesLabel": "邀请最多使用次数",
       "unlimited": "不限次数",
-      "uses": "{{formattedCount}} 次"
+      "uses_one": "{{formattedCount}} 次",
+      "uses_other": "{{formattedCount}} 次"
     },
     "generate": "生成邀请链接",
     "generating": "正在生成…",
@@ -205,15 +208,19 @@
     "revoke": "撤销",
     "revoking": "正在撤销…",
     "usage": {
-      "unlimited": "已使用 {{formattedCount}} 次 · 不限次数",
-      "limited": "已使用 {{uses}} / {{maxUses}} 次"
+      "limited": "已使用 {{uses}} / {{maxUses}} 次",
+      "unlimited_one": "已使用 {{formattedCount}} 次 · 不限次数",
+      "unlimited_other": "已使用 {{formattedCount}} 次 · 不限次数"
     },
     "time": {
-      "recently": "最近创建",
+      "recently": "最近",
       "justNow": "刚刚",
-      "minutesAgo": "{{formattedCount}} 分钟前",
-      "hoursAgo": "{{formattedCount}} 小时前",
-      "daysAgo": "{{formattedCount}} 天前"
+      "daysAgo_one": "{{formattedCount}} 天前",
+      "daysAgo_other": "{{formattedCount}} 天前",
+      "hoursAgo_one": "{{formattedCount}} 小时前",
+      "hoursAgo_other": "{{formattedCount}} 小时前",
+      "minutesAgo_one": "{{formattedCount}} 分钟前",
+      "minutesAgo_other": "{{formattedCount}} 分钟前"
     },
     "expiry": {
       "neverExpires": "永不过期",
@@ -238,7 +245,8 @@
     "typing": {
       "one": "{{name}} 正在思考…",
       "two": "{{first}} 和 {{second}} 正在思考…",
-      "many": "{{first}}、{{second}} 和另外 {{formattedCount}} 个智能体正在思考…"
+      "many_one": "{{first}}、{{second}} 和另外 {{formattedCount}} 个智能体正在思考…",
+      "many_other": "{{first}}、{{second}} 和另外 {{formattedCount}} 个智能体正在思考…"
     },
     "mentions": {
       "agentSubtitle": "智能体 · @{{handle}}",
@@ -254,15 +262,16 @@
       "botPairTitle": "{{first}} 和 {{second}} 还没有聊过",
       "botPairText": "需要彼此协助时，它们会互发私信。",
       "agentRoomTitle": "向 {{agentName}} 打个招呼",
-      "agentRoomText": "这是你们的一对一私聊。选择下方提示语，或自己输入消息。",
+      "agentRoomText": "这是你们的一对一私信。选择下方提示语，或自己输入消息。",
       "noMessagesTitle": "暂无消息",
-      "agentDmText": "这是一对一私聊。打个招呼，开始对话。",
+      "agentDmText": "这是一对一私信。打个招呼，开始对话。",
       "quietTitle": "这个 Pod 还很安静",
       "quietText": "用 @ 提及智能体或队友，成员列表中的所有人都能看到并回复。"
     },
     "heartbeat": {
-      "recent": "最近收到 {{formattedCount}} 次心跳",
-      "none": "最近没有收到心跳"
+      "none": "最近没有收到心跳",
+      "recent_one": "最近收到 {{formattedCount}} 次心跳",
+      "recent_other": "最近收到 {{formattedCount}} 次心跳"
     },
     "team": {
       "view": "查看 Pod 团队",
@@ -285,7 +294,7 @@
       "label": "只读对话",
       "title": "只读模式——你正在旁观这场对话",
       "botPair": "{{first}} 和 {{second}} 正在直接对话。若要与它们交流，请在共享团队 Pod 中 @提及其中一个。",
-      "agentDm": "你可以阅读这场一对一对话，但不能发消息。若要与该智能体交流，请在共享团队 Pod 中 @提及它。"
+      "agentDm": "你可以阅读这场一对一私信，但不能发消息。若要与该智能体交流，请在共享团队 Pod 中 @提及它。"
     },
     "composer": {
       "placeholder": "发消息到 {{podName}}…",

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -1,10 +1,11 @@
 // @ts-nocheck
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import axios from 'axios';
 import { AuthContext } from '../../context/AuthContext';
 import V2App from '../V2App';
+import i18n from '../../i18n';
 
 // Mock surface includes `defaults` and `interceptors` so the transitive
 // import chain (Register → axiosConfig → axios.defaults.baseURL = ...) does
@@ -105,5 +106,21 @@ describe('V2 routing', () => {
       if (originalInviteToken === undefined) delete process.env.REACT_APP_COMMUNITY_INVITE_TOKEN;
       else process.env.REACT_APP_COMMUNITY_INVITE_TOKEN = originalInviteToken;
     }
+  });
+
+  test('renders the migrated auth chrome in Simplified Chinese', async () => {
+    await act(async () => {
+      await i18n.changeLanguage('zh-CN');
+    });
+    const view = renderAt('/v2/login');
+
+    expect(screen.getByRole('heading', { name: '登录' })).toBeInTheDocument();
+    expect(screen.getByLabelText('邮箱')).toBeInTheDocument();
+    expect(screen.getByText('Commonly 是智能体与人共同协作的空间。')).toBeInTheDocument();
+
+    view.unmount();
+    await act(async () => {
+      await i18n.changeLanguage('en');
+    });
   });
 });

--- a/frontend/src/v2/components/V2AuthBrand.tsx
+++ b/frontend/src/v2/components/V2AuthBrand.tsx
@@ -1,22 +1,27 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 // The one brand row for auth-card pages (login / register / forgot / reset /
 // oauth-complete). Same mark as the nav rail and the landing page — the
 // open-C with three dots — NOT a letter "c" (the old auth pages drifted to a
 // plain letter, which read as a different logo next to every other surface).
 // Wordmark stays lowercase to match the rail (app chrome, not marketing).
-const V2AuthBrand: React.FC = () => (
-  <div className="v2-login__brand">
-    <span className="v2-rail__brand-icon" aria-label="Commonly">
-      <svg width="18" height="18" viewBox="0 0 64 64" fill="none" aria-hidden="true">
-        <path d="M 50 17.7 A 22 22 0 1 0 50 46.3" stroke="currentColor" strokeWidth="9" strokeLinecap="round" />
-        <circle cx="25" cy="32" r="2.4" fill="currentColor" />
-        <circle cx="32" cy="32" r="2.4" fill="currentColor" />
-        <circle cx="39" cy="32" r="2.4" fill="currentColor" />
-      </svg>
-    </span>
-    commonly
-  </div>
-);
+const V2AuthBrand: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="v2-login__brand">
+      <span className="v2-rail__brand-icon" aria-label={t('common.brandName')}>
+        <svg width="18" height="18" viewBox="0 0 64 64" fill="none" aria-hidden="true">
+          <path d="M 50 17.7 A 22 22 0 1 0 50 46.3" stroke="currentColor" strokeWidth="9" strokeLinecap="round" />
+          <circle cx="25" cy="32" r="2.4" fill="currentColor" />
+          <circle cx="32" cy="32" r="2.4" fill="currentColor" />
+          <circle cx="39" cy="32" r="2.4" fill="currentColor" />
+        </svg>
+      </span>
+      {t('common.brandWordmark')}
+    </div>
+  );
+};
 
 export default V2AuthBrand;

--- a/frontend/src/v2/components/V2FirstRunHero.tsx
+++ b/frontend/src/v2/components/V2FirstRunHero.tsx
@@ -1,8 +1,11 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useV2Api } from '../hooks/useV2Api';
+import { useTranslation } from 'react-i18next';
 
 const POLL_INTERVAL_MS = 3_000;
+const CHECK_MARK = '✓';
+const EXTERNAL_LINK_MARK = '↗';
 export const FIRST_RUN_DISMISSED_KEY = 'v2.firstRun.dismissed';
 export const FIRST_RUN_STARTED_KEY = 'v2.firstRun.started';
 
@@ -39,7 +42,7 @@ const writeFlag = (key: string, value: boolean): void => {
 
 const StepMark: React.FC<{ done: boolean; children: React.ReactNode }> = ({ done, children }) => (
   <span className={`v2-first-run__step-mark${done ? ' v2-first-run__step-mark--done' : ''}`} aria-hidden="true">
-    {done ? '✓' : children}
+    {done ? CHECK_MARK : children}
   </span>
 );
 
@@ -48,6 +51,7 @@ interface V2FirstRunHeroProps {
 }
 
 const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) => {
+  const { t } = useTranslation();
   const api = useV2Api();
   const navigate = useNavigate();
   const [dismissed, setDismissed] = useState(() => readFlag(FIRST_RUN_DISMISSED_KEY));
@@ -68,9 +72,9 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
       setStatusError(null);
       if (!next.issued) setEngaged(true);
     } catch {
-      setStatusError('Connection status is temporarily unavailable. We’ll keep checking.');
+      setStatusError(t('firstRun.errors.statusUnavailable'));
     }
-  }, [api]);
+  }, [api, t]);
 
   // Reserve the empty-state slot while the ownership probe is unresolved,
   // but do not flash the full onboarding card for an established user.
@@ -149,30 +153,30 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
     } catch (error) {
       const message = (error as { response?: { data?: { message?: string } } })
         ?.response?.data?.message;
-      setRoomError(message || 'Could not open your 1:1 yet. Try again.');
+      setRoomError(message || t('firstRun.errors.roomFailed'));
       setOpeningRoom(false);
     }
   };
 
   return (
     <section className="v2-first-run" aria-labelledby="v2-first-run-title">
-      <div className="v2-first-run__eyebrow">Your first five minutes</div>
+      <div className="v2-first-run__eyebrow">{t('firstRun.eyebrow')}</div>
       <div className="v2-first-run__heading-row">
         <div>
-          <h2 id="v2-first-run-title" className="v2-first-run__title">Bring your agent into the room</h2>
+          <h2 id="v2-first-run-title" className="v2-first-run__title">{t('firstRun.title')}</h2>
           <p className="v2-first-run__lede">
-            Connect Claude Code, Cursor, or Codex, then start a private conversation without leaving your workspace.
+            {t('firstRun.lede')}
           </p>
         </div>
-        <button type="button" className="v2-first-run__skip" onClick={dismiss}>Skip for now</button>
+        <button type="button" className="v2-first-run__skip" onClick={dismiss}>{t('firstRun.skip')}</button>
       </div>
 
       <ol className="v2-first-run__steps">
         <li className="v2-first-run__step">
           <StepMark done={Boolean(status?.issued)}>1</StepMark>
           <div className="v2-first-run__step-body">
-            <strong>Connect your agent</strong>
-            <span>Generate its private runtime token and copy the setup command for your tool.</span>
+            <strong>{t('firstRun.steps.connect.title')}</strong>
+            <span>{t('firstRun.steps.connect.text')}</span>
             {!status?.issued && (
               <a
                 className="v2-first-run__setup"
@@ -181,8 +185,8 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
                 rel="noopener noreferrer"
                 onClick={openSetup}
               >
-                Open connection setup
-                <span aria-hidden="true">↗</span>
+                {t('firstRun.steps.connect.openSetup')}
+                <span aria-hidden="true">{EXTERNAL_LINK_MARK}</span>
               </a>
             )}
           </div>
@@ -191,9 +195,9 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
         <li className="v2-first-run__step">
           <StepMark done={Boolean(status?.connected)}>2</StepMark>
           <div className="v2-first-run__step-body">
-            <strong>{status?.connected ? 'Connected' : 'Start your agent'}</strong>
+            <strong>{status?.connected ? t('firstRun.steps.start.connected') : t('firstRun.steps.start.title')}</strong>
             <span className={status?.connected ? 'v2-first-run__connected' : ''} role="status" aria-live="polite">
-              {status?.connected ? '✓ Connected' : 'Waiting for your agent to connect…'}
+              {status?.connected ? t('firstRun.steps.start.connectedStatus') : t('firstRun.steps.start.waiting')}
             </span>
             {statusError && <span className="v2-first-run__error">{statusError}</span>}
           </div>
@@ -202,8 +206,8 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
         <li className="v2-first-run__step">
           <StepMark done={false}>3</StepMark>
           <div className="v2-first-run__step-body">
-            <strong>Start with one hello</strong>
-            <span>Your agent gets its own durable identity and private 1:1 with you.</span>
+            <strong>{t('firstRun.steps.hello.title')}</strong>
+            <span>{t('firstRun.steps.hello.text')}</span>
             {status?.connected && status.connectedAgent && (
               <button
                 type="button"
@@ -211,7 +215,7 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
                 onClick={sayHello}
                 disabled={openingRoom}
               >
-                {openingRoom ? 'Opening…' : 'Say hello'}
+                {openingRoom ? t('firstRun.steps.hello.opening') : t('firstRun.steps.hello.cta')}
               </button>
             )}
             {roomError && <span className="v2-first-run__error">{roomError}</span>}

--- a/frontend/src/v2/components/V2ForgotPassword.tsx
+++ b/frontend/src/v2/components/V2ForgotPassword.tsx
@@ -2,11 +2,13 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import axios from '../../utils/axiosConfig';
 import V2AuthBrand from './V2AuthBrand';
+import { Trans, useTranslation } from 'react-i18next';
 
 // Forgot-password request form. The backend always answers generically
 // (no account enumeration), so the success state is unconditional once
 // the request lands.
 const V2ForgotPassword: React.FC = () => {
+  const { t } = useTranslation();
   const [email, setEmail] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [done, setDone] = useState(false);
@@ -21,7 +23,7 @@ const V2ForgotPassword: React.FC = () => {
       setDone(true);
     } catch (err) {
       const e1 = err as { response?: { data?: { message?: string; error?: string } } };
-      setError(e1.response?.data?.error || e1.response?.data?.message || 'Something went wrong — try again.');
+      setError(e1.response?.data?.error || e1.response?.data?.message || t('auth.forgot.errors.failed'));
     } finally {
       setSubmitting(false);
     }
@@ -31,25 +33,26 @@ const V2ForgotPassword: React.FC = () => {
     <div className="v2-login">
       <form className="v2-login__card" onSubmit={handleSubmit}>
         <V2AuthBrand />
-        <h1 className="v2-login__title">Reset your password</h1>
+        <h1 className="v2-login__title">{t('auth.forgot.title')}</h1>
         {done ? (
           <>
             <p className="v2-login__subtitle">
-              If that email has an account, a reset link is on its way. The link
-              is valid for one hour.
+              {t('auth.forgot.sent')}
             </p>
             <div className="v2-login__hint">
-              Back to <Link to="/v2/login" className="v2-login__link">sign in</Link>
+              <Trans
+                i18nKey="auth.forgot.backToSignIn"
+                components={{ signIn: <Link to="/v2/login" className="v2-login__link" /> }}
+              />
             </div>
           </>
         ) : (
           <>
             <p className="v2-login__subtitle">
-              Enter your account email and we&apos;ll send you a reset link. If you
-              signed up with Google or GitHub, you can also just sign in with them.
+              {t('auth.forgot.instructions')}
             </p>
             <label className="v2-login__field">
-              <span className="v2-login__label">Email</span>
+              <span className="v2-login__label">{t('auth.fields.email')}</span>
               <input
                 className="v2-login__input"
                 type="email"
@@ -60,11 +63,14 @@ const V2ForgotPassword: React.FC = () => {
               />
             </label>
             <button type="submit" className="v2-login__submit" disabled={submitting}>
-              {submitting ? 'Sending…' : 'Send reset link'}
+              {submitting ? t('auth.forgot.sending') : t('auth.forgot.submit')}
             </button>
             {error && <div className="v2-login__error">{error}</div>}
             <div className="v2-login__hint">
-              Remembered it? <Link to="/v2/login" className="v2-login__link">Sign in</Link>
+              <Trans
+                i18nKey="auth.forgot.remembered"
+                components={{ signIn: <Link to="/v2/login" className="v2-login__link" /> }}
+              />
             </div>
           </>
         )}

--- a/frontend/src/v2/components/V2InviteModal.tsx
+++ b/frontend/src/v2/components/V2InviteModal.tsx
@@ -5,6 +5,8 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useV2Api } from '../hooks/useV2Api';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 
 interface V2InviteModalProps {
   open: boolean;
@@ -24,39 +26,44 @@ interface ManagedInvite {
 
 type ExpiryPreset = 'never' | '24' | '168' | '720';
 type MaxUsesPreset = 'unlimited' | '1' | '10' | '25';
+const CLOSE_MARK = '×';
 
 const inviteUrlFor = (token: string): string => (
   `${window.location.origin}/v2/invite/${token}`
 );
 
-const creatorName = (invite: ManagedInvite): string => (
+const creatorName = (invite: ManagedInvite, t: TFunction): string => (
   typeof invite.createdBy === 'object' && invite.createdBy?.username
     ? invite.createdBy.username
-    : 'Pod member'
+    : t('inviteModal.podMember')
 );
 
-const relativeCreatedAt = (value: string): string => {
+const relativeCreatedAt = (value: string, t: TFunction, locale: string): string => {
   const created = new Date(value).getTime();
   const elapsed = Date.now() - created;
-  if (!Number.isFinite(created) || elapsed < 0) return 'Recently';
+  if (!Number.isFinite(created) || elapsed < 0) return t('inviteModal.time.recently');
   const minutes = Math.floor(elapsed / 60_000);
-  if (minutes < 1) return 'Just now';
-  if (minutes < 60) return `${minutes}m ago`;
+  if (minutes < 1) return t('inviteModal.time.justNow');
+  const format = (count: number) => new Intl.NumberFormat(locale).format(count);
+  if (minutes < 60) return t('inviteModal.time.minutesAgo', { count: minutes, formattedCount: format(minutes) });
   const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
+  if (hours < 24) return t('inviteModal.time.hoursAgo', { count: hours, formattedCount: format(hours) });
   const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d ago`;
-  return new Date(value).toLocaleDateString();
+  if (days < 7) return t('inviteModal.time.daysAgo', { count: days, formattedCount: format(days) });
+  return new Date(value).toLocaleDateString(locale);
 };
 
-const expiryLabel = (value?: string | null): string => {
-  if (!value) return 'Never expires';
+const expiryLabel = (value: string | null | undefined, t: TFunction, locale: string): string => {
+  if (!value) return t('inviteModal.expiry.neverExpires');
   const expiry = new Date(value);
-  if (!Number.isFinite(expiry.getTime())) return 'Expiry unavailable';
-  return `Expires ${expiry.toLocaleDateString()}`;
+  if (!Number.isFinite(expiry.getTime())) return t('inviteModal.expiry.unavailable');
+  return t('inviteModal.expiry.expiresOn', { date: expiry.toLocaleDateString(locale) });
 };
 
 const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onClose }) => {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.resolvedLanguage || i18n.language || 'en';
+  const numberFormatter = new Intl.NumberFormat(locale);
   const api = useV2Api();
   const navigate = useNavigate();
   const [tab, setTab] = useState<'people' | 'agent'>('people');
@@ -80,11 +87,11 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
       setInvites(Array.isArray(data) ? data : []);
     } catch (err) {
       const e = err as { response?: { data?: { msg?: string } }; message?: string };
-      setListError(e.response?.data?.msg || e.message || 'Could not load invite links.');
+      setListError(e.response?.data?.msg || e.message || t('inviteModal.errors.loadFailed'));
     } finally {
       setListLoading(false);
     }
-  }, [api, podId]);
+  }, [api, podId, t]);
 
   // Reset transient state when the modal closes or switches pods — otherwise
   // an old invite URL can flash before the next pod's links load.
@@ -122,11 +129,11 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
       await loadInvites();
     } catch (err) {
       const e = err as { response?: { data?: { msg?: string } }; message?: string };
-      setError(e.response?.data?.msg || e.message || 'Could not generate invite.');
+      setError(e.response?.data?.msg || e.message || t('inviteModal.errors.generateFailed'));
     } finally {
       setBusy(false);
     }
-  }, [api, expiry, loadInvites, maxUses, podId]);
+  }, [api, expiry, loadInvites, maxUses, podId, t]);
 
   const handleCopy = useCallback(async (link: string, token: string) => {
     if (!link) return;
@@ -149,11 +156,11 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
       if (url === inviteUrlFor(token)) setUrl('');
     } catch (err) {
       const e = err as { response?: { data?: { msg?: string } }; message?: string };
-      setListError(e.response?.data?.msg || e.message || 'Could not revoke invite.');
+      setListError(e.response?.data?.msg || e.message || t('inviteModal.errors.revokeFailed'));
     } finally {
       setRevokingToken(null);
     }
-  }, [api, url]);
+  }, [api, t, url]);
 
   if (!open) return null;
 
@@ -162,13 +169,13 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
       className="v2-modal__overlay"
       role="dialog"
       aria-modal="true"
-      aria-label="Invite to pod"
+      aria-label={t('inviteModal.dialogLabel')}
       onClick={onClose}
     >
       <div className="v2-modal" onClick={(e) => e.stopPropagation()}>
         <div className="v2-modal__head">
-          <div className="v2-modal__title">Invite to {podName}</div>
-          <button type="button" className="v2-modal__close" aria-label="Close" onClick={onClose}>×</button>
+          <div className="v2-modal__title">{t('inviteModal.title', { podName })}</div>
+          <button type="button" className="v2-modal__close" aria-label={t('common.close')} onClick={onClose}>{CLOSE_MARK}</button>
         </div>
         <div className="v2-modal__tabs" role="tablist">
           <button
@@ -178,7 +185,7 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
             aria-selected={tab === 'people'}
             onClick={() => setTab('people')}
           >
-            Invite people
+            {t('inviteModal.tabs.people')}
           </button>
           <button
             type="button"
@@ -187,42 +194,42 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
             aria-selected={tab === 'agent'}
             onClick={() => setTab('agent')}
           >
-            Add agent
+            {t('inviteModal.tabs.agent')}
           </button>
         </div>
         <div className="v2-modal__body">
           {tab === 'people' && (
             <>
               <p className="v2-modal__hint">
-                Create a link anyone with a Commonly account can use to join this pod.
+                {t('inviteModal.peopleHint')}
               </p>
               <div className="v2-invite-options">
                 <label className="v2-invite-options__field">
-                  <span>Expires after</span>
+                  <span>{t('inviteModal.options.expiresAfter')}</span>
                   <select
                     className="v2-invite-options__select"
-                    aria-label="Invite expiry"
+                    aria-label={t('inviteModal.options.expiryLabel')}
                     value={expiry}
                     onChange={(event) => setExpiry(event.target.value as ExpiryPreset)}
                   >
-                    <option value="never">Never</option>
-                    <option value="24">24 hours</option>
-                    <option value="168">7 days</option>
-                    <option value="720">30 days</option>
+                    <option value="never">{t('inviteModal.options.never')}</option>
+                    <option value="24">{t('inviteModal.options.hours24')}</option>
+                    <option value="168">{t('inviteModal.options.days7')}</option>
+                    <option value="720">{t('inviteModal.options.days30')}</option>
                   </select>
                 </label>
                 <label className="v2-invite-options__field">
-                  <span>Maximum uses</span>
+                  <span>{t('inviteModal.options.maximumUses')}</span>
                   <select
                     className="v2-invite-options__select"
-                    aria-label="Invite maximum uses"
+                    aria-label={t('inviteModal.options.maximumUsesLabel')}
                     value={maxUses}
                     onChange={(event) => setMaxUses(event.target.value as MaxUsesPreset)}
                   >
-                    <option value="unlimited">Unlimited</option>
-                    <option value="1">1 use</option>
-                    <option value="10">10 uses</option>
-                    <option value="25">25 uses</option>
+                    <option value="unlimited">{t('inviteModal.options.unlimited')}</option>
+                    <option value="1">{t('inviteModal.options.uses', { count: 1, formattedCount: numberFormatter.format(1) })}</option>
+                    <option value="10">{t('inviteModal.options.uses', { count: 10, formattedCount: numberFormatter.format(10) })}</option>
+                    <option value="25">{t('inviteModal.options.uses', { count: 25, formattedCount: numberFormatter.format(25) })}</option>
                   </select>
                 </label>
               </div>
@@ -232,7 +239,7 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
                 onClick={handleGenerate}
                 disabled={busy}
               >
-                {busy ? 'Generating…' : 'Generate invite link'}
+                {busy ? t('inviteModal.generating') : t('inviteModal.generate')}
               </button>
               {url && (
                 <>
@@ -240,7 +247,7 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
                     <input
                       type="text"
                       className="v2-invite-link"
-                      aria-label="New invite link"
+                      aria-label={t('inviteModal.newLinkLabel')}
                       readOnly
                       value={url}
                       onFocus={(e) => e.currentTarget.select()}
@@ -250,41 +257,49 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
                       className="v2-invite-card__cta v2-invite-card__cta--secondary"
                       onClick={() => handleCopy(url, 'new')}
                     >
-                      {copiedToken === 'new' ? 'Copied!' : 'Copy'}
+                      {copiedToken === 'new' ? t('common.copied') : t('common.copy')}
                     </button>
                   </div>
                   <p className="v2-modal__hint v2-modal__hint--muted">
-                    The new link also appears under Active links below.
+                    {t('inviteModal.newLinkHint')}
                   </p>
                 </>
               )}
               {error && <div className="v2-modal__error">{error}</div>}
 
               <section className="v2-invite-manage" aria-labelledby="active-invite-links">
-                <div className="v2-modal__section-title" id="active-invite-links">Active links</div>
-                {listLoading && <div className="v2-invite-manage__empty">Loading links…</div>}
+                <div className="v2-modal__section-title" id="active-invite-links">{t('inviteModal.activeLinks')}</div>
+                {listLoading && <div className="v2-invite-manage__empty">{t('inviteModal.loadingLinks')}</div>}
                 {!listLoading && invites.length === 0 && !listError && (
-                  <div className="v2-invite-manage__empty">No active invite links.</div>
+                  <div className="v2-invite-manage__empty">{t('inviteModal.noActiveLinks')}</div>
                 )}
                 {!listLoading && invites.length > 0 && (
                   <div className="v2-invite-manage__list">
                     {invites.map((invite) => {
                       const link = inviteUrlFor(invite.token);
-                      const creator = creatorName(invite);
+                      const creator = creatorName(invite, t);
                       return (
                         <div className="v2-invite-manage__item" key={invite.token}>
                           <div className="v2-invite-manage__summary">
                             <strong>{creator}</strong>
-                            <span>{relativeCreatedAt(invite.createdAt)}</span>
+                            <span>{relativeCreatedAt(invite.createdAt, t, locale)}</span>
                           </div>
                           <div className="v2-invite-manage__meta">
-                            <span>{invite.maxUses == null ? `${invite.uses} uses · unlimited` : `${invite.uses} of ${invite.maxUses} uses`}</span>
-                            <span>{expiryLabel(invite.expiresAt)}</span>
+                            <span>{invite.maxUses == null
+                              ? t('inviteModal.usage.unlimited', {
+                                count: invite.uses,
+                                formattedCount: numberFormatter.format(invite.uses),
+                              })
+                              : t('inviteModal.usage.limited', {
+                                uses: numberFormatter.format(invite.uses),
+                                maxUses: numberFormatter.format(invite.maxUses),
+                              })}</span>
+                            <span>{expiryLabel(invite.expiresAt, t, locale)}</span>
                           </div>
                           <input
                             type="text"
                             className="v2-invite-manage__url"
-                            aria-label={`Invite link created by ${creator}`}
+                            aria-label={t('inviteModal.createdByLabel', { creator })}
                             readOnly
                             value={link}
                             onFocus={(event) => event.currentTarget.select()}
@@ -295,16 +310,16 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
                               className="v2-invite-manage__action"
                               onClick={() => handleCopy(link, invite.token)}
                             >
-                              {copiedToken === invite.token ? 'Copied!' : 'Copy'}
+                              {copiedToken === invite.token ? t('common.copied') : t('common.copy')}
                             </button>
                             <button
                               type="button"
                               className="v2-invite-manage__action v2-invite-manage__action--danger"
                               onClick={() => handleRevoke(invite.token)}
                               disabled={revokingToken === invite.token}
-                              aria-label={`Revoke invite created by ${creator}`}
+                              aria-label={t('inviteModal.revokeLabel', { creator })}
                             >
-                              {revokingToken === invite.token ? 'Revoking…' : 'Revoke'}
+                              {revokingToken === invite.token ? t('inviteModal.revoking') : t('inviteModal.revoke')}
                             </button>
                           </div>
                         </div>
@@ -319,7 +334,7 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
           {tab === 'agent' && (
             <>
               <p className="v2-modal__hint">
-                Pick an agent from the catalog to install into this pod.
+                {t('inviteModal.agentHint')}
               </p>
               <button
                 type="button"
@@ -329,7 +344,7 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
                   navigate(`/v2/agents/browse?podId=${podId}`);
                 }}
               >
-                Browse agents →
+                {t('inviteModal.browseAgents')}
               </button>
             </>
           )}

--- a/frontend/src/v2/components/V2InviteRedeem.tsx
+++ b/frontend/src/v2/components/V2InviteRedeem.tsx
@@ -9,6 +9,7 @@ import axios from 'axios';
 import { useAuth } from '../../context/AuthContext';
 import { useV2Api } from '../hooks/useV2Api';
 import V2Avatar from './V2Avatar';
+import { Trans, useTranslation } from 'react-i18next';
 
 interface InvitePodInfo {
   _id: string;
@@ -30,9 +31,9 @@ interface InvitePreviewResponse {
   expiresAt?: string | null;
 }
 
-const DM_INVITE_REFUSAL = 'This is a private 1:1 conversation — it can\'t be joined with an invite link.';
-
 const V2InviteRedeem: React.FC = () => {
+  const { t, i18n } = useTranslation();
+  const numberFormatter = new Intl.NumberFormat(i18n.resolvedLanguage || i18n.language || 'en');
   const { token } = useParams<{ token: string }>();
   const navigate = useNavigate();
   const location = useLocation();
@@ -59,13 +60,13 @@ const V2InviteRedeem: React.FC = () => {
         );
         if (!cancelled) setPreview(res.data);
       } catch {
-        if (!cancelled) setError('This invite is no longer valid.');
+        if (!cancelled) setError(t('inviteRedeem.errors.invalid'));
       } finally {
         if (!cancelled) setLoading(false);
       }
     })();
     return () => { cancelled = true; };
-  }, [authLoading, isAuthenticated, token]);
+  }, [authLoading, isAuthenticated, t, token]);
 
   // Resolve the invite once auth is confirmed. Idempotent — server returns
   // alreadyMember=true if the user already belongs to the pod, and the UI
@@ -81,13 +82,13 @@ const V2InviteRedeem: React.FC = () => {
       } catch (err) {
         if (cancelled) return;
         const e = err as { response?: { data?: { msg?: string } }; message?: string };
-        setError(e.response?.data?.msg || e.message || 'This invite is no longer valid.');
+        setError(e.response?.data?.msg || e.message || t('inviteRedeem.errors.invalid'));
       } finally {
         if (!cancelled) setLoading(false);
       }
     })();
     return () => { cancelled = true; };
-  }, [authLoading, isAuthenticated, token, api]);
+  }, [authLoading, isAuthenticated, token, api, t]);
 
   const handleJoin = async () => {
     if (!token) return;
@@ -103,8 +104,8 @@ const V2InviteRedeem: React.FC = () => {
       const e = err as { response?: { data?: { code?: string; msg?: string } }; message?: string };
       setError(
         e.response?.data?.code === 'dm_membership_refused'
-          ? DM_INVITE_REFUSAL
-          : (e.response?.data?.msg || e.message || 'Could not join — try again.'),
+          ? t('inviteRedeem.errors.dmRefused')
+          : (e.response?.data?.msg || e.message || t('inviteRedeem.errors.joinFailed')),
       );
     } finally {
       setRedeeming(false);
@@ -112,7 +113,7 @@ const V2InviteRedeem: React.FC = () => {
   };
 
   if (authLoading || loading) {
-    return <div className="v2-invite-page"><div className="v2-invite-card v2-invite-card--loading">Loading invite…</div></div>;
+    return <div className="v2-invite-page"><div className="v2-invite-card v2-invite-card--loading">{t('inviteRedeem.loading')}</div></div>;
   }
 
   // ---- anonymous: preview + signup funnel ----
@@ -121,33 +122,35 @@ const V2InviteRedeem: React.FC = () => {
       return (
         <div className="v2-invite-page">
           <div className="v2-invite-card">
-            <div className="v2-invite-card__title">Invite unavailable</div>
-            <div className="v2-invite-card__error">{error || 'This invite is no longer valid.'}</div>
-            <Link to="/v2" className="v2-invite-card__cta">What is Commonly?</Link>
+            <div className="v2-invite-card__title">{t('inviteRedeem.unavailable')}</div>
+            <div className="v2-invite-card__error">{error || t('inviteRedeem.errors.invalid')}</div>
+            <Link to="/v2" className="v2-invite-card__cta">{t('inviteRedeem.whatIsCommonly')}</Link>
           </div>
         </div>
       );
     }
-    const podName = preview.pod?.name || 'a pod';
+    const podName = preview.pod?.name || t('inviteRedeem.fallbackPod');
     const count = preview.pod?.memberCount ?? 0;
     return (
       <div className="v2-invite-page">
         <div className="v2-invite-card">
           <V2Avatar name={podName} size="lg" />
-          <div className="v2-invite-card__title">You&rsquo;ve been invited to {podName}</div>
+          <div className="v2-invite-card__title">{t('inviteRedeem.invitedTo', { podName })}</div>
           <div className="v2-invite-card__meta">
-            {count} member{count === 1 ? '' : 's'} · humans and agents working together on Commonly
+            {t('inviteRedeem.previewMeta', { count, formattedCount: numberFormatter.format(count) })}
           </div>
           <button
             type="button"
             className="v2-invite-card__cta"
             onClick={() => navigate(`/v2/register?next=${nextParam}`)}
           >
-            Sign up to join
+            {t('inviteRedeem.signUpToJoin')}
           </button>
           <div className="v2-invite-card__meta">
-            Already have an account?{' '}
-            <Link to={`/v2/login?next=${nextParam}`} className="v2-login__link">Log in</Link>
+            <Trans
+              i18nKey="inviteRedeem.alreadyHaveAccount"
+              components={{ login: <Link to={`/v2/login?next=${nextParam}`} className="v2-login__link" /> }}
+            />
           </div>
         </div>
       </div>
@@ -159,10 +162,10 @@ const V2InviteRedeem: React.FC = () => {
     return (
       <div className="v2-invite-page">
         <div className="v2-invite-card">
-          <div className="v2-invite-card__title">Invite unavailable</div>
+          <div className="v2-invite-card__title">{t('inviteRedeem.unavailable')}</div>
           <div className="v2-invite-card__error">{error}</div>
           <button type="button" className="v2-invite-card__cta" onClick={() => navigate('/v2', { replace: true })}>
-            Go to your pods
+            {t('inviteRedeem.goToPods')}
           </button>
         </div>
       </div>
@@ -171,7 +174,7 @@ const V2InviteRedeem: React.FC = () => {
   if (!invite) return null;
 
   const pod = invite.pod;
-  const podName = pod.name || 'Untitled pod';
+  const podName = pod.name || t('inviteRedeem.untitledPod');
 
   return (
     <div className="v2-invite-page">
@@ -182,7 +185,10 @@ const V2InviteRedeem: React.FC = () => {
           <div className="v2-invite-card__description">{pod.description}</div>
         )}
         <div className="v2-invite-card__meta">
-          {pod.memberCount ?? 0} member{pod.memberCount === 1 ? '' : 's'}
+          {t('inviteRedeem.memberCount', {
+            count: pod.memberCount ?? 0,
+            formattedCount: numberFormatter.format(pod.memberCount ?? 0),
+          })}
         </div>
         {error && <div className="v2-invite-card__error">{error}</div>}
         {invite.alreadyMember ? (
@@ -191,7 +197,7 @@ const V2InviteRedeem: React.FC = () => {
             className="v2-invite-card__cta"
             onClick={() => navigate(`/v2/pods/${pod._id}`, { replace: true })}
           >
-            Go to pod →
+            {t('inviteRedeem.goToPod')}
           </button>
         ) : (
           <button
@@ -200,7 +206,7 @@ const V2InviteRedeem: React.FC = () => {
             onClick={handleJoin}
             disabled={redeeming}
           >
-            {redeeming ? 'Joining…' : `Join ${podName}`}
+            {redeeming ? t('inviteRedeem.joining') : t('inviteRedeem.joinPod', { podName })}
           </button>
         )}
       </div>

--- a/frontend/src/v2/components/V2Login.tsx
+++ b/frontend/src/v2/components/V2Login.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
+import { useTranslation } from 'react-i18next';
 import V2OAuthButtons from './V2OAuthButtons';
 import V2AuthBrand from './V2AuthBrand';
 
@@ -10,19 +11,20 @@ interface LocationState {
 
 // Error codes the backend OAuth callback can bounce back with (as
 // ?oauthError=). Anything unlisted falls through to the generic line.
-const OAUTH_ERROR_MESSAGES: Record<string, string> = {
-  invitation_required: 'Registration is invite-only right now. Use an invitation link to sign up, or join the waitlist.',
-  invitation_invalid: 'That invitation code is invalid or used up.',
-  email_unverified: 'Your provider account has no verified email address, so we can\'t link it safely.',
-  provider_denied: 'Sign-in was cancelled at the provider.',
-  state_invalid: 'That sign-in attempt expired. Please try again.',
-  exchange_failed: 'Sign-in could not be completed. Please try again.',
-  provider_error: 'Something went wrong talking to the sign-in provider. Please try again.',
-  bot_account: 'This email belongs to an agent account and can\'t be used for social sign-in.',
+const OAUTH_ERROR_KEYS: Record<string, string> = {
+  invitation_required: 'auth.login.oauthErrors.invitationRequired',
+  invitation_invalid: 'auth.login.oauthErrors.invitationInvalid',
+  email_unverified: 'auth.login.oauthErrors.emailUnverified',
+  provider_denied: 'auth.login.oauthErrors.providerDenied',
+  state_invalid: 'auth.login.oauthErrors.stateInvalid',
+  exchange_failed: 'auth.login.oauthErrors.exchangeFailed',
+  provider_error: 'auth.login.oauthErrors.providerError',
+  bot_account: 'auth.login.oauthErrors.botAccount',
 };
 
 const V2Login: React.FC = () => {
   const { login, error: authError, loading } = useAuth();
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
   const [email, setEmail] = useState('');
@@ -48,7 +50,7 @@ const V2Login: React.FC = () => {
       navigate(dest, { replace: true });
     } catch (err) {
       const e1 = err as { response?: { data?: { error?: string; msg?: string } }; message?: string };
-      setLocalError(e1.response?.data?.error || e1.response?.data?.msg || e1.message || 'Login failed');
+      setLocalError(e1.response?.data?.error || e1.response?.data?.msg || e1.message || t('auth.login.errors.failed'));
     } finally {
       setSubmitting(false);
     }
@@ -57,7 +59,7 @@ const V2Login: React.FC = () => {
   const params = new URLSearchParams(location.search);
   const oauthErrorCode = params.get('oauthError');
   const oauthError = oauthErrorCode
-    ? (OAUTH_ERROR_MESSAGES[oauthErrorCode] || OAUTH_ERROR_MESSAGES.provider_error)
+    ? t(OAUTH_ERROR_KEYS[oauthErrorCode] || OAUTH_ERROR_KEYS.provider_error)
     : null;
   const nextPath = params.get('next') || undefined;
 
@@ -67,13 +69,13 @@ const V2Login: React.FC = () => {
     <div className="v2-login">
       <form className="v2-login__card" onSubmit={handleSubmit}>
         <V2AuthBrand />
-        <h1 className="v2-login__title">Sign in</h1>
+        <h1 className="v2-login__title">{t('auth.login.title')}</h1>
         <p className="v2-login__subtitle">
-          Commonly is the shared space where agents and humans collaborate.
+          {t('auth.login.subtitle')}
         </p>
 
         <label className="v2-login__field">
-          <span className="v2-login__label">Email</span>
+          <span className="v2-login__label">{t('auth.fields.email')}</span>
           <input
             className="v2-login__input"
             type="email"
@@ -85,7 +87,7 @@ const V2Login: React.FC = () => {
         </label>
 
         <label className="v2-login__field">
-          <span className="v2-login__label">Password</span>
+          <span className="v2-login__label">{t('auth.fields.password')}</span>
           <input
             className="v2-login__input"
             type="password"
@@ -101,11 +103,11 @@ const V2Login: React.FC = () => {
           className="v2-login__submit"
           disabled={submitting || loading}
         >
-          {submitting ? 'Signing in...' : 'Sign in'}
+          {submitting ? t('auth.login.signingIn') : t('auth.login.submit')}
         </button>
 
         <div className="v2-login__forgot">
-          <Link to="/v2/forgot-password" className="v2-login__link">Forgot password?</Link>
+          <Link to="/v2/forgot-password" className="v2-login__link">{t('auth.login.forgotPassword')}</Link>
         </div>
 
         {errorMessage && <div className="v2-login__error">{errorMessage}</div>}
@@ -113,9 +115,9 @@ const V2Login: React.FC = () => {
         <V2OAuthButtons next={nextPath} />
 
         <div className="v2-login__hint">
-          New to Commonly?
+          {t('auth.login.newToCommonly')}
           {' '}
-          <Link to="/v2/register" className="v2-login__link">Create an account</Link>
+          <Link to="/v2/register" className="v2-login__link">{t('auth.login.createAccount')}</Link>
         </div>
       </form>
     </div>

--- a/frontend/src/v2/components/V2OAuthButtons.tsx
+++ b/frontend/src/v2/components/V2OAuthButtons.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from '../../utils/axiosConfig';
 import getApiBaseUrl from '../../utils/apiBaseUrl';
+import { useTranslation } from 'react-i18next';
 
 // Social sign-in buttons shared by V2Login and V2Register. Renders nothing
 // until /api/auth/oauth/providers confirms a provider is configured, so
@@ -51,6 +52,7 @@ const readProviderCache = (): OAuthProvider[] => {
 };
 
 const V2OAuthButtons: React.FC<V2OAuthButtonsProps> = ({ invite, next }) => {
+  const { t } = useTranslation();
   // Seed from cache so repeat visitors see the buttons instantly; the fetch
   // below reconciles. A *successful* empty response (self-hosted w/o OAuth)
   // correctly clears; only network failures fall back to the cached value.
@@ -91,12 +93,12 @@ const V2OAuthButtons: React.FC<V2OAuthButtonsProps> = ({ invite, next }) => {
 
   return (
     <>
-      <div className="v2-login__or"><span>or</span></div>
+      <div className="v2-login__or"><span>{t('auth.oauth.or')}</span></div>
       <div className="v2-login__oauth">
         {providers.map((p) => (
           <a key={p.id} className="v2-login__oauth-btn" href={startUrl(p.id)}>
             {PROVIDER_ICONS[p.id]}
-            Continue with {p.label}
+            {t('auth.oauth.continueWith', { provider: p.label })}
           </a>
         ))}
       </div>

--- a/frontend/src/v2/components/V2OAuthComplete.tsx
+++ b/frontend/src/v2/components/V2OAuthComplete.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import axios from '../../utils/axiosConfig';
 import V2AuthBrand from './V2AuthBrand';
+import { useTranslation } from 'react-i18next';
 
 // Landing pad for the OAuth redirect chain. The backend callback hands us a
 // short-lived one-time code (never the JWT itself — it would end up in
@@ -12,6 +13,7 @@ const V2OAuthComplete: React.FC = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const fired = useRef(false); // StrictMode double-mount guard — the code is single-use
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (fired.current) return;
@@ -42,8 +44,8 @@ const V2OAuthComplete: React.FC = () => {
     <div className="v2-login">
       <div className="v2-login__card">
         <V2AuthBrand />
-        <h1 className="v2-login__title">Signing you in…</h1>
-        <p className="v2-login__subtitle">Completing sign-in with your provider.</p>
+        <h1 className="v2-login__title">{t('auth.oauthComplete.title')}</h1>
+        <p className="v2-login__subtitle">{t('auth.oauthComplete.subtitle')}</p>
       </div>
     </div>
   );

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -10,20 +10,25 @@ import { UseV2PodsResult, V2PodMember } from '../hooks/useV2Pods';
 import { useSocket } from '../../context/SocketContext';
 import { useAuth } from '../../context/AuthContext';
 import { initialsFor } from '../utils/avatars';
+import { Trans, useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 
 const PLAN_MODE_KEY = 'v2.podMode';
 const AGENT_DELIVERY_HINT_KEY = 'v2.agentDeliveryHint';
 
-const STARTER_PROMPTS = [
-  'Introduce yourself — what are you best at?',
-  "Here's what I'm working on — where can you help?",
-  'What should I ask you first?',
+const STARTER_PROMPT_KEYS = [
+  'podChat.starters.introduce',
+  'podChat.starters.help',
+  'podChat.starters.firstQuestion',
 ] as const;
+const CLOSE_MARK = '×';
+const COMMAND_KEY = '⌘';
+const ENTER_KEY = '↵';
 
 type PodMode = 'plan' | 'execute';
 
-const podMarkFor = (name: string, type?: string): string => (
-  type === 'agent-room' ? 'DM' : initialsFor(name).slice(0, 2)
+const podMarkFor = (name: string, type: string | undefined, dmLabel: string): string => (
+  type === 'agent-room' ? dmLabel : initialsFor(name).slice(0, 2)
 );
 
 const normalizeAgentSegment = (value: string | undefined): string =>
@@ -75,13 +80,20 @@ interface TypingAgentEntry {
 }
 
 const TypingIndicator: React.FC<{ agents: TypingAgentEntry[] }> = ({ agents }) => {
+  const { t, i18n } = useTranslation();
   if (!agents || agents.length === 0) return null;
   const names = agents.map((a) => a.displayName);
   const label = names.length === 1
-    ? `${names[0]} is thinking…`
+    ? t('podChat.typing.one', { name: names[0] })
     : names.length === 2
-      ? `${names[0]} and ${names[1]} are thinking…`
-      : `${names[0]}, ${names[1]} and ${names.length - 2} other${names.length - 2 === 1 ? '' : 's'} are thinking…`;
+      ? t('podChat.typing.two', { first: names[0], second: names[1] })
+      : t('podChat.typing.many', {
+        first: names[0],
+        second: names[1],
+        count: names.length - 2,
+        formattedCount: new Intl.NumberFormat(i18n.resolvedLanguage || i18n.language || 'en')
+          .format(names.length - 2),
+      });
   return (
     <div className="v2-chat__typing" aria-live="polite">
       <div className="v2-chat__typing-avatars">
@@ -97,10 +109,10 @@ const TypingIndicator: React.FC<{ agents: TypingAgentEntry[] }> = ({ agents }) =
   );
 };
 
-const modeCopy = (mode: PodMode) => (
+const modeCopy = (mode: PodMode, t: TFunction) => (
   mode === 'plan'
-    ? 'Discuss and plan with your agents — no actions are run.'
-    : 'Agents can take actions and ship work.'
+    ? t('podChat.mode.planDescription')
+    : t('podChat.mode.executeDescription')
 );
 
 const readMode = (podId: string): PodMode => {
@@ -155,6 +167,8 @@ const Icon = ({ d }: { d: string }) => (
 );
 
 const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVisible = false, inspectorCollapsed, onToggleInspector, onOpenMember, onOpenInvite, onOpenFile, onOpenMobileNav }) => {
+  const { t, i18n } = useTranslation();
+  const numberFormatter = new Intl.NumberFormat(i18n.resolvedLanguage || i18n.language || 'en');
   const { pod, members, messages, agents, sendMessage, loading, error } = detail;
   const api = useV2Api();
   const { socket, connected } = useSocket();
@@ -304,7 +318,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
         id: username,
         label: display,
         labelLower: `${display} ${rawName} ${username} ${mentionValue}`.toLowerCase(),
-        subtitle: `Agent · @${mentionValue}`,
+        subtitle: t('podChat.mentions.agentSubtitle', { handle: mentionValue }),
         avatar,
         isAgent: true,
         value: mentionValue,
@@ -327,7 +341,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
         id: m._id || username,
         label: username,
         labelLower: username.toLowerCase(),
-        subtitle: 'Member',
+        subtitle: t('podChat.mentions.member'),
         avatar: m.profilePicture || null,
         isAgent: false,
         value: username,
@@ -346,7 +360,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
     });
 
     return items;
-  }, [members, agents]);
+  }, [members, agents, t]);
 
   const filteredMentions: MentionItem[] = useMemo(() => {
     if (!mentionOpen) return [];
@@ -512,8 +526,8 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
       type="button"
       className="v2-chat__mobile-nav-btn"
       onClick={onOpenMobileNav}
-      title="Show pods"
-      aria-label="Show pods list"
+      title={t('podChat.mobile.showPods')}
+      aria-label={t('podChat.mobile.showPodsList')}
     >
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
         <path d="M3 6h18M3 12h18M3 18h18" />
@@ -530,8 +544,8 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
           </div>
         )}
         <div className="v2-empty">
-          <div className="v2-empty__title">No pod selected</div>
-          <div className="v2-empty__text">Pick a pod from the sidebar, or create a new one to get started.</div>
+          <div className="v2-empty__title">{t('podChat.empty.noPodTitle')}</div>
+          <div className="v2-empty__text">{t('podChat.empty.noPodText')}</div>
         </div>
       </main>
     );
@@ -555,7 +569,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
   const botMembers = (members || []).filter((m) => m?.isBot);
   const isBotToBot = isAgentDm && botMembers.length >= 2 && botMembers.length === (members || []).length;
   const botPair = isBotToBot
-    ? botMembers.slice(0, 2).map((m) => m.username || 'Agent')
+    ? botMembers.slice(0, 2).map((m) => m.username || t('common.agent'))
     : null;
 
   const handleSend = async (override?: string) => {
@@ -648,7 +662,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
       }
     } catch (err) {
       const e = err as { response?: { data?: { msg?: string } } };
-      setComposerError(e.response?.data?.msg || 'Failed to upload file. Please try again.');
+      setComposerError(e.response?.data?.msg || t('podChat.errors.uploadFailed'));
     } finally {
       setUploading(false);
       if (fileInputRef.current) fileInputRef.current.value = '';
@@ -671,8 +685,12 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
     !!agent.lastHeartbeatAt && Date.now() - new Date(agent.lastHeartbeatAt).getTime() < 10 * 60 * 1000
   )).length;
   const liveState = onlineAgentCount > 0
-    ? `${onlineAgentCount} recent heartbeat${onlineAgentCount === 1 ? '' : 's'}`
-    : 'No recent heartbeats';
+    ? t('podChat.heartbeat.recent', {
+      count: onlineAgentCount,
+      formattedCount: numberFormatter.format(onlineAgentCount),
+    })
+    : t('podChat.heartbeat.none');
+  const starterPrompts = STARTER_PROMPT_KEYS.map((key) => t(key));
 
   return (
     <main className="v2-pane v2-pane--main">
@@ -681,7 +699,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
           <div className="v2-chat__header-row">
             {mobileNavButton}
             <div className="v2-chat__title">
-              <span className="v2-chat__title-mark">{podMarkFor(pod.name, pod.type)}</span>
+              <span className="v2-chat__title-mark">{podMarkFor(pod.name, pod.type, t('podChat.dmMark'))}</span>
               <span className="v2-chat__title-text">{pod.name}</span>
             </div>
 
@@ -690,8 +708,8 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
                 type="button"
                 className={`v2-chat__avatars v2-chat__avatars--button${inspectorCollapsed ? '' : ' v2-chat__avatars--active'}`}
                 onClick={onToggleInspector}
-                title={inspectorCollapsed ? 'View pod team' : 'Hide pod team'}
-                aria-label={inspectorCollapsed ? 'View pod team' : 'Hide pod team'}
+                title={inspectorCollapsed ? t('podChat.team.view') : t('podChat.team.hide')}
+                aria-label={inspectorCollapsed ? t('podChat.team.view') : t('podChat.team.hide')}
                 aria-pressed={!inspectorCollapsed}
               >
                 {visibleMembers.map((m) => (
@@ -719,26 +737,26 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
                 the user. Re-enable when the mode actually drives behavior
                 (agent autonomy gating, suggestion ranking, etc.). */}
             {false && (
-              <div className={`v2-chat__mode-toggle v2-chat__mode-toggle--header v2-chat__mode-toggle--${mode}`} role="group" aria-label="Pod mode preference">
+              <div className={`v2-chat__mode-toggle v2-chat__mode-toggle--header v2-chat__mode-toggle--${mode}`} role="group" aria-label={t('podChat.mode.preference')}>
                 <button
                   type="button"
                   className={`v2-chat__mode-option${mode === 'plan' ? ' v2-chat__mode-option--active' : ''}`}
                   onClick={() => handleSetMode('plan')}
                   aria-pressed={mode === 'plan'}
-                  title={modeCopy('plan')}
+                  title={modeCopy('plan', t)}
                 >
                   <Icon d="M9 11l3 3L22 4M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11" />
-                  Plan
+                  {t('podChat.mode.plan')}
                 </button>
                 <button
                   type="button"
                   className={`v2-chat__mode-option${mode === 'execute' ? ' v2-chat__mode-option--active' : ''}`}
                   onClick={() => handleSetMode('execute')}
                   aria-pressed={mode === 'execute'}
-                  title={modeCopy('execute')}
+                  title={modeCopy('execute', t)}
                 >
                   <Icon d="M5 3l14 9-14 9V3z" />
-                  Execute
+                  {t('podChat.mode.execute')}
                 </button>
               </div>
             )}
@@ -748,8 +766,8 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
                 type="button"
                 className="v2-chat__icon-btn"
                 onClick={onOpenInvite}
-                title="Invite to this pod"
-                aria-label="Invite to this pod"
+                title={t('podChat.invite')}
+                aria-label={t('podChat.invite')}
               >
                 <Icon d="M16 21v-2a4 4 0 00-4-4H6a4 4 0 00-4 4v2M9 11a4 4 0 100-8 4 4 0 000 8zM20 8v6M17 11h6" />
               </button>
@@ -779,34 +797,34 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
                 <div className="v2-empty">
                   {isBotToBot && botPair ? (
                     <>
-                      <div className="v2-empty__title">{botPair[0]} and {botPair[1]} haven&apos;t talked yet</div>
-                      <div className="v2-empty__text">They&apos;ll DM each other when one of them needs the other&apos;s help.</div>
+                      <div className="v2-empty__title">{t('podChat.empty.botPairTitle', { first: botPair[0], second: botPair[1] })}</div>
+                      <div className="v2-empty__text">{t('podChat.empty.botPairText')}</div>
                     </>
                   ) : isAgentRoom && botMembers.length === 1 ? (
                     (() => {
                       const rawUsername = botMembers[0]?.username || '';
                       const agentName = agentDisplayNames.get(rawUsername.toLowerCase())
                         || rawUsername
-                        || 'agent';
+                        || t('common.agent');
                       return (
                         <>
-                          <div className="v2-empty__title">Say hi to {agentName}</div>
+                          <div className="v2-empty__title">{t('podChat.empty.agentRoomTitle', { agentName })}</div>
                           <div className="v2-empty__text">
-                            This is your private 1:1. Choose a prompt below, or write your own.
+                            {t('podChat.empty.agentRoomText')}
                           </div>
                         </>
                       );
                     })()
                   ) : isAgentDm ? (
                     <>
-                      <div className="v2-empty__title">No messages yet</div>
-                      <div className="v2-empty__text">This is a private 1:1 conversation. Say hello to get started.</div>
+                      <div className="v2-empty__title">{t('podChat.empty.noMessagesTitle')}</div>
+                      <div className="v2-empty__text">{t('podChat.empty.agentDmText')}</div>
                     </>
                   ) : (
                     <>
-                      <div className="v2-empty__title">This pod is quiet</div>
+                      <div className="v2-empty__title">{t('podChat.empty.quietTitle')}</div>
                       <div className="v2-empty__text">
-                        Use @ to mention an agent or teammate—everyone in the member list can see and reply.
+                        {t('podChat.empty.quietText')}
                       </div>
                     </>
                   )}
@@ -824,8 +842,11 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
                   />
                   {agentDeliveryHint?.messageId === m.id && (
                     <div className="v2-chat__delivery-hint" role="status">
-                      No agent was notified — @mention one to get a reply. Try{' '}
-                      <strong>@{agentDeliveryHint.mentionHandle}</strong>.
+                      <Trans
+                        i18nKey="podChat.deliveryHint"
+                        values={{ handle: agentDeliveryHint.mentionHandle }}
+                        components={{ handle: <strong /> }}
+                      />
                     </div>
                   )}
                 </React.Fragment>
@@ -841,8 +862,8 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
               && messages.length === 0
               && !firstRunVisible
               && !draft.trim() && (
-                <div className="v2-chat__starter-prompts" role="group" aria-label="Conversation starters">
-                  {STARTER_PROMPTS.map((prompt) => (
+                <div className="v2-chat__starter-prompts" role="group" aria-label={t('podChat.starters.label')}>
+                  {starterPrompts.map((prompt) => (
                     <button
                       key={prompt}
                       type="button"
@@ -856,7 +877,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
             )}
 
             {isReadOnly ? (
-              <div className="v2-chat__readonly" role="note" aria-label="Read-only conversation">
+              <div className="v2-chat__readonly" role="note" aria-label={t('podChat.readOnly.label')}>
                 <div className="v2-chat__readonly-icon" aria-hidden="true">
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                     <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
@@ -864,11 +885,11 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
                   </svg>
                 </div>
                 <div className="v2-chat__readonly-body">
-                  <div className="v2-chat__readonly-title">Read-only — you&apos;re observing this conversation</div>
+                  <div className="v2-chat__readonly-title">{t('podChat.readOnly.title')}</div>
                   <div className="v2-chat__readonly-text">
                     {isBotToBot && botPair
-                      ? `${botPair[0]} and ${botPair[1]} are talking directly. To engage them, @-mention either in a shared team pod.`
-                      : 'You can read this 1:1 but not post. To engage, @-mention the agent in a shared team pod.'}
+                      ? t('podChat.readOnly.botPair', { first: botPair[0], second: botPair[1] })
+                      : t('podChat.readOnly.agentDm')}
                   </div>
                 </div>
               </div>
@@ -877,16 +898,20 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
               {replyTarget && (
                 <div className="v2-chat__reply-chip" role="status">
                   <span className="v2-chat__reply-chip-label">
-                    Replying to <strong>{replyTarget.user?.username || 'message'}</strong>:{' '}
+                    <Trans
+                      i18nKey="podChat.replyingTo"
+                      values={{ author: replyTarget.user?.username || t('podChat.messageFallback') }}
+                      components={{ author: <strong /> }}
+                    />{' '}
                     {String(replyTarget.content || '').replace(/\[\[upload:[^\]]*\]\]/g, '📎').slice(0, 80)}
                   </span>
                   <button
                     type="button"
                     className="v2-chat__reply-chip-cancel"
-                    aria-label="Cancel reply"
+                    aria-label={t('podChat.cancelReply')}
                     onClick={() => setReplyTarget(null)}
                   >
-                    ×
+                    {CLOSE_MARK}
                   </button>
                 </div>
               )}
@@ -894,7 +919,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
                 <textarea
                   ref={composerInputRef}
                   className="v2-chat__composer-input"
-                  placeholder={`Message ${pod.name}…`}
+                  placeholder={t('podChat.composer.placeholder', { podName: pod.name })}
                   value={draft}
                   onChange={(e) => {
                     const next = e.target.value;
@@ -972,8 +997,8 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
                   <button
                     type="button"
                     className="v2-chat__composer-icon-btn"
-                    title={uploading ? 'Uploading…' : 'Attach file'}
-                    aria-label="Attach file"
+                    title={uploading ? t('podChat.composer.uploading') : t('podChat.composer.attachFile')}
+                    aria-label={t('podChat.composer.attachFile')}
                     onClick={() => fileInputRef.current?.click()}
                     disabled={uploading}
                   >
@@ -985,8 +1010,8 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
                   className={`v2-chat__send v2-chat__send--${mode}`}
                   onClick={() => handleSend()}
                   disabled={sending || !draft.trim()}
-                  title={sending ? 'Sending…' : 'Send message'}
-                  aria-label={sending ? 'Sending…' : 'Send message'}
+                  title={sending ? t('podChat.composer.sending') : t('podChat.composer.send')}
+                  aria-label={sending ? t('podChat.composer.sending') : t('podChat.composer.send')}
                 >
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                     <path d="M2.5 11.4 21.2 3.1c.6-.3 1.2.3.9.9L13.8 22.7c-.3.6-1.2.6-1.4-.1l-2.7-7.4-7.4-2.7c-.7-.2-.7-1.1.2-1.1z" />
@@ -999,8 +1024,8 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
                 </div>
               )}
               <div className="v2-chat__composer-hint">
-                <span><kbd>@</kbd> mention an agent</span>
-                <span><kbd>⌘</kbd><kbd>↵</kbd> to send</span>
+                <span><kbd>@</kbd> {t('podChat.composer.mentionAgent')}</span>
+                <span><kbd>{COMMAND_KEY}</kbd><kbd>{ENTER_KEY}</kbd> {t('podChat.composer.toSend')}</span>
               </div>
             </div>
             )}

--- a/frontend/src/v2/components/V2Register.tsx
+++ b/frontend/src/v2/components/V2Register.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams, Navigate, Link } from 'react-router-dom';
 import axios from '../../utils/axiosConfig';
 import V2OAuthButtons from './V2OAuthButtons';
 import V2AuthBrand from './V2AuthBrand';
+import { Trans, useTranslation } from 'react-i18next';
 
 // v2-native sign-up. Pairs with V2Login (reuses the .v2-login styles) so the
 // auth surfaces match after v2 became the default. Mirrors the legacy
@@ -23,6 +24,7 @@ const Brand: React.FC = () => (
 );
 
 const V2Register: React.FC = () => {
+  const { t } = useTranslation();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const [username, setUsername] = useState('');
@@ -66,7 +68,7 @@ const V2Register: React.FC = () => {
         invitationCode: invitationCode.trim(),
       });
       const data = res.data as { message?: string };
-      const message = data?.message || 'Your account is ready. Sign in to continue.';
+      const message = data?.message || t('auth.register.success.ready');
       // The backend only sends a verification email (and withholds a usable
       // session) when SMTP is configured — its message says to check email in
       // that case. When auto-verified, no email is sent and sign-in works
@@ -77,7 +79,7 @@ const V2Register: React.FC = () => {
       setDone(message);
     } catch (err) {
       const e1 = err as { response?: { data?: { error?: string; msg?: string } } };
-      setError(e1.response?.data?.error || e1.response?.data?.msg || 'Registration failed.');
+      setError(e1.response?.data?.error || e1.response?.data?.msg || t('auth.register.errors.failed'));
     } finally {
       setSubmitting(false);
     }
@@ -89,14 +91,17 @@ const V2Register: React.FC = () => {
         <div className="v2-login__card">
           <Brand />
           <h1 className="v2-login__title">
-            {verifyPending ? 'Check your email' : 'Account created'}
+            {verifyPending ? t('auth.register.success.checkEmailTitle') : t('auth.register.success.createdTitle')}
           </h1>
-          <p className="v2-login__subtitle">{done}</p>
+          <p className="v2-login__subtitle">
+            {verifyPending ? t('auth.register.success.checkEmailMessage') : t('auth.register.success.ready')}
+          </p>
           {verifyPending ? (
             <p className="v2-login__hint">
-              We sent a verification link to your email. Verify your address,
-              then{' '}
-              <Link to={loginHref} className="v2-login__link">sign in</Link>.
+              <Trans
+                i18nKey="auth.register.success.verifyThenSignIn"
+                components={{ signIn: <Link to={loginHref} className="v2-login__link" /> }}
+              />
             </p>
           ) : (
             <button
@@ -104,7 +109,7 @@ const V2Register: React.FC = () => {
               className="v2-login__submit"
               onClick={() => navigate(loginHref)}
             >
-              Continue to sign in
+              {t('auth.register.success.continue')}
             </button>
           )}
         </div>
@@ -116,13 +121,13 @@ const V2Register: React.FC = () => {
     <div className="v2-login">
       <form className="v2-login__card" onSubmit={handleSubmit}>
         <Brand />
-        <h1 className="v2-login__title">Create your account</h1>
+        <h1 className="v2-login__title">{t('auth.register.title')}</h1>
         <p className="v2-login__subtitle">
-          Join the shared space where agents and humans collaborate.
+          {t('auth.register.subtitle')}
         </p>
 
         <label className="v2-login__field">
-          <span className="v2-login__label">Username</span>
+          <span className="v2-login__label">{t('auth.fields.username')}</span>
           <input
             className="v2-login__input"
             type="text"
@@ -134,7 +139,7 @@ const V2Register: React.FC = () => {
         </label>
 
         <label className="v2-login__field">
-          <span className="v2-login__label">Email</span>
+          <span className="v2-login__label">{t('auth.fields.email')}</span>
           <input
             className="v2-login__input"
             type="email"
@@ -146,7 +151,7 @@ const V2Register: React.FC = () => {
         </label>
 
         <label className="v2-login__field">
-          <span className="v2-login__label">Password</span>
+          <span className="v2-login__label">{t('auth.fields.password')}</span>
           <input
             className="v2-login__input"
             type="password"
@@ -162,19 +167,19 @@ const V2Register: React.FC = () => {
             unless a code arrived via the URL, so the field stays hidden. */}
         {policy.loaded && !policy.inviteOnly && (
           <label className="v2-login__field">
-            <span className="v2-login__label">Invitation code (optional)</span>
+            <span className="v2-login__label">{t('auth.register.invitationCode')}</span>
             <input
               className="v2-login__input"
               type="text"
               autoComplete="off"
-              placeholder="Unlocks hosted agents"
+              placeholder={t('auth.register.invitationPlaceholder')}
               value={invitationCode}
               onChange={(e) => setInvitationCode(e.target.value)}
             />
             {/* The full explanation lives below the field, not in the
                 placeholder — placeholders clip at the input's width. */}
             <span className="v2-login__field-hint">
-              No code? Leave blank — you can bring your own agents and redeem a code later in Settings.
+              {t('auth.register.invitationHint')}
             </span>
           </label>
         )}
@@ -184,7 +189,7 @@ const V2Register: React.FC = () => {
           className="v2-login__submit"
           disabled={submitting}
         >
-          {submitting ? 'Creating account...' : 'Create account'}
+          {submitting ? t('auth.register.creating') : t('auth.register.submit')}
         </button>
 
         {error && <div className="v2-login__error">{error}</div>}
@@ -192,9 +197,9 @@ const V2Register: React.FC = () => {
         <V2OAuthButtons invite={invitationCode || undefined} next={nextPath} />
 
         <div className="v2-login__hint">
-          Already have an account?
+          {t('auth.register.alreadyHaveAccount')}
           {' '}
-          <Link to="/v2/login" className="v2-login__link">Sign in</Link>
+          <Link to="/v2/login" className="v2-login__link">{t('auth.login.submit')}</Link>
         </div>
       </form>
     </div>

--- a/frontend/src/v2/components/V2ResetPassword.tsx
+++ b/frontend/src/v2/components/V2ResetPassword.tsx
@@ -2,11 +2,13 @@ import React, { useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import axios from '../../utils/axiosConfig';
 import V2AuthBrand from './V2AuthBrand';
+import { Trans, useTranslation } from 'react-i18next';
 
 // Landing pad for the emailed reset link (/v2/reset-password?token=...).
 // Token consumption is server-side; a used or expired token surfaces the
 // backend's "Invalid or expired reset link" with a path back to /forgot.
 const V2ResetPassword: React.FC = () => {
+  const { t } = useTranslation();
   const [searchParams] = useSearchParams();
   const token = searchParams.get('token') || '';
   const [password, setPassword] = useState('');
@@ -19,11 +21,11 @@ const V2ResetPassword: React.FC = () => {
     e.preventDefault();
     setError(null);
     if (password.length < 8) {
-      setError('Password must be at least 8 characters.');
+      setError(t('auth.reset.errors.tooShort'));
       return;
     }
     if (password !== confirm) {
-      setError('Passwords do not match.');
+      setError(t('auth.reset.errors.mismatch'));
       return;
     }
     setSubmitting(true);
@@ -32,7 +34,7 @@ const V2ResetPassword: React.FC = () => {
       setDone(true);
     } catch (err) {
       const e1 = err as { response?: { data?: { error?: string } } };
-      setError(e1.response?.data?.error || 'Reset failed — the link may have expired.');
+      setError(e1.response?.data?.error || t('auth.reset.errors.failed'));
     } finally {
       setSubmitting(false);
     }
@@ -42,27 +44,27 @@ const V2ResetPassword: React.FC = () => {
     <div className="v2-login">
       <form className="v2-login__card" onSubmit={handleSubmit}>
         <V2AuthBrand />
-        <h1 className="v2-login__title">Choose a new password</h1>
+        <h1 className="v2-login__title">{t('auth.reset.title')}</h1>
         {done ? (
           <>
-            <p className="v2-login__subtitle">Password updated. You can sign in now.</p>
+            <p className="v2-login__subtitle">{t('auth.reset.updated')}</p>
             <Link to="/v2/login" className="v2-login__submit" style={{ textAlign: 'center', textDecoration: 'none', display: 'block' }}>
-              Go to sign in
+              {t('auth.reset.goToSignIn')}
             </Link>
           </>
         ) : !token ? (
           <>
             <p className="v2-login__subtitle">
-              This page needs the reset link from your email. Request a new one below.
+              {t('auth.reset.missingToken')}
             </p>
             <div className="v2-login__hint">
-              <Link to="/v2/forgot-password" className="v2-login__link">Send me a reset link</Link>
+              <Link to="/v2/forgot-password" className="v2-login__link">{t('auth.reset.sendNewLink')}</Link>
             </div>
           </>
         ) : (
           <>
             <label className="v2-login__field">
-              <span className="v2-login__label">New password</span>
+              <span className="v2-login__label">{t('auth.reset.newPassword')}</span>
               <input
                 className="v2-login__input"
                 type="password"
@@ -73,7 +75,7 @@ const V2ResetPassword: React.FC = () => {
               />
             </label>
             <label className="v2-login__field">
-              <span className="v2-login__label">Confirm password</span>
+              <span className="v2-login__label">{t('auth.reset.confirmPassword')}</span>
               <input
                 className="v2-login__input"
                 type="password"
@@ -84,13 +86,16 @@ const V2ResetPassword: React.FC = () => {
               />
             </label>
             <button type="submit" className="v2-login__submit" disabled={submitting}>
-              {submitting ? 'Updating…' : 'Update password'}
+              {submitting ? t('auth.reset.updating') : t('auth.reset.submit')}
             </button>
             {error && (
               <div className="v2-login__error">
                 {error}
                 {' '}
-                <Link to="/v2/forgot-password" className="v2-login__link">Request a new link</Link>
+                <Trans
+                  i18nKey="auth.reset.requestNewLink"
+                  components={{ request: <Link to="/v2/forgot-password" className="v2-login__link" /> }}
+                />
               </div>
             )}
           </>


### PR DESCRIPTION
## Summary

Phase 1B of #709 extends the merged i18n infrastructure across the next bounded set of high-visibility chrome:

- login, registration, OAuth, password reset, invite-required, and email verification flows
- invite redeem and invite management surfaces
- first-run connection hero
- Pod chat chrome: empty/read-only states, typing/delivery feedback, starter prompts, composer controls, and accessibility labels

User-authored Pod names/descriptions, messages, agent output, and reply content remain untouched.

## Translation invariants

- `agent` → `智能体`
- `memory` → `记忆` (never `内存`)
- `Pod` remains `Pod`
- second person uses `你`, never `您`
- avoids literal `通过…进行…` calques
- dates and numbers use `Intl` with the active locale
- English and zh-CN catalogs have 379 matching normalized key paths

The zh-CN additions are machine-drafted and **blocked on Sam's native-speaker review** before merge.

## Guardrail

The `i18next/no-literal-string` Phase 1 manifest now includes exactly the migrated Phase 1B components. New JSX literals in these files fail ESLint.

## Verification

- `npm test -- --watchAll=false --runInBand` — 60 suites / 262 tests passed
- `npm run build` — passed
- migrated-file ESLint — 0 errors (existing repo TSX-extension warnings only)
- real Chromium browser matrix:
  - EN + zh-CN
  - 1280×900 + 390×844
  - login, first-run hero, and invite modal
  - correct `html[lang]`; no document, card, hero, or modal overflow

Full repository lint remains red on the pre-existing backend lint backlog (1,300 baseline errors); no changed-file lint errors are introduced here.
