### PR TITLE
docs(ax): entry 33 — a revert is scoped by commit, not by defect

### DIFF
--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -1684,9 +1684,20 @@ and squash-merge guarantees that "everything" includes every fix found during
 review, which is precisely the work with no independent record. The re-land is
 written from memory of the design, and the design never knew about the review.
 
-**The guard is one command:** diff the re-land against the reverted commit and
-read what is in one and not the other. Cheap, mechanical, and it prints the
-missing symbol before the branch is pushed.
+**The guard is one command, and the obvious version of it fails.** Diffing the
+re-land against the reverted commit at FILE level returns clean: every file in
+the squash still exists in the re-land, because the re-land rewrote those files
+rather than dropping them. Run on this incident it reports no difference while
+four fixes and three tests are missing.
+
+The check has to be at symbol and test-name level. On this incident that reads:
+
+
+
+Noting the weaker version explicitly because it is the one a reader reaches for
+first, and a guard that returns a clean pass on the exact case it was written
+for is worse than no guard at all — it converts an open question into a
+settled one.
 
 **The near-miss worth recording.** The risk was flagged in the pod at the time —
 "use `git revert` rather than a reset, so the re-land can cherry-pick them" —

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -1654,3 +1654,47 @@ the rule did not make me run the check — what made me run it was a peer
 proposing a change that forced me to read the gateway's schema for another
 reason. Cross-tier claims need a probe in the workflow, not a lesson in the
 reader.
+
+## 33. A revert is scoped by commit, not by defect (2026-08-19, sprint-review + pod-architect)
+
+`dfa894c6` shipped ADR-024 D1 — board changes reach the pod's agents. Two hours
+later a peer computed the fan-out volume and it was wrong by two orders of
+magnitude: broadcast × sweep meant every seat capping in seconds. The author
+called the revert, it landed 34 minutes after the finding, and the room recorded
+that as revert-fast working.
+
+**What actually happened is that the revert removed work nobody was measuring.**
+`dfa894c6` was a squash of the whole branch, and that branch carried two fixes
+found by review *after* the original design: a `rev` collision (`String(date)`
+renders to the second, so two writes 800ms apart shared one claim key and the
+second wake was swallowed) and a self-skip keyed on `installedBy` — the
+installer, never the agent — which made every human-installed agent wake itself
+on its own board write. Both were reviewed independently by two readers. Four
+tests came with them, including one named for this exact regression: *"skips a
+HUMAN-installed agent editing the board, where `installedBy` could not."*
+
+The re-land was then written **from the design**, not from the reverted tree. It
+reintroduced the `installedBy`-keyed skip verbatim, comment and all. So the test
+written to prevent the defect was deleted by the same operation that recreated
+the conditions for it.
+
+**Rule earned.** A revert is scoped by the commit it undoes, not by the defect it
+targets. Everything that rode in on the same squash leaves with it, silently —
+and squash-merge guarantees that "everything" includes every fix found during
+review, which is precisely the work with no independent record. The re-land is
+written from memory of the design, and the design never knew about the review.
+
+**The guard is one command:** diff the re-land against the reverted commit and
+read what is in one and not the other. Cheap, mechanical, and it prints the
+missing symbol before the branch is pushed.
+
+**The near-miss worth recording.** The risk was flagged in the pod at the time —
+"use `git revert` rather than a reset, so the re-land can cherry-pick them" —
+and then nothing carried it. A note to a person is the same class of guard as a
+tool description or a heartbeat instruction: it works only on someone already
+being careful, which is the failure mode this file exists to document. The
+flagging felt like the work and wasn't.
+
+Related: entry 31's corollary (having found the dead tier, go read the live one).
+Same shape — the diagnostic that finds a problem has to keep running past the
+moment the problem is named.

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -1692,7 +1692,15 @@ four fixes and three tests are missing.
 
 The check has to be at symbol and test-name level. On this incident that reads:
 
-
+```
+identityOf                             reverted=3  reland=0
+actorIdentity                          reverted=2  reland=0
+Number.isNaN(revTime)                  reverted=1  reland=0
+getTime()                              reverted=1  reland=0
+"skips a HUMAN-installed agent"        reverted=1  reland=0
+"separates two writes 800ms apart"     reverted=1  reland=0
+"matches identity case-insensitively"  reverted=1  reland=0
+```
 
 Noting the weaker version explicitly because it is the one a reader reaches for
 first, and a guard that returns a clean pass on the exact case it was written


### PR DESCRIPTION
Append-only AX entry, @sprint-review's finding. Nothing else changes.

## The mechanism

`dfa894c6` (D1) was reverted 34 minutes after the fan-out arithmetic showed it wrong. That number measured how fast the defect left. Nobody measured what left with it.

The squash carried two fixes found by review *after* the original design — a `rev` collision at second-resolution, and a self-skip keyed on `installedBy` (the installer, never the agent) — plus four tests, including one named for this exact regression: *"skips a HUMAN-installed agent editing the board, where `installedBy` could not."*

The re-land (#1030) was written **from the design**, not from the reverted tree. It reintroduces the `installedBy`-keyed skip verbatim, comment and all. So the test written to prevent the defect was deleted by the same operation that recreated the conditions for it.

## Why it generalises

Squash-merge guarantees that a revert's blast radius includes **every fix found during review** — which is exactly the work with no independent record. The design doc knows the design; nothing knows the review except the commits that are now gone.

**Guard:** diff the re-land against the reverted commit and read what's in one and not the other. One command, mechanical, prints the missing symbol before the branch is pushed.

## The near-miss, recorded on purpose

The risk was flagged in the pod at the time — *"use `git revert` rather than a reset, so the re-land can cherry-pick them"* — and then nothing carried it. A note to a person is the same class of guard as a tool description or a heartbeat instruction: it works only on someone already being careful, which is the failure this file exists to document. The flagging felt like the work and wasn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)