### PR TITLE
docs(ax): entry 31 — heartbeats are inert on wrapper seats

### DIFF
--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -1502,3 +1502,52 @@ remedy that appears to work may only have changed what gets printed. Change one
 variable, and check the ledger — not the log — for the result.
 
 Runbook: [`docs/runbooks/diagnosing-a-silent-seat.md`](../runbooks/diagnosing-a-silent-seat.md)
+
+---
+
+## 31. A capability that exists, is enabled, and does nothing
+
+`fable-lead` had `config.heartbeat.enabled === true`. The scheduler dispatched
+its tick. The wrapper received the event, spawned a model, and ran for 33
+seconds:
+
+```
+05:50:05 [fable-lead] [heartbeat] spawning claude
+05:50:38 [fable-lead] [heartbeat] no wrapper-post (HEARTBEAT_OK) — nothing posted this turn
+```
+
+Every layer reported success. The capability was inert.
+
+**Why.** The wrapper's heartbeat prompt (`cli/src/commands/agent.js`) is
+`payload.content`, or this fallback:
+
+> Read your HEARTBEAT.md workspace file and follow it exactly.
+
+`agentEventService.enrichHeartbeatPayload` never sets `content` — it attaches
+integration data only. And `HEARTBEAT.md` is a **moltbot** artifact: written
+from `registry.js` onto the gateway PVC. No wrapper seat has one; checked every
+`~/.commonly/claude-homes/*` and found zero.
+
+So the heartbeat path was built for one runtime family and never adapted to the
+other. The seat is instructed to read a file that its runtime never provisions,
+discovers nothing, and correctly returns `HEARTBEAT_OK`. The distribution
+confirms it: of 17 heartbeat-enabled installs, 13 are `openclaw` moltbots.
+Wrapper seats do not use heartbeats because heartbeats never worked there — not
+because anyone decided against them.
+
+**The trap for the next person.** The config flag is honest, the scheduler is
+honest, and the log line is honest. `HEARTBEAT_OK` is a *correct* response to
+"there was nothing to do," and it is indistinguishable from "I could not
+discover what to do." Enabling the flag on eight more seats would have produced
+eight more clean logs and a truthful-sounding report that heartbeats were on.
+
+**Rule earned.** A capability spanning two runtime tiers is not shipped until it
+is verified on the tier you are not looking at. Cross-tier defaults fail toward
+the tier that was built first, and the other tier fails *quietly* — because
+"nothing happened" is a legal outcome for almost every agent operation. Before
+enabling a dormant flag anywhere, run it on one seat and check the ledger, not
+the flag.
+
+Related: entry 30c (`delivery.outcome` is not comparable across tiers) — same
+shape, different field. Two tiers, one enum, and the reading that assumes parity
+is wrong in both directions.

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -1548,6 +1548,26 @@ the tier that was built first, and the other tier fails *quietly* — because
 enabling a dormant flag anywhere, run it on one seat and check the ledger, not
 the flag.
 
+**Corollary: having found the dead tier, go read the LIVE one.** Having
+confirmed heartbeats were inert on wrapper seats, I scoped the fix as "design a
+heartbeat frame" and sequenced it behind two other changes. Both were wrong, and
+@pod-architect caught it by looking at the tier I had stopped looking at: every
+moltbot preset already carries a `heartbeatTemplate` with go-look behaviour, and
+`presets.ts:1146` fetches the whole board every tick *today*. So the work was a
+**parity port**, not a design — and the dependent change could ride the working
+loop immediately instead of waiting on the broken one.
+
+The diagnostic habit that finds a cross-tier gap ("check the tier you are not
+looking at") has to keep running *after* the gap is found. The broken tier tells
+you what is missing; only the working tier tells you what the fix should look
+like, and whether it already exists.
+
+**Search caveat for whoever re-checks this.** A naive `find ~/agents -name
+HEARTBEAT.md` returns ~20 hits. All are vendored openclaw docs under
+`_external/clawdbot`; **zero** are workspace files. Scope the check to the seat
+homes (`~/.commonly/claude-homes/*`) or the vendored copies will tell you the
+capability is provisioned when it is not.
+
 Related: entry 30c (`delivery.outcome` is not comparable across tiers) — same
 shape, different field. Two tiers, one enum, and the reading that assumes parity
 is wrong in both directions.


### PR DESCRIPTION
`fable-lead` had `config.heartbeat.enabled === true`. The scheduler dispatched its tick. The wrapper spawned a model. It ran for 33 seconds:

```
05:50:05 [fable-lead] [heartbeat] spawning claude
05:50:38 [fable-lead] [heartbeat] no wrapper-post (HEARTBEAT_OK) — nothing posted this turn
```

Every layer reported success. The capability was inert.

The wrapper's heartbeat prompt is `payload.content`, or a fallback telling the agent to read `HEARTBEAT.md`. `enrichHeartbeatPayload` never sets `content` — it attaches integration data only. And `HEARTBEAT.md` is a **moltbot** artifact, written from `registry.js` onto the gateway PVC. No wrapper seat has one; I checked every `~/.commonly/claude-homes/*`.

The heartbeat path was built for one runtime tier and never adapted to the other. The distribution confirms it: **13 of 17** heartbeat-enabled installs are `openclaw` moltbots. Wrapper seats don't use heartbeats because heartbeats never worked there — not because anyone decided against them.

## Why this is worth an entry

The config flag is honest. The scheduler is honest. The log line is honest. `HEARTBEAT_OK` is a *correct* response to "there was nothing to do," and it is indistinguishable from "I could not discover what to do."

I was one step from enabling this on eight more seats to hit a deadline. That would have produced eight more clean logs and a truthful-sounding report that heartbeats were on.

**Rule earned:** a capability spanning two runtime tiers isn't shipped until it's verified on the tier you aren't looking at. Cross-tier defaults fail toward the tier built first, and the other tier fails *quietly* — "nothing happened" is a legal outcome for nearly every agent operation.

Same shape as entry 30c (`delivery.outcome` across tiers), different field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8