### PR TITLE
fix(agents): page runtime message history

### DIFF
--- a/backend/__tests__/unit/models/PgMessage.test.js
+++ b/backend/__tests__/unit/models/PgMessage.test.js
@@ -68,6 +68,18 @@ describe('PG Message model', () => {
     expect(res[0]).toHaveProperty('messageType', 'text');
   });
 
+  it('findByPodId applies the exclusive before cursor', async () => {
+    const before = '2026-08-01T00:00:00.000Z';
+    pool.query.mockResolvedValueOnce({ rows: [] });
+
+    await Message.findByPodId('p', 5, before);
+
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('m.created_at < $2'),
+      ['p', before, 5],
+    );
+  });
+
   it('findById returns formatted message', async () => {
     pool.query.mockResolvedValueOnce({
       rows: [

--- a/backend/__tests__/unit/routes/agentsRuntime.messagesPagination.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.messagesPagination.test.js
@@ -68,7 +68,7 @@ describe('GET /pods/:podId/messages pagination contract (#795)', () => {
 
     expect(res.status).toBe(200);
     expect(AgentMessageService.getRecentMessages)
-      .toHaveBeenCalledWith('pod-1', 3, 'bot-1', cursor);
+      .toHaveBeenCalledWith('pod-1', 3, 'bot-1', new Date(cursor));
     expect(res.body).toEqual({
       messages: [
         { id: 'page-oldest', createdAt: '2026-07-31T21:00:00.000Z' },
@@ -115,8 +115,21 @@ describe('GET /pods/:podId/messages pagination contract (#795)', () => {
     expect(AgentMessageService.getRecentMessages).not.toHaveBeenCalled();
   });
 
+  test('rejects an operator-shaped cursor instead of passing a query object through', async () => {
+    const res = await request(app)
+      .get('/api/agents/runtime/pods/pod-1/messages?before%5B%24gt%5D=2026-08-01');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual(expect.objectContaining({
+      code: 'invalid_query_parameter',
+      parameter: 'before',
+    }));
+    expect(AgentMessageService.getRecentMessages).not.toHaveBeenCalled();
+  });
+
   test.each([
     ['before', 'not-a-timestamp'],
+    ['before', '{"$gt":""}'],
     ['limit', '2.5'],
   ])('rejects malformed %s instead of answering a different query', async (parameter, value) => {
     const res = await request(app)

--- a/backend/__tests__/unit/routes/agentsRuntime.messagesPagination.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.messagesPagination.test.js
@@ -68,7 +68,7 @@ describe('GET /pods/:podId/messages pagination contract (#795)', () => {
 
     expect(res.status).toBe(200);
     expect(AgentMessageService.getRecentMessages)
-      .toHaveBeenCalledWith('pod-1', 3, 'bot-1', new Date(cursor));
+      .toHaveBeenCalledWith('pod-1', 3, 'bot-1', Date.parse(cursor));
     expect(res.body).toEqual({
       messages: [
         { id: 'page-oldest', createdAt: '2026-07-31T21:00:00.000Z' },

--- a/backend/__tests__/unit/routes/agentsRuntime.messagesPagination.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.messagesPagination.test.js
@@ -1,0 +1,132 @@
+/**
+ * #795 — agent history pagination must be truthful.
+ *
+ * The live route accepted `before` and `offset` but silently ignored both,
+ * returning a plausible newest page to callers that had asked for older
+ * history. These tests mount the real router so the query contract, cursor
+ * wiring, and page-boundary response are checked together.
+ */
+
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(), verify: jest.fn(), decode: jest.fn() }));
+
+jest.mock('../../../middleware/agentRuntimeAuth', () => (req, res, next) => {
+  req.agentUser = { _id: 'bot-1' };
+  req.agentInstallations = [{ podId: 'pod-1', status: 'active' }];
+  req.agentAuthorizedPodIds = ['pod-1'];
+  next();
+});
+jest.mock('../../../middleware/auth', () => (req, res, next) => next());
+jest.mock('../../../middleware/apiTokenScopes', () => ({
+  requireApiTokenScopes: () => (req, res, next) => next(),
+}));
+
+jest.mock('../../../services/agentEventService', () => ({}));
+jest.mock('../../../services/agentIdentityService', () => ({
+  buildAgentUsername: jest.fn((a) => a),
+}));
+jest.mock('../../../services/agentMessageService', () => ({
+  getRecentMessages: jest.fn(),
+}));
+jest.mock('../../../services/agentThreadService', () => ({}));
+jest.mock('../../../services/podContextService', () => ({}));
+jest.mock('../../../services/globalModelConfigService', () => ({}));
+jest.mock('../../../services/socialPolicyService', () => ({}));
+jest.mock('../../../integrations', () => ({ get: jest.fn() }));
+jest.mock('../../../models/Activity', () => ({}));
+jest.mock('../../../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/Post', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/Pod', () => ({ find: jest.fn() }));
+jest.mock('../../../services/dmService', () => ({ getOrCreateAgentDM: jest.fn() }));
+jest.mock('../../../models/Integration', () => ({ find: jest.fn(), findOne: jest.fn() }));
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { findOne: jest.fn(), find: jest.fn() },
+}));
+
+const express = require('express');
+const request = require('supertest');
+const AgentMessageService = require('../../../services/agentMessageService');
+const router = require('../../../routes/agentsRuntime');
+
+const app = express();
+app.use(express.json());
+app.use('/api/agents/runtime', router);
+
+const cursor = '2026-08-01T00:00:00.000Z';
+
+describe('GET /pods/:podId/messages pagination contract (#795)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('passes before through and proves another page with one extra row', async () => {
+    AgentMessageService.getRecentMessages.mockResolvedValue([
+      { id: 'proof-row', createdAt: '2026-07-31T20:00:00.000Z' },
+      { id: 'page-oldest', createdAt: '2026-07-31T21:00:00.000Z' },
+      { id: 'page-newest', createdAt: '2026-07-31T22:00:00.000Z' },
+    ]);
+
+    const res = await request(app)
+      .get(`/api/agents/runtime/pods/pod-1/messages?limit=2&before=${encodeURIComponent(cursor)}`);
+
+    expect(res.status).toBe(200);
+    expect(AgentMessageService.getRecentMessages)
+      .toHaveBeenCalledWith('pod-1', 3, 'bot-1', cursor);
+    expect(res.body).toEqual({
+      messages: [
+        { id: 'page-oldest', createdAt: '2026-07-31T21:00:00.000Z' },
+        { id: 'page-newest', createdAt: '2026-07-31T22:00:00.000Z' },
+      ],
+      hasMore: true,
+    });
+  });
+
+  test('reports end-of-history when the extra row is absent', async () => {
+    AgentMessageService.getRecentMessages.mockResolvedValue([
+      { id: 'oldest', createdAt: '2026-07-31T21:00:00.000Z' },
+      { id: 'newest', createdAt: '2026-07-31T22:00:00.000Z' },
+    ]);
+
+    const res = await request(app)
+      .get('/api/agents/runtime/pods/pod-1/messages?limit=2');
+
+    expect(res.status).toBe(200);
+    expect(res.body.hasMore).toBe(false);
+    expect(res.body.messages.map((message) => message.id)).toEqual(['oldest', 'newest']);
+  });
+
+  test('keeps the documented 50-message clamp while fetching a proof row', async () => {
+    AgentMessageService.getRecentMessages.mockResolvedValue([]);
+
+    const res = await request(app)
+      .get('/api/agents/runtime/pods/pod-1/messages?limit=200');
+
+    expect(res.status).toBe(200);
+    expect(AgentMessageService.getRecentMessages.mock.calls[0][1]).toBe(51);
+  });
+
+  test('rejects unsupported query parameters instead of silently dropping them', async () => {
+    const res = await request(app)
+      .get('/api/agents/runtime/pods/pod-1/messages?offset=10');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual(expect.objectContaining({
+      code: 'unsupported_query_parameters',
+      unsupportedQueryParams: ['offset'],
+    }));
+    expect(res.body.message).toContain('Supported parameters: limit, before');
+    expect(AgentMessageService.getRecentMessages).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['before', 'not-a-timestamp'],
+    ['limit', '2.5'],
+  ])('rejects malformed %s instead of answering a different query', async (parameter, value) => {
+    const res = await request(app)
+      .get(`/api/agents/runtime/pods/pod-1/messages?${parameter}=${encodeURIComponent(value)}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual(expect.objectContaining({
+      code: 'invalid_query_parameter',
+      parameter,
+    }));
+    expect(AgentMessageService.getRecentMessages).not.toHaveBeenCalled();
+  });
+});

--- a/backend/__tests__/unit/services/agentMessageService.selfIdentity.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.selfIdentity.test.js
@@ -31,13 +31,17 @@ const POD = 'pod-1';
 const SELF = 'agent-user-1';
 const OTHER = 'agent-user-2';
 
-// Mongo path: Message.find(...).sort(...).limit(...).populate(...).lean()
+// Mongo path: Message.find(...).where(...).lt(...).sort(...).limit(...).populate(...).lean()
 const mockMongoChain = (rows) => {
-  const populate = jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(rows) });
-  const limit = jest.fn().mockReturnValue({ populate });
-  const sort = jest.fn().mockReturnValue({ limit });
-  Message.find.mockReturnValue({ sort });
-  return { populate };
+  const query = {};
+  query.where = jest.fn().mockReturnValue(query);
+  query.lt = jest.fn().mockReturnValue(query);
+  query.sort = jest.fn().mockReturnValue(query);
+  query.limit = jest.fn().mockReturnValue(query);
+  query.populate = jest.fn().mockReturnValue(query);
+  query.lean = jest.fn().mockResolvedValue(rows);
+  Message.find.mockReturnValue(query);
+  return query;
 };
 
 describe('getRecentMessages — PG path', () => {
@@ -172,14 +176,13 @@ describe('getRecentMessages — Mongo fallback path', () => {
 
   test('applies the same exclusive history cursor on the Mongo fallback', async () => {
     const beforeMs = Date.parse('2026-08-01T00:00:00.000Z');
-    mockMongoChain([]);
+    const query = mockMongoChain([]);
 
     await AgentMessageService.getRecentMessages(POD, 10, SELF, beforeMs);
 
-    expect(Message.find).toHaveBeenCalledWith({
-      podId: POD,
-      createdAt: { $lt: new Date(beforeMs) },
-    });
+    expect(Message.find).toHaveBeenCalledWith({ podId: POD });
+    expect(query.where).toHaveBeenCalledWith('createdAt');
+    expect(query.lt).toHaveBeenCalledWith(new Date(beforeMs));
   });
 });
 

--- a/backend/__tests__/unit/services/agentMessageService.selfIdentity.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.selfIdentity.test.js
@@ -66,6 +66,15 @@ describe('getRecentMessages — PG path', () => {
     expect(out.map((m) => m.self)).toEqual([true, false]);
   });
 
+  test('passes the exclusive history cursor to PostgreSQL', async () => {
+    const before = '2026-08-01T00:00:00.000Z';
+    PGMessage.findByPodId.mockResolvedValue([]);
+
+    await AgentMessageService.getRecentMessages(POD, 10, SELF, before);
+
+    expect(PGMessage.findByPodId).toHaveBeenCalledWith(POD, 10, before);
+  });
+
   // Its absence is how a client detects a server too old to compute `self`.
   test('omits `self` when no caller identity is given', async () => {
     PGMessage.findByPodId.mockResolvedValue([
@@ -146,6 +155,18 @@ describe('getRecentMessages — Mongo fallback path', () => {
     const theirs = out.find((m) => String(m.userId._id) === OTHER);
     expect(mine.self).toBe(true);
     expect(theirs.self).toBe(false);
+  });
+
+  test('applies the same exclusive history cursor on the Mongo fallback', async () => {
+    const before = '2026-08-01T00:00:00.000Z';
+    mockMongoChain([]);
+
+    await AgentMessageService.getRecentMessages(POD, 10, SELF, before);
+
+    expect(Message.find).toHaveBeenCalledWith({
+      podId: POD,
+      createdAt: { $lt: new Date(before) },
+    });
   });
 });
 

--- a/backend/__tests__/unit/services/agentMessageService.selfIdentity.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.selfIdentity.test.js
@@ -67,12 +67,23 @@ describe('getRecentMessages — PG path', () => {
   });
 
   test('passes the exclusive history cursor to PostgreSQL', async () => {
-    const before = '2026-08-01T00:00:00.000Z';
+    const before = new Date('2026-08-01T00:00:00.000Z');
     PGMessage.findByPodId.mockResolvedValue([]);
 
     await AgentMessageService.getRecentMessages(POD, 10, SELF, before);
 
-    expect(PGMessage.findByPodId).toHaveBeenCalledWith(POD, 10, before);
+    expect(PGMessage.findByPodId).toHaveBeenCalledWith(POD, 10, before.toISOString());
+  });
+
+  test.each([
+    ['a raw string', '2026-08-01T00:00:00.000Z'],
+    ['an invalid Date', new Date(Number.NaN)],
+  ])('rejects %s before any database query', async (_label, before) => {
+    await expect(AgentMessageService.getRecentMessages(POD, 10, SELF, before))
+      .rejects.toThrow('before must be a valid Date');
+
+    expect(PGMessage.findByPodId).not.toHaveBeenCalled();
+    expect(Message.find).not.toHaveBeenCalled();
   });
 
   // Its absence is how a client detects a server too old to compute `self`.
@@ -158,14 +169,14 @@ describe('getRecentMessages — Mongo fallback path', () => {
   });
 
   test('applies the same exclusive history cursor on the Mongo fallback', async () => {
-    const before = '2026-08-01T00:00:00.000Z';
+    const before = new Date('2026-08-01T00:00:00.000Z');
     mockMongoChain([]);
 
     await AgentMessageService.getRecentMessages(POD, 10, SELF, before);
 
     expect(Message.find).toHaveBeenCalledWith({
       podId: POD,
-      createdAt: { $lt: new Date(before) },
+      createdAt: { $lt: before },
     });
   });
 });

--- a/backend/__tests__/unit/services/agentMessageService.selfIdentity.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.selfIdentity.test.js
@@ -67,20 +67,22 @@ describe('getRecentMessages — PG path', () => {
   });
 
   test('passes the exclusive history cursor to PostgreSQL', async () => {
-    const before = new Date('2026-08-01T00:00:00.000Z');
+    const beforeMs = Date.parse('2026-08-01T00:00:00.000Z');
     PGMessage.findByPodId.mockResolvedValue([]);
 
-    await AgentMessageService.getRecentMessages(POD, 10, SELF, before);
+    await AgentMessageService.getRecentMessages(POD, 10, SELF, beforeMs);
 
-    expect(PGMessage.findByPodId).toHaveBeenCalledWith(POD, 10, before.toISOString());
+    expect(PGMessage.findByPodId).toHaveBeenCalledWith(
+      POD, 10, new Date(beforeMs).toISOString(),
+    );
   });
 
   test.each([
     ['a raw string', '2026-08-01T00:00:00.000Z'],
-    ['an invalid Date', new Date(Number.NaN)],
+    ['NaN', Number.NaN],
   ])('rejects %s before any database query', async (_label, before) => {
     await expect(AgentMessageService.getRecentMessages(POD, 10, SELF, before))
-      .rejects.toThrow('before must be a valid Date');
+      .rejects.toThrow('beforeMs must be a valid epoch timestamp');
 
     expect(PGMessage.findByPodId).not.toHaveBeenCalled();
     expect(Message.find).not.toHaveBeenCalled();
@@ -169,14 +171,14 @@ describe('getRecentMessages — Mongo fallback path', () => {
   });
 
   test('applies the same exclusive history cursor on the Mongo fallback', async () => {
-    const before = new Date('2026-08-01T00:00:00.000Z');
+    const beforeMs = Date.parse('2026-08-01T00:00:00.000Z');
     mockMongoChain([]);
 
-    await AgentMessageService.getRecentMessages(POD, 10, SELF, before);
+    await AgentMessageService.getRecentMessages(POD, 10, SELF, beforeMs);
 
     expect(Message.find).toHaveBeenCalledWith({
       podId: POD,
-      createdAt: { $lt: before },
+      createdAt: { $lt: new Date(beforeMs) },
     });
   });
 });

--- a/backend/__tests__/unit/services/agentMessageService.selfIdentity.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.selfIdentity.test.js
@@ -180,7 +180,7 @@ describe('getRecentMessages — Mongo fallback path', () => {
 
     await AgentMessageService.getRecentMessages(POD, 10, SELF, beforeMs);
 
-    expect(Message.find).toHaveBeenCalledWith({ podId: POD });
+    expect(Message.find).toHaveBeenCalledWith({ podId: { $eq: POD } });
     expect(query.where).toHaveBeenCalledWith('createdAt');
     expect(query.lt).toHaveBeenCalledWith(new Date(beforeMs));
   });

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -1336,16 +1336,51 @@ router.get('/pods/:podId/messages', agentRuntimeAuth, async (req: any, res: any)
       return res.status(403).json({ message: 'Agent token not authorized for this pod' });
     }
 
-    const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 20, 1), 50);
+    const supportedQueryParams = new Set(['limit', 'before']);
+    const unsupportedQueryParams = Object.keys(req.query || {})
+      .filter((key) => !supportedQueryParams.has(key));
+    if (unsupportedQueryParams.length > 0) {
+      return res.status(400).json({
+        message: `Unsupported query parameter(s): ${unsupportedQueryParams.join(', ')}. Supported parameters: limit, before.`,
+        code: 'unsupported_query_parameters',
+        unsupportedQueryParams,
+      });
+    }
+
+    const rawLimit = req.query?.limit;
+    if (rawLimit !== undefined
+      && (typeof rawLimit !== 'string' || !/^\d+$/.test(rawLimit) || Number(rawLimit) < 1)) {
+      return res.status(400).json({
+        message: 'limit must be a positive integer',
+        code: 'invalid_query_parameter',
+        parameter: 'limit',
+      });
+    }
+    const limit = Math.min(Number(rawLimit || 20), 50);
+
+    const before = req.query?.before;
+    if (before !== undefined
+      && (typeof before !== 'string' || !before.trim() || Number.isNaN(Date.parse(before)))) {
+      return res.status(400).json({
+        message: 'before must be a valid timestamp',
+        code: 'invalid_query_parameter',
+        parameter: 'before',
+      });
+    }
+
     // Pass the caller's own user id so each message carries a server-computed
     // `self` flag. The wrapper uses it to tell "I posted via my tool" from
     // "some OTHER agent posted while I was thinking" — the latter used to
     // silently swallow this agent's reply in any multi-agent pod (#757).
     const messages = await AgentMessageService.getRecentMessages(
-      podId, limit, req.agentUser?._id,
+      podId, limit + 1, req.agentUser?._id, before,
     );
+    const hasMore = messages.length > limit;
+    // getRecentMessages returns chronological order. The data query selected
+    // the newest `limit + 1` rows, so the extra proof row is the oldest one.
+    const page = hasMore ? messages.slice(-limit) : messages;
 
-    return res.json({ messages });
+    return res.json({ messages: page, hasMore });
   } catch (error: any) {
     console.error('Error fetching pod messages:', error);
     return res.status(500).json({ message: 'Failed to fetch messages' });

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -1358,15 +1358,18 @@ router.get('/pods/:podId/messages', agentRuntimeAuth, async (req: any, res: any)
     }
     const limit = Math.min(Number(rawLimit || 20), 50);
 
-    const before = req.query?.before;
-    if (before !== undefined
-      && (typeof before !== 'string' || !before.trim() || Number.isNaN(Date.parse(before)))) {
+    const rawBefore = req.query?.before;
+    if (rawBefore !== undefined
+      && (typeof rawBefore !== 'string'
+        || !rawBefore.trim()
+        || Number.isNaN(Date.parse(rawBefore)))) {
       return res.status(400).json({
         message: 'before must be a valid timestamp',
         code: 'invalid_query_parameter',
         parameter: 'before',
       });
     }
+    const before = rawBefore === undefined ? undefined : new Date(rawBefore);
 
     // Pass the caller's own user id so each message carries a server-computed
     // `self` flag. The wrapper uses it to tell "I posted via my tool" from

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -1369,14 +1369,14 @@ router.get('/pods/:podId/messages', agentRuntimeAuth, async (req: any, res: any)
         parameter: 'before',
       });
     }
-    const before = rawBefore === undefined ? undefined : new Date(rawBefore);
+    const beforeMs = rawBefore === undefined ? undefined : Date.parse(rawBefore);
 
     // Pass the caller's own user id so each message carries a server-computed
     // `self` flag. The wrapper uses it to tell "I posted via my tool" from
     // "some OTHER agent posted while I was thinking" — the latter used to
     // silently swallow this agent's reply in any multi-agent pod (#757).
     const messages = await AgentMessageService.getRecentMessages(
-      podId, limit + 1, req.agentUser?._id, before,
+      podId, limit + 1, req.agentUser?._id, beforeMs,
     );
     const hasMore = messages.length > limit;
     // getRecentMessages returns chronological order. The data query selected

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -1633,8 +1633,9 @@ class AgentMessageService {
    * is how a client detects an older server (see #757).
    *
    * `before` is an exclusive timestamp cursor applied identically on the PG
-   * and Mongo fallback paths. It must already be a validated Date so raw
-   * request values never cross this service boundary into a database query.
+   * and Mongo fallback paths. It must already be a validated epoch timestamp
+   * so raw request values never cross this service boundary into a database
+   * query and the query value cannot carry a user-controlled object shape.
    * Callers may request one extra row to determine whether an older page
    * exists without changing this array-shaped service contract for existing
    * internal consumers.
@@ -1643,15 +1644,18 @@ class AgentMessageService {
     podId: unknown,
     limit = 20,
     selfUserId?: unknown,
-    before?: Date,
+    beforeMs?: number,
   ): Promise<MessageNormalized[]> {
     if (!podId) {
       throw new Error('podId is required');
     }
-    if (before !== undefined
-      && (!(before instanceof Date) || Number.isNaN(before.getTime()))) {
-      throw new Error('before must be a valid Date');
+    if (beforeMs !== undefined
+      && (typeof beforeMs !== 'number'
+        || !Number.isFinite(beforeMs)
+        || Number.isNaN(new Date(beforeMs).getTime()))) {
+      throw new Error('beforeMs must be a valid epoch timestamp');
     }
+    const before = beforeMs === undefined ? undefined : new Date(beforeMs);
 
     const selfId = selfUserId ? String(selfUserId) : null;
     const withSelf = (authorId: unknown): { self?: boolean } => (

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -1701,7 +1701,7 @@ class AgentMessageService {
       }
     }
 
-    let messageQuery = Message.find({ podId });
+    let messageQuery = Message.find({ podId: { $eq: podId } });
     if (before) {
       messageQuery = messageQuery.where('createdAt').lt(before);
     }

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -1633,18 +1633,24 @@ class AgentMessageService {
    * is how a client detects an older server (see #757).
    *
    * `before` is an exclusive timestamp cursor applied identically on the PG
-   * and Mongo fallback paths. Callers may request one extra row to determine
-   * whether an older page exists without changing this array-shaped service
-   * contract for existing internal consumers.
+   * and Mongo fallback paths. It must already be a validated Date so raw
+   * request values never cross this service boundary into a database query.
+   * Callers may request one extra row to determine whether an older page
+   * exists without changing this array-shaped service contract for existing
+   * internal consumers.
    */
   static async getRecentMessages(
     podId: unknown,
     limit = 20,
     selfUserId?: unknown,
-    before?: string,
+    before?: Date,
   ): Promise<MessageNormalized[]> {
     if (!podId) {
       throw new Error('podId is required');
+    }
+    if (before !== undefined
+      && (!(before instanceof Date) || Number.isNaN(before.getTime()))) {
+      throw new Error('before must be a valid Date');
     }
 
     const selfId = selfUserId ? String(selfUserId) : null;
@@ -1660,7 +1666,7 @@ class AgentMessageService {
             limit: number,
             before?: string,
           ): Promise<Array<Record<string, unknown>>>;
-        }).findByPodId(String(podId), limit, before);
+        }).findByPodId(String(podId), limit, before?.toISOString());
 
         return messages.map((msg) => {
           const username = (msg.username as string) || 'Unknown';
@@ -1692,7 +1698,7 @@ class AgentMessageService {
     }
 
     const query: Record<string, unknown> = { podId };
-    if (before) query.createdAt = { $lt: new Date(before) };
+    if (before) query.createdAt = { $lt: before };
     const messages: Array<Record<string, unknown>> = await Message.find(query)
       .sort({ createdAt: -1 })
       .limit(limit)

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -1701,9 +1701,11 @@ class AgentMessageService {
       }
     }
 
-    const query: Record<string, unknown> = { podId };
-    if (before) query.createdAt = { $lt: before };
-    const messages: Array<Record<string, unknown>> = await Message.find(query)
+    let messageQuery = Message.find({ podId });
+    if (before) {
+      messageQuery = messageQuery.where('createdAt').lt(before);
+    }
+    const messages: Array<Record<string, unknown>> = await messageQuery
       .sort({ createdAt: -1 })
       .limit(limit)
       // `isBot` MUST stay in this projection: it is read below, and omitting it

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -1631,11 +1631,17 @@ class AgentMessageService {
    * owner-scoped and assigned at install. A client that guesses wrong silently
    * double-posts. Omit the argument and no `self` key is emitted at all, which
    * is how a client detects an older server (see #757).
+   *
+   * `before` is an exclusive timestamp cursor applied identically on the PG
+   * and Mongo fallback paths. Callers may request one extra row to determine
+   * whether an older page exists without changing this array-shaped service
+   * contract for existing internal consumers.
    */
   static async getRecentMessages(
     podId: unknown,
     limit = 20,
     selfUserId?: unknown,
+    before?: string,
   ): Promise<MessageNormalized[]> {
     if (!podId) {
       throw new Error('podId is required');
@@ -1649,8 +1655,12 @@ class AgentMessageService {
     if (PGMessage && process.env.PG_HOST) {
       try {
         const messages: Array<Record<string, unknown>> = await (PGMessage as {
-          findByPodId(id: string, limit: number): Promise<Array<Record<string, unknown>>>;
-        }).findByPodId(String(podId), limit);
+          findByPodId(
+            id: string,
+            limit: number,
+            before?: string,
+          ): Promise<Array<Record<string, unknown>>>;
+        }).findByPodId(String(podId), limit, before);
 
         return messages.map((msg) => {
           const username = (msg.username as string) || 'Unknown';
@@ -1681,7 +1691,9 @@ class AgentMessageService {
       }
     }
 
-    const messages: Array<Record<string, unknown>> = await Message.find({ podId })
+    const query: Record<string, unknown> = { podId };
+    if (before) query.createdAt = { $lt: new Date(before) };
+    const messages: Array<Record<string, unknown>> = await Message.find(query)
       .sort({ createdAt: -1 })
       .limit(limit)
       // `isBot` MUST stay in this projection: it is read below, and omitting it

--- a/commonly-mcp/__tests__/tools.test.mjs
+++ b/commonly-mcp/__tests__/tools.test.mjs
@@ -85,12 +85,17 @@ describe('commonly_post_message', () => {
 });
 
 describe('commonly_get_messages', () => {
-  it('GETs with limit in the query string', async () => {
+  it('GETs with limit and the history cursor in the query string', async () => {
     const fetchSpy = installFetch(async () => okResponse([]));
-    await byName.commonly_get_messages.call({ podId: 'POD', limit: 5 });
+    await byName.commonly_get_messages.call({
+      podId: 'POD',
+      limit: 5,
+      before: '2026-08-01T00:00:00.000Z',
+    });
     const [url] = fetchSpy.mock.calls[0];
     expect(url).toContain('/pods/POD/messages?');
     expect(url).toContain('limit=5');
+    expect(url).toContain('before=2026-08-01T00%3A00%3A00.000Z');
   });
 });
 

--- a/commonly-mcp/package-lock.json
+++ b/commonly-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@commonly/mcp",
-  "version": "0.1.0",
+  "name": "@commonlyai/mcp",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@commonly/mcp",
-      "version": "0.1.0",
+      "name": "@commonlyai/mcp",
+      "version": "0.1.9",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4"
       },

--- a/commonly-mcp/package.json
+++ b/commonly-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Commonly MCP Server \u2014 exposes the kernel HTTP surface (CAP per ADR-004) as standard MCP tools so any MCP-capable runtime can consume `commonly_*` tools without driver-specific code.",
   "type": "module",
   "bin": {

--- a/commonly-mcp/src/client.js
+++ b/commonly-mcp/src/client.js
@@ -13,7 +13,7 @@
  * `HttpError`. No global state beyond the env-derived config object.
  */
 
-const USER_AGENT = 'commonly-mcp/0.1.8';
+const USER_AGENT = 'commonly-mcp/0.1.9';
 
 export class HttpError extends Error {
   constructor(status, body, message) {

--- a/commonly-mcp/src/index.js
+++ b/commonly-mcp/src/index.js
@@ -28,7 +28,7 @@ import { loadConfig } from './client.js';
 import { buildTools } from './tools.js';
 
 const PACKAGE_NAME = '@commonlyai/mcp';
-const PACKAGE_VERSION = '0.1.8';
+const PACKAGE_VERSION = '0.1.9';
 
 const main = async () => {
   // Fail fast on missing env. The MCP host (codex/claude) will surface this

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -93,15 +93,16 @@ export const buildTools = (config) => {
     },
     {
       name: 'commonly_get_messages',
-      description: 'Read recent chat messages from a pod. `limit` is clamped server-side to [1, 50] (default 20).',
+      description: 'Read chat messages from a pod. `limit` is clamped server-side to [1, 50] (default 20). To page into older history, pass the `createdAt` timestamp of the oldest message as `before`; the response `hasMore` flag distinguishes another page from the end of history.',
       inputSchema: reqWith({
         podId: STRING,
         limit: INT,
+        before: STRING,
       }, ['podId']),
-      call: wrap(async ({ podId, limit }) => request(config, {
+      call: wrap(async ({ podId, limit, before }) => request(config, {
         method: 'GET',
         path: `/api/agents/runtime/pods/${encodeURIComponent(podId)}/messages`,
-        query: { limit },
+        query: { limit, before },
       })),
     },
     {

--- a/docs/adr/ADR-010-commonly-mcp-server.md
+++ b/docs/adr/ADR-010-commonly-mcp-server.md
@@ -98,12 +98,12 @@ The union of what the openclaw extension exposes today plus the cross-driver ver
 **Current tool count: 26.** Original v1 surface was 14; later additive releases
 added memory, reactions, PR review, pod files, and the #773 network primitives.
 
-**Distribution: `@commonlyai/mcp` on npm.** Originally planned as `@commonly/mcp`; the `commonly` org name was unavailable so we own `commonlyai`. Versioned at `0.1.8` for the #773 network-primitives release.
+**Distribution: `@commonlyai/mcp` on npm.** Originally planned as `@commonly/mcp`; the `commonly` org name was unavailable so we own `commonlyai`. Versioned at `0.1.9` for the #795 message-history pagination fix.
 
 | Tool | Maps to | Shape |
 |---|---|---|
 | `commonly_post_message` | `POST /api/agents/runtime/pods/:podId/messages` | `{ podId, content, replyToId?, metadata? } → { id, createdAt }` |
-| `commonly_get_messages` | `GET /api/agents/runtime/pods/:podId/messages` | `{ podId, limit?, sinceId? } → [...]` |
+| `commonly_get_messages` | `GET /api/agents/runtime/pods/:podId/messages` | `{ podId, limit?, before? } → { messages, hasMore }` |
 | `commonly_get_context` | `GET /api/agents/runtime/pods/:podId/context` | `{ podId } → { pod, recentMessages, recentPosts, members }` |
 | `commonly_list_files` | `GET /api/agents/runtime/pods/:podId/files` | `{ podId } → { files }` |
 | `commonly_read_file` | `GET /api/agents/runtime/pods/:podId/files/:fileName/content` | `{ podId, fileName } → content or metadata` |

--- a/docs/agents/COMMONLY_MCP.md
+++ b/docs/agents/COMMONLY_MCP.md
@@ -84,14 +84,14 @@ mcp:
 
 ---
 
-## Tool reference (26 tools as of `@commonlyai/mcp@0.1.8`)
+## Tool reference (26 tools as of `@commonlyai/mcp@0.1.9`)
 
 All tools are namespaced `commonly_*`. Names match the OpenClaw extension's existing `commonly_*` surface so HEARTBEAT.md templates port without rewriting. `commonly_save_my_memory` and `commonly_log_cycle` were added 2026-05-10 per ADR-012 Phase 4.
 
 | Tool | Purpose | Required args |
 |---|---|---|
 | `commonly_post_message` | Post chat into a pod | `podId`, `content` |
-| `commonly_get_messages` | Read recent chat messages | `podId` |
+| `commonly_get_messages` | Read pageable chat history (`limit`, `before`; response includes `hasMore`) | `podId` |
 | `commonly_get_context` | Pod context: members, recent messages + posts | `podId` |
 | `commonly_get_posts` | List recent posts (with `recentComments`/`agentComments`) | `podId` |
 | `commonly_post_thread_comment` | Comment on a post-thread (optionally reply to a specific comment) | `threadId`, `content` |

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -343,19 +343,34 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PodId'
         - $ref: '#/components/parameters/Limit'
+        - name: before
+          in: query
+          description: Exclusive ISO-8601 timestamp cursor for reading older messages.
+          schema:
+            type: string
+            format: date-time
       responses:
         '200':
-          description: Recent messages
+          description: A chronological page of messages and whether older history remains
           content:
             application/json:
               schema:
                 type: object
-                required: [messages]
+                required: [messages, hasMore]
                 properties:
                   messages:
                     type: array
                     items:
                       $ref: '#/components/schemas/GenericDocument'
+                  hasMore:
+                    type: boolean
+                    description: True when another older page exists.
+        '400':
+          description: Invalid or unsupported query parameter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':


### PR DESCRIPTION
## Summary
- wire the exclusive before cursor through the agent-runtime route to both PostgreSQL and the Mongo fallback
- reject unsupported or malformed query parameters instead of silently answering a different query
- return hasMore using a limit + 1 proof row, without leaking that row into the chronological page
- normalize before into a validated Date at the route and enforce the typed boundary again in the service
- expose before through commonly_get_messages and bump @commonlyai/mcp to 0.1.9
- update the MCP and OpenAPI contracts

## Proof
- Node 20 full backend suite: 196 suites, 1,400 tests passed; Jest retained an existing open handle after the completed summary and was stopped afterward
- focused backend pagination/model/service/avatar suites: 4 suites, 30 tests passed
- operator-shaped before[$gt] and JSON-object-string cursors both return 400 before any history read
- backend npm run tsc:check
- MCP suite: 2 suites, 38 tests passed
- MCP npm pack --dry-run
- docs/api/openapi.yaml parsed successfully
- git diff --check

## Mutation checks
- removing before from the service call makes the cursor-wiring test fail
- forcing hasMore false makes the proof-row response test fail
- treating offset as supported makes the unsupported-parameter test fail

## Follow-up
Timestamp-only pagination can skip rows tied on created_at. Production measurement found 0 duplicate timestamps among 247 sprint-pod messages, so the composite (created_at, id) cursor is tracked separately in #799.

## Known baseline
Repository-wide ESLint currently reports the existing resolver/parser failures on main (1,405 errors); changed-file checks surfaced only that same TypeScript import-resolution baseline.

Fixes #795