### PR TITLE
fix(agents): a manifest-declared heartbeat IS an opt-in — project it into the install config

### DIFF
--- a/backend/__tests__/unit/scripts/seed-native-agents.config.test.js
+++ b/backend/__tests__/unit/scripts/seed-native-agents.config.test.js
@@ -1,0 +1,74 @@
+/**
+ * buildInstallationConfig — the manifest→installation config projection.
+ *
+ * The heartbeat block is the regression under test. #833 made heartbeat
+ * dispatch opt-in (`config.heartbeat.enabled === true`); the seeder never
+ * projected the manifest's declared heartbeat into that flag, so
+ * pod-summarizer — whose ONLY trigger is the heartbeat — stopped running
+ * entirely at the 2026-08-04 deploy: an 8-day silent first-party outage,
+ * surfaced by the #891 reviews. A manifest that declares
+ * `triggers: ['heartbeat']` IS the owner's choice; the projection makes the
+ * scheduler see it.
+ */
+
+const { buildInstallationConfig } = require('../../../scripts/seed-native-agents');
+
+const baseApp = {
+  agentName: 'test-app',
+  displayName: 'Test App',
+  description: 'x',
+  systemPrompt: 'do the thing',
+  model: 'test/model',
+  tools: ['post_message'],
+};
+
+describe('buildInstallationConfig', () => {
+  test('a manifest-declared heartbeat trigger opts the install in, interval on the key the scheduler reads', () => {
+    const config = buildInstallationConfig({
+      ...baseApp,
+      triggers: ['heartbeat'],
+      heartbeatIntervalMinutes: 360,
+    });
+    // `enabled: true` is the only value schedulerService dispatches on (#833),
+    // and `everyMinutes` is what resolveHeartbeatIntervalMinutes reads —
+    // the old top-level heartbeatIntervalMinutes copy was read by nothing
+    // and pod-summarizer ran hourly for four months while declaring 360.
+    expect(config.heartbeat).toEqual({ enabled: true, everyMinutes: 360 });
+    expect(config.heartbeatIntervalMinutes).toBeUndefined();
+  });
+
+  test('a heartbeat trigger without a declared interval opts in on the scheduler default', () => {
+    const config = buildInstallationConfig({ ...baseApp, triggers: ['heartbeat'] });
+    expect(config.heartbeat).toEqual({ enabled: true });
+  });
+
+  test('apps without a heartbeat trigger get NO heartbeat block — #833 stays opt-in', () => {
+    // task-clerk (mention) and pod-welcomer (pod.join) ran on default-on
+    // heartbeats they never declared before #833; re-enabling them here would
+    // silently undo the opt-in contract for the native class.
+    for (const triggers of [['mention'], ['pod.join'], []]) {
+      const config = buildInstallationConfig({ ...baseApp, triggers });
+      expect(config.heartbeat).toBeUndefined();
+    }
+  });
+
+  test('runtime, prompt, tools, triggers, and limits project as before', () => {
+    const config = buildInstallationConfig({
+      ...baseApp,
+      triggers: ['mention'],
+      maxTurns: 4,
+      maxTokens: 9000,
+      maxWallClockMs: 60000,
+    });
+    expect(config).toEqual({
+      runtime: { runtimeType: 'native' },
+      systemPrompt: 'do the thing',
+      model: 'test/model',
+      tools: ['post_message'],
+      triggers: ['mention'],
+      maxTurns: 4,
+      maxTokens: 9000,
+      maxWallClockMs: 60000,
+    });
+  });
+});

--- a/backend/scripts/seed-native-agents.ts
+++ b/backend/scripts/seed-native-agents.ts
@@ -35,6 +35,55 @@ const INSTALLED_BY_USER_ID = '67a9ceb240f8f53015944a05'; // xcjsam admin
 const VERSION = '1.0.0';
 const HELLO_NATIVE_AGENT_NAME = 'hello-native';
 
