### PR TITLE
fix(approvals): derive the decider from the accountable human, not pod.createdBy

### DIFF
--- a/backend/__tests__/unit/services/approvalActionService.decider.test.js
+++ b/backend/__tests__/unit/services/approvalActionService.decider.test.js
@@ -1,0 +1,220 @@
+/**
+ * W1 commit 0 — the decider derivation (ADR-020 D2/D3, plan
+ * docs/plans/2026-08-13-agent-platform-consolidation.md).
+ *
+ * `ownerUserId = pod.createdBy` made cards undecidable by construction in
+ * bot-created pods — 63 of 261 production pods, measured. The owner-only
+ * resolve gate then refused a decider who could never exist and the card sat
+ * on the WAITING face forever.
+ *
+ * These pin the derivation itself:
+ *  - the accountable human is the INSTALLER first, pod creator as fallback
+ *  - a candidate must RESOLVE to a non-bot User, not merely be present —
+ *    agentsRuntime's auto-install writes a bot _id, and the seeder writes a
+ *    hardcoded admin id that is a dangling ref on a self-hosted instance
+ *  - when no human resolves we REFUSE to mint; no row, no card message
+ *
+ * Sibling of approvalActionService.test.js, which covers resolve/execute.
+ */
+
+const mockApprovalCreate = jest.fn();
+jest.mock('../../../models/ApprovalAction', () => ({
+  findById: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+  create: (...args) => mockApprovalCreate(...args),
+}));
+
+const mockPodFindById = jest.fn();
+jest.mock('../../../models/Pod', () => ({
+  findById: (...args) => mockPodFindById(...args),
+  create: jest.fn(),
+  updateOne: jest.fn(),
+}));
+
+const mockUserFindById = jest.fn();
+jest.mock('../../../models/User', () => ({
+  findById: (...args) => mockUserFindById(...args),
+}));
+
+const mockInstallFindOne = jest.fn();
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: {
+    findOne: (...args) => mockInstallFindOne(...args),
+    findOneAndUpdate: jest.fn(),
+  },
+  AgentRegistry: { getByName: jest.fn(), create: jest.fn() },
+}));
+
+const mockPostMessage = jest.fn();
+jest.mock('../../../services/agentMessageService', () => ({
+  postMessage: (...args) => mockPostMessage(...args),
+}));
+
+jest.mock('../../../services/agentIdentityService', () => ({
+  getOrCreateAgentUser: jest.fn(),
+  syncUserToPostgreSQL: jest.fn(),
+}));
+
+jest.mock('../../../config/socket', () => ({ getIO: jest.fn(() => null) }));
+
+const { proposeAction } = require('../../../services/approvalActionService');
+
+const HUMAN_INSTALLER = 'aaaaaaaaaaaaaaaaaaaaaaa1';
+const HUMAN_POD_CREATOR = 'aaaaaaaaaaaaaaaaaaaaaaa2';
+const BOT_USER = 'bbbbbbbbbbbbbbbbbbbbbbb1';
+const DANGLING = 'cccccccccccccccccccccccc';
+
+// Pod.findById(...).select(...).lean()
+const podLookup = (createdBy) => {
+  mockPodFindById.mockReturnValue({
+    select: () => ({ lean: async () => (createdBy === null ? null : { createdBy }) }),
+  });
+};
+
+// AgentInstallation.findOne serves two callers: the decider lookup (keyed on
+// podId) and findForeignLocalAgentOwner (keyed on installedBy $ne). Route by
+// query shape so a test can drive them independently.
+const installLookup = ({ installedBy, foreignOwner = null }) => {
+  mockInstallFindOne.mockImplementation((query) => {
+    if (query && query.installedBy) return Promise.resolve(foreignOwner);
+    return Promise.resolve(installedBy === null ? null : { installedBy });
+  });
+};
+
+const userLookup = (byId) => {
+  mockUserFindById.mockImplementation(async (id) => byId[String(id)] || null);
+};
+
+const HUMANS = {
+  [HUMAN_INSTALLER]: { _id: HUMAN_INSTALLER, isBot: false },
+  [HUMAN_POD_CREATOR]: { _id: HUMAN_POD_CREATOR, isBot: false },
+  [BOT_USER]: { _id: BOT_USER, isBot: true },
+};
+
+const propose = (over = {}) => proposeAction({
+  podId: 'pod-1',
+  agentName: 'scout',
+  instanceId: 'default',
+  displayName: 'Scout',
+  actionType: 'create_pod',
+  params: { name: 'Design Studio', type: 'chat' },
+  summary: 'Create a pod for design work',
+  ...over,
+});
+
+describe('proposeAction — decider derivation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApprovalCreate.mockImplementation(async (doc) => ({
+      ...doc,
+      _id: 'appr-1',
+      // The schema defaults this; buildCardPayload calls toISOString on it.
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      save: jest.fn().mockResolvedValue(undefined),
+    }));
+    mockPostMessage.mockResolvedValue({ success: true, message: { _id: 'msg-1' } });
+    userLookup(HUMANS);
+  });
+
+  test('human-created pod with no installation — creator is the decider (baseline)', async () => {
+    podLookup(HUMAN_POD_CREATOR);
+    installLookup({ installedBy: null });
+
+    const result = await propose();
+
+    expect(result.ok).toBe(true);
+    expect(mockApprovalCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerUserId: HUMAN_POD_CREATOR }),
+    );
+  });
+
+  test('bot-created pod with a human installer — the installer decides (the 63/261 fix)', async () => {
+    podLookup(BOT_USER);
+    installLookup({ installedBy: HUMAN_INSTALLER });
+
+    const result = await propose();
+
+    expect(result.ok).toBe(true);
+    expect(mockApprovalCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerUserId: HUMAN_INSTALLER }),
+    );
+  });
+
+  test('installer outranks pod creator when both are human (accountability order)', async () => {
+    podLookup(HUMAN_POD_CREATOR);
+    installLookup({ installedBy: HUMAN_INSTALLER });
+
+    await propose();
+
+    expect(mockApprovalCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerUserId: HUMAN_INSTALLER }),
+    );
+  });
+
+  test('bot installer AND bot pod creator — refuses to mint, no row and no card', async () => {
+    podLookup(BOT_USER);
+    installLookup({ installedBy: BOT_USER });
+
+    const result = await propose();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/undecidable/);
+    expect(mockApprovalCreate).not.toHaveBeenCalled();
+    expect(mockPostMessage).not.toHaveBeenCalled();
+  });
+
+  test('installedBy present but unresolvable — refuses (the self-hosted seeder hole)', async () => {
+    // seed-native-agents writes a hardcoded admin ObjectId. On any other
+    // instance that user does not exist, so the field is a dangling ref
+    // rather than a bot — a presence check would have passed it through.
+    podLookup(BOT_USER);
+    installLookup({ installedBy: DANGLING });
+
+    const result = await propose();
+
+    expect(result.ok).toBe(false);
+    expect(mockApprovalCreate).not.toHaveBeenCalled();
+  });
+
+  test('unresolvable installer falls back to a human pod creator', async () => {
+    podLookup(HUMAN_POD_CREATOR);
+    installLookup({ installedBy: DANGLING });
+
+    const result = await propose();
+
+    expect(result.ok).toBe(true);
+    expect(mockApprovalCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerUserId: HUMAN_POD_CREATOR }),
+    );
+  });
+
+  test('missing pod is refused before any derivation work', async () => {
+    podLookup(null);
+    installLookup({ installedBy: HUMAN_INSTALLER });
+
+    const result = await propose();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('pod not found');
+    expect(mockApprovalCreate).not.toHaveBeenCalled();
+  });
+
+  test('connect_local_agent name guard checks the derived decider, not the pod creator', async () => {
+    // Bot-created pod: pre-fix this guard compared against a bot id, so a name
+    // the deciding human already owned looked foreign and got refused.
+    podLookup(BOT_USER);
+    installLookup({ installedBy: HUMAN_INSTALLER, foreignOwner: null });
+
+    const result = await propose({
+      actionType: 'connect_local_agent',
+      params: { name: 'my-laptop' },
+      summary: 'Connect your laptop agent',
+    });
+
+    expect(result.ok).toBe(true);
+    const foreignCheck = mockInstallFindOne.mock.calls
+      .map(([query]) => query)
+      .find((query) => query && query.installedBy);
+    expect(foreignCheck.installedBy).toEqual({ $ne: HUMAN_INSTALLER });
+  });
+});

