### PR TITLE
fix(mentions): the welcome reply teaches the handle, and names the right one

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -1360,4 +1360,82 @@ describe('AgentMentionService', () => {
       })).resolves.toEqual({ enqueued: [], implicit: [], skipped: [] });
     });
   });
+  // ── the greeter naming its own handle must not re-trigger itself ─────────
+  //
+  // The welcome cue instructs the agent to close with "@<handle> anytime".
+  // That puts the agent's OWN handle into a message the agent itself sent, so
+  // the self-mention guard is what stops an endless wake loop — and it is now
+  // load-bearing rather than incidental.
+  //
+  // The resolution is non-obvious and worth pinning: the support agent's
+  // identity is (agentName 'hq-support', instanceId 'commonly-support'), and
+  // `@commonly-support` resolves through BOTH the instanceId key and the
+  // displayName slug to that same pair. isSelfMention compares the pair, so
+  // it matches. Rename the display name without thinking and this test is
+  // what catches the loop.
+  describe('a greeter that names its own handle does not wake itself', () => {
+    const supportInstall = {
+      agentName: 'hq-support',
+      instanceId: 'commonly-support',
+      displayName: 'Commonly Support',
+    };
+
+    beforeEach(() => {
+      AgentInstallation.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([supportInstall]),
+      });
+      AgentProfile.find.mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+      Pod.findById.mockReturnValue({
+        select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue({ type: 'chat' }) }),
+      });
+      AgentEvent.countDocuments.mockResolvedValue(0);
+      // The sender IS the support agent.
+      User.findById.mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue({
+            isBot: true,
+            botMetadata: { agentName: 'hq-support', instanceId: 'commonly-support' },
+          }),
+        }),
+      });
+    });
+
+    test('the display-slug handle in its own reply enqueues nothing', async () => {
+      const res = await AgentMentionService.enqueueMentions({
+        podId: 'pod-1',
+        message: { content: 'Happy to help — you can @commonly-support anytime.' },
+        userId: 'support-bot-user',
+        username: 'Commonly Support',
+      });
+      expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+      expect(res.enqueued).toEqual([]);
+    });
+
+    test('its bare agentName in its own reply also enqueues nothing', async () => {
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-1',
+        message: { content: 'reach me at @hq-support' },
+        userId: 'support-bot-user',
+        username: 'Commonly Support',
+      });
+      expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+    });
+
+    test('but a HUMAN using that same handle still reaches the agent', async () => {
+      User.findById.mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue({ isBot: false }),
+        }),
+      });
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-1',
+        message: { content: '@commonly-support how do I attach an agent?' },
+        userId: 'human-1',
+        username: 'user-9228',
+      });
+      expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+      const [event] = AgentEventService.enqueue.mock.calls[0];
+      expect(event.agentName).toBe('hq-support');
+    });
+  });
 });

--- a/backend/__tests__/unit/services/welcomeWakeService.test.js
+++ b/backend/__tests__/unit/services/welcomeWakeService.test.js
@@ -14,6 +14,7 @@ const {
   maybeFireWelcomeWake,
   isDesignatedGreeter,
   findGreeters,
+  mentionHandleFor,
 } = require('../../../services/welcomeWakeService');
 
 const POD_ID = new mongoose.Types.ObjectId().toString();
