### PR TITLE
fix(v2): reaction counts rode high next to the emoji — align ink, not boxes

### DIFF
--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,0 +1,1 @@
+/Users/xcjsam/Documents/workspace/commonly/.claude/worktrees/sprint-2026-05-24-installable-projection/frontend/node_modules

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -224,4 +224,15 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(landing, '.v2-landing__adapters')).toContain('minmax(0, 1fr)');
     expect(ruleBody(landing, '.v2-landing__adapter')).toContain('min-width: 0');
   });
+
+  test('reaction chips baseline-align emoji ink with the count (not box-centering)', () => {
+    // align-items: center centers the spans' layout boxes, but Apple Color
+    // Emoji ink extends below the baseline while digit ink does not, so the
+    // count visibly rides high on desktop (2026-08-05, Sam's HQ screenshot).
+    // Baseline alignment + a 22px emoji line box (chip inner height, which is
+    // the only thing vertically centering the pair once baseline is on) is
+    // the fix; both halves are load-bearing and invisible to jsdom.
+    expect(ruleBody(v2, '.v2-root button.v2-msg__reaction')).toContain('align-items: baseline');
+    expect(ruleBody(v2, '.v2-msg__reaction-emoji')).toContain('line-height: 22px');
+  });
 });

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -5641,7 +5641,7 @@
 }
 .v2-msg__reaction {
   display: inline-flex;
-  align-items: center;
+  align-items: baseline; /* see button rule below -- ink vs box */
   gap: 4px;
   height: 24px;
   padding: 0 8px;
@@ -5659,7 +5659,10 @@
 }
 .v2-msg__reaction-emoji {
   font-size: 13px;
-  line-height: 1;
+  /* Chip inner height (24px - 2x1px border). With baseline alignment on the
+   * chip, this tall line box is the ONLY thing centering the glyph pair
+   * vertically -- shrink it back to 1 and the pair top-hugs the chip. */
+  line-height: 22px;
 }
 .v2-msg__reaction-count {
   font-weight: 600;
@@ -5685,7 +5688,15 @@
   padding: 0 8px;
   border-radius: 999px;
   display: inline-flex;
-  align-items: center;
+  /* Baseline, not center: box-centering aligns the spans' LAYOUT boxes,
+   * but Apple Color Emoji ink extends below the baseline while digit ink
+   * does not, so on desktop the count visibly rides high (reported by Sam
+   * 2026-08-05, HQ screenshot; reproduced 3x-zoomed in Chromium). Digits
+   * hanging on the emoji's baseline is how "\1F44D 2" renders in plain
+   * inline text -- the reference that looks right on every platform. The
+   * emoji span's 22px line-height (chip inner height, below) is what
+   * vertically centers the shared line inside the fixed-height chip. */
+  align-items: baseline;
   gap: 4px;
   font-size: 12px;
   line-height: 1;


### PR DESCRIPTION
Closes the desktop half of #865 (Sam's HQ screenshot: count digit visibly above the emoji's center; mobile fine).

## The measurement trap, for the record

The chip flex-centers its two spans, and the spans' **layout boxes are perfectly centered** — probed live with `getBoundingClientRect`: 0.00px offset on every chip, while the bug sat in plain sight. Apple Color Emoji ink extends below the baseline; digit ink does not, so **box centering diverges from ink centering** by a couple of pixels on desktop. The instrument measured the box; users see the ink. (Same lesson as the layout-invariants rule one layer down: verify what users see, not what the DOM reports.)

## The fix — exact by construction, no nudged constants

- `align-items: baseline` on the chip: digits hang on the emoji's baseline, which is how "👍 2" renders in plain inline text — the reference that looks right on every platform (and why mobile was already fine).
- `line-height: 22px` (chip inner height) on the emoji span — with baseline on, this line box is the **only** thing vertically centering the pair; that's documented inline because shrinking it back to 1 top-hugs the chip.

Verified visually in-browser, current vs fixed side by side at 3× zoom: current reproduces the screenshot, fixed sits both glyphs on one baseline, chip geometry (24px pill) unchanged.

## Guard

Added to `v2-layout-invariants` — both halves are load-bearing and invisible to jsdom. 21/21 invariants green; V2MessageBubble suite green.

Remaining in #865, deliberately untouched tonight: the triple `.v2-msg__reaction` definition cleanup (the "dead" block contributes the hover transition) and reactions being absent from the public read-only showcase view entirely.