### PR TITLE
[ON HOLD — do not merge] feat(llm): add named OrcaRouter provider for backend LLM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,10 @@ OPENAI_BASE_URL=
 OPENROUTER_API_KEY=
 OPENROUTER_BASE_URL=
 
+# OrcaRouter (OpenAI-compatible gateway, sk-orca- keys)
+ORCAROUTER_API_KEY=
+ORCAROUTER_BASE_URL=
+
 # Google Gemini (direct, not via OpenRouter)
 GEMINI_API_KEY=
 

--- a/backend/__tests__/unit/services/globalModelConfigService.test.js
+++ b/backend/__tests__/unit/services/globalModelConfigService.test.js
@@ -23,6 +23,10 @@ describe('globalModelConfigService', () => {
       baseUrl: 'https://openrouter.ai/api/v1',
       model: '',
     });
+    expect(result.llmService.orcarouter).toEqual({
+      baseUrl: 'https://api.orcarouter.ai/v1',
+      model: '',
+    });
     expect(result.openclaw.provider).toBe('google');
     expect(result.openclaw.model).toBe('google/gemini-2.5-flash');
     expect(result.openclaw.fallbackModels).toEqual([
@@ -102,5 +106,45 @@ describe('globalModelConfigService', () => {
 
     const updateArg = SystemSetting.findOneAndUpdate.mock.calls[0][1];
     expect(updateArg.$set.value.openclaw.model).toBe('openrouter/arcee-ai/trinity-large-preview:free');
+  });
+
+  it('drops stored OrcaRouter key and keeps only routing fields', async () => {
+    SystemSetting.findOne.mockReturnValueOnce({
+      lean: jest.fn().mockResolvedValueOnce({
+        key: 'llm.globalModelConfig',
+        value: {
+          llmService: {
+            provider: 'orcarouter',
+            model: 'openai/gpt-5.5',
+            orcarouter: {
+              baseUrl: 'https://api.orcarouter.ai/v1',
+              model: 'openai/gpt-5.5',
+              apiKey: 'sk-orca-existing',
+            },
+          },
+        },
+      }),
+    });
+    SystemSetting.findOneAndUpdate.mockResolvedValueOnce({});
+
+    const result = await GlobalModelConfigService.setConfig({
+      llmService: {
+        provider: 'orcarouter',
+        model: 'openai/gpt-5.5',
+        orcarouter: {
+          model: 'anthropic/claude-sonnet-5',
+          apiKey: 'sk-orca-new-value',
+        },
+      },
+    }, 'u1');
+
+    const updateArg = SystemSetting.findOneAndUpdate.mock.calls[0][1];
+    expect(updateArg.$set.value.llmService.orcarouter).toEqual({
+      baseUrl: 'https://api.orcarouter.ai/v1',
+      model: 'anthropic/claude-sonnet-5',
+    });
+    expect(updateArg.$set.value.llmService.orcarouter.apiKey).toBeUndefined();
+    expect(result.llmService.provider).toBe('orcarouter');
+    expect(result.llmService.orcarouter.apiKey).toBeUndefined();
   });
 });

--- a/backend/services/globalModelConfigService.ts
+++ b/backend/services/globalModelConfigService.ts
@@ -7,11 +7,17 @@ export interface OpenRouterServiceConfig {
   model: string;
 }
 
