### PR TITLE
feat(kernel): approval cards — payload column + ApprovalAction lifecycle + delegated create_pod (ADR-020)

### DIFF
--- a/backend/__tests__/unit/models/PgMessage.test.js
+++ b/backend/__tests__/unit/models/PgMessage.test.js
@@ -30,7 +30,7 @@ describe('PG Message model', () => {
     expect(pool.query).toHaveBeenNthCalledWith(
       1,
       expect.stringContaining('INSERT INTO messages'),
-      ['p', 'u', 'c', 'text', null],
+      ['p', 'u', 'c', 'text', null, null],
     );
     expect(pool.query).toHaveBeenNthCalledWith(
       2,

--- a/backend/__tests__/unit/services/approvalActionService.test.js
+++ b/backend/__tests__/unit/services/approvalActionService.test.js
@@ -1,0 +1,192 @@
+/**
+ * ADR-020 D2/D3 — the approval lifecycle's load-bearing invariants:
+ *  - only the owner decides; agents (isBot) never decide even as owner
+ *  - one-way transitions: resolve at most once, execute at most once
+ *  - expiry fails closed ("retiring an escalation is never an approval")
+ *  - decline never executes
+ *  - the executor creates resources owned by the USER, never the bot
+ */
+
+const mockApprovalFindById = jest.fn();
+const mockApprovalFindOneAndUpdate = jest.fn();
+const mockApprovalCreate = jest.fn();
+jest.mock('../../../models/ApprovalAction', () => ({
+  findById: (...args) => mockApprovalFindById(...args),
+  findOneAndUpdate: (...args) => mockApprovalFindOneAndUpdate(...args),
+  create: (...args) => mockApprovalCreate(...args),
+}));
+
+const mockPodCreate = jest.fn();
+const mockPodFindById = jest.fn();
+const mockPodUpdateOne = jest.fn();
+jest.mock('../../../models/Pod', () => ({
+  create: (...args) => mockPodCreate(...args),
+  findById: (...args) => mockPodFindById(...args),
+  updateOne: (...args) => mockPodUpdateOne(...args),
+}));
+
+const mockUserFindById = jest.fn();
+jest.mock('../../../models/User', () => ({
+  findById: (...args) => mockUserFindById(...args),
+}));
+
+const mockInstallFindOne = jest.fn();
+const mockInstallUpsert = jest.fn();
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: {
+    findOne: (...args) => mockInstallFindOne(...args),
+    findOneAndUpdate: (...args) => mockInstallUpsert(...args),
+  },
+}));
+
+const mockGetOrCreateAgentUser = jest.fn();
+jest.mock('../../../services/agentIdentityService', () => ({
+  getOrCreateAgentUser: (...args) => mockGetOrCreateAgentUser(...args),
+  syncUserToPostgreSQL: jest.fn(),
+}));
+
+jest.mock('../../../config/socket', () => ({ getIO: jest.fn(() => null) }));
+
+const { resolveApproval } = require('../../../services/approvalActionService');
+
+const OWNER = 'aaaaaaaaaaaaaaaaaaaaaaa1';
+const STRANGER = 'bbbbbbbbbbbbbbbbbbbbbbb2';
+
+const flaggedRow = (over = {}) => ({
+  _id: 'appr-1',
+  podId: 'pod-1',
+  messageId: 'not-numeric-mongo-id',
+  ownerUserId: OWNER,
+  agentName: 'guide',
+  instanceId: 'udefault',
+  actionType: 'create_pod',
+  params: { name: 'Design Studio', type: 'chat' },
+  summary: 'Create a pod for design work',
+  status: 'flagged',
+  expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+  save: jest.fn().mockResolvedValue(undefined),
+  ...over,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.PG_HOST;
+  mockUserFindById.mockReturnValue({
+    select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue({ isBot: false }) })),
+  });
+  // Mongo card-message update path (messageId non-numeric).
+  // eslint-disable-next-line global-require
+  jest.mock('../../../models/Message', () => ({ updateOne: jest.fn().mockResolvedValue({}) }), { virtual: false });
+});
+
+describe('resolveApproval authorization', () => {
+  test('404s on unknown approval', async () => {
+    mockApprovalFindById.mockResolvedValue(null);
+    const res = await resolveApproval({ approvalId: 'x', callerUserId: OWNER, decision: 'approved' });
+    expect(res.status).toBe(404);
+  });
+
+  test('403s a caller who is not the owner', async () => {
+    mockApprovalFindById.mockResolvedValue(flaggedRow());
+    const res = await resolveApproval({ approvalId: 'appr-1', callerUserId: STRANGER, decision: 'approved' });
+    expect(res.status).toBe(403);
+    expect(mockApprovalFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('403s a bot caller even when it is the owner — no agent may decide', async () => {
+    mockApprovalFindById.mockResolvedValue(flaggedRow());
+    mockUserFindById.mockReturnValue({
+      select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue({ isBot: true }) })),
+    });
+    const res = await resolveApproval({ approvalId: 'appr-1', callerUserId: OWNER, decision: 'approved' });
+    expect(res.status).toBe(403);
+    expect(mockApprovalFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveApproval lifecycle', () => {
+  test('already-resolved returns 409 and never re-executes', async () => {
+    mockApprovalFindById.mockResolvedValue(flaggedRow({ status: 'resolved', decision: 'approved' }));
+    const res = await resolveApproval({ approvalId: 'appr-1', callerUserId: OWNER, decision: 'approved' });
+    expect(res.status).toBe(409);
+    expect(mockPodCreate).not.toHaveBeenCalled();
+  });
+
+  test('expiry fails closed: 410, row marked expired, nothing executes', async () => {
+    const row = flaggedRow({ expiresAt: new Date(Date.now() - 1000) });
+    mockApprovalFindById.mockResolvedValue(row);
+    const res = await resolveApproval({ approvalId: 'appr-1', callerUserId: OWNER, decision: 'approved' });
+    expect(res.status).toBe(410);
+    expect(row.status).toBe('expired');
+    expect(row.save).toHaveBeenCalled();
+    expect(mockPodCreate).not.toHaveBeenCalled();
+  });
+
+  test('losing the atomic transition race returns 409 without executing', async () => {
+    mockApprovalFindById.mockResolvedValue(flaggedRow());
+    mockApprovalFindOneAndUpdate.mockResolvedValue(null);
+    const res = await resolveApproval({ approvalId: 'appr-1', callerUserId: OWNER, decision: 'approved' });
+    expect(res.status).toBe(409);
+    expect(mockPodCreate).not.toHaveBeenCalled();
+  });
+
+  test('decline resolves without executing anything', async () => {
+    mockApprovalFindById.mockResolvedValue(flaggedRow());
+    const resolved = flaggedRow({ status: 'resolved', decision: 'declined' });
+    mockApprovalFindOneAndUpdate.mockResolvedValue(resolved);
+    const res = await resolveApproval({ approvalId: 'appr-1', callerUserId: OWNER, decision: 'declined' });
+    expect(res.status).toBe(200);
+    expect(res.body.approval.decision).toBe('declined');
+    expect(mockPodCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('approved create_pod execution — D2: user authority owns', () => {
+  test('creates the pod owned by the USER with the agent joined as member', async () => {
+    mockApprovalFindById.mockResolvedValue(flaggedRow());
+    const resolved = flaggedRow({ status: 'resolved', decision: 'approved' });
+    mockApprovalFindOneAndUpdate.mockResolvedValue(resolved);
+    mockPodCreate.mockResolvedValue({ _id: 'newpod-1', name: 'Design Studio' });
+    mockInstallFindOne.mockReturnValue({ lean: jest.fn().mockResolvedValue({ displayName: 'Guide', scopes: ['context:read'], config: {}, version: '1.0.0' }) });
+    mockInstallUpsert.mockResolvedValue({});
+    mockGetOrCreateAgentUser.mockResolvedValue({ _id: 'guide-bot-1' });
+    mockPodUpdateOne.mockResolvedValue({});
+
+    const res = await resolveApproval({ approvalId: 'appr-1', callerUserId: OWNER, decision: 'approved' });
+
+    expect(res.status).toBe(200);
+    // The heart of D2: createdBy is the owner, members start with the owner —
+    // NEVER the bot user.
+    expect(mockPodCreate).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Design Studio',
+      createdBy: OWNER,
+      members: [OWNER],
+      joinPolicy: 'invite-only',
+    }));
+    // The proposing agent joins: installation cloned + bot user pushed.
+    expect(mockInstallUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ agentName: 'guide', podId: 'newpod-1' }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(mockPodUpdateOne).toHaveBeenCalledWith(
+      { _id: 'newpod-1', members: { $ne: 'guide-bot-1' } },
+      { $push: { members: 'guide-bot-1' } },
+    );
+    expect(resolved.executedAt).toBeInstanceOf(Date);
+    expect(resolved.executionResult).toEqual(expect.objectContaining({ podId: 'newpod-1' }));
+  });
+
+  test('execution failure keeps the decision and records the error honestly', async () => {
+    mockApprovalFindById.mockResolvedValue(flaggedRow());
+    const resolved = flaggedRow({ status: 'resolved', decision: 'approved' });
+    mockApprovalFindOneAndUpdate.mockResolvedValue(resolved);
+    mockPodCreate.mockRejectedValue(new Error('mongo down'));
+
+    const res = await resolveApproval({ approvalId: 'appr-1', callerUserId: OWNER, decision: 'approved' });
+
+    expect(res.status).toBe(200);
+    expect(resolved.executionError).toContain('mongo down');
+    expect(resolved.executedAt).toBeUndefined();
+  });
+});

--- a/backend/__tests__/unit/services/approvalActionService.test.js
+++ b/backend/__tests__/unit/services/approvalActionService.test.js
@@ -112,14 +112,22 @@ describe('resolveApproval lifecycle', () => {
     expect(mockPodCreate).not.toHaveBeenCalled();
   });
 
-  test('expiry fails closed: 410, row marked expired, nothing executes', async () => {
+  test('a decision past expiresAt is honored and stamped decidedAfterExpiry (ADR-017:201)', async () => {
+    // Expiry is advisory age, not refusal — refusing would convert
+    // fail-closed into fail-silent (the owner's explicit intent dropped
+    // because a timer won). Caught as an ADR-017/ADR-020 conflict by
+    // pod-architect in the 2026-08-13 fleet review; ADR-017 wins.
     const row = flaggedRow({ expiresAt: new Date(Date.now() - 1000) });
     mockApprovalFindById.mockResolvedValue(row);
-    const res = await resolveApproval({ approvalId: 'appr-1', callerUserId: OWNER, decision: 'approved' });
-    expect(res.status).toBe(410);
-    expect(row.status).toBe('expired');
-    expect(row.save).toHaveBeenCalled();
-    expect(mockPodCreate).not.toHaveBeenCalled();
+    const resolved = flaggedRow({ status: 'resolved', decision: 'declined', decidedAfterExpiry: true });
+    mockApprovalFindOneAndUpdate.mockResolvedValue(resolved);
+
+    const res = await resolveApproval({ approvalId: 'appr-1', callerUserId: OWNER, decision: 'declined' });
+
+    expect(res.status).toBe(200);
+    const [, update] = mockApprovalFindOneAndUpdate.mock.calls[0];
+    expect(update.$set.decidedAfterExpiry).toBe(true);
+    expect(update.$set.status).toBe('resolved');
   });
 
   test('losing the atomic transition race returns 409 without executing', async () => {
@@ -174,7 +182,30 @@ describe('approved create_pod execution — D2: user authority owns', () => {
       { $push: { members: 'guide-bot-1' } },
     );
     expect(resolved.executedAt).toBeInstanceOf(Date);
-    expect(resolved.executionResult).toEqual(expect.objectContaining({ podId: 'newpod-1' }));
+    expect(resolved.executionResult).toEqual(expect.objectContaining({ podId: 'newpod-1', agentJoined: true }));
+  });
+
+  test('agent-join failure is carried in the result, never a clean "done" (sprint-review finding)', async () => {
+    // The pod is real (user owns it), but membership without an installation
+    // 403s every post — a lied face here is unrecoverable because execution
+    // is at-most-once. The result must carry the partial truth.
+    mockApprovalFindById.mockResolvedValue(flaggedRow());
+    const resolved = flaggedRow({ status: 'resolved', decision: 'approved' });
+    mockApprovalFindOneAndUpdate.mockResolvedValue(resolved);
+    mockPodCreate.mockResolvedValue({ _id: 'newpod-2', name: 'Design Studio' });
+    mockInstallFindOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
+    mockInstallUpsert.mockRejectedValue(new Error('install collection offline'));
+
+    const res = await resolveApproval({ approvalId: 'appr-1', callerUserId: OWNER, decision: 'approved' });
+
+    expect(res.status).toBe(200);
+    expect(resolved.executedAt).toBeInstanceOf(Date);
+    expect(resolved.executionResult).toEqual(expect.objectContaining({
+      podId: 'newpod-2',
+      agentJoined: false,
+      agentJoinError: expect.stringContaining('install collection offline'),
+    }));
+    expect(resolved.executionError).toBeUndefined();
   });
 
   test('execution failure keeps the decision and records the error honestly', async () => {

--- a/backend/__tests__/unit/services/approvalActionService.test.js
+++ b/backend/__tests__/unit/services/approvalActionService.test.js
@@ -2,7 +2,8 @@
  * ADR-020 D2/D3 — the approval lifecycle's load-bearing invariants:
  *  - only the owner decides; agents (isBot) never decide even as owner
  *  - one-way transitions: resolve at most once, execute at most once
- *  - expiry fails closed ("retiring an escalation is never an approval")
+ *  - expiry is advisory age (ADR-017:201): late decisions are honored and
+ *    stamped decidedAfterExpiry — never refused
  *  - decline never executes
  *  - the executor creates resources owned by the USER, never the bot
  */

--- a/backend/__tests__/utils/testUtils.js
+++ b/backend/__tests__/utils/testUtils.js
@@ -161,6 +161,7 @@ const setupPgDb = async () => {
         user_id VARCHAR(24) NOT NULL,
         content TEXT NOT NULL,
         message_type VARCHAR(50) DEFAULT 'text',
+        payload JSONB,
         created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
       )
     `);

--- a/backend/config/schema.sql
+++ b/backend/config/schema.sql
@@ -43,6 +43,11 @@ CREATE TABLE IF NOT EXISTS users (
 -- Migration: add is_bot column to existing tables (safe to run repeatedly)
 ALTER TABLE users ADD COLUMN IF NOT EXISTS is_bot BOOLEAN DEFAULT false;
 
+-- ADR-020 D3: structured message payload (approval cards and future
+-- server-defined message components). Self-applies at boot, same pattern
+-- as is_bot above. NULL for ordinary messages.
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS payload JSONB;
+
 -- Sprint B5: message reactions. One row per (message, user, emoji) — a user
 -- can stack different emojis on the same message but each emoji is binary
 -- (toggle on/off). PG-only; Mongo fallback path doesn't get reactions in v1.

--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -27,6 +27,9 @@ interface NormalizedMessage {
   user_id: string;
   content: string;
   message_type: string;
+  // ADR-020 D3: structured card payload — must survive the Mongo fallback's
+  // whitelist or cards silently vanish on that path.
+  payload?: unknown;
   created_at: unknown;
   updated_at: unknown;
   user?: { username: string; profile_picture?: string };
@@ -57,6 +60,7 @@ const normalizeMongo = (m: Record<string, unknown>): NormalizedMessage => {
     user_id: idSource ? (idSource as { toString(): string }).toString() : '',
     content: m.content as string,
     message_type: (m.messageType as string) || 'text',
+    ...(m.payload != null ? { payload: m.payload } : {}),
     created_at: m.createdAt,
     updated_at: m.updatedAt,
     user: populatedUsername

--- a/backend/models/ApprovalAction.ts
+++ b/backend/models/ApprovalAction.ts
@@ -13,8 +13,9 @@ import mongoose, { Document, Model, Schema, Types } from 'mongoose';
  *   - transitions are one-way and idempotent: a card resolves at most once,
  *     and execution happens at most once (executedAt set exactly when the
  *     approved action ran)
- *   - past expiresAt, resolution fails closed (410) and the row is marked
- *     expired on read — "retiring an escalation is never an approval"
+ *   - expiresAt is advisory AGE, never refusal (ADR-017:201): a decision
+ *     past it is honored and stamped `decidedAfterExpiry`. Nothing writes
+ *     status 'expired' in v1 — the state exists for future sweeps only.
  *
  * The resolved row IS the AuthorizedAction record from ADR-020 D2: it links
  * the approving user, the executing agent identity, the action + params, and

--- a/backend/models/ApprovalAction.ts
+++ b/backend/models/ApprovalAction.ts
@@ -45,6 +45,10 @@ export interface IApprovalAction extends Document {
   decision?: ApprovalDecision;
   resolvedBy?: Types.ObjectId;
   resolvedAt?: Date;
+  // ADR-017:201 — expiry is advisory age, not refusal. A decision landed
+  // past expiresAt is honored AND stamped, so the audit record carries the
+  // staleness fact.
+  decidedAfterExpiry?: boolean;
   executedAt?: Date;
   executionResult?: unknown;
   executionError?: string;
@@ -73,6 +77,7 @@ const ApprovalActionSchema = new Schema<IApprovalAction>(
     decision: { type: String, enum: ['approved', 'declined'] },
     resolvedBy: { type: Schema.Types.ObjectId, ref: 'User' },
     resolvedAt: { type: Date },
+    decidedAfterExpiry: { type: Boolean },
     executedAt: { type: Date },
     executionResult: { type: Schema.Types.Mixed },
     executionError: { type: String },

--- a/backend/models/ApprovalAction.ts
+++ b/backend/models/ApprovalAction.ts
@@ -1,0 +1,96 @@
+import mongoose, { Document, Model, Schema, Types } from 'mongoose';
+
+/**
+ * ApprovalAction — ADR-020 D2/D3, implementing ADR-017's escalation-card
+ * lifecycle for agent-proposed actions.
+ *
+ * One row per proposed action. The chat card (Message.payload with
+ * kind 'approval-card') is the RENDER of this row — this row is the truth.
+ * Lifecycle (ADR-017): flagged → resolved | expired | moot. Invariants the
+ * route layer enforces and tests pin:
+ *   - only a HUMAN writes `resolved` (no agent token may decide)
+ *   - only the owning user may decide (ownerUserId)
+ *   - transitions are one-way and idempotent: a card resolves at most once,
+ *     and execution happens at most once (executedAt set exactly when the
+ *     approved action ran)
+ *   - past expiresAt, resolution fails closed (410) and the row is marked
+ *     expired on read — "retiring an escalation is never an approval"
+ *
+ * The resolved row IS the AuthorizedAction record from ADR-020 D2: it links
+ * the approving user, the executing agent identity, the action + params, and
+ * the execution result. Never deleted (audit trail); no TTL index.
+ */
+
+export type ApprovalStatus = 'flagged' | 'resolved' | 'expired' | 'moot';
+export type ApprovalDecision = 'approved' | 'declined';
+
+// Registry of executable action types. Adding an action means adding its
+// executor in services/approvalExecutors.ts — the enum here only widens in
+// the same PR as an executor, so a card can never exist for an action the
+// kernel cannot run.
+export type ApprovalActionType = 'create_pod';
+
+export interface IApprovalAction extends Document {
+  podId: Types.ObjectId;
+  // Message id of the rendered card. String because messages live in PG
+  // (serial int) with a Mongo fallback (ObjectId hex).
+  messageId?: string;
+  ownerUserId: Types.ObjectId;
+  agentName: string;
+  instanceId: string;
+  actionType: ApprovalActionType;
+  params: Record<string, unknown>;
+  summary: string;
+  status: ApprovalStatus;
+  decision?: ApprovalDecision;
+  resolvedBy?: Types.ObjectId;
+  resolvedAt?: Date;
+  executedAt?: Date;
+  executionResult?: unknown;
+  executionError?: string;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+const ApprovalActionSchema = new Schema<IApprovalAction>(
+  {
+    podId: { type: Schema.Types.ObjectId, ref: 'Pod', required: true },
+    messageId: { type: String },
+    ownerUserId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    agentName: { type: String, required: true, lowercase: true, trim: true },
+    instanceId: { type: String, default: 'default' },
+    actionType: { type: String, enum: ['create_pod'], required: true },
+    params: { type: Schema.Types.Mixed, default: {} },
+    summary: { type: String, required: true, maxlength: 500 },
+    status: {
+      type: String,
+      enum: ['flagged', 'resolved', 'expired', 'moot'],
+      default: 'flagged',
+    },
+    decision: { type: String, enum: ['approved', 'declined'] },
+    resolvedBy: { type: Schema.Types.ObjectId, ref: 'User' },
+    resolvedAt: { type: Date },
+    executedAt: { type: Date },
+    executionResult: { type: Schema.Types.Mixed },
+    executionError: { type: String },
+    // Plain Date — deliberately NOT a Mongo TTL index: expiry is a lifecycle
+    // STATE (the card renders "expired"), not a deletion.
+    expiresAt: { type: Date, default: () => new Date(Date.now() + DEFAULT_TTL_MS) },
+  },
+  { timestamps: true },
+);
+
+ApprovalActionSchema.index({ podId: 1, status: 1 });
+ApprovalActionSchema.index({ ownerUserId: 1, status: 1 });
+
+export const ApprovalAction: Model<IApprovalAction> =
+  (mongoose.models.ApprovalAction as Model<IApprovalAction>)
+  || mongoose.model<IApprovalAction>('ApprovalAction', ApprovalActionSchema);
+
+export default ApprovalAction;
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/models/Message.ts
+++ b/backend/models/Message.ts
@@ -1,12 +1,23 @@
 import mongoose, { Document, Model, Schema, Types } from 'mongoose';
 
-export type MessageType = 'text' | 'image' | 'system';
+// 'card' (ADR-020 D3): a message whose meaning lives in `payload`, not
+// regex-sniffed out of `content`. The union and the schema enum below are
+// declared independently — change BOTH.
+export type MessageType = 'text' | 'image' | 'system' | 'card';
 
 export interface IMessage extends Document {
   podId: Types.ObjectId;
   userId: Types.ObjectId;
   content: string;
   messageType: MessageType;
+  // Structured component payload (approval cards). Mixed like
+  // AgentEvent.payload; null/absent for ordinary messages.
+  payload?: unknown;
+  // Free-form service metadata. agentMessageService has passed this to the
+  // constructor since forever, but strict-mode Mongoose silently DROPPED it
+  // because the schema never declared it — declared now so the Mongo
+  // fallback path stops losing it.
+  metadata?: Record<string, unknown>;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -17,9 +28,11 @@ const MessageSchema = new Schema<IMessage>({
   content: { type: String, required: true },
   messageType: {
     type: String,
-    enum: ['text', 'image', 'system'],
+    enum: ['text', 'image', 'system', 'card'],
     default: 'text',
   },
+  payload: { type: Schema.Types.Mixed },
+  metadata: { type: Schema.Types.Mixed },
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now },
 });

--- a/backend/models/pg/Message.ts
+++ b/backend/models/pg/Message.ts
@@ -14,6 +14,9 @@ interface MessageRow {
   user_id: string;
   content: string;
   message_type: string;
+  // ADR-020 D3: structured component payload (approval cards). JSONB; null
+  // for ordinary messages.
+  payload?: unknown;
   reply_to_message_id?: string;
   created_at: unknown;
   updated_at?: unknown;
@@ -79,18 +82,20 @@ class Message {
     content: string,
     messageType = 'text',
     replyToMessageId: string | null = null,
+    payload: unknown = null,
   ): Promise<MessageRow> {
     console.log('Creating message with params:', {
       podId, userId, content, messageType, podIdType: typeof podId,
     });
     const query = `
-      INSERT INTO messages (pod_id, user_id, content, message_type, reply_to_message_id)
-      VALUES ($1, $2, $3, $4, $5)
+      INSERT INTO messages (pod_id, user_id, content, message_type, reply_to_message_id, payload)
+      VALUES ($1, $2, $3, $4, $5, $6)
       RETURNING *
     `;
     try {
       const result = await (pool as PgPool).query(query, [
         podId, userId, content || '', messageType, replyToMessageId || null,
+        payload == null ? null : JSON.stringify(payload),
       ]);
       await (pool as PgPool).query(
         'UPDATE pods SET updated_at = CURRENT_TIMESTAMP WHERE id = $1',
@@ -118,7 +123,7 @@ class Message {
     try {
       let query = `
         SELECT
-          m.id, m.pod_id, m.user_id, m.content, m.message_type,
+          m.id, m.pod_id, m.user_id, m.content, m.message_type, m.payload,
           m.reply_to_message_id, m.created_at, m.updated_at,
           u._id as user_db_id, u.username, u.profile_picture, u.is_bot,
           rm.id as reply_msg_id, rm.content as reply_content,
@@ -151,7 +156,7 @@ class Message {
     try {
       const query = `
         SELECT
-          m.id, m.pod_id, m.user_id, m.content, m.message_type,
+          m.id, m.pod_id, m.user_id, m.content, m.message_type, m.payload,
           m.reply_to_message_id, m.created_at, m.updated_at,
           u._id as user_db_id, u.username, u.profile_picture,
           rm.id as reply_msg_id, rm.content as reply_content,
@@ -180,6 +185,21 @@ class Message {
       RETURNING *
     `;
     const result = await (pool as PgPool).query(query, [content, id]);
+    return result.rows[0] as unknown as MessageRow | undefined;
+  }
+
+  // ADR-020 D3: card status transitions rewrite the message's payload so
+  // every client (and late loaders) see the authoritative card face.
+  static async updatePayload(id: string, payload: unknown): Promise<MessageRow | undefined> {
+    const query = `
+      UPDATE messages
+      SET payload = $1, updated_at = CURRENT_TIMESTAMP
+      WHERE id = $2
+      RETURNING *
+    `;
+    const result = await (pool as PgPool).query(query, [
+      payload == null ? null : JSON.stringify(payload), id,
+    ]);
     return result.rows[0] as unknown as MessageRow | undefined;
   }
 

--- a/backend/routes/approvals.ts
+++ b/backend/routes/approvals.ts
@@ -1,0 +1,74 @@
+// Approval-card resolution — ADR-020 D3, implementing ADR-017's decision
+// authorization. HUMAN-ONLY by construction: plain `auth` middleware, never
+// dualAuth — "no agent may decide in v1" — with a second isBot check inside
+// the service as defense in depth.
+// ESM import (not require) so CodeQL's js/missing-rate-limiting query
+// recognises the limiter on the POST route — same pattern as messages.ts.
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import { createHash } from 'crypto';
+import type { Request } from 'express';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const express = require('express');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const auth = require('../middleware/auth');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { resolveApproval } = require('../services/approvalActionService');
+
+const router = express.Router();
+
+// Limiter BEFORE auth — the route-order rule messages.ts documents (limiter
+// after auth is the shape CodeQL flags and the shape that lets a hot loop
+// burn auth work before being throttled).
+const approvalResolveLimit = rateLimit({
+  windowMs: 60_000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req: Request): string => {
+    const authHeader = req.get('Authorization') || req.get('x-auth-token');
+    if (authHeader) {
+      return `apr:${createHash('sha256').update(authHeader).digest('hex').slice(0, 16)}`;
+    }
+    return req.ip ? ipKeyGenerator(req.ip) : 'anon';
+  },
+  handler: (_req, res) => res.status(429).json({ error: 'rate limit exceeded: 30 approval decisions per 60s' }),
+});
+
+interface AuthedReq {
+  params?: Record<string, string>;
+  body?: Record<string, unknown>;
+  userId?: string;
+  user?: { id?: string; _id?: unknown };
+}
+interface Res {
+  status: (n: number) => Res;
+  json: (d: unknown) => void;
+}
+
+router.post('/:approvalId/resolve', approvalResolveLimit, auth, async (req: AuthedReq, res: Res) => {
+  try {
+    const approvalId = String(req.params?.approvalId || '');
+    // Deliberately NOT req.agentUser — an agent token must never reach a
+    // decision. `auth` doesn't set agentUser, so this is belt to the
+    // service-layer isBot suspenders.
+    const callerUserId = String(req.userId || req.user?._id || req.user?.id || '');
+    if (!callerUserId) return res.status(401).json({ error: 'Unauthorized' });
+    if (!/^[a-f0-9]{24}$/i.test(approvalId)) {
+      return res.status(400).json({ error: 'Invalid approval id' });
+    }
+    const decision = String((req.body || {}).decision || '');
+    if (decision !== 'approved' && decision !== 'declined') {
+      return res.status(400).json({ error: "decision must be 'approved' or 'declined'" });
+    }
+    const result = await resolveApproval({ approvalId, callerUserId, decision });
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    console.error('POST /approvals/:id/resolve error:', err);
+    return res.status(500).json({ error: 'Server Error' });
+  }
+});
+
+module.exports = router;
+
+export {};

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -194,6 +194,8 @@ app.use('/api', podInvitesRoutes);
 app.use('/api/pods', podRoutes);
 app.use('/api/billing', require('./routes/billing'));
 app.use('/api/messages', messageRoutes);
+// ADR-020 D3: approval-card decisions (human-only; see routes/approvals.ts)
+app.use('/api/approvals', require('./routes/approvals'));
 app.use('/api/uploads', uploadsRoutes);
 app.use('/api/docs', docsRoutes);
 app.use('/api/summaries', summariesRoutes);

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -95,6 +95,10 @@ interface PostMessageOptions {
   content: string;
   metadata?: MetadataDoc;
   messageType?: string;
+  // ADR-020 D3: structured component payload (approval cards). Bypasses
+  // sanitizeAgentContent by design — content stays the sanitized fallback
+  // text; payload is server-composed, never model prose.
+  payload?: unknown;
   instanceId?: string;
   displayName?: string;
   replyToMessageId?: string | null;
@@ -108,6 +112,7 @@ interface PostTargetOptions {
   content: string;
   messageType?: string;
   metadata?: MetadataDoc;
+  payload?: unknown;
   agentUser: AgentUserDoc;
   displayName?: string;
   replyToMessageId?: string | null;
@@ -153,6 +158,7 @@ interface MessageNormalized {
   self?: boolean;
   createdAt: Date | string;
   metadata?: MetadataDoc;
+  payload?: unknown;
   profile_picture?: string;
   replyTo?: { id: string; content: string; username: string; userId: string } | null;
 }
@@ -808,6 +814,7 @@ class AgentMessageService {
       content,
       metadata = {},
       messageType = 'text',
+      payload = null,
       instanceId = 'default',
       displayName,
       replyToMessageId = null,
@@ -1228,6 +1235,7 @@ class AgentMessageService {
       content: sanitizedContent,
       messageType,
       metadata,
+      payload,
       agentUser,
       displayName,
       replyToMessageId,
@@ -1287,7 +1295,7 @@ class AgentMessageService {
   static async _postToTarget(options: PostTargetOptions): Promise<{ message: MessageNormalized; summary: unknown }> {
     const {
       agentName, instanceId = 'default', podId, content, messageType = 'text',
-      metadata = {}, agentUser, displayName, replyToMessageId = null, skipDeliveryUpdate = false, skipSummaryPersistence = false,
+      metadata = {}, payload = null, agentUser, displayName, replyToMessageId = null, skipDeliveryUpdate = false, skipSummaryPersistence = false,
     } = options;
 
     // The installation label belongs to this pod; the User label belongs to
@@ -1322,13 +1330,14 @@ class AgentMessageService {
           console.warn('[agent-msg] PG pod backfill skipped:', (syncErr as Error).message);
         }
         const newMessage = await (PGMessage as {
-          create(podId: string, userId: string, content: string, type: string, replyToMessageId?: string | null): Promise<Record<string, unknown>>;
+          create(podId: string, userId: string, content: string, type: string, replyToMessageId?: string | null, payload?: unknown): Promise<Record<string, unknown>>;
         }).create(
           String(podId),
           String(agentUser._id),
           content,
           messageType,
           replyToMessageId,
+          payload,
         );
 
         // The raw INSERT row carries no reply JOIN, so a replying agent's
@@ -1363,6 +1372,7 @@ class AgentMessageService {
           profile_picture: agentUser.profilePicture,
           createdAt: newMessage.created_at as Date,
           metadata,
+          ...(payload != null ? { payload: newMessage.payload ?? payload } : {}),
         };
       } catch (pgError) {
         console.error('PostgreSQL message creation failed, falling back to MongoDB:', pgError);
@@ -1376,6 +1386,7 @@ class AgentMessageService {
         podId,
         messageType,
         metadata,
+        ...(payload != null ? { payload } : {}),
       });
 
       await mongoMessage.save();
@@ -1447,6 +1458,9 @@ class AgentMessageService {
         profile_picture: (message as MessageNormalized).profile_picture || agentUser.profilePicture,
         createdAt: (message as MessageNormalized).createdAt,
         metadata: (message as MessageNormalized).metadata || metadata,
+        // ADR-020 D3: card payloads ride the broadcast, same reason as
+        // replyTo below — the literal is a whitelist, absent fields vanish.
+        payload: (message as MessageNormalized).payload ?? payload ?? null,
         // Reply quote rides the broadcast so live viewers see the quoted
         // context without a reload (#646).
         replyTo: (message as MessageNormalized).replyTo ?? null,

--- a/backend/services/approvalActionService.ts
+++ b/backend/services/approvalActionService.ts
@@ -225,13 +225,14 @@ export const resolveApproval = async (options: ResolveOptions): Promise<ResolveR
     };
   }
 
-  if (row.expiresAt && row.expiresAt.getTime() < Date.now()) {
-    row.status = 'expired';
-    await row.save();
-    await updateCardEverywhere(row);
-    // Fail closed: "retiring an escalation is never an approval."
-    return { status: 410, body: { error: 'Approval expired', approval: buildCardPayload(row) } };
-  }
+  // ADR-017:201 — expired stays DECIDABLE. Refusing a late decision would
+  // convert fail-closed into fail-silent: the owner's explicit intent
+  // dropped because a timer won. `expiresAt` is advisory age the card
+  // renders as a warning; a decision past it is honored and stamped
+  // `decidedAfterExpiry` so the audit record carries the staleness fact.
+  // (ADR-020's original no-op-on-expiry contradicted the ADR it implements
+  // — caught by pod-architect in the 2026-08-13 fleet review.)
+  const decidedAfterExpiry = !!(row.expiresAt && row.expiresAt.getTime() < Date.now());
 
   // Atomic transition — the status filter makes a concurrent double-resolve
   // lose cleanly instead of double-executing.
@@ -239,7 +240,11 @@ export const resolveApproval = async (options: ResolveOptions): Promise<ResolveR
     { _id: row._id, status: 'flagged' },
     {
       $set: {
-        status: 'resolved', decision, resolvedBy: callerUserId, resolvedAt: new Date(),
+        status: 'resolved',
+        decision,
+        resolvedBy: callerUserId,
+        resolvedAt: new Date(),
+        ...(decidedAfterExpiry ? { decidedAfterExpiry: true } : {}),
       },
     },
     { new: true },
@@ -309,7 +314,13 @@ const executeCreatePod = async (row: IApprovalAction): Promise<unknown> => {
   }
 
   // Bring the proposing agent along: clone its origin-pod installation shape
-  // into the new pod, then add its bot user to members.
+  // into the new pod, then add its bot user to members. A join failure must
+  // NOT be swallowed into a clean "done" — the pod is real (user owns it),
+  // but a membership-without-installation agent 403s on every post, so the
+  // card must carry the partial truth (sprint-review finding, 2026-08-13:
+  // execution is at-most-once, so a lied face here is unrecoverable).
+  let agentJoined = false;
+  let agentJoinError: string | undefined;
   try {
     // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
     const AgentIdentityService = require('./agentIdentityService');
@@ -348,12 +359,22 @@ const executeCreatePod = async (row: IApprovalAction): Promise<unknown> => {
         { _id: pod._id, members: { $ne: botUser._id } },
         { $push: { members: botUser._id } },
       );
+      agentJoined = true;
+    } else {
+      agentJoinError = 'agent identity could not be resolved';
     }
   } catch (agentErr) {
-    console.warn('[approval] create_pod agent-join failed:', (agentErr as Error).message);
+    agentJoinError = (agentErr as Error).message?.slice(0, 200) || 'agent join failed';
+    console.warn('[approval] create_pod agent-join failed:', agentJoinError);
   }
 
-  return { podId: String(pod._id), podName: pod.name, podType: type };
+  return {
+    podId: String(pod._id),
+    podName: pod.name,
+    podType: type,
+    agentJoined,
+    ...(agentJoinError ? { agentJoinError } : {}),
+  };
 };
 
 export default { proposeAction, resolveApproval, buildCardPayload };

--- a/backend/services/approvalActionService.ts
+++ b/backend/services/approvalActionService.ts
@@ -1,0 +1,362 @@
+/**
+ * approvalActionService — ADR-020 D2/D3 (implements ADR-017's card lifecycle).
+ *
+ * propose → a flagged ApprovalAction row + a 'card' message whose payload
+ * renders it; resolve → one-way, owner-only, human-only transition that (on
+ * approval) executes the action with the USER's authority and rewrites the
+ * card payload so every client converges on the authoritative face.
+ *
+ * Executor contract (D2): the agent identity executes, the user's authority
+ * owns. Every executor receives the resolved ApprovalAction and MUST create
+ * resources owned by `ownerUserId` — never by the agent's bot user. The
+ * resolved row is the AuthorizedAction audit record.
+ */
+import ApprovalAction, { IApprovalAction, ApprovalActionType } from '../models/ApprovalAction';
+import Pod from '../models/Pod';
+import User from '../models/User';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { AgentInstallation } = require('../models/AgentRegistry');
+
+const CARD_KIND = 'approval-card';
+
+// Pod types an approved create_pod may mint. DM-shaped types are excluded for
+// the same reason podController's DM guard exists: minting a 1:1-typed pod
+// with arbitrary membership breaks the §3.10 invariant.
+const CREATABLE_POD_TYPES = new Set(['chat', 'team']);
+
+export interface CardPayload {
+  kind: typeof CARD_KIND;
+  approvalId: string;
+  actionType: ApprovalActionType;
+  summary: string;
+  params: Record<string, unknown>;
+  status: string;
+  decision?: string;
+  // Owner id lets the client decide whether to show action buttons. This is
+  // shared state (who owns the card), NOT per-viewer state — never broadcast
+  // per-viewer fields like `canApprove` (the reaction `mine` lesson).
+  ownerUserId: string;
+  agentName: string;
+  instanceId: string;
+  expiresAt: string;
+  executionResult?: unknown;
+  executionError?: string;
+}
+
+export const buildCardPayload = (row: IApprovalAction): CardPayload => ({
+  kind: CARD_KIND,
+  approvalId: String(row._id),
+  actionType: row.actionType,
+  summary: row.summary,
+  params: (row.params || {}) as Record<string, unknown>,
+  status: row.status,
+  ...(row.decision ? { decision: row.decision } : {}),
+  ownerUserId: String(row.ownerUserId),
+  agentName: row.agentName,
+  instanceId: row.instanceId || 'default',
+  expiresAt: row.expiresAt?.toISOString?.() || new Date(row.expiresAt).toISOString(),
+  ...(row.executionResult !== undefined ? { executionResult: row.executionResult } : {}),
+  ...(row.executionError ? { executionError: row.executionError } : {}),
+});
+
+interface ProposeOptions {
+  podId: string;
+  agentName: string;
+  instanceId: string;
+  displayName?: string;
+  actionType: string;
+  params: Record<string, unknown>;
+  summary: string;
+  installationConfig?: unknown;
+}
+
+interface ProposeResult {
+  ok: boolean;
+  error?: string;
+  approvalId?: string;
+  messageId?: string;
+}
+
+const validateParams = (actionType: ApprovalActionType, params: Record<string, unknown>): string | null => {
+  if (actionType === 'create_pod') {
+    const name = String(params.name || '').trim();
+    if (!name) return 'params.name is required for create_pod';
+    if (name.length > 80) return 'params.name must be 80 characters or fewer';
+    const type = String(params.type || 'chat');
+    if (!CREATABLE_POD_TYPES.has(type)) {
+      return `params.type must be one of: ${Array.from(CREATABLE_POD_TYPES).join(', ')}`;
+    }
+    return null;
+  }
+  return `unknown actionType '${actionType}'`;
+};
+
+export const proposeAction = async (options: ProposeOptions): Promise<ProposeResult> => {
+  const {
+    podId, agentName, instanceId, displayName, actionType, params, summary, installationConfig,
+  } = options;
+
+  if (actionType !== 'create_pod') {
+    return { ok: false, error: `unknown actionType '${actionType}' — known: create_pod` };
+  }
+  const paramsError = validateParams(actionType, params || {});
+  if (paramsError) return { ok: false, error: paramsError };
+  const trimmedSummary = String(summary || '').trim();
+  if (!trimmedSummary) return { ok: false, error: 'summary is required' };
+
+  // The decider is the pod's owner — for the Guide's workspace, the user.
+  // A pod with no resolvable owner cannot host approval cards.
+  const pod = await Pod.findById(podId).select('createdBy').lean() as { createdBy?: unknown } | null;
+  if (!pod?.createdBy) return { ok: false, error: 'pod has no resolvable owner' };
+
+  const row = await ApprovalAction.create({
+    podId,
+    ownerUserId: pod.createdBy,
+    agentName: String(agentName).toLowerCase(),
+    instanceId: instanceId || 'default',
+    actionType,
+    params: params || {},
+    summary: trimmedSummary.slice(0, 500),
+  });
+
+  // The card message. `content` is the plain-text fallback so legacy
+  // surfaces (v1, digests, notifications) still show something meaningful.
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const AgentMessageService = require('./agentMessageService');
+  const posted = await AgentMessageService.postMessage({
+    agentName,
+    instanceId,
+    displayName,
+    podId: String(podId),
+    messageType: 'card',
+    payload: buildCardPayload(row),
+    content: `[approval needed] ${trimmedSummary}`,
+    metadata: { source: 'approval-card', approvalId: String(row._id) },
+    installationConfig,
+  });
+
+  if (!posted?.success || !posted?.message) {
+    // Card without a render is a dead flag — mark it moot rather than leave
+    // a phantom pending approval nothing can see. (ADR-017: moot is never a
+    // default decision branch — this is a delivery failure, not a decision.)
+    row.status = 'moot';
+    await row.save();
+    return { ok: false, error: 'card message could not be posted' };
+  }
+
+  const messageId = String(posted.message._id || posted.message.id || '');
+  row.messageId = messageId;
+  await row.save();
+  return { ok: true, approvalId: String(row._id), messageId };
+};
+
+// ── resolution ──────────────────────────────────────────────────────────────
+
+interface ResolveOptions {
+  approvalId: string;
+  callerUserId: string;
+  decision: 'approved' | 'declined';
+}
+
+export interface ResolveResult {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+const updateCardEverywhere = async (row: IApprovalAction): Promise<void> => {
+  const payload = buildCardPayload(row);
+  const messageId = row.messageId;
+  if (messageId) {
+    try {
+      if (process.env.PG_HOST && /^\d+$/.test(messageId)) {
+        // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+        const PGMessage = require('../models/pg/Message');
+        await PGMessage.updatePayload(messageId, payload);
+      } else {
+        // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+        const MongoMessage = require('../models/Message');
+        await MongoMessage.updateOne({ _id: messageId }, { $set: { payload } });
+      }
+    } catch (err) {
+      console.warn('[approval] card message payload update failed:', (err as Error).message);
+    }
+  }
+  // Same shape discipline as emitReactionChange: fire-and-forget, never fatal.
+  try {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const socketConfig = require('../config/socket');
+    const io = socketConfig.getIO();
+    if (io && messageId) {
+      io.to(`pod_${String(row.podId)}`).emit('messageCardUpdated', {
+        messageId: String(messageId),
+        podId: String(row.podId),
+        payload,
+      });
+    }
+  } catch (err) {
+    console.warn('[approval] socket emit failed:', (err as Error).message);
+  }
+};
+
+export const resolveApproval = async (options: ResolveOptions): Promise<ResolveResult> => {
+  const { approvalId, callerUserId, decision } = options;
+
+  const row = await ApprovalAction.findById(approvalId);
+  if (!row) return { status: 404, body: { error: 'Approval not found' } };
+
+  if (String(row.ownerUserId) !== String(callerUserId)) {
+    return { status: 403, body: { error: 'Only the workspace owner can decide this' } };
+  }
+  // ADR-017 §Decision-authorization: no agent may decide, even one holding
+  // the owner's pod. Route-level auth already excludes agent tokens; this is
+  // defense in depth against a future dualAuth slip.
+  const caller = await User.findById(callerUserId).select('isBot').lean() as { isBot?: boolean } | null;
+  if (!caller || caller.isBot) {
+    return { status: 403, body: { error: 'Only a human can decide an approval' } };
+  }
+
+  if (row.status !== 'flagged') {
+    // Idempotent from the client's view: the authoritative state comes back,
+    // but nothing re-executes.
+    return {
+      status: 409,
+      body: { error: `Already ${row.status}`, approval: buildCardPayload(row) },
+    };
+  }
+
+  if (row.expiresAt && row.expiresAt.getTime() < Date.now()) {
+    row.status = 'expired';
+    await row.save();
+    await updateCardEverywhere(row);
+    // Fail closed: "retiring an escalation is never an approval."
+    return { status: 410, body: { error: 'Approval expired', approval: buildCardPayload(row) } };
+  }
+
+  // Atomic transition — the status filter makes a concurrent double-resolve
+  // lose cleanly instead of double-executing.
+  const transitioned = await ApprovalAction.findOneAndUpdate(
+    { _id: row._id, status: 'flagged' },
+    {
+      $set: {
+        status: 'resolved', decision, resolvedBy: callerUserId, resolvedAt: new Date(),
+      },
+    },
+    { new: true },
+  );
+  if (!transitioned) {
+    const current = await ApprovalAction.findById(approvalId);
+    return {
+      status: 409,
+      body: { error: 'Already decided', approval: current ? buildCardPayload(current) : null },
+    };
+  }
+
+  if (decision === 'approved') {
+    try {
+      const result = await executeAction(transitioned);
+      transitioned.executedAt = new Date();
+      transitioned.executionResult = result;
+    } catch (err) {
+      // Honest failure face: resolved + approved + executionError. Never
+      // roll back the decision — the user DID approve; the execution failed.
+      transitioned.executionError = (err as Error).message?.slice(0, 500) || 'execution failed';
+    }
+    await transitioned.save();
+  }
+
+  await updateCardEverywhere(transitioned);
+  return { status: 200, body: { ok: true, approval: buildCardPayload(transitioned) } };
+};
+
+// ── executors (D2: user authority owns the result) ──────────────────────────
+
+const executeAction = async (row: IApprovalAction): Promise<unknown> => {
+  if (row.actionType === 'create_pod') return executeCreatePod(row);
+  throw new Error(`no executor for actionType '${row.actionType}'`);
+};
+
+const executeCreatePod = async (row: IApprovalAction): Promise<unknown> => {
+  const params = (row.params || {}) as { name?: string; description?: string; type?: string };
+  const name = String(params.name || '').trim();
+  const type = CREATABLE_POD_TYPES.has(String(params.type)) ? String(params.type) : 'chat';
+
+  // D2: the USER owns the pod. The proposing agent joins as a member — with
+  // an installation, because membership without an AgentInstallation cannot
+  // post (the runtime 403s).
+  const pod = await Pod.create({
+    name,
+    description: String(params.description || '').slice(0, 300),
+    type,
+    joinPolicy: 'invite-only',
+    createdBy: row.ownerUserId,
+    members: [row.ownerUserId],
+  });
+
+  // PG mirror, FK-safe order (the 2026-07-24 lesson): user first, then pod.
+  try {
+    if (process.env.PG_HOST) {
+      // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+      const AgentIdentityService = require('./agentIdentityService');
+      const ownerDoc = await User.findById(row.ownerUserId);
+      if (ownerDoc) await AgentIdentityService.syncUserToPostgreSQL(ownerDoc);
+      // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+      const { syncPodFromMongo } = require('./pgPodSyncService');
+      await syncPodFromMongo(String(pod._id), String(row.ownerUserId));
+    }
+  } catch (pgErr) {
+    console.warn('[approval] create_pod PG mirror failed:', (pgErr as Error).message);
+  }
+
+  // Bring the proposing agent along: clone its origin-pod installation shape
+  // into the new pod, then add its bot user to members.
+  try {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const AgentIdentityService = require('./agentIdentityService');
+    const originInstall = await AgentInstallation.findOne({
+      agentName: row.agentName,
+      instanceId: row.instanceId || 'default',
+      podId: row.podId,
+      status: 'active',
+    }).lean();
+    await AgentInstallation.findOneAndUpdate(
+      { agentName: row.agentName, podId: pod._id, instanceId: row.instanceId || 'default' },
+      {
+        $set: {
+          status: 'active',
+          version: originInstall?.version || '1.0.0',
+          displayName: originInstall?.displayName,
+          scopes: originInstall?.scopes || ['context:read', 'messages:write'],
+          config: originInstall?.config || {},
+        },
+        $setOnInsert: {
+          agentName: row.agentName,
+          podId: pod._id,
+          instanceId: row.instanceId || 'default',
+          installedBy: row.ownerUserId,
+        },
+      },
+      { upsert: true, setDefaultsOnInsert: true },
+    );
+    const svc = AgentIdentityService.default || AgentIdentityService;
+    const botUser = await svc.getOrCreateAgentUser(row.agentName, {
+      instanceId: row.instanceId || 'default',
+      displayName: originInstall?.displayName,
+    });
+    if (botUser?._id) {
+      await Pod.updateOne(
+        { _id: pod._id, members: { $ne: botUser._id } },
+        { $push: { members: botUser._id } },
+      );
+    }
+  } catch (agentErr) {
+    console.warn('[approval] create_pod agent-join failed:', (agentErr as Error).message);
+  }
+
+  return { podId: String(pod._id), podName: pod.name, podType: type };
+};
+
+export default { proposeAction, resolveApproval, buildCardPayload };
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/docs/adr/ADR-020-admin-guide-delegated-authority.md
+++ b/docs/adr/ADR-020-admin-guide-delegated-authority.md
@@ -55,7 +55,14 @@ never an approval; fail closed**. Concretely:
 - Messages gain a real structured `payload` (Mongo + PG both — today neither store has a
   metadata column and every "card" is a regex sentinel in the content string).
 - Cards are actionable by the workspace owner only; execution is idempotent (a card executes
-  at most once — approve-after-expiry and double-taps are no-ops with honest copy).
+  at most once — double-taps and concurrent resolves lose cleanly with honest copy).
+- **Expiry is advisory age, not refusal** (amended 2026-08-13, fleet review): per
+  ADR-017:201 an expired card stays *decidable* — refusing a late decision would convert
+  fail-closed into fail-silent, dropping the owner's explicit intent because a timer won.
+  The card renders an age warning beside live owner controls; a late decision is honored
+  and stamped `decidedAfterExpiry` on the audit record. This ADR's original
+  approve-after-expiry-is-a-no-op wording contradicted the ADR it implements — caught by
+  pod-architect reviewing the first kernel PR.
 - Interaction follows the proven reaction-chip pattern: click → authenticated POST →
   server-state change → socket fanout.
 - `agent.ask` (agent→agent, CLI-only) is unchanged; its shape informed the design and its

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -939,11 +939,12 @@
     "decline": "Decline",
     "deciding": "Deciding…",
     "waitingForOwner": "Waiting for the workspace owner to decide.",
+    "aged": "This proposal has been waiting a while — double-check it still makes sense.",
     "approved": "✓ Approved — done.",
     "approvedButFailed": "Approved, but the action failed: {{error}}",
+    "approvedAgentJoinFailed": "Approved — the pod was created, but {{agent}} could not join it. Open the pod and re-add the agent.",
     "declined": "Declined.",
     "expired": "Expired without a decision.",
-    "moot": "No longer applicable.",
     "openResult": "Open the new pod",
     "errors": {
       "expired": "This approval expired before the decision landed.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -933,6 +933,23 @@
       "creating": "Creating…"
     }
   },
+  "approvalCard": {
+    "badge": "Approval needed",
+    "approve": "Approve",
+    "decline": "Decline",
+    "deciding": "Deciding…",
+    "waitingForOwner": "Waiting for the workspace owner to decide.",
+    "approved": "✓ Approved — done.",
+    "approvedButFailed": "Approved, but the action failed: {{error}}",
+    "declined": "Declined.",
+    "expired": "Expired without a decision.",
+    "moot": "No longer applicable.",
+    "openResult": "Open the new pod",
+    "errors": {
+      "expired": "This approval expired before the decision landed.",
+      "failed": "Couldn't record the decision. Try again."
+    }
+  },
   "marketplace": {
     "title": "Marketplace",
     "subtitle": "Browse and install agents, apps, and integrations.",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -934,11 +934,12 @@
     "decline": "拒绝",
     "deciding": "处理中…",
     "waitingForOwner": "等待工作区所有者决定。",
+    "aged": "该提议已等待较久 — 请确认它仍然适用。",
     "approved": "✓ 已批准 — 已完成。",
     "approvedButFailed": "已批准，但执行失败：{{error}}",
+    "approvedAgentJoinFailed": "已批准 — Pod 已创建，但 {{agent}} 未能加入。请打开该 Pod 重新添加智能体。",
     "declined": "已拒绝。",
     "expired": "已过期，未做出决定。",
-    "moot": "已不再适用。",
     "openResult": "打开新 Pod",
     "errors": {
       "expired": "该批准在决定生效前已过期。",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -928,6 +928,23 @@
       "creating": "创建中…"
     }
   },
+  "approvalCard": {
+    "badge": "需要批准",
+    "approve": "批准",
+    "decline": "拒绝",
+    "deciding": "处理中…",
+    "waitingForOwner": "等待工作区所有者决定。",
+    "approved": "✓ 已批准 — 已完成。",
+    "approvedButFailed": "已批准，但执行失败：{{error}}",
+    "declined": "已拒绝。",
+    "expired": "已过期，未做出决定。",
+    "moot": "已不再适用。",
+    "openResult": "打开新 Pod",
+    "errors": {
+      "expired": "该批准在决定生效前已过期。",
+      "failed": "决定未能保存，请重试。"
+    }
+  },
   "marketplace": {
     "title": "应用市场",
     "subtitle": "浏览并安装智能体、应用和集成。",

--- a/frontend/src/v2/components/V2ApprovalCard.tsx
+++ b/frontend/src/v2/components/V2ApprovalCard.tsx
@@ -31,10 +31,19 @@ const V2ApprovalCard: React.FC<V2ApprovalCardProps> = ({ message, authorLabel, t
   const payload = message.payload || {};
   const status = payload.status || 'flagged';
   const isOwner = !!currentUser?._id && String(currentUser._id) === String(payload.ownerUserId || '');
-  const expired = status === 'flagged' && payload.expiresAt
-    ? new Date(payload.expiresAt).getTime() < Date.now()
-    : status === 'expired';
-  const resultPodId = (payload.executionResult as { podId?: string } | undefined)?.podId;
+  // ADR-017:201 — expiry is advisory AGE, not refusal. A flagged card past
+  // expiresAt stays decidable; it renders an age warning beside live buttons
+  // rather than dead ones. Only an explicitly-transitioned 'expired' status
+  // renders the terminal face.
+  const aged = status === 'flagged' && !!payload.expiresAt
+    && new Date(payload.expiresAt).getTime() < Date.now();
+  const execution = payload.executionResult as
+    | { podId?: string; agentJoined?: boolean; agentJoinError?: string }
+    | undefined;
+  const resultPodId = execution?.podId;
+  // Partial success is its own truth: the pod exists (user owns it) but the
+  // agent couldn't join and would 403 on every post — say so, don't say done.
+  const agentJoinFailed = execution?.agentJoined === false;
 
   const decide = async (decision: 'approved' | 'declined') => {
     if (deciding || !payload.approvalId) return;
@@ -61,36 +70,45 @@ const V2ApprovalCard: React.FC<V2ApprovalCardProps> = ({ message, authorLabel, t
         </div>
         <div className="v2-approval__summary">{payload.summary || message.content}</div>
 
-        {status === 'flagged' && !expired && (
-          isOwner ? (
-            <div className="v2-approval__actions">
-              <button
-                type="button"
-                className="v2-approval__btn v2-approval__btn--approve"
-                disabled={deciding}
-                onClick={() => decide('approved')}
-              >
-                {deciding ? t('approvalCard.deciding') : t('approvalCard.approve')}
-              </button>
-              <button
-                type="button"
-                className="v2-approval__btn v2-approval__btn--decline"
-                disabled={deciding}
-                onClick={() => decide('declined')}
-              >
-                {t('approvalCard.decline')}
-              </button>
-            </div>
-          ) : (
-            <div className="v2-approval__state">{t('approvalCard.waitingForOwner')}</div>
-          )
+        {status === 'flagged' && (
+          <>
+            {aged && (
+              <div className="v2-approval__state v2-approval__state--expired">
+                {t('approvalCard.aged')}
+              </div>
+            )}
+            {isOwner ? (
+              <div className="v2-approval__actions">
+                <button
+                  type="button"
+                  className="v2-approval__btn v2-approval__btn--approve"
+                  disabled={deciding}
+                  onClick={() => decide('approved')}
+                >
+                  {deciding ? t('approvalCard.deciding') : t('approvalCard.approve')}
+                </button>
+                <button
+                  type="button"
+                  className="v2-approval__btn v2-approval__btn--decline"
+                  disabled={deciding}
+                  onClick={() => decide('declined')}
+                >
+                  {t('approvalCard.decline')}
+                </button>
+              </div>
+            ) : (
+              <div className="v2-approval__state">{t('approvalCard.waitingForOwner')}</div>
+            )}
+          </>
         )}
 
         {status === 'resolved' && payload.decision === 'approved' && (
-          <div className="v2-approval__state v2-approval__state--approved">
+          <div className={`v2-approval__state ${payload.executionError || agentJoinFailed ? 'v2-approval__state--attention' : 'v2-approval__state--approved'}`}>
             {payload.executionError
               ? t('approvalCard.approvedButFailed', { error: payload.executionError })
-              : t('approvalCard.approved')}
+              : agentJoinFailed
+                ? t('approvalCard.approvedAgentJoinFailed', { agent: payload.agentName || 'agent' })
+                : t('approvalCard.approved')}
             {resultPodId && !payload.executionError && (
               <button
                 type="button"
@@ -109,17 +127,15 @@ const V2ApprovalCard: React.FC<V2ApprovalCardProps> = ({ message, authorLabel, t
           </div>
         )}
 
-        {(status === 'expired' || (status === 'flagged' && expired)) && (
+        {status === 'expired' && (
           <div className="v2-approval__state v2-approval__state--expired">
             {t('approvalCard.expired')}
           </div>
         )}
-
-        {status === 'moot' && (
-          <div className="v2-approval__state v2-approval__state--expired">
-            {t('approvalCard.moot')}
-          </div>
-        )}
+        {/* No 'moot' face: its only writer is the delivery-failure branch,
+            which fires precisely when no card message exists to render it
+            (pod-architect, fleet review 2026-08-13). The model keeps the
+            state for audit; the UI declares only reachable faces. */}
 
         {error && <div className="v2-approval__error" role="alert">{error}</div>}
       </div>

--- a/frontend/src/v2/components/V2ApprovalCard.tsx
+++ b/frontend/src/v2/components/V2ApprovalCard.tsx
@@ -1,0 +1,130 @@
+// ADR-020 D3 — the approval card, first payload-driven message component.
+//
+// Renders the ApprovalAction's authoritative face from `message.payload`
+// (kind 'approval-card'). Action buttons show ONLY for the card's owner
+// (payload.ownerUserId — shared state, compared client-side to the viewer;
+// never a broadcast per-viewer flag). Click → POST /api/approvals/:id/resolve
+// → server rewrites the payload → `messageCardUpdated` patches every client.
+// No optimistic update: an approval is exactly the kind of state where the
+// server's word is the only honest one (same discipline as reactions).
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../../context/AuthContext';
+import { useV2Api } from '../hooks/useV2Api';
+import type { V2Message } from '../hooks/useV2PodDetail';
+
+interface V2ApprovalCardProps {
+  message: V2Message;
+  authorLabel: string;
+  time: string | null;
+}
+
+const V2ApprovalCard: React.FC<V2ApprovalCardProps> = ({ message, authorLabel, time }) => {
+  const { t } = useTranslation();
+  const { currentUser } = useAuth();
+  const api = useV2Api();
+  const navigate = useNavigate();
+  const [deciding, setDeciding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const payload = message.payload || {};
+  const status = payload.status || 'flagged';
+  const isOwner = !!currentUser?._id && String(currentUser._id) === String(payload.ownerUserId || '');
+  const expired = status === 'flagged' && payload.expiresAt
+    ? new Date(payload.expiresAt).getTime() < Date.now()
+    : status === 'expired';
+  const resultPodId = (payload.executionResult as { podId?: string } | undefined)?.podId;
+
+  const decide = async (decision: 'approved' | 'declined') => {
+    if (deciding || !payload.approvalId) return;
+    setDeciding(true);
+    setError(null);
+    try {
+      await api.post(`/api/approvals/${encodeURIComponent(payload.approvalId)}/resolve`, { decision });
+      // State lands via messageCardUpdated; nothing to set here.
+    } catch (err) {
+      const status409 = (err as { response?: { status?: number } })?.response?.status;
+      setError(status409 === 410 ? t('approvalCard.errors.expired') : t('approvalCard.errors.failed'));
+    } finally {
+      setDeciding(false);
+    }
+  };
+
+  return (
+    <div className="v2-msg v2-msg--system" data-testid="approval-card">
+      <div className="v2-approval">
+        <div className="v2-approval__head">
+          <span className="v2-approval__badge">{t('approvalCard.badge')}</span>
+          <span className="v2-approval__agent">{authorLabel}</span>
+          {time && <span className="v2-approval__time">{time}</span>}
+        </div>
+        <div className="v2-approval__summary">{payload.summary || message.content}</div>
+
+        {status === 'flagged' && !expired && (
+          isOwner ? (
+            <div className="v2-approval__actions">
+              <button
+                type="button"
+                className="v2-approval__btn v2-approval__btn--approve"
+                disabled={deciding}
+                onClick={() => decide('approved')}
+              >
+                {deciding ? t('approvalCard.deciding') : t('approvalCard.approve')}
+              </button>
+              <button
+                type="button"
+                className="v2-approval__btn v2-approval__btn--decline"
+                disabled={deciding}
+                onClick={() => decide('declined')}
+              >
+                {t('approvalCard.decline')}
+              </button>
+            </div>
+          ) : (
+            <div className="v2-approval__state">{t('approvalCard.waitingForOwner')}</div>
+          )
+        )}
+
+        {status === 'resolved' && payload.decision === 'approved' && (
+          <div className="v2-approval__state v2-approval__state--approved">
+            {payload.executionError
+              ? t('approvalCard.approvedButFailed', { error: payload.executionError })
+              : t('approvalCard.approved')}
+            {resultPodId && !payload.executionError && (
+              <button
+                type="button"
+                className="v2-approval__result-link"
+                onClick={() => navigate(`/v2/pods/${resultPodId}`)}
+              >
+                {t('approvalCard.openResult')}
+              </button>
+            )}
+          </div>
+        )}
+
+        {status === 'resolved' && payload.decision === 'declined' && (
+          <div className="v2-approval__state v2-approval__state--declined">
+            {t('approvalCard.declined')}
+          </div>
+        )}
+
+        {(status === 'expired' || (status === 'flagged' && expired)) && (
+          <div className="v2-approval__state v2-approval__state--expired">
+            {t('approvalCard.expired')}
+          </div>
+        )}
+
+        {status === 'moot' && (
+          <div className="v2-approval__state v2-approval__state--expired">
+            {t('approvalCard.moot')}
+          </div>
+        )}
+
+        {error && <div className="v2-approval__error" role="alert">{error}</div>}
+      </div>
+    </div>
+  );
+};
+
+export default V2ApprovalCard;

--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import V2Avatar from './V2Avatar';
 import V2GithubPrCard, { parseGithubPrUrls } from './V2GithubPrCard';
+import V2ApprovalCard from './V2ApprovalCard';
 import { V2Message } from '../hooks/useV2PodDetail';
 import { formatRelativeTime } from '../utils/grouping';
 import { useAuth } from '../../context/AuthContext';
@@ -306,6 +307,13 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
   const isClickable = !!onAuthorClick && !!agentAuthorKeys?.has(rawUsername.toLowerCase());
   const handleAuthorClick = isClickable ? () => onAuthorClick?.(rawUsername) : undefined;
   const time = formatRelativeTime(message.created_at);
+
+  // ADR-020 D3: payload-driven components render from structure, not
+  // content regex — the first message class where `payload` is the truth
+  // and `content` is only the plain-text fallback for legacy surfaces.
+  if (message.payload?.kind === 'approval-card') {
+    return <V2ApprovalCard message={message} authorLabel={author} time={time} />;
+  }
 
   // §3.8 system event card. Detected by content shape (commonly-bot only
   // posts this exact form), so we don't depend on a metadata column the PG

--- a/frontend/src/v2/hooks/useV2PodDetail.ts
+++ b/frontend/src/v2/hooks/useV2PodDetail.ts
@@ -52,6 +52,23 @@ export interface V2Message {
     mine: boolean;
     users?: Array<{ id: string; username: string; displayName?: string }>;
   }>;
+  // ADR-020 D3: structured component payload. `kind` discriminates renderers
+  // (approval-card first). Server-composed; survives normalizeMessage via
+  // the `...raw` spread — declared here so consumers can read it typed.
+  payload?: {
+    kind?: string;
+    approvalId?: string;
+    actionType?: string;
+    summary?: string;
+    params?: Record<string, unknown>;
+    status?: string;
+    decision?: string;
+    ownerUserId?: string;
+    agentName?: string;
+    expiresAt?: string;
+    executionResult?: { podId?: string; podName?: string } | Record<string, unknown>;
+    executionError?: string;
+  } | null;
 }
 
 export interface V2Agent {
@@ -341,11 +358,25 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
           : m
       )));
     };
+    // ADR-020 D3: card status transitions. Same patch discipline as
+    // reactions — one field on one message; the server's payload is
+    // authoritative (card faces are shared state, never per-viewer).
+    const handleCardUpdate = (update: { messageId: string; podId?: string; payload?: V2Message['payload'] }) => {
+      if (!update || !update.messageId) return;
+      if (update.podId && update.podId !== podId) return;
+      setMessages((prev) => prev.map((m) => (
+        String(m.id) === String(update.messageId)
+          ? { ...m, payload: update.payload }
+          : m
+      )));
+    };
     socket.on('newMessage', handleNewMessage);
     socket.on('messageReaction', handleReactionChange);
+    socket.on('messageCardUpdated', handleCardUpdate);
     return () => {
       socket.off('newMessage', handleNewMessage);
       socket.off('messageReaction', handleReactionChange);
+      socket.off('messageCardUpdated', handleCardUpdate);
       leavePod(podId);
     };
   }, [podId, socket, connected, joinPod, leavePod, currentUser?._id]);

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -6943,6 +6943,11 @@
   font-weight: 600;
 }
 
+.v2-approval__state--attention {
+  color: #b45309;
+  font-weight: 600;
+}
+
 .v2-approval__state--expired {
   color: var(--v2-text-muted);
   font-style: italic;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -6834,3 +6834,132 @@
     flex: 0 0 78vw;
   }
 }
+
+/* ── Approval card (ADR-020 D3 / ADR-017) ──────────────────────────────── */
+
+.v2-approval {
+  border: 1px solid var(--v2-border);
+  border-left: 3px solid var(--v2-accent);
+  border-radius: 10px;
+  background: var(--v2-surface);
+  padding: 12px 16px;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.v2-approval__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.v2-approval__badge {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--v2-accent-text);
+  background: var(--v2-accent-soft);
+  border-radius: 4px;
+  padding: 2px 7px;
+}
+
+.v2-approval__agent {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--v2-text-secondary);
+}
+
+.v2-approval__time {
+  font-size: 11.5px;
+  color: var(--v2-text-muted);
+  margin-left: auto;
+}
+
+.v2-approval__summary {
+  font-size: 14px;
+  color: var(--v2-text-primary);
+  line-height: 1.45;
+}
+
+.v2-approval__actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.v2-root button.v2-approval__btn {
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 7px 16px;
+  cursor: pointer;
+  border: 1px solid var(--v2-border);
+}
+
+.v2-root button.v2-approval__btn--approve {
+  background: var(--v2-accent);
+  border-color: var(--v2-accent);
+  color: #fff;
+}
+
+.v2-root button.v2-approval__btn--approve:not(:disabled):hover {
+  background: var(--v2-accent-strong);
+}
+
+.v2-root button.v2-approval__btn--decline {
+  background: var(--v2-surface);
+  color: var(--v2-text-secondary);
+}
+
+.v2-root button.v2-approval__btn--decline:not(:disabled):hover {
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
+}
+
+.v2-root button.v2-approval__btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.v2-approval__state {
+  font-size: 13px;
+  color: var(--v2-text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.v2-approval__state--approved {
+  color: #047857;
+  font-weight: 600;
+}
+
+.v2-approval__state--declined {
+  color: var(--v2-text-tertiary);
+  font-weight: 600;
+}
+
+.v2-approval__state--expired {
+  color: var(--v2-text-muted);
+  font-style: italic;
+}
+
+.v2-root button.v2-approval__result-link {
+  border: none;
+  background: none;
+  color: var(--v2-accent-text);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.v2-approval__error {
+  font-size: 12.5px;
+  color: #b91c1c;
+}


### PR DESCRIPTION
ADR-020 (ratified, #924) D2+D3+D7, first kernel PR of the build. Sharpen seats: **@sprint-review** this is yours to review; **@pod-architect** please check `ApprovalAction` + `approvalActionService` against ADR-017's invariants specifically.

**What lands:**
- **Structured message `payload`** — Mongo `Mixed` + PG `JSONB` (self-applying `schema.sql` ALTER, the `is_bot` pattern), threaded through every explicit whitelist: PG create/find column lists, agentMessageService's five literals, `normalizeMongo`, the `newMessage` socket literal. Bonus fix: the Mongo schema finally declares `metadata` — strict mode silently dropped it on the fallback path.
- **`ApprovalAction`** — ADR-017's lifecycle as code: `flagged → resolved/expired/moot`; only a human writes `resolved` (plain `auth` route, never `dualAuth`, plus service-level `isBot` defense); owner-only; atomic one-way transition; expiry fails closed; execute-at-most-once; execution failure recorded honestly on a kept decision. The resolved row IS D2's AuthorizedAction audit record.
- **`create_pod` executor** — delegated authority in practice: pod owned by the USER (`createdBy` + first member — never the bot), proposing agent joins with its installation cloned, PG mirrored FK-safe.
- **Card UI** — `V2ApprovalCard` renders five faces from payload; `messageCardUpdated` socket event (verbatim `messageReaction` pattern) patches one field on one message; no optimistic update. en + zh.

**Not in this PR** (next: producer PR): the `commonly_propose_action` native tool, the per-agent tool gating fix (recon found `TOOLS` goes unfiltered to every native agent), and the Guide prompt change. No card can exist in prod until the producer lands — this PR is inert until then by design.

Tests: 16 green locally (authorization matrix, lifecycle one-way-ness, D2 ownership assertions). Typecheck clean both tiers; frontend jest in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8