### PR TITLE
feat(pods): owner-writable Community tier, and creation stops asking (#768)

### DIFF
--- a/backend/__tests__/unit/routes/pods.visibility.test.js
+++ b/backend/__tests__/unit/routes/pods.visibility.test.js
@@ -1,0 +1,206 @@
+/**
+ * POST /api/pods/:id/visibility — owner-writable Community tier (#768).
+ *
+ * Before this route, `communityListed` was settable only from
+ * routes/admin/pods.ts behind adminAuth, so the creation flow's most prominent
+ * choice was inert for every non-admin: picking "Open to join" produced
+ * joinPolicy:'open' on a pod nobody could discover, because self-joinable is
+ * `community AND open` and a normal user could not reach community.
+ *
+ * The invariant these tests defend is ADR-016 #1 — listed => readable — which
+ * this route satisfies by writing BOTH flags in one action rather than
+ * offering the admin surface's two steps.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// The route's own limiter is 10/hour per IP — correct in production, and it
+// would 429 partway through this suite since every request shares one IP.
+// Stubbed to a pass-through so the tests exercise the handler; the limiter's
+// presence is asserted separately below.
+jest.mock('express-rate-limit', () => {
+  const factory = () => (_req, _res, next) => next();
+  factory.ipKeyGenerator = (ip) => ip;
+  return { __esModule: true, default: factory, ipKeyGenerator: factory.ipKeyGenerator };
+});
+
+jest.mock('../../../middleware/auth', () => (req, _res, next) => {
+  req.userId = req.headers['x-test-user'] || 'owner-1';
+  next();
+});
+
+const podSave = jest.fn();
+const mockPod = { value: null };
+
+jest.mock('../../../models/Pod', () => ({
+  findById: jest.fn(() => Promise.resolve(mockPod.value)),
+}));
+
+jest.mock('../../../models/User', () => ({
+  findById: jest.fn(() => ({
+    select: jest.fn(() => ({ lean: jest.fn(() => Promise.resolve({ role: 'user' })) })),
+  })),
+}));
+
+jest.mock('../../../models/AuditLog', () => ({ create: jest.fn(() => Promise.resolve()) }));
+
+// Route module pulls in a wide surface; stub the parts irrelevant here.
+jest.mock('../../../controllers/podController', () => ({
+  getAllPods: (_q, res) => res.json([]),
+  getPodsByType: (_q, res) => res.json([]),
+  getPodById: (_q, res) => res.json({}),
+  createPod: (_q, res) => res.json({}),
+  joinPod: (_q, res) => res.json({}),
+  leavePod: (_q, res) => res.json({}),
+  removeMember: (_q, res) => res.json({}),
+  deletePod: (_q, res) => res.json({}),
+}));
+
+const AuditLog = require('../../../models/AuditLog');
+
+const app = express();
+app.use(express.json());
+app.use('/api/pods', require('../../../routes/pods'));
+
+const pod = (over = {}) => ({
+  _id: 'pod-1',
+  type: 'chat',
+  publicRead: false,
+  communityListed: false,
+  createdBy: 'owner-1',
+  save: podSave,
+  ...over,
+});
+
+const setVisibility = (tier, user = 'owner-1') => request(app)
+  .post('/api/pods/pod-1/visibility')
+  .set('x-test-user', user)
+  .send({ tier });
+
+describe('POST /api/pods/:id/visibility', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    podSave.mockResolvedValue(undefined);
+    mockPod.value = pod();
+  });
+
+  describe('the owner can finally reach Community — the #768 fix', () => {
+    test('promoting sets BOTH flags in one write', async () => {
+      const res = await setVisibility('community');
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ tier: 'community', publicRead: true, communityListed: true });
+      expect(mockPod.value.publicRead).toBe(true);
+      expect(mockPod.value.communityListed).toBe(true);
+      expect(podSave).toHaveBeenCalledTimes(1);
+    });
+
+    // The whole point. A two-step owner flow would 409 forever on
+    // listing_requires_public_read, because publicRead (showcase) is admin-only.
+    test('never leaves the pod listed-but-unreadable (ADR-016 invariant 1)', async () => {
+      await setVisibility('community');
+      expect(mockPod.value.communityListed && !mockPod.value.publicRead).toBe(false);
+    });
+
+    test('demoting to private clears both', async () => {
+      mockPod.value = pod({ publicRead: true, communityListed: true });
+      const res = await setVisibility('private');
+      expect(res.status).toBe(200);
+      expect(mockPod.value.publicRead).toBe(false);
+      expect(mockPod.value.communityListed).toBe(false);
+    });
+  });
+
+  describe('showcase stays admin-only', () => {
+    // publicRead without listing publishes every future message to anonymous
+    // readers. Owners get the two ends of the ladder, not the curated middle.
+    test('tier "showcase" is rejected', async () => {
+      const res = await setVisibility('showcase');
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('invalid_tier');
+      expect(podSave).not.toHaveBeenCalled();
+    });
+
+    test('garbage tiers are rejected without writing', async () => {
+      for (const t of ['public', '', null, 'COMMUNITY']) {
+        // eslint-disable-next-line no-await-in-loop
+        const res = await setVisibility(t);
+        expect(res.status).toBe(400);
+      }
+      expect(podSave).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('who may call it', () => {
+    test('a non-owner non-admin is refused', async () => {
+      const res = await setVisibility('community', 'someone-else');
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('not_pod_owner');
+      expect(podSave).not.toHaveBeenCalled();
+    });
+
+    test('a global admin may act on a pod they do not own', async () => {
+      const User = require('../../../models/User');
+      User.findById.mockReturnValue({
+        select: jest.fn(() => ({ lean: jest.fn(() => Promise.resolve({ role: 'admin' })) })),
+      });
+      const res = await setVisibility('community', 'admin-9');
+      expect(res.status).toBe(200);
+    });
+
+    test('a missing pod is 404, not a silent success', async () => {
+      mockPod.value = null;
+      const res = await setVisibility('community');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('DM kinds stay terminally private', () => {
+    test.each(['agent-room', 'agent-dm', 'agent-admin'])('%s cannot be listed', async (type) => {
+      mockPod.value = pod({ type });
+      const res = await setVisibility('community');
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('pod_type_not_listable');
+      expect(podSave).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('publishing is audited', () => {
+    test('promotion writes a community.list audit row naming the owner', async () => {
+      await setVisibility('community');
+      expect(AuditLog.create).toHaveBeenCalledWith(expect.objectContaining({
+        action: 'community.list',
+        target: 'pod-1',
+        userId: 'owner-1',
+      }));
+    });
+
+    test('demotion writes community.unlist', async () => {
+      mockPod.value = pod({ publicRead: true, communityListed: true });
+      await setVisibility('private');
+      expect(AuditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'community.unlist' }),
+      );
+    });
+
+    // Audit is best-effort; losing the row must not lose the visibility change.
+    test('an audit failure does not fail the request', async () => {
+      AuditLog.create.mockRejectedValue(new Error('audit down'));
+      const res = await setVisibility('community');
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // The limiter is stubbed above, so its wiring needs its own check: publishing
+  // is the one owner action that exposes content to non-members, and it must
+  // not be callable in a tight loop.
+  describe('the route is rate-limited', () => {
+    test('a limiter middleware sits in front of the handler', () => {
+      const layer = require('../../../routes/pods').stack
+        .find((l) => l.route && l.route.path === '/:id/visibility');
+      expect(layer).toBeTruthy();
+      // auth + limiter + handler — more than just auth and the handler.
+      expect(layer.route.stack.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+});

--- a/backend/routes/pods.ts
+++ b/backend/routes/pods.ts
@@ -14,6 +14,10 @@ const { getAllPods, getPodsByType, getPodById, createPod, joinPod, leavePod, rem
 const Pod = require('../models/Pod');
 const User = require('../models/User');
 // eslint-disable-next-line global-require
+const AuditLog = require('../models/AuditLog');
+// eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+const { NON_LISTABLE_POD_TYPES } = require('../services/podListing') as { NON_LISTABLE_POD_TYPES: readonly string[] };
+// eslint-disable-next-line global-require
 const DMService = require('../services/dmService');
 // eslint-disable-next-line global-require
 const Announcement = require('../models/Announcement');
@@ -33,6 +37,10 @@ interface AuthReq {
   query?: Record<string, string>;
   body?: Record<string, unknown>;
   file?: { path: string };
+  // Present on every express request; declared because the visibility route
+  // records them on the AuditLog row that publishing a pod produces.
+  ip?: string;
+  headers?: Record<string, string | undefined>;
 }
 interface Res {
   status: (n: number) => Res;
@@ -475,6 +483,120 @@ router.get('/:param', auth, async (req: AuthReq, res: Res) => {
   if (isObjectId) { req.params!.id = param || ''; return getPodById(req, res); }
   req.params!.type = param || '';
   return getPodsByType(req, res);
+});
+
+// Promoting a room to Community makes it world-readable AND discoverable, so
+// it is rate-limited harder than ordinary pod admin actions: this is the one
+// owner-writable control that publishes content to people who are not members
+// and do not have an account.
+const podVisibilityRateLimit = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  limit: 10,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+});
+
+/**
+ * POST /api/pods/:id/visibility  { tier: 'private' | 'community' }
+ *
+ * ADR-016's ordered tier (private -> showcase -> community), owner-writable
+ * for the two ends. Before this, `communityListed` was settable ONLY from
+ * `routes/admin/pods.ts` behind adminAuth, which made the creation flow's most
+ * prominent choice inert for every non-admin: a user picking "Open to join"
+ * got `joinPolicy: 'open'` on a pod nobody could find, because
+ * `self-joinable <=> community AND open` and they could not reach community
+ * (#768).
+ *
+ * ONE ATOMIC WRITE, both flags together — deliberately, and not the admin
+ * route's two steps. The admin surface separates them because `showcase`
+ * (publicRead without listing) is a real curated state it needs to express.
+ * An owner cannot reach that state: `showcase` is admin-only, so an owner-side
+ * two-step would 409 on `listing_requires_public_read` forever with no way to
+ * clear it. Writing the pair together is also what ADR-016 invariant 1
+ * (listed => readable) asks of any writer that can prove it.
+ *
+ * Deliberately NOT exposed to agents: this is a `dualAuth`-free human route.
+ * An agent that could publish its own pod could exfiltrate a private room's
+ * entire future history with one call.
+ */
+router.post('/:id/visibility', podVisibilityRateLimit, auth, async (req: AuthReq, res: Res) => {
+  try {
+    const userId = req.userId || (req as unknown as { user?: { id?: string } }).user?.id;
+    const { tier } = (req.body || {}) as { tier?: string };
+
+    if (tier !== 'private' && tier !== 'community') {
+      return res.status(400).json({
+        error: 'invalid_tier',
+        // `showcase` is intentionally absent: it publishes every future
+        // message to anonymous readers and stays an audited admin action.
+        message: "tier must be 'private' or 'community'",
+      });
+    }
+
+    const podId = req.params?.id;
+    if (!podId) return res.status(400).json({ error: 'Pod id is required' });
+
+    const pod = await Pod.findById(podId) as {
+      _id: { toString: () => string };
+      type?: string;
+      publicRead?: boolean;
+      communityListed?: boolean;
+      createdBy?: { toString: () => string };
+      save: () => Promise<unknown>;
+    } | null;
+    if (!pod) return res.status(404).json({ error: 'Pod not found' });
+
+    const isCreator = pod.createdBy && userId && pod.createdBy.toString() === String(userId);
+    let isGlobalAdmin = false;
+    if (!isCreator && userId) {
+      const userRow = await User.findById(userId).select('role').lean() as { role?: string } | null;
+      isGlobalAdmin = userRow?.role === 'admin';
+    }
+    if (!isCreator && !isGlobalAdmin) {
+      return res.status(403).json({
+        error: 'not_pod_owner',
+        message: 'Only the pod creator or a global admin may change pod visibility',
+      });
+    }
+
+    // DM kinds are terminally private (ADR-001 s3.10 / ADR-016 invariant 3).
+    // Guarded here as well as at the admin writer because this is now a
+    // second door into the same flags.
+    if (NON_LISTABLE_POD_TYPES.includes(String(pod.type))) {
+      return res.status(400).json({
+        error: 'pod_type_not_listable',
+        message: `Cannot change Community visibility for a personal pod type (${pod.type})`,
+      });
+    }
+
+    const listed = tier === 'community';
+    pod.publicRead = listed;
+    pod.communityListed = listed;
+    await pod.save();
+
+    try {
+      await AuditLog.create({
+        action: listed ? 'community.list' : 'community.unlist',
+        target: pod._id.toString(),
+        detail: `tier=${tier} publicRead=${listed} communityListed=${listed} type=${pod.type} via=owner`,
+        userId,
+        ip: req.ip,
+        userAgent: req.headers?.['user-agent'],
+      });
+    } catch (auditErr) {
+      console.warn('[pods] visibility audit log write failed (non-fatal):', (auditErr as Error).message);
+    }
+
+    return res.json({
+      id: pod._id.toString(),
+      tier,
+      publicRead: pod.publicRead,
+      communityListed: pod.communityListed,
+    });
+  } catch (err) {
+    console.error('[pods] visibility change error:', (err as Error).message);
+    return res.status(500).json({ error: 'Server Error' });
+  }
 });
 
 router.get('/:type/:id', auth, getPodById);

--- a/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
@@ -73,7 +73,11 @@ describe('V2PodsSidebar create flow', () => {
     });
   });
 
