### PR TITLE
fix: keep community and startup views personal

### DIFF
--- a/backend/__tests__/service/pods.community-scope.test.js
+++ b/backend/__tests__/service/pods.community-scope.test.js
@@ -146,20 +146,17 @@ describe('GET /api/pods community scope', () => {
     await closeMongoDb();
   });
 
-  it('returns non-member public pods while excluding every personal pod type', async () => {
+  it('returns only listed public pods the caller has joined', async () => {
     const res = await request(app)
       .get('/api/pods?scope=community')
       .set('Authorization', `Bearer ${viewerToken}`);
 
     expect(res.status).toBe(200);
     const ids = res.body.map((pod) => pod._id);
-    expect(ids).toEqual(expect.arrayContaining([
-      communityPod._id.toString(),
-      studyCommunityPod._id.toString(),
-      joinedCommunityPod._id.toString(),
-      inviteOnlyPod._id.toString(),
-    ]));
-    expect(ids).toHaveLength(4);
+    expect(ids).toEqual([joinedCommunityPod._id.toString()]);
+    expect(ids).not.toContain(communityPod._id.toString());
+    expect(ids).not.toContain(studyCommunityPod._id.toString());
+    expect(ids).not.toContain(inviteOnlyPod._id.toString());
     expect(ids).not.toContain(privatePod._id.toString());
     expect(ids).not.toContain(nonPublicListedPod._id.toString());
     // Readable-but-unlisted showcase rooms must stay OFF the Community tab.

--- a/backend/__tests__/unit/controllers/podController.test.js
+++ b/backend/__tests__/unit/controllers/podController.test.js
@@ -340,22 +340,26 @@ describe('podController', () => {
     expect(res.json).toHaveBeenCalledWith([myPod]);
   });
 
-  it('getAllPods keeps the existing community query exact', async () => {
+  it('getAllPods community scope requires listed, readable member pods', async () => {
     const sort = jest.fn().mockResolvedValue([]);
     const populateThird = jest.fn(() => ({ sort }));
     const populateSecond = jest.fn(() => ({ populate: populateThird, sort }));
     const populateFirst = jest.fn(() => ({ populate: populateSecond, sort }));
     Pod.find.mockReturnValue({ populate: populateFirst });
 
-    const req = { query: { scope: 'community' }, userId: 'me', user: {} };
+    const communityUserId = '507f1f77bcf86cd799439011';
+    const req = { query: { scope: 'community' }, userId: communityUserId, user: {} };
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
     await podController.getAllPods(req, res);
 
     expect(Pod.find).toHaveBeenCalledWith({
       publicRead: true,
       communityListed: true,
+      members: expect.anything(),
       type: { $nin: ['agent-room', 'agent-dm', 'agent-admin'] },
     });
+    const [query] = Pod.find.mock.calls[0];
+    expect(String(query.members)).toBe(communityUserId);
   });
 
   it('getAllPods discover scope requires listed, readable, joinable non-member pods', async () => {

--- a/backend/controllers/podController.ts
+++ b/backend/controllers/podController.ts
@@ -161,13 +161,13 @@ exports.getAllPods = async (req: any, res: any) => {
     const scope = String(req.query?.scope || 'mine').toLowerCase();
     const isCommunityScope = scope === 'community';
     const isDiscoverScope = scope === 'discover';
-    let discoverCallerId = null;
-    if (isDiscoverScope) {
+    let scopedCallerId = null;
+    if (isCommunityScope || isDiscoverScope) {
       const rawCallerId = String(req.userId || req.user?.id || '');
       if (!mongoose.Types.ObjectId.isValid(rawCallerId)) {
         return res.status(401).json({ error: 'User authentication failed' });
       }
-      discoverCallerId = new mongoose.Types.ObjectId(rawCallerId);
+      scopedCallerId = new mongoose.Types.ObjectId(rawCallerId);
     }
     // Exclude agent-admin DM pods from default listing; only show when
     // explicitly requested and the caller is a member.
@@ -181,7 +181,7 @@ exports.getAllPods = async (req: any, res: any) => {
         publicRead: true,
         communityListed: true,
         joinPolicy: { $ne: 'invite-only' },
-        members: { $ne: discoverCallerId },
+        members: { $ne: scopedCallerId },
         type: type
           ? { $eq: type, $nin: COMMUNITY_EXCLUDED_POD_TYPES }
           : { $nin: COMMUNITY_EXCLUDED_POD_TYPES },
@@ -192,6 +192,7 @@ exports.getAllPods = async (req: any, res: any) => {
         // publicRead for anonymous viewing without appearing in Community.
         publicRead: true,
         communityListed: true,
+        members: scopedCallerId,
         type: type
           ? { $eq: type, $nin: COMMUNITY_EXCLUDED_POD_TYPES }
           : { $nin: COMMUNITY_EXCLUDED_POD_TYPES },

--- a/frontend/src/v2/__tests__/V2InviteDmGate.test.tsx
+++ b/frontend/src/v2/__tests__/V2InviteDmGate.test.tsx
@@ -31,6 +31,10 @@ jest.mock('../hooks/useV2PodDetail', () => ({
   }),
 }));
 
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ currentUser: { _id: 'human-1', username: 'new-human' } }),
+}));
+
 jest.mock('../components/V2NavRail', () => () => null);
 jest.mock('../components/V2PodsSidebar', () => () => null);
 jest.mock('../components/V2PodInspector', () => () => null);

--- a/frontend/src/v2/__tests__/V2LayoutSelection.test.tsx
+++ b/frontend/src/v2/__tests__/V2LayoutSelection.test.tsx
@@ -1,0 +1,154 @@
+/* eslint-disable react/display-name */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import {
+  MemoryRouter, Route, Routes, useLocation,
+} from 'react-router-dom';
+import V2Layout from '../components/V2Layout';
+import type { V2Pod } from '../hooks/useV2Pods';
+
+const mockPodsState = {
+  pods: [] as V2Pod[],
+  loading: false,
+  error: null,
+  refresh: jest.fn(),
+  createPod: jest.fn(),
+  deletePod: jest.fn(),
+  patchLastMessage: jest.fn(),
+};
+
+jest.mock('../hooks/useV2Pods', () => ({
+  useV2Pods: () => mockPodsState,
+}));
+
+jest.mock('../hooks/useV2PodDetail', () => ({
+  useV2PodDetail: () => ({
+    pod: null,
+    members: [],
+    messages: [],
+    agents: [],
+    loading: false,
+    error: null,
+  }),
+}));
+
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ currentUser: { _id: 'human-1', username: 'new-human' } }),
+}));
+
+jest.mock('../components/V2NavRail', () => () => null);
+jest.mock('../components/V2PodsSidebar', () => () => null);
+jest.mock('../components/V2PodChat', () => () => null);
+jest.mock('../components/V2PodInspector', () => () => null);
+jest.mock('../components/V2InviteModal', () => () => null);
+jest.mock('../components/V2FirstRunHero', () => () => null);
+
+const CurrentPath = () => {
+  const location = useLocation();
+  return <span data-testid="current-path">{location.pathname}</span>;
+};
+
+const hqPod: V2Pod = {
+  _id: 'hq',
+  name: 'Commonly HQ',
+  joinPolicy: 'open',
+  createdBy: { _id: 'hq-owner' },
+  createdAt: '2026-07-20T00:00:00.000Z',
+};
+
+const workspacePod: V2Pod = {
+  _id: 'workspace',
+  name: 'My Workspace',
+  joinPolicy: 'invite-only',
+  createdBy: { _id: 'human-1' },
+  createdAt: '2026-07-21T00:00:00.000Z',
+};
+
+const newerWorkspacePod: V2Pod = {
+  ...workspacePod,
+  _id: 'newer-workspace',
+  name: 'Newer Workspace',
+  createdAt: '2026-07-22T00:00:00.000Z',
+};
+
+const renderAutoLayout = () => render(
+  <MemoryRouter initialEntries={['/v2']}>
+    <Routes>
+      <Route path="/v2" element={<V2Layout selectionMode="auto" />} />
+      <Route path="/v2/pods/:podId" element={<CurrentPath />} />
+    </Routes>
+  </MemoryRouter>,
+);
+
+describe('V2Layout default pod selection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockPodsState.pods = [hqPod, newerWorkspacePod, workspacePod];
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('lands a new user in their oldest own workspace instead of auto-joined HQ', async () => {
+    renderAutoLayout();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/workspace');
+    });
+  });
+
+  test('a valid last visited pod wins over the workspace', async () => {
+    localStorage.setItem('v2:lastPodId', 'hq');
+    renderAutoLayout();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/hq');
+    });
+  });
+
+  test('a stale last visited pod falls back to the workspace', async () => {
+    localStorage.setItem('v2:lastPodId', 'deleted-pod');
+    renderAutoLayout();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/workspace');
+    });
+  });
+
+  test('falls back to the first pod when the user owns no workspace', async () => {
+    mockPodsState.pods = mockPodsState.pods.map((pod) => (
+      pod.joinPolicy === 'invite-only'
+        ? { ...pod, createdBy: { _id: 'someone-else' } }
+        : pod
+    ));
+    renderAutoLayout();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/hq');
+    });
+  });
+
+  test('records every visited pod for the next automatic selection', async () => {
+    render(
+      <MemoryRouter initialEntries={['/v2/pods/workspace']}>
+        <Routes>
+          <Route
+            path="/v2/pods/:podId"
+            element={(
+              <>
+                <V2Layout selectionMode="param" />
+                <CurrentPath />
+              </>
+            )}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(localStorage.getItem('v2:lastPodId')).toBe('workspace');
+    });
+  });
+});

