### PR TITLE
fix(agents): the #508 mention dampener never counted thread mentions

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -1101,7 +1101,10 @@ describe('AgentMentionService', () => {
           agentName: 'openclaw',
           instanceId: 'cody',
           podId: 'pod-loop-1',
-          type: 'chat.mention',
+          // Was `type: 'chat.mention'` — this assertion pinned #976 rather
+          // than catching it, because it described the query the code made
+          // instead of the population the gate covers.
+          type: { $in: ['chat.mention', 'thread.mention'] },
         }),
       );
       expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
@@ -1598,6 +1601,93 @@ describe('AgentMentionService', () => {
       expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
       const [event] = AgentEventService.enqueue.mock.calls[0];
       expect(event.agentName).toBe('hq-support');
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // #976 — the #508 dampener gates BOTH mention types but used to count
+  // only chat.mention, so a bot<->bot thread-mention loop was measured
+  // against a counter it could never move.
+  // ------------------------------------------------------------------
+  describe('#508 mention dampener — event-type coverage (#976)', () => {
+    const setup = () => {
+      AgentInstallation.find.mockReturnValue({
+        lean: jest.fn().mockResolvedValue([
+          { agentName: 'smoke-echo', instanceId: 'default', displayName: 'Smoke Echo' },
+        ]),
+      });
+      AgentProfile.find.mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+      // A DIFFERENT bot: the dampener only runs for bot senders, and the
+      // self-mention guard must not pre-empt it.
+      User.findById.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue({
+          _id: 'agent-user-2',
+          isBot: true,
+          botMetadata: { agentName: 'other-agent', instanceId: 'default' },
+        }),
+      });
+    };
+
+    const mention = (extra = {}) => AgentMentionService.enqueueMentions({
+      podId: 'pod-dampen',
+      message: { content: '@smoke-echo again', id: 'msg-d1', ...extra },
+      userId: 'agent-user-2',
+      username: 'other-agent',
+    });
+
+    test('the count selects both mention types, not just chat.mention', async () => {
+      setup();
+      await mention();
+      const query = AgentEvent.countDocuments.mock.calls[0][0];
+      // The assertion is on the SELECTOR rather than on a suppression,
+      // because the defect was invisible in behaviour: with the old query a
+      // thread-mention loop simply counted zero forever, and "not dampened"
+      // is indistinguishable from "under the threshold".
+      expect(query.type).toEqual({ $in: ['chat.mention', 'thread.mention'] });
+    });
+
+    // A blanket countDocuments mock cannot express this defect: it returns the
+    // same number whatever the query asks for, so the old selector looks
+    // healthy. These drive a tiny selector-aware store instead — which is the
+    // production failure exactly, a counter reading rows it never selects.
+    const withStore = (rows) => {
+      AgentEvent.countDocuments.mockImplementation(async (query) => {
+        const wanted = query?.type?.$in ?? [query?.type];
+        return rows.filter((r) => wanted.includes(r.type)).length;
+      });
+    };
+
+    test('a thread-mention loop is dampened, where the chat-only counter read zero', async () => {
+      setup();
+      withStore(Array.from({ length: 4 }, () => ({ type: 'thread.mention' })));
+
+      const res = await mention({
+        source: 'thread',
+        thread: { postId: 'thread-1', postContent: 'parent' },
+      });
+
+      expect(res.enqueued).toEqual([]);
+      expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+    });
+
+    test('the budget is shared, so alternating surfaces cannot each sit at half of it', async () => {
+      // 2 + 2 is over the threshold of 3 together and under it apart. A
+      // per-type budget would let this loop run forever with both counters
+      // permanently below the line.
+      setup();
+      withStore([
+        { type: 'chat.mention' }, { type: 'chat.mention' },
+        { type: 'thread.mention' }, { type: 'thread.mention' },
+      ]);
+
+      const chat = await mention();
+      const thread = await mention({
+        source: 'thread', thread: { postId: 't-2', postContent: 'p' },
+      });
+
+      expect(chat.enqueued).toEqual([]);
+      expect(thread.enqueued).toEqual([]);
     });
   });
 });

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -112,12 +112,26 @@ interface SenderRow {
 // ping-pong forever, burning quota, without ever tripping that guard.
 // This count-based sliding-window backstop suppresses a bot->bot mention
 // once the target has already received more than MENTION_LOOP_MAX
-// chat.mention events in the same pod within MENTION_LOOP_WINDOW_MS — i.e.
+// mention events in the same pod within MENTION_LOOP_WINDOW_MS — i.e.
 // >3 mentions to the same bot in 5 min in a pod = treat as a loop. Genuine
 // handoffs (a human mention, or an infrequent agent handoff) stay under
 // the threshold and are never dampened.
 const MENTION_LOOP_WINDOW_MS = 5 * 60 * 1000; // #508 dampener — 5 min sliding window
 const MENTION_LOOP_MAX = 3; // #508 dampener — >3 mentions to same bot/pod/window = loop
+
+// The event types a mention can be enqueued as. ONE enumeration, used both to
+// type `eventType` and to select the dampener's rows — because those two
+// drifting apart is exactly the bug this constant was introduced to fix
+// (#976): the counter hardcoded 'chat.mention' while the gate it fed covered
+// thread.mention too, so a bot<->bot thread-mention loop was measured against
+// a number it could never move and was never dampened.
+//
+// ONE shared budget across both types, not one per type. The resource being
+// protected is the target's model turns, and a thread mention costs exactly
+// what a chat mention costs. Splitting the budget would also hand an
+// alternating loop double the allowance for free — mention in chat, mention
+// in a thread, repeat, each counter sitting at half the threshold forever.
+const MENTION_EVENT_TYPES = ['chat.mention', 'thread.mention'] as const;
 
 /**
  * Mention Aliases
@@ -979,7 +993,7 @@ const enqueueMentions = async ({
 }: EnqueueMentionsOptions): Promise<EnqueueResult> => {
   const rawContent = message?.content || message?.text || '';
   const source = message?.source || 'chat';
-  const eventType: 'chat.mention' | 'thread.mention' = source === 'thread' ? 'thread.mention' : 'chat.mention';
+  const eventType: (typeof MENTION_EVENT_TYPES)[number] = source === 'thread' ? 'thread.mention' : 'chat.mention';
   // Author/age frame inputs — identical for every target of this
   // message, so resolved once here rather than at each of the four
   // enqueue sites below. Same values that already go into the envelope
@@ -1129,6 +1143,8 @@ const enqueueMentions = async ({
   // #508 mutual bot<->bot loop dampener. Returns true when this mention
   // should be SUPPRESSED because the target bot has already been mentioned
   // more than MENTION_LOOP_MAX times in this pod within the recent window.
+  // Counts BOTH mention types (MENTION_EVENT_TYPES) because it gates both —
+  // see the constant for why the budget is shared rather than per-type.
   // CRITICAL: only dampens bot->bot. `senderAgentName` is non-null ONLY
   // when the sender is a bot (set above from sender.isBot + botMetadata), so
   // a human sender short-circuits to `false` and is NEVER dampened. The
@@ -1141,7 +1157,7 @@ const enqueueMentions = async ({
         agentName: target.agentName.toLowerCase(),
         instanceId: target.instanceId || 'default',
         podId,
-        type: 'chat.mention',
+        type: { $in: MENTION_EVENT_TYPES },
         createdAt: { $gte: new Date(Date.now() - MENTION_LOOP_WINDOW_MS) },
       });
       if (count > MENTION_LOOP_MAX) {


### PR DESCRIPTION
Closes #976. Found by @sprint-review (53986); I verified it from source and took the fix since the issue sat open and unassigned with no PR.

## The defect

`isLoopDampened` gates **both** mention types — `enqueueMentions` writes `type: eventType`, which is `'thread.mention'` when `source === 'thread'` — but its count query hardcoded `type: 'chat.mention'`.

So a thread mention was measured against a counter it could never increment. A bot↔bot thread-mention loop stays flat at zero and is never damped, however long it runs.

Confirmed by reading the call graph, not by inference: `isLoopDampened` at `:1090` gates the enqueues at `:1146`, `:1194`, `:1261`, all of which write `type: eventType`.

## Shared budget, not per-type

The fix counts both types on one budget rather than giving each its own.

The resource being protected is the **target's model turns**, and a thread mention costs exactly what a chat mention costs — the dampener's own comment says "mentioned more than MENTION_LOOP_MAX times", which is surface-agnostic. Splitting the budget would also hand an alternating loop double the allowance for free: mention in chat, mention in a thread, repeat, with each counter parked below the threshold permanently.

The sibling `isWakeLoopDampened` isn't a precedent either way — its counter and its gate already cover the same single type, so it has never had to decide this.

Both the selector and the `eventType` annotation now read from one `MENTION_EVENT_TYPES` constant. That's the structural half: the two drifting apart *is* the defect, and a third mention-shaped type added later now joins the enumeration in one place instead of silently escaping the dampener.

## An existing test pinned the bug

```js
expect(AgentEvent.countDocuments).toHaveBeenCalledWith(
  expect.objectContaining({ ..., type: 'chat.mention' }),
);
```

It didn't catch this — it locked it in. The assertion described the query the code *made* rather than the population the gate *covers*, so the two could disagree and the test would defend the disagreement. Updated, with a comment saying as much, because that failure mode is more reusable than this bug.

## Tests

Three added, **all verified red against the old selector**.

The first drafts of two of them passed against the buggy code, which is worth stating plainly: a blanket `countDocuments.mockResolvedValue(4)` returns the same number whatever the query asks for — precisely the thing that cannot reproduce "a counter reading rows it never selects." They now drive a small selector-aware store, so the chat-only query sees zero exactly as it did in production:

- the selector covers both types (asserted on the query, since with the old code "not dampened" and "under the threshold" are indistinguishable in behaviour)
- a 4-thread-mention loop is dampened, where the chat-only counter read zero
- 2 chat + 2 thread dampens both surfaces — over the threshold together, under it apart, which is the alternation bypass

`70/70` across both `agentMentionService` suites, 0 tsc errors in the touched file.

Not verified: no live bot↔bot thread-mention loop has been observed, here or anywhere. This is code-level, same as the issue said.

🤖 Generated with [Claude Code](https://claude.com/claude-code)