### PR TITLE
fix(shell): restore the #891 agentStateService clobbered by #935 — pod pages crash

### DIFF
--- a/backend/__tests__/unit/services/agentStateService.activity.test.js
+++ b/backend/__tests__/unit/services/agentStateService.activity.test.js
@@ -1,0 +1,33 @@
+/**
+ * agentStateService.deriveActivityBucket — the coarse activity vocabulary
+ * (Raft P4). SEPARATE file from agentStateService.test.js on purpose: the
+ * first version of this suite was written AT that path and silently
+ * replaced the #891 honesty-rules suite — which is exactly why the clobber
+ * it should have caught shipped (2026-08-13 live incident).
+ */
+const { deriveActivityBucket } = require('../../../services/agentStateService');
+
+const minutesAgo = (m) => new Date(Date.now() - m * 60 * 1000);
+
+describe('deriveActivityBucket', () => {
+  test('no signal + webhook runtime = never-connected (the connect step was not finished)', () => {
+    expect(deriveActivityBucket(null, 'webhook')).toBe('never-connected');
+    expect(deriveActivityBucket(undefined, 'moltbot')).toBe('never-connected');
+  });
+
+  test('no signal + native runtime = ready — native agents have no connection to make (#915 lesson)', () => {
+    expect(deriveActivityBucket(null, 'native')).toBe('ready');
+  });
+
+  test('seen within 10 minutes = active', () => {
+    expect(deriveActivityBucket(minutesAgo(3), 'webhook')).toBe('active');
+  });
+
+  test('seen within a day = idle', () => {
+    expect(deriveActivityBucket(minutesAgo(120), 'webhook')).toBe('idle');
+  });
+
+  test('silent for over a day = stale', () => {
+    expect(deriveActivityBucket(minutesAgo(60 * 25), 'webhook')).toBe('stale');
+  });
+});

--- a/backend/__tests__/unit/services/agentStateService.test.js
+++ b/backend/__tests__/unit/services/agentStateService.test.js
@@ -1,32 +1,120 @@
 /**
- * agentStateService.deriveAgentState — the ONE bucket vocabulary (Raft
- * comparison P4). Pinned here so a surface-local rewrite of the thresholds
- * shows up as a red test, not as two surfaces disagreeing in front of a
- * user asking "is my agent connected?".
+ * agentStateService.deriveAgentState — #891 surface 1's honesty rules, pure.
+ *
+ * Contract under test (each rule earned by a measured review finding):
+ *  - BYO installs derive from lastUsedAt: null → never-connected,
+ *    fresh → listening, stale → gone-dark
+ *  - the union of BOTH token stores decides (finding D: legacy/new split
+ *    made live agents read null)
+ *  - native and push-webhook installs are 'reachable' by construction
+ *  - gateway/cloud classes are 'unknown' — never guessed (finding A)
+ *  - fixCommand attaches ONLY for the owner, only in fixable states
+ *    (split key: instructions to someone who can't perform them are the
+ *    P1/P2 contradiction)
  */
-const { deriveAgentState } = require('../../../services/agentStateService');
 
