### PR TITLE
feat(agents): connect network primitives end to end

### DIFF
--- a/backend/__tests__/service/agentsRuntime.crossAgent.test.js
+++ b/backend/__tests__/service/agentsRuntime.crossAgent.test.js
@@ -167,6 +167,7 @@ describe('Cross-agent HTTP routes (ADR-003 Phase 4)', () => {
         .set('Authorization', `Bearer ${aliceToken}`);
 
       expect(res.status).toBe(200);
+      expect(res.headers).toHaveProperty('ratelimit-policy');
       expect(res.body.pods.map((candidate) => candidate.podId))
         .not.toContain(privateRoom._id.toString());
     });
@@ -190,6 +191,7 @@ describe('Cross-agent HTTP routes (ADR-003 Phase 4)', () => {
         .send({});
 
       expect(res.status).toBe(403);
+      expect(res.headers).toHaveProperty('ratelimit-policy');
       expect(res.body.message).toMatch(/invite-only/i);
     });
 

--- a/backend/__tests__/service/agentsRuntime.crossAgent.test.js
+++ b/backend/__tests__/service/agentsRuntime.crossAgent.test.js
@@ -133,6 +133,90 @@ describe('Cross-agent HTTP routes (ADR-003 Phase 4)', () => {
     bobToken = await installAndIssueToken('bob');
   });
 
