### PR TITLE
docs(cli): a rationale its own PR falsified eleven minutes later

### DIFF
--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -1730,19 +1730,26 @@ Docs:
         workspacePath: record.workspacePath || null,
         intervalMs: parseInt(opts.interval, 10),
         log: (line) => console.log(`${stamp()} [${name}] ${line}`),
-        // Both sinks are stamped, and both must be. A spawn failure is emitted
-        // through `log` AND `onError` — they serve different contracts, the
-        // narrative line keeping the event-type prefix and the error channel
-        // being what an embedder hooks — so each failure already prints twice
-        // into this one merged stream.
+        // Both sinks are stamped, and both must be — but not for the reason
+        // this comment gave until now, which its own PR falsified.
         //
-        // Stamping only `log:` would therefore date ONE COPY of each failure and
-        // leave its twin bare. That is worse to read than no stamps at all: a
-        // stamped line beside an identical unstamped one looks like two events
-        // at two times, so the artifact that already inflates the count would
-        // start inflating the timeline too. Stamped on both, the pair collapses
-        // — same message, same millisecond, one event — where `grep -c
-        // 'session limit'` previously returned 8 for 4 failures.
+        // A spawn failure is routed to `onError` when a caller provides one and
+        // to `log` only as the fallback, so in `agent run` — which always passes
+        // one — EVERY failure line comes out of the error channel and none out
+        // of the log. Stamping only `log:` would leave the entire failure class
+        // undated, which is the class these stamps exist for.
+        //
+        // The two sinks also carry genuinely different text elsewhere: the
+        // no-prompt skip logs a terse line and sends a detailed diagnostic, so
+        // one stamped and one bare would date half of that pair.
+        //
+        // (History, because the reasoning moved twice. This originally argued
+        // from a DOUBLE emission — the retry path called both sinks with
+        // identical text, so `grep -c 'session limit'` returned 8 for 4 failures
+        // and a per-event count read as two deliveries. That was true when the
+        // stamps landed and false eleven minutes later, when the same PR
+        // collapsed the duplication. The conclusion survived the premise; the
+        // sentence did not, and nothing in the diff pointed at it.)
         onError: (err) => console.error(`${stamp()} [${name}] ${err.message}`),
       });
 


### PR DESCRIPTION
Found by @sprint-review while drafting #1003, and it is the third instance in that PR's own list — confirmed on merged `main`, not on a branch.

#1002 stamped both log sinks and justified it from a **double emission**: the retry path called `log(...)` and `onError?.(wrapped)` with identical text, so every spawn failure printed twice into one merged stream (`grep -c 'session limit'` → 8 for 4 failures).

That was true when the stamps landed. `13ad4366`, **in the same PR, eleven minutes later**, collapsed the duplication — and the comment kept arguing from it. It is on `main` right now at `cli/src/commands/agent.js:1733-1745`, asserting a behaviour the PR's own new test forbids:

```js
expect(logs.filter((l) => /claude process died/.test(l))).toHaveLength(0);
```

## The conclusion survives; the reason does not

Both sinks still must be stamped — for the reason the comment originally gave and then abandoned under review. A spawn failure now routes to `onError` when a caller provides one, and to `log` only as the fallback. In `agent run`, which always passes one, **every failure line comes out of the error channel and none out of the log**, so stamping only `log:` would leave the entire failure class undated.

There is a second, independent case: the no-prompt skip sends genuinely different text to each sink — a terse log line and a detailed diagnostic — so one stamped and one bare would date half of that pair.

Note the shape of the churn: my first version said "stamping only `log:` would leave every failure line undated." @sprint-review correctly refuted it (each failure printed twice, so one copy *would* be dated), I rewrote it, and then the collapse made the original claim true again. The comment ended up asserting the one thing that was false at both ends.

## Why the history stays in the comment

Rewritten rather than overwritten, because the failure mode is the lesson and #1003 is about to name it: **a diff shows changed code and never the prose it just invalidated.** Here the prose was five lines from the change, added by the same PR, and survived three rounds of review — two of which rewrote this exact block.

Full cli suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)