-const minutesAgo = (m) => new Date(Date.now() - m * 60 * 1000);
+const { deriveAgentState, AGENT_LISTENING_STALE_MS } = require('../../../services/agentStateService');
+
+const NOW = 1_700_000_000_000;
+
+const byoInstall = (overrides = {}) => ({
+  agentName: 'sam-agent',
+  instanceId: 'default',
+  displayName: 'Sam Agent',
+  installedBy: 'owner-1',
+  config: { runtime: { runtimeType: 'webhook', host: 'byo' } },
+  runtimeTokens: [],
+  ...overrides,
+});
 
 describe('deriveAgentState', () => {
-  test('no signal + webhook runtime = never-connected (the connect step was not finished)', () => {
-    expect(deriveAgentState(null, 'webhook')).toBe('never-connected');
-    expect(deriveAgentState(undefined, 'moltbot')).toBe('never-connected');
+  test('BYO with no token use anywhere → never-connected, owner gets the fix command', () => {
+    const row = deriveAgentState(byoInstall(), [], 'owner-1', NOW);
+    expect(row.state).toBe('never-connected');
+    expect(row.fixCommand).toBe('commonly agent run sam-agent');
   });
 
-  test('no signal + native runtime = ready — native agents have no connection to make (#915 lesson)', () => {
-    expect(deriveAgentState(null, 'native')).toBe('ready');
+  test('the same state seen by a NON-owner carries the explanation but no instruction', () => {
+    const row = deriveAgentState(byoInstall(), [], 'someone-else', NOW);
+    expect(row.state).toBe('never-connected');
+    expect(row.isOwner).toBe(false);
+    expect(row.fixCommand).toBeUndefined();
   });
 
-  test('seen within 10 minutes = active', () => {
-    expect(deriveAgentState(minutesAgo(3), 'webhook')).toBe('active');
+  test('fresh use on the INSTALLATION token store → listening', () => {
+    const row = deriveAgentState(
+      byoInstall({ runtimeTokens: [{ lastUsedAt: new Date(NOW - 10_000) }] }),
+      [],
+      'owner-1',
+      NOW,
+    );
+    expect(row.state).toBe('listening');
+    expect(row.fixCommand).toBeUndefined(); // nothing to fix
   });
 
-  test('seen within a day = idle', () => {
-    expect(deriveAgentState(minutesAgo(120), 'webhook')).toBe('idle');
+  test('fresh use on the USER token store alone also counts — the union decides (finding D)', () => {
+    const row = deriveAgentState(
+      byoInstall(),
+      [{ lastUsedAt: new Date(NOW - 10_000) }],
+      'owner-1',
+      NOW,
+    );
+    expect(row.state).toBe('listening');
   });
 
-  test('silent for over a day = stale', () => {
-    expect(deriveAgentState(minutesAgo(60 * 25), 'webhook')).toBe('stale');
+  test('stale use → gone-dark, and the owner gets the wake command', () => {
+    const row = deriveAgentState(
+      byoInstall({ runtimeTokens: [{ lastUsedAt: new Date(NOW - AGENT_LISTENING_STALE_MS - 1000) }] }),
+      [],
+      'owner-1',
+      NOW,
+    );
+    expect(row.state).toBe('gone-dark');
+    expect(row.fixCommand).toBe('commonly agent run sam-agent');
+  });
+
+  test('native runtime is reachable by construction — no dot, no lastUsedAt reading', () => {
+    const row = deriveAgentState(
+      byoInstall({ config: { runtime: { runtimeType: 'native' } } }),
+      [],
+      'owner-1',
+      NOW,
+    );
+    expect(row.state).toBe('reachable');
+    expect(row.lastUsedAt).toBeNull();
+  });
+
+  test('a push webhook (webhookUrl set) is reachable regardless of token use', () => {
+    const row = deriveAgentState(
+      byoInstall({ config: { runtime: { runtimeType: 'webhook', host: 'byo', webhookUrl: 'https://x.example/cap' } } }),
+      [],
+      'owner-1',
+      NOW,
+    );
+    expect(row.state).toBe('reachable');
+  });
+
+  test('gateway/cloud classes are unknown — never guessed from a shared boot timestamp (finding A)', () => {
+    const row = deriveAgentState(
+      byoInstall({
+        config: { runtime: { runtimeType: 'moltbot', host: 'cloud' } },
+        runtimeTokens: [{ lastUsedAt: new Date(NOW - 5_000) }], // fresh, and still not trusted
+      }),
+      [],
+      'owner-1',
+      NOW,
+    );
+    expect(row.state).toBe('unknown');
+    expect(row.fixCommand).toBeUndefined();
+  });
+
+  test('legacy local-cli installs count as BYO', () => {
+    const row = deriveAgentState(
+      byoInstall({ config: { runtime: { runtimeType: 'local-cli' } } }),
+      [],
+      'owner-1',
+      NOW,
+    );
+    expect(row.state).toBe('never-connected');
   });
 });

--- a/backend/services/agentStateService.ts
+++ b/backend/services/agentStateService.ts
@@ -1,24 +1,127 @@
 /**
- * agentStateService — the ONE derivation of "is this agent alive?".
+ * agentStateService — #891 surface 1's derivation, kept pure.
  *
- * Proof of life comes from three sources, each covering a runtime class the
- * others miss: heartbeat AgentEvents (gateway moltbots), runtime-token
- * lastUsedAt (BYO wrappers / MCP seats), AgentRun rows (native in-process
- * agents). The pod-agents roster route and the native runtime's
- * commonly_agent_status tool both call THIS module — the Raft comparison
- * (P4, 2026-08-12) flagged that we derive status in multiple places with
- * different vocabulary; this is the consolidation point. Do not fork the
- * bucket thresholds into a surface-local copy.
+ * Answers, per agent install: can it actually respond to a mention right
+ * now? States are PER RUNTIME CLASS because the #891 review measured
+ * `lastUsedAt` lying for every class except the polling one:
+ *
+ *   - BYO wrapper/MCP installs (host 'byo' or legacy local-cli, no
+ *     webhookUrl): the wrapper polls every ~5s while alive, so lastUsedAt is
+ *     an honest reachability signal. null → never-connected · fresh →
+ *     listening · stale → gone-dark.
+ *   - push webhooks (webhookUrl set) and native runtime: reachable by
+ *     construction — no dot, no guess.
+ *   - everything else (gateway moltbots, cloud): 'unknown'. The gateway
+ *     stamps one shared boot timestamp for a whole fleet (finding A);
+ *     pretending to know is the false positive the ratified doc bans.
+ *
+ * Split key (decision 1): the state is the EXPLANATION and goes to any pod
+ * viewer; `fixCommand` is an instruction and attaches only for the owner —
+ * an instruction addressed to someone who cannot perform it is the P1/P2
+ * contradiction the review caught.
+ *
+ * lastUsedAt is the max across BOTH token stores (User.agentRuntimeTokens
+ * and AgentInstallation.runtimeTokens) — the legacy/new split that made
+ * live agents read null (finding D). Pure function: callers fetch, this
+ * derives; the seam is what makes the honesty rules testable without a DB.
  */
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const mongoose = require('mongoose');
+
+export const AGENT_LISTENING_STALE_MS = 5 * 60 * 1000;
+
+export type AgentReachState = 'listening' | 'gone-dark' | 'never-connected' | 'reachable' | 'unknown';
+
+interface TokenRow { lastUsedAt?: Date | string | null }
+
+interface InstallationRow {
+  agentName?: string;
+  instanceId?: string;
+  displayName?: string;
+  installedBy?: unknown;
+  config?: { runtime?: { runtimeType?: string; host?: string; webhookUrl?: string } };
+  runtimeTokens?: TokenRow[];
+}
+
+export interface AgentStateRow {
+  agentName: string;
+  instanceId: string;
+  displayName: string;
+  state: AgentReachState;
+  lastUsedAt: string | null;
+  isOwner: boolean;
+  fixCommand?: string;
+}
+
+const latestUse = (tokenLists: TokenRow[][]): Date | null => {
+  let latest: Date | null = null;
+  for (const list of tokenLists) {
+    for (const row of list || []) {
+      if (!row?.lastUsedAt) continue;
+      const used = new Date(row.lastUsedAt as string);
+      if (Number.isNaN(used.getTime())) continue;
+      if (!latest || used > latest) latest = used;
+    }
+  }
+  return latest;
+};
+
+export function deriveAgentState(
+  installation: InstallationRow,
+  userTokens: TokenRow[],
+  callerId: string,
+  now: number = Date.now(),
+): AgentStateRow {
+  const agentName = String(installation.agentName || '').toLowerCase();
+  const instanceId = String(installation.instanceId || 'default');
+  const runtime = installation.config?.runtime || {};
+  const runtimeType = String(runtime.runtimeType || '').toLowerCase();
+  const isByo = runtime.host === 'byo' || runtimeType === 'local-cli';
+  const isPushWebhook = Boolean(runtime.webhookUrl);
+  const isNative = runtimeType === 'native';
+
+  let state: AgentReachState;
+  let lastUsedAt: Date | null = null;
+  if (isNative || isPushWebhook) {
+    state = 'reachable';
+  } else if (!isByo) {
+    state = 'unknown';
+  } else {
+    lastUsedAt = latestUse([installation.runtimeTokens || [], userTokens || []]);
+    if (!lastUsedAt) state = 'never-connected';
+    else if (now - lastUsedAt.getTime() <= AGENT_LISTENING_STALE_MS) state = 'listening';
+    else state = 'gone-dark';
+  }
+
+  const isOwner = String(installation.installedBy || '') === String(callerId || '');
+  const needsFix = state === 'never-connected' || state === 'gone-dark';
+  return {
+    agentName,
+    instanceId,
+    displayName: installation.displayName || agentName,
+    state,
+    lastUsedAt: lastUsedAt ? lastUsedAt.toISOString() : null,
+    isOwner,
+    ...(isOwner && needsFix ? { fixCommand: `commonly agent run ${agentName}` } : {}),
+  };
+}
+
+// ── activity buckets (Raft P4, added 2026-08-13) ────────────────────────────
+// A SECOND derivation lives here deliberately, under a DIFFERENT name.
+// `deriveAgentState` above answers "can a mention land right now?" (per
+// runtime class, honesty-first). `deriveActivityBucket` below answers "when
+// was this agent last alive, in coarse buckets?" for rosters and Scout's
+// commonly_agent_status tool. The first version of this addition was
+// written as a NEW FILE at this same path and silently clobbered the #891
+// service AND its same-named test (the test that would have caught it) —
+// every pod page crashed on the string payload (2026-08-13 live incident).
+// Never add a "new" service without reading the path first; never name two
+// exports the same thing because they feel similar.
 
 const ACTIVE_WINDOW_MS = 10 * 60 * 1000; // active within 10 minutes
 const STALE_AFTER_MS = 24 * 60 * 60 * 1000; // stale after a silent day
 
-export type AgentStateBucket = 'active' | 'idle' | 'stale' | 'ready' | 'never-connected';
+export type AgentActivityBucket = 'active' | 'idle' | 'stale' | 'ready' | 'never-connected';
 
-interface InstallationLike {
+interface ActivityInstallationLike {
   agentName: string;
   instanceId?: string;
   config?: { runtime?: { runtimeType?: string } };
@@ -26,14 +129,16 @@ interface InstallationLike {
 
 /**
  * Batch: max(last heartbeat, last run, last token use) per (agentName,
- * instanceId) for one pod. Extracted verbatim from the pod-agents route so
- * the route and the tool cannot drift. Advisory by contract — throws are the
- * caller's to soften; each internal source degrades to "no signal".
+ * instanceId) for one pod — heartbeats cover gateway moltbots, AgentRuns
+ * cover native agents, token lastUsedAt covers BYO/MCP wrappers. Shared by
+ * the pod-agents roster route and commonly_agent_status.
  */
 export const collectPodAgentActivity = async (
   podId: string,
-  installations: InstallationLike[],
+  installations: ActivityInstallationLike[],
 ): Promise<Map<string, Date | null>> => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mongoose = require('mongoose');
   const key = (agentName: string, instanceId?: string) => `${agentName}:${instanceId || 'default'}`;
   const result = new Map<string, Date | null>();
   if (!installations.length) return result;
@@ -95,9 +200,8 @@ export const collectPodAgentActivity = async (
   }
 
   // Token lastUsedAt lives on the bot User rows. buildAgentUsername is a
-  // NAMED export (not a static on the default service class) — destructure,
-  // or the token source silently drops out of the max (caught by the #915
-  // regression suite during extraction).
+  // NAMED export — destructure, or the token source silently drops out of
+  // the max (caught by the #915 regression suite).
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { buildAgentUsername } = require('./agentIdentityService');
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -132,15 +236,14 @@ export const collectPodAgentActivity = async (
 };
 
 /**
- * The bucket vocabulary every surface speaks. `ready` is the honest word for
- * a native in-process agent with no runs yet — it has no connection to make,
- * it runs when addressed; calling it "never connected" (#915's bug) taught
- * users a false model.
+ * Coarse activity vocabulary for rosters and Scout's status tool. `ready`
+ * is the honest word for a native in-process agent with no runs yet — it
+ * has no connection to make (#915 lesson).
  */
-export const deriveAgentState = (
+export const deriveActivityBucket = (
   lastActiveAt: Date | null | undefined,
   runtimeType?: string,
-): AgentStateBucket => {
+): AgentActivityBucket => {
   if (!lastActiveAt) {
     return runtimeType === 'native' ? 'ready' : 'never-connected';
   }
@@ -150,7 +253,9 @@ export const deriveAgentState = (
   return 'stale';
 };
 
-export default { collectPodAgentActivity, deriveAgentState };
+export default {
+  deriveAgentState, AGENT_LISTENING_STALE_MS, collectPodAgentActivity, deriveActivityBucket,
+};
 // CJS compat: let require() return the default export directly
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/services/nativeRuntimeService.ts
+++ b/backend/services/nativeRuntimeService.ts
@@ -424,7 +424,7 @@ async function dispatchTool(
         // One derivation, shared with the pod-agents roster route — the
         // Raft-comparison P4 rule: never fork status vocabulary per surface.
         const { AgentInstallation } = require('../models/AgentRegistry');
-        const { collectPodAgentActivity, deriveAgentState } = require('./agentStateService');
+        const { collectPodAgentActivity, deriveActivityBucket } = require('./agentStateService');
         const installations = await AgentInstallation.find({
           podId: ctx.podId,
           status: 'active',
@@ -438,7 +438,7 @@ async function dispatchTool(
             name: i.displayName || i.agentName,
             agentName: i.agentName,
             runtime: runtimeType,
-            state: deriveAgentState(lastActiveAt, runtimeType),
+            state: deriveActivityBucket(lastActiveAt, runtimeType),
             lastActiveAt: lastActiveAt ? new Date(lastActiveAt).toISOString() : null,
           };
         });

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -285,8 +285,17 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
   const agentStateByHandle = useMemo(() => {
     const map = new Map<string, AgentStateRow>();
     agentStates.forEach((s) => {
-      map.set(s.agentName.toLowerCase(), s);
-      if (s.instanceId && s.instanceId !== 'default') map.set(s.instanceId.toLowerCase(), s);
+      // Defensive on shape: this surface promises "silence over a wrong
+      // dot", and that must include a malformed payload. A backend
+      // regression that returned bare strings here crashed the ENTIRE pod
+      // page via this exact line (2026-08-13 agentStateService clobber) —
+      // degrade to no-dots, never to an error boundary.
+      const agentName = typeof s?.agentName === 'string' ? s.agentName : '';
+      if (!agentName) return;
+      map.set(agentName.toLowerCase(), s);
+      if (typeof s.instanceId === 'string' && s.instanceId && s.instanceId !== 'default') {
+        map.set(s.instanceId.toLowerCase(), s);
+      }
     });
     return map;
   }, [agentStates]);


### PR DESCRIPTION
## P0 — live crash, my defect, caught in my own post-deploy browser verification

#935's activity derivation was written as a **new file** at `backend/services/agentStateService.ts` — a path where the #891 mention-honesty service already lived. Its test was written at the exact path of the #891 suite, so **the clobber also buried the test that would have caught it**, and CI stayed green — two overwrites, each hiding the other.

Live effect: `GET /:podId/agent-states` called my `deriveAgentState(lastActiveAt, runtimeType)` with `(installation, tokens, callerId)` → `new Date(installation)` → NaN → every agent `'stale'` as a **bare string** → the composer typeahead's `s.agentName.toLowerCase()` throws → **the entire pod page error-boundaries** for every user.

## Fix
- `agentStateService.ts` + its test restored **verbatim from #910**; the activity pieces re-added in the same file under non-colliding names (`collectPodAgentActivity`, `deriveActivityBucket`) with call sites updated; activity tests in their own file.
- `V2PodChat`: the honesty surface's own contract is "silence over a wrong dot" — that now covers malformed payloads too; shape-guard so a bad backend degrades to no-dots, never an error boundary.

## Proof
All 8 restored #891 honesty cases + 5 activity cases + the #915 roster regression suite pass; both typechecks clean.

Lesson (also inlined at the collision site): never add a "new" service without reading the path first; never name two exports the same because they feel similar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8