### PR TITLE
docs(cli): price the misclassification the quota allowlist keeps paying

### DIFF
--- a/cli/src/lib/spawn-retry.js
+++ b/cli/src/lib/spawn-retry.js
@@ -29,6 +29,23 @@ export const SPAWN_RETRY_JITTER_MAX_RATIO = 0.2;
 // RUNTIME, the weakest class with the shortest backoff, against a provider that
 // was not going to answer for hours.
 //
+// What a miss costs, measured against these constants (intervalMs 5000,
+// jitter 0; `*` = circuit open):
+//
+//   quota          n=1,2,3 ->  900s*  900s*  900s*
+//   configuration  n=1,2,3 ->  900s*  900s*  900s*
+//   rate_limit     n=1,2,3 ->   60s*  120s*  240s*
+//   runtime        n=1,2,3 ->    5s     10s    60s*
+//
+// So an unmatched wording is not one class off — it is 180x faster on the
+// first retry than the class it belonged in, and the only class that does not
+// open the circuit at n=1. That is the price of a missing string, and it is
+// why the entry below is a list of exact wordings rather than a loose pattern.
+//
+// Note RUNTIME is also `classifySpawnFailure`'s fallthrough, so "unrecognised"
+// and "transient local fault" resolve to the same, most aggressive schedule.
+// That is a structural issue rather than a vocabulary one — see #996.
+//
 // Deliberately NOT loosened to a bare `limit`: QUOTA is tested before
 // RATE_LIMIT, so that would swallow every "rate limit" error into the 15-minute
 // cooldown. Add exact wordings, not looser ones.


### PR DESCRIPTION
Comment-only change to `cli/src/lib/spawn-retry.js`. Suggested by @pod-architect after #995 merged.

## Why

#995 rewrote the comment above `QUOTA_RE` to record both times an exhaustion wording missed it:

```
2026-08-03  codex  "Your workspace is out of credits."   → `out of credits`
2026-08-18  claude "You've hit your session limit"       → `session limit`
```

and correctly says the miss meant "RUNTIME, the weakest class with the shortest backoff." That is accurate and it is *qualitative* — which is what leaves the rule underneath it ("Add exact wordings, not looser ones") reading as a style preference rather than a cost.

It is a large cost. Measured against the constants in this file:

```
class=quota          n=1,2,3 ->  900s*  900s*  900s*
class=configuration  n=1,2,3 ->  900s*  900s*  900s*
class=rate_limit     n=1,2,3 ->   60s*  120s*  240s*
class=runtime        n=1,2,3 ->    5s     10s    60s*      (* = circuit open)
```

An unmatched wording is not one class off. It is **180× faster on the first retry** than the class it belonged in, and RUNTIME is the only class that does not open the circuit at `n=1`. On 2026-08-18 that put nine seats on a 5s/10s/60s ladder against an account that could not answer until a fixed reset time.

## What changed

The four-class table, plus one sentence naming the fallthrough issue and pointing at #996 — `classifySpawnFailure` returns `RUNTIME` when nothing matches, so "unrecognised" and "transient local fault" resolve to the same most-aggressive schedule. That is structural rather than a vocabulary gap and is **not** fixed here; recording it beside the allowlist is what stops the next reader treating another added string as the whole remedy.

## Verification

- Table **regenerated from the file after editing**, not pasted from memory — output matches the committed comment exactly.
- `cli` spawn-retry suite: **18/18 passing**.
- Lint: not runnable in this workspace (`eslint` absent from `cli/node_modules`); comment-only, left to CI.

No behaviour change. The retry ladder is correct as it stands — escalating on a seat-wide failure counter is the right signal for a provider outage — so nothing here touches thresholds or classes.