### PR TITLE
fix(pods): add the communityListed writer and align the join gate (#772)

### DIFF
--- a/backend/__tests__/service/pods.community-listing.test.js
+++ b/backend/__tests__/service/pods.community-listing.test.js
@@ -1,0 +1,224 @@
+/**
+ * #772 — the community-listing writer.
+ *
+ * `communityListed` gates both discovery scopes and the direct-join path, but
+ * had no HTTP writer: only a seed script or a hand-written Mongo write could
+ * set it. These tests cover the new admin endpoint AND the invariant it exists
+ * to protect — listed ⇒ readable — including the cascade from the sibling
+ * showcase toggle, which could otherwise re-create the broken state.
+ *
+ * Service tier (real Mongo) rather than unit: the whole point is the persisted
+ * state transition and the interaction between two endpoints plus the join
+ * gate. Mocking the model away would test nothing that matters here.
+ */
+process.env.PG_HOST = '';
+process.env.JWT_SECRET = 'community-listing-test-secret';
+
+jest.mock('jsonwebtoken', () => ({
+  sign: ({ id }) => `test-token:${id}`,
+  verify: (token) => ({ id: token.replace('test-token:', '') }),
+}));
+
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const request = require('supertest');
+const Pod = require('../../models/Pod');
+const User = require('../../models/User');
+const AuditLog = require('../../models/AuditLog');
+const adminPodRoutes = require('../../routes/admin/pods');
+const podRoutes = require('../../routes/pods');
+const {
+  setupMongoDb,
+  closeMongoDb,
+  clearMongoDb,
+} = require('../utils/testUtils');
+
+describe('POST /api/admin/pods/:podId/listing', () => {
+  let app;
+  let admin;
+  let owner;
+  let viewer;
+  let adminToken;
+  let viewerToken;
+
+  beforeAll(async () => {
+    await setupMongoDb();
+    app = express();
+    app.use(express.json());
+    app.use('/api/admin/pods', adminPodRoutes);
+    app.use('/api/pods', podRoutes);
+  });
+
+  beforeEach(async () => {
+    await clearMongoDb();
+    admin = await User.create({
+      username: `listing-admin-${Date.now()}`,
+      email: `listing-admin-${Date.now()}@test.com`,
+      password: 'Password123!',
+      verified: true,
+      role: 'admin',
+    });
+    owner = await User.create({
+      username: `listing-owner-${Date.now()}`,
+      email: `listing-owner-${Date.now()}@test.com`,
+      password: 'Password123!',
+      verified: true,
+    });
+    viewer = await User.create({
+      username: `listing-viewer-${Date.now()}`,
+      email: `listing-viewer-${Date.now()}@test.com`,
+      password: 'Password123!',
+      verified: true,
+    });
+    adminToken = jwt.sign({ id: admin._id }, process.env.JWT_SECRET);
+    viewerToken = jwt.sign({ id: viewer._id }, process.env.JWT_SECRET);
+  });
+
+  afterAll(async () => {
+    await clearMongoDb();
+    await closeMongoDb();
+  });
+
+  const createPod = (overrides = {}) => Pod.create({
+    name: `Listing test ${Math.random()}`,
+    type: 'team',
+    createdBy: owner._id,
+    members: [owner._id],
+    publicRead: false,
+    communityListed: false,
+    joinPolicy: 'open',
+    ...overrides,
+  });
+
+  const setListing = (podId, communityListed, token = adminToken) => request(app)
+    .post(`/api/admin/pods/${podId}/listing`)
+    .set('Authorization', `Bearer ${token}`)
+    .send({ communityListed });
+
+  const setShowcase = (podId, publicRead, token = adminToken) => request(app)
+    .post(`/api/admin/pods/${podId}/showcase`)
+    .set('Authorization', `Bearer ${token}`)
+    .send({ publicRead });
+
+  it('lists a publicRead pod to Community', async () => {
+    const pod = await createPod({ publicRead: true });
+
+    const res = await setListing(pod._id, true).expect(200);
+
+    expect(res.body).toMatchObject({ publicRead: true, communityListed: true });
+    const fresh = await Pod.findById(pod._id).lean();
+    expect(fresh.communityListed).toBe(true);
+  });
+
+  it('refuses to list a pod that is not publicRead, and leaves it untouched', async () => {
+    const pod = await createPod({ publicRead: false });
+
+    const res = await setListing(pod._id, true).expect(409);
+
+    expect(res.body.code).toBe('listing_requires_public_read');
+    const fresh = await Pod.findById(pod._id).lean();
+    expect(fresh.communityListed).toBe(false);
+  });
+
+  it('always allows unlisting, including on a pod that is not publicRead', async () => {
+    // Reachable on legacy rows written by the seed script before this endpoint
+    // existed — unlisting must never be blocked by the publish precondition.
+    const pod = await createPod({ publicRead: false, communityListed: true });
+
+    await setListing(pod._id, false).expect(200);
+
+    const fresh = await Pod.findById(pod._id).lean();
+    expect(fresh.communityListed).toBe(false);
+  });
+
+  it('rejects personal pod types', async () => {
+    const pod = await createPod({ type: 'agent-dm', publicRead: true });
+
+    const res = await setListing(pod._id, true).expect(400);
+
+    expect(res.body.error).toMatch(/personal pod type/i);
+    const fresh = await Pod.findById(pod._id).lean();
+    expect(fresh.communityListed).toBe(false);
+  });
+
+  it('requires a boolean body and a real pod', async () => {
+    const pod = await createPod({ publicRead: true });
+
+    await request(app)
+      .post(`/api/admin/pods/${pod._id}/listing`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ communityListed: 'yes' })
+      .expect(400);
+
+    await setListing('507f1f77bcf86cd799439011', true).expect(404);
+  });
+
+  it('refuses a non-admin caller', async () => {
+    const pod = await createPod({ publicRead: true });
+
+    await setListing(pod._id, true, viewerToken).expect(403);
+
+    const fresh = await Pod.findById(pod._id).lean();
+    expect(fresh.communityListed).toBe(false);
+  });
+
+  it('audits the listing change', async () => {
+    const pod = await createPod({ publicRead: true });
+
+    await setListing(pod._id, true).expect(200);
+
+    const entry = await AuditLog.findOne({ action: 'community.list' }).lean();
+    expect(entry.target).toBe(String(pod._id));
+    expect(String(entry.userId)).toBe(String(admin._id));
+  });
+
+  describe('the listed ⇒ readable invariant', () => {
+    it('cascades an unlist when the showcase toggle unpublishes a listed pod', async () => {
+      const pod = await createPod({ publicRead: true, communityListed: true });
+
+      const res = await setShowcase(pod._id, false).expect(200);
+
+      expect(res.body).toMatchObject({ publicRead: false, communityListed: false });
+      const fresh = await Pod.findById(pod._id).lean();
+      expect(fresh.communityListed).toBe(false);
+    });
+
+    it('leaves an unlisted pod alone when unpublishing', async () => {
+      const pod = await createPod({ publicRead: true, communityListed: false });
+
+      await setShowcase(pod._id, false).expect(200);
+
+      const fresh = await Pod.findById(pod._id).lean();
+      expect(fresh.communityListed).toBe(false);
+      expect(fresh.publicRead).toBe(false);
+    });
+  });
+
+  describe('end to end: listing is what unblocks joining', () => {
+    const join = (podId) => request(app)
+      .post(`/api/pods/${podId}/join`)
+      .set('Authorization', `Bearer ${viewerToken}`);
+
+    it('turns a refused join into an accepted one', async () => {
+      const pod = await createPod({ publicRead: true, joinPolicy: 'open' });
+
+      // The #772 starting state: open joinPolicy is a dormant bit.
+      await join(pod._id).expect(403);
+
+      await setListing(pod._id, true).expect(200);
+
+      await join(pod._id).expect(200);
+      const fresh = await Pod.findById(pod._id).lean();
+      expect(fresh.members.map(String)).toContain(String(viewer._id));
+    });
+
+    it('does not make an invite-only pod joinable', async () => {
+      const pod = await createPod({ publicRead: true, joinPolicy: 'invite-only' });
+
+      await setListing(pod._id, true).expect(200);
+
+      const res = await join(pod._id).expect(403);
+      expect(res.body.code).toBe('join_refused');
+    });
+  });
+});

