### PR TITLE
feat(shell): v2-native task board — the run board stops exiting the shell

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -892,6 +892,47 @@
       "moreRows_other": "{{count}} more rows not shown. Click Open for the full file."
     }
   },
+  "board": {
+    "title": "Board",
+    "backToChat": "Back to chat",
+    "newTask": "New task",
+    "taskCount_one": "{{count}} task",
+    "taskCount_other": "{{count}} tasks",
+    "loadErrorTitle": "Couldn't load the board",
+    "loadErrorText": "Check your connection and try again.",
+    "createError": "Couldn't create the task. Try again.",
+    "col": {
+      "pending": "Pending",
+      "inProgress": "In Progress",
+      "blocked": "Blocked",
+      "done": "Done"
+    },
+    "emptyCol": {
+      "pending": "Nothing pending",
+      "inProgress": "Nothing in progress",
+      "blocked": "All clear",
+      "done": "None complete yet"
+    },
+    "move": {
+      "start": "Start",
+      "block": "Block",
+      "finish": "Done",
+      "resume": "Resume",
+      "reopen": "Reopen"
+    },
+    "detail": {
+      "updates": "Updates",
+      "pr": "View PR"
+    },
+    "form": {
+      "title": "Title",
+      "titlePlaceholder": "What needs to happen?",
+      "assignee": "Assignee (optional)",
+      "assigneePlaceholder": "agent or teammate name",
+      "create": "Create task",
+      "creating": "Creating…"
+    }
+  },
   "marketplace": {
     "title": "Marketplace",
     "subtitle": "Browse and install agents, apps, and integrations.",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -888,6 +888,46 @@
       "moreRows_other": "还有 {{count}} 行未显示。点击「打开」查看完整文件。"
     }
   },
