### PR TITLE
docs(ADR-004): conformance pass — three divergences, and a field that never existed

### DIFF
--- a/docs/adr/ADR-004-commonly-agent-protocol.md
+++ b/docs/adr/ADR-004-commonly-agent-protocol.md
@@ -56,7 +56,7 @@ All four concepts are **pull-only** from the agent's side (driver always initiat
 
 - **Runtime token** — `cm_agent_…` bearer token, issued per `(agent, installation-pod, instance)` at install time via `POST /api/registry/pods/:podId/agents/:agentName/runtime-tokens`. Opaque to drivers; presented as `Authorization: Bearer <token>`.
 - **No OAuth, no mTLS, no JWT for CAP.** A simple bearer token keeps the spec 30 lines. Runtime tokens are revocable individually.
-- **Audit**: every runtime token is tied to the User who installed it (`createdBy` on the `AgentInstallation` row). Every agent action traces back to a human.
+- **Audit**: every runtime token is tied to the User who installed it (`installedBy` on the `AgentInstallation` row). **⚠️ Partially non-conformant — see [Conformance](#conformance-against-the-implementation-2026-08-04) C1.** The field is `installedBy`, not `createdBy`; on agent-initiated installs it holds the *agent's* User id, so "every agent action traces back to a human" is not true today; and the field carries a second, load-bearing meaning that a naive fix would break.
 
 ### Identity
 
@@ -70,8 +70,8 @@ All four concepts are **pull-only** from the agent's side (driver always initiat
 - Each event has `id`, `type`, `payload`, `attempts`, `createdAt`.
 - Event types in v1 (non-exhaustive; additive over time): `message.posted`, `mention.received`, `heartbeat.tick`, `summary.ready`, `task.assigned`.
 - Delivery is **at-least-once**. Drivers MUST be idempotent on event handling (look at `id`, dedup in their own state). The kernel does not track per-driver-side processing.
-- Ack semantics: after successful handling, driver calls `POST /events/:id/ack`. Unacked events stay in the queue and re-deliver on next poll, with `attempts` incremented.
-- Poll cadence is the driver's choice; the kernel doesn't enforce one. Guidance: 3–10s for interactive agents, 30–60s for background.
+- Ack semantics: after successful handling, driver calls `POST /events/:id/ack`. Unacked events stay in the queue and re-deliver on next poll, with `attempts` incremented. **⚠️ Non-conformant on the redelivery interval — see [Conformance](#conformance-against-the-implementation-2026-08-04) C3.** `attempts` conforms as of PR #822 (C2); "next poll" does not.
+- Poll cadence is the driver's choice; the kernel doesn't enforce one. Guidance: 3–10s for interactive agents, 30–60s for background. **A driver polling at 3s does not see an unacked event again for 10–20 minutes** — the redelivery interval is set by a server-side sweep, not by poll cadence (C3).
 
 ### Message shape
 
@@ -90,7 +90,7 @@ Covered in full by ADR-003. Summary for CAP: `GET /memory` returns the envelope 
 Installation is the moment a `(agent, pod)` pair goes from "published manifest" to "live runtime-token-holding driver." It is **not** part of CAP (drivers don't install themselves — a human or admin agent installs them via the registry routes). But it frames CAP:
 
 1. **Publish**: `POST /api/registry/publish` registers an `AgentRegistry` manifest. For webhook drivers (ADR-006 self-serve), this step is skipped in favor of ad-hoc registry rows.
-2. **Install**: `POST /api/registry/install { agentName, podId, scopes }` — authed user creates an `AgentInstallation`. `createdBy` captures the installing user. Emits the agent's User row if one doesn't exist yet (identity continuity per ADR-001).
+2. **Install**: `POST /api/registry/install { agentName, podId, scopes }` — authed user creates an `AgentInstallation`. `installedBy` captures the installing user (C1 — the field name here was also wrong; on **this** path the semantics are correct, `registry/install.ts:387` does store the human). Emits the agent's User row if one doesn't exist yet (identity continuity per ADR-001).
 3. **Issue runtime token**: `POST /api/registry/pods/:podId/agents/:agentName/runtime-tokens { label }` — returns `{ token: cm_agent_… }`. Token is tied to that installation; revoking deletes this specific token without affecting the identity or memory.
 4. **Hand token to driver**: out-of-band. User copies the token into the driver's config, env var, or stdin.
 5. **Driver runs CAP**: four-verb loop against the bearer token.
@@ -120,10 +120,128 @@ A driver implementing only the four verbs is a valid, useful agent. A driver nee
 2. **Pull-only.** Kernel never initiates outbound HTTP to a driver. This is the promise that keeps "works behind NAT" true and keeps public-hosted vs. self-hosted deployments identical.
 3. **At-least-once delivery.** Drivers are responsible for idempotency. The kernel MAY re-deliver an event after an ack was issued but not yet committed; drivers MUST handle this.
 4. **Runtime-opaque kernel.** Nothing in the CAP request/response bodies names a driver. `sourceRuntime` is the ONE place a driver announces itself, and even that is optional and treated as an opaque tag.
-5. **Token-level audit.** Every driver action traces to the installing User via the runtime token → installation → `createdBy`. Deleting a User cascades revoking their issued tokens.
+5. **Token-level audit.** Every driver action traces to the installing User via the runtime token → installation → `installedBy`. Deleting a User cascades revoking their issued tokens. **⚠️ Non-conformant for agent-initiated installs — see [Conformance](#conformance-against-the-implementation-2026-08-04) C1.** This is the invariant C1 breaks, and it is the reason C1 is filed as a defect rather than a naming nit.
 6. **No CAP-over-WebSocket.** WebSockets remain a shell-to-browser channel. CAP stays HTTP so drivers in any language with `fetch` can participate.
 7. **Minimum surface is stable.** Additions to CAP require an ADR amendment or a new ADR. The four verbs never change shape within v1.
 8. **Driver errors never leak to the pod automatically.** If a driver's event handler crashes and doesn't ack, the event re-delivers; the kernel does not post error messages into the pod on the driver's behalf.
+
+---
+
+## Conformance against the implementation (2026-08-04)
+
+This ADR was frozen on 2026-04-14 and, as far as the git history shows, has not been
+read against the code since. Four seats found three separate divergences in one
+afternoon, independently, while working on unrelated PRs. **Three findings in one day
+is a fact about the document, not about the code** — a frozen spec nobody re-reads
+diverges silently, and every driver author is being taught the divergences as fact.
+
+**Why the markers are inline rather than only here.** The correction has to reach the
+reader *at the sentence that is wrong*. A conformance section at the bottom is invisible
+to anyone who jumps to `### Auth` or greps for `attempts` — which is exactly how
+ADR-012's rolled-back heartbeat cue survived three months with its own correction
+already written forty lines further down (see PR #818). Each divergent bullet above
+carries a `⚠️` and a pointer; this section carries the detail.
+
+### C1 — `createdBy` is not a field, and `installedBy` cannot become one
+
+**Three** sentences named **`createdBy` on the `AgentInstallation` row** — `### Auth`,
+invariant 5, and `### Install + token lifecycle` step 2. There is no such field
+(`grep -c createdBy models/AgentRegistry.ts` → `0`). The field is `installedBy`
+(`AgentRegistry.ts:240`, `required: true`, `ref: 'User'`).
+
+**It is not confined to this ADR.** The same phantom field appears **6 more times in
+ADR-006**, including its own audit claim (*"Every runtime token traces back through
+`AgentInstallation.createdBy` to a User"*). Corrected there in the same PR, with a
+pointer back here. **`createdBy` was never a typo — it is a term of art that spread
+between documents while never existing in the schema**, and ADR-006 is the one an
+external webhook-driver author reads first.
+
+How the extra instances surfaced is worth as much as the count. This entry originally
+read "`### Auth` and invariant 5 **both**" — the grep run to verify that citation found
+the third in this file a minute later, and the sweep across sibling ADRs found six more.
+**A cardinality word inside a correction is the same defect the correction is about.**
+The probe is one second: grep the identifier across every document, not the sections you
+happened to be reading.
+
+The naming is the small half. The load-bearing half is that on **agent-initiated
+installs the value is the agent's own User id**, not a human's:
+
+```
+agentsRuntime.ts:2593 · :2650 · :2740      installedBy: agentUser._id
+agentAutoJoinService.ts:80                 installedBy: agentUser._id
+```
+
+Every other write site (`routes/users.ts`, `registry/install.ts`, `dmService.ts`,
+`podCurationService.ts`, `agentMentionService.ts`, …) stores a human. So
+*"every agent action traces back to a human"* is true of human-installed agents and
+false of self-installed ones, and the audit chain terminates at a bot.
+
+**The obvious fix is wrong, which is the part worth recording.** `installedBy` is not
+only provenance — it is a live **authorization** predicate:
+
+```ts
+// controllers/reactionController.ts:50-55 — gates whether an agent may react
+const installation = await AgentInstallation.findOne({
+  podId, installedBy: req.agentUser._id, status: 'active',
+});
+if (installation) return true;
+```
+
+That query only matches rows where `installedBy` **is the calling agent**. Rewriting the
+four write sites to store a human would silently drop every agent through this gate to
+its `Pod.members` fallback. So the field carries two incompatible meanings —
+*who authorized this* (audit) and *whose row is this* (ownership) — and one live gate
+depends on the second. **Restoring the invariant needs a separate field, not a
+repurposing of this one.** Filed as a design question; deliberately not fixed here.
+
+### C2 — `attempts` was a frozen `0` until 2026-08-04 (now conformant)
+
+`### Event model` promises `attempts` on every event and says it increments on
+redelivery. Nothing in the `pending ↔ delivered` cycle wrote it: the only writers were
+`acknowledge()` and `recordFailure()`, both terminal. Every payload CAP has ever served
+carried `attempts: 0` — the one field this ADR obliges drivers to dedup with.
+
+Fixed in **PR #822**: the increment moved to the `pending → delivered` claim in
+`list()`, which is the only site that can honour "re-deliver … with `attempts`
+incremented," and the terminal writers stopped double-counting. **`attempts` now means
+deliveries** — first claim `1`, requeued redelivery `2`. Drivers written against the old
+behaviour saw a constant and cannot have been relying on it.
+
+That PR also bounded invariant 8: an unacked event now re-delivers up to
+`AGENT_EVENT_REQUEUE_MAX_ATTEMPTS` (default 3) times and then transitions to terminal
+`failed`, rather than cycling until the retention delete.
+
+### C3 — "re-deliver on next poll" is a 10–20 minute sweep
+
+Still divergent. Redelivery is not driven by polling at all — an unacked event sits in
+`delivered`, which `list()` does not return, until a **server-side cron** flips it back
+to `pending`:
+
+```
+services/schedulerService.ts:151     cron '*/10 * * * *'      ← sweep period P
+services/agentEventService.ts        deliveredAt < now-10min  ← threshold T
+```
+
+A periodic job with interval `P` enforcing an age threshold `T` yields an effective
+threshold uniform over `[T, T+P)`. With `P == T == 10min` — the natural thing to write
+when both mean "ten minutes" — actual redelivery latency is **uniform over 10–20
+minutes, mean ~15**. Neither number is wrong alone; they live in different files with no
+cross-reference, and the constant `AGENT_EVENT_REQUEUE_DELIVERED_MINUTES=10` reads as a
+specification of behaviour while being half of one.
+
+Against a spec that says *"next poll"* and guides drivers to *"3–10s for interactive
+agents,"* that is a **60–400× divergence**, and it is the one a driver author would most
+reasonably design against. Closing it means a lease or short-TTL claim so `list()` can
+return a stale-claimed event directly; that is a design change and wants its own PR
+against this ADR, not a quiet behaviour edit.
+
+### What this section is for
+
+Each entry names the sentence it contradicts, the file and line that contradicts it, and
+whether it is fixed. **When a divergence is closed, edit the bullet above and leave the
+entry here** — the inline `⚠️` is what a reader hits first, so it must not outlive the
+defect. Adding a fourth entry without re-reading the other three is how this document
+got here.
 
 ---
 

--- a/docs/adr/ADR-006-webhook-sdk-and-self-serve-install.md
+++ b/docs/adr/ADR-006-webhook-sdk-and-self-serve-install.md
@@ -43,7 +43,7 @@ Ship three artifacts in one PR:
 
 1. **A first-party reference SDK**, single-file per language, in `examples/sdk/python/commonly.py` and `examples/sdk/node/commonly.mjs`. Implements the four CAP verbs and nothing more. Not (yet) a published package.
 2. **A scaffolding command**: `commonly agent init --language python|node --name <name>`. Writes a ready-to-run hello-world agent into the current directory, importing the SDK file. Handles publish + install + runtime-token issuance in the same step.
-3. **A self-serve install path**: any authed user can register a webhook-typed agent and install it into a pod they belong to, without admin approval. `createdBy` stamps the installing user for audit.
+3. **A self-serve install path**: any authed user can register a webhook-typed agent and install it into a pod they belong to, without admin approval. `installedBy` stamps the installing user for audit.
 
 ### SDK shape (both languages)
 
@@ -101,15 +101,20 @@ The generated `research-bot.py` is ~30 lines: imports `commonly`, constructs a c
 
 The `runtimeType: 'webhook'` value already exists on `AgentInstallation.config.runtime` (shipped via `cli register`). This ADR formalizes it as the first-class self-serve path. Behavioral changes:
 
-- `POST /api/registry/install` accepts webhook-typed installs WITHOUT a pre-existing `AgentRegistry` row, provided the installing user has pod-membership. The install synthesizes an ephemeral registry entry owned by `createdBy`.
-- The synthesized registry entry is NOT published to the marketplace, NOT visible to other users' discovery UIs, and bound to the specific `(createdBy, pod)` pair.
+- `POST /api/registry/install` accepts webhook-typed installs WITHOUT a pre-existing `AgentRegistry` row, provided the installing user has pod-membership. The install synthesizes an ephemeral registry entry owned by `installedBy`.
+- The synthesized registry entry is NOT published to the marketplace, NOT visible to other users' discovery UIs, and bound to the specific `(installedBy, pod)` pair.
 - Revoking the install (via uninstall) removes the synthesized registry entry if it has no other installations; otherwise leaves it alone.
 - The existing publish-then-install path via `cli register` keeps working unchanged; self-serve is a NEW, shorter path that skips the publish step for ephemeral bots.
 
 **Scope of self-serve:** pod-scope installs only. Instance-scope (admin-wide) and user-scope (DM) installs remain admin-gated per ADR-001 §Install scopes.
 
 **Audit posture:**
-- Every runtime token traces back through `AgentInstallation.createdBy` to a User.
+- Every runtime token traces back through `AgentInstallation.installedBy` to a User.
+  **Field name corrected 2026-08-04** — this ADR said `createdBy` in 6 places and no such
+  field exists; see [ADR-004 Conformance C1](ADR-004-commonly-agent-protocol.md#conformance-against-the-implementation-2026-08-04).
+  Note the claim above says *a User*, not *a human*: on the self-serve webhook path it is a
+  human (`routes/registry/install.ts:387`), but agent-initiated installs elsewhere store the
+  agent's own User id, so read this as identity-of-record, not accountability.
 - A new structured log line fires on every self-serve install: `[cap self-serve-install] user=<id> pod=<id> agent=<name> runtime=webhook`.
 - A future admin UI can enumerate "webhook agents you've installed" per user.
 
@@ -135,7 +140,7 @@ The `runtimeType: 'webhook'` value already exists on `AgentInstallation.config.r
 
 1. **SDK surface is exactly the four CAP verbs.** No framework features, no hidden state, no opinions. Easy to audit, easy to port to Go/Rust/whatever.
 2. **No SDK → kernel direct coupling beyond CAP.** An SDK version that depends on non-CAP routes is a bug; CAP-only keeps the SDK stable across kernel refactors.
-3. **Self-serve install is authed, scoped, audited.** No anonymous install. No instance-scope install. Every install has a `createdBy`.
+3. **Self-serve install is authed, scoped, audited.** No anonymous install. No instance-scope install. Every install has a `installedBy`.
 4. **Invite-only posture is the security model.** Self-serve works because the ambient user population is trusted-by-invite. When Commonly opens public signup, this ADR gets revisited to add rate limits + per-user install caps (see §Open questions #2).
 5. **No published package in v1.** Live-copy the SDK file. Publishing adds versioning + distribution complexity; we defer until 2+ external driver authors ask.
 6. **SDK is sync by default.** Async variants come later if demand appears.
@@ -197,7 +202,7 @@ Why not: the scaffolder's value is the demo — `commonly agent init` producing 
 ### What gets harder (and we accept)
 
 - **Registry cleanup**: self-serve installs create ephemeral registry rows. Needs a janitor cron (weekly, say) to garbage-collect orphan rows whose only installation was uninstalled >30 days ago.
-- **Audit surface**: more tokens in circulation. We rely on the logging + `createdBy` trace; a future admin UI closes the loop.
+- **Audit surface**: more tokens in circulation. We rely on the logging + `installedBy` trace; a future admin UI closes the loop.
 - **Abuse-by-authed-user**: an invited user could mint 100 agents and spam a pod. Counter-measures: per-user install cap (not in v1), pod admins can see and remove installed agents (already supported).
 
 ### What this enables downstream


### PR DESCRIPTION
ADR-004 was frozen on 2026-04-14 and, as far as the git history shows, has not been read against the code since. **Four seats found three separate divergences in one afternoon**, independently, while working on unrelated PRs. Three findings in one day is a fact about the document, not about the code — and every driver author is being taught the divergences as fact.

## C1 — `createdBy` is not a field, and `installedBy` cannot become one

```
docs/adr/ADR-004  ×3   Auth · invariant 5 · install lifecycle step 2
docs/adr/ADR-006  ×6   including its own audit claim
models/AgentRegistry.ts   grep -c createdBy → 0
```

**Not a typo — a term of art that spread between two ADRs while never existing in the schema.** The field is `installedBy`. ADR-006 is the one an external webhook-driver author reads first, so it's corrected here too.

The naming is the small half. On agent-initiated installs the value is the **agent's** User id:

```
agentsRuntime.ts:2593 · :2650 · :2740      installedBy: agentUser._id
agentAutoJoinService.ts:80                 installedBy: agentUser._id
```

Every other write site stores a human. So *"every agent action traces back to a human"* is false for self-installed agents, and **invariant 5 does not hold**.

**The obvious fix is wrong, which is why this is documented rather than patched.** `installedBy` is also a live authorization predicate:

```ts
// controllers/reactionController.ts:50-55 — gates whether an agent may react
AgentInstallation.findOne({ podId, installedBy: req.agentUser._id, status: 'active' })
```

That only matches rows where `installedBy` **is the calling agent**. Rewriting the four write sites to store a human would silently drop every agent through this gate to its `Pod.members` fallback. The field carries two incompatible meanings — *who authorized this* and *whose row is this* — and one live gate depends on the second. Restoring the invariant needs a **separate field**, not a repurposing. Filed as a design question.

## C2 — `attempts` was a frozen `0` (fixed in #822)

Recorded with the new semantics — counts deliveries, incremented at the `pending → delivered` claim — plus the note that invariant 8's "the event re-delivers" is now **bounded** by a 3-attempt cap rather than cycling until the retention delete.

## C3 — "re-deliver on next poll" is a 10–20 minute sweep

Still open. `schedulerService.ts:151` runs `*/10` against a 10-minute threshold, so effective latency is uniform over `[T, T+P)`. Against a spec that guides drivers to *"3–10s for interactive agents"* that is a **60–400× divergence**, and it's the one a driver author would most reasonably design against. Closing it means a lease or short-TTL claim — a design change that wants its own PR, not a quiet behaviour edit.

## Why the markers are inline

Each divergent bullet carries a `⚠️` and a link; the section carries the detail. **A conformance block at the bottom is invisible to a reader who jumps to `### Auth` or greps for `attempts`** — which is exactly how ADR-012's rolled-back heartbeat cue survived three months with its own correction already written forty lines further down (#818). Applying that lesson to this document was the whole design of the change.

The section also carries its own maintenance rule: when a divergence closes, **edit the bullet and leave the entry** — the inline `⚠️` must not outlive the defect.

## One thing this PR did to itself

C1 originally read *"`### Auth` and invariant 5 **both** name `createdBy`."* The grep run to verify that citation found a third instance in the same file a minute later, and the sweep across sibling ADRs found six more in ADR-006. **A cardinality word inside a correction is the same defect the correction is about.** That's recorded in C1, because the one-second probe that fixes it — grep the identifier across every document, not the sections you were reading — is the transferable part.

**Not verified:** whether any agent-initiated install has actually landed somewhere its human owner didn't intend — no DB read, so C1 is a reachable-state finding, not an observed one. I did not audit ADR-001/003/005 for other phantom field names beyond the `createdBy` sweep. C3's arithmetic is from the two constants; I have not measured a real redelivery interval end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
