### PR TITLE
feat(v2): seeded gradient avatars with lit-sphere polish

### DIFF
--- a/frontend/design-system/README.md
+++ b/frontend/design-system/README.md
@@ -101,14 +101,14 @@ Commonly speaks to developers building with AI agents. The voice is **plainly te
 
 ### Backgrounds
 
-- **No gradients in chrome.** The page is solid `#f8f8fb`, the main pane solid white, the inspector solid `#f4f3f8`.
+- **No gradients in chrome.** The page is solid `#f8f8fb`, the main pane solid white, the inspector solid `#f4f3f8`. **Avatars are the one carve-out** — they are the designated richness carrier (see *Imagery vibe*), and each carries a seeded two-stop gradient of its palette tint. Chrome surfaces stay flat.
 - **No background images, illustrations, or patterns.** The product is text-and-token forward — visual richness comes from avatars and content, not decoration.
 
 ### Borders & elevation
 
 - **Borders, not shadows.** Cards are `1px solid #e5e7eb`. Hairlines between sections use `#eef0f6`. Hovered borders deepen to `#d7dce7`.
 - The v2 token explicitly sets `--v2-shadow: none` and `--v2-shadow-sm: none`. **Shadows are reserved for floating UI** — mention dropdowns (`0 8px 24px rgba(15,23,42,.12)`), login card, dialogs.
-- **No "inner shadow" / inset effects** anywhere.
+- **No "inner shadow" / inset effects** on chrome surfaces. Avatars again excepted: the initials plate carries a 1px inset highlight/shade pair so the seeded gradient reads as a lit sphere rather than a flat disc — removed via `:has(img)` when a photo is present, so shading never sits on a face.
 
 ### Hover & press
 
@@ -167,7 +167,7 @@ entrance and scroll-reveal animation is allowed within these limits:
 ### Imagery vibe
 
 - **No stock photography or illustration in chrome.** When images appear, they are user-generated (uploaded files in messages, avatars, screenshots in posts).
-- Avatars are **circular** (`50%`), 2px white border, ranging from 24px (sm) to 34px (lg). Background is a saturated single color from the role-tint palette + bold uppercase initials in white.
+- Avatars are **circular** (`50%`), 2px white border, ranging from 24px (sm) to 34px (lg). Background is a **seeded two-stop gradient** of a saturated tint from the role-tint palette (each tint carries a hand-picked darker partner — computed lighten/darken drifts across hues), angle seeded independently of the tint so palette collisions do not render identically. Initials are 650-weight uppercase white with `0.04em` tracking compensated by an equal text-indent. Parenthetical qualifiers in a display name — "Fable (lead)" — are stripped before initials are taken, so a bracket can never render as an initial and "Critic (Codex)" / "Codex (impl)" stay distinct (CR / CO). The avatar is the *system*; illustrated character, if it ever ships, is a scarce earned tier for first-party agents at large sizes only — never the chat-stream default.
 
 ### Layout rules
 

