### PR TITLE
feat(ops): ask the kernel which seats are producing output

### DIFF
--- a/backend/scripts/seat-output.ts
+++ b/backend/scripts/seat-output.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/*
+ * Which seats are producing output, and which are silent — and why.
+ *
+ * Everything here is already persisted on AgentEvent (`delivery.outcome`,
+ * `delivery.reason`, `status`, `attempts`). Nothing surfaced it, so answering
+ * "is this agent working?" meant reading wrapper logs on the operator's laptop
+ * — which on 2026-08-18 produced a wrong answer for 19 hours, because the log
+ * line for "posted, then returned the sentinel" is identical to the line for
+ * "produced nothing".
+ *
+ * The kernel knows. It records `outcome: 'posted'` with the messageId. Ask it.
+ *
+ * Usage:
+ *   node dist/scripts/seat-output.js               # last 60 min
+ *   node dist/scripts/seat-output.js --minutes 240
+ *   node dist/scripts/seat-output.js --agent fable-lead
+ *
+ * Reads only. Safe to run against production.
+ */
+
+/* eslint-disable no-console */
+const mongoose = require('mongoose');
+
+const argMinutes = process.argv.indexOf('--minutes');
+const WINDOW_MIN = argMinutes > -1 ? Number(process.argv[argMinutes + 1]) || 60 : 60;
+const argAgent = process.argv.indexOf('--agent');
+const ONLY_AGENT = argAgent > -1 ? String(process.argv[argAgent + 1] || '').toLowerCase() : null;
+
+const main = async () => {
+  const uri = process.env.MONGO_URI;
+  if (!uri) {
+    console.error('MONGO_URI is required');
+    process.exit(1);
+  }
+  await mongoose.connect(uri);
+  const events = mongoose.connection.collection('agentevents');
+
+  const since = new Date(Date.now() - WINDOW_MIN * 60 * 1000);
+  const match: Record<string, unknown> = { createdAt: { $gte: since } };
+  if (ONLY_AGENT) match.agentName = ONLY_AGENT;
+
+  const rows = await events.aggregate([
+    { $match: match },
+    {
+      $group: {
+        _id: { agent: '$agentName', instance: '$instanceId' },
+        total: { $sum: 1 },
+        posted: { $sum: { $cond: [{ $eq: ['$delivery.outcome', 'posted'] }, 1, 0] } },
+        noAction: { $sum: { $cond: [{ $eq: ['$delivery.outcome', 'no_action'] }, 1, 0] } },
+        errored: { $sum: { $cond: [{ $eq: ['$delivery.outcome', 'error'] }, 1, 0] } },
+        // Terminal 'failed' is the dead-letter surface: these events hit the
+        // requeue cap and will never be served again. Nothing else shows them.
+        deadLettered: { $sum: { $cond: [{ $eq: ['$status', 'failed'] }, 1, 0] } },
+        stillPending: { $sum: { $cond: [{ $eq: ['$status', 'pending'] }, 1, 0] } },
+        lastPostedAt: {
+          $max: { $cond: [{ $eq: ['$delivery.outcome', 'posted'] }, '$delivery.updatedAt', null] },
+        },
+      },
+    },
+    { $sort: { posted: 1, total: -1 } },
+  ]).toArray();
+
+  console.log(`\nSeat output, last ${WINDOW_MIN} min (since ${since.toISOString()})\n`);
+  console.log(
+    'seat'.padEnd(22)
+    + 'events'.padStart(7) + 'posted'.padStart(8) + 'no_act'.padStart(8)
+    + 'error'.padStart(7) + 'DEAD'.padStart(6) + 'pend'.padStart(6) + '  last posted',
+  );
+
+  const silent: string[] = [];
+  for (const r of rows) {
+    const seat = `${r._id.agent}${r._id.instance && r._id.instance !== 'default' ? `:${r._id.instance}` : ''}`;
+    if (r.posted === 0 && r.total > 0) silent.push(seat);
+    console.log(
+      seat.padEnd(22)
+      + String(r.total).padStart(7) + String(r.posted).padStart(8) + String(r.noAction).padStart(8)
+      + String(r.errored).padStart(7) + String(r.deadLettered).padStart(6)
+      + String(r.stillPending).padStart(6)
+      + '  ' + (r.lastPostedAt ? new Date(r.lastPostedAt).toISOString() : '—'),
+    );
+  }
+
+  // The question this script exists to answer, stated outright rather than
+  // left for the reader to infer from a table.
+  if (silent.length) {
+    console.log(`\n⚠ woken but produced nothing: ${silent.join(', ')}`);
+    console.log('  Reasons given, most frequent first:');
+    const reasons = await events.aggregate([
+      { $match: { ...match, 'delivery.outcome': { $in: ['no_action', 'error'] } } },
+      { $group: { _id: { agent: '$agentName', reason: '$delivery.reason' }, n: { $sum: 1 } } },
+      { $sort: { n: -1 } },
+      { $limit: 12 },
+    ]).toArray();
+    for (const r of reasons) {
+      if (!silent.includes(r._id.agent)) continue;
+      console.log(`    ${String(r._id.agent).padEnd(20)} ${String(r._id.reason || '(none given)').padEnd(28)} ${r.n}`);
+    }
+  } else {
+    console.log('\n✓ every woken seat posted at least once in the window');
+  }
+
+  const totalDead = rows.reduce((a: number, r: Record<string, number>) => a + (r.deadLettered || 0), 0);
+  if (totalDead > 0) {
+    console.log(`\n⚠ ${totalDead} event(s) in terminal 'failed' — hit the requeue cap, never retried, invisible to list(). See #998.`);
+  }
+
+  await mongoose.disconnect();
+};
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/scripts/seat-output.ts
+++ b/backend/scripts/seat-output.ts
@@ -68,10 +68,35 @@ const main = async () => {
     + 'error'.padStart(7) + 'DEAD'.padStart(6) + 'pend'.padStart(6) + '  last posted',
   );
 
