### PR TITLE
docs(agents): the ladder's common case climbs one rung, it does not skip

### DIFF
--- a/backend/__tests__/unit/scripts/moltbotToolContract.test.js
+++ b/backend/__tests__/unit/scripts/moltbotToolContract.test.js
@@ -240,8 +240,15 @@ describe('moltbot tool contract', () => {
       /**
        * Why the ladder is cheap enough to run on every CI job: a FOUND path
        * cannot be a graft artifact. Grafts remove history; they never invent
-       * it. So exit 0 is trustworthy even in a shallow repo and terminates
-       * immediately — the common case never fetches anything.
+       * it. So exit 0 is trustworthy even in a shallow repo and terminates at
+       * once — the climb stops at the first rung that finds a path.
+       *
+       * This said "the common case never fetches anything" until 2026-08-05,
+       * which was wrong: a pin at rest sits BEHIND its branch tip, so the fast
+       * path misses and the steady state is one rung, not zero. The test below
+       * is still correct — it pins exit-0-is-terminal — but the claim it was
+       * filed under was not. Cheap here means "stops early", never "does
+       * nothing". Caught by @sprint-review against #840's live CI verdict.
        */
       it('treats exit 0 as terminal even while shallow, without deepening', () => {
         const { exec, rungs } = shallowRepoWhere({ ancestry: () => 0 });

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -364,3 +364,68 @@ Three instances found the same day, at three layers, none with any notion of dri
 The server's 400 is the best agent-facing artifact encountered this sprint: *"cycles is append-only — payload must be `{ append: { content, ts?, podId? } }`"*. It names the exact required shape, and it taught more in one response than the tool description it contradicts. Its one gap is entry #6's sharpened lesson — it names the required **payload** but not the required **tool**, so a diligent reader digs deeper into the wrong surface. **The pattern worth copying: an error that states the shape it wants. The pattern worth completing: also state where that shape is accepted.**
 
 **Not verified:** the openclaw extension's own tool list — `_external/clawdbot` is an uninitialized submodule on every seat that looked, so "`commonly_read_attachment` exists nowhere" is proven for `@commonlyai/mcp` and this repo, and *inferred* for openclaw. No cluster read: the `HEARTBEAT.md` provisioning path is traced from source, not observed on a moltbot PVC. The three-400 sequence is @ux-lead's measurement, reproduced here only as far as the tool schema, not re-run.
+
+---
+
+## 14. A comment refuted by a measurement thirty lines above it, in the same file (2026-08-05, sprint-review + pod-architect)
+
+`scripts/verify-moltbot-tool-contract.js`, both sentences written by me in one
+commit:
+
+```
+:261  // Measured on the real post-merge state in CI shape (pin one hop back,
+:262  // as a merge commit's second parent):
+:264  //   depth-1            is-ancestor → 1  (wrong)
+:265  //   after --deepen=64  is-ancestor → 0  (correct)
+        ⋮
+:295  // cheap — the common case never climbs.
+```
+
+The measurement records the pin one hop behind the tip and climbing one rung.
+Thirty lines later the same function claims the common case never climbs. Both
+in the same commit, by the same author, neither read against the other.
+
+### Why this is its own sub-genus, not another stale citation
+
+The rest of this log is about claims that **decayed** — true when written, false
+later, no diff to show it (entries #6, #13). This one was **false on arrival**
+and self-refuting: the file carries its own counter-evidence, so any reader who
+reads the whole function has everything needed to catch it. Which is exactly
+why it survives. A reader who reaches `:295` has read `:261` thirty lines
+earlier and *believes they already understand the cost model*; the sentence
+confirms the summary they are carrying rather than contradicting the data they
+read. Proximity is what makes it invisible, not distance.
+
+It also passes every check this repo has. Tests pin behaviour, and **the
+behaviour was correct** — the ladder always climbed. Nothing in a test suite,
+a linter, or a reviewer's diff view compares two comments for consistency.
+
+### The tell, and the discriminator that found it
+
+@sprint-review did not read the comment. They reproduced the CI shape, ran the
+check, and read the **verdict string**: `is an ancestor`, not `is the tip` —
+proof the fast path never fired. An output that distinguishes which branch of
+the code ran is worth more than any amount of re-reading, and this file had
+already been given one for a different reason.
+
+The residual error is the sharpest part. My *fix* said the fast path fires
+"right after a bump" — still wrong, and **#840, the PR the whole sprint is
+about, is the counterexample**: it bumps to `70bd82b8` while openclaw main is
+at `38f717bc6`, so it is a brand-new bump whose fast path still misses. The
+precise condition is narrower than "after a bump": *after a bump made TO the
+tip, and only until the branch next moves.* Caught by @ux-lead. **Third
+revision of one sentence** — and per the pin-comment lesson in `CLAUDE.md`, a
+sentence needing three revisions is asking for a check, not a fourth wording.
+
+**Lesson:** when a comment summarizes a measurement, put them adjacent or
+delete one. A summary that drifts from data in the same file is not caught by
+any tier of test, is invisible in a diff that touches only one of them, and
+reads as *more* authoritative for sitting next to evidence. Where the claim is
+load-bearing — this one describes cost, which is what a future change
+optimizes against — state the condition precisely enough to be falsifiable, and
+name the live artifact that would falsify it.
+
+**Not verified:** @sprint-review's CI-log readings (`--depth=1 --recursive`
+submodule line, the `is an ancestor` verdict string) are taken from their
+message; they are consistent with my own measurement of the same shape, which
+is corroboration rather than independent confirmation.

--- a/scripts/verify-moltbot-tool-contract.js
+++ b/scripts/verify-moltbot-tool-contract.js
@@ -46,11 +46,13 @@
  *   pin behind tip  ← AT REST  35M → 71M, 1.3s   — one --deepen=64 rung
  *   pin genuinely orphaned      35M → 288M, 18s  — the whole ladder, then FAIL
  *
- * The middle row is the normal one, not the first: a pin sits behind its branch
- * tip except in the moments right after a bump, so the fast path is the
- * exception and one rung is the steady state. Only the last row is expensive,
- * it is a build that was failing anyway, and it is the only shape where a
- * cheaper answer would be a guess.
+ * The middle row is the normal one, not the first. The fast path fires only
+ * when the pin IS the tip — that is, after a bump made TO the tip, and only
+ * until the branch next moves. Note that is narrower than "right after a bump":
+ * #840 bumps to `70bd82b8` while openclaw main is at `38f717bc6`, so it is a
+ * brand-new bump whose fast path still misses. One rung is the steady state.
+ * Only the last row is expensive, it is a build that was failing anyway, and it
+ * is the only shape where a cheaper answer would be a guess.
  *
  * EXIT CODES
  *   0  both contracts hold
@@ -227,7 +229,9 @@ const checkPinReachable = ({ exec = execFileSync } = {}) => {
 
   // Fast path, and the only one that is trustworthy in a shallow checkout:
   // if the pin IS the branch tip, containment is settled without any history.
-  // Worth doing first because it is also the common case right after a bump.
+  // Worth doing first because it costs one rev-parse — but it is NOT the
+  // common case. It fires only after a bump made TO the tip, and only until
+  // the branch next moves; see the COST table in the header.
   let tip = null;
   try {
     tip = String(git(['rev-parse', ref])).trim();

--- a/scripts/verify-moltbot-tool-contract.js
+++ b/scripts/verify-moltbot-tool-contract.js
@@ -42,12 +42,15 @@
  * history as the answer needs, and stops at the first rung that finds a path.
  * Measured end-to-end against a real depth-1 submodule checkout:
  *
- *   pin is the branch tip      no fetch at all, no ancestry walk
- *   pin one hop back (#840)    35M → 71M, 1.3s   — one --deepen=64 rung
- *   pin genuinely orphaned     35M → 288M, 18s   — the whole ladder, then FAIL
+ *   pin is the branch tip       no fetch at all, no ancestry walk
+ *   pin behind tip  ← AT REST  35M → 71M, 1.3s   — one --deepen=64 rung
+ *   pin genuinely orphaned      35M → 288M, 18s  — the whole ladder, then FAIL
  *
- * Only the last is expensive, it is a build that was failing anyway, and it is
- * the only shape where a cheaper answer would be a guess.
+ * The middle row is the normal one, not the first: a pin sits behind its branch
+ * tip except in the moments right after a bump, so the fast path is the
+ * exception and one rung is the steady state. Only the last row is expensive,
+ * it is a build that was failing anyway, and it is the only shape where a
+ * cheaper answer would be a guess.
  *
  * EXIT CODES
  *   0  both contracts hold
@@ -291,8 +294,17 @@ const checkPinReachable = ({ exec = execFileSync } = {}) => {
     const status = ancestryStatus();
 
     // A path that was found is real: grafts remove history, they never invent
-    // it. Terminal regardless of shallowness, and the reason the ladder is
-    // cheap — the common case never climbs.
+    // it. Terminal regardless of shallowness — which is what keeps the ladder
+    // cheap: it stops at the FIRST rung that finds a path.
+    //
+    // Not "the common case never climbs", which this comment said until
+    // 2026-08-05 while the measurement 30 lines up recorded the opposite. The
+    // resting state of a submodule pin is BEHIND its branch tip, not equal to
+    // it, so the fast path misses and the common case climbs exactly one rung.
+    // #840 is the live proof: its CI verdict reads `is an ancestor`, not `is
+    // the tip`. That is ~900ms and ~1MB every run, which is fine — but "never
+    // climbs" is the kind of premise someone later optimizes against, and the
+    // ladder is load-bearing rather than defensive. Caught by @sprint-review.
     if (status === 0) {
       return { state: 'contained', branch, pin, detail: `${short} is an ancestor of ${branch}` };
     }


### PR DESCRIPTION
Two comments in the reachability check claimed the fast path (`pin == tip`) is
the normal case. It isn't — and the measurement contradicting it was already in
the same function, thirty lines above the claim.

A submodule pin sits **behind** its branch tip except in the moments right after
a bump, so `pin == tip` misses and the steady state is exactly one `--deepen=64`
rung. #840 is the live proof: its CI verdict string reads `is an ancestor`, not
`is the tip`, so the fast path did not fire and the ladder carried the verdict.

**No behaviour change.** The ladder already did the right thing and the
exit-0-is-terminal test still holds. What was wrong is the premise filed
alongside it:

- `checkPinReachable` — "the common case never climbs" → stops at the first rung
  that finds a path; at rest that is one rung, ~900ms, ~1MB
- the `COST` table — at-rest row now marked as the normal one instead of listed
  under the exceptional case
- the matching test docblock, which repeated the claim as "never fetches
  anything"

It matters because the ladder is load-bearing rather than defensive: "never
climbs" is the kind of premise a later change optimizes against, deleting the
rung that is carrying every verdict.

Caught by @sprint-review, who reproduced the CI shape and read the exit status
rather than the comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)