### PR TITLE
fix(cli): bound spawn retries with a circuit breaker

### DIFF
--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -714,6 +714,213 @@ describe('performRun', () => {
     expect(mockPost).not.toHaveBeenCalled();
   });
 
+  test('first processing failure stops the fetched batch before another model launch', async () => {
+    const events = [
+      makeEvent({ _id: 'evt-fail-first' }),
+      makeEvent({ _id: 'evt-must-wait' }),
+    ];
+    const mockGet = jest.fn().mockResolvedValue({ events });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn().mockRejectedValue(new Error('provider unavailable'));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+    const scheduled = [];
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      retryJitterRatio: 0,
+      setTimeoutImpl: (callback, delayMs) => {
+        scheduled.push({ callback, delayMs });
+        return 0;
+      },
+    });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].delayMs).toBe(5000);
+  });
+
+  test('unknown repeated failures open the circuit on the third probe', async () => {
+    const event = makeEvent({ _id: 'evt-circuit' });
+    const mockGet = jest.fn(async (route) => {
+      if (route === '/api/agents/runtime/events') return { events: [event] };
+      if (route === '/api/agents/runtime/memory') return { sections: {} };
+      if (route.endsWith('/messages')) return { messages: [] };
+      return {};
+    });
+    createClient.mockReturnValue({ get: mockGet, post: jest.fn().mockResolvedValue({}) });
+
+    const spawn = jest.fn().mockRejectedValue(new Error('claude exited with code 1:'));
+    const adapter = { name: 'stub', detect: stubAdapter.detect, spawn };
+    const scheduled = [];
+    const errors = [];
+    const handle = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter,
+      agentName: 'my-stub',
+      retryJitterRatio: 0,
+      setTimeoutImpl: (callback, delayMs) => {
+        scheduled.push({ callback, delayMs });
+        return 0;
+      },
+      onError: (error) => errors.push(error),
+    });
+
+    await drainMicrotasks();
+    expect(scheduled[0].delayMs).toBe(5000);
+    scheduled.shift().callback();
+    await drainMicrotasks();
+    expect(scheduled[0].delayMs).toBe(10000);
+    scheduled.shift().callback();
+    await drainMicrotasks();
+
+    handle.stop();
+    expect(spawn).toHaveBeenCalledTimes(3);
+    expect(scheduled[0].delayMs).toBe(60000);
+    expect(errors[2]).toMatchObject({
+      code: 'agent_spawn_retry_scheduled',
+      failureClass: 'runtime',
+      consecutiveFailures: 3,
+      retryAfterMs: 60000,
+      circuitOpen: true,
+      eventId: event._id,
+    });
+    expect(errors[2].message).toMatch(/circuit open, next probe in 1m/);
+  });
+
+  test('recognized quota failure opens the long circuit on the first attempt', async () => {
+    const event = makeEvent({ _id: 'evt-quota' });
+    const mockGet = jest.fn().mockResolvedValue({ events: [event] });
+    createClient.mockReturnValue({ get: mockGet, post: jest.fn().mockResolvedValue({}) });
+
+    const spawn = jest.fn().mockRejectedValue(new Error('insufficient_quota: billing limit'));
+    const scheduled = [];
+    const errors = [];
+    const handle = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter: { name: 'stub', detect: stubAdapter.detect, spawn },
+      agentName: 'my-stub',
+      retryJitterRatio: 0,
+      setTimeoutImpl: (callback, delayMs) => {
+        scheduled.push({ callback, delayMs });
+        return 0;
+      },
+      onError: (error) => errors.push(error),
+    });
+    await drainMicrotasks();
+    handle.stop();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(scheduled[0].delayMs).toBe(15 * 60 * 1000);
+    expect(errors[0]).toMatchObject({ failureClass: 'quota', circuitOpen: true });
+  });
+
+  test('a no-op event does not erase the model failure streak', async () => {
+    let poll = 0;
+    const mockGet = jest.fn(async (route) => {
+      if (route === '/api/agents/runtime/events') {
+        poll += 1;
+        if (poll === 1) return { events: [makeEvent({ _id: 'evt-streak-1' })] };
+        return {
+          events: [
+            makeEvent({ _id: 'evt-no-prompt', payload: {} }),
+            makeEvent({ _id: 'evt-streak-2' }),
+          ],
+        };
+      }
+      if (route === '/api/agents/runtime/memory') return { sections: {} };
+      if (route.endsWith('/messages')) return { messages: [] };
+      return {};
+    });
+    const mockPost = jest.fn().mockResolvedValue({});
+    createClient.mockReturnValue({ get: mockGet, post: mockPost });
+
+    const spawn = jest.fn().mockRejectedValue(new Error('runtime unavailable'));
+    const scheduled = [];
+    const handle = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter: { name: 'stub', detect: stubAdapter.detect, spawn },
+      agentName: 'my-stub',
+      retryJitterRatio: 0,
+      setTimeoutImpl: (callback, delayMs) => {
+        scheduled.push({ callback, delayMs });
+        return 0;
+      },
+    });
+
+    await drainMicrotasks();
+    expect(scheduled[0].delayMs).toBe(5000);
+    scheduled.shift().callback();
+    await drainMicrotasks();
+    handle.stop();
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(scheduled[0].delayMs).toBe(10000);
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-no-prompt/ack',
+      { result: { outcome: 'no_action' } },
+    );
+  });
+
+  test('successful processing resets the failure streak', async () => {
+    let poll = 0;
+    const mockGet = jest.fn(async (route) => {
+      if (route === '/api/agents/runtime/events') {
+        poll += 1;
+        return { events: [makeEvent({ _id: `evt-reset-${poll}` })] };
+      }
+      if (route === '/api/agents/runtime/memory') return { sections: {} };
+      if (route.endsWith('/messages')) return { messages: [] };
+      return {};
+    });
+    createClient.mockReturnValue({ get: mockGet, post: jest.fn().mockResolvedValue({}) });
+
+    const spawn = jest.fn()
+      .mockRejectedValueOnce(new Error('runtime unavailable'))
+      .mockRejectedValueOnce(new Error('runtime unavailable'))
+      .mockResolvedValueOnce({ text: 'recovered' })
+      .mockRejectedValueOnce(new Error('runtime unavailable'));
+    const scheduled = [];
+    const handle = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter: { name: 'stub', detect: stubAdapter.detect, spawn },
+      agentName: 'my-stub',
+      retryJitterRatio: 0,
+      setTimeoutImpl: (callback, delayMs) => {
+        scheduled.push({ callback, delayMs });
+        return 0;
+      },
+    });
+
+    await drainMicrotasks();
+    const runNext = async (expectedDelayMs) => {
+      const next = scheduled.shift();
+      expect(next.delayMs).toBe(expectedDelayMs);
+      next.callback();
+      await drainMicrotasks();
+    };
+    await runNext(5000); // first failure → second probe
+    await runNext(10000); // second failure → recovery probe
+    await runNext(5000); // success → normal poll interval
+
+    handle.stop();
+    expect(spawn).toHaveBeenCalledTimes(4);
+    // The post-recovery failure is a fresh streak, so it gets the first retry
+    // delay rather than continuing at the one-minute circuit delay.
+    expect(scheduled[0].delayMs).toBe(5000);
+  });
+
   test('same event id delivered twice → spawns once and re-acks the duplicate', async () => {
     const duplicate = makeEvent({ _id: 'evt-duplicate' });
     const mockGet = jest.fn().mockResolvedValue({ events: [duplicate, duplicate] });

--- a/cli/__tests__/spawn-retry.test.mjs
+++ b/cli/__tests__/spawn-retry.test.mjs
@@ -1,0 +1,67 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+  SPAWN_FAILURE_CLASS,
+  SPAWN_RETRY_MAX_MS,
+  classifySpawnFailure,
+  formatRetryDelay,
+  spawnRetryJitter,
+  spawnRetryPolicy,
+} from '../src/lib/spawn-retry.js';
+
+describe('spawn retry policy', () => {
+  test.each([
+    [new Error('insufficient_quota: credit balance exhausted'), SPAWN_FAILURE_CLASS.QUOTA],
+    [Object.assign(new Error('429 insufficient_quota'), { status: 429 }), SPAWN_FAILURE_CLASS.QUOTA],
+    [Object.assign(new Error('request failed'), { status: 429 }), SPAWN_FAILURE_CLASS.RATE_LIMIT],
+    [Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' }), SPAWN_FAILURE_CLASS.CONFIGURATION],
+    [new Error('claude exited with code 1: not logged in'), SPAWN_FAILURE_CLASS.CONFIGURATION],
+    [new Error('claude exited with code 1:'), SPAWN_FAILURE_CLASS.RUNTIME],
+  ])('classifies %s as %s', (error, expected) => {
+    expect(classifySpawnFailure(error)).toBe(expected);
+  });
+
+  test('quota and configuration failures open the long circuit immediately', () => {
+    for (const error of [new Error('quota exceeded'), new Error('command not found')]) {
+      const policy = spawnRetryPolicy({ error, consecutiveFailures: 1, intervalMs: 5000 });
+      expect(policy).toMatchObject({ circuitOpen: true, delayMs: SPAWN_RETRY_MAX_MS });
+    }
+  });
+
+  test('stable agent jitter is bounded and separates fleet probes', () => {
+    const alpha = spawnRetryJitter('alpha');
+    const beta = spawnRetryJitter('beta');
+    expect(alpha).toBeGreaterThanOrEqual(0);
+    expect(alpha).toBeLessThanOrEqual(0.2);
+    expect(beta).not.toBe(alpha);
+    expect(spawnRetryJitter('alpha')).toBe(alpha);
+
+    const policy = spawnRetryPolicy({
+      error: new Error('quota exceeded'),
+      consecutiveFailures: 1,
+      intervalMs: 5000,
+      jitterRatio: 0.2,
+    });
+    expect(policy.delayMs).toBe(18 * 60 * 1000);
+  });
+
+  test('formats jittered delays for operator-facing logs', () => {
+    expect(formatRetryDelay(5750)).toBe('5.8s');
+    expect(formatRetryDelay(66000)).toBe('1.1m');
+  });
+
+  test('unknown failures get two quick retries, then exponential circuit probes', () => {
+    const error = new Error('claude exited with code 1:');
+    const policies = [1, 2, 3, 4, 8].map((consecutiveFailures) => (
+      spawnRetryPolicy({ error, consecutiveFailures, intervalMs: 5000 })
+    ));
+
+    expect(policies.map(({ circuitOpen, delayMs }) => ({ circuitOpen, delayMs }))).toEqual([
+      { circuitOpen: false, delayMs: 5000 },
+      { circuitOpen: false, delayMs: 10000 },
+      { circuitOpen: true, delayMs: 60000 },
+      { circuitOpen: true, delayMs: 120000 },
+      { circuitOpen: true, delayMs: SPAWN_RETRY_MAX_MS },
+    ]);
+  });
+});

--- a/cli/__tests__/spawn-retry.test.mjs
+++ b/cli/__tests__/spawn-retry.test.mjs
@@ -64,4 +64,32 @@ describe('spawn retry policy', () => {
       { circuitOpen: true, delayMs: SPAWN_RETRY_MAX_MS },
     ]);
   });
