### PR TITLE
chore(backfill): stamp ACTIVE installs only, and record the production run

### DIFF
--- a/backend/scripts/backfill-byo-host-stamp.ts
+++ b/backend/scripts/backfill-byo-host-stamp.ts
@@ -39,6 +39,7 @@ const mongoose = require('mongoose');
 const { AgentInstallation } = require('../models/AgentRegistry');
 
 const APPLY = process.argv.includes('--apply');
+const INCLUDE_INACTIVE = process.argv.includes('--include-inactive');
 
 const main = async () => {
   const uri = process.env.MONGO_URI;
@@ -74,13 +75,37 @@ const main = async () => {
     return runtime && typeof runtime === 'object' ? runtime : null;
   };
 
-  const candidates = rows.filter((row: any) => {
+  // ACTIVE only, unless --include-inactive is passed.
+  //
+  // Measured on production before the first apply: 191 rows matched the shape
+  // but split 136 uninstalled / 39 stale / 16 active, and the uninstalled set
+  // is almost entirely dead `byo-smoke-*` / `byo-e2e-*` fixtures. Stamping
+  // those is harmless and pointless — it writes 136 rows nothing reads, and it
+  // inflates the reported number so the next person cannot tell how many real
+  // seats were affected.
+  //
+  // The 16 active rows are the ones the honesty surface, the stalled-connect
+  // trigger and `commonly_agent_status` actually read, and they are the seats
+  // belonging to the users this whole change exists for.
+  const shapeMatches = (row: any) => {
     const runtime = runtimeOf(row);
     if (!runtime) return false;
     if (runtime.host) return false;
     if (runtime.webhookUrl) return false;
     return String(runtime.runtimeType || '').toLowerCase() === 'webhook';
+  };
+  const matched = rows.filter(shapeMatches);
+  const candidates = INCLUDE_INACTIVE
+    ? matched
+    : matched.filter((row: any) => row.status === 'active');
+
+  const byStatus: Record<string, number> = {};
+  matched.forEach((r: any) => {
+    const k = r.status || 'none';
+    byStatus[k] = (byStatus[k] || 0) + 1;
   });
+  console.log(`shape matches by status: ${JSON.stringify(byStatus)}`);
+  if (!INCLUDE_INACTIVE) console.log('(stamping ACTIVE only — pass --include-inactive to widen)');
 
   console.log(`installs scanned:      ${rows.length}`);
   console.log(`already stamped:       ${rows.filter((r: any) => runtimeOf(r)?.host).length}`);


### PR DESCRIPTION
Scoping the backfill to what actually matters, and recording the production run.

## Why

Measured before the first apply — 191 rows matched the shape, but:

```
uninstalled 136 · stale 39 · ACTIVE 16
```

The uninstalled set is almost entirely dead `byo-smoke-*` / `byo-e2e-*` fixtures. Stamping them writes 136 rows nothing reads **and** inflates the reported number past the point where the next person can tell how many real seats were affected.

Default is now **active-only**; `--include-inactive` widens. The run prints the status split up front so the number is legible before anyone decides to write.

## The production run

Ran with this scoping: **16 stamped.** Verified against the live API rather than trusting the script's own counter — and the result is better evidence than the count.

Four seats in the smoke workspace that **all read `unknown`** an hour ago now derive three *different* answers:

| seat | now | meaning |
|---|---|---|
| `smoke-guide-…-agent` | `listening` | a wrapper really is polling |
| `npm-verify-agent` | `gone-dark` | it ran, then stopped |
| `verify-seat` | `never-connected` | never polled |

And the casualties resolved: `ngoc-tran-agent` and `kaka-agent` both `never-connected`, where the platform previously could not say anything at all.

That is the "knowable in both directions" property the unit test asserts — the stamp does not make everything look broken, it makes the answer *true*. This is the production evidence for it.

## Incidental, and worth noting

`scout` reads `reachable` in every one of those workspaces. Each of those users had a working, zero-setup agent the whole time, walked past it to the BYO connect page, and got silence from the seat they made instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8
