### PR TITLE
docs(ax-audit): anchor entry 28's citations to strings, not offsets

### DIFF
--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -1327,8 +1327,9 @@ Every wake carries a server-composed trigger frame. Its load-bearing sentence
 > That stamp is when the message was WRITTEN, not when it reached you — **an
 > unacked event is re-served, so a redelivery arrives with this same stamp.**
 
-The wrapper says the same thing from the other side. On a spawn failure
-(`cli/src/commands/agent.js:1078-1081`):
+The wrapper says the same thing from the other side. On a spawn failure —
+composed in `performRun`'s `tick`, on the `spawnRetryPolicy` catch path, as
+`` `${state}, next probe in ${retryIn}` ``:
 
 ```
 … (1 consecutive) — event 6a842eb896408f264d9a4846 remains unacked;
@@ -1341,7 +1342,7 @@ event* and promises it returns.
 **What actually happens.** `AgentEventService.list()` hard-filters
 `status: 'pending'`. A failed spawn leaves the event `delivered`, and the
 wrapper has no nack and no release — the file contains exactly one POST to
-`/api/agents/runtime/events/`, the ack at `:1109`, so this is structural rather
+`/api/agents/runtime/events/`, the ack, so this is structural rather
 than an omission. The event is invisible to every subsequent poll by construction: the "next
 probe in 5.1s" cannot fetch the event the same line just named. Only
 `garbageCollect()`'s requeue restores it, on a `*/10` cron gated at

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -1329,7 +1329,7 @@ Every wake carries a server-composed trigger frame. Its load-bearing sentence
 
 The wrapper says the same thing from the other side. On a spawn failure —
 composed in `performRun`'s `tick`, on the `spawnRetryPolicy` catch path, as
-`` `${state}, next probe in ${retryIn}` ``:
+grep `next probe in` — the one literal that reads identically in the source and in the log line you are holding:
 
 ```
 … (1 consecutive) — event 6a842eb896408f264d9a4846 remains unacked;


### PR DESCRIPTION
Follow-up to #997 (merged). Prose only — entry 28's findings, dates and numbers are unchanged.

## Why

#997 shipped `cli/src/commands/agent.js:1078-1081`, correcting an earlier `:1133` that had been read off a branch carrying #981's offsets. The new number is right today and **will be wrong shortly**: #981 is open, touches that file from `:44` down, and its author measured the shift as "+3 through :715, then growing to +69 by EOF."

An append-only audit is read months later by someone who was not in the room. A citation that holds against exactly one tree is a citation that is wrong by the time anyone uses it — and entry 28 would need correcting a third time.

## What changed

| before | after |
|---|---|
| ``On a spawn failure (`cli/src/commands/agent.js:1078-1081`)`` | ``On a spawn failure — composed in `performRun`'s `tick`, on the `spawnRetryPolicy` catch path, as `` `${state}, next probe in ${retryIn}` `` `` |
| ``exactly one POST to `/api/agents/runtime/events/`, the ack at `:1109``` | ``exactly one POST to `/api/agents/runtime/events/`, the ack`` |

The second sentence was **already durable** — "the file contains exactly one POST" is a count a reader re-verifies with one grep, and it stays true or fails loudly. The bare `:1109` beside it added nothing but a second thing to go stale.

## Verified against the change that would break it

Not asserted — tested against #981 specifically, since it is the known-future renumbering:

- both anchors are **unique in the tree today** — one hit each in `cli/src/commands/agent.js`;
- #981 leaves the `next probe in` template **untouched** (0 matching lines in its diff);
- #981's two new `/api/agents/runtime/events/` lines land in `cli/__tests__/run-loop.test.mjs` — **zero in `agent.js`**, so the file-scoped count still reads 1 after it merges.

**The scoping is load-bearing and worth stating**, because it qualifies the rule this PR is applying: a repo-wide count of that string would go 1 → 3 on the same merge. "A count survives renumbering where a line does not" is true only when the count names the file it is counting in.

## Disclosure

I recommended this in review while #997 was open, then posted the comment about ninety seconds after it merged without re-checking its state — the exact race I hold a note about. Hence a follow-up PR rather than a review comment that would have landed in time. Related: checklist rule 15 in #1003.