### PR TITLE
feat(shell): card aligns to the message column + durable pending-approvals index (card UX round 2)

### DIFF
--- a/backend/__tests__/unit/routes/approvals.pending.test.js
+++ b/backend/__tests__/unit/routes/approvals.pending.test.js
@@ -1,0 +1,96 @@
+/**
+ * GET /api/approvals/pending — the durable pending-approvals index (ADR-020).
+ * Backed by ApprovalAction rows, not card messages: messages retire under
+ * the 30-day retention window; flagged approvals must stay findable.
+ * Read gate = pod visibility; deciding stays owner-only in /resolve.
+ */
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.userId = 'u1';
+  req.user = { id: 'u1', _id: 'u1' };
+  next();
+});
+
+const mockPodFindById = jest.fn();
+jest.mock('../../../models/Pod', () => ({
+  findById: (...args) => mockPodFindById(...args),
+}));
+
+const mockCanViewPod = jest.fn();
+jest.mock('../../../services/dmService', () => ({
+  canViewPod: (...args) => mockCanViewPod(...args),
+}));
+
+const mockApprovalFind = jest.fn();
+jest.mock('../../../models/ApprovalAction', () => ({
+  find: (...args) => mockApprovalFind(...args),
+}));
+
+jest.mock('../../../services/approvalActionService', () => ({
+  buildCardPayload: (row) => ({
+    kind: 'approval-card',
+    approvalId: String(row._id),
+    summary: row.summary,
+    agentName: row.agentName,
+    ownerUserId: String(row.ownerUserId),
+    status: row.status,
+  }),
+  resolveApproval: jest.fn(),
+}));
+
+const approvalsRouter = require('../../../routes/approvals');
+
+const app = express();
+app.use(express.json());
+app.use('/api/approvals', approvalsRouter);
+
+const POD_ID = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPodFindById.mockResolvedValue({ _id: POD_ID, members: ['u1'] });
+  mockCanViewPod.mockResolvedValue(true);
+  mockApprovalFind.mockReturnValue({
+    sort: jest.fn().mockReturnValue({
+      limit: jest.fn().mockResolvedValue([
+        {
+          _id: 'appr-1',
+          summary: 'Create a pod called Design Studio',
+          agentName: 'guide',
+          ownerUserId: 'u1',
+          status: 'flagged',
+          messageId: '123',
+          createdAt: new Date('2026-08-13T07:00:00Z'),
+        },
+      ]),
+    }),
+  });
+});
+
+describe('GET /api/approvals/pending', () => {
+  test('returns flagged rows with card payloads for a pod member', async () => {
+    const res = await request(app).get(`/api/approvals/pending?podId=${POD_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.body.approvals).toHaveLength(1);
+    expect(res.body.approvals[0]).toEqual(expect.objectContaining({
+      approvalId: 'appr-1',
+      agentName: 'guide',
+      messageId: '123',
+    }));
+    expect(mockApprovalFind).toHaveBeenCalledWith({ podId: POD_ID, status: 'flagged' });
+  });
+
+  test('403s a caller who cannot view the pod', async () => {
+    mockCanViewPod.mockResolvedValue(false);
+    const res = await request(app).get(`/api/approvals/pending?podId=${POD_ID}`);
+    expect(res.status).toBe(403);
+    expect(mockApprovalFind).not.toHaveBeenCalled();
+  });
+
+  test('400s a missing or malformed podId', async () => {
+    const res = await request(app).get('/api/approvals/pending?podId=nope');
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/routes/approvals.ts
+++ b/backend/routes/approvals.ts
@@ -46,6 +46,48 @@ interface Res {
   json: (d: unknown) => void;
 }
 
+// Pending approvals for a pod, from the ApprovalAction rows — NOT the card
+// messages. Chat messages retire under the 30-day PG retention window while
+// approval rows never expire, so "scroll up and find the card" is unreliable
+// by construction; this is the durable index the inspector renders. Read
+// gate = pod visibility (members); DECIDING stays owner-only in resolve.
+router.get('/pending', approvalResolveLimit, auth, async (req: AuthedReq & { query?: Record<string, string> }, res: Res) => {
+  try {
+    const podId = String((req as { query?: Record<string, string> }).query?.podId || '');
+    const callerUserId = String(req.userId || req.user?._id || req.user?.id || '');
+    if (!callerUserId) return res.status(401).json({ error: 'Unauthorized' });
+    if (!/^[a-f0-9]{24}$/i.test(podId)) {
+      return res.status(400).json({ error: 'podId is required' });
+    }
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Pod = require('../models/Pod');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const DMService = require('../services/dmService');
+    const pod = await Pod.findById(podId);
+    if (!pod) return res.status(404).json({ error: 'Pod not found' });
+    const canView = await DMService.canViewPod(callerUserId, pod);
+    if (!canView) return res.status(403).json({ error: 'Access denied' });
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const ApprovalAction = require('../models/ApprovalAction');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { buildCardPayload } = require('../services/approvalActionService');
+    const rows = await ApprovalAction.find({ podId, status: 'flagged' })
+      .sort({ createdAt: -1 })
+      .limit(50);
+    return res.status(200).json({
+      approvals: rows.map((row: unknown) => ({
+        ...buildCardPayload(row),
+        messageId: (row as { messageId?: string }).messageId || null,
+        createdAt: (row as { createdAt?: Date }).createdAt || null,
+      })),
+    });
+  } catch (err) {
+    console.error('GET /approvals/pending error:', err);
+    return res.status(500).json({ error: 'Server Error' });
+  }
+});
+
 router.post('/:approvalId/resolve', approvalResolveLimit, auth, async (req: AuthedReq, res: Res) => {
   try {
     const approvalId = String(req.params?.approvalId || '');

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -835,6 +835,11 @@
       "recentTasks": "Recent tasks",
       "empty": "No tasks yet. Agents will create tasks here as they work — or @-mention one with a request."
     },
+    "approvals": {
+      "title_one": "{{count}} approval waiting",
+      "title_other": "{{count}} approvals waiting",
+      "waiting": "waiting for the owner"
+    },
     "taskPill": {
       "done": "Done",
       "blocked": "Blocked",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -832,6 +832,10 @@
       "recentTasks": "最近任务",
       "empty": "还没有任务。智能体工作时会在这里创建任务 —— 或 @提及 某个智能体并向它提出请求。"
     },
+    "approvals": {
+      "title_other": "{{count}} 个待批准",
+      "waiting": "等待所有者决定"
+    },
     "taskPill": {
       "done": "已完成",
       "blocked": "受阻",

--- a/frontend/src/v2/components/V2ApprovalCard.tsx
+++ b/frontend/src/v2/components/V2ApprovalCard.tsx
@@ -61,7 +61,7 @@ const V2ApprovalCard: React.FC<V2ApprovalCardProps> = ({ message, authorLabel, t
   };
 
   return (
-    <div className="v2-msg v2-msg--system" data-testid="approval-card">
+    <div className="v2-msg v2-msg--system v2-msg--card" data-testid="approval-card">
       <div className="v2-approval">
         <div className="v2-approval__head">
           <span className="v2-approval__badge">{t('approvalCard.badge')}</span>

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -817,6 +817,63 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
     socket.on('task_updated', onTaskUpdated);
     return () => { socket.off('task_updated', onTaskUpdated); };
   }, [pod?._id, socket, connected]);
+
+  // ADR-020 D3: pending approvals from the ApprovalAction rows — the durable
+  // index. Card MESSAGES retire under the 30-day retention window; a flagged
+  // approval must stay findable regardless of how far the card scrolled
+  // (Sam, 2026-08-13). Refetches on the same socket event that patches chat.
+  interface PendingApproval {
+    approvalId: string;
+    summary: string;
+    agentName: string;
+    ownerUserId: string;
+    expiresAt?: string;
+    createdAt?: string;
+  }
+  const [pendingApprovals, setPendingApprovals] = useState<PendingApproval[]>([]);
+  const [approvalRefresh, setApprovalRefresh] = useState(0);
+  const [decidingApprovalId, setDecidingApprovalId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const podId = pod?._id;
+    if (!podId) { setPendingApprovals([]); return undefined; }
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await api.get<{ approvals: PendingApproval[] }>(
+          `/api/approvals/pending?podId=${encodeURIComponent(podId)}`,
+        );
+        if (!cancelled) setPendingApprovals(data.approvals || []);
+      } catch {
+        if (!cancelled) setPendingApprovals([]);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [pod?._id, api, approvalRefresh]);
+
+  useEffect(() => {
+    const podId = pod?._id;
+    if (!podId || !socket || !connected) return undefined;
+    const onCardUpdated = (payload: { podId?: string } | null) => {
+      if (!payload || (payload.podId && payload.podId !== podId)) return;
+      setApprovalRefresh((n) => n + 1);
+    };
+    socket.on('messageCardUpdated', onCardUpdated);
+    return () => { socket.off('messageCardUpdated', onCardUpdated); };
+  }, [pod?._id, socket, connected]);
+
+  const decideApproval = async (approvalId: string, decision: 'approved' | 'declined') => {
+    if (decidingApprovalId) return;
+    setDecidingApprovalId(approvalId);
+    try {
+      await api.post(`/api/approvals/${encodeURIComponent(approvalId)}/resolve`, { decision });
+    } catch {
+      // The refetch below shows the authoritative state either way.
+    } finally {
+      setDecidingApprovalId(null);
+      setApprovalRefresh((n) => n + 1);
+    }
+  };
   const [privateError, setPrivateError] = useState<string | null>(null);
   // ADR-001 §3.10 + Sprint B1: agent-DM pods involving the currently-inspected
   // agent. Surfaces clickable links so humans can observe agent↔agent
@@ -1766,6 +1823,53 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
 
               {tab === 'overview' && (
                 <>
+                  {pendingApprovals.length > 0 && (
+                    <section className="v2-inspector__section" data-testid="inspector-approvals">
+                      <div className="v2-inspector__section-title">
+                        {t('inspector.approvals.title', { count: pendingApprovals.length })}
+                      </div>
+                      <div className="v2-inspector__approvals">
+                        {pendingApprovals.map((appr) => {
+                          const isApprovalOwner = !!currentUser?._id
+                            && String(currentUser._id) === String(appr.ownerUserId);
+                          return (
+                            <div key={appr.approvalId} className="v2-inspector__approval-row">
+                              <div className="v2-inspector__approval-summary" title={appr.summary}>
+                                {appr.summary}
+                              </div>
+                              <div className="v2-inspector__approval-meta">
+                                <span className="v2-inspector__approval-agent">{appr.agentName}</span>
+                                {isApprovalOwner ? (
+                                  <span className="v2-inspector__approval-actions">
+                                    <button
+                                      type="button"
+                                      className="v2-approval__btn v2-approval__btn--approve"
+                                      disabled={decidingApprovalId === appr.approvalId}
+                                      onClick={() => decideApproval(appr.approvalId, 'approved')}
+                                    >
+                                      {t('approvalCard.approve')}
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className="v2-approval__btn v2-approval__btn--decline"
+                                      disabled={decidingApprovalId === appr.approvalId}
+                                      onClick={() => decideApproval(appr.approvalId, 'declined')}
+                                    >
+                                      {t('approvalCard.decline')}
+                                    </button>
+                                  </span>
+                                ) : (
+                                  <span className="v2-inspector__approval-waiting">
+                                    {t('inspector.approvals.waiting')}
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </section>
+                  )}
                   {progressSection}
                   {nowSection}
                   {pod.description && goalSection}

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -6847,12 +6847,20 @@
    rail (the rail-on-rounded-card is the generic look we deliberately avoid;
    flagged by Sam on the first live card, 2026-08-13). */
 
+/* The card sits IN the message content column, not flush with the row edge:
+   38px avatar column + 12px gap, in lockstep with the .v2-msg grid. Without
+   this inset the card starts 50px left of every bubble's text and reads as
+   misaligned (measured 372 vs 422; Sam, 2026-08-13). */
+.v2-msg.v2-msg--card {
+  padding-left: 50px;
+}
+
 .v2-approval {
   border: 1px solid var(--v2-border-soft);
   border-radius: var(--v2-radius);
   background: var(--v2-accent-soft);
   padding: 12px 16px;
-  max-width: 480px;
+  max-width: none;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -6973,4 +6981,56 @@
 .v2-approval__error {
   font-size: 12.5px;
   color: #b91c1c;
+}
+
+/* Inspector pending-approvals index (durable, row-backed — cards in chat
+   retire with message retention; this list never does). */
+.v2-inspector__approvals {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.v2-inspector__approval-row {
+  border: 1px solid var(--v2-border-soft);
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-accent-soft);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.v2-inspector__approval-summary {
+  font-size: 13px;
+  color: var(--v2-text-primary);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.v2-inspector__approval-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.v2-inspector__approval-agent {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--v2-text-secondary);
+}
+
+.v2-inspector__approval-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.v2-inspector__approval-waiting {
+  font-size: 11.5px;
+  color: var(--v2-text-muted);
+  font-style: italic;
 }


### PR DESCRIPTION
Sam's two flags on the live card, both structural:

**Alignment** — the card rendered flush with the row edge, 50px left of every bubble's text (measured: card at x=372, message text at x=422 — the `.v2-msg` grid's 38px avatar column + 12px gap that system rows skip). `v2-msg--card` gives it the content-column inset in lockstep with the grid; the card fills the column, so its box matches the bubbles' box exactly.

**Findability** — "can it be counted as a message so old unapproved ones are scrollable?" It IS a message (persists, scrolls) — but that's not durable enough: chat messages retire under the 30-day PG retention window while `ApprovalAction` rows never expire, so scroll-hunting is unreliable *by construction*. New `GET /api/approvals/pending` (pod-visibility read gate; deciding stays owner-only in `/resolve`) + an inspector Overview section listing flagged approvals with inline Approve/Decline for the owner, refreshing on the same `messageCardUpdated` socket event that patches chat. An approval stays findable and actionable forever, regardless of where its card scrolled — this is also the first brick of ADR-017's attention feed.

Tests: 3 route cases green locally; typecheck clean both tiers; browser check post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8