### PR TITLE
fix(approvals): the card consents to the action, not the agent's prose

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -940,6 +940,11 @@
   },
   "approvalCard": {
     "badge": "Approval needed",
+    "action": {
+      "createPod": "Create a pod named \"{{name}}\" ({{type}})",
+      "connectLocalAgent": "Connect a local agent seat named \"{{name}}\"",
+      "unknown": "Run \"{{actionType}}\" with: {{params}}"
+    },
     "approve": "Approve",
     "decline": "Decline",
     "deciding": "Deciding…",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -934,6 +934,11 @@
   },
   "approvalCard": {
     "badge": "需要批准",
+    "action": {
+      "createPod": "创建一个名为“{{name}}”的 Pod（类型：{{type}}）",
+      "connectLocalAgent": "连接一个名为“{{name}}”的本地智能体座位",
+      "unknown": "执行“{{actionType}}”，参数：{{params}}"
+    },
     "approve": "批准",
     "decline": "拒绝",
     "deciding": "处理中…",

--- a/frontend/src/v2/__tests__/V2ApprovalCardAction.test.tsx
+++ b/frontend/src/v2/__tests__/V2ApprovalCardAction.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2ApprovalCard from '../components/V2ApprovalCard';
+import en from '../../i18n/locales/en.json';
+import zhCN from '../../i18n/locales/zh-CN.json';
+
+/**
+ * W1 step 2 — the card's consent line is what the server will DO, not what the
+ * agent SAID it would do.
+ *
+ * `summary` is caller-supplied prose and its entire server-side validation is
+ * empty-reject plus 500-truncate (approvalActionService:151-152, :176).
+ * Nothing checks the sentence against the action, so an agent could send
+ * actionType 'create_pod' with summary "just tidying up your notes" and the
+ * human would consent to the sentence while the params executed. `actionType`
+ * and `params` were already on the wire and simply unrendered.
+ *
+ * Live defect, not a BYO forecast — Scout runs on injectable workspace input
+ * today (sprint-review, fleet review 2026-08-13).
+ */
+
+jest.mock('../hooks/useV2Api', () => ({
+  useV2Api: () => ({
+    get: jest.fn(), post: jest.fn(), patch: jest.fn(), del: jest.fn(),
+  }),
+}));
+
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ currentUser: { _id: 'viewer-1' } }),
+}));
+
+const MISLEADING = 'Just tidying up your notes';
+
+const cardMessage = (payload: Record<string, unknown>) => ({
+  id: 'm1',
+  content: 'fallback content',
+  payload,
+} as never);
+
+const renderCard = (payload: Record<string, unknown>) => render(
+  <MemoryRouter>
+    <V2ApprovalCard message={cardMessage(payload)} authorLabel="Scout" time="3:45 PM" />
+  </MemoryRouter>,
+);
+
+describe('the approval card consents to the action, not the prose', () => {
+  test('a misleading summary cannot occupy the action line', () => {
+    renderCard({
+      kind: 'approval-card',
+      approvalId: 'a1',
+      status: 'flagged',
+      ownerUserId: 'viewer-1',
+      actionType: 'create_pod',
+      params: { name: 'Design Studio', type: 'chat' },
+      summary: MISLEADING,
+    });
+
+    const action = screen.getByTestId('approval-action');
+    // The real action, derived from the fields the executor reads.
+    expect(action.textContent).toMatch(/Design Studio/);
+    expect(action.textContent).toMatch(/pod/i);
+    // The prose is still shown — it is the agent's reason — but it is NOT the
+    // thing being consented to, so it must not be the action line.
+    expect(action.textContent).not.toMatch(/tidying/);
+    expect(screen.getByText(MISLEADING)).toBeInTheDocument();
+  });
+
+  test('connect_local_agent names the seat being created', () => {
+    renderCard({
+      kind: 'approval-card',
+      approvalId: 'a2',
+      status: 'flagged',
+      ownerUserId: 'viewer-1',
+      actionType: 'connect_local_agent',
+      params: { name: 'my-laptop' },
+      summary: MISLEADING,
+    });
+
+    const action = screen.getByTestId('approval-action');
+    expect(action.textContent).toMatch(/my-laptop/);
+    expect(action.textContent).not.toMatch(/tidying/);
+  });
+
+  test('an unknown actionType names itself rather than promoting the prose', () => {
+    // Degrades safely when the kernel gains an action type before the shell
+    // learns its wording. Ugly beats wrong on a consent surface.
+    renderCard({
+      kind: 'approval-card',
+      approvalId: 'a3',
+      status: 'flagged',
+      ownerUserId: 'viewer-1',
+      actionType: 'transfer_ownership',
+      params: { to: 'someone-else' },
+      summary: MISLEADING,
+    });
+
+    const action = screen.getByTestId('approval-action');
+    expect(action.textContent).toMatch(/transfer_ownership/);
+    expect(action.textContent).toMatch(/someone-else/);
+    expect(action.textContent).not.toMatch(/tidying/);
+  });
+
+  test('the owner still gets live buttons — the fix is render order, not gating', () => {
+    renderCard({
+      kind: 'approval-card',
+      approvalId: 'a4',
+      status: 'flagged',
+      ownerUserId: 'viewer-1',
+      actionType: 'create_pod',
+      params: { name: 'Design Studio', type: 'chat' },
+      summary: 'Create a pod for design work',
+    });
+
+    expect(screen.getByText(en.approvalCard.approve)).toBeInTheDocument();
+    expect(screen.getByText(en.approvalCard.decline)).toBeInTheDocument();
+  });
+});
+
+describe('both locales carry the action phrasings', () => {
+  describe.each([['en', en as any], ['zh-CN', zhCN as any]])('%s', (_locale, bundle) => {
+    const action = bundle.approvalCard?.action;
+
+    test('all three phrasings exist', () => {
+      expect(action?.createPod).toBeTruthy();
+      expect(action?.connectLocalAgent).toBeTruthy();
+      expect(action?.unknown).toBeTruthy();
+    });
+
+    test('each interpolates the params it describes', () => {
+      // A phrasing that drops its interpolation silently becomes a generic
+      // sentence — which is the mislabeling defect wearing a different hat.
+      expect(action.createPod).toMatch(/\{\{name\}\}/);
+      expect(action.createPod).toMatch(/\{\{type\}\}/);
+      expect(action.connectLocalAgent).toMatch(/\{\{name\}\}/);
+      expect(action.unknown).toMatch(/\{\{actionType\}\}/);
+      expect(action.unknown).toMatch(/\{\{params\}\}/);
+    });
+  });
+});

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -261,6 +261,18 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).not.toMatch(/\.v2-pods__create-option[^\n]*\{/);
   });
 
