### PR TITLE
fix(agents): a guessed pod name was a credential for joining any non-DM pod

### DIFF
--- a/backend/__tests__/unit/routes/agentsRuntime.podCreateDedup.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.podCreateDedup.test.js
@@ -237,4 +237,55 @@ describe('POST /pods dedup refuses to widen a 1:1 DM (ADR-001 §3.10)', () => {
     // so this is a real pass through the dedup path, not an early return.
     expect(mockInstall).toHaveBeenCalled();
   });
+
+  // ── The findability tier, ported from #819 ────────────────────────────────
+  //
+  // These are the cases that separate `isDirectlyJoinable` from the
+  // joinPolicy-only gate that was proposed first. Each pod below declares
+  // SOME openness and is still not joinable by name, so a suite without them
+  // passes the one-predicate-short version of this fix. That version was
+  // mine; these tests exist because it was wrong.
+  //
+  // Asserting on `mockInstall` as well as on the status is deliberate: the
+  // install is the write that grants POSTING RIGHTS, and per CLAUDE.md auth
+  // goes through AgentInstallation, not pod.members. A refusal that blocked
+  // the members.push but still installed would look correct on status alone.
+
+  test('private + joinPolicy:open — the dormant declaration is not permission', async () => {
+    // ADR-016:46 calls this "a dormant declaration, not an incoherence: open
+    // once listed." `joinPolicy` alone reads the dormant value as live
+    // permission — which is the #772 bug the ADR exists to close.
+    mockFoundPod.value = existing('chat', undefined, { joinPolicy: 'open' });
+    const res = await createPod();
+    expect(res.status).toBe(403);
+    expect(podSave).not.toHaveBeenCalled();
+    expect(mockInstall).not.toHaveBeenCalled();
+  });
+
+  test('showcase tier (publicRead, not listed) is readable but not joinable', async () => {
+    mockFoundPod.value = existing('chat', undefined, { publicRead: true, joinPolicy: 'open' });
+    const res = await createPod();
+    expect(res.status).toBe(403);
+    expect(mockInstall).not.toHaveBeenCalled();
+  });
+
+  test('community + invite-only is findable but not self-joinable', async () => {
+    mockFoundPod.value = existing('chat', undefined, {
+      publicRead: true, communityListed: true, joinPolicy: 'invite-only',
+    });
+    const res = await createPod();
+    expect(res.status).toBe(403);
+    expect(mockInstall).not.toHaveBeenCalled();
+  });
+
+  test('a non-joinable private pod gets no commonly-bot either — no context:read', async () => {
+    // The third write on this branch, and the one that is a read grant rather
+    // than a membership change. The DM case is covered above; this pins that
+    // the property-gated refusal stops it too, not just the type-gated one.
+    mockFoundPod.value = existing('chat', undefined, { joinPolicy: 'open' });
+    const res = await createPod();
+    expect(res.status).toBe(403);
+    const installedAgents = mockInstall.mock.calls.map(([agentName]) => agentName);
+    expect(installedAgents).not.toContain('commonly-bot');
+  });
 });

--- a/backend/__tests__/unit/routes/agentsRuntime.podCreateDedup.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.podCreateDedup.test.js
@@ -82,14 +82,20 @@ app.use('/api/agents/runtime', router);
 
 // Default seeding is the DM case: two members, and the caller (bot-1) is NOT
 // one of them — that is the shape the guard has to refuse.
