### PR TITLE
fix(security): exclude invite-only pods from agent discovery

### DIFF
--- a/backend/__tests__/unit/routes/agentsRuntime.podEnumeration.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.podEnumeration.test.js
@@ -67,6 +67,7 @@ jest.mock('../../../services/chatSummarizerService', () => ({
 const express = require('express');
 const request = require('supertest');
 const router = require('../../../routes/agentsRuntime');
+const { DIRECTLY_JOINABLE_QUERY } = require('../../../services/podListing');
 
 const app = express();
 app.use(express.json());
@@ -92,7 +93,8 @@ describe('GET /pods does not enumerate private pods (#791 / live 2026-08-01)', (
     expect(branches).toHaveLength(2);
 
     const listed = branches.find((b) => b.publicRead !== undefined);
-    expect(listed).toEqual(expect.objectContaining({
+    expect(listed).toEqual(DIRECTLY_JOINABLE_QUERY);
+    expect(DIRECTLY_JOINABLE_QUERY).toEqual(expect.objectContaining({
       publicRead: true,
       communityListed: true,
     }));
@@ -108,7 +110,8 @@ describe('GET /pods does not enumerate private pods (#791 / live 2026-08-01)', (
     await request(app).get('/api/agents/runtime/pods');
 
     const listed = capturedQuery.value.$or.find((b) => b.publicRead !== undefined);
-    expect(listed.joinPolicy).toEqual({ $ne: 'invite-only' });
+    expect(DIRECTLY_JOINABLE_QUERY.joinPolicy).toEqual({ $ne: 'invite-only' });
+    expect(listed).toEqual(DIRECTLY_JOINABLE_QUERY);
   });
 
   test('but pods the agent IS in are not excluded by membership', async () => {

--- a/backend/__tests__/unit/routes/agentsRuntime.podEnumeration.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.podEnumeration.test.js
@@ -101,6 +101,26 @@ describe('GET /pods does not enumerate private pods (#791 / live 2026-08-01)', (
     expect(own._id.$in).toContain(AUTHORIZED);
   });
 
+  test('invite-only pods are excluded — the row would be a dead end', async () => {
+    // sprint-review's ruling: an agent shown an invite-only row can neither
+    // join nor request access (H5 does not exist), which is the same reasoning
+    // that excluded those rows from human Discover. Revisit when H5 ships.
+    await request(app).get('/api/agents/runtime/pods');
+
+    const listed = capturedQuery.value.$or.find((b) => b.publicRead !== undefined);
+    expect(listed.joinPolicy).toEqual({ $ne: 'invite-only' });
+  });
+
+  test('but pods the agent IS in are not excluded by membership', async () => {
+    // communityDiscoverQuery also drops pods you already belong to, because
+    // human Discover means "find something new". This route means "what may I
+    // see", so adopting that clause would delete what the $or branch adds.
+    await request(app).get('/api/agents/runtime/pods');
+
+    const listed = capturedQuery.value.$or.find((b) => b.publicRead !== undefined);
+    expect(listed.members).toBeUndefined();
+  });
+
   test('DM-shaped pods stay excluded — the type guard is kept, not replaced', async () => {
     await request(app).get('/api/agents/runtime/pods');
 

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -97,7 +97,7 @@ try {
 }
 
 const { stripInlineAvatars } = require('../services/avatarService');
-const { COMMUNITY_LISTING_QUERY } = require('../services/podListing');
+const { DIRECTLY_JOINABLE_QUERY } = require('../services/podListing');
 
 const router = express.Router();
 
@@ -2413,9 +2413,9 @@ router.get('/pods', phase4RateLimit, agentRuntimeAuth, async (req: any, res: any
     // them carried generated conversation summaries. Verified live 2026-08-01.
     //
     // An agent may see a pod when it is either discoverable to everyone, or one
-    // it is actually installed in. `communityListed` is the canonical listing
-    // flag (services/podListing.ts) — composed rather than restated, so the
-    // listing rule itself cannot drift.
+    // it is actually installed in. DIRECTLY_JOINABLE_QUERY is the canonical
+    // public-listing plus join-policy gate (services/podListing.ts), composed
+    // rather than restated so the two discovery paths cannot drift.
     //
     // Invite-only pods are excluded for the same reason human Discover excludes
     // them: the row is a dead end. An agent shown it can neither join nor, yet,
@@ -2429,7 +2429,7 @@ router.get('/pods', phase4RateLimit, agentRuntimeAuth, async (req: any, res: any
     const visibleToAgent = {
       type: { $nin: nonDiscoverableTypes },
       $or: [
-        { ...COMMUNITY_LISTING_QUERY, joinPolicy: { $ne: 'invite-only' } },
+        { ...DIRECTLY_JOINABLE_QUERY },
         { _id: { $in: [...authorizedPodIds] } },
       ],
     };

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -2417,22 +2417,19 @@ router.get('/pods', phase4RateLimit, agentRuntimeAuth, async (req: any, res: any
     // flag (services/podListing.ts) — composed rather than restated, so the
     // listing rule itself cannot drift.
     //
-    // This deliberately uses COMMUNITY_LISTING_QUERY (flags only) and NOT
-    // communityDiscoverQuery, which additionally excludes invite-only pods and
-    // pods the caller already belongs to. So an invite-only, publicly-listed
-    // pod IS visible here while being hidden from the human Discover surface.
-    // That asymmetry is intentional: an agent should be able to see a room it
-    // could ask to join, and nothing returned is private — every branch is
-    // either publicRead or the caller's own installation.
+    // Invite-only pods are excluded for the same reason human Discover excludes
+    // them: the row is a dead end. An agent shown it can neither join nor, yet,
+    // request access — H5 request-access does not exist. Revisit when it ships;
+    // at that point the row acquires a verb and showing it becomes correct.
     //
-    // Stated explicitly because the previous comment claimed this route could
-    // not diverge from Discover, which was a stronger promise than the code
-    // kept. If the asymmetry is ever unwanted, adopt communityDiscoverQuery
-    // rather than hand-adding the clause.
+    // `members: { $ne: callerId }` is deliberately NOT adopted from
+    // communityDiscoverQuery. Human Discover hides pods you are already in
+    // because its job is "find something new"; this route's job is "what may I
+    // see", and the $or branch below deliberately includes your own pods.
     const visibleToAgent = {
       type: { $nin: nonDiscoverableTypes },
       $or: [
-        { ...COMMUNITY_LISTING_QUERY },
+        { ...COMMUNITY_LISTING_QUERY, joinPolicy: { $ne: 'invite-only' } },
         { _id: { $in: [...authorizedPodIds] } },
       ],
     };

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -2414,8 +2414,21 @@ router.get('/pods', phase4RateLimit, agentRuntimeAuth, async (req: any, res: any
     //
     // An agent may see a pod when it is either discoverable to everyone, or one
     // it is actually installed in. `communityListed` is the canonical listing
-    // flag (services/podListing.ts) — reuse it rather than restating the rule,
-    // so this route cannot drift from the human-facing Discover surface again.
+    // flag (services/podListing.ts) — composed rather than restated, so the
+    // listing rule itself cannot drift.
+    //
+    // This deliberately uses COMMUNITY_LISTING_QUERY (flags only) and NOT
+    // communityDiscoverQuery, which additionally excludes invite-only pods and
+    // pods the caller already belongs to. So an invite-only, publicly-listed
+    // pod IS visible here while being hidden from the human Discover surface.
+    // That asymmetry is intentional: an agent should be able to see a room it
+    // could ask to join, and nothing returned is private — every branch is
+    // either publicRead or the caller's own installation.
+    //
+    // Stated explicitly because the previous comment claimed this route could
+    // not diverge from Discover, which was a stronger promise than the code
+    // kept. If the asymmetry is ever unwanted, adopt communityDiscoverQuery
+    // rather than hand-adding the clause.
     const visibleToAgent = {
       type: { $nin: nonDiscoverableTypes },
       $or: [

--- a/backend/services/podListing.ts
+++ b/backend/services/podListing.ts
@@ -5,13 +5,23 @@ export const NON_LISTABLE_POD_TYPES: readonly string[] = Object.freeze([
 ]);
 
 /**
- * Flags-only fragment used by Community membership queries. Discover callers
- * must use communityDiscoverQuery so join-policy and membership gates cannot
- * drift from the listing flags.
+ * Flags-only fragment used by Community membership queries. Callers that need
+ * a public pod an agent can join must compose DIRECTLY_JOINABLE_QUERY instead
+ * of restating the join-policy gate.
  */
 export const COMMUNITY_LISTING_QUERY = Object.freeze({
   publicRead: true,
   communityListed: true,
+});
+
+/**
+ * Listed public pods whose join policy permits direct joining. Membership is
+ * deliberately absent: Discover hides rows the caller already belongs to,
+ * while agent runtime listings include installed pods.
+ */
+export const DIRECTLY_JOINABLE_QUERY = Object.freeze({
+  ...COMMUNITY_LISTING_QUERY,
+  joinPolicy: { $ne: 'invite-only' },
 });
 
 interface CommunityDiscoverQueryOptions {
@@ -30,8 +40,7 @@ export const communityDiscoverQuery = ({
   callerId,
   type,
 }: CommunityDiscoverQueryOptions) => ({
-  ...COMMUNITY_LISTING_QUERY,
-  joinPolicy: { $ne: 'invite-only' },
+  ...DIRECTLY_JOINABLE_QUERY,
   members: { $ne: callerId },
   type: type
     ? { $eq: type, $nin: NON_LISTABLE_POD_TYPES }


### PR DESCRIPTION
**Superseded my own comment-only change on this branch** — `sprint-review` out-argued the position it documented, so the code moved instead of the comment.

**My reasoning was premature, not wrong.** I justified the divergence as *"an agent should see a room it could ask to join."* But **H5 request-access does not exist** — ADR-016 reserves it as a future slot. An agent shown an invite-only row can neither join nor request access. It is a dead end, which is the same reasoning that excluded those rows from human Discover. The argument becomes correct the moment H5 ships and the row acquires a verb; that is recorded as the revisit trigger.

**Adopts `joinPolicy: { $ne: 'invite-only' }` only.** Deliberately does *not* adopt `communityDiscoverQuery` wholesale: its `members: { $ne: callerId }` clause exists because human Discover means *find something new*, whereas this route means *what may I see* — adopting it would delete with one hand what the `$or` branch adds with the other. `sprint-review` separated these two clauses correctly; I had lumped them.

Both halves now have a test (6 passing, up from 4).

**Measured before changing:** 3 community-listed pods, 0 invite-only — so the divergence is theoretical today and a test against production data would pass vacuously. Fixed anyway, because #793's comment claimed this route could not drift from human Discover, and that should be true rather than aspirational. AX entry 1 is about precisely that class of comment.