+  // Outcome-silence is NOT seat-silence. The native tier acks 'acknowledged'
+  // and never writes `delivery.outcome: 'posted'`, so keying on that alone
+  // reports a perfectly healthy user-facing agent as mute — which this script
+  // did on its first run, against `scout` (68 replies in 7 days) and against
+  // the `commonly-bot` 288-event row in its own output.
+  //
+  // So before calling a seat silent, ask the message ledger. Caught in review
+  // by fable-lead; the native-tier outcome write is a separate kernel issue,
+  // not a blocker for this detector.
+  const ledger = mongoose.connection.collection('messages');
   const silent: string[] = [];
+  const postingUnrecorded: string[] = [];
   for (const r of rows) {
     const seat = `${r._id.agent}${r._id.instance && r._id.instance !== 'default' ? `:${r._id.instance}` : ''}`;
-    if (r.posted === 0 && r.total > 0) silent.push(seat);
+    if (r.posted === 0 && r.total > 0) {
+      // Identity fans out per user (`scout` has 115 rows: scout + scout-u<hash>).
+      // One row is not the agent — resolve the whole set or undercount silently.
+      const identities = await mongoose.connection.collection('users')
+        .find({ 'botMetadata.agentName': r._id.agent }, { projection: { _id: 1 } })
+        .toArray();
+      const wrote = identities.length
+        ? await ledger.countDocuments({
+          userId: { $in: identities.map((u: { _id: unknown }) => u._id) },
+          createdAt: { $gte: since },
+        })
+        : 0;
+      if (wrote > 0) postingUnrecorded.push(`${seat} (${wrote} in ledger)`);
+      else silent.push(seat);
+    }
     console.log(
       seat.padEnd(22)
       + String(r.total).padStart(7) + String(r.posted).padStart(8) + String(r.noAction).padStart(8)
@@ -86,18 +111,35 @@ const main = async () => {
   if (silent.length) {
     console.log(`\n⚠ woken but produced nothing: ${silent.join(', ')}`);
     console.log('  Reasons given, most frequent first:');
+    // Group by (agent, instance) and compare the SAME composed label used
+    // above. Grouping on bare agentName while `silent[]` holds
+    // "agent:instance" means the match never fires for a suffixed seat — so
+    // the explanation went missing exactly when it was needed. Found in
+    // review by fable-lead.
     const reasons = await events.aggregate([
       { $match: { ...match, 'delivery.outcome': { $in: ['no_action', 'error'] } } },
-      { $group: { _id: { agent: '$agentName', reason: '$delivery.reason' }, n: { $sum: 1 } } },
+      {
+        $group: {
+          _id: { agent: '$agentName', instance: '$instanceId', reason: '$delivery.reason' },
+          n: { $sum: 1 },
+        },
+      },
       { $sort: { n: -1 } },
       { $limit: 12 },
     ]).toArray();
     for (const r of reasons) {
-      if (!silent.includes(r._id.agent)) continue;
-      console.log(`    ${String(r._id.agent).padEnd(20)} ${String(r._id.reason || '(none given)').padEnd(28)} ${r.n}`);
+      const label = `${r._id.agent}${r._id.instance && r._id.instance !== 'default' ? `:${r._id.instance}` : ''}`;
+      if (!silent.includes(label)) continue;
+      console.log(`    ${label.padEnd(20)} ${String(r._id.reason || '(none given)').padEnd(28)} ${r.n}`);
     }
   } else {
     console.log('\n✓ every woken seat posted at least once in the window');
+  }
+
+  if (postingUnrecorded.length) {
+    console.log(`\nℹ posting, outcomes unrecorded by this tier: ${postingUnrecorded.join(', ')}`);
+    console.log('  These wrote to the message ledger but never recorded delivery.outcome:"posted".');
+    console.log('  Not a silent seat — a native-tier ack gap. Separate kernel issue.');
   }
 
   const totalDead = rows.reduce((a: number, r: Record<string, number>) => a + (r.deadLettered || 0), 0);


### PR DESCRIPTION
First concrete slice of #1012.

## The data was always there

`AgentEvent` already persists `delivery.outcome` (`posted` | `no_action` | `error` | `skipped` | `acknowledged`), `delivery.reason`, `status` (including terminal `failed`), and `attempts`. **Nothing surfaced any of it.**

So "is this agent working?" was answered by grepping wrapper logs on the operator's laptop. That method gave a wrong answer for 19 hours yesterday: the log line for *posted via tool, then returned the sentinel* is byte-identical to the line for *produced nothing*, because `silentReply` is evaluated before `agentPostedItself`. Five remedies were applied to a seat that was never broken.

**The kernel knew the whole time.** It records `outcome: 'posted'` with the messageId.

## Validated against production before shipping

Read-only, 180-minute window:

```
pod-architect   total 17  posted  3  no_action 14
sprint-impl     total 17  posted  0  no_action 17   <- genuinely silent
ux-lead         total 16  posted  2  no_action 14
sprint-review   total  8  posted  7  no_action  1
fable-lead      total  6  posted  5  no_action  1   <- confirms yesterday's repair
commonly-bot    total 288 posted  0  no_action  0   <- no outcome recorded at all
```

Two things that table produced on its first run, neither of which I knew:

1. **`sprint-impl` is the one genuinely silent seat** — 17 wakes, zero posts. Previously indistinguishable from `ux-lead`, which is at least contributing.
2. **`commonly-bot` has 288 events with no delivery outcome recorded.** Either a delivery path that never acks with outcome data, or a gap in the ack contract. Not chased here — flagging rather than guessing.

## What it reports

Per seat over a window: total wakes, posted, no_action, error, terminal-failed, still-pending, last-posted timestamp. Then it **states the conclusion outright** rather than leaving it to be inferred from the table — which seats were woken and produced nothing, and the reasons they gave.

It also counts terminal `failed` events, which are the #998 dead-letter surface and are invisible to `list()`.

## Scope

Deliberately a script, not an endpoint. Reads only, safe against production, no new auth surface. If it proves useful the natural next step is an admin-authed endpoint — but a read-only script is the version worth having now.

Run in-cluster so no credential leaves the pod:

```
kubectl exec -n commonly-dev deploy/backend -- node dist/scripts/seat-output.js --minutes 240
```
