### PR TITLE
feat: add Community pod filter

### DIFF
--- a/backend/__tests__/service/pods.community-scope.test.js
+++ b/backend/__tests__/service/pods.community-scope.test.js
@@ -1,0 +1,123 @@
+process.env.PG_HOST = '';
+process.env.JWT_SECRET = 'community-scope-test-secret';
+
+// This suite exercises route ownership and controller filtering, not JWT
+// cryptography. Keep it runnable on Node 26, where jsonwebtoken's transitive
+// SlowBuffer dependency is not yet compatible.
+jest.mock('jsonwebtoken', () => ({
+  sign: ({ id }) => `test-token:${id}`,
+  verify: (token) => ({ id: token.replace('test-token:', '') }),
+}));
+
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const request = require('supertest');
+const Pod = require('../../models/Pod');
+const User = require('../../models/User');
+const podRoutes = require('../../routes/pods');
+const {
+  setupMongoDb,
+  closeMongoDb,
+  clearMongoDb,
+} = require('../utils/testUtils');
+
+describe('GET /api/pods community scope', () => {
+  let app;
+  let viewer;
+  let otherUser;
+  let viewerToken;
+  let memberPod;
+  let communityPod;
+  let privatePod;
+  let forcedPersonalPods;
+
+  beforeAll(async () => {
+    await setupMongoDb();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/pods', podRoutes);
+
+    viewer = await User.create({
+      username: 'community-viewer',
+      email: 'community-viewer@test.com',
+      password: 'Password123!',
+      isVerified: true,
+    });
+    otherUser = await User.create({
+      username: 'community-owner',
+      email: 'community-owner@test.com',
+      password: 'Password123!',
+      isVerified: true,
+    });
+    viewerToken = jwt.sign({ id: viewer._id }, process.env.JWT_SECRET, { expiresIn: '1h' });
+
+    memberPod = await Pod.create({
+      name: 'My private team',
+      type: 'team',
+      createdBy: viewer._id,
+      members: [viewer._id],
+      publicRead: false,
+    });
+    communityPod = await Pod.create({
+      name: 'Public community pod',
+      type: 'team',
+      createdBy: otherUser._id,
+      members: [otherUser._id],
+      publicRead: true,
+    });
+    privatePod = await Pod.create({
+      name: 'Other private team',
+      type: 'team',
+      createdBy: otherUser._id,
+      members: [otherUser._id],
+      publicRead: false,
+    });
+    forcedPersonalPods = await Promise.all(['agent-room', 'agent-dm', 'agent-admin'].map((type) => (
+      Pod.create({
+        name: `Forced public ${type}`,
+        type,
+        createdBy: otherUser._id,
+        members: [otherUser._id],
+        // These rows bypass the admin toggle deliberately. The discovery
+        // query must remain safe even if legacy/manual data is malformed.
+        publicRead: true,
+      })
+    )));
+  });
+
+  afterAll(async () => {
+    await clearMongoDb();
+    await closeMongoDb();
+  });
+
+  it('returns non-member public pods while excluding every personal pod type', async () => {
+    const res = await request(app)
+      .get('/api/pods?scope=community')
+      .set('Authorization', `Bearer ${viewerToken}`);
+
+    expect(res.status).toBe(200);
+    const ids = res.body.map((pod) => pod._id);
+    expect(ids).toEqual([communityPod._id.toString()]);
+    expect(ids).not.toContain(privatePod._id.toString());
+    forcedPersonalPods.forEach((pod) => {
+      expect(ids).not.toContain(pod._id.toString());
+    });
+  });
+
+  it('keeps the default listing membership-only for the same fixtures', async () => {
+    const res = await request(app)
+      .get('/api/pods')
+      .set('Authorization', `Bearer ${viewerToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.map((pod) => pod._id)).toEqual([memberPod._id.toString()]);
+    expect(res.body.map((pod) => pod._id)).not.toContain(communityPod._id.toString());
+  });
+
+  it('still requires authentication', async () => {
+    const res = await request(app).get('/api/pods?scope=community');
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/controllers/podController.ts
+++ b/backend/controllers/podController.ts
@@ -17,6 +17,7 @@ if (process.env.PG_HOST) {
 }
 
 const VALID_POD_TYPES = ['chat', 'study', 'games', 'agent-ensemble', 'agent-admin', 'agent-room', 'team'];
+const COMMUNITY_EXCLUDED_POD_TYPES = ['agent-room', 'agent-dm', 'agent-admin'];
 const DEFAULT_POD_AGENT = process.env.DEFAULT_POD_AGENT_NAME || 'commonly-bot';
 const DEFAULT_POD_AGENT_SCOPES = [
   'context:read',
@@ -156,9 +157,22 @@ const installDefaultAgentForPod = async ({ pod, userId }: { pod: any; userId: an
 exports.getAllPods = async (req: any, res: any) => {
   try {
     const { type } = req.query;
+    const scope = String(req.query?.scope || 'mine').toLowerCase();
+    const isCommunityScope = scope === 'community';
     // Exclude agent-admin DM pods from default listing; only show when
     // explicitly requested and the caller is a member.
-    const query = type ? { type } : { type: { $ne: 'agent-admin' } };
+    // Community is an explicit, additive discovery scope. Personal pod types
+    // stay excluded even if a malformed/admin-created row has publicRead=true.
+    // Keep the default query semantically identical to the privacy-hardened
+    // membership listing below.
+    const query = isCommunityScope
+      ? {
+        publicRead: true,
+        type: type
+          ? { $eq: type, $nin: COMMUNITY_EXCLUDED_POD_TYPES }
+          : { $nin: COMMUNITY_EXCLUDED_POD_TYPES },
+      }
+      : (type ? { type } : { type: { $ne: 'agent-admin' } });
 
     let pods = await Pod.find(query)
       .populate('createdBy', 'username profilePicture')
@@ -184,9 +198,8 @@ exports.getAllPods = async (req: any, res: any) => {
     // their own pod list must be their own pods, otherwise every
     // private DM in the instance leaks into their sidebar (which made
     // xcjsam see — and try to post into — sam-demo's agent-rooms).
-    const scope = String(req.query?.scope || 'mine').toLowerCase();
     const isPersonal = type === 'agent-admin' || type === 'agent-room' || type === 'agent-dm';
-    if (req.userId) {
+    if (req.userId && !isCommunityScope) {
       const wantsAll = scope === 'all';
       const isAdmin = wantsAll ? await isGlobalAdminRequest(req) : false;
       const filterToMine = isPersonal || !wantsAll || !isAdmin;

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1242,7 +1242,8 @@
     "filters": {
       "all": "All",
       "team": "Team",
-      "private": "Private"
+      "private": "Private",
+      "community": "Community"
     },
     "groups": {
       "pinned": "Pinned",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1238,7 +1238,8 @@
     "filters": {
       "all": "全部",
       "team": "团队",
-      "private": "私密"
+      "private": "私密",
+      "community": "社区"
     },
     "groups": {
       "pinned": "已置顶",

--- a/frontend/src/v2/__tests__/V2PodsSidebar.community.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodsSidebar.community.test.tsx
@@ -1,12 +1,20 @@
 // @ts-nocheck
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, useLocation } from 'react-router-dom';
+import i18n, { i18nReady } from '../../i18n';
 import V2PodsSidebar from '../components/V2PodsSidebar';
 
 const COMMUNITY_POD_ID = 'community-pod';
 const mockJoinPod = jest.fn();
 const mockSeedFromExisting = jest.fn();
+const mockApiGet = jest.fn();
+const mockApi = {
+  get: mockApiGet,
+  post: jest.fn(),
+  patch: jest.fn(),
+  del: jest.fn(),
+};
 
 jest.mock('../hooks/useV2Pods', () => ({
   useV2Pods: () => ({
@@ -24,6 +32,10 @@ jest.mock('../hooks/useV2Pinned', () => ({
     toggle: jest.fn(),
     isPinned: () => false,
   }),
+}));
+
+jest.mock('../hooks/useV2Api', () => ({
+  useV2Api: () => mockApi,
 }));
 
 jest.mock('../hooks/useV2Unread', () => ({
@@ -44,13 +56,14 @@ jest.mock('../../context/AuthContext', () => ({
 
 const CurrentPath = () => <div data-testid="current-path">{useLocation().pathname}</div>;
 
-const makePod = (id: string, memberIds: string[]) => ({
+const makePod = (id: string, memberIds: string[], overrides = {}) => ({
   _id: id,
   name: id === COMMUNITY_POD_ID ? 'Commonly HQ' : 'My Workspace',
   type: 'team',
   members: memberIds.map((_id) => ({ _id, username: _id, isBot: false })),
   createdAt: '2026-07-21T12:00:00.000Z',
   updatedAt: '2026-07-21T12:00:00.000Z',
+  ...overrides,
 });
 
 const renderSidebar = (pods) => {
@@ -72,17 +85,26 @@ const renderSidebar = (pods) => {
 describe('V2PodsSidebar Community offer', () => {
   const originalCommunityPodId = process.env.REACT_APP_COMMUNITY_POD_ID;
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    process.env.REACT_APP_COMMUNITY_POD_ID = COMMUNITY_POD_ID;
+  beforeAll(async () => {
+    await i18nReady;
   });
 
-  afterAll(() => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockApiGet.mockResolvedValue([]);
+    process.env.REACT_APP_COMMUNITY_POD_ID = COMMUNITY_POD_ID;
+    await act(async () => {
+      await i18n.changeLanguage('en');
+    });
+  });
+
+  afterAll(async () => {
     if (originalCommunityPodId === undefined) {
       delete process.env.REACT_APP_COMMUNITY_POD_ID;
     } else {
       process.env.REACT_APP_COMMUNITY_POD_ID = originalCommunityPodId;
     }
+    await i18n.changeLanguage('en');
   });
 
   test('shows for a configured Community pod the human has not joined and navigates to the redirect', () => {
@@ -107,5 +129,39 @@ describe('V2PodsSidebar Community offer', () => {
     renderSidebar([makePod('workspace', ['human-1'])]);
 
     expect(screen.queryByRole('button', { name: 'Join HQ' })).not.toBeInTheDocument();
+  });
+
+  test('Community shows public discovery and HQ, excludes personal pods, and leaves All personal', async () => {
+    mockApiGet.mockResolvedValue([
+      makePod('public-space', [], { name: 'Open Builders', publicRead: true }),
+      makePod(COMMUNITY_POD_ID, [], { publicRead: true }),
+      makePod('forced-public-dm', [], {
+        name: 'Private agent room',
+        type: 'agent-room',
+        publicRead: true,
+      }),
+    ]);
+    renderSidebar([makePod('workspace', ['human-1'])]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Community' }));
+    expect(await screen.findByText('Open Builders')).toBeInTheDocument();
+    expect(screen.getByText('Commonly HQ')).toBeInTheDocument();
+    expect(screen.queryByText('Private agent room')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    expect(screen.getByText('My Workspace')).toBeInTheDocument();
+    expect(screen.queryByText('Open Builders')).not.toBeInTheDocument();
+    expect(screen.queryByText('Commonly HQ')).not.toBeInTheDocument();
+    await waitFor(() => expect(mockApiGet).toHaveBeenCalledWith('/api/pods?scope=community'));
+  });
+
+  test('renders the Community tab from both locale catalogs', async () => {
+    renderSidebar([makePod('workspace', ['human-1'])]);
+    expect(screen.getByRole('button', { name: 'Community' })).toBeInTheDocument();
+
+    await act(async () => {
+      await i18n.changeLanguage('zh-CN');
+    });
+    expect(screen.getByRole('button', { name: '社区' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -124,6 +124,16 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(v2, '.v2-pods__community')).toContain('flex-shrink: 0');
   });
 
+  test('the four pod filters stay on one row in the narrow sidebar', () => {
+    // The desktop sidebar leaves only ~240px inside its gutter (less than the
+    // mobile drawer). A four-column grid keeps Community beside the existing
+    // filters without horizontal scrolling or wrapping in either locale.
+    const rule = ruleBody(v2, '.v2-pods__filters');
+    expect(rule).toContain('display: grid');
+    expect(rule).toContain('grid-template-columns: minmax(0, 0.75fr) minmax(0, 1fr) minmax(0, 1.15fr) minmax(0, 1.7fr)');
+    expect(rule).toContain('overflow: visible');
+  });
+
   test('starter prompts wrap within the mobile chat pane', () => {
     // At 390px the rail leaves a narrow main pane. Both the row and each chip
     // need explicit shrink/wrap rules or the longest prompt creates horizontal

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -6,15 +6,17 @@ import { groupPods, formatRelativeTime } from '../utils/grouping';
 import { initialsFor } from '../utils/avatars';
 import { useV2Pinned } from '../hooks/useV2Pinned';
 import { useV2Unread } from '../hooks/useV2Unread';
+import { useV2Api } from '../hooks/useV2Api';
 import { useSocket } from '../../context/SocketContext';
 import { useAuth } from '../../context/AuthContext';
 
-type Filter = 'all' | 'team' | 'private';
+type Filter = 'all' | 'team' | 'private' | 'community';
 
 const FILTERS: Array<{ key: Filter; labelKey: string }> = [
   { key: 'all', labelKey: 'filters.all' },
   { key: 'team', labelKey: 'filters.team' },
   { key: 'private', labelKey: 'filters.private' },
+  { key: 'community', labelKey: 'filters.community' },
 ];
 
 // Both agent-room (user↔agent) and agent-dm (any 2-member combo) show
@@ -23,6 +25,7 @@ const FILTERS: Array<{ key: Filter; labelKey: string }> = [
 // that no human is in the conversation.
 const isDmPod = (pod: V2Pod): boolean => pod.type === 'agent-room' || pod.type === 'agent-dm';
 const podKind = (pod: V2Pod): 'team' | 'private' => (isDmPod(pod) ? 'private' : 'team');
+const isPersonalPod = (pod: V2Pod): boolean => isDmPod(pod) || pod.type === 'agent-admin';
 
 const isAgentToAgent = (pod: V2Pod): boolean => {
   if (pod.type !== 'agent-dm') return false;
@@ -63,13 +66,14 @@ const podSnippetFor = (pod: V2Pod, meta: string): string => {
   return pod.description?.trim() || meta;
 };
 
-const matchesFilter = (pod: V2Pod, filter: Filter): boolean => {
+const matchesPersonalFilter = (pod: V2Pod, filter: Filter): boolean => {
   switch (filter) {
     // "Team" is the strictest pod-type filter — only pods explicitly typed
     // as team (multi-human collaborative). "Private" is 1:1 DMs.
     // "All" covers everything (the redundant "Pod" filter was removed).
     case 'team': return pod.type === 'team';
     case 'private': return podKind(pod) === 'private';
+    case 'community': return false;
     case 'all':
     default:
       return true;
@@ -92,12 +96,36 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
 }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const api = useV2Api();
   const ownPodsState = useV2Pods();
   const { pods, loading, error, createPod, patchLastMessage } = podsState || ownPodsState;
   const { pinned, toggle: togglePin, isPinned } = useV2Pinned();
   const { socket, connected, joinPod } = useSocket();
   const { currentUser } = useAuth();
   const { isUnread, bumpLatest, seedFromExisting } = useV2Unread(selectedPodId);
+  const [communityPods, setCommunityPods] = useState<V2Pod[]>([]);
+  const [communityLoading, setCommunityLoading] = useState(true);
+
+  // Discovery is intentionally fetched into separate state. Merging these
+  // rows into `pods` would make non-member public pods leak into All/Team,
+  // undoing the membership-only sidebar invariant from #375.
+  useEffect(() => {
+    let active = true;
+    setCommunityLoading(true);
+    api.get<V2Pod[]>('/api/pods?scope=community')
+      .then((data) => {
+        if (active) setCommunityPods(Array.isArray(data) ? data : []);
+      })
+      .catch(() => {
+        if (active) setCommunityPods([]);
+      })
+      .finally(() => {
+        if (active) setCommunityLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [api]);
 
   // Seed lastSeen for any pod we've never observed before, using its current
   // newest-message timestamp. Without this, the very first load badges every
@@ -236,21 +264,36 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
     };
   }, [socket, connected]);
 
+  const communityPodIds = useMemo(
+    () => new Set(communityPods.map((pod) => pod._id)),
+    [communityPods],
+  );
+  const communityCandidates = useMemo(() => {
+    const byId = new Map<string, V2Pod>();
+    communityPods.forEach((pod) => byId.set(pod._id, pod));
+    // Prefer the membership-list row when both endpoints return a pod; it is
+    // the row socket/unread state already knows about.
+    pods.forEach((pod) => byId.set(pod._id, pod));
+    return Array.from(byId.values()).filter((pod) => {
+      if (isPersonalPod(pod)) return false;
+      const isPublicMembership = memberPodIds.includes(pod._id) && pod.publicRead === true;
+      return communityPodIds.has(pod._id)
+        || isPublicMembership
+        || (Boolean(communityPodId) && pod._id === communityPodId);
+    });
+  }, [communityPods, communityPodIds, pods, memberPodIds, communityPodId]);
+
   const filtered = useMemo(() => {
     const term = search.trim().toLowerCase();
-    return pods
-      .filter((pod) => matchesFilter(pod, filter))
+    const candidates = filter === 'community' ? communityCandidates : pods;
+    return candidates
+      .filter((pod) => filter === 'community' || matchesPersonalFilter(pod, filter))
       .filter((pod) => !term
         || (pod.name || '').toLowerCase().includes(term)
         || (pod.description || '').toLowerCase().includes(term));
-  }, [pods, filter, search]);
+  }, [communityCandidates, pods, filter, search]);
 
-  const filterCounts = useMemo(() => (
-    FILTERS.reduce<Record<Filter, number>>((counts, item) => {
-      counts[item.key] = pods.filter((pod) => matchesFilter(pod, item.key)).length;
-      return counts;
-    }, { all: 0, team: 0, private: 0 })
-  ), [pods]);
+  const visibleLoading = loading || (filter === 'community' && communityLoading);
 
   // Default grouping is chronological (Pinned / Today / Yesterday / This week
   // / Earlier). When the user filters down to Private, recency buckets stop
@@ -417,21 +460,20 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
               aria-pressed={filter === f.key}
             >
               {t(`podsSidebar.${f.labelKey}`)}
-              <span className="v2-filter-count">{filterCounts[f.key]}</span>
             </button>
           ))}
         </div>
 
         <div className="v2-pods__list">
-          {loading && <div className="v2-pods__empty"><span className="v2-spinner" /></div>}
-          {!loading && error && <div className="v2-pods__empty">{error}</div>}
-          {!loading && !error && filtered.length === 0 && (
+          {visibleLoading && <div className="v2-pods__empty"><span className="v2-spinner" /></div>}
+          {!visibleLoading && error && <div className="v2-pods__empty">{error}</div>}
+          {!visibleLoading && !error && filtered.length === 0 && (
             <div className="v2-pods__empty">
               {search ? t('podsSidebar.empty.noMatch') : t('podsSidebar.empty.noPods')}
             </div>
           )}
 
-          {!loading && grouped.map((group) => (
+          {!visibleLoading && grouped.map((group) => (
             <div key={group.label}>
               <div className="v2-pods__group-label">{group.label}</div>
               {group.items.map((pod) => {

--- a/frontend/src/v2/hooks/useV2Pods.ts
+++ b/frontend/src/v2/hooks/useV2Pods.ts
@@ -20,6 +20,7 @@ export interface V2Pod {
   description?: string;
   type?: string;
   joinPolicy?: string;
+  publicRead?: boolean;
   members?: (V2PodMember | string)[];
   createdBy?: { _id?: string; username?: string };
   createdAt?: string;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -780,22 +780,25 @@
 }
 
 .v2-pods__filters {
-  display: flex;
-  gap: 6px;
+  display: grid;
+  grid-template-columns: minmax(0, 0.75fr) minmax(0, 1fr) minmax(0, 1.15fr) minmax(0, 1.7fr);
+  gap: 4px;
   padding: 0;
   margin-bottom: 18px;
   flex-shrink: 0;
-  overflow-x: auto;
+  overflow: visible;
 }
 
 .v2-pods__filter {
   height: 32px;
-  padding: 0 9px;
-  font-size: 13px;
+  min-width: 0;
+  padding: 0 2px;
+  font-size: 12px;
   font-weight: 500;
   color: #4b5563;
   border-radius: var(--v2-radius-sm);
   text-align: center;
+  white-space: nowrap;
   transition: background 80ms ease, color 80ms ease;
 }
 


### PR DESCRIPTION
## Summary
- add an authenticated `scope=community` pod listing for non-personal `publicRead` pods while preserving the default membership-only listing
- add a bilingual Community/社区 sidebar tab backed by a separate, deduplicated discovery dataset so All/Team/Private remain personal
- exclude every DM/admin pod shape defensively and keep the four-tab row on one line at desktop and mobile widths

## Proof
- backend controller + service suites: 24 tests passed
- full frontend suite: 61 suites / 270 tests passed
- i18n manifest, base-key parity, and CLDR completeness: passed
- backend + frontend production builds: passed
- changed frontend files: ESLint 0 errors
- Chromium: EN + zh-CN at 1280x900 and 390x844; one row, `scrollWidth === clientWidth`, no document overflow, no page errors

## Privacy invariant
Community discovery is stored separately from the membership list. The regression tests assert that the same non-member public pod appears under Community and remains absent from the default/All view.