### PR TITLE
fix(native): claim before acting — the D3 gap the fleet's own audit found

### DIFF
--- a/backend/__tests__/unit/services/nativeRuntimeService.claims.test.js
+++ b/backend/__tests__/unit/services/nativeRuntimeService.claims.test.js
@@ -1,0 +1,144 @@
+/**
+ * ADR-018 D3 — the native runtime claims before acting, like every driver we
+ * ship. Gap found by the fleet's own implementation audit (Sharpen msg
+ * 53016): the event queue pre-claims DELIVERY but nothing claimed the
+ * MESSAGE, so two concurrent native agents could both act on one trigger.
+ *
+ * Contract under test:
+ *  - message-shaped triggers claim payload.messageId before any run/LLM work
+ *  - a lost CAS stands down: no AgentRun row, no LLM call, no typing, and
+ *    the result reads as a successful (acked) no-op
+ *  - a won claim runs, then releases in the same cleanup that stops typing
+ *  - claim infrastructure failure fails OPEN (#887) — the run proceeds
+ *  - triggers without a message (heartbeat) never touch the claim service
+ */
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+jest.mock('../../../models/Pod', () => ({
+  findById: jest.fn(() => ({
+    lean: jest.fn().mockResolvedValue({ name: 'Launch Room' }),
+  })),
+}));
+
+jest.mock('../../../models/AgentRun', () => ({
+  create: jest.fn(),
+}));
+
+jest.mock('../../../services/agentTypingService', () => ({
+  emitAgentTypingStart: jest.fn(),
+  emitAgentTypingStop: jest.fn(),
+}));
+
+jest.mock('../../../services/agentMessageService', () => ({
+  postMessage: jest.fn().mockResolvedValue({ success: true }),
+}));
+
+jest.mock('../../../services/messageClaimService', () => ({
+  claim: jest.fn(),
+  release: jest.fn(),
+}));
+
+const axios = require('axios').default;
+const AgentRun = require('../../../models/AgentRun');
+const MessageClaimService = require('../../../services/messageClaimService');
+const typing = require('../../../services/agentTypingService');
+const { runAgent } = require('../../../services/nativeRuntimeService');
+
+const installation = {
+  podId: 'pod-1',
+  agentName: 'pod-summarizer',
+  instanceId: 'default',
+  displayName: 'Pod Summarizer',
+  config: {
+    runtime: { runtimeType: 'native' },
+    systemPrompt: 'summarize',
+    model: 'test/model',
+    tools: [],
+  },
+};
+
+describe('nativeRuntimeService claim-before-act (ADR-018 D3)', () => {
+  const previousEnv = {
+    baseUrl: process.env.LITELLM_BASE_URL,
+    masterKey: process.env.LITELLM_MASTER_KEY,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.LITELLM_BASE_URL = 'http://litellm.test';
+    process.env.LITELLM_MASTER_KEY = 'test-key';
+    MessageClaimService.claim.mockResolvedValue({ claimed: true, expiresAt: new Date() });
+    MessageClaimService.release.mockResolvedValue({ released: true });
+    AgentRun.create.mockImplementation(async (doc) => ({
+      _id: 'run-1',
+      ...doc,
+      save: jest.fn().mockResolvedValue(undefined),
+    }));
+    axios.post.mockResolvedValue({
+      status: 200,
+      data: {
+        choices: [{ message: { role: 'assistant', content: 'NO_REPLY' } }],
+        usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 },
+      },
+      headers: {},
+    });
+  });
+
+  afterAll(() => {
+    if (previousEnv.baseUrl === undefined) delete process.env.LITELLM_BASE_URL;
+    else process.env.LITELLM_BASE_URL = previousEnv.baseUrl;
+    if (previousEnv.masterKey === undefined) delete process.env.LITELLM_MASTER_KEY;
+    else process.env.LITELLM_MASTER_KEY = previousEnv.masterKey;
+  });
+
+  const mentionTrigger = {
+    type: 'chat.mention',
+    eventId: 'evt-1',
+    payload: { messageId: 'msg-77', content: 'hey @pod-summarizer' },
+  };
+
+  test('a won claim runs the turn, then releases in the same cleanup that stops typing', async () => {
+    const result = await runAgent(installation, mentionTrigger);
+    expect(MessageClaimService.claim).toHaveBeenCalledWith({
+      messageId: 'msg-77', podId: 'pod-1', agentName: 'pod-summarizer', instanceId: 'default',
+    });
+    expect(AgentRun.create).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('succeeded');
+    expect(MessageClaimService.release).toHaveBeenCalledWith({
+      messageId: 'msg-77', agentName: 'pod-summarizer', instanceId: 'default',
+    });
+    expect(typing.emitAgentTypingStop).toHaveBeenCalled();
+  });
+
+  test('a lost CAS stands down: no run row, no LLM call, no typing, acked no-op', async () => {
+    MessageClaimService.claim.mockResolvedValue({ claimed: false, claimedBy: 'task-clerk' });
+    const result = await runAgent(installation, mentionTrigger);
+    expect(result).toEqual({
+      runId: '', status: 'succeeded', totalTurns: 0, totalTokens: 0,
+    });
+    expect(AgentRun.create).not.toHaveBeenCalled();
+    expect(axios.post).not.toHaveBeenCalled();
+    expect(typing.emitAgentTypingStart).not.toHaveBeenCalled();
+    expect(MessageClaimService.release).not.toHaveBeenCalled();
+  });
+
+  test('claim infrastructure failure fails OPEN — the run proceeds unguarded (#887)', async () => {
+    MessageClaimService.claim.mockRejectedValue(new Error('pg down'));
+    const result = await runAgent(installation, mentionTrigger);
+    expect(result.status).toBe('succeeded');
+    expect(AgentRun.create).toHaveBeenCalledTimes(1);
+    // Nothing was held, so nothing releases.
+    expect(MessageClaimService.release).not.toHaveBeenCalled();
+  });
+
+  test('heartbeat triggers never touch the claim service', async () => {
+    await runAgent(installation, { type: 'heartbeat', eventId: 'evt-2', payload: {} });
+    expect(MessageClaimService.claim).not.toHaveBeenCalled();
+  });
+});

