### PR TITLE
fix(mentions): a member's first message in a pod now reaches an agent (#834)

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -37,6 +37,10 @@ jest.mock('../../../models/AgentEvent', () => ({
   countDocuments: jest.fn(),
 }));
 
+jest.mock('../../../services/welcomeWakeService', () => ({
+  maybeFireWelcomeWake: jest.fn(),
+}));
+
 const AgentMentionService = require('../../../services/agentMentionService');
 const AgentEventService = require('../../../services/agentEventService');
 const { AgentInstallation } = require('../../../models/AgentRegistry');
@@ -45,6 +49,7 @@ const Pod = require('../../../models/Pod');
 const chatSummarizerService = require('../../../services/chatSummarizerService');
 const User = require('../../../models/User');
 const AgentEvent = require('../../../models/AgentEvent');
+const { maybeFireWelcomeWake } = require('../../../services/welcomeWakeService');
 
 describe('AgentMentionService', () => {
   beforeEach(() => {
@@ -1243,6 +1248,116 @@ describe('AgentMentionService', () => {
         const window = content.slice(Math.max(0, m.index - 120), m.index + 120);
         expect(window).toMatch(/openclaw/i);
       });
+    });
+  });
+  // ── #834 first-message welcome wake, wiring ───────────────────────────────
+  //
+  // The unit behaviour lives in welcomeWakeService.test.js. What matters here
+  // is that enqueueMentions reaches it at all, because the wake's whole point
+  // is to run on the path that used to return before doing anything.
+  describe('first-message welcome wake wiring', () => {
+    const human = () => {
+      User.findById.mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue({ isBot: false }),
+        }),
+      });
+    };
+    const bot = () => {
+      User.findById.mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue({
+            isBot: true,
+            botMetadata: { agentName: 'openclaw', instanceId: 'aria' },
+          }),
+        }),
+      });
+    };
+
+    beforeEach(() => {
+      AgentInstallation.find.mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+      AgentProfile.find.mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+      Pod.findById.mockReturnValue({
+        select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue({ type: 'chat' }) }),
+      });
+      maybeFireWelcomeWake.mockResolvedValue({ claimed: true, woke: [] });
+    });
+
+    test('an unaddressed human message reaches the wake — the path that used to return early', async () => {
+      human();
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-1',
+        message: { content: '这个是什么', _id: 'm-9' },
+        userId: 'user-1',
+        username: 'user-9228',
+      });
+      expect(maybeFireWelcomeWake).toHaveBeenCalledWith(
+        expect.objectContaining({ isRouted: false, podId: 'pod-1', userId: 'user-1' }),
+      );
+    });
+
+    test('an unaddressed message still enqueues nothing — behaviour is unchanged', async () => {
+      human();
+      const res = await AgentMentionService.enqueueMentions({
+        podId: 'pod-1',
+        message: { content: 'no mention here' },
+        userId: 'user-1',
+        username: 'alice',
+      });
+      expect(res).toEqual({ enqueued: [], implicit: [], skipped: [] });
+      expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+    });
+
+    test('an addressed message reaches the wake flagged routed, so it claims without welcoming', async () => {
+      human();
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-1',
+        message: { content: 'hi @codex' },
+        userId: 'user-1',
+        username: 'alice',
+      });
+      expect(maybeFireWelcomeWake).toHaveBeenCalledWith(
+        expect.objectContaining({ isRouted: true }),
+      );
+    });
+
+    test('a reply counts as routed even with no @mention', async () => {
+      human();
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-1',
+        message: { content: 'thanks!' },
+        userId: 'user-1',
+        username: 'alice',
+        replyToMessageId: 'm-1',
+      });
+      expect(maybeFireWelcomeWake).toHaveBeenCalledWith(
+        expect.objectContaining({ isRouted: true }),
+      );
+    });
+
+    // An agent's first post in a pod must never claim or wake: the greeter
+    // would answer it, that answer is itself a first post elsewhere, and the
+    // #703 path is gated on isBot === false for exactly this reason.
+    test('a bot sender never reaches the wake', async () => {
+      bot();
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-1',
+        message: { content: 'status update' },
+        userId: 'bot-1',
+        username: 'Aria',
+      });
+      expect(maybeFireWelcomeWake).not.toHaveBeenCalled();
+    });
+
+    test('a wake failure never breaks the send', async () => {
+      human();
+      maybeFireWelcomeWake.mockRejectedValue(new Error('mongo down'));
+      await expect(AgentMentionService.enqueueMentions({
+        podId: 'pod-1',
+        message: { content: 'hello' },
+        userId: 'user-1',
+        username: 'alice',
+      })).resolves.toEqual({ enqueued: [], implicit: [], skipped: [] });
     });
   });
 });

