### PR TITLE
fix(cli): bootstrap `agent run` from COMMONLY_AGENT_TOKEN — BYO copy-paste works (#913)

### DIFF
--- a/cli/__tests__/attach.test.mjs
+++ b/cli/__tests__/attach.test.mjs
@@ -30,6 +30,7 @@ const {
   saveAgentToken,
   loadAgentToken,
   buildDefaultEnvironment,
+  bootstrapAgentRecordFromEnv,
 } = await import('../src/commands/agent.js');
 
 const makeClient = ({ publishOk = true, runtimeToken = null } = {}) => {
@@ -227,5 +228,135 @@ describe('saveAgentToken / loadAgentToken', () => {
 
   test('loadAgentToken returns null when the file does not exist', () => {
     expect(loadAgentToken('never-attached')).toBeNull();
+  });
+});
+
+// ── #913: bootstrap the token record from env vars on first `agent run` ─────
+describe('bootstrapAgentRecordFromEnv', () => {
+  const identityResponse = {
+    agentName: 'smoke-agent',
+    instanceId: 'default',
+    installations: [
+      { podId: 'pod-dm', podType: 'agent-admin', instanceId: 'default', status: 'active', type: 'dm' },
+      { podId: 'pod-main', podType: 'chat', instanceId: 'default', status: 'active', type: 'installation' },
+    ],
+  };
+
+  const makeRegistry = ({ claudeFound = true, codexFound = true } = {}) => ({
+    getAdapter: (n) => ({
+      claude: { name: 'claude', detect: async () => (claudeFound ? { path: '/bin/claude', version: '1' } : null) },
+      codex: { name: 'codex', detect: async () => (codexFound ? { path: '/bin/codex', version: '1' } : null) },
+    }[n] || null),
+    listAdapterNames: () => ['stub', 'claude', 'codex'],
+  });
+
+  const makeFactory = (response = identityResponse) => {
+    const get = jest.fn(async (route) => {
+      if (route === '/api/agents/runtime/installations') return response;
+      throw new Error(`unexpected GET ${route}`);
+    });
+    return jest.fn(() => ({ get }));
+  };
+
+  test('returns null when COMMONLY_AGENT_TOKEN is not set', async () => {
+    const record = await bootstrapAgentRecordFromEnv({ name: 'smoke-agent', env: {} });
+    expect(record).toBeNull();
+  });
+
+  test('rejects a non-runtime token instead of sending it anywhere', async () => {
+    const factory = makeFactory();
+    await expect(bootstrapAgentRecordFromEnv({
+      name: 'smoke-agent',
+      env: { COMMONLY_AGENT_TOKEN: 'eyJhbGciOi-user-jwt' },
+      clientFactory: factory,
+    })).rejects.toThrow(/cm_agent_/);
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  test('synthesizes a full record from the installations endpoint + detected adapter', async () => {
+    const factory = makeFactory();
+    const record = await bootstrapAgentRecordFromEnv({
+      name: 'smoke-agent',
+      env: {
+        COMMONLY_AGENT_TOKEN: 'cm_agent_abc123',
+        COMMONLY_API_URL: 'https://api.example.test',
+      },
+      clientFactory: factory,
+      adapterRegistry: makeRegistry(),
+    });
+
+    expect(factory).toHaveBeenCalledWith({ instance: 'https://api.example.test', token: 'cm_agent_abc123' });
+    expect(record.agentName).toBe('smoke-agent');
+    expect(record.instanceId).toBe('default');
+    // podId prefers the real installation over the agent-admin DM row
+    expect(record.podId).toBe('pod-main');
+    expect(record.instanceUrl).toBe('https://api.example.test');
+    expect(record.runtimeToken).toBe('cm_agent_abc123');
+    expect(record.adapter).toBe('claude');
+    expect(record.workspacePath).toBeNull();
+    // environment matches what attach would have written for the same adapter
+    expect(record.environment.mcp[0].name).toBe('commonly');
+    expect(record.environment.mcp[0].env.COMMONLY_AGENT_TOKEN).toBe('${COMMONLY_AGENT_TOKEN}');
+  });
+
+  test('falls through the detect order when the first CLI is absent', async () => {
+    const record = await bootstrapAgentRecordFromEnv({
+      name: 'smoke-agent',
+      env: { COMMONLY_AGENT_TOKEN: 'cm_agent_abc123', COMMONLY_API_URL: 'https://api.example.test' },
+      clientFactory: makeFactory(),
+      adapterRegistry: makeRegistry({ claudeFound: false }),
+    });
+    expect(record.adapter).toBe('codex');
+  });
+
+  test('errors with install guidance when no CLI is on PATH', async () => {
+    await expect(bootstrapAgentRecordFromEnv({
+      name: 'smoke-agent',
+      env: { COMMONLY_AGENT_TOKEN: 'cm_agent_abc123', COMMONLY_API_URL: 'https://api.example.test' },
+      clientFactory: makeFactory(),
+      adapterRegistry: makeRegistry({ claudeFound: false, codexFound: false }),
+    })).rejects.toThrow(/No supported agent CLI found on PATH/);
+  });
+
+  test('honors --adapter override and validates it', async () => {
+    const record = await bootstrapAgentRecordFromEnv({
+      name: 'smoke-agent',
+      env: { COMMONLY_AGENT_TOKEN: 'cm_agent_abc123', COMMONLY_API_URL: 'https://api.example.test' },
+      clientFactory: makeFactory(),
+      adapterRegistry: makeRegistry(),
+      adapterOverride: 'codex',
+    });
+    expect(record.adapter).toBe('codex');
+
+    await expect(bootstrapAgentRecordFromEnv({
+      name: 'smoke-agent',
+      env: { COMMONLY_AGENT_TOKEN: 'cm_agent_abc123', COMMONLY_API_URL: 'https://api.example.test' },
+      clientFactory: makeFactory(),
+      adapterRegistry: makeRegistry(),
+      adapterOverride: 'gemini',
+    })).rejects.toThrow(/Unknown adapter 'gemini'/);
+  });
+
+  test("the token's identity wins over a mistyped CLI argument", async () => {
+    const log = jest.fn();
+    const record = await bootstrapAgentRecordFromEnv({
+      name: 'smoke-agnet',
+      env: { COMMONLY_AGENT_TOKEN: 'cm_agent_abc123', COMMONLY_API_URL: 'https://api.example.test' },
+      clientFactory: makeFactory(),
+      adapterRegistry: makeRegistry(),
+      log,
+    });
+    expect(record.agentName).toBe('smoke-agent');
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("token belongs to 'smoke-agent'"));
+  });
+
+  test('wraps identity-resolution failures with the URL and a copy hint', async () => {
+    const get = jest.fn(async () => { throw new Error('HTTP 401'); });
+    await expect(bootstrapAgentRecordFromEnv({
+      name: 'smoke-agent',
+      env: { COMMONLY_AGENT_TOKEN: 'cm_agent_abc123', COMMONLY_API_URL: 'https://api.example.test' },
+      clientFactory: () => ({ get }),
+      adapterRegistry: makeRegistry(),
+    })).rejects.toThrow(/against https:\/\/api\.example\.test: HTTP 401/);
   });
 });

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "Apache-2.0",
   "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
   "type": "module",

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -57,10 +57,12 @@ const tokenFile = (name) => join(tokensDir(), `${name}.json`);
 
 export const saveAgentToken = (name, record) => {
   if (!existsSync(tokensDir())) mkdirSync(tokensDir(), { recursive: true });
+  // mode applies on create only — the record carries a live cm_agent_* secret,
+  // same handling as performInit's .commonly-env.
   writeFileSync(
     tokenFile(name),
     JSON.stringify({ ...record, savedAt: new Date().toISOString() }, null, 2),
-    'utf8',
+    { encoding: 'utf8', mode: 0o600 },
   );
 };
 
@@ -77,6 +79,91 @@ export const loadAgentToken = (name) => {
 export const deleteAgentToken = (name) => {
   const file = tokenFile(name);
   if (existsSync(file)) rmSync(file);
+};
+
+// ── env-var bootstrap for `agent run` (#913) ────────────────────────────────
+// The BYO connect page hands a fresh user two env exports and
+// `commonly agent run <name>` — on a machine that has never run
+// `commonly agent attach`, so no token file exists and run used to dead-end.
+// The runtime token IS the identity: everything else in the record either
+// comes from `GET /api/agents/runtime/installations` (agentName, instanceId,
+// podId) or is a local fact (which CLI binary to wrap). Returns a record ready
+// for saveAgentToken, or null when COMMONLY_AGENT_TOKEN isn't set (caller
+// falls back to the attach hint).
+export const BOOTSTRAP_ADAPTER_DETECT_ORDER = ['claude', 'codex'];
+
+export const bootstrapAgentRecordFromEnv = async ({
+  name,
+  env = process.env,
+  clientFactory = createClient,
+  adapterRegistry = { getAdapter, listAdapterNames },
+  adapterOverride = null,
+  log = () => {},
+}) => {
+  const runtimeToken = (env.COMMONLY_AGENT_TOKEN || '').trim();
+  if (!runtimeToken) return null;
+  if (!runtimeToken.startsWith('cm_agent_')) {
+    throw new Error('COMMONLY_AGENT_TOKEN is set but is not a runtime token (expected cm_agent_… prefix).');
+  }
+  const instanceUrl = (env.COMMONLY_API_URL || '').trim() || resolveInstanceUrl(undefined);
+
+  let identity;
+  try {
+    identity = await clientFactory({ instance: instanceUrl, token: runtimeToken })
+      .get('/api/agents/runtime/installations');
+  } catch (err) {
+    throw new Error(
+      `Could not resolve the agent behind COMMONLY_AGENT_TOKEN against ${instanceUrl}: ${err.message}. `
+      + 'Check the token was copied whole and the URL matches the instance that issued it.',
+    );
+  }
+
+  const installs = Array.isArray(identity?.installations) ? identity.installations : [];
+  const primary = installs.find((i) => i.type === 'installation' && i.status === 'active')
+    || installs[0] || null;
+
+  // The adapter names a binary on THIS machine — the one fact the server
+  // cannot know. Explicit --adapter wins; otherwise probe the known CLIs.
+  let adapterName = adapterOverride;
+  if (adapterOverride) {
+    const adapter = adapterRegistry.getAdapter(adapterOverride);
+    if (!adapter) {
+      throw new Error(`Unknown adapter '${adapterOverride}'. Known: ${adapterRegistry.listAdapterNames().join(', ')}`);
+    }
+    if (!await adapter.detect()) {
+      throw new Error(`Adapter '${adapterOverride}' not found on PATH.`);
+    }
+  } else {
+    for (const candidate of BOOTSTRAP_ADAPTER_DETECT_ORDER) {
+      const adapter = adapterRegistry.getAdapter(candidate);
+      // eslint-disable-next-line no-await-in-loop
+      if (adapter && await adapter.detect()) { adapterName = candidate; break; }
+    }
+    if (!adapterName) {
+      throw new Error(
+        `No supported agent CLI found on PATH (looked for: ${BOOTSTRAP_ADAPTER_DETECT_ORDER.join(', ')}). `
+        + 'Install one, or pass --adapter <name>.',
+      );
+    }
+  }
+
+  // The token's identity wins over the CLI argument — a mistyped name must
+  // not fork a second identity for the same token.
+  const agentName = identity?.agentName || name;
+  if (String(agentName).toLowerCase() !== String(name).toLowerCase()) {
+    log(`token belongs to '${agentName}', not '${name}' — using the token's identity`);
+  }
+
+  return {
+    agentName,
+    instanceId: identity?.instanceId || primary?.instanceId || 'default',
+    podId: primary?.podId || null,
+    instanceUrl,
+    runtimeToken,
+    adapter: adapterName,
+    environment: buildDefaultEnvironment(adapterName),
+    workspacePath: null,
+  };
 };
 
 /**
@@ -1552,11 +1639,33 @@ Docs:
     .command('run <name>')
     .description('Run the local-CLI wrapper loop for an attached agent')
     .option('--interval <ms>', 'Poll interval in ms', '5000')
+    .option('--adapter <name>', 'CLI to wrap on first-run bootstrap (claude|codex); ignored when a token file already exists')
     .action(async (name, opts) => {
-      const record = loadAgentToken(name);
+      let record = loadAgentToken(name);
       if (!record) {
-        console.error(`No token for '${name}'. Run: commonly agent attach <adapter> --pod <podId> --name ${name}`);
-        process.exit(1);
+        // First run on this machine: the BYO connect page hands out env vars,
+        // not a token file — bootstrap the record from them (#913).
+        try {
+          record = await bootstrapAgentRecordFromEnv({
+            name,
+            adapterOverride: opts.adapter || null,
+            log: (line) => console.log(`[${name}] ${line}`),
+          });
+        } catch (err) {
+          console.error(err.message);
+          process.exit(1);
+        }
+        if (record) {
+          saveAgentToken(record.agentName, record);
+          console.log(`[${name}] bootstrapped ${tokenFile(record.agentName)} from COMMONLY_AGENT_TOKEN (adapter: ${record.adapter})`);
+        } else {
+          console.error(
+            `No token for '${name}'. Either export COMMONLY_API_URL + COMMONLY_AGENT_TOKEN`
+            + ` (shown on the Connect your own agent page) and re-run, or:`
+            + ` commonly agent attach <adapter> --pod <podId> --name ${name}`,
+          );
+          process.exit(1);
+        }
       }
 
       const adapter = getAdapter(record.adapter);

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -29,7 +29,10 @@ const DEFAULT_SCOPES = [
 ];
 const DEFAULT_AGENT_NAME = 'my-mcp-agent';
 const DEFAULT_POD_TYPE = 'chat';
-const CLI_INSTALL_COMMAND = 'npm i -g @commonlyai/cli';
+// @latest matters: `agent run` learned to bootstrap from these env vars in
+// 0.1.9 — a machine with an older global install must upgrade, not skip the
+// line because the binary already resolves.
+const CLI_INSTALL_COMMAND = 'npm i -g @commonlyai/cli@latest';
 const CLI_INIT_COMMAND = 'commonly agent init --name <n> --pod <podId>';
 const MEMORY_FILE_NAME = 'MEMORY.md';
 const CLAUDE_FILE_NAME = 'CLAUDE.md';
@@ -282,7 +285,7 @@ const V2AgentBYO: React.FC = () => {
   // previous screen, so first-time users hit "command not found" one step
   // after we stopped watching (#887 class).
   const listenSnippet = issued
-    ? `# first time on this machine: ${CLI_INSTALL_COMMAND}\nexport COMMONLY_API_URL=${apiUrl}\nexport COMMONLY_AGENT_TOKEN=${issued.token}\ncommonly agent run ${issued.agentName}`
+    ? `# install or update the CLI first: ${CLI_INSTALL_COMMAND}\nexport COMMONLY_API_URL=${apiUrl}\nexport COMMONLY_AGENT_TOKEN=${issued.token}\ncommonly agent run ${issued.agentName}`
     : '';
 
   const cursorSnippet = issued


### PR DESCRIPTION
Closes #913.

## What

The BYO connect page instructs: export `COMMONLY_API_URL` + `COMMONLY_AGENT_TOKEN`, then `commonly agent run <name>`. But `agent run` only ever read `~/.commonly/tokens/<name>.json` — written exclusively by `agent attach` — so every real self-serve user dead-ended on `No token for '<name>'`. This is the probable cause of the ~15 dead installs (token issued, never used).

Now, when the token file is absent and `COMMONLY_AGENT_TOKEN` is set, `agent run` bootstraps the record:

- identity (`agentName`, `instanceId`, `podId`) from `GET /api/agents/runtime/installations` — the runtime token is the identity, so a mistyped CLI name cannot fork a second local identity (the token's name wins, with a log line)
- adapter by probing PATH (`claude` → `codex`), overridable via new `--adapter` flag; actionable error when nothing is installed
- environment regenerated via the same `buildDefaultEnvironment` attach uses
- record persisted with `mode: 0600` (it carries a live `cm_agent_*` secret — `saveAgentToken` previously wrote world-readable; tightened for all callers)

CLI `0.1.8 → 0.1.9`. Page install line becomes `npm i -g @commonlyai/cli@latest` (an existing older global install must upgrade, not skip the line), and the snippet comment now says "install or update".

## Proof

- Live E2E: deleted the smoke agent's token file, exported only the two env vars, ran the source CLI → `bootstrapped ~/.commonly/tokens/smoke-guide-1786582346-agent.json from COMMONLY_AGENT_TOKEN (adapter: claude)` → polling; the BYO page checkmark flipped.
- `cli`: 282 tests passing locally (8 new bootstrap cases: env-absent, non-`cm_agent_` rejection before any network call, full synthesis, detect fall-through, no-CLI error, `--adapter` validation, identity-wins-over-argument, wrapped resolution errors).
- `frontend`: typecheck clean locally; jest runs in CI (its tier on this machine). The existing snippet-presence assertion still pins the install line.

## Ship note

The fix reaches users only when 0.1.9 is on npm — the page's instructions run against whatever `npm i -g` serves. Publish is a separate, deliberate step after merge (no publish workflow exists; it's a manual `npm publish` from `cli/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8