### PR TITLE
fix(register): mirror the default workspace pod into Postgres

### DIFF
--- a/backend/__tests__/unit/controllers/authController.workspacePgMirror.test.js
+++ b/backend/__tests__/unit/controllers/authController.workspacePgMirror.test.js
@@ -1,0 +1,52 @@
+// createDefaultWorkspacePod must mirror the new "My Workspace" pod into
+// PostgreSQL at registration. Before the 2026-07-24 fix it only wrote Mongo,
+// so a fresh user's workspace was missing from PG until its first chat message
+// (the messageController lazy backfill) — and any *non-message* PG op on it
+// (adding a member/agent first) FK-failed on the absent `pods` row. Registration
+// also hasn't synced the user to PG by this point, so the pod's member insert
+// would fail its user_id FK unless the user is synced FIRST. This guards both.
+
+// jsonwebtoken must be mocked or it fails to load under the Node-26 drift
+// (buffer-equal-constant-time) — same guard the sibling authController test uses.
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 'tok'), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('bcryptjs', () => ({ hash: jest.fn(), compare: jest.fn(), genSalt: jest.fn(() => 'salt') }));
+jest.mock('@sendgrid/mail', () => ({ setApiKey: jest.fn(), send: jest.fn().mockResolvedValue({}) }));
+jest.mock('../../../services/communityPodService', () => ({
+  ensureUserInCommunityPod: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockSyncUser = jest.fn().mockResolvedValue(undefined);
+const mockSyncPod = jest.fn().mockResolvedValue({});
+jest.mock('../../../models/Pod', () => ({ create: jest.fn().mockResolvedValue({ _id: 'pod-123' }) }));
+jest.mock('../../../models/User', () => ({ findById: jest.fn().mockResolvedValue({ _id: 'user-1' }) }));
+jest.mock('../../../models/Task', () => ({ create: jest.fn().mockResolvedValue([]) }));
+jest.mock('../../../services/agentIdentityService', () => ({ syncUserToPostgreSQL: mockSyncUser }));
+jest.mock('../../../services/pgPodSyncService', () => ({ syncPodFromMongo: mockSyncPod }));
+
+const authController = require('../../../controllers/authController');
+
+describe('createDefaultWorkspacePod PG mirror (2026-07-24 incident)', () => {
+  const OLD_PG = process.env.PG_HOST;
+  afterAll(() => {
+    if (OLD_PG === undefined) delete process.env.PG_HOST;
+    else process.env.PG_HOST = OLD_PG;
+  });
+  beforeEach(() => jest.clearAllMocks());
+
+  test('mirrors the workspace into PG — user synced BEFORE the pod (FK-safe order)', async () => {
+    process.env.PG_HOST = 'localhost';
+    await authController.createDefaultWorkspacePod('user-1');
+
+    expect(mockSyncUser).toHaveBeenCalledTimes(1);
+    expect(mockSyncPod).toHaveBeenCalledWith('pod-123', 'user-1');
+    // The user MUST sync first, or PGPod.create's member insert FK-fails.
+    expect(mockSyncUser.mock.invocationCallOrder[0])
+      .toBeLessThan(mockSyncPod.mock.invocationCallOrder[0]);
+  });
+
+  test('skips the PG mirror entirely when PG_HOST is unset (Mongo-only dev)', async () => {
+    delete process.env.PG_HOST;
+    await authController.createDefaultWorkspacePod('user-1');
+    expect(mockSyncPod).not.toHaveBeenCalled();
+  });
+});

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -87,6 +87,27 @@ const createDefaultWorkspacePod = async (userId: any) => {
       members: [userId],
     });
 
+    // Mirror the workspace into PostgreSQL immediately. The UI path
+    // (`createPod`) already does this, but registration's workspace pod did
+    // not — so every new user's workspace lived only in Mongo until its first
+    // chat message (the messageController lazy backfill). Any *non-message* PG
+    // operation on it (adding a member/agent before any message) then FK-failed
+    // on the missing `pods` row (2026-07-24 re-home incident). Sync the user
+    // first — registration has not written it to PG yet, so the pod's member
+    // insert would otherwise fail its user_id FK. Best-effort: PG drift is
+    // still caught by the lazy backfill, so never fail registration on it.
+    try {
+      if (process.env.PG_HOST) {
+        const userDoc = await User.findById(userId);
+        if (userDoc) await AgentIdentityService.syncUserToPostgreSQL(userDoc);
+        // eslint-disable-next-line global-require
+        const { syncPodFromMongo } = require('../services/pgPodSyncService');
+        await syncPodFromMongo(pod._id.toString(), String(userId));
+      }
+    } catch (pgErr: any) {
+      console.warn('[register] default workspace PG mirror failed:', pgErr?.message);
+    }
+
     // Starter checklist — scripted onboarding on the real task board (no
     // dedicated checklist UI to maintain). Matches tasksApi's TASK-###
     // numbering so later tasks continue the sequence. Best-effort, same as


### PR DESCRIPTION
## Bug

`createPod` (the UI path) mirrors new pods into Postgres (`podController.ts:409`), but **`createDefaultWorkspacePod`** — the auto "My Workspace" created at registration — only did the Mongo `Pod.create`. So every new user's personal workspace was **missing from PG** until its first chat message triggered the `messageController` lazy backfill (`syncPodFromMongo`).

Any **non-message** PG operation on a message-less workspace then hit the `pods` foreign key and failed — surfaced 2026-07-24 while re-homing accidentally-public agents into users' fresh workspaces (the `pod_members` insert FK-failed on the absent `pods` row).

## Fix

Mirror the workspace to PG at creation, reusing the existing helpers:
- Registration hasn't synced the user to PG yet, so **sync the user first** (`syncUserToPostgreSQL`) — otherwise `PGPod.create`'s member insert fails its `user_id` FK.
- Then **`syncPodFromMongo`** (the same backfill the message path uses) creates the PG pod row + members.
- Best-effort: PG drift is still caught by the lazy backfill, so registration never fails on a PG hiccup.

## Test

`authController.workspacePgMirror.test.js` — pins the mirror happens, the **FK-safe user-before-pod ordering**, and that it's skipped when `PG_HOST` is unset. Existing `authController.test.js` (18 tests) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMeWzgFxsfBcjoLVLewEES