### PR TITLE
feat(native): commonly_propose_action + enforced tool gating + Guide propose-don't-create (ADR-020 producer)

### DIFF
--- a/backend/__tests__/unit/services/nativeRuntimeService.toolGating.test.js
+++ b/backend/__tests__/unit/services/nativeRuntimeService.toolGating.test.js
@@ -1,0 +1,38 @@
+/**
+ * ADR-020 D1 — the manifest tool allowlist is ENFORCED, not decorative.
+ *
+ * Before toolsForConfig, TOOLS went unfiltered to every native agent and
+ * each definition's `tools` list was documentation. Now: a declared list
+ * filters exactly; an undeclared (legacy) config keeps the pre-gate surface
+ * MINUS approval proposing, which is opt-in by declaration only.
+ */
+const { toolsForConfig } = require('../../../services/nativeRuntimeService');
+
+const names = (tools) => tools.map((t) => t.function.name);
+
+describe('toolsForConfig', () => {
+  test('a declared allowlist filters exactly', () => {
+    const tools = toolsForConfig({ tools: ['commonly_post_message', 'commonly_propose_action'] });
+    expect(names(tools).sort()).toEqual(['commonly_post_message', 'commonly_propose_action']);
+  });
+
+  test('legacy configs without a tool list never see propose_action', () => {
+    for (const cfg of [null, undefined, {}, { tools: 'not-an-array' }]) {
+      const tools = toolsForConfig(cfg);
+      expect(names(tools)).not.toContain('commonly_propose_action');
+      // ...but keep the pre-gate surface working (back-compat).
+      expect(names(tools)).toContain('commonly_post_message');
+      expect(names(tools)).toContain('commonly_read_context');
+    }
+  });
+
+  test('the guide manifest grants propose_action', () => {
+    // eslint-disable-next-line global-require
+    const { guideApp } = require('../../../config/native-agents/guide');
+    const tools = toolsForConfig({ tools: [...guideApp.tools] });
+    expect(names(tools)).toContain('commonly_propose_action');
+    // The manifest and the runtime's schema must agree — a declared tool with
+    // no schema would silently vanish here.
+    expect(tools.length).toBe(guideApp.tools.length);
+  });
+});

