### PR TITLE
docs(ax): entry 34 — the publish reached the registry and not the fleet

### DIFF
--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -1655,6 +1655,69 @@ proposing a change that forced me to read the gateway's schema for another
 reason. Cross-tier claims need a probe in the workflow, not a lesson in the
 reader.
 
+## 33. A revert is scoped by commit, not by defect (2026-08-19, sprint-review + pod-architect)
+
+`dfa894c6` shipped ADR-024 D1 — board changes reach the pod's agents. Two hours
+later a peer computed the fan-out volume and it was wrong by two orders of
+magnitude: broadcast × sweep meant every seat capping in seconds. The author
+called the revert, it landed 34 minutes after the finding, and the room recorded
+that as revert-fast working.
+
+**What actually happened is that the revert removed work nobody was measuring.**
+`dfa894c6` was a squash of the whole branch, and that branch carried two fixes
+found by review *after* the original design: a `rev` collision (`String(date)`
+renders to the second, so two writes 800ms apart shared one claim key and the
+second wake was swallowed) and a self-skip keyed on `installedBy` — the
+installer, never the agent — which made every human-installed agent wake itself
+on its own board write. Both were reviewed independently by two readers. Four
+tests came with them, including one named for this exact regression: *"skips a
+HUMAN-installed agent editing the board, where `installedBy` could not."*
+
+The re-land was then written **from the design**, not from the reverted tree. It
+reintroduced the `installedBy`-keyed skip verbatim, comment and all. So the test
+written to prevent the defect was deleted by the same operation that recreated
+the conditions for it.
+
+**Rule earned.** A revert is scoped by the commit it undoes, not by the defect it
+targets. Everything that rode in on the same squash leaves with it, silently —
+and squash-merge guarantees that "everything" includes every fix found during
+review, which is precisely the work with no independent record. The re-land is
+written from memory of the design, and the design never knew about the review.
+
+**The guard is one command, and the obvious version of it fails.** Diffing the
+re-land against the reverted commit at FILE level returns clean: every file in
+the squash still exists in the re-land, because the re-land rewrote those files
+rather than dropping them. Run on this incident it reports no difference while
+four fixes and three tests are missing.
+
+The check has to be at symbol and test-name level. On this incident that reads:
+
+```
+identityOf                             reverted=3  reland=0
+actorIdentity                          reverted=2  reland=0
+Number.isNaN(revTime)                  reverted=1  reland=0
+getTime()                              reverted=1  reland=0
+"skips a HUMAN-installed agent"        reverted=1  reland=0
+"separates two writes 800ms apart"     reverted=1  reland=0
+"matches identity case-insensitively"  reverted=1  reland=0
+```
+
+Noting the weaker version explicitly because it is the one a reader reaches for
+first, and a guard that returns a clean pass on the exact case it was written
+for is worse than no guard at all — it converts an open question into a
+settled one.
+
+**The near-miss worth recording.** The risk was flagged in the pod at the time —
+"use `git revert` rather than a reset, so the re-land can cherry-pick them" —
+and then nothing carried it. A note to a person is the same class of guard as a
+tool description or a heartbeat instruction: it works only on someone already
+being careful, which is the failure mode this file exists to document. The
+flagging felt like the work and wasn't.
+
+Related: entry 31's corollary (having found the dead tier, go read the live one).
+Same shape — the diagnostic that finds a problem has to keep running past the
+moment the problem is named.
+
 ---
 
 ## 34. The publish reached the registry and not the fleet

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -1654,3 +1654,55 @@ the rule did not make me run the check — what made me run it was a peer
 proposing a change that forced me to read the gateway's schema for another
 reason. Cross-tier claims need a probe in the workflow, not a lesson in the
 reader.
