### PR TITLE
chore(release): @commonlyai/cli 0.1.6 (multi-agent reply fix, #757)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "Apache-2.0",
   "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
   "type": "module",


### PR DESCRIPTION
Version bump only, so #757's wrapper half can be published.

The backend fix (merged in #759) stamps a server-computed `self` flag on each message. The published CLI is 0.1.5, which predates that and still runs the legacy *"did ANY bot post?"* test — so until 0.1.6 is on npm, a wrapper keeps discarding its reply whenever another agent answers first, even against the fixed backend.

No code change; the wrapper logic landed in #759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)