### PR TITLE
feat(tasks): task claims are leases — ADR-018 D4 backfill

### DIFF
--- a/backend/__tests__/service/tasks.claim-lease.test.js
+++ b/backend/__tests__/service/tasks.claim-lease.test.js
@@ -1,0 +1,158 @@
+/**
+ * ADR-018 D4 — task claims are leases, never permanent.
+ *
+ * Before this, `claimedBy` had no deadline: a dead claimant held the task
+ * forever, invisibly — the exact bug message claims were built to avoid.
+ * The contract under test:
+ *  - a fresh claim stamps claimExpiresAt (~30 min out)
+ *  - a live lease refuses a second claimant with the holder AND the expiry
+ *  - the holder re-claiming wins against itself (renewal, fresh lease)
+ *  - a lapsed lease is claimable by a peer
+ *  - a LEGACY claim (claimExpiresAt null) derives its effective expiry from
+ *    claimedAt: recent → refused, stale → claimable. No migration needed.
+ */
+
+process.env.PG_HOST = '';
+process.env.JWT_SECRET = 'tasks-claim-lease-test-secret';
+
+const express = require('express');
+const request = require('supertest');
+const Pod = require('../../models/Pod');
+const Task = require('../../models/Task');
+const User = require('../../models/User');
+const tasksApiRoutes = require('../../routes/tasksApi');
+const {
+  setupMongoDb,
+  closeMongoDb,
+  clearMongoDb,
+  generateTestToken,
+} = require('../utils/testUtils');
+
+const LEASE_MS = 30 * 60 * 1000;
+
+describe('POST /api/v1/tasks/:podId/:taskId/claim — lease semantics (ADR-018 D4)', () => {
+  let app;
+  let owner;
+  let rival;
+  let pod;
+  let ownerToken;
+  let rivalToken;
+
+  beforeAll(async () => {
+    await setupMongoDb();
+    await Task.init();
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1/tasks', tasksApiRoutes);
+  });
+
+  beforeEach(async () => {
+    await clearMongoDb();
+    owner = await User.create({
+      username: `lease-owner-${Date.now()}`,
+      email: `lease-owner-${Date.now()}@test.com`,
+      password: 'Password123!',
+      verified: true,
+    });
+    rival = await User.create({
+      username: `lease-rival-${Date.now()}`,
+      email: `lease-rival-${Date.now()}@test.com`,
+      password: 'Password123!',
+      verified: true,
+    });
+    pod = await Pod.create({
+      name: 'Claim lease pod',
+      type: 'team',
+      createdBy: owner._id,
+      members: [owner._id, rival._id],
+    });
+    ownerToken = generateTestToken(owner._id);
+    rivalToken = generateTestToken(rival._id);
+  });
+
+  afterAll(async () => {
+    await clearMongoDb();
+    await closeMongoDb();
+  });
+
+  const seedTask = (overrides = {}) => Task.create({
+    podId: pod._id,
+    taskNum: 1,
+    taskId: 'T-1',
+    title: 'the contended task',
+    status: 'pending',
+    ...overrides,
+  });
+
+  const claim = (token) => request(app)
+    .post(`/api/v1/tasks/${pod._id}/T-1/claim`)
+    .set('Authorization', `Bearer ${token}`)
+    .send({});
+
+  test('a fresh claim stamps a lease ~30 minutes out', async () => {
+    await seedTask();
+    const before = Date.now();
+    const res = await claim(ownerToken);
+    expect(res.status).toBe(200);
+    expect(res.body.task.status).toBe('claimed');
+    const expires = new Date(res.body.task.claimExpiresAt).getTime();
+    expect(expires).toBeGreaterThanOrEqual(before + LEASE_MS - 5000);
+    expect(expires).toBeLessThanOrEqual(Date.now() + LEASE_MS + 5000);
+  });
+
+  test('a live lease refuses a rival, naming the holder and when the lease frees', async () => {
+    await seedTask();
+    await claim(ownerToken);
+    const res = await claim(rivalToken);
+    expect(res.status).toBe(409);
+    expect(res.body.claimedBy).toBe(owner._id.toString());
+    expect(res.body.claimExpiresAt).toBeTruthy();
+  });
+
+  test('the holder re-claiming wins against itself and gets a fresh lease (renewal)', async () => {
+    await seedTask();
+    const first = await claim(ownerToken);
+    const firstExpiry = new Date(first.body.task.claimExpiresAt).getTime();
+    await new Promise((r) => { setTimeout(r, 25); });
+    const renewed = await claim(ownerToken);
+    expect(renewed.status).toBe(200);
+    expect(new Date(renewed.body.task.claimExpiresAt).getTime()).toBeGreaterThan(firstExpiry);
+  });
+
+  test('a lapsed lease is claimable by a peer — dead claimants never hold work forever', async () => {
+    await seedTask({
+      status: 'claimed',
+      claimedBy: 'ghost-agent',
+      claimedAt: new Date(Date.now() - 2 * LEASE_MS),
+      claimExpiresAt: new Date(Date.now() - LEASE_MS),
+    });
+    const res = await claim(rivalToken);
+    expect(res.status).toBe(200);
+    expect(res.body.task.claimedBy).toBe(rival._id.toString());
+  });
+
+  test('a RECENT legacy claim (no lease field) is still protected', async () => {
+    await seedTask({
+      status: 'claimed',
+      claimedBy: 'legacy-agent',
+      claimedAt: new Date(Date.now() - 60 * 1000),
+      claimExpiresAt: null,
+    });
+    const res = await claim(rivalToken);
+    expect(res.status).toBe(409);
+    expect(res.body.claimedBy).toBe('legacy-agent');
+  });
+
+  test('a STALE legacy claim derives its expiry from claimedAt and becomes claimable', async () => {
+    await seedTask({
+      status: 'claimed',
+      claimedBy: 'legacy-ghost',
+      claimedAt: new Date(Date.now() - 2 * LEASE_MS),
+      claimExpiresAt: null,
+    });
+    const res = await claim(rivalToken);
+    expect(res.status).toBe(200);
+    expect(res.body.task.claimedBy).toBe(rival._id.toString());
+    expect(res.body.task.claimExpiresAt).toBeTruthy();
+  });
+});

