### PR TITLE
fix(socket): remove unauthenticated typing relay

### DIFF
--- a/backend/__tests__/unit/server.agentTypingTransport.test.js
+++ b/backend/__tests__/unit/server.agentTypingTransport.test.js
@@ -5,8 +5,8 @@ const serverSource = fs.readFileSync(path.resolve(__dirname, '../../server.ts'),
 
 describe('server agent typing transport', () => {
   it('does not relay browser-supplied agent typing events', () => {
-    expect(serverSource).not.toMatch(/socket\.on\(\s*['"]agent_typing_start['"]/);
-    expect(serverSource).not.toMatch(/socket\.on\(\s*['"]agent_typing_stop['"]/);
+    expect(serverSource).not.toContain('agent_typing_start');
+    expect(serverSource).not.toContain('agent_typing_stop');
   });
 
   it('keeps the server-side typing service bound to Socket.IO', () => {

--- a/backend/__tests__/unit/server.agentTypingTransport.test.js
+++ b/backend/__tests__/unit/server.agentTypingTransport.test.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+const serverSource = fs.readFileSync(path.resolve(__dirname, '../../server.ts'), 'utf8');
+
+describe('server agent typing transport', () => {
+  it('does not relay browser-supplied agent typing events', () => {
+    expect(serverSource).not.toMatch(/socket\.on\(\s*['"]agent_typing_start['"]/);
+    expect(serverSource).not.toMatch(/socket\.on\(\s*['"]agent_typing_stop['"]/);
+  });
+
+  it('keeps the server-side typing service bound to Socket.IO', () => {
+    expect(serverSource).toContain(
+      "const { bindSocketIO: bindAgentTypingSocketIO } = require('./services/agentTypingService');",
+    );
+    expect(serverSource).toContain('bindAgentTypingSocketIO(io);');
+  });
+});

--- a/backend/__tests__/unit/services/agentTypingService.test.js
+++ b/backend/__tests__/unit/services/agentTypingService.test.js
@@ -1,0 +1,64 @@
+const {
+  bindSocketIO,
+  emitAgentTypingStart,
+  emitAgentTypingStop,
+} = require('../../../services/agentTypingService');
+
+describe('agentTypingService', () => {
+  let emit;
+  let to;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    emit = jest.fn();
+    to = jest.fn(() => ({ emit }));
+    bindSocketIO({ to });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('is the server-side path that starts and stops a pod-scoped agent indicator', () => {
+    emitAgentTypingStart({
+      podId: 'pod-1',
+      agentName: 'OpenClaw',
+      instanceId: 'reviewer',
+      displayName: 'Code Reviewer',
+      avatar: 'avatar-url',
+    });
+
+    expect(to).toHaveBeenCalledWith('pod_pod-1');
+    expect(emit).toHaveBeenCalledWith('agent_typing_start', {
+      podId: 'pod-1',
+      agentName: 'openclaw',
+      instanceId: 'reviewer',
+      displayName: 'Code Reviewer',
+      avatar: 'avatar-url',
+    });
+
+    emitAgentTypingStop({ podId: 'pod-1', agentName: 'OpenClaw', instanceId: 'reviewer' });
+
+    expect(emit).toHaveBeenLastCalledWith('agent_typing_stop', {
+      podId: 'pod-1',
+      agentName: 'openclaw',
+      instanceId: 'reviewer',
+    });
+  });
+
+  it('clears a typing indicator that does not receive a server-side stop', () => {
+    emitAgentTypingStart({
+      podId: 'pod-2',
+      agentName: 'scout',
+      displayName: 'Scout',
+    });
+
+    jest.advanceTimersByTime(30_000);
+
+    expect(emit).toHaveBeenLastCalledWith('agent_typing_stop', {
+      podId: 'pod-2',
+      agentName: 'scout',
+      instanceId: 'default',
+    });
+  });
+});

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -530,28 +530,6 @@ io.on('connection', (socket: any) => {
     await emitPresence(podId);
   });
 
-  // Agent typing indicators — forwarded from clients (gateway / SDK adapters)
-  // into the pod room. Server-side services use agentTypingService directly.
-  socket.on('agent_typing_start', (payload: {
-    podId: string;
-    agentName: string;
-    instanceId?: string;
-    displayName: string;
-    avatar?: string;
-  }) => {
-    if (!payload?.podId || !payload?.agentName) return;
-    io.to(`pod_${payload.podId}`).emit('agent_typing_start', payload);
-  });
-
-  socket.on('agent_typing_stop', (payload: {
-    podId: string;
-    agentName: string;
-    instanceId?: string;
-  }) => {
-    if (!payload?.podId || !payload?.agentName) return;
-    io.to(`pod_${payload.podId}`).emit('agent_typing_stop', payload);
-  });
-
   // Send a message to a pod
   socket.on(
     'sendMessage',


### PR DESCRIPTION
## Summary
- remove the client-controlled `agent_typing_start` / `agent_typing_stop` Socket.io relays
- retain server-side `agentTypingService` as the authenticated producer
- add service coverage for direct stop and safety-timeout cleanup

## Verification
- `cd backend && node_modules/.bin/jest __tests__/unit/services/agentTypingService.test.js --runInBand` (2 passed)
- inspected the pinned OpenClaw submodule (`70bd82b8`) and repository clients: no producer emits the removed socket events
- `git diff --check`