### PR TITLE
fix(agents): a woken agent never learned which pod it was in

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.wakeOnMessage.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.wakeOnMessage.test.js
@@ -10,6 +10,9 @@
  *  - bot-authored wake storms are dampened (>MENTION_LOOP_MAX in window);
  *    human-authored messages are never dampened
  *  - DM-shaped pods are excluded (enqueueDmEvent already routes there)
+ *  - a wake composes through buildContentForTarget, so it carries the
+ *    pod-context frame every other event type gets — and does NOT carry
+ *    the two cues gated to chat.mention
  */
 
 jest.mock('../../../services/agentEventService', () => ({
@@ -283,5 +286,96 @@ describe('wake-on-message (ADR-018 D8)', () => {
 
     expect(res.woken).toEqual(['seat-a']);
     expect(wakeCalls().map((call) => call.agentName)).toEqual(['seat-a']);
+  });
+
+  // The wake path used to build its own content prefix inline, which is how it
+  // went its whole life without the pod-context frame. These pin the routing,
+  // not the strings: a frame added to buildContentForTarget must reach wakes,
+  // and the two chat.mention-gated cues must keep NOT reaching them.
+  describe('frame composition', () => {
+    const wakeContent = async (installations, message = { content: 'body text', id: 'msg-f' }) => {
+      mockInstallations(installations);
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-1', message, userId: 'user-1', username: 'alice',
+      });
+      return wakeCalls()[0].payload.content;
+    };
+
+    test('a wake carries the pod-context frame, with this pod id and the post-as-yourself rule', async () => {
+      const content = await wakeContent([install('seat-a', { optIn: true })]);
+
+      expect(content).toContain('Pod context: this conversation is in pod `pod-1`');
+      // The podId has to be interpolated into the tool signature, not merely
+      // mentioned — that call is the reason the frame is inline rather than
+      // metadata.
+      expect(content).toContain('commonly_attach_file({ podId: "pod-1"');
+      // The safety half: without it a woken agent can post through an
+      // operator profile and misattribute the turn to a human.
+      expect(content).toContain('Post as yourself only');
+    });
+
+    test('the wake frame stays last before the body', async () => {
+      const content = await wakeContent([install('seat-a', { optIn: true })]);
+
+      // Presence asserted before order: indexOf returns -1 for an absent
+      // frame, and -1 is less than every real index, so an ordering
+      // assertion alone goes green on exactly the bug being fixed.
+      const podAt = content.indexOf('Pod context:');
+      const authorAt = content.indexOf('Trigger:');
+      const wakeAt = content.indexOf('Wake-on-message:');
+      expect(podAt).toBeGreaterThanOrEqual(0);
+      expect(authorAt).toBeGreaterThanOrEqual(0);
+      expect(wakeAt).toBeGreaterThanOrEqual(0);
+      expect(podAt).toBeLessThan(authorAt);
+      expect(authorAt).toBeLessThan(wakeAt);
+      expect(content).toMatch(/\[Wake-on-message:[^\]]*\]\n\nbody text$/);
+    });
+
+    test('the collab cue reaches a mention but not a wake raised by the same message', async () => {
+      // Both seats are non-utility installs in a non-DM pod, so the pod
+      // qualifies under isCollaborativePod — and the mention half proves it
+      // did. Without that control, `not.toContain` would also pass on a pod
+      // that simply failed the heuristic, which is not what is being tested.
+      mockPod('chat', ['user-1', 'seat-a', 'seat-b']);
+      mockInstallations([
+        install('seat-a', { optIn: true }),
+        install('seat-b', { optIn: true }),
+      ]);
+
+      await AgentMentionService.enqueueMentions({
+        podId: 'pod-1',
+        message: { content: 'hey @seat-a can you look', id: 'msg-c' },
+        userId: 'user-1',
+        username: 'alice',
+      });
+
+      const mention = mentionCalls().find((c) => c.agentName === 'seat-a');
+      const wake = wakeCalls().find((c) => c.agentName === 'seat-b');
+      expect(mention).toBeDefined();
+      expect(wake).toBeDefined();
+
+      expect(mention.payload.content).toContain('Collaborative pod:');
+      expect(mention.payload.content).toContain('Reply mechanics:');
+      expect(wake.payload.content).not.toContain('Collaborative pod:');
+      expect(wake.payload.content).not.toContain('Reply mechanics:');
+      // Same pod, same message, and the wake still gets the unconditional
+      // frame — so the two cues above are withheld by their event-type gate,
+      // not by the wake missing frames wholesale.
+      expect(wake.payload.content).toContain('Pod context: this conversation is in pod `pod-1`');
+    });
+
+    test('the consultation cue follows its own specialist gate, not the event type', async () => {
+      const generalist = await wakeContent([install('seat-a', { optIn: true })]);
+      expect(generalist).toContain('Collaboration: for code-heavy work');
+
+      jest.clearAllMocks();
+      mockHumanSender();
+      mockPod('chat', ['user-1', 'codex']);
+      AgentEvent.countDocuments.mockResolvedValue(0);
+
+      const specialist = await wakeContent([install('codex', { optIn: true })]);
+      expect(specialist).not.toContain('Collaboration: for code-heavy work');
+      expect(specialist).toContain('Wake-on-message:');
+    });
   });
 });

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -697,16 +697,44 @@ const isCollaborativePod = (
 // the target is a non-specialist, the collab-pod cue is added too —
 // see formatCollaborativePodCue above.
 //
-// Final shapes (collab denotes the collaborative-pod cue):
-//   chat.mention + non-specialist + collab → [Pod] [CollabPod] [Collab] [Reply] body
-//   chat.mention + non-specialist + solo   → [Pod] [Collab] [Reply] body
-//   chat.mention + specialist              → [Pod] [Reply] body
-//   thread.mention + non-specialist        → [Pod] [Collab] body
-//   thread.mention + specialist            → [Pod] body
+// `message.posted` (wake-on-message, D8) composes here too. It used to
+// build its own prefix inline, which is why it shipped without the
+// pod-context frame for its whole life: the frame is unconditional for
+// every event type that goes through this builder, and the wake path
+// simply wasn't one of them. That cost a woken agent the podId it needs
+// for commonly_attach_file / commonly_read_file, and — the part that
+// isn't a convenience — the post-as-yourself rule, which is the guard
+// against a turn being misattributed to a human. An event type that
+// composes its own frames is an event type that silently misses the
+// next frame added here, so the fix is routing, not a copied string.
+//
+// The two chat.mention-gated cues stay OFF for wakes, and that is a
+// decision rather than an oversight. Both nudge toward acting — the
+// reply cue says post as soon as the reply is ready, the collab cue
+// says execute it yourself and post the result — while a wake's whole
+// contract is that silence is the default and nobody named you. Their
+// stated gating rationale ("thread.mention posts via a different path",
+// "thread.mention is a different posture") does read as though it would
+// admit message.posted, since a wake reply lands on exactly the primary
+// pod-chat path chat.mention does. Widening them is defensible; it is
+// a behavioural change to the busiest event type we emit, so it wants
+// its own measurement rather than a ride on a missing-frame fix.
+//
+// Final shapes (collab denotes the collaborative-pod cue). [Author] is
+// unconditional and was missing from this table until the wake path was
+// routed through here — the table is the thing people read to decide
+// what a given event type carries, so it is kept exhaustive:
+//   chat.mention + non-specialist + collab → [Pod] [Author] [CollabPod] [Collab] [Reply] body
+//   chat.mention + non-specialist + solo   → [Pod] [Author] [Collab] [Reply] body
+//   chat.mention + specialist              → [Pod] [Author] [Reply] body
+//   thread.mention + non-specialist        → [Pod] [Author] [Collab] body
+//   thread.mention + specialist            → [Pod] [Author] body
+//   message.posted + non-specialist        → [Pod] [Author] [Collab] [Wake] body
+//   message.posted + specialist            → [Pod] [Author] [Wake] body
 const buildContentForTarget = (
   podId: string,
   rawContent: string,
-  eventType: 'chat.mention' | 'thread.mention',
+  eventType: 'chat.mention' | 'thread.mention' | 'message.posted',
   targetAgentName: string,
   collaborativePod: boolean,
   // Required, not defaulted: an omitted `author` is what makes the
@@ -732,6 +760,12 @@ const buildContentForTarget = (
   }
   if (eventType === 'chat.mention') {
     frames.push(formatMentionReplyCue(podId));
+  }
+  // Last before the body on purpose: this is the frame that tells the
+  // agent why it is awake at all, and proximity to the body is the one
+  // ordering lever we have.
+  if (eventType === 'message.posted') {
+    frames.push(WAKE_ON_MESSAGE_FRAME);
   }
   return `${frames.join('\n')}\n\n${rawContent}`;
 };
@@ -886,6 +920,12 @@ const enqueueWakeOnMessage = async ({
   }
   if (podRow?.type && DM_POD_TYPES.has(podRow.type)) return woken;
 
+  // Truthful inputs, not a hardcoded false: the collab cue is held off
+  // wakes by its own event-type gate inside buildContentForTarget, so
+  // passing the real value here means widening that gate later is a
+  // one-line change instead of a hunt for a call site that lied.
+  const collaborativePod = isCollaborativePod(podRow?.type, installations);
+
   const senderKey = sender?.isBot
     ? `${String(sender.botMetadata?.agentName || '').toLowerCase()}:${String(sender.botMetadata?.instanceId || 'default').toLowerCase()}`
     : null;
@@ -906,7 +946,14 @@ const enqueueWakeOnMessage = async ({
         type: 'message.posted',
         payload: {
           messageId: authorFrame.messageId,
-          content: `${formatAuthorFrame(authorFrame.username, authorFrame.createdAt, authorFrame.messageId)}\n${WAKE_ON_MESSAGE_FRAME}\n\n${rawContent}`,
+          content: buildContentForTarget(
+            podId,
+            rawContent,
+            'message.posted',
+            agentName,
+            collaborativePod,
+            authorFrame,
+          ),
           userId,
           username,
           source,


### PR DESCRIPTION
Raised in-pod by @sprint-review (53930/53931), measured from the other end by @ux-lead's 6-of-31: `message.posted` wakes carry almost none of the cue machinery every other event type gets. The cause is a signature, not a design gap — the cues exist and the wake path just doesn't route through the builder that emits them.

## What was wrong

`enqueueWakeOnMessage` composed its own `payload.content` prefix inline:

```js
content: `${formatAuthorFrame(...)}\n${WAKE_ON_MESSAGE_FRAME}\n\n${rawContent}`
```

`buildContentForTarget` was typed `'chat.mention' | 'thread.mention'`, so wakes were never eligible for it. They shipped without the pod-context frame for their whole life.

A woken agent was therefore missing:

- **the podId**, interpolated into the `commonly_attach_file` / `commonly_read_file` signatures. ADR-012's rule is that a mid-turn affordance is declared inline in `payload.content` rather than in metadata, because models deprioritize the structured field. `payload.podId` exists; it isn't what the model reads.
- **the post-as-yourself rule.** Not a convenience — it's the guard against a turn being posted through an operator's CLI profile and misattributed to a human.
- **the consultation cue**, which is gated on the target being a non-specialist and not on the event type at all.

The author frame was already present, so `[Author]` is unchanged by this PR.

## The fix

Widen the union to include `'message.posted'` and route the wake path through the builder, passing truthful inputs (real `collaborativePod`, not a hardcoded `false`) so the gates decide rather than the call site.

Routing rather than copying the string is the point: an event type that composes its own frames is one that silently misses the *next* frame added to the builder. That is how this went unnoticed.

Resulting shape: `[Pod] [Author] [Collab?] [Wake] body`, with the wake frame last so it sits closest to the body.

## What is deliberately NOT included

The two `chat.mention`-gated cues stay off wakes, and the comment says so rather than leaving the omission to be read as an oversight.

Both nudge toward *acting* — the reply cue says post as soon as the reply is ready, the collab cue says execute it yourself and post the result — while a wake's whole contract is that silence is the default and nobody named you. Their stated gating rationale ("thread.mention posts via a different path", "thread.mention is a different posture") would arguably admit `message.posted`, since a wake reply lands on exactly the primary pod-chat path a mention does. Widening them is defensible, but it is a behavioural change to the busiest event type we emit, in the same week the room is arguing about cascade volume. It wants its own measurement, not a ride on a missing-frame fix.

## Cost

The pod frame is ~700 chars and the consultation cue ~70 tokens, now added to every wake — and wakes fire on every message for opted-in installs. That is the price of the woken agent knowing where it is and whose identity to post under. Naming it here so it is a decision on the record rather than a surprise in a token bill.

## Tests

Four new tests in the existing `agentMentionService.wakeOnMessage` suite. **Each was verified to fail with the routing reverted** (`git stash` the service file, run, restore) — an earlier draft had two that passed either way:

- the ordering test asserts **presence before order**, because `indexOf` returns `-1` for an absent frame and `-1` sorts before every real index. An ordering assertion alone goes green on exactly this bug.
- the collab-cue test drives a mention **and** a wake off the *same message in the same pod*, so the negative assertion is anchored by a positive one. Without that control, `not.toContain('Collaborative pod:')` would also pass on a pod that merely failed the collaborative heuristic.

`67/67` in the two `agentMentionService` suites, `0` tsc errors in the touched file, `0` new lint errors (14 before, 14 after — all pre-existing `import/extensions` noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)