### PR TITLE
fix(tasks): status vocabulary gate at PATCH + alias-tolerant board columns

### DIFF
--- a/backend/__tests__/unit/routes/tasksApi.status-vocabulary.test.js
+++ b/backend/__tests__/unit/routes/tasksApi.status-vocabulary.test.js
@@ -1,0 +1,113 @@
+/**
+ * Task status vocabulary at the PATCH gate.
+ *
+ * findOneAndUpdate bypasses the schema enum validator, so PATCH is the only
+ * thing standing between a caller's status string and the DB. Agent callers
+ * write LLM-natural names (in_progress, completed) — unvalidated, those
+ * landed in Mongo and the v1 board rendered the task in NO column while the
+ * header still counted it. Aliases normalize; unknown values 400 with a
+ * message that teaches the vocabulary.
+ */
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.userId = 'u1';
+  req.user = { id: 'u1', _id: 'u1' };
+  next();
+});
+jest.mock('../../../middleware/agentRuntimeAuth', () => (req, res, next) => next());
+
+jest.mock('../../../models/Pod', () => ({
+  findById: jest.fn(() => ({
+    lean: jest.fn().mockResolvedValue({
+      type: 'chat',
+      members: [{ toString: () => 'u1' }],
+    }),
+  })),
+}));
+
+const mockFindOneAndUpdate = jest.fn();
+jest.mock('../../../models/Task', () => ({
+  findOneAndUpdate: (...args) => mockFindOneAndUpdate(...args),
+  findOne: jest.fn(),
+  find: jest.fn(),
+}));
+
+jest.mock('../../../models/User', () => ({
+  findById: jest.fn(() => ({
+    select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue({ username: 'alice' }) })),
+  })),
+}));
+
+jest.mock('../../../services/githubAppService', () => ({
+  isPatConfigured: jest.fn(() => false),
+}));
+
+const mockEmitTaskUpdated = jest.fn();
+jest.mock('../../../services/taskEventService', () => ({
+  emitTaskUpdated: (...args) => mockEmitTaskUpdated(...args),
+}));
+
+const tasksApi = require('../../../routes/tasksApi');
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/tasks', tasksApi);
+
+const POD_ID = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+
+beforeEach(() => {
+  mockFindOneAndUpdate.mockReset();
+  mockFindOneAndUpdate.mockResolvedValue({ taskId: 'TASK-001', status: 'claimed' });
+  mockEmitTaskUpdated.mockReset();
+});
+
+describe('PATCH /:podId/:taskId status vocabulary', () => {
+  test.each([
+    ['in_progress', 'claimed'],
+    ['In_Progress', 'claimed'],
+    ['completed', 'done'],
+    ['todo', 'pending'],
+  ])("normalizes alias '%s' to canonical '%s'", async (alias, canonical) => {
+    const res = await request(app)
+      .patch(`/api/v1/tasks/${POD_ID}/TASK-001`)
+      .send({ status: alias });
+
+    expect(res.status).toBe(200);
+    const [, update] = mockFindOneAndUpdate.mock.calls[0];
+    expect(update.$set.status).toBe(canonical);
+    // The audit-trail line records the canonical value, not the alias.
+    expect(update.$push.updates.text).toContain(`status → ${canonical}`);
+    expect(mockEmitTaskUpdated).toHaveBeenCalled();
+  });
+
+  test('passes canonical statuses through unchanged', async () => {
+    const res = await request(app)
+      .patch(`/api/v1/tasks/${POD_ID}/TASK-001`)
+      .send({ status: 'blocked' });
+
+    expect(res.status).toBe(200);
+    expect(mockFindOneAndUpdate.mock.calls[0][1].$set.status).toBe('blocked');
+  });
+
+  test('rejects unknown statuses with the vocabulary in the error', async () => {
+    const res = await request(app)
+      .patch(`/api/v1/tasks/${POD_ID}/TASK-001`)
+      .send({ status: 'wip' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/pending\|claimed\|done\|blocked/);
+    expect(res.body.error).toMatch(/'wip'/);
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('non-status patches are unaffected by the gate', async () => {
+    const res = await request(app)
+      .patch(`/api/v1/tasks/${POD_ID}/TASK-001`)
+      .send({ title: 'renamed' });
+
+    expect(res.status).toBe(200);
+    expect(mockFindOneAndUpdate.mock.calls[0][1].$set.title).toBe('renamed');
+  });
+});

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -421,6 +421,25 @@ router.post('/:podId/:taskId/updates', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
+// Task.status vocabulary. findOneAndUpdate does NOT run the schema's enum
+// validator, so this route is the only gate between a caller's status string
+// and the DB — and agent callers routinely write the LLM-natural names
+// (in_progress, completed). Unvalidated, those landed in Mongo and the board
+// rendered the task in no column while still counting it in the header.
+// Aliases are normalized (agents should not have to memorize our enum);
+// anything else is a 400 that TEACHES the vocabulary instead of guessing.
+const VALID_TASK_STATUSES = ['pending', 'claimed', 'done', 'blocked'];
+const TASK_STATUS_ALIASES: Record<string, string> = {
+  in_progress: 'claimed',
+  'in-progress': 'claimed',
+  inprogress: 'claimed',
+  todo: 'pending',
+  open: 'pending',
+  completed: 'done',
+  complete: 'done',
+  finished: 'done',
+};
+
 router.patch('/:podId/:taskId', auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId, taskId } = req.params || {};
@@ -430,6 +449,17 @@ router.patch('/:podId/:taskId', auth, async (req: AuthReq, res: Res) => {
     const body = (req.body || {}) as Record<string, unknown>;
     allowed.forEach((k) => { if (body[k] !== undefined) fieldUpdates[k] = body[k]; });
     if (Object.keys(fieldUpdates).length === 0) return res.status(400).json({ error: 'No updatable fields provided' });
+    if (fieldUpdates.status !== undefined) {
+      const raw = String(fieldUpdates.status).trim().toLowerCase();
+      const normalized = TASK_STATUS_ALIASES[raw] || raw;
+      if (!VALID_TASK_STATUSES.includes(normalized)) {
+        return res.status(400).json({
+          error: `status must be one of ${VALID_TASK_STATUSES.join('|')} (got '${fieldUpdates.status}'). `
+            + 'Aliases accepted: in_progress→claimed, completed→done, todo→pending.',
+        });
+      }
+      fieldUpdates.status = normalized;
+    }
     const access = await requirePodMember(podId || '', userId, { write: true });
     if (access.error) return res.status(access.status || 500).json({ error: access.error });
     const author = await resolveAuthor(req);

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -1237,3 +1237,36 @@ rate check on agent posts, and external agents pin package versions, so the
 old text keeps shipping until they upgrade. The only verification that the new
 text bound is re-measuring the length distribution — and a skill or description
 that silently failed to load looks exactly like one that loaded and worked.
+
+## 26. The task PATCH accepted any status string, and the board rendered the result nowhere (2026-08-12, operator session)
+
+`PATCH /api/v1/tasks/:podId/:taskId` whitelisted *which fields* an agent may
+update but never *what values* — and `findOneAndUpdate` does not run the
+schema's enum validator, so the route was the only gate and the gate was open.
+An agent writing `status: "in_progress"` — the most natural name a model emits
+for "I am working on this" — got a 200, an audit-trail line reading
+`status → in_progress`, and a task the v1 board rendered in **no column at
+all**: the board's four columns filtered by strict equality against
+`pending|claimed|blocked|done`, while the header still counted the task. The
+v2 inspector, meanwhile, silently *tolerated* the alias (counting
+`in_progress` as in-progress) — one surface forgiving, one surface strict,
+and the agent's 200 told it the write was fine. Nothing anywhere taught the
+actual vocabulary.
+
+Measured before fixing: prod had zero alias rows (343 pending / 121 done /
+23 blocked / 15 claimed), so this was latent — the trap was set and armed but
+nobody had stepped in it. That is the right time to fix a surface like this,
+and also exactly when it is hardest to justify noticing.
+
+**Fixed** in `backend/routes/tasksApi.ts`: status values normalize through an
+alias map (`in_progress→claimed`, `completed→done`, `todo→pending`, …) and
+unknown values 400 with the vocabulary in the error text — the rejection
+teaches. The v1 board's columns now match status *sets*, so any row that
+predates the gate still renders somewhere visible.
+
+**Rule earned:** a field whitelist is not a value gate. Any write surface an
+agent can reach must either validate values or state, in its error, the
+vocabulary it wanted — silence plus a 200 is how an agent learns a false
+model with full confidence. And when two surfaces disagree on tolerance
+(inspector forgiving, board strict), the forgiving one is hiding the defect
+the strict one is expressing.

--- a/frontend/src/components/ChatRoom.tsx
+++ b/frontend/src/components/ChatRoom.tsx
@@ -358,6 +358,12 @@ interface BoardColumnMeta {
     label: string;
     color: string;
     borderColor: string;
+    // Statuses this column renders. The canonical vocabulary is the key, but
+    // alias statuses written before the PATCH route normalized them
+    // (in_progress, completed — LLM-natural names) must land SOMEWHERE: a
+    // strict-equality filter made such tasks count in the header yet render
+    // in no column at all.
+    statuses: string[];
 }
 
 interface DroppableColumnProps {
@@ -4087,16 +4093,16 @@ const ChatRoom = () => {
                     {/* Board Tab */}
                     {activeTab === 'board' && (() => {
                         const COLS: BoardColumnMeta[] = [
-                            { key: 'pending', label: 'Pending', color: '#555', borderColor: '#9e9e9e' },
-                            { key: 'claimed', label: 'In Progress', color: '#1565c0', borderColor: '#1976d2' },
-                            { key: 'blocked', label: 'Blocked', color: '#c62828', borderColor: '#e53935' },
-                            { key: 'done', label: 'Done', color: '#2e7d32', borderColor: '#43a047' },
+                            { key: 'pending', label: 'Pending', color: '#555', borderColor: '#9e9e9e', statuses: ['pending', 'todo', 'open'] },
+                            { key: 'claimed', label: 'In Progress', color: '#1565c0', borderColor: '#1976d2', statuses: ['claimed', 'in_progress', 'in-progress'] },
+                            { key: 'blocked', label: 'Blocked', color: '#c62828', borderColor: '#e53935', statuses: ['blocked'] },
+                            { key: 'done', label: 'Done', color: '#2e7d32', borderColor: '#43a047', statuses: ['done', 'completed', 'complete'] },
                         ];
                         const activeDragTask = activeDragTaskId
                             ? tasks.find(t => t.taskId === activeDragTaskId)
                             : null;
                         const activeDragCol = activeDragTask
-                            ? COLS.find(c => c.key === activeDragTask.status) || COLS[0]
+                            ? COLS.find(c => c.statuses.includes(activeDragTask.status)) || COLS[0]
                             : null;
                         const handleDragStart = (event: DragStartEvent) => {
                             setActiveDragTaskId(String(event.active.id));
@@ -4139,7 +4145,7 @@ const ChatRoom = () => {
                                 >
                                     <Box sx={{ display: 'flex', gap: 2, p: 2, overflowX: 'auto', overflowY: 'hidden', flex: 1, alignItems: 'flex-start' }}>
                                         {COLS.map(col => {
-                                            const colTasks = tasks.filter(t => t.status === col.key);
+                                            const colTasks = tasks.filter(t => col.statuses.includes(t.status));
                                             const emptyHelper = col.key === 'pending'
                                                 ? 'Nothing pending'
                                                 : col.key === 'claimed'


### PR DESCRIPTION
Follow-on from #916, answering "does the old task board UI also need fixing?" — yes, one real correctness defect (this PR) plus a design question (separate decision).

**The defect:** `PATCH /api/v1/tasks/:podId/:taskId` whitelists *fields* but not *values*, and `findOneAndUpdate` bypasses the schema enum validator — so `status: "in_progress"` (the most natural thing an agent writes) landed in Mongo with a 200, and the v1 board's strict-equality columns rendered that task **nowhere** while the header still counted it. The v2 inspector silently tolerated the same alias — one surface forgiving, one strict, nothing teaching the vocabulary. Measured prod before fixing: zero alias rows (343/121/23/15 across the four canonical statuses) — latent, not active.

- **Backend**: status aliases normalize (`in_progress→claimed`, `completed→done`, `todo→pending`, …); unknown values 400 **with the vocabulary in the error text** so the rejection teaches the agent. Audit line records the canonical value.
- **Frontend (v1 board)**: columns filter by status *sets* so any pre-gate row still renders somewhere; drag-overlay lookup matches.
- **AX audit entry 26**: "a field whitelist is not a value gate."

Tests: 7 route cases green locally; typecheck clean both tiers; frontend jest runs in CI (its tier on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8