### PR TITLE
fix(onboarding): per-user Guide identities — shared instanceId meant one shared memory for all users

### DIFF
--- a/backend/__tests__/unit/controllers/authController.guideIdentity.test.js
+++ b/backend/__tests__/unit/controllers/authController.guideIdentity.test.js
@@ -1,0 +1,78 @@
+/**
+ * Per-user Guide identity fork.
+ *
+ * Identity is the join key for everything (ADR-003: one memory envelope per
+ * (agentName, instanceId)). Installing every user's Guide as (guide,
+ * 'default') gave the whole instance ONE shared memory doc — user A's
+ * durable preferences readable from user B's workspace. Caught 2026-08-13
+ * with zero bytes written; these pin the fork so it cannot regress.
+ */
+
+// jsonwebtoken must be mocked or it fails to load under the Node-26 drift
+// (buffer-equal-constant-time) — same guard the sibling authController tests use.
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 'tok'), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('bcryptjs', () => ({ hash: jest.fn(), compare: jest.fn(), genSalt: jest.fn(() => 'salt') }));
+jest.mock('@sendgrid/mail', () => ({ setApiKey: jest.fn(), send: jest.fn().mockResolvedValue({}) }));
+jest.mock('../../../services/communityPodService', () => ({
+  ensureUserInCommunityPod: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockSyncUser = jest.fn().mockResolvedValue(undefined);
+const mockSyncPod = jest.fn().mockResolvedValue({});
+const mockGetOrCreateAgentUser = jest.fn().mockResolvedValue({ _id: 'guide-bot-1' });
+const mockInstallUpsert = jest.fn().mockResolvedValue({});
+const mockPostMessage = jest.fn().mockResolvedValue({});
+const mockPodUpdateOne = jest.fn().mockResolvedValue({});
+
+jest.mock('../../../models/Pod', () => ({
+  create: jest.fn().mockImplementation(async () => ({ _id: 'pod-123' })),
+  updateOne: (...args) => mockPodUpdateOne(...args),
+}));
+jest.mock('../../../models/User', () => ({ findById: jest.fn().mockResolvedValue({ _id: 'user-1' }) }));
+jest.mock('../../../models/Task', () => ({ create: jest.fn().mockResolvedValue([]) }));
+jest.mock('../../../services/agentIdentityService', () => ({
+  syncUserToPostgreSQL: mockSyncUser,
+  getOrCreateAgentUser: (...args) => mockGetOrCreateAgentUser(...args),
+}));
+jest.mock('../../../services/pgPodSyncService', () => ({ syncPodFromMongo: mockSyncPod }));
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { findOneAndUpdate: (...args) => mockInstallUpsert(...args) },
+}));
+jest.mock('../../../scripts/seed-native-agents', () => ({
+  buildInstallationConfig: jest.fn(() => ({ runtime: { runtimeType: 'native' } })),
+}));
+jest.mock('../../../services/agentMessageService', () => ({
+  postMessage: (...args) => mockPostMessage(...args),
+}));
+
+const authController = require('../../../controllers/authController');
+
+describe('createDefaultWorkspacePod guide identity fork (2026-08-13)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('installs the guide under a userId-derived instanceId, never default', async () => {
+    await authController.createDefaultWorkspacePod('User-1');
+
+    const [filter, update] = mockInstallUpsert.mock.calls[0];
+    expect(filter.instanceId).toBe('uuser-1');
+    expect(update.$setOnInsert.instanceId).toBe('uuser-1');
+    expect(filter.instanceId).not.toBe('default');
+
+    expect(mockGetOrCreateAgentUser).toHaveBeenCalledWith('guide', expect.objectContaining({
+      instanceId: 'uuser-1',
+    }));
+    expect(mockPostMessage).toHaveBeenCalledWith(expect.objectContaining({
+      agentName: 'guide',
+      instanceId: 'uuser-1',
+    }));
+  });
+
+  test('two users get two distinct guide identities — the memory-envelope fork', async () => {
+    await authController.createDefaultWorkspacePod('aaaa1111');
+    await authController.createDefaultWorkspacePod('bbbb2222');
+
+    const ids = mockInstallUpsert.mock.calls.map(([filter]) => filter.instanceId);
+    expect(ids).toEqual(['uaaaa1111', 'ubbbb2222']);
+    expect(new Set(ids).size).toBe(2);
+  });
+});

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -164,8 +164,18 @@ const createDefaultWorkspacePod = async (userId: any) => {
       // eslint-disable-next-line global-require
       const { AgentInstallation } = require('../models/AgentRegistry');
 
+      // Per-user identity fork. Identity is the join key for EVERYTHING —
+      // ADR-003 keys the memory envelope by (agentName, instanceId) — so a
+      // shared instanceId would give every user's Guide ONE memory doc: user
+      // A's "my repo is X" surfacing in user B's workspace. Same leak class
+      // as the 2026-07-03 BYO incident, caught pre-data this time. The
+      // userId-derived instanceId forks memory, AgentRuns, caps, and the bot
+      // User row per user; displayName stays "Guide" everywhere (per-user
+      // guides never share a pod, so no render collision exists).
+      const guideInstanceId = `u${String(userId).toLowerCase()}`;
+
       await AgentInstallation.findOneAndUpdate(
-        { agentName: guideApp.agentName, podId: pod._id, instanceId: 'default' },
+        { agentName: guideApp.agentName, podId: pod._id, instanceId: guideInstanceId },
         {
           $set: {
             status: 'active',
@@ -177,7 +187,7 @@ const createDefaultWorkspacePod = async (userId: any) => {
           $setOnInsert: {
             agentName: guideApp.agentName,
             podId: pod._id,
-            instanceId: 'default',
+            instanceId: guideInstanceId,
             installedBy: userId,
           },
         },
@@ -185,7 +195,7 @@ const createDefaultWorkspacePod = async (userId: any) => {
       );
 
       const guideUser = await AgentIdentityService.getOrCreateAgentUser(guideApp.agentName, {
-        instanceId: 'default',
+        instanceId: guideInstanceId,
         displayName: guideApp.displayName,
         description: guideApp.description,
       });
@@ -202,7 +212,7 @@ const createDefaultWorkspacePod = async (userId: any) => {
         const AgentMessageService = require('../services/agentMessageService');
         await AgentMessageService.postMessage({
           agentName: guideApp.agentName,
-          instanceId: 'default',
+          instanceId: guideInstanceId,
           podId: pod._id.toString(),
           displayName: guideApp.displayName,
           content:

--- a/backend/scripts/migrate-guide-per-user-identity.ts
+++ b/backend/scripts/migrate-guide-per-user-identity.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/*
+ * Fork the shared Guide identity into per-user identities.
+ *
+ * Every Guide installed before this migration used (guide, 'default') —
+ * ONE identity for every user. Identity is the join key for everything
+ * (ADR-003: one memory envelope per (agentName, instanceId)), so all users'
+ * Guides shared a single memory doc: user A's "my repo is X" would surface
+ * in user B's workspace. Same leak class as the 2026-07-03 BYO incident.
+ * Measured before writing this script: zero bytes had ever been written to
+ * the shared envelope, so this is prevention, not remediation.
+ *
+ * For each active AgentInstallation { agentName:'guide', instanceId:'default' }:
+ *   1. owner = installation.installedBy, falling back to pod.createdBy
+ *   2. newInstanceId = `u${owner}` (matches the signup path post-fix)
+ *   3. ensure the per-user bot User exists (getOrCreateAgentUser)
+ *   4. swap pod membership: remove the shared guide bot, add the per-user bot
+ *   5. re-key the installation's instanceId in place
+ *
+ * The shared (guide, 'default') bot User row is NEVER deleted (ADR-001
+ * identity continuity — its historical messages keep their author); it is
+ * only removed from pod membership. If a shared memory envelope exists with
+ * content (it should not), it is QUARANTINED by re-keying its instanceId to
+ * 'default-quarantined' — never copied to any user, never deleted.
+ *
+ * Idempotent: a second run finds zero 'default' guide installs.
+ *
+ * Usage:
+ *   ts-node backend/scripts/migrate-guide-per-user-identity.ts          # apply
+ *   ts-node backend/scripts/migrate-guide-per-user-identity.ts --dry    # report
+ */
+
+import mongoose from 'mongoose';
+import Pod from '../models/Pod';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { AgentInstallation } = require('../models/AgentRegistry');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const AgentMemory = require('../models/AgentMemory');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const AgentIdentityService = require('../services/agentIdentityService').default
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  || require('../services/agentIdentityService');
+
+const DRY = process.argv.includes('--dry');
+
+async function main(): Promise<void> {
+  const uri = process.env.MONGO_URI;
+  if (!uri) throw new Error('MONGO_URI is required');
+  await mongoose.connect(uri);
+
+  const sharedInstalls = await AgentInstallation.find({
+    agentName: 'guide',
+    instanceId: 'default',
+    status: 'active',
+  });
+  console.log(`[guide-fork] ${sharedInstalls.length} shared-identity guide install(s)`);
+
+  const sharedBot = await AgentIdentityService.getOrCreateAgentUser('guide', {
+    instanceId: 'default',
+    displayName: 'Guide',
+  });
+
+  for (const install of sharedInstalls) {
+    const pod = await Pod.findById(install.podId);
+    const owner = install.installedBy?.toString() || pod?.createdBy?.toString();
+    if (!owner) {
+      console.warn(`[guide-fork] SKIP install ${install._id}: no owner resolvable`);
+      continue;
+    }
+    const newInstanceId = `u${owner.toLowerCase()}`;
+    console.log(`[guide-fork] pod=${install.podId} owner=${owner} → instanceId=${newInstanceId}${DRY ? ' (dry)' : ''}`);
+    if (DRY) continue;
+
+    const perUserBot = await AgentIdentityService.getOrCreateAgentUser('guide', {
+      instanceId: newInstanceId,
+      displayName: 'Guide',
+    });
+
+    if (pod && sharedBot?._id) {
+      await Pod.updateOne({ _id: pod._id }, { $pull: { members: sharedBot._id } });
+    }
+    if (pod && perUserBot?._id) {
+      await Pod.updateOne(
+        { _id: pod._id, members: { $ne: perUserBot._id } },
+        { $push: { members: perUserBot._id } },
+      );
+    }
+
+    install.instanceId = newInstanceId;
+    await install.save();
+  }
+
+  // Quarantine, never copy: a shared envelope's writes are unattributable
+  // mixtures across users by construction.
+  const sharedEnvelope = await AgentMemory.findOne({ agentName: 'guide', instanceId: 'default' });
+  if (sharedEnvelope) {
+    const size = String(sharedEnvelope.content || '').length;
+    console.log(`[guide-fork] shared envelope exists (${size} chars) — quarantining${DRY ? ' (dry)' : ''}`);
+    if (!DRY) {
+      sharedEnvelope.instanceId = 'default-quarantined';
+      await sharedEnvelope.save();
+    }
+  } else {
+    console.log('[guide-fork] no shared envelope — nothing to quarantine');
+  }
+
+  await mongoose.disconnect();
+  console.log('[guide-fork] done');
+}
+
+main().catch((err) => {
+  console.error('[guide-fork] failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Found during the admin-Guide design grill (Sam flagged the identity question; the fact-check confirmed a live bug).

**The bug:** every user's Guide installed as `(guide, 'default')` — one identity instance-wide. ADR-003 keys the memory envelope by `(agentName, instanceId)`, and the native runtime's `commonly_read_memory`/`commonly_write_memory` key by exactly that with no user/pod scoping — so **all Guides shared one memory doc**, while the Guide's own prompt encourages writing durable user preferences into it. User A's "my repo is X" would surface in user B's workspace. Same class as the 2026-07-03 BYO identity+memory leak.

**Blast radius, measured before fixing:** 1 guide install (the smoke fixture), 7 runs, and the shared envelope **was never created** — zero bytes ever written. Prevention, not remediation.

**Fix:** signup derives `instanceId = u<userId>` — forking memory, bot User row, AgentRuns, and the daily cap per user (cap + wake paths already key by `(pod, agentName, instanceId)`; verified they flow unchanged). `displayName` stays "Guide"; per-user guides never share a pod so no render collision exists. Migration script (`migrate-guide-per-user-identity.ts`, `--dry` supported) re-keys existing installs, swaps pod membership, never deletes the shared bot User (ADR-001 identity continuity), and **quarantines** any shared envelope rather than copying unattributable mixed-user content.

Tests: derived-instanceId pinned on install/opener/bot-user + two-users-two-identities. Green locally; typecheck clean.

Post-merge: run the migration against dev (1 row), then the smoke workspace re-verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8