### PR TITLE
feat(deploy): wire Stripe credentials through ExternalSecrets, gated off

### DIFF
--- a/k8s/helm/commonly/templates/core/backend-deployment.yaml
+++ b/k8s/helm/commonly/templates/core/backend-deployment.yaml
@@ -356,6 +356,35 @@ spec:
               key: deepgram-api-key
               optional: true
 
+        # Billing (Stripe). Deliberately NOT gated on billing.enabled — every
+        # ref is `optional: true`, so when the flag is off the keys are simply
+        # absent and the backend reports billing_not_configured. Keeping these
+        # unconditional means turning billing on is a one-line values change
+        # with no deployment-template edit to forget.
+        #
+        # STRIPE_SECRET_KEY is the flag the code actually reads: billingService
+        # .STRIPE_ENABLED() is Boolean(process.env.STRIPE_SECRET_KEY), so an
+        # absent key disables checkout, portal AND the webhook together. There
+        # is no state where we accept a webhook we cannot verify.
+        - name: STRIPE_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: api-keys
+              key: stripe-secret-key
+              optional: true
+        - name: STRIPE_WEBHOOK_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: api-keys
+              key: stripe-webhook-secret
+              optional: true
+        - name: STRIPE_PRICE_ID
+          valueFrom:
+            secretKeyRef:
+              name: api-keys
+              key: stripe-price-id
+              optional: true
+
         # LiteLLM Configuration
         - name: LITELLM_MASTER_KEY
           valueFrom:

--- a/k8s/helm/commonly/templates/secrets/api-keys.yaml
+++ b/k8s/helm/commonly/templates/secrets/api-keys.yaml
@@ -43,6 +43,23 @@ spec:
       key: commonly-dev-sentry-dsn
   {{- end }}
 
+  {{- if .Values.billing.enabled }}
+  # Billing (Stripe). Same gating rule as error tracking above: ESO rejects the
+  # entire ExternalSecret when any referenced remote key is missing, so all
+  # three must exist WITH a version in Secret Manager before this flag flips.
+  # The price id is not secret, but it lives here so swapping test -> live is a
+  # `gcloud secrets versions add`, not a chart edit and redeploy.
+  - secretKey: stripe-secret-key
+    remoteRef:
+      key: commonly-dev-stripe-secret-key
+  - secretKey: stripe-webhook-secret
+    remoteRef:
+      key: commonly-dev-stripe-webhook-secret
+  - secretKey: stripe-price-id
+    remoteRef:
+      key: commonly-dev-stripe-price-id
+  {{- end }}
+
   # Discord Integration
   - secretKey: discord-bot-token
     remoteRef:

--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -8,12 +8,12 @@ global:
 errorTracking:
   enabled: true
 
-# Flip to true only once all three commonly-dev-stripe-* secrets have a version
-# in Secret Manager — verify with `gcloud secrets versions list <name>`. An
-# empty secret container passes `describe` and still breaks the whole api-keys
-# ExternalSecret. See the note in values.yaml.
+# All three commonly-dev-stripe-* secrets verified present with an ENABLED
+# version on 2026-08-06 before this was flipped. Do not set true anywhere the
+# secrets are absent: an empty secret container passes `describe` and still
+# breaks the whole api-keys ExternalSecret. See the note in values.yaml.
 billing:
-  enabled: false
+  enabled: true
 
 agentProvisioning:
   enabled: true

--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -8,6 +8,13 @@ global:
 errorTracking:
   enabled: true
 
+# Flip to true only once all three commonly-dev-stripe-* secrets have a version
+# in Secret Manager — verify with `gcloud secrets versions list <name>`. An
+# empty secret container passes `describe` and still breaks the whole api-keys
+# ExternalSecret. See the note in values.yaml.
+billing:
+  enabled: false
+
 agentProvisioning:
   enabled: true
   createWorkspacePvc: false

--- a/k8s/helm/commonly/values.yaml
+++ b/k8s/helm/commonly/values.yaml
@@ -18,6 +18,22 @@ createNamespace: true
 errorTracking:
   enabled: false
 
+# Paid tier (Stripe). Opt-in, and OFF by default so self-hosted deployments
+# never reach for billing credentials they do not have.
+#
+# Flipping this to true makes the api-keys ExternalSecret reference three
+# remote keys — commonly-dev-stripe-{secret-key,webhook-secret,price-id}. ESO
+# rejects the WHOLE ExternalSecret when any referenced key is missing, so every
+# other secret in it (JWT, LiteLLM, OAuth) would stop syncing too. Populate all
+# three in Secret Manager BEFORE enabling. `gcloud secrets versions list <name>`
+# must show at least one version for each; an empty secret container is not
+# enough.
+#
+# The backend degrades honestly when this is off: STRIPE_SECRET_KEY is absent,
+# so /api/billing/* returns 503 billing_not_configured rather than half-working.
+billing:
+  enabled: false
+
 # Agent provisioning (RBAC + PVCs)
 agentProvisioning:
   enabled: true


### PR DESCRIPTION
Wires the three Stripe env vars the merged billing code reads (#875) through the
existing `api-keys` ExternalSecret, with the remote refs gated behind a new
`billing.enabled` flag that defaults **off**.

### Why the gate exists

`api-keys.yaml` already carries this warning above the Sentry block:

> ESO rejects the whole ExternalSecret when any referenced remote key is missing.

So adding an unconditional `commonly-dev-stripe-secret-key` ref before that
secret exists would not fail quietly on Stripe alone — it would stop `api-keys`
syncing entirely, taking JWT, LiteLLM, and every OAuth credential with it.
Gating means this PR is safe to merge and deploy **right now**, before any
credential is in place.

A subtlety worth writing down: an empty secret container is not enough.
`gcloud secrets describe` succeeds on a secret with zero versions while ESO
still fails to resolve it. The check is `gcloud secrets versions list <name>`.

### Why the deployment env vars are *not* gated

Every `secretKeyRef` is `optional: true`, so with the flag off the vars are
simply absent — and `billingService.STRIPE_ENABLED()` is
`Boolean(process.env.STRIPE_SECRET_KEY)`, so checkout, portal, and the webhook
all disable together. There is no state where we accept a webhook we cannot
verify. Keeping them unconditional makes enabling billing a one-line values
change with no template edit to forget.

### Secret Manager state

Containers are created and IAM is already sufficient — `commonly-secrets-sa`
holds `roles/secretmanager.secretAccessor` at the project level, and the
existing secrets carry no per-secret policy, so nothing extra was granted.

| secret | populated |
|---|---|
| `commonly-dev-stripe-price-id` | ✅ v1 |
| `commonly-dev-stripe-secret-key` | ⬜ awaiting operator |
| `commonly-dev-stripe-webhook-secret` | ⬜ awaiting operator |

The price id is not secret, but it lives in Secret Manager anyway so swapping
test credentials for live ones is a `versions add` rather than a chart edit and
redeploy.

### Verification

- `helm template` with the flag **off**: zero `stripe` refs in the
  ExternalSecret, `commonly-dev-jwt-secret` still present.
- `helm template` with the flag **on**: all three refs render.
- Backend env vars render as 3 in both states, as intended.
- `helm lint` clean in both states.

Flipping `billing.enabled: true` in `values-dev.yaml` is the follow-up, once
the two remaining secrets have versions.
