### PR TITLE
chore(mcp): 0.3.1 — publish the PR-tool removal that shipped only to source

### DIFF
--- a/commonly-mcp/package.json
+++ b/commonly-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Commonly MCP Server \u2014 exposes the kernel HTTP surface (CAP per ADR-004) as standard MCP tools so any MCP-capable runtime can consume `commonly_*` tools without driver-specific code.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## The bug is a version number that means two things

`npm @commonlyai/mcp@0.3.0` and `main`'s `commonly-mcp@0.3.0` are **different code.**

#964 removed `commonly_pr_diff` and `commonly_pr_review` from the MCP tool list — correctly; they called `/api/github/pulls/*`, which spent the server's shared GitHub PAT against a caller-supplied `owner`/`repo`, so any `cm_agent_*` token could read diffs from and post reviews onto any repo that credential reached. The routes were deleted in the same PR.

**The version was never bumped.** So the correction reached the repo and reached no seat. Every MCP agent installed from npm still advertises two tools that now 404 — which is worse than never having them, because the model plans around a capability that fails at the call rather than routing to something that works.

## Verification — the shipped artifact, not this tree

```
$ npm view @commonlyai/mcp version
0.3.0

$ npm pack @commonlyai/mcp && tar xzf commonlyai-mcp-0.3.0.tgz
$ grep -o "commonly_pr_[a-z]*" package/src/tools.js | sort -u
commonly_pr_diff
commonly_pr_review
```

and on `main`:

```
$ gh api .../commonly-mcp/src/tools.js?ref=main | base64 -d | grep -c "name: 'commonly_pr_"
0
```

`main` carries a comment where the tools used to be, explaining the removal and pointing at the replacement. The published package carries the tools.

I checked npm rather than the working tree because of the `smoke-the-shipped-artifact` rule, and this is exactly the case that rule exists for — reading the repo here tells you the problem is fixed.

## What this PR does

The version bump, and only that. The code correction is already on `main`.

## Replacement is already documented

`presets.ts:1203` points codex and claude-code seats at:

- `gh pr diff <N>` to read the diff
- `gh pr review <N> --approve|--request-changes|--comment --body "…"` to post the review onto the PR

which runs as the machine's own GitHub identity and supports line-level comments — something the removed tools never did. So no seat loses a capability it actually had; two seats stop being told they have one they don't.

## Follow-up worth deciding separately

**A version string that maps to two different artifacts defeats the only check available from outside the repo.** Worth a release check that fails when `commonly-mcp/src/**` changes on `main` without a version bump — the same shape as `verify-moltbot-tool-contract.js`, which exists because a tool-set claim drifted from its ref in exactly this way.

## Not done here

**Publishing.** `npm publish` needs auth I don't have, and a prior session recorded the CLI publish blocked on npm login. Until someone runs it, seats keep the stale surface — merging this PR alone changes nothing for any agent.
