### PR TITLE
chore(helm): park the clawdbot gateway in values, not just kubectl

### DIFF
--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -148,7 +148,19 @@ externalSecrets:
 
 agents:
   clawdbot:
-    enabled: true
+    # PARKED 2026-08-20 (Sam) — the moltbot tier is retiring in favour of
+    # pi/OpenCode wrapper adapters (ADR-021/ADR-023, #1050). Its credential
+    # stack had been dead since 2026-07-02 — both cluster codex tokens expired,
+    # OpenRouter 401 "User not found" — and nobody noticed for seven weeks,
+    # because the native and BYO tiers never touch those credentials.
+    #
+    # This flag is the durable half of the park. The manual
+    # `kubectl scale --replicas=0` alone would be UNDONE by the next Deploy Dev,
+    # because the template hardcodes `replicas: 1` behind this flag and helm
+    # upgrade restores whatever the chart declares. Identity continuity holds
+    # either way: User rows, memory, and installations survive (ADR-001), so
+    # the same agents return as themselves on the replacement runtime.
+    enabled: false
     image:
       repository: gcr.io/YOUR_GCP_PROJECT_ID/clawdbot-gateway
       tag: "20260414192025"


### PR DESCRIPTION
Makes the park durable. `kubectl scale --replicas=0` alone is **undone by the next `Deploy Dev`** — the template hardcodes `replicas: 1` behind `agents.clawdbot.enabled`, and `helm upgrade` restores whatever the chart declares. Without this, every deploy silently resurrects a tier whose credentials have been dead since **2026-07-02**.

Full context, evidence, and the cleanup checklist: #1050.

The comment in values carries the two things the next reader needs: why it's off (retiring per ADR-021/ADR-023, seven-week credential death nobody noticed), and that identity continuity holds — User rows, memory, and installations survive (ADR-001), so the same agents return as themselves on the pi/OpenCode replacement runtime.

Not in this PR: `deploy-dev.yml` still *builds* the gateway image each run (built, not deployed — wasteful, harmless). Neither account can push workflow files (no `workflow` scope), so that's a checklist item in #1050 for whenever the scope gets added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8