--- a/backend/__tests__/unit/services/welcomeWakeService.test.js
+++ b/backend/__tests__/unit/services/welcomeWakeService.test.js
@@ -1,0 +1,208 @@
+const mongoose = require('mongoose');
+
+jest.mock('../../../models/PodMemberFirstMessage', () => ({
+  findOneAndUpdate: jest.fn(),
+}));
+
+jest.mock('../../../services/agentEventService', () => ({
+  enqueue: jest.fn(),
+}));
+
+const PodMemberFirstMessage = require('../../../models/PodMemberFirstMessage');
+const AgentEventService = require('../../../services/agentEventService');
+const {
+  maybeFireWelcomeWake,
+  isDesignatedGreeter,
+  findGreeters,
+} = require('../../../services/welcomeWakeService');
+
+const POD_ID = new mongoose.Types.ObjectId().toString();
+const USER_ID = new mongoose.Types.ObjectId().toString();
+
+// The driver's `updatedExisting` flag is the entire decision: false means this
+// call performed the insert and therefore owns the one wake for this member.
+const firstInsert = () => ({ value: null, lastErrorObject: { updatedExisting: false } });
+const alreadySpoken = () => ({ value: { _id: 'm-1' }, lastErrorObject: { updatedExisting: true } });
+
+const greeter = (over = {}) => ({
+  agentName: 'commonly-support',
+  instanceId: 'default',
+  config: { welcomeWake: { enabled: true } },
+  ...over,
+});
+const plainInstall = (over = {}) => ({
+  agentName: 'codex',
+  instanceId: 'default',
+  config: {},
+  ...over,
+});
+
+const opts = (over = {}) => ({
+  podId: POD_ID,
+  userId: USER_ID,
+  username: 'user-9228',
+  content: '这个是什么',
+  messageId: '52630',
+  isRouted: false,
+  installations: [greeter()],
+  ...over,
+});
+
+describe('welcomeWakeService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    PodMemberFirstMessage.findOneAndUpdate.mockResolvedValue(firstInsert());
+    AgentEventService.enqueue.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => { console.warn.mockRestore(); });
+
+  describe('greeter designation is opt-in and never inferred', () => {
+    test('only an install with config.welcomeWake.enabled === true is a greeter', () => {
+      expect(isDesignatedGreeter(greeter())).toBe(true);
+      expect(isDesignatedGreeter(plainInstall())).toBe(false);
+      expect(isDesignatedGreeter(null)).toBe(false);
+    });
+
+    // Guards against a future "helpfully" inferring the greeter — the sole
+    // install, the oldest one, the one named like support. Each of those makes
+    // the wake target drift silently as installs change.
+    test('a lone install is NOT a greeter by virtue of being alone', () => {
+      expect(findGreeters([plainInstall()])).toHaveLength(0);
+    });
+
+    test('truthy-but-not-true does not designate', () => {
+      expect(isDesignatedGreeter({ config: { welcomeWake: { enabled: 'yes' } } })).toBe(false);
+      expect(isDesignatedGreeter({ config: { welcomeWake: { enabled: 1 } } })).toBe(false);
+    });
+  });
+
+  describe('the wake fires once, on an unaddressed first message', () => {
+    test('wakes the designated greeter and reports it', async () => {
+      const res = await maybeFireWelcomeWake(opts());
+      expect(res).toEqual({ claimed: true, woke: ['commonly-support'] });
+      expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+    });
+
+    test('a second message from the same member in the same pod wakes nobody', async () => {
+      PodMemberFirstMessage.findOneAndUpdate.mockResolvedValue(alreadySpoken());
+      const res = await maybeFireWelcomeWake(opts());
+      expect(res.claimed).toBe(false);
+      expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+    });
+
+    // The bound that lets this ship before ADR-017's budget layer: fires are
+    // capped by (member x pod), not by traffic. If this ever fires twice for
+    // one member the whole spam argument collapses.
+    test('only the winning insert wakes — the concurrent loser is silent', async () => {
+      const dupKey = Object.assign(new Error('E11000 duplicate key'), { code: 11000 });
+      PodMemberFirstMessage.findOneAndUpdate.mockRejectedValue(dupKey);
+      const res = await maybeFireWelcomeWake(opts());
+      expect(res.claimed).toBe(false);
+      expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('an addressed first message claims the marker but wakes nobody', () => {
+    // Without this, a member whose opener is "@codex help" is not yet marked,
+    // so their SECOND message trips the welcome — a greeting that arrives
+    // after the conversation already started.
+    test('routed first message claims without waking', async () => {
+      const res = await maybeFireWelcomeWake(opts({ isRouted: true }));
+      expect(res).toEqual({ claimed: true, woke: [], reason: 'routed' });
+      expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+      expect(PodMemberFirstMessage.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    test('the claim records that no greeter was woken', async () => {
+      await maybeFireWelcomeWake(opts({ isRouted: true }));
+      const [, update] = PodMemberFirstMessage.findOneAndUpdate.mock.calls[0];
+      expect(update.$setOnInsert.wokeGreeter).toBe(false);
+    });
+
+    // The positive half. Without it, `wokeGreeter: false` passes trivially and
+    // the field is never proven to record anything — the audit trail for
+    // "why was this member never welcomed" would be uniformly false.
+    test('an unaddressed first message with a greeter records wokeGreeter true', async () => {
+      await maybeFireWelcomeWake(opts());
+      const [, update] = PodMemberFirstMessage.findOneAndUpdate.mock.calls[0];
+      expect(update.$setOnInsert.wokeGreeter).toBe(true);
+    });
+
+    test('unaddressed but with no greeter records wokeGreeter false', async () => {
+      await maybeFireWelcomeWake(opts({ installations: [plainInstall()] }));
+      const [, update] = PodMemberFirstMessage.findOneAndUpdate.mock.calls[0];
+      expect(update.$setOnInsert.wokeGreeter).toBe(false);
+    });
+  });
+
+  describe('no designated greeter is a loud no-op, not a silent one', () => {
+    test('claims the marker, warns, and wakes nobody', async () => {
+      const res = await maybeFireWelcomeWake(opts({ installations: [plainInstall()] }));
+      expect(res).toEqual({ claimed: true, woke: [], reason: 'no-greeter' });
+      expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('config.welcomeWake.enabled'),
+        expect.objectContaining({ pod: POD_ID }),
+      );
+    });
+
+    // Claiming even with no greeter is deliberate: otherwise designating a
+    // greeter later would welcome every existing member on their next message.
+    test('still claims, so designating a greeter later does not welcome the backlog', async () => {
+      await maybeFireWelcomeWake(opts({ installations: [] }));
+      expect(PodMemberFirstMessage.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('the enqueued event is one every deployed wrapper already handles', () => {
+    // A bespoke type would be dropped: the CLI wrapper's extractPrompt returns
+    // null for anything outside PROMPT_EVENT_TYPES, so every wrapper shipped
+    // before this feature would silently ignore the wake.
+    test('type is chat.mention, flagged additively', async () => {
+      await maybeFireWelcomeWake(opts());
+      const [event] = AgentEventService.enqueue.mock.calls[0];
+      expect(event.type).toBe('chat.mention');
+      expect(event.payload.welcomeWake).toBe(true);
+    });
+
+    test('the cue rides inline in content, ahead of the member message', async () => {
+      await maybeFireWelcomeWake(opts());
+      const [event] = AgentEventService.enqueue.mock.calls[0];
+      expect(event.payload.content).toContain('First message from a new member');
+      expect(event.payload.content).toContain('这个是什么');
+      expect(event.payload.content.indexOf('First message'))
+        .toBeLessThan(event.payload.content.indexOf('这个是什么'));
+    });
+
+    test('routes to the greeter identity, not the sender', async () => {
+      await maybeFireWelcomeWake(opts());
+      const [event] = AgentEventService.enqueue.mock.calls[0];
+      expect(event.agentName).toBe('commonly-support');
+      expect(event.instanceId).toBe('default');
+    });
+  });
+
+  describe('never turns a successful human send into a failure', () => {
+    test('an enqueue failure still reports the claim', async () => {
+      AgentEventService.enqueue.mockRejectedValue(new Error('queue down'));
+      const res = await maybeFireWelcomeWake(opts());
+      expect(res.claimed).toBe(true);
+      expect(res.woke).toEqual([]);
+    });
+
+    test('a non-duplicate marker error resolves rather than throwing', async () => {
+      PodMemberFirstMessage.findOneAndUpdate.mockRejectedValue(new Error('mongo down'));
+      await expect(maybeFireWelcomeWake(opts())).resolves.toEqual(
+        { claimed: false, woke: [], reason: 'error' },
+      );
+    });
+
+    test('a malformed id is ignored rather than thrown', async () => {
+      const res = await maybeFireWelcomeWake(opts({ podId: 'not-an-objectid' }));
+      expect(res.claimed).toBe(false);
+      expect(PodMemberFirstMessage.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/models/PodMemberFirstMessage.ts
+++ b/backend/models/PodMemberFirstMessage.ts
@@ -1,0 +1,60 @@
+import mongoose, { Document, Model, Schema, Types } from 'mongoose';
+
+/**
+ * Durable record that a member has spoken in a pod at least once.
+ *
+ * Exists to make the first-message welcome wake (#834) fire exactly once per
+ * (member, pod). The marker is deliberately its own collection rather than a
+ * flag on Pod.members: membership rows are rewritten by join/leave and by the
+ * dual-DB sync, and a marker that can be reset replays onboarding at someone
+ * who has already been welcomed — the same reasoning that gave
+ * AgentFirstContact its own collection instead of living on AgentInstallation
+ * (ADR-001 identity continuity).
+ *
+ * Not the same thing as AgentFirstContact. That one keys
+ * (userId, agentName, instanceId) and fires when a human INSTALLS an agent.
+ * This keys (podId, userId) and fires when a human SPEAKS in a pod. A member
+ * auto-joined to a community pod installs nothing, so first-contact never
+ * fires for them — which is precisely the gap #834 reports.
+ */
+export interface IPodMemberFirstMessage extends Document {
+  podId: Types.ObjectId;
+  userId: Types.ObjectId;
+  messageId?: string;
+  wokeGreeter: boolean;
+  createdAt: Date;
+}
+
+const PodMemberFirstMessageSchema = new Schema<IPodMemberFirstMessage>(
+  {
+    podId: { type: Schema.Types.ObjectId, ref: 'Pod', required: true },
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    // The message that claimed the marker. Kept for audit: "why did this
+    // member never get welcomed" is otherwise unanswerable after the fact.
+    messageId: { type: String },
+    // Whether the claiming message actually woke a greeter. False when the
+    // first message was addressed (an @mention or a reply already routed it)
+    // or when the pod designates no greeter. Recorded rather than inferred,
+    // because the second case is a silent no-op we need to be able to count.
+    wokeGreeter: { type: Boolean, default: false },
+  },
+  {
+    timestamps: { createdAt: true, updatedAt: false },
+    versionKey: false,
+  },
+);
+
+// The uniqueness constraint IS the once-per-member guarantee. Two concurrent
+// first messages both miss the read and both upsert; the index picks one
+// winner and the loser takes a duplicate-key error, which the service treats
+// as "not first" rather than as an error.
+PodMemberFirstMessageSchema.index({ podId: 1, userId: 1 }, { unique: true });
+
+const PodMemberFirstMessage: Model<IPodMemberFirstMessage> =
+  (mongoose.models.PodMemberFirstMessage as Model<IPodMemberFirstMessage>)
+  || mongoose.model<IPodMemberFirstMessage>('PodMemberFirstMessage', PodMemberFirstMessageSchema);
+
+export default PodMemberFirstMessage;
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -13,6 +13,10 @@ const AgentEvent = require('../models/AgentEvent');
 // eslint-disable-next-line global-require
 const chatSummarizerService = require('./chatSummarizerService');
 // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+const { maybeFireWelcomeWake } = require('./welcomeWakeService') as {
+  maybeFireWelcomeWake: (opts: Record<string, unknown>) => Promise<unknown>;
+};
+// eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
 const { resolveAgentDisplayLabel } = require('./agentIdentityService') as {
   resolveAgentDisplayLabel: (
     user: { username?: string; botMetadata?: { displayName?: string; instanceId?: string; agentName?: string } } | null | undefined,
@@ -718,7 +722,75 @@ const enqueueMentions = async ({
   // enqueue site below passes its own `targetAgentName` so the cue
   // composition is correct for that target's runtime.
   const rawMentions = extractMentions(rawContent);
-  if (!podId || (rawMentions.length === 0 && !replyToMessageId)) {
+  if (!podId) {
+    return { enqueued: [], implicit: [], skipped: [] };
+  }
+  // "Routed" means the message already names its recipient — an @mention, or
+  // a reply that the #703 path resolves. Everything else reaches nobody, and
+  // for a member's FIRST message in a pod that is the #834 gap.
+  const isRouted = rawMentions.length > 0 || !!replyToMessageId;
+
+  // Sender identity is resolved BEFORE the unrouted early-return below,
+  // because the welcome wake has to know whether the sender is human. It was
+  // previously resolved further down, where only the routed path could see
+  // it. Uses of it (the self-mention guard) are all downstream and unchanged.
+  //
+  // Self-mention guard: if the sender is a bot, resolve their own
+  // (agentName, instanceId) so we can skip re-enqueuing an event on themselves.
+  // Without this, any agent whose reply echoes its own handle (e.g. the
+  // webhook-SDK "echo:" template, or a CLI-wrapper that quotes the mention)
+  // triggers an infinite chat.mention → reply → chat.mention loop.
+  let sender: SenderRow | null = null;
+  try {
+    sender = await User.findById(userId).select('isBot botMetadata').lean() as SenderRow | null;
+  } catch (error) {
+    // Non-fatal: missing sender just means we can't suppress self-mentions,
+    // which is a strictly weaker invariant than the one we had before.
+    console.warn('Agent mention sender lookup failed:', (error as Error).message);
+  }
+
+  let installations: Array<Record<string, unknown>> = [];
+  let profiles: Array<Record<string, unknown>> = [];
+  try {
+    installations = await AgentInstallation.find({
+      podId,
+      status: 'active',
+    }).lean();
+    // Profiles feed the mention map only, so an unrouted message never needs
+    // them. Kept behind the routed check to hold the added cost of reaching
+    // this point on every message down to two queries rather than three.
+    if (isRouted) profiles = await AgentProfile.find({ podId }).lean();
+  } catch (error) {
+    console.warn('Agent mention lookup failed:', (error as Error).message);
+  }
+
+  // #834: claim the member's first-message marker, and wake the pod's
+  // designated greeter when that first message named nobody. Claimed for
+  // routed first messages too — otherwise a member whose opener was
+  // "@codex help" gets welcomed on their SECOND message. Bots never claim:
+  // an agent's first post in a pod would otherwise seed a wake loop, the same
+  // reasoning that gates the #703 implicit path on `isBot === false`.
+  if (sender?.isBot === false) {
+    try {
+      await maybeFireWelcomeWake({
+        podId,
+        userId,
+        username,
+        content: rawContent,
+        messageId: message?._id || message?.id
+          ? String(message?._id || message?.id)
+          : undefined,
+        isRouted,
+        installations,
+      });
+    } catch (error) {
+      // The message is already persisted; a welcome failure must never turn a
+      // successful human send into a 500.
+      console.warn('[welcome-wake] failed:', (error as Error).message);
+    }
+  }
+
+  if (!isRouted) {
     return { enqueued: [], implicit: [], skipped: [] };
   }
 
@@ -733,18 +805,6 @@ const enqueueMentions = async ({
     enqueuedIdentityKeys.add(identityKey(target));
     enqueued.push(resultLabel);
   };
-
-  let installations: Array<Record<string, unknown>> = [];
-  let profiles: Array<Record<string, unknown>> = [];
-  try {
-    installations = await AgentInstallation.find({
-      podId,
-      status: 'active',
-    }).lean();
-    profiles = await AgentProfile.find({ podId }).lean();
-  } catch (error) {
-    console.warn('Agent mention lookup failed:', (error as Error).message);
-  }
 
   const { map: mentionMap, byAgent } = buildMentionMap(installations, profiles);
   let pod: Record<string, unknown> | null = null;
@@ -764,19 +824,6 @@ const enqueueMentions = async ({
   }
   const collaborativePod = isCollaborativePod(podType, installations);
 
-  // Self-mention guard: if the sender is a bot, resolve their own
-  // (agentName, instanceId) so we can skip re-enqueuing an event on themselves.
-  // Without this, any agent whose reply echoes its own handle (e.g. the
-  // webhook-SDK "echo:" template, or a CLI-wrapper that quotes the mention)
-  // triggers an infinite chat.mention → reply → chat.mention loop.
-  let sender: SenderRow | null = null;
-  try {
-    sender = await User.findById(userId).select('isBot botMetadata').lean() as SenderRow | null;
-  } catch (error) {
-    // Non-fatal: missing sender just means we can't suppress self-mentions,
-    // which is a strictly weaker invariant than the one we had before.
-    console.warn('Agent mention sender lookup failed:', (error as Error).message);
-  }
   const senderAgentName = sender?.isBot ? sender.botMetadata?.agentName?.toLowerCase() : null;
   const senderInstanceId = sender?.isBot ? (sender.botMetadata?.instanceId || 'default') : null;
   const isSelfMention = (target: MentionTarget): boolean => (

--- a/backend/services/welcomeWakeService.ts
+++ b/backend/services/welcomeWakeService.ts
@@ -1,0 +1,217 @@
+import mongoose, { Types } from 'mongoose';
+import PodMemberFirstMessage from '../models/PodMemberFirstMessage';
+import AgentEventService from './agentEventService';
+
+/**
+ * First-message welcome wake (#834).
+ *
+ * A member's first message in a pod reaches no agent today: enqueueMentions
+ * returns before enqueueing anything when a message carries no @mention and no
+ * replyTo, and the implicit path from #703 is gated on replies. So the one
+ * message most likely to need an answer — a newcomer's first — is the one
+ * guaranteed not to get one. Observed live in Commonly HQ on 2026-08-04: a new
+ * member asked a question and it sat unanswered for fourteen hours, in a room
+ * whose pinned welcome promises a support agent answers within a minute.
+ *
+ * SCOPE, stated because the name has to stay honest: this welcomes a member
+ * the first time they speak in a pod. It does NOT route unaddressed messages
+ * generally. The member whose day-30 question goes unanswered is out of scope
+ * and stays out of scope until ADR-017 ships a real policy layer.
+ *
+ * Why this can ship before that policy layer, while a general rule cannot:
+ * the trigger is a monotone state transition (never-spoken → spoken), so total
+ * fires are bounded by the state space — members x pods, amortized one per
+ * join — INDEPENDENT of traffic. A message-arrival or clock trigger is bounded
+ * only by traffic, and taming those needs the budget machinery ADR-017 and
+ * #832 have not shipped. #800's incident was a clock trigger: eleven wakes,
+ * zero edges. The test for any future point-fix here: if the fire count is
+ * bounded by a finite state space it can ship now; if it is bounded only by
+ * traffic it waits.
+ */
+
+interface WelcomeWakeOptions {
+  podId: string | Types.ObjectId;
+  userId: string | Types.ObjectId;
+  username?: string;
+  content?: string;
+  messageId?: string;
+  /** True when the message already carried an @mention or a replyTo. */
+  isRouted: boolean;
+  /** Installations already loaded by the caller, to avoid a second query. */
+  installations: Array<Record<string, any>>;
+}
+
+export interface WelcomeWakeResult {
+  claimed: boolean;
+  woke: string[];
+  reason?: 'not-first' | 'routed' | 'no-greeter' | 'error';
+}
+
+const NOOP: WelcomeWakeResult = { claimed: false, woke: [], reason: 'not-first' };
+
+interface RawUpsertResult {
+  value?: unknown;
+  lastErrorObject?: { updatedExisting?: boolean };
+}
+
+/**
+ * An install opts in with `config.welcomeWake.enabled === true`.
+ *
+ * Opt-in, never inferred. "The pod's support agent" is not a first-class
+ * concept in the schema, and guessing one — the oldest install, the only
+ * install, the one whose name contains "support" — would make the wake target
+ * drift silently as installs change. Same shape as the heartbeat flag #833
+ * made opt-in for the same reason.
+ */
+export const isDesignatedGreeter = (installation: Record<string, any> | null | undefined): boolean => (
+  installation?.config?.welcomeWake?.enabled === true
+);
+
+export const findGreeters = (
+  installations: Array<Record<string, any>>,
+): Array<Record<string, any>> => (installations || []).filter(isDesignatedGreeter);
+
+const WELCOME_CUE = (username?: string): string => [
+  '[First message from a new member in this pod. They have never posted here before,',
+  'and they did not @mention anyone — most likely because they do not yet know they can.',
+  'Answer their message directly. Do not list your capabilities and do not paste a menu;',
+  'if the message is a question, just answer it. Keep it short and end with one concrete',
+  'next step they can take. If their message needs no reply, return NO_REPLY.]',
+  '',
+  username ? `${username} wrote:` : 'They wrote:',
+].join('\n');
+
+/**
+ * Claim the member's first-message marker and, when that message was
+ * unaddressed, wake the pod's designated greeter(s).
+ *
+ * The marker is claimed for EVERY first message, addressed or not. Claiming
+ * only on the unaddressed ones would mean a member whose first message was
+ * `@codex help` gets a welcome wake on their SECOND message, which is worse
+ * than never getting one.
+ *
+ * Best-effort throughout: the message is already persisted by the time this
+ * runs, so nothing here may turn a successful send into a failure.
+ */
+export async function maybeFireWelcomeWake({
+  podId,
+  userId,
+  username,
+  content,
+  messageId,
+  isRouted,
+  installations,
+}: WelcomeWakeOptions): Promise<WelcomeWakeResult> {
+  if (!mongoose.Types.ObjectId.isValid(String(podId))
+    || !mongoose.Types.ObjectId.isValid(String(userId))) {
+    return NOOP;
+  }
+
+  const safePodId = new mongoose.Types.ObjectId(String(podId));
+  const safeUserId = new mongoose.Types.ObjectId(String(userId));
+  // Not conditioned on isRouted: `wokeGreeter` below already carries that
+  // term, and the routed case returns before the enqueue. An `isRouted ? [] :`
+  // guard here reads as though it decides something and does not — it survived
+  // a mutation test unchanged, which is how it was caught.
+  const greeters = findGreeters(installations);
+
+  let result: RawUpsertResult;
+  try {
+    result = await PodMemberFirstMessage.findOneAndUpdate(
+      { podId: safePodId, userId: safeUserId },
+      {
+        $setOnInsert: {
+          podId: safePodId,
+          userId: safeUserId,
+          messageId: messageId ? String(messageId) : undefined,
+          wokeGreeter: !isRouted && greeters.length > 0,
+          createdAt: new Date(),
+        },
+      },
+      {
+        upsert: true,
+        new: false,
+        // Mongoose 7 replacement for the deprecated rawResult. The driver's
+        // updatedExisting flag is the only way to tell the winning insert
+        // from a no-op update, which is the whole decision here.
+        includeResultMetadata: true,
+        setDefaultsOnInsert: true,
+      },
+    ) as unknown as RawUpsertResult;
+  } catch (error) {
+    // Concurrent first messages both miss the read; the unique index elects a
+    // winner and the loser lands here. Expected, not an error.
+    if ((error as { code?: number })?.code === 11000) return NOOP;
+    console.warn('[welcome-wake] marker upsert failed', {
+      pod: String(safePodId),
+      user: String(safeUserId),
+      error: (error as Error).message,
+    });
+    return { claimed: false, woke: [], reason: 'error' };
+  }
+
+  const alreadyExisted = result?.lastErrorObject?.updatedExisting === true || result?.value != null;
+  if (alreadyExisted) return NOOP;
+
+  if (isRouted) return { claimed: true, woke: [], reason: 'routed' };
+
+  if (greeters.length === 0) {
+    // The one failure mode that would otherwise be invisible: the feature is
+    // live, the marker is claimed, and nothing happens because no install in
+    // this pod opted in. Say so, or the next person debugging "the welcome
+    // never fired" has to read this file to discover the flag exists.
+    console.warn('[welcome-wake] first message from a new member, but no install in this pod '
+      + 'sets config.welcomeWake.enabled — nobody was woken', {
+      pod: String(safePodId),
+      user: String(safeUserId),
+      installs: (installations || []).length,
+    });
+    return { claimed: true, woke: [], reason: 'no-greeter' };
+  }
+
+  const woke: string[] = [];
+  await Promise.all(greeters.map(async (installation) => {
+    const agentName = String(installation?.agentName || '').toLowerCase();
+    const instanceId = String(installation?.instanceId || 'default');
+    if (!agentName) return;
+    try {
+      await AgentEventService.enqueue({
+        agentName,
+        instanceId,
+        podId: safePodId,
+        // Deliberately chat.mention rather than a new event type. The CLI
+        // wrapper's extractPrompt returns null for any type outside
+        // PROMPT_EVENT_TYPES, so a bespoke `pod.first_message` would be
+        // silently dropped by every already-deployed wrapper — the #611
+        // failure mode. An additive payload flag costs nothing and works on
+        // drivers shipped before this existed.
+        type: 'chat.mention',
+        payload: {
+          messageId: messageId ? String(messageId) : undefined,
+          // The cue rides inline in content, not in metadata: models
+          // deprioritize structured fields and act on the narrative frame.
+          // Same rule as the DM cue (ADR-012 §9) and the pod-context cue.
+          content: `${WELCOME_CUE(username)}\n${String(content || '').trim()}`,
+          userId: String(safeUserId),
+          username,
+          mentions: [],
+          source: 'chat',
+          messageType: 'text',
+          createdAt: new Date(),
+          welcomeWake: true,
+        },
+      });
+      woke.push(agentName);
+    } catch (error) {
+      console.warn('[welcome-wake] event enqueue failed', {
+        agent: agentName,
+        pod: String(safePodId),
+        error: (error as Error).message,
+      });
+    }
+  }));
+
+  return { claimed: true, woke };
+}
+
+export default { maybeFireWelcomeWake, isDesignatedGreeter, findGreeters };


### PR DESCRIPTION
Closes #834.

`enqueueMentions` returned before enqueueing anything when a message carried no `@mention` and no `replyTo` (`agentMentionService.ts:721`), and the implicit path from #703 is gated on replies (`:999`). So the one message most likely to need an answer — a newcomer's first — was the one guaranteed not to get one.

Observed live in Commonly HQ on 2026-08-04: a new member asked a question and it sat **fourteen hours**, in a room whose pinned welcome promises a support agent answers within a minute. That promise only ever held for people who already knew to type `@commonly-support` — which someone asking "what is this" definitionally does not. HQ also auto-joins at verify, so they had not chosen the room either.

## Scope, and why the name matters

This is a **first-message welcome wake**. It is not general routing of unaddressed messages. The member whose day-30 question goes unanswered is out of scope and stays out of scope until ADR-017 ships a policy layer.

**Why this can ship before that layer when a general rule cannot** — the distinction is edge-triggered vs level-triggered. The trigger here is a monotone state transition (never-spoken → spoken), so total fires are bounded by the state space (members × pods, amortized one per join), *independent of traffic*. Message-arrival and clock triggers are bounded only by traffic, and taming those needs the budget machinery ADR-017 and #832 have not shipped. #800's incident was a clock trigger: eleven wakes, zero edges.

That gives a reusable test for future point-fixes here: **bounded by a finite state space → can ship now; bounded only by traffic → waits for budgets.**

The proxy-calcification worry is real but does not apply: any future wake policy strictly *supersedes* "a new member's first message is wake-worthy" — it absorbs this rule rather than ripping it out. It is a floor, not a ceiling.

## Four things the design turns on

**The marker is claimed for every first message, addressed or not.** Claiming only unaddressed ones would welcome a member on their *second* message when their opener was `@codex help` — a greeting arriving after the conversation already started.

**Greeters are explicit opt-in** (`config.welcomeWake.enabled === true`), never inferred. "The pod's support agent" is not a schema concept, and guessing one — sole install, oldest install, name contains "support" — makes the wake target drift silently as installs change. Same stance as #833's heartbeat flag, for the same reason.

**A first message with no designated greeter still claims the marker, and logs a warning.** The silent no-op was the failure mode most likely to ship: feature live, marker claimed, nothing happening, and nothing anywhere saying why. It still claims — otherwise designating a greeter later would welcome every existing member on their next message.

**The event is enqueued as `chat.mention`, not a new type.** The CLI wrapper's `extractPrompt` returns `null` for anything outside `PROMPT_EVENT_TYPES` (`chat.mention`, `message.posted`, `dm.message`, `first_contact`), so a bespoke `pod.first_message` would be silently dropped by every already-deployed wrapper — the #611 failure mode, and it would have looked like the feature simply did not work. An additive `welcomeWake: true` payload flag costs nothing and works on drivers shipped before this existed.

## Wiring

Sender resolution moves above the unrouted early-return so the wake can check `isBot === false`; every existing use of it is downstream and unchanged. Bots never claim or wake — an agent's first post would otherwise seed a loop, the same reasoning that gates #703 on `isBot === false`. `AgentProfile` now loads only on the routed path, holding the added cost of reaching that point to two queries rather than three.

`PodMemberFirstMessage` gets its own collection rather than a flag on `Pod.members`: membership rows are rewritten by join/leave and by the dual-DB sync, and a marker that can be reset replays onboarding at someone already welcomed — the same reasoning that gave `AgentFirstContact` its own collection. It is deliberately *not* `AgentFirstContact`, which keys `(userId, agentName, instanceId)` and fires on **install**; a member auto-joined to a community pod installs nothing, which is exactly the gap.

## Known cost, stated rather than buried

One marker upsert per human message. Bounded and indexed, but a write where there was none. If profiling shows it, the fix is a read-first fast path (indexed `findOne`, upsert only on miss). I did not pre-optimize: the correct-and-simple version matches `firstContactService` exactly, and matching a reviewed pattern beat inventing a faster unreviewed one.

## This ships inert

Nothing is welcomed until an install sets `config.welcomeWake.enabled`. Designating `commonly-support` in HQ is a separate, explicit step — so merging this cannot surprise anyone, and equally, merging alone does not fix the reported incident.

## Verification

- 18 service tests + 6 wiring tests; 41 existing mention tests unchanged and passing
- Full backend suite against a `48ffcc16` baseline on identical `node_modules`: failures **identical at 53 suites / 35 tests**, totals **+1 suite / +24 tests** — exactly what this adds. (The 53 are pre-existing local env failures, e.g. `Cannot find module '@sentry/node'`.)
- Typecheck clean; the two `instrument.ts` errors are pre-existing, confirmed identical with these changes stashed
- No new lint debt — the untouched sibling test produces the same import-rule output
- **Mutation-tested**, which caught dead code in my own first draft: an `isRouted ? [] : findGreeters(...)` guard that read as decisive and survived deletion untouched. Removed, and the missing positive `wokeGreeter: true` assertion added; dropping the routed early-return and forcing `wokeGreeter` false are both now caught.

Spec sharpenings courtesy of @fable-lead's review of the issue.
