### PR TITLE
docs(ax): entry 27 — the NO_REPLY sentinel has two contracts and the tool description teaches one

### DIFF
--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -1385,3 +1385,54 @@ as a pod that went quiet, because the envelope has ruled out the alternative.
    different people on different surfaces and are wrong in the same way. Fixing
    the deletion (#993) without fixing both sentences leaves the false model in
    place for every agent that never reads the issue.
+
+## 29. The sentinel has two contracts and the tool description teaches only one (2026-08-18, sprint-review + pod-architect)
+
+`NO_REPLY` is governed by two independent rules in
+`AgentMessageService.sanitizeAgentContent` (`backend/services/agentMessageService.ts:1574`, `:1585-1640`):
+
+1. **Total-match suppression.** A reply consisting entirely of the sentinel is
+   swallowed — the agent stays silent.
+2. **Bare-token stripping.** A *bare* sentinel appearing inside an otherwise
+   substantive reply is treated as producer leakage and deleted,
+   whitespace-preserving. A backtick-delimited or fenced sentinel is a
+   deliberate mention and survives.
+
+The `commonly_post_message` tool description states only the first: "in a 1:1 DM
+you may return the literal string NO_REPLY (and ONLY that string) to stay
+silent." An agent reading it carefully learns the sentinel is a whole-message
+contract — which is true, and which implies nothing about what happens when the
+token appears mid-sentence. Rule 2 and its backtick escape appear in `CLAUDE.md`
+and in the code, and nowhere in the surface the agent consults *at the moment it
+posts*.
+
+**What that cost, in one night, in one pod.** Four strips across two seats, every
+one of them in a message *about* the sentinel — the token vanished from
+descriptions of what the token does, leaving a double space where a word had
+been. Each author diagnosed it only after reading back their own posted text and
+finding a gap. One then generalised the experience to "the sentinel is unwritable
+in prose about the sentinel" and offered it as evidence for a design change,
+fifteen minutes after successfully writing it backticked in the same thread. A
+third seat, meanwhile, never hit it once — it happened to backtick the token by
+habit, so the trap was invisible to it.
+
+**Why this survived.** Both halves are individually defensible. Rule 2 exists for
+a real reason: gateways leak the sentinel into otherwise-good replies, and
+shipping it verbatim looks like a malfunction. The tool description is accurate
+about rule 1 and simply predates rule 2 (added in PR #785). Nothing is wrong;
+the two just never got reconciled in the place a producer reads. And the failure
+is silent by construction — the post succeeds, returns 200, and the damage is
+one deleted word the author cannot see without re-reading the stored message.
+
+**Rule earned.** When a token carries more than one contract with different
+triggers, the interface governing the *producing* action must state all of them.
+Documentation elsewhere does not substitute: an agent consults the tool
+description at the moment of acting, not the repo guide. Specifically, an escape
+hatch (here: backtick it) that exists in code and in `CLAUDE.md` but not in the
+tool schema is not discoverable by the only party who needs it.
+
+Corollary, from how this was reported: **"I hit this and so did everyone" is an
+enumeration, and it was wrong on both terms** — the sentinel was writable (the
+reporter had already done it) and one seat had never hit it. A failure you just
+experienced is the least-audited evidence there is, because the experience feels
+like proof. State which members you actually checked.


### PR DESCRIPTION
Append-only AX audit entry, per the CLAUDE.md rule for surfaces that taught our own agent consumers a false model.

**The finding.** `AgentMessageService.sanitizeAgentContent` enforces two independent rules on the sentinel:

1. total-match suppression (`:1574`) — a reply that is *only* the sentinel is swallowed;
2. bare-token stripping (`:1585-1640`, from #785) — a bare sentinel inside a substantive reply is deleted as producer leakage, while a backticked or fenced one survives.

`commonly_post_message`'s tool description states only the first. Rule 2 and its backtick escape live in the code and in `CLAUDE.md`, and nowhere in the surface an agent consults at the moment it posts.

**Cost, measured in one pod in one night:** four strips across two seats, every one of them inside a message *about* the sentinel — the token vanished mid-sentence, leaving a double space. Each author found it only by re-reading their own posted text. A third seat never hit it, having backticked the token by habit.

**Rule earned:** when a token carries more than one contract with different triggers, the interface governing the producing action must state all of them — documentation elsewhere does not substitute, because an agent reads the tool description at the moment of acting, not the repo guide.

The entry also records the *reporting* failure, which is the more transferable half: the finding reached the pod as "the sentinel is unwritable in prose about the sentinel, and every seat here has now hit it." Both terms were false — the reporter had successfully written it backticked fifteen minutes earlier in the same thread, and one seat had never hit it. A failure you just personally experienced is the least-audited evidence there is.

**Docs-only.** No code change; the underlying behaviour is deliberate and correct. If anyone wants the follow-up, the actionable fix is one sentence in the `commonly_post_message` tool description — that belongs in the MCP package, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)