### PR TITLE
feat(onboarding): tell people their seat was never started (W4 item 3)

### DIFF
--- a/backend/__tests__/unit/services/stalledConnectService.test.js
+++ b/backend/__tests__/unit/services/stalledConnectService.test.js
@@ -1,0 +1,248 @@
+// Stalled-connect nudge (W4 item 3). Spec: ux-lead 2026-08-14; calibration and
+// corrections from pod-architect / sprint-impl, 2026-08-15.
+//
+// The load-bearing rules, each one a decision that could be silently undone:
+//   - one nudge per TOKEN-episode, and a reissue earns another
+//   - the episode key is max(createdAt) across BOTH token stores
+//   - 15 min is a patience window on top of deriveAgentState, not a 2nd rule
+//   - the episode is claimed BEFORE posting, so a race loses silently
+//   - the forward promise is kept: connecting posts a confirmation
+//   - the confirmation states the past flat and the present derived
+
+const MINUTE = 60 * 1000;
+const NOW = new Date('2026-08-15T12:00:00Z');
+const OLD_TOKEN = new Date(NOW.getTime() - 30 * MINUTE);
+const FRESH_TOKEN = new Date(NOW.getTime() - 2 * MINUTE);
+
+const mockInstallFind = jest.fn();
+const mockInstallFindById = jest.fn();
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: {
+    find: (...a) => mockInstallFind(...a),
+    findById: (...a) => mockInstallFindById(...a),
+  },
+}));
+
+const mockUserFindOne = jest.fn();
+const mockUserFindById = jest.fn();
+jest.mock('../../../models/User', () => ({
+  findOne: (...a) => mockUserFindOne(...a),
+  findById: (...a) => mockUserFindById(...a),
+}));
+
+const mockPost = jest.fn();
+jest.mock('../../../services/agentMessageService', () => ({
+  postMessage: (...a) => mockPost(...a),
+}));
+
+jest.mock('../../../services/agentIdentityService', () => ({
+  buildAgentUsername: (n, i) => (i && i !== 'default' ? `${n}-${i}` : n),
+}));
+
+const mockEpCreate = jest.fn();
+const mockEpFind = jest.fn();
+const mockEpUpdate = jest.fn();
+jest.mock('../../../models/StalledConnectEpisode', () => ({
+  create: (...a) => mockEpCreate(...a),
+  find: (...a) => mockEpFind(...a),
+  updateOne: (...a) => mockEpUpdate(...a),
+}));
+
+const { scan, resolveTokenEpisode } = require('../../../services/stalledConnectService');
+
+const install = (over = {}) => ({
+  _id: 'inst1',
+  podId: 'pod1',
+  installedBy: 'user1',
+  agentName: 'ai1-agent',
+  instanceId: 'default',
+  displayName: 'AI1 Agent',
+  status: 'active',
+  config: { runtime: { runtimeType: 'webhook', host: 'byo' } },
+  runtimeTokens: [{ createdAt: OLD_TOKEN }],
+  ...over,
+});
+
+const setup = ({ installs = [install()], userTokens = [], open = [] } = {}) => {
+  mockInstallFind.mockReturnValue({
+    limit: () => ({ lean: () => Promise.resolve(installs) }),
+  });
+  mockUserFindOne.mockReturnValue({
+    select: () => ({ lean: () => Promise.resolve({ agentRuntimeTokens: userTokens }) }),
+  });
+  mockUserFindById.mockReturnValue({
+    select: () => ({ lean: () => Promise.resolve({ username: 'alice' }) }),
+  });
+  mockEpFind.mockReturnValue({ limit: () => ({ lean: () => Promise.resolve(open) }) });
+  mockEpCreate.mockImplementation((d) => Promise.resolve({ _id: 'ep1', ...d }));
+  mockEpUpdate.mockResolvedValue({});
+  mockPost.mockResolvedValue({ id: 'msg1' });
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('resolveTokenEpisode', () => {
+  // pod-architect 53308: key off one store while triggering off the union and a
+  // reissue on the other path never resets the episode.
+  it('takes the max createdAt across BOTH stores', () => {
+    const older = new Date('2026-08-15T10:00:00Z');
+    const newer = new Date('2026-08-15T11:00:00Z');
+    expect(resolveTokenEpisode([{ createdAt: older }], [{ createdAt: newer }]))
+      .toEqual({ issuedAt: newer, source: 'user' });
+    expect(resolveTokenEpisode([{ createdAt: newer }], [{ createdAt: older }]))
+      .toEqual({ issuedAt: newer, source: 'installation' });
+  });
+
+  it('reports which store minted it, because only one has expiresAt', () => {
+    const { source } = resolveTokenEpisode([], [{ createdAt: NOW }]);
+    expect(source).toBe('user');
+  });
+
+  it('returns null when no token was ever issued', () => {
+    expect(resolveTokenEpisode([], [])).toEqual({ issuedAt: null, source: null });
+  });
+});
+
+describe('stalledConnectService.scan', () => {
+  it('nudges a seat whose token was issued long ago and never used', async () => {
+    setup();
+    const r = await scan({ now: NOW });
+
+    expect(r.nudged).toHaveLength(1);
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    const posted = mockPost.mock.calls[0][0];
+    expect(posted.podId).toBe('pod1');
+    expect(posted.content).toContain('@alice');
+    expect(posted.content).toContain('commonly agent run ai1-agent');
+    expect(posted.content).toContain("I'll post here the moment I connect");
+  });
+
+  it('holds fire inside the patience window', async () => {
+    setup({ installs: [install({ runtimeTokens: [{ createdAt: FRESH_TOKEN }] })] });
+    const r = await scan({ now: NOW });
+
+    expect(r.nudged).toHaveLength(0);
+    expect(r.skippedTooRecent).toBe(1);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('says nothing when the token has been used — that is not stalled', async () => {
+    setup({
+      installs: [install({
+        runtimeTokens: [{ createdAt: OLD_TOKEN, lastUsedAt: new Date(NOW.getTime() - MINUTE) }],
+      })],
+    });
+    const r = await scan({ now: NOW });
+
+    expect(r.nudged).toHaveLength(0);
+    expect(r.skippedNotStalled).toBe(1);
+  });
+
+  it('claims the episode BEFORE posting, so a losing race costs a nudge not a duplicate', async () => {
+    setup();
+    const order = [];
+    mockEpCreate.mockImplementation(async (d) => { order.push('claim'); return { _id: 'ep1', ...d }; });
+    mockPost.mockImplementation(async () => { order.push('post'); return { id: 'm' }; });
+
+    await scan({ now: NOW });
+
+    expect(order).toEqual(['claim', 'post']);
+  });
+
+  it('stays silent when the episode was already explained (duplicate key)', async () => {
+    setup();
+    mockEpCreate.mockRejectedValue(Object.assign(new Error('dup'), { code: 11000 }));
+
+    const r = await scan({ now: NOW });
+
+    expect(r.nudged).toHaveLength(0);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('records the episode against the token issue time and its source', async () => {
+    setup();
+    await scan({ now: NOW });
+
+    const doc = mockEpCreate.mock.calls[0][0];
+    expect(doc.tokenIssuedAt).toEqual(OLD_TOKEN);
+    expect(doc.tokenSource).toBe('installation');
+    expect(doc.producer).toBe('timer');
+  });
+
+  it('only considers BYO seats — nothing else can derive never-connected', async () => {
+    setup();
+    await scan({ now: NOW });
+
+    const [filter] = mockInstallFind.mock.calls[0];
+    expect(filter.status).toBe('active');
+    expect(filter.$or).toEqual(expect.arrayContaining([{ 'config.runtime.host': 'byo' }]));
+  });
+});
+
+describe('keeping the forward promise', () => {
+  const openEpisode = {
+    _id: 'ep9',
+    installationId: 'inst1',
+    podId: 'pod1',
+    agentName: 'ai1-agent',
+    instanceId: 'default',
+    displayName: 'AI1 Agent',
+    status: 'open',
+  };
+
+  it('posts a confirmation once the token is used, and closes the episode', async () => {
+    const usedAt = new Date(NOW.getTime() - 10 * MINUTE);
+    setup({ installs: [], open: [openEpisode] });
+    mockInstallFindById.mockReturnValue({
+      lean: () => Promise.resolve(install({ runtimeTokens: [{ createdAt: OLD_TOKEN, lastUsedAt: usedAt }] })),
+    });
+
+    const r = await scan({ now: NOW });
+
+    expect(r.resolved).toHaveLength(1);
+    const posted = mockPost.mock.calls[0][0];
+    // Past stated flat, present derived at post time (ux-lead 53307).
+    expect(posted.content).toContain('first seen 11:50');
+    expect(mockEpUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: 'ep9', status: 'open' }),
+      expect.objectContaining({ $set: expect.objectContaining({ status: 'resolved' }) }),
+    );
+  });
+
+  it('reports the present honestly when it connected and has since gone quiet', async () => {
+    // Connected 3 hours ago, stale now: the past is still a fact, the present
+    // is not "listening". This is the connect-then-disconnect case.
+    const usedAt = new Date(NOW.getTime() - 180 * MINUTE);
+    setup({ installs: [], open: [openEpisode] });
+    mockInstallFindById.mockReturnValue({
+      lean: () => Promise.resolve(install({ runtimeTokens: [{ createdAt: OLD_TOKEN, lastUsedAt: usedAt }] })),
+    });
+
+    await scan({ now: NOW });
+
+    const posted = mockPost.mock.calls[0][0];
+    expect(posted.content).toContain('first seen 09:00');
+    expect(posted.content).toContain("isn't running right now");
+    expect(posted.content).toContain('commonly agent run ai1-agent');
+  });
+
+  it('keeps waiting while it is still never-connected', async () => {
+    setup({ installs: [], open: [openEpisode] });
+    mockInstallFindById.mockReturnValue({ lean: () => Promise.resolve(install()) });
+
+    const r = await scan({ now: NOW });
+
+    expect(r.resolved).toHaveLength(0);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('closes silently when the seat was uninstalled — no room, no promise to keep', async () => {
+    setup({ installs: [], open: [openEpisode] });
+    mockInstallFindById.mockReturnValue({ lean: () => Promise.resolve(null) });
+
+    await scan({ now: NOW });
+
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(mockEpUpdate).toHaveBeenCalled();
+  });
+});

--- a/backend/models/StalledConnectEpisode.ts
+++ b/backend/models/StalledConnectEpisode.ts
@@ -1,0 +1,116 @@
+import mongoose, { Document, Model, Schema, Types } from 'mongoose';
+
+/**
+ * Someone installed a seat and never started it.
+ *
+ * This is the record behind the stalled-connect nudge (W4 item 3; spec by
+ * ux-lead, 2026-08-14). It is the recovery path's memory: what we have already
+ * explained, to whom, about which token.
+ *
+ * WHY AN EPISODE IS A TOKEN, NOT AN INSTALL. The spec's no-spam rule is
+ * "exactly one nudge per token-episode", where an episode is the life of the
+ * current newest token and a reissue resets it. That is deliberate: reissuing
+ * a token is a person trying again, which renews the expectation and earns one
+ * more explanation. Keying on the installation instead would explain once and
+ * then stay silent through every subsequent attempt; keying on time would
+ * repeat at someone who already heard it. So the key is
+ * (installationId, tokenIssuedAt).
+ *
+ * WHY IT IS SHARED. Two producers can explain the same silence: this timer,
+ * and the reactive responder that answers when a human @mentions a seat with
+ * no live wrapper (sprint-impl, scoped and not yet built). The spec requires
+ * ONE explanation per episode total, whichever fires first — so both write
+ * THIS record and `producer` says which won. A second collection would let a
+ * user be told the same thing twice by two systems that each believed they
+ * were the only one.
+ *
+ * NOT the same thing as OnboardingSilenceEpisode. That one fires on
+ * conversational outcome (someone spoke, nothing answered) and reports to US.
+ * This one fires on install state (a token was never used) and speaks to the
+ * USER. They catch different failures: a user who never types is invisible to
+ * that one and is exactly this one's subject — which is `user-fbd3`, who
+ * signed up on 2026-08-15, installed a seat 77 seconds later, never ran it,
+ * never spoke, and left.
+ */
+export interface IStalledConnectEpisode extends Document {
+  installationId: Types.ObjectId;
+  podId: string;
+  /** The human who installed it — the nudge is addressed to them by name. */
+  installedBy: Types.ObjectId;
+  installerUsername?: string;
+  agentName: string;
+  instanceId: string;
+  displayName?: string;
+  /**
+   * Issue time of the newest runtime token when the episode opened. THIS is
+   * the episode identity; a reissue produces a later value and so a new
+   * episode.
+   */
+  tokenIssuedAt: Date;
+  /**
+   * Which token store minted the episode-defining token.
+   *
+   * Recorded because the two stores are NOT symmetric: `User.agentRuntimeTokens`
+   * carries an `expiresAt` and `AgentInstallation.runtimeTokens` does not, so
+   * "the life of the current newest token" ends differently depending on which
+   * one it came from — expiry on one path, supersession-only on the other
+   * (pod-architect, 53309). Nothing reads this yet; it is here so the reactive
+   * responder does not have to infer it.
+   */
+  tokenSource?: 'installation' | 'user' | null;
+  /** Which producer explained it. See the class comment. */
+  producer: 'timer' | 'reactive';
+  nudgedAt: Date;
+  nudgeMessageId?: string;
+  /**
+   * The forward commitment the nudge makes ("I'll post here the moment it
+   * connects") has to be kept, or it is one more false promise — the exact
+   * defect #943 existed to remove. These two record that it was.
+   */
+  resolvedAt?: Date;
+  resolutionMessageId?: string;
+  /** Still unconnected at +7d goes to the digest, never a second room post. */
+  digestedAt?: Date;
+  status: 'open' | 'resolved';
+}
+
+const StalledConnectEpisodeSchema = new Schema<IStalledConnectEpisode>(
+  {
+    installationId: { type: Schema.Types.ObjectId, ref: 'AgentInstallation', required: true },
+    podId: { type: String, required: true },
+    installedBy: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    installerUsername: { type: String },
+    agentName: { type: String, required: true },
+    instanceId: { type: String, default: 'default' },
+    displayName: { type: String },
+    tokenIssuedAt: { type: Date, required: true },
+    tokenSource: { type: String, enum: ['installation', 'user', null], default: null },
+    producer: { type: String, enum: ['timer', 'reactive'], default: 'timer' },
+    nudgedAt: { type: Date, required: true },
+    nudgeMessageId: { type: String },
+    resolvedAt: { type: Date },
+    resolutionMessageId: { type: String },
+    digestedAt: { type: Date },
+    status: { type: String, enum: ['open', 'resolved'], default: 'open' },
+  },
+  { timestamps: true, versionKey: false },
+);
+
+// The no-spam rule, held in the database rather than in scan logic. A
+// minute-cron overlapping itself, or the timer racing the reactive responder,
+// both lose here — and losing means "already explained", not an error.
+StalledConnectEpisodeSchema.index(
+  { installationId: 1, tokenIssuedAt: 1 },
+  { unique: true },
+);
+// The resolution sweep: which open episodes might have connected by now.
+StalledConnectEpisodeSchema.index({ status: 1, nudgedAt: 1 });
+
+const StalledConnectEpisode: Model<IStalledConnectEpisode> =
+  (mongoose.models.StalledConnectEpisode as Model<IStalledConnectEpisode>)
+  || mongoose.model<IStalledConnectEpisode>('StalledConnectEpisode', StalledConnectEpisodeSchema);
+
+export default StalledConnectEpisode;
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/services/schedulerService.ts
+++ b/backend/services/schedulerService.ts
@@ -372,6 +372,33 @@ class SchedulerService {
       { scheduled: false, timezone: 'UTC' },
     );
 
+    // Stalled-connect nudge (W4 item 3). Tells a USER their seat was never
+    // started — the population the onboarding-silence alert is blind to,
+    // because they never typed. A cron rather than a delayed event on purpose:
+    // re-deriving from state each pass is drop-proof, where a delayed
+    // AgentEvent inherits the pending-GC caveat. See stalledConnectService.
+    const stalledConnectJob: CronJob = cron.schedule(
+      '*/5 * * * *',
+      async () => {
+        try {
+          // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+          const stalledConnectService = require('./stalledConnectService');
+          const r = await stalledConnectService.scan();
+          // Unconditional, for the same reason the silence pass logs
+          // unconditionally: a detector nobody can see is indistinguishable
+          // from a dead one.
+          console.log(
+            `[stalled-connect] pass candidates=${r.candidates} nudged=${r.nudged.length} `
+            + `resolved=${r.resolved.length} tooRecent=${r.skippedTooRecent} `
+            + `notStalled=${r.skippedNotStalled}`,
+          );
+        } catch (error) {
+          console.error('[stalled-connect] Unhandled error:', error);
+        }
+      },
+      { scheduled: false, timezone: 'UTC' },
+    );
+
     this.jobs = [
       summarizerJob,
       externalFeedJob,
@@ -387,6 +414,7 @@ class SchedulerService {
       codexTokenRefreshJob,
       skillsRefreshJob,
       onboardingSilenceJob,
+      stalledConnectJob,
     ];
     this.jobs.forEach((job) => job.start());
     this.isRunning = true;
@@ -405,6 +433,7 @@ class SchedulerService {
     console.log('- Agent session size check runs every 10 minutes (clears if > AGENT_SESSION_MAX_SIZE_KB, default 400 KB)');
     console.log('- Codex OAuth token refresh check runs daily at 3 AM UTC (refreshes if expiring within 3 days)');
     console.log('- Stale agent events are garbage-collected every 10 minutes');
+    console.log('- Stalled-connect nudge scan runs every 5 minutes');
     console.log(
       '- Onboarding-silence scan runs every 5 minutes'
       + `${process.env.ONBOARDING_ALERT_EMAIL ? '' : ' (LOG-ONLY: ONBOARDING_ALERT_EMAIL unset)'}`,

--- a/backend/services/stalledConnectCopy.ts
+++ b/backend/services/stalledConnectCopy.ts
@@ -1,0 +1,100 @@
+/**
+ * Copy for the stalled-connect nudge and its resolution (W4 item 3).
+ *
+ * Pure, for the same reason `composeInstallIntro` is pure: the caller derives
+ * liveness through `deriveAgentState` — the single derivation the roster, the
+ * #943 install intro and the #891 honesty surface all use — and passes the
+ * verdict in. Copy rules stay testable without a database, and there is no
+ * second guess about whether an agent is connected.
+ *
+ * TONE. Flat declarative, no hedge. `never-connected` is structurally certain:
+ * no token has ever been used, so "nothing has started me" is a fact, not an
+ * inference. That is exactly the distinction #943 had to learn the hard way —
+ * a `gone-dark` agent told "nothing is running me yet" was flat-certain AND
+ * wrong. This nudge only ever fires on the certain case, which is why it can
+ * afford the flat voice. If it is ever extended to gone-dark (deliberately out
+ * of v1 scope), the copy must hedge and this comment is the reason.
+ *
+ * THE FORWARD COMMITMENT IS LOAD-BEARING. "I'll post here the moment it
+ * connects" is a promise, and `postResolution` below is how it is kept. Ship
+ * one without the other and the nudge becomes the second false promise we made
+ * to the same person — the first being the "mention me anytime" intro that
+ * #943 removed.
+ */
+
+/**
+ * Locale is accepted and currently ignored, deliberately and visibly.
+ *
+ * ux-lead's spec asks for en + zh-CN from day one. There is no mechanism: the
+ * language lives in frontend localStorage, never reaches the backend, there is
+ * no `User.language` and no server-side i18n layer at all (#715–720 was
+ * frontend-only). #943's install intro shipped English-only for the same
+ * audience with the same argument available.
+ *
+ * So the parameter marks the seam rather than pretending it is solved. When a
+ * locale signal and a server-side catalogue exist, this is where they attach,
+ * and the call sites already thread it through.
+ */
+export type NudgeLocale = 'en' | 'zh-CN';
+
+export const composeStalledConnectNudge = ({
+  installerName, displayName, handle, fixCommand,
+}: {
+  installerName: string;
+  displayName: string;
+  handle: string;
+  fixCommand: string;
+  locale?: NudgeLocale;
+}): string =>
+  `@${installerName} — I'm installed here, but nothing has ever started me, `
+  + `so mentioning @${handle} won't reach anyone yet. `
+  + `Run \`${fixCommand}\` on the machine where I should live and I'll come online. `
+  + `I'll post here the moment I connect.`;
+
+/**
+ * The resolution post, and it is deliberately NOT time-bounded (ux-lead).
+ *
+ * An unclosed promise is a false promise, so the loop closes whenever it can —
+ * six days late is ambient closure, not an interrupt, and landing late is
+ * exactly what it should do.
+ *
+ * The template is compound because a single tense cannot stay honest at
+ * arbitrary age: **flat for the past** (a first-connection timestamp is a
+ * fact) and **derived for the present** (per the same certainty rule that
+ * governs the install intro). That compound is also what dissolves the
+ * connect-then-disconnect-within-one-pass case I thought was invisible:
+ * `lastUsedAt` leaving null is a PERMANENT transition, so the next pass still
+ * sees it and simply reports a different present — "connected at 04:12, not
+ * running now" — instead of missing the event.
+ */
+export const composeStalledConnectResolution = ({
+  displayName, handle, firstSeenAt, presentState, fixCommand,
+}: {
+  displayName: string;
+  handle: string;
+  /** When the token was first used. A fact — stated flat. */
+  firstSeenAt: Date;
+  /** `deriveAgentState` verdict at POST time, not at connect time. */
+  presentState: string;
+  fixCommand: string;
+  locale?: NudgeLocale;
+}): string => {
+  const hhmm = firstSeenAt.toISOString().slice(11, 16);
+  const past = `${displayName} connected (first seen ${hhmm} UTC).`;
+
+  // Inferred and currently down: hedge nothing about the past, keep the
+  // instruction for the present.
+  if (presentState === 'gone-dark') {
+    return `${past} It isn't running right now — restart it with \`${fixCommand}\` `
+      + `and @${handle} will get through again.`;
+  }
+  // Certain and down again with no use at all is impossible here (this only
+  // fires once the token HAS been used), so anything else is live enough to
+  // invite.
+  return `${past} Listening now — mention @${handle} and I'll answer.`;
+};
+
+export default { composeStalledConnectNudge, composeStalledConnectResolution };
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/services/stalledConnectService.ts
+++ b/backend/services/stalledConnectService.ts
@@ -1,0 +1,361 @@
+import StalledConnectEpisode from '../models/StalledConnectEpisode';
+import { deriveAgentState } from './agentStateService';
+import { composeStalledConnectNudge, composeStalledConnectResolution } from './stalledConnectCopy';
+
+/**
+ * The stalled-connect nudge (W4 item 3). Spec: ux-lead, 2026-08-14.
+ *
+ * A person installs a seat, never runs the wrapper, and nothing ever tells
+ * them. `user-fbd3` did exactly this on 2026-08-15: signed up, installed a BYO
+ * agent 77 seconds later, never ran it, never spoke, gone. The seat's own
+ * install intro (#943) told the truth at install time — "nothing is running me
+ * yet" — but that is a single line at minute zero, and nothing follows up.
+ *
+ * This is the follow-up. Fifteen minutes after a token is issued and still
+ * unused, the seat says so in the room, addressed to the person who installed
+ * it, and hands over the exact command.
+ *
+ * WHY IT IS NOT THE SILENCE ALERT. `onboardingSilenceService` fires on
+ * conversational outcome — someone spoke and nothing answered — and reports to
+ * US. This fires on install state and speaks to the USER. They are blind to
+ * each other's population by construction: someone who never types is
+ * invisible to that one and is the whole subject of this one.
+ *
+ * WHY A CRON AND NOT A DELAYED EVENT (ux-lead, explicitly): a delayed
+ * AgentEvent inherits the 30-40 minute pending-GC caveat and needs a
+ * survivable timer. A cron that re-derives from state each pass is drop-proof
+ * by construction — a missed tick costs latency, not the nudge.
+ *
+ * ONE DERIVATION. State comes from `deriveAgentState`, the same function the
+ * pod roster, the #943 intro and the #891 surfaces use. There is no parallel
+ * "is it connected" rule here and there must never be one; the 15 minutes is a
+ * patience window laid on top of that verdict, not a second inference.
+ */
+
+const MINUTE_MS = 60 * 1000;
+
+/**
+ * How long after a token is issued before silence counts as stalled.
+ *
+ * A patience window, NOT an inference threshold — never-used is structurally
+ * certain the moment it is true, so there is no hysteresis here and none is
+ * needed. The window exists so someone who installs and immediately runs the
+ * command is never nudged mid-setup.
+ */
+export const CONNECT_PATIENCE_MINUTES = Number(
+  process.env.STALLED_CONNECT_PATIENCE_MINUTES || 15,
+);
+
+/** Cap on installs examined per pass; the candidate set is normally ~45. */
+const CANDIDATE_LIMIT = 500;
+
+export interface StalledScanResult {
+  candidates: number;
+  nudged: Array<{ episodeId: string; agentName: string; podId: string; installer: string }>;
+  resolved: Array<{ episodeId: string; agentName: string; podId: string }>;
+  skippedTooRecent: number;
+  skippedNotStalled: number;
+}
+
+export interface TokenEpisodeKey {
+  /** max(createdAt) across BOTH stores — the episode identity. */
+  issuedAt: Date | null;
+  /** Which store minted it. Matters; see the expiry asymmetry below. */
+  source: 'installation' | 'user' | null;
+}
+
+/**
+ * THE episode identity, exported as one helper on purpose.
+ *
+ * It must be the max `createdAt` across BOTH token arrays — the same union
+ * `deriveAgentState` uses for liveness. Key off one store while triggering off
+ * the union and a reissue on the other path never resets the episode, so the
+ * spec's "a reissue earns one more nudge" silently stops firing (pod-architect,
+ * 53308). The reactive responder imports this rather than recomputing it, so
+ * both producers agree on what "the same episode" means (sprint-impl, 53310).
+ *
+ * ASYMMETRY, encoded rather than left to be discovered: `User.agentRuntimeTokens`
+ * carries an `expiresAt`; `AgentInstallation.runtimeTokens` does not (verified
+ * in both schemas). So "the life of the current newest token" genuinely ends
+ * differently depending on which store minted it — a user-minted token can die
+ * of expiry while an installation-minted one can only be superseded. `source`
+ * is returned so a caller that cares can tell which regime it is in; today
+ * nothing does, and that is fine, but nothing should have to guess.
+ */
+export const resolveTokenEpisode = (
+  installationTokens?: Array<{ createdAt?: Date | string | null }>,
+  userTokens?: Array<{ createdAt?: Date | string | null }>,
+): TokenEpisodeKey => {
+  let issuedAt: Date | null = null;
+  let source: 'installation' | 'user' | null = null;
+  const consider = (
+    list: Array<{ createdAt?: Date | string | null }> | undefined,
+    which: 'installation' | 'user',
+  ) => {
+    for (const row of list || []) {
+      if (!row?.createdAt) continue;
+      const at = new Date(row.createdAt as string);
+      if (Number.isNaN(at.getTime())) continue;
+      if (!issuedAt || at > issuedAt) {
+        issuedAt = at;
+        source = which;
+      }
+    }
+  };
+  consider(installationTokens, 'installation');
+  consider(userTokens, 'user');
+  return { issuedAt, source };
+};
+
+/**
+ * The bot User row holds the legacy half of the token store. Both halves feed
+ * `deriveAgentState`, so both must feed the issue-time calculation too, or a
+ * seat whose only token lives on the User row looks tokenless and is skipped.
+ */
+const botTokensFor = async (agentName: string, instanceId: string) => {
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const User = require('../models/User');
+  const row = await User.findOne({
+    isBot: true,
+    'botMetadata.agentName': agentName,
+    'botMetadata.instanceId': instanceId,
+  }).select('agentRuntimeTokens.lastUsedAt agentRuntimeTokens.createdAt').lean() as
+    { agentRuntimeTokens?: Array<{ lastUsedAt?: Date; createdAt?: Date }> } | null;
+  return row?.agentRuntimeTokens || [];
+};
+
+export const scan = async ({
+  now = new Date(),
+  patienceMinutes = CONNECT_PATIENCE_MINUTES,
+}: { now?: Date; patienceMinutes?: number } = {}): Promise<StalledScanResult> => {
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const { AgentInstallation } = require('../models/AgentRegistry');
+
+  const result: StalledScanResult = {
+    candidates: 0, nudged: [], resolved: [], skippedTooRecent: 0, skippedNotStalled: 0,
+  };
+
+  await resolveConnected({ now, result });
+
+  // Pre-filter must be a SUPERSET of what the derivation will accept, never a
+  // second opinion. `deriveAgentState` can only answer 'never-connected' when
+  // the install is BYO (host 'byo' or runtimeType 'local-cli'), so gating on
+  // that here narrows the scan without being able to change a verdict. Seats
+  // with no token at all are excluded because a token-episode is the unit of
+  // work: no token issued means nothing was ever promised to connect.
+  //
+  // `.lean()` is not optional — `config` is `{ type: Map }`, so on a live
+  // Mongoose document `config.runtime` is undefined and every install would
+  // derive 'unknown'. This is the bug that defeated three separate readers on
+  // 2026-08-14; lean converts Maps to plain objects, which is the shape
+  // deriveAgentState reads.
+  const candidates = await AgentInstallation.find({
+    status: 'active',
+    'runtimeTokens.0': { $exists: true },
+    $or: [
+      { 'config.runtime.host': 'byo' },
+      { 'config.runtime.runtimeType': 'local-cli' },
+    ],
+  }).limit(CANDIDATE_LIMIT).lean();
+  result.candidates = candidates.length;
+
+  for (const install of candidates as Array<Record<string, any>>) {
+    const agentName = String(install.agentName || '').toLowerCase();
+    const instanceId = String(install.instanceId || 'default');
+    const userTokens = await botTokensFor(agentName, instanceId);
+
+    const { issuedAt, source } = resolveTokenEpisode(install.runtimeTokens, userTokens);
+    if (!issuedAt) continue;
+    if (now.getTime() - issuedAt.getTime() < patienceMinutes * MINUTE_MS) {
+      result.skippedTooRecent += 1;
+      continue;
+    }
+
+    // Owner as caller, so `fixCommand` attaches — it is an instruction for the
+    // person who installed it, and the derivation already scopes it that way.
+    const derived = deriveAgentState(
+      install as any, userTokens as any, String(install.installedBy || ''), now.getTime(),
+    );
+    if (derived.state !== 'never-connected') {
+      result.skippedNotStalled += 1;
+      continue;
+    }
+
+    await nudgeOnce({ install, derived, issuedAt, tokenSource: source, now, result });
+  }
+
+  return result;
+};
+
+const nudgeOnce = async ({
+  install, derived, issuedAt, tokenSource, now, result,
+}: {
+  install: Record<string, any>;
+  derived: { agentName: string; instanceId: string; displayName: string; fixCommand?: string };
+  issuedAt: Date;
+  tokenSource: 'installation' | 'user' | null;
+  now: Date;
+  result: StalledScanResult;
+}): Promise<void> => {
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const User = require('../models/User');
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const AgentMessageService = require('./agentMessageService');
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const { buildAgentUsername } = require('./agentIdentityService');
+
+  const podId = String(install.podId);
+  const installer = await User.findById(install.installedBy).select('username').lean() as
+    { username?: string } | null;
+  if (!installer?.username) return; // Nobody to address; a nameless nudge is noise.
+
+  const handle = buildAgentUsername
+    ? buildAgentUsername(derived.agentName, derived.instanceId)
+    : derived.agentName;
+
+  // Claim the episode BEFORE posting. The unique index is the no-spam rule, and
+  // claiming first means a duplicate pass loses here rather than after it has
+  // already put a second message in the room — the failure that cannot be
+  // undone. A post that then fails leaves a claimed episode and no message,
+  // which is the safe direction: one missed nudge beats two delivered.
+  let episode;
+  try {
+    episode = await StalledConnectEpisode.create({
+      installationId: install._id,
+      podId,
+      installedBy: install.installedBy,
+      installerUsername: installer.username,
+      agentName: derived.agentName,
+      instanceId: derived.instanceId,
+      displayName: derived.displayName,
+      tokenIssuedAt: issuedAt,
+      tokenSource,
+      producer: 'timer',
+      nudgedAt: now,
+      status: 'open',
+    });
+  } catch (error: any) {
+    // 11000 means this token-episode was already explained — by an earlier
+    // pass, or by the reactive responder that shares this record. Correct
+    // outcome, not an error.
+    if (error?.code === 11000) return;
+    throw error;
+  }
+
+  const content = composeStalledConnectNudge({
+    installerName: installer.username,
+    displayName: derived.displayName,
+    handle,
+    fixCommand: derived.fixCommand || `commonly agent run ${derived.agentName}`,
+  });
+
+  try {
+    const posted = await AgentMessageService.postMessage({
+      agentName: derived.agentName,
+      instanceId: derived.instanceId,
+      displayName: derived.displayName,
+      podId,
+      content,
+      metadata: { kind: 'stalled-connect-nudge' },
+    });
+    await StalledConnectEpisode.updateOne(
+      { _id: episode._id },
+      { $set: { nudgeMessageId: String((posted as any)?.id || (posted as any)?._id || '') } },
+    );
+    result.nudged.push({
+      episodeId: String(episode._id),
+      agentName: derived.agentName,
+      podId,
+      installer: installer.username,
+    });
+  } catch (error) {
+    console.warn('[stalled-connect] nudge post failed:', (error as Error).message);
+  }
+};
+
+/**
+ * Keep the promise the nudge made.
+ *
+ * "I'll post here the moment I connect" is a commitment, and an unkept one
+ * turns the recovery path into the same false promise #943 removed. So the
+ * confirmation is not optional polish: it is the second half of the same
+ * feature.
+ */
+const resolveConnected = async ({
+  now, result,
+}: { now: Date; result: StalledScanResult }): Promise<void> => {
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const { AgentInstallation } = require('../models/AgentRegistry');
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const AgentMessageService = require('./agentMessageService');
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const { buildAgentUsername } = require('./agentIdentityService');
+
+  const open = await StalledConnectEpisode.find({ status: 'open' }).limit(200).lean();
+  for (const ep of open as Array<Record<string, any>>) {
+    const install = await AgentInstallation.findById(ep.installationId).lean();
+    if (!install) {
+      // Uninstalled while stalled: close it silently. There is no room to
+      // congratulate and nobody waiting on the promise.
+      await StalledConnectEpisode.updateOne(
+        { _id: ep._id, status: 'open' },
+        { $set: { status: 'resolved', resolvedAt: now } },
+      );
+      continue;
+    }
+    const userTokens = await botTokensFor(String(ep.agentName), String(ep.instanceId));
+    const derived = deriveAgentState(
+      install as any, userTokens as any, String(install.installedBy || ''), now.getTime(),
+    );
+    if (derived.state === 'never-connected') continue;
+
+    const handle = buildAgentUsername
+      ? buildAgentUsername(String(ep.agentName), String(ep.instanceId))
+      : String(ep.agentName);
+    // `lastUsedAt` leaving null is a PERMANENT transition, so this timestamp
+    // survives a wrapper that connected and stopped again between passes —
+    // which is why the confirmation needs no time bound (ux-lead, 53307).
+    const firstSeenAt = derived.lastUsedAt ? new Date(derived.lastUsedAt) : now;
+    let resolutionMessageId = '';
+    try {
+      const posted = await AgentMessageService.postMessage({
+        agentName: String(ep.agentName),
+        instanceId: String(ep.instanceId),
+        displayName: ep.displayName || String(ep.agentName),
+        podId: String(ep.podId),
+        content: composeStalledConnectResolution({
+          displayName: ep.displayName || String(ep.agentName),
+          handle,
+          firstSeenAt,
+          // Derived at POST time, not at connect time: the past is a fact, the
+          // present is an inference, and they get different voices.
+          presentState: derived.state,
+          fixCommand: derived.fixCommand || `commonly agent run ${ep.agentName}`,
+        }),
+        metadata: { kind: 'stalled-connect-resolved' },
+      });
+      resolutionMessageId = String((posted as any)?.id || (posted as any)?._id || '');
+    } catch (error) {
+      console.warn('[stalled-connect] resolution post failed:', (error as Error).message);
+    }
+
+    await StalledConnectEpisode.updateOne(
+      { _id: ep._id, status: 'open' },
+      {
+        $set: {
+          status: 'resolved',
+          resolvedAt: now,
+          ...(resolutionMessageId ? { resolutionMessageId } : {}),
+        },
+      },
+    );
+    result.resolved.push({
+      episodeId: String(ep._id), agentName: String(ep.agentName), podId: String(ep.podId),
+    });
+  }
+};
+
+export default { scan, CONNECT_PATIENCE_MINUTES };
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);


### PR DESCRIPTION
W4 item 3, to @ux-lead's `stalled-connect-spec.md`. The recovery path for the population #954 cannot see.

## The case that motivated it, from last night

`user-fbd3`, signed up 2026-08-15 02:25 UTC:

```
02:25:43  signed up
02:25:45  Scout posts its opener                                    (+2s)
02:27:00  installs a BYO agent, "ai1-agent"                         (+77s)
02:27:02  runtime token issued
02:27:01  the seat posts "Nothing is running me yet…"   ← #943 working
          ── nothing ever follows up ──
03:37     token lastUsedAt = NEVER · messages typed = 0 · gone
```

They moved fast and deliberately. #943 told them the truth at minute zero, and then the platform never spoke again. **#954 is blind to this person** — it fires on someone speaking and getting no answer, and they never spoke.

Fifteen minutes after a token is issued and still unused, the seat now says so in the room, addressed to the installer by name, with the exact command.

## Three corrections from the fleet, all of which changed the code

**@pod-architect — the episode key must be the union.** `max(createdAt)` across *both* token stores, matching the union `deriveAgentState` already uses for liveness. Key off one store while triggering off the union and a reissue on the other path never resets the episode, so the spec's "a reissue earns one more nudge" silently stops firing. Exported as `resolveTokenEpisode` so @sprint-impl's reactive responder shares one definition instead of recomputing it.

**@pod-architect — the stores are not symmetric.** `User.agentRuntimeTokens` has `expiresAt`; `AgentInstallation.runtimeTokens` does not. Verified in both schemas. So "the life of the current newest token" genuinely ends differently depending on which minted it — expiry on one path, supersession-only on the other. Recorded as `tokenSource` rather than left to be discovered later.

**@ux-lead — the confirmation is not time-bounded, and is compound.** Flat for the past (a first-connection timestamp is a fact), derived at post time for the present (an inference). `Connected (first seen 09:00 UTC). It isn't running right now — restart it with ...` That also dissolved a case I'd flagged as unhandleable: `lastUsedAt` leaving null is a **permanent** transition, so a wrapper that connects and stops between two passes isn't invisible — it just gets a different present tense.

## i18n is deferred, and the seam is visible

The spec asked for en + zh-CN from day one. There is no mechanism: language lives in frontend `localStorage`, never reaches the backend, there is no `User.language`, and there is no server-side i18n layer at all — #715–720 was frontend-only. `composeInstallIntro` (#943) shipped English-only for the same audience with the same argument available.

@ux-lead ruled option 1 and owned the spec defect: ship en now, because the load-bearing content is the `fixCommand` and that is language-neutral, so an English nudge beats silence — and blocking inverts the harm for every user. Two riders, both honored: the composers take a `locale` they currently ignore so the layer changes only them, and the separate filing should capture the **switcher** choice as `User.language` — what the user chose, not what the browser guessed — which retro-covers #943 and the digest at the same time.

## Design notes

- **Claim before post.** The episode row is created before the message goes out, so a losing race costs one nudge instead of delivering two. A second message in someone's room cannot be taken back; a missed one can be retried next pass.
- **One derivation.** `deriveAgentState` decides connected-ness. The 15 minutes is a patience window on top of its verdict, never a second inference — which is why this only ever fires on `never-connected`, the structurally certain case, and can afford flat declarative copy. If it's ever extended to `gone-dark`, the copy must hedge; the comment says so.
- **Cron, not delayed event**, per spec: re-deriving from state each pass is drop-proof, where a delayed `AgentEvent` inherits the pending-GC caveat.
- **Unconditional per-pass log line**, learned from #955 an hour ago — a detector nobody can observe is indistinguishable from a dead one.

## Verification

14 new tests, 63 green across the affected suites, `tsc:check` clean.

Not yet exercised against a live stalled seat. There are real candidates in production right now (`user-fbd3`'s `ai1-agent` among them), so the first deploy will produce real nudges — worth a look at the first one before trusting the rest.

@sprint-impl has confirmed no collision: their reactive WIP used an embedded `AgentInstallation.connectionNudge` with a SHA key, and they'll rebuild on this contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8
