### PR TITLE
fix(cli): recover content-less wakes instead of silently acking them (#896)

### DIFF
--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -681,7 +681,7 @@ describe('performRun', () => {
     expect(spawn).not.toHaveBeenCalled();
     expect(mockPost).toHaveBeenCalledWith(
       '/api/agents/runtime/events/evt-nopod/ack',
-      { result: { outcome: 'no_action' } },
+      { result: { outcome: 'no_action', reason: 'no-prompt' } },
     );
     expect(mockPost).toHaveBeenCalledTimes(1);
   });
@@ -869,7 +869,7 @@ describe('performRun', () => {
     expect(scheduled[0].delayMs).toBe(10000);
     expect(mockPost).toHaveBeenCalledWith(
       '/api/agents/runtime/events/evt-no-prompt/ack',
-      { result: { outcome: 'no_action' } },
+      { result: { outcome: 'no_action', reason: 'no-prompt' } },
     );
   });
 
@@ -1657,6 +1657,47 @@ describe('performRun — ADR-018 enforcement', () => {
       .filter((e) => e.code === 'agent_spawn_retry_scheduled')
       .map((e) => e.consecutiveFailures);
     expect(streaks).toEqual([1, 2]);
+  });
+
+  test('#896: a content-less event WITH a messageId spawns a recovery turn instead of a silent ack', async () => {
+    const { post } = makeClient({
+      events: [makeEvent({ _id: 'evt-bare', payload: { messageId: 'msg-1' } })],
+    });
+    const spawn = jest.fn(async () => ({ text: 'NO_REPLY' }));
+    const { stop } = run({ name: 'stub', detect: stubAdapter.detect, spawn });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const prompt = spawn.mock.calls[0][0];
+    expect(prompt).toContain('Recovered wake');
+    expect(prompt).toContain('msg-1');
+    expect(prompt).toContain('NO_REPLY');
+    // It flows through the normal enforcement path — the claim was taken.
+    expect(post).toHaveBeenCalledWith(CLAIM_PATH, expect.anything());
+  });
+
+  test('#896: a truly-empty event is still acked but the skip is surfaced through onError', async () => {
+    const errors = [];
+    const { post } = makeClient({
+      events: [makeEvent({ _id: 'evt-empty', payload: {} })],
+    });
+    const spawn = jest.fn();
+    const { stop } = run(
+      { name: 'stub', detect: stubAdapter.detect, spawn },
+      { onError: (e) => errors.push(e) },
+    );
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-empty/ack',
+      { result: { outcome: 'no_action', reason: 'no-prompt' } },
+    );
+    const skip = errors.find((e) => e.code === 'agent_event_skipped_no_prompt');
+    expect(skip).toBeTruthy();
+    expect(skip.message).toContain('evt-empty');
   });
 
   test('length gate: an over-limit reply is split into ordered messages at post time', async () => {

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -515,7 +515,24 @@ export const runMemoryImport = async ({
 const extractPrompt = (event) => {
   const p = event.payload || {};
   if (PROMPT_EVENT_TYPES.has(event.type)) {
-    return p.content || p.prompt || p.text || null;
+    const content = p.content || p.prompt || p.text || null;
+    if (content) return content;
+    // #896: a message-shaped event with a messageId but NO content used to be
+    // acked silently as "no prompt — no-op", which reads exactly like a
+    // swallowed wake (the pilot's boot-backlog mystery — repro'd 2026-08-12:
+    // cold starts were healthy; content-less payloads were the whole story).
+    // The wrapper has enough to recover: name the message and let the agent
+    // read the room. Between silence and one model turn, the #887 rule says
+    // spend the turn — the claim gate and cascade cap bound the cost.
+    if (p.messageId) {
+      return [
+        `[Recovered wake: this ${event.type} event named message ${p.messageId} but carried no content — `
+        + 'a producer bug, not your fault. Read the recent messages before deciding anything.]',
+        'Check the pod\'s recent messages (commonly_get_context / commonly_get_messages), find that message,',
+        'and decide whether it needs YOU specifically. Most likely it does not: return NO_REPLY.',
+      ].join('\n');
+    }
+    return null;
   }
   if (event.type === 'heartbeat') {
     return p.content || [
@@ -636,8 +653,20 @@ export const performRun = ({
     if (!prompt || !eventPodId) {
       // No prompt, or nowhere to post the response — skip spawn entirely so
       // we never consume a CLI turn for a message with no destination.
+      // Surfaced through onError, not just the log: a silently-acked event is
+      // indistinguishable from a swallowed wake (#896 — the pilot burned an
+      // evening on exactly this ambiguity). It is still acked (deliberate
+      // decline, not a retry), but the operator can now see the skip.
       log(`[${event.type}] no prompt — no-op`);
-      return { outcome: 'no_action' };
+      onError?.(Object.assign(
+        new Error(
+          `${event.type} event ${event._id} was acked WITHOUT a spawn: `
+          + `${!eventPodId ? 'no podId to post into' : 'payload carried no content and no messageId'}. `
+          + 'If this wake mattered, its producer is sending an unusable payload.',
+        ),
+        { code: 'agent_event_skipped_no_prompt', eventId: event._id },
+      ));
+      return { outcome: 'no_action', reason: 'no-prompt' };
     }
 
     // Snapshot the pod's recent messages so that, after the spawn, we can


### PR DESCRIPTION
Closes #896 — with a diagnosis that changes what the bug was.

**Repro'd live before fixing**: stopped a seat's wrapper, queued one well-formed wake and one content-less wake (messageId only), cold-started the wrapper. The well-formed backlog event claimed, spawned, and processed normally — **cold start is healthy**. The content-less event hit the no-prompt path and was acked `no-op`, silently. That silent ack *is* the "boot-backlog swallow": the pilot's seeding produced content-less payloads, and the correlation with wrapper start was coincidental (events were batch-seeded before wrappers started).

Fix, on the #887 rule (between silence and one model turn, spend the turn):
- **messageId but no content** → synthesized recovery prompt ("event named message N but carried no content — read the room, decide, NO_REPLY likely"), flowing through the normal claim/cascade enforcement so cost stays bounded.
- **Truly empty** → still acked as a deliberate decline, but surfaced via `onError` with code `agent_event_skipped_no_prompt` — visible skip instead of a log whisper.

2 new run-loop tests (recovery spawn incl. claim taken; empty-event onError surfacing); mutation-checked (disabling the recovery branch reddens exactly its test); 2 pre-existing exact-shape ack assertions extended with the additive `reason` field (intent unchanged). Full CLI suite 266 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8