### PR TITLE
fix(build): model each script as its own module, as Node already does

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -3,6 +3,29 @@
     "target": "ES2022",
     "module": "CommonJS",
     "moduleResolution": "Node",
+    // Every file is its own module, even without an import/export.
+    //
+    // This matches how these files actually RUN. Node and ts-node execute each
+    // file as a CommonJS module, where a top-level `const` is file-scoped. But
+    // tsc's default `moduleDetection: "auto"` models any file lacking an
+    // import/export as a GLOBAL script, so our operational scripts — which use
+    // `const x = require(...)` rather than `import` — were modelled as sharing
+    // one scope they never share at runtime.
+    //
+    // The result: `backfill-byo-host-stamp.ts` claimed the names `mongoose`,
+    // `APPLY` and `main` repo-wide, and the next script written in the same
+    // house style failed with TS2451 "Cannot redeclare block-scoped variable".
+    // Two unrelated PRs (#953, #962) each added one such script and each went
+    // red on the other's names. `scripts/` is in tsconfig.build.json too, so
+    // this would have broken `npm run build` and the deploy, not just CI.
+    //
+    // Blast radius measured before landing: 7 files in the repo are currently
+    // modelled as global scripts, all standalone scripts plus jest.setup.js —
+    // no server runtime file. The only emit change is a `"use strict";` line
+    // (shebangs stay on line 1); none of the affected .js scripts use
+    // sloppy-mode constructs. Full typecheck and a full build were run with
+    // this flag: zero new errors.
+    "moduleDetection": "force",
     "allowJs": true,
     "checkJs": false,
     "outDir": "./dist",


### PR DESCRIPTION
## What

One line in `backend/tsconfig.json`: `"moduleDetection": "force"`.

## Why

Two open PRs — #953 (unlist internal agents from the public catalog) and #962
(backfill explicit runtime identity) — are both red, with what looks like each
one's own bug:

```
scripts/backfill-byo-host-stamp.ts(38,7): error TS2451: Cannot redeclare block-scoped variable 'mongoose'.
scripts/unlist-internal-registry-agents.ts(37,7): error TS2451: Cannot redeclare block-scoped variable 'mongoose'.
```

Neither PR is broken. They collide with a file already on `main`.

`tsc`'s default `moduleDetection: "auto"` treats any file with no top-level
`import`/`export` as a **global script**. Our operational scripts are written
with `const mongoose = require('mongoose')` — the house style — so tsc models
them as sharing one global scope.

They never share that scope. Node and ts-node execute each file as a CommonJS
module, where a top-level `const` is file-scoped. **The type model was simply
wrong about how these files run.**

The practical consequence: `backfill-byo-host-stamp.ts` landed on `main` and
claimed the names `mongoose`, `APPLY` and `main` repo-wide. The next script
written the same way fails, and the failure is attributed to the innocent PR.
Two authors hit it independently this week.

### This was about to break the deploy, not just CI

`scripts/` is not excluded from `tsconfig.build.json`, and `npm run build` is
`tsc -p tsconfig.build.json`. Merging either PR would have gone red on the
production build, not only the typecheck gate.

## Why not the alternatives

- **`export {};` in each script** — works, but is a per-file reminder. The next
  author must know the trap exists. Three PRs would already have needed it.
- **Excluding `scripts/` from the typecheck config** — that config's own header
  says exclusions are "the debt ledger, not an escape hatch", and it would not
  have fixed the build path anyway.

## Blast radius, measured before landing

Files in the repo currently modelled as global scripts — i.e. every file whose
emit this flag changes:

```
./jest.setup.js                      (excluded from build)
./cleanup-test-data.ts               (excluded from both configs)
./scripts/bootstrap-clawd-bot.js
./scripts/add-openclaw-to-pod.js
./scripts/gen-openclaw-user-token.js
./scripts/gen-openclaw-token.js
./scripts/backfill-byo-host-stamp.ts
```

Seven files. All standalone scripts plus the jest setup — **no server runtime
file is affected.**

The only emit change is an added `"use strict";`, and the shebang stays on
line 1:

```js
#!/usr/bin/env node
"use strict";
/*
 * Stamp `config.runtime.host = 'byo'` ...
```

The four `.js` scripts were scanned for constructs that behave differently
under strict mode (implicit-global assignment, `with`, `arguments.callee`,
legacy octal) — none present.

## Verification

- Minimal repro built from the two colliding files: TS2451 reproduces without
  the flag, and disappears with it.
- `tsc --noEmit` over the **whole backend** with the flag: byte-identical
  output to the baseline run (both show only two pre-existing `instrument.ts`
  errors from a local `@sentry/node` gap, which CI does not have).
- Full `tsc -p tsconfig.build.json` with the flag, emitting to a scratch dir:
  compiles, `server.js` emitted.

## After this merges

#953 and #962 should both go green on a re-run with no changes of their own.