-const existing = (type, members = [{ _id: 'human-9' }, { _id: 'bot-7' }]) => ({
+const existing = (type, members = [{ _id: 'human-9' }, { _id: 'bot-7' }], flags = {}) => ({
   _id: `pod-${type}`,
   name: 'Nova and Theo',
   type,
   members,
+  // Absent by default — an unlisted, non-public pod is the common case and
+  // the one a non-member must not be able to join by guessing its name.
+  ...flags,
   save: podSave,
   populate: podPopulate,
 });
+
+const asMember = [{ _id: 'human-9' }, { _id: 'bot-1' }];
+const LISTED_OPEN = { publicRead: true, communityListed: true, joinPolicy: 'open' };
 
 const createPod = () => request(app)
   .post('/api/agents/runtime/pods')
@@ -104,10 +110,10 @@ describe('POST /pods dedup refuses to widen a 1:1 DM (ADR-001 §3.10)', () => {
   describe.each(['agent-room', 'agent-dm'])('name collides with an existing %s', (type) => {
     beforeEach(() => { mockFoundPod.value = existing(type); });
 
-    test('refuses with 403 dm_membership_refused', async () => {
+    test('refuses with 403 pod_name_unavailable', async () => {
       const res = await createPod();
       expect(res.status).toBe(403);
-      expect(res.body.code).toBe('dm_membership_refused');
+      expect(res.body.code).toBe('pod_name_unavailable');
     });
 
     test('does not add the caller as a third member', async () => {
@@ -135,10 +141,78 @@ describe('POST /pods dedup refuses to widen a 1:1 DM (ADR-001 §3.10)', () => {
   // agent-admin is deliberately NOT in the guard set — admin pods are N:1
   // (multiple admins ↔ one agent), per CLAUDE.md. Asserted so a future
   // "tidy up the set" edit has to argue with a test.
-  test('agent-admin is NOT refused — admin pods are N:1 by design', async () => {
-    mockFoundPod.value = existing('agent-admin');
+  // agent-admin is deliberately NOT in the DM guard set. Seeded with the
+  // caller already a member, because agent-admin is in NON_LISTABLE_POD_TYPES
+  // and so is never directly joinable — a non-member is refused by the
+  // joinability gate below, which is correct but would test the wrong thing
+  // here. What this pins is only that the DM guard does not claim it.
+  test('agent-admin is NOT refused as a DM — admin pods are N:1 by design', async () => {
+    mockFoundPod.value = existing('agent-admin', asMember);
     const res = await createPod();
     expect(res.status).not.toBe(403);
+  });
+
+  // ------------------------------------------------------------------
+  // A guessed name was a credential for joining any non-DM pod. The five
+  // other writers to `members` all gate on joinability; this branch gated on
+  // nothing. `POST /pods/:podId/self-install` — the dedicated agent-join
+  // path — refuses invite-only, refuses non-members, and requires an active
+  // installation; the dedup branch enforced none of the three.
+  // ------------------------------------------------------------------
+  describe('a non-member cannot join a non-joinable pod by guessing its name', () => {
+    const cases = [
+      ['invite-only, otherwise listed', { ...LISTED_OPEN, joinPolicy: 'invite-only' }],
+      ['unlisted and non-public', {}],
+      ['public but not community-listed', { publicRead: true, communityListed: false }],
+      // ADR-016:46 — `joinPolicy: 'open'` below the community tier is a
+      // DORMANT declaration: it means "open once listed", not "open now".
+      // This is the case a joinPolicy-only gate lets through, which is why
+      // the check is isDirectlyJoinable and not `joinPolicy !== 'invite-only'`.
+      ['dormant open — joinPolicy open but never listed', { publicRead: false, communityListed: false, joinPolicy: 'open' }],
+    ];
+
+    test.each(cases)('refuses %s', async (_label, flags) => {
+      mockFoundPod.value = existing('chat', undefined, flags);
+      const res = await createPod();
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('pod_name_unavailable');
+    });
+
+    test.each(cases)('performs none of the three writes for %s', async (_label, flags) => {
+      mockFoundPod.value = existing('chat', undefined, flags);
+      await createPod();
+      expect(podSave).not.toHaveBeenCalled();
+      expect(mockFoundPod.value.members).toHaveLength(2);
+      expect(mockInstall).not.toHaveBeenCalled();
+    });
+  });
+
+  test('a directly joinable pod still joins — the gate is not a blanket refusal', async () => {
+    mockFoundPod.value = existing('chat', undefined, LISTED_OPEN);
+    const res = await createPod();
+    expect(res.status).toBe(200);
+    expect(podSave).toHaveBeenCalled();
+    expect(mockFoundPod.value.members).toContain('bot-1');
+  });
+
+  // Pod names are guessable by construction — resolveAgentDisplayLabel emits
+  // "Nova and Theo" — so a refusal that names its reason is an existence
+  // oracle for other people's private pods. Both refusals must be byte-identical.
+  test('the DM refusal and the non-joinable refusal are indistinguishable', async () => {
+    mockFoundPod.value = existing('agent-dm');
+    const dm = await createPod();
+    jest.clearAllMocks();
+    mockFoundPod.value = existing('chat', undefined, {});
+    const other = await createPod();
+
+    expect(dm.status).toBe(other.status);
+    expect(dm.body).toEqual(other.body);
+    // The remedy (`commonly_open_dm`) is offered in both, so it discloses
+    // nothing. What must never appear is anything about the pod that was
+    // FOUND — its type or its id — since that is what the caller is fishing
+    // for and did not already know.
+    const body = JSON.stringify(dm.body);
+    expect(body).not.toMatch(/agent-dm|agent-room|pod-agent-dm/);
   });
 
   // The caller is seeded as ALREADY a member here, deliberately. What this

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -2638,20 +2638,58 @@ router.post('/pods', phase4RateLimit, agentRuntimeAuth, async (req: any, res: an
       // CREATE endpoint, and returning someone's DM from it is not something
       // any caller needs. A third party who wants a private channel with one
       // of the two members spawns a NEW agent-dm via commonly_open_dm.
-      const { DM_POD_TYPES_GUARD } = require('../services/agentIdentityService');
-      if (DM_POD_TYPES_GUARD.has(String(existingPod.type))) {
+      // One refusal shape for every reason. The caller learns "that name is
+      // taken by something you can't join" and nothing else: which pod, what
+      // type, and whether it is a DM are all withheld, because pod names are
+      // guessable by construction — resolveAgentDisplayLabel produces
+      // "Nova and Theo" — and a refusal that names the reason turns this
+      // endpoint into an existence oracle for other people's private pods.
+      // Same principle as the personal-pod-types 404 on direct GET: the
+      // *existence* surface must not advertise conversations you aren't in.
+      // Operators still get the reason, server-side, in the warn below.
+      const refusePodNameCollision = (reason: string) => {
         console.warn(
           `[agent] pod-create dedup refused: "${name}" resolves to pod ${existingPod._id} `
-          + `type=${existingPod.type} (1:1 DM). ADR-001 §3.10.`,
+          + `type=${existingPod.type} — ${reason}`,
         );
         return res.status(403).json({
-          code: 'dm_membership_refused',
-          message: 'A 1:1 DM pod already uses this name. DM pods are 1:1 and cannot be '
-            + 'joined by a third party — pick a different name, or open a new DM with '
-            + 'commonly_open_dm for a private conversation.',
+          code: 'pod_name_unavailable',
+          message: 'That pod name is already taken by a pod you cannot join. Pick a '
+            + 'different name. To start a private conversation with a specific agent, '
+            + 'use commonly_open_dm instead of creating a pod by name.',
         });
+      };
+
+      const { DM_POD_TYPES_GUARD } = require('../services/agentIdentityService');
+      if (DM_POD_TYPES_GUARD.has(String(existingPod.type))) {
+        return refusePodNameCollision('1:1 DM pod (ADR-001 §3.10)');
       }
+
       const isMember = existingPod.members?.some((m: any) => m._id.toString() === agentUser._id.toString());
+
+      // The DM guard above closes the worst case; this closes the rest of it.
+      // The five other writers to `members` all gate on joinability — the
+      // dedicated agent-join path (`POST /pods/:podId/self-install`) refuses
+      // invite-only, refuses non-members of pods it doesn't own, and requires
+      // an active installation. This branch enforced none of them, so a
+      // guessed name was a credential for joining ANY non-DM pod in the
+      // instance: private, invite-only, another team's — all of it, plus
+      // posting rights via AgentInstallation.install and commonly-bot with
+      // context:read.
+      //
+      // Gate on isDirectlyJoinable, not on joinPolicy. `joinPolicy: 'open'`
+      // below the community tier is a dormant declaration (ADR-016:46) — it
+      // means "open once listed", not "open now" — so a pod with
+      // publicRead:false, communityListed:false, joinPolicy:'open' passes a
+      // joinPolicy-only check and is exactly the pod that must be refused.
+      // isDirectlyJoinable = isCommunityListed && joinPolicy !== 'invite-only',
+      // which is the same predicate the community browse surface uses, so a
+      // pod is joinable-by-name here iff it was already discoverable anyway.
+      const { isDirectlyJoinable } = require('../services/podListing');
+      if (!isMember && !isDirectlyJoinable(existingPod)) {
+        return refusePodNameCollision('caller is not a member and the pod is not directly joinable');
+      }
+
       if (!isMember) {
         existingPod.members.push(agentUser._id);
         await existingPod.save();


### PR DESCRIPTION
Stacked on #817 — same handler, sequenced rather than parallel. Merge #817 first; this retargets to `main` automatically.

## What #817 left open

#817 refused the dedup branch for DM types. The branch itself still does `Pod.findOne({ name })` — global, unfiltered, with the comment saying so out loud: *"if a pod with this name already exists anywhere, join it and return it."*

The dedicated agent-join path gates three things:

| `POST /pods/:podId/self-install` | dedup branch |
|---|---|
| `joinPolicy === 'invite-only'` → 403 | — |
| `!isAgentOwned && !isMember` → 403 | — |
| no active installation → 403 | — |

@sprint-review demonstrated it at the route level rather than arguing it — invite-only chat pod, caller not a member: `200`, added to `members`, and both `openclaw` and `commonly-bot` installed. All three writes, the same three #817 refuses for DMs.

## The gate

`!isMember && !isDirectlyJoinable(existingPod) → 403`.

**`isDirectlyJoinable`, not `joinPolicy`** — this is the whole point, and it's @ux-lead's finding. `joinPolicy: 'open'` below the community tier is a *dormant declaration* (ADR-016:46): it means "open once listed", not "open now". So `publicRead:false, communityListed:false, joinPolicy:'open'` sails through a joinPolicy-only check and is exactly the pod that must be refused. `isDirectlyJoinable = isCommunityListed && joinPolicy !== 'invite-only'` is the same predicate the community browse surface uses, so a pod is joinable-by-name here iff it was already discoverable anyway.

## Refusal body

Both refusals now return one body — `pod_name_unavailable`, *"That pod name is already taken by a pod you cannot join."* #817's message named the collision as a 1:1 DM, which is an existence oracle: pod names are guessable by construction (`resolveAgentDisplayLabel` emits *"Nova and Theo"*), and CLAUDE.md's own precedent is that personal pod types **404** non-members on direct GET so the existence surface doesn't advertise other people's DMs. Operators keep the reason server-side in the `console.warn`. `dm_membership_refused` remains the posting-path code and is untouched.

## Verification

20/20 green. Mutation-probed:

| mutation | result |
|---|---|
| gate → `joinPolicy === 'invite-only'` (the wrong fix) | **7 failed** |
| drop the `!isMember` exemption | **2 failed** |
| baseline | 20/20, `tsc` 0 errors in file |

Anchor count asserted before each mutation; restores verified with `diff -q`.

Tests cover invite-only, unlisted/non-public, public-but-not-listed, the ADR-016:46 dormant-open case, that a genuinely joinable pod still joins, and that the DM and non-joinable refusals are byte-identical.

Assigned by @ux-lead; probe by @sprint-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)