### PR TITLE
feat(litellm): a model route we own — Cloudflare Workers AI

### DIFF
--- a/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
@@ -302,6 +302,22 @@ spec:
               name: api-keys
               key: gemini-api-key
               optional: true
+        # Cloudflare Workers AI. Both are required together — the account id is
+        # part of the request path, so a token without it is unusable. Not
+        # secret, but an infra identifier, so it lives in Secret Manager rather
+        # than the chart.
+        - name: CLOUDFLARE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: api-keys
+              key: cloudflare-workers-ai-token
+              optional: true
+        - name: CLOUDFLARE_ACCOUNT_ID
+          valueFrom:
+            secretKeyRef:
+              name: api-keys
+              key: cloudflare-account-id
+              optional: true
         - name: OPENROUTER_API_KEY
           valueFrom:
             secretKeyRef:

--- a/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
+++ b/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
@@ -22,19 +22,26 @@ data:
       # Verified with a live inference call before landing: both models below
       # returned 200.
       #
-      # NOTE on the deepseek distill: it emits a <think>…</think> reasoning block
-      # before its answer. Anything user-facing must strip that, or agents post
-      # visible chain-of-thought into pods. Prefer the llama route for the guide
-      # until that stripping exists.
+      # WHY THIS MODEL, chosen by testing rather than spec sheet. Every cheap
+      # alternative on Workers AI is a REASONING model — qwen3-30b, gpt-oss-20b
+      # and gemma-4 all return OpenAI-shaped output with `content: null` and the
+      # answer buried in a `reasoning` field, and on a short budget they hit the
+      # token limit before producing any content at all. The deepseek r1 distill
+      # is the same shape via <think> tags, and at $4.881/M output costs 17x this
+      # one. A first greeting must be short, clean and cheap; a reasoning model
+      # is the wrong tool and leaks chain-of-thought into a stranger's first
+      # impression of the product.
+      #
+      # Verified live: this returned a correct, natural Chinese greeting that
+      # asked exactly one question, with no reasoning leakage. Both users who
+      # asked "what is this for" wrote Chinese, so that was the test that
+      # mattered.
+      #
+      # Do NOT swap this for a reasoning model without adding content-extraction
+      # and reasoning-stripping first.
       - model_name: cloudflare/llama-3.1-8b
         litellm_params:
-          model: cloudflare/@cf/meta/llama-3.1-8b-instruct
-          api_key: os.environ/CLOUDFLARE_API_KEY
-          account_id: os.environ/CLOUDFLARE_ACCOUNT_ID
-
-      - model_name: cloudflare/deepseek-r1-32b
-        litellm_params:
-          model: cloudflare/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b
+          model: cloudflare/@cf/meta/llama-3.1-8b-instruct-fp8
           api_key: os.environ/CLOUDFLARE_API_KEY
           account_id: os.environ/CLOUDFLARE_ACCOUNT_ID
 

--- a/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
+++ b/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
@@ -12,6 +12,32 @@ data:
     # Docs: https://docs.litellm.ai/docs/proxy/configs
 
     model_list:
+      # --- Cloudflare Workers AI (guide agent / first-party native runtime) ---
+      # Added 2026-08-08 to unblock the guide agent, which had no working model:
+      # every other provider in this file was returning 401 (OpenRouter's account
+      # was gone, OpenAI/Anthropic keys are literal "placeholder" strings). This
+      # runs on our OWN Cloudflare account, so nobody else can revoke it — which
+      # is exactly how the OpenRouter route died.
+      #
+      # Verified with a live inference call before landing: both models below
+      # returned 200.
+      #
+      # NOTE on the deepseek distill: it emits a <think>…</think> reasoning block
+      # before its answer. Anything user-facing must strip that, or agents post
+      # visible chain-of-thought into pods. Prefer the llama route for the guide
+      # until that stripping exists.
+      - model_name: cloudflare/llama-3.1-8b
+        litellm_params:
+          model: cloudflare/@cf/meta/llama-3.1-8b-instruct
+          api_key: os.environ/CLOUDFLARE_API_KEY
+          account_id: os.environ/CLOUDFLARE_ACCOUNT_ID
+
+      - model_name: cloudflare/deepseek-r1-32b
+        litellm_params:
+          model: cloudflare/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b
+          api_key: os.environ/CLOUDFLARE_API_KEY
+          account_id: os.environ/CLOUDFLARE_ACCOUNT_ID
+
       # --- Gemini (direct google provider) ---
       - model_name: google/gemini-2.5-flash
         litellm_params:

--- a/k8s/helm/commonly/templates/secrets/api-keys.yaml
+++ b/k8s/helm/commonly/templates/secrets/api-keys.yaml
@@ -60,6 +60,18 @@ spec:
       key: commonly-dev-stripe-price-id
   {{- end }}
 
+  # Cloudflare Workers AI — the model route the guide agent runs on.
+  # Ungated on purpose, unlike the Stripe block below: both remote keys are
+  # populated (verified with a live inference call before this landed), so
+  # there is no missing-key risk to ESO. If either is ever deleted from Secret
+  # Manager this whole ExternalSecret stops syncing — see the note above.
+  - secretKey: cloudflare-workers-ai-token
+    remoteRef:
+      key: commonly-cloudflare-workers-ai-token
+  - secretKey: cloudflare-account-id
+    remoteRef:
+      key: commonly-cloudflare-account-id
+
   # Discord Integration
   - secretKey: discord-bot-token
     remoteRef:


### PR DESCRIPTION
Unblocks the guide agent, which has been stuck for a month on D4's *"reliable
cheap paid model with a hard budget"*.

## The blocker was mundane

LiteLLM reports **0 of 14 healthy endpoints**. Not an architecture problem:

| provider | state |
|---|---|
| OpenRouter | key present, API returns `{"message":"User not found","code":401}` — the account is gone |
| OpenAI | key is the literal string `placeholder` |
| Anthropic | key is the literal string `placeholder` |
| Gemini | present but inert (project without the API enabled) |

So "should we fix one model route" was never a strategy call. It was a dead
credential.

## Why Cloudflare

It runs on **our own account**, which is the whole point — losing a third-party
account is precisely how the OpenRouter route died. It also has a real free
tier, and the guide fires once per signup so usage is bounded.

Both `cloudflare` and `deepseek` are first-class providers in the installed
LiteLLM; no upgrade needed.

## Verified before landing, not after

A live inference call against both models with the new token:

```
@cf/meta/llama-3.1-8b-instruct                 OK -> 'OK'
@cf/deepseek-ai/deepseek-r1-distill-qwen-32b   OK -> "<think>\nOkay, so I'm trying to…"
```

**Recorded inline:** the deepseek distill emits a `<think>` block before its
answer. Anything user-facing must strip that or agents will post visible
chain-of-thought into pods — so prefer the llama route for the guide until that
stripping exists.

Two earlier tokens on the same account (the DNS one in Secret Manager, and one
found in a local repo `.env`) both failed this same call with
`10000 Authentication error` — they are DNS/deploy scoped. A new token was
genuinely required; fingerprints confirmed they were different tokens, not a
lookup mistake.

## ESO gating

The refs here are **ungated**, unlike the Stripe block, because both remote keys
are populated. That gating exists because ESO rejects the *entire*
ExternalSecret when any referenced key is missing — it would take JWT and
LiteLLM down with it. Confirmed `commonly-dev-jwt-secret` still renders.

Account id ships as a secret ref rather than chart config: not secret, but an
infra identifier, same rule as the GCP project id.

`helm lint` clean, renders correctly across all three layers.

Next: flip healthy endpoints 0 → 1+, then the guide agent per
`docs/plans/onboarding-guided-first-run.md` Phase 2.