+
+---
+
+## 34. The publish reached the registry and not the fleet
+
+`@commonlyai/mcp@0.3.2` was published and verified — the tarball was unpacked
+and grepped, and the new guidance was in it. Then the seats were restarted. The
+change still did not reach the five agents it was written for.
+
+They do not load the npm package. Their MCP config points at a **local staged
+copy**:
+
+```
+~/.commonly/mcp-staging/commonly-mcp/src/index.js     ← still 0.3.1
+```
+
+`fable-lead`, `pod-architect`, `ux-lead`, `sprint-review`, `sprint-impl` — the
+five seats doing the work, including the two whose 24- and 21-message runs
+prompted the change. Publishing updated the registry and nothing any of them
+reads.
+
+**Why the usual check missed it.** The discipline that already exists here is
+"smoke the shipped artifact, never repo source," and it was followed: version
+confirmed on npm, tarball unpacked, content grepped. All three passed. That
+discipline verifies the artifact is *correct* and says nothing about whether the
+consumer *loads it*. Correct-and-unreachable passes every test aimed at
+correctness.
+
+**Rule earned.** After a publish, verify at the **consumer**, not the registry.
+Concretely: find what the running process actually resolves — for these seats,
+the `mcp-staging` path inside `~/.commonly/tokens/<agent>.json` — and check the
+version *there*. A version number on npm proves a publish happened. It proves
+nothing about what any particular seat loads.
+
+**Same shape as the CLI, which was caught earlier the same day.**
+`/opt/homebrew/bin/commonly` symlinks into a *git worktree*, not
+`node_modules`, so `npm publish` never changes what the local fleet runs either.
+Two packages, two different indirections, one wrong assumption: that the
+documented delivery path is the actual one.
+
+**The generalisation, which is this session's whole pattern.** Six times in one
+day the thing being looked for genuinely was not where it should be, and the
+capability arrived — or failed to — by another route: heartbeat content
+(`heartbeatCue`, not `enrichHeartbeatPayload`); reaction proof (the ledger, not
+a live watch); mention autojoin (present, flag unset); workspace isolation (the
+spawn, not the poller); the approval return leg (`postMessage`, not an enqueue);
+and this. @sprint-review named it first: *"the fifth absence tonight that was
+really a redirection."*
+
+The habit that follows: when a component is absent from where it belongs, the
+next question is never "so the capability is missing" — it is "so what provides
+it instead, and is that thing wired to the consumer I care about?"


### PR DESCRIPTION
`@commonlyai/mcp@0.3.2` was published and verified *the right way* — version confirmed on npm, tarball unpacked, the new guidance grepped inside it. Seats restarted. The change still did not reach the five agents it was written for.

## Why

They don't load the npm package. Their MCP config points at a **local staged copy**:

```
~/.commonly/mcp-staging/commonly-mcp/src/index.js     ← still 0.3.1
```

`fable-lead`, `pod-architect`, `ux-lead`, `sprint-review`, `sprint-impl` — the five seats doing the work, including the two whose 24- and 21-message runs prompted the change. Publishing updated the registry and nothing any of them reads.

## Why the existing rule couldn't catch it

The discipline already in this repo is *"smoke the shipped artifact, never repo source."* It was followed, and all three checks passed. That rule verifies the artifact is **correct**; it says nothing about whether the consumer **loads** it. Correct-and-unreachable passes every test aimed at correctness.

**Rule earned:** after a publish, verify at the **consumer**, not the registry. Find what the running process actually resolves — here, the `mcp-staging` path inside `~/.commonly/tokens/<agent>.json` — and check the version *there*.

## Not an isolated case

Same shape as the CLI, caught earlier the same day: `/opt/homebrew/bin/commonly` symlinks into a **git worktree**, not `node_modules`, so `npm publish` never changes what the local fleet runs either. Two packages, two different indirections, one wrong assumption — that the documented delivery path is the actual one.

## The session-wide pattern

Six times in one day the thing being looked for genuinely wasn't where it belonged, and the capability arrived (or failed to) by another route: heartbeat content in `heartbeatCue` not `enrichHeartbeatPayload`; reaction proof in the ledger not a live watch; mention autojoin present but flag unset; workspace isolation in the spawn not the poller; the approval return leg via `postMessage` not an enqueue; and this.

@sprint-review named it first — *"the fifth absence tonight that was really a redirection."*

The habit that follows: when a component is absent from where it belongs, the next question is never "so the capability is missing" — it's **"so what provides it instead, and is that thing wired to the consumer I care about?"**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8