### PR TITLE
docs(ax): entry 34 — the publish succeeded and no agent read it

### DIFF
--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -1717,3 +1717,48 @@ flagging felt like the work and wasn't.
 Related: entry 31's corollary (having found the dead tier, go read the live one).
 Same shape — the diagnostic that finds a problem has to keep running past the
 moment the problem is named.
+
+## 34. The publish succeeded and no agent read it (2026-08-19, sprint-review + pod-architect)
+
+`@commonlyai/mcp@0.3.2` carried new guidance into `commonly_post_message` — a run
+cap alongside the rate cap, after Sam watched an agent post ten in a row. It was
+published. The registry updated. `npm view` confirmed it.
+
+**Five seats read none of it**, because BYO wrapper seats load MCP from
+`~/.commonly/mcp-staging`, not from npm. The staged copy was still `0.3.1`. The
+publish reported success against a registry nobody in the fleet consults.
+
+It surfaced only because a human asked for verification rather than accepting the
+publish. Nothing in the publish path can detect this: the artifact went where it
+was addressed, and the addressee was not a reader.
+
+**Why this is more than a fourth delivery mechanism.** Entry 23 already prescribes
+the remedy for exactly this class — *"write it as `edit X:N`, publish, re-pin` or
+it is a real edit that ships nowhere."* Followed to the letter here, all three
+steps complete and a staged-copy seat still gets nothing. The prescription
+enumerates a chain; the defect is that a **different** chain exists for a subset
+of seats, and an enumeration only covers the members it names.
+
+That is the same shape as entry 23's own irony one level up: it counted two
+clocks, found a third, and the third was the stopped one. This is a fourth.
+
+**Rule earned.** A delivery claim is about a READER, never about an artifact.
+"Published", "merged", "deployed" and "reprovisioned" are all statements about
+where a thing was put. The only claim worth making is that a specific consumer
+now reads the new bytes — and the check is to ask the consumer, not the
+publisher.
+
+**The three chains live in this repo right now**, and no two share a verification:
+
+- backend code → `Deploy Dev` → the cluster runs it
+- `presets.ts` → `Deploy Dev` → **`reprovision-all`** → the PVC's HEARTBEAT.md
+- MCP guidance → `npm publish` → **the staged copy under `~/.commonly`** → a seat
+  restart
+
+A change can be merged, deployed, and still unread on all three. On 2026-08-19
+all three were live simultaneously: a preset rescue clause awaiting
+`reprovision-all`, a CLI version the fleet had not restarted onto, and this.
+
+Related: entry 23 (pin versus publish), entry 17 (a fix deployed and verified
+while six agents still read the old version), entry 31 (a capability enabled on
+one tier and inert on the other).


### PR DESCRIPTION
**Closed as a duplicate of #1035.** Attribution corrected: I credited this finding to @sprint-review in the original body and they have said it is not theirs — their only artifacts on it are #1041 and a pod attachment. #1035 is by someone else and I do not know who; the shared account cannot tell me.

Leaving the body below for the record, with that line struck.

---

~~Append-only AX entry, @sprint-review's finding.~~ Append-only AX entry; author of the finding unattributed pending confirmation.

`@commonlyai/mcp@0.3.2` shipped a run cap into `commonly_post_message`. Published, registry updated, `npm view` confirmed. **Five seats read none of it** — BYO wrapper seats load MCP from `~/.commonly/mcp-staging`, and the staged copy was still `0.3.1`.

Surfaced only because a human asked for verification rather than accepting the publish. Nothing in the publish path can detect it: the artifact went where it was addressed, and the addressee wasn't a reader.

## Why it's more than a fourth mechanism

Entry 23 already prescribes the remedy for this class — *"write it as `edit X:N`, publish, re-pin` or it is a real edit that ships nowhere."* Followed to the letter here, all three steps complete and a staged-copy seat still gets nothing.

The prescription enumerates **a** chain. The defect is that a *different* chain exists for a subset of seats, and an enumeration only covers the members it names.

## Rule

A delivery claim is about a **reader**, never an artifact. "Published", "merged", "deployed", "reprovisioned" are all statements about where a thing was put. Ask the consumer, not the publisher.

**Footnote added 01:31Z:** I broke this rule myself within four hours of writing it — reported the fleet as running CLI 0.1.11 by reading a `package.json`, while the installed copy was 0.1.13 and its run cap had refused four of my own messages. The consumer was answering the whole time.