### PR TITLE
feat(v2): strengthen create and first-run onboarding

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -150,6 +150,7 @@
     "title": "Bring your agent into the room",
     "lede": "Connect Claude Code, Cursor, or Codex, then start a private conversation without leaving your workspace.",
     "skip": "Skip for now",
+    "reopen": "Guide",
     "steps": {
       "connect": {
         "title": "Connect your agent",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -270,7 +270,6 @@
     },
     "newPod": {
       "label": "New Pod starter actions",
-      "eyebrow": "Start here",
       "title": "Your Pod is ready",
       "text": "Bring in people or an agent, or start the conversation yourself.",
       "dismiss": "Dismiss starter actions",
@@ -1273,22 +1272,15 @@
       "betweenAgents": "Between agents · {{count}}"
     },
     "create": {
-      "title": "Create a Pod",
-      "intro": "Choose how people join. You can invite teammates and add agents after the Pod is ready.",
-      "policyLabel": "Who can join",
       "teamOption": "Team Pod",
-      "teamDescription": "A shared space for a team. Invite people and agents as you go.",
+      "teamDescription": "Anyone can find and join if listed.",
       "privateOption": "Private Pod",
-      "privateDescription": "Invite-only membership for work you want to keep contained.",
-      "nameLabel": "Pod name",
+      "privateDescription": "Invite-only — you add people.",
       "namePlaceholder": "Pod name",
-      "goalLabel": "What will this Pod accomplish?",
       "goalPlaceholder": "Goal or description",
       "cancel": "Cancel",
       "creating": "Creating...",
-      "submit": "Create",
-      "submitTeam": "Create team Pod",
-      "submitPrivate": "Create private Pod"
+      "submit": "Create"
     },
     "empty": {
       "noMatch": "No pods match your search.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -270,6 +270,7 @@
     },
     "newPod": {
       "label": "New Pod starter actions",
+      "eyebrow": "Start here",
       "title": "Your Pod is ready",
       "text": "Bring in people or an agent, or start the conversation yourself.",
       "dismiss": "Dismiss starter actions",
@@ -1272,13 +1273,22 @@
       "betweenAgents": "Between agents · {{count}}"
     },
     "create": {
+      "title": "Create a Pod",
+      "intro": "Choose how people join. You can invite teammates and add agents after the Pod is ready.",
+      "policyLabel": "Who can join",
       "teamOption": "Team Pod",
+      "teamDescription": "A shared space for a team. Invite people and agents as you go.",
       "privateOption": "Private Pod",
+      "privateDescription": "Invite-only membership for work you want to keep contained.",
+      "nameLabel": "Pod name",
       "namePlaceholder": "Pod name",
+      "goalLabel": "What will this Pod accomplish?",
       "goalPlaceholder": "Goal or description",
       "cancel": "Cancel",
       "creating": "Creating...",
-      "submit": "Create"
+      "submit": "Create",
+      "submitTeam": "Create team Pod",
+      "submitPrivate": "Create private Pod"
     },
     "empty": {
       "noMatch": "No pods match your search.",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -270,6 +270,7 @@
     },
     "newPod": {
       "label": "新 Pod 开始操作",
+      "eyebrow": "从这里开始",
       "title": "Pod 已就绪",
       "text": "邀请队友、添加智能体，或自己开始对话。",
       "dismiss": "关闭开始操作",
@@ -1268,13 +1269,22 @@
       "betweenAgents": "智能体之间 · {{count}}"
     },
     "create": {
+      "title": "创建 Pod",
+      "intro": "先选择谁可以加入。创建后，你可以邀请队友并添加智能体。",
+      "policyLabel": "谁可以加入",
       "teamOption": "团队 Pod",
+      "teamDescription": "适合团队协作，随时邀请成员和智能体加入。",
       "privateOption": "私密 Pod",
+      "privateDescription": "仅限受邀成员，适合需要严格控制的工作。",
+      "nameLabel": "Pod 名称",
       "namePlaceholder": "Pod 名称",
+      "goalLabel": "这个 Pod 要完成什么？",
       "goalPlaceholder": "目标或描述",
       "cancel": "取消",
       "creating": "创建中...",
-      "submit": "创建"
+      "submit": "创建",
+      "submitTeam": "创建团队 Pod",
+      "submitPrivate": "创建私密 Pod"
     },
     "empty": {
       "noMatch": "没有匹配的 Pod。",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -270,7 +270,6 @@
     },
     "newPod": {
       "label": "新 Pod 开始操作",
-      "eyebrow": "从这里开始",
       "title": "Pod 已就绪",
       "text": "邀请队友、添加智能体，或自己开始对话。",
       "dismiss": "关闭开始操作",
@@ -1269,22 +1268,15 @@
       "betweenAgents": "智能体之间 · {{count}}"
     },
     "create": {
-      "title": "创建 Pod",
-      "intro": "先选择谁可以加入。创建后，你可以邀请队友并添加智能体。",
-      "policyLabel": "谁可以加入",
       "teamOption": "团队 Pod",
-      "teamDescription": "适合团队协作，随时邀请成员和智能体加入。",
+      "teamDescription": "列入发现后，任何人都可以找到并加入。",
       "privateOption": "私密 Pod",
-      "privateDescription": "仅限受邀成员，适合需要严格控制的工作。",
-      "nameLabel": "Pod 名称",
+      "privateDescription": "仅限邀请，由你添加成员。",
       "namePlaceholder": "Pod 名称",
-      "goalLabel": "这个 Pod 要完成什么？",
       "goalPlaceholder": "目标或描述",
       "cancel": "取消",
       "creating": "创建中...",
-      "submit": "创建",
-      "submitTeam": "创建团队 Pod",
-      "submitPrivate": "创建私密 Pod"
+      "submit": "创建"
     },
     "empty": {
       "noMatch": "没有匹配的 Pod。",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -150,6 +150,7 @@
     "title": "把你的智能体请进房间",
     "lede": "接入 Claude Code、Cursor 或 Codex，然后直接在工作空间中开始一对一私信。",
     "skip": "暂时跳过",
+    "reopen": "帮助",
     "steps": {
       "connect": {
         "title": "接入你的智能体",

--- a/frontend/src/v2/__tests__/V2CommunityNav.test.tsx
+++ b/frontend/src/v2/__tests__/V2CommunityNav.test.tsx
@@ -1,12 +1,15 @@
 // @ts-nocheck
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import {
+  act, fireEvent, render, screen,
+} from '@testing-library/react';
 import {
   MemoryRouter, Route, Routes, useLocation,
 } from 'react-router-dom';
 import axios from 'axios';
 import V2CommunityRedirect from '../components/V2CommunityRedirect';
 import V2NavRail from '../components/V2NavRail';
+import i18n, { i18nReady } from '../../i18n';
 
 const mockLogout = jest.fn();
 const mockAxiosGet = axios.get as jest.Mock;
@@ -24,10 +27,10 @@ const COMMUNITY_INVITE_TOKEN = '7b91255f18ae3c0ae3721707a6613731';
 
 const CurrentPath = () => <div data-testid="current-path">{useLocation().pathname}</div>;
 
-const renderRail = () => render(
+const renderRail = (onOpenGuide?: () => void) => render(
   <MemoryRouter initialEntries={['/v2/agents']}>
     <div className="v2-root">
-      <V2NavRail />
+      <V2NavRail onOpenGuide={onOpenGuide} />
     </div>
   </MemoryRouter>,
 );
@@ -47,13 +50,20 @@ describe('Community navigation', () => {
   const originalPodId = process.env.REACT_APP_COMMUNITY_POD_ID;
   const originalInviteToken = process.env.REACT_APP_COMMUNITY_INVITE_TOKEN;
 
+  beforeAll(async () => {
+    await i18nReady;
+  });
+
   beforeEach(() => {
     process.env.REACT_APP_COMMUNITY_POD_ID = COMMUNITY_POD_ID;
     process.env.REACT_APP_COMMUNITY_INVITE_TOKEN = COMMUNITY_INVITE_TOKEN;
     jest.clearAllMocks();
+    return act(async () => {
+      await i18n.changeLanguage('en');
+    });
   });
 
-  afterAll(() => {
+  afterAll(async () => {
     if (originalPodId === undefined) {
       delete process.env.REACT_APP_COMMUNITY_POD_ID;
     } else {
@@ -64,6 +74,7 @@ describe('Community navigation', () => {
     } else {
       process.env.REACT_APP_COMMUNITY_INVITE_TOKEN = originalInviteToken;
     }
+    await i18n.changeLanguage('en');
   });
 
   test('shows the rail entry only when a community pod is configured', () => {
@@ -74,6 +85,19 @@ describe('Community navigation', () => {
     delete process.env.REACT_APP_COMMUNITY_POD_ID;
     renderRail();
     expect(screen.queryByRole('button', { name: 'Community' })).not.toBeInTheDocument();
+  });
+
+  test('opens the first-run guide from a localized rail action', async () => {
+    const openGuide = jest.fn();
+    renderRail(openGuide);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Guide' }));
+    expect(openGuide).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await i18n.changeLanguage('zh-CN');
+    });
+    expect(screen.getByRole('button', { name: '帮助' })).toBeInTheDocument();
   });
 
   test('sends members to the Community pod', async () => {

--- a/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
+++ b/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
@@ -59,7 +59,14 @@ jest.mock('../../context/AuthContext', () => ({
   useAuth: () => ({ currentUser: { _id: 'human-1', username: 'new-human' } }),
 }));
 
-jest.mock('../components/V2NavRail', () => () => <nav>Rail</nav>);
+jest.mock('../components/V2NavRail', () => (
+  { onOpenGuide }: { onOpenGuide?: () => void },
+) => (
+  <nav>
+    Rail
+    {onOpenGuide && <button type="button" onClick={onOpenGuide}>Guide</button>}
+  </nav>
+));
 jest.mock('../components/V2PodsSidebar', () => () => <aside>Pods</aside>);
 jest.mock('../components/V2PodInspector', () => () => <aside>Inspector</aside>);
 jest.mock('../components/V2InviteModal', () => () => null);
@@ -298,5 +305,32 @@ describe('V2Layout first-run placement', () => {
     });
     expect(screen.queryByRole('dialog', { name: 'Bring your agent into the room' })).not.toBeInTheDocument();
     expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  test('reopens the dismissed guide from the rail and restores onboarding suppression', async () => {
+    localStorage.setItem(FIRST_RUN_DISMISSED_KEY, '1');
+    render(
+      <MemoryRouter initialEntries={['/v2/pods/hq']}>
+        <Routes>
+          <Route path="/v2/pods/:podId" element={<V2Layout selectionMode="param" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Quiet pod empty state')).toBeInTheDocument();
+    });
+    expect(mockGet).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Guide' }));
+
+    expect(await screen.findByRole('dialog', { name: 'Bring your agent into the room' }))
+      .toBeInTheDocument();
+    expect(screen.queryByText('Quiet pod empty state')).not.toBeInTheDocument();
+    expect(localStorage.getItem(FIRST_RUN_DISMISSED_KEY)).toBeNull();
+    expect(localStorage.getItem(FIRST_RUN_STARTED_KEY)).toBe('1');
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/api/users/me/agent-connection');
+    });
   });
 });

--- a/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
+++ b/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
@@ -63,10 +63,9 @@ jest.mock('../components/V2NavRail', () => () => <nav>Rail</nav>);
 jest.mock('../components/V2PodsSidebar', () => () => <aside>Pods</aside>);
 jest.mock('../components/V2PodInspector', () => () => <aside>Inspector</aside>);
 jest.mock('../components/V2InviteModal', () => () => null);
-jest.mock('../components/V2PodChat', () => ({ firstRunHero }: { firstRunHero?: React.ReactNode }) => (
-  <main>
+jest.mock('../components/V2PodChat', () => () => (
+  <main data-testid="pod-chat">
     <span>Normal pod view</span>
-    {firstRunHero}
   </main>
 ));
 
@@ -125,6 +124,7 @@ describe('V2FirstRunHero', () => {
     renderHero();
     await flush();
 
+    expect(screen.getByRole('dialog', { name: 'Bring your agent into the room' })).toBeInTheDocument();
     expect(screen.getByText('Waiting for your agent to connect…')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Open connection setup/i })).toHaveAttribute('target', '_blank');
 
@@ -201,6 +201,17 @@ describe('V2FirstRunHero', () => {
     expect(mockGet).not.toHaveBeenCalled();
   });
 
+  test('dismisses the first-run modal with Escape', async () => {
+    renderHero();
+    await flush();
+
+    expect(screen.getByRole('dialog', { name: 'Bring your agent into the room' })).toHaveFocus();
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(screen.queryByRole('dialog', { name: 'Bring your agent into the room' })).not.toBeInTheDocument();
+    expect(localStorage.getItem(FIRST_RUN_DISMISSED_KEY)).toBe('1');
+  });
+
   test('the started latch survives a reload until the connected CTA is used', async () => {
     localStorage.setItem(FIRST_RUN_STARTED_KEY, '1');
     mockGet.mockResolvedValue(connected);
@@ -232,7 +243,7 @@ describe('V2Layout first-run placement', () => {
     jest.useRealTimers();
   });
 
-  test('shows onboarding inside an agent-rich pod when the human owns no installation', async () => {
+  test('shows onboarding as a shell-level modal when the human owns no installation', async () => {
     render(
       <MemoryRouter initialEntries={['/v2/pods/hq']}>
         <Routes>
@@ -243,7 +254,9 @@ describe('V2Layout first-run placement', () => {
     await flush();
 
     expect(screen.getByText('Normal pod view')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Bring your agent into the room' })).toBeInTheDocument();
+    const dialog = screen.getByRole('dialog', { name: 'Bring your agent into the room' });
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByTestId('pod-chat')).not.toContainElement(dialog);
     expect(mockGet).toHaveBeenCalledWith('/api/users/me/agent-connection');
   });
 });

--- a/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
+++ b/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
@@ -63,9 +63,10 @@ jest.mock('../components/V2NavRail', () => () => <nav>Rail</nav>);
 jest.mock('../components/V2PodsSidebar', () => () => <aside>Pods</aside>);
 jest.mock('../components/V2PodInspector', () => () => <aside>Inspector</aside>);
 jest.mock('../components/V2InviteModal', () => () => null);
-jest.mock('../components/V2PodChat', () => () => (
+jest.mock('../components/V2PodChat', () => ({ firstRunVisible }: { firstRunVisible?: boolean }) => (
   <main data-testid="pod-chat">
     <span>Normal pod view</span>
+    {!firstRunVisible && <span>Quiet pod empty state</span>}
   </main>
 ));
 
@@ -124,7 +125,8 @@ describe('V2FirstRunHero', () => {
     renderHero();
     await flush();
 
-    expect(screen.getByRole('dialog', { name: 'Bring your agent into the room' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Bring your agent into the room' }))
+      .toHaveAttribute('aria-modal', 'true');
     expect(screen.getByText('Waiting for your agent to connect…')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Open connection setup/i })).toHaveAttribute('target', '_blank');
 
@@ -202,11 +204,27 @@ describe('V2FirstRunHero', () => {
   });
 
   test('dismisses the first-run modal with Escape', async () => {
+    const priorControl = document.createElement('button');
+    document.body.appendChild(priorControl);
+    priorControl.focus();
     renderHero();
     await flush();
 
     expect(screen.getByRole('dialog', { name: 'Bring your agent into the room' })).toHaveFocus();
     fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(screen.queryByRole('dialog', { name: 'Bring your agent into the room' })).not.toBeInTheDocument();
+    expect(localStorage.getItem(FIRST_RUN_DISMISSED_KEY)).toBe('1');
+    expect(priorControl).toHaveFocus();
+    priorControl.remove();
+  });
+
+  test('dismisses the first-run modal from the backdrop', async () => {
+    renderHero();
+    await flush();
+
+    const dialog = screen.getByRole('dialog', { name: 'Bring your agent into the room' });
+    fireEvent.mouseDown(dialog.parentElement as HTMLElement);
 
     expect(screen.queryByRole('dialog', { name: 'Bring your agent into the room' })).not.toBeInTheDocument();
     expect(localStorage.getItem(FIRST_RUN_DISMISSED_KEY)).toBe('1');
@@ -258,5 +276,27 @@ describe('V2Layout first-run placement', () => {
     expect(dialog).toBeInTheDocument();
     expect(screen.getByTestId('pod-chat')).not.toContainElement(dialog);
     expect(mockGet).toHaveBeenCalledWith('/api/users/me/agent-connection');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skip for now' }));
+    await waitFor(() => {
+      expect(screen.getByText('Quiet pod empty state')).toBeInTheDocument();
+    });
+  });
+
+  test('keeps the shell unblocked when first-run was already dismissed', async () => {
+    localStorage.setItem(FIRST_RUN_DISMISSED_KEY, '1');
+    render(
+      <MemoryRouter initialEntries={['/v2/pods/hq']}>
+        <Routes>
+          <Route path="/v2/pods/:podId" element={<V2Layout selectionMode="param" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Quiet pod empty state')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('dialog', { name: 'Bring your agent into the room' })).not.toBeInTheDocument();
+    expect(mockGet).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/v2/__tests__/V2PodChatStarter.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatStarter.test.tsx
@@ -174,10 +174,7 @@ describe('V2PodChat starter prompts', () => {
     expect(screen.queryByRole('group', { name: 'Conversation starters' })).not.toBeInTheDocument();
     withMessage.unmount();
 
-    renderChat(makeAgentRoom(), {
-      firstRunVisible: true,
-      firstRunHero: <div>First-run guide</div>,
-    });
+    renderChat(makeAgentRoom(), { firstRunVisible: true });
     expect(screen.queryByRole('group', { name: 'Conversation starters' })).not.toBeInTheDocument();
   });
 });
@@ -233,14 +230,12 @@ describe('V2PodChat just-created Pod starter panel', () => {
     withMessage.unmount();
   });
 
-  test('keeps the first-run guide above the starter panel', () => {
+  test('keeps the first-run modal ahead of the starter panel without minting an invite', () => {
     sessionStorage.setItem('v2.justCreated.p1', '1');
-    renderChat(makeDetail(), {
-      firstRunVisible: true,
-      firstRunHero: <div>First-run guide</div>,
-    });
-    expect(screen.getByText('First-run guide')).toBeInTheDocument();
+    renderChat(makeDetail(), { firstRunVisible: true });
+
     expect(screen.queryByText('Your Pod is ready')).not.toBeInTheDocument();
+    expect(axios.post).not.toHaveBeenCalled();
   });
 
   test('does not mint an invite when the starter panel does not render', () => {

--- a/frontend/src/v2/__tests__/V2PodsSidebar.community.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodsSidebar.community.test.tsx
@@ -172,13 +172,23 @@ describe('V2PodsSidebar Community offer', () => {
       hqPod,
     ]);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Community' }));
+    const communityFilter = screen.getByRole('button', { name: 'Community' });
+    fireEvent.click(communityFilter);
+    expect(communityFilter).toHaveClass('v2-pods__filter--active');
+    expect(screen.getByRole('button', { name: 'All' }))
+      .not.toHaveClass('v2-pods__filter--active');
+    expect(screen.getByRole('button', { name: 'Joined' }))
+      .toHaveClass('v2-pods__community-tab--active');
     expect(await screen.findByText('Joined Builders')).toBeInTheDocument();
     expect(screen.getByText('Commonly HQ')).toBeInTheDocument();
     expect(screen.queryByText('Open Builders')).not.toBeInTheDocument();
     expect(mockApiGet).not.toHaveBeenCalledWith('/api/pods?scope=discover');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Discover' }));
+    const discoverView = screen.getByRole('button', { name: 'Discover' });
+    fireEvent.click(discoverView);
+    expect(discoverView).toHaveClass('v2-pods__community-tab--active');
+    expect(screen.getByRole('button', { name: 'Joined' }))
+      .not.toHaveClass('v2-pods__community-tab--active');
     expect(await screen.findByText('Open Builders')).toBeInTheDocument();
     expect(screen.getByText('Build in public with the community.')).toBeInTheDocument();
     expect(screen.getByText('0 members')).toBeInTheDocument();

--- a/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
@@ -81,14 +81,21 @@ describe('V2PodsSidebar create flow', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'New Pod' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Private Pod' }));
-    fireEvent.change(screen.getByPlaceholderText('Pod name'), {
+    const createDialog = screen.getByRole('dialog', { name: 'Create a Pod' });
+    expect(createDialog).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /Team Pod/ })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByText(/shared space for a team/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('radio', { name: /Private Pod/ }));
+    expect(screen.getByRole('radio', { name: /Private Pod/ })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByText(/invite-only membership/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Pod name'), {
       target: { value: 'Launch circle' },
     });
-    fireEvent.change(screen.getByPlaceholderText('Goal or description'), {
+    fireEvent.change(screen.getByLabelText('What will this Pod accomplish?'), {
       target: { value: 'Prepare the launch' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create private Pod' }));
 
     await waitFor(() => {
       expect(mockCreatePod).toHaveBeenCalledWith(
@@ -100,5 +107,29 @@ describe('V2PodsSidebar create flow', () => {
     });
     expect(sessionStorage.getItem('v2.justCreated.new-private-pod')).toBe('1');
     expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/new-private-pod');
+  });
+
+  it('closes the create dialog with Escape without creating a Pod', () => {
+    const podsState = {
+      pods: [],
+      loading: false,
+      error: null,
+      createPod: mockCreatePod,
+      patchLastMessage: jest.fn(),
+    };
+    render(
+      <MemoryRouter>
+        <V2PodsSidebar selectedPodId={null} podsState={podsState} />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'New Pod' }));
+    expect(screen.getByRole('dialog', { name: 'Create a Pod' })).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(screen.queryByRole('dialog', { name: 'Create a Pod' })).not.toBeInTheDocument();
+    expect(mockCreatePod).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'New Pod' })).toHaveFocus();
   });
 });

--- a/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
@@ -1,10 +1,11 @@
 // @ts-nocheck
 import React from 'react';
 import {
-  fireEvent, render, screen, waitFor,
+  act, fireEvent, render, screen, waitFor,
 } from '@testing-library/react';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import V2PodsSidebar from '../components/V2PodsSidebar';
+import i18n, { i18nReady } from '../../i18n';
 
 const mockCreatePod = jest.fn();
 
@@ -54,9 +55,16 @@ jest.mock('../../context/AuthContext', () => ({
 const CurrentPath = () => <div data-testid="current-path">{useLocation().pathname}</div>;
 
 describe('V2PodsSidebar create flow', () => {
-  beforeEach(() => {
+  beforeAll(async () => {
+    await i18nReady;
+  });
+
+  beforeEach(async () => {
     jest.clearAllMocks();
     sessionStorage.clear();
+    await act(async () => {
+      await i18n.changeLanguage('en');
+    });
     mockCreatePod.mockResolvedValue({
       _id: 'new-private-pod',
       name: 'Launch circle',
@@ -81,21 +89,19 @@ describe('V2PodsSidebar create flow', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'New Pod' }));
-    const createDialog = screen.getByRole('dialog', { name: 'Create a Pod' });
-    expect(createDialog).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: /Team Pod/ })).toHaveAttribute('aria-checked', 'true');
-    expect(screen.getByText(/shared space for a team/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Team Pod/ })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('Anyone can find and join if listed.')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('radio', { name: /Private Pod/ }));
-    expect(screen.getByRole('radio', { name: /Private Pod/ })).toHaveAttribute('aria-checked', 'true');
-    expect(screen.getByText(/invite-only membership/i)).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText('Pod name'), {
+    fireEvent.click(screen.getByRole('button', { name: /Private Pod/ }));
+    expect(screen.getByRole('button', { name: /Private Pod/ })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('Invite-only — you add people.')).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('Pod name'), {
       target: { value: 'Launch circle' },
     });
-    fireEvent.change(screen.getByLabelText('What will this Pod accomplish?'), {
+    fireEvent.change(screen.getByPlaceholderText('Goal or description'), {
       target: { value: 'Prepare the launch' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Create private Pod' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
 
     await waitFor(() => {
       expect(mockCreatePod).toHaveBeenCalledWith(
@@ -109,7 +115,10 @@ describe('V2PodsSidebar create flow', () => {
     expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/new-private-pod');
   });
 
-  it('closes the create dialog with Escape without creating a Pod', () => {
+  it('renders both policy helpers from the Simplified Chinese catalog', async () => {
+    await act(async () => {
+      await i18n.changeLanguage('zh-CN');
+    });
     const podsState = {
       pods: [],
       loading: false,
@@ -123,13 +132,10 @@ describe('V2PodsSidebar create flow', () => {
       </MemoryRouter>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'New Pod' }));
-    expect(screen.getByRole('dialog', { name: 'Create a Pod' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '新建 Pod' }));
 
-    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.getByText('列入发现后，任何人都可以找到并加入。')).toBeInTheDocument();
+    expect(screen.getByText('仅限邀请，由你添加成员。')).toBeInTheDocument();
 
-    expect(screen.queryByRole('dialog', { name: 'Create a Pod' })).not.toBeInTheDocument();
-    expect(mockCreatePod).not.toHaveBeenCalled();
-    expect(screen.getByRole('button', { name: 'New Pod' })).toHaveFocus();
   });
 });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -41,7 +41,6 @@ describe('v2 layout invariants (CSS rule presence)', () => {
   const showcase = read('../showcase/v2-showcase.css');
   const aprofile = read('../agents/v2-agent-profile.css');
   const landing = read('../landing/v2-landing.css');
-  const podsSidebar = read('../components/V2PodsSidebar.tsx');
 
   test('Your Team card name owns its line so the category chip cannot crush it', () => {
     const rule = ruleBody(v2, '.v2-team-card__name');
@@ -167,19 +166,6 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(panel).toContain('width: min(760px, 100%)');
     expect(actions).toContain('repeat(2, minmax(0, 1fr))');
     expect(v2).toContain('.v2-chat__new-pod-actions {\n    grid-template-columns: minmax(0, 1fr)');
-  });
-
-  test('the create-Pod policy cards collapse to one column on phones', () => {
-    const dialog = ruleBody(v2, '.v2-create-pod');
-    const options = ruleBody(v2, '.v2-create-pod__policy-options');
-    expect(dialog).toContain('width: min(620px, 100%)');
-    expect(options).toContain('repeat(2, minmax(0, 1fr))');
-    expect(v2).toContain('.v2-create-pod__policy-options {\n    grid-template-columns: minmax(0, 1fr)');
-  });
-
-  test('the create-Pod dialog escapes the transformed mobile sidebar', () => {
-    expect(podsSidebar).toContain('createPortal((');
-    expect(podsSidebar).toContain('document.querySelector(V2_ROOT_SELECTOR)');
   });
 
   test('invite management controls collapse to one column on phones', () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -41,6 +41,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
   const showcase = read('../showcase/v2-showcase.css');
   const aprofile = read('../agents/v2-agent-profile.css');
   const landing = read('../landing/v2-landing.css');
+  const podsSidebar = read('../components/V2PodsSidebar.tsx');
 
   test('Your Team card name owns its line so the category chip cannot crush it', () => {
     const rule = ruleBody(v2, '.v2-team-card__name');
@@ -97,12 +98,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(rule).toContain('border: 1px solid var(--v2-border)');
   });
 
-  test('the first-run card and message pane shrink to the mobile content width', () => {
-    // The rail remains visible on phones, leaving ~326px at a 390px viewport.
-    // A fixed-width onboarding card would overflow behind the rail; both the
-    // card cap and reduced transcript gutter are load-bearing for that layout.
+  test('the first-run modal stays within the mobile viewport', () => {
+    // First-run is shell-level now: the overlay must own the viewport and the
+    // dialog must cap both axes so the last step and dismissal stay reachable
+    // at 390x844 instead of overflowing behind the fixed shell.
+    expect(ruleBody(v2, '.v2-first-run__overlay')).toContain('position: fixed');
     expect(ruleBody(v2, '.v2-first-run')).toContain('width: min(720px, 100%)');
-    expect(v2).toContain('.v2-chat__messages {\n    padding-inline: 14px');
+    expect(ruleBody(v2, '.v2-first-run')).toContain('max-height: calc(100dvh - 48px)');
+    expect(ruleBody(v2, '.v2-first-run')).toContain('overflow-y: auto');
   });
 
   test('the first-run setup CTA beats the global inherited anchor color', () => {
@@ -161,9 +164,22 @@ describe('v2 layout invariants (CSS rule presence)', () => {
   test('the new-pod starter panel shrinks and stacks inside the mobile chat pane', () => {
     const panel = ruleBody(v2, '.v2-chat__new-pod');
     const actions = ruleBody(v2, '.v2-chat__new-pod-actions');
-    expect(panel).toContain('width: min(720px, 100%)');
+    expect(panel).toContain('width: min(760px, 100%)');
     expect(actions).toContain('repeat(2, minmax(0, 1fr))');
     expect(v2).toContain('.v2-chat__new-pod-actions {\n    grid-template-columns: minmax(0, 1fr)');
+  });
+
+  test('the create-Pod policy cards collapse to one column on phones', () => {
+    const dialog = ruleBody(v2, '.v2-create-pod');
+    const options = ruleBody(v2, '.v2-create-pod__policy-options');
+    expect(dialog).toContain('width: min(620px, 100%)');
+    expect(options).toContain('repeat(2, minmax(0, 1fr))');
+    expect(v2).toContain('.v2-create-pod__policy-options {\n    grid-template-columns: minmax(0, 1fr)');
+  });
+
+  test('the create-Pod dialog escapes the transformed mobile sidebar', () => {
+    expect(podsSidebar).toContain('createPortal((');
+    expect(podsSidebar).toContain('document.querySelector(V2_ROOT_SELECTOR)');
   });
 
   test('invite management controls collapse to one column on phones', () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -148,6 +148,21 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(row).toContain('34px minmax(0, 1fr) auto');
   });
 
+  test('pod filters have an explicit selected indicator and the composer keeps its strong focus ring', () => {
+    const primaryActive = ruleBody(v2, '.v2-root button.v2-pods__filter--active');
+    const communityActive = ruleBody(v2, '.v2-root button.v2-pods__community-tab--active');
+    const composerFocus = ruleBody(v2, '.v2-chat__composer-input-wrap:focus-within');
+
+    [primaryActive, communityActive].forEach((rule) => {
+      expect(rule).toContain('background: var(--v2-accent-soft)');
+      expect(rule).toContain('color: var(--v2-accent-text)');
+      expect(rule).toContain('border-color: var(--v2-accent)');
+      expect(rule).toContain('box-shadow: inset 0 -2px 0 var(--v2-accent)');
+    });
+    expect(composerFocus).toContain('border-color: var(--v2-accent)');
+    expect(composerFocus).toContain('box-shadow: var(--v2-focus-ring)');
+  });
+
   test('starter prompts wrap within the mobile chat pane', () => {
     // At 390px the rail leaves a narrow main pane. Both the row and each chip
     // need explicit shrink/wrap rules or the longest prompt creates horizontal

--- a/frontend/src/v2/components/V2FirstRunHero.tsx
+++ b/frontend/src/v2/components/V2FirstRunHero.tsx
@@ -50,9 +50,13 @@ const StepMark: React.FC<{ done: boolean; children: React.ReactNode }> = ({ done
 
 interface V2FirstRunHeroProps {
   onVisibilityChange?: (visible: boolean) => void;
+  reopenRequest?: number;
 }
 
-const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) => {
+const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({
+  onVisibilityChange,
+  reopenRequest = 0,
+}) => {
   const { t } = useTranslation();
   const api = useV2Api();
   const navigate = useNavigate();
@@ -90,6 +94,16 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
     writeFlag(FIRST_RUN_STARTED_KEY, false);
     setDismissed(true);
   }, []);
+
+  useEffect(() => {
+    if (reopenRequest === 0) return;
+    writeFlag(FIRST_RUN_DISMISSED_KEY, false);
+    writeFlag(FIRST_RUN_STARTED_KEY, true);
+    setDismissed(false);
+    setEngaged(true);
+    setStatusError(null);
+    setRoomError(null);
+  }, [reopenRequest]);
 
   useEffect(() => {
     onVisibilityChange?.(shouldProbe);

--- a/frontend/src/v2/components/V2FirstRunHero.tsx
+++ b/frontend/src/v2/components/V2FirstRunHero.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useV2Api } from '../hooks/useV2Api';
 import { useTranslation } from 'react-i18next';
@@ -54,6 +56,7 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
   const { t } = useTranslation();
   const api = useV2Api();
   const navigate = useNavigate();
+  const dialogRef = useRef<HTMLElement | null>(null);
   const [dismissed, setDismissed] = useState(() => readFlag(FIRST_RUN_DISMISSED_KEY));
   // `engaged` is a session latch. Once a zero-install user sees the hero, an
   // install appearing during the poll must advance the card to Waiting / Say
@@ -80,6 +83,12 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
   // but do not flash the full onboarding card for an established user.
   const shouldProbe = !dismissed && (engaged || status === null || status.issued === false);
   const visible = !dismissed && (engaged || status?.issued === false);
+
+  const dismiss = useCallback(() => {
+    writeFlag(FIRST_RUN_DISMISSED_KEY, true);
+    writeFlag(FIRST_RUN_STARTED_KEY, false);
+    setDismissed(true);
+  }, []);
 
   useEffect(() => {
     onVisibilityChange?.(shouldProbe);
@@ -121,17 +130,48 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
     };
   }, [pollStatus, shouldProbe, status?.connected]);
 
+  useEffect(() => {
+    if (!visible) return undefined;
+
+    const dialog = dialogRef.current;
+    dialog?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        dismiss();
+        return;
+      }
+      if (event.key !== 'Tab' || !dialog) return;
+
+      const focusable = Array.from(dialog.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ));
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [dismiss, visible]);
+
   if (!visible) return null;
 
   const openSetup = () => {
     writeFlag(FIRST_RUN_STARTED_KEY, true);
     setEngaged(true);
-  };
-
-  const dismiss = () => {
-    writeFlag(FIRST_RUN_DISMISSED_KEY, true);
-    writeFlag(FIRST_RUN_STARTED_KEY, false);
-    setDismissed(true);
   };
 
   const sayHello = async () => {
@@ -159,70 +199,81 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
   };
 
   return (
-    <section className="v2-first-run" aria-labelledby="v2-first-run-title">
-      <div className="v2-first-run__eyebrow">{t('firstRun.eyebrow')}</div>
-      <div className="v2-first-run__heading-row">
-        <div>
-          <h2 id="v2-first-run-title" className="v2-first-run__title">{t('firstRun.title')}</h2>
-          <p className="v2-first-run__lede">
-            {t('firstRun.lede')}
-          </p>
+    <div className="v2-first-run__overlay" onMouseDown={dismiss}>
+      <section
+        ref={dialogRef}
+        className="v2-first-run"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="v2-first-run-title"
+        aria-describedby="v2-first-run-description"
+        tabIndex={-1}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="v2-first-run__eyebrow">{t('firstRun.eyebrow')}</div>
+        <div className="v2-first-run__heading-row">
+          <div>
+            <h2 id="v2-first-run-title" className="v2-first-run__title">{t('firstRun.title')}</h2>
+            <p id="v2-first-run-description" className="v2-first-run__lede">
+              {t('firstRun.lede')}
+            </p>
+          </div>
+          <button type="button" className="v2-first-run__skip" onClick={dismiss}>{t('firstRun.skip')}</button>
         </div>
-        <button type="button" className="v2-first-run__skip" onClick={dismiss}>{t('firstRun.skip')}</button>
-      </div>
 
-      <ol className="v2-first-run__steps">
-        <li className="v2-first-run__step">
-          <StepMark done={Boolean(status?.issued)}>1</StepMark>
-          <div className="v2-first-run__step-body">
-            <strong>{t('firstRun.steps.connect.title')}</strong>
-            <span>{t('firstRun.steps.connect.text')}</span>
-            {!status?.issued && (
-              <a
-                className="v2-first-run__setup"
-                href="/v2/agents/byo"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={openSetup}
-              >
-                {t('firstRun.steps.connect.openSetup')}
-                <span aria-hidden="true">{EXTERNAL_LINK_MARK}</span>
-              </a>
-            )}
-          </div>
-        </li>
+        <ol className="v2-first-run__steps">
+          <li className="v2-first-run__step">
+            <StepMark done={Boolean(status?.issued)}>1</StepMark>
+            <div className="v2-first-run__step-body">
+              <strong>{t('firstRun.steps.connect.title')}</strong>
+              <span>{t('firstRun.steps.connect.text')}</span>
+              {!status?.issued && (
+                <a
+                  className="v2-first-run__setup"
+                  href="/v2/agents/byo"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={openSetup}
+                >
+                  {t('firstRun.steps.connect.openSetup')}
+                  <span aria-hidden="true">{EXTERNAL_LINK_MARK}</span>
+                </a>
+              )}
+            </div>
+          </li>
 
-        <li className="v2-first-run__step">
-          <StepMark done={Boolean(status?.connected)}>2</StepMark>
-          <div className="v2-first-run__step-body">
-            <strong>{status?.connected ? t('firstRun.steps.start.connected') : t('firstRun.steps.start.title')}</strong>
-            <span className={status?.connected ? 'v2-first-run__connected' : ''} role="status" aria-live="polite">
-              {status?.connected ? t('firstRun.steps.start.connectedStatus') : t('firstRun.steps.start.waiting')}
-            </span>
-            {statusError && <span className="v2-first-run__error">{statusError}</span>}
-          </div>
-        </li>
+          <li className="v2-first-run__step">
+            <StepMark done={Boolean(status?.connected)}>2</StepMark>
+            <div className="v2-first-run__step-body">
+              <strong>{status?.connected ? t('firstRun.steps.start.connected') : t('firstRun.steps.start.title')}</strong>
+              <span className={status?.connected ? 'v2-first-run__connected' : ''} role="status" aria-live="polite">
+                {status?.connected ? t('firstRun.steps.start.connectedStatus') : t('firstRun.steps.start.waiting')}
+              </span>
+              {statusError && <span className="v2-first-run__error">{statusError}</span>}
+            </div>
+          </li>
 
-        <li className="v2-first-run__step">
-          <StepMark done={false}>3</StepMark>
-          <div className="v2-first-run__step-body">
-            <strong>{t('firstRun.steps.hello.title')}</strong>
-            <span>{t('firstRun.steps.hello.text')}</span>
-            {status?.connected && status.connectedAgent && (
-              <button
-                type="button"
-                className="v2-first-run__hello"
-                onClick={sayHello}
-                disabled={openingRoom}
-              >
-                {openingRoom ? t('firstRun.steps.hello.opening') : t('firstRun.steps.hello.cta')}
-              </button>
-            )}
-            {roomError && <span className="v2-first-run__error">{roomError}</span>}
-          </div>
-        </li>
-      </ol>
-    </section>
+          <li className="v2-first-run__step">
+            <StepMark done={false}>3</StepMark>
+            <div className="v2-first-run__step-body">
+              <strong>{t('firstRun.steps.hello.title')}</strong>
+              <span>{t('firstRun.steps.hello.text')}</span>
+              {status?.connected && status.connectedAgent && (
+                <button
+                  type="button"
+                  className="v2-first-run__hello"
+                  onClick={sayHello}
+                  disabled={openingRoom}
+                >
+                  {openingRoom ? t('firstRun.steps.hello.opening') : t('firstRun.steps.hello.cta')}
+                </button>
+              )}
+              {roomError && <span className="v2-first-run__error">{roomError}</span>}
+            </div>
+          </li>
+        </ol>
+      </section>
+    </div>
   );
 };
 

--- a/frontend/src/v2/components/V2FirstRunHero.tsx
+++ b/frontend/src/v2/components/V2FirstRunHero.tsx
@@ -57,6 +57,7 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
   const api = useV2Api();
   const navigate = useNavigate();
   const dialogRef = useRef<HTMLElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
   const [dismissed, setDismissed] = useState(() => readFlag(FIRST_RUN_DISMISSED_KEY));
   // `engaged` is a session latch. Once a zero-install user sees the hero, an
   // install appearing during the poll must advance the card to Waiting / Say
@@ -134,6 +135,9 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
     if (!visible) return undefined;
 
     const dialog = dialogRef.current;
+    previousFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
     dialog?.focus();
 
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -164,7 +168,11 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
     };
 
     document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previousFocusRef.current?.focus();
+      previousFocusRef.current = null;
+    };
   }, [dismiss, visible]);
 
   if (!visible) return null;

--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -90,8 +90,9 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   // it entirely (the sidebar is always a visible column there).
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   // Assume visible until the ownership-status probe resolves. This prevents
-  // the legacy empty-state copy flashing underneath the onboarding card; an
-  // established/dismissed user flips it off as soon as the hero resolves.
+  // the empty-state stack from flashing while the shell-level first-run modal
+  // decides whether it should open; an established/dismissed user flips it off
+  // as soon as the probe resolves.
   const [firstRunVisible, setFirstRunVisible] = useState(true);
   const openMobileNav = useCallback(() => setMobileNavOpen(true), []);
   const closeMobileNav = useCallback(() => setMobileNavOpen(false), []);
@@ -205,7 +206,6 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
       <V2PodChat
         detail={detail}
         podsState={podsState}
-        firstRunHero={<V2FirstRunHero onVisibilityChange={setFirstRunVisible} />}
         firstRunVisible={firstRunVisible}
         inspectorCollapsed={inspectorCollapsed}
         onToggleInspector={selectedPodId ? toggleInspector : undefined}
@@ -228,6 +228,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
           onPendingOpenFileNameConsumed={clearPendingOpenFileName}
         />
       )}
+      <V2FirstRunHero onVisibilityChange={setFirstRunVisible} />
       {inviteEnabled && detail.pod && (
         <V2InviteModal
           open={inviteOpen}

--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -94,6 +94,10 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   // decides whether it should open; an established/dismissed user flips it off
   // as soon as the probe resolves.
   const [firstRunVisible, setFirstRunVisible] = useState(true);
+  const [firstRunReopenRequest, setFirstRunReopenRequest] = useState(0);
+  const reopenFirstRun = useCallback(() => {
+    setFirstRunReopenRequest((request) => request + 1);
+  }, []);
   const openMobileNav = useCallback(() => setMobileNavOpen(true), []);
   const closeMobileNav = useCallback(() => setMobileNavOpen(false), []);
   const toggleInspector = useCallback(() => {
@@ -188,7 +192,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
 
   return (
     <div className={shellClass}>
-      <V2NavRail onPodsMobileNav={openMobileNav} />
+      <V2NavRail onPodsMobileNav={openMobileNav} onOpenGuide={reopenFirstRun} />
       {mobileNavOpen && (
         <button
           type="button"
@@ -228,7 +232,10 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
           onPendingOpenFileNameConsumed={clearPendingOpenFileName}
         />
       )}
-      <V2FirstRunHero onVisibilityChange={setFirstRunVisible} />
+      <V2FirstRunHero
+        onVisibilityChange={setFirstRunVisible}
+        reopenRequest={firstRunReopenRequest}
+      />
       {inviteEnabled && detail.pod && (
         <V2InviteModal
           open={inviteOpen}

--- a/frontend/src/v2/components/V2NavRail.tsx
+++ b/frontend/src/v2/components/V2NavRail.tsx
@@ -4,6 +4,7 @@ import V2Avatar from './V2Avatar';
 import V2FeedbackMenu from './V2FeedbackMenu';
 import V2LangSwitch from './V2LangSwitch';
 import { useAuth } from '../../context/AuthContext';
+import { useTranslation } from 'react-i18next';
 
 interface NavItem {
   key: string;
@@ -39,13 +40,15 @@ interface V2NavRailProps {
   // single chat with no way back to the list). Undefined on surfaces without a
   // drawer (feature pages) — those fall back to plain navigation.
   onPodsMobileNav?: () => void;
+  onOpenGuide?: () => void;
 }
 
 const isMobileViewport = (): boolean => (
   typeof window !== 'undefined' && !!window.matchMedia?.('(max-width: 760px)').matches
 );
 
-const V2NavRail: React.FC<V2NavRailProps> = ({ onPodsMobileNav }) => {
+const V2NavRail: React.FC<V2NavRailProps> = ({ onPodsMobileNav, onOpenGuide }) => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
   const { currentUser, logout } = useAuth();
@@ -102,6 +105,21 @@ const V2NavRail: React.FC<V2NavRailProps> = ({ onPodsMobileNav }) => {
               {item.dividerAfter && <span className="v2-rail__divider" aria-hidden="true" />}
             </React.Fragment>
           ))}
+          {onOpenGuide && (
+            <button
+              type="button"
+              className="v2-rail__item"
+              onClick={onOpenGuide}
+              title={t('firstRun.reopen')}
+              data-label={t('firstRun.reopen')}
+              aria-label={t('firstRun.reopen')}
+            >
+              <span className="v2-rail__item-icon">
+                <Icon d="M9.1 9a3 3 0 115.83 1c0 2-3 2-3 4M12 18h.01" />
+              </span>
+              <span className="v2-rail__item-label">{t('firstRun.reopen')}</span>
+            </button>
+          )}
         </nav>
 
         <div className="v2-rail__user">

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -137,10 +137,9 @@ const writeMode = (podId: string, mode: PodMode) => {
 interface V2PodChatProps {
   detail: UseV2PodDetailResult;
   podsState?: UseV2PodsResult;
-  // A status-gated onboarding card supplied by V2Layout. It sits inside the
-  // pod transcript rather than replacing the pod, so the workspace header,
-  // composer, task board, and mobile navigation remain reachable.
-  firstRunHero?: React.ReactNode;
+  // V2Layout owns the shell-level first-run modal. This flag reserves the
+  // empty-state slot while its status probe resolves and keeps the just-created
+  // starter panel behind the modal when onboarding is active.
   firstRunVisible?: boolean;
   // Inspector wiring — when present, the avatar group becomes the "show team"
   // entry. Inspector itself is rendered by V2Layout so this is just the
@@ -168,7 +167,7 @@ const Icon = ({ d }: { d: string }) => (
   </svg>
 );
 
-const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVisible = false, inspectorCollapsed, onToggleInspector, onOpenMember, onOpenInvite, onOpenFile, onOpenMobileNav }) => {
+const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, inspectorCollapsed, onToggleInspector, onOpenMember, onOpenInvite, onOpenFile, onOpenMobileNav }) => {
   const { t, i18n } = useTranslation();
   const numberFormatter = new Intl.NumberFormat(i18n.resolvedLanguage || i18n.language || 'en');
   const { pod, members, messages, agents, sendMessage, loading, error } = detail;
@@ -876,7 +875,6 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
                   {error}
                 </div>
               )}
-              {firstRunHero}
               {loading && messages.length === 0 && (
                 <div className="v2-empty"><span className="v2-spinner" /></div>
               )}
@@ -884,6 +882,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
                 <section className="v2-chat__new-pod" aria-label={t('podChat.newPod.label')}>
                   <div className="v2-chat__new-pod-head">
                     <div>
+                      <div className="v2-chat__new-pod-kicker">{t('podChat.newPod.eyebrow')}</div>
                       <div className="v2-chat__new-pod-title">{t('podChat.newPod.title')}</div>
                       <div className="v2-chat__new-pod-text">{t('podChat.newPod.text')}</div>
                     </div>
@@ -900,57 +899,66 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunHero, firstRunVis
                   </div>
                   <div className="v2-chat__new-pod-actions">
                     <div className="v2-chat__new-pod-action v2-chat__new-pod-action--invite">
-                      <div className="v2-chat__new-pod-action-title">{t('podChat.newPod.inviteTitle')}</div>
-                      <div className="v2-chat__new-pod-action-text">{t('podChat.newPod.inviteText')}</div>
-                      {starterInviteLoading && (
-                        <div className="v2-chat__new-pod-status">{t('podChat.newPod.preparingInvite')}</div>
-                      )}
-                      {starterInviteUrl && (
-                        <div className="v2-invite-link-row">
-                          <input
-                            type="text"
-                            className="v2-invite-link"
-                            aria-label={t('podChat.newPod.inviteLinkLabel')}
-                            readOnly
-                            value={starterInviteUrl}
-                            onFocus={(event) => event.currentTarget.select()}
-                          />
-                          <button
-                            type="button"
-                            className="v2-chat__new-pod-copy"
-                            onClick={() => { void handleStarterInviteCopy(); }}
-                          >
-                            {starterInviteCopied ? t('common.copied') : t('common.copy')}
-                          </button>
-                        </div>
-                      )}
-                      {starterInviteError && (
-                        <div className="v2-chat__new-pod-error">
-                          <span>{starterInviteError}</span>
-                          <button
-                            type="button"
-                            onClick={() => { void generateStarterInvite(pod._id); }}
-                          >
-                            {t('podChat.newPod.tryAgain')}
-                          </button>
-                        </div>
-                      )}
+                      <span className="v2-chat__new-pod-step" aria-hidden="true">1</span>
+                      <div className="v2-chat__new-pod-action-body">
+                        <div className="v2-chat__new-pod-action-title">{t('podChat.newPod.inviteTitle')}</div>
+                        <div className="v2-chat__new-pod-action-text">{t('podChat.newPod.inviteText')}</div>
+                        {starterInviteLoading && (
+                          <div className="v2-chat__new-pod-status">{t('podChat.newPod.preparingInvite')}</div>
+                        )}
+                        {starterInviteUrl && (
+                          <div className="v2-invite-link-row">
+                            <input
+                              type="text"
+                              className="v2-invite-link"
+                              aria-label={t('podChat.newPod.inviteLinkLabel')}
+                              readOnly
+                              value={starterInviteUrl}
+                              onFocus={(event) => event.currentTarget.select()}
+                            />
+                            <button
+                              type="button"
+                              className="v2-chat__new-pod-copy"
+                              onClick={() => { void handleStarterInviteCopy(); }}
+                            >
+                              {starterInviteCopied ? t('common.copied') : t('common.copy')}
+                            </button>
+                          </div>
+                        )}
+                        {starterInviteError && (
+                          <div className="v2-chat__new-pod-error">
+                            <span>{starterInviteError}</span>
+                            <button
+                              type="button"
+                              onClick={() => { void generateStarterInvite(pod._id); }}
+                            >
+                              {t('podChat.newPod.tryAgain')}
+                            </button>
+                          </div>
+                        )}
+                      </div>
                     </div>
                     <button
                       type="button"
                       className="v2-chat__new-pod-action"
                       onClick={() => onOpenInvite?.('agent')}
                     >
-                      <span className="v2-chat__new-pod-action-title">{t('podChat.newPod.addAgentTitle')}</span>
-                      <span className="v2-chat__new-pod-action-text">{t('podChat.newPod.addAgentText')}</span>
+                      <span className="v2-chat__new-pod-step" aria-hidden="true">2</span>
+                      <span className="v2-chat__new-pod-action-body">
+                        <span className="v2-chat__new-pod-action-title">{t('podChat.newPod.addAgentTitle')}</span>
+                        <span className="v2-chat__new-pod-action-text">{t('podChat.newPod.addAgentText')}</span>
+                      </span>
                     </button>
                     <button
                       type="button"
                       className="v2-chat__new-pod-action"
                       onClick={() => composerInputRef.current?.focus()}
                     >
-                      <span className="v2-chat__new-pod-action-title">{t('podChat.newPod.messageTitle')}</span>
-                      <span className="v2-chat__new-pod-action-text">{t('podChat.newPod.messageText')}</span>
+                      <span className="v2-chat__new-pod-step" aria-hidden="true">3</span>
+                      <span className="v2-chat__new-pod-action-body">
+                        <span className="v2-chat__new-pod-action-title">{t('podChat.newPod.messageTitle')}</span>
+                        <span className="v2-chat__new-pod-action-text">{t('podChat.newPod.messageText')}</span>
+                      </span>
                     </button>
                   </div>
                 </section>

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -882,7 +882,6 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                 <section className="v2-chat__new-pod" aria-label={t('podChat.newPod.label')}>
                   <div className="v2-chat__new-pod-head">
                     <div>
-                      <div className="v2-chat__new-pod-kicker">{t('podChat.newPod.eyebrow')}</div>
                       <div className="v2-chat__new-pod-title">{t('podChat.newPod.title')}</div>
                       <div className="v2-chat__new-pod-text">{t('podChat.newPod.text')}</div>
                     </div>
@@ -899,66 +898,57 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                   </div>
                   <div className="v2-chat__new-pod-actions">
                     <div className="v2-chat__new-pod-action v2-chat__new-pod-action--invite">
-                      <span className="v2-chat__new-pod-step" aria-hidden="true">1</span>
-                      <div className="v2-chat__new-pod-action-body">
-                        <div className="v2-chat__new-pod-action-title">{t('podChat.newPod.inviteTitle')}</div>
-                        <div className="v2-chat__new-pod-action-text">{t('podChat.newPod.inviteText')}</div>
-                        {starterInviteLoading && (
-                          <div className="v2-chat__new-pod-status">{t('podChat.newPod.preparingInvite')}</div>
-                        )}
-                        {starterInviteUrl && (
-                          <div className="v2-invite-link-row">
-                            <input
-                              type="text"
-                              className="v2-invite-link"
-                              aria-label={t('podChat.newPod.inviteLinkLabel')}
-                              readOnly
-                              value={starterInviteUrl}
-                              onFocus={(event) => event.currentTarget.select()}
-                            />
-                            <button
-                              type="button"
-                              className="v2-chat__new-pod-copy"
-                              onClick={() => { void handleStarterInviteCopy(); }}
-                            >
-                              {starterInviteCopied ? t('common.copied') : t('common.copy')}
-                            </button>
-                          </div>
-                        )}
-                        {starterInviteError && (
-                          <div className="v2-chat__new-pod-error">
-                            <span>{starterInviteError}</span>
-                            <button
-                              type="button"
-                              onClick={() => { void generateStarterInvite(pod._id); }}
-                            >
-                              {t('podChat.newPod.tryAgain')}
-                            </button>
-                          </div>
-                        )}
-                      </div>
+                      <div className="v2-chat__new-pod-action-title">{t('podChat.newPod.inviteTitle')}</div>
+                      <div className="v2-chat__new-pod-action-text">{t('podChat.newPod.inviteText')}</div>
+                      {starterInviteLoading && (
+                        <div className="v2-chat__new-pod-status">{t('podChat.newPod.preparingInvite')}</div>
+                      )}
+                      {starterInviteUrl && (
+                        <div className="v2-invite-link-row">
+                          <input
+                            type="text"
+                            className="v2-invite-link"
+                            aria-label={t('podChat.newPod.inviteLinkLabel')}
+                            readOnly
+                            value={starterInviteUrl}
+                            onFocus={(event) => event.currentTarget.select()}
+                          />
+                          <button
+                            type="button"
+                            className="v2-chat__new-pod-copy"
+                            onClick={() => { void handleStarterInviteCopy(); }}
+                          >
+                            {starterInviteCopied ? t('common.copied') : t('common.copy')}
+                          </button>
+                        </div>
+                      )}
+                      {starterInviteError && (
+                        <div className="v2-chat__new-pod-error">
+                          <span>{starterInviteError}</span>
+                          <button
+                            type="button"
+                            onClick={() => { void generateStarterInvite(pod._id); }}
+                          >
+                            {t('podChat.newPod.tryAgain')}
+                          </button>
+                        </div>
+                      )}
                     </div>
                     <button
                       type="button"
                       className="v2-chat__new-pod-action"
                       onClick={() => onOpenInvite?.('agent')}
                     >
-                      <span className="v2-chat__new-pod-step" aria-hidden="true">2</span>
-                      <span className="v2-chat__new-pod-action-body">
-                        <span className="v2-chat__new-pod-action-title">{t('podChat.newPod.addAgentTitle')}</span>
-                        <span className="v2-chat__new-pod-action-text">{t('podChat.newPod.addAgentText')}</span>
-                      </span>
+                      <span className="v2-chat__new-pod-action-title">{t('podChat.newPod.addAgentTitle')}</span>
+                      <span className="v2-chat__new-pod-action-text">{t('podChat.newPod.addAgentText')}</span>
                     </button>
                     <button
                       type="button"
                       className="v2-chat__new-pod-action"
                       onClick={() => composerInputRef.current?.focus()}
                     >
-                      <span className="v2-chat__new-pod-step" aria-hidden="true">3</span>
-                      <span className="v2-chat__new-pod-action-body">
-                        <span className="v2-chat__new-pod-action-title">{t('podChat.newPod.messageTitle')}</span>
-                        <span className="v2-chat__new-pod-action-text">{t('podChat.newPod.messageText')}</span>
-                      </span>
+                      <span className="v2-chat__new-pod-action-title">{t('podChat.newPod.messageTitle')}</span>
+                      <span className="v2-chat__new-pod-action-text">{t('podChat.newPod.messageText')}</span>
                     </button>
                   </div>
                 </section>

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -1,4 +1,7 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback, useEffect, useMemo, useRef, useState,
+} from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { UseV2PodsResult, V2Pod, useV2Pods } from '../hooks/useV2Pods';
@@ -20,6 +23,7 @@ const FILTERS: Array<{ key: Filter; labelKey: string }> = [
   { key: 'community', labelKey: 'filters.community' },
 ];
 const COMMUNITY_VIEWS: CommunityView[] = ['joined', 'discover'];
+const V2_ROOT_SELECTOR = '.v2-root';
 
 // Both agent-room (user↔agent) and agent-dm (any 2-member combo) show
 // up under the Private filter. agent-dm with two bot members gets a
@@ -204,11 +208,53 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
   const [newPodGoal, setNewPodGoal] = useState('');
   const [newPodJoinPolicy, setNewPodJoinPolicy] = useState<'open' | 'invite-only'>('open');
   const [createError, setCreateError] = useState<string | null>(null);
+  const newPodButtonRef = useRef<HTMLButtonElement | null>(null);
+  const createDialogRef = useRef<HTMLFormElement | null>(null);
+  const createNameInputRef = useRef<HTMLInputElement | null>(null);
   // Pod IDs an agent is currently typing into. Set, not bool, because
   // multiple agents could type at once. Cleared after 30s safety in case the
   // stop event is missed.
   const [typingPods, setTypingPods] = useState<Set<string>>(() => new Set());
   const typingTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  const closeCreate = useCallback(() => {
+    setShowCreate(false);
+    setNewPodJoinPolicy('open');
+    setCreateError(null);
+  }, []);
+
+  useEffect(() => {
+    if (!showCreate) return undefined;
+
+    createNameInputRef.current?.focus();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeCreate();
+        return;
+      }
+      if (event.key !== 'Tab' || !createDialogRef.current) return;
+
+      const focusable = Array.from(createDialogRef.current.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ));
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      newPodButtonRef.current?.focus();
+    };
+  }, [closeCreate, showCreate]);
 
   // Join every member-pod's socket room so we hear newMessage / typing events
   // even while another pod is selected. The chat room hook (`useV2PodDetail`)
@@ -441,7 +487,7 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
         setNewPodName('');
         setNewPodGoal('');
         setNewPodJoinPolicy('open');
-        setShowCreate(false);
+        closeCreate();
         selectPod(pod._id);
       } else {
         setCreateError(t('podsSidebar.errors.createFailed'));
@@ -470,10 +516,11 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
             </button>
           </div>
           <button
+            ref={newPodButtonRef}
             type="button"
             className="v2-pods__new-btn"
             onClick={() => {
-              setShowCreate((next) => !next);
+              setShowCreate(true);
               setNewPodJoinPolicy('open');
               setCreateError(null);
             }}
@@ -484,70 +531,6 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
             </svg>
             {t('podsSidebar.newPod')}
           </button>
-          {showCreate && (
-            <form className="v2-pods__create" onSubmit={handleCreatePod}>
-              <div className="v2-pods__create-options">
-                <button
-                  type="button"
-                  className={`v2-pods__create-option${newPodJoinPolicy === 'open' ? ' v2-pods__create-option--active' : ''}`}
-                  aria-pressed={newPodJoinPolicy === 'open'}
-                  onClick={() => {
-                    setNewPodJoinPolicy('open');
-                    setCreateError(null);
-                  }}
-                >
-                  {t('podsSidebar.create.teamOption')}
-                </button>
-                <button
-                  type="button"
-                  className={`v2-pods__create-option${newPodJoinPolicy === 'invite-only' ? ' v2-pods__create-option--active' : ''}`}
-                  aria-pressed={newPodJoinPolicy === 'invite-only'}
-                  onClick={() => {
-                    setNewPodJoinPolicy('invite-only');
-                    setCreateError(null);
-                  }}
-                >
-                  {t('podsSidebar.create.privateOption')}
-                </button>
-              </div>
-              <input
-                className="v2-pods__create-input"
-                type="text"
-                value={newPodName}
-                onChange={(e) => setNewPodName(e.target.value)}
-                placeholder={t('podsSidebar.create.namePlaceholder')}
-                autoFocus
-              />
-              <input
-                className="v2-pods__create-input"
-                type="text"
-                value={newPodGoal}
-                onChange={(e) => setNewPodGoal(e.target.value)}
-                placeholder={t('podsSidebar.create.goalPlaceholder')}
-              />
-              {createError && <div className="v2-pods__create-error">{createError}</div>}
-              <div className="v2-pods__create-actions">
-                <button
-                  type="button"
-                  className="v2-pods__create-cancel"
-                  onClick={() => {
-                    setShowCreate(false);
-                    setNewPodJoinPolicy('open');
-                    setCreateError(null);
-                  }}
-                >
-                  {t('podsSidebar.create.cancel')}
-                </button>
-                <button
-                  type="submit"
-                  className="v2-pods__create-submit"
-                  disabled={creating || !newPodName.trim()}
-                >
-                  {creating ? t('podsSidebar.create.creating') : t('podsSidebar.create.submit')}
-                </button>
-              </div>
-            </form>
-          )}
           <div className="v2-pods__search">
             <span className="v2-pods__search-icon">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -738,6 +721,136 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
           </section>
         )}
       </div>
+      {/* Keep fixed-position modal chrome outside the transformed mobile
+          sidebar. A fixed descendant of that drawer is otherwise off-screen. */}
+      {showCreate && createPortal((
+        <div className="v2-modal__overlay" role="presentation" onMouseDown={closeCreate}>
+          <form
+            ref={createDialogRef}
+            className="v2-modal v2-create-pod"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="v2-create-pod-title"
+            aria-describedby="v2-create-pod-description"
+            onSubmit={handleCreatePod}
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <div className="v2-modal__head">
+              <div>
+                <div id="v2-create-pod-title" className="v2-create-pod__title">
+                  {t('podsSidebar.create.title')}
+                </div>
+                <p id="v2-create-pod-description" className="v2-create-pod__intro">
+                  {t('podsSidebar.create.intro')}
+                </p>
+              </div>
+              <button
+                type="button"
+                className="v2-modal__close"
+                aria-label={t('common.close')}
+                onClick={closeCreate}
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M18 6L6 18M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div className="v2-modal__body v2-create-pod__body">
+              <fieldset className="v2-create-pod__policy">
+                <legend>{t('podsSidebar.create.policyLabel')}</legend>
+                <div className="v2-create-pod__policy-options" role="radiogroup">
+                  <button
+                    type="button"
+                    role="radio"
+                    className={`v2-create-pod__policy-option${newPodJoinPolicy === 'open' ? ' v2-create-pod__policy-option--active' : ''}`}
+                    aria-checked={newPodJoinPolicy === 'open'}
+                    onClick={() => {
+                      setNewPodJoinPolicy('open');
+                      setCreateError(null);
+                    }}
+                  >
+                    <span className="v2-create-pod__policy-icon" aria-hidden="true">
+                      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M16 21v-2a4 4 0 00-4-4H6a4 4 0 00-4 4v2M9 11a4 4 0 100-8 4 4 0 000 8zM19 8v6M16 11h6" />
+                      </svg>
+                    </span>
+                    <span className="v2-create-pod__policy-copy">
+                      <strong>{t('podsSidebar.create.teamOption')}</strong>
+                      <span>{t('podsSidebar.create.teamDescription')}</span>
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    role="radio"
+                    className={`v2-create-pod__policy-option${newPodJoinPolicy === 'invite-only' ? ' v2-create-pod__policy-option--active' : ''}`}
+                    aria-checked={newPodJoinPolicy === 'invite-only'}
+                    onClick={() => {
+                      setNewPodJoinPolicy('invite-only');
+                      setCreateError(null);
+                    }}
+                  >
+                    <span className="v2-create-pod__policy-icon" aria-hidden="true">
+                      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                        <rect x="4" y="10" width="16" height="11" rx="2" />
+                        <path d="M8 10V7a4 4 0 018 0v3" />
+                      </svg>
+                    </span>
+                    <span className="v2-create-pod__policy-copy">
+                      <strong>{t('podsSidebar.create.privateOption')}</strong>
+                      <span>{t('podsSidebar.create.privateDescription')}</span>
+                    </span>
+                  </button>
+                </div>
+              </fieldset>
+
+              <label className="v2-create-pod__field">
+                <span>{t('podsSidebar.create.nameLabel')}</span>
+                <input
+                  ref={createNameInputRef}
+                  className="v2-pods__create-input"
+                  type="text"
+                  value={newPodName}
+                  onChange={(event) => setNewPodName(event.target.value)}
+                  placeholder={t('podsSidebar.create.namePlaceholder')}
+                />
+              </label>
+              <label className="v2-create-pod__field">
+                <span>{t('podsSidebar.create.goalLabel')}</span>
+                <input
+                  className="v2-pods__create-input"
+                  type="text"
+                  value={newPodGoal}
+                  onChange={(event) => setNewPodGoal(event.target.value)}
+                  placeholder={t('podsSidebar.create.goalPlaceholder')}
+                />
+              </label>
+              {createError && <div className="v2-pods__create-error" role="alert">{createError}</div>}
+            </div>
+            <div className="v2-create-pod__actions">
+              <button
+                type="button"
+                className="v2-pods__create-cancel"
+                onClick={closeCreate}
+              >
+                {t('podsSidebar.create.cancel')}
+              </button>
+              <button
+                type="submit"
+                className="v2-pods__create-submit"
+                disabled={creating || !newPodName.trim()}
+              >
+                {creating
+                  ? t('podsSidebar.create.creating')
+                  : t(
+                    newPodJoinPolicy === 'invite-only'
+                      ? 'podsSidebar.create.submitPrivate'
+                      : 'podsSidebar.create.submitTeam',
+                  )}
+              </button>
+            </div>
+          </form>
+        </div>
+      ), document.querySelector(V2_ROOT_SELECTOR) || document.body)}
     </aside>
   );
 };

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -1,7 +1,4 @@
-import React, {
-  useCallback, useEffect, useMemo, useRef, useState,
-} from 'react';
-import { createPortal } from 'react-dom';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { UseV2PodsResult, V2Pod, useV2Pods } from '../hooks/useV2Pods';
@@ -23,7 +20,6 @@ const FILTERS: Array<{ key: Filter; labelKey: string }> = [
   { key: 'community', labelKey: 'filters.community' },
 ];
 const COMMUNITY_VIEWS: CommunityView[] = ['joined', 'discover'];
-const V2_ROOT_SELECTOR = '.v2-root';
 
 // Both agent-room (user↔agent) and agent-dm (any 2-member combo) show
 // up under the Private filter. agent-dm with two bot members gets a
@@ -208,53 +204,11 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
   const [newPodGoal, setNewPodGoal] = useState('');
   const [newPodJoinPolicy, setNewPodJoinPolicy] = useState<'open' | 'invite-only'>('open');
   const [createError, setCreateError] = useState<string | null>(null);
-  const newPodButtonRef = useRef<HTMLButtonElement | null>(null);
-  const createDialogRef = useRef<HTMLFormElement | null>(null);
-  const createNameInputRef = useRef<HTMLInputElement | null>(null);
   // Pod IDs an agent is currently typing into. Set, not bool, because
   // multiple agents could type at once. Cleared after 30s safety in case the
   // stop event is missed.
   const [typingPods, setTypingPods] = useState<Set<string>>(() => new Set());
   const typingTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
-
-  const closeCreate = useCallback(() => {
-    setShowCreate(false);
-    setNewPodJoinPolicy('open');
-    setCreateError(null);
-  }, []);
-
-  useEffect(() => {
-    if (!showCreate) return undefined;
-
-    createNameInputRef.current?.focus();
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        closeCreate();
-        return;
-      }
-      if (event.key !== 'Tab' || !createDialogRef.current) return;
-
-      const focusable = Array.from(createDialogRef.current.querySelectorAll<HTMLElement>(
-        'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      ));
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      newPodButtonRef.current?.focus();
-    };
-  }, [closeCreate, showCreate]);
 
   // Join every member-pod's socket room so we hear newMessage / typing events
   // even while another pod is selected. The chat room hook (`useV2PodDetail`)
@@ -487,7 +441,7 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
         setNewPodName('');
         setNewPodGoal('');
         setNewPodJoinPolicy('open');
-        closeCreate();
+        setShowCreate(false);
         selectPod(pod._id);
       } else {
         setCreateError(t('podsSidebar.errors.createFailed'));
@@ -516,11 +470,10 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
             </button>
           </div>
           <button
-            ref={newPodButtonRef}
             type="button"
             className="v2-pods__new-btn"
             onClick={() => {
-              setShowCreate(true);
+              setShowCreate((next) => !next);
               setNewPodJoinPolicy('open');
               setCreateError(null);
             }}
@@ -531,6 +484,72 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
             </svg>
             {t('podsSidebar.newPod')}
           </button>
+          {showCreate && (
+            <form className="v2-pods__create" onSubmit={handleCreatePod}>
+              <div className="v2-pods__create-options">
+                <button
+                  type="button"
+                  className={`v2-pods__create-option${newPodJoinPolicy === 'open' ? ' v2-pods__create-option--active' : ''}`}
+                  aria-pressed={newPodJoinPolicy === 'open'}
+                  onClick={() => {
+                    setNewPodJoinPolicy('open');
+                    setCreateError(null);
+                  }}
+                >
+                  <strong>{t('podsSidebar.create.teamOption')}</strong>
+                  <span>{t('podsSidebar.create.teamDescription')}</span>
+                </button>
+                <button
+                  type="button"
+                  className={`v2-pods__create-option${newPodJoinPolicy === 'invite-only' ? ' v2-pods__create-option--active' : ''}`}
+                  aria-pressed={newPodJoinPolicy === 'invite-only'}
+                  onClick={() => {
+                    setNewPodJoinPolicy('invite-only');
+                    setCreateError(null);
+                  }}
+                >
+                  <strong>{t('podsSidebar.create.privateOption')}</strong>
+                  <span>{t('podsSidebar.create.privateDescription')}</span>
+                </button>
+              </div>
+              <input
+                className="v2-pods__create-input"
+                type="text"
+                value={newPodName}
+                onChange={(e) => setNewPodName(e.target.value)}
+                placeholder={t('podsSidebar.create.namePlaceholder')}
+                autoFocus
+              />
+              <input
+                className="v2-pods__create-input"
+                type="text"
+                value={newPodGoal}
+                onChange={(e) => setNewPodGoal(e.target.value)}
+                placeholder={t('podsSidebar.create.goalPlaceholder')}
+              />
+              {createError && <div className="v2-pods__create-error">{createError}</div>}
+              <div className="v2-pods__create-actions">
+                <button
+                  type="button"
+                  className="v2-pods__create-cancel"
+                  onClick={() => {
+                    setShowCreate(false);
+                    setNewPodJoinPolicy('open');
+                    setCreateError(null);
+                  }}
+                >
+                  {t('podsSidebar.create.cancel')}
+                </button>
+                <button
+                  type="submit"
+                  className="v2-pods__create-submit"
+                  disabled={creating || !newPodName.trim()}
+                >
+                  {creating ? t('podsSidebar.create.creating') : t('podsSidebar.create.submit')}
+                </button>
+              </div>
+            </form>
+          )}
           <div className="v2-pods__search">
             <span className="v2-pods__search-icon">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -721,136 +740,6 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
           </section>
         )}
       </div>
-      {/* Keep fixed-position modal chrome outside the transformed mobile
-          sidebar. A fixed descendant of that drawer is otherwise off-screen. */}
-      {showCreate && createPortal((
-        <div className="v2-modal__overlay" role="presentation" onMouseDown={closeCreate}>
-          <form
-            ref={createDialogRef}
-            className="v2-modal v2-create-pod"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="v2-create-pod-title"
-            aria-describedby="v2-create-pod-description"
-            onSubmit={handleCreatePod}
-            onMouseDown={(event) => event.stopPropagation()}
-          >
-            <div className="v2-modal__head">
-              <div>
-                <div id="v2-create-pod-title" className="v2-create-pod__title">
-                  {t('podsSidebar.create.title')}
-                </div>
-                <p id="v2-create-pod-description" className="v2-create-pod__intro">
-                  {t('podsSidebar.create.intro')}
-                </p>
-              </div>
-              <button
-                type="button"
-                className="v2-modal__close"
-                aria-label={t('common.close')}
-                onClick={closeCreate}
-              >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="M18 6L6 18M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-            <div className="v2-modal__body v2-create-pod__body">
-              <fieldset className="v2-create-pod__policy">
-                <legend>{t('podsSidebar.create.policyLabel')}</legend>
-                <div className="v2-create-pod__policy-options" role="radiogroup">
-                  <button
-                    type="button"
-                    role="radio"
-                    className={`v2-create-pod__policy-option${newPodJoinPolicy === 'open' ? ' v2-create-pod__policy-option--active' : ''}`}
-                    aria-checked={newPodJoinPolicy === 'open'}
-                    onClick={() => {
-                      setNewPodJoinPolicy('open');
-                      setCreateError(null);
-                    }}
-                  >
-                    <span className="v2-create-pod__policy-icon" aria-hidden="true">
-                      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-                        <path d="M16 21v-2a4 4 0 00-4-4H6a4 4 0 00-4 4v2M9 11a4 4 0 100-8 4 4 0 000 8zM19 8v6M16 11h6" />
-                      </svg>
-                    </span>
-                    <span className="v2-create-pod__policy-copy">
-                      <strong>{t('podsSidebar.create.teamOption')}</strong>
-                      <span>{t('podsSidebar.create.teamDescription')}</span>
-                    </span>
-                  </button>
-                  <button
-                    type="button"
-                    role="radio"
-                    className={`v2-create-pod__policy-option${newPodJoinPolicy === 'invite-only' ? ' v2-create-pod__policy-option--active' : ''}`}
-                    aria-checked={newPodJoinPolicy === 'invite-only'}
-                    onClick={() => {
-                      setNewPodJoinPolicy('invite-only');
-                      setCreateError(null);
-                    }}
-                  >
-                    <span className="v2-create-pod__policy-icon" aria-hidden="true">
-                      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-                        <rect x="4" y="10" width="16" height="11" rx="2" />
-                        <path d="M8 10V7a4 4 0 018 0v3" />
-                      </svg>
-                    </span>
-                    <span className="v2-create-pod__policy-copy">
-                      <strong>{t('podsSidebar.create.privateOption')}</strong>
-                      <span>{t('podsSidebar.create.privateDescription')}</span>
-                    </span>
-                  </button>
-                </div>
-              </fieldset>
-
-              <label className="v2-create-pod__field">
-                <span>{t('podsSidebar.create.nameLabel')}</span>
-                <input
-                  ref={createNameInputRef}
-                  className="v2-pods__create-input"
-                  type="text"
-                  value={newPodName}
-                  onChange={(event) => setNewPodName(event.target.value)}
-                  placeholder={t('podsSidebar.create.namePlaceholder')}
-                />
-              </label>
-              <label className="v2-create-pod__field">
-                <span>{t('podsSidebar.create.goalLabel')}</span>
-                <input
-                  className="v2-pods__create-input"
-                  type="text"
-                  value={newPodGoal}
-                  onChange={(event) => setNewPodGoal(event.target.value)}
-                  placeholder={t('podsSidebar.create.goalPlaceholder')}
-                />
-              </label>
-              {createError && <div className="v2-pods__create-error" role="alert">{createError}</div>}
-            </div>
-            <div className="v2-create-pod__actions">
-              <button
-                type="button"
-                className="v2-pods__create-cancel"
-                onClick={closeCreate}
-              >
-                {t('podsSidebar.create.cancel')}
-              </button>
-              <button
-                type="submit"
-                className="v2-pods__create-submit"
-                disabled={creating || !newPodName.trim()}
-              >
-                {creating
-                  ? t('podsSidebar.create.creating')
-                  : t(
-                    newPodJoinPolicy === 'invite-only'
-                      ? 'podsSidebar.create.submitPrivate'
-                      : 'podsSidebar.create.submitTeam',
-                  )}
-              </button>
-            </div>
-          </form>
-        </div>
-      ), document.querySelector(V2_ROOT_SELECTOR) || document.body)}
     </aside>
   );
 };

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -664,50 +664,21 @@
   background: var(--v2-accent-strong);
 }
 
-.v2-pods__create {
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
-  padding: 10px;
-  border: 1px solid var(--v2-border);
-  border-radius: var(--v2-radius);
-  background: var(--v2-surface);
-  margin-bottom: 14px;
-}
-
-.v2-pods__create-options {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 6px;
-}
-
-.v2-pods__create-option {
-  height: 32px;
-  border-radius: var(--v2-radius-sm);
-  border: 1px solid var(--v2-border);
-  color: var(--v2-text-secondary);
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.v2-pods__create-option--active {
-  background: var(--v2-accent-soft);
-  border-color: var(--v2-border-strong);
-  color: var(--v2-accent-text);
-}
-
 .v2-pods__create-input {
   width: 100%;
-  padding: 8px 9px;
+  min-height: 42px;
+  padding: 9px 11px;
   border: 1px solid var(--v2-border);
   border-radius: var(--v2-radius-sm);
   background: var(--v2-surface);
-  font-size: 12px;
+  color: var(--v2-text-primary);
+  font-size: 13px;
   outline: none;
 }
 
 .v2-pods__create-input:focus {
   border-color: var(--v2-accent);
+  box-shadow: var(--v2-focus-ring);
 }
 
 .v2-pods__create-error {
@@ -715,17 +686,12 @@
   color: var(--v2-danger);
 }
 
-.v2-pods__create-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
 .v2-pods__create-cancel,
 .v2-pods__create-submit {
-  padding: 6px 9px;
+  min-height: 38px;
+  padding: 8px 14px;
   border-radius: var(--v2-radius-sm);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 700;
 }
 
@@ -1480,17 +1446,31 @@
   font-weight: 650;
 }
 
-/* First-run attach card lives inside the selected pod transcript instead of
-   replacing the pod shell. That keeps the workspace, composer, and mobile
-   drawer reachable while the agent connection status updates live. */
+/* First-run is a shell-level dialog. The overlay separates the one-time setup
+   path from pod content, while the dialog itself owns overflow on short mobile
+   viewports so every step and the dismissal control stay reachable. */
+.v2-first-run__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  display: grid;
+  place-items: center;
+  overflow-y: auto;
+  padding: 24px;
+  background: rgba(15, 23, 42, 0.42);
+}
+
 .v2-first-run {
   width: min(720px, 100%);
-  margin: 24px auto 16px;
+  max-height: calc(100dvh - 48px);
+  overflow-y: auto;
   padding: 28px;
   border: 1px solid var(--v2-border);
   border-radius: var(--v2-radius-lg);
   background: var(--v2-surface);
   color: var(--v2-text-primary);
+  box-shadow: var(--v2-shadow-md, 0 8px 24px rgba(15, 23, 42, 0.12));
+  outline: none;
 }
 
 .v2-first-run__eyebrow {
@@ -1730,12 +1710,12 @@
 
 .v2-chat__new-pod {
   align-self: center;
-  width: min(720px, 100%);
+  width: min(760px, 100%);
   margin: auto;
-  padding: 20px;
-  border: 1px solid var(--v2-border);
+  padding: 24px;
+  border: 1px solid var(--v2-border-strong);
   border-radius: var(--v2-radius-lg);
-  background: var(--v2-surface);
+  background: var(--v2-bg-subtle);
 }
 
 .v2-chat__new-pod-head {
@@ -1746,9 +1726,18 @@
   margin-bottom: 16px;
 }
 
+.v2-chat__new-pod-kicker {
+  margin-bottom: 6px;
+  color: var(--v2-accent-text);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .v2-chat__new-pod-title {
   color: var(--v2-text-primary);
-  font-size: 17px;
+  font-size: 20px;
   font-weight: 700;
   letter-spacing: -0.02em;
 }
@@ -1784,13 +1773,13 @@
 
 .v2-root button.v2-chat__new-pod-action,
 .v2-chat__new-pod-action {
-  display: flex;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
   min-width: 0;
   min-height: 116px;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 5px;
-  padding: 12px;
+  align-items: start;
+  gap: 10px;
+  padding: 14px;
   border: 1px solid var(--v2-border);
   border-radius: var(--v2-radius);
   background: var(--v2-surface);
@@ -1805,6 +1794,27 @@
 .v2-root button.v2-chat__new-pod-action:hover {
   border-color: var(--v2-border-strong);
   background: var(--v2-accent-soft);
+}
+
+.v2-chat__new-pod-step {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--v2-accent-soft);
+  color: var(--v2-accent-text);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.v2-chat__new-pod-action-body {
+  display: flex;
+  min-width: 0;
+  height: 100%;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
 }
 
 .v2-chat__new-pod-action-title {
@@ -3784,6 +3794,132 @@
   margin-top: 4px;
 }
 
+.v2-create-pod {
+  width: min(620px, 100%);
+}
+
+.v2-create-pod .v2-modal__head {
+  align-items: flex-start;
+  padding: 20px 22px 16px;
+}
+
+.v2-create-pod__title {
+  color: var(--v2-text-primary);
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+}
+
+.v2-create-pod__intro {
+  max-width: 460px;
+  margin: 5px 0 0;
+  color: var(--v2-text-secondary);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.v2-create-pod__body {
+  gap: 16px;
+  padding: 18px 22px 20px;
+}
+
+.v2-create-pod__policy {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.v2-create-pod__policy legend,
+.v2-create-pod__field > span {
+  margin-bottom: 7px;
+  color: var(--v2-text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.v2-create-pod__policy-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.v2-root button.v2-create-pod__policy-option,
+.v2-create-pod__policy-option {
+  display: grid;
+  min-width: 0;
+  min-height: 112px;
+  grid-template-columns: 36px minmax(0, 1fr);
+  align-items: start;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  text-align: left;
+  transition: background 80ms ease, border-color 80ms ease;
+}
+
+.v2-root button.v2-create-pod__policy-option:hover,
+.v2-create-pod__policy-option:hover {
+  border-color: var(--v2-border-strong);
+  background: var(--v2-bg-subtle);
+}
+
+.v2-root button.v2-create-pod__policy-option--active,
+.v2-create-pod__policy-option--active {
+  border-color: var(--v2-accent);
+  background: var(--v2-accent-soft);
+}
+
+.v2-create-pod__policy-icon {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-bg-subtle);
+  color: var(--v2-text-secondary);
+}
+
+.v2-create-pod__policy-option--active .v2-create-pod__policy-icon {
+  background: var(--v2-surface);
+  color: var(--v2-accent-text);
+}
+
+.v2-create-pod__policy-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.v2-create-pod__policy-copy strong {
+  color: var(--v2-text-primary);
+  font-size: 13px;
+}
+
+.v2-create-pod__policy-copy > span {
+  color: var(--v2-text-secondary);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.v2-create-pod__field {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.v2-create-pod__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 14px 22px 18px;
+  border-top: 1px solid var(--v2-border-soft);
+}
+
 .v2-modal__section-title {
   font-size: 12px;
   font-weight: 700;
@@ -3985,6 +4121,23 @@
 @media (max-width: 480px) {
   .v2-modal__overlay {
     padding: 12px;
+  }
+
+  .v2-create-pod__policy-options {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .v2-root button.v2-create-pod__policy-option,
+  .v2-create-pod__policy-option {
+    min-height: 0;
+  }
+
+  .v2-create-pod__actions {
+    padding-inline: 16px;
+  }
+
+  .v2-create-pod__actions .v2-pods__create-submit {
+    flex: 1;
   }
 
   .v2-invite-options {
@@ -5110,8 +5263,12 @@
     padding-inline: 14px;
   }
 
+  .v2-first-run__overlay {
+    padding: 12px;
+  }
+
   .v2-first-run {
-    margin-top: 14px;
+    max-height: calc(100dvh - 24px);
     padding: 20px 16px;
   }
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -664,21 +664,66 @@
   background: var(--v2-accent-strong);
 }
 
+.v2-pods__create {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 10px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius);
+  background: var(--v2-surface);
+  margin-bottom: 14px;
+}
+
+.v2-pods__create-options {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 6px;
+}
+
+.v2-pods__create-option {
+  display: flex;
+  min-height: 48px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 7px 9px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-sm);
+  color: var(--v2-text-secondary);
+  text-align: left;
+}
+
+.v2-pods__create-option strong {
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.v2-pods__create-option span {
+  color: var(--v2-text-tertiary);
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.v2-pods__create-option--active {
+  background: var(--v2-accent-soft);
+  border-color: var(--v2-border-strong);
+  color: var(--v2-accent-text);
+}
+
 .v2-pods__create-input {
   width: 100%;
-  min-height: 42px;
-  padding: 9px 11px;
+  padding: 8px 9px;
   border: 1px solid var(--v2-border);
   border-radius: var(--v2-radius-sm);
   background: var(--v2-surface);
-  color: var(--v2-text-primary);
-  font-size: 13px;
+  font-size: 12px;
   outline: none;
 }
 
 .v2-pods__create-input:focus {
   border-color: var(--v2-accent);
-  box-shadow: var(--v2-focus-ring);
 }
 
 .v2-pods__create-error {
@@ -686,12 +731,17 @@
   color: var(--v2-danger);
 }
 
+.v2-pods__create-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 .v2-pods__create-cancel,
 .v2-pods__create-submit {
-  min-height: 38px;
-  padding: 8px 14px;
+  padding: 6px 9px;
   border-radius: var(--v2-radius-sm);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 700;
 }
 
@@ -1726,15 +1776,6 @@
   margin-bottom: 16px;
 }
 
-.v2-chat__new-pod-kicker {
-  margin-bottom: 6px;
-  color: var(--v2-accent-text);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
 .v2-chat__new-pod-title {
   color: var(--v2-text-primary);
   font-size: 20px;
@@ -1773,13 +1814,13 @@
 
 .v2-root button.v2-chat__new-pod-action,
 .v2-chat__new-pod-action {
-  display: grid;
-  grid-template-columns: 28px minmax(0, 1fr);
+  display: flex;
   min-width: 0;
   min-height: 116px;
-  align-items: start;
-  gap: 10px;
-  padding: 14px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+  padding: 12px;
   border: 1px solid var(--v2-border);
   border-radius: var(--v2-radius);
   background: var(--v2-surface);
@@ -1794,27 +1835,6 @@
 .v2-root button.v2-chat__new-pod-action:hover {
   border-color: var(--v2-border-strong);
   background: var(--v2-accent-soft);
-}
-
-.v2-chat__new-pod-step {
-  display: grid;
-  width: 28px;
-  height: 28px;
-  place-items: center;
-  border-radius: 50%;
-  background: var(--v2-accent-soft);
-  color: var(--v2-accent-text);
-  font-size: 11px;
-  font-weight: 700;
-}
-
-.v2-chat__new-pod-action-body {
-  display: flex;
-  min-width: 0;
-  height: 100%;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 5px;
 }
 
 .v2-chat__new-pod-action-title {
@@ -3794,132 +3814,6 @@
   margin-top: 4px;
 }
 
-.v2-create-pod {
-  width: min(620px, 100%);
-}
-
-.v2-create-pod .v2-modal__head {
-  align-items: flex-start;
-  padding: 20px 22px 16px;
-}
-
-.v2-create-pod__title {
-  color: var(--v2-text-primary);
-  font-size: 20px;
-  font-weight: 700;
-  letter-spacing: -0.025em;
-}
-
-.v2-create-pod__intro {
-  max-width: 460px;
-  margin: 5px 0 0;
-  color: var(--v2-text-secondary);
-  font-size: 13px;
-  line-height: 1.45;
-}
-
-.v2-create-pod__body {
-  gap: 16px;
-  padding: 18px 22px 20px;
-}
-
-.v2-create-pod__policy {
-  min-width: 0;
-  margin: 0;
-  padding: 0;
-  border: 0;
-}
-
-.v2-create-pod__policy legend,
-.v2-create-pod__field > span {
-  margin-bottom: 7px;
-  color: var(--v2-text-secondary);
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.v2-create-pod__policy-options {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.v2-root button.v2-create-pod__policy-option,
-.v2-create-pod__policy-option {
-  display: grid;
-  min-width: 0;
-  min-height: 112px;
-  grid-template-columns: 36px minmax(0, 1fr);
-  align-items: start;
-  gap: 10px;
-  padding: 14px;
-  border: 1px solid var(--v2-border);
-  border-radius: var(--v2-radius);
-  background: var(--v2-surface);
-  color: var(--v2-text-primary);
-  text-align: left;
-  transition: background 80ms ease, border-color 80ms ease;
-}
-
-.v2-root button.v2-create-pod__policy-option:hover,
-.v2-create-pod__policy-option:hover {
-  border-color: var(--v2-border-strong);
-  background: var(--v2-bg-subtle);
-}
-
-.v2-root button.v2-create-pod__policy-option--active,
-.v2-create-pod__policy-option--active {
-  border-color: var(--v2-accent);
-  background: var(--v2-accent-soft);
-}
-
-.v2-create-pod__policy-icon {
-  display: grid;
-  width: 36px;
-  height: 36px;
-  place-items: center;
-  border-radius: var(--v2-radius-sm);
-  background: var(--v2-bg-subtle);
-  color: var(--v2-text-secondary);
-}
-
-.v2-create-pod__policy-option--active .v2-create-pod__policy-icon {
-  background: var(--v2-surface);
-  color: var(--v2-accent-text);
-}
-
-.v2-create-pod__policy-copy {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  gap: 5px;
-}
-
-.v2-create-pod__policy-copy strong {
-  color: var(--v2-text-primary);
-  font-size: 13px;
-}
-
-.v2-create-pod__policy-copy > span {
-  color: var(--v2-text-secondary);
-  font-size: 11px;
-  line-height: 1.45;
-}
-
-.v2-create-pod__field {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-}
-
-.v2-create-pod__actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  padding: 14px 22px 18px;
-  border-top: 1px solid var(--v2-border-soft);
-}
-
 .v2-modal__section-title {
   font-size: 12px;
   font-weight: 700;
@@ -4121,23 +4015,6 @@
 @media (max-width: 480px) {
   .v2-modal__overlay {
     padding: 12px;
-  }
-
-  .v2-create-pod__policy-options {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .v2-root button.v2-create-pod__policy-option,
-  .v2-create-pod__policy-option {
-    min-height: 0;
-  }
-
-  .v2-create-pod__actions {
-    padding-inline: 16px;
-  }
-
-  .v2-create-pod__actions .v2-pods__create-submit {
-    flex: 1;
   }
 
   .v2-invite-options {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -823,9 +823,11 @@
   background: var(--v2-surface-hover);
 }
 
-.v2-pods__filter--active {
+.v2-root button.v2-pods__filter--active {
   background: var(--v2-accent-soft);
   color: var(--v2-accent-text);
+  border-color: var(--v2-accent);
+  box-shadow: inset 0 -2px 0 var(--v2-accent);
   font-weight: 600;
 }
 
@@ -842,6 +844,13 @@
   min-width: 0;
   padding-inline: 8px;
   white-space: nowrap;
+}
+
+.v2-root button.v2-pods__community-tab--active {
+  background: var(--v2-accent-soft);
+  color: var(--v2-accent-text);
+  border-color: var(--v2-accent);
+  box-shadow: inset 0 -2px 0 var(--v2-accent);
 }
 
 .v2-pods__list {


### PR DESCRIPTION
## Summary
- promote the existing first-five-minutes guide from the chat transcript to a shell-level modal without changing its visibility, polling, engagement, or dismissal model
- add modal accessibility guarantees: dialog semantics, initial focus, focus restore, Escape/backdrop dismissal, focus trap, and mobile internal scrolling
- keep the existing create flow intact while adding one-line explanations for Team vs Private policy in both locales
- give the already-shipped just-created Pod starter panel a bounded visual-weight bump only

## Verification
- `cd frontend && npm test -- --watchAll=false --runInBand` — 64 suites, 293 tests
- `cd frontend && npm run build` — pass
- focused first-run / create / starter / i18n / layout suites — 45 tests
- changed-file ESLint — 0 errors
- real Chromium: EN + zh-CN at 1280x900 and 390x844; modal and create-policy helpers stay within viewport with zero horizontal overflow

## Guarantee coverage
- modal role + `aria-modal`, focus-on-open and prior-focus restore
- Escape and backdrop both persist the existing dismissed flag
- dismissed/connected users do not see the modal
- chat empty state returns after dismissal; starter invite is not minted while first-run owns the shell
- Team and Private helper copy renders from both locale catalogs

## Review gate
The two new `zh-CN.json` policy helpers are draft UI copy following the locked glossary. Merge is blocked on Sam native-speaker review of the zh-CN diff.