@@ -203,6 +204,50 @@ describe('welcomeWakeService', () => {
       const res = await maybeFireWelcomeWake(opts({ podId: 'not-an-objectid' }));
       expect(res.claimed).toBe(false);
       expect(PodMemberFirstMessage.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+  });
+  // ── the reply has to teach the handle, and teach the RIGHT one ───────────
+  //
+  // This wake fires once per member per pod. Their next unaddressed message
+  // reaches nobody, deliberately — a continuation window cannot distinguish a
+  // message meant for the agent from one meant for another human, and with
+  // two greeters it wakes both on everything. So the single reply this
+  // produces is the only chance to close the discoverability gap, and it has
+  // to name a handle that actually works.
+  describe('the cue teaches the handle a human would type', () => {
+    test('prefers the displayName slug — what the UI renders', () => {
+      expect(mentionHandleFor({
+        agentName: 'hq-support', instanceId: 'commonly-support', displayName: 'Commonly Support',
+      })).toBe('commonly-support');
+    });
+
+    // The trap this exists for: the agent's TOKEN says agentName 'hq-support',
+    // but nobody in the room types that. An agent asked to name its own handle
+    // answers from its token and sends the user a handle they never see.
+    test('does NOT fall back to agentName when a display handle exists', () => {
+      expect(mentionHandleFor({
+        agentName: 'hq-support', instanceId: 'commonly-support', displayName: 'Commonly Support',
+      })).not.toBe('hq-support');
+    });
+
+    test('falls back to instanceId, then agentName', () => {
+      expect(mentionHandleFor({ agentName: 'codex', instanceId: 'cody' })).toBe('cody');
+      expect(mentionHandleFor({ agentName: 'codex', instanceId: 'default' })).toBe('codex');
+    });
+
+    test('the cue names the handle inline, with an @', async () => {
+      await maybeFireWelcomeWake(opts({
+        installations: [greeter({ displayName: 'Commonly Support' })],
+      }));
+      const [event] = AgentEventService.enqueue.mock.calls[0];
+      expect(event.payload.content).toContain('@commonly-support');
+    });
+
+    test('the cue asks for it as the closing line, not a capability menu', async () => {
+      await maybeFireWelcomeWake(opts());
+      const [event] = AgentEventService.enqueue.mock.calls[0];
+      expect(event.payload.content).toMatch(/how to reach you again/i);
+      expect(event.payload.content).toMatch(/do not paste a menu/i);
     });
   });
 });

--- a/backend/services/welcomeWakeService.ts
+++ b/backend/services/welcomeWakeService.ts
@@ -71,12 +71,51 @@ export const findGreeters = (
   installations: Array<Record<string, any>>,
 ): Array<Record<string, any>> => (installations || []).filter(isDesignatedGreeter);
 
