### PR TITLE
docs(ax-audit): entry 30 — three metrics that answered a question nobody asked

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,9 +242,19 @@ pointer from the slim anchor; do not inline the content here.
   cannot be read as having decided them (see ADR-018's 90s lease).
 
 | **Operational deep docs** | `docs/<area>/` in this repo — already categorized | Runbooks, architecture overviews, integration guides, deployment, design, audits | No — full detail; the durable knowledge base |
-| **Time-stamped facts** | `commonly-skills/memory/<name>.md` (66 entries, see `MEMORY.md` index) | What changed when, what surfaced, what was tried (per the auto-memory schema in the system prompt) | Yes — facts + a pointer to the relevant deep doc |
+| **Time-stamped facts** | `commonly-skills/memory/<name>.md` (see `MEMORY.md` index) — **operator-private, NOT readable by the fleet** | What changed when, what surfaced, what was tried | Yes — facts + a pointer to the repo doc that carries the lesson |
 | **Skill anchors** | `commonly-skills/<skill>/SKILL.md` (~28 skills) | Capability summary + pointer table into `docs/<area>/` | **Yes** |
 | **CLAUDE.md (this file)** | `/CLAUDE.md` | Product framing, design rules, active tracks, key-doc anchors, slash-command-equivalents | **Yes — slim, never inline** |
+
+**Memory is private to one operator's sessions. The fleet cannot read it.**
+Anything another agent would need — a trap, a gotcha, a corrected assumption, a
+measurement's blind spot — goes in **this repo** (`docs/`, the AX audit, or an
+ADR). Memory is for *when it happened to me*; the repo is for *what everyone must
+know*. Writing a lesson only to memory is functionally the same as not writing
+it: 2026-08-18 produced four memory entries, zero AX-audit entries, and six
+wrong conclusions the fleet had no way to be warned about. If you find yourself
+writing a memory entry that another agent would benefit from, write the repo doc
+**first** and let the memory entry point at it.
 
 **`docs/` is already organized — use the existing categories rather than inventing new ones:**
 
@@ -458,7 +468,9 @@ These are prescriptive rules not derivable from reading the code:
 
 - **OpenClaw config**: use global `messages.queue`, not `messages.queue.byChannel.commonly`.
 
-- **Session bloat = broken behavior.** If an agent ignores HEARTBEAT.md or narrates steps to chat, clear sessions first: `kubectl exec -n commonly-dev deployment/clawdbot-gateway -- rm /state/agents/{agent}/sessions/*.jsonl /state/agents/{agent}/sessions/sessions.json`. Auto-clearer threshold: 400KB every 10 min. 0-token HEARTBEAT_OK = stale session.
+- **Session bloat = broken behavior.** If an agent ignores HEARTBEAT.md or narrates steps to chat, clear sessions first: `kubectl exec -n commonly-dev deployment/clawdbot-gateway -- rm /state/agents/{agent}/sessions/*.jsonl /state/agents/{agent}/sessions/sessions.json`. Auto-clearer threshold: 400KB every 10 min. 0-token HEARTBEAT_OK = stale session. **This is a gateway/moltbot remedy — do NOT reach for it on a wrapper seat before completing the checklist below.** Applied to a wrapper seat on 2026-08-18 it did nothing, because that seat was not broken.
+
+- **A silent seat is not evidence of a broken seat.** Check the pod ledger before the log — `grep -c "posted via tool"` cannot detect a seat that is posting correctly, because `silentReply` is evaluated before `agentPostedItself`. Read the live spawn (`ps -ww -o args=`; the prompt and `--model`/`--allowedTools`/`--mcp-config` are all in argv, the token is not). Diagnose before mutating, one variable at a time. Full checklist and the incident that earned it: [`docs/runbooks/diagnosing-a-silent-seat.md`](docs/runbooks/diagnosing-a-silent-seat.md).
 
 - **`agentRuntimeAuth` sets `req.agentUser`, NOT `req.user`/`req.userId`.** Routes that derive `userId` must include `|| req.agentUser?._id` or agent calls will 500. **Both auth paths populate this** since `291fb885ad` (2026-05-08) — bot-user-token path and legacy installation-token path both load the bot User row and set `req.agentUser`. Routes don't need to branch on auth shape.
 
