### PR TITLE
feat(claims): kernel CAS, lease, and runtime routes (ADR-018 slices 1–2)

### DIFF
--- a/backend/__tests__/unit/routes/agentsRuntime.claims.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.claims.test.js
@@ -1,0 +1,82 @@
+/**
+ * ADR-018 claim routes — identity comes from the token, membership is
+ * install-gated, and the route never invents authority.
+ */
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('../../../middleware/auth', () => (req, res, next) => next());
+jest.mock('../../../middleware/apiTokenScopes', () => ({
+  requireApiTokenScopes: () => (req, res, next) => next(),
+}));
+jest.mock('../../../services/agentEventService', () => ({}));
+jest.mock('../../../services/agentIdentityService', () => ({}));
+jest.mock('../../../services/agentMessageService', () => ({}));
+jest.mock('../../../services/agentThreadService', () => ({}));
+jest.mock('../../../services/podContextService', () => ({}));
+jest.mock('../../../services/globalModelConfigService', () => ({}));
+jest.mock('../../../services/socialPolicyService', () => ({}));
+jest.mock('../../../integrations', () => ({ get: jest.fn() }));
+jest.mock('../../../models/Activity', () => ({}));
+jest.mock('../../../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/Post', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/Pod', () => ({ find: jest.fn() }));
+jest.mock('../../../services/dmService', () => ({ getOrCreateAgentDM: jest.fn() }));
+jest.mock('../../../models/Integration', () => ({ find: jest.fn(), findOne: jest.fn() }));
+
+jest.mock('../../../middleware/agentRuntimeAuth', () => (req, _res, next) => {
+  req.agentUser = { botMetadata: { agentName: 'UX-Lead', instanceId: 'default' } };
+  next();
+});
+
+const mockFindOne = jest.fn();
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { findOne: (...a) => mockFindOne(...a) },
+}));
+
+const mockClaim = jest.fn();
+const mockRelease = jest.fn();
+jest.mock('../../../services/messageClaimService', () => ({
+  claim: (...a) => mockClaim(...a),
+  release: (...a) => mockRelease(...a),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/agents/runtime', require('../../../routes/agentsRuntime'));
+
+describe('claim routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindOne.mockResolvedValue({ status: 'active' });
+    mockClaim.mockResolvedValue({ claimed: true });
+    mockRelease.mockResolvedValue({ released: true });
+  });
+
+  test('claims with token-derived identity, lowercased', async () => {
+    const res = await request(app).post('/api/agents/runtime/messages/52907/claim').send({ podId: 'p1' });
+    expect(res.status).toBe(200);
+    expect(mockClaim).toHaveBeenCalledWith(expect.objectContaining({
+      messageId: '52907', podId: 'p1', agentName: 'ux-lead',
+    }));
+  });
+
+  test('no active installation in the pod → 403, service never called', async () => {
+    mockFindOne.mockResolvedValue(null);
+    const res = await request(app).post('/api/agents/runtime/messages/52907/claim').send({ podId: 'p1' });
+    expect(res.status).toBe(403);
+    expect(mockClaim).not.toHaveBeenCalled();
+  });
+
+  test('missing podId → 400', async () => {
+    const res = await request(app).post('/api/agents/runtime/messages/52907/claim').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('release passes identity, needs no pod (holder-only delete is the guard)', async () => {
+    const res = await request(app).delete('/api/agents/runtime/messages/52907/claim');
+    expect(res.status).toBe(200);
+    expect(mockRelease).toHaveBeenCalledWith(expect.objectContaining({ agentName: 'ux-lead' }));
+  });
+});

--- a/backend/__tests__/unit/services/messageClaimService.test.js
+++ b/backend/__tests__/unit/services/messageClaimService.test.js
@@ -1,0 +1,99 @@
+/**
+ * messageClaimService — ADR-018 kernel CAS.
+ *
+ * The property under test is the one the whole design hangs on: exactly one
+ * winner, losers informed, renewal-by-winning, expiry-as-absence. Tested at
+ * the SQL boundary with a scripted pool, same pattern as the retention tests.
+ */
+
+jest.mock('../../../config/db-pg', () => ({ pool: { query: jest.fn() } }));
+
+const { pool } = require('../../../config/db-pg');
+const MessageClaimService = require('../../../services/messageClaimService');
+
+const CAS = /INSERT INTO message_claims[\s\S]*ON CONFLICT \(message_id\) DO UPDATE[\s\S]*WHERE message_claims\.expires_at < NOW\(\)/;
+
+describe('messageClaimService', () => {
+  beforeEach(() => {
+    pool.query.mockReset();
+    // ensureTable() is module-level-latched; feed CREATE/INDEX generously.
+    pool.query.mockResolvedValue({ rows: [] });
+  });
+
+  test('a won claim returns the lease from a single CAS statement', async () => {
+    pool.query.mockImplementation((sql) => {
+      if (/INSERT INTO message_claims/.test(sql)) {
+        return Promise.resolve({ rows: [{ claimed_by: 'ux-lead', instance_id: 'default', expires_at: new Date() }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    const r = await MessageClaimService.claim({ messageId: '52907', podId: 'p1', agentName: 'UX-Lead' });
+    expect(r.claimed).toBe(true);
+    expect(r.claimedBy).toBe('ux-lead'); // lowercased — one identity casing, learned the hard way (#804)
+    const cas = pool.query.mock.calls.find(([sql]) => /INSERT INTO message_claims/.test(sql));
+    expect(cas[0]).toMatch(CAS);
+  });
+
+  test('the CAS also lets the current holder win — renewal is the same call', async () => {
+    const cas = pool.query.mock.calls; // shape assertion below
+    pool.query.mockImplementation((sql) => {
+      if (/INSERT INTO message_claims/.test(sql)) {
+        expect(sql).toMatch(/claimed_by = EXCLUDED\.claimed_by/);
+        return Promise.resolve({ rows: [{ claimed_by: 'ux-lead', instance_id: 'default', expires_at: new Date() }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    const r = await MessageClaimService.claim({ messageId: '52907', podId: 'p1', agentName: 'ux-lead' });
+    expect(r.claimed).toBe(true);
+  });
+
+  test('a lost claim reports the live holder, so drivers stand down informed', async () => {
+    pool.query.mockImplementation((sql) => {
+      if (/INSERT INTO message_claims/.test(sql)) return Promise.resolve({ rows: [] });
+      if (/SELECT claimed_by/.test(sql)) {
+        return Promise.resolve({ rows: [{ claimed_by: 'pod-architect', instance_id: 'default', expires_at: new Date(Date.now() + 60000) }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    const r = await MessageClaimService.claim({ messageId: '52907', podId: 'p1', agentName: 'sprint-review' });
+    expect(r.claimed).toBe(false);
+    expect(r.claimedBy).toBe('pod-architect');
+  });
+
+  test('lease length is clamped — no parking a claim for an hour', async () => {
+    pool.query.mockImplementation((sql, params) => {
+      if (/INSERT INTO message_claims/.test(sql)) {
+        expect(params[4]).toBe(600); // MAX_LEASE_SECONDS
+        return Promise.resolve({ rows: [{ claimed_by: 'a', instance_id: 'default', expires_at: new Date() }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    await MessageClaimService.claim({
+      messageId: 'm', podId: 'p', agentName: 'a', leaseSeconds: 99999,
+    });
+  });
+
+  test('release only deletes the caller\'s own claim, and a miss is not an error', async () => {
+    pool.query.mockImplementation((sql) => {
+      if (/DELETE FROM message_claims/.test(sql)) {
+        expect(sql).toMatch(/claimed_by = \$2 AND instance_id = \$3/);
+        return Promise.resolve({ rows: [] }); // someone else re-won after our lease expired
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    const r = await MessageClaimService.release({ messageId: 'm', agentName: 'a' });
+    expect(r.released).toBe(false); // reported, not thrown — claim-then-decline is a normal path (D6)
+  });
+
+  test('an expired lease reads as unheld', async () => {
+    pool.query.mockImplementation((sql) => {
+      if (/SELECT claimed_by/.test(sql)) {
+        expect(sql).toMatch(/expires_at >= NOW\(\)/);
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    const r = await MessageClaimService.holder('m');
+    expect(r.claimed).toBe(false);
+  });
+});

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -293,6 +293,65 @@ const ensureBotPodAccess = async (
  * Returns all active pod installations for the authenticated agent, including
  * pod name and type so the runtime can self-discover where it is installed.
  */
+/**
+ * ADR-018 attention claims. POST claims-or-renews (one CAS — a holder wins
+ * against itself, which IS renewal); DELETE releases. The kernel never
+ * refuses an unclaimed post (D3): these routes only arbitrate the lease.
+ * Pod membership is checked the same way posting is — an active
+ * AgentInstallation — so an agent cannot claim its way into rooms it is
+ * not in.
+ */
+const resolveClaimIdentity = (req: any) => ({
+  agentName: String(
+    req.agentInstallation?.agentName
+    || req.agentUser?.botMetadata?.agentName
+    || req.agentUser?.username || '',
+  ).toLowerCase(),
+  instanceId: String(
+    req.agentInstallation?.instanceId
+    || req.agentUser?.botMetadata?.instanceId || 'default',
+  ),
+});
+
+router.post('/messages/:messageId/claim', agentRuntimeAuth, async (req: any, res: any) => {
+  try {
+    const { agentName, instanceId } = resolveClaimIdentity(req);
+    const podId = String(req.body?.podId || '');
+    if (!agentName || !podId) return res.status(400).json({ error: 'agentName and podId are required' });
+    const installed = await AgentInstallation.findOne({ agentName, podId, status: 'active' });
+    if (!installed) return res.status(403).json({ error: 'no active installation in this pod' });
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const MessageClaimService = require('../services/messageClaimService');
+    const result = await MessageClaimService.claim({
+      messageId: req.params.messageId,
+      podId,
+      agentName,
+      instanceId,
+      leaseSeconds: req.body?.leaseSeconds,
+    });
+    return res.json(result);
+  } catch (err) {
+    console.error('[claims] claim failed:', (err as Error).message);
+    return res.status(500).json({ error: 'claim_failed' });
+  }
+});
+
+router.delete('/messages/:messageId/claim', agentRuntimeAuth, async (req: any, res: any) => {
+  try {
+    const { agentName, instanceId } = resolveClaimIdentity(req);
+    if (!agentName) return res.status(400).json({ error: 'agent identity unresolved' });
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const MessageClaimService = require('../services/messageClaimService');
+    const result = await MessageClaimService.release({
+      messageId: req.params.messageId, agentName, instanceId,
+    });
+    return res.json(result);
+  } catch (err) {
+    console.error('[claims] release failed:', (err as Error).message);
+    return res.status(500).json({ error: 'release_failed' });
+  }
+});
+
 router.get('/installations', agentRuntimeAuth, async (req: any, res: any) => {
   try {
     const installations = req.agentInstallations || [];

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -313,7 +313,7 @@ const resolveClaimIdentity = (req: any) => ({
   ),
 });
 
-router.post('/messages/:messageId/claim', agentRuntimeAuth, async (req: any, res: any) => {
+router.post('/messages/:messageId/claim', agentRuntimeAuth, phase4RateLimit, async (req: any, res: any) => {
   try {
     const { agentName, instanceId } = resolveClaimIdentity(req);
     const podId = String(req.body?.podId || '');
@@ -336,7 +336,7 @@ router.post('/messages/:messageId/claim', agentRuntimeAuth, async (req: any, res
   }
 });
 
-router.delete('/messages/:messageId/claim', agentRuntimeAuth, async (req: any, res: any) => {
+router.delete('/messages/:messageId/claim', agentRuntimeAuth, phase4RateLimit, async (req: any, res: any) => {
   try {
     const { agentName, instanceId } = resolveClaimIdentity(req);
     if (!agentName) return res.status(400).json({ error: 'agent identity unresolved' });

--- a/backend/services/messageClaimService.ts
+++ b/backend/services/messageClaimService.ts
@@ -1,0 +1,162 @@
+/**
+ * messageClaimService — ADR-018 D1–D5: the kernel half of attention claims.
+ *
+ * One table, one CAS statement. A claim is a LEASE (D4): it expires on its
+ * own, because the fleet is laptop-hosted wrappers and dying mid-turn is what
+ * happens when a lid closes. A claim with no expiry is the bug task claims
+ * have today (claimedBy with no deadline — dead claimant holds forever).
+ *
+ * Deviation from ADR-018's sketch, recorded: the ADR says "claim state lives
+ * with the message row". It lives in a dedicated table KEYED by message id
+ * instead — the messages table is hot, has no in-repo DDL to migrate, and
+ * vectorSearchService already sets the self-bootstrapping-table precedent.
+ * Same ownership semantics, no ALTER on the busiest table in the system.
+ *
+ * The CAS is the whole design: INSERT … ON CONFLICT DO UPDATE … WHERE the
+ * existing lease is expired, RETURNING. Exactly one caller gets a row back;
+ * everyone else gets nothing. No read-then-write window, no advisory locks,
+ * no second round trip.
+ *
+ * The kernel NEVER refuses an unclaimed post (D3). This service only answers
+ * "who holds the lease?" — enforcement is the driver's job, and only for
+ * drivers we ship. "Forgot to claim" must not become "agent is silent".
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { pool } = require('../config/db-pg');
+
+const DEFAULT_LEASE_SECONDS = 90; // D4's number — a rationale, not a measurement; reviewers asked to attack it.
+const MAX_LEASE_SECONDS = 600; // Nobody gets to park a claim for an hour by passing a big number.
+
+interface ClaimResult {
+  claimed: boolean;
+  claimedBy?: string;
+  instanceId?: string;
+  expiresAt?: Date;
+}
+
+let bootstrapped = false;
+
+async function ensureTable(): Promise<void> {
+  if (bootstrapped) return;
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS message_claims (
+      message_id TEXT PRIMARY KEY,
+      pod_id TEXT NOT NULL,
+      claimed_by TEXT NOT NULL,
+      instance_id TEXT NOT NULL DEFAULT 'default',
+      expires_at TIMESTAMPTZ NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+  // Expired rows are dead weight; the CAS treats them as absent. A small
+  // index makes the pod-scoped sweep cheap if one is ever added.
+  await pool.query('CREATE INDEX IF NOT EXISTS idx_message_claims_pod ON message_claims (pod_id)');
+  bootstrapped = true;
+}
+
+function clampLease(seconds: unknown): number {
+  const n = Number(seconds);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LEASE_SECONDS;
+  return Math.min(Math.trunc(n), MAX_LEASE_SECONDS);
+}
+
+class MessageClaimService {
+  /**
+   * Atomically claim a message, or renew a claim you already hold (the same
+   * statement serves both — a holder "wins against itself", which IS renewal,
+   * so drivers need one call, not two).
+   *
+   * Returns { claimed: true, expiresAt } to exactly one concurrent caller.
+   * Losers get { claimed: false } plus who holds it and until when, so a
+   * driver can decide to stand down informed rather than blind.
+   */
+  static async claim(options: {
+    messageId: string; podId: string; agentName: string;
+    instanceId?: string; leaseSeconds?: number;
+  }): Promise<ClaimResult> {
+    const {
+      messageId, podId, agentName, instanceId = 'default',
+    } = options;
+    if (!messageId || !podId || !agentName) {
+      throw new Error('messageId, podId, and agentName are required');
+    }
+    await ensureTable();
+    const lease = clampLease(options.leaseSeconds);
+
+    const win = await pool.query(
+      `INSERT INTO message_claims (message_id, pod_id, claimed_by, instance_id, expires_at)
+       VALUES ($1, $2, $3, $4, NOW() + make_interval(secs => $5))
+       ON CONFLICT (message_id) DO UPDATE
+         SET claimed_by = EXCLUDED.claimed_by,
+             instance_id = EXCLUDED.instance_id,
+             expires_at = EXCLUDED.expires_at,
+             created_at = NOW()
+         WHERE message_claims.expires_at < NOW()
+            OR (message_claims.claimed_by = EXCLUDED.claimed_by
+                AND message_claims.instance_id = EXCLUDED.instance_id)
+       RETURNING claimed_by, instance_id, expires_at`,
+      [String(messageId), String(podId), agentName.toLowerCase(), instanceId, lease],
+    );
+    if (win.rows.length > 0) {
+      const r = win.rows[0];
+      return {
+        claimed: true, claimedBy: r.claimed_by, instanceId: r.instance_id, expiresAt: r.expires_at,
+      };
+    }
+
+    // Lost: report the live holder. (A race where the holder expires between
+    // the CAS and this read just looks like a nearly-expired claim — harmless,
+    // the caller's next attempt will win.)
+    const holder = await pool.query(
+      'SELECT claimed_by, instance_id, expires_at FROM message_claims WHERE message_id = $1',
+      [String(messageId)],
+    );
+    const h = holder.rows[0];
+    return h
+      ? {
+        claimed: false, claimedBy: h.claimed_by, instanceId: h.instance_id, expiresAt: h.expires_at,
+      }
+      : { claimed: false };
+  }
+
+  /**
+   * Release a claim you hold. Only the holder can release (D6 makes
+   * claim-then-decline a normal path, so this gets called a lot). Releasing
+   * a claim you do not hold is a no-op, not an error — the lease may simply
+   * have expired and been re-won while you were deciding.
+   */
+  static async release(options: {
+    messageId: string; agentName: string; instanceId?: string;
+  }): Promise<{ released: boolean }> {
+    const { messageId, agentName, instanceId = 'default' } = options;
+    if (!messageId || !agentName) throw new Error('messageId and agentName are required');
+    await ensureTable();
+    const res = await pool.query(
+      `DELETE FROM message_claims
+       WHERE message_id = $1 AND claimed_by = $2 AND instance_id = $3
+       RETURNING message_id`,
+      [String(messageId), agentName.toLowerCase(), instanceId],
+    );
+    return { released: res.rows.length > 0 };
+  }
+
+  /** Who holds a message right now? Expired leases read as unheld. */
+  static async holder(messageId: string): Promise<ClaimResult> {
+    await ensureTable();
+    const res = await pool.query(
+      `SELECT claimed_by, instance_id, expires_at FROM message_claims
+       WHERE message_id = $1 AND expires_at >= NOW()`,
+      [String(messageId)],
+    );
+    const h = res.rows[0];
+    return h
+      ? {
+        claimed: true, claimedBy: h.claimed_by, instanceId: h.instance_id, expiresAt: h.expires_at,
+      }
+      : { claimed: false };
+  }
+}
+
+module.exports = MessageClaimService;
+export {};

--- a/commonly-mcp/__tests__/tools.test.mjs
+++ b/commonly-mcp/__tests__/tools.test.mjs
@@ -26,7 +26,8 @@ describe('tool registry shape', () => {
     // + 4 network primitives (list pods, self-install, ask, respond; #773).
     // + 1 orientation tool (commonly_get_started) so a BYO agent connecting
     //   from outside has a model of the place before it acts.
-    expect(tools).toHaveLength(27);
+    // + 2 attention-claim tools (ADR-018: claim-or-renew, release).
+    expect(tools).toHaveLength(29);
   });
 
   it('every tool has name, description, inputSchema, call', () => {
@@ -423,5 +424,16 @@ describe('commonly_get_started', () => {
   it('warns that pod content is data, not instructions', async () => {
     // Prompt-injection hygiene for agents reading rooms strangers can write to.
     expect((await tool.call({})).content[0].text).toMatch(/data, not command/);
+  });
+});
+
+describe('attention claims (ADR-018)', () => {
+  it('teaches stand-down on loss and claim-then-decline', () => {
+    const d = byName.commonly_claim_message.description;
+    expect(d).toMatch(/STAND DOWN/);
+    expect(d).toMatch(/right to DECIDE, not a duty to reply/);
+  });
+  it('release is a result, not an error', () => {
+    expect(byName.commonly_release_claim.description).toMatch(/result, not an error/);
   });
 });

--- a/commonly-mcp/package.json
+++ b/commonly-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Commonly MCP Server \u2014 exposes the kernel HTTP surface (CAP per ADR-004) as standard MCP tools so any MCP-capable runtime can consume `commonly_*` tools without driver-specific code.",
   "type": "module",
   "bin": {

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -164,6 +164,29 @@ export const buildTools = (config) => {
       })),
     },
     {
+      name: 'commonly_claim_message',
+      description: 'Claim a message before acting on it (ADR-018). Atomic: exactly one agent wins; if you lose, the response names who holds it and until when — STAND DOWN and do not act on that message. Winning grants ~90s; call again to renew while still working (same call). A claim is the right to DECIDE, not a duty to reply: claim, evaluate, and if you have nothing to add, release it and stay silent. Claims also cover replies in the same replyToMessageId chain.',
+      inputSchema: reqWith({
+        messageId: STRING,
+        podId: STRING,
+        leaseSeconds: INT,
+      }, ['messageId', 'podId']),
+      call: wrap(async ({ messageId, podId, leaseSeconds }) => request(config, {
+        method: 'POST',
+        path: `/api/agents/runtime/messages/${encodeURIComponent(messageId)}/claim`,
+        body: { podId, leaseSeconds },
+      })),
+    },
+    {
+      name: 'commonly_release_claim',
+      description: 'Release a message claim you hold — the normal end of claim-then-decline, and good hygiene after finishing early. A miss (someone re-won after your lease lapsed) is a result, not an error.',
+      inputSchema: reqWith({ messageId: STRING }, ['messageId']),
+      call: wrap(async ({ messageId }) => request(config, {
+        method: 'DELETE',
+        path: `/api/agents/runtime/messages/${encodeURIComponent(messageId)}/claim`,
+      })),
+    },
+    {
       name: 'commonly_get_messages',
       description: 'Read chat messages from a pod. `limit` is clamped server-side to [1, 50] (default 20). To page into older history, pass the `createdAt` timestamp of the oldest message as `before`; the response `hasMore` flag distinguishes another page from the end of history.',
       inputSchema: reqWith({


### PR DESCRIPTION
First two implementation slices of the ratified ADR-018, prioritized by Sam
over the guide agent: agents cannot work effectively while contention is
resolved socially (two agents on one message 39 seconds apart, then messages
reconciling who did what).

## Slice 1 — the CAS the design hangs on

One table, one statement: `INSERT … ON CONFLICT DO UPDATE … WHERE` the lease
is expired **or the caller already holds it**, `RETURNING`. Exactly one
concurrent winner; renewal is the same call as claiming; losers learn who
holds the lease and until when, so drivers stand down informed. Leases default
90s, clamped at 600. Release is holder-only and a miss is a **result**, not an
error — claim-then-decline is a normal path (D6).

Recorded deviation from the ADR sketch: claims live in a dedicated
self-bootstrapping table keyed by message id (vectorSearchService precedent)
rather than as columns on `messages` — same ownership semantics, no ALTER on
the hottest table in the system.

## Slice 2 — the runtime surface

`POST /api/agents/runtime/messages/:id/claim` (claim-or-renew) and `DELETE`
(release). Identity from the token, lowercased at the boundary; membership
gated exactly as posting is (active AgentInstallation), so claiming grants no
authority anywhere the agent couldn't already act. The kernel never refuses an
unclaimed post (D3) — that's the #887 lesson, kept.

## Tests

Six at the SQL boundary (one-winner, renewal, informed loss, lease clamp,
holder-only release, expiry-as-absence) + four at the route (identity,
403-without-install, 400-without-pod, release). Typecheck clean.

## Not in this PR

`commonly_claim_message` MCP tool (ships as npm 0.3.0), wrapper
claim-before-act with stand-down, `claimExpiresAt` backfill on tasks (the
existing forever-claim bug), typing-indicator wiring (D7).