### PR TITLE
fix(repo): untrack node_modules symlinks that dodged the dir-only ignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 .DS_Store
 npm-debug.log
 
-node_modules/
+# no trailing slash: the dir-only form let node_modules SYMLINKS get committed (#818, #867)
+node_modules
 
 .env
 

--- a/backend/node_modules
+++ b/backend/node_modules
@@ -1,1 +1,0 @@
-/Users/xcjsam/Documents/workspace/commonly/.claude/worktrees/sprint-2026-05-24-installable-projection/backend/node_modules

--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,1 +1,0 @@
-/Users/xcjsam/Documents/workspace/commonly/.claude/worktrees/sprint-2026-05-24-installable-projection/frontend/node_modules


### PR DESCRIPTION
## What

Two committed **symlinks** are on `main`, both pointing at absolute paths inside one operator worktree (`.claude/worktrees/sprint-2026-05-24-installable-projection/…`):

| path | arrived in | merged |
|---|---|---|
| `backend/node_modules` | #818 | 2026-08-04 22:18Z |
| `frontend/node_modules` | #867 | 2026-08-06 02:54Z |

## Why gitignore didn't stop them

`.gitignore:7` is `node_modules/` — the trailing slash makes it **directory-only**. A symlink named `node_modules` is not a directory to the matcher, so `git add -A` picks it up. (Docker's ignore file is immune to the same trap because it `filepath.Clean`s patterns, stripping the slash.)

## Measured blast radius (each claim executed, not inferred)

- **Docker builds: safe.** Context-exclusion test with positive and negative controls: with `.dockerignore` `node_modules/` present the symlink is `CTX-EXCLUDED`; without it, `CTX-PRESENT`. Production-scale corroboration: the live backend image (`e55f0c21`, deployed 01:27Z tonight) was built from a symlink-carrying tree and succeeded — the failure mode (`COPY . .` clobbering `/app/node_modules` before `npx tsc`) is loud and did not fire.
- **CI: safe.** `npm ci` removes the entry before installing; both carrier PRs passed checks.
- **Every other checkout: NOT safe.** Reproduced in a scratch repo: `git pull` exits **0** and **silently replaces a real, populated `node_modules` directory with the dangling symlink** (ignored paths are expendable to checkout). Next build/test in that tree fails with missing modules — or, on the one machine where the target resolves, silently runs against a May-24 worktree's dependencies: version skew with no error anywhere.

## Fix

- `git rm --cached` both symlinks (the author's local links are untouched — only the index entry is removed).
- `.gitignore`: drop the trailing slash with a same-file comment naming the defect, so the pattern matches file, dir, and symlink forms and the next `git add -A` can't re-commit one.

## Not done here

- No `.dockerignore` changes — verified already safe, and touching them would change a working exclusion.
- The three intentional symlinks (`AGENTS.md`, `.agents/skills`, `.claude/skills`) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)