### PR TITLE
fix(onboarding): the install intro stops promising a listener that isn't there (W4 preventive)

### DIFF
--- a/backend/__tests__/unit/routes/registry.install-intro-honesty.test.js
+++ b/backend/__tests__/unit/routes/registry.install-intro-honesty.test.js
@@ -25,7 +25,7 @@ const base = {
 
 describe('install intro — the promise matches reality', () => {
   test('a seat with nothing running it does NOT invite a mention', () => {
-    const intro = composeInstallIntro({ ...base, listening: false });
+    const intro = composeInstallIntro({ ...base, state: 'never-connected' });
 
     // The exact sentence the four casualties acted on must be absent.
     expect(intro).not.toMatch(/Mention me with @ngoc-tran-agent when you need me/);
@@ -39,10 +39,36 @@ describe('install intro — the promise matches reality', () => {
     // A running agent installed into a NEW pod is genuinely reachable. Telling
     // that room "nothing is running me" would be the opposite defect, which is
     // why the caller derives state instead of assuming a fresh seat is dead.
-    const intro = composeInstallIntro({ ...base, listening: true });
+    const intro = composeInstallIntro({ ...base, state: 'listening' });
 
     expect(intro).toMatch(/Mention me with @ngoc-tran-agent when you need me/);
     expect(intro).not.toMatch(/won't reach anyone/);
+    expect(intro).not.toMatch(/commonly agent run/);
+  });
+
+  test('gone-dark hedges instead of asserting — it is inferred, and the agent DID run', () => {
+    // ux-lead, fleet review 2026-08-14. An earlier draft took a boolean, which
+    // collapsed `never-connected` (structurally certain: no token ever used)
+    // into `gone-dark` (inferred from staleness). A gone-dark reused agent was
+    // then told "Nothing is running me yet" — flat-certain and factually
+    // wrong. Asserting an inference in the agent's own voice is the same
+    // defect this whole function exists to remove.
+    const intro = composeInstallIntro({ ...base, state: 'gone-dark' });
+
+    expect(intro).not.toMatch(/Nothing is running me yet/);
+    expect(intro).toMatch(/don't look connected|may not reach/);
+    // The instruction still has to be there — hedging the claim must not cost
+    // the reader the fix.
+    expect(intro).toMatch(/commonly agent run ngoc-tran-agent/);
+  });
+
+  test('an unknown state keeps the invitation — we only warn about what we can show', () => {
+    // Gateway/cloud classes derive to 'unknown', and so does a derivation
+    // failure. Wrongly telling a live agent's room that nothing listens is the
+    // opposite lie, so silence about liveness is the correct default.
+    const intro = composeInstallIntro({ ...base, state: 'unknown' });
+
+    expect(intro).toMatch(/Mention me with @ngoc-tran-agent when you need me/);
     expect(intro).not.toMatch(/commonly agent run/);
   });
 
@@ -50,8 +76,8 @@ describe('install intro — the promise matches reality', () => {
     // A BYO user is told their agent is named "sam-agent" while the mention
     // handle is the instanceId (GH smoke finding 2026-07-05). Both branches
     // must use the handle.
-    const live = composeInstallIntro({ ...base, handle: 'scout', listening: true });
-    const dead = composeInstallIntro({ ...base, handle: 'scout', listening: false });
+    const live = composeInstallIntro({ ...base, handle: 'scout', state: 'listening' });
+    const dead = composeInstallIntro({ ...base, handle: 'scout', state: 'never-connected' });
 
     expect(live).toMatch(/@scout/);
     expect(dead).toMatch(/@scout/);
@@ -60,15 +86,15 @@ describe('install intro — the promise matches reality', () => {
   test('a meaningful blurb survives in both branches', () => {
     const opts = { ...base, blurb: 'I review pull requests.' };
 
-    expect(composeInstallIntro({ ...opts, listening: true })).toMatch(/I review pull requests\./);
-    expect(composeInstallIntro({ ...opts, listening: false })).toMatch(/I review pull requests\./);
+    expect(composeInstallIntro({ ...opts, state: 'listening' })).toMatch(/I review pull requests\./);
+    expect(composeInstallIntro({ ...opts, state: 'never-connected' })).toMatch(/I review pull requests\./);
   });
 
   test('a blurb that just repeats the name is dropped, not echoed', () => {
     // Older CLI versions seeded description from displayName, producing
     // "Hi all — I'm bot. bot Ping me ...".
     const intro = composeInstallIntro({
-      ...base, displayName: 'bot', blurb: 'BOT', listening: true,
+      ...base, displayName: 'bot', blurb: 'BOT', state: 'listening',
     });
 
     expect(intro).toMatch(/just joined the pod/);
@@ -79,7 +105,7 @@ describe('install intro — the promise matches reality', () => {
     // Whoever reads this in a shared pod usually cannot run the command. The
     // instruction names the installer rather than commanding the room — the
     // same split agentStateService makes between state and fixCommand.
-    const intro = composeInstallIntro({ ...base, listening: false });
+    const intro = composeInstallIntro({ ...base, state: 'never-connected' });
 
     expect(intro).toMatch(/Whoever installed me/);
   });

--- a/backend/__tests__/unit/routes/registry.install-intro-honesty.test.js
+++ b/backend/__tests__/unit/routes/registry.install-intro-honesty.test.js
@@ -1,0 +1,86 @@
+/**
+ * The install intro must not promise a listener that does not exist.
+ *
+ * Posted server-side at seat creation, the old copy always said "Mention me
+ * with @handle when you need me" — for a BYO seat, before any wrapper process
+ * exists. Production message history shows exactly what that costs:
+ *
+ *   m0re        2026-08-04  "@m0re-agent 1"                        → silence
+ *   l3r0ys4n3   2026-08-07  "Hi" (right after the intro)           → silence
+ *   user-8863   2026-08-09  asked 3× whether the connection worked → silence
+ *   ngoc-tran   2026-08-10  "@ngoc-tran-agent what modal you use"  → silence
+ *
+ * None of the four returned. The promise is made in the AGENT'S OWN VOICE,
+ * which is why it matters more than the connect page's honesty copy (#887) —
+ * that fix never touched this sentence.
+ */
+
+const { composeInstallIntro } = require('../../../routes/registry/helpers');
+
+const base = {
+  displayName: 'Ngoc Tran Agent',
+  handle: 'ngoc-tran-agent',
+  fixCommand: 'commonly agent run ngoc-tran-agent',
+};
+
+describe('install intro — the promise matches reality', () => {
+  test('a seat with nothing running it does NOT invite a mention', () => {
+    const intro = composeInstallIntro({ ...base, listening: false });
+
+    // The exact sentence the four casualties acted on must be absent.
+    expect(intro).not.toMatch(/Mention me with @ngoc-tran-agent when you need me/);
+    // It must say plainly that a mention goes nowhere...
+    expect(intro).toMatch(/won't reach anyone/);
+    // ...and hand over the one command that fixes it.
+    expect(intro).toMatch(/commonly agent run ngoc-tran-agent/);
+  });
+
+  test('a live seat still invites the mention — the fix must not lie the other way', () => {
+    // A running agent installed into a NEW pod is genuinely reachable. Telling
+    // that room "nothing is running me" would be the opposite defect, which is
+    // why the caller derives state instead of assuming a fresh seat is dead.
+    const intro = composeInstallIntro({ ...base, listening: true });
+
+    expect(intro).toMatch(/Mention me with @ngoc-tran-agent when you need me/);
+    expect(intro).not.toMatch(/won't reach anyone/);
+    expect(intro).not.toMatch(/commonly agent run/);
+  });
+
+  test('the handle, not the agent name, is what gets mentioned', () => {
+    // A BYO user is told their agent is named "sam-agent" while the mention
+    // handle is the instanceId (GH smoke finding 2026-07-05). Both branches
+    // must use the handle.
+    const live = composeInstallIntro({ ...base, handle: 'scout', listening: true });
+    const dead = composeInstallIntro({ ...base, handle: 'scout', listening: false });
+
+    expect(live).toMatch(/@scout/);
+    expect(dead).toMatch(/@scout/);
+  });
+
+  test('a meaningful blurb survives in both branches', () => {
+    const opts = { ...base, blurb: 'I review pull requests.' };
+
+    expect(composeInstallIntro({ ...opts, listening: true })).toMatch(/I review pull requests\./);
+    expect(composeInstallIntro({ ...opts, listening: false })).toMatch(/I review pull requests\./);
+  });
+
+  test('a blurb that just repeats the name is dropped, not echoed', () => {
+    // Older CLI versions seeded description from displayName, producing
+    // "Hi all — I'm bot. bot Ping me ...".
+    const intro = composeInstallIntro({
+      ...base, displayName: 'bot', blurb: 'BOT', listening: true,
+    });
+
+    expect(intro).toMatch(/just joined the pod/);
+    expect(intro).not.toMatch(/bot\. BOT/i);
+  });
+
+  test('the dead-seat copy never blames the reader', () => {
+    // Whoever reads this in a shared pod usually cannot run the command. The
+    // instruction names the installer rather than commanding the room — the
+    // same split agentStateService makes between state and fixCommand.
+    const intro = composeInstallIntro({ ...base, listening: false });
+
+    expect(intro).toMatch(/Whoever installed me/);
+  });
+});

--- a/backend/routes/registry/helpers.ts
+++ b/backend/routes/registry/helpers.ts
@@ -283,12 +283,20 @@ const buildOpenClawIntegrationChannels = (integrations: any[] = []) => {
  * agentStateService is pure too.
  */
 const composeInstallIntro = ({
-  displayName, blurb, handle, listening, fixCommand,
+  displayName, blurb, handle, state, fixCommand,
 }: {
   displayName: string;
   blurb?: string;
   handle: string;
-  listening: boolean;
+  // The `deriveAgentState` enum, passed WHOLE rather than flattened to a
+  // boolean. An earlier draft took `listening: boolean`, which collapsed two
+  // different certainty classes: `never-connected` is structurally certain (no
+  // token has ever been used), while `gone-dark` is INFERRED from staleness.
+  // Under the boolean, a gone-dark agent was told "Nothing is running me yet"
+  // — flat-certain AND factually wrong, since it demonstrably ran. Asserting a
+  // guess in the agent's own voice is the very defect this function exists to
+  // remove, so the hedge is not decoration (ux-lead, fleet review 2026-08-14).
+  state: string;
   fixCommand: string;
 }): string => {
   // Older CLI versions seeded description from displayName, producing intros
@@ -300,10 +308,23 @@ const composeInstallIntro = ({
   const lead = meaningless
     ? `Hi all — I'm ${displayName}, just joined the pod.`
     : `Hi all — I'm ${displayName}. ${trimmed}`;
-  if (listening) return `${lead} Mention me with @${handle} when you need me.`;
-  return `${lead} Nothing is running me yet, so mentioning me won't reach anyone. `
-    + `Whoever installed me can start me with \`${fixCommand}\` on the machine `
-    + `where I should live — then @${handle} will get through.`;
+
+  // Certain, and never ran: flat declarative.
+  if (state === 'never-connected') {
+    return `${lead} Nothing is running me yet, so mentioning me won't reach anyone. `
+      + `Whoever installed me can start me with \`${fixCommand}\` on the machine `
+      + `where I should live — then @${handle} will get through.`;
+  }
+  // Inferred, and it DID run: hedge the claim, keep the instruction.
+  if (state === 'gone-dark') {
+    return `${lead} I don't look connected right now — I was running earlier and `
+      + `have gone quiet, so a mention may not reach me. Whoever installed me can `
+      + `start me again with \`${fixCommand}\` — then @${handle} will get through.`;
+  }
+  // reachable / listening / unknown — anything we cannot show to be down keeps
+  // the invitation. Wrongly telling a live agent's room that nothing listens is
+  // the opposite lie.
+  return `${lead} Mention me with @${handle} when you need me.`;
 };
 
 const resolveDisplayLabelFromUser = (user: any, fallback: string): string => {

--- a/backend/routes/registry/helpers.ts
+++ b/backend/routes/registry/helpers.ts
@@ -266,6 +266,46 @@ const buildOpenClawIntegrationChannels = (integrations: any[] = []) => {
 // sync via the same fallback chain: botMetadata.displayName → instanceId
 // (when not 'default') → username → fallback. Never falls back to
 // botMetadata.agentName (runtime-leaning).
+/**
+ * The install intro, composed so its promise matches reality.
+ *
+ * The old copy said "Mention me with @handle when you need me" every time,
+ * posted server-side the moment a seat is created — which for a BYO seat is
+ * before any wrapper exists to answer. Production message history shows four
+ * users taking that invitation and getting total silence: m0re (08-04),
+ * l3r0ys4n3 (08-07), user-8863 (08-09, who asked three times in two phrasings
+ * whether the connection was working), ngoc-tran (08-10). None came back.
+ *
+ * Pure on purpose: the caller derives liveness via `deriveAgentState` (the
+ * same derivation the #891 honesty surface and the pod roster use — one
+ * source of truth, not a second guess) and passes the verdict in. That keeps
+ * the copy rules testable without a DB, which is the whole reason
+ * agentStateService is pure too.
+ */
+const composeInstallIntro = ({
+  displayName, blurb, handle, listening, fixCommand,
+}: {
+  displayName: string;
+  blurb?: string;
+  handle: string;
+  listening: boolean;
+  fixCommand: string;
+}): string => {
+  // Older CLI versions seeded description from displayName, producing intros
+  // like "Hi all — I'm bot. bot Ping me ...". Drop a blurb that just repeats
+  // the name.
+  const trimmed = String(blurb || '').trim().replace(/\s+/g, ' ');
+  const meaningless = !trimmed
+    || trimmed.toLowerCase() === String(displayName).toLowerCase();
+  const lead = meaningless
+    ? `Hi all — I'm ${displayName}, just joined the pod.`
+    : `Hi all — I'm ${displayName}. ${trimmed}`;
+  if (listening) return `${lead} Mention me with @${handle} when you need me.`;
+  return `${lead} Nothing is running me yet, so mentioning me won't reach anyone. `
+    + `Whoever installed me can start me with \`${fixCommand}\` on the machine `
+    + `where I should live — then @${handle} will get through.`;
+};
+
 const resolveDisplayLabelFromUser = (user: any, fallback: string): string => {
   if (!user) return fallback;
   const meta = user.botMetadata || {};
@@ -567,6 +607,7 @@ module.exports = {
   resolveInstallation,
   buildAgentProfileId,
   resolveRuntimeInstanceId,
+  composeInstallIntro,
 };
 
 export {};

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -594,7 +594,13 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
         // Reused-agent installs are why this derives rather than assumes: an
         // already-running agent installed into a new pod IS listening, and
         // telling that room otherwise would be the opposite lie.
-        let listening = true;
+        // The state enum is passed through WHOLE. Flattening it to a boolean
+        // collapsed `never-connected` (structurally certain) into `gone-dark`
+        // (inferred from staleness), which made a gone-dark agent announce
+        // "Nothing is running me yet" — flat-certain and factually wrong,
+        // since it demonstrably ran. Asserting an inference in the agent's own
+        // voice is the same defect in a new costume (ux-lead, 2026-08-14).
+        let state = 'unknown';
         let fixCommand = `commonly agent run ${safeAgentName}`;
         try {
           const owner = await User.findById(userId)
@@ -605,11 +611,12 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
             owner?.agentRuntimeTokens || [],
             String(userId),
           );
-          listening = derived.state !== 'never-connected' && derived.state !== 'gone-dark';
+          state = derived.state;
           if (derived.fixCommand) fixCommand = derived.fixCommand;
         } catch (stateErr: unknown) {
-          // Fail toward the old copy: wrongly telling a LIVE agent's room that
-          // nothing is listening is a worse lie than the one being fixed.
+          // Fail toward the invitation: wrongly telling a LIVE agent's room
+          // that nothing is listening is a worse lie than the one being fixed.
+          // 'unknown' is exactly that branch, and it is an honest label here.
           console.warn('[install] intro liveness derivation failed', {
             agent: agent.agentName,
             instance: normalizedInstanceId,
@@ -620,7 +627,7 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
           displayName,
           blurb: isMeaninglessBlurb ? '' : blurb,
           handle,
-          listening,
+          state,
           fixCommand,
         });
         await AgentMessageService.postMessage({

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -11,6 +11,7 @@ const Pod = require('../../models/Pod');
 const User = require('../../models/User');
 const AgentIdentityService = require('../../services/agentIdentityService');
 const AgentMessageService = require('../../services/agentMessageService');
+const { deriveAgentState } = require('../../services/agentStateService');
 const FirstContactService = require('../../services/firstContactService');
 const { normalizeAvatarUrl } = require('../../services/avatarService');
 const {
@@ -22,6 +23,7 @@ const {
   sanitizeRuntimeConfig,
   resolveGatewayForRequest,
   buildAgentProfileId,
+  composeInstallIntro,
 } = require('./helpers');
 const {
   AUTO_GRANTED_INTEGRATION_SCOPES,
@@ -575,9 +577,52 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
         const handle = normalizedInstanceId && normalizedInstanceId !== 'default'
           ? normalizedInstanceId
           : safeAgentName;
-        const intro = isMeaninglessBlurb
-          ? `Hi all — I'm ${displayName}, just joined the pod. Mention me with @${handle}.`
-          : `Hi all — I'm ${displayName}. ${blurb} Mention me with @${handle} when you need me.`;
+        // Honesty gate (2026-08-14). This intro used to promise "Mention me
+        // with @handle when you need me" UNCONDITIONALLY — posted server-side
+        // the moment the seat is created, which for a BYO seat is before any
+        // wrapper process exists to answer.
+        //
+        // Measured cost, from production message history: four users mentioned
+        // a seat with nobody home and got total silence — m0re (08-04),
+        // l3r0ys4n3 (08-07), user-8863 (08-09, who asked three times in two
+        // phrasings whether the connection was working), ngoc-tran (08-10).
+        // None returned. The promise is made in the AGENT'S OWN VOICE, which
+        // is the most authoritative surface we have, so it has to be
+        // conditional on the same derivation the #891 honesty surface and the
+        // pod roster already use — not a second, divergent guess.
+        //
+        // Reused-agent installs are why this derives rather than assumes: an
+        // already-running agent installed into a new pod IS listening, and
+        // telling that room otherwise would be the opposite lie.
+        let listening = true;
+        let fixCommand = `commonly agent run ${safeAgentName}`;
+        try {
+          const owner = await User.findById(userId)
+            .select('agentRuntimeTokens').lean() as
+              { agentRuntimeTokens?: { lastUsedAt?: Date | string | null }[] } | null;
+          const derived = deriveAgentState(
+            installation,
+            owner?.agentRuntimeTokens || [],
+            String(userId),
+          );
+          listening = derived.state !== 'never-connected' && derived.state !== 'gone-dark';
+          if (derived.fixCommand) fixCommand = derived.fixCommand;
+        } catch (stateErr: unknown) {
+          // Fail toward the old copy: wrongly telling a LIVE agent's room that
+          // nothing is listening is a worse lie than the one being fixed.
+          console.warn('[install] intro liveness derivation failed', {
+            agent: agent.agentName,
+            instance: normalizedInstanceId,
+            error: (stateErr as Error).message,
+          });
+        }
+        const intro = composeInstallIntro({
+          displayName,
+          blurb: isMeaninglessBlurb ? '' : blurb,
+          handle,
+          listening,
+          fixCommand,
+        });
         await AgentMessageService.postMessage({
           agentName: agent.agentName,
           instanceId: normalizedInstanceId,

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -600,15 +600,28 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
         // "Nothing is running me yet" — flat-certain and factually wrong,
         // since it demonstrably ran. Asserting an inference in the agent's own
         // voice is the same defect in a new costume (ux-lead, 2026-08-14).
+        //
+        // The token store is the BOT's, not the installer's (sprint-impl,
+        // fleet review 2026-08-14). `deriveAgentState` unions
+        // `installation.runtimeTokens` with a USER's `agentRuntimeTokens`, and
+        // the user it means is the agent's bot row — that is where a polling
+        // wrapper stamps `lastUsedAt`. An earlier draft passed the human
+        // installer's tokens, a store a wrapper never writes, so a reused and
+        // demonstrably live seat computed as never-connected and would have
+        // been announced as dead. Same identity match the pod roster uses
+        // (routes/pods.ts:437).
         let state = 'unknown';
         let fixCommand = `commonly agent run ${safeAgentName}`;
         try {
-          const owner = await User.findById(userId)
-            .select('agentRuntimeTokens').lean() as
+          const botRow = await User.findOne({
+            isBot: true,
+            'botMetadata.agentName': agent.agentName,
+            'botMetadata.instanceId': normalizedInstanceId,
+          }).select('agentRuntimeTokens.lastUsedAt').lean() as
               { agentRuntimeTokens?: { lastUsedAt?: Date | string | null }[] } | null;
           const derived = deriveAgentState(
             installation,
-            owner?.agentRuntimeTokens || [],
+            botRow?.agentRuntimeTokens || [],
             String(userId),
           );
           state = derived.state;


### PR DESCRIPTION
**W4's preventive half.** The plan has the *reactive* trigger (respond after a mention stalls); nothing stopped us making the false promise in the first place.

## The measured failure

The intro is posted **server-side at seat creation** and always said *"Mention me with @handle when you need me."* For a BYO seat that is before any wrapper exists. Four users took the invitation and got total silence:

| user | date | what they said | reply |
|---|---|---|---|
| m0re | 08-04 | `@m0re-agent 1` — testing if anything was alive | none |
| l3r0ys4n3 | 08-07 | `Hi`, right after the intro | none |
| user-8863 | 08-09 | asked **three times**, in two phrasings, whether the connection was working | none |
| ngoc-tran | 08-10 | `@ngoc-tran-agent what modal you use` | none |

None returned. Across **21 real signups since 08-01**: 21 verified, 21 got a workspace, **5 ever typed anything**, and 4 of those 5 are the rows above. **Reply rate on genuine user mentions: zero.**

This also corrects our own record. The consolidation plan's "Current truth" says *"nobody's first mention has ever failed — users historically never got far enough."* All four failures predate the plan.

## The fix

Liveness now comes from `deriveAgentState` — the same derivation the #891 honesty surface and the pod roster use, so there's one source of truth instead of a second guess:

- **not listening** → *"Nothing is running me yet, so mentioning me won't reach anyone. Whoever installed me can start me with `commonly agent run <name>` on the machine where I should live — then @handle will get through."*
- **listening** → unchanged.

**Why derive instead of assume a fresh seat is dead:** an already-running agent installed into a *new* pod genuinely is reachable, and telling that room otherwise would be the opposite lie. Derivation failure falls back to the old copy for the same reason.

The copy instruction names **the installer**, not the reader — most people seeing it in a shared pod can't run the command. Same split `agentStateService` already makes between `state` (everyone) and `fixCommand` (owner only).

## Structure

Composition moved to `composeInstallIntro` in `registry/helpers`, kept pure, so the copy rules are testable without a DB — the same reason `agentStateService` is pure. Six tests, including the inverse case (a live seat must still invite the mention).

## Note on local test runs

`registry.install-runtime-type.test.js` fails to even load on my machine — `jsonwebtoken` → `buffer-equal-constant-time` reads `SlowBuffer`, removed in **Node 26**. It breaks on `install.ts:5`, untouched here, and hits any backend test importing `middleware/auth`. Environmental; CI is the control. Worth knowing now that the backend has moved to Node 22 LTS.

## Not included

The reactive responder (answer a mention that lands on a dead seat) — W4 item 3. That's the recovery path for seats installed *before* this fix, and it's the natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8