-  it('creates a real invite-only Pod and marks it for the starter panel', async () => {
+  it('creates a Pod from name + purpose alone, born private', async () => {
+    // ADR-016 / #768: creation asks for intent, not audience. Every pod is
+    // born private and unlisted; `joinPolicy: 'open'` is the DORMANT
+    // declaration ("open once listed"), not a choice the creator made here.
+    // Visibility moves to a later, deliberate act via POST /pods/:id/visibility.
     const podsState = {
       pods: [],
       loading: false,
@@ -89,12 +93,12 @@ describe('V2PodsSidebar create flow', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'New Pod' }));
-    expect(screen.getByRole('button', { name: /Open to join/ })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByText('Anyone can join if this pod is listed in Community.')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Invite-only/ }));
-    expect(screen.getByRole('button', { name: /Invite-only/ })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByText('Only people you invite can join.')).toBeInTheDocument();
+    // The audience choice is gone — it set one field, could not be honoured
+    // for non-admins, and asked a stranger to decide before they had content.
+    expect(screen.queryByRole('button', { name: /Open to join/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Invite-only/ })).not.toBeInTheDocument();
+
     fireEvent.change(screen.getByPlaceholderText('Pod name'), {
       target: { value: 'Launch circle' },
     });
@@ -108,14 +112,14 @@ describe('V2PodsSidebar create flow', () => {
         'Launch circle',
         'Prepare the launch',
         'team',
-        'invite-only',
+        'open',
       );
     });
     expect(sessionStorage.getItem('v2.justCreated.new-private-pod')).toBe('1');
     expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/new-private-pod');
   });
 
