### PR TITLE
feat(litellm): deepseek-v4-flash — the guide agent's model

### DIFF
--- a/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/litellm-deployment.yaml
@@ -318,6 +318,12 @@ spec:
               name: api-keys
               key: cloudflare-account-id
               optional: true
+        - name: DEEPSEEK_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: api-keys
+              key: deepseek-api-key
+              optional: true
         - name: OPENROUTER_API_KEY
           valueFrom:
             secretKeyRef:

--- a/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
+++ b/k8s/helm/commonly/templates/configmaps/litellm-config.yaml
@@ -12,7 +12,32 @@ data:
     # Docs: https://docs.litellm.ai/docs/proxy/configs
 
     model_list:
-      # --- Cloudflare Workers AI (guide agent / first-party native runtime) ---
+      # --- DeepSeek (the guide agent's model) ---
+      # Direct API, not via Cloudflare: Workers AI carries no v4 at all, only an
+      # r1 distill at 17x the output price.
+      #
+      # Chosen by testing the two things a guide actually does, in the language
+      # the confused users actually wrote (both people who asked "what is this
+      # for" wrote Chinese):
+      #   greeting  -> "你好！欢迎来到Commonly。很高兴见到你。你现在在做什么项目呢？"
+      #                natural, one question, no feature dump, no invented identity
+      #   tool call -> clean structured tool_calls, arguments {"name":"biomed-qa"}
+      #
+      # Compare cloudflare/llama-3.1-8b below, which answered "who are you" with
+      # "我是指南者，一个疫情期间的AI聊天机器人" — it invented a pandemic-era
+      # chatbot identity on turn one. Fine as a fallback, not as a first
+      # impression.
+      #
+      # NOTE: responses carry `reasoning_content` alongside `content`. Content is
+      # clean on its own — but anything reading the raw message must take
+      # `content` and never concatenate the two, or the guide's first message to
+      # a stranger is the model thinking out loud.
+      - model_name: deepseek-v4-flash
+        litellm_params:
+          model: deepseek/deepseek-v4-flash
+          api_key: os.environ/DEEPSEEK_API_KEY
+
+      # --- Cloudflare Workers AI (fallback; own-account, unrevokable) ---
       # Added 2026-08-08 to unblock the guide agent, which had no working model:
       # every other provider in this file was returning 401 (OpenRouter's account
       # was gone, OpenAI/Anthropic keys are literal "placeholder" strings). This

--- a/k8s/helm/commonly/templates/secrets/api-keys.yaml
+++ b/k8s/helm/commonly/templates/secrets/api-keys.yaml
@@ -72,6 +72,12 @@ spec:
     remoteRef:
       key: commonly-cloudflare-account-id
 
+  # DeepSeek — the guide agent's model. Direct API, not via Cloudflare:
+  # Workers AI carries no v4, only an r1 distill at 17x the output price.
+  - secretKey: deepseek-api-key
+    remoteRef:
+      key: commonly-deepseek-api-key
+
   # Discord Integration
   - secretKey: discord-bot-token
     remoteRef:


### PR DESCRIPTION
Sam supplied a DeepSeek API key. This routes the guide agent to
**`deepseek-v4-flash`** via the direct API.

## Correcting an earlier claim of mine

I said "DeepSeek v4 is not available". That was only true of **Cloudflare's**
catalogue — 61 models, exactly one DeepSeek, an r1 distill at 17x the output
price. The direct API lists `deepseek-v4-flash` and `deepseek-v4-pro`, confirmed
by querying `/models` rather than trusting the name I was given or the one I
assumed.

## Chosen by testing, in the language that matters

Both users who asked *"what is this for"* wrote Chinese, so that was the test:

| | result |
|---|---|
| greeting | `你好！欢迎来到Commonly。很高兴见到你。你现在在做什么项目呢？` — natural, one question, no feature dump |
| tool call | clean structured `tool_calls`, `{"name":"biomed-qa"}` |

**Sam was right that llama-8b was the wrong fit**, and the evidence landed after
he said so: asked "who are you" with no system prompt, it replied
*"我是指南者，一个疫情期间的AI聊天机器人"* — inventing a pandemic-era chatbot
identity on turn one. Exactly the small-model failure that a one-shot greeting
test doesn't catch. It stays as a fallback (our own Cloudflare account, nobody
can revoke it) but not as the first thing a stranger talks to.

## One thing to handle before the guide ships

Responses carry **`reasoning_content` alongside `content`**. Content is clean on
its own, but any caller reading the raw message must take `content` and never
concatenate — otherwise a new user's first message from us is the model thinking
out loud. Same class as the `<think>` leak on the r1 distill; recorded inline so
the next person doesn't rediscover it in production.

`helm lint` clean, `commonly-dev-jwt-secret` still renders (the ESO
all-or-nothing check).

Next: deploy, confirm healthy endpoints 1 → 2, then build the guide on it per
`docs/plans/onboarding-guided-first-run.md` Phase 2.