### PR TITLE
fix(v2): stop firing a 404 before every fallback avatar

### DIFF
--- a/frontend/src/v2/components/V2Avatar.tsx
+++ b/frontend/src/v2/components/V2Avatar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { normalizeUploadUrl } from '../../utils/apiBaseUrl';
+import { getAvatarSrc } from '../../utils/avatarUtils';
 import {
   characterAvatarFor, gradientFor, initialsFor, AvatarKind,
 } from '../utils/avatars';
@@ -46,7 +46,16 @@ const V2Avatar: React.FC<V2AvatarProps> = ({
   const initials = initialsFor(seed);
   const display = title || seed || undefined;
   const rawSrc = typeof src === 'string' && src.trim().length > 0 ? src.trim() : null;
-  const cleanSrc = normalizeUploadUrl(rawSrc) || null;
+  // getAvatarSrc, NOT normalizeUploadUrl. Every User row's profilePicture
+  // defaults to the literal string 'default' (models/User.ts), which
+  // normalizeUploadUrl passes through untouched — so every default-avatar user
+  // rendered <img src="default">, fired a guaranteed 404 relative to the page,
+  // and only reached the character/initials tier after the error round-trip.
+  // getAvatarSrc (the v1 util) already knows the sentinel ids ('default' and
+  // the legacy color names) mean NO IMAGE, and returns null for anything that
+  // is not a plausible image reference — no request, no flash, straight to the
+  // right tier.
+  const cleanSrc = getAvatarSrc(rawSrc) || null;
   const [imgFailed, setImgFailed] = React.useState(false);
 
   // Character tier (photo still wins, below). Memoized because the SVG build


### PR DESCRIPTION
Every User row defaults `profilePicture` to the **literal string `'default'`** (`models/User.ts:202`). V2Avatar passed it straight to `<img>`, so every default-avatar user fired a guaranteed 404 (resolved relative to the page), and only reached the robot/face/initials tier after the error round-trip.

Three costs, all removed by routing through `getAvatarSrc` — the v1 util that already knows the sentinel ids:

1. **A wasted request per avatar per user** — chat renders dozens at once.
2. **A flash** — photo attempt → error → re-render to the real tier.
3. **The one that answered Sam's question:** `photo: true` for everyone made the face/robot tiers look like they rarely applied — they were hiding behind an error path. Robots and bigSmile faces now render immediately for every user without a real photo.

Found while answering why the human avatar tier seemed invisible. The util predates v2 and handles `'default'` plus the legacy color-name ids; v2 simply never used it. Sixth "the answer already existed, unwired" of the week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8