### PR TITLE
fix(shell): Your Team last-seen covers native + BYO runtimes, not just heartbeats (#915)

### DIFF
--- a/backend/__tests__/unit/routes/registry.pod-agents-activity.test.js
+++ b/backend/__tests__/unit/routes/registry.pod-agents-activity.test.js
@@ -1,0 +1,204 @@
+/**
+ * #915 — Your Team's "last seen" must cover every runtime class.
+ *
+ * `lastHeartbeatAt` derives from delivered heartbeat AgentEvents, which only
+ * gateway moltbots produce. Native agents (the Guide) run via AgentRun rows
+ * and BYO wrappers stamp runtime-token lastUsedAt — with heartbeats as the
+ * only source, the Guide's card read "Never connected" two minutes after it
+ * replied. The route now projects `lastActiveAt` = max(heartbeat, token use,
+ * AgentRun start) alongside the unchanged `lastHeartbeatAt`.
+ */
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.user = { id: 'user-1' };
+  req.userId = 'user-1';
+  next();
+});
+
+jest.mock('../../../middleware/adminAuth', () => (req, res, next) => next());
+
+jest.mock('../../../models/Pod', () => ({
+  findById: jest.fn(),
+}));
+
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentRegistry: {
+    find: jest.fn(),
+  },
+  AgentInstallation: {
+    getInstalledAgents: jest.fn(),
+  },
+}));
+
+jest.mock('../../../models/AgentProfile', () => ({
+  find: jest.fn(),
+}));
+jest.mock('../../../models/AgentTemplate', () => ({
+  find: jest.fn(),
+}));
+jest.mock('../../../models/AgentEvent', () => ({
+  aggregate: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../../../models/AgentRun', () => ({
+  aggregate: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../../models/User', () => ({
+  find: jest.fn().mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue([]),
+    }),
+  }),
+}));
+
+jest.mock('../../../services/dmService', () => ({
+  canViewPod: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('../../../services/agentIdentityService', () => ({
+  buildAgentUsername: jest.fn((agentName, instanceId) => `${agentName}-${instanceId}`),
+  default: {
+    getAgentTypeConfig: jest.fn().mockReturnValue(null),
+  },
+}));
+
+jest.mock('../../../routes/registry/presets', () => ({
+  PRESET_DEFINITIONS: [],
+  DEFAULT_BRANCH: 'main',
+}));
+
+const Pod = require('../../../models/Pod');
+const AgentProfile = require('../../../models/AgentProfile');
+const AgentTemplate = require('../../../models/AgentTemplate');
+const AgentEvent = require('../../../models/AgentEvent');
+const AgentRun = require('../../../models/AgentRun');
+const User = require('../../../models/User');
+const { AgentRegistry, AgentInstallation } = require('../../../models/AgentRegistry');
+const registryRoutes = require('../../../routes/registry');
+
+const app = express();
+app.use(express.json());
+app.use('/api/registry', registryRoutes);
+
+// Valid 24-hex id: the route casts podId to ObjectId for the AgentRun $match
+// (aggregation does not cast), and an invalid id would short-circuit the
+// lookup through its defensive catch.
+const POD_ID = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+
+const baseInstallation = (over = {}) => ({
+  agentName: 'guide',
+  instanceId: 'default',
+  displayName: 'Guide',
+  version: '1.0.0',
+  status: 'active',
+  scopes: [],
+  createdAt: new Date('2026-08-01T00:00:00.000Z'),
+  usage: {},
+  installedBy: 'user-1',
+  config: new Map(Object.entries({ runtime: { runtimeType: 'native' } })),
+  ...over,
+});
+
+const stubLeanChains = () => {
+  AgentRegistry.find.mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue([]),
+    }),
+  });
+  AgentProfile.find.mockReturnValue({
+    lean: jest.fn().mockResolvedValue([]),
+  });
+  AgentTemplate.find.mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue([]),
+    }),
+  });
+  Pod.findById.mockReturnValue({
+    lean: jest.fn().mockResolvedValue({
+      _id: POD_ID,
+      createdBy: 'user-1',
+      members: ['user-1'],
+    }),
+  });
+};
+
+describe('pod agents lastActiveAt derivation (#915)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stubLeanChains();
+  });
+
+  it('surfaces AgentRun activity for native agents with no heartbeats and no tokens', async () => {
+    AgentInstallation.getInstalledAgents.mockResolvedValue([baseInstallation()]);
+    AgentRun.aggregate.mockResolvedValue([
+      {
+        _id: { agentName: 'guide', instanceId: 'default' },
+        lastRunAt: new Date('2026-08-12T19:04:00.000Z'),
+      },
+    ]);
+
+    const res = await request(app).get(`/api/registry/pods/${POD_ID}/agents`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.agents).toHaveLength(1);
+    expect(res.body.agents[0].lastHeartbeatAt).toBeNull();
+    expect(res.body.agents[0].lastActiveAt).toBe('2026-08-12T19:04:00.000Z');
+  });
+
+  it('takes the max across heartbeat events and runtime-token use', async () => {
+    AgentInstallation.getInstalledAgents.mockResolvedValue([
+      baseInstallation({ agentName: 'my-byo', config: new Map() }),
+    ]);
+    AgentEvent.aggregate.mockResolvedValue([
+      {
+        _id: { agentName: 'my-byo', instanceId: 'default' },
+        lastHeartbeatAt: new Date('2026-08-10T00:00:00.000Z'),
+      },
+    ]);
+    User.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          {
+            username: 'my-byo-default',
+            agentRuntimeTokens: [
+              { lastUsedAt: new Date('2026-08-12T19:30:00.000Z') },
+              { lastUsedAt: new Date('2026-08-01T00:00:00.000Z') },
+            ],
+          },
+        ]),
+      }),
+    });
+
+    const res = await request(app).get(`/api/registry/pods/${POD_ID}/agents`);
+
+    expect(res.status).toBe(200);
+    // Heartbeat field stays what it always was; the new field takes the max.
+    expect(res.body.agents[0].lastHeartbeatAt).toBe('2026-08-10T00:00:00.000Z');
+    expect(res.body.agents[0].lastActiveAt).toBe('2026-08-12T19:30:00.000Z');
+  });
+
+  it('returns null lastActiveAt when no source has ever seen the agent', async () => {
+    AgentInstallation.getInstalledAgents.mockResolvedValue([
+      baseInstallation({ agentName: 'never-started', config: new Map() }),
+    ]);
+
+    const res = await request(app).get(`/api/registry/pods/${POD_ID}/agents`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.agents[0].lastActiveAt).toBeNull();
+    expect(res.body.agents[0].lastHeartbeatAt).toBeNull();
+  });
+
+  it('keeps the roster alive when the AgentRun lookup fails', async () => {
+    AgentInstallation.getInstalledAgents.mockResolvedValue([baseInstallation()]);
+    AgentRun.aggregate.mockRejectedValue(new Error('collection offline'));
+
+    const res = await request(app).get(`/api/registry/pods/${POD_ID}/agents`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.agents).toHaveLength(1);
+    expect(res.body.agents[0].lastActiveAt).toBeNull();
+  });
+});