--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -9,6 +9,7 @@ import V2FirstRunHero from './V2FirstRunHero';
 import { useV2Pods } from '../hooks/useV2Pods';
 import { useV2PodDetail } from '../hooks/useV2PodDetail';
 import { getSignedAttachmentUrl } from '../../utils/signedAttachmentUrl';
+import { useAuth } from '../../context/AuthContext';
 
 interface V2LayoutProps {
   selectionMode?: 'auto' | 'param';
@@ -20,6 +21,7 @@ export type InspectorView =
   | { kind: 'artifact'; artifactId: string };
 
 const INSPECTOR_PREF_KEY = 'v2.inspectorCollapsed';
+const LAST_POD_KEY = 'v2:lastPodId';
 const INVITE_BLOCKED_POD_TYPES = new Set(['agent-room', 'agent-dm']);
 
 const readInspectorCollapsed = (): boolean => {
@@ -42,9 +44,32 @@ const writeInspectorCollapsed = (next: boolean) => {
   }
 };
 
+const readLastPodId = (): string | null => {
+  try {
+    return localStorage.getItem(LAST_POD_KEY);
+  } catch {
+    return null;
+  }
+};
+
+const writeLastPodId = (podId: string) => {
+  try {
+    localStorage.setItem(LAST_POD_KEY, podId);
+  } catch {
+    // localStorage unavailable; auto-selection falls back to the workspace.
+  }
+};
+
+const createdAtTime = (createdAt?: string): number => {
+  if (!createdAt) return Number.POSITIVE_INFINITY;
+  const parsed = Date.parse(createdAt);
+  return Number.isNaN(parsed) ? Number.POSITIVE_INFINITY : parsed;
+};
+
 const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   const { podId: paramPodId } = useParams<{ podId: string }>();
   const navigate = useNavigate();
+  const { currentUser } = useAuth();
   const podsState = useV2Pods();
   const { pods, loading } = podsState;
 
@@ -122,14 +147,27 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   useEffect(() => {
     setInspectorView({ kind: 'overview' });
     setMobileNavOpen(false);
+    if (paramPodId) writeLastPodId(paramPodId);
   }, [paramPodId]);
 
-  // Auto-pick the first pod when the user lands on /v2 directly, so the
-  // three-column layout doesn't render an empty main pane on first load.
+  // Resume the last valid room. A new user without history lands in their
+  // self-created invite-only workspace rather than the auto-joined HQ.
   useEffect(() => {
     if (selectionMode !== 'auto' || paramPodId || loading) return;
-    if (pods.length > 0) navigate(`/v2/pods/${pods[0]._id}`, { replace: true });
-  }, [selectionMode, paramPodId, pods, loading, navigate]);
+    if (pods.length === 0) return;
+
+    const lastPodId = readLastPodId();
+    const lastPod = lastPodId ? pods.find((pod) => pod._id === lastPodId) : undefined;
+    const ownWorkspace = pods
+      .filter((pod) => (
+        pod.createdBy?._id === currentUser?._id
+        && pod.joinPolicy === 'invite-only'
+      ))
+      .sort((left, right) => createdAtTime(left.createdAt) - createdAtTime(right.createdAt))[0];
+    const destination = lastPod || ownWorkspace || pods[0];
+
+    navigate(`/v2/pods/${destination._id}`, { replace: true });
+  }, [selectionMode, paramPodId, pods, loading, navigate, currentUser?._id]);
 
   const selectedPodId = paramPodId || null;
   const detail = useV2PodDetail(selectedPodId);