+/**
+ * Project a first-party app manifest into AgentInstallation.config.
+ *
+ * The heartbeat block is the load-bearing part. Heartbeat dispatch is opt-in
+ * (#833: `config.heartbeat.enabled === true`, nothing else fires), and a
+ * manifest that declares `triggers: ['heartbeat']` IS that choice — the
+ * author wrote it down. #833's migration read the unset install flag as
+ * "nobody chose this" and silently unplugged pod-summarizer, whose only
+ * trigger is the heartbeat: zero runs from the 2026-08-04 deploy until this
+ * fix (the reviews on #891 surfaced it as an 8-day first-party outage).
+ *
+ * The interval rides along as `heartbeat.everyMinutes` — the key the
+ * scheduler actually reads (`resolveHeartbeatIntervalMinutes`). The old
+ * top-level `heartbeatIntervalMinutes` copy was read by NOTHING:
+ * pod-summarizer declared 360 and ran hourly on the scheduler's default for
+ * four months. One projected field, one reader, no second copy to drift.
+ *
+ * Apps whose manifests do not declare a heartbeat trigger (task-clerk:
+ * mention, pod-welcomer: pod.join) get no heartbeat block — before #833 they
+ * ran on default-on heartbeats they never asked for, and restoring that
+ * would re-break #833's contract. pod-welcomer staying dark is the separate
+ * `pod.join`-has-no-producer bug, not a heartbeat problem.
+ */
+export function buildInstallationConfig(
+  app: NativeAgentDefinition,
+): Record<string, unknown> {
+  const configObj: Record<string, unknown> = {
+    runtime: { runtimeType: 'native' },
+    systemPrompt: app.systemPrompt,
+    model: app.model,
+    tools: app.tools || [],
+    triggers: app.triggers || [],
+  };
+  if ((app.triggers || []).includes('heartbeat')) {
+    configObj.heartbeat = {
+      enabled: true,
+      ...(typeof app.heartbeatIntervalMinutes === 'number'
+        ? { everyMinutes: app.heartbeatIntervalMinutes }
+        : {}),
+    };
+  }
+  if (typeof app.maxTurns === 'number') configObj.maxTurns = app.maxTurns;
+  if (typeof app.maxTokens === 'number') configObj.maxTokens = app.maxTokens;
+  if (typeof app.maxWallClockMs === 'number') {
+    configObj.maxWallClockMs = app.maxWallClockMs;
+  }
+  return configObj;
+}
+
 export async function seedNativeAgents(): Promise<void> {
   try {
     console.log(
@@ -301,21 +350,7 @@ async function seedOneApp(app: NativeAgentDefinition): Promise<void> {
   //
   //    Config is stored as a plain object; Mongoose's Map<String, Mixed>
   //    schema accepts POJOs transparently, matching Round-1 conventions.
-  const configObj: Record<string, unknown> = {
-    runtime: { runtimeType: 'native' },
-    systemPrompt: app.systemPrompt,
-    model: app.model,
-    tools: app.tools || [],
-    triggers: app.triggers || [],
-  };
-  if (typeof app.heartbeatIntervalMinutes === 'number') {
-    configObj.heartbeatIntervalMinutes = app.heartbeatIntervalMinutes;
-  }
-  if (typeof app.maxTurns === 'number') configObj.maxTurns = app.maxTurns;
-  if (typeof app.maxTokens === 'number') configObj.maxTokens = app.maxTokens;
-  if (typeof app.maxWallClockMs === 'number') {
-    configObj.maxWallClockMs = app.maxWallClockMs;
-  }
+  const configObj = buildInstallationConfig(app);
 
   try {
     await AgentInstallation.findOneAndUpdate(
@@ -376,4 +411,4 @@ async function seedOneApp(app: NativeAgentDefinition): Promise<void> {
 // CJS compat so `require('./scripts/seed-native-agents').seedNativeAgents(...)`
 // works the same as the rest of the backend.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-module.exports = { seedNativeAgents };
+module.exports = { seedNativeAgents, buildInstallationConfig };


### PR DESCRIPTION
## What

#833 (heartbeat opt-in) gates dispatch on `config.heartbeat.enabled === true`. The native-app seeder never projected the manifest's declared heartbeat into that flag, so **pod-summarizer — whose only trigger is the heartbeat — has run zero times since the 2026-08-04 deploy**. The Sharpen reviews on #891 surfaced it (msgs 52989/52991): all three first-party apps flipped `stale` this morning, and `AgentRun` shows the pulse stopping at 20:13Z on Aug 4 — minutes before #833's deploy.

`buildInstallationConfig` (extracted, pure, tested) now projects a manifest `triggers: ['heartbeat']` into `{ heartbeat: { enabled: true, everyMinutes } }`:

- `enabled: true` — a manifest that declares the trigger IS the owner's choice; #833's "nobody chose this" reading was wrong for this class.
- `everyMinutes` on the key the scheduler actually reads (`resolveHeartbeatIntervalMinutes`). The old top-level `heartbeatIntervalMinutes` was read by **nothing** — pod-summarizer declared 360 and ran hourly on the default for four months. The dead copy is removed rather than left to drift.

**Deploy is the repair**: the seeder `$set`s config (and `status: 'active'`) on every boot, so the production install self-heals on the next deploy — no manual migration.

## Deliberately unchanged

- task-clerk (`mention`) and pod-welcomer (`pod.join`) get no heartbeat block — they never declared one; pre-#833 they ran on default-on heartbeats nobody asked for. Restoring that would undo #833's contract.
- pod-welcomer's declared `pod.join` trigger has **no producer anywhere in production** (review msg 52990, confirmed against 1727 runs with zero pod.join firings in 52991) — that's a separate bug, being filed with the review follow-ups.

## Tests

4 unit tests on the projection; mutation-checked (disabling the projection reddens exactly the two heartbeat tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8