### PR TITLE
feat(v2): guide newly created pods to first message

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -268,6 +268,22 @@
       "quietTitle": "This pod is quiet",
       "quietText": "Use @ to mention an agent or teammate—everyone in the member list can see and reply."
     },
+    "newPod": {
+      "label": "New Pod starter actions",
+      "title": "Your Pod is ready",
+      "text": "Bring in people or an agent, or start the conversation yourself.",
+      "dismiss": "Dismiss starter actions",
+      "inviteTitle": "Invite people",
+      "inviteText": "Share this link to bring teammates in.",
+      "preparingInvite": "Creating invite link…",
+      "inviteLinkLabel": "Invite link for this Pod",
+      "inviteError": "The invite link could not be created.",
+      "tryAgain": "Try again",
+      "addAgentTitle": "Add an agent",
+      "addAgentText": "Choose an agent to add to this Pod.",
+      "messageTitle": "Write the first message",
+      "messageText": "Start the conversation in the composer."
+    },
     "heartbeat": {
       "recent_one": "{{formattedCount}} recent heartbeat",
       "recent_other": "{{formattedCount}} recent heartbeats",
@@ -1251,9 +1267,8 @@
       "betweenAgents": "Between agents · {{count}}"
     },
     "create": {
-      "teamOption": "Create Team Pod",
-      "privateOption": "Start Private Pod",
-      "privateHint": "Start a Private pod from an agent row or existing private conversation.",
+      "teamOption": "Team Pod",
+      "privateOption": "Private Pod",
       "namePlaceholder": "Pod name",
       "goalPlaceholder": "Goal or description",
       "cancel": "Cancel",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -268,6 +268,22 @@
       "quietTitle": "这个 Pod 还很安静",
       "quietText": "用 @ 提及智能体或队友，成员列表中的所有人都能看到并回复。"
     },