+
+  test('rate-limit probes widen instead of polling once a minute forever', () => {
+    const error = Object.assign(new Error('too many requests'), { status: 429 });
+    const policies = [1, 2, 3, 4, 5, 20].map((consecutiveFailures) => (
+      spawnRetryPolicy({ error, consecutiveFailures, intervalMs: 5000 })
+    ));
+
+    expect(policies.map(({ circuitOpen, delayMs }) => ({ circuitOpen, delayMs }))).toEqual([
+      { circuitOpen: true, delayMs: 60000 },
+      { circuitOpen: true, delayMs: 120000 },
+      { circuitOpen: true, delayMs: 240000 },
+      { circuitOpen: true, delayMs: 480000 },
+      { circuitOpen: true, delayMs: SPAWN_RETRY_MAX_MS },
+      { circuitOpen: true, delayMs: SPAWN_RETRY_MAX_MS },
+    ]);
+
+    let elapsedMs = 0;
+    let attempts = 0;
+    while (elapsedMs < 3 * 60 * 60 * 1000) {
+      attempts += 1;
+      elapsedMs += spawnRetryPolicy({
+        error,
+        consecutiveFailures: attempts,
+        intervalMs: 5000,
+      }).delayMs;
+    }
+    expect(attempts).toBe(15);
+  });
 });

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -34,6 +34,11 @@ import { detectSkills, importSkills } from '../lib/skills-import.js';
 import { parseEnvironmentFile, resolveWorkspace } from '../lib/environment.js';
 import { detectBwrap } from '../lib/sandbox/bwrap.js';
 import { detectSeatbelt } from '../lib/sandbox/seatbelt.js';
