### PR TITLE
fix(community): listing is opt-in — separate communityListed from publicRead

### DIFF
--- a/backend/__tests__/service/pods.community-scope.test.js
+++ b/backend/__tests__/service/pods.community-scope.test.js
@@ -28,6 +28,7 @@ describe('GET /api/pods community scope', () => {
   let viewerToken;
   let memberPod;
   let communityPod;
+  let showcasePod;
   let privatePod;
   let forcedPersonalPods;
 
@@ -65,6 +66,17 @@ describe('GET /api/pods community scope', () => {
       createdBy: otherUser._id,
       members: [otherUser._id],
       publicRead: true,
+      communityListed: true,
+    });
+    // Readable but NOT listed — the showcase-room shape (Eng Milestone etc.):
+    // anonymous read access stays, Community tab must not surface it.
+    showcasePod = await Pod.create({
+      name: 'Showcase room (readable, unlisted)',
+      type: 'team',
+      createdBy: otherUser._id,
+      members: [otherUser._id],
+      publicRead: true,
+      communityListed: false,
     });
     privatePod = await Pod.create({
       name: 'Other private team',
@@ -80,8 +92,10 @@ describe('GET /api/pods community scope', () => {
         createdBy: otherUser._id,
         members: [otherUser._id],
         // These rows bypass the admin toggle deliberately. The discovery
-        // query must remain safe even if legacy/manual data is malformed.
+        // query must remain safe even if legacy/manual data is malformed —
+        // even when BOTH flags are (wrongly) set on a personal pod type.
         publicRead: true,
+        communityListed: true,
       })
     )));
   });
@@ -100,6 +114,8 @@ describe('GET /api/pods community scope', () => {
     const ids = res.body.map((pod) => pod._id);
     expect(ids).toEqual([communityPod._id.toString()]);
     expect(ids).not.toContain(privatePod._id.toString());
+    // Readable-but-unlisted showcase rooms must stay OFF the Community tab.
+    expect(ids).not.toContain(showcasePod._id.toString());
     forcedPersonalPods.forEach((pod) => {
       expect(ids).not.toContain(pod._id.toString());
     });

--- a/backend/controllers/podController.ts
+++ b/backend/controllers/podController.ts
@@ -167,7 +167,10 @@ exports.getAllPods = async (req: any, res: any) => {
     // membership listing below.
     const query = isCommunityScope
       ? {
+        // Listed is opt-in and distinct from readable: showcase rooms keep
+        // publicRead for anonymous viewing without appearing in Community.
         publicRead: true,
+        communityListed: true,
         type: type
           ? { $eq: type, $nin: COMMUNITY_EXCLUDED_POD_TYPES }
           : { $nin: COMMUNITY_EXCLUDED_POD_TYPES },

--- a/backend/models/Pod.ts
+++ b/backend/models/Pod.ts
@@ -63,6 +63,12 @@ export interface IPod extends Document {
   // personal pod type (agent-dm / agent-room / agent-admin); the admin
   // toggle rejects those. Defaults false so every existing pod is private.
   publicRead: boolean;
+  // Community-tab listing is OPT-IN and separate from readability: publicRead
+  // grants anonymous/showcase READ access; communityListed additionally puts
+  // the pod on the Community discovery surface. Showcase rooms (Eng Milestone
+  // etc.) stay publicRead but unlisted. Listing is admin-curated for now; an
+  // owner-side "request listing" flow is the planned phase 2 (Sam 2026-07-22).
+  communityListed: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -131,6 +137,7 @@ const PodSchema = new Schema<IPod>(
     // Admin-set only; never on personal pod types. Gates the anonymous
     // /api/showcase read path. See backend/routes/showcase.ts.
     publicRead: { type: Boolean, default: false },
+    communityListed: { type: Boolean, default: false },
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now },
   },


### PR DESCRIPTION
Sam's catch on the live Community tab: the showcase rooms (Eng Milestone, First 10 Users) appeared because #721 used `publicRead` as the listing criterion — but those pods are publicRead for the landing/YC **showcase links**, not for discovery.

**Model fix**: `publicRead` = anonymous READ access (showcase). `communityListed` (new, default false) = opt-in Community-tab discovery. The community scope now requires both; personal pod types stay excluded even with both flags wrongly set (tested).

**Curation posture** (Sam's call): listing is admin-curated for now; owner-side 'request listing → admin approval' is phase 2 when demand appears.

Post-merge: flip `communityListed: true` on the HQ pod only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMeWzgFxsfBcjoLVLewEES