### PR TITLE
feat(i18n): internationalize the v2 shell — 12 components, Phase 2

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -35,13 +35,14 @@ module.exports = {
       version: 'detect',
     },
   },
-  // Phase 1 zh-CN manifest. Extend this exact list only as each surface
+  // zh-CN migration manifest. Extend this exact list only as each surface
   // migrates, so translated components cannot regress to JSX literals.
   overrides: [
     {
       files: [
         'src/v2/landing/V2LandingPage.tsx',
         'src/v2/components/V2LangSwitch.tsx',
+        // Phase 1B — auth + first-run + invite + pod-chat (#716)
         'src/v2/components/V2AuthBrand.tsx',
         'src/v2/components/V2Login.tsx',
         'src/v2/components/V2Register.tsx',
@@ -55,6 +56,19 @@ module.exports = {
         'src/v2/components/V2PodChat.tsx',
         'src/v2/components/V2FirstRunHero.tsx',
         'src/v2/components/V2InviteModal.tsx',
+        // Phase 2 — the v2 shell (#719)
+        'src/v2/agents/V2AgentProfile.tsx',
+        'src/v2/components/V2AdminAnalytics.tsx',
+        'src/v2/components/V2AdminUsers.tsx',
+        'src/v2/components/V2AgentBYO.tsx',
+        'src/v2/components/V2FeedbackMenu.tsx',
+        'src/v2/components/V2PodInspector.tsx',
+        'src/v2/components/V2PodsSidebar.tsx',
+        'src/v2/components/V2YourTeamPage.tsx',
+        'src/v2/landing/V2ComparePage.tsx',
+        'src/v2/marketplace/V2MarketplaceDetailPage.tsx',
+        'src/v2/marketplace/V2MarketplacePage.tsx',
+        'src/v2/showcase/V2Showcase.tsx',
       ],
       rules: {
         'i18next/no-literal-string': ['error', {
@@ -64,6 +78,7 @@ module.exports = {
               'className', 'styleName', 'style', 'type', 'key', 'id',
               'width', 'height', 'to', 'href', 'src', 'rel', 'target',
               'variant', 'size', 'component', 'role', 'name', 'autoComplete',
+              'field',
               'inputMode', 'accept', 'd', 'viewBox', 'fill', 'fontSize', 'stroke',
               'sx', 'value', 'aria-hidden', 'anchorOrigin', 'transformOrigin',
               'PaperProps',

--- a/frontend/src/i18n/__tests__/translationKeys.test.ts
+++ b/frontend/src/i18n/__tests__/translationKeys.test.ts
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import path from 'path';
+
+type TranslationTree = { [key: string]: string | TranslationTree };
+
+const eslintConfig = require('../../../.eslintrc.js');
+
+const flattenKeys = (tree: TranslationTree, prefix = ''): string[] => (
+  Object.entries(tree).flatMap(([key, value]) => {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    return typeof value === 'string' ? [fullKey] : flattenKeys(value, fullKey);
+  })
+);
+
+const readJson = (fileName: string): TranslationTree => JSON.parse(
+  fs.readFileSync(path.join(__dirname, '..', 'locales', fileName), 'utf8'),
+);
+
+const literalTranslationKeys = (source: string): string[] => {
+  const keys = new Set<string>();
+  const tCall = /\bt\(\s*(['"`])([^'"`]+)\1/g;
+  const transProp = /\bi18nKey\s*=\s*(['"])([^'"]+)\1/g;
+
+  for (const pattern of [tCall, transProp]) {
+    let match = pattern.exec(source);
+    while (match) {
+      if (match[1] !== '`' || !match[2].includes('${')) keys.add(match[2]);
+      match = pattern.exec(source);
+    }
+  }
+
+  return [...keys];
+};
+
+describe('i18n migration manifest', () => {
+  const manifestOverride = eslintConfig.overrides.find(
+    (override: { rules?: Record<string, unknown> }) => override.rules?.['i18next/no-literal-string'],
+  );
+  const migratedFiles: string[] = manifestOverride?.files || [];
+  const enKeys = new Set(flattenKeys(readJson('en.json')));
+  const zhKeys = new Set(flattenKeys(readJson('zh-CN.json')));
+  const hasKey = (keys: Set<string>, key: string): boolean => (
+    keys.has(key) || keys.has(`${key}_one`) || keys.has(`${key}_other`)
+  );
+
+  it('keeps English and Simplified Chinese key paths identical', () => {
+    expect([...zhKeys].sort()).toEqual([...enKeys].sort());
+  });
+
+  it('resolves every literal translation key used by a migrated component', () => {
+    expect(migratedFiles.length).toBeGreaterThan(0);
+
+    const missing: string[] = [];
+    for (const relativePath of migratedFiles) {
+      const source = fs.readFileSync(path.join(__dirname, '../../..', relativePath), 'utf8');
+      for (const key of literalTranslationKeys(source)) {
+        if (!hasKey(enKeys, key)) missing.push(`${relativePath}: en:${key}`);
+        if (!hasKey(zhKeys, key)) missing.push(`${relativePath}: zh-CN:${key}`);
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+
+  it('keeps the deferred message bubble outside the migrated-file manifest', () => {
+    expect(migratedFiles).not.toContain('src/v2/components/V2MessageBubble.tsx');
+  });
+});

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -599,5 +599,781 @@
       "license": "License (Apache-2.0)",
       "copyright": "© {{year}} Commonly. Code licensed under Apache-2.0; the Commonly name and logo are trademarks of the Commonly project."
     }
+  },
+  "adminUsers": {
+    "columns": {
+      "actions": "Actions"
+    },
+    "statusFilters": {
+      "all": "All",
+      "pending": "Pending",
+      "invited": "Invited",
+      "closed": "Closed"
+    },
+    "lifecycle": {
+      "joinedDays_one": "joined {{count}}d",
+      "joinedDays_other": "joined {{count}}d",
+      "joinedUnknown": "joined —",
+      "pods_one": "{{count}} pod",
+      "pods_other": "{{count}} pods",
+      "messages_one": "{{count}} msg",
+      "messages_other": "{{count}} msgs"
+    },
+    "actions": {
+      "ban": "Ban",
+      "unban": "Unban",
+      "delete": "Delete",
+      "refresh": "Refresh",
+      "reopen": "Reopen",
+      "working": "Working…",
+      "sendInvitation": "Send invitation",
+      "sending": "Sending…",
+      "generateCode": "Generate code",
+      "generating": "Generating…",
+      "copy": "Copy",
+      "copied": "Copied!",
+      "dismiss": "Dismiss",
+      "revoke": "Revoke",
+      "revoking": "Revoking…"
+    },
+    "prompts": {
+      "ban": "Ban {{username}}? Optional reason:",
+      "deleteUser": "Permanently delete {{username}} ({{email}})? This cannot be undone.",
+      "revokeCode": "Revoke invitation code {{code}}? This cannot be undone."
+    },
+    "notices": {
+      "smtpNotConfigured": "SMTP not configured — generate a code below and share it manually instead."
+    },
+    "errors": {
+      "loadUsers": "Failed to load users.",
+      "updateBan": "Failed to update ban state.",
+      "deleteUser": "Failed to delete user.",
+      "loadWaitlist": "Failed to load waitlist.",
+      "loadInvites": "Failed to load invitation codes.",
+      "sendInvitation": "Failed to send invitation.",
+      "reopenRequest": "Failed to reopen request.",
+      "generateCode": "Failed to generate invitation code.",
+      "revokeCode": "Failed to revoke invitation code."
+    },
+    "registered": {
+      "title": "Registered users",
+      "subtitle": "Everyone with an account on this instance. Ban stops logins immediately; delete is permanent.",
+      "analyticsLink": "Usage analytics →",
+      "searchPlaceholder": "Search username or email…",
+      "loading": "Loading users…",
+      "noMatch": "No users match.",
+      "demoteAdminFirst": "Demote the admin role first",
+      "columns": {
+        "username": "Username",
+        "email": "Email",
+        "role": "Role",
+        "status": "Status",
+        "lifecycle": "Lifecycle"
+      },
+      "userStatus": {
+        "banned": "banned",
+        "active": "active",
+        "unverified": "unverified"
+      }
+    },
+    "waitlist": {
+      "title": "Waitlist",
+      "subtitle": "Review access requests and send invitation codes.",
+      "searchPlaceholder": "Search email, name, or organization…",
+      "filterByStatus": "Filter by status",
+      "loading": "Loading waitlist…",
+      "emptyTitle": "No waitlist requests",
+      "emptyFiltered": "No requests match the current filters.",
+      "emptyDefault": "New access requests will appear here.",
+      "invitedBy": "by {{username}}",
+      "invitedCode": "code {{code}}",
+      "columns": {
+        "email": "Email",
+        "name": "Name",
+        "organization": "Organization",
+        "useCase": "Use case",
+        "status": "Status",
+        "requested": "Requested",
+        "invited": "Invited"
+      },
+      "status": {
+        "pending": "pending",
+        "invited": "invited",
+        "closed": "closed"
+      }
+    },
+    "invites": {
+      "title": "Invitation codes",
+      "subtitle": "Generate codes to share manually, and revoke codes you no longer want active.",
+      "newCodeLabel": "New code — copy and share it manually",
+      "dismissNewCode": "Dismiss new code",
+      "loading": "Loading invitation codes…",
+      "emptyTitle": "No invitation codes",
+      "emptyText": "Generate a code to get started.",
+      "columns": {
+        "code": "Code",
+        "uses": "Uses",
+        "status": "Status",
+        "expires": "Expires",
+        "created": "Created"
+      },
+      "codeStatus": {
+        "active": "active",
+        "revoked": "revoked"
+      }
+    }
+  },
+  "inspector": {
+    "now": "NOW",
+    "statusLabel": "Status: {{status}}",
+    "unknown": "unknown",
+    "unknownUser": "Unknown",
+    "aiAgent": "AI Agent",
+    "online": "Online",
+    "idle": "Idle",
+    "back": "Back",
+    "backToOverview": "Back to overview",
+    "hidePodTeam": "Hide pod team",
+    "createdByMeta": "Created by {{name}} · {{date}}",
+    "agentCount": "{{count}} agent",
+    "agentCount_other": "{{count}} agents",
+    "humanCount": "{{count}} human",
+    "humanCount_other": "{{count}} humans",
+    "untitledAnnouncement": "Untitled announcement",
+    "externalLink": "External link",
+    "memberNotFound": "Member not found.",
+    "artifactNotFound": "Artifact not found.",
+    "talkTo": "Talk to {{name}}",
+    "confirmDeletePod": "Delete \"{{name}}\"? This removes the pod and its messages.",
+    "heading": {
+      "member": "Member",
+      "artifact": "Artifact"
+    },
+    "roles": {
+      "owner": "Owner",
+      "human": "Human",
+      "aiAgent": "AI Agent"
+    },
+    "actions": {
+      "cancel": "Cancel",
+      "open": "Open"
+    },
+    "tabs": {
+      "ariaLabel": "Inspector sections",
+      "overview": "Overview",
+      "members": "Members",
+      "tasks": "Tasks",
+      "manage": "Manage"
+    },
+    "progress": {
+      "title": "Progress",
+      "stat": "{{complete}} of {{total}} task complete",
+      "stat_other": "{{complete}} of {{total}} tasks complete"
+    },
+    "goal": {
+      "title": "Goal",
+      "empty": "No goal set yet."
+    },
+    "artifacts": {
+      "title": "Artifacts",
+      "add": "+ Add",
+      "addShort": "Add",
+      "adding": "Adding…",
+      "urlPlaceholder": "Paste a Notion, Google Doc, Figma, GitHub, Zoom URL…",
+      "empty": "No artifacts yet — share Notion, Sheets, or Figma links and they'll appear here."
+    },
+    "members": {
+      "invite": "Invite",
+      "inviteTitle": "Invite people or add an agent to this pod",
+      "manage": "Manage",
+      "manageTitle": "Manage agents installed in this pod",
+      "empty": "No members yet.",
+      "notShownForDirect": "Members are not shown for direct pods."
+    },
+    "runState": {
+      "title": "Run state",
+      "blocked": "Blocked",
+      "blockedCount": "{{count}} blocked",
+      "inProgress": "In Progress",
+      "inProgressCount": "{{count}} in progress",
+      "complete": "Complete",
+      "completeCount": "{{count}} complete",
+      "viewRunBoard": "View run board",
+      "recentTasks": "Recent tasks",
+      "empty": "No tasks yet. Agents will create tasks here as they work — or @-mention one with a request."
+    },
+    "taskPill": {
+      "done": "Done",
+      "blocked": "Blocked",
+      "active": "Active"
+    },
+    "detail": {
+      "workingOn": "Working on",
+      "purpose": "Purpose",
+      "specialties": "Specialties",
+      "directMessages": "Direct messages",
+      "peer": "peer",
+      "openDm": "Open {{name}} ↔ {{peer}}",
+      "type": "Type",
+      "source": "Source"
+    },
+    "runtime": {
+      "byo": "BYO",
+      "byoHostTitle": "BYO — you run this agent (laptop, server, anywhere)",
+      "rowAria": "{{label}} runtime",
+      "rowAriaByo": "{{label}} runtime, BYO",
+      "rowTitleByo": "{{label}} · BYO (you run it)"
+    },
+    "danger": {
+      "title": "Danger zone",
+      "text": "Deleting this pod removes all messages, tasks, and artifacts. This cannot be undone.",
+      "deletePod": "Delete pod"
+    },
+    "errors": {
+      "couldNotAddLink": "Could not add link.",
+      "privatePodNotOpened": "Private pod could not be opened.",
+      "privatePodNotOpenedForAgent": "Private pod could not be opened for this agent."
+    },
+    "preview": {
+      "loading": "Loading…",
+      "loadingPdf": "Loading PDF…",
+      "loadingCsv": "Loading CSV…",
+      "renderingWord": "Rendering Word document…",
+      "renderingExcel": "Rendering Excel workbook…",
+      "renderingPowerpoint": "Rendering PowerPoint deck…",
+      "couldNotLoad": "Could not load: {{error}}",
+      "couldNotPreview": "Could not preview: {{error}}",
+      "couldNotLoadFile": "Could not load file",
+      "couldNotLoadDocument": "Could not load document",
+      "couldNotLoadWorkbook": "Could not load workbook",
+      "couldNotRenderPreview": "Could not render preview",
+      "couldNotRenderSheet": "Could not render sheet: {{error}}",
+      "emptyFile": "Empty file",
+      "emptySheet": "Empty sheet",
+      "emptyDocument": "Empty document",
+      "emptyDeck": "Empty deck",
+      "truncated": "Preview truncated at 200 KB. Click Open for the full file.",
+      "moreRows": "{{count}} more row not shown. Click Open for the full file.",
+      "moreRows_other": "{{count}} more rows not shown. Click Open for the full file."
+    }
+  },
+  "marketplace": {
+    "title": "Marketplace",
+    "subtitle": "Browse and install agents, apps, and integrations.",
+    "subtitleLocked": "Install agents and apps like packages.",
+    "searchPlaceholder": "Search agents, apps, integrations…",
+    "categories": {
+      "all": "All categories",
+      "productivity": "Productivity",
+      "development": "Development",
+      "analytics": "Analytics",
+      "support": "Support",
+      "communication": "Communication",
+      "other": "Other"
+    },
+    "kinds": {
+      "all": "All kinds",
+      "agent": "Agents",
+      "app": "Apps",
+      "skill": "Skills",
+      "bundle": "Bundles"
+    },
+    "filters": {
+      "kindLabel": "Kind",
+      "categoryLabel": "Category",
+      "installToPodLabel": "Install to pod"
+    },
+    "tabs": {
+      "discover": "Discover",
+      "installed": "Installed",
+      "installedWithCount": "Installed ({{count}})"
+    },
+    "sections": {
+      "results": "Results",
+      "allListings": "All listings",
+      "officialTitle": "Official integrations",
+      "officialSub": "Curated by Commonly — connect from a pod.",
+      "mcpTitle": "MCP apps (preview)",
+      "mcpSub": "Interactive UI rendered inside MCP-compatible hosts."
+    },
+    "card": {
+      "verified": "Verified",
+      "verifiedTooltip": "Verified by Commonly",
+      "noDescription": "No description provided.",
+      "installsCount": "{{count}} installs"
+    },
+    "actions": {
+      "install": "Install",
+      "installing": "Installing…",
+      "remove": "Remove",
+      "removing": "Removing…"
+    },
+    "official": {
+      "mcpApp": "MCP app",
+      "integration": "integration",
+      "mcpHostRequired": "MCP host required",
+      "connectInPod": "Connect in pod",
+      "docs": "Docs"
+    },
+    "empty": {
+      "noListingsTitle": "No listings yet",
+      "noListingsText": "Nothing matches your filters. Try a broader search, or publish the first one.",
+      "pickPodText": "Pick a pod to see what's installed.",
+      "nothingInstalledTitle": "Nothing installed here yet",
+      "nothingInstalledText": "Browse Discover and install your first one."
+    },
+    "status": {
+      "pickPodToInstall": "Pick a pod above to install into.",
+      "installed": "Installed {{name}} into {{pod}}.",
+      "podFallback": "pod",
+      "removed": "Removed {{name}}.",
+      "openPodToConnect": "Open a pod to connect {{name}}."
+    },
+    "errors": {
+      "loadFailed": "Failed to load the marketplace.",
+      "installFailed": "Could not install — try again.",
+      "removeFailed": "Could not remove — try again."
+    },
+    "gate": {
+      "cloudAgentsNotEntitled": "Hosted agents require an upgrade or admin — connect your own agent instead.",
+      "connectYourOwnAgent": "Connect your own agent"
+    },
+    "comingSoon": {
+      "badge": "Coming soon",
+      "title": "A marketplace of installable agents",
+      "text": "We're curating agents you can install in one click. In the meantime, you can already bring your own — connect Claude Code, Cursor, or Codex and it becomes a full member of your pods.",
+      "cta": "Bring your own agent"
+    }
+  },
+  "compare": {
+    "kicker": "Compare",
+    "title": "Commonly vs Raft",
+    "lede": "Commonly and Raft both put humans and agents in one shared workspace, with your agents running on your own runtime. The difference is ownership: Commonly is open-source and self-hostable, with no per-agent tax.",
+    "close": "Want a hosted product and don't mind closed-source? Raft is good, and shipping. Want to own the substrate — self-host it, pay no per-agent tax, fork it, and federate it? That's Commonly.",
+    "note": "Comparison reflects each product's public positioning. Raft is a trademark of its respective owner; this page is not affiliated with or endorsed by Raft.",
+    "nav": {
+      "primaryLabel": "Primary",
+      "home": "Home",
+      "signIn": "Sign in"
+    },
+    "actions": {
+      "openApp": "Open the app",
+      "getStarted": "Get started",
+      "starOnGithub": "Star on GitHub"
+    },
+    "table": {
+      "ariaLabel": "Commonly compared with Raft",
+      "commonly": "Commonly",
+      "raft": "Raft"
+    },
+    "rows": {
+      "source": {
+        "dim": "Source",
+        "commonly": "Open — Apache-2.0, every line readable",
+        "raft": "Closed source"
+      },
+      "selfHost": {
+        "dim": "Self-host",
+        "commonly": "Yes — docker compose up on your own infra",
+        "raft": "Hosted product"
+      },
+      "perAgentCost": {
+        "dim": "Per-agent cost",
+        "commonly": "$0 — run one agent or fifty",
+        "raft": "Per-seat + per-agent pricing"
+      },
+      "yourData": {
+        "dim": "Your data",
+        "commonly": "On your machines when self-hosted",
+        "raft": "On their cloud"
+      },
+      "federation": {
+        "dim": "Federation",
+        "commonly": "On the roadmap — agents across instances",
+        "raft": "Single hosted instance"
+      },
+      "sharedWorkspace": {
+        "dim": "Shared workspace",
+        "commonly": "Humans + agents in one set of pods",
+        "raft": "Humans + agents in one workspace"
+      },
+      "byoRuntime": {
+        "dim": "Bring your own runtime",
+        "commonly": "Native, OpenClaw, Codex, Claude Code, webhook",
+        "raft": "Bring your own agent daemon"
+      }
+    },
+    "footer": {
+      "product": "Product",
+      "openSource": "Open source",
+      "license": "License (Apache-2.0)"
+    }
+  },
+  "showcase": {
+    "nav": {
+      "brandHome": "Commonly home",
+      "primary": "Primary",
+      "whatIs": "What is Commonly?",
+      "signIn": "Sign in",
+      "signUpToJoin": "Sign up to join"
+    },
+    "actions": {
+      "startYourOwnRoom": "Start your own room"
+    },
+    "banner": {
+      "regionLabel": "Sign up to join Commonly",
+      "text": "A live look inside a Commonly room — sign up to start your own."
+    },
+    "unavailable": {
+      "errorTitle": "This room couldn't be loaded",
+      "privateTitle": "This room isn't public",
+      "errorText": "Something went wrong loading this conversation. Try again in a moment.",
+      "privateText": "It may have been made private or removed. Explore what Commonly is, or start your own room."
+    },
+    "room": {
+      "defaultName": "Commonly room",
+      "memberCount_one": "{{count}} member",
+      "memberCount_other": "{{count}} members",
+      "agentCount_one": "{{count}} agent",
+      "agentCount_other": "{{count}} agents",
+      "readOnlyView": "Read-only view",
+      "agentsLabel": "Agents in this room"
+    },
+    "messages": {
+      "olderHidden": "Earlier messages are hidden in this public view.",
+      "emptyTitle": "No messages yet",
+      "emptyText": "This room is quiet right now. Check back soon."
+    },
+    "footer": {
+      "title": "This is a real Commonly room.",
+      "text": "Bring your team and your agents into one shared memory. Start your own in minutes — it's open-source and free."
+    }
+  },
+  "agentByo": {
+    "eyebrow": "Connect any runtime",
+    "title": "Bring your own agent",
+    "description": "Connect Claude Code, Cursor, or Codex to your Commonly pods via MCP. ~2 minutes.",
+    "form": {
+      "nameLabel": "Agent name",
+      "nameHint": "Lower-case letters, digits, and dashes. This is the identity your agent posts as.",
+      "podLabel": "Install into pod",
+      "podHint": "Your agent will be installed here. You can install it into more pods later.",
+      "loadingPods": "Loading pods…"
+    },
+    "actions": {
+      "install": "Install + generate token",
+      "issuing": "Issuing token…",
+      "copy": "Copy",
+      "copied": "Copied!",
+      "goToPod": "Go to your pod",
+      "installAnother": "Install another"
+    },
+    "footnote": {
+      "preferCli": "Prefer the CLI?",
+      "then": "then",
+      "notSure": "Not sure which path?",
+      "mcpVsCli": "MCP vs CLI vs SDK",
+      "fullWalkthrough": "full walkthrough"
+    },
+    "result": {
+      "heading": "Token issued for",
+      "copyOnceLead": "Copy this",
+      "copyOnceEmphasis": "once",
+      "copyOnceRest": "Commonly hashes the token after issuance — if you lose it, come back here and rotate (re-running install with the same name is idempotent on identity; the token is reissued fresh)."
+    },
+    "snippets": {
+      "runtimeToken": "Runtime token",
+      "claudeCode": "Claude Code",
+      "cursor": "Cursor — add to ~/.cursor/mcp.json",
+      "memory": "Bring its memory (optional)"
+    },
+    "memory": {
+      "doneLead": "✓ Memory imported —",
+      "doneRest": "arrives knowing your project. It shows up in the agent's profile under long-term memory.",
+      "pasteLead": "Paste your agent's local",
+      "pasteOr": "or",
+      "pasteRest": "(or pick the file) and it starts here with everything it already knows. Appends to its long-term memory; never overwrites. Nothing is sent until you click import.",
+      "placeholder": "# Paste MEMORY.md / CLAUDE.md content here…",
+      "fileAriaLabel": "Choose a memory file",
+      "import": "Import memory",
+      "importing": "Importing…"
+    },
+    "errors": {
+      "nameRequired": "Agent name must contain at least one letter or digit.",
+      "podRequired": "Pick a pod to install into.",
+      "tokenEmpty": "Install succeeded but token issuance returned empty. Retry, or contact ops.",
+      "installFailed": "Install failed.",
+      "fileTooLarge": "That file is over the 256KB import ceiling — trim it or paste the relevant part.",
+      "importFailed": "Import failed."
+    }
+  },
+  "agentProfile": {
+    "loading": "Loading…",
+    "nav": {
+      "backToCommonly": "Back to Commonly",
+      "whatIsCommonly": "What is Commonly?",
+      "signIn": "Sign in",
+      "signUp": "Sign up"
+    },
+    "notFound": {
+      "title": "Agent not found",
+      "body": "This agent may not exist. Explore what Commonly is, or start your own team."
+    },
+    "actions": {
+      "startYourOwnTeam": "Start your own team"
+    },
+    "hero": {
+      "official": "Official",
+      "activeInPods_one": "Active in {{count}} pod",
+      "activeInPods_other": "Active in {{count}} pods",
+      "memories_one": "{{count}} memory",
+      "memories_other": "{{count}} memories",
+      "talkTo": "Talk to {{name}}"
+    },
+    "pods": {
+      "title": "Pods",
+      "publicTitle": "Public pods",
+      "allPods": "all pods",
+      "activeAgo": "active {{time}}",
+      "remove": "Remove",
+      "removing": "Removing…",
+      "removeAria": "Remove {{agentName}} from {{podName}}",
+      "removeConfirm": "Remove {{agentName}} from \"{{podName}}\"? Its memory and identity are kept — it just leaves this pod.",
+      "removeError": "Could not remove the agent from that pod."
+    },
+    "skills": {
+      "title": "Installed skills"
+    },
+    "memory": {
+      "title": "Memory layer",
+      "roleOwner": "owner",
+      "roleAdmin": "admin",
+      "viewTag": "{{role}} view · private",
+      "indexSummary_one": "{{notes}} notes across {{count}} section{{updated}}. Visible to you; hidden from the public profile.",
+      "indexSummary_other": "{{notes}} notes across {{count}} sections{{updated}}. Visible to you; hidden from the public profile.",
+      "updatedClause": " · updated {{time}}",
+      "more": "+{{count}} more",
+      "entriesRemembered": "entries remembered",
+      "persistent": "Persistent memory carried across every pod and runtime this agent joins.",
+      "lastUpdated": "Last updated {{time}}.",
+      "none": "No memory recorded yet."
+    },
+    "activity": {
+      "title": "Recent activity",
+      "turnsAgo_one": "{{count}} turn · {{time}}",
+      "turnsAgo_other": "{{count}} turns · {{time}}"
+    },
+    "footer": {
+      "tagline": "Every agent on Commonly keeps one identity and memory — across any runtime."
+    }
+  },
+  "adminAnalytics": {
+    "title": "Usage",
+    "subtitle": "First-party numbers from this instance's own database — nothing is sent to third parties.",
+    "timeRangeAria": "Time range",
+    "rangeDays": "{{days}}d",
+    "userAdminLink": "User admin →",
+    "loading": "Loading analytics…",
+    "errors": {
+      "loadFailed": "Failed to load analytics."
+    },
+    "cards": {
+      "dau": {
+        "label": "Active today",
+        "hint": "humans active in the last 24h"
+      },
+      "wau": {
+        "label": "Active this week",
+        "hint": "humans active in the last 7 days"
+      },
+      "signups": {
+        "label": "Signups ({{days}}d)",
+        "hint": "new human accounts in range"
+      },
+      "messages": {
+        "label": "Messages ({{days}}d)",
+        "hint": "all messages, agents included"
+      },
+      "total": {
+        "label": "Total users",
+        "hint": "human accounts, all time"
+      }
+    },
+    "charts": {
+      "signupsPerDay": "Signups / day",
+      "messagesPerDay": "Messages / day",
+      "signupsLabel": "Signups",
+      "messagesLabel": "Messages",
+      "signupsUnit": "signups",
+      "messagesUnit": "messages",
+      "perDayAria": "{{label}} per day",
+      "barTitle": "{{date}}: {{value}} {{unit}}"
+    },
+    "funnel": {
+      "title": "Activation funnel",
+      "summary": "Of {{signups}} signups in the last {{days}} days: {{attachRate}}% attached an agent · {{messageRate}}% sent a message · {{d1Rate}}% returned after day 1 · {{d7Rate}}% after day 7.",
+      "table": {
+        "cohort": "Cohort",
+        "signups": "Signups",
+        "attachedAgent": "Attached agent",
+        "sentMessage": "Sent message",
+        "returnedD1": "Returned D1",
+        "returnedD7": "Returned D7"
+      }
+    }
+  },
+  "podsSidebar": {
+    "title": "Pods",
+    "newPod": "New Pod",
+    "closeTitle": "Close pods",
+    "closeAriaLabel": "Close pods list",
+    "searchPlaceholder": "Search pods...",
+    "filtersAriaLabel": "Pod filters",
+    "unreadAriaLabel": "Unread messages",
+    "typing": "typing…",
+    "pinTitle": "Pin",
+    "unpinTitle": "Unpin",
+    "pinAriaLabel": "Pin pod",
+    "unpinAriaLabel": "Unpin pod",
+    "filters": {
+      "all": "All",
+      "team": "Team",
+      "private": "Private"
+    },
+    "groups": {
+      "pinned": "Pinned",
+      "directMessages": "Direct messages",
+      "betweenAgents": "Between agents · {{count}}"
+    },
+    "create": {
+      "teamOption": "Create Team Pod",
+      "privateOption": "Start Private Pod",
+      "privateHint": "Start a Private pod from an agent row or existing private conversation.",
+      "namePlaceholder": "Pod name",
+      "goalPlaceholder": "Goal or description",
+      "cancel": "Cancel",
+      "creating": "Creating...",
+      "submit": "Create"
+    },
+    "empty": {
+      "noMatch": "No pods match your search.",
+      "noPods": "No pods yet. Create one to get started."
+    },
+    "meta": {
+      "directMessage": "Direct message",
+      "agentCount_one": "{{count}} agent",
+      "agentCount_other": "{{count}} agents",
+      "memberCount_one": "{{count}} member",
+      "memberCount_other": "{{count}} members"
+    },
+    "errors": {
+      "createFailed": "Unable to create pod. Check that you are signed in and try again."
+    },
+    "community": {
+      "title": "Join Commonly HQ",
+      "copy": "Meet the builders and their agents.",
+      "button": "Join HQ"
+    }
+  },
+  "feedbackMenu": {
+    "button": "Feedback",
+    "optionsLabel": "Feedback options",
+    "actions": {
+      "reportBug": "Report a bug",
+      "requestFeature": "Request a feature",
+      "askQuestion": "Ask a question",
+      "joinDiscord": "Join our Discord"
+    }
+  },
+  "marketplaceDetail": {
+    "loading": "Loading…",
+    "backToMarketplace": "← Back to marketplace",
+    "install": "Install",
+    "untitled": "Untitled",
+    "categoryOther": "other",
+    "kindApp": "app",
+    "unknownPublisher": "unknown",
+    "unrated": "unrated",
+    "componentFallback": "component",
+    "byPublisher": "by {{publisher}}",
+    "installsCount": "{{count}} installs",
+    "version": "v{{version}}",
+    "verifiedBadge": "✓ Verified",
+    "verifiedTitle": "Verified by Commonly",
+    "sections": {
+      "components": "Components",
+      "requiredScopes": "Required scopes",
+      "about": "About"
+    },
+    "errors": {
+      "noInstallable": "No installable specified",
+      "manifestNotFound": "Manifest not found",
+      "loadFailed": "Failed to load marketplace entry",
+      "notFound": "Not found"
+    }
+  },
+  "yourTeam": {
+    "title": "Your Team",
+    "loading": "Loading…",
+    "untitledProject": "Untitled project",
+    "subtitle": {
+      "empty": "No agents yet — hire your first one to get started.",
+      "summary": "{{agents}} working across {{projects}}",
+      "agentCount_one": "{{count}} agent",
+      "agentCount_other": "{{count}} agents",
+      "projectCount_one": "{{count}} project",
+      "projectCount_other": "{{count}} projects"
+    },
+    "actions": {
+      "hire": "+ Hire an agent",
+      "connectOwn": "Connect your own agent",
+      "cancel": "Cancel"
+    },
+    "redeem": {
+      "placeholder": "Invitation code",
+      "unlock": "Unlock",
+      "unlocking": "Unlocking…",
+      "gated": "Hosted agents are invite-gated during beta.",
+      "haveCode": "Have an invitation code?",
+      "success": "Hosted agents unlocked — hire your first one from the catalog."
+    },
+    "empty": {
+      "title": "Build your AI team",
+      "text": "Agents you hire join your projects, share your project memory, and ship work back to you. Don't have a hosted agent? Connect your own — Claude Code, Cursor, or Codex — in about two minutes.",
+      "hireFirst": "+ Hire your first agent"
+    },
+    "tabs": {
+      "ariaLabel": "Filter by role",
+      "all": "All ({{count}})",
+      "category": "{{label}} ({{count}})"
+    },
+    "card": {
+      "inProject": "in",
+      "roleTitle": "Role: {{role}}",
+      "profile": "Profile",
+      "viewProfileAria": "View {{name}}'s profile",
+      "talkTo": "Talk to",
+      "talkToAria": "Talk to {{name}} one-to-one",
+      "opening": "Opening…"
+    },
+    "activity": {
+      "noRecent": "No recent activity",
+      "justNow": "Just now",
+      "minutesAgo": "{{count}}m ago",
+      "hoursAgo": "{{count}}h ago",
+      "daysAgo": "{{count}}d ago"
+    },
+    "runtime": {
+      "native": "Native",
+      "openclaw": "OpenClaw",
+      "webhook": "Webhook",
+      "cli": "CLI wrapper",
+      "cloudSandbox": "Cloud sandbox"
+    },
+    "errors": {
+      "loadFailed": "Could not load your team.",
+      "redeemFailed": "Could not redeem that code.",
+      "openRoomFailed": "Could not open a 1:1 with this agent — try again."
+    }
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -599,5 +599,781 @@
       "license": "许可证（Apache-2.0）",
       "copyright": "© {{year}} Commonly。代码采用 Apache-2.0 许可；Commonly 名称和标志是 Commonly 项目的商标。"
     }
+  },
+  "adminUsers": {
+    "columns": {
+      "actions": "操作"
+    },
+    "statusFilters": {
+      "all": "全部",
+      "pending": "待处理",
+      "invited": "已邀请",
+      "closed": "已关闭"
+    },
+    "lifecycle": {
+      "joinedDays_one": "加入 {{count}} 天",
+      "joinedDays_other": "加入 {{count}} 天",
+      "joinedUnknown": "加入 —",
+      "pods_one": "{{count}} 个 Pod",
+      "pods_other": "{{count}} 个 Pod",
+      "messages_one": "{{count}} 条消息",
+      "messages_other": "{{count}} 条消息"
+    },
+    "actions": {
+      "ban": "封禁",
+      "unban": "解封",
+      "delete": "删除",
+      "refresh": "刷新",
+      "reopen": "重新开启",
+      "working": "处理中…",
+      "sendInvitation": "发送邀请",
+      "sending": "发送中…",
+      "generateCode": "生成邀请码",
+      "generating": "生成中…",
+      "copy": "复制",
+      "copied": "已复制！",
+      "dismiss": "关闭",
+      "revoke": "撤销",
+      "revoking": "撤销中…"
+    },
+    "prompts": {
+      "ban": "封禁 {{username}}？可选填写原因：",
+      "deleteUser": "永久删除 {{username}}（{{email}}）？此操作无法撤销。",
+      "revokeCode": "撤销邀请码 {{code}}？此操作无法撤销。"
+    },
+    "notices": {
+      "smtpNotConfigured": "SMTP 未配置 — 请在下方生成邀请码并手动分享。"
+    },
+    "errors": {
+      "loadUsers": "加载用户失败。",
+      "updateBan": "更新封禁状态失败。",
+      "deleteUser": "删除用户失败。",
+      "loadWaitlist": "加载 Waitlist 失败。",
+      "loadInvites": "加载邀请码失败。",
+      "sendInvitation": "发送邀请失败。",
+      "reopenRequest": "重新开启请求失败。",
+      "generateCode": "生成邀请码失败。",
+      "revokeCode": "撤销邀请码失败。"
+    },
+    "registered": {
+      "title": "已注册用户",
+      "subtitle": "本实例上拥有账户的所有人。封禁会立即阻止登录；删除是永久性的。",
+      "analyticsLink": "使用分析 →",
+      "searchPlaceholder": "搜索用户名或邮箱…",
+      "loading": "加载用户中…",
+      "noMatch": "没有匹配的用户。",
+      "demoteAdminFirst": "请先取消管理员角色",
+      "columns": {
+        "username": "用户名",
+        "email": "邮箱",
+        "role": "角色",
+        "status": "状态",
+        "lifecycle": "生命周期"
+      },
+      "userStatus": {
+        "banned": "已封禁",
+        "active": "活跃",
+        "unverified": "未验证"
+      }
+    },
+    "waitlist": {
+      "title": "Waitlist",
+      "subtitle": "审核访问请求并发送邀请码。",
+      "searchPlaceholder": "搜索邮箱、姓名或组织…",
+      "filterByStatus": "按状态筛选",
+      "loading": "加载 Waitlist 中…",
+      "emptyTitle": "暂无 Waitlist 请求",
+      "emptyFiltered": "没有符合当前筛选条件的请求。",
+      "emptyDefault": "新的访问请求会显示在这里。",
+      "invitedBy": "由 {{username}}",
+      "invitedCode": "邀请码 {{code}}",
+      "columns": {
+        "email": "邮箱",
+        "name": "姓名",
+        "organization": "组织",
+        "useCase": "使用场景",
+        "status": "状态",
+        "requested": "请求时间",
+        "invited": "邀请时间"
+      },
+      "status": {
+        "pending": "待处理",
+        "invited": "已邀请",
+        "closed": "已关闭"
+      }
+    },
+    "invites": {
+      "title": "邀请码",
+      "subtitle": "生成邀请码以手动分享，并撤销你不再希望生效的邀请码。",
+      "newCodeLabel": "新邀请码 — 复制并手动分享",
+      "dismissNewCode": "关闭新邀请码",
+      "loading": "加载邀请码中…",
+      "emptyTitle": "暂无邀请码",
+      "emptyText": "生成一个邀请码即可开始。",
+      "columns": {
+        "code": "邀请码",
+        "uses": "使用次数",
+        "status": "状态",
+        "expires": "过期时间",
+        "created": "创建时间"
+      },
+      "codeStatus": {
+        "active": "生效中",
+        "revoked": "已撤销"
+      }
+    }
+  },
+  "inspector": {
+    "now": "当前",
+    "statusLabel": "状态：{{status}}",
+    "unknown": "未知",
+    "unknownUser": "未知",
+    "aiAgent": "AI 智能体",
+    "online": "在线",
+    "idle": "空闲",
+    "back": "返回",
+    "backToOverview": "返回概览",
+    "hidePodTeam": "隐藏 Pod 团队",
+    "createdByMeta": "由 {{name}} 创建 · {{date}}",
+    "agentCount": "{{count}} 个智能体",
+    "agentCount_other": "{{count}} 个智能体",
+    "humanCount": "{{count}} 位成员",
+    "humanCount_other": "{{count}} 位成员",
+    "untitledAnnouncement": "无标题公告",
+    "externalLink": "外部链接",
+    "memberNotFound": "未找到成员。",
+    "artifactNotFound": "未找到产物。",
+    "talkTo": "和 {{name}} 聊天",
+    "confirmDeletePod": "删除“{{name}}”？此操作会移除该 Pod 及其消息。",
+    "heading": {
+      "member": "成员",
+      "artifact": "产物"
+    },
+    "roles": {
+      "owner": "所有者",
+      "human": "成员",
+      "aiAgent": "AI 智能体"
+    },
+    "actions": {
+      "cancel": "取消",
+      "open": "打开"
+    },
+    "tabs": {
+      "ariaLabel": "检视器分区",
+      "overview": "概览",
+      "members": "成员",
+      "tasks": "任务",
+      "manage": "管理"
+    },
+    "progress": {
+      "title": "进度",
+      "stat": "{{total}} 个任务中已完成 {{complete}} 个",
+      "stat_other": "{{total}} 个任务中已完成 {{complete}} 个"
+    },
+    "goal": {
+      "title": "目标",
+      "empty": "尚未设定目标。"
+    },
+    "artifacts": {
+      "title": "产物",
+      "add": "+ 添加",
+      "addShort": "添加",
+      "adding": "添加中…",
+      "urlPlaceholder": "粘贴 Notion、Google Doc、Figma、GitHub、Zoom 链接…",
+      "empty": "还没有产物 — 分享 Notion、Sheets 或 Figma 链接，它们会显示在这里。"
+    },
+    "members": {
+      "invite": "邀请",
+      "inviteTitle": "邀请他人或向此 Pod 添加智能体",
+      "manage": "管理",
+      "manageTitle": "管理安装在此 Pod 的智能体",
+      "empty": "还没有成员。",
+      "notShownForDirect": "私信 Pod 不显示成员。"
+    },
+    "runState": {
+      "title": "运行状态",
+      "blocked": "受阻",
+      "blockedCount": "{{count}} 个受阻",
+      "inProgress": "进行中",
+      "inProgressCount": "{{count}} 个进行中",
+      "complete": "已完成",
+      "completeCount": "{{count}} 个已完成",
+      "viewRunBoard": "查看运行看板",
+      "recentTasks": "最近任务",
+      "empty": "还没有任务。智能体工作时会在这里创建任务 — 或 @提及 某个智能体并提出请求。"
+    },
+    "taskPill": {
+      "done": "已完成",
+      "blocked": "受阻",
+      "active": "进行中"
+    },
+    "detail": {
+      "workingOn": "正在进行",
+      "purpose": "用途",
+      "specialties": "专长",
+      "directMessages": "私信",
+      "peer": "对方",
+      "openDm": "打开 {{name}} ↔ {{peer}}",
+      "type": "类型",
+      "source": "来源"
+    },
+    "runtime": {
+      "byo": "BYO",
+      "byoHostTitle": "BYO — 你自己运行这个智能体（笔记本、服务器或任何地方）",
+      "rowAria": "{{label}} 运行时",
+      "rowAriaByo": "{{label}} 运行时，BYO",
+      "rowTitleByo": "{{label}} · BYO（你自己运行）"
+    },
+    "danger": {
+      "title": "危险区",
+      "text": "删除此 Pod 会移除所有消息、任务和产物。此操作无法撤销。",
+      "deletePod": "删除 Pod"
+    },
+    "errors": {
+      "couldNotAddLink": "无法添加链接。",
+      "privatePodNotOpened": "无法打开私有 Pod。",
+      "privatePodNotOpenedForAgent": "无法为该智能体打开私有 Pod。"
+    },
+    "preview": {
+      "loading": "加载中…",
+      "loadingPdf": "正在加载 PDF…",
+      "loadingCsv": "正在加载 CSV…",
+      "renderingWord": "正在渲染 Word 文档…",
+      "renderingExcel": "正在渲染 Excel 工作簿…",
+      "renderingPowerpoint": "正在渲染 PowerPoint 演示文稿…",
+      "couldNotLoad": "无法加载：{{error}}",
+      "couldNotPreview": "无法预览：{{error}}",
+      "couldNotLoadFile": "无法加载文件",
+      "couldNotLoadDocument": "无法加载文档",
+      "couldNotLoadWorkbook": "无法加载工作簿",
+      "couldNotRenderPreview": "无法渲染预览",
+      "couldNotRenderSheet": "无法渲染工作表：{{error}}",
+      "emptyFile": "空文件",
+      "emptySheet": "空工作表",
+      "emptyDocument": "空文档",
+      "emptyDeck": "空演示文稿",
+      "truncated": "预览已截断至 200 KB。点击「打开」查看完整文件。",
+      "moreRows": "还有 {{count}} 行未显示。点击「打开」查看完整文件。",
+      "moreRows_other": "还有 {{count}} 行未显示。点击「打开」查看完整文件。"
+    }
+  },
+  "marketplace": {
+    "title": "应用市场",
+    "subtitle": "浏览并安装智能体、应用和集成。",
+    "subtitleLocked": "像安装软件包一样安装智能体和应用。",
+    "searchPlaceholder": "搜索智能体、应用、集成…",
+    "categories": {
+      "all": "全部分类",
+      "productivity": "效率",
+      "development": "开发",
+      "analytics": "分析",
+      "support": "支持",
+      "communication": "沟通",
+      "other": "其他"
+    },
+    "kinds": {
+      "all": "全部类型",
+      "agent": "智能体",
+      "app": "应用",
+      "skill": "技能",
+      "bundle": "捆绑包"
+    },
+    "filters": {
+      "kindLabel": "类型",
+      "categoryLabel": "分类",
+      "installToPodLabel": "安装到 Pod"
+    },
+    "tabs": {
+      "discover": "发现",
+      "installed": "已安装",
+      "installedWithCount": "已安装 ({{count}})"
+    },
+    "sections": {
+      "results": "结果",
+      "allListings": "全部列表",
+      "officialTitle": "官方集成",
+      "officialSub": "由 Commonly 精选 — 从 Pod 中连接。",
+      "mcpTitle": "MCP 应用（预览）",
+      "mcpSub": "在兼容 MCP 的宿主中渲染的交互式界面。"
+    },
+    "card": {
+      "verified": "已验证",
+      "verifiedTooltip": "由 Commonly 验证",
+      "noDescription": "暂无描述。",
+      "installsCount": "{{count}} 次安装"
+    },
+    "actions": {
+      "install": "安装",
+      "installing": "安装中…",
+      "remove": "移除",
+      "removing": "移除中…"
+    },
+    "official": {
+      "mcpApp": "MCP 应用",
+      "integration": "集成",
+      "mcpHostRequired": "需要 MCP 宿主",
+      "connectInPod": "在 Pod 中连接",
+      "docs": "文档"
+    },
+    "empty": {
+      "noListingsTitle": "暂无列表",
+      "noListingsText": "没有符合筛选条件的结果。试试更宽泛的搜索，或发布第一个。",
+      "pickPodText": "选择一个 Pod 查看已安装的内容。",
+      "nothingInstalledTitle": "这里还没有安装任何内容",
+      "nothingInstalledText": "浏览「发现」并安装你的第一个。"
+    },
+    "status": {
+      "pickPodToInstall": "先在上方选择一个 Pod 再安装。",
+      "installed": "已将 {{name}} 安装到 {{pod}}。",
+      "podFallback": "Pod",
+      "removed": "已移除 {{name}}。",
+      "openPodToConnect": "打开一个 Pod 来连接 {{name}}。"
+    },
+    "errors": {
+      "loadFailed": "加载应用市场失败。",
+      "installFailed": "无法安装 — 请重试。",
+      "removeFailed": "无法移除 — 请重试。"
+    },
+    "gate": {
+      "cloudAgentsNotEntitled": "托管智能体需要升级或管理员权限 — 请改为连接你自己的智能体。",
+      "connectYourOwnAgent": "连接你自己的智能体"
+    },
+    "comingSoon": {
+      "badge": "即将推出",
+      "title": "可安装智能体的应用市场",
+      "text": "我们正在精选可一键安装的智能体。在此期间，你已经可以自带智能体 — 连接 Claude Code、Cursor 或 Codex，它就会成为你 Pod 的正式成员。",
+      "cta": "自带智能体"
+    }
+  },
+  "compare": {
+    "kicker": "对比",
+    "title": "Commonly 对比 Raft",
+    "lede": "Commonly 和 Raft 都把人类和智能体放进同一个共享工作空间，你的智能体运行在你自己的运行时上。差别在于所有权：Commonly 开源、可自托管，且不对每个智能体收费。",
+    "close": "想要托管产品、也不介意闭源？Raft 很不错，而且在持续交付。想要拥有底层——自托管、不为每个智能体付费、Fork 它、把它联邦化？那就是 Commonly。",
+    "note": "本对比反映各产品的公开定位。Raft 是其各自所有者的商标；本页面与 Raft 无关联，也未获其背书。",
+    "nav": {
+      "primaryLabel": "主导航",
+      "home": "首页",
+      "signIn": "登录"
+    },
+    "actions": {
+      "openApp": "打开应用",
+      "getStarted": "开始使用",
+      "starOnGithub": "在 GitHub 上 Star"
+    },
+    "table": {
+      "ariaLabel": "Commonly 与 Raft 对比",
+      "commonly": "Commonly",
+      "raft": "Raft"
+    },
+    "rows": {
+      "source": {
+        "dim": "源码",
+        "commonly": "开放——Apache-2.0，每一行都可读",
+        "raft": "闭源"
+      },
+      "selfHost": {
+        "dim": "自托管",
+        "commonly": "支持——在你自己的基础设施上 docker compose up",
+        "raft": "托管产品"
+      },
+      "perAgentCost": {
+        "dim": "单个智能体费用",
+        "commonly": "$0——运行一个还是五十个智能体都一样",
+        "raft": "按席位 + 按智能体计费"
+      },
+      "yourData": {
+        "dim": "你的数据",
+        "commonly": "自托管时留在你自己的机器上",
+        "raft": "在他们的云上"
+      },
+      "federation": {
+        "dim": "联邦化",
+        "commonly": "在路线图上——跨实例的智能体互通",
+        "raft": "单一托管实例"
+      },
+      "sharedWorkspace": {
+        "dim": "共享工作空间",
+        "commonly": "人类 + 智能体在同一组 Pod 中",
+        "raft": "人类 + 智能体在同一工作空间中"
+      },
+      "byoRuntime": {
+        "dim": "自带运行时",
+        "commonly": "原生、OpenClaw、Codex、Claude Code、Webhook",
+        "raft": "自带智能体守护进程"
+      }
+    },
+    "footer": {
+      "product": "产品",
+      "openSource": "开源",
+      "license": "许可证（Apache-2.0）"
+    }
+  },
+  "showcase": {
+    "nav": {
+      "brandHome": "Commonly 首页",
+      "primary": "主导航",
+      "whatIs": "什么是 Commonly？",
+      "signIn": "登录",
+      "signUpToJoin": "注册加入"
+    },
+    "actions": {
+      "startYourOwnRoom": "创建你自己的 Pod"
+    },
+    "banner": {
+      "regionLabel": "注册加入 Commonly",
+      "text": "实时一览 Commonly Pod 内部 — 注册创建你自己的。"
+    },
+    "unavailable": {
+      "errorTitle": "无法加载此 Pod",
+      "privateTitle": "此 Pod 非公开",
+      "errorText": "加载此对话时出错。请稍后重试。",
+      "privateText": "它可能已被设为私密或删除。了解 Commonly 是什么，或创建你自己的 Pod。"
+    },
+    "room": {
+      "defaultName": "Commonly Pod",
+      "memberCount_one": "{{count}} 名成员",
+      "memberCount_other": "{{count}} 名成员",
+      "agentCount_one": "{{count}} 个智能体",
+      "agentCount_other": "{{count}} 个智能体",
+      "readOnlyView": "只读视图",
+      "agentsLabel": "此 Pod 中的智能体"
+    },
+    "messages": {
+      "olderHidden": "在此公开视图中，更早的消息已隐藏。",
+      "emptyTitle": "暂无消息",
+      "emptyText": "此 Pod 目前很安静。请稍后再来看看。"
+    },
+    "footer": {
+      "title": "这是一个真实的 Commonly Pod。",
+      "text": "把你的团队和智能体带入同一份共享记忆。几分钟即可创建你自己的 — 开源且免费。"
+    }
+  },
+  "agentByo": {
+    "eyebrow": "连接任意运行时",
+    "title": "接入你自己的智能体",
+    "description": "通过 MCP 把 Claude Code、Cursor 或 Codex 接入你的 Commonly pod，约 2 分钟。",
+    "form": {
+      "nameLabel": "智能体名称",
+      "nameHint": "小写字母、数字和连字符。这是你的智能体发帖时使用的身份。",
+      "podLabel": "安装到 pod",
+      "podHint": "你的智能体将安装在这里。之后你可以把它安装到更多 pod。",
+      "loadingPods": "正在加载 pod…"
+    },
+    "actions": {
+      "install": "安装并生成 token",
+      "issuing": "正在签发 token…",
+      "copy": "复制",
+      "copied": "已复制！",
+      "goToPod": "前往你的 pod",
+      "installAnother": "再安装一个"
+    },
+    "footnote": {
+      "preferCli": "更喜欢用 CLI？",
+      "then": "然后",
+      "notSure": "不确定用哪条路径？",
+      "mcpVsCli": "MCP、CLI 与 SDK 对比",
+      "fullWalkthrough": "完整教程"
+    },
+    "result": {
+      "heading": "已为以下智能体签发 token：",
+      "copyOnceLead": "请立即复制",
+      "copyOnceEmphasis": "一次",
+      "copyOnceRest": "Commonly 会在签发后对 token 做哈希处理——如果你弄丢了，回到这里重新轮换（用相同名称重新安装对身份是幂等的，token 会重新签发）。"
+    },
+    "snippets": {
+      "runtimeToken": "运行时 token",
+      "claudeCode": "Claude Code",
+      "cursor": "Cursor——添加到 ~/.cursor/mcp.json",
+      "memory": "导入它的记忆（可选）"
+    },
+    "memory": {
+      "doneLead": "✓ 记忆已导入——",
+      "doneRest": "带着对你项目的了解上线。它会显示在智能体资料页的长期记忆中。",
+      "pasteLead": "粘贴你智能体本地的",
+      "pasteOr": "或",
+      "pasteRest": "（或选择文件），它就会带着已经掌握的一切从这里开始。内容会追加到它的长期记忆，绝不覆盖。点击导入前不会发送任何内容。",
+      "placeholder": "# 在此粘贴 MEMORY.md / CLAUDE.md 内容…",
+      "fileAriaLabel": "选择记忆文件",
+      "import": "导入记忆",
+      "importing": "正在导入…"
+    },
+    "errors": {
+      "nameRequired": "智能体名称必须至少包含一个字母或数字。",
+      "podRequired": "请选择要安装到的 pod。",
+      "tokenEmpty": "安装成功，但 token 签发返回为空。请重试，或联系运维。",
+      "installFailed": "安装失败。",
+      "fileTooLarge": "该文件超过 256KB 的导入上限——请精简，或只粘贴相关部分。",
+      "importFailed": "导入失败。"
+    }
+  },
+  "agentProfile": {
+    "loading": "加载中…",
+    "nav": {
+      "backToCommonly": "返回 Commonly",
+      "whatIsCommonly": "Commonly 是什么？",
+      "signIn": "登录",
+      "signUp": "注册"
+    },
+    "notFound": {
+      "title": "未找到智能体",
+      "body": "该智能体可能不存在。了解 Commonly 是什么，或组建你自己的团队。"
+    },
+    "actions": {
+      "startYourOwnTeam": "组建你自己的团队"
+    },
+    "hero": {
+      "official": "官方",
+      "activeInPods_one": "活跃于 {{count}} 个 Pod",
+      "activeInPods_other": "活跃于 {{count}} 个 Pod",
+      "memories_one": "{{count}} 条记忆",
+      "memories_other": "{{count}} 条记忆",
+      "talkTo": "与 {{name}} 对话"
+    },
+    "pods": {
+      "title": "Pod",
+      "publicTitle": "公开 Pod",
+      "allPods": "全部 Pod",
+      "activeAgo": "活跃于 {{time}}",
+      "remove": "移除",
+      "removing": "移除中…",
+      "removeAria": "将 {{agentName}} 从 {{podName}} 移除",
+      "removeConfirm": "将 {{agentName}} 从 \"{{podName}}\" 移除？它的记忆和身份会保留——只是离开这个 Pod。",
+      "removeError": "无法将该智能体从此 Pod 移除。"
+    },
+    "skills": {
+      "title": "已安装技能"
+    },
+    "memory": {
+      "title": "记忆层",
+      "roleOwner": "所有者",
+      "roleAdmin": "管理员",
+      "viewTag": "{{role}}视图 · 私有",
+      "indexSummary_one": "{{notes}} 条笔记，分布在 {{count}} 个板块{{updated}}。仅你可见；对公开资料页隐藏。",
+      "indexSummary_other": "{{notes}} 条笔记，分布在 {{count}} 个板块{{updated}}。仅你可见；对公开资料页隐藏。",
+      "updatedClause": " · 更新于 {{time}}",
+      "more": "还有 {{count}} 条",
+      "entriesRemembered": "条已记住的条目",
+      "persistent": "持久记忆会随该智能体加入的每个 Pod 和运行时一同延续。",
+      "lastUpdated": "最后更新于 {{time}}。",
+      "none": "尚无记忆记录。"
+    },
+    "activity": {
+      "title": "近期活动",
+      "turnsAgo_one": "{{count}} 轮 · {{time}}",
+      "turnsAgo_other": "{{count}} 轮 · {{time}}"
+    },
+    "footer": {
+      "tagline": "Commonly 上的每个智能体都保有唯一的身份和记忆——跨越任何运行时。"
+    }
+  },
+  "adminAnalytics": {
+    "title": "使用情况",
+    "subtitle": "来自本实例自有数据库的第一方数据 — 不会发送给任何第三方。",
+    "timeRangeAria": "时间范围",
+    "rangeDays": "{{days}} 天",
+    "userAdminLink": "用户管理 →",
+    "loading": "正在加载分析数据…",
+    "errors": {
+      "loadFailed": "加载分析数据失败。"
+    },
+    "cards": {
+      "dau": {
+        "label": "今日活跃",
+        "hint": "过去 24 小时内活跃的人类用户"
+      },
+      "wau": {
+        "label": "本周活跃",
+        "hint": "过去 7 天内活跃的人类用户"
+      },
+      "signups": {
+        "label": "注册数（{{days}} 天）",
+        "hint": "该时间范围内新增的人类账户"
+      },
+      "messages": {
+        "label": "消息数（{{days}} 天）",
+        "hint": "所有消息，含 agent"
+      },
+      "total": {
+        "label": "总用户数",
+        "hint": "人类账户，全部时间"
+      }
+    },
+    "charts": {
+      "signupsPerDay": "每日注册数",
+      "messagesPerDay": "每日消息数",
+      "signupsLabel": "注册数",
+      "messagesLabel": "消息数",
+      "signupsUnit": "次注册",
+      "messagesUnit": "条消息",
+      "perDayAria": "每日{{label}}",
+      "barTitle": "{{date}}：{{value}} {{unit}}"
+    },
+    "funnel": {
+      "title": "激活漏斗",
+      "summary": "在过去 {{days}} 天的 {{signups}} 个注册中：{{attachRate}}% 挂载了 agent · {{messageRate}}% 发送了消息 · {{d1Rate}}% 在第 1 天后回访 · {{d7Rate}}% 在第 7 天后回访。",
+      "table": {
+        "cohort": "群组",
+        "signups": "注册数",
+        "attachedAgent": "已挂载 agent",
+        "sentMessage": "已发消息",
+        "returnedD1": "D1 回访",
+        "returnedD7": "D7 回访"
+      }
+    }
+  },
+  "podsSidebar": {
+    "title": "Pod",
+    "newPod": "新建 Pod",
+    "closeTitle": "关闭 Pod",
+    "closeAriaLabel": "关闭 Pod 列表",
+    "searchPlaceholder": "搜索 Pod...",
+    "filtersAriaLabel": "Pod 筛选",
+    "unreadAriaLabel": "未读消息",
+    "typing": "正在输入…",
+    "pinTitle": "置顶",
+    "unpinTitle": "取消置顶",
+    "pinAriaLabel": "置顶 Pod",
+    "unpinAriaLabel": "取消置顶 Pod",
+    "filters": {
+      "all": "全部",
+      "team": "团队",
+      "private": "私密"
+    },
+    "groups": {
+      "pinned": "已置顶",
+      "directMessages": "私信",
+      "betweenAgents": "智能体之间 · {{count}}"
+    },
+    "create": {
+      "teamOption": "创建团队 Pod",
+      "privateOption": "创建私密 Pod",
+      "privateHint": "请从智能体所在行或已有的私密会话中创建私密 Pod。",
+      "namePlaceholder": "Pod 名称",
+      "goalPlaceholder": "目标或描述",
+      "cancel": "取消",
+      "creating": "创建中...",
+      "submit": "创建"
+    },
+    "empty": {
+      "noMatch": "没有匹配的 Pod。",
+      "noPods": "还没有 Pod。创建一个开始使用。"
+    },
+    "meta": {
+      "directMessage": "私信",
+      "agentCount_one": "{{count}} 个智能体",
+      "agentCount_other": "{{count}} 个智能体",
+      "memberCount_one": "{{count}} 名成员",
+      "memberCount_other": "{{count}} 名成员"
+    },
+    "errors": {
+      "createFailed": "无法创建 Pod。请确认你已登录后重试。"
+    },
+    "community": {
+      "title": "加入 Commonly HQ",
+      "copy": "结识开发者和他们的智能体。",
+      "button": "加入 HQ"
+    }
+  },
+  "feedbackMenu": {
+    "button": "反馈",
+    "optionsLabel": "反馈选项",
+    "actions": {
+      "reportBug": "报告 Bug",
+      "requestFeature": "请求功能",
+      "askQuestion": "提问",
+      "joinDiscord": "加入我们的 Discord"
+    }
+  },
+  "marketplaceDetail": {
+    "loading": "加载中…",
+    "backToMarketplace": "← 返回应用市场",
+    "install": "安装",
+    "untitled": "未命名",
+    "categoryOther": "其他",
+    "kindApp": "应用",
+    "unknownPublisher": "未知",
+    "unrated": "暂无评分",
+    "componentFallback": "组件",
+    "byPublisher": "作者 {{publisher}}",
+    "installsCount": "{{count}} 次安装",
+    "version": "v{{version}}",
+    "verifiedBadge": "✓ 已验证",
+    "verifiedTitle": "由 Commonly 验证",
+    "sections": {
+      "components": "组件",
+      "requiredScopes": "所需权限范围",
+      "about": "关于"
+    },
+    "errors": {
+      "noInstallable": "未指定可安装项",
+      "manifestNotFound": "未找到清单",
+      "loadFailed": "加载应用市场条目失败",
+      "notFound": "未找到"
+    }
+  },
+  "yourTeam": {
+    "title": "你的团队",
+    "loading": "加载中…",
+    "untitledProject": "未命名项目",
+    "subtitle": {
+      "empty": "还没有智能体 —— 雇佣第一个智能体开始使用。",
+      "summary": "{{agents}}，分布在 {{projects}}",
+      "agentCount_one": "{{count}} 个智能体",
+      "agentCount_other": "{{count}} 个智能体",
+      "projectCount_one": "{{count}} 个项目",
+      "projectCount_other": "{{count}} 个项目"
+    },
+    "actions": {
+      "hire": "+ 雇佣智能体",
+      "connectOwn": "连接你自己的智能体",
+      "cancel": "取消"
+    },
+    "redeem": {
+      "placeholder": "邀请码",
+      "unlock": "解锁",
+      "unlocking": "解锁中…",
+      "gated": "内测期间，托管智能体采用邀请制。",
+      "haveCode": "有邀请码？",
+      "success": "已解锁托管智能体 —— 从应用市场雇佣第一个智能体。"
+    },
+    "empty": {
+      "title": "组建你的 AI 团队",
+      "text": "你雇佣的智能体会加入你的项目，共享项目记忆，并把成果交付给你。没有托管智能体？连接你自己的 —— Claude Code、Cursor 或 Codex —— 大约两分钟即可完成。",
+      "hireFirst": "+ 雇佣第一个智能体"
+    },
+    "tabs": {
+      "ariaLabel": "按角色筛选",
+      "all": "全部（{{count}}）",
+      "category": "{{label}}（{{count}}）"
+    },
+    "card": {
+      "inProject": "在",
+      "roleTitle": "角色：{{role}}",
+      "profile": "资料页",
+      "viewProfileAria": "查看 {{name}} 的资料页",
+      "talkTo": "对话",
+      "talkToAria": "与 {{name}} 一对一对话",
+      "opening": "打开中…"
+    },
+    "activity": {
+      "noRecent": "近期无活动",
+      "justNow": "刚刚",
+      "minutesAgo": "{{count}} 分钟前",
+      "hoursAgo": "{{count}} 小时前",
+      "daysAgo": "{{count}} 天前"
+    },
+    "runtime": {
+      "native": "原生",
+      "openclaw": "OpenClaw",
+      "webhook": "Webhook",
+      "cli": "CLI 封装器",
+      "cloudSandbox": "云沙箱"
+    },
+    "errors": {
+      "loadFailed": "无法加载你的团队。",
+      "redeemFailed": "无法兑换该邀请码。",
+      "openRoomFailed": "无法与该智能体开启一对一对话 —— 请重试。"
+    }
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -648,7 +648,7 @@
       "loadUsers": "加载用户失败。",
       "updateBan": "更新封禁状态失败。",
       "deleteUser": "删除用户失败。",
-      "loadWaitlist": "加载 Waitlist 失败。",
+      "loadWaitlist": "加载等候名单失败。",
       "loadInvites": "加载邀请码失败。",
       "sendInvitation": "发送邀请失败。",
       "reopenRequest": "重新开启请求失败。",
@@ -657,7 +657,7 @@
     },
     "registered": {
       "title": "已注册用户",
-      "subtitle": "本实例上拥有账户的所有人。封禁会立即阻止登录；删除是永久性的。",
+      "subtitle": "本实例上拥有账户的所有人。封禁会立即阻止登录，删除则不可恢复。",
       "analyticsLink": "使用分析 →",
       "searchPlaceholder": "搜索用户名或邮箱…",
       "loading": "加载用户中…",
@@ -677,12 +677,12 @@
       }
     },
     "waitlist": {
-      "title": "Waitlist",
+      "title": "等候名单",
       "subtitle": "审核访问请求并发送邀请码。",
       "searchPlaceholder": "搜索邮箱、姓名或组织…",
       "filterByStatus": "按状态筛选",
-      "loading": "加载 Waitlist 中…",
-      "emptyTitle": "暂无 Waitlist 请求",
+      "loading": "加载等候名单中…",
+      "emptyTitle": "暂无等候名单请求",
       "emptyFiltered": "没有符合当前筛选条件的请求。",
       "emptyDefault": "新的访问请求会显示在这里。",
       "invitedBy": "由 {{username}}",
@@ -704,7 +704,7 @@
     },
     "invites": {
       "title": "邀请码",
-      "subtitle": "生成邀请码以手动分享，并撤销你不再希望生效的邀请码。",
+      "subtitle": "生成邀请码手动分享，并撤销不再需要的邀请码。",
       "newCodeLabel": "新邀请码 — 复制并手动分享",
       "dismissNewCode": "关闭新邀请码",
       "loading": "加载邀请码中…",
@@ -751,7 +751,7 @@
     },
     "roles": {
       "owner": "所有者",
-      "human": "成员",
+      "human": "人类",
       "aiAgent": "AI 智能体"
     },
     "actions": {
@@ -788,7 +788,7 @@
       "manage": "管理",
       "manageTitle": "管理安装在此 Pod 的智能体",
       "empty": "还没有成员。",
-      "notShownForDirect": "私信 Pod 不显示成员。"
+      "notShownForDirect": "私信不显示成员列表。"
     },
     "runState": {
       "title": "运行状态",
@@ -800,7 +800,7 @@
       "completeCount": "{{count}} 个已完成",
       "viewRunBoard": "查看运行看板",
       "recentTasks": "最近任务",
-      "empty": "还没有任务。智能体工作时会在这里创建任务 — 或 @提及 某个智能体并提出请求。"
+      "empty": "还没有任务。智能体工作时会在这里创建任务 —— 或 @提及 某个智能体并向它提出请求。"
     },
     "taskPill": {
       "done": "已完成",
@@ -812,7 +812,7 @@
       "purpose": "用途",
       "specialties": "专长",
       "directMessages": "私信",
-      "peer": "对方",
+      "peer": "对端",
       "openDm": "打开 {{name}} ↔ {{peer}}",
       "type": "类型",
       "source": "来源"
@@ -860,7 +860,7 @@
   "marketplace": {
     "title": "应用市场",
     "subtitle": "浏览并安装智能体、应用和集成。",
-    "subtitleLocked": "像安装软件包一样安装智能体和应用。",
+    "subtitleLocked": "像装软件包一样安装智能体和应用。",
     "searchPlaceholder": "搜索智能体、应用、集成…",
     "categories": {
       "all": "全部分类",
@@ -894,7 +894,7 @@
       "officialTitle": "官方集成",
       "officialSub": "由 Commonly 精选 — 从 Pod 中连接。",
       "mcpTitle": "MCP 应用（预览）",
-      "mcpSub": "在兼容 MCP 的宿主中渲染的交互式界面。"
+      "mcpSub": "在兼容 MCP 的宿主中呈现的交互式界面。"
     },
     "card": {
       "verified": "已验证",
@@ -941,7 +941,7 @@
     "comingSoon": {
       "badge": "即将推出",
       "title": "可安装智能体的应用市场",
-      "text": "我们正在精选可一键安装的智能体。在此期间，你已经可以自带智能体 — 连接 Claude Code、Cursor 或 Codex，它就会成为你 Pod 的正式成员。",
+      "text": "我们正在精选可一键安装的智能体。在此之前，你已经可以自带智能体 —— 连接 Claude Code、Cursor 或 Codex，它就会成为你 Pod 的正式成员。",
       "cta": "自带智能体"
     }
   },
@@ -949,7 +949,7 @@
     "kicker": "对比",
     "title": "Commonly 对比 Raft",
     "lede": "Commonly 和 Raft 都把人类和智能体放进同一个共享工作空间，你的智能体运行在你自己的运行时上。差别在于所有权：Commonly 开源、可自托管，且不对每个智能体收费。",
-    "close": "想要托管产品、也不介意闭源？Raft 很不错，而且在持续交付。想要拥有底层——自托管、不为每个智能体付费、Fork 它、把它联邦化？那就是 Commonly。",
+    "close": "想要托管产品、也不介意闭源？Raft 很不错，而且在持续交付。想拥有底层能力 —— 自托管、不为每个智能体付费、Fork、把它联邦化？那就是 Commonly。",
     "note": "本对比反映各产品的公开定位。Raft 是其各自所有者的商标；本页面与 Raft 无关联，也未获其背书。",
     "nav": {
       "primaryLabel": "主导航",
@@ -969,17 +969,17 @@
     "rows": {
       "source": {
         "dim": "源码",
-        "commonly": "开放——Apache-2.0，每一行都可读",
+        "commonly": "开放 —— Apache-2.0，每一行都可读",
         "raft": "闭源"
       },
       "selfHost": {
         "dim": "自托管",
-        "commonly": "支持——在你自己的基础设施上 docker compose up",
+        "commonly": "支持 —— 在你自己的基础设施上 docker compose up",
         "raft": "托管产品"
       },
       "perAgentCost": {
         "dim": "单个智能体费用",
-        "commonly": "$0——运行一个还是五十个智能体都一样",
+        "commonly": "$0 —— 运行 1 个还是 50 个智能体都一样",
         "raft": "按席位 + 按智能体计费"
       },
       "yourData": {
@@ -989,7 +989,7 @@
       },
       "federation": {
         "dim": "联邦化",
-        "commonly": "在路线图上——跨实例的智能体互通",
+        "commonly": "在路线图上 —— 跨实例的智能体互通",
         "raft": "单一托管实例"
       },
       "sharedWorkspace": {
@@ -1046,26 +1046,26 @@
     },
     "footer": {
       "title": "这是一个真实的 Commonly Pod。",
-      "text": "把你的团队和智能体带入同一份共享记忆。几分钟即可创建你自己的 — 开源且免费。"
+      "text": "把你的团队和智能体带进同一份共享记忆。几分钟就能创建你自己的 Pod —— 开源且免费。"
     }
   },
   "agentByo": {
     "eyebrow": "连接任意运行时",
     "title": "接入你自己的智能体",
-    "description": "通过 MCP 把 Claude Code、Cursor 或 Codex 接入你的 Commonly pod，约 2 分钟。",
+    "description": "用 MCP 把 Claude Code、Cursor 或 Codex 接入你的 Commonly Pod，约 2 分钟。",
     "form": {
       "nameLabel": "智能体名称",
       "nameHint": "小写字母、数字和连字符。这是你的智能体发帖时使用的身份。",
-      "podLabel": "安装到 pod",
-      "podHint": "你的智能体将安装在这里。之后你可以把它安装到更多 pod。",
-      "loadingPods": "正在加载 pod…"
+      "podLabel": "安装到 Pod",
+      "podHint": "你的智能体会安装在这里。之后可以把它安装到更多 Pod。",
+      "loadingPods": "正在加载 Pod…"
     },
     "actions": {
-      "install": "安装并生成 token",
-      "issuing": "正在签发 token…",
+      "install": "安装并生成令牌",
+      "issuing": "正在签发令牌…",
       "copy": "复制",
       "copied": "已复制！",
-      "goToPod": "前往你的 pod",
+      "goToPod": "前往你的 Pod",
       "installAnother": "再安装一个"
     },
     "footnote": {
@@ -1076,23 +1076,23 @@
       "fullWalkthrough": "完整教程"
     },
     "result": {
-      "heading": "已为以下智能体签发 token：",
+      "heading": "已为以下智能体签发令牌：",
       "copyOnceLead": "请立即复制",
       "copyOnceEmphasis": "一次",
-      "copyOnceRest": "Commonly 会在签发后对 token 做哈希处理——如果你弄丢了，回到这里重新轮换（用相同名称重新安装对身份是幂等的，token 会重新签发）。"
+      "copyOnceRest": "Commonly 会在签发后把令牌哈希存储 —— 如果弄丢了，回到这里重新轮换（用相同名称重新安装不会改变身份，令牌会重新签发）。"
     },
     "snippets": {
-      "runtimeToken": "运行时 token",
+      "runtimeToken": "运行时令牌",
       "claudeCode": "Claude Code",
       "cursor": "Cursor——添加到 ~/.cursor/mcp.json",
       "memory": "导入它的记忆（可选）"
     },
     "memory": {
       "doneLead": "✓ 记忆已导入——",
-      "doneRest": "带着对你项目的了解上线。它会显示在智能体资料页的长期记忆中。",
+      "doneRest": "带着对你项目的了解上线，并显示在该智能体资料页的长期记忆里。",
       "pasteLead": "粘贴你智能体本地的",
       "pasteOr": "或",
-      "pasteRest": "（或选择文件），它就会带着已经掌握的一切从这里开始。内容会追加到它的长期记忆，绝不覆盖。点击导入前不会发送任何内容。",
+      "pasteRest": "（或选择文件），它就会带着已掌握的一切从这里开始。内容只会追加到它的长期记忆，绝不覆盖。点击「导入」前不会发送任何内容。",
       "placeholder": "# 在此粘贴 MEMORY.md / CLAUDE.md 内容…",
       "fileAriaLabel": "选择记忆文件",
       "import": "导入记忆",
@@ -1100,8 +1100,8 @@
     },
     "errors": {
       "nameRequired": "智能体名称必须至少包含一个字母或数字。",
-      "podRequired": "请选择要安装到的 pod。",
-      "tokenEmpty": "安装成功，但 token 签发返回为空。请重试，或联系运维。",
+      "podRequired": "请选择要安装到的 Pod。",
+      "tokenEmpty": "安装成功，但令牌签发返回为空。请重试，或联系运维。",
       "installFailed": "安装失败。",
       "fileTooLarge": "该文件超过 256KB 的导入上限——请精简，或只粘贴相关部分。",
       "importFailed": "导入失败。"
@@ -1138,7 +1138,7 @@
       "remove": "移除",
       "removing": "移除中…",
       "removeAria": "将 {{agentName}} 从 {{podName}} 移除",
-      "removeConfirm": "将 {{agentName}} 从 \"{{podName}}\" 移除？它的记忆和身份会保留——只是离开这个 Pod。",
+      "removeConfirm": "将 {{agentName}} 从「{{podName}}」移除？它的记忆和身份会保留——只是离开这个 Pod。",
       "removeError": "无法将该智能体从此 Pod 移除。"
     },
     "skills": {
@@ -1154,7 +1154,7 @@
       "updatedClause": " · 更新于 {{time}}",
       "more": "还有 {{count}} 条",
       "entriesRemembered": "条已记住的条目",
-      "persistent": "持久记忆会随该智能体加入的每个 Pod 和运行时一同延续。",
+      "persistent": "持久记忆会跟随该智能体，延续到它加入的每个 Pod 和运行时。",
       "lastUpdated": "最后更新于 {{time}}。",
       "none": "尚无记忆记录。"
     },
@@ -1192,7 +1192,7 @@
       },
       "messages": {
         "label": "消息数（{{days}} 天）",
-        "hint": "所有消息，含 agent"
+        "hint": "所有消息，含智能体"
       },
       "total": {
         "label": "总用户数",
@@ -1211,11 +1211,11 @@
     },
     "funnel": {
       "title": "激活漏斗",
-      "summary": "在过去 {{days}} 天的 {{signups}} 个注册中：{{attachRate}}% 挂载了 agent · {{messageRate}}% 发送了消息 · {{d1Rate}}% 在第 1 天后回访 · {{d7Rate}}% 在第 7 天后回访。",
+      "summary": "在过去 {{days}} 天的 {{signups}} 个注册中：{{attachRate}}% 挂载了智能体 · {{messageRate}}% 发送了消息 · {{d1Rate}}% 在第 1 天后回访 · {{d7Rate}}% 在第 7 天后回访。",
       "table": {
         "cohort": "群组",
         "signups": "注册数",
-        "attachedAgent": "已挂载 agent",
+        "attachedAgent": "已挂载智能体",
         "sentMessage": "已发消息",
         "returnedD1": "D1 回访",
         "returnedD7": "D7 回访"
@@ -1318,7 +1318,7 @@
     "untitledProject": "未命名项目",
     "subtitle": {
       "empty": "还没有智能体 —— 雇佣第一个智能体开始使用。",
-      "summary": "{{agents}}，分布在 {{projects}}",
+      "summary": "{{agents}}，分布在 {{projects}} 中",
       "agentCount_one": "{{count}} 个智能体",
       "agentCount_other": "{{count}} 个智能体",
       "projectCount_one": "{{count}} 个项目",
@@ -1339,7 +1339,7 @@
     },
     "empty": {
       "title": "组建你的 AI 团队",
-      "text": "你雇佣的智能体会加入你的项目，共享项目记忆，并把成果交付给你。没有托管智能体？连接你自己的 —— Claude Code、Cursor 或 Codex —— 大约两分钟即可完成。",
+      "text": "你雇佣的智能体会加入你的项目，共享项目记忆，把成果交付给你。没有托管智能体？连接你自己的 —— Claude Code、Cursor 或 Codex —— 大约两分钟就能搞定。",
       "hireFirst": "+ 雇佣第一个智能体"
     },
     "tabs": {
@@ -1348,7 +1348,7 @@
       "category": "{{label}}（{{count}}）"
     },
     "card": {
-      "inProject": "在",
+      "inProject": "属于",
       "roleTitle": "角色：{{role}}",
       "profile": "资料页",
       "viewProfileAria": "查看 {{name}} 的资料页",

--- a/frontend/src/v2/agents/V2AgentProfile.tsx
+++ b/frontend/src/v2/agents/V2AgentProfile.tsx
@@ -19,6 +19,7 @@ import './v2-agent-profile.css';
 // axios instance injects the viewer's bearer token; a dedicated instance keeps
 // this public endpoint anonymous regardless of auth state.
 let _client: ReturnType<typeof axios.create> | null = null;
+const BRAND_ICON = 'c';
 const getClient = () => {
   if (!_client) _client = axios.create({ baseURL: getApiBaseUrl() });
   return _client;
@@ -82,8 +83,8 @@ const TopBar: React.FC<{ authed?: boolean }> = ({ authed }) => {
   return (
     <header className="v2-aprofile__bar">
       <Link className="v2-aprofile__brand" to={authed ? '/v2' : '/v2/landing'}>
-        <span className="v2-rail__brand-icon">c</span>
-        Commonly
+        <span className="v2-rail__brand-icon">{BRAND_ICON}</span>
+        {t('common.brandName')}
       </Link>
       <nav className="v2-aprofile__nav">
         {authed ? (

--- a/frontend/src/v2/agents/V2AgentProfile.tsx
+++ b/frontend/src/v2/agents/V2AgentProfile.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import axios from 'axios';
 import getApiBaseUrl from '../../utils/apiBaseUrl';
 import V2Avatar from '../components/V2Avatar';
@@ -76,30 +77,34 @@ const timeAgo = (iso?: string | null): string => {
 // Auth-aware chrome: anonymous visitors get the conversion nav (What is Commonly? /
 // Sign in / Sign up); a signed-in viewer gets a link back into the app instead —
 // the sign-up CTAs don't belong once you're logged in.
-const TopBar: React.FC<{ authed?: boolean }> = ({ authed }) => (
-  <header className="v2-aprofile__bar">
-    <Link className="v2-aprofile__brand" to={authed ? '/v2' : '/v2/landing'}>
-      <span className="v2-rail__brand-icon">c</span>
-      Commonly
-    </Link>
-    <nav className="v2-aprofile__nav">
-      {authed ? (
-        <Link className="v2-aprofile__btn v2-aprofile__btn--ghost" to="/v2/agents">Back to Commonly</Link>
-      ) : (
-        <>
-          <Link className="v2-aprofile__navlink" to="/v2/landing">What is Commonly?</Link>
-          <Link className="v2-aprofile__navlink" to="/v2/login">Sign in</Link>
-          <Link className="v2-aprofile__btn v2-aprofile__btn--primary" to="/v2/register">Sign up</Link>
-        </>
-      )}
-    </nav>
-  </header>
-);
+const TopBar: React.FC<{ authed?: boolean }> = ({ authed }) => {
+  const { t } = useTranslation();
+  return (
+    <header className="v2-aprofile__bar">
+      <Link className="v2-aprofile__brand" to={authed ? '/v2' : '/v2/landing'}>
+        <span className="v2-rail__brand-icon">c</span>
+        Commonly
+      </Link>
+      <nav className="v2-aprofile__nav">
+        {authed ? (
+          <Link className="v2-aprofile__btn v2-aprofile__btn--ghost" to="/v2/agents">{t('agentProfile.nav.backToCommonly')}</Link>
+        ) : (
+          <>
+            <Link className="v2-aprofile__navlink" to="/v2/landing">{t('agentProfile.nav.whatIsCommonly')}</Link>
+            <Link className="v2-aprofile__navlink" to="/v2/login">{t('agentProfile.nav.signIn')}</Link>
+            <Link className="v2-aprofile__btn v2-aprofile__btn--primary" to="/v2/register">{t('agentProfile.nav.signUp')}</Link>
+          </>
+        )}
+      </nav>
+    </header>
+  );
+};
 
 const isAuthed = (): boolean =>
   typeof window !== 'undefined' && !!window.localStorage.getItem('token');
 
 const V2AgentProfile: React.FC = () => {
+  const { t } = useTranslation();
   const { agentName, instanceId } = useParams<{ agentName: string; instanceId?: string }>();
   const [data, setData] = useState<AgentProfile | null>(null);
   const [state, setState] = useState<'loading' | 'ready' | 'error'>('loading');
@@ -145,7 +150,7 @@ const V2AgentProfile: React.FC = () => {
     const token = typeof window !== 'undefined' ? window.localStorage.getItem('token') : null;
     if (!token || !agentName) return;
     // eslint-disable-next-line no-alert
-    if (!window.confirm(`Remove ${agentName} from "${podName}"? Its memory and identity are kept — it just leaves this pod.`)) return;
+    if (!window.confirm(t('agentProfile.pods.removeConfirm', { agentName, podName }))) return;
     setRemoving(podId);
     try {
       await getClient().delete(
@@ -155,11 +160,11 @@ const V2AgentProfile: React.FC = () => {
       await Promise.all([fetchProfile(), fetchMemoryIndex()]);
     } catch {
       // eslint-disable-next-line no-alert
-      window.alert('Could not remove the agent from that pod.');
+      window.alert(t('agentProfile.pods.removeError'));
     } finally {
       setRemoving(null);
     }
-  }, [agentName, fetchProfile, fetchMemoryIndex]);
+  }, [t, agentName, fetchProfile, fetchMemoryIndex]);
 
   useEffect(() => { fetchProfile(); fetchMemoryIndex(); }, [fetchProfile, fetchMemoryIndex]);
 
@@ -167,7 +172,7 @@ const V2AgentProfile: React.FC = () => {
     return (
       <div className="v2-root v2-aprofile">
         <TopBar authed={isAuthed()} />
-        <div className="v2-aprofile__center"><div className="v2-aprofile__muted">Loading…</div></div>
+        <div className="v2-aprofile__center"><div className="v2-aprofile__muted">{t('agentProfile.loading')}</div></div>
       </div>
     );
   }
@@ -176,11 +181,11 @@ const V2AgentProfile: React.FC = () => {
       <div className="v2-root v2-aprofile">
         <TopBar authed={isAuthed()} />
         <div className="v2-aprofile__center">
-          <h1 className="v2-aprofile__empty-title">Agent not found</h1>
-          <p className="v2-aprofile__muted">This agent may not exist. Explore what Commonly is, or start your own team.</p>
+          <h1 className="v2-aprofile__empty-title">{t('agentProfile.notFound.title')}</h1>
+          <p className="v2-aprofile__muted">{t('agentProfile.notFound.body')}</p>
           <div className="v2-aprofile__cta-row">
-            <Link className="v2-aprofile__btn v2-aprofile__btn--primary" to="/v2/register">Start your own team</Link>
-            <Link className="v2-aprofile__btn v2-aprofile__btn--ghost" to="/v2/landing">What is Commonly?</Link>
+            <Link className="v2-aprofile__btn v2-aprofile__btn--primary" to="/v2/register">{t('agentProfile.actions.startYourOwnTeam')}</Link>
+            <Link className="v2-aprofile__btn v2-aprofile__btn--ghost" to="/v2/landing">{t('agentProfile.nav.whatIsCommonly')}</Link>
           </div>
         </div>
       </div>
@@ -203,12 +208,12 @@ const V2AgentProfile: React.FC = () => {
             <div className="v2-aprofile__name-row">
               <h1 className="v2-aprofile__name">{agent.displayName}</h1>
               {runtimeLabel && <span className="v2-aprofile__runtime">{runtimeLabel}</span>}
-              {agent.officialAgent && <span className="v2-aprofile__badge">Official</span>}
+              {agent.officialAgent && <span className="v2-aprofile__badge">{t('agentProfile.hero.official')}</span>}
             </div>
             {agent.description && <p className="v2-aprofile__desc">{agent.description}</p>}
             <div className="v2-aprofile__meta">
-              <span>Active in {pods.count} pod{pods.count === 1 ? '' : 's'}</span>
-              {memory.has && <span>· {memory.entryCount} memories</span>}
+              <span>{t('agentProfile.hero.activeInPods', { count: pods.count })}</span>
+              {memory.has && <span>· {t('agentProfile.hero.memories', { count: memory.entryCount })}</span>}
               {agent.personality?.tone && <span>· {agent.personality.tone}</span>}
             </div>
             {(agent.capabilities.length > 0 || (agent.personality?.interests?.length || 0) > 0) && (
@@ -218,7 +223,7 @@ const V2AgentProfile: React.FC = () => {
               </div>
             )}
           </div>
-          <Link className="v2-aprofile__btn v2-aprofile__btn--primary" to={authed ? '/v2/agents' : '/v2/register'}>Talk to {firstName}</Link>
+          <Link className="v2-aprofile__btn v2-aprofile__btn--primary" to={authed ? '/v2/agents' : '/v2/register'}>{t('agentProfile.hero.talkTo', { name: firstName })}</Link>
         </section>
 
         <div className="v2-aprofile__grid">
@@ -233,24 +238,24 @@ const V2AgentProfile: React.FC = () => {
             return (
               <section className="v2-aprofile__card">
                 <h2 className="v2-aprofile__card-title">
-                  {ownerPods ? 'Pods' : 'Public pods'} <span className="v2-aprofile__count">{ownerPods ? pods.count : list.length}</span>
-                  {ownerPods && pods.count > list.length && <span className="v2-aprofile__owner-tag">all pods</span>}
+                  {ownerPods ? t('agentProfile.pods.title') : t('agentProfile.pods.publicTitle')} <span className="v2-aprofile__count">{ownerPods ? pods.count : list.length}</span>
+                  {ownerPods && pods.count > list.length && <span className="v2-aprofile__owner-tag">{t('agentProfile.pods.allPods')}</span>}
                 </h2>
                 <ul className="v2-aprofile__list v2-aprofile__scroll">
                   {list.map((p) => (
                     <li key={p.id} className="v2-aprofile__pod">
                       <Link className="v2-aprofile__pod-name" to={`/v2/pods/${p.id}`}>{p.name}</Link>
                       {p.lastMessage?.snippet && <span className="v2-aprofile__pod-msg">“{p.lastMessage.snippet}”</span>}
-                      {p.lastActive && <span className="v2-aprofile__pod-when">active {timeAgo(p.lastActive)}</span>}
+                      {p.lastActive && <span className="v2-aprofile__pod-when">{t('agentProfile.pods.activeAgo', { time: timeAgo(p.lastActive) })}</span>}
                       {ownerPods && (
                         <button
                           type="button"
                           className="v2-aprofile__pod-remove"
                           onClick={() => handleRemoveFromPod(p.id, p.name)}
                           disabled={removing === p.id}
-                          aria-label={`Remove ${agentName} from ${p.name}`}
+                          aria-label={t('agentProfile.pods.removeAria', { agentName, podName: p.name })}
                         >
-                          {removing === p.id ? 'Removing…' : 'Remove'}
+                          {removing === p.id ? t('agentProfile.pods.removing') : t('agentProfile.pods.remove')}
                         </button>
                       )}
                     </li>
@@ -265,7 +270,7 @@ const V2AgentProfile: React.FC = () => {
               carry the "what it does" story otherwise. */}
           {skills.length > 0 && (
             <section className="v2-aprofile__card">
-              <h2 className="v2-aprofile__card-title">Installed skills <span className="v2-aprofile__count">{skills.length}</span></h2>
+              <h2 className="v2-aprofile__card-title">{t('agentProfile.skills.title')} <span className="v2-aprofile__count">{skills.length}</span></h2>
               <ul className="v2-aprofile__list">
                 {skills.slice(0, 12).map((s) => (
                   <li key={s.name} className="v2-aprofile__skill">
@@ -281,14 +286,27 @@ const V2AgentProfile: React.FC = () => {
               index (section headers + snippets), fetched with their token. */}
           <section className={`v2-aprofile__card${memIndex && memIndex.sections.length > 0 ? ' v2-aprofile__card--wide' : ''}`}>
             <h2 className="v2-aprofile__card-title">
-              Memory layer
-              {memIndex && <span className="v2-aprofile__owner-tag">{memIndex.viewerRole} view · private</span>}
+              {t('agentProfile.memory.title')}
+              {memIndex && (
+                <span className="v2-aprofile__owner-tag">
+                  {t('agentProfile.memory.viewTag', {
+                    role: memIndex.viewerRole === 'admin'
+                      ? t('agentProfile.memory.roleAdmin')
+                      : t('agentProfile.memory.roleOwner'),
+                  })}
+                </span>
+              )}
             </h2>
             {memIndex && memIndex.sections.length > 0 ? (
               <div className="v2-aprofile__memidx">
                 <p className="v2-aprofile__muted">
-                  {memIndex.totalEntries} notes across {memIndex.sections.length} section{memIndex.sections.length === 1 ? '' : 's'}
-                  {memIndex.updatedAt ? ` · updated ${timeAgo(memIndex.updatedAt)}` : ''}. Visible to you; hidden from the public profile.
+                  {t('agentProfile.memory.indexSummary', {
+                    notes: memIndex.totalEntries,
+                    count: memIndex.sections.length,
+                    updated: memIndex.updatedAt
+                      ? t('agentProfile.memory.updatedClause', { time: timeAgo(memIndex.updatedAt) })
+                      : '',
+                  })}
                 </p>
                 <div className="v2-aprofile__memcols v2-aprofile__scroll">
                   {memIndex.sections.map((sec) => (
@@ -302,7 +320,7 @@ const V2AgentProfile: React.FC = () => {
                           </li>
                         ))}
                       </ul>
-                      {sec.notes.length > 5 && <span className="v2-aprofile__more">+{sec.notes.length - 5} more</span>}
+                      {sec.notes.length > 5 && <span className="v2-aprofile__more">{t('agentProfile.memory.more', { count: sec.notes.length - 5 })}</span>}
                     </div>
                   ))}
                 </div>
@@ -311,28 +329,28 @@ const V2AgentProfile: React.FC = () => {
               <div className="v2-aprofile__memory">
                 <div className="v2-aprofile__stat">
                   <span className="v2-aprofile__stat-num">{memory.entryCount}</span>
-                  <span className="v2-aprofile__stat-label">entries remembered</span>
+                  <span className="v2-aprofile__stat-label">{t('agentProfile.memory.entriesRemembered')}</span>
                 </div>
                 <p className="v2-aprofile__muted">
-                  Persistent memory carried across every pod and runtime this agent joins.
-                  {memory.updatedAt && ` Last updated ${timeAgo(memory.updatedAt)}.`}
+                  {t('agentProfile.memory.persistent')}
+                  {memory.updatedAt && ` ${t('agentProfile.memory.lastUpdated', { time: timeAgo(memory.updatedAt) })}`}
                 </p>
               </div>
             ) : (
-              <p className="v2-aprofile__muted">No memory recorded yet.</p>
+              <p className="v2-aprofile__muted">{t('agentProfile.memory.none')}</p>
             )}
           </section>
 
           {/* Recent activity */}
           {activity.length > 0 && (
             <section className="v2-aprofile__card">
-              <h2 className="v2-aprofile__card-title">Recent activity</h2>
+              <h2 className="v2-aprofile__card-title">{t('agentProfile.activity.title')}</h2>
               <ul className="v2-aprofile__list">
                 {activity.map((a, i) => (
                   <li key={i} className="v2-aprofile__run">
                     <span className={`v2-aprofile__run-dot v2-aprofile__run-dot--${a.errorKind ? 'err' : a.status}`} />
                     <span className="v2-aprofile__run-label">{a.trigger || a.status}</span>
-                    <span className="v2-aprofile__muted">{a.turns} turn{a.turns === 1 ? '' : 's'} · {timeAgo(a.startedAt)}</span>
+                    <span className="v2-aprofile__muted">{t('agentProfile.activity.turnsAgo', { count: a.turns, time: timeAgo(a.startedAt) })}</span>
                   </li>
                 ))}
               </ul>
@@ -342,8 +360,8 @@ const V2AgentProfile: React.FC = () => {
 
         {!authed && (
           <div className="v2-aprofile__footer-cta">
-            <span>Every agent on Commonly keeps one identity and memory — across any runtime.</span>
-            <Link className="v2-aprofile__btn v2-aprofile__btn--primary" to="/v2/register">Start your own team</Link>
+            <span>{t('agentProfile.footer.tagline')}</span>
+            <Link className="v2-aprofile__btn v2-aprofile__btn--primary" to="/v2/register">{t('agentProfile.actions.startYourOwnTeam')}</Link>
           </div>
         )}
       </main>

--- a/frontend/src/v2/components/V2AdminAnalytics.tsx
+++ b/frontend/src/v2/components/V2AdminAnalytics.tsx
@@ -5,6 +5,7 @@
 // (see V2App.tsx). Charts are plain inline SVG — no chart library.
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { useV2Api } from '../hooks/useV2Api';
 
 interface UsageDaily {
@@ -55,7 +56,8 @@ const errMessage = (err: unknown, fallback: string): string => {
 
 // Compact bar chart. Bars scale to the series max; a max of 0 renders an
 // empty (but stable-height) chart, so zero-data instances degrade gracefully.
-const Bars: React.FC<{ data: UsageDaily[]; field: 'signups' | 'messages'; label: string }> = ({ data, field, label }) => {
+const Bars: React.FC<{ data: UsageDaily[]; field: 'signups' | 'messages'; label: string; unit: string }> = ({ data, field, label, unit }) => {
+  const { t } = useTranslation();
   const W = 600;
   const H = 120;
   const max = Math.max(1, ...data.map((d) => d[field]));
@@ -66,7 +68,7 @@ const Bars: React.FC<{ data: UsageDaily[]; field: 'signups' | 'messages'; label:
       viewBox={`0 0 ${W} ${H}`}
       preserveAspectRatio="none"
       role="img"
-      aria-label={`${label} per day`}
+      aria-label={t('adminAnalytics.charts.perDayAria', { label })}
     >
       {data.map((d, i) => {
         const h = Math.round((d[field] / max) * (H - 4));
@@ -80,7 +82,7 @@ const Bars: React.FC<{ data: UsageDaily[]; field: 'signups' | 'messages'; label:
             rx={1.5}
             className="v2-admin-analytics__bar"
           >
-            <title>{`${d.date}: ${d[field]} ${label.toLowerCase()}`}</title>
+            <title>{t('adminAnalytics.charts.barTitle', { date: d.date, value: d[field], unit })}</title>
           </rect>
         );
       })}
@@ -89,6 +91,7 @@ const Bars: React.FC<{ data: UsageDaily[]; field: 'signups' | 'messages'; label:
 };
 
 const V2AdminAnalytics: React.FC = () => {
+  const { t } = useTranslation();
   const api = useV2Api();
   const [days, setDays] = useState(30);
   const [usage, setUsage] = useState<UsageResponse | null>(null);
@@ -111,7 +114,7 @@ const V2AdminAnalytics: React.FC = () => {
           setFunnel(f);
         }
       } catch (err) {
-        if (!cancelled) setError(errMessage(err, 'Failed to load analytics.'));
+        if (!cancelled) setError(errMessage(err, t('adminAnalytics.errors.loadFailed')));
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -120,11 +123,11 @@ const V2AdminAnalytics: React.FC = () => {
   }, [api, days]);
 
   const cards = usage ? [
-    { key: 'dau', label: 'Active today', value: usage.totals.dau, hint: 'humans active in the last 24h' },
-    { key: 'wau', label: 'Active this week', value: usage.totals.wau, hint: 'humans active in the last 7 days' },
-    { key: 'signups', label: `Signups (${usage.days}d)`, value: usage.totals.signups, hint: 'new human accounts in range' },
-    { key: 'messages', label: `Messages (${usage.days}d)`, value: usage.totals.messages, hint: 'all messages, agents included' },
-    { key: 'total', label: 'Total users', value: usage.totals.totalUsers, hint: 'human accounts, all time' },
+    { key: 'dau', label: t('adminAnalytics.cards.dau.label'), value: usage.totals.dau, hint: t('adminAnalytics.cards.dau.hint') },
+    { key: 'wau', label: t('adminAnalytics.cards.wau.label'), value: usage.totals.wau, hint: t('adminAnalytics.cards.wau.hint') },
+    { key: 'signups', label: t('adminAnalytics.cards.signups.label', { days: usage.days }), value: usage.totals.signups, hint: t('adminAnalytics.cards.signups.hint') },
+    { key: 'messages', label: t('adminAnalytics.cards.messages.label', { days: usage.days }), value: usage.totals.messages, hint: t('adminAnalytics.cards.messages.hint') },
+    { key: 'total', label: t('adminAnalytics.cards.total.label'), value: usage.totals.totalUsers, hint: t('adminAnalytics.cards.total.hint') },
   ] : [];
 
   // Newest cohorts first; the table is the drill-down under the charts.
@@ -134,13 +137,13 @@ const V2AdminAnalytics: React.FC = () => {
     <div className="v2-admin-analytics">
       <div className="v2-admin-users__section-head">
         <div>
-          <h2 className="v2-admin-users__section-title">Usage</h2>
+          <h2 className="v2-admin-users__section-title">{t('adminAnalytics.title')}</h2>
           <p className="v2-admin-users__section-sub">
-            First-party numbers from this instance&rsquo;s own database — nothing is sent to third parties.
+            {t('adminAnalytics.subtitle')}
           </p>
         </div>
         <div className="v2-admin-analytics__head-actions">
-          <div className="v2-admin-users__tabs" role="tablist" aria-label="Time range">
+          <div className="v2-admin-users__tabs" role="tablist" aria-label={t('adminAnalytics.timeRangeAria')}>
             {RANGES.map((r) => (
               <button
                 key={r}
@@ -150,18 +153,18 @@ const V2AdminAnalytics: React.FC = () => {
                 className={`v2-admin-users__tab${days === r ? ' v2-admin-users__tab--active' : ''}`}
                 onClick={() => setDays(r)}
               >
-                {r}d
+                {t('adminAnalytics.rangeDays', { days: r })}
               </button>
             ))}
           </div>
-          <Link to="/v2/admin/users" className="v2-admin-analytics__crosslink">User admin →</Link>
+          <Link to="/v2/admin/users" className="v2-admin-analytics__crosslink">{t('adminAnalytics.userAdminLink')}</Link>
         </div>
       </div>
 
       {error && <div className="v2-admin-users__error" role="alert">{error}</div>}
 
       {loading ? (
-        <div className="v2-admin-users__loading"><span className="v2-spinner" /> Loading analytics…</div>
+        <div className="v2-admin-users__loading"><span className="v2-spinner" /> {t('adminAnalytics.loading')}</div>
       ) : (
         <>
           <div className="v2-admin-analytics__cards">
@@ -176,12 +179,12 @@ const V2AdminAnalytics: React.FC = () => {
           {usage && (
             <div className="v2-admin-analytics__charts">
               <div className="v2-admin-analytics__chart-card">
-                <div className="v2-admin-analytics__chart-title">Signups / day</div>
-                <Bars data={usage.daily} field="signups" label="Signups" />
+                <div className="v2-admin-analytics__chart-title">{t('adminAnalytics.charts.signupsPerDay')}</div>
+                <Bars data={usage.daily} field="signups" label={t('adminAnalytics.charts.signupsLabel')} unit={t('adminAnalytics.charts.signupsUnit')} />
               </div>
               <div className="v2-admin-analytics__chart-card">
-                <div className="v2-admin-analytics__chart-title">Messages / day</div>
-                <Bars data={usage.daily} field="messages" label="Messages" />
+                <div className="v2-admin-analytics__chart-title">{t('adminAnalytics.charts.messagesPerDay')}</div>
+                <Bars data={usage.daily} field="messages" label={t('adminAnalytics.charts.messagesLabel')} unit={t('adminAnalytics.charts.messagesUnit')} />
               </div>
             </div>
           )}
@@ -189,23 +192,28 @@ const V2AdminAnalytics: React.FC = () => {
           {funnel && (
             <section className="v2-admin-users__section">
               <div>
-                <h2 className="v2-admin-users__section-title">Activation funnel</h2>
+                <h2 className="v2-admin-users__section-title">{t('adminAnalytics.funnel.title')}</h2>
                 <p className="v2-admin-users__section-sub">
-                  Of {funnel.totals.signups} signups in the last {funnel.days} days:{' '}
-                  {funnel.totals.attachRatePct}% attached an agent · {funnel.totals.messageRatePct}% sent a message ·{' '}
-                  {funnel.totals.d1ReturnPct}% returned after day 1 · {funnel.totals.d7ReturnPct}% after day 7.
+                  {t('adminAnalytics.funnel.summary', {
+                    signups: funnel.totals.signups,
+                    days: funnel.days,
+                    attachRate: funnel.totals.attachRatePct,
+                    messageRate: funnel.totals.messageRatePct,
+                    d1Rate: funnel.totals.d1ReturnPct,
+                    d7Rate: funnel.totals.d7ReturnPct,
+                  })}
                 </p>
               </div>
               <div className="v2-admin-users__table-wrap">
                 <table className="v2-admin-users__table">
                   <thead>
                     <tr>
-                      <th>Cohort</th>
-                      <th>Signups</th>
-                      <th>Attached agent</th>
-                      <th>Sent message</th>
-                      <th>Returned D1</th>
-                      <th>Returned D7</th>
+                      <th>{t('adminAnalytics.funnel.table.cohort')}</th>
+                      <th>{t('adminAnalytics.funnel.table.signups')}</th>
+                      <th>{t('adminAnalytics.funnel.table.attachedAgent')}</th>
+                      <th>{t('adminAnalytics.funnel.table.sentMessage')}</th>
+                      <th>{t('adminAnalytics.funnel.table.returnedD1')}</th>
+                      <th>{t('adminAnalytics.funnel.table.returnedD7')}</th>
                     </tr>
                   </thead>
                   <tbody>

--- a/frontend/src/v2/components/V2AdminUsers.tsx
+++ b/frontend/src/v2/components/V2AdminUsers.tsx
@@ -14,6 +14,7 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { useV2Api } from '../hooks/useV2Api';
 
 interface AdminRef {
@@ -79,12 +80,7 @@ interface InvitationMutationResponse {
   invitation?: InvitationRow;
 }
 
-const STATUS_FILTERS: Array<{ value: 'all' | WaitlistStatus; label: string }> = [
-  { value: 'all', label: 'All' },
-  { value: 'pending', label: 'Pending' },
-  { value: 'invited', label: 'Invited' },
-  { value: 'closed', label: 'Closed' },
-];
+const STATUS_FILTER_VALUES: Array<'all' | WaitlistStatus> = ['all', 'pending', 'invited', 'closed'];
 
 const formatDate = (value: string | null): string => {
   if (!value) return '—';
@@ -125,17 +121,26 @@ type RegisteredUser = {
 // failure-isolated fetch so moderation keeps working if PostgreSQL is down.
 type LifecycleStats = Record<string, { pods: number; messages: number }>;
 
-const lifecycleLabel = (u: RegisteredUser, stats: LifecycleStats | null): string => {
+const lifecycleLabel = (
+  u: RegisteredUser,
+  stats: LifecycleStats | null,
+  t: (key: string, opts?: Record<string, unknown>) => string,
+): string => {
   const joined = u.createdAt
-    ? `joined ${Math.max(0, Math.floor((Date.now() - new Date(u.createdAt).getTime()) / (24 * 60 * 60 * 1000)))}d`
-    : 'joined —';
+    ? t('adminUsers.lifecycle.joinedDays', {
+        count: Math.max(0, Math.floor((Date.now() - new Date(u.createdAt).getTime()) / (24 * 60 * 60 * 1000))),
+      })
+    : t('adminUsers.lifecycle.joinedUnknown');
   const s = stats?.[u.id];
   if (!s) return joined;
-  return `${joined} · ${s.pods} pod${s.pods === 1 ? '' : 's'} · ${s.messages} msg${s.messages === 1 ? '' : 's'}`;
+  const podsLabel = t('adminUsers.lifecycle.pods', { count: s.pods });
+  const messagesLabel = t('adminUsers.lifecycle.messages', { count: s.messages });
+  return `${joined} · ${podsLabel} · ${messagesLabel}`;
 };
 
 const V2AdminUsers: React.FC = () => {
   const api = useV2Api();
+  const { t } = useTranslation();
 
   // ---- Registered users state (moderation: ban / remove) ----
   const [users, setUsers] = useState<RegisteredUser[]>([]);
@@ -167,11 +172,11 @@ const V2AdminUsers: React.FC = () => {
       const data = await api.get<{ users?: RegisteredUser[] }>(`/api/admin/users?${params.toString()}`);
       setUsers(data.users || []);
     } catch (err: unknown) {
-      setUsersError(errMessage(err, 'Failed to load users.'));
+      setUsersError(errMessage(err, t('adminUsers.errors.loadUsers')));
     } finally {
       setUsersLoading(false);
     }
-  }, [api]);
+  }, [api, t]);
 
   useEffect(() => {
     const handle = setTimeout(() => { fetchUsers(userSearch); }, 250);
@@ -181,7 +186,7 @@ const V2AdminUsers: React.FC = () => {
   const handleBanToggle = async (u: RegisteredUser) => {
     const banning = !u.banned;
     // eslint-disable-next-line no-alert
-    const reason = banning ? window.prompt(`Ban ${u.username}? Optional reason:`, '') : null;
+    const reason = banning ? window.prompt(t('adminUsers.prompts.ban', { username: u.username }), '') : null;
     if (banning && reason === null) return; // prompt cancelled
     setUserBusy(u.id);
     try {
@@ -191,7 +196,7 @@ const V2AdminUsers: React.FC = () => {
       });
       await fetchUsers(userSearch);
     } catch (err: unknown) {
-      setUsersError(errMessage(err, 'Failed to update ban state.'));
+      setUsersError(errMessage(err, t('adminUsers.errors.updateBan')));
     } finally {
       setUserBusy(null);
     }
@@ -199,13 +204,13 @@ const V2AdminUsers: React.FC = () => {
 
   const handleDeleteUser = async (u: RegisteredUser) => {
     // eslint-disable-next-line no-alert
-    if (!window.confirm(`Permanently delete ${u.username} (${u.email})? This cannot be undone.`)) return;
+    if (!window.confirm(t('adminUsers.prompts.deleteUser', { username: u.username, email: u.email }))) return;
     setUserBusy(u.id);
     try {
       await api.del(`/api/admin/users/${encodeURIComponent(u.id)}`);
       await fetchUsers(userSearch);
     } catch (err: unknown) {
-      setUsersError(errMessage(err, 'Failed to delete user.'));
+      setUsersError(errMessage(err, t('adminUsers.errors.deleteUser')));
     } finally {
       setUserBusy(null);
     }
@@ -242,12 +247,12 @@ const V2AdminUsers: React.FC = () => {
       const data = await api.get<WaitlistResponse>(`/api/admin/users/waitlist?${params.toString()}`);
       setWaitlist(Array.isArray(data?.requests) ? data.requests : []);
     } catch (err) {
-      setWaitlistError(errMessage(err, 'Failed to load waitlist.'));
+      setWaitlistError(errMessage(err, t('adminUsers.errors.loadWaitlist')));
       setWaitlist([]);
     } finally {
       setWaitlistLoading(false);
     }
-  }, [api, search, statusFilter]);
+  }, [api, search, statusFilter, t]);
 
   const loadInvites = useCallback(async () => {
     setInvitesLoading(true);
@@ -256,12 +261,12 @@ const V2AdminUsers: React.FC = () => {
       const data = await api.get<InvitationsResponse>('/api/admin/users/invitations?limit=100');
       setInvites(Array.isArray(data?.invitations) ? data.invitations : []);
     } catch (err) {
-      setInvitesError(errMessage(err, 'Failed to load invitation codes.'));
+      setInvitesError(errMessage(err, t('adminUsers.errors.loadInvites')));
       setInvites([]);
     } finally {
       setInvitesLoading(false);
     }
-  }, [api]);
+  }, [api, t]);
 
   // Debounce waitlist reloads on search/filter changes so each keystroke
   // doesn't fire a request.
@@ -300,10 +305,10 @@ const V2AdminUsers: React.FC = () => {
       if (errStatus(err) === 503) {
         setRowNotice((prev) => ({
           ...prev,
-          [row.id]: 'SMTP not configured — generate a code below and share it manually instead.',
+          [row.id]: t('adminUsers.notices.smtpNotConfigured'),
         }));
       } else {
-        setRowNotice((prev) => ({ ...prev, [row.id]: errMessage(err, 'Failed to send invitation.') }));
+        setRowNotice((prev) => ({ ...prev, [row.id]: errMessage(err, t('adminUsers.errors.sendInvitation')) }));
       }
     } finally {
       setRowBusy(null);
@@ -324,7 +329,7 @@ const V2AdminUsers: React.FC = () => {
         await loadWaitlist();
       }
     } catch (err) {
-      setRowNotice((prev) => ({ ...prev, [row.id]: errMessage(err, 'Failed to reopen request.') }));
+      setRowNotice((prev) => ({ ...prev, [row.id]: errMessage(err, t('adminUsers.errors.reopenRequest')) }));
     } finally {
       setRowBusy(null);
     }
@@ -340,7 +345,7 @@ const V2AdminUsers: React.FC = () => {
       setNewCode(code);
       await loadInvites();
     } catch (err) {
-      setGenerateError(errMessage(err, 'Failed to generate invitation code.'));
+      setGenerateError(errMessage(err, t('adminUsers.errors.generateCode')));
     } finally {
       setGenerating(false);
     }
@@ -348,7 +353,7 @@ const V2AdminUsers: React.FC = () => {
 
   const revoke = async (invite: InvitationRow) => {
     // eslint-disable-next-line no-alert
-    if (typeof window !== 'undefined' && !window.confirm(`Revoke invitation code ${invite.code}? This cannot be undone.`)) {
+    if (typeof window !== 'undefined' && !window.confirm(t('adminUsers.prompts.revokeCode', { code: invite.code }))) {
       return;
     }
     setInviteBusy(invite.id);
@@ -363,7 +368,7 @@ const V2AdminUsers: React.FC = () => {
         await loadInvites();
       }
     } catch (err) {
-      setInvitesError(errMessage(err, 'Failed to revoke invitation code.'));
+      setInvitesError(errMessage(err, t('adminUsers.errors.revokeCode')));
     } finally {
       setInviteBusy(null);
     }
@@ -385,10 +390,20 @@ const V2AdminUsers: React.FC = () => {
     return 'v2-admin-users__badge v2-admin-users__badge--warn';
   };
 
+  const waitlistStatusLabel = (status: string): string => {
+    if (status === 'pending' || status === 'invited' || status === 'closed') {
+      return t(`adminUsers.waitlist.status.${status}`);
+    }
+    return status;
+  };
+
   const waitlistEmpty = !waitlistLoading && !waitlistError && waitlist.length === 0;
   const invitesEmpty = !invitesLoading && !invitesError && invites.length === 0;
 
-  const filterTabs = useMemo(() => STATUS_FILTERS, []);
+  const filterTabs = useMemo(
+    () => STATUS_FILTER_VALUES.map((value) => ({ value, label: t(`adminUsers.statusFilters.${value}`) })),
+    [t],
+  );
 
   return (
     <div className="v2-admin-users">
@@ -396,36 +411,36 @@ const V2AdminUsers: React.FC = () => {
       <section className="v2-admin-users__section">
         <div className="v2-admin-users__section-head">
           <div>
-            <h2 className="v2-admin-users__section-title">Registered users</h2>
+            <h2 className="v2-admin-users__section-title">{t('adminUsers.registered.title')}</h2>
             <p className="v2-admin-users__section-sub">
-              Everyone with an account on this instance. Ban stops logins immediately; delete is permanent.{' '}
-              <Link to="/v2/admin/analytics" className="v2-admin-analytics__crosslink">Usage analytics →</Link>
+              {t('adminUsers.registered.subtitle')}{' '}
+              <Link to="/v2/admin/analytics" className="v2-admin-analytics__crosslink">{t('adminUsers.registered.analyticsLink')}</Link>
             </p>
           </div>
           <input
             className="v2-admin-users__search"
             type="search"
-            placeholder="Search username or email…"
+            placeholder={t('adminUsers.registered.searchPlaceholder')}
             value={userSearch}
             onChange={(e) => setUserSearch(e.target.value)}
           />
         </div>
         {usersError && <div className="v2-admin-users__error" role="alert">{usersError}</div>}
         {usersLoading ? (
-          <div className="v2-admin-users__empty">Loading users…</div>
+          <div className="v2-admin-users__empty">{t('adminUsers.registered.loading')}</div>
         ) : users.length === 0 ? (
-          <div className="v2-admin-users__empty">No users match.</div>
+          <div className="v2-admin-users__empty">{t('adminUsers.registered.noMatch')}</div>
         ) : (
           <div className="v2-admin-users__table-wrap">
             <table className="v2-admin-users__table">
               <thead>
                 <tr>
-                  <th>Username</th>
-                  <th>Email</th>
-                  <th>Role</th>
-                  <th>Status</th>
-                  <th>Lifecycle</th>
-                  <th aria-label="Actions" />
+                  <th>{t('adminUsers.registered.columns.username')}</th>
+                  <th>{t('adminUsers.registered.columns.email')}</th>
+                  <th>{t('adminUsers.registered.columns.role')}</th>
+                  <th>{t('adminUsers.registered.columns.status')}</th>
+                  <th>{t('adminUsers.registered.columns.lifecycle')}</th>
+                  <th aria-label={t('adminUsers.columns.actions')} />
                 </tr>
               </thead>
               <tbody>
@@ -438,30 +453,30 @@ const V2AdminUsers: React.FC = () => {
                       <td>{u.role}</td>
                       <td>
                         {u.banned
-                          ? <span className="v2-admin-users__badge v2-admin-users__badge--banned" title={u.banReason || undefined}>banned</span>
-                          : (u.verified ? 'active' : 'unverified')}
+                          ? <span className="v2-admin-users__badge v2-admin-users__badge--banned" title={u.banReason || undefined}>{t('adminUsers.registered.userStatus.banned')}</span>
+                          : (u.verified ? t('adminUsers.registered.userStatus.active') : t('adminUsers.registered.userStatus.unverified'))}
                       </td>
                       <td className="v2-admin-users__cell-muted" title={u.createdAt ? new Date(u.createdAt).toLocaleDateString() : undefined}>
-                        {lifecycleLabel(u, lifecycle)}
+                        {lifecycleLabel(u, lifecycle, t)}
                       </td>
                       <td className="v2-admin-users__row-actions">
                         <button
                           type="button"
                           className="v2-admin-users__btn"
                           disabled={busy || u.role === 'admin'}
-                          title={u.role === 'admin' ? 'Demote the admin role first' : undefined}
+                          title={u.role === 'admin' ? t('adminUsers.registered.demoteAdminFirst') : undefined}
                           onClick={() => handleBanToggle(u)}
                         >
-                          {busy ? '…' : (u.banned ? 'Unban' : 'Ban')}
+                          {busy ? '…' : (u.banned ? t('adminUsers.actions.unban') : t('adminUsers.actions.ban'))}
                         </button>
                         <button
                           type="button"
                           className="v2-admin-users__btn v2-admin-users__btn--danger"
                           disabled={busy || u.role === 'admin'}
-                          title={u.role === 'admin' ? 'Demote the admin role first' : undefined}
+                          title={u.role === 'admin' ? t('adminUsers.registered.demoteAdminFirst') : undefined}
                           onClick={() => handleDeleteUser(u)}
                         >
-                          Delete
+                          {t('adminUsers.actions.delete')}
                         </button>
                       </td>
                     </tr>
@@ -477,9 +492,9 @@ const V2AdminUsers: React.FC = () => {
       <section className="v2-admin-users__section">
         <div className="v2-admin-users__section-head">
           <div>
-            <h2 className="v2-admin-users__section-title">Waitlist</h2>
+            <h2 className="v2-admin-users__section-title">{t('adminUsers.waitlist.title')}</h2>
             <p className="v2-admin-users__section-sub">
-              Review access requests and send invitation codes.
+              {t('adminUsers.waitlist.subtitle')}
             </p>
           </div>
           <button
@@ -488,7 +503,7 @@ const V2AdminUsers: React.FC = () => {
             onClick={() => loadWaitlist()}
             disabled={waitlistLoading}
           >
-            Refresh
+            {t('adminUsers.actions.refresh')}
           </button>
         </div>
 
@@ -496,11 +511,11 @@ const V2AdminUsers: React.FC = () => {
           <input
             type="search"
             className="v2-admin-users__input"
-            placeholder="Search email, name, or organization…"
+            placeholder={t('adminUsers.waitlist.searchPlaceholder')}
             value={search}
             onChange={(e) => setSearch(e.target.value)}
           />
-          <div className="v2-admin-users__tabs" role="tablist" aria-label="Filter by status">
+          <div className="v2-admin-users__tabs" role="tablist" aria-label={t('adminUsers.waitlist.filterByStatus')}>
             {filterTabs.map((tab) => (
               <button
                 key={tab.value}
@@ -522,15 +537,15 @@ const V2AdminUsers: React.FC = () => {
 
         {waitlistLoading ? (
           <div className="v2-admin-users__loading">
-            <span className="v2-spinner" /> Loading waitlist…
+            <span className="v2-spinner" /> {t('adminUsers.waitlist.loading')}
           </div>
         ) : waitlistEmpty ? (
           <div className="v2-empty">
-            <div className="v2-empty__title">No waitlist requests</div>
+            <div className="v2-empty__title">{t('adminUsers.waitlist.emptyTitle')}</div>
             <div className="v2-empty__text">
               {search || statusFilter !== 'all'
-                ? 'No requests match the current filters.'
-                : 'New access requests will appear here.'}
+                ? t('adminUsers.waitlist.emptyFiltered')
+                : t('adminUsers.waitlist.emptyDefault')}
             </div>
           </div>
         ) : (
@@ -538,14 +553,14 @@ const V2AdminUsers: React.FC = () => {
             <table className="v2-admin-users__table">
               <thead>
                 <tr>
-                  <th>Email</th>
-                  <th>Name</th>
-                  <th>Organization</th>
-                  <th>Use case</th>
-                  <th>Status</th>
-                  <th>Requested</th>
-                  <th>Invited</th>
-                  <th aria-label="Actions" />
+                  <th>{t('adminUsers.waitlist.columns.email')}</th>
+                  <th>{t('adminUsers.waitlist.columns.name')}</th>
+                  <th>{t('adminUsers.waitlist.columns.organization')}</th>
+                  <th>{t('adminUsers.waitlist.columns.useCase')}</th>
+                  <th>{t('adminUsers.waitlist.columns.status')}</th>
+                  <th>{t('adminUsers.waitlist.columns.requested')}</th>
+                  <th>{t('adminUsers.waitlist.columns.invited')}</th>
+                  <th aria-label={t('adminUsers.columns.actions')} />
                 </tr>
               </thead>
               <tbody>
@@ -564,7 +579,7 @@ const V2AdminUsers: React.FC = () => {
                           {row.note && <span className="v2-admin-users__note">{row.note}</span>}
                         </td>
                         <td>
-                          <span className={statusBadgeClass(row.status)}>{row.status}</span>
+                          <span className={statusBadgeClass(row.status)}>{waitlistStatusLabel(row.status)}</span>
                         </td>
                         <td className="v2-admin-users__cell-muted">{formatDate(row.createdAt)}</td>
                         <td className="v2-admin-users__cell-muted">
@@ -572,10 +587,10 @@ const V2AdminUsers: React.FC = () => {
                             <>
                               {formatDate(row.invitationSentAt || row.invitedAt)}
                               {row.invitedBy?.username && (
-                                <span className="v2-admin-users__note">by {row.invitedBy.username}</span>
+                                <span className="v2-admin-users__note">{t('adminUsers.waitlist.invitedBy', { username: row.invitedBy.username })}</span>
                               )}
                               {row.invitationCode?.code && (
-                                <span className="v2-admin-users__note">code {row.invitationCode.code}</span>
+                                <span className="v2-admin-users__note">{t('adminUsers.waitlist.invitedCode', { code: row.invitationCode.code })}</span>
                               )}
                             </>
                           ) : '—'}
@@ -588,7 +603,7 @@ const V2AdminUsers: React.FC = () => {
                               onClick={() => reopen(row)}
                               disabled={busy}
                             >
-                              {busy ? 'Working…' : 'Reopen'}
+                              {busy ? t('adminUsers.actions.working') : t('adminUsers.actions.reopen')}
                             </button>
                           ) : row.status === 'closed' ? (
                             <button
@@ -597,7 +612,7 @@ const V2AdminUsers: React.FC = () => {
                               onClick={() => reopen(row)}
                               disabled={busy}
                             >
-                              {busy ? 'Working…' : 'Reopen'}
+                              {busy ? t('adminUsers.actions.working') : t('adminUsers.actions.reopen')}
                             </button>
                           ) : (
                             <button
@@ -606,7 +621,7 @@ const V2AdminUsers: React.FC = () => {
                               onClick={() => sendInvitation(row)}
                               disabled={busy}
                             >
-                              {busy ? 'Sending…' : 'Send invitation'}
+                              {busy ? t('adminUsers.actions.sending') : t('adminUsers.actions.sendInvitation')}
                             </button>
                           )}
                         </td>
@@ -631,9 +646,9 @@ const V2AdminUsers: React.FC = () => {
       <section className="v2-admin-users__section">
         <div className="v2-admin-users__section-head">
           <div>
-            <h2 className="v2-admin-users__section-title">Invitation codes</h2>
+            <h2 className="v2-admin-users__section-title">{t('adminUsers.invites.title')}</h2>
             <p className="v2-admin-users__section-sub">
-              Generate codes to share manually, and revoke codes you no longer want active.
+              {t('adminUsers.invites.subtitle')}
             </p>
           </div>
           <button
@@ -642,7 +657,7 @@ const V2AdminUsers: React.FC = () => {
             onClick={generateCode}
             disabled={generating}
           >
-            {generating ? 'Generating…' : 'Generate code'}
+            {generating ? t('adminUsers.actions.generating') : t('adminUsers.actions.generateCode')}
           </button>
         </div>
 
@@ -650,22 +665,22 @@ const V2AdminUsers: React.FC = () => {
 
         {newCode && (
           <div className="v2-admin-users__newcode">
-            <div className="v2-admin-users__newcode-label">New code — copy and share it manually</div>
+            <div className="v2-admin-users__newcode-label">{t('adminUsers.invites.newCodeLabel')}</div>
             <code className="v2-admin-users__newcode-value">{newCode}</code>
             <button
               type="button"
               className="v2-admin-users__btn v2-admin-users__btn--ghost"
               onClick={() => copy(`new:${newCode}`, newCode)}
             >
-              {copied === `new:${newCode}` ? 'Copied!' : 'Copy'}
+              {copied === `new:${newCode}` ? t('adminUsers.actions.copied') : t('adminUsers.actions.copy')}
             </button>
             <button
               type="button"
               className="v2-admin-users__btn v2-admin-users__btn--ghost"
               onClick={() => setNewCode(null)}
-              aria-label="Dismiss new code"
+              aria-label={t('adminUsers.invites.dismissNewCode')}
             >
-              Dismiss
+              {t('adminUsers.actions.dismiss')}
             </button>
           </div>
         )}
@@ -674,24 +689,24 @@ const V2AdminUsers: React.FC = () => {
 
         {invitesLoading ? (
           <div className="v2-admin-users__loading">
-            <span className="v2-spinner" /> Loading invitation codes…
+            <span className="v2-spinner" /> {t('adminUsers.invites.loading')}
           </div>
         ) : invitesEmpty ? (
           <div className="v2-empty">
-            <div className="v2-empty__title">No invitation codes</div>
-            <div className="v2-empty__text">Generate a code to get started.</div>
+            <div className="v2-empty__title">{t('adminUsers.invites.emptyTitle')}</div>
+            <div className="v2-empty__text">{t('adminUsers.invites.emptyText')}</div>
           </div>
         ) : (
           <div className="v2-admin-users__table-wrap">
             <table className="v2-admin-users__table">
               <thead>
                 <tr>
-                  <th>Code</th>
-                  <th>Uses</th>
-                  <th>Status</th>
-                  <th>Expires</th>
-                  <th>Created</th>
-                  <th aria-label="Actions" />
+                  <th>{t('adminUsers.invites.columns.code')}</th>
+                  <th>{t('adminUsers.invites.columns.uses')}</th>
+                  <th>{t('adminUsers.invites.columns.status')}</th>
+                  <th>{t('adminUsers.invites.columns.expires')}</th>
+                  <th>{t('adminUsers.invites.columns.created')}</th>
+                  <th aria-label={t('adminUsers.columns.actions')} />
                 </tr>
               </thead>
               <tbody>
@@ -706,7 +721,7 @@ const V2AdminUsers: React.FC = () => {
                           className="v2-admin-users__inline-copy"
                           onClick={() => copy(`code:${invite.id}`, invite.code)}
                         >
-                          {copied === `code:${invite.id}` ? 'Copied!' : 'Copy'}
+                          {copied === `code:${invite.id}` ? t('adminUsers.actions.copied') : t('adminUsers.actions.copy')}
                         </button>
                       </td>
                       <td className="v2-admin-users__cell-muted">
@@ -717,7 +732,7 @@ const V2AdminUsers: React.FC = () => {
                           ? 'v2-admin-users__badge v2-admin-users__badge--ok'
                           : 'v2-admin-users__badge v2-admin-users__badge--muted'}
                         >
-                          {invite.isActive ? 'active' : 'revoked'}
+                          {invite.isActive ? t('adminUsers.invites.codeStatus.active') : t('adminUsers.invites.codeStatus.revoked')}
                         </span>
                       </td>
                       <td className="v2-admin-users__cell-muted">{formatDate(invite.expiresAt)}</td>
@@ -730,7 +745,7 @@ const V2AdminUsers: React.FC = () => {
                             onClick={() => revoke(invite)}
                             disabled={busy}
                           >
-                            {busy ? 'Revoking…' : 'Revoke'}
+                            {busy ? t('adminUsers.actions.revoking') : t('adminUsers.actions.revoke')}
                           </button>
                         )}
                       </td>

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -16,6 +16,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import axios from '../../utils/axiosConfig';
 import V2FeaturePage from './V2FeaturePage';
 import { useV2Api } from '../hooks/useV2Api';
@@ -35,6 +36,7 @@ const sanitizeAgentName = (raw: string): string => raw
   .slice(0, 64);
 
 const V2AgentBYO: React.FC = () => {
+  const { t } = useTranslation();
   const api = useV2Api();
   const navigate = useNavigate();
   const [pods, setPods] = useState<V2Pod[]>([]);
@@ -83,11 +85,11 @@ const V2AgentBYO: React.FC = () => {
     setError(null);
     const cleanName = sanitizeAgentName(name);
     if (!cleanName) {
-      setError('Agent name must contain at least one letter or digit.');
+      setError(t('agentByo.errors.nameRequired'));
       return;
     }
     if (!podId) {
-      setError('Pick a pod to install into.');
+      setError(t('agentByo.errors.podRequired'));
       return;
     }
     setSubmitting(true);
@@ -120,7 +122,7 @@ const V2AgentBYO: React.FC = () => {
       );
       const tok = tokenRes?.token;
       if (!tok) {
-        setError('Install succeeded but token issuance returned empty. Retry, or contact ops.');
+        setError(t('agentByo.errors.tokenEmpty'));
       } else {
         setIssued({ token: tok, agentName: cleanName, podId });
         setMemoryText('');
@@ -129,7 +131,7 @@ const V2AgentBYO: React.FC = () => {
       }
     } catch (err) {
       const e = err as { response?: { data?: { error?: string; message?: string } }; message?: string };
-      setError(e.response?.data?.error || e.response?.data?.message || e.message || 'Install failed.');
+      setError(e.response?.data?.error || e.response?.data?.message || e.message || t('agentByo.errors.installFailed'));
     } finally {
       setSubmitting(false);
     }
@@ -150,7 +152,7 @@ const V2AgentBYO: React.FC = () => {
   const onMemoryFile = async (file: File | undefined) => {
     if (!file) return;
     if (file.size > 256 * 1024) {
-      setMemoryError('That file is over the 256KB import ceiling — trim it or paste the relevant part.');
+      setMemoryError(t('agentByo.errors.fileTooLarge'));
       return;
     }
     setMemoryError(null);
@@ -182,7 +184,7 @@ const V2AgentBYO: React.FC = () => {
       setMemoryDone(true);
     } catch (err) {
       const e = err as { response?: { data?: { error?: string } }; message?: string };
-      setMemoryError(e.response?.data?.error || e.message || 'Import failed.');
+      setMemoryError(e.response?.data?.error || e.message || t('agentByo.errors.importFailed'));
     } finally {
       setMemoryBusy(false);
     }
@@ -220,15 +222,15 @@ const V2AgentBYO: React.FC = () => {
 
   return (
     <V2FeaturePage
-      eyebrow="Connect any runtime"
-      title="Bring your own agent"
-      description="Connect Claude Code, Cursor, or Codex to your Commonly pods via MCP. ~2 minutes."
+      eyebrow={t('agentByo.eyebrow')}
+      title={t('agentByo.title')}
+      description={t('agentByo.description')}
       showPodsSidebar={false}
     >
       {!issued && (
         <div className="v2-byo__form">
           <label className="v2-byo__field">
-            <span className="v2-byo__label">Agent name</span>
+            <span className="v2-byo__label">{t('agentByo.form.nameLabel')}</span>
             <input
               type="text"
               value={name}
@@ -237,23 +239,23 @@ const V2AgentBYO: React.FC = () => {
               className="v2-byo__input"
             />
             <span className="v2-byo__hint">
-              Lower-case letters, digits, and dashes. This is the identity your agent posts as.
+              {t('agentByo.form.nameHint')}
             </span>
           </label>
           <label className="v2-byo__field">
-            <span className="v2-byo__label">Install into pod</span>
+            <span className="v2-byo__label">{t('agentByo.form.podLabel')}</span>
             <select
               value={podId}
               onChange={(e) => setPodId(e.target.value)}
               className="v2-byo__input"
             >
-              {pods.length === 0 && <option value="">Loading pods…</option>}
+              {pods.length === 0 && <option value="">{t('agentByo.form.loadingPods')}</option>}
               {pods.map((p) => (
                 <option key={p._id} value={p._id}>{p.name} ({p.type || 'chat'})</option>
               ))}
             </select>
             <span className="v2-byo__hint">
-              Your agent will be installed here. You can install it into more pods later.
+              {t('agentByo.form.podHint')}
             </span>
           </label>
           {error && <div className="v2-byo__error">{error}</div>}
@@ -263,33 +265,31 @@ const V2AgentBYO: React.FC = () => {
             disabled={submitting || !podId}
             className="v2-byo__submit"
           >
-            {submitting ? 'Issuing token…' : 'Install + generate token'}
+            {submitting ? t('agentByo.actions.issuing') : t('agentByo.actions.install')}
           </button>
           <p className="v2-byo__footnote">
-            Prefer the CLI? <code>npm i -g @commonlyai/cli</code>, then{' '}
+            {t('agentByo.footnote.preferCli')} <code>npm i -g @commonlyai/cli</code>, {t('agentByo.footnote.then')}{' '}
             <code>commonly agent init --name &lt;n&gt; --pod &lt;podId&gt;</code>.{' '}
-            Not sure which path?{' '}
-            <a href="https://github.com/Team-Commonly/commonly/blob/main/docs/agents/CONNECTING_LOCAL_AGENTS.md" target="_blank" rel="noopener noreferrer">MCP vs CLI vs SDK</a>
+            {t('agentByo.footnote.notSure')}{' '}
+            <a href="https://github.com/Team-Commonly/commonly/blob/main/docs/agents/CONNECTING_LOCAL_AGENTS.md" target="_blank" rel="noopener noreferrer">{t('agentByo.footnote.mcpVsCli')}</a>
             {' · '}
-            <a href="https://github.com/Team-Commonly/commonly/blob/main/docs/MCP_INTEGRATION.md" target="_blank" rel="noopener noreferrer">full walkthrough</a>.
+            <a href="https://github.com/Team-Commonly/commonly/blob/main/docs/MCP_INTEGRATION.md" target="_blank" rel="noopener noreferrer">{t('agentByo.footnote.fullWalkthrough')}</a>.
           </p>
         </div>
       )}
 
       {issued && (
         <div className="v2-byo__result">
-          <h2>Token issued for <code>{issued.agentName}</code></h2>
+          <h2>{t('agentByo.result.heading')} <code>{issued.agentName}</code></h2>
           <p>
-            Copy this <strong>once</strong>. Commonly hashes the token after issuance — if you lose
-            it, come back here and rotate (re-running install with the same name is idempotent on
-            identity; the token is reissued fresh).
+            {t('agentByo.result.copyOnceLead')} <strong>{t('agentByo.result.copyOnceEmphasis')}</strong>. {t('agentByo.result.copyOnceRest')}
           </p>
 
           <div className="v2-byo__snippet">
             <div className="v2-byo__snippet-head">
-              <span>Runtime token</span>
+              <span>{t('agentByo.snippets.runtimeToken')}</span>
               <button type="button" onClick={() => copy('tok', issued.token)} className="v2-byo__copy">
-                {copied === 'tok' ? 'Copied!' : 'Copy'}
+                {copied === 'tok' ? t('agentByo.actions.copied') : t('agentByo.actions.copy')}
               </button>
             </div>
             <pre className="v2-byo__pre">{issued.token}</pre>
@@ -297,9 +297,9 @@ const V2AgentBYO: React.FC = () => {
 
           <div className="v2-byo__snippet">
             <div className="v2-byo__snippet-head">
-              <span>Claude Code</span>
+              <span>{t('agentByo.snippets.claudeCode')}</span>
               <button type="button" onClick={() => copy('claude', claudeSnippet)} className="v2-byo__copy">
-                {copied === 'claude' ? 'Copied!' : 'Copy'}
+                {copied === 'claude' ? t('agentByo.actions.copied') : t('agentByo.actions.copy')}
               </button>
             </div>
             <pre className="v2-byo__pre">{claudeSnippet}</pre>
@@ -307,9 +307,9 @@ const V2AgentBYO: React.FC = () => {
 
           <div className="v2-byo__snippet">
             <div className="v2-byo__snippet-head">
-              <span>Cursor — add to ~/.cursor/mcp.json</span>
+              <span>{t('agentByo.snippets.cursor')}</span>
               <button type="button" onClick={() => copy('cursor', cursorSnippet)} className="v2-byo__copy">
-                {copied === 'cursor' ? 'Copied!' : 'Copy'}
+                {copied === 'cursor' ? t('agentByo.actions.copied') : t('agentByo.actions.copy')}
               </button>
             </div>
             <pre className="v2-byo__pre">{cursorSnippet}</pre>
@@ -317,24 +317,21 @@ const V2AgentBYO: React.FC = () => {
 
           <div className="v2-byo__snippet">
             <div className="v2-byo__snippet-head">
-              <span>Bring its memory (optional)</span>
+              <span>{t('agentByo.snippets.memory')}</span>
             </div>
             {memoryDone ? (
               <p className="v2-byo__memory-done">
-                ✓ Memory imported — <code>{issued.agentName}</code> arrives knowing your project.
-                It shows up in the agent&apos;s profile under long-term memory.
+                {t('agentByo.memory.doneLead')} <code>{issued.agentName}</code> {t('agentByo.memory.doneRest')}
               </p>
             ) : (
               <div className="v2-byo__memory">
                 <p className="v2-byo__hint">
-                  Paste your agent&apos;s local <code>MEMORY.md</code> or <code>CLAUDE.md</code> (or
-                  pick the file) and it starts here with everything it already knows. Appends to its
-                  long-term memory; never overwrites. Nothing is sent until you click import.
+                  {t('agentByo.memory.pasteLead')} <code>MEMORY.md</code> {t('agentByo.memory.pasteOr')} <code>CLAUDE.md</code> {t('agentByo.memory.pasteRest')}
                 </p>
                 <textarea
                   className="v2-byo__input v2-byo__memory-text"
                   rows={6}
-                  placeholder="# Paste MEMORY.md / CLAUDE.md content here…"
+                  placeholder={t('agentByo.memory.placeholder')}
                   value={memoryText}
                   onChange={(e) => setMemoryText(e.target.value)}
                 />
@@ -342,7 +339,7 @@ const V2AgentBYO: React.FC = () => {
                   <input
                     type="file"
                     accept=".md,text/markdown,text/plain"
-                    aria-label="Choose a memory file"
+                    aria-label={t('agentByo.memory.fileAriaLabel')}
                     onChange={(e) => onMemoryFile(e.target.files?.[0])}
                   />
                   <button
@@ -351,7 +348,7 @@ const V2AgentBYO: React.FC = () => {
                     disabled={memoryBusy || !memoryText.trim()}
                     onClick={importMemory}
                   >
-                    {memoryBusy ? 'Importing…' : 'Import memory'}
+                    {memoryBusy ? t('agentByo.memory.importing') : t('agentByo.memory.import')}
                   </button>
                 </div>
                 {memoryError && <div className="v2-byo__error">{memoryError}</div>}
@@ -365,14 +362,14 @@ const V2AgentBYO: React.FC = () => {
               onClick={() => navigate(`/v2/pods/${issued.podId}`)}
               className="v2-byo__submit"
             >
-              Go to your pod
+              {t('agentByo.actions.goToPod')}
             </button>
             <button
               type="button"
               onClick={() => { setIssued(null); }}
               className="v2-byo__secondary"
             >
-              Install another
+              {t('agentByo.actions.installAnother')}
             </button>
           </div>
         </div>

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -27,6 +27,12 @@ const DEFAULT_SCOPES = [
   'context:read', 'summaries:read', 'messages:write', 'messages:read',
   'posts:write', 'posts:read', 'memory:read', 'memory:write',
 ];
+const DEFAULT_AGENT_NAME = 'my-mcp-agent';
+const DEFAULT_POD_TYPE = 'chat';
+const CLI_INSTALL_COMMAND = 'npm i -g @commonlyai/cli';
+const CLI_INIT_COMMAND = 'commonly agent init --name <n> --pod <podId>';
+const MEMORY_FILE_NAME = 'MEMORY.md';
+const CLAUDE_FILE_NAME = 'CLAUDE.md';
 
 const sanitizeAgentName = (raw: string): string => raw
   .toLowerCase()
@@ -47,12 +53,12 @@ const V2AgentBYO: React.FC = () => {
   const { currentUser } = useAuth();
   const defaultAgentName = (() => {
     const u = (currentUser?.username || '').toLowerCase().replace(/[^a-z0-9-]/g, '');
-    return u ? `${u}-agent` : 'my-mcp-agent';
+    return u ? `${u}-agent` : DEFAULT_AGENT_NAME;
   })();
   const [name, setName] = useState<string>(defaultAgentName);
   // currentUser can resolve after mount — refresh the default if untouched.
   useEffect(() => {
-    setName((prev) => (prev === 'my-mcp-agent' && defaultAgentName !== 'my-mcp-agent' ? defaultAgentName : prev));
+    setName((prev) => (prev === DEFAULT_AGENT_NAME && defaultAgentName !== DEFAULT_AGENT_NAME ? defaultAgentName : prev));
   }, [defaultAgentName]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -235,7 +241,7 @@ const V2AgentBYO: React.FC = () => {
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder="my-mcp-agent"
+              placeholder={DEFAULT_AGENT_NAME}
               className="v2-byo__input"
             />
             <span className="v2-byo__hint">
@@ -251,7 +257,7 @@ const V2AgentBYO: React.FC = () => {
             >
               {pods.length === 0 && <option value="">{t('agentByo.form.loadingPods')}</option>}
               {pods.map((p) => (
-                <option key={p._id} value={p._id}>{p.name} ({p.type || 'chat'})</option>
+                <option key={p._id} value={p._id}>{p.name} ({p.type || DEFAULT_POD_TYPE})</option>
               ))}
             </select>
             <span className="v2-byo__hint">
@@ -268,8 +274,8 @@ const V2AgentBYO: React.FC = () => {
             {submitting ? t('agentByo.actions.issuing') : t('agentByo.actions.install')}
           </button>
           <p className="v2-byo__footnote">
-            {t('agentByo.footnote.preferCli')} <code>npm i -g @commonlyai/cli</code>, {t('agentByo.footnote.then')}{' '}
-            <code>commonly agent init --name &lt;n&gt; --pod &lt;podId&gt;</code>.{' '}
+            {t('agentByo.footnote.preferCli')} <code>{CLI_INSTALL_COMMAND}</code>, {t('agentByo.footnote.then')}{' '}
+            <code>{CLI_INIT_COMMAND}</code>.{' '}
             {t('agentByo.footnote.notSure')}{' '}
             <a href="https://github.com/Team-Commonly/commonly/blob/main/docs/agents/CONNECTING_LOCAL_AGENTS.md" target="_blank" rel="noopener noreferrer">{t('agentByo.footnote.mcpVsCli')}</a>
             {' · '}
@@ -326,7 +332,7 @@ const V2AgentBYO: React.FC = () => {
             ) : (
               <div className="v2-byo__memory">
                 <p className="v2-byo__hint">
-                  {t('agentByo.memory.pasteLead')} <code>MEMORY.md</code> {t('agentByo.memory.pasteOr')} <code>CLAUDE.md</code> {t('agentByo.memory.pasteRest')}
+                  {t('agentByo.memory.pasteLead')} <code>{MEMORY_FILE_NAME}</code> {t('agentByo.memory.pasteOr')} <code>{CLAUDE_FILE_NAME}</code> {t('agentByo.memory.pasteRest')}
                 </p>
                 <textarea
                   className="v2-byo__input v2-byo__memory-text"

--- a/frontend/src/v2/components/V2FeedbackMenu.tsx
+++ b/frontend/src/v2/components/V2FeedbackMenu.tsx
@@ -6,6 +6,7 @@ import LightbulbOutlinedIcon from '@mui/icons-material/LightbulbOutlined';
 import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
 import QuestionAnswerOutlinedIcon from '@mui/icons-material/QuestionAnswerOutlined';
 import { useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import {
   buildBugReportUrl,
   buildFeatureRequestUrl,
@@ -14,6 +15,7 @@ import {
 } from '../utils/feedbackLinks';
 
 const V2FeedbackMenu: React.FC = () => {
+  const { t } = useTranslation();
   const location = useLocation();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
   const v2Root = anchorEl?.closest('.v2-root') as HTMLElement | null;
@@ -32,11 +34,11 @@ const V2FeedbackMenu: React.FC = () => {
       <button
         type="button"
         className="v2-rail__feedback"
-        aria-label="Feedback"
+        aria-label={t('feedbackMenu.button')}
         aria-expanded={open}
         aria-controls={open ? 'v2-feedback-options' : undefined}
         onClick={handleOpen}
-        title="Feedback"
+        title={t('feedbackMenu.button')}
       >
         <FeedbackOutlinedIcon aria-hidden="true" />
       </button>
@@ -49,7 +51,7 @@ const V2FeedbackMenu: React.FC = () => {
         transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         PaperProps={{ className: 'v2-feedback-menu__popover', elevation: 0 }}
       >
-        <nav id="v2-feedback-options" className="v2-feedback-menu__list" aria-label="Feedback options">
+        <nav id="v2-feedback-options" className="v2-feedback-menu__list" aria-label={t('feedbackMenu.optionsLabel')}>
           <a
             className="v2-feedback-menu__item"
             href={buildBugReportUrl(location.pathname)}
@@ -58,7 +60,7 @@ const V2FeedbackMenu: React.FC = () => {
             onClick={handleClose}
           >
             <BugReportOutlinedIcon aria-hidden="true" />
-            <span>Report a bug</span>
+            <span>{t('feedbackMenu.actions.reportBug')}</span>
           </a>
           <a
             className="v2-feedback-menu__item"
@@ -68,7 +70,7 @@ const V2FeedbackMenu: React.FC = () => {
             onClick={handleClose}
           >
             <LightbulbOutlinedIcon aria-hidden="true" />
-            <span>Request a feature</span>
+            <span>{t('feedbackMenu.actions.requestFeature')}</span>
           </a>
           <a
             className="v2-feedback-menu__item"
@@ -78,7 +80,7 @@ const V2FeedbackMenu: React.FC = () => {
             onClick={handleClose}
           >
             <QuestionAnswerOutlinedIcon aria-hidden="true" />
-            <span>Ask a question</span>
+            <span>{t('feedbackMenu.actions.askQuestion')}</span>
           </a>
           <a
             className="v2-feedback-menu__item"
@@ -88,7 +90,7 @@ const V2FeedbackMenu: React.FC = () => {
             onClick={handleClose}
           >
             <ForumOutlinedIcon aria-hidden="true" />
-            <span>Join our Discord</span>
+            <span>{t('feedbackMenu.actions.joinDiscord')}</span>
           </a>
         </nav>
       </Popover>

--- a/frontend/src/v2/components/V2LangSwitch.tsx
+++ b/frontend/src/v2/components/V2LangSwitch.tsx
@@ -7,6 +7,8 @@ const LANGUAGES = [
   { code: 'en' as const, label: 'English', short: 'EN' },
   { code: 'zh-CN' as const, label: '中文', short: '中文' },
 ];
+const CARET_ICON = '▾';
+const CHECK_ICON = '✓';
 
 // Dropdown language menu (Sam's call 2026-07-22: reads like the other nav
 // options, not a two-button pill). Trigger shows the active language; the
@@ -50,7 +52,7 @@ const V2LangSwitch: React.FC = () => {
         onClick={() => setOpen((v) => !v)}
       >
         {active.short}
-        <span className="v2-lang-switch__caret" aria-hidden="true">▾</span>
+        <span className="v2-lang-switch__caret" aria-hidden="true">{CARET_ICON}</span>
       </button>
       {open && (
         <ul className="v2-lang-switch__menu" role="listbox" aria-label={t('common.language.label')}>
@@ -63,7 +65,7 @@ const V2LangSwitch: React.FC = () => {
               >
                 <span>{lang.label}</span>
                 {lang.code === active.code && (
-                  <span className="v2-lang-switch__check" aria-hidden="true">✓</span>
+                  <span className="v2-lang-switch__check" aria-hidden="true">{CHECK_ICON}</span>
                 )}
               </button>
             </li>

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -77,6 +77,12 @@ interface TaskApiResponse {
   tasks: TaskItem[];
 }
 
+const TASK_PILL_CLASS = {
+  complete: 'v2-inspector__pill v2-inspector__pill--complete',
+  blocked: 'v2-inspector__pill v2-inspector__pill--blocked',
+  progress: 'v2-inspector__pill v2-inspector__pill--progress',
+} as const;
+
 interface AnnouncementItem {
   _id: string;
   title?: string;
@@ -1413,10 +1419,10 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
                 const isDone = task.status === 'done' || task.status === 'completed';
                 const isBlocked = task.status === 'blocked';
                 const pillClass = isDone
-                  ? 'v2-inspector__pill v2-inspector__pill--complete'
+                  ? TASK_PILL_CLASS.complete
                   : isBlocked
-                    ? 'v2-inspector__pill v2-inspector__pill--blocked'
-                    : 'v2-inspector__pill v2-inspector__pill--progress';
+                    ? TASK_PILL_CLASS.blocked
+                    : TASK_PILL_CLASS.progress;
                 const pillLabel = isDone ? t('inspector.taskPill.done') : isBlocked ? t('inspector.taskPill.blocked') : t('inspector.taskPill.active');
                 const assignee = task.assignee ? `@${task.assignee}` : null;
                 return (

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import Papa from 'papaparse';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import V2Avatar from './V2Avatar';
 import { UseV2PodDetailResult, V2Agent } from '../hooks/useV2PodDetail';
@@ -248,6 +249,7 @@ const useTextPreview = (signedUrl: string | null): {
   const [truncated, setTruncated] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(!!signedUrl);
+  const { t } = useTranslation();
   useEffect(() => {
     if (!signedUrl) { setText(null); setLoading(false); return; }
     let cancelled = false;
@@ -280,12 +282,12 @@ const useTextPreview = (signedUrl: string | null): {
         setLoading(false);
       } catch (e) {
         if (cancelled) return;
-        setError(e instanceof Error ? e.message : 'Could not load file');
+        setError(e instanceof Error ? e.message : t('inspector.preview.couldNotLoadFile'));
         setLoading(false);
       }
     })();
     return () => { cancelled = true; };
-  }, [signedUrl]);
+  }, [signedUrl, t]);
   return { text, truncated, error, loading };
 };
 
@@ -314,8 +316,9 @@ const PreviewMute: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 );
 
 const ImagePreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
+  const { t } = useTranslation();
   const { url, loading } = useSignedFileUrl(artifact.fileName);
-  if (loading) return <PreviewBox><PreviewMute>Loading…</PreviewMute></PreviewBox>;
+  if (loading) return <PreviewBox><PreviewMute>{t('inspector.preview.loading')}</PreviewMute></PreviewBox>;
   if (!url) return null;
   return (
     <PreviewBox>
@@ -325,8 +328,9 @@ const ImagePreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => 
 };
 
 const PdfPreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
+  const { t } = useTranslation();
   const { url, loading } = useSignedFileUrl(artifact.fileName);
-  if (loading) return <PreviewBox><PreviewMute>Loading PDF…</PreviewMute></PreviewBox>;
+  if (loading) return <PreviewBox><PreviewMute>{t('inspector.preview.loadingPdf')}</PreviewMute></PreviewBox>;
   if (!url) return null;
   return (
     <PreviewBox>
@@ -340,10 +344,11 @@ const PdfPreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
 };
 
 const TextPreview: React.FC<{ artifact: PreviewArtifact; markdown?: boolean; pretty?: boolean }> = ({ artifact, markdown, pretty }) => {
+  const { t } = useTranslation();
   const { url } = useSignedFileUrl(artifact.fileName);
   const { text, truncated, error, loading } = useTextPreview(url);
-  if (loading) return <PreviewBox><PreviewMute>Loading…</PreviewMute></PreviewBox>;
-  if (error) return <PreviewBox><PreviewMute>Could not load: {error}</PreviewMute></PreviewBox>;
+  if (loading) return <PreviewBox><PreviewMute>{t('inspector.preview.loading')}</PreviewMute></PreviewBox>;
+  if (error) return <PreviewBox><PreviewMute>{t('inspector.preview.couldNotLoad', { error })}</PreviewMute></PreviewBox>;
   if (text == null) return null;
   // For JSON, try to pretty-print; on parse failure fall through to raw.
   let body = text;
@@ -363,23 +368,24 @@ const TextPreview: React.FC<{ artifact: PreviewArtifact; markdown?: boolean; pre
           fontSize: 12, lineHeight: 1.5, whiteSpace: 'pre-wrap', wordBreak: 'break-word',
         }}>{body}</pre>
       )}
-      {truncated && <PreviewMute>Preview truncated at 200 KB. Click Open for the full file.</PreviewMute>}
+      {truncated && <PreviewMute>{t('inspector.preview.truncated')}</PreviewMute>}
     </PreviewBox>
   );
 };
 
 const CsvPreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
+  const { t } = useTranslation();
   const { url } = useSignedFileUrl(artifact.fileName);
   const { text, truncated, error, loading } = useTextPreview(url);
-  if (loading) return <PreviewBox><PreviewMute>Loading CSV…</PreviewMute></PreviewBox>;
-  if (error) return <PreviewBox><PreviewMute>Could not load: {error}</PreviewMute></PreviewBox>;
+  if (loading) return <PreviewBox><PreviewMute>{t('inspector.preview.loadingCsv')}</PreviewMute></PreviewBox>;
+  if (error) return <PreviewBox><PreviewMute>{t('inspector.preview.couldNotLoad', { error })}</PreviewMute></PreviewBox>;
   if (!text) return null;
   // RFC 4180 parsing via papaparse — handles quoted commas, escaped quotes,
   // and multi-line cells. The hand-roll we shipped previously broke on real
   // spreadsheet exports.
   const parsed = Papa.parse<string[]>(text, { skipEmptyLines: true });
   const rows = parsed.data;
-  if (rows.length === 0) return <PreviewBox><PreviewMute>Empty file</PreviewMute></PreviewBox>;
+  if (rows.length === 0) return <PreviewBox><PreviewMute>{t('inspector.preview.emptyFile')}</PreviewMute></PreviewBox>;
   const PREVIEW_ROW_CAP = 20;
   const [headerRow, ...allBodyRows] = rows;
   const bodyRows = allBodyRows.slice(0, PREVIEW_ROW_CAP);
@@ -409,8 +415,8 @@ const CsvPreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
       {(truncated || moreRows > 0) && (
         <PreviewMute>
           {truncated
-            ? 'Preview truncated at 200 KB. Click Open for the full file.'
-            : `${moreRows} more row${moreRows === 1 ? '' : 's'} not shown. Click Open for the full file.`}
+            ? t('inspector.preview.truncated')
+            : t('inspector.preview.moreRows', { count: moreRows })}
         </PreviewMute>
       )}
     </PreviewBox>
@@ -423,6 +429,7 @@ const CsvPreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
 // (headings, lists, tables, bold/italic) and skips rare inline shapes. For
 // pixel-faithful render the user clicks Open and uses Word / Office Online.
 const DocxPreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
+  const { t } = useTranslation();
   const { url, loading: urlLoading } = useSignedFileUrl(artifact.fileName);
   const [html, setHtml] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -464,19 +471,19 @@ const DocxPreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
         setHtml(result.value || '');
       } catch (e) {
         if (cancelled) return;
-        setError(e instanceof Error ? e.message : 'Could not load document');
+        setError(e instanceof Error ? e.message : t('inspector.preview.couldNotLoadDocument'));
       } finally {
         if (!cancelled) setBusy(false);
       }
     })();
     return () => { cancelled = true; };
-  }, [url]);
-  if (urlLoading || busy) return <PreviewBox><PreviewMute>Rendering Word document…</PreviewMute></PreviewBox>;
-  if (error) return <PreviewBox><PreviewMute>Could not preview: {error}</PreviewMute></PreviewBox>;
+  }, [url, t]);
+  if (urlLoading || busy) return <PreviewBox><PreviewMute>{t('inspector.preview.renderingWord')}</PreviewMute></PreviewBox>;
+  if (error) return <PreviewBox><PreviewMute>{t('inspector.preview.couldNotPreview', { error })}</PreviewMute></PreviewBox>;
   // mammoth returns "" (not null) when the docx body has no paragraphs/runs,
   // so html=="" is the empty-document signal. Surface a placeholder rather
   // than rendering nothing — matches the XlsxPreview empty-sheet UX.
-  if (html === '') return <PreviewBox><PreviewMute>Empty document</PreviewMute></PreviewBox>;
+  if (html === '') return <PreviewBox><PreviewMute>{t('inspector.preview.emptyDocument')}</PreviewMute></PreviewBox>;
   if (!html) return null;
   return (
     <PreviewBox>
@@ -498,6 +505,7 @@ const DocxPreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
 // SheetJS produces a <table> for each sheet; we wrap it in our scroll
 // container and add light styling so it doesn't dump unstyled rows.
 const XlsxPreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
+  const { t } = useTranslation();
   const { url, loading: urlLoading } = useSignedFileUrl(artifact.fileName);
   const [sheets, setSheets] = useState<{ name: string; html: string }[] | null>(null);
   const [activeSheet, setActiveSheet] = useState(0);
@@ -529,7 +537,7 @@ const XlsxPreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
           // and fall back to a placeholder for genuinely empty sheets.
           const cellKeys = Object.keys(ws || {}).filter((k) => !k.startsWith('!'));
           if (cellKeys.length === 0) {
-            return { name, html: '<p style="color:#888;font-style:italic">Empty sheet</p>' };
+            return { name, html: `<p style="color:#888;font-style:italic">${t('inspector.preview.emptySheet')}</p>` };
           }
           if (!ws['!ref']) {
             try {
@@ -550,22 +558,22 @@ const XlsxPreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
           try {
             return { name, html: XLSX.utils.sheet_to_html(ws, { header: '', footer: '' }) };
           } catch (cellErr) {
-            return { name, html: `<p style="color:#888;font-style:italic">Could not render sheet: ${(cellErr as Error).message}</p>` };
+            return { name, html: `<p style="color:#888;font-style:italic">${t('inspector.preview.couldNotRenderSheet', { error: (cellErr as Error).message })}</p>` };
           }
         });
         if (cancelled) return;
         setSheets(out);
       } catch (e) {
         if (cancelled) return;
-        setError(e instanceof Error ? e.message : 'Could not load workbook');
+        setError(e instanceof Error ? e.message : t('inspector.preview.couldNotLoadWorkbook'));
       } finally {
         if (!cancelled) setBusy(false);
       }
     })();
     return () => { cancelled = true; };
-  }, [url]);
-  if (urlLoading || busy) return <PreviewBox><PreviewMute>Rendering Excel workbook…</PreviewMute></PreviewBox>;
-  if (error) return <PreviewBox><PreviewMute>Could not preview: {error}</PreviewMute></PreviewBox>;
+  }, [url, t]);
+  if (urlLoading || busy) return <PreviewBox><PreviewMute>{t('inspector.preview.renderingExcel')}</PreviewMute></PreviewBox>;
+  if (error) return <PreviewBox><PreviewMute>{t('inspector.preview.couldNotPreview', { error })}</PreviewMute></PreviewBox>;
   if (!sheets || sheets.length === 0) return null;
   const current = sheets[Math.min(activeSheet, sheets.length - 1)];
   return (
@@ -615,6 +623,7 @@ const XlsxPreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
 // we sandbox it inside an iframe via srcdoc so its scripts (three.js loader)
 // can't touch the host page.
 const PptxPreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
+  const { t } = useTranslation();
   const [html, setHtml] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -652,18 +661,18 @@ const PptxPreview: React.FC<{ artifact: PreviewArtifact }> = ({ artifact }) => {
         }
       } catch (e) {
         if (cancelled) return;
-        setError(e instanceof Error ? e.message : 'Could not render preview');
+        setError(e instanceof Error ? e.message : t('inspector.preview.couldNotRenderPreview'));
       } finally {
         if (!cancelled) setBusy(false);
       }
     })();
     return () => { cancelled = true; };
-  }, [artifact.fileName]);
-  if (busy) return <PreviewBox><PreviewMute>Rendering PowerPoint deck…</PreviewMute></PreviewBox>;
-  if (error) return <PreviewBox><PreviewMute>Could not preview: {error}</PreviewMute></PreviewBox>;
+  }, [artifact.fileName, t]);
+  if (busy) return <PreviewBox><PreviewMute>{t('inspector.preview.renderingPowerpoint')}</PreviewMute></PreviewBox>;
+  if (error) return <PreviewBox><PreviewMute>{t('inspector.preview.couldNotPreview', { error })}</PreviewMute></PreviewBox>;
   // Empty string == zero-slide deck (set above); render the same placeholder
   // shape DocxPreview/XlsxPreview use for genuinely-empty deliverables.
-  if (html === '') return <PreviewBox><PreviewMute>Empty deck</PreviewMute></PreviewBox>;
+  if (html === '') return <PreviewBox><PreviewMute>{t('inspector.preview.emptyDeck')}</PreviewMute></PreviewBox>;
   if (!html) return null;
   return (
     <PreviewBox>
@@ -762,20 +771,21 @@ const resolveRuntimeBadge = (
   return { ...identity, isByo: isByo || type === 'local-cli' };
 };
 
-const memberRoleLabel = (
+const memberRoleKey = (
   member: { _id?: string; isBot?: boolean },
   ownerId: string | undefined,
   isAgent: boolean,
-): 'Owner' | 'Human' | 'AI Agent' => {
-  if (ownerId && member._id === ownerId) return 'Owner';
-  if (isAgent || member.isBot) return 'AI Agent';
-  return 'Human';
+): 'owner' | 'human' | 'aiAgent' => {
+  if (ownerId && member._id === ownerId) return 'owner';
+  if (isAgent || member.isBot) return 'aiAgent';
+  return 'human';
 };
 
 const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   detail, podsState, view, onClose, onOpenMember, onOpenArtifact, onBack, onOpenInvite,
   pendingOpenFileName, onPendingOpenFileNameConsumed,
 }) => {
+  const { t } = useTranslation();
   const { pod, members, agents } = detail;
   const api = useV2Api();
   const navigate = useNavigate();
@@ -837,8 +847,8 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
     // memo doesn't throw before render. (The Inspector renders a loading
     // shell when `pod` is null; we just need the memo to not crash.)
     const raw = pod?.createdBy?.username || '';
-    return agentDisplayByUsername.get(raw.toLowerCase()) || raw || 'unknown';
-  }, [pod?.createdBy?.username, agentDisplayByUsername]);
+    return agentDisplayByUsername.get(raw.toLowerCase()) || raw || t('inspector.unknown');
+  }, [pod?.createdBy?.username, agentDisplayByUsername, t]);
 
   // Set of usernames that map to an installed agent — used to filter the
   // members[] list down to actual humans. The backend's `User.isBot` flag
@@ -1028,7 +1038,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   const agentCount = agents.length;
   const created = pod.createdAt ? new Date(pod.createdAt).toLocaleDateString([], {
     month: 'short', day: 'numeric',
-  }) : 'unknown';
+  }) : t('inspector.unknown');
   const ownerId = pod.createdBy?._id;
 
   const openPrivatePod = async (agent: V2Agent) => {
@@ -1041,16 +1051,16 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
       });
       const roomId = data.room?._id;
       if (roomId) navigate(`/v2/pods/${roomId}`);
-      else setPrivateError('Private pod could not be opened for this agent.');
+      else setPrivateError(t('inspector.errors.privatePodNotOpenedForAgent'));
     } catch (err) {
       const e = err as { response?: { data?: { message?: string; error?: string; msg?: string } }; message?: string };
-      setPrivateError(e.response?.data?.message || e.response?.data?.error || e.response?.data?.msg || e.message || 'Private pod could not be opened.');
+      setPrivateError(e.response?.data?.message || e.response?.data?.error || e.response?.data?.msg || e.message || t('inspector.errors.privatePodNotOpened'));
     }
   };
 
   const handleDeletePod = async () => {
     if (!podsState || !pod) return;
-    const confirmed = window.confirm(`Delete "${pod.name}"? This removes the pod and its messages.`);
+    const confirmed = window.confirm(t('inspector.confirmDeletePod', { name: pod.name }));
     if (!confirmed) return;
     const deleted = await podsState.deletePod(pod._id);
     if (deleted) navigate('/v2', { replace: true });
@@ -1067,7 +1077,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   const nowSection = nowAgent && nowTask && (
     <section className="v2-inspector__section">
       <div className="v2-inspector__now">
-        <div className="v2-inspector__now-eyebrow">NOW</div>
+        <div className="v2-inspector__now-eyebrow">{t('inspector.now')}</div>
         <div className="v2-inspector__now-title">
           <span className="v2-inspector__now-pulse" />
           {(nowAgent.profile?.displayName || nowAgent.displayName || nowAgent.agentName)}
@@ -1075,7 +1085,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
           {nowTask.title}
         </div>
         <div className="v2-inspector__now-meta">
-          Status: {nowTask.status.replace('_', ' ')}
+          {t('inspector.statusLabel', { status: nowTask.status.replace('_', ' ') })}
         </div>
       </div>
     </section>
@@ -1089,10 +1099,10 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   const progressPct = totalTasks > 0 ? Math.round((runState.complete / totalTasks) * 100) : 0;
   const progressSection = totalTasks > 0 && (
     <section className="v2-inspector__section">
-      <div className="v2-inspector__section-title">Progress</div>
+      <div className="v2-inspector__section-title">{t('inspector.progress.title')}</div>
       <div className="v2-inspector__progress-row">
         <span className="v2-inspector__progress-stat">
-          {runState.complete} of {totalTasks} task{totalTasks === 1 ? '' : 's'} complete
+          {t('inspector.progress.stat', { complete: runState.complete, total: totalTasks, count: totalTasks })}
         </span>
         <span className="v2-inspector__progress-pct">{progressPct}%</span>
       </div>
@@ -1107,9 +1117,9 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   // ------------------------------------------------------------------
   const goalSection = (
     <section className="v2-inspector__section">
-      <div className="v2-inspector__section-title">Goal</div>
+      <div className="v2-inspector__section-title">{t('inspector.goal.title')}</div>
       <div className="v2-inspector__goal-text">
-        {pod.description?.trim() || <span className="v2-mute">No goal set yet.</span>}
+        {pod.description?.trim() || <span className="v2-mute">{t('inspector.goal.empty')}</span>}
       </div>
     </section>
   );
@@ -1122,12 +1132,12 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
     ...announcements.map((a) => ({
       id: `ann-${a._id}`,
       kind: 'Announcement',
-      title: a.title || a.content || 'Untitled announcement',
+      title: a.title || a.content || t('inspector.untitledAnnouncement'),
     })),
     ...externalLinks.map((l) => ({
       id: `link-${l._id}`,
       kind: l.type || 'other_link',
-      title: l.name || l.url || 'External link',
+      title: l.name || l.url || t('inspector.externalLink'),
       subtitle: l.url,
       url: l.url,
     })),
@@ -1158,7 +1168,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
       setAddLinkOpen(false);
     } catch (err) {
       const e = err as { response?: { data?: { message?: string } }; message?: string };
-      setAddLinkError(e.response?.data?.message || e.message || 'Could not add link.');
+      setAddLinkError(e.response?.data?.message || e.message || t('inspector.errors.couldNotAddLink'));
     } finally {
       setAddLinkBusy(false);
     }
@@ -1167,7 +1177,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   const artifactsSection = (
     <section className="v2-inspector__section">
       <div className="v2-inspector__section-head">
-        <div className="v2-inspector__section-title">Artifacts</div>
+        <div className="v2-inspector__section-title">{t('inspector.artifacts.title')}</div>
         <button
           type="button"
           className="v2-inspector__link"
@@ -1177,7 +1187,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
           }}
           aria-expanded={addLinkOpen}
         >
-          {addLinkOpen ? 'Cancel' : '+ Add'}
+          {addLinkOpen ? t('inspector.actions.cancel') : t('inspector.artifacts.add')}
         </button>
       </div>
       {addLinkOpen && (
@@ -1197,7 +1207,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
                 void handleAddLinkSubmit();
               }
             }}
-            placeholder="Paste a Notion, Google Doc, Figma, GitHub, Zoom URL…"
+            placeholder={t('inspector.artifacts.urlPlaceholder')}
             autoFocus
             disabled={addLinkBusy}
             style={{
@@ -1230,7 +1240,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
                 cursor: 'pointer',
               }}
             >
-              Cancel
+              {t('inspector.actions.cancel')}
             </button>
             <button
               type="button"
@@ -1247,13 +1257,13 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
                 cursor: addLinkBusy || !addLinkUrl.trim() ? 'not-allowed' : 'pointer',
               }}
             >
-              {addLinkBusy ? 'Adding…' : 'Add'}
+              {addLinkBusy ? t('inspector.artifacts.adding') : t('inspector.artifacts.addShort')}
             </button>
           </div>
         </div>
       )}
       {artifactItems.length === 0 && !addLinkOpen ? (
-        <div className="v2-inspector__empty">No artifacts yet — share Notion, Sheets, or Figma links and they&apos;ll appear here.</div>
+        <div className="v2-inspector__empty">{t('inspector.artifacts.empty')}</div>
       ) : artifactItems.length > 0 && (
         <div className="v2-inspector__artifacts">
           {artifactItems.map((a) => {
@@ -1286,25 +1296,25 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
             type="button"
             className="v2-inspector__action v2-inspector__action--primary"
             onClick={onOpenInvite}
-            title="Invite people or add an agent to this pod"
+            title={t('inspector.members.inviteTitle')}
           >
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
               <path d="M12 5v14M5 12h14" />
             </svg>
-            Invite
+            {t('inspector.members.invite')}
           </button>
         )}
         <button
           type="button"
           className="v2-inspector__action"
           onClick={() => navigate(`/v2/agents?podId=${pod._id}`)}
-          title="Manage agents installed in this pod"
+          title={t('inspector.members.manageTitle')}
         >
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
             <circle cx="12" cy="12" r="3" />
             <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 11-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 11-4 0v-.09a1.65 1.65 0 00-1-1.51 1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 11-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 110-4h.09a1.65 1.65 0 001.51-1 1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 112.83-2.83l.06.06a1.65 1.65 0 001.82.33h0a1.65 1.65 0 001-1.51V3a2 2 0 114 0v.09a1.65 1.65 0 001 1.51h0a1.65 1.65 0 001.82-.33l.06-.06a2 2 0 112.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82v0a1.65 1.65 0 001.51 1H21a2 2 0 110 4h-.09a1.65 1.65 0 00-1.51 1z" />
           </svg>
-          Manage
+          {t('inspector.members.manage')}
         </button>
       </div>
       {privateError && <div className="v2-chat__error" style={{ marginBottom: 8 }}>{privateError}</div>}
@@ -1330,17 +1340,17 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
             <span className="v2-inspector__member-meta">
               <span className="v2-inspector__member-name">{name}</span>
               <span className="v2-inspector__member-role">
-                {agent.category ? `${agent.category} · AI Agent` : 'AI Agent'}
+                {agent.category ? `${agent.category} · ${t('inspector.aiAgent')}` : t('inspector.aiAgent')}
               </span>
             </span>
             {badge && (
               <span
                 className="v2-runtime-row"
-                title={`${badge.label}${badge.isByo ? ' · BYO (you run it)' : ''}`}
-                aria-label={`${badge.label} runtime${badge.isByo ? ', BYO' : ''}`}
+                title={badge.isByo ? t('inspector.runtime.rowTitleByo', { label: badge.label }) : badge.label}
+                aria-label={badge.isByo ? t('inspector.runtime.rowAriaByo', { label: badge.label }) : t('inspector.runtime.rowAria', { label: badge.label })}
               >
                 <span className="v2-runtime-row__label">{badge.label}</span>
-                {badge.isByo && <span className="v2-runtime-row__byo" aria-hidden>BYO</span>}
+                {badge.isByo && <span className="v2-runtime-row__byo" aria-hidden>{t('inspector.runtime.byo')}</span>}
               </span>
             )}
             {isOnline && <span className="v2-online-dot" style={{ background: 'var(--v2-success)' }} />}
@@ -1348,38 +1358,38 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
         );
       })}
       {humanMembers.map((member) => {
-        const role = memberRoleLabel(member, ownerId, false);
+        const roleKey = memberRoleKey(member, ownerId, false);
         return (
           <div key={`human-${member._id}`} className="v2-inspector__member-row v2-inspector__member-row--static">
-            <V2Avatar name={member.username || 'Unknown'} src={member.profilePicture || undefined} size="md" />
+            <V2Avatar name={member.username || t('inspector.unknownUser')} src={member.profilePicture || undefined} size="md" />
             <span className="v2-inspector__member-meta">
               <span className="v2-inspector__member-name">{member.username}</span>
-              <span className="v2-inspector__member-role">{role}</span>
+              <span className="v2-inspector__member-role">{t(`inspector.roles.${roleKey}`)}</span>
             </span>
           </div>
         );
       })}
       {agents.length === 0 && humanCount === 0 && (
-        <div className="v2-inspector__empty">No members yet.</div>
+        <div className="v2-inspector__empty">{t('inspector.members.empty')}</div>
       )}
     </section>
   );
 
   const runStateSection = (
     <section className="v2-inspector__section">
-      <div className="v2-inspector__section-title">Run state</div>
+      <div className="v2-inspector__section-title">{t('inspector.runState.title')}</div>
       <div className="v2-inspector__runstate">
         <div className="v2-inspector__runstate-row">
-          <span className="v2-inspector__runstate-label">{runState.blocked} blocked</span>
-          <span className="v2-inspector__pill v2-inspector__pill--blocked">Blocked</span>
+          <span className="v2-inspector__runstate-label">{t('inspector.runState.blockedCount', { count: runState.blocked })}</span>
+          <span className="v2-inspector__pill v2-inspector__pill--blocked">{t('inspector.runState.blocked')}</span>
         </div>
         <div className="v2-inspector__runstate-row">
-          <span className="v2-inspector__runstate-label">{runState.inProgress + runState.pending} in progress</span>
-          <span className="v2-inspector__pill v2-inspector__pill--progress">In Progress</span>
+          <span className="v2-inspector__runstate-label">{t('inspector.runState.inProgressCount', { count: runState.inProgress + runState.pending })}</span>
+          <span className="v2-inspector__pill v2-inspector__pill--progress">{t('inspector.runState.inProgress')}</span>
         </div>
         <div className="v2-inspector__runstate-row">
-          <span className="v2-inspector__runstate-label">{runState.complete} complete</span>
-          <span className="v2-inspector__pill v2-inspector__pill--complete">Complete</span>
+          <span className="v2-inspector__runstate-label">{t('inspector.runState.completeCount', { count: runState.complete })}</span>
+          <span className="v2-inspector__pill v2-inspector__pill--complete">{t('inspector.runState.complete')}</span>
         </div>
       </div>
       {(runState.blocked + runState.inProgress + runState.pending + runState.complete) > 0 ? (
@@ -1394,24 +1404,24 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
             className="v2-inspector__link v2-inspector__link--block"
             onClick={() => navigate(`/v2/pods/${pod.type || 'chat'}/${pod._id}`)}
           >
-            View run board
+            {t('inspector.runState.viewRunBoard')}
           </button>
           {recentTasks.length > 0 && (
             <div className="v2-inspector__task-list">
-              <div className="v2-inspector__section-subtitle">Recent tasks</div>
-              {recentTasks.map((t) => {
-                const isDone = t.status === 'done' || t.status === 'completed';
-                const isBlocked = t.status === 'blocked';
+              <div className="v2-inspector__section-subtitle">{t('inspector.runState.recentTasks')}</div>
+              {recentTasks.map((task) => {
+                const isDone = task.status === 'done' || task.status === 'completed';
+                const isBlocked = task.status === 'blocked';
                 const pillClass = isDone
                   ? 'v2-inspector__pill v2-inspector__pill--complete'
                   : isBlocked
                     ? 'v2-inspector__pill v2-inspector__pill--blocked'
                     : 'v2-inspector__pill v2-inspector__pill--progress';
-                const pillLabel = isDone ? 'Done' : isBlocked ? 'Blocked' : 'Active';
-                const assignee = t.assignee ? `@${t.assignee}` : null;
+                const pillLabel = isDone ? t('inspector.taskPill.done') : isBlocked ? t('inspector.taskPill.blocked') : t('inspector.taskPill.active');
+                const assignee = task.assignee ? `@${task.assignee}` : null;
                 return (
-                  <div key={t.taskId} className="v2-inspector__task-row">
-                    <div className="v2-inspector__task-title" title={t.title}>{t.title}</div>
+                  <div key={task.taskId} className="v2-inspector__task-row">
+                    <div className="v2-inspector__task-title" title={task.title}>{task.title}</div>
                     <div className="v2-inspector__task-meta">
                       {assignee && <span className="v2-inspector__task-assignee">{assignee}</span>}
                       <span className={pillClass}>{pillLabel}</span>
@@ -1424,7 +1434,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
         </>
       ) : (
         <div className="v2-inspector__empty" style={{ marginTop: 12 }}>
-          No tasks yet. Agents will create tasks here as they work — or @-mention one with a request.
+          {t('inspector.runState.empty')}
         </div>
       )}
     </section>
@@ -1438,7 +1448,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
     const agent = agentByKey.get(agentKey);
     if (!agent) {
       return (
-        <div className="v2-inspector__empty">Member not found.</div>
+        <div className="v2-inspector__empty">{t('inspector.memberNotFound')}</div>
       );
     }
     const name = agent.profile?.displayName || agent.displayName || agent.agentName;
@@ -1461,17 +1471,17 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
           <div className="v2-inspector__detail-name">{name}</div>
           <div className="v2-inspector__detail-sub">
             <span className="v2-online-dot" style={{ background: isOnline ? 'var(--v2-success)' : 'var(--v2-text-muted)' }} />
-            {isOnline ? 'Online' : 'Idle'} · {agent.category ? `${agent.category} · AI Agent` : 'AI Agent'}
+            {isOnline ? t('inspector.online') : t('inspector.idle')} · {agent.category ? `${agent.category} · ${t('inspector.aiAgent')}` : t('inspector.aiAgent')}
           </div>
           {badge && (
             <div className="v2-inspector__detail-runtime">
-              <span className="v2-runtime-pill" aria-label={`${badge.label} runtime${badge.isByo ? ', BYO' : ''}`}>
+              <span className="v2-runtime-pill" aria-label={badge.isByo ? t('inspector.runtime.rowAriaByo', { label: badge.label }) : t('inspector.runtime.rowAria', { label: badge.label })}>
                 <span className="v2-runtime-pill__mono">{badge.mono}</span>
                 <span className="v2-runtime-pill__label">{badge.label}</span>
               </span>
               {badge.isByo && (
-                <span className="v2-runtime-host" title="BYO — you run this agent (laptop, server, anywhere)">
-                  BYO
+                <span className="v2-runtime-host" title={t('inspector.runtime.byoHostTitle')}>
+                  {t('inspector.runtime.byo')}
                 </span>
               )}
             </div>
@@ -1484,7 +1494,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
               className="v2-inspector__btn v2-inspector__btn--primary"
               onClick={() => openPrivatePod(agent)}
             >
-              Talk to {name}
+              {t('inspector.talkTo', { name })}
             </button>
           )}
           <button
@@ -1492,25 +1502,25 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
             className="v2-inspector__btn"
             onClick={() => navigate(`/v2/agents?podId=${pod._id}&agent=${encodeURIComponent(agentKeyOf(agent))}`)}
           >
-            Manage
+            {t('inspector.members.manage')}
           </button>
         </div>
         {privateError && <div className="v2-chat__error" style={{ marginTop: 8 }}>{privateError}</div>}
         {task && (
           <div className="v2-inspector__detail-card">
-            <div className="v2-inspector__detail-kicker">Working on</div>
+            <div className="v2-inspector__detail-kicker">{t('inspector.detail.workingOn')}</div>
             <div className="v2-inspector__detail-body">{task.title}</div>
           </div>
         )}
         {purpose && (
           <div className="v2-inspector__detail-card">
-            <div className="v2-inspector__detail-kicker">Purpose</div>
+            <div className="v2-inspector__detail-kicker">{t('inspector.detail.purpose')}</div>
             <div className="v2-inspector__detail-body">{purpose}</div>
           </div>
         )}
         {specialties.length > 0 && (
           <div className="v2-inspector__detail-card">
-            <div className="v2-inspector__detail-kicker">Specialties</div>
+            <div className="v2-inspector__detail-kicker">{t('inspector.detail.specialties')}</div>
             <div className="v2-inspector__chip-row">
               {specialties.map((s) => <span key={s} className="v2-inspector__chip">{s}</span>)}
             </div>
@@ -1522,17 +1532,17 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
           if (list.length === 0) return null;
           return (
             <div className="v2-inspector__detail-card">
-              <div className="v2-inspector__detail-kicker">Direct messages</div>
+              <div className="v2-inspector__detail-kicker">{t('inspector.detail.directMessages')}</div>
               <div className="v2-inspector__dm-list">
                 {list.map((dm) => {
-                  const peer = dm.otherMember?.displayName || 'peer';
+                  const peer = dm.otherMember?.displayName || t('inspector.detail.peer');
                   return (
                     <button
                       key={dm.podId}
                       type="button"
                       className="v2-inspector__dm-row"
                       onClick={() => navigate(`/v2/pods/${dm.podId}`)}
-                      title={`Open ${name} ↔ ${peer}`}
+                      title={t('inspector.detail.openDm', { name, peer })}
                     >
                       <span className="v2-inspector__dm-name">{name} ↔ {peer}</span>
                       <span className="v2-inspector__dm-arrow" aria-hidden="true">→</span>
@@ -1566,7 +1576,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   const renderArtifactDetail = (artifactId: string) => {
     const found = artifactItems.find((a) => a.id === artifactId);
     if (!found) {
-      return <div className="v2-inspector__empty">Artifact not found.</div>;
+      return <div className="v2-inspector__empty">{t('inspector.artifactNotFound')}</div>;
     }
     const meta = artifactMeta(found.kind);
     const openable = !!found.fileName || !!safeHref(found.url);
@@ -1594,13 +1604,13 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
               className="v2-inspector__btn v2-inspector__btn--primary"
               onClick={() => { void handleOpenArtifact(found); }}
             >
-              Open
+              {t('inspector.actions.open')}
             </button>
           </div>
         )}
         {found.subtitle && (
           <div className="v2-inspector__detail-card">
-            <div className="v2-inspector__detail-kicker">{found.fileName ? 'Type' : 'Source'}</div>
+            <div className="v2-inspector__detail-kicker">{found.fileName ? t('inspector.detail.type') : t('inspector.detail.source')}</div>
             <div className="v2-inspector__detail-body" style={{ wordBreak: 'break-all' }}>{found.subtitle}</div>
           </div>
         )}
@@ -1615,8 +1625,8 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   const heading = isOverview
     ? pod.name
     : view.kind === 'member'
-      ? 'Member'
-      : 'Artifact';
+      ? t('inspector.heading.member')
+      : t('inspector.heading.artifact');
 
   return (
     <aside className="v2-pane v2-pane--inspector">
@@ -1627,10 +1637,10 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
               type="button"
               className="v2-inspector__back"
               onClick={onBack}
-              aria-label="Back to overview"
+              aria-label={t('inspector.backToOverview')}
             >
               <Icon d="M15 18l-6-6 6-6" size={16} />
-              Back
+              {t('inspector.back')}
             </button>
           )}
           {isOverview && (
@@ -1639,10 +1649,10 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
               <div className="v2-inspector__pod-block">
                 <div className="v2-inspector__pod-name" title={pod.name}>{pod.name}</div>
                 <div className="v2-inspector__pod-meta">
-                  Created by {createdByDisplay} · {created}
+                  {t('inspector.createdByMeta', { name: createdByDisplay, date: created })}
                 </div>
                 <div className="v2-inspector__pod-meta">
-                  {!isPrivatePod && <>{agentCount} agent{agentCount === 1 ? '' : 's'} · </>}{humanCount} human{humanCount === 1 ? '' : 's'}
+                  {!isPrivatePod && <>{t('inspector.agentCount', { count: agentCount })} · </>}{t('inspector.humanCount', { count: humanCount })}
                 </div>
               </div>
             </div>
@@ -1655,8 +1665,8 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
               type="button"
               className="v2-inspector__close"
               onClick={onClose}
-              title="Hide pod team"
-              aria-label="Hide pod team"
+              title={t('inspector.hidePodTeam')}
+              aria-label={t('inspector.hidePodTeam')}
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <line x1="6" y1="6" x2="18" y2="18" />
@@ -1668,7 +1678,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
         <div className="v2-inspector__body">
           {view.kind === 'overview' && (
             <>
-              <div className="v2-inspector__tabs" role="tablist" aria-label="Inspector sections">
+              <div className="v2-inspector__tabs" role="tablist" aria-label={t('inspector.tabs.ariaLabel')}>
                 <button
                   type="button"
                   role="tab"
@@ -1676,7 +1686,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
                   className={`v2-inspector__tab${tab === 'overview' ? ' v2-inspector__tab--active' : ''}`}
                   onClick={() => setTab('overview')}
                 >
-                  Overview
+                  {t('inspector.tabs.overview')}
                 </button>
                 {!isPrivatePod && (
                   <button
@@ -1686,7 +1696,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
                     className={`v2-inspector__tab${tab === 'members' ? ' v2-inspector__tab--active' : ''}`}
                     onClick={() => setTab('members')}
                   >
-                    Members
+                    {t('inspector.tabs.members')}
                     <span className="v2-inspector__tab-count">{agentCount + humanCount}</span>
                   </button>
                 )}
@@ -1697,7 +1707,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
                   className={`v2-inspector__tab${tab === 'tasks' ? ' v2-inspector__tab--active' : ''}`}
                   onClick={() => setTab('tasks')}
                 >
-                  Tasks
+                  {t('inspector.tabs.tasks')}
                   {(runState.blocked + runState.inProgress + runState.pending) > 0 && (
                     <span className="v2-inspector__tab-count">
                       {runState.blocked + runState.inProgress + runState.pending}
@@ -1711,7 +1721,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
                   className={`v2-inspector__tab${tab === 'manage' ? ' v2-inspector__tab--active' : ''}`}
                   onClick={() => setTab('manage')}
                 >
-                  Manage
+                  {t('inspector.tabs.manage')}
                 </button>
               </div>
 
@@ -1724,23 +1734,23 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
                 </>
               )}
               {tab === 'members' && (
-                <>{membersSection || <div className="v2-inspector__empty">Members are not shown for direct pods.</div>}</>
+                <>{membersSection || <div className="v2-inspector__empty">{t('inspector.members.notShownForDirect')}</div>}</>
               )}
               {tab === 'tasks' && runStateSection}
               {tab === 'manage' && (
                 <>
                   {podsState && (
                     <section className="v2-inspector__section v2-inspector__danger">
-                      <div className="v2-inspector__danger-title">Danger zone</div>
+                      <div className="v2-inspector__danger-title">{t('inspector.danger.title')}</div>
                       <div className="v2-inspector__danger-text">
-                        Deleting this pod removes all messages, tasks, and artifacts. This cannot be undone.
+                        {t('inspector.danger.text')}
                       </div>
                       <button
                         type="button"
                         className="v2-inspector__btn v2-inspector__btn--danger"
                         onClick={handleDeletePod}
                       >
-                        Delete pod
+                        {t('inspector.danger.deletePod')}
                       </button>
                     </section>
                   )}

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { UseV2PodsResult, V2Pod, useV2Pods } from '../hooks/useV2Pods';
 import { groupPods, formatRelativeTime } from '../utils/grouping';
@@ -10,10 +11,10 @@ import { useAuth } from '../../context/AuthContext';
 
 type Filter = 'all' | 'team' | 'private';
 
-const FILTERS: Array<{ key: Filter; label: string }> = [
-  { key: 'all', label: 'All' },
-  { key: 'team', label: 'Team' },
-  { key: 'private', label: 'Private' },
+const FILTERS: Array<{ key: Filter; labelKey: string }> = [
+  { key: 'all', labelKey: 'filters.all' },
+  { key: 'team', labelKey: 'filters.team' },
+  { key: 'private', labelKey: 'filters.private' },
 ];
 
 // Both agent-room (user↔agent) and agent-dm (any 2-member combo) show
@@ -89,6 +90,7 @@ interface V2PodsSidebarProps {
 const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
   selectedPodId, podsState, mobileOpen = false, onMobileClose,
 }) => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const ownPodsState = useV2Pods();
   const { pods, loading, error, createPod, patchLastMessage } = podsState || ownPodsState;
@@ -271,11 +273,11 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
     const a2a = rest.filter((p) => isAgentToAgent(p));
     const dms = rest.filter((p) => !isAgentToAgent(p));
     const buckets: Array<{ label: string; items: typeof filtered }> = [];
-    if (pinnedItems.length) buckets.push({ label: 'Pinned', items: sortByRecency(pinnedItems) });
-    if (dms.length) buckets.push({ label: 'Direct messages', items: sortByRecency(dms) });
-    if (a2a.length) buckets.push({ label: `Between agents · ${a2a.length}`, items: sortByRecency(a2a) });
+    if (pinnedItems.length) buckets.push({ label: t('podsSidebar.groups.pinned'), items: sortByRecency(pinnedItems) });
+    if (dms.length) buckets.push({ label: t('podsSidebar.groups.directMessages'), items: sortByRecency(dms) });
+    if (a2a.length) buckets.push({ label: t('podsSidebar.groups.betweenAgents', { count: a2a.length }), items: sortByRecency(a2a) });
     return buckets;
-  }, [filter, filtered, pinned]);
+  }, [filter, filtered, pinned, t]);
 
   // Navigate to a pod and, on mobile, dismiss the slide-over drawer so the
   // user lands directly in the chat instead of behind the overlay.
@@ -298,7 +300,7 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
         setShowCreate(false);
         selectPod(pod._id);
       } else {
-        setCreateError('Unable to create pod. Check that you are signed in and try again.');
+        setCreateError(t('podsSidebar.errors.createFailed'));
       }
     } finally {
       setCreating(false);
@@ -310,13 +312,13 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
       <div className="v2-pods">
         <div className="v2-pods__header">
           <div className="v2-pods__title">
-            Pods
+            {t('podsSidebar.title')}
             <button
               type="button"
               className="v2-pods__mobile-close"
               onClick={() => onMobileClose?.()}
-              title="Close pods"
-              aria-label="Close pods list"
+              title={t('podsSidebar.closeTitle')}
+              aria-label={t('podsSidebar.closeAriaLabel')}
             >
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M18 6L6 18M6 6l12 12" />
@@ -335,20 +337,20 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
               <path d="M12 5v14M5 12h14" />
             </svg>
-            New Pod
+            {t('podsSidebar.newPod')}
           </button>
           {showCreate && (
             <form className="v2-pods__create" onSubmit={handleCreatePod}>
               <div className="v2-pods__create-options">
                 <button type="button" className="v2-pods__create-option v2-pods__create-option--active">
-                  Create Team Pod
+                  {t('podsSidebar.create.teamOption')}
                 </button>
                 <button
                   type="button"
                   className="v2-pods__create-option"
-                  onClick={() => setCreateError('Start a Private pod from an agent row or existing private conversation.')}
+                  onClick={() => setCreateError(t('podsSidebar.create.privateHint'))}
                 >
-                  Start Private Pod
+                  {t('podsSidebar.create.privateOption')}
                 </button>
               </div>
               <input
@@ -356,7 +358,7 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
                 type="text"
                 value={newPodName}
                 onChange={(e) => setNewPodName(e.target.value)}
-                placeholder="Pod name"
+                placeholder={t('podsSidebar.create.namePlaceholder')}
                 autoFocus
               />
               <input
@@ -364,7 +366,7 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
                 type="text"
                 value={newPodGoal}
                 onChange={(e) => setNewPodGoal(e.target.value)}
-                placeholder="Goal or description"
+                placeholder={t('podsSidebar.create.goalPlaceholder')}
               />
               {createError && <div className="v2-pods__create-error">{createError}</div>}
               <div className="v2-pods__create-actions">
@@ -376,14 +378,14 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
                     setCreateError(null);
                   }}
                 >
-                  Cancel
+                  {t('podsSidebar.create.cancel')}
                 </button>
                 <button
                   type="submit"
                   className="v2-pods__create-submit"
                   disabled={creating || !newPodName.trim()}
                 >
-                  {creating ? 'Creating...' : 'Create'}
+                  {creating ? t('podsSidebar.create.creating') : t('podsSidebar.create.submit')}
                 </button>
               </div>
             </form>
@@ -398,14 +400,14 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
             <input
               type="text"
               className="v2-pods__search-input"
-              placeholder="Search pods..."
+              placeholder={t('podsSidebar.searchPlaceholder')}
               value={search}
               onChange={(e) => setSearch(e.target.value)}
             />
           </div>
         </div>
 
-        <div className="v2-pods__filters v2-filter-segment" aria-label="Pod filters">
+        <div className="v2-pods__filters v2-filter-segment" aria-label={t('podsSidebar.filtersAriaLabel')}>
           {FILTERS.map((f) => (
             <button
               key={f.key}
@@ -414,7 +416,7 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
               onClick={() => setFilter(f.key)}
               aria-pressed={filter === f.key}
             >
-              {f.label}
+              {t(`podsSidebar.${f.labelKey}`)}
               <span className="v2-filter-count">{filterCounts[f.key]}</span>
             </button>
           ))}
@@ -425,7 +427,7 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
           {!loading && error && <div className="v2-pods__empty">{error}</div>}
           {!loading && !error && filtered.length === 0 && (
             <div className="v2-pods__empty">
-              {search ? 'No pods match your search.' : 'No pods yet. Create one to get started.'}
+              {search ? t('podsSidebar.empty.noMatch') : t('podsSidebar.empty.noPods')}
             </div>
           )}
 
@@ -438,10 +440,10 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
                 const time = formatRelativeTime(pod.lastMessage?.createdAt || pod.updatedAt || pod.createdAt);
                 const active = pod._id === selectedPodId;
                 const meta = podKind(pod) === 'private'
-                  ? 'Direct message'
+                  ? t('podsSidebar.meta.directMessage')
                   : (agentCount > 0
-                    ? `${agentCount} agent${agentCount === 1 ? '' : 's'}`
-                    : `${memberCount} member${memberCount === 1 ? '' : 's'}`);
+                    ? t('podsSidebar.meta.agentCount', { count: agentCount })
+                    : t('podsSidebar.meta.memberCount', { count: memberCount }));
                 const snippet = podSnippetFor(pod, meta);
                 const pinnedNow = isPinned(pod._id);
                 const typing = typingPods.has(pod._id);
@@ -462,11 +464,11 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
                       <span className="v2-pods__item-body">
                         <span className="v2-pods__item-title-row">
                           <span className="v2-pods__item-title">{pod.name}</span>
-                          {unread && <span className="v2-pods__item-dot" aria-label="Unread messages" />}
+                          {unread && <span className="v2-pods__item-dot" aria-label={t('podsSidebar.unreadAriaLabel')} />}
                           <span className="v2-pods__item-time">{time}</span>
                         </span>
                         <span className={`v2-pods__item-snippet${typing ? ' v2-pods__item-snippet--typing' : ''}`}>
-                          {typing ? 'typing…' : snippet}
+                          {typing ? t('podsSidebar.typing') : snippet}
                         </span>
                       </span>
                     </button>
@@ -474,8 +476,8 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
                       type="button"
                       className={`v2-pods__pin${pinnedNow ? ' v2-pods__pin--active' : ''}`}
                       onClick={() => togglePin(pod._id)}
-                      title={pinnedNow ? 'Unpin' : 'Pin'}
-                      aria-label={pinnedNow ? 'Unpin pod' : 'Pin pod'}
+                      title={pinnedNow ? t('podsSidebar.unpinTitle') : t('podsSidebar.pinTitle')}
+                      aria-label={pinnedNow ? t('podsSidebar.unpinAriaLabel') : t('podsSidebar.pinAriaLabel')}
                       aria-pressed={pinnedNow}
                     >
                       <svg width="14" height="14" viewBox="0 0 24 24" fill={pinnedNow ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -492,10 +494,10 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
         {showCommunityOffer && (
           <section className="v2-pods__community" aria-labelledby="v2-community-offer-title">
             <div id="v2-community-offer-title" className="v2-pods__community-title">
-              Join Commonly HQ
+              {t('podsSidebar.community.title')}
             </div>
             <div className="v2-pods__community-copy">
-              Meet the builders and their agents.
+              {t('podsSidebar.community.copy')}
             </div>
             <button
               type="button"
@@ -505,7 +507,7 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
                 onMobileClose?.();
               }}
             >
-              Join HQ
+              {t('podsSidebar.community.button')}
             </button>
           </section>
         )}

--- a/frontend/src/v2/components/V2YourTeamPage.tsx
+++ b/frontend/src/v2/components/V2YourTeamPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import axios from 'axios';
 import V2Avatar from './V2Avatar';
 import { useAuth } from '../../context/AuthContext';
@@ -24,31 +25,35 @@ interface AgentInstallationSummary {
   podName?: string;
 }
 
-const RUNTIME_LABEL: Record<string, string> = {
-  internal: 'Native',
-  moltbot: 'OpenClaw',
-  webhook: 'Webhook',
-  cli: 'CLI wrapper',
-  managed: 'Cloud sandbox',
+const RUNTIME_LABEL_KEY: Record<string, string> = {
+  internal: 'yourTeam.runtime.native',
+  moltbot: 'yourTeam.runtime.openclaw',
+  webhook: 'yourTeam.runtime.webhook',
+  cli: 'yourTeam.runtime.cli',
+  managed: 'yourTeam.runtime.cloudSandbox',
 };
 
-const formatRuntime = (a: AgentInstallationSummary): string => {
-  const t = a.runtime?.runtimeType;
-  if (!t) return 'Native';
-  return RUNTIME_LABEL[t] || t;
+const formatRuntime = (a: AgentInstallationSummary, t: (key: string) => string): string => {
+  const rt = a.runtime?.runtimeType;
+  if (!rt) return t('yourTeam.runtime.native');
+  const key = RUNTIME_LABEL_KEY[rt];
+  return key ? t(key) : rt;
 };
 
-const formatRelative = (iso?: string | null): string => {
-  if (!iso) return 'No recent activity';
+const formatRelative = (
+  iso: string | null | undefined,
+  t: (key: string, opts?: Record<string, unknown>) => string,
+): string => {
+  if (!iso) return t('yourTeam.activity.noRecent');
   const ms = Date.now() - new Date(iso).getTime();
-  if (Number.isNaN(ms)) return 'No recent activity';
+  if (Number.isNaN(ms)) return t('yourTeam.activity.noRecent');
   const min = Math.floor(ms / 60000);
-  if (min < 1) return 'Just now';
-  if (min < 60) return `${min}m ago`;
+  if (min < 1) return t('yourTeam.activity.justNow');
+  if (min < 60) return t('yourTeam.activity.minutesAgo', { count: min });
   const hr = Math.floor(min / 60);
-  if (hr < 24) return `${hr}h ago`;
+  if (hr < 24) return t('yourTeam.activity.hoursAgo', { count: hr });
   const d = Math.floor(hr / 24);
-  return `${d}d ago`;
+  return t('yourTeam.activity.daysAgo', { count: d });
 };
 
 const dedupeAgents = (agents: AgentInstallationSummary[]): AgentInstallationSummary[] => {
@@ -69,6 +74,7 @@ const dedupeAgents = (agents: AgentInstallationSummary[]): AgentInstallationSumm
 
 const V2YourTeamPage: React.FC = () => {
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const { user } = useAuth();
   // Hosted (cloud) agents require an entitlement the open-registration tier
   // doesn't have. Until the user payload carries an explicit `entitlements`
@@ -118,7 +124,7 @@ const V2YourTeamPage: React.FC = () => {
       setRedeemOpen(false);
     } catch (err: unknown) {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
-      setRedeemError(msg || 'Could not redeem that code.');
+      setRedeemError(msg || t('yourTeam.errors.redeemFailed'));
     } finally {
       setRedeeming(false);
     }
@@ -148,7 +154,7 @@ const V2YourTeamPage: React.FC = () => {
             return (r.data?.agents || []).map((a) => ({
               ...a,
               podId: p._id,
-              podName: p.name || p.title || 'Untitled project',
+              podName: p.name || p.title || t('yourTeam.untitledProject'),
             }));
           } catch {
             return [];
@@ -159,7 +165,7 @@ const V2YourTeamPage: React.FC = () => {
         setAgents(dedupeAgents(flat));
       } catch (e: unknown) {
         if (cancelled) return;
-        const msg = (e as { message?: string })?.message || 'Could not load your team.';
+        const msg = (e as { message?: string })?.message || t('yourTeam.errors.loadFailed');
         setError(msg);
       } finally {
         if (!cancelled) setLoading(false);
@@ -213,7 +219,7 @@ const V2YourTeamPage: React.FC = () => {
       navigate(`/v2/pods/${roomId}`);
     } catch (err: unknown) {
       const resp = (err as { response?: { data?: { message?: string } } })?.response;
-      setError(resp?.data?.message || 'Could not open a 1:1 with this agent — try again.');
+      setError(resp?.data?.message || t('yourTeam.errors.openRoomFailed'));
       setOpening(null);
     }
   };
@@ -222,13 +228,16 @@ const V2YourTeamPage: React.FC = () => {
     <div className="v2-team">
       <header className="v2-team__header">
         <div>
-          <h1 className="v2-team__title">Your Team</h1>
+          <h1 className="v2-team__title">{t('yourTeam.title')}</h1>
           <p className="v2-team__subtitle">
             {loading
-              ? 'Loading…'
+              ? t('yourTeam.loading')
               : sortedAgents.length === 0
-                ? 'No agents yet — hire your first one to get started.'
-                : `${sortedAgents.length} agent${sortedAgents.length === 1 ? '' : 's'} working across ${pods.length} project${pods.length === 1 ? '' : 's'}`}
+                ? t('yourTeam.subtitle.empty')
+                : t('yourTeam.subtitle.summary', {
+                    agents: t('yourTeam.subtitle.agentCount', { count: sortedAgents.length }),
+                    projects: t('yourTeam.subtitle.projectCount', { count: pods.length }),
+                  })}
           </p>
         </div>
         <div className="v2-team__actions">
@@ -237,14 +246,14 @@ const V2YourTeamPage: React.FC = () => {
             className="v2-team__hire-cta"
             onClick={() => navigate(primaryHirePath)}
           >
-            + Hire an agent
+            {t('yourTeam.actions.hire')}
           </button>
           <button
             type="button"
             className="v2-team__byo-cta"
             onClick={() => navigate('/v2/agents/byo')}
           >
-            Connect your own agent
+            {t('yourTeam.actions.connectOwn')}
           </button>
         </div>
       </header>
@@ -256,25 +265,25 @@ const V2YourTeamPage: React.FC = () => {
               <input
                 className="v2-login__input"
                 type="text"
-                placeholder="Invitation code"
+                placeholder={t('yourTeam.redeem.placeholder')}
                 value={redeemCode}
                 onChange={(e) => setRedeemCode(e.target.value)}
                 autoFocus
               />
               <button type="submit" className="v2-team__hire-cta" disabled={redeeming || !redeemCode.trim()}>
-                {redeeming ? 'Unlocking…' : 'Unlock'}
+                {redeeming ? t('yourTeam.redeem.unlocking') : t('yourTeam.redeem.unlock')}
               </button>
               <button type="button" className="v2-team__byo-cta" onClick={() => { setRedeemOpen(false); setRedeemError(null); }}>
-                Cancel
+                {t('yourTeam.actions.cancel')}
               </button>
               {redeemError && <span className="v2-team__redeem-error">{redeemError}</span>}
             </form>
           ) : (
             <span>
-              Hosted agents are invite-gated during beta.
+              {t('yourTeam.redeem.gated')}
               {' '}
               <button type="button" className="v2-team__redeem-link" onClick={() => setRedeemOpen(true)}>
-                Have an invitation code?
+                {t('yourTeam.redeem.haveCode')}
               </button>
             </span>
           )}
@@ -282,7 +291,7 @@ const V2YourTeamPage: React.FC = () => {
       )}
       {redeemed && (
         <div className="v2-team__redeem v2-team__redeem--success">
-          Hosted agents unlocked — hire your first one from the catalog.
+          {t('yourTeam.redeem.success')}
         </div>
       )}
 
@@ -292,10 +301,9 @@ const V2YourTeamPage: React.FC = () => {
 
       {!loading && sortedAgents.length === 0 && !error && (
         <div className="v2-team__empty">
-          <div className="v2-team__empty-title">Build your AI team</div>
+          <div className="v2-team__empty-title">{t('yourTeam.empty.title')}</div>
           <div className="v2-team__empty-text">
-            Agents you hire join your projects, share your project memory, and ship work back to you.
-            Don&apos;t have a hosted agent? Connect your own — Claude Code, Cursor, or Codex — in about two minutes.
+            {t('yourTeam.empty.text')}
           </div>
           <div className="v2-team__empty-actions">
             <button
@@ -303,21 +311,21 @@ const V2YourTeamPage: React.FC = () => {
               className="v2-team__hire-cta"
               onClick={() => navigate(primaryHirePath)}
             >
-              + Hire your first agent
+              {t('yourTeam.empty.hireFirst')}
             </button>
             <button
               type="button"
               className="v2-team__byo-cta"
               onClick={() => navigate('/v2/agents/byo')}
             >
-              Connect your own agent
+              {t('yourTeam.actions.connectOwn')}
             </button>
           </div>
         </div>
       )}
 
       {categories.length > 1 && (
-        <div className="v2-team__tabs" role="tablist" aria-label="Filter by role">
+        <div className="v2-team__tabs" role="tablist" aria-label={t('yourTeam.tabs.ariaLabel')}>
           <button
             type="button"
             role="tab"
@@ -325,7 +333,7 @@ const V2YourTeamPage: React.FC = () => {
             aria-selected={filter === 'all'}
             onClick={() => setFilter('all')}
           >
-            All ({sortedAgents.length})
+            {t('yourTeam.tabs.all', { count: sortedAgents.length })}
           </button>
           {categories.map((cat) => {
             const count = sortedAgents.filter((a) => a.category === cat).length;
@@ -338,7 +346,7 @@ const V2YourTeamPage: React.FC = () => {
                 aria-selected={filter === cat}
                 onClick={() => setFilter(cat)}
               >
-                {cat} ({count})
+                {t('yourTeam.tabs.category', { label: cat, count })}
               </button>
             );
           })}
@@ -348,9 +356,9 @@ const V2YourTeamPage: React.FC = () => {
       <div className="v2-team__grid">
         {filteredAgents.map((a) => {
           const display = a.displayName || a.name;
-          const podLabel = a.podName || 'Untitled project';
-          const runtimeLabel = formatRuntime(a);
-          const lastSeen = formatRelative(a.lastHeartbeatAt);
+          const podLabel = a.podName || t('yourTeam.untitledProject');
+          const runtimeLabel = formatRuntime(a, t);
+          const lastSeen = formatRelative(a.lastHeartbeatAt, t);
           const cardKey = `${a.name}:${a.instanceId}`;
           const isOpening = opening === cardKey;
           const onCardClick = () => {
@@ -375,11 +383,11 @@ const V2YourTeamPage: React.FC = () => {
                 <div className="v2-team-card__name-row">
                   <span className="v2-team-card__name">{display}</span>
                   {a.category && (
-                    <span className="v2-role-chip" title={`Role: ${a.category}`}>{a.category}</span>
+                    <span className="v2-role-chip" title={t('yourTeam.card.roleTitle', { role: a.category })}>{a.category}</span>
                   )}
                   <span className="v2-team-card__runtime">{runtimeLabel}</span>
                 </div>
-                <div className="v2-team-card__pod">in <em>{podLabel}</em></div>
+                <div className="v2-team-card__pod">{t('yourTeam.card.inProject')} <em>{podLabel}</em></div>
                 <div className="v2-team-card__activity">
                   <span className="v2-team-card__dot" data-active={a.status === 'active'} />
                   {lastSeen}
@@ -393,18 +401,18 @@ const V2YourTeamPage: React.FC = () => {
                     e.stopPropagation();
                     navigate(`/v2/agent/${encodeURIComponent(a.name)}/${encodeURIComponent(a.instanceId || 'default')}`);
                   }}
-                  aria-label={`View ${display}'s profile`}
+                  aria-label={t('yourTeam.card.viewProfileAria', { name: display })}
                 >
-                  Profile
+                  {t('yourTeam.card.profile')}
                 </button>
                 <button
                   type="button"
                   className="v2-team-card__talk"
                   onClick={(e) => handleTalkTo(a, e)}
                   disabled={isOpening}
-                  aria-label={`Talk to ${display} one-to-one`}
+                  aria-label={t('yourTeam.card.talkToAria', { name: display })}
                 >
-                  {isOpening ? 'Opening…' : 'Talk to'}
+                  {isOpening ? t('yourTeam.card.opening') : t('yourTeam.card.talkTo')}
                 </button>
               </div>
             </article>

--- a/frontend/src/v2/landing/V2ComparePage.tsx
+++ b/frontend/src/v2/landing/V2ComparePage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../context/AuthContext';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
@@ -23,10 +24,10 @@ const Mark: React.FC<{ size?: number }> = ({ size = 26 }) => (
 );
 
 interface Row {
-  dim: string;
-  commonly: string;
+  // Stable key into the `compare.rows.<key>` translation group. User-facing
+  // copy (dim / commonly / raft) is resolved via t() inside the component.
+  key: string;
   commonlyWin: boolean;
-  raft: string;
   // Parity dimensions — both products offer it. Rendered as a check on BOTH sides
   // (Raft's in a neutral tone) rather than a misleading dash, keeping the page
   // "generous + factual".
@@ -34,21 +35,22 @@ interface Row {
 }
 
 const ROWS: Row[] = [
-  { dim: 'Source', commonly: 'Open — Apache-2.0, every line readable', commonlyWin: true, raft: 'Closed source' },
-  { dim: 'Self-host', commonly: 'Yes — docker compose up on your own infra', commonlyWin: true, raft: 'Hosted product' },
-  { dim: 'Per-agent cost', commonly: '$0 — run one agent or fifty', commonlyWin: true, raft: 'Per-seat + per-agent pricing' },
-  { dim: 'Your data', commonly: 'On your machines when self-hosted', commonlyWin: true, raft: 'On their cloud' },
-  { dim: 'Federation', commonly: 'On the roadmap — agents across instances', commonlyWin: true, raft: 'Single hosted instance' },
-  { dim: 'Shared workspace', commonly: 'Humans + agents in one set of pods', commonlyWin: false, parity: true, raft: 'Humans + agents in one workspace' },
-  { dim: 'Bring your own runtime', commonly: 'Native, OpenClaw, Codex, Claude Code, webhook', commonlyWin: false, parity: true, raft: 'Bring your own agent daemon' },
+  { key: 'source', commonlyWin: true },
+  { key: 'selfHost', commonlyWin: true },
+  { key: 'perAgentCost', commonlyWin: true },
+  { key: 'yourData', commonlyWin: true },
+  { key: 'federation', commonlyWin: true },
+  { key: 'sharedWorkspace', commonlyWin: false, parity: true },
+  { key: 'byoRuntime', commonlyWin: false, parity: true },
 ];
 
 const V2ComparePage: React.FC = () => {
+  const { t } = useTranslation();
   const { isAuthenticated } = useAuth();
   // Signed-out visitors get routed to /v2/register (invite-code + waitlist),
   // not the /v2/login dead-end. Returning users use the "Sign in" nav link.
   const appHref = isAuthenticated ? '/v2' : '/v2/register';
-  const primaryLabel = isAuthenticated ? 'Open the app' : 'Get started';
+  const primaryLabel = isAuthenticated ? t('compare.actions.openApp') : t('compare.actions.getStarted');
   return (
   <div className="v2-root v2-landing">
     <header className="v2-landing__bar">
@@ -56,68 +58,64 @@ const V2ComparePage: React.FC = () => {
         <span className="v2-landing__mark"><Mark size={26} /></span>
         <span className="v2-landing__brand-name">Commonly</span>
       </Link>
-      <nav className="v2-landing__nav" aria-label="Primary">
-        <Link className="v2-landing__navlink" to="/v2/landing">Home</Link>
+      <nav className="v2-landing__nav" aria-label={t('compare.nav.primaryLabel')}>
+        <Link className="v2-landing__navlink" to="/v2/landing">{t('compare.nav.home')}</Link>
         <a className="v2-landing__navlink" href={REPO} target="_blank" rel="noreferrer">GitHub</a>
         {!isAuthenticated && (
-          <Link className="v2-landing__navlink" to="/v2/login">Sign in</Link>
+          <Link className="v2-landing__navlink" to="/v2/login">{t('compare.nav.signIn')}</Link>
         )}
         <Link className="v2-landing__btn v2-landing__btn--primary v2-landing__btn--sm" to={appHref}>
-          {isAuthenticated ? 'Open the app' : 'Get started'}
+          {isAuthenticated ? t('compare.actions.openApp') : t('compare.actions.getStarted')}
         </Link>
       </nav>
     </header>
 
     <main>
       <section className="v2-landing__section v2-compare__head">
-        <div className="v2-landing__kicker">Compare</div>
-        <h1 className="v2-compare__title">Commonly vs Raft</h1>
+        <div className="v2-landing__kicker">{t('compare.kicker')}</div>
+        <h1 className="v2-compare__title">{t('compare.title')}</h1>
         <p className="v2-compare__lede">
-          Commonly and Raft both put humans and agents in one shared workspace, with your agents running on
-          your own runtime. The difference is ownership: Commonly is open-source and self-hostable, with no
-          per-agent tax.
+          {t('compare.lede')}
         </p>
 
-        <div className="v2-compare__table" role="table" aria-label="Commonly compared with Raft">
+        <div className="v2-compare__table" role="table" aria-label={t('compare.table.ariaLabel')}>
           <div className="v2-compare__row v2-compare__row--head" role="row">
             <div className="v2-compare__cell v2-compare__cell--dim" role="columnheader" />
             <div className="v2-compare__cell v2-compare__cell--us" role="columnheader">
-              <span className="v2-landing__mark"><Mark size={18} /></span> Commonly
+              <span className="v2-landing__mark"><Mark size={18} /></span> {t('compare.table.commonly')}
             </div>
-            <div className="v2-compare__cell" role="columnheader">Raft</div>
+            <div className="v2-compare__cell" role="columnheader">{t('compare.table.raft')}</div>
           </div>
           {ROWS.map((r) => (
-            <div className="v2-compare__row" role="row" key={r.dim}>
-              <div className="v2-compare__cell v2-compare__cell--dim" role="rowheader">{r.dim}</div>
+            <div className="v2-compare__row" role="row" key={r.key}>
+              <div className="v2-compare__cell v2-compare__cell--dim" role="rowheader">{t(`compare.rows.${r.key}.dim`)}</div>
               <div className="v2-compare__cell v2-compare__cell--us" role="cell">
                 {(r.commonlyWin || r.parity) && <CheckCircleOutlineIcon className="v2-compare__ic v2-compare__ic--yes" fontSize="inherit" />}
-                <span>{r.commonly}</span>
+                <span>{t(`compare.rows.${r.key}.commonly`)}</span>
               </div>
               <div className="v2-compare__cell" role="cell">
                 {r.parity
                   ? <CheckCircleOutlineIcon className="v2-compare__ic v2-compare__ic--muted" fontSize="inherit" />
                   : <RemoveCircleOutlineIcon className="v2-compare__ic v2-compare__ic--muted" fontSize="inherit" />}
-                <span>{r.raft}</span>
+                <span>{t(`compare.rows.${r.key}.raft`)}</span>
               </div>
             </div>
           ))}
         </div>
 
         <p className="v2-compare__close">
-          Want a hosted product and don&apos;t mind closed-source? Raft is good, and shipping. Want to own the
-          substrate — self-host it, pay no per-agent tax, fork it, and federate it? That&apos;s Commonly.
+          {t('compare.close')}
         </p>
 
         <div className="v2-landing__cta-row v2-compare__cta">
           <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>{primaryLabel}</Link>
           <a className="v2-landing__btn v2-landing__btn--ghost" href={REPO} target="_blank" rel="noreferrer">
             <span className="v2-landing__btn-mark"><Mark size={18} /></span>
-            Star on GitHub
+            {t('compare.actions.starOnGithub')}
           </a>
         </div>
         <p className="v2-compare__note">
-          Comparison reflects each product&apos;s public positioning. Raft is a trademark of its respective owner;
-          this page is not affiliated with or endorsed by Raft.
+          {t('compare.note')}
         </p>
       </section>
     </main>
@@ -129,14 +127,14 @@ const V2ComparePage: React.FC = () => {
       </div>
       <div className="v2-landing__footer-cols">
         <div className="v2-landing__footer-col">
-          <div className="v2-landing__footer-title">Product</div>
-          <Link className="v2-landing__footer-link" to="/v2/landing">Home</Link>
+          <div className="v2-landing__footer-title">{t('compare.footer.product')}</div>
+          <Link className="v2-landing__footer-link" to="/v2/landing">{t('compare.nav.home')}</Link>
           <Link className="v2-landing__footer-link" to={appHref}>{primaryLabel}</Link>
         </div>
         <div className="v2-landing__footer-col">
-          <div className="v2-landing__footer-title">Open source</div>
+          <div className="v2-landing__footer-title">{t('compare.footer.openSource')}</div>
           <a className="v2-landing__footer-link" href={REPO} target="_blank" rel="noreferrer">GitHub</a>
-          <a className="v2-landing__footer-link" href={`${REPO}/blob/main/LICENSE`} target="_blank" rel="noreferrer">License (Apache-2.0)</a>
+          <a className="v2-landing__footer-link" href={`${REPO}/blob/main/LICENSE`} target="_blank" rel="noreferrer">{t('compare.footer.license')}</a>
         </div>
       </div>
     </footer>

--- a/frontend/src/v2/landing/V2ComparePage.tsx
+++ b/frontend/src/v2/landing/V2ComparePage.tsx
@@ -13,6 +13,7 @@ import './v2-landing.css';
 // ownership", generous to Raft, grounded in what anyone can verify.
 
 const REPO = 'https://github.com/Team-Commonly/commonly';
+const GITHUB_BRAND = 'GitHub';
 
 const Mark: React.FC<{ size?: number }> = ({ size = 26 }) => (
   <svg width={size} height={size} viewBox="0 0 64 64" aria-hidden="true" focusable="false">
@@ -56,11 +57,11 @@ const V2ComparePage: React.FC = () => {
     <header className="v2-landing__bar">
       <Link className="v2-landing__brand" to="/v2/landing" style={{ textDecoration: 'none' }}>
         <span className="v2-landing__mark"><Mark size={26} /></span>
-        <span className="v2-landing__brand-name">Commonly</span>
+        <span className="v2-landing__brand-name">{t('common.brandName')}</span>
       </Link>
       <nav className="v2-landing__nav" aria-label={t('compare.nav.primaryLabel')}>
         <Link className="v2-landing__navlink" to="/v2/landing">{t('compare.nav.home')}</Link>
-        <a className="v2-landing__navlink" href={REPO} target="_blank" rel="noreferrer">GitHub</a>
+        <a className="v2-landing__navlink" href={REPO} target="_blank" rel="noreferrer">{GITHUB_BRAND}</a>
         {!isAuthenticated && (
           <Link className="v2-landing__navlink" to="/v2/login">{t('compare.nav.signIn')}</Link>
         )}
@@ -123,7 +124,7 @@ const V2ComparePage: React.FC = () => {
     <footer className="v2-landing__footer">
       <div className="v2-landing__footer-brand">
         <span className="v2-landing__mark"><Mark size={22} /></span>
-        <span className="v2-landing__brand-name">Commonly</span>
+        <span className="v2-landing__brand-name">{t('common.brandName')}</span>
       </div>
       <div className="v2-landing__footer-cols">
         <div className="v2-landing__footer-col">
@@ -133,7 +134,7 @@ const V2ComparePage: React.FC = () => {
         </div>
         <div className="v2-landing__footer-col">
           <div className="v2-landing__footer-title">{t('compare.footer.openSource')}</div>
-          <a className="v2-landing__footer-link" href={REPO} target="_blank" rel="noreferrer">GitHub</a>
+          <a className="v2-landing__footer-link" href={REPO} target="_blank" rel="noreferrer">{GITHUB_BRAND}</a>
           <a className="v2-landing__footer-link" href={`${REPO}/blob/main/LICENSE`} target="_blank" rel="noreferrer">{t('compare.footer.license')}</a>
         </div>
       </div>

--- a/frontend/src/v2/marketplace/V2MarketplaceDetailPage.tsx
+++ b/frontend/src/v2/marketplace/V2MarketplaceDetailPage.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from 'react-i18next';
 import axios from 'axios';
 import ReactMarkdown from 'react-markdown';
 
+const RATING_ICON = '★';
+
 // V2 marketplace detail page — `/v2/marketplace/:installableId`.
 //
 // Surfaces a single Installable manifest from /api/marketplace/manifests/:id
@@ -191,7 +193,7 @@ const V2MarketplaceDetailPage: React.FC = () => {
             <div className="v2-marketplace-detail__stats">
               <span>{t('marketplaceDetail.installsCount', { count: totalInstalls })}</span>
               <span className="v2-marketplace-detail__sep">·</span>
-              <span>★ {rating}</span>
+              <span>{RATING_ICON} {rating}</span>
               {doc.latestVersion ? (
                 <>
                   <span className="v2-marketplace-detail__sep">·</span>

--- a/frontend/src/v2/marketplace/V2MarketplaceDetailPage.tsx
+++ b/frontend/src/v2/marketplace/V2MarketplaceDetailPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import axios from 'axios';
 import ReactMarkdown from 'react-markdown';
 
@@ -68,8 +69,12 @@ const formatNumber = (n: number | undefined): string => {
   return String(v);
 };
 
-const formatRating = (r: number | undefined, count: number | undefined): string => {
-  if (!r) return 'unrated';
+const formatRating = (
+  r: number | undefined,
+  count: number | undefined,
+  unratedLabel: string,
+): string => {
+  if (!r) return unratedLabel;
   const fixed = r.toFixed(1);
   return count ? `${fixed} (${count})` : fixed;
 };
@@ -77,13 +82,14 @@ const formatRating = (r: number | undefined, count: number | undefined): string 
 const V2MarketplaceDetailPage: React.FC = () => {
   const { installableId } = useParams<{ installableId: string }>();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const [doc, setDoc] = useState<Installable | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!installableId) {
-      setError('No installable specified');
+      setError(t('marketplaceDetail.errors.noInstallable'));
       setLoading(false);
       return;
     }
@@ -101,41 +107,41 @@ const V2MarketplaceDetailPage: React.FC = () => {
         // Other failures show a generic error; the network details are in the
         // console for operators.
         if (err?.response?.status === 404) {
-          setError('Manifest not found');
+          setError(t('marketplaceDetail.errors.manifestNotFound'));
         } else {
-          setError('Failed to load marketplace entry');
+          setError(t('marketplaceDetail.errors.loadFailed'));
           // eslint-disable-next-line no-console
           console.error('[v2-marketplace-detail] fetch error:', err?.message || err);
         }
       })
       .finally(() => setLoading(false));
-  }, [installableId]);
+  }, [installableId, t]);
 
   if (loading) {
     return (
       <div className="v2-marketplace-detail v2-marketplace-detail--loading">
-        Loading…
+        {t('marketplaceDetail.loading')}
       </div>
     );
   }
   if (error || !doc) {
     return (
       <div className="v2-marketplace-detail v2-marketplace-detail--error">
-        <div className="v2-empty__title">{error || 'Not found'}</div>
+        <div className="v2-empty__title">{error || t('marketplaceDetail.errors.notFound')}</div>
         <div className="v2-empty__text">
-          <Link to="/v2/marketplace">← Back to marketplace</Link>
+          <Link to="/v2/marketplace">{t('marketplaceDetail.backToMarketplace')}</Link>
         </div>
       </div>
     );
   }
 
-  const display = doc.marketplace?.displayName || doc.name || doc.installableId || 'Untitled';
-  const category = doc.marketplace?.category || 'other';
-  const kind = doc.kind || 'app';
+  const display = doc.marketplace?.displayName || doc.name || doc.installableId || t('marketplaceDetail.untitled');
+  const category = doc.marketplace?.category || t('marketplaceDetail.categoryOther');
+  const kind = doc.kind || t('marketplaceDetail.kindApp');
   const verified = Boolean(doc.marketplace?.verified);
-  const publisher = doc.marketplace?.publisher?.name || 'unknown';
+  const publisher = doc.marketplace?.publisher?.name || t('marketplaceDetail.unknownPublisher');
   const totalInstalls = formatNumber(doc.stats?.totalInstalls);
-  const rating = formatRating(doc.marketplace?.rating, doc.marketplace?.ratingCount);
+  const rating = formatRating(doc.marketplace?.rating, doc.marketplace?.ratingCount, t('marketplaceDetail.unrated'));
   const components = Array.isArray(doc.components) ? doc.components : [];
   const requires = Array.isArray(doc.requires) ? doc.requires : [];
 
@@ -150,7 +156,7 @@ const V2MarketplaceDetailPage: React.FC = () => {
     <div className="v2-marketplace-detail">
       <div className="v2-marketplace-detail__header">
         <Link to="/v2/marketplace" className="v2-marketplace-detail__back">
-          ← Back to marketplace
+          {t('marketplaceDetail.backToMarketplace')}
         </Link>
 
         <div className="v2-marketplace-detail__identity">
@@ -170,8 +176,8 @@ const V2MarketplaceDetailPage: React.FC = () => {
             <h1 className="v2-marketplace-detail__title">
               {display}
               {verified ? (
-                <span className="v2-marketplace-detail__badge" title="Verified by Commonly">
-                  ✓ Verified
+                <span className="v2-marketplace-detail__badge" title={t('marketplaceDetail.verifiedTitle')}>
+                  {t('marketplaceDetail.verifiedBadge')}
                 </span>
               ) : null}
             </h1>
@@ -180,22 +186,22 @@ const V2MarketplaceDetailPage: React.FC = () => {
               <span className="v2-marketplace-detail__sep">·</span>
               <span className="v2-marketplace-detail__category">{category}</span>
               <span className="v2-marketplace-detail__sep">·</span>
-              <span className="v2-marketplace-detail__publisher">by {publisher}</span>
+              <span className="v2-marketplace-detail__publisher">{t('marketplaceDetail.byPublisher', { publisher })}</span>
             </div>
             <div className="v2-marketplace-detail__stats">
-              <span>{totalInstalls} installs</span>
+              <span>{t('marketplaceDetail.installsCount', { count: totalInstalls })}</span>
               <span className="v2-marketplace-detail__sep">·</span>
               <span>★ {rating}</span>
               {doc.latestVersion ? (
                 <>
                   <span className="v2-marketplace-detail__sep">·</span>
-                  <span>v{doc.latestVersion}</span>
+                  <span>{t('marketplaceDetail.version', { version: doc.latestVersion })}</span>
                 </>
               ) : null}
             </div>
           </div>
           <button type="button" className="v2-marketplace-detail__install" onClick={handleInstall}>
-            Install
+            {t('marketplaceDetail.install')}
           </button>
         </div>
       </div>
@@ -207,11 +213,11 @@ const V2MarketplaceDetailPage: React.FC = () => {
 
         {components.length > 0 ? (
           <section className="v2-marketplace-detail__section">
-            <h2>Components</h2>
+            <h2>{t('marketplaceDetail.sections.components')}</h2>
             <ul className="v2-marketplace-detail__components">
               {components.map((c, i) => (
                 <li key={`${c.type}-${c.name}-${i}`}>
-                  <span className="v2-marketplace-detail__component-type">{c.type || 'component'}</span>
+                  <span className="v2-marketplace-detail__component-type">{c.type || t('marketplaceDetail.componentFallback')}</span>
                   <span className="v2-marketplace-detail__component-name">{c.name || ''}</span>
                 </li>
               ))}
@@ -221,7 +227,7 @@ const V2MarketplaceDetailPage: React.FC = () => {
 
         {requires.length > 0 ? (
           <section className="v2-marketplace-detail__section">
-            <h2>Required scopes</h2>
+            <h2>{t('marketplaceDetail.sections.requiredScopes')}</h2>
             <ul className="v2-marketplace-detail__requires">
               {requires.map((s) => (
                 <li key={s} className="v2-marketplace-detail__scope">{s}</li>
@@ -232,7 +238,7 @@ const V2MarketplaceDetailPage: React.FC = () => {
 
         {doc.readme ? (
           <section className="v2-marketplace-detail__section">
-            <h2>About</h2>
+            <h2>{t('marketplaceDetail.sections.about')}</h2>
             <div className="v2-marketplace-detail__readme">
               <ReactMarkdown>{doc.readme}</ReactMarkdown>
             </div>

--- a/frontend/src/v2/marketplace/V2MarketplacePage.tsx
+++ b/frontend/src/v2/marketplace/V2MarketplacePage.tsx
@@ -28,6 +28,8 @@ interface Pod {
   name: string;
 }
 
+const DEFAULT_INSTALLABLE_KIND = 'app';
+
 const CATEGORIES = [
   { id: 'all', labelKey: 'marketplace.categories.all' },
   { id: 'productivity', labelKey: 'marketplace.categories.productivity' },
@@ -303,7 +305,7 @@ const V2MarketplacePage: React.FC = () => {
         </div>
         <p className="v2-mkt-card__desc">{app.description || t('marketplace.card.noDescription')}</p>
         <div className="v2-mkt-card__meta">
-          <span className="v2-mkt-card__chip">{String(app.kind || 'app')}</span>
+          <span className="v2-mkt-card__chip">{String(app.kind || DEFAULT_INSTALLABLE_KIND)}</span>
           <span className="v2-mkt-card__stat">{t('marketplace.card.installsCount', { count: Number(app.installs || 0) })}</span>
         </div>
         <div className="v2-mkt-card__actions">

--- a/frontend/src/v2/marketplace/V2MarketplacePage.tsx
+++ b/frontend/src/v2/marketplace/V2MarketplacePage.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import axios from 'axios';
 import './V2MarketplacePage.css';
 
@@ -28,21 +29,21 @@ interface Pod {
 }
 
 const CATEGORIES = [
-  { id: 'all', label: 'All categories' },
-  { id: 'productivity', label: 'Productivity' },
-  { id: 'development', label: 'Development' },
-  { id: 'analytics', label: 'Analytics' },
-  { id: 'support', label: 'Support' },
-  { id: 'communication', label: 'Communication' },
-  { id: 'other', label: 'Other' },
+  { id: 'all', labelKey: 'marketplace.categories.all' },
+  { id: 'productivity', labelKey: 'marketplace.categories.productivity' },
+  { id: 'development', labelKey: 'marketplace.categories.development' },
+  { id: 'analytics', labelKey: 'marketplace.categories.analytics' },
+  { id: 'support', labelKey: 'marketplace.categories.support' },
+  { id: 'communication', labelKey: 'marketplace.categories.communication' },
+  { id: 'other', labelKey: 'marketplace.categories.other' },
 ];
 
 const KINDS = [
-  { id: 'all', label: 'All kinds' },
-  { id: 'agent', label: 'Agents' },
-  { id: 'app', label: 'Apps' },
-  { id: 'skill', label: 'Skills' },
-  { id: 'bundle', label: 'Bundles' },
+  { id: 'all', labelKey: 'marketplace.kinds.all' },
+  { id: 'agent', labelKey: 'marketplace.kinds.agent' },
+  { id: 'app', labelKey: 'marketplace.kinds.app' },
+  { id: 'skill', labelKey: 'marketplace.kinds.skill' },
+  { id: 'bundle', labelKey: 'marketplace.kinds.bundle' },
 ];
 
 const authHeaders = (): Record<string, string> => ({
@@ -100,6 +101,7 @@ const toInstalledLegacyApp = (app: any): App => ({
 const initial = (s?: string): string => (s || '?').trim().charAt(0).toUpperCase() || '?';
 
 const V2MarketplacePage: React.FC = () => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [apps, setApps] = useState<App[]>([]);
   const [official, setOfficial] = useState<any[]>([]);
@@ -148,7 +150,7 @@ const V2MarketplacePage: React.FC = () => {
         setApps((((res.data as any)?.items) || []).map(toMarketplaceApp));
       } catch {
         if (cancelled) return;
-        setError('Failed to load the marketplace.');
+        setError(t('marketplace.errors.loadFailed'));
         setApps([]);
       } finally {
         if (!cancelled) setLoading(false);
@@ -216,7 +218,7 @@ const V2MarketplacePage: React.FC = () => {
 
   const install = async (app: App, e: React.MouseEvent) => {
     e.stopPropagation();
-    if (!selectedPodId) { setStatus('Pick a pod above to install into.'); return; }
+    if (!selectedPodId) { setStatus(t('marketplace.status.pickPodToInstall')); return; }
     setBusyId(app.id);
     setStatus(null);
     setGate(null);
@@ -228,14 +230,17 @@ const V2MarketplacePage: React.FC = () => {
         displayName: app.displayName || undefined,
         scopes: Array.isArray(app.scopes) ? app.scopes : [],
       }, { headers: authHeaders() });
-      setStatus(`Installed ${app.displayName || app.name} into ${pods.find((p) => p._id === selectedPodId)?.name || 'pod'}.`);
+      setStatus(t('marketplace.status.installed', {
+        name: app.displayName || app.name,
+        pod: pods.find((p) => p._id === selectedPodId)?.name || t('marketplace.status.podFallback'),
+      }));
       fetchInstalled();
     } catch (err: any) {
       const data = err?.response?.data;
       if (data?.code === 'cloud_agents_not_entitled') {
-        setGate(data.message || 'Hosted agents require an upgrade or admin — connect your own agent instead.');
+        setGate(data.message || t('marketplace.gate.cloudAgentsNotEntitled'));
       } else {
-        setStatus(data?.error || 'Could not install — try again.');
+        setStatus(data?.error || t('marketplace.errors.installFailed'));
       }
     } finally {
       setBusyId('');
@@ -256,17 +261,17 @@ const V2MarketplacePage: React.FC = () => {
       } else {
         await axios.delete(`/api/apps/pods/${selectedPodId}/apps/${app.installationId}`, { headers: authHeaders() });
       }
-      setStatus(`Removed ${app.displayName || app.name}.`);
+      setStatus(t('marketplace.status.removed', { name: app.displayName || app.name }));
       fetchInstalled();
     } catch {
-      setStatus('Could not remove — try again.');
+      setStatus(t('marketplace.errors.removeFailed'));
     } finally {
       setBusyId('');
     }
   };
 
   const connect = (entry: any) => {
-    setStatus(`Open a pod to connect ${entry.name}.`);
+    setStatus(t('marketplace.status.openPodToConnect', { name: entry.name }));
     navigate('/v2');
   };
 
@@ -291,15 +296,15 @@ const V2MarketplacePage: React.FC = () => {
           <div className="v2-mkt-card__id">
             <div className="v2-mkt-card__name-row">
               <span className="v2-mkt-card__name">{app.displayName}</span>
-              {app.verified ? <span className="v2-mkt-card__badge" title="Verified by Commonly">Verified</span> : null}
+              {app.verified ? <span className="v2-mkt-card__badge" title={t('marketplace.card.verifiedTooltip')}>{t('marketplace.card.verified')}</span> : null}
             </div>
             <span className="v2-mkt-card__handle">@{app.name}</span>
           </div>
         </div>
-        <p className="v2-mkt-card__desc">{app.description || 'No description provided.'}</p>
+        <p className="v2-mkt-card__desc">{app.description || t('marketplace.card.noDescription')}</p>
         <div className="v2-mkt-card__meta">
           <span className="v2-mkt-card__chip">{String(app.kind || 'app')}</span>
-          <span className="v2-mkt-card__stat">{Number(app.installs || 0)} installs</span>
+          <span className="v2-mkt-card__stat">{t('marketplace.card.installsCount', { count: Number(app.installs || 0) })}</span>
         </div>
         <div className="v2-mkt-card__actions">
           {installedNow ? (
@@ -309,7 +314,7 @@ const V2MarketplacePage: React.FC = () => {
               disabled={busy}
               onClick={(ev) => remove(app, ev)}
             >
-              {busy ? 'Removing…' : 'Remove'}
+              {busy ? t('marketplace.actions.removing') : t('marketplace.actions.remove')}
             </button>
           ) : (
             <button
@@ -318,7 +323,7 @@ const V2MarketplacePage: React.FC = () => {
               disabled={busy}
               onClick={(ev) => install(app, ev)}
             >
-              {busy ? 'Installing…' : 'Install'}
+              {busy ? t('marketplace.actions.installing') : t('marketplace.actions.install')}
             </button>
           )}
         </div>
@@ -339,7 +344,7 @@ const V2MarketplacePage: React.FC = () => {
           )}
           <div className="v2-mkt-card__id">
             <span className="v2-mkt-card__name">{entry.name}</span>
-            <span className="v2-mkt-card__handle">{isMcp ? 'MCP app' : entry.type || 'integration'}{entry.category ? ` · ${entry.category}` : ''}</span>
+            <span className="v2-mkt-card__handle">{isMcp ? t('marketplace.official.mcpApp') : entry.type || t('marketplace.official.integration')}{entry.category ? ` · ${entry.category}` : ''}</span>
           </div>
         </div>
         <p className="v2-mkt-card__desc">{entry.description || ''}</p>
@@ -355,10 +360,10 @@ const V2MarketplacePage: React.FC = () => {
             disabled={isMcp}
             onClick={() => (isMcp ? undefined : connect(entry))}
           >
-            {isMcp ? 'MCP host required' : 'Connect in pod'}
+            {isMcp ? t('marketplace.official.mcpHostRequired') : t('marketplace.official.connectInPod')}
           </button>
           {entry.docsUrl && (
-            <a className="v2-mkt-card__btn v2-mkt-card__btn--ghost" href={entry.docsUrl} target="_blank" rel="noreferrer">Docs</a>
+            <a className="v2-mkt-card__btn v2-mkt-card__btn--ghost" href={entry.docsUrl} target="_blank" rel="noreferrer">{t('marketplace.official.docs')}</a>
           )}
         </div>
       </article>
@@ -375,23 +380,19 @@ const V2MarketplacePage: React.FC = () => {
     return (
       <div className="v2-mkt">
         <header className="v2-mkt__header">
-          <h1 className="v2-mkt__title">Marketplace</h1>
-          <p className="v2-mkt__subtitle">Install agents and apps like packages.</p>
+          <h1 className="v2-mkt__title">{t('marketplace.title')}</h1>
+          <p className="v2-mkt__subtitle">{t('marketplace.subtitleLocked')}</p>
         </header>
         <div className="v2-mkt__comingsoon">
-          <div className="v2-mkt__comingsoon-badge">Coming soon</div>
-          <h2 className="v2-mkt__comingsoon-title">A marketplace of installable agents</h2>
-          <p className="v2-mkt__comingsoon-text">
-            We&apos;re curating agents you can install in one click. In the meantime,
-            you can already bring your own — connect Claude Code, Cursor, or Codex and
-            it becomes a full member of your pods.
-          </p>
+          <div className="v2-mkt__comingsoon-badge">{t('marketplace.comingSoon.badge')}</div>
+          <h2 className="v2-mkt__comingsoon-title">{t('marketplace.comingSoon.title')}</h2>
+          <p className="v2-mkt__comingsoon-text">{t('marketplace.comingSoon.text')}</p>
           <button
             type="button"
             className="v2-mkt__comingsoon-cta"
             onClick={() => navigate('/v2/agents/byo')}
           >
-            Bring your own agent
+            {t('marketplace.comingSoon.cta')}
           </button>
         </div>
       </div>
@@ -401,26 +402,26 @@ const V2MarketplacePage: React.FC = () => {
   return (
     <div className="v2-mkt">
       <header className="v2-mkt__header">
-        <h1 className="v2-mkt__title">Marketplace</h1>
-        <p className="v2-mkt__subtitle">Browse and install agents, apps, and integrations.</p>
+        <h1 className="v2-mkt__title">{t('marketplace.title')}</h1>
+        <p className="v2-mkt__subtitle">{t('marketplace.subtitle')}</p>
       </header>
 
       <div className="v2-mkt__filterbar">
         <input
           className="v2-mkt__search"
           type="search"
-          placeholder="Search agents, apps, integrations…"
+          placeholder={t('marketplace.searchPlaceholder')}
           value={search}
           onChange={(e) => setSearch(e.target.value)}
         />
-        <select className="v2-mkt__control" value={kind} onChange={(e) => setKind(e.target.value)} aria-label="Kind">
-          {KINDS.map((k) => <option key={k.id} value={k.id}>{k.label}</option>)}
+        <select className="v2-mkt__control" value={kind} onChange={(e) => setKind(e.target.value)} aria-label={t('marketplace.filters.kindLabel')}>
+          {KINDS.map((k) => <option key={k.id} value={k.id}>{t(k.labelKey)}</option>)}
         </select>
-        <select className="v2-mkt__control" value={category} onChange={(e) => setCategory(e.target.value)} aria-label="Category">
-          {CATEGORIES.map((c) => <option key={c.id} value={c.id}>{c.label}</option>)}
+        <select className="v2-mkt__control" value={category} onChange={(e) => setCategory(e.target.value)} aria-label={t('marketplace.filters.categoryLabel')}>
+          {CATEGORIES.map((c) => <option key={c.id} value={c.id}>{t(c.labelKey)}</option>)}
         </select>
         {pods.length > 0 && (
-          <select className="v2-mkt__control" value={selectedPodId} onChange={(e) => setSelectedPodId(e.target.value)} aria-label="Install to pod">
+          <select className="v2-mkt__control" value={selectedPodId} onChange={(e) => setSelectedPodId(e.target.value)} aria-label={t('marketplace.filters.installToPodLabel')}>
             {pods.map((p) => <option key={p._id} value={p._id}>{p.name}</option>)}
           </select>
         )}
@@ -428,10 +429,10 @@ const V2MarketplacePage: React.FC = () => {
 
       <div className="v2-mkt__tabs" role="tablist">
         <button type="button" role="tab" aria-selected={tab === 'discover'} className={`v2-mkt__tab${tab === 'discover' ? ' v2-mkt__tab--active' : ''}`} onClick={() => setTab('discover')}>
-          Discover
+          {t('marketplace.tabs.discover')}
         </button>
         <button type="button" role="tab" aria-selected={tab === 'installed'} className={`v2-mkt__tab${tab === 'installed' ? ' v2-mkt__tab--active' : ''}`} onClick={() => setTab('installed')}>
-          Installed{installed.length ? ` (${installed.length})` : ''}
+          {installed.length ? t('marketplace.tabs.installedWithCount', { count: installed.length }) : t('marketplace.tabs.installed')}
         </button>
       </div>
 
@@ -444,7 +445,7 @@ const V2MarketplacePage: React.FC = () => {
             className="v2-mkt__gate-btn"
             onClick={() => navigate('/v2/agents/byo')}
           >
-            Connect your own agent
+            {t('marketplace.gate.connectYourOwnAgent')}
           </button>
         </div>
       )}
@@ -453,15 +454,15 @@ const V2MarketplacePage: React.FC = () => {
       {tab === 'discover' ? (
         <>
           <section className="v2-mkt__section">
-            <h2 className="v2-mkt__section-title">{search || kind !== 'all' || category !== 'all' ? 'Results' : 'All listings'}</h2>
+            <h2 className="v2-mkt__section-title">{search || kind !== 'all' || category !== 'all' ? t('marketplace.sections.results') : t('marketplace.sections.allListings')}</h2>
             {loading ? (
               <div className="v2-mkt__grid">
                 {[0, 1, 2, 3].map((i) => <div key={i} className="v2-mkt-card v2-mkt-card--skeleton" />)}
               </div>
             ) : apps.length === 0 ? (
               <div className="v2-mkt__empty">
-                <div className="v2-mkt__empty-title">No listings yet</div>
-                <div className="v2-mkt__empty-text">Nothing matches your filters. Try a broader search, or publish the first one.</div>
+                <div className="v2-mkt__empty-title">{t('marketplace.empty.noListingsTitle')}</div>
+                <div className="v2-mkt__empty-text">{t('marketplace.empty.noListingsText')}</div>
               </div>
             ) : (
               <div className="v2-mkt__grid">{apps.map(renderListingCard)}</div>
@@ -470,16 +471,16 @@ const V2MarketplacePage: React.FC = () => {
 
           {officialIntegrations.length > 0 && (
             <section className="v2-mkt__section">
-              <h2 className="v2-mkt__section-title">Official integrations</h2>
-              <p className="v2-mkt__section-sub">Curated by Commonly — connect from a pod.</p>
+              <h2 className="v2-mkt__section-title">{t('marketplace.sections.officialTitle')}</h2>
+              <p className="v2-mkt__section-sub">{t('marketplace.sections.officialSub')}</p>
               <div className="v2-mkt__grid">{officialIntegrations.map(renderOfficialCard)}</div>
             </section>
           )}
 
           {mcpListings.length > 0 && (
             <section className="v2-mkt__section">
-              <h2 className="v2-mkt__section-title">MCP apps (preview)</h2>
-              <p className="v2-mkt__section-sub">Interactive UI rendered inside MCP-compatible hosts.</p>
+              <h2 className="v2-mkt__section-title">{t('marketplace.sections.mcpTitle')}</h2>
+              <p className="v2-mkt__section-sub">{t('marketplace.sections.mcpSub')}</p>
               <div className="v2-mkt__grid">{mcpListings.map(renderOfficialCard)}</div>
             </section>
           )}
@@ -487,11 +488,11 @@ const V2MarketplacePage: React.FC = () => {
       ) : (
         <section className="v2-mkt__section">
           {!selectedPodId ? (
-            <div className="v2-mkt__empty"><div className="v2-mkt__empty-text">Pick a pod to see what&apos;s installed.</div></div>
+            <div className="v2-mkt__empty"><div className="v2-mkt__empty-text">{t('marketplace.empty.pickPodText')}</div></div>
           ) : installed.length === 0 ? (
             <div className="v2-mkt__empty">
-              <div className="v2-mkt__empty-title">Nothing installed here yet</div>
-              <div className="v2-mkt__empty-text">Browse Discover and install your first one.</div>
+              <div className="v2-mkt__empty-title">{t('marketplace.empty.nothingInstalledTitle')}</div>
+              <div className="v2-mkt__empty-text">{t('marketplace.empty.nothingInstalledText')}</div>
             </div>
           ) : (
             <div className="v2-mkt__grid">{installed.map(renderListingCard)}</div>

--- a/frontend/src/v2/showcase/V2Showcase.tsx
+++ b/frontend/src/v2/showcase/V2Showcase.tsx
@@ -227,7 +227,7 @@ const V2Showcase: React.FC = () => {
     <header className="v2-showcase__bar">
       <Link className="v2-showcase__brand" to="/v2/landing" aria-label={t('showcase.nav.brandHome')}>
         <span className="v2-showcase__mark"><Mark size={24} /></span>
-        <span className="v2-showcase__brand-name">Commonly</span>
+        <span className="v2-showcase__brand-name">{t('common.brandName')}</span>
       </Link>
       <nav className="v2-showcase__nav" aria-label={t('showcase.nav.primary')}>
         <Link className="v2-showcase__navlink" to="/v2/landing">{t('showcase.nav.whatIs')}</Link>

--- a/frontend/src/v2/showcase/V2Showcase.tsx
+++ b/frontend/src/v2/showcase/V2Showcase.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import axios from 'axios';
 import getApiBaseUrl from '../../utils/apiBaseUrl';
 import V2Avatar from '../components/V2Avatar';
@@ -145,6 +146,7 @@ const toV2Message = (m: ShowcaseMessage): V2Message => {
 type LoadState = 'loading' | 'ready' | 'not-public' | 'error';
 
 const V2Showcase: React.FC = () => {
+  const { t } = useTranslation();
   const { podId: podIdParam } = useParams<{ podId: string }>();
   const podId = podIdParam || DEFAULT_SHOWCASE_POD_ID;
 
@@ -223,15 +225,15 @@ const V2Showcase: React.FC = () => {
 
   const topBar = (
     <header className="v2-showcase__bar">
-      <Link className="v2-showcase__brand" to="/v2/landing" aria-label="Commonly home">
+      <Link className="v2-showcase__brand" to="/v2/landing" aria-label={t('showcase.nav.brandHome')}>
         <span className="v2-showcase__mark"><Mark size={24} /></span>
         <span className="v2-showcase__brand-name">Commonly</span>
       </Link>
-      <nav className="v2-showcase__nav" aria-label="Primary">
-        <Link className="v2-showcase__navlink" to="/v2/landing">What is Commonly?</Link>
-        <Link className="v2-showcase__navlink" to="/v2/login">Sign in</Link>
+      <nav className="v2-showcase__nav" aria-label={t('showcase.nav.primary')}>
+        <Link className="v2-showcase__navlink" to="/v2/landing">{t('showcase.nav.whatIs')}</Link>
+        <Link className="v2-showcase__navlink" to="/v2/login">{t('showcase.nav.signIn')}</Link>
         <Link className="v2-showcase__btn v2-showcase__btn--primary v2-showcase__btn--sm" to="/v2/register">
-          Sign up to join
+          {t('showcase.nav.signUpToJoin')}
         </Link>
       </nav>
     </header>
@@ -256,16 +258,16 @@ const V2Showcase: React.FC = () => {
         <div className="v2-showcase__center">
           <div className="v2-showcase__empty">
             <div className="v2-showcase__empty-title">
-              {isError ? "This room couldn't be loaded" : "This room isn't public"}
+              {isError ? t('showcase.unavailable.errorTitle') : t('showcase.unavailable.privateTitle')}
             </div>
             <div className="v2-showcase__empty-text">
               {isError
-                ? 'Something went wrong loading this conversation. Try again in a moment.'
-                : 'It may have been made private or removed. Explore what Commonly is, or start your own room.'}
+                ? t('showcase.unavailable.errorText')
+                : t('showcase.unavailable.privateText')}
             </div>
             <div className="v2-showcase__empty-cta">
-              <Link className="v2-showcase__btn v2-showcase__btn--primary" to="/v2/register">Start your own room</Link>
-              <Link className="v2-showcase__btn v2-showcase__btn--ghost" to="/v2/landing">What is Commonly?</Link>
+              <Link className="v2-showcase__btn v2-showcase__btn--primary" to="/v2/register">{t('showcase.actions.startYourOwnRoom')}</Link>
+              <Link className="v2-showcase__btn v2-showcase__btn--ghost" to="/v2/landing">{t('showcase.nav.whatIs')}</Link>
             </div>
           </div>
         </div>
@@ -282,17 +284,17 @@ const V2Showcase: React.FC = () => {
 
       {/* Sticky conversion banner — the load-bearing CTA. Makes it obvious this
           is a real, live room and that the visitor can have one too. */}
-      <div className="v2-showcase__banner" role="region" aria-label="Sign up to join Commonly">
+      <div className="v2-showcase__banner" role="region" aria-label={t('showcase.banner.regionLabel')}>
         <span className="v2-showcase__banner-text">
           <span aria-hidden="true">👀 </span>
-          A live look inside a Commonly room — sign up to start your own.
+          {t('showcase.banner.text')}
         </span>
         <span className="v2-showcase__banner-cta">
           <Link className="v2-showcase__btn v2-showcase__btn--primary v2-showcase__btn--sm" to="/v2/register">
-            Sign up to join
+            {t('showcase.nav.signUpToJoin')}
           </Link>
           <Link className="v2-showcase__btn v2-showcase__btn--ghost v2-showcase__btn--sm" to="/v2/landing">
-            What is Commonly?
+            {t('showcase.nav.whatIs')}
           </Link>
         </span>
       </div>
@@ -305,20 +307,20 @@ const V2Showcase: React.FC = () => {
               {(pod?.name || '?').slice(0, 2).toUpperCase()}
             </span>
             <div>
-              <h1 className="v2-showcase__room-name">{pod?.name || 'Commonly room'}</h1>
+              <h1 className="v2-showcase__room-name">{pod?.name || t('showcase.room.defaultName')}</h1>
               <div className="v2-showcase__room-meta">
                 {typeof pod?.memberCount === 'number' && (
-                  <span>{pod.memberCount} member{pod.memberCount === 1 ? '' : 's'}</span>
+                  <span>{t('showcase.room.memberCount', { count: pod.memberCount })}</span>
                 )}
                 {agents.length > 0 && (
-                  <span>· {agents.length} agent{agents.length === 1 ? '' : 's'}</span>
+                  <span>· {t('showcase.room.agentCount', { count: agents.length })}</span>
                 )}
-                <span className="v2-showcase__room-live">· Read-only view</span>
+                <span className="v2-showcase__room-live">· {t('showcase.room.readOnlyView')}</span>
               </div>
             </div>
           </div>
           {agents.length > 0 && (
-            <div className="v2-showcase__agents" aria-label="Agents in this room">
+            <div className="v2-showcase__agents" aria-label={t('showcase.room.agentsLabel')}>
               {agents.slice(0, 6).map((a) => (
                 <V2Avatar
                   key={`${a.agentName}:${a.instanceId || ''}`}
@@ -343,12 +345,12 @@ const V2Showcase: React.FC = () => {
             no identity inspector. V2MessageBubble with no handlers is inert. */}
         <section className="v2-showcase__messages">
           {hasMore && (
-            <div className="v2-showcase__older-note">Earlier messages are hidden in this public view.</div>
+            <div className="v2-showcase__older-note">{t('showcase.messages.olderHidden')}</div>
           )}
           {messages.length === 0 ? (
             <div className="v2-showcase__empty">
-              <div className="v2-showcase__empty-title">No messages yet</div>
-              <div className="v2-showcase__empty-text">This room is quiet right now. Check back soon.</div>
+              <div className="v2-showcase__empty-title">{t('showcase.messages.emptyTitle')}</div>
+              <div className="v2-showcase__empty-text">{t('showcase.messages.emptyText')}</div>
             </div>
           ) : (
             messages.map((m) => (
@@ -360,13 +362,13 @@ const V2Showcase: React.FC = () => {
 
         {/* Footer conversion card — reinforce that this is a real, ownable room. */}
         <section className="v2-showcase__footer-cta">
-          <div className="v2-showcase__footer-title">This is a real Commonly room.</div>
+          <div className="v2-showcase__footer-title">{t('showcase.footer.title')}</div>
           <div className="v2-showcase__footer-text">
-            Bring your team and your agents into one shared memory. Start your own in minutes — it&apos;s open-source and free.
+            {t('showcase.footer.text')}
           </div>
           <div className="v2-showcase__empty-cta">
-            <Link className="v2-showcase__btn v2-showcase__btn--primary" to="/v2/register">Sign up to join</Link>
-            <Link className="v2-showcase__btn v2-showcase__btn--ghost" to="/v2/landing">What is Commonly?</Link>
+            <Link className="v2-showcase__btn v2-showcase__btn--primary" to="/v2/register">{t('showcase.nav.signUpToJoin')}</Link>
+            <Link className="v2-showcase__btn v2-showcase__btn--ghost" to="/v2/landing">{t('showcase.nav.whatIs')}</Link>
           </div>
         </section>
       </main>


### PR DESCRIPTION
Global-translation Phase 2: every remaining v2 surface's user-facing strings extracted to `t()`, with en + zh-CN drafts. Follows #715's infra + landing.

**Coverage** (one namespace per component): admin users + analytics, pod inspector, marketplace + detail, compare, showcase, agent BYO, agent profile, pods sidebar, feedback menu, your-team. ~511 new keys.

**Invariants**
- en.json and zh-CN.json verified to have IDENTICAL key sets (no raw-key renders).
- Backend enum values, API paths, brand/runtime names (OpenClaw, Codex, Pod, GitHub…), and dynamic user data left untranslated by design.
- zh drafted against the `zh-cn-ui-localization` skill glossary; **a native-voice polish pass + Sam's translation review gate precede merge.**

**Deferred**: V2MessageBubble (a pre-existing `message._id` type issue predates this PR; redone as a small follow-up).

Tests: 21 v2 suites / 81 pass. Lint: 0 errors. Post-merge: live browser check of a few translated surfaces (admin, marketplace, inspector) in zh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMeWzgFxsfBcjoLVLewEES