### PR TITLE
fix(agents): the attempts counter has no writer, and two drivers have no terminal state

### DIFF
--- a/backend/__tests__/unit/services/agentEventService.lifecycle.test.js
+++ b/backend/__tests__/unit/services/agentEventService.lifecycle.test.js
@@ -61,6 +61,7 @@ const AgentEvent = require('../../../models/AgentEvent');
 const AgentMemory = require('../../../models/AgentMemory');
 const { AgentInstallation } = require('../../../models/AgentRegistry');
 const AgentEventService = require('../../../services/agentEventService');
+const { runAgent } = require('../../../services/nativeRuntimeService');
 
 // Let fire-and-forget promise chains (webhook delivery, native settle) run.
 const flush = () => new Promise((resolve) => setImmediate(resolve));
@@ -250,7 +251,7 @@ describe('driver paths reach a terminal state', () => {
     };
 
     test('creates the event already counted as one delivery', async () => {
-      require('../../../services/nativeRuntimeService').runAgent.mockResolvedValue({ ok: true });
+      runAgent.mockResolvedValue({ ok: true });
 
       await enqueueNative();
 
@@ -264,7 +265,7 @@ describe('driver paths reach a terminal state', () => {
     });
 
     test('a completed run acks — without this the requeue hands it to an external poller', async () => {
-      require('../../../services/nativeRuntimeService').runAgent.mockResolvedValue({ ok: true });
+      runAgent.mockResolvedValue({ ok: true });
       AgentEvent.findOneAndUpdate.mockResolvedValue({
         _id: 'evt-n', agentName: 'clerk', instanceId: 'default', podId: 'p1',
         type: 'task.assigned', payload: {}, status: 'acked', memoryRevisionAtDelivery: 0,
@@ -279,7 +280,7 @@ describe('driver paths reach a terminal state', () => {
     });
 
     test('a failed run is terminal too, not left for redelivery', async () => {
-      require('../../../services/nativeRuntimeService').runAgent
+      runAgent
         .mockRejectedValue(new Error('model timeout'));
       AgentEvent.findOneAndUpdate.mockResolvedValue({
         _id: 'evt-n', agentName: 'clerk', instanceId: 'default', podId: 'p1',
@@ -298,7 +299,7 @@ describe('driver paths reach a terminal state', () => {
       // The rejection handler is scoped to runAgent via two-argument .then. A
       // chained .catch would swallow this ack rejection and then mark a run
       // that actually succeeded as 'failed' — silently inverting the outcome.
-      require('../../../services/nativeRuntimeService').runAgent.mockResolvedValue({ ok: true });
+      runAgent.mockResolvedValue({ ok: true });
       AgentEvent.findOneAndUpdate.mockRejectedValue(new Error('mongo down'));
 
       await enqueueNative();

--- a/backend/__tests__/unit/services/agentEventService.lifecycle.test.js
+++ b/backend/__tests__/unit/services/agentEventService.lifecycle.test.js
@@ -1,0 +1,311 @@
+/**
+ * AgentEvent lifecycle: the delivery counter and the terminal states.
+ *
+ * Four defects sat in one lifecycle, each one hiding the next:
+ *
+ *   1. `attempts` was never incremented anywhere in the pending↔delivered
+ *      cycle, so every payload the kernel has ever served carried `attempts: 0`
+ *      — the field ADR-004 §Event model obliges drivers to dedup with.
+ *   2. Because nothing wrote it, `attempts < cap` in garbageCollect() was a
+ *      guard on a frozen variable: structurally unable to fire.
+ *   3. Turning the counter on without a cap-exhaustion pass would have been
+ *      worse than leaving it off — a capped event fails the requeue predicate,
+ *      and a 'delivered' row is invisible to list(), so it would sit stuck for
+ *      the full 168h retention window. That is the Task #67 symptom the
+ *      requeue exists to fix, recreated by its own fix.
+ *   4. Two driver classes never reach a terminal state at all, so the requeue
+ *      was picking up work that had already succeeded — for webhooks that
+ *      meant re-POSTing a handled event every ~10-20 min, forever.
+ *
+ * These tests pin the counter's single owner and each terminal transition. The
+ * assertions are deliberately about the QUERY SHAPE rather than about observed
+ * counts: this is a mocked-model suite, so a test that only checked "some
+ * update happened" would pass against every one of the four bugs above.
+ */
+
+jest.mock('../../../models/AgentEvent', () => ({
+  create: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+  findByIdAndUpdate: jest.fn(),
+  find: jest.fn(),
+  updateMany: jest.fn(),
+  deleteMany: jest.fn(),
+}));
+
+jest.mock('../../../models/AgentMemory', () => ({
+  findOne: jest.fn(),
+  updateOne: jest.fn(),
+}));
+
+jest.mock('../../../services/agentMemoryService', () => ({
+  buildMemoryDigestBundle: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { find: jest.fn(), findOne: jest.fn() },
+}));
+
+jest.mock('../../../models/Integration', () => ({}));
+jest.mock('../../../models/Gateway', () => ({ findById: jest.fn() }));
+jest.mock('../../../services/agentIdentityService', () => ({
+  getAgentTypeConfig: jest.fn(() => ({ runtime: 'moltbot' })),
+}));
+jest.mock('../../../services/agentProvisionerService', () => ({
+  clearAgentRuntimeSessions: jest.fn(),
+  restartAgentRuntime: jest.fn(),
+  resolveOpenClawAccountId: jest.fn(() => 'acct'),
+}));
+jest.mock('../../../services/nativeRuntimeService', () => ({ runAgent: jest.fn() }));
+
+const AgentEvent = require('../../../models/AgentEvent');
+const AgentMemory = require('../../../models/AgentMemory');
+const { AgentInstallation } = require('../../../models/AgentRegistry');
+const AgentEventService = require('../../../services/agentEventService');
+
+// Let fire-and-forget promise chains (webhook delivery, native settle) run.
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+const lastCall = (mockFn) => mockFn.mock.calls[mockFn.mock.calls.length - 1];
+
+describe('attempts is a delivery counter with exactly one writer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    AgentMemory.findOne.mockReturnValue({
+      select: () => ({ lean: () => Promise.resolve({ revision: 3, lastSeenRevision: 1 }) }),
+    });
+  });
+
+  test('list() increments attempts on the pending → delivered claim', async () => {
+    AgentEvent.find.mockReturnValue({
+      sort: () => ({
+        limit: () => ({ select: () => ({ lean: () => Promise.resolve([{ _id: 'evt-1' }]) }) }),
+      }),
+    });
+    AgentEvent.findOneAndUpdate.mockReturnValue({
+      lean: () => Promise.resolve({
+        _id: 'evt-1', agentName: 'pixel', instanceId: 'default', podId: 'p1',
+        type: 'chat.mention', payload: {}, status: 'delivered', attempts: 1,
+      }),
+    });
+
+    await AgentEventService.list({ agentName: 'pixel', instanceId: 'default' });
+
+    const [filter, update, options] = lastCall(AgentEvent.findOneAndUpdate);
+    expect(filter).toEqual({ _id: 'evt-1', status: 'pending' });
+    // The claim IS the delivery — ADR-004 §Event model.
+    expect(update.$inc).toEqual({ attempts: 1 });
+    expect(update.$set).toEqual(expect.objectContaining({ status: 'delivered' }));
+    // `new: true` is what makes the incremented value the one the driver is
+    // handed. Without it the payload would still report the pre-claim count.
+    expect(options).toEqual({ new: true });
+  });
+
+  test('acknowledge() does NOT increment — an ack is not a delivery', async () => {
+    AgentEvent.findOneAndUpdate.mockResolvedValue({
+      _id: 'evt-1', agentName: 'pixel', instanceId: 'default', podId: 'p1',
+      type: 'chat.mention', payload: {}, status: 'acked', memoryRevisionAtDelivery: 0,
+    });
+
+    await AgentEventService.acknowledge('evt-1', 'pixel', 'default', { outcome: 'no_action' });
+
+    const [, update] = lastCall(AgentEvent.findOneAndUpdate);
+    expect(update.$set).toEqual(expect.objectContaining({ status: 'acked' }));
+    // Double-counting here is what made a normally-handled event read
+    // `attempts: 2` and turned the field into "deliveries plus transitions."
+    expect(update.$inc).toBeUndefined();
+  });
+
+  test('recordFailure() does NOT increment either', async () => {
+    AgentEvent.findOneAndUpdate.mockResolvedValue({
+      _id: 'evt-1', agentName: 'pixel', instanceId: 'default', podId: 'p1',
+      type: 'chat.mention', payload: {}, status: 'failed',
+    });
+
+    await AgentEventService.recordFailure('evt-1', 'pixel', 'default', 'boom');
+
+    const [, update] = lastCall(AgentEvent.findOneAndUpdate);
+    expect(update.$set).toEqual(expect.objectContaining({ status: 'failed', error: 'boom' }));
+    expect(update.$inc).toBeUndefined();
+  });
+});
+
+describe('garbageCollect: the requeue predicate and its cap', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    AgentEvent.updateMany.mockResolvedValue({ modifiedCount: 0 });
+    AgentEvent.deleteMany.mockResolvedValue({ deletedCount: 0 });
+  });
+
+  const passes = () => AgentEvent.updateMany.mock.calls.map(([filter, update]) => ({ filter, update }));
+
+  test('requeue no longer filters on the phantom `ackedAt` field', async () => {
+    await AgentEventService.garbageCollect({});
+
+    const [requeue] = passes();
+    // `ackedAt` is not on IAgentEvent and not in the schema — Mongoose stripped
+    // it, so the clause matched every document and read as a live narrowing to
+    // anyone auditing the predicate. Asserting its ABSENCE is the point: a test
+    // that only checked the surviving keys would pass with it still there.
+    expect(Object.keys(requeue.filter)).not.toContain('ackedAt');
+    expect(requeue.filter).toEqual(expect.objectContaining({ status: 'delivered' }));
+    expect(requeue.update.$set).toEqual({ status: 'pending', deliveredAt: null });
+  });
+
+  test('a second pass retires cap-exhausted events to the terminal failed state', async () => {
+    await AgentEventService.garbageCollect({ requeueMaxAttempts: 3 });
+
+    const expire = passes().find((p) => p.update.$set?.status === 'failed');
+    expect(expire).toBeDefined();
+    expect(expire.filter).toEqual(expect.objectContaining({
+      status: 'delivered',
+      attempts: { $gte: 3 },
+    }));
+    expect(expire.update.$set.error).toMatch(/cap exhausted/i);
+  });
+
+  test('the two passes are disjoint — no document can be touched by both', async () => {
+    await AgentEventService.garbageCollect({ requeueMaxAttempts: 3 });
+
+    const requeue = passes().find((p) => p.update.$set?.status === 'pending');
+    const expire = passes().find((p) => p.update.$set?.status === 'failed');
+
+    // Disjointness rides on `attempts` alone: < cap vs >= cap. If a future edit
+    // makes the expire pass `$gt` (or the requeue `$lte`), one GC run could
+    // requeue an event and immediately fail it, losing the redelivery.
+    expect(requeue.filter.$or).toEqual([
+      { attempts: { $lt: 3 } },
+      { attempts: { $exists: false } },
+    ]);
+    expect(expire.filter.attempts).toEqual({ $gte: 3 });
+  });
+
+  test('reports what it retired, so a poison-event backlog is visible in ops output', async () => {
+    AgentEvent.updateMany
+      .mockResolvedValueOnce({ modifiedCount: 2 })   // requeued
+      .mockResolvedValueOnce({ modifiedCount: 5 });  // expired
+
+    const result = await AgentEventService.garbageCollect({});
+
+    expect(result.requeuedDelivered).toBe(2);
+    expect(result.expiredDelivered).toBe(5);
+  });
+});
+
+describe('driver paths reach a terminal state', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    AgentInstallation.findOne.mockResolvedValue(null);
+    AgentEvent.findByIdAndUpdate.mockResolvedValue({});
+  });
+
+  test('a successful webhook POST terminates as acked, not delivered', async () => {
+    AgentEvent.create.mockResolvedValue({
+      _id: 'evt-w', agentName: 'hookbot', instanceId: 'default', podId: 'p1',
+      type: 'chat.mention', payload: {}, status: 'pending', attempts: 0,
+    });
+    AgentInstallation.find.mockReturnValue({
+      lean: () => Promise.resolve([{
+        agentName: 'hookbot',
+        config: { runtime: { webhookUrl: 'https://example.test/hook' } },
+      }]),
+    });
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ outcome: 'no_action' }),
+    });
+
+    await AgentEventService.enqueue({
+      agentName: 'hookbot', instanceId: 'default', podId: 'p1', type: 'chat.mention', payload: {},
+    });
+    await flush();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [, update] = lastCall(AgentEvent.findByIdAndUpdate);
+    // 'delivered' here is what fed a handled event back into the requeue
+    // population and re-POSTed it ~10-20 min later, indefinitely.
+    expect(update.status).toBe('acked');
+    expect(update['delivery.outcome']).toBe('no_action');
+  });
+
+  describe('native runtime', () => {
+    const nativeInstall = {
+      _id: 'inst-n',
+      agentName: 'clerk',
+      config: { runtime: { runtimeType: 'native' } },
+    };
+
+    const enqueueNative = async () => {
+      AgentInstallation.findOne.mockReturnValue({ lean: () => Promise.resolve(nativeInstall) });
+      AgentInstallation.find.mockReturnValue({ lean: () => Promise.resolve([]) });
+      AgentEvent.create.mockResolvedValue({
+        _id: 'evt-n', agentName: 'clerk', instanceId: 'default', podId: 'p1',
+        type: 'task.assigned', payload: {}, status: 'delivered', attempts: 1,
+      });
+      await AgentEventService.enqueue({
+        agentName: 'clerk', instanceId: 'default', podId: 'p1', type: 'task.assigned', payload: {},
+      });
+      await flush();
+      await flush();
+    };
+
+    test('creates the event already counted as one delivery', async () => {
+      require('../../../services/nativeRuntimeService').runAgent.mockResolvedValue({ ok: true });
+
+      await enqueueNative();
+
+      // list() never claims a native event, so if the create doesn't count the
+      // delivery nothing ever will — and the driver sees attempts: 0 on an
+      // event that has been delivered exactly once.
+      expect(AgentEvent.create).toHaveBeenCalledWith(expect.objectContaining({
+        status: 'delivered',
+        attempts: 1,
+      }));
+    });
+
+    test('a completed run acks — without this the requeue hands it to an external poller', async () => {
+      require('../../../services/nativeRuntimeService').runAgent.mockResolvedValue({ ok: true });
+      AgentEvent.findOneAndUpdate.mockResolvedValue({
+        _id: 'evt-n', agentName: 'clerk', instanceId: 'default', podId: 'p1',
+        type: 'task.assigned', payload: {}, status: 'acked', memoryRevisionAtDelivery: 0,
+      });
+
+      await enqueueNative();
+
+      const acked = AgentEvent.findOneAndUpdate.mock.calls
+        .find(([, update]) => update.$set?.status === 'acked');
+      expect(acked).toBeDefined();
+      expect(acked[0]).toEqual(expect.objectContaining({ _id: 'evt-n' }));
+    });
+
+    test('a failed run is terminal too, not left for redelivery', async () => {
+      require('../../../services/nativeRuntimeService').runAgent
+        .mockRejectedValue(new Error('model timeout'));
+      AgentEvent.findOneAndUpdate.mockResolvedValue({
+        _id: 'evt-n', agentName: 'clerk', instanceId: 'default', podId: 'p1',
+        type: 'task.assigned', payload: {}, status: 'failed',
+      });
+
+      await enqueueNative();
+
+      const failed = AgentEvent.findOneAndUpdate.mock.calls
+        .find(([, update]) => update.$set?.status === 'failed');
+      expect(failed).toBeDefined();
+      expect(failed[1].$set.error).toMatch(/native runtime error: model timeout/);
+    });
+
+    test('an ack that itself fails does not get reported as a failed run', async () => {
+      // The rejection handler is scoped to runAgent via two-argument .then. A
+      // chained .catch would swallow this ack rejection and then mark a run
+      // that actually succeeded as 'failed' — silently inverting the outcome.
+      require('../../../services/nativeRuntimeService').runAgent.mockResolvedValue({ ok: true });
+      AgentEvent.findOneAndUpdate.mockRejectedValue(new Error('mongo down'));
+
+      await enqueueNative();
+
+      const failed = AgentEvent.findOneAndUpdate.mock.calls
+        .find(([, update]) => update.$set?.status === 'failed');
+      expect(failed).toBeUndefined();
+    });
+  });
+});

