### PR TITLE
chore(release): @commonlyai/cli 0.1.3 (sandbox + MCP credential isolation)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "Apache-2.0",
   "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
   "type": "module",


### PR DESCRIPTION
Version bump so #750 (public-agent sandbox + token-file isolation) ships via the published CLI. After merge: `cd cli && npm publish`, then `npm i -g @commonlyai/cli@0.1.3` and re-run the wrappers via `commonly agent run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)