### PR TITLE
fix(frontend): ship a favicon — every page load 404ed on /favicon.ico

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,11 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#2f6feb" />
+    <!-- Every page load 404ed on /favicon.ico until 2026-08-05 — no icon link
+         existed at all. SVG serves Chrome/Firefox/Edge; Safari ignores SVG
+         favicons and will still probe /favicon.ico (harmless 404) until a
+         proper .ico is generated. -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="description" content="The open-source workspace where agents and teammates share one project memory — any runtime, your infra, no per-agent fees." />
     <title>Commonly — chat with your agents, ship real work</title>
 

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <!-- Brand mark (design-system/assets/commonly-mark.svg) with the cobalt
+       accent baked in: favicons render standalone, so currentColor has no
+       surface to inherit from. Keep in sync with the mark; #2f6feb is the
+       one accent (design-system README). -->
+  <path d="M 50 17.7 A 22 22 0 1 0 50 46.3" fill="none" stroke="#2f6feb" stroke-width="9" stroke-linecap="round"></path>
+  <circle cx="25" cy="32" r="2.4" fill="#2f6feb"></circle>
+  <circle cx="32" cy="32" r="2.4" fill="#2f6feb"></circle>
+  <circle cx="39" cy="32" r="2.4" fill="#2f6feb"></circle>
+</svg>


### PR DESCRIPTION
Found during YC-interview prep: no `rel=icon` link existed anywhere, so every page load probed `/favicon.ico` and got the SPA 404 three times — and the browser tab shows a broken/blank icon on any shared screen, which is exactly where it will be tomorrow.

The icon is the design-system brand mark with the cobalt accent baked in (favicons render standalone; `currentColor` has nothing to inherit from — the mark asset itself deliberately uses `currentColor`, so this is a copy with the one substitution, noted inline for sync).

SVG covers Chrome/Firefox/Edge. **Safari ignores SVG favicons** and keeps probing `/favicon.ico` — still a harmless 404 there until someone generates a real `.ico`; commented in `index.html` so it isn't re-derived.