### PR TITLE
fix(v2): one stray click permanently deleted the onboarding

### DIFF
--- a/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
+++ b/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
@@ -155,7 +155,9 @@ describe('V2FirstRunHero', () => {
       podId: 'workspace-1',
     });
     expect(mockNavigate).toHaveBeenCalledWith('/v2/pods/room-1');
-    expect(localStorage.getItem(FIRST_RUN_DISMISSED_KEY)).toBe('1');
+    // Completing writes the same timestamp shape as an explicit skip, so no
+    // path leaves a legacy '1' that a later read would treat as expired.
+    expect(Number(localStorage.getItem(FIRST_RUN_DISMISSED_KEY))).toBeGreaterThan(0);
   });
 
   test('stops polling after unmount', async () => {
@@ -204,8 +206,8 @@ describe('V2FirstRunHero', () => {
     });
   });
 
-  test('dismissal persists and avoids starting the poll', async () => {
-    localStorage.setItem(FIRST_RUN_DISMISSED_KEY, '1');
+  test('an explicit recent skip persists and avoids starting the poll', async () => {
+    localStorage.setItem(FIRST_RUN_DISMISSED_KEY, String(Date.now()));
     renderHero();
     await flush();
 
@@ -213,31 +215,76 @@ describe('V2FirstRunHero', () => {
     expect(mockGet).not.toHaveBeenCalled();
   });
 
-  test('dismisses the first-run modal with Escape', async () => {
+  /*
+   * The guide used to be suppressed forever. These pin the two ways it now
+   * comes back for someone who never connected — the only population the
+   * expiry can reach, since `issued: true` hides it regardless.
+   */
+  test('a skip older than the TTL stops suppressing the guide', async () => {
+    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    localStorage.setItem(FIRST_RUN_DISMISSED_KEY, String(eightDaysAgo));
+    renderHero();
+    await flush();
+
+    expect(await screen.findByRole('dialog', { name: 'Bring your agent into the room' }))
+      .toBeInTheDocument();
+  });
+
+  test("a legacy '1' flag no longer suppresses forever", async () => {
+    // Written by the version where any stray click set a permanent flag. Those
+    // users are exactly the ones we lost; treat the flag as long expired.
+    localStorage.setItem(FIRST_RUN_DISMISSED_KEY, '1');
+    renderHero();
+    await flush();
+
+    expect(await screen.findByRole('dialog', { name: 'Bring your agent into the room' }))
+      .toBeInTheDocument();
+  });
+
+  test('Escape closes for this view and persists nothing', async () => {
     const priorControl = document.createElement('button');
     document.body.appendChild(priorControl);
     priorControl.focus();
-    renderHero();
+    const { unmount } = renderHero();
     await flush();
 
     expect(screen.getByRole('dialog', { name: 'Bring your agent into the room' })).toHaveFocus();
     fireEvent.keyDown(document, { key: 'Escape' });
 
     expect(screen.queryByRole('dialog', { name: 'Bring your agent into the room' })).not.toBeInTheDocument();
-    expect(localStorage.getItem(FIRST_RUN_DISMISSED_KEY)).toBe('1');
+    expect(localStorage.getItem(FIRST_RUN_DISMISSED_KEY)).toBeNull();
     expect(priorControl).toHaveFocus();
     priorControl.remove();
+
+    // The property that matters: it comes back.
+    unmount();
+    renderHero();
+    await flush();
+    expect(await screen.findByRole('dialog', { name: 'Bring your agent into the room' }))
+      .toBeInTheDocument();
   });
 
-  test('dismisses the first-run modal from the backdrop', async () => {
-    renderHero();
+  /*
+   * This is the defect that shipped: `onMouseDown={dismiss}` on the overlay
+   * meant one stray click destroyed the only explanation of the product a new
+   * user ever sees, permanently. 15 users attached an agent and never sent a
+   * message, and step 3 of this card is "say hello".
+   */
+  test('a backdrop click closes for this view and the guide returns', async () => {
+    const { unmount } = renderHero();
     await flush();
 
     const dialog = screen.getByRole('dialog', { name: 'Bring your agent into the room' });
     fireEvent.mouseDown(dialog.parentElement as HTMLElement);
 
     expect(screen.queryByRole('dialog', { name: 'Bring your agent into the room' })).not.toBeInTheDocument();
-    expect(localStorage.getItem(FIRST_RUN_DISMISSED_KEY)).toBe('1');
+    expect(localStorage.getItem(FIRST_RUN_DISMISSED_KEY)).toBeNull();
+
+    unmount();
+    renderHero();
+    await flush();
+    expect(await screen.findByRole('dialog', { name: 'Bring your agent into the room' }))
+      .toBeInTheDocument();
   });
 
   test.each([
@@ -255,7 +302,7 @@ describe('V2FirstRunHero', () => {
     status,
     readyControl,
   }) => {
-    localStorage.setItem(FIRST_RUN_DISMISSED_KEY, '1');
+    localStorage.setItem(FIRST_RUN_DISMISSED_KEY, String(Date.now()));
     mockGet.mockResolvedValue(status);
     renderHero();
     await flush();
@@ -279,7 +326,8 @@ describe('V2FirstRunHero', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Skip for now' }));
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    expect(localStorage.getItem(FIRST_RUN_DISMISSED_KEY)).toBe('1');
+    // Only the explicit button persists, and it stores when — not a forever bit.
+    expect(Number(localStorage.getItem(FIRST_RUN_DISMISSED_KEY))).toBeGreaterThan(0);
     expect(localStorage.getItem(FIRST_RUN_STARTED_KEY)).toBeNull();
   });
 
@@ -337,7 +385,7 @@ describe('V2Layout first-run placement', () => {
   });
 
   test('keeps the shell unblocked when first-run was already dismissed', async () => {
-    localStorage.setItem(FIRST_RUN_DISMISSED_KEY, '1');
+    localStorage.setItem(FIRST_RUN_DISMISSED_KEY, String(Date.now()));
     render(
       <MemoryRouter initialEntries={['/v2/pods/hq']}>
         <Routes>
@@ -354,7 +402,7 @@ describe('V2Layout first-run placement', () => {
   });
 
   test('reopens the dismissed guide from the rail and restores onboarding suppression', async () => {
-    localStorage.setItem(FIRST_RUN_DISMISSED_KEY, '1');
+    localStorage.setItem(FIRST_RUN_DISMISSED_KEY, String(Date.now()));
     render(
       <MemoryRouter initialEntries={['/v2/pods/hq']}>
         <Routes>

--- a/frontend/src/v2/components/V2FirstRunHero.tsx
+++ b/frontend/src/v2/components/V2FirstRunHero.tsx
@@ -25,11 +25,52 @@ export interface AgentConnectionStatus {
   connectedAgent: ConnectedAgent | null;
 }
 
+/**
+ * How long an explicit "Skip for now" suppresses the guide.
+ *
+ * It expires rather than persisting forever, and the expiry only matters for
+ * someone who never issued a token — `visible` already gates on
+ * `status.issued === false`, so a user who did connect never sees it again
+ * regardless of this clock. The people it brings back are exactly the ones who
+ * skipped and then never managed to connect.
+ */
+const DISMISS_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 const readFlag = (key: string): boolean => {
   try {
     return localStorage.getItem(key) === '1';
   } catch {
     return false;
+  }
+};
+
+/**
+ * Was the guide skipped, and is that skip still in force?
+ *
+ * Legacy `'1'` values were written by the version where any stray click set a
+ * permanent flag. They are treated as long-expired on purpose: those users are
+ * indistinguishable from ones who deliberately skipped, and if they connected
+ * successfully the `issued` gate keeps the guide hidden anyway. The only people
+ * this re-reaches are the ones we lost.
+ */
+const readDismissed = (now: number): boolean => {
+  try {
+    const raw = localStorage.getItem(FIRST_RUN_DISMISSED_KEY);
+    if (!raw) return false;
+    if (raw === '1') return false;
+    const at = Number(raw);
+    return Number.isFinite(at) && now - at < DISMISS_TTL_MS;
+  } catch {
+    return false;
+  }
+};
+
+const writeDismissedAt = (at: number | null): void => {
+  try {
+    if (at === null) localStorage.removeItem(FIRST_RUN_DISMISSED_KEY);
+    else localStorage.setItem(FIRST_RUN_DISMISSED_KEY, String(at));
+  } catch {
+    // Storage unavailable; this render still behaves, only persistence is lost.
   }
 };
 
@@ -59,7 +100,17 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
   const navigate = useNavigate();
   const dialogRef = useRef<HTMLElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
-  const [dismissed, setDismissed] = useState(() => readFlag(FIRST_RUN_DISMISSED_KEY));
+  const [dismissed, setDismissed] = useState(() => readDismissed(Date.now()));
+  // Closing is not skipping. Clicking away or pressing Escape hides the card
+  // for this view only and writes nothing — it returns on the next load. Only
+  // the explicit Skip button persists anything.
+  //
+  // This split is the whole point of the component's second version: the first
+  // one dismissed permanently on `onMouseDown` anywhere on the overlay, so the
+  // most reflexive gesture a person makes when a modal appears destroyed the
+  // only explanation of the product they were ever shown. 15 users attached an
+  // agent and never sent a message; step 3 of this card is "say hello".
+  const [closed, setClosed] = useState(false);
   // `engaged` is a session latch. Once a zero-install user sees the hero, an
   // install appearing during the poll must advance the card to Waiting / Say
   // hello rather than make it disappear mid-flow. The persisted started flag
@@ -84,10 +135,16 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
   // Reserve the empty-state slot while the ownership probe is unresolved,
   // but do not flash the full onboarding card for an established user.
   const shouldProbe = !dismissed && (engaged || status === null || status.issued === false);
-  const visible = !dismissed && (engaged || status?.issued === false);
+  const visible = !dismissed && !closed && (engaged || status?.issued === false);
 
-  const dismiss = useCallback(() => {
-    writeFlag(FIRST_RUN_DISMISSED_KEY, true);
+  /** Hide for this view only. Writes nothing; returns on the next load. */
+  const close = useCallback(() => {
+    setClosed(true);
+  }, []);
+
+  /** The explicit Skip button: suppress for DISMISS_TTL_MS, then re-offer. */
+  const skip = useCallback(() => {
+    writeDismissedAt(Date.now());
     writeFlag(FIRST_RUN_STARTED_KEY, false);
     setDismissed(true);
   }, []);
@@ -97,9 +154,12 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
       // Clearing dismissal alone does not reopen for an established owner:
       // issued=true makes the normal first-run gate false. Reusing the started
       // latch keeps one visibility model for both new and connected users.
-      writeFlag(FIRST_RUN_DISMISSED_KEY, false);
+      writeDismissedAt(null);
       writeFlag(FIRST_RUN_STARTED_KEY, true);
       setDismissed(false);
+      // Also clear a session close, or asking for the guide from the menu does
+      // nothing for anyone who clicked away earlier in the same visit.
+      setClosed(false);
       setEngaged(true);
       setStatusError(null);
       setRoomError(null);
@@ -160,7 +220,8 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         event.preventDefault();
-        dismiss();
+        // Escape means "not now", never "never". It used to persist.
+        close();
         return;
       }
       if (event.key !== 'Tab' || !dialog) return;
@@ -190,7 +251,7 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
       previousFocusRef.current?.focus();
       previousFocusRef.current = null;
     };
-  }, [dismiss, visible]);
+  }, [close, visible]);
 
   if (!visible) return null;
 
@@ -212,7 +273,10 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
       });
       const roomId = data.room?._id;
       if (!roomId) throw new Error('Agent room not returned');
-      writeFlag(FIRST_RUN_DISMISSED_KEY, true);
+      // Completion, not a skip — but it writes the same timestamp so no code
+      // path leaves a legacy '1' behind. A user who got here has issued:true,
+      // so the `visible` gate keeps the guide away regardless of the clock.
+      writeDismissedAt(Date.now());
       writeFlag(FIRST_RUN_STARTED_KEY, false);
       navigate(`/v2/pods/${roomId}`);
     } catch (error) {
@@ -224,7 +288,7 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
   };
 
   return (
-    <div className="v2-first-run__overlay" onMouseDown={dismiss}>
+    <div className="v2-first-run__overlay" onMouseDown={close}>
       <section
         ref={dialogRef}
         className="v2-first-run"
@@ -243,7 +307,7 @@ const V2FirstRunHero: React.FC<V2FirstRunHeroProps> = ({ onVisibilityChange }) =
               {t('firstRun.lede')}
             </p>
           </div>
-          <button type="button" className="v2-first-run__skip" onClick={dismiss}>{t('firstRun.skip')}</button>
+          <button type="button" className="v2-first-run__skip" onClick={skip}>{t('firstRun.skip')}</button>
         </div>
 
         <ol className="v2-first-run__steps">


### PR DESCRIPTION
Found while investigating why a new user asked "有什么作用呢" 48 seconds after
registering, and got no answer.

**We already have onboarding.** `V2FirstRunHero` ships with the right three
steps — connect your agent → start it → **say hello** — fully translated
(`接入你的智能体` / `启动智能体` / `先打声招呼`). Nothing needed building.

**It was being deleted by its own backdrop.**

```tsx
<div className="v2-first-run__overlay" onMouseDown={dismiss}>
```

That, plus Escape, wrote `v2.firstRun.dismissed = '1'` to localStorage with no
expiry. One click anywhere — the single most reflexive thing a person does when
a modal appears — permanently removed the only explanation of the product they
would ever be shown. The only way back was a "Guide" item inside the feedback
menu.

## Why this is the activation bug

Measured on production today:

| | count |
|---|---|
| registered | 91 |
| attached an agent | 36 |
| ever sent a message | 27 |
| **attached and never spoke** | **15** |

**Step 3 of this card is "say hello"** — precisely the attach → first-message
conversion. Those 15 completed step 1 and never saw step 3 again.

## The change

Closing is now separate from skipping.

| action | before | after |
|---|---|---|
| backdrop click | permanent | closes this view, writes nothing, returns next load |
| Escape | permanent | same |
| **Skip for now** | permanent | timestamp, expires after 7 days |
| completing (say hello) | wrote `'1'` | writes the same timestamp shape |

The expiry can only re-reach someone who **never issued a token** — `visible`
already gates on `issued === false`, so anyone who actually connected stays
gated out regardless of the clock.

Legacy `'1'` values read as expired deliberately: they were written by the
version where any click set them, so those users are indistinguishable from
deliberate skippers, and the ones who connected are still hidden by `issued`.

**Regression caught in review of my own diff:** `sayHello` — the *success*
path — also wrote `'1'`, which the new reader treats as not-dismissed. Users
who completed onboarding would have been nagged again. Fixed.

## Tests

Eight of the fifteen existing tests **encoded the defect** — "dismisses the
first-run modal from the backdrop" asserted the permanent write. Rewritten to
the intended contract, including the property that matters: *after closing, the
guide comes back*. Verified by reverting the component and confirming 8 fail.

28 suites / 144 tests green, typecheck clean.

Plan: `docs/plans/onboarding-guided-first-run.md` (branch
`plan/onboarding-guided-first-run`).