### PR TITLE
fix(onboarding): the install intro read config as an object; it is a Map

### DIFF
--- a/backend/__tests__/unit/services/agentStateService.configShape.test.js
+++ b/backend/__tests__/unit/services/agentStateService.configShape.test.js
@@ -1,0 +1,64 @@
+/**
+ * `deriveAgentState` reads `config.runtime` directly, and `AgentInstallation`
+ * declares `config: { type: Map, of: Mixed }` (AgentRegistry.ts:235). So the
+ * SHAPE of what you hand it decides the answer:
+ *
+ *   - `.lean()` / `.toObject()` → plain object → `config.runtime` works
+ *   - a live Mongoose document   → Map        → `config.runtime` is undefined
+ *
+ * Caught live 2026-08-14, not in CI. After the host:'byo' stamp shipped, a seat
+ * minted by the real connect flow derived `never-connected` through
+ * /agent-states (which uses `.lean()`) while the install route — holding the
+ * live document — derived `unknown` and posted "Mention me with @handle when
+ * you need me" to a seat with nobody home. Two readers of one field
+ * disagreeing purely because one held a document.
+ *
+ * Every existing unit test passed throughout, because they all pass plain
+ * objects. These pin the failure mode itself so a future caller that forgets
+ * `.lean()` fails here instead of in production copy.
+ */
+
+const { deriveAgentState } = require('../../../services/agentStateService');
+
+const base = { agentName: 'stamp-verify-agent', instanceId: 'default', installedBy: 'u1' };
+
+describe('deriveAgentState is shape-sensitive on config', () => {
+  test('a plain object (what .lean() gives) reads the stamp', () => {
+    const state = deriveAgentState(
+      { ...base, config: { runtime: { runtimeType: 'webhook', host: 'byo' } }, runtimeTokens: [] },
+      [],
+      'u1',
+    );
+
+    expect(state.state).toBe('never-connected');
+  });
+
+  test('a Mongoose Map silently reads as NO runtime — the live bug', () => {
+    // Not a recommendation, a warning: this is what the install route passed.
+    // A Map has no `.runtime` property, so the honesty layer goes blind and
+    // answers `unknown` — which renders as the cheerful invitation.
+    const state = deriveAgentState(
+      { ...base, config: new Map([['runtime', { runtimeType: 'webhook', host: 'byo' }]]), runtimeTokens: [] },
+      [],
+      'u1',
+    );
+
+    expect(state.state).toBe('unknown');
+    expect(state.fixCommand).toBeUndefined();
+  });
+
+  test('normalizing the Map first restores the correct answer', () => {
+    // The fix applied at the install call site.
+    const { normalizeConfigMap } = require('../../../routes/registry/helpers');
+    const map = new Map([['runtime', { runtimeType: 'webhook', host: 'byo' }]]);
+
+    const state = deriveAgentState(
+      { ...base, config: normalizeConfigMap(map) || {}, runtimeTokens: [] },
+      [],
+      'u1',
+    );
+
+    expect(state.state).toBe('never-connected');
+    expect(state.fixCommand).toBe('commonly agent run stamp-verify-agent');
+  });
+});

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -645,8 +645,33 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
             'botMetadata.instanceId': normalizedInstanceId,
           }).select('agentRuntimeTokens.lastUsedAt').lean() as
               { agentRuntimeTokens?: { lastUsedAt?: Date | string | null }[] } | null;
+          // `config` is `{ type: Map, of: Mixed }` (AgentRegistry.ts:235), so
+          // on a LIVE Mongoose document `installation.config.runtime` is
+          // undefined — a Map needs `.get()`. `deriveAgentState` reads
+          // `config?.runtime` directly, so passing the live doc made it see an
+          // empty runtime, answer `unknown`, and pick the invitation copy.
+          //
+          // Verified live: after the host:'byo' stamp shipped, a seat minted by
+          // the real connect flow derived `never-connected` through
+          // /agent-states (which uses `.lean()`, and lean converts Maps to
+          // plain objects) while this call site still produced "Mention me with
+          // @handle when you need me". Two readers of one field disagreeing
+          // because one of them held a Mongoose document.
+          //
+          // Unit tests could not catch it: they pass plain objects, which is
+          // the shape lean gives and the shape this line did NOT have.
+          // Built field-by-field on purpose: spreading a Mongoose document
+          // copies internals rather than the fields (they live under `_doc`),
+          // which would fail the same silent way.
           const derived = deriveAgentState(
-            installation,
+            {
+              agentName: installation.agentName,
+              instanceId: installation.instanceId,
+              displayName: installation.displayName,
+              installedBy: installation.installedBy,
+              runtimeTokens: installation.runtimeTokens,
+              config: normalizeConfigMap(installation.config) || {},
+            },
             botRow?.agentRuntimeTokens || [],
             String(userId),
           );


### PR DESCRIPTION
**Caught by live verification, not CI** — and it made #943 a no-op on the exact path it was written for.

## The bug

`AgentInstallation` declares `config: { type: Map, of: Mixed }` (`AgentRegistry.ts:235`). On a **live Mongoose document**, `config.runtime` is therefore `undefined` — a Map needs `.get()`. `deriveAgentState` reads `config?.runtime` directly, so the install route handed it a document, it saw an empty runtime, answered `unknown`, and picked the cheerful invitation copy.

## How it surfaced

Two readers of one field disagreeing. After the `host:'byo'` stamp (#945) shipped, I minted a seat through the **real** connect flow and asked both:

```
/agent-states  (uses .lean() — Maps become plain objects) → never-connected  ✅
install route  (holds the live document)                  → unknown          ❌

posted intro: "Hi all — I'm stamp-verify-agent. A connected agent.
               Mention me with @stamp-verify-agent when you need me."
```

That is precisely the promise #943 exists to stop making, to a seat with nobody home.

## Why no test caught it

Every unit test passed throughout, because they all pass **plain objects** — the shape `.lean()` gives, and the shape this call site did not have. Green CI, inert in production.

The new suite pins the failure mode itself rather than the fix:

- the same input as a **Map** reads `unknown` with no `fixCommand` — the live bug, asserted
- normalizing it first restores `never-connected` + `commonly agent run <name>`

## Note on the shape

Built field-by-field rather than spread: spreading a Mongoose document copies internals instead of fields (they live under `_doc`) and would fail the same silent way.

## Still outstanding after this

The pre-existing seats — `verify-seat`, `npm-verify-agent`, and the ~200 others — still read `unknown` and need `scripts/backfill-byo-host-stamp.ts` (merged in #945, dry-run by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8