### PR TITLE
fix(shell): "No agent was notified" hint vs wake-on-message contradiction (#914)

### DIFF
--- a/backend/__tests__/unit/controllers/messageController.test.js
+++ b/backend/__tests__/unit/controllers/messageController.test.js
@@ -85,7 +85,9 @@ describe('messageController', () => {
       await messageController.createMessage(req, res);
       expect(res.json).toHaveBeenCalledWith({
         ...mockMessage,
-        agentDelivery: { enqueued: 0, implicit: [], agentsInPod: 2 },
+        agentDelivery: {
+          enqueued: 0, implicit: [], agentsInPod: 2, woken: 0,
+        },
       });
       expect(AgentMentionService.enqueueMentions).toHaveBeenCalled();
       expect(AgentMentionService.enqueueDmEvent).not.toHaveBeenCalled();
@@ -116,7 +118,35 @@ describe('messageController', () => {
       });
       expect(res.json).toHaveBeenCalledWith({
         ...mockMessage,
-        agentDelivery: { enqueued: 1, implicit: [], agentsInPod: 2 },
+        agentDelivery: {
+          enqueued: 1, implicit: [], agentsInPod: 2, woken: 0,
+        },
+      });
+    });
+
+    it('counts wake-on-message targets so the composer hint stays truthful (#914)', async () => {
+      const mockMessage = { id: 4, content: 'hello with no mention' };
+      Pod.findById.mockResolvedValue({ members: ['u1'], type: 'chat' });
+      PGMessage.create.mockResolvedValue(mockMessage);
+      // The Guide's wake-on-message path: nothing mention-enqueued, one woken.
+      AgentMentionService.enqueueMentions.mockResolvedValueOnce({
+        enqueued: [], implicit: [], skipped: [], woken: ['guide'],
+      });
+      AgentInstallation.countDocuments.mockResolvedValueOnce(1);
+      const req = {
+        params: { podId: 'p1' },
+        body: { content: 'hello with no mention' },
+        user: { id: 'u1', username: 'alice' },
+      };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await messageController.createMessage(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        ...mockMessage,
+        agentDelivery: {
+          enqueued: 0, implicit: [], agentsInPod: 1, woken: 1,
+        },
       });
     });
 

--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -266,7 +266,9 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
     // version of this rule.
     const isDmPod = pod.type === 'agent-admin' || pod.type === 'agent-room' || pod.type === 'agent-dm';
     let responseMessage: NormalizedMessage | (NormalizedMessage & {
-      agentDelivery: { enqueued: number; implicit: string[]; agentsInPod: number };
+      agentDelivery: {
+        enqueued: number; implicit: string[]; agentsInPod: number; woken: number;
+      };
     }) = message;
     if (isDmPod) {
       await AgentMentionService.enqueueDmEvent({ podId, message, userId, username });
@@ -292,6 +294,11 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
           enqueued: mentionResult.enqueued.length,
           implicit: mentionResult.implicit || [],
           agentsInPod,
+          // Wake-on-message targets (ADR-018 D8). Without this count the
+          // composer's "No agent was notified" hint fires in the one pod
+          // every new user starts in — while the Guide is already waking on
+          // the very same message (#914).
+          woken: mentionResult.woken?.length ?? 0,
         },
       };
     }

--- a/frontend/src/v2/__tests__/V2PodChatDeliveryHint.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatDeliveryHint.test.tsx
@@ -1,12 +1,13 @@
 // @ts-nocheck
 import React, { useState } from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import V2PodChat from '../components/V2PodChat';
 import { AuthContext } from '../../context/AuthContext';
 
