### PR TITLE
fix(onboarding): stamp host='byo' on self-serve seats — the 202 installs that read 'unknown'

### DIFF
--- a/backend/__tests__/unit/routes/registry.byo-host-stamp.test.js
+++ b/backend/__tests__/unit/routes/registry.byo-host-stamp.test.js
@@ -1,0 +1,88 @@
+/**
+ * Self-serve polling seats must be stamped `host: 'byo'` at install.
+ *
+ * The mislabelling this fixes is a single mismatch: the connect page posts
+ * `runtimeType: 'webhook'` (ADR-006's self-serve branch requires that value to
+ * synthesize a manifest) while the user never runs a webhook — they run
+ * `commonly agent run`, which POLLS. With no `host`, `deriveAgentState` asks
+ * push-webhook? / native? / byo?, gets no to all three, and answers `unknown`.
+ *
+ * Measured 2026-08-14 (pod-architect): 202 of 314 active installs derive
+ * `unknown`, and every real BYO user seat is in that 202, including all four
+ * users who mentioned a dead seat and got silence. The honesty surface, the
+ * install intro (#943) and W4's stalled-connect trigger all read that
+ * derivation — so all three were inert for exactly the population they exist
+ * to protect.
+ *
+ * The rule is tested here as a pure predicate rather than through the install
+ * route, which cannot be imported under Node 26 (jsonwebtoken →
+ * buffer-equal-constant-time reads the removed SlowBuffer). The predicate is
+ * kept identical to install.ts's condition; if that ever drifts, the
+ * deriveAgentState assertions below still describe the contract that matters.
+ */
+
+const { deriveAgentState } = require('../../../services/agentStateService');
+
+// Mirrors the condition in routes/registry/install.ts.
+const shouldStampByo = (runtime) => !runtime.host
+  && String(runtime.runtimeType || '').toLowerCase() === 'webhook'
+  && !runtime.webhookUrl;
+
+describe('self-serve seats are stamped byo at install', () => {
+  test('webhook-typed with no webhookUrl is a polling seat', () => {
+    // Exactly what V2AgentBYO.tsx:151 posts.
+    expect(shouldStampByo({ runtimeType: 'webhook' })).toBe(true);
+  });
+
+  test('a PUSH webhook supplies a URL and must NOT be restamped', () => {
+    // The discriminator. No registry route writes webhookUrl — it only ever
+    // arrives in caller config — so its presence means a real push webhook,
+    // which deriveAgentState already calls reachable by construction.
+    expect(shouldStampByo({ runtimeType: 'webhook', webhookUrl: 'https://example.com/hook' })).toBe(false);
+  });
+
+  test('an explicit host is never overwritten', () => {
+    // The CLI attach path already sets this correctly.
+    expect(shouldStampByo({ runtimeType: 'webhook', host: 'cloud' })).toBe(false);
+    expect(shouldStampByo({ runtimeType: 'claude-code', host: 'byo' })).toBe(false);
+  });
+
+  test('native and other runtimes are untouched', () => {
+    expect(shouldStampByo({ runtimeType: 'native' })).toBe(false);
+    expect(shouldStampByo({})).toBe(false);
+  });
+});
+
+describe('the stamp is what makes the honesty surface work at all', () => {
+  const install = (runtime) => ({
+    agentName: 'kaka-agent', instanceId: 'default', installedBy: 'u1', config: { runtime }, runtimeTokens: [],
+  });
+
+  test('WITHOUT the stamp a never-run seat reads `unknown` — no warning, no nudge', () => {
+    // This is the production state of all four casualties: the seat has never
+    // been polled, and the platform cannot say so.
+    const state = deriveAgentState(install({ runtimeType: 'webhook' }), [], 'u1');
+
+    expect(state.state).toBe('unknown');
+    expect(state.fixCommand).toBeUndefined();
+  });
+
+  test('WITH the stamp the same seat reads `never-connected` and offers the fix', () => {
+    const state = deriveAgentState(install({ runtimeType: 'webhook', host: 'byo' }), [], 'u1');
+
+    expect(state.state).toBe('never-connected');
+    expect(state.fixCommand).toBe('commonly agent run kaka-agent');
+  });
+
+  test('a stamped seat that HAS been polled recently reads listening', () => {
+    // The stamp must not make everything look broken — it makes the answer
+    // knowable in both directions.
+    const state = deriveAgentState(
+      install({ runtimeType: 'webhook', host: 'byo' }),
+      [{ lastUsedAt: new Date() }],
+      'u1',
+    );
+
+    expect(state.state).toBe('listening');
+  });
+});

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -311,6 +311,32 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
         runtimeConfig.runtimeType = manifestRuntimeType;
       }
     }
