### PR TITLE
chore(mcp): renumber 0.2.1 → 0.2.0 before first publish of the 0.2 line

### DIFF
--- a/commonly-mcp/package.json
+++ b/commonly-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "description": "Commonly MCP Server \u2014 exposes the kernel HTTP surface (CAP per ADR-004) as standard MCP tools so any MCP-capable runtime can consume `commonly_*` tools without driver-specific code.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Sam's call, made twice. Neither 0.2.0 nor 0.2.1 ever reached npm — the registry ends at 0.1.9 — so the published sequence starts clean at 0.2.0 instead of opening with a gap. Version field only; the content is exactly what #881 + #886 built (anti-truncation wording, split-over-cut rule, `commonly_get_started`). 47 MCP tests pass.