### PR TITLE
fix(landing): zh hero grammar + language dropdown in nav

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -30,7 +30,8 @@
     "hero": {
       "eyebrow": "Open-source · Apache 2.0",
       "ariaLabel": "Chat with your Claude Code, Cursor, Codex — your whole team.",
-      "titleLead": "Chat with your",
+      "titlePrefix": "Chat with your",
+      "titleSuffix": "",
       "lede": "Get real work done by talking to your agents — in an open-source workspace where they all share one project memory, so nothing gets re-explained. Any runtime, your infra, no per-agent fees.",
       "selfHostInstall": "Self-host install",
       "builtBy": "Built in the open by",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -30,7 +30,8 @@
     "hero": {
       "eyebrow": "开源 · Apache 2.0",
       "ariaLabel": "与你的 Claude Code、Cursor、Codex，以及整个团队对话。",
-      "titleLead": "与你的智能工具对话",
+      "titlePrefix": "与你的",
+      "titleSuffix": "对话",
       "lede": "跟智能体对话，把真正的工作做完——它们在同一个开源工作空间里共享项目记忆，你不用一遍遍重复解释。支持任意运行时，部署在你自己的基础设施上，绝不按智能体收费。",
       "selfHostInstall": "自托管安装命令",
       "builtBy": "公开构建者",

--- a/frontend/src/v2/__tests__/V2LangSwitch.test.tsx
+++ b/frontend/src/v2/__tests__/V2LangSwitch.test.tsx
@@ -35,14 +35,40 @@ describe('V2LangSwitch', () => {
     );
 
     expect(screen.getByText('Features')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Switch to Simplified Chinese' }));
+
+    // Dropdown: trigger shows the active language, menu opens on click.
+    const trigger = screen.getByRole('button', { name: 'Language' });
+    expect(trigger).toHaveTextContent('EN');
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole('button', { name: '中文' }));
 
     expect(await screen.findByText('功能')).toBeInTheDocument();
     expect(document.documentElement.lang).toBe('zh-CN');
     expect(localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe('zh-CN');
+    // Menu closes after selection.
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: '切换到英文' }));
+    // Trigger now reflects zh; switch back via the reopened menu.
+    const zhTrigger = screen.getByRole('button', { name: '语言' });
+    expect(zhTrigger).toHaveTextContent('中文');
+    fireEvent.click(zhTrigger);
+    fireEvent.click(screen.getByRole('button', { name: 'English' }));
     expect(await screen.findByText('Features')).toBeInTheDocument();
+    expect(document.documentElement.lang).toBe('en');
+  });
+
+  it('closes the menu on Escape and outside click without changing language', async () => {
+    render(<V2LangSwitch />);
+    const trigger = screen.getByRole('button', { name: 'Language' });
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+
+    fireEvent.click(trigger);
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
     expect(document.documentElement.lang).toBe('en');
   });
 });

--- a/frontend/src/v2/components/V2LangSwitch.tsx
+++ b/frontend/src/v2/components/V2LangSwitch.tsx
@@ -1,38 +1,75 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-// Language names are self-labels, not localized chrome.
-const ENGLISH_LANGUAGE_NAME = 'EN';
-const CHINESE_LANGUAGE_NAME = '中文';
+// Language names are self-labels, not localized chrome — every reader must
+// recognize their own language regardless of the active locale.
+const LANGUAGES = [
+  { code: 'en' as const, label: 'English', short: 'EN' },
+  { code: 'zh-CN' as const, label: '中文', short: '中文' },
+];
 