+export interface OrcaRouterServiceConfig {
+  baseUrl: string;
+  model: string;
+}
+
 export interface LlmServiceConfig {
   provider: string;
   model: string;
   contextLimit: number;
   openrouter: OpenRouterServiceConfig;
+  orcarouter: OrcaRouterServiceConfig;
 }
 
 export interface CommunityAgentModel {
@@ -34,11 +40,15 @@ export interface GlobalModelConfig {
 
 const DEFAULT_CONFIG: GlobalModelConfig = {
   llmService: {
-    provider: 'auto', // auto | gemini | litellm | openrouter
+    provider: 'auto', // auto | gemini | litellm | openrouter | orcarouter
     model: 'gemini-2.5-flash',
     contextLimit: 128000, // max input tokens for the configured model
     openrouter: {
       baseUrl: 'https://openrouter.ai/api/v1',
+      model: '',
+    },
+    orcarouter: {
+      baseUrl: 'https://api.orcarouter.ai/v1',
       model: '',
     },
   },
@@ -70,7 +80,7 @@ let cachedAt = 0;
 
 const normalizeProvider = (value: unknown): string => {
   const normalized = String(value || '').trim().toLowerCase();
-  if (['auto', 'gemini', 'litellm', 'openrouter', 'openai', 'anthropic'].includes(normalized)) {
+  if (['auto', 'gemini', 'litellm', 'openrouter', 'orcarouter', 'openai', 'anthropic'].includes(normalized)) {
     return normalized;
   }
   return DEFAULT_CONFIG.llmService.provider;
@@ -171,6 +181,13 @@ const sanitize = (candidate: Partial<GlobalModelConfig> = {}): GlobalModelConfig
         ),
         model: normalizeModel(llm?.openrouter?.model),
       },
+      orcarouter: {
+        baseUrl: normalizeModel(
+          llm?.orcarouter?.baseUrl,
+          DEFAULT_CONFIG.llmService.orcarouter.baseUrl,
+        ),
+        model: normalizeModel(llm?.orcarouter?.model),
+      },
     },
     openclaw: {
       provider: normalizeOpenClawProvider(oc?.provider),
@@ -223,6 +240,10 @@ class GlobalModelConfigService {
             ...defaults.llmService.openrouter,
             ...(stored.llmService?.openrouter || {}),
           },
+          orcarouter: {
+            ...defaults.llmService.orcarouter,
+            ...(stored.llmService?.orcarouter || {}),
+          },
         },
         openclaw: {
           ...defaults.openclaw,
@@ -247,6 +268,10 @@ class GlobalModelConfigService {
         openrouter: {
           ...current.llmService.openrouter,
           ...((patch && patch.llmService && patch.llmService.openrouter) || {}),
+        },
+        orcarouter: {
+          ...current.llmService.orcarouter,
+          ...((patch && patch.llmService && patch.llmService.orcarouter) || {}),
         },
       },
       openclaw: {

--- a/backend/services/llmService.ts
+++ b/backend/services/llmService.ts
@@ -4,6 +4,7 @@ import GlobalModelConfigService from './globalModelConfigService';
 
 const DEFAULT_MODEL = 'gemini-2.5-flash';
 const DEFAULT_OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+const DEFAULT_ORCAROUTER_BASE_URL = 'https://api.orcarouter.ai/v1';
 const DEFAULT_MAX_OUTPUT_TOKENS = 2048;
 const DEFAULT_LLM_TIMEOUT_MS = Number(process.env.LLM_REQUEST_TIMEOUT_MS) || 120000;
 
@@ -34,6 +35,12 @@ interface LiteLLMConfig {
 }
 
 interface OpenRouterConfig {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+}
+
+interface OrcaRouterConfig {
   baseUrl: string;
   apiKey: string;
   model: string;
@@ -95,6 +102,32 @@ const getOpenRouterConfig = (globalConfig: Record<string, unknown> | null = null
   ).trim();
   if (!apiKey) {
     throw new Error('OpenRouter API key is required');
+  }
+  return {
+    baseUrl,
+    apiKey,
+    model,
+  };
+};
+
+const getOrcaRouterConfig = (globalConfig: Record<string, unknown> | null = null): OrcaRouterConfig => {
+  const settings = globalConfig || {};
+  const orcaRouterSettings = (settings?.llmService as unknown as Record<string, unknown>)?.orcarouter as unknown as Record<string, unknown> || {};
+  const baseUrl = String(
+    orcaRouterSettings.baseUrl
+    || process.env.ORCAROUTER_BASE_URL
+    || DEFAULT_ORCAROUTER_BASE_URL,
+  ).trim().replace(/\/$/, '');
+  const apiKey = String(process.env.ORCAROUTER_API_KEY || '').trim();
+  const model = String(
+    orcaRouterSettings.model
+    || (settings?.llmService as unknown as Record<string, unknown>)?.model
+    || (settings?.llmService as unknown as Record<string, unknown>)?.defaultModel
+    || process.env.ORCAROUTER_MODEL
+    || DEFAULT_MODEL,
+  ).trim();
+  if (!apiKey) {
+    throw new Error('OrcaRouter API key is required');
   }
   return {
     baseUrl,
@@ -173,8 +206,20 @@ const parseOpenRouterModel = (modelName: unknown): string => {
   return normalized;
 };
 
+const parseOrcaRouterModel = (modelName: unknown): string => {
+  const normalized = String(modelName || '').trim();
+  if (!normalized) return '';
+  if (normalized.startsWith('orcarouter/')) {
+    return normalized.slice('orcarouter/'.length);
+  }
+  if (normalized.startsWith('orcarouter:')) {
+    return normalized.slice('orcarouter:'.length);
+  }
+  return normalized;
+};
+
 const stripProviderPrefix = (modelName: unknown): string => {
-  const stripped = parseOpenRouterModel(modelName);
+  const stripped = parseOrcaRouterModel(parseOpenRouterModel(modelName));
   // Also strip provider org prefixes like "anthropic/claude-3" -> not valid for Gemini
   // If it contains a slash and doesn't start with "gemini", it's not a Gemini model
   if (stripped.includes('/') && !stripped.startsWith('gemini')) {
@@ -204,6 +249,32 @@ const generateViaOpenRouter = async (
         'Content-Type': 'application/json',
         'HTTP-Referer': process.env.OPENROUTER_HTTP_REFERER || process.env.FRONTEND_URL || 'https://commonly.me',
         'X-Title': process.env.OPENROUTER_APP_TITLE || 'Commonly',
+      },
+      timeout: options.timeout || DEFAULT_LLM_TIMEOUT_MS,
+    },
+  );
+  return parseLiteLLMResponse(response.data);
+};
+
+const generateViaOrcaRouter = async (
+  prompt: string,
+  options: GenerateOptions = {},
+  globalConfig: Record<string, unknown> | null = null,
+): Promise<string> => {
+  const config = getOrcaRouterConfig(globalConfig);
+  const selectedModel = parseOrcaRouterModel(options.model || config.model);
+  const response = await axios.post(
+    `${config.baseUrl}/chat/completions`,
+    {
+      model: selectedModel,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: options.temperature ?? 0.4,
+      max_tokens: options.maxTokens || DEFAULT_MAX_OUTPUT_TOKENS,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        'Content-Type': 'application/json',
       },
       timeout: options.timeout || DEFAULT_LLM_TIMEOUT_MS,
     },
@@ -241,6 +312,26 @@ export const generateText = async (prompt: string, options: GenerateOptions = {}
       const err = error as LLMProviderError;
       console.warn(
         `[llm-service] OpenRouter failed (model=${selectedModel}): ${err.message}${err.providerCode ? ` [code=${err.providerCode}]` : ''}`,
+      );
+      if (process.env.GEMINI_API_KEY) {
+        const geminiOptions = { ...runOptions, model: stripProviderPrefix(selectedModel) };
+        console.warn(`[llm-service] Falling back to Gemini (model=${geminiOptions.model})`);
+        return generateViaGemini(prompt, geminiOptions);
+      }
+      throw error;
+    }
+  }
+
+  const shouldUseOrcaRouter = configuredProvider === 'orcarouter'
+    || String(selectedModel).startsWith('orcarouter/')
+    || String(selectedModel).startsWith('orcarouter:');
+  if (shouldUseOrcaRouter) {
+    try {
+      return await generateViaOrcaRouter(prompt, runOptions, globalModelConfig as unknown as Record<string, unknown>);
+    } catch (error) {
+      const err = error as LLMProviderError;
+      console.warn(
+        `[llm-service] OrcaRouter failed (model=${selectedModel}): ${err.message}${err.providerCode ? ` [code=${err.providerCode}]` : ''}`,
       );
       if (process.env.GEMINI_API_KEY) {
         const geminiOptions = { ...runOptions, model: stripProviderPrefix(selectedModel) };

--- a/frontend/src/components/admin/GlobalIntegrations.tsx
+++ b/frontend/src/components/admin/GlobalIntegrations.tsx
@@ -106,6 +106,10 @@ const GlobalIntegrations = () => {
         baseUrl: 'https://openrouter.ai/api/v1',
         model: '',
       },
+      orcarouter: {
+        baseUrl: 'https://api.orcarouter.ai/v1',
+        model: '',
+      },
     },
     openclaw: {
       provider: 'google',
@@ -222,6 +226,10 @@ const GlobalIntegrations = () => {
               baseUrl: nextModelPolicy?.llmService?.openrouter?.baseUrl || 'https://openrouter.ai/api/v1',
               model: nextModelPolicy?.llmService?.openrouter?.model || '',
             },
+            orcarouter: {
+              baseUrl: nextModelPolicy?.llmService?.orcarouter?.baseUrl || 'https://api.orcarouter.ai/v1',
+              model: nextModelPolicy?.llmService?.orcarouter?.model || '',
+            },
           },
           openclaw: {
             provider: nextModelPolicy?.openclaw?.provider || 'google',
@@ -263,6 +271,10 @@ const GlobalIntegrations = () => {
         openrouter: {
           baseUrl: modelPolicy?.llmService?.openrouter?.baseUrl || '',
           model: modelPolicy?.llmService?.openrouter?.model || '',
+        },
+        orcarouter: {
+          baseUrl: modelPolicy?.llmService?.orcarouter?.baseUrl || '',
+          model: modelPolicy?.llmService?.orcarouter?.model || '',
         },
       },
       openclaw: {
@@ -878,6 +890,7 @@ const GlobalIntegrations = () => {
                   <MenuItem value="anthropic">Anthropic</MenuItem>
                   <MenuItem value="litellm">LiteLLM</MenuItem>
                   <MenuItem value="openrouter">OpenRouter</MenuItem>
+                  <MenuItem value="orcarouter">OrcaRouter</MenuItem>
                 </Select>
               </FormControl>
             </Grid>
@@ -950,6 +963,47 @@ const GlobalIntegrations = () => {
                     fullWidth
                     size="small"
                     helperText="Example: openai/gpt-4.1-mini"
+                  />
+                </Grid>
+              </>
+            )}
+            {modelPolicy.llmService.provider === 'orcarouter' && (
+              <>
+                <Grid item xs={12} md={4}>
+                  <TextField
+                    label="OrcaRouter Base URL"
+                    value={modelPolicy.llmService.orcarouter.baseUrl}
+                    onChange={(event) => setModelPolicy({
+                      ...modelPolicy,
+                      llmService: {
+                        ...modelPolicy.llmService,
+                        orcarouter: {
+                          ...modelPolicy.llmService.orcarouter,
+                          baseUrl: event.target.value,
+                        },
+                      },
+                    })}
+                    fullWidth
+                    size="small"
+                  />
+                </Grid>
+                <Grid item xs={12} md={4}>
+                  <TextField
+                    label="OrcaRouter Model"
+                    value={modelPolicy.llmService.orcarouter.model}
+                    onChange={(event) => setModelPolicy({
+                      ...modelPolicy,
+                      llmService: {
+                        ...modelPolicy.llmService,
+                        orcarouter: {
+                          ...modelPolicy.llmService.orcarouter,
+                          model: event.target.value,
+                        },
+                      },
+                    })}
+                    fullWidth
+                    size="small"
+                    helperText="Example: openai/gpt-5.5"
                   />
                 </Grid>
               </>


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a named model provider for the
backend LLM service, mirroring the existing OpenRouter wiring. OrcaRouter is an
OpenAI-compatible model routing gateway exposing 190+ models from OpenAI,
Anthropic, Google, DeepSeek and others behind a single endpoint and one
`sk-orca-` key. It also runs gateway-level, zero-trust security for AI agents on
the same endpoint — screening every prompt/response and governing every tool
call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## Type

- [x] New feature
- [x] Agent integration

## Related Issues

N/A

## What this changes

- `backend/services/globalModelConfigService.ts`: adds the `orcarouter` block
  (`baseUrl` + `model`) to the `llmService` config, its sanitize/merge logic and
  the provider allowlist
- `backend/services/llmService.ts`: adds `getOrcaRouterConfig`,
  `generateViaOrcaRouter`, `parseOrcaRouterModel` and routing when the provider
  is `orcarouter` or the model carries an `orcarouter/` prefix
- `frontend/src/components/admin/GlobalIntegrations.tsx`: adds OrcaRouter to the
  Backend LLM Provider picker with Base URL + Model fields
- `.env.example`: documents `ORCAROUTER_API_KEY` / `ORCAROUTER_BASE_URL`
- `backend/__tests__/unit/services/globalModelConfigService.test.js`: covers
  OrcaRouter defaults and the apiKey drop on save

## Why a separate provider rather than the OpenAI-compatible escape hatch

This mirrors how OpenRouter is wired in this repo, so the model picker, config
reference and env docs stay consistent for users.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. Set `ORCAROUTER_API_KEY`.
3. Pick a model id such as `openai/gpt-5.5`, `anthropic/claude-sonnet-5` or
   `deepseek/deepseek-v4-flash`. The full catalog is at
   https://www.orcarouter.ai/models.

## Test Plan

- [x] Backend tests pass (`cd backend && npm test`) — `globalModelConfigService`
  unit suite and `admin.globalIntegrations` route suite green; see Notes for the
  full-suite caveat in this sandbox
- [ ] Frontend tests pass (`cd frontend && npm test`)
- [x] Linting / typecheck passes — backend `tsc --noEmit` clean, frontend
  `eslint src/.../GlobalIntegrations.tsx` clean, frontend `tsc --noEmit` clean
- [ ] Tested locally with `./dev.sh up`
- [x] Added/updated tests for new behavior

## Notes for Reviewer

Verified live through the new code path: `generateText` with an
`orcarouter/`-prefixed model returns a normal completion from
https://api.orcarouter.ai/v1/chat/completions.

In this Windows sandbox the full backend `npm test` run hangs on an unrelated
open-handle test after the changed-file suites pass; the suites covering the
changed code (`globalModelConfigService.test.js`, `admin.globalIntegrations.test.js`)
are green.
