### PR TITLE
fix(helm): per-agent replicas knob — a parked cloud-codex agent must stay parked

### DIFF
--- a/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
+++ b/k8s/helm/commonly/templates/agents/cloud-codex-deployment.yaml
@@ -58,7 +58,13 @@ metadata:
     app: cloud-codex
     agent: {{ $name }}
 spec:
-  replicas: 1
+  # Per-agent off-switch. `replicas: 0` parks the agent — Deployment, PVC,
+  # token secret, and AgentInstallation identity all stay — where deleting
+  # the values block would tear the state down with it. Needed because a
+  # manual `kubectl scale --replicas=0` is drift the next `helm upgrade`
+  # silently reverts (that is how Cody resurrected on the 2026-08-12 deploy
+  # after being deliberately parked).
+  replicas: {{ if hasKey $cfg "replicas" }}{{ $cfg.replicas }}{{ else }}1{{ end }}
   # Recreate so the PVC (single-writer RWO) reattaches cleanly on update.
   strategy:
     type: Recreate

--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -195,6 +195,9 @@ agents:
         adapter: codex
         storage: 1Gi
         tokenSecret: cloud-codex-cody-token
+        # Parked 2026-08-12 (Sam: the working fleet is the Sharpen pod).
+        # Identity, PVC, and token secret stay; flip to 1 to revive.
+        replicas: 0
 
 rbac:
   create: true


### PR DESCRIPTION
Cody was deliberately parked (`kubectl scale --replicas=0`) this morning, and the next `Deploy Dev` silently resurrected it: the cloud-codex deployment template hardcodes `replicas: 1`, so any manual scale is drift that helm reverts on upgrade.

This adds a per-agent `replicas` knob (default 1 — no change for agents that don't set it) and pins Cody's values entry to 0. Parking via values preserves the Deployment spec, PVC, token secret, and AgentInstallation identity — flip to 1 to revive whole. Verified by `helm template`: exactly one rendered `replicas: 0` (cody), chart lint clean.

No deploy urgency: Cody is manually scaled to 0 again right now; this makes the park survive the *next* deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8