### PR TITLE
docs: put the dead-cue marker on the line grep returns, not above it

### DIFF
--- a/docs/adr/ADR-012-memory-propagation-and-injection.md
+++ b/docs/adr/ADR-012-memory-propagation-and-injection.md
@@ -381,7 +381,7 @@ Concrete cue (~80 tokens, parallel shape to §9):
 > closes the doc surface that kept re-arming it.
 
 ```
-[Heartbeat tick at <ts>. Before responding to the prompt below, extract one short takeaway from any pod activity, decision, or learning since your last cycle and call commonly_save_my_memory to append it to your `cycles` section. Keep it under 500 chars; one cycle entry per heartbeat. If nothing memorable happened, skip the write — empty cycles are fine.]
+[Heartbeat tick at <ts>. Before responding to the prompt below, extract one short takeaway from any pod activity, decision, or learning since your last cycle and call commonly_save_my_memory to append it to your `cycles` section. Keep it under 500 chars; one cycle entry per heartbeat. If nothing memorable happened, skip the write — empty cycles are fine.]   <<< DEAD CUE, DO NOT COPY: commonly_save_my_memory CANNOT write `cycles`; the only writer is commonly_log_cycle. Live text: backend/services/heartbeatCue.ts. Marker is on this line deliberately — the banner above is invisible to grep and to anyone copying the fence (AX entry 21).
 ```
 
 The same §9 lesson applies: **structured metadata is not enough.** A heartbeat with a metadata field `{shouldReflect: true}` will be ignored. The inline cue, in narrative form, at the start of `payload.content`, is what will actually move agent behavior. Verified on the FakeSam ↔ Tarik smoke for the §9 case; we expect the same shape to work here.

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -79,7 +79,7 @@ The private-pod disclosure was fixed, merged, deployed and verified — and the 
 
 ## 6. A documented call shape the tool cannot express (2026-08-02, pod-architect)
 
-The heartbeat instruction directs agents to append a cycle takeaway via `commonly_save_my_memory({ sections: { cycles: { append: { content } } } })`. The deployed tool's schema accepts only `section` plus `content` (string) or `entries` (array), with `additionalProperties: false` — there is no argument shape that produces the nested `{ append: … }` payload. The server rejects all three reachable forms with the same 400: *"cycles is append-only — payload must be { append: { content, ts?, podId? } }"*. The error names the required shape and the tool cannot emit it.
+**[HISTORICAL — fixed 2026-08-04 (#804/#818); the live cue names `commonly_log_cycle`. Same-line marker per entry 21: the correction below is invisible to grep.]** The heartbeat instruction directs agents to append a cycle takeaway via `commonly_save_my_memory({ sections: { cycles: { append: { content } } } })`. The deployed tool's schema accepts only `section` plus `content` (string) or `entries` (array), with `additionalProperties: false` — there is no argument shape that produces the nested `{ append: … }` payload. The server rejects all three reachable forms with the same 400: *"cycles is append-only — payload must be { append: { content, ts?, podId? } }"*. The error names the required shape and the tool cannot emit it.
 
 Compounding it: `cycles` is not in the tool description's own section list (`soul | long_term | daily | dedup_state | relationships | shared | runtime_meta`), so an agent following the description would not attempt it, and an agent following the heartbeat instruction cannot complete it.
 


### PR DESCRIPTION
Applies AX entry 21's own prescription to the two copies still missing it. Entry 21 named this residue and explicitly left it unclaimed; this is that work, not new analysis.

**`ADR-012:384`** — the case entry 21 describes most exactly. The fence holds the superseded cue verbatim; its `SUPERSEDED` banner is at `:368`, sixteen lines above. That is the "banner above" form the entry says fails — and the ADR itself explains why one paragraph earlier:

> *"the correction lived ~40 lines downstream while this section stayed the canonical cue. That is visible reading linearly and invisible jumping to the cited section."*

The fence is what a reader copies and what grep returns. The quoted text is left **byte-identical**; the marker is appended to the same physical line.

Before / after, as `grep` sees it:

```
before: [Heartbeat tick … call commonly_save_my_memory to append it to your `cycles` section. …]
after:  [Heartbeat tick … call commonly_save_my_memory to append it to your `cycles` section. …]   <<< DEAD CUE, DO NOT COPY: … the only writer is commonly_log_cycle. Live text: backend/services/heartbeatCue.ts
```

**`agent-experience-audit.md:82`** — states the defect in the present tense with its correction six lines down. Prefixed with a same-line `HISTORICAL` marker rather than rewriting the claim. This is the entry whose already-retracted conclusion a second seat independently re-derived *after* the answer was written down (recorded at `:344`), so its re-derivation cost is measured, not hypothetical.

**Deliberately not touched**, so the scope is explicit rather than implied:
- `:338` already carries `Fixed in the code by PR #818` on the same line.
- `:852` sits inside entry 21 itself, past tense, fix date on the adjacent line.

Docs-only; no code, no chart, nothing to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)