### PR TITLE
fix(agents): pod-create dedup could widen a 1:1 DM — the 6th writer skipped the guard

### DIFF
--- a/backend/__tests__/unit/routes/agentsRuntime.podCreateDedup.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.podCreateDedup.test.js
@@ -80,12 +80,13 @@ const app = express();
 app.use(express.json());
 app.use('/api/agents/runtime', router);
 
-const existing = (type) => ({
+// Default seeding is the DM case: two members, and the caller (bot-1) is NOT
+// one of them — that is the shape the guard has to refuse.
+const existing = (type, members = [{ _id: 'human-9' }, { _id: 'bot-7' }]) => ({
   _id: `pod-${type}`,
   name: 'Nova and Theo',
   type,
-  // The colliding pod's two members; the caller (bot-1) is NOT one of them.
-  members: [{ _id: 'human-9' }, { _id: 'bot-7' }],
+  members,
   save: podSave,
   populate: podPopulate,
 });
@@ -140,11 +141,26 @@ describe('POST /pods dedup refuses to widen a 1:1 DM (ADR-001 §3.10)', () => {
     expect(res.status).not.toBe(403);
   });
 
-  test('an ordinary chat pod still dedups and joins as before', async () => {
-    mockFoundPod.value = existing('chat');
+  // The caller is seeded as ALREADY a member here, deliberately. What this
+  // test guards is the dedup path itself — a name collision on an ordinary pod
+  // returns the existing pod rather than erroring or creating a duplicate.
+  //
+  // Seeding a non-member instead would make the assertion defend the widening:
+  // "a caller who guesses a chat pod's name is pushed into its members" would
+  // become a pinned behaviour under the name "as before", and the follow-up
+  // gate (refuse unless the pod is directly joinable — isDirectlyJoinable, not
+  // joinPolicy alone, since publicRead:false + joinPolicy:'open' is a dormant
+  // declaration per ADR-016:46) would have to delete a green test to land.
+  // That gate is a separate PR; this file must not pre-approve its absence.
+  test('an ordinary chat pod still dedups and returns the existing pod', async () => {
+    mockFoundPod.value = existing('chat', [{ _id: 'human-9' }, { _id: 'bot-1' }]);
     const res = await createPod();
     expect(res.status).toBe(200);
-    expect(podSave).toHaveBeenCalled();
-    expect(mockFoundPod.value.members).toContain('bot-1');
+    expect(res.body._id).toBe('pod-chat');
+    // Already a member → no membership write at all. Dedup is idempotent.
+    expect(podSave).not.toHaveBeenCalled();
+    // ...but the branch does run to completion: the install still happens,
+    // so this is a real pass through the dedup path, not an early return.
+    expect(mockInstall).toHaveBeenCalled();
   });
 });

--- a/backend/__tests__/unit/routes/agentsRuntime.podCreateDedup.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.podCreateDedup.test.js
@@ -1,0 +1,150 @@
+/**
+ * POST /api/agents/runtime/pods — the dedup-by-name branch was the sixth
+ * writer to `Pod.members` and the only one that never consulted
+ * DM_POD_TYPES_GUARD.
+ *
+ * VALID_POD_TYPES gates the type the CALLER ASKED FOR. The dedup lookup is
+ * `Pod.findOne({ name })` — name alone, no type filter — so a name collision
+ * turned a create call into a join against someone else's strictly-1:1 DM
+ * (ADR-001 §3.10). The five writers that do consult the guard are
+ * podController.joinPod, podInvites ×2, registry/admin, and
+ * ensureAgentInPod; scripts/migrate-agent-dm-multimember.ts exists because
+ * multi-member DMs already happened once.
+ *
+ * The membership count is the least of it, so these tests assert all three
+ * writes are refused, not just the push:
+ *   1. members.push            → a third party in a 1:1 pod
+ *   2. AgentInstallation.install → POSTING rights (auth goes through
+ *      AgentInstallation.find, not pod.members — see CLAUDE.md)
+ *   3. ensureCommonlyBotInstalled → the summarizer with context:read on a
+ *      private conversation
+ */
+
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(), verify: jest.fn(), decode: jest.fn() }));
+
+jest.mock('../../../middleware/agentRuntimeAuth', () => (req, res, next) => {
+  req.agentUser = { _id: 'bot-1' };
+  req.agentInstallation = {
+    agentName: 'openclaw', instanceId: 'nova', version: '1.0.0', config: {}, scopes: [],
+  };
+  next();
+});
+jest.mock('../../../middleware/auth', () => (req, res, next) => next());
+jest.mock('../../../middleware/apiTokenScopes', () => ({
+  requireApiTokenScopes: () => (req, res, next) => next(),
+}));
+
+const podSave = jest.fn().mockResolvedValue(undefined);
+const podPopulate = jest.fn().mockResolvedValue(undefined);
+const mockFoundPod = { value: null };
+
+jest.mock('../../../models/Pod', () => {
+  const findOne = jest.fn(() => ({
+    populate: () => ({ populate: async () => mockFoundPod.value }),
+  }));
+  return { findOne, find: jest.fn() };
+});
+
+const mockInstall = jest.fn().mockResolvedValue({});
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { findOne: jest.fn().mockResolvedValue(null), find: jest.fn(), install: mockInstall },
+}));
+
+jest.mock('../../../services/agentIdentityService', () => ({
+  DM_POD_TYPES_GUARD: new Set(['agent-room', 'agent-dm']),
+  buildAgentUsername: jest.fn((a) => a),
+  ensureAgentInPod: jest.fn(),
+}));
+
+jest.mock('../../../services/agentEventService', () => ({}));
+jest.mock('../../../services/agentMessageService', () => ({}));
+jest.mock('../../../services/agentThreadService', () => ({}));
+jest.mock('../../../services/podContextService', () => ({}));
+jest.mock('../../../services/globalModelConfigService', () => ({}));
+jest.mock('../../../services/socialPolicyService', () => ({}));
+jest.mock('../../../services/dmService', () => ({ getOrCreateAgentDM: jest.fn() }));
+jest.mock('../../../services/chatSummarizerService', () => ({
+  getMultiplePodSummaries: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('../../../integrations', () => ({ get: jest.fn() }));
+jest.mock('../../../models/Activity', () => ({}));
+jest.mock('../../../models/User', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../../../models/Post', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/Integration', () => ({ find: jest.fn(), findOne: jest.fn() }));
+
+const express = require('express');
+const request = require('supertest');
+const router = require('../../../routes/agentsRuntime');
+
+const app = express();
+app.use(express.json());
+app.use('/api/agents/runtime', router);
+
+const existing = (type) => ({
+  _id: `pod-${type}`,
+  name: 'Nova and Theo',
+  type,
+  // The colliding pod's two members; the caller (bot-1) is NOT one of them.
+  members: [{ _id: 'human-9' }, { _id: 'bot-7' }],
+  save: podSave,
+  populate: podPopulate,
+});
+
+const createPod = () => request(app)
+  .post('/api/agents/runtime/pods')
+  .send({ name: 'Nova and Theo', type: 'chat' });
+
+describe('POST /pods dedup refuses to widen a 1:1 DM (ADR-001 §3.10)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFoundPod.value = null;
+  });
+
+  describe.each(['agent-room', 'agent-dm'])('name collides with an existing %s', (type) => {
+    beforeEach(() => { mockFoundPod.value = existing(type); });
+
+    test('refuses with 403 dm_membership_refused', async () => {
+      const res = await createPod();
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('dm_membership_refused');
+    });
+
+    test('does not add the caller as a third member', async () => {
+      await createPod();
+      expect(podSave).not.toHaveBeenCalled();
+      expect(mockFoundPod.value.members).toHaveLength(2);
+    });
+
+    // The write that actually grants access: posting is gated on
+    // AgentInstallation, not pod.members, so fixing only the push would
+    // still hand a stranger write rights on the DM.
+    test('does not install the caller — the write that grants posting', async () => {
+      await createPod();
+      expect(mockInstall).not.toHaveBeenCalled();
+    });
+
+    // And commonly-bot would arrive with context:read on a private 1:1.
+    test('does not install commonly-bot into the DM', async () => {
+      await createPod();
+      const installedAgents = mockInstall.mock.calls.map(([agentName]) => agentName);
+      expect(installedAgents).not.toContain('commonly-bot');
+    });
+  });
+
+  // agent-admin is deliberately NOT in the guard set — admin pods are N:1
+  // (multiple admins ↔ one agent), per CLAUDE.md. Asserted so a future
+  // "tidy up the set" edit has to argue with a test.
+  test('agent-admin is NOT refused — admin pods are N:1 by design', async () => {
+    mockFoundPod.value = existing('agent-admin');
+    const res = await createPod();
+    expect(res.status).not.toBe(403);
+  });
+
+  test('an ordinary chat pod still dedups and joins as before', async () => {
+    mockFoundPod.value = existing('chat');
+    const res = await createPod();
+    expect(res.status).toBe(200);
+    expect(podSave).toHaveBeenCalled();
+    expect(mockFoundPod.value.members).toContain('bot-1');
+  });
+});

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -2561,6 +2561,40 @@ router.post('/pods', phase4RateLimit, agentRuntimeAuth, async (req: any, res: an
       .populate('createdBy', 'username profilePicture')
       .populate('members', 'username profilePicture');
     if (existingPod) {
+      // DM pods are strictly 1:1 (ADR-001 §3.10). VALID_POD_TYPES above gates
+      // the type the caller ASKED for, but this dedup branch matches on name
+      // ALONE and never re-checks the type of what it found — so a name
+      // collision turns a create call into a join against someone else's 1:1
+      // DM. This was the sixth write path to `members` and the only one that
+      // did not consult DM_POD_TYPES_GUARD (podController.joinPod,
+      // podInvites ×2, registry/admin, and ensureAgentInPod are the five that
+      // do). A membership invariant enforced at 5 of 6 writers is not an
+      // invariant — scripts/migrate-agent-dm-multimember.ts exists because
+      // multi-member DMs already happened once, and this writer is how they
+      // could happen again.
+      //
+      // Refuse the whole branch, not just the members.push: the two writes
+      // below are worse than the membership count. AgentInstallation.install
+      // grants posting rights (auth goes through AgentInstallation.find, NOT
+      // pod.members), and ensureCommonlyBotInstalled adds the summarizer with
+      // context:read on a private 1:1 conversation. Fail closed, including
+      // for a caller who is already one of the two members — this is a
+      // CREATE endpoint, and returning someone's DM from it is not something
+      // any caller needs. A third party who wants a private channel with one
+      // of the two members spawns a NEW agent-dm via commonly_open_dm.
+      const { DM_POD_TYPES_GUARD } = require('../services/agentIdentityService');
+      if (DM_POD_TYPES_GUARD.has(String(existingPod.type))) {
+        console.warn(
+          `[agent] pod-create dedup refused: "${name}" resolves to pod ${existingPod._id} `
+          + `type=${existingPod.type} (1:1 DM). ADR-001 §3.10.`,
+        );
+        return res.status(403).json({
+          code: 'dm_membership_refused',
+          message: 'A 1:1 DM pod already uses this name. DM pods are 1:1 and cannot be '
+            + 'joined by a third party — pick a different name, or open a new DM with '
+            + 'commonly_open_dm for a private conversation.',
+        });
+      }
       const isMember = existingPod.members?.some((m: any) => m._id.toString() === agentUser._id.toString());
       if (!isMember) {
         existingPod.members.push(agentUser._id);


### PR DESCRIPTION
@ux-lead's Finding B, verified from source and **larger than it was scoped**.

## The hole

`POST /api/agents/runtime/pods` validates the type the caller **asked for** against `VALID_POD_TYPES` (which excludes the DM types). But the global dedup lookup underneath is `Pod.findOne({ name })` — **name alone, no type filter** — and the branch that fires on a hit never re-checks what it found. A name collision turned a create call into a join against someone else's strictly-1:1 DM (ADR-001 §3.10).

This was the **sixth** write path to `Pod.members` and the only one that did not consult `DM_POD_TYPES_GUARD`:

| writer | consults guard |
|---|---|
| `podController.joinPod:477` | ✅ |
| `podInvites:175` | ✅ |
| `podInvites:242` | ✅ |
| `registry/admin:347` | ✅ |
| `agentIdentityService.ensureAgentInPod:512` | ✅ |
| `agentsRuntime` pod-create dedup | ❌ |

A membership invariant enforced at 5 of 6 writers is not an invariant. `scripts/migrate-agent-dm-multimember.ts` exists **because multi-member DMs already happened once** — a one-shot cleanup against an open drain.

## Why it refuses the whole branch, not just the push

The branch performs **three** writes, and the two after the push are worse than the membership count:

| write | consequence |
|---|---|
| `members.push` | a third party in a 1:1 pod |
| `AgentInstallation.install` | **posting rights** — auth goes through `AgentInstallation.find`, *not* `pod.members`, so fixing only the push still hands a stranger write access |
| `ensureCommonlyBotInstalled` | the summarizer, with **`context:read` on a private 1:1 conversation** |

It refuses even when the caller **is** one of the two members: this is a CREATE endpoint, returning someone's DM from it serves no caller, and the commonly-bot install would leak on that path too. `403` / `code: 'dm_membership_refused'`, matching the established contract. A third party who wants a private channel with one of the two members spawns a new `agent-dm` via `commonly_open_dm`.

`agent-admin` stays **out** of the guard set (N:1 by design) and there is now a test asserting that, so a future "tidy up the set" edit has to argue with it.

## Tests — 10, and the second mutation is the one that matters

| mutation | result |
|---|---|
| guard removed (the pre-fix state) | **8 fail**, 2 pass |
| guard blocks **only** the `members.push` | **6 fail**, 4 pass — membership assertions pass, **all four install assertions fail** |

So the partial fix that stops at the membership count does not survive this suite. Both control tests (`agent-admin`, ordinary chat pod) pass under every mutation, confirming they are not riding the refusal.

Typecheck: 57 errors before and after — all pre-existing, **0 in this file**. The 4 sibling `agentsRuntime` suites that fail to import do so identically on clean `main` (local Node 26; CI pins 20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)