-  it('renders both policy helpers from the Simplified Chinese catalog', async () => {
+  it('the simplified create form still localizes (zh-CN)', async () => {
     await act(async () => {
       await i18n.changeLanguage('zh-CN');
     });
@@ -134,10 +138,12 @@ describe('V2PodsSidebar create flow', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '新建 Pod' }));
 
-    expect(screen.getByRole('button', { name: /开放加入/ })).toBeInTheDocument();
-    expect(screen.getByText('列入「社区」后，任何人都可以加入。')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /仅限邀请/ })).toBeInTheDocument();
-    expect(screen.getByText('只有你邀请的人才能加入。')).toBeInTheDocument();
+    // Audience options are gone in every locale — a zh-only regression here
+    // would mean the removal was done in the component but not the catalog.
+    expect(screen.queryByRole('button', { name: /开放加入/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /仅限邀请/ })).not.toBeInTheDocument();
 
+    // What SHOULD localize: the fields creation still asks for.
+    expect(screen.getByPlaceholderText('Pod 名称')).toBeInTheDocument();
   });
 });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -236,14 +236,11 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(v2, '.v2-msg__reaction-emoji')).toContain('line-height: 22px');
   });
 
-  test('create-pod options carry the .v2-root button. prefix or the reset erases them', () => {
-    // The global reset (.v2-root button:not(.MuiButtonBase-root), 0-2-1)
-    // beats any bare class (0-1-0) and strips border/background/padding. The
-    // create-pod option buttons shipped bare and rendered as plain prose with
-    // no selection feedback — found live the night before the YC interview.
-    // Selection must be the accent, not a gray border, or "selected" is
-    // invisible even when it wins the cascade.
-    expect(ruleBody(v2, '.v2-root button.v2-pods__create-option')).toContain('border: 1px solid');
-    expect(ruleBody(v2, '.v2-root button.v2-pods__create-option--active')).toContain('var(--v2-accent)');
+  test('create-pod panel no longer ships audience options (ADR-016 / #768)', () => {
+    // Creation asks name + purpose only; visibility is a later act. If option
+    // buttons ever come back to this panel they MUST carry the
+    // `.v2-root button.` prefix — the global reset (0-2-1) beats a bare class
+    // and renders them as plain prose, which shipped once (#870).
+    expect(v2).not.toMatch(/\.v2-pods__create-option[^\n]*\{/);
   });
 });

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -202,7 +202,11 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
   const [showCreate, setShowCreate] = useState(false);
   const [newPodName, setNewPodName] = useState('');
   const [newPodGoal, setNewPodGoal] = useState('');
-  const [newPodJoinPolicy, setNewPodJoinPolicy] = useState<'open' | 'invite-only'>('open');
+  // Every pod is born private and unlisted (ADR-016). `joinPolicy: 'open'`
+  // below the community tier is a DORMANT declaration — "open once listed" —
+  // not an audience the creator is choosing here. Creation asks for name and
+  // purpose only; visibility is set later, on a pod that has something in it.
+  const newPodJoinPolicy = 'open' as const;
   const [createError, setCreateError] = useState<string | null>(null);
   // Pod IDs an agent is currently typing into. Set, not bool, because
   // multiple agents could type at once. Cleared after 30s safety in case the
@@ -443,7 +447,6 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
         }
         setNewPodName('');
         setNewPodGoal('');