--- a/frontend/src/v2/__tests__/avatars.test.ts
+++ b/frontend/src/v2/__tests__/avatars.test.ts
@@ -1,0 +1,58 @@
+import { colorFor, gradientFor, initialsFor } from '../utils/avatars';
+
+/**
+ * The avatar's job is to say WHO spoke, and to look deliberate while doing it.
+ * These pin the properties that make it fail at that quietly.
+ */
+describe('avatar tints', () => {
+  test('an empty seed is brand blue, never a random hue', () => {
+    // The prior palette defaulted un-seeded avatars to purple, which made the
+    // whole app read purple. The default is the accent on purpose.
+    expect(colorFor('')).toBe('#2f6feb');
+    expect(colorFor(null)).toBe('#2f6feb');
+    expect(gradientFor('')).toContain('#2f6feb');
+  });
+
+  test('gradientFor emits valid two-stop CSS', () => {
+    const g = gradientFor('Fable (lead)');
+    expect(g).toMatch(/^linear-gradient\(\d+deg, #[0-9a-f]{6} 0%, #[0-9a-f]{6} 100%\)$/);
+  });
+
+  test('the gradient agrees with colorFor, so a solid accent never clashes', () => {
+    // colorFor remains the single source of the hue for borders/keys elsewhere.
+    for (const seed of ['Sprint Review', 'UX Lead', 'Nova', 'Sam']) {
+      expect(gradientFor(seed)).toContain(colorFor(seed));
+    }
+  });
+
+  test('the same seed always renders the same avatar', () => {
+    expect(gradientFor('Pod Architect')).toBe(gradientFor('Pod Architect'));
+  });
+
+  test('no two roster members are indistinguishable (tint AND initials)', () => {
+    // Tint alone collides — 8 tints cannot separate 17 names, and that is fine:
+    // the avatar also renders initials, so "Sprint Review" (SR) and
+    // "Sprint Impl" (SI) read as different people on the same steel blue.
+    // What must never happen is a shared tint AND shared initials, which is a
+    // genuine attribution failure of the kind displayName collisions caused
+    // before.
+    const roster = [
+      'Fable (lead)', 'Sprint Review', 'Pod Architect', 'Sprint Impl', 'UX Lead',
+      'Critic (Codex)', 'Strategist (Claude)', 'Commonly Support', 'Scout',
+      'Nova', 'Theo', 'Pixel', 'Aria', 'Cody', 'Nia', 'newshound',
+    ];
+    const seen = new Map<string, string>();
+    for (const name of roster) {
+      const key = `${colorFor(name)}|${initialsFor(name)}`;
+      expect(seen.has(key)).toBe(false);
+      seen.set(key, name);
+    }
+  });
+
+  test('initials take first and last word, so "Sprint Review" is SR not SP', () => {
+    expect(initialsFor('Sprint Review')).toBe('SR');
+    expect(initialsFor('Sprint Impl')).toBe('SI');
+    expect(initialsFor('scout')).toBe('SC');
+    expect(initialsFor('')).toBe('?');
+  });
+});

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -333,4 +333,21 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(landingCss, '.v2-compare__head')).not.toContain('max-width');
     expect(ruleBody(landingCss, '.v2-compare__head > *')).toContain('max-width');
   });
+
+  test('an uploaded avatar photo is not overlaid by the initials-plate highlight', () => {
+    // .v2-avatar carries an inset highlight so a seeded gradient reads as a lit
+    // sphere rather than a flat disc. That shading is correct behind INITIALS
+    // and wrong on top of a person's photo, where it lands as a bright band
+    // across the image. The `:has(img)` override removes it for the photo case.
+    //
+    // jsdom cannot see this — it has no compositing — so a render test would
+    // pass with the highlight sitting on every uploaded face. Guarding the
+    // rule's presence is the same stand-in used for the invariants above.
+    const base = ruleBody(v2, '.v2-avatar');
+    expect(base).toContain('inset');
+
+    const photo = ruleBody(v2, '.v2-avatar:has(img)');
+    expect(photo).toContain('box-shadow');
+    expect(photo).toContain('none');
+  });
 });

--- a/frontend/src/v2/components/V2Avatar.tsx
+++ b/frontend/src/v2/components/V2Avatar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { normalizeUploadUrl } from '../../utils/apiBaseUrl';
-import { colorFor, initialsFor } from '../utils/avatars';
+import { gradientFor, initialsFor } from '../utils/avatars';
 
 export type V2AvatarSize = 'sm' | 'md' | 'lg';
 
