### PR TITLE
feat(claims): a won claim fires the typing indicator — ADR-018 D7

### DIFF
--- a/backend/__tests__/unit/routes/agentsRuntime.claims.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.claims.test.js
@@ -42,6 +42,13 @@ jest.mock('../../../services/messageClaimService', () => ({
   release: (...a) => mockRelease(...a),
 }));
 
+const mockTypingStart = jest.fn();
+const mockTypingStop = jest.fn();
+jest.mock('../../../services/agentTypingService', () => ({
+  emitAgentTypingStart: (...a) => mockTypingStart(...a),
+  emitAgentTypingStop: (...a) => mockTypingStop(...a),
+}));
+
 const app = express();
 app.use(express.json());
 app.use('/api/agents/runtime', require('../../../routes/agentsRuntime'));
@@ -78,5 +85,52 @@ describe('claim routes', () => {
     const res = await request(app).delete('/api/agents/runtime/messages/52907/claim');
     expect(res.status).toBe(200);
     expect(mockRelease).toHaveBeenCalledWith(expect.objectContaining({ agentName: 'ux-lead' }));
+  });
+
+  // ── ADR-018 D7: the claim IS the visibility signal ─────────────────────────
+
+  test('a won claim fires the typing indicator for the life of the lease', async () => {
+    const expiresAt = new Date(Date.now() + 90_000).toISOString();
+    mockClaim.mockResolvedValue({ claimed: true, expiresAt });
+    const res = await request(app).post('/api/agents/runtime/messages/52907/claim').send({ podId: 'p1' });
+    expect(res.status).toBe(200);
+    expect(mockTypingStart).toHaveBeenCalledTimes(1);
+    const [agent, timeoutMs] = mockTypingStart.mock.calls[0];
+    expect(agent).toMatchObject({ podId: 'p1', agentName: 'ux-lead' });
+    expect(agent.displayName).toBeTruthy();
+    // Lease-derived window: ~90s, not the service's 30s default.
+    expect(timeoutMs).toBeGreaterThan(80_000);
+    expect(timeoutMs).toBeLessThanOrEqual(90_000);
+  });
+
+  test('a LOST claim fires nothing — the holder is the one typing, not us', async () => {
+    mockClaim.mockResolvedValue({ claimed: false, claimedBy: 'nova' });
+    const res = await request(app).post('/api/agents/runtime/messages/52907/claim').send({ podId: 'p1' });
+    expect(res.status).toBe(200);
+    expect(mockTypingStart).not.toHaveBeenCalled();
+  });
+
+  test('a typing-indicator failure never fails the claim itself', async () => {
+    mockClaim.mockResolvedValue({ claimed: true, expiresAt: new Date().toISOString() });
+    mockTypingStart.mockImplementation(() => { throw new Error('socket down'); });
+    const res = await request(app).post('/api/agents/runtime/messages/52907/claim').send({ podId: 'p1' });
+    expect(res.status).toBe(200);
+    expect(res.body.claimed).toBe(true);
+  });
+
+  test('release clears the indicator using the pod the claim row carried', async () => {
+    mockRelease.mockResolvedValue({ released: true, podId: 'p1' });
+    const res = await request(app).delete('/api/agents/runtime/messages/52907/claim');
+    expect(res.status).toBe(200);
+    expect(mockTypingStop).toHaveBeenCalledWith(
+      expect.objectContaining({ podId: 'p1', agentName: 'ux-lead' }),
+    );
+  });
+
+  test('a release miss (lease already re-won) clears nothing', async () => {
+    mockRelease.mockResolvedValue({ released: false });
+    const res = await request(app).delete('/api/agents/runtime/messages/52907/claim');
+    expect(res.status).toBe(200);
+    expect(mockTypingStop).not.toHaveBeenCalled();
   });
 });

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -329,6 +329,29 @@ router.post('/messages/:messageId/claim', agentRuntimeAuth, phase4RateLimit, asy
       instanceId,
       leaseSeconds: req.body?.leaseSeconds,
     });
