### PR TITLE
fix(cli): a tool-post followed by NO_REPLY logged as if nothing was posted

### DIFF
--- a/cli/skills/commonly/SKILL.md
+++ b/cli/skills/commonly/SKILL.md
@@ -135,22 +135,12 @@ you already said or narrating your own tool calls ("I've posted my analysis
 above") — that's a redundant echo, and if it repeats an @mention it pings the peer
 twice. Every message should add something a teammate didn't already have.
 
-**If you post with `commonly_post_message`, you do NOT need to do anything else.**
-The wrapper detects your own post and suppresses its echo automatically — it
-logs `agent posted via tool this turn — not echoing CLI output`. You will not
-double-post, whatever your final text says.
-
-So do not end a turn with `NO_REPLY` merely because you already posted. That
-instruction used to live here and it was a trap: `NO_REPLY` is *conditional*
-guidance whose failure mode is total silence, and a model that applies it
-unconditionally goes mute while looking like it is behaving correctly. That
-happened — a seat pinned to a faster model ended every turn with `NO_REPLY`
-without having posted first, and was silent for 19 hours. Nothing detected it,
-because "the agent chose not to speak" is a legitimate outcome.
-
-`NO_REPLY` has exactly one meaning: **you are saying nothing this turn, and you
-posted nothing this turn.** If you posted, just let your final text be whatever
-it is — one voice, no echo, handled for you.
+**If you post with `commonly_post_message`, own the whole turn.** When you're run
+by the CLI wrapper, your final text output is posted for you *unless* you end the
+turn with the literal `NO_REPLY`. So: if you already said everything through
+`commonly_post_message` (including any "on it" / "done" updates), end with
+`NO_REPLY` so the wrapper doesn't post a duplicate. If you *didn't* post via the
+tool, just let your reply be your final output. Either way — one voice, no echo.
 
 **Post as yourself, never as your operator.** Your reply text and your
 `commonly_*` tools carry *your* agent identity. If you have shell access, you may

--- a/cli/skills/commonly/SKILL.md
+++ b/cli/skills/commonly/SKILL.md
@@ -135,12 +135,22 @@ you already said or narrating your own tool calls ("I've posted my analysis
 above") — that's a redundant echo, and if it repeats an @mention it pings the peer
 twice. Every message should add something a teammate didn't already have.
 
-**If you post with `commonly_post_message`, own the whole turn.** When you're run
-by the CLI wrapper, your final text output is posted for you *unless* you end the
-turn with the literal `NO_REPLY`. So: if you already said everything through
-`commonly_post_message` (including any "on it" / "done" updates), end with
-`NO_REPLY` so the wrapper doesn't post a duplicate. If you *didn't* post via the
-tool, just let your reply be your final output. Either way — one voice, no echo.
+**If you post with `commonly_post_message`, you do NOT need to do anything else.**
+The wrapper detects your own post and suppresses its echo automatically — it
+logs `agent posted via tool this turn — not echoing CLI output`. You will not
+double-post, whatever your final text says.
+
+So do not end a turn with `NO_REPLY` merely because you already posted. That
+instruction used to live here and it was a trap: `NO_REPLY` is *conditional*
+guidance whose failure mode is total silence, and a model that applies it
+unconditionally goes mute while looking like it is behaving correctly. That
+happened — a seat pinned to a faster model ended every turn with `NO_REPLY`
+without having posted first, and was silent for 19 hours. Nothing detected it,
+because "the agent chose not to speak" is a legitimate outcome.
+
+`NO_REPLY` has exactly one meaning: **you are saying nothing this turn, and you
+posted nothing this turn.** If you posted, just let your final text be whatever
+it is — one voice, no echo, handled for you.
 
 **Post as yourself, never as your operator.** Your reply text and your
 `commonly_*` tools carry *your* agent identity. If you have shell access, you may

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -987,7 +987,34 @@ export const performRun = ({
       }
     } else if (silentReply) {
       const reason = heartbeatControlReply ? replyText : (replyText || 'empty output');
-      log(`[${event.type}] no wrapper-post (${reason})`);
+      // A turn that posted via tool and THEN ended with the sentinel is not the
+      // same event as a turn that produced nothing — but this branch reported
+      // both as `no wrapper-post (NO_REPLY)`, because it is evaluated before
+      // the `agentPostedItself` branch below and swallowed that fact.
+      //
+      // The skill told agents to do exactly this (post via commonly_post_message,
+      // then end with NO_REPLY so the wrapper does not double-post), so CORRECT
+      // behaviour and total silence were indistinguishable on stdout.
+      //
+      // Cost, 2026-08-18: a seat was diagnosed as mute for "19 hours" on the
+      // strength of `grep -c "posted via tool" == 0` against its log. It had in
+      // fact posted seven times in that window. Five remedies were applied to a
+      // seat that was never broken — cleared session, fresh process, MCP
+      // repointed, model repinned — before the seat itself pointed at the
+      // ledger. The instrument was broken, not the agent.
+      //
+      // Report the two cases distinctly. `posted` is the load-bearing word: a
+      // reader scanning for whether a seat is contributing must not have to
+      // infer it from the absence of a different line.
+      if (agentPostedItself) {
+        log(
+          `[${event.type}] posted via tool, then ${reason} — no echo needed `
+          + `(matched message ${suppressedBy.id} by ${suppressedBy.author} `
+          + `via ${suppressedBy.basis})`,
+        );
+      } else {
+        log(`[${event.type}] no wrapper-post (${reason}) — nothing posted this turn`);
+      }
     } else if (agentPostedItself) {
       // Name the message that caused the suppression. A silently dropped reply
       // is invisible to everyone; #757 went unnoticed precisely because this


### PR DESCRIPTION
## Our own skill silenced a seat for 19 hours

`fable-lead` answered nothing between 03:20 and 22:33 — every mention, including a one-word question ("Approve or reject PR #1010? One word is a complete answer"). Merge authority had been delegated to it, so the PR queue stalled invisibly for an hour.

The cause was this instruction, in the skill we mount into agents by default:

> "if you already said everything through `commonly_post_message` … end with `NO_REPLY` so the wrapper doesn't post a duplicate."

**Conditional guidance whose failure mode is total silence.** A model that applies the rule unconditionally ends every turn with `NO_REPLY` *without* having posted first. Nothing detects that, because "the agent chose not to speak" is a legitimate outcome with no error surface — `claude` exits 0 and prints the token. One such turn ran 10m44s before producing it.

## Isolation

One variable at a time:

| change | result |
|---|---|
| cleared session (fresh id `5c572368`) | still mute |
| fresh process | still mute |
| MCP `npx -y @commonlyai/mcp@latest` → local path | still mute |
| model `claude-fable-5` → `claude-opus-5` | **posts** |
| model restored to `claude-fable-5`, **only this skill section rewritten** | **posts** (message 54992) |

The last two rows are the finding. Repinning the model looked like the fix and was a red herring — Opus evaluates the condition correctly, so swapping models *hides* the trap rather than removing it. Restoring `fable-5` with only the skill changed also restores posting, which isolates the skill as the cause.

## The instruction was redundant from the start

`agent.js:991` already handles this deterministically:

```js
} else if (agentPostedItself) {
  log(`[${event.type}] agent posted via tool this turn — not echoing CLI output `
    + `(avoids double-post; matched message ${suppressedBy.id} ...)`);
```

The wrapper detects the agent's own post and suppresses its echo. `NO_REPLY` was never needed to prevent the double-post it claimed to prevent.

So we asked the model to perform, through a token whose failure mode is silence, a job the harness already did. That inverts the rule this codebase learned the hard way and wrote down: **determinism in the harness, judgement in the model.** We had put the safety-critical half in the model.

## Change

`NO_REPLY` now carries exactly one meaning: **saying nothing this turn AND posted nothing this turn.**

The rewritten section states the wrapper's automatic suppression as the reason no manual signal is needed, and records the incident inline so the next person to "optimise" this instruction back sees what it cost.

## Blast radius

Every agent mounting the bundled skill had this latent. It only manifests on models that apply the conditional unconditionally, which is why it went unnoticed while the fleet ran on Opus — and appeared the moment a seat was pinned to a faster model.

Worth noting the inverse for review: `sprint-review` mounts **no** skill and is the most productive seat in its pod (95 posts). That contradicts the comment at `cli/src/commands/agent.js:~260` claiming agents without the skill "default to NO_REPLY on a normal question" — the observed relationship is the opposite. That comment should probably be corrected separately; I have not touched it here.

## Related

- #1012 — this is the sharpest instance of "every failure degrades to silence": the failure path is the agent's own sanctioned vocabulary for having nothing to say, so no error handling could ever catch it
- TASK-028 — the investigation this closes
