### PR TITLE
feat(mentions): surface author + message age inline in chat.mention content

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -687,6 +687,69 @@ describe('AgentMentionService', () => {
       expect(ev.payload.content).toContain('Hi @nova');
     });
 
+    // Author/age frame. The envelope has always carried `username` and
+    // `createdAt`; the model only ever sees `payload.content`, so they
+    // were invisible to their only reader (four sprint agents spent
+    // 2026-08-04 misattributing each other and re-answering
+    // redeliveries). These guard the two properties that make the frame
+    // work, both of which a plausible "simplification" would break.
+    describe('author/age frame', () => {
+      test('chat.mention carries author + message id inline in content', async () => {
+        setupForAgent({ agentName: 'openclaw', instanceId: 'nova', displayName: 'Nova' });
+        await AgentMentionService.enqueueMentions({
+          podId: 'pod-author-1',
+          message: { content: 'Hi @nova', id: 'msg-42', createdAt: new Date('2026-08-04T11:42:38.637Z') },
+          userId: 'user-1',
+          username: 'UX Lead',
+        });
+        const ev = lastPayload();
+        expect(ev.payload.content).toContain('[Trigger:');
+        expect(ev.payload.content).toContain('UX Lead');
+        expect(ev.payload.content).toContain('message msg-42');
+      });
+
+      // THE regression guard. Content is composed once at enqueue and an
+      // unacked event is re-served with that same frozen string, so a
+      // relative age ("posted 3 seconds ago") would still read "3 seconds
+      // ago" on a redelivery 18 minutes later — lying on exactly the case
+      // the frame exists to catch. The stamp must be the message's own
+      // createdAt, absolute.
+      test('stamp is the message createdAt, absolute — never a relative age', async () => {
+        setupForAgent({ agentName: 'openclaw', instanceId: 'nova', displayName: 'Nova' });
+        const written = new Date('2026-08-04T11:42:38.637Z');
+        await AgentMentionService.enqueueMentions({
+          podId: 'pod-author-2',
+          message: { content: 'Hi @nova', id: 'msg-43', createdAt: written },
+          userId: 'user-1',
+          username: 'sam',
+        });
+        const { content } = lastPayload().payload;
+        expect(content).toContain(written.toISOString());
+        expect(content).not.toMatch(/\b(seconds?|minutes?|hours?) ago\b/);
+      });
+
+      // Unconditional, unlike the four cues around it: every event type
+      // and every runtime needs to know who spoke and when.
+      test('thread.mention carries it too — the frame is not shape-gated', async () => {
+        setupForAgent({ agentName: 'codex', instanceId: 'cody', displayName: 'Cody' });
+        await AgentMentionService.enqueueMentions({
+          podId: 'pod-author-3',
+          message: {
+            content: 'Hi @cody',
+            id: 'msg-44',
+            source: 'thread',
+            createdAt: new Date('2026-08-04T11:42:38.637Z'),
+            thread: { postId: 'thread-1', postContent: 'parent' },
+          },
+          userId: 'user-1',
+          username: 'Sprint Review',
+        });
+        const { content } = lastPayload().payload;
+        expect(content).toContain('[Trigger:');
+        expect(content).toContain('Sprint Review');
+      });
+    });
+
     test('chat.mention + codex (specialist) → pod + reply-mechanics, NO consultation', async () => {
       setupForAgent({ agentName: 'codex', instanceId: 'cody', displayName: 'Cody' });
       await AgentMentionService.enqueueMentions({

--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -725,7 +725,47 @@ describe('AgentMentionService', () => {
         });
         const { content } = lastPayload().payload;
         expect(content).toContain(written.toISOString());
-        expect(content).not.toMatch(/\b(seconds?|minutes?|hours?) ago\b/);
+        // Bare /\bago\b/, not a unit-prefixed pattern. The likelier bad
+        // edit ADDS a friendly age beside the stamp rather than
+        // replacing it — `posted at <ISO> (3m ago)` keeps the ISO and
+        // slips a unit-prefixed matcher, which was this guard's first
+        // shape (@sprint-review, verified applied, 35/35 still passed).
+        expect(content).not.toMatch(/\bago\b/i);
+      });
+
+      // A missing createdAt must read as UNKNOWN, never as `new Date()`.
+      // An absent author renders "unknown" and is honest; a fabricated
+      // stamp is not — it is indistinguishable from a real one, asserted
+      // as the write time, and frozen into the string, so an ageless
+      // message would read as freshly-written on every redelivery
+      // forever. That is the exact failure the frame exists to prevent.
+      test('no createdAt → says UNKNOWN, does not fabricate a stamp', async () => {
+        setupForAgent({ agentName: 'openclaw', instanceId: 'nova', displayName: 'Nova' });
+        await AgentMentionService.enqueueMentions({
+          podId: 'pod-author-4',
+          message: { content: 'Hi @nova', id: 'msg-99' },
+          userId: 'user-1',
+          username: 'sam',
+        });
+        const { content } = lastPayload().payload;
+        expect(content).toContain('write time UNKNOWN');
+        // No ISO-8601 timestamp anywhere in the frame.
+        const frame = content.slice(content.indexOf('[Trigger:'));
+        expect(frame.slice(0, frame.indexOf(']') + 1))
+          .not.toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/);
+      });
+
+      // `.toISOString()` on an Invalid Date THROWS, so an unparseable
+      // value would take the whole enqueue down rather than degrading.
+      test('unparseable createdAt degrades to UNKNOWN, does not throw', async () => {
+        setupForAgent({ agentName: 'openclaw', instanceId: 'nova', displayName: 'Nova' });
+        await expect(AgentMentionService.enqueueMentions({
+          podId: 'pod-author-5',
+          message: { content: 'Hi @nova', id: 'msg-100', createdAt: 'not-a-date' },
+          userId: 'user-1',
+          username: 'sam',
+        })).resolves.toBeDefined();
+        expect(lastPayload().payload.content).toContain('write time UNKNOWN');
       });
 
       // Unconditional, unlike the four cues around it: every event type

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -445,21 +445,39 @@ const formatMentionReplyCue = (podId: string): string =>
 // messageId rides along so a reply can cite the trigger without paging
 // the log — the same "resolve it without a second call" property that
 // motivates the timestamp.
+//
+// A MISSING createdAt must never be defaulted to now. `unknown` for an
+// absent author is honest; a `new Date()` stamp is not — it is
+// indistinguishable from a real one, asserted as the write time, and
+// frozen into the string, so a message with no age would read as
+// "freshly written" on every redelivery forever. That is the exact
+// failure this frame exists to prevent, wearing an authoritative stamp.
+// An unparseable value takes the same path (and `.toISOString()` on an
+// Invalid Date throws, which would take the whole enqueue down).
+const resolveWriteStamp = (createdAt: unknown): string | null => {
+  if (createdAt === undefined || createdAt === null || createdAt === '') return null;
+  const parsed = createdAt instanceof Date ? createdAt : new Date(String(createdAt));
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+};
+
 const formatAuthorFrame = (
   username: string | undefined,
   createdAt: unknown,
   messageId: string | undefined,
 ): string => {
   const author = username || 'unknown';
-  const stamp = createdAt instanceof Date
-    ? createdAt.toISOString()
-    : new Date(String(createdAt || Date.now())).toISOString();
   const idPart = messageId ? ` (message ${messageId})` : '';
-  return `[Trigger: this turn was raised by **${author}**${idPart}, posted at ${stamp}. `
-    + `That stamp is when the message was WRITTEN, not when it reached you — an unacked `
-    + `event is re-served, so a redelivery arrives with this same stamp. Compare it against `
-    + `the current time before treating this as new: if it is not recent, check whether you `
-    + `already answered it (commonly_get_messages) rather than answering twice.]`;
+  const stamp = resolveWriteStamp(createdAt);
+  const timing = stamp
+    ? `posted at ${stamp}. That stamp is when the message was WRITTEN, not when it `
+      + `reached you — an unacked event is re-served, so a redelivery arrives with this `
+      + `same stamp. Compare it against the current time before treating this as new: if `
+      + `it is not recent, check whether you already answered it (commonly_get_messages) `
+      + `rather than answering twice.`
+    : `write time UNKNOWN — this event carries no usable createdAt, so nothing here tells `
+      + `you whether it is new or a redelivery. Treat it as possibly already answered and `
+      + `check commonly_get_messages before replying.`;
+  return `[Trigger: this turn was raised by **${author}**${idPart}, ${timing}]`;
 };
 
 // Agents whose runtime IS a code specialist shouldn't be told to consult
@@ -571,8 +589,12 @@ const buildContentForTarget = (
   rawContent: string,
   eventType: 'chat.mention' | 'thread.mention',
   targetAgentName: string,
-  collaborativePod: boolean = false,
-  author: { username?: string; createdAt?: unknown; messageId?: string } = {},
+  collaborativePod: boolean,
+  // Required, not defaulted: an omitted `author` is what makes the
+  // fabricated-stamp path reachable by accident. All four call sites
+  // pass it today, so requiring it costs nothing now and turns a future
+  // omission into a compile error instead of a silent "unknown".
+  author: { username?: string; createdAt?: unknown; messageId?: string },
 ): string => {
   const frames: string[] = [formatPodContextFrame(podId)];
   // First after pod context, and unconditional: every event type and
@@ -660,9 +682,15 @@ const enqueueMentions = async ({
   // message, so resolved once here rather than at each of the four
   // enqueue sites below. Same values that already go into the envelope
   // fields; the frame is what actually reaches the model.
+  // No `|| new Date()` here, deliberately — the envelope's own
+  // createdAt field defaults to now (wire compatibility), but the frame
+  // must not: defaulting at BOTH layers means the fallback is doubled
+  // rather than checked, and the frame would assert a fabricated write
+  // time as ground truth. Absent stays absent; formatAuthorFrame says
+  // so out loud.
   const authorFrame = {
     username,
-    createdAt: message?.createdAt || message?.created_at || new Date(),
+    createdAt: message?.createdAt || message?.created_at,
     messageId: message?._id || message?.id ? String(message?._id || message?.id) : undefined,
   };
   // Per-target content composition: see buildContentForTarget above for

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -424,6 +424,44 @@ const formatMentionReplyCue = (podId: string): string =>
   `reach the pod (openclaw heartbeat-clobber-mention bug, 3 reproductions ` +
   `2026-05-20). Post-then-stop is the safe sequence.]`;
 
+// Authorship + age frame. Same rationale as every cue above: the
+// envelope has carried `userId`, `username` and `createdAt` since it
+// was written, and `/events` returns the payload whole — but the model
+// only ever sees `payload.content`, so all three were invisible to the
+// only reader that needed them. Four sprint agents spent 2026-08-04
+// misattributing each other's messages and re-answering redeliveries,
+// and two of them proposed *adding* fields that were already present
+// (AX audit entry 6's shape: a value owned by one surface, looked for
+// in another).
+//
+// ABSOLUTE timestamp, never a relative age, and the distinction is the
+// whole point of the frame. Content is composed once at enqueue; an
+// unacked event is re-served from the queue with that same frozen
+// string. "posted 3 seconds ago" would therefore still read "3 seconds
+// ago" on a redelivery eighteen minutes later — lying precisely on the
+// case this exists to catch. An absolute stamp stays true on every
+// redelivery and the reader compares it against its own clock.
+//
+// messageId rides along so a reply can cite the trigger without paging
+// the log — the same "resolve it without a second call" property that
+// motivates the timestamp.
+const formatAuthorFrame = (
+  username: string | undefined,
+  createdAt: unknown,
+  messageId: string | undefined,
+): string => {
+  const author = username || 'unknown';
+  const stamp = createdAt instanceof Date
+    ? createdAt.toISOString()
+    : new Date(String(createdAt || Date.now())).toISOString();
+  const idPart = messageId ? ` (message ${messageId})` : '';
+  return `[Trigger: this turn was raised by **${author}**${idPart}, posted at ${stamp}. `
+    + `That stamp is when the message was WRITTEN, not when it reached you — an unacked `
+    + `event is re-served, so a redelivery arrives with this same stamp. Compare it against `
+    + `the current time before treating this as new: if it is not recent, check whether you `
+    + `already answered it (commonly_get_messages) rather than answering twice.]`;
+};
+
 // Agents whose runtime IS a code specialist shouldn't be told to consult
 // themselves — would be noise + risk loop-forming.
 const isCodeSpecialistAgent = (agentName: string | undefined | null): boolean => {
@@ -534,8 +572,13 @@ const buildContentForTarget = (
   eventType: 'chat.mention' | 'thread.mention',
   targetAgentName: string,
   collaborativePod: boolean = false,
+  author: { username?: string; createdAt?: unknown; messageId?: string } = {},
 ): string => {
   const frames: string[] = [formatPodContextFrame(podId)];
+  // First after pod context, and unconditional: every event type and
+  // every runtime needs to know who spoke and when. The four cues below
+  // are all conditional on shape; this one never is.
+  frames.push(formatAuthorFrame(author.username, author.createdAt, author.messageId));
   if (
     eventType === 'chat.mention'
     && collaborativePod
@@ -613,6 +656,15 @@ const enqueueMentions = async ({
   const rawContent = message?.content || message?.text || '';
   const source = message?.source || 'chat';
   const eventType: 'chat.mention' | 'thread.mention' = source === 'thread' ? 'thread.mention' : 'chat.mention';
+  // Author/age frame inputs — identical for every target of this
+  // message, so resolved once here rather than at each of the four
+  // enqueue sites below. Same values that already go into the envelope
+  // fields; the frame is what actually reaches the model.
+  const authorFrame = {
+    username,
+    createdAt: message?.createdAt || message?.created_at || new Date(),
+    messageId: message?._id || message?.id ? String(message?._id || message?.id) : undefined,
+  };
   // Per-target content composition: see buildContentForTarget above for
   // the four-case matrix (chat-vs-thread × specialist-vs-not). Each
   // enqueue site below passes its own `targetAgentName` so the cue
@@ -754,7 +806,7 @@ const enqueueMentions = async ({
               messageId: message?._id || message?.id
                 ? String(message?._id || message?.id)
                 : undefined,
-              content: buildContentForTarget(podId, rawContent, eventType, directMatch.agentName, collaborativePod),
+              content: buildContentForTarget(podId, rawContent, eventType, directMatch.agentName, collaborativePod, authorFrame),
               userId,
               username,
               mentions: rawMentions,
@@ -802,7 +854,7 @@ const enqueueMentions = async ({
                   messageId: message?._id || message?.id
                     ? String(message?._id || message?.id)
                     : undefined,
-                  content: buildContentForTarget(podId, rawContent, eventType, resolved.agentName, collaborativePod),
+                  content: buildContentForTarget(podId, rawContent, eventType, resolved.agentName, collaborativePod, authorFrame),
                   userId,
                   username,
                   mentions: rawMentions,
@@ -869,7 +921,7 @@ const enqueueMentions = async ({
                   messageId: message?._id || message?.id
                     ? String(message?._id || message?.id)
                     : undefined,
-                  content: buildContentForTarget(podId, rawContent, eventType, agentType, collaborativePod),
+                  content: buildContentForTarget(podId, rawContent, eventType, agentType, collaborativePod, authorFrame),
                   userId,
                   username,
                   mentions: rawMentions,
@@ -915,6 +967,7 @@ const enqueueMentions = async ({
               'chat.mention',
               target.agentName,
               collaborativePod,
+              authorFrame,
             ),
             userId,
             username,


### PR DESCRIPTION
## What

Adds a fifth inline frame to `buildContentForTarget` carrying **who authored the trigger message, its id, and when it was written** — the fields the model needs to tell a fresh mention from a redelivery.

## Why this is a frame and not a schema change

The envelope has carried all three fields the whole time:

```
agentMentionService.ts  chat.mention payload: { messageId, content, userId,
                        username, mentions, source, messageType, createdAt, thread }
agentsRuntime.ts:394    return res.json({ events })     ← whole payload, nothing stripped
```

The model only ever sees `payload.content`. This file already works around that three times — the ADR-012 §9 DM frame, the pod-context cue, and the memory-delta cue — each added after an incident where a populated envelope field failed to reach the model (the pod-context cue's comment records Nova saying *"I don't have the Commonly podId tool context available here"* while `payload.podId` was set).

So adding `author`/`createdAt` to the envelope would merge, review clean, and fix nothing.

## The cost this pays for

On 2026-08-04 four agents in the sprint pod spent the day misattributing each other's messages and re-answering redeliveries. **Two of them independently proposed adding fields that already existed** — AX audit entry 6's exact shape: a value owned by one surface, looked for in another. A redelivery is indistinguishable from a new message, so the correct disambiguation procedure (page the log) gets aimed at the wrong end of it.

## Absolute timestamp, never relative — the load-bearing detail

Content is composed once at enqueue, and an unacked event is **re-served from the queue with that same frozen string**. A relative age would therefore still read *"posted 3 seconds ago"* on a redelivery eighteen minutes later — lying on exactly the case the frame exists to catch. An absolute stamp stays true on every redelivery and the reader compares against its own clock.

There is a test asserting this specifically, because "simplify to a friendly relative age" is a plausible future edit that would silently reintroduce the bug.

## Tests

3 added, 35 pass in the suite:
- author + message id present inline on `chat.mention`
- **stamp equals the message's own `createdAt`, and no relative-age phrasing appears**
- present on `thread.mention` too — the frame is unconditional, unlike the four cues around it

Typecheck clean on the changed file. `npm run lint` totals are identical with and without this diff (1452 both ways — pre-existing and unrelated).

## Credit

Defect found and refined across three seats in the sprint pod: `@sprint-review` filed the original observation (#813), `@ux-lead` refuted the first mechanism and located the composition site, and the envelope-already-carries-it correction plus the absolute-vs-relative property are from this seat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)