--- a/backend/routes/registry/helpers.ts
+++ b/backend/routes/registry/helpers.ts
@@ -281,8 +281,11 @@ const buildAgentInstallationPayload = (installation: any, {
   profile = null,
   iconUrl = '',
   lastHeartbeatAt = null,
+  lastActiveAt = null,
   user = null,
-}: { profile?: any; iconUrl?: string; lastHeartbeatAt?: any; user?: any } = {}) => {
+}: {
+  profile?: any; iconUrl?: string; lastHeartbeatAt?: any; lastActiveAt?: any; user?: any;
+} = {}) => {
   if (!installation) return null;
   const normalizedConfig = normalizeConfigMap(installation.config);
   const runtimeConfig = sanitizeRuntimeConfig(
@@ -311,6 +314,11 @@ const buildAgentInstallationPayload = (installation: any, {
     scopes: installation.scopes,
     installedAt: installation.createdAt,
     lastHeartbeatAt,
+    // Latest proof of life across every runtime class: delivered heartbeat
+    // events (gateway moltbots), runtime-token use (BYO wrappers/MCP), and
+    // AgentRun starts (native). `lastHeartbeatAt` alone reads as "Never
+    // connected" for native agents that talked minutes ago (#915).
+    lastActiveAt: lastActiveAt || lastHeartbeatAt,
     usage: installation.usage,
     installedBy: installation.installedBy?.toString?.() || installation.installedBy,
     runtime: runtimeConfig,

--- a/backend/routes/registry/pod-agents.ts
+++ b/backend/routes/registry/pod-agents.ts
@@ -154,6 +154,37 @@ podAgentsRouter.get('/pods/:podId/agents', auth, async (req: any, res: any) => {
       heartbeatRows.map((r: any) => [`${r._id.agentName}:${r._id.instanceId}`, r.lastHeartbeatAt]),
     );
 
+    // Native agents never heartbeat and never use a runtime token — their
+    // proof of life is AgentRun rows. Same key shape as heartbeatMap; uses
+    // the { podId, agentName, instanceId, startedAt } index. Aggregation
+    // $match does not cast, so podId must be an ObjectId (#915).
+    let runRows: any[] = [];
+    try {
+      const AgentRun = require('../../models/AgentRun');
+      const mongoose = require('mongoose');
+      runRows = await AgentRun.aggregate([
+        {
+          $match: {
+            podId: new mongoose.Types.ObjectId(String(podId)),
+            agentName: { $in: installations.map((i: any) => i.agentName) },
+          },
+        },
+        { $sort: { startedAt: -1 } },
+        {
+          $group: {
+            _id: { agentName: '$agentName', instanceId: '$instanceId' },
+            lastRunAt: { $first: '$startedAt' },
+          },
+        },
+      ]);
+    } catch (runErr) {
+      // Activity enrichment is advisory — never fail the roster over it.
+      console.warn('[pod-agents] AgentRun activity lookup failed:', (runErr as Error).message);
+    }
+    const runMap = new Map(
+      runRows.map((r: any) => [`${r._id.agentName}:${r._id.instanceId || 'default'}`, r.lastRunAt]),
+    );
+
     const registryEntries = await AgentRegistry.find({
       agentName: { $in: installations.map((i: any) => i.agentName) },
     }).select('agentName iconUrl').lean();
@@ -206,7 +237,7 @@ podAgentsRouter.get('/pods/:podId/agents', auth, async (req: any, res: any) => {
     }
     const userRows = usernameSet.size > 0
       ? await User.find({ username: { $in: Array.from(usernameSet) } })
-        .select('username botMetadata')
+        .select('username botMetadata agentRuntimeTokens.lastUsedAt')
         .lean()
       : [];
     const userByUsername = new Map<string, any>(
@@ -222,10 +253,22 @@ podAgentsRouter.get('/pods/:podId/agents', auth, async (req: any, res: any) => {
         const instanceKey = `${i.agentName}:${i.instanceId || 'default'}`;
         const username = AgentIdentityService.buildAgentUsername(i.agentName, i.instanceId || 'default');
         const user = userByUsername.get(username) || null;
+        // Max across the three proof-of-life sources; each covers a runtime
+        // class the others miss (heartbeats: gateway; token use: BYO/MCP;
+        // runs: native).
+        const tokenTimes = (user?.agentRuntimeTokens || [])
+          .map((tok: any) => (tok?.lastUsedAt ? new Date(tok.lastUsedAt).getTime() : 0));
+        const candidates = [
+          heartbeatMap.get(instanceKey), runMap.get(instanceKey), ...tokenTimes,
+        ]
+          .map((v: any) => (v ? new Date(v).getTime() : 0))
+          .filter((v: number) => Number.isFinite(v) && v > 0);
+        const lastActiveAt = candidates.length > 0 ? new Date(Math.max(...candidates)) : null;
         return buildAgentInstallationPayload(i, {
           profile,
           iconUrl: templateIcon || iconMap.get(i.agentName) || '',
           lastHeartbeatAt: heartbeatMap.get(instanceKey) || null,
+          lastActiveAt,
           user,
         });
       }),

--- a/frontend/src/v2/__tests__/V2ConnectHonesty.test.ts
+++ b/frontend/src/v2/__tests__/V2ConnectHonesty.test.ts
@@ -57,6 +57,15 @@ describe('the connect flow states what it does not do', () => {
     expect(src).toMatch(/if \(!iso\) return t\('yourTeam\.activity\.neverConnected'\)/);
   });
 
+  test('Your Team derives last-seen from lastActiveAt, not heartbeats alone (#915)', () => {
+    const src = read('../components/V2YourTeamPage.tsx');
+    // Heartbeat-only derivation showed the native Guide as "Never connected"
+    // minutes after it replied. lastActiveAt (max across heartbeats, token
+    // use, AgentRuns) must be the primary source with heartbeat fallback.
+    expect(src).toMatch(/a\.lastActiveAt \?\? a\.lastHeartbeatAt/);
+    expect(src).toMatch(/formatRelative\(lastSeenIso\(a\), t\)/);
+  });
+
   test('the BYO page ships the command that makes an agent listen', () => {
     const src = read('../components/V2AgentBYO.tsx');
     expect(src).toMatch(/commonly agent run/);

--- a/frontend/src/v2/components/V2YourTeamPage.tsx
+++ b/frontend/src/v2/components/V2YourTeamPage.tsx
@@ -19,6 +19,9 @@ interface AgentInstallationSummary {
   status?: string;
   installedAt?: string;
   lastHeartbeatAt?: string | null;
+  // Max across heartbeats, runtime-token use, and native AgentRuns (#915).
+  // Older backends omit it — fall back to lastHeartbeatAt via lastSeenTime.
+  lastActiveAt?: string | null;
   runtime?: { runtimeType?: string; provider?: string } | null;
   category?: string | null;
   podId?: string;
@@ -46,9 +49,10 @@ const formatRelative = (
 ): string => {
   // An agent that has NEVER been seen is not the same as a quiet one, and
   // conflating them is how 13 unreachable installs sat in Your Team looking
-  // healthy. `lastHeartbeatAt` is derived from heartbeat events, so a BYO
-  // agent whose wrapper was never started has none at all — the user wired up
-  // MCP, saw the agent appear here, @mentioned it, and got silence (#887).
+  // healthy (#887). Callers pass lastSeenIso() — the max across heartbeat
+  // events, runtime-token use, and native AgentRuns — because any single
+  // source lies for the runtime classes it doesn't cover: heartbeat-only
+  // showed the Guide as "Never connected" minutes after it replied (#915).
   if (!iso) return t('yourTeam.activity.neverConnected');
   const ms = Date.now() - new Date(iso).getTime();
   if (Number.isNaN(ms)) return t('yourTeam.activity.noRecent');
@@ -61,6 +65,14 @@ const formatRelative = (
   return t('yourTeam.activity.daysAgo', { count: d });
 };
 
+const lastSeenIso = (a: AgentInstallationSummary): string | null =>
+  a.lastActiveAt ?? a.lastHeartbeatAt ?? null;
+
+const lastSeenTime = (a: AgentInstallationSummary): number => {
+  const iso = lastSeenIso(a);
+  return iso ? new Date(iso).getTime() : 0;
+};
+
 const dedupeAgents = (agents: AgentInstallationSummary[]): AgentInstallationSummary[] => {
   const seen = new Map<string, AgentInstallationSummary>();
   for (const a of agents) {
@@ -70,9 +82,7 @@ const dedupeAgents = (agents: AgentInstallationSummary[]): AgentInstallationSumm
       seen.set(key, a);
       continue;
     }
-    const prev = existing.lastHeartbeatAt ? new Date(existing.lastHeartbeatAt).getTime() : 0;
-    const next = a.lastHeartbeatAt ? new Date(a.lastHeartbeatAt).getTime() : 0;
-    if (next > prev) seen.set(key, a);
+    if (lastSeenTime(a) > lastSeenTime(existing)) seen.set(key, a);
   }
   return Array.from(seen.values());
 };
@@ -181,11 +191,7 @@ const V2YourTeamPage: React.FC = () => {
   }, []);
 
   const sortedAgents = useMemo(() => {
-    return [...agents].sort((a, b) => {
-      const ta = a.lastHeartbeatAt ? new Date(a.lastHeartbeatAt).getTime() : 0;
-      const tb = b.lastHeartbeatAt ? new Date(b.lastHeartbeatAt).getTime() : 0;
-      return tb - ta;
-    });
+    return [...agents].sort((a, b) => lastSeenTime(b) - lastSeenTime(a));
   }, [agents]);
 
   // Available categories — derived from loaded agents. Order: deterministic
@@ -363,7 +369,7 @@ const V2YourTeamPage: React.FC = () => {
           const display = a.displayName || a.name;
           const podLabel = a.podName || t('yourTeam.untitledProject');
           const runtimeLabel = formatRuntime(a, t);
-          const lastSeen = formatRelative(a.lastHeartbeatAt, t);
+          const lastSeen = formatRelative(lastSeenIso(a), t);
           const cardKey = `${a.name}:${a.instanceId}`;
           const isOpening = opening === cardKey;
           const onCardClick = () => {


### PR DESCRIPTION
Closes #915.

From the 2026-08-12 smoke: the Your Team card showed **"Never connected"** for the Guide two minutes after it answered a message — the card's only source was delivered-heartbeat `AgentEvent`s, which native agents (AgentRun rows) and BYO wrappers (runtime-token `lastUsedAt`) never produce.

- **Backend** (`/api/registry/pods/:podId/agents`): additive `lastActiveAt` = max(delivered heartbeat, runtime-token `lastUsedAt`, `AgentRun.startedAt`). `lastHeartbeatAt` unchanged for existing consumers. AgentRun lookup failure degrades to old behavior (roster never fails over enrichment); `$match` gets a real ObjectId since aggregation doesn't cast.
- **Frontend** (Your Team): sorts, dedupes, and renders from `lastActiveAt ?? lastHeartbeatAt`.

This is #891 (agent status honesty) surface 2 — same derivation family the composer/typeahead got in #910.

Tests: 4 new route cases (native-run-only, max-across-sources, never-seen, lookup-failure) green locally; connect-honesty presence test pins the frontend derivation; typecheck clean. Frontend jest runs in CI (its tier on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8