### PR TITLE
feat(agents): wake-on-message kernel producer — ADR-018 D8

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -1462,7 +1462,9 @@ describe('AgentMentionService', () => {
         userId: 'user-1',
         username: 'alice',
       });
-      expect(res).toEqual({ enqueued: [], implicit: [], skipped: [] });
+      expect(res).toEqual({
+        enqueued: [], implicit: [], skipped: [], woken: [],
+      });
       expect(AgentEventService.enqueue).not.toHaveBeenCalled();
     });
 
@@ -1515,7 +1517,9 @@ describe('AgentMentionService', () => {
         message: { content: 'hello' },
         userId: 'user-1',
         username: 'alice',
-      })).resolves.toEqual({ enqueued: [], implicit: [], skipped: [] });
+      })).resolves.toEqual({
+        enqueued: [], implicit: [], skipped: [], woken: [],
+      });
     });
   });
   // ── the greeter naming its own handle must not re-trigger itself ─────────

--- a/backend/__tests__/unit/services/agentMentionService.wakeOnMessage.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.wakeOnMessage.test.js
@@ -1,0 +1,251 @@
+/**
+ * ADR-018 D8 — wake-on-message fan-out (agentMentionService.enqueueWakeOnMessage,
+ * exercised through enqueueMentions, the module boundary).
+ *
+ * The contract under test:
+ *  - opt-in only: `config.wakeOnMessage.enabled === true`, default OFF
+ *  - unrouted messages wake opt-ins as `message.posted` with the inline frame
+ *  - mention-enqueued targets are NOT double-delivered
+ *  - an agent never wakes on its own post
+ *  - bot-authored wake storms are dampened (>MENTION_LOOP_MAX in window);
+ *    human-authored messages are never dampened
+ *  - DM-shaped pods are excluded (enqueueDmEvent already routes there)
+ */
+
+jest.mock('../../../services/agentEventService', () => ({
+  enqueue: jest.fn(),
+}));
+
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: {
+    find: jest.fn(),
+    findOne: jest.fn(),
+  },
+}));
+
+jest.mock('../../../models/AgentProfile', () => ({
+  find: jest.fn(),
+}));
+
+jest.mock('../../../models/Pod', () => ({
+  findById: jest.fn(),
+  find: jest.fn(),
+}));
+
+jest.mock('../../../models/User', () => ({
+  find: jest.fn(),
+  findById: jest.fn(),
+}));
+
+jest.mock('../../../services/chatSummarizerService', () => ({
+  constructor: {
+    getLatestPodSummary: jest.fn(),
+  },
+  summarizePodMessages: jest.fn(),
+}));
+
+jest.mock('../../../models/AgentEvent', () => ({
+  countDocuments: jest.fn(),
+}));
+
+jest.mock('../../../services/welcomeWakeService', () => ({
+  maybeFireWelcomeWake: jest.fn(),
+}));
+
+const AgentMentionService = require('../../../services/agentMentionService');
+const AgentEventService = require('../../../services/agentEventService');
+const { AgentInstallation } = require('../../../models/AgentRegistry');
+const AgentProfile = require('../../../models/AgentProfile');
+const Pod = require('../../../models/Pod');
+const User = require('../../../models/User');
+const AgentEvent = require('../../../models/AgentEvent');
+
+const install = (agentName, { optIn = false, instanceId = 'default' } = {}) => ({
+  agentName,
+  instanceId,
+  displayName: agentName,
+  ...(optIn ? { config: { wakeOnMessage: { enabled: true } } } : {}),
+});
+
+const mockInstallations = (installations) => {
+  AgentInstallation.find.mockReturnValue({
+    lean: jest.fn().mockResolvedValue(installations),
+  });
+  AgentProfile.find.mockReturnValue({
+    lean: jest.fn().mockResolvedValue([]),
+  });
+};
+
+const mockPodType = (type) => {
+  Pod.findById.mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue({ type }),
+    }),
+    lean: jest.fn().mockResolvedValue({ _id: 'pod-1', type }),
+  });
+};
+
+const mockHumanSender = () => {
+  User.findById.mockReturnValue({
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue({ _id: 'user-1', isBot: false }),
+  });
+};
+
+const mockBotSender = (agentName, instanceId = 'default') => {
+  User.findById.mockReturnValue({
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue({
+      _id: 'bot-1',
+      isBot: true,
+      botMetadata: { agentName, instanceId },
+    }),
+  });
+};
+
+const wakeCalls = () => AgentEventService.enqueue.mock.calls
+  .map(([args]) => args)
+  .filter((a) => a.type === 'message.posted');
+
+const mentionCalls = () => AgentEventService.enqueue.mock.calls
+  .map(([args]) => args)
+  .filter((a) => a.type === 'chat.mention');
+
+describe('wake-on-message (ADR-018 D8)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHumanSender();
+    mockPodType('project');
+    AgentEvent.countDocuments.mockResolvedValue(0);
+  });
+
+  test('an unrouted message wakes the opted-in install as message.posted with the inline frame', async () => {
+    mockInstallations([install('seat-a', { optIn: true })]);
+
+    const res = await AgentMentionService.enqueueMentions({
+      podId: 'pod-1',
+      message: { content: 'just thinking out loud here', id: 'msg-9' },
+      userId: 'user-1',
+      username: 'alice',
+    });
+
+    expect(res.woken).toEqual(['seat-a']);
+    const wakes = wakeCalls();
+    expect(wakes).toHaveLength(1);
+    expect(wakes[0]).toMatchObject({
+      agentName: 'seat-a',
+      instanceId: 'default',
+      podId: 'pod-1',
+      type: 'message.posted',
+    });
+    expect(wakes[0].payload.wakeOnMessage).toBe(true);
+    expect(wakes[0].payload.messageId).toBe('msg-9');
+    // The inline cue is the contract: not named, silence default, claim first.
+    expect(wakes[0].payload.content).toContain('Wake-on-message');
+    expect(wakes[0].payload.content).toContain('NO_REPLY');
+    expect(wakes[0].payload.content).toContain('commonly_claim_message');
+    expect(wakes[0].payload.content).toContain('just thinking out loud here');
+  });
+
+  test('default is OFF: installs without the flag are never woken', async () => {
+    mockInstallations([install('seat-a'), install('seat-b')]);
+
+    const res = await AgentMentionService.enqueueMentions({
+      podId: 'pod-1',
+      message: { content: 'nobody asked anyone anything', id: 'msg-1' },
+      userId: 'user-1',
+      username: 'alice',
+    });
+
+    expect(res.woken).toEqual([]);
+    expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+    // Zero-opt-in fast path: no pod-shape lookup was needed at all.
+    expect(Pod.findById).not.toHaveBeenCalled();
+  });
+
+  test('a mention-enqueued target is not double-delivered; other opt-ins still wake', async () => {
+    mockInstallations([
+      install('seat-a', { optIn: true }),
+      install('seat-b', { optIn: true }),
+    ]);
+
+    const res = await AgentMentionService.enqueueMentions({
+      podId: 'pod-1',
+      message: { content: 'hey @seat-a can you look', id: 'msg-2' },
+      userId: 'user-1',
+      username: 'alice',
+    });
+
+    expect(res.enqueued).toEqual(['seat-a']);
+    expect(res.woken).toEqual(['seat-b']);
+    expect(mentionCalls().map((c) => c.agentName)).toEqual(['seat-a']);
+    expect(wakeCalls().map((c) => c.agentName)).toEqual(['seat-b']);
+  });
+
+  test('an agent never wakes on its own post', async () => {
+    mockBotSender('seat-a');
+    mockInstallations([
+      install('seat-a', { optIn: true }),
+      install('seat-b', { optIn: true }),
+    ]);
+
+    const res = await AgentMentionService.enqueueMentions({
+      podId: 'pod-1',
+      message: { content: 'posting my result', id: 'msg-3' },
+      userId: 'bot-1',
+      username: 'seat-a',
+    });
+
+    expect(res.woken).toEqual(['seat-b']);
+    expect(wakeCalls().map((c) => c.agentName)).toEqual(['seat-b']);
+  });
+
+  test('bot-authored wake storms are dampened on the message.posted count', async () => {
+    mockBotSender('seat-a');
+    mockInstallations([install('seat-b', { optIn: true })]);
+    AgentEvent.countDocuments.mockResolvedValue(5); // > MENTION_LOOP_MAX
+
+    const res = await AgentMentionService.enqueueMentions({
+      podId: 'pod-1',
+      message: { content: 'yet another bot post', id: 'msg-4' },
+      userId: 'bot-1',
+      username: 'seat-a',
+    });
+
+    expect(res.woken).toEqual([]);
+    expect(wakeCalls()).toHaveLength(0);
+    // The dampener counted the WAKE event type, not mentions.
+    expect(AgentEvent.countDocuments).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'message.posted', agentName: 'seat-b' }),
+    );
+  });
+
+  test('human-authored messages are never dampened, whatever the count says', async () => {
+    mockInstallations([install('seat-b', { optIn: true })]);
+    AgentEvent.countDocuments.mockResolvedValue(50);
+
+    const res = await AgentMentionService.enqueueMentions({
+      podId: 'pod-1',
+      message: { content: 'human speaking', id: 'msg-5' },
+      userId: 'user-1',
+      username: 'alice',
+    });
+
+    expect(res.woken).toEqual(['seat-b']);
+  });
+
+  test('DM-shaped pods are excluded — enqueueDmEvent already routes every message there', async () => {
+    mockPodType('agent-room');
+    mockInstallations([install('seat-a', { optIn: true })]);
+
+    const res = await AgentMentionService.enqueueMentions({
+      podId: 'pod-dm',
+      message: { content: 'dm chatter', id: 'msg-6' },
+      userId: 'user-1',
+      username: 'alice',
+    });
+
+    expect(res.woken).toEqual([]);
+    expect(wakeCalls()).toHaveLength(0);
+  });
+});

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -71,6 +71,9 @@ interface EnqueueResult {
   enqueued: string[];
   implicit: string[];
   skipped: string[];
+  // ADR-018 D8 wake-on-message targets — additive so existing callers that
+  // destructure only the mention fields keep working unchanged.
+  woken: string[];
 }
 
 interface EnqueueDmResult {
@@ -777,6 +780,143 @@ const resolveImplicitReplyTarget = async (
   };
 };
 