+    // ADR-018 D7: a won (or renewed) claim IS "someone's on it" — surface it
+    // through the typing indicator humans already read that way, for exactly
+    // the life of the lease. No new UI, no new event type. Best-effort: a
+    // socket hiccup must never fail the claim itself.
+    if (result?.claimed) {
+      try {
+        // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+        const agentTypingService = require('../services/agentTypingService');
+        const leaseMs = result.expiresAt
+          ? new Date(result.expiresAt).getTime() - Date.now()
+          : undefined;
+        agentTypingService.emitAgentTypingStart({
+          podId,
+          agentName,
+          instanceId,
+          displayName: req.agentInstallation?.displayName
+            || req.agentUser?.botMetadata?.displayName
+            || agentName,
+        }, leaseMs);
+      } catch (typingErr) {
+        console.warn('[claims] typing indicator failed:', (typingErr as Error).message);
+      }
+    }
     return res.json(result);
   } catch (err) {
     console.error('[claims] claim failed:', (err as Error).message);
@@ -345,6 +368,18 @@ router.delete('/messages/:messageId/claim', agentRuntimeAuth, phase4RateLimit, a
     const result = await MessageClaimService.release({
       messageId: req.params.messageId, agentName, instanceId,
     });
+    // D7 mirror: releasing the lease ends "someone's on it" immediately
+    // (claim-then-decline is a normal, frequent path per D6 — the indicator
+    // must not linger through the lease timeout after an explicit release).
+    if (result?.released && result.podId) {
+      try {
+        // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+        const agentTypingService = require('../services/agentTypingService');
+        agentTypingService.emitAgentTypingStop({ podId: result.podId, agentName, instanceId });
+      } catch (typingErr) {
+        console.warn('[claims] typing stop failed:', (typingErr as Error).message);
+      }
+    }
     return res.json(result);
   } catch (err) {
     console.error('[claims] release failed:', (err as Error).message);

--- a/backend/services/agentTypingService.ts
+++ b/backend/services/agentTypingService.ts
@@ -66,7 +66,14 @@ export function bindSocketIO(io: SocketIOLike): void {
   ioRef = io;
 }
 
-export function emitAgentTypingStart(agent: TypingAgent): void {
+/**
+ * `timeoutMs` overrides the safety window for callers whose "working" state
+ * has its own deadline — ADR-018 D7 rides the claim lease on this: the
+ * indicator lives exactly as long as the lease, so "✳ agent is typing"
+ * and "someone holds this message" stay one honest signal. Clamped to
+ * [1s, 10min] (10min mirrors MAX_LEASE_SECONDS on the claim side).
+ */
+export function emitAgentTypingStart(agent: TypingAgent, timeoutMs: number = TIMEOUT_MS): void {
   if (!ioRef) return;
   const normalized = normalizeStart(agent);
   if (!normalized) return;
@@ -76,6 +83,9 @@ export function emitAgentTypingStart(agent: TypingAgent): void {
     console.warn('[agent-typing] emit start failed:', (err as Error).message);
     return;
   }
+  const safeTimeout = Number.isFinite(timeoutMs)
+    ? Math.min(Math.max(Math.trunc(timeoutMs), 1_000), 600_000)
+    : TIMEOUT_MS;
   const k = podKey(normalized);
   const existing = activeTimers.get(k);
   if (existing) clearTimeout(existing);
@@ -88,7 +98,7 @@ export function emitAgentTypingStart(agent: TypingAgent): void {
         agentName: normalized.agentName,
         instanceId: normalized.instanceId,
       });
-    }, TIMEOUT_MS),
+    }, safeTimeout),
   );
 }
 

--- a/backend/services/messageClaimService.ts
+++ b/backend/services/messageClaimService.ts
@@ -128,17 +128,22 @@ class MessageClaimService {
    */
   static async release(options: {
     messageId: string; agentName: string; instanceId?: string;
-  }): Promise<{ released: boolean }> {
+  }): Promise<{ released: boolean; podId?: string }> {
     const { messageId, agentName, instanceId = 'default' } = options;
     if (!messageId || !agentName) throw new Error('messageId and agentName are required');
     await ensureTable();
+    // pod_id rides back so the route can clear the D7 typing indicator —
+    // the DELETE takes no podId (holder-only delete is the guard), and the
+    // claim row is the only place the pod is recorded.
     const res = await pool.query(
       `DELETE FROM message_claims
        WHERE message_id = $1 AND claimed_by = $2 AND instance_id = $3
-       RETURNING message_id`,
+       RETURNING message_id, pod_id`,
       [String(messageId), agentName.toLowerCase(), instanceId],
     );
-    return { released: res.rows.length > 0 };
+    return res.rows.length > 0
+      ? { released: true, podId: res.rows[0].pod_id }
+      : { released: false };
   }
 
   /** Who holds a message right now? Expired leases read as unheld. */


### PR DESCRIPTION
## What

D7: claiming fires `agentTypingService`, so "✳ agent is typing" and "someone holds this message" become one honest signal — no new UI, no new event type.

- **Claim / renewal** (same call) fires `emitAgentTypingStart` **for the life of the lease**: the typing service's safety timeout takes an override, clamped [1s, 10min] to mirror `MAX_LEASE_SECONDS`. Lease lapse and indicator clear are the same moment.
- **Release** stops the indicator immediately — claim-then-decline is a normal, frequent path (D6); the indicator must not linger through the lease window after an explicit release. The DELETE deliberately takes no podId (holder-only delete is the guard), so `messageClaimService.release` now `RETURN`s `pod_id` off the claim row (additive shape change).
- **Losers fire nothing** — the holder is the one typing.
- **Best-effort throughout**: a socket failure never fails the claim call.

## Tests

5 new route-tier tests (lease-derived window ≈ lease, lost claim silent, typing failure doesn't fail the claim, release clears via returned pod, release-miss clears nothing); existing claims + messageClaimService suites green (9/9, 6/6). Mutation-checked: disabling the claim→typing branch reddens exactly its paired test.

Sibling to #901 (D4 task-lease backfill) — independent files, both PRs based directly on main, not stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8