### PR TITLE
fix: derive wake policy from pod shape

### DIFF
--- a/backend/__tests__/unit/controllers/authController.guideIdentity.test.js
+++ b/backend/__tests__/unit/controllers/authController.guideIdentity.test.js
@@ -25,7 +25,11 @@ const mockPostMessage = jest.fn().mockResolvedValue({});
 const mockPodUpdateOne = jest.fn().mockResolvedValue({});
 
 jest.mock('../../../models/Pod', () => ({
-  create: jest.fn().mockImplementation(async () => ({ _id: 'pod-123' })),
+  create: jest.fn().mockImplementation(async (attrs) => ({
+    _id: 'pod-123',
+    type: attrs.type,
+    members: attrs.members,
+  })),
   updateOne: (...args) => mockPodUpdateOne(...args),
 }));
 jest.mock('../../../models/User', () => ({ findById: jest.fn().mockResolvedValue({ _id: 'user-1' }) }));
@@ -39,7 +43,10 @@ jest.mock('../../../models/AgentRegistry', () => ({
   AgentInstallation: { findOneAndUpdate: (...args) => mockInstallUpsert(...args) },
 }));
 jest.mock('../../../scripts/seed-native-agents', () => ({
-  buildInstallationConfig: jest.fn(() => ({ runtime: { runtimeType: 'native' } })),
+  buildInstallationConfig: jest.fn(() => ({
+    runtime: { runtimeType: 'native' },
+    wakeOnMessage: { enabled: true },
+  })),
 }));
 jest.mock('../../../services/agentMessageService', () => ({
   postMessage: (...args) => mockPostMessage(...args),
@@ -75,6 +82,9 @@ describe('createDefaultWorkspacePod guide identity fork (2026-08-13)', () => {
       agentName: 'scout',
       instanceId: expected,
     }));
+    // My Workspace is personal at install time, so Guide keeps its explicit
+    // wake request. A shared room uses the same resolver and is mention-only.
+    expect(update.$set.config.wakeOnMessage.enabled).toBe(true);
   });
 
   test('two users get two distinct guide identities — the memory-envelope fork', async () => {

--- a/backend/__tests__/unit/models/AgentInstallation.wakePolicy.test.js
+++ b/backend/__tests__/unit/models/AgentInstallation.wakePolicy.test.js
@@ -1,0 +1,89 @@
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const Pod = require('../../../models/Pod');
+const User = require('../../../models/User');
+const { AgentInstallation } = require('../../../models/AgentRegistry');
+
+describe('AgentInstallation wake-policy install boundary', () => {
+  let mongoServer;
+  let owner;
+  let guide;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create({
+      binary: { version: '7.0.14', skipMD5: true },
+      instance: { dbName: 'agent-installation-wake-policy-test' },
+    });
+    await mongoose.connect(mongoServer.getUri());
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer?.stop();
+  });
+
+  beforeEach(async () => {
+    await Promise.all([Pod.deleteMany({}), User.deleteMany({}), AgentInstallation.deleteMany({})]);
+    owner = await User.create({ username: 'owner', email: 'owner@example.com', password: 'placeholder' });
+    guide = await User.create({
+      username: 'guide',
+      email: 'guide@agent.local',
+      password: 'placeholder',
+      isBot: true,
+    });
+  });
+
+  const installGuide = (podId) => AgentInstallation.install('guide', podId, {
+    version: '1.0.0',
+    installedBy: owner._id,
+    config: { wakeOnMessage: { enabled: true } },
+  });
+
+  test('preserves Guide wake-on-message only for a personal chat', async () => {
+    const pod = await Pod.create({
+      name: 'My Workspace',
+      type: 'chat',
+      createdBy: owner._id,
+      members: [owner._id, guide._id],
+    });
+
+    await installGuide(pod._id);
+
+    const installation = await AgentInstallation.findOne({ agentName: 'guide', podId: pod._id });
+    expect(installation.config.get('wakeOnMessage')).toEqual({ enabled: true });
+  });
+
+  test('normalizes the same manifest opt-in off before it reaches a shared chat row', async () => {
+    const teammate = await User.create({ username: 'teammate', email: 'teammate@example.com', password: 'placeholder' });
+    const pod = await Pod.create({
+      name: 'Project',
+      type: 'chat',
+      createdBy: owner._id,
+      members: [owner._id, guide._id, teammate._id],
+    });
+
+    await installGuide(pod._id);
+
+    const installation = await AgentInstallation.findOne({ agentName: 'guide', podId: pod._id });
+    expect(installation.config.get('wakeOnMessage')).toEqual({ enabled: false });
+  });
+
+  test('keeps the install but fails closed if it cannot load the pod shape', async () => {
+    const pod = await Pod.create({
+      name: 'My Workspace',
+      type: 'chat',
+      createdBy: owner._id,
+      members: [owner._id, guide._id],
+    });
+    const lookup = jest.spyOn(Pod, 'findById').mockImplementationOnce(() => {
+      throw new Error('temporary database error');
+    });
+
+    await installGuide(pod._id);
+
+    const installation = await AgentInstallation.findOne({ agentName: 'guide', podId: pod._id });
+    expect(installation.config.get('wakeOnMessage')).toEqual({ enabled: false });
+    lookup.mockRestore();
+  });
+});

