### PR TITLE
fix(retention): Pro pays for unlimited history; the cron never knew Pro existed

### DIFF
--- a/backend/__tests__/services/pgRetentionService.test.js
+++ b/backend/__tests__/services/pgRetentionService.test.js
@@ -6,6 +6,21 @@ jest.mock('../../models/pg/Message', () => ({
 }));
 jest.mock('node-cron', () => ({ schedule: jest.fn(() => ({ start: jest.fn(), stop: jest.fn() })) }));
 
+// `find().select().lean()` — chainable, so the service's real call shape works.
+const mockChain = (result) => ({ select: () => ({ lean: () => result }) });
+const mockProUsers = { value: [] };
+const mockProPods = { value: [] };
+jest.mock('../../models/User', () => ({
+  find: jest.fn(() => mockChain(
+    mockProUsers.value instanceof Error
+      ? Promise.reject(mockProUsers.value)
+      : Promise.resolve(mockProUsers.value),
+  )),
+}));
+jest.mock('../../models/Pod', () => ({
+  find: jest.fn(() => mockChain(Promise.resolve(mockProPods.value))),
+}));
+
 const { pool } = require('../../config/db-pg');
 const Message = require('../../models/pg/Message');
 const cron = require('node-cron');
@@ -42,6 +57,8 @@ describe('pgRetentionService.runMessageRetention', () => {
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockProUsers.value = [];
+    mockProPods.value = [];
   });
 
   afterEach(() => {
@@ -72,7 +89,7 @@ describe('pgRetentionService.runMessageRetention', () => {
     await runMessageRetention();
 
     expect(Message.deleteOlderThan).toHaveBeenCalledTimes(1);
-    expect(Message.deleteOlderThan).toHaveBeenCalledWith(30);
+    expect(Message.deleteOlderThan).toHaveBeenCalledWith(30, []);
     const vacuumCalls = pool.query.mock.calls.filter(([sql]) => /^VACUUM/i.test(sql));
     expect(vacuumCalls).toHaveLength(1);
     expect(vacuumCalls[0][0]).toMatch(/VACUUM ANALYZE messages/i);
@@ -143,7 +160,7 @@ describe('pgRetentionService.runMessageRetention', () => {
     await runMessageRetention();
 
     expect(Message.deleteOlderThan).toHaveBeenCalledTimes(1);
-    expect(Message.deleteOlderThan).toHaveBeenCalledWith(30);
+    expect(Message.deleteOlderThan).toHaveBeenCalledWith(30, []);
   });
 
   it('uses custom capacity and target via env', async () => {
@@ -165,7 +182,65 @@ describe('pgRetentionService.runMessageRetention', () => {
     await expect(runMessageRetention()).resolves.toBeUndefined();
     expect(errSpy).toHaveBeenCalledWith('[pg-retention] failed:', 'db down');
   });
+  /*
+   * The Pro tier's headline promise is "Unlimited message history — nothing
+   * expires at 30 days". Until this landed, the cron deleted a paying
+   * customer's messages on exactly the free-tier schedule, and the step-down
+   * under storage pressure could take that to a single day.
+   */
+  describe('Pro-protected pods', () => {
+    it('passes the protected pod ids to the delete', async () => {
+      mockProUsers.value = [{ _id: 'u-pro' }];
+      mockProPods.value = [{ _id: 'pod-1' }, { _id: 'pod-2' }];
+      mockSizeQueries([1, 1]);
+      Message.deleteOlderThan.mockResolvedValue({ deleted: 0 });
+
+      await runMessageRetention();
+      expect(Message.deleteOlderThan).toHaveBeenCalledWith(30, ['pod-1', 'pod-2']);
+    });
+
+    // The step-down is the dangerous path: it is where a paying user's window
+    // would otherwise walk from 30 days toward the 1-day floor.
+    it('every step-down tier keeps the same protection', async () => {
+      mockProUsers.value = [{ _id: 'u-pro' }];
+      mockProPods.value = [{ _id: 'pod-1' }];
+      // Stays over target so the loop steps down repeatedly.
+      mockSizeQueries([7.9, 7.9, 7.9, 7.9, 7.9, 7.9]);
+      Message.deleteOlderThan.mockResolvedValue({ deleted: 1 });
+
+      await runMessageRetention();
+      expect(Message.deleteOlderThan.mock.calls.length).toBeGreaterThan(1);
+      Message.deleteOlderThan.mock.calls.forEach(([, protectedIds]) => {
+        expect(protectedIds).toEqual(['pod-1']);
+      });
+    });
+
+    // The property worth more than the feature: never destroy paid data
+    // because a lookup failed. A skipped night of cleanup is recoverable.
+    it('ABORTS the entire run when the lookup fails, deleting nothing', async () => {
+      mockProUsers.value = new Error('mongo unreachable');
+      mockSizeQueries([7.9, 7.9]);
+      Message.deleteOlderThan.mockResolvedValue({ deleted: 99 });
+
+      await runMessageRetention();
+      expect(Message.deleteOlderThan).not.toHaveBeenCalled();
+      expect(errSpy).toHaveBeenCalledWith(
+        expect.stringContaining('ABORT'),
+        expect.stringContaining('mongo unreachable'),
+      );
+    });
+
+    it('with no Pro users the delete is unchanged', async () => {
+      mockProUsers.value = [];
+      mockSizeQueries([1, 1]);
+      Message.deleteOlderThan.mockResolvedValue({ deleted: 0 });
+
+      await runMessageRetention();
+      expect(Message.deleteOlderThan).toHaveBeenCalledWith(30, []);
+    });
+  });
 });
+
 
 describe('pgRetentionService.initPgRetention', () => {
   beforeEach(() => {

--- a/backend/__tests__/unit/models/pg/message.retentionExempt.test.js
+++ b/backend/__tests__/unit/models/pg/message.retentionExempt.test.js
@@ -77,4 +77,43 @@ describe('Message.deleteOlderThan retention exemption', () => {
     expect(await Message.deleteOlderThan(NaN)).toEqual({ deleted: 0 });
     expect(pool.query).not.toHaveBeenCalled();
   });
+
+  /*
+   * The Pro tier sells "Unlimited message history — nothing expires at 30
+   * days". These pin the mechanism that makes that sentence true.
+   */
+  describe('Pro-protected pods', () => {
+    const PRO_A = '6b111111111111111111111a';
+    const PRO_B = '6b222222222222222222222b';
+
+    it('protected pods are excluded even with no env list', async () => {
+      await Message.deleteOlderThan(30, [PRO_A, PRO_B]);
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toMatch(/pod_id != ALL\(\$2\)/);
+      expect(params[1]).toEqual([PRO_A, PRO_B]);
+    });
+
+    // Operator-pinned and paid pods are exempt for different reasons; one
+    // must never silently replace the other.
+    it('unions with the env list rather than replacing it', async () => {
+      process.env.PG_RETENTION_EXEMPT_POD_IDS = `${SHOWCASE},${HQ}`;
+      await Message.deleteOlderThan(30, [PRO_A]);
+      const [, params] = pool.query.mock.calls[0];
+      expect(params[1]).toEqual([SHOWCASE, HQ, PRO_A]);
+    });
+
+    it('a pod in both lists is exempted once, not twice', async () => {
+      process.env.PG_RETENTION_EXEMPT_POD_IDS = SHOWCASE;
+      await Message.deleteOlderThan(30, [SHOWCASE, PRO_A]);
+      const [, params] = pool.query.mock.calls[0];
+      expect(params[1]).toEqual([SHOWCASE, PRO_A]);
+    });
+
+    it('no protected pods and no env is still the unconditional delete', async () => {
+      await Message.deleteOlderThan(30, []);
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).not.toMatch(/pod_id/);
+      expect(params).toEqual(['30 days']);
+    });
+  });
 });

--- a/backend/models/pg/Message.ts
+++ b/backend/models/pg/Message.ts
@@ -214,14 +214,25 @@ class Message {
    * smallest honest stopgap that cannot drift into being a second tier
    * system — it names specific operator-owned pods, nothing more.
    */
-  static async deleteOlderThan(days: number): Promise<{ deleted: number }> {
+  /*
+   * `protectedPodIds` is the entitlement half the comment above anticipated.
+   * The caller resolves it (retention policy is not this model's business, and
+   * the answer lives in Mongo), and it is UNIONED with the env list rather
+   * than replacing it — operator-pinned pods and paid pods are both exempt,
+   * for different reasons.
+   */
+  static async deleteOlderThan(
+    days: number,
+    protectedPodIds: string[] = [],
+  ): Promise<{ deleted: number }> {
     if (!Number.isFinite(days) || days <= 0) {
       return { deleted: 0 };
     }
-    const exempt = String(process.env.PG_RETENTION_EXEMPT_POD_IDS || '')
+    const fromEnv = String(process.env.PG_RETENTION_EXEMPT_POD_IDS || '')
       .split(',')
       .map((s) => s.trim())
       .filter(Boolean);
+    const exempt = [...new Set([...fromEnv, ...protectedPodIds.map(String).filter(Boolean)])];
     const query = exempt.length > 0
       ? `DELETE FROM messages WHERE created_at < NOW() - $1::interval AND pod_id != ALL($2) RETURNING id`
       : `DELETE FROM messages WHERE created_at < NOW() - $1::interval RETURNING id`;

--- a/backend/services/pgRetentionService.ts
+++ b/backend/services/pgRetentionService.ts
@@ -19,8 +19,12 @@
 const cron = require('node-cron');
 // eslint-disable-next-line global-require
 const Message = require('../models/pg/Message') as {
-  deleteOlderThan: (days: number) => Promise<{ deleted: number }>;
+  deleteOlderThan: (days: number, protectedPodIds?: string[]) => Promise<{ deleted: number }>;
 };
+// eslint-disable-next-line global-require
+const User = require('../models/User');
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
 // eslint-disable-next-line global-require
 const { pool } = require('../config/db-pg') as {
   pool: { query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }> };
@@ -88,6 +92,34 @@ async function vacuumMessages(): Promise<void> {
   }
 }
 
+/**
+ * Pods whose history the Pro tier promises to keep.
+ *
+ * The landing page sells "Unlimited message history — nothing expires at 30
+ * days" as the headline Pro feature. This is what makes that true; without it
+ * the cron below deletes a paying customer's messages on exactly the same
+ * schedule as a free user's, and the step-down under storage pressure can take
+ * that to a single day.
+ *
+ * ANY Pro member protects the pod, not just the creator. A conversation with
+ * one free and one paying participant cannot be half-deleted — the Pro user
+ * would see their own history disappear, which is the exact thing they paid to
+ * prevent.
+ *
+ * Throws rather than returning empty. The caller must abort the run: deleting
+ * paid-for data because a lookup failed is unrecoverable, while skipping one
+ * night of cleanup costs nothing.
+ */
+export async function resolveProtectedPodIds(): Promise<string[]> {
+  const proUsers = await User.find({ 'entitlements.pro': true }).select('_id').lean();
+  if (proUsers.length === 0) return [];
+  const proIds = proUsers.map((u: { _id: unknown }) => u._id);
+  const pods = await Pod.find({
+    $or: [{ members: { $in: proIds } }, { createdBy: { $in: proIds } }],
+  }).select('_id').lean();
+  return pods.map((p: { _id: unknown }) => String(p._id));
+}
+
 function formatBytes(bytes: number): string {
   if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(2)} GiB`;
   if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(2)} MiB`;
@@ -110,17 +142,31 @@ export async function runMessageRetention(): Promise<void> {
     const stepDays = resolveStepDays();
     const targetBytes = Math.floor(capacity * (targetPct / 100));
 
+    // Resolved ONCE per run and threaded through every tier below, including
+    // the step-down. A failure here aborts before a single row is deleted —
+    // see resolveProtectedPodIds.
+    let protectedPodIds: string[];
+    try {
+      protectedPodIds = await resolveProtectedPodIds();
+    } catch (err) {
+      console.error(
+        '[pg-retention] ABORT: could not resolve Pro-protected pods, refusing to delete: %s',
+        (err as Error).message,
+      );
+      return;
+    }
+
     const initialSize = await getDatabaseSizeBytes();
     console.log(
       `[pg-retention] start: size=${initialSize !== null ? formatBytes(initialSize) : 'unknown'} ` +
       `target=${formatBytes(targetBytes)} (${targetPct}% of ${formatBytes(capacity)}) ` +
-      `retention=${startDays}d step=${stepDays}d`,
+      `retention=${startDays}d step=${stepDays}d protectedPods=${protectedPodIds.length}`,
     );
 
     let totalDeleted = 0;
     let currentDays = Math.max(FLOOR_DAYS, Math.trunc(startDays));
 
-    const first = await Message.deleteOlderThan(currentDays);
+    const first = await Message.deleteOlderThan(currentDays, protectedPodIds);
     totalDeleted += first.deleted || 0;
     await vacuumMessages();
     let size = await getDatabaseSizeBytes();
@@ -146,7 +192,7 @@ export async function runMessageRetention(): Promise<void> {
       }
       const sizeBefore = size;
       currentDays = Math.max(FLOOR_DAYS, currentDays - stepDays);
-      const tierResult = await Message.deleteOlderThan(currentDays);
+      const tierResult = await Message.deleteOlderThan(currentDays, protectedPodIds);
       totalDeleted += tierResult.deleted || 0;
       await vacuumMessages();
       size = await getDatabaseSizeBytes();


### PR DESCRIPTION
Caught by Sam while reviewing the billing work: *"did we even filter user during pg data clean up?"*

No. We did not.

## The gap

The landing page sells **"Unlimited message history — nothing expires at 30
days"** as the headline Pro feature, and `#875` started charging for it.
`Message.deleteOlderThan` filtered on exactly two things:

```sql
DELETE FROM messages
WHERE created_at < NOW() - $1::interval
  AND pod_id != ALL($2)   -- an env list of operator-pinned pods
```

Message age, and an env var. Nothing that knows the Pro tier exists. A paying
customer's messages were deleted on precisely the free-tier schedule.

Worse than the flat window: under storage pressure `pgRetentionService` steps
the window **down** toward a one-day floor. A Pro subscriber could have been
left with 24 hours of history while being billed to keep it forever.

Verified live before fixing — the cron is scheduled daily at 03:00 UTC, running
a 30-day window, exempting only the two showroom pods.

## Exposure

**Nobody has lost paid-for data.** The first Pro account is hours old and has
nothing older than 30 days. The breach would have landed roughly a month after
the first paying customer's oldest message, silently, with the copy still
promising otherwise.

## The fix

The mechanism the existing comment in `Message.ts` explicitly asked for:

> Env-var rather than a pod flag, deliberately, for now: the paid tier being
> designed makes retention a per-account entitlement, and THAT mechanism should
> own per-pod retention when it lands.

- `deleteOlderThan(days, protectedPodIds)` — **unioned** with the env list, not
  replacing it. Operator-pinned and paid pods are exempt for different reasons
  and neither should mask the other.
- Resolved once per run and threaded through **every tier including the
  step-down** — that loop is the path that would otherwise walk a paying user
  to the floor, and fixing only the first call would have looked correct.
- **Any** Pro member protects a pod, not just its creator. A conversation with
  one free and one paying participant cannot be half-deleted, or the Pro user
  watches their own history vanish.

## The property worth more than the feature

If the entitlement lookup throws, the run **aborts before a single row is
deleted**. Destroying paid-for data because Mongo blinked is unrecoverable;
skipping one night of cleanup is not.

## Verification

Nine new/updated tests across the SQL boundary and the service. Reverted the
fix and confirmed they fail. Typecheck clean.

Related: #875, #876, #877.