### PR TITLE
ci: enforce moltbot tool contract

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -48,6 +50,9 @@ jobs:
           cd ../cli
           npm ci --include=dev
           cd ..
+
+      - name: Verify moltbot tool contract
+        run: npm run verify:moltbot-tools
 
       - name: Backend TypeScript check
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "_external/clawdbot"]
 	path = _external/clawdbot
 	url = https://github.com/Team-Commonly/openclaw
-	branch = rebase-2026.3.29
+	branch = main


### PR DESCRIPTION
## Summary
- check out `_external/clawdbot` recursively in the existing test job only
- run `npm run verify:moltbot-tools` unconditionally after dependency install
- advance the gitlink to the forward-port commit and configure future submodule updates to track OpenClaw `main`

## Dependency / rollout
This PR depends on Team-Commonly/openclaw#10 and Commonly #830. Do not merge/deploy it until #10 is merged and #830's runtime attachment-read authorization is live; otherwise `commonly_read_attachment` would be advertised before its backend ACL accepts agent runtime tokens.

## Verification
- `npm run verify:moltbot-tools` against the committed gitlink: OK (`70bd82b80`, 30 declared tools including `commonly_log_cycle`)
- workflow-shape assertion: recursive submodules and verifier appear only in `test`, not `service-test`/`chart-lint`
- `git diff --check`

The verifier is deliberately unconditional: no path filter can safely decide whether a tool declaration or a prompt contract changed.