--- a/backend/__tests__/unit/services/agentMentionService.wakeOnMessage.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.wakeOnMessage.test.js
@@ -76,12 +76,12 @@ const mockInstallations = (installations) => {
   });
 };
 
-const mockPodType = (type) => {
+const mockPod = (type, members = ['user-1', 'seat-a']) => {
   Pod.findById.mockReturnValue({
     select: jest.fn().mockReturnValue({
-      lean: jest.fn().mockResolvedValue({ type }),
+      lean: jest.fn().mockResolvedValue({ type, members }),
     }),
-    lean: jest.fn().mockResolvedValue({ _id: 'pod-1', type }),
+    lean: jest.fn().mockResolvedValue({ _id: 'pod-1', type, members }),
   });
 };
 
@@ -115,7 +115,7 @@ describe('wake-on-message (ADR-018 D8)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockHumanSender();
-    mockPodType('project');
+    mockPod('chat');
     AgentEvent.countDocuments.mockResolvedValue(0);
   });
 
@@ -235,12 +235,29 @@ describe('wake-on-message (ADR-018 D8)', () => {
   });
 
   test('DM-shaped pods are excluded — enqueueDmEvent already routes every message there', async () => {
-    mockPodType('agent-room');
+    mockPod('agent-room');
     mockInstallations([install('seat-a', { optIn: true })]);
 
     const res = await AgentMentionService.enqueueMentions({
       podId: 'pod-dm',
       message: { content: 'dm chatter', id: 'msg-6' },
+      userId: 'user-1',
+      username: 'alice',
+    });
+
+    expect(res.woken).toEqual([]);
+    expect(wakeCalls()).toHaveLength(0);
+  });
+
+  test('a historic opt-in is disabled as soon as its chat becomes shared', async () => {
+    // Config was stamped while the room was personal; another human joining
+    // must switch this delivery path to mention-only without reinstalling.
+    mockPod('chat', ['user-1', 'seat-a', 'user-2']);
+    mockInstallations([install('seat-a', { optIn: true })]);
+
+    const res = await AgentMentionService.enqueueMentions({
+      podId: 'pod-1',
+      message: { content: 'team update', id: 'msg-7' },
       userId: 'user-1',
       username: 'alice',
     });

--- a/backend/__tests__/unit/services/approvalActionService.test.js
+++ b/backend/__tests__/unit/services/approvalActionService.test.js
@@ -161,8 +161,13 @@ describe('approved create_pod execution — D2: user authority owns', () => {
     mockApprovalFindById.mockResolvedValue(flaggedRow());
     const resolved = flaggedRow({ status: 'resolved', decision: 'approved' });
     mockApprovalFindOneAndUpdate.mockResolvedValue(resolved);
-    mockPodCreate.mockResolvedValue({ _id: 'newpod-1', name: 'Design Studio' });
-    mockInstallFindOne.mockReturnValue({ lean: jest.fn().mockResolvedValue({ displayName: 'Guide', scopes: ['context:read'], config: {}, version: '1.0.0' }) });
+    mockPodCreate.mockResolvedValue({ _id: 'newpod-1', name: 'Design Studio', type: 'chat', members: [OWNER] });
+    mockInstallFindOne.mockReturnValue({ lean: jest.fn().mockResolvedValue({
+      displayName: 'Guide',
+      scopes: ['context:read'],
+      config: { wakeOnMessage: { enabled: true } },
+      version: '1.0.0',
+    }) });
     mockInstallUpsert.mockResolvedValue({});
     mockGetOrCreateAgentUser.mockResolvedValue({ _id: 'guide-bot-1' });
     mockPodUpdateOne.mockResolvedValue({});
@@ -184,6 +189,9 @@ describe('approved create_pod execution — D2: user authority owns', () => {
       expect.anything(),
       expect.anything(),
     );
+    // A newly-created chat begins personal (owner + agent) and keeps the
+    // explicit opt-in; later fan-out re-resolves this when membership changes.
+    expect(mockInstallUpsert.mock.calls[0][1].$set.config.wakeOnMessage.enabled).toBe(true);
     expect(mockPodUpdateOne).toHaveBeenCalledWith(
       { _id: 'newpod-1', members: { $ne: 'guide-bot-1' } },
       { $push: { members: 'guide-bot-1' } },

--- a/backend/__tests__/unit/services/schedulerService.digestEmail.test.js
+++ b/backend/__tests__/unit/services/schedulerService.digestEmail.test.js
@@ -66,4 +66,16 @@ describe('scheduler daily digest delivery', () => {
     expect(dailyDigestService.generateAllDailyDigests.mock.invocationCallOrder[0])
       .toBeLessThan(digestEmailService.sendDigestEmails.mock.invocationCallOrder[0]);
   });
+
+  it('owns cron jobs once per process even if a second scheduler instance starts', () => {
+    schedulerService.start();
+    const scheduledByFirstStart = require('node-cron').schedule.mock.calls.length;
+    const SchedulerService = schedulerService.constructor;
+    const secondInstance = new SchedulerService();
+
+    secondInstance.start();
+
+    expect(require('node-cron').schedule).toHaveBeenCalledTimes(scheduledByFirstStart);
+    expect(secondInstance.isRunning).toBe(false);
+  });
 });

--- a/backend/__tests__/unit/services/wakePolicyService.test.js
+++ b/backend/__tests__/unit/services/wakePolicyService.test.js
@@ -1,0 +1,36 @@
+const {
+  isOneToOneShapedPod,
+  resolveWakePolicy,
+  wakeOnMessageEnabledForPod,
+} = require('../../../services/wakePolicyService');
+
+const wakeConfig = { runtime: { runtimeType: 'native' }, wakeOnMessage: { enabled: true } };
+
+describe('wake policy — personal rooms wake, shared rooms mention-only', () => {
+  test('keeps an explicit opt-in for a 1:1-shaped private chat', () => {
+    const pod = { type: 'chat', members: ['owner', 'guide'] };
+
+    expect(isOneToOneShapedPod(pod)).toBe(true);
+    expect(resolveWakePolicy(wakeConfig, pod)).toEqual(wakeConfig);
+    expect(wakeOnMessageEnabledForPod(wakeConfig, pod)).toBe(true);
+  });
+
+  test('turns the same opt-in off in a shared chat and every non-chat shape', () => {
+    const shared = { type: 'chat', members: ['owner', 'guide', 'teammate'] };
+
+    expect(isOneToOneShapedPod(shared)).toBe(false);
+    expect(resolveWakePolicy(wakeConfig, shared)).toEqual({
+      runtime: { runtimeType: 'native' },
+      wakeOnMessage: { enabled: false },
+    });
+    expect(wakeOnMessageEnabledForPod(wakeConfig, shared)).toBe(false);
+    expect(wakeOnMessageEnabledForPod(wakeConfig, { type: 'team', members: ['owner'] })).toBe(false);
+  });
+
+  test('preserves default-off configurations and fails closed without a pod shape', () => {
+    const defaultOff = { runtime: { runtimeType: 'native' } };
+
+    expect(resolveWakePolicy(defaultOff, undefined)).toEqual(defaultOff);
+    expect(wakeOnMessageEnabledForPod(wakeConfig, undefined)).toBe(false);
+  });
+});

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -8,6 +8,7 @@ const AgentIdentityService = require('../services/agentIdentityService');
 const { sendEmail } = require('../services/emailService');
 const { ensureUserInCommunityPod } = require('../services/communityPodService');
 const { normalizeAvatarUrl } = require('../services/avatarService');
+const { resolveWakePolicy } = require('../services/wakePolicyService');
 
 const joinCommunityPodBestEffort = (userId: any) => {
   void ensureUserInCommunityPod(userId).catch((err: Error) => {
@@ -192,7 +193,7 @@ const createDefaultWorkspacePod = async (userId: any) => {
             version: '1.0.0',
             displayName: scoutApp.displayName,
             scopes: ['context:read', 'messages:write', 'memory:read', 'memory:write'],
-            config: buildInstallationConfig(scoutApp),
+            config: resolveWakePolicy(buildInstallationConfig(scoutApp), pod),
           },
           $setOnInsert: {
             agentName: scoutApp.agentName,

--- a/backend/models/AgentRegistry.ts
+++ b/backend/models/AgentRegistry.ts
@@ -1,4 +1,6 @@
 import mongoose, { Document, Model, Schema, Types } from 'mongoose';
+import Pod from './Pod';
+import { hasWakeOnMessageOptIn, resolveWakePolicy } from '../services/wakePolicyService';
 
 export type RegistryType = 'commonly-official' | 'commonly-community' | 'private';
 export type RegistryStatus = 'active' | 'deprecated' | 'unpublished' | 'pending-review';
@@ -271,6 +273,24 @@ AgentInstallationSchema.statics.isInstalled = async function (agentName: string,
   return !!installation;
 };
 
+// Install writers may request wake-on-message, but the room decides whether
+// that request is safe. Keep the policy next to the model helper so every
+// normal install/upsert path gets the same derivation; the two historical
+// direct writes resolve it explicitly at their call sites.
+const resolveInstallWakePolicy = async (
+  podId: Types.ObjectId,
+  config: Map<string, unknown> | undefined,
+): Promise<Map<string, unknown> | undefined> => {
+  if (!config || !hasWakeOnMessageOptIn(config)) return config;
+  try {
+    const pod = await Pod.findById(podId).select('type members').lean();
+    return resolveWakePolicy(config, pod) as unknown as Map<string, unknown>;
+  } catch {
+    // Preserve the install while failing closed on the expensive behavior.
+    return resolveWakePolicy(config, null) as unknown as Map<string, unknown>;
+  }
+};
+
 AgentInstallationSchema.statics.install = async function (agentName: string, podId: Types.ObjectId, options: {
   version: string;
   config?: Map<string, unknown>;
@@ -280,16 +300,17 @@ AgentInstallationSchema.statics.install = async function (agentName: string, pod
   displayName?: string;
 }) {
   const { version, config, scopes, installedBy, instanceId = 'default', displayName } = options;
+  const resolvedConfig = await resolveInstallWakePolicy(podId, config);
   const existing = await this.findOne({ agentName: agentName.toLowerCase(), podId, instanceId });
   if (existing) {
     if (existing.status === 'active') throw new Error('Agent already installed');
     existing.status = 'active';
     existing.version = version;
-    existing.config = config;
+    existing.config = resolvedConfig;
     existing.scopes = scopes;
     return existing.save();
   }
-  return this.create({ agentName: agentName.toLowerCase(), podId, instanceId, displayName, version, config, scopes, installedBy });
+  return this.create({ agentName: agentName.toLowerCase(), podId, instanceId, displayName, version, config: resolvedConfig, scopes, installedBy });
 };
 
 /**
@@ -313,11 +334,12 @@ AgentInstallationSchema.statics.upsert = async function (agentName: string, podI
   displayName?: string;
 }) {
   const { version, config, scopes, installedBy, instanceId = 'default', displayName } = options;
+  const resolvedConfig = await resolveInstallWakePolicy(podId, config);
   const filter = { agentName: agentName.toLowerCase(), podId, instanceId };
   const update = {
     $setOnInsert: { agentName: agentName.toLowerCase(), podId, instanceId, installedBy, version, displayName },
     $set: {
-      ...(config ? { config } : {}),
+      ...(resolvedConfig ? { config: resolvedConfig } : {}),
       ...(scopes ? { scopes } : {}),
       status: 'active',
     },

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -16,6 +16,7 @@ const chatSummarizerService = require('./chatSummarizerService');
 const { maybeFireWelcomeWake } = require('./welcomeWakeService') as {
   maybeFireWelcomeWake: (opts: Record<string, unknown>) => Promise<unknown>;
 };
+import { hasWakeOnMessageOptIn, wakeOnMessageEnabledForPod } from './wakePolicyService';
 // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
 const { resolveAgentDisplayLabel } = require('./agentIdentityService') as {
   resolveAgentDisplayLabel: (
@@ -813,11 +814,6 @@ const WAKE_ON_MESSAGE_FRAME = '[Wake-on-message: you wake on EVERY message in '
   + 'act, the message must be claimed first (commonly_claim_message) — if the '
   + 'claim is already held by a peer, stand down.]';
 
-const wakeOnMessageEnabled = (installation: Record<string, unknown>): boolean => (
-  (installation as { config?: { wakeOnMessage?: { enabled?: unknown } } })
-    ?.config?.wakeOnMessage?.enabled === true
-);
-
 // #508's shape, pointed at the wake path: a BOT-authored message that would
 // wake a target already woken >MENTION_LOOP_MAX times in the window is a wake
 // storm, not collaboration. Human-authored messages are never dampened —
@@ -873,19 +869,24 @@ const enqueueWakeOnMessage = async ({
   authorFrame: { username: string; createdAt: unknown; messageId: string | undefined };
 }): Promise<string[]> => {
   const woken: string[] = [];
-  const targets = (installations || []).filter(wakeOnMessageEnabled);
-  if (targets.length === 0) return woken;
+  const optedIn = (installations || []).filter((installation) => hasWakeOnMessageOptIn(installation.config));
+  if (optedIn.length === 0) return woken;
 
-  let podType: string | null = null;
+  let podRow: { type?: string; members?: unknown[] } | null = null;
   try {
-    const podRow = await Pod.findById(podId).select('type').lean() as { type?: string } | null;
-    podType = podRow?.type || null;
+    podRow = await Pod.findById(podId).select('type members').lean() as { type?: string; members?: unknown[] } | null;
   } catch {
     // Cannot verify the pod shape — skip rather than risk double-delivering
     // into a DM pod that enqueueDmEvent already covers.
     return woken;
   }
-  if (podType && DM_POD_TYPES.has(podType)) return woken;
+  if (podRow?.type && DM_POD_TYPES.has(podRow.type)) return woken;
+
+  // Re-resolve at delivery time. A personal room can become shared after the
+  // installation was created; never let a stale config turn every new line
+  // into a wake after that transition.
+  const targets = optedIn.filter((installation) => wakeOnMessageEnabledForPod(installation.config, podRow));
+  if (targets.length === 0) return woken;
 
   const senderKey = sender?.isBot
     ? `${String(sender.botMetadata?.agentName || '').toLowerCase()}:${String(sender.botMetadata?.instanceId || 'default').toLowerCase()}`

--- a/backend/services/approvalActionService.ts
+++ b/backend/services/approvalActionService.ts
@@ -14,6 +14,7 @@
 import ApprovalAction, { IApprovalAction, ApprovalActionType } from '../models/ApprovalAction';
 import Pod from '../models/Pod';
 import User from '../models/User';
+import { resolveWakePolicy } from './wakePolicyService';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { AgentInstallation } = require('../models/AgentRegistry');
@@ -641,7 +642,7 @@ const executeCreatePod = async (row: IApprovalAction): Promise<unknown> => {
           version: originInstall?.version || '1.0.0',
           displayName: originInstall?.displayName,
           scopes: originInstall?.scopes || ['context:read', 'messages:write'],
-          config: originInstall?.config || {},
+          config: resolveWakePolicy(originInstall?.config || {}, pod),
         },
         $setOnInsert: {
           agentName: row.agentName,

--- a/backend/services/schedulerService.ts
+++ b/backend/services/schedulerService.ts
@@ -107,6 +107,10 @@ interface CodexRefreshResult {
   expiresAt: number;
 }
 
+// Cron jobs are process-local. Keep one module-private owner so a second
+// SchedulerService instance cannot start a duplicate job set in this process.
+let activeScheduler: SchedulerService | null = null;
+
 class SchedulerService {
   isRunning: boolean;
 
@@ -118,7 +122,7 @@ class SchedulerService {
   }
 
   start(): void {
-    if (this.isRunning) {
+    if (activeScheduler) {
       console.log('Scheduler is already running');
       return;
     }
@@ -418,6 +422,7 @@ class SchedulerService {
     ];
     this.jobs.forEach((job) => job.start());
     this.isRunning = true;
+    activeScheduler = this;
 
     console.log('Scheduler started successfully');
     console.log('- Summarizer runs every hour');
@@ -506,7 +511,7 @@ class SchedulerService {
   }
 
   stop(): void {
-    if (!this.isRunning) {
+    if (activeScheduler !== this) {
       console.log('Scheduler is not running');
       return;
     }
@@ -519,6 +524,7 @@ class SchedulerService {
     });
     this.jobs = [];
     this.isRunning = false;
+    activeScheduler = null;
     console.log('Scheduler stopped');
   }
 

--- a/backend/services/wakePolicyService.ts
+++ b/backend/services/wakePolicyService.ts
@@ -1,0 +1,69 @@
+/**
+ * Wake policy is installation-specific, but whether waking on every message
+ * is appropriate is a property of the room. A manifest may opt in; this
+ * resolver applies that opt-in only while the pod is still 1:1-shaped.
+ *
+ * Keep this pure. Install writers and the message fan-out both use it, so a
+ * second human joining a room takes effect on the next message even if the
+ * installation row was created while the room was personal.
+ */
+
+export interface WakePolicyPod {
+  type?: string | null;
+  members?: unknown[] | null;
+}
+
+type ConfigRecord = Record<string, unknown>;
+
+const asRecord = (value: unknown): ConfigRecord => {
+  if (value instanceof Map) return Object.fromEntries(value.entries()) as ConfigRecord;
+  if (value && typeof value === 'object' && !Array.isArray(value)) return { ...(value as ConfigRecord) };
+  return {};
+};
+
+const requestedWake = (config: ConfigRecord): ConfigRecord | null => {
+  const wake = config.wakeOnMessage;
+  return wake && typeof wake === 'object' && !Array.isArray(wake)
+    ? asRecord(wake)
+    : null;
+};
+
+/** Whether this installation asked to wake on every message at all. */
+export const hasWakeOnMessageOptIn = (config: unknown): boolean => (
+  requestedWake(asRecord(config))?.enabled === true
+);
+
+/** A chat stays 1:1-shaped through the owner + one agent. */
+export const isOneToOneShapedPod = (pod: WakePolicyPod | null | undefined): boolean => (
+  pod?.type === 'chat' && Array.isArray(pod.members) && pod.members.length <= 2
+);
+
+/**
+ * Preserve a manifest's default-off setting. For an explicit opt-in, the
+ * room shape is authoritative: a shared room is mention-only.
+ */
+export const resolveWakePolicy = (
+  config: unknown,
+  pod: WakePolicyPod | null | undefined,
+): ConfigRecord => {
+  const resolved = asRecord(config);
+  const wake = requestedWake(resolved);
+  if (!wake || wake.enabled !== true) return resolved;
+
+  return {
+    ...resolved,
+    wakeOnMessage: {
+      ...wake,
+      enabled: isOneToOneShapedPod(pod),
+    },
+  };
+};
+
+export const wakeOnMessageEnabledForPod = (
+  config: unknown,
+  pod: WakePolicyPod | null | undefined,
+): boolean => {
+  const resolved = resolveWakePolicy(config, pod);
+  const wake = resolved.wakeOnMessage;
+  return !!(wake && typeof wake === 'object' && (wake as { enabled?: unknown }).enabled === true);
+};


### PR DESCRIPTION
## Summary
- resolve wake-on-message policy from a pod’s 1:1/shared shape at model install, signup, approval cloning, and fanout
- make scheduler startup process-singleton to prevent duplicate cron sets
- cover the three install paths, dynamic shared-room cutoff, and singleton behavior

## Verification
- `npm test -- --runInBand __tests__/unit/services/wakePolicyService.test.js __tests__/unit/models/AgentInstallation.wakePolicy.test.js __tests__/unit/services/agentMentionService.wakeOnMessage.test.js __tests__/unit/controllers/authController.guideIdentity.test.js __tests__/unit/services/approvalActionService.test.js __tests__/unit/services/schedulerService.digestEmail.test.js` (31 passed)
- `npm run tsc:check`
- Mutation checks: shared-member threshold, runtime fanout resolver, and singleton guard each red the relevant tests.