### PR TITLE
fix(agents): the ask limiter's most restrictive setting gave its most permissive one

### DIFF
--- a/backend/__tests__/unit/services/agentAskService.rateLimitEnv.test.js
+++ b/backend/__tests__/unit/services/agentAskService.rateLimitEnv.test.js
@@ -1,0 +1,67 @@
+// #985: AGENT_ASK_RATE_LIMIT_PER_HOUR=0 resolved to 30 — the most restrictive
+// setting silently produced the most permissive one.
+//
+// These pin the DELIVERED constant (__testing__.ASK_RATE_LIMIT_PER_HOUR),
+// re-required under each env value, rather than a extracted resolver. A test
+// against a helper stays green if a later edit stops routing the env var
+// through it; this one cannot.
+//
+// The models are mocked because AgentRegistry.ts calls mongoose.model()
+// unguarded, so jest.resetModules() + re-require would throw
+// OverwriteModelError. Nothing here reaches the database.
+
+jest.mock('../../../services/agentEventService', () => ({ enqueue: jest.fn() }));
+jest.mock('../../../models/AgentRegistry', () => ({ AgentInstallation: {} }));
+jest.mock('../../../models/AgentAsk', () => ({}));
+
+const ENV_KEY = 'AGENT_ASK_RATE_LIMIT_PER_HOUR';
+const original = process.env[ENV_KEY];
+
+const limitFor = (raw) => {
+  jest.resetModules();
+  if (raw === undefined) delete process.env[ENV_KEY];
+  else process.env[ENV_KEY] = raw;
+  // eslint-disable-next-line global-require
+  return require('../../../services/agentAskService').__testing__.ASK_RATE_LIMIT_PER_HOUR;
+};
+
+afterAll(() => {
+  if (original === undefined) delete process.env[ENV_KEY];
+  else process.env[ENV_KEY] = original;
+});
+
+describe('ASK_RATE_LIMIT_PER_HOUR env resolution (#985)', () => {
+  it('clamps 0 to the floor instead of falling through to the default', () => {
+    expect(limitFor('0')).toBe(1);
+  });
+
+  it('clamps a sub-1 fraction to the floor — parseInt("0.5") is a falsy 0', () => {
+    expect(limitFor('0.5')).toBe(1);
+  });
+
+  // Control: this case was already correct before the fix. It is here so a
+  // regression that swings the other way — treating every unparsable value as
+  // the floor — fails instead of looking like a stricter version of the fix.
+  it('still falls back to the default for a non-numeric value', () => {
+    expect(limitFor('abc')).toBe(30);
+  });
+
+  // Control pair: absence must stay absence. An empty string is how a k8s env
+  // block spells "unset", and it must not read as a 0 now that 0 no longer
+  // routes to the default by accident.
+  it('falls back to the default when unset', () => {
+    expect(limitFor(undefined)).toBe(30);
+  });
+
+  it('falls back to the default for an empty string', () => {
+    expect(limitFor('')).toBe(30);
+  });
+
+  it('clamps a negative to the floor, as it always did', () => {
+    expect(limitFor('-5')).toBe(1);
+  });
+
+  it('passes a normal value through untouched', () => {
+    expect(limitFor('7')).toBe(7);
+  });
+});

--- a/backend/services/agentAskService.ts
+++ b/backend/services/agentAskService.ts
@@ -30,10 +30,24 @@ const AgentAsk = require('../models/AgentAsk');
 // only by agent NAME (not name+instance) so an attacker can't trivially
 // bypass the cap by varying instanceId on the from side. The pod is part of
 // the key so a chatty agent in one pod doesn't block its work in another.
-const ASK_RATE_LIMIT_PER_HOUR = Math.max(
-  1,
-  Number.parseInt(process.env.AGENT_ASK_RATE_LIMIT_PER_HOUR || '', 10) || 30,
+// #985: the `|| 30` must not see the PARSED value. Number.parseInt('0') is 0
+// and Number.parseInt('0.5') is also 0 — both falsy — so they fell through to
+// the default instead of clamping to the floor, and an operator dialling the
+// limiter to its most restrictive setting silently got its most permissive
+// one. Every other out-of-range value already clamped (-5 gave 1). Testing the
+// parse for NaN separates "unparsable, use the default" from "parsed low,
+// clamp it", which is what `||` could not express.
+//
+// The floor stays 1 deliberately. Making 0 mean "asks disabled" would work at
+// the consumer (`recentCount >= 0` refuses everything) but that is a new
+// capability, not this bug — left to #985's author.
+const parsedAskRateLimit = Number.parseInt(
+  process.env.AGENT_ASK_RATE_LIMIT_PER_HOUR || '',
+  10,
 );
+const ASK_RATE_LIMIT_PER_HOUR = Number.isNaN(parsedAskRateLimit)
+  ? 30
+  : Math.max(1, parsedAskRateLimit);
 const ASK_RATE_WINDOW_MS = 60 * 60 * 1000;
 const DEFAULT_EXPIRY_MS = 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
Closes #985 — filed by @sprint-review, whose diagnosis is exact; this is the fix plus a control-verified regression test.

## The defect

```js
Math.max(1, Number.parseInt(process.env.AGENT_ASK_RATE_LIMIT_PER_HOUR || '', 10) || 30)
```

`||` sees the **parsed** value. `parseInt('0')` is `0` and `parseInt('0.5')` is also `0` — both falsy — so they fall through to the default and never reach `Math.max` to be clamped.

| env | before | after |
|---|---|---|
| `0` | **30** | 1 |
| `0.5` | **30** | 1 |
| `-5` | 1 | 1 |
| `abc` | 30 | 30 |
| unset / `''` | 30 | 30 |
| `7` | 7 | 7 |

Only two rows move, and they are the two that inverted the operator's intent: every *other* out-of-range value already clamped to the floor, so `0` was uniquely the input that turned the most restrictive setting into the most permissive one.

## The fix

Split the NaN test out from the clamp, so the two questions stop sharing one operator — unparsable means "use the default", parsed-low means "clamp to the floor". `||` cannot express both.

## What this deliberately does not do

The floor stays **1**, not 0. Making `0` mean "asks disabled" would in fact work at the consumer — the gate is `recentCount >= ASK_RATE_LIMIT_PER_HOUR`, so a limit of 0 refuses every ask rather than dividing by zero or reading as unlimited — but that is a new capability, not this defect. Left to whoever owns the ask surface.

## Proof

`backend/__tests__/unit/services/agentAskService.rateLimitEnv.test.js` — 7 cases, run red first: `0` and `0.5` failed with `Received: 30`, the five controls passed unchanged. After the fix, 7/7.

Two deliberate choices in the test:

- It pins the **delivered** constant (`__testing__.ASK_RATE_LIMIT_PER_HOUR`, re-required per env value) rather than an extracted resolver. A test against a helper stays green if a later edit stops routing the env var through it.
- It carries controls in both directions — `abc` must still reach the default, and `''`/unset must stay absence rather than reading as a `0` now that `0` no longer routes to the default by accident.

The models are mocked because `AgentRegistry.ts` calls `mongoose.model()` unguarded, so `jest.resetModules()` + re-require throws `OverwriteModelError`. Nothing here touches a database.

**Not verified:** the pre-existing `agentAskService.test.ts` suite does not run on this machine — it dies importing `jsonwebtoken` under local Node 26, on unmodified `main` as well as on this branch (0 tests collected either way). CI pins Node 20 and is the real signal for that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)