--- a/backend/services/nativeRuntimeService.ts
+++ b/backend/services/nativeRuntimeService.ts
@@ -484,6 +484,46 @@ export async function runAgent(
     installation.displayName || agentName,
   );
 
+  // ADR-018 D3: native is one of OUR drivers — deterministic claim-before-act,
+  // the same rule the CLI wrapper enforces (#894). Fleet audit (Sharpen msg
+  // 53016) found this gap: the event queue pre-claims DELIVERY, but nothing
+  // claimed the MESSAGE, so two concurrent native agents could both act on
+  // one trigger. A lost CAS is a complete, silent stand-down — no AgentRun
+  // row, deliberately: a stand-down is not an execution, and the acked event
+  // carries the trace. Claim infrastructure failures fail OPEN (#887):
+  // enforcement must never silence an agent on an infrastructure fault.
+  // Raw-type gate mirrors the wrapper's claimable set (mention variants +
+  // message-shaped wakes); heartbeat/task/join triggers carry no message.
+  const CLAIMABLE_RAW_TYPES = new Set([
+    'chat.mention', 'thread.mention', 'mention', 'chat.message', 'message.posted', 'dm.message',
+  ]);
+  const claimMessageId = CLAIMABLE_RAW_TYPES.has(String(trigger.type))
+    ? String((trigger.payload as { messageId?: unknown } | null)?.messageId || '')
+    : '';
+  let claimHeld = false;
+  if (claimMessageId) {
+    try {
+      // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+      const MessageClaimService = require('./messageClaimService');
+      const claim = await MessageClaimService.claim({
+        messageId: claimMessageId, podId, agentName, instanceId,
+      });
+      if (claim?.claimed) {
+        claimHeld = true;
+      } else if (claim) {
+        console.log(
+          `[native-runtime] ${agentName}:${instanceId} stood down — message ${claimMessageId} `
+          + `claimed by ${claim.claimedBy || 'another agent'}`,
+        );
+        return {
+          runId: '', status: 'succeeded', totalTurns: 0, totalTokens: 0,
+        };
+      }
+    } catch (err) {
+      console.warn('[native-runtime] claim unavailable — proceeding unguarded (#887):', (err as Error).message);
+    }
+  }
+
   // Best-effort pod name lookup for user-message framing. Never block on it.
   let podName = 'this pod';
   try {
@@ -511,12 +551,28 @@ export async function runAgent(
   const runId = String(run._id);
 
   // Typing indicator — best-effort; stop guaranteed via emitStop() below.
+  // The claim releases in the same cleanup: typing-stops and lease-release
+  // are one moment (D7 — "someone's on it" ends when the turn ends), and
+  // emitStop is already called on every terminal path of this function.
   const emitStop = () => {
     try {
       const typing = require('./agentTypingService');
       typing.emitAgentTypingStop({ podId, agentName, instanceId });
     } catch (err) {
       console.warn('[native-runtime] typing stop failed:', (err as Error).message);
+    }
+    if (claimHeld) {
+      claimHeld = false;
+      try {
+        // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+        const MessageClaimService = require('./messageClaimService');
+        // Fire-and-forget: a miss just means the lease already lapsed.
+        Promise.resolve(
+          MessageClaimService.release({ messageId: claimMessageId, agentName, instanceId }),
+        ).catch(() => {});
+      } catch (err) {
+        console.warn('[native-runtime] claim release failed:', (err as Error).message);
+      }
     }
   };
   try {


### PR DESCRIPTION
Sprint Impl's implementation audit (Sharpen msg 53016) — run through the shipped wake/claim machinery it was auditing — found that the native runtime never claims: `agentEventService` fire-and-forgets `runAgent()` with no `MessageClaimService` call, so two concurrent **native** agents could still both act on one message. D3's table lists native as one of our drivers; this closes the row.

- `runAgent` claims `payload.messageId` for message-shaped triggers (raw-type set mirrors the wrapper's claimable set) **before** the AgentRun row, typing, or any LLM call.
- Lost CAS → silent stand-down: no run row (a stand-down is not an execution; the acked event carries the trace), no typing, zero tokens.
- Release rides the existing `emitStop` cleanup — lease release and typing-stop are one moment (D7), and `emitStop` already covers every terminal path.
- Claim infrastructure failure fails OPEN (#887).
- Native calls the claim **service** directly (not the HTTP route), so the D7 route wiring doesn't double-fire typing — native keeps its own indicator lifecycle.

4 unit tests (won-claim runs+releases, lost-CAS full stand-down, fail-open, heartbeat never claims); the sibling first-contact suite stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8