### PR TITLE
docs(adr): name the real reason a bespoke event type gets dropped (#968 follow-up)

### DIFF
--- a/backend/__tests__/unit/services/welcomeWakeService.test.js
+++ b/backend/__tests__/unit/services/welcomeWakeService.test.js
@@ -158,9 +158,11 @@ describe('welcomeWakeService', () => {
   });
 
   describe('the enqueued event is one every deployed wrapper already handles', () => {
-    // A bespoke type would be dropped: the CLI wrapper's extractPrompt returns
-    // null for anything outside PROMPT_EVENT_TYPES, so every wrapper shipped
-    // before this feature would silently ignore the wake.
+    // A bespoke type would be dropped: the CLI wrapper's extractPrompt has no
+    // branch for one and falls through to null, so every wrapper shipped before
+    // this feature would silently ignore the wake. Not "outside
+    // PROMPT_EVENT_TYPES" — heartbeat, agent.ask and agent.ask.response are all
+    // handled outside that set.
     test('type is chat.mention, flagged additively', async () => {
       await maybeFireWelcomeWake(opts());
       const [event] = AgentEventService.enqueue.mock.calls[0];

--- a/backend/services/welcomeWakeService.ts
+++ b/backend/services/welcomeWakeService.ts
@@ -218,11 +218,13 @@ export async function maybeFireWelcomeWake({
         agentName,
         instanceId,
         podId: safePodId,
-        // Deliberately chat.mention rather than a new event type. The CLI
-        // wrapper's extractPrompt returns null for any type outside
-        // PROMPT_EVENT_TYPES, so a bespoke `pod.first_message` would be
-        // silently dropped by every already-deployed wrapper — the #611
-        // failure mode. An additive payload flag costs nothing and works on
+        // Deliberately chat.mention rather than a new event type. A new type
+        // needs a wrapper release: the CLI wrapper's extractPrompt has no
+        // branch for one and falls through to null, so a bespoke
+        // `pod.first_message` would be silently dropped by every
+        // already-deployed wrapper — the #611 failure mode. (The boundary is
+        // the branch, not the set: extractPrompt also handles heartbeat,
+        // agent.ask and agent.ask.response outside PROMPT_EVENT_TYPES.) An additive payload flag costs nothing and works on
         // drivers shipped before this existed.
         type: 'chat.mention',
         payload: {

--- a/backend/services/welcomeWakeService.ts
+++ b/backend/services/welcomeWakeService.ts
@@ -224,8 +224,9 @@ export async function maybeFireWelcomeWake({
         // `pod.first_message` would be silently dropped by every
         // already-deployed wrapper — the #611 failure mode. (The boundary is
         // the branch, not the set: extractPrompt also handles heartbeat,
-        // agent.ask and agent.ask.response outside PROMPT_EVENT_TYPES.) An additive payload flag costs nothing and works on
-        // drivers shipped before this existed.
+        // agent.ask and agent.ask.response outside PROMPT_EVENT_TYPES.) An
+        // additive payload flag costs nothing and works on drivers shipped
+        // before this existed.
         type: 'chat.mention',
         payload: {
           messageId: messageId ? String(messageId) : undefined,

--- a/docs/adr/ADR-018-agent-attention-claims.md
+++ b/docs/adr/ADR-018-agent-attention-claims.md
@@ -88,9 +88,12 @@ with different liveness rules. Drivers auto-renew while genuinely working.
 
 On lease expiry the message becomes claimable again and the existing
 mention-redelivery path handles retry. **No `claim.expired` event type.**
-Deployed wrappers drop unknown event types silently (`extractPrompt` returns
-null outside `PROMPT_EVENT_TYPES`) — the welcome wake shipped as
-`chat.mention` for exactly this reason, and a coordination signal that only
+A new type needs a wrapper release; deployed wrappers drop types they
+predate. (`extractPrompt` has no branch for an unknown type and falls through
+to null — but the boundary is the branch, not the set: `heartbeat`,
+`agent.ask` and `agent.ask.response` are all handled outside
+`PROMPT_EVENT_TYPES`.) The welcome wake shipped as `chat.mention` for exactly
+this reason, and a coordination signal that only
 new drivers can hear would recreate #887 inside the coordination layer itself.
 
 ### D6 — A claim is the right to decide, not a duty to reply


### PR DESCRIPTION
ADR-018 D5 argues there should be no `claim.expired` event type, and backs it with a mechanism that is false:

> Deployed wrappers drop unknown event types silently (`extractPrompt` returns null outside `PROMPT_EVENT_TYPES`)

`extractPrompt` handles three types outside that set, in explicit branches below it — `heartbeat`, `agent.ask`, `agent.ask.response` (`cli/src/commands/agent.js:628-663`). The set's own comment says as much:

```js
// Chat event types whose payload already contains the prompt the wrapper
// should forward verbatim. Heartbeat and consult events need event-specific
// framing, so extractPrompt handles them separately below.
```

**The decision is unaffected.** A bespoke `claim.expired` really would be dropped — but because `extractPrompt` has no branch for it and falls through to `return null` at the end, and a deployed wrapper cannot grow a branch without a release. The boundary is the branch, not the set.

Why it is worth a PR rather than a note: #968 ratified ADR-018, and its status line names exactly two unsettled items (D4's lease length, BYO compliance). Everything else now reads as verified, including this.

### Three copies, not one

The same sentence had been copied into two more places, both reaching the right conclusion from the wrong premise:

| file | what it justifies |
|---|---|
| `docs/adr/ADR-018-agent-attention-claims.md` | D5 — no `claim.expired` type |
| `backend/services/welcomeWakeService.ts` | why the welcome wake enqueues `chat.mention` |
| `backend/__tests__/unit/services/welcomeWakeService.test.js` | the describe block asserting it |

All three corrected together, so grep does not resurface the false version.

Comments and prose only — no behavior change, no test assertion touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)