### PR TITLE
style(v2): align accents and pod-list geometry

### DIFF
--- a/frontend/design-system/tokens.css
+++ b/frontend/design-system/tokens.css
@@ -40,6 +40,8 @@
   /* ---------- Semantic ---------- */
   --c-success:         #10b981;
   --c-success-soft:    #e3f6ec;
+  --c-success-ring:    rgba(16, 185, 129, 0.40); /* live-activity pulse */
+  --c-success-ring-strong: rgba(16, 185, 129, 0.50);
   --c-warning:         #f4a23a;
   --c-warning-soft:    #fdefdc;
   --c-info:            #0891b2;   /* cyan — distinct from accent blue */

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -179,7 +179,9 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(snippet).toContain('height: 16px');
     expect(snippet).toContain('white-space: nowrap');
     expect(snippet).toContain('text-overflow: ellipsis');
-    expect(time).toContain('width: 44px');
+    // The slot must fit the longest current English clock labels. A narrower
+    // reservation visibly elided AM/PM and made a clock ambiguous (#928).
+    expect(time).toContain('width: 56px');
     expect(v2).toContain('.v2-pods__row--pinned .v2-pods__item-time');
   });
 

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -30,7 +30,11 @@ const read = (rel: string): string =>
 // Grab the body of the first `<selector> { ... }` block. Selectors here have no
 // nested braces, so a naive slice to the next `}` is sufficient.
 const ruleBody = (css: string, selector: string): string => {
-  const start = css.indexOf(`${selector} {`);
+  // Prefer a selector at the start of a CSS line. A descendant selector can
+  // contain the same text (`.parent .target {`) and is not the rule being
+  // pinned.
+  const lineStart = css.indexOf(`\n${selector} {`);
+  const start = lineStart === -1 ? css.indexOf(`${selector} {`) : lineStart + 1;
   if (start === -1) return '';
   const end = css.indexOf('}', start);
   return end === -1 ? '' : css.slice(start, end);
@@ -139,13 +143,55 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // mobile drawer). A four-column grid keeps Community beside the existing
     // filters without horizontal scrolling or wrapping in either locale.
     // Pattern updated 2026-08-13 (Sam's raggedness flag): three EQUAL
-    // segments + one content-sized auto column for the long label — the
-    // per-label hand-tuned fractions read as four random widths. The
-    // invariant's intent (one row, no wrap) is unchanged.
+    // segments + one content-sized, capped Community column — the per-label
+    // hand-tuned fractions read as four random widths. The invariant's intent
+    // (one row, no wrap) is unchanged.
     const rule = ruleBody(v2, '.v2-pods__filters');
     expect(rule).toContain('display: grid');
-    expect(rule).toContain('grid-template-columns: repeat(3, minmax(0, 1fr)) auto');
+    expect(rule).toContain('grid-template-columns: repeat(3, minmax(0, 1fr)) fit-content(92px)');
     expect(rule).toContain('overflow: visible');
+    expect(ruleBody(v2, '.v2-pods__filter')).toContain('text-overflow: ellipsis');
+  });
+
+  test('accent treatment is a wash, never a message rail', () => {
+    // Accent rails made otherwise ordinary cards look like generic callouts.
+    // Message mentions retain their semantic wash, while quote edges stay
+    // neutral structural affordances.
+    expect(v2).not.toMatch(/border-left:\s*[^;]*var\(--v2-accent\)/);
+    const mention = ruleBody(v2, '.v2-msg--mention');
+    expect(mention).toContain('background: var(--v2-accent-soft)');
+    expect(mention).toContain('border-radius: var(--v2-radius-sm)');
+  });
+
+  test('quote edges share the same neutral 3px structural weight', () => {
+    expect(ruleBody(v2, '.v2-msg__content blockquote')).toContain('border-left: 3px solid var(--v2-border)');
+    expect(ruleBody(v2, '.v2-msg__quote')).toContain('border-left: 3px solid var(--v2-border)');
+    expect(ruleBody(v2, '.v2-board__detail-updates li')).toContain('border-left: 3px solid var(--v2-border)');
+  });
+
+  test('pod rows reserve one preview line and a fixed meta slot', () => {
+    const row = ruleBody(v2, '.v2-pods__item');
+    const snippet = ruleBody(v2, '.v2-pods__item-snippet');
+    const time = ruleBody(v2, '.v2-pods__item-time');
+
+    expect(row).toContain('height: 64px');
+    expect(row).toContain('overflow: hidden');
+    expect(snippet).toContain('height: 16px');
+    expect(snippet).toContain('white-space: nowrap');
+    expect(snippet).toContain('text-overflow: ellipsis');
+    expect(time).toContain('width: 44px');
+    expect(v2).toContain('.v2-pods__row--pinned .v2-pods__item-time');
+  });
+
+  test('the inspector activity pulse uses semantic tokens, not raw color literals', () => {
+    const pulse = ruleBody(v2, '.v2-inspector__now-pulse');
+    expect(pulse).toContain('var(--v2-success-ring-strong)');
+    expect(v2.slice(v2.indexOf('@keyframes v2-now-pulse'), v2.indexOf('.v2-inspector__now-meta')))
+      .toContain('var(--v2-success-ring)');
+  });
+
+  test('v2 focus treatment reuses the shared focus-ring token', () => {
+    expect(ruleBody(v2, '.v2-board__field input:focus')).toContain('box-shadow: var(--v2-focus-ring)');
   });
 
   test('the Community sub-tabs and Discover rows shrink inside the narrow sidebar', () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -169,7 +169,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(v2, '.v2-board__detail-updates li')).toContain('border-left: 3px solid var(--v2-border)');
   });
 