--- a/backend/services/agentEventService.ts
+++ b/backend/services/agentEventService.ts
@@ -80,6 +80,10 @@ interface GarbageCollectResult {
   failedRetentionHours: number;
   requeuedDelivered?: number;
   requeueDeliveredMinutes?: number;
+  // Events that hit the requeue cap and were retired to the terminal 'failed'
+  // state. Without this pass they would sit in 'delivered' — invisible to
+  // list(), ineligible for requeue — until the 168h retention delete.
+  expiredDelivered?: number;
 }
 
 interface SessionSizeEntry {
@@ -204,8 +208,18 @@ const deliverEventViaWebhook = async (installation: InstallationDoc, event: Even
       }
     }
 
+    // Terminal, not 'delivered'. The webhook has returned 2xx and its outcome
+    // is recorded — there is no later ack coming, because ADR-006 drivers do
+    // not poll and cannot call POST /events/:id/ack. Leaving these 'delivered'
+    // put every successfully-handled webhook event into the garbageCollect()
+    // requeue population, which has no `delivery` exclusion: ~10-20 min after
+    // a successful POST the row flipped back to 'pending' and the endpoint was
+    // called AGAIN with the same event. That is duplicate delivery across the
+    // whole webhook driver class, not queue hygiene — and it is exactly the
+    // at-least-once behaviour ADR-004 permits, arriving for a reason the
+    // driver has no way to distinguish from a real retry.
     await AgentEvent.findByIdAndUpdate(event._id, {
-      status: 'delivered',
+      status: 'acked',
       deliveredAt: new Date(),
       'delivery.outcome': outcome,
       'delivery.updatedAt': new Date(),
@@ -589,25 +603,36 @@ class AgentEventService {
 
     // Task #67: requeue events stuck in 'delivered' status whose poller
     // crashed/errored before processing. The /events endpoint only returns
-    // `status: 'pending'` events, so a 'delivered' event with no `ackedAt`
-    // becomes invisible to the agent forever — neither retried nor surfaced.
+    // `status: 'pending'` events, so an unhandled 'delivered' event becomes
+    // invisible to the agent forever — neither retried nor surfaced.
     // Saw this 2026-05-18: Cody's old pod marked 2 chat.mentions delivered
     // then died on a stale config; the new pod never re-fetched them.
     //
-    // Requeue rule: status === 'delivered' AND ackedAt is null AND
-    // deliveredAt is older than 10 min (env-tunable) AND attempts < 3
-    // (prevent infinite loops on poison events). The 10-min default
-    // accommodates legitimately-long-running tool calls — codex exec for
-    // multi-slide LLM generation can take 3-5 min — without re-firing
-    // while the agent is still processing.
+    // Requeue rule: status === 'delivered' AND deliveredAt is older than
+    // 10 min (env-tunable) AND attempts < 3 (prevent infinite loops on
+    // poison events). The 10-min default accommodates legitimately-long-
+    // running tool calls — codex exec for multi-slide LLM generation can
+    // take 3-5 min — without re-firing while the agent is still processing.
+    //
+    // Effective redelivery latency is NOT 10 minutes: schedulerService runs
+    // this job on `*/10`, so an event delivered just after a pass waits for
+    // the one after next. Period P and threshold T give [T, T+P) — uniform
+    // over 10-20 min here, mean ~15. Change both numbers together.
+    //
+    // The predicate previously also required `ackedAt: {$in: [null, undefined]}`.
+    // There is no `ackedAt` field on AgentEvent — not in IAgentEvent, not in
+    // the schema, never written — so Mongoose stripped it and the clause
+    // matched every document. Dropped rather than "fixed": `status: 'delivered'`
+    // already excludes acked events, since ack moves the row to 'acked'.
     let requeuedDelivered = 0;
+    let expiredDelivered = 0;
+    const attemptCap = Math.max(requeueMaxAttempts, 1);
     try {
       const requeueResult = await AgentEvent.updateMany(
         {
           status: 'delivered',
-          ackedAt: { $in: [null, undefined] },
           deliveredAt: { $lt: requeueThreshold },
-          $or: [{ attempts: { $lt: Math.max(requeueMaxAttempts, 1) } }, { attempts: { $exists: false } }],
+          $or: [{ attempts: { $lt: attemptCap } }, { attempts: { $exists: false } }],
         },
         {
           $set: { status: 'pending', deliveredAt: null },
@@ -616,6 +641,31 @@ class AgentEventService {
       requeuedDelivered = requeueResult?.modifiedCount || 0;
       if (requeuedDelivered > 0) {
         console.log(`[agent-event] requeued ${requeuedDelivered} stuck 'delivered' events older than ${requeueDeliveredMinutes}min`);
+      }
+
+      // Retire events that have exhausted the cap. This pass is what makes the
+      // cap a bound rather than a leak: `attempts >= cap` fails the requeue
+      // predicate, and a 'delivered' row is invisible to list(), so without a
+      // terminal transition a poison event silently reproduces the exact Task
+      // #67 symptom above — stuck, unretried, unsurfaced — for the full 168h
+      // retention window. Disjoint from the requeue by `attempts` alone, so
+      // the two passes cannot touch the same document in one run.
+      const expireResult = await AgentEvent.updateMany(
+        {
+          status: 'delivered',
+          deliveredAt: { $lt: requeueThreshold },
+          attempts: { $gte: attemptCap },
+        },
+        {
+          $set: {
+            status: 'failed',
+            error: `requeue cap exhausted after ${attemptCap} delivery attempts without an ack`,
+          },
+        },
+      ) as { modifiedCount?: number };
+      expiredDelivered = expireResult?.modifiedCount || 0;
+      if (expiredDelivered > 0) {
+        console.warn(`[agent-event] retired ${expiredDelivered} 'delivered' events that exhausted the ${attemptCap}-attempt requeue cap`);
       }
     } catch (err: unknown) {
       console.warn('[agent-event] requeue pass failed:', (err as Error).message);
@@ -645,6 +695,7 @@ class AgentEventService {
       failedRetentionHours: Math.max(failedRetentionHours, 1),
       requeuedDelivered,
       requeueDeliveredMinutes: Math.max(requeueDeliveredMinutes, 1),
+      expiredDelivered,
     };
   }
 
@@ -812,11 +863,20 @@ class AgentEventService {
       podId,
       type,
       payload: eventPayload,
-      // Native runs resolve in-process, so we mark the event delivered
-      // immediately — it remains in the DB for auditability but never
-      // sits in the pending queue polled by external runtimes.
+      // Native runs resolve in-process, so the event is claimed at creation
+      // rather than polled. `attempts: 1` because this IS its one delivery —
+      // the claim in list() never runs for native events, and a native event
+      // reaching a driver with attempts: 0 would misreport the same way an
+      // external redelivery used to.
+      //
+      // This used to read "never sits in the pending queue polled by external
+      // runtimes." That was true when written and false from the moment the
+      // Task #67 requeue shipped: 'delivered' with no terminal transition is
+      // precisely the requeue's target population, so every native event
+      // entered the pending queue ~10-20 min after creation, guaranteed. The
+      // settle handlers below close it — success acks, failure records.
       ...(routedToNative
-        ? { status: 'delivered', deliveredAt: new Date() }
+        ? { status: 'delivered', deliveredAt: new Date(), attempts: 1 }
         : {}),
     }) as EventDoc;
 
@@ -827,13 +887,44 @@ class AgentEventService {
         const eventIdStr = String((event._id as { toString?: () => string })?.toString?.() || '');
         // Fire-and-forget — callers of enqueue() must never block on the
         // loop. Errors are logged but never rethrown.
+        // Settle the event on the run's actual outcome. nativeRuntimeService
+        // contains no ack or recordFailure call of its own, so before this the
+        // native lifecycle had no terminal state at all: every native event
+        // stayed 'delivered' forever and was structurally unackable. Doing it
+        // here rather than inside runAgent keeps the terminal transition next
+        // to the non-terminal state that created it.
         Promise.resolve(runAgent(nativeInstallation, {
           type,
           eventId: eventIdStr,
           payload: event.payload,
-        })).catch((err: Error) => {
-          console.error('[native-runtime] runAgent failed:', err?.message || err);
-        });
+        // Two-argument .then, deliberately, NOT .then().catch(): a chained
+        // .catch would also catch a rejection thrown by the success handler,
+        // so a failing acknowledge() would fall through and mark a run that
+        // actually succeeded as 'failed'. The rejection handler here is scoped
+        // to runAgent alone. Both terminal calls swallow their own errors so
+        // this stays fire-and-forget for the caller.
+        })).then(
+          () => this.acknowledge(
+            eventIdStr,
+            agentName,
+            instanceId,
+            { outcome: 'acknowledged', reason: 'native-runtime-completed' },
+          ).catch((ackErr: Error) => {
+            console.warn('[native-runtime] ack after successful run failed:', ackErr?.message || ackErr);
+          }),
+          (err: Error) => {
+            console.error('[native-runtime] runAgent failed:', err?.message || err);
+            // Terminal on failure too — a native event that errored must not
+            // be left for the requeue to hand to an external poller that
+            // cannot run it.
+            return this.recordFailure(
+              eventIdStr,
+              agentName,
+              instanceId,
+              `native runtime error: ${err?.message || String(err)}`,
+            ).catch(() => undefined);
+          },
+        );
       } catch (dispatchErr) {
         console.warn(
           '[native-runtime] dispatch error:',
@@ -962,6 +1053,18 @@ class AgentEventService {
       // so even if the _id were tampered with, the query is bounded.
       const safeId = candidate._id != null ? String(candidate._id) : '';
       if (!safeId) continue;
+      // ADR-004 §Event model: "Unacked events stay in the queue and re-deliver
+      // on next poll, with `attempts` incremented." The claim IS the delivery,
+      // so this is the only site that can honour that sentence — and until it
+      // did, `attempts` was a frozen 0 on every payload the kernel has ever
+      // served. CAP obliges drivers to be idempotent using what we send them;
+      // a counter that never moves tells a driver every redelivery is a first
+      // delivery. It also made `attempts < cap` in garbageCollect() a guard on
+      // a variable nothing wrote — structurally unable to fire.
+      //
+      // `attempts` therefore counts DELIVERIES, not lifecycle transitions:
+      // first claim is 1, a requeued redelivery is 2. `{new: true}` means the
+      // value the driver receives in the payload is the post-increment one.
       const updated = await AgentEvent.findOneAndUpdate(
         { _id: safeId, status: 'pending' },
         {
@@ -970,6 +1073,7 @@ class AgentEventService {
             memoryRevisionAtDelivery: currentRevision,
             deliveredAt: new Date(),
           },
+          $inc: { attempts: 1 },
         },
         { new: true },
       ).lean() as EventDoc | null;
@@ -1027,7 +1131,11 @@ class AgentEventService {
           deliveredAt: new Date(),
           ...(normalizedDelivery ? { delivery: normalizedDelivery } : {}),
         },
-        $inc: { attempts: 1 },
+        // No $inc here. `attempts` counts deliveries (incremented at the claim
+        // in list()); an ack is not a delivery. Incrementing at both sites made
+        // a normally-handled event read `attempts: 2` and left the field
+        // meaning "deliveries plus terminal transitions" — a number no driver
+        // can use for the ADR-004 dedup it is obliged to perform.
       },
       { new: true },
     ) as EventDoc | null;
@@ -1131,7 +1239,9 @@ class AgentEventService {
   ): Promise<EventDoc | null> {
     const result = await AgentEvent.findOneAndUpdate(
       { _id: eventId, agentName: agentName.toLowerCase(), instanceId },
-      { $set: { status: 'failed', error: errorMessage }, $inc: { attempts: 1 } },
+      // No $inc — see acknowledge(). `attempts` is a delivery counter owned by
+      // the claim in list(); a terminal transition must not inflate it.
+      { $set: { status: 'failed', error: errorMessage } },
       { new: true },
     ) as EventDoc | null;
 


### PR DESCRIPTION
`attempts` is a frozen `0` on every payload the kernel has ever served, and the guard that reads it has never fired. Fixing that alone would have made things worse, so this is the whole lifecycle in one PR — at @pod-architect's suggestion, since the driver fixes live in the same thirty lines.

## The counter

**ADR-004 §Event model:** *"Unacked events stay in the queue and re-deliver on next poll, with `attempts` incremented."*

Nothing increments it in the pending↔delivered cycle. `attempts` moves only at `acknowledge()` (`:1030`) and `recordFailure()` (`:1134`) — **both terminal**. So the field CAP obliges every driver to dedup with is constant, and a driver has no way to tell a redelivery from a first delivery.

That also froze the requeue's own guard:

```
garbageCollect()  attempts < 3        ← reads as a poison-event bound
write sites       acked | failed      ← both terminal, both outside the cycle
```

**The guard's condition and the variable's write sites are in complementary states**, which is exactly why it looks fine in review. It has never once fired.

`list()` now increments on the pending → delivered claim. The claim *is* the delivery, so it's the only site that can honour `:73`, and `{new: true}` means the value the driver receives is the post-increment one. **`attempts` counts deliveries:** first claim `1`, requeued redelivery `2`. `acknowledge()` and `recordFailure()` stop incrementing — with the claim counting, double-writing made a normally-handled event read `attempts: 2` and left the field meaning *"deliveries plus terminal transitions,"* which is not a number anyone can dedup on.

## Why the counter needed a cap in the same PR

Turning it on without a cap-exhaustion pass is **worse than leaving it off.** A capped event fails the requeue predicate, and a `'delivered'` row is invisible to `list()` — so it sits stuck until the 168h retention delete. That is precisely the Task #67 symptom the requeue exists to fix, **recreated by its own fix.**

Second pass retires `attempts >= cap` to terminal `failed`. The two are disjoint on `attempts` alone (`< cap` vs `>= cap`), so no document can be touched by both in one run.

## Two driver classes had no terminal state at all

| driver | before | consequence |
|---|---|---|
| **native** | created `'delivered'`; `nativeRuntimeService` has **zero** ack/recordFailure calls | structurally unackable — every native event entered the pending queue ~10-20 min later and could be handed to an external poller that cannot run it |
| **webhook** | `'delivered'` after a **successful** POST; requeue has no `delivery` exclusion | **the endpoint was called again ~10-20 min later, indefinitely** — duplicate delivery across the whole ADR-006 driver class |

Both now settle. Native acks on completion and records failure on error, via a **two-argument `.then`** rather than `.then().catch()` — a chained catch would also catch a rejection from the success handler and mark a run that actually succeeded as failed. There's a test for that inversion specifically.

## The phantom predicate

`ackedAt: { $in: [null, undefined] }` — **there is no `ackedAt` field.** Not in `IAgentEvent`, not in the schema, never written; Mongoose strips it, so the clause matched every document while reading as a live narrowing. Dropped rather than "fixed": `status: 'delivered'` already excludes acked events. Caught by @pod-architect.

## Verification

```
21 pass (12 new + 9 existing)   ·   tsc --noEmit  0 errors

M1  drop $inc at the claim                    → 1 fail
M2  expire pass $gte → $gt (off-by-one)       → 2 fail
M3  webhook back to 'delivered'               → 1 fail
M4  native drops attempts: 1                  → 1 fail
```

Assertions are on **query shape**, not on observed counts — this is a mocked-model suite, and a test that only checked "an update happened" would pass against all four bugs.

## Not fixed here, documented at the site

**Effective redelivery latency is 10-20 min, not 10.** `schedulerService` runs this job on `*/10` and the threshold is also 10 min, so period `P` and threshold `T` give `[T, T+P)` — uniform, mean ~15. ADR-004 says *"next poll"* and tells drivers 3-10s. Closing that gap means a lease or a short-TTL claim, which is a design question and wants its own PR against ADR-004.

**Not verified:** no DB or cluster read — I can show these paths are reachable and cannot show how many rows are in each state today. The webhook duplicate-delivery claim in particular is derived from the predicate, not observed against a live endpoint. Suites run: this one plus the existing `agentEventService` suite; not the full backend run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