--- a/backend/__tests__/service/pods.discover-join.test.js
+++ b/backend/__tests__/service/pods.discover-join.test.js
@@ -105,6 +105,20 @@ describe('POST /api/pods/:id/join discovery gate', () => {
     expect(fresh.members.map(String)).not.toContain(String(viewer._id));
   });
 
+  it('refuses direct self-join to a listed pod that is not publicRead (#772)', async () => {
+    // The join gate used to check `communityListed` alone while both discovery
+    // queries required `publicRead && communityListed` — so this pod was
+    // joinable by anyone holding its id, yet invisible on every discovery
+    // surface. You can only self-join what you could have found.
+    const pod = await createPod({ publicRead: false, communityListed: true });
+
+    const res = await join(pod._id).expect(403);
+
+    expect(res.body.code).toBe('join_refused');
+    const fresh = await Pod.findById(pod._id).lean();
+    expect(fresh.members.map(String)).not.toContain(String(viewer._id));
+  });
+
   it('returns 200 for an existing member even when the pod is not directly joinable', async () => {
     const pod = await createPod({
       communityListed: false,

--- a/backend/__tests__/unit/controllers/podController.test.js
+++ b/backend/__tests__/unit/controllers/podController.test.js
@@ -258,6 +258,10 @@ describe('podController', () => {
       ],
       createdBy: { toString: () => 'creator-id' },
       joinPolicy: 'open',
+      // Listed ⇒ readable (#772): the join gate now uses the same predicate as
+      // the discovery scopes, so `communityListed` without `publicRead` is not
+      // a joinable state — it was the invisible-but-joinable bug.
+      publicRead: true,
       communityListed: true,
     };
     Pod.findById

--- a/backend/controllers/podController.ts
+++ b/backend/controllers/podController.ts
@@ -8,6 +8,7 @@ const Integration = require('../models/Integration');
 const { AgentRegistry, AgentInstallation } = require('../models/AgentRegistry');
 const AgentProfile = require('../models/AgentProfile');
 const AgentIdentityService = require('../services/agentIdentityService');
+const { COMMUNITY_LISTING_QUERY, isDirectlyJoinable } = require('../services/podListing');
 const User = require('../models/User');
 // Add PGPod at the top level if it's available
 let PGPod: any;
@@ -178,8 +179,7 @@ exports.getAllPods = async (req: any, res: any) => {
     // membership listing below.
     const query = isDiscoverScope
       ? {
-        publicRead: true,
-        communityListed: true,
+        ...COMMUNITY_LISTING_QUERY,
         joinPolicy: { $ne: 'invite-only' },
         members: { $ne: scopedCallerId },
         type: type
@@ -190,8 +190,7 @@ exports.getAllPods = async (req: any, res: any) => {
       ? {
         // Listed is opt-in and distinct from readable: showcase rooms keep
         // publicRead for anonymous viewing without appearing in Community.
-        publicRead: true,
-        communityListed: true,
+        ...COMMUNITY_LISTING_QUERY,
         members: scopedCallerId,
         type: type
           ? { $eq: type, $nin: COMMUNITY_EXCLUDED_POD_TYPES }
@@ -492,7 +491,12 @@ exports.joinPod = async (req: any, res: any) => {
     // keeps optimistic clients and retried requests idempotent.
     if (!isMember) {
       const isAdmin = await isGlobalAdminRequest(req);
-      const isJoinable = pod.communityListed === true && pod.joinPolicy !== 'invite-only';
+      // Same predicate the discovery scopes query on (#772). Previously this
+      // checked `communityListed` alone, so a { publicRead: false,
+      // communityListed: true } pod was joinable by id while being invisible
+      // to every discovery surface. You can only self-join what you could
+      // have found.
+      const isJoinable = isDirectlyJoinable(pod);
       if (!isAdmin && !isJoinable) {
         return res.status(403).json({
           code: 'join_refused',

--- a/backend/models/Pod.ts
+++ b/backend/models/Pod.ts
@@ -68,6 +68,13 @@ export interface IPod extends Document {
   // the pod on the Community discovery surface. Showcase rooms (Eng Milestone
   // etc.) stay publicRead but unlisted. Listing is admin-curated for now; an
   // owner-side "request listing" flow is the planned phase 2 (Sam 2026-07-22).
+  //
+  // Written via POST /api/admin/pods/:podId/listing (routes/admin/pods.ts).
+  // INVARIANT (#772): listed ⇒ readable. `communityListed` is a strict
+  // refinement of `publicRead`, never independent of it — the listing route
+  // refuses to list a non-publicRead pod, and the showcase route cascades an
+  // unlist when it unpublishes. See services/podListing.ts for the predicate
+  // shared by the discovery queries and the join gate.
   communityListed: boolean;
   createdAt: Date;
   updatedAt: Date;

--- a/backend/routes/admin/pods.ts
+++ b/backend/routes/admin/pods.ts
@@ -66,6 +66,16 @@ router.post(
       }
 
       pod.publicRead = publicRead;
+
+      // Preserve the listing invariant (#772): listed ⇒ readable. Unpublishing
+      // a listed pod must also unlist it, otherwise this route re-creates the
+      // exact { publicRead: false, communityListed: true } state the listing
+      // endpoint below refuses to produce.
+      const cascadeUnlisted = !publicRead && pod.communityListed === true;
+      if (cascadeUnlisted) {
+        pod.communityListed = false;
+      }
+
       await pod.save();
 
       // Audit the world-readable state change (security review F6): who/when/
@@ -74,7 +84,8 @@ router.post(
         await AuditLog.create({
           action: publicRead ? 'showcase.publish' : 'showcase.unpublish',
           target: pod._id.toString(),
-          detail: `publicRead=${publicRead} type=${pod.type}`,
+          detail: `publicRead=${publicRead} type=${pod.type}`
+            + (cascadeUnlisted ? ' communityListed=false (cascade)' : ''),
           userId: req.userId || req.user?.id,
           ip: req.ip,
           userAgent: req.headers?.['user-agent'],
@@ -83,9 +94,95 @@ router.post(
         console.warn('[admin/pods] audit log write failed (non-fatal):', (auditErr as Error).message);
       }
 
-      return res.json({ id: pod._id.toString(), publicRead: pod.publicRead });
+      return res.json({
+        id: pod._id.toString(),
+        publicRead: pod.publicRead,
+        communityListed: pod.communityListed === true,
+      });
     } catch (err) {
       console.error('[admin/pods] showcase toggle error:', (err as Error).message);
+      return res.status(500).json({ error: 'Server Error' });
+    }
+  },
+);
+
+// POST /api/admin/pods/:podId/listing  { communityListed: boolean }
+//
+// The missing writer (#772). `communityListed` gates both discovery scopes and
+// the direct-join path, but until now nothing could set it over HTTP — only
+// scripts/seed-community-pods.ts or a hand-written Mongo write. That made
+// `joinPolicy: 'open'` a dormant bit and blocked every community-growth path
+// at the data layer.
+//
+// Admin-only, matching the curation model already recorded on the schema
+// (models/Pod.ts): "Listing is admin-curated for now; an owner-side 'request
+// listing' flow is the planned phase 2 (Sam 2026-07-22)." ADR-016 may rename
+// the field and add the owner-side path; neither changes the need for a writer.
+//
+// ⚠️ Listing a pod puts it on the Community discovery surface AND makes it
+// directly self-joinable by any authenticated user (unless invite-only). It is
+// strictly more exposure than `publicRead` alone, which is why it requires
+// publicRead first.
+router.post(
+  '/:podId/listing',
+  adminPodsRateLimit,
+  auth,
+  adminAuth,
+  async (req: any, res: any) => {
+    try {
+      const { podId } = req.params;
+      const { communityListed } = req.body || {};
+      if (typeof communityListed !== 'boolean') {
+        return res.status(400).json({ error: 'communityListed (boolean) is required' });
+      }
+
+      const pod = await Pod.findById(podId);
+      if (!pod) {
+        return res.status(404).json({ error: 'Pod not found' });
+      }
+
+      if (PERSONAL_POD_TYPES.has(String(pod.type))) {
+        return res.status(400).json({
+          error: `Cannot list a personal pod type (${pod.type}) on the community surface`,
+        });
+      }
+
+      // The invariant: listed ⇒ readable. Refuse to create the
+      // joinable-but-invisible state rather than silently flipping publicRead
+      // on the admin's behalf — publishing a room world-readable is a
+      // deliberate, separately-audited act (see the showcase toggle above).
+      // Unlisting is always allowed.
+      if (communityListed && pod.publicRead !== true) {
+        return res.status(409).json({
+          error: 'Pod must be publicRead before it can be listed to Community. '
+            + 'Publish it via POST /api/admin/pods/:podId/showcase first.',
+          code: 'listing_requires_public_read',
+        });
+      }
+
+      pod.communityListed = communityListed;
+      await pod.save();
+
+      try {
+        await AuditLog.create({
+          action: communityListed ? 'community.list' : 'community.unlist',
+          target: pod._id.toString(),
+          detail: `communityListed=${communityListed} type=${pod.type} joinPolicy=${pod.joinPolicy}`,
+          userId: req.userId || req.user?.id,
+          ip: req.ip,
+          userAgent: req.headers?.['user-agent'],
+        });
+      } catch (auditErr) {
+        console.warn('[admin/pods] audit log write failed (non-fatal):', (auditErr as Error).message);
+      }
+
+      return res.json({
+        id: pod._id.toString(),
+        publicRead: pod.publicRead === true,
+        communityListed: pod.communityListed,
+      });
+    } catch (err) {
+      console.error('[admin/pods] listing toggle error:', (err as Error).message);
       return res.status(500).json({ error: 'Server Error' });
     }
   },

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -229,7 +229,7 @@ app.use('/api/agent-profile', require('./routes/agentProfile'));
 // Authed owner/admin-only agent memory index (private counterpart to the public
 // profile). Self-gates via auth middleware + owner/admin check inside the route.
 app.use('/api/agent-memory', require('./routes/agentMemoryView'));
-app.use('/api/admin/pods', adminPodsRoutes); // Admin pod ops (showcase toggle)
+app.use('/api/admin/pods', adminPodsRoutes); // Admin pod ops (showcase + community-listing toggles)
 app.use('/api/pods', agentEnsembleRoutes); // Agent Ensemble Pod endpoints
 
 // Test routes (development only)

--- a/backend/services/podListing.ts
+++ b/backend/services/podListing.ts
@@ -1,0 +1,76 @@
+/**
+ * Community listing + direct-join eligibility — single source of truth.
+ *
+ * THE INVARIANT (#772): `communityListed` is a strict REFINEMENT of
+ * `publicRead`. Listed ⇒ readable. A `{ publicRead: false,
+ * communityListed: true }` pod is not a supported state; before this module
+ * existed it was reachable, and it meant "joinable but invisible" — the join
+ * gate checked `communityListed` alone while both discovery queries required
+ * `publicRead && communityListed`. Anyone holding the pod id could walk into
+ * a room that no discovery surface would ever show them.
+ *
+ * The two call sites (discovery query in podController.listPods, in-memory
+ * check in podController.joinPod) now derive from the same predicate, so they
+ * cannot drift apart again. If you add a third surface, use these helpers
+ * rather than open-coding the flag check.
+ *
+ * Why narrow rather than widen: making listing work WITHOUT `publicRead` is
+ * defensible (the community scope is authenticated-only), but it widens who
+ * can enter a room. That is a pod-model decision for ADR-016, not something a
+ * missing-writer bugfix should smuggle in. Narrowing is the safe direction on
+ * a privacy gate.
+ */
+
+// Personal / DM pod types. These are never listable, never joinable by a
+// third party, and never publishable — a 1:1 room is private by definition.
+// NOTE: the same three values also live in podController
+// (COMMUNITY_EXCLUDED_POD_TYPES), routes/admin/pods (PERSONAL_POD_TYPES) and
+// agentIdentityService (DM_POD_TYPES_GUARD). Consolidating those is a
+// separate concern from this fix; see #772 discussion.
+export const NON_LISTABLE_POD_TYPES: readonly string[] = [
+  'agent-room',
+  'agent-dm',
+  'agent-admin',
+];
+
+export interface ListingFlags {
+  type?: string;
+  publicRead?: boolean;
+  communityListed?: boolean;
+  joinPolicy?: string;
+}
+
+/** A pod type that may appear on the community surface at all. */
+export function isListablePodType(type: unknown): boolean {
+  return !NON_LISTABLE_POD_TYPES.includes(String(type));
+}
+
+/**
+ * The listing predicate shared by both discovery scopes. Expressed as a Mongo
+ * query fragment so `listPods` and the eligibility check below cannot diverge.
+ */
+export const COMMUNITY_LISTING_QUERY = Object.freeze({
+  publicRead: true,
+  communityListed: true,
+});
+
+/** Is this pod on the community discovery surface? */
+export function isCommunityListed(pod: ListingFlags | null | undefined): boolean {
+  if (!pod) return false;
+  return isListablePodType(pod.type)
+    && pod.publicRead === true
+    && pod.communityListed === true;
+}
+
+/**
+ * May a non-member walk into this pod directly (no invite, no admin bypass)?
+ *
+ * Deliberately the discovery predicate PLUS the join policy: you can only
+ * self-join something you could have found. Invite redemption
+ * (routes/podInvites) remains the separate, intentional rail into an
+ * invite-only pod and is unaffected.
+ */
+export function isDirectlyJoinable(pod: ListingFlags | null | undefined): boolean {
+  if (!pod) return false;
+  return isCommunityListed(pod) && pod.joinPolicy !== 'invite-only';
+}


### PR DESCRIPTION
Closes #772.

## The bug

`communityListed` gates both discovery scopes and the direct-join path, but nothing could set it over HTTP — not the owner, not an admin. Only `scripts/seed-community-pods.ts` or a hand-written Mongo write. `joinPolicy: 'open'` was a dormant bit and every community-growth path was blocked at the data layer.

## The writer

`POST /api/admin/pods/:podId/listing { communityListed: boolean }` — admin-only, rate-limited, audited, sibling to the existing showcase toggle.

Admin-only isn't me pre-empting ADR-016. `models/Pod.ts` already records the call: *"Listing is admin-curated for now; an owner-side 'request listing' flow is the planned phase 2 (Sam 2026-07-22)."* This implements that. ADR-016 can still rename the field and add the owner-side path — neither removes the need for a writer, which is why this didn't wait on it.

## The contradiction

The issue flags it: join gated on `communityListed` alone while both discovery queries require `publicRead && communityListed`. So `{publicRead: false, communityListed: true}` was **joinable by anyone holding the pod id, yet invisible on every discovery surface**.

**The rule: `communityListed` is a strict refinement of `publicRead`. Listed ⇒ readable.** Both call sites now derive from one predicate in `services/podListing.ts`, so they can't drift apart again.

I chose to **narrow** rather than widen. Making listing work without `publicRead` is defensible — the community scope is authenticated-only, so listing-without-world-readable is a coherent thing to want. But it widens who can walk into a room, and that's a pod-model decision for ADR-016, not something a missing-writer bugfix should smuggle in. Narrowing is the safe direction on a privacy gate. **If you want them decoupled, say so and I'll do it as its own change with its own argument.**

## Two things beyond the issue text

1. **The showcase toggle could re-create the broken state.** It sets `publicRead: false` without touching `communityListed`. Closing the hole while leaving the thing that reopens it isn't a fix, so unpublishing now cascades an unlist.
2. **Listing a non-`publicRead` pod returns 409, not an auto-publish.** Flipping a room world-readable is a deliberate, separately-audited act — the endpoint shouldn't do it as a side effect. Unlisting is always allowed, so legacy seed-script rows stay cleanable.

## Tests

Service tier (real Mongo) — the point is the persisted state transition and the interaction between two endpoints plus the join gate; mocking the model away would test nothing that matters. 19 passing across the new suite and the existing join suite:

- endpoint: happy path, 409 precondition, unlist-always-allowed, personal-type rejection, body validation, 404, non-admin 403, audit write
- the invariant: unpublish cascades an unlist; unlisted pods unaffected
- end-to-end: listing turns a refused join into an accepted one — and does **not** make an invite-only pod joinable
- regression in `pods.discover-join.test.js`: the listed-but-not-`publicRead` pod is now refused

One unit fixture in `podController.test.js` asserted a joinable `communityListed`-without-`publicRead` pod. It now sets both — that state is no longer reachable. (It surfaced as two failures, not one: when the gate refuses early, the test's queued `mockReturnValueOnce` goes unconsumed and `clearAllMocks` doesn't drain the once-queue, so it leaked into a later `getPodById` test. Fixing the fixture fixes both.)

## Notes for the reviewer

- Verified `npx tsc --noEmit` clean for every file I touched. 8 suites fail to run repo-wide on a `jsonwebtoken`/`buffer-equal-constant-time` prototype error — **confirmed pre-existing on clean `main`**, environmental, not from this branch.
- `NON_LISTABLE_POD_TYPES` is now the *fourth* copy of the same three pod-type strings (`COMMUNITY_EXCLUDED_POD_TYPES`, `PERSONAL_POD_TYPES`, `DM_POD_TYPES_GUARD`). Consolidating them is real cleanup but a different concern — left alone to keep this PR to one.
- No frontend surface for the toggle yet; this is the API layer #772 asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)