### PR TITLE
Auto-join verified users to Commonly HQ

### DIFF
--- a/backend/__tests__/unit/controllers/authController.test.js
+++ b/backend/__tests__/unit/controllers/authController.test.js
@@ -3,6 +3,11 @@ const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const User = require('../../../models/User');
 const WaitlistRequest = require('../../../models/WaitlistRequest');
+
+jest.mock('../../../services/communityPodService', () => ({
+  ensureUserInCommunityPod: jest.fn().mockResolvedValue(undefined),
+}));
+const { ensureUserInCommunityPod } = require('../../../services/communityPodService');
 const authController = require('../../../controllers/authController');
 const {
   setupMongoDb,
@@ -405,10 +410,31 @@ describe('Auth Controller Tests', () => {
 
       await authController.verifyEmail(req, res);
 
+      expect(ensureUserInCommunityPod).toHaveBeenCalledWith(userId);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
           message: expect.stringContaining('Email verified successfully'),
         }),
+      );
+    });
+
+    it('still verifies successfully when the background community join rejects', async () => {
+      const userId = new mongoose.Types.ObjectId().toString();
+      jwt.verify.mockReturnValueOnce({ id: userId });
+      User.findByIdAndUpdate = jest.fn().mockResolvedValueOnce({ _id: userId, verified: true });
+      ensureUserInCommunityPod.mockRejectedValueOnce(new Error('community unavailable'));
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const req = { query: { token: 'valid-token' } };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await authController.verifyEmail(req, res);
+      await Promise.resolve();
+
+      expect(res.json).toHaveBeenCalledWith({ message: 'Email verified successfully' });
+      expect(res.status).not.toHaveBeenCalledWith(500);
+      expect(warn).toHaveBeenCalledWith(
+        '[community-pod] background join failed after auth transition:',
+        'community unavailable',
       );
     });
 

--- a/backend/__tests__/unit/controllers/invitationEntitlement.test.js
+++ b/backend/__tests__/unit/controllers/invitationEntitlement.test.js
@@ -2,6 +2,11 @@ const User = require('../../../models/User');
 const InvitationCode = require('../../../models/InvitationCode');
 const Pod = require('../../../models/Pod');
 const Task = require('../../../models/Task');