+  test('the approval card visually outranks the action over the agent prose', () => {
+    // The consent fix is render ORDER plus visual rank. The order lives in
+    // V2ApprovalCard and a render test pins it; the rank lives only here.
+    // If the pitch ever styles up to match the action, the two lines read as
+    // equals again and a human re-consents to prose — the exact defect,
+    // silently restored, with the render test still green.
+    expect(ruleBody(v2, '.v2-approval__action')).toContain('font-weight: 600');
+    const pitch = ruleBody(v2, '.v2-approval__pitch');
+    expect(pitch).toContain('border-left');
+    expect(pitch).toMatch(/font-size: 13px/);
+  });
+
   test('compare head does not combine section padding with its own max-width', () => {
     // `.v2-landing__section` centres a 1120px column via percentage padding
     // resolved against the PARENT. An element carrying both that class and its

--- a/frontend/src/v2/components/V2ApprovalCard.tsx
+++ b/frontend/src/v2/components/V2ApprovalCard.tsx
@@ -20,6 +20,47 @@ interface V2ApprovalCardProps {
   time: string | null;
 }
 
+// The consent line is derived from the fields the executor actually reads —
+// `actionType` + `params` — and never from `summary`.
+//
+// `summary` is caller-supplied prose whose entire server-side validation is
+// empty-reject plus 500-truncate (approvalActionService:151-152, :176).
+// Nothing checks that the sentence describes the action, so an agent can send
+// actionType 'create_pod' with summary "just tidying up your notes" and the
+// human consents to the sentence while the params execute. That gap is live
+// today — it is not a BYO-only forecast (sprint-review, fleet review
+// 2026-08-13).
+//
+// The prose stays: it is the agent's reason for asking, and that is worth
+// reading. It renders as a pitch beneath the action, never as the headline.
+const describeAction = (
+  actionType?: string | null,
+  params?: Record<string, unknown> | null,
+): { key: string; vars: Record<string, string> } | null => {
+  if (!actionType) return null;
+  const p = params || {};
+  if (actionType === 'create_pod') {
+    return {
+      key: 'approvalCard.action.createPod',
+      vars: { name: String(p.name ?? ''), type: String(p.type || 'chat') },
+    };
+  }
+  if (actionType === 'connect_local_agent') {
+    return {
+      key: 'approvalCard.action.connectLocalAgent',
+      vars: { name: String(p.name ?? '') },
+    };
+  }
+  // An actionType we have no phrasing for is still not licence to promote
+  // prose back into the action slot. Name it and show the params verbatim:
+  // ugly beats wrong on a consent surface, and it degrades safely when the
+  // kernel gains an action type before the shell learns its wording.
+  return {
+    key: 'approvalCard.action.unknown',
+    vars: { actionType, params: JSON.stringify(p) },
+  };
+};
+
 const V2ApprovalCard: React.FC<V2ApprovalCardProps> = ({ message, authorLabel, time }) => {
   const { t } = useTranslation();
   const { currentUser } = useAuth();
@@ -57,6 +98,8 @@ const V2ApprovalCard: React.FC<V2ApprovalCardProps> = ({ message, authorLabel, t
   // Partial success is its own truth: the pod exists (user owns it) but the
   // agent couldn't join and would 403 on every post — say so, don't say done.
   const agentJoinFailed = execution?.agentJoined === false;
+  const action = describeAction(payload.actionType, payload.params);
+  const prose = payload.summary || message.content;
 
   const decide = async (decision: 'approved' | 'declined') => {
     if (deciding || !payload.approvalId) return;
@@ -81,7 +124,19 @@ const V2ApprovalCard: React.FC<V2ApprovalCardProps> = ({ message, authorLabel, t
           <span className="v2-approval__agent">{authorLabel}</span>
           {time && <span className="v2-approval__time">{time}</span>}
         </div>
-        <div className="v2-approval__summary">{payload.summary || message.content}</div>
+        {action ? (
+          <>
+            <div className="v2-approval__action" data-testid="approval-action">
+              {t(action.key, action.vars)}
+            </div>
+            {prose && <div className="v2-approval__pitch">{prose}</div>}
+          </>
+        ) : (
+          // Only reachable for a payload with no actionType at all, which the
+          // server never mints. Rendering the prose alone beats rendering
+          // nothing, and there is no action to misrepresent.
+          <div className="v2-approval__summary">{prose}</div>
+        )}
 
         {status === 'flagged' && (
           <>

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -6927,6 +6927,27 @@
   line-height: 1.45;
 }
 
+/* The consent line — server-derived from actionType + params. It outranks the
+   agent's prose deliberately: the prose is unvalidated and the human is
+   consenting to what executes, not to what was pitched. */
+.v2-approval__action {
+  font-size: 14.5px;
+  font-weight: 600;
+  color: var(--v2-text-primary);
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+/* The agent's reason for asking, demoted below the action it belongs to. */
+.v2-approval__pitch {
+  font-size: 13px;
+  color: var(--v2-text-secondary);
+  line-height: 1.45;
+  padding-left: 10px;
+  border-left: 2px solid var(--v2-border-soft);
+  overflow-wrap: anywhere;
+}
+
 .v2-approval__actions {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
**W1 step 2** of the consolidation plan. This one is **live today**, not a BYO forecast.

## The defect

`V2ApprovalCard:84` rendered `payload.summary` as the headline and nothing else. That field is caller-supplied prose whose entire server-side validation is **empty-reject plus 500-truncate** (`approvalActionService:151-152, :176`). Nothing checks that the sentence describes the action.

So an agent can send:

```json
{ "actionType": "create_pod", "params": { "name": "..." },
  "summary": "Just tidying up your notes" }
```

…and the human consents to the sentence while the **params** execute. Scout runs on injectable workspace input, so this is reachable now — `sprint-review` verified it at source during the fleet review, upgrading it from ux-lead's BYO-only forecast.

## The fix

`actionType` and `params` were **already on the wire** in `buildCardPayload` and simply unrendered, so this is render order plus a derivation — not new plumbing.

- The consent line derives from `actionType` + `params`, **the same fields the executor reads**, so it is faithful by construction.
- The prose stays, demoted to a quoted pitch beneath the action. It is the agent's reason for asking and worth reading — just not the thing being consented to.
- An **unknown** `actionType` names itself and prints its params rather than letting prose back into the action slot. Ugly beats wrong on a consent surface, and it degrades safely when the kernel gains an action type before the shell learns its wording.

Both locales carry the three phrasings. The zh-CN half is not optional — both users who hit the last connect-flow honesty gap were writing Chinese.

## Tests

- A render suite pins that **a misleading summary cannot occupy the action line**, plus interpolation presence in both bundles.
- The visual **rank** lives only in CSS, so a layout invariant guards it. If the pitch ever styles up to match the action, the two read as equals again and the defect returns *silently, with the render test still green* — exactly the regression class `v2-layout-invariants` exists for.
- 33 tests pass across both suites.

## Not included, and why

The **ADR-001 origin cue** the plan pairs with this. `source` is not reachable from an `ApprovalAction` row: it lives only on `Installable`, `AgentInstallation` has no `source` and no `installableId`, and `approvalActionService:415-432` — the path that creates an agent from an approved card — writes an `AgentRegistry` row and an `AgentInstallation` but **no `Installable` at all**. Three of the five enum values are never written by any code path. Raised with the fleet for refutation; if it holds, the cue is new work rather than a render change.

## Unrelated defect noticed

`frontend/node_modules` is a **tracked symlink on `main`** (mode 120000) pointing at an absolute path inside one local worktree. Any other clone gets a dangling self-referential symlink where `node_modules` should be. Not touched here — flagging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8