--- a/backend/config/native-agents/guide.ts
+++ b/backend/config/native-agents/guide.ts
@@ -51,6 +51,12 @@ export const guideApp = {
     + '- DO things instead of describing them. Asked to track something → '
     + 'commonly_create_task. Told a durable preference ("I prefer zh-CN", '
     + '"my repo is X") → commonly_write_memory, once, without narrating it.\n'
+    + '- PROPOSE, never just do, anything that creates a surface others can '
+    + 'see or join. Asked for a new pod → commonly_propose_action with '
+    + 'actionType create_pod; an approval card appears and the pod is created '
+    + 'only if the user approves. The card IS your reply — do not post a '
+    + 'separate message describing the proposal, and never claim the pod '
+    + 'exists before the card shows approved.\n'
     + '- Read the room first when history matters: commonly_read_context '
     + 'before answering questions about what happened here.\n'
     + '- Silence is a valid turn. If a message needs nothing from you — the '
@@ -74,6 +80,8 @@ export const guideApp = {
     'commonly_write_memory',
     'commonly_post_message',
     'commonly_create_task',
+    // ADR-020: outward-visible actions (create_pod) via approval card only.
+    'commonly_propose_action',
   ],
   iconUrl: '',
   categories: ['onboarding', 'utility'],

--- a/backend/config/native-agents/types.ts
+++ b/backend/config/native-agents/types.ts
@@ -22,7 +22,8 @@ export type CommonlyTool =
   | 'commonly_read_memory'
   | 'commonly_write_memory'
   | 'commonly_post_message'
-  | 'commonly_create_task';
+  | 'commonly_create_task'
+  | 'commonly_propose_action';
 
 export interface NativeAgentDefinition {
   agentName: string;

--- a/backend/scripts/refresh-native-agent-configs.ts
+++ b/backend/scripts/refresh-native-agent-configs.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/*
+ * Re-project native-agent manifests onto their existing installations.
+ *
+ * ADR-001: one manifest, N runtime projections, and UPDATES PROPAGATE. The
+ * signup path stamps buildInstallationConfig(manifest) at install time, so a
+ * manifest change (new tool grant, prompt change, cap change) reaches new
+ * users only — every existing install keeps the config frozen at its signup
+ * moment. This script closes that gap: for each first-party native agent, it
+ * rewrites config on all active installations from the CURRENT manifest.
+ *
+ * Deliberately config-only: never touches identity (agentName/instanceId/
+ * User rows), membership, memory, or status — a manifest refresh must never
+ * be able to become an identity migration by accident.
+ *
+ * Idempotent. `--dry` prints the plan.
+ *
+ * Usage:
+ *   ts-node backend/scripts/refresh-native-agent-configs.ts          # apply
+ *   ts-node backend/scripts/refresh-native-agent-configs.ts --dry    # report
+ */
+
+import mongoose from 'mongoose';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { AgentInstallation } = require('../models/AgentRegistry');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { buildInstallationConfig } = require('./seed-native-agents');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { FIRST_PARTY_APPS } = require('../config/native-agents/apps');
+
+const DRY = process.argv.includes('--dry');
+
+async function main(): Promise<void> {
+  const uri = process.env.MONGO_URI;
+  if (!uri) throw new Error('MONGO_URI is required');
+  await mongoose.connect(uri);
+
+  for (const app of FIRST_PARTY_APPS) {
+    const installs = await AgentInstallation.find({
+      agentName: app.agentName,
+      status: 'active',
+    });
+    console.log(`[config-refresh] ${app.agentName}: ${installs.length} active install(s)`);
+    if (DRY) continue;
+    const config = buildInstallationConfig(app);
+    for (const install of installs) {
+      install.config = config;
+      // eslint-disable-next-line no-await-in-loop
+      await install.save();
+    }
+    console.log(`[config-refresh] ${app.agentName}: refreshed`);
+  }
+
+  await mongoose.disconnect();
+  console.log('[config-refresh] done');
+}
+
+main().catch((err) => {
+  console.error('[config-refresh] failed:', err);
+  process.exit(1);
+});

--- a/backend/services/nativeRuntimeService.ts
+++ b/backend/services/nativeRuntimeService.ts
@@ -173,7 +173,57 @@ const TOOLS = [
       },
     },
   },
+  {
+    type: 'function',
+    function: {
+      name: 'commonly_propose_action',
+      description:
+        'Propose an action that needs the workspace owner\'s approval. Posts an '
+        + 'approval card to the pod; the action runs only if the owner approves. '
+        + 'Use for anything that creates a surface others can see or join — '
+        + 'currently: create_pod. Do NOT also post a separate chat message about '
+        + 'the proposal; the card IS the message.',
+      parameters: {
+        type: 'object',
+        properties: {
+          actionType: {
+            type: 'string',
+            enum: ['create_pod'],
+            description: 'The action being proposed',
+          },
+          summary: {
+            type: 'string',
+            description: 'One sentence, in the user\'s language: what will happen if they approve',
+          },
+          params: {
+            type: 'object',
+            description: 'Action parameters. For create_pod: { name (required), description?, type? ("chat"|"team") }',
+            properties: {
+              name: { type: 'string' },
+              description: { type: 'string' },
+              type: { type: 'string', enum: ['chat', 'team'] },
+            },
+          },
+        },
+        required: ['actionType', 'summary', 'params'],
+      },
+    },
+  },
 ];
+
+// ADR-020 D1: the manifest's `tools` list is the capability boundary, and it
+// must be ENFORCED here, not just declared. Before this filter, TOOLS went
+// unfiltered to every native agent — the allowlist in each agent definition
+// was decorative (caught in the 2026-08-13 build recon). Installs that
+// predate tool lists (no cfg.tools) keep the pre-gate surface minus
+// approval proposing, which is opt-in by declaration only.
+export const toolsForConfig = (cfg: { tools?: unknown } | null | undefined): typeof TOOLS => {
+  const declared = Array.isArray(cfg?.tools) ? (cfg?.tools as string[]) : null;
+  if (!declared) {
+    return TOOLS.filter((t) => t.function.name !== 'commonly_propose_action');
+  }
+  return TOOLS.filter((t) => declared.includes(t.function.name));
+};
 
 // --- tool dispatcher -------------------------------------------------------
 
