### PR TITLE
fix: make NO_REPLY suppression and sanitization explicit

### DIFF
--- a/backend/__tests__/service/clawdbot-e2e.test.js
+++ b/backend/__tests__/service/clawdbot-e2e.test.js
@@ -672,16 +672,27 @@ describe('Clawdbot E2E Integration Tests', () => {
       expect(res.body.message.content).toContain('Hello from Clawdbot');
     });
 
-    test('preserves NO_REPLY when it is part of substantive content', async () => {
-      const content = 'Sentinels are total-match contracts: NO_REPLY inside prose is visible.';
-      const res = await request(app)
+    test('strips bare NO_REPLY leakage but preserves code-formatted mentions', async () => {
+      const bareContent = 'A producer leaked NO_REPLY into substantive content.';
+      const bareRes = await request(app)
         .post(`/api/agents/runtime/pods/${testPod._id}/messages`)
         .set('Authorization', `Bearer ${agentToken}`)
-        .send({ content, messageType: 'text' });
+        .send({ content: bareContent, messageType: 'text' });
 
-      expect(res.status).toBe(200);
-      expect(res.body.success).toBe(true);
-      expect(res.body.message.content).toBe(content);
+      expect(bareRes.status).toBe(200);
+      expect(bareRes.body.success).toBe(true);
+      expect(bareRes.body.message.content)
+        .toBe('A producer leaked  into substantive content.');
+
+      const escapedContent = 'Use `NO_REPLY` only as a whole reply.';
+      const escapedRes = await request(app)
+        .post(`/api/agents/runtime/pods/${testPod._id}/messages`)
+        .set('Authorization', `Bearer ${agentToken}`)
+        .send({ content: escapedContent, messageType: 'text' });
+
+      expect(escapedRes.status).toBe(200);
+      expect(escapedRes.body.success).toBe(true);
+      expect(escapedRes.body.message.content).toBe(escapedContent);
     });
 
     test('should reject posting to unauthorized pod', async () => {

--- a/backend/__tests__/service/clawdbot-e2e.test.js
+++ b/backend/__tests__/service/clawdbot-e2e.test.js
@@ -672,6 +672,18 @@ describe('Clawdbot E2E Integration Tests', () => {
       expect(res.body.message.content).toContain('Hello from Clawdbot');
     });
 
+    test('preserves NO_REPLY when it is part of substantive content', async () => {
+      const content = 'Sentinels are total-match contracts: NO_REPLY inside prose is visible.';
+      const res = await request(app)
+        .post(`/api/agents/runtime/pods/${testPod._id}/messages`)
+        .set('Authorization', `Bearer ${agentToken}`)
+        .send({ content, messageType: 'text' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.message.content).toBe(content);
+    });
+
     test('should reject posting to unauthorized pod', async () => {
       // Create another pod that clawdbot is NOT installed on
       const otherPod = await Pod.create({

--- a/backend/__tests__/unit/services/agentMessageService.chatNoise.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.chatNoise.test.js
@@ -34,19 +34,18 @@ describe('AgentMessageService.isRuntimeToolFailureNote', () => {
   });
 });
 
-describe('sanitizeAgentContent — concatenated NO_REPLY sentinels', () => {
-  it('strips doubled and tripled sentinel runs', () => {
+describe('sanitizeAgentContent — total-match NO_REPLY sentinel', () => {
+  it('strips only sentinel-only replies, including legacy duplicated runs', () => {
+    expect(AgentMessageService.sanitizeAgentContent('NO_REPLY')).toBe('');
     expect(AgentMessageService.sanitizeAgentContent('NO_REPLYNO_REPLY')).toBe('');
     expect(AgentMessageService.sanitizeAgentContent('NO_REPLYNO_REPLYNO_REPLY')).toBe('');
     expect(AgentMessageService.sanitizeAgentContent('NO_REPLY NO_REPLY')).toBe('');
   });
 
-  it('still strips the single sentinel and preserves real content', () => {
-    expect(AgentMessageService.sanitizeAgentContent('NO_REPLY')).toBe('');
-    expect(AgentMessageService.sanitizeAgentContent('Shipped the fix.\nNO_REPLY')).toBe('Shipped the fix.');
-    // Mid-sentence mentions lose the token (pre-existing behavior) but the
-    // line survives.
+  it('preserves sentinel-plus-content exactly', () => {
+    expect(AgentMessageService.sanitizeAgentContent('Shipped the fix.\nNO_REPLY'))
+      .toBe('Shipped the fix.\nNO_REPLY');
     expect(AgentMessageService.sanitizeAgentContent('Reply with NO_REPLY when done.'))
-      .toBe('Reply with  when done.');
+      .toBe('Reply with NO_REPLY when done.');
   });
 });

--- a/backend/__tests__/unit/services/agentMessageService.chatNoise.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.chatNoise.test.js
@@ -42,6 +42,10 @@ describe('sanitizeAgentContent — NO_REPLY suppression and sanitization', () =>
     expect(AgentMessageService.sanitizeAgentContent('NO_REPLY NO_REPLY')).toBe('');
   });
 
+  it('keeps fenced sentinel-only replies silent before preserving code spans', () => {
+    expect(AgentMessageService.sanitizeAgentContent('```text\nNO_REPLY\n```')).toBe('');
+  });
+
   it('keeps substantive replies but strips bare producer-leakage tokens', () => {
     expect(AgentMessageService.sanitizeAgentContent('Shipped the fix.\nNO_REPLY'))
       .toBe('Shipped the fix.');

--- a/backend/__tests__/unit/services/agentMessageService.chatNoise.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.chatNoise.test.js
@@ -34,7 +34,7 @@ describe('AgentMessageService.isRuntimeToolFailureNote', () => {
   });
 });
 
-describe('sanitizeAgentContent — total-match NO_REPLY sentinel', () => {
+describe('sanitizeAgentContent — NO_REPLY suppression and sanitization', () => {
   it('strips only sentinel-only replies, including legacy duplicated runs', () => {
     expect(AgentMessageService.sanitizeAgentContent('NO_REPLY')).toBe('');
     expect(AgentMessageService.sanitizeAgentContent('NO_REPLYNO_REPLY')).toBe('');
@@ -42,10 +42,24 @@ describe('sanitizeAgentContent — total-match NO_REPLY sentinel', () => {
     expect(AgentMessageService.sanitizeAgentContent('NO_REPLY NO_REPLY')).toBe('');
   });
 
-  it('preserves sentinel-plus-content exactly', () => {
+  it('keeps substantive replies but strips bare producer-leakage tokens', () => {
     expect(AgentMessageService.sanitizeAgentContent('Shipped the fix.\nNO_REPLY'))
-      .toBe('Shipped the fix.\nNO_REPLY');
+      .toBe('Shipped the fix.');
     expect(AgentMessageService.sanitizeAgentContent('Reply with NO_REPLY when done.'))
-      .toBe('Reply with NO_REPLY when done.');
+      .toBe('Reply with  when done.');
+  });
+
+  it('preserves code-formatted sentinel mentions', () => {
+    expect(AgentMessageService.sanitizeAgentContent('Reply with `NO_REPLY` when done.'))
+      .toBe('Reply with `NO_REPLY` when done.');
+    expect(AgentMessageService.sanitizeAgentContent(
+      'The literal is ``NO_REPLY``; bare NO_REPLY is leakage.',
+    )).toBe('The literal is ``NO_REPLY``; bare  is leakage.');
+    expect(AgentMessageService.sanitizeAgentContent(
+      'Example:\n```text\nNO_REPLY\n```\nDo not copy bare NO_REPLY.',
+    )).toBe('Example:\n```text\nNO_REPLY\n```\nDo not copy bare .');
+    expect(AgentMessageService.sanitizeAgentContent(
+      '```text\nNO_REPLY is discussed here.\n```',
+    )).toBe('NO_REPLY is discussed here.');
   });
 });

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -1531,23 +1531,86 @@ class AgentMessageService {
     // sentinel mentions inside it exactly.
     if (outerFence) return trimmed;
 
-    // Bare sentinel tokens inside a substantive reply are producer leakage:
-    // remove them without suppressing the reply. Backtick-formatted spans are
-    // deliberate mentions and must survive verbatim. Matching variable-length
-    // backtick delimiters covers inline spans and fenced blocks without
-    // rewriting whitespace-sensitive content around them.
-    const codeSpan = /(`+)([\s\S]*?)\1/g;
+    // Bare sentinel tokens inside a substantive reply are producer leakage;
+    // matching backtick-delimited spans are deliberate mentions. Pair the
+    // delimiters in a linear scan rather than running a backtracking regex on
+    // user-controlled message text.
+    const delimiterRuns: Array<{ start: number; end: number; length: number }> = [];
+    for (let index = 0; index < trimmed.length;) {
+      if (trimmed[index] !== '`') {
+        index += 1;
+        continue;
+      }
+      const start = index;
+      while (index < trimmed.length && trimmed[index] === '`') index += 1;
+      delimiterRuns.push({ start, end: index, length: index - start });
+    }
+
+    const pendingDelimiter = new Map<
+      number,
+      { start: number; end: number; length: number }
+    >();
+    const protectedRanges: Array<{ start: number; end: number }> = [];
+    for (const run of delimiterRuns) {
+      const opening = pendingDelimiter.get(run.length);
+      if (opening) {
+        protectedRanges.push({ start: opening.start, end: run.end });
+        pendingDelimiter.delete(run.length);
+      } else {
+        pendingDelimiter.set(run.length, run);
+      }
+    }
+    protectedRanges.sort((left, right) => left.start - right.start);
+
+    const mergedRanges: Array<{ start: number; end: number }> = [];
+    for (const range of protectedRanges) {
+      const previous = mergedRanges[mergedRanges.length - 1];
+      if (previous && range.start <= previous.end) {
+        previous.end = Math.max(previous.end, range.end);
+      } else {
+        mergedRanges.push({ ...range });
+      }
+    }
+
+    const isWordCharacter = (character: string | undefined): boolean => (
+      character !== undefined
+      && (
+        (character >= 'A' && character <= 'Z')
+        || (character >= 'a' && character <= 'z')
+        || (character >= '0' && character <= '9')
+        || character === '_'
+      )
+    );
+    const sentinel = 'NO_REPLY';
     let cleaned = '';
     let cursor = 0;
-    for (const match of trimmed.matchAll(codeSpan)) {
-      const matchIndex = match.index ?? cursor;
-      cleaned += trimmed
-        .slice(cursor, matchIndex)
-        .replace(/\b(?:NO_REPLY)+\b/g, '');
-      cleaned += match[0];
-      cursor = matchIndex + match[0].length;
+    let rangeIndex = 0;
+    while (cursor < trimmed.length) {
+      const range = mergedRanges[rangeIndex];
+      if (range && cursor === range.start) {
+        cleaned += trimmed.slice(range.start, range.end);
+        cursor = range.end;
+        rangeIndex += 1;
+        continue;
+      }
+
+      if (
+        trimmed.startsWith(sentinel, cursor)
+        && !isWordCharacter(trimmed[cursor - 1])
+      ) {
+        let sentinelEnd = cursor;
+        while (trimmed.startsWith(sentinel, sentinelEnd)) {
+          sentinelEnd += sentinel.length;
+        }
+        if (!isWordCharacter(trimmed[sentinelEnd])) {
+          cursor = sentinelEnd;
+          continue;
+        }
+      }
+
+      cleaned += trimmed[cursor];
+      cursor += 1;
     }
-    cleaned += trimmed.slice(cursor).replace(/\b(?:NO_REPLY)+\b/g, '');
 
     // Do not map/trim individual lines here. Whitespace-sensitive payloads
     // (Python, YAML, diffs, markdown nesting) are normal agent traffic, and a

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -1516,20 +1516,43 @@ class AgentMessageService {
     const raw = String(content);
     if (!raw.trim()) return '';
 
-    const stripped = raw.replace(/^```[^\n]*\n([\s\S]*?)```\s*$/s, '$1');
+    const outerFence = raw.match(/^```[^\n]*\n([\s\S]*?)```\s*$/s);
+    const stripped = outerFence ? outerFence[1] : raw;
     const trimmed = stripped.trim();
 
     // Sentinels are total-match contracts: suppress only when the complete
     // reply consists of NO_REPLY tokens. Gateways have historically joined
     // silent blocks into "NO_REPLYNO_REPLY" (or separated duplicates with
-    // whitespace), so retain that compatibility without deleting the token
-    // from substantive prose. Sentinel-plus-content is content, always.
+    // whitespace), so retain that compatibility.
     if (/^(?:NO_REPLY\s*)+$/.test(trimmed)) return '';
+
+    // A fully fenced reply is explicitly code-formatted even though this
+    // sanitizer removes the outer transport fence before storage. Preserve
+    // sentinel mentions inside it exactly.
+    if (outerFence) return trimmed;
+
+    // Bare sentinel tokens inside a substantive reply are producer leakage:
+    // remove them without suppressing the reply. Backtick-formatted spans are
+    // deliberate mentions and must survive verbatim. Matching variable-length
+    // backtick delimiters covers inline spans and fenced blocks without
+    // rewriting whitespace-sensitive content around them.
+    const codeSpan = /(`+)([\s\S]*?)\1/g;
+    let cleaned = '';
+    let cursor = 0;
+    for (const match of trimmed.matchAll(codeSpan)) {
+      const matchIndex = match.index ?? cursor;
+      cleaned += trimmed
+        .slice(cursor, matchIndex)
+        .replace(/\b(?:NO_REPLY)+\b/g, '');
+      cleaned += match[0];
+      cursor = matchIndex + match[0].length;
+    }
+    cleaned += trimmed.slice(cursor).replace(/\b(?:NO_REPLY)+\b/g, '');
 
     // Do not map/trim individual lines here. Whitespace-sensitive payloads
     // (Python, YAML, diffs, markdown nesting) are normal agent traffic, and a
     // line-wise sanitizer previously flattened their indentation.
-    return trimmed;
+    return cleaned.trim();
   }
 
   /**

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -1526,9 +1526,11 @@ class AgentMessageService {
     // whitespace), so retain that compatibility.
     if (/^(?:NO_REPLY\s*)+$/.test(trimmed)) return '';
 
-    // A fully fenced reply is explicitly code-formatted even though this
-    // sanitizer removes the outer transport fence before storage. Preserve
-    // sentinel mentions inside it exactly.
+    // A substantive fully fenced reply is explicitly code-formatted even
+    // though this sanitizer removes the outer transport fence before storage.
+    // Preserve sentinel mentions inside it exactly. A fenced sentinel-only
+    // reply was already suppressed above so runtimes cannot bypass silence by
+    // wrapping the token in a transport fence.
     if (outerFence) return trimmed;
 
     // Bare sentinel tokens inside a substantive reply are producer leakage;

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -1517,37 +1517,19 @@ class AgentMessageService {
     if (!raw.trim()) return '';
 
     const stripped = raw.replace(/^```[^\n]*\n([\s\S]*?)```\s*$/s, '$1');
+    const trimmed = stripped.trim();
 
-    const cleaned = stripped
-      .split(/\r?\n/)
-      // (?:NO_REPLY)+ handles concatenated sentinels: gateways occasionally
-      // join two silent blocks into "NO_REPLYNO_REPLY", which has no word
-      // boundary between the runs and sailed through \bNO_REPLY\b verbatim
-      // into live pods (2026-07-03).
-      //
-      // Only the sentinel is removed — indentation and blank lines are NOT.
-      // The old form was `.map(l => l.replace(...).trim()).filter(Boolean)`,
-      // which per-line-trimmed every message and dropped every empty line.
-      // That is sentinel cleanup with a whitespace bulldozer attached: Python
-      // sent through an agent lost its indentation (`    y = x + 1` arrived as
-      // `y = x + 1`), so a task with one missing `:` reached the agent as code
-      // that also raised IndentationError, and agent-authored code blocks came
-      // out flattened. Whitespace-sensitive payloads (Python, YAML, diffs,
-      // markdown nesting) are normal traffic in an agent pod — verified live
-      // 2026-07-16 by posting identical text through both paths: the user path
-      // (messageController) kept indentation, this one destroyed it.
-      .map((line) => {
-        const withoutSentinel = line.replace(/\b(?:NO_REPLY)+\b/g, '');
-        // A line that was ONLY a sentinel (plus padding) becomes blank rather
-        // than lingering as stray spaces; genuine content keeps its indent.
-        return withoutSentinel.trim() ? withoutSentinel : '';
-      })
-      .join('\n')
-      // Leading/trailing blank lines are still cosmetic noise — but interior
-      // structure now survives.
-      .trim();
+    // Sentinels are total-match contracts: suppress only when the complete
+    // reply consists of NO_REPLY tokens. Gateways have historically joined
+    // silent blocks into "NO_REPLYNO_REPLY" (or separated duplicates with
+    // whitespace), so retain that compatibility without deleting the token
+    // from substantive prose. Sentinel-plus-content is content, always.
+    if (/^(?:NO_REPLY\s*)+$/.test(trimmed)) return '';
 
-    return cleaned;
+    // Do not map/trim individual lines here. Whitespace-sensitive payloads
+    // (Python, YAML, diffs, markdown nesting) are normal agent traffic, and a
+    // line-wise sanitizer previously flattened their indentation.
+    return trimmed;
   }
 
   /**

--- a/backend/services/systemExchangeTriggers.ts
+++ b/backend/services/systemExchangeTriggers.ts
@@ -147,7 +147,10 @@ async function findPreviousNonSilentMessage(podId: string, senderUserId: string)
     );
     for (const m of result.rows) {
       const raw = typeof m?.content === 'string' ? (m.content as string) : String(m?.content ?? '');
-      const cleaned = typeof sanitize === 'function' ? sanitize(raw) : raw.trim().replace(/\bNO_REPLY\b/g, '').trim();
+      const trimmed = raw.trim();
+      const cleaned = typeof sanitize === 'function'
+        ? sanitize(raw)
+        : (/^(?:NO_REPLY\s*)+$/.test(trimmed) ? '' : trimmed);
       if (cleaned) return cleaned;
     }
     return null;

--- a/docs/SUMMARIZER_AND_AGENTS.md
+++ b/docs/SUMMARIZER_AND_AGENTS.md
@@ -311,7 +311,7 @@ OPENCLAW_USER_TOKEN=<cm_*>              # User token (optional MCP access)
 2. **Test agent events in isolation** - See `backend/__tests__/service/two-way-integration-e2e.test.js`
 3. **Use runtime tokens for external agents** - Never use user tokens for agent auth
 4. **Sync agent users to PostgreSQL** - Ensures messages persist (`AgentIdentityService.syncUserToPostgreSQL()`)
-5. **Sanitize agent content** - Suppress `NO_REPLY` only when the complete reply is sentinel-only via `AgentMessageService.sanitizeAgentContent()`; sentinel-plus-content remains visible
+5. **Sanitize agent content** - Suppress `NO_REPLY` only when the complete reply is sentinel-only via `AgentMessageService.sanitizeAgentContent()`; strip bare mid-content producer leakage while preserving deliberate code-formatted mentions
 
 ---
 

--- a/docs/SUMMARIZER_AND_AGENTS.md
+++ b/docs/SUMMARIZER_AND_AGENTS.md
@@ -311,7 +311,7 @@ OPENCLAW_USER_TOKEN=<cm_*>              # User token (optional MCP access)
 2. **Test agent events in isolation** - See `backend/__tests__/service/two-way-integration-e2e.test.js`
 3. **Use runtime tokens for external agents** - Never use user tokens for agent auth
 4. **Sync agent users to PostgreSQL** - Ensures messages persist (`AgentIdentityService.syncUserToPostgreSQL()`)
-5. **Sanitize agent content** - Remove `NO_REPLY` tokens via `AgentMessageService.sanitizeAgentContent()`
+5. **Sanitize agent content** - Suppress `NO_REPLY` only when the complete reply is sentinel-only via `AgentMessageService.sanitizeAgentContent()`; sentinel-plus-content remains visible
 
 ---
 


### PR DESCRIPTION
## Outcome

Agent messages now use two explicit sentinel contracts:

1. suppression is total-match — only sentinel-only replies stay silent;
2. sanitization removes bare mid-content producer leakage while preserving deliberate code-formatted mentions.

Closes #783.

## Changes

- keep whole-reply suppression for bare, duplicated, whitespace-separated, and fenced sentinel-only gateway output
- strip bare mid-content tokens without suppressing substantive replies
- preserve sentinel mentions inside variable-length backtick spans and fenced code
- preserve the historical outer-fence unwrap for substantive fenced replies
- align the system-exchange fallback suppression rule
- update the operator doc
- add unit and runtime-route coverage for bare leakage, code-formatted mentions, and fenced-silence precedence

## Proof

Node 20:

- focused unit + runtime-route suites: 34/34 green
- `tsc --noEmit -p tsconfig.typescheck.json`: clean
- mutation removing bare-token stripping: exactly the paired bare-leakage unit test turns red
- mutation stripping inside code spans: exactly the paired code-formatting unit test turns red
- mutation allowing fenced sentinel-only output through: exactly the paired precedence test turns red

The first code-span implementation triggered a high-severity CodeQL polynomial-regex alert on attacker-controlled message text. The shipped implementation uses delimiter pairing plus a linear scan and cleared CodeQL at the prior head; fresh checks are running for this comment/test-only follow-up.

Focused ESLint is not a useful signal for these legacy test files: it reports their pre-existing TS-module resolution and iteration-rule violations. No new lint finding was identified in the changed lines.

## Scope boundary

- #784 tracks two legacy bridge `.includes("NO_REPLY")` matchers outside this kernel storage path.
- `_external/clawdbot` is not initialized in this workspace, so its separate sentinel semantics remain explicitly unaudited.
- The CLAUDE.md/skill wording correction and complete cross-layer checklist remain in the gated sprint-close docs batch.