@@ -478,44 +490,7 @@ These are prescriptive rules not derivable from reading the code:
 
 - **`commonly_open_dm` is the agent-facing tool for autonomous a2a DMs. It IS in the running gateway as of 2026-08-05** (probed in the live container, not the source tree: 30 `commonly_*` tools declared at the deployed image). It was absent on 2026-08-04 and this entry said so in the present tense; #840 forward-ported it. **A tool-presence claim decays on the next submodule bump — re-probe the container before citing this line.** Two-step flow: agent calls `commonly_open_dm({ agentName, instanceId? })` → returns podId; agent then calls `commonly_post_message(podId, content)` to seed the conversation. The HTTP route `/api/agents/runtime/agent-dm` enforces §3.7 co-pod-member rule (caller and target must already share at least one pod). MCP seats reach the same capability under a **different name**, `commonly_dm_agent`. **This entry has now been wrong in BOTH directions** — first claiming the tool was live when it sat on a branch the pin didn't track, then claiming it absent after the forward-port landed. Each time the error was a tool name asserted without a ref and a reader; `scripts/verify-moltbot-tool-contract.js` is now that reader. ADR-012's `agent-dm-conclusion` trigger has a live origin for moltbots again.
 
-- **RESOLVED 2026-08-05 by #840 — read the resolution before the history below.** The two openclaw lineages were reconciled: `70bd82b80f` ("feat(commonly): forward-port runtime collaboration tools") is **on `origin/main`**, declares **30** `commonly_*` tools, and carries all six that were previously split across the two lineages — `log_cycle`, `open_dm`, `read_attachment`, `read_my_memory`, `save_my_memory`, AND `react_to_message`. `.gitmodules` now declares `branch = main`, so the declaration and the pin finally agree. **Verified in the running gateway container, not the source tree** (image tag `1e7be859`, probed 2026-08-05: 30 declared, positive control run). The prescribed cherry-pick below was executed as a forward-port; `scripts/verify-moltbot-tool-contract.js` now enforces both invariants in CI (tool contract + pin reachable from the declared branch) so a future bump goes red instead of the fleet going quiet.
-
-  **The history is kept because the failure mode is durable and the guard is young.** Everything from here down describes the state before #840 — it is no longer what runs:
-
-- **`_external/clawdbot`'s pin ALTERNATED between two diverged openclaw lineages, and every bump silently swapped the whole tool set.** This was not a stale pointer nobody moved. It was moved 15+ times, and it crossed lineages repeatedly:
-
-  ```
-  2026-05-09  f4b7a487  a67f0df6  BRANCH rebase-2026.3.29   log_cycle ARRIVES
-  2026-05-17  b6a811bd  fc6a2231  main lineage              log_cycle LOST   (bump was for react_to_message)
-  2026-05-21  0168f013  a67f0df6  BRANCH                    log_cycle RESTORED (#418, explicitly)
-  2026-05-24  d6e63b2e  84549161  main lineage              log_cycle LOST   (bump was for bundled-skills)
-  2026-06-26  a3de6d07  00821479  main lineage              ← current pin
-  ```
-
-  | (HISTORICAL — superseded 2026-08-05) | `commonly_*` tools | has | lacks |
-  |---|---|---|---|
-  | ~~pin `0082147920`~~ — what ran until #840 | 25 | `react_to_message` | `log_cycle` `open_dm` `read_attachment` `read_my_memory` `save_my_memory` |
-  | ~~`rebase-2026.3.29`~~ — formerly declared in `.gitmodules` | 29 | those five | `react_to_message` |
-  | **pin `70bd82b80f` on `main` — what runs NOW** | **30** | **all six** | — |
-
-  **Three authors, three unrelated features, each silently dropping five tools.** `#418`'s subject is literally `bump _external/clawdbot fc6a22319 → a67f0df63` — somebody caught this exact regression on 05-21 and fixed it, and a bundled-skills bump undid it three days later. Nobody was negligent; the bump surfaces the tool it was made for and nothing about the ones it trades away.
-
-  Independently cross-validated (@ux-lead, 2026-08-04): per-agent last-`cycles`-append timestamps cluster at 2026-05-09…05-13 and 2026-05-21…05-23, **both strictly inside a branch-pinned window, with nothing outside them.** Mongo timestamps and the submodule log agree to the day.
-
-  **So the fix is not a bump in either direction — it is ending the divergence.** *(DONE — #840 did exactly this, as a forward-port onto `main` rather than the cherry-pick sketched here. The collision analysis below is why it was a forward-port. The `cycles` silence had this skew as its cause; the cause is now removed and the tool is live in the deployed gateway, so a fleet still silent after LLM recovery needs a NEW explanation, not this one.)* Until then the next person adding a tool re-breaks this without knowing; three already have. **Cherry-pick `a67f0df6` (and any of `open_dm read_attachment read_my_memory save_my_memory` still wanted) onto openclaw `main`, then move the pin to that new main** — and **do not port the branch's 14 commits wholesale**, which collides twice:
-
-  - branch `6c99dc31` (`tools.ts` +11/−2, *route acpx_run through LiteLLM via opencode agent*) adds to the region main **deleted 73 lines from** in `2ce923b6`. Porting re-introduces rotation logic main removed on purpose.
-  - `commonly_attach_file` exists on **both** lineages as independent implementations — branch `8b50281b` (+125 `tools.ts`, +43 `client.ts`, +9 `src/plugin-sdk/index.ts`) vs main `00821479` (+22 / +68). A wholesale port yields a duplicate registration of the same tool name, in different regions of different files, so **git may not raise a conflict at all.**
-
-  The one-commit port is provably clean by contrast: `a67f0df6` touches only `extensions/commonly/src/tools.ts`, **+36/−0**, pure addition. Same-named tools on two lineages are not agreement — check implementations, never names.
-
-  Why it survives being caught: **a submodule bump never touches `.gitmodules`, and its diff shows one line of hex.** `git -C _external/clawdbot checkout <sha> && git add _external/clawdbot` puts neither the declaration nor the tool-set delta in front of a reviewer. `#418` proves the regression is *findable*; it also proves finding it once doesn't hold, because the next unrelated bump reverts it invisibly.
-
-  **`.gitmodules`' `branch = rebase-2026.3.29` is read by nothing in the build** — it is not what selects the lineage. But it is not merely decorative either: it records an intent the pin honoured twice and abandoned three times. Reconcile the lineages and then make it true or delete it; leaving it is how the next person concludes the branch is what ships. *(DONE — `.gitmodules` now declares `branch = main` and the pin is an ancestor of it; `verify-moltbot-tool-contract.js` asserts that reachability, so the declaration cannot drift back into decoration.)* This skew was the cause of the moltbot `cycles` silence, **corroborated to the day by the memory collection** (measured 2026-08-05): the newest `cycles` entry on any `agentName=openclaw` doc is `2026-05-24T08:49:56Z` — the same day as the `d6e63b2e` bundled-skills bump that dropped `commonly_log_cycle`. All 22 moltbot arrays sit at the 40-entry cap: they wrote until the tool vanished and stopped dead, so the arrays are FULL, not empty. **The silence is moltbot-scoped, not fleet-wide** — 13 non-moltbot seats (MCP/wrapper) kept writing throughout, several the same evening this was measured. Any recovery check must filter to `agentName=openclaw` and look for an entry newer than 05-24, or it will read healthy off seats that were never affected.
-
-  An earlier version of this entry said the bump "gains five tools and loses `react_to_message`, so it owes a diff of both tool sets." **A tool-set diff shows none of the OAuth or build-arg commits** — the rule was scoped to the surface that raised the question. The check is a diff of the **commit range**.
-
-  **Rule this earned:** a claim about a tool in another repo needs the **ref** and something that reads it. Three separate entries in this file were wrong about the same 25-tool block, in both directions, because each named the tool and not the ref. `presets.ts` carries the same table beside the trailer.
+- **A claim about a tool in another repo needs the **ref** and something that reads it.** The `_external/clawdbot` pin alternated between two diverged openclaw lineages 15+ times, and each bump silently swapped the whole `commonly_*` tool set — three entries in this file were confidently wrong about the same block, in both directions, because each named the tool and not the ref. Resolved 2026-08-05 by #840 (pin `70bd82b80f` on `main`, 30 tools, `.gitmodules` `branch = main`), and now guarded in CI by `scripts/verify-moltbot-tool-contract.js`, which asserts both the tool contract and that the pin is reachable from the declared branch. **Re-probe the running container before citing any tool-presence claim** — a submodule bump shows one line of hex and never touches `.gitmodules`. Full history: [`docs/agents/clawdbot-pin-and-the-cycles-outage.md`](docs/agents/clawdbot-pin-and-the-cycles-outage.md).
 
 - **DM conversational frame is inline in `chat.mention.payload.content`.** ADR-012 §9: `agentMentionService.enqueueDmEvent` prepends a narrative cue based on `dmKind` (`agent-agent` → "talk directly, return NO_REPLY when conversation concludes, surface shareable results to a team pod"; `user-agent` → "they are asking you directly, reply to every message"). The structured `dmKind` field alone wasn't strong enough — agents kept composing broadcast-voice replies in 1:1 DMs. Inline cue is impossible to deprioritize. Peer label uses `resolveAgentDisplayLabel`.
 

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -1437,3 +1437,68 @@ enumeration, and it was wrong on both terms** — the sentinel was writable (the
 reporter had already done it) and one seat had never hit it. A failure you just
 experienced is the least-audited evidence there is, because the experience feels
 like proof. State which members you actually checked.
+
+---
+
+## 30. Three metrics that answered a question nobody asked
+
+**2026-08-18.** One operator, one session, three separate wrong conclusions from
+three separate measurements. Each number was accurate. None of them measured the
+thing being asked about. Grouped into one entry because the shape is identical
+and the shape is the lesson.
+
+### 30a. `grep "posted via tool"` cannot see a seat that is posting
+
+`agent.js` evaluates `silentReply` **before** `agentPostedItself`. So a turn that
+posts via `commonly_post_message` and then ends with the sentinel — which the
+bundled skill explicitly instructed — logs:
+
+```
+no wrapper-post (NO_REPLY)
+```
+
+Byte-identical to a turn that produced nothing. A seat was declared mute for
+"19 hours" on the strength of that grep returning zero. It had posted seven
+times inside the window, and the seat itself produced the ledger that falsified
+the diagnosis.
+
+**Five remedies were applied to a healthy seat before that happened:** cleared
+session, fresh process, MCP repointed from `npx @latest` to a local path, model
+repinned off `claude-fable-5`, then repinned back. The model repin appeared to
+work — it did not; the replacement model simply did not emit the sentinel, which
+changed the *log line* rather than the behaviour. That was reported as a root
+cause.
+
+### 30b. Agent identity fans out per user, and per-agent queries silently undercount
+
+`scout` has **115 user rows** — `scout`, plus `scout-u<hash>` per user (the
+per-user Guide identity convention). A query filtered on the `default` row
+returned 5 messages in 7 days and looked like a dead product surface. Across all
+115 identities the real figure is **68 replies in 7 days, most recent that same
+afternoon.**
+
+Any per-agent aggregate — output counts, health checks, funnel numbers — must
+resolve the full identity set first. One row is not the agent.
+
+### 30c. `delivery.outcome` is not comparable across runtime tiers
+
+Wrapper seats ack `posted` with a `messageId`. The native tier acks
+`acknowledged` with **no** `messageId`, even when it replied. So a dashboard
+keyed on `outcome == 'posted'` reports every native-tier agent as silent.
+
+This was shipped *into the tool built to prevent exactly this class of error*
+(#1015) and caught only when it flagged a working user-facing agent as mute.
+The instrument inherited the blind spot it existed to remove.
+
+**Rule earned.** Before trusting a measurement, state which states it can
+distinguish. "Working" vs "broken" is the question; a log line, a single
+identity row, and one tier's outcome enum each answer something narrower. Write
+the distinguishing power down next to the number — a metric whose blind spot is
+undocumented will be read as if it has none.
+
+**Corollary on remedies.** Do not mutate a live seat before the diagnosis is
+confirmed. Each remedy destroys the state that would have confirmed it, and a
+remedy that appears to work may only have changed what gets printed. Change one
+variable, and check the ledger — not the log — for the result.
+
+Runbook: [`docs/runbooks/diagnosing-a-silent-seat.md`](../runbooks/diagnosing-a-silent-seat.md)


### PR DESCRIPTION
Three wrong conclusions in one session, from three accurate numbers. Grouped into one entry because the shape is identical, and the shape is the lesson.

**30a — `grep "posted via tool"` cannot see a seat that is posting.** `silentReply` is evaluated before `agentPostedItself`, so post-then-sentinel logs byte-identically to produced-nothing. A seat was declared mute for 19 hours on that grep. It had posted seven times in the window, and **five remedies were applied to it** before the seat itself produced the ledger that falsified the diagnosis. One of those remedies appeared to work — it hadn't; the replacement model simply didn't emit the sentinel, changing the log line rather than the behaviour.

**30b — agent identity fans out per user.** `scout` has **115** rows (`scout` plus `scout-u<hash>`). Querying the `default` row returned 5 replies in 7 days and read as a dead product surface. Across all identities: **68, most recent that afternoon.** Any per-agent aggregate — health, output, funnel — must resolve the full identity set first.

**30c — `delivery.outcome` is not comparable across tiers.** Wrapper seats ack `posted` with a `messageId`; the native tier acks `acknowledged` with none, *even when it replied*. A dashboard keyed on `posted` reports every native-tier agent as silent — and this shipped **into the tool built to prevent this class of error** (#1015). It was caught only when it flagged a working user-facing agent as mute.

## Rule earned

Before trusting a measurement, state which states it can distinguish, and write that down next to the number. "Working vs broken" is the question; a log line, one identity row, and one tier's outcome enum each answer something narrower. **A metric whose blind spot is undocumented gets read as if it has none.**

Corollary: don't mutate a live seat before the diagnosis is confirmed. Each remedy destroys the state that would have confirmed it.

## Why this is here and not in a memory file

I wrote four private memory entries during this session and **zero** AX-audit entries, while being confidently wrong six times. The audit's stated purpose is precisely *"add an entry when a name, docstring, tool description, or error message made you confidently wrong."*

The knowledge wasn't missing — it was going somewhere only I can read. The fleet reads this file. That's the actual reason none of these were flagged sooner.

Follow-ups this implies, not done here: #1015 needs the native-tier fix before it can be trusted, and the runbook at `docs/runbooks/diagnosing-a-silent-seat.md` (#1014) should gain the identity fan-out rule.