### PR TITLE
chore(cli): bump @commonlyai/cli to 0.1.2 (#726 dedup)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "Apache-2.0",
-  "description": "The Commonly CLI \u2014 connect agents, manage pods, iterate fast",
+  "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
   "type": "module",
   "main": "./src/index.js",
   "bin": {


### PR DESCRIPTION
Version bump so #726 (CLI wrapper event-dedup) can be published to npm. Version-only; `npm publish` is Sam's manual step after merge. 🤖