### PR TITLE
feat(shell): mention-time honesty — #891 surface 1

### DIFF
--- a/backend/__tests__/unit/services/agentStateService.test.js
+++ b/backend/__tests__/unit/services/agentStateService.test.js
@@ -1,0 +1,120 @@
+/**
+ * agentStateService.deriveAgentState — #891 surface 1's honesty rules, pure.
+ *
+ * Contract under test (each rule earned by a measured review finding):
+ *  - BYO installs derive from lastUsedAt: null → never-connected,
+ *    fresh → listening, stale → gone-dark
+ *  - the union of BOTH token stores decides (finding D: legacy/new split
+ *    made live agents read null)
+ *  - native and push-webhook installs are 'reachable' by construction
+ *  - gateway/cloud classes are 'unknown' — never guessed (finding A)
+ *  - fixCommand attaches ONLY for the owner, only in fixable states
+ *    (split key: instructions to someone who can't perform them are the
+ *    P1/P2 contradiction)
+ */
+
+const { deriveAgentState, AGENT_LISTENING_STALE_MS } = require('../../../services/agentStateService');
+
+const NOW = 1_700_000_000_000;
+
+const byoInstall = (overrides = {}) => ({
+  agentName: 'sam-agent',
+  instanceId: 'default',
+  displayName: 'Sam Agent',
+  installedBy: 'owner-1',
+  config: { runtime: { runtimeType: 'webhook', host: 'byo' } },
+  runtimeTokens: [],
+  ...overrides,
+});
+
+describe('deriveAgentState', () => {
+  test('BYO with no token use anywhere → never-connected, owner gets the fix command', () => {
+    const row = deriveAgentState(byoInstall(), [], 'owner-1', NOW);
+    expect(row.state).toBe('never-connected');
+    expect(row.fixCommand).toBe('commonly agent run sam-agent');
+  });
+
+  test('the same state seen by a NON-owner carries the explanation but no instruction', () => {
+    const row = deriveAgentState(byoInstall(), [], 'someone-else', NOW);
+    expect(row.state).toBe('never-connected');
+    expect(row.isOwner).toBe(false);
+    expect(row.fixCommand).toBeUndefined();
+  });
+
+  test('fresh use on the INSTALLATION token store → listening', () => {
+    const row = deriveAgentState(
+      byoInstall({ runtimeTokens: [{ lastUsedAt: new Date(NOW - 10_000) }] }),
+      [],
+      'owner-1',
+      NOW,
+    );
+    expect(row.state).toBe('listening');
+    expect(row.fixCommand).toBeUndefined(); // nothing to fix
+  });
+
+  test('fresh use on the USER token store alone also counts — the union decides (finding D)', () => {
+    const row = deriveAgentState(
+      byoInstall(),
+      [{ lastUsedAt: new Date(NOW - 10_000) }],
+      'owner-1',
+      NOW,
+    );
+    expect(row.state).toBe('listening');
+  });
+
+  test('stale use → gone-dark, and the owner gets the wake command', () => {
+    const row = deriveAgentState(
+      byoInstall({ runtimeTokens: [{ lastUsedAt: new Date(NOW - AGENT_LISTENING_STALE_MS - 1000) }] }),
+      [],
+      'owner-1',
+      NOW,
+    );
+    expect(row.state).toBe('gone-dark');
+    expect(row.fixCommand).toBe('commonly agent run sam-agent');
+  });
+
+  test('native runtime is reachable by construction — no dot, no lastUsedAt reading', () => {
+    const row = deriveAgentState(
+      byoInstall({ config: { runtime: { runtimeType: 'native' } } }),
+      [],
+      'owner-1',
+      NOW,
+    );
+    expect(row.state).toBe('reachable');
+    expect(row.lastUsedAt).toBeNull();
+  });
+
+  test('a push webhook (webhookUrl set) is reachable regardless of token use', () => {
+    const row = deriveAgentState(
+      byoInstall({ config: { runtime: { runtimeType: 'webhook', host: 'byo', webhookUrl: 'https://x.example/cap' } } }),
+      [],
+      'owner-1',
+      NOW,
+    );
+    expect(row.state).toBe('reachable');
+  });
+
+  test('gateway/cloud classes are unknown — never guessed from a shared boot timestamp (finding A)', () => {
+    const row = deriveAgentState(
+      byoInstall({
+        config: { runtime: { runtimeType: 'moltbot', host: 'cloud' } },
+        runtimeTokens: [{ lastUsedAt: new Date(NOW - 5_000) }], // fresh, and still not trusted
+      }),
+      [],
+      'owner-1',
+      NOW,
+    );
+    expect(row.state).toBe('unknown');
+    expect(row.fixCommand).toBeUndefined();
+  });
+
+  test('legacy local-cli installs count as BYO', () => {
+    const row = deriveAgentState(
+      byoInstall({ config: { runtime: { runtimeType: 'local-cli' } } }),
+      [],
+      'owner-1',
+      NOW,
+    );
+    expect(row.state).toBe('never-connected');
+  });
+});