@@ -317,6 +367,36 @@ async function dispatchTool(
             taskId: String(created.taskId),
             taskNum: created.taskNum,
             _id: String(created._id),
+          },
+        };
+      }
+
+      case 'commonly_propose_action': {
+        // ADR-020 D1/D3: outward-visible actions go through an approval card.
+        // proposeAction validates, creates the ApprovalAction row, and posts
+        // the card message itself — the tool-loop marks postedViaTool so the
+        // fallback never double-posts narration beside the card.
+        const { proposeAction } = require('./approvalActionService');
+        const result = await proposeAction({
+          podId: String(ctx.podId),
+          agentName: ctx.agentName,
+          instanceId: ctx.instanceId,
+          displayName: ctx.displayName,
+          actionType: String(args.actionType || ''),
+          params: (args.params && typeof args.params === 'object'
+            ? args.params : {}) as Record<string, unknown>,
+          summary: String(args.summary || ''),
+          installationConfig: ctx.installationConfig,
+        });
+        if (!result.ok) {
+          return { content: { ok: false, error: result.error }, error: 'propose_failed' };
+        }
+        return {
+          content: {
+            ok: true,
+            proposed: true,
+            approvalId: result.approvalId,
+            note: 'Approval card posted. The action runs only if the owner approves — do not post another message about it.',
           },
         };
       }
@@ -689,7 +769,8 @@ export async function runAgent(
           {
             model,
             messages,
-            tools: TOOLS,
+            // ADR-020 D1: the manifest's tool allowlist, enforced.
+            tools: toolsForConfig(cfg),
             tool_choice: 'auto',
             // Guard the untrusted-user / untrusted-pod-content surface (see the
             // NATIVE_RUNTIME_GUARDRAILS note above). Omitted entirely when empty
@@ -781,6 +862,13 @@ export async function runAgent(
             finalMessage = typeof (parsedArgs as any)?.content === 'string'
               ? String((parsedArgs as any).content)
               : undefined;
+          }
+          // Proposing posts the card message itself — without this, the
+          // fallback below would double-post the model's narration next to
+          // the card (the exact double-post class commonly_post_message's
+          // special case exists for).
+          if (tc.function?.name === 'commonly_propose_action' && !result.error) {
+            postedViaTool = true;
           }
           messages.push({
             role: 'tool',

--- a/packages/commonly-apps/src/types.ts
+++ b/packages/commonly-apps/src/types.ts
@@ -15,7 +15,8 @@ export type CommonlyTool =
   | 'commonly_read_memory'
   | 'commonly_write_memory'
   | 'commonly_post_message'
-  | 'commonly_create_task';
+  | 'commonly_create_task'
+  | 'commonly_propose_action';
 
 export interface NativeAgentDefinition {
   /** Canonical agent name. Kebab-case. Used as AgentRegistry.agentName. */


### PR DESCRIPTION
The producer half of #925's approval loop — with this merged and deployed, the full D7 slice goes live: Guide proposes → card renders → owner approves → pod exists, user-owned. **@sprint-review** yours again; **@pod-architect** the D1 gating semantics (legacy-config back-compat minus opt-in-only propose) is the part worth your lens.

- **`commonly_propose_action`** (create_pod only, matching the executor registry) → `proposeAction` posts the card itself; the tool loop marks `postedViaTool` so the fallback can't double-post narration beside the card.
- **D1 enforced**: `toolsForConfig` filters the LLM call by the manifest's tool allowlist. Recon found `TOOLS` went unfiltered to every native agent — the per-agent list was documentation. Legacy configs (no list) keep the pre-gate surface minus `propose_action` (opt-in by declaration only). A test pins manifest↔schema agreement.
- **Guide manifest + prompt**: grants the tool; prompt gains the boundary — outward surfaces are *proposed*, the card is the reply, never claim the pod exists before the card says approved.
- **`refresh-native-agent-configs.ts`**: ADR-001 updates-propagate for existing installs; config-only by design; `--dry` supported. Run against dev post-merge (2 guide installs at most), then the live E2E.

Tests: 3 gating cases green locally; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8