+  describe('agent pod network routes', () => {
+    it('creates a team pod through the runtime route', async () => {
+      const res = await request(app)
+        .post('/api/agents/runtime/pods')
+        .set('Authorization', `Bearer ${aliceToken}`)
+        .send({
+          name: `Agent Sub-pod ${Date.now()}`,
+          description: 'Created by a collaborating agent',
+          type: 'team',
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.type).toBe('team');
+      expect(res.body.members.map((member) => String(member._id || member)))
+        .toContain(String(res.body.createdBy._id || res.body.createdBy));
+    });
+
+    it('does not expose 1:1 agent rooms through pod discovery', async () => {
+      const aliceUser = await User.findOne({
+        isBot: true,
+        'botMetadata.agentName': 'alice',
+      });
+      const privateRoom = await Pod.create({
+        name: `Private Agent Room ${Date.now()}`,
+        type: 'agent-room',
+        createdBy: adminUser._id,
+        members: [adminUser._id, aliceUser._id],
+      });
+
+      const res = await request(app)
+        .get('/api/agents/runtime/pods')
+        .set('Authorization', `Bearer ${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.pods.map((candidate) => candidate.podId))
+        .not.toContain(privateRoom._id.toString());
+    });
+
+    it('refuses self-install into an invite-only agent-owned pod', async () => {
+      const aliceUser = await User.findOne({
+        isBot: true,
+        'botMetadata.agentName': 'alice',
+      });
+      const inviteOnlyPod = await Pod.create({
+        name: `Invite-only Agent Pod ${Date.now()}`,
+        type: 'team',
+        joinPolicy: 'invite-only',
+        createdBy: aliceUser._id,
+        members: [aliceUser._id],
+      });
+
+      const res = await request(app)
+        .post(`/api/agents/runtime/pods/${inviteOnlyPod._id}/self-install`)
+        .set('Authorization', `Bearer ${bobToken}`)
+        .send({});
+
+      expect(res.status).toBe(403);
+      expect(res.body.message).toMatch(/invite-only/i);
+    });
+
+    it('self-installs into an open agent-owned pod', async () => {
+      const aliceUser = await User.findOne({
+        isBot: true,
+        'botMetadata.agentName': 'alice',
+      });
+      const openPod = await Pod.create({
+        name: `Open Agent Pod ${Date.now()}`,
+        type: 'team',
+        joinPolicy: 'open',
+        createdBy: aliceUser._id,
+        members: [aliceUser._id],
+      });
+
+      const res = await request(app)
+        .post(`/api/agents/runtime/pods/${openPod._id}/self-install`)
+        .set('Authorization', `Bearer ${bobToken}`)
+        .send({});
+
+      expect(res.status).toBe(201);
+      expect(res.body.podId).toBe(openPod._id.toString());
+      expect(await AgentInstallation.isInstalled('bob', openPod._id, 'default')).toBe(true);
+    });
+  });
+
   // ----------------------------------------------------------------------- //
   // GET /memory/shared                                                      //
   // ----------------------------------------------------------------------- //

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -2399,7 +2399,12 @@ async function ensureCommonlyBotInstalled(podId: any, installedBy: any) {
 router.get('/pods', agentRuntimeAuth, async (req: any, res: any) => {
   try {
     const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 20, 1), 50);
-    const pods = await Pod.find({ type: { $nin: ['dm', 'agent-admin'] } })
+    const nonDiscoverableTypes = [
+      'dm', // legacy rows
+      'agent-admin',
+      ...AgentIdentityService.DM_POD_TYPES_GUARD,
+    ];
+    const pods = await Pod.find({ type: { $nin: nonDiscoverableTypes } })
       .sort({ updatedAt: -1 })
       .limit(limit)
       .select('name description type members updatedAt')
@@ -2477,7 +2482,10 @@ router.post('/pods', phase4RateLimit, agentRuntimeAuth, async (req: any, res: an
       return res.status(400).json({ message: 'name and type are required' });
     }
 
-    const VALID_POD_TYPES = ['chat', 'study', 'games', 'agent-ensemble', 'agent-admin'];
+    // Keep parity with the Pod model and human creation route. `team` is the
+    // ordinary multi-human pod shape used by the v2 shell; excluding it here
+    // made agent-created sub-pods disappear from the Team filter.
+    const VALID_POD_TYPES = ['chat', 'study', 'games', 'agent-ensemble', 'agent-admin', 'team'];
     if (!VALID_POD_TYPES.includes(type)) {
       return res.status(400).json({ message: `Invalid pod type. Must be one of: ${VALID_POD_TYPES.join(', ')}` });
     }
@@ -2612,7 +2620,9 @@ router.post('/pods/:podId/self-install', agentRuntimeAuth, async (req: any, res:
     }
 
     const { podId } = req.params;
-    const pod = await Pod.findById(podId).select('_id name type createdBy members').lean();
+    const pod = await Pod.findById(podId)
+      .select('_id name type joinPolicy createdBy members')
+      .lean();
     if (!pod) {
       return res.status(404).json({ message: 'Pod not found' });
     }

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -2396,7 +2396,7 @@ async function ensureCommonlyBotInstalled(podId: any, installedBy: any) {
  * List public pods the agent can discover and join.
  * Returns pods ordered by recent activity, excluding DM pods.
  */
-router.get('/pods', agentRuntimeAuth, async (req: any, res: any) => {
+router.get('/pods', phase4RateLimit, agentRuntimeAuth, async (req: any, res: any) => {
   try {
     const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 20, 1), 50);
     const nonDiscoverableTypes = [
@@ -2612,7 +2612,7 @@ router.post('/pods', phase4RateLimit, agentRuntimeAuth, async (req: any, res: an
  * member list. This allows agents to join pods they (or other agents) created without waiting
  * for the 2-hour auto-join cron.
  */
-router.post('/pods/:podId/self-install', agentRuntimeAuth, async (req: any, res: any) => {
+router.post('/pods/:podId/self-install', phase4RateLimit, agentRuntimeAuth, async (req: any, res: any) => {
   try {
     const agentUser = req.agentUser;
     if (!agentUser) {

--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -463,6 +463,40 @@ describe('performRun', () => {
     );
   });
 
+  test('heartbeat control word with substantive output is not silently swallowed', async () => {
+    const events = [makeEvent({
+      _id: 'evt-hb-prefixed-update',
+      type: 'heartbeat',
+      payload: { content: 'Check for a decision that needs a human.' },
+    })];
+    const mockGet = jest.fn().mockResolvedValue({ events });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const content = 'HEARTBEAT_OK — nothing urgent, but the release owner still needs to choose a date';
+    const spawn = jest.fn(async () => ({ text: content }));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/pods/pod-abc/messages',
+      { content },
+    );
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-hb-prefixed-update/ack',
+      { result: { outcome: 'posted' } },
+    );
+  });
+
   test('manual heartbeat without content still runs with a safe fallback prompt', async () => {
     const events = [makeEvent({
       _id: 'evt-hb-manual',

--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -392,19 +392,17 @@ describe('performRun', () => {
     fs.rmSync(agentCwd, { recursive: true, force: true });
   });
 
-  test('heartbeat event with payload.content is suppressed — chat-only events spawn', async () => {
-    // Regression: a heartbeat with a stray `content` field must NOT trigger
-    // a spawn. Only PROMPT_EVENT_TYPES are forwarded to the CLI.
+  test('heartbeat event spawns the CLI but keeps HEARTBEAT_OK out of chat', async () => {
     const events = [makeEvent({
       _id: 'evt-hb',
       type: 'heartbeat',
-      payload: { content: 'do not spawn me' },
+      payload: { content: 'Run your heartbeat checklist.' },
     })];
     const mockGet = jest.fn().mockResolvedValue({ events });
     const mockPost = jest.fn().mockResolvedValue({});
     createClient.mockReturnValue({ get: mockGet, post: mockPost });
 
-    const spawn = jest.fn();
+    const spawn = jest.fn(async () => ({ text: 'HEARTBEAT_OK' }));
     const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
 
     const { stop } = performRun({
@@ -417,12 +415,212 @@ describe('performRun', () => {
     await drainMicrotasks();
     stop();
 
-    expect(spawn).not.toHaveBeenCalled();
+    expect(spawn).toHaveBeenCalledWith(
+      'Run your heartbeat checklist.',
+      expect.objectContaining({ metadata: { event: events[0] } }),
+    );
+    expect(mockPost).not.toHaveBeenCalledWith(
+      '/api/agents/runtime/pods/pod-abc/messages',
+      expect.anything(),
+    );
     expect(mockPost).toHaveBeenCalledWith(
       '/api/agents/runtime/events/evt-hb/ack',
       { result: { outcome: 'no_action' } },
     );
     expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  test('heartbeat event posts substantive output before acking', async () => {
+    const events = [makeEvent({
+      _id: 'evt-hb-update',
+      type: 'heartbeat',
+      payload: { content: 'Check for a decision that needs a human.' },
+    })];
+    const mockGet = jest.fn().mockResolvedValue({ events });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn(async () => ({ text: 'The release owner needs to choose a date.' }));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/pods/pod-abc/messages',
+      { content: 'The release owner needs to choose a date.' },
+    );
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-hb-update/ack',
+      { result: { outcome: 'posted' } },
+    );
+  });
+
+  test('manual heartbeat without content still runs with a safe fallback prompt', async () => {
+    const events = [makeEvent({
+      _id: 'evt-hb-manual',
+      type: 'heartbeat',
+      payload: { trigger: 'admin-manual' },
+    })];
+    const mockGet = jest.fn().mockResolvedValue({ events });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn(async () => ({ text: 'HEARTBEAT_NOOP' }));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn.mock.calls[0][0]).toContain('Heartbeat tick.');
+    expect(mockPost).not.toHaveBeenCalledWith(
+      '/api/agents/runtime/pods/pod-abc/messages',
+      expect.anything(),
+    );
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-hb-manual/ack',
+      { result: { outcome: 'no_action' } },
+    );
+  });
+
+  test('agent.ask routes the CLI final answer privately back to the requester', async () => {
+    const events = [makeEvent({
+      _id: 'evt-ask',
+      type: 'agent.ask',
+      payload: {
+        requestId: 'ask/123',
+        fromAgent: 'planner',
+        fromInstanceId: 'default',
+        question: 'What is the riskiest edge case?',
+      },
+    })];
+    const mockGet = jest.fn().mockResolvedValue({ events });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn(async () => ({ text: 'An expired request racing the response.' }));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn.mock.calls[0][0]).toContain('@planner asks:');
+    expect(spawn.mock.calls[0][0]).toContain('What is the riskiest edge case?');
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/asks/ask%2F123/respond',
+      { content: 'An expired request racing the response.' },
+    );
+    expect(mockPost).not.toHaveBeenCalledWith(
+      '/api/agents/runtime/pods/pod-abc/messages',
+      expect.anything(),
+    );
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-ask/ack',
+      { result: { outcome: 'posted' } },
+    );
+  });
+
+  test('agent.ask re-acks when the agent already responded through its MCP tool', async () => {
+    const events = [makeEvent({
+      _id: 'evt-ask-already-responded',
+      type: 'agent.ask',
+      payload: {
+        requestId: 'ask-responded',
+        fromAgent: 'planner',
+        question: 'Ready?',
+      },
+    })];
+    const mockGet = jest.fn().mockResolvedValue({ events });
+    const mockPost = jest.fn(async (route) => {
+      if (route.endsWith('/asks/ask-responded/respond')) {
+        const err = new Error('ask has already been responded to');
+        err.status = 409;
+        err.body = { code: 'already_responded' };
+        throw err;
+      }
+      return {};
+    });
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn(async () => ({ text: 'Yes.' }));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-ask-already-responded/ack',
+      { result: { outcome: 'posted' } },
+    );
+  });
+
+  test('agent.ask.response reaches the requester without forcing pod chat noise', async () => {
+    const events = [makeEvent({
+      _id: 'evt-ask-response',
+      type: 'agent.ask.response',
+      payload: {
+        requestId: 'ask-123',
+        fromAgent: 'reviewer',
+        fromInstanceId: 'opus',
+        question: 'What is the riskiest edge case?',
+        response: 'An expired request racing the response.',
+      },
+    })];
+    const mockGet = jest.fn().mockResolvedValue({ events });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn(async () => ({ text: 'NO_REPLY' }));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn.mock.calls[0][0]).toContain('@reviewer:opus answered:');
+    expect(spawn.mock.calls[0][0]).toContain('An expired request racing the response.');
+    expect(mockPost).not.toHaveBeenCalledWith(
+      '/api/agents/runtime/pods/pod-abc/messages',
+      expect.anything(),
+    );
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-ask-response/ack',
+      { result: { outcome: 'no_action' } },
+    );
   });
 
   test('chat event with no podId → no spawn, no message, acked as no_action', async () => {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "Apache-2.0",
   "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
   "type": "module",

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -107,9 +107,9 @@ export const listLocalAgents = () => {
     .filter(Boolean);
 };
 
-// Event types that carry a prompt the wrapper should forward to the CLI.
-// Other event types (heartbeat, delivery, etc.) are acked as no_action even
-// if they happen to carry `content` in their payload.
+// Chat event types whose payload already contains the prompt the wrapper
+// should forward verbatim. Heartbeat and consult events need event-specific
+// framing, so extractPrompt handles them separately below.
 const PROMPT_EVENT_TYPES = new Set([
   'chat.mention',
   'message.posted',
@@ -431,9 +431,48 @@ export const runMemoryImport = async ({
 // ── run: local-CLI wrapper loop (ADR-005) ────────────────────────────────────
 
 const extractPrompt = (event) => {
-  if (!PROMPT_EVENT_TYPES.has(event.type)) return null;
   const p = event.payload || {};
-  return p.content || p.prompt || p.text || null;
+  if (PROMPT_EVENT_TYPES.has(event.type)) {
+    return p.content || p.prompt || p.text || null;
+  }
+  if (event.type === 'heartbeat') {
+    return p.content || [
+      'Heartbeat tick.',
+      'Read your HEARTBEAT.md workspace file and follow it exactly.',
+      'HEARTBEAT_OK is a return value — never post it or any narration to pod chat.',
+    ].join('\n');
+  }
+  if (event.type === 'agent.ask') {
+    if (!p.requestId || !p.question) return null;
+    const sender = p.fromAgent
+      ? `@${p.fromAgent}${p.fromInstanceId && p.fromInstanceId !== 'default' ? `:${p.fromInstanceId}` : ''}`
+      : 'Another agent';
+    return [
+      '[Private agent consultation]',
+      `${sender} asks:`,
+      String(p.question),
+      '',
+      'Answer the agent directly, including a concise refusal if appropriate.',
+      'Your local wrapper will route your final response privately to the requester.',
+      'Do not call commonly_respond_to_ask and do not post the answer into pod chat.',
+    ].join('\n');
+  }
+  if (event.type === 'agent.ask.response') {
+    if (!p.response) return null;
+    const responder = p.fromAgent
+      ? `@${p.fromAgent}${p.fromInstanceId && p.fromInstanceId !== 'default' ? `:${p.fromInstanceId}` : ''}`
+      : 'The consulted agent';
+    return [
+      '[Private agent consultation response]',
+      ...(p.question ? [`Your question: ${String(p.question)}`] : []),
+      `${responder} answered:`,
+      String(p.response),
+      '',
+      'Use this answer to continue the work you were doing.',
+      'Only post a concise pod update if a human needs it; otherwise return NO_REPLY.',
+    ].join('\n');
+  }
+  return null;
 };
 
 /**
@@ -516,7 +555,11 @@ export const performRun = ({
         return null; // detection unavailable — fall back to posting the reply
       }
     };
-    const preSpawn = await snapshotMessages();
+    // A consult request's final output is routed to the ask-response endpoint,
+    // never echoed into the pod. It therefore does not need pod-message
+    // snapshotting (and cannot be detected through that channel anyway).
+    const shouldSnapshotMessages = event.type !== 'agent.ask';
+    const preSpawn = shouldSnapshotMessages ? await snapshotMessages() : null;
     const preSpawnIds = preSpawn
       ? new Set(preSpawn.map((m) => String(m._id || m.id)))
       : null;
@@ -584,8 +627,39 @@ export const performRun = ({
         }
       }
     }
-    if (!replyText || replyText === 'NO_REPLY') {
-      log(`[${event.type}] no wrapper-post (${replyText === 'NO_REPLY' ? 'NO_REPLY' : 'empty output'})`);
+    const heartbeatControlReply = event.type === 'heartbeat'
+      && /^(HEARTBEAT_OK|HEARTBEAT_NOOP)$/i.test(replyText);
+    const silentReply = !replyText || replyText === 'NO_REPLY' || heartbeatControlReply;
+    let delivered = agentPostedItself;
+
+    if (event.type === 'agent.ask') {
+      if (silentReply) {
+        const reason = heartbeatControlReply ? replyText : (replyText || 'empty output');
+        log(`[${event.type}] no private response (${reason})`);
+      } else {
+        try {
+          await client.post(
+            `/api/agents/runtime/asks/${encodeURIComponent(event.payload.requestId)}/respond`,
+            { content: replyText },
+          );
+          delivered = true;
+          log(`[${event.type}] routed private response (${Buffer.byteLength(replyText)} bytes)`);
+        } catch (err) {
+          // A tool-capable agent may have called commonly_respond_to_ask
+          // despite the wrapper instruction. Treat the kernel's idempotent
+          // "already responded" result as delivered rather than re-running
+          // the model forever.
+          if (err?.status === 409 && err?.body?.code === 'already_responded') {
+            delivered = true;
+            log(`[${event.type}] response already routed by agent tool`);
+          } else {
+            throw err;
+          }
+        }
+      }
+    } else if (silentReply) {
+      const reason = heartbeatControlReply ? replyText : (replyText || 'empty output');
+      log(`[${event.type}] no wrapper-post (${reason})`);
     } else if (agentPostedItself) {
       // Name the message that caused the suppression. A silently dropped reply
       // is invisible to everyone; #757 went unnoticed precisely because this
@@ -599,6 +673,7 @@ export const performRun = ({
       await client.post(`/api/agents/runtime/pods/${eventPodId}/messages`, {
         content: replyText,
       });
+      delivered = true;
       log(`[${event.type}] posted ${Buffer.byteLength(replyText)} bytes`);
     }
     if (result.memorySummary) {
@@ -613,7 +688,7 @@ export const performRun = ({
         onError?.(new Error(`memory sync failed: ${err.message}`, { cause: err }));
       }
     }
-    return { outcome: 'posted' };
+    return { outcome: delivered ? 'posted' : 'no_action' };
   };
 
   const tick = async () => {

--- a/commonly-mcp/README.md
+++ b/commonly-mcp/README.md
@@ -20,7 +20,7 @@ npx -y @commonlyai/mcp
 
 ```bash
 claude mcp add commonly \
-  -e COMMONLY_API_URL=https://api-dev.commonly.me \
+  -e COMMONLY_API_URL=https://api.commonly.me \
   -e COMMONLY_AGENT_TOKEN=cm_agent_xxx \
   -- npx -y @commonlyai/mcp
 ```
@@ -43,7 +43,7 @@ Add to `~/.cursor/mcp.json` or `.cursor/mcp.json`:
       "command": "npx",
       "args": ["-y", "@commonlyai/mcp"],
       "env": {
-        "COMMONLY_API_URL": "https://api-dev.commonly.me",
+        "COMMONLY_API_URL": "https://api.commonly.me",
         "COMMONLY_AGENT_TOKEN": "cm_agent_xxx"
       }
     }
@@ -53,11 +53,11 @@ Add to `~/.cursor/mcp.json` or `.cursor/mcp.json`:
 
 ## Tools
 
-19 `commonly_*` tools, grouped:
+26 `commonly_*` tools, grouped:
 
-- **Messaging** — `commonly_post_message`, `commonly_get_messages`, `commonly_get_context`, `commonly_get_posts`, `commonly_post_thread_comment`, `commonly_react_to_message`
+- **Messaging + files** — `commonly_post_message`, `commonly_get_messages`, `commonly_get_context`, `commonly_get_posts`, `commonly_post_thread_comment`, `commonly_react_to_message`, `commonly_list_files`, `commonly_read_file`, `commonly_attach_file`
 - **Tasks** — `commonly_get_tasks`, `commonly_create_task`, `commonly_claim_task`, `commonly_complete_task`, `commonly_update_task`
-- **Pods + DMs** — `commonly_create_pod`, `commonly_dm_agent`
+- **Pods + agent network** — `commonly_create_pod`, `commonly_list_pods`, `commonly_self_install_into_pod`, `commonly_dm_agent`, `commonly_ask_agent`, `commonly_respond_to_ask`
 - **Memory** — `commonly_read_agent_memory`, `commonly_write_agent_memory`, `commonly_save_my_memory`, `commonly_log_cycle`
 - **Code review** — `commonly_pr_diff`, `commonly_pr_review`
 

--- a/commonly-mcp/__tests__/client.test.mjs
+++ b/commonly-mcp/__tests__/client.test.mjs
@@ -8,10 +8,10 @@ import { loadConfig, request, HttpError } from '../src/client.js';
 describe('loadConfig', () => {
   it('parses a valid env', () => {
     const cfg = loadConfig({
-      COMMONLY_API_URL: 'https://api-dev.commonly.me/',
+      COMMONLY_API_URL: 'https://api.commonly.me/',
       COMMONLY_AGENT_TOKEN: 'cm_agent_abcdef',
     });
-    expect(cfg.baseUrl).toBe('https://api-dev.commonly.me'); // trailing slash stripped
+    expect(cfg.baseUrl).toBe('https://api.commonly.me'); // trailing slash stripped
     expect(cfg.token).toBe('cm_agent_abcdef');
   });
 

--- a/commonly-mcp/__tests__/tools.test.mjs
+++ b/commonly-mcp/__tests__/tools.test.mjs
@@ -15,7 +15,7 @@ const tools = buildTools(cfg);
 const byName = Object.fromEntries(tools.map((t) => [t.name, t]));
 
 describe('tool registry shape', () => {
-  it('ships exactly the v1 surface (21 tools)', () => {
+  it('ships the complete cross-driver tool surface', () => {
     // 14 tools (ADR-010 Phase 1) + 2 added in Phase 4 (commonly_save_my_memory,
     // commonly_log_cycle) so MCP-capable runtimes (Claude Code, Cursor, Codex
     // via wrapper) have the same memory write surface as the openclaw extension.
@@ -23,7 +23,8 @@ describe('tool registry shape', () => {
     // + 2 added for PR code review (commonly_pr_diff, commonly_pr_review, #441).
     // + 2 added for agent file access (commonly_list_files, commonly_read_file).
     // + 1 added for agent file upload (commonly_attach_file).
-    expect(tools).toHaveLength(22);
+    // + 4 network primitives (list pods, self-install, ask, respond; #773).
+    expect(tools).toHaveLength(26);
   });
 
   it('every tool has name, description, inputSchema, call', () => {
@@ -188,12 +189,31 @@ describe('commonly_get_tasks / create / claim / complete / update', () => {
 });
 
 describe('commonly_create_pod', () => {
-  it('POSTs to /pods with name + description', async () => {
+  it('POSTs to /pods with the required standard pod type', async () => {
     const fetchSpy = installFetch(async () => okResponse({ podId: 'P1' }));
     await byName.commonly_create_pod.call({ name: 'New', description: 'desc' });
     const [url, init] = fetchSpy.mock.calls[0];
     expect(url).toBe('https://x.example/api/agents/runtime/pods');
-    expect(JSON.parse(init.body)).toEqual({ name: 'New', description: 'desc' });
+    expect(JSON.parse(init.body)).toEqual({ name: 'New', description: 'desc', type: 'team' });
+  });
+});
+
+describe('pod discovery and self-install', () => {
+  it('list_pods GETs /pods with a limit', async () => {
+    const fetchSpy = installFetch(async () => okResponse({ pods: [] }));
+    await byName.commonly_list_pods.call({ limit: 12 });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://x.example/api/agents/runtime/pods?limit=12');
+    expect(init.method).toBe('GET');
+  });
+
+  it('self_install POSTs to the encoded pod path', async () => {
+    const fetchSpy = installFetch(async () => okResponse({ podId: 'P/1' }));
+    await byName.commonly_self_install_into_pod.call({ podId: 'P/1' });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://x.example/api/agents/runtime/pods/P%2F1/self-install');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({});
   });
 });
 
@@ -241,6 +261,42 @@ describe('commonly_dm_agent', () => {
     const result = await byName.commonly_dm_agent.call({ agentName: 'self' });
     expect(result.isError).toBe(true);
     expect(JSON.parse(result.content[0].text).message).toBe('Cannot DM yourself');
+  });
+});
+
+describe('cross-agent ask tools', () => {
+  it('ask_agent POSTs the consultation to the shared pod', async () => {
+    const fetchSpy = installFetch(async () => okResponse({
+      requestId: 'ask/1', expiresAt: '2026-07-29T00:00:00.000Z',
+    }));
+    await byName.commonly_ask_agent.call({
+      podId: 'P/1',
+      targetAgent: 'reviewer',
+      targetInstanceId: 'opus',
+      question: 'What did I miss?',
+      requestId: 'ask/1',
+    });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://x.example/api/agents/runtime/pods/P%2F1/ask');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({
+      targetAgent: 'reviewer',
+      targetInstanceId: 'opus',
+      question: 'What did I miss?',
+      requestId: 'ask/1',
+    });
+  });
+
+  it('respond_to_ask POSTs the private answer to the encoded request path', async () => {
+    const fetchSpy = installFetch(async () => okResponse({ ok: true }));
+    await byName.commonly_respond_to_ask.call({
+      requestId: 'ask/1',
+      content: 'Check the empty state.',
+    });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://x.example/api/agents/runtime/asks/ask%2F1/respond');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({ content: 'Check the empty state.' });
   });
 });
 

--- a/commonly-mcp/package.json
+++ b/commonly-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Commonly MCP Server \u2014 exposes the kernel HTTP surface (CAP per ADR-004) as standard MCP tools so any MCP-capable runtime can consume `commonly_*` tools without driver-specific code.",
   "type": "module",
   "bin": {

--- a/commonly-mcp/src/client.js
+++ b/commonly-mcp/src/client.js
@@ -13,7 +13,7 @@
  * `HttpError`. No global state beyond the env-derived config object.
  */
 
-const USER_AGENT = 'commonly-mcp/0.1.0';
+const USER_AGENT = 'commonly-mcp/0.1.8';
 
 export class HttpError extends Error {
   constructor(status, body, message) {
@@ -36,7 +36,7 @@ export const loadConfig = (env = process.env) => {
   const baseUrl = env.COMMONLY_API_URL;
   const token = env.COMMONLY_AGENT_TOKEN;
   if (!baseUrl) {
-    throw new Error('COMMONLY_API_URL is required (e.g. https://api-dev.commonly.me)');
+    throw new Error('COMMONLY_API_URL is required (e.g. https://api.commonly.me)');
   }
   if (!token) {
     throw new Error('COMMONLY_AGENT_TOKEN is required (cm_agent_* runtime token)');

--- a/commonly-mcp/src/index.js
+++ b/commonly-mcp/src/index.js
@@ -12,7 +12,7 @@
  * runtime token in `COMMONLY_AGENT_TOKEN`. See ADR-010 §Auth contract.
  *
  * Run:
- *   COMMONLY_API_URL=https://api-dev.commonly.me \
+ *   COMMONLY_API_URL=https://api.commonly.me \
  *   COMMONLY_AGENT_TOKEN=cm_agent_... \
  *   npx @commonlyai/mcp
  */
@@ -28,7 +28,7 @@ import { loadConfig } from './client.js';
 import { buildTools } from './tools.js';
 
 const PACKAGE_NAME = '@commonlyai/mcp';
-const PACKAGE_VERSION = '0.1.0';
+const PACKAGE_VERSION = '0.1.8';
 
 const main = async () => {
   // Fail fast on missing env. The MCP host (codex/claude) will surface this

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -256,7 +256,7 @@ export const buildTools = (config) => {
     },
     {
       name: 'commonly_create_pod',
-      description: 'Create or join a pod by name. Backend dedupes globally — same-name pods reuse the existing one and auto-join the caller.',
+      description: 'Create or join a standard team pod by name. Backend dedupes globally — same-name pods reuse the existing one and auto-join the caller.',
       inputSchema: reqWith({
         name: STRING,
         description: STRING,
@@ -264,7 +264,30 @@ export const buildTools = (config) => {
       call: wrap(async ({ name, description }) => request(config, {
         method: 'POST',
         path: '/api/agents/runtime/pods',
-        body: { name, description },
+        // The runtime route requires a pod type. Keep the agent-facing tool
+        // small and create the ordinary team shape; specialized pod types
+        // remain explicit admin/model decisions.
+        body: { name, description, type: 'team' },
+      })),
+    },
+    {
+      name: 'commonly_list_pods',
+      description: 'Discover pods this agent may be able to join. Returns recent pods with `isMember`, member counts, type, and `latestSummary`; `limit` is clamped server-side to [1, 50].',
+      inputSchema: required({ limit: INT }),
+      call: wrap(async ({ limit }) => request(config, {
+        method: 'GET',
+        path: '/api/agents/runtime/pods',
+        query: { limit },
+      })),
+    },
+    {
+      name: 'commonly_self_install_into_pod',
+      description: 'Install this agent into a discovered pod. Allowed only for agent-owned pods or pods where this agent is already a member; invite-only pods reject self-install.',
+      inputSchema: reqWith({ podId: STRING }, ['podId']),
+      call: wrap(async ({ podId }) => request(config, {
+        method: 'POST',
+        path: `/api/agents/runtime/pods/${encodeURIComponent(podId)}/self-install`,
+        body: {},
       })),
     },
     {
@@ -340,6 +363,39 @@ export const buildTools = (config) => {
       })),
     },
     {
+      name: 'commonly_ask_agent',
+      description: 'Ask another agent in the same pod a private, mediated question. Returns immediately with a `requestId`; the answer arrives later as an `agent.ask.response` runtime event. Use this for a focused consultation without adding intermediate chat noise.',
+      inputSchema: reqWith({
+        podId: STRING,
+        targetAgent: STRING,
+        targetInstanceId: STRING,
+        question: STRING,
+        requestId: STRING,
+      }, ['podId', 'targetAgent', 'question']),
+      call: wrap(async ({
+        podId, targetAgent, targetInstanceId, question, requestId,
+      }) => request(config, {
+        method: 'POST',
+        path: `/api/agents/runtime/pods/${encodeURIComponent(podId)}/ask`,
+        body: {
+          targetAgent, targetInstanceId, question, requestId,
+        },
+      })),
+    },
+    {
+      name: 'commonly_respond_to_ask',
+      description: 'Respond to an `agent.ask` runtime event using its `requestId`. Only the agent originally targeted by the ask may respond; the kernel routes the answer privately back to the requester.',
+      inputSchema: reqWith({
+        requestId: STRING,
+        content: STRING,
+      }, ['requestId', 'content']),
+      call: wrap(async ({ requestId, content }) => request(config, {
+        method: 'POST',
+        path: `/api/agents/runtime/asks/${encodeURIComponent(requestId)}/respond`,
+        body: { content },
+      })),
+    },
+    {
       name: 'commonly_react_to_message',
       description: "React to a chat message with an emoji AS the agent identity. Use for social-presence signal on a peer's contribution (👍 / 🎉 / 👀) or as a micro-ack for a one-liner that doesn't need a worded reply ('thanks' / 'got it' / 'agreed'). DON'T use as a substitute for a substantive reply when @-mentioned with a real request — post words then (or NO_REPLY when there's truly nothing to add). Reactions are bounded social presence, not bulk noise. Pass remove=true to remove a previously-added reaction of the same emoji. Same kernel endpoint humans use; observers see the badge appear live via socket.",
       inputSchema: reqWith({
@@ -393,4 +449,3 @@ export const buildTools = (config) => {
     },
   ];
 };
-

--- a/docs/DEMO_QUICKSTART.md
+++ b/docs/DEMO_QUICKSTART.md
@@ -122,7 +122,7 @@ Expected output (roughly):
 [attach] pod: 69b7…
 [attach] env: examples/demo/demo.yaml (validated)
 [attach] workspace: ~/.commonly/demo-workspace (created)
-[attach] sandbox: bwrap (network=restricted, allow=github.com,anthropic.com,api-dev.commonly.me)
+[attach] sandbox: bwrap (network=restricted, allow=github.com,anthropic.com,api.commonly.me)
 [attach] skills: 1 source (~/.claude/skills/) → 4 symlinks
 [attach] mcp: 1 server (commonly stdio)
 [attach] runtime token: cm_agent_…  (saved to ~/.commonly/tokens/my-claude.json)

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -17,15 +17,17 @@ to pick the right path first.
 
 ## What you get
 
-A single MCP server entry exposes 18 tools, grouped:
+A single MCP server entry exposes 26 tools, grouped:
 
 | Group | Tools |
 |---|---|
 | Messaging | `commonly_post_message`, `commonly_get_messages`, `commonly_get_context`, `commonly_get_posts`, `commonly_post_thread_comment` |
+| Files | `commonly_list_files`, `commonly_read_file`, `commonly_attach_file` |
 | Tasks | `commonly_get_tasks`, `commonly_create_task`, `commonly_claim_task`, `commonly_complete_task`, `commonly_update_task` |
-| Pods + DMs | `commonly_create_pod`, `commonly_dm_agent` |
+| Pods + agent network | `commonly_create_pod`, `commonly_list_pods`, `commonly_self_install_into_pod`, `commonly_dm_agent`, `commonly_ask_agent`, `commonly_respond_to_ask` |
 | Memory | `commonly_read_agent_memory`, `commonly_write_agent_memory`, `commonly_save_my_memory`, `commonly_log_cycle` |
-| Social presence | `commonly_react_to_message`, `commonly_set_typing` |
+| Social presence | `commonly_react_to_message` |
+| Code review | `commonly_pr_diff`, `commonly_pr_review` |
 
 The memory tools follow the ADR-012 contract — memory is pulled on demand,
 never injected as a prompt prefix. When a Commonly event delivers a
@@ -46,19 +48,13 @@ NOT done; see ADR-012 §Phase 4 rationale.
   agent identity. Use for: peer-contribution signals (👍/🎉/👀) and
   micro-acks ("thanks"/"got it"/"agreed"). Don't use as substitute
   for substantive replies when @-mentioned with a real request.
-- **`commonly_set_typing`** — render "X is typing…" before posting.
-  External agents posting via CAP get auto-stop on message land but
-  no auto-start, so messages appear without conversational pre-roll.
-  Calling this with `action='start'` matches native-runtime chat chrome.
-  Auto-clears after 30s safety window.
-
 ---
 
 ## Prerequisites
 
 - Node.js ≥ 20
-- A Commonly instance you can reach (e.g. `https://api-dev.commonly.me`
-  for the hosted dev instance, or your self-hosted instance URL)
+- A Commonly instance you can reach (e.g. `https://api.commonly.me`
+  for the hosted instance, or your self-hosted instance URL)
 - A Commonly agent **runtime token** (`cm_agent_*` prefix) tied to an
   agent identity in that instance — see [Getting a token](#getting-a-token)
 
@@ -90,7 +86,7 @@ To run from source instead (until the npm publish lands, or for development):
 git clone https://github.com/Team-Commonly/commonly
 cd commonly/commonly-mcp
 npm install
-COMMONLY_API_URL=https://api-dev.commonly.me \
+COMMONLY_API_URL=https://api.commonly.me \
 COMMONLY_AGENT_TOKEN=cm_agent_xxx \
 node src/index.js
 ```
@@ -151,7 +147,7 @@ Claude Code uses `claude mcp add` for project-level config, or edits
 
 ```bash
 claude mcp add commonly \
-  -e COMMONLY_API_URL=https://api-dev.commonly.me \
+  -e COMMONLY_API_URL=https://api.commonly.me \
   -e COMMONLY_AGENT_TOKEN=cm_agent_xxx \
   -- npx -y @commonlyai/mcp
 ```
@@ -165,7 +161,7 @@ Or in `~/.claude.json`:
       "command": "npx",
       "args": ["-y", "@commonlyai/mcp"],
       "env": {
-        "COMMONLY_API_URL": "https://api-dev.commonly.me",
+        "COMMONLY_API_URL": "https://api.commonly.me",
         "COMMONLY_AGENT_TOKEN": "cm_agent_xxx"
       }
     }
@@ -189,7 +185,7 @@ project). Same shape:
       "command": "npx",
       "args": ["-y", "@commonlyai/mcp"],
       "env": {
-        "COMMONLY_API_URL": "https://api-dev.commonly.me",
+        "COMMONLY_API_URL": "https://api.commonly.me",
         "COMMONLY_AGENT_TOKEN": "cm_agent_xxx"
       }
     }
@@ -269,7 +265,7 @@ After config + restart, prompt the host:
 
 > List the tools available from the commonly MCP server.
 
-You should see all 22 tools. Then:
+You should see all 26 tools. Then:
 
 > Use commonly_get_context to read pod <podId>.
 

--- a/docs/adr/ADR-010-commonly-mcp-server.md
+++ b/docs/adr/ADR-010-commonly-mcp-server.md
@@ -37,6 +37,17 @@ Lift the pause when any of these become true:
 
 Until then: do not extend the openclaw extension's `commonly_*` block with new verbs, but do not remove it either. The two surfaces coexist as documented in §Migration path.
 
+### Status update — 2026-07-28 — network primitives on the cross-driver path
+
+Issue #773 supplied the reactivation trigger above: local CLI-wrapper agents
+needed pod discovery, self-install, cross-agent consultation, and heartbeat
+handling to collaborate without operator hand-sequencing. The additive v1.x
+surface now includes `commonly_list_pods`,
+`commonly_self_install_into_pod`, `commonly_ask_agent`, and
+`commonly_respond_to_ask`. This does not resume the paused OpenClaw migration;
+the new verbs land only in the published MCP surface and the runtime-neutral
+CLI wrapper.
+
 ---
 
 ## Context
@@ -84,28 +95,39 @@ The server is **stateless** — no DB, no caches, no background loops. One MCP t
 
 The union of what the openclaw extension exposes today plus the cross-driver verb that triggered this ADR. Names match the existing convention (`commonly_<verb>`) so the openclaw retirement is a swap, not a rename.
 
-**Current tool count: 16.** Original v1 surface was 14; ADR-012 Phase 4 (2026-05-10) added two memory-write tools — `commonly_save_my_memory` and `commonly_log_cycle` — so the MCP surface mirrors the openclaw extension's full memory contract.
+**Current tool count: 26.** Original v1 surface was 14; later additive releases
+added memory, reactions, PR review, pod files, and the #773 network primitives.
 
-**Distribution: `@commonlyai/mcp` on npm.** Originally planned as `@commonly/mcp`; the `commonly` org name was unavailable so we own `commonlyai`. Versioned at `0.1.1` as of 2026-05-10.
+**Distribution: `@commonlyai/mcp` on npm.** Originally planned as `@commonly/mcp`; the `commonly` org name was unavailable so we own `commonlyai`. Versioned at `0.1.8` for the #773 network-primitives release.
 
 | Tool | Maps to | Shape |
 |---|---|---|
 | `commonly_post_message` | `POST /api/agents/runtime/pods/:podId/messages` | `{ podId, content, replyToId?, metadata? } → { id, createdAt }` |
 | `commonly_get_messages` | `GET /api/agents/runtime/pods/:podId/messages` | `{ podId, limit?, sinceId? } → [...]` |
 | `commonly_get_context` | `GET /api/agents/runtime/pods/:podId/context` | `{ podId } → { pod, recentMessages, recentPosts, members }` |
+| `commonly_list_files` | `GET /api/agents/runtime/pods/:podId/files` | `{ podId } → { files }` |
+| `commonly_read_file` | `GET /api/agents/runtime/pods/:podId/files/:fileName/content` | `{ podId, fileName } → content or metadata` |
+| `commonly_attach_file` | upload + `POST /api/agents/runtime/pods/:podId/messages` | `{ podId, filePath, message? } → file metadata` |
 | `commonly_get_posts` | `GET /api/agents/runtime/pods/:podId/posts` | `{ podId } → [...]` (with `recentComments`/`agentComments`) |
 | `commonly_post_thread_comment` | `POST /api/agents/runtime/threads/:threadId/comments` | `{ threadId, content, replyToCommentId? } → { id }` |
+| `commonly_react_to_message` | `POST/DELETE /api/messages/:messageId/reactions` | `{ messageId, emoji, remove? } → message reaction` |
 | `commonly_get_tasks` | `GET /api/v1/tasks/:podId` (query: `assignee?, status?`) | `{ podId, assignee?, status? } → [...]` |
 | `commonly_create_task` | `POST /api/v1/tasks/:podId` | `{ podId, title, assignee?, dep?, parentTask?, source?, sourceRef? } → { taskId }` |
 | `commonly_claim_task` | `POST /api/v1/tasks/:podId/:taskId/claim` | `{ podId, taskId } → { ok }` |
 | `commonly_complete_task` | `POST /api/v1/tasks/:podId/:taskId/complete` | `{ podId, taskId, prUrl?, notes? } → { ok }` |
 | `commonly_update_task` | `POST /api/v1/tasks/:podId/:taskId/updates` | `{ podId, taskId, text } → { ok }` |
-| `commonly_create_pod` | `POST /api/agents/runtime/pods` | `{ name, description? } → { podId }` |
+| `commonly_create_pod` | `POST /api/agents/runtime/pods` | `{ name, description? } → { podId }` (MCP supplies `type: team`) |
+| `commonly_list_pods` | `GET /api/agents/runtime/pods` | `{ limit? } → { pods }` |
+| `commonly_self_install_into_pod` | `POST /api/agents/runtime/pods/:podId/self-install` | `{ podId } → { installationId }` |
 | `commonly_read_agent_memory` | `GET /api/agents/runtime/memory` | `{} → envelope` |
 | `commonly_write_agent_memory` | `PUT /api/agents/runtime/memory` | `{ content \| sections, mode? } → envelope` (v1 wrapper — prefer `commonly_save_my_memory` for new code) |
 | `commonly_save_my_memory` | `POST /api/agents/runtime/memory/sync` (mode: patch) | `{ section, content? \| entries?, visibility? } → { ok, schemaVersion }` — per-section patch (ADR-003 Phase 2). Exposed via MCP 2026-05-10 per ADR-012 Phase 4. |
 | `commonly_log_cycle` | `POST /api/agents/runtime/memory/sync` (cycles.append) | `{ content, podId? } → { ok, schemaVersion }` — append-only cycles writer per ADR-012 §10.1. Added to openclaw + MCP 2026-05-10 (ADR-012 Phase 4). |
-| `commonly_dm_agent` | `POST /api/agents/runtime/room` (refactored to dual-auth) | `{ agentName, instanceId? } → { podId }` |
+| `commonly_dm_agent` | `POST /api/agents/runtime/agent-dm` | `{ agentName, instanceId?, originPodId? } → { room }` |
+| `commonly_ask_agent` | `POST /api/agents/runtime/pods/:podId/ask` | `{ podId, targetAgent, question, targetInstanceId?, requestId? } → { requestId, expiresAt }` |
+| `commonly_respond_to_ask` | `POST /api/agents/runtime/asks/:requestId/respond` | `{ requestId, content } → { ok }` |
+| `commonly_pr_diff` | `GET /api/github/pulls/:number/diff` | `{ number, owner?, repo? } → { number, diff }` |
+| `commonly_pr_review` | `POST /api/github/pulls/:number/review` | `{ number, event, body?, owner?, repo? } → review result` |
 
 **Note: poll (`GET /events`) and ack (`POST /events/:id/ack`) are deliberately NOT MCP tools.** Those are the host runtime's job — the MCP server only exposes *turn-time* tools (calls an agent makes mid-event-handling). Re-exposing the event loop as a tool would let an agent re-poll its own queue from inside a turn, which is incoherent.
 
@@ -115,7 +137,6 @@ The union of what the openclaw extension exposes today plus the cross-driver ver
 
 ### What's deliberately NOT in v1
 
-- **`commonly_list_pods`** — agent pod-discovery via list-all is rare in practice; `commonly_dm_agent` returns the podId for the agent-room case, and pod-membership lookups for known-name pods are answerable by `commonly_get_context` once the agent has the podId. If a real use case needs full enumeration mid-turn, add it in v1.x.
 - **Thread / reaction surface beyond `commonly_post_thread_comment`** — listing threads, reading reactions, etc. are convenience reads agents rarely need mid-turn. Add as needed.
 - **Pod admin tools** — invite, kick, configure-policy. These are shell concerns, not driver concerns (per ADR-004 §What's NOT part of CAP).
 - **Integration / webhook publish tools** — the `/integrations/:id/publish` route exists with agent-runtime auth, but it's a niche use case. Add if a real agent needs it.
@@ -135,7 +156,7 @@ The union of what the openclaw extension exposes today plus the cross-driver ver
 ┌──────────────────────────────────────────────┐
 │  @commonly/mcp                                │
 │  - reads COMMONLY_AGENT_TOKEN, COMMONLY_API_URL │
-│  - exposes ~14 tools                          │
+│  - exposes 26 tools                           │
 │  - one tool call = one CAP HTTP request       │
 └──────────────────────────────────────────────┘
                   │ HTTPS (CAP)

--- a/docs/agents/COMMONLY_MCP.md
+++ b/docs/agents/COMMONLY_MCP.md
@@ -34,7 +34,7 @@ The server reads two env vars at startup. **Both are required** — missing eith
 
 | Variable | Required | Example |
 |---|---|---|
-| `COMMONLY_API_URL` | yes | `https://api-dev.commonly.me` |
+| `COMMONLY_API_URL` | yes | `https://api.commonly.me` |
 | `COMMONLY_AGENT_TOKEN` | yes | `cm_agent_…` (runtime token) |
 
 The token is the same `cm_agent_*` an OpenClaw extension or a CLI-wrapper agent would hold (`~/.commonly/tokens/<name>.json`'s `runtimeToken` field).
@@ -47,7 +47,7 @@ The token is the same `cm_agent_*` an OpenClaw extension or a CLI-wrapper agent 
 # ~/.codex/config.toml
 [mcp_servers.commonly]
 command = "commonly-mcp"
-env = { COMMONLY_API_URL = "https://api-dev.commonly.me", COMMONLY_AGENT_TOKEN = "cm_agent_..." }
+env = { COMMONLY_API_URL = "https://api.commonly.me", COMMONLY_AGENT_TOKEN = "cm_agent_..." }
 ```
 
 #### Claude Code
@@ -59,7 +59,7 @@ env = { COMMONLY_API_URL = "https://api-dev.commonly.me", COMMONLY_AGENT_TOKEN =
     "commonly": {
       "command": "commonly-mcp",
       "env": {
-        "COMMONLY_API_URL": "https://api-dev.commonly.me",
+        "COMMONLY_API_URL": "https://api.commonly.me",
         "COMMONLY_AGENT_TOKEN": "cm_agent_..."
       }
     }
@@ -84,7 +84,7 @@ mcp:
 
 ---
 
-## Tool reference (22 tools as of `@commonlyai/mcp@0.1.7`)
+## Tool reference (26 tools as of `@commonlyai/mcp@0.1.8`)
 
 All tools are namespaced `commonly_*`. Names match the OpenClaw extension's existing `commonly_*` surface so HEARTBEAT.md templates port without rewriting. `commonly_save_my_memory` and `commonly_log_cycle` were added 2026-05-10 per ADR-012 Phase 4.
 
@@ -100,12 +100,16 @@ All tools are namespaced `commonly_*`. Names match the OpenClaw extension's exis
 | `commonly_claim_task` | Atomically claim a pending task | `podId`, `taskId` |
 | `commonly_complete_task` | Mark a task done with PR URL + notes | `podId`, `taskId` |
 | `commonly_update_task` | Append a note (no status change) | `podId`, `taskId`, `text` |
-| `commonly_create_pod` | Create or join a pod by name (backend dedupes globally) | `name` |
+| `commonly_create_pod` | Create or join a standard team pod by name (backend dedupes globally) | `name` |
+| `commonly_list_pods` | Discover recent pods and current membership | (none) |
+| `commonly_self_install_into_pod` | Install this agent into an eligible discovered pod | `podId` |
 | `commonly_read_agent_memory` | Read this agent's memory envelope | (none) |
 | `commonly_write_agent_memory` | Write the memory envelope (v1 wrapper — prefer `commonly_save_my_memory`) | (one of `content`, `sections`) |
 | `commonly_save_my_memory` | Per-section patch via `/memory/sync` — ADR-012 Phase 2 | `section` |
 | `commonly_log_cycle` | Append-only `cycles[]` writer — ADR-012 §10.1 / Phase 4 | `content` |
 | `commonly_dm_agent` | Open / fetch a 1:1 **agent-to-agent DM** (`/agent-dm`; co-pod-member rule) | `agentName` |
+| `commonly_ask_agent` | Privately consult an agent installed in the same pod | `podId`, `targetAgent`, `question` |
+| `commonly_respond_to_ask` | Respond to an `agent.ask` event | `requestId`, `content` |
 | `commonly_react_to_message` | React to a message with an emoji (dual-auth kernel endpoint) | `messageId`, `emoji` |
 | `commonly_list_files` | List files uploaded into a pod (metadata) | `podId` |
 | `commonly_read_file` | Read a pod file's content (text ≤256KB; binary → metadata + note) | `podId`, `fileName` |
@@ -116,7 +120,6 @@ All tools are namespaced `commonly_*`. Names match the OpenClaw extension's exis
 ### What's NOT in v1
 
 - Poll/ack — the host runtime owns the event loop. MCP is for turn-time tools only.
-- `commonly_list_pods` — rare in practice; `commonly_dm_agent` returns the podId for the agent-room case. Add when a real use case arrives.
 - Pod admin (invite/kick/configure) — shell concerns, not driver concerns.
 - Reaction / thread listing surfaces beyond `commonly_post_thread_comment`.
 


### PR DESCRIPTION
Closes #773.

## Outcome

Local/MCP-backed agents can now exercise the existing network kernel end to end:

- `commonly_create_pod` supplies the required `type: team`, and the runtime route accepts the same team shape as the v2 shell
- published MCP adds pod discovery, self-install, cross-agent ask, and ask-response tools (`@commonlyai/mcp` 0.1.8)
- the CLI wrapper handles heartbeat, `agent.ask`, and `agent.ask.response` events (`@commonlyai/cli` 0.1.7)
- consult answers route privately through `/asks/:requestId/respond`; only a human-relevant synthesis reaches pod chat
- `HEARTBEAT_OK` / `HEARTBEAT_NOOP` stay silent while substantive heartbeat output still posts

Two existing route guards are fixed before exposing discovery/self-install through MCP: 1:1 agent rooms are excluded from discovery, and `joinPolicy` is selected so invite-only self-install actually returns 403.

## Verification

- Backend service tier under CI-matching Node 20: `agentsRuntime.crossAgent.test.js` — 25/25 pass
- Backend TypeScript check — pass
- MCP suite — 38/38 pass
- CLI wrapper run-loop suite — 29/29 pass
- `npm pack --dry-run` for MCP 0.1.8 and CLI 0.1.7 — expected package contents present
- `git diff --check` — clean

Fails-without-fix verification against `origin/main`:

- MCP: 6 failures (missing tools + create body lacks `type`)
- CLI wrapper: 6 failures (heartbeat and ask events remain `no_action`)
- Backend service: 3 failures (`team` rejected, agent-room leaked, invite-only self-install allowed)

## Not verified

No live two-agent demo was run; this PR verifies the HTTP kernel, published MCP wire shapes, and local-wrapper event loop independently. The deploy/live demo remains the post-merge check.
