### PR TITLE
docs(tasks): record why claimable is absent from the tool schema

### DIFF
--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -126,6 +126,10 @@ router.get('/:podId', auth, async (req: AuthReq, res: Res) => {
     // meaning what it reads as. Anything that is not a string is dropped.
     const assignee = typeof req.query?.assignee === 'string' ? req.query.assignee : undefined;
     const status = typeof req.query?.status === 'string' ? req.query.status : undefined;
+    // Deliberately absent from the MCP tool schema, and NOT an oversight to
+    // close. Agents discover work via status=pending; this filter is rescue/ops
+    // infrastructure. Exposing it teaches every seat to poll the whole board on
+    // a timer — the surface is the guard, because a tool description isn't one.
     const claimable = req.query?.claimable === 'true';
     const access = await requirePodMember(podId || '', userId);
     if (access.error) return res.status(access.status || 500).json({ error: access.error });


### PR DESCRIPTION
`?claimable=true` shipped in #1022 documenting what it composes with, and nothing about who may call it.

No tool surface declares the parameter — not the openclaw extension (`tools.ts`), not `commonly-mcp/src/tools.js` — so an agent cannot send it. Without a note, the next reader greps the schemas, finds nothing, and files the absence as an oversight to close. It is the opposite: a decision, because exposing the filter teaches every seat to poll the whole board on a timer.

Text is @pod-architect's, **recorded verbatim rather than paraphrased**. The `resetMs` sentence in #1010 became permanently wrong exactly that way — one person's summary of another's reasoning, inherited into a PR body and then into review arguments.

Comment-only, typechecked before pushing: asserted no `*/` in the added prose, then ran `tsc:check` — 0 errors. #1009 is why that check is not skippable on a docs diff.