### PR TITLE
feat(cli): claim fairness — addressed seats always speak, race winners start from the back

### DIFF
--- a/cli/__tests__/enforcement.test.mjs
+++ b/cli/__tests__/enforcement.test.mjs
@@ -14,10 +14,13 @@
 
 import { jest } from '@jest/globals';
 import {
+  ADDRESSED_EVENT_TYPES,
   CLAIMABLE_EVENT_TYPES,
   classifyTrigger,
   createCascadeGovernor,
+  createClaimHandicap,
   createClaimKeeper,
+  peerHoldsFrame,
   splitForChat,
   deliverChatReply,
 } from '../src/lib/enforcement.js';
@@ -357,6 +360,53 @@ describe('deliverChatReply', () => {
     expect(post).toHaveBeenCalledTimes(res.messages);
     expect(post.mock.calls.map((c) => c[1].content).join('\n\n')).toBe(text);
     expect(log).toHaveBeenCalledWith(expect.stringContaining('older server'));
+  });
+});
+
+describe('createClaimHandicap', () => {
+  test('no handicap before any win; a win adds a jittered delay to the NEXT race', () => {
+    let clock = 0;
+    const handicap = createClaimHandicap({
+      delayMs: 3000, jitterMs: 1000, now: () => clock, random: () => 0.5,
+    });
+    expect(handicap.yieldDelayMs('pod-1')).toBe(0);
+    handicap.recordWin('pod-1');
+    expect(handicap.yieldDelayMs('pod-1')).toBe(3500);
+    expect(handicap.yieldDelayMs('pod-2')).toBe(0); // per pod
+  });
+
+  test('a loss clears the handicap — you are only the monopolist while winning', () => {
+    const handicap = createClaimHandicap({ delayMs: 3000, jitterMs: 0 });
+    handicap.recordWin('pod-1');
+    handicap.recordLoss('pod-1');
+    expect(handicap.yieldDelayMs('pod-1')).toBe(0);
+  });
+
+  test('the handicap decays after windowMs of quiet', () => {
+    let clock = 0;
+    const handicap = createClaimHandicap({
+      delayMs: 3000, jitterMs: 0, windowMs: 1000, now: () => clock,
+    });
+    handicap.recordWin('pod-1');
+    clock = 1001;
+    expect(handicap.yieldDelayMs('pod-1')).toBe(0);
+  });
+});
+
+describe('peerHoldsFrame / ADDRESSED_EVENT_TYPES', () => {
+  test('addressed types are the human-chose-you set; broadcast wakes are not in it', () => {
+    expect(ADDRESSED_EVENT_TYPES.has('chat.mention')).toBe(true);
+    expect(ADDRESSED_EVENT_TYPES.has('thread.mention')).toBe(true);
+    expect(ADDRESSED_EVENT_TYPES.has('dm.message')).toBe(true);
+    expect(ADDRESSED_EVENT_TYPES.has('message.posted')).toBe(false);
+  });
+
+  test('the peer frame names the holder, the message, and the raised bar', () => {
+    const frame = peerHoldsFrame('nova', '52997');
+    expect(frame).toContain('@nova');
+    expect(frame).toContain('52997');
+    expect(frame).toContain('materially different');
+    expect(frame).toContain('NO_REPLY');
   });
 });
 

--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -1472,9 +1472,13 @@ describe('performRun — ADR-018 enforcement', () => {
     );
   });
 
