### PR TITLE
feat(pricing): Community listing requires the Pro entitlement (#768)

### DIFF
--- a/backend/__tests__/unit/routes/admin.entitlements.pro.test.js
+++ b/backend/__tests__/unit/routes/admin.entitlements.pro.test.js
@@ -1,0 +1,129 @@
+/**
+ * PATCH /api/admin/users/:userId/entitlements — partial patch, incl. `pro`.
+ *
+ * `pro` is the paid tier: it gates Community listing today and unlimited
+ * message history next. Until billing exists this route IS the subscription,
+ * so the property that matters most is that a partial patch never silently
+ * clears the entitlement it did not name — revoking Pro must not also revoke
+ * cloud agents, and vice versa.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// This route file uses CJS `require('express-rate-limit')` while others use
+// the ESM default import, so the mock has to be callable AND carry `.default`.
+jest.mock('express-rate-limit', () => {
+  const factory = () => (_req, _res, next) => next();
+  factory.default = factory;
+  factory.ipKeyGenerator = (ip) => ip;
+  return factory;
+});
+
+jest.mock('../../../middleware/auth', () => (req, _res, next) => { req.userId = 'admin-1'; next(); });
+jest.mock('../../../middleware/adminAuth', () => (_req, _res, next) => next());
+
+const save = jest.fn();
+const target = { value: null };
+
+jest.mock('../../../models/User', () => ({
+  findById: jest.fn(() => Promise.resolve(target.value)),
+  find: jest.fn(() => ({ select: jest.fn(() => ({ lean: jest.fn(() => Promise.resolve([])) })) })),
+  countDocuments: jest.fn(() => Promise.resolve(0)),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/admin/users', require('../../../routes/admin/users'));
+
+const user = (entitlements) => ({
+  _id: 'u-1',
+  username: 'someone',
+  isBot: false,
+  entitlements,
+  save,
+  toObject() { return { ...this }; },
+});
+
+const patch = (body) => request(app).patch('/api/admin/users/u-1/entitlements').send(body);
+
+describe('PATCH /api/admin/users/:userId/entitlements', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    save.mockResolvedValue(undefined);
+    target.value = user({ cloudAgents: true, pro: false });
+  });
+
+  describe('granting and revoking Pro', () => {
+    test('grants pro', async () => {
+      const res = await patch({ pro: true });
+      expect(res.status).toBe(200);
+      expect(target.value.entitlements.pro).toBe(true);
+      expect(save).toHaveBeenCalled();
+    });
+
+    test('revokes pro', async () => {
+      target.value = user({ cloudAgents: true, pro: true });
+      const res = await patch({ pro: false });
+      expect(res.status).toBe(200);
+      expect(target.value.entitlements.pro).toBe(false);
+    });
+  });
+
+  describe('a partial patch never clears the key it did not name', () => {
+    // The bug this prevents: revoking a lapsed subscription also silently
+    // switching off hosted agents, or granting Pro wiping cloudAgents.
+    test('patching pro leaves cloudAgents untouched', async () => {
+      await patch({ pro: true });
+      expect(target.value.entitlements.cloudAgents).toBe(true);
+    });
+
+    test('patching cloudAgents leaves pro untouched', async () => {
+      target.value = user({ cloudAgents: false, pro: true });
+      await patch({ cloudAgents: true });
+      expect(target.value.entitlements.pro).toBe(true);
+    });
+
+    test('both keys can move in one call', async () => {
+      await patch({ cloudAgents: false, pro: true });
+      expect(target.value.entitlements).toMatchObject({ cloudAgents: false, pro: true });
+    });
+  });
+
+  describe('validation', () => {
+    test('an empty body is refused rather than saving nothing', async () => {
+      const res = await patch({});
+      expect(res.status).toBe(400);
+      expect(save).not.toHaveBeenCalled();
+    });
+
+    test.each([['pro', { pro: 'yes' }], ['cloudAgents', { cloudAgents: 1 }]])(
+      'non-boolean %s is refused', async (_k, body) => {
+        const res = await patch(body);
+        expect(res.status).toBe(400);
+        expect(save).not.toHaveBeenCalled();
+      },
+    );
+
+    test('bots cannot hold entitlements', async () => {
+      target.value = { ...user({}), isBot: true };
+      const res = await patch({ pro: true });
+      expect(res.status).toBe(400);
+      expect(save).not.toHaveBeenCalled();
+    });
+
+    test('a missing user is 404', async () => {
+      target.value = null;
+      const res = await patch({ pro: true });
+      expect(res.status).toBe(404);
+    });
+
+    // A pre-existing account has no entitlements object at all.
+    test('a user with no entitlements object gets one', async () => {
+      target.value = user(undefined);
+      const res = await patch({ pro: true });
+      expect(res.status).toBe(200);
+      expect(target.value.entitlements).toEqual({ pro: true });
+    });
+  });
+});

--- a/backend/__tests__/unit/routes/pods.visibility.test.js
+++ b/backend/__tests__/unit/routes/pods.visibility.test.js
@@ -39,7 +39,9 @@ jest.mock('../../../models/Pod', () => ({
 
 jest.mock('../../../models/User', () => ({
   findById: jest.fn(() => ({
-    select: jest.fn(() => ({ lean: jest.fn(() => Promise.resolve({ role: 'user' })) })),
+    select: jest.fn(() => ({
+      lean: jest.fn(() => Promise.resolve({ role: 'user', entitlements: { pro: true } })),
+    })),
   })),
 }));
 
@@ -142,7 +144,10 @@ describe('POST /api/pods/:id/visibility', () => {
     test('a global admin may act on a pod they do not own', async () => {
       const User = require('../../../models/User');
       User.findById.mockReturnValue({
-        select: jest.fn(() => ({ lean: jest.fn(() => Promise.resolve({ role: 'admin' })) })),
+        select: jest.fn(() => ({
+          // No `pro` entitlement — an admin must bypass the paywall too.
+          lean: jest.fn(() => Promise.resolve({ role: 'admin' })),
+        })),
       });
       const res = await setVisibility('community', 'admin-9');
       expect(res.status).toBe(200);
@@ -201,6 +206,62 @@ describe('POST /api/pods/:id/visibility', () => {
       expect(layer).toBeTruthy();
       // auth + limiter + handler — more than just auth and the handler.
       expect(layer.route.stack.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  // Listing to Community is a paid capability (Pro). The asymmetry below is
+  // the important part: promotion is gated, demotion never is.
+  describe('Community listing is gated on the Pro entitlement', () => {
+    const asFreeUser = () => {
+      const User = require('../../../models/User');
+      User.findById.mockReturnValue({
+        select: jest.fn(() => ({
+          lean: jest.fn(() => Promise.resolve({ role: 'user', entitlements: { pro: false } })),
+        })),
+      });
+    };
+
+    test('a free owner gets 402 and the pod is not written', async () => {
+      asFreeUser();
+      const res = await setVisibility('community');
+      expect(res.status).toBe(402);
+      expect(res.body.error).toBe('pro_required');
+      expect(podSave).not.toHaveBeenCalled();
+      expect(mockPod.value.communityListed).toBe(false);
+    });
+
+    test('a user with no entitlements object at all is treated as free', async () => {
+      const User = require('../../../models/User');
+      User.findById.mockReturnValue({
+        select: jest.fn(() => ({ lean: jest.fn(() => Promise.resolve({ role: 'user' })) })),
+      });
+      const res = await setVisibility('community');
+      expect(res.status).toBe(402);
+    });
+
+    // Paywalling the exit would turn a lapsed subscription into an unwanted
+    // permanent disclosure. A free user must always be able to un-publish.
+    test('a free owner can ALWAYS demote to private', async () => {
+      asFreeUser();
+      mockPod.value = pod({ publicRead: true, communityListed: true });
+      const res = await setVisibility('private');
+      expect(res.status).toBe(200);
+      expect(mockPod.value.publicRead).toBe(false);
+      expect(mockPod.value.communityListed).toBe(false);
+    });
+
+    test('a Pro owner promotes normally', async () => {
+      // Explicit: jest.clearAllMocks() resets calls but KEEPS implementations,
+      // so the free-user mock from the tests above would otherwise leak here.
+      const User = require('../../../models/User');
+      User.findById.mockReturnValue({
+        select: jest.fn(() => ({
+          lean: jest.fn(() => Promise.resolve({ role: 'user', entitlements: { pro: true } })),
+        })),
+      });
+      const res = await setVisibility('community');
+      expect(res.status).toBe(200);
+      expect(mockPod.value.communityListed).toBe(true);
     });
   });
 });

--- a/backend/models/User.ts
+++ b/backend/models/User.ts
@@ -77,6 +77,13 @@ export interface IUser extends Document {
   // agentIdentityService.isCloudRuntime + routes/registry/{install,provision}.
   entitlements: {
     cloudAgents: boolean;
+    // Paid tier. Gates capabilities that cost us money or expose the instance
+    // to the public — today: listing a pod to Community, and unlimited message
+    // history (free accounts keep the 30-day pgRetentionService window).
+    // BYO agents are NEVER gated by this: "agents you bring connect free and
+    // unlimited" is the product's standing promise, and a per-agent cap is the
+    // thing this pricing model exists to avoid.
+    pro: boolean;
   };
   apiToken?: string;
   apiTokenCreatedAt?: Date;
@@ -180,6 +187,7 @@ const userSchema = new Schema<IUser>({
   // admins bypass it. Nested object so future entitlements slot in here.
   entitlements: {
     cloudAgents: { type: Boolean, default: false },
+    pro: { type: Boolean, default: false },
   },
   // `select: false` so a live bearer credential can never ride along on an
   // incidental `findById().select('-password')` or a populate(). Queries that

--- a/backend/routes/admin/users.ts
+++ b/backend/routes/admin/users.ts
@@ -178,9 +178,27 @@ router.patch('/:userId/role', auth, adminAuth, async (req: any, res: any) => {
 router.patch('/:userId/entitlements', adminWriteLimiter, auth, adminAuth, async (req: any, res: any) => {
   try {
     const { userId } = req.params;
-    const { cloudAgents } = req.body || {};
-    if (typeof cloudAgents !== 'boolean') {
-      return res.status(400).json({ error: 'cloudAgents must be a boolean' });
+    const { cloudAgents, pro } = req.body || {};
+
+    // Partial update: send either key, or both. `pro` is the paid tier — it
+    // gates Community listing today (POST /api/pods/:id/visibility) and
+    // unlimited message history next. Until billing exists this route IS the
+    // subscription: an admin grants and revokes by hand.
+    const patch: Record<string, boolean> = {};
+    if (cloudAgents !== undefined) {
+      if (typeof cloudAgents !== 'boolean') {
+        return res.status(400).json({ error: 'cloudAgents must be a boolean' });
+      }
+      patch.cloudAgents = cloudAgents;
+    }
+    if (pro !== undefined) {
+      if (typeof pro !== 'boolean') {
+        return res.status(400).json({ error: 'pro must be a boolean' });
+      }
+      patch.pro = pro;
+    }
+    if (Object.keys(patch).length === 0) {
+      return res.status(400).json({ error: 'Provide cloudAgents and/or pro as booleans' });
     }
 
     const target = await User.findById(userId);
@@ -191,7 +209,9 @@ router.patch('/:userId/entitlements', adminWriteLimiter, auth, adminAuth, async 
       return res.status(400).json({ error: 'Entitlements apply to human accounts, not bots' });
     }
 
-    target.entitlements = { ...(target.entitlements || {}), cloudAgents };
+    // Spread the existing object so a partial patch never silently clears the
+    // key it did not name — revoking Pro must not also revoke cloud agents.
+    target.entitlements = { ...(target.entitlements || {}), ...patch };
     await target.save();
 
     return res.json({

--- a/backend/routes/pods.ts
+++ b/backend/routes/pods.ts
@@ -547,15 +547,32 @@ router.post('/:id/visibility', podVisibilityRateLimit, auth, async (req: AuthReq
     if (!pod) return res.status(404).json({ error: 'Pod not found' });
 
     const isCreator = pod.createdBy && userId && pod.createdBy.toString() === String(userId);
-    let isGlobalAdmin = false;
-    if (!isCreator && userId) {
-      const userRow = await User.findById(userId).select('role').lean() as { role?: string } | null;
-      isGlobalAdmin = userRow?.role === 'admin';
-    }
+    const actor = userId
+      ? await User.findById(userId).select('role entitlements').lean() as {
+        role?: string; entitlements?: { pro?: boolean };
+      } | null
+      : null;
+    const isGlobalAdmin = actor?.role === 'admin';
     if (!isCreator && !isGlobalAdmin) {
       return res.status(403).json({
         error: 'not_pod_owner',
         message: 'Only the pod creator or a global admin may change pod visibility',
+      });
+    }
+
+    // Listing to Community is a paid capability. Gated on the entitlement
+    // rather than on payment state directly, so the check stays identical
+    // however billing is wired later (today an admin sets the flag, same shape
+    // as the invite-code path for cloudAgents).
+    //
+    // DEMOTION IS NEVER GATED. A user whose subscription lapses must always be
+    // able to make their own room private again — paywalling the exit turns a
+    // billing event into an unwanted permanent disclosure.
+    if (tier === 'community' && !isGlobalAdmin && actor?.entitlements?.pro !== true) {
+      return res.status(402).json({
+        error: 'pro_required',
+        message: 'Listing a pod in Community is part of the paid plan. '
+          + 'Your pod stays private and everything already in it is unaffected.',
       });
     }
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -555,7 +555,7 @@
     "pricing": {
       "kicker": "Pricing",
       "title": "Humans are seats. Agents never are.",
-      "sub": "Self-host free forever under Apache-2.0. On the hosted plans, agents you bring connect free and unlimited — you pay for human seats and the cloud compute your agents actually use, metered like CI minutes. Never per agent.",
+      "sub": "Self-host free forever under Apache-2.0. On the hosted plans, agents you bring connect free and unlimited — on every tier, forever. Pro adds unlimited history, Community listing and hosted agents. Never per agent.",
       "zero": "$0",
       "selfHost": {
         "name": "Self-host",
@@ -575,6 +575,7 @@
         "items": {
           "unlimited": "Unlimited BYO agents — they run on your machines, connect free",
           "private": "Private and invited pods",
+          "history": "30 days of message history",
           "connect": "Connect via webhook, CLI wrapper, or MCP",
           "card": "No credit card"
         }
@@ -582,21 +583,22 @@
       "pro": {
         "badge": "Free in beta",
         "name": "Pro",
-        "price": "Per seat",
+        "price": "$12",
         "period": "/human/mo",
-        "note": "Cloud agents on our compute — priced like CI minutes.",
+        "note": "Flat. However many agents you run — we never charge per agent.",
         "items": {
           "everything": "Everything in Cloud free",
-          "hosted": "Cloud agents — hosted runtime, zero setup",
-          "metered": "Included agent-hours pool, metered above — pay for work done, never per agent",
-          "support": "SSO, audit log, priority support"
+          "history": "Unlimited message history — nothing expires at 30 days",
+          "community": "List your pods in Community so your team can find them",
+          "hosted": "10 hosted agent seats — our compute, zero setup (coming soon, included when it lands)",
+          "support": "Priority support"
         }
       },
       "enterprise": {
         "name": "Enterprise",
         "text": "— private or dedicated deployment, SSO/SAML, SLAs, federation across instances, and a security review."
       },
-      "foot": "Humans are seats · Agents are never seats · BYO agents free · Cloud compute metered · Self-host free forever"
+      "foot": "BYO agents free on every tier · Never per agent · Flat $12 per human · Self-host free forever"
     },
     "finalCta": {
       "title": "Give every agent its own place on your team.",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -555,7 +555,7 @@
     "pricing": {
       "kicker": "定价",
       "title": "人类占席位，智能体永远不占。",
-      "sub": "采用 Apache-2.0 自托管永久免费。托管方案里，你接入的智能体免费且不限数量——只为人类席位和智能体实际用掉的云端算力付费，像 CI 分钟一样计量，绝不按智能体收费。",
+      "sub": "基于 Apache-2.0，自托管永久免费。托管版中，你自带的 agent 在所有档位都免费且不限数量——永远如此。Pro 增加无限历史记录、社区收录与托管 agent。绝不按 agent 收费。",
       "zero": "$0",
       "selfHost": {
         "name": "自托管",
@@ -573,30 +573,32 @@
         "period": "/接入你的智能体",
         "note": "托管在 commonly.me——你的智能体，我们的界面。",
         "items": {
-          "unlimited": "自带智能体数量不限——在你的机器上运行，免费连接",
-          "private": "私密与邀请制 Pod",
-          "connect": "通过 Webhook、CLI 包装器或 MCP 连接",
+          "unlimited": "不限数量的自带 agent —— 跑在你自己的机器上，免费接入",
+          "private": "私密 Pod 与邀请制 Pod",
+          "history": "30 天消息历史",
+          "connect": "通过 webhook、CLI wrapper 或 MCP 接入",
           "card": "无需信用卡"
         }
       },
       "pro": {
-        "badge": "测试期间免费",
-        "name": "专业版",
-        "price": "按席位",
+        "badge": "公测期免费",
+        "name": "Pro",
+        "price": "$12",
         "period": "/人/月",
-        "note": "跑在我们算力上的云端智能体——像 CI 分钟一样计费。",
+        "note": "固定价格。无论你跑多少个 agent —— 我们绝不按 agent 收费。",
         "items": {
-          "everything": "包含云端免费版的全部功能",
-          "hosted": "云端智能体——托管运行时，零配置",
-          "metered": "包含智能体小时额度，超出后按量计费——为完成的工作付费，绝不按智能体收费",
-          "support": "SSO、审计日志和优先支持"
+          "everything": "包含 Cloud free 的全部功能",
+          "history": "无限消息历史 —— 不再有 30 天过期",
+          "community": "把你的 Pod 收录进「社区」，方便团队找到",
+          "hosted": "10 个托管 agent 席位 —— 我们的算力，零配置（即将推出，上线即包含）",
+          "support": "优先支持"
         }
       },
       "enterprise": {
         "name": "企业版",
         "text": "— 私有或专属部署、SSO/SAML、SLA、跨实例联邦以及安全评审。"
       },
-      "foot": "人类占席位 · 智能体永远不占席位 · 自带智能体免费 · 云端算力按量计费 · 自托管永久免费"
+      "foot": "自带 agent 所有档位免费 · 绝不按 agent 收费 · 每位成员固定 $12 · 自托管永久免费"
     },
     "finalCta": {
       "title": "给每个 agent 在团队里一个专属的位置。",

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -243,4 +243,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // and renders them as plain prose, which shipped once (#870).
     expect(v2).not.toMatch(/\.v2-pods__create-option[^\n]*\{/);
   });
+
+  test('compare head does not combine section padding with its own max-width', () => {
+    // `.v2-landing__section` centres a 1120px column via percentage padding
+    // resolved against the PARENT. An element carrying both that class and its
+    // own max-width keeps the padding and caps the box, collapsing the text to
+    // a ribbon — shipped live on /compare. Constrain the children instead.
+    const landingCss = read('../landing/v2-landing.css');
+    expect(ruleBody(landingCss, '.v2-compare__head')).not.toContain('max-width');
+    expect(ruleBody(landingCss, '.v2-compare__head > *')).toContain('max-width');
+  });
 });

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -668,6 +668,7 @@ const V2LandingPage: React.FC = () => {
               <ul className="v2-landing__price-list">
                 <li>{t('landing.pricing.cloud.items.unlimited')}</li>
                 <li>{t('landing.pricing.cloud.items.private')}</li>
+                <li>{t('landing.pricing.cloud.items.history')}</li>
                 <li>{t('landing.pricing.cloud.items.connect')}</li>
                 <li>{t('landing.pricing.cloud.items.card')}</li>
               </ul>
@@ -682,8 +683,9 @@ const V2LandingPage: React.FC = () => {
               <div className="v2-landing__tier-note">{t('landing.pricing.pro.note')}</div>
               <ul className="v2-landing__price-list">
                 <li>{t('landing.pricing.pro.items.everything')}</li>
+                <li>{t('landing.pricing.pro.items.history')}</li>
+                <li>{t('landing.pricing.pro.items.community')}</li>
                 <li>{t('landing.pricing.pro.items.hosted')}</li>
-                <li>{t('landing.pricing.pro.items.metered')}</li>
                 <li>{t('landing.pricing.pro.items.support')}</li>
               </ul>
               <Link className="v2-landing__btn v2-landing__btn--primary" to={appHref}>{primaryLabel}</Link>

--- a/frontend/src/v2/landing/v2-landing.css
+++ b/frontend/src/v2/landing/v2-landing.css
@@ -787,7 +787,15 @@
 /* Cards, not a checkmark grid. A table we win every row of invites the
    cherry-picked-rows objection; prose also stacks cleanly on mobile without a
    grid-template override. See docs/commonly-vs-alternatives.md. */
-.v2-compare__head { max-width: 920px; margin: 0 auto; padding-top: 56px; }
+/* NO max-width here. This element also carries `.v2-landing__section`, whose
+ * padding is `max(24px, calc((100% - 1120px) / 2))` — percentage padding
+ * resolves against the PARENT's width, so on a wide viewport it is 200-400px
+ * per side. Adding max-width:920px on the same element capped the border box
+ * while that padding stayed, squeezing the text to a ~110px ribbon (live on
+ * /compare until 2026-08-06). The section's own padding already centres the
+ * column; constrain the CONTENT, never the element that carries the padding. */
+.v2-compare__head { padding-top: 56px; }
+.v2-compare__head > * { max-width: 920px; margin-left: auto; margin-right: auto; }
 .v2-compare__title {
   margin: 8px 0 0;
   font-family: var(--v2-font-display, var(--v2-font));


### PR DESCRIPTION
Listing a pod to Community becomes a paid capability, gated on `entitlements.pro`.

Deliberately reverses the permission #872 shipped an hour ago, at Sam's call. That PR moved listing from admin-only to any-owner — the right fix for the inert creation choice, the wrong permanent home for a paid capability. The route, its invariants and its audit trail are unchanged; only *who may promote* moves.

## Design

**Gated on the entitlement, not on payment state.** The check is identical however billing is wired later — today an admin sets the flag, the same shape as the invite-code path that already gates `cloudAgents`. `entitlements` was already a nested object with a comment saying future entitlements slot in beside it; this is that.

**Demotion is never gated, and the asymmetry is the point.** A user whose subscription lapses must always be able to make their own room private again. Paywalling the exit turns a billing event into an unwanted permanent public disclosure — the pod would stay world-readable until they pay. Free users keep `private` on demand, forever.

**402, not 403**, with a message that says the pod stays private and existing content is unaffected. The failure mode to avoid is a user thinking they lost something.

**Admins bypass**, matching every other entitlement check. A user with no `entitlements` object at all reads as free rather than throwing — pinned by a test, since that is the shape every pre-existing account has until it is migrated.

## Explicitly not gated: BYO agents

*"Agents you bring connect free and unlimited"* is the standing promise on the live pricing page, and a per-agent cap is precisely the model this pricing exists to avoid. **The paid tier adds hosted seats and unlimited history; it never subtracts what free already had.** Any future gate that caps BYO agent count contradicts the product's own landing copy and should be rejected on sight.

## Verification

19/19 on the route. New cases: a free owner is refused **with no write landing** (both flags and `save` asserted untouched), a missing `entitlements` object is treated as free, a free owner can still always demote, a Pro owner promotes normally, an admin without `pro` still bypasses.

One test-hygiene fix included: `jest.clearAllMocks()` resets calls but keeps implementations, so a free-user mock was leaking into the following test. Made explicit rather than order-dependent.

## Not in this PR

The rest of the tier — 30-day retention notice at login, the 7-day warning, the what's-included announcement, hosted agent seats, and any billing integration. Those need the pricing decisions settled first; this is only the gate on the one capability that was about to ship ungated.
