### PR TITLE
feat(tasks): cue heartbeat task deltas

### DIFF
--- a/backend/__tests__/unit/services/agentEventService.lifecycle.test.js
+++ b/backend/__tests__/unit/services/agentEventService.lifecycle.test.js
@@ -37,6 +37,10 @@ jest.mock('../../../models/AgentMemory', () => ({
   updateOne: jest.fn(),
 }));
 
+jest.mock('../../../models/Task', () => ({
+  aggregate: jest.fn(),
+}));
+
 jest.mock('../../../services/agentMemoryService', () => ({
   buildMemoryDigestBundle: jest.fn(() => ({})),
 }));
@@ -59,6 +63,7 @@ jest.mock('../../../services/nativeRuntimeService', () => ({ runAgent: jest.fn()
 
 const AgentEvent = require('../../../models/AgentEvent');
 const AgentMemory = require('../../../models/AgentMemory');
+const Task = require('../../../models/Task');
 const { AgentInstallation } = require('../../../models/AgentRegistry');
 const AgentEventService = require('../../../services/agentEventService');
 const { runAgent } = require('../../../services/nativeRuntimeService');
@@ -127,6 +132,88 @@ describe('attempts is a delivery counter with exactly one writer', () => {
     const [, update] = lastCall(AgentEvent.findOneAndUpdate);
     expect(update.$set).toEqual(expect.objectContaining({ status: 'failed', error: 'boom' }));
     expect(update.$inc).toBeUndefined();
+  });
+});
+
+describe('heartbeat task-update cue', () => {
+  const podId = { toString: () => '64f000000000000000000001' };
+  const lastCycleAt = new Date('2026-08-17T16:00:00.000Z');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    AgentInstallation.findOne.mockReturnValue({
+      select: () => ({ lean: () => Promise.resolve(null) }),
+      lean: () => Promise.resolve(null),
+    });
+    AgentInstallation.find.mockReturnValue({ lean: () => Promise.resolve([]) });
+    AgentEvent.create.mockImplementation(async (event) => ({
+      _id: 'heartbeat-1',
+      ...event,
+      status: 'pending',
+      attempts: 0,
+    }));
+  });
+
+  test('counts updates since the latest cycle and prepends only an on-demand cue', async () => {
+    AgentMemory.findOne.mockReturnValue({
+      select: () => ({
+        lean: () => Promise.resolve({
+          sections: {
+            cycles: {
+              // Deliberately unordered: the cursor is the newest valid entry,
+              // not an assumed array position.
+              entries: [{ ts: new Date('2026-08-17T15:30:00.000Z') }, { ts: lastCycleAt }],
+            },
+          },
+        }),
+      }),
+    });
+    Task.aggregate.mockResolvedValue([{ count: 2 }]);
+
+    await AgentEventService.enqueue({
+      agentName: 'scout', instanceId: 'workspace-a', podId, type: 'heartbeat',
+      payload: { content: 'Scheduler heartbeat for pod 64f000000000000000000001.' },
+    });
+
+    expect(Task.aggregate).toHaveBeenCalledWith([
+      { $match: { podId } },
+      { $unwind: '$updates' },
+      { $match: { 'updates.createdAt': { $gt: lastCycleAt } } },
+      { $count: 'count' },
+    ]);
+    const payload = AgentEvent.create.mock.calls[0][0].payload;
+    expect(payload.content).toContain('[tasks: 2 task updates since your last cycle — call commonly_get_tasks if relevant.]');
+    expect(payload.content).toContain('Scheduler heartbeat for pod');
+    expect(payload.content).not.toContain('Claimed by');
+  });
+
+  test('skips the query before an agent has logged a cycle', async () => {
+    AgentMemory.findOne.mockReturnValue({
+      select: () => ({ lean: () => Promise.resolve({ sections: { cycles: { entries: [] } } }) }),
+    });
+
+    await AgentEventService.enqueue({
+      agentName: 'scout', instanceId: 'workspace-a', podId, type: 'heartbeat',
+      payload: { content: 'Scheduler heartbeat for pod 64f000000000000000000001.' },
+    });
+
+    expect(Task.aggregate).not.toHaveBeenCalled();
+    expect(AgentEvent.create.mock.calls[0][0].payload.content).not.toContain('[tasks:');
+  });
+
+  test('keeps the heartbeat intact when the task aggregate fails', async () => {
+    AgentMemory.findOne.mockReturnValue({
+      select: () => ({ lean: () => Promise.resolve({ sections: { cycles: { entries: [{ ts: lastCycleAt }] } } }) }),
+    });
+    Task.aggregate.mockRejectedValue(new Error('board unavailable'));
+
+    await AgentEventService.enqueue({
+      agentName: 'scout', instanceId: 'workspace-a', podId, type: 'heartbeat',
+      payload: { content: 'Scheduler heartbeat for pod 64f000000000000000000001.' },
+    });
+
+    expect(AgentEvent.create.mock.calls[0][0].payload.content)
+      .toBe('Scheduler heartbeat for pod 64f000000000000000000001.');
   });
 });
 

