### PR TITLE
Dedup re-delivered CLI wrapper events

### DIFF
--- a/cli/__tests__/lib.test.mjs
+++ b/cli/__tests__/lib.test.mjs
@@ -40,6 +40,13 @@ const {
   listInstances,
   DEFAULT_URL,
 } = await import('../src/lib/config.js');
+const {
+  getSession,
+  setSession,
+  wasEventHandled,
+  recordHandledEvent,
+  clearSessions,
+} = await import('../src/lib/session-store.js');
 
 // ── config.js tests ───────────────────────────────────────────────────────────
 
@@ -179,6 +186,52 @@ describe('config.js', () => {
     expect(dev).toBeTruthy();
     expect(dev.active).toBe(true);
     expect(prod.active).toBe(false);
+  });
+});
+
+// ── session-store.js tests ───────────────────────────────────────────────────
+
+describe('session-store.js handled-event ring', () => {
+  const sessionsDir = path.join(configTmpDir, '.commonly', 'sessions');
+  const eventsFile = path.join(sessionsDir, 'ring-agent.events.json');
+  const sessionFile = path.join(sessionsDir, 'ring-agent.json');
+
+  beforeEach(() => {
+    fs.rmSync(sessionsDir, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(sessionsDir, { recursive: true, force: true });
+  });
+
+  test('handled-event persistence keeps an oldest-first ring capped at 500 ids', () => {
+    for (let index = 0; index <= 500; index += 1) {
+      recordHandledEvent('ring-agent', `evt-${index}`);
+    }
+
+    const persisted = JSON.parse(fs.readFileSync(eventsFile, 'utf8'));
+    expect(persisted).toHaveLength(500);
+    expect(persisted[0]).toBe('evt-1');
+    expect(persisted[499]).toBe('evt-500');
+    expect(wasEventHandled('ring-agent', 'evt-0')).toBe(false);
+    expect(wasEventHandled('ring-agent', 'evt-1')).toBe(true);
+    expect(wasEventHandled('ring-agent', 'evt-500')).toBe(true);
+  });
+
+  test('clearSessions removes both session and handled-event files', () => {
+    setSession('ring-agent', 'pod-1', 'session-1');
+    recordHandledEvent('ring-agent', 'evt-handled');
+    recordHandledEvent('other-agent', 'evt-other');
+    expect(fs.existsSync(sessionFile)).toBe(true);
+    expect(fs.existsSync(eventsFile)).toBe(true);
+
+    clearSessions('ring-agent');
+
+    expect(fs.existsSync(sessionFile)).toBe(false);
+    expect(fs.existsSync(eventsFile)).toBe(false);
+    expect(getSession('ring-agent', 'pod-1')).toBeNull();
+    expect(wasEventHandled('ring-agent', 'evt-handled')).toBe(false);
+    expect(wasEventHandled('other-agent', 'evt-other')).toBe(true);
   });
 });
 

--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -7,6 +7,8 @@
  *  - Happy path: event → adapter.spawn → post to pod → ack
  *  - No-prompt event: no spawn, still acked as 'no_action'
  *  - Adapter failure: no post, no ack (kernel re-delivers — ADR-005)
+ *  - Duplicate delivery: no second spawn, duplicate is re-acked
+ *  - Ack failure: handled id persists before the kernel re-delivers
  *  - Session continuity: newSessionId persists; next event sees it
  *  - stop() halts further polling
  *
@@ -37,7 +39,12 @@ await jest.unstable_mockModule('../src/lib/api.js', () => ({
 
 const { createClient } = await import('../src/lib/api.js');
 const { performRun } = await import('../src/commands/agent.js');
-const { getSession, setSession, clearSessions } = await import('../src/lib/session-store.js');
+const {
+  getSession,
+  setSession,
+  clearSessions,
+  wasEventHandled,
+} = await import('../src/lib/session-store.js');
 const stubAdapter = (await import('../src/lib/adapters/stub.js')).default;
 
 const makeEvent = (overrides = {}) => ({
@@ -342,6 +349,122 @@ describe('performRun', () => {
 
     // CRITICAL: no message post, no ack — kernel MUST re-deliver.
     expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  test('same event id delivered twice → spawns once and re-acks the duplicate', async () => {
+    const duplicate = makeEvent({ _id: 'evt-duplicate' });
+    const mockGet = jest.fn().mockResolvedValue({ events: [duplicate, duplicate] });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn(async () => ({ text: 'handled once' }));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    const ackCalls = mockPost.mock.calls.filter(([route]) => route.endsWith('/ack'));
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(ackCalls).toHaveLength(2);
+    expect(ackCalls[0][1]).toEqual({ result: { outcome: 'posted' } });
+    expect(ackCalls[1][1]).toEqual({
+      result: { outcome: 'no_action', reason: 'duplicate-delivery' },
+    });
+  });
+
+  test('spawn failure is not recorded, so re-delivery spawns again', async () => {
+    const event = makeEvent({ _id: 'evt-retry-after-spawn-failure' });
+    const mockGet = jest.fn().mockResolvedValue({ events: [event] });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn().mockRejectedValue(new Error('runtime unavailable'));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    const first = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    first.stop();
+
+    const second = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    second.stop();
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(wasEventHandled('my-stub', event._id)).toBe(false);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  test('ack failure persists the handled id, so a second run skips spawn and re-acks', async () => {
+    const event = makeEvent({ _id: 'evt-persisted-before-ack' });
+    const mockGet = jest.fn().mockResolvedValue({ events: [event] });
+    let ackAttempts = 0;
+    const mockPost = jest.fn(async (route) => {
+      if (route.endsWith('/ack')) {
+        ackAttempts += 1;
+        if (ackAttempts === 1) throw new Error('ack transport offline');
+      }
+      return {};
+    });
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn(async () => ({ text: 'completed before ack' }));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+    const errors = [];
+
+    const first = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+      onError: (err) => errors.push(err),
+    });
+    await drainMicrotasks();
+    first.stop();
+
+    const eventsFile = path.join(
+      sessionsTmpDir, '.commonly', 'sessions', 'my-stub.events.json',
+    );
+    expect(JSON.parse(fs.readFileSync(eventsFile, 'utf8'))).toEqual([event._id]);
+
+    const second = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+      onError: (err) => errors.push(err),
+    });
+    await drainMicrotasks();
+    second.stop();
+
+    const ackCalls = mockPost.mock.calls.filter(([route]) => route.endsWith('/ack'));
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(ackCalls).toHaveLength(2);
+    expect(ackCalls[1][1]).toEqual({
+      result: { outcome: 'no_action', reason: 'duplicate-delivery' },
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(/Ack failed.*ack transport offline/);
   });
 
   test('newSessionId from spawn is persisted and reused on the next turn', async () => {

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -21,7 +21,13 @@ import { getToken, resolveInstanceUrl } from '../lib/config.js';
 import { startPoller } from '../lib/poller.js';
 import { startWebhookServer, forwardToLocalWebhook } from '../lib/webhook-server.js';
 import { getAdapter, listAdapterNames } from '../lib/adapters/index.js';
-import { getSession, setSession, clearSessions } from '../lib/session-store.js';
+import {
+  getSession,
+  setSession,
+  clearSessions,
+  wasEventHandled,
+  recordHandledEvent,
+} from '../lib/session-store.js';
 import { readLongTerm, syncBack } from '../lib/memory-bridge.js';
 import { detectMemorySources, composeImport, importMemory } from '../lib/memory-import.js';
 import { detectSkills, importSkills } from '../lib/skills-import.js';
@@ -542,13 +548,23 @@ export const performRun = ({
       for (const event of events) {
         if (!running) break;
         let result;
-        try {
-          result = await processEvent(event);
-        } catch (err) {
-          // Spawn failed — skip ack, let kernel re-deliver (ADR-005).
-          log(`[${event.type}] spawn error: ${err.message}`);
-          onError?.(err);
-          continue;
+        if (wasEventHandled(agentName, event._id)) {
+          result = { outcome: 'no_action', reason: 'duplicate-delivery' };
+          log(`[${event.type}] duplicate delivery ${event._id} — skipping spawn and re-acking`);
+        } else {
+          try {
+            result = await processEvent(event);
+          } catch (err) {
+            // Spawn failed — do not record or ack, so the kernel can re-deliver
+            // the event after the local runtime recovers (ADR-005).
+            log(`[${event.type}] spawn error: ${err.message}`);
+            onError?.(err);
+            continue;
+          }
+          // Record after successful processing but before ack. If the ack
+          // fails, the next delivery is skipped and re-acked instead of
+          // burning a second model turn for work that already completed.
+          recordHandledEvent(agentName, event._id);
         }
         try {
           await client.post(`/api/agents/runtime/events/${event._id}/ack`, { result });
@@ -703,7 +719,8 @@ export const performInit = async ({
  *      7 days after all installs go inactive — we don't force-revoke here
  *      because the token may legitimately still be in use for another pod.
  *   2. Local token file at ~/.commonly/tokens/<name>.json
- *   3. Local session store at ~/.commonly/sessions/<name>.json
+ *   3. Local session + handled-event stores at
+ *      ~/.commonly/sessions/<name>{,.events}.json
  *
  * Idempotent: if the backend returns 404 (already uninstalled elsewhere), we
  * still clean up local files so the CLI state stays in sync with reality.

--- a/cli/src/lib/session-store.js
+++ b/cli/src/lib/session-store.js
@@ -14,6 +14,11 @@
  *   }
  *
  * CLIs without sessions simply never call setSession — getSession returns null.
+ *
+ * Handled runtime-event IDs are intentionally persisted in a separate
+ * `<agent>.events.json` file. Keeping the bounded event ring separate means
+ * session-map readers retain their existing on-disk shape while a wrapper
+ * restart can still suppress a re-delivered event whose ack previously failed.
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'fs';
@@ -22,6 +27,9 @@ import { homedir } from 'os';
 
 const sessionsDir = () => join(homedir(), '.commonly', 'sessions');
 const sessionsFile = (agentName) => join(sessionsDir(), `${agentName}.json`);
+const handledEventsFile = (agentName) => join(sessionsDir(), `${agentName}.events.json`);
+const MAX_HANDLED_EVENTS = 500;
+const handledEventsCache = new Map();
 
 const readAgent = (agentName) => {
   const file = sessionsFile(agentName);
@@ -38,6 +46,42 @@ const writeAgent = (agentName, state) => {
   writeFileSync(sessionsFile(agentName), JSON.stringify(state, null, 2), 'utf8');
 };
 
+const readHandledEvents = (agentName) => {
+  const file = handledEventsFile(agentName);
+  if (!existsSync(file)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(file, 'utf8'));
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((eventId) => typeof eventId === 'string' && eventId.length > 0)
+      .slice(-MAX_HANDLED_EVENTS);
+  } catch {
+    return [];
+  }
+};
+
+const getHandledEvents = (agentName) => {
+  const file = handledEventsFile(agentName);
+  // Tests, detach, or an operator may remove the file while this process is
+  // alive. Reset the mirror rather than retaining IDs that no longer exist on
+  // disk; a fresh process likewise hydrates from the persisted ring.
+  if (!existsSync(file)) {
+    const empty = { ids: [], set: new Set() };
+    handledEventsCache.set(agentName, empty);
+    return empty;
+  }
+  if (!handledEventsCache.has(agentName)) {
+    const ids = readHandledEvents(agentName);
+    handledEventsCache.set(agentName, { ids, set: new Set(ids) });
+  }
+  return handledEventsCache.get(agentName);
+};
+
+const writeHandledEvents = (agentName, ids) => {
+  if (!existsSync(sessionsDir())) mkdirSync(sessionsDir(), { recursive: true });
+  writeFileSync(handledEventsFile(agentName), JSON.stringify(ids, null, 2), 'utf8');
+};
+
 export const getSession = (agentName, podId) => {
   if (!agentName || !podId) return null;
   return readAgent(agentName)[podId]?.sessionId || null;
@@ -50,7 +94,26 @@ export const setSession = (agentName, podId, sessionId) => {
   writeAgent(agentName, state);
 };
 
+export const wasEventHandled = (agentName, eventId) => {
+  if (!agentName || !eventId) return false;
+  return getHandledEvents(agentName).set.has(String(eventId));
+};
+
+export const recordHandledEvent = (agentName, eventId) => {
+  if (!agentName || !eventId) return;
+  const normalizedId = String(eventId);
+  const current = getHandledEvents(agentName);
+  if (current.set.has(normalizedId)) return;
+
+  const ids = [...current.ids, normalizedId].slice(-MAX_HANDLED_EVENTS);
+  writeHandledEvents(agentName, ids);
+  handledEventsCache.set(agentName, { ids, set: new Set(ids) });
+};
+
 export const clearSessions = (agentName) => {
   const file = sessionsFile(agentName);
   if (existsSync(file)) rmSync(file);
+  const eventsFile = handledEventsFile(agentName);
+  if (existsSync(eventsFile)) rmSync(eventsFile);
+  handledEventsCache.delete(agentName);
 };


### PR DESCRIPTION
Closes #725.

## Summary

- persist the last 500 handled event IDs per agent in `~/.commonly/sessions/<agent>.events.json`, separate from the existing session map
- skip adapter spawn for an already-handled delivery and re-ack it as `no_action` with `reason: duplicate-delivery`
- record only after processing succeeds and before ack, preserving spawn-failure re-delivery while preventing ack-failure replays from burning another model turn
- remove both session and handled-event files during detach/`clearSessions`

`poller.js` is intentionally unchanged; this PR is scoped to the ADR-005 CLI wrapper run loop.

## Verification

- focused run-loop + library suites: 2 suites, 44 tests passed
- complete CLI suite: 15 suites passed; 166 passed, 8 skipped
- Node syntax checks for both changed source files: passed
- ad-hoc ESLint (`no-undef` + `no-unused-vars`) on both changed source files: passed
- package-local `npm run lint` remains unavailable because the CLI package does not install/declare `eslint` (pre-existing package setup; no lint dependency added in this behavior PR)

## Load-bearing regressions

- same event ID twice → one spawn, two acks, second ack carries duplicate reason
- spawn throws → ID remains unrecorded and the next delivery spawns again
- ack failure → handled ID is already on disk; a second `performRun` skips spawn and re-acks
- persisted ring evicts the oldest ID at 501 and stays capped at 500
- `clearSessions` removes both files without touching another agent's handled IDs
