### PR TITLE
fix(cli): refuse to attach an unsandboxed agent to a public pod (#771)

### DIFF
--- a/cli/__tests__/public-pod-sandbox-gate.test.mjs
+++ b/cli/__tests__/public-pod-sandbox-gate.test.mjs
@@ -1,0 +1,95 @@
+/**
+ * #771 — attaching to a public pod without a sandbox declaration must fail.
+ *
+ * The public-agent sandbox is deny-by-default and attack-tested, but it only
+ * engages once `sandbox.trust` and `sandbox.mode` are declared. `sandbox.mode`
+ * defaults to `'none'`, and nothing connected "this pod is public" to "this
+ * agent must be confined" — so an agent attached with no sandbox block ran
+ * unconfined, silently.
+ *
+ * `hq-support` ran that way in a 67-member public pod until 2026-07-27. Its
+ * permission deny-list was doing the file-blocking work; the OS-level sandbox
+ * never engaged. Deny-by-default only means something if ABSENT is refused.
+ */
+import { jest } from '@jest/globals';
+import { assertSandboxDeclaredForPublicPod } from '../src/commands/agent.js';
+
+const clientFor = (pod) => ({ get: jest.fn().mockResolvedValue(pod) });
+
+const PUBLIC_POD = { _id: 'p1', name: 'Commonly HQ', publicRead: true };
+const PRIVATE_POD = { _id: 'p2', name: 'My Workspace', publicRead: false };
+const SANDBOXED = { sandbox: { trust: 'public', mode: 'read-only' } };
+
+describe('public-pod sandbox gate', () => {
+  test('refuses a public pod when no sandbox is declared at all', async () => {
+    // The exact hq-support shape: an environment with mcp/skills but no
+    // `sandbox` key whatsoever.
+    const environment = { version: 1, mcp: [], skills: {} };
+
+    await expect(assertSandboxDeclaredForPublicPod({
+      client: clientFor(PUBLIC_POD), podId: 'p1', environment,
+    })).rejects.toThrow(/publicly readable/i);
+  });
+
+  test('refuses when there is no environment file at all', async () => {
+    await expect(assertSandboxDeclaredForPublicPod({
+      client: clientFor(PUBLIC_POD), podId: 'p1', environment: null,
+    })).rejects.toThrow(/no sandbox/i);
+  });
+
+  test('refuses when sandbox.mode is explicitly none', async () => {
+    await expect(assertSandboxDeclaredForPublicPod({
+      client: clientFor(PUBLIC_POD),
+      podId: 'p1',
+      environment: { sandbox: { trust: 'public', mode: 'none' } },
+    })).rejects.toThrow(/publicly readable/i);
+  });
+
+  test('refuses a communityListed pod even when publicRead is false', async () => {
+    await expect(assertSandboxDeclaredForPublicPod({
+      client: clientFor({ _id: 'p3', name: 'Bug Reports', communityListed: true }),
+      podId: 'p3',
+      environment: {},
+    })).rejects.toThrow(/publicly readable/i);
+  });
+
+  test('the error tells the operator exactly what to add', async () => {
+    // A refusal that does not say how to proceed just gets worked around.
+    await expect(assertSandboxDeclaredForPublicPod({
+      client: clientFor(PUBLIC_POD), podId: 'p1', environment: {},
+    })).rejects.toThrow(/"trust": "public"/);
+  });
+
+  test('allows a public pod once a sandbox IS declared', async () => {
+    await expect(assertSandboxDeclaredForPublicPod({
+      client: clientFor(PUBLIC_POD), podId: 'p1', environment: SANDBOXED,
+    })).resolves.toBeUndefined();
+  });
+
+  test('leaves private pods alone — this gate is only about public exposure', async () => {
+    await expect(assertSandboxDeclaredForPublicPod({
+      client: clientFor(PRIVATE_POD), podId: 'p2', environment: null,
+    })).resolves.toBeUndefined();
+  });
+
+  test('does not query the pod at all when a sandbox is already declared', async () => {
+    const client = clientFor(PUBLIC_POD);
+    await assertSandboxDeclaredForPublicPod({
+      client, podId: 'p1', environment: SANDBOXED,
+    });
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  test('an unreadable pod warns and proceeds rather than failing the attach', async () => {
+    // Failing attach on an unrelated network fault would be its own footgun —
+    // but a SILENT skip is how the original hole stayed invisible, so it warns.
+    const log = jest.fn();
+    const client = { get: jest.fn().mockRejectedValue(new Error('403')) };
+
+    await expect(assertSandboxDeclaredForPublicPod({
+      client, podId: 'p1', environment: null, log,
+    })).resolves.toBeUndefined();
+
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/could not read pod visibility/i));
+  });
+});

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -183,6 +183,68 @@ export const buildDefaultEnvironment = (adapterName) => {
   return environment;
 };
 
+// ── public-pod sandbox gate ─────────────────────────────────────────────────
+
+/**
+ * Refuse to attach an agent to a publicly-readable pod unless it declares an
+ * enforced sandbox.
+ *
+ * The public-agent sandbox is real and attack-tested, but it only engages once
+ * `sandbox.trust` and `sandbox.mode` are declared: `sandbox.mode` defaults to
+ * `'none'`, and nothing previously connected "this pod is public" to "this
+ * agent must be confined". An agent attached with no sandbox block simply ran
+ * unconfined, silently, with the operator none the wiser.
+ *
+ * That is not hypothetical — `hq-support` ran that way in a 67-member public
+ * pod until 2026-07-27. Its permission deny-list was doing the file-blocking
+ * work while the OS-level sandbox never engaged at all.
+ *
+ * Deny-by-default only means something if ABSENT is refused, so this is a hard
+ * error rather than a warning. If the pod's visibility cannot be determined
+ * (older server, network failure, permissions), attach proceeds — failing the
+ * attach on an unrelated fault would be its own footgun — but says so, because
+ * a silent skip is how the original hole stayed invisible.
+ */
+export const assertSandboxDeclaredForPublicPod = async ({
+  client,
+  podId,
+  environment,
+  log = () => {},
+}) => {
+  if (!podId || !client) return;
+
+  const mode = environment?.sandbox?.mode;
+  const trust = environment?.sandbox?.trust;
+  const declared = Boolean(trust) && Boolean(mode) && mode !== 'none';
+  if (declared) return;
+
+  let pod = null;
+  try {
+    pod = await client.get(`/api/pods/${podId}`);
+  } catch {
+    log(
+      'warning: could not read pod visibility, so the public-pod sandbox check '
+      + 'was skipped. If this pod is public, attach with sandbox.trust=public.',
+    );
+    return;
+  }
+
+  const isPublic = Boolean(pod?.publicRead) || Boolean(pod?.communityListed);
+  if (!isPublic) return;
+
+  const label = pod?.name ? `"${pod.name}"` : podId;
+  throw new Error(
+    `${label} is publicly readable, so this agent would take instructions from `
+    + 'people you do not control — but its environment declares no sandbox, and '
+    + 'an undeclared sandbox means NO sandbox.\n\n'
+    + 'Add a sandbox block to the environment file and retry:\n\n'
+    + '  "sandbox": { "trust": "public", "mode": "read-only" }\n\n'
+    + 'Modes for a public agent: "read-only" or "workspace" (macOS Seatbelt / '
+    + 'Linux bwrap). To attach an agent to a private pod instead, pass that '
+    + 'pod id.',
+  );
+};
+
 // ── attach: register a local-CLI-wrapped agent (ADR-005) ────────────────────
 
 /**
@@ -287,6 +349,14 @@ export const performAttach = async ({
       log(`environment: applied default with @commonlyai/mcp wired (pass --env to override)`);
     }
   }
+
+  // Deny-by-default has to mean "absent = refuse". Runs outside the branch
+  // above because the dangerous case is an agent attached with NO sandbox
+  // declaration at all — the branch that validates sandbox settings never
+  // executes for those, so the agent silently ran unsandboxed.
+  await assertSandboxDeclaredForPublicPod({
+    client, podId, environment, log,
+  });
 
   // Identity-bearing runtime tag from the adapter (e.g. 'codex', 'claude-
   // code'). Falls back to adapter.name for adapters that haven't been


### PR DESCRIPTION
Closes #771.

Deny-by-default only means something if **absent is refused**. It wasn't.

`sandbox.mode` defaults to `'none'`, and nothing connected *"this pod is public"* to *"this agent must be confined"* — so an agent attached with no sandbox block ran unconfined, silently. `hq-support` ran that way in a 67-member public pod until yesterday; its permission deny-list was doing the file-blocking work while the OS sandbox never engaged.

Attach now reads the target pod and refuses when it's `publicRead`/`communityListed` with no enforced sandbox. **The check runs outside the `if (envPath)` branch** — the dangerous case is an agent with no environment file at all, for which that branch never executed.

Unreadable pod → proceeds with a warning. Failing attach on an unrelated network fault would be its own footgun, but a *silent* skip is how the original hole stayed invisible.

9 new tests including the exact hq-support shape (env with mcp/skills, no `sandbox` key). CLI suite green.