### PR TITLE
fix(onboarding): kernel-driven starter-task completion + inspector/board consistency (#916)

### DIFF
--- a/backend/__tests__/unit/middleware/agentRuntimeAuth.test.js
+++ b/backend/__tests__/unit/middleware/agentRuntimeAuth.test.js
@@ -14,13 +14,20 @@ const mockSecret = { hash: jest.fn(), randomSecret: jest.fn() };
 jest.mock('../../../utils/secret', () => mockSecret);
 
 const mockUserFindOne = jest.fn();
+const mockUserUpdateOne = jest.fn();
 const mockInstallationFindOne = jest.fn();
 const mockInstallationFind = jest.fn();
 const mockInstallationUpdateOne = jest.fn();
+const mockCompleteStarterTask = jest.fn();
+
+jest.mock('../../../services/starterTaskService', () => ({
+  completeConnectAgentStarterTask: (...args) => mockCompleteStarterTask(...args),
+}));
 
 jest.mock('../../../models/User', () => {
   function User() {}
   User.findOne = (...args) => mockUserFindOne(...args);
+  User.updateOne = (...args) => mockUserUpdateOne(...args);
   return User;
 });
 jest.mock('../../../models/AgentRegistry', () => ({
@@ -54,9 +61,13 @@ beforeEach(() => {
   mockSecret.hash.mockReset();
   mockSecret.hash.mockReturnValue('hashed-token');
   mockUserFindOne.mockReset();
+  mockUserUpdateOne.mockReset();
+  mockUserUpdateOne.mockResolvedValue({});
   mockInstallationFindOne.mockReset();
   mockInstallationFind.mockReset();
   mockInstallationUpdateOne.mockReset();
+  mockCompleteStarterTask.mockReset();
+  mockCompleteStarterTask.mockResolvedValue(undefined);
 });
 
 describe('agentRuntimeAuth path 2 (install-bound token) — #66 fix', () => {
@@ -95,6 +106,71 @@ describe('agentRuntimeAuth path 2 (install-bound token) — #66 fix', () => {
     expect(req.agentAuthorizedPodIds).toEqual(['pod-a', 'pod-b']);
     expect(req.agentInstallation).toBe(matchedInstall);
     expect(next).toHaveBeenCalled();
+    // The matched token had no lastUsedAt → first-ever use → the
+    // connect-agent starter task fires for every authorized pod (#916).
+    expect(mockCompleteStarterTask).toHaveBeenCalledWith({
+      podIds: ['pod-a', 'pod-b'],
+      agentLabel: 'codex',
+    });
+  });
+
+  test('does not fire the starter hook when the token was used before (#916)', async () => {
+    mockUserFindOne.mockResolvedValue(null);
+    mockInstallationFindOne.mockResolvedValue({
+      _id: 'install-a',
+      agentName: 'codex',
+      instanceId: 'cody',
+      podId: { toString: () => 'pod-a' },
+      runtimeTokens: [{ tokenHash: 'hashed-token', lastUsedAt: new Date('2026-08-01T00:00:00Z') }],
+    });
+    mockInstallationFind.mockResolvedValue([]);
+    mockInstallationUpdateOne.mockResolvedValue({});
+
+    await agentRuntimeAuth(buildReq('cm_agent_test'), buildRes(), jest.fn());
+
+    expect(mockCompleteStarterTask).not.toHaveBeenCalled();
+  });
+});
+
+describe('agentRuntimeAuth path 1 (User-row token) — first-use starter hook (#916)', () => {
+  const buildAgentUser = (lastUsedAt) => ({
+    _id: 'bot-user-1',
+    username: 'my-byo-agent',
+    isBot: true,
+    botMetadata: { agentName: 'my-byo-agent', instanceId: 'default', displayName: 'My BYO Agent' },
+    agentRuntimeTokens: [{ tokenHash: 'hashed-token', ...(lastUsedAt ? { lastUsedAt } : {}) }],
+  });
+
+  test('fires once, with the installation podIds and the display label', async () => {
+    mockUserFindOne.mockResolvedValue(buildAgentUser(null));
+    mockInstallationFind.mockReturnValue({
+      lean: async () => [
+        { podId: { toString: () => 'pod-workspace' }, status: 'active' },
+      ],
+    });
+
+    const req = buildReq('cm_agent_test');
+    const next = jest.fn();
+    await agentRuntimeAuth(req, buildRes(), next);
+
+    expect(next).toHaveBeenCalled();
+    expect(mockCompleteStarterTask).toHaveBeenCalledWith({
+      podIds: ['pod-workspace'],
+      agentLabel: 'My BYO Agent',
+    });
+  });
+
+  test('stays silent on every subsequent authentication', async () => {
+    mockUserFindOne.mockResolvedValue(buildAgentUser(new Date('2026-08-12T00:00:00Z')));
+    mockInstallationFind.mockReturnValue({
+      lean: async () => [
+        { podId: { toString: () => 'pod-workspace' }, status: 'active' },
+      ],
+    });
+
+    await agentRuntimeAuth(buildReq('cm_agent_test'), buildRes(), jest.fn());
+
+    expect(mockCompleteStarterTask).not.toHaveBeenCalled();
   });
 
   test('returns 401 when token doesnt match any install OR user', async () => {

--- a/backend/__tests__/unit/services/starterTaskService.test.js
+++ b/backend/__tests__/unit/services/starterTaskService.test.js
@@ -1,0 +1,93 @@
+/**
+ * #916 — completeConnectAgentStarterTask contract:
+ *  - targets ONLY the seeded connect-agent starter (sourceRef match), never
+ *    tasks by title or positional taskId
+ *  - only pending/claimed flip; an already-done card is left alone
+ *  - emits task_updated so the live board and inspector refresh
+ *  - dedups pod ids, skips falsy ones, and never throws (fire-and-forget
+ *    from the auth path — a board write must not fail a request)
+ */
+
+const mockFindOneAndUpdate = jest.fn();
+jest.mock('../../../models/Task', () => ({
+  findOneAndUpdate: (...args) => mockFindOneAndUpdate(...args),
+}));
+
+const mockEmitTaskUpdated = jest.fn();
+jest.mock('../../../services/taskEventService', () => ({
+  emitTaskUpdated: (...args) => mockEmitTaskUpdated(...args),
+}));
+
+const {
+  completeConnectAgentStarterTask,
+  CONNECT_AGENT_SOURCE_REF,
+} = require('../../../services/starterTaskService');
+
+const POD_A = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+const POD_B = 'bbbbbbbbbbbbbbbbbbbbbbbb';
+
+beforeEach(() => {
+  mockFindOneAndUpdate.mockReset();
+  mockEmitTaskUpdated.mockReset();
+});
+
+describe('completeConnectAgentStarterTask', () => {
+  test('completes the seeded starter by sourceRef and emits task_updated', async () => {
+    const updatedTask = { taskId: 'TASK-001', status: 'done' };
+    mockFindOneAndUpdate.mockResolvedValue(updatedTask);
+
+    await completeConnectAgentStarterTask({ podIds: [POD_A], agentLabel: 'My BYO Agent' });
+
+    expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(1);
+    const [filter, update] = mockFindOneAndUpdate.mock.calls[0];
+    expect(String(filter.podId)).toBe(POD_A);
+    expect(filter.sourceRef).toBe(CONNECT_AGENT_SOURCE_REF);
+    // Never resurrect a done/blocked card — only the untouched states flip.
+    expect(filter.status).toEqual({ $in: ['pending', 'claimed'] });
+    expect(update.$set.status).toBe('done');
+    expect(update.$set.completedAt).toBeInstanceOf(Date);
+    expect(update.$push.updates.text).toContain('My BYO Agent');
+    expect(mockEmitTaskUpdated).toHaveBeenCalledWith(POD_A, updatedTask, 'updated');
+  });
+
+  test('does not emit when no starter task matched', async () => {
+    mockFindOneAndUpdate.mockResolvedValue(null);
+
+    await completeConnectAgentStarterTask({ podIds: [POD_A], agentLabel: 'agent' });
+
+    expect(mockEmitTaskUpdated).not.toHaveBeenCalled();
+  });
+
+  test('dedups pod ids and skips falsy entries', async () => {
+    mockFindOneAndUpdate.mockResolvedValue(null);
+
+    await completeConnectAgentStarterTask({
+      podIds: [POD_A, POD_A, null, undefined, POD_B],
+      agentLabel: 'agent',
+    });
+
+    expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  test('never throws — a failing write is contained per pod', async () => {
+    mockFindOneAndUpdate
+      .mockRejectedValueOnce(new Error('mongo down'))
+      .mockResolvedValueOnce({ taskId: 'TASK-001', status: 'done' });
+
+    await expect(completeConnectAgentStarterTask({
+      podIds: [POD_A, POD_B],
+      agentLabel: 'agent',
+    })).resolves.toBeUndefined();
+
+    // The second pod still completed despite the first failing.
+    expect(mockEmitTaskUpdated).toHaveBeenCalledTimes(1);
+  });
+
+  test('an invalid pod id is contained too', async () => {
+    await expect(completeConnectAgentStarterTask({
+      podIds: ['not-a-hex-id'],
+      agentLabel: 'agent',
+    })).resolves.toBeUndefined();
+    expect(mockEmitTaskUpdated).not.toHaveBeenCalled();
+  });
+});

--- a/backend/middleware/agentRuntimeAuth.ts
+++ b/backend/middleware/agentRuntimeAuth.ts
@@ -68,6 +68,10 @@ export default async function agentRuntimeAuth(req: Request, res: Response, next
       if (tokenRecord?.expiresAt && tokenRecord.expiresAt < new Date()) {
         return res.status(401).json({ message: 'Session token expired' });
       }
+      // Pre-update value: a token with no lastUsedAt is authenticating for
+      // the very first time — the #909 verified-listening moment. Observed
+      // once per token; drives the connect-agent starter task below (#916).
+      const isFirstTokenUse = !tokenRecord?.lastUsedAt;
 
       try {
         await User.updateOne(
@@ -100,6 +104,15 @@ export default async function agentRuntimeAuth(req: Request, res: Response, next
       req.agentInstallations = installations as never[];
       req.agentAuthorizedPodIds = authorizedPodIds;
       req.agentInstallation = (installations[0] as never) || null;
+
+      if (isFirstTokenUse) {
+        // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+        const { completeConnectAgentStarterTask } = require('../services/starterTaskService');
+        void completeConnectAgentStarterTask({
+          podIds: installationPodIds,
+          agentLabel: agentUser.botMetadata?.displayName || agentName,
+        });
+      }
       return next();
     }
 
@@ -111,6 +124,11 @@ export default async function agentRuntimeAuth(req: Request, res: Response, next
     if (!installation) {
       return res.status(401).json({ message: 'Invalid agent token' });
     }
+
+    // Same first-use observation as the User-token path above (#916).
+    const legacyTokenRecord = (installation.runtimeTokens || [])
+      .find((t: { tokenHash?: string }) => t.tokenHash === tokenHash);
+    const isFirstLegacyTokenUse = !legacyTokenRecord?.lastUsedAt;
 
     try {
       await AgentInstallation.updateOne(
@@ -142,6 +160,15 @@ export default async function agentRuntimeAuth(req: Request, res: Response, next
     req.agentAuthorizedPodIds = allActiveInstallations
       .map((inst: { podId?: { toString: () => string } }) => inst?.podId?.toString())
       .filter(Boolean) as string[];
+
+    if (isFirstLegacyTokenUse) {
+      // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+      const { completeConnectAgentStarterTask } = require('../services/starterTaskService');
+      void completeConnectAgentStarterTask({
+        podIds: req.agentAuthorizedPodIds,
+        agentLabel: installation.displayName || installation.agentName,
+      });
+    }
 
     // Also resolve and attach the bot User so downstream routes that derive
     // `req.agentUser._id` (file-upload uploaderId, message authorship) work

--- a/backend/services/agentWebSocketService.ts
+++ b/backend/services/agentWebSocketService.ts
@@ -71,6 +71,7 @@ interface InstallationDoc {
   instanceId?: string;
   podId?: unknown;
   status?: string;
+  displayName?: string;
   runtimeTokens?: Array<{ tokenHash: string; lastUsedAt?: Date }>;
 }
 
@@ -309,6 +310,13 @@ class AgentWebSocketService {
         }) as AgentUserDoc | null;
 
         if (agentUser) {
+          // Pre-update: no lastUsedAt = first-ever authentication. The WS
+          // transport stamps the same field the HTTP middleware does, so
+          // skipping the hook here would swallow the first-use signal for
+          // WS-first agents permanently (#916).
+          const wsTokenRecord = (agentUser.agentRuntimeTokens || [])
+            .find((t: { tokenHash?: string; lastUsedAt?: Date }) => t.tokenHash === tokenHash);
+          const isFirstTokenUse = !wsTokenRecord?.lastUsedAt;
           try {
             await User.updateOne(
               { _id: agentUser._id, 'agentRuntimeTokens.tokenHash': tokenHash },
@@ -321,6 +329,22 @@ class AgentWebSocketService {
           const { agentName, instanceId } = resolveTokenAgentIdentity(agentUser);
 
           if (agentName) {
+            if (isFirstTokenUse) {
+              try {
+                const installs = await AgentInstallation.find({
+                  agentName, instanceId, status: 'active',
+                }).select('podId').lean() as Array<{ podId?: { toString: () => string } }>;
+                // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+                const { completeConnectAgentStarterTask } = require('./starterTaskService');
+                void completeConnectAgentStarterTask({
+                  podIds: installs.map((i) => i?.podId?.toString()),
+                  agentLabel: (agentUser as { botMetadata?: { displayName?: string } })
+                    .botMetadata?.displayName || agentName,
+                });
+              } catch (starterErr) {
+                console.warn('[agent-ws] starter-task hook failed:', (starterErr as Error).message);
+              }
+            }
             return { agentName, instanceId, agentUserId: String(agentUser._id || '') };
           }
         }
@@ -331,6 +355,9 @@ class AgentWebSocketService {
         }) as InstallationDoc | null;
 
         if (installation) {
+          const wsInstallTokenRecord = (installation.runtimeTokens || [])
+            .find((t: { tokenHash?: string; lastUsedAt?: Date }) => t.tokenHash === tokenHash);
+          const isFirstLegacyUse = !wsInstallTokenRecord?.lastUsedAt;
           try {
             await AgentInstallation.updateOne(
               { _id: installation._id, 'runtimeTokens.tokenHash': tokenHash },
@@ -338,6 +365,19 @@ class AgentWebSocketService {
             );
           } catch (err) {
             console.warn('Failed to update agent token usage:', (err as Error).message);
+          }
+
+          if (isFirstLegacyUse) {
+            try {
+              // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+              const { completeConnectAgentStarterTask } = require('./starterTaskService');
+              void completeConnectAgentStarterTask({
+                podIds: [installation.podId ? String(installation.podId) : null],
+                agentLabel: installation.displayName || installation.agentName,
+              });
+            } catch (starterErr) {
+              console.warn('[agent-ws] starter-task hook failed:', (starterErr as Error).message);
+            }
           }
 
           return {

--- a/backend/services/starterTaskService.ts
+++ b/backend/services/starterTaskService.ts
@@ -1,0 +1,66 @@
+/**
+ * starterTaskService — #916
+ *
+ * The signup flow seeds three starter tasks (authController.
+ * createDefaultWorkspacePod), identified by stable sourceRef keys. TASK-001
+ * "Connect your first agent" describes an event the kernel can observe
+ * directly: a BYO runtime token authenticating for the first time (#909's
+ * verified-listening moment). Completing the card from that fact keeps the
+ * board honest — before this, the Guide would narrate "that's your first
+ * starter task done" while the card sat in Pending forever.
+ *
+ * Caller contract: fire-and-forget from the token-auth first-use paths
+ * (agentRuntimeAuth HTTP + agentWebSocketService WS). Never throws; a board
+ * write must not be able to fail an auth request.
+ */
+import mongoose from 'mongoose';
+import Task from '../models/Task';
+
+// eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+const { emitTaskUpdated } = require('./taskEventService');
+
+export const CONNECT_AGENT_SOURCE_REF = 'onboarding:connect-agent';
+
+export const completeConnectAgentStarterTask = async ({
+  podIds,
+  agentLabel,
+}: {
+  podIds: Array<string | undefined | null>;
+  agentLabel: string;
+}): Promise<void> => {
+  const uniquePodIds = Array.from(new Set((podIds || []).filter(Boolean).map(String)));
+  for (const podId of uniquePodIds) {
+    try {
+      const task = await Task.findOneAndUpdate(
+        {
+          podId: mongoose.Types.ObjectId.createFromHexString(podId),
+          sourceRef: CONNECT_AGENT_SOURCE_REF,
+          status: { $in: ['pending', 'claimed'] },
+        },
+        {
+          $set: { status: 'done', completedAt: new Date() },
+          $push: {
+            updates: {
+              text: `Completed automatically — ${agentLabel} connected and is listening`,
+              author: 'system',
+              authorId: null,
+              createdAt: new Date(),
+            },
+          },
+        },
+        { new: true },
+      );
+      if (task) emitTaskUpdated(podId, task, 'updated');
+    } catch (err) {
+      console.warn(
+        `[starter-task] connect-agent auto-complete failed for pod ${podId}:`,
+        (err as Error).message,
+      );
+    }
+  }
+};
+
+export default { CONNECT_AGENT_SOURCE_REF, completeConnectAgentStarterTask };
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -823,6 +823,8 @@
     },
     "runState": {
       "title": "Run state",
+      "pending": "Pending",
+      "pendingCount": "{{count}} pending",
       "blocked": "Blocked",
       "blockedCount": "{{count}} blocked",
       "inProgress": "In Progress",
@@ -836,6 +838,7 @@
     "taskPill": {
       "done": "Done",
       "blocked": "Blocked",
+      "pending": "Pending",
       "active": "Active"
     },
     "detail": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -820,6 +820,8 @@
     },
     "runState": {
       "title": "运行状态",
+      "pending": "待处理",
+      "pendingCount": "{{count}} 个待处理",
       "blocked": "受阻",
       "blockedCount": "{{count}} 个受阻",
       "inProgress": "进行中",
@@ -833,6 +835,7 @@
     "taskPill": {
       "done": "已完成",
       "blocked": "受阻",
+      "pending": "待处理",
       "active": "进行中"
     },
     "detail": {

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -8,6 +8,7 @@ import { UseV2PodDetailResult, V2Agent } from '../hooks/useV2PodDetail';
 import { UseV2PodsResult } from '../hooks/useV2Pods';
 import { useV2Api } from '../hooks/useV2Api';
 import { useAuth } from '../../context/AuthContext';
+import { useSocket } from '../../context/SocketContext';
 import { getSignedAttachmentUrl } from '../../utils/signedAttachmentUrl';
 import getApiBaseUrl from '../../utils/apiBaseUrl';
 import type { InspectorView } from './V2Layout';
@@ -799,6 +800,23 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   const [agentTasks, setAgentTasks] = useState<AgentTaskMap>({});
   const [runState, setRunState] = useState<RunStateCounts>({ blocked: 0, inProgress: 0, complete: 0, pending: 0 });
   const [recentTasks, setRecentTasks] = useState<TaskItem[]>([]);
+  // Bumped by task_updated socket events so the tab count / run state /
+  // recent list track the board live. Without it, tasks fetched once per
+  // pod-open — a task created mid-conversation ("it's task #4") sat next to
+  // a tab still saying "Tasks 3" until a full reload (#916).
+  const [taskRefresh, setTaskRefresh] = useState(0);
+  const { socket, connected } = useSocket();
+
+  useEffect(() => {
+    const podId = pod?._id;
+    if (!podId || !socket || !connected) return undefined;
+    const onTaskUpdated = (payload: { podId?: string } | null) => {
+      if (!payload || (payload.podId && payload.podId !== podId)) return;
+      setTaskRefresh((n) => n + 1);
+    };
+    socket.on('task_updated', onTaskUpdated);
+    return () => { socket.off('task_updated', onTaskUpdated); };
+  }, [pod?._id, socket, connected]);
   const [privateError, setPrivateError] = useState<string | null>(null);
   // ADR-001 §3.10 + Sprint B1: agent-DM pods involving the currently-inspected
   // agent. Surfaces clickable links so humans can observe agent↔agent
@@ -960,7 +978,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
       }
     })();
     return () => { cancelled = true; };
-  }, [pod?._id, agents, api]);
+  }, [pod?._id, agents, api, taskRefresh]);
 
   useEffect(() => {
     const podId = pod?._id;
@@ -1384,14 +1402,22 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
   const runStateSection = (
     <section className="v2-inspector__section">
       <div className="v2-inspector__section-title">{t('inspector.runState.title')}</div>
+      {/* Same four buckets, same order, as the board's columns — the two
+          surfaces sit one click apart, and folding `pending` into "In
+          Progress" here read as "3 in progress" beside a board showing the
+          same three tasks as Pending (#916). */}
       <div className="v2-inspector__runstate">
+        <div className="v2-inspector__runstate-row">
+          <span className="v2-inspector__runstate-label">{t('inspector.runState.pendingCount', { count: runState.pending })}</span>
+          <span className="v2-inspector__pill v2-inspector__pill--progress">{t('inspector.runState.pending')}</span>
+        </div>
+        <div className="v2-inspector__runstate-row">
+          <span className="v2-inspector__runstate-label">{t('inspector.runState.inProgressCount', { count: runState.inProgress })}</span>
+          <span className="v2-inspector__pill v2-inspector__pill--progress">{t('inspector.runState.inProgress')}</span>
+        </div>
         <div className="v2-inspector__runstate-row">
           <span className="v2-inspector__runstate-label">{t('inspector.runState.blockedCount', { count: runState.blocked })}</span>
           <span className="v2-inspector__pill v2-inspector__pill--blocked">{t('inspector.runState.blocked')}</span>
-        </div>
-        <div className="v2-inspector__runstate-row">
-          <span className="v2-inspector__runstate-label">{t('inspector.runState.inProgressCount', { count: runState.inProgress + runState.pending })}</span>
-          <span className="v2-inspector__pill v2-inspector__pill--progress">{t('inspector.runState.inProgress')}</span>
         </div>
         <div className="v2-inspector__runstate-row">
           <span className="v2-inspector__runstate-label">{t('inspector.runState.completeCount', { count: runState.complete })}</span>
@@ -1418,12 +1444,21 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
               {recentTasks.map((task) => {
                 const isDone = task.status === 'done' || task.status === 'completed';
                 const isBlocked = task.status === 'blocked';
+                const isPending = task.status === 'pending';
                 const pillClass = isDone
                   ? TASK_PILL_CLASS.complete
                   : isBlocked
                     ? TASK_PILL_CLASS.blocked
                     : TASK_PILL_CLASS.progress;
-                const pillLabel = isDone ? t('inspector.taskPill.done') : isBlocked ? t('inspector.taskPill.blocked') : t('inspector.taskPill.active');
+                // A pending task labelled "Active" was the third distinct
+                // status mapping on this rail (#916) — say what the board says.
+                const pillLabel = isDone
+                  ? t('inspector.taskPill.done')
+                  : isBlocked
+                    ? t('inspector.taskPill.blocked')
+                    : isPending
+                      ? t('inspector.taskPill.pending')
+                      : t('inspector.taskPill.active');
                 const assignee = task.assignee ? `@${task.assignee}` : null;
                 return (
                   <div key={task.taskId} className="v2-inspector__task-row">


### PR DESCRIPTION
Closes #916.

Three claim-vs-state drifts on the first-workspace board, caught in the 2026-08-12 smoke:

1. **TASK-001 completes from the kernel fact, not narration.** The Guide said "that's your first starter task done" while the card sat Pending. Now the first-ever authentication of a BYO runtime token (the same moment #909's checkmark keys on) auto-completes the seeded card — matched by `sourceRef: onboarding:connect-agent`, only `pending/claimed` flip, system update line, `task_updated` emitted. Hooked at both `agentRuntimeAuth` paths **and** the WS transport (it stamps the same `lastUsedAt`, so skipping it would swallow the first-use signal for WS-first agents permanently). Fire-and-forget; a board write can never fail auth.
2. **Inspector goes live.** It now subscribes to `task_updated` (emitted by every task write; previously only the v1 board listened) — no more "Tasks 3" beside a chat message announcing task #4.
3. **One status vocabulary.** Run state shows the board's four buckets in the board's order (pending un-folded from "In Progress"), and the recent-task pill says "Pending" rather than "Active". en + zh.

Tests: 5 service-contract cases + 3 middleware first-use cases green locally; typecheck clean; frontend jest runs in CI (its tier on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8