### PR TITLE
fix(shell): approval card speaks the syscard idiom + pod-filter segment cleanup (de-slop round 1)

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -138,9 +138,13 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // The desktop sidebar leaves only ~240px inside its gutter (less than the
     // mobile drawer). A four-column grid keeps Community beside the existing
     // filters without horizontal scrolling or wrapping in either locale.
+    // Pattern updated 2026-08-13 (Sam's raggedness flag): three EQUAL
+    // segments + one content-sized auto column for the long label — the
+    // per-label hand-tuned fractions read as four random widths. The
+    // invariant's intent (one row, no wrap) is unchanged.
     const rule = ruleBody(v2, '.v2-pods__filters');
     expect(rule).toContain('display: grid');
-    expect(rule).toContain('grid-template-columns: minmax(0, 0.75fr) minmax(0, 1fr) minmax(0, 1.15fr) minmax(0, 1.7fr)');
+    expect(rule).toContain('grid-template-columns: repeat(3, minmax(0, 1fr)) auto');
     expect(rule).toContain('overflow: visible');
   });
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -810,7 +810,13 @@
 
 .v2-pods__filters {
   display: grid;
-  grid-template-columns: minmax(0, 0.75fr) minmax(0, 1fr) minmax(0, 1.15fr) minmax(0, 1.7fr);
+  /* Three equal segments + one content-sized. The previous hand-tuned
+     fractions (0.75/1/1.15/1.7) sized every column to its English label —
+     four random widths reading as ragged (Sam, 2026-08-13). True equal
+     quarters can't hold "Community" at legible size in this rail, so the
+     long label gets the one deliberate auto column; whether that label
+     changes is the design pass's call. */
+  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
   gap: 4px;
   padding: 0;
   margin-bottom: 18px;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -6835,13 +6835,16 @@
   }
 }
 
-/* ── Approval card (ADR-020 D3 / ADR-017) ──────────────────────────────── */
+/* ── Approval card (ADR-020 D3 / ADR-017) ──────────────────────────────────
+   Speaks the syscard idiom (§3.8 agent-dm card): soft accent-tinted ground +
+   soft border + house radius. The TINT signals "system surface" — no accent
+   rail (the rail-on-rounded-card is the generic look we deliberately avoid;
+   flagged by Sam on the first live card, 2026-08-13). */
 
 .v2-approval {
-  border: 1px solid var(--v2-border);
-  border-left: 3px solid var(--v2-accent);
-  border-radius: 10px;
-  background: var(--v2-surface);
+  border: 1px solid var(--v2-border-soft);
+  border-radius: var(--v2-radius);
+  background: var(--v2-accent-soft);
   padding: 12px 16px;
   max-width: 480px;
   display: flex;
@@ -6861,9 +6864,6 @@
   letter-spacing: 0.07em;
   text-transform: uppercase;
   color: var(--v2-accent-text);
-  background: var(--v2-accent-soft);
-  border-radius: 4px;
-  padding: 2px 7px;
 }
 
 .v2-approval__agent {
@@ -6891,7 +6891,7 @@
 }
 
 .v2-root button.v2-approval__btn {
-  border-radius: 8px;
+  border-radius: var(--v2-radius-sm);
   font-size: 13px;
   font-weight: 600;
   padding: 7px 16px;
@@ -6910,7 +6910,7 @@
 }
 
 .v2-root button.v2-approval__btn--decline {
-  background: var(--v2-surface);
+  background: var(--v2-bg);
   color: var(--v2-text-secondary);
 }
 


### PR DESCRIPTION
Sam's design read on the first live approval card: the accent rail on a rounded card is the classic AI-generated-UI element. Correct — and the repo's own house idiom (the §3.8 syscard) already answers it: soft accent-tinted ground + soft border + radius token, the TINT doing the signaling. The card now speaks it — rail gone, badge reduced to typographic accent, radii on tokens, decline button grounded for affordance against the tint.

Second flag, measured live: the pod-filter tabs were hand-tuned to per-label fractions (37/49/57/84px — ragged). Equal quarters can't hold "Community" legibly (63px needed vs 57 available at 11.5px, empirically), so: three equal segments + one deliberate auto column. Whether the label itself changes is @ux-lead's call in the systemic pass.

This is round 1 of the non-slop accent audit — the systemic sweep (every rail/generic treatment across v2, plus the pod-list row consistency) goes to the fleet's polish slice with an expanded brief.

CSS-only; the existing browser-verification habit applies post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8