### PR TITLE
fix(agents): keep pod labels out of principal identity

### DIFF
--- a/backend/__tests__/unit/routes/agentsRuntime.post-message.config.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.post-message.config.test.js
@@ -17,6 +17,13 @@ jest.mock('../../../services/agentThreadService', () => ({}));
 jest.mock('../../../services/podContextService', () => ({}));
 jest.mock('../../../services/globalModelConfigService', () => ({}));
 jest.mock('../../../services/socialPolicyService', () => ({}));
+// agentsRuntime mounts its upload route at module load. This test exercises
+// the message route only, so isolate the upload stack (and its JWT/native
+// dependency chain) rather than making this route contract test depend on it.
+jest.mock('../../../routes/uploads', () => ({
+  uploadSingle: () => (req, res, next) => next(),
+  handleUpload: jest.fn(),
+}));
 jest.mock('../../../integrations', () => ({ get: jest.fn() }));
 jest.mock('../../../models/Activity', () => ({}));
 jest.mock('../../../models/User', () => ({ findById: jest.fn() }));

--- a/backend/__tests__/unit/routes/registry.list-agents-config.test.js
+++ b/backend/__tests__/unit/routes/registry.list-agents-config.test.js
@@ -32,10 +32,8 @@ jest.mock('../../../models/AgentEvent', () => ({
   aggregate: jest.fn().mockResolvedValue([]),
 }));
 
-// User.find is called inside the GET /pods/:podId/agents handler to resolve
-// botMetadata.displayName for each install. Without a mock the handler waits
-// on the real Mongoose model (no DB connection in this unit test) and times
-// out at 10s.
+// User.find provides the portable principal as a fallback only. Pod-scoped
+// AgentProfile / AgentInstallation labels must win when present.
 jest.mock('../../../models/User', () => ({
   find: jest.fn().mockReturnValue({
     select: jest.fn().mockReturnValue({
@@ -79,6 +77,7 @@ jest.mock('../../../routes/registry/presets', () => ({
 const Pod = require('../../../models/Pod');
 const AgentProfile = require('../../../models/AgentProfile');
 const AgentTemplate = require('../../../models/AgentTemplate');
+const User = require('../../../models/User');
 const { AgentRegistry, AgentInstallation } = require('../../../models/AgentRegistry');
 const registryRoutes = require('../../../routes/registry');
 
@@ -150,5 +149,56 @@ describe('registry list pod agents config payload', () => {
         mode: 'all', allPods: true, podIds: [], skillNames: [],
       },
     });
+  });
+
+  it('keeps a pod-scoped label when the portable principal has a different label', async () => {
+    Pod.findById.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({
+        _id: 'pod-1',
+        createdBy: 'user-1',
+        members: ['user-1'],
+      }),
+    });
+    AgentInstallation.getInstalledAgents.mockResolvedValue([
+      {
+        agentName: 'cl-strategist',
+        instanceId: 'strategist-fable',
+        displayName: 'Strategist (Claude)',
+        version: '1.0.0',
+        status: 'active',
+        scopes: [],
+        usage: {},
+      },
+    ]);
+    AgentRegistry.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+    });
+    AgentProfile.find.mockReturnValue({
+      lean: jest.fn().mockResolvedValue([
+        {
+          agentName: 'cl-strategist',
+          instanceId: 'strategist-fable',
+          name: 'Strategist (Claude)',
+        },
+      ]),
+    });
+    AgentTemplate.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+    });
+    User.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            username: 'cl-strategist-strategist-fable',
+            botMetadata: { displayName: 'Strategist (Fable)' },
+          },
+        ]),
+      }),
+    });
+
+    const res = await request(app).get('/api/registry/pods/pod-1/agents');
+
+    expect(res.status).toBe(200);
+    expect(res.body.agents[0].displayName).toBe('Strategist (Claude)');
   });
 });

--- a/backend/__tests__/unit/services/agentIdentityService.collisionResolver.test.js
+++ b/backend/__tests__/unit/services/agentIdentityService.collisionResolver.test.js
@@ -119,6 +119,59 @@ describe('inline displayName collision resolver (sticky dedup)', () => {
     expect(mockSaved).toHaveLength(0);
   });
 
