### PR TITLE
fix(v2): make pod labels say what the code does (#770)

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -853,8 +853,8 @@
     },
     "errors": {
       "couldNotAddLink": "Could not add link.",
-      "privatePodNotOpened": "Private pod could not be opened.",
-      "privatePodNotOpenedForAgent": "Private pod could not be opened for this agent."
+      "privatePodNotOpened": "The 1:1 with this agent could not be opened.",
+      "privatePodNotOpenedForAgent": "A 1:1 could not be opened for this agent."
     },
     "preview": {
       "loading": "Loading…",
@@ -1269,7 +1269,7 @@
     "filters": {
       "all": "All",
       "team": "Team",
-      "private": "Private",
+      "private": "DMs",
       "community": "Community"
     },
     "communityViews": {
@@ -1283,10 +1283,10 @@
       "betweenAgents": "Between agents · {{count}}"
     },
     "create": {
-      "teamOption": "Team Pod",
-      "teamDescription": "Anyone can find and join if listed.",
-      "privateOption": "Private Pod",
-      "privateDescription": "Invite-only — you add people.",
+      "teamOption": "Open to join",
+      "teamDescription": "Anyone can join if this pod is listed in Community.",
+      "privateOption": "Invite-only",
+      "privateDescription": "Only people you invite can join.",
       "namePlaceholder": "Pod name",
       "goalPlaceholder": "Goal or description",
       "cancel": "Cancel",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -850,8 +850,8 @@
     },
     "errors": {
       "couldNotAddLink": "无法添加链接。",
-      "privatePodNotOpened": "无法打开私有 Pod。",
-      "privatePodNotOpenedForAgent": "无法为该智能体打开私有 Pod。"
+      "privatePodNotOpened": "无法打开与该智能体的一对一对话。",
+      "privatePodNotOpenedForAgent": "无法为该智能体打开一对一对话。"
     },
     "preview": {
       "loading": "加载中…",
@@ -1265,7 +1265,7 @@
     "filters": {
       "all": "全部",
       "team": "团队",
-      "private": "私密",
+      "private": "私信",
       "community": "社区"
     },
     "communityViews": {
@@ -1279,10 +1279,10 @@
       "betweenAgents": "智能体之间 · {{count}}"
     },
     "create": {
-      "teamOption": "团队 Pod",
-      "teamDescription": "列入「发现」后，任何人都可以找到并加入。",
-      "privateOption": "私密 Pod",
-      "privateDescription": "仅限受邀，由你添加成员。",
+      "teamOption": "开放加入",
+      "teamDescription": "列入「社区」后，任何人都可以加入。",
+      "privateOption": "仅限邀请",
+      "privateDescription": "只有你邀请的人才能加入。",
       "namePlaceholder": "Pod 名称",
       "goalPlaceholder": "目标或描述",
       "cancel": "取消",

--- a/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
@@ -89,12 +89,12 @@ describe('V2PodsSidebar create flow', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'New Pod' }));
-    expect(screen.getByRole('button', { name: /Team Pod/ })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByText('Anyone can find and join if listed.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Open to join/ })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('Anyone can join if this pod is listed in Community.')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Private Pod/ }));
-    expect(screen.getByRole('button', { name: /Private Pod/ })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByText('Invite-only — you add people.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Invite-only/ }));
+    expect(screen.getByRole('button', { name: /Invite-only/ })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('Only people you invite can join.')).toBeInTheDocument();
     fireEvent.change(screen.getByPlaceholderText('Pod name'), {
       target: { value: 'Launch circle' },
     });
@@ -134,8 +134,8 @@ describe('V2PodsSidebar create flow', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '新建 Pod' }));
 
-    expect(screen.getByText('列入「发现」后，任何人都可以找到并加入。')).toBeInTheDocument();
-    expect(screen.getByText('仅限受邀，由你添加成员。')).toBeInTheDocument();
+    expect(screen.getByText('列入「社区」后，任何人都可以加入。')).toBeInTheDocument();
+    expect(screen.getByText('只有你邀请的人才能加入。')).toBeInTheDocument();
 
   });
 });

--- a/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
@@ -134,7 +134,9 @@ describe('V2PodsSidebar create flow', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '新建 Pod' }));
 
+    expect(screen.getByRole('button', { name: /开放加入/ })).toBeInTheDocument();
     expect(screen.getByText('列入「社区」后，任何人都可以加入。')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /仅限邀请/ })).toBeInTheDocument();
     expect(screen.getByText('只有你邀请的人才能加入。')).toBeInTheDocument();
 
   });

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -1039,7 +1039,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
 
   if (!pod) return <aside className="v2-pane v2-pane--inspector" />;
 
