### PR TITLE
fix(native): drop the dead-key moderation guardrail — every guarded run 401'd before its model

### DIFF
--- a/k8s/helm/commonly/templates/core/backend-deployment.yaml
+++ b/k8s/helm/commonly/templates/core/backend-deployment.yaml
@@ -416,6 +416,15 @@ spec:
           value: {{ .Values.backend.env.agentSessionMaxSizeKb | quote }}
         {{- end }}
 
+        # Native-runtime guardrail set (comma-separated; see
+        # docs/runbooks/litellm-guardrails.md). Helm-tracked so the value
+        # survives deploys — a kubectl-set env is drift the next upgrade
+        # silently reverts (the cloud-codex replicas lesson, PR #900).
+        {{- if .Values.backend.env.nativeRuntimeGuardrails }}
+        - name: NATIVE_RUNTIME_GUARDRAILS
+          value: {{ .Values.backend.env.nativeRuntimeGuardrails | quote }}
+        {{- end }}
+
         # GCP Secret Manager credentials
         {{- if .Values.externalSecrets.enabled }}
         - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -80,6 +80,16 @@ backend:
     # via /chatgpt-auth/auth.json (rotator-managed). Pairs with
     # litellm.codexBypassLitellm: false + litellm.codexAuthRotator.enabled: true.
     codexBypassLitellm: "false"
+    # injection-guard ONLY (2026-08-13). The default pair includes
+    # openai-moderation-enforce, whose OPENAI_API_KEY is the literal
+    # "placeholder" — every guarded native run has 401'd on the guardrail
+    # BEFORE reaching its model (found by the Guide smoke test; also the
+    # probable cause of the native fleet's 98% July failure rate, which
+    # predates the August LiteLLM outage). injection-guard is LiteLLM-native
+    # (no key, no external service) and keeps the prompt-injection block for
+    # untrusted input. Restore the pair only after a real OpenAI moderation
+    # key lands in the api-keys secret.
+    nativeRuntimeGuardrails: "injection-guard"
 
 frontend:
   replicaCount: 1


### PR DESCRIPTION
The Guide's first live smoke run (fresh signup on dev, first hello) failed with `Incorrect API key provided: placeholder` from **platform.openai.com** — while a direct probe of `deepseek-v4-flash` through the same LiteLLM path authenticates fine. The 401 is the `openai-moderation-enforce` guardrail, whose `OPENAI_API_KEY` is the literal string `placeholder`: **every guarded native run has been dying on the guardrail before reaching any model.** Timeline note: this is also the probable cause of the native fleet's 98% July failure rate (guardrails validated 2026-07-01; the August `ECONNREFUSED` wall the #891 review found was layered on top).

Fix:
- `NATIVE_RUNTIME_GUARDRAILS` becomes a helm-tracked backend env (the documented off-switch, but through values — a `kubectl set env` is drift the next upgrade reverts, per the #900 lesson).
- Dev pins `injection-guard` only: it's LiteLLM-native (keyless, no external service) and is the layer that matters for untrusted input. The moderation layer returns when a real OpenAI key lands in the api-keys secret (Sam credential decision, noted in the values comment).

Render-verified (`helm template` shows the env; lint clean). Post-merge deploy + the Guide smoke test rerun is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8