### PR TITLE
fix(agents): pod-create dedup gates on findability, not just DM type

### DIFF
--- a/backend/__tests__/unit/routes/agentsRuntime.podCreateDedup.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.podCreateDedup.test.js
@@ -80,15 +80,27 @@ const app = express();
 app.use(express.json());
 app.use('/api/agents/runtime', router);
 
-// Default seeding is the DM case: two members, and the caller (bot-1) is NOT
-// one of them — that is the shape the guard has to refuse.
-const existing = (type, members = [{ _id: 'human-9' }, { _id: 'bot-7' }]) => ({
+// Default seeding is the DM/private case: two members, the caller (bot-1) is
+// NOT one of them, and no visibility flags — that is both the shape the DM
+// guard must refuse and the shape the property gate must refuse. Tests that
+// need a joinable pod say so explicitly, so forgetting to opt in fails closed.
+const existing = (type, overrides = {}) => ({
   _id: `pod-${type}`,
   name: 'Nova and Theo',
   type,
-  members,
+  members: [{ _id: 'human-9' }, { _id: 'bot-7' }],
   save: podSave,
   populate: podPopulate,
+  ...overrides,
+});
+
+// tier = community ∧ joinPolicy = 'open' — the only self-joinable shape
+// (ADR-016 §Join). This is what the dedup branch is legitimately for.
+const joinable = (type, overrides = {}) => existing(type, {
+  publicRead: true,
+  communityListed: true,
+  joinPolicy: 'open',
+  ...overrides,
 });
 
 const createPod = () => request(app)
@@ -132,28 +144,31 @@ describe('POST /pods dedup refuses to widen a 1:1 DM (ADR-001 §3.10)', () => {
     });
   });
 
