### PR TITLE
test(i18n): enforce CLDR plural completeness

### DIFF
--- a/frontend/src/i18n/__tests__/translationKeys.test.ts
+++ b/frontend/src/i18n/__tests__/translationKeys.test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 type TranslationTree = { [key: string]: string | TranslationTree };
 
 const eslintConfig = require('../../../.eslintrc.js');
+const PLURAL_SUFFIX = /_(zero|one|two|few|many|other)$/;
 
 const flattenKeys = (tree: TranslationTree, prefix = ''): string[] => (
   Object.entries(tree).flatMap(([key, value]) => {
@@ -40,11 +41,23 @@ describe('i18n migration manifest', () => {
   const enKeys = new Set(flattenKeys(readJson('en.json')));
   const zhKeys = new Set(flattenKeys(readJson('zh-CN.json')));
   const hasKey = (keys: Set<string>, key: string): boolean => (
-    keys.has(key) || keys.has(`${key}_one`) || keys.has(`${key}_other`)
+    keys.has(key) || [...keys].some((candidate) => candidate.replace(PLURAL_SUFFIX, '') === key)
   );
 
-  it('keeps English and Simplified Chinese key paths identical', () => {
-    expect([...zhKeys].sort()).toEqual([...enKeys].sort());
+  it('keeps English and Simplified Chinese base key paths identical', () => {
+    const normalize = (keys: Set<string>) => [...new Set([...keys].map((key) => key.replace(PLURAL_SUFFIX, '')))];
+    expect(normalize(zhKeys).sort()).toEqual(normalize(enKeys).sort());
+  });
+
+  it('provides every CLDR plural form required by each language', () => {
+    const pluralBases = new Set([...enKeys, ...zhKeys].filter((key) => PLURAL_SUFFIX.test(key)).map((key) => key.replace(PLURAL_SUFFIX, '')));
+    const missing = (language: string, keys: Set<string>) => [...pluralBases].flatMap((base) => (
+      new Intl.PluralRules(language).resolvedOptions().pluralCategories
+        .filter((category) => !keys.has(`${base}_${category}`))
+        .map((category) => `${language}:${base}_${category}`)
+    ));
+
+    expect([...missing('en', enKeys), ...missing('zh-CN', zhKeys)]).toEqual([]);
   });
 
   it('resolves every literal translation key used by a migrated component', () => {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -736,8 +736,10 @@
     "hidePodTeam": "Hide pod team",
     "createdByMeta": "Created by {{name}} · {{date}}",
     "agentCount": "{{count}} agent",
+    "agentCount_one": "{{count}} agent",
     "agentCount_other": "{{count}} agents",
     "humanCount": "{{count}} human",
+    "humanCount_one": "{{count}} human",
     "humanCount_other": "{{count}} humans",
     "untitledAnnouncement": "Untitled announcement",
     "externalLink": "External link",
@@ -768,6 +770,7 @@
     "progress": {
       "title": "Progress",
       "stat": "{{complete}} of {{total}} task complete",
+      "stat_one": "{{complete}} of {{total}} task complete",
       "stat_other": "{{complete}} of {{total}} tasks complete"
     },
     "goal": {
@@ -854,6 +857,7 @@
       "emptyDeck": "Empty deck",
       "truncated": "Preview truncated at 200 KB. Click Open for the full file.",
       "moreRows": "{{count}} more row not shown. Click Open for the full file.",
+      "moreRows_one": "{{count}} more row not shown. Click Open for the full file.",
       "moreRows_other": "{{count}} more rows not shown. Click Open for the full file."
     }
   },


### PR DESCRIPTION
## Summary
- compare locale catalogs by normalized plural base keys instead of misleading raw path equality
- assert every pluralized key provides each CLDR category required by that locale
- add four English singular forms the new guard immediately exposed

English now has 929 raw paths and zh-CN has 925 by design: English requires `_one` and `_other`, while zh-CN requires only `_other`; normalized base-key parity remains exact. No Chinese copy changed.

## Verification
- `npm test -- --runInBand src/i18n/__tests__/translationKeys.test.ts`
- `npm test -- --runInBand src/i18n`
- `npm test -- --runInBand` — 61 suites, 267 tests
- `npx eslint --quiet src/i18n/__tests__/translationKeys.test.ts`
- `git diff --check`

`npm run typecheck` remains blocked by three pre-existing errors in `V2GithubPrCard.tsx` and `V2MessageBubble.tsx`, outside this diff.