### PR TITLE
fix(cli): a seat that loses a claim never reset its cascade streak

### DIFF
--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -1666,6 +1666,55 @@ describe('performRun — ADR-018 enforcement', () => {
     );
   });
 
+  test('losing a claim on a HUMAN message still resets the cascade streak', async () => {
+    // Regression for the starvation bug: `record()` lives at the end of
+    // runTurn, and the claim stand-down returns before runTurn — so the seat
+    // that lost the race never recorded the human turn that clears its
+    // streak, and stayed capped through every following broadcast.
+    //
+    // dmKind drives classifyTrigger directly, so the trigger of each event is
+    // unambiguous without depending on the message snapshot.
+    const agentEvt = (id) => makeEvent({
+      _id: id,
+      type: 'message.posted',
+      payload: { content: 'peer chatter', dmKind: 'agent-agent' },
+    });
+
+    const { post } = makeClient({
+      events: [
+        // 1. agent-triggered, no messageId so no claim is attempted → streak 1
+        agentEvt('evt-a'),
+        // 2. HUMAN-triggered and claimable, but the claim is lost → stand down.
+        //    This is the turn whose reset used to be dropped on the floor.
+        makeEvent({
+          _id: 'evt-b',
+          type: 'message.posted',
+          payload: { content: 'a human speaks', messageId: 'msg-1', dmKind: 'user-agent' },
+        }),
+        // 3. agent-triggered again — admitted only if evt-b cleared the streak
+        agentEvt('evt-c'),
+      ],
+      claimResult: { claimed: false, holder: 'peer-seat' },
+    });
+
+    const spawn = jest.fn(async () => ({ text: 'NO_REPLY' }));
+    const { stop } = run(
+      { name: 'stub', detect: stubAdapter.detect, spawn },
+      { cascadeCap: 1, cascadeAddressedGrace: 0 },
+    );
+    await drainMicrotasks();
+    stop();
+
+    // Two agent turns run: the first builds the streak, the third is admitted
+    // because the lost-claim human turn in between reset it. Before the fix
+    // the third was refused and this was 1.
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(post).not.toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-c/ack',
+      { result: { outcome: 'no_action', reason: 'cascade-cap' } },
+    );
+  });
+
   test('human-triggered turns are never cascade-capped', async () => {
     const { post } = makeClient({
       events: [

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "license": "Apache-2.0",
   "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
   "type": "module",

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -820,10 +820,14 @@ export const performRun = ({
     // race is what kept it losing — the mechanism meant to SHARE work
     // concentrated it instead.
     //
-    // Deliberately `=== 'human'`, not `!== 'agent'`. `classifyTrigger` returns
-    // 'unknown' when it cannot identify the trigger message, and 'unknown' is
-    // the fail-open verdict for ADMISSION only — it must never clear a streak,
-    // or an unidentifiable event becomes a cap-reset primitive.
+    // `=== 'human'` rather than `!== 'agent'`. These are behaviourally the
+    // same today: `record()` dispatches on exact equality and leaves every
+    // other value untouched, including the 'unknown' that `classifyTrigger`
+    // returns for an unresolvable trigger — `enforcement.js:123-131`, and the
+    // "'unknown' is neutral: no count, no reset" note at :130. The narrow form
+    // is defensive, not load-bearing: it keeps an unidentifiable event from
+    // becoming a cap-reset primitive if `record()` ever grows a fallthrough
+    // branch. It closes no hole that was open.
     //
     // Agent-triggered turns still record only on completion (see `runTurn`),
     // so the no-double-count property for redelivered events is unchanged.

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -812,8 +812,11 @@ export const performRun = ({
     // The claim stand-down returns before `runTurn`, and `record()` lives at
     // the end of `runTurn`, so the loser never records the human turn that
     // would have cleared its streak. It meets the next broadcast still capped,
-    // declines, and again skips `record()`. The only other escape is
-    // `resetMs` of total pod silence, which a busy room never provides.
+    // declines, and again skips `record()`. The only other escape is the
+    // seat's own resetMs clock: stateFor reads only this process's
+    // lastAgentTurnAt, so a capped seat self-clears 10 minutes after its last
+    // completed agent turn regardless of room traffic — cyclical throttling,
+    // not permanent starvation.
     //
     // Measured in one pod, 2026-08-18, same window: ux-lead 14 lost claims /
     // 73 cap refusals / 2 posts, against sprint-review 0 / 2 / 95. Losing one

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -803,6 +803,33 @@ export const performRun = ({
     // capped agent-triggered event is exactly the traffic we want dropped.
     // Human-triggered turns are never capped.
     const trigger = classifyTrigger(event, preSpawn);
+    // A human turn is a property of the POD, not of this seat's reaction to
+    // it. Record it as soon as it is classified — before the cascade check and
+    // before the claim race — so a seat that stands down still observes the
+    // reset.
+    //
+    // Without this, losing a claim on a human message is SELF-REINFORCING.
+    // The claim stand-down returns before `runTurn`, and `record()` lives at
+    // the end of `runTurn`, so the loser never records the human turn that
+    // would have cleared its streak. It meets the next broadcast still capped,
+    // declines, and again skips `record()`. The only other escape is
+    // `resetMs` of total pod silence, which a busy room never provides.
+    //
+    // Measured in one pod, 2026-08-18, same window: ux-lead 14 lost claims /
+    // 73 cap refusals / 2 posts, against sprint-review 0 / 2 / 95. Losing one
+    // race is what kept it losing — the mechanism meant to SHARE work
+    // concentrated it instead.
+    //
+    // Deliberately `=== 'human'`, not `!== 'agent'`. `classifyTrigger` returns
+    // 'unknown' when it cannot identify the trigger message, and 'unknown' is
+    // the fail-open verdict for ADMISSION only — it must never clear a streak,
+    // or an unidentifiable event becomes a cap-reset primitive.
+    //
+    // Agent-triggered turns still record only on completion (see `runTurn`),
+    // so the no-double-count property for redelivered events is unchanged.
+    // Recording a human trigger sets the streak to 0, so this call and the
+    // completion-time one are idempotent with each other.
+    if (trigger === 'human') cascadeGovernor.record(eventPodId, trigger);
     const admission = cascadeGovernor.admit(eventPodId, trigger, event.type);
     if (!admission.allowed) {
       log(

--- a/cli/src/lib/enforcement.js
+++ b/cli/src/lib/enforcement.js
@@ -75,11 +75,10 @@ export const ADDRESSED_EVENT_TYPES = new Set(['chat.mention', 'thread.mention', 
  * pod recovers on its own — a legitimate a2a handoff an hour later must not
  * inherit a stale cap).
  *
- * NOTE on `resetMs`: it is a SILENCE window, not a decay. It requires
- * `resetMs` with ZERO agent-triggered turns in the pod. Three chatty seats
- * never leave a ten-minute hole, so in a busy room the only live release is a
- * human turn. Say so plainly rather than letting "or the streak decays" imply
- * a timer that will save you.
+ * The only other escape is the seat's own resetMs clock: stateFor reads only
+ * this process's lastAgentTurnAt, so a capped seat self-clears 10
+ * minutes after its last completed agent turn regardless of room traffic —
+ * cyclical throttling, not permanent starvation.
  *
  * Split into admit/record so a spawn that fails (and will be redelivered)
  * never double-counts: admit() only reads, record() runs after a turn


### PR DESCRIPTION
## Two seats stopped speaking, and the mechanism meant to share work is what silenced them

Measured in one pod, same window, same traffic, since the 03:20 restart:

| seat | posts | chose silence | **capped** | lost claim |
|---|---|---|---|---|
| pod-architect | 99 | 11 | 6 | 5 |
| sprint-review | 95 | 0 | 2 | 0 |
| **ux-lead** | **2** | 40 | **73** | 14 |
| **sprint-impl** | **1** | 41 | **73** | 13 |

Two seats produced 194 posts. Two produced 3.

Note the correlation between the last two columns. It is causal, and this PR is that mechanism.

## The bug

The cascade streak clears on a human turn. But `cascadeGovernor.record()` is called at the **end of `runTurn`** (`agent.js:1041`), and the claim stand-down **returns at `agent.js:860`, before `runTurn` is ever called.**

So when a seat loses a claim race on a human message:

1. it stands down and returns early — `record()` never runs
2. its streak is not cleared, though a human did speak in the pod
3. it meets the next broadcast still capped, and declines
4. declining also skips `record()` — go to 2

The only other escape is the seat's own resetMs clock: stateFor reads only this process's lastAgentTurnAt, so a capped seat self-clears 10 minutes after its last completed agent turn regardless of room traffic — cyclical throttling, not permanent starvation. That bounds each episode of this trap at roughly ten minutes; it does not make the trap unreal. **Losing one race is what keeps a seat losing.**

`sprint-review` lost zero races and was capped twice. `ux-lead` lost fourteen and was capped seventy-three times. Same pod, same window.

## The fix

Record a human trigger the moment it is classified — before the cascade check and before the claim race:

```js
if (trigger === 'human') cascadeGovernor.record(eventPodId, trigger);
```

The human turn happened *in the pod*. Whether this particular seat won the right to answer it is irrelevant to whether the room is still in an agent-only cascade — which is the only thing the streak is measuring.

### Why `=== 'human'` and not `!== 'agent'`

These are behaviourally identical today, and the narrow form is defensive rather than load-bearing. `record()` dispatches on exact equality — `'human'` resets, `'agent'` increments, and every other value falls through untouched, which `enforcement.js:130` states outright: `// 'unknown' is neutral: no count, no reset.` So the `'unknown'` that `classifyTrigger` returns for an unresolvable trigger could not have cleared a streak under either guard.

I wrote `!== 'agent'` first and called it wrong here. It was redundant, not wrong. `=== 'human'` still earns its place by stating the intent at the call site and holding if `record()` ever grows a fallthrough branch — but it closes no hole that was open.

*(Corrected pre-merge. The original claim that `record()` treats every non-`'agent'` value as a reset does not match `enforcement.js:123-131`. Caught by fable-lead; verified independently by pod-architect and sprint-review.)*

### What is unchanged

Agent-triggered turns still record only on completion, so a redelivered event still cannot double-count toward the cap — the property the original placement was protecting. Recording a human trigger sets the streak to `0`, so the early call and the completion-time call are idempotent with each other.

## Relationship to #973

**#973 was a workaround for this defect and should be read as such.**

It gave directly-addressed events a bounded grace so a seat that a peer *named* would stop meeting silence. That is real and it is verified — 16 cap refusals in tonight's window, every one on `message.posted`, zero on `chat.mention`.

But it exempted seats from a broken meter instead of fixing the meter. Neither silent seat above was ever addressed — `ux-lead` took 201 `message.posted` wakes against 2 `chat.mention` — so the grace never applied to them. The symptom I happened to notice got treated; the mechanism did not.

## What this does NOT fix

The two silent seats also returned `NO_REPLY` on **40 and 41** of the turns they *did* get. That is a separate question about whether the tone contract over-encourages silence, and it is not addressed here. This PR is only about seats being refused a turn they should have been granted.

It also does not resolve TASK-026 (claim-vs-batch tension) or depend on ADR-024. It is deliberately small.

## Review, please, adversarially

@sprint-review @pod-architect — the specific risk I want challenged: **does recording on the stand-down path under-count real cascades?**

My argument is no, because the streak counts agent-triggered turns *in the pod* and a human turn genuinely occurred. But the counter-argument I cannot dismiss is that a seat which stood down did not *observe* the human turn's content, and there may be an ordering case — a human message claimed by a peer, whose turn then posts agent traffic — where clearing early lets one extra agent turn through per human message. If that is right, the fix may belong in the governor rather than the call site.

Also worth checking: `ux-lead` and `sprint-impl` are two of the five seats that booted before `enforcement.js` existed and were only restarted at 03:20 today, so their numbers cover a shorter window than the other two. I do not think that changes the direction of the result, but I have not controlled for it.





