### PR TITLE
feat(kernel): the work sweep — rescue lapsed leases, wake seats only for named work (#1044)

### DIFF
--- a/backend/__tests__/unit/services/kernelWorkSweepService.test.js
+++ b/backend/__tests__/unit/services/kernelWorkSweepService.test.js
@@ -21,6 +21,18 @@ jest.mock('../../../services/taskEventService', () => ({
   notifyFoundWork: (...args) => mockNotifyFoundWork(...args),
 }));
 
+// The contract pin below requires routes/tasksApi for its claimableConditions
+// export, and the route module drags express middleware at load —
+// middleware/auth pulls jsonwebtoken, whose buffer-equal-constant-time dep
+// crashes on Node 26 before any test registers (the incompat #1029's revert
+// note recorded). Mocked exactly the way the tasksApi route suites already do;
+// none of these mocks touch the pure function under test.
+jest.mock('../../../middleware/auth', () => (req, res, next) => next());
+jest.mock('../../../middleware/agentRuntimeAuth', () => (req, res, next) => next());
+jest.mock('../../../models/Pod', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../../../services/githubAppService', () => ({ isPatConfigured: jest.fn(() => false) }));
+
 const Task = require('../../../models/Task');
 const KernelWorkSweepService = require('../../../services/kernelWorkSweepService');
 
@@ -120,6 +132,21 @@ describe('sweep', () => {
     expect(result.woken).toBe(1);
   });
 
+  it('matches only NEWLY actionable rows — standing stock is never re-nagged', async () => {
+    // fable's gate one. Without the updatedAt window, a pod with one unloved
+    // unassigned task gets a kernel wake EVERY pass forever — the turn-burner
+    // reborn. A task every seat declined once is deliberately unclaimed.
+    Task.aggregate.mockResolvedValue([]);
+
+    await KernelWorkSweepService.sweep(NOW);
+
+    const [pipeline] = Task.aggregate.mock.calls[0];
+    const match = pipeline[0].$match;
+    expect(match.updatedAt).toBeDefined();
+    expect(match.updatedAt.$gte).toEqual(new Date(NOW.getTime() - 10 * 60 * 1000));
+    expect(match.status).toBe('pending');
+  });
+
   it('names at most five items inline — a longer wake is a report, not a wake', async () => {
     const many = Array.from({ length: 9 }, (_, i) => ({ taskId: `TASK-${i}`, title: `t${i}` }));
     Task.aggregate.mockResolvedValue([{ _id: POD_A, tasks: many, count: 9 }]);
@@ -140,5 +167,29 @@ describe('sweep', () => {
     expect(result).toEqual({ scannedPods: 0, rescued: 0, woken: 0, skippedNoWork: 0 });
     expect(Task.find).not.toHaveBeenCalled();
     expect(mockNotifyFoundWork).not.toHaveBeenCalled();
+  });
+});
+
+describe('lapsed contract — the sweep and the claim CAS agree on what lapsed means', () => {
+  // A SUBSET assertion, not toEqual: claimableConditions has four branches
+  // (pending, self-renewal, and the two expiry ones); lapsedConditions is only
+  // the expiry pair. Equality on the whole would simply always fail (fable,
+  // 56080). The pin is that the sweep's definition deep-equals the LAST TWO
+  // entries of the claim CAS's — same fields, same operators, same lease
+  // arithmetic — so "claimable by a peer" and "rescued by the kernel" can
+  // never quietly mean different things.
+  //
+  // Mutation-probed before shipping (fable, 56081): with the sweep's lease
+  // constant changed to 31 minutes, this test went red on the claimedAt date.
+  // It is not a test that can only pass.
+  it('lapsedConditions deep-equals the two expiry branches of claimableConditions', () => {
+    // eslint-disable-next-line global-require
+    const { claimableConditions } = require('../../../routes/tasksApi');
+    const now = new Date('2026-08-20T20:00:00Z');
+
+    const sweep = KernelWorkSweepService.lapsedConditions(now);
+    const cas = claimableConditions(now);
+
+    expect(sweep).toEqual(cas.slice(-2));
   });
 });

--- a/backend/__tests__/unit/services/kernelWorkSweepService.test.js
+++ b/backend/__tests__/unit/services/kernelWorkSweepService.test.js
@@ -1,0 +1,144 @@
+/**
+ * Kernel work sweep (#1044). The properties pinned here are the ones whose
+ * violation is quiet: a rescue that clobbers a live renewal looks like a
+ * rescue; a wake on an empty board looks like liveness; an unpriced wake
+ * looks like delivery.
+ */
+const mongoose = require('mongoose');
+
+jest.mock('../../../models/Task', () => ({
+  find: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+  aggregate: jest.fn(),
+}));
+
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { find: jest.fn() },
+}));
+
+const mockNotifyFoundWork = jest.fn();
+jest.mock('../../../services/taskEventService', () => ({
+  notifyFoundWork: (...args) => mockNotifyFoundWork(...args),
+}));
+
+const Task = require('../../../models/Task');
+const KernelWorkSweepService = require('../../../services/kernelWorkSweepService');
+
+const POD_A = new mongoose.Types.ObjectId().toString();
+const NOW = new Date('2026-08-20T20:00:00Z');
+
+const lapsedTask = (overrides = {}) => ({
+  _id: new mongoose.Types.ObjectId(),
+  podId: POD_A,
+  taskId: 'TASK-007',
+  title: 'stalled work',
+  status: 'claimed',
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.AGENT_WORK_SWEEP_DISABLED;
+  Task.find.mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+  });
+  Task.aggregate.mockResolvedValue([]);
+  mockNotifyFoundWork.mockResolvedValue({ woken: 1 });
+});
+
+describe('rescueLapsed', () => {
+  it('rescues through a CAS whose filter carries the lapsed predicate', async () => {
+    const t = lapsedTask();
+    Task.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([t]) }),
+    });
+    Task.findOneAndUpdate.mockResolvedValue({ ...t, status: 'pending' });
+
+    const rescued = await KernelWorkSweepService.rescueLapsed(NOW);
+
+    expect(rescued).toHaveLength(1);
+    const [filter, update] = Task.findOneAndUpdate.mock.calls[0];
+    // The lapsed predicate must travel INTO the write. Filtering only by _id
+    // is the read-then-write @sprint-review caught: a claimant renewing
+    // between the find and the update gets silently clobbered.
+    expect(filter._id).toBe(t._id);
+    expect(Array.isArray(filter.$or)).toBe(true);
+    expect(JSON.stringify(filter.$or)).toContain('claimExpiresAt');
+    // Assignee cleared, or the task returns to the dead seat's lane where no
+    // other assignee-scoped fetch ever sees it (#1023).
+    expect(update.$set.assignee).toBeNull();
+    expect(update.$set.status).toBe('pending');
+  });
+
+  it('a renewal between find and update wins — the sweep records no rescue', async () => {
+    Task.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([lapsedTask()]) }),
+    });
+    // CAS misses: the holder renewed, no lapsed branch matches.
+    Task.findOneAndUpdate.mockResolvedValue(null);
+
+    const rescued = await KernelWorkSweepService.rescueLapsed(NOW);
+    expect(rescued).toHaveLength(0);
+  });
+
+  it('the write names the kernel actor in the audit trail', async () => {
+    const t = lapsedTask();
+    Task.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([t]) }),
+    });
+    Task.findOneAndUpdate.mockResolvedValue({ ...t, status: 'pending' });
+
+    await KernelWorkSweepService.rescueLapsed(NOW);
+
+    const [, update] = Task.findOneAndUpdate.mock.calls[0];
+    expect(update.$push.updates.author).toBe('kernel-sweep');
+    expect(update.$push.updates.text).toContain('kernel sweep');
+  });
+});
+
+describe('sweep', () => {
+  it('the empty case enqueues NOTHING — zero turns is the entire point', async () => {
+    const result = await KernelWorkSweepService.sweep(NOW);
+
+    expect(result.rescued).toBe(0);
+    expect(result.woken).toBe(0);
+    expect(mockNotifyFoundWork).not.toHaveBeenCalled();
+  });
+
+  it('wakes only pods that actually have actionable work, naming it', async () => {
+    Task.aggregate.mockResolvedValue([
+      { _id: POD_A, tasks: [{ taskId: 'TASK-007', title: 'stalled work' }], count: 1 },
+    ]);
+
+    const result = await KernelWorkSweepService.sweep(NOW);
+
+    expect(mockNotifyFoundWork).toHaveBeenCalledTimes(1);
+    const [podId, items, count] = mockNotifyFoundWork.mock.calls[0];
+    expect(String(podId)).toBe(POD_A);
+    expect(items[0].taskId).toBe('TASK-007');
+    expect(count).toBe(1);
+    expect(result.woken).toBe(1);
+  });
+
+  it('names at most five items inline — a longer wake is a report, not a wake', async () => {
+    const many = Array.from({ length: 9 }, (_, i) => ({ taskId: `TASK-${i}`, title: `t${i}` }));
+    Task.aggregate.mockResolvedValue([{ _id: POD_A, tasks: many, count: 9 }]);
+
+    await KernelWorkSweepService.sweep(NOW);
+
+    const [, items, count] = mockNotifyFoundWork.mock.calls[0];
+    expect(items).toHaveLength(5);
+    expect(count).toBe(9);
+  });
+
+  it('the kill switch stops everything without a deploy', async () => {
+    process.env.AGENT_WORK_SWEEP_DISABLED = 'true';
+    Task.aggregate.mockResolvedValue([{ _id: POD_A, tasks: [{ taskId: 'T' }], count: 1 }]);
+
+    const result = await KernelWorkSweepService.sweep(NOW);
+
+    expect(result).toEqual({ scannedPods: 0, rescued: 0, woken: 0, skippedNoWork: 0 });
+    expect(Task.find).not.toHaveBeenCalled();
+    expect(mockNotifyFoundWork).not.toHaveBeenCalled();
+  });
+});

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -173,10 +173,6 @@ router.get('/:podId', auth, async (req: AuthReq, res: Res) => {
     // meaning what it reads as. Anything that is not a string is dropped.
     const assignee = typeof req.query?.assignee === 'string' ? req.query.assignee : undefined;
     const status = typeof req.query?.status === 'string' ? req.query.status : undefined;
-    // Deliberately absent from the MCP tool schema, and NOT an oversight to
-    // close. Agents discover work via status=pending; this filter is rescue/ops
-    // infrastructure. Exposing it teaches every seat to poll the whole board on
-    // a timer — the surface is the guard, because a tool description isn't one.
     const claimable = req.query?.claimable === 'true';
     const access = await requirePodMember(podId || '', userId);
     if (access.error) return res.status(access.status || 500).json({ error: access.error });
@@ -665,5 +661,11 @@ router.patch('/:podId/:taskId', taskWriteRateLimit(60), auth, async (req: AuthRe
 });
 
 module.exports = router;
+// `module.exports = router` CLOBBERS the ES named exports above — under CJS
+// require, `claimableConditions` did not survive and destructuring it returned
+// undefined (found when the kernel-sweep contract pin tried to import it; the
+// export had been unreachable since #1022 shipped it). Re-attached explicitly
+// so the single definition of "claimable" is actually consumable.
+module.exports.claimableConditions = claimableConditions;
 
 export {};

--- a/backend/services/kernelWorkSweepService.ts
+++ b/backend/services/kernelWorkSweepService.ts
@@ -41,6 +41,12 @@ const { AgentInstallation } = require('../models/AgentRegistry');
 const KERNEL_ACTOR = 'kernel-sweep';
 const TASK_CLAIM_LEASE_MS = 30 * 60 * 1000;
 
+// MUST match the cron cadence in schedulerService ('4,14,24,... * * * *' =
+// every 10 minutes). The newly-actionable window is one sweep period: wider
+// re-wakes standing stock, narrower drops rows that landed between passes.
+// If the cron cadence changes, this changes with it — they are one decision.
+const SWEEP_INTERVAL_MS = 10 * 60 * 1000;
+
 // How many found items a wake names inline. More than this and the wake stops
 // being "here is your work" and becomes a report; the seat can list the board
 // itself once it knows there is a reason to.
@@ -67,8 +73,12 @@ class KernelWorkSweepService {
    * The lapsed-lease predicate, matching the claim CAS's two expiry branches
    * (tasksApi.claimableConditions). Duplicated as data rather than imported
    * because importing the route module here would drag express middleware into
-   * the scheduler; the contract test in tasksApi's suite pins the two shapes
-   * together the same way the CLI/backend mention lists are pinned.
+   * the scheduler. The contract pin lives in
+   * __tests__/unit/services/kernelWorkSweepService.test.js ("lapsed contract"):
+   * a SUBSET assertion — these two branches deep-equal the last two entries of
+   * claimableConditions(now) — because the shapes are deliberately not equal
+   * (the claim CAS also admits pending and self-renewal). Mutation-probed red
+   * before it shipped; see the PR body.
    */
   static lapsedConditions(now: Date): Record<string, unknown>[] {
     return [
@@ -130,11 +140,23 @@ class KernelWorkSweepService {
     // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
     const { notifyFoundWork } = require('./taskEventService');
 
-    // Pods with any actionable row: pending+unassigned. (Just-rescued rows are
-    // pending+unassigned by construction, so they are covered here without a
-    // separate channel.)
+    // NEWLY actionable only — fable's gate one on this PR. Without the window,
+    // newly-actionable is indistinguishable from standing stock, and a pod with
+    // one unloved unassigned task gets a kernel wake EVERY pass, forever: the
+    // turn-burner this service exists to kill, reborn one layer down. A task
+    // every seat declined once is deliberately unclaimed; re-nagging is not
+    // discovery. Rescued rows enter the window because the rescue's
+    // findOneAndUpdate bumps updatedAt (Task has timestamps: true), so they
+    // still need no separate channel.
+    const since = new Date(now.getTime() - SWEEP_INTERVAL_MS);
     const actionable = await Task.aggregate([
-      { $match: { status: 'pending', $or: [{ assignee: null }, { assignee: '' }, { assignee: { $exists: false } }] } },
+      {
+        $match: {
+          status: 'pending',
+          updatedAt: { $gte: since },
+          $or: [{ assignee: null }, { assignee: '' }, { assignee: { $exists: false } }],
+        },
+      },
       { $group: { _id: '$podId', tasks: { $push: { taskId: '$taskId', title: '$title' } }, count: { $sum: 1 } } },
     ]) as Array<{ _id: unknown; tasks: Array<{ taskId?: string; title?: string }>; count: number }>;
 

--- a/backend/services/kernelWorkSweepService.ts
+++ b/backend/services/kernelWorkSweepService.ts
@@ -1,0 +1,169 @@
+/**
+ * Kernel work sweep (#1044, ruled by fable-lead).
+ *
+ * The ruling this implements, verbatim: "a timer that spends a model turn to
+ * discover nothing is wrong at any breadth — the fix isn't a better tick, it's
+ * moving the timer kernel-side. A cron that sweeps for lapsed leases and
+ * unassigned rows and enqueues ONLY when it finds something makes the empty
+ * case cost zero turns. HEARTBEAT_OK shouldn't exist as an outcome: if the
+ * payload can't name work, don't wake the seat."
+ *
+ * Why the kernel and not an agent: the previous design rode theo's heartbeat
+ * (a moltbot), and the moltbot tier is parked (#1050) — its credentials had
+ * been dead for seven weeks without anyone noticing. That left "theo-less pods
+ * and theo itself as a single point" (fable, 55842) as the uncovered case;
+ * parking the tier made it the ONLY case. A lapsed→pending transition needs no
+ * model judgment, so nothing about this requires an LLM at all.
+ *
+ * Fable's three build constraints, all enforced here or in the same PR:
+ *  1. Writes carry a NAMED kernel actor (`kernel-sweep`) in the task's update
+ *     trail — an unexplained status flip in an audit trail is how "the label
+ *     chain failing where attribution is load-bearing" incidents start.
+ *  2. Kernel-originated wakes carry `triggerAuthor: 'kernel'` and NO dmKind —
+ *     the third pricing branch. Priced as 'agent' they would count toward the
+ *     cascade cap and silence seats exactly when the board is busiest (more
+ *     real work → more counted wakes). Priced as 'human' they would CLEAR the
+ *     brake on unrelated cascades. Older CLIs that predate the branch see no
+ *     dmKind and no messageId and classify 'unknown', which is neutral — so
+ *     the safe behaviour degrades gracefully instead of breaking.
+ *  3. Rescue is a per-task CAS, never a read-then-write. The lapsed predicate
+ *     sits INSIDE the findOneAndUpdate filter, so a claimant renewing between
+ *     the sweep's read and its write wins and the sweep loses — @sprint-review
+ *     caught exactly this clobber in the first rescue design, where the sweep
+ *     period equalled the lease and the race ran on every cycle.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const Task = require('../models/Task');
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const { AgentInstallation } = require('../models/AgentRegistry');
+
+const KERNEL_ACTOR = 'kernel-sweep';
+const TASK_CLAIM_LEASE_MS = 30 * 60 * 1000;
+
+// How many found items a wake names inline. More than this and the wake stops
+// being "here is your work" and becomes a report; the seat can list the board
+// itself once it knows there is a reason to.
+const MAX_NAMED_ITEMS = 5;
+
+interface SweepResult {
+  scannedPods: number;
+  rescued: number;
+  woken: number;
+  skippedNoWork: number;
+}
+
+interface TaskRow {
+  _id: unknown;
+  podId: unknown;
+  taskId?: string;
+  title?: string;
+  status?: string;
+  assignee?: string | null;
+}
+
+class KernelWorkSweepService {
+  /**
+   * The lapsed-lease predicate, matching the claim CAS's two expiry branches
+   * (tasksApi.claimableConditions). Duplicated as data rather than imported
+   * because importing the route module here would drag express middleware into
+   * the scheduler; the contract test in tasksApi's suite pins the two shapes
+   * together the same way the CLI/backend mention lists are pinned.
+   */
+  static lapsedConditions(now: Date): Record<string, unknown>[] {
+    return [
+      { status: 'claimed', claimExpiresAt: { $lt: now } },
+      { status: 'claimed', claimExpiresAt: null, claimedAt: { $lt: new Date(now.getTime() - TASK_CLAIM_LEASE_MS) } },
+    ];
+  }
+
+  /**
+   * Rescue every lapsed lease back to `pending`, one CAS per task.
+   *
+   * Clearing the assignee is NOT optional (@pod-architect, #1023): status
+   * alone returns the task to the lane of the seat that died holding it,
+   * where no other seat's assignee-scoped fetch will ever see it.
+   */
+  static async rescueLapsed(now: Date): Promise<TaskRow[]> {
+    const candidates = await Task.find({ $or: KernelWorkSweepService.lapsedConditions(now) })
+      .select('_id podId taskId title status assignee claimedBy')
+      .lean() as TaskRow[];
+
+    const rescued: TaskRow[] = [];
+    for (const t of candidates) {
+      // eslint-disable-next-line no-await-in-loop
+      const won = await Task.findOneAndUpdate(
+        // The lapsed predicate travels INTO the filter: if the holder renewed
+        // after our find, no branch matches and this is a no-op. The server
+        // arbitrates, not our snapshot.
+        { _id: t._id, $or: KernelWorkSweepService.lapsedConditions(now) },
+        {
+          $set: {
+            status: 'pending',
+            assignee: null,
+            claimedBy: null,
+            claimedAt: null,
+            claimExpiresAt: null,
+          },
+          $push: {
+            updates: {
+              text: 'Lease lapsed — returned to pending by the kernel sweep',
+              author: KERNEL_ACTOR,
+              authorId: null,
+              createdAt: now,
+            },
+          },
+        },
+        { new: true },
+      ) as TaskRow | null;
+      if (won) rescued.push(won);
+    }
+    return rescued;
+  }
+
+  /**
+   * One coalesced wake per opted-in seat, in pods that have actionable work —
+   * and no event at all where there is none. The empty case costs zero model
+   * turns, which is the entire point of the ruling.
+   */
+  static async wakeForFoundWork(now: Date): Promise<{ woken: number; skippedNoWork: number; scannedPods: number }> {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+    const { notifyFoundWork } = require('./taskEventService');
+
+    // Pods with any actionable row: pending+unassigned. (Just-rescued rows are
+    // pending+unassigned by construction, so they are covered here without a
+    // separate channel.)
+    const actionable = await Task.aggregate([
+      { $match: { status: 'pending', $or: [{ assignee: null }, { assignee: '' }, { assignee: { $exists: false } }] } },
+      { $group: { _id: '$podId', tasks: { $push: { taskId: '$taskId', title: '$title' } }, count: { $sum: 1 } } },
+    ]) as Array<{ _id: unknown; tasks: Array<{ taskId?: string; title?: string }>; count: number }>;
+
+    let woken = 0;
+    let skippedNoWork = 0;
+    for (const pod of actionable) {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await notifyFoundWork(pod._id, pod.tasks.slice(0, MAX_NAMED_ITEMS), pod.count, now);
+      if (result.woken > 0) woken += result.woken; else skippedNoWork += 1;
+    }
+    return { woken, skippedNoWork, scannedPods: actionable.length };
+  }
+
+  static async sweep(now: Date = new Date()): Promise<SweepResult> {
+    if (String(process.env.AGENT_WORK_SWEEP_DISABLED || '').toLowerCase() === 'true') {
+      return { scannedPods: 0, rescued: 0, woken: 0, skippedNoWork: 0 };
+    }
+    const rescued = await KernelWorkSweepService.rescueLapsed(now);
+    const { woken, skippedNoWork, scannedPods } = await KernelWorkSweepService.wakeForFoundWork(now);
+    if (rescued.length || woken) {
+      console.log(`[kernel-sweep] rescued=${rescued.length} woken=${woken} pods=${scannedPods}`);
+    }
+    return { scannedPods, rescued: rescued.length, woken, skippedNoWork };
+  }
+}
+
+// Re-exported so the wake path and any future consumer name the same actor.
+export { KERNEL_ACTOR };
+export default KernelWorkSweepService;
+// CJS compat: let require() return the class directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports.default; Object.assign(module.exports, exports);

--- a/backend/services/schedulerService.ts
+++ b/backend/services/schedulerService.ts
@@ -404,6 +404,26 @@ class SchedulerService {
       { scheduled: false, timezone: 'UTC' },
     );
 
+    // #1044 kernel work sweep. De-phased from the on-the-minute jobs (:04 etc)
+    // so its DB pass never stacks on the heartbeat dispatcher's. Every 10
+    // minutes: the sweep period intentionally EQUALS the 30-min lease's
+    // renewal cadence divisor, giving lapse-to-rescue a ≤40-min worst case —
+    // fable's "bounded rather than open-ended" bar — while the CAS inside the
+    // rescue makes a period-vs-lease race harmless.
+    const kernelWorkSweepJob: CronJob = cron.schedule(
+      '4,14,24,34,44,54 * * * *',
+      async () => {
+        try {
+          // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+          const KernelWorkSweepService = require('./kernelWorkSweepService');
+          await KernelWorkSweepService.sweep();
+        } catch (error) {
+          console.error('[kernel-sweep] pass failed:', error);
+        }
+      },
+      { scheduled: false, timezone: 'UTC' },
+    );
+
     this.jobs = [
       summarizerJob,
       externalFeedJob,
@@ -420,6 +440,7 @@ class SchedulerService {
       skillsRefreshJob,
       onboardingSilenceJob,
       stalledConnectJob,
+      kernelWorkSweepJob,
     ];
     this.jobs.forEach((job) => job.start());
     this.isRunning = true;

--- a/backend/services/taskEventService.ts
+++ b/backend/services/taskEventService.ts
@@ -255,10 +255,106 @@ export async function notifyPodAgents(
   }
 }
 
+/**
+ * Kernel-sweep wake (#1044): the pod has actionable work — pending, unassigned
+ * — and the kernel found it, so no model turn was spent discovering it.
+ *
+ * Differences from `notifyPodAgents`, each deliberate:
+ *
+ * - `triggerAuthor: 'kernel'` and NO dmKind. The third pricing branch (fable,
+ *   55845): kernel-found work is not agent churn — priced 'agent' it counts
+ *   toward the cascade cap and silences seats exactly when the board is
+ *   busiest; priced 'human' it clears the brake on unrelated cascades. CLIs
+ *   that predate the branch see no dmKind and no messageId and classify
+ *   'unknown', which is neutral — graceful degradation, not breakage.
+ * - The content NAMES the work. "If the payload can't name work, don't wake
+ *   the seat" is the ruling this exists to satisfy; a wake that says "go
+ *   look" re-creates the HEARTBEAT_OK turn-burner one layer down.
+ * - Same `boardWake` fold as change wakes, so a sweep wake and a change wake
+ *   collapse into ONE pending wake per seat rather than queueing separately.
+ *   Known bounded leak, recorded not fixed (same stance as fable's 55846): an
+ *   agent change folding into a pending kernel wake rides under kernel
+ *   pricing — at most one per drain.
+ */
+export async function notifyFoundWork(
+  podId: unknown,
+  items: Array<{ taskId?: string; title?: string }>,
+  totalCount: number,
+  now: Date = new Date(),
+): Promise<{ woken: number }> {
+  if (!podId || !items?.length) return { woken: 0 };
+  try {
+    /* eslint-disable global-require, @typescript-eslint/no-require-imports */
+    const { AgentInstallation } = require('../models/AgentRegistry');
+    const AgentEventService = require('./agentEventService');
+    const { wakeOnMessageEnabled } = require('./agentMentionService');
+    const AgentEvent = require('../models/AgentEvent');
+    /* eslint-enable global-require, @typescript-eslint/no-require-imports */
+
+    const normalizedPodId = String(podId);
+    const active = await AgentInstallation.find({ podId: normalizedPodId, status: 'active' }).lean();
+    const installs = (active || []).filter(wakeOnMessageEnabled);
+    if (!installs.length) return { woken: 0 };
+
+    const listed = items
+      .map((t) => `- ${t.taskId || '?'} — ${String(t.title || '(untitled)').slice(0, 80)}`)
+      .join('\n');
+    const more = totalCount > items.length ? `\n…and ${totalCount - items.length} more on the board.` : '';
+    const content = [
+      `[The kernel found unclaimed work in this pod — ${totalCount} pending, unassigned:]`,
+      '',
+      listed + more,
+      '',
+      'Nobody named you; the board did. If one of these is genuinely yours to',
+      'do: claim it first (a 409 means a peer got there — move on), then start.',
+      'If none fit your role, return NO_REPLY. Do not narrate the list back.',
+    ].join('\n');
+
+    let woken = 0;
+    await Promise.all(installs.map(async (install: Record<string, unknown>) => {
+      const agentName = install.agentName;
+      const instanceId = install.instanceId || 'default';
+      try {
+        const folded = await AgentEvent.findOneAndUpdate(
+          {
+            agentName, instanceId, podId: normalizedPodId, status: 'pending', 'payload.boardWake': true,
+          },
+          { $set: { 'payload.content': content, 'payload.foundWorkAt': now } },
+          { new: true },
+        );
+        if (folded) { woken += 1; return; }
+        await AgentEventService.enqueue({
+          agentName,
+          instanceId,
+          podId: normalizedPodId,
+          type: 'message.posted',
+          payload: {
+            content,
+            podId: normalizedPodId,
+            boardWake: true,
+            boardChanges: 0,
+            foundWorkAt: now,
+            // The third pricing branch. No dmKind, deliberately.
+            triggerAuthor: 'kernel',
+          },
+        });
+        woken += 1;
+      } catch (err) {
+        console.warn(`[task-event] found-work enqueue failed for ${agentName}:`, (err as Error).message);
+      }
+    }));
+    return { woken };
+  } catch (err) {
+    console.warn('[task-event] found-work notify failed:', (err as Error).message);
+    return { woken: 0 };
+  }
+}
+
 export default {
   bindSocketIO,
   emitTaskUpdated,
   notifyPodAgents,
+  notifyFoundWork,
 };
 
 // CJS compat: let require() return the default export directly

--- a/cli/__tests__/enforcement.test.mjs
+++ b/cli/__tests__/enforcement.test.mjs
@@ -125,6 +125,37 @@ describe('createCascadeGovernor', () => {
 // silence. It is neither. These pin the shape the docstring now claims, so a
 // future edit that makes refusals record (or that shares state across pods)
 // fails here instead of quietly re-arming the wrong mental model.
+describe('classifyTrigger — the kernel branch (#1044)', () => {
+  it('classifies a kernel-found wake as kernel, before any dmKind reading', () => {
+    // triggerAuthor is the honest field (#1018) and wins where both appear.
+    expect(classifyTrigger({ payload: { triggerAuthor: 'kernel' } }, [])).toBe('kernel');
+    expect(classifyTrigger(
+      { payload: { triggerAuthor: 'kernel', dmKind: 'agent-agent' } }, [],
+    )).toBe('kernel');
+  });
+
+  it('a kernel wake neither counts toward the streak nor clears it', () => {
+    // Priced as agent it silences seats exactly when the board is busiest;
+    // priced as human it clears the brake on unrelated cascades. Neutral,
+    // by design rather than by fallback.
+    const gov = createCascadeGovernor({ cap: 1, addressedGrace: 0 });
+    gov.record('pod', 'agent');
+    expect(gov.admit('pod', 'agent', 'message.posted').allowed).toBe(false);
+
+    gov.record('pod', 'kernel');
+    // Still capped: the kernel turn did not reset the brake...
+    expect(gov.admit('pod', 'agent', 'message.posted').allowed).toBe(false);
+    // ...and the kernel wake itself is always admitted.
+    expect(gov.admit('pod', 'kernel', 'message.posted').allowed).toBe(true);
+  });
+
+  it('an old-CLI payload shape (no triggerAuthor, no messageId) stays unknown-neutral', () => {
+    // Graceful degradation: a fleet that predates the branch prices kernel
+    // wakes as unknown, which is also neutral — never silencing.
+    expect(classifyTrigger({ payload: { boardWake: true, content: 'x' } }, [])).toBe('unknown');
+  });
+});
+
 describe('cascade governor — token-bucket shape', () => {
   // Mirrors the run loop: agent.js returns on a refusal WITHOUT calling
   // record(), so only admitted turns move `lastAgentTurnAt`.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
-  "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
+  "description": "The Commonly CLI \u2014 connect agents, manage pods, iterate fast",
   "type": "module",
   "main": "./src/index.js",
   "bin": {

--- a/cli/src/lib/enforcement.js
+++ b/cli/src/lib/enforcement.js
@@ -45,6 +45,14 @@ export const CLAIMABLE_EVENT_TYPES = new Set([
  */
 export const classifyTrigger = (event, recentMessages) => {
   const p = event?.payload || {};
+  // The third pricing branch (#1044, fable 55845). Kernel-found work is not
+  // agent churn and must not price as it: counted as 'agent' it eats cascade
+  // budget exactly when the board is busiest; counted as 'human' it CLEARS the
+  // brake on unrelated cascades. 'kernel' is neutral like 'unknown' — no
+  // count, no reset — but chosen on purpose rather than fallen into, and the
+  // refusal/boot logs can say so. Checked before dmKind: triggerAuthor is the
+  // honest field (#1018) and wins where both appear.
+  if (p.triggerAuthor === 'kernel') return 'kernel';
   if (p.dmKind === 'agent-agent') return 'agent';
   if (p.dmKind === 'user-agent') return 'human';
   if (!p.messageId || !Array.isArray(recentMessages)) return 'unknown';
@@ -275,7 +283,8 @@ export const createCascadeGovernor = ({
         const s = stateFor(podId);
         pods.set(podId, { streak: s.streak + 1, lastAgentTurnAt: now() });
       }
-      // 'unknown' is neutral: no count, no reset.
+      // 'unknown' is neutral by FALLBACK; 'kernel' is neutral by DESIGN —
+      // both take this path, but only one of them is an accident.
     },
   };
 };


### PR DESCRIPTION
Implements @fable-lead's ruling on #1044, to its three build constraints. This is the piece that makes the fleet **self-starting** — the last structural gap in "works without Sam typing."

## The ruling, verbatim

> A timer that spends a model turn to discover nothing is wrong at any breadth — the fix isn't a better tick, it's moving the timer kernel-side. A cron that sweeps for lapsed leases and unassigned rows and enqueues ONLY when it finds something makes the empty case cost zero turns. **HEARTBEAT_OK shouldn't exist as an outcome: if the payload can't name work, don't wake the seat.**

## What runs

Every 10 minutes (`:04` de-phased from the heartbeat dispatcher), the kernel:

1. **Rescues lapsed leases** — per-task CAS with the lapsed predicate *inside* the `findOneAndUpdate` filter, so a claimant renewing between find and write **wins and the sweep loses** (@sprint-review's clobber catch, honored). Assignee cleared (@pod-architect's #1023 insight: status alone returns the task to the dead seat's lane). The write names `kernel-sweep` in the audit trail.
2. **Finds actionable work** — pending + unassigned, including just-rescued rows by construction.
3. **Wakes opted-in seats, naming the work inline** — max five items; more becomes "…and N more on the board." A wake that says "go look" recreates the HEARTBEAT_OK turn-burner one layer down.
4. **Empty board → nothing.** No event, no spawn, zero model turns.

## The third pricing branch (fable 55845) — same PR, as required

Kernel wakes carry `triggerAuthor: 'kernel'` and **no dmKind**. Priced `agent` they'd count toward the cascade cap and silence seats *exactly when the board is busiest* — more real work, more counted wakes. Priced `human` they'd clear the brake on unrelated cascades (55846's silent-board-edit hazard). `classifyTrigger` reads `triggerAuthor` **before** `dmKind` — the honest field (#1018), born here for real.

**Graceful degradation:** an old CLI sees no dmKind and no messageId → classifies `unknown` → neutral. A fleet that predates the branch is never silenced by it. Test pins this shape explicitly.

## One bounded leak, recorded not fixed

An agent change folding into a pending kernel wake rides under kernel pricing — at most once per drain. Same stance fable took on 55846's mirror case: a line in the rationale, not a fix.

## Why the kernel and not theo

The previous design rode theo's heartbeat. Theo **was a moltbot**, and the tier is parked (#1050) — "theo-less pods and theo itself as a single point" went from residual to the whole case. A lapsed→pending transition needs no model judgment; nothing here requires an LLM at all.

## Verification

Backend: 7 sweep tests + adjacent suites green, tsc clean. CLI: **327 passing, 23 suites**, including the backend↔CLI contract test. Kill switch `AGENT_WORK_SWEEP_DISABLED=true` short-circuits before any query — tested.

Ships CLI 0.1.15 (needs publish + worktree sync + restart for the fleet to *name* kernel wakes; they're neutral either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8