### PR TITLE
docs(adr): ratify ADR-018 (attention claims), open items marked unsettled

### DIFF
--- a/docs/adr/ADR-018-agent-attention-claims.md
+++ b/docs/adr/ADR-018-agent-attention-claims.md
@@ -1,6 +1,6 @@
 # ADR-018 — Agent attention claims: claim, lease, turn-taking
 
-**Status:** Proposed — awaiting Sam's ratification and agent-staff review
+**Status:** Accepted — ratified by Sam 2026-08-17. Two items inside remain explicitly UNSETTLED and are not ratified by this status: D4's 90s lease length (this ADR calls it "a guess with a rationale, not a measurement") and whether BYO agents will comply with the claim convention. Treat both as open until measured; see §Open questions.
 **Date:** 2026-08-11
 **Method:** settled through a full grilling session (design-tree interview, every branch visited); the decisions below are Sam's, the facts are measured
 **Relates to:** ADR-017 (attention routing *to the human* — a different problem), ADR-012 (memory), #887 (silent mentions)


### PR DESCRIPTION
Ratifies ADR-018 per Sam, 2026-08-17.

## Why this matters beyond a status line

ADR-018 sat at **Proposed** while ADR-020 was **Accepted**. On 2026-08-17 that gap produced a live regression: #963's author needed a rule about pod shape and wake policy, found it in the ratified ADR-020 D6 (which is about the Guide's *admin authority*, not about whether colleagues may speak), and shipped a change that contradicted ADR-018 D8 — *"a setting, not a ratchet… all wake, one acts."*

The code is fixed (#967). The condition that produced it is fixed here.

**Rule earned:** an unratified ADR loses to a ratified one even when it is more specific, more recent, and directly on point. Leaving a decision at Proposed is not neutral — it delegates the decision to whoever ratified something adjacent.

## What is deliberately NOT ratified

Accepted status could be read as settling everything inside, which would repeat the same error one level down. The ADR flags two items as open in its own text, and the status line now names them:

- **D4's 90s lease length** — the ADR calls it "a guess with a rationale, not a measurement"
- **Whether BYO agents will comply** with the claim convention

Both stay open until measured.

## Related

- #952 (D6.1/D6.2 amendment) merged alongside this
- ADR-024 — the shared-awareness/private-context/per-agent-queue ADR that ADR-018 D10 defers to — is drafted and under review with pod-architect. Worth landing reasonably soon: it now sits as an unratified draft against a newly-Accepted ADR-018, which is the same asymmetry described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8