### PR TITLE
fix(pods): joinPolicy is optional — the required type licensed a fail-closed read

### DIFF
--- a/backend/__tests__/unit/services/podListing.test.js
+++ b/backend/__tests__/unit/services/podListing.test.js
@@ -3,8 +3,7 @@
  *
  * `joinPolicy` has a mongoose default of 'open', but a default applies on
  * write: documents created before the field existed carry no `joinPolicy`
- * at all, and production still holds 18 of them. Every read here must
- * therefore fail OPEN — `!== 'invite-only'`, never `=== 'open'` — so a
+ * at all. Every read here must therefore fail OPEN — `!== 'invite-only'`, never `=== 'open'` — so a
  * legacy pod stays joinable instead of silently disappearing from Discover.
  *
  * The predicate and the query are two encodings of the same rule, and they

--- a/backend/__tests__/unit/services/podListing.test.js
+++ b/backend/__tests__/unit/services/podListing.test.js
@@ -1,0 +1,85 @@
+/**
+ * podListing — the join-policy gate, tested against the ABSENT field.
+ *
+ * `joinPolicy` has a mongoose default of 'open', but a default applies on
+ * write: documents created before the field existed carry no `joinPolicy`
+ * at all, and production still holds 18 of them. Every read here must
+ * therefore fail OPEN — `!== 'invite-only'`, never `=== 'open'` — so a
+ * legacy pod stays joinable instead of silently disappearing from Discover.
+ *
+ * The predicate and the query are two encodings of the same rule, and they
+ * are consumed by different callers (podController's join path vs. the
+ * Mongo listing queries). They can drift apart, so both are asserted on the
+ * absent-field case, not just the predicate.
+ */
+const {
+  isCommunityListed,
+  isDirectlyJoinable,
+  DIRECTLY_JOINABLE_QUERY,
+  communityDiscoverQuery,
+  NON_LISTABLE_POD_TYPES,
+} = require('../../../services/podListing');
+
+const listedPod = (overrides = {}) => ({
+  type: 'chat',
+  publicRead: true,
+  communityListed: true,
+  ...overrides,
+});
+
+describe('podListing join-policy gate', () => {
+  describe('absent joinPolicy (legacy rows) must fail OPEN', () => {
+    test('isDirectlyJoinable is true when the field is missing entirely', () => {
+      const pod = listedPod();
+      expect('joinPolicy' in pod).toBe(false);
+      expect(isDirectlyJoinable(pod)).toBe(true);
+    });
+
+    test('isDirectlyJoinable is true when the field is explicitly undefined', () => {
+      expect(isDirectlyJoinable(listedPod({ joinPolicy: undefined }))).toBe(true);
+    });
+
+    test('isDirectlyJoinable is true when the field is null', () => {
+      expect(isDirectlyJoinable(listedPod({ joinPolicy: null }))).toBe(true);
+    });
+
+    // The query half of the same rule. `{ $ne: 'invite-only' }` matches
+    // documents where the field is absent; `{ $eq: 'open' }` would not, so
+    // this asserts the encoding rather than just the value.
+    test('DIRECTLY_JOINABLE_QUERY negates invite-only rather than asserting open', () => {
+      expect(DIRECTLY_JOINABLE_QUERY.joinPolicy).toEqual({ $ne: 'invite-only' });
+      expect(DIRECTLY_JOINABLE_QUERY.joinPolicy).not.toEqual({ $eq: 'open' });
+      expect(DIRECTLY_JOINABLE_QUERY.joinPolicy).not.toBe('open');
+    });
+
+    test('communityDiscoverQuery inherits the same fail-open gate', () => {
+      const query = communityDiscoverQuery({ callerId: 'user-1' });
+      expect(query.joinPolicy).toEqual({ $ne: 'invite-only' });
+    });
+  });
+
+  describe('present joinPolicy still gates as before', () => {
+    test('open is joinable', () => {
+      expect(isDirectlyJoinable(listedPod({ joinPolicy: 'open' }))).toBe(true);
+    });
+
+    test('invite-only is not joinable', () => {
+      expect(isDirectlyJoinable(listedPod({ joinPolicy: 'invite-only' }))).toBe(false);
+    });
+  });
+
+  describe('the join gate does not override the listing gate', () => {
+    test('an unlisted pod is not joinable even with no joinPolicy', () => {
+      expect(isDirectlyJoinable(listedPod({ communityListed: false }))).toBe(false);
+    });
+
+    test('a non-public pod is not joinable even with no joinPolicy', () => {
+      expect(isDirectlyJoinable(listedPod({ publicRead: false }))).toBe(false);
+    });
+
+    test.each(NON_LISTABLE_POD_TYPES)('%s is never listed or joinable', (type) => {
+      expect(isCommunityListed(listedPod({ type }))).toBe(false);
+      expect(isDirectlyJoinable(listedPod({ type }))).toBe(false);
+    });
+  });
+});

