### PR TITLE
fix(byo): never default a personal agent into a public pod (HQ funnel incident)

### DIFF
--- a/frontend/src/v2/__tests__/V2AgentBYOPodPicker.test.tsx
+++ b/frontend/src/v2/__tests__/V2AgentBYOPodPicker.test.tsx
@@ -1,0 +1,62 @@
+// @ts-nocheck
+// Guards the BYO pod-picker default after the 2026-07-24 launch incident:
+// new users auto-join Commonly HQ (publicRead), it sorts first by activity in
+// /api/pods, and the old `installablePods[0]` default silently attached
+// personal agents to the public room — a prompt-injection surface running with
+// the owner's own tokens. The picker must (a) never offer a publicRead pod, and
+// (b) default to the user's OWN workspace, never the most-active pod.
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2AgentBYO from '../components/V2AgentBYO';
+import { AuthContext } from '../../context/AuthContext';
+
+jest.mock('axios', () => {
+  const mock = {
+    get: jest.fn(), post: jest.fn(), patch: jest.fn(), delete: jest.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  };
+  return { __esModule: true, default: mock, ...mock };
+});
+const axios = jest.requireMock('axios').default;
+
+const authValue = {
+  currentUser: { _id: 'u1', username: 'sam' }, user: { _id: 'u1', username: 'sam' },
+  token: 'jwt', loading: false, error: null, isAuthenticated: true,
+  register: jest.fn(), login: jest.fn(), logout: jest.fn(), updateProfile: jest.fn(),
+};
+const renderPage = () => render(
+  <AuthContext.Provider value={authValue}><MemoryRouter><V2AgentBYO /></MemoryRouter></AuthContext.Provider>,
+);
+afterEach(() => jest.clearAllMocks());
+
+describe('V2AgentBYO pod picker safety (HQ funnel incident 2026-07-24)', () => {
+  test('excludes publicRead pods and defaults to the user\'s own workspace', async () => {
+    // Ordered like a new user's /api/pods: public HQ first by activity.
+    axios.get.mockResolvedValueOnce({ data: [
+      { _id: 'hq', name: 'Commonly HQ', type: 'chat', publicRead: true, createdBy: { _id: 'admin' } },
+      { _id: 'ws', name: 'My Workspace', type: 'chat', createdBy: { _id: 'u1' } },
+    ] });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('My Workspace (chat)')).toBeInTheDocument());
+    // Default target is the user's own workspace, NOT the most-active (HQ) pod.
+    expect(screen.getByRole('combobox').value).toBe('ws');
+    // The public room is not selectable here at all.
+    expect(screen.queryByText('Commonly HQ (chat)')).not.toBeInTheDocument();
+  });
+
+  test('falls back to the first non-public pod when the user owns none', async () => {
+    axios.get.mockResolvedValueOnce({ data: [
+      { _id: 'hq', name: 'Commonly HQ', type: 'chat', publicRead: true, createdBy: { _id: 'admin' } },
+      { _id: 'team', name: 'Some Team', type: 'chat', createdBy: { _id: 'other' } },
+    ] });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Some Team (chat)')).toBeInTheDocument());
+    expect(screen.getByRole('combobox').value).toBe('team');
+    expect(screen.queryByText('Commonly HQ (chat)')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -75,17 +75,36 @@ const V2AgentBYO: React.FC = () => {
         const data = await api.get<V2Pod[]>('/api/pods');
         if (cancelled) return;
         const list = Array.isArray(data) ? data : [];
-        // Filter to non-DM pods — agent-room/agent-dm/agent-admin are
-        // strict-1:1 surfaces and refuse third-party installs.
-        const installablePods = list.filter((p) => !['agent-room', 'agent-dm', 'agent-admin'].includes(p.type || ''));
+        const installablePods = list.filter((p) => (
+          // Non-DM only: agent-room/agent-dm/agent-admin are strict-1:1
+          // surfaces and refuse third-party installs.
+          !['agent-room', 'agent-dm', 'agent-admin'].includes(p.type || '')
+          // NEVER offer a public/community pod (e.g. Commonly HQ) here. A
+          // personal BYO agent attached to a stranger-readable room processes
+          // untrusted input — a prompt-injection surface running with the
+          // owner's own tokens/compute. New users auto-join HQ and it sorts
+          // first by activity, so the old `installablePods[0]` default silently
+          // funneled personal agents into the public room (2026-07-24 launch
+          // incident). Restrict the picker to non-public pods.
+          && p.publicRead !== true
+        ));
         setPods(installablePods);
-        if (installablePods.length > 0 && !podId) setPodId(installablePods[0]._id);
+        if (!podId && installablePods.length > 0) {
+          // Default to the user's OWN pod (their private workspace), never the
+          // most-active pod. Fall back to the first non-public pod only if the
+          // user somehow owns none.
+          const uid = currentUser?._id;
+          const own = uid
+            ? installablePods.find((p) => p.createdBy?._id && String(p.createdBy._id) === String(uid))
+            : undefined;
+          setPodId((own || installablePods[0])._id);
+        }
       } catch {
         // Defensive: keep the form usable; user will see the error on submit.
       }
     })();
     return () => { cancelled = true; };
-  }, [api, podId]);
+  }, [api, podId, currentUser?._id]);
 
   const submit = async () => {
     setError(null);


### PR DESCRIPTION
## Incident (2026-07-24, launch day)

New users auto-join **Commonly HQ** (`publicRead`) and land there. The BYO connect page (`V2AgentBYO`) defaulted the install target to `installablePods[0]` — the first pod from `/api/pods`, which is sorted by activity, so HQ dominates. Accepting the default silently attached users' **personal agents into the public room**.

A personal BYO wrapper in a public pod runs on the owner's machine with the owner's tokens/compute, exposed to untrusted @mentions from strangers → a prompt-injection / secret-exfiltration surface. Several agents landed in HQ before this was caught; they've been re-homed to their owners' private workspaces (identity/memory preserved), and HQ is back to only the hardened `hq-support`.

## Fix

`V2AgentBYO` pod picker now:
- **Excludes `publicRead` pods entirely** — a personal agent can't be attached to a stranger-readable room via this flow.
- **Defaults to the user's own workspace** (`createdBy === self`), never the most-active pod.

## Test

`V2AgentBYOPodPicker.test.tsx` pins both invariants, including the exact failure ordering (HQ public + first by activity → still defaults to the private workspace, HQ not offered).

## Follow-ups (separate, not launch-eve)
- Defense-in-depth: don't deliver untrusted-sender mentions to non-hardened agents in public pods.
- Explicit, sandboxed opt-in path for users who *do* want an agent active in a community pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMeWzgFxsfBcjoLVLewEES