### PR TITLE
docs: lead with the dead-cue marker; same-line was necessary and not sufficient

### DIFF
--- a/docs/adr/ADR-012-memory-propagation-and-injection.md
+++ b/docs/adr/ADR-012-memory-propagation-and-injection.md
@@ -328,9 +328,8 @@ interface ICyclesSection {
 - **Cap: 40 entries.** At a 30-min heartbeat cadence that's 20 hours of context; at 10-min it's ~7 hours. Tunable in v1.x with production data.
 - **Char cap: 500.** Larger than `system_exchanges.takeaway` (280) because the agent is generalizing a whole turn, not capturing a verbatim slice. Still small enough that 40 entries × 500 chars ≈ 20KB worst-case section size.
 - **Append-only via `commonly_log_cycle({ content, podId? })`.** *(As-planned this
-  read `commonly_save_my_memory(section: 'cycles', append: {...})`; that tool
-  cannot write `cycles` — see the §10.3 supersede note and "What actually
-  shipped" below.)* Whole-array overwrite is *not* allowed (a write that replaces the entries array drops history). The `/memory` and `/memory/sync` routes gain an `append` mode for `cycles[]` analogous to the `$push + $position:0 + $slice` pattern `appendSystemExchange` already uses.
+  read `commonly_save_my_memory(section: 'cycles', append: {...})` — DEAD, that tool cannot write `cycles`;
+  see the §10.3 supersede note and "What actually shipped" below.)* Whole-array overwrite is *not* allowed (a write that replaces the entries array drops history). The `/memory` and `/memory/sync` routes gain an `append` mode for `cycles[]` analogous to the `$push + $position:0 + $slice` pattern `appendSystemExchange` already uses.
 - **No platform writer.** `cycles[]` is the agent's reflection space — only the agent writes to it. The platform never appends here.
 - **Visibility hard-coded `'private'`** — same rule as `system_exchanges` for the same reason.
 
@@ -381,7 +380,7 @@ Concrete cue (~80 tokens, parallel shape to §9):
 > closes the doc surface that kept re-arming it.
 
 ```
-[Heartbeat tick at <ts>. Before responding to the prompt below, extract one short takeaway from any pod activity, decision, or learning since your last cycle and call commonly_save_my_memory to append it to your `cycles` section. Keep it under 500 chars; one cycle entry per heartbeat. If nothing memorable happened, skip the write — empty cycles are fine.]   <<< DEAD CUE, DO NOT COPY: commonly_save_my_memory CANNOT write `cycles`; the only writer is commonly_log_cycle. Live text: backend/services/heartbeatCue.ts. Marker is on this line deliberately — the banner above is invisible to grep and to anyone copying the fence (AX entry 21).
+DEAD CUE, DO NOT COPY — commonly_save_my_memory CANNOT write `cycles`; the only writer is commonly_log_cycle. Live text: backend/services/heartbeatCue.ts. Marker leads the line deliberately: same-line was not enough, because this line is 644 chars and a truncating reader hid a trailing marker (AX entry 21). >>> [Heartbeat tick at <ts>. Before responding to the prompt below, extract one short takeaway from any pod activity, decision, or learning since your last cycle and call commonly_save_my_memory to append it to your `cycles` section. Keep it under 500 chars; one cycle entry per heartbeat. If nothing memorable happened, skip the write — empty cycles are fine.]
 ```
 
 The same §9 lesson applies: **structured metadata is not enough.** A heartbeat with a metadata field `{shouldReflect: true}` will be ignored. The inline cue, in narrative form, at the start of `payload.content`, is what will actually move agent behavior. Verified on the FakeSam ↔ Tarik smoke for the §9 case; we expect the same shape to work here.

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -335,7 +335,7 @@ Every heartbeat tick delivers two instructions that **cannot be executed on an M
 
 **1. "Read your HEARTBEAT.md workspace file and follow it exactly."** No such file exists on an MCP seat. `HEARTBEAT.md` is provisioned from `backend/routes/registry/presets.ts` (`heartbeatTemplate`, ~19 presets) into a **moltbot PVC workspace** by `agentProvisionerService{,K8s}`. An ADR-005 wrapper or cloud-codex seat, whose workspace is a plain git clone, never receives one. Confirmed independently on two seats. The instruction is not merely a no-op — nothing in the cue tells the agent that absence is *expected*, so the honest reading is "I am failing a stated requirement," and it costs a filesystem check every tick to discover otherwise.
 
-**2. The cycle-write instruction names a tool that cannot serve it.** The deployed cue says `commonly_save_my_memory({ sections: { cycles: { append: { content } } } })`. That tool's MCP schema exposes `section | content | entries | visibility` — **there is no `append` field to put the payload in**, and its description enumerates `soul | long_term | daily | dedup_state | relationships | shared | runtime_meta`, omitting `cycles` entirely. This is entry #6, still deployed. Fixed in the code by PR #818.
+**2. [FIXED by #818 — the cue below is historical] The cycle-write instruction names a tool that cannot serve it.** The deployed cue says `commonly_save_my_memory({ sections: { cycles: { append: { content } } } })`. That tool's MCP schema exposes `section | content | entries | visibility` — **there is no `append` field to put the payload in**, and its description enumerates `soul | long_term | daily | dedup_state | relationships | shared | runtime_meta`, omitting `cycles` entirely. This was entry #6, deployed at the time of writing. Fixed in the code by PR #818.
 
 ### The finding is the recurrence, not the defect
 
@@ -849,9 +849,8 @@ docblock, a `presets.ts` comment, three ADR-012 correction notes, and two
 entries in this file — plus `CLAUDE.md`'s openclaw pin table.
 
 **What happened.** The heartbeat cue told agents to write `cycles` via
-`commonly_save_my_memory({ sections: { cycles: { append: … } } })` — a tool that
-refuses the section by design. It was live from 2026-05-03 (#293) and fixed
-2026-08-04 (#804, #818). Fixed thoroughly: the constant moved into its own
+`commonly_save_my_memory({ sections: { cycles: { append: … } } })` — DEAD, a tool that refuses the section by design; fixed 2026-08-04 (#804, #818).
+It was live from 2026-05-03 (#293). Fixed thoroughly: the constant moved into its own
 module with its own test, `presets.ts` gained an explanatory comment, ADR-012
 §10.3 gained a ⚠️ SUPERSEDED banner directly above the old text, and this file
 gained two entries.
@@ -913,9 +912,14 @@ what is no longer true in exactly the surfaces agents search first.** The better
 the writeup, the more copies. The failure is not sloppiness — it is thoroughness
 with no expiry.
 
-- **Put the marker on the same line as the quote.** `DEAD — see heartbeatCue.ts:`
-  prefixed inline, not a banner above. The marker has to survive being the only
-  line anyone sees.
+- **Put the marker on the same line as the quote — and make it *lead* the line.**
+  `DEAD — see heartbeatCue.ts:` prefixed inline, not a banner above. The marker
+  has to survive being the only line anyone sees. **Same-line turned out to be
+  necessary and not sufficient**, found while applying this rule: ADR-012's
+  quoted cue is a **644-character** line, so a marker appended to its end sat at
+  char 363 and vanished under every reader that truncates — the offending line
+  and the marked line rendered identically, which is this entry's own defect one
+  level down. Lead with the marker; measure the offset if the line is long.
 - **A table that says "what runs" needs a date and a reader.** Present-tense
   claims about another repo's artifacts decay on a bump that touches one line of
   hex. Prefer a script that reads the artifact over a table that restates it —
@@ -932,8 +936,11 @@ cue module — previously uncovered despite being, by ADR-012 §10.3's own
 reasoning, the strongest agent-facing surface we ship — and by dating and
 striking `CLAUDE.md`'s superseded pin table.
 
-**Not verified:** the other five verbatim copies still carry no same-line
-marker. This entry names the fix; applying it to each quote is unclaimed work.
+**Applied 2026-08-06 (#861 + follow-up).** All copies now carry a leading
+marker, verified by offset rather than by eye — `ADR-012:384` (@1 of 674),
+`:82` (@4 of 741), `:338` (@7 of 572), and `:852` (disqualifier moved onto the
+invocation's own line). The measurement is the point: the first pass put three
+of them on the same line and one of those was still invisible.
 
 ---
 


### PR DESCRIPTION
Follow-up to #861, found by measuring my own fix instead of reading it.

#861 applied AX entry 21's prescription — *"put the marker on the same line as the quote… it has to survive being the only line anyone sees."* It did that. Then I measured where the markers actually sat:

```
ADR-012:384   len=644   marker@363     ← same line, invisible
```

**A 644-character line truncates.** At char 363 the marker is past the cut for a narrow terminal, a `grep | cut`, and most review UIs — so the marked line and the unmarked line render identically. That is entry 21's own defect one level down: correct text the instrument never displays. Same family as the null instruments this file is mostly about.

**Now, measured rather than eyeballed:**

```
ADR-012:384   len=674   marker@1
audit:82      len=741   marker@4
audit:338     len=572   marker@7
```

**Two copies #861 missed, because "same line" was the test it used.** `ADR-012:331` and `audit:852` each *end* on the dead invocation with the disqualifier wrapped onto the next line — so a one-line grep hit shows a dead call reading as live:

```
before:  `commonly_save_my_memory({ sections: { cycles: { append: … } } })` — a tool that
after:   `commonly_save_my_memory({ sections: { cycles: { append: … } } })` — DEAD, a tool that refuses the section by design; fixed 2026-08-04 (#804, #818).
```

**Entry 21 amended** — the rule becomes *"lead the line, and measure the offset if the line is long,"* with the 644-char case recorded as why. Its `**Not verified:** the other five verbatim copies still carry no same-line marker` closer is replaced by what was applied, with the offsets, and by the fact that the first pass got three of four onto the same line and one of those three was still invisible.

Docs-only; no code, no chart, nothing to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)