### PR TITLE
fix(agents): the guard's scope was answering a question nobody re-asked

### DIFF
--- a/backend/__tests__/unit/scripts/moltbotToolContract.test.js
+++ b/backend/__tests__/unit/scripts/moltbotToolContract.test.js
@@ -14,13 +14,19 @@
  * than against invented ones.
  */
 
+const fs = require('fs');
+const path = require('path');
+
 const {
   parseDeclaredTools,
   collectRequiredTools,
   loadCyclesTrailer,
+  loadMentionCues,
   readDeclaredBranch,
   checkPinReachable,
   readGitlinkSha,
+  stripComments,
+  MENTION_CUES,
 } = require('../../../../scripts/verify-moltbot-tool-contract');
 
 // Shape lifted verbatim from extensions/commonly/src/tools.ts at both refs.
@@ -37,10 +43,14 @@ const PIN_SOURCE = [
   'commonly_react_to_message', 'commonly_read_agent_memory',
 ].map(declaration).join('\n');
 
-// rebase-2026.3.29 — has log_cycle + open_dm, lacks react_to_message
+// rebase-2026.3.29 — has log_cycle + open_dm + read_attachment, lacks
+// react_to_message. read_attachment and open_dm are listed because the
+// widened contract requires them (the mention cues name both); they are real
+// declarations on this lineage, not fixture padding.
 const BRANCH_SOURCE = [
   'commonly_post_message', 'commonly_get_messages', 'commonly_attach_file',
   'commonly_log_cycle', 'commonly_open_dm', 'commonly_save_my_memory',
+  'commonly_read_attachment',
 ].map(declaration).join('\n');
 
 describe('moltbot tool contract', () => {
@@ -77,7 +87,7 @@ describe('moltbot tool contract', () => {
       const declared = parseDeclaredTools(BRANCH_SOURCE);
       expect(declared.has('commonly_log_cycle')).toBe(true);
       expect(declared.has('commonly_react_to_message')).toBe(false);
-      expect(declared.size).toBe(6);
+      expect(declared.size).toBe(7);
     });
 
     // The whole investigation turned on this distinction. `presets.ts` asserted
@@ -107,8 +117,14 @@ describe('moltbot tool contract', () => {
       return [...collectRequiredTools().keys()].filter((t) => !declared.has(t));
     };
 
+    // Three, not one. The trailer-only contract caught commonly_log_cycle;
+    // widening to the mention cues catches two more that the old pin also
+    // lacked and every agent was told on every mention to call. Measured
+    // against the real 00821479 tool block on 2026-08-05.
     it('FAILS against the pin — this is the live regression', () => {
-      expect(missingFrom(PIN_SOURCE)).toEqual(['commonly_log_cycle']);
+      expect(missingFrom(PIN_SOURCE)).toEqual([
+        'commonly_log_cycle', 'commonly_read_attachment', 'commonly_open_dm',
+      ]);
     });
 
     it('PASSES against the branch', () => {
@@ -121,6 +137,97 @@ describe('moltbot tool contract', () => {
     // pin moved — which is the event this whole check exists to catch.
     it('is not vacuous: the two lineages give different verdicts', () => {
       expect(missingFrom(PIN_SOURCE)).not.toEqual(missingFrom(BRANCH_SOURCE));
+    });
+  });
+
+  /**
+   * The mention cues — the wide surface. The trailer reaches an agent once a
+   * heartbeat; these reach every agent on every mention. Widening the contract
+   * to them is only safe because of the driver-scoped exclusion, and these
+   * tests exist mostly to keep that exclusion from becoming a hole.
+   */
+  describe('inline mention cues', () => {
+    const cueText = loadMentionCues();
+
+    it('reads the live cues rather than a restatement of them', () => {
+      // Control: an extraction that silently returned '' would satisfy every
+      // "does not require X" assertion below by emptiness.
+      expect(cueText.length).toBeGreaterThan(1000);
+      expect(cueText).toContain('[Pod context:');
+      expect(cueText).toContain('[Reply mechanics:');
+    });
+
+    it('requires the tools the cues tell every agent to call', () => {
+      const required = collectRequiredTools();
+      ['commonly_attach_file', 'commonly_read_attachment', 'commonly_post_message',
+        'commonly_get_messages', 'commonly_open_dm'].forEach((tool) => {
+        expect([...required.keys()]).toContain(tool);
+      });
+      expect(required.get('commonly_open_dm')).toMatch(/mention cues/i);
+    });
+
+    // The reason a naive widening is wrong. These are MCP names, deliberately
+    // present beside their openclaw counterpart because the cue ships to every
+    // seat. Requiring them of an openclaw pin reds a correct line.
+    it('does not require the MCP names the cues address to other drivers', () => {
+      const required = [...collectRequiredTools().keys()];
+      expect(required).not.toContain('commonly_read_file');
+      expect(required).not.toContain('commonly_dm_agent');
+    });
+
+    // ...and the exclusion has to stay earned. Both names must still be in the
+    // delivered text; an exemption for a tool no longer mentioned is a hole
+    // that would silently excuse a future, genuine requirement.
+    it('exempts only names that actually appear in the cues', () => {
+      expect(cueText).toContain('commonly_read_file');
+      expect(cueText).toContain('commonly_dm_agent');
+    });
+
+    // Both halves of each pair must be present, or the cue is telling one
+    // driver class to call something it does not have — the original defect.
+    it('keeps each capability named under BOTH driver namespaces', () => {
+      expect(cueText).toContain('commonly_read_attachment');
+      expect(cueText).toContain('commonly_open_dm');
+    });
+
+    it('ignores tool names that appear only in comments', () => {
+      // agentMentionService.ts discusses tools at length in comments,
+      // including ones that deliberately do not exist on the pinned lineage.
+      // A comment is not delivered to an agent and must not become a
+      // requirement.
+      const src = [
+        '// discussion of `commonly_ghost_tool` that no runtime declares',
+        '/* commonly_block_comment_tool */',
+        'const formatThingCue = (): string =>',
+        '  `[Thing: call commonly_real_tool to do the thing. '
+        + 'Padding so the region clears the non-vacuity floor for slicing.]`;',
+        '',
+        'const next = 1;',
+      ].join('\n');
+      const stripped = stripComments(src);
+      expect(stripped).toContain('commonly_real_tool');
+      expect(stripped).not.toContain('commonly_ghost_tool');
+      expect(stripped).not.toContain('commonly_block_comment_tool');
+      // Blanking, not deleting: line structure survives so `^const` anchors
+      // still land where they did in the original.
+      expect(stripped.split('\n')).toHaveLength(src.split('\n').length);
+    });
+
+    it('does not treat a URL as a line comment', () => {
+      expect(stripComments('const u = "https://example.com/commonly_x";'))
+        .toContain('commonly_x');
+    });
+
+    // The coverage-gap guard. A cue added and not registered would ship tool
+    // names nobody checks, and the check would still print OK — which is the
+    // failure mode this whole file exists to prevent, reproduced inside it.
+    it('every cue the service defines is registered', () => {
+      const servicePath = path.join(__dirname, '../../../services/agentMentionService.ts');
+      const src = fs.readFileSync(servicePath, 'utf8');
+      const defined = (stripComments(src).match(/^const (format[A-Za-z]*(?:Cue|Frame))\b/gm) || [])
+        .map((m) => m.replace('const ', ''));
+      expect(defined.length).toBeGreaterThan(0);
+      expect(defined.sort()).toEqual([...MENTION_CUES].sort());
     });
   });
 

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -439,9 +439,20 @@ const formatPodContextFrame = (podId: string): string =>
 // consult a specialist via 1:1 DM instead of refusing capability.
 // The DM opener has TWO names, one per driver class, and this cue used
 // to name only openclaw's. `commonly_open_dm` is the openclaw-extension
-// tool (live since 11878b43c); `@commonlyai/mcp` exposes the same
-// capability as `commonly_dm_agent` (docs/MCP_INTEGRATION.md §Pods +
-// agent network). Since this frame ships to every agent unconditionally,
+// tool; `@commonlyai/mcp` exposes the same capability as
+// `commonly_dm_agent` (docs/MCP_INTEGRATION.md §Pods + agent network).
+//
+// This comment used to source the openclaw half to "live since
+// 11878b43c" — a commit on the lineage `.gitmodules` DECLARED, not the
+// one the gitlink tracked, so the tool was in fact absent from the
+// running gateway for the 88 days ending 2026-08-05. It is present now
+// (pin 70bd82b8 declares it), which is why the sentence read true
+// without ever having been checked. No ref is cited here any more on
+// purpose: scripts/verify-moltbot-tool-contract.js reads this cue and
+// the pinned tool block on every CI run, so the claim has a reader
+// instead of a citation. If that check is ever removed, this line goes
+// back to being a guess.
+// Since this frame ships to every agent unconditionally,
 // naming one namespace tells the other half of the fleet to call
 // something they do not have — the ADR-005 wrapper and cloud-codex seats
 // are all MCP consumers. Name both, or condition on driver class; the

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -429,3 +429,61 @@ name the live artifact that would falsify it.
 submodule line, the `is an ancestor` verdict string) are taken from their
 message; they are consistent with my own measurement of the same shape, which
 is corroboration rather than independent confirmation.
+
+---
+
+## 15. The guard's scope silently defined what counted as checked (2026-08-05, pod-architect)
+
+**Surface:** `scripts/verify-moltbot-tool-contract.js` — the check that fires
+when a submodule bump swaps the openclaw lineage out from under a tool the
+fleet is told to call.
+
+The guard shipped (#843) reading exactly one source of agent-facing text: the
+cycles reflection trailer. That was a deliberate, stated scope — #818 and #842
+were open on the inline mention cues at the time, and a guard straddling an
+open PR is a merge conflict rather than a safeguard. The header said so, and
+named widening as the next step.
+
+What the scope choice also did, silently, was define the answer to "is the
+fleet being told to call tools it does not have?" as **one tool**. That number
+was load-bearing: it appears in `CLAUDE.md`, in the PR body, in the pod
+discussion, and in this file. Nobody re-derived it after the guard existed,
+because the guard printed OK.
+
+Widening to the mention cues and re-running against the OLD pin (`00821479`,
+what was live until today's deploy) gives:
+
+```
+required: log_cycle  attach_file  read_attachment  post_message  get_messages  open_dm
+MISSING at 00821479: log_cycle    read_attachment              open_dm
+```
+
+**Three, not one.** `commonly_open_dm` had been named to openclaw seats by the
+consultation cue — every mention, every agent — while the pinned extension did
+not declare it. That is the same defect as `commonly_log_cycle`, on a surface
+about 100× wider than the heartbeat, and it went uncounted for the same 88
+days. It was independently known (`CLAUDE.md` records the tool as absent from
+the running gateway) without anyone connecting it to the cue that demanded it.
+
+**Lesson:** a check's scope is a claim about the world in the shape of a
+silence. "The trailer names one missing tool" reads, once the check is green,
+as "one tool is missing" — and the narrower the scope, the more confidently the
+green is over-read. When you scope a check deliberately, the scope belongs in
+the *output*, not only in a header comment: the OK line should say what it did
+not look at. Widen on the stated trigger, and when you do, **re-run the widened
+check against the state the narrow one blessed** — the interesting number is
+what the old scope was not counting.
+
+**Corollary, on why the widening needed care:** the naive version reds on a
+correct line. The cues name `commonly_read_file` and `commonly_dm_agent` (MCP)
+beside `commonly_read_attachment` and `commonly_open_dm` (openclaw), because
+they ship to every seat and entry #13 in this file is the incident that put
+both names there. Demanding an MCP name of an openclaw pin punishes the fix.
+The exemption is therefore driver-scoped *and* self-checking: a name exempted
+but no longer present in the cue is a hard error, because an exemption that
+outlives its justification is a hole that would excuse the next real violation.
+
+**Not verified:** that no OTHER agent-facing surface names an undeclared tool.
+Two sources are covered now (trailer, mention cues); registry presets beyond
+the trailer, MCP tool descriptions, and the agent-runtime `context` payload are
+not, and nothing yet reports that they are not.

--- a/scripts/verify-moltbot-tool-contract.js
+++ b/scripts/verify-moltbot-tool-contract.js
@@ -26,12 +26,22 @@
  * about another repo's state does not get fixed; it decays, and prose has no
  * mechanism to notice.
  *
- * WHAT IT CHECKS. Every `commonly_*` tool the cycles trailer tells an agent to
- * call must be declared in the pinned extension's tool block. Scoped to the
- * trailer on purpose: the inline mention cues in `agentMentionService.ts` are
- * being changed on #818, and a guard that straddles an open PR is a merge
- * conflict rather than a safeguard. Widening it to those cues is the obvious
- * next step once #818 lands — see WIDENING below.
+ * WHAT IT CHECKS. Every `commonly_*` tool an agent is TOLD to call must be
+ * declared in the pinned extension's tool block. Two sources of such text
+ * today: the cycles reflection trailer (per heartbeat) and the inline mention
+ * cues in `agentMentionService.ts` (every mention, every agent). The second is
+ * by far the wider surface and was the last to be covered — it was left out
+ * originally only because #818/#842 were open on those exact lines and a guard
+ * straddling an open PR is a merge conflict rather than a safeguard.
+ *
+ * NOT EVERY NAMED TOOL IS THE PIN'S RESPONSIBILITY. Some cues name a capability
+ * under BOTH driver namespaces because they ship to every seat unconditionally
+ * — `commonly_read_file` (MCP) beside `commonly_read_attachment` (openclaw),
+ * `commonly_dm_agent` beside `commonly_open_dm`. Demanding the MCP name of an
+ * openclaw pin would red the build over a line that is deliberately correct, so
+ * a source declares those in `namedForOtherDrivers` and they are excluded.
+ * The exclusion is itself checked: a name listed there that no longer appears
+ * in the cue is a hard error, so the list cannot quietly grow into a hole.
  *
  * WHAT IT ALSO CHECKS. That the pinned commit is contained in the branch
  * `.gitmodules` declares. That is a separate invariant on the same subject and
@@ -66,7 +76,10 @@
  * loudly rather than folding it into success.
  *
  * WIDENING: add a source to REQUIRED_TOOL_SOURCES. Each entry supplies the
- * text an agent receives; every `commonly_*` token in it becomes required.
+ * text an agent receives; every `commonly_*` token in it becomes required,
+ * except names it lists in `namedForOtherDrivers`. Supply text by reading the
+ * live source of truth, never by restating it here — a restated cue drifts
+ * from the delivered one and the guard then defends a string nobody receives.
  */
 
 const fs = require('fs');
@@ -93,8 +106,89 @@ const loadCyclesTrailer = () => {
   return raw.slice(bodyStart, end);
 };
 
+const MENTION_SERVICE = path.join(REPO_ROOT, 'backend', 'services', 'agentMentionService.ts');
+
+/**
+ * The inline cues prepended to `chat.mention.payload.content`, in delivery
+ * order. Registered by name rather than discovered, because a cue that names a
+ * tool must be a deliberate entry on this list — but see the inventory check
+ * below, which makes forgetting to register one an error instead of a silent
+ * gap in coverage.
+ */
+const MENTION_CUES = [
+  'formatPodContextFrame',
+  'formatAuthorFrame',
+  'formatCollaborativePodCue',
+  'formatConsultationCue',
+  'formatMentionReplyCue',
+];
+
+/**
+ * Blank a comment out rather than deleting it, so every later offset and
+ * line-start anchor still lands where it did in the original text.
+ */
+const blankOut = (text) => text.replace(/[^\n]/g, ' ');
+
+/**
+ * Comments are NOT delivered to agents, and this file's comments discuss tools
+ * at length — including backticked names of tools that deliberately do not
+ * exist on the pinned lineage. Counting one would red the build over a
+ * paragraph. The `[^:]` guard keeps `https://` from being read as a comment.
+ */
+const stripComments = (src) => src
+  .replace(/\/\*[\s\S]*?\*\//g, blankOut)
+  .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) => lead + blankOut(m.slice(lead.length)));
+
+/**
+ * The text of every inline mention cue, concatenated. Read from the live
+ * service for the same reason loadCyclesTrailer reads presets.ts: a cue that
+ * starts naming a different tool is covered without anyone remembering to
+ * come back here.
+ */
+const loadMentionCues = () => {
+  const code = stripComments(fs.readFileSync(MENTION_SERVICE, 'utf8'));
+
+  // Inventory: a cue added and not registered would be uncovered, and an
+  // uncovered surface reads exactly like a passing one. Fail instead.
+  const present = (code.match(/^const (format[A-Za-z]*(?:Cue|Frame))\b/gm) || [])
+    .map((m) => m.replace(/^const /, ''));
+  const unregistered = present.filter((name) => !MENTION_CUES.includes(name));
+  if (unregistered.length) {
+    throw new Error(
+      `agentMentionService.ts defines mention cues this check does not know about: `
+      + `${unregistered.join(', ')}. Add them to MENTION_CUES — a cue outside the list `
+      + 'ships tool names no one is checking.',
+    );
+  }
+
+  return MENTION_CUES.map((name) => {
+    const start = code.indexOf(`\nconst ${name}`);
+    if (start === -1) throw new Error(`${name} not found in agentMentionService.ts`);
+    // To the next top-level declaration; the cues are one-per-region and this
+    // holds for both arrow-expression and block bodies (formatAuthorFrame).
+    const rest = code.slice(start + 1);
+    const end = rest.search(/\n(?:const|export|function) /);
+    const body = end === -1 ? rest : rest.slice(0, end);
+    // A region that sliced to nothing would contribute no tool names and look
+    // exactly like a cue that names none.
+    if (body.length < 80) {
+      throw new Error(`${name} sliced to ${body.length} chars — the region shape has changed`);
+    }
+    return body;
+  }).join('\n');
+};
+
 const REQUIRED_TOOL_SOURCES = [
   { name: 'cycles reflection trailer (presets.ts)', text: loadCyclesTrailer },
+  {
+    name: 'inline mention cues (agentMentionService.ts)',
+    text: loadMentionCues,
+    // Named on purpose for NON-openclaw seats, alongside the openclaw name for
+    // the same capability. These are MCP tools; the pin neither has nor owes
+    // them. Every entry is asserted to still appear in the cue text below, so
+    // this list cannot outlive the line that justified it.
+    namedForOtherDrivers: ['commonly_read_file', 'commonly_dm_agent'],
+  },
 ];
 
 /** Every `commonly_*` token an agent is told to call, across all sources. */
@@ -102,7 +196,24 @@ const collectRequiredTools = () => {
   const required = new Map();
   REQUIRED_TOOL_SOURCES.forEach((source) => {
     const text = typeof source.text === 'function' ? source.text() : source.text;
-    (text.match(/commonly_[a-z_]+/g) || []).forEach((tool) => {
+    const named = text.match(/commonly_[a-z_]+/g) || [];
+
+    // An exemption for a name the source no longer mentions is a hole with no
+    // remaining justification — and it would keep excusing that tool if a cue
+    // later started requiring it for real. Same reasoning as the empty-parse
+    // control in main(): a check must not pass by having nothing to look at.
+    (source.namedForOtherDrivers || []).forEach((tool) => {
+      if (!named.includes(tool)) {
+        throw new Error(
+          `${source.name} lists ${tool} in namedForOtherDrivers, but the source no longer `
+          + 'names it. Delete the exemption rather than leaving it to excuse a future use.',
+        );
+      }
+    });
+
+    const exempt = new Set(source.namedForOtherDrivers || []);
+    named.forEach((tool) => {
+      if (exempt.has(tool)) return;
       if (!required.has(tool)) required.set(tool, source.name);
     });
   });
@@ -374,7 +485,21 @@ const checkPinReachable = ({ exec = execFileSync } = {}) => {
 };
 
 const main = () => {
-  const required = collectRequiredTools();
+  let required;
+  try {
+    required = collectRequiredTools();
+  } catch (err) {
+    // Every throw on this path means the guard could not read what agents are
+    // told — a stale exemption, an unregistered cue, a moved region. That is
+    // "cannot verify" (2), not "contract violated" (1), and emphatically not
+    // an uncaught stack trace that a CI reader would mistake for either.
+    console.error(
+      `[moltbot-tool-contract] CANNOT VERIFY — could not derive the required tool set.\n`
+      + `  ${err.message}\n`
+      + '  Exiting 2. The check did not run; it did not pass.',
+    );
+    process.exit(2);
+  }
   const pin = readGitlinkSha();
 
   if (!fs.existsSync(EXTENSION_TOOLS)) {
@@ -443,10 +568,16 @@ const main = () => {
       + '  openclaw main, then pin that.',
     );
   } else {
+    // Name the sources in the PASS line, not only in a header comment. A green
+    // check is read as "nothing is wrong", and the narrower the scope the more
+    // confidently that is over-read — for two months this printed OK over a
+    // surface it had never been pointed at. The scope belongs in the output.
     console.log(
       `[moltbot-tool-contract] OK — pin ${pin} declares ${declared.size} commonly_* tools, `
       + `including all ${required.size} the fleet is instructed to call `
-      + `(${[...required.keys()].join(', ')}).`,
+      + `(${[...required.keys()].join(', ')}).\n`
+      + `  Sources read: ${REQUIRED_TOOL_SOURCES.map((s) => s.name).join('; ')}.\n`
+      + '  Agent-facing text outside those sources is NOT covered by this result.',
     );
   }
 
@@ -463,6 +594,7 @@ const main = () => {
 if (require.main === module) main();
 
 module.exports = {
-  parseDeclaredTools, collectRequiredTools, loadCyclesTrailer, readDeclaredBranch, checkPinReachable,
-  readGitlinkSha,
+  parseDeclaredTools, collectRequiredTools, loadCyclesTrailer, loadMentionCues,
+  readDeclaredBranch, checkPinReachable, readGitlinkSha,
+  MENTION_CUES, REQUIRED_TOOL_SOURCES, stripComments,
 };


### PR DESCRIPTION
Widens `scripts/verify-moltbot-tool-contract.js` from one source of agent-facing text to two — the trigger #843 named, now that #842 has landed on the lines in question.

## The finding this produced

The guard shipped reading only the cycles reflection trailer. That scope was deliberate and documented. What it *also* did was fix the answer to "how many tools is the fleet told to call that its runtime doesn't have?" at **one** — a number that reached `CLAUDE.md`, three PR bodies and the audit doc, and that nobody re-derived once the check went green.

Re-running the widened contract against `00821479`, the pin that was live until today's deploy:

```
required:  log_cycle  attach_file  read_attachment  post_message  get_messages  open_dm
MISSING:   log_cycle             read_attachment                              open_dm
```

**Three, not one.** `commonly_open_dm` was named to openclaw seats by the consultation cue — on *every mention, to every agent* — while the pinned extension did not declare it. Same defect as `commonly_log_cycle`, on a surface roughly 100× wider than the heartbeat, uncounted for the same 88 days. Its absence was independently known (`CLAUDE.md` records it); nothing connected it to the cue demanding it.

## Why the naive widening would be wrong

The cues name `commonly_read_file` and `commonly_dm_agent` (MCP) **beside** `commonly_read_attachment` and `commonly_open_dm` (openclaw), because they ship to every seat unconditionally. That pairing is the fix from #842 and audit entry #13. Feeding the cue through the contract unchanged would demand an MCP tool of an openclaw pin and red the build over a line that is deliberately correct — a guard that reds on the fix is worse than no guard.

So a source declares `namedForOtherDrivers`, and **the exemption is itself checked**: a name listed there that no longer appears in the cue is a hard error. An exemption that outlives its justification is a hole that would go on excusing the next real violation.

## Failure directions, verified by mutation against the live files

Not asserted in a test — mutated, run, restored, restore confirmed:

| mutation | exit | |
|---|---|---|
| a cue starts naming an unclassified tool | **1** | FAIL, attributed to the cue |
| an exempted name is removed from the cue | **2** | CANNOT VERIFY, names the stale entry |
| a new cue is defined but not registered | **2** | CANNOT VERIFY, names the cue |

The third is the coverage-gap guard. Without it a new cue ships tool names nobody checks while the guard still prints OK — this PR's own defect, reproduced inside the fix for it. Throws from the source layer now exit 2 instead of crashing out as 1: could-not-read is not contract-violated.

## Also

- **The PASS line now names the sources it read and states what it did not cover.** Same reasoning: a green check is read as "nothing is wrong", and the narrower the scope the more confidently that is over-read.
- **Drops `live since 11878b43c`** from the consultation cue's comment. That commit is on the lineage `.gitmodules` *declared*, not the one the gitlink tracked — the sentence was false for 88 days and is true today only because the pin moved. No ref replaces it: this check reads that cue on every CI run, so the claim has a reader instead of a citation.
- Audit entry #15.

## Test

```
guard suite            35 pass, 0.7s
agentMentionService    87 pass (both suites together)
live run               exit 0 — 6 required, all declared at 70bd82b8
lint                   clean
```

**Not verified:** that no *other* agent-facing surface names an undeclared tool. Two sources are covered; registry presets beyond the trailer, MCP tool descriptions, and the agent-runtime `context` payload are not — and nothing yet reports that they aren't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)