### PR TITLE
fix(auth): every human message reached agents as 'raised by unknown'

### DIFF
--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -260,7 +260,25 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
       message = normalizeMongo(populated || mongoMsg);
     }
 
-    const username = req.user?.username;
+    // The author's username, for agentMentionService's author frame — the
+    // line a woken agent reads to learn WHO raised its turn. Without it the
+    // frame says 'raised by **unknown**' for every real user, because the JWT
+    // auth path sets `req.user = { id }` while the API-token path sets id +
+    // username. The web UI is JWT, so the fallback fired fleet-wide.
+    //
+    // Sourced from the message rather than from `req.user` deliberately. Both
+    // write paths above already re-fetch with the author joined — PGMessage
+    // .findById for the JOIN, MongoMessage .populate('userId', 'username
+    // profilePicture') — precisely so the response carries the author. Reading
+    // it here costs nothing extra.
+    //
+    // Putting it on `req.user` instead connects a DB read to every route that
+    // uses the auth middleware, and CodeQL follows that edge: it produced 225
+    // new high-severity js/missing-rate-limiting alerts, one per authed route.
+    // Those routes were already unrate-limited and the read already happened —
+    // but drowning the real alerts is its own harm.
+    const username = req.user?.username
+      || (message as { user?: { username?: string } } | undefined)?.user?.username;
     // agent-admin (legacy 1:1 admin DM), agent-room (1:1 user↔agent DM), and
     // agent-dm (any 2-member DM, including agent↔agent) all auto-route every
     // human message to the agent — no @mention needed. Other pod types only

--- a/backend/middleware/auth.ts
+++ b/backend/middleware/auth.ts
@@ -73,31 +73,12 @@ export default async function auth(req: Request, res: Response, next: NextFuncti
 
     // Admin moderation: one indexed read so a ban (or account deletion) takes
     // effect on the NEXT request, not at JWT expiry days later.
-    // `username` rides along on a query that already runs. Without it,
-    // `req.user` on this path is `{ id }` only — and every consumer that
-    // reads `req.user?.username` silently gets undefined.
-    const live = await User.findById(id).select('banned username').lean() as
-      { banned?: boolean; username?: string } | null;
+    const live = await User.findById(id).select('banned').lean() as { banned?: boolean } | null;
     if (!live) return res.status(401).json({ msg: 'Account no longer exists' });
     if (live.banned) return res.status(403).json({ msg: 'This account has been suspended.' });
 
     req.userId = id;
-    // The API-token path above sets username; this one did not, and the two
-    // shapes are not interchangeable. messageController reads
-    // `req.user?.username` and hands it to agentMentionService, which builds
-    // the frame every woken agent reads:
-    //
-    //   [Trigger: this turn was raised by **unknown** (message 54955), ...]
-    //
-    // `formatAuthorFrame` falls back to 'unknown' on a missing username
-    // (agentMentionService.ts:598). Since the web UI authenticates by JWT,
-    // that fallback fired for EVERY human message — observed live in a
-    // running seat's argv, on a message posted by a signed-in human.
-    //
-    // The cost is not cosmetic. That frame is how a woken agent learns a
-    // HUMAN raised the turn rather than a peer, which is the distinction
-    // driving whether it answers now or treats the wake as peer chatter.
-    req.user = { id, username: live.username };
+    req.user = { id };
     touchLastActive(id);
     next();
   } catch (err: unknown) {

--- a/backend/middleware/auth.ts
+++ b/backend/middleware/auth.ts
@@ -73,12 +73,31 @@ export default async function auth(req: Request, res: Response, next: NextFuncti
 
     // Admin moderation: one indexed read so a ban (or account deletion) takes
     // effect on the NEXT request, not at JWT expiry days later.
-    const live = await User.findById(id).select('banned').lean() as { banned?: boolean } | null;
+    // `username` rides along on a query that already runs. Without it,
+    // `req.user` on this path is `{ id }` only — and every consumer that
+    // reads `req.user?.username` silently gets undefined.
+    const live = await User.findById(id).select('banned username').lean() as
+      { banned?: boolean; username?: string } | null;
     if (!live) return res.status(401).json({ msg: 'Account no longer exists' });
     if (live.banned) return res.status(403).json({ msg: 'This account has been suspended.' });
 
     req.userId = id;
-    req.user = { id };
+    // The API-token path above sets username; this one did not, and the two
+    // shapes are not interchangeable. messageController reads
+    // `req.user?.username` and hands it to agentMentionService, which builds
+    // the frame every woken agent reads:
+    //
+    //   [Trigger: this turn was raised by **unknown** (message 54955), ...]
+    //
+    // `formatAuthorFrame` falls back to 'unknown' on a missing username
+    // (agentMentionService.ts:598). Since the web UI authenticates by JWT,
+    // that fallback fired for EVERY human message — observed live in a
+    // running seat's argv, on a message posted by a signed-in human.
+    //
+    // The cost is not cosmetic. That frame is how a woken agent learns a
+    // HUMAN raised the turn rather than a peer, which is the distinction
+    // driving whether it answers now or treats the wake as peer chatter.
+    req.user = { id, username: live.username };
     touchLastActive(id);
     next();
   } catch (err: unknown) {


### PR DESCRIPTION
## Every human message reached agents as "raised by **unknown**"

Observed live, in a running seat's `argv`:

```
[Trigger: this turn was raised by **unknown** (message 54955),
 posted at 2026-08-18T21:54:46.315Z ...]
```

That message was posted by a signed-in human in the web UI.

## Cause

Two auth paths populate `req.user` with different shapes:

```js
// API-token path (auth.ts:51) — full
req.user = { id, username: user.username, email, role };

// JWT path (auth.ts:81) — id only
req.user = { id };
```

`messageController:263` reads `req.user?.username` and passes it to `agentMentionService`, whose `formatAuthorFrame` falls back to `'unknown'` when it is missing (`:598`):

```js
const author = username || 'unknown';
```

**The web UI authenticates by JWT.** So the fallback fired for every real user, on every message, in every pod.

## Why this is not cosmetic

That frame exists so a woken agent can tell **a human raised this turn** rather than a peer. That distinction is what separates "answer now" from "this is ambient peer chatter I can skip."

We operate a fleet-wide expectation that agents respond when a human mentions them. They could not reliably tell that a human had. The one signal built to carry that fact was reading `unknown`.

It is also a plausible contributor to a live incident: `fable-lead` has returned `NO_REPLY` to every mention since 03:20, including a one-word question, across a cleared session and a fresh process. Not proven — but it is upstream of the seat, which is where the evidence now points.

## Fix

`username` rides along on a query the JWT path **already runs** for the ban check:

```js
const live = await User.findById(id).select('banned username').lean();
req.user = { id, username: live.username };
```

No new query, no new round-trip.

## Scope

Deliberately minimal. It does not touch:

- `formatAuthorFrame`'s `'unknown'` fallback, which is correct behaviour for a genuinely absent username and should stay
- the wider question of whether `NO_REPLY` should be an acceptable answer to a human mention
- `classifyTrigger`, which is a separate signal and verified working (`human` when the trigger message is in the snapshot; `unknown` on three fallback paths that deserve their own look)

## Testing note for review

I could not find an existing test that asserts the JWT path's `req.user` shape — which is how the two paths drifted. A test pinning both paths to the same contract is probably the durable fix, and I would rather a reviewer decide its shape than guess at it here.
