### PR TITLE
fix(db): an idle pg client error was crashing the API

### DIFF
--- a/backend/__tests__/unit/config/dbPgPoolError.test.js
+++ b/backend/__tests__/unit/config/dbPgPoolError.test.js
@@ -1,0 +1,66 @@
+/**
+ * The pg pool must have an 'error' listener.
+ *
+ * node-postgres emits 'error' on an IDLE pooled client when the server drops
+ * the connection. EventEmitter turns an 'error' event with no listener into a
+ * thrown exception, which terminates the process — so the absence of this one
+ * listener is the difference between a reconnect and an outage.
+ *
+ * It took the API down twice on 2026-08-20 with the FATAL
+ * "terminating connection due to administrator command", which is what managed
+ * Postgres says during failover, patching, or connection recycling. A routine
+ * provider-side event was converting into a full outage, once per maintenance
+ * window, forever.
+ *
+ * Asserted on the module's own registration rather than by simulating a crash:
+ * a test that actually emitted an unhandled error would take the jest worker
+ * down with it, which is the very behaviour under test.
+ */
+const path = require('path');
+
+describe('pg pool error handling', () => {
+  const modulePath = path.join(__dirname, '../../../config/db-pg.ts');
+  const registered = [];
+
+  beforeEach(() => {
+    jest.resetModules();
+    registered.length = 0;
+    process.env.PG_HOST = 'localhost';
+    process.env.PG_USER = 'test';
+    process.env.PG_PASSWORD = 'test';
+    process.env.PG_DATABASE = 'test';
+
+    jest.doMock('pg', () => ({
+      Pool: class FakePool {
+        on(event, cb) {
+          registered.push(event);
+          return this;
+        }
+
+        connect() { return Promise.resolve({ query: async () => ({ rows: [{}] }), release() {} }); }
+
+        query() { return Promise.resolve({ rows: [] }); }
+
+        end() { return Promise.resolve(); }
+      },
+    }));
+  });
+
+  afterEach(() => {
+    jest.dontMock('pg');
+  });
+
+  it("registers an 'error' listener, without which an idle-client error kills the process", () => {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    require(modulePath);
+    expect(registered).toContain('error');
+  });
+
+  it("still registers the 'connect' listener it already had", () => {
+    // The error handler was added beside an existing connect handler; this
+    // pins that the addition did not displace it.
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    require(modulePath);
+    expect(registered).toContain('connect');
+  });
+});

--- a/backend/config/db-pg.ts
+++ b/backend/config/db-pg.ts
@@ -78,6 +78,28 @@ if (pool) {
   (pool as { on: (event: string, cb: (client: { query: (sql: string) => Promise<void> }) => void) => void }).on('connect', (client) => {
     client.query('SET default_transaction_read_only = off').catch(() => {});
   });
+
+  // An IDLE pooled client that errors with no 'error' listener is an unhandled
+  // EventEmitter error, which in Node terminates the process. That is not a
+  // theoretical footgun — it took the API down twice on 2026-08-20 with:
+  //
+  //   error: terminating connection due to administrator command  (severity FATAL)
+  //
+  // which is what managed Postgres says during a failover, a patch window, or
+  // ordinary connection recycling. In other words a ROUTINE event on the
+  // provider side was converting into a full outage on ours, and the pod
+  // restart loop (`restarts: 2` inside two minutes) meant every maintenance
+  // window would do it again.
+  //
+  // The pool already handles the recovery correctly on its own: the broken
+  // client is discarded and the next checkout dials a fresh one. All that was
+  // missing was a listener so the error stays an error instead of becoming a
+  // process exit. Logged rather than swallowed — a silent reconnect would hide
+  // a genuinely failing database, and "it fails quietly" is the pattern this
+  // codebase keeps paying for.
+  (pool as { on: (event: string, cb: (err: Error) => void) => void }).on('error', (err) => {
+    console.error('[pg-pool] idle client error (connection discarded, pool will reconnect):', err?.message || err);
+  });
 }
 
 const connectPG = async (): Promise<unknown> => {


### PR DESCRIPTION
**Live incident, just now.** The API returned 503 and the backend pod restarted **twice in two minutes**.

## Cause

```
error: terminating connection due to administrator command   (severity: FATAL)
```

That's what managed Postgres says during a failover, a patch window, or ordinary connection recycling — a **routine** provider-side event.

`node-postgres` emits `'error'` on the idle pooled client when that happens. The pool had an `on('connect')` listener and **no `on('error')` listener**. EventEmitter turns an unhandled `'error'` event into a thrown exception, so the process died and every request 503'd until Kubernetes restarted it.

**Every future Postgres maintenance window would have done this again.**

## The fix

One listener. The pool already recovers correctly on its own — the broken client is discarded and the next checkout dials a fresh one. All that was missing was something to keep the error *an error* instead of a process exit.

Logged rather than swallowed, deliberately: a silent reconnect would hide a genuinely failing database, and "it fails quietly" is the pattern this codebase keeps paying for.

## Why the test asserts registration rather than the crash

A test that actually emitted an unhandled `'error'` would take the jest worker down with it — which is exactly the behaviour under test. So it pins that the listener is registered, plus that the pre-existing `'connect'` listener survived the addition.

## Note on severity

This is the same failure family as most of today's findings, with the sign flipped: the system converts a **recoverable** condition into a total stop. It's the loud version, which is why it was caught in seconds rather than months — but the underlying reflex is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8