--- a/backend/services/approvalActionService.ts
+++ b/backend/services/approvalActionService.ts
@@ -135,6 +135,45 @@ const findForeignLocalAgentOwner = async (
   return !!foreign;
 };
 
+/**
+ * The decider is the accountable HUMAN — not whoever happens to have created
+ * the pod.
+ *
+ * `ownerUserId = pod.createdBy` was the original derivation and it is wrong at
+ * scale: 63 of 261 production pods are bot-created, so a card proposed in one
+ * was undecidable by construction. The owner-only resolve gate refused a
+ * decider who could never exist, and the card sat on the WAITING face forever.
+ * On a consent surface that fails silent, which is the one failure mode a
+ * consent surface may not have.
+ *
+ * Candidates are tried in accountability order: whoever installed this agent
+ * here answers for what it proposes; the pod's creator is the fallback.
+ *
+ * Each candidate must RESOLVE to a non-bot User, which is stricter than
+ * testing the field for presence, and deliberately so — `installedBy` is not
+ * reliably a human. `agentsRuntime`'s auto-install paths store a bot `_id`
+ * (:2850, :2907, :2997), and `seed-native-agents` stores a hardcoded admin id
+ * that simply does not exist on a self-hosted instance, where it is a dangling
+ * ref rather than a bot. A presence check catches neither; resolution catches
+ * both.
+ *
+ * Returning null means refuse to mint. That is the honest outcome: an
+ * undecidable card is the exact failure this derivation exists to prevent, and
+ * a refusal at propose time tells the agent something it can act on.
+ */
+const resolveHumanDecider = async (candidates: unknown[]): Promise<string | null> => {
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    const key = candidate ? String(candidate) : '';
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    // eslint-disable-next-line no-await-in-loop
+    const user = await User.findById(key);
+    if (user && user.isBot !== true) return String(user._id);
+  }
+  return null;
+};
+
 export const proposeAction = async (options: ProposeOptions): Promise<ProposeResult> => {
   const {
     podId, agentName, instanceId, displayName, actionType, params, summary, installationConfig,
@@ -151,14 +190,29 @@ export const proposeAction = async (options: ProposeOptions): Promise<ProposeRes
   const trimmedSummary = String(summary || '').trim();
   if (!trimmedSummary) return { ok: false, error: 'summary is required' };
 
-  // The decider is the pod's owner — for the Guide's workspace, the user.
-  // A pod with no resolvable owner cannot host approval cards.
   const pod = await Pod.findById(podId).select('createdBy').lean() as { createdBy?: unknown } | null;
-  if (!pod?.createdBy) return { ok: false, error: 'pod has no resolvable owner' };
+  if (!pod) return { ok: false, error: 'pod not found' };
+
+  // See resolveHumanDecider: installer first, pod creator as fallback, and the
+  // winner must resolve to a real non-bot User.
+  const install = await AgentInstallation.findOne({
+    agentName: String(agentName).toLowerCase(),
+    podId,
+    instanceId: instanceId || 'default',
+    status: 'active',
+  });
+  const ownerUserId = await resolveHumanDecider([install?.installedBy, pod.createdBy]);
+  if (!ownerUserId) {
+    return {
+      ok: false,
+      error: 'no accountable human owns this pod, so an approval card here would be undecidable — '
+        + 'a human must install the agent or own the pod before it can propose actions',
+    };
+  }
 
   if (actionType === 'connect_local_agent') {
     const requestedName = String((params || {}).name || '').trim().toLowerCase();
-    if (await findForeignLocalAgentOwner(requestedName, pod.createdBy)) {
+    if (await findForeignLocalAgentOwner(requestedName, ownerUserId)) {
       return {
         ok: false,
         error: `the agent name "${requestedName}" is already in use by another user — pick a different name`,
@@ -168,7 +222,7 @@ export const proposeAction = async (options: ProposeOptions): Promise<ProposeRes
 
   const row = await ApprovalAction.create({
     podId,
-    ownerUserId: pod.createdBy,
+    ownerUserId,
     agentName: String(agentName).toLowerCase(),
     instanceId: instanceId || 'default',
     actionType,


### PR DESCRIPTION
**W1 commit 0** of `docs/plans/2026-08-13-agent-platform-consolidation.md`, and a blocker for the rest of W1.

## The defect

`ownerUserId = pod.createdBy` made approval cards **undecidable by construction** wherever a bot created the pod — **63 of 261 production pods**. The owner-only resolve gate then refused a decider who could never exist, so the card sat on the WAITING face forever. A consent surface may not fail silent.

## The fix

The decider is the accountable human, tried in accountability order: **whoever installed this agent here**, then **the pod's creator**.

Each candidate must **resolve to a non-bot User** rather than merely be present. That is stricter than the original review remedy on purpose — it catches two cases an `isBot` field check does not:

| case | why a presence/isBot check misses it |
|---|---|
| `agentsRuntime.ts:2850, :2907, :2997` auto-install | stores a **bot `_id`** in `installedBy` — the field is not reliably human |
| `seed-native-agents.ts:387` | stores a **hardcoded admin ObjectId**. On a self-hosted instance that user does not exist, so it is a **dangling ref**, not a bot — undecidable for a different reason, and it survives an `isBot` test |

When no human resolves, we **refuse to mint**. An undecidable card is precisely the failure this derivation exists to prevent, and a propose-time refusal gives the agent something it can act on.

The `connect_local_agent` foreign-name guard moves to the derived decider as well — sprint-review flagged this line as coupled. In a bot-created pod it was comparing against a bot id, so a name the deciding human already owned looked foreign and was refused.

## Review provenance

The blocker and the 63/261 measurement came from **pod-architect**; the "refuse when no human *resolves*" strengthening and the coupled `:429` line came from **sprint-review**, both in the Sharpen fleet review. Their `installedBy` write-path survey listed four paths; this change was written against **nine**, including the three bot-id writers above, which is what motivated resolution over presence.

## Tests

New sibling suite `approvalActionService.decider.test.js` (the directory's `<service>.<aspect>` convention, not a same-named file — the #936 clobber lesson). Pins the derivation, both fallbacks, both refusal causes, and the name-guard coupling. Existing `approvalActionService` + `approvals.pending` suites pass unchanged — 24 tests total.

## Not in this PR

The `/propose-action` route, the card render fix, and `commonly_propose_action` are W1 steps 1–3 and land separately. See the review note on the plan's origin-cue requirement — ADR-001's `source` axis is not reachable from an ApprovalAction row today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8