### PR TITLE
fix(backfill): the byo-stamp scan read config as an object; it is a Map

### DIFF
--- a/backend/scripts/backfill-byo-host-stamp.ts
+++ b/backend/scripts/backfill-byo-host-stamp.ts
@@ -48,22 +48,43 @@ const main = async () => {
   }
   await mongoose.connect(uri);
 
-  // Deliberately NOT filtered in the query: `config` is a Mixed/Map field
-  // across generations of install rows, so shape-matching in Mongo silently
-  // misses variants. Filter in JS where the shape is inspectable.
-  const rows = await AgentInstallation.find({}).select('agentName instanceId podId config status');
+  // `.lean()` is load-bearing, not an optimization. `config` is declared
+  // `{ type: Map, of: Mixed }` (AgentRegistry.ts:235), so on a live Mongoose
+  // document `config.runtime` is undefined — a Map needs `.get()`. The first
+  // version of this script omitted `.lean()` and its dry run reported
+  // "scanned 545, already stamped 0, candidates 0" against a database where
+  // two seats were demonstrably stamped and ~200 were candidates. Every row
+  // filtered out on a property that cannot exist.
+  //
+  // With `--apply` that would have written nothing and printed success: the
+  // migration-reports-success-and-writes-nothing failure this file already
+  // warns about below, arriving through a different door. The dry run is what
+  // caught it.
+  const rows = await AgentInstallation.find({})
+    .select('agentName instanceId podId config status')
+    .lean();
+
+  const runtimeOf = (row: any) => {
+    const config = row?.config;
+    if (!config) return null;
+    // Defensive both ways: lean() gives a plain object, but a caller that
+    // hands this a live document should degrade to a correct read rather than
+    // a silent empty one.
+    const runtime = typeof config.get === 'function' ? config.get('runtime') : config.runtime;
+    return runtime && typeof runtime === 'object' ? runtime : null;
+  };
 
   const candidates = rows.filter((row: any) => {
-    const runtime = row?.config?.runtime;
-    if (!runtime || typeof runtime !== 'object') return false;
+    const runtime = runtimeOf(row);
+    if (!runtime) return false;
     if (runtime.host) return false;
     if (runtime.webhookUrl) return false;
     return String(runtime.runtimeType || '').toLowerCase() === 'webhook';
   });
 
   console.log(`installs scanned:      ${rows.length}`);
-  console.log(`already stamped:       ${rows.filter((r: any) => r?.config?.runtime?.host).length}`);
-  console.log(`push webhooks skipped: ${rows.filter((r: any) => r?.config?.runtime?.webhookUrl).length}`);
+  console.log(`already stamped:       ${rows.filter((r: any) => runtimeOf(r)?.host).length}`);
+  console.log(`push webhooks skipped: ${rows.filter((r: any) => runtimeOf(r)?.webhookUrl).length}`);
   console.log(`candidates to stamp:   ${candidates.length}`);
   candidates.slice(0, 20).forEach((row: any) => {
     console.log(`  ${row.agentName}:${row.instanceId || 'default'} pod=${row.podId} status=${row.status}`);
@@ -78,15 +99,20 @@ const main = async () => {
 
   let stamped = 0;
   for (const row of candidates) {
-    const runtime = { ...(row.config.runtime || {}), host: 'byo' };
-    // Assign the whole config object back: Mixed paths do not reliably mark
-    // themselves dirty on nested mutation, which is the classic way a
-    // migration reports success and writes nothing.
-    row.config = { ...(row.config || {}), runtime };
-    row.markModified('config');
+    // `updateOne` with a dotted path rather than load-mutate-save. The rows
+    // are lean (see the scan above), so there is no document to save; and a
+    // dotted `$set` on a Map path writes the one key without rewriting the
+    // whole config, so a concurrent install touching another key is not
+    // clobbered. It also sidesteps the Mixed-path dirty-tracking problem that
+    // the load-mutate-save shape has to remember to handle.
     // eslint-disable-next-line no-await-in-loop
-    await row.save();
-    stamped += 1;
+    const res = await AgentInstallation.updateOne(
+      { _id: row._id },
+      { $set: { 'config.runtime.host': 'byo' } },
+    );
+    // Count what the DB says it changed, not what we intended — the whole
+    // reason this script needed a second pass.
+    stamped += (res?.modifiedCount ?? res?.nModified ?? 0);
   }
 
   console.log(`\nstamped ${stamped} installs.`);


### PR DESCRIPTION
The dry run caught this, which is the only reason it's a commit and not an incident.

## What happened

`config` is `{ type: Map, of: Mixed }` (`AgentRegistry.ts:235`), so on a live Mongoose document `config.runtime` is `undefined`. The scan omitted `.lean()`, so **every row filtered out on a property that cannot exist.** Against production:

```
installs scanned:      545
already stamped:       0     ← two seats were demonstrably stamped
push webhooks skipped: 0
candidates to stamp:   0     ← ~200 are candidates
```

With `--apply` it would have **written nothing and printed success** — the migration-reports-success-and-writes-nothing failure this file already warned about, arriving through a different door than the one guarded.

## The actual lesson

This is the **same** Map-vs-object defect just fixed in the install intro (#947). I wrote this script *before* diagnosing that one and never came back to it. The fix got applied where the bug was found rather than everywhere the shape is read — which is how one root cause ships twice.

## The fix

- Scan uses `.lean()`, plus a `runtimeOf` reader that handles **both** shapes, so a caller passing a live document degrades to a correct read instead of a silently empty one.
- Write switched to `updateOne` with a dotted `$set`. The rows are lean so there's no document to save; a dotted path writes one key without rewriting the whole config, so a concurrent install touching another key isn't clobbered; and it sidesteps Mixed-path dirty tracking entirely.
- The counter reports what the **DB says it modified**, not what the loop intended — the exact gap that let the first version look successful.

## Next

Re-run the dry run after this merges. Expect ~200 candidates, and the two already-stamped seats to show under `already stamped` rather than `0`. Only then `--apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8