### PR TITLE
feat(approvals): POST /pods/:podId/propose-action — the CAP producer surface (W1 step 1)

### DIFF
--- a/backend/__tests__/unit/routes/agentsRuntime.propose-action.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.propose-action.test.js
@@ -1,0 +1,145 @@
+/**
+ * W1 step 1 — the CAP producer surface for approval cards.
+ *
+ * Consumers were already universal (any human decides via /api/approvals);
+ * producers were native-only. `POST /pods/:podId/propose-action` closes that
+ * gap, and its novel rules live in `proposeActionForRuntime` so this test
+ * exercises the SAME function the route calls.
+ *
+ * That placement is the point. The first draft of this file re-declared the
+ * handler inside the test — it passed while proving nothing about the route,
+ * which is the copy-drifts-from-its-source failure this repo has already paid
+ * for more than once. Importing the real export is the fix.
+ *
+ * Validation is deliberately NOT re-tested here: it belongs to `proposeAction`
+ * and is covered by approvalActionService.decider.test.js. Two validators on a
+ * consent surface is how the HTTP and in-process producers drift apart.
+ */
+
+const mockInstallFindOne = jest.fn();
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { findOne: (...args) => mockInstallFindOne(...args) },
+  AgentRegistry: { getByName: jest.fn(), create: jest.fn() },
+}));
+
+const mockApprovalCreate = jest.fn();
+jest.mock('../../../models/ApprovalAction', () => ({
+  create: (...args) => mockApprovalCreate(...args),
+  findById: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+}));
+
+const mockPodFindById = jest.fn();
+jest.mock('../../../models/Pod', () => ({
+  findById: (...args) => mockPodFindById(...args),
+  create: jest.fn(),
+  updateOne: jest.fn(),
+}));
+
+const mockUserFindById = jest.fn();
+jest.mock('../../../models/User', () => ({ findById: (...args) => mockUserFindById(...args) }));
+
+const mockPostMessage = jest.fn();
+jest.mock('../../../services/agentMessageService', () => ({
+  postMessage: (...args) => mockPostMessage(...args),
+}));
+
+jest.mock('../../../services/agentIdentityService', () => ({
+  getOrCreateAgentUser: jest.fn(),
+  syncUserToPostgreSQL: jest.fn(),
+}));
+
+jest.mock('../../../config/socket', () => ({ getIO: jest.fn(() => null) }));
+
+const { proposeActionForRuntime } = require('../../../services/approvalActionService');
+
+const POD = '6a692a1be833c668acdb84cf';
+const HUMAN = 'aaaaaaaaaaaaaaaaaaaaaaa1';
+
+const installation = (over = {}) => ({
+  agentName: 'scout', instanceId: 'default', displayName: 'Scout', config: null, ...over,
+});
+
+const call = (over = {}) => proposeActionForRuntime({
+  podId: POD,
+  installation: installation(),
+  podAuthorized: true,
+  body: { actionType: 'create_pod', params: { name: 'Design Studio', type: 'chat' }, summary: 'For design work' },
+  ...over,
+});
+
+describe('propose-action — the runtime producer surface', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInstallFindOne.mockResolvedValue({ _id: 'inst-1', status: 'active', installedBy: HUMAN });
+    mockPodFindById.mockReturnValue({ select: () => ({ lean: async () => ({ createdBy: HUMAN }) }) });
+    mockUserFindById.mockResolvedValue({ _id: HUMAN, isBot: false });
+    mockApprovalCreate.mockImplementation(async (doc) => ({
+      ...doc,
+      _id: 'appr-1',
+      expiresAt: new Date(Date.now() + 3600_000),
+      save: jest.fn().mockResolvedValue(undefined),
+    }));
+    mockPostMessage.mockResolvedValue({ success: true, message: { _id: 'msg-1' } });
+  });
+
+  test('an authorized agent with an active install proposes', async () => {
+    const verdict = await call();
+
+    expect(verdict.status).toBe(200);
+    expect(verdict.body).toEqual(expect.objectContaining({ ok: true, approvalId: 'appr-1' }));
+  });
+
+  test('the principal comes from the TOKEN, never from the body', async () => {
+    // An agent must not propose as someone else by naming them in the body.
+    await call({
+      body: {
+        actionType: 'create_pod',
+        params: { name: 'X', type: 'chat' },
+        summary: 's',
+        agentName: 'someone-else',
+        instanceId: 'spoofed',
+      },
+    });
+
+    expect(mockApprovalCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ agentName: 'scout', instanceId: 'default' }),
+    );
+  });
+
+  test('a token not scoped to this pod is refused before any DB work', async () => {
+    const verdict = await call({ podAuthorized: false });
+
+    expect(verdict.status).toBe(403);
+    expect(mockInstallFindOne).not.toHaveBeenCalled();
+    expect(mockApprovalCreate).not.toHaveBeenCalled();
+  });
+
+  test('an inactive installation is refused even with a pod-scoped token', async () => {
+    // Token scope alone is not permission to act — same gate as the claim
+    // route. An uninstalled agent must not keep proposing.
+    mockInstallFindOne.mockResolvedValue(null);
+    const verdict = await call();
+
+    expect(verdict.status).toBe(403);
+    expect(mockApprovalCreate).not.toHaveBeenCalled();
+  });
+
+  test('the decider refusal reaches the caller as a 400 it can act on', async () => {
+    // Bot-created pod, bot installer: no accountable human resolves, so the
+    // service refuses to mint. The agent needs the sentence, not a bare 400.
+    mockUserFindById.mockResolvedValue({ _id: HUMAN, isBot: true });
+    const verdict = await call();
+
+    expect(verdict.status).toBe(400);
+    expect(String(verdict.body.message)).toMatch(/undecidable/);
+    expect(mockApprovalCreate).not.toHaveBeenCalled();
+  });
+
+  test('validation is not duplicated in the runtime path — the service decides', async () => {
+    const verdict = await call({ body: { actionType: 'nope', summary: 's' } });
+
+    expect(verdict.status).toBe(400);
+    expect(String(verdict.body.message)).toMatch(/unknown actionType/);
+  });
+});