--- a/backend/models/Pod.ts
+++ b/backend/models/Pod.ts
@@ -33,8 +33,11 @@ export interface IPod extends Document {
   type: PodType;
   // OPTIONAL, and the `?` is load-bearing. The schema below defaults this
   // to 'open', but a mongoose default applies on WRITE — documents created
-  // before the field existed have no `joinPolicy` at all, and production
-  // still holds 18 of them. Declaring it required told a type-checking
+  // before the field existed have no `joinPolicy` at all. (No count here on
+  // purpose: a census in a permanent comment is stale the moment rows are
+  // written, and the type is justified by one such row existing — or by the
+  // possibility of one — not by how many there are today.) Declaring it
+  // required told a type-checking
   // reader the field is always present, which licenses `=== 'open'`; that
   // test is false for every legacy row and would fail CLOSED, silently
   // hiding pods that are in fact joinable.

--- a/backend/models/Pod.ts
+++ b/backend/models/Pod.ts
@@ -31,7 +31,20 @@ export interface IPod extends Document {
   name: string;
   description?: string;
   type: PodType;
-  joinPolicy: PodJoinPolicy;
+  // OPTIONAL, and the `?` is load-bearing. The schema below defaults this
+  // to 'open', but a mongoose default applies on WRITE — documents created
+  // before the field existed have no `joinPolicy` at all, and production
+  // still holds 18 of them. Declaring it required told a type-checking
+  // reader the field is always present, which licenses `=== 'open'`; that
+  // test is false for every legacy row and would fail CLOSED, silently
+  // hiding pods that are in fact joinable.
+  //
+  // Read it as `!== 'invite-only'` (fail open), never `=== 'open'`. That is
+  // what every production read already does, and what DIRECTLY_JOINABLE_QUERY
+  // encodes as `{ $ne: 'invite-only' }` — see services/podListing.ts, whose
+  // own CommunityListingPod already declared the field optional. The two
+  // declarations of one field disagreed; this is the one that was wrong.
+  joinPolicy?: PodJoinPolicy;
   parentPod?: Types.ObjectId | null;
   agentEnsemble: {
     enabled: boolean;


### PR DESCRIPTION
@ux-lead's finding on #812, from the type side. `backend/models/Pod.ts` declared:

```ts
joinPolicy: PodJoinPolicy;   // no `?`
```

The schema defaults it to `'open'`, but **a mongoose default applies on write** — documents created before the field existed carry no `joinPolicy` at all, and production still holds **18** of them. So the interface told a type-checking reader the field is always present, which licenses `pod.joinPolicy === 'open'`. That test is false for every legacy row and fails **closed**, silently hiding pods that are in fact joinable.

This is the **opposite direction** from the `$ne: 'invite-only'` query finding on #812, which fails open (correctly). Same field, same 18 rows, two hazards pointing opposite ways depending on whether you read the data or the type.

## The two declarations of one field already disagreed

`services/podListing.ts` declares its own `CommunityListingPod` with `joinPolicy?: unknown` — optional. Every production read is written `!== 'invite-only'`. **The reading layer modelled absence correctly; the model layer denied it.** This fixes the one that was wrong, and states the convention at the declaration where the next reader meets it.

## Tests

New unit suite for the gate, asserted against the **absent** field specifically — missing key, explicit `undefined`, and `null` — plus the query encoding, because the predicate and the query are two encodings of one rule consumed by different callers and can drift apart.

Mutation-verified, both halves:

| mutation | result |
|---|---|
| predicate `!== 'invite-only'` → `=== 'open'` | **3 tests fail** |
| query `$ne: 'invite-only'` → `$eq: 'open'` | **2 tests fail** |

12 pass. Typecheck: 57 errors before and after — all pre-existing, **0 added**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)