### PR TITLE
fix(identity): opaque per-user tokens never surface in displayName suffixes

### DIFF
--- a/backend/__tests__/unit/services/agentIdentityService.collisionResolver.test.js
+++ b/backend/__tests__/unit/services/agentIdentityService.collisionResolver.test.js
@@ -188,6 +188,41 @@ describe('inline displayName collision resolver (sticky dedup)', () => {
     expect(mockSaved[0].botMetadata.displayName).toBe('Pixel (Pixel-Demo)');
   });
 
+  test('opaque per-user token colliding with a canonical peer keeps the bare name', async () => {
+    // Every user's Guide is displayName "Guide" by design. Suffixing the
+    // collision puts the opaque token in every chat byline of every user
+    // except the first ("Guide (U0da521ab41)", observed live 2026-08-13).
+    // Opaque tokens are machine identity — same convention as the #930
+    // mention-handle rule — so the resolver must skip them entirely.
+    mockPeers = [
+      {
+        _id: 'first-users-guide',
+        botMetadata: { displayName: 'Guide', instanceId: 'u11aa22bb33' },
+      },
+    ];
+    await AgentIdentityService.getOrCreateAgentUser('guide', {
+      instanceId: 'u0da521ab41',
+      displayName: 'Guide',
+    });
+    expect(mockSaved.length).toBe(1);
+    expect(mockSaved[0].botMetadata.displayName).toBe('Guide');
+  });
+
+  test('legacy long-form opaque token also keeps the bare name', async () => {
+    mockPeers = [
+      {
+        _id: 'first-users-guide',
+        botMetadata: { displayName: 'Guide', instanceId: 'u11aa22bb33' },
+      },
+    ];
+    await AgentIdentityService.getOrCreateAgentUser('guide', {
+      instanceId: 'u6a7d154b0ec237d4b15dd28b',
+      displayName: 'Guide',
+    });
+    expect(mockSaved.length).toBe(1);
+    expect(mockSaved[0].botMetadata.displayName).toBe('Guide');
+  });
+
   test('new install IS canonical (shorter instanceId than existing peer) — keeps bare name', async () => {
     // pixel-stub-x already has displayName="Pixel" with longer instanceId
     mockPeers = [

--- a/backend/scripts/strip-opaque-displayname-suffixes.ts
+++ b/backend/scripts/strip-opaque-displayname-suffixes.ts
@@ -1,0 +1,85 @@
+/**
+ * strip-opaque-displayname-suffixes — one-shot repair for per-user agents
+ * whose displayName carries a collision suffix built from their own opaque
+ * instance token ("Guide (U0da521ab41)", observed live 2026-08-13).
+ *
+ * The inline collision resolver (agentIdentityService) and the offline
+ * dedup script both suffixed opaque per-user tokens like any other
+ * instanceId. Since every user's Guide shares displayName "Guide" by
+ * design, that put the opaque token into the chat byline of every user's
+ * Guide except the first — the exact leak the #930 identity convention
+ * exists to prevent. Both writers now skip opaque tokens; this sweep
+ * repairs rows written before the fix.
+ *
+ * Safety: only strips a suffix that is EXACTLY the humanization of the
+ * row's own instanceId, so a legitimately human-suffixed name ("Pixel
+ * (Pixel-Demo)") can never match. Idempotent.
+ *
+ * Run:  node --import tsx backend/scripts/strip-opaque-displayname-suffixes.ts [--dry]
+ */
+import mongoose from 'mongoose';
+
+const DRY = process.argv.includes('--dry');
+
+// Keep aligned with isOpaquePerUserToken in agentIdentityService and
+// isOpaqueInstanceToken in V2PodChat.
+const isOpaquePerUserToken = (instanceId: string): boolean => (
+  /^u[a-f0-9]{10}([a-f0-9]{14})?$/.test((instanceId || '').toLowerCase())
+);
+
+// Mirror of the humanizer in the inline resolver / dedup script: opaque
+// tokens have no -/_ separators, so this is just an uppercased first char.
+const humanize = (instanceId: string): string => instanceId
+  .split(/[-_]/)
+  .map((seg) => seg.charAt(0).toUpperCase() + seg.slice(1))
+  .join('-');
+
+interface BotUser {
+  _id: mongoose.Types.ObjectId;
+  username?: string;
+  botMetadata?: { displayName?: string; instanceId?: string };
+}
+
+async function main() {
+  const uri = process.env.MONGO_URI;
+  if (!uri) {
+    console.error('MONGO_URI is required');
+    process.exit(2);
+  }
+  await mongoose.connect(uri);
+  const User = mongoose.model<BotUser>(
+    'User',
+    new mongoose.Schema<BotUser>({}, { strict: false }),
+    'users',
+  );
+
+  const bots = await User.find({ 'botMetadata.instanceId': { $regex: /^u[a-f0-9]{10}/ } })
+    .select('username botMetadata')
+    .lean<BotUser[]>();
+
+  let repaired = 0;
+  for (const u of bots) {
+    const instanceId = (u.botMetadata?.instanceId || '').trim();
+    const display = (u.botMetadata?.displayName || '').trim();
+    if (!isOpaquePerUserToken(instanceId) || !display) continue;
+    const suffix = ` (${humanize(instanceId)})`;
+    if (!display.endsWith(suffix)) continue;
+    const bare = display.slice(0, -suffix.length).trim();
+    if (!bare) continue;
+    console.log(`${DRY ? '[dry] ' : ''}${u.username}: "${display}" → "${bare}"`);
+    if (!DRY) {
+      await User.updateOne(
+        { _id: u._id },
+        { $set: { 'botMetadata.displayName': bare } },
+      );
+    }
+    repaired += 1;
+  }
+  console.log(`\nDone — ${repaired} row(s) ${DRY ? 'would be ' : ''}repaired.`);
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error('Sweep failed:', err);
+  process.exit(1);
+});

--- a/backend/services/agentIdentityService.ts
+++ b/backend/services/agentIdentityService.ts
@@ -311,6 +311,16 @@ interface GetOrCreateOptions {
  * we don't compare it against itself (would always return canonical and
  * never apply a suffix).
  */
+/**
+ * Opaque per-user instance tokens (`u` + sha256(userId) prefix, or the
+ * legacy long form) are machine identity, never human-facing copy — the
+ * same convention the mention-handle rule enforces on the frontend
+ * (isOpaqueInstanceToken in V2PodChat, #930). Keep the two regexes
+ * identical.
+ */
+const isOpaquePerUserToken = (instanceId: string): boolean =>
+  /^u[a-f0-9]{10}([a-f0-9]{14})?$/.test((instanceId || '').toLowerCase());
+
 async function resolveCollisionFreeDisplayName(
   desiredName: string,
   instanceId: string,
@@ -318,6 +328,14 @@ async function resolveCollisionFreeDisplayName(
 ): Promise<string> {
   const trimmed = (desiredName || '').trim();
   if (!trimmed) return trimmed;
+  // Per-user agents (opaque instance tokens) keep the bare name. Every
+  // user's Guide is displayName "Guide" — suffixing the collision would
+  // put the opaque token in every chat byline of every user except the
+  // first ("Guide (U0da521ab41)", observed live 2026-08-13). Their pods
+  // are the owner's own surfaces, so two users' same-named agents never
+  // co-render; if a shared-pod surface ever needs disambiguation, the
+  // honest label is the OWNER, not the token (ADR-020 follow-up).
+  if (isOpaquePerUserToken(instanceId)) return trimmed;
   // If the name already carries a parenthetical suffix, treat as
   // already-disambiguated and pass through. Avoids "Pixel (Pixel-Demo) (Pixel-Demo)"
   // loops when the same install reprovisions.

--- a/scripts/dedupe-agent-display-names.ts
+++ b/scripts/dedupe-agent-display-names.ts
@@ -56,6 +56,18 @@ const looksAlreadyDisambiguated = (displayName: string): boolean => (
   /\([^)]+\)\s*$/.test(displayName.trim())
 );
 
+// Opaque per-user instance tokens (`u` + sha256(userId) prefix, or the
+// legacy long form) are machine identity, never human-facing copy. Their
+// agents are excluded from dedup entirely: every user's Guide shares the
+// displayName "Guide" by design, their pods are the owner's own surfaces
+// (no co-render ambiguity), and a token suffix in a byline is exactly the
+// leak the #930 convention exists to prevent. Keep this regex identical
+// to isOpaquePerUserToken in agentIdentityService (the inline resolver)
+// and isOpaqueInstanceToken in V2PodChat.
+const isOpaquePerUserToken = (instanceId: string): boolean => (
+  /^u[a-f0-9]{10}([a-f0-9]{14})?$/.test((instanceId || '').toLowerCase())
+);
+
 const pickCanonical = (users: BotUser[]): BotUser => {
   // Deterministic preference: shortest instanceId wins (so "pixel" beats
   // "pixel-demo"); ties resolved alphabetically. Stable across re-runs.
@@ -84,6 +96,8 @@ async function main() {
   for (const u of bots) {
     const display = (u.botMetadata?.displayName || '').trim();
     if (!display) continue;
+    // Per-user agents neither receive a suffix nor force one on peers.
+    if (isOpaquePerUserToken(u.botMetadata?.instanceId || '')) continue;
     if (!groups.has(display)) groups.set(display, []);
     groups.get(display)!.push(u);
   }


### PR DESCRIPTION
## Why

Spotted while verifying the reaction-strip fix (#933): the smoke user's Guide renders as **"Guide (U0da521ab41)"** in every chat byline. The inline collision resolver (`resolveCollisionFreeDisplayName`) treats the opaque per-user token like any other instanceId — and since every user's Guide is displayName "Guide" **by design**, every user's Guide except the very first gets the token suffixed into its human-facing label. That's the exact leak the #930 identity convention exists to prevent, at the third of the four name sources.

## What

- **Inline resolver**: opaque tokens (convention `u`+10hex, or the legacy long form) exit before the peer query — bare name kept. Per-user agents are pod-scoped; two users' same-named agents never co-render in v1. If a shared-pod surface someday needs disambiguation, the honest label is the **owner** ("Sam's Guide"), not the token — noted for ADR-020.
- **Offline dedup script**: opaque-token agents excluded from grouping entirely (neither receive nor force a suffix). Regex kept byte-identical across all three copies (resolver / script / V2PodChat) with cross-references in comments.
- **`strip-opaque-displayname-suffixes.ts`**: one-shot repair for rows written before the fix. Only strips a suffix that is exactly the humanization of the row's own token — a legit human suffix ("Pixel (Pixel-Demo)") cannot match. `--dry` supported. Will run on dev post-deploy (1 known row).

## Proof

Collision-resolver suite extended: opaque convention token + legacy long form both keep the bare name against a colliding canonical peer; all 12 tests pass locally.

Historical PG username snapshots keep their old labels — those are frozen at post time by design; new messages resolve clean after the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8