### PR TITLE
feat(community): add Discover browse-and-join UI

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1261,6 +1261,11 @@
       "private": "Private",
       "community": "Community"
     },
+    "communityViews": {
+      "ariaLabel": "Community views",
+      "joined": "Joined",
+      "discover": "Discover"
+    },
     "groups": {
       "pinned": "Pinned",
       "directMessages": "Direct messages",
@@ -1288,6 +1293,16 @@
     },
     "errors": {
       "createFailed": "Unable to create pod. Check that you are signed in and try again."
+    },
+    "discover": {
+      "join": "Join",
+      "joining": "Joining…",
+      "empty": "No community Pods to discover right now.",
+      "joinedEmpty": "You haven't joined any community Pods yet.",
+      "loadFailed": "Couldn't load community Pods. Try again.",
+      "inviteRequired": "This Pod needs an invite link to join.",
+      "rateLimited": "Too many join attempts. Wait a moment and try again.",
+      "joinFailed": "Couldn't join this Pod. Try again."
     },
     "community": {
       "title": "Join Commonly HQ",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1257,6 +1257,11 @@
       "private": "私密",
       "community": "社区"
     },
+    "communityViews": {
+      "ariaLabel": "社区视图",
+      "joined": "已加入",
+      "discover": "发现"
+    },
     "groups": {
       "pinned": "已置顶",
       "directMessages": "私信",
@@ -1284,6 +1289,16 @@
     },
     "errors": {
       "createFailed": "无法创建 Pod。请确认你已登录后重试。"
+    },
+    "discover": {
+      "join": "加入",
+      "joining": "加入中…",
+      "empty": "暂时没有可加入的社区 Pod。",
+      "joinedEmpty": "你还没有加入社区 Pod。",
+      "loadFailed": "无法加载社区 Pod，请重试。",
+      "inviteRequired": "这个 Pod 需要邀请链接才能加入。",
+      "rateLimited": "加入尝试过于频繁，请稍后再试。",
+      "joinFailed": "无法加入这个 Pod，请重试。"
     },
     "community": {
       "title": "加入 Commonly HQ",

--- a/frontend/src/v2/__tests__/V2PodsSidebar.community.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodsSidebar.community.test.tsx
@@ -8,6 +8,7 @@ import V2PodsSidebar from '../components/V2PodsSidebar';
 const COMMUNITY_POD_ID = 'community-pod';
 const mockJoinPod = jest.fn();
 const mockSeedFromExisting = jest.fn();
+const mockRefresh = jest.fn();
 const mockApiGet = jest.fn();
 const mockApi = {
   get: mockApiGet,
@@ -21,7 +22,9 @@ jest.mock('../hooks/useV2Pods', () => ({
     pods: [],
     loading: false,
     error: null,
+    refresh: mockRefresh,
     createPod: jest.fn(),
+    deletePod: jest.fn(),
     patchLastMessage: jest.fn(),
   }),
 }));
