### PR TITLE
fix(hire): stop selling the parked tier — catalog filter + Presets tab removal

### DIFF
--- a/backend/routes/registry/catalog.ts
+++ b/backend/routes/registry/catalog.ts
@@ -54,8 +54,24 @@ catalogRouter.get('/agents', auth, async (req: any, res: any) => {
       offset: parseInt(offset, 10),
     });
 
+    // The moltbot tier is PARKED (#1050): its gateway runs at zero replicas
+    // and its credentials died 2026-07-02. Offering its agents in the hire
+    // catalog sells a seat nothing will ever answer from — a user installs
+    // NewsHound, mentions it, and gets the exact silent-dead-seat experience
+    // the park exists to stop pretending about. Registry rows carry no runtime
+    // discriminator (all 45 are unset), so the canonical AGENT_TYPES map is
+    // the filter. When the pi/OpenCode adapters revive these identities under
+    // a new runtime, the map entry changes and they reappear here on their
+    // own — deprecation follows the runtime, not a hand-kept list.
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const AgentIdentityService = require('../../services/agentIdentityService');
+    const listable = agents.filter((a: any) => {
+      const cfg = AgentIdentityService.getAgentTypeConfig(a.agentName);
+      return !cfg || cfg.runtime !== 'moltbot';
+    });
+
     res.json({
-      agents: agents.map((a: any) => ({
+      agents: listable.map((a: any) => ({
         name: a.agentName,
         displayName: a.displayName,
         description: a.description,
@@ -65,7 +81,7 @@ catalogRouter.get('/agents', auth, async (req: any, res: any) => {
         stats: a.stats,
         iconUrl: a.iconUrl,
       })),
-      total: agents.length,
+      total: listable.length,
     });
   } catch (error) {
     console.error('Error listing agents:', error);

--- a/frontend/src/components/agents/AgentsHub.tsx
+++ b/frontend/src/components/agents/AgentsHub.tsx
@@ -125,8 +125,14 @@ const getPresetSkillStatus = (skill) => {
 };
 
 const TAB_DISCOVER = 0;
-const TAB_PRESETS = 1;
-const TAB_INSTALLED = 2;
+// TAB_PRESETS removed 2026-08-20: the presets were moltbot templates for the
+// PARKED tier (#1050), and rendering the tab exec'd into a gateway that runs
+// at zero replicas — four cards stuck on "Loading preset..." for 30 seconds,
+// then offers of agents nothing would ever run. Deprecated per Sam. The
+// backend endpoint stays for admin tooling; this surface is gone. When the
+// pi/OpenCode adapters bring templated agents back, they come back through
+// the catalog with a live runtime, not through a bespoke tab.
+const TAB_INSTALLED = 1;
 const ADMIN_VIEW_INSTALLATIONS = 'installations';
 const ADMIN_VIEW_EVENTS = 'events';
 
@@ -372,7 +378,7 @@ const AgentsHub = ({ currentPodId: propPodId = null }) => {
     return creatorId?.toString?.() === currentUserId.toString();
   };
 
-  const adminTabIndex = isGlobalAdmin ? 3 : -1;
+  const adminTabIndex = isGlobalAdmin ? 2 : -1;
 
   const formatDateTime = (value) => {
     if (!value) return '—';
@@ -450,7 +456,9 @@ const AgentsHub = ({ currentPodId: propPodId = null }) => {
   useEffect(() => {
     fetchAgents();
     fetchTemplates();
-    fetchAgentPresets();
+    // fetchAgentPresets() removed with the Presets tab — the endpoint execs
+    // into the parked moltbot gateway and hangs ~30s against a deployment
+    // that does not exist. See TAB_PRESETS removal note above.
   }, [category, searchQuery]);
 
   // Fetch installed agents for selected pod
@@ -2759,7 +2767,6 @@ const AgentsHub = ({ currentPodId: propPodId = null }) => {
       <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>
         <Tabs value={activeTab} onChange={(e, v) => setActiveTab(v)}>
           <Tab label="Discover" />
-          <Tab label={`Presets ${presets.length > 0 ? `(${presets.length})` : ''}`} />
           <Tab label={`Installed ${installedAgents.length > 0 ? `(${installedAgents.length})` : ''}`} />
           {isGlobalAdmin && (
             <Tab label={`Admin ${adminTotal > 0 ? `(${adminTotal})` : ''}`} />
@@ -2837,182 +2844,7 @@ const AgentsHub = ({ currentPodId: propPodId = null }) => {
       )}
 
       {/* Installed Tab */}
-      {activeTab === TAB_PRESETS && (
-        <Box>
-          {presetsError && (
-            <Alert severity="warning" sx={{ mb: 2 }}>
-              {presetsError}
-            </Alert>
-          )}
-          {presetCapabilities && (
-            <Paper variant="outlined" sx={{ p: 2, mb: 3, borderRadius: 2 }}>
-              <Typography variant="subtitle2" sx={{ mb: 1 }}>
-                Default Gateway Capability Snapshot
-              </Typography>
-              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                <Chip
-                  size="small"
-                  color={presetCapabilities.pluginStatus === 'detected' ? 'success' : 'default'}
-                  label={`Plugins: ${presetCapabilities.pluginStatus}`}
-                />
-                <Chip size="small" label={`Gemini ${presetCapabilities.llmProviders?.google ? 'configured' : 'missing'}`} />
-                <Chip size="small" label={`OpenAI ${presetCapabilities.llmProviders?.openai ? 'configured' : 'missing'}`} />
-                <Chip size="small" label={`Anthropic ${presetCapabilities.llmProviders?.anthropic ? 'configured' : 'missing'}`} />
-                <Chip size="small" label={`LiteLLM ${presetCapabilities.llmProviders?.litellm ? 'configured' : 'missing'}`} />
-              </Stack>
-              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mt: 1 }}>
-                <Chip
-                  size="small"
-                  label={`Built-in skills ${presetRuntimeSkills?.status || 'unknown'}${
-                    presetRuntimeSkills?.skills?.length ? ` (${presetRuntimeSkills.skills.length})` : ''
-                  }`}
-                  variant="outlined"
-                />
-                <Chip
-                  size="small"
-                  label={`Dockerfile.commonly ${presetDockerCapabilities?.status || 'unknown'}`}
-                  variant="outlined"
-                />
-              </Stack>
-            </Paper>
-          )}
-          {presetCategories.length > 1 && (
-            <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2 }}>
-              {presetCategories.map((cat) => (
-                <Chip
-                  key={cat}
-                  label={cat === 'all' ? 'All Presets' : cat}
-                  color={presetCategory === cat ? 'primary' : 'default'}
-                  variant={presetCategory === cat ? 'filled' : 'outlined'}
-                  onClick={() => setPresetCategory(cat)}
-                />
-              ))}
-            </Stack>
-          )}
-          <Grid container spacing={2}>
-            {presetsLoading
-              ? [1, 2, 3, 4].map((id) => (
-                  <Grid item xs={12} md={6} key={id}>
-                    <Card variant="outlined">
-                      <CardContent>
-                        <Typography variant="subtitle1">Loading preset...</Typography>
-                      </CardContent>
-                    </Card>
-                  </Grid>
-                ))
-              : filteredPresets.map((preset) => (
-                  <Grid item xs={12} md={6} key={preset.id}>
-                    <Card variant="outlined" sx={{ height: '100%' }}>
-                      <CardContent>
-                        <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }} flexWrap="wrap" useFlexGap>
-                          <Typography variant="h6">{preset.title}</Typography>
-                          <Chip size="small" label={preset.category} />
-                          <Chip
-                            size="small"
-                            color={preset.readiness?.ready ? 'success' : 'warning'}
-                            label={preset.readiness?.ready ? 'Ready' : 'Needs setup'}
-                          />
-                        </Stack>
-                        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                          {preset.description}
-                        </Typography>
-                        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
-                          Usage: {preset.targetUsage}
-                        </Typography>
-
-                        <Typography variant="subtitle2" sx={{ mb: 0.5 }}>Required Tools</Typography>
-                        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2 }}>
-                          {(preset.requiredTools || []).map((tool) => (
-                            <Chip
-                              key={tool.id}
-                              size="small"
-                              color={tool.available ? 'success' : 'default'}
-                              variant={tool.available ? 'filled' : 'outlined'}
-                              label={`${tool.label}${tool.available ? '' : ' (missing)'}`}
-                            />
-                          ))}
-                        </Stack>
-
-                        <Typography variant="subtitle2" sx={{ mb: 0.5 }}>API Setup</Typography>
-                        <Stack spacing={0.5}>
-                          {(preset.apiRequirements || []).map((requirement) => (
-                            <Typography key={requirement.key} variant="caption" color="text.secondary">
-                              {requirement.configured ? 'Configured' : 'Missing'}: `{requirement.key}` - {requirement.purpose}
-                            </Typography>
-                          ))}
-                        </Stack>
-                        <Typography variant="subtitle2" sx={{ mt: 2, mb: 0.5 }}>Default Skills</Typography>
-                        <Stack spacing={1}>
-                          {(preset.defaultSkills || []).map((skill) => {
-                            const status = getPresetSkillStatus(skill);
-                            return (
-                              <Box key={skill.id} sx={{ border: `1px solid ${theme.palette.divider}`, borderRadius: 1.5, p: 1 }}>
-                                <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
-                                  <Typography variant="caption" sx={{ fontWeight: 700 }}>
-                                    {skill.id}
-                                  </Typography>
-                                  <Chip size="small" color={status.color as any} label={status.label} />
-                                </Stack>
-                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-                                  {skill.reason}
-                                </Typography>
-                                {(skill.binStatus || []).length > 0 && (
-                                  <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-                                    Bins: {(skill.binStatus || [])
-                                      .map((entry) => `${entry.bin}${entry.installed ? '' : ' (missing)'}`)
-                                      .join(', ')}
-                                  </Typography>
-                                )}
-                                {(skill.envStatus || []).length > 0 && (
-                                  <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.25 }}>
-                                    Env: {(skill.envStatus || [])
-                                      .map((entry) => `${entry.key}${entry.configured ? '' : ' (missing)'}`)
-                                      .join(', ')}
-                                  </Typography>
-                                )}
-                              </Box>
-                            );
-                          })}
-                        </Stack>
-                        <Typography variant="subtitle2" sx={{ mt: 2, mb: 0.5 }}>
-                          Recommended Env/API Variables
-                        </Typography>
-                        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                          {(preset.recommendedEnv || []).map((entry) => (
-                            <Chip
-                              key={entry.key}
-                              size="small"
-                              color={entry.configured ? 'success' : 'default'}
-                              variant={entry.configured ? 'filled' : 'outlined'}
-                              label={`${entry.key}${entry.configured ? '' : ' (missing)'}`}
-                              title={entry.purpose || ''}
-                            />
-                          ))}
-                        </Stack>
-                      </CardContent>
-                      <CardActions sx={{ px: 2, pb: 2, pt: 0 }}>
-                        <Button
-                          variant="contained"
-                          onClick={() => handleInstallPreset(preset)}
-                          disabled={presetInstallLoadingId === preset.id}
-                        >
-                          {presetInstallLoadingId === preset.id ? 'Preparing...' : 'Install Preset'}
-                        </Button>
-                        <Button variant="text" size="small" onClick={() => setActiveTab(TAB_DISCOVER)}>
-                          Browse Agent
-                        </Button>
-                      </CardActions>
-                    </Card>
-                  </Grid>
-                ))}
-          </Grid>
-          {!presetsLoading && filteredPresets.length === 0 && !presetsError && (
-            <Alert severity="info" sx={{ mt: 2 }}>
-              No presets available for this category.
-            </Alert>
-          )}
-        </Box>
-      )}
+      {/* Presets panel removed with the tab — see TAB_PRESETS note near the top. */}
 
       {activeTab === TAB_INSTALLED && (
         <Box>


### PR DESCRIPTION
Sam opened Hire-an-agent and called both halves of this correctly.

## What he saw, verified live

**Discover's first cards were NewsHound and SocialPulse** — both `moltbot` runtime per the canonical `AGENT_TYPES` map. Their gateway runs at **zero replicas** and their credentials died **July 2** (#1050). Install one today and you've hired a seat nothing will ever answer from — the silent-dead-seat experience, sold through the front door.

**The Presets tab showed four cards stuck on "Loading preset…"** — its endpoint execs into the parked gateway with a **30-second timeout**, hanging every page load against a deployment that doesn't exist, before offering theo/nova/pixel templates for a retired runtime.

## The changes

**Catalog filter (backend):** registry rows carry no runtime discriminator (checked: all 45 are unset), so `AGENT_TYPES` is the filter — entries whose runtime is `moltbot` are excluded from browse. When pi/OpenCode revives those identities under a live runtime, the map entry changes and they **reappear on their own**. Deprecation follows the runtime, not a hand-kept list.

**Presets tab (frontend):** tab removed, 177-line panel excised, the mount-time fetch dropped — so the 30s hang leaves the whole page, not just the tab. Backend endpoint stays for admin tooling.

## Scope held deliberately

The deeper preset-state excision (`installPresetContext` etc.) threads into the *live* install flow — not worth destabilising for dead code Vite doesn't even warn on. It rides the pi/OpenCode revival. Verified: no `noUnusedLocals` in frontend tsconfig, syntax-checked the edited file, and the build is Vite (my earlier CRA framing of this app was wrong — only the jest config is react-scripts-era).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8