### PR TITLE
feat(v2): make app boot a brand moment

### DIFF
--- a/frontend/design-system/tokens.css
+++ b/frontend/design-system/tokens.css
@@ -98,6 +98,17 @@
   --c-dur-slow:    200ms;
   --c-dur-page:    300ms;       /* layout shifts */
 
+  /* Motion identity — the mark's three dots and the chat typing cue share
+     one cadence. State affordances use the same named timing layer without
+     inheriting the typing semantics. */
+  --motion-stagger:    0.18s;
+  --motion-breath:     1.2s;
+  --motion-pulse:      1.6s;
+  --motion-spin:       0.8s;
+  --motion-ease-breath: ease-in-out;
+  --motion-ease-state:  ease-out;
+  --motion-ease-linear: linear;
+
   /* ---------- Typography ---------- */
   /* SF-first stack — uses the OS-installed San Francisco family on Apple
      devices; falls through to BlinkMacSystemFont (Chrome's SF alias) and

--- a/frontend/src/v2/V2App.tsx
+++ b/frontend/src/v2/V2App.tsx
@@ -69,16 +69,33 @@ class V2ErrorBoundary extends React.Component<{ children: React.ReactNode }, { e
   }
 }
 
+// This is inline rather than an <img> so the mark's existing three dots can
+// use the product typing rhythm. Its geometry matches the canonical minimal
+// mark in frontend/design-system/assets/commonly-mark.svg: one C ring, then
+// dots at x=25/32/39 with r=2.4 in a 64px viewBox.
+const V2Boot: React.FC = () => (
+  <div className="v2-boot" role="status" aria-label="Loading Commonly">
+    <svg className="v2-boot__mark" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+      <path
+        d="M 50 17.7 A 22 22 0 1 0 50 46.3"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="9"
+        strokeLinecap="round"
+      />
+      <circle className="v2-boot__mark-dot" cx="25" cy="32" r="2.4" fill="currentColor" />
+      <circle className="v2-boot__mark-dot" cx="32" cy="32" r="2.4" fill="currentColor" />
+      <circle className="v2-boot__mark-dot" cx="39" cy="32" r="2.4" fill="currentColor" />
+    </svg>
+  </div>
+);
+
 const V2RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { isAuthenticated, loading } = useAuth();
   const location = useLocation();
 
   if (loading) {
-    return (
-      <div className="v2-empty">
-        <span className="v2-spinner" />
-      </div>
-    );
+    return <V2Boot />;
   }
 
   if (!isAuthenticated) {
@@ -96,11 +113,7 @@ const V2Home: React.FC = () => {
   const { isAuthenticated, loading } = useAuth();
 
   if (loading) {
-    return (
-      <div className="v2-empty">
-        <span className="v2-spinner" />
-      </div>
-    );
+    return <V2Boot />;
   }
 
   if (!isAuthenticated) {

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -51,6 +51,14 @@ const renderAt = (path: string, auth = baseAuth) => render(
 );
 
 describe('V2 routing', () => {
+  test('auth boot centers the branded typing mark instead of an inline spinner', () => {
+    renderAt('/v2', { ...baseAuth, loading: true });
+
+    expect(screen.getByRole('status', { name: 'Loading Commonly' })).toBeInTheDocument();
+    expect(document.querySelectorAll('.v2-boot__mark-dot')).toHaveLength(3);
+    expect(document.querySelector('.v2-spinner')).not.toBeInTheDocument();
+  });
+
   test('login route renders v2 login form', () => {
     renderAt('/v2/login');
     expect(screen.getByRole('heading', { name: /^Sign in$/i })).toBeInTheDocument();

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -40,8 +40,13 @@ const ruleBody = (css: string, selector: string): string => {
   return end === -1 ? '' : css.slice(start, end);
 };
 
+const cssVariable = (css: string, name: string): string | undefined => (
+  new RegExp(`${name}\\s*:\\s*([^;]+);`).exec(css)?.[1].trim()
+);
+
 describe('v2 layout invariants (CSS rule presence)', () => {
   const v2 = read('../v2.css');
+  const tokens = read('../../../design-system/tokens.css');
   const showcase = read('../showcase/v2-showcase.css');
   const aprofile = read('../agents/v2-agent-profile.css');
   const landing = read('../landing/v2-landing.css');
@@ -50,6 +55,41 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     const rule = ruleBody(v2, '.v2-team-card__name');
     expect(rule).toContain('flex: 1 0 100%');
     expect(rule).toContain('min-width: 0');
+  });
+
+  test('motion timing is tokenized and all three existing V2 animations consume it', () => {
+    expect(tokens).toContain('--motion-stagger:    0.18s');
+    expect(tokens).toContain('--motion-breath:     1.2s');
+    expect(tokens).toContain('--motion-ease-breath: ease-in-out');
+    expect(tokens).toContain('--motion-ease-state:  ease-out');
+    expect(tokens).toContain('--motion-ease-linear: linear');
+
+    // V2 is a scoped stylesheet, so it cannot inherit :root tokens directly.
+    // Bind its local copy to the design-system source of truth rather than
+    // allowing the two timing layers to quietly diverge.
+    const v2Root = ruleBody(v2, '.v2-root');
+    for (const name of [
+      '--motion-stagger',
+      '--motion-breath',
+      '--motion-pulse',
+      '--motion-spin',
+      '--motion-ease-breath',
+      '--motion-ease-state',
+      '--motion-ease-linear',
+    ]) {
+      expect(cssVariable(v2Root, name)).toBe(cssVariable(tokens, name));
+    }
+
+    expect(ruleBody(v2, '.v2-chat__typing-dots > span')).toContain('var(--motion-breath)');
+    expect(ruleBody(v2, '.v2-inspector__now-pulse')).toContain('var(--motion-pulse)');
+    expect(ruleBody(v2, '.v2-spinner')).toContain('var(--motion-spin)');
+  });
+
+  test('the app boot mark reuses the typing keyframes and does not replace state spinners', () => {
+    expect(ruleBody(v2, '.v2-boot__mark-dot')).toContain('animation: v2-typing-dot');
+    expect(ruleBody(v2, '.v2-boot__mark-dot:nth-of-type(2)')).toContain('var(--motion-stagger)');
+    expect(ruleBody(v2, '.v2-boot__mark-dot:nth-of-type(3)')).toContain('var(--motion-stagger)');
+    expect(ruleBody(v2, '.v2-spinner')).toContain('animation: v2-spin');
   });
 
   test('Your Team grid columns can shrink below 320px on phones', () => {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -71,6 +71,17 @@
   --v2-pods-w: 272px;
   --v2-inspector-w: 336px;
 
+  /* Keep production's scoped V2 layer in step with design-system/tokens.css.
+     The typing cadence belongs to the minimal mark; pulse/spin retain their
+     separate state-affordance semantics. */
+  --motion-stagger: 0.18s;
+  --motion-breath: 1.2s;
+  --motion-pulse: 1.6s;
+  --motion-spin: 0.8s;
+  --motion-ease-breath: ease-in-out;
+  --motion-ease-state: ease-out;
+  --motion-ease-linear: linear;
+
   font-family: var(--v2-font);
   color: var(--v2-text-primary);
   background: var(--v2-page-bg);
