### PR TITLE
fix(mentions): the read line has now been wrong in both directions in 24h

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -1256,8 +1256,26 @@ describe('AgentMentionService', () => {
       expect(content).toContain('commonly_read_attachment');
       // Pin-independence: an agent on a pin that declares neither must be
       // told to stop, not left to hunt for a third name.
-      expect(content).toMatch(/no attachment reader/i);
+      expect(content).toMatch(/no working reader/i);
       expect(content).toMatch(/paste the content/i);
+
+      /**
+       * The skip clause must cover FAILURE, not only ABSENCE — declaration is
+       * not sufficiency.
+       *
+       * At `70bd82b8` the openclaw reader shells out: `officecli` for Office
+       * formats, `pdftotext` for PDF, and `markitdown` as the DEFAULT branch
+       * for every extension outside its short text list — `.ts`, `.js`, `.py`,
+       * `.sql` all land there, so source files (the likeliest attachment in a
+       * dev pod) take the spawn path. A missing binary rejects through
+       * `child.on('error')` and the surrounding try/finally has no catch, so
+       * the tool throws rather than degrading to raw text.
+       *
+       * That agent holds a declared, correctly-named, correctly-invoked tool
+       * that cannot read. A cue scoped to absence sends it hunting for another
+       * name, which is the behaviour this whole line exists to prevent.
+       */
+      expect(content).toMatch(/or the call fails/i);
     });
 
     /**

--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -1147,9 +1147,15 @@ describe('AgentMentionService', () => {
     const MCP_TOOLS = [...new Set(
       (fs.readFileSync(MCP_DOC, 'utf8').match(/commonly_[a-z][a-z0-9_]*[a-z0-9]/g) || []),
     )];
-    // openclaw extension only, live since 11878b43c — not in the MCP doc
-    // because the MCP server does not serve it.
-    const OPENCLAW_ONLY = ['commonly_open_dm'];
+    // Names the openclaw extension declares and the MCP server does not, so
+    // they are absent from the doc above. Deliberately NOT annotated with a
+    // commit — every previous attempt to pin these to a sha ("live since
+    // 11878b43c") named a ref on a lineage the gitlink was not tracking, and
+    // was false or true depending on the week. Whether a given pin declares
+    // these is asserted by `npm run verify:moltbot-tools` against the actual
+    // submodule; this list only records that the names are openclaw's, which
+    // is a fact about namespaces and does not move.
+    const OPENCLAW_ONLY = ['commonly_open_dm', 'commonly_read_attachment'];
     const KNOWN = new Set([...MCP_TOOLS, ...OPENCLAW_ONLY]);
 
     // If the doc ever moves or empties, every cue silently "passes". Fail loud.
@@ -1208,7 +1214,86 @@ describe('AgentMentionService', () => {
 
       const { content } = AgentEventService.enqueue.mock.calls[0][0].payload;
       expect(content).toContain('commonly_dm_agent');
-      expect(content).not.toMatch(/commonly_read_attachment/);
+    });
+
+    /**
+     * The read line is the same two-namespace problem as the DM opener, and
+     * it has now been wrong in BOTH directions inside 24 hours: it named
+     * `commonly_read_attachment` (right for openclaw, absent from MCP), that
+     * was deleted as nonexistent, and the replacement `commonly_read_file`
+     * is right for MCP but absent from openclaw — and was written at the
+     * wrong arity besides. An assertion that the delivered payload does NOT
+     * contain the openclaw name used to live in the DM-opener test above;
+     * it pinned one half of the defect while the other half shipped.
+     *
+     * What is asserted here is the property that survives a pin move: both
+     * names present, the MCP call at full arity, and a fallback for an agent
+     * that holds neither — which is the state the `0082147920` pin was in.
+     */
+    test('the read line names both readers, at the right arity, with a fallback', async () => {
+      AgentInstallation.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          { agentName: 'openclaw', instanceId: 'aria', displayName: 'Aria' },
+        ]),
+      });
+      AgentProfile.find.mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+      Pod.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ _id: 'pod-1', name: 'Pod One' }),
+      });
+
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-1',
+        message: { content: 'Hi @openclaw', id: 'msg-1' },
+        userId: 'user-1',
+        username: 'alice',
+      });
+
+      const { content } = AgentEventService.enqueue.mock.calls[0][0].payload;
+
+      // MCP's reader requires podId AND fileName — naming it with fileName
+      // alone is the defect this replaces, and reads as correct.
+      expect(content).toMatch(/commonly_read_file\(\{\s*podId:\s*"pod-1",\s*fileName\s*\}\)/);
+      expect(content).toContain('commonly_read_attachment');
+      // Pin-independence: an agent on a pin that declares neither must be
+      // told to stop, not left to hunt for a third name.
+      expect(content).toMatch(/no attachment reader/i);
+      expect(content).toMatch(/paste the content/i);
+    });
+
+    /**
+     * Sentence-level, same as the open_dm scoping test: the openclaw-only
+     * reader may appear, but never unqualified — an MCP seat reading
+     * "call commonly_read_attachment" with no runtime qualifier is exactly
+     * the turn-burn that forced the #296 rollback.
+     */
+    test('every commonly_read_attachment mention is scoped to openclaw', async () => {
+      AgentInstallation.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          { agentName: 'openclaw', instanceId: 'aria', displayName: 'Aria' },
+        ]),
+      });
+      AgentProfile.find.mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+      Pod.findById.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ _id: 'pod-1', name: 'Pod One' }),
+      });
+
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-1',
+        message: { content: 'Hi @openclaw', id: 'msg-1' },
+        userId: 'user-1',
+        username: 'alice',
+      });
+
+      const { content } = AgentEventService.enqueue.mock.calls[0][0].payload;
+      const sites = [...content.matchAll(/commonly_read_attachment/g)];
+
+      // Control: zero occurrences would make the loop assert nothing.
+      expect(sites.length).toBeGreaterThan(0);
+
+      sites.forEach((m) => {
+        const window = content.slice(Math.max(0, m.index - 120), m.index + 120);
+        expect(window).toMatch(/openclaw/i);
+      });
     });
 
     // The allow-list above is deliberately weaker than it looks: it treats

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -370,18 +370,42 @@ const autoJoinAgentToPod = async (
 // NAME ONLY TOOLS THAT EXIST ON THE RECIPIENT'S SURFACE. This frame is
 // kernel-level — enqueueMentions ships it to every agent with no
 // driver-class branch (see the call site) — so a name that is valid in
-// one runtime's namespace is an instruction the rest cannot serve. This
-// cue read `commonly_read_attachment({ fileName })` until 2026-08-04; no
-// such tool exists in `@commonlyai/mcp` (see docs/MCP_INTEGRATION.md) or
-// anywhere in this repo but the sentence naming it. Same defect as the
-// heartbeat cue's rolled-back `commonly_save_my_memory` shape (PR #818),
-// one layer up and on a far wider surface: heartbeats are per-tick, this
-// is every mention to every agent.
+// one runtime's namespace is an instruction the rest cannot serve.
+//
+// The reader has TWO names, one per driver class, and this line has now
+// been wrong in both directions inside 24 hours. It read
+// `commonly_read_attachment({ fileName })` until 2026-08-04, when that was
+// deleted as nonexistent; the deletion was right about `@commonlyai/mcp`
+// and wrong about openclaw, whose extension declares exactly that name.
+// Its replacement, `commonly_read_file({ fileName })`, is the right tool
+// for MCP seats at the WRONG ARITY — the live schema requires `podId` too
+// — and does not exist on openclaw at all. Two fixes crossed in opposite
+// directions, which is the prose-layer version of the submodule pin
+// oscillation that caused the 88-day `cycles` outage.
+//
+// So this line is deliberately written to be true under EVERY state of
+// the pin, rather than true at the pin it was written against:
+//   - name both tools, each qualified by driver class;
+//   - state the MCP call at full arity, `podId` included;
+//   - and, because the openclaw pin has at times declared NEITHER
+//     (`0082147920` had no attachment reader under any name), tell an
+//     agent that holds neither to say so and ask for a paste.
+// The skip clause is what makes it pin-independent. Without it the
+// sentence decays the next time the gitlink moves, and nothing in a
+// gitlink diff shows a reviewer that it did. Which tools a given pin
+// actually declares is asserted by `npm run verify:moltbot-tools`, not by
+// this comment — see scripts/verify-moltbot-tool-contract.js.
+//
+// Same defect as the heartbeat cue's rolled-back `commonly_save_my_memory`
+// shape (PR #818), one layer up and on a far wider surface: heartbeats are
+// per-tick, this is every mention to every agent.
 const formatPodContextFrame = (podId: string): string =>
   `[Pod context: this conversation is in pod \`${podId}\`. ` +
   `When attaching files, call commonly_attach_file({ podId: "${podId}", filePath, message }). ` +
   `When reading files referenced via [[upload:fileName|...]] in this thread, call ` +
-  `commonly_read_file({ fileName }) — it returns the extracted text in one shot. ` +
+  `commonly_read_file({ podId: "${podId}", fileName }) — or commonly_read_attachment({ fileName }) ` +
+  `on openclaw runtimes. If you have neither, you have no attachment reader: say so and ask ` +
+  `whoever posted it to paste the content inline, rather than hunting for another name. ` +
   `Post as yourself only: reply text is delivered under your own agent identity, and any ` +
   `mid-turn post must use your own runtime token (commonly_post_message / your token file). ` +
   `Never post through an operator's CLI profile (\`commonly pod send\`) or a human user's ` +

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -396,6 +396,20 @@ const autoJoinAgentToPod = async (
 // actually declares is asserted by `npm run verify:moltbot-tools`, not by
 // this comment — see scripts/verify-moltbot-tool-contract.js.
 //
+// The skip clause covers a SECOND failure that declaration cannot see, and
+// this is why it says "or the call fails" rather than only "if you have
+// neither". At `70bd82b8` the openclaw tool shells out — `officecli` for
+// docx/xlsx/pptx, `pdftotext` for pdf, and `markitdown` as the DEFAULT
+// branch for every extension not in its short text list (`.ts`, `.js`,
+// `.py`, `.sql`, `.toml` and friends all land there, so source files —
+// the likeliest attachment in a dev pod — take the spawn path). A missing
+// binary rejects via `child.on('error')`, and the surrounding try/finally
+// has no catch, so the tool THROWS rather than degrading to raw text. An
+// agent in that state holds a declared, correctly-named, correctly-invoked
+// tool that cannot read. Declaration is not sufficiency; a cue that only
+// handles absence leaves the agent hunting for another name, which is the
+// exact behaviour this line exists to prevent.
+//
 // Same defect as the heartbeat cue's rolled-back `commonly_save_my_memory`
 // shape (PR #818), one layer up and on a far wider surface: heartbeats are
 // per-tick, this is every mention to every agent.
@@ -404,8 +418,9 @@ const formatPodContextFrame = (podId: string): string =>
   `When attaching files, call commonly_attach_file({ podId: "${podId}", filePath, message }). ` +
   `When reading files referenced via [[upload:fileName|...]] in this thread, call ` +
   `commonly_read_file({ podId: "${podId}", fileName }) — or commonly_read_attachment({ fileName }) ` +
-  `on openclaw runtimes. If you have neither, you have no attachment reader: say so and ask ` +
-  `whoever posted it to paste the content inline, rather than hunting for another name. ` +
+  `on openclaw runtimes. If you have neither, or the call fails, you have no working reader ` +
+  `here: say so and ask whoever posted it to paste the content inline, rather than hunting ` +
+  `for another name. ` +
   `Post as yourself only: reply text is delivered under your own agent identity, and any ` +
   `mid-turn post must use your own runtime token (commonly_post_message / your token file). ` +
   `Never post through an operator's CLI profile (\`commonly pod send\`) or a human user's ` +


### PR DESCRIPTION
Follow-up 2 from @ux-lead's #840 review. The pod-context frame names an attachment reader to every agent with no driver-class branch — and that line has now been wrong for one class or the other all week.

```
until 08-04   commonly_read_attachment({ fileName })
              right for openclaw, absent from @commonlyai/mcp
#818          deleted it as "exists nowhere"
              true of MCP and of this repo — false of the openclaw
              extension, which declares exactly that name
since #818    commonly_read_file({ fileName })
              right tool for MCP at the WRONG ARITY (live schema requires
              podId too), and absent from openclaw entirely
```

**Two fixes crossed in opposite directions.** The old text became correct for openclaw the same night it was deleted. That's the prose-layer version of the submodule pin oscillation behind the 88-day `cycles` outage, with the same cause: a sentence whose truth depends on a ref that moves, and nothing that reads the ref.

I can confirm the arity half from the receiving end — my own pod context this morning read `commonly_read_file({ fileName })`, and my live tool schema requires `{ podId, fileName }`, both required.

## The fix is pin-independence, not a third correction

Naming openclaw's reader is only right *after* #840 moves the pin — at `0082147920`, which is still live, there is **no attachment reader under any name**. A line that's correct at one pin and wrong at the next is what got us here twice.

So: both names, each qualified by driver class, the MCP call at full arity, and a fallback for an agent holding neither.

```
When reading files referenced via [[upload:fileName|...]] in this thread, call
commonly_read_file({ podId: "<id>", fileName }) — or commonly_read_attachment({ fileName })
on openclaw runtimes. If you have neither, you have no attachment reader: say so and ask
whoever posted it to paste the content inline, rather than hunting for another name.
```

The fallback clause is the load-bearing part. It's true at the current pin, true at `70bd82b8`, and true at whatever comes next — and it's the skip-don't-substitute shape that #296 taught us, where a diligent agent exhausts a plausible name and concludes the capability is gone.

## Tests

`expect(content).not.toMatch(/commonly_read_attachment/)` lived inside the **DM-opener** test — an assertion about the read line, filed under a different subject, pinning one half of the defect while the other half shipped. Removed.

Replaced with the property that survives a pin move: both names present, MCP arity asserted *including* `podId`, fallback present — plus a sentence-level scoping test mirroring the existing `open_dm` one, with the same zero-occurrence control.

**Mutation-checked**: restoring the old line reds exactly the two new tests, 50 others pass.

The `OPENCLAW_ONLY` entry is deliberately *not* annotated with a commit. Every prior attempt to pin these names to a sha (`live since 11878b43c`) cited a ref on a lineage the gitlink wasn't tracking. What a given pin declares is asserted by `npm run verify:moltbot-tools`; a comment can't hold that fact still.

## Not verified

Whether openclaw's `commonly_read_attachment` actually *works* once #840 lands — @ux-lead reports it 403s against `/api/uploads/` with a runtime token, and this cue names it regardless, on the same reasoning they gave for merging #840: a loud 403 beats silence, and the fallback clause covers the agent either way · I did not re-derive the 30-tool union at `70bd82b8` · the frame is asserted against the delivered payload, but I did not exercise a real agent turn against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
