### PR TITLE
fix(shell): collapse the empty reaction strip — the phantom band under every message

### DIFF
--- a/frontend/src/v2/__tests__/V2MessageBubble.test.tsx
+++ b/frontend/src/v2/__tests__/V2MessageBubble.test.tsx
@@ -42,4 +42,53 @@ describe('V2MessageBubble', () => {
       'https://api.commonly.me/api/uploads/avatar.png',
     );
   });
+
+  // The reactions row must not reserve layout space when it holds only the
+  // hover "+" trigger — the invisible band under every message pushed
+  // approval cards visibly away from their trigger text (2026-08-13).
+  it('collapses the reactions row (--bare) when a message has no reactions', () => {
+    render(
+      <MemoryRouter>
+        <V2MessageBubble
+          message={{
+            id: '42',
+            pod_id: 'pod-1',
+            user_id: 'sender-1',
+            content: 'hello',
+            message_type: 'text',
+            created_at: '2026-08-13T00:00:00.000Z',
+            user: { username: 'sender' },
+            reactions: [],
+          }}
+        />
+      </MemoryRouter>,
+    );
+
+    const row = screen.getByLabelText('Reactions');
+    expect(row.className).toContain('v2-msg__reactions--bare');
+    expect(screen.getByRole('button', { name: 'Add reaction' })).toBeInTheDocument();
+  });
+
+  it('keeps the reactions row in flow when chips exist', () => {
+    render(
+      <MemoryRouter>
+        <V2MessageBubble
+          message={{
+            id: '43',
+            pod_id: 'pod-1',
+            user_id: 'sender-1',
+            content: 'hello',
+            message_type: 'text',
+            created_at: '2026-08-13T00:00:00.000Z',
+            user: { username: 'sender' },
+            reactions: [{ emoji: '👍', count: 2, mine: false }],
+          }}
+        />
+      </MemoryRouter>,
+    );
+
+    const row = screen.getByLabelText('Reactions');
+    expect(row.className).not.toContain('v2-msg__reactions--bare');
+    expect(screen.getByText('👍')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -240,6 +240,19 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(v2, '.v2-msg__reaction-emoji')).toContain('line-height: 22px');
   });
 
+  test('the bare reactions row collapses instead of reserving a blank band', () => {
+    // A no-chips row holds only the opacity-0 hover "+", but it used to keep
+    // 24px + 6px of layout space under EVERY message — the phantom band that
+    // pushed approval cards visibly away from their trigger text (2026-08-13).
+    // Both halves are load-bearing: height 0 removes the band; the absolute
+    // add-wrap keeps the trigger reachable without re-expanding the row. The
+    // rule looks inert in isolation — do not "clean it up".
+    expect(ruleBody(v2, '.v2-msg__reactions--bare')).toContain('height: 0');
+    expect(ruleBody(v2, '.v2-msg__reactions--bare .v2-msg__reaction-add-wrap')).toContain(
+      'position: absolute',
+    );
+  });
+
   test('create-pod panel no longer ships audience options (ADR-016 / #768)', () => {
     // Creation asks name + purpose only; visibility is a later act. If option
     // buttons ever come back to this panel they MUST carry the

--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -545,8 +545,17 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
             return `${names.join(', ')} reacted with ${r.emoji}${r.mine ? ' (you)' : ''}`;
           };
 
+          // A row with no chips holds only the hover "+" trigger; --bare
+          // collapses it out of layout so it stops reserving a blank band
+          // under the message. A transient error line re-expands the row —
+          // it's real content the user must be able to read.
+          const bare = renderList.length === 0 && !reactionError;
+
           return (
-            <div className="v2-msg__reactions" aria-label="Reactions">
+            <div
+              className={`v2-msg__reactions${bare ? ' v2-msg__reactions--bare' : ''}`}
+              aria-label="Reactions"
+            >
               {renderList.map((r, idx) => (
                 <button
                   key={`${r.emoji}-${idx}`}

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -5738,6 +5738,35 @@
   }
 }
 
+/* A reactions row with no chips (--bare) holds only the invisible hover
+ * "+" — but it still reserved 24px + 6px margin under EVERY message, and
+ * that phantom band is what made the approval card sit visibly far from
+ * the text that triggered it (Sam, 2026-08-13). Bare rows collapse to
+ * zero height and the trigger floats at the row's top-right, in the empty
+ * space beside the author line — no layout shift on hover, nothing
+ * overlapped (head content is all left-aligned). Rows with chips, or a
+ * transient error line, stay in flow: those are content, not chrome.
+ * The picker keeps anchoring to the add-wrap and opens above it. */
+.v2-msg {
+  position: relative;
+}
+.v2-msg__reactions--bare {
+  height: 0;
+  margin-top: 0;
+}
+.v2-msg__reactions--bare .v2-msg__reaction-add-wrap {
+  position: absolute;
+  top: 10px;
+  right: 4px;
+}
+/* With the trigger at the row's right edge, a left-anchored picker grows
+ * rightward out of the chat column (measured jutting over the inspector);
+ * anchor it right so it opens leftward into the chat area instead. */
+.v2-msg__reactions--bare .v2-msg__reaction-picker {
+  left: auto;
+  right: 0;
+}
+
 .v2-msg__reaction-picker {
   position: absolute;
   bottom: calc(100% + 6px);


### PR DESCRIPTION
## Why

Sam's flag this morning: *"that card is also too far away from the message why?"*

Measured live: the approval card sat **46px** below its trigger text. The space wasn't the card's — it was an invisible **reactions strip** under every message. The hover-only "+" trigger fades via `opacity` (deliberately, so layout stays stable), which means a row with zero reactions still reserves 24px + 6px margin. Every message in every pod carries that phantom band; a solid tinted card just makes it conspicuous.

## What

- `.v2-msg__reactions--bare` (no chips, no error line): collapses to `height: 0`, and the "+" floats absolutely at the row's top-right, beside the author line — nothing overlapped, no layout shift on hover.
- Its picker anchors `right: 0` so it opens leftward into the chat column (left-anchored it jutted over the inspector — measured).
- Rows with chips or a transient reaction-error stay in flow: those are content, not chrome.

## Proof

Live preview via injected CSS on commonly.me before pushing:
- trigger-text → card gap: **46px → 16px** (matches inter-message rhythm)
- hover "+" appears at row top-right (y +10, right edge −4), picker opens fully inside the chat column (right edge 905 < 909)
- component tests pin both directions (bare collapses / chips stay); layout invariant guards the rule — it looks inert in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8