### PR TITLE
fix(v2): create-pod options rendered as plain prose — the reset ate them

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -235,4 +235,15 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(v2, '.v2-root button.v2-msg__reaction')).toContain('align-items: baseline');
     expect(ruleBody(v2, '.v2-msg__reaction-emoji')).toContain('line-height: 22px');
   });
+
+  test('create-pod options carry the .v2-root button. prefix or the reset erases them', () => {
+    // The global reset (.v2-root button:not(.MuiButtonBase-root), 0-2-1)
+    // beats any bare class (0-1-0) and strips border/background/padding. The
+    // create-pod option buttons shipped bare and rendered as plain prose with
+    // no selection feedback — found live the night before the YC interview.
+    // Selection must be the accent, not a gray border, or "selected" is
+    // invisible even when it wins the cascade.
+    expect(ruleBody(v2, '.v2-root button.v2-pods__create-option')).toContain('border: 1px solid');
+    expect(ruleBody(v2, '.v2-root button.v2-pods__create-option--active')).toContain('var(--v2-accent)');
+  });
 });

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -720,20 +720,37 @@
   gap: 6px;
 }
 
-.v2-pods__create-option {
+/* .v2-root button. prefix, not bare .v2-pods__create-option: the global
+ * button reset (.v2-root button:not(.MuiButtonBase-root), specificity 0-2-1)
+ * beats a bare class (0-1-0) and strips border/background/padding — so both
+ * options rendered as PLAIN PROSE with zero selection feedback, live, until
+ * 2026-08-06 (Sam: "no distinction at all", the night before the YC
+ * interview). Same war the reaction chips and filter segments already fought;
+ * this panel never got the workaround. Every rule here that must survive the
+ * reset carries the prefix. */
+.v2-root button.v2-pods__create-option {
   display: flex;
   min-height: 48px;
   flex-direction: column;
   align-items: flex-start;
   gap: 2px;
-  padding: 7px 9px;
+  padding: 8px 10px;
+  background: #ffffff;
   border: 1px solid var(--v2-border);
   border-radius: var(--v2-radius-sm);
   color: var(--v2-text-secondary);
   text-align: left;
+  transition: background 80ms ease, border-color 80ms ease;
+}
+
+.v2-root button.v2-pods__create-option:hover {
+  border-color: var(--v2-border-strong);
 }
 
 .v2-pods__create-option strong {
+  display: flex;
+  align-items: center;
+  gap: 5px;
   font-size: 12px;
   font-weight: 700;
 }
@@ -745,10 +762,23 @@
   line-height: 1.35;
 }
 
-.v2-pods__create-option--active {
+/* Selected = the accent, unambiguously: soft fill + accent border + a dot
+ * beside the label. The original --active used border-color:
+ * var(--v2-border-strong) — gray — which would have been near-invisible even
+ * without the reset eating it. */
+.v2-root button.v2-pods__create-option--active {
   background: var(--v2-accent-soft);
-  border-color: var(--v2-border-strong);
+  border-color: var(--v2-accent);
   color: var(--v2-accent-text);
+}
+
+.v2-root button.v2-pods__create-option--active strong::after {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--v2-accent);
+  flex: none;
 }
 
 .v2-pods__create-input {


### PR DESCRIPTION
Sam, the night before the YC interview: *"not usable, no intuition on what is clicked, and no distinction at all."* He was measurably right — verified live with a seeded smoke user, both option buttons computed to `background: transparent, border: 0px, padding: 0`. The join-policy choice rendered as two paragraphs of prose. The active state painted nothing.

## Root cause

This codebase's most-documented CSS trap claiming another victim: the global reset `.v2-root button:not(.MuiButtonBase-root)` (specificity 0-2-1) beats a bare class (0-1-0) and strips exactly the properties that make an option look like an option. The reaction chips (#867) and filter segments already carry the `.v2-root button.` prefix workaround — the create panel never got it. Compounding: the intended `--active` style used a **gray** border (`--v2-border-strong`), near-invisible even had it won the cascade.

## Fix — verified on production before committing

CSS-only. Injected the rules into the live page with a seeded smoke user and screenshotted **both selection states** before shipping: selected = accent-soft fill + accent border + 6px accent dot beside the label; unselected = plain card with hover feedback; 80ms transitions per the design system.

Also verified the full path while there: **create was never broken** — smoke user created a pod end-to-end (and deleted it after). The UI was just illegible, which reads as broken.

## Guard

`v2-layout-invariants`: the prefixed rule must exist and `--active` must reference `var(--v2-accent)` — both jsdom-invisible properties. 22/22 invariants, sidebar + create-hook suites green.

Post-interview (#770 remains open): the *considered* creation flow against ratified ADR-016 — this PR makes the existing panel legible, it does not redesign it.