### PR DESCRIPTION
## Summary
- make `scope=community` return only public, listed pods the caller has joined
- preserve `scope=discover` as the only browse surface and leave the default membership listing unchanged
- resume a valid last-visited pod on `/v2`, otherwise land new users in their oldest self-created invite-only workspace before falling back to the first pod
- persist the current pod id on each pod visit

Part of #732 (PR 1: A + C only).

## Tests
- `cd backend && npm test -- --runInBand __tests__/service/pods.community-scope.test.js` (5/5)
- `cd backend && npm run tsc:check`
- `cd frontend && npm test -- --watchAll=false --runInBand src/v2/__tests__/V2LayoutSelection.test.tsx src/v2/__tests__/V2InviteDmGate.test.tsx src/v2/__tests__/V2FirstRunHero.test.tsx` (17/17)
- `cd frontend && npm test -- --watchAll=false --runInBand` (64 suites / 285 tests)
- `cd frontend && npm run build`
- changed frontend files: ESLint clean

## Local environment notes
- Full backend Jest is not executable on local Node 26 because `jsonwebtoken`’s transitive `buffer-equal-constant-time` dependency references removed `SlowBuffer.prototype`; the changed backend suite is mocked around this known issue and passes. CI on the supported runtime is the executable gate.
- Full frontend typecheck still reports the pre-existing `V2GithubPrCard` state-union and `V2MessageBubble._id` errors; this PR adds no typecheck errors.