@@ -1766,11 +1777,11 @@
   height: 4px;
   border-radius: 50%;
   background: var(--v2-text-tertiary);
-  animation: v2-typing-dot 1.2s infinite ease-in-out;
+  animation: v2-typing-dot var(--motion-breath) infinite var(--motion-ease-breath);
 }
 
-.v2-chat__typing-dots > span:nth-child(2) { animation-delay: 0.18s; }
-.v2-chat__typing-dots > span:nth-child(3) { animation-delay: 0.36s; }
+.v2-chat__typing-dots > span:nth-child(2) { animation-delay: var(--motion-stagger); }
+.v2-chat__typing-dots > span:nth-child(3) { animation-delay: calc(var(--motion-stagger) + var(--motion-stagger)); }
 
 @keyframes v2-typing-dot {
   0%, 60%, 100% { transform: translateY(0); opacity: 0.35; }
@@ -2976,7 +2987,7 @@
   border-radius: 50%;
   background: var(--v2-success);
   box-shadow: 0 0 0 0 var(--v2-success-ring-strong);
-  animation: v2-now-pulse 1.6s ease-out infinite;
+  animation: v2-now-pulse var(--motion-pulse) var(--motion-ease-state) infinite;
   flex-shrink: 0;
 }
 
@@ -5122,6 +5133,38 @@
   color: var(--v2-text-tertiary);
 }
 
+/* App boot has no content state to impersonate, so the minimal mark can own
+   the moment. The dots use the exact typing keyframes; inline spinners retain
+   their state-specific v2-spin affordance below. */
+.v2-boot {
+  flex: 1;
+  display: grid;
+  place-items: center;
+  min-height: 0;
+  background: var(--v2-page-bg);
+}
+
+.v2-boot__mark {
+  width: 64px;
+  height: 64px;
+  color: var(--v2-accent);
+  overflow: visible;
+}
+
+.v2-boot__mark-dot {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: v2-typing-dot var(--motion-breath) infinite var(--motion-ease-breath);
+}
+
+.v2-boot__mark-dot:nth-of-type(2) {
+  animation-delay: var(--motion-stagger);
+}
+
+.v2-boot__mark-dot:nth-of-type(3) {
+  animation-delay: calc(var(--motion-stagger) + var(--motion-stagger));
+}
+
 .v2-empty__title {
   font-size: 16px;
   font-weight: 700;
@@ -5140,7 +5183,7 @@
   border: 2px solid var(--v2-border);
   border-top-color: var(--v2-accent);
   border-radius: 50%;
-  animation: v2-spin 0.8s linear infinite;
+  animation: v2-spin var(--motion-spin) var(--motion-ease-linear) infinite;
   display: inline-block;
 }
 


### PR DESCRIPTION
Implements mood-moment item 1 from #1052. V2 app boot now centers the minimal Commonly mark with the existing typing cadence; content skeletons, inline spinners, and the active-now pulse retain their state-specific affordances. Motion timing is tokenized in both the design-system and scoped V2 layers, with an invariant preventing drift.