### PR TITLE
fix(onboarding): capture the nudge's message id, which is nested under `message`

### DIFF
--- a/backend/__tests__/unit/services/stalledConnectService.test.js
+++ b/backend/__tests__/unit/services/stalledConnectService.test.js
@@ -76,7 +76,7 @@ const setup = ({ installs = [install()], userTokens = [], open = [] } = {}) => {
   mockEpFind.mockReturnValue({ limit: () => ({ lean: () => Promise.resolve(open) }) });
   mockEpCreate.mockImplementation((d) => Promise.resolve({ _id: 'ep1', ...d }));
   mockEpUpdate.mockResolvedValue({});
-  mockPost.mockResolvedValue({ id: 'msg1' });
+  mockPost.mockResolvedValue({ success: true, message: { id: 'msg1' } });
 };
 
 beforeEach(() => jest.clearAllMocks());
@@ -142,7 +142,10 @@ describe('stalledConnectService.scan', () => {
     setup();
     const order = [];
     mockEpCreate.mockImplementation(async (d) => { order.push('claim'); return { _id: 'ep1', ...d }; });
-    mockPost.mockImplementation(async () => { order.push('post'); return { id: 'm' }; });
+    mockPost.mockImplementation(async () => {
+      order.push('post');
+      return { success: true, message: { id: 'm' } };
+    });
 
     await scan({ now: NOW });
 
@@ -157,6 +160,30 @@ describe('stalledConnectService.scan', () => {
 
     expect(r.nudged).toHaveLength(0);
     expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  // The first live run landed 10 correct messages and recorded 10 empty ids,
+  // because postMessage returns { success, message } and the code read
+  // `posted.id`. The old fixture returned `{ id }` — the shape the bug
+  // expected — so the tests agreed with the bug rather than with the service.
+  it('records the real message id, which is nested under `message`', async () => {
+    setup();
+    await scan({ now: NOW });
+
+    expect(mockEpUpdate).toHaveBeenCalledWith(
+      { _id: 'ep1' },
+      { $set: { nudgeMessageId: 'msg1' } },
+    );
+  });
+
+  it('does not report a nudge when postMessage declined to post', async () => {
+    setup();
+    mockPost.mockResolvedValue({ success: true, skipped: true, reason: 'duplicate_recent' });
+
+    const r = await scan({ now: NOW });
+
+    expect(r.nudged).toHaveLength(0);
+    expect(mockEpUpdate).not.toHaveBeenCalled();
   });
 
   it('records the episode against the token issue time and its source', async () => {

--- a/backend/services/stalledConnectService.ts
+++ b/backend/services/stalledConnectService.ts
@@ -124,6 +124,27 @@ const botTokensFor = async (agentName: string, instanceId: string) => {
   return row?.agentRuntimeTokens || [];
 };
 
+/**
+ * Pull the message id out of an AgentMessageService.postMessage result.
+ *
+ * It is NOT at the top level. The success shape is
+ * `{ success, message, summary }`, so the id lives at `message.id` (PG, the
+ * primary store) or `message._id` (the Mongo fallback path). Reading
+ * `posted.id` yields undefined, which is what the first live run did: ten
+ * nudges landed correctly in ten pods and all ten recorded
+ * `nudgeMessageId: ''`. The messages were fine; the audit trail was not — and
+ * "why did this person never get nudged" is unanswerable without it.
+ *
+ * Returns null rather than '' for the skipped shapes (`{ success, skipped }`),
+ * so a caller can tell "posted" from "declined to post".
+ */
+const extractMessageId = (posted: unknown): string | null => {
+  const msg = (posted as { message?: { id?: unknown; _id?: unknown } })?.message;
+  const raw = msg?.id ?? msg?._id;
+  if (raw === undefined || raw === null || raw === '') return null;
+  return String(raw);
+};
+
 export const scan = async ({
   now = new Date(),
   patienceMinutes = CONNECT_PATIENCE_MINUTES,
@@ -258,9 +279,22 @@ const nudgeOnce = async ({
       content,
       metadata: { kind: 'stalled-connect-nudge' },
     });
+    const messageId = extractMessageId(posted);
+    if (!messageId) {
+      // postMessage can succeed-without-posting (`skipped: true` for duplicate
+      // or suppressed sends). Counting that as delivered is the silent-success
+      // shape: the episode stays claimed either way — correct, since something
+      // decided this room did not need the message — but the caller must not
+      // be told a nudge went out when none did.
+      console.warn(
+        `[stalled-connect] no message id for episode=${episode._id} `
+        + `agent=${derived.agentName} — post skipped or shape changed`,
+      );
+      return;
+    }
     await StalledConnectEpisode.updateOne(
       { _id: episode._id },
-      { $set: { nudgeMessageId: String((posted as any)?.id || (posted as any)?._id || '') } },
+      { $set: { nudgeMessageId: messageId } },
     );
     result.nudged.push({
       episodeId: String(episode._id),
@@ -334,7 +368,7 @@ const resolveConnected = async ({
         }),
         metadata: { kind: 'stalled-connect-resolved' },
       });
-      resolutionMessageId = String((posted as any)?.id || (posted as any)?._id || '');
+      resolutionMessageId = extractMessageId(posted) || '';
     } catch (error) {
       console.warn('[stalled-connect] resolution post failed:', (error as Error).message);
     }


### PR DESCRIPTION
Found by reading production after #956 deployed, not by CI.

## What happened

The first live pass did the right thing: `candidates=26 nudged=10 tooRecent=0 notStalled=16`, and ten messages landed in ten pods — right people, right pods, right commands. Verified in PG, e.g.

> `@kaka — I'm installed here, but nothing has ever started me, so mentioning @kaka-agent won't reach anyone yet. Run `commonly agent run kaka-agent` on the machine where I should live and I'll come online. I'll post here the moment I connect.`

And all ten episodes recorded `nudgeMessageId: ''`.

`AgentMessageService.postMessage` returns `{ success, message, summary }` — the id is at `message.id` (PG, the primary store) or `message._id` (Mongo fallback). The code read `posted.id`. Undefined every time.

The messages were fine. The audit trail was not, and "why did this person never get nudged" is unanswerable without it — which is exactly the question this feature exists to make answerable. @sprint-impl's reactive responder inherits the same record.

## Why the tests passed

The fixture returned `{ id: 'msg1' }` — **the shape the bug expected**. I wrote the mock from the calling code's assumption instead of from what `postMessage` actually returns, so the test agreed with the bug rather than with the service.

That is the third variant of this in two days, after "a test that re-declared the handler instead of importing it" and "a test that passed `podAuthorized: true` and so only proved the service honours a flag". Same root: **a fixture asserted against an assumption is not evidence.** The fixture now matches the real return shape and a test pins the recorded id.

## Second fix in here

`postMessage` can succeed-without-posting (`{ success: true, skipped: true }` for duplicate or suppressed sends). That was being counted as a delivered nudge — the silent-success shape yet again. The episode stays claimed, which is right (something decided that room did not need the message), but the caller is no longer told a nudge went out when none did.

## Not fixed here

The ten already-sent episodes keep their empty ids. The messages exist (`53316`–`53325`) and are recoverable by pod + timestamp if we want them backfilled — say the word. I did not do it silently because it is a data write to repair an audit field, and the messages themselves are already correctly delivered.

## Correction to something I said before deploying

I told Sam "nobody gets more than one" nudge. True for every real user, and **false for the smoke fixture**, which has two stalled seats in one pod and so got two messages there. Episodes are per (installation, token), so a user with two stalled seats in one pod gets two posts. Correct behaviour, wrong claim.

65 tests green, `tsc:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8
