### PR TITLE
ci: gate packages/types on tsc (reopens #828)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,20 @@ jobs:
           cd frontend
           npm run typecheck
 
+      # packages/types has zero dependencies and zero external imports, so it
+      # needs no install of its own — it typechecks with the compiler the
+      # backend step already installed. Gated now because it is green now;
+      # that is the only moment a gate is free.
+      #
+      # packages/commonly-apps is deliberately NOT gated here. It defines the
+      # same tsc:check script and is equally uninvoked, but it needs @types/node
+      # and is not npm ci'd by this job, so adding it means adding an install.
+      # Its actual state is unknown, not assumed green. Separate change.
+      - name: Shared types TypeScript check
+        run: |
+          cd packages/types
+          ../../backend/node_modules/.bin/tsc --noEmit -p tsconfig.json
+
       - name: Run backend tests with coverage
         run: |
           cd backend


### PR DESCRIPTION
Reopens #828, which was closed unmerged rather than rejected. It was stacked on `fix/frontend-typecheck-gate` (#826); merging #826 with `--delete-branch` deleted the base branch, and GitHub auto-closed this PR as a side effect. GitHub refuses to reopen a PR whose base is gone, so this is a fresh PR with the same commit rebased onto `main`.

`packages/types` defines a `tsc:check` script that nothing invokes. It is green today, verified locally against the compiler the backend step already installs:

```
$ cd packages/types && ../../backend/node_modules/.bin/tsc --noEmit -p tsconfig.json
$ echo $?
0
```

Gating it now is free — it costs no install, because `packages/types` has zero dependencies and zero external imports. The moment to add a gate is while the thing is already passing; after it drifts, the same change becomes a migration.

`packages/commonly-apps` is deliberately **not** gated here. It defines the same uninvoked `tsc:check`, but it needs `@types/node` and is not `npm ci`'d by this job, so gating it means adding an install step. Its real state is unknown rather than assumed green — that is a separate change with a separate risk.

Follows the same reasoning as #823 (the typecheck gate that skipped `middleware/` and six other directories): a check that exists but never runs is not a check.