-  test('a lost claim stands the turn down: no spawn, no post, acked no_action', async () => {
+  test('a lost claim on a BROADCAST wake stands the turn down: no spawn, no post, acked no_action', async () => {
+    // Was a chat.mention event before the fairness ruling (Sam, 2026-08-12:
+    // "loser may never get a chance to speak") — addressed losses now proceed
+    // peer-aware (own test below); the hard stand-down contract continues to
+    // hold for broadcast wakes, asserted here.
     const { post, del } = makeClient({
-      events: [makeClaimEvent()],
+      events: [makeClaimEvent({ type: 'message.posted' })],
       claimResult: { claimed: false, claimedBy: 'nova', expiresAt: 'later' },
     });
     const spawn = jest.fn();
@@ -1626,7 +1630,9 @@ describe('performRun — ADR-018 enforcement', () => {
 
     const batches = [
       [makeEvent({ _id: 'evt-fail-1' })],
-      [makeClaimEvent({ _id: 'evt-held' })],
+      // Broadcast wake, post-fairness: addressed claim-losses now spawn
+      // peer-aware, so the stand-down under test must ride message.posted.
+      [makeClaimEvent({ _id: 'evt-held', type: 'message.posted' })],
       [makeEvent({ _id: 'evt-fail-2' })],
       [],
     ];
@@ -1657,6 +1663,72 @@ describe('performRun — ADR-018 enforcement', () => {
       .filter((e) => e.code === 'agent_spawn_retry_scheduled')
       .map((e) => e.consecutiveFailures);
     expect(streaks).toEqual([1, 2]);
+  });
+
+  test('fairness: a claim LOSS on a direct mention proceeds peer-aware instead of standing down', async () => {
+    const { post, del } = makeClient({
+      events: [makeClaimEvent()], // chat.mention — the seat was addressed
+      claimResult: { claimed: false, claimedBy: 'nova' },
+    });
+    const spawn = jest.fn(async () => ({ text: 'a materially different take' }));
+    const { stop } = run({ name: 'stub', detect: stubAdapter.detect, spawn });
+    await drainMicrotasks();
+    stop();
+
+    // The addressed seat still spoke — peer-aware, not silenced.
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const prompt = spawn.mock.calls[0][0];
+    expect(prompt).toContain('@nova');
+    expect(prompt).toContain('materially different');
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/pods/pod-abc/messages',
+      { content: 'a materially different take' },
+    );
+    expect(del).not.toHaveBeenCalled(); // nothing was held
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-1/ack',
+      { result: { outcome: 'posted' } },
+    );
+  });
+
+  test('fairness: a claim LOSS on a broadcast wake still stands down hard', async () => {
+    const { post } = makeClient({
+      events: [makeClaimEvent({ type: 'message.posted' })],
+      claimResult: { claimed: false, claimedBy: 'nova' },
+    });
+    const spawn = jest.fn();
+    const { stop } = run({ name: 'stub', detect: stubAdapter.detect, spawn });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-1/ack',
+      { result: { outcome: 'no_action', reason: 'claim-held' } },
+    );
+  });
+
+  test('fairness: winning a broadcast race handicaps the NEXT race in that pod', async () => {
+    const sleeps = [];
+    const { post } = makeClient({
+      events: [
+        makeClaimEvent({ _id: 'evt-w1', type: 'message.posted' }),
+        makeClaimEvent({ _id: 'evt-w2', type: 'message.posted', payload: { content: 'again', messageId: 'msg-2' } }),
+      ],
+    });
+    const spawn = jest.fn(async () => ({ text: 'NO_REPLY' }));
+    const { stop } = run(
+      { name: 'stub', detect: stubAdapter.detect, spawn },
+      { sleepImpl: (ms) => { sleeps.push(ms); return Promise.resolve(); } },
+    );
+    await drainMicrotasks();
+    stop();
+
+    // First race: no handicap. Second race, same pod, after a win: yielded.
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(sleeps).toHaveLength(1);
+    expect(sleeps[0]).toBeGreaterThanOrEqual(3000);
+    expect(post.mock.calls.filter(([r]) => r.endsWith('/claim'))).toHaveLength(2);
   });
 
   test('#896: a content-less event WITH a messageId spawns a recovery turn instead of a silent ack', async () => {

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -40,11 +40,14 @@ import {
   spawnRetryPolicy,
 } from '../lib/spawn-retry.js';
 import {
+  ADDRESSED_EVENT_TYPES,
   CLAIMABLE_EVENT_TYPES,
   classifyTrigger,
   createCascadeGovernor,
+  createClaimHandicap,
   createClaimKeeper,
   deliverChatReply,
+  peerHoldsFrame,
 } from '../lib/enforcement.js';
 
 // ── Token file I/O — ~/.commonly/tokens/<name>.json (ADR-005) ───────────────
@@ -623,6 +626,8 @@ export const performRun = ({
   cascadeResetMs = 10 * 60 * 1000,
   chatCharLimit = 400,
   maxChatChunks = 3,
+  claimYieldDelayMs = 3000,
+  sleepImpl = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); }),
 }) => {
   const client = createClient({ instance: instanceUrl, token });
   let running = true;
@@ -638,6 +643,8 @@ export const performRun = ({
   // Per-seat cascade state — lives with the process, like the session store.
   // A wrapper restart forgets the streak; the decay window covers that gap.
   const cascadeGovernor = createCascadeGovernor({ cap: cascadeCap, resetMs: cascadeResetMs });
+  // Fairness: recent broadcast-race winners start the next race from the back.
+  const claimHandicap = createClaimHandicap({ delayMs: claimYieldDelayMs });
 
   // Adapters default `ctx.cwd` to this path. Node's child_process.spawn
   // rejects with "spawn <bin> ENOENT" when cwd does not exist — same shape
@@ -714,13 +721,28 @@ export const performRun = ({
     }
 
     // ── ADR-018 enforcement: claim-before-act ───────────────────────────────
-    // Losing the claim is a complete turn (stand down, ack): the holder owns
-    // the conversation, and liveness on holder death comes from the HOLDER's
-    // own event staying unacked, not from ours. Claim-route failures proceed
-    // unguarded — enforcement must never make an agent silent (#887).
+    // Losing a BROADCAST race is a complete turn (stand down, ack): the
+    // holder owns the conversation, and liveness on holder death comes from
+    // the HOLDER's own event staying unacked, not from ours. Losing while
+    // DIRECTLY ADDRESSED is different — a human chose this seat, and that
+    // outranks being beaten to a CAS: the seat still gets its turn, peer-aware
+    // (add your view only if materially different). Claim-route failures
+    // proceed unguarded — enforcement must never make an agent silent (#887).
     let claimKeeper = null;
+    let peerFrame = null;
     const claimMessageId = event.payload?.messageId;
     if (claimMessageId && CLAIMABLE_EVENT_TYPES.has(event.type)) {
+      // Fairness: the winner of this pod's previous broadcast race enters the
+      // next one after a jittered delay. Everyone still claims — a hard
+      // cooldown could leave a message with NO claimant, which is #887
+      // self-inflicted — recent winners just start from the back.
+      if (event.type === 'message.posted') {
+        const yieldMs = claimHandicap.yieldDelayMs(eventPodId);
+        if (yieldMs > 0) {
+          log(`[${event.type}] yielding ${yieldMs}ms before claiming — won this pod's previous broadcast race`);
+          await sleepImpl(yieldMs);
+        }
+      }
       claimKeeper = createClaimKeeper(client, {
         messageId: claimMessageId,
         podId: eventPodId,
@@ -731,10 +753,20 @@ export const performRun = ({
       });
       const claim = await claimKeeper.acquire();
       if (!claim.claimed && !claim.failOpen) {
-        log(`[${event.type}] message ${claimMessageId} already claimed by ${claim.holder} — standing down`);
-        return { outcome: 'no_action', reason: 'claim-held' };
-      }
-      if (claim.claimed) {
+        if (ADDRESSED_EVENT_TYPES.has(event.type)) {
+          log(
+            `[${event.type}] message ${claimMessageId} held by ${claim.holder} — `
+            + 'proceeding peer-aware (this seat was directly addressed)',
+          );
+          peerFrame = peerHoldsFrame(claim.holder, claimMessageId);
+          claimKeeper = null; // nothing held: no renewal, no release, no isLost gate
+        } else {
+          claimHandicap.recordLoss(eventPodId);
+          log(`[${event.type}] message ${claimMessageId} already claimed by ${claim.holder} — standing down`);
+          return { outcome: 'no_action', reason: 'claim-held' };
+        }
+      } else if (claim.claimed) {
+        if (event.type === 'message.posted') claimHandicap.recordWin(eventPodId);
         claimKeeper.startRenewal();
       } else {
         log(`[${event.type}] claim unavailable (${claim.error?.message || 'unknown error'}) — proceeding unguarded`);
@@ -743,7 +775,13 @@ export const performRun = ({
 
     try {
       return await runTurn({
-        event, eventPodId, prompt, preSpawnIds, snapshotMessages, claimKeeper, trigger,
+        event,
+        eventPodId,
+        prompt: peerFrame ? `${peerFrame}\n\n${prompt}` : prompt,
+        preSpawnIds,
+        snapshotMessages,
+        claimKeeper,
+        trigger,
       });
     } finally {
       await claimKeeper?.release();

--- a/cli/src/lib/enforcement.js
+++ b/cli/src/lib/enforcement.js
@@ -105,6 +105,62 @@ export const createCascadeGovernor = ({
   };
 };
 
+// ── claim fairness ──────────────────────────────────────────────────────────
+
+// Direct-address event types: the seat was NAMED (explicit @, implicit human
+// reply, or DM routing). A lost claim on these does not silence the seat —
+// being chosen by a human outranks being beaten to a CAS. Broadcast wakes
+// (message.posted) are the opposite: nobody asked for THIS seat, so a lost
+// race is a free stand-down.
+export const ADDRESSED_EVENT_TYPES = new Set(['chat.mention', 'thread.mention', 'dm.message']);
+
+// Frame prepended when an ADDRESSED seat lost the claim race: it still gets
+// its turn, but knows a peer is (probably) already answering — the bar for
+// posting rises from "have something to say" to "have something DIFFERENT".
+export const peerHoldsFrame = (holder, messageId) => (
+  `[Claim notice: @${holder} holds message ${messageId} and is likely responding. `
+  + 'You were directly addressed, so you still get this turn — but add your view ONLY '
+  + 'if it is materially different from what they would cover; otherwise return NO_REPLY.]'
+);
+
+/**
+ * Win-weighted claim delay — the "cooldown" that keeps one fast seat from
+ * monopolising a pod's broadcast wakes without ever risking that NOBODY
+ * claims. A seat that won its previous broadcast race in a pod waits a small
+ * jittered delay before entering the next one; everyone still claims, recent
+ * winners just start from the back. A loss (or `windowMs` of quiet) clears
+ * the handicap — you are only the monopolist while you are actually winning.
+ *
+ * Deliberately NOT a hard cooldown: with all seats abstaining, a message
+ * goes unhandled — the #887 shape again, self-inflicted.
+ */
+export const createClaimHandicap = ({
+  delayMs = 3000,
+  jitterMs = 1000,
+  windowMs = 5 * 60 * 1000,
+  now = Date.now,
+  random = Math.random,
+} = {}) => {
+  const wins = new Map(); // podId -> lastBroadcastWinAt
+
+  return {
+    recordWin(podId) {
+      wins.set(podId, now());
+    },
+    recordLoss(podId) {
+      wins.delete(podId);
+    },
+    yieldDelayMs(podId) {
+      const at = wins.get(podId);
+      // Explicit undefined check: a win recorded at clock 0 is still a win
+      // (a falsy-timestamp `!at` here silently disabled the handicap for the
+      // first test clock tick — caught by the unit suite).
+      if (at === undefined || now() - at > windowMs) return 0;
+      return delayMs + Math.floor(random() * jitterMs);
+    },
+  };
+};
+
 // ── claim keeper ────────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## What

The fairness pass on claim coordination, from Sam's review of the live run: each seat carries a distinct perspective, and pure first-CAS-wins had two failure shapes.

**1. Addressed losses no longer silence.** A claim loss on a direct address (`chat.mention` / `thread.mention` / `dm.message`) proceeds **peer-aware** — a frame names the holder and raises the posting bar to "materially different, else NO_REPLY" — instead of a silent stand-down. The sharp case this fixes: `@a @b look at this` previously got exactly one answer with the other seat silently acked, against the human's explicit intent. Broadcast wakes keep the zero-turn hard stand-down (that economics win is the point of claims).

**2. Win-weighted claim delay** — the cooldown, shaped for liveness: the winner of a pod's previous broadcast race enters the next one ~3-4s late (jittered). Everyone still claims — a *hard* cooldown risks all seats abstaining and a message going unhandled — recent winners just start from the back. A loss or 5 quiet minutes clears it.

**Deliberately not built** (named here per the review): the winner-declines-for-everyone case (claim winner returns NO_REPLY and the losers were already acked — one seat's judgment decides for the fleet). A second-opinion redelivery chain would multiply exactly the turn cost the cooldown addresses; a human mention remains the recourse. Revisit on the first observed wrong decline.

## Tests

5 handicap/frame unit tests + 3 run-loop integration tests; both glue points mutation-verified. Two pre-existing assertions encoding the old addressed-loss stand-down updated to broadcast events **citing this ruling** (assertion change, not inversion — the stand-down contract is unchanged for the traffic it still governs). Full CLI suite 274 green. Also fixes a falsy-zero-timestamp bug in the handicap that the unit suite caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8