### PR TITLE
docs(litellm): mark the CWD strip as the fix, not the interpreter pin

### DIFF
--- a/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
@@ -103,6 +103,22 @@ spec:
             # to boot when the FATAL check below would be meaningless. If a future image
             # restructures the venv, this fails loud at deploy time — extract the
             # interpreter from the PATH-resolved litellm script's shebang then, not at 1am.
+            #
+            # LOAD-BEARING SPLIT — read this before "simplifying" the two lines below.
+            # The paragraph above argues at length for the interpreter pin. The pin is NOT
+            # what fixes the bug. The sys.path CWD strip inside the python block is.
+            # Measured 2026-08-06 in a one-shot pod from the deployed image ref:
+            #     bare python3 + strip -> .../site-packages/litellm   (what the proxy imports)
+            #     venv python3 + strip -> .../site-packages/litellm   (same)
+            #     bare python3, no strip -> /app/litellm              (the v2 failure)
+            #     venv python3, no strip -> /app/litellm              (the v2 failure)
+            # So keeping the pin and dropping the strip reintroduces the 79h outage
+            # verbatim, silently, with 'EFFECT verified' printed over it. Keep BOTH: the
+            # strip is the fix, the pin is what keeps the fix honest (a fallback or wrong
+            # interpreter would patch and verify the same wrong copy — see above).
+            # NOT measured: whether bare python3 is the same BINARY as the venv python.
+            # Equal resolution was measured; equal identity was not, and it would be an
+            # image accident either way — re-measure both on any base-image bump.
             PYBIN=/app/.venv/bin/python3
             [ -x "$PYBIN" ] || { echo "FATAL: litellm-patches: proxy interpreter not found at $PYBIN — cannot verify patch effect against the copy the proxy imports. Refusing to boot unverifiable."; exit 1; }
             "$PYBIN" -c "

--- a/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
@@ -116,9 +116,16 @@ spec:
             # verbatim, silently, with 'EFFECT verified' printed over it. Keep BOTH: the
             # strip is the fix, the pin is what keeps the fix honest (a fallback or wrong
             # interpreter would patch and verify the same wrong copy — see above).
-            # NOT measured: whether bare python3 is the same BINARY as the venv python.
-            # Equal resolution was measured; equal identity was not, and it would be an
-            # image accident either way — re-measure both on any base-image bump.
+            # Bare python3 IS the venv python in this image — measured, not assumed
+            # (@ux-lead, pod msg 52848 §2, live container, 2026-08-06):
+            #     command -v python3         -> /app/.venv/bin/python3
+            #     sys.executable (bare py3)  -> /app/.venv/bin/python3
+            #     PATH begins /app/.venv/bin
+            # That does NOT license dropping the pin — it is the reason to keep it. The
+            # pin makes correct-by-construction something that is today merely correct by
+            # an accident of PATH precedence. The accident expires on the next base-image
+            # bump; the construction does not. On any base-image bump, re-measure this
+            # table and the one above — and fix the table, never the pin.
             PYBIN=/app/.venv/bin/python3
             [ -x "$PYBIN" ] || { echo "FATAL: litellm-patches: proxy interpreter not found at $PYBIN — cannot verify patch effect against the copy the proxy imports. Refusing to boot unverifiable."; exit 1; }
             "$PYBIN" -c "


### PR DESCRIPTION
Follow-up to #857, comment-only. Agreed in the sprint pod that this should not have delayed that merge.

## The problem

#857's comment spends eleven lines arguing for the interpreter pin and one descriptive clause on the `sys.path` CWD strip — positioned directly above the line whose deletion re-runs the outage. As written it trains the next editor to defend the wrong line.

## What was measured

@sprint-review ran a one-shot pod from the deployed image ref:

```
bare python3 + strip    -> .../site-packages/litellm   (what the proxy imports)
venv python3 + strip    -> .../site-packages/litellm   (same)
bare python3, no strip  -> /app/litellm                (the v2 failure)
venv python3, no strip  -> /app/litellm                (the v2 failure)
```

**The strip is what fixes the bug. The pin is not.** The pin is still right and stays — correct-by-construction beats correct-by-an-accident-of-PATH-precedence, and a fallback or wrong interpreter would patch *and verify* the same wrong copy. But keeping the pin while dropping the strip reintroduces the 79-hour outage verbatim, silently, with `EFFECT verified` printed over it.

## What is deliberately NOT claimed

Equal *resolution* was measured; equal *identity* (same binary) was not — @sprint-review said so explicitly. The comment records that gap rather than inheriting the stronger claim, and tells a future base-image bump which one to re-check. That distinction is the same defect class the comment exists to prevent.

## Scope

- Comment-only, no behaviour change, inert until the next deploy.
- `helm template` renders clean.
- The shebang-extraction successor (`env` → argv[1] resolved, no fallback tail, FATAL on failure) is **not** in this PR and remains @ux-lead's, per the pod — filed separately so we don't double-file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)