-const WELCOME_CUE = (username?: string): string => [
+/**
+ * The handle a HUMAN would type to reach this install — not the agent's own
+ * `agentName`.
+ *
+ * These differ, and the difference is a trap. The support agent's token
+ * carries `agentName: 'hq-support'` while everyone in the room sees
+ * "Commonly Support" and types `@commonly-support`. An agent asked to name
+ * its own handle answers from its token and gets it wrong, so the cue states
+ * it rather than delegating the guess.
+ *
+ * Mirrors buildMentionMap's resolution order: displayName slug first (what
+ * the UI renders and therefore what a person copies), instanceId second.
+ */
+const slugifyHandle = (value = ''): string => value
+  .toString().trim().toLowerCase()
+  .replace(/[^a-z0-9-]/g, '-')
+  .replace(/-+/g, '-')
+  .replace(/^-+|-+$/g, '');
+
+export const mentionHandleFor = (installation: Record<string, any>): string => {
+  const display = slugifyHandle(String(installation?.displayName || ''));
+  if (display) return display;
+  const instanceId = String(installation?.instanceId || '');
+  if (instanceId && instanceId !== 'default') return slugifyHandle(instanceId);
+  return slugifyHandle(String(installation?.agentName || ''));
+};
+
+const WELCOME_CUE = (username: string | undefined, handle: string): string => [
   '[First message from a new member in this pod. They have never posted here before,',
   'and they did not @mention anyone — most likely because they do not yet know they can.',
   'Answer their message directly. Do not list your capabilities and do not paste a menu;',
-  'if the message is a question, just answer it. Keep it short and end with one concrete',
-  'next step they can take. If their message needs no reply, return NO_REPLY.]',
+  'if the message is a question, just answer it. Keep it short.',
+  '',
+  // The one durable thing this reply can do. This wake fires ONCE per member
+  // per pod, so their next unaddressed message reaches nobody — by design,
+  // because a continuation window cannot tell a message meant for you from
+  // one meant for another human, and with two greeters installed it wakes
+  // both on everything. The fix for that is not more routing, it is closing
+  // the discoverability gap while they are looking at proof that it works.
+  // A pinned room description already failed at this; the agent that just
+  // answered them will not.
+  `End by telling them how to reach you again: they can @${handle} anytime, or reply`,
+  'directly to your message. Say it once, plainly, as the last line — not as a menu.',
+  '',
+  'If their message needs no reply at all, return NO_REPLY.]',
   '',
   username ? `${username} wrote:` : 'They wrote:',
 ].join('\n');
@@ -191,7 +230,7 @@ export async function maybeFireWelcomeWake({
           // The cue rides inline in content, not in metadata: models
           // deprioritize structured fields and act on the narrative frame.
           // Same rule as the DM cue (ADR-012 §9) and the pod-context cue.
-          content: `${WELCOME_CUE(username)}\n${String(content || '').trim()}`,
+          content: `${WELCOME_CUE(username, mentionHandleFor(installation))}\n${String(content || '').trim()}`,
           userId: String(safeUserId),
           username,
           mentions: [],


### PR DESCRIPTION
Follow-up to #838, from Sam's review. Two changes — and one of them is a correction to a design I proposed and he was right to reject.

## The gap he found

The wake fires once per member per pod, so a newcomer's **second** unaddressed message reaches nobody. Only a reply-threaded follow-up routes (via #703), and someone who didn't know to `@mention` almost certainly doesn't know to reply-thread either.

I proposed a bounded continuation window: keep routing that member's messages to the greeter for N messages or T minutes. **That was wrong**, for reasons worth recording:

- **It cannot tell a message meant for the agent from one meant for another human.** In a pod where people talk to each other, it wakes the agent on everything a newcomer says for the whole window.
- **With two greeters installed it wakes both**, on everything, with no notion of who owns the conversation. No principled tiebreak exists — a sign the design is wrong rather than incomplete.
- **My justification was bad reasoning.** I argued it was principled because fires stay bounded by (member × pod) × a constant rather than by traffic. But a bound on *how many* unwarranted wakes happen doesn't make any of them warranted. That's proxy-thinking — the exact failure #838's own PR text warns about, committed while citing the rule.

I also overstated the problem to justify the fix. "Trained then abandoned" was wrong: message 2 getting silence is not a regression, it is what every other message in the room does today. The honest version is "helped once, then normal" — strictly better than before.

## What this does instead

The gap is **discoverability**, not routing: the newcomer doesn't know how to address the agent. So close that, at the one moment it lands — in the reply, from the agent that just demonstrably helped them. A pinned room description already failed at this; an in-context line from a working agent won't.

The cue now ends with:

> End by telling them how to reach you again: they can @commonly-support anytime, or reply directly to your message. Say it once, plainly, as the last line — not as a menu.

No new state, no routing change, degrades gracefully with multiple agents.

## Naming the right handle — which is not the one the agent knows

The support agent's token carries `agentName: 'hq-support'`, while the room renders "Commonly Support" and humans type `@commonly-support`. **An agent asked to name its own handle answers from its token and hands the user a string they have never seen.**

So the cue states the handle rather than delegating the guess. `mentionHandleFor` mirrors `buildMentionMap`'s own resolution order — displayName slug first (what the UI renders, therefore what a person copies), then instanceId, then agentName.

## The self-mention guard is now load-bearing

Instructing an agent to write its own handle puts that handle into a message the agent itself sent. Verified it resolves the way the guard requires: `@commonly-support` maps through **both** the instanceId key and the displayName slug to `(hq-support, commonly-support)` — exactly the pair `isSelfMention` compares — so it matches and suppresses.

That was previously an incidental property. It is now a contract, so it has three regression tests, including that a **human** typing the same handle still reaches the agent. Rename a display name carelessly and those tests are what catch the resulting wake loop.

## Verification

- 23 service tests + 50 mention tests (3 new)
- Typecheck clean
- **Mutation-verified**: neutering `isSelfMention` fails all three new self-mention tests, so they pin real behavior rather than passing vacuously
