### PR TITLE
chore(runtime): backend Node 18 → 22 LTS — pi turn-engine prerequisite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 
@@ -179,7 +179,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:22
 
 WORKDIR /app
 


### PR DESCRIPTION
## Why now

ADR-020 D4 ratified the pi SDK (`@earendil-works/pi-coding-agent`, spike-validated) as Scout's turn engine — and the integration is blocked on a hard constraint: **the SDK requires Node ≥22.19, prod runs 18.20.8** (EOL since April 2025). This is D0 of the pi arc: the runtime bump, isolated from the engine code so each risk lands separately.

- `backend/Dockerfile`: `node:18` → `node:22` (LTS)
- `tests.yml` (both jobs): Node 20 → 22 — the tested version becomes the shipped version, closing the current 18-vs-20 skew as well

## Risk

Low: no native-compiled deps in the backend (bcryptjs is pure JS; mongo/pg drivers are fine on 22). The documented jsonwebtoken/SlowBuffer breakage is Node 26-specific. Full backend suite runs on 22 in this PR's CI — that's the proof.

D1 (next PR): turn-engine seam in nativeRuntimeService + pi engine behind a per-manifest flag (`engine: 'pi'`, Scout first) + env kill-switch; backend stays the scheduler (wake/claims/caps/AgentRun unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8