### PR TITLE
fix(mentions): present and callable is still not working

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -1276,6 +1276,19 @@ describe('AgentMentionService', () => {
        * name, which is the behaviour this whole line exists to prevent.
        */
       expect(content).toMatch(/or the call fails/i);
+
+      /**
+       * ...and the THIRD state, which is neither absence nor failure.
+       *
+       * Probed on the deployed gateway (934df6de) 2026-08-05: markitdown is
+       * installed without extras, so a valid PNG converts to exit 0 and zero
+       * bytes. Nothing throws, nothing is missing, the status code says
+       * success. The agent receives "" and reports the file as blank —
+       * a specific false statement, not a vague one, which is why the cue
+       * names it rather than only saying "you have no reader".
+       */
+      expect(content).toMatch(/returns nothing/i);
+      expect(content).toMatch(/reporting the file as empty/i);
     });
 
     /**

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -410,6 +410,27 @@ const autoJoinAgentToPod = async (
 // handles absence leaves the agent hunting for another name, which is the
 // exact behaviour this line exists to prevent.
 //
+// THIRD STATE — "or it returns nothing". Present and callable is still not
+// working. Probed against the deployed gateway 2026-08-05, image 934df6de,
+// on a valid 1x1 PNG (magic bytes asserted in the probe, because a first
+// attempt with random bytes was a fixture that could itself explain the
+// result):
+//
+//   markitdown probe.ts   exit 0, correct content
+//   markitdown real.png   exit 0, ZERO bytes
+//
+// The image installs `pip3 install markitdown pypdf` with no extras, so
+// there is no image converter and markitdown succeeds at producing nothing.
+// That is neither absence nor failure: nothing throws, nothing is missing,
+// the status code is 0. An agent handed "" does not conclude "I cannot read
+// images" — it concludes the image is blank, and reports that confidently.
+// Hence "or reporting the file as empty": the failure mode being prevented
+// is a specific false statement, not a general vagueness.
+//
+// This costs a genuinely-empty attachment a false "I could not read it".
+// That trade is deliberate — an empty upload is rare, a format outside the
+// extras is not, and only one of the two errors is silent.
+//
 // Same defect as the heartbeat cue's rolled-back `commonly_save_my_memory`
 // shape (PR #818), one layer up and on a far wider surface: heartbeats are
 // per-tick, this is every mention to every agent.
@@ -418,9 +439,9 @@ const formatPodContextFrame = (podId: string): string =>
   `When attaching files, call commonly_attach_file({ podId: "${podId}", filePath, message }). ` +
   `When reading files referenced via [[upload:fileName|...]] in this thread, call ` +
   `commonly_read_file({ podId: "${podId}", fileName }) — or commonly_read_attachment({ fileName }) ` +
-  `on openclaw runtimes. If you have neither, or the call fails, you have no working reader ` +
-  `here: say so and ask whoever posted it to paste the content inline, rather than hunting ` +
-  `for another name. ` +
+  `on openclaw runtimes. If you have neither, or the call fails, or it returns nothing, you ` +
+  `have no working reader here: say so and ask whoever posted it to paste the content inline, ` +
+  `rather than hunting for another name or reporting the file as empty. ` +
   `Post as yourself only: reply text is delivered under your own agent identity, and any ` +
   `mid-turn post must use your own runtime token (commonly_post_message / your token file). ` +
   `Never post through an operator's CLI profile (\`commonly pod send\`) or a human user's ` +


### PR DESCRIPTION
The read cue handles two states — *you have no reader*, or *the call fails*. There is a third, and it's the one that makes an agent say something specific and false.

## Evidence

Probed against the gateway deployed today (`934df6de`), after the rebuild that finally put the extractors in the image:

```
markitdown probe.ts   → exit 0, correct content
markitdown real.png   → exit 0, ZERO bytes      (valid PNG, magic bytes asserted)
```

The image runs `pip3 install markitdown pypdf` with **no extras**, so there is no image converter and markitdown succeeds at producing nothing. Nothing throws, nothing is missing, the status code is 0.

An agent handed `""` does not conclude *"I can't read images."* It concludes **the image is blank**, and reports that confidently to whoever uploaded it.

## The change

```diff
-on openclaw runtimes. If you have neither, or the call fails, you have no working reader
-here: say so and ask whoever posted it to paste the content inline, rather than hunting
-for another name.
+on openclaw runtimes. If you have neither, or the call fails, or it returns nothing, you
+have no working reader here: say so and ask whoever posted it to paste the content inline,
+rather than hunting for another name or reporting the file as empty.
```

The second clause is doing real work. `"you have no working reader"` alone does not stop an agent that believes it *succeeded* — it has to be told that the specific conclusion "the file is empty" is the wrong one.

**Cost, stated:** a genuinely-empty attachment now gets a false *"I couldn't read it."* Deliberate trade — an empty upload is rare, a format outside the extras is not, and only one of those two errors is silent.

## Scope

The other half is upstream: `pip3 install markitdown[all]` in the openclaw Dockerfile. That needs a PR there plus a pin bump, so it inherits the whole lineage problem documented in `CLAUDE.md`. **This half protects agents while that is outstanding**, and is worth having regardless — extras will never cover every format either.

## Method note

The first run of this probe used random bytes as the `.png` — an invalid fixture that could itself explain an empty result. Discarded and re-run with a base64 1×1 PNG asserting magic bytes in the probe. The result held.

## Test

```
agentMentionService + guard   87 pass
verify:moltbot-tools          exit 0 — 6 required, all declared at 70bd82b8
```

Two assertions added to the existing skip-clause test (`returns nothing`, `reporting the file as empty`), alongside the `or the call fails` one from #842.

**Not verified:** whether `markitdown[all]` would extract anything *useful* from a real screenshot versus EXIF noise. I tested a 1×1 pixel, which proves the empty-return path exists and says nothing about extraction quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)