@@ -71,7 +74,9 @@ const renderSidebar = (pods) => {
     pods,
     loading: false,
     error: null,
+    refresh: mockRefresh,
     createPod: jest.fn(),
+    deletePod: jest.fn(),
     patchLastMessage: jest.fn(),
   };
   return render(
@@ -91,7 +96,11 @@ describe('V2PodsSidebar Community offer', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockApiGet.mockReset();
+    mockApi.post.mockReset();
     mockApiGet.mockResolvedValue([]);
+    mockApi.post.mockResolvedValue(null);
+    mockRefresh.mockResolvedValue(undefined);
     process.env.REACT_APP_COMMUNITY_POD_ID = COMMUNITY_POD_ID;
     await act(async () => {
       await i18n.changeLanguage('en');
@@ -131,37 +140,136 @@ describe('V2PodsSidebar Community offer', () => {
     expect(screen.queryByRole('button', { name: 'Join HQ' })).not.toBeInTheDocument();
   });
 
-  test('Community shows public discovery and HQ, excludes personal pods, and leaves All personal', async () => {
-    mockApiGet.mockResolvedValue([
-      makePod('public-space', [], { name: 'Open Builders', publicRead: true }),
-      makePod(COMMUNITY_POD_ID, [], { publicRead: true }),
-      makePod('forced-public-dm', [], {
-        name: 'Private agent room',
-        type: 'agent-room',
-        publicRead: true,
-      }),
+  test('splits joined Community pods from discoverable non-members without leaking them into All', async () => {
+    const joinedPod = makePod('joined-space', ['human-1'], {
+      name: 'Joined Builders',
+      publicRead: true,
+    });
+    const hqPod = makePod(COMMUNITY_POD_ID, ['human-1'], { publicRead: true });
+    mockApiGet.mockImplementation((url) => {
+      if (url === '/api/pods?scope=community') {
+        return Promise.resolve([joinedPod, hqPod]);
+      }
+      if (url === '/api/pods?scope=discover') {
+        return Promise.resolve([
+          makePod('public-space', [], {
+            name: 'Open Builders',
+            description: 'Build in public with the community.',
+            publicRead: true,
+          }),
+          makePod('forced-public-dm', [], {
+            name: 'Private agent room',
+            type: 'agent-room',
+            publicRead: true,
+          }),
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+    renderSidebar([
+      makePod('workspace', ['human-1']),
+      joinedPod,
+      hqPod,
     ]);
-    renderSidebar([makePod('workspace', ['human-1'])]);
 
     fireEvent.click(screen.getByRole('button', { name: 'Community' }));
-    expect(await screen.findByText('Open Builders')).toBeInTheDocument();
+    expect(await screen.findByText('Joined Builders')).toBeInTheDocument();
     expect(screen.getByText('Commonly HQ')).toBeInTheDocument();
+    expect(screen.queryByText('Open Builders')).not.toBeInTheDocument();
+    expect(mockApiGet).not.toHaveBeenCalledWith('/api/pods?scope=discover');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Discover' }));
+    expect(await screen.findByText('Open Builders')).toBeInTheDocument();
+    expect(screen.getByText('Build in public with the community.')).toBeInTheDocument();
+    expect(screen.getByText('0 members')).toBeInTheDocument();
     expect(screen.queryByText('Private agent room')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'All' }));
     expect(screen.getByText('My Workspace')).toBeInTheDocument();
     expect(screen.queryByText('Open Builders')).not.toBeInTheDocument();
-    expect(screen.queryByText('Commonly HQ')).not.toBeInTheDocument();
-    await waitFor(() => expect(mockApiGet).toHaveBeenCalledWith('/api/pods?scope=community'));
+    await waitFor(() => {
+      expect(mockApiGet).toHaveBeenCalledWith('/api/pods?scope=community');
+      expect(mockApiGet).toHaveBeenCalledWith('/api/pods?scope=discover');
+    });
   });
 
-  test('renders the Community tab from both locale catalogs', async () => {
+  test('joins a discovered pod, moves it to Joined, refreshes memberships, and navigates in', async () => {
+    const discoveredPod = makePod('bug-reports', [], {
+      name: 'Bug Reports',
+      description: 'Help make Commonly better.',
+      publicRead: true,
+    });
+    const joinedPod = makePod('bug-reports', ['human-1'], {
+      name: 'Bug Reports',
+      description: 'Help make Commonly better.',
+      publicRead: true,
+    });
+    mockApiGet.mockImplementation((url) => (
+      url === '/api/pods?scope=discover'
+        ? Promise.resolve([discoveredPod])
+        : Promise.resolve([])
+    ));
+    mockApi.post.mockResolvedValue(joinedPod);
+    renderSidebar([makePod('workspace', ['human-1'])]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Community' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Discover' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Join' }));
+
+    await waitFor(() => {
+      expect(mockApi.post).toHaveBeenCalledWith('/api/pods/bug-reports/join');
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/bug-reports');
+    });
+    expect(screen.getByRole('button', { name: 'Joined' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('Bug Reports')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Join' })).not.toBeInTheDocument();
+  });
+
+  test.each([
+    [403, 'This Pod needs an invite link to join.'],
+    [429, 'Too many join attempts. Wait a moment and try again.'],
+  ])('keeps a discovered pod visible and explains a %s join refusal', async (status, message) => {
+    const discoveredPod = makePod('feature-requests', [], {
+      name: 'Feature Requests',
+      publicRead: true,
+    });
+    mockApiGet.mockImplementation((url) => (
+      url === '/api/pods?scope=discover'
+        ? Promise.resolve([discoveredPod])
+        : Promise.resolve([])
+    ));
+    mockApi.post.mockRejectedValue({ response: { status } });
+    renderSidebar([makePod('workspace', ['human-1'])]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Community' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Discover' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Join' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(message);
+    expect(screen.getByText('Feature Requests')).toBeInTheDocument();
+    expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/workspace');
+  });
+
+  test('renders the Community discovery controls from both locale catalogs', async () => {
+    mockApiGet.mockImplementation((url) => (
+      url === '/api/pods?scope=discover'
+        ? Promise.resolve([makePod('public-space', [], { name: 'Open Builders' })])
+        : Promise.resolve([])
+    ));
     renderSidebar([makePod('workspace', ['human-1'])]);
     expect(screen.getByRole('button', { name: 'Community' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Community' }));
+    expect(screen.getByRole('button', { name: 'Joined' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Discover' }));
+    expect(await screen.findByRole('button', { name: 'Join' })).toBeInTheDocument();
 
     await act(async () => {
       await i18n.changeLanguage('zh-CN');
     });
     expect(screen.getByRole('button', { name: '社区' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '已加入' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '发现' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '加入' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -134,6 +134,18 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(rule).toContain('overflow: visible');
   });
 
+  test('the Community sub-tabs and Discover rows shrink inside the narrow sidebar', () => {
+    // Joined/Discover adds a second segmented row beneath the four main
+    // filters. Equal minmax(0, 1fr) tracks keep both locale labels on one line,
+    // while the Discover card gives its copy column the only shrinkable track.
+    const tabs = ruleBody(v2, '.v2-pods__community-tabs');
+    const row = ruleBody(v2, '.v2-pods__discover-row');
+    expect(tabs).toContain('display: grid');
+    expect(tabs).toContain('repeat(2, minmax(0, 1fr))');
+    expect(tabs).toContain('overflow: hidden');
+    expect(row).toContain('34px minmax(0, 1fr) auto');
+  });
+
   test('starter prompts wrap within the mobile chat pane', () => {
     // At 390px the rail leaves a narrow main pane. Both the row and each chip
     // need explicit shrink/wrap rules or the longest prompt creates horizontal

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -11,6 +11,7 @@ import { useSocket } from '../../context/SocketContext';
 import { useAuth } from '../../context/AuthContext';
 
 type Filter = 'all' | 'team' | 'private' | 'community';
+type CommunityView = 'joined' | 'discover';
 
 const FILTERS: Array<{ key: Filter; labelKey: string }> = [
   { key: 'all', labelKey: 'filters.all' },
@@ -18,6 +19,7 @@ const FILTERS: Array<{ key: Filter; labelKey: string }> = [
   { key: 'private', labelKey: 'filters.private' },
   { key: 'community', labelKey: 'filters.community' },
 ];
+const COMMUNITY_VIEWS: CommunityView[] = ['joined', 'discover'];
 
 // Both agent-room (user↔agent) and agent-dm (any 2-member combo) show
 // up under the Private filter. agent-dm with two bot members gets a
@@ -98,13 +100,24 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
   const navigate = useNavigate();
   const api = useV2Api();
   const ownPodsState = useV2Pods();
-  const { pods, loading, error, createPod, patchLastMessage } = podsState || ownPodsState;
+  const {
+    pods, loading, error, refresh, createPod, patchLastMessage,
+  } = podsState || ownPodsState;
   const { pinned, toggle: togglePin, isPinned } = useV2Pinned();
   const { socket, connected, joinPod } = useSocket();
   const { currentUser } = useAuth();
   const { isUnread, bumpLatest, seedFromExisting } = useV2Unread(selectedPodId);
+  const [filter, setFilter] = useState<Filter>('all');
+  const [search, setSearch] = useState('');
   const [communityPods, setCommunityPods] = useState<V2Pod[]>([]);
   const [communityLoading, setCommunityLoading] = useState(true);
+  const [communityView, setCommunityView] = useState<CommunityView>('joined');
+  const [discoverPods, setDiscoverPods] = useState<V2Pod[]>([]);
+  const [discoverLoading, setDiscoverLoading] = useState(false);
+  const [discoverError, setDiscoverError] = useState<string | null>(null);
+  const [joinedDiscoverPods, setJoinedDiscoverPods] = useState<V2Pod[]>([]);
+  const [joiningPodId, setJoiningPodId] = useState<string | null>(null);
+  const [joinNotice, setJoinNotice] = useState<string | null>(null);
 
   // Discovery is intentionally fetched into separate state. Merging these
   // rows into `pods` would make non-member public pods leak into All/Team,
@@ -126,6 +139,33 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
       active = false;
     };
   }, [api]);
+
+  // Discover stays separate from the membership-backed pod list: this endpoint
+  // deliberately returns pods the caller has NOT joined. Fetch it only while
+  // the Discover view is active so the default personal sidebar does not pay
+  // for discovery data it never renders.
+  useEffect(() => {
+    if (filter !== 'community' || communityView !== 'discover') return undefined;
+    let active = true;
+    setDiscoverLoading(true);
+    setDiscoverError(null);
+    api.get<V2Pod[]>('/api/pods?scope=discover')
+      .then((data) => {
+        if (!active) return;
+        setDiscoverPods((Array.isArray(data) ? data : []).filter((pod) => !isPersonalPod(pod)));
+      })
+      .catch(() => {
+        if (!active) return;
+        setDiscoverPods([]);
+        setDiscoverError(t('podsSidebar.discover.loadFailed'));
+      })
+      .finally(() => {
+        if (active) setDiscoverLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [api, communityView, filter, t]);
 
   // Seed lastSeen for any pod we've never observed before, using its current
   // newest-message timestamp. Without this, the very first load badges every
@@ -158,8 +198,6 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
   const showCommunityOffer = Boolean(communityPodId) && Boolean(currentUser?._id)
     && !loading && !error
     && !memberPodIds.includes(communityPodId);
-  const [filter, setFilter] = useState<Filter>('all');
-  const [search, setSearch] = useState('');
   const [creating, setCreating] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
   const [newPodName, setNewPodName] = useState('');
@@ -272,29 +310,50 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
   const communityCandidates = useMemo(() => {
     const byId = new Map<string, V2Pod>();
     communityPods.forEach((pod) => byId.set(pod._id, pod));
+    joinedDiscoverPods.forEach((pod) => byId.set(pod._id, pod));
     // Prefer the membership-list row when both endpoints return a pod; it is
     // the row socket/unread state already knows about.
     pods.forEach((pod) => byId.set(pod._id, pod));
+    const effectiveMemberIds = new Set([
+      ...memberPodIds,
+      ...joinedDiscoverPods.map((pod) => pod._id),
+    ]);
     return Array.from(byId.values()).filter((pod) => {
       if (isPersonalPod(pod)) return false;
-      const isPublicMembership = memberPodIds.includes(pod._id) && pod.publicRead === true;
+      if (!effectiveMemberIds.has(pod._id)) return false;
       return communityPodIds.has(pod._id)
-        || isPublicMembership
+        || joinedDiscoverPods.some((joined) => joined._id === pod._id)
+        || pod.publicRead === true
         || (Boolean(communityPodId) && pod._id === communityPodId);
     });
-  }, [communityPods, communityPodIds, pods, memberPodIds, communityPodId]);
+  }, [
+    communityPods,
+    communityPodIds,
+    joinedDiscoverPods,
+    pods,
+    memberPodIds,
+    communityPodId,
+  ]);
 
   const filtered = useMemo(() => {
     const term = search.trim().toLowerCase();
-    const candidates = filter === 'community' ? communityCandidates : pods;
+    const candidates = filter === 'community'
+      ? (communityView === 'discover' ? discoverPods : communityCandidates)
+      : pods;
     return candidates
       .filter((pod) => filter === 'community' || matchesPersonalFilter(pod, filter))
       .filter((pod) => !term
         || (pod.name || '').toLowerCase().includes(term)
         || (pod.description || '').toLowerCase().includes(term));
-  }, [communityCandidates, pods, filter, search]);
+  }, [communityCandidates, communityView, discoverPods, pods, filter, search]);
 
-  const visibleLoading = loading || (filter === 'community' && communityLoading);
+  const visibleLoading = loading || (
+    filter === 'community'
+    && (communityView === 'discover' ? discoverLoading : communityLoading)
+  );
+  const visibleError = filter === 'community' && communityView === 'discover'
+    ? discoverError
+    : error;
 
   // Default grouping is chronological (Pinned / Today / Yesterday / This week
   // / Earlier). When the user filters down to Private, recency buckets stop
@@ -303,6 +362,7 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
   // so a section header makes the relationship explicit at a glance and
   // doubles as a count of how many a2a conversations are happening.
   const grouped = useMemo(() => {
+    if (filter === 'community' && communityView === 'discover') return [];
     if (filter !== 'private') return groupPods(filtered, pinned);
     const sortByRecency = <T extends { lastMessage?: { createdAt?: string | Date | null } | null; updatedAt?: string | Date; createdAt?: string | Date }>(items: T[]): T[] => {
       const ts = (it: T) => {
@@ -321,13 +381,41 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
     if (dms.length) buckets.push({ label: t('podsSidebar.groups.directMessages'), items: sortByRecency(dms) });
     if (a2a.length) buckets.push({ label: t('podsSidebar.groups.betweenAgents', { count: a2a.length }), items: sortByRecency(a2a) });
     return buckets;
-  }, [filter, filtered, pinned, t]);
+  }, [communityView, filter, filtered, pinned, t]);
 
   // Navigate to a pod and, on mobile, dismiss the slide-over drawer so the
   // user lands directly in the chat instead of behind the overlay.
   const selectPod = (podId: string) => {
     navigate(`/v2/pods/${podId}`);
     onMobileClose?.();
+  };
+
+  const handleJoinDiscoverPod = async (pod: V2Pod) => {
+    setJoiningPodId(pod._id);
+    setJoinNotice(null);
+    try {
+      const joined = await api.post<V2Pod>(`/api/pods/${pod._id}/join`);
+      const joinedPod = joined?._id ? joined : pod;
+      setDiscoverPods((current) => current.filter((item) => item._id !== pod._id));
+      setJoinedDiscoverPods((current) => [
+        joinedPod,
+        ...current.filter((item) => item._id !== joinedPod._id),
+      ]);
+      setCommunityView('joined');
+      void refresh?.();
+      selectPod(joinedPod._id);
+    } catch (err) {
+      const status = (err as { response?: { status?: number } }).response?.status;
+      if (status === 403) {
+        setJoinNotice(t('podsSidebar.discover.inviteRequired'));
+      } else if (status === 429) {
+        setJoinNotice(t('podsSidebar.discover.rateLimited'));
+      } else {
+        setJoinNotice(t('podsSidebar.discover.joinFailed'));
+      }
+    } finally {
+      setJoiningPodId(null);
+    }
   };
 
   const handleCreatePod = async (event: React.FormEvent) => {
@@ -483,7 +571,10 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
               key={f.key}
               type="button"
               className={`v2-pods__filter v2-filter-segment__item${filter === f.key ? ' v2-pods__filter--active v2-filter-segment__item--active' : ''}`}
-              onClick={() => setFilter(f.key)}
+              onClick={() => {
+                setFilter(f.key);
+                setJoinNotice(null);
+              }}
               aria-pressed={filter === f.key}
             >
               {t(`podsSidebar.${f.labelKey}`)}
@@ -491,14 +582,80 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
           ))}
         </div>
 
+        {filter === 'community' && (
+          <div
+            className="v2-pods__community-tabs v2-filter-segment"
+            aria-label={t('podsSidebar.communityViews.ariaLabel')}
+          >
+            {COMMUNITY_VIEWS.map((view) => (
+              <button
+                key={view}
+                type="button"
+                className={`v2-pods__community-tab v2-filter-segment__item${communityView === view ? ' v2-pods__community-tab--active v2-filter-segment__item--active' : ''}`}
+                onClick={() => {
+                  setCommunityView(view);
+                  setJoinNotice(null);
+                }}
+                aria-pressed={communityView === view}
+              >
+                {t(`podsSidebar.communityViews.${view}`)}
+              </button>
+            ))}
+          </div>
+        )}
+
         <div className="v2-pods__list">
           {visibleLoading && <div className="v2-pods__empty"><span className="v2-spinner" /></div>}
-          {!visibleLoading && error && <div className="v2-pods__empty">{error}</div>}
-          {!visibleLoading && !error && filtered.length === 0 && (
+          {!visibleLoading && visibleError && <div className="v2-pods__empty">{visibleError}</div>}
+          {!visibleLoading
+            && !visibleError
+            && filter === 'community'
+            && communityView === 'discover'
+            && joinNotice && (
+            <div className="v2-pods__join-notice" role="alert">{joinNotice}</div>
+          )}
+          {!visibleLoading && !visibleError && filtered.length === 0 && (
             <div className="v2-pods__empty">
-              {search ? t('podsSidebar.empty.noMatch') : t('podsSidebar.empty.noPods')}
+              {search
+                ? t('podsSidebar.empty.noMatch')
+                : (filter === 'community'
+                  ? t(
+                    communityView === 'discover'
+                      ? 'podsSidebar.discover.empty'
+                      : 'podsSidebar.discover.joinedEmpty',
+                  )
+                  : t('podsSidebar.empty.noPods'))}
             </div>
           )}
+
+          {!visibleLoading
+            && !visibleError
+            && filter === 'community'
+            && communityView === 'discover'
+            && filtered.map((pod) => (
+              <article key={pod._id} className="v2-pods__discover-row">
+                <span className={podMarkClass(pod)}>{podMarkFor(pod)}</span>
+                <span className="v2-pods__discover-body">
+                  <span className="v2-pods__discover-title">{pod.name}</span>
+                  {pod.description && (
+                    <span className="v2-pods__discover-description">{pod.description}</span>
+                  )}
+                  <span className="v2-pods__discover-meta">
+                    {t('podsSidebar.meta.memberCount', { count: pod.members?.length || 0 })}
+                  </span>
+                </span>
+                <button
+                  type="button"
+                  className="v2-pods__discover-join"
+                  disabled={joiningPodId === pod._id}
+                  onClick={() => void handleJoinDiscoverPod(pod)}
+                >
+                  {joiningPodId === pod._id
+                    ? t('podsSidebar.discover.joining')
+                    : t('podsSidebar.discover.join')}
+                </button>
+              </article>
+            ))}
 
           {!visibleLoading && grouped.map((group) => (
             <div key={group.label}>

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -813,6 +813,21 @@
   font-weight: 600;
 }
 
+.v2-pods__community-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4px;
+  margin: -10px 0 14px;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.v2-pods__community-tab {
+  min-width: 0;
+  padding-inline: 8px;
+  white-space: nowrap;
+}
+
 .v2-pods__list {
   flex: 1;
   overflow-y: auto;
@@ -1068,6 +1083,81 @@
   text-align: center;
   color: var(--v2-text-tertiary);
   font-size: 13px;
+}
+
+.v2-pods__join-notice {
+  margin-bottom: 8px;
+  padding: 9px 10px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.v2-pods__discover-row {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  margin-bottom: 6px;
+  border: 1px solid var(--v2-border-soft);
+  border-radius: var(--v2-radius);
+  background: var(--v2-surface);
+}
+
+.v2-pods__discover-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.v2-pods__discover-title {
+  overflow: hidden;
+  color: var(--v2-text-primary);
+  font-size: 13px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-pods__discover-description {
+  overflow: hidden;
+  color: var(--v2-text-tertiary);
+  display: -webkit-box;
+  font-size: 12px;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.v2-pods__discover-meta {
+  color: var(--v2-text-muted);
+  font-size: 11px;
+}
+
+.v2-root button.v2-pods__discover-join {
+  min-width: 44px;
+  min-height: 30px;
+  padding-inline: 9px;
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-accent-soft);
+  color: var(--v2-accent-text);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.v2-root button.v2-pods__discover-join:hover {
+  background: var(--v2-accent);
+  color: var(--v2-surface);
+}
+
+.v2-root button.v2-pods__discover-join:disabled {
+  cursor: wait;
+  opacity: 0.65;
 }
 
 .v2-pods__community {


### PR DESCRIPTION
## Summary
- split the Community sidebar into membership-backed Joined and lazy-loaded Discover views
- list joinable non-member pods with description/member count and one-click join; move successful joins into Joined, refresh memberships, and navigate into the pod
- keep discovery data isolated from All/Team/Private and show specific invite-required / rate-limit guidance
- add EN + zh-CN chrome (`Discover`/`发现`, `Join`/`加入`) and load-bearing narrow-sidebar layout guards

## Verification
- `cd frontend && npm test -- --watchAll=false --runInBand` — 63 suites, 284 tests passed
- focused sidebar + layout + translation guard — 3 suites, 30 tests passed
- `cd frontend && npm run build` — passed
- changed-file ESLint — 0 errors (repository-standard TSX extension warnings only)
- real browser: EN + zh-CN at 1280×900 and 390×844; document/sidebar/list overflow all 0 in all four cells

## Review notes
- Discover is fetched only after the sub-tab is opened; it never enters the personal `pods` dataset.
- Client-side personal-pod exclusion is retained as defense in depth even though `scope=discover` already excludes DM types.
- zh-CN strings follow the locked glossary (社区 / 发现 / 加入, Pod untranslated) and are ready for Sam’s native-language pass.

Closes #727