### PR TITLE
fix(dev): the event re-dispatch route denied every authenticated caller

### DIFF
--- a/backend/routes/dev.ts
+++ b/backend/routes/dev.ts
@@ -99,7 +99,13 @@ router.post('/agents/events', auth, async (req: AuthReq, res: Res) => {
       return res.status(404).json({ error: 'Pod not found' });
     }
 
-    if (!isMember(pod, req.user?._id)) {
+    // Both auth paths set req.userId and req.user.id; NEITHER sets
+    // req.user._id, which this read used exclusively — so the route denied
+    // every authenticated caller since the auth shape changed (checklist §7:
+    // a value one layer reads that another layer only promises in prose).
+    // Found live 2026-08-12 seeding the wake/claim test.
+    const callerId = (req as { userId?: string }).userId || req.user?._id || req.user?.id;
+    if (!isMember(pod, callerId)) {
       return res.status(403).json({ error: 'Access denied' });
     }
 


### PR DESCRIPTION
`POST /api/dev/agents/events` fed `isMember` the field `req.user._id` — which neither auth path sets (both set `req.user.id` + `req.userId`). The membership check compared against `undefined`, so the route 403'd every authenticated caller. The pilot's re-dispatch tooling has been dead since the auth shape changed; found live while seeding today's wake/claim test, which had to fall back to a direct kernel insert.

One-line fix: read `req.userId` first (the field every other route uses), user-object fields as fallback. Checklist §7 in textbook form — a value one layer reads that another layer promises only in prose.

No test added: the file has no harness today and the route is dev-only, NODE_ENV-gated; noting that explicitly rather than silently (review rule 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8