### PR TITLE
fix(agents): the collector destroyed the events the requeue had just rescued

### DIFF
--- a/backend/__tests__/unit/services/agentEventService.lifecycle.test.js
+++ b/backend/__tests__/unit/services/agentEventService.lifecycle.test.js
@@ -286,6 +286,47 @@ describe('garbageCollect: the requeue predicate and its cap', () => {
     expect(expire.filter.attempts).toEqual({ $gte: 3 });
   });
 
+  // #993: the requeue at :650 and the pending delete at :698 ran in the same
+  // Promise.all against different fields — the requeue sets `status` but not
+  // `createdAt`, so an event it had just rescued walked into a `createdAt`-keyed
+  // delete carrying its original age. 38 events were destroyed in one measured
+  // hour, and the log paired them per run (11:00: requeued 17, deletedPending 17).
+  //
+  // These pin the horizon rather than the mechanism: as long as pending ages out
+  // on the SAME schedule as everything else, no rescue can be undone by a sweep
+  // in its own pass, and a seat can be down for a restart or a quota reset
+  // without its queue being destroyed underneath it.
+  const deletes = () => AgentEvent.deleteMany.mock.calls.map(([filter]) => filter);
+
+  test('pending events age out on the same horizon as delivered and acked', async () => {
+    await AgentEventService.garbageCollect({});
+
+    const pending = deletes().find((f) => f.status === 'pending');
+    const settled = deletes().find((f) => Array.isArray(f.status?.$in));
+
+    expect(pending).toBeDefined();
+    expect(settled).toBeDefined();
+    // Same instant, not merely "both long": a shorter pending horizon is exactly
+    // what let the sweep outrun the retry lifecycle.
+    expect(pending.createdAt.$lt.getTime()).toBe(settled.createdAt.$lt.getTime());
+  });
+
+  test('no delete predicate can destroy a pending event inside the retry window', async () => {
+    // The retry ceiling is 15 min x 1.2 jitter = 18 min (cli spawn-retry), and a
+    // seat restart is unbounded. Any pending horizon shorter than the retention
+    // one re-arms both. 24h is a deliberately loose floor — the real value is
+    // 168h — so this fails on a regression rather than on a retuning.
+    await AgentEventService.garbageCollect({});
+
+    const now = Date.now();
+    for (const filter of deletes()) {
+      const targetsPending = filter.status === 'pending'
+        || (Array.isArray(filter.status?.$in) && filter.status.$in.includes('pending'));
+      if (!targetsPending) continue;
+      expect(now - filter.createdAt.$lt.getTime()).toBeGreaterThan(24 * 60 * 60 * 1000);
+    }
+  });
+
   test('reports what it retired, so a poison-event backlog is visible in ops output', async () => {
     AgentEvent.updateMany
       .mockResolvedValueOnce({ modifiedCount: 2 })   // requeued

--- a/backend/models/OnboardingSilenceEpisode.ts
+++ b/backend/models/OnboardingSilenceEpisode.ts
@@ -15,11 +15,21 @@ import mongoose, { Document, Model, Schema, Types } from 'mongoose';
  * `messageCount` — until something answers. Only then can a new one open. The
  * partial unique index below IS that guarantee; it is not advisory.
  *
- * WHY THE EVENT SNAPSHOT IS NOT OPTIONAL. AgentEvent pending rows are deleted
- * at AGENT_EVENT_STALE_PENDING_MINUTES (default 30). The alert fires at 15.
- * In the 15 minutes between, and never again after, the queue can still
- * distinguish two failures that look identical afterwards and need opposite
- * fixes:
+ * WHY THE EVENT SNAPSHOT IS NOT OPTIONAL. The original reason was a race: at
+ * the time this was written, AgentEvent pending rows were deleted 30 minutes
+ * after creation while the alert fired at 15, so the evidence existed for
+ * fifteen minutes and never again. That deletion window is gone — pending rows
+ * now age out on the same 168h clock as everything else (#993) — and the
+ * snapshot is still not optional, for a reason that outlives any retention
+ * setting:
+ *
+ * The rows survive; their STATUS does not. `pending` becomes `delivered`
+ * becomes `acked`, and a query run later reports the queue as it ended, not as
+ * it was when the alert fired. The discriminator below is a statement about a
+ * moment, and the moment is the one thing a surviving row cannot give back.
+ *
+ * So: capture at fire time, because the queue can distinguish two failures that
+ * look identical afterwards and need opposite fixes:
  *
  *   - nothing was ever enqueued  → a producer bug (the write path skipped
  *     enqueueMentions — see pgMessageController, which does exactly this)
@@ -27,7 +37,9 @@ import mongoose, { Document, Model, Schema, Types } from 'mongoose';
  *     and died)
  *
  * Capture it at fire time or the alert is a report that something is wrong
- * with no way left to say what. Calibration: pod-architect, 2026-08-15.
+ * with no way left to say what. Calibration: pod-architect, 2026-08-15;
+ * rationale corrected 2026-08-18 when the 30-minute deletion it rested on was
+ * removed.
  */
 export interface IAgentEventSnapshot {
   /** AgentEvents in this pod between the message and the alert. */

--- a/backend/models/OnboardingSilenceEpisode.ts
+++ b/backend/models/OnboardingSilenceEpisode.ts
@@ -20,13 +20,19 @@ import mongoose, { Document, Model, Schema, Types } from 'mongoose';
  * after creation while the alert fired at 15, so the evidence existed for
  * fifteen minutes and never again. That deletion window is gone — pending rows
  * now age out on the same 168h clock as everything else (#993) — and the
- * snapshot is still not optional, for a reason that outlives any retention
- * setting:
+ * snapshot is still not optional, for two reasons the deletion was never the
+ * only one:
  *
- * The rows survive; their STATUS does not. `pending` becomes `delivered`
- * becomes `acked`, and a query run later reports the queue as it ended, not as
- * it was when the alert fired. The discriminator below is a statement about a
- * moment, and the moment is the one thing a surviving row cannot give back.
+ * 1. STATUS MOVES. `pending` becomes `delivered` becomes `acked`, so a query
+ *    run later reports the queue as it ended, not as it was when the alert
+ *    fired. The discriminator below is a statement about a moment.
+ * 2. THE WINDOW CANNOT BE REBUILT. The field is a count of events in this pod
+ *    BETWEEN the message and the alert. Later traffic lands in the same pod, so
+ *    `noneEnqueued` in particular degrades from a fact into an inference the
+ *    moment anything else is enqueued there.
+ *
+ * And the rows themselves are not permanent — they age out at 168h. "Outlives
+ * the deletion" is the claim, not "outlives retention".
  *
  * So: capture at fire time, because the queue can distinguish two failures that
  * look identical afterwards and need opposite fixes:

--- a/backend/services/agentEventService.ts
+++ b/backend/services/agentEventService.ts
@@ -70,7 +70,6 @@ interface DeliveryMeta {
 }
 
 interface GarbageCollectOptions {
-  stalePendingMinutes?: number;
   deliveredRetentionHours?: number;
   failedRetentionHours?: number;
   requeueDeliveredMinutes?: number;
@@ -82,7 +81,6 @@ interface GarbageCollectResult {
   deletedDelivered: number;
   deletedFailed: number;
   totalDeleted: number;
-  stalePendingMinutes: number;
   deliveredRetentionHours: number;
   failedRetentionHours: number;
   requeuedDelivered?: number;
@@ -608,14 +606,12 @@ class AgentEventService {
   }
 
   static async garbageCollect({
-    stalePendingMinutes = Number(process.env.AGENT_EVENT_STALE_PENDING_MINUTES || 30),
     deliveredRetentionHours = Number(process.env.AGENT_EVENT_DELIVERED_RETENTION_HOURS || 168),
     failedRetentionHours = Number(process.env.AGENT_EVENT_FAILED_RETENTION_HOURS || 168),
     requeueDeliveredMinutes = Number(process.env.AGENT_EVENT_REQUEUE_DELIVERED_MINUTES || 10),
     requeueMaxAttempts = Number(process.env.AGENT_EVENT_REQUEUE_MAX_ATTEMPTS || 3),
   }: GarbageCollectOptions = {}): Promise<GarbageCollectResult> {
     const now = Date.now();
-    const stalePendingThreshold = new Date(now - (Math.max(stalePendingMinutes, 1) * 60 * 1000));
     const deliveredThreshold = new Date(now - (Math.max(deliveredRetentionHours, 1) * 60 * 60 * 1000));
     const failedThreshold = new Date(now - (Math.max(failedRetentionHours, 1) * 60 * 60 * 1000));
     const requeueThreshold = new Date(now - (Math.max(requeueDeliveredMinutes, 1) * 60 * 1000));
@@ -695,7 +691,28 @@ class AgentEventService {
     // schedule — once an event is past the `delivered` threshold it's stale
     // whether the agent ever explicitly acked or not.
     const [pendingResult, deliveredResult, failedResult] = await Promise.all([
-      AgentEvent.deleteMany({ status: 'pending', createdAt: { $lt: stalePendingThreshold } }),
+      // #993: this used to run on a 30-minute `stalePendingThreshold`, which put
+      // it AHEAD of the retry lifecycle rather than after it. The requeue pass
+      // above sets `status` but not `createdAt`, so an event it had just rescued
+      // walked straight into this delete carrying its original age — rescue and
+      // destruction in the same Promise.all, keyed on different fields. Measured
+      // over one hour: 38 pending events destroyed, with the log pairing the two
+      // per run (11:00 requeued 17, then deleted 17).
+      //
+      // Pending now ages out on the same horizon as everything else. That is not
+      // just "longer": it has to be the SAME instant, because any shorter pending
+      // window re-opens the race — against an 18-minute retry ceiling, against a
+      // seat restart, against a quota outage that resets at a wall-clock hour.
+      // Giving the lifecycle room also makes the cap reachable for the first
+      // time, so cap-exhausted events reach `failed` with a reason instead of
+      // vanishing (which is the dead-letter surface this had no other way to get).
+      //
+      // AGENT_EVENT_STALE_PENDING_MINUTES is deliberately NOT read here any more.
+      // It still governs the admin dashboard's stale-pending COUNT
+      // (routes/admin/agentEvents.ts), where "pending for over 30 minutes" is a
+      // useful thing to look at — and is now actionable, because seeing it no
+      // longer means the row is about to be destroyed.
+      AgentEvent.deleteMany({ status: 'pending', createdAt: { $lt: deliveredThreshold } }),
       AgentEvent.deleteMany({ status: { $in: ['delivered', 'acked'] }, createdAt: { $lt: deliveredThreshold } }),
       AgentEvent.deleteMany({ status: 'failed', createdAt: { $lt: failedThreshold } }),
     ]) as Array<{ deletedCount?: number }>;
@@ -709,7 +726,6 @@ class AgentEventService {
       deletedDelivered,
       deletedFailed,
       totalDeleted: deletedPending + deletedDelivered + deletedFailed,
-      stalePendingMinutes: Math.max(stalePendingMinutes, 1),
       deliveredRetentionHours: Math.max(deliveredRetentionHours, 1),
       failedRetentionHours: Math.max(failedRetentionHours, 1),
       requeuedDelivered,

--- a/backend/services/onboardingAlertService.ts
+++ b/backend/services/onboardingAlertService.ts
@@ -94,8 +94,11 @@ const logEpisode = (e: SilenceEpisodeSummary, delivery: string): void => {
 };
 
 /**
- * The one inference this service makes, and it is only possible before the
- * 30-minute pending-GC deletes the evidence.
+ * The one inference this service makes. It used to be possible only before the
+ * 30-minute pending-GC deleted the evidence; #993 removed that deletion, and
+ * the inference is still time-bound for two reasons that outlast it — rows age
+ * out at 168h, and `status` moves (`pending` → `delivered` → `acked`) so a
+ * later query reports the queue as it ended rather than as it was.
  *
  * `never-enqueued` and `enqueued-never-answered` need opposite fixes — a
  * producer bug in the write path versus a runtime that did not run — and after

--- a/backend/services/onboardingSilenceService.ts
+++ b/backend/services/onboardingSilenceService.ts
@@ -63,9 +63,21 @@ const MINUTE_MS = 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Past the first requeue (10m). The upper bound used to be the 30-minute
- * pending-GC window; #993 removed it, so this number is now a floor plus a
- * judgement about how long a newcomer should wait, not a midpoint.
+ * Floor: past the first requeue (10m), so the alert cannot fire inside a
+ * legitimate retry. That bound is unchanged.
+ *
+ * The ceiling used to be the 30-minute pending-GC window, and #993 removed it.
+ * Left there, the only surviving constraint is ">10", which admits 25 or 60 as
+ * readily as 15 — the value would be right by inertia, with nothing recorded to
+ * stop the next editor moving it.
+ *
+ * So the ceiling is re-derived from the reply distribution instead of from the
+ * collector: every genuine reply measured over 21 days landed inside 107
+ * SECONDS, and the next cluster was 10+ hours. Nothing legitimate lives between
+ * two minutes and ten hours, so waiting beyond the floor buys no accuracy — it
+ * only delays the alert. **Keep this as close to the 10-minute floor as the
+ * floor allows; raising it is a pure loss.** That is a real constraint and it
+ * does not depend on the collector at all.
  */
 export const SILENCE_THRESHOLD_MINUTES = Number(
   process.env.ONBOARDING_SILENCE_THRESHOLD_MINUTES || 15,

--- a/backend/services/onboardingSilenceService.ts
+++ b/backend/services/onboardingSilenceService.ts
@@ -22,10 +22,15 @@ import { HUMAN_FILTER, BOT_FILTER } from './userClassification';
  *   than from the observed reply spread, because the spread is a sample of a
  *   system that mostly worked and the constants stay true when the sample
  *   changes. AGENT_EVENT_REQUEUE_DELIVERED_MINUTES is 10, so anything under
- *   ~12 fires inside a legitimate retry; AGENT_EVENT_STALE_PENDING_MINUTES is
- *   30, past which the evidence is deleted along with the answer. 15 sits
- *   between them. (Observed replies agree: every genuine one in 21 days landed
- *   inside 107 seconds, and the next cluster was 10+ hours.)
+ *   ~12 fires inside a legitimate retry. The upper bracket was
+ *   AGENT_EVENT_STALE_PENDING_MINUTES at 30, past which the evidence used to be
+ *   deleted along with the answer; 15 sat between the two. That upper bracket
+ *   is gone as of 2026-08-18 — pending rows now age out on the 168h clock
+ *   (#993) — so only the lower constraint still derives this number, and 15 is
+ *   now a floor plus a judgement about how long a newcomer should wait, not a
+ *   midpoint. Re-deriving it from the constants alone will no longer reproduce
+ *   it. (Observed replies agree with the value: every genuine one in 21 days
+ *   landed inside 107 seconds, and the next cluster was 10+ hours.)
  *
  * - **Not idle-gated.** "Fire only if the user has since gone idle" would be
  *   measured by `lastActive`, which over-counts — V2PodChat polls every 60s,

--- a/backend/services/onboardingSilenceService.ts
+++ b/backend/services/onboardingSilenceService.ts
@@ -62,7 +62,11 @@ import { HUMAN_FILTER, BOT_FILTER } from './userClassification';
 const MINUTE_MS = 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-/** Past the first requeue (10m), inside the pending-GC window (30m). */
+/**
+ * Past the first requeue (10m). The upper bound used to be the 30-minute
+ * pending-GC window; #993 removed it, so this number is now a floor plus a
+ * judgement about how long a newcomer should wait, not a midpoint.
+ */
 export const SILENCE_THRESHOLD_MINUTES = Number(
   process.env.ONBOARDING_SILENCE_THRESHOLD_MINUTES || 15,
 );

--- a/backend/services/schedulerService.ts
+++ b/backend/services/schedulerService.ts
@@ -380,7 +380,8 @@ class SchedulerService {
     // started — the population the onboarding-silence alert is blind to,
     // because they never typed. A cron rather than a delayed event on purpose:
     // re-deriving from state each pass is drop-proof, where a delayed
-    // AgentEvent inherits the pending-GC caveat. See stalledConnectService.
+    // AgentEvent inherited the pending-GC caveat (#993 removed it; the cron
+    // is still right, for the drop-proofness rather than the deletion).
     const stalledConnectJob: CronJob = cron.schedule(
       '*/5 * * * *',
       async () => {

--- a/backend/services/stalledConnectService.ts
+++ b/backend/services/stalledConnectService.ts
@@ -21,10 +21,14 @@ import { composeStalledConnectNudge, composeStalledConnectResolution } from './s
  * each other's population by construction: someone who never types is
  * invisible to that one and is the whole subject of this one.
  *
- * WHY A CRON AND NOT A DELAYED EVENT (ux-lead, explicitly): a delayed
- * AgentEvent inherits the 30-40 minute pending-GC caveat and needs a
- * survivable timer. A cron that re-derives from state each pass is drop-proof
- * by construction — a missed tick costs latency, not the nudge.
+ * WHY A CRON AND NOT A DELAYED EVENT (ux-lead, explicitly): the original
+ * reason was that a delayed AgentEvent inherited the 30-40 minute pending-GC
+ * caveat and so needed a survivable timer. #993 removed that deletion, and the
+ * conclusion is unchanged for the stronger half of the original argument: a
+ * cron that re-derives from state each pass is drop-proof against ANY delivery
+ * failure, not just against a sweep — a missed tick costs latency, not the
+ * nudge. Do not re-open this on the grounds that events now survive 168h; that
+ * was never the load-bearing half.
  *
  * ONE DERIVATION. State comes from `deriveAgentState`, the same function the
  * pod roster, the #943 intro and the #891 surfaces use. There is no parallel


### PR DESCRIPTION
Closes #993. Filed by @sprint-review, escalated by @ux-lead, and resolved in the issue thread by discarding four narrower fixes — including two of mine — in favour of deleting a threshold.

## The defect

`garbageCollect()` runs a requeue pass and a delete pass in the same `Promise.all`, keyed on **different fields**:

```ts
// :650 — rescue: delivered → pending
updateMany({ status: 'delivered', deliveredAt: { $lt: requeueThreshold }, ... },
           { $set: { status: 'pending', deliveredAt: null } })

// :698 — destroy: pending older than 30 minutes
deleteMany({ status: 'pending', createdAt: { $lt: stalePendingThreshold } })
```

The requeue sets `status` but never touches `createdAt`. So an event it had just rescued walked into the delete **carrying its original age**, in the same function call, before any poller could see it. Seats poll every 5s; the three events @sprint-review traced were fetched **zero** times between rescue and deletion.

Measured on one instance over one hour — the collector's own log pairs the two passes per run:

| GC run | `requeued N stuck 'delivered'` | `deletedPending` |
|---|---|---|
| 10:30 | 7 | 5 |
| 10:40 | 30 | 13 |
| 10:50 | 2 | 2 |
| 11:00 | **17** | **17** |

**38 pending events destroyed in seven runs.** Seven were traced to specific agent turns that never happened. The other 31 are unrecoverable — deletion leaves no row, no status, no error, and the per-seat wrapper logs carry no timestamps.

## The fix is the horizon, not the mechanism

Pending now ages out on the same instant as `delivered` and `acked`.

It has to be the **same instant** rather than merely longer, because any shorter pending window re-opens the same race — against the 18-minute retry ceiling (`SPAWN_RETRY_MAX_MS` × 1.2 jitter), against a seat restart, against a quota outage that resets at a wall-clock hour. Four narrower predicates were proposed in the thread and each failed on a case this handles for free:

| proposal | why it was dropped |
|---|---|
| retire aged pending to `failed` | keeps the 30-min horizon — fixes "silently", not "discards" |
| scope the delete to `attempts: 0` | a seat that is merely *stopped* produces the same row (event `6a842b0d` sat pending 30 min across a restart) |
| gate on an active `AgentInstallation` | correct but consults a signal that moves in **days** (7 to `stale`, 14 to prune) against events that live 7 |
| split delete/retire by `attempts` | inherits the `attempts` flaw above, and strands `pending`+`attempts>=1` with no sweep at all |

## It also makes `failed` reachable for the first time

That path has **never fired**: 0 documents at `status: 'failed'`, 0 with `attempts >= 3`. Git dates the two causes back to back with no gap. Before #822 (2026-08-04) `attempts` had two writers — the ack path and `recordFailure` — and **both fired only on terminal transitions**, so the counter went 0 → 1 when an event finished and never moved on redelivery; `attempts < cap` guarded a field that could not reach the cap. Since #822 the counter is honest, and this delete pre-empts a cap that needs three deliveries at 10–20 minute spacing (~T+30 to T+50) against a delete at T+30.

With room to run, cap-exhausted events retire to `failed` **with a reason**, which is the dead-letter surface @ux-lead escalated for — obtained by deleting a threshold rather than adding a mechanism.

## Proof

Two new tests in `agentEventService.lifecycle.test.js`, run red first: both fail on unmodified `main`, the 16 existing lifecycle tests pass unchanged. 27/27 across both `agentEventService` suites after.

They pin the **horizon**, not the implementation — one asserts the pending and settled deletes share the same `createdAt` instant, the other asserts no delete predicate touching `pending` can fire inside 24h (a deliberately loose floor, so it fails on a regression rather than on a retuning).

## Not changed

`AGENT_EVENT_STALE_PENDING_MINUTES` is no longer read here, deliberately. It still governs the admin dashboard's stale-pending count (`routes/admin/agentEvents.ts`), where "pending for over 30 minutes" is now *actionable* — seeing it no longer means the row is about to be destroyed.

**Not verified:** behaviour under a real Mongo. These tests assert the predicates passed to a mocked `deleteMany`, which is the right tier for a filter change but does not exercise retention end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
