### PR TITLE
fix(v2): regroup nav rail — language + guide with feedback

### DIFF
--- a/frontend/src/v2/components/V2NavRail.tsx
+++ b/frontend/src/v2/components/V2NavRail.tsx
@@ -74,9 +74,6 @@ const V2NavRail: React.FC<V2NavRailProps> = ({ onPodsMobileNav }) => {
   return (
     <aside className="v2-pane v2-pane--rail">
       <div className="v2-rail">
-        <div className="v2-rail__language">
-          <V2LangSwitch />
-        </div>
         <div className="v2-rail__brand">
           <span className="v2-rail__brand-icon" aria-label="Commonly">
             <svg width="18" height="18" viewBox="0 0 64 64" fill="none" aria-hidden="true">
@@ -107,38 +104,48 @@ const V2NavRail: React.FC<V2NavRailProps> = ({ onPodsMobileNav }) => {
           ))}
         </nav>
 
-        <div className="v2-rail__user">
-          <V2Avatar name={currentUser?.username || 'You'} size="md" online />
-          <div style={{ minWidth: 0, flex: 1 }}>
-            <div className="v2-rail__user-name" style={{
-              whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
-            }}
+        <div className="v2-rail__foot">
+          {/* Help & preferences — language, guide, feedback grouped together
+              (Sam 2026-07-23: guide belongs with feedback; language switch
+              moved off its cramped above-the-logo slot into this cluster). */}
+          <div className="v2-rail__utility">
+            <V2LangSwitch />
+            <button
+              type="button"
+              className="v2-rail__guide"
+              onClick={requestFirstRunGuide}
+              title={t('firstRun.reopen')}
+              aria-label={t('firstRun.reopen')}
             >
-              {currentUser?.username || 'You'}
-            </div>
-            <div className="v2-rail__user-status">
-              <span className="v2-online-dot" />
-              Online
-            </div>
+              <Icon d="M9.1 9a3 3 0 115.83 1c0 2-3 2-3 4M12 18h.01" />
+            </button>
+            <V2FeedbackMenu />
           </div>
-          <button
-            type="button"
-            className="v2-rail__guide"
-            onClick={requestFirstRunGuide}
-            title={t('firstRun.reopen')}
-            aria-label={t('firstRun.reopen')}
-          >
-            <Icon d="M9.1 9a3 3 0 115.83 1c0 2-3 2-3 4M12 18h.01" />
-          </button>
-          <V2FeedbackMenu />
-          <button
-            type="button"
-            className="v2-rail__signout"
-            onClick={logout}
-            title="Sign out"
-          >
-            <Icon d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4M16 17l5-5-5-5M21 12H9" />
-          </button>
+          <span className="v2-rail__foot-sep" aria-hidden="true" />
+          {/* Account */}
+          <div className="v2-rail__user">
+            <V2Avatar name={currentUser?.username || 'You'} size="md" online />
+            <div style={{ minWidth: 0, flex: 1 }}>
+              <div className="v2-rail__user-name" style={{
+                whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+              }}
+              >
+                {currentUser?.username || 'You'}
+              </div>
+              <div className="v2-rail__user-status">
+                <span className="v2-online-dot" />
+                Online
+              </div>
+            </div>
+            <button
+              type="button"
+              className="v2-rail__signout"
+              onClick={logout}
+              title="Sign out"
+            >
+              <Icon d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4M16 17l5-5-5-5M21 12H9" />
+            </button>
+          </div>
         </div>
       </div>
     </aside>

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -387,19 +387,39 @@
   justify-content: space-between;
 }
 
-.v2-rail__language {
+/* Bottom of the rail: a help/preferences cluster (language · guide · feedback)
+   sits above a divider, then the account cluster (avatar · sign out). */
+.v2-rail__foot {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
 }
 
-.v2-rail__language .v2-lang-switch__trigger {
+.v2-rail__utility {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.v2-rail__foot-sep {
+  width: 24px;
+  height: 1px;
+  background: var(--v2-border);
+}
+
+.v2-rail__utility .v2-lang-switch__trigger {
   padding: 2px 4px;
   font-size: 10px;
   font-weight: 700;
 }
 
-/* In the narrow rail the menu must open toward the content, not off-screen. */
-.v2-rail__language .v2-lang-switch__menu {
+/* At the foot of the rail the menu must open upward + toward content,
+   not downward off the bottom of the viewport. */
+.v2-rail__utility .v2-lang-switch__menu {
+  top: auto;
+  bottom: calc(100% + 6px);
   right: auto;
   left: 0;
 }
@@ -510,7 +530,6 @@
 }
 
 .v2-rail__user {
-  margin-top: auto;
   min-height: 48px;
   padding: 0;
   display: flex;


### PR DESCRIPTION
## Summary
Two nav-rail placement fixes from Sam's live-shell feedback (2026-07-23):
1. **Language switcher** moved off its cramped slot *above the logo* into a bottom **help/preferences cluster**; its dropdown now opens **upward** so it doesn't clip off the bottom of the rail.
2. **Guide (?)** grouped with **Feedback** in that same cluster, separated by a divider from the account cluster (avatar + sign out).

New rail structure: `brand → nav → foot{ utility[language · guide · feedback] · divider · account[avatar · signout] }`.

## Notes
- `V2LangSwitch`, guide button, and `V2FeedbackMenu` are unchanged components — only their placement in `V2NavRail` moved; `.v2-rail__language` CSS replaced by `.v2-rail__foot` / `.v2-rail__utility`.
- Removed `.v2-rail__language` (no references remain in src/).
- `V2CommunityNav` + `V2FeedbackMenu` tests mount the real rail and resolve Guide/Feedback by role+label — unaffected.

## Verification
- Post-deploy real-browser check on commonly.me (nav-layout change; jsdom can't verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)