### PR TITLE
fix(scheduler): the boot banner described heartbeats as if they all run

### DIFF
--- a/backend/__tests__/unit/services/schedulerService.heartbeatOptIn.test.js
+++ b/backend/__tests__/unit/services/schedulerService.heartbeatOptIn.test.js
@@ -11,6 +11,9 @@
  * covered `false` would have passed against the old behaviour too.
  */
 
+const fs = require('fs');
+const path = require('path');
+
 jest.mock('jsonwebtoken', () => ({ sign: jest.fn(), verify: jest.fn(), decode: jest.fn() }));
 jest.mock('../../../services/agentEventService', () => ({
   enqueue: jest.fn().mockResolvedValue({ _id: 'evt' }),
@@ -76,5 +79,28 @@ describe('dispatchAgentHeartbeats — opt-in', () => {
       trigger: 'test', respectIntervals: false,
     });
     expect(r.enqueued).toBeGreaterThan(0);
+  });
+
+  test("the startup banner's heartbeat line names the gate, not just the cadence", () => {
+    // The behaviour above is only half of what an operator relies on; the other
+    // half is the one sentence describing it at boot. That sentence read
+    // "Agent heartbeats run every 10 minutes with per-agent intervals" — true
+    // about the dispatcher, silent about the opt-in — and on 2026-08-18 it sent
+    // a reader to resolveHeartbeatIntervalMinutes to compute a fleet wake rate
+    // from a field that is never reached for a seat which never opted in. The
+    // number was retracted; the sentence that produced it would not have been.
+    //
+    // Asserted on the source text because the banner is emitted inside start(),
+    // which schedules real cron jobs. Matched on the gate's NAME rather than on
+    // wording, so a rephrase stays green and a re-simplification does not.
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../services/schedulerService.ts'), 'utf8',
+    );
+    const banner = src.slice(src.indexOf('- Agent heartbeats'));
+    const line = banner.slice(0, banner.indexOf(');'));
+    expect(line).toContain('heartbeat.enabled');
+    // Control: the slice really did capture the banner and not an empty string,
+    // which would satisfy nothing above and look identical to a pass.
+    expect(line).toContain('10 minutes');
   });
 });

--- a/backend/services/schedulerService.ts
+++ b/backend/services/schedulerService.ts
@@ -431,7 +431,20 @@ class SchedulerService {
     console.log('- Agent event GC runs every 10 minutes');
     console.log('- Themed pod autonomy runs every 2 hours');
     console.log('- Agent auto-join (agent-owned pods) runs every 2 hours');
-    console.log('- Agent heartbeats run every 10 minutes with per-agent intervals');
+    // Names the opt-in gate on purpose. Every other line in this banner
+    // describes a job that simply runs; this one describes a job that runs
+    // only for installs that asked for it (#800 made it opt-in after 166 of
+    // 245 active installs were found ticking hourly on a default nobody set).
+    // The old line read "run every 10 minutes with per-agent intervals",
+    // which is true about the dispatcher and silent about the gate — and it
+    // sent a reader straight to resolveHeartbeatIntervalMinutes to compute a
+    // fleet-wide wake rate off a field that is never reached for a seat that
+    // never opted in.
+    console.log(
+      '- Agent heartbeats dispatch every 10 minutes; only installs with'
+      + ' config.heartbeat.enabled === true fire, each on its own interval'
+      + ' (config.heartbeat.everyMinutes, default 60)',
+    );
     console.log(
       `- OpenClaw sessions reset every ${AgentEventService.getSessionResetIntervalHours()} hour(s)`,
     );


### PR DESCRIPTION
## The line

```
- Agent heartbeats run every 10 minutes with per-agent intervals
```

True about the dispatcher, silent about the gate. Since #800 the gate is the dominant fact about heartbeats: `heartbeatEnabled !== true` returns at `schedulerService.ts:1023`, before the interval is ever resolved — so an install that never opted in has no interval, no tick, and no cost. 166 of 245 active installs across 48 owners were found ticking hourly on the old default, each spending its owner's own model quota.

Every other line in that banner describes a job that simply runs. This one described a job that mostly does not, in the same voice.

## Why now

It cost something today, in this repo, inside an hour.

@sprint-review read the line, went to `resolveHeartbeatIntervalMinutes` (default **60**, not the 10 the banner implies), and computed a fleet heartbeat range of **~88–530 wakes over 22h across 4 seats** — a number wide enough to change what a separate ADR claim was asserting. It was wrong for a reason the arithmetic could not reveal: `resolveHeartbeatIntervalMinutes` is not called until `:1042`, downstream of a gate none of those seats pass. They verified it and retracted on #974 (`issuecomment-5325966029`).

The retraction is durable. The sentence that produced it would have gone on producing it — which is the failure this repo has already logged as *"a fix to a false model must land where the model is produced, not where it was diagnosed"* (AX audit entry 13).

## The change

```
- Agent heartbeats dispatch every 10 minutes; only installs with
  config.heartbeat.enabled === true fire, each on its own interval
  (config.heartbeat.everyMinutes, default 60)
```

Names the cadence, the gate, the per-install interval, and its default — the four things the old line invited a reader to go and guess at.

## Test

Added to `schedulerService.heartbeatOptIn.test.js`, which already defends the `undefined` vs `true` distinction — the banner is the operator-facing half of the same invariant.

It asserts on the **source text** rather than by invoking `start()`, which schedules real cron jobs. It matches the gate's **field name** rather than the wording, so a rephrase stays green and a re-simplification back to "heartbeats run" goes red. It carries a control assertion (`10 minutes`) so a slice that captured nothing cannot pass as a match — an empty string satisfies no `toContain` and looks identical to a correct one otherwise.

Confirmed red against the old banner line before being kept. 5/5 in the file, no new tsc errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)