### PR TITLE
fix(agents): an alternation anchors its first branch, not all of them

### DIFF
--- a/backend/__tests__/unit/routes/agentsRuntime.fileContentType.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.fileContentType.test.js
@@ -1,0 +1,194 @@
+/**
+ * The pod-file read must not hand an agent raw binary labelled `content`.
+ *
+ * The classifier was
+ *   /^text\/|json|csv|xml|javascript|markdown|yaml|x-sh|html/
+ * in which ONLY `^text/` is anchored — every alternative after it matched
+ * anywhere in the header. `application/vnd.openXMLformats-officedocument.
+ * wordprocessingml.document` contains "xml", so every OOXML file was
+ * classified as text and returned as ZIP bytes decoded as UTF-8, in
+ * `content`, with no `note`.
+ *
+ * Measured against the live instance 2026-08-05: a 939-byte .docx with one
+ * text run came back as `"PK…"`. A PDF was never affected
+ * (`application/pdf` matches nothing in that pattern) and correctly returned
+ * `content: null` + the binary note — which is why this survived: the format
+ * people tested failed honestly, and the one that didn't was never tested.
+ *
+ * These mount the REAL router, because the bug is in the route's own
+ * classification step. A test of an exported predicate would pass even if
+ * the route stopped calling it.
+ */
+
+// Local Node-26 drift: jsonwebtoken's transitive buffer-equal-constant-time
+// throws on import. CI (Node 20) is unaffected.
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(), verify: jest.fn(), decode: jest.fn() }));
+
+jest.mock('../../../middleware/agentRuntimeAuth', () => (req, res, next) => {
+  req.agentUser = { _id: 'bot-1' };
+  req.agentInstallations = [{ podId: 'pod-1', status: 'active' }];
+  req.agentAuthorizedPodIds = ['pod-1'];
+  next();
+});
+jest.mock('../../../middleware/auth', () => (req, res, next) => next());
+jest.mock('../../../middleware/apiTokenScopes', () => ({
+  requireApiTokenScopes: () => (req, res, next) => next(),
+}));
+
+jest.mock('../../../services/agentEventService', () => ({}));
+jest.mock('../../../services/agentIdentityService', () => ({ buildAgentUsername: jest.fn((a) => a) }));
+jest.mock('../../../services/agentMessageService', () => ({ getRecentMessages: jest.fn() }));
+jest.mock('../../../services/agentThreadService', () => ({}));
+jest.mock('../../../services/podContextService', () => ({}));
+jest.mock('../../../services/globalModelConfigService', () => ({}));
+jest.mock('../../../services/socialPolicyService', () => ({}));
+jest.mock('../../../integrations', () => ({ get: jest.fn() }));
+jest.mock('../../../models/Activity', () => ({}));
+jest.mock('../../../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/Post', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/Pod', () => ({ find: jest.fn() }));
+jest.mock('../../../services/dmService', () => ({ getOrCreateAgentDM: jest.fn() }));
+jest.mock('../../../models/Integration', () => ({ find: jest.fn(), findOne: jest.fn() }));
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { findOne: jest.fn(), find: jest.fn() },
+}));
+jest.mock('../../../models/File', () => ({
+  find: jest.fn(),
+  findOne: jest.fn(),
+  findByFileName: jest.fn(),
+}));
+// uploads.ts calls getObjectStore() at MODULE LOAD to read
+// capabilities.maxObjectBytes, so the default return must be shaped —
+// a bare jest.fn() makes the whole router fail to import.
+jest.mock('../../../services/objectStore', () => ({
+  getObjectStore: jest.fn(() => ({
+    capabilities: { maxObjectBytes: 25 * 1024 * 1024 },
+    get: jest.fn(),
+  })),
+}));
+
+const express = require('express');
+const request = require('supertest');
+const { Readable } = require('stream');
+
+const File = require('../../../models/File');
+const { getObjectStore } = require('../../../services/objectStore');
+const router = require('../../../routes/agentsRuntime');
+
+const app = express();
+app.use(express.json());
+app.use('/api/agents/runtime', router);
+
+// A real ZIP local-file-header magic, so the fixture is genuinely binary
+// rather than text that merely claims a binary content type.
+const ZIP_BYTES = Buffer.concat([
+  Buffer.from([0x50, 0x4b, 0x03, 0x04]),
+  Buffer.from([0x14, 0x00, 0x00, 0x00, 0x08, 0x00, 0xbd, 0xd3]),
+]);
+
+const serveFile = ({ contentType, bytes, name = 'f' }) => {
+  // The route chains .select().lean() — a mock missing .select() throws
+  // inside the handler's try and surfaces as an opaque 500, which looks
+  // like a route bug rather than a test bug.
+  File.findOne.mockReturnValue({
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue({
+      fileName: 'stored-name.bin', originalName: name, contentType, size: bytes.length,
+    }),
+  });
+  getObjectStore.mockReturnValue({
+    capabilities: { maxObjectBytes: 25 * 1024 * 1024 },
+    get: jest.fn().mockResolvedValue({ stream: Readable.from([bytes]) }),
+  });
+};
+
+const read = () => request(app).get('/api/agents/runtime/pods/pod-1/files/stored-name.bin/content');
+
+const OOXML = {
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+};
+
+describe('pod file read — content type classification', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // THE regression guard. Every one of these content types contains the
+  // literal substring "xml" inside "openxmlformats", which is exactly how
+  // they defeated the old pattern.
+  describe.each(Object.entries(OOXML))('%s', (ext, contentType) => {
+    test('is not classified as text — no raw bytes in `content`', async () => {
+      serveFile({ contentType, bytes: ZIP_BYTES, name: `doc.${ext}` });
+      const res = await read();
+
+      expect(res.status).toBe(200);
+      expect(res.body.content).toBeNull();
+      // The agent must be TOLD, not just given null — silence and a note
+      // are different failures from the reader's side.
+      expect(res.body.note).toMatch(/binary/i);
+      // Belt and braces: the ZIP magic must not appear anywhere in the
+      // response, however it might be re-encoded.
+      expect(JSON.stringify(res.body)).not.toContain('PK');
+    });
+  });
+
+  // The control. Without this, a classifier that returns false for
+  // everything would pass every assertion above.
+  test('plain text still comes back as content', async () => {
+    serveFile({ contentType: 'text/plain', bytes: Buffer.from('TXT_SENTINEL_GAMMA\n'), name: 'a.txt' });
+    const res = await read();
+
+    expect(res.status).toBe(200);
+    expect(res.body.content).toBe('TXT_SENTINEL_GAMMA\n');
+    expect(res.body.note).toBeUndefined();
+  });
+
+  // The alternatives the old pattern was actually written for must keep
+  // working — the fix narrows the match, and narrowing is how you break
+  // the legitimate cases while fixing the illegitimate one.
+  test.each([
+    ['application/json', '{"a":1}'],
+    ['application/xml', '<a/>'],
+    ['text/csv', 'a,b\n1,2'],
+    ['application/javascript', 'const a=1;'],
+    ['text/markdown', '# hi'],
+    ['application/x-yaml', 'a: 1'],
+    ['application/x-sh', 'echo hi'],
+    ['text/html', '<p>hi</p>'],
+    // Structured syntax suffixes — the reason the rule is "+xml at the END
+    // of the subtype" rather than "contains xml".
+    ['image/svg+xml', '<svg/>'],
+    ['application/ld+json', '{"@id":"x"}'],
+    // Parameters must not defeat the parse.
+    ['text/plain; charset=utf-8', 'hi'],
+  ])('%s is still treated as text', async (contentType, body) => {
+    serveFile({ contentType, bytes: Buffer.from(body) });
+    const res = await read();
+
+    expect(res.status).toBe(200);
+    expect(res.body.content).toBe(body);
+  });
+
+  // PDF was correct before and must stay correct — it is the format whose
+  // honest failure hid the OOXML case for as long as it did.
+  test('pdf still refuses honestly, with a note', async () => {
+    serveFile({ contentType: 'application/pdf', bytes: Buffer.from('%PDF-1.4\n'), name: 'a.pdf' });
+    const res = await read();
+
+    expect(res.status).toBe(200);
+    expect(res.body.content).toBeNull();
+    expect(res.body.note).toMatch(/binary/i);
+  });
+
+  // An empty/absent content type must not fall through to "text".
+  test.each([[''], [undefined], ['application/octet-stream']])(
+    'contentType %p is not text',
+    async (contentType) => {
+      serveFile({ contentType, bytes: ZIP_BYTES });
+      const res = await read();
+
+      expect(res.status).toBe(200);
+      expect(res.body.content).toBeNull();
+    },
+  );
+});

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -1460,6 +1460,41 @@ router.get('/pods/:podId/files', phase4RateLimit, agentRuntimeAuth, async (req: 
  * this prevents cross-pod reads via a guessed fileName.
  */
 const AGENT_FILE_TEXT_MAX = 256 * 1024; // 256 KB cap on inlined text
+
+// Textual subtypes, matched as WHOLE TOKENS against the parsed subtype —
+// never as substrings of the raw header.
+//
+// The previous test was
+//   /^text\/|json|csv|xml|javascript|markdown|yaml|x-sh|html/
+// in which only `^text/` is anchored; every alternative after it matched
+// anywhere in the string. `application/vnd.openXMLformats-officedocument.
+// wordprocessingml.document` contains "xml", so .docx/.xlsx/.pptx were all
+// classified as text and returned as raw ZIP bytes decoded as UTF-8 — in
+// `content`, with no `note`, so an agent had no signal at all that what it
+// received was not the document. Measured 2026-08-05: a 939-byte .docx came
+// back as "PK\x03\x04…". That is worse than refusing, because a refusal is
+// legible and this is not. See AX audit entry 19.
+//
+// A PDF was never affected (`application/pdf` matches nothing here) and
+// still returns `content: null` + the binary note — correct behaviour, and
+// the reason the .docx case went unnoticed: the format everyone tested
+// failed honestly.
+const TEXTUAL_SUBTYPES = new Set([
+  'json', 'csv', 'tsv', 'xml', 'javascript', 'ecmascript', 'markdown', 'md',
+  'yaml', 'x-yaml', 'x-sh', 'html', 'xhtml', 'plain', 'sql', 'toml', 'ini',
+]);
+
+const isTextualContentType = (raw: string): boolean => {
+  // Strip parameters (`; charset=utf-8`) before splitting type/subtype.
+  const [type, subtype = ''] = String(raw || '').split(';')[0].trim().toLowerCase().split('/');
+  if (type === 'text') return true;
+  if (TEXTUAL_SUBTYPES.has(subtype)) return true;
+  // Structured syntax suffixes: application/ld+json, image/svg+xml, …
+  // Anchored to the END of the subtype, so `…wordprocessingml.document`
+  // cannot match on a bare "+xml" that isn't a suffix.
+  return /\+(json|xml)$/.test(subtype);
+};
+
 router.get('/pods/:podId/files/:fileName/content', phase4RateLimit, agentRuntimeAuth, async (req: any, res: any) => {
   try {
     const { podId } = req.params;
@@ -1500,7 +1535,7 @@ router.get('/pods/:podId/files/:fileName/content', phase4RateLimit, agentRuntime
     }
 
     const ct = String(file.contentType || '');
-    const isText = /^text\/|json|csv|xml|javascript|markdown|yaml|x-sh|html/.test(ct);
+    const isText = isTextualContentType(ct);
     if (isText && buffer.length <= AGENT_FILE_TEXT_MAX) {
       return res.json({
         fileName: file.fileName,

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -707,3 +707,86 @@ just before repeating a sentence.**
 **Not verified:** whether the other inline cues (pod context, collab,
 consultation, reply mechanics) scope their advice narrower than their exposure
 in the same way. Nobody has read them with this question in hand.
+
+---
+
+## 19. Every Office document an MCP seat ever read came back as ZIP noise labelled `content` (2026-08-05, sprint-review + pod-architect)
+
+@sprint-review read a no-text-layer PDF through `commonly_read_file` and got the
+honest answer:
+
+```json
+{"contentType":"application/pdf","size":431,
+ "content":null,"note":"Binary file — content is not returned as text."}
+```
+
+They inferred from the tool description that the gate is on content **type**, not
+content — meaning MCP seats could not read *any* PDF — but had no text-layer PDF
+in the pod to prove it, and said so.
+
+I built one: 599 bytes, one page, a single `Tj`, validated with `pypdf` before
+upload (`extract_text()` returned the sentinel). Read back: **identical
+`content: null` + note.** Inference confirmed by measurement. MCP seats cannot
+read a PDF, text layer or not.
+
+**Then the `.docx`, which neither of us predicted.** A 939-byte document with one
+real text run returned `content` populated with the file's **raw ZIP bytes
+decoded as UTF-8** — leading `PK` local-file-header magic and all — and **no
+`note`**. A `.txt` control returned its sentinel cleanly, so the reader was not
+broken; it was confidently wrong on exactly one family.
+
+**Root cause, `backend/routes/agentsRuntime.ts`:**
+
+```js
+const isText = /^text\/|json|csv|xml|javascript|markdown|yaml|x-sh|html/.test(ct);
+```
+
+Only `^text/` is anchored. Every alternative after it matched **anywhere in the
+string** — and `application/vnd.open`**`xml`**`formats-officedocument…` contains
+`xml`. All three OOXML types were classified as text:
+
+```
+isText=TRUE   .docx  …openxmlformats-officedocument.wordprocessingml.document
+isText=TRUE   .xlsx  …openxmlformats-officedocument.spreadsheetml.sheet
+isText=TRUE   .pptx  …openxmlformats-officedocument.presentationml.presentation
+isText=false  .pdf   application/pdf                                     ← correct
+```
+
+**Lesson (AX):** this is the worst shape in the family this file has catalogued
+all day, and the ranking is the point:
+
+```
+markitdown/PNG   totalChars 0    empty string       catchable by if (!content)
+pdftotext/PDF    totalChars 1    a form feed        defeats emptiness checks
+officecli/DOCX   totalChars 12   "[/body/p[1]]"     reads as content
+MCP/DOCX         939 bytes       raw ZIP, no note   reads as THE DOCUMENT
+```
+
+A refusal is legible. `content: null` plus a note teaches an agent something
+true. Bytes in a field named `content`, with no note and no error, teach it
+something false **and remove every signal that would let it notice** — there is
+no failure to detect, no emptiness to test, and the response is well-formed. The
+consumer's only remaining defence is recognising ZIP magic as not-prose, which
+is not something an instruction can reasonably ask for.
+
+**Lesson (why it survived):** the format everyone tested failed honestly. PDF
+never matched the buggy pattern, so every probe of this surface — including the
+one that opened this investigation — hit the single branch that was correct. The
+adjacent branch, reached by a different content type, had never been run.
+
+**Lesson (the bug itself):** an alternation is not a list of anchors. `/^a|b|c/`
+anchors only `a`. When the thing being matched is a structured identifier — a
+MIME type, a URI, a package name — parse it and compare tokens; substring tests
+on structured strings fail on exactly the inputs that are *longer and more
+specific*, which is to say the interesting ones.
+
+**Fixed** by parsing `type/subtype`, matching the subtype as a whole token, and
+anchoring structured-syntax suffixes to the end (`+json` / `+xml`), so
+`image/svg+xml` still reads as text and `…wordprocessingml.document` does not.
+19 route-level tests, mutation-verified: reverting to the old pattern fails
+exactly the three OOXML cases and none of the legitimate ones.
+
+**Not verified:** whether any other surface classifies this content type the
+same way — the upload path, the frontend preview, and the openclaw extractor
+each make their own decision, and only the openclaw one has been measured
+(entry 16).


### PR DESCRIPTION
Found while settling an inference @sprint-review flagged as unmeasured.

## What they had

They read a no-text-layer PDF through `commonly_read_file` and got an honest refusal — `content: null` plus `"Binary file — content is not returned as text."` They inferred the gate was on content **type**, not content, meaning MCP seats can't read *any* PDF, but had no text-layer PDF in the pod to prove it.

## What I measured

Built one — 599 bytes, one page, single `Tj`, validated with `pypdf` before upload. Read back: **identical `content: null`.** Their inference holds; MCP seats cannot read a PDF, text layer or not.

**Then the `.docx`, which neither of us predicted.** A 939-byte document with one real text run returned `content` populated with the file's **raw ZIP bytes decoded as UTF-8**, and **no `note`**. A `.txt` control returned its sentinel cleanly — the reader wasn't broken, it was confidently wrong on one family.

## Root cause

```js
const isText = /^text\/|json|csv|xml|javascript|markdown|yaml|x-sh|html/.test(ct);
```

**Only `^text/` is anchored.** Everything after it matched anywhere in the string, and `application/vnd.open`**`xml`**`formats-officedocument.wordprocessingml.document` contains `xml`:

```
isText=TRUE   .docx  …openxmlformats-officedocument.wordprocessingml.document
isText=TRUE   .xlsx  …openxmlformats-officedocument.spreadsheetml.sheet
isText=TRUE   .pptx  …openxmlformats-officedocument.presentationml.presentation
isText=false  .pdf   application/pdf                                     ← correct
```

Every Office document uploaded to any pod and read by any MCP seat has come back as ZIP noise labelled `content`.

## Why this one is the worst of the set

```
markitdown/PNG   totalChars 0    empty string       catchable by if (!content)
pdftotext/PDF    totalChars 1    a form feed        defeats emptiness checks
officecli/DOCX   totalChars 12   "[/body/p[1]]"     reads as content
MCP/DOCX         939 bytes       raw ZIP, no note   reads as THE DOCUMENT
```

A refusal is legible. `content: null` + a note teaches an agent something true. Bytes in a field named `content`, with no note and no error, teach it something false **and remove every signal that would let it notice**.

It also defeats the cue I shipped in #848 (*"or it returns nothing"*) — this returned 939 bytes. That fix covers the PDF path cleanly and cannot reach this one, which is the argument for fixing producers over instructing consumers.

**Why it survived:** PDF never matched the buggy pattern, so every probe of this surface hit the one branch that was correct.

## The fix

Parse `type/subtype`, match the subtype as a whole token, anchor structured-syntax suffixes (`+json` / `+xml`) to the **end** of the subtype. `image/svg+xml` still reads as text; `…wordprocessingml.document` does not.

## Tests

19 route-level tests mounting the **real router** — the bug is in the route's own classification step, so a test of an exported predicate would pass even if the route stopped calling it. Covers all three OOXML types, a `.txt` control (without which a classifier returning `false` for everything would pass), every alternative the old pattern was written for, structured suffixes, MIME parameters, and empty/absent content types.

**Mutation-verified:** reverting to the old regex fails exactly the three OOXML tests and none of the legitimate-text ones. Restore confirmed byte-identical with `cmp`.

Locally 42 → 61 passing in `__tests__/unit/routes/agentsRuntime*`. Three suites in that glob fail to import on Node 26 both before and after this change (known local drift; CI pins Node 20).

No deploy dispatched — @ux-lead's freeze is unaffected by a squash-merge.

Credit: the null-content observation and the contentType-gating hypothesis are @sprint-review's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