+
+jest.mock('../../../services/communityPodService', () => ({
+  ensureUserInCommunityPod: jest.fn().mockResolvedValue(undefined),
+}));
+const { ensureUserInCommunityPod } = require('../../../services/communityPodService');
 const authController = require('../../../controllers/authController');
 const {
   setupMongoDb,
@@ -104,6 +109,8 @@ describe('Invitation → cloudAgents entitlement', () => {
       expect(res.status).toHaveBeenCalledWith(201);
       const user = await User.findOne({ email: 'newbie@example.com' });
       expect(user.entitlements.cloudAgents).toBe(false);
+      expect(user.verified).toBe(true);
+      expect(ensureUserInCommunityPod).toHaveBeenCalledWith(user._id);
     });
 
     it('fails loudly on a provided-but-invalid code even though registration is open', async () => {
@@ -180,6 +187,7 @@ describe('Invitation → cloudAgents entitlement', () => {
       const fresh = await User.findById(user._id);
       expect(fresh.verified).toBe(true);
       expect(fresh.password).not.toBe('old-hashed');
+      expect(ensureUserInCommunityPod).toHaveBeenCalledWith(user._id);
     });
 
     it('rejects tokens with the wrong purpose and short passwords', async () => {

--- a/backend/__tests__/unit/controllers/oauthController.test.js
+++ b/backend/__tests__/unit/controllers/oauthController.test.js
@@ -3,6 +3,11 @@ const jwt = require('jsonwebtoken');
 const User = require('../../../models/User');
 const OAuthLoginState = require('../../../models/OAuthLoginState');
 const InvitationCode = require('../../../models/InvitationCode');
+
+jest.mock('../../../services/communityPodService', () => ({
+  ensureUserInCommunityPod: jest.fn().mockResolvedValue(undefined),
+}));
+const { ensureUserInCommunityPod } = require('../../../services/communityPodService');
 const oauthController = require('../../../controllers/oauthController');
 const authController = require('../../../controllers/authController');
 const {
@@ -166,6 +171,7 @@ describe('OAuth Controller', () => {
       expect(user.username).toBe('octo-dev');
       expect(user.authProviders).toHaveLength(1);
       expect(user.authProviders[0]).toMatchObject({ provider: 'github', providerId: '4242' });
+      expect(ensureUserInCommunityPod).toHaveBeenCalledWith(user._id);
 
       const redirectUrl = new URL(res.redirect.mock.calls[0][0]);
       expect(redirectUrl.origin).toBe('https://app.test.local');
@@ -195,6 +201,7 @@ describe('OAuth Controller', () => {
       expect(user.authProviders[0].providerId).toBe('4242');
       expect(user.verified).toBe(true); // provider-asserted
       expect(await User.countDocuments({})).toBe(1); // linked, not duplicated
+      expect(ensureUserInCommunityPod).toHaveBeenCalledWith(existing._id);
     });
 
     it('enforces the invite gate for brand-new signups', async () => {

--- a/backend/__tests__/unit/scripts/backfill-hq-members.test.js
+++ b/backend/__tests__/unit/scripts/backfill-hq-members.test.js
@@ -1,0 +1,103 @@
+const User = require('../../../models/User');
+const Pod = require('../../../models/Pod');
+const { backfillHqMembers } = require('../../../scripts/backfill-hq-members');
+
+jest.mock('jsonwebtoken', () => ({
+  sign: jest.fn().mockReturnValue('test-jwt-token'),
+  verify: jest.fn(),
+}));
+const {
+  setupMongoDb,
+  closeMongoDb,
+  clearMongoDb,
+} = require('../../utils/testUtils');
+
+describe('backfill-hq-members', () => {
+  beforeAll(async () => {
+    await setupMongoDb();
+  });
+
+  afterAll(async () => {
+    await closeMongoDb();
+  });
+
+  afterEach(async () => {
+    await clearMongoDb();
+    jest.restoreAllMocks();
+    delete process.env.COMMUNITY_POD_ID;
+  });
+
+  const seed = async () => {
+    const existing = await User.create({
+      username: 'existing-human',
+      email: 'existing@example.com',
+      password: 'hashed',
+      verified: true,
+    });
+    const newcomer = await User.create({
+      username: 'new-human',
+      email: 'new@example.com',
+      password: 'hashed',
+      verified: true,
+    });
+    const bot = await User.create({
+      username: 'community-bot',
+      email: 'bot@example.com',
+      password: 'hashed',
+      verified: true,
+      isBot: true,
+    });
+    const unverified = await User.create({
+      username: 'unverified-human',
+      email: 'unverified@example.com',
+      password: 'hashed',
+      verified: false,
+    });
+    const pod = await Pod.create({
+      name: 'Commonly HQ',
+      type: 'chat',
+      createdBy: existing._id,
+      members: [existing._id],
+    });
+    process.env.COMMUNITY_POD_ID = String(pod._id);
+    return {
+      existing, newcomer, bot, unverified, pod,
+    };
+  };
+
+  it('defaults to dry-run and mutates nothing', async () => {
+    const { pod, newcomer } = await seed();
+
+    const result = await backfillHqMembers();
+
+    expect(result).toMatchObject({
+      apply: false,
+      totalVerifiedHumans: 2,
+      alreadyMembers: 1,
+      wouldAdd: 1,
+    });
+    const fresh = await Pod.findById(pod._id);
+    expect(fresh.members.map(String)).not.toContain(String(newcomer._id));
+  });
+
+  it('applies idempotently and excludes bots and unverified users', async () => {
+    const {
+      existing, newcomer, bot, unverified, pod,
+    } = await seed();
+    const find = jest.spyOn(User, 'find');
+
+    const first = await backfillHqMembers({ apply: true });
+    const second = await backfillHqMembers({ apply: true });
+
+    expect(find).toHaveBeenCalledWith({ verified: true, isBot: { $ne: true } });
+    expect(first).toMatchObject({ totalVerifiedHumans: 2, alreadyMembers: 1, wouldAdd: 1 });
+    expect(second).toMatchObject({ totalVerifiedHumans: 2, alreadyMembers: 2, wouldAdd: 0 });
+
+    const fresh = await Pod.findById(pod._id);
+    const memberIds = fresh.members.map(String);
+    expect(memberIds).toEqual(expect.arrayContaining([String(existing._id), String(newcomer._id)]));
+    expect(memberIds).not.toContain(String(bot._id));
+    expect(memberIds).not.toContain(String(unverified._id));
+    expect(memberIds.filter((id) => id === String(newcomer._id))).toHaveLength(1);
+  });
+});

--- a/backend/__tests__/unit/services/communityPodService.test.js
+++ b/backend/__tests__/unit/services/communityPodService.test.js
@@ -1,0 +1,49 @@
+const Pod = require('../../../models/Pod');
+const { ensureUserInCommunityPod } = require('../../../services/communityPodService');
+
+jest.mock('../../../models/Pod', () => ({
+  updateOne: jest.fn(),
+}));
+
+describe('communityPodService', () => {
+  const originalCommunityPodId = process.env.COMMUNITY_POD_ID;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.COMMUNITY_POD_ID;
+  });
+
+  afterAll(() => {
+    if (originalCommunityPodId === undefined) delete process.env.COMMUNITY_POD_ID;
+    else process.env.COMMUNITY_POD_ID = originalCommunityPodId;
+  });
+
+  it('fails open without configuration and performs no write', async () => {
+    await expect(ensureUserInCommunityPod('user-1')).resolves.toBeUndefined();
+    expect(Pod.updateOne).not.toHaveBeenCalled();
+  });
+
+  it('adds membership idempotently with $addToSet', async () => {
+    process.env.COMMUNITY_POD_ID = 'community-pod';
+    Pod.updateOne.mockResolvedValue({ matchedCount: 1, modifiedCount: 1 });
+
+    await ensureUserInCommunityPod('user-1');
+
+    expect(Pod.updateOne).toHaveBeenCalledWith(
+      { _id: 'community-pod' },
+      { $addToSet: { members: 'user-1' } },
+    );
+  });
+
+  it('swallows membership-write failures', async () => {
+    process.env.COMMUNITY_POD_ID = 'community-pod';
+    Pod.updateOne.mockRejectedValue(new Error('mongo unavailable'));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(ensureUserInCommunityPod('user-1')).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      '[community-pod] membership update failed:',
+      'mongo unavailable',
+    );
+  });
+});

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -6,6 +6,13 @@ const InvitationCode = require('../models/InvitationCode');
 const WaitlistRequest = require('../models/WaitlistRequest');
 const AgentIdentityService = require('../services/agentIdentityService');
 const { sendEmail } = require('../services/emailService');
+const { ensureUserInCommunityPod } = require('../services/communityPodService');
+
+const joinCommunityPodBestEffort = (userId: any) => {
+  void ensureUserInCommunityPod(userId).catch((err: Error) => {
+    console.warn('[community-pod] background join failed after auth transition:', err.message);
+  });
+};
 
 const parseBooleanEnv = (value: any) => {
   if (value === undefined || value === null || value === '') return null;
@@ -237,6 +244,8 @@ exports.register = async (req: any, res: any) => {
     await user.save();
 
     await createDefaultWorkspacePod(user._id);
+
+    if (shouldAutoVerify) joinCommunityPodBestEffort(user._id);
 
     if (hasEmailConfig) {
       // Generate email verification token
@@ -479,6 +488,7 @@ exports.resetPassword = async (req: any, res: any) => {
     // accounts that never finished the signup verification email.
     user.verified = true;
     await user.save();
+    joinCommunityPodBestEffort(user._id);
 
     return res.json({ message: 'Password updated. You can sign in now.' });
   } catch (err: any) {
@@ -499,6 +509,8 @@ exports.verifyEmail = async (req: any, res: any) => {
       { new: true },
     );
     if (!user) return res.status(400).json({ error: 'Invalid token' });
+
+    joinCommunityPodBestEffort(user._id);
 
     res.json({ message: 'Email verified successfully' });
   } catch (err) {

--- a/backend/controllers/oauthController.ts
+++ b/backend/controllers/oauthController.ts
@@ -8,6 +8,13 @@ const {
   redeemInvitationCode,
   createDefaultWorkspacePod,
 } = require('./authController');
+const { ensureUserInCommunityPod } = require('../services/communityPodService');
+
+const joinCommunityPodBestEffort = (userId: any) => {
+  void ensureUserInCommunityPod(userId).catch((err: Error) => {
+    console.warn('[community-pod] background join failed after OAuth transition:', err.message);
+  });
+};
 
 // Social login (GitHub + Google) for HUMAN accounts. Deliberately framework-
 // free: two provider entries, an authorization-code flow, and a one-time
@@ -263,6 +270,7 @@ exports.oauthCallback = async (req: any, res: any) => {
         // The provider verified this email even if our SMTP loop never did.
         user.verified = true;
         await user.save();
+        joinCommunityPodBestEffort(user._id);
       }
     }
 
@@ -295,6 +303,7 @@ exports.oauthCallback = async (req: any, res: any) => {
       });
       await user.save();
       await createDefaultWorkspacePod(user._id);
+      joinCommunityPodBestEffort(user._id);
     }
 
     const exchangeCode = crypto.randomBytes(24).toString('hex');

--- a/backend/scripts/backfill-hq-members.ts
+++ b/backend/scripts/backfill-hq-members.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import mongoose from 'mongoose';
+import Pod from '../models/Pod';
+import User from '../models/User';
+import { getCommunityPodId } from '../services/communityPodService';
+
+export interface BackfillHqMembersResult {
+  configured: boolean;
+  podFound: boolean;
+  apply: boolean;
+  totalVerifiedHumans: number;
+  alreadyMembers: number;
+  wouldAdd: number;
+}
+
+const emptyResult = (apply: boolean): BackfillHqMembersResult => ({
+  configured: false,
+  podFound: false,
+  apply,
+  totalVerifiedHumans: 0,
+  alreadyMembers: 0,
+  wouldAdd: 0,
+});
+
+/**
+ * Backfill verified human users into the configured community Pod.
+ * Dry-run is the default; callers must opt into mutation with `apply: true`.
+ */
+export async function backfillHqMembers(
+  options: { apply?: boolean } = {},
+): Promise<BackfillHqMembersResult> {
+  const apply = options.apply === true;
+  const podId = getCommunityPodId();
+  if (!podId) {
+    console.warn('[community-pod-backfill] COMMUNITY_POD_ID is unset; nothing to do.');
+    return emptyResult(apply);
+  }
+
+  const result = { ...emptyResult(apply), configured: true };
+
+  try {
+    const [users, pod] = await Promise.all([
+      User.find({ verified: true, isBot: { $ne: true } }).select('_id').lean(),
+      Pod.findById(podId).select('members').lean(),
+    ]);
+
+    result.totalVerifiedHumans = users.length;
+    if (!pod) {
+      console.warn('[community-pod-backfill] configured Pod was not found; nothing to do.');
+      return result;
+    }
+    result.podFound = true;
+
+    const existingMembers = new Set((pod.members || []).map((memberId) => String(memberId)));
+    const userIds = users.map((user) => user._id);
+    result.alreadyMembers = userIds.filter((userId) => existingMembers.has(String(userId))).length;
+    result.wouldAdd = result.totalVerifiedHumans - result.alreadyMembers;
+
+    if (apply && userIds.length > 0) {
+      await Pod.updateOne(
+        { _id: podId },
+        { $addToSet: { members: { $each: userIds } } },
+      );
+    }
+    return result;
+  } catch (err) {
+    console.warn('[community-pod-backfill] failed open:', (err as Error).message);
+    return result;
+  }
+}
+
+if (require.main === module) {
+  const apply = process.argv.includes('--apply');
+  const uri = process.env.MONGO_URI;
+  if (!uri) {
+    console.error('MONGO_URI is required.');
+    process.exit(1);
+  }
+
+  (async () => {
+    await mongoose.connect(uri);
+    try {
+      const result = await backfillHqMembers({ apply });
+      console.log(
+        `HQ membership backfill ${apply ? '(apply)' : '(dry-run)'} `
+        + `totalVerifiedHumans=${result.totalVerifiedHumans} `
+        + `alreadyMembers=${result.alreadyMembers} wouldAdd=${result.wouldAdd}`,
+      );
+    } finally {
+      await mongoose.disconnect();
+    }
+  })().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/backend/services/communityPodService.ts
+++ b/backend/services/communityPodService.ts
@@ -1,0 +1,38 @@
+import Pod from '../models/Pod';
+
+let missingConfigLogged = false;
+
+export const getCommunityPodId = (): string | null => {
+  const podId = String(process.env.COMMUNITY_POD_ID || '').trim();
+  return podId || null;
+};
+
+/**
+ * Best-effort membership projection for the instance community Pod.
+ *
+ * This is intentionally only a Mongo Pod.members write: it does not install
+ * agents, emit notifications, or enter the first-contact path. `$addToSet`
+ * makes repeated verification/OAuth callbacks idempotent.
+ */
+export const ensureUserInCommunityPod = async (userId: unknown): Promise<void> => {
+  const podId = getCommunityPodId();
+  if (!podId) {
+    if (!missingConfigLogged) {
+      missingConfigLogged = true;
+      console.warn('[community-pod] COMMUNITY_POD_ID is unset; automatic membership is disabled.');
+    }
+    return;
+  }
+
+  try {
+    const result = await Pod.updateOne(
+      { _id: podId },
+      { $addToSet: { members: userId } },
+    );
+    if (result.matchedCount === 0) {
+      console.warn('[community-pod] configured Pod was not found; automatic membership skipped.');
+    }
+  } catch (err) {
+    console.warn('[community-pod] membership update failed:', (err as Error).message);
+  }
+};

--- a/k8s/helm/commonly/templates/core/backend-deployment.yaml
+++ b/k8s/helm/commonly/templates/core/backend-deployment.yaml
@@ -146,6 +146,10 @@ spec:
               key: BACKEND_URL
               optional: true
         {{- end }}
+        {{- if .Values.backend.env.communityPodId }}
+        - name: COMMUNITY_POD_ID
+          value: {{ .Values.backend.env.communityPodId | quote }}
+        {{- end }}
 
         # Email Configuration (SMTP2GO)
         - name: SMTP2GO_API_KEY

--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -42,6 +42,7 @@ backend:
     agentProvisionerNodePool: "dev"
     frontendUrl: "https://commonly.me"
     backendUrl: "https://api.commonly.me"
+    communityPodId: "6a5fe677306155f677c26abf"
     # Must match the callback URL registered on the GitHub/Google OAuth apps.
     oauthCallbackBaseUrl: "https://api.commonly.me"
     commonlyApiUrl: ""

--- a/k8s/helm/commonly/values.yaml
+++ b/k8s/helm/commonly/values.yaml
@@ -69,6 +69,9 @@ backend:
     agentProvisionerNodePool: ""
     frontendUrl: "https://commonly.me"
     backendUrl: "https://api.commonly.me"
+    # Optional instance community Pod. Empty keeps self-hosted registration
+    # independent of community wiring.
+    communityPodId: ""
     # Base URL presented to OAuth providers as the redirect_uri origin.
     # Empty = derive from the request host (fine when the API has one host).
     oauthCallbackBaseUrl: ""


### PR DESCRIPTION
## Summary

- add a fail-open, idempotent community-Pod membership service for verified humans
- invoke it after email verification, password-reset verification, OAuth verification/account creation, and SMTP-less born-verified registration
- add a dry-run-by-default `backfill-hq-members` script with explicit `--apply`
- configure the hosted HQ Pod through an optional Helm value while leaving self-hosted defaults unset

This is pure `Pod.members` membership. It does not install agents, emit notifications, or enter the first-contact path.

## Verification

- focused backend suites: 5 passed, 54 tests passed
- backend TypeScript build: passed
- Helm lint with `values-dev.yaml`: passed
- rendered dev manifest includes `COMMUNITY_POD_ID`; base manifest omits it
- changed-JS ESLint (with the repository's known unresolved-extension baseline rules disabled): passed
- full local backend suite: 133 suites / 780 tests passed; the 49 failing suites all hit the existing Node 26 `jsonwebtoken` / `buffer-equal-constant-time` incompatibility before exercising application code. GitHub CI's supported runtime is the merge gate.

## Load-bearing regressions

- missing configuration performs no write and never throws
- membership write rejection cannot fail verification
- OAuth new-account and existing-account verification paths invoke membership projection
- backfill is dry-run by default, excludes bots/unverified users, and remains idempotent across repeated apply runs