-  // agent-admin is deliberately NOT in the guard set — admin pods are N:1
-  // (multiple admins ↔ one agent), per CLAUDE.md. Asserted so a future
-  // "tidy up the set" edit has to argue with a test.
-  test('agent-admin is NOT refused — admin pods are N:1 by design', async () => {
+  // agent-admin is deliberately NOT in DM_POD_TYPES_GUARD — admin pods are
+  // N:1 (multiple admins <-> one agent), per CLAUDE.md, so the DM guard must
+  // not claim it. It IS in NON_LISTABLE_POD_TYPES, so the property gate does.
+  // Asserted on the CODE, not just the status, so a future "tidy up the set"
+  // edit that moves it into the DM guard has to argue with a test.
+  test('agent-admin is refused by the property gate, not the DM guard', async () => {
     mockFoundPod.value = existing('agent-admin');
     const res = await createPod();
-    expect(res.status).not.toBe(403);
+    // Still refused — but by the PROPERTY gate, not the DM guard, and the
+    // distinct code is the point. agent-admin is deliberately outside
+    // DM_POD_TYPES_GUARD because it is N:1 by design; it is inside
+    // NON_LISTABLE_POD_TYPES because N:1 does not mean anyone may be the N
+    // (ADR-016:21, "terminally private like a DM for a different reason").
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('pod_not_directly_joinable');
+    expect(res.body.code).not.toBe('dm_membership_refused');
   });
 
   // The caller is seeded as ALREADY a member here, deliberately. What this
   // test guards is the dedup path itself — a name collision on an ordinary pod
   // returns the existing pod rather than erroring or creating a duplicate.
-  //
-  // Seeding a non-member instead would make the assertion defend the widening:
-  // "a caller who guesses a chat pod's name is pushed into its members" would
-  // become a pinned behaviour under the name "as before", and the follow-up
-  // gate (refuse unless the pod is directly joinable — isDirectlyJoinable, not
-  // joinPolicy alone, since publicRead:false + joinPolicy:'open' is a dormant
-  // declaration per ADR-016:46) would have to delete a green test to land.
-  // That gate is a separate PR; this file must not pre-approve its absence.
+  // Seeding a non-member instead would make the assertion defend the widening
+  // that the property gate below now refuses.
   test('an ordinary chat pod still dedups and returns the existing pod', async () => {
-    mockFoundPod.value = existing('chat', [{ _id: 'human-9' }, { _id: 'bot-1' }]);
+    mockFoundPod.value = existing('chat', { members: [{ _id: 'human-9' }, { _id: 'bot-1' }] });
     const res = await createPod();
     expect(res.status).toBe(200);
     expect(res.body._id).toBe('pod-chat');
@@ -162,5 +177,57 @@ describe('POST /pods dedup refuses to widen a 1:1 DM (ADR-001 §3.10)', () => {
     // ...but the branch does run to completion: the install still happens,
     // so this is a real pass through the dedup path, not an early return.
     expect(mockInstall).toHaveBeenCalled();
+  });
+
+  // The other legitimate case, and the one that proves the gate is a gate and
+  // not a blanket refusal: a NON-member joining a pod they could have found in
+  // Discover. tier = community AND joinPolicy = 'open' is the only shape that
+  // passes, and it must keep passing or the dedup branch is dead code.
+  test('a community-listed open pod still admits a non-member', async () => {
+    mockFoundPod.value = joinable('chat');
+    const res = await createPod();
+    expect(res.status).toBe(200);
+    expect(podSave).toHaveBeenCalled();
+    expect(mockFoundPod.value.members).toContain('bot-1');
+    expect(mockInstall).toHaveBeenCalled();
+  });
+
+  describe('a non-member cannot join by guessing the name (ADR-016 invariant 2)', () => {
+    // The case a joinPolicy-only gate misses, and the reason this gate reads
+    // the tier instead. ADR-016:46 — `joinPolicy:'open'` below community tier
+    // is "a dormant declaration, not an incoherence: open once listed."
+    test('private + joinPolicy:open — the dormant declaration is not permission', async () => {
+      mockFoundPod.value = existing('chat', { publicRead: false, joinPolicy: 'open' });
+      const res = await createPod();
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('pod_not_directly_joinable');
+      expect(podSave).not.toHaveBeenCalled();
+      expect(mockInstall).not.toHaveBeenCalled();
+    });
+
+    test('showcase tier (publicRead, not listed) is readable but not joinable', async () => {
+      mockFoundPod.value = existing('chat', { publicRead: true, communityListed: false });
+      const res = await createPod();
+      expect(res.status).toBe(403);
+      expect(mockInstall).not.toHaveBeenCalled();
+    });
+
+    test('community + invite-only is findable but not self-joinable', async () => {
+      mockFoundPod.value = joinable('chat', { joinPolicy: 'invite-only' });
+      const res = await createPod();
+      expect(res.status).toBe(403);
+      expect(mockInstall).not.toHaveBeenCalled();
+    });
+
+    // The write that actually grants access, asserted on the general case and
+    // not only the DM one: refusing the push while still installing would
+    // hand a stranger posting rights on a private pod.
+    test('refusal covers commonly-bot too — no context:read on a private pod', async () => {
+      mockFoundPod.value = existing('team');
+      await createPod();
+      const installed = mockInstall.mock.calls.map(([agentName]) => agentName);
+      expect(installed).not.toContain('commonly-bot');
+      expect(mockInstall).not.toHaveBeenCalled();
+    });
   });
 });

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -97,7 +97,7 @@ try {
 }
 
 const { stripInlineAvatars } = require('../services/avatarService');
-const { DIRECTLY_JOINABLE_QUERY } = require('../services/podListing');
+const { DIRECTLY_JOINABLE_QUERY, isDirectlyJoinable } = require('../services/podListing');
 
 const router = express.Router();
 
@@ -2596,6 +2596,40 @@ router.post('/pods', phase4RateLimit, agentRuntimeAuth, async (req: any, res: an
         });
       }
       const isMember = existingPod.members?.some((m: any) => m._id.toString() === agentUser._id.toString());
+      // The DM refusal above closes the sharpest case by TYPE. This closes the
+      // general one by PROPERTY: what makes a dedup-join unsafe was never "the
+      // pod is a DM", it is "the caller could not have found this pod".
+      // `Pod.findOne({ name })` is global and unfiltered, so an exact name is
+      // otherwise sufficient to join — and be installed into — any pod in the
+      // instance.
+      //
+      // ADR-016 §Join owns this predicate: "self-joinable <=> tier = community
+      // AND joinPolicy = 'open'. You can only self-join what you could have
+      // found." Composing `isDirectlyJoinable` rather than restating flags here
+      // is invariant 5 (podListing is the sole owner of the flag logic); a
+      // second hand-maintained list at a writer is what invariant 5 prevents.
+      //
+      // Gating on joinPolicy ALONE would not be enough, and the miss is the
+      // plainest case: a private pod with `joinPolicy:'open'` passes an
+      // invite-only check and is still name-joinable. ADR-016:46 calls that "a
+      // dormant declaration, not an incoherence: open once listed" — so reading
+      // it as live permission is the #772 bug the ADR was written to kill.
+      // `isDirectlyJoinable` requires publicRead AND communityListed AND
+      // not-invite-only, so the dormant case stays dormant.
+      //
+      // Members are exempt: an existing member re-creating by name is the
+      // legitimate idempotent create this dedup branch exists for.
+      if (!isMember && !isDirectlyJoinable(existingPod)) {
+        console.warn(
+          `[agent] pod-create dedup refused: "${name}" resolves to pod ${existingPod._id} `
+          + 'which is not directly joinable (ADR-016 §Join, invariant 2).',
+        );
+        return res.status(403).json({
+          code: 'pod_not_directly_joinable',
+          message: 'A pod with this name already exists and is not open to join. '
+            + 'Pick a different name.',
+        });
+      }
       if (!isMember) {
         existingPod.members.push(agentUser._id);
         await existingPod.save();


### PR DESCRIPTION
**Stacked on #817** (base is `fix/agent-pod-dedup-dm-guard`, so the diff here is only the additional change). #817 closes the sharpest case by **type**; this closes the general one by **property**.

Raised by @ux-lead on #817, whose correction is the reason this is a tier check and not a `joinPolicy` check.

## The gap #817 leaves

`Pod.findOne({ name })` in the dedup branch is global and unfiltered. After #817, an exact pod name is still sufficient for a non-member to be added to `members`, granted posting rights via `AgentInstallation.install`, and to pull `commonly-bot` in with `context:read` — for any pod not in `DM_POD_TYPES_GUARD`:

- private `team` / `chat` / `study` / `games` pods (`publicRead:false`, invisible in Discover)
- `showcase`-tier pods (`publicRead:true`, not listed)
- `community` + `invite-only`
- **`agent-admin`** — deliberately outside `DM_POD_TYPES_GUARD` because admin rooms are N:1, which per ADR-016:21 makes them *"terminally private like a DM for a different reason."* N:1 does not mean anyone may be the N.

Demonstrated at the route level before writing anything — invite-only chat pod, caller not a member, on #817's own head:

```
status:   200
members:  [human-9, bot-7, "bot-1"]
installs: ["openclaw", "commonly-bot"]
```

## Why the property and not the type

The thing that makes a dedup-join unsafe was never *"the pod is a DM"* — it is *"the caller could not have found this pod."* ADR-016 §Join already owns that predicate:

> **self-joinable ⟺ tier = community ∧ joinPolicy = 'open'.** You can only self-join what you could have found.

So this composes `isDirectlyJoinable` from `services/podListing.ts` rather than restating flags at the writer, which is **invariant 5** (podListing is the sole owner of the flag logic) rather than a second hand-maintained type list.

**Gating on `joinPolicy` alone — my own first cut — is one predicate short**, and the miss is the plainest case: a private pod with `joinPolicy:'open'` passes an invite-only check and stays name-joinable. ADR-016:46 calls that *"a dormant declaration, not an incoherence: open once listed"*, so reading it as live permission is the #772 incoherence the ADR was written to kill.

## Two of #817's control tests changed, not patched

The new gate correctly changes their outcome, which is the evidence it works:

- **`an ordinary chat pod still dedups and joins as before`** asserted that a **non-member** is added — that test pinned this bypass, with `as before` in its name. Split into the two legitimate cases: a community-listed open pod (non-member joins), and an existing member re-creating by name (idempotent create).
- **`agent-admin is NOT refused`** → now refused by the property gate. Asserted on the response **code** (`pod_not_directly_joinable`, and explicitly *not* `dm_membership_refused`) so a future "tidy up the set" edit that moves `agent-admin` into `DM_POD_TYPES_GUARD` has to argue with a test.

Members stay exempt — you cannot widen a pod you are already in.

## Verification

```
15 tests pass                                        (was 10 on #817)
tsc --noEmit -p tsconfig.typescheck.json  → 0 errors

M1  gate removed entirely                → 5 fail
M2  gate weakened to joinPolicy-only     → 4 fail, including private+open
```

**M2 is the one that earns the suite** — it is the one-predicate-short version, and a looser test set would pass it.

## Not verified

No DB read, so I can show the path is reachable and not that it has fired in production. I ran this suite and the typecheck, not the full backend run. The `console.warn` logs a pod name and id, consistent with #817's existing warn — I'd take the same "generic refusal" note I left on #817's 403 body if reviewers want the existence surface tightened, but I've kept the message generic here (`A pod with this name already exists and is not open to join`) rather than naming the type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
