### PR TITLE
docs(adr): scope-boundary cross-links, and the status discipline that earned them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,23 @@ pointer from the slim anchor; do not inline the content here.
 | Tier | Lives in | What it holds | Slim? |
 |---|---|---|---|
 | **Strategic decisions** | `docs/adr/ADR-*.md` (15 ADRs) | Decisions with multi-quarter horizon, irreversibles, the "why" | No — full reasoning belongs in the ADR |
+
+**ADR status discipline (earned 2026-08-17, by a production regression).**
+
+- **An unratified ADR loses to a ratified one** — even when it is more specific,
+  more recent, and directly on point. Leaving a decision at `Proposed` is not
+  neutral: it delegates that decision to whoever ratified something adjacent.
+  ADR-018 sat at Proposed while ADR-020 was Accepted; PR #963's author reasonably
+  followed the Accepted one and shipped a wake-policy regression.
+- **Status was the second-order problem. Discoverability was the first.** The
+  author did not ignore ADR-018 D8 — they never found it. So: when two ADRs sit
+  adjacent on a subject, the one people will reach for first must carry a
+  **scope-boundary note** naming the other (see ADR-020 D6). A cross-link would
+  have prevented the regression at either status.
+- **Ratifying does not settle what the ADR itself calls a guess.** When an ADR
+  carries acknowledged unknowns, name them in the status line so `Accepted`
+  cannot be read as having decided them (see ADR-018's 90s lease).
+
 | **Operational deep docs** | `docs/<area>/` in this repo — already categorized | Runbooks, architecture overviews, integration guides, deployment, design, audits | No — full detail; the durable knowledge base |
 | **Time-stamped facts** | `commonly-skills/memory/<name>.md` (66 entries, see `MEMORY.md` index) | What changed when, what surfaced, what was tried (per the auto-memory schema in the system prompt) | Yes — facts + a pointer to the relevant deep doc |
 | **Skill anchors** | `commonly-skills/<skill>/SKILL.md` (~28 skills) | Capability summary + pointer table into `docs/<area>/` | **Yes** |

--- a/docs/adr/ADR-020-admin-guide-delegated-authority.md
+++ b/docs/adr/ADR-020-admin-guide-delegated-authority.md
@@ -104,6 +104,20 @@ a workspace gains a second human, the kernel auto-opens the user↔Guide `agent-
 **approval cards migrate there** — owner-only decisions don't belong in a room teammates
 read. Admin powers never fire from shared pods (D1 surfaces + prompt-injection scope).
 
+> **Scope boundary — read before implementing against this decision.** D6 governs where
+> the *Guide's admin authority* and *approval cards* live. It says nothing about whether
+> ordinary agents may respond without being mentioned; **that is ADR-018 D8**
+> (wake-on-message is a per-install setting, "a setting, not a ratchet", and claims are
+> what make a busy room safe — all wake, one acts).
+>
+> Note also that "1:1-shaped" here counts **humans**, not members: a workspace with one
+> human and several agents is still single-human.
+>
+> This note exists because PR #963 read D6 as the governing rule for wake policy, gated
+> wake-on-message on `members.length <= 2`, and demoted every multi-agent workspace to
+> mention-only in production. ADR-018 was the governing document but sat at Proposed
+> while this one was Accepted. Fixed in #967; ADR-018 ratified in #968.
+
 ### D7 — First slice (agile order)
 One end-to-end line, forcing each primitive into existence minimally: message `payload`
 column → ADR-017 card render → approve action → Guide executes `create_pod` with


### PR DESCRIPTION
Fixes the condition behind the 2026-08-17 wake-policy regression, rather than the code (that was #967) or the status (that was #968).

## What actually failed

#963's author did **not** ignore ADR-018 D8. They never found it.

They needed a rule about pod shape and wake policy. They went to the ADR that discusses pod shape — ADR-020 D6 — and it answered. Nothing in D6 said it governs *the Guide's admin authority and approval cards*, not *whether ordinary agents may respond without being mentioned*. So they gated wake-on-message on `members.length <= 2`, counting bots, and every multi-agent workspace in production dropped to mention-only.

Status was the second-order problem. **Discoverability was the first** — a cross-link would have prevented this at either status.

## Changes

**ADR-020 D6** gains a scope-boundary note: it governs admin authority, ADR-018 D8 governs wake-on-message, and its "1:1-shaped" counts **humans, not members** — the specific misreading that shipped.

**CLAUDE.md** gains three rules, where an implementer will actually encounter them:

1. An unratified ADR loses to a ratified one, even when more specific and directly on point. Leaving a decision at Proposed delegates it to whoever ratified something adjacent.
2. When two ADRs sit adjacent on a subject, the one people reach for first carries a scope-boundary note naming the other.
3. Ratifying does not settle what an ADR itself calls a guess — name those in the status line (see ADR-018's 90s lease, #968).

## Deliberately not done

No CI check for stale `Proposed` ADRs. With one active maintainer that is process for its own sake; a cross-link in the document someone is already reading costs nothing and works.

## Related
#963 (caused it) · #967 (fixed the code) · #968 (ratified ADR-018) · ADR-024 draft, under review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8