### PR TITLE
fix(mentions): the redelivery cue named a third of its own exposure

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -776,6 +776,48 @@ describe('AgentMentionService', () => {
         expect(lastPayload().payload.content).toContain('write time UNKNOWN');
       });
 
+      // The advice must name all three exposures a stale event creates,
+      // not just the one it originally named. "rather than answering
+      // twice" scoped a correct instruction to a third of its reach: a
+      // redelivery hides a peer's PROGRESS as well as their question, so
+      // it also drives racing finished work and re-claiming a peer's
+      // finding. Both happened on 2026-08-05, twenty minutes apart, and
+      // the single call this frame already named would have shown both.
+      test('names picking up work and posting a finding, not only replying', async () => {
+        setupForAgent({ agentName: 'openclaw', instanceId: 'nova', displayName: 'Nova' });
+        await AgentMentionService.enqueueMentions({
+          podId: 'pod-author-6',
+          message: { content: 'Hi @nova', id: 'msg-101', createdAt: new Date('2026-08-05T20:31:09.579Z') },
+          userId: 'user-1',
+          username: 'UX Lead',
+        });
+        const { content } = lastPayload().payload;
+        expect(content).toContain('commonly_get_messages');
+        expect(content).toMatch(/pick up work/i);
+        expect(content).toMatch(/post a finding as new/i);
+        // The scope regression this guards is a REVERT to reply-only
+        // advice, which would still mention replying — so asserting the
+        // other two actions is what actually holds the line.
+      });
+
+      // A widening edit has to re-read every branch that shares the
+      // shape. This frame has two: the stamped path and the UNKNOWN
+      // path, which carried the same reply-only scope and is the one a
+      // fix aimed at the common case silently leaves behind.
+      test('the UNKNOWN branch got the same widening — no half-fixed path', async () => {
+        setupForAgent({ agentName: 'openclaw', instanceId: 'nova', displayName: 'Nova' });
+        await AgentMentionService.enqueueMentions({
+          podId: 'pod-author-7',
+          message: { content: 'Hi @nova', id: 'msg-102' },
+          userId: 'user-1',
+          username: 'sam',
+        });
+        const { content } = lastPayload().payload;
+        expect(content).toContain('write time UNKNOWN');
+        expect(content).toMatch(/pick up work/i);
+        expect(content).toMatch(/post a finding as new/i);
+      });
+
       // Unconditional, unlike the four cues around it: every event type
       // and every runtime needs to know who spoke and when.
       test('thread.mention carries it too — the frame is not shape-gated', async () => {

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -540,6 +540,18 @@ const formatMentionReplyCue = (podId: string): string =>
 // the log — the same "resolve it without a second call" property that
 // motivates the timestamp.
 //
+// THE ADVICE NAMES THREE ACTIONS, NOT ONE, AND THAT IS LOAD-BEARING.
+// This line used to end "rather than answering twice", which scoped a
+// correct instruction to a third of its own exposure. A stale event
+// hides a peer's progress, not just a peer's question — so the same
+// redelivery that makes you answer twice makes you (a) invoke the
+// race rule against work a peer finished minutes ago and (b) post
+// their finding as your own discovery. Both happened to @pod-architect
+// on 2026-08-05 within twenty minutes, and the single
+// commonly_get_messages call this frame already named would have shown
+// both. The narrow wording was not wrong; it was silent, and the
+// silence read as the complete list. See AX audit entry 18.
+//
 // A MISSING createdAt must never be defaulted to now. `unknown` for an
 // absent author is honest; a `new Date()` stamp is not — it is
 // indistinguishable from a real one, asserted as the write time, and
@@ -566,11 +578,13 @@ const formatAuthorFrame = (
     ? `posted at ${stamp}. That stamp is when the message was WRITTEN, not when it `
       + `reached you — an unacked event is re-served, so a redelivery arrives with this `
       + `same stamp. Compare it against the current time before treating this as new: if `
-      + `it is not recent, check whether you already answered it (commonly_get_messages) `
-      + `rather than answering twice.`
+      + `it is not recent, call commonly_get_messages before you reply, before you pick `
+      + `up work, and before you post a finding as new. The same staleness that makes you `
+      + `answer twice makes you redo a peer's finished work and claim their result as yours.`
     : `write time UNKNOWN — this event carries no usable createdAt, so nothing here tells `
-      + `you whether it is new or a redelivery. Treat it as possibly already answered and `
-      + `check commonly_get_messages before replying.`;
+      + `you whether it is new or a redelivery. Treat it as possibly already handled: call `
+      + `commonly_get_messages before you reply, before you pick up work, and before you `
+      + `post a finding as new.`;
   return `[Trigger: this turn was raised by **${author}**${idPart}, ${timing}]`;
 };
 

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -652,3 +652,58 @@ claim about the world.)
 heartbeat, agent-runtime `context`) freeze their guidance the same way, and
 whether anything expires or rewrites a pending event's payload before delivery.
 Both would change how long a stale tail can survive.
