### PR TITLE
feat(onboarding): alert when a newcomer types and nothing answers (W4 item 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,25 @@ TELEGRAM_BOT_TOKEN=
 # SENDGRID_FROM_EMAIL=noreply@yourdomain.com
 
 # -----------------------------------------------------------------------------
+# Onboarding-silence alert  (OPTIONAL, but the alert is log-only without it)
+# -----------------------------------------------------------------------------
+# Where "a new user typed and nothing answered" is sent. The detection cron
+# runs regardless and always logs a machine-readable line; set this and it also
+# reaches a person. Leaving it unset is a supported configuration, not a
+# mistake — but then the only reader is `kubectl logs`, and the whole point of
+# this alert is that nobody has to decide to go look.
+# ONBOARDING_ALERT_EMAIL=ops@yourdomain.com
+#
+# Tunables (defaults are calibrated against production — see
+# backend/services/onboardingSilenceService.ts before changing them):
+# ONBOARDING_SILENCE_THRESHOLD_MINUTES=15   # past the 10-min event requeue,
+#                                           # inside the 30-min pending GC
+# ONBOARDING_SILENCE_WINDOW_DAYS=7          # how long after signup counts as onboarding
+# ONBOARDING_SILENCE_LOOKBACK_HOURS=24      # how far back one pass judges
+# ONBOARDING_SILENCE_ROLLUP_THRESHOLD=5     # per-hour count above which alerts collapse
+# ONBOARDING_SILENCE_RESOLUTION_WINDOW_DAYS=7
+
+# -----------------------------------------------------------------------------
 # X / Twitter integration  (OPTIONAL)
 # -----------------------------------------------------------------------------
 # X_API_KEY=

--- a/backend/__tests__/unit/routes/admin.analytics.silence.test.js
+++ b/backend/__tests__/unit/routes/admin.analytics.silence.test.js
@@ -1,0 +1,111 @@
+const request = require('supertest');
+const express = require('express');
+
+// GET /api/admin/analytics/silence — the pull half of the onboarding-silence
+// alert (W4 item 2). The cron pushes; this exists so "did the fix work" is
+// answerable without hand-reading production transcripts, which is how every
+// onboarding defect was found on 2026-08-14.
+
+let mockRole = 'admin';
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.user = { id: 'admin1' };
+  req.userId = 'admin1';
+  next();
+});
+jest.mock('../../../middleware/adminAuth', () => (req, res, next) => {
+  if (mockRole !== 'admin') return res.status(403).json({ message: 'Admin access required' });
+  return next();
+});
+jest.mock('../../../middleware/ipRateLimit', () => ({
+  cloudflareIpRateLimitKeyGenerator: () => 'test-key',
+}));
+jest.mock('../../../models/User', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../../../models/Pod', () => ({ aggregate: jest.fn() }));
+jest.mock('../../../models/AgentRegistry', () => ({ AgentInstallation: { distinct: jest.fn() } }));
+jest.mock('../../../config/db-pg', () => ({ pool: { query: jest.fn() } }));
+
+const mockFind = jest.fn();
+jest.mock('../../../models/OnboardingSilenceEpisode', () => ({ find: (...a) => mockFind(...a) }));
+
+const routes = require('../../../routes/admin/analytics');
+
+const chain = (rows) => ({
+  sort: () => ({ limit: () => ({ lean: () => Promise.resolve(rows) }) }),
+});
+
+const ep = (over = {}) => ({
+  _id: 'ep1',
+  userId: 'u1',
+  username: 'newcomer',
+  podId: 'p1',
+  podName: 'My Workspace',
+  firstTypedAt: new Date('2026-08-15T11:30:00Z'),
+  accountAgeMinutes: 12,
+  messageCount: 2,
+  status: 'open',
+  eventSnapshot: {
+    total: 0, byStatus: {}, targets: [], noneEnqueued: true,
+  },
+  ...over,
+});
+
+describe('GET /api/admin/analytics/silence', () => {
+  let app;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRole = 'admin';
+    app = express();
+    app.use('/api/admin/analytics', routes);
+  });
+
+  it('returns episodes with a diagnosis and a status split', async () => {
+    mockFind.mockReturnValue(chain([
+      ep(),
+      ep({
+        _id: 'ep2',
+        status: 'resolved',
+        outcome: 'human-rescued',
+        resolutionLagSeconds: 36000,
+        eventSnapshot: {
+          total: 2, byStatus: { pending: 2 }, targets: ['scout/u1'], noneEnqueued: false,
+        },
+      }),
+    ]));
+
+    const res = await request(app).get('/api/admin/analytics/silence');
+
+    expect(res.status).toBe(200);
+    expect(res.body.totals).toMatchObject({
+      episodes: 2, open: 1, resolved: 1, humanRescued: 1,
+    });
+    expect(res.body.totals.byDiagnosis).toEqual({
+      'never-enqueued': 1, 'enqueued-never-answered': 1,
+    });
+    expect(res.body.thresholdMinutes).toBe(15);
+  });
+
+  it('reports whether an alert would actually reach anyone', async () => {
+    mockFind.mockReturnValue(chain([]));
+    delete process.env.ONBOARDING_ALERT_EMAIL;
+
+    const res = await request(app).get('/api/admin/analytics/silence');
+
+    // A dashboard that shows "0 stranded users" while delivery is unconfigured
+    // is indistinguishable from a healthy funnel. Say which one it is.
+    expect(res.body.alertRecipientConfigured).toBe(false);
+  });
+
+  it('clamps days to [1, 90]', async () => {
+    mockFind.mockReturnValue(chain([]));
+
+    const res = await request(app).get('/api/admin/analytics/silence?days=9999');
+
+    expect(res.body.days).toBe(90);
+  });
+
+  it('403s non-admins', async () => {
+    mockRole = 'user';
+    const res = await request(app).get('/api/admin/analytics/silence');
+    expect(res.status).toBe(403);
+  });
+});

--- a/backend/__tests__/unit/services/onboardingAlertService.test.js
+++ b/backend/__tests__/unit/services/onboardingAlertService.test.js
@@ -1,0 +1,174 @@
+// Onboarding-silence DELIVERY (W4 item 2).
+//
+// Detection is tested next door. This file is about the half that can fail
+// quietly: an alert that computes correctly and tells nobody is the exact
+// shape of the three "silent success" defects found on 2026-08-14, and it is
+// the worst place in the codebase to add a fourth. So the behaviours asserted
+// here are mostly about refusing to be inert.
+
+const mockScan = jest.fn();
+jest.mock('../../../services/onboardingSilenceService', () => ({
+  scan: (...a) => mockScan(...a),
+  SILENCE_THRESHOLD_MINUTES: 15,
+  ROLLUP_COLLAPSE_THRESHOLD: 5,
+}));
+
+const mockSendEmail = jest.fn();
+jest.mock('../../../services/emailService', () => ({ sendEmail: (...a) => mockSendEmail(...a) }));
+
+const mockCount = jest.fn();
+const mockUpdateOne = jest.fn();
+const mockUpdateMany = jest.fn();
+jest.mock('../../../models/OnboardingSilenceEpisode', () => ({
+  countDocuments: (...a) => mockCount(...a),
+  updateOne: (...a) => mockUpdateOne(...a),
+  updateMany: (...a) => mockUpdateMany(...a),
+}));
+
+const { runOnce, diagnose } = require('../../../services/onboardingAlertService');
+
+const episode = (over = {}) => ({
+  episodeId: 'ep1',
+  userId: 'u1',
+  username: 'newcomer',
+  podId: 'p1',
+  podName: 'My Workspace',
+  firstMessageId: '900',
+  firstTypedAt: new Date('2026-08-15T11:30:00Z'),
+  accountAgeMinutes: 12,
+  messageCount: 2,
+  eventSnapshot: {
+    total: 0, byStatus: {}, targets: [], noneEnqueued: true,
+  },
+  ...over,
+});
+
+const emptyScan = {
+  scannedMessages: 0, opened: [], updated: 0, resolved: [], skippedNoAgent: 0,
+};
+
+let errSpy;
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.ONBOARDING_ALERT_EMAIL;
+  mockCount.mockResolvedValue(1);
+  mockUpdateOne.mockResolvedValue({});
+  mockUpdateMany.mockResolvedValue({});
+  mockSendEmail.mockResolvedValue({});
+  errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => errSpy.mockRestore());
+
+describe('onboardingAlertService.runOnce', () => {
+  it('sends one email per stranded user', async () => {
+    process.env.ONBOARDING_ALERT_EMAIL = 'ops@example.com';
+    mockScan.mockResolvedValue({ ...emptyScan, opened: [episode(), episode({ episodeId: 'ep2', username: 'other' })] });
+
+    const r = await runOnce();
+
+    expect(mockSendEmail).toHaveBeenCalledTimes(2);
+    expect(r.delivered).toBe(2);
+    expect(r.rollup).toBe(false);
+    expect(mockSendEmail.mock.calls[0][0].to).toBe('ops@example.com');
+    expect(mockSendEmail.mock.calls[0][0].subject).toContain('newcomer');
+  });
+
+  it('collapses into one rollup above the hourly threshold', async () => {
+    process.env.ONBOARDING_ALERT_EMAIL = 'ops@example.com';
+    mockScan.mockResolvedValue({
+      ...emptyScan,
+      opened: [episode(), episode({ episodeId: 'ep2' }), episode({ episodeId: 'ep3' })],
+    });
+    mockCount.mockResolvedValue(9); // pressure from this pass plus earlier ones
+
+    const r = await runOnce();
+
+    expect(r.rollup).toBe(true);
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail.mock.calls[0][0].textBody).toContain('9 in the last hour');
+    expect(mockUpdateMany).toHaveBeenCalled();
+  });
+
+  it('counts rolling-hour pressure from the DB, not just this pass', async () => {
+    process.env.ONBOARDING_ALERT_EMAIL = 'ops@example.com';
+    mockScan.mockResolvedValue({ ...emptyScan, opened: [episode()] });
+    mockCount.mockResolvedValue(20); // a burst spread across earlier ticks
+
+    const r = await runOnce();
+
+    expect(r.rollup).toBe(true);
+  });
+
+  it('says so loudly when no recipient is configured, instead of silently dropping', async () => {
+    mockScan.mockResolvedValue({ ...emptyScan, opened: [episode()] });
+
+    const r = await runOnce();
+
+    expect(r.unconfigured).toBe(true);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    const shouted = errSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(shouted).toContain('NO ALERT RECIPIENT IS CONFIGURED');
+    expect(shouted).toContain('ONBOARDING_ALERT_EMAIL');
+  });
+
+  it('still emits the machine-readable line when email is unconfigured', async () => {
+    mockScan.mockResolvedValue({ ...emptyScan, opened: [episode()] });
+
+    await runOnce();
+
+    const logged = errSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logged).toContain('[onboarding-silence] ALERT');
+    expect(logged).toContain('user=newcomer');
+    expect(logged).toContain('delivery=log-only');
+  });
+
+  it('does not mark an episode alerted when the send throws', async () => {
+    process.env.ONBOARDING_ALERT_EMAIL = 'ops@example.com';
+    mockScan.mockResolvedValue({ ...emptyScan, opened: [episode()] });
+    mockSendEmail.mockRejectedValue(new Error('smtp down'));
+
+    const r = await runOnce();
+
+    expect(r.delivered).toBe(0);
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when nothing is stranded', async () => {
+    process.env.ONBOARDING_ALERT_EMAIL = 'ops@example.com';
+    mockScan.mockResolvedValue(emptyScan);
+
+    const r = await runOnce();
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(r.delivered).toBe(0);
+    expect(r.unconfigured).toBe(false);
+  });
+});
+
+describe('diagnose', () => {
+  // This is the whole reason the snapshot is taken before the 30-minute GC:
+  // these two point at opposite fixes and are indistinguishable afterwards.
+  it('names a producer bug when nothing was ever enqueued', () => {
+    expect(diagnose(episode())).toBe('never-enqueued');
+  });
+
+  it('names a runtime bug when the queue had work and nothing answered', () => {
+    expect(diagnose(episode({
+      eventSnapshot: {
+        total: 1, byStatus: { pending: 1 }, targets: ['scout/u1'], noneEnqueued: false,
+      },
+    }))).toBe('enqueued-never-answered');
+  });
+
+  it('distinguishes an acked event that produced no reply', () => {
+    expect(diagnose(episode({
+      eventSnapshot: {
+        total: 1, byStatus: { acked: 1 }, targets: ['scout/u1'], noneEnqueued: false,
+      },
+    }))).toBe('acked-but-no-reply');
+  });
+
+  it('reports unknown rather than guessing when no snapshot survives', () => {
+    expect(diagnose(episode({ eventSnapshot: undefined }))).toBe('unknown');
+  });
+});

