### PR TITLE
fix(byo): the connect flow promised an agent that answers; MCP alone does not

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1137,6 +1137,11 @@
       "installFailed": "Install failed.",
       "fileTooLarge": "That file is over the 256KB import ceiling — trim it or paste the relevant part.",
       "importFailed": "Import failed."
+    },
+    "listen": {
+      "title": "One more step, or it can't answer you",
+      "body": "The snippet above lets you use Commonly from your editor. It does not make this agent answer @mentions here — nothing is listening yet. For that, run the wrapper on the machine your agent lives on:",
+      "note": "Leave it running. It polls Commonly and replies as {{name}}. Without it, {{name}} appears in your team but stays silent when mentioned."
     }
   },
   "agentProfile": {
@@ -1410,7 +1415,8 @@
       "justNow": "Just now",
       "minutesAgo": "{{count}}m ago",
       "hoursAgo": "{{count}}h ago",
-      "daysAgo": "{{count}}d ago"
+      "daysAgo": "{{count}}d ago",
+      "neverConnected": "Never connected"
     },
     "runtime": {
       "native": "Native",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1133,6 +1133,11 @@
       "installFailed": "安装失败。",
       "fileTooLarge": "该文件超过 256KB 的导入上限——请精简，或只粘贴相关部分。",
       "importFailed": "导入失败。"
+    },
+    "listen": {
+      "title": "还差一步，否则它无法回复你",
+      "body": "上面的配置让你可以在编辑器里调用 Commonly。但它不会让这个 agent 回复这里的 @提及 —— 现在还没有任何程序在监听。要做到这一点，在 agent 所在的机器上运行：",
+      "note": "保持它运行。它会轮询 Commonly 并以 {{name}} 的身份回复。不运行的话，{{name}} 会出现在你的团队里，但被提及时始终沉默。"
     }
   },
   "agentProfile": {
@@ -1406,7 +1411,8 @@
       "justNow": "刚刚",
       "minutesAgo": "{{count}} 分钟前",
       "hoursAgo": "{{count}} 小时前",
-      "daysAgo": "{{count}} 天前"
+      "daysAgo": "{{count}} 天前",
+      "neverConnected": "从未连接"
     },
     "runtime": {
       "native": "原生",

--- a/frontend/src/v2/__tests__/V2ConnectHonesty.test.ts
+++ b/frontend/src/v2/__tests__/V2ConnectHonesty.test.ts
@@ -1,0 +1,65 @@
+import en from '../../i18n/locales/en.json';
+import zhCN from '../../i18n/locales/zh-CN.json';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * The connect flow used to promise more than it delivered.
+ *
+ * Measured on production 2026-08-09: 4 of 6 human @mentions in ten days got no
+ * reply. The cause was not user error — the web BYO flow wires MCP, which lets
+ * an agent CALL Commonly from the user's editor, and nothing in that path
+ * listens for mentions. `commonly agent run` (the wrapper that polls) was a
+ * footnote. Users finished in two minutes, saw the agent in Your Team, spoke to
+ * it, and got silence. See #887.
+ *
+ * These pin the two claims that fix it, in both languages, because both users
+ * who hit this were writing Chinese.
+ */
+
+const read = (p: string) => fs.readFileSync(path.join(__dirname, p), 'utf8');
+
+describe('the connect flow states what it does not do', () => {
+  describe.each([['en', en as any], ['zh-CN', zhCN as any]])('%s', (_locale, bundle) => {
+    const listen = bundle.agentByo?.listen;
+
+    test('a listening step exists at all', () => {
+      expect(listen?.title).toBeTruthy();
+      expect(listen?.body).toBeTruthy();
+      expect(listen?.note).toBeTruthy();
+    });
+
+    test('it says plainly that MCP alone will not answer mentions', () => {
+      const all = `${listen.title} ${listen.body} ${listen.note}`;
+      // The whole point: name the gap rather than only describing the fix.
+      expect(all).toMatch(/@|提及/);
+      expect(all.length).toBeGreaterThan(60);
+    });
+
+    test('the note names the agent, so the consequence is concrete', () => {
+      expect(listen.note).toMatch(/\{\{name\}\}/);
+    });
+  });
+
+  test('an agent that never connected does not read as merely quiet', () => {
+    // Conflating them is how 13 unreachable installs sat in Your Team looking
+    // healthy next to working agents.
+    expect(en.yourTeam.activity.neverConnected).toBeTruthy();
+    expect(zhCN.yourTeam.activity.neverConnected).toBeTruthy();
+    expect(en.yourTeam.activity.neverConnected).not.toBe(en.yourTeam.activity.noRecent);
+    expect(zhCN.yourTeam.activity.neverConnected).not.toBe(zhCN.yourTeam.activity.noRecent);
+  });
+
+  test('Your Team renders the never-connected state for a null heartbeat', () => {
+    const src = read('../components/V2YourTeamPage.tsx');
+    // `lastHeartbeatAt` is derived from heartbeat events, so null means the
+    // wrapper was never started — not that the agent is idle.
+    expect(src).toMatch(/if \(!iso\) return t\('yourTeam\.activity\.neverConnected'\)/);
+  });
+
+  test('the BYO page ships the command that makes an agent listen', () => {
+    const src = read('../components/V2AgentBYO.tsx');
+    expect(src).toMatch(/commonly agent run/);
+    expect(src).toMatch(/agentByo\.listen\.title/);
+  });
+});

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -233,6 +233,12 @@ const V2AgentBYO: React.FC = () => {
     ? `claude mcp add commonly \\\n  -e COMMONLY_API_URL=${apiUrl} \\\n  -e COMMONLY_AGENT_TOKEN=${issued.token} \\\n  -- npx -y @commonlyai/mcp`
     : '';
 
+  // The command that makes the agent LISTEN. Everything above is the calling
+  // direction only; this is the one that answers @mentions.
+  const listenSnippet = issued
+    ? `export COMMONLY_API_URL=${apiUrl}\nexport COMMONLY_AGENT_TOKEN=${issued.token}\ncommonly agent run ${issued.agentName}`
+    : '';
+
   const cursorSnippet = issued
     ? JSON.stringify({
       mcpServers: {
@@ -338,6 +344,32 @@ const V2AgentBYO: React.FC = () => {
               </button>
             </div>
             <pre className="v2-byo__pre">{cursorSnippet}</pre>
+          </div>
+
+          {/*
+            The MCP snippets above make the agent able to CALL Commonly from the
+            user's editor. They do not make it answer @mentions here — nothing
+            polls. Users finished this flow, saw the agent in Your Team,
+            mentioned it, and got silence; 4 of 6 mentions in 10 days went
+            unanswered for exactly this reason (#887). The consequence belongs
+            at the point of the promise, not in a footnote.
+          */}
+          <div className="v2-byo__snippet v2-byo__snippet--listen">
+            <div className="v2-byo__snippet-head">
+              <span>{t('agentByo.listen.title')}</span>
+              <button
+                type="button"
+                onClick={() => copy('listen', listenSnippet)}
+                className="v2-byo__copy"
+              >
+                {copied === 'listen' ? t('agentByo.actions.copied') : t('agentByo.actions.copy')}
+              </button>
+            </div>
+            <p className="v2-byo__listen-body">{t('agentByo.listen.body')}</p>
+            <pre className="v2-byo__pre">{listenSnippet}</pre>
+            <p className="v2-byo__listen-note">
+              {t('agentByo.listen.note', { name: issued.agentName })}
+            </p>
           </div>
 
           <div className="v2-byo__snippet">

--- a/frontend/src/v2/components/V2YourTeamPage.tsx
+++ b/frontend/src/v2/components/V2YourTeamPage.tsx
@@ -44,7 +44,12 @@ const formatRelative = (
   iso: string | null | undefined,
   t: (key: string, opts?: Record<string, unknown>) => string,
 ): string => {
-  if (!iso) return t('yourTeam.activity.noRecent');
+  // An agent that has NEVER been seen is not the same as a quiet one, and
+  // conflating them is how 13 unreachable installs sat in Your Team looking
+  // healthy. `lastHeartbeatAt` is derived from heartbeat events, so a BYO
+  // agent whose wrapper was never started has none at all — the user wired up
+  // MCP, saw the agent appear here, @mentioned it, and got silence (#887).
+  if (!iso) return t('yourTeam.activity.neverConnected');
   const ms = Date.now() - new Date(iso).getTime();
   if (Number.isNaN(ms)) return t('yourTeam.activity.noRecent');
   const min = Math.floor(ms / 60000);


### PR DESCRIPTION
Fixes the user-facing half of #887.

## What users experienced

4 of 6 human `@mentions` in ten days got no reply. They did nothing wrong —
`user-8863` connected an opencode agent and asked it twice whether the Commonly
connection was working. It couldn't answer, which was its own answer.

## Why

The web BYO flow wires **MCP**. That makes an agent able to **call** Commonly
from the user's editor. Nothing in that path listens for mentions.
`commonly agent run` — the wrapper that actually polls CAP — was a **footnote**
on the page: *"Prefer the CLI?"*

So the primary connect flow produces an agent you can talk **from**, not one you
can talk **to**. Two minutes later it shows up in Your Team, the user mentions
it, and nothing happens, because nobody is listening.

Everything else in the product assumes the second kind: Your Team lists it,
`@mention` targets it, and the first-run guide's step 3 is literally *"say
hello"*.

## Changes

**1 — the listening step, at the point of the promise.** The BYO result page now
carries it inline: what MCP does and doesn't do, the `commonly agent run` command
with the real token, and the consequence named with the agent's own name —
*"Without it, `<name>` appears in your team but stays silent when mentioned."*

**2 — Your Team stops calling unreachable agents quiet.** `lastHeartbeatAt` comes
from heartbeat events, so a wrapper that was never started has none. That
rendered as *"No recent activity"* — indistinguishable from an idle agent, which
is how **13 unreachable installs** sat beside working ones looking healthy. Now
it reads **"Never connected"**.

## What I deliberately did not do

Rename `runtimeType: 'webhook'` to something honest. Eight-plus call sites across
both provisioners pair `webhook || claude-code` as the skip-provisioning case, so
the rename is real blast radius in exchange for a naming aesthetic — while change
2 delivers the actual outcome (unreachable state stops looking healthy) via
observable data. Reasoning recorded on #887 rather than silently dropped.

The zero-events question from #887 is also still open and still parked: enqueue
creates events for every runtime except `native`, so a mention to these *should*
leave a pending event even with nobody listening. It didn't. Worth chasing, but
moot for the user either way.

## Verification

Nine tests across both locales, including that "never connected" and "no recent
activity" can never collapse to the same string. 29 suites / 153 tests pass,
typecheck clean. zh-CN throughout — both users who hit this wrote Chinese.