+    "newPod": {
+      "label": "新 Pod 开始操作",
+      "title": "Pod 已就绪",
+      "text": "邀请队友、添加智能体，或自己开始对话。",
+      "dismiss": "关闭开始操作",
+      "inviteTitle": "邀请队友",
+      "inviteText": "分享链接，邀请队友加入。",
+      "preparingInvite": "正在创建邀请链接…",
+      "inviteLinkLabel": "这个 Pod 的邀请链接",
+      "inviteError": "邀请链接创建失败。",
+      "tryAgain": "重试",
+      "addAgentTitle": "添加智能体",
+      "addAgentText": "选择要添加到这个 Pod 的智能体。",
+      "messageTitle": "发送第一条消息",
+      "messageText": "在输入框中开始对话。"
+    },
     "heartbeat": {
       "none": "最近没有收到心跳",
       "recent_one": "最近收到 {{formattedCount}} 次心跳",
@@ -1247,9 +1263,8 @@
       "betweenAgents": "智能体之间 · {{count}}"
     },
     "create": {
-      "teamOption": "创建团队 Pod",
-      "privateOption": "创建私密 Pod",
-      "privateHint": "请从智能体所在行或已有的私密会话中创建私密 Pod。",
+      "teamOption": "团队 Pod",
+      "privateOption": "私密 Pod",
       "namePlaceholder": "Pod 名称",
       "goalPlaceholder": "目标或描述",
       "cancel": "取消",

--- a/frontend/src/v2/__tests__/V2InviteDmGate.test.tsx
+++ b/frontend/src/v2/__tests__/V2InviteDmGate.test.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import V2Layout from '../components/V2Layout';
 
@@ -34,10 +34,21 @@ jest.mock('../hooks/useV2PodDetail', () => ({
 jest.mock('../components/V2NavRail', () => () => null);
 jest.mock('../components/V2PodsSidebar', () => () => null);
 jest.mock('../components/V2PodInspector', () => () => null);
-jest.mock('../components/V2InviteModal', () => () => null);
+jest.mock('../components/V2InviteModal', () => function MockV2InviteModal({ open, initialTab }) {
+  return open ? <div data-testid="invite-modal-tab">{initialTab}</div> : null;
+});
 jest.mock('../components/V2FirstRunHero', () => () => null);
 jest.mock('../components/V2PodChat', () => function MockV2PodChat({ onOpenInvite }) {
-  return <div>{onOpenInvite && <button type="button">Invite</button>}</div>;
+  return (
+    <div>
+      {onOpenInvite && (
+        <>
+          <button type="button" onClick={() => onOpenInvite()}>Invite</button>
+          <button type="button" onClick={() => onOpenInvite('agent')}>Add agent</button>
+        </>
+      )}
+    </div>
+  );
 });
 
 const renderLayout = () => render(
@@ -63,5 +74,13 @@ describe('V2 invite affordance gating', () => {
     mockPodType = podType;
     renderLayout();
     expect(screen.getByRole('button', { name: 'Invite' })).toBeInTheDocument();
+  });
+
+  test('passes the starter action through to the modal agent tab', () => {
+    mockPodType = 'chat';
+    renderLayout();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add agent' }));
+    expect(screen.getByTestId('invite-modal-tab')).toHaveTextContent('agent');
   });
 });

--- a/frontend/src/v2/__tests__/V2InviteModal.test.tsx
+++ b/frontend/src/v2/__tests__/V2InviteModal.test.tsx
@@ -17,10 +17,16 @@ jest.mock('../hooks/useV2Api', () => ({
   useV2Api: () => mockApi,
 }));
 
-const renderModal = () => render(
+const renderModal = (initialTab = 'people') => render(
   <MemoryRouter>
     <div className="v2-root">
-      <V2InviteModal open podId="pod-1" podName="Launch room" onClose={jest.fn()} />
+      <V2InviteModal
+        open
+        podId="pod-1"
+        podName="Launch room"
+        initialTab={initialTab}
+        onClose={jest.fn()}
+      />
     </div>
   </MemoryRouter>,
 );
@@ -72,5 +78,13 @@ describe('V2InviteModal', () => {
 
     await waitFor(() => expect(mockApi.del).toHaveBeenCalledWith(`/api/invites/${token}`));
     await waitFor(() => expect(screen.queryByText('Aria')).not.toBeInTheDocument());
+  });
+
+  test('opens directly on the agent tab when requested by the starter panel', () => {
+    renderModal('agent');
+
+    expect(screen.getByRole('tab', { name: 'Add agent' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('button', { name: 'Browse agents →' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Generate invite link' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/v2/__tests__/V2PodChatStarter.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatStarter.test.tsx
@@ -218,7 +218,7 @@ describe('V2PodChat just-created Pod starter panel', () => {
     expect(composer).toHaveFocus();
   });
 
-  test('stays absent without the flag, after messages arrive, or behind first-run', async () => {
+  test('stays absent without the flag or after messages arrive', async () => {
     const noFlag = renderChat(makeDetail());
     expect(screen.queryByText('Your Pod is ready')).not.toBeInTheDocument();
     expect(screen.getByText('This pod is quiet')).toBeInTheDocument();
@@ -231,7 +231,9 @@ describe('V2PodChat just-created Pod starter panel', () => {
     expect(screen.queryByText('Your Pod is ready')).not.toBeInTheDocument();
     await waitFor(() => expect(sessionStorage.getItem('v2.justCreated.p1')).toBeNull());
     withMessage.unmount();
+  });
 
+  test('keeps the first-run guide above the starter panel', () => {
     sessionStorage.setItem('v2.justCreated.p1', '1');
     renderChat(makeDetail(), {
       firstRunVisible: true,
@@ -239,6 +241,13 @@ describe('V2PodChat just-created Pod starter panel', () => {
     });
     expect(screen.getByText('First-run guide')).toBeInTheDocument();
     expect(screen.queryByText('Your Pod is ready')).not.toBeInTheDocument();
+  });
+
+  test('does not mint an invite when the starter panel does not render', () => {
+    renderChat(makeDetail());
+
+    expect(screen.queryByText('Your Pod is ready')).not.toBeInTheDocument();
+    expect(screen.getByText('This pod is quiet')).toBeInTheDocument();
     expect(axios.post).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/v2/__tests__/V2PodChatStarter.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatStarter.test.tsx
@@ -4,6 +4,7 @@ import {
   fireEvent, render, screen, waitFor,
 } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import axios from 'axios';
 import V2PodChat from '../components/V2PodChat';
 import { AuthContext } from '../../context/AuthContext';
 
@@ -23,6 +24,10 @@ jest.mock('../components/V2MessageBubble', () => {
 // jsdom has no scrollIntoView; the component auto-scrolls on mount.
 beforeAll(() => {
   Element.prototype.scrollIntoView = jest.fn();
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText: jest.fn().mockResolvedValue(undefined) },
+  });
 });
 
 // Same mock surface as V2Login.test.tsx — axiosConfig assigns
@@ -86,6 +91,12 @@ const makeAgentRoom = (overrides = {}) => makeDetail({
 });
 
 describe('V2PodChat teaching empty states', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+    axios.post.mockResolvedValue({ data: {} });
+  });
+
   test('regular empty pods teach visible membership and @-mentions', () => {
     renderChat(makeDetail());
 
@@ -120,6 +131,12 @@ describe('V2PodChat teaching empty states', () => {
 });
 
 describe('V2PodChat starter prompts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+    axios.post.mockResolvedValue({ data: {} });
+  });
+
   test('render for an empty agent room after first-run and never auto-send', async () => {
     const detail = makeAgentRoom();
     renderChat(detail);
@@ -162,5 +179,78 @@ describe('V2PodChat starter prompts', () => {
       firstRunHero: <div>First-run guide</div>,
     });
     expect(screen.queryByRole('group', { name: 'Conversation starters' })).not.toBeInTheDocument();
+  });
+});
+
+describe('V2PodChat just-created Pod starter panel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+    axios.post.mockResolvedValue({ data: {} });
+  });
+
+  test('pre-generates a copyable invite and offers agent and composer actions', async () => {
+    const token = 'd'.repeat(32);
+    const onOpenInvite = jest.fn();
+    sessionStorage.setItem('v2.justCreated.p1', '1');
+    axios.post.mockResolvedValueOnce({ data: { token } });
+    renderChat(makeDetail(), { onOpenInvite });
+
+    expect(await screen.findByText('Your Pod is ready')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/pods/p1/invites',
+        {},
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+    });
+
+    const inviteUrl = `${window.location.origin}/v2/invite/${token}`;
+    expect(await screen.findByLabelText('Invite link for this Pod')).toHaveValue(inviteUrl);
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith(inviteUrl));
+
+    fireEvent.click(screen.getByRole('button', { name: /^Add an agent/ }));
+    expect(onOpenInvite).toHaveBeenCalledWith('agent');
+
+    const composer = screen.getByPlaceholderText('Message My Workspace…');
+    fireEvent.click(screen.getByRole('button', { name: /^Write the first message/ }));
+    expect(composer).toHaveFocus();
+  });
+
+  test('stays absent without the flag, after messages arrive, or behind first-run', async () => {
+    const noFlag = renderChat(makeDetail());
+    expect(screen.queryByText('Your Pod is ready')).not.toBeInTheDocument();
+    expect(screen.getByText('This pod is quiet')).toBeInTheDocument();
+    noFlag.unmount();
+
+    sessionStorage.setItem('v2.justCreated.p1', '1');
+    const withMessage = renderChat(makeDetail({
+      messages: [{ id: 'm1', content: 'First!', user: { username: 'solo-user' } }],
+    }));
+    expect(screen.queryByText('Your Pod is ready')).not.toBeInTheDocument();
+    await waitFor(() => expect(sessionStorage.getItem('v2.justCreated.p1')).toBeNull());
+    withMessage.unmount();
+
+    sessionStorage.setItem('v2.justCreated.p1', '1');
+    renderChat(makeDetail(), {
+      firstRunVisible: true,
+      firstRunHero: <div>First-run guide</div>,
+    });
+    expect(screen.getByText('First-run guide')).toBeInTheDocument();
+    expect(screen.queryByText('Your Pod is ready')).not.toBeInTheDocument();
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  test('dismisses explicitly and clears the session flag', async () => {
+    sessionStorage.setItem('v2.justCreated.p1', '1');
+    axios.post.mockResolvedValueOnce({ data: { token: 'e'.repeat(32) } });
+    renderChat(makeDetail());
+
+    expect(await screen.findByText('Your Pod is ready')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss starter actions' }));
+
+    expect(screen.queryByText('Your Pod is ready')).not.toBeInTheDocument();
+    expect(sessionStorage.getItem('v2.justCreated.p1')).toBeNull();
   });
 });

--- a/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
@@ -1,0 +1,104 @@
+// @ts-nocheck
+import React from 'react';
+import {
+  fireEvent, render, screen, waitFor,
+} from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import V2PodsSidebar from '../components/V2PodsSidebar';
+
+const mockCreatePod = jest.fn();
+
+jest.mock('../hooks/useV2Pods', () => ({
+  useV2Pods: () => ({
+    pods: [],
+    loading: false,
+    error: null,
+    createPod: mockCreatePod,
+    patchLastMessage: jest.fn(),
+  }),
+}));
+
+jest.mock('../hooks/useV2Pinned', () => ({
+  useV2Pinned: () => ({
+    pinned: new Set(),
+    toggle: jest.fn(),
+    isPinned: () => false,
+  }),
+}));
+
+jest.mock('../hooks/useV2Api', () => ({
+  useV2Api: () => ({
+    get: jest.fn().mockResolvedValue([]),
+    post: jest.fn(),
+    patch: jest.fn(),
+    del: jest.fn(),
+  }),
+}));
+
+jest.mock('../hooks/useV2Unread', () => ({
+  useV2Unread: () => ({
+    isUnread: () => false,
+    bumpLatest: jest.fn(),
+    seedFromExisting: jest.fn(),
+  }),
+}));
+
+jest.mock('../../context/SocketContext', () => ({
+  useSocket: () => ({ socket: null, connected: false, joinPod: jest.fn() }),
+}));
+
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ currentUser: { _id: 'human-1', username: 'builder' } }),
+}));
+
+const CurrentPath = () => <div data-testid="current-path">{useLocation().pathname}</div>;
+
+describe('V2PodsSidebar create flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+    mockCreatePod.mockResolvedValue({
+      _id: 'new-private-pod',
+      name: 'Launch circle',
+      type: 'team',
+      joinPolicy: 'invite-only',
+    });
+  });
+
+  it('creates a real invite-only Pod and marks it for the starter panel', async () => {
+    const podsState = {
+      pods: [],
+      loading: false,
+      error: null,
+      createPod: mockCreatePod,
+      patchLastMessage: jest.fn(),
+    };
+    render(
+      <MemoryRouter initialEntries={['/v2']}>
+        <V2PodsSidebar selectedPodId={null} podsState={podsState} />
+        <CurrentPath />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'New Pod' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Private Pod' }));
+    fireEvent.change(screen.getByPlaceholderText('Pod name'), {
+      target: { value: 'Launch circle' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Goal or description'), {
+      target: { value: 'Prepare the launch' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => {
+      expect(mockCreatePod).toHaveBeenCalledWith(
+        'Launch circle',
+        'Prepare the launch',
+        'team',
+        'invite-only',
+      );
+    });
+    expect(sessionStorage.getItem('v2.justCreated.new-private-pod')).toBe('1');
+    expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/new-private-pod');
+  });
+});

--- a/frontend/src/v2/__tests__/useV2PodsCreate.test.tsx
+++ b/frontend/src/v2/__tests__/useV2PodsCreate.test.tsx
@@ -1,0 +1,47 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useV2Pods } from '../hooks/useV2Pods';
+
+const mockApi = {
+  get: jest.fn(),
+  post: jest.fn(),
+  patch: jest.fn(),
+  del: jest.fn(),
+};
+
+jest.mock('../hooks/useV2Api', () => ({
+  useV2Api: () => mockApi,
+}));
+
+describe('useV2Pods create', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApi.get.mockResolvedValue([]);
+    mockApi.post.mockResolvedValue({
+      _id: 'private-pod',
+      name: 'Launch circle',
+      type: 'team',
+      joinPolicy: 'invite-only',
+    });
+  });
+
+  it('passes an invite-only join policy through to the create endpoint', async () => {
+    const { result } = renderHook(() => useV2Pods());
+    await waitFor(() => expect(mockApi.get).toHaveBeenCalledWith('/api/pods'));
+
+    await act(async () => {
+      await result.current.createPod(
+        'Launch circle',
+        'Prepare the launch',
+        'team',
+        'invite-only',
+      );
+    });
+
+    expect(mockApi.post).toHaveBeenCalledWith('/api/pods', {
+      name: 'Launch circle',
+      description: 'Prepare the launch',
+      type: 'team',
+      joinPolicy: 'invite-only',
+    });
+  });
+});

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -146,6 +146,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(chip).toContain('white-space: normal');
   });
 
+  test('the new-pod starter panel shrinks and stacks inside the mobile chat pane', () => {
+    const panel = ruleBody(v2, '.v2-chat__new-pod');
+    const actions = ruleBody(v2, '.v2-chat__new-pod-actions');
+    expect(panel).toContain('width: min(720px, 100%)');
+    expect(actions).toContain('repeat(2, minmax(0, 1fr))');
+    expect(v2).toContain('.v2-chat__new-pod-actions {\n    grid-template-columns: minmax(0, 1fr)');
+  });
+
   test('invite management controls collapse to one column on phones', () => {
     // The modal is wider than the mobile shell and carries two selects plus a
     // URL/copy row. At <=480px both must wrap or the link input pushes the

--- a/frontend/src/v2/components/V2InviteModal.tsx
+++ b/frontend/src/v2/components/V2InviteModal.tsx
@@ -12,6 +12,7 @@ interface V2InviteModalProps {
   open: boolean;
   podId: string;
   podName: string;
+  initialTab?: V2InviteTab;
   onClose: () => void;
 }
 
@@ -26,6 +27,7 @@ interface ManagedInvite {
 
 type ExpiryPreset = 'never' | '24' | '168' | '720';
 type MaxUsesPreset = 'unlimited' | '1' | '10' | '25';
+export type V2InviteTab = 'people' | 'agent';
 const CLOSE_MARK = '×';
 
 const inviteUrlFor = (token: string): string => (
@@ -60,13 +62,15 @@ const expiryLabel = (value: string | null | undefined, t: TFunction, locale: str
   return t('inviteModal.expiry.expiresOn', { date: expiry.toLocaleDateString(locale) });
 };
 
-const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onClose }) => {
+const V2InviteModal: React.FC<V2InviteModalProps> = ({
+  open, podId, podName, initialTab = 'people', onClose,
+}) => {
   const { t, i18n } = useTranslation();
   const locale = i18n.resolvedLanguage || i18n.language || 'en';
   const numberFormatter = new Intl.NumberFormat(locale);
   const api = useV2Api();
   const navigate = useNavigate();
-  const [tab, setTab] = useState<'people' | 'agent'>('people');
+  const [tab, setTab] = useState<V2InviteTab>(initialTab);
   const [url, setUrl] = useState<string>('');
   const [expiry, setExpiry] = useState<ExpiryPreset>('168');
   const [maxUses, setMaxUses] = useState<MaxUsesPreset>('unlimited');
@@ -96,7 +100,7 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
   // Reset transient state when the modal closes or switches pods — otherwise
   // an old invite URL can flash before the next pod's links load.
   useEffect(() => {
-    setTab('people');
+    setTab(initialTab);
     setUrl('');
     setExpiry('168');
     setMaxUses('unlimited');
@@ -106,7 +110,7 @@ const V2InviteModal: React.FC<V2InviteModalProps> = ({ open, podId, podName, onC
     setBusy(false);
     setRevokingToken(null);
     if (!open) setInvites([]);
-  }, [open, podId]);
+  }, [open, podId, initialTab]);
 
   useEffect(() => {
     if (!open || !podId) return;

--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -4,7 +4,7 @@ import V2NavRail from './V2NavRail';
 import V2PodsSidebar from './V2PodsSidebar';
 import V2PodChat from './V2PodChat';
 import V2PodInspector from './V2PodInspector';
-import V2InviteModal from './V2InviteModal';
+import V2InviteModal, { type V2InviteTab } from './V2InviteModal';
 import V2FirstRunHero from './V2FirstRunHero';
 import { useV2Pods } from '../hooks/useV2Pods';
 import { useV2PodDetail } from '../hooks/useV2PodDetail';
@@ -54,7 +54,11 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   // invite icon and the inspector "+ Invite" button can both open it. The
   // modal itself is V2InviteModal — this component just owns open/close.
   const [inviteOpen, setInviteOpen] = useState(false);
-  const openInvite = useCallback(() => setInviteOpen(true), []);
+  const [inviteInitialTab, setInviteInitialTab] = useState<V2InviteTab>('people');
+  const openInvite = useCallback((initialTab: V2InviteTab = 'people') => {
+    setInviteInitialTab(initialTab);
+    setInviteOpen(true);
+  }, []);
   const closeInvite = useCallback(() => setInviteOpen(false), []);
   // Mobile (<=760px) pods drawer. The sidebar is a fixed slide-over on phones
   // instead of a grid column; this owns its open/closed state. Desktop ignores
@@ -181,7 +185,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
           onOpenMember={openInspectorMember}
           onOpenArtifact={openInspectorArtifact}
           onBack={resetInspectorView}
-          onOpenInvite={inviteEnabled ? openInvite : undefined}
+          onOpenInvite={inviteEnabled ? () => openInvite() : undefined}
           pendingOpenFileName={pendingOpenFileName}
           onPendingOpenFileNameConsumed={clearPendingOpenFileName}
         />
@@ -191,6 +195,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
           open={inviteOpen}
           podId={detail.pod._id}
           podName={detail.pod.name || 'pod'}
+          initialTab={inviteInitialTab}
           onClose={closeInvite}
         />
       )}

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -12,9 +12,11 @@ import { useAuth } from '../../context/AuthContext';
 import { initialsFor } from '../utils/avatars';
 import { Trans, useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
+import type { V2InviteTab } from './V2InviteModal';
 
 const PLAN_MODE_KEY = 'v2.podMode';
 const AGENT_DELIVERY_HINT_KEY = 'v2.agentDeliveryHint';
+const JUST_CREATED_POD_KEY = 'v2.justCreated';
 
 const STARTER_PROMPT_KEYS = [
   'podChat.starters.introduce',
@@ -149,7 +151,7 @@ interface V2PodChatProps {
   // Opens the shared invite modal (rendered by V2Layout). The header
   // invite icon delegates to this so the chat path matches the inspector
   // path and a single modal instance handles both surfaces.
-  onOpenInvite?: () => void;
+  onOpenInvite?: (initialTab?: V2InviteTab) => void;
   // Click on an in-message file pill routes here. Passed straight through
   // to V2MessageBubble → FilePill so the click opens the inspector
   // artifact preview instead of window.open()'ing a raw file in a new tab.
@@ -177,6 +179,11 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
   const [sending, setSending] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [composerError, setComposerError] = useState<string | null>(null);
+  const [justCreatedPodId, setJustCreatedPodId] = useState<string | null>(null);
+  const [starterInviteUrl, setStarterInviteUrl] = useState('');
+  const [starterInviteLoading, setStarterInviteLoading] = useState(false);
+  const [starterInviteError, setStarterInviteError] = useState<string | null>(null);
+  const [starterInviteCopied, setStarterInviteCopied] = useState(false);
   const [agentDeliveryHint, setAgentDeliveryHint] = useState<{
     messageId: string;
     mentionHandle: string;
@@ -187,6 +194,8 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const composerInputRef = useRef<HTMLTextAreaElement | null>(null);
   const mentionDropdownRef = useRef<HTMLDivElement | null>(null);
+  const starterInviteRequestedPodRef = useRef<string | null>(null);
+  const starterInviteActivePodRef = useRef<string | null>(null);
 
   // Agent typing indicator state. Backend already emits agent_typing_start/
   // agent_typing_stop via agentTypingService — this just listens and renders.
@@ -215,6 +224,84 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
   useEffect(() => {
     setAgentDeliveryHint(null);
   }, [pod?._id]);
+
+  useEffect(() => {
+    const podId = pod?._id || null;
+    starterInviteActivePodRef.current = podId;
+    starterInviteRequestedPodRef.current = null;
+    setStarterInviteUrl('');
+    setStarterInviteError(null);
+    setStarterInviteLoading(false);
+    setStarterInviteCopied(false);
+    if (!podId) {
+      setJustCreatedPodId(null);
+      return;
+    }
+    try {
+      setJustCreatedPodId(
+        sessionStorage.getItem(`${JUST_CREATED_POD_KEY}.${podId}`) === '1' ? podId : null,
+      );
+    } catch {
+      setJustCreatedPodId(null);
+    }
+  }, [pod?._id]);
+
+  const clearJustCreatedPod = useCallback((podId: string) => {
+    try {
+      sessionStorage.removeItem(`${JUST_CREATED_POD_KEY}.${podId}`);
+    } catch {
+      // State still clears for this mount when sessionStorage is unavailable.
+    }
+    setJustCreatedPodId((current) => (current === podId ? null : current));
+  }, []);
+
+  useEffect(() => {
+    if (!pod?._id || messages.length === 0 || justCreatedPodId !== pod._id) return;
+    clearJustCreatedPod(pod._id);
+  }, [clearJustCreatedPod, justCreatedPodId, messages.length, pod?._id]);
+
+  const generateStarterInvite = useCallback(async (podId: string) => {
+    starterInviteRequestedPodRef.current = podId;
+    setStarterInviteLoading(true);
+    setStarterInviteError(null);
+    setStarterInviteCopied(false);
+    try {
+      const data = await api.post<{ token?: string }>(`/api/pods/${podId}/invites`, {});
+      if (!data?.token) throw new Error('missing invite token');
+      if (starterInviteActivePodRef.current !== podId) return;
+      setStarterInviteUrl(`${window.location.origin}/v2/invite/${data.token}`);
+    } catch {
+      if (starterInviteActivePodRef.current !== podId) return;
+      starterInviteRequestedPodRef.current = null;
+      setStarterInviteError(t('podChat.newPod.inviteError'));
+    } finally {
+      if (starterInviteActivePodRef.current === podId) setStarterInviteLoading(false);
+    }
+  }, [api, t]);
+
+  const starterPanelVisible = Boolean(
+    pod
+    && justCreatedPodId === pod._id
+    && messages.length === 0
+    && !loading
+    && !firstRunVisible,
+  );
+
+  useEffect(() => {
+    if (!starterPanelVisible || !pod?._id || starterInviteUrl) return;
+    if (starterInviteRequestedPodRef.current === pod._id) return;
+    void generateStarterInvite(pod._id);
+  }, [generateStarterInvite, pod?._id, starterInviteUrl, starterPanelVisible]);
+
+  const handleStarterInviteCopy = useCallback(async () => {
+    if (!starterInviteUrl) return;
+    try {
+      await navigator.clipboard.writeText(starterInviteUrl);
+      setStarterInviteCopied(true);
+    } catch {
+      // The read-only field remains selectable for manual copy.
+    }
+  }, [starterInviteUrl]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -765,7 +852,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
               <button
                 type="button"
                 className="v2-chat__icon-btn"
-                onClick={onOpenInvite}
+                onClick={() => onOpenInvite()}
                 title={t('podChat.invite')}
                 aria-label={t('podChat.invite')}
               >
@@ -793,7 +880,82 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
               {loading && messages.length === 0 && (
                 <div className="v2-empty"><span className="v2-spinner" /></div>
               )}
-              {!firstRunVisible && !loading && messages.length === 0 && (
+              {starterPanelVisible && pod && (
+                <section className="v2-chat__new-pod" aria-label={t('podChat.newPod.label')}>
+                  <div className="v2-chat__new-pod-head">
+                    <div>
+                      <div className="v2-chat__new-pod-title">{t('podChat.newPod.title')}</div>
+                      <div className="v2-chat__new-pod-text">{t('podChat.newPod.text')}</div>
+                    </div>
+                    <button
+                      type="button"
+                      className="v2-chat__new-pod-dismiss"
+                      aria-label={t('podChat.newPod.dismiss')}
+                      onClick={() => clearJustCreatedPod(pod._id)}
+                    >
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                        <path d="M18 6L6 18M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </div>
+                  <div className="v2-chat__new-pod-actions">
+                    <div className="v2-chat__new-pod-action v2-chat__new-pod-action--invite">
+                      <div className="v2-chat__new-pod-action-title">{t('podChat.newPod.inviteTitle')}</div>
+                      <div className="v2-chat__new-pod-action-text">{t('podChat.newPod.inviteText')}</div>
+                      {starterInviteLoading && (
+                        <div className="v2-chat__new-pod-status">{t('podChat.newPod.preparingInvite')}</div>
+                      )}
+                      {starterInviteUrl && (
+                        <div className="v2-invite-link-row">
+                          <input
+                            type="text"
+                            className="v2-invite-link"
+                            aria-label={t('podChat.newPod.inviteLinkLabel')}
+                            readOnly
+                            value={starterInviteUrl}
+                            onFocus={(event) => event.currentTarget.select()}
+                          />
+                          <button
+                            type="button"
+                            className="v2-chat__new-pod-copy"
+                            onClick={() => { void handleStarterInviteCopy(); }}
+                          >
+                            {starterInviteCopied ? t('common.copied') : t('common.copy')}
+                          </button>
+                        </div>
+                      )}
+                      {starterInviteError && (
+                        <div className="v2-chat__new-pod-error">
+                          <span>{starterInviteError}</span>
+                          <button
+                            type="button"
+                            onClick={() => { void generateStarterInvite(pod._id); }}
+                          >
+                            {t('podChat.newPod.tryAgain')}
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      className="v2-chat__new-pod-action"
+                      onClick={() => onOpenInvite?.('agent')}
+                    >
+                      <span className="v2-chat__new-pod-action-title">{t('podChat.newPod.addAgentTitle')}</span>
+                      <span className="v2-chat__new-pod-action-text">{t('podChat.newPod.addAgentText')}</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="v2-chat__new-pod-action"
+                      onClick={() => composerInputRef.current?.focus()}
+                    >
+                      <span className="v2-chat__new-pod-action-title">{t('podChat.newPod.messageTitle')}</span>
+                      <span className="v2-chat__new-pod-action-text">{t('podChat.newPod.messageText')}</span>
+                    </button>
+                  </div>
+                </section>
+              )}
+              {!starterPanelVisible && !firstRunVisible && !loading && messages.length === 0 && (
                 <div className="v2-empty">
                   {isBotToBot && botPair ? (
                     <>

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -164,6 +164,7 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
   const [showCreate, setShowCreate] = useState(false);
   const [newPodName, setNewPodName] = useState('');
   const [newPodGoal, setNewPodGoal] = useState('');
+  const [newPodJoinPolicy, setNewPodJoinPolicy] = useState<'open' | 'invite-only'>('open');
   const [createError, setCreateError] = useState<string | null>(null);
   // Pod IDs an agent is currently typing into. Set, not bool, because
   // multiple agents could type at once. Cleared after 30s safety in case the
@@ -336,10 +337,22 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
     setCreating(true);
     setCreateError(null);
     try {
-      const pod = await createPod(name, newPodGoal.trim() || undefined, 'team');
+      const pod = await createPod(
+        name,
+        newPodGoal.trim() || undefined,
+        'team',
+        newPodJoinPolicy,
+      );
       if (pod?._id) {
+        try {
+          sessionStorage.setItem(`v2.justCreated.${pod._id}`, '1');
+        } catch {
+          // The pod still opens normally when sessionStorage is unavailable;
+          // only the one-session starter panel is skipped.
+        }
         setNewPodName('');
         setNewPodGoal('');
+        setNewPodJoinPolicy('open');
         setShowCreate(false);
         selectPod(pod._id);
       } else {
@@ -373,6 +386,7 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
             className="v2-pods__new-btn"
             onClick={() => {
               setShowCreate((next) => !next);
+              setNewPodJoinPolicy('open');
               setCreateError(null);
             }}
             disabled={creating}
@@ -385,13 +399,25 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
           {showCreate && (
             <form className="v2-pods__create" onSubmit={handleCreatePod}>
               <div className="v2-pods__create-options">
-                <button type="button" className="v2-pods__create-option v2-pods__create-option--active">
+                <button
+                  type="button"
+                  className={`v2-pods__create-option${newPodJoinPolicy === 'open' ? ' v2-pods__create-option--active' : ''}`}
+                  aria-pressed={newPodJoinPolicy === 'open'}
+                  onClick={() => {
+                    setNewPodJoinPolicy('open');
+                    setCreateError(null);
+                  }}
+                >
                   {t('podsSidebar.create.teamOption')}
                 </button>
                 <button
                   type="button"
-                  className="v2-pods__create-option"
-                  onClick={() => setCreateError(t('podsSidebar.create.privateHint'))}
+                  className={`v2-pods__create-option${newPodJoinPolicy === 'invite-only' ? ' v2-pods__create-option--active' : ''}`}
+                  aria-pressed={newPodJoinPolicy === 'invite-only'}
+                  onClick={() => {
+                    setNewPodJoinPolicy('invite-only');
+                    setCreateError(null);
+                  }}
                 >
                   {t('podsSidebar.create.privateOption')}
                 </button>
@@ -418,6 +444,7 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
                   className="v2-pods__create-cancel"
                   onClick={() => {
                     setShowCreate(false);
+                    setNewPodJoinPolicy('open');
                     setCreateError(null);
                   }}
                 >

--- a/frontend/src/v2/hooks/useV2Pods.ts
+++ b/frontend/src/v2/hooks/useV2Pods.ts
@@ -33,7 +33,12 @@ export interface UseV2PodsResult {
   loading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
-  createPod: (name: string, description?: string, type?: 'team' | 'chat') => Promise<V2Pod | null>;
+  createPod: (
+    name: string,
+    description?: string,
+    type?: 'team' | 'chat',
+    joinPolicy?: 'open' | 'invite-only',
+  ) => Promise<V2Pod | null>;
   deletePod: (podId: string) => Promise<boolean>;
   patchLastMessage: (podId: string, last: V2PodLastMessage) => void;
 }
@@ -62,13 +67,14 @@ export const useV2Pods = (): UseV2PodsResult => {
     name: string,
     description?: string,
     type: 'team' | 'chat' = 'team',
+    joinPolicy: 'open' | 'invite-only' = 'open',
   ): Promise<V2Pod | null> => {
     try {
       const pod = await api.post<V2Pod>('/api/pods', {
         name,
         description: description || '',
         type,
-        joinPolicy: 'open',
+        joinPolicy,
       });
       setPods((prev) => [pod, ...prev]);
       return pod;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -1638,6 +1638,134 @@
   flex-shrink: 0;
 }
 
+.v2-chat__new-pod {
+  align-self: center;
+  width: min(720px, 100%);
+  margin: auto;
+  padding: 20px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-lg);
+  background: var(--v2-surface);
+}
+
+.v2-chat__new-pod-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.v2-chat__new-pod-title {
+  color: var(--v2-text-primary);
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.v2-chat__new-pod-text {
+  max-width: 520px;
+  margin-top: 4px;
+  color: var(--v2-text-secondary);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.v2-root button.v2-chat__new-pod-dismiss {
+  display: grid;
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border-radius: var(--v2-radius-sm);
+  color: var(--v2-text-tertiary);
+}
+
+.v2-root button.v2-chat__new-pod-dismiss:hover {
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
+}
+
+.v2-chat__new-pod-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.v2-root button.v2-chat__new-pod-action,
+.v2-chat__new-pod-action {
+  display: flex;
+  min-width: 0;
+  min-height: 116px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+  padding: 12px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  text-align: left;
+}
+
+.v2-root button.v2-chat__new-pod-action {
+  transition: background 80ms ease, border-color 80ms ease;
+}
+
+.v2-root button.v2-chat__new-pod-action:hover {
+  border-color: var(--v2-border-strong);
+  background: var(--v2-accent-soft);
+}
+
+.v2-chat__new-pod-action-title {
+  color: var(--v2-text-primary);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.v2-chat__new-pod-action-text,
+.v2-chat__new-pod-status {
+  color: var(--v2-text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.v2-chat__new-pod-action--invite .v2-invite-link-row {
+  width: 100%;
+  margin-top: auto;
+}
+
+.v2-root button.v2-chat__new-pod-copy {
+  flex: 0 0 auto;
+  padding: 0 10px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-surface);
+  color: var(--v2-accent-text);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.v2-root button.v2-chat__new-pod-copy:hover {
+  background: var(--v2-accent-soft);
+}
+
+.v2-chat__new-pod-error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: auto;
+  color: var(--v2-danger);
+  font-size: 11px;
+}
+
+.v2-root .v2-chat__new-pod-error button {
+  flex: 0 0 auto;
+  color: var(--v2-accent-text);
+  font-size: 11px;
+  font-weight: 700;
+}
+
 .v2-root button.v2-chat__starter-prompt {
   min-width: 0;
   max-width: 100%;
@@ -1658,6 +1786,21 @@
   border-color: var(--v2-border-strong);
   background: var(--v2-accent-soft);
   color: var(--v2-accent-text);
+}
+
+@media (max-width: 700px) {
+  .v2-chat__new-pod {
+    padding: 16px;
+  }
+
+  .v2-chat__new-pod-actions {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .v2-root button.v2-chat__new-pod-action,
+  .v2-chat__new-pod-action {
+    min-height: 0;
+  }
 }
 
 .v2-chat__composer-input-wrap {


### PR DESCRIPTION
## Summary

- make both pod creation choices honest: Team Pod creates with `joinPolicy: open`, Private Pod with `joinPolicy: invite-only`
- mark newly created pods in session storage and open a starter panel in their empty transcript
- pre-generate a reusable invite link, reuse the invite modal's agent tab, and focus the existing composer for the first message
- add English and locked-glossary zh-CN chrome plus responsive desktop/mobile styling

## Verification

- `cd frontend && npm test -- --runInBand` — 63 suites, 278 tests passed
- `cd frontend && npm run build` — passed
- changed-file ESLint — 0 errors (8 existing JSX-extension warnings)
- translation key/base-key/CLDR guard — passed
- `git diff --check` — passed
- real browser: EN + zh-CN at 1280×900 and 390×844 — no wrap or horizontal overflow; desktop actions are 3-column and mobile stacks to 1-column

The repository-wide lint command is currently blocked by 1,306 pre-existing backend errors (legacy unresolved imports/parser failures); this PR changes no backend files.

## Review gate

The zh-CN additions were drafted against the mandatory locked glossary (`Pod` retained, `智能体`, `你`, natural non-calque phrasing). They remain blocked on Sam's native-speaker review before merge.
