### PR TITLE
fix(agents): heartbeat is opt-in, not opt-out

### DIFF
--- a/backend/__tests__/unit/services/schedulerService.heartbeatCue.test.js
+++ b/backend/__tests__/unit/services/schedulerService.heartbeatCue.test.js
@@ -27,7 +27,9 @@ const INSTALLATION = {
   agentName: 'openclaw',
   instanceId: 'nova',
   podId: '69b7ddff0ce64c9648365fc4',
-  config: { autonomy: { heartbeat: true } },
+  // Heartbeat dispatch is opt-in — an install that never set `enabled` does not
+  // fire at all, so a cue fixture has to opt in before it can assert on content.
+  config: { autonomy: { heartbeat: true }, heartbeat: { enabled: true } },
 };
 
 const mockInstallations = (installations) => {

--- a/backend/__tests__/unit/services/schedulerService.heartbeatOptIn.test.js
+++ b/backend/__tests__/unit/services/schedulerService.heartbeatOptIn.test.js
@@ -1,0 +1,80 @@
+/**
+ * Heartbeat dispatch is opt-in (#832 follow-up).
+ *
+ * The guard used to be `enabled === false`, which meant an install that had
+ * never expressed an opinion still woke on a timer. Measured on production
+ * 2026-08-04: 166 of 245 active installations, across 48 distinct owners, were
+ * ticking hourly on that default alone — each spending its own owner's model
+ * quota to run a heartbeat that has no content contract behind it (#800).
+ *
+ * The distinction this file defends is `undefined` vs `true`. A test that only
+ * covered `false` would have passed against the old behaviour too.
+ */
+
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('../../../services/agentEventService', () => ({
+  enqueue: jest.fn().mockResolvedValue({ _id: 'evt' }),
+}));
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { find: jest.fn() },
+}));
+// The enqueue path builds an activity hint from recent posts; that aggregate
+// is not what this file is testing, and unmocked it blocks on a real Mongo.
+jest.mock('../../../models/Post', () => ({ aggregate: jest.fn().mockResolvedValue([]) }));
+jest.mock('../../../models/Message', () => ({ aggregate: jest.fn().mockResolvedValue([]) }));
+
+const AgentEventService = require('../../../services/agentEventService');
+const { AgentInstallation } = require('../../../models/AgentRegistry');
+const SchedulerService = require('../../../services/schedulerService').constructor;
+
+const install = (heartbeat) => ({
+  _id: 'i1',
+  agentName: 'a',
+  instanceId: 'default',
+  podId: 'p1',
+  status: 'active',
+  config: heartbeat === undefined ? {} : { heartbeat },
+});
+
+const mockFind = (rows) => {
+  const lean = jest.fn().mockResolvedValue(rows);
+  const select = jest.fn().mockReturnValue({ lean });
+  AgentInstallation.find.mockReturnValue({ select, lean });
+};
+
+describe('dispatchAgentHeartbeats — opt-in', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('an install with no heartbeat config does NOT fire', async () => {
+    mockFind([install(undefined)]);
+    const r = await SchedulerService.dispatchAgentHeartbeats({
+      trigger: 'test', respectIntervals: false,
+    });
+    expect(r.enqueued).toBe(0);
+    expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+  });
+
+  test('an install with heartbeat present but enabled unset does NOT fire', async () => {
+    mockFind([install({ everyMinutes: 60 })]);
+    const r = await SchedulerService.dispatchAgentHeartbeats({
+      trigger: 'test', respectIntervals: false,
+    });
+    expect(r.enqueued).toBe(0);
+  });
+
+  test('enabled:false still does not fire', async () => {
+    mockFind([install({ enabled: false, everyMinutes: 60 })]);
+    const r = await SchedulerService.dispatchAgentHeartbeats({
+      trigger: 'test', respectIntervals: false,
+    });
+    expect(r.enqueued).toBe(0);
+  });
+
+  test('enabled:true DOES fire — opting in still works', async () => {
+    mockFind([install({ enabled: true, everyMinutes: 60 })]);
+    const r = await SchedulerService.dispatchAgentHeartbeats({
+      trigger: 'test', respectIntervals: false,
+    });
+    expect(r.enqueued).toBeGreaterThan(0);
+  });
+});

--- a/backend/services/schedulerService.ts
+++ b/backend/services/schedulerService.ts
@@ -844,7 +844,7 @@ class SchedulerService {
       if (installation?.config?.heartbeat?.global === true) {
         const agentKey = `${agentName}:${instanceId}`;
         if (seenGlobalAgents.has(agentKey)) continue;
-        if (installation?.config?.heartbeat?.enabled === false) continue;
+        if (installation?.config?.heartbeat?.enabled !== true) continue;
         seenGlobalAgents.add(agentKey);
         toProcess.push({ installation, isGlobal: true });
       } else {
@@ -937,8 +937,15 @@ class SchedulerService {
 
     const enqueueResults = await Promise.all(
       toProcess.map(async ({ installation, isGlobal }) => {
+        // Opt-in, not opt-out. `undefined` must NOT fire: an install that never
+        // expressed an opinion about heartbeats does not get one. The previous
+        // `=== false` check made every agent anyone installed wake on a timer
+        // forever unless someone found and set a field they never see — 166 of
+        // 245 active installs across 48 owners were ticking hourly on that
+        // default alone, spending each owner's own model quota to run a
+        // heartbeat with no content behind it (#800).
         const heartbeatEnabled = installation?.config?.heartbeat?.enabled;
-        if (heartbeatEnabled === false) return { enqueued: 0, skippedByInterval: 0 };
+        if (heartbeatEnabled !== true) return { enqueued: 0, skippedByInterval: 0 };
         const autonomyEnabled = installation?.config?.autonomy?.enabled;
         if (autonomyEnabled === false) return { enqueued: 0, skippedByInterval: 0 };
 


### PR DESCRIPTION
Sam's call: default heartbeat off, on only if the owner enables it.

**The guard was `enabled === false`**, so `undefined` fired. Measured on production today:

| | |
|---|---:|
| active installations | 245 |
| distinct owners | 48 |
| **ticking on the unset default** | **166** |
| off only because someone set the flag by hand | 59 |
| explicitly opted in (`enabled: true`) | 20 |

Each tick spends that owner's own model quota. For BYO agents it is a bill sent to someone who never asked for a heartbeat and has no product surface to stop one (#832) — to run a heartbeat whose prompt points at a `HEARTBEAT.md` that nothing provisions on the CAP path (#800).

**Migration is clean:** turns off exactly the 166 that never opted in, preserves all 20 that did.

Both guards now require `=== true`. Tests target `undefined` vs `true` — the distinction that actually changed — and are mutation-verified: reverting the guard fails exactly the two undefined cases.