-        setNewPodJoinPolicy('open');
         setShowCreate(false);
         selectPod(pod._id);
       } else {
@@ -477,7 +480,6 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
             className="v2-pods__new-btn"
             onClick={() => {
               setShowCreate((next) => !next);
-              setNewPodJoinPolicy('open');
               setCreateError(null);
             }}
             disabled={creating}
@@ -489,32 +491,6 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
           </button>
           {showCreate && (
             <form className="v2-pods__create" onSubmit={handleCreatePod}>
-              <div className="v2-pods__create-options">
-                <button
-                  type="button"
-                  className={`v2-pods__create-option${newPodJoinPolicy === 'open' ? ' v2-pods__create-option--active' : ''}`}
-                  aria-pressed={newPodJoinPolicy === 'open'}
-                  onClick={() => {
-                    setNewPodJoinPolicy('open');
-                    setCreateError(null);
-                  }}
-                >
-                  <strong>{t('podsSidebar.create.teamOption')}</strong>
-                  <span>{t('podsSidebar.create.teamDescription')}</span>
-                </button>
-                <button
-                  type="button"
-                  className={`v2-pods__create-option${newPodJoinPolicy === 'invite-only' ? ' v2-pods__create-option--active' : ''}`}
-                  aria-pressed={newPodJoinPolicy === 'invite-only'}
-                  onClick={() => {
-                    setNewPodJoinPolicy('invite-only');
-                    setCreateError(null);
-                  }}
-                >
-                  <strong>{t('podsSidebar.create.privateOption')}</strong>
-                  <span>{t('podsSidebar.create.privateDescription')}</span>
-                </button>
-              </div>
               <input
                 className="v2-pods__create-input"
                 type="text"
@@ -537,7 +513,6 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
                   className="v2-pods__create-cancel"
                   onClick={() => {
                     setShowCreate(false);
-                    setNewPodJoinPolicy('open');
                     setCreateError(null);
                   }}
                 >

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -714,72 +714,16 @@
   margin-bottom: 14px;
 }
 
-.v2-pods__create-options {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 6px;
-}
-
-/* .v2-root button. prefix, not bare .v2-pods__create-option: the global
- * button reset (.v2-root button:not(.MuiButtonBase-root), specificity 0-2-1)
- * beats a bare class (0-1-0) and strips border/background/padding — so both
- * options rendered as PLAIN PROSE with zero selection feedback, live, until
- * 2026-08-06 (Sam: "no distinction at all", the night before the YC
- * interview). Same war the reaction chips and filter segments already fought;
- * this panel never got the workaround. Every rule here that must survive the
- * reset carries the prefix. */
-.v2-root button.v2-pods__create-option {
-  display: flex;
-  min-height: 48px;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 2px;
-  padding: 8px 10px;
-  background: #ffffff;
-  border: 1px solid var(--v2-border);
-  border-radius: var(--v2-radius-sm);
-  color: var(--v2-text-secondary);
-  text-align: left;
-  transition: background 80ms ease, border-color 80ms ease;
-}
-
-.v2-root button.v2-pods__create-option:hover {
-  border-color: var(--v2-border-strong);
-}
-
-.v2-pods__create-option strong {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.v2-pods__create-option span {
-  color: var(--v2-text-tertiary);
-  font-size: 10px;
-  font-weight: 500;
-  line-height: 1.35;
-}
-
-/* Selected = the accent, unambiguously: soft fill + accent border + a dot
- * beside the label. The original --active used border-color:
- * var(--v2-border-strong) — gray — which would have been near-invisible even
- * without the reset eating it. */
-.v2-root button.v2-pods__create-option--active {
-  background: var(--v2-accent-soft);
-  border-color: var(--v2-accent);
-  color: var(--v2-accent-text);
-}
-
-.v2-root button.v2-pods__create-option--active strong::after {
-  content: '';
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--v2-accent);
-  flex: none;
-}
+/* Creation no longer asks about audience (ADR-016 / #768): every pod is born
+ * private, and visibility is set later on a pod that has content worth
+ * disclosing. The two option cards and their styles are gone with it — along
+ * with the selected-state dot, which was a fourth signal saying what the
+ * accent fill, border and text colour already said.
+ *
+ * Kept as a note rather than silence because the rules that lived here fought
+ * the global button reset (.v2-root button:not(.MuiButtonBase-root), 0-2-1),
+ * and anything reintroducing option buttons in this panel will need the same
+ * `.v2-root button.` prefix or it will render as plain prose again (#870). */
 
 .v2-pods__create-input {
   width: 100%;


### PR DESCRIPTION
Closes the inert-choice half of #768. Implements the ratification proposal posted there.

## The bug, restated precisely

`createPod` writes `joinPolicy` and hardcodes `type`; `communityListed` — the flag that decides whether anyone can **find** the pod — was writable only from `routes/admin/pods.ts` behind `adminAuth`. Since self-joinable is `community AND open`, a user picking **"Open to join"** got a pod nobody could discover, and had no path to fix it. The most prominent control in the creation flow did nothing for every non-admin.

## 1. `POST /api/pods/:id/visibility { tier: 'private' | 'community' }`

Owner- or admin-scoped. Rate limited to **10/hour** — this is the one owner action that exposes content to non-members and to people with no account. Audited on every call. Refused for DM kinds.

**It writes both flags in one action, and that is the design, not a shortcut.** The admin route splits them because `showcase` (publicRead without listing) is a real curated state it needs to express. An owner cannot reach that state, so an owner-side two-step would 409 on `listing_requires_public_read` forever with no way to clear it. Writing the pair atomically is also precisely what ADR-016 invariant 1 (*listed ⇒ readable*) asks of any writer that can prove it.

`showcase` stays admin-only: it publishes every future message to anonymous readers.

**Deliberately not exposed to agents** — no `dualAuth`. An agent that could publish its own pod could exfiltrate a private room's entire future history in one call.

## 2. Creation asks for intent, not audience

The two option cards are gone. Every pod is born private; `joinPolicy: 'open'` below the community tier is the **dormant declaration** ("open once listed"), not a choice a stranger should make about a room with nothing in it. Visibility becomes a later, deliberate act on a pod that has content worth disclosing — ADR-016's own position, and it makes the panel simpler rather than larger.

This also retires the selected-state dot from #870: with the cards gone it has nothing to mark, and it was a fourth signal saying what the accent fill, border and text colour already said.

## No migration — verified, not assumed

Queried production before writing a line: **zero pods are in an unrepresentable state** (listed-but-unreadable). All 235 land in exactly the three tiers, and the 18 legacy `null` joinPolicy rows are already covered by the fail-open predicate.

```
private   publicRead=false/undefined  communityListed=false/undefined  -> 230
showcase  publicRead=true             communityListed=undefined        ->   2
community publicRead=true             communityListed=true             ->   3
```

## Verification

- **15 new route tests**: invariant 1 holds on promote, `showcase` refused, garbage tiers refused without writing, non-owner refused, admin allowed, 404 on missing pod, all three DM kinds refused, audit row written on list *and* unlist, audit failure non-fatal, limiter wired.
- The limiter is stubbed in tests (10/hour would 429 mid-suite on a shared IP) so its **wiring is asserted separately** rather than silently lost.
- Frontend suites rewritten for the simplified form, **including a zh-CN case** so the removal can't be done in the component but missed in the locale catalog.
- Layout invariant now asserts the option *rules* are gone, and documents that anything reintroducing option buttons here needs the `.v2-root button.` prefix or it renders as plain prose (#870).
- Backend + frontend typecheck clean; 33/33 across the four affected frontend suites.

## Sequencing note

This unblocks #871 (agent-led onboarding): a guide agent can now offer "a room your team can find" without the platform refusing. The remaining #768 work is the UI control for the tier in pod settings, plus the naming pass (Private / Showcase / Community; Open / Invite-only; DM) that stops "private" meaning three different things.
