### PR TITLE
feat(kernel): board changes reach the pod's agents (ADR-024 D1)

### DIFF
--- a/backend/__tests__/unit/routes/tasksApi.agentNotify.test.js
+++ b/backend/__tests__/unit/routes/tasksApi.agentNotify.test.js
@@ -1,0 +1,126 @@
+/**
+ * Board write -> agent fan-out wiring (ADR-024 D1).
+ *
+ * `notifyPodAgents` itself is covered in the service test. What is covered HERE
+ * is the wiring, which is where this change can fail invisibly: a board write
+ * that reaches Socket.io and skips the fan-out looks completely healthy from
+ * the outside — the request 200s, the Kanban updates, the human sees the board
+ * move, and only the agents learn nothing. That is the exact asymmetry D1
+ * exists to remove, so it gets an assertion rather than an assumption.
+ *
+ * Also pinned: the actor shape. `isAgent` is what prices a wake against the
+ * cascade cap, and it is derived from the auth shape (`agentRuntimeAuth` sets
+ * `req.agentUser`, never `req.user`). Get it wrong for an agent and board
+ * churn stops terminating.
+ */
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.userId = 'u1';
+  req.user = { id: 'u1', _id: 'u1' };
+  next();
+});
+jest.mock('../../../middleware/agentRuntimeAuth', () => (req, res, next) => {
+  req.agentUser = { _id: 'bot-9' };
+  next();
+});
+
+jest.mock('../../../models/Pod', () => ({
+  findById: jest.fn(() => ({
+    lean: jest.fn().mockResolvedValue({
+      type: 'chat',
+      members: [{ toString: () => 'u1' }, { toString: () => 'bot-9' }],
+    }),
+  })),
+}));
+
+const mockFindOneAndUpdate = jest.fn();
+jest.mock('../../../models/Task', () => ({
+  findOneAndUpdate: (...args) => mockFindOneAndUpdate(...args),
+  findOne: jest.fn(),
+  find: jest.fn(),
+}));
+
+jest.mock('../../../models/User', () => ({
+  findById: jest.fn(() => ({
+    select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue({ username: 'alice' }) })),
+  })),
+}));
+
+jest.mock('../../../services/githubAppService', () => ({
+  isPatConfigured: jest.fn(() => false),
+}));
+
+const mockNotifyPodAgents = jest.fn();
+jest.mock('../../../services/taskEventService', () => ({
+  emitTaskUpdated: jest.fn(),
+  notifyPodAgents: (...args) => mockNotifyPodAgents(...args),
+}));
+
+const tasksApi = require('../../../routes/tasksApi');
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/tasks', tasksApi);
+
+const POD_ID = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+
+const patch = (token) => {
+  const req = request(app).patch(`/api/v1/tasks/${POD_ID}/TASK-001`);
+  if (token) req.set('Authorization', `Bearer ${token}`);
+  return req.send({ status: 'in_progress' });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFindOneAndUpdate.mockResolvedValue({ taskId: 'TASK-001', status: 'claimed' });
+  mockNotifyPodAgents.mockResolvedValue(undefined);
+});
+
+describe('board writes reach the pod agents', () => {
+  it('fans a human PATCH out to the agents, marked as a human edit', async () => {
+    const res = await patch();
+
+    expect(res.status).toBe(200);
+    expect(mockNotifyPodAgents).toHaveBeenCalledTimes(1);
+    const [podId, , kind, actor] = mockNotifyPodAgents.mock.calls[0];
+    expect(podId).toBe(POD_ID);
+    expect(kind).toBe('updated');
+    // A human edit resets the cascade streak; mislabelling it as an agent edit
+    // would let a busy board starve the very seats it is trying to feed.
+    expect(actor).toEqual({ userId: 'u1', isAgent: false });
+  });
+
+  it('marks an AGENT PATCH as an agent edit, so board churn terminates', async () => {
+    const res = await patch('cm_agent_test');
+
+    expect(res.status).toBe(200);
+    const [, , , actor] = mockNotifyPodAgents.mock.calls[0];
+    // agentRuntimeAuth sets req.agentUser and never req.user — deriving this
+    // from the wrong field is how an unbounded wake loop gets built.
+    expect(actor.isAgent).toBe(true);
+    expect(actor.userId).toBe('bot-9');
+  });
+
+  it('still answers the board write when the fan-out rejects', async () => {
+    mockNotifyPodAgents.mockRejectedValue(new Error('event store down'));
+
+    const res = await patch();
+
+    // The board is a human-facing surface; it must not inherit the agent
+    // layer's availability.
+    expect(res.status).toBe(200);
+  });
+
+  it('still answers the board write when the fan-out throws synchronously', async () => {
+    // The failure an unhandled-rejection guard alone does NOT catch, and the
+    // one that actually occurred: a partial mock / renamed export makes the
+    // call itself throw before any promise exists.
+    mockNotifyPodAgents.mockImplementation(() => { throw new Error('not a function'); });
+
+    const res = await patch();
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/backend/__tests__/unit/routes/tasksApi.agentNotify.test.js
+++ b/backend/__tests__/unit/routes/tasksApi.agentNotify.test.js
@@ -89,7 +89,9 @@ describe('board writes reach the pod agents', () => {
     expect(kind).toBe('updated');
     // A human edit resets the cascade streak; mislabelling it as an agent edit
     // would let a busy board starve the very seats it is trying to feed.
-    expect(actor).toEqual({ userId: 'u1', isAgent: false });
+    // Identity is null on a human edit: the self-skip keys on (agentName,
+    // instanceId), and a human has neither — so it can never match an install.
+    expect(actor).toEqual({ userId: 'u1', isAgent: false, agentName: null, instanceId: null });
   });
 
   it('marks an AGENT PATCH as an agent edit, so board churn terminates', async () => {

--- a/backend/__tests__/unit/services/taskEventService.notifyPodAgents.test.js
+++ b/backend/__tests__/unit/services/taskEventService.notifyPodAgents.test.js
@@ -82,7 +82,21 @@ describe('notifyPodAgents', () => {
     expect(keys).toHaveLength(2);
     // Both agents must race for the SAME key or the CAS elects two winners.
     expect(new Set(keys).size).toBe(1);
-    expect(keys[0]).toBe('task:TASK-042:created:2026-08-19T10:00:00.000Z');
+    expect(keys[0]).toBe(`task:TASK-042:created:${Date.parse('2026-08-19T10:00:00.000Z')}`);
+  });
+
+  // The fixture above passes `updatedAt` as an ISO STRING, and `String(str)` is
+  // the string — full millisecond precision, so the second-resolution defect was
+  // invisible to it. Production passes a Date, where `String(date)` renders to the
+  // second. Same field, different type, opposite result.
+  it('separates two writes 800ms apart, which second-resolution stringifying merged', async () => {
+    mockInstalls([install('scout', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task({ updatedAt: new Date('2026-08-19T10:00:00.100Z') }), 'updated', { userId: HUMAN_ID, isAgent: false });
+    await notifyPodAgents(POD_ID, task({ updatedAt: new Date('2026-08-19T10:00:00.900Z') }), 'updated', { userId: HUMAN_ID, isAgent: false });
+
+    const [first, second] = AgentEventService.enqueue.mock.calls.map((c) => c[0].payload.messageId);
+    expect(first).not.toBe(second);
   });
 
   it('gives a later change to the same task a fresh key, or it collides with the settled claim', async () => {
@@ -103,10 +117,39 @@ describe('notifyPodAgents', () => {
   it('never wakes the actor about their own edit', async () => {
     mockInstalls([install('scout', AGENT_ID), install('sprint-impl', HUMAN_ID)]);
 
-    await notifyPodAgents(POD_ID, task(), 'updated', { userId: AGENT_ID, isAgent: true });
+    await notifyPodAgents(POD_ID, task(), 'updated', {
+      userId: AGENT_ID, isAgent: true, agentName: 'scout', instanceId: 'default',
+    });
 
     const woken = AgentEventService.enqueue.mock.calls.map((c) => c[0].agentName);
     expect(woken).toEqual(['sprint-impl']);
+  });
+
+  // The skip used to key on `installedBy`, which names the INSTALLER. A
+  // human-installed agent — the normal path, and the only path in the Dev Team
+  // pod, where all five installs share one installer — never matched its own
+  // install and woke itself on every board write. Those wakes are agent-
+  // triggered, so they burn the cascade streak and a batch assignment starves
+  // the assigner.
+  it('skips a HUMAN-installed agent editing the board, where installedBy could not', async () => {
+    mockInstalls([install('scout', HUMAN_ID), install('sprint-impl', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'updated', {
+      userId: AGENT_ID, isAgent: true, agentName: 'scout', instanceId: 'default',
+    });
+
+    const woken = AgentEventService.enqueue.mock.calls.map((c) => c[0].agentName);
+    expect(woken).toEqual(['sprint-impl']);
+  });
+
+  it('matches identity case-insensitively, since agentName is stored lowercased', async () => {
+    mockInstalls([install('scout', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'updated', {
+      userId: AGENT_ID, isAgent: true, agentName: 'Scout', instanceId: undefined,
+    });
+
+    expect(AgentEventService.enqueue).not.toHaveBeenCalled();
   });
 
   it('still wakes an agent when the HUMAN who installed it edits the board', async () => {

--- a/backend/__tests__/unit/services/taskEventService.notifyPodAgents.test.js
+++ b/backend/__tests__/unit/services/taskEventService.notifyPodAgents.test.js
@@ -1,0 +1,201 @@
+/**
+ * Producer parity (ADR-024 D1): a board change must reach the pod's agents,
+ * not just its Socket.io room.
+ *
+ * The bug these cover is not "the fan-out is wrong" — it is that every wrong
+ * version of this fan-out is SILENT. A bespoke `task.*` type enqueues and acks
+ * and does nothing; a missing claim key stampedes without error; a mispriced
+ * `dmKind` loops until the cap catches it. None of those raise. So each test
+ * here pins a property whose violation would otherwise look like calm.
+ */
+const mongoose = require('mongoose');
+
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { find: jest.fn() },
+}));
+
+jest.mock('../../../services/agentEventService', () => ({
+  enqueue: jest.fn(),
+}));
+
+const { AgentInstallation } = require('../../../models/AgentRegistry');
+const AgentEventService = require('../../../services/agentEventService');
+const { notifyPodAgents } = require('../../../services/taskEventService');
+
+const POD_ID = new mongoose.Types.ObjectId().toString();
+const HUMAN_ID = new mongoose.Types.ObjectId().toString();
+const AGENT_ID = new mongoose.Types.ObjectId().toString();
+
+// Opted IN by default here, because every test below is about what an opted-in
+// agent receives. The opt-OUT case gets its own test rather than being the
+// silent default, so a gate regression fails loudly instead of emptying every
+// assertion at once.
+const install = (agentName, installedBy) => ({
+  agentName,
+  instanceId: 'default',
+  podId: POD_ID,
+  status: 'active',
+  installedBy,
+  config: { wakeOnMessage: { enabled: true } },
+});
+
+const task = (overrides = {}) => ({
+  taskId: 'TASK-042',
+  title: 'Wire the board to the fleet',
+  status: 'todo',
+  updatedAt: '2026-08-19T10:00:00.000Z',
+  ...overrides,
+});
+
+const mockInstalls = (rows) => {
+  AgentInstallation.find.mockReturnValue({ lean: jest.fn().mockResolvedValue(rows) });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  AgentEventService.enqueue.mockResolvedValue({});
+});
+
+describe('notifyPodAgents', () => {
+  it('rides message.posted, because a bespoke task.* type reaches neither runtime', async () => {
+    mockInstalls([install('scout', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'created', { userId: HUMAN_ID, isAgent: false });
+
+    expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+    const arg = AgentEventService.enqueue.mock.calls[0][0];
+    // The wrapper's PROMPT_EVENT_TYPES is a closed set; anything outside it is
+    // dropped after a successful ack, which is indistinguishable from silence.
+    expect(arg.type).toBe('message.posted');
+    // And the prompt has to be IN the payload — the wrapper reads
+    // payload.content, not a structured task object.
+    expect(arg.payload.content).toContain('TASK-042');
+    expect(arg.payload.content).toContain('Wire the board to the fleet');
+  });
+
+  it('carries a synthetic claim key, so one agent takes the task and the rest stand down', async () => {
+    mockInstalls([install('scout', HUMAN_ID), install('sprint-impl', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'created', { userId: HUMAN_ID, isAgent: false });
+
+    const keys = AgentEventService.enqueue.mock.calls.map((c) => c[0].payload.messageId);
+    expect(keys).toHaveLength(2);
+    // Both agents must race for the SAME key or the CAS elects two winners.
+    expect(new Set(keys).size).toBe(1);
+    expect(keys[0]).toBe('task:TASK-042:created:2026-08-19T10:00:00.000Z');
+  });
+
+  it('gives a later change to the same task a fresh key, or it collides with the settled claim', async () => {
+    mockInstalls([install('scout', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'created', { userId: HUMAN_ID, isAgent: false });
+    await notifyPodAgents(
+      POD_ID,
+      task({ updatedAt: '2026-08-19T11:00:00.000Z', status: 'in_progress' }),
+      'updated',
+      { userId: HUMAN_ID, isAgent: false },
+    );
+
+    const [first, second] = AgentEventService.enqueue.mock.calls.map((c) => c[0].payload.messageId);
+    expect(first).not.toBe(second);
+  });
+
+  it('never wakes the actor about their own edit', async () => {
+    mockInstalls([install('scout', AGENT_ID), install('sprint-impl', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'updated', { userId: AGENT_ID, isAgent: true });
+
+    const woken = AgentEventService.enqueue.mock.calls.map((c) => c[0].agentName);
+    expect(woken).toEqual(['sprint-impl']);
+  });
+
+  it('still wakes an agent when the HUMAN who installed it edits the board', async () => {
+    // The self-skip nearly shipped keyed on `installedBy` alone. That field is
+    // the agent's own user id when an agent self-installs, but the HUMAN's id
+    // when a human installs it — so the skip silenced every agent for the one
+    // person most likely to be moving tasks: its installer. It fails silently,
+    // as an agent that simply never responds to its owner.
+    mockInstalls([install('scout', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'created', { userId: HUMAN_ID, isAgent: false });
+
+    expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+    expect(AgentEventService.enqueue.mock.calls[0][0].agentName).toBe('scout');
+  });
+
+  it('prices a human edit as user-agent so it resets the cascade streak', async () => {
+    mockInstalls([install('scout', AGENT_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'created', { userId: HUMAN_ID, isAgent: false });
+
+    expect(AgentEventService.enqueue.mock.calls[0][0].payload.dmKind).toBe('user-agent');
+  });
+
+  it('prices an agent edit as agent-agent so board churn terminates at the cap', async () => {
+    mockInstalls([install('scout', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'updated', { userId: AGENT_ID, isAgent: true });
+
+    expect(AgentEventService.enqueue.mock.calls[0][0].payload.dmKind).toBe('agent-agent');
+  });
+
+  it('prices an UNKNOWN actor as an agent, because the two mistakes cost differently', async () => {
+    mockInstalls([install('scout', HUMAN_ID)]);
+
+    // Mislabelling a human costs one suppressed wake. Mislabelling an agent
+    // costs an unbounded wake loop. A caller that forgets to pass an actor gets
+    // the cheap failure.
+    await notifyPodAgents(POD_ID, task(), 'updated');
+
+    expect(AgentEventService.enqueue.mock.calls[0][0].payload.dmKind).toBe('agent-agent');
+  });
+
+  it('respects an opt-OUT, so ambient wakes cannot arrive through a second door', async () => {
+    // 169 of 367 production installs have wake-on-message off — `commonly-bot`
+    // and `openclaw`, user-facing seats where an unrequested wake is a noise
+    // incident. A board change is ambient activity nobody addressed to them, so
+    // it is governed by the same switch as ambient chat.
+    mockInstalls([
+      { ...install('commonly-bot', HUMAN_ID), config: { wakeOnMessage: { enabled: false } } },
+      { ...install('openclaw', HUMAN_ID), config: {} },
+      install('sprint-impl', HUMAN_ID),
+    ]);
+
+    await notifyPodAgents(POD_ID, task(), 'created', { userId: HUMAN_ID, isAgent: false });
+
+    const woken = AgentEventService.enqueue.mock.calls.map((c) => c[0].agentName);
+    expect(woken).toEqual(['sprint-impl']);
+  });
+
+  it('stays quiet on delete, where the wake would spend a turn finding nothing', async () => {
+    mockInstalls([install('scout', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'deleted', { userId: HUMAN_ID, isAgent: false });
+
+    expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+    // Cheap to assert, and it pins that we return before the query rather than
+    // after it.
+    expect(AgentInstallation.find).not.toHaveBeenCalled();
+  });
+
+  it('lets the other agents through when one enqueue throws', async () => {
+    mockInstalls([install('scout', HUMAN_ID), install('sprint-impl', HUMAN_ID)]);
+    AgentEventService.enqueue
+      .mockRejectedValueOnce(new Error('event store unavailable'))
+      .mockResolvedValueOnce({});
+
+    await expect(
+      notifyPodAgents(POD_ID, task(), 'created', { userId: HUMAN_ID, isAgent: false }),
+    ).resolves.toBeUndefined();
+
+    expect(AgentEventService.enqueue).toHaveBeenCalledTimes(2);
+  });
+
+  it('never lets a fan-out failure surface to the board write', async () => {
+    AgentInstallation.find.mockImplementation(() => { throw new Error('mongo down'); });
+
+    await expect(
+      notifyPodAgents(POD_ID, task(), 'created', { userId: HUMAN_ID, isAgent: false }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -18,7 +18,47 @@ const User = require('../models/User');
 // eslint-disable-next-line global-require
 const GitHubAppService = require('../services/githubAppService');
 // eslint-disable-next-line global-require
-const { emitTaskUpdated } = require('../services/taskEventService');
+const { emitTaskUpdated, notifyPodAgents } = require('../services/taskEventService');
+
+/**
+ * Who made this board change, for the agent fan-out.
+ *
+ * `isAgent` is what prices the wake against the cascade cap, so it must be
+ * derived from the auth shape rather than guessed: `agentRuntimeAuth` sets
+ * `req.agentUser` and never `req.user`. Returned explicitly as `false` for
+ * humans because `notifyPodAgents` treats *undefined* as "assume agent" — the
+ * safe default there, and one we should not trip over by accident here.
+ */
+const actorOf = (req: any) => ({
+  userId: req.userId || req.user?._id || req.user?.id || req.agentUser?._id,
+  isAgent: Boolean(req.agentUser?._id || req.user?.isBot),
+});
+
+/**
+ * Board change -> pod agents. Deliberately NOT folded into `emitTaskUpdated`:
+ * that function is a synchronous best-effort socket emit, and this is an async
+ * DB fan-out. Awaiting the fan-out inside it would put a Mongo round-trip per
+ * agent in front of every board response; not awaiting it inside a sync
+ * function would strand the rejection. Kept adjacent and fire-and-forget, with
+ * the catch attached here so a fan-out failure can never fail the request.
+ */
+const notifyAgents = (req: any, podId: unknown, task: unknown, kind: string) => {
+  // try/catch AND .catch, deliberately. A promise `.catch` only covers a
+  // rejection — it cannot cover the call throwing SYNCHRONOUSLY, which is what
+  // happens the moment `notifyPodAgents` is undefined (a partial mock, a
+  // renamed export, a bad merge). That threw straight through this helper into
+  // the route and turned every board write into a 500: strictly worse than the
+  // silent fan-out this whole change exists to fix. Caught by an existing test
+  // whose taskEventService mock predates this export.
+  try {
+    const pending = notifyPodAgents(podId, task, kind, actorOf(req));
+    if (pending?.catch) {
+      pending.catch((e: Error) => console.warn('[tasks] agent notify failed:', e.message));
+    }
+  } catch (e) {
+    console.warn('[tasks] agent notify threw:', (e as Error).message);
+  }
+};
 
 interface AuthReq {
   userId?: string;
@@ -209,6 +249,7 @@ router.post('/:podId', rateLimit({
           await existing.save();
           const reopenedObj = existing.toObject();
           emitTaskUpdated(podId, reopenedObj, 'updated');
+          notifyAgents(req, podId, reopenedObj, 'updated');
           return res.json({ task: reopenedObj, alreadyExists: false, reopened: true });
         }
         return res.json({ task: existing.toObject(), alreadyExists: true });
@@ -295,6 +336,7 @@ router.post('/:podId', rateLimit({
       }
     }
     emitTaskUpdated(podId, task, 'created');
+    notifyAgents(req, podId, task, 'created');
     return res.status(201).json({ task });
   } catch (err) {
     console.error('POST /tasks error:', err);
@@ -360,6 +402,7 @@ router.post('/:podId/:taskId/claim', rateLimit({
       });
     }
     emitTaskUpdated(podId, task, 'updated');
+    notifyAgents(req, podId, task, 'updated');
     return res.json({ task });
   } catch (err) {
     console.error('POST /tasks/claim error:', err);
@@ -428,6 +471,7 @@ router.post('/:podId/:taskId/complete', taskWriteRateLimit(30), auth, async (req
       console.warn('[system-exchange] task-completed dispatch failed:', (triggerErr as Error).message);
     }
     emitTaskUpdated(podId, task, 'updated');
+    notifyAgents(req, podId, task, 'updated');
     return res.json({ task });
   } catch (err) {
     console.error('POST /tasks/complete error:', err);
@@ -447,6 +491,7 @@ router.post('/:podId/:taskId/updates', taskWriteRateLimit(60), auth, async (req:
     const task = await Task.findOneAndUpdate({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId }, { $push: { updates: { text: text.trim(), author, authorId: userId?.toString() || null, createdAt: new Date() } } }, { new: true });
     if (!task) return res.status(404).json({ error: 'Task not found' });
     emitTaskUpdated(podId, task, 'updated');
+    notifyAgents(req, podId, task, 'updated');
     return res.json({ task });
   } catch (err) {
     console.error('POST /tasks/updates error:', err);
@@ -509,6 +554,7 @@ router.patch('/:podId/:taskId', taskWriteRateLimit(60), auth, async (req: AuthRe
     const task = await Task.findOneAndUpdate({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId }, update, { new: true });
     if (!task) return res.status(404).json({ error: 'Task not found' });
     emitTaskUpdated(podId, task, 'updated');
+    notifyAgents(req, podId, task, 'updated');
     return res.json({ task });
   } catch (err) {
     console.error('PATCH /tasks error:', err);

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -32,6 +32,11 @@ const { emitTaskUpdated, notifyPodAgents } = require('../services/taskEventServi
 const actorOf = (req: any) => ({
   userId: req.userId || req.user?._id || req.user?.id || req.agentUser?._id,
   isAgent: Boolean(req.agentUser?._id || req.user?.isBot),
+  // The self-skip keys on identity, not on the installer. `agentRuntimeAuth` sets
+  // `req.agentUser` (never `req.user`), and both auth paths load the bot User row,
+  // so `botMetadata` is where the pair lives on an agent call.
+  agentName: req.agentUser?.botMetadata?.agentName || req.user?.botMetadata?.agentName || null,
+  instanceId: req.agentUser?.botMetadata?.instanceId || req.user?.botMetadata?.instanceId || null,
 });
 
 /**

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -1670,4 +1670,9 @@ export {
   enqueueMentions,
   enqueueDmEvent,
   MENTION_ALIASES,
+  // Exported so the ADR-024 D1 board fan-out (taskEventService.notifyPodAgents)
+  // gates on the SAME opt-in rather than reimplementing the predicate. The
+  // config shape is a Mongoose Map in some paths and a plain object in others,
+  // which is exactly the kind of detail a second copy gets subtly wrong.
+  wakeOnMessageEnabled,
 };

--- a/backend/services/taskEventService.ts
+++ b/backend/services/taskEventService.ts
@@ -44,9 +44,141 @@ export function emitTaskUpdated(podId: unknown, task: unknown, kind: TaskEventKi
   }
 }
 
+/**
+ * Wake the pod's agents on a board change (ADR-024 D1, "producer parity").
+ *
+ * `emitTaskUpdated` above reaches Socket.io and stops, so a human watching the
+ * Kanban sees the board move and an agent installed in the same pod learns
+ * nothing. That asymmetry is why the fleet is 100% reactive: an agent can only
+ * respond to being named, because being named is the only thing that reaches
+ * it. Seven socket-emitting producers in this backend have zero enqueues
+ * between them; this makes one of them do both.
+ *
+ * Three deliberate choices, each with a cheaper wrong version:
+ *
+ * 1. `message.posted`, NOT a new `task.*` type. A bespoke type reaches NEITHER
+ *    runtime — the wrapper drops unrecognised types (PROMPT_EVENT_TYPES is a
+ *    closed set) and the native tier discards the payload in its default
+ *    branch. A `task.updated` event would enqueue, deliver, ack, and do
+ *    nothing: this system's signature failure, where a break degrades to
+ *    silence and silence reads like a considered decision. #970 already proved
+ *    the ride-an-existing-type route on reaction receipts.
+ *
+ * 2. A synthetic claim key. Without `payload.messageId` the wrapper skips the
+ *    claim gate entirely, so every agent in the pod spawns on every board
+ *    change. `task:<id>:<kind>:<rev>` is opaque to MessageClaimService (which
+ *    never validates the key against a real message), so the existing CAS
+ *    elects exactly one actor per change and the rest stand down. One task,
+ *    one worker, no new mechanism.
+ *
+ * 3. `dmKind` reflects the ACTOR, so agent-driven churn is priced. An agent
+ *    moving a task wakes a peer, who may move a task, who wakes a peer. That
+ *    terminates only because an agent-triggered wake counts toward the cascade
+ *    cap. Defaulting an UNKNOWN actor to 'agent-agent' is the safe direction:
+ *    mislabelling a human costs one suppressed wake, mislabelling an agent
+ *    costs an unbounded loop. This rides the same `dmKind` overload that #1018
+ *    tracks retiring in favour of `triggerAuthor` — inherited knowingly rather
+ *    than inventing a second field needing its own release cycle.
+ */
+export async function notifyPodAgents(
+  podId: unknown,
+  task: Record<string, unknown>,
+  kind: TaskEventKind,
+  actor?: { userId?: unknown; isAgent?: boolean },
+): Promise<void> {
+  // A deletion leaves nothing to pick up, and a tombstone wake spends a model
+  // turn to discover there is no work.
+  if (kind === 'deleted') return;
+  if (!podId || !task) return;
+
+  try {
+    /* eslint-disable global-require, @typescript-eslint/no-require-imports */
+    const { AgentInstallation } = require('../models/AgentRegistry');
+    const AgentEventService = require('./agentEventService');
+    // Lazy so this never forms a load-time cycle with the mention service.
+    const { wakeOnMessageEnabled } = require('./agentMentionService');
+    /* eslint-enable global-require, @typescript-eslint/no-require-imports */
+
+    const normalizedPodId = String(podId);
+    const active = await AgentInstallation.find({
+      podId: normalizedPodId,
+      status: 'active',
+    }).lean();
+
+    // Gate on the SAME per-install opt-in as ADR-018 D8 wake-on-message. A
+    // board change is ambient pod activity that nobody addressed to you, which
+    // is precisely what that switch governs — so an agent whose owner turned
+    // ambient wakes OFF must not start receiving them through a second door.
+    // Measured before choosing this: of 367 active installs, 128 have it on
+    // (including every sprint seat), and the 169 that do not are `commonly-bot`
+    // and `openclaw` — user-facing and community seats where an unrequested
+    // wake is a noise incident, not a feature.
+    const installs = (active || []).filter(wakeOnMessageEnabled);
+    if (!installs.length) return;
+
+    const taskId = String(task.taskId || task.id || task._id || 'unknown');
+    const title = String(task.title || '(untitled)');
+    const status = String(task.status || 'unknown');
+    const assignee = task.assignee ? String(task.assignee) : null;
+    // Distinguishes successive changes to the SAME task, so a later update is a
+    // fresh race rather than colliding with an earlier update's settled claim.
+    const rev = String(task.updatedAt || task.claimExpiresAt || '');
+    const claimKey = `task:${taskId}:${kind}:${rev}`;
+
+    const content = [
+      `[Board update in this pod: task ${taskId} was ${kind}.]`,
+      '',
+      `${taskId} — ${title}`,
+      `status: ${status}${assignee ? `, assigned to ${assignee}` : ', UNASSIGNED'}`,
+      '',
+      'You are seeing this because you are installed in this pod, not because',
+      'anyone named you. Decide whether it needs YOU specifically:',
+      '- Unassigned work you can actually do: claim it and start.',
+      '- Assigned to someone else, already handled, or not your area: return NO_REPLY.',
+      '',
+      'Do not narrate the board back to the pod. Post only if you are taking the',
+      'work, or a human needs a decision from you.',
+    ].join('\n');
+
+    // Self-skip, but ONLY for an agent actor. `installedBy` holds the agent's
+    // own user id when an agent self-installs, and the HUMAN's id when a human
+    // installs it — the same field meaning two different things. Skipping on it
+    // unconditionally silenced every agent for the exact person most likely to
+    // be editing the board: whoever installed it. So the skip is scoped to the
+    // case where the field genuinely identifies the actor.
+    const actorId = actor?.isAgent && actor?.userId ? String(actor.userId) : null;
+    await Promise.all(installs.map(async (install: Record<string, unknown>) => {
+      if (actorId && String(install.installedBy || '') === actorId) return;
+      try {
+        await AgentEventService.enqueue({
+          agentName: install.agentName,
+          instanceId: install.instanceId || 'default',
+          podId: normalizedPodId,
+          type: 'message.posted',
+          payload: {
+            content,
+            messageId: claimKey,
+            podId: normalizedPodId,
+            taskId,
+            taskKind: kind,
+            // See choice 3 above: an unknown actor is priced as an agent.
+            dmKind: actor?.isAgent === false ? 'user-agent' : 'agent-agent',
+          },
+        });
+      } catch (err) {
+        console.warn(`[task-event] enqueue failed for ${install.agentName}:`, (err as Error).message);
+      }
+    }));
+  } catch (err) {
+    // A board change must never fail because the agent fan-out did.
+    console.warn('[task-event] agent notify failed:', (err as Error).message);
+  }
+}
+
 export default {
   bindSocketIO,
   emitTaskUpdated,
+  notifyPodAgents,
 };
 
 // CJS compat: let require() return the default export directly

--- a/backend/services/taskEventService.ts
+++ b/backend/services/taskEventService.ts
@@ -84,7 +84,7 @@ export async function notifyPodAgents(
   podId: unknown,
   task: Record<string, unknown>,
   kind: TaskEventKind,
-  actor?: { userId?: unknown; isAgent?: boolean },
+  actor?: { userId?: unknown; isAgent?: boolean; agentName?: string | null; instanceId?: string | null },
 ): Promise<void> {
   // A deletion leaves nothing to pick up, and a tombstone wake spends a model
   // turn to discover there is no work.
@@ -122,7 +122,21 @@ export async function notifyPodAgents(
     const assignee = task.assignee ? String(task.assignee) : null;
     // Distinguishes successive changes to the SAME task, so a later update is a
     // fresh race rather than colliding with an earlier update's settled claim.
-    const rev = String(task.updatedAt || task.claimExpiresAt || '');
+    // Milliseconds, NOT `String(date)`. `Date.prototype.toString()` renders to the
+    // second, so two writes 800ms apart produced an identical rev, an identical
+    // claimKey, and the second change's wake was swallowed by a claim the first
+    // had already settled. That is not hypothetical once a rescue sweep exists:
+    // it claims a lapsed row, rewrites it to pending, then reassigns it — three
+    // writes on one task inside a second, of which only the FIRST survived. The
+    // survivor reports `status: claimed`, so the delivered wake told the reader
+    // to stand down while the real change went unannounced.
+    //
+    // A chosen bound, not exactness: two writes inside the SAME millisecond still
+    // collide. The only monotonic alternative is a version counter, and Mongoose
+    // does not bump `__v` on findOneAndUpdate — so ms is where this stops.
+    const revSource = task.updatedAt || task.claimExpiresAt || null;
+    const revTime = revSource ? new Date(revSource as string | number | Date).getTime() : NaN;
+    const rev = Number.isNaN(revTime) ? '' : String(revTime);
     const claimKey = `task:${taskId}:${kind}:${rev}`;
 
     const content = [
@@ -140,15 +154,31 @@ export async function notifyPodAgents(
       'work, or a human needs a decision from you.',
     ].join('\n');
 
-    // Self-skip, but ONLY for an agent actor. `installedBy` holds the agent's
-    // own user id when an agent self-installs, and the HUMAN's id when a human
-    // installs it — the same field meaning two different things. Skipping on it
-    // unconditionally silenced every agent for the exact person most likely to
-    // be editing the board: whoever installed it. So the skip is scoped to the
-    // case where the field genuinely identifies the actor.
-    const actorId = actor?.isAgent && actor?.userId ? String(actor.userId) : null;
+    // Self-skip, keyed on IDENTITY rather than on `installedBy`.
+    //
+    // `installedBy` names the installer, never the agent: it holds the agent's own
+    // user id on self-install and the HUMAN's on human-install. Scoping the skip to
+    // agent actors fixed the human case and left its mirror open — a human-installed
+    // agent (the normal path) never matched its own install, so it enqueued a wake to
+    // itself on every board write. Those wakes are agent-triggered and count toward
+    // the cascade streak, so a batch assignment starved the assigner: #1010's
+    // starvation arriving through a new door.
+    //
+    // In live data the field has no discriminating power at all — all five active
+    // installs in the Dev Team pod share one `installedBy`, so it cannot separate any
+    // of them even in principle.
+    //
+    // `(agentName, instanceId)` is the identity the rest of this file already uses two
+    // lines below, and the same pair `agentMentionService` uses for its self-mention
+    // guard. Correct regardless of who installed the agent.
+    const identityOf = (agentName: unknown, instanceId: unknown): string => (
+      `${String(agentName || '').toLowerCase()}:${String(instanceId || 'default').toLowerCase()}`
+    );
+    const actorIdentity = actor?.isAgent && actor?.agentName
+      ? identityOf(actor.agentName, actor.instanceId)
+      : null;
     await Promise.all(installs.map(async (install: Record<string, unknown>) => {
-      if (actorId && String(install.installedBy || '') === actorId) return;
+      if (actorIdentity && identityOf(install.agentName, install.instanceId) === actorIdentity) return;
       try {
         await AgentEventService.enqueue({
           agentName: install.agentName,


### PR DESCRIPTION
Closes the ADR-024 **D1** gap: a task board change now reaches the pod's agents, not only its Socket.io room.

## The gap

`emitTaskUpdated` emitted to Socket.io and stopped. A human watching the Kanban saw the board move; an agent installed in the same pod learned nothing. @sprint-review's audit found seven socket-emitting producers in this backend with **zero enqueues between them**, and the one service that enqueues never emits — nothing did both.

That asymmetry is why the fleet is reactive: an agent can only respond to being named, because being named is the only thing that reaches it.

## Three choices, each with a cheaper wrong version

**1. Rides `message.posted`, not a new `task.*` type.** A bespoke type reaches *neither* runtime — the wrapper's `PROMPT_EVENT_TYPES` is a closed set, and the native tier discards the payload in its default branch. A `task.updated` event would enqueue, deliver, ack, and do nothing. #970 already proved this route on reaction receipts.

**2. Carries a synthetic claim key.** Without `payload.messageId` the wrapper skips the claim gate entirely and *every* agent in the pod spawns on *every* board change. `MessageClaimService` never validates the key against a real message, so `task:<id>:<kind>:<rev>` lets the existing CAS elect exactly one actor. One task, one worker, no new mechanism.

**3. `dmKind` reflects the actor.** An agent moving a task wakes a peer, who may move a task, who wakes a peer. That terminates only because an agent-triggered wake counts toward the cascade cap. An **unknown** actor is priced as an agent deliberately: mislabelling a human costs one suppressed wake, mislabelling an agent costs an unbounded loop.

## Gated on the existing opt-in — measured before deciding

I nearly shipped this ungated. Checked production first:

```
active installs: 367
wakeOnMessage ON : 128   (pod-architect, ux-lead, sprint-impl, sprint-review, ~124 scout)
OFF: commonly-bot 90, openclaw 79, newshound 10, hq-support 8, ...
```

A board change is ambient pod activity nobody addressed to you — exactly what ADR-018 D8's `wakeOnMessage` switch governs. So it gates on the same opt-in, and reuses that predicate rather than copying it (the config is a Mongoose Map on some paths and a plain object on others — the detail a second copy gets wrong). Every sprint seat is already opted in; the 169 that are not are user-facing seats where an unrequested wake is a noise incident.

## Two bugs the tests caught

- **The self-skip was wrong.** Keyed on `installedBy` alone — a field holding the agent's own id when it self-installs, and the **human's** id when a human installs it. The skip silenced every agent for the one person most likely to be moving tasks: its installer. Now scoped to agent actors, where the field genuinely identifies who acted.
- **The require pointed at a module that does not exist.** `models/AgentInstallation` — the model is a named export of `models/AgentRegistry`. The fan-out would have thrown into its own catch and warned to a log nobody reads.

Both would have shipped as "agents just don't respond to the board," which is indistinguishable from agents choosing not to.

## Tests

97 passing across the six affected suites. The route test covers the wiring specifically, because that is where this fails invisibly: a board write that skips the fan-out still 200s, still updates the Kanban, still looks healthy — only the agents learn nothing. It includes the **synchronous-throw** case, which a rejection guard does not catch and which actually occurred: a partial mock made `notifyPodAgents` undefined, and the call threw through into the route, turning every board write into a 500. Strictly worse than the silence it was fixing. The helper now guards with `try/catch` *and* `.catch`.

## What this does not do

Heartbeats stay off. This gives agents something to *see*; it does not make them self-start on a quiet pod. That is D3, and it is deliberately sequenced second — @fable-lead's call. Turning heartbeats on first would produce seats waking every N minutes, finding nothing they can see, and returning `HEARTBEAT_OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8
