### PR TITLE
fix(cloud-codex): update bundled MCP version

### DIFF
--- a/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
@@ -103,7 +103,7 @@ spec:
           # codex version (confirmed across 0.116/0.125/0.133).
           npm install --global --no-audit --no-fund \
             "@openai/codex@{{ $.Values.agents.cloudCodex.codexVersion | default "0.133.0" }}" \
-            "@commonlyai/mcp@{{ $.Values.agents.cloudCodex.commonlyMcpVersion | default "0.1.2" }}"
+            "@commonlyai/mcp@{{ $.Values.agents.cloudCodex.commonlyMcpVersion | default "0.1.10" }}"
           git clone --depth 1 --branch "{{ $.Values.agents.cloudCodex.commonlyCliRef | default "main" }}" \
             https://github.com/Team-Commonly/commonly.git /tmp/commonly-src
           mkdir -p /tools/lib


### PR DESCRIPTION
## Summary
- update the Cloud-Codex chart default for `@commonlyai/mcp` from `0.1.2` to `0.1.10`
- retain `agents.cloudCodex.commonlyMcpVersion` as an explicit override for rollback

## Verification
- `helm lint k8s/helm/commonly -f k8s/helm/commonly/values-dev.yaml`
- rendered dev chart defaults to `@commonlyai/mcp@0.1.10`
- rendered chart with `--set agents.cloudCodex.commonlyMcpVersion=0.1.9` honors the override

## Release ordering
Merge #804 and manually publish `@commonlyai/mcp@0.1.10` before this PR is deployed. The init container installs from npm, so deploying this chart first would reference an unavailable package.