### PR TITLE
docs(agents): the escape-hatch build ships without the attachment extractors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,8 +322,29 @@ docker build frontend --build-arg REACT_APP_API_URL=https://api.commonly.me \
 (cd _external/clawdbot && docker build \
   --build-arg OPENCLAW_EXTENSIONS=acpx \
   --build-arg OPENCLAW_INSTALL_GH_CLI=1 \
+  --build-arg OPENCLAW_INSTALL_DOC_TOOLCHAIN=1 \
   -t "$REG/clawdbot-gateway:$TAG" . && docker push "$REG/clawdbot-gateway:$TAG")
 ```
+
+`OPENCLAW_INSTALL_DOC_TOOLCHAIN=1` is not optional in practice and was missing
+here until 2026-08-05. `deploy-dev.yml` passes it; this escape hatch did not, so
+a hand-built hotfix image silently shipped without the extractors
+`commonly_read_attachment` shells out to, and nothing failed until an agent
+tried to read an attachment — at which point it throws rather than degrading.
+Its scope also widened underneath the name: at pin `00821479` the arg installed
+only `officecli` (write-side, for *generating* .docx/.xlsx/.pptx), and the
+forward-port widened the same arg to add `poppler-utils` + `markitdown` +
+`pypdf` for the *read* path. Verified on the live gateway 2026-08-05:
+`officecli` present, `pdftotext` and `markitdown` absent — matching the old pin
+exactly. **A build arg whose meaning changed without its name changing is not
+something a reader of this file can infer; check the Dockerfile at the pin
+before assuming an omitted arg is harmless.**
+
+Note also that the gateway image is where the openclaw *extension code* lives —
+`commonly_*` tools included. A submodule bump alone changes nothing live, and
+`reprovision-all` only regenerates `moltbot.json` from the DB. A pin change
+reaches agents as: **merge → `Deploy Dev` (rebuilds from the new gitlink) →
+`reprovision-all`.**
 
 `gcloud builds submit` is blocked by the dev project's org policy on AR uploads, so don't reach for it.
 


### PR DESCRIPTION
`deploy-dev.yml:114` passes `--build-arg OPENCLAW_INSTALL_DOC_TOOLCHAIN=1`. The
manual build documented in CLAUDE.md did not, so a hand-built hotfix image ships
without the binaries `commonly_read_attachment` shells out to — and nothing
fails until an agent reads an attachment, where a missing binary rejects through
`child.on('error')` and throws out of `execute` rather than degrading to raw text.

**Why an omitted build-arg looked harmless: the arg widened underneath its own
name.** At pin `00821479` it installed only `officecli`, commented as letting
agents *generate* .docx/.xlsx/.pptx — a write-side toolchain, reasonable to skip
for a hotfix. The forward-port widened the same arg to add `poppler-utils` +
`markitdown` + `pypdf` for the *read* path and rewrote the comment to name
`commonly_read_attachment`. Same name, different meaning, no diff in this file
to show it.

**Confirmed against the running gateway rather than inferred:**

```
officecli   /usr/local/bin/officecli
pdftotext   ABSENT
markitdown  ABSENT   (module not importable either)
```

That split cannot come from the new block, where all three install in one `&&`
chain — it matches the old pin exactly. Container and source agree to the line.

Also records what a pin bump does and does not reach: the openclaw extension
code (`commonly_*` tools included) is baked into the gateway image at build
time, and `reprovision-all` only regenerates `moltbot.json` from the DB. So a
bump is inert until `Deploy Dev` rebuilds from the new gitlink — merge →
Deploy Dev → reprovision.

Docs only; no code paths touched.

Found by @ux-lead, who read the Dockerfile at the new pin and flagged this line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)