### PR TITLE
fix(landing): rotating hero term hugs its suffix (zh 对话 gap)

### DIFF
--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -94,16 +94,26 @@ const RotatingTerm: React.FC<{ terms: string[] }> = ({ terms }) => {
 
   // Static fallback shows the closing term — the sentence must stand alone.
   const staticIndex = terms.length - 1;
+  const shownIndex = rotating ? active : staticIndex;
   return (
+    // The sizer holds ONLY the active term in normal flow, so the slot width
+    // tracks that term instead of the widest one. Critical for suffixed
+    // grammars (zh 「与你的___对话」): a fixed widest-term slot would strand
+    // the suffix far to the right on short terms. English has no suffix, so
+    // this is invisible there. Animated terms are absolutely positioned over
+    // the sizer.
     <span className="v2-landing__rotator" aria-hidden="true">
-      {terms.map((term, i) => (
-        <span
-          key={term}
-          className={`v2-landing__rotator-term${(rotating ? i === active : i === staticIndex) ? ' v2-landing__rotator-term--active' : ''}`}
-        >
-          {term}
-        </span>
-      ))}
+      <span className="v2-landing__rotator-sizer">{terms[shownIndex]}</span>
+      <span className="v2-landing__rotator-stack">
+        {terms.map((term, i) => (
+          <span
+            key={term}
+            className={`v2-landing__rotator-term${i === shownIndex ? ' v2-landing__rotator-term--active' : ''}`}
+          >
+            {term}
+          </span>
+        ))}
+      </span>
     </span>
   );
 };

--- a/frontend/src/v2/landing/v2-landing.css
+++ b/frontend/src/v2/landing/v2-landing.css
@@ -1011,15 +1011,33 @@
    at a calm 2.6s cadence (see the marketing-motion carve-out). Cobalt is
    the page's one accent; the rotating term is the hero's one accent use. */
 .v2-landing__rotator {
-  display: inline-grid;
+  position: relative;
+  display: inline-block;
   overflow: hidden;
   vertical-align: bottom;
   color: var(--v2-accent);
   padding-bottom: 0.06em; /* keep descenders (y, p) out of the clip */
+  /* Width tracks the active term (via the sizer) — smooth the resize so the
+     suffix glides rather than jumps when a shorter/longer term rotates in. */
+  transition: width 350ms ease-out;
+}
+
+/* In-flow, invisible: defines the slot's width + height from the active term. */
+.v2-landing__rotator-sizer {
+  visibility: hidden;
+  white-space: nowrap;
+}
+
+/* Animated terms sit on top of the sizer, filling it. */
+.v2-landing__rotator-stack {
+  position: absolute;
+  inset: 0;
 }
 
 .v2-landing__rotator-term {
-  grid-area: 1 / 1;
+  position: absolute;
+  left: 0;
+  top: 0;
   opacity: 0;
   transform: translateY(0.55em);
   white-space: nowrap;


### PR DESCRIPTION
Follow-up to #717. Moving the rotating term inside the sentence frame exposed a spacing bug in zh: the fixed widest-term slot stranded 对话 far right on short terms.

Fix: in-flow invisible sizer holds only the active term (slot width tracks it), animated terms absolutely positioned over it, 350ms width transition so 对话 glides. English (no suffix) is visually unchanged. 17 landing/invariant tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMeWzgFxsfBcjoLVLewEES