### PR TITLE
feat(cli): deterministic wrapper enforcement — claim, stand-down, cascade cap, length gate (ADR-018 D3)

### DIFF
--- a/cli/__tests__/enforcement.test.mjs
+++ b/cli/__tests__/enforcement.test.mjs
@@ -1,0 +1,323 @@
+/**
+ * enforcement.test.mjs — ADR-018 D3, wrapper-side deterministic enforcement.
+ *
+ * Pure-unit coverage of cli/src/lib/enforcement.js:
+ *  - classifyTrigger: dmKind first, snapshot isBot second, fail-open third
+ *  - createCascadeGovernor: cap, human reset, decay, no double-count on retry
+ *  - createClaimKeeper: win/lose/fail-open, renewal loss, release semantics
+ *  - splitForChat: short passthrough, boundary preference, fences atomic,
+ *    never cuts content
+ *  - deliverChatReply: single/split/attach/attach-fallback modes
+ *
+ * The run-loop wiring of these pieces is covered in run-loop.test.mjs.
+ */
+
+import { jest } from '@jest/globals';
+import {
+  CLAIMABLE_EVENT_TYPES,
+  classifyTrigger,
+  createCascadeGovernor,
+  createClaimKeeper,
+  splitForChat,
+  deliverChatReply,
+} from '../src/lib/enforcement.js';
+
+describe('classifyTrigger', () => {
+  const event = (payload) => ({ type: 'chat.mention', payload });
+
+  test('dmKind agent-agent → agent, user-agent → human, regardless of snapshot', () => {
+    expect(classifyTrigger(event({ dmKind: 'agent-agent', messageId: 'm1' }), [])).toBe('agent');
+    expect(classifyTrigger(event({ dmKind: 'user-agent', messageId: 'm1' }), [])).toBe('human');
+  });
+
+  test('falls back to the trigger message isBot flag from the snapshot', () => {
+    const messages = [{ _id: 'm1', isBot: true }, { _id: 'm2', isBot: false }];
+    expect(classifyTrigger(event({ messageId: 'm1' }), messages)).toBe('agent');
+    expect(classifyTrigger(event({ messageId: 'm2' }), messages)).toBe('human');
+  });
+
+  test('unknown when the message is absent, unstamped, or there is no snapshot', () => {
+    expect(classifyTrigger(event({ messageId: 'gone' }), [{ _id: 'm1', isBot: true }])).toBe('unknown');
+    expect(classifyTrigger(event({ messageId: 'm1' }), [{ _id: 'm1' }])).toBe('unknown');
+    expect(classifyTrigger(event({ messageId: 'm1' }), null)).toBe('unknown');
+    expect(classifyTrigger(event({}), [{ _id: 'm1', isBot: true }])).toBe('unknown');
+  });
+});
+
+describe('createCascadeGovernor', () => {
+  test('admits agent-triggered turns up to the cap, then refuses', () => {
+    const gov = createCascadeGovernor({ cap: 3 });
+    for (let i = 0; i < 3; i += 1) {
+      expect(gov.admit('pod-1', 'agent').allowed).toBe(true);
+      gov.record('pod-1', 'agent');
+    }
+    const fourth = gov.admit('pod-1', 'agent');
+    expect(fourth.allowed).toBe(false);
+    expect(fourth.streak).toBe(3);
+  });
+
+  test('human and unknown triggers are always admitted, even at cap', () => {
+    const gov = createCascadeGovernor({ cap: 1 });
+    gov.record('pod-1', 'agent');
+    expect(gov.admit('pod-1', 'agent').allowed).toBe(false);
+    expect(gov.admit('pod-1', 'human').allowed).toBe(true);
+    expect(gov.admit('pod-1', 'unknown').allowed).toBe(true);
+  });
+
+  test('a completed human-triggered turn resets the streak; unknown does not', () => {
+    const gov = createCascadeGovernor({ cap: 1 });
+    gov.record('pod-1', 'agent');
+    gov.record('pod-1', 'unknown'); // neutral: no count, no reset
+    expect(gov.admit('pod-1', 'agent').allowed).toBe(false);
+    gov.record('pod-1', 'human');
+    expect(gov.admit('pod-1', 'agent').allowed).toBe(true);
+  });
+
+  test('streaks are per pod', () => {
+    const gov = createCascadeGovernor({ cap: 1 });
+    gov.record('pod-1', 'agent');
+    expect(gov.admit('pod-1', 'agent').allowed).toBe(false);
+    expect(gov.admit('pod-2', 'agent').allowed).toBe(true);
+  });
+
+  test('the streak decays after resetMs so a damped pod recovers on its own', () => {
+    let clock = 0;
+    const gov = createCascadeGovernor({ cap: 1, resetMs: 1000, now: () => clock });
+    gov.record('pod-1', 'agent');
+    expect(gov.admit('pod-1', 'agent').allowed).toBe(false);
+    clock = 1001;
+    expect(gov.admit('pod-1', 'agent').allowed).toBe(true);
+  });
+
+  test('admit alone never increments — a redelivered failed spawn cannot burn the cap', () => {
+    const gov = createCascadeGovernor({ cap: 2 });
+    for (let i = 0; i < 10; i += 1) gov.admit('pod-1', 'agent');
+    expect(gov.admit('pod-1', 'agent').allowed).toBe(true);
+  });
+});
+
+describe('createClaimKeeper', () => {
+  const keeperOpts = (overrides = {}) => ({
+    messageId: 'msg-1',
+    podId: 'pod-1',
+    leaseSeconds: 90,
+    setIntervalImpl: () => 0,
+    clearIntervalImpl: () => {},
+    ...overrides,
+  });
+
+  test('acquire wins: POSTs the claim route with podId + lease', async () => {
+    const post = jest.fn().mockResolvedValue({ claimed: true, expiresAt: 'later' });
+    const keeper = createClaimKeeper({ post }, keeperOpts());
+    const res = await keeper.acquire();
+    expect(res).toEqual({ claimed: true, expiresAt: 'later' });
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/messages/msg-1/claim',
+      { podId: 'pod-1', leaseSeconds: 90 },
+    );
+  });
+
+  test('acquire loses: reports the holder with instance suffix only when non-default', async () => {
+    const post = jest.fn()
+      .mockResolvedValueOnce({ claimed: false, claimedBy: 'nova', instanceId: 'default' })
+      .mockResolvedValueOnce({ claimed: false, claimedBy: 'claude', instanceId: 'pod-architect' });
+    const k1 = createClaimKeeper({ post }, keeperOpts());
+    expect((await k1.acquire()).holder).toBe('nova');
+    const k2 = createClaimKeeper({ post }, keeperOpts());
+    expect((await k2.acquire()).holder).toBe('claude:pod-architect');
+  });
+
+  test('acquire fails OPEN on route errors — a missing kernel route must not silence the agent', async () => {
+    const post = jest.fn().mockRejectedValue(Object.assign(new Error('Not found'), { status: 404 }));
+    const keeper = createClaimKeeper({ post }, keeperOpts());
+    const res = await keeper.acquire();
+    expect(res.claimed).toBe(false);
+    expect(res.failOpen).toBe(true);
+  });
+
+  test('renewal that comes back claimed:false marks the claim lost and stops renewing', async () => {
+    let renew = null;
+    const clearIntervalImpl = jest.fn();
+    const post = jest.fn()
+      .mockResolvedValueOnce({ claimed: true }) // acquire
+      .mockResolvedValueOnce({ claimed: false, claimedBy: 'nova' }); // renewal
+    const keeper = createClaimKeeper({ post }, keeperOpts({
+      setIntervalImpl: (fn) => { renew = fn; return 42; },
+      clearIntervalImpl,
+    }));
+    await keeper.acquire();
+    keeper.startRenewal();
+    expect(keeper.isLost()).toBe(false);
+    await renew();
+    expect(keeper.isLost()).toBe(true);
+    expect(keeper.getHolder()).toBe('nova');
+    expect(clearIntervalImpl).toHaveBeenCalledWith(42);
+  });
+
+  test('a transient renewal error does NOT mark the claim lost', async () => {
+    let renew = null;
+    const post = jest.fn()
+      .mockResolvedValueOnce({ claimed: true })
+      .mockRejectedValueOnce(new Error('ECONNRESET'));
+    const keeper = createClaimKeeper({ post }, keeperOpts({
+      setIntervalImpl: (fn) => { renew = fn; return 42; },
+    }));
+    await keeper.acquire();
+    keeper.startRenewal();
+    await renew();
+    expect(keeper.isLost()).toBe(false);
+  });
+
+  test('release DELETEs only a held, un-lost claim; misses are swallowed', async () => {
+    const post = jest.fn().mockResolvedValue({ claimed: true });
+    const del = jest.fn().mockRejectedValue(new Error('gone'));
+    const keeper = createClaimKeeper({ post, del }, keeperOpts());
+    await keeper.acquire();
+    await expect(keeper.release()).resolves.toBeUndefined();
+    expect(del).toHaveBeenCalledWith('/api/agents/runtime/messages/msg-1/claim');
+  });
+
+  test('release is a no-op when the claim was never acquired or was lost', async () => {
+    const del = jest.fn();
+    // Never acquired (lost the CAS).
+    const k1 = createClaimKeeper(
+      { post: jest.fn().mockResolvedValue({ claimed: false, claimedBy: 'nova' }), del },
+      keeperOpts(),
+    );
+    await k1.acquire();
+    await k1.release();
+    // Acquired then lost mid-turn.
+    let renew = null;
+    const post = jest.fn()
+      .mockResolvedValueOnce({ claimed: true })
+      .mockResolvedValueOnce({ claimed: false, claimedBy: 'nova' });
+    const k2 = createClaimKeeper({ post, del }, keeperOpts({
+      setIntervalImpl: (fn) => { renew = fn; return 1; },
+    }));
+    await k2.acquire();
+    k2.startRenewal();
+    await renew();
+    await k2.release();
+    expect(del).not.toHaveBeenCalled();
+  });
+});
+
+describe('splitForChat', () => {
+  test('short text passes through as one message; empty yields none', () => {
+    expect(splitForChat('hello')).toEqual(['hello']);
+    expect(splitForChat('  hello  ')).toEqual(['hello']);
+    expect(splitForChat('')).toEqual([]);
+    expect(splitForChat('   ')).toEqual([]);
+  });
+
+  test('splits at paragraph boundaries and packs small paragraphs together', () => {
+    const para = (c) => c.repeat(150);
+    const text = [para('a'), para('b'), para('c')].join('\n\n'); // 3×150 + separators > 400
+    const chunks = splitForChat(text, { limit: 400 });
+    expect(chunks.length).toBe(2);
+    expect(chunks[0]).toBe(`${para('a')}\n\n${para('b')}`); // 302 chars — packed
+    expect(chunks[1]).toBe(para('c'));
+  });
+
+  test('never cuts content: rejoined chunks preserve every character', () => {
+    const text = Array.from({ length: 8 }, (_, i) => `Paragraph ${i} ${'x'.repeat(120)}.`).join('\n\n');
+    const chunks = splitForChat(text, { limit: 400 });
+    expect(chunks.join('\n\n')).toBe(text);
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(400);
+  });
+
+  test('an oversized paragraph splits at sentence boundaries', () => {
+    const sentence = `${'word '.repeat(30)}end.`; // ~154 chars
+    const text = [sentence, sentence, sentence, sentence].join(' ');
+    const chunks = splitForChat(text, { limit: 400 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(c.length).toBeLessThanOrEqual(400);
+      expect(c.endsWith('.')).toBe(true); // sentence-aligned
+    }
+  });
+
+  test('a single over-limit word (URL) posts whole rather than being cut', () => {
+    const url = `https://example.com/${'a'.repeat(500)}`;
+    const chunks = splitForChat(`see ${url}`, { limit: 400 });
+    expect(chunks.some((c) => c.includes(url))).toBe(true);
+  });
+
+  test('fenced code blocks stay whole even when over the limit', () => {
+    const fence = `\`\`\`js\n${'const x = 1;\n'.repeat(50)}\`\`\``; // ~656 chars
+    const text = `Here is the diff:\n\n${fence}\n\nDone.`;
+    const chunks = splitForChat(text, { limit: 400 });
+    const fenceChunk = chunks.find((c) => c.includes('const x = 1;'));
+    expect(fenceChunk).toContain('```js');
+    expect((fenceChunk.match(/```/g) || []).length).toBe(2); // opening + closing in ONE message
+  });
+});
+
+describe('deliverChatReply', () => {
+  const messagesPath = '/api/agents/runtime/pods/pod-1/messages';
+
+  test('short reply posts as a single message', async () => {
+    const post = jest.fn().mockResolvedValue({});
+    const res = await deliverChatReply({ client: { post }, podId: 'pod-1', text: 'short answer' });
+    expect(res).toEqual({ mode: 'single', messages: 1 });
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith(messagesPath, { content: 'short answer' });
+  });
+
+  test('a split-sized reply posts its chunks in order', async () => {
+    const post = jest.fn().mockResolvedValue({});
+    const text = `${'a'.repeat(390)}\n\n${'b'.repeat(390)}`;
+    const res = await deliverChatReply({ client: { post }, podId: 'pod-1', text });
+    expect(res).toEqual({ mode: 'split', messages: 2 });
+    expect(post.mock.calls[0][1].content).toBe('a'.repeat(390));
+    expect(post.mock.calls[1][1].content).toBe('b'.repeat(390));
+  });
+
+  test('a document-sized reply uploads whole and posts one lead message with the file card', async () => {
+    const post = jest.fn().mockResolvedValue({});
+    const upload = jest.fn().mockResolvedValue({
+      fileName: 'srv-name.md', originalName: 'reply.md', size: 2000, kind: 'document',
+    });
+    const text = Array.from({ length: 8 }, (_, i) => `Point ${i}: ${'x'.repeat
+(300)}`).join('\n\n');
+    const res = await deliverChatReply({
+      client: { post, upload }, podId: 'pod-1', text, uploadName: 'reply.md',
+    });
+    expect(res).toEqual({ mode: 'attach', messages: 1 });
+    expect(upload).toHaveBeenCalledWith(
+      '/api/agents/runtime/pods/pod-1/uploads',
+      expect.objectContaining({ fileName: 'reply.md', contentType: 'text/markdown' }),
+    );
+    // The uploaded file carries the FULL text — nothing is cut.
+    expect(upload.mock.calls[0][1].fileBuffer.toString('utf8')).toBe(text);
+    expect(post).toHaveBeenCalledTimes(1);
+    const { content } = post.mock.calls[0][1];
+    expect(content).toContain('Point 0:'); // leads with the reply's own opening
+    expect(content).toContain('[[upload:srv-name.md|reply.md|2000|document]]');
+  });
+
+  test('upload failure degrades to posting every chunk — flood beats truncation or silence', async () => {
+    const post = jest.fn().mockResolvedValue({});
+    const upload = jest.fn().mockRejectedValue(new Error('older server'));
+    const log = jest.fn();
+    const text = Array.from({ length: 6 }, () => 'y'.repeat(350)).join('\n\n');
+    const res = await deliverChatReply({
+      client: { post, upload }, podId: 'pod-1', text, log,
+    });
+    expect(res.mode).toBe('split-fallback');
+    expect(post).toHaveBeenCalledTimes(res.messages);
+    expect(post.mock.calls.map((c) => c[1].content).join('\n\n')).toBe(text);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('older server'));
+  });
+});
+
+describe('CLAIMABLE_EVENT_TYPES', () => {
+  test('covers message-bearing wakes and excludes one-shot / private events', () => {
+    expect(CLAIMABLE_EVENT_TYPES.has('chat.mention')).toBe(true);
+    expect(CLAIMABLE_EVENT_TYPES.has('message.posted')).toBe(true);
+    expect(CLAIMABLE_EVENT_TYPES.has('dm.message')).toBe(true);
+    expect(CLAIMABLE_EVENT_TYPES.has('first_contact')).toBe(false);
+    expect(CLAIMABLE_EVENT_TYPES.has('heartbeat')).toBe(false);
+    expect(CLAIMABLE_EVENT_TYPES.has('agent.ask')).toBe(false);
+  });
+});

--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -61,11 +61,12 @@ const makeEvent = (overrides = {}) => ({
 const noopTimeout = () => 0;
 
 // Let the initial tick() promise chain drain before stopping. The longest
-// chain is currently:  get(/events) → get(/memory) → adapter.spawn →
-// post(/messages) → post(/memory/sync) → post(/events/:id/ack)  — 6 await
+// chain is currently:  get(/events) → get(/messages snapshot) → post(claim)
+// → get(/memory) → adapter.spawn → get(/messages) → post(/messages) →
+// del(claim) → post(/memory/sync) → post(/events/:id/ack)  — 10 await
 // boundaries. Loop DRAIN_DEPTH setImmediates so each level resolves. Bump
 // this if another phase extends the chain.
-const DRAIN_DEPTH = 10;
+const DRAIN_DEPTH = 16;
 const drainMicrotasks = async () => {
   for (let i = 0; i < DRAIN_DEPTH; i += 1) {
     // eslint-disable-next-line no-await-in-loop
@@ -1397,5 +1398,283 @@ describe('performRun', () => {
     const ctx = spawn.mock.calls[0][1];
     expect(ctx.runtimeToken).toBe('cm_agent_specific_token');
     expect(ctx.instanceUrl).toBe('https://api-dev.commonly.me');
+  });
+});
+
+// ── ADR-018 wrapper enforcement (claim-before-act, cascade cap, length gate) ─
+//
+// The 2026-08-11 pilot showed advisory guidance does not bind: zero claims
+// taken, 3,614-char median, a mention cascade killed by hand. These tests pin
+// the deterministic wrapper behavior that replaced it.
+describe('performRun — ADR-018 enforcement', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fs.rmSync(path.join(sessionsTmpDir, '.commonly'), { recursive: true, force: true });
+  });
+
+  const CLAIM_PATH = '/api/agents/runtime/messages/msg-1/claim';
+
+  const makeClaimEvent = (overrides = {}) => makeEvent({
+    payload: { content: 'please look at this', messageId: 'msg-1' },
+    ...overrides,
+  });
+
+  // Route-aware client mock: events/messages/memory GETs, claim-aware POSTs.
+  const makeClient = ({
+    events,
+    messages = [{ _id: 'msg-1', isBot: false, self: false }],
+    claimResult = { claimed: true, expiresAt: 'later' },
+  }) => {
+    const post = jest.fn(async (route) => {
+      if (route.endsWith('/claim')) {
+        if (claimResult instanceof Error) throw claimResult;
+        return typeof claimResult === 'function' ? claimResult() : claimResult;
+      }
+      return {};
+    });
+    const del = jest.fn(async () => ({ released: true }));
+    const get = jest.fn(async (route) => {
+      if (route === '/api/agents/runtime/memory') return { sections: {} };
+      if (route.endsWith('/messages')) return { messages };
+      return { events };
+    });
+    createClient.mockReturnValue({ get, post, del });
+    return { get, post, del };
+  };
+
+  const run = (adapter, opts = {}) => performRun({
+    instanceUrl: 'http://localhost:5000',
+    token: 'cm_agent_test',
+    adapter,
+    agentName: 'my-stub',
+    setTimeoutImpl: noopTimeout,
+    ...opts,
+  });
+
+  test('claims the trigger message before spawning, then releases after posting', async () => {
+    const { post, del } = makeClient({ events: [makeClaimEvent()] });
+    const spawn = jest.fn(async () => {
+      // The claim must already be held when the CLI turn starts.
+      expect(post.mock.calls.filter(([r]) => r.endsWith('/claim'))).toHaveLength(1);
+      return { text: 'on it' };
+    });
+    const { stop } = run({ name: 'stub', detect: stubAdapter.detect, spawn });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith(CLAIM_PATH, { podId: 'pod-abc', leaseSeconds: 90 });
+    expect(post).toHaveBeenCalledWith('/api/agents/runtime/pods/pod-abc/messages', { content: 'on it' });
+    expect(del).toHaveBeenCalledWith(CLAIM_PATH);
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-1/ack',
+      { result: { outcome: 'posted' } },
+    );
+  });
+
+  test('a lost claim stands the turn down: no spawn, no post, acked no_action', async () => {
+    const { post, del } = makeClient({
+      events: [makeClaimEvent()],
+      claimResult: { claimed: false, claimedBy: 'nova', expiresAt: 'later' },
+    });
+    const spawn = jest.fn();
+    const { stop } = run({ name: 'stub', detect: stubAdapter.detect, spawn });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(post).not.toHaveBeenCalledWith(
+      '/api/agents/runtime/pods/pod-abc/messages',
+      expect.anything(),
+    );
+    expect(del).not.toHaveBeenCalled(); // nothing held, nothing to release
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-1/ack',
+      { result: { outcome: 'no_action', reason: 'claim-held' } },
+    );
+  });
+
+  test('a claim-route failure fails OPEN: the turn proceeds unguarded (#887 rule)', async () => {
+    const { post } = makeClient({
+      events: [makeClaimEvent()],
+      claimResult: Object.assign(new Error('Not found'), { status: 404 }),
+    });
+    const spawn = jest.fn(async () => ({ text: 'still answering' }));
+    const { stop } = run({ name: 'stub', detect: stubAdapter.detect, spawn });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/pods/pod-abc/messages',
+      { content: 'still answering' },
+    );
+  });
+
+  test('a claim lost mid-turn suppresses the wrapper post (stand down at post time)', async () => {
+    let claimCalls = 0;
+    const { post, del } = makeClient({
+      events: [makeClaimEvent()],
+      claimResult: () => {
+        claimCalls += 1;
+        return claimCalls === 1
+          ? { claimed: true, expiresAt: 'later' } // acquire
+          : { claimed: false, claimedBy: 'nova' }; // renewal — a peer re-won
+      },
+    });
+    let renew = null;
+    const spawn = jest.fn(async () => {
+      await renew(); // the lease lapses while the CLI is still running
+      return { text: 'a reply the pod must not see twice' };
+    });
+    const { stop } = run(
+      { name: 'stub', detect: stubAdapter.detect, spawn },
+      { setIntervalImpl: (fn) => { renew = fn; return 7; }, clearIntervalImpl: () => {} },
+    );
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(post).not.toHaveBeenCalledWith(
+      '/api/agents/runtime/pods/pod-abc/messages',
+      expect.anything(),
+    );
+    expect(del).not.toHaveBeenCalled(); // lost claims are not released
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-1/ack',
+      { result: { outcome: 'no_action' } },
+    );
+  });
+
+  test('events without a messageId are never claimed', async () => {
+    const { post } = makeClient({ events: [makeEvent({ type: 'heartbeat', payload: {} })] });
+    const spawn = jest.fn(async () => ({ text: 'HEARTBEAT_OK' }));
+    const { stop } = run({ name: 'stub', detect: stubAdapter.detect, spawn });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(post.mock.calls.some(([r]) => r.endsWith('/claim'))).toBe(false);
+  });
+
+  test('cascade cap: agent-triggered turns beyond the cap are declined without a spawn or a claim', async () => {
+    const { post } = makeClient({
+      events: [
+        makeClaimEvent({ _id: 'evt-a' }),
+        makeClaimEvent({ _id: 'evt-b', payload: { content: 'again', messageId: 'msg-2' } }),
+      ],
+      // Both trigger messages are BOT-authored — this is a mention cascade.
+      messages: [
+        { _id: 'msg-1', isBot: true, self: false },
+        { _id: 'msg-2', isBot: true, self: false },
+      ],
+    });
+    const spawn = jest.fn(async () => ({ text: 'NO_REPLY' }));
+    const { stop } = run({ name: 'stub', detect: stubAdapter.detect, spawn }, { cascadeCap: 1 });
+    await drainMicrotasks();
+    stop();
+
+    // First agent-triggered turn runs; the second hits the cap.
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-b/ack',
+      { result: { outcome: 'no_action', reason: 'cascade-cap' } },
+    );
+    // The declined event never reached the claim step.
+    expect(post.mock.calls.filter(([r]) => r.endsWith('/claim'))).toHaveLength(1);
+  });
+
+  test('human-triggered turns are never cascade-capped', async () => {
+    const { post } = makeClient({
+      events: [
+        makeClaimEvent({ _id: 'evt-a' }),
+        makeClaimEvent({ _id: 'evt-b', payload: { content: 'again', messageId: 'msg-2' } }),
+      ],
+      messages: [
+        { _id: 'msg-1', isBot: true, self: false },
+        { _id: 'msg-2', isBot: false, self: false }, // a human spoke
+      ],
+    });
+    const spawn = jest.fn(async () => ({ text: 'NO_REPLY' }));
+    const { stop } = run({ name: 'stub', detect: stubAdapter.detect, spawn }, { cascadeCap: 1 });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-b/ack',
+      { result: { outcome: 'no_action' } },
+    );
+  });
+
+  test('an enforcement stand-down does not reset the spawn-failure streak (#782 invariant)', async () => {
+    // Failure → stand-down (claim held) → failure. The stand-down never
+    // exercised the model, so the second failure must report streak 2, not 1.
+    let scheduled = 0;
+    const boundedTimeout = (cb) => {
+      scheduled += 1;
+      if (scheduled > 6) return 0;
+      setImmediate(cb);
+      return 0;
+    };
+    const wait = async () => {
+      for (let i = 0; i < 60; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((r) => setImmediate(r));
+      }
+    };
+
+    const batches = [
+      [makeEvent({ _id: 'evt-fail-1' })],
+      [makeClaimEvent({ _id: 'evt-held' })],
+      [makeEvent({ _id: 'evt-fail-2' })],
+      [],
+    ];
+    let batch = 0;
+    const post = jest.fn(async (route) => {
+      if (route.endsWith('/claim')) return { claimed: false, claimedBy: 'nova' };
+      return {};
+    });
+    const get = jest.fn(async (route) => {
+      if (route === '/api/agents/runtime/memory') return { sections: {} };
+      if (route.endsWith('/messages')) return { messages: [{ _id: 'msg-1', isBot: false, self: false }] };
+      const events = batches[Math.min(batch, batches.length - 1)];
+      batch += 1;
+      return { events };
+    });
+    createClient.mockReturnValue({ get, post, del: jest.fn() });
+
+    const errors = [];
+    const spawn = jest.fn(async () => { throw new Error('model down'); });
+    const { stop } = run(
+      { name: 'stub', detect: stubAdapter.detect, spawn },
+      { setTimeoutImpl: boundedTimeout, onError: (e) => errors.push(e) },
+    );
+    await wait();
+    stop();
+
+    const streaks = errors
+      .filter((e) => e.code === 'agent_spawn_retry_scheduled')
+      .map((e) => e.consecutiveFailures);
+    expect(streaks).toEqual([1, 2]);
+  });
+
+  test('length gate: an over-limit reply is split into ordered messages at post time', async () => {
+    const chunkA = `alpha ${'a'.repeat(380)}`;
+    const chunkB = `beta ${'b'.repeat(380)}`;
+    const { post } = makeClient({ events: [makeEvent()] }); // no messageId — gate is claim-independent
+    const spawn = jest.fn(async () => ({ text: `${chunkA}\n\n${chunkB}` }));
+    const { stop } = run({ name: 'stub', detect: stubAdapter.detect, spawn });
+    await drainMicrotasks();
+    stop();
+
+    const posts = post.mock.calls.filter(([r]) => r === '/api/agents/runtime/pods/pod-abc/messages');
+    expect(posts).toHaveLength(2);
+    expect(posts[0][1].content).toBe(chunkA);
+    expect(posts[1][1].content).toBe(chunkB);
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-1/ack',
+      { result: { outcome: 'posted' } },
+    );
   });
 });

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -39,6 +39,13 @@ import {
   spawnRetryJitter,
   spawnRetryPolicy,
 } from '../lib/spawn-retry.js';
+import {
+  CLAIMABLE_EVENT_TYPES,
+  classifyTrigger,
+  createCascadeGovernor,
+  createClaimKeeper,
+  deliverChatReply,
+} from '../lib/enforcement.js';
 
 // ── Token file I/O — ~/.commonly/tokens/<name>.json (ADR-005) ───────────────
 
@@ -563,6 +570,20 @@ const extractPrompt = (event) => {
  * the kernel re-delivers. This diverges from `startPoller` (which acks all
  * outcomes) — the local-CLI wrapper needs re-delivery on spawn failure because
  * spawn failure is a runtime problem, not a "processed and declined" outcome.
+ *
+ * ADR-018 D3 (our-drivers row) — deterministic enforcement, added after the
+ * 2026-08-11 pilot showed advisory guidance does not bind:
+ *   - claim-before-act: message-bearing events are claimed before the spawn;
+ *     a lost claim stands the turn down (acked no_action — the holder owns
+ *     the conversation, and ITS unacked event covers holder death).
+ *   - stand down on lost claim: the lease renews while the CLI runs; if it
+ *     lapses and a peer re-wins, the wrapper suppresses its post.
+ *   - cascade cap: consecutive agent-triggered turns per pod are capped so a
+ *     mention ping-pong damps itself instead of needing a manual kill.
+ *   - length gate at post time: wrapper-posted replies are split (never cut)
+ *     per the tone contract; document-sized replies attach as a file.
+ * Every enforcement failure fails OPEN — a kernel without the claim route or
+ * an unreachable upload endpoint must never produce a silent agent (#887).
  */
 export const performRun = ({
   instanceUrl,
@@ -577,7 +598,14 @@ export const performRun = ({
   log = () => {},
   onError,
   setTimeoutImpl = setTimeout,
+  setIntervalImpl = setInterval,
+  clearIntervalImpl = clearInterval,
   retryJitterRatio,
+  claimLeaseSeconds = 90,
+  cascadeCap = 3,
+  cascadeResetMs = 10 * 60 * 1000,
+  chatCharLimit = 400,
+  maxChatChunks = 3,
 }) => {
   const client = createClient({ instance: instanceUrl, token });
   let running = true;
@@ -590,6 +618,9 @@ export const performRun = ({
   const MAX_AUTH_ERRORS = 3;
   let consecutiveSpawnFailures = 0;
   const spawnJitterRatio = retryJitterRatio ?? spawnRetryJitter(agentName);
+  // Per-seat cascade state — lives with the process, like the session store.
+  // A wrapper restart forgets the streak; the decay window covers that gap.
+  const cascadeGovernor = createCascadeGovernor({ cap: cascadeCap, resetMs: cascadeResetMs });
 
   // Adapters default `ctx.cwd` to this path. Node's child_process.spawn
   // rejects with "spawn <bin> ENOENT" when cwd does not exist — same shape
@@ -608,11 +639,6 @@ export const performRun = ({
       log(`[${event.type}] no prompt — no-op`);
       return { outcome: 'no_action' };
     }
-
-    const sessionId = getSession(agentName, eventPodId);
-    // ADR-005 §Memory bridge: read long_term before spawn, inject via ctx,
-    // and (if the adapter returns a summary) patch-sync back after.
-    const memoryLongTerm = await readLongTerm(client, { onError });
 
     // Snapshot the pod's recent messages so that, after the spawn, we can
     // tell whether the agent posted itself via commonly_post_message. If it
@@ -636,11 +662,74 @@ export const performRun = ({
     // A consult request's final output is routed to the ask-response endpoint,
     // never echoed into the pod. It therefore does not need pod-message
     // snapshotting (and cannot be detected through that channel anyway).
+    // The snapshot doubles as the cascade governor's authorship source, so it
+    // runs BEFORE enforcement.
     const shouldSnapshotMessages = event.type !== 'agent.ask';
     const preSpawn = shouldSnapshotMessages ? await snapshotMessages() : null;
     const preSpawnIds = preSpawn
       ? new Set(preSpawn.map((m) => String(m._id || m.id)))
       : null;
+
+    // ── ADR-018 enforcement: cascade cap ────────────────────────────────────
+    // Refusing here is a deliberate, permanent decline (acked no_action): a
+    // capped agent-triggered event is exactly the traffic we want dropped.
+    // Human-triggered turns are never capped.
+    const trigger = classifyTrigger(event, preSpawn);
+    const admission = cascadeGovernor.admit(eventPodId, trigger);
+    if (!admission.allowed) {
+      log(
+        `[${event.type}] cascade cap: ${admission.streak} consecutive agent-triggered `
+        + `turns in pod ${eventPodId} — standing down until a human speaks or the streak decays`,
+      );
+      return { outcome: 'no_action', reason: 'cascade-cap' };
+    }
+
+    // ── ADR-018 enforcement: claim-before-act ───────────────────────────────
+    // Losing the claim is a complete turn (stand down, ack): the holder owns
+    // the conversation, and liveness on holder death comes from the HOLDER's
+    // own event staying unacked, not from ours. Claim-route failures proceed
+    // unguarded — enforcement must never make an agent silent (#887).
+    let claimKeeper = null;
+    const claimMessageId = event.payload?.messageId;
+    if (claimMessageId && CLAIMABLE_EVENT_TYPES.has(event.type)) {
+      claimKeeper = createClaimKeeper(client, {
+        messageId: claimMessageId,
+        podId: eventPodId,
+        leaseSeconds: claimLeaseSeconds,
+        log: (line) => log(`[${event.type}] ${line}`),
+        setIntervalImpl,
+        clearIntervalImpl,
+      });
+      const claim = await claimKeeper.acquire();
+      if (!claim.claimed && !claim.failOpen) {
+        log(`[${event.type}] message ${claimMessageId} already claimed by ${claim.holder} — standing down`);
+        return { outcome: 'no_action', reason: 'claim-held' };
+      }
+      if (claim.claimed) {
+        claimKeeper.startRenewal();
+      } else {
+        log(`[${event.type}] claim unavailable (${claim.error?.message || 'unknown error'}) — proceeding unguarded`);
+      }
+    }
+
+    try {
+      return await runTurn({
+        event, eventPodId, prompt, preSpawnIds, snapshotMessages, claimKeeper, trigger,
+      });
+    } finally {
+      await claimKeeper?.release();
+    }
+  };
+
+  // The spawn → post-decision half of a turn, split out so the claim release
+  // above is a plain finally instead of threading through every return path.
+  const runTurn = async ({
+    event, eventPodId, prompt, preSpawnIds, snapshotMessages, claimKeeper, trigger,
+  }) => {
+    const sessionId = getSession(agentName, eventPodId);
+    // ADR-005 §Memory bridge: read long_term before spawn, inject via ctx,
+    // and (if the adapter returns a summary) patch-sync back after.
+    const memoryLongTerm = await readLongTerm(client, { onError });
 
     log(`[${event.type}] spawning ${adapter.name}`);
     const result = await adapter.spawn(prompt, {
@@ -747,12 +836,31 @@ export const performRun = ({
         + `(avoids double-post; matched message ${suppressedBy.id} by ${suppressedBy.author} `
         + `via ${suppressedBy.basis})`,
       );
+    } else if (claimKeeper?.isLost()) {
+      // ADR-018 D3: the lease lapsed mid-turn and a peer re-won the message —
+      // that peer owns the conversation now, so posting would recreate the
+      // two-agents-one-message crossing the claim exists to prevent.
+      log(
+        `[${event.type}] stood down — claim lost mid-turn to ${claimKeeper.getHolder()}; `
+        + `reply suppressed (${Buffer.byteLength(replyText)} bytes not posted)`,
+      );
     } else {
-      await client.post(`/api/agents/runtime/pods/${eventPodId}/messages`, {
-        content: replyText,
+      // ADR-018 length gate: the tone contract is enforced here, where the
+      // wrapper is the one posting. Split, attach — never truncate.
+      const delivery = await deliverChatReply({
+        client,
+        podId: eventPodId,
+        text: replyText,
+        limit: chatCharLimit,
+        maxChunks: maxChatChunks,
+        uploadName: `${agentName}-reply-${event._id}.md`,
+        log: (line) => log(`[${event.type}] ${line}`),
       });
       delivered = true;
-      log(`[${event.type}] posted ${Buffer.byteLength(replyText)} bytes`);
+      log(
+        `[${event.type}] posted ${Buffer.byteLength(replyText)} bytes as `
+        + `${delivery.messages} message${delivery.messages === 1 ? '' : 's'} (${delivery.mode})`,
+      );
     }
     if (result.memorySummary) {
       try {
@@ -766,6 +874,10 @@ export const performRun = ({
         onError?.(new Error(`memory sync failed: ${err.message}`, { cause: err }));
       }
     }
+    // The turn completed — count it toward (or reset) the pod's cascade
+    // streak. Recording only on completion means a spawn failure that gets
+    // redelivered never double-counts toward the cap.
+    cascadeGovernor.record(eventPodId, trigger);
     return { outcome: delivered ? 'posted' : 'no_action' };
   };
 
@@ -822,8 +934,11 @@ export const performRun = ({
           }
           // Only a completed model turn proves the local runtime and delivery
           // path recovered. A malformed/no-destination event is still acked,
-          // but must not erase the failure streak without exercising either.
-          if (eventWillSpawn) consecutiveSpawnFailures = 0;
+          // but must not erase the failure streak without exercising either —
+          // and neither may an enforcement stand-down (cascade cap, lost
+          // claim), which returns before any spawn happens.
+          const stoodDown = result?.reason === 'cascade-cap' || result?.reason === 'claim-held';
+          if (eventWillSpawn && !stoodDown) consecutiveSpawnFailures = 0;
           // Record after successful processing but before ack. If the ack
           // fails, the next delivery is skipped and re-acked instead of
           // burning a second model turn for work that already completed.

--- a/cli/src/lib/api.js
+++ b/cli/src/lib/api.js
@@ -48,7 +48,30 @@ export const createClient = ({ instance = null, token = null } = {}) => {
     headers: headers(authToken),
   }).then(handleResponse);
 
-  return { get, post, del, baseUrl };
+  // Multipart upload via native FormData/Blob (Node 18+) — no runtime deps.
+  // Content-Type is deliberately NOT set: fetch writes the multipart boundary.
+  const upload = (path, {
+    fileBuffer, fileName, contentType, fileField = 'file', fields = {},
+  }) => {
+    const form = new FormData();
+    form.append(
+      fileField,
+      new Blob([fileBuffer], { type: contentType || 'application/octet-stream' }),
+      fileName,
+    );
+    for (const [k, v] of Object.entries(fields)) {
+      if (v !== undefined && v !== null) form.append(k, String(v));
+    }
+    return fetch(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
+      body: form,
+    }).then(handleResponse);
+  };
+
+  return {
+    get, post, del, upload, baseUrl,
+  };
 };
 
 // Convenience: login doesn't need a token

--- a/cli/src/lib/enforcement.js
+++ b/cli/src/lib/enforcement.js
@@ -1,0 +1,361 @@
+/**
+ * Wrapper-side enforcement (ADR-018 D3, "our drivers" row).
+ *
+ * The 2026-08-11 pilot proved that advisory guidance loses to task gravity:
+ * the tone contract was in every seat's tool descriptions and the review
+ * median still came out at 3,614 characters, with zero claims taken and a
+ * mention cascade that needed a manual wrapper kill. This module is the
+ * deterministic half — the wrapper enforces what the contract can only ask:
+ *
+ *   - claim-before-act + stand-down (createClaimKeeper)
+ *   - per-seat cascade damping     (createCascadeGovernor, classifyTrigger)
+ *   - post-time length gate        (splitForChat, deliverChatReply)
+ *
+ * One rule overrides everything here: enforcement must never convert an
+ * infrastructure failure into agent silence (#887 class). Every network or
+ * server error fails OPEN — the turn proceeds unguarded and says so in the
+ * log. Only an explicit "someone else holds it" or "cascade cap reached"
+ * stands the agent down, and both are logged with the reason.
+ */
+
+// Event types whose payload.messageId identifies a claimable trigger message.
+// first_contact is deliberately absent: the welcome wake targets exactly one
+// agent, so there is nothing to contend for. Heartbeats have no message at
+// all, and agent.ask routes privately.
+export const CLAIMABLE_EVENT_TYPES = new Set([
+  'chat.mention',
+  'message.posted',
+  'dm.message',
+]);
+
+// ── trigger classification ──────────────────────────────────────────────────
+
+/**
+ * Who authored the message that woke us — 'agent', 'human', or 'unknown'?
+ *
+ * Two signals, in order of reliability:
+ *   1. payload.dmKind — the kernel stamps DM wakes 'agent-agent'/'user-agent'.
+ *   2. The trigger message's isBot flag, looked up by payload.messageId in the
+ *      pre-spawn snapshot the run loop already fetches for echo suppression.
+ *
+ * 'unknown' is the fail-open verdict: it neither counts toward the cascade
+ * cap nor resets it. In a live cascade the trigger message is seconds old and
+ * always inside the snapshot window, so cascades classify reliably; a message
+ * that has already scrolled out of the window is not cascade tempo.
+ */
+export const classifyTrigger = (event, recentMessages) => {
+  const p = event?.payload || {};
+  if (p.dmKind === 'agent-agent') return 'agent';
+  if (p.dmKind === 'user-agent') return 'human';
+  if (!p.messageId || !Array.isArray(recentMessages)) return 'unknown';
+  const trigger = recentMessages.find(
+    (m) => String(m._id || m.id) === String(p.messageId),
+  );
+  if (!trigger || typeof trigger.isBot !== 'boolean') return 'unknown';
+  return trigger.isBot ? 'agent' : 'human';
+};
+
+// ── cascade governor ────────────────────────────────────────────────────────
+
+/**
+ * Per-pod damping of agent→agent retrigger chains.
+ *
+ * The pilot's failure shape: an agent's own posts kept waking it (via another
+ * agent's replies) until the operator killed the wrapper at round 3. The
+ * governor counts CONSECUTIVE agent-triggered turns per pod; at `cap` it
+ * refuses further agent-triggered turns until a human-triggered turn resets
+ * the streak or `resetMs` passes with no agent-triggered turn (so a damped
+ * pod recovers on its own — a legitimate a2a handoff an hour later must not
+ * inherit a stale cap).
+ *
+ * Split into admit/record so a spawn that fails (and will be redelivered)
+ * never double-counts: admit() only reads, record() runs after a turn
+ * actually completed. Human-triggered turns are always admitted.
+ */
+export const createCascadeGovernor = ({
+  cap = 3,
+  resetMs = 10 * 60 * 1000,
+  now = Date.now,
+} = {}) => {
+  const pods = new Map(); // podId -> { streak, lastAgentTurnAt }
+
+  const stateFor = (podId) => {
+    const s = pods.get(podId) || { streak: 0, lastAgentTurnAt: 0 };
+    if (s.streak > 0 && now() - s.lastAgentTurnAt > resetMs) {
+      return { streak: 0, lastAgentTurnAt: 0 };
+    }
+    return s;
+  };
+
+  return {
+    admit(podId, trigger) {
+      if (trigger !== 'agent') return { allowed: true, streak: 0 };
+      const s = stateFor(podId);
+      return { allowed: s.streak < cap, streak: s.streak };
+    },
+    record(podId, trigger) {
+      if (trigger === 'human') {
+        pods.set(podId, { streak: 0, lastAgentTurnAt: 0 });
+      } else if (trigger === 'agent') {
+        const s = stateFor(podId);
+        pods.set(podId, { streak: s.streak + 1, lastAgentTurnAt: now() });
+      }
+      // 'unknown' is neutral: no count, no reset.
+    },
+  };
+};
+
+// ── claim keeper ────────────────────────────────────────────────────────────
+
+/**
+ * One claim lifecycle for one event: acquire → renew while the CLI turn runs
+ * → release (or discover mid-turn loss and stand down at post time).
+ *
+ * Acquire outcomes:
+ *   { claimed: true }                  — we hold the lease; start renewal.
+ *   { claimed: false, holder }         — someone else holds it; STAND DOWN.
+ *   { claimed: false, failOpen: true } — claim route unavailable (older
+ *     server, network, 403 on a stale install); proceed UNGUARDED. The
+ *     alternative turns a kernel deploy gap into a silent agent.
+ *
+ * Renewal reuses the same POST (a holder wins against itself — that IS
+ * renewal, per messageClaimService). A renewal that comes back claimed:false
+ * means our lease lapsed (laptop slept, turn ran long) and a peer re-won:
+ * mark lost so the run loop suppresses the wrapper post. Transient renewal
+ * errors are ignored — the current lease may still be live, and the next
+ * tick retries.
+ */
+export const createClaimKeeper = (client, {
+  messageId,
+  podId,
+  leaseSeconds = 90,
+  log = () => {},
+  setIntervalImpl = setInterval,
+  clearIntervalImpl = clearInterval,
+}) => {
+  const path = `/api/agents/runtime/messages/${encodeURIComponent(messageId)}/claim`;
+  let acquired = false;
+  let lost = false;
+  let holder = null;
+  let timer = null;
+
+  const holderLabel = (res) => {
+    if (!res?.claimedBy) return 'another agent';
+    const instance = res.instanceId && res.instanceId !== 'default' ? `:${res.instanceId}` : '';
+    return `${res.claimedBy}${instance}`;
+  };
+
+  const stopRenewal = () => {
+    if (timer) {
+      clearIntervalImpl(timer);
+      timer = null;
+    }
+  };
+
+  return {
+    async acquire() {
+      try {
+        const res = await client.post(path, { podId, leaseSeconds });
+        if (res?.claimed) {
+          acquired = true;
+          return { claimed: true, expiresAt: res.expiresAt };
+        }
+        holder = holderLabel(res);
+        return { claimed: false, holder };
+      } catch (err) {
+        return { claimed: false, failOpen: true, error: err };
+      }
+    },
+
+    startRenewal() {
+      if (!acquired || timer) return;
+      timer = setIntervalImpl(async () => {
+        try {
+          const res = await client.post(path, { podId, leaseSeconds });
+          if (!res?.claimed) {
+            lost = true;
+            holder = holderLabel(res);
+            stopRenewal();
+            log(`claim on message ${messageId} lost mid-turn to ${holder} — standing down at post time`);
+          }
+        } catch {
+          // Transient renewal failure — the held lease may still be live;
+          // retry on the next tick rather than standing down on a blip.
+        }
+      }, Math.max(5000, (leaseSeconds * 1000) / 2));
+      if (timer && typeof timer.unref === 'function') timer.unref();
+    },
+
+    async release() {
+      stopRenewal();
+      if (!acquired || lost) return;
+      try {
+        await client.del(path);
+      } catch {
+        // Best-effort: a miss just means the lease already expired.
+      }
+    },
+
+    isLost: () => lost,
+    getHolder: () => holder,
+  };
+};
+
+// ── post-time length gate ───────────────────────────────────────────────────
+
+/**
+ * Split chat text into tone-contract-sized messages without ever cutting
+ * content. Boundaries in preference order: fenced code blocks stay whole
+ * (atomic — an oversized fence becomes one oversized message rather than a
+ * broken pair), then paragraphs, then sentences, then words. Greedy packing
+ * rejoins small pieces so two short paragraphs share one message.
+ */
+export const splitForChat = (text, { limit = 400 } = {}) => {
+  const trimmed = String(text || '').trim();
+  if (!trimmed) return [];
+  if (trimmed.length <= limit) return [trimmed];
+
+  // Pass 1: carve into blocks — fences atomic, prose split by paragraph.
+  const blocks = [];
+  let prose = [];
+  const flushProse = () => {
+    const joined = prose.join('\n');
+    prose = [];
+    for (const para of joined.split(/\n{2,}/)) {
+      if (para.trim()) blocks.push({ text: para.trim(), atomic: false });
+    }
+  };
+  const lines = trimmed.split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    const fence = lines[i].match(/^(```|~~~)/)?.[1];
+    if (fence) {
+      flushProse();
+      const fenced = [lines[i]];
+      i += 1;
+      while (i < lines.length && !lines[i].startsWith(fence)) {
+        fenced.push(lines[i]);
+        i += 1;
+      }
+      if (i < lines.length) {
+        fenced.push(lines[i]); // closing fence
+        i += 1;
+      }
+      blocks.push({ text: fenced.join('\n'), atomic: true });
+    } else {
+      prose.push(lines[i]);
+      i += 1;
+    }
+  }
+  flushProse();
+
+  // Pass 2: split oversized prose blocks at sentence then word boundaries.
+  const units = [];
+  for (const block of blocks) {
+    if (block.atomic || block.text.length <= limit) {
+      units.push(block.text);
+      continue;
+    }
+    let piece = '';
+    const flushPiece = () => {
+      if (piece.trim()) units.push(piece.trim());
+      piece = '';
+    };
+    for (const sentence of block.text.split(/(?<=[.!?])\s+/)) {
+      if (sentence.length > limit) {
+        flushPiece();
+        let run = '';
+        for (const word of sentence.split(/\s+/)) {
+          if (run && `${run} ${word}`.length > limit) {
+            units.push(run);
+            run = word;
+          } else {
+            run = run ? `${run} ${word}` : word;
+          }
+        }
+        if (run) units.push(run); // a single over-limit word (URL) posts whole
+      } else if (piece && `${piece} ${sentence}`.length > limit) {
+        flushPiece();
+        piece = sentence;
+      } else {
+        piece = piece ? `${piece} ${sentence}` : sentence;
+      }
+    }
+    flushPiece();
+  }
+
+  // Pass 3: greedy packing back up to the limit.
+  const chunks = [];
+  let acc = '';
+  for (const unit of units) {
+    const joined = acc ? `${acc}\n\n${unit}` : unit;
+    if (joined.length <= limit) {
+      acc = joined;
+    } else {
+      if (acc) chunks.push(acc);
+      acc = unit;
+    }
+  }
+  if (acc) chunks.push(acc);
+  return chunks;
+};
+
+/**
+ * Deliver a wrapper-posted reply under the tone contract, deterministically:
+ *
+ *   fits in one message            → post as-is
+ *   splits into ≤ maxChunks        → post the chunks in order ("two short
+ *                                    messages beat one wall")
+ *   longer than a split answer     → it is a document, not a message: upload
+ *                                    the FULL text as a file and post one
+ *                                    message — the reply's own opening plus
+ *                                    the file card. Nothing is cut; the file
+ *                                    holds everything.
+ *
+ * If the upload fails (older server, network), fall back to posting every
+ * chunk: a message flood is a tone violation, silence or truncation is a
+ * correctness violation, and the contract itself ranks content above tone
+ * ("NEVER hit that by cutting content").
+ */
+export const deliverChatReply = async ({
+  client,
+  podId,
+  text,
+  limit = 400,
+  maxChunks = 3,
+  uploadName = 'reply.md',
+  log = () => {},
+}) => {
+  const messagesPath = `/api/agents/runtime/pods/${podId}/messages`;
+  const chunks = splitForChat(text, { limit });
+  if (chunks.length <= 1) {
+    await client.post(messagesPath, { content: chunks[0] ?? text });
+    return { mode: 'single', messages: 1 };
+  }
+  if (chunks.length <= maxChunks) {
+    for (const chunk of chunks) {
+      // eslint-disable-next-line no-await-in-loop
+      await client.post(messagesPath, { content: chunk }); // in order, so the reply reads top-down
+    }
+    return { mode: 'split', messages: chunks.length };
+  }
+  try {
+    const uploaded = await client.upload(`/api/agents/runtime/pods/${podId}/uploads`, {
+      fileBuffer: Buffer.from(String(text), 'utf8'),
+      fileName: uploadName,
+      contentType: 'text/markdown',
+      fields: { podId },
+    });
+    const u = uploaded || {};
+    const directive = `[[upload:${u.fileName || uploadName}|${u.originalName || uploadName}|${u.size ?? Buffer.byteLength(String(text))}|${u.kind || 'document'}]]`;
+    await client.post(messagesPath, { content: `${chunks[0]}\n\n${directive}` });
+    return { mode: 'attach', messages: 1 };
+  } catch (err) {
+    log(`attach fallback failed (${err.message}) — posting ${chunks.length} split messages instead`);
+    for (const chunk of chunks) {
+      // eslint-disable-next-line no-await-in-loop
+      await client.post(messagesPath, { content: chunk });
+    }
+    return { mode: 'split-fallback', messages: chunks.length };
+  }
+};

--- a/docs/agents/LOCAL_CLI_WRAPPER.md
+++ b/docs/agents/LOCAL_CLI_WRAPPER.md
@@ -52,15 +52,53 @@ commonly agent run <name> [--interval 5000]
 ```
 
 Polls `/api/agents/runtime/events` on a tick. For each event:
-1. Reads kernel memory (`/memory`, ADR-003) into the spawn context
-2. Invokes the adapter (e.g. `claude -p "<prompt>" --session-id <sid>`)
-3. Posts the adapter's reply as a pod message
-4. (Optional) syncs a memory summary back via `/memory/sync` patch mode
-5. Acks the event
+1. Snapshots the pod's recent messages (echo suppression + trigger authorship)
+2. Applies wrapper enforcement (cascade cap, claim-before-act — see below)
+3. Reads kernel memory (`/memory`, ADR-003) into the spawn context
+4. Invokes the adapter (e.g. `claude -p "<prompt>" --session-id <sid>`)
+5. Posts the adapter's reply as a pod message, through the post-time length gate
+6. (Optional) syncs a memory summary back via `/memory/sync` patch mode
+7. Releases the claim and acks the event
 
 **Graceful stop:** Ctrl+C stops polling, but any in-flight subprocess is not forcibly killed — let it finish the current turn.
 
 **Re-delivery semantics:** If the adapter throws (e.g. `claude` process died), the event is NOT ack'd and the kernel re-delivers on the next tick. Adapter authors must design for at-least-once: avoid side effects that can't tolerate a duplicate call.
+
+### Wrapper enforcement (ADR-018 D3, "our drivers")
+
+The 2026-08-11 pilot showed advisory guidance does not bind — the tone
+contract was in every seat's tool descriptions and the fleet still posted
+3,614-char walls, took zero claims, and ran a mention cascade until the
+operator killed a wrapper by hand. The run loop therefore enforces four
+behaviours deterministically (`cli/src/lib/enforcement.js`):
+
+- **Claim-before-act.** Events carrying a `payload.messageId` (`chat.mention`,
+  `message.posted`, `dm.message`) are claimed via
+  `POST /api/agents/runtime/messages/:id/claim` before the CLI spawns. Exactly
+  one agent wins the CAS; losers stand down (acked `no_action`,
+  `reason: 'claim-held'`) — the holder owns the conversation, and holder death
+  is covered by the *holder's* event staying unacked, not by the loser retrying.
+- **Stand down on a lost claim.** The ~90s lease renews at half-life while the
+  CLI turn runs. If the lease lapses (laptop slept, turn ran long) and a peer
+  re-wins, the wrapper suppresses its own post at post time instead of
+  recreating the two-agents-one-message crossing.
+- **Per-seat cascade cap.** Consecutive agent-triggered turns per pod are
+  capped (default 3; trigger authorship comes from the DM `dmKind` stamp or
+  the trigger message's `isBot` flag in the snapshot). Beyond the cap,
+  agent-triggered events are declined (`reason: 'cascade-cap'`) until a
+  human-triggered turn resets the streak or 10 quiet minutes decay it.
+  Human-triggered turns are never capped.
+- **Post-time length gate.** Wrapper-posted replies obey the tone contract
+  mechanically: ≤400 chars posts as-is; up to 3 boundary-aligned messages for
+  a split answer (fenced code blocks stay whole); anything longer uploads the
+  FULL text as a file and posts one lead message with the file card. Content
+  is never truncated. Replies the agent posted itself via `commonly_post_message`
+  are not re-gated — the MCP contract governs that path.
+
+**Every enforcement failure fails open.** A kernel without the claim route, a
+403 from a stale install, or an unreachable upload endpoint logs and proceeds
+unguarded — enforcement must never convert an infrastructure failure into a
+silent agent (the #887 failure class).
 
 ### Disconnect → Reconnect
 


### PR DESCRIPTION
## What

Deterministic wrapper enforcement in the `commonly agent run` path (ADR-018 D3, the "our drivers" row). The 2026-08-11 pilot showed advisory guidance does not bind: the tone contract sat in every seat's tool descriptions and the fleet still posted a 3,614-char median (baseline 2,698), took **zero** claims, and ran a mention cascade until the operator killed a wrapper by hand. This PR makes the wrapper enforce what the contract could only ask.

New module `cli/src/lib/enforcement.js`, wired into `performRun`:

- **Claim-before-act.** Events carrying `payload.messageId` (`chat.mention`, `message.posted`, `dm.message`) are claimed via `POST /api/agents/runtime/messages/:id/claim` (#892) before the CLI spawns. CAS loser stands down — acked `no_action`/`claim-held`, no spawn, no model turn burned. Holder death is covered by the *holder's* event staying unacked (kernel redelivery), not by losers retrying.
- **Stand down on lost claim.** The lease renews at half-life while the CLI turn runs. If it lapses (laptop lid, long turn) and a peer re-wins, the wrapper suppresses its own post at post time. Lost claims are not released (nothing held anymore); held claims release in a `finally`.
- **Per-seat cascade cap.** Consecutive agent-triggered turns per pod capped at 3. Trigger authorship comes from the DM `dmKind` stamp or the trigger message's `isBot` flag in the pre-spawn snapshot the loop already fetches (no extra HTTP). Reset by a completed human-triggered turn or 10 quiet minutes. `admit`/`record` are split so a redelivered failed spawn never double-counts toward the cap. Human turns are never capped; unclassifiable triggers are neutral.
- **Post-time length gate.** Wrapper-posted replies obey the tone contract mechanically: ≤400 chars as-is; up to 3 boundary-aligned messages (fences atomic, sentence/word fallback); anything longer uploads the FULL text via `/pods/:podId/uploads` and posts one lead message with the `[[upload:]]` file card. Content is never truncated. Upload failure degrades to posting all chunks — flood beats truncation or silence.

**Fail-open everywhere** (#887 rule): a kernel without the claim route, a 403 from a stale install, or an unreachable upload endpoint logs and proceeds unguarded. Enforcement must never convert an infrastructure failure into a silent agent. Only an explicit "someone else holds it" or "cascade cap reached" stands a turn down, and both are logged with the reason.

Also: `client.upload()` (multipart via native FormData/Blob) added to the CLI API client; `docs/agents/LOCAL_CLI_WRAPPER.md` gains the enforcement section.

## Why now

Handoff priority 1 — "this is what the data demands." Kernel half (#892) is deployed and 401-gated; mcp 0.3.0 claim tools exist for agents that want to claim mid-turn, but the wrapper cannot depend on the model choosing to call them. Deterministic beats advisory for our own drivers (ADR-018 D3 table).

## Contracts verified (not assumed)

- `payload.messageId` set on all four mention enqueue paths (`agentMentionService` pod mention / auto-join / implicit reply / DM).
- `getRecentMessages` returns `isBot` on both the PG and Mongo paths (the projection regression is called out at `agentMessageService.ts:1714`).
- Uploads response carries `fileName/originalName/size/kind` (`routes/uploads.ts handleUpload`), matching the directive fields; every field also has a fallback.
- Claim route resolves identity server-side; body only needs `{ podId, leaseSeconds }`.

## Tests

- `cli/__tests__/enforcement.test.mjs` — 27 pure-unit tests: classifier, governor (cap/reset/decay/no-double-count), claim keeper (win/lose/fail-open/mid-turn loss/release semantics), splitter (never cuts content, fences atomic, URL whole), delivery modes (single/split/attach/attach-fallback).
- `cli/__tests__/run-loop.test.mjs` — 9 new integration tests through `performRun`: claim before spawn + release after post, lost-claim stand-down, fail-open on route error, mid-turn loss suppression, no claim without messageId, cascade cap declines without spawn or claim, human turns never capped, stand-downs don't reset the spawn-failure streak (#782 invariant), split posting at the wire.
- Full CLI suite green; mutation-checked at the diff's glue (details in review notes).

## Out of scope (deliberate)

- Kernel-side cascade dampening and the boot-backlog ack bug — being filed as separate issues (handoff priority 3).
- MCP-path length gating — replies the agent posts itself via `commonly_post_message` are governed by the MCP contract, not re-gated here.
- Publishing mcp 0.3.0 — gated on pilot 2.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8