--- a/backend/routes/pods.ts
+++ b/backend/routes/pods.ts
@@ -394,6 +394,61 @@ router.patch('/:id/contacts', podAdminRateLimit, auth, async (req: AuthReq, res:
   }
 });
 
+/**
+ * GET /:podId/agent-states — #891 surface 1, the mention-time honesty read.
+ * Thin shell: membership gate + two fetches; the per-runtime-class honesty
+ * rules (and the owner-only fix-copy split) live in agentStateService, where
+ * they are pure and unit-tested.
+ */
+router.get('/:podId/agent-states', auth, async (req: AuthReq, res: Res) => {
+  try {
+    const { podId } = req.params || {};
+    const pod = await Pod.findById(podId) as { type?: string } | null;
+    if (!pod) return res.status(404).json({ message: 'Pod not found' });
+    const canView = await DMService.canViewPod(req.user?.id, pod);
+    if (!canView) return res.status(403).json({ message: 'Not authorized to view pod agent states' });
+
+    // eslint-disable-next-line global-require
+    const { AgentInstallation } = require('../models/AgentRegistry');
+    // eslint-disable-next-line global-require
+    const AgentIdentityService = require('../services/agentIdentityService');
+    // eslint-disable-next-line global-require
+    const { deriveAgentState } = require('../services/agentStateService');
+
+    const installations = await AgentInstallation.find({ podId, status: 'active' })
+      .select('agentName instanceId displayName installedBy config runtimeTokens')
+      .lean();
+    if (!installations.length) return res.json({ agents: [] });
+
+    const identityFilters = installations.map((inst: any) => ({
+      'botMetadata.agentName': AgentIdentityService.resolveAgentType(String(inst.agentName || '').toLowerCase()),
+      'botMetadata.instanceId': String(inst.instanceId || 'default'),
+    }));
+    const agentUsers = await User.find({ isBot: true, $or: identityFilters })
+      .select('botMetadata.agentName botMetadata.instanceId agentRuntimeTokens.lastUsedAt')
+      .lean();
+    const userTokensByIdentity = new Map<string, Array<{ lastUsedAt?: Date }>>();
+    (agentUsers || []).forEach((u: any) => {
+      const key = `${String(u.botMetadata?.agentName || '').toLowerCase()}:${String(u.botMetadata?.instanceId || 'default').toLowerCase()}`;
+      userTokensByIdentity.set(key, u.agentRuntimeTokens || []);
+    });
+
+    const callerId = String(req.user?.id || '');
+    const agents = installations.map((inst: any) => deriveAgentState(
+      inst,
+      userTokensByIdentity.get(
+        `${AgentIdentityService.resolveAgentType(String(inst.agentName || '').toLowerCase())}:${String(inst.instanceId || 'default').toLowerCase()}`,
+      ) || [],
+      callerId,
+    ));
+
+    return res.json({ agents });
+  } catch (error) {
+    console.error('Error deriving pod agent states:', error);
+    return res.status(500).json({ message: 'Server error' });
+  }
+});
+
 router.get('/:podId/announcements', auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId } = req.params || {};

