### PR TITLE
feat(kernel): board changes reach agents, bounded on delivery (ADR-024 D1, re-land)

### DIFF
--- a/backend/__tests__/unit/routes/tasksApi.agentNotify.test.js
+++ b/backend/__tests__/unit/routes/tasksApi.agentNotify.test.js
@@ -1,0 +1,126 @@
+/**
+ * Board write -> agent fan-out wiring (ADR-024 D1).
+ *
+ * `notifyPodAgents` itself is covered in the service test. What is covered HERE
+ * is the wiring, which is where this change can fail invisibly: a board write
+ * that reaches Socket.io and skips the fan-out looks completely healthy from
+ * the outside — the request 200s, the Kanban updates, the human sees the board
+ * move, and only the agents learn nothing. That is the exact asymmetry D1
+ * exists to remove, so it gets an assertion rather than an assumption.
+ *
+ * Also pinned: the actor shape. `isAgent` is what prices a wake against the
+ * cascade cap, and it is derived from the auth shape (`agentRuntimeAuth` sets
+ * `req.agentUser`, never `req.user`). Get it wrong for an agent and board
+ * churn stops terminating.
+ */
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.userId = 'u1';
+  req.user = { id: 'u1', _id: 'u1' };
+  next();
+});
+jest.mock('../../../middleware/agentRuntimeAuth', () => (req, res, next) => {
+  req.agentUser = { _id: 'bot-9' };
+  next();
+});
+
+jest.mock('../../../models/Pod', () => ({
+  findById: jest.fn(() => ({
+    lean: jest.fn().mockResolvedValue({
+      type: 'chat',
+      members: [{ toString: () => 'u1' }, { toString: () => 'bot-9' }],
+    }),
+  })),
+}));
+
+const mockFindOneAndUpdate = jest.fn();
+jest.mock('../../../models/Task', () => ({
+  findOneAndUpdate: (...args) => mockFindOneAndUpdate(...args),
+  findOne: jest.fn(),
+  find: jest.fn(),
+}));
+
+jest.mock('../../../models/User', () => ({
+  findById: jest.fn(() => ({
+    select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue({ username: 'alice' }) })),
+  })),
+}));
+
+jest.mock('../../../services/githubAppService', () => ({
+  isPatConfigured: jest.fn(() => false),
+}));
+
+const mockNotifyPodAgents = jest.fn();
+jest.mock('../../../services/taskEventService', () => ({
+  emitTaskUpdated: jest.fn(),
+  notifyPodAgents: (...args) => mockNotifyPodAgents(...args),
+}));
+
+const tasksApi = require('../../../routes/tasksApi');
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/tasks', tasksApi);
+
+const POD_ID = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+
+const patch = (token) => {
+  const req = request(app).patch(`/api/v1/tasks/${POD_ID}/TASK-001`);
+  if (token) req.set('Authorization', `Bearer ${token}`);
+  return req.send({ status: 'in_progress' });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFindOneAndUpdate.mockResolvedValue({ taskId: 'TASK-001', status: 'claimed' });
+  mockNotifyPodAgents.mockResolvedValue(undefined);
+});
+
+describe('board writes reach the pod agents', () => {
+  it('fans a human PATCH out to the agents, marked as a human edit', async () => {
+    const res = await patch();
+
+    expect(res.status).toBe(200);
+    expect(mockNotifyPodAgents).toHaveBeenCalledTimes(1);
+    const [podId, , kind, actor] = mockNotifyPodAgents.mock.calls[0];
+    expect(podId).toBe(POD_ID);
+    expect(kind).toBe('updated');
+    // A human edit resets the cascade streak; mislabelling it as an agent edit
+    // would let a busy board starve the very seats it is trying to feed.
+    expect(actor).toEqual({ userId: 'u1', isAgent: false });
+  });
+
+  it('marks an AGENT PATCH as an agent edit, so board churn terminates', async () => {
+    const res = await patch('cm_agent_test');
+
+    expect(res.status).toBe(200);
+    const [, , , actor] = mockNotifyPodAgents.mock.calls[0];
+    // agentRuntimeAuth sets req.agentUser and never req.user — deriving this
+    // from the wrong field is how an unbounded wake loop gets built.
+    expect(actor.isAgent).toBe(true);
+    expect(actor.userId).toBe('bot-9');
+  });
+
+  it('still answers the board write when the fan-out rejects', async () => {
+    mockNotifyPodAgents.mockRejectedValue(new Error('event store down'));
+
+    const res = await patch();
+
+    // The board is a human-facing surface; it must not inherit the agent
+    // layer's availability.
+    expect(res.status).toBe(200);
+  });
+
+  it('still answers the board write when the fan-out throws synchronously', async () => {
+    // The failure an unhandled-rejection guard alone does NOT catch, and the
+    // one that actually occurred: a partial mock / renamed export makes the
+    // call itself throw before any promise exists.
+    mockNotifyPodAgents.mockImplementation(() => { throw new Error('not a function'); });
+
+    const res = await patch();
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/backend/__tests__/unit/services/taskEventService.notifyPodAgents.test.js
+++ b/backend/__tests__/unit/services/taskEventService.notifyPodAgents.test.js
@@ -159,10 +159,55 @@ describe('notifyPodAgents', () => {
   it('never wakes the actor about their own edit', async () => {
     mockInstalls([install('scout', AGENT_ID), install('sprint-impl', HUMAN_ID)]);
 
-    await notifyPodAgents(POD_ID, task(), 'updated', { userId: AGENT_ID, isAgent: true });
+    await notifyPodAgents(POD_ID, task(), 'updated', {
+      userId: AGENT_ID, isAgent: true, agentName: 'scout', instanceId: 'default',
+    });
 
     const woken = AgentEventService.enqueue.mock.calls.map((c) => c[0].agentName);
     expect(woken).toEqual(['sprint-impl']);
+  });
+
+  it('skips a HUMAN-INSTALLED agent editing the board, which installedBy cannot match', async () => {
+    // @pod-architect caught this on review. The skip used to compare the actor's
+    // userId to `install.installedBy` — which holds the agent's own id only when
+    // it self-installed. A human-installed agent editing the board matches
+    // nothing, fails to skip, and wakes ITSELF. `installedBy` has now produced a
+    // bug from both directions, which is why the key is identity instead.
+    mockInstalls([install('scout', HUMAN_ID), install('sprint-impl', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'updated', {
+      userId: AGENT_ID, isAgent: true, agentName: 'scout', instanceId: 'default',
+    });
+
+    const woken = AgentEventService.enqueue.mock.calls.map((c) => c[0].agentName);
+    expect(woken).toEqual(['sprint-impl']);
+  });
+
+  it('matches the self-skip case-insensitively, so a capitalised name still skips', async () => {
+    mockInstalls([install('Scout', HUMAN_ID), install('sprint-impl', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'updated', {
+      userId: AGENT_ID, isAgent: true, agentName: 'SCOUT', instanceId: 'default',
+    });
+
+    const woken = AgentEventService.enqueue.mock.calls.map((c) => c[0].agentName);
+    expect(woken).toEqual(['sprint-impl']);
+  });
+
+  it('does not skip a DIFFERENT instance of the same agent name', async () => {
+    // scout fans out per user (scout-u<hash>); one instance editing the board
+    // must still reach its siblings, or a 115-identity agent silences itself.
+    mockInstalls([
+      { ...install('scout', HUMAN_ID), instanceId: 'u0da521ab41' },
+      { ...install('scout', HUMAN_ID), instanceId: 'ucc4035c51b' },
+    ]);
+
+    await notifyPodAgents(POD_ID, task(), 'updated', {
+      userId: AGENT_ID, isAgent: true, agentName: 'scout', instanceId: 'u0da521ab41',
+    });
+
+    const woken = AgentEventService.enqueue.mock.calls.map((c) => c[0].instanceId);
+    expect(woken).toEqual(['ucc4035c51b']);
   });
 
   it('still wakes an agent when the HUMAN who installed it edits the board', async () => {

--- a/backend/__tests__/unit/services/taskEventService.notifyPodAgents.test.js
+++ b/backend/__tests__/unit/services/taskEventService.notifyPodAgents.test.js
@@ -1,0 +1,257 @@
+/**
+ * Producer parity (ADR-024 D1): a board change must reach the pod's agents,
+ * not just its Socket.io room.
+ *
+ * The bug these cover is not "the fan-out is wrong" — it is that every wrong
+ * version of this fan-out is SILENT. A bespoke `task.*` type enqueues and acks
+ * and does nothing; a missing claim key stampedes without error; a mispriced
+ * `dmKind` loops until the cap catches it. None of those raise. So each test
+ * here pins a property whose violation would otherwise look like calm.
+ */
+const mongoose = require('mongoose');
+
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { find: jest.fn() },
+}));
+
+jest.mock('../../../services/agentEventService', () => ({
+  enqueue: jest.fn(),
+}));
+
+jest.mock('../../../models/AgentEvent', () => ({
+  findOneAndUpdate: jest.fn(),
+  updateOne: jest.fn(),
+}));
+
+const { AgentInstallation } = require('../../../models/AgentRegistry');
+const AgentEventService = require('../../../services/agentEventService');
+const AgentEvent = require('../../../models/AgentEvent');
+const { notifyPodAgents } = require('../../../services/taskEventService');
+
+const POD_ID = new mongoose.Types.ObjectId().toString();
+const HUMAN_ID = new mongoose.Types.ObjectId().toString();
+const AGENT_ID = new mongoose.Types.ObjectId().toString();
+
+// Opted IN by default here, because every test below is about what an opted-in
+// agent receives. The opt-OUT case gets its own test rather than being the
+// silent default, so a gate regression fails loudly instead of emptying every
+// assertion at once.
+const install = (agentName, installedBy) => ({
+  agentName,
+  instanceId: 'default',
+  podId: POD_ID,
+  status: 'active',
+  installedBy,
+  config: { wakeOnMessage: { enabled: true } },
+});
+
+const task = (overrides = {}) => ({
+  taskId: 'TASK-042',
+  title: 'Wire the board to the fleet',
+  status: 'todo',
+  updatedAt: '2026-08-19T10:00:00.000Z',
+  ...overrides,
+});
+
+const mockInstalls = (rows) => {
+  AgentInstallation.find.mockReturnValue({ lean: jest.fn().mockResolvedValue(rows) });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  AgentEventService.enqueue.mockResolvedValue({});
+  // Default: nothing undrained, so each test exercises the fresh-enqueue path
+  // unless it explicitly seeds a pending wake.
+  AgentEvent.findOneAndUpdate.mockResolvedValue(null);
+  AgentEvent.updateOne.mockResolvedValue({});
+});
+
+describe('notifyPodAgents', () => {
+  it('rides message.posted, because a bespoke task.* type reaches neither runtime', async () => {
+    mockInstalls([install('scout', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'created', { userId: HUMAN_ID, isAgent: false });
+
+    expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+    const arg = AgentEventService.enqueue.mock.calls[0][0];
+    // The wrapper's PROMPT_EVENT_TYPES is a closed set; anything outside it is
+    // dropped after a successful ack, which is indistinguishable from silence.
+    expect(arg.type).toBe('message.posted');
+    // And the prompt has to be IN the payload — the wrapper reads
+    // payload.content, not a structured task object.
+    expect(arg.payload.content).toContain('TASK-042');
+    expect(arg.payload.content).toContain('Wire the board to the fleet');
+  });
+
+  it('folds a second change into an undrained wake instead of enqueueing again', async () => {
+    // The defect this replaces: the first version carried a per-task claim key
+    // so the CAS would elect one actor. @sprint-review's number killed it —
+    // the claim key dedupes ACTION, never DELIVERY. Every seat was still
+    // enqueued and still woke; 39 board writes across 4 opted-in seats is 156
+    // wakes, every seat caps at 3 within seconds, and D1 silences the fleet it
+    // exists to inform. The bound has to be on delivery.
+    mockInstalls([install('scout', HUMAN_ID)]);
+    AgentEvent.findOneAndUpdate.mockResolvedValue({
+      _id: 'evt-1',
+      payload: { boardChanges: 1 },
+    });
+
+    await notifyPodAgents(POD_ID, task(), 'updated', { userId: HUMAN_ID, isAgent: false });
+
+    expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+    expect(AgentEvent.updateOne).toHaveBeenCalledTimes(1);
+    // The summary must reflect the POST-increment count, or a seat reads "2
+    // changes" when three are waiting.
+    const [, update] = AgentEvent.updateOne.mock.calls[0];
+    expect(update.$set['payload.content']).toContain('2 changes');
+  });
+
+  it('matches the fold on boardWake, never on event type', async () => {
+    // Board wakes ride `message.posted`, which ordinary chat also uses. Folding
+    // on type would collapse a board change INTO someone's unread message and
+    // destroy it.
+    mockInstalls([install('scout', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'updated', { userId: HUMAN_ID, isAgent: false });
+
+    const [filter] = AgentEvent.findOneAndUpdate.mock.calls[0];
+    expect(filter['payload.boardWake']).toBe(true);
+    expect(filter.status).toBe('pending');
+    expect(filter.type).toBeUndefined();
+  });
+
+  it('carries no messageId, so every seat looks and the task CAS arbitrates', async () => {
+    mockInstalls([install('scout', HUMAN_ID), install('sprint-impl', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'created', { userId: HUMAN_ID, isAgent: false });
+
+    // A messageId would re-engage the wrapper's claim gate and put us back to
+    // one-looker-per-change — dedupe at the wrong layer. Contention belongs on
+    // the task claim, one level down, where it actually is.
+    for (const [arg] of AgentEventService.enqueue.mock.calls) {
+      expect(arg.payload.messageId).toBeUndefined();
+      expect(arg.payload.boardWake).toBe(true);
+    }
+  });
+
+  it('re-prices a folded batch as human when a human edit lands on agent churn', async () => {
+    // Otherwise one agent write early in a sweep permanently marks a wake the
+    // human later contributed to, and the seat spends cascade budget on it.
+    mockInstalls([install('scout', AGENT_ID)]);
+    AgentEvent.findOneAndUpdate.mockResolvedValue({ _id: 'evt-1', payload: { boardChanges: 2 } });
+
+    await notifyPodAgents(POD_ID, task(), 'updated', { userId: HUMAN_ID, isAgent: false });
+
+    const [, update] = AgentEvent.findOneAndUpdate.mock.calls[0];
+    expect(update.$set['payload.dmKind']).toBe('user-agent');
+  });
+
+  it('does NOT re-price a folded batch when the new change is another agent edit', async () => {
+    mockInstalls([install('scout', HUMAN_ID)]);
+    AgentEvent.findOneAndUpdate.mockResolvedValue({ _id: 'evt-1', payload: { boardChanges: 1 } });
+
+    await notifyPodAgents(POD_ID, task(), 'updated', { userId: AGENT_ID, isAgent: true });
+
+    const [, update] = AgentEvent.findOneAndUpdate.mock.calls[0];
+    expect(update.$set).toBeUndefined();
+  });
+
+  it('never wakes the actor about their own edit', async () => {
+    mockInstalls([install('scout', AGENT_ID), install('sprint-impl', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'updated', { userId: AGENT_ID, isAgent: true });
+
+    const woken = AgentEventService.enqueue.mock.calls.map((c) => c[0].agentName);
+    expect(woken).toEqual(['sprint-impl']);
+  });
+
+  it('still wakes an agent when the HUMAN who installed it edits the board', async () => {
+    // The self-skip nearly shipped keyed on `installedBy` alone. That field is
+    // the agent's own user id when an agent self-installs, but the HUMAN's id
+    // when a human installs it — so the skip silenced every agent for the one
+    // person most likely to be moving tasks: its installer. It fails silently,
+    // as an agent that simply never responds to its owner.
+    mockInstalls([install('scout', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'created', { userId: HUMAN_ID, isAgent: false });
+
+    expect(AgentEventService.enqueue).toHaveBeenCalledTimes(1);
+    expect(AgentEventService.enqueue.mock.calls[0][0].agentName).toBe('scout');
+  });
+
+  it('prices a human edit as user-agent so it resets the cascade streak', async () => {
+    mockInstalls([install('scout', AGENT_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'created', { userId: HUMAN_ID, isAgent: false });
+
+    expect(AgentEventService.enqueue.mock.calls[0][0].payload.dmKind).toBe('user-agent');
+  });
+
+  it('prices an agent edit as agent-agent so board churn terminates at the cap', async () => {
+    mockInstalls([install('scout', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'updated', { userId: AGENT_ID, isAgent: true });
+
+    expect(AgentEventService.enqueue.mock.calls[0][0].payload.dmKind).toBe('agent-agent');
+  });
+
+  it('prices an UNKNOWN actor as an agent, because the two mistakes cost differently', async () => {
+    mockInstalls([install('scout', HUMAN_ID)]);
+
+    // Mislabelling a human costs one suppressed wake. Mislabelling an agent
+    // costs an unbounded wake loop. A caller that forgets to pass an actor gets
+    // the cheap failure.
+    await notifyPodAgents(POD_ID, task(), 'updated');
+
+    expect(AgentEventService.enqueue.mock.calls[0][0].payload.dmKind).toBe('agent-agent');
+  });
+
+  it('respects an opt-OUT, so ambient wakes cannot arrive through a second door', async () => {
+    // 169 of 367 production installs have wake-on-message off — `commonly-bot`
+    // and `openclaw`, user-facing seats where an unrequested wake is a noise
+    // incident. A board change is ambient activity nobody addressed to them, so
+    // it is governed by the same switch as ambient chat.
+    mockInstalls([
+      { ...install('commonly-bot', HUMAN_ID), config: { wakeOnMessage: { enabled: false } } },
+      { ...install('openclaw', HUMAN_ID), config: {} },
+      install('sprint-impl', HUMAN_ID),
+    ]);
+
+    await notifyPodAgents(POD_ID, task(), 'created', { userId: HUMAN_ID, isAgent: false });
+
+    const woken = AgentEventService.enqueue.mock.calls.map((c) => c[0].agentName);
+    expect(woken).toEqual(['sprint-impl']);
+  });
+
+  it('stays quiet on delete, where the wake would spend a turn finding nothing', async () => {
+    mockInstalls([install('scout', HUMAN_ID)]);
+
+    await notifyPodAgents(POD_ID, task(), 'deleted', { userId: HUMAN_ID, isAgent: false });
+
+    expect(AgentEventService.enqueue).not.toHaveBeenCalled();
+    // Cheap to assert, and it pins that we return before the query rather than
+    // after it.
+    expect(AgentInstallation.find).not.toHaveBeenCalled();
+  });
+
+  it('lets the other agents through when one enqueue throws', async () => {
+    mockInstalls([install('scout', HUMAN_ID), install('sprint-impl', HUMAN_ID)]);
+    AgentEventService.enqueue
+      .mockRejectedValueOnce(new Error('event store unavailable'))
+      .mockResolvedValueOnce({});
+
+    await expect(
+      notifyPodAgents(POD_ID, task(), 'created', { userId: HUMAN_ID, isAgent: false }),
+    ).resolves.toBeUndefined();
+
+    expect(AgentEventService.enqueue).toHaveBeenCalledTimes(2);
+  });
+
+  it('never lets a fan-out failure surface to the board write', async () => {
+    AgentInstallation.find.mockImplementation(() => { throw new Error('mongo down'); });
+
+    await expect(
+      notifyPodAgents(POD_ID, task(), 'created', { userId: HUMAN_ID, isAgent: false }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -29,10 +29,22 @@ const { emitTaskUpdated, notifyPodAgents } = require('../services/taskEventServi
  * `notifyPodAgents` treats *undefined* as "assume agent" — the safe default
  * there, and not one to trip over by accident here.
  */
-const actorOf = (req: any) => ({
-  userId: req.userId || req.user?._id || req.user?.id || req.agentUser?._id,
-  isAgent: Boolean(req.agentUser?._id || req.user?.isBot),
-});
+const actorOf = (req: any) => {
+  const isAgent = Boolean(req.agentUser?._id || req.user?.isBot);
+  // Identity, not just a user id. The self-skip downstream keys on
+  // (agentName, instanceId) because `installedBy` means the agent on a
+  // self-install and the HUMAN on a human-install — supplying only userId let a
+  // human-installed agent fail to match its own install and wake itself.
+  // Both auth shapes carry the same metadata: agentRuntimeAuth sets
+  // `req.agentUser`, the dual-auth path leaves the bot on `req.user`.
+  const meta = req.agentUser?.botMetadata || req.user?.botMetadata || {};
+  return {
+    userId: req.userId || req.user?._id || req.user?.id || req.agentUser?._id,
+    isAgent,
+    agentName: isAgent ? (meta.agentName || undefined) : undefined,
+    instanceId: isAgent ? (meta.instanceId || 'default') : undefined,
+  };
+};
 
 /**
  * Board change -> pod agents. Deliberately NOT folded into `emitTaskUpdated`:

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -18,7 +18,42 @@ const User = require('../models/User');
 // eslint-disable-next-line global-require
 const GitHubAppService = require('../services/githubAppService');
 // eslint-disable-next-line global-require
-const { emitTaskUpdated } = require('../services/taskEventService');
+const { emitTaskUpdated, notifyPodAgents } = require('../services/taskEventService');
+
+/**
+ * Who made this board change, for the agent fan-out.
+ *
+ * `isAgent` prices the wake against the cascade cap, so it is derived from the
+ * auth shape rather than guessed: `agentRuntimeAuth` sets `req.agentUser` and
+ * never `req.user`. Returned explicitly as `false` for humans because
+ * `notifyPodAgents` treats *undefined* as "assume agent" — the safe default
+ * there, and not one to trip over by accident here.
+ */
+const actorOf = (req: any) => ({
+  userId: req.userId || req.user?._id || req.user?.id || req.agentUser?._id,
+  isAgent: Boolean(req.agentUser?._id || req.user?.isBot),
+});
+
+/**
+ * Board change -> pod agents. Deliberately NOT folded into `emitTaskUpdated`:
+ * that is a synchronous best-effort socket emit, this is an async DB fan-out.
+ *
+ * try/catch AND .catch, deliberately. A promise `.catch` cannot cover the call
+ * throwing SYNCHRONOUSLY, which is what happens the moment `notifyPodAgents` is
+ * undefined — a partial mock, a renamed export, a bad merge. That threw through
+ * into the route and turned every board write into a 500: strictly worse than
+ * the silent fan-out this exists to fix.
+ */
+const notifyAgents = (req: any, podId: unknown, task: unknown, kind: string) => {
+  try {
+    const pending = notifyPodAgents(podId, task, kind, actorOf(req));
+    if (pending?.catch) {
+      pending.catch((e: Error) => console.warn('[tasks] agent notify failed:', e.message));
+    }
+  } catch (e) {
+    console.warn('[tasks] agent notify threw:', (e as Error).message);
+  }
+};
 
 interface AuthReq {
   userId?: string;
@@ -227,6 +262,7 @@ router.post('/:podId', rateLimit({
           await existing.save();
           const reopenedObj = existing.toObject();
           emitTaskUpdated(podId, reopenedObj, 'updated');
+          notifyAgents(req, podId, reopenedObj, 'updated');
           return res.json({ task: reopenedObj, alreadyExists: false, reopened: true });
         }
         return res.json({ task: existing.toObject(), alreadyExists: true });
@@ -313,6 +349,7 @@ router.post('/:podId', rateLimit({
       }
     }
     emitTaskUpdated(podId, task, 'created');
+    notifyAgents(req, podId, task, 'created');
     return res.status(201).json({ task });
   } catch (err) {
     console.error('POST /tasks error:', err);
@@ -440,6 +477,7 @@ router.post('/:podId/:taskId/claim', rateLimit({
       });
     }
     emitTaskUpdated(podId, task, 'updated');
+    notifyAgents(req, podId, task, 'updated');
     return res.json({ task });
   } catch (err) {
     console.error('POST /tasks/claim error:', err);
@@ -508,6 +546,7 @@ router.post('/:podId/:taskId/complete', taskWriteRateLimit(30), auth, async (req
       console.warn('[system-exchange] task-completed dispatch failed:', (triggerErr as Error).message);
     }
     emitTaskUpdated(podId, task, 'updated');
+    notifyAgents(req, podId, task, 'updated');
     return res.json({ task });
   } catch (err) {
     console.error('POST /tasks/complete error:', err);
@@ -527,6 +566,7 @@ router.post('/:podId/:taskId/updates', taskWriteRateLimit(60), auth, async (req:
     const task = await Task.findOneAndUpdate({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId }, { $push: { updates: { text: text.trim(), author, authorId: userId?.toString() || null, createdAt: new Date() } } }, { new: true });
     if (!task) return res.status(404).json({ error: 'Task not found' });
     emitTaskUpdated(podId, task, 'updated');
+    notifyAgents(req, podId, task, 'updated');
     return res.json({ task });
   } catch (err) {
     console.error('POST /tasks/updates error:', err);
@@ -600,6 +640,7 @@ router.patch('/:podId/:taskId', taskWriteRateLimit(60), auth, async (req: AuthRe
     const task = await Task.findOneAndUpdate({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId }, update, { new: true });
     if (!task) return res.status(404).json({ error: 'Task not found' });
     emitTaskUpdated(podId, task, 'updated');
+    notifyAgents(req, podId, task, 'updated');
     return res.json({ task });
   } catch (err) {
     console.error('PATCH /tasks error:', err);

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -1670,4 +1670,9 @@ export {
   enqueueMentions,
   enqueueDmEvent,
   MENTION_ALIASES,
+  // Exported so the ADR-024 D1 board fan-out (taskEventService.notifyPodAgents)
+  // gates on the SAME opt-in rather than reimplementing the predicate. The
+  // config shape is a Mongoose Map on some paths and a plain object on others,
+  // which is exactly the kind of detail a second copy gets subtly wrong.
+  wakeOnMessageEnabled,
 };

--- a/backend/services/taskEventService.ts
+++ b/backend/services/taskEventService.ts
@@ -107,7 +107,15 @@ export async function notifyPodAgents(
   podId: unknown,
   task: Record<string, unknown>,
   kind: TaskEventKind,
-  actor?: { userId?: unknown; isAgent?: boolean },
+  actor?: {
+    userId?: unknown;
+    isAgent?: boolean;
+    // Identity of the acting agent, when there is one. Carries the self-skip;
+    // `userId` cannot, because `installedBy` is the human's id on a
+    // human-installed agent.
+    agentName?: string;
+    instanceId?: string;
+  },
 ): Promise<void> {
   // A deletion leaves nothing to pick up, and a tombstone wake spends a model
   // turn to discover there is no work.
@@ -157,19 +165,32 @@ export async function notifyPodAgents(
       'work, or a human needs a decision from you.',
     ].join('\n');
 
-    // Self-skip, but ONLY for an agent actor. `installedBy` holds the agent's
-    // own user id when an agent self-installs, and the HUMAN's id when a human
-    // installs it — the same field meaning two different things. Skipping on it
-    // unconditionally silenced every agent for the exact person most likely to
-    // be editing the board: whoever installed it. So the skip is scoped to the
-    // case where the field genuinely identifies the actor.
+    // Self-skip keyed on IDENTITY, never on `installedBy`.
+    //
+    // `installedBy` means two different things — the agent's own user id when
+    // an agent self-installs, the HUMAN's id when a human installs it — and
+    // both readings have now shipped a bug, from opposite directions.
+    // Comparing it against any actor silenced every agent for its own
+    // installer, the person most likely to be moving tasks. Scoping that to
+    // agent actors fixed the human case and left the mirror image, which
+    // @pod-architect caught on review: a HUMAN-installed agent editing the
+    // board does not match its installer's id, so it fails to skip and wakes
+    // itself.
+    //
+    // (agentName, instanceId) identifies the acting agent under BOTH install
+    // paths, which is what this skip has always meant. Normalised the way
+    // AgentInstallation stores them — lowercased name, 'default' for a missing
+    // instance — so a case difference cannot quietly reintroduce the self-wake.
     // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
     const AgentEvent = require('../models/AgentEvent');
     const dmKind = actor?.isAgent === false ? 'user-agent' : 'agent-agent';
 
-    const actorId = actor?.isAgent && actor?.userId ? String(actor.userId) : null;
+    const actorKey = actor?.isAgent && actor?.agentName
+      ? `${String(actor.agentName).toLowerCase()}::${String(actor.instanceId || 'default')}`
+      : null;
     await Promise.all(installs.map(async (install: Record<string, unknown>) => {
-      if (actorId && String(install.installedBy || '') === actorId) return;
+      const installKey = `${String(install.agentName || '').toLowerCase()}::${String(install.instanceId || 'default')}`;
+      if (actorKey && installKey === actorKey) return;
       const agentName = install.agentName;
       const instanceId = install.instanceId || 'default';
       try {

--- a/backend/services/taskEventService.ts
+++ b/backend/services/taskEventService.ts
@@ -44,9 +44,200 @@ export function emitTaskUpdated(podId: unknown, task: unknown, kind: TaskEventKi
   }
 }
 
+/**
+ * Wake the pod's agents on a board change (ADR-024 D1, "producer parity").
+ *
+ * `emitTaskUpdated` above reaches Socket.io and stops, so a human watching the
+ * Kanban sees the board move and an agent installed in the same pod learns
+ * nothing. That asymmetry is why the fleet is 100% reactive: an agent can only
+ * respond to being named, because being named is the only thing that reaches
+ * it. Seven socket-emitting producers in this backend have zero enqueues
+ * between them; this makes one of them do both.
+ *
+ * Three deliberate choices, each with a cheaper wrong version:
+ *
+ * 1. `message.posted`, NOT a new `task.*` type. A bespoke type reaches NEITHER
+ *    runtime — the wrapper drops unrecognised types (PROMPT_EVENT_TYPES is a
+ *    closed set) and the native tier discards the payload in its default
+ *    branch. A `task.updated` event would enqueue, deliver, ack, and do
+ *    nothing: this system's signature failure, where a break degrades to
+ *    silence and silence reads like a considered decision. #970 already proved
+ *    the ride-an-existing-type route on reaction receipts.
+ *
+ * 2. Coalescing, NOT a per-task claim key. The first version of this used a
+ *    synthetic `task:<id>:<kind>:<rev>` messageId so the claim CAS would elect
+ *    one actor per change. @sprint-review killed it with a number: the claim
+ *    key **dedupes action, never delivery**. Every opted-in seat is still
+ *    enqueued and still wakes; the losers only discover they lost after
+ *    spawning. A board sweep writing 39 rows across 4 opted-in seats is 156
+ *    wakes, each one `agent-agent`, so every seat hits the cascade cap of 3
+ *    within seconds and goes deaf for the reset window — D1 switched on would
+ *    silence the fleet it exists to inform.
+ *
+ *    So the bound has to be on DELIVERY. At most one *pending* board wake per
+ *    (agent, instance, pod): a second change folds into the undrained first
+ *    instead of appending. 39 writes become 1 wake, and each seat looks at the
+ *    board once rather than once per row. There is no messageId, deliberately
+ *    — every seat SHOULD look; the per-task claim CAS already arbitrates who
+ *    actually takes what, one layer down, where the contention really is.
+ *
+ *    This is a step toward ADR-024 D3's inbox, not a workaround around it:
+ *    "collapse what is still undelivered" is what an inbox does.
+ *
+ *    Residual, stated rather than hidden: the fold is a findOneAndUpdate, so
+ *    two board writes landing in the same instant can both miss and both
+ *    insert. The bound is therefore "roughly one" pending wake, not exactly
+ *    one — worst case a small constant, never the 39 it replaces. A sweep is
+ *    sequential within one agent's turn, which is the case that actually
+ *    produced the 156. Tightening it to exactly-one needs a unique partial
+ *    index on (agentName, instanceId, podId) where status is pending and
+ *    boardWake is true; deliberately not added here, because that index would
+ *    also constrain every non-board event sharing those fields.
+ *
+ * 3. `dmKind` reflects the ACTOR, so agent-driven churn is priced. An agent
+ *    moving a task wakes a peer, who may move a task, who wakes a peer. That
+ *    terminates only because an agent-triggered wake counts toward the cascade
+ *    cap. Defaulting an UNKNOWN actor to 'agent-agent' is the safe direction:
+ *    mislabelling a human costs one suppressed wake, mislabelling an agent
+ *    costs an unbounded loop. This rides the same `dmKind` overload that #1018
+ *    tracks retiring in favour of `triggerAuthor` — inherited knowingly rather
+ *    than inventing a second field needing its own release cycle.
+ */
+export async function notifyPodAgents(
+  podId: unknown,
+  task: Record<string, unknown>,
+  kind: TaskEventKind,
+  actor?: { userId?: unknown; isAgent?: boolean },
+): Promise<void> {
+  // A deletion leaves nothing to pick up, and a tombstone wake spends a model
+  // turn to discover there is no work.
+  if (kind === 'deleted') return;
+  if (!podId || !task) return;
+
+  try {
+    /* eslint-disable global-require, @typescript-eslint/no-require-imports */
+    const { AgentInstallation } = require('../models/AgentRegistry');
+    const AgentEventService = require('./agentEventService');
+    // Lazy so this never forms a load-time cycle with the mention service.
+    const { wakeOnMessageEnabled } = require('./agentMentionService');
+    /* eslint-enable global-require, @typescript-eslint/no-require-imports */
+
+    const normalizedPodId = String(podId);
+    const active = await AgentInstallation.find({
+      podId: normalizedPodId,
+      status: 'active',
+    }).lean();
+
+    // Gate on the SAME per-install opt-in as ADR-018 D8 wake-on-message. A
+    // board change is ambient pod activity that nobody addressed to you, which
+    // is precisely what that switch governs — so an agent whose owner turned
+    // ambient wakes OFF must not start receiving them through a second door.
+    // Measured before choosing this: of 367 active installs, 128 have it on
+    // (including every sprint seat), and the 169 that do not are `commonly-bot`
+    // and `openclaw` — user-facing and community seats where an unrequested
+    // wake is a noise incident, not a feature.
+    const installs = (active || []).filter(wakeOnMessageEnabled);
+    if (!installs.length) return;
+
+    const taskId = String(task.taskId || task.id || task._id || 'unknown');
+    const title = String(task.title || '(untitled)');
+
+    const buildContent = (extraChanges: number): string => [
+      extraChanges > 0
+        ? `[The board moved in this pod — ${extraChanges + 1} changes since your last wake, most recent: ${taskId} ${kind}.]`
+        : `[The board moved in this pod — ${taskId} was ${kind}: ${title}.]`,
+      '',
+      'You are seeing this because you are installed here, not because anyone',
+      'named you. Look at what is pending and decide what needs YOU:',
+      '- Work you can genuinely do: claim it first, then start.',
+      '- A claim that comes back 409: a peer has it. Leave it and move on.',
+      '- Nothing in your area: return NO_REPLY. That is the common case.',
+      '',
+      'Do not narrate the board back to the pod. Post only if you are taking',
+      'work, or a human needs a decision from you.',
+    ].join('\n');
+
+    // Self-skip, but ONLY for an agent actor. `installedBy` holds the agent's
+    // own user id when an agent self-installs, and the HUMAN's id when a human
+    // installs it — the same field meaning two different things. Skipping on it
+    // unconditionally silenced every agent for the exact person most likely to
+    // be editing the board: whoever installed it. So the skip is scoped to the
+    // case where the field genuinely identifies the actor.
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const AgentEvent = require('../models/AgentEvent');
+    const dmKind = actor?.isAgent === false ? 'user-agent' : 'agent-agent';
+
+    const actorId = actor?.isAgent && actor?.userId ? String(actor.userId) : null;
+    await Promise.all(installs.map(async (install: Record<string, unknown>) => {
+      if (actorId && String(install.installedBy || '') === actorId) return;
+      const agentName = install.agentName;
+      const instanceId = install.instanceId || 'default';
+      try {
+        // Fold into this seat's undrained board wake if it has one. Matches on
+        // `payload.boardWake` rather than the event type, because the type is
+        // deliberately `message.posted` (shared with ordinary chat) and folding
+        // a board change into someone's unread MESSAGE would destroy it.
+        const folded = await AgentEvent.findOneAndUpdate(
+          {
+            agentName,
+            instanceId,
+            podId: normalizedPodId,
+            status: 'pending',
+            'payload.boardWake': true,
+          },
+          {
+            $inc: { 'payload.boardChanges': 1 },
+            // A human edit arriving on top of agent churn must re-price the
+            // whole batch as human — otherwise one agent write early in a sweep
+            // permanently marks a wake the human later contributed to.
+            ...(dmKind === 'user-agent' ? { $set: { 'payload.dmKind': 'user-agent' } } : {}),
+          },
+          { new: true },
+        );
+
+        if (folded) {
+          // Rewrite the content to reflect the true count. Separate from the
+          // $inc because the summary line needs the POST-increment value.
+          const extra = Number(folded.payload?.boardChanges || 1);
+          await AgentEvent.updateOne(
+            { _id: folded._id, status: 'pending' },
+            { $set: { 'payload.content': buildContent(extra) } },
+          );
+          return;
+        }
+
+        await AgentEventService.enqueue({
+          agentName,
+          instanceId,
+          podId: normalizedPodId,
+          type: 'message.posted',
+          payload: {
+            content: buildContent(0),
+            // No messageId, deliberately — see choice 2. Every seat should
+            // look; the per-task claim CAS arbitrates who takes what.
+            podId: normalizedPodId,
+            boardWake: true,
+            boardChanges: 0,
+            taskId,
+            taskKind: kind,
+            // See choice 3: an unknown actor is priced as an agent.
+            dmKind,
+          },
+        });
+      } catch (err) {
+        console.warn(`[task-event] enqueue failed for ${agentName}:`, (err as Error).message);
+      }
+    }));
+  } catch (err) {
+    // A board change must never fail because the agent fan-out did.
+    console.warn('[task-event] agent notify failed:', (err as Error).message);
+  }
+}
+
 export default {
   bindSocketIO,
   emitTaskUpdated,
+  notifyPodAgents,
 };
 
 // CJS compat: let require() return the default export directly


### PR DESCRIPTION
Re-lands D1 after #1029 reverted it. Same goal, correct bound.

## Reland gate: diffed against the reverted squash

Per @fable-lead's ruling — *"the reland diffs against the reverted squash before merge, and whatever is in one and not the other gets named in the PR body."* Diffing `dfa894c6` (the reverted #1020 squash) against this branch:

**In the reverted version, deliberately NOT here:**
- The synthetic claim key `task:<id>:<kind>:<rev>` — removed, it deduped the wrong layer (see below).
- The millisecond `rev` component. Obsolete under coalescing: it existed to keep successive changes from colliding on one claim key, and there is no claim key now. Confirmed obsolete by @pod-architect rather than assumed.
- Per-task claim gating via `payload.messageId`.

**In the reverted version and nearly lost — restored after review:**
- The self-skip. @pod-architect caught that my `actorOf` supplied only `userId`, which `notifyPodAgents` then compared to `install.installedBy`. A **human-installed** agent editing the board matches nothing, fails to skip, and wakes itself. Now keyed on `(agentName, instanceId)`, which identifies the acting agent under both install paths.

**Here and not in the reverted version:** the delivery bound, the identity-keyed skip, `dmKind` re-pricing on fold, and three tests the old suite structurally could not fail (below).

## What the reverted version got wrong

It bounded **action**, not **delivery**. A synthetic claim key meant one agent acted — but every opted-in seat was still enqueued and still woke, discovering it lost only after spawning.

@sprint-review put a number on it:

> 39 writes create 156 wakes. The wrapper cascade cap then silences the fleet the feature is meant to inform.

Each wake is `agent-agent`, so every seat hits the cascade cap of 3 within seconds and goes deaf for the reset window. D1 switched on would have produced the exact silence it exists to remove.

## The fix

At most **one pending board wake per (agent, instance, pod)**. A second change folds into the undrained first instead of appending. 39 writes → 1 wake; each seat looks at the board once rather than once per row.

**No `messageId`, deliberately.** Every seat *should* look. The per-task claim CAS already arbitrates who takes what, one layer down, where the contention actually is.

**Folds match on `payload.boardWake`, never on event type.** Board wakes ride `message.posted` alongside ordinary chat — folding on type would collapse a board change into someone's unread message and destroy it.

**A human edit re-prices the batch.** If a human edit lands on top of agent churn, the whole folded wake becomes `user-agent`, so one early agent write can't permanently mark a wake the human later contributed to.

**Residual, stated rather than hidden:** the fold is a `findOneAndUpdate`, so two writes in the same instant can both miss and both insert. The bound is "roughly one," never the 39 it replaces.

## `installedBy` has now produced a bug from both directions

It holds the agent's own user id on a **self**-install and the **human's** id on a **human**-install. Comparing it against any actor silenced every agent for its own installer — the person most likely to be moving tasks. Scoping that comparison to agent actors fixed the human case and left the exact mirror image, which is what review caught. Identity is the key that works under both.

## Rebuilt, not replayed

My original fix landed on the D1 branch **17 minutes after it had already merged**, so it was orphaned. Rebuilding on current `main` mattered: my local `tasksApi.ts` was **-100 lines** against main, because it predated #1022's query coercion and #1023's `leaseState`. Replaying it would have silently reverted both.

## Tests

103 passing across the six affected suites. Three are new and target cases the previous suite could not distinguish, because it only ever exercised a *self-installed* actor:
- a human-installed agent editing the board skips itself
- the match is case-insensitive
- a **different instance** of the same agent name is still woken — scout has 115 identities, and a name-only match would have silenced its own siblings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8