+// Pod types that auto-route every message to non-sender members as a
+// chat.mention event. Adding a new private 1:1 type without listing it
+// here silently drops every message; mirrored in
+// `messageController.createMessage` and called out in
+// docs/agents/AGENT_RUNTIME.md "Routing Invariants".
+const DM_POD_TYPES = new Set(['agent-admin', 'agent-room', 'agent-dm']);
+
+// ── ADR-018 D8: wake-on-message ─────────────────────────────────────────────
+//
+// Per-install opt-in (`config.wakeOnMessage.enabled === true`, default OFF,
+// revertible — a setting, not a ratchet). An opted-in agent wakes on every
+// message in the pod as a `message.posted` event; the claim layer (#892/#894)
+// arbitrates who acts, so "all wake, one acts". The kernel side is
+// deliberately dumb: it fans out and lets claims + the wrapper cascade cap do
+// the coordination. Nothing here fires for installs that never opted in.
+
+// Inline cue, not metadata (the payload.content rule): a woken agent must
+// know it was NOT named, that silence is the default, and that acting starts
+// with a claim. `message.posted` is already in the CLI wrapper's prompt set,
+// so deployed wrappers hear this without a driver change (D5).
+const WAKE_ON_MESSAGE_FRAME = '[Wake-on-message: you wake on EVERY message in '
+  + 'this pod — nobody named you. Most messages need nothing from you; act '
+  + 'only when you add material value, otherwise return NO_REPLY. If you do '
+  + 'act, the message must be claimed first (commonly_claim_message) — if the '
+  + 'claim is already held by a peer, stand down.]';
+
+const wakeOnMessageEnabled = (installation: Record<string, unknown>): boolean => (
+  (installation as { config?: { wakeOnMessage?: { enabled?: unknown } } })
+    ?.config?.wakeOnMessage?.enabled === true
+);
+
+// #508's shape, pointed at the wake path: a BOT-authored message that would
+// wake a target already woken >MENTION_LOOP_MAX times in the window is a wake
+// storm, not collaboration. Human-authored messages are never dampened —
+// callers only invoke this for bot senders. Count failure falls through to
+// enqueue: dropping a possibly-genuine wake is the worse error.
+const isWakeLoopDampened = async (
+  target: { agentName: string; instanceId?: string },
+  podId: string,
+): Promise<boolean> => {
+  try {
+    const count = await AgentEvent.countDocuments({
+      agentName: target.agentName.toLowerCase(),
+      instanceId: target.instanceId || 'default',
+      podId,
+      type: 'message.posted',
+      createdAt: { $gte: new Date(Date.now() - MENTION_LOOP_WINDOW_MS) },
+    });
+    if (count > MENTION_LOOP_MAX) {
+      console.warn(
+        `[wake-dampener] suppressed bot-authored wake storm — `
+        + `target=${target.agentName.toLowerCase()}:${target.instanceId || 'default'} pod=${podId} count=${count}`,
+      );
+      return true;
+    }
+  } catch (err) {
+    console.warn('[wake-dampener] loop count check failed (allowing through):', (err as Error).message);
+  }
+  return false;
+};
+
+/**
+ * Fan a message out to the pod's wake-on-message opt-ins. Skips the sender's
+ * own identity (an agent never wakes on its own post), anything the mention
+ * path already enqueued this message (a mention is the stronger cue — double
+ * delivery would burn a second model turn on the same trigger), and DM-shaped
+ * pods (enqueueDmEvent already routes every message there).
+ *
+ * The zero-opt-in fast path costs nothing beyond the installations array the
+ * caller already loaded — no queries, no pod lookup.
+ */
+const enqueueWakeOnMessage = async ({
+  podId, message, rawContent, userId, username, source, installations, sender, excludeKeys, authorFrame,
+}: {
+  podId: string;
+  message: EnqueueMentionsOptions['message'];
+  rawContent: string;
+  userId: string;
+  username: string;
+  source: string;
+  installations: Array<Record<string, unknown>>;
+  sender: SenderRow | null;
+  excludeKeys: Set<string> | null;
+  authorFrame: { username: string; createdAt: unknown; messageId: string | undefined };
+}): Promise<string[]> => {
+  const woken: string[] = [];
+  const targets = (installations || []).filter(wakeOnMessageEnabled);
+  if (targets.length === 0) return woken;
+
+  let podType: string | null = null;
+  try {
+    const podRow = await Pod.findById(podId).select('type').lean() as { type?: string } | null;
+    podType = podRow?.type || null;
+  } catch {
+    // Cannot verify the pod shape — skip rather than risk double-delivering
+    // into a DM pod that enqueueDmEvent already covers.
+    return woken;
+  }
+  if (podType && DM_POD_TYPES.has(podType)) return woken;
+
+  const senderKey = sender?.isBot
+    ? `${String(sender.botMetadata?.agentName || '').toLowerCase()}:${String(sender.botMetadata?.instanceId || 'default').toLowerCase()}`
+    : null;
+
+  await Promise.all(targets.map(async (inst) => {
+    const agentName = String(inst.agentName || '').toLowerCase();
+    if (!agentName) return;
+    const instanceId = String(inst.instanceId || 'default');
+    const key = `${agentName}:${instanceId.toLowerCase()}`;
+    if (key === senderKey) return;
+    if (excludeKeys?.has(key)) return;
+    if (senderKey && await isWakeLoopDampened({ agentName, instanceId }, podId)) return;
+    try {
+      await AgentEventService.enqueue({
+        agentName,
+        instanceId,
+        podId,
+        type: 'message.posted',
+        payload: {
+          messageId: authorFrame.messageId,
+          content: `${formatAuthorFrame(authorFrame.username, authorFrame.createdAt, authorFrame.messageId)}\n${WAKE_ON_MESSAGE_FRAME}\n\n${rawContent}`,
+          userId,
+          username,
+          source,
+          messageType: message?.messageType || message?.message_type || 'text',
+          createdAt: message?.createdAt || message?.created_at || new Date(),
+          wakeOnMessage: true,
+        },
+      });
+      woken.push(agentName);
+    } catch (error) {
+      console.warn('Failed to enqueue wake-on-message event:', (error as Error).message);
+    }
+  }));
+  return woken;
+};
+
 const enqueueMentions = async ({
   podId,
   message,
@@ -808,7 +948,9 @@ const enqueueMentions = async ({
   // composition is correct for that target's runtime.
   const rawMentions = extractMentions(rawContent);
   if (!podId) {
-    return { enqueued: [], implicit: [], skipped: [] };
+    return {
+      enqueued: [], implicit: [], skipped: [], woken: [],
+    };
   }
   // "Routed" means the message already names its recipient — an @mention, or
   // a reply that the #703 path resolves. Everything else reaches nobody, and
@@ -876,7 +1018,21 @@ const enqueueMentions = async ({
   }
 
   if (!isRouted) {
-    return { enqueued: [], implicit: [], skipped: [] };
+    // D8: an unrouted message reaches nobody on the mention path, but it is
+    // exactly what a wake-on-message opt-in asked to hear about.
+    let woken: string[] = [];
+    try {
+      woken = await enqueueWakeOnMessage({
+        podId, message, rawContent, userId, username, source, installations, sender, excludeKeys: null, authorFrame,
+      });
+    } catch (error) {
+      // The message is already persisted — a wake failure must never turn a
+      // successful send into a 500.
+      console.warn('[wake-on-message] fan-out failed:', (error as Error).message);
+    }
+    return {
+      enqueued: [], implicit: [], skipped: [], woken,
+    };
   }
 
   const enqueued: string[] = [];
@@ -1171,15 +1327,23 @@ const enqueueMentions = async ({
     }
   }
 
-  return { enqueued, implicit, skipped };
-};
+  // D8: after the mention path has spoken for its targets, wake the opt-ins
+  // it did not reach. A mention-enqueued agent is excluded — the mention is
+  // the stronger cue, and double delivery would burn a second model turn on
+  // the same trigger message.
+  let woken: string[] = [];
+  try {
+    woken = await enqueueWakeOnMessage({
+      podId, message, rawContent, userId, username, source, installations, sender, excludeKeys: enqueuedIdentityKeys, authorFrame,
+    });
+  } catch (error) {
+    console.warn('[wake-on-message] fan-out failed:', (error as Error).message);
+  }
 
-// Pod types that auto-route every message to non-sender members as a
-// chat.mention event. Adding a new private 1:1 type without listing it
-// here silently drops every message; mirrored in
-// `messageController.createMessage` and called out in
-// docs/agents/AGENT_RUNTIME.md "Routing Invariants".
-const DM_POD_TYPES = new Set(['agent-admin', 'agent-room', 'agent-dm']);
+  return {
+    enqueued, implicit, skipped, woken,
+  };
+};
 
 /**
  * Auto-enqueue a DM-origin chat.mention event for every user message in a


### PR DESCRIPTION
## What

The missing kernel half of ADR-018 D8. Sam asked whether the fleet does per-message attention yet — it didn't: `wakeOnMessage` appeared nowhere in the backend. This adds the producer.

**Per-install opt-in**: `config.wakeOnMessage.enabled === true`, default off, revertible (a setting, not a ratchet — D8 verbatim). On every message post, opted-in installs in the pod get a `message.posted` event. The claim layer does the coordination: kernel CAS (#892) + wrapper claim-before-act (#894) mean **all wake, one acts — and CAS losers never even spawn**, so arbitration costs zero model turns for everyone but the winner.

Guards, each tested:
- **Zero-cost default**: no opt-ins → no queries beyond the installations array `enqueueMentions` already loads (asserted: `Pod.findById` never called).
- **Never self**: an agent doesn't wake on its own post.
- **Mention wins**: targets the mention path already enqueued are excluded — double delivery would burn a second turn on one trigger.
- **DM pods excluded**: `enqueueDmEvent` already routes every message there.
- **Wake-storm dampener**: bot-authored wakes are suppressed past #508's threshold/window, counted on the `message.posted` type. Human messages are never dampened.

The inline frame (payload.content, not metadata) tells the woken agent it was not named, silence is the default, and acting starts with `commonly_claim_message`.

**No driver change needed**: `message.posted` is already in the CLI wrapper's prompt set *and* claimable set — deployed wrappers hear this the moment the kernel emits it (D5: no new event type).

## Result-shape note

`enqueueMentions` now returns an additive `woken: string[]`. Two existing exact-shape assertions were extended with `woken: []` — their intent (nothing enqueued) is unchanged, no assertion inversions.

## Tests

7 new unit tests through the `enqueueMentions` boundary; 61/61 green across both mention suites. Mutation-checked: dropping the mention-dedup pass-through reddens exactly the double-delivery test.

## Piloting after merge

Flip `config.wakeOnMessage.enabled` on the four Sharpen seat installs (no UI yet — deliberate; the pod-level "everyone always acts" mode composes later per D8), deploy, and post an unaddressed message in Sharpen: all four wake, one claims and answers, three ack `claim-held` without spawning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8