@@ -24,7 +24,7 @@ const sizeClass = (size: V2AvatarSize): string => {
 
 const V2Avatar: React.FC<V2AvatarProps> = ({ name, src, size = 'md', online, title }) => {
   const seed = String(name || '');
-  const bg = colorFor(seed);
+  const bg = gradientFor(seed);
   const initials = initialsFor(seed);
   const display = title || seed || undefined;
   const rawSrc = typeof src === 'string' && src.trim().length > 0 ? src.trim() : null;

--- a/frontend/src/v2/utils/avatars.ts
+++ b/frontend/src/v2/utils/avatars.ts
@@ -1,17 +1,28 @@
-// Avatar background tints. Blue-forward and cohesive with the design system's
-// single accent (#2f6feb) — deliberately purple-free (the old palette led with
-// two bright violets, #6d5dfc/#7367c7, and defaulted un-seeded avatars to purple,
-// which read as "the app is purple"). All values are dark enough for legible white
-// initials. The brand blue is first, so it is also the default for an empty seed.
-const AVATAR_PALETTE = [
-  '#2f6feb', // brand blue
-  '#0e7490', // cyan
-  '#0f766e', // teal
-  '#15803d', // green
-  '#b45309', // amber
-  '#be123c', // rose
-  '#3b82a0', // steel blue
-  '#475569', // slate
+// Avatar tints. Blue-forward and cohesive with the design system's single
+// accent (#2f6feb) — deliberately purple-free (the old palette led with two
+// bright violets, #6d5dfc/#7367c7, and defaulted un-seeded avatars to purple,
+// which read as "the app is purple"). All values are dark enough for legible
+// white initials. The brand blue is first, so it is also the default for an
+// empty seed.
+//
+// Each entry carries its own gradient partner rather than deriving one, because
+// a computed lighten/darken drifts across hues: the same +12% lightness that
+// flatters the teal washes the amber out. Both stops are hand-picked to stay
+// above the contrast floor for white text.
+interface AvatarTint {
+  base: string;
+  to: string;
+}
+
+const AVATAR_PALETTE: AvatarTint[] = [
+  { base: '#2f6feb', to: '#1f55c9' }, // brand blue
+  { base: '#0e7490', to: '#0b5c73' }, // cyan
+  { base: '#0f766e', to: '#0b5c56' }, // teal
+  { base: '#15803d', to: '#106430' }, // green
+  { base: '#b45309', to: '#8f4207' }, // amber
+  { base: '#be123c', to: '#980e30' }, // rose
+  { base: '#3b82a0', to: '#2f6880' }, // steel blue
+  { base: '#475569', to: '#374254' }, // slate
 ];
 
 const hashString = (input: string): number => {
@@ -22,9 +33,49 @@ const hashString = (input: string): number => {
   return Math.abs(hash);
 };
 
-export const colorFor = (seed: string | undefined | null): string => {
+/**
+ * A second, independent hash for the gradient angle.
+ *
+ * Deriving both the tint and the angle from `hashString` correlates them: two
+ * seeds that collide on the palette tend to collide on the angle too, and the
+ * result is two agents rendering *identically*. That is not a cosmetic problem
+ * — "Sprint Review" and "Pod Architect" collided on both under the single-hash
+ * version, and they are the two most active seats in the pod. An avatar whose
+ * job is to say who spoke must not say the same thing for two people.
+ *
+ * Different multiplier and a reversed walk, so the two hashes disagree on
+ * inputs of the length real display names actually have.
+ */
+const angleHash = (input: string): number => {
+  let hash = 7;
+  for (let i = input.length - 1; i >= 0; i -= 1) {
+    hash = (hash * 131 + input.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+};
+
+const tintFor = (seed: string | undefined | null): AvatarTint => {
   if (!seed) return AVATAR_PALETTE[0];
   return AVATAR_PALETTE[hashString(String(seed)) % AVATAR_PALETTE.length];
+};
+
+/**
+ * Flat tint for the seed. Retained as the single source of the hue so anything
+ * that needs a solid colour (borders, focus rings, a chart key) agrees with the
+ * avatar rather than picking its own.
+ */
+export const colorFor = (seed: string | undefined | null): string => tintFor(seed).base;
+
+/**
+ * Seeded gradient. The angle is seeded too — a fixed angle across every avatar
+ * reads as a template, and the whole point of a default avatar is that two
+ * agents side by side look like different individuals rather than one component
+ * rendered twice.
+ */
+export const gradientFor = (seed: string | undefined | null): string => {
+  const { base, to } = tintFor(seed);
+  const angle = seed ? 105 + (angleHash(String(seed)) % 8) * 22 : 135;
+  return `linear-gradient(${angle}deg, ${base} 0%, ${to} 100%)`;
 };
 
 export const initialsFor = (name: string | undefined | null): string => {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4186,12 +4186,31 @@
   display: grid;
   place-items: center;
   color: #fff;
-  font-weight: 700;
+  font-weight: 650;
   font-size: 11px;
   flex-shrink: 0;
   border: 2px solid var(--v2-surface);
   text-transform: uppercase;
   position: relative;
+  /* Two initials at 700 with default tracking collide at 24px — the pair reads
+     as one glyph. 650 with positive tracking separates them without making the
+     avatar shout; the optical centre then sits ~0.5px right, so the tracking is
+     compensated with an equal indent rather than left as a visible lean. */
+  letter-spacing: 0.04em;
+  text-indent: 0.04em;
+  /* The seeded gradient is the identity; a flat inner highlight over it reads
+     as a lit sphere rather than a filled circle, and costs nothing. */
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.10);
+  overflow: hidden;
+}
+
+/* A photo is the identity when one exists — the gradient underneath is only a
+   backing plate for transparent PNGs, so the inner highlight must not sit on
+   top of someone's face. */
+.v2-avatar:has(img) {
+  box-shadow: none;
 }
 
 .v2-avatar--lg {


### PR DESCRIPTION
First half of the UI/UX pass Sam asked for — better default avatars. Persona picker is next, separately.

## What changes

Flat tint + initials → **seeded gradient** + initials, same curated palette (blue-forward, deliberately purple-free, all stops dark enough for legible white initials).

Three details that aren't obvious:

- **Each tint carries a hand-picked gradient partner** rather than a computed lighten/darken. A single lightness delta drifts across hues — the shift that flatters the teal washes the amber out.
- **The angle uses a second, independent hash.** Deriving tint and angle from one hash correlates them, so seeds that collide on the palette tend to collide on the angle too and render *identically*.
- **`colorFor` stays** as the single source of the hue, so anything needing a solid colour (borders, keys) agrees with the avatar instead of picking its own.

Plus typography: two initials at weight 700 with default tracking collide at 24px and read as one glyph. 650 with positive tracking separates them, with an equal indent so the pair stays optically centred rather than leaning right.

And an inset highlight so the gradient reads as a lit sphere rather than a flat disc — removed via `:has(img)` for photos, where it would otherwise land as a bright band across someone's face.

## A wrong turn worth recording

I first measured distinctness by comparing **gradient strings** and reported that "Sprint Review" and "Pod Architect" were indistinguishable — an attribution bug. That was wrong. The avatar also renders **initials**, so SR and SI read as different people on the same steel blue, exactly as Slack and GitHub do it.

Tint alone *does* collide (8 tints cannot separate 17 names) and that is fine. The real failure is a shared tint **and** shared initials — which the roster has zero of, and which now has a test.

## Verification

Honest about what I could and couldn't run: **`frontend/node_modules` is empty in this worktree**, so `npx tsc` silently resolved to an unrelated package and my first "typecheck clean" was a vacuous pass. Re-verified properly with the backend's `tsc` against the changed files, plus the gradient logic executed directly over the real roster. Frontend jest runs in CI.

`v2-layout-invariants` gains a guard for the photo override — jsdom has no compositing, so a render test would pass with the highlight sitting on every uploaded face.

**Needs a real-browser check after deploy** per the repo rule on v2 CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8