### PR TITLE
fix(cli): stamp the line that dates the restart

### DIFF
--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -1700,7 +1700,7 @@ Docs:
         }
         if (record) {
           saveAgentToken(record.agentName, record);
-          console.log(`[${name}] bootstrapped ${tokenFile(record.agentName)} from COMMONLY_AGENT_TOKEN (adapter: ${record.adapter})`);
+          console.log(`${stamp()} [${name}] bootstrapped ${tokenFile(record.agentName)} from COMMONLY_AGENT_TOKEN (adapter: ${record.adapter})`);
         } else {
           console.error(
             `No token for '${name}'. Either export COMMONLY_API_URL + COMMONLY_AGENT_TOKEN`
@@ -1717,7 +1717,14 @@ Docs:
         process.exit(1);
       }
 
-      console.log(`[${name}] polling ${record.instanceUrl} for events (ctrl+c to stop)`);
+      // THE line to stamp, not just one of them. It is the first line of every
+      // seat log and the truncation boundary — the fleet is launched as
+      // `nohup … > log 2>&1`, so this banner is written at boot and everything
+      // before it is gone. Stamped, it dates the restart from the log itself.
+      // Unstamped, it took `ps -o lstart` to establish when nine seats came
+      // back on 2026-08-18, and that only worked because the processes were
+      // still alive — after the next restart that route is gone too.
+      console.log(`${stamp()} [${name}] polling ${record.instanceUrl} for events (ctrl+c to stop)`);
 
       const { stop } = performRun({
         instanceUrl: record.instanceUrl,
@@ -1754,7 +1761,7 @@ Docs:
       });
 
       process.on('SIGINT', () => {
-        console.log(`\n[${name}] stopping...`);
+        console.log(`\n${stamp()} [${name}] stopping...`);
         stop();
         process.exit(0);
       });


### PR DESCRIPTION
Found by @sprint-review. #1002 stamped four sinks and missed the one that cost the most.

## Why this line and not the others

The boot banner is a **direct `console.log`** in the `agent run` action, emitted before `performRun` is called — so it never passed through the injected `log:` that #1002 fixed:

```js
console.log(`[${name}] polling ${record.instanceUrl} for events (ctrl+c to stop)`);
```

It is the **first line of every seat log and the truncation boundary**. The fleet runs as `nohup … > log 2>&1`, so this line is written at boot and everything before it is gone. That makes it the only line capable of dating a restart *from the log itself*.

Unstamped, establishing when nine seats came back on 2026-08-18 required `ps -o lstart`. That worked only because the processes were still alive — one more restart and the route is gone, and the log that replaced the evidence still cannot say when it started.

## Also stamped

The bootstrap-success line and the SIGINT `stopping...` line — the other two direct `console` calls in this action. Between them the log now carries a **dated open and a dated close**, so a truncated file can be placed on a clock at both ends rather than neither.

## Deliberately not stamped

`register`, `connect`, `attach`, `detach`. Those print to a terminal a human is watching, where a timestamp on every line is noise rather than evidence. The distinction is redirected-and-outlives-its-process versus read-once-and-discarded.

Full cli suite green; `registerAgent` builds with the helper in scope (an out-of-scope reference throws at call time, which is how that bug class surfaces — see AX entry 28).

**Not verified:** the rendered output, for the same reason as #1002 — these sinks live inside `.action()`, which no test invokes. The honest check is a seat restart, which belongs to whoever fast-forwards `live/main-tracking`. That check is now cheaper: the first line of the new log will either carry a stamp or it won't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)