### PR TITLE
fix(onboarding): make the silence detector observably alive

### DIFF
--- a/backend/__tests__/unit/routes/admin.analytics.silence.test.js
+++ b/backend/__tests__/unit/routes/admin.analytics.silence.test.js
@@ -27,6 +27,11 @@ jest.mock('../../../config/db-pg', () => ({ pool: { query: jest.fn() } }));
 const mockFind = jest.fn();
 jest.mock('../../../models/OnboardingSilenceEpisode', () => ({ find: (...a) => mockFind(...a) }));
 
+const mockSettingFindOne = jest.fn();
+jest.mock('../../../models/SystemSetting', () => ({
+  findOne: (...a) => mockSettingFindOne(...a),
+}));
+
 const routes = require('../../../routes/admin/analytics');
 
 const chain = (rows) => ({
@@ -54,6 +59,10 @@ describe('GET /api/admin/analytics/silence', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockRole = 'admin';
+    // Fresh heartbeat by default; individual tests override to test staleness.
+    mockSettingFindOne.mockReturnValue({
+      lean: () => Promise.resolve({ value: { lastScanAt: new Date().toISOString() } }),
+    });
     app = express();
     app.use('/api/admin/analytics', routes);
   });
@@ -101,6 +110,29 @@ describe('GET /api/admin/analytics/silence', () => {
     const res = await request(app).get('/api/admin/analytics/silence?days=9999');
 
     expect(res.body.days).toBe(90);
+  });
+
+  // An empty list means "nothing is broken" ONLY if the detector ran. These two
+  // exist because on 2026-08-15 a live pass produced no output and a dead cron
+  // would have looked exactly the same.
+  it('reports a fresh scan as not stale', async () => {
+    mockFind.mockReturnValue(chain([]));
+
+    const res = await request(app).get('/api/admin/analytics/silence');
+
+    expect(res.body.staleScan).toBe(false);
+    expect(res.body.lastScanAt).toEqual(expect.any(String));
+  });
+
+  it('flags staleScan when the detector has not run, so zero episodes proves nothing', async () => {
+    mockFind.mockReturnValue(chain([]));
+    mockSettingFindOne.mockReturnValue({ lean: () => Promise.resolve(null) });
+
+    const res = await request(app).get('/api/admin/analytics/silence');
+
+    expect(res.body.totals.episodes).toBe(0);
+    expect(res.body.staleScan).toBe(true);
+    expect(res.body.lastScanAt).toBeNull();
   });
 
   it('403s non-admins', async () => {

--- a/backend/__tests__/unit/services/onboardingAlertService.test.js
+++ b/backend/__tests__/unit/services/onboardingAlertService.test.js
@@ -16,6 +16,11 @@ jest.mock('../../../services/onboardingSilenceService', () => ({
 const mockSendEmail = jest.fn();
 jest.mock('../../../services/emailService', () => ({ sendEmail: (...a) => mockSendEmail(...a) }));
 
+const mockSettingUpdate = jest.fn();
+jest.mock('../../../models/SystemSetting', () => ({
+  updateOne: (...a) => mockSettingUpdate(...a),
+}));
+
 const mockCount = jest.fn();
 const mockUpdateOne = jest.fn();
 const mockUpdateMany = jest.fn();
@@ -48,16 +53,56 @@ const emptyScan = {
 };
 
 let errSpy;
+let logSpy;
 beforeEach(() => {
   jest.clearAllMocks();
   delete process.env.ONBOARDING_ALERT_EMAIL;
+  mockSettingUpdate.mockResolvedValue({});
+  logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
   mockCount.mockResolvedValue(1);
   mockUpdateOne.mockResolvedValue({});
   mockUpdateMany.mockResolvedValue({});
   mockSendEmail.mockResolvedValue({});
   errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 });
-afterEach(() => errSpy.mockRestore());
+afterEach(() => { errSpy.mockRestore(); logSpy.mockRestore(); });
+
+// The detector must be observably alive. Found the hard way on 2026-08-15:
+// the first live pass produced no output at all, so "ran and everything is
+// fine" and "is dead" were indistinguishable — the pod-summarizer failure,
+// inside the service written to catch it.
+describe('liveness', () => {
+  it('records a heartbeat even when it finds nothing', async () => {
+    mockScan.mockResolvedValue(emptyScan);
+
+    await runOnce();
+
+    expect(mockSettingUpdate).toHaveBeenCalledTimes(1);
+    const [filter, update, opts] = mockSettingUpdate.mock.calls[0];
+    expect(filter.key).toBe('onboardingSilence.lastScan');
+    expect(update.$set.value.lastScanAt).toEqual(expect.any(String));
+    expect(opts).toEqual({ upsert: true });
+  });
+
+  it('logs one line per pass regardless of outcome', async () => {
+    mockScan.mockResolvedValue(emptyScan);
+
+    await runOnce();
+
+    const lines = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(lines).toContain('[onboarding-silence] pass');
+  });
+
+  it('does not let a failed heartbeat suppress the alert', async () => {
+    process.env.ONBOARDING_ALERT_EMAIL = 'ops@example.com';
+    mockSettingUpdate.mockRejectedValue(new Error('mongo down'));
+    mockScan.mockResolvedValue({ ...emptyScan, opened: [episode()] });
+
+    const r = await runOnce();
+
+    expect(r.delivered).toBe(1);
+  });
+});
 
 describe('onboardingAlertService.runOnce', () => {
   it('sends one email per stranded user', async () => {

--- a/backend/routes/admin/analytics.ts
+++ b/backend/routes/admin/analytics.ts
@@ -262,7 +262,18 @@ router.get('/silence', adminReadLimiter, auth, adminAuth, async (req: any, res: 
     // eslint-disable-next-line global-require
     const { SILENCE_THRESHOLD_MINUTES } = require('../../services/onboardingSilenceService');
     // eslint-disable-next-line global-require
-    const { diagnose } = require('../../services/onboardingAlertService');
+    const { diagnose, HEARTBEAT_KEY } = require('../../services/onboardingAlertService');
+    // eslint-disable-next-line global-require
+    const SystemSetting = require('../../models/SystemSetting');
+
+    // "0 stranded users" is only good news if something is still looking.
+    // Without this, a healthy funnel and a dead cron render identically — the
+    // failure mode this whole endpoint exists to report on.
+    const beat = await SystemSetting.findOne({ key: HEARTBEAT_KEY }).lean() as
+      { value?: { lastScanAt?: string } } | null;
+    const lastScanAt = beat?.value?.lastScanAt || null;
+    const staleScan = !lastScanAt
+      || (Date.now() - new Date(lastScanAt).getTime()) > 15 * 60 * 1000;
 
     const episodes = await OnboardingSilenceEpisode.find({ detectedAt: { $gte: since } })
       .sort({ detectedAt: -1 }).limit(500).lean();
@@ -296,6 +307,9 @@ router.get('/silence', adminReadLimiter, auth, adminAuth, async (req: any, res: 
       since: since.toISOString(),
       thresholdMinutes: SILENCE_THRESHOLD_MINUTES,
       alertRecipientConfigured: Boolean((process.env.ONBOARDING_ALERT_EMAIL || '').trim()),
+      lastScanAt,
+      // True means: do not read `episodes: []` as "nothing is broken".
+      staleScan,
       totals: {
         episodes: shaped.length,
         open: open.length,
@@ -309,6 +323,7 @@ router.get('/silence', adminReadLimiter, auth, adminAuth, async (req: any, res: 
         'only a bot author counts as a reply; a human answering is recorded as human-rescued',
         'pods without an active AgentInstallation are never counted — nothing there could answer',
         'diagnosis is only meaningful when captured at fire time; agent events are GC-ed at 30 min',
+        'staleScan=true means the detector itself has not run recently — an empty list proves nothing',
       ],
     });
   } catch (err: any) {

--- a/backend/services/onboardingAlertService.ts
+++ b/backend/services/onboardingAlertService.ts
@@ -24,6 +24,49 @@ import {
 const RECIPIENT = () => (process.env.ONBOARDING_ALERT_EMAIL || '').trim();
 const ROLLING_WINDOW_MS = 60 * 60 * 1000;
 
+/** Where the liveness heartbeat lives, so a reader can ask "is this alive?". */
+export const HEARTBEAT_KEY = 'onboardingSilence.lastScan';
+
+/**
+ * Record that a pass happened, whatever it found.
+ *
+ * WHY THIS EXISTS, and it is not decoration. The first live verification of
+ * this service (2026-08-15) produced no log output — and "the scan ran and
+ * everything is fine" was indistinguishable from "the scan is dead". That is
+ * precisely the `pod-summarizer` failure: a cron that failed every six hours
+ * for a month while every component reported success. Shipping it inside the
+ * service built to catch that failure would have been the joke writing itself.
+ *
+ * So a pass always leaves a mark. Zero stranded users is only good news if
+ * something is still looking, and `lastScanAt` is what lets a reader tell the
+ * difference. Surfaced on GET /api/admin/analytics/silence as `staleScan`.
+ */
+const recordHeartbeat = async (now: Date, result: ScanResult): Promise<void> => {
+  try {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const SystemSetting = require('../models/SystemSetting');
+    await SystemSetting.updateOne(
+      { key: HEARTBEAT_KEY },
+      {
+        $set: {
+          key: HEARTBEAT_KEY,
+          value: {
+            lastScanAt: now.toISOString(),
+            scannedMessages: result.scannedMessages,
+            opened: result.opened.length,
+            resolved: result.resolved.length,
+            skippedNoAgent: result.skippedNoAgent,
+          },
+        },
+      },
+      { upsert: true },
+    );
+  } catch (error) {
+    // A heartbeat that throws must never suppress the alert it accompanies.
+    console.warn('[onboarding-silence] heartbeat write failed:', (error as Error).message);
+  }
+};
+
 /**
  * Machine-readable, one line per episode, always emitted.
  *
@@ -116,6 +159,16 @@ export const runOnce = async (
 ): Promise<ScanResult & { delivered: number; rollup: boolean; unconfigured: boolean }> => {
   const now = opts.now || new Date();
   const result = await scan({ ...opts, now });
+  await recordHeartbeat(now, result);
+
+  // One line per pass, unconditionally. 288 lines a day is nothing against this
+  // log volume, and it is the difference between a quiet instrument and a dead
+  // one — which is the whole subject of this service.
+  console.log(
+    `[onboarding-silence] pass scanned=${result.scannedMessages} `
+    + `opened=${result.opened.length} absorbed=${result.updated} `
+    + `resolved=${result.resolved.length} skippedNoAgent=${result.skippedNoAgent}`,
+  );
 
   if (result.resolved.length > 0) {
     for (const r of result.resolved) {


### PR DESCRIPTION
Follow-up to #954, found by verifying it live rather than trusting the deploy.

## What happened

#954 deployed successfully at 04:35. The cron registered, the startup line was there, the collection and its three indexes were created. Then the first pass ran and **produced no output whatsoever** — because the code logged only when it found something.

So from outside, these were identical:

- the scan ran, nobody is stranded, all is well
- the scan is dead

That is the `pod-summarizer` failure — a cron failing every six hours for a month while every component reported success — reproduced *inside the service written to catch it*. I could only establish it was alive by invoking the deployed service by hand, which is exactly the "a human decides to look" problem #954 exists to end.

An empty result from an unobservable detector is not evidence of a healthy funnel.

## Fix

| change | why |
|---|---|
| heartbeat to `SystemSetting: onboardingSilence.lastScan` every pass | a mark that survives log rotation and is queryable |
| one log line per pass, unconditional | 288/day is free against this volume, and makes it greppable in `kubectl logs` |
| `lastScanAt` + `staleScan` on `GET /api/admin/analytics/silence` | lets a reader tell "nothing is broken" from "nothing is watching" |

The heartbeat is best-effort and explicitly cannot suppress an alert — a Mongo failure while writing it must not turn a real stranded user into silence. There's a test for that specific ordering.

## Verified live before writing this

Ran the **deployed** service against production (image `3e4a5c3f`):

```
constants:      threshold=15m lookback=24h window=7d
default pass  → scanned=14 opened=0 absorbed=0 resolved=0 skippedNoAgent=0
21-day pass   → scanned=54 opened=10 absorbed=6 skippedNoAgent=1
```

So detection works — it scanned 14 real messages and correctly found nobody stranded in the live window, and reproduces the same 10 episodes as the pre-merge dry run when given a wider lookback.

**Also worth recording: my pre-deploy prediction was wrong.** I told Sam the first pass would retroactively alert on ~6–9 historical users. It found zero, because the *signup* window is 7 days but the *message* lookback is 24 hours, and the most recent stranded message was ~25 hours old. The two windows are independent and I conflated them. No retroactive batch happens — which is arguably better, but it wasn't what I said.

Those 10 episodes did get written to production by my 21-day verification pass, and I deleted them: they were true, but produced by a hand-run configuration the live cron would never use, and leaving them would make `/silence` imply the alert had been watching since 08-09. Reproducible on demand with `scan({ lookbackHours: 24 * 21 })`.

49 tests green, `tsc:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8