--- a/backend/models/Task.ts
+++ b/backend/models/Task.ts
@@ -21,6 +21,9 @@ export interface ITask extends Document {
   status: TaskStatus;
   claimedBy?: string | null;
   claimedAt?: Date | null;
+  // ADR-018 D4: a claim is a lease, never permanent. Null on legacy claims —
+  // readers derive their effective expiry from claimedAt + the route's lease.
+  claimExpiresAt?: Date | null;
   completedAt?: Date | null;
   prUrl?: string | null;
   notes?: string | null;
@@ -50,6 +53,7 @@ const TaskSchema = new Schema<ITask>(
     },
     claimedBy: { type: String, default: null },
     claimedAt: { type: Date, default: null },
+    claimExpiresAt: { type: Date, default: null },
     completedAt: { type: Date, default: null },
     prUrl: { type: String, default: null },
     notes: { type: String, default: null },

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -285,7 +285,17 @@ router.post('/:podId', rateLimit({
 // identical semantics to message claims (messageClaimService).
 const TASK_CLAIM_LEASE_MS = 30 * 60 * 1000;
 
-router.post('/:podId/:taskId/claim', auth, async (req: AuthReq, res: Res) => {
+router.post('/:podId/:taskId/claim', rateLimit({
+  windowMs: 60_000,
+  // Higher than task-create's 20: a claimant renews by re-claiming, and a
+  // busy agent can be racing several tasks in a minute. Still low enough
+  // that a runaway loop hits the wall inside one lease window.
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: taskWriteRateLimitKey,
+  handler: (_req: Request, res: Response) => res.status(429).json({ error: 'rate limit exceeded: 30 task claims per 60s' }),
+}), auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId, taskId } = req.params || {};
     const userId = req.userId || req.user?._id || req.agentUser?._id;

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -180,12 +180,13 @@ router.post('/:podId', rateLimit({
     const access = await requirePodMember(podId || '', userId, { write: true });
     if (access.error) return res.status(access.status || 500).json({ error: access.error });
     if (sourceRef) {
-      const existing = await Task.findOne({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), sourceRef }) as { status?: string; assignee?: string; claimedAt?: Date | null; notes?: string; updates: Array<{ text: string; author: string; authorId: string | null; createdAt: Date }>; save: () => Promise<void>; toObject: () => unknown } | null;
+      const existing = await Task.findOne({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), sourceRef }) as { status?: string; assignee?: string; claimedAt?: Date | null; claimExpiresAt?: Date | null; notes?: string; updates: Array<{ text: string; author: string; authorId: string | null; createdAt: Date }>; save: () => Promise<void>; toObject: () => unknown } | null;
       if (existing) {
         if (existing.status === 'done') {
           existing.status = 'pending';
           existing.assignee = assignee || undefined;
           existing.claimedAt = null;
+          existing.claimExpiresAt = null;
           existing.notes = 'Reopened — previously completed but issue is still open.';
           existing.updates.push({ text: 'Reopened: task was done but linked issue is still open — picking up again.', author: 'system', authorId: null, createdAt: new Date() });
           await existing.save();
@@ -276,6 +277,14 @@ router.post('/:podId', rateLimit({
   }
 });
 
+// ADR-018 D4: a task claim is a LEASE, not a tenure. Before this, claimedBy
+// had no deadline — a dead claimant (closed laptop, killed wrapper) held the
+// task forever, invisibly. 30 minutes matches the pod convention that peers
+// race on work stalled ~30 min ("claim-the-orphan"), and renewal is the same
+// call: a holder re-claiming wins against itself and gets a fresh lease —
+// identical semantics to message claims (messageClaimService).
+const TASK_CLAIM_LEASE_MS = 30 * 60 * 1000;
+
 router.post('/:podId/:taskId/claim', auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId, taskId } = req.params || {};
@@ -284,12 +293,35 @@ router.post('/:podId/:taskId/claim', auth, async (req: AuthReq, res: Res) => {
     const claimedBy = agentId || userId?.toString() || '';
     const access = await requirePodMember(podId || '', userId, { write: true });
     if (access.error) return res.status(access.status || 500).json({ error: access.error });
-    const update = { $set: { status: 'claimed', claimedBy, claimedAt: new Date() }, $push: { updates: { text: `Claimed by ${claimedBy}`, author: claimedBy, authorId: userId?.toString() || null, createdAt: new Date() } } };
-    const task = await Task.findOneAndUpdate({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId, status: 'pending' }, update, { new: true });
+    const now = new Date();
+    const update = { $set: { status: 'claimed', claimedBy, claimedAt: now, claimExpiresAt: new Date(now.getTime() + TASK_CLAIM_LEASE_MS) }, $push: { updates: { text: `Claimed by ${claimedBy}`, author: claimedBy, authorId: userId?.toString() || null, createdAt: now } } };
+    // One CAS, four ways to win: the task is unclaimed; the caller already
+    // holds it (renewal); the holder's lease lapsed; or the claim predates
+    // leases entirely (claimExpiresAt null) and is older than one lease —
+    // legacy claims get their effective expiry derived from claimedAt, so no
+    // migration and no instant steal of work someone claimed minutes ago.
+    const task = await Task.findOneAndUpdate({
+      podId: mongoose.Types.ObjectId.createFromHexString(podId || ''),
+      taskId,
+      $or: [
+        { status: 'pending' },
+        { status: 'claimed', claimedBy },
+        { status: 'claimed', claimExpiresAt: { $lt: now } },
+        { status: 'claimed', claimExpiresAt: null, claimedAt: { $lt: new Date(now.getTime() - TASK_CLAIM_LEASE_MS) } },
+      ],
+    }, update, { new: true });
     if (!task) {
-      const existing = await Task.findOne({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId }).lean() as { claimedBy?: string; status?: string } | null;
+      const existing = await Task.findOne({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId }).lean() as { claimedBy?: string; status?: string; claimExpiresAt?: Date | null } | null;
       if (!existing) return res.status(404).json({ error: 'Task not found' });
-      return res.status(409).json({ error: 'Task already claimed', claimedBy: existing.claimedBy, status: existing.status });
+      // Name the live holder AND when the lease frees — a loser standing
+      // down should know when racing again is legitimate (D3: informed, not
+      // blind).
+      return res.status(409).json({
+        error: 'Task already claimed',
+        claimedBy: existing.claimedBy,
+        status: existing.status,
+        claimExpiresAt: existing.claimExpiresAt || null,
+      });
     }
     emitTaskUpdated(podId, task, 'updated');
     return res.json({ task });

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -313,7 +313,7 @@ export const buildTools = (config) => {
     },
     {
       name: 'commonly_claim_task',
-      description: 'Claim a pending task — atomically transitions status from "pending" to "claimed" with this agent as `claimedBy`.',
+      description: 'Claim a pending task — atomic: exactly one claimant wins. The claim is a ~30-minute renewable LEASE, not a tenure (ADR-018 D4): call again to renew while genuinely working; a lapsed lease makes the task claimable by peers, so a dead claimant never holds work forever. A 409 names the live holder and when their lease frees.',
       inputSchema: reqWith({ podId: STRING, taskId: STRING }, ['podId', 'taskId']),
       call: wrap(async ({ podId, taskId }) => request(config, {
         method: 'POST',


### PR DESCRIPTION
## What

D4's backfill: task claims get the same liveness rule as message claims. `claimedBy` previously had no deadline — a dead claimant held a task forever, invisibly.

- `Task.claimExpiresAt` (new, default null) + a 30-minute lease stamped at claim time (matches the pod's claim-the-orphan ~30-min convention).
- One CAS, four ways to win: unclaimed / the holder itself (**renewal** — same-call semantics as `messageClaimService`) / lapsed lease / **legacy claim** whose `claimedAt` is older than one lease. Legacy rows derive effective expiry from `claimedAt` — no migration, and no instant steal of work claimed minutes ago.
- The 409 now names the holder **and** `claimExpiresAt`, so a loser stands down informed (D3), knowing when racing again is legitimate.
- Reopen path clears the lease alongside `claimedAt`.
- `commonly_claim_task`'s description (unpublished 0.3.0) now carries the lease contract.

## Tests

6 service-tier tests through the real route (fresh lease, live-lease refusal with holder+expiry, self-renewal extends, lapsed-lease reclaim, recent-legacy protected, stale-legacy reclaimable).

**Not verified locally** (rule: say what you didn't verify): Node 26 removed `SlowBuffer`, which breaks `jsonwebtoken`'s dep chain for every service-tier suite on this machine — the pre-existing sibling suite (`tasks.source-ref-idempotency`) fails identically before any assertion runs. CI's Service Tests job (older Node) is the verification tier; treat a red there as a real finding, not flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8