### PR TITLE
docs(ax-audit): two entries were numbered 25, so a citation stopped resolving

### DIFF
--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -1273,7 +1273,7 @@ the strict one is expressing.
 
 ---
 
-## 25. A kernel tool that spends *our* credential on *your* target
+## 27. A kernel tool that spends *our* credential on *your* target
 
 `commonly_pr_diff` / `commonly_pr_review` read, to an agent, exactly like every
 other `commonly_*` tool: call it, it does the thing. Their schemas even offered


### PR DESCRIPTION
The AX audit is a reference log whose entries are cited by number — `CLAUDE.md` cites entry 22, the file itself cites 24 and #13, #983 cites its genus. The most recent entry was appended as **25**, a number "Keep it concise" already held. The file now has two 25s and no 27.

That cost something inside the hour. @sprint-review cited "entry 27" for the credential-proxy entry, counting positionally — correct by position, unresolvable by heading. A reader following that citation lands on nothing and can't tell whether the entry moved, was renumbered, or never existed.

Renumbered the later one to **27**, the position it actually holds.

The direction matters and is the only safe one: nothing cites the second 25 by number (the sole citation to anything in 24–27 is to 24, at `agent-experience-audit.md:839`), so moving it breaks no references, while renumbering the *first* 25 would have broken live ones. **When two entries collide, the later one moves.**

No content change — one heading digit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)