+// Dropdown language menu (Sam's call 2026-07-22: reads like the other nav
+// options, not a two-button pill). Trigger shows the active language; the
+// menu lists all languages with the active one checked. Closes on outside
+// click, Escape, and selection.
 const V2LangSwitch: React.FC = () => {
   const { t, i18n } = useTranslation();
-  const activeLanguage = i18n.resolvedLanguage === 'zh-CN' ? 'zh-CN' : 'en';
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const active = LANGUAGES.find((l) => l.code === i18n.resolvedLanguage) || LANGUAGES[0];
 
-  const selectLanguage = (language: 'en' | 'zh-CN') => {
-    void i18n.changeLanguage(language);
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDocClick = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const selectLanguage = (code: 'en' | 'zh-CN') => {
+    void i18n.changeLanguage(code);
+    setOpen(false);
   };
 
   return (
-    <div className="v2-lang-switch" role="group" aria-label={t('common.language.label')}>
+    <div className="v2-lang-switch" ref={rootRef}>
       <button
         type="button"
-        className={`v2-lang-switch__option${activeLanguage === 'en' ? ' v2-lang-switch__option--active' : ''}`}
-        aria-pressed={activeLanguage === 'en'}
-        aria-label={t('common.language.switchToEnglish')}
-        onClick={() => selectLanguage('en')}
+        className="v2-lang-switch__trigger"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={t('common.language.label')}
+        onClick={() => setOpen((v) => !v)}
       >
-        {ENGLISH_LANGUAGE_NAME}
+        {active.short}
+        <span className="v2-lang-switch__caret" aria-hidden="true">▾</span>
       </button>
-      <button
-        type="button"
-        className={`v2-lang-switch__option${activeLanguage === 'zh-CN' ? ' v2-lang-switch__option--active' : ''}`}
-        aria-pressed={activeLanguage === 'zh-CN'}
-        aria-label={t('common.language.switchToChinese')}
-        onClick={() => selectLanguage('zh-CN')}
-      >
-        {CHINESE_LANGUAGE_NAME}
-      </button>
+      {open && (
+        <ul className="v2-lang-switch__menu" role="listbox" aria-label={t('common.language.label')}>
+          {LANGUAGES.map((lang) => (
+            <li key={lang.code} role="option" aria-selected={lang.code === active.code}>
+              <button
+                type="button"
+                className={`v2-lang-switch__item${lang.code === active.code ? ' v2-lang-switch__item--active' : ''}`}
+                onClick={() => selectLanguage(lang.code)}
+              >
+                <span>{lang.label}</span>
+                {lang.code === active.code && (
+                  <span className="v2-lang-switch__check" aria-hidden="true">✓</span>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 };

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -270,10 +270,12 @@ const V2LandingPage: React.FC = () => {
           {!isAuthenticated && (
             <Link className="v2-landing__navlink" to="/v2/login">{t('landing.nav.signIn')}</Link>
           )}
+          {/* Language menu reads like a nav option; the primary CTA stays the
+              rightmost element (Sam's call 2026-07-22). */}
+          <V2LangSwitch />
           <Link className="v2-landing__btn v2-landing__btn--primary v2-landing__btn--sm" to={appHref}>
             {primaryLabel}
           </Link>
-          <V2LangSwitch />
         </nav>
       </header>
 
@@ -282,10 +284,17 @@ const V2LandingPage: React.FC = () => {
         <section className="v2-landing__hero">
           <div className="v2-landing__hero-inner">
             <div className="v2-landing__eyebrow">{t('landing.hero.eyebrow')}</div>
+            {/* The rotating term must sit INSIDE the sentence frame so
+                grammars that wrap the object work: en "Chat with your ___"
+                (empty suffix), zh 「与你的___对话」. Never concatenate a
+                translated sentence around the term at one end only. */}
             <h1 className="v2-landing__title" aria-label={t('landing.hero.ariaLabel')}>
-              <StaggerWords text={t('landing.hero.titleLead')} />
+              <StaggerWords text={t('landing.hero.titlePrefix')} />
               <br />
               <RotatingTerm terms={rotatingTerms} />
+              {t('landing.hero.titleSuffix') && (
+                <span className="v2-landing__title-suffix">{t('landing.hero.titleSuffix')}</span>
+              )}
             </h1>
             <p className="v2-landing__lede">{t('landing.hero.lede')}</p>
 

--- a/frontend/src/v2/landing/v2-landing.css
+++ b/frontend/src/v2/landing/v2-landing.css
@@ -32,6 +32,12 @@
   padding-right: max(24px, calc((100% - 1120px) / 2));
 }
 
+/* Suffix after the rotating term (zh: 「与你的___对话」). Same visual
+   weight as the title; the space is handled by the margin, not the string. */
+.v2-landing__title-suffix {
+  margin-left: 0.18em;
+}
+
 /* ---------- Top bar (sticky) ---------- */
 .v2-landing__bar {
   position: sticky;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -141,34 +141,77 @@
 
 /* ---------- Language switch ---------- */
 
+/* Language dropdown. The trigger deliberately reads like a plain nav
+   option (no pill chrome) so it sits naturally among nav links; the menu
+   is a small anchored card. */
 .v2-lang-switch {
+  position: relative;
+  display: inline-flex;
+}
+
+.v2-lang-switch__trigger {
   display: inline-flex;
   align-items: center;
-  padding: 2px;
-  border: 1px solid var(--v2-border);
-  border-radius: var(--v2-radius-pill);
-  background: var(--v2-bg-subtle);
-}
-
-.v2-lang-switch__option {
-  min-width: 30px;
-  min-height: 24px;
-  padding: 0 7px;
-  border-radius: var(--v2-radius-pill);
-  color: var(--v2-text-tertiary);
-  font-size: 10px;
-  font-weight: 700;
+  gap: 4px;
+  padding: 4px 6px;
+  border-radius: var(--v2-radius-sm, 8px);
+  color: var(--v2-text-secondary);
+  font-size: 13px;
+  font-weight: 500;
   line-height: 1;
-  transition: background 80ms ease, color 80ms ease;
+  transition: color 80ms ease;
 }
 
-.v2-lang-switch__option:hover {
+.v2-lang-switch__trigger:hover {
   color: var(--v2-text-primary);
 }
 
-.v2-lang-switch__option--active {
+.v2-lang-switch__caret {
+  font-size: 9px;
+  color: var(--v2-text-muted);
+}
+
+.v2-lang-switch__menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 40;
+  min-width: 132px;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
   background: var(--v2-surface);
+  border: 1px solid var(--v2-border);
+  border-radius: 10px;
+  box-shadow: var(--v2-shadow-md, 0 8px 24px rgba(16, 24, 40, 0.12));
+}
+
+.v2-lang-switch__item {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 7px 10px;
+  border-radius: 7px;
+  color: var(--v2-text-secondary);
+  font-size: 13px;
+  text-align: left;
+  transition: background 80ms ease, color 80ms ease;
+}
+
+.v2-lang-switch__item:hover {
+  background: var(--v2-bg-subtle);
+  color: var(--v2-text-primary);
+}
+
+.v2-lang-switch__item--active {
   color: var(--v2-accent-text);
+  font-weight: 600;
+}
+
+.v2-lang-switch__check {
+  font-size: 11px;
 }
 
 /* ---------- Shared filter grammar ---------- */
@@ -348,10 +391,16 @@
   justify-content: center;
 }
 
-.v2-rail__language .v2-lang-switch__option {
-  min-width: 24px;
-  padding: 0 4px;
-  font-size: 9px;
+.v2-rail__language .v2-lang-switch__trigger {
+  padding: 2px 4px;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+/* In the narrow rail the menu must open toward the content, not off-screen. */
+.v2-rail__language .v2-lang-switch__menu {
+  right: auto;
+  left: 0;
 }
 
 .v2-rail__brand {


### PR DESCRIPTION
Sam's design feedback on the live zh-CN landing:

1. **Hero grammar**: rotating term moves INSIDE the sentence frame — zh now reads 「与你的［Claude Code…整个团队］对话」 via `titlePrefix`/`titleSuffix` keys (en: 'Chat with your ___', empty suffix). The previous shape stranded the term after a complete sentence.
2. **Switcher → dropdown**: nav-option-styled trigger (active language + caret) opening a listbox; Escape/outside-click/selection close; rail variant opens leftward to stay on-screen.
3. **Nav order**: language menu among the nav links; primary CTA restored as the rightmost element.

Tests: dropdown interaction, close-without-change, existing i18n/landing/invariants — 21 pass. Post-merge: live browser check EN + zh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMeWzgFxsfBcjoLVLewEES