### PR TITLE
docs(adr): ADR-024 — shared awareness, private context, and the agent's inbox (Proposed)

### DIFF
--- a/docs/adr/ADR-024-shared-awareness-and-the-agent-inbox.md
+++ b/docs/adr/ADR-024-shared-awareness-and-the-agent-inbox.md
@@ -1,6 +1,9 @@
 # ADR-024 — Shared awareness, private context, and the agent's inbox
 
-**Status:** Proposed — NOT ratified. Requires pod-architect and sprint-review sign-off before implementation.
+**Status:** **Accepted** — direction ratified by Sam, 2026-08-18, on fable-lead's recommendation
+("ship it — a dispatch-layer bug fix, not a strategy fork"). The *implementation* still owes
+pod-architect and sprint-review a review; ratifying the direction is not a waiver of that.
+D3's tick interval remains unchosen and must be measured, not guessed.
 **Date:** 2026-08-18
 **Companions:** [`ADR-018`](ADR-018-agent-attention-claims.md) (D8 wake-on-message, D10 defers this ADR),
 [`ADR-003`](ADR-003-memory-as-kernel-primitive.md), [`ADR-012`](ADR-012-memory-propagation-and-injection.md),

--- a/docs/adr/ADR-024-shared-awareness-and-the-agent-inbox.md
+++ b/docs/adr/ADR-024-shared-awareness-and-the-agent-inbox.md
@@ -26,6 +26,12 @@ would under-serve both."* This is that document.
 wakes to produce 5 posts and spent 28 consecutive turns discovering it was not allowed to speak —
 five of those refusals on `chat.mention`, i.e. a peer named it directly and got silence.
 
+**Attribute the two halves of that correctly** — an earlier draft of this ADR did not, and
+fable-lead caught it. The wasted *turns* are D3's defect. The **zero tasks claimed is mostly D1's**:
+agents never receive `task_updated`, so the board was invisible to them all night. They could not
+have claimed work they could not see. Batching alone would have produced a cheaper version of the
+same silence, so producer parity is load-bearing for the outcome here, not garnish.
+
 Three dampeners were already in place (self-wake guard, `isWakeLoopDampened`, the cascade
 governor). All three fired. The room still burned 767 turns to produce nothing.
 
@@ -98,11 +104,18 @@ A poll returns a batch. The batch is **one turn**, not N.
 4. **Acknowledge the batch, not each item.** `AgentEvent` already supports it
    (pending/delivered/acked, requeue 10min × 3).
 
-**Humans interrupt; agents queue.** A human-authored event addressed to this seat bypasses the
-batch and wakes immediately. Everything agent-authored waits for the tick. This is how people
-actually behave — you interrupt for the person who asked you directly, and you batch the channel —
-and it preserves the responsiveness that matters (a user waiting on Scout) while removing the cost
-that does not (four agents narrating at each other).
+**Humans interrupt; agents queue — but an interrupt FLUSHES the inbox, it does not bypass it.**
+A human-authored event addressed to this seat fires the turn immediately instead of waiting for the
+tick. It does not create a second, narrower code path that sees only the mention.
+
+**Every turn is a batch turn. A human mention changes WHEN the turn fires, never WHAT it sees.**
+This correction is fable-lead's and it is the load-bearing one in D3: a carve-out that bypassed the
+batch would rebuild the shredder for precisely the cases that matter most, so the turns with a human
+waiting on them would be the only blind ones left.
+
+The effect is still what the shape promises — you interrupt for the person who asked you directly,
+and you batch the channel — and it preserves the responsiveness that matters (a user waiting on
+Scout) while removing the cost that does not (four agents narrating at each other).
 
 ### D4 — Safety in a busy room comes from claims, never from gating who may wake
 
@@ -157,8 +170,11 @@ spent the turn it was trying to save.
 
 1. **Tick interval.** Unchosen. Needs measurement against real collaboration, not a guess.
 2. **Does a batched turn actually reduce circular replies**, or merely make each turn longer?
-3. **Backpressure**: what happens when a batch exceeds what fits in a turn? Truncate, summarise,
-   or split — and which loses least.
+3. ~~**Backpressure**: what happens when a batch exceeds what fits in a turn?~~ **Answered** —
+   ADR-012 already decides this and the question should not have been reopened here. The batch
+   header always carries the **true** count; bodies cap; the remainder is pulled on demand — cued,
+   not injected. So truncation may narrow what a turn reads, never what it knows arrived. An agent
+   that sees "7 new" and 4 bodies still knows there are 7.
 4. **Deferral acknowledgement.** A seat that reads an item and does not act still leaves the sender
    with silence. A reaction is the cheap candidate, but agents cannot currently receive reactions
    either (same D1 gap).
@@ -168,6 +184,21 @@ spent the turn it was trying to save.
 ## Verification
 
 Not ratified by merging. Ratified when pod-architect and sprint-review have both reviewed it.
+
+**fable-lead reviewed 2026-08-18 and returned "ship it", with three corrections, all applied
+above** (attribution of the zero-claims number to D1; interrupt-flushes-not-bypasses; open
+question 3 already settled by ADR-012). It independently verified `poller.js:34-57` rather than
+taking the diagnosis on trust, and reframed the change usefully: this is a **dispatch-layer bug
+fix, not a strategy fork.** It also superseded its own earlier position unprompted — D4 here
+overrules the enforcement half of its ADR-020 D6 (wake-on-message flipping to mention-only on room
+shape), on the grounds that its original rationale was cost and batching deletes that arithmetic.
+The **provenance gate survives**, which is what D4 already says.
+
+On the alternative this ADR rejects: fable-lead's verdict is **sequence, don't choose.** A
+"Convene"-style scoped session is a layer above dispatch, and one built on today's dispatch would
+still shred its own session's inbox — participants would consume a focused session one blind turn
+at a time. Dispatch fix now; the recorded-decision artifact next; N-party sessions when a real
+deliberation needs more than the two that `agent-dm` already gives us.
 The author has been wrong on this subject three times in one day — merging #963, then proposing a
 fix that would have overruled the owner at a different threshold, then framing broadcast itself as
 the error when broadcast is the product. Review this adversarially.

--- a/docs/adr/ADR-024-shared-awareness-and-the-agent-inbox.md
+++ b/docs/adr/ADR-024-shared-awareness-and-the-agent-inbox.md
@@ -1,0 +1,173 @@
+# ADR-024 — Shared awareness, private context, and the agent's inbox
+
+**Status:** Proposed — NOT ratified. Requires pod-architect and sprint-review sign-off before implementation.
+**Date:** 2026-08-18
+**Companions:** [`ADR-018`](ADR-018-agent-attention-claims.md) (D8 wake-on-message, D10 defers this ADR),
+[`ADR-003`](ADR-003-memory-as-kernel-primitive.md), [`ADR-012`](ADR-012-memory-propagation-and-injection.md),
+[`ADR-017`](ADR-017-attention-routing.md), [`ADR-020`](ADR-020-admin-guide-delegated-authority.md) (D6 narrowed here)
+
+---
+
+## Context
+
+ADR-018 D10 deferred this: *"coordination and knowledge are different problems, and one document
+would under-serve both."* This is that document.
+
+**The measurement that forced it.** An overnight session in one pod, four agents, no human present:
+
+| seat | wakes | posts | cap refusals |
+|---|---|---|---|
+| sprint-review | 223 | 78 | 22 |
+| pod-architect | 226 | 66 | 54 |
+| sprint-impl | 267 | **15** | 54 |
+| ux-lead | 51 | **5** | 28 |
+
+**767 wakes. 164 posts. Zero tasks claimed for the last several hours of it.** One seat took 51
+wakes to produce 5 posts and spent 28 consecutive turns discovering it was not allowed to speak —
+five of those refusals on `chat.mention`, i.e. a peer named it directly and got silence.
+
+Three dampeners were already in place (self-wake guard, `isWakeLoopDampened`, the cascade
+governor). All three fired. The room still burned 767 turns to produce nothing.
+
+**The diagnosis is not "too much broadcast."** Waking everyone is correct and deliberate: it is
+what makes a room a room rather than a work queue, and it is the property a shared space exists to
+provide. The defect is one line in `cli/src/lib/poller.js`:
+
+```js
+const { events = [] } = await client.get('/api/agents/runtime/events', { limit: 10 });
+for (const event of events) { await onEvent(event); }   // ← N turns, not one
+```
+
+**The batch is already fetched and then shredded.** Ten messages arrive together and become ten
+independent turns, each blind to the other nine. That is why seats answer each other in circles:
+message 3 frequently already answers message 1, and no turn ever sees both.
+
+We turned an inbox into an interrupt stream, then built three dampeners to survive it.
+
+---
+
+## Decision
+
+### D1 — Shared awareness is a property of the place, not of the agents
+
+Everyone in a pod can see the work: messages, board state, task transitions. An agent should not
+have to poll or be told in order to know what is happening around it.
+
+**Not true today, and the gap is one-directional.** As sprint-review put it after auditing both
+sides — and this framing is better than the one this ADR originally carried:
+
+> Seven socket-emitting producers in backend, every one with zero enqueues; the one enqueuing
+> service never emits. **Nothing does both.**
+
+`task_updated`, `messageCardUpdated`, `messageReaction`, `podPresence` and `agent_typing_*` all
+fan out to Socket.io and stop. Humans see the board move live; agents learn nothing.
+
+**Implementation constraint, found the hard way:** a new `task.*` event type would reach neither
+runtime — the wrapper drops unrecognised types, and the native tier's default branch discards the
+payload. Producer parity must either fix both tiers or ride an event type both already read.
+Do not assume a new type is deliverable because the queue accepts it.
+
+### D2 — Context stays private; awareness is not a shared brain
+
+Each agent keeps its own memory, working context and judgement. Awareness means *I can see the
+work*, never *we think with one mind*.
+
+- **No ambient injection of another agent's context.** ADR-012 holds: pulled on demand, cued not
+  injected.
+- **A pod-level shared store, when it exists, is additive and provider-pluggable** (ADR-018 D10).
+  A place agents deliberately write to — not a merge of their private contexts.
+
+The value of a colleague is that they know things you do not and judge differently. A design that
+converges their context deletes the reason to have more than one.
+
+### D3 — The agent has an inbox, not an interrupt line
+
+**This replaces the earlier draft of D3, which described the right goal (the agent owns a queue)
+with a weaker mechanism (defer-while-claimed). Batching subsumes it.**
+
+A poll returns a batch. The batch is **one turn**, not N.
+
+1. **One tick, one turn.** The agent receives everything waiting: *"7 new — 2 mention you, 1
+   touches the task you hold, 4 are peer chatter."* It decides what, if anything, to act on, with
+   all of it visible at once.
+2. **The count is the classifier, computed before the turn.** Who sent it, were you named, does it
+   reference your claimed work. Structural, cheap, and never requires reading a message to decide
+   whether reading it was worth it.
+3. **Cadence is the cooldown.** An agent that just acted naturally has a gap before its next tick.
+   No cap, no refusal, no seat silently muted.
+4. **Acknowledge the batch, not each item.** `AgentEvent` already supports it
+   (pending/delivered/acked, requeue 10min × 3).
+
+**Humans interrupt; agents queue.** A human-authored event addressed to this seat bypasses the
+batch and wakes immediately. Everything agent-authored waits for the tick. This is how people
+actually behave — you interrupt for the person who asked you directly, and you batch the channel —
+and it preserves the responsiveness that matters (a user waiting on Scout) while removing the cost
+that does not (four agents narrating at each other).
+
+### D4 — Safety in a busy room comes from claims, never from gating who may wake
+
+ADR-018 D8, restated because it was violated within a week of being written: wake-on-message is a
+per-install **setting, not a ratchet**; **all wake, one acts**; claims are the safety mechanism.
+
+- An explicit opt-in is honoured **at any member count**. Many agents all awake is the intended
+  product.
+- Room shape MUST NOT override an owner's setting, at install or at delivery.
+- The real hazard behind #963 survives, narrowed: a config **clone** can inherit an opt-in nobody
+  made for it. Gate the clone. That is provenance, not shape.
+
+### D5 — ADR-020 D6 is narrowed to what it was about
+
+D6 governs the **Guide's admin authority and approval cards**, not whether ordinary colleagues may
+respond unmentioned. Its "1:1-shaped" test counts **humans**, not members.
+
+---
+
+## What this rejects
+
+**Central speaker selection.** AutoGen's `GroupChatManager` picks one speaker per turn
+(`round_robin` / `auto` / `candidate_func`). It is the right answer for a workflow orchestrator and
+the wrong one here for two reasons: a manager cannot exist over BYO agents running on other
+people's machines, and selecting one speaker deletes the awareness the room exists to provide.
+We keep broadcast and fix the consumption.
+
+**More damping.** Three dampeners already fire and the room still burned 767 turns. A fourth is
+not the answer to the failure of the first three.
+
+**Classification by reading.** Any "let the agent decide whether to respond" design has already
+spent the turn it was trying to save.
+
+---
+
+## Consequences
+
+- Turn cost drops from **O(messages × agents)** to **O(agents × ticks)**. On the measured night:
+  ~767 wakes → ~40.
+- **Latency rises for agent-to-agent traffic** to at most one tick. This is the real cost and the
+  reason D3 carves out human-addressed events. If a tick is long, peer collaboration feels slow;
+  if short, the saving shrinks. The interval is the tuning knob and it is not yet chosen.
+- The cascade governor becomes largely vestigial. Keep it as a backstop; do not delete it in the
+  same change that removes its load.
+- A batched turn sees more context, so replies should improve — an agent can notice that message 3
+  already answered message 1. Unmeasured, and worth measuring.
+- `commonly_get_started` grows an inbox section.
+
+---
+
+## Open questions
+
+1. **Tick interval.** Unchosen. Needs measurement against real collaboration, not a guess.
+2. **Does a batched turn actually reduce circular replies**, or merely make each turn longer?
+3. **Backpressure**: what happens when a batch exceeds what fits in a turn? Truncate, summarise,
+   or split — and which loses least.
+4. **Deferral acknowledgement.** A seat that reads an item and does not act still leaves the sender
+   with silence. A reaction is the cheap candidate, but agents cannot currently receive reactions
+   either (same D1 gap).
+
+---
+
+## Verification
+
+Not ratified by merging. Ratified when pod-architect and sprint-review have both reviewed it.
+The author has been wrong on this subject three times in one day — merging #963, then proposing a
+fix that would have overruled the owner at a different threshold, then framing broadcast itself as
+the error when broadcast is the product. Review this adversarially.


### PR DESCRIPTION
**Proposed. Not ratified. Do not implement against this until pod-architect and sprint-review have both reviewed it.**

The ADR that ADR-018 D10 defers to.

## What forced it

One pod, four agents, overnight, no human present:

| seat | wakes | posts | cap refusals |
|---|---|---|---|
| sprint-review | 223 | 78 | 22 |
| pod-architect | 226 | 66 | 54 |
| sprint-impl | 267 | **15** | 54 |
| ux-lead | 51 | **5** | 28 |

**767 wakes, 164 posts, zero tasks claimed for hours.** All three existing dampeners fired — self-wake guard, `isWakeLoopDampened`, cascade governor — and the room still burned the turns. One seat spent 28 consecutive turns discovering it wasn't allowed to speak, five of those on direct mentions.

## The diagnosis, and what it is NOT

It is not "too much broadcast." Waking everyone is deliberate and correct — it is what makes a room a room, and it's the property a shared space exists to provide.

The defect is one line in `cli/src/lib/poller.js`:

```js
const { events = [] } = await client.get('/api/agents/runtime/events', { limit: 10 });
for (const event of events) { await onEvent(event); }   // ← N turns, not one
```

**The batch is already fetched, then shredded.** Ten messages arrive together and become ten turns, each blind to the other nine. That's why seats answer in circles: message 3 frequently already answers message 1, and no turn ever sees both.

We turned an inbox into an interrupt stream and then built three dampeners to survive it.

## D3, the substance

One tick, one turn. The count is the classifier, computed before the turn. Cadence is the cooldown. Ack the batch, not each item.

And the carve-out that keeps it usable: **humans interrupt, agents queue.** A human-authored event addressed to this seat wakes immediately; agent traffic waits for the tick. That's how people behave, and it protects the latency that matters (a user waiting on Scout) while removing the cost that doesn't.

## Deliberately rejected

**Central speaker selection.** AutoGen's `GroupChatManager` is right for a workflow orchestrator and wrong here: a manager cannot exist over BYO agents on other people's machines, and picking one speaker deletes the awareness the room provides. Cumora's `Convene` is the nearest good idea and is scoping, not selection.

**A fourth dampener.** Three fire already.

## Honest costs, in the ADR

- Agent-to-agent latency rises to at most one tick. Interval unchosen; it's the real tradeoff.
- Whether batching actually reduces circular replies is **unmeasured**.
- Backpressure when a batch exceeds a turn is unsolved.

## Corrections carried

- sprint-review's framing replaces mine: *"seven socket-emitting producers with zero enqueues; the one enqueuing service never emits. Nothing does both."*
- sprint-review's constraint: a new `task.*` type reaches **neither** tier — wrapper drops unknown types, native's default branch drops the payload. Producer parity must fix both tiers or ride a type both already read.
- Sam's correction: wake-everyone is the insight, not the error. An earlier draft of this ADR had that backwards.

## Related
#973 (cascade-cap stopgap — this makes it largely vestigial) · ADR-018 (ratified #968) · ADR-020 D6 (cross-linked #969)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8