### PR TITLE
Community Discover: harden join and seed feedback pods

### DIFF
--- a/backend/__tests__/service/pods.community-scope.test.js
+++ b/backend/__tests__/service/pods.community-scope.test.js
@@ -28,6 +28,10 @@ describe('GET /api/pods community scope', () => {
   let viewerToken;
   let memberPod;
   let communityPod;
+  let studyCommunityPod;
+  let joinedCommunityPod;
+  let inviteOnlyPod;
+  let nonPublicListedPod;
   let showcasePod;
   let privatePod;
   let forcedPersonalPods;
@@ -67,6 +71,43 @@ describe('GET /api/pods community scope', () => {
       members: [otherUser._id],
       publicRead: true,
       communityListed: true,
+      joinPolicy: 'open',
+    });
+    studyCommunityPod = await Pod.create({
+      name: 'Public study community pod',
+      type: 'study',
+      createdBy: otherUser._id,
+      members: [otherUser._id],
+      publicRead: true,
+      communityListed: true,
+      joinPolicy: 'open',
+    });
+    joinedCommunityPod = await Pod.create({
+      name: 'Already joined community pod',
+      type: 'team',
+      createdBy: otherUser._id,
+      members: [otherUser._id, viewer._id],
+      publicRead: true,
+      communityListed: true,
+      joinPolicy: 'open',
+    });
+    inviteOnlyPod = await Pod.create({
+      name: 'Invite-only community pod',
+      type: 'team',
+      createdBy: otherUser._id,
+      members: [otherUser._id],
+      publicRead: true,
+      communityListed: true,
+      joinPolicy: 'invite-only',
+    });
+    nonPublicListedPod = await Pod.create({
+      name: 'Listed but not publicly readable',
+      type: 'team',
+      createdBy: otherUser._id,
+      members: [otherUser._id],
+      publicRead: false,
+      communityListed: true,
+      joinPolicy: 'open',
     });
     // Readable but NOT listed — the showcase-room shape (Eng Milestone etc.):
     // anonymous read access stays, Community tab must not surface it.
@@ -112,13 +153,50 @@ describe('GET /api/pods community scope', () => {
 
     expect(res.status).toBe(200);
     const ids = res.body.map((pod) => pod._id);
-    expect(ids).toEqual([communityPod._id.toString()]);
+    expect(ids).toEqual(expect.arrayContaining([
+      communityPod._id.toString(),
+      studyCommunityPod._id.toString(),
+      joinedCommunityPod._id.toString(),
+      inviteOnlyPod._id.toString(),
+    ]));
+    expect(ids).toHaveLength(4);
     expect(ids).not.toContain(privatePod._id.toString());
+    expect(ids).not.toContain(nonPublicListedPod._id.toString());
     // Readable-but-unlisted showcase rooms must stay OFF the Community tab.
     expect(ids).not.toContain(showcasePod._id.toString());
     forcedPersonalPods.forEach((pod) => {
       expect(ids).not.toContain(pod._id.toString());
     });
+  });
+
+  it('discovers only listed, readable, joinable pods the caller has not joined', async () => {
+    const res = await request(app)
+      .get('/api/pods?scope=discover')
+      .set('Authorization', `Bearer ${viewerToken}`);
+
+    expect(res.status).toBe(200);
+    const ids = res.body.map((pod) => pod._id);
+    expect(ids).toEqual(expect.arrayContaining([
+      communityPod._id.toString(),
+      studyCommunityPod._id.toString(),
+    ]));
+    expect(ids).toHaveLength(2);
+    expect(ids).not.toContain(joinedCommunityPod._id.toString());
+    expect(ids).not.toContain(inviteOnlyPod._id.toString());
+    expect(ids).not.toContain(showcasePod._id.toString());
+    expect(ids).not.toContain(nonPublicListedPod._id.toString());
+    forcedPersonalPods.forEach((pod) => {
+      expect(ids).not.toContain(pod._id.toString());
+    });
+  });
+
+  it('honors the optional type filter in discover scope', async () => {
+    const res = await request(app)
+      .get('/api/pods?scope=discover&type=study')
+      .set('Authorization', `Bearer ${viewerToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.map((pod) => pod._id)).toEqual([studyCommunityPod._id.toString()]);
   });
 
   it('keeps the default listing membership-only for the same fixtures', async () => {
@@ -127,7 +205,11 @@ describe('GET /api/pods community scope', () => {
       .set('Authorization', `Bearer ${viewerToken}`);
 
     expect(res.status).toBe(200);
-    expect(res.body.map((pod) => pod._id)).toEqual([memberPod._id.toString()]);
+    expect(res.body.map((pod) => pod._id)).toEqual(expect.arrayContaining([
+      memberPod._id.toString(),
+      joinedCommunityPod._id.toString(),
+    ]));
+    expect(res.body).toHaveLength(2);
     expect(res.body.map((pod) => pod._id)).not.toContain(communityPod._id.toString());
   });
 

--- a/backend/__tests__/service/pods.discover-join.test.js
+++ b/backend/__tests__/service/pods.discover-join.test.js
@@ -1,0 +1,161 @@
+process.env.PG_HOST = '';
+process.env.JWT_SECRET = 'discover-join-test-secret';
+
+jest.mock('jsonwebtoken', () => ({
+  sign: ({ id }) => `test-token:${id}`,
+  verify: (token) => ({ id: token.replace('test-token:', '') }),
+}));
+
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const request = require('supertest');
+const Pod = require('../../models/Pod');
+const User = require('../../models/User');
+const { PodInvite } = require('../../models/PodInvite');
+const podRoutes = require('../../routes/pods');
+const podInvitesRoutes = require('../../routes/podInvites');
+const {
+  setupMongoDb,
+  closeMongoDb,
+  clearMongoDb,
+} = require('../utils/testUtils');
+
+describe('POST /api/pods/:id/join discovery gate', () => {
+  let app;
+  let viewer;
+  let owner;
+  let admin;
+  let viewerToken;
+  let adminToken;
+
+  beforeAll(async () => {
+    await setupMongoDb();
+    app = express();
+    app.use(express.json());
+    // Keep production ownership order: invite routes must precede the pods
+    // catch-all so /api/pods/:podId/invites remains reachable (#712).
+    app.use('/api', podInvitesRoutes);
+    app.use('/api/pods', podRoutes);
+  });
+
+  beforeEach(async () => {
+    await clearMongoDb();
+    viewer = await User.create({
+      username: `discover-viewer-${Date.now()}`,
+      email: `discover-viewer-${Date.now()}@test.com`,
+      password: 'Password123!',
+      verified: true,
+    });
+    owner = await User.create({
+      username: `discover-owner-${Date.now()}`,
+      email: `discover-owner-${Date.now()}@test.com`,
+      password: 'Password123!',
+      verified: true,
+    });
+    admin = await User.create({
+      username: `discover-admin-${Date.now()}`,
+      email: `discover-admin-${Date.now()}@test.com`,
+      password: 'Password123!',
+      verified: true,
+      role: 'admin',
+    });
+    viewerToken = jwt.sign({ id: viewer._id }, process.env.JWT_SECRET);
+    adminToken = jwt.sign({ id: admin._id }, process.env.JWT_SECRET);
+  });
+
+  afterAll(async () => {
+    await clearMongoDb();
+    await closeMongoDb();
+  });
+
+  const createPod = (overrides = {}) => Pod.create({
+    name: `Join test ${Math.random()}`,
+    type: 'team',
+    createdBy: owner._id,
+    members: [owner._id],
+    publicRead: true,
+    communityListed: true,
+    joinPolicy: 'open',
+    ...overrides,
+  });
+
+  const join = (podId, token = viewerToken) => request(app)
+    .post(`/api/pods/${podId}/join`)
+    .set('Authorization', `Bearer ${token}`);
+
+  it('joins a listed open pod atomically and makes repeat joins idempotent', async () => {
+    const pod = await createPod();
+
+    const first = await join(pod._id).expect(200);
+    const second = await join(pod._id).expect(200);
+
+    expect(first.body.members.map((member) => member._id)).toContain(String(viewer._id));
+    expect(second.body.members.map((member) => member._id)).toContain(String(viewer._id));
+    const fresh = await Pod.findById(pod._id).lean();
+    expect(fresh.members.map(String).filter((id) => id === String(viewer._id))).toHaveLength(1);
+  });
+
+  it('refuses direct self-join to an open but unlisted pod', async () => {
+    const pod = await createPod({ communityListed: false });
+
+    const res = await join(pod._id).expect(403);
+
+    expect(res.body.code).toBe('join_refused');
+    const fresh = await Pod.findById(pod._id).lean();
+    expect(fresh.members.map(String)).not.toContain(String(viewer._id));
+  });
+
+  it('returns 200 for an existing member even when the pod is not directly joinable', async () => {
+    const pod = await createPod({
+      communityListed: false,
+      joinPolicy: 'invite-only',
+      members: [owner._id, viewer._id],
+    });
+
+    const res = await join(pod._id).expect(200);
+
+    expect(res.body.members.map((member) => member._id)).toContain(String(viewer._id));
+    const fresh = await Pod.findById(pod._id).lean();
+    expect(fresh.members.map(String).filter((id) => id === String(viewer._id))).toHaveLength(1);
+  });
+
+  it('refuses direct self-join to a listed invite-only pod', async () => {
+    const pod = await createPod({ joinPolicy: 'invite-only' });
+
+    const res = await join(pod._id).expect(403);
+
+    expect(res.body.code).toBe('join_refused');
+  });
+
+  it('keeps the personal-DM refusal ahead of discovery eligibility', async () => {
+    const pod = await createPod({ type: 'agent-dm' });
+
+    const res = await join(pod._id).expect(403);
+
+    expect(res.body.msg).toMatch(/1:1.*third-person/i);
+    expect(res.body.code).not.toBe('join_refused');
+  });
+
+  it('retains the global-admin bypass for non-DM pods', async () => {
+    const pod = await createPod({ communityListed: false, joinPolicy: 'invite-only' });
+
+    await join(pod._id, adminToken).expect(200);
+
+    const fresh = await Pod.findById(pod._id).lean();
+    expect(fresh.members.map(String)).toContain(String(admin._id));
+  });
+
+  it('keeps invite redemption as the distinct rail into invite-only pods', async () => {
+    const pod = await createPod({ communityListed: false, joinPolicy: 'invite-only' });
+    const token = 'a'.repeat(32);
+    await PodInvite.create({ token, podId: pod._id, createdBy: owner._id });
+
+    await request(app)
+      .post(`/api/invites/${token}/redeem`)
+      .set('Authorization', `Bearer ${viewerToken}`)
+      .expect(200);
+
+    const fresh = await Pod.findById(pod._id).lean();
+    expect(fresh.members.map(String)).toContain(String(viewer._id));
+  });
+});

--- a/backend/__tests__/unit/controllers/podController.test.js
+++ b/backend/__tests__/unit/controllers/podController.test.js
@@ -246,10 +246,10 @@ describe('podController', () => {
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({ msg: expect.stringMatching(/1:1.*third-person/i) }),
     );
-    expect(pod.save).not.toHaveBeenCalled();
+    expect(Pod.updateOne).not.toHaveBeenCalled();
   });
 
-  it('joinPod still works on regular chat pods (regression guard)', async () => {
+  it('joinPod atomically joins a listed, open chat pod', async () => {
     const pod = {
       _id: 'chat-1',
       type: 'chat',
@@ -258,7 +258,7 @@ describe('podController', () => {
       ],
       createdBy: { toString: () => 'creator-id' },
       joinPolicy: 'open',
-      save: jest.fn().mockResolvedValue(undefined),
+      communityListed: true,
     };
     Pod.findById
       .mockResolvedValueOnce(pod)
@@ -270,7 +270,13 @@ describe('podController', () => {
     const req = { params: { id: 'chat-1' }, userId: 'new-user-id', user: {} };
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
     await podController.joinPod(req, res);
-    expect(pod.save).toHaveBeenCalled();
+    expect(Pod.updateOne).toHaveBeenCalledWith(
+      { _id: 'chat-1' },
+      {
+        $addToSet: { members: 'new-user-id' },
+        $set: { updatedAt: expect.any(Date) },
+      },
+    );
     expect(res.status).not.toHaveBeenCalledWith(403);
   });
 
@@ -328,9 +334,51 @@ describe('podController', () => {
     const req = { query: {}, userId: 'admin-id', user: {} };
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
     await podController.getAllPods(req, res);
+    expect(Pod.find).toHaveBeenCalledWith({ type: { $ne: 'agent-admin' } });
     // Default scope=mine: admin is filtered to their own pods, NOT every
     // chat pod in the instance.
     expect(res.json).toHaveBeenCalledWith([myPod]);
+  });
+
+  it('getAllPods keeps the existing community query exact', async () => {
+    const sort = jest.fn().mockResolvedValue([]);
+    const populateThird = jest.fn(() => ({ sort }));
+    const populateSecond = jest.fn(() => ({ populate: populateThird, sort }));
+    const populateFirst = jest.fn(() => ({ populate: populateSecond, sort }));
+    Pod.find.mockReturnValue({ populate: populateFirst });
+
+    const req = { query: { scope: 'community' }, userId: 'me', user: {} };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    await podController.getAllPods(req, res);
+
+    expect(Pod.find).toHaveBeenCalledWith({
+      publicRead: true,
+      communityListed: true,
+      type: { $nin: ['agent-room', 'agent-dm', 'agent-admin'] },
+    });
+  });
+
+  it('getAllPods discover scope requires listed, readable, joinable non-member pods', async () => {
+    const sort = jest.fn().mockResolvedValue([]);
+    const populateThird = jest.fn(() => ({ sort }));
+    const populateSecond = jest.fn(() => ({ populate: populateThird, sort }));
+    const populateFirst = jest.fn(() => ({ populate: populateSecond, sort }));
+    Pod.find.mockReturnValue({ populate: populateFirst });
+
+    const discoverUserId = '507f1f77bcf86cd799439011';
+    const req = { query: { scope: 'discover' }, userId: discoverUserId, user: {} };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    await podController.getAllPods(req, res);
+
+    expect(Pod.find).toHaveBeenCalledWith({
+      publicRead: true,
+      communityListed: true,
+      joinPolicy: { $ne: 'invite-only' },
+      members: { $ne: expect.anything() },
+      type: { $nin: ['agent-room', 'agent-dm', 'agent-admin'] },
+    });
+    const [query] = Pod.find.mock.calls[0];
+    expect(String(query.members.$ne)).toBe(discoverUserId);
   });
 
   it('getAllPods scope=all returns everything for admins (explicit moderation view)', async () => {

--- a/backend/__tests__/unit/routes/pods.test.js
+++ b/backend/__tests__/unit/routes/pods.test.js
@@ -42,6 +42,22 @@ describe('pods routes', () => {
     expect(controllers.joinPod).toHaveBeenCalled();
   });
 
+  it('rate-limits direct join attempts to 20 per token per minute', async () => {
+    const authorization = 'Bearer join-rate-limit-test';
+    for (let index = 0; index < 20; index += 1) {
+      await request(app)
+        .post('/api/pods/123/join')
+        .set('Authorization', authorization)
+        .expect(200);
+    }
+
+    const limited = await request(app)
+      .post('/api/pods/123/join')
+      .set('Authorization', authorization)
+      .expect(429);
+    expect(limited.body.msg).toMatch(/20 pod joins per 60s/);
+  });
+
   it('DELETE /api/pods/123/members/456 calls removeMember', async () => {
     await request(app).delete('/api/pods/123/members/456').expect(200);
     expect(controllers.removeMember).toHaveBeenCalled();

--- a/backend/__tests__/unit/scripts/seed-community-pods.test.js
+++ b/backend/__tests__/unit/scripts/seed-community-pods.test.js
@@ -1,0 +1,128 @@
+process.env.PG_HOST = '';
+
+jest.mock('jsonwebtoken', () => ({
+  sign: jest.fn().mockReturnValue('test-jwt-token'),
+  verify: jest.fn(),
+}));
+
+jest.mock('../../../models/pg/Pod', () => ({
+  create: jest.fn(),
+}));
+
+const User = require('../../../models/User');
+const Pod = require('../../../models/Pod');
+const PGPod = require('../../../models/pg/Pod');
+const { seedCommunityPods } = require('../../../scripts/seed-community-pods');
+const {
+  setupMongoDb,
+  closeMongoDb,
+  clearMongoDb,
+} = require('../../utils/testUtils');
+
+describe('seed-community-pods', () => {
+  beforeAll(async () => {
+    await setupMongoDb();
+  });
+
+  afterAll(async () => {
+    await closeMongoDb();
+  });
+
+  afterEach(async () => {
+    await clearMongoDb();
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    delete process.env.COMMUNITY_POD_ID;
+    process.env.PG_HOST = '';
+  });
+
+  const seedHq = async () => {
+    const owner = await User.create({
+      username: 'community-seed-owner',
+      email: 'community-seed-owner@example.com',
+      password: 'hashed',
+      verified: true,
+    });
+    const hq = await Pod.create({
+      name: 'Commonly HQ',
+      type: 'team',
+      createdBy: owner._id,
+      members: [owner._id],
+    });
+    process.env.COMMUNITY_POD_ID = String(hq._id);
+    return { owner, hq };
+  };
+
+  it('defaults to dry-run and writes nothing', async () => {
+    const { hq } = await seedHq();
+
+    const result = await seedCommunityPods();
+
+    expect(result).toEqual({
+      apply: false,
+      total: 2,
+      existing: 0,
+      wouldCreate: 2,
+      created: 0,
+      updated: 0,
+    });
+    expect(await Pod.countDocuments({ parentPod: hq._id })).toBe(0);
+    expect(PGPod.create).not.toHaveBeenCalled();
+  });
+
+  it('creates both feedback Pods once and is a no-op when re-applied', async () => {
+    const { owner, hq } = await seedHq();
+
+    const first = await seedCommunityPods({ apply: true });
+    const second = await seedCommunityPods({ apply: true });
+
+    expect(first).toMatchObject({ created: 2, updated: 0, wouldCreate: 2 });
+    expect(second).toMatchObject({ created: 0, updated: 0, wouldCreate: 0, existing: 2 });
+    const children = await Pod.find({ parentPod: hq._id }).sort({ name: 1 }).lean();
+    expect(children.map((pod) => pod.name)).toEqual(['Bug Reports', 'Feature Requests']);
+    children.forEach((pod) => {
+      expect(pod).toMatchObject({
+        type: 'team',
+        joinPolicy: 'open',
+        publicRead: true,
+        communityListed: true,
+      });
+      expect(String(pod.parentPod)).toBe(String(hq._id));
+      expect(String(pod.createdBy)).toBe(String(owner._id));
+      expect(pod.members.map(String)).toEqual([String(owner._id)]);
+    });
+  });
+
+  it('aborts when the configured HQ Pod does not exist', async () => {
+    process.env.COMMUNITY_POD_ID = '507f1f77bcf86cd799439011';
+
+    await expect(seedCommunityPods({ apply: true }))
+      .rejects.toThrow('Configured COMMUNITY_POD_ID Pod was not found');
+    expect(await Pod.countDocuments()).toBe(0);
+  });
+
+  it('aborts when COMMUNITY_POD_ID is unset', async () => {
+    delete process.env.COMMUNITY_POD_ID;
+
+    await expect(seedCommunityPods())
+      .rejects.toThrow('COMMUNITY_POD_ID is required');
+    expect(await Pod.countDocuments()).toBe(0);
+  });
+
+  it('keeps Mongo seeds when the best-effort PostgreSQL mirror fails', async () => {
+    const { hq } = await seedHq();
+    process.env.PG_HOST = 'configured-for-test';
+    PGPod.create.mockRejectedValue(new Error('postgres unavailable'));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await seedCommunityPods({ apply: true });
+
+    expect(result.created).toBe(2);
+    expect(await Pod.countDocuments({ parentPod: hq._id })).toBe(2);
+    expect(PGPod.create).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledWith(
+      '[community-pod-seed] PostgreSQL mirror failed:',
+      'postgres unavailable',
+    );
+  });
+});

--- a/backend/controllers/podController.ts
+++ b/backend/controllers/podController.ts
@@ -1,3 +1,4 @@
+const mongoose = require('mongoose');
 const Pod = require('../models/Pod');
 const Message = require('../models/Message');
 const Post = require('../models/Post');
@@ -159,13 +160,33 @@ exports.getAllPods = async (req: any, res: any) => {
     const { type } = req.query;
     const scope = String(req.query?.scope || 'mine').toLowerCase();
     const isCommunityScope = scope === 'community';
+    const isDiscoverScope = scope === 'discover';
+    let discoverCallerId = null;
+    if (isDiscoverScope) {
+      const rawCallerId = String(req.userId || req.user?.id || '');
+      if (!mongoose.Types.ObjectId.isValid(rawCallerId)) {
+        return res.status(401).json({ error: 'User authentication failed' });
+      }
+      discoverCallerId = new mongoose.Types.ObjectId(rawCallerId);
+    }
     // Exclude agent-admin DM pods from default listing; only show when
     // explicitly requested and the caller is a member.
-    // Community is an explicit, additive discovery scope. Personal pod types
-    // stay excluded even if a malformed/admin-created row has publicRead=true.
+    // Community and Discover are explicit, additive discovery scopes. Personal
+    // pod types stay excluded even if a malformed/admin-created row has the
+    // listing/read flags forced true.
     // Keep the default query semantically identical to the privacy-hardened
     // membership listing below.
-    const query = isCommunityScope
+    const query = isDiscoverScope
+      ? {
+        publicRead: true,
+        communityListed: true,
+        joinPolicy: { $ne: 'invite-only' },
+        members: { $ne: discoverCallerId },
+        type: type
+          ? { $eq: type, $nin: COMMUNITY_EXCLUDED_POD_TYPES }
+          : { $nin: COMMUNITY_EXCLUDED_POD_TYPES },
+      }
+      : isCommunityScope
       ? {
         // Listed is opt-in and distinct from readable: showcase rooms keep
         // publicRead for anonymous viewing without appearing in Community.
@@ -202,7 +223,7 @@ exports.getAllPods = async (req: any, res: any) => {
     // private DM in the instance leaks into their sidebar (which made
     // xcjsam see — and try to post into — sam-demo's agent-rooms).
     const isPersonal = type === 'agent-admin' || type === 'agent-room' || type === 'agent-dm';
-    if (req.userId && !isCommunityScope) {
+    if (req.userId && !isCommunityScope && !isDiscoverScope) {
       const wantsAll = scope === 'all';
       const isAdmin = wantsAll ? await isGlobalAdminRequest(req) : false;
       const filterToMine = isPersonal || !wantsAll || !isAdmin;
@@ -423,11 +444,6 @@ exports.createPod = async (req: any, res: any) => {
 // Join a pod
 exports.joinPod = async (req: any, res: any) => {
   try {
-    console.log('Join pod request received:', {
-      params: req.params,
-      body: req.body,
-    });
-
     const { id } = req.params;
 
     if (!id) {
@@ -435,31 +451,16 @@ exports.joinPod = async (req: any, res: any) => {
     }
 
     // Access the user ID safely
-    const userId = req.userId || req.user.id;
-    console.log('User ID from request:', userId);
+    const userId = req.userId || req.user?.id || req.user?._id;
 
     if (!userId) {
       return res.status(401).json({ msg: 'User authentication failed' });
     }
 
-    // Check if pod exists
-    console.log('Finding pod with ID:', id);
     const pod = await Pod.findById(id);
 
     if (!pod) {
       return res.status(404).json({ msg: 'Pod not found' });
-    }
-
-    console.log('Pod found:', { podId: pod._id, members: pod.members });
-
-    // Check if user is already a member
-    const isMember = pod.members.some(
-      (member: any) => member.toString() === userId.toString(),
-    );
-    console.log('Is user already a member?', isMember);
-
-    if (isMember) {
-      return res.status(400).json({ msg: 'Already a member of this pod' });
     }
 
     // Agent DMs are strictly 1:1 (ADR-001 §3.10). The pod is created with
@@ -482,44 +483,45 @@ exports.joinPod = async (req: any, res: any) => {
       });
     }
 
-    // Enforce invite-only policy
-    if (pod.joinPolicy === 'invite-only') {
+    const isMember = (pod.members || []).some(
+      (member: any) => String(member?._id || member) === String(userId),
+    );
+
+    // Repeated self-join requests are successful and side-effect free. This
+    // keeps optimistic clients and retried requests idempotent.
+    if (!isMember) {
       const isAdmin = await isGlobalAdminRequest(req);
-      const isCreator = pod.createdBy.toString() === userId.toString();
-      if (!isAdmin && !isCreator) {
-        return res.status(403).json({ msg: 'This pod is invite-only. Ask the pod creator to add you.' });
+      const isJoinable = pod.communityListed === true && pod.joinPolicy !== 'invite-only';
+      if (!isAdmin && !isJoinable) {
+        return res.status(403).json({
+          code: 'join_refused',
+          msg: 'This pod cannot be joined directly. Ask a member for an invite link.',
+        });
       }
+
+      await Pod.updateOne(
+        { _id: pod._id },
+        {
+          $addToSet: { members: userId },
+          $set: { updatedAt: new Date() },
+        },
+      );
     }
 
-    // Add user to pod members
-    console.log('Adding user to pod members');
-    pod.members.push(userId);
-    pod.updatedAt = Date.now();
-
-    console.log('Saving pod with new member');
-    await pod.save();
-
-    // Return the updated pod with populated data
-    console.log('Retrieving updated pod with populated data');
     const updatedPod = await Pod.findById(id)
       .populate('createdBy', 'username profilePicture')
       .populate('members', 'username profilePicture isBot');
 
-    console.log('Join pod successful, returning updated pod');
-    res.json(updatedPod);
+    return res.json(updatedPod);
   } catch (err: any) {
     console.error('Error in joinPod:', err.message);
-    console.error('Full error:', err);
 
     if (err.kind === 'ObjectId') {
       return res.status(404).json({ msg: 'Pod not found' });
     }
 
-    // Return more specific error information to help with debugging
     return res.status(500).json({
       msg: 'Server Error',
-      error: err.message,
-      stack: process.env.NODE_ENV === 'production' ? null : err.stack,
     });
   }
 };

--- a/backend/routes/pods.ts
+++ b/backend/routes/pods.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
-import rateLimit from 'express-rate-limit';
+import { createHash } from 'crypto';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 // eslint-disable-next-line global-require
 const express = require('express');
 // eslint-disable-next-line global-require
@@ -40,6 +41,14 @@ interface Res {
 }
 
 const router: ReturnType<typeof express.Router> = express.Router();
+
+const podJoinRateLimitKey = (req: any) => {
+  const authHeader = req.get?.('authorization') || req.get?.('x-auth-token');
+  if (authHeader) {
+    return `tok:${createHash('sha256').update(authHeader).digest('hex').slice(0, 16)}`;
+  }
+  return req.ip ? ipKeyGenerator(req.ip) : 'anon';
+};
 
 const storage = multer.diskStorage({
   destination: (req: unknown, file: unknown, cb: (err: Error | null, dir: string) => void) => {
@@ -284,7 +293,14 @@ router.get('/:id/context', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
-router.post('/:id/join', auth, joinPod);
+router.post('/:id/join', rateLimit({
+  windowMs: 60_000,
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: podJoinRateLimitKey,
+  handler: (_req: any, res: any) => res.status(429).json({ msg: 'rate limit exceeded: 20 pod joins per 60s' }),
+}), auth, joinPod);
 router.post('/:id/leave', auth, leavePod);
 router.delete('/:id/members/:memberId', auth, removeMember);
 

--- a/backend/scripts/seed-community-pods.ts
+++ b/backend/scripts/seed-community-pods.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import mongoose from 'mongoose';
+import Pod from '../models/Pod';
+import { getCommunityPodId } from '../services/communityPodService';
+
+const COMMUNITY_POD_SEEDS = [
+  {
+    name: 'Bug Reports',
+    description: 'Report bugs, share reproduction details, and follow fixes.',
+  },
+  {
+    name: 'Feature Requests',
+    description: 'Suggest improvements and discuss ideas for Commonly.',
+  },
+] as const;
+
+export interface SeedCommunityPodsResult {
+  apply: boolean;
+  total: number;
+  existing: number;
+  wouldCreate: number;
+  created: number;
+  updated: number;
+}
+
+/**
+ * Seed the two open, listed feedback Pods beneath Commonly HQ.
+ * Dry-run is the default; callers must opt into mutation with `apply: true`.
+ */
+export async function seedCommunityPods(
+  options: { apply?: boolean } = {},
+): Promise<SeedCommunityPodsResult> {
+  const apply = options.apply === true;
+  const communityPodId = getCommunityPodId();
+  if (!communityPodId) {
+    throw new Error('COMMUNITY_POD_ID is required.');
+  }
+
+  const hq = await Pod.findById(communityPodId).select('_id createdBy').lean();
+  if (!hq) {
+    throw new Error('Configured COMMUNITY_POD_ID Pod was not found.');
+  }
+
+  const existingPods = await Pod.find({
+    parentPod: hq._id,
+    name: { $in: COMMUNITY_POD_SEEDS.map((seed) => seed.name) },
+  }).select('name').lean();
+  const existingNames = new Set(existingPods.map((pod) => pod.name));
+  const result: SeedCommunityPodsResult = {
+    apply,
+    total: COMMUNITY_POD_SEEDS.length,
+    existing: existingNames.size,
+    wouldCreate: COMMUNITY_POD_SEEDS.length - existingNames.size,
+    created: 0,
+    updated: 0,
+  };
+
+  if (!apply) return result;
+
+  for (const seed of COMMUNITY_POD_SEEDS) {
+    const write = await Pod.updateOne(
+      { name: seed.name, parentPod: hq._id },
+      {
+        $setOnInsert: {
+          description: seed.description,
+          type: 'team',
+          joinPolicy: 'open',
+          publicRead: true,
+          communityListed: true,
+          createdBy: hq.createdBy,
+          members: [hq.createdBy],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      },
+      { upsert: true, timestamps: false },
+    );
+
+    result.created += write.upsertedCount || 0;
+    result.updated += write.modifiedCount || 0;
+
+    if (process.env.PG_HOST && write.upsertedId) {
+      try {
+        // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+        const PGPod = require('../models/pg/Pod');
+        await PGPod.create(
+          seed.name,
+          seed.description,
+          'team',
+          String(hq.createdBy),
+          String(write.upsertedId),
+        );
+      } catch (err) {
+        // Mongo is authoritative; lazy PG sync can repair a failed mirror.
+        console.warn('[community-pod-seed] PostgreSQL mirror failed:', (err as Error).message);
+      }
+    }
+  }
+
+  return result;
+}
+
+if (require.main === module) {
+  const apply = process.argv.includes('--apply');
+  const uri = process.env.MONGO_URI;
+  if (!uri) {
+    console.error('MONGO_URI is required.');
+    process.exit(1);
+  }
+
+  (async () => {
+    await mongoose.connect(uri);
+    try {
+      const result = await seedCommunityPods({ apply });
+      console.log(
+        `Community Pod seed ${apply ? '(apply)' : '(dry-run)'} `
+        + `total=${result.total} existing=${result.existing} `
+        + `wouldCreate=${result.wouldCreate} created=${result.created} updated=${result.updated}`,
+      );
+    } finally {
+      await mongoose.disconnect();
+    }
+  })().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- harden the existing direct-join endpoint so joinable community Pods use an atomic, idempotent, rate-limited path
- add an authenticated `scope=discover` listing for public, listed, joinable Pods the caller has not joined
- add a dry-run-by-default seed for the Bug Reports and Feature Requests children of Commonly HQ, with a best-effort PostgreSQL mirror

## Safety invariants

- direct self-join is limited to `communityListed && joinPolicy !== 'invite-only'`; unlisted and invite-only Pods still require an invite
- the existing DM-type refusal runs before every other join rule
- global-admin bypass remains available for non-DM Pods
- `scope=mine` and `scope=community` retain their existing query shapes and behavior
- seed re-runs are true no-ops: `$setOnInsert` is paired with `timestamps: false`, and the real-model test asserts zero second-run modifications

## Verification

- `npm test -- --runInBand __tests__/unit/controllers/podController.test.js __tests__/service/pods.community-scope.test.js __tests__/service/pods.discover-join.test.js __tests__/unit/routes/pods.test.js __tests__/unit/scripts/seed-community-pods.test.js` — 5 suites, 46 tests passed
- `npm run tsc:check` — passed
- full backend run on local Node 26: 135 suites / 797 tests passed; 49 suites failed at `jsonwebtoken` import because its transitive `buffer-equal-constant-time` dependency reads the removed `SlowBuffer.prototype` (known local-runtime baseline; CI's supported Node runtime is authoritative)
- repository backend lint remains at the pre-existing baseline (the script targets `.js` while TypeScript files are not parser-configured); changed TypeScript passes `tsc:check`

## Post-deploy operator step

Run from the backend container/workdir:

```sh
npx ts-node scripts/seed-community-pods.ts
npx ts-node scripts/seed-community-pods.ts --apply
```

The first command is dry-run only. Apply requires `COMMUNITY_POD_ID` to resolve to the HQ Pod.

Closes #727