+    // Stamp `host: 'byo'` on self-serve polling seats.
+    //
+    // Every self-serve BYO seat is currently born MISLABELLED, and it is one
+    // mismatch: the connect page posts `runtimeType: 'webhook'` (ADR-006's
+    // self-serve branch requires that value to synthesize a manifest) while the
+    // user never runs a webhook — they run `commonly agent run`, which POLLS.
+    // No `host` is written, so `deriveAgentState` asks its three questions
+    // (push-webhook? native? byo?), gets no to all three, and returns
+    // 'unknown'.
+    //
+    // Measured cost: 202 of 314 active installs derive 'unknown', and every
+    // real BYO user seat is in that 202 — including all four users who
+    // mentioned a dead seat and got silence (pod-architect, fleet review
+    // 2026-08-14). The honesty surface, the install intro (#943) and W4's
+    // stalled-connect trigger all read that derivation, so all three are inert
+    // for exactly the population they exist to protect.
+    //
+    // Discriminator: a PUSH webhook must supply `webhookUrl` — no registry
+    // route ever writes that field, it only ever arrives in caller config — so
+    // webhook-typed WITHOUT a URL is a polling seat. Never overwrite an
+    // explicit host; the CLI attach path already sets it correctly.
+    if (!runtimeConfig.host
+      && String(runtimeConfig.runtimeType || '').toLowerCase() === 'webhook'
+      && !runtimeConfig.webhookUrl) {
+      runtimeConfig.host = 'byo';
+    }
     if (Object.keys(runtimeConfig).length) {
       installConfig.runtime = runtimeConfig;
     }

--- a/backend/scripts/backfill-byo-host-stamp.ts
+++ b/backend/scripts/backfill-byo-host-stamp.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/*
+ * Stamp `config.runtime.host = 'byo'` on self-serve polling seats that were
+ * created without it.
+ *
+ * Every self-serve BYO seat has been born mislabelled. The connect page posts
+ * `runtimeType: 'webhook'` — ADR-006's self-serve branch requires that value to
+ * synthesize a manifest — while the user never runs a webhook; they run
+ * `commonly agent run`, which POLLS. No `host` was written, so
+ * `deriveAgentState` asks push-webhook? / native? / byo?, gets no to all three,
+ * and answers `unknown`.
+ *
+ * Measured on production 2026-08-14 (pod-architect): 202 of 314 active installs
+ * derive `unknown`, and every real BYO user seat is in that 202 — including all
+ * four users who mentioned a seat with nobody home and got silence (m0re 08-04,
+ * l3r0ys4n3 08-07, user-8863 08-09, ngoc-tran 08-10). The honesty surface, the
+ * install intro (#943) and W4's stalled-connect trigger all read that
+ * derivation, so all three are inert for exactly the people they exist to
+ * protect until these rows are corrected.
+ *
+ * `registry/install.ts` closes this going forward. This script is the
+ * historical half — read-side normalization CANNOT substitute for it, because
+ * `normalizeRuntimeIdentity` can only rescue the legacy `local-cli` +
+ * `wrappedCli` shape and these rows carry neither. There is nothing in them to
+ * infer from; the information has to be put back.
+ *
+ * Discriminator, identical to the write path: a PUSH webhook must supply
+ * `webhookUrl` (no registry route writes that field — it only ever arrives in
+ * caller config), so webhook-typed WITHOUT a URL is a polling seat. Rows with
+ * an explicit host are never touched.
+ *
+ * Usage:
+ *   npx ts-node backend/scripts/backfill-byo-host-stamp.ts          # dry run
+ *   npx ts-node backend/scripts/backfill-byo-host-stamp.ts --apply
+ */
+
+/* eslint-disable no-console */
+const mongoose = require('mongoose');
+const { AgentInstallation } = require('../models/AgentRegistry');
+
+const APPLY = process.argv.includes('--apply');
+
+const main = async () => {
+  const uri = process.env.MONGO_URI;
+  if (!uri) {
+    console.error('MONGO_URI is required');
+    process.exit(1);
+  }
+  await mongoose.connect(uri);
+
+  // Deliberately NOT filtered in the query: `config` is a Mixed/Map field
+  // across generations of install rows, so shape-matching in Mongo silently
+  // misses variants. Filter in JS where the shape is inspectable.
+  const rows = await AgentInstallation.find({}).select('agentName instanceId podId config status');
+
+  const candidates = rows.filter((row: any) => {
+    const runtime = row?.config?.runtime;
+    if (!runtime || typeof runtime !== 'object') return false;
+    if (runtime.host) return false;
+    if (runtime.webhookUrl) return false;
+    return String(runtime.runtimeType || '').toLowerCase() === 'webhook';
+  });
+
+  console.log(`installs scanned:      ${rows.length}`);
+  console.log(`already stamped:       ${rows.filter((r: any) => r?.config?.runtime?.host).length}`);
+  console.log(`push webhooks skipped: ${rows.filter((r: any) => r?.config?.runtime?.webhookUrl).length}`);
+  console.log(`candidates to stamp:   ${candidates.length}`);
+  candidates.slice(0, 20).forEach((row: any) => {
+    console.log(`  ${row.agentName}:${row.instanceId || 'default'} pod=${row.podId} status=${row.status}`);
+  });
+  if (candidates.length > 20) console.log(`  … and ${candidates.length - 20} more`);
+
+  if (!APPLY) {
+    console.log('\nDRY RUN — re-run with --apply to write.');
+    await mongoose.disconnect();
+    return;
+  }
+
+  let stamped = 0;
+  for (const row of candidates) {
+    const runtime = { ...(row.config.runtime || {}), host: 'byo' };
+    // Assign the whole config object back: Mixed paths do not reliably mark
+    // themselves dirty on nested mutation, which is the classic way a
+    // migration reports success and writes nothing.
+    row.config = { ...(row.config || {}), runtime };
+    row.markModified('config');
+    // eslint-disable-next-line no-await-in-loop
+    await row.save();
+    stamped += 1;
+  }
+
+  console.log(`\nstamped ${stamped} installs.`);
+  await mongoose.disconnect();
+};
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
**W4 item 1 — and it is the prerequisite for everything else in W4, not a parallel item.**