+let mockSocketValue = { socket: null, connected: false };
 jest.mock('../../context/SocketContext', () => ({
-  useSocket: () => ({ socket: null, connected: false }),
+  useSocket: () => mockSocketValue,
 }));
 
 jest.mock('axios', () => {
@@ -30,6 +31,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   sessionStorage.clear();
+  mockSocketValue = { socket: null, connected: false };
 });
 
 const authValue = {
@@ -127,6 +129,9 @@ describe('V2PodChat agent delivery hint', () => {
 
   test.each([
     ['an agent was enqueued', { enqueued: 1, implicit: [], agentsInPod: 1 }],
+    ['a wake-on-message agent was woken (#914)', {
+      enqueued: 0, implicit: [], agentsInPod: 1, woken: 1,
+    }],
     ['the backend omits delivery metadata', undefined],
   ])('stays hidden when %s', async (_label, agentDelivery) => {
     const response = makeMessage('ordinary send', agentDelivery);
@@ -138,5 +143,33 @@ describe('V2PodChat agent delivery hint', () => {
     await screen.findByText('ordinary send');
 
     expect(screen.queryByText(/No agent was notified/i)).not.toBeInTheDocument();
+  });
+
+  test('clears the visible hint the moment an agent starts typing (#914)', async () => {
+    const handlers = {};
+    mockSocketValue = {
+      socket: {
+        on: (event, fn) => { handlers[event] = fn; },
+        off: jest.fn(),
+        emit: jest.fn(),
+      },
+      connected: true,
+    };
+    const response = makeMessage('hello room', {
+      enqueued: 0, implicit: [], agentsInPod: 1,
+    });
+    renderHarness(response);
+
+    sendDraft('hello room');
+    const hint = await screen.findByRole('status');
+    expect(hint).toHaveTextContent('No agent was notified');
+
+    act(() => {
+      handlers.agent_typing_start({ podId: 'pod-1', agentName: 'guide', displayName: 'Guide' });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/No agent was notified/i)).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -631,6 +631,9 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
       if (!payload || (payload.podId && payload.podId !== podId)) return;
       const agentName = payload.agentName || payload.username;
       if (!agentName) return;
+      // An agent typing in this pod falsifies "No agent was notified" — the
+      // hint must not sit above a landing reply (#914).
+      setAgentDeliveryHint(null);
       const key = keyFor({ agentName, instanceId: payload.instanceId });
       scheduleAutoStop(key);
       setTypingAgents((prev) => {
@@ -783,6 +786,10 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
         if (
           delivery
           && delivery.enqueued === 0
+          // A wake-on-message agent (the Guide in every fresh workspace) WAS
+          // notified — "No agent was notified" would be false on screen while
+          // it's already typing (#914).
+          && (delivery.woken ?? 0) === 0
           && delivery.agentsInPod > 0
           && mentionHandle
         ) {

--- a/frontend/src/v2/hooks/useV2PodDetail.ts
+++ b/frontend/src/v2/hooks/useV2PodDetail.ts
@@ -35,6 +35,8 @@ export interface V2Message {
     enqueued: number;
     implicit: string[];
     agentsInPod: number;
+    // Wake-on-message targets (#914). Optional: older backends omit it.
+    woken?: number;
   };
   // Sprint B5: per-message reactions, aggregated server-side.
   // Each entry is `{emoji, count, mine, users?}` — `users` is the


### PR DESCRIPTION
Closes #914.

Caught in the 2026-08-12 live smoke: sending a mention-less message in a fresh workspace rendered "No agent was notified — @mention one to get a reply. Try **@guide**" at the same moment "Guide is thinking…" appeared, and the banner stayed pinned above the Guide's landed reply.

Root cause: the hint keys on `agentDelivery.enqueued === 0` from the send response, but wake-on-message targets (ADR-018 D8) live in a separate `woken` list that `enqueueMentions` already returns and the controller never projected.

- **Backend**: `agentDelivery` gains `woken` (count). Additive — older clients ignore it, and the frontend treats it as optional for older backends.
- **Frontend**: hint additionally requires `woken === 0`; and an `agent_typing_start` for the current pod clears any visible hint, since typing falsifies the banner's claim no matter how the agent was reached.

Tests: controller envelope cases + new woken>0 case (backend unit tier green locally); hint suite gains woken-suppression and typing-clears-hint cases. Frontend jest runs in CI (its tier on this machine); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8