### PR TITLE
test(cli): pin dmKind ahead of the messageId check in classifyTrigger

### DIFF
--- a/cli/__tests__/enforcement.test.mjs
+++ b/cli/__tests__/enforcement.test.mjs
@@ -36,6 +36,24 @@ describe('classifyTrigger', () => {
     expect(classifyTrigger(event({ dmKind: 'user-agent', messageId: 'm1' }), [])).toBe('human');
   });
 
+  // ADR-024 D1 board wakes carry `dmKind` and NO `messageId` — deliberately, so
+  // every opted-in seat looks and the per-task claim CAS arbitrates
+  // (taskEventService.ts:237). That backend comment is only safe because the
+  // dmKind branches sit ABOVE the messageId check here. Move the messageId
+  // check up, or add an early `if (!p.messageId) return 'unknown'`, and every
+  // board wake classifies 'unknown' — which by design neither counts toward the
+  // cascade cap nor resets it, so the cap silently stops engaging and the
+  // 156-wake sweep this governor exists to bound comes back.
+  //
+  // The suite already asserted dmKind pricing and messageId fallback, but every
+  // dmKind case supplied a messageId and every messageId case omitted dmKind —
+  // so the one combination the backend actually emits was never exercised, and
+  // both reorderings passed 107/107.
+  test('prices by dmKind with NO messageId — the board-wake shape', () => {
+    expect(classifyTrigger(event({ dmKind: 'agent-agent' }), [])).toBe('agent');
+    expect(classifyTrigger(event({ dmKind: 'user-agent' }), [])).toBe('human');
+  });
+
   test('falls back to the trigger message isBot flag from the snapshot', () => {
     const messages = [{ _id: 'm1', isBot: true }, { _id: 'm2', isBot: false }];
     expect(classifyTrigger(event({ messageId: 'm1' }), messages)).toBe('agent');


### PR DESCRIPTION
Closes @fable-lead's stated precondition for the conditional-sweep design: *"it prices through the dmKind-before-messageId ordering 55838 just showed is load-bearing, so pin that ordering in the contract check first."*

It was not pinned. This adds the pin, with the measurement that shows why it was needed.

## The coupling

ADR-024 D1 board wakes carry `dmKind` and **no** `messageId` — deliberately, so every opted-in seat looks and the per-task claim CAS arbitrates (`backend/services/taskEventService.ts:237-238`). That backend comment is only safe because the two `dmKind` branches sit **above** the `messageId` check in `cli/src/lib/enforcement.js:48-50`.

Neither file can see the other. The backend says "no messageId, deliberately" and cannot explain why that is safe; the CLI explains `'unknown'` and never names who depends on the order.

## Measurement

Baseline `cli/__tests__/enforcement.test.mjs` + `cli/__tests__/run-loop.test.mjs`: **107/107 green**.

| mutation | result |
|---|---|
| early `if (!p.messageId) return 'unknown'` above the dmKind branches | **107/107 green** — undetected |
| `messageId` check moved above the dmKind branches | **107/107 green** — undetected |

Both break every board wake: it classifies `'unknown'`, which by `enforcement.js:252` neither counts toward the cascade cap nor resets it. The cap silently stops engaging and the 156-wake sweep the governor exists to bound comes back.

## Why the existing tests missed it

The gap was a **combination**, not a missing subject. The suite already asserted dmKind pricing (`:34`) and messageId fallback (`:39`) — but every dmKind case supplied a `messageId`, and every `messageId` case omitted `dmKind`. The one shape the backend actually emits was never exercised.

The added case fails on both mutants and passes on main.

## Not verified

- Whether a kernel-side sweep (fable-lead's proposal) would route through `notifyPodAgents` at all. If it builds its own path, `taskEventService.ts:186`'s actor→dmKind ternary doesn't bind it and the pricing question is still open, just elsewhere.
- I diffed `enforcement.js` only against the running seats, not the rest of the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)