### PR TITLE
fix(v2): nav rail polish + community tab uses communityListed not publicRead

### DIFF
--- a/frontend/src/v2/__tests__/V2CommunityNav.test.tsx
+++ b/frontend/src/v2/__tests__/V2CommunityNav.test.tsx
@@ -88,18 +88,21 @@ describe('Community navigation', () => {
     expect(screen.queryByRole('button', { name: 'Community' })).not.toBeInTheDocument();
   });
 
-  test('opens the first-run guide from a localized rail action', async () => {
+  test('reopens the first-run guide from the feedback menu', async () => {
     const reopen = jest.fn();
     window.addEventListener(FIRST_RUN_REOPEN_EVENT, reopen);
     renderRail();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Guide' }));
+    // Guide now lives inside the feedback menu, beside report-a-bug / request-a-feature.
+    fireEvent.click(screen.getByRole('button', { name: 'Feedback' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Guide' }));
     expect(reopen).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       await i18n.changeLanguage('zh-CN');
     });
-    expect(screen.getByRole('button', { name: '指南' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '反馈' }));
+    expect(await screen.findByRole('button', { name: '指南' })).toBeInTheDocument();
     window.removeEventListener(FIRST_RUN_REOPEN_EVENT, reopen);
   });
 

--- a/frontend/src/v2/__tests__/V2CommunityNav.test.tsx
+++ b/frontend/src/v2/__tests__/V2CommunityNav.test.tsx
@@ -94,15 +94,16 @@ describe('Community navigation', () => {
     renderRail();
 
     // Guide now lives inside the feedback menu, beside report-a-bug / request-a-feature.
-    fireEvent.click(screen.getByRole('button', { name: 'Feedback' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Guide' }));
+    // MUI's modal aria-hides the rail ancestor in jsdom, so menu items need { hidden: true }.
+    fireEvent.click(screen.getByRole('button', { name: 'Feedback', hidden: true }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Guide', hidden: true }));
     expect(reopen).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       await i18n.changeLanguage('zh-CN');
     });
-    fireEvent.click(screen.getByRole('button', { name: '反馈' }));
-    expect(await screen.findByRole('button', { name: '指南' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '反馈', hidden: true }));
+    expect(await screen.findByRole('button', { name: '指南', hidden: true })).toBeInTheDocument();
     window.removeEventListener(FIRST_RUN_REOPEN_EVENT, reopen);
   });
 

--- a/frontend/src/v2/components/V2FeedbackMenu.tsx
+++ b/frontend/src/v2/components/V2FeedbackMenu.tsx
@@ -5,8 +5,10 @@ import FeedbackOutlinedIcon from '@mui/icons-material/FeedbackOutlined';
 import LightbulbOutlinedIcon from '@mui/icons-material/LightbulbOutlined';
 import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
 import QuestionAnswerOutlinedIcon from '@mui/icons-material/QuestionAnswerOutlined';
+import MenuBookOutlinedIcon from '@mui/icons-material/MenuBookOutlined';
 import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { requestFirstRunGuide } from '../firstRunGuide';
 import {
   buildBugReportUrl,
   buildFeatureRequestUrl,
@@ -52,6 +54,14 @@ const V2FeedbackMenu: React.FC = () => {
         PaperProps={{ className: 'v2-feedback-menu__popover', elevation: 0 }}
       >
         <nav id="v2-feedback-options" className="v2-feedback-menu__list" aria-label={t('feedbackMenu.optionsLabel')}>
+          <button
+            type="button"
+            className="v2-feedback-menu__item"
+            onClick={() => { requestFirstRunGuide(); handleClose(); }}
+          >
+            <MenuBookOutlinedIcon aria-hidden="true" />
+            <span>{t('firstRun.reopen')}</span>
+          </button>
           <a
             className="v2-feedback-menu__item"
             href={buildBugReportUrl(location.pathname)}

--- a/frontend/src/v2/components/V2NavRail.tsx
+++ b/frontend/src/v2/components/V2NavRail.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
 import V2Avatar from './V2Avatar';
 import V2FeedbackMenu from './V2FeedbackMenu';
 import V2LangSwitch from './V2LangSwitch';
 import { useAuth } from '../../context/AuthContext';
-import { requestFirstRunGuide } from '../firstRunGuide';
 
 interface NavItem {
   key: string;
@@ -48,7 +46,6 @@ const isMobileViewport = (): boolean => (
 );
 
 const V2NavRail: React.FC<V2NavRailProps> = ({ onPodsMobileNav }) => {
-  const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
   const { currentUser, logout } = useAuth();
@@ -105,20 +102,12 @@ const V2NavRail: React.FC<V2NavRailProps> = ({ onPodsMobileNav }) => {
         </nav>
 
         <div className="v2-rail__foot">
-          {/* Help & preferences — language, guide, feedback grouped together
-              (Sam 2026-07-23: guide belongs with feedback; language switch
-              moved off its cramped above-the-logo slot into this cluster). */}
+          {/* Help & preferences — language switch + the help/feedback menu
+              (Sam 2026-07-23: the guide moved into the feedback menu next to
+              report-a-bug / request-a-feature; language switch lives here too,
+              off its old cramped above-the-logo slot). */}
           <div className="v2-rail__utility">
             <V2LangSwitch />
-            <button
-              type="button"
-              className="v2-rail__guide"
-              onClick={requestFirstRunGuide}
-              title={t('firstRun.reopen')}
-              aria-label={t('firstRun.reopen')}
-            >
-              <Icon d="M9.1 9a3 3 0 115.83 1c0 2-3 2-3 4M12 18h.01" />
-            </button>
             <V2FeedbackMenu />
           </div>
           <span className="v2-rail__foot-sep" aria-hidden="true" />

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -321,9 +321,12 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
     return Array.from(byId.values()).filter((pod) => {
       if (isPersonalPod(pod)) return false;
       if (!effectiveMemberIds.has(pod._id)) return false;
+      // Community membership is opt-in `communityListed` (the scope=community
+      // result set + Discover-joined + HQ) — NOT `publicRead`. publicRead is
+      // anonymous/showcase read only (#722); showcase pods like the milestone
+      // and engineering rooms are publicRead but must NOT appear in Community.
       return communityPodIds.has(pod._id)
         || joinedDiscoverPods.some((joined) => joined._id === pod._id)
-        || pod.publicRead === true
         || (Boolean(communityPodId) && pod._id === communityPodId);
     });
   }, [

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -400,7 +400,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
 }
 
 .v2-rail__foot-sep {
@@ -410,9 +410,18 @@
 }
 
 .v2-rail__utility .v2-lang-switch__trigger {
-  padding: 2px 4px;
-  font-size: 10px;
+  min-height: 24px;
+  padding: 2px 6px;
+  gap: 3px;
+  font-size: 11px;
   font-weight: 700;
+  color: var(--v2-text-tertiary);
+  border-radius: var(--v2-radius-sm);
+}
+
+.v2-rail__utility .v2-lang-switch__trigger:hover {
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
 }
 
 /* At the foot of the rail the menu must open upward + toward content,
@@ -543,7 +552,6 @@
   display: none;
 }
 
-.v2-rail__guide,
 .v2-rail__feedback,
 .v2-rail__signout {
   width: 24px;
@@ -558,7 +566,6 @@
   transition: background 80ms ease, color 80ms ease;
 }
 
-.v2-rail__guide:hover,
 .v2-rail__feedback:hover,
 .v2-rail__feedback[aria-expanded="true"],
 .v2-rail__signout:hover {
@@ -566,7 +573,6 @@
   color: var(--v2-text-primary);
 }
 
-.v2-rail__guide svg,
 .v2-rail__feedback svg,
 .v2-rail__signout svg {
   width: 18px;


### PR DESCRIPTION
## Summary
Nav/sidebar polish from Sam's live feedback (2026-07-23):

**Nav rail**
- **Guide moved into the feedback menu** as its top item, beside Report-a-bug / Request-a-feature — consolidates help affordances, declutters the rail (`MenuBookOutlined` + the existing `firstRun.reopen` label; same reopen event).
- **Language switch** rendering/spacing polished (11px, tertiary color, hover fill, 24px tap target).
- Removed dead `.v2-rail__guide` styles + unused `useTranslation`.

**Community tab leak fix**
- `V2PodsSidebar` Joined view included any `publicRead` member pod, so **showcase rooms (milestone, engineering — `publicRead` for YC/landing but NOT `communityListed`) leaked into a user's Community tab.** Dropped the `publicRead` clause; Joined = `scope=community` (communityListed) + Discover-joined + HQ, per the #722 `publicRead ≠ communityListed` split. Showcase pods stay in All/Team.

## Tests
- `V2CommunityNav` guide test reaches Guide via the feedback menu with `{ hidden: true }` (MUI aria-hides the rail in jsdom).
- Existing community-sidebar tests unaffected (they seed joined pods via `scope=community` / Discover, not `publicRead`).
- Post-deploy real-browser verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)