### PR TITLE
docs(backend): "same version as the gateway image" was never checkable

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,9 +3,32 @@ FROM node:18
 WORKDIR /app
 
 # OfficeCLI binary — used by the PPTX preview route to render .pptx → HTML
-# server-side. Same upstream + version as the gateway image. Pinned with
-# SHA256 verification against the release's SHA256SUMS artifact so a future
-# upstream artifact swap fails the build instead of silently shipping.
+# server-side. Pinned with SHA256 verification against the release's
+# SHA256SUMS artifact so a future upstream artifact swap fails the build
+# instead of silently shipping.
+#
+# This comment used to add "Same upstream + version as the gateway image."
+# Same upstream, yes. Same version, no — and it cannot be, because the
+# gateway does not pin. openclaw's Dockerfile pulls
+# `releases/latest/download/${asset}` with no version and no checksum, so
+# "same version" was true at most on the day it was written and drifts every
+# time upstream publishes. Measured against both running containers
+# 2026-08-05:
+#
+#   backend  (this file, pinned)      1.0.70
+#   gateway  (openclaw, `latest`)     1.0.143   ← upstream latest, 2026-07-28
+#
+# Seventy-three releases apart, in one system, for the same file formats: this
+# image renders .pptx for the preview route, the gateway extracts .docx/.pptx
+# for commonly_read_attachment. Do not reason about one from the other.
+#
+# Deliberately not "fixed" by bumping to 1.0.143 — the pin is doing its job,
+# and matching a floating target once just restarts the drift. The real fix is
+# upstream pinning + checksum in openclaw's Dockerfile, which needs a PR there
+# and a submodule bump; see the pin-skew entry in CLAUDE.md for why that is
+# not a one-liner. Until then the divergence is a known, measured fact rather
+# than a claim of sameness, and `officecli --version` in each container is the
+# check that keeps it honest.
 ARG OPENCLAW_OFFICECLI_VERSION=1.0.70
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
     ARCH="$(uname -m)" && \


### PR DESCRIPTION
> **Implements item 2 of #846.** The finding — floating `latest` in the gateway, the false "same version" claim, and the 73-release gap — was established by @sprint-review in the pod (52725, 52728) and filed as #846 at 20:06:55Z, *before* I re-derived it independently at 20:22. I did not know that when I opened this; my framing of it as my discovery was wrong. What this PR adds is the code change #846 deferred as "a diversion from the finish line" — item 1 (upstream pinning) is still open there.

---


The comment on our pinned OfficeCLI block claimed **"Same upstream + version as the gateway image."** Same upstream holds. Same version does not — and structurally could not, because the gateway doesn't pin.

## Measured, not inferred

```
backend  (this file, pinned)     1.0.70
gateway  (openclaw, `latest`)    1.0.143     ← upstream latest, published 2026-07-28
```

`kubectl exec … officecli --version` against both running containers. **Seventy-three releases apart, in one system, for the same file formats** — this image renders `.pptx` for the preview route; the gateway extracts `.docx`/`.pptx` for `commonly_read_attachment`.

openclaw's Dockerfile pulls `releases/latest/download/${asset}` with no version and no checksum, so "same version" was true at most on the day it was written and drifts every time upstream publishes.

## Provenance

@sprint-review noticed, reading a single deploy log, that the two `officecli` install blocks don't match — one pins a version and verifies against the release's `SHA256SUMS`, the other pulls `latest` and `chmod +x`. They explicitly flagged which-image-is-which as unresolved.

It resolves as **ours / theirs**:

| build log | file | shape |
|---|---|---|
| `#8 [3/10]` | `backend/Dockerfile` — single `FROM`, so buildkit numbers steps `[N/10]` | pinned + `sha256sum -c` |
| `#37 [stage-4 17/19]` | openclaw's `Dockerfile` — 5 `FROM`s, block guarded by the `OPENCLAW_INSTALL_DOC_TOOLCHAIN` ARG | `latest`, no checksum |

We hardened ours in #306 ("so a future upstream artifact swap fails the build instead of silently shipping") and **the hardening was never carried upstream** — which is also why the comment could assert sameness without anyone noticing it had stopped being true.

## What this PR does not do

**Not bumping to 1.0.143.** The pin is doing its job; matching a floating target once just restarts the drift. The real fix is pinning + checksum in openclaw's `Dockerfile`, which needs a PR there plus a submodule bump, so it inherits the lineage problem documented in `CLAUDE.md`. Worth an upstream issue once tonight's chain lands — @sprint-review's call, and I agree it shouldn't divert now.

Until then the divergence is recorded as a **measured fact** rather than a claim of sameness, with the check named (`officecli --version` in each container).

Comment-only; no build behaviour changes.

**Not verified:** whether 1.0.70 → 1.0.143 actually changes `.pptx`/`.docx` output for the files we handle. The versions differ; whether the *behaviour* does is a separate question I did not test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
