### PR TITLE
feat(onboarding): the Guide — a live first teammate in every new workspace (plan D4)

### DIFF
--- a/backend/__tests__/service/auth.test.js
+++ b/backend/__tests__/service/auth.test.js
@@ -92,8 +92,15 @@ describe('Auth Routes Integration Tests', () => {
       expect(pod.name).toBe('My Workspace');
       expect(pod.type).toBe('chat');
       expect(pod.joinPolicy).toBe('invite-only');
-      // Creator is the sole member.
-      expect(pod.members.map((m) => m.toString())).toEqual([user._id.toString()]);
+      // Membership changed by plan D4 (the Guide, PR #911): the workspace's
+      // first inhabitants are the creator AND the per-user guide agent — the
+      // "sole member" assertion encoded the pre-Guide behavior.
+      const memberIds = pod.members.map((m) => m.toString());
+      expect(memberIds).toContain(user._id.toString());
+      const guideUser = await User.findOne({ isBot: true, 'botMetadata.agentName': 'guide' });
+      expect(guideUser).toBeTruthy();
+      expect(memberIds).toContain(guideUser._id.toString());
+      expect(memberIds).toHaveLength(2);
     });
 
     it('defaults entitlements.cloudAgents to false for new signups', async () => {

--- a/backend/__tests__/unit/scripts/seed-native-agents.config.test.js
+++ b/backend/__tests__/unit/scripts/seed-native-agents.config.test.js
@@ -52,6 +52,23 @@ describe('buildInstallationConfig', () => {
     }
   });
 
+  test('a manifest wake-on-message opt-in projects onto the flag the producer reads (ADR-018 D8)', () => {
+    const config = buildInstallationConfig({
+      ...baseApp,
+      triggers: ['mention', 'chat.message'],
+      wakeOnMessage: true,
+      dailyRunCap: 60,
+    });
+    expect(config.wakeOnMessage).toEqual({ enabled: true });
+    expect(config.dailyRunCap).toBe(60);
+  });
+
+  test('apps that do not declare wake-on-message get no flag — D8 stays opt-in', () => {
+    const config = buildInstallationConfig({ ...baseApp, triggers: ['mention'] });
+    expect(config.wakeOnMessage).toBeUndefined();
+    expect(config.dailyRunCap).toBeUndefined();
+  });
+
   test('runtime, prompt, tools, triggers, and limits project as before', () => {
     const config = buildInstallationConfig({
       ...baseApp,

--- a/backend/__tests__/unit/services/nativeRuntimeService.dailyCap.test.js
+++ b/backend/__tests__/unit/services/nativeRuntimeService.dailyCap.test.js
@@ -1,0 +1,134 @@
+/**
+ * D4 cost ceiling — config.dailyRunCap in the native runtime.
+ *
+ * The Guide runs a paid model in every new user's workspace; the cap makes
+ * its cost bounded by construction. Contract:
+ *  - at cap → decline before ANY claim, run row, or LLM call
+ *  - under cap → runs normally
+ *  - count failure fails OPEN (#887's shape — infrastructure faults must
+ *    not silence an agent)
+ *  - no cap configured → the counter is never consulted
+ */
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+jest.mock('../../../models/Pod', () => ({
+  findById: jest.fn(() => ({
+    lean: jest.fn().mockResolvedValue({ name: 'My Workspace' }),
+  })),
+}));
+
+jest.mock('../../../models/AgentRun', () => ({
+  create: jest.fn(),
+  countDocuments: jest.fn(),
+}));
+
+jest.mock('../../../services/agentTypingService', () => ({
+  emitAgentTypingStart: jest.fn(),
+  emitAgentTypingStop: jest.fn(),
+}));
+
+jest.mock('../../../services/agentMessageService', () => ({
+  postMessage: jest.fn().mockResolvedValue({ success: true }),
+}));
+
+jest.mock('../../../services/messageClaimService', () => ({
+  claim: jest.fn(),
+  release: jest.fn(),
+}));
+
+const axios = require('axios').default;
+const AgentRun = require('../../../models/AgentRun');
+const MessageClaimService = require('../../../services/messageClaimService');
+const { runAgent } = require('../../../services/nativeRuntimeService');
+
+const installation = (config = {}) => ({
+  podId: 'pod-1',
+  agentName: 'guide',
+  instanceId: 'default',
+  displayName: 'Guide',
+  config: {
+    runtime: { runtimeType: 'native' },
+    systemPrompt: 'guide them',
+    model: 'deepseek-v4-flash',
+    tools: [],
+    dailyRunCap: 3,
+    ...config,
+  },
+});
+
+const mentionTrigger = {
+  type: 'chat.mention',
+  eventId: 'evt-1',
+  payload: { messageId: 'msg-1', content: 'hi @guide' },
+};
+
+describe('nativeRuntimeService daily run cap (D4)', () => {
+  const previousEnv = {
+    baseUrl: process.env.LITELLM_BASE_URL,
+    masterKey: process.env.LITELLM_MASTER_KEY,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.LITELLM_BASE_URL = 'http://litellm.test';
+    process.env.LITELLM_MASTER_KEY = 'test-key';
+    MessageClaimService.claim.mockResolvedValue({ claimed: true, expiresAt: new Date() });
+    MessageClaimService.release.mockResolvedValue({ released: true });
+    AgentRun.create.mockImplementation(async (doc) => ({
+      _id: 'run-1',
+      ...doc,
+      save: jest.fn().mockResolvedValue(undefined),
+    }));
+    axios.post.mockResolvedValue({
+      status: 200,
+      data: {
+        choices: [{ message: { role: 'assistant', content: 'NO_REPLY' } }],
+        usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+      },
+      headers: {},
+    });
+  });
+
+  afterAll(() => {
+    if (previousEnv.baseUrl === undefined) delete process.env.LITELLM_BASE_URL;
+    else process.env.LITELLM_BASE_URL = previousEnv.baseUrl;
+    if (previousEnv.masterKey === undefined) delete process.env.LITELLM_MASTER_KEY;
+    else process.env.LITELLM_MASTER_KEY = previousEnv.masterKey;
+  });
+
+  test('at cap: declines before any claim, run row, or LLM call', async () => {
+    AgentRun.countDocuments.mockResolvedValue(3);
+    const result = await runAgent(installation(), mentionTrigger);
+    expect(result).toEqual({
+      runId: '', status: 'succeeded', totalTurns: 0, totalTokens: 0,
+    });
+    expect(MessageClaimService.claim).not.toHaveBeenCalled();
+    expect(AgentRun.create).not.toHaveBeenCalled();
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  test('under cap: runs normally', async () => {
+    AgentRun.countDocuments.mockResolvedValue(2);
+    const result = await runAgent(installation(), mentionTrigger);
+    expect(result.status).toBe('succeeded');
+    expect(AgentRun.create).toHaveBeenCalledTimes(1);
+  });
+
+  test('count failure fails OPEN — the run proceeds', async () => {
+    AgentRun.countDocuments.mockRejectedValue(new Error('mongo down'));
+    const result = await runAgent(installation(), mentionTrigger);
+    expect(result.status).toBe('succeeded');
+    expect(AgentRun.create).toHaveBeenCalledTimes(1);
+  });
+
+  test('no cap configured: the counter is never consulted', async () => {
+    await runAgent(installation({ dailyRunCap: undefined }), mentionTrigger);
+    expect(AgentRun.countDocuments).not.toHaveBeenCalled();
+  });
+});

--- a/backend/config/native-agents/apps.ts
+++ b/backend/config/native-agents/apps.ts
@@ -2,6 +2,7 @@ import type { NativeAgentDefinition } from './types';
 import { podWelcomerApp } from './pod-welcomer';
 import { taskClerkApp } from './task-clerk';
 import { podSummarizerApp } from './pod-summarizer';
+import { guideApp } from './guide';
 
 export type { NativeAgentDefinition, NativeAgentTrigger, CommonlyTool } from './types';
 
@@ -24,4 +25,5 @@ export const FIRST_PARTY_APPS: NativeAgentDefinition[] = [
   podWelcomerApp,
   taskClerkApp,
   podSummarizerApp,
+  guideApp,
 ];

--- a/backend/config/native-agents/guide.ts
+++ b/backend/config/native-agents/guide.ts
@@ -1,0 +1,91 @@
+import type { NativeAgentDefinition } from './types';
+
+/**
+ * Guide — the per-user onboarding agent (retention plan D4). Auto-installed
+ * into every new user's My Workspace at signup, so the first minute contains
+ * a live agent instead of an empty room. It IS the tour: conversational,
+ * does real things (tasks, memory), and coaches the BYO connect path that is
+ * the activation step.
+ *
+ * Per-user, not per-instance: `perUser: true` tells the seeder to publish
+ * the registry row but NOT install into the demo pod — installation happens
+ * per workspace in authController.createDefaultWorkspacePod.
+ *
+ * Model: deepseek-v4-flash via LiteLLM (alias verified in
+ * litellm-config.yaml) — the D4 blocker was native apps dying on the free
+ * OpenRouter tier (#510); the guide gets a reliable cheap paid model with a
+ * hard daily cap instead, because it embarrasses us at exactly the moment
+ * that matters most if it doesn't answer.
+ */
+export const guideApp = {
+  agentName: 'guide',
+  displayName: 'Guide',
+  description:
+    'Your first teammate on Commonly. Lives in your workspace, answers '
+    + 'questions about the product, helps you connect your own agents, and '
+    + 'does real work — tasks, memory — so you can see how agents here behave.',
+  systemPrompt:
+    'You are Guide, the user\'s first teammate on Commonly — a shared workspace '
+    + 'where humans and agents from any origin work together. You live in their '
+    + 'private "My Workspace" pod. They just signed up; you may be the first '
+    + 'agent they have ever talked to here. Your job is that their first minutes '
+    + 'feel alive and their questions get true answers.\n'
+    + '\n'
+    + 'WHAT YOU KNOW ABOUT THIS WORKSPACE:\n'
+    + '- It was created at signup with three starter tasks on the task board: '
+    + '"Connect your first agent", "Give your agent its first task", and '
+    + '"Invite a teammate". They are the onboarding checklist. Reference them '
+    + 'when relevant; when the user completes one, acknowledge it briefly.\n'
+    + '- The user connects their own agent (Claude Code, Cursor, Codex, etc.) '
+    + 'via Agents → "Connect your own agent". That page issues a token, shows '
+    + 'the exact commands, and verifies the connection live — it flips to a '
+    + 'checkmark when their agent first checks in. The final command that makes '
+    + 'their agent ANSWER mentions is `commonly agent run <name>` — without it, '
+    + 'the agent appears in the team but stays silent.\n'
+    + '\n'
+    + 'HOW TO BEHAVE:\n'
+    + '- Match the user\'s language. If they write Chinese, answer in Chinese.\n'
+    + '- This is a chat room, not a report surface: aim under 400 characters '
+    + 'per message, one idea per message, no headers, no bullet-point walls, '
+    + 'never open with a bold sentence. Post the answer, not your reasoning.\n'
+    + '- DO things instead of describing them. Asked to track something → '
+    + 'commonly_create_task. Told a durable preference ("I prefer zh-CN", '
+    + '"my repo is X") → commonly_write_memory, once, without narrating it.\n'
+    + '- Read the room first when history matters: commonly_read_context '
+    + 'before answering questions about what happened here.\n'
+    + '- Silence is a valid turn. If a message needs nothing from you — the '
+    + 'user is addressing another agent, or thinking out loud — reply with '
+    + 'exactly NO_REPLY and nothing else.\n'
+    + '\n'
+    + 'HARD RULES:\n'
+    + '- Never invent platform features, prices, or limits. If you do not '
+    + 'know, say you do not know — a wrong answer about the product is worse '
+    + 'than no answer, because you are the product\'s first impression.\n'
+    + '- Never paste long documents into chat.\n'
+    + '- You cannot run code, browse the web, or reach anything outside this '
+    + 'workspace\'s tools. Say so plainly when asked for those.\n'
+    + '- Never claim the user\'s own agent is connected or working — the '
+    + 'connect page verifies that, not you. Point them there instead.',
+  model: 'deepseek-v4-flash',
+  triggers: ['mention', 'chat.message'],
+  tools: [
+    'commonly_read_context',
+    'commonly_read_memory',
+    'commonly_write_memory',
+    'commonly_post_message',
+    'commonly_create_task',
+  ],
+  iconUrl: '',
+  categories: ['onboarding', 'utility'],
+  maxTurns: 6,
+  maxTokens: 12000,
+  perUser: true,
+  // The cost decision D4 called out: bounded by construction. 60 guide runs
+  // per workspace per day is far above real onboarding usage and still a
+  // hard ceiling on a runaway conversation loop.
+  dailyRunCap: 60,
+  // Every message in the user's own workspace wakes the guide (ADR-018 D8) —
+  // a private 1:1-shaped room where requiring @guide on every line would be
+  // the old dead-room feel. Claims + caps make this safe.
+  wakeOnMessage: true,
+} as const satisfies NativeAgentDefinition;

--- a/backend/config/native-agents/types.ts
+++ b/backend/config/native-agents/types.ts
@@ -38,4 +38,13 @@ export interface NativeAgentDefinition {
   maxTurns?: number;
   maxTokens?: number;
   maxWallClockMs?: number;
+  // Per-user apps (the Guide) publish a registry row but are NOT installed
+  // into the demo pod by the seeder — installation happens per workspace at
+  // signup (authController.createDefaultWorkspacePod).
+  perUser?: boolean;
+  // Hard ceiling on runs per installation per day, enforced by
+  // nativeRuntimeService before any model call. Absent = uncapped.
+  dailyRunCap?: number;
+  // ADR-018 D8: opt the installation into wake-on-message at install time.
+  wakeOnMessage?: boolean;
 }

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -149,6 +149,72 @@ const createDefaultWorkspacePod = async (userId: any) => {
     } catch (taskError: any) {
       console.warn('[register] starter checklist seeding failed:', taskError?.message);
     }
+
+    // Retention plan D4: the Guide — the workspace's first inhabitant. The
+    // empty-pod first minute is the biggest onboarding hole; a live agent
+    // that answers immediately IS the tour. Native runtime (no npm, no user
+    // setup), wake-on-message so the user never has to learn @mentions to
+    // get their first reply, hard daily run cap for cost. Best-effort like
+    // everything else here: a guide hiccup must never fail signup.
+    try {
+      // eslint-disable-next-line global-require
+      const { guideApp } = require('../config/native-agents/guide');
+      // eslint-disable-next-line global-require
+      const { buildInstallationConfig } = require('../scripts/seed-native-agents');
+      // eslint-disable-next-line global-require
+      const { AgentInstallation } = require('../models/AgentRegistry');
+
+      await AgentInstallation.findOneAndUpdate(
+        { agentName: guideApp.agentName, podId: pod._id, instanceId: 'default' },
+        {
+          $set: {
+            status: 'active',
+            version: '1.0.0',
+            displayName: guideApp.displayName,
+            scopes: ['context:read', 'messages:write', 'memory:read', 'memory:write'],
+            config: buildInstallationConfig(guideApp),
+          },
+          $setOnInsert: {
+            agentName: guideApp.agentName,
+            podId: pod._id,
+            instanceId: 'default',
+            installedBy: userId,
+          },
+        },
+        { upsert: true, setDefaultsOnInsert: true },
+      );
+
+      const guideUser = await AgentIdentityService.getOrCreateAgentUser(guideApp.agentName, {
+        instanceId: 'default',
+        displayName: guideApp.displayName,
+        description: guideApp.description,
+      });
+      if (guideUser?._id) {
+        await Pod.updateOne(
+          { _id: pod._id, members: { $ne: guideUser._id } },
+          { $push: { members: guideUser._id } },
+        );
+        // Scripted opener — deterministic and free, so the room is never
+        // empty and never depends on a model call succeeding at the exact
+        // moment a first impression is being formed. The guide's MODEL turns
+        // begin with the user's first message.
+        // eslint-disable-next-line global-require
+        const AgentMessageService = require('../services/agentMessageService');
+        await AgentMessageService.postMessage({
+          agentName: guideApp.agentName,
+          instanceId: 'default',
+          podId: pod._id.toString(),
+          displayName: guideApp.displayName,
+          content:
+            'Welcome — this workspace is yours, and I live here. Ask me anything '
+            + 'about Commonly, or just tell me what you\'re working on. When you\'re '
+            + 'ready, the three starter tasks on the board walk you through connecting '
+            + 'your own agent. 中文也可以，直接说。',
+        });
+      }
+    } catch (guideError: any) {
+      console.warn('[register] guide agent install failed:', guideError?.message);
+    }
   } catch (podError: any) {
     console.warn('[register] default workspace pod creation failed:', podError?.message);
   }

--- a/backend/scripts/seed-native-agents.ts
+++ b/backend/scripts/seed-native-agents.ts
@@ -81,6 +81,10 @@ export function buildInstallationConfig(
   if (typeof app.maxWallClockMs === 'number') {
     configObj.maxWallClockMs = app.maxWallClockMs;
   }
+  // Same manifest-is-the-choice rule as heartbeat: a declared wake-on-message
+  // opt-in projects onto the flag the producer actually reads (ADR-018 D8).
+  if (app.wakeOnMessage === true) configObj.wakeOnMessage = { enabled: true };
+  if (typeof app.dailyRunCap === 'number') configObj.dailyRunCap = app.dailyRunCap;
   return configObj;
 }
 
@@ -308,6 +312,15 @@ async function seedOneApp(app: NativeAgentDefinition): Promise<void> {
       (err as { message?: string })?.message || err,
     );
     // Non-fatal — registry row is in place; marketplace projection is best-effort.
+  }
+
+  // Per-user apps (the Guide) stop here: registry row + Installable
+  // projection only. Their installation is per workspace, at signup
+  // (authController.createDefaultWorkspacePod) — installing them into the
+  // demo pod would be a second, unowned copy.
+  if (app.perUser) {
+    console.log(`[native-seed]   ${appLabel} is per-user — registry published, demo-pod install skipped`);
+    return;
   }
 
   // 2. Demo pod must exist; if not, skip the install step gracefully.

--- a/backend/services/nativeRuntimeService.ts
+++ b/backend/services/nativeRuntimeService.ts
@@ -484,6 +484,37 @@ export async function runAgent(
     installation.displayName || agentName,
   );
 
+  // D4 cost ceiling: per-installation daily run cap, enforced before any
+  // claim or model work. The Guide runs on a paid model in every new user's
+  // workspace — bounded by construction, not by hope. Count failure fails
+  // OPEN (#887's shape: an infrastructure fault must not silence an agent);
+  // only an actual at-cap count declines, loudly.
+  const dailyRunCap = Number(cfg.dailyRunCap);
+  if (Number.isFinite(dailyRunCap) && dailyRunCap > 0) {
+    try {
+      const AgentRunModel = require('../models/AgentRun');
+      const dayStart = new Date();
+      dayStart.setUTCHours(0, 0, 0, 0);
+      const runsToday = await AgentRunModel.countDocuments({
+        podId: installation.podId,
+        agentName,
+        instanceId,
+        startedAt: { $gte: dayStart },
+      });
+      if (runsToday >= dailyRunCap) {
+        console.warn(
+          `[native-runtime] ${agentName}:${instanceId} daily run cap (${dailyRunCap}) reached `
+          + `in pod ${podId} — declining until UTC midnight`,
+        );
+        return {
+          runId: '', status: 'succeeded', totalTurns: 0, totalTokens: 0,
+        };
+      }
+    } catch (err) {
+      console.warn('[native-runtime] daily-cap count failed — proceeding unguarded:', (err as Error).message);
+    }
+  }
+
   // ADR-018 D3: native is one of OUR drivers — deterministic claim-before-act,
   // the same rule the CLI wrapper enforces (#894). Fleet audit (Sharpen msg
   // 53016) found this gap: the event queue pre-claims DELIVERY, but nothing

--- a/packages/commonly-apps/src/types.ts
+++ b/packages/commonly-apps/src/types.ts
@@ -61,4 +61,17 @@ export interface NativeAgentDefinition {
   maxTurns?: number;
   maxTokens?: number;
   maxWallClockMs?: number;
+
+  /**
+   * Per-user apps (the Guide) publish a registry row but are NOT installed
+   * into the demo pod by the seeder — installation happens per workspace at
+   * signup.
+   */
+  perUser?: boolean;
+
+  /** Hard ceiling on runs per installation per day. Absent = uncapped. */
+  dailyRunCap?: number;
+
+  /** ADR-018 D8: opt installations into wake-on-message at install time. */
+  wakeOnMessage?: boolean;
 }


### PR DESCRIPTION
## What

The proactive half of the onboarding fix (retention plan D4, model decision resolved): every new signup's My Workspace gets the **Guide** — a native-runtime agent that's alive before the user has connected anything.

- **Scripted opener at signup** (deterministic, free — the room is never empty, and the first impression never depends on a model call succeeding); model turns start with the user's first message.
- **Wake-on-message** (ADR-018 D8, manifest-declared → projected onto the flag the producer reads, same rule as the #895 heartbeat fix): no @mention tax on the first hello in a private workspace. Claims (#899/#904) and caps make this safe.
- **Coaches what already exists**: the starter checklist (already seeded at signup) and the BYO connect page (which now live-verifies, #909). Hard rule in the prompt: never claim the user's agent is connected — the connect page verifies that, not the Guide.
- **Cost bounded by construction**: `deepseek-v4-flash` via LiteLLM (alias verified in `litellm-config.yaml` — #510's free-tier failures are why D4 called this the one real cost decision) + a generic `config.dailyRunCap` in the native runtime — at-cap declines before any claim/run-row/LLM call, count failure fails open (#887), Guide capped at 60 runs/workspace/day.
- **`perUser` manifests**: seeder publishes the registry row, skips the demo-pod install; installation is per-workspace in `createDefaultWorkspacePod`, best-effort (a guide hiccup never fails signup).

## Tests

14 unit tests: config projection (wakeOnMessage/dailyRunCap, D8-stays-opt-in), the cap (at-cap full decline, under-cap runs, fail-open, no-cap-no-count), existing native claims suite green.

## Named follow-ups (not in this PR)

Backfill for existing users (after fresh-signup proof); funnel metrics (verified-listen <24h, first-mention answered <2min); the post-deploy smoke = register a fresh account on dev and talk to the Guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8