+  "board": {
+    "title": "看板",
+    "backToChat": "返回聊天",
+    "newTask": "新建任务",
+    "taskCount_other": "{{count}} 个任务",
+    "loadErrorTitle": "看板加载失败",
+    "loadErrorText": "请检查网络连接后重试。",
+    "createError": "任务创建失败，请重试。",
+    "col": {
+      "pending": "待处理",
+      "inProgress": "进行中",
+      "blocked": "受阻",
+      "done": "已完成"
+    },
+    "emptyCol": {
+      "pending": "没有待处理任务",
+      "inProgress": "没有进行中的任务",
+      "blocked": "一切正常",
+      "done": "还没有完成的任务"
+    },
+    "move": {
+      "start": "开始",
+      "block": "标记受阻",
+      "finish": "完成",
+      "resume": "继续",
+      "reopen": "重新打开"
+    },
+    "detail": {
+      "updates": "更新记录",
+      "pr": "查看 PR"
+    },
+    "form": {
+      "title": "标题",
+      "titlePlaceholder": "需要做什么？",
+      "assignee": "负责人（可选）",
+      "assigneePlaceholder": "智能体或队友名称",
+      "create": "创建任务",
+      "creating": "创建中…"
+    }
+  },
   "marketplace": {
     "title": "应用市场",
     "subtitle": "浏览并安装智能体、应用和集成。",

--- a/frontend/src/v2/V2App.tsx
+++ b/frontend/src/v2/V2App.tsx
@@ -29,6 +29,7 @@ import V2MarketplaceDetailPage from './marketplace/V2MarketplaceDetailPage';
 import './marketplace/V2MarketplaceDetailPage.css';
 import AgentsHub from '../components/agents/AgentsHub';
 import V2AgentBYO from './components/V2AgentBYO';
+import V2PodBoard from './components/V2PodBoard';
 import SkillsCatalogPage from '../components/skills/SkillsCatalogPage';
 import ActivityFeedPage from '../components/activity/ActivityFeedPage';
 import AnalyticsDashboard from '../components/analytics/AnalyticsDashboard';
@@ -194,6 +195,20 @@ const V2App: React.FC = () => {
                 <Route
                   path="dashboard"
                   element={feature('Dashboard', 'Your dashboard tools, kept inside the v2 shell.', <Dashboard />)}
+                />
+                {/* Board must precede the param routes: the static "board"
+                    segment outranks both pods/:podId and pods/:podType/:roomId
+                    in v6 matching, but keeping it first makes intent legible. */}
+                <Route
+                  path="pods/:podId/board"
+                  element={feature(
+                    'Board',
+                    'Pod task board inside the v2 shell.',
+                    <V2PodBoard />,
+                    false,
+                    /* V2PodBoard owns its own header (pod name + back). */
+                    false,
+                  )}
                 />
                 <Route path="pods/:podId" element={<V2PodIdRoute />} />
                 <Route

--- a/frontend/src/v2/__tests__/V2PodBoard.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodBoard.test.tsx
@@ -1,0 +1,156 @@
+// @ts-nocheck
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import V2PodBoard from '../components/V2PodBoard';
+import { AuthContext } from '../../context/AuthContext';
+
+let mockSocketValue = { socket: null, connected: false };
+jest.mock('../../context/SocketContext', () => ({
+  useSocket: () => mockSocketValue,
+}));
+
+jest.mock('axios', () => {
+  const mock = {
+    get: jest.fn(),
+    post: jest.fn(() => Promise.resolve({ data: {} })),
+    patch: jest.fn(() => Promise.resolve({ data: {} })),
+    delete: jest.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  };
+  return { __esModule: true, default: mock, ...mock };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const axios = require('axios').default;
+
+const authValue = {
+  currentUser: { _id: 'u1', username: 'alice' },
+  user: { _id: 'u1', username: 'alice' },
+  token: 't',
+  loading: false,
+  error: null,
+  isAuthenticated: true,
+  register: jest.fn(),
+  login: jest.fn(),
+  logout: jest.fn(),
+  updateProfile: jest.fn(),
+};
+
+const TASKS = [
+  { taskId: 'TASK-001', title: 'Connect your first agent', status: 'done', updates: [] },
+  { taskId: 'TASK-002', title: 'Give your agent its first task', status: 'pending', updates: [] },
+  // Alias statuses written before the #921 vocabulary gate must render in
+  // their canonical columns, not vanish.
+  { taskId: 'N-3', title: 'Legacy alias in progress', status: 'in_progress', updates: [] },
+  { taskId: 'N-4', title: 'Legacy alias completed', status: 'completed', updates: [] },
+];
+
+const wireAxios = (tasks = TASKS) => {
+  axios.get.mockImplementation((url) => {
+    if (url.startsWith('/api/v1/tasks/')) return Promise.resolve({ data: { tasks } });
+    if (url.startsWith('/api/pods/')) return Promise.resolve({ data: { name: 'My Workspace' } });
+    return Promise.resolve({ data: {} });
+  });
+};
+
+const renderBoard = () => render(
+  <AuthContext.Provider value={authValue}>
+    <MemoryRouter initialEntries={['/v2/pods/pod-1/board']}>
+      <Routes>
+        <Route path="/v2/pods/:podId/board" element={<V2PodBoard />} />
+        <Route path="/v2/pods/:podId" element={<div>chat page</div>} />
+      </Routes>
+    </MemoryRouter>
+  </AuthContext.Provider>,
+);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSocketValue = { socket: null, connected: false };
+  wireAxios();
+});
+
+describe('V2PodBoard', () => {
+  test('renders four canonical columns and places alias statuses in them', async () => {
+    renderBoard();
+
+    const pending = await screen.findByRole('region', { name: 'Pending' });
+    const inProgress = screen.getByRole('region', { name: 'In Progress' });
+    const done = screen.getByRole('region', { name: 'Done' });
+    screen.getByRole('region', { name: 'Blocked' });
+
+    expect(within(pending).getByText('Give your agent its first task')).toBeInTheDocument();
+    // 'in_progress' and 'completed' are pre-gate aliases — they render in
+    // their canonical columns instead of disappearing (#921 sets).
+    expect(within(inProgress).getByText('Legacy alias in progress')).toBeInTheDocument();
+    expect(within(done).getByText('Legacy alias completed')).toBeInTheDocument();
+    expect(within(done).getByText('Connect your first agent')).toBeInTheDocument();
+  });
+
+  test('Start moves a pending task via PATCH with optimistic column change', async () => {
+    axios.patch.mockResolvedValue({
+      data: { task: { taskId: 'TASK-002', title: 'Give your agent its first task', status: 'claimed', updates: [] } },
+    });
+    renderBoard();
+
+    const pending = await screen.findByRole('region', { name: 'Pending' });
+    fireEvent.click(within(pending).getByRole('button', { name: 'Start' }));
+
+    expect(axios.patch).toHaveBeenCalledWith(
+      '/api/v1/tasks/pod-1/TASK-002',
+      { status: 'claimed' },
+      expect.any(Object),
+    );
+    const inProgress = screen.getByRole('region', { name: 'In Progress' });
+    await waitFor(() => {
+      expect(within(inProgress).getByText('Give your agent its first task')).toBeInTheDocument();
+    });
+  });
+
+  test('creates a task from the dialog', async () => {
+    axios.post.mockResolvedValue({ data: { task: { taskId: 'N-9', title: 'Ship it', status: 'pending' } } });
+    renderBoard();
+    await screen.findByRole('region', { name: 'Pending' });
+
+    fireEvent.click(screen.getByRole('button', { name: /New task/ }));
+    fireEvent.change(screen.getByPlaceholderText('What needs to happen?'), { target: { value: 'Ship it' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create task' }));
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/tasks/pod-1',
+        { title: 'Ship it' },
+        expect.any(Object),
+      );
+    });
+  });
+
+  test('refetches when a task_updated socket event lands for this pod', async () => {
+    const handlers = {};
+    mockSocketValue = {
+      socket: {
+        on: (event, fn) => { handlers[event] = fn; },
+        off: jest.fn(),
+        emit: jest.fn(),
+      },
+      connected: true,
+    };
+    renderBoard();
+    await screen.findByRole('region', { name: 'Pending' });
+
+    const tasksCallsBefore = axios.get.mock.calls.filter(([url]) => url.startsWith('/api/v1/tasks/')).length;
+    act(() => {
+      handlers.task_updated({ podId: 'pod-1', task: {}, kind: 'created' });
+    });
+
+    await waitFor(() => {
+      const tasksCallsAfter = axios.get.mock.calls.filter(([url]) => url.startsWith('/api/v1/tasks/')).length;
+      expect(tasksCallsAfter).toBeGreaterThan(tasksCallsBefore);
+    });
+  });
+});

--- a/frontend/src/v2/components/V2PodBoard.tsx
+++ b/frontend/src/v2/components/V2PodBoard.tsx
@@ -1,0 +1,398 @@
+// V2-native task board — /v2/pods/:podId/board.
+//
+// Until now "View run board" dropped users out of the v2 shell into the v1
+// Pod Tools ChatRoom (MUI chrome, integrations sidebar, different nav) — the
+// only v2 surface whose primary action exited v2. This page keeps the board
+// inside the shell: four canonical columns (alias statuses render in their
+// canonical column, mirroring the #921 sets), click-to-move actions instead
+// of drag (works on phones, verifiable in CI), a create dialog, a detail
+// dialog with the updates timeline, and live refresh via the same
+// `task_updated` socket event the inspector consumes.
+//
+// Status moves PATCH `/api/v1/tasks/:podId/:taskId` with optimistic
+// update + revert — the same call the v1 board makes, so both boards stay
+// behaviorally interchangeable while v1 winds down.
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useV2Api } from '../hooks/useV2Api';
+import { useSocket } from '../../context/SocketContext';
+
+type CanonicalStatus = 'pending' | 'claimed' | 'blocked' | 'done';
+
+interface BoardTask {
+  taskId: string;
+  title: string;
+  status: string;
+  assignee?: string | null;
+  notes?: string | null;
+  prUrl?: string | null;
+  updatedAt?: string;
+  updates?: Array<{ text: string; author: string; createdAt?: string }>;
+}
+
+interface ColumnMeta {
+  key: CanonicalStatus;
+  labelKey: string;
+  emptyKey: string;
+  pillClass: string;
+  // Alias statuses written before the PATCH vocabulary gate (#921) render in
+  // their canonical column instead of disappearing.
+  statuses: string[];
+  // Click-to-move targets offered on cards in this column.
+  moves: Array<{ to: CanonicalStatus; labelKey: string }>;
+}
+
+const COLUMNS: ColumnMeta[] = [
+  {
+    key: 'pending',
+    labelKey: 'board.col.pending',
+    emptyKey: 'board.emptyCol.pending',
+    pillClass: 'v2-inspector__pill v2-inspector__pill--progress',
+    statuses: ['pending', 'todo', 'open'],
+    moves: [
+      { to: 'claimed', labelKey: 'board.move.start' },
+      { to: 'blocked', labelKey: 'board.move.block' },
+    ],
+  },
+  {
+    key: 'claimed',
+    labelKey: 'board.col.inProgress',
+    emptyKey: 'board.emptyCol.inProgress',
+    pillClass: 'v2-inspector__pill v2-inspector__pill--progress',
+    statuses: ['claimed', 'in_progress', 'in-progress'],
+    moves: [
+      { to: 'done', labelKey: 'board.move.finish' },
+      { to: 'blocked', labelKey: 'board.move.block' },
+    ],
+  },
+  {
+    key: 'blocked',
+    labelKey: 'board.col.blocked',
+    emptyKey: 'board.emptyCol.blocked',
+    pillClass: 'v2-inspector__pill v2-inspector__pill--blocked',
+    statuses: ['blocked'],
+    moves: [
+      { to: 'claimed', labelKey: 'board.move.resume' },
+      { to: 'pending', labelKey: 'board.move.reopen' },
+    ],
+  },
+  {
+    key: 'done',
+    labelKey: 'board.col.done',
+    emptyKey: 'board.emptyCol.done',
+    pillClass: 'v2-inspector__pill v2-inspector__pill--complete',
+    statuses: ['done', 'completed', 'complete'],
+    moves: [
+      { to: 'pending', labelKey: 'board.move.reopen' },
+    ],
+  },
+];
+
+const V2PodBoard: React.FC = () => {
+  const { podId } = useParams<{ podId: string }>();
+  const { t } = useTranslation();
+  const api = useV2Api();
+  const navigate = useNavigate();
+  const { socket, connected } = useSocket();
+
+  const [tasks, setTasks] = useState<BoardTask[]>([]);
+  const [podName, setPodName] = useState<string>('');
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [selected, setSelected] = useState<BoardTask | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+  const [newAssignee, setNewAssignee] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!podId) return;
+    try {
+      const data = await api.get<{ tasks: BoardTask[] }>(`/api/v1/tasks/${podId}`);
+      setTasks(data.tasks || []);
+      setLoadError(false);
+    } catch {
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [api, podId]);
+
+  useEffect(() => {
+    setLoading(true);
+    load();
+  }, [load]);
+
+  // Pod name for the header — membership-gated read; a failure only costs
+  // the label.
+  useEffect(() => {
+    if (!podId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const pod = await api.get<{ name?: string }>(`/api/pods/${podId}`);
+        if (!cancelled && pod?.name) setPodName(pod.name);
+      } catch {
+        // Header falls back to the generic title.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [api, podId]);
+
+  // Same live wire the inspector uses — the board must never be staler than
+  // the chat narrating it.
+  useEffect(() => {
+    if (!podId || !socket || !connected) return undefined;
+    const onTaskUpdated = (payload: { podId?: string } | null) => {
+      if (!payload || (payload.podId && payload.podId !== podId)) return;
+      load();
+    };
+    socket.on('task_updated', onTaskUpdated);
+    return () => { socket.off('task_updated', onTaskUpdated); };
+  }, [podId, socket, connected, load]);
+
+  const moveTask = useCallback(async (task: BoardTask, to: CanonicalStatus) => {
+    if (!podId || task.status === to) return;
+    const previous = task;
+    setTasks((prev) => prev.map((item) => (item.taskId === task.taskId ? { ...item, status: to } : item)));
+    setSelected((prev) => (prev && prev.taskId === task.taskId ? { ...prev, status: to } : prev));
+    try {
+      const res = await api.patch<{ task: BoardTask }>(
+        `/api/v1/tasks/${podId}/${encodeURIComponent(task.taskId)}`,
+        { status: to },
+      );
+      const updated = res.task;
+      setTasks((prev) => prev.map((item) => (item.taskId === updated.taskId ? updated : item)));
+      setSelected((prev) => (prev && prev.taskId === updated.taskId ? updated : prev));
+    } catch {
+      setTasks((prev) => prev.map((item) => (item.taskId === previous.taskId ? previous : item)));
+      setSelected((prev) => (prev && prev.taskId === previous.taskId ? previous : prev));
+    }
+  }, [api, podId]);
+
+  const createTask = useCallback(async () => {
+    const title = newTitle.trim();
+    if (!podId || !title || creating) return;
+    setCreating(true);
+    setCreateError(null);
+    try {
+      await api.post(`/api/v1/tasks/${podId}`, {
+        title,
+        ...(newAssignee.trim() ? { assignee: newAssignee.trim() } : {}),
+      });
+      setNewTitle('');
+      setNewAssignee('');
+      setCreateOpen(false);
+      load();
+    } catch {
+      setCreateError(t('board.createError'));
+    } finally {
+      setCreating(false);
+    }
+  }, [api, podId, newTitle, newAssignee, creating, load, t]);
+
+  const columnTasks = useMemo(() => {
+    const byColumn = new Map<CanonicalStatus, BoardTask[]>();
+    COLUMNS.forEach((col) => {
+      byColumn.set(col.key, tasks.filter((task) => col.statuses.includes(task.status)));
+    });
+    return byColumn;
+  }, [tasks]);
+
+  const pillFor = (status: string): { className: string; label: string } => {
+    const col = COLUMNS.find((c) => c.statuses.includes(status)) || COLUMNS[0];
+    return { className: col.pillClass, label: t(col.labelKey) };
+  };
+
+  return (
+    <div className="v2-board" data-testid="v2-board">
+      <header className="v2-board__head">
+        <button
+          type="button"
+          className="v2-board__back"
+          onClick={() => navigate(`/v2/pods/${podId}`)}
+        >
+          ← {t('board.backToChat')}
+        </button>
+        <div className="v2-board__title-wrap">
+          <h1 className="v2-board__title">{podName || t('board.title')}</h1>
+          <span className="v2-board__subtitle">
+            {t('board.taskCount', { count: tasks.length })}
+          </span>
+        </div>
+        <button
+          type="button"
+          className="v2-board__new"
+          onClick={() => { setCreateError(null); setCreateOpen(true); }}
+        >
+          + {t('board.newTask')}
+        </button>
+      </header>
+
+      {loading && <div className="v2-empty"><span className="v2-spinner" /></div>}
+      {!loading && loadError && (
+        <div className="v2-empty">
+          <div className="v2-empty__title">{t('board.loadErrorTitle')}</div>
+          <div className="v2-empty__text">{t('board.loadErrorText')}</div>
+        </div>
+      )}
+
+      {!loading && !loadError && (
+        <div className="v2-board__columns">
+          {COLUMNS.map((col) => {
+            const items = columnTasks.get(col.key) || [];
+            return (
+              <section key={col.key} className="v2-board__col" aria-label={t(col.labelKey)}>
+                <div className="v2-board__col-head">
+                  <span className="v2-board__col-name">{t(col.labelKey)}</span>
+                  <span className="v2-board__col-count">{items.length}</span>
+                </div>
+                {items.length === 0 && (
+                  <div className="v2-board__col-empty">{t(col.emptyKey)}</div>
+                )}
+                {items.map((task) => (
+                  <article key={task.taskId} className="v2-board__card">
+                    <button
+                      type="button"
+                      className="v2-board__card-main"
+                      onClick={() => setSelected(task)}
+                    >
+                      <span className="v2-board__card-id">{task.taskId}</span>
+                      <span className="v2-board__card-title">{task.title}</span>
+                      {task.assignee && (
+                        <span className="v2-board__card-assignee">@{task.assignee}</span>
+                      )}
+                    </button>
+                    <div className="v2-board__card-actions">
+                      {col.moves.map((move) => (
+                        <button
+                          key={move.to}
+                          type="button"
+                          className="v2-board__card-move"
+                          onClick={() => moveTask(task, move.to)}
+                        >
+                          {t(move.labelKey)}
+                        </button>
+                      ))}
+                    </div>
+                  </article>
+                ))}
+              </section>
+            );
+          })}
+        </div>
+      )}
+
+      {selected && (
+        <div className="v2-modal__overlay" role="presentation" onClick={() => setSelected(null)}>
+          <div
+            className="v2-modal v2-board__detail"
+            role="dialog"
+            aria-label={selected.title}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="v2-modal__head">
+              <div className="v2-modal__title">
+                <span className="v2-board__card-id">{selected.taskId}</span> {selected.title}
+              </div>
+              <button type="button" className="v2-modal__close" onClick={() => setSelected(null)}>×</button>
+            </div>
+            <div className="v2-modal__body">
+              <div className="v2-board__detail-meta">
+                {(() => { const pill = pillFor(selected.status); return <span className={pill.className}>{pill.label}</span>; })()}
+                {selected.assignee && <span className="v2-board__card-assignee">@{selected.assignee}</span>}
+                {selected.prUrl && (
+                  <a className="v2-board__detail-pr" href={selected.prUrl} target="_blank" rel="noreferrer">
+                    {t('board.detail.pr')}
+                  </a>
+                )}
+              </div>
+              {selected.notes && <p className="v2-board__detail-notes">{selected.notes}</p>}
+              <div className="v2-board__detail-moves">
+                {(COLUMNS.find((c) => c.statuses.includes(selected.status))?.moves || []).map((move) => (
+                  <button
+                    key={move.to}
+                    type="button"
+                    className="v2-board__card-move"
+                    onClick={() => moveTask(selected, move.to)}
+                  >
+                    {t(move.labelKey)}
+                  </button>
+                ))}
+              </div>
+              {(selected.updates?.length || 0) > 0 && (
+                <>
+                  <div className="v2-modal__section-title">{t('board.detail.updates')}</div>
+                  <ul className="v2-board__detail-updates">
+                    {(selected.updates || []).slice().reverse().map((update, index) => (
+                      // Updates have no id; index-in-reversed-list is stable
+                      // for a render of an immutable snapshot.
+                      // eslint-disable-next-line react/no-array-index-key
+                      <li key={index}>
+                        <span className="v2-board__detail-update-author">{update.author}</span>
+                        <span className="v2-board__detail-update-text">{update.text}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {createOpen && (
+        <div className="v2-modal__overlay" role="presentation" onClick={() => setCreateOpen(false)}>
+          <div
+            className="v2-modal v2-board__create"
+            role="dialog"
+            aria-label={t('board.newTask')}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="v2-modal__head">
+              <div className="v2-modal__title">{t('board.newTask')}</div>
+              <button type="button" className="v2-modal__close" onClick={() => setCreateOpen(false)}>×</button>
+            </div>
+            <div className="v2-modal__body">
+              <label className="v2-board__field">
+                <span>{t('board.form.title')}</span>
+                <input
+                  type="text"
+                  value={newTitle}
+                  onChange={(event) => setNewTitle(event.target.value)}
+                  onKeyDown={(event) => { if (event.key === 'Enter') createTask(); }}
+                  placeholder={t('board.form.titlePlaceholder')}
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
+                  autoFocus
+                />
+              </label>
+              <label className="v2-board__field">
+                <span>{t('board.form.assignee')}</span>
+                <input
+                  type="text"
+                  value={newAssignee}
+                  onChange={(event) => setNewAssignee(event.target.value)}
+                  onKeyDown={(event) => { if (event.key === 'Enter') createTask(); }}
+                  placeholder={t('board.form.assigneePlaceholder')}
+                />
+              </label>
+              {createError && <div className="v2-modal__error">{createError}</div>}
+              <button
+                type="button"
+                className="v2-board__create-submit"
+                disabled={!newTitle.trim() || creating}
+                onClick={createTask}
+              >
+                {creating ? t('board.form.creating') : t('board.form.create')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default V2PodBoard;

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -1425,16 +1425,14 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
         </div>
       </div>
       {(runState.blocked + runState.inProgress + runState.pending + runState.complete) > 0 ? (
-        // Tasks exist — link to run-board AND surface the recent task list.
-        // (View run board target route still falls back to `/v2/pods/chat/<id>`
-        // v1 chat view since v2 has no dedicated tasks-board route — but
-        // when there's at least one task the link has somewhere meaningful
-        // to go.)
+        // Tasks exist — link to the v2-native board AND surface the recent
+        // task list. (This used to exit the shell into the v1 Pod Tools
+        // ChatRoom — the only v2 surface whose primary action left v2.)
         <>
           <button
             type="button"
             className="v2-inspector__link v2-inspector__link--block"
-            onClick={() => navigate(`/v2/pods/${pod.type || 'chat'}/${pod._id}`)}
+            onClick={() => navigate(`/v2/pods/${pod._id}/board`)}
           >
             {t('inspector.runState.viewRunBoard')}
           </button>

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -6512,3 +6512,325 @@
   opacity: 0.7;
   cursor: default;
 }
+
+/* ── V2 Pod Board — /v2/pods/:podId/board ──────────────────────────────── */
+
+.v2-board {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--v2-bg-subtle);
+}
+
+.v2-board__head {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 20px;
+  background: var(--v2-bg);
+  border-bottom: 1px solid var(--v2-border);
+}
+
+.v2-root button.v2-board__back {
+  border: none;
+  background: none;
+  color: var(--v2-text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 6px 8px;
+  border-radius: 6px;
+  white-space: nowrap;
+}
+
+.v2-root button.v2-board__back:hover {
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
+}
+
+.v2-board__title-wrap {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.v2-board__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--v2-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-board__subtitle {
+  font-size: 12.5px;
+  color: var(--v2-text-tertiary);
+  white-space: nowrap;
+}
+
+.v2-root button.v2-board__new {
+  border: none;
+  background: var(--v2-accent);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 14px;
+  border-radius: 8px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.v2-root button.v2-board__new:hover {
+  background: var(--v2-accent-strong);
+}
+
+.v2-board__columns {
+  display: flex;
+  gap: 14px;
+  padding: 16px 20px 24px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  flex: 1;
+  min-height: 0;
+  align-items: flex-start;
+}
+
+.v2-board__col {
+  flex: 1 1 0;
+  min-width: 230px;
+  max-width: 340px;
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-border);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 100%;
+  overflow-y: auto;
+}
+
+.v2-board__col-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 4px;
+}
+
+.v2-board__col-name {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--v2-text-secondary);
+}
+
+.v2-board__col-count {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v2-text-tertiary);
+  background: var(--v2-surface-tint);
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+
+.v2-board__col-empty {
+  font-size: 13px;
+  color: var(--v2-text-muted);
+  padding: 14px 6px;
+  text-align: center;
+}
+
+.v2-board__card {
+  border: 1px solid var(--v2-border);
+  border-radius: 10px;
+  background: var(--v2-bg);
+  overflow: hidden;
+}
+
+.v2-root button.v2-board__card-main {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  width: 100%;
+  border: none;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+  padding: 10px 12px 6px;
+}
+
+.v2-root button.v2-board__card-main:hover {
+  background: var(--v2-surface-hover);
+}
+
+.v2-board__card-id {
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  font-size: 10.5px;
+  color: var(--v2-text-muted);
+  letter-spacing: 0.03em;
+}
+
+.v2-board__card-title {
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--v2-text-primary);
+  line-height: 1.35;
+}
+
+.v2-board__card-assignee {
+  font-size: 12px;
+  color: var(--v2-accent-text);
+  font-weight: 500;
+}
+
+.v2-board__card-actions {
+  display: flex;
+  gap: 6px;
+  padding: 4px 10px 10px;
+}
+
+.v2-root button.v2-board__card-move {
+  border: 1px solid var(--v2-border);
+  background: var(--v2-surface);
+  color: var(--v2-text-secondary);
+  font-size: 11.5px;
+  font-weight: 600;
+  border-radius: 6px;
+  padding: 3px 10px;
+  cursor: pointer;
+}
+
+.v2-root button.v2-board__card-move:hover {
+  border-color: var(--v2-border-strong);
+  color: var(--v2-text-primary);
+  background: var(--v2-surface-hover);
+}
+
+.v2-board__detail-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.v2-board__detail-pr {
+  font-size: 12.5px;
+  color: var(--v2-accent-text);
+  font-weight: 500;
+}
+
+.v2-board__detail-notes {
+  font-size: 13.5px;
+  color: var(--v2-text-secondary);
+  margin: 0 0 12px;
+  white-space: pre-wrap;
+}
+
+.v2-board__detail-moves {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.v2-board__detail-updates {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.v2-board__detail-updates li {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  font-size: 12.5px;
+  border-left: 2px solid var(--v2-border);
+  padding-left: 10px;
+}
+
+.v2-board__detail-update-author {
+  font-weight: 600;
+  color: var(--v2-text-secondary);
+  font-size: 11.5px;
+}
+
+.v2-board__detail-update-text {
+  color: var(--v2-text-secondary);
+}
+
+.v2-board__field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-bottom: 12px;
+}
+
+.v2-board__field span {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v2-text-secondary);
+}
+
+.v2-board__field input {
+  border: 1px solid var(--v2-border);
+  border-radius: 8px;
+  padding: 9px 12px;
+  font-size: 13.5px;
+  color: var(--v2-text-primary);
+  background: var(--v2-bg);
+}
+
+.v2-board__field input:focus {
+  outline: none;
+  border-color: var(--v2-accent);
+  box-shadow: 0 0 0 3px rgba(47, 111, 235, 0.14);
+}
+
+.v2-root button.v2-board__create-submit {
+  border: none;
+  background: var(--v2-accent);
+  color: #fff;
+  font-size: 13.5px;
+  font-weight: 600;
+  padding: 9px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.v2-root button.v2-board__create-submit:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.v2-root button.v2-board__create-submit:not(:disabled):hover {
+  background: var(--v2-accent-strong);
+}
+
+@media (max-width: 760px) {
+  .v2-board__head {
+    padding: 12px 14px;
+    gap: 10px;
+  }
+
+  .v2-board__columns {
+    padding: 12px 14px 20px;
+  }
+
+  .v2-board__col {
+    min-width: 250px;
+    max-width: none;
+    flex: 0 0 78vw;
+  }
+}


### PR DESCRIPTION
Sam: "maybe fix the board now to make it usable." The correctness half landed in #921; this is the usability half.

**The problem:** "View run board" was the only v2 primary action that *left* v2 — it dropped users into the v1 Pod Tools ChatRoom (MUI chrome, integrations sidebar, different navigation). The board a new user meets on day one (starter missions live there) was a context switch into the legacy app.

**New:** `V2PodBoard` at `/v2/pods/:podId/board`, inside the v2 shell:
- Four canonical columns; alias statuses (`in_progress`, `completed`) render in their canonical columns — same sets as #921, so pre-gate rows can't vanish.
- Click-to-move per column (Start / Block / Done / Resume / Reopen) via the same `PATCH` the v1 board uses, optimistic with revert. No drag dependency — works on phones, verifiable in CI. Drag can layer on later without changing the API surface.
- Card → detail dialog (status, assignee, notes, PR link, updates timeline — where the "Completed automatically" starter-task line from #920 shows). Header → New task dialog.
- Live via `task_updated` (same wire as the inspector).
- v2 design tokens throughout; columns scroll horizontally on narrow viewports. en + zh.

Inspector's "View run board" now targets the new route. The v1 board is untouched and stays behaviorally interchangeable (same PATCH path) while it winds down.

Tests: 4 jest cases (alias placement, optimistic move + PATCH shape, create POST, socket refetch) in CI's tier; typecheck clean. **Real-browser layout check happens post-deploy** per the CLAUDE.md v2-CSS rule (jsdom has no layout engine) — screenshots will land on the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8