-  test('pod rows reserve one preview line and a fixed meta slot', () => {
+  test('pod rows reserve one preview line and a locale-shaped time slot', () => {
     const row = ruleBody(v2, '.v2-pods__item');
     const snippet = ruleBody(v2, '.v2-pods__item-snippet');
     const time = ruleBody(v2, '.v2-pods__item-time');
@@ -179,9 +179,12 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(snippet).toContain('height: 16px');
     expect(snippet).toContain('white-space: nowrap');
     expect(snippet).toContain('text-overflow: ellipsis');
-    // The slot must fit the longest current English clock labels. A narrower
-    // reservation visibly elided AM/PM and made a clock ambiguous (#928).
-    expect(time).toContain('width: 56px');
+    // Relative time comes from the viewer's browser locale, so a fixed English
+    // pixel width will eventually clip a clock. Keep its intrinsic width and
+    // let the already-ellipsized title absorb the remaining line.
+    expect(time).toContain('flex-shrink: 0');
+    expect(time).toContain('white-space: nowrap');
+    expect(time).not.toContain('width:');
     expect(v2).toContain('.v2-pods__row--pinned .v2-pods__item-time');
   });
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -28,6 +28,8 @@
 
   --v2-success: #10b981;
   --v2-success-soft: #e3f6ec;
+  --v2-success-ring: rgba(16, 185, 129, 0.40);
+  --v2-success-ring-strong: rgba(16, 185, 129, 0.50);
   --v2-warning: #f4a23a;
   --v2-warning-soft: #fdefdc;
   --v2-info: #0891b2;
@@ -810,13 +812,10 @@
 
 .v2-pods__filters {
   display: grid;
-  /* Three equal segments + one content-sized. The previous hand-tuned
-     fractions (0.75/1/1.15/1.7) sized every column to its English label —
-     four random widths reading as ragged (Sam, 2026-08-13). True equal
-     quarters can't hold "Community" at legible size in this rail, so the
-     long label gets the one deliberate auto column; whether that label
-     changes is the design pass's call. */
-  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+  /* Community is product vocabulary, not a layout compromise. The first
+     three filters share the available width; Community keeps its readable
+     content width but is capped so it cannot consume a narrow rail. */
+  grid-template-columns: repeat(3, minmax(0, 1fr)) fit-content(92px);
   gap: 4px;
   padding: 0;
   margin-bottom: 18px;
@@ -834,6 +833,8 @@
   border-radius: var(--v2-radius-sm);
   text-align: center;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   transition: background 80ms ease, color 80ms ease;
 }
 
@@ -902,18 +903,11 @@
   opacity: 1;
 }
 
-/* Hide the inline time on hover so the pin (top-right) doesn't overlap.
-   The time sits at the right edge of the title row in normal state. */
-.v2-pods__row:hover .v2-pods__item-time {
+/* The pin overlays the fixed time slot, so revealing it cannot reflow the
+   title or preview. */
+.v2-pods__row:hover .v2-pods__item-time,
+.v2-pods__row--pinned .v2-pods__item-time {
   visibility: hidden;
-}
-/* Reserve a margin for the pin so the 2-line snippet doesn't run under
-   it on hover (or on already-pinned rows). */
-.v2-pods__row:hover .v2-pods__item-snippet,
-.v2-pods__row--pinned .v2-pods__item-snippet,
-.v2-pods__row:hover .v2-pods__item-title,
-.v2-pods__row--pinned .v2-pods__item-title {
-  padding-right: 28px;
 }
 .v2-root button.v2-pods__pin:hover {
   background: var(--v2-surface-hover);
@@ -925,11 +919,12 @@
 
 .v2-pods__item {
   display: grid;
-  grid-template-columns: 32px minmax(0, 1fr);
+  grid-template-columns: 34px minmax(0, 1fr);
   align-items: start;
   gap: 10px;
-  min-height: 60px;
+  height: 64px;
   padding: 10px;
+  overflow: hidden;
   border-radius: var(--v2-radius);
   cursor: pointer;
   width: 100%;
@@ -1009,12 +1004,14 @@
   align-items: center;
   gap: 6px;
   min-width: 0;
+  height: 20px;
 }
 
 .v2-pods__item-title {
   flex: 1;
   min-width: 0;
   font-size: 14px;
+  line-height: 20px;
   font-weight: 600;
   color: var(--v2-text-primary);
   white-space: nowrap;
@@ -1088,12 +1085,13 @@
 
 .v2-pods__item-snippet {
   font-size: 12px;
-  line-height: 1.35;
+  line-height: 16px;
   color: var(--v2-text-tertiary);
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+  display: block;
+  height: 16px;
+  white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* Title-row sibling — sits to the right of the pod name. Slack/iMessage
@@ -1101,10 +1099,15 @@
    second line is reserved entirely for the message preview. */
 .v2-pods__item-time {
   flex-shrink: 0;
+  width: 44px;
   font-size: 11px;
   color: var(--v2-text-tertiary);
   font-variant-numeric: tabular-nums;
   align-self: baseline;
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .v2-pods__empty {
@@ -2535,12 +2538,10 @@
   white-space: nowrap;
 }
 
-/* Solid accent-soft wash + 2px accent rail when the current user is
-   @-mentioned in this message. No gradients (system rule). */
+/* A mention is a tinted system signal, not a separate card or accent rail. */
 .v2-msg--mention {
   background: var(--v2-accent-soft);
-  border-left: 2px solid var(--v2-accent);
-  border-radius: 0 var(--v2-radius-sm) var(--v2-radius-sm) 0;
+  border-radius: var(--v2-radius-sm);
   padding: 8px 10px 8px 10px;
   margin-left: -12px;
 }
@@ -2974,15 +2975,15 @@
   height: 8px;
   border-radius: 50%;
   background: var(--v2-success);
-  box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.5);
+  box-shadow: 0 0 0 0 var(--v2-success-ring-strong);
   animation: v2-now-pulse 1.6s ease-out infinite;
   flex-shrink: 0;
 }
 
 @keyframes v2-now-pulse {
-  0%   { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.4); }
-  70%  { box-shadow: 0 0 0 6px rgba(16, 185, 129, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
+  0%   { box-shadow: 0 0 0 0 var(--v2-success-ring); }
+  70%  { box-shadow: 0 0 0 6px transparent; }
+  100% { box-shadow: 0 0 0 0 transparent; }
 }
 
 .v2-inspector__now-meta {
@@ -6762,7 +6763,7 @@
   flex-direction: column;
   gap: 1px;
   font-size: 12.5px;
-  border-left: 2px solid var(--v2-border);
+  border-left: 3px solid var(--v2-border);
   padding-left: 10px;
 }
 
@@ -6801,7 +6802,7 @@
 .v2-board__field input:focus {
   outline: none;
   border-color: var(--v2-accent);
-  box-shadow: 0 0 0 3px rgba(47, 111, 235, 0.14);
+  box-shadow: var(--v2-focus-ring);
 }
 
 .v2-root button.v2-board__create-submit {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -903,7 +903,7 @@
   opacity: 1;
 }
 
-/* The pin overlays the fixed time slot, so revealing it cannot reflow the
+/* The pin overlays the reserved time slot, so revealing it cannot reflow the
    title or preview. */
 .v2-pods__row:hover .v2-pods__item-time,
 .v2-pods__row--pinned .v2-pods__item-time {
@@ -1099,16 +1099,14 @@
    second line is reserved entirely for the message preview. */
 .v2-pods__item-time {
   flex-shrink: 0;
-  /* 56px keeps the longest current relative-time labels ("Yesterday" and
-     "11:59 PM") legible while preserving a stable title/hover geometry. */
-  width: 56px;
+  /* Relative-time formatting follows the viewer's browser locale. Do not
+     cap it to an English measurement: title ellipsis is safer than clipping
+     a clock, and visibility:hidden still reserves this row's slot on hover. */
   font-size: 11px;
   color: var(--v2-text-tertiary);
   font-variant-numeric: tabular-nums;
   align-self: baseline;
-  overflow: hidden;
   text-align: right;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -1099,7 +1099,9 @@
    second line is reserved entirely for the message preview. */
 .v2-pods__item-time {
   flex-shrink: 0;
-  width: 44px;
+  /* 56px keeps the longest current relative-time labels ("Yesterday" and
+     "11:59 PM") legible while preserving a stable title/hover geometry. */
+  width: 56px;
   font-size: 11px;
   color: var(--v2-text-tertiary);
   font-variant-numeric: tabular-nums;


### PR DESCRIPTION
## Summary
- remove the remaining message accent rail while preserving the mention wash; unify quote edges at 3px
- keep Community in a capped 3+auto filter grid; give every pod row one reserved preview line and a locale-safe time slot
- route the live pulse and board focus treatment through shared semantic tokens

## Shadow audit
Classified all 42 v2 declarations: floating menus/popovers/modals and focus rings remain; resting surfaces inherit the existing no-shadow V2 tokens.

## Verification
- Browser check: 64px rows; 20px title; 16px preview slot including empty; Community resolves to 66px under cap. The locale-shaped timestamp stays fully readable; hiding it reserves its natural width, so hover does not reflow text.
- `npm test -- --watchAll=false --runInBand src/v2/__tests__/v2-layout-invariants.test.ts` (28 passed)
- `npm run typecheck`
- `npm run build`
- `npm run lint` remains blocked by the pre-existing `PersonalityBuilder.tsx:440` unescaped-entity error