### PR TITLE
fix(cli): a quota stall was classified as a runtime blip and probed every 5s

### DIFF
--- a/cli/__tests__/spawn-retry.test.mjs
+++ b/cli/__tests__/spawn-retry.test.mjs
@@ -100,6 +100,40 @@ describe('spawn retry policy', () => {
  * outage, where every one of them classified as RUNTIME — the weakest class,
  * with the shortest backoff — instead of QUOTA.
  */
+
+describe('classifies the Claude CLI session-limit string (2026-08-18 outage)', () => {
+  // Verbatim from the fleet stall on 2026-08-18. `QUOTA_RE` already carried
+  // "usage limit" — Claude's OTHER exhaustion wording — and missed this one by
+  // a single word, so every seat took the RUNTIME ladder (5.6s, 11.2s, 1.1m)
+  // against a provider that would not answer until 4am.
+  const SESSION_LIMIT = "claude exited with code 1: You've hit your session limit "
+    + '· resets 4am (America/Los_Angeles)';
+
+  test("the CLI's session-limit wording is QUOTA, not RUNTIME", () => {
+    expect(classifySpawnFailure(new Error(SESSION_LIMIT)))
+      .toBe(SPAWN_FAILURE_CLASS.QUOTA);
+  });
+
+  test('so it opens the circuit at the full cooldown on the first failure', () => {
+    const { circuitOpen, delayMs } = spawnRetryPolicy({
+      error: new Error(SESSION_LIMIT),
+      consecutiveFailures: 1,
+      intervalMs: 5000,
+    });
+    expect(circuitOpen).toBe(true);
+    expect(delayMs).toBe(SPAWN_RETRY_MAX_MS);
+  });
+
+  // Guard on the widening, not just the fix. QUOTA is tested before
+  // RATE_LIMIT, so a pattern loose enough to match "limit" on its own would
+  // swallow every rate-limit error into a 15-minute cooldown.
+  test('a rate-limit error is still RATE_LIMIT, not captured by the new pattern', () => {
+    expect(classifySpawnFailure(new Error('429 rate limit exceeded, retry shortly')))
+      .toBe(SPAWN_FAILURE_CLASS.RATE_LIMIT);
+    expect(classifySpawnFailure(new Error('Too many requests — slow down')))
+      .toBe(SPAWN_FAILURE_CLASS.RATE_LIMIT);
+  });
+});
 describe('classifies real provider-exhaustion strings (2026-08-03 outage)', () => {
   test("codex's exact out-of-credits wording is QUOTA, not RUNTIME", () => {
     const error = new Error(

--- a/cli/src/lib/spawn-retry.js
+++ b/cli/src/lib/spawn-retry.js
@@ -19,11 +19,20 @@ export const SPAWN_CIRCUIT_THRESHOLD = 3;
 export const SPAWN_RETRY_MAX_MS = 15 * 60 * 1000;
 export const SPAWN_RETRY_JITTER_MAX_RATIO = 0.2;
 
-// `out of credits` is codex's exact wording for an exhausted workspace balance
-// ("Your workspace is out of credits. Ask your workspace owner to refill…").
-// Without it that outage classified as RUNTIME and drew the shortest backoff —
-// observed live on 2026-08-03 before this pattern was added.
-const QUOTA_RE = /(?:quota|usage limit|credit balance|out of credits|billing|insufficient[_ -]?quota|resource exhausted|spending limit)/i;
+// This list is a per-provider allowlist, and it only ever grows after an
+// outage has already been misclassified. Twice now:
+//   2026-08-03  codex  "Your workspace is out of credits."   → `out of credits`
+//   2026-08-18  claude "You've hit your session limit"       → `session limit`
+// The second one is the instructive failure: `usage limit` was already here —
+// it is Claude's OTHER exhaustion wording — so the fleet stalled for an hour on
+// a string one word away from a pattern we had. Both times the miss meant
+// RUNTIME, the weakest class with the shortest backoff, against a provider that
+// was not going to answer for hours.
+//
+// Deliberately NOT loosened to a bare `limit`: QUOTA is tested before
+// RATE_LIMIT, so that would swallow every "rate limit" error into the 15-minute
+// cooldown. Add exact wordings, not looser ones.
+const QUOTA_RE = /(?:quota|usage limit|session limit|credit balance|out of credits|billing|insufficient[_ -]?quota|resource exhausted|spending limit)/i;
 const RATE_LIMIT_RE = /(?:rate[ -]?limit|too many requests|\b429\b|overloaded|capacity)/i;
 const CONFIGURATION_RE = /(?:ENOENT|command not found|not on PATH|login required|not logged in|invalid api key|authentication failed|unauthori[sz]ed|forbidden|\b40[13]\b)/i;
 


### PR DESCRIPTION
Found by @ux-lead while diagnosing the 2026-08-18 fleet stall (in-pod, alongside #993). Their diagnosis is exact; this is the fix plus a control-verified regression test.

## The defect

`QUOTA_RE` (`cli/src/lib/spawn-retry.js:26`) matched `usage limit` but not `session limit`. The Claude CLI's exhaustion wording is:

```
claude exited with code 1: You've hit your session limit · resets 4am (America/Los_Angeles)
```

That misses every alternative in the pattern, so `classifySpawnFailure` fell through to `RUNTIME` — the weakest class, with the shortest backoff. Observed live on my own seat: `5.6s → 11.2s → 1.1m`, against a provider that would not answer until 4am. `QUOTA` opens the circuit on the **first** failure at the full `SPAWN_RETRY_MAX_MS` ceiling, which is the right response to a quota that resets at a wall-clock hour.

## Why it's worth more than a one-word diff

`usage limit` was already in the list — it is Claude's *other* exhaustion wording. So the fleet stalled for an hour on a string one word away from a pattern we already had.

That makes this the **second** instance of the same shape. The comment directly above `QUOTA_RE` documents the first:

> `out of credits` is codex's exact wording for an exhausted workspace balance … Without it that outage classified as RUNTIME and drew the shortest backoff — observed live on 2026-08-03 before this pattern was added.

The pattern list is a per-provider allowlist that only ever grows *after* an outage has already been misclassified. The comment now records both dates and says that plainly, so the next person adding to it knows they are the third.

## What this deliberately does not do

Not loosened to a bare `limit`. `QUOTA` is tested before `RATE_LIMIT`, so a pattern that broad would swallow every rate-limit error into a 15-minute cooldown — turning a fix for one misclassification into a worse one in the other direction. The test asserts that directly rather than leaving it to review: `429 rate limit exceeded` and `Too many requests` must still classify `RATE_LIMIT` after the widening.

## Proof

Run red first against the live string: both defect tests failed (classifying `RUNTIME`), and the rate-limit guard passed before *and* after — it is a control, not a beneficiary. Full cli suite green: 21 suites, 298 passed.

## Scope — this does not rescue the lost events

Stated because the two findings arrived together and it would be easy to read this as the fix for both. The events lost in the 2026-08-18 stall die in `agentEventService.garbageCollect()` (#993), where the requeue and the stale-pending delete run in the same pass. That happens regardless of which backoff the seat chose. Correcting the class reduces wasted spawn attempts during an outage; it does not change what happens to the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)