### PR TITLE
fix(tasks): a lapsed lease was claimable and unfindable at the same time

### DIFF
--- a/backend/__tests__/service/tasks.claim-lease.test.js
+++ b/backend/__tests__/service/tasks.claim-lease.test.js
@@ -187,4 +187,96 @@ describe('POST /api/v1/tasks/:podId/:taskId/claim — lease semantics (ADR-018 D
     expect(res.body.task.claimedBy).toBe(rival._id.toString());
     expect(res.body.task.claimExpiresAt).toBeTruthy();
   });
+
+  // Every test above drives the CAS directly, which is why the suite could go
+  // green while a lapsed task was unreachable: "claimable by a peer" was only
+  // ever asserted against the predicate, never against what a peer can FIND.
+  // ADR-018 declined a reaper, so discovery is the whole recovery path —
+  // these reach the task the way an agent actually would.
+  describe('discovery — a peer must be able to FIND the work the CAS would grant', () => {
+    const list = (token, query = '') => request(app)
+      .get(`/api/v1/tasks/${pod._id}${query}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    const lapsed = () => seedTask({
+      status: 'claimed',
+      claimedBy: 'ghost-agent',
+      claimedAt: new Date(Date.now() - 2 * LEASE_MS),
+      claimExpiresAt: new Date(Date.now() - LEASE_MS),
+    });
+
+    // EVERY test here seeds this too. Without it they pass against the unfixed
+    // route: an unknown query param is ignored, so `?claimable=true` returns
+    // the whole board — which of course contains the lapsed task. Asserting
+    // "the lapsed one is present" therefore proves nothing. The control is a
+    // task that must be ABSENT, so an ignored filter fails loudly. Found by
+    // running these against origin/main before opening the PR; three of five
+    // were green there, which is the same defect this PR exists to fix.
+    const liveHeld = () => Task.create({
+      podId: pod._id,
+      taskNum: 2,
+      taskId: 'T-2',
+      title: 'held by a living claimant',
+      status: 'claimed',
+      claimedBy: 'busy-agent',
+      claimedAt: new Date(),
+      claimExpiresAt: new Date(Date.now() + LEASE_MS),
+    });
+
+    test('?claimable=true surfaces a lapsed lease that ?status=pending cannot, and only that one', async () => {
+      await lapsed();
+      await liveHeld();
+      const pending = await list(rivalToken, '?status=pending');
+      expect(pending.status).toBe(200);
+      expect(pending.body.tasks).toHaveLength(0);
+
+      const claimableRes = await list(rivalToken, '?claimable=true');
+      expect(claimableRes.status).toBe(200);
+      expect(claimableRes.body.tasks.map((t) => t.taskId)).toEqual(['T-1']);
+    });
+
+    test('a peer can go from discovery to a granted claim without being told the taskId', async () => {
+      await lapsed();
+      await liveHeld();
+      const found = await list(rivalToken, '?claimable=true');
+      expect(found.body.tasks).toHaveLength(1);
+      const [discovered] = found.body.tasks;
+      const res = await request(app)
+        .post(`/api/v1/tasks/${pod._id}/${discovered.taskId}/claim`)
+        .set('Authorization', `Bearer ${rivalToken}`)
+        .send({});
+      expect(res.status).toBe(200);
+      expect(res.body.task.claimedBy).toBe(rival._id.toString());
+    });
+
+    test('a LIVE lease is not offered — the filter narrows, it does not just return the board', async () => {
+      await liveHeld();
+      const res = await list(rivalToken, '?claimable=true');
+      expect(res.status).toBe(200);
+      expect(res.body.tasks).toHaveLength(0);
+    });
+
+    test('a RECENT legacy claim stays hidden while a STALE one surfaces', async () => {
+      await seedTask({
+        status: 'claimed',
+        claimedBy: 'legacy-agent',
+        claimedAt: new Date(Date.now() - 60 * 1000),
+        claimExpiresAt: null,
+      });
+      expect((await list(rivalToken, '?claimable=true')).body.tasks).toHaveLength(0);
+
+      await Task.updateOne(
+        { podId: pod._id, taskId: 'T-1' },
+        { $set: { claimedAt: new Date(Date.now() - 2 * LEASE_MS) } },
+      );
+      expect((await list(rivalToken, '?claimable=true')).body.tasks.map((t) => t.taskId)).toEqual(['T-1']);
+    });
+
+    test('claimable composes with status rather than overriding it', async () => {
+      await lapsed();
+      await liveHeld();
+      const both = await list(rivalToken, '?status=claimed&claimable=true');
+      expect(both.body.tasks.map((t) => t.taskId)).toEqual(['T-1']);
+    });
+  });
 });

--- a/backend/__tests__/unit/routes/tasksApi.queryCoercion.test.js
+++ b/backend/__tests__/unit/routes/tasksApi.queryCoercion.test.js
@@ -1,0 +1,94 @@
+/**
+ * Query-parameter coercion at the task list boundary.
+ *
+ * Express's extended query parser is the whole problem: `?assignee[$ne]=x`
+ * arrives as an OBJECT and `?status=a&status=b` as an ARRAY. Destructured
+ * straight out of req.query, the first reached Mongo as an operator and the
+ * second turned `status.includes(',')` into Array.includes — a predicate that
+ * still reads like a substring test while meaning something else.
+ *
+ * These assert on the QUERY OBJECT handed to Task.find rather than on the
+ * response, because the response cannot distinguish "operator rejected" from
+ * "operator ran and matched everything" — an unfiltered list returns every
+ * pod task either way, which is exactly why this was invisible.
+ */
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.userId = 'u1';
+  req.user = { id: 'u1', _id: 'u1' };
+  next();
+});
+jest.mock('../../../middleware/agentRuntimeAuth', () => (req, res, next) => next());
+
+jest.mock('../../../models/Pod', () => ({
+  findById: jest.fn(() => ({
+    lean: jest.fn().mockResolvedValue({ type: 'chat', members: [{ toString: () => 'u1' }] }),
+  })),
+}));
+
+const mockFind = jest.fn();
+jest.mock('../../../models/Task', () => ({
+  find: (...args) => mockFind(...args),
+  findOne: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+}));
+
+jest.mock('../../../models/User', () => ({
+  findById: jest.fn(() => ({
+    select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue({ username: 'alice' }) })),
+  })),
+}));
+
+const tasksApiRoutes = require('../../../routes/tasksApi');
+
+const POD = '69b7ddff0ce64c9648365fc4';
+
+describe('GET /api/v1/tasks/:podId — query coercion at the boundary', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFind.mockReturnValue({ sort: () => ({ lean: async () => [] }) });
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1/tasks', tasksApiRoutes);
+  });
+
+  const queryPassedToMongo = () => mockFind.mock.calls[0][0];
+
+  test('an operator object in assignee never reaches the query', async () => {
+    const res = await request(app).get(`/api/v1/tasks/${POD}?assignee[$ne]=nova`);
+    expect(res.status).toBe(200);
+    expect(queryPassedToMongo()).not.toHaveProperty('assignee');
+  });
+
+  test('an operator object in status never reaches the query', async () => {
+    const res = await request(app).get(`/api/v1/tasks/${POD}?status[$ne]=done`);
+    expect(res.status).toBe(200);
+    expect(queryPassedToMongo()).not.toHaveProperty('status');
+  });
+
+  test('a repeated status param is an array, and is dropped rather than misread', async () => {
+    const res = await request(app).get(`/api/v1/tasks/${POD}?status=pending&status=claimed`);
+    expect(res.status).toBe(200);
+    expect(queryPassedToMongo()).not.toHaveProperty('status');
+  });
+
+  test('claimable only fires on the exact string, so an array cannot force it', async () => {
+    await request(app).get(`/api/v1/tasks/${POD}?claimable[]=true`);
+    expect(queryPassedToMongo()).not.toHaveProperty('$or');
+    jest.clearAllMocks();
+    mockFind.mockReturnValue({ sort: () => ({ lean: async () => [] }) });
+    await request(app).get(`/api/v1/tasks/${POD}?claimable=true`);
+    expect(queryPassedToMongo()).toHaveProperty('$or');
+  });
+
+  test('legitimate string filters still work, comma list included', async () => {
+    await request(app).get(`/api/v1/tasks/${POD}?assignee=nova&status=pending,claimed`);
+    const q = queryPassedToMongo();
+    expect(q.assignee).toBe('nova');
+    expect(q.status).toEqual({ $in: ['pending', 'claimed'] });
+  });
+});

--- a/backend/__tests__/unit/routes/tasksApi.queryCoercion.test.js
+++ b/backend/__tests__/unit/routes/tasksApi.queryCoercion.test.js
@@ -56,7 +56,18 @@ describe('GET /api/v1/tasks/:podId — query coercion at the boundary', () => {
     app.use('/api/v1/tasks', tasksApiRoutes);
   });
 
-  const queryPassedToMongo = () => mockFind.mock.calls[0][0];
+  // Domain guard, by the rule these tests are an instance of: every assertion
+  // below is negative-form (`not.toHaveProperty`), and a negative passes on a
+  // subject that does not exist. Asserting the query is well-formed FIRST means
+  // "the key is absent" can only mean the coercion dropped it — never that the
+  // handler bailed, that `find` ran with undefined, or that the shape changed
+  // underneath. Positive-form assertions need no such guard: `toBe('nova')`
+  // fails honestly on undefined.
+  const queryPassedToMongo = () => {
+    const q = mockFind.mock.calls[0][0];
+    expect(q).toHaveProperty('podId');
+    return q;
+  };
 
   test('an operator object in assignee never reaches the query', async () => {
     const res = await request(app).get(`/api/v1/tasks/${POD}?assignee[$ne]=nova`);

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -118,7 +118,15 @@ router.get('/:podId', auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId } = req.params || {};
     const userId = req.userId || req.user?._id || req.agentUser?._id;
-    const { assignee, status, claimable } = req.query || {};
+    // Coerced at the boundary rather than destructured. Express's extended
+    // query parser turns `?assignee[$ne]=x` into an OBJECT and `?status=a&status=b`
+    // into an ARRAY, and both used to flow straight into the Mongo query below:
+    // the first as an operator injection, the second as a silent switch from
+    // String.includes to Array.includes, where `status.includes(',')` stops
+    // meaning what it reads as. Anything that is not a string is dropped.
+    const assignee = typeof req.query?.assignee === 'string' ? req.query.assignee : undefined;
+    const status = typeof req.query?.status === 'string' ? req.query.status : undefined;
+    const claimable = req.query?.claimable === 'true';
     const access = await requirePodMember(podId || '', userId);
     if (access.error) return res.status(access.status || 500).json({ error: access.error });
     const query: Record<string, unknown> = { podId: mongoose.Types.ObjectId.createFromHexString(podId || '') };
@@ -128,7 +136,7 @@ router.get('/:podId', auth, async (req: AuthReq, res: Res) => {
     // ?status=claimed&claimable=true asks the useful narrow question — show me
     // the lapsed claims specifically — while ?claimable=true alone answers
     // "what can this pod's agents pick up right now", lapsed leases included.
-    if (claimable === 'true') query.$or = claimableConditions(new Date());
+    if (claimable) query.$or = claimableConditions(new Date());
     const tasks = await Task.find(query).sort({ taskNum: 1 }).lean();
     return res.json({ tasks });
   } catch (err) {

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -118,12 +118,17 @@ router.get('/:podId', auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId } = req.params || {};
     const userId = req.userId || req.user?._id || req.agentUser?._id;
-    const { assignee, status } = req.query || {};
+    const { assignee, status, claimable } = req.query || {};
     const access = await requirePodMember(podId || '', userId);
     if (access.error) return res.status(access.status || 500).json({ error: access.error });
     const query: Record<string, unknown> = { podId: mongoose.Types.ObjectId.createFromHexString(podId || '') };
     if (assignee) query.assignee = assignee;
     if (status) query.status = status.includes(',') ? { $in: status.split(',') } : status;
+    // Composes with `status` by AND rather than overriding it, so
+    // ?status=claimed&claimable=true asks the useful narrow question — show me
+    // the lapsed claims specifically — while ?claimable=true alone answers
+    // "what can this pod's agents pick up right now", lapsed leases included.
+    if (claimable === 'true') query.$or = claimableConditions(new Date());
     const tasks = await Task.find(query).sort({ taskNum: 1 }).lean();
     return res.json({ tasks });
   } catch (err) {
@@ -310,6 +315,32 @@ router.post('/:podId', rateLimit({
 // identical semantics to message claims (messageClaimService).
 const TASK_CLAIM_LEASE_MS = 30 * 60 * 1000;
 
+// The single definition of "claimable", shared by the CLAIM path and the LIST
+// path. They used to disagree: the CAS below grants a lapsed lease, while
+// GET /tasks could only filter on stored `status`, so a lapsed task was
+// grantable and unfindable at the same time. That is why
+// tasks.claim-lease.test.js:154 ("a lapsed lease is claimable by a peer")
+// passes while no peer can reach the task — it drives the CAS directly and
+// never asks whether the work can be discovered.
+//
+// ADR-018 put kernel enforcement of claims out of scope, so there is no reaper
+// and recovery is lazy: discovery IS the recovery mechanism. That makes this
+// predicate load-bearing rather than a convenience filter.
+//
+// Parameterised, never copied. `claimedBy` adds the self-renewal branch the
+// CAS needs; the list omits it deliberately, because "what can I pick up" does
+// not mean work the caller already holds. One function, so the expiry rule
+// cannot drift between call sites and quietly re-open this gap.
+export const claimableConditions = (
+  now: Date,
+  claimedBy?: string,
+): Record<string, unknown>[] => [
+  { status: 'pending' },
+  ...(claimedBy ? [{ status: 'claimed', claimedBy }] : []),
+  { status: 'claimed', claimExpiresAt: { $lt: now } },
+  { status: 'claimed', claimExpiresAt: null, claimedAt: { $lt: new Date(now.getTime() - TASK_CLAIM_LEASE_MS) } },
+];
+
 router.post('/:podId/:taskId/claim', rateLimit({
   windowMs: 60_000,
   // Higher than task-create's 20: a claimant renews by re-claiming, and a
@@ -339,12 +370,7 @@ router.post('/:podId/:taskId/claim', rateLimit({
     const task = await Task.findOneAndUpdate({
       podId: mongoose.Types.ObjectId.createFromHexString(podId || ''),
       taskId,
-      $or: [
-        { status: 'pending' },
-        { status: 'claimed', claimedBy },
-        { status: 'claimed', claimExpiresAt: { $lt: now } },
-        { status: 'claimed', claimExpiresAt: null, claimedAt: { $lt: new Date(now.getTime() - TASK_CLAIM_LEASE_MS) } },
-      ],
+      $or: claimableConditions(now, claimedBy),
     }, update, { new: true });
     if (!task) {
       const existing = await Task.findOne({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId }).lean() as { claimedBy?: string; status?: string; claimExpiresAt?: Date | null } | null;


### PR DESCRIPTION
## The test that promised this was already fixed

`tasks.claim-lease.test.js:154` is named **"a lapsed lease is claimable by a peer — dead claimants never hold work forever"**, and it passes. Dead claimants hold work forever anyway.

It drives the CAS directly. `POST /:podId/:taskId/claim` really does have four ways to win, two covering a lapsed lease and a stale legacy claim — so the grant works, *if you already know the taskId*. `GET /:podId` filtered on `assignee` and `status` only, and a lapsed task's **stored** status is still `claimed`. No peer listing pending work could ever see the task the CAS would hand them.

Claimable, and unreachable. The suite never noticed because it only ever asked the predicate, never asked what a peer can find.

## Why this is correctness, not a filter feature

ADR-018 puts kernel enforcement of claims **out of scope**, and its entire task clause is *"add `claimExpiresAt` to `Task`, honoured by the existing claim path"*. There is deliberately no reaper — recovery is lazy. That makes discovery the whole recovery mechanism.

Concretely, under the autonomy work: a board change is delivered once, to one claim winner. If that winner dies, the lease lapses and nothing recovers the task, because nothing can see it.

## The change

`claimableConditions(now, claimedBy?)` becomes the single definition of claimable, consumed by both routes. **Parameterised rather than copied** — `claimedBy` adds the self-renewal branch the CAS needs; the list omits it, because "what can I pick up" does not mean work the caller already holds. A second copy of the expiry rule is exactly how `:154` goes green while the behaviour rots again.

`?claimable=true` composes with `status` by AND, so `?status=claimed&claimable=true` asks the narrow question (show me the lapsed claims) while `?claimable=true` alone answers "what can this pod's agents pick up right now".

## On the tests — three of five were vacuous

My first version of the discovery block went **green against `origin/main`**. An unknown query param is ignored, so the unfiltered board comes back, and it contains the lapsed task — "the lapsed one is present" proved nothing.

Every discovery test now also seeds a live-held task that must be **absent**, so an ignored filter fails loudly:

| | unfixed route | with fix |
|---|---|---|
| discovery tests | 5 failed | 5 passed |
| whole file | 7 passed / 5 failed | 12 passed |

That is the same defect this PR fixes, committed inside the fix for it, and it was only caught by running the new tests against the unfixed tree before opening this.

## Verification

- `tasks.claim-lease.test.js` — 12/12, red/green differential above
- backend suite — 246 suites, 1972 tests, all passing
- `npm run tsc:check` — clean