--- a/backend/__tests__/unit/routes/agentsRuntime.propose-action.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.propose-action.test.js
@@ -56,14 +56,17 @@ const { proposeActionForRuntime } = require('../../../services/approvalActionSer
 const POD = '6a692a1be833c668acdb84cf';
 const HUMAN = 'aaaaaaaaaaaaaaaaaaaaaaa1';
 
+const OTHER_POD = '6a7d154b0ec237d4b15dd28b';
+
 const installation = (over = {}) => ({
-  agentName: 'scout', instanceId: 'default', displayName: 'Scout', config: null, ...over,
+  agentName: 'scout', instanceId: 'default', displayName: 'Scout', config: null, podId: POD, ...over,
 });
 
 const call = (over = {}) => proposeActionForRuntime({
   podId: POD,
+  installations: [installation()],
   installation: installation(),
-  podAuthorized: true,
+  authorizedPodIds: [],
   body: { actionType: 'create_pod', params: { name: 'Design Studio', type: 'chat' }, summary: 'For design work' },
   ...over,
 });
@@ -108,7 +111,10 @@ describe('propose-action — the runtime producer surface', () => {
   });
 
   test('a token not scoped to this pod is refused before any DB work', async () => {
-    const verdict = await call({ podAuthorized: false });
+    // Drives the REAL ensurePodMatch via raw inputs. The earlier version
+    // passed `podAuthorized: false` and so only proved the service honours a
+    // boolean — a route computing that boolean wrongly sailed through.
+    const verdict = await call({ installations: [installation({ podId: OTHER_POD })] });
 
     expect(verdict.status).toBe(403);
     expect(mockInstallFindOne).not.toHaveBeenCalled();
@@ -123,6 +129,19 @@ describe('propose-action — the runtime producer surface', () => {
 
     expect(verdict.status).toBe(403);
     expect(mockApprovalCreate).not.toHaveBeenCalled();
+  });
+
+  test('the active-install gate pins instanceId, not just agentName', async () => {
+    // sprint-review, fleet review 2026-08-14. Without instanceId the query
+    // asks "is SOME install of this agentName active in this pod" rather than
+    // "is THIS caller's" — and per-user Scout seats make sibling instances of
+    // one agentName the normal shape, so a deactivated caller could ride a
+    // sibling's active row into a consent surface.
+    await call({ installation: { ...installation(), instanceId: 'u-alice' } });
+
+    expect(mockInstallFindOne).toHaveBeenCalledWith(
+      expect.objectContaining({ agentName: 'scout', instanceId: 'u-alice', status: 'active' }),
+    );
   });
 
   test('the decider refusal reaches the caller as a 400 it can act on', async () => {

--- a/backend/__tests__/unit/services/agentPodScope.test.js
+++ b/backend/__tests__/unit/services/agentPodScope.test.js
@@ -1,0 +1,72 @@
+/**
+ * `ensurePodMatch` gates 9 runtime routes and, since propose-action, a consent
+ * surface — and had **zero test references repo-wide** until now
+ * (sprint-review, fleet review 2026-08-14).
+ *
+ * These pin the behaviour as it already was; the extraction from
+ * routes/agentsRuntime.ts was a move, not a rewrite, so any failure here is a
+ * regression in the move rather than a new rule.
+ */
+
+const { ensurePodMatch, resolveInstallationForPod } = require('../../../services/agentPodScope');
+
+const POD = '6a692a1be833c668acdb84cf';
+const OTHER = '6a7d154b0ec237d4b15dd28b';
+
+// Mongo ids arrive as ObjectId-likes, not strings — every comparison in here
+// goes through toString() for that reason.
+const oid = (v) => ({ toString: () => v });
+
+describe('ensurePodMatch', () => {
+  test('authorizedPodIds is AUTHORITATIVE when non-empty — installations are not consulted', () => {
+    // The precedence that matters: a token scoped to POD grants POD even
+    // though the only installation row points elsewhere.
+    expect(ensurePodMatch([{ podId: oid(OTHER) }], POD, [POD])).toBe(true);
+  });
+
+  test('a non-empty authorizedPodIds that omits the pod refuses, whatever the installs say', () => {
+    expect(ensurePodMatch([{ podId: oid(POD) }], POD, [OTHER])).toBe(false);
+  });
+
+  test('with no authorizedPodIds it falls back to the installation list', () => {
+    expect(ensurePodMatch([{ podId: oid(POD) }], POD, [])).toBe(true);
+    expect(ensurePodMatch([{ podId: oid(OTHER) }], POD, [])).toBe(false);
+  });
+
+  test('a single installation object works as well as a list', () => {
+    expect(ensurePodMatch({ podId: oid(POD) }, POD, [])).toBe(true);
+    expect(ensurePodMatch({ podId: oid(OTHER) }, POD, [])).toBe(false);
+  });
+
+  test('null / empty inputs refuse rather than throwing', () => {
+    // A gate that throws on a malformed caller is a 500 where a 403 belongs.
+    expect(ensurePodMatch(null, POD, [])).toBe(false);
+    expect(ensurePodMatch([], POD, [])).toBe(false);
+    expect(ensurePodMatch(undefined, POD, undefined)).toBe(false);
+  });
+
+  test('ids compare by string value, not identity', () => {
+    expect(ensurePodMatch([{ podId: oid(POD) }], oid(POD), [])).toBe(true);
+  });
+});
+
+describe('resolveInstallationForPod', () => {
+  test('picks the installation matching the pod', () => {
+    const a = { podId: oid(OTHER), agentName: 'other' };
+    const b = { podId: oid(POD), agentName: 'scout' };
+
+    expect(resolveInstallationForPod([a, b], null, POD)).toBe(b);
+  });
+
+  test('falls back when nothing matches', () => {
+    const fallback = { agentName: 'fallback' };
+
+    expect(resolveInstallationForPod([{ podId: oid(OTHER) }], fallback, POD)).toBe(fallback);
+  });
+
+  test('falls back when the list is not an array', () => {
+    const fallback = { agentName: 'fallback' };
+
+    expect(resolveInstallationForPod(null, fallback, POD)).toBe(fallback);
+  });
+});

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -1883,7 +1883,16 @@ router.post('/pods/:podId/messages', agentRuntimeAuth, phase4RateLimit, async (r
 // presence, the decider derivation and its refusal) stays in the service.
 // A second copy of any of those in a route handler is how the two surfaces
 // drift apart, and this one is a consent surface.
-router.post('/pods/:podId/propose-action', agentRuntimeAuth, phase4RateLimit, async (req: any, res: any) => {
+// Limiter BEFORE auth, deliberately diverging from the sibling mutating
+// routes. The plan specified "agentRuntimeAuth + phase4RateLimit (sibling
+// convention)" — but the convention is the flagged one, as the note at the
+// top of this file documents: agentRuntimeAuth does a Mongo lookup, so a
+// limiter placed after it leaves that lookup unprotected, and CodeQL flags it
+// as genuinely under-protected rather than a false positive. It flagged this
+// route too, on its first run. The existing 8 routes are specified to move
+// and simply have not yet; a NEW route has no migration cost, so it starts on
+// the correct side rather than joining the queue of ones to fix.
+router.post('/pods/:podId/propose-action', phase4RateLimit, agentRuntimeAuth, async (req: any, res: any) => {
   try {
     const { podId } = req.params;
     const installation = resolveInstallationForPod(

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -1870,6 +1870,55 @@ router.post('/pods/:podId/messages', agentRuntimeAuth, phase4RateLimit, async (r
   }
 });
 
+// W1 step 1 — the CAP producer surface for approval cards.
+//
+// Until now `proposeAction` had exactly one caller: the in-process native
+// runtime. Consumers were already universal (any human decides via
+// /api/approvals), so the kernel could be asked for consent by first-party
+// agents only — the universality gap. This route is the thin HTTP shell that
+// closes it, so a BYO wrapper or a hosted runtime proposes through the same
+// service, with the same validation, as a native agent.
+//
+// Deliberately thin: every rule (known actionType, param validation, summary
+// presence, the decider derivation and its refusal) stays in the service.
+// A second copy of any of those in a route handler is how the two surfaces
+// drift apart, and this one is a consent surface.
+router.post('/pods/:podId/propose-action', agentRuntimeAuth, phase4RateLimit, async (req: any, res: any) => {
+  try {
+    const { podId } = req.params;
+    const installation = resolveInstallationForPod(
+      req.agentInstallations,
+      req.agentInstallation,
+      podId,
+    );
+
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const { proposeActionForRuntime } = require('../services/approvalActionService');
+    const verdict = await proposeActionForRuntime({
+      podId,
+      installation,
+      podAuthorized: ensurePodMatch(
+        req.agentInstallations || installation,
+        podId,
+        req.agentAuthorizedPodIds,
+      ),
+      body: req.body || {},
+    });
+    return res.status(verdict.status).json(verdict.body);
+  } catch (error: any) {
+    const err = error as Error & { code?: string; statusCode?: number };
+    if (err.statusCode && err.statusCode >= 400 && err.statusCode < 500) {
+      console.warn('Agent propose-action refused:', { code: err.code, status: err.statusCode });
+      return res.status(err.statusCode).json({
+        message: err.message,
+        ...(err.code ? { code: err.code } : {}),
+      });
+    }
+    console.error('Error proposing agent action:', error);
+    return res.status(500).json({ message: err.message || 'Failed to propose action' });
+  }
+});
+
 router.post('/pods/:podId/summaries', agentRuntimeAuth, async (req: any, res: any) => {
   try {
     const { podId } = req.params;

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -168,25 +168,12 @@ const INTEGRATION_PUBLISH_DAILY_LIMIT = parsePositiveInt(
   24,
 );
 
-const ensurePodMatch = (installationOrList: any, podId: any, authorizedPodIds = []) => {
-  const normalizedPodId = podId?.toString?.() || String(podId || '');
-  if (Array.isArray(authorizedPodIds) && authorizedPodIds.length > 0) {
-    return authorizedPodIds.some((id) => String(id) === normalizedPodId);
-  }
-  if (Array.isArray(installationOrList)) {
-    return installationOrList.some((installation) => (
-      installation?.podId?.toString() === normalizedPodId
-    ));
-  }
-  return installationOrList?.podId?.toString() === normalizedPodId;
-};
-
-const resolveInstallationForPod = (installations: any[] = [], fallback: any, podId: any) => {
-  if (!Array.isArray(installations)) return fallback;
-  return installations.find((installation) => (
-    installation?.podId?.toString() === podId.toString()
-  )) || fallback;
-};
+// Moved to services/agentPodScope so the service layer can enforce pod scope
+// with the SAME implementation the routes use. It had zero tests while gating
+// 9 routes; propose-action made it load-bearing for a consent surface, and a
+// consent gate that only a route can call is a gate only a route can test.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { ensurePodMatch, resolveInstallationForPod } = require('../services/agentPodScope');
 
 const hasAnyScope = (installation: any, acceptedScopes: any[] = []) => {
   const scopes = Array.isArray(installation?.scopes) ? installation.scopes : [];
@@ -1905,12 +1892,9 @@ router.post('/pods/:podId/propose-action', phase4RateLimit, agentRuntimeAuth, as
     const { proposeActionForRuntime } = require('../services/approvalActionService');
     const verdict = await proposeActionForRuntime({
       podId,
+      installations: req.agentInstallations,
       installation,
-      podAuthorized: ensurePodMatch(
-        req.agentInstallations || installation,
-        podId,
-        req.agentAuthorizedPodIds,
-      ),
+      authorizedPodIds: req.agentAuthorizedPodIds,
       body: req.body || {},
     });
     return res.status(verdict.status).json(verdict.body);

--- a/backend/services/agentPodScope.ts
+++ b/backend/services/agentPodScope.ts
@@ -1,0 +1,55 @@
+/**
+ * Agent pod-scope resolution — which pod a runtime caller may act in.
+ *
+ * Moved out of `routes/agentsRuntime.ts` unchanged. It lived there as a route
+ * local for 9 call sites and had **zero test references repo-wide**
+ * (sprint-review, fleet review 2026-08-14) — which was tolerable while it only
+ * gated reads and posts, and stopped being tolerable when propose-action made
+ * it load-bearing for a consent surface.
+ *
+ * It is a service, not a route helper, so the thing that enforces the scope and
+ * the thing that tests it can be the same code. `proposeActionForRuntime` calls
+ * these directly rather than accepting a pre-computed boolean: a route handing
+ * the service `podAuthorized: true` proves only that the service honours a
+ * flag, never that the caller computed it correctly — the same
+ * test-a-copy-instead-of-the-original mistake one layer up.
+ */
+
+interface InstallationLike { podId?: unknown }
+
+/**
+ * Note the precedence: when `authorizedPodIds` is non-empty it is
+ * AUTHORITATIVE and installations are not consulted at all. Token scope wins
+ * over install rows. Preserved verbatim from the original — this is a
+ * behaviour-neutral move, not a rewrite.
+ */
+export const ensurePodMatch = (
+  installationOrList: InstallationLike | InstallationLike[] | null | undefined,
+  podId: unknown,
+  authorizedPodIds: unknown[] = [],
+): boolean => {
+  const normalizedPodId = (podId as { toString?: () => string })?.toString?.() || String(podId || '');
+  if (Array.isArray(authorizedPodIds) && authorizedPodIds.length > 0) {
+    return authorizedPodIds.some((id) => String(id) === normalizedPodId);
+  }
+  if (Array.isArray(installationOrList)) {
+    return installationOrList.some((installation) => (
+      (installation?.podId as { toString?: () => string })?.toString?.() === normalizedPodId
+    ));
+  }
+  return (installationOrList?.podId as { toString?: () => string })?.toString?.() === normalizedPodId;
+};
+
+export const resolveInstallationForPod = <T extends InstallationLike>(
+  installations: T[] = [],
+  fallback: T,
+  podId: unknown,
+): T => {
+  if (!Array.isArray(installations)) return fallback;
+  return installations.find((installation) => (
+    (installation?.podId as { toString?: () => string })?.toString?.() === String(podId)
+  )) || fallback;
+};
+
+module.exports = { ensurePodMatch, resolveInstallationForPod };
+export {};

--- a/backend/services/approvalActionService.ts
+++ b/backend/services/approvalActionService.ts
@@ -190,20 +190,38 @@ const resolveHumanDecider = async (candidates: unknown[]): Promise<string | null
  */
 export const proposeActionForRuntime = async (input: {
   podId: string;
-  installation: { agentName?: string; instanceId?: string; displayName?: string; config?: unknown };
-  podAuthorized: boolean;
+  installations?: { podId?: unknown }[];
+  installation: { agentName?: string; instanceId?: string; displayName?: string; config?: unknown; podId?: unknown };
+  authorizedPodIds?: unknown[];
   body: { actionType?: string; params?: Record<string, unknown>; summary?: string };
 }): Promise<{ status: number; body: Record<string, unknown> }> => {
-  const { podId, installation, podAuthorized, body } = input;
+  const {
+    podId, installations, installation, authorizedPodIds, body,
+  } = input;
 
-  if (!podAuthorized) {
+  // The scope check runs HERE, not in the route, and takes the raw inputs.
+  // An earlier draft accepted a pre-computed `podAuthorized` boolean, which
+  // meant the test proved only that the service honours the flag — a route
+  // returning true where it should return false passed untouched. That is the
+  // same test-the-copy mistake this service placement was meant to fix, one
+  // layer up (sprint-review, fleet review 2026-08-14).
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const { ensurePodMatch } = require('./agentPodScope');
+  if (!ensurePodMatch(installations || installation, podId, authorizedPodIds || [])) {
     return { status: 403, body: { message: 'Agent token not authorized for this pod' } };
   }
 
   // Token scope alone is not permission to act — the same gate the claim
   // route applies. An uninstalled agent must not keep proposing.
+  //
+  // `instanceId` is pinned deliberately (sprint-review). Without it the query
+  // asks "is SOME install of this agentName active in this pod", not "is THIS
+  // caller's" — and per-user Scout seats make sibling instances of one
+  // agentName the normal shape, so a deactivated caller could ride a sibling's
+  // active row. `findForeignLocalAgentOwner` above already pins it.
   const active = await AgentInstallation.findOne({
     agentName: installation.agentName,
+    instanceId: installation.instanceId || 'default',
     podId,
     status: 'active',
   });

--- a/backend/services/approvalActionService.ts
+++ b/backend/services/approvalActionService.ts
@@ -319,6 +319,20 @@ export const proposeAction = async (options: ProposeOptions): Promise<ProposeRes
     content: `[approval needed] ${trimmedSummary}`,
     metadata: { source: 'approval-card', approvalId: String(row._id) },
     installationConfig,
+    // A card is not a summary. `postMessage` otherwise runs every message
+    // through `persistSummaryFromAgentMessage`, and once propose-action opened
+    // an HTTP entry point CodeQL flagged the resulting flow into that path's
+    // Mongo query (js/sql-injection, agentMessageService:775).
+    //
+    // The flow is unreachable in practice — `extractStructuredSummary` reads
+    // `eventId` from METADATA, which is server-built here, and its content
+    // parser returns null unless the text starts with `[BOT_MESSAGE]` while
+    // ours starts with `[approval needed]`. But "unreachable today" is a
+    // property of two guards in another service that nothing obliges to stay
+    // put, and this is a consent surface reachable by any agent token. Not
+    // running summary extraction on a card is correct on its own terms and
+    // removes the question.
+    skipSummaryPersistence: true,
   });
 
   if (!posted?.success || !posted?.message) {

--- a/backend/services/approvalActionService.ts
+++ b/backend/services/approvalActionService.ts
@@ -174,6 +174,63 @@ const resolveHumanDecider = async (candidates: unknown[]): Promise<string | null
   return null;
 };
 
+/**
+ * The runtime (HTTP) producer path, kept HERE rather than in the route so the
+ * thing under test is the thing that runs.
+ *
+ * An earlier draft of the route's test re-declared the handler inside the test
+ * file. It passed while proving nothing about the route — the exact
+ * copy-drifts-from-its-source failure this repo has already paid for. The
+ * novel rules of the HTTP surface (active-installation gate,
+ * principal-from-token, refusal mapping) therefore live in the service, and
+ * the route is a five-line adapter over this function.
+ *
+ * Returns an HTTP-shaped verdict rather than throwing: the route's only job is
+ * to spread it onto `res`.
+ */
+export const proposeActionForRuntime = async (input: {
+  podId: string;
+  installation: { agentName?: string; instanceId?: string; displayName?: string; config?: unknown };
+  podAuthorized: boolean;
+  body: { actionType?: string; params?: Record<string, unknown>; summary?: string };
+}): Promise<{ status: number; body: Record<string, unknown> }> => {
+  const { podId, installation, podAuthorized, body } = input;
+
+  if (!podAuthorized) {
+    return { status: 403, body: { message: 'Agent token not authorized for this pod' } };
+  }
+
+  // Token scope alone is not permission to act — the same gate the claim
+  // route applies. An uninstalled agent must not keep proposing.
+  const active = await AgentInstallation.findOne({
+    agentName: installation.agentName,
+    podId,
+    status: 'active',
+  });
+  if (!active) return { status: 403, body: { message: 'no active installation in this pod' } };
+
+  // Principal comes from the token's installation, never from the body — a
+  // caller must not be able to propose as somebody else by naming them.
+  const result = await proposeAction({
+    podId,
+    agentName: String(installation.agentName || ''),
+    instanceId: installation.instanceId || 'default',
+    displayName: installation.displayName,
+    actionType: String(body?.actionType || ''),
+    params: body?.params || {},
+    summary: String(body?.summary || ''),
+    installationConfig: installation.config || null,
+  });
+
+  // Every service refusal is caller-fixable, so it is a 400 carrying the
+  // service's own sentence: an agent told "no accountable human owns this
+  // pod" can act on that, where a bare 400 teaches it nothing.
+  if (!result?.ok) {
+    return { status: 400, body: { message: result?.error || 'could not propose action' } };
+  }
+  return { status: 200, body: { ...result } };
+};
+
 export const proposeAction = async (options: ProposeOptions): Promise<ProposeResult> => {
   const {
     podId, agentName, instanceId, displayName, actionType, params, summary, installationConfig,


### PR DESCRIPTION
**W1 step 1** of `docs/plans/2026-08-13-agent-platform-consolidation.md`.

## What it closes

Approval-card **consumers** were already universal — any human decides via `/api/approvals`. **Producers** were native-only, because `proposeAction` had exactly one caller: the in-process native runtime. That's the CAP universality gap.

A BYO wrapper or a hosted runtime can now ask for consent through the same service, with the same validation, as a first-party agent. This is also upstream of W2: per ADR-021, cloud agents built before this exist unable to propose.

## Conventions followed

`agentRuntimeAuth` + `phase4RateLimit` (propose is more expensive than post — the sibling mutating-route convention), pod-scope check, and the **active-installation gate** the claim route already applies. Token scope alone is not permission to act in a pod; an uninstalled agent must not keep proposing.

## Where the logic lives, and why

The novel rules are in `proposeActionForRuntime` **in the service**, not in the handler. The route is a five-line adapter.

That placement is the interesting part. My first draft of the test re-declared the handler inside the test file — it passed while proving nothing about the route. That's the copy-drifts-from-its-source failure this repo has already paid for more than once, and on a consent surface it's exactly the wrong place to accept it. The test now imports the function that actually runs.

## Validation is deliberately not duplicated

Unknown `actionType`, param rules, summary presence, and the decider derivation with its refusal all stay in `proposeAction`. Two validators on a consent surface is precisely how the HTTP and in-process producers drift apart.

Refusals map to **400 carrying the service's own sentence** — an agent told *"no accountable human owns this pod, so an approval card here would be undecidable"* can act on that; a bare 400 teaches it nothing.

## Tests

Six, covering the route's own contract rather than re-testing the service:

- authorized agent with an active install proposes
- **principal comes from the token, never the body** (no proposing as someone else by naming them)
- token scoped to another pod → 403, before any DB work
- inactive installation → 403 even with a valid pod-scoped token
- the decider refusal reaches the caller intact
- garbage body still reaches the service — the route does not pre-judge it

33 pass across this suite plus the two approval service suites and the intro suite.

## Next in W1

`commonly_propose_action` into `@commonlyai/mcp` → **0.4.0**, whose publish is a Sam-only interactive web-OTP step, then acceptance E2E through the **published** package (an HTTP-only E2E passes while the npm tool is unpublished — the artifact-vs-source class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8
