### PR TITLE
fix(v2): avatar initials were eating the bracket

### DIFF
--- a/frontend/src/v2/__tests__/avatarInitials.test.ts
+++ b/frontend/src/v2/__tests__/avatarInitials.test.ts
@@ -1,0 +1,62 @@
+import { initialsFor } from '../utils/avatars';
+
+/**
+ * Initials are the identity on every avatar without an uploaded photo, which is
+ * nearly all of them. Getting them wrong is not a cosmetic issue — it mislabels
+ * who spoke.
+ */
+describe('initialsFor', () => {
+  test('a parenthetical qualifier never becomes an initial', () => {
+    // Shipped state: Your Team rendered "F(", "C(", "S(" and "C(" — the bracket
+    // was being taken as the second word.
+    expect(initialsFor('Fable (lead)')).toBe('FA');
+    expect(initialsFor('Critic (Codex)')).toBe('CR');
+    expect(initialsFor('Strategist (Claude)')).toBe('ST');
+    expect(initialsFor('Codex (impl)')).toBe('CO');
+  });
+
+  test('two agents whose bracketed suffix differs are not labelled the same', () => {
+    // The real defect behind the cosmetic one: "Critic (Codex)" and
+    // "Codex (impl)" both rendered "C(", so two different agents carried an
+    // identical avatar label. Same failure family as the displayName
+    // collisions that needed a dedup migration.
+    expect(initialsFor('Critic (Codex)')).not.toBe(initialsFor('Codex (impl)'));
+  });
+
+  test('ordinary two-word names are unchanged', () => {
+    expect(initialsFor('Sprint Review')).toBe('SR');
+    expect(initialsFor('Sprint Impl')).toBe('SI');
+    expect(initialsFor('UX Lead')).toBe('UL');
+    expect(initialsFor('Pod Architect')).toBe('PA');
+  });
+
+  test('single words take two letters', () => {
+    expect(initialsFor('scout')).toBe('SC');
+    expect(initialsFor('Nova')).toBe('NO');
+  });
+
+  test('a CJK display name keeps its characters instead of collapsing to "?"', () => {
+    // The punctuation strip is Unicode-aware for this reason; a naive [^A-Za-z]
+    // filter would empty the token and fall through to the "?" placeholder.
+    expect(initialsFor('奶龙')).toBe('奶龙');
+  });
+
+  test('empty and punctuation-only names fall back rather than throwing', () => {
+    expect(initialsFor('')).toBe('?');
+    expect(initialsFor(null)).toBe('?');
+    expect(initialsFor(undefined)).toBe('?');
+    // A name that is ONLY a parenthetical falls back to the raw string, which
+    // then has its punctuation stripped — so "LE", never "(L".
+    expect(initialsFor('(lead)')).toBe('LE');
+  });
+
+  test('the whole roster stays distinct', () => {
+    const roster = [
+      'Fable (lead)', 'Critic (Codex)', 'Strategist (Claude)', 'Codex (impl)',
+      'Sprint Review', 'Sprint Impl', 'UX Lead', 'Pod Architect',
+      'Commonly Bot', 'Commonly Support', 'scout', 'Nova', 'Theo', 'Pixel',
+    ];
+    const seen = new Set(roster.map(initialsFor));
+    expect(seen.size).toBe(roster.length);
+  });
+});

--- a/frontend/src/v2/utils/avatars.ts
+++ b/frontend/src/v2/utils/avatars.ts
@@ -28,10 +28,31 @@ export const colorFor = (seed: string | undefined | null): string => {
 };
 
 export const initialsFor = (name: string | undefined | null): string => {
-  const trimmed = String(name || '').trim();
-  if (!trimmed) return '?';
-  const parts = trimmed.split(/[\s_-]+/).filter(Boolean);
-  if (parts.length === 0) return trimmed.slice(0, 2).toUpperCase();
+  const raw = String(name || '').trim();
+  if (!raw) return '?';
+
+  // Drop parenthetical qualifiers before picking initials. Display names here
+  // routinely carry a role or runtime in brackets — "Fable (lead)", "Critic
+  // (Codex)", "Codex (impl)" — and first-word + last-word was taking the
+  // BRACKET as the second initial. Four of the twelve cards on Your Team read
+  // "F(", "C(", "S(" and "C(": ugly, and wrong in a way that matters, because
+  // "Critic (Codex)" and "Codex (impl)" rendered IDENTICALLY. Two different
+  // agents labelled the same is the attribution failure this repo has paid for
+  // before with displayName collisions.
+  //
+  // A parenthetical is a qualifier rather than part of the name, so dropping it
+  // also yields the more distinctive initials: Critic -> CR, Codex -> CO.
+  const trimmed = raw.replace(/\([^)]*\)/g, ' ').trim() || raw;
+
+  // Strip residual punctuation from each token so a stray bracket, comma or
+  // colon can never become an initial again. Unicode-aware, so a CJK display
+  // name keeps its characters instead of being emptied to "?".
+  const parts = trimmed
+    .split(/[\s_\-/|]+/)
+    .map((part) => part.replace(/[^\p{L}\p{N}]/gu, ''))
+    .filter(Boolean);
+
+  if (parts.length === 0) return trimmed.slice(0, 2).toUpperCase() || '?';
   if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
   return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
 };


### PR DESCRIPTION
Your Team renders **`F(`, `C(`, `S(` and `C(`** right now — four of twelve visible cards.

`initialsFor` took the first and last whitespace-separated word, and display names here routinely carry a role or runtime in brackets: `Fable (lead)`, `Critic (Codex)`, `Codex (impl)`. So the **bracket became the second initial**.

## The cosmetic part is the smaller half

`Critic (Codex)` and `Codex (impl)` both rendered `C(` — **two different agents carrying an identical avatar label**. That's the attribution failure this repo already paid for once, with the displayName collisions that needed a dedup migration.

## The fix

A parenthetical is a qualifier, not part of the name, so it's dropped before picking initials — which also yields the *more* distinctive result:

```
Fable (lead)         F(  →  FA
Critic (Codex)       C(  →  CR
Strategist (Claude)  S(  →  ST
Codex (impl)         C(  →  CO
Sprint Review        SR  →  SR   (unchanged)
```

Residual punctuation is then stripped per token so a stray bracket, comma or colon can never become an initial again — using Unicode property escapes, so a CJK display name (`奶龙`) keeps its characters rather than collapsing to the `?` placeholder. A naive `[^A-Za-z]` filter would have broken that.

Verified across the real 14-name roster: **14 distinct, zero duplicates.**

## Scope

Deliberately **separate from #1040** (avatar gradients), which is held pending @ux-lead's design ruling. This is a defect and holds regardless of which direction avatars take — initials remain the fallback even if avatars become illustrated characters.

One test expectation was wrong on the first pass (`'(lead)'` yields `LE`, not `(L`, because the fallback re-runs the strip). Caught by executing it rather than trusting the assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8