+  test('a sibling pod label cannot overwrite the portable agent identity', async () => {
+    // One principal can be installed in several pods. The displayName passed
+    // by CAP is the target installation's label, not permission to rename the
+    // shared User row. This is the cross-pod regression that previously made
+    // historical bylines oscillate between the two rooms.
+    mockExisting = {
+      _id: 'strategist-id',
+      username: 'cl-strategist-strategist-fable',
+      isBot: true,
+      botMetadata: {
+        agentName: 'cl-strategist',
+        instanceId: 'strategist-fable',
+        displayName: 'Strategist (Fable)',
+        runtime: 'codex',
+      },
+    };
+
+    const user = await AgentIdentityService.getOrCreateAgentUser('cl-strategist', {
+      instanceId: 'strategist-fable',
+      // This is the label from the sibling pod's AgentInstallation.
+      displayName: 'Strategist (Claude)',
+    });
+
+    expect(user.botMetadata.displayName).toBe('Strategist (Fable)');
+    expect(mockSaved).toHaveLength(0);
+  });
+
+  test('a same-pod installation rename cannot silently rename the principal', async () => {
+    // The config route owns the pod-scoped AgentInstallation/AgentProfile
+    // rename. A later post from that same pod must not turn it into a global
+    // identity rename as a side effect.
+    mockExisting = {
+      _id: 'strategist-id',
+      username: 'cl-strategist-strategist-fable',
+      isBot: true,
+      botMetadata: {
+        agentName: 'cl-strategist',
+        instanceId: 'strategist-fable',
+        displayName: 'Strategist (Claude)',
+        runtime: 'codex',
+      },
+    };
+
+    const user = await AgentIdentityService.getOrCreateAgentUser('cl-strategist', {
+      instanceId: 'strategist-fable',
+      // The installation/profile was renamed inside this pod.
+      displayName: 'Strategy reviewer',
+    });
+
+    expect(user.botMetadata.displayName).toBe('Strategist (Claude)');
+    expect(mockSaved).toHaveLength(0);
+  });
+
   test('new install collides with an existing canonical — gets suffix', async () => {
     // openclaw-pixel already has displayName="Pixel" with instanceId "pixel" (shorter)
     mockPeers = [

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -1615,7 +1615,9 @@ router.post('/pods/:podId/typing', agentRuntimeAuth, phase4RateLimit, async (req
       return res.json({ ok: true, action: 'stop' });
     }
 
-    // Build the start payload from the bot User row (display name + avatar).
+    // The label is pod-scoped on the installation. Fetch the User only for
+    // the portable avatar/fallback; never let its principal label override
+    // this pod's configured agent label.
     let displayName = installation.displayName || agentName;
     let avatar: string | undefined;
     try {
@@ -1626,7 +1628,7 @@ router.post('/pods/:podId/typing', agentRuntimeAuth, phase4RateLimit, async (req
         profilePicture?: string;
         botMetadata?: { displayName?: string };
       };
-      displayName = agentUser?.botMetadata?.displayName || agentUser?.username || displayName;
+      displayName = installation.displayName || agentUser?.botMetadata?.displayName || agentUser?.username || agentName;
       avatar = agentUser?.profilePicture || undefined;
     } catch (identityError) {
       console.warn('[agent-typing route] identity lookup failed:', (identityError as Error).message);

--- a/backend/routes/registry/helpers.ts
+++ b/backend/routes/registry/helpers.ts
@@ -289,16 +289,18 @@ const buildAgentInstallationPayload = (installation: any, {
     normalizedConfig?.runtime || installation.config?.runtime || null,
     installation.agentName,
   );
-  // Display label — prefer the User's `botMetadata.displayName` (curated,
-  // identity-bearing) over `installation.displayName` (which can hold the
-  // stale runtime label "openclaw" from pre-fix pod creation paths).
-  // Falls back to the stored installation displayName, then a generic.
-  // The stale-data backfill in scripts/rename-agent-dm-pods.ts repairs
-  // existing rows; this resolver is defense-in-depth.
-  const fallback = installation.displayName || installation.agentName || '';
-  const displayName = user
-    ? resolveDisplayLabelFromUser(user, fallback)
-    : fallback;
+  // The profile and installation are scoped to this pod; the User is the
+  // portable principal. Read the scoped labels first. Reversing that order
+  // makes a label written in one pod bleed into every other pod that renders
+  // this same principal.
+  const profileDisplayName = typeof profile?.name === 'string' ? profile.name.trim() : '';
+  const installationDisplayName = typeof installation.displayName === 'string'
+    ? installation.displayName.trim()
+    : '';
+  const identityFallback = installation.agentName || '';
+  const displayName = profileDisplayName
+    || installationDisplayName
+    || (user ? resolveDisplayLabelFromUser(user, identityFallback) : identityFallback);
   return {
     name: installation.agentName,
     instanceId: installation.instanceId || 'default',

--- a/backend/services/agentEventService.ts
+++ b/backend/services/agentEventService.ts
@@ -280,6 +280,15 @@ const signalAgentTyping = async (event: EventDoc): Promise<void> => {
     let displayName = event.agentName;
     let avatar: string | undefined;
     try {
+      // Events are delivered to a concrete pod. Prefer that installation's
+      // label over the shared User label so the typing indicator follows the
+      // same scope rule as a posted message.
+      const installation = await AgentInstallation.findOne({
+        agentName: event.agentName,
+        instanceId: event.instanceId || 'default',
+        podId: event.podId,
+        status: 'active',
+      }).select('displayName').lean() as { displayName?: string } | null;
       const agentUser = await AgentIdentityService.getOrCreateAgentUser(event.agentName, {
         instanceId: event.instanceId || 'default',
       }) as {
@@ -287,7 +296,10 @@ const signalAgentTyping = async (event: EventDoc): Promise<void> => {
         profilePicture?: string;
         botMetadata?: { displayName?: string };
       };
-      displayName = agentUser?.botMetadata?.displayName || agentUser?.username || event.agentName;
+      displayName = installation?.displayName
+        || agentUser?.botMetadata?.displayName
+        || agentUser?.username
+        || event.agentName;
       avatar = agentUser?.profilePicture || undefined;
     } catch (identityError) {
       // Fall back to the raw agent name — typing indicator is cosmetic, not load-bearing.

--- a/backend/services/agentIdentityService.ts
+++ b/backend/services/agentIdentityService.ts
@@ -426,16 +426,26 @@ class AgentIdentityService {
       console.log(`Upgraded user to bot: ${username}`);
     } else {
       const existingMeta = agentUser.botMetadata || {};
-      const requestedDisplayName = options.displayName
-        ? String(options.displayName).trim()
-        : '';
+      const hasStoredDisplayName = typeof existingMeta.displayName === 'string'
+        && existingMeta.displayName.trim().length > 0;
+      // `displayName` is supplied by an AgentInstallation on normal CAP
+      // requests. Installations are pod-scoped; this User row is the
+      // portable principal for (agentName, instanceId). Letting a routine
+      // post refresh the principal label therefore lets one pod rewrite the
+      // label seen by every sibling pod (and every historical PG message
+      // joined through this User). Use an incoming name only when creating
+      // or repairing a principal that has no label. An intentional principal
+      // rename needs an explicit identity-level operation, not a side effect
+      // of posting from one installation.
       const needsUpdate = !existingMeta.agentName
         || existingMeta.agentName !== resolvedType
         || existingMeta.instanceId !== instanceId
         || !existingMeta.runtime
-        || (requestedDisplayName && existingMeta.displayName !== requestedDisplayName);
+        || !hasStoredDisplayName;
       if (needsUpdate) {
-        const refreshRawDisplayName = options.displayName || existingMeta.displayName || typeConfig?.officialDisplayName || resolvedType;
+        const refreshRawDisplayName = hasStoredDisplayName
+          ? String(existingMeta.displayName)
+          : (options.displayName || typeConfig?.officialDisplayName || resolvedType);
         agentUser.botMetadata = {
           ...existingMeta,
           displayName: await resolveCollisionFreeDisplayName(refreshRawDisplayName, instanceId, agentUser._id),

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -1290,7 +1290,10 @@ class AgentMessageService {
       metadata = {}, agentUser, displayName, replyToMessageId = null, skipDeliveryUpdate = false, skipSummaryPersistence = false,
     } = options;
 
-    const senderDisplayName = agentUser?.botMetadata?.displayName || displayName || agentUser?.username;
+    // The installation label belongs to this pod; the User label belongs to
+    // the portable principal. A live post must render with the former so a
+    // sibling pod's label cannot leak into this room through the shared User.
+    const senderDisplayName = displayName || agentUser?.botMetadata?.displayName || agentUser?.username;
     let message: MessageNormalized | null = null;
 
     if (PGMessage && process.env.PG_HOST) {


### PR DESCRIPTION
## Summary
- prevent routine CAP posts from using a pod installation label to mutate the shared agent principal
- prefer pod-scoped profile/install labels for messages, typing, and pod-agent payloads
- cover cross-pod and same-pod rename regressions; isolate the post-route test from an unrelated upload dependency

## Verification
- `npm run tsc:check`
- `npm test -- --runInBand __tests__/unit/services/agentIdentityService.collisionResolver.test.js __tests__/unit/routes/registry.list-agents-config.test.js`
- `npm test -- --runInBand __tests__/unit/routes/agentsRuntime.post-message.config.test.js`