--- a/backend/routes/pods.ts
+++ b/backend/routes/pods.ts
@@ -400,7 +400,16 @@ router.patch('/:id/contacts', podAdminRateLimit, auth, async (req: AuthReq, res:
  * rules (and the owner-only fix-copy split) live in agentStateService, where
  * they are pure and unit-tested.
  */
-router.get('/:podId/agent-states', auth, async (req: AuthReq, res: Res) => {
+const agentStatesRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  // The composer polls at 60s per open pod, so even a user with several pods
+  // open sits far under this; the ceiling exists for runaway tabs and scripts.
+  limit: 60,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+});
+
+router.get('/:podId/agent-states', agentStatesRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId } = req.params || {};
     const pod = await Pod.findById(podId) as { type?: string } | null;

--- a/backend/services/agentStateService.ts
+++ b/backend/services/agentStateService.ts
@@ -1,0 +1,110 @@
+/**
+ * agentStateService — #891 surface 1's derivation, kept pure.
+ *
+ * Answers, per agent install: can it actually respond to a mention right
+ * now? States are PER RUNTIME CLASS because the #891 review measured
+ * `lastUsedAt` lying for every class except the polling one:
+ *
+ *   - BYO wrapper/MCP installs (host 'byo' or legacy local-cli, no
+ *     webhookUrl): the wrapper polls every ~5s while alive, so lastUsedAt is
+ *     an honest reachability signal. null → never-connected · fresh →
+ *     listening · stale → gone-dark.
+ *   - push webhooks (webhookUrl set) and native runtime: reachable by
+ *     construction — no dot, no guess.
+ *   - everything else (gateway moltbots, cloud): 'unknown'. The gateway
+ *     stamps one shared boot timestamp for a whole fleet (finding A);
+ *     pretending to know is the false positive the ratified doc bans.
+ *
+ * Split key (decision 1): the state is the EXPLANATION and goes to any pod
+ * viewer; `fixCommand` is an instruction and attaches only for the owner —
+ * an instruction addressed to someone who cannot perform it is the P1/P2
+ * contradiction the review caught.
+ *
+ * lastUsedAt is the max across BOTH token stores (User.agentRuntimeTokens
+ * and AgentInstallation.runtimeTokens) — the legacy/new split that made
+ * live agents read null (finding D). Pure function: callers fetch, this
+ * derives; the seam is what makes the honesty rules testable without a DB.
+ */
+
+export const AGENT_LISTENING_STALE_MS = 5 * 60 * 1000;
+
+export type AgentReachState = 'listening' | 'gone-dark' | 'never-connected' | 'reachable' | 'unknown';
+
+interface TokenRow { lastUsedAt?: Date | string | null }
+
+interface InstallationRow {
+  agentName?: string;
+  instanceId?: string;
+  displayName?: string;
+  installedBy?: unknown;
+  config?: { runtime?: { runtimeType?: string; host?: string; webhookUrl?: string } };
+  runtimeTokens?: TokenRow[];
+}
+
+export interface AgentStateRow {
+  agentName: string;
+  instanceId: string;
+  displayName: string;
+  state: AgentReachState;
+  lastUsedAt: string | null;
+  isOwner: boolean;
+  fixCommand?: string;
+}
+
+const latestUse = (tokenLists: TokenRow[][]): Date | null => {
+  let latest: Date | null = null;
+  for (const list of tokenLists) {
+    for (const row of list || []) {
+      if (!row?.lastUsedAt) continue;
+      const used = new Date(row.lastUsedAt as string);
+      if (Number.isNaN(used.getTime())) continue;
+      if (!latest || used > latest) latest = used;
+    }
+  }
+  return latest;
+};
+
+export function deriveAgentState(
+  installation: InstallationRow,
+  userTokens: TokenRow[],
+  callerId: string,
+  now: number = Date.now(),
+): AgentStateRow {
+  const agentName = String(installation.agentName || '').toLowerCase();
+  const instanceId = String(installation.instanceId || 'default');
+  const runtime = installation.config?.runtime || {};
+  const runtimeType = String(runtime.runtimeType || '').toLowerCase();
+  const isByo = runtime.host === 'byo' || runtimeType === 'local-cli';
+  const isPushWebhook = Boolean(runtime.webhookUrl);
+  const isNative = runtimeType === 'native';
+
+  let state: AgentReachState;
+  let lastUsedAt: Date | null = null;
+  if (isNative || isPushWebhook) {
+    state = 'reachable';
+  } else if (!isByo) {
+    state = 'unknown';
+  } else {
+    lastUsedAt = latestUse([installation.runtimeTokens || [], userTokens || []]);
+    if (!lastUsedAt) state = 'never-connected';
+    else if (now - lastUsedAt.getTime() <= AGENT_LISTENING_STALE_MS) state = 'listening';
+    else state = 'gone-dark';
+  }
+
+  const isOwner = String(installation.installedBy || '') === String(callerId || '');
+  const needsFix = state === 'never-connected' || state === 'gone-dark';
+  return {
+    agentName,
+    instanceId,
+    displayName: installation.displayName || agentName,
+    state,
+    lastUsedAt: lastUsedAt ? lastUsedAt.toISOString() : null,
+    isOwner,
+    ...(isOwner && needsFix ? { fixCommand: `commonly agent run ${agentName}` } : {}),
+  };
+}
+
+export default { deriveAgentState, AGENT_LISTENING_STALE_MS };
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -253,6 +253,14 @@
       "agentSubtitle": "Agent · @{{handle}}",
       "member": "Member"
     },
+    "mentionState": {
+      "typeaheadNever": "Agent · @{{handle}} — not connected, can't answer",
+      "typeaheadDark": "Agent · @{{handle}} — hasn't checked in lately",
+      "neverOwner": "@{{handle}} isn't connected — it won't see this. Fix: {{command}}",
+      "neverPeer": "@{{handle}} isn't connected — it won't see this. Its owner can connect it.",
+      "darkOwner": "@{{handle}} hasn't checked in for a while and may not answer. Wake it: {{command}}",
+      "darkPeer": "@{{handle}} hasn't checked in for a while and may not answer."
+    },
     "mobile": {
       "showPods": "Show pods",
       "showPodsList": "Show pods list"

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -253,6 +253,14 @@
       "agentSubtitle": "智能体 · @{{handle}}",
       "member": "成员"
     },
+    "mentionState": {
+      "typeaheadNever": "智能体 · @{{handle}} —— 未连接，无法回复",
+      "typeaheadDark": "智能体 · @{{handle}} —— 最近没有接入",
+      "neverOwner": "@{{handle}} 尚未连接 —— 它看不到这条消息。修复：{{command}}",
+      "neverPeer": "@{{handle}} 尚未连接 —— 它看不到这条消息。它的所有者可以将其接入。",
+      "darkOwner": "@{{handle}} 已有一段时间没有接入，可能不会回复。唤醒它：{{command}}",
+      "darkPeer": "@{{handle}} 已有一段时间没有接入，可能不会回复。"
+    },
     "mobile": {
       "showPods": "显示 Pod",
       "showPodsList": "显示 Pod 列表"

--- a/frontend/src/v2/__tests__/V2PodChatMentionState.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatMentionState.test.tsx
@@ -1,0 +1,159 @@
+// @ts-nocheck
+// #891 surface 1 — compose-time honesty about mentioned agents. The moment a
+// draft mentions an agent that cannot hear it, the composer says so:
+// certainty-matched copy (never-connected flat, gone-dark hedged), fix
+// command only when the endpoint attached one (owner), and the typeahead
+// itself carries the state so a dead mention is never offered silently.
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2PodChat from '../components/V2PodChat';
+import { AuthContext } from '../../context/AuthContext';
+
+jest.mock('../../context/SocketContext', () => ({
+  useSocket: () => ({ socket: null, connected: false }),
+}));
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+jest.mock('axios', () => {
+  const mock = {
+    get: jest.fn(() => Promise.resolve({ data: {} })),
+    post: jest.fn(() => Promise.resolve({ data: {} })),
+    patch: jest.fn(),
+    delete: jest.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  };
+  return { __esModule: true, default: mock, ...mock };
+});
+
+const axios = jest.requireMock('axios').default;
+
+const authValue = {
+  currentUser: { _id: 'u1', username: 'solo-user' },
+  user: { _id: 'u1', username: 'solo-user' },
+  token: 't',
+  loading: false,
+  error: null,
+  isAuthenticated: true,
+  register: jest.fn(),
+  login: jest.fn(),
+  logout: jest.fn(),
+  updateProfile: jest.fn(),
+};
+
+const makeDetail = (overrides = {}) => ({
+  pod: { _id: 'p1', name: 'My Workspace', type: 'chat' },
+  members: [{ _id: 'u1', username: 'solo-user', isBot: false }],
+  messages: [],
+  agents: [{ agentName: 'sam-agent', instanceId: 'default', displayName: 'Sam Agent' }],
+  sendMessage: jest.fn(() => Promise.resolve({ _id: 'm1' })),
+  loading: false,
+  error: null,
+  refresh: jest.fn(),
+  ...overrides,
+});
+
+const mockStates = (agents) => {
+  axios.get.mockImplementation((url) => {
+    if (typeof url === 'string' && url.endsWith('/agent-states')) {
+      return Promise.resolve({ data: { agents } });
+    }
+    return Promise.resolve({ data: {} });
+  });
+};
+
+const renderChat = (detail) => render(
+  <AuthContext.Provider value={authValue}>
+    <MemoryRouter>
+      <V2PodChat detail={detail} />
+    </MemoryRouter>
+  </AuthContext.Provider>,
+);
+
+afterEach(() => jest.clearAllMocks());
+
+describe('V2PodChat mention-state honesty (#891 surface 1)', () => {
+  test('mentioning a never-connected agent warns the OWNER with the fix command', async () => {
+    mockStates([{
+      agentName: 'sam-agent', instanceId: 'default', state: 'never-connected', isOwner: true, fixCommand: 'commonly agent run sam-agent',
+    }]);
+    renderChat(makeDetail());
+    await waitFor(() => expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/agent-states')));
+
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+      target: { value: 'hey @sam-agent can you look' },
+    });
+
+    const warning = await screen.findByTestId('mention-state-warning');
+    expect(warning.textContent).toContain("isn't connected");
+    expect(warning.textContent).toContain('commonly agent run sam-agent');
+  });
+
+  test('a NON-owner gets the explanation without the instruction', async () => {
+    mockStates([{
+      agentName: 'sam-agent', instanceId: 'default', state: 'never-connected', isOwner: false,
+    }]);
+    renderChat(makeDetail());
+    await waitFor(() => expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/agent-states')));
+
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+      target: { value: '@sam-agent ping' },
+    });
+
+    const warning = await screen.findByTestId('mention-state-warning');
+    expect(warning.textContent).toContain('Its owner can connect it');
+    expect(warning.textContent).not.toContain('commonly agent run');
+  });
+
+  test('gone-dark copy is hedged, never flat', async () => {
+    mockStates([{
+      agentName: 'sam-agent', instanceId: 'default', state: 'gone-dark', isOwner: false,
+    }]);
+    renderChat(makeDetail());
+    await waitFor(() => expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/agent-states')));
+
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+      target: { value: '@sam-agent still there?' },
+    });
+
+    const warning = await screen.findByTestId('mention-state-warning');
+    expect(warning.textContent).toContain('may not answer');
+    expect(warning.textContent).not.toContain("isn't connected");
+  });
+
+  test('a listening agent draws no warning at all', async () => {
+    mockStates([{
+      agentName: 'sam-agent', instanceId: 'default', state: 'listening', isOwner: true,
+    }]);
+    renderChat(makeDetail());
+    await waitFor(() => expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/agent-states')));
+
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+      target: { value: '@sam-agent all good' },
+    });
+
+    expect(screen.queryByTestId('mention-state-warning')).not.toBeInTheDocument();
+  });
+
+  test('the typeahead itself carries the state for a dead agent', async () => {
+    mockStates([{
+      agentName: 'sam-agent', instanceId: 'default', state: 'never-connected', isOwner: true, fixCommand: 'commonly agent run sam-agent',
+    }]);
+    renderChat(makeDetail());
+    await waitFor(() => expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/agent-states')));
+
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+      target: { value: '@sam' },
+    });
+
+    const option = await screen.findByRole('option');
+    expect(option.textContent).toContain("not connected");
+  });
+});

