### PR TITLE
docs(ADR-016): agent-ensemble is a listable room, not a presentation label

### DIFF
--- a/docs/adr/ADR-016-pod-model-and-visibility.md
+++ b/docs/adr/ADR-016-pod-model-and-visibility.md
@@ -19,12 +19,13 @@ Three kinds, all derived from `type` — the second exists because listability, 
 
 - `kind = 'dm'` — `type ∈ {agent-room, agent-dm}` (ADR-001 §3.10, strictly 1:1)
 - `kind = 'admin-room'` — `type = 'agent-admin'`: N:1, so not a DM, but in `NON_LISTABLE_POD_TYPES` and refused by both visibility writers, so **terminally private like a DM for a different reason**
-- `kind = 'room'` — everything else (`team`, `chat`, `study`, `games`): the only listable kind
+- `kind = 'room'` — everything else (`team`, `chat`, `study`, `games`, `agent-ensemble`): the only listable kind
 
 An earlier draft called `agent-admin` a plain room, which overstated its reachable states — see the enumeration.
 
 - DMs are terminally private: never listable, never publicRead, membership fixed at 2. Every visibility writer refuses them (already true in PR #779's endpoints).
 - The behaviorally identical room types (`team`, `chat`, `study`, `games` — no backend branch keys on them) become **presentation labels**. We do not collapse the `type` column now: additive-not-destructive, and identity continuity says a stored discriminator outlives its UI. Answering the stub: yes to *conceptual* collapse, no to a column migration nothing needs yet.
+- **`agent-ensemble` is the exception and must not be collapsed.** It is a listable room by this model — in the schema enum, absent from `NON_LISTABLE_POD_TYPES` — but it is not a presentation label: `backend/routes/agentEnsemble.ts` gates seven endpoints on `pod.type !== 'agent-ensemble'`, and `models/Pod.ts` carries an `agentEnsemble: { enabled, topic, participants }` subdocument that exists for it alone. It is the most branch-keyed room type there is. Anyone applying the conceptual collapse above to it breaks those routes.
 
 ### Visibility — an ordered tier, each step strictly adds audience
 


### PR DESCRIPTION
Factual correction to a claim that merged with #792. **Not a model change** — whether `agent-ensemble` *should* be listable is @pod-architect's call, and I have not touched it.

## What is wrong on main

§Kind, two adjacent lines:

> - \`kind = 'room'\` — everything else (\`team\`, \`chat\`, \`study\`, \`games\`): the only listable kind
> - The behaviorally identical room types (\`team\`, \`chat\`, \`study\`, \`games\` — **no backend branch keys on them**) become **presentation labels**.

`agent-ensemble` is missing from both parentheticals, and the second claim is false for it:

| evidence | count |
|---|---|
| `backend/routes/agentEnsemble.ts` — `if (pod.type !== 'agent-ensemble') return 400` | **7 endpoints** |
| `models/Pod.ts` — `agentEnsemble: { enabled, topic, participants }` subdocument | exists for it alone |

It is in the schema enum (`models/Pod.ts:82`) and absent from `NON_LISTABLE_POD_TYPES`, so by this ADR's own derivation it *is* a listable room — it is simply the one room type that is emphatically not a presentation label.

The risk is concrete: this ADR says yes to a *conceptual* collapse of room types. An implementer who takes "behaviorally identical, no backend branch keys" at face value and applies the collapse to `agent-ensemble` breaks seven routes.

## Why now rather than a comment

I raised this during review of #792 (twice — the first time it read as one name missing from a list, so it was reasonable to deprioritize). The rewrite promoted it from an omission into a load-bearing claim, and it merged 19 minutes after the review. It is now in the document Sam ratifies from, so the cheapest correct thing is two lines rather than a note asking someone to make them.

## Left open for @pod-architect

Whether `agent-ensemble` *should* be listable at all is a model question, not a factual one. If the intent is that it should be non-listable, the fix is in `NON_LISTABLE_POD_TYPES`, not here — and this ADR should say so. Close this PR and do that instead if that is the call.

Docs-only, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)