### PR TITLE
feat(v2): clarify selected tabs and reopen the guide

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -150,6 +150,7 @@
     "title": "Bring your agent into the room",
     "lede": "Connect Claude Code, Cursor, or Codex, then start a private conversation without leaving your workspace.",
     "skip": "Skip for now",
+    "reopen": "Guide",
     "steps": {
       "connect": {
         "title": "Connect your agent",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -150,6 +150,7 @@
     "title": "把你的智能体请进房间",
     "lede": "接入 Claude Code、Cursor 或 Codex，然后直接在工作空间中开始一对一私信。",
     "skip": "暂时跳过",
+    "reopen": "指南",
     "steps": {
       "connect": {
         "title": "接入你的智能体",

--- a/frontend/src/v2/__tests__/V2CommunityNav.test.tsx
+++ b/frontend/src/v2/__tests__/V2CommunityNav.test.tsx
@@ -1,12 +1,16 @@
 // @ts-nocheck
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import {
+  act, fireEvent, render, screen,
+} from '@testing-library/react';
 import {
   MemoryRouter, Route, Routes, useLocation,
 } from 'react-router-dom';
 import axios from 'axios';
 import V2CommunityRedirect from '../components/V2CommunityRedirect';
 import V2NavRail from '../components/V2NavRail';
+import i18n, { i18nReady } from '../../i18n';
+import { FIRST_RUN_REOPEN_EVENT } from '../firstRunGuide';
 
 const mockLogout = jest.fn();
 const mockAxiosGet = axios.get as jest.Mock;
@@ -47,13 +51,20 @@ describe('Community navigation', () => {
   const originalPodId = process.env.REACT_APP_COMMUNITY_POD_ID;
   const originalInviteToken = process.env.REACT_APP_COMMUNITY_INVITE_TOKEN;
 
+  beforeAll(async () => {
+    await i18nReady;
+  });
+
   beforeEach(() => {
     process.env.REACT_APP_COMMUNITY_POD_ID = COMMUNITY_POD_ID;
     process.env.REACT_APP_COMMUNITY_INVITE_TOKEN = COMMUNITY_INVITE_TOKEN;
     jest.clearAllMocks();
+    return act(async () => {
+      await i18n.changeLanguage('en');
+    });
   });
 
-  afterAll(() => {
+  afterAll(async () => {
     if (originalPodId === undefined) {
       delete process.env.REACT_APP_COMMUNITY_POD_ID;
     } else {
@@ -64,6 +75,7 @@ describe('Community navigation', () => {
     } else {
       process.env.REACT_APP_COMMUNITY_INVITE_TOKEN = originalInviteToken;
     }
+    await i18n.changeLanguage('en');
   });
 
   test('shows the rail entry only when a community pod is configured', () => {
@@ -74,6 +86,21 @@ describe('Community navigation', () => {
     delete process.env.REACT_APP_COMMUNITY_POD_ID;
     renderRail();
     expect(screen.queryByRole('button', { name: 'Community' })).not.toBeInTheDocument();
+  });
+
+  test('opens the first-run guide from a localized rail action', async () => {
+    const reopen = jest.fn();
+    window.addEventListener(FIRST_RUN_REOPEN_EVENT, reopen);
+    renderRail();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Guide' }));
+    expect(reopen).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await i18n.changeLanguage('zh-CN');
+    });
+    expect(screen.getByRole('button', { name: '指南' })).toBeInTheDocument();
+    window.removeEventListener(FIRST_RUN_REOPEN_EVENT, reopen);
   });
 
   test('sends members to the Community pod', async () => {

--- a/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
+++ b/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
@@ -59,7 +59,17 @@ jest.mock('../../context/AuthContext', () => ({
   useAuth: () => ({ currentUser: { _id: 'human-1', username: 'new-human' } }),
 }));
 
-jest.mock('../components/V2NavRail', () => () => <nav>Rail</nav>);
+jest.mock('../components/V2NavRail', () => () => (
+  <nav>
+    Rail
+    <button
+      type="button"
+      onClick={() => globalThis.dispatchEvent(new Event('commonly:reopen-first-run'))}
+    >
+      Guide
+    </button>
+  </nav>
+));
 jest.mock('../components/V2PodsSidebar', () => () => <aside>Pods</aside>);
 jest.mock('../components/V2PodInspector', () => () => <aside>Inspector</aside>);
 jest.mock('../components/V2InviteModal', () => () => null);
@@ -230,6 +240,49 @@ describe('V2FirstRunHero', () => {
     expect(localStorage.getItem(FIRST_RUN_DISMISSED_KEY)).toBe('1');
   });
 
+  test.each([
+    {
+      label: 'connected',
+      status: connected,
+      readyControl: 'Say hello',
+    },
+    {
+      label: 'unconnected',
+      status: unissued,
+      readyControl: 'Open connection setup',
+    },
+  ])('reopens for a dismissed $label user and then dismisses normally', async ({
+    status,
+    readyControl,
+  }) => {
+    localStorage.setItem(FIRST_RUN_DISMISSED_KEY, '1');
+    mockGet.mockResolvedValue(status);
+    renderHero();
+    await flush();
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(mockGet).not.toHaveBeenCalled();
+
+    act(() => {
+      window.dispatchEvent(new Event('commonly:reopen-first-run'));
+    });
+
+    expect(screen.getByRole('dialog', { name: 'Bring your agent into the room' }))
+      .toBeInTheDocument();
+    expect(localStorage.getItem(FIRST_RUN_DISMISSED_KEY)).toBeNull();
+    expect(localStorage.getItem(FIRST_RUN_STARTED_KEY)).toBe('1');
+    await flush();
+    expect(await screen.findByRole(
+      status.connected ? 'button' : 'link',
+      { name: readyControl },
+    )).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skip for now' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(localStorage.getItem(FIRST_RUN_DISMISSED_KEY)).toBe('1');
+    expect(localStorage.getItem(FIRST_RUN_STARTED_KEY)).toBeNull();
+  });
+
   test('the started latch survives a reload until the connected CTA is used', async () => {
     localStorage.setItem(FIRST_RUN_STARTED_KEY, '1');
     mockGet.mockResolvedValue(connected);
@@ -298,5 +351,32 @@ describe('V2Layout first-run placement', () => {
     });
     expect(screen.queryByRole('dialog', { name: 'Bring your agent into the room' })).not.toBeInTheDocument();
     expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  test('reopens the dismissed guide from the rail and restores onboarding suppression', async () => {
+    localStorage.setItem(FIRST_RUN_DISMISSED_KEY, '1');
+    render(
+      <MemoryRouter initialEntries={['/v2/pods/hq']}>
+        <Routes>
+          <Route path="/v2/pods/:podId" element={<V2Layout selectionMode="param" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Quiet pod empty state')).toBeInTheDocument();
+    });
+    expect(mockGet).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Guide' }));
+
+    expect(await screen.findByRole('dialog', { name: 'Bring your agent into the room' }))
+      .toBeInTheDocument();
+    expect(screen.queryByText('Quiet pod empty state')).not.toBeInTheDocument();
+    expect(localStorage.getItem(FIRST_RUN_DISMISSED_KEY)).toBeNull();
+    expect(localStorage.getItem(FIRST_RUN_STARTED_KEY)).toBe('1');
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/api/users/me/agent-connection');
+    });
   });
 });

--- a/frontend/src/v2/__tests__/V2PodsSidebar.community.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodsSidebar.community.test.tsx
@@ -172,13 +172,23 @@ describe('V2PodsSidebar Community offer', () => {
       hqPod,
     ]);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Community' }));
+    const communityFilter = screen.getByRole('button', { name: 'Community' });
+    fireEvent.click(communityFilter);
+    expect(communityFilter).toHaveClass('v2-pods__filter--active');
+    expect(screen.getByRole('button', { name: 'All' }))
+      .not.toHaveClass('v2-pods__filter--active');
+    expect(screen.getByRole('button', { name: 'Joined' }))
+      .toHaveClass('v2-pods__community-tab--active');
     expect(await screen.findByText('Joined Builders')).toBeInTheDocument();
     expect(screen.getByText('Commonly HQ')).toBeInTheDocument();
     expect(screen.queryByText('Open Builders')).not.toBeInTheDocument();
     expect(mockApiGet).not.toHaveBeenCalledWith('/api/pods?scope=discover');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Discover' }));
+    const discoverView = screen.getByRole('button', { name: 'Discover' });
+    fireEvent.click(discoverView);
+    expect(discoverView).toHaveClass('v2-pods__community-tab--active');
+    expect(screen.getByRole('button', { name: 'Joined' }))
+      .not.toHaveClass('v2-pods__community-tab--active');
     expect(await screen.findByText('Open Builders')).toBeInTheDocument();
     expect(screen.getByText('Build in public with the community.')).toBeInTheDocument();
     expect(screen.getByText('0 members')).toBeInTheDocument();

--- a/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
@@ -134,8 +134,8 @@ describe('V2PodsSidebar create flow', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '新建 Pod' }));
 
-    expect(screen.getByText('列入发现后，任何人都可以找到并加入。')).toBeInTheDocument();
-    expect(screen.getByText('仅限邀请，由你添加成员。')).toBeInTheDocument();
+    expect(screen.getByText('列入「发现」后，任何人都可以找到并加入。')).toBeInTheDocument();
+    expect(screen.getByText('仅限受邀，由你添加成员。')).toBeInTheDocument();
 
   });
 });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -148,6 +148,16 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(row).toContain('34px minmax(0, 1fr) auto');
   });
 
+  test('the shared filter segment uses an unmistakable token-backed selected state', () => {
+    const active = ruleBody(v2, '.v2-root button.v2-filter-segment__item--active');
+
+    expect(active).toContain('background: var(--v2-accent)');
+    expect(active).toContain('border-color: var(--v2-accent)');
+    expect(active).toContain('color: var(--v2-surface)');
+    expect(active).toContain('font-weight: 700');
+    expect(active).not.toContain('var(--v2-accent-soft)');
+  });
+
   test('starter prompts wrap within the mobile chat pane', () => {
     // At 390px the rail leaves a narrow main pane. Both the row and each chip
     // need explicit shrink/wrap rules or the longest prompt creates horizontal

--- a/frontend/src/v2/components/V2FirstRunHero.tsx
+++ b/frontend/src/v2/components/V2FirstRunHero.tsx
@@ -4,6 +4,7 @@ import React, {
 import { useNavigate } from 'react-router-dom';
 import { useV2Api } from '../hooks/useV2Api';
 import { useTranslation } from 'react-i18next';
+import { FIRST_RUN_REOPEN_EVENT } from '../firstRunGuide';
 
 const POLL_INTERVAL_MS = 3_000;
 const CHECK_MARK = '✓';
@@ -89,6 +90,22 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
     writeFlag(FIRST_RUN_DISMISSED_KEY, true);
     writeFlag(FIRST_RUN_STARTED_KEY, false);
     setDismissed(true);
+  }, []);
+
+  useEffect(() => {
+    const reopen = () => {
+      // Clearing dismissal alone does not reopen for an established owner:
+      // issued=true makes the normal first-run gate false. Reusing the started
+      // latch keeps one visibility model for both new and connected users.
+      writeFlag(FIRST_RUN_DISMISSED_KEY, false);
+      writeFlag(FIRST_RUN_STARTED_KEY, true);
+      setDismissed(false);
+      setEngaged(true);
+      setStatusError(null);
+      setRoomError(null);
+    };
+    window.addEventListener(FIRST_RUN_REOPEN_EVENT, reopen);
+    return () => window.removeEventListener(FIRST_RUN_REOPEN_EVENT, reopen);
   }, []);
 
   useEffect(() => {

--- a/frontend/src/v2/components/V2NavRail.tsx
+++ b/frontend/src/v2/components/V2NavRail.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import V2Avatar from './V2Avatar';
 import V2FeedbackMenu from './V2FeedbackMenu';
 import V2LangSwitch from './V2LangSwitch';
 import { useAuth } from '../../context/AuthContext';
+import { requestFirstRunGuide } from '../firstRunGuide';
 
 interface NavItem {
   key: string;
@@ -46,6 +48,7 @@ const isMobileViewport = (): boolean => (
 );
 
 const V2NavRail: React.FC<V2NavRailProps> = ({ onPodsMobileNav }) => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
   const { currentUser, logout } = useAuth();
@@ -118,6 +121,15 @@ const V2NavRail: React.FC<V2NavRailProps> = ({ onPodsMobileNav }) => {
               Online
             </div>
           </div>
+          <button
+            type="button"
+            className="v2-rail__guide"
+            onClick={requestFirstRunGuide}
+            title={t('firstRun.reopen')}
+            aria-label={t('firstRun.reopen')}
+          >
+            <Icon d="M9.1 9a3 3 0 115.83 1c0 2-3 2-3 4M12 18h.01" />
+          </button>
           <V2FeedbackMenu />
           <button
             type="button"

--- a/frontend/src/v2/firstRunGuide.ts
+++ b/frontend/src/v2/firstRunGuide.ts
@@ -1,0 +1,5 @@
+export const FIRST_RUN_REOPEN_EVENT = 'commonly:reopen-first-run';
+
+export const requestFirstRunGuide = (): void => {
+  window.dispatchEvent(new Event(FIRST_RUN_REOPEN_EVENT));
+};

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -280,10 +280,11 @@
   color: var(--v2-text-primary);
 }
 
-.v2-filter-segment__item--active {
-  border-color: transparent;
-  background: var(--v2-accent-soft);
-  color: var(--v2-accent-text);
+.v2-root button.v2-filter-segment__item--active {
+  border-color: var(--v2-accent);
+  background: var(--v2-accent);
+  color: var(--v2-surface);
+  font-weight: 700;
 }
 
 .v2-filter-count {
@@ -523,6 +524,7 @@
   display: none;
 }
 
+.v2-rail__guide,
 .v2-rail__feedback,
 .v2-rail__signout {
   width: 24px;
@@ -537,6 +539,7 @@
   transition: background 80ms ease, color 80ms ease;
 }
 
+.v2-rail__guide:hover,
 .v2-rail__feedback:hover,
 .v2-rail__feedback[aria-expanded="true"],
 .v2-rail__signout:hover {
@@ -544,6 +547,7 @@
   color: var(--v2-text-primary);
 }
 
+.v2-rail__guide svg,
 .v2-rail__feedback svg,
 .v2-rail__signout svg {
   width: 18px;
@@ -821,12 +825,6 @@
 .v2-pods__filter:hover {
   color: var(--v2-text-primary);
   background: var(--v2-surface-hover);
-}
-
-.v2-pods__filter--active {
-  background: var(--v2-accent-soft);
-  color: var(--v2-accent-text);
-  font-weight: 600;
 }
 
 .v2-pods__community-tabs {


### PR DESCRIPTION
## Summary
- make the shared filter-segment selected state unmistakable with solid cobalt, white text, and bold weight; both the main pod filters and Community sub-tabs inherit the one rule
- remove the duplicate weak pod-filter override so it cannot silently win the cascade again
- add a persistent localized Guide / 指南 action beside Feedback and Sign out in the nav-rail footer
- reopen the existing first-run modal through a tiny window event, clearing dismissal and setting the existing started/engaged latch so connected users reopen correctly too
- leave the composer's already-strong accent border and focus ring unchanged

## Stacked PR
This companion is intentionally based on #734 head `d8733704` because it touches `V2FirstRunHero.tsx` and `v2.css`. The PR targets `codex/732-create-first-run-ux` so review shows only F/G. After #734 merges, rebase this branch onto `main` and retarget the PR.

## Root cause
The sidebar's selected state was both visually weak and split across a shared segment class plus a duplicate pod-specific override. The shared rule now owns the treatment for both rows. Its selector includes the v2 root/button scope so the global button reset cannot erase the background, border, or text color.

## Verification
- `cd frontend && npm test -- --watchAll=false --runInBand` — 64 suites, 298 tests
- `cd frontend && npm run build` — pass
- focused F/G suites — 4 suites, 44 tests
- changed-file ESLint — 0 errors
- `git diff --check` — pass
- real Chromium: EN + zh-CN at 1280×900 and 390×844
  - both active tab tiers compute to `rgb(47, 111, 235)` background/border, white text, weight 700
  - Guide / 指南 reopens for a connected user, focuses the dialog, sets `started=1`, and Escape restores focus to the footer action
  - composer retains the existing cobalt border + 3px focus ring
  - zero horizontal overflow and zero page errors in all four cells

## Guarantee coverage
- shared selected-state invariant asserts `--v2-accent`, rejects `--v2-accent-soft`, and pins white token-backed text + weight 700
- connected and unconnected dismissed-user tests both reopen, assert both storage transitions, and dismiss normally
- rail test proves the localized action emits the one shared reopen event
- shell integration proves reopening suppresses the chat empty state and resumes the existing connection probe

## Review gate
The only new zh-CN copy is `firstRun.reopen: "指南"`. Merge remains blocked on Sam's native-speaker review.