-  const isPrivatePod = pod.type === 'agent-room';
+  const isAgentRoom = pod.type === 'agent-room';
   const humanCount = humanMembers.length;
   const agentCount = agents.length;
   const created = pod.createdAt ? new Date(pod.createdAt).toLocaleDateString([], {
@@ -1294,7 +1294,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
     </section>
   );
 
-  const membersSection = !isPrivatePod && (
+  const membersSection = !isAgentRoom && (
     <section className="v2-inspector__section v2-inspector__section--quiet">
       <div className="v2-inspector__members-actions">
         {onOpenInvite && (
@@ -1658,7 +1658,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
                   {t('inspector.createdByMeta', { name: createdByDisplay, date: created })}
                 </div>
                 <div className="v2-inspector__pod-meta">
-                  {!isPrivatePod && <>{t('inspector.agentCount', { count: agentCount })} · </>}{t('inspector.humanCount', { count: humanCount })}
+                  {!isAgentRoom && <>{t('inspector.agentCount', { count: agentCount })} · </>}{t('inspector.humanCount', { count: humanCount })}
                 </div>
               </div>
             </div>
@@ -1694,7 +1694,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
                 >
                   {t('inspector.tabs.overview')}
                 </button>
-                {!isPrivatePod && (
+                {!isAgentRoom && (
                   <button
                     type="button"
                     role="tab"

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -22,7 +22,7 @@ const FILTERS: Array<{ key: Filter; labelKey: string }> = [
 const COMMUNITY_VIEWS: CommunityView[] = ['joined', 'discover'];
 
 // Both agent-room (user↔agent) and agent-dm (any 2-member combo) show
-// up under the Private filter. agent-dm with two bot members gets a
+// up under the DMs filter. agent-dm with two bot members gets a
 // distinct icon ("AA" — agent ↔ agent) so users can tell at a glance
 // that no human is in the conversation.
 const isDmPod = (pod: V2Pod): boolean => pod.type === 'agent-room' || pod.type === 'agent-dm';
@@ -71,7 +71,7 @@ const podSnippetFor = (pod: V2Pod, meta: string): string => {
 const matchesPersonalFilter = (pod: V2Pod, filter: Filter): boolean => {
   switch (filter) {
     // "Team" is the strictest pod-type filter — only pods explicitly typed
-    // as team (multi-human collaborative). "Private" is 1:1 DMs.
+    // as team (multi-human collaborative). "DMs" is 1:1 conversations.
     // "All" covers everything (the redundant "Pod" filter was removed).
     case 'team': return pod.type === 'team';
     case 'private': return podKind(pod) === 'private';
@@ -359,7 +359,7 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
     : error;
 
   // Default grouping is chronological (Pinned / Today / Yesterday / This week
-  // / Earlier). When the user filters down to Private, recency buckets stop
+  // / Earlier). When the user filters down to DMs, recency buckets stop
   // adding signal — DMs are already a tight list — and the meaningful split
   // is human↔agent vs agent↔agent. Bot-bot rooms are observer-only (§3.7),
   // so a section header makes the relationship explicit at a glance and


### PR DESCRIPTION
First slice of #770, per the sprint direction: **label accuracy only** — make the words true for what the code does today. The richer creation modal is deliberately NOT built here; that needs the #768/ADR-016 model decision first, and a proposal is going to the pod separately.

## What "Private" meant before this PR

| Surface | Label | What it actually is |
|---|---|---|
| Creation card | "Private Pod" | An invite-only `type:'team'` pod — same kind as "Team Pod", only `joinPolicy` differs |
| Sidebar filter | "Private" | 1:1 DMs (`agent-room` + `agent-dm`) |
| Inspector errors | "Private pod" | An `agent-room` (your 1:1 with an agent) |

## Changes (strings + comments only, no behavior)

- **Creation card**: "Team Pod" → **"Open to join"** ("Anyone can join if this pod is listed in Community." — the actual `joinPod` rule: `communityListed && joinPolicy !== 'invite-only'`), "Private Pod" → **"Invite-only"** ("Only people you invite can join."). The old pair implied two pod kinds; the choice sets exactly one field, `joinPolicy`.
- **Sidebar filter**: "Private" → **"DMs"** — consistent with the existing "Direct messages" group header inside that same filter.
- **Inspector**: error strings now say "1:1 with this agent"; `isPrivatePod` → `isAgentRoom` (mechanical rename, 4 sites).
- **zh-CN** updated to the same meanings (私密 → 私信 for the filter, 团队/私密 Pod → 开放加入/仅限邀请).

## Deliberately not touched

- The **"Team" filter still excludes My Workspace** (`type:'chat'`) — whether workspace belongs under Team is a model question for #768/ADR-016, not a label fix.
- The v1 `PodRedirect.tsx` "Team Pods" button (legacy surface).
- "Open to join" copy stays truthful whether or not #772 lands: joining an open pod requires a Community listing either way; #772 just makes listing settable.

## Tests

- Updated `V2PodsSidebarCreate.test.tsx` assertions (en + zh catalogs).
- Full v2 suite: **26 suites / 119 tests pass**.

Closes nothing — #770 stays open for the modal proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)