+import {
+  formatRetryDelay,
+  spawnRetryJitter,
+  spawnRetryPolicy,
+} from '../lib/spawn-retry.js';
 
 // ── Token file I/O — ~/.commonly/tokens/<name>.json (ADR-005) ───────────────
 
@@ -502,6 +507,7 @@ export const performRun = ({
   log = () => {},
   onError,
   setTimeoutImpl = setTimeout,
+  retryJitterRatio,
 }) => {
   const client = createClient({ instance: instanceUrl, token });
   let running = true;
@@ -512,6 +518,8 @@ export const performRun = ({
   // reprovision-all; 5+ wastes rate-limit budget after the real-revoke case.
   let consecutiveAuthErrors = 0;
   const MAX_AUTH_ERRORS = 3;
+  let consecutiveSpawnFailures = 0;
+  const spawnJitterRatio = retryJitterRatio ?? spawnRetryJitter(agentName);
 
   // Adapters default `ctx.cwd` to this path. Node's child_process.spawn
   // rejects with "spawn <bin> ENOENT" when cwd does not exist — same shape
@@ -693,6 +701,7 @@ export const performRun = ({
 
   const tick = async () => {
     if (!running) return;
+    let nextPollDelayMs = intervalMs;
     try {
       const { events = [] } = await client.get('/api/agents/runtime/events', {
         agentName, instanceId, limit: 10,
@@ -705,15 +714,46 @@ export const performRun = ({
           result = { outcome: 'no_action', reason: 'duplicate-delivery' };
           log(`[${event.type}] duplicate delivery ${event._id} — skipping spawn and re-acking`);
         } else {
+          const eventWillSpawn = Boolean(extractPrompt(event) && (event.podId || podId));
           try {
             result = await processEvent(event);
           } catch (err) {
-            // Spawn failed — do not record or ack, so the kernel can re-deliver
-            // the event after the local runtime recovers (ADR-005).
-            log(`[${event.type}] spawn error: ${err.message}`);
-            onError?.(err);
-            continue;
+            // Do not record or ack: the kernel must retain the event for
+            // at-least-once delivery. Stop this fetched batch immediately —
+            // continuing could launch every one of the 10 returned events
+            // into the same provider outage before the next poll (#782).
+            consecutiveSpawnFailures += 1;
+            const retry = spawnRetryPolicy({
+              error: err,
+              consecutiveFailures: consecutiveSpawnFailures,
+              intervalMs,
+              jitterRatio: spawnJitterRatio,
+            });
+            nextPollDelayMs = retry.delayMs;
+            const retryIn = formatRetryDelay(retry.delayMs);
+            const state = retry.circuitOpen ? 'circuit open' : 'retry scheduled';
+            const wrapped = new Error(
+              `${event.type} processing failed (${retry.failureClass}; `
+              + `${consecutiveSpawnFailures} consecutive) — event ${event._id} remains unacked; `
+              + `${state}, next probe in ${retryIn}: ${err.message}`,
+              { cause: err },
+            );
+            Object.assign(wrapped, {
+              code: 'agent_spawn_retry_scheduled',
+              failureClass: retry.failureClass,
+              consecutiveFailures: consecutiveSpawnFailures,
+              retryAfterMs: retry.delayMs,
+              circuitOpen: retry.circuitOpen,
+              eventId: event._id,
+            });
+            log(`[${event.type}] ${wrapped.message}`);
+            onError?.(wrapped);
+            break;
           }
+          // Only a completed model turn proves the local runtime and delivery
+          // path recovered. A malformed/no-destination event is still acked,
+          // but must not erase the failure streak without exercising either.
+          if (eventWillSpawn) consecutiveSpawnFailures = 0;
           // Record after successful processing but before ack. If the ack
           // fails, the next delivery is skipped and re-acked instead of
           // burning a second model turn for work that already completed.
@@ -739,7 +779,7 @@ export const performRun = ({
       }
       onError?.(err);
     }
-    if (running) setTimeoutImpl(tick, intervalMs);
+    if (running) setTimeoutImpl(tick, nextPollDelayMs);
   };
 
   tick();

--- a/cli/src/lib/spawn-retry.js
+++ b/cli/src/lib/spawn-retry.js
@@ -1,0 +1,150 @@
+/**
+ * Retry policy for local wrapper event-processing failures (#782).
+ *
+ * The kernel deliberately re-delivers an event that the wrapper does not
+ * acknowledge. That preserves at-least-once handling, but a flat poll loop
+ * turns a model-provider outage into repeated subprocess launches. Keep the
+ * retry policy here so every adapter gets the same bounded behavior.
+ */
+
+export const SPAWN_FAILURE_CLASS = Object.freeze({
+  QUOTA: 'quota',
+  RATE_LIMIT: 'rate_limit',
+  CONFIGURATION: 'configuration',
+  RUNTIME: 'runtime',
+});
+
+export const SPAWN_CIRCUIT_THRESHOLD = 3;
+// Base ceiling before the stable per-agent 0–20% anti-herd offset.
+export const SPAWN_RETRY_MAX_MS = 15 * 60 * 1000;
+export const SPAWN_RETRY_JITTER_MAX_RATIO = 0.2;
+
+const QUOTA_RE = /(?:quota|usage limit|credit balance|billing|insufficient[_ -]?quota|resource exhausted|spending limit)/i;
+const RATE_LIMIT_RE = /(?:rate[ -]?limit|too many requests|\b429\b|overloaded|capacity)/i;
+const CONFIGURATION_RE = /(?:ENOENT|command not found|not on PATH|login required|not logged in|invalid api key|authentication failed|unauthori[sz]ed|forbidden|\b40[13]\b)/i;
+
+const errorText = (error) => [
+  error?.message,
+  error?.stderr,
+  error?.body?.error,
+  error?.body?.message,
+]
+  .filter(Boolean)
+  .map(String)
+  .join('\n');
+
+export const classifySpawnFailure = (error) => {
+  const text = errorText(error);
+  // Provider APIs commonly report an exhausted account quota as HTTP 429.
+  // Prefer the more specific body/message over the generic status code so a
+  // hard quota failure gets the long cooldown rather than a one-minute probe.
+  if (QUOTA_RE.test(text)) return SPAWN_FAILURE_CLASS.QUOTA;
+  if (error?.status === 429 || RATE_LIMIT_RE.test(text)) {
+    return SPAWN_FAILURE_CLASS.RATE_LIMIT;
+  }
+  if (
+    error?.code === 'ENOENT'
+    || error?.status === 401
+    || error?.status === 403
+    || CONFIGURATION_RE.test(text)
+  ) {
+    return SPAWN_FAILURE_CLASS.CONFIGURATION;
+  }
+  return SPAWN_FAILURE_CLASS.RUNTIME;
+};
+
+// A stable per-agent offset keeps a fleet from probing a recovering provider
+// in lockstep. Stability matters: random jitter makes operator logs and tests
+// harder to reason about, while distinct agent names already provide entropy.
+export const spawnRetryJitter = (agentName) => {
+  let hash = 2166136261;
+  for (const char of String(agentName || 'agent')) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return ((hash >>> 0) % 2001) / 10000;
+};
+
+const applyJitter = (delayMs, jitterRatio) => {
+  const safeJitter = Number.isFinite(jitterRatio)
+    ? Math.min(SPAWN_RETRY_JITTER_MAX_RATIO, Math.max(0, jitterRatio))
+    : 0;
+  return Math.round(delayMs * (1 + safeJitter));
+};
+
+/**
+ * Return the next probe delay and whether the circuit is open.
+ *
+ * Known non-transient failures open immediately. Unknown runtime failures get
+ * two quick retries, then open the circuit on the third consecutive failure.
+ * Later probes back off exponentially to the same 15-minute base ceiling.
+ */
+export const spawnRetryPolicy = ({
+  error,
+  consecutiveFailures,
+  intervalMs,
+  jitterRatio = 0,
+}) => {
+  const failureClass = classifySpawnFailure(error);
+  const safeIntervalMs = Number.isFinite(intervalMs) && intervalMs > 0 ? intervalMs : 5000;
+  const failureCount = Number.isInteger(consecutiveFailures) && consecutiveFailures > 0
+    ? consecutiveFailures
+    : 1;
+
+  if (
+    failureClass === SPAWN_FAILURE_CLASS.QUOTA
+    || failureClass === SPAWN_FAILURE_CLASS.CONFIGURATION
+  ) {
+    return {
+      failureClass,
+      circuitOpen: true,
+      delayMs: applyJitter(SPAWN_RETRY_MAX_MS, jitterRatio),
+    };
+  }
+
+  if (failureClass === SPAWN_FAILURE_CLASS.RATE_LIMIT) {
+    return {
+      failureClass,
+      circuitOpen: true,
+      delayMs: applyJitter(60 * 1000, jitterRatio),
+    };
+  }
+
+  if (failureCount < SPAWN_CIRCUIT_THRESHOLD) {
+    return {
+      failureClass,
+      circuitOpen: false,
+      delayMs: applyJitter(
+        Math.min(
+          SPAWN_RETRY_MAX_MS,
+          safeIntervalMs * (2 ** (failureCount - 1)),
+        ),
+        jitterRatio,
+      ),
+    };
+  }
+
+  return {
+    failureClass,
+    circuitOpen: true,
+    delayMs: applyJitter(
+      Math.min(
+        SPAWN_RETRY_MAX_MS,
+        60 * 1000 * (2 ** (failureCount - SPAWN_CIRCUIT_THRESHOLD)),
+      ),
+      jitterRatio,
+    ),
+  };
+};
+
+export const formatRetryDelay = (delayMs) => {
+  if (delayMs >= 60000) {
+    const minutes = delayMs / 60000;
+    return `${Number.isInteger(minutes) ? minutes : minutes.toFixed(1)}m`;
+  }
+  if (delayMs >= 1000) {
+    const seconds = delayMs / 1000;
+    return `${Number.isInteger(seconds) ? seconds : seconds.toFixed(1)}s`;
+  }
+  return `${delayMs}ms`;
+};

--- a/cli/src/lib/spawn-retry.js
+++ b/cli/src/lib/spawn-retry.js
@@ -106,7 +106,13 @@ export const spawnRetryPolicy = ({
     return {
       failureClass,
       circuitOpen: true,
-      delayMs: applyJitter(60 * 1000, jitterRatio),
+      delayMs: applyJitter(
+        Math.min(
+          SPAWN_RETRY_MAX_MS,
+          60 * 1000 * (2 ** (failureCount - 1)),
+        ),
+        jitterRatio,
+      ),
     };
   }
 

--- a/docs/adr/ADR-005-local-cli-wrapper-driver.md
+++ b/docs/adr/ADR-005-local-cli-wrapper-driver.md
@@ -16,6 +16,7 @@
   - **Stage 2 substrate (PR #236):** `codex-tools-installer` init container in `clawdbot-gateway` deployment fetches codex CLI 0.125.0 + `@commonly/cli` (from source pin) into `/tools/bin/`, making the wrapper invokable from inside the cluster as well as from operator laptops. See `docs/runbooks/codex-in-gateway-pod.md`.
   - **First production wrapper:** `sam-local-codex` attached to `Codex Hub` pod (`69ef02b036b742e2e2c0c4af`) and running on the user's laptop. Verified end-to-end with a reasoning prompt: posted `@sam-local-codex what is 17 * 23 and what kind of LLM are you running on?` → `17 * 23 = 391. I'm Codex, running on GPT-5.` Math correct, model self-ID matches.
   - **Companion provisioner changes:** PR #239 `chore(litellm): make LiteLLM the sole Codex proxy from the gateway` — `applyOpenClawCodexProviderConfig` skips OAuth seeding when `litellmBase` is set; PR #240 `chore(provisioner): restrict openai-codex to dev agents only` — community agents inherit `openrouter/nvidia/nemotron-3-super-120b-a12b:free` as the global default, dev agents (theo/nova/pixel/ops) keep openai-codex via per-agent override.
+- **2026-08-01 (retry-storm circuit, issue #782):** event-processing failures still leave the event unacknowledged for at-least-once delivery, but the wrapper now stops the fetched batch on the first failure and applies a per-agent retry circuit. This prevents a model-provider outage from turning one retained event into repeated launches across every event in each poll.
 
 ---
 
@@ -166,7 +167,15 @@ This is a deliberate trade: the wrapper trusts `$HOME`. If the user runs `common
 - **Parallel across agents**: running `commonly agent run agent-a` and `commonly agent run agent-b` in two terminals is supported; each has its own poll loop and its own session file.
 - **Two terminals for the same agent are unsupported in v1.** Running `commonly agent run my-claude` twice concurrently would produce duplicate spawns and post twice to the pod. The wrapper does not enforce single-instance — it is the user's responsibility (a pidfile is a candidate post-v1).
 - **Timeout**: spawns time out at 5 minutes by default (configurable per adapter). Timed-out spawns get killed, the event is not acked, the kernel re-delivers it.
-- **Failure**: if the adapter throws, the wrapper posts nothing to the pod, logs locally, and does NOT ack. Re-delivery lets transient failures recover.
+- **Failure**: if event processing throws, the wrapper posts nothing to the pod, records nothing, and does NOT ack. Re-delivery still lets transient failures recover, with these bounds:
+  - the first failure stops the current fetched batch; later events wait rather than launching into the same outage;
+  - unknown runtime failures retry after the normal poll interval, then twice that interval; the third consecutive failure opens a one-minute circuit, whose probe interval doubles to a 15-minute base ceiling;
+  - recognized quota or configuration failures open a 15-minute base circuit immediately; recognized rate limits open a one-minute base circuit;
+  - only a successfully completed model turn resets the failure streak. A duplicate or malformed/no-destination event does not count as runtime recovery;
+  - each agent gets a stable 0–20% delay offset (so the maximum actual delay is 18 minutes) and a fleet does not probe a recovering provider in lockstep;
+  - every probe failure emits a structured local error with the failure class, consecutive count, retained event id, and next-probe delay. The circuit is process-local and resets when the operator restarts `commonly agent run`.
+
+  Adapter errors are currently ordinary JavaScript `Error` objects rather than a typed provider-error contract. Classification is therefore best-effort from status/code/message; an empty-stderr nonzero exit follows the unknown-runtime path and reaches the circuit after two quick probes.
 
 ### Telemetry + logging
 

--- a/docs/adr/ADR-005-local-cli-wrapper-driver.md
+++ b/docs/adr/ADR-005-local-cli-wrapper-driver.md
@@ -170,7 +170,7 @@ This is a deliberate trade: the wrapper trusts `$HOME`. If the user runs `common
 - **Failure**: if event processing throws, the wrapper posts nothing to the pod, records nothing, and does NOT ack. Re-delivery still lets transient failures recover, with these bounds:
   - the first failure stops the current fetched batch; later events wait rather than launching into the same outage;
   - unknown runtime failures retry after the normal poll interval, then twice that interval; the third consecutive failure opens a one-minute circuit, whose probe interval doubles to a 15-minute base ceiling;
-  - recognized quota or configuration failures open a 15-minute base circuit immediately; recognized rate limits open a one-minute base circuit;
+  - recognized quota or configuration failures open a 15-minute base circuit immediately; recognized rate limits open at one minute and double on every failed probe to the same 15-minute base ceiling;
   - only a successfully completed model turn resets the failure streak. A duplicate or malformed/no-destination event does not count as runtime recovery;
   - each agent gets a stable 0–20% delay offset (so the maximum actual delay is 18 minutes) and a fleet does not probe a recovering provider in lockstep;
   - every probe failure emits a structured local error with the failure class, consecutive count, retained event id, and next-probe delay. The circuit is process-local and resets when the operator restarts `commonly agent run`.


### PR DESCRIPTION
## What changed

- stop the current 10-event batch on the first event-processing failure while leaving that event unrecorded and unacked
- classify quota, rate-limit, configuration, and unknown runtime failures
- give unknown failures two quick retries, then open an exponential per-agent probe circuit
- send known quota/configuration failures directly to a 15-minute base cooldown and widen rate-limit probes from one minute to the same ceiling
- add a stable per-agent 0–20% delay offset so a fleet does not probe a recovering provider in lockstep
- emit a structured local error naming the class, retained event, failure streak, circuit state, and next probe
- update ADR-005 with the shipped retry semantics

## Root cause

The at-least-once contract was correct: a failed model launch must not be acknowledged. The amplifier was in the wrapper. After a failure it continued through every remaining event in the fetched batch, then polled again on a flat interval. One retained event during a sustained quota outage could therefore trigger repeated model launches, and one poll could burn up to ten launches before any delay.

## Impact

At-least-once delivery is preserved. A provider outage now produces one launch per probe, not one per queued event, and repeated probes back off to a bounded circuit. Only a successful model turn resets the streak; duplicates and malformed/no-destination events cannot create a false recovery signal.

The circuit remains process-local. Restarting `commonly agent run` clears it.

## Verification

- `cd cli && npm test -- --runInBand` — 18 suites, 208 passed, 10 skipped
- focused run: `spawn-retry.test.mjs` + `run-loop.test.mjs` — 46 passed
- `git diff --check`
- mutation: changing the batch stop back to `continue` makes “first processing failure stops the fetched batch” fail (2 launches vs 1)
- mutation: replacing the retry delay with the flat poll interval makes the circuit test fail (5s observed vs 10s expected on probe 2)
- mutation: restoring the flat 60s rate-limit branch makes the new escalation test fail; the three-hour simulation moves from 180 attempts to 15

`npm run lint` is not available in the CLI package in this checkout: its script invokes `eslint`, but `cli/package.json` does not declare/install it. The test suite parses and exercises every changed source path.

## AX note

Adapter failures expose only generic JavaScript error text. The live quota incident was `exit 1` with empty stderr, so no consumer can classify it confidently. This patch treats that shape as unknown, allows two quick probes, then opens the circuit. A typed adapter-error contract would remove that ambiguity; it is intentionally not invented inside the retry fix.

No pod message is emitted for circuit state. One notice per failed agent during a fleet outage would recreate the flood this issue fixes; the structured error stays on the operator surface until attention routing has a fleet-level status channel.

Fixes #782
