### PR TITLE
chore(ts): the typecheck gate skipped middleware/ and six other directories

### DIFF
--- a/backend/tsconfig.typescheck.json
+++ b/backend/tsconfig.typescheck.json
@@ -1,18 +1,32 @@
 {
+  // The gate is only as wide as this file. It is EXCLUDE-driven on purpose:
+  // an enumerated `include` list silently stops covering any directory added
+  // after it was written, and the miss looks identical to a pass. This config
+  // previously listed 8 directories and so did not typecheck middleware/,
+  // providers/, gateway/, types/, scripts/, migrations/ or seed/ — including
+  // agentRuntimeAuth, which every agent route depends on. All seven were
+  // already clean; nobody knew, because nothing checked.
+  //
+  // Add exclusions here only for files you are consciously carrying as debt,
+  // never to make a red build green. A new directory is covered by default.
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": [
-    "models/**/*.ts",
-    "controllers/**/*.ts",
-    "routes/**/*.ts",
-    "services/**/*.ts",
-    "integrations/**/*.ts",
-    "config/**/*.ts",
-    "utils/**/*.ts",
-    "src/**/*.ts",
-    "src/**/*.d.ts"
-  ],
-  "exclude": ["node_modules", "dist", "**/__tests__/**", "**/*.test.ts", "**/*.spec.ts"]
+  "compilerOptions": { "noEmit": true },
+  "include": ["**/*.ts"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    // Vendored/authored elsewhere — not this package's source.
+    "commonly-bundled-skills",
+    "docs",
+    // Root-level scratch scripts, unreferenced by package.json or any route
+    // or service. 54 pre-existing errors between them. Fix or delete rather
+    // than extending this list — it is the debt ledger, not an escape hatch.
+    "test-discord-integration.ts",
+    "test-discord-interactions.ts",
+    "test-discord-commands.ts",
+    "cleanup-test-data.ts"
+  ]
 }


### PR DESCRIPTION
Based on `main`, independent of the #817/#821 and #813/#820 stacks.

## The correction that led here

@ux-lead reported that `Test & Coverage` is *"structurally blind"* to type-level changes and proposed adding `npm run tsc:check` to the workflow. **That step already exists** — `.github/workflows/tests.yml:53-56`, inside the `Test & Coverage` job, no `continue-on-error`, since `4ac17629` on 2026-04-09. Verified end to end: a type error in `models/Pod.ts` makes the script exit `2` with 5 errors.

The premise underneath was right (ts-jest strips types, so jest cannot see a type change) — the leap was from *jest* to *the whole check*, which is a job with five steps. But chasing it found a real version of the same defect one layer down.

## The actual gap

`tsconfig.typescheck.json` **enumerated 8 directories**. Backend has seven more containing `.ts`:

`middleware/` · `providers/` · `gateway/` · `types/` · `scripts/` · `migrations/` · `seed/`

So the required gate never typechecked `middleware/agentRuntimeAuth.ts` — the module every agent route depends on for `req.agentUser`.

**Demonstrated, not argued:**

| | exit |
|---|---|
| `const __probe: number = "not a number"` in `middleware/agentRuntimeAuth.ts`, **new** config | **2** (1 error, names the file) |
| same error, **old** config | **0** |
| clean tree, new config | 0 |

## The fix, and why it is exclude-driven

All seven directories were **already clean** — that is the point. Nobody knew, because nothing checked, and *an enumerated `include` list stops covering any directory added after it is written while the miss looks exactly like a pass.* Adding seven lines would fix today and re-break on the next directory.

Inverted to `include: ["**/*.ts"]` plus an explicit exclude list, so a new directory is covered by default and the failure mode flips from silently-unchecked to listed-as-debt. The four root-level scratch scripts (`test-discord-*.ts`, `cleanup-test-data.ts` — 54 pre-existing errors, unreferenced by `package.json` or any route or service) are excluded by name with a comment saying to fix or delete them rather than extend the list.

Starts green: `npm run tsc:check` exits 0.

## Why it is worth landing

`Test & Coverage` is the only required context on `main` (`required_pull_request_reviews` is null). Anything that gate cannot see, nothing can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)