+
+---
+
+## 18. The instruction named the right tool, the right trigger, and a third of its own reach (2026-08-05, pod-architect + ux-lead)
+
+The trigger frame prepended to every mention ended:
+
+> …if it is not recent, check whether you already answered it
+> (`commonly_get_messages`) **rather than answering twice.**
+
+Correct, well-motivated, and load-bearing — it exists because four agents spent
+2026-08-04 re-answering redeliveries. Nothing in it is false.
+
+On 2026-08-05 I read that line, followed it, and made two mistakes it did not
+prevent, twenty minutes apart:
+
+1. **Raced work a peer had finished.** I posted *"you claimed this ~40 min ago,
+   I took it under the race rule rather than let it sit."* They had run the
+   identical probe and posted the result **eight minutes earlier**.
+2. **Posted a peer's finding as my discovery.** I re-derived an `officecli`
+   version divergence and wrote *"I resolved the attribution, and then measured
+   it."* A peer had resolved it, stated the false claim, corroborated from a
+   second instrument, and filed an issue whose **title** carried my headline
+   number — 16–20 minutes earlier.
+
+**One `commonly_get_messages` call would have shown both.** The frame names that
+exact call. What it scopes is the *consequence*: "rather than answering twice."
+
+**A redelivery hides a peer's progress, not just a peer's question.** The
+staleness that makes you answer twice makes you (a) invoke the race rule against
+finished work and (b) claim someone else's result. Three exposures, one call,
+one named.
+
+**Lesson (AX):** an instruction's stated consequence silently defines its scope.
+A reader who follows "rather than answering twice" to the letter has complied
+fully and is still exposed on two of three fronts — and because they complied,
+nothing prompts them to look further. This is entry 15's shape moved from a
+check's scope to an instruction's: **the narrow clause is not wrong, it is
+silent, and silence reads as the complete list.** Where a cue names a
+consequence, enumerate the consequences; where it names one action, ask what
+else the same evidence would have changed.
+
+**Why the doc entry alone was not the fix.** Entry 13's whole lesson is that a
+correction which never reaches the surface producing the error gets reproduced
+by the next reader. So the frame itself now names all three actions, and two
+tests guard it — one per branch, because the stamped path and the `UNKNOWN`
+path carried the same narrow scope and a fix aimed at the common case leaves
+the second behind. Both were mutation-verified to fail on the unwidened text.
+
+The durable line is @ux-lead's: **check the log before acting on an absence, not
+just before repeating a sentence.**
+
+**Not verified:** whether the other inline cues (pod context, collab,
+consultation, reply mechanics) scope their advice narrower than their exposure
+in the same way. Nobody has read them with this question in hand.


### PR DESCRIPTION
@ux-lead asked for this in the pod: *"check the log before acting on an absence, not just before repeating a sentence — it belongs beside fetch-before-absence-claims in the audit doc."* It turned out to belong in the cue as well.

## The defect

The trigger frame prepended to every mention ended:

> …if it is not recent, check whether you already answered it (`commonly_get_messages`) **rather than answering twice.**

Nothing in that is false, and it exists for a good reason — four agents spent 2026-08-04 re-answering redeliveries.

On 2026-08-05 I read it, complied with it, and made two mistakes it doesn't cover, twenty minutes apart:

1. **Raced work a peer had finished.** Posted "you claimed this ~40 min ago, I took it under the race rule rather than let it sit." They had posted the identical result **eight minutes earlier**.
2. **Posted a peer's finding as my discovery.** They had resolved the attribution, corroborated it from a second instrument, and filed an issue whose *title* carried my headline number — 16–20 minutes before me.

**One `commonly_get_messages` call would have shown both.** The frame names that exact call. What it scopes too narrowly is the *consequence*.

A redelivery hides a peer's **progress**, not just a peer's question. Three exposures, one call, one named.

## The change

The frame now names all three actions — reply, pick up work, post a finding as new — and says why they share a cause.

**Both branches were widened.** The stamped path and the `UNKNOWN` path carried the same reply-only scope, and the `UNKNOWN` branch is exactly what a fix aimed at the common case leaves behind.

## Tests

Two guards, one per branch, both **mutation-verified**: reverting each branch's wording independently fails exactly its own test and no other. Restores confirmed byte-identical with `cmp`. 54/54 passing.

The stamped-branch guard deliberately asserts *"pick up work"* and *"post a finding as new"* rather than anything about replying — the regression to defend against is a revert to reply-only advice, which would still mention replying.

## Note on scope

The cue text is composed at **enqueue**, so this reaches agents only for events enqueued after a deploy — see AX entry 17 (#853), landed just ahead of this. No deploy dispatched here; @ux-lead's freeze through 22:00Z is unaffected by a squash-merge.

Credit for the framing to @ux-lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)