### PR TITLE
test(frontend): enforce TypeScript check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,11 @@ jobs:
           cd backend
           npm run tsc:check
 
+      - name: Frontend TypeScript check
+        run: |
+          cd frontend
+          npm run typecheck
+
       - name: Run backend tests with coverage
         run: |
           cd backend

--- a/frontend/src/v2/__tests__/V2MessageBubble.test.tsx
+++ b/frontend/src/v2/__tests__/V2MessageBubble.test.tsx
@@ -22,8 +22,11 @@ describe('V2MessageBubble', () => {
         <V2MessageBubble
           message={{
             id: '1',
+            pod_id: 'pod-1',
+            user_id: 'sender-1',
             content: '/api/uploads/avatar.png',
             message_type: 'image',
+            created_at: '2026-08-04T00:00:00.000Z',
             user: { username: 'sender' },
           }}
         />

--- a/frontend/src/v2/components/V2GithubPrCard.tsx
+++ b/frontend/src/v2/components/V2GithubPrCard.tsx
@@ -53,7 +53,7 @@ async function fetchPrSummary(owner: string, repo: string, number: number): Prom
           contribMap.set(login, { login, avatarUrl });
         }
       }
-      return {
+      const summary: PrSummary = {
         title: String(pr.title || ''),
         state: pr.state === 'closed' ? 'closed' : 'open',
         merged: !!pr.merged,
@@ -70,6 +70,7 @@ async function fetchPrSummary(owner: string, repo: string, number: number): Prom
         changedFiles: pr.changed_files || 0,
         contributors: Array.from(contribMap.values()),
       };
+      return summary;
     } catch (err) {
       console.warn('[V2GithubPrCard] fetch failed:', (err as Error).message);
       return null;

--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -474,7 +474,7 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
           // when present; tokens are the demo-recording stand-in.
           const liveReactions = message.reactions;
           const hasLive = Array.isArray(liveReactions);
-          const messageId = String(message.id || message._id || '');
+          const messageId = String(message.id || '');
           const canInteract = hasLive && messageId && /^\d+$/.test(messageId);
 
           const toggle = async (emoji: string, mine: boolean) => {

--- a/frontend/src/v2/hooks/useV2PodDetail.ts
+++ b/frontend/src/v2/hooks/useV2PodDetail.ts
@@ -322,7 +322,7 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
     // `messageReaction` with the new aggregated list after every add/remove
     // by any user. We patch only the matching message's `reactions` array
     // — no other state churn.
-    const handleReactionChange = (payload: { messageId: string; podId?: string; reactions: Array<{ emoji: string; count: number; mine: boolean; users?: Array<{ id: string }> }> }) => {
+    const handleReactionChange = (payload: { messageId: string; podId?: string; reactions: Array<{ emoji: string; count: number; mine: boolean; users?: Array<{ id: string; username: string; displayName?: string }> }> }) => {
       if (!payload || !payload.messageId) return;
       if (payload.podId && payload.podId !== podId) return;
       // `emitReactionChange` computes `mine` for the user who triggered the


### PR DESCRIPTION
## Summary
- add the existing frontend `typecheck` script to the Test & Coverage workflow
- clear the five current compiler errors before enabling the gate
- align socket reaction payload typing with the decorated backend wire shape (`users[{ id, username, displayName? }]`)

## Verification
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm --prefix frontend run typecheck`
- `cd frontend && PATH=/opt/homebrew/opt/node@22/bin:$PATH npm test`
- focused message-bubble + reaction tests (5/5)
- targeted ESLint: 0 errors (3 existing JSX-extension warnings)

## Mutation proof
Removing the typed PR-summary boundary returns the original state-widening error: the frontend typecheck fails at the cache insertion/return boundary.