--- a/backend/__tests__/unit/services/onboardingAlertService.test.js
+++ b/backend/__tests__/unit/services/onboardingAlertService.test.js
@@ -38,7 +38,7 @@ const episode = (over = {}) => ({
   accountAgeMinutes: 12,
   messageCount: 2,
   eventSnapshot: {
-    total: 0, byStatus: {}, targets: [], noneEnqueued: true,
+    total: 0, byStatus: {}, targets: [], noneEnqueued: true, runsStarted: 0,
   },
   ...over,
 });
@@ -155,17 +155,25 @@ describe('diagnose', () => {
   it('names a runtime bug when the queue had work and nothing answered', () => {
     expect(diagnose(episode({
       eventSnapshot: {
-        total: 1, byStatus: { pending: 1 }, targets: ['scout/u1'], noneEnqueued: false,
+        total: 1, byStatus: { pending: 1 }, targets: ['scout/u1'], noneEnqueued: false, runsStarted: 0,
       },
     }))).toBe('enqueued-never-answered');
   });
 
-  it('distinguishes an acked event that produced no reply', () => {
-    expect(diagnose(episode({
+  // An acked event with no reply is NOT one fault, and collapsing the two
+  // would report a declined-at-cap runtime as a broken one. ADR-022 D5 makes
+  // at-cap more common, so the bucket would get less accurate over time.
+  it('separates "acked but never ran" from "ran and stayed silent"', () => {
+    const acked = (runsStarted) => episode({
       eventSnapshot: {
-        total: 1, byStatus: { acked: 1 }, targets: ['scout/u1'], noneEnqueued: false,
+        total: 1, byStatus: { acked: 1 }, targets: ['scout/u1'], noneEnqueued: false, runsStarted,
       },
-    }))).toBe('acked-but-no-reply');
+    });
+    // No AgentRun row: declined at the daily cap (which returns `succeeded`
+    // before writing one) or lost the claim to a peer. Never started.
+    expect(diagnose(acked(0))).toBe('acked-never-ran');
+    // A run exists: it started and produced nothing. Different investigation.
+    expect(diagnose(acked(2))).toBe('ran-but-silent');
   });
 
   it('reports unknown rather than guessing when no snapshot survives', () => {

--- a/backend/__tests__/unit/services/onboardingSilenceService.test.js
+++ b/backend/__tests__/unit/services/onboardingSilenceService.test.js
@@ -29,6 +29,9 @@ jest.mock('../../../models/Pod', () => ({ find: (...a) => mockPodFind(...a) }));
 const mockEventFind = jest.fn();
 jest.mock('../../../models/AgentEvent', () => ({ find: (...a) => mockEventFind(...a) }));
 
+const mockRunCount = jest.fn();
+jest.mock('../../../models/AgentRun', () => ({ countDocuments: (...a) => mockRunCount(...a) }));
+
 const mockEpisodeFindOne = jest.fn();
 const mockEpisodeFind = jest.fn();
 const mockEpisodeCreate = jest.fn();
@@ -67,7 +70,9 @@ const setup = ({
   openEpisodes = [],
   existingEpisode = null,
   events = [],
+  runsStarted = 0,
 } = {}) => {
+  mockRunCount.mockResolvedValue(runsStarted);
   mockEpisodeFind.mockReturnValue(limitLean(openEpisodes));
   mockEpisodeFindOne.mockResolvedValue(existingEpisode);
   mockEpisodeCreate.mockImplementation((doc) => Promise.resolve({ _id: 'ep1', ...doc }));
@@ -246,6 +251,21 @@ describe('onboardingSilenceService.scan', () => {
       targets: ['scout/u1'],
       noneEnqueued: false,
     });
+  });
+
+  it('counts AgentRuns in the same window, so "acked" can be split by whether anything ran', async () => {
+    setup({
+      events: [{ agentName: 'scout', instanceId: 'u1', status: 'acked', type: 'chat.mention' }],
+      runsStarted: 3,
+    });
+    const result = await scan({ now: NOW });
+
+    expect(result.opened[0].eventSnapshot.runsStarted).toBe(3);
+    // Bounded to the episode window — a lifetime count would call every pod
+    // with any history "it ran".
+    const [filter] = mockRunCount.mock.calls[0];
+    expect(filter.startedAt.$gte).toEqual(TYPED_AT);
+    expect(filter.startedAt.$lte).toEqual(NOW);
   });
 
   it('records noneEnqueued when the write path never reached the queue', async () => {

--- a/backend/__tests__/unit/services/onboardingSilenceService.test.js
+++ b/backend/__tests__/unit/services/onboardingSilenceService.test.js
@@ -1,0 +1,326 @@
+// Onboarding-silence detection (W4 item 2).
+//
+// The load-bearing behaviours, each of which is a decision someone made and
+// could silently undo:
+//   - fires only past the 15-minute threshold (10-min requeue must get a shot)
+//   - only a BOT reply counts; a human answering is a different outcome
+//   - the pod must hold an ACTIVE AgentInstallation, not just an agent member
+//   - one episode per (user, pod), no matter how many times they typed
+//   - re-scanning covered ground is a no-op, because passes overlap by design
+//   - the AgentEvent snapshot is taken at fire time, before the 30-min GC
+
+const MINUTE = 60 * 1000;
+const DAY = 24 * 60 * MINUTE;
+
+const mockPgQuery = jest.fn();
+jest.mock('../../../config/db-pg', () => ({ pool: { query: (...a) => mockPgQuery(...a) } }));
+
+const mockUserFind = jest.fn();
+jest.mock('../../../models/User', () => ({ find: (...a) => mockUserFind(...a) }));
+
+const mockInstallFind = jest.fn();
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { find: (...a) => mockInstallFind(...a) },
+}));
+
+const mockPodFind = jest.fn();
+jest.mock('../../../models/Pod', () => ({ find: (...a) => mockPodFind(...a) }));
+
+const mockEventFind = jest.fn();
+jest.mock('../../../models/AgentEvent', () => ({ find: (...a) => mockEventFind(...a) }));
+
+const mockEpisodeFindOne = jest.fn();
+const mockEpisodeFind = jest.fn();
+const mockEpisodeCreate = jest.fn();
+const mockEpisodeUpdateOne = jest.fn();
+jest.mock('../../../models/OnboardingSilenceEpisode', () => ({
+  findOne: (...a) => mockEpisodeFindOne(...a),
+  find: (...a) => mockEpisodeFind(...a),
+  create: (...a) => mockEpisodeCreate(...a),
+  updateOne: (...a) => mockEpisodeUpdateOne(...a),
+}));
+
+const { scan } = require('../../../services/onboardingSilenceService');
+
+// A real ObjectId-shaped pod id — the service converts pod ids for the Mongo
+// side and skips anything that is not a valid ObjectId.
+const POD = '6a692a1be833c668acdb84cf';
+const OTHER_POD = '6a692a1be833c668acdb84ce';
+const NEWCOMER = '6a7f155f47c4fb09e8a9d4fa';
+const SCOUT = '6a5fe696306155f677c26d6f';
+const HUMAN_PEER = '6a5fe696306155f677c26d70';
+
+const NOW = new Date('2026-08-15T12:00:00Z');
+/** Typed 30 min ago: comfortably past the 15-minute judging threshold. */
+const TYPED_AT = new Date(NOW.getTime() - 30 * MINUTE);
+
+const lean = (rows) => ({ select: () => ({ lean: () => Promise.resolve(rows) }) });
+const limitLean = (rows) => ({ limit: () => ({ lean: () => Promise.resolve(rows) }) });
+
+const setup = ({
+  messages = [{
+    id: 900, pod_id: POD, user_id: NEWCOMER, created_at: TYPED_AT,
+  }],
+  podMessages = null,
+  installs = [{ podId: POD }],
+  bots = [{ _id: SCOUT }],
+  openEpisodes = [],
+  existingEpisode = null,
+  events = [],
+} = {}) => {
+  mockEpisodeFind.mockReturnValue(limitLean(openEpisodes));
+  mockEpisodeFindOne.mockResolvedValue(existingEpisode);
+  mockEpisodeCreate.mockImplementation((doc) => Promise.resolve({ _id: 'ep1', ...doc }));
+  mockEpisodeUpdateOne.mockResolvedValue({ modifiedCount: 1 });
+
+  mockUserFind.mockImplementation((filter) => {
+    // The newcomer lookup is keyed on createdAt; the bot lookup on _id $in.
+    if (filter && filter.createdAt) {
+      return lean([{ _id: NEWCOMER, username: 'newcomer', createdAt: new Date(NOW.getTime() - DAY) }]);
+    }
+    return lean(bots);
+  });
+  mockInstallFind.mockReturnValue(lean(installs));
+  mockPodFind.mockReturnValue(lean([{ _id: POD, name: 'My Workspace' }]));
+  mockEventFind.mockReturnValue({ select: () => ({ lean: () => Promise.resolve(events) }) });
+
+  // Call 1 = the newcomer's own messages; call 2 = everything in those pods.
+  mockPgQuery.mockReset();
+  mockPgQuery
+    .mockResolvedValueOnce({ rows: messages })
+    .mockResolvedValueOnce({ rows: podMessages === null ? messages : podMessages });
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('onboardingSilenceService.scan', () => {
+  it('opens an episode when a newcomer typed and nothing answered', async () => {
+    setup();
+    const result = await scan({ now: NOW });
+
+    expect(result.opened).toHaveLength(1);
+    expect(result.opened[0]).toMatchObject({
+      userId: NEWCOMER, podId: POD, podName: 'My Workspace', messageCount: 1,
+    });
+    expect(mockEpisodeCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire on a message younger than the threshold', async () => {
+    // The judging window is [now-lookback, now-threshold]. A message typed 5
+    // minutes ago is outside it, so PG never returns it — assert the bound we
+    // send to PG rather than re-implementing the filter in the test.
+    setup();
+    await scan({ now: NOW, thresholdMinutes: 15 });
+
+    const [, params] = mockPgQuery.mock.calls[0];
+    const judgeBefore = params[2];
+    expect(NOW.getTime() - judgeBefore.getTime()).toBe(15 * MINUTE);
+  });
+
+  it('counts a bot reply inside the window as answered', async () => {
+    setup({
+      podMessages: [
+        {
+          id: 900, pod_id: POD, user_id: NEWCOMER, created_at: TYPED_AT, 
+        },
+        {
+          id: 901, pod_id: POD, user_id: SCOUT, created_at: new Date(TYPED_AT.getTime() + 5 * MINUTE),
+        },
+      ],
+    });
+    const result = await scan({ now: NOW });
+
+    expect(result.opened).toHaveLength(0);
+    expect(mockEpisodeCreate).not.toHaveBeenCalled();
+  });
+
+  it('does NOT count a human reply as answered — that is a different outcome', async () => {
+    setup({
+      podMessages: [
+        {
+          id: 900, pod_id: POD, user_id: NEWCOMER, created_at: TYPED_AT, 
+        },
+        {
+          id: 901, pod_id: POD, user_id: HUMAN_PEER, created_at: new Date(TYPED_AT.getTime() + 2 * MINUTE),
+        },
+      ],
+      bots: [{ _id: SCOUT }], // HUMAN_PEER is deliberately not in the bot set
+    });
+    const result = await scan({ now: NOW });
+
+    expect(result.opened).toHaveLength(1);
+  });
+
+  it('does not count a bot reply that lands after the threshold', async () => {
+    setup({
+      podMessages: [
+        {
+          id: 900, pod_id: POD, user_id: NEWCOMER, created_at: TYPED_AT, 
+        },
+        {
+          id: 901, pod_id: POD, user_id: SCOUT, created_at: new Date(TYPED_AT.getTime() + 20 * MINUTE),
+        },
+      ],
+    });
+    const result = await scan({ now: NOW, thresholdMinutes: 15 });
+
+    expect(result.opened).toHaveLength(1);
+  });
+
+  it('skips pods with no active AgentInstallation — nothing there could answer', async () => {
+    setup({ installs: [] });
+    const result = await scan({ now: NOW });
+
+    expect(result.opened).toHaveLength(0);
+    expect(result.skippedNoAgent).toBe(1);
+  });
+
+  it('gates on an ACTIVE installation, not on pod membership', async () => {
+    setup();
+    await scan({ now: NOW });
+
+    const [filter] = mockInstallFind.mock.calls[0];
+    expect(filter.status).toBe('active');
+  });
+
+  it('absorbs a second silent message into the open episode instead of opening another', async () => {
+    setup({
+      existingEpisode: {
+        _id: 'ep1', firstTypedAt: TYPED_AT, firstMessageId: '900', status: 'open',
+      },
+      messages: [{
+        id: 901, pod_id: POD, user_id: NEWCOMER, created_at: new Date(TYPED_AT.getTime() + MINUTE),
+      }],
+    });
+    const result = await scan({ now: NOW });
+
+    expect(result.opened).toHaveLength(0);
+    expect(result.updated).toBe(1);
+    expect(mockEpisodeCreate).not.toHaveBeenCalled();
+  });
+
+  it('guards the absorb with a monotone watermark so overlapping passes cannot double-count', async () => {
+    setup({
+      existingEpisode: {
+        _id: 'ep1', firstTypedAt: TYPED_AT, firstMessageId: '900', status: 'open',
+      },
+      messages: [{
+        id: 901, pod_id: POD, user_id: NEWCOMER, created_at: new Date(TYPED_AT.getTime() + MINUTE),
+      }],
+    });
+    await scan({ now: NOW });
+
+    const [filter, update] = mockEpisodeUpdateOne.mock.calls[0];
+    // The replay-protection has to be IN the query, not in JS before it.
+    expect(filter.$or).toEqual(expect.arrayContaining([
+      { lastAbsorbedAt: { $lt: new Date(TYPED_AT.getTime() + MINUTE) } },
+    ]));
+    expect(filter.firstMessageId).toEqual({ $ne: '901' });
+    expect(update.$inc).toEqual({ messageCount: 1 });
+  });
+
+  it('treats a duplicate-key race as "already open" rather than as a failure', async () => {
+    setup();
+    const dup = Object.assign(new Error('E11000'), { code: 11000 });
+    mockEpisodeCreate.mockRejectedValue(dup);
+
+    await expect(scan({ now: NOW })).resolves.toMatchObject({ opened: [] });
+  });
+
+  it('snapshots the agent-event queue at fire time', async () => {
+    setup({
+      events: [
+        {
+          agentName: 'scout', instanceId: 'u1', status: 'pending', type: 'chat.mention', 
+        },
+        {
+          agentName: 'scout', instanceId: 'u1', status: 'delivered', type: 'chat.mention', 
+        },
+      ],
+    });
+    const result = await scan({ now: NOW });
+
+    expect(result.opened[0].eventSnapshot).toMatchObject({
+      total: 2,
+      byStatus: { pending: 1, delivered: 1 },
+      targets: ['scout/u1'],
+      noneEnqueued: false,
+    });
+  });
+
+  it('records noneEnqueued when the write path never reached the queue', async () => {
+    setup({ events: [] });
+    const result = await scan({ now: NOW });
+
+    expect(result.opened[0].eventSnapshot.noneEnqueued).toBe(true);
+  });
+
+  it('only considers accounts inside the onboarding window', async () => {
+    setup();
+    await scan({ now: NOW, onboardingWindowDays: 7 });
+
+    const [filter] = mockUserFind.mock.calls[0];
+    expect(NOW.getTime() - filter.createdAt.$gte.getTime()).toBe(7 * DAY);
+    // And it must exclude bots, or agents chatting to each other look like
+    // stranded newcomers.
+    expect(filter.isBot).toEqual({ $ne: true });
+  });
+
+  it('resolves an open episode a bot has since answered, recording the lag', async () => {
+    setup({
+      openEpisodes: [{
+        _id: 'ep9', userId: NEWCOMER, podId: OTHER_POD, firstTypedAt: TYPED_AT, status: 'open',
+      }],
+      messages: [],
+    });
+    // resolveOpenEpisodes queries PG first, before the two scan queries.
+    mockPgQuery.mockReset();
+    mockPgQuery
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 950, pod_id: OTHER_POD, user_id: SCOUT, created_at: new Date(TYPED_AT.getTime() + 90 * 1000),
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await scan({ now: NOW });
+
+    expect(result.resolved).toEqual([
+      { episodeId: 'ep9', outcome: 'answered', lagSeconds: 90 },
+    ]);
+  });
+
+  it('stops polling episodes older than the resolution window instead of re-querying forever', async () => {
+    // An episode nobody ever answered never closes on its own, and resolution
+    // costs one PG query per open episode per pass. Unbounded, the cron gets
+    // more expensive the more users we failed — exactly backwards.
+    setup({ messages: [] });
+    await scan({ now: NOW });
+
+    const [filter] = mockEpisodeFind.mock.calls[0];
+    expect(filter.status).toBe('open');
+    expect(NOW.getTime() - filter.firstTypedAt.$gte.getTime()).toBe(7 * DAY);
+  });
+
+  it('classifies a human-only rescue separately from the platform answering', async () => {
+    setup({
+      openEpisodes: [{
+        _id: 'ep9', userId: NEWCOMER, podId: OTHER_POD, firstTypedAt: TYPED_AT, status: 'open',
+      }],
+      bots: [], // nobody in the reply set is a bot
+      messages: [],
+    });
+    mockPgQuery.mockReset();
+    mockPgQuery
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 950, pod_id: OTHER_POD, user_id: HUMAN_PEER, created_at: new Date(TYPED_AT.getTime() + 3600 * 1000),
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await scan({ now: NOW });
+
+    expect(result.resolved[0].outcome).toBe('human-rescued');
+  });
+});

--- a/backend/models/OnboardingSilenceEpisode.ts
+++ b/backend/models/OnboardingSilenceEpisode.ts
@@ -38,6 +38,24 @@ export interface IAgentEventSnapshot {
   targets: string[];
   /** True when nothing was enqueued at all — the producer-bug fingerprint. */
   noneEnqueued: boolean;
+  /**
+   * AgentRuns started in this pod during the same window.
+   *
+   * Without it, "acked and no reply" is one label over at least three
+   * different faults: the runtime declined at its daily cap (which returns
+   * `status:'succeeded'` at nativeRuntimeService:634, BEFORE AgentRun.create
+   * at :695, so there is no run row), another agent won the claim and this
+   * seat stood down, or it genuinely ran and produced nothing. The first two
+   * are "we never ran"; the third is "we ran and stayed silent". Opposite
+   * investigations, and a run count separates them.
+   *
+   * It does NOT separate at-cap from claim-lost — both have zero runs.
+   * `message_claims.claimed_by` is the discriminator for that, and is
+   * deliberately not read here: claim-lost is routine in a multi-agent pod
+   * and the alert would want to re-attribute the failure to the claim holder,
+   * which is a bigger change than a label.
+   */
+  runsStarted: number;
 }
 
 export interface IOnboardingSilenceEpisode extends Document {
@@ -97,6 +115,7 @@ const OnboardingSilenceEpisodeSchema = new Schema<IOnboardingSilenceEpisode>(
         byStatus: { type: Object, default: {} },
         targets: { type: [String], default: [] },
         noneEnqueued: { type: Boolean, default: true },
+        runsStarted: { type: Number, default: 0 },
       }, { _id: false }),
     },
     resolvedAt: { type: Date },

--- a/backend/models/OnboardingSilenceEpisode.ts
+++ b/backend/models/OnboardingSilenceEpisode.ts
@@ -1,0 +1,135 @@
+import mongoose, { Document, Model, Schema, Types } from 'mongoose';
+
+/**
+ * A newcomer typed into a room that could have answered, and nothing did.
+ *
+ * This is the record behind the "signed up, typed, got no reply" alert (W4
+ * item 2). It exists as its own collection for the same reason
+ * PodMemberFirstMessage does: the fact being recorded is a one-time lifecycle
+ * event, and anything stored on a row that join/leave or the dual-DB sync
+ * rewrites would replay the alert at someone already alerted about.
+ *
+ * EPISODE, not message. A user typing four times into a dead room is one
+ * failure, not four. An episode opens on the first unanswered message in a
+ * (user, pod) pair and stays open — absorbing further silent messages into
+ * `messageCount` — until something answers. Only then can a new one open. The
+ * partial unique index below IS that guarantee; it is not advisory.
+ *
+ * WHY THE EVENT SNAPSHOT IS NOT OPTIONAL. AgentEvent pending rows are deleted
+ * at AGENT_EVENT_STALE_PENDING_MINUTES (default 30). The alert fires at 15.
+ * In the 15 minutes between, and never again after, the queue can still
+ * distinguish two failures that look identical afterwards and need opposite
+ * fixes:
+ *
+ *   - nothing was ever enqueued  → a producer bug (the write path skipped
+ *     enqueueMentions — see pgMessageController, which does exactly this)
+ *   - enqueued and never acked   → a runtime bug (the agent never ran, or ran
+ *     and died)
+ *
+ * Capture it at fire time or the alert is a report that something is wrong
+ * with no way left to say what. Calibration: pod-architect, 2026-08-15.
+ */
+export interface IAgentEventSnapshot {
+  /** AgentEvents in this pod between the message and the alert. */
+  total: number;
+  /** Per-status counts, e.g. { pending: 1, delivered: 2 }. */
+  byStatus: Record<string, number>;
+  /** Seats the queue tried to reach, as `agentName/instanceId`. */
+  targets: string[];
+  /** True when nothing was enqueued at all — the producer-bug fingerprint. */
+  noneEnqueued: boolean;
+}
+
+export interface IOnboardingSilenceEpisode extends Document {
+  userId: Types.ObjectId;
+  username?: string;
+  podId: string;
+  podName?: string;
+  /** PG `messages.id` of the first unanswered message (integer, held as text). */
+  firstMessageId: string;
+  firstTypedAt: Date;
+  /** How far into this account's life the silence happened. */
+  accountAgeMinutes: number;
+  messageCount: number;
+  /**
+   * Watermark for absorbing repeat messages into an open episode. Passes
+   * overlap by design, so `messageCount` must only ever move forward: an
+   * absorb is guarded on `lastAbsorbedAt < thisMessage`, which makes
+   * re-scanning covered ground a no-op instead of an inflating counter.
+   */
+  lastAbsorbedAt?: Date;
+  lastAbsorbedMessageId?: string;
+  status: 'open' | 'resolved';
+  /** Only meaningful once resolved; `human-rescued` is a distinct outcome. */
+  outcome?: 'answered' | 'human-rescued';
+  detectedAt: Date;
+  alertSentAt?: Date;
+  /** Set when the hourly collapse rule suppressed the individual delivery. */
+  collapsedIntoRollup: boolean;
+  eventSnapshot?: IAgentEventSnapshot;
+  resolvedAt?: Date;
+  resolutionLagSeconds?: number;
+}
+
+const OnboardingSilenceEpisodeSchema = new Schema<IOnboardingSilenceEpisode>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    username: { type: String },
+    // Held as a string because pods are addressed as strings across the
+    // dual-DB boundary: PG `messages.pod_id` is varchar, Mongo `_id` is an
+    // ObjectId, and this collection is joined against both.
+    podId: { type: String, required: true },
+    podName: { type: String },
+    firstMessageId: { type: String, required: true },
+    firstTypedAt: { type: Date, required: true },
+    accountAgeMinutes: { type: Number, required: true },
+    messageCount: { type: Number, default: 1 },
+    lastAbsorbedAt: { type: Date },
+    lastAbsorbedMessageId: { type: String },
+    status: { type: String, enum: ['open', 'resolved'], default: 'open' },
+    outcome: { type: String, enum: ['answered', 'human-rescued'] },
+    detectedAt: { type: Date, required: true },
+    alertSentAt: { type: Date },
+    collapsedIntoRollup: { type: Boolean, default: false },
+    eventSnapshot: {
+      type: new Schema<IAgentEventSnapshot>({
+        total: { type: Number, default: 0 },
+        byStatus: { type: Object, default: {} },
+        targets: { type: [String], default: [] },
+        noneEnqueued: { type: Boolean, default: true },
+      }, { _id: false }),
+    },
+    resolvedAt: { type: Date },
+    resolutionLagSeconds: { type: Number },
+  },
+  { timestamps: true, versionKey: false },
+);
+
+// One OPEN episode per (user, pod) — the no-duplicate-alert guarantee, held in
+// the database rather than in scan logic, because two overlapping scan passes
+// (a slow pass plus the next cron tick) would both miss the read and both
+// insert. The loser takes a duplicate-key error, which the service treats as
+// "already open" rather than as a failure.
+OnboardingSilenceEpisodeSchema.index(
+  { userId: 1, podId: 1 },
+  { unique: true, partialFilterExpression: { status: 'open' } },
+);
+// The admin read path: "what happened since <date>", newest first.
+OnboardingSilenceEpisodeSchema.index({ status: 1, detectedAt: -1 });
+// The resolution sweep, which runs every 5 minutes and is bounded by
+// RESOLUTION_WINDOW_DAYS. Keyed on firstTypedAt rather than detectedAt because
+// the window it asks about is "how long since the person spoke", not "how long
+// since we noticed".
+OnboardingSilenceEpisodeSchema.index({ status: 1, firstTypedAt: 1 });
+
+const OnboardingSilenceEpisode: Model<IOnboardingSilenceEpisode> =
+  (mongoose.models.OnboardingSilenceEpisode as Model<IOnboardingSilenceEpisode>)
+  || mongoose.model<IOnboardingSilenceEpisode>(
+    'OnboardingSilenceEpisode',
+    OnboardingSilenceEpisodeSchema,
+  );
+
+export default OnboardingSilenceEpisode;
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/routes/admin/analytics.ts
+++ b/backend/routes/admin/analytics.ts
@@ -35,29 +35,12 @@ const adminReadLimiter = rateLimit({
 const DAY_MS = 24 * 60 * 60 * 1000;
 const dayKey = (d: Date) => d.toISOString().slice(0, 10);
 
-// Who counts as a human, and why it takes TWO signals.
-//
-// Not every bot User row carries botMetadata.agentName. Rows created by the
-// gateway bridge, the summarizer, and several openclaw install paths set
-// botMetadata WITHOUT an agentName key. A filter keyed only on agentName
-// therefore passes them as humans — on the dev instance that was 8 rows
-// (clawdbot-bridge, commonly-summarizer, openclaw-inst-*, socialpulse-*),
-// inflating totalUsers/DAU/WAU/signups ~10% and deflating every funnel rate,
-// because a bot in the denominator can never convert.
-//
-// These two are exact logical complements (De Morgan) — keep them that way.
-// Anything counted as a human here must NOT be counted as a bot there, or
-// the "distinct human posters" metric double-subtracts.
-const HUMAN_FILTER = {
-  isBot: { $ne: true },
-  'botMetadata.agentName': { $exists: false },
-};
-const BOT_FILTER = {
-  $or: [
-    { isBot: true },
-    { 'botMetadata.agentName': { $exists: true } },
-  ],
-};
+// Who counts as a human takes TWO signals, and the definition now lives in
+// services/userClassification.ts because the onboarding-silence alert needs
+// the identical split. It used to be inline here; a second copy of a rule this
+// subtle is how it drifts.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { HUMAN_FILTER, BOT_FILTER } = require('../../services/userClassification');
 
 // Distinct PG user_ids with at least one message, within the candidate set.
 // Isolated so tests can run without a live PostgreSQL (mocked module).
@@ -259,6 +242,78 @@ router.get('/lifecycle', adminReadLimiter, auth, adminAuth, async (_req: any, re
   } catch (err: any) {
     console.error('Lifecycle analytics failed:', err.message);
     return res.status(500).json({ message: 'Failed to compute lifecycle stats' });
+  }
+});
+
+// GET /api/admin/analytics/silence?days=14
+// Newcomers who typed into a room that could have answered, and got nothing.
+//
+// The cron alert (services/onboardingAlertService.ts) pushes; this pulls. Both
+// exist because they fail differently: email needs configuration and can
+// bounce, and an alert you can only receive is one you cannot go back and
+// check. This endpoint is also what makes "did the fix work" answerable
+// without re-reading production transcripts by hand.
+router.get('/silence', adminReadLimiter, auth, adminAuth, async (req: any, res: any) => {
+  try {
+    const days = Math.max(1, Math.min(90, parseInt(req.query.days, 10) || 14));
+    const since = new Date(Date.now() - days * DAY_MS);
+    // eslint-disable-next-line global-require
+    const OnboardingSilenceEpisode = require('../../models/OnboardingSilenceEpisode');
+    // eslint-disable-next-line global-require
+    const { SILENCE_THRESHOLD_MINUTES } = require('../../services/onboardingSilenceService');
+    // eslint-disable-next-line global-require
+    const { diagnose } = require('../../services/onboardingAlertService');
+
+    const episodes = await OnboardingSilenceEpisode.find({ detectedAt: { $gte: since } })
+      .sort({ detectedAt: -1 }).limit(500).lean();
+
+    const shaped = episodes.map((e: any) => ({
+      id: String(e._id),
+      user: e.username || String(e.userId),
+      userId: String(e.userId),
+      pod: e.podName || e.podId,
+      podId: e.podId,
+      firstTypedAt: e.firstTypedAt,
+      accountAgeMinutes: e.accountAgeMinutes,
+      messageCount: e.messageCount,
+      status: e.status,
+      outcome: e.outcome || null,
+      resolutionLagSeconds: e.resolutionLagSeconds ?? null,
+      alerted: Boolean(e.alertSentAt),
+      collapsedIntoRollup: Boolean(e.collapsedIntoRollup),
+      diagnosis: diagnose({
+        firstTypedAt: e.firstTypedAt, eventSnapshot: e.eventSnapshot,
+      } as any),
+      eventSnapshot: e.eventSnapshot || null,
+    }));
+
+    const open = shaped.filter((e: any) => e.status === 'open');
+    const byDiagnosis: Record<string, number> = {};
+    for (const e of shaped) byDiagnosis[e.diagnosis] = (byDiagnosis[e.diagnosis] || 0) + 1;
+
+    return res.json({
+      days,
+      since: since.toISOString(),
+      thresholdMinutes: SILENCE_THRESHOLD_MINUTES,
+      alertRecipientConfigured: Boolean((process.env.ONBOARDING_ALERT_EMAIL || '').trim()),
+      totals: {
+        episodes: shaped.length,
+        open: open.length,
+        resolved: shaped.length - open.length,
+        humanRescued: shaped.filter((e: any) => e.outcome === 'human-rescued').length,
+        byDiagnosis,
+      },
+      episodes: shaped,
+      notes: [
+        'an episode is one (user, pod) run of silence, not one message',
+        'only a bot author counts as a reply; a human answering is recorded as human-rescued',
+        'pods without an active AgentInstallation are never counted — nothing there could answer',
+        'diagnosis is only meaningful when captured at fire time; agent events are GC-ed at 30 min',
+      ],
+    });
+  } catch (err: any) {
+    console.error('Silence analytics failed:', err.message);
+    return res.status(500).json({ message: 'Failed to compute silence episodes' });
   }
 });
 

--- a/backend/services/onboardingAlertService.ts
+++ b/backend/services/onboardingAlertService.ts
@@ -1,0 +1,188 @@
+import OnboardingSilenceEpisode from '../models/OnboardingSilenceEpisode';
+import {
+  scan, ROLLUP_COLLAPSE_THRESHOLD, SILENCE_THRESHOLD_MINUTES, SilenceEpisodeSummary, ScanResult,
+} from './onboardingSilenceService';
+
+/**
+ * Delivery for the onboarding-silence alert.
+ *
+ * Split from detection because they fail for different reasons and only one of
+ * them is allowed to be quiet: a detection bug means we do not know onboarding
+ * broke, a delivery bug means we knew and did not say. Keeping them in one
+ * function would have let an SMTP outage look identical to a healthy funnel.
+ *
+ * THIS SERVICE REFUSES TO BE SILENTLY INERT. If no recipient is configured it
+ * says so, loudly, on every pass that had something to report — rather than
+ * computing episodes correctly and dropping them on the floor with a success
+ * return. Three of the eight defects found on 2026-08-14 were exactly that
+ * shape (an at-cap decline returning `succeeded`, a claim that swallowed a
+ * message, a summarizer failing on a cron for a month), and an alerting
+ * service that can be silently disabled is the worst possible place to add a
+ * fourth.
+ */
+
+const RECIPIENT = () => (process.env.ONBOARDING_ALERT_EMAIL || '').trim();
+const ROLLING_WINDOW_MS = 60 * 60 * 1000;
+
+/**
+ * Machine-readable, one line per episode, always emitted.
+ *
+ * The email needs configuration and can bounce; this cannot. It is what makes
+ * the alert greppable in `kubectl logs` and what a future log-based monitor
+ * would key on, so it stays even when email works.
+ */
+const logEpisode = (e: SilenceEpisodeSummary, delivery: string): void => {
+  const snap = e.eventSnapshot;
+  console.error(
+    '[onboarding-silence] ALERT'
+    + ` user=${e.username || e.userId}`
+    + ` userId=${e.userId}`
+    + ` pod=${e.podName || e.podId}`
+    + ` podId=${e.podId}`
+    + ` messageId=${e.firstMessageId}`
+    + ` typedAt=${e.firstTypedAt.toISOString()}`
+    + ` accountAgeMin=${e.accountAgeMinutes}`
+    + ` messages=${e.messageCount}`
+    + ` events=${snap ? snap.total : 'unknown'}`
+    + ` eventStatus=${snap ? JSON.stringify(snap.byStatus) : '{}'}`
+    + ` diagnosis=${diagnose(e)}`
+    + ` delivery=${delivery}`,
+  );
+};
+
+/**
+ * The one inference this service makes, and it is only possible before the
+ * 30-minute pending-GC deletes the evidence.
+ *
+ * `never-enqueued` and `enqueued-never-answered` need opposite fixes — a
+ * producer bug in the write path versus a runtime that did not run — and after
+ * GC both look like an empty queue. Naming it at fire time is the whole reason
+ * the snapshot is taken.
+ */
+export const diagnose = (e: SilenceEpisodeSummary): string => {
+  if (!e.eventSnapshot) return 'unknown';
+  if (e.eventSnapshot.noneEnqueued) return 'never-enqueued';
+  const { byStatus } = e.eventSnapshot;
+  if ((byStatus.acked || 0) > 0) return 'acked-but-no-reply';
+  if ((byStatus.failed || 0) > 0) return 'event-failed';
+  return 'enqueued-never-answered';
+};
+
+const line = (e: SilenceEpisodeSummary): string =>
+  `- ${e.username || e.userId} in "${e.podName || e.podId}"`
+  + ` — typed ${e.messageCount} message(s), first at ${e.firstTypedAt.toISOString()},`
+  + ` ${e.accountAgeMinutes} min after signing up. Diagnosis: ${diagnose(e)}.`;
+
+const sendMail = async (subject: string, text: string): Promise<boolean> => {
+  const to = RECIPIENT();
+  if (!to) return false;
+  try {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const { sendEmail } = require('./emailService');
+    await sendEmail({
+      to,
+      subject,
+      textBody: text,
+      htmlBody: `<pre style="font:14px ui-monospace,monospace">${
+        text.replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c] as string))
+      }</pre>`,
+    });
+    return true;
+  } catch (error) {
+    console.error('[onboarding-silence] delivery FAILED:', (error as Error).message);
+    return false;
+  }
+};
+
+/**
+ * Run one detection pass and deliver whatever it opened.
+ *
+ * Above ROLLUP_COLLAPSE_THRESHOLD new episodes in a rolling hour, individual
+ * mails collapse into one rollup — the base rate is ~1/day on a working
+ * system, but the failure this watches for is a regression, and a regression
+ * strands users in bulk.
+ */
+export const runOnce = async (
+  opts: Parameters<typeof scan>[0] = {},
+): Promise<ScanResult & { delivered: number; rollup: boolean; unconfigured: boolean }> => {
+  const now = opts.now || new Date();
+  const result = await scan({ ...opts, now });
+
+  if (result.resolved.length > 0) {
+    for (const r of result.resolved) {
+      console.log(
+        `[onboarding-silence] resolved episode=${r.episodeId}`
+        + ` outcome=${r.outcome} lagSeconds=${r.lagSeconds}`,
+      );
+    }
+  }
+
+  if (result.opened.length === 0) {
+    return {
+      ...result, delivered: 0, rollup: false, unconfigured: false,
+    };
+  }
+
+  // Rolling-hour pressure includes episodes opened by earlier passes, or a
+  // burst spread across ticks would slip under the threshold on every one.
+  const recentCount = await OnboardingSilenceEpisode.countDocuments({
+    detectedAt: { $gte: new Date(now.getTime() - ROLLING_WINDOW_MS) },
+  });
+  const rollup = recentCount > ROLLUP_COLLAPSE_THRESHOLD;
+
+  const configured = Boolean(RECIPIENT());
+  if (!configured) {
+    console.error(
+      `[onboarding-silence] ${result.opened.length} stranded user(s) detected and NO ALERT`
+      + ' RECIPIENT IS CONFIGURED — set ONBOARDING_ALERT_EMAIL. Episodes are recorded and'
+      + ' readable at GET /api/admin/analytics/silence, but nothing was sent.',
+    );
+  }
+
+  let delivered = 0;
+  if (rollup) {
+    const body = `${result.opened.length} new stranded user(s) in this pass;`
+      + ` ${recentCount} in the last hour. Collapsed to one alert.\n\n`
+      + `${result.opened.map(line).join('\n')}\n\n`
+      + `Threshold: ${SILENCE_THRESHOLD_MINUTES} min with no reply from any agent.\n`
+      + 'A burst usually means a regression rather than N unlucky users.';
+    if (await sendMail(
+      `[Commonly] ${result.opened.length} users typed and got no reply`, body,
+    )) delivered = 1;
+    for (const e of result.opened) logEpisode(e, rollup ? 'rollup' : 'none');
+    await OnboardingSilenceEpisode.updateMany(
+      { _id: { $in: result.opened.map((e) => e.episodeId) } },
+      { $set: { collapsedIntoRollup: true, alertSentAt: delivered ? now : undefined } },
+    );
+  } else {
+    for (const e of result.opened) {
+      const body = `${line(e)}\n\n`
+        + `They signed up, said something, and nothing answered within ${SILENCE_THRESHOLD_MINUTES} minutes.\n\n`
+        + `Pod: ${e.podName || ''} (${e.podId})\n`
+        + `Agent events in that pod after they typed: ${e.eventSnapshot?.total ?? 'unknown'}`
+        + `${e.eventSnapshot?.targets?.length ? ` -> ${e.eventSnapshot.targets.join(', ')}` : ''}\n`
+        + `Diagnosis: ${diagnose(e)}\n\n`
+        + '"never-enqueued" points at the write path (a producer bug); '
+        + '"enqueued-never-answered" points at the runtime.';
+      const ok = await sendMail(
+        `[Commonly] ${e.username || 'A new user'} typed and got no reply`, body,
+      );
+      if (ok) {
+        delivered += 1;
+        await OnboardingSilenceEpisode.updateOne(
+          { _id: e.episodeId }, { $set: { alertSentAt: now } },
+        );
+      }
+      logEpisode(e, ok ? 'email' : 'log-only');
+    }
+  }
+
+  return {
+    ...result, delivered, rollup, unconfigured: !configured,
+  };
+};
+
+export default { runOnce, diagnose };
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/services/onboardingAlertService.ts
+++ b/backend/services/onboardingAlertService.ts
@@ -62,8 +62,17 @@ const logEpisode = (e: SilenceEpisodeSummary, delivery: string): void => {
 export const diagnose = (e: SilenceEpisodeSummary): string => {
   if (!e.eventSnapshot) return 'unknown';
   if (e.eventSnapshot.noneEnqueued) return 'never-enqueued';
-  const { byStatus } = e.eventSnapshot;
-  if ((byStatus.acked || 0) > 0) return 'acked-but-no-reply';
+  const { byStatus, runsStarted } = e.eventSnapshot;
+  if ((byStatus.acked || 0) > 0) {
+    // "Acked and no reply" is not one fault. With no AgentRun the runtime
+    // never started: it declined at its daily cap (which returns
+    // `succeeded` before writing a run row) or another agent won the claim
+    // and this seat stood down. With a run, it started and produced nothing
+    // — a different investigation entirely. Reporting both as one label
+    // would make the at-cap case read as a runtime failure, and ADR-022 D5
+    // makes at-cap more common rather than less.
+    return (runsStarted || 0) > 0 ? 'ran-but-silent' : 'acked-never-ran';
+  }
   if ((byStatus.failed || 0) > 0) return 'event-failed';
   return 'enqueued-never-answered';
 };

--- a/backend/services/onboardingSilenceService.ts
+++ b/backend/services/onboardingSilenceService.ts
@@ -159,16 +159,26 @@ export const snapshotAgentEvents = async (
   until: Date,
 ): Promise<IAgentEventSnapshot> => {
   const empty: IAgentEventSnapshot = {
-    total: 0, byStatus: {}, targets: [], noneEnqueued: true,
+    total: 0, byStatus: {}, targets: [], noneEnqueued: true, runsStarted: 0,
   };
   if (!mongoose.Types.ObjectId.isValid(podId)) return empty;
   try {
     // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
     const AgentEvent = require('../models/AgentEvent');
-    const rows = await AgentEvent.find({
-      podId: new mongoose.Types.ObjectId(podId),
-      createdAt: { $gte: since, $lte: until },
-    }).select('agentName instanceId status type').lean();
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const AgentRun = require('../models/AgentRun');
+    const objectId = new mongoose.Types.ObjectId(podId);
+
+    const [rows, runsStarted] = await Promise.all([
+      AgentEvent.find({
+        podId: objectId,
+        createdAt: { $gte: since, $lte: until },
+      }).select('agentName instanceId status type').lean(),
+      // See IAgentEventSnapshot.runsStarted: this is what separates "the
+      // runtime declined before creating a run" from "it ran and said
+      // nothing". Indexed by { podId, agentName, instanceId, startedAt }.
+      AgentRun.countDocuments({ podId: objectId, startedAt: { $gte: since, $lte: until } }),
+    ]);
 
     const byStatus: Record<string, number> = {};
     const targets = new Set<string>();
@@ -181,6 +191,7 @@ export const snapshotAgentEvents = async (
       byStatus,
       targets: [...targets],
       noneEnqueued: rows.length === 0,
+      runsStarted,
     };
   } catch (error) {
     // Evidence-gathering must never be the reason an alert fails to fire.

--- a/backend/services/onboardingSilenceService.ts
+++ b/backend/services/onboardingSilenceService.ts
@@ -1,0 +1,455 @@
+import mongoose from 'mongoose';
+import OnboardingSilenceEpisode, { IAgentEventSnapshot } from '../models/OnboardingSilenceEpisode';
+import { HUMAN_FILTER, BOT_FILTER } from './userClassification';
+
+/**
+ * "Signed up, typed, got no reply" — the onboarding-silence alert (W4 item 2).
+ *
+ * WHAT THIS EXISTS FOR. On 2026-08-14 every onboarding defect we know about
+ * was found by a human deciding to read production transcripts: an inert
+ * honesty fix, a Map read that defeated three separate callers, a migration
+ * that would have written nothing and reported success, a summarizer failing
+ * on a cron for a month unnoticed. The fixes were real; the detection was a
+ * person choosing to look. This service is the part that does not require
+ * anyone to choose.
+ *
+ * It answers exactly one question, on a cron: did a newcomer say something in
+ * a room that could have answered, and did nothing answer?
+ *
+ * CALIBRATION (pod-architect, 2026-08-15 — against production, not intuition):
+ *
+ * - **15 minutes, wall-clock.** Derived from the queue's own constants rather
+ *   than from the observed reply spread, because the spread is a sample of a
+ *   system that mostly worked and the constants stay true when the sample
+ *   changes. AGENT_EVENT_REQUEUE_DELIVERED_MINUTES is 10, so anything under
+ *   ~12 fires inside a legitimate retry; AGENT_EVENT_STALE_PENDING_MINUTES is
+ *   30, past which the evidence is deleted along with the answer. 15 sits
+ *   between them. (Observed replies agree: every genuine one in 21 days landed
+ *   inside 107 seconds, and the next cluster was 10+ hours.)
+ *
+ * - **Not idle-gated.** "Fire only if the user has since gone idle" would be
+ *   measured by `lastActive`, which over-counts — V2PodChat polls every 60s,
+ *   so an abandoned open tab reads as presence. Idle-gating would also make
+ *   the rate incomparable across cohorts, which kills the alert's second job:
+ *   telling us whether a fix worked.
+ *
+ * - **The pod must contain >= 1 ACTIVE AgentInstallation**, not merely an
+ *   agent in `pod.members`. A member without an installation gets 403 when it
+ *   tries to post, so it was never going to answer either. This is the same
+ *   predicate the posting path itself uses, so the alert and the kernel agree
+ *   on "could anything have answered here" by construction.
+ *
+ * - **Only a bot author counts as a reply.** The claim being made is *the
+ *   platform did not answer*; a human answering is a different outcome and a
+ *   good one, and folding it in weakens the claim. It is recorded as its own
+ *   outcome (`human-rescued`) rather than discarded — at the 10h/13h latencies
+ *   seen in production it mostly says the room was being read, not that the
+ *   product worked.
+ *
+ * WHAT THIS DOES NOT DO. It does not nudge the user; that is the
+ * stalled-connect trigger (W4 item 3, ux-lead's spec), which fires on install
+ * state rather than on conversational outcome and speaks to the user rather
+ * than to us. The two are complementary: a seat whose token was never used is
+ * caught by that one before anybody types, and a Scout that breaks tonight is
+ * caught by this one, which knows nothing about tokens.
+ */
+
+const MINUTE_MS = 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Past the first requeue (10m), inside the pending-GC window (30m). */
+export const SILENCE_THRESHOLD_MINUTES = Number(
+  process.env.ONBOARDING_SILENCE_THRESHOLD_MINUTES || 15,
+);
+
+/** "Newcomer" — how long after signup a silence still counts as onboarding. */
+export const ONBOARDING_WINDOW_DAYS = Number(
+  process.env.ONBOARDING_SILENCE_WINDOW_DAYS || 7,
+);
+
+/**
+ * How far back a single pass looks for messages to judge.
+ *
+ * The cron runs far more often than this, so passes overlap heavily and a
+ * missed tick (deploy, restart, PG blip) is picked up by the next one instead
+ * of falling through the floor. Re-scanning is safe because the episode index
+ * makes opening idempotent — the same drop-proof-by-re-derivation argument
+ * ux-lead's stalled-connect spec uses to prefer a cron over a delayed event.
+ */
+export const SCAN_LOOKBACK_HOURS = Number(
+  process.env.ONBOARDING_SILENCE_LOOKBACK_HOURS || 24,
+);
+
+/**
+ * Above this many NEW episodes in a rolling hour, individual delivery collapses
+ * into one rollup.
+ *
+ * The per-incident base rate is ~1/day, measured on a system that works. The
+ * failure this alert exists to catch is a regression, and a regression strands
+ * users in bulk — which is precisely when per-incident becomes twenty pages in
+ * a minute. Cheap to add now, expensive to add during the incident that needs
+ * it.
+ */
+export const ROLLUP_COLLAPSE_THRESHOLD = Number(
+  process.env.ONBOARDING_SILENCE_ROLLUP_THRESHOLD || 5,
+);
+
+/**
+ * How long an open episode keeps being checked for a late answer.
+ *
+ * Resolution costs one PG query per open episode per pass, forever, and an
+ * episode nobody ever answered never closes on its own — so without a bound
+ * the steady-state cost of this cron grows monotonically with the number of
+ * users we failed. That is precisely backwards.
+ *
+ * Past this window an episode STAYS open rather than being auto-closed,
+ * because "open" is a true statement about it: nothing ever answered. It just
+ * stops being polled. Auto-closing would be cheaper and would also be a lie.
+ */
+export const RESOLUTION_WINDOW_DAYS = Number(
+  process.env.ONBOARDING_SILENCE_RESOLUTION_WINDOW_DAYS || 7,
+);
+
+export interface SilenceEpisodeSummary {
+  episodeId: string;
+  userId: string;
+  username?: string;
+  podId: string;
+  podName?: string;
+  firstMessageId: string;
+  firstTypedAt: Date;
+  accountAgeMinutes: number;
+  messageCount: number;
+  eventSnapshot?: IAgentEventSnapshot;
+}
+
+export interface ScanResult {
+  scannedMessages: number;
+  opened: SilenceEpisodeSummary[];
+  updated: number;
+  resolved: Array<{ episodeId: string; outcome: 'answered' | 'human-rescued'; lagSeconds: number }>;
+  skippedNoAgent: number;
+}
+
+interface PgMessageRow {
+  id: string | number;
+  pod_id: string;
+  user_id: string;
+  created_at: Date;
+}
+
+/** Isolated so tests can run without a live PostgreSQL. */
+const pgQuery = async (text: string, params: unknown[]): Promise<{ rows: PgMessageRow[] }> => {
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const { pool } = require('../config/db-pg');
+  return pool.query(text, params);
+};
+
+/**
+ * What the agent-event queue knew, at the moment we decided this was silence.
+ *
+ * MUST be captured at fire time. Pending rows are deleted at 30 minutes and
+ * the alert fires at 15, so this is the only window in which "nothing was ever
+ * enqueued" (a producer bug) can be told apart from "enqueued and never acked"
+ * (a runtime bug). Afterwards both look like an empty queue.
+ */
+export const snapshotAgentEvents = async (
+  podId: string,
+  since: Date,
+  until: Date,
+): Promise<IAgentEventSnapshot> => {
+  const empty: IAgentEventSnapshot = {
+    total: 0, byStatus: {}, targets: [], noneEnqueued: true,
+  };
+  if (!mongoose.Types.ObjectId.isValid(podId)) return empty;
+  try {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const AgentEvent = require('../models/AgentEvent');
+    const rows = await AgentEvent.find({
+      podId: new mongoose.Types.ObjectId(podId),
+      createdAt: { $gte: since, $lte: until },
+    }).select('agentName instanceId status type').lean();
+
+    const byStatus: Record<string, number> = {};
+    const targets = new Set<string>();
+    for (const r of rows as Array<Record<string, any>>) {
+      byStatus[r.status] = (byStatus[r.status] || 0) + 1;
+      targets.add(`${r.agentName}/${r.instanceId || 'default'}`);
+    }
+    return {
+      total: rows.length,
+      byStatus,
+      targets: [...targets],
+      noneEnqueued: rows.length === 0,
+    };
+  } catch (error) {
+    // Evidence-gathering must never be the reason an alert fails to fire.
+    console.warn('[onboarding-silence] event snapshot failed:', (error as Error).message);
+    return empty;
+  }
+};
+
+/**
+ * One detection pass. Safe to run concurrently with itself and safe to re-run
+ * over ground it has already covered.
+ */
+export const scan = async ({
+  now = new Date(),
+  thresholdMinutes = SILENCE_THRESHOLD_MINUTES,
+  onboardingWindowDays = ONBOARDING_WINDOW_DAYS,
+  lookbackHours = SCAN_LOOKBACK_HOURS,
+}: {
+  now?: Date;
+  thresholdMinutes?: number;
+  onboardingWindowDays?: number;
+  lookbackHours?: number;
+} = {}): Promise<ScanResult> => {
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const User = require('../models/User');
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const { AgentInstallation } = require('../models/AgentRegistry');
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const Pod = require('../models/Pod');
+
+  const result: ScanResult = {
+    scannedMessages: 0, opened: [], updated: 0, resolved: [], skippedNoAgent: 0,
+  };
+
+  const thresholdMs = thresholdMinutes * MINUTE_MS;
+  // Only messages already older than the threshold can be judged; anything
+  // newer still has time to be answered legitimately.
+  const judgeBefore = new Date(now.getTime() - thresholdMs);
+  const windowStart = new Date(now.getTime() - lookbackHours * 60 * MINUTE_MS);
+  const signupSince = new Date(now.getTime() - onboardingWindowDays * DAY_MS);
+
+  const newcomers = await User.find({ createdAt: { $gte: signupSince }, ...HUMAN_FILTER })
+    .select('_id username createdAt').lean();
+
+  await resolveOpenEpisodes({ now, result });
+
+  if (newcomers.length === 0) return result;
+
+  const byId = new Map<string, any>(newcomers.map((u: any) => [String(u._id), u]));
+  const candidateIds = [...byId.keys()];
+
+  const { rows: typed } = await pgQuery(
+    "SELECT id, pod_id, user_id, created_at FROM messages"
+    + " WHERE user_id = ANY($1) AND message_type = 'text'"
+    + ' AND created_at >= $2 AND created_at <= $3'
+    + ' ORDER BY created_at ASC',
+    [candidateIds, windowStart, judgeBefore],
+  );
+  result.scannedMessages = typed.length;
+  if (typed.length === 0) return result;
+
+  // Which of those pods could have answered at all? Active installation, not
+  // membership — a member without one 403s on post.
+  const podIds = [...new Set(typed.map((m) => String(m.pod_id)))];
+  const objectIdPods = podIds
+    .filter((p) => mongoose.Types.ObjectId.isValid(p))
+    .map((p) => new mongoose.Types.ObjectId(p));
+  const liveInstalls = await AgentInstallation.find({
+    podId: { $in: objectIdPods }, status: 'active',
+  }).select('podId').lean();
+  const podsThatCouldAnswer = new Set(
+    (liveInstalls as Array<{ podId: unknown }>).map((i) => String(i.podId)),
+  );
+
+  const eligible = typed.filter((m) => podsThatCouldAnswer.has(String(m.pod_id)));
+  result.skippedNoAgent = typed.length - eligible.length;
+  if (eligible.length === 0) return result;
+
+  // Everything said in those pods across the window, so replies can be matched
+  // in memory rather than with a query per message.
+  const eligiblePods = [...new Set(eligible.map((m) => String(m.pod_id)))];
+  const { rows: allInPods } = await pgQuery(
+    'SELECT id, pod_id, user_id, created_at FROM messages'
+    + ' WHERE pod_id = ANY($1) AND created_at >= $2 ORDER BY created_at ASC',
+    [eligiblePods, windowStart],
+  );
+
+  const authorIds = [...new Set(allInPods.map((m) => String(m.user_id)))];
+  const botIds = new Set(
+    (await User.find({ _id: { $in: authorIds }, ...BOT_FILTER }).select('_id').lean())
+      .map((u: any) => String(u._id)),
+  );
+
+  const byPod = new Map<string, PgMessageRow[]>();
+  for (const m of allInPods) {
+    const k = String(m.pod_id);
+    if (!byPod.has(k)) byPod.set(k, []);
+    byPod.get(k)!.push(m);
+  }
+
+  const podNames = new Map<string, string>(
+    (await Pod.find({ _id: { $in: eligiblePods.filter((p) => mongoose.Types.ObjectId.isValid(p)) } })
+      .select('_id name').lean() as Array<{ _id: unknown; name?: string }>)
+      .map((p) => [String(p._id), p.name || '']),
+  );
+
+  for (const m of eligible) {
+    const typedAt = new Date(m.created_at);
+    const deadline = new Date(typedAt.getTime() + thresholdMs);
+    const podMsgs = byPod.get(String(m.pod_id)) || [];
+    const answered = podMsgs.some((x) => {
+      const t = new Date(x.created_at);
+      return t > typedAt && t <= deadline
+        && String(x.user_id) !== String(m.user_id)
+        && botIds.has(String(x.user_id));
+    });
+    if (answered) continue;
+
+    const user = byId.get(String(m.user_id));
+    await openOrExtendEpisode({
+      message: m, typedAt, user, now, podName: podNames.get(String(m.pod_id)), result,
+    });
+  }
+
+  return result;
+};
+
+/**
+ * Open a new episode, or fold this message into the one already open for the
+ * same (user, pod). One stranded conversation is one failure regardless of how
+ * many times the person tried.
+ */
+const openOrExtendEpisode = async ({
+  message, typedAt, user, now, podName, result,
+}: {
+  message: PgMessageRow;
+  typedAt: Date;
+  user: any;
+  now: Date;
+  podName?: string;
+  result: ScanResult;
+}): Promise<void> => {
+  const podId = String(message.pod_id);
+  const userId = String(message.user_id);
+
+  const existing = await OnboardingSilenceEpisode.findOne({ userId, podId, status: 'open' });
+  if (existing) {
+    // Absorb, idempotently. Passes overlap by design (a 24h lookback re-run
+    // every 5 minutes), so this must be a no-op the second time it sees the
+    // same message. The monotone watermark in the FILTER is what makes it one:
+    // after the first application `lastAbsorbedAt` is no longer < typedAt, so
+    // a replay matches nothing. Doing the comparison in JS and the write
+    // separately would leave a window where two passes both increment.
+    const absorbed = await OnboardingSilenceEpisode.updateOne(
+      {
+        _id: existing._id,
+        status: 'open',
+        firstMessageId: { $ne: String(message.id) },
+        $or: [
+          { lastAbsorbedAt: { $exists: false } },
+          { lastAbsorbedAt: null },
+          { lastAbsorbedAt: { $lt: typedAt } },
+        ],
+      },
+      {
+        $inc: { messageCount: 1 },
+        $set: { lastAbsorbedMessageId: String(message.id), lastAbsorbedAt: typedAt },
+      },
+    );
+    if (absorbed.modifiedCount > 0) result.updated += 1;
+    return;
+  }
+
+  const eventSnapshot = await snapshotAgentEvents(podId, typedAt, now);
+  const accountAgeMinutes = Math.round(
+    (typedAt.getTime() - new Date(user?.createdAt || typedAt).getTime()) / MINUTE_MS,
+  );
+
+  try {
+    const created = await OnboardingSilenceEpisode.create({
+      userId,
+      username: user?.username,
+      podId,
+      podName,
+      firstMessageId: String(message.id),
+      firstTypedAt: typedAt,
+      accountAgeMinutes,
+      messageCount: 1,
+      status: 'open',
+      detectedAt: now,
+      eventSnapshot,
+    });
+    result.opened.push({
+      episodeId: String(created._id),
+      userId,
+      username: user?.username,
+      podId,
+      podName,
+      firstMessageId: String(message.id),
+      firstTypedAt: typedAt,
+      accountAgeMinutes,
+      messageCount: 1,
+      eventSnapshot,
+    });
+  } catch (error: any) {
+    // The partial unique index is the concurrency guarantee: a second pass
+    // racing this one loses here, and losing means "already open", not failure.
+    if (error?.code !== 11000) throw error;
+  }
+};
+
+/**
+ * Close episodes that have since been answered, and record which kind of
+ * answer it was. A resolved episode also re-arms the pair — the next silence
+ * for the same user in the same pod is a genuinely new failure.
+ */
+const resolveOpenEpisodes = async ({
+  now, result,
+}: { now: Date; result: ScanResult }): Promise<void> => {
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const User = require('../models/User');
+
+  // Bounded: see RESOLUTION_WINDOW_DAYS. Episodes older than the window stay
+  // open — truthfully — but stop costing a query every five minutes.
+  const open = await OnboardingSilenceEpisode.find({
+    status: 'open',
+    firstTypedAt: { $gte: new Date(now.getTime() - RESOLUTION_WINDOW_DAYS * DAY_MS) },
+  }).limit(200).lean();
+  if (open.length === 0) return;
+
+  for (const ep of open as Array<Record<string, any>>) {
+    const { rows } = await pgQuery(
+      'SELECT id, pod_id, user_id, created_at FROM messages'
+      + ' WHERE pod_id = $1 AND created_at > $2 AND user_id <> $3'
+      + ' ORDER BY created_at ASC LIMIT 25',
+      [String(ep.podId), new Date(ep.firstTypedAt), String(ep.userId)],
+    );
+    if (rows.length === 0) continue;
+
+    const authorIds = [...new Set(rows.map((r) => String(r.user_id)))];
+    const botIds = new Set(
+      (await User.find({ _id: { $in: authorIds }, ...BOT_FILTER }).select('_id').lean())
+        .map((u: any) => String(u._id)),
+    );
+
+    const answerer = rows.find((r) => botIds.has(String(r.user_id)));
+    const rescuer = rows[0];
+    const closing = answerer || rescuer;
+    const outcome: 'answered' | 'human-rescued' = answerer ? 'answered' : 'human-rescued';
+    const lagSeconds = Math.round(
+      (new Date(closing.created_at).getTime() - new Date(ep.firstTypedAt).getTime()) / 1000,
+    );
+
+    await OnboardingSilenceEpisode.updateOne(
+      { _id: ep._id, status: 'open' },
+      {
+        $set: {
+          status: 'resolved',
+          outcome,
+          resolvedAt: now,
+          resolutionLagSeconds: lagSeconds,
+        },
+      },
+    );
+    result.resolved.push({ episodeId: String(ep._id), outcome, lagSeconds });
+  }
+};
+
+export default { scan, snapshotAgentEvents };
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/services/schedulerService.ts
+++ b/backend/services/schedulerService.ts
@@ -341,6 +341,37 @@ class SchedulerService {
       { scheduled: false, timezone: 'UTC' },
     );
 
+    // "Signed up, typed, got no reply" — the onboarding-silence alert
+    // (W4 item 2). Every onboarding defect found on 2026-08-14 was found by a
+    // human choosing to read production; this is the part that does not need
+    // anyone to choose. See backend/services/onboardingSilenceService.ts for
+    // the calibration behind the 15-minute threshold.
+    //
+    // Every 5 minutes, not every 15: the threshold is how long silence must
+    // last before it counts, and the period is how long we then wait to say
+    // so. Matching them would double the worst-case time-to-alert.
+    const onboardingSilenceJob: CronJob = cron.schedule(
+      '*/5 * * * *',
+      async () => {
+        try {
+          // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+          const onboardingAlertService = require('./onboardingAlertService');
+          const result = await onboardingAlertService.runOnce();
+          if (result.opened.length > 0 || result.resolved.length > 0) {
+            console.log(
+              `[onboarding-silence] scanned=${result.scannedMessages} `
+              + `opened=${result.opened.length} absorbed=${result.updated} `
+              + `resolved=${result.resolved.length} skippedNoAgent=${result.skippedNoAgent} `
+              + `delivered=${result.delivered} rollup=${result.rollup}`,
+            );
+          }
+        } catch (error) {
+          console.error('[onboarding-silence] Unhandled error:', error);
+        }
+      },
+      { scheduled: false, timezone: 'UTC' },
+    );
+
     this.jobs = [
       summarizerJob,
       externalFeedJob,
@@ -355,6 +386,7 @@ class SchedulerService {
       agentSessionSizeCheckJob,
       codexTokenRefreshJob,
       skillsRefreshJob,
+      onboardingSilenceJob,
     ];
     this.jobs.forEach((job) => job.start());
     this.isRunning = true;
@@ -373,6 +405,10 @@ class SchedulerService {
     console.log('- Agent session size check runs every 10 minutes (clears if > AGENT_SESSION_MAX_SIZE_KB, default 400 KB)');
     console.log('- Codex OAuth token refresh check runs daily at 3 AM UTC (refreshes if expiring within 3 days)');
     console.log('- Stale agent events are garbage-collected every 10 minutes');
+    console.log(
+      '- Onboarding-silence scan runs every 5 minutes'
+      + `${process.env.ONBOARDING_ALERT_EMAIL ? '' : ' (LOG-ONLY: ONBOARDING_ALERT_EMAIL unset)'}`,
+    );
     console.log('- Skills catalog refreshes from upstream every 6 hours (stars re-fetched via GitHub API)');
 
     setTimeout(() => {

--- a/backend/services/userClassification.ts
+++ b/backend/services/userClassification.ts
@@ -1,0 +1,37 @@
+/**
+ * Who counts as a human, and why it takes TWO signals.
+ *
+ * Not every bot User row carries botMetadata.agentName. Rows created by the
+ * gateway bridge, the summarizer, and several openclaw install paths set
+ * botMetadata WITHOUT an agentName key. A filter keyed only on agentName
+ * therefore passes them as humans — on the dev instance that was 8 rows
+ * (clawdbot-bridge, commonly-summarizer, openclaw-inst-*, socialpulse-*),
+ * inflating totalUsers/DAU/WAU/signups ~10% and deflating every funnel rate,
+ * because a bot in the denominator can never convert.
+ *
+ * These two are exact logical complements (De Morgan) — keep them that way.
+ * Anything counted as a human here must NOT be counted as a bot there, or the
+ * "distinct human posters" metric double-subtracts.
+ *
+ * This module exists so there is ONE definition. The pair previously lived
+ * inline in routes/admin/analytics.ts; the onboarding-silence alert needs the
+ * identical split, and a second copy of a rule this subtle drifts from the
+ * first — a filter keyed on naming convention rather than on these two fields
+ * is what produced the `scott@agents.commonly.local` false alarm on
+ * 2026-08-14. Import it; do not restate it.
+ */
+export const HUMAN_FILTER = {
+  isBot: { $ne: true },
+  'botMetadata.agentName': { $exists: false },
+} as const;
+
+export const BOT_FILTER = {
+  $or: [
+    { isBot: true },
+    { 'botMetadata.agentName': { $exists: true } },
+  ],
+} as const;
+
+// CJS compat: these are consumed from both `import` and `require()` call sites.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports; Object.assign(module.exports, exports);


### PR DESCRIPTION
Closes W4 item 2. The instrument, not another fix.

## Why

Every onboarding defect found on 2026-08-14 was found by a human deciding to read production transcripts. The fixes were real; the detection was a person choosing to look. `pod-summarizer` failed every six hours for a month and nobody noticed. This is the part that does not require anyone to choose.

A cron asks one question every five minutes: **did someone who signed up recently say something in a room that could have answered, and did nothing answer?**

An **episode** is one `(user, pod)` run of silence, not one message — someone typing four times into a dead room is one failure, not four.

## Calibration

Threshold and semantics were calibrated against production by @pod-architect rather than guessed:

| decision | value | why |
|---|---|---|
| threshold | **15 min, wall-clock** | `AGENT_EVENT_REQUEUE_DELIVERED_MINUTES` is 10, so under ~12 fires inside a legitimate retry; `AGENT_EVENT_STALE_PENDING_MINUTES` is 30, past which the evidence is deleted along with the answer |
| not idle-gated | — | idle would key on `lastActive`, which over-counts: `V2PodChat.tsx:279` polls every 60s, so an abandoned tab reads as presence. It would also make the rate incomparable across cohorts, killing the alert's second job |
| scope | pod holds **≥1 active `AgentInstallation`** | not membership — a member without an installation 403s on post, so it was never going to answer either. Same predicate the posting path uses |
| reply | **bot authors only** | the claim is *the platform did not answer*; a human answering is recorded as `human-rescued` rather than folded in |
| unit | per-incident + hourly collapse | base rate is ~1/day on a working system, but the failure this watches for is a regression, and regressions strand users in bulk |

The observed data agrees independently: across 21 days, **every genuine reply landed inside 107 seconds** (5s, 15s, 40s, 48s, 73s, 103s, 107s) and the next cluster was 10+ hours. Nothing lands in between.

## The event snapshot is not optional

`AgentEvent` pending rows are deleted at 30 minutes; we fire at 15. That gap is the **only** window in which two failures that look identical afterwards can be told apart:

- `never-enqueued` → a producer bug (the write path skipped `enqueueMentions`)
- `enqueued-never-answered` → a runtime bug

They need opposite fixes. Captured at fire time or the alert reports that something is wrong with no way left to say what.

## Delivery refuses to be silently inert

Detection and delivery are separate services because they fail differently and only one is allowed to be quiet. With no `ONBOARDING_ALERT_EMAIL` set, the service **says so loudly on every pass that had something to report** rather than computing correctly and returning success. Three of the eight defects found on 08-14 were that exact shape; an alerting service is the worst possible place to add a fourth. A machine-readable `[onboarding-silence] ALERT …` line is always emitted regardless of email config.

`GET /api/admin/analytics/silence` is the pull half — an alert you can only receive is one you cannot go back and check, and it makes "did the fix work" answerable without re-reading transcripts by hand.

## `lastLogin` is deliberately not built

W4 item 2 was written as "`lastLogin` + alert". `lastLogin` does not exist — but the instrument it was meant to provide already does. `User.lastActive` is written on every authenticated request at a 15-minute throttle (`middleware/auth.ts:14`) and is **live in production**: DAU 9, WAU 24, returnedD1 5, which would be structural zeros if it were frozen.

With a 7-day JWT, a login timestamp samples an engaged daily user at weekly granularity — misleading rather than merely redundant. Dropping it was confirmed by @ux-lead and @pod-architect. The real caveat runs the other way: `lastActive` *over*-counts, and that is now documented where it is read.

## Verification

- **43 tests**, all green, including the 12 pre-existing analytics tests after `HUMAN_FILTER`/`BOT_FILTER` moved into `services/userClassification.ts` (one definition, not two copies of a subtle rule)
- `tsc:check` clean — baseline-compared against `main` by stash, identical output
- **Ran the real service against production data, read-only** (episode model stubbed in `require.cache`; zero writes): 54 messages scanned, 1 skipped for having no agent, **16 raw hits collapsing to 10 episodes with 6 absorbed** — matching an independently written probe. The collapse rule is doing real work.

## Not in scope

This does not nudge the user — that is W4 item 3 (@ux-lead's stalled-connect spec), which fires on install state and speaks to the user. They are complementary: that one catches a seat whose token was never used before anybody types; this one catches a Scout that breaks tonight, and knows nothing about tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8