## Every self-serve BYO seat is born mislabelled

One mismatch causes it. The connect page posts `runtimeType: 'webhook'` (`V2AgentBYO.tsx:151`) because ADR-006's self-serve branch *requires* that value to synthesize a manifest — while the user never runs a webhook. They run `commonly agent run`, which **polls**. No `host` is written, so `deriveAgentState` asks its three questions — push-webhook? native? byo? — gets no to all three, and answers `unknown`.

## What that costs, measured

pod-architect, against production:

> Keyed on `never-connected` the trigger covers **12 of 314** active installs — and all 12 are our own seats. **202 derive `unknown`, and every real BYO user seat is in that 202**, including all four named casualties.

| user | date | what they sent | reply |
|---|---|---|---|
| m0re | 08-04 | `@m0re-agent 1` | none |
| l3r0ys4n3 | 08-07 | `Hi` | none |
| user-8863 | 08-09 | asked **3×** whether the connection worked | none |
| ngoc-tran | 08-10 | `@ngoc-tran-agent what modal you use` | none |

The #891 honesty surface, the install intro (#943) and W4's stalled-connect trigger **all** read this derivation. So all three are decoration until this lands — #943 would have merged, deployed, and changed nothing for the exact people it was written for.

## The fix

Stamp `host: 'byo'` when a seat is webhook-typed with **no** `webhookUrl`.

That discriminator is sound because a genuine push webhook must supply a URL, and **no registry route ever writes `webhookUrl`** — it only arrives in caller config. An explicit host is never overwritten; the CLI attach path already sets it correctly.

## Why there is a backfill, and why read-side can't replace it

`scripts/backfill-byo-host-stamp.ts` (dry-run by default) handles the existing 202.

I went looking for a read-side fix first, because it would rescue history for free. It cannot work — I checked the casualty rows directly, and `normalizeRuntimeIdentity` only rescues the legacy `local-cli` + `wrappedCli` shape, which these carry neither of. There is no information in the row to infer `byo` from; it has to be put back.

The script assigns the whole `config` object and calls `markModified` — Mixed paths do not reliably mark themselves dirty on nested mutation, which is the classic way a migration reports success and writes nothing.

## Tests

Seven. They pin the predicate (including the push-webhook case that must **not** be restamped, and the explicit-host case that must not be overwritten) and, more importantly, the *consequence*:

- without the stamp, a never-run seat reads `unknown` with **no** `fixCommand`
- with the stamp, the same seat reads `never-connected` and offers `commonly agent run <name>`
- a stamped seat polled recently reads `listening` — the stamp makes the answer knowable in both directions, it does not just make everything look broken

## Follow-up this does not do

pod-architect's warning stands and should shape the acceptance test for W4 item 3: a synthetic install created with `host:'byo'` passes every case while the real population stays uncovered. That assertion has to run against a seat minted by the **actual** self-serve connect flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8