--- a/backend/__tests__/unit/services/agentEventService.lifecycle.test.js
+++ b/backend/__tests__/unit/services/agentEventService.lifecycle.test.js
@@ -137,10 +137,11 @@ describe('attempts is a delivery counter with exactly one writer', () => {
 
 describe('heartbeat task-update cue', () => {
   const podId = { toString: () => '64f000000000000000000001' };
-  const lastCycleAt = new Date('2026-08-17T16:00:00.000Z');
+  let lastCycleAt;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    lastCycleAt = new Date(Date.now() - (10 * 60 * 1000));
     AgentInstallation.findOne.mockReturnValue({
       select: () => ({ lean: () => Promise.resolve(null) }),
       lean: () => Promise.resolve(null),
@@ -162,7 +163,7 @@ describe('heartbeat task-update cue', () => {
             cycles: {
               // Deliberately unordered: the cursor is the newest valid entry,
               // not an assumed array position.
-              entries: [{ ts: new Date('2026-08-17T15:30:00.000Z') }, { ts: lastCycleAt }],
+              entries: [{ ts: new Date(lastCycleAt.getTime() - (30 * 60 * 1000)) }, { ts: lastCycleAt }],
             },
           },
         }),
@@ -190,6 +191,24 @@ describe('heartbeat task-update cue', () => {
   test('skips the query before an agent has logged a cycle', async () => {
     AgentMemory.findOne.mockReturnValue({
       select: () => ({ lean: () => Promise.resolve({ sections: { cycles: { entries: [] } } }) }),
+    });
+
+    await AgentEventService.enqueue({
+      agentName: 'scout', instanceId: 'workspace-a', podId, type: 'heartbeat',
+      payload: { content: 'Scheduler heartbeat for pod 64f000000000000000000001.' },
+    });
+
+    expect(Task.aggregate).not.toHaveBeenCalled();
+    expect(AgentEvent.create.mock.calls[0][0].payload.content).not.toContain('[tasks:');
+  });
+
+  test('skips the query when the last cycle is stale', async () => {
+    AgentMemory.findOne.mockReturnValue({
+      select: () => ({
+        lean: () => Promise.resolve({
+          sections: { cycles: { entries: [{ ts: new Date(Date.now() - (25 * 60 * 60 * 1000)) }] } },
+        }),
+      }),
     });
 
     await AgentEventService.enqueue({

--- a/backend/services/agentEventService.ts
+++ b/backend/services/agentEventService.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import Task from '../models/Task';
 
 // eslint-disable-next-line global-require
 const AgentEvent = require('../models/AgentEvent');
@@ -818,6 +819,63 @@ class AgentEventService {
     }
   }
 
+  // Task-board delta cue: use the agent's own most recent `cycles` entry as
+  // the cursor, then surface only the number of audit updates in this pod.
+  // Like the ADR-012 memory cue, this is deliberately a tool hint, not an
+  // inline summary: task bodies can be stale by the time an event is claimed
+  // and can be far larger than a heartbeat budget.
+  //
+  // No prior cycle means no trustworthy "since" boundary. Skip rather than
+  // turning an agent's first heartbeat into a request to re-read every task
+  // update the pod has ever recorded.
+  private static async prependTaskUpdateCue(
+    agentName: string,
+    instanceId: string,
+    podId: unknown,
+    payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const content = payload?.content;
+    if (typeof content !== 'string' || content.length === 0) return payload;
+
+    try {
+      const memDoc = await AgentMemory.findOne({
+        agentName: agentName.toLowerCase(),
+        instanceId,
+      })
+        .select({ 'sections.cycles.entries.ts': 1 })
+        .lean() as { sections?: { cycles?: { entries?: Array<{ ts?: unknown }> } } } | null;
+
+      const cycleDates = memDoc?.sections?.cycles?.entries
+        ?.map((entry) => new Date(entry?.ts as string | number | Date))
+        .filter((ts) => !Number.isNaN(ts.getTime())) || [];
+      const lastCycleAt = cycleDates.reduce<Date | null>(
+        (latest, ts) => (!latest || ts > latest ? ts : latest),
+        null,
+      );
+      if (!lastCycleAt) return payload;
+
+      // `podId` reaches scheduled heartbeats as the Pod document's ObjectId.
+      // Keep that value intact: Mongoose does not cast aggregation pipelines,
+      // so stringifying it here would turn a real delta into a false zero.
+      const result = await Task.aggregate([
+        { $match: { podId } },
+        { $unwind: '$updates' },
+        { $match: { 'updates.createdAt': { $gt: lastCycleAt } } },
+        { $count: 'count' },
+      ]) as Array<{ count?: number }>;
+      const delta = Number(result[0]?.count || 0);
+      if (delta <= 0) return payload;
+
+      const cue = `[tasks: ${delta} task ${delta === 1 ? 'update' : 'updates'} since your last cycle — call commonly_get_tasks if relevant.]`;
+      return { ...payload, content: `${cue}\n\n${content}` };
+    } catch (err) {
+      // The cue is observational only. A board query failure must never
+      // suppress a heartbeat or make task delivery depend on analytics.
+      console.warn('[agent-event] task-update-cue prepend skipped:', (err as Error).message);
+      return payload;
+    }
+  }
+
   static async enqueue({
     agentName, podId, type, payload = {}, instanceId = 'default',
   }: EnqueueOptions): Promise<EventDoc> {
@@ -837,9 +895,12 @@ class AgentEventService {
     // Memory-changed cue applies to message-driven events only. Heartbeat
     // already has the HEARTBEAT.md trailer (Phase 2.J) telling agents to
     // pull memory; double-cueing inflates the prompt for no benefit.
-    const eventPayload = (type === 'chat.mention' || type === 'thread.mention')
+    const memoryCuedPayload = (type === 'chat.mention' || type === 'thread.mention')
       ? await this.prependMemoryCue(agentName, instanceId, baseEventPayload)
       : baseEventPayload;
+    const eventPayload = type === 'heartbeat'
+      ? await this.prependTaskUpdateCue(agentName, instanceId, podId, memoryCuedPayload)
+      : memoryCuedPayload;
 
     // Pre-resolve the installation to decide routing. Native-runtime
     // installations skip the external event queue entirely and run the agent

--- a/backend/services/agentEventService.ts
+++ b/backend/services/agentEventService.ts
@@ -25,6 +25,12 @@ const {
   buildMemoryDigestBundle,
 } = require('./agentMemoryService');
 
+// At the 10–30 minute heartbeat cadence, cycles' 40-entry retention window
+// represents roughly 7–20 hours of normal activity. A day-old cursor is not
+// a useful delta boundary: it would turn a recovered agent's next heartbeat
+// into an accidental count of historical board churn.
+const TASK_UPDATE_CUE_MAX_CURSOR_AGE_MS = 24 * 60 * 60 * 1000;
+
 interface EventDoc {
   _id?: unknown;
   type?: string;
@@ -853,6 +859,9 @@ class AgentEventService {
         null,
       );
       if (!lastCycleAt) return payload;
+      if (Date.now() - lastCycleAt.getTime() > TASK_UPDATE_CUE_MAX_CURSOR_AGE_MS) {
+        return payload;
+      }
 
       // `podId` reaches scheduled heartbeats as the Pod document's ObjectId.
       // Keep that value intact: Mongoose does not cast aggregation pipelines,


### PR DESCRIPTION
## Summary
- prepend a best-effort task-update count to heartbeat content using the agent’s latest cycle as its cursor
- keep task bodies out of the prompt and direct agents to `commonly_get_tasks` only when relevant
- skip first-cycle/history replay and preserve heartbeat delivery on lookup failures

## Verification
- `cd backend && npm test -- --runInBand __tests__/unit/services/agentEventService.lifecycle.test.js __tests__/unit/services/agentEventService.test.js` (24 passed)
- `cd backend && npm run tsc:check`
- mutation: removing the heartbeat cue hook made the new count/payload test fail