### PR TITLE
ci: gate packages/types on tsc

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,20 @@ jobs:
           cd frontend
           npm run typecheck
 
+      # packages/types has zero dependencies and zero external imports, so it
+      # needs no install of its own — it typechecks with the compiler the
+      # backend step already installed. Gated now because it is green now;
+      # that is the only moment a gate is free.
+      #
+      # packages/commonly-apps is deliberately NOT gated here. It defines the
+      # same tsc:check script and is equally uninvoked, but it needs @types/node
+      # and is not npm ci'd by this job, so adding it means adding an install.
+      # Its actual state is unknown, not assumed green. Separate change.
+      - name: Shared types TypeScript check
+        run: |
+          cd packages/types
+          ../../backend/node_modules/.bin/tsc --noEmit -p tsconfig.json
+
       - name: Run backend tests with coverage
         run: |
           cd backend


### PR DESCRIPTION
**Stacked on #826** — base is that branch, not `main`, because #826 is the only other open PR touching `tests.yml` and this lands in the adjacent hunk. Merge #826 first and this rebases to nothing.

`packages/types` defines `typecheck: tsc --noEmit` and **nothing has ever invoked it** — the same defined-but-uninvoked shape #826 fixes for the frontend. @ux-lead found it; this gates it.

## It costs no install

The package has **zero dependencies and zero external imports**, so it typechecks with the compiler the backend step already installed:

```yaml
- name: Shared types TypeScript check
  run: |
    cd packages/types
    ../../backend/node_modules/.bin/tsc --noEmit -p tsconfig.json
```

That's a correction to the framing it was handed to me with ("a two-line add whose only cost is an install step") — there is no install step. Verified: `deps: {}`, `devDeps: {}`, and no non-relative import anywhere in `src/`.

It is green **today**, which is the only moment a gate is free.

## Mutation-checked

A gate that cannot go red is decoration, so:

| state | result |
|---|---|
| clean | `exit 0` |
| `export const __mutationProbe: number = "not a number"` in `src/user.ts` | `TS2322`, **exit 2** |
| probe reverted | `exit 0`, `git status` clean |

Workflow YAML re-parsed after the edit; step lands after both existing typechecks and before the test steps.

## packages/commonly-apps is deliberately NOT here

It has the identical uninvoked `tsc:check`, but it needs `@types/node` and this job never `npm ci`s it, so gating it means **adding an install step** — a different change with a different cost. Running it as-is yields `TS2688 cannot find type definition file for 'node'`, which is an environment gap, not a finding. **Its real state is unknown, not assumed green.** Flagging rather than silently scoping it out.

## Not verified

Any follow-up that adds the `packages/*` install + `commonly-apps` step touches `.github/workflows/` again and needs the workflow-scoped token — same constraint this push had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)