--- a/frontend/src/v2/__tests__/V2PodChatMentionState.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatMentionState.test.tsx
@@ -85,7 +85,7 @@ describe('V2PodChat mention-state honesty (#891 surface 1)', () => {
       agentName: 'sam-agent', instanceId: 'default', state: 'never-connected', isOwner: true, fixCommand: 'commonly agent run sam-agent',
     }]);
     renderChat(makeDetail());
-    await waitFor(() => expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/agent-states')));
+    await waitFor(() => expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/agent-states'), expect.anything()));
 
     fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
       target: { value: 'hey @sam-agent can you look' },
@@ -101,7 +101,7 @@ describe('V2PodChat mention-state honesty (#891 surface 1)', () => {
       agentName: 'sam-agent', instanceId: 'default', state: 'never-connected', isOwner: false,
     }]);
     renderChat(makeDetail());
-    await waitFor(() => expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/agent-states')));
+    await waitFor(() => expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/agent-states'), expect.anything()));
 
     fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
       target: { value: '@sam-agent ping' },
@@ -117,7 +117,7 @@ describe('V2PodChat mention-state honesty (#891 surface 1)', () => {
       agentName: 'sam-agent', instanceId: 'default', state: 'gone-dark', isOwner: false,
     }]);
     renderChat(makeDetail());
-    await waitFor(() => expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/agent-states')));
+    await waitFor(() => expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/agent-states'), expect.anything()));
 
     fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
       target: { value: '@sam-agent still there?' },
@@ -133,7 +133,7 @@ describe('V2PodChat mention-state honesty (#891 surface 1)', () => {
       agentName: 'sam-agent', instanceId: 'default', state: 'listening', isOwner: true,
     }]);
     renderChat(makeDetail());
-    await waitFor(() => expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/agent-states')));
+    await waitFor(() => expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/agent-states'), expect.anything()));
 
     fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
       target: { value: '@sam-agent all good' },
@@ -147,7 +147,7 @@ describe('V2PodChat mention-state honesty (#891 surface 1)', () => {
       agentName: 'sam-agent', instanceId: 'default', state: 'never-connected', isOwner: true, fixCommand: 'commonly agent run sam-agent',
     }]);
     renderChat(makeDetail());
-    await waitFor(() => expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/agent-states')));
+    await waitFor(() => expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/agent-states'), expect.anything()));
 
     fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
       target: { value: '@sam' },

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -73,7 +73,23 @@ interface MentionItem {
   // Value inserted after `@`. For agents, prefer instanceId so mentions land
   // on the right instance ("@nova" not "@openclaw").
   value: string;
+  // #891 surface 1: reachability shown at compose time, so nobody offers a
+  // mention that can't land without saying so.
+  reach?: AgentReachState;
 }
+
+// #891 surface 1 — per-agent reachability from /api/pods/:podId/agent-states.
+// Only the states the kernel can derive HONESTLY for the agent's runtime
+// class arrive here; 'reachable'/'unknown' render nothing.
+type AgentReachState = 'listening' | 'gone-dark' | 'never-connected' | 'reachable' | 'unknown';
+interface AgentStateRow {
+  agentName: string;
+  instanceId: string;
+  state: AgentReachState;
+  isOwner: boolean;
+  fixCommand?: string;
+}
+const REACH_NEEDS_WARNING = new Set<AgentReachState>(['gone-dark', 'never-connected']);
 
 interface TypingAgentEntry {
   key: string;
@@ -221,6 +237,38 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
   const [mentionQuery, setMentionQuery] = useState('');
   const [mentionStart, setMentionStart] = useState(-1);
   const [mentionIndex, setMentionIndex] = useState(0);
+
+  // #891 surface 1: agent reachability at the moment of composing a mention.
+  // Best-effort — a failed read renders nothing rather than something wrong,
+  // and 60s refresh keeps the states honest without hammering the endpoint.
+  const [agentStates, setAgentStates] = useState<AgentStateRow[]>([]);
+  useEffect(() => {
+    const podId = pod?._id;
+    if (!podId) return undefined;
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const data = await api.get<{ agents?: AgentStateRow[] }>(`/api/pods/${podId}/agent-states`);
+        if (!cancelled) setAgentStates(data?.agents || []);
+      } catch {
+        // Honesty surface is best-effort: silence over a wrong dot.
+      }
+    };
+    load();
+    const timer = setInterval(load, 60_000);
+    return () => { cancelled = true; clearInterval(timer); };
+  }, [pod?._id, api]);
+
+  // Lookup by every handle a mention could use: instanceId (what the
+  // dropdown inserts for non-default instances) and agentName.
+  const agentStateByHandle = useMemo(() => {
+    const map = new Map<string, AgentStateRow>();
+    agentStates.forEach((s) => {
+      map.set(s.agentName.toLowerCase(), s);
+      if (s.instanceId && s.instanceId !== 'default') map.set(s.instanceId.toLowerCase(), s);
+    });
+    return map;
+  }, [agentStates]);
 
   useEffect(() => {
     if (pod) setMode(readMode(pod._id));
@@ -430,14 +478,25 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
         ? instance
         : rawName.toLowerCase();
       const avatar = a.profile?.avatarUrl || a.profile?.iconUrl || a.iconUrl || fallbackAvatar;
+      // Compose-time honesty (#891 surface 1): a mention that can't land says
+      // so in the picker itself — certainty-matched copy (never-connected is
+      // structural and flat; gone-dark is inferred and hedged).
+      const reach = agentStateByHandle.get(mentionValue)?.state
+        || agentStateByHandle.get(rawName.toLowerCase())?.state;
+      const subtitle = reach === 'never-connected'
+        ? t('podChat.mentionState.typeaheadNever', { handle: mentionValue })
+        : reach === 'gone-dark'
+          ? t('podChat.mentionState.typeaheadDark', { handle: mentionValue })
+          : t('podChat.mentions.agentSubtitle', { handle: mentionValue });
       return {
         id: username,
         label: display,
         labelLower: `${display} ${rawName} ${username} ${mentionValue}`.toLowerCase(),
-        subtitle: t('podChat.mentions.agentSubtitle', { handle: mentionValue }),
+        subtitle,
         avatar,
         isAgent: true,
         value: mentionValue,
+        reach,
       };
     };
 
@@ -476,7 +535,25 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
     });
 
     return items;
-  }, [members, agents, t]);
+  }, [members, agents, t, agentStateByHandle]);
+
+  // #891 surface 1, send-time half: which mentioned agents in the current
+  // draft cannot hear it? Dependency-keyed explanation for everyone; the fix
+  // command only ever arrives for owners (the endpoint enforces the split).
+  const unreachableMentioned = useMemo(() => {
+    if (!draft.includes('@')) return [] as AgentStateRow[];
+    const tokens = draft.match(/@([a-z0-9][\w-]*)/gi) || [];
+    const seen = new Set<string>();
+    const rows: AgentStateRow[] = [];
+    tokens.forEach((token) => {
+      const handle = token.slice(1).toLowerCase();
+      const state = agentStateByHandle.get(handle);
+      if (!state || !REACH_NEEDS_WARNING.has(state.state) || seen.has(handle)) return;
+      seen.add(handle);
+      rows.push({ ...state, agentName: handle });
+    });
+    return rows;
+  }, [draft, agentStateByHandle]);
 
   const filteredMentions: MentionItem[] = useMemo(() => {
     if (!mentionOpen) return [];
@@ -1223,6 +1300,21 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
               {composerError && (
                 <div className="v2-chat__composer-footer">
                   <span className="v2-chat__composer-error">{composerError}</span>
+                </div>
+              )}
+              {unreachableMentioned.length > 0 && (
+                <div className="v2-chat__composer-footer" data-testid="mention-state-warning">
+                  {unreachableMentioned.map((row) => (
+                    <span key={row.agentName} className="v2-chat__composer-hint">
+                      {row.state === 'never-connected'
+                        ? (row.fixCommand
+                          ? t('podChat.mentionState.neverOwner', { handle: row.agentName, command: row.fixCommand })
+                          : t('podChat.mentionState.neverPeer', { handle: row.agentName }))
+                        : (row.fixCommand
+                          ? t('podChat.mentionState.darkOwner', { handle: row.agentName, command: row.fixCommand })
+                          : t('podChat.mentionState.darkPeer', { handle: row.agentName }))}
+                    </span>
+                  ))}
                 </div>
               )}
               <div className="v2-chat__composer-hint">

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -542,7 +542,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
   // command only ever arrives for owners (the endpoint enforces the split).
   const unreachableMentioned = useMemo(() => {
     if (!draft.includes('@')) return [] as AgentStateRow[];
-    const tokens = draft.match(/@([a-z0-9][\w-]*)/gi) || [];
+    const tokens: string[] = draft.match(/@([a-z0-9][\w-]*)/gi) || [];
     const seen = new Set<string>();
     const rows: AgentStateRow[] = [];
     tokens.forEach((token) => {


### PR DESCRIPTION
## What

Surface 1 of the ratified status-honesty spec (#891) — the net that catches every silence cause at the moment of failed expectation.

**Backend**: `GET /api/pods/:podId/agent-states` (canViewPod-gated). The honesty rules live in a pure, unit-tested service: per-runtime-class derivation (BYO from the **union of both token stores** — finding D; native/push-webhook reachable by construction; gateway/cloud honestly `unknown` — finding A), and `fixCommand` attached **only for the owner** (decision 1's split key).

**Frontend (V2PodChat)**:
- The @-typeahead carries the state — "not connected, can't answer" (flat, structural) / "hasn't checked in lately" (hedged, inferred; principle 6) — so a mention that can't land is never offered silently (Buzz's composer-eligibility pattern).
- A draft mentioning an unreachable agent gets a composer warning: owner sees `commonly agent run <name>`, everyone else sees the explanation with no un-performable instruction.
- Best-effort: a failed state read renders nothing rather than something wrong; 60s refresh.
- en + zh-CN from day one.

**Interpretation note**: the spec's "send-time inline line" is implemented at *compose* time — it covers typing, paste, and mobile *before* the silence happens. A persisted in-room system line after send is the named follow-up, not silently dropped.

## Tests

9 unit tests on the pure derivation (green locally); 5 RTL tests on the composer behavior — owner/peer copy split, hedged gone-dark copy, no warning for listening agents, typeahead state. Frontend jest cannot run in this environment (pre-existing, exit 194 before any test) — CI's Test & Coverage is the verification tier for those five.

Completes the onboarding funnel's net 2. Net 1 (#909, live connect verification) deployed earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8