### PR TITLE
fix(pods): refuse DM pod types at creation, the one unguarded entrance

### DIFF
--- a/backend/__tests__/unit/controllers/podController.test.js
+++ b/backend/__tests__/unit/controllers/podController.test.js
@@ -123,6 +123,60 @@ describe('podController', () => {
     expect(res.json).toHaveBeenCalledWith(savedPod);
   });
 
+  // ADR-016 enforcement gap, found reviewing #802 (2026-08-04): every DM guard
+  // in the codebase is an ENTRANCE guard (join, invite create, invite redeem,
+  // install) and none covered creation — so this endpoint minted one-member
+  // agent-room pods with a 200, which no later guard can repair.
+  it('createPod refuses DM pod types and creates nothing', async () => {
+    const save = jest.fn();
+    Pod.mockImplementation(() => ({ save }));
+    const req = {
+      body: { name: 'Sneaky Room', type: 'agent-room' },
+      userId: 'creator',
+    };
+    const res = { json: jest.fn(), status: jest.fn().mockReturnThis(), send: jest.fn() };
+
+    await podController.createPod(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'dm_pod_not_creatable' }));
+    // The refusal must also not write: a 400 that still saved would be the
+    // exact defect this guard exists to prevent.
+    expect(Pod).not.toHaveBeenCalled();
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('createPod still accepts ordinary room types', async () => {
+    const savedPod = { _id: 'p-chat', populate: jest.fn().mockResolvedValue() };
+    const save = jest.fn().mockResolvedValue(savedPod);
+    Pod.mockImplementation(() => ({ save }));
+    const req = { body: { name: 'Normal Room', type: 'chat' }, userId: 'creator' };
+    const res = { json: jest.fn(), status: jest.fn().mockReturnThis(), send: jest.fn() };
+
+    await podController.createPod(req, res);
+
+    expect(save).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(savedPod);
+  });
+
+  // The guard is deliberately NOT implemented by narrowing VALID_POD_TYPES,
+  // because that constant is also the read filter for getPodsByType. This
+  // pins the separation: refusing to CREATE agent-room must not stop READING
+  // the agent-room pods that the DM rail legitimately created.
+  it('getPodsByType still serves agent-room after the creation guard', async () => {
+    const req = { params: { type: 'agent-room' } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const sort = jest.fn().mockResolvedValue([]);
+    const populateSecond = jest.fn(() => ({ sort }));
+    const populateFirst = jest.fn(() => ({ populate: populateSecond, sort }));
+    Pod.find.mockReturnValue({ populate: populateFirst });
+
+    await podController.getPodsByType(req, res);
+
+    expect(res.status).not.toHaveBeenCalledWith(400);
+    expect(Pod.find).toHaveBeenCalledWith({ type: 'agent-room' });
+  });
+
   it('createPod does NOT auto-install commonly-bot by default (opt-in via AUTO_INSTALL_DEFAULT_AGENT=1)', async () => {
     // Regression: pre-beta this defaulted ON, which put the summarizer bot
     // into the member list of every UI-created pod — including real users'

--- a/backend/controllers/podController.ts
+++ b/backend/controllers/podController.ts
@@ -384,6 +384,27 @@ exports.createPod = async (req: any, res: any) => {
       return res.status(400).json({ msg: 'Invalid pod type' });
     }
 
+    // ADR-001 §3.10 / ADR-016 invariant 3: DM pods are strictly 1:1 and are
+    // created only by paths that establish BOTH members (dmService
+    // .getOrCreateAgentDmRoom, ensureAgentInPod, commonly_open_dm). This
+    // endpoint writes `members: [req.userId]`, so allowing a DM type here
+    // mints a one-member DM pod — and every later guard is an *entrance*
+    // guard (join, invite create, invite redeem, install), so none of them
+    // can repair a pod that was born malformed.
+    //
+    // Derived from DM_POD_TYPES_GUARD rather than by narrowing
+    // VALID_POD_TYPES: that constant is also the read filter for
+    // getPodsByType above, so narrowing it for a creation reason would
+    // silently 400 a read endpoint. The guard is the thing that *is* the DM
+    // predicate; a hand-maintained allowlist only happens to agree with it.
+    const { DM_POD_TYPES_GUARD } = require('../services/agentIdentityService');
+    if (DM_POD_TYPES_GUARD.has(String(type))) {
+      return res.status(400).json({
+        msg: 'DM pods are 1:1 and cannot be created here — they are created with both members by the DM rail. Use type "chat" for a multi-party room, or start a DM with the agent.',
+        code: 'dm_pod_not_creatable',
+      });
+    }
+
     const newPod = new Pod({
       name,
       description,


### PR DESCRIPTION
Closes the writer-side gap @sprint-review found reviewing #802. Their finding, my verification and fix.

## The defect

`POST /api/pods` accepted `type: 'agent-room'`, and `createPod` writes `members: [req.userId]` — **a one-member DM-kind pod, created and returned 200.** That violates ADR-001 §3.10 and ADR-016 invariant 3 (*dm ⇒ private, membership fixed at 2*) at the writer.

`DM_POD_TYPES_GUARD` is consulted at **six** sites — and not one is creation:

| site | path |
|---|---|
| `podController.ts:477` | join |
| `podInvites.ts:175` | invite create |
| `podInvites.ts:242` | invite redeem |
| `registry/admin.ts:347` | install |
| `agentIdentityService.ts:512` | ensure-in-pod |
| `agentsRuntime.ts:2444` | discovery exclusion |

*(The review's table listed four; the two extra are `registry/admin` and `agentIdentityService`. The claim is unaffected and stronger for it.)*

Every **entrance** into a DM pod was guarded except the one that **makes** it. `Pod.ts`'s only pre-save hook (`:148`) pushes `createdBy` into `members` and enforces no DM cardinality, so there is no model-level backstop: a pod born malformed stays malformed, and no entrance guard downstream can repair it.

## Why not just narrow `VALID_POD_TYPES`

Because that constant does two jobs — `:383` (createPod, a write gate) and `:279` (`getPodsByType`, a read filter). Narrowing it for a creation reason silently 400s a read endpoint, and this isn't theoretical:

```
mutation: drop 'agent-room' from VALID_POD_TYPES
→ 4 tests red, including TWO pre-existing guards on main:
    getPodsByType filters agent-room to caller membership for non-admins
    getPodsByType filters agent-room to caller membership even for global admins
```

**main's own tests already reject the obvious fix.** One constant, two jobs — this ADR's drift theme at smaller scale. The gate now derives from `DM_POD_TYPES_GUARD`, the thing that *is* the DM predicate, rather than a hand-maintained list that only happens to agree with it.

## Tests

- **refusal asserts 400 AND that nothing was written** — `Pod` never constructed, `save` never called. A refusal that still saves is precisely the defect this guard exists to prevent (reviewer-checklist rule 2)
- ordinary room types still create
- `getPodsByType` still serves `agent-room` — pins the read/write split so the wrong fix can't be applied later without going red

**Mutation-proven:** disabling the guard (`if (false && …)`) reddens exactly **1** test, no collateral. 26/26 green, `tsc:check` clean.

## Verified vs not

- **Locally verified**, unlike #804 — this suite has no `jsonwebtoken` import, so it runs on this host's Node 26.
- **Not verified: whether malformed one-member `agent-room` rows already exist in production.** Unmeasured, not unobserved. If any exist this PR does not clean them up — `scripts/migrate-agent-room-multimember.ts` addresses the >2 case, not the <2 case.
- Not verified: the PG mirror write path, and live behaviour (nothing is currently deployed — last `Deploy Dev` was 2026-08-02 at `eb05c683`).
- `agent-admin` is deliberately untouched: it is N:1 by design and not in `DM_POD_TYPES_GUARD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)