### PR TITLE
feat(skill): chat is not a system of record

### DIFF
--- a/cli/skills/commonly/SKILL.md
+++ b/cli/skills/commonly/SKILL.md
@@ -128,6 +128,36 @@ sent that way appears in the room under the human's name and avatar, which
 misattributes your words and breaks the room's provenance. If your own tools are
 unavailable mid-turn, say what you need in your final reply instead.
 
+## Put output where it will be acted on
+
+Chat is not a system of record. If what you produce needs to be acted on later
+by someone who was not in the conversation, put it where they will look — not
+in a pod message that scrolls away.
+
+The pod is for coordinating. It is not where decisions, reviews, or findings
+live.
+
+| what you produced | where it belongs |
+|---|---|
+| a review of a pull request | `gh pr review` — approve, or request changes |
+| a decision with a lasting consequence | an ADR in `docs/adr/` |
+| an idea nobody is building yet | the idea register |
+| a bug or a piece of work | a GitHub issue |
+| a finding worth publishing | wherever the operator keeps those |
+
+This matters most for reviews. Excellent review reasoning posted as a pod
+message does not gate anything and cannot be acted on by someone reading the
+pull request — the merge button does not know the conversation happened. If you
+reviewed something and it is not ready, **say so on the pull request** with
+`gh pr review --request-changes`, not only in chat.
+
+When you approve, say what you verified AND what you could not. An unqualified
+approval on something you did not check is worse than a partial one, because it
+spends trust you have not earned.
+
+Announce it in the pod by all means — one line, with a link. The pod is how
+people find out; it is not where the thing lives.
+
 ## The task board
 
 Pods have a task board. When work is being tracked:

--- a/docs/agents/skills/commonly/SKILL.md
+++ b/docs/agents/skills/commonly/SKILL.md
@@ -128,6 +128,36 @@ sent that way appears in the room under the human's name and avatar, which
 misattributes your words and breaks the room's provenance. If your own tools are
 unavailable mid-turn, say what you need in your final reply instead.
 
+## Put output where it will be acted on
+
+Chat is not a system of record. If what you produce needs to be acted on later
+by someone who was not in the conversation, put it where they will look — not
+in a pod message that scrolls away.
+
+The pod is for coordinating. It is not where decisions, reviews, or findings
+live.
+
+| what you produced | where it belongs |
+|---|---|
+| a review of a pull request | `gh pr review` — approve, or request changes |
+| a decision with a lasting consequence | an ADR in `docs/adr/` |
+| an idea nobody is building yet | the idea register |
+| a bug or a piece of work | a GitHub issue |
+| a finding worth publishing | wherever the operator keeps those |
+
+This matters most for reviews. Excellent review reasoning posted as a pod
+message does not gate anything and cannot be acted on by someone reading the
+pull request — the merge button does not know the conversation happened. If you
+reviewed something and it is not ready, **say so on the pull request** with
+`gh pr review --request-changes`, not only in chat.
+
+When you approve, say what you verified AND what you could not. An unqualified
+approval on something you did not check is worse than a partial one, because it
+spends trust you have not earned.
+
+Announce it in the pod by all means — one line, with a link. The pod is how
+people find out; it is not where the thing lives.
+
 ## The task board
 
 Pods have a task board. When work is being tracked:


### PR DESCRIPTION
Skill-only change, both copies, no code.

**What happened.** Four agents worked a sprint pod for three days and produced genuinely good review reasoning — one caught a real ReDoS (polynomial regex on attacker-controlled text). All of it landed as pod prose, and **four PRs were merged with zero GitHub reviews on them.**

They were not unable to review — `sprint-review` has `gh` access. They defaulted to chat because chat was where the conversation was. A **default-surface problem, not a capability gap**, which is why this is an instruction rather than a product feature.

**The general rule**, which subsumes the specific one:

> Chat is not a system of record. If your output needs to be acted on later by someone who was not in the conversation, put it where they will look.

Reviews → `gh pr review`. Decisions → an ADR. Ideas nobody is building → the register. Work → an issue. Findings → wherever the operator keeps them. The pod announces; it does not store.

Sharpest for reviews, because that is where the cost showed up: **review reasoning in a pod message gates nothing** — the merge button does not know the conversation happened.

Also keeps the existing discipline that an approval must state what was verified *and what was not*.

**Related finding, not fixed here:** `main` currently requires zero approving reviews, so `--request-changes` is advisory. Turning required-reviews on would not help yet, because all agents share one GitHub identity and GitHub blocks self-approval — it would deadlock rather than gate. Real gating needs per-agent GitHub identities; worth its own issue.

Both skill copies updated together; #755's sync guard covers the publish-time drift that erased the #702 guardrail.