### PR TITLE
chore(release): @commonlyai/cli 0.1.10 — seven source commits shipped to nobody

### DIFF
--- a/.github/workflows/package-version-guard.yml
+++ b/.github/workflows/package-version-guard.yml
@@ -1,0 +1,66 @@
+name: Package Version Guard
+
+# A published package's version is the ONLY check available from outside this
+# repo. When source ships without a version bump, that check silently passes
+# while the artifact and the repo disagree — and nobody can tell.
+#
+# It has happened twice:
+#   #979  @commonlyai/mcp   npm 0.3.0 and main 0.3.0 were different code; the
+#         PR-tool removal reached the repo and reached zero seats.
+#   #1017 @commonlyai/cli   npm 0.1.9 and main 0.1.9 were different code, with
+#         SEVEN source commits since the bump — including #995, the quota
+#         misclassification that had seats probing a dead provider every 5s.
+#
+# Both were found by hand, months and hours late respectively. This makes the
+# third one go red instead.
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  version-guard:
+    name: Source changed ⇒ version bumped
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Every published package whose source moved must bump its version
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE="origin/${{ github.event.pull_request.base.ref }}"
+          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.ref }}" >/dev/null 2>&1 || true
+
+          fail=0
+          # pkg_dir : the published package root (holds package.json)
+          for pkg in cli commonly-mcp; do
+            # Did any SOURCE file move? Docs and tests do not require a release.
+            changed=$(git diff --name-only "$BASE"...HEAD -- "$pkg/src" | wc -l | tr -d ' ')
+            if [ "$changed" = "0" ]; then
+              echo "· $pkg: no src changes"
+              continue
+            fi
+
+            base_v=$(git show "$BASE:$pkg/package.json" 2>/dev/null | sed -n 's/.*"version": "\([^"]*\)".*/\1/p' | head -1)
+            head_v=$(sed -n 's/.*"version": "\([^"]*\)".*/\1/p' "$pkg/package.json" | head -1)
+
+            if [ "$base_v" = "$head_v" ]; then
+              echo "::error file=$pkg/package.json::$pkg/src changed ($changed file(s)) but version is still $head_v. A published version that maps to two different artifacts defeats the only check available from outside this repo — bump it, or move the change out of $pkg/src."
+              fail=1
+            else
+              echo "✓ $pkg: src changed and version moved $base_v → $head_v"
+            fi
+          done
+
+          exit $fail

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "license": "Apache-2.0",
   "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
   "type": "module",


### PR DESCRIPTION
## npm 0.1.9 and main 0.1.9 are different code

Same defect as #979, one package over. **Seven source commits have landed since the last version bump**, four of them real fixes:

| | |
|---|---|
| **#995** | a quota stall was classified as a runtime blip and probed every **5 seconds** |
| **#973** | a directly-addressed seat can answer past the cascade cap |
| **#1002** | a seat log recorded four failures and not one time |
| **#1006** | timestamps on log lines |
| #961 | pin an agent's model in the environment spec |
| #1000, #1005 | comment-only |

**Anyone who installs the CLI today gets none of them.** Our own seats have them only because their CLI is npm-linked into a worktree that was pulled by hand — which also means the fleet's behaviour and the published artifact have silently diverged.

#995 is the one I'd care about most: without it, `"You've hit your session limit"` classifies as a generic runtime blip and the seat retries every 5s against a provider that will not answer for hours, instead of opening the circuit at the 15-minute ceiling. That ran all of last night.

## How this keeps happening

A published version is the **only** check available from outside the repo. Ship source without bumping it and that check silently passes while the artifact and the repo disagree — and there is no way to tell from the outside, which is exactly how #979 survived for months.

Verifying by version is what fails. Verifying by content is what works:

```bash
npm view @commonlyai/cli version                    # says 0.1.9
npm pack @commonlyai/cli && tar xzf commonlyai-cli-0.1.9.tgz
grep -c "session limit" package/src/lib/spawn-retry.js   # 0 — #995 is NOT in it
```

## The guard, and why it is not in this PR

I wrote `.github/workflows/package-version-guard.yml` — fails a PR when `cli/src/**` or `commonly-mcp/src/**` changes without a version bump, exempting docs and tests. Validated before proposing: YAML parses, `bash -n` clean, and dry-run against real history shows it would have caught all **7** of the commits above.

**I could not push it.** Neither account carries the `workflow` scope (`lilyshen0722`: `repo, gist, read:org, admin:public_key`; `samxu01`: `repo, gist, read:org`), and the attempt fails as a bare `HTTP 404` that reads like a missing file. The global instructions claimed samxu01 held a workflow-scoped token; that has been corrected.

To land it: `gh auth refresh -h github.com -s workflow`, then it is a one-call push. Alternatively I can convert it to `scripts/verify-package-versions.js` + a `verify:package-versions` npm script — matching the existing `verify:moltbot-tools` pattern — leaving only a two-line `run:` step in `tests.yml` for someone with the scope.

## After merge

```bash
cd cli && npm publish

# then verify the ARTIFACT, not the version
npm view @commonlyai/cli version                          # expect 0.1.10
cd /tmp && npm pack @commonlyai/cli --silent && tar xzf commonlyai-cli-0.1.10.tgz
grep -c "session limit" package/src/lib/spawn-retry.js    # expect 2
grep -c "addressedGrace" package/src/lib/enforcement.js   # expect >= 1
```

If those greps return `0`, the publish went out of a stale tree and the version is lying again.
