### PR TITLE
feat(avatars): preset pickers for humans AND agents; deprecate AI generation

### DIFF
--- a/backend/__tests__/unit/routes/agentProfile.avatar.test.js
+++ b/backend/__tests__/unit/routes/agentProfile.avatar.test.js
@@ -1,0 +1,161 @@
+/**
+ * Owner-editable agent avatar (Sam, 2026-08-20).
+ *
+ * The gate is creation-shaped: the caller must be an admin or the installer of
+ * an ACTIVE installation of this agent. These tests pin the gate and the write
+ * order — Mongo User first (source of truth), then the PG mirror through the
+ * ONE sanctioned door (syncUserToPostgreSQL), then AgentRegistry.iconUrl so
+ * the Your-Team cards can't drift from the profile.
+ */
+
+jest.mock('../../../models/User', () => ({
+  findOneAndUpdate: jest.fn(),
+}));
+jest.mock('../../../models/Pod', () => ({}));
+jest.mock('../../../models/AgentMemory', () => ({}));
+jest.mock('../../../models/AgentRun', () => ({}));
+jest.mock('../../../models/PodAsset', () => ({}));
+jest.mock('../../../models/pg/Message', () => ({}));
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { findOne: jest.fn() },
+  AgentRegistry: { updateOne: jest.fn() },
+}));
+jest.mock('../../../services/agentIdentityService', () => ({
+  resolveAgentDisplayLabel: jest.fn((u, f) => f),
+  syncUserToPostgreSQL: jest.fn(),
+}));
+// jsonwebtoken crashes under Node 26 in jest (buffer-equal-constant-time);
+// route suites mock the middleware and call handlers directly.
+jest.mock('../../../middleware/auth', () => jest.fn((req, res, next) => next()));
+
+const User = require('../../../models/User');
+const { AgentInstallation, AgentRegistry } = require('../../../models/AgentRegistry');
+const AgentIdentityService = require('../../../services/agentIdentityService');
+const router = require('../../../routes/agentProfile');
+
+const getHandler = (method, path) => {
+  const layer = router.stack.find((entry) => (
+    entry.route && entry.route.path === path && entry.route.methods[method]
+  ));
+  if (!layer) throw new Error(`${method.toUpperCase()} ${path} handler not found`);
+  return layer.route.stack[layer.route.stack.length - 1].handle;
+};
+
+const response = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn(),
+});
+
+const installationLookup = (result) => {
+  AgentInstallation.findOne.mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(result) }),
+  });
+};
+
+const putAvatar = getHandler('put', '/:agentName/:instanceId?/avatar');
+const canEdit = getHandler('get', '/:agentName/:instanceId?/avatar/can-edit');
+
+describe('agent avatar editing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    User.findOneAndUpdate.mockResolvedValue({ _id: 'bot-1', profilePicture: 'bottts:theo:v3' });
+    AgentRegistry.updateOne.mockResolvedValue({});
+    AgentIdentityService.syncUserToPostgreSQL.mockResolvedValue(undefined);
+  });
+
+  const reqFor = (user, avatar = 'bottts:theo:default-v3') => ({
+    params: { agentName: 'theo', instanceId: 'default' },
+    body: { avatar },
+    userId: user.id,
+    user,
+  });
+
+  it('lets the installer of an active installation update the avatar', async () => {
+    installationLookup({ _id: 'inst-1' });
+    const res = response();
+
+    await putAvatar(reqFor({ id: 'owner-1', role: 'user' }), res);
+
+    // The gate queried for THIS caller's active installation of THIS agent.
+    expect(AgentInstallation.findOne).toHaveBeenCalledWith({
+      agentName: 'theo', instanceId: 'default', status: 'active', installedBy: 'owner-1',
+    });
+    expect(User.findOneAndUpdate).toHaveBeenCalledWith(
+      { isBot: true, 'botMetadata.agentName': 'theo', 'botMetadata.instanceId': 'default' },
+      { $set: { profilePicture: 'bottts:theo:default-v3' } },
+      { new: true },
+    );
+    // Both downstream surfaces moved in the same request.
+    expect(AgentIdentityService.syncUserToPostgreSQL).toHaveBeenCalled();
+    expect(AgentRegistry.updateOne).toHaveBeenCalledWith(
+      { agentName: 'theo' }, { $set: { iconUrl: 'bottts:theo:default-v3' } },
+    );
+    expect(res.json).toHaveBeenCalledWith({ ok: true, avatar: 'bottts:theo:default-v3' });
+  });
+
+  it('403s a stranger without touching any store', async () => {
+    installationLookup(null);
+    const res = response();
+
+    await putAvatar(reqFor({ id: 'stranger-9', role: 'user' }), res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(User.findOneAndUpdate).not.toHaveBeenCalled();
+    expect(AgentRegistry.updateOne).not.toHaveBeenCalled();
+  });
+
+  it('lets an admin edit without owning an installation', async () => {
+    const res = response();
+
+    await putAvatar(reqFor({ id: 'admin-1', role: 'admin' }), res);
+
+    expect(AgentInstallation.findOne).not.toHaveBeenCalled();
+    expect(User.findOneAndUpdate).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+  });
+
+  it('400s anything that is not a bottts preset or an upload reference', async () => {
+    const res = response();
+    // AI-generation URLs, data URIs, and the human face scheme are all invalid
+    // here — agents are robots, and raw generation is deprecated.
+    for (const bad of ['bigsmile:sam-v1', 'data:image/png;base64,AAAA', 'javascript:alert(1)', '']) {
+      await putAvatar(reqFor({ id: 'admin-1', role: 'admin' }, bad), res);
+    }
+    expect(res.status).toHaveBeenCalledTimes(4);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(User.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('accepts an uploaded-image reference', async () => {
+    const res = response();
+    await putAvatar(reqFor({ id: 'admin-1', role: 'admin' }, '/api/uploads/custom-icon.png'), res);
+    expect(res.json).toHaveBeenCalledWith({ ok: true, avatar: '/api/uploads/custom-icon.png' });
+  });
+
+  it('404s when no bot User row matches the identity', async () => {
+    User.findOneAndUpdate.mockResolvedValue(null);
+    const res = response();
+    await putAvatar(reqFor({ id: 'admin-1', role: 'admin' }), res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(AgentRegistry.updateOne).not.toHaveBeenCalled();
+  });
+
+  it('still succeeds when the PG mirror write fails — Mongo is the source of truth', async () => {
+    AgentIdentityService.syncUserToPostgreSQL.mockRejectedValue(new Error('pg down'));
+    const res = response();
+    await putAvatar(reqFor({ id: 'admin-1', role: 'admin' }), res);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+  });
+
+  it('can-edit reports the same verdict the write path enforces', async () => {
+    installationLookup({ _id: 'inst-1' });
+    const yes = response();
+    await canEdit(reqFor({ id: 'owner-1', role: 'user' }), yes);
+    expect(yes.json).toHaveBeenCalledWith({ canEdit: true });
+
+    installationLookup(null);
+    const no = response();
+    await canEdit(reqFor({ id: 'stranger-9', role: 'user' }), no);
+    expect(no.json).toHaveBeenCalledWith({ canEdit: false });
+  });
+});

--- a/backend/routes/agentProfile.ts
+++ b/backend/routes/agentProfile.ts
@@ -40,6 +40,12 @@ const PodAsset = require('../models/PodAsset');
 const PGMessage = require('../models/pg/Message');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { resolveAgentDisplayLabel } = require('../services/agentIdentityService');
+// eslint-disable-next-line global-require
+const AgentIdentityService = require('../services/agentIdentityService');
+// eslint-disable-next-line global-require
+const authMiddleware = require('../middleware/auth');
+// eslint-disable-next-line global-require
+const { AgentRegistry } = require('../models/AgentRegistry');
 
 interface Res {
   status: (n: number) => Res;
@@ -219,6 +225,93 @@ router.get('/:agentName/:instanceId?', async (req: Req, res: Res) => {
   } catch (err) {
     console.error('[agent-profile] error:', (err as Error).message);
     res.status(500).json({ error: 'Server Error' });
+  }
+});
+
+
+// ── Owner-editable agent avatar (Sam, 2026-08-20) ───────────────────────────
+//
+// "If created by someone" — the gate is creation-shaped: the caller must be an
+// admin or the installer of an active installation of this agent. Accepts the
+// deterministic robot scheme ('bottts:<seed>') or an uploaded-image reference;
+// never raw AI generation, which is deprecated.
+//
+// Writes go through the ONE sanctioned door for the dual-store problem:
+// Mongo User first, then AgentIdentityService.syncUserToPostgreSQL — the July
+// half-write incident is why no code path may touch pg users directly. If the
+// mirror is retired (#1062), the sync call becomes a no-op and this endpoint
+// stays correct unchanged. The registry iconUrl (the Your-Team card source)
+// moves in the same request so the three icon surfaces cannot drift.
+
+const canEditAgentAvatar = async (req: any, agentName: string, instanceId: string): Promise<boolean> => {
+  const callerId = req.userId || req.user?._id || req.user?.id;
+  if (!callerId) return false;
+  if (req.user?.role === 'admin') return true;
+  const owned = await AgentInstallation.findOne({
+    agentName,
+    instanceId,
+    status: 'active',
+    installedBy: callerId,
+  }).select('_id').lean();
+  return Boolean(owned);
+};
+
+const AGENT_AVATAR_SCHEME = /^bottts:[\w:.-]{1,120}$/;
+const isUploadRef = (v: string): boolean => (
+  v.startsWith('/api/uploads/') || v.startsWith('/uploads/') || /^https:\/\/[^\s]+\/(api\/)?uploads\//.test(v)
+);
+
+router.get('/:agentName/:instanceId?/avatar/can-edit', authMiddleware, async (req: any, res: Res) => {
+  const agentName = String(req.params?.agentName || '').trim().toLowerCase();
+  const instanceId = String(req.params?.instanceId || 'default').trim() || 'default';
+  res.json({ canEdit: await canEditAgentAvatar(req, agentName, instanceId) });
+});
+
+router.put('/:agentName/:instanceId?/avatar', authMiddleware, async (req: any, res: Res) => {
+  try {
+    const agentName = String(req.params?.agentName || '').trim().toLowerCase();
+    const instanceId = String(req.params?.instanceId || 'default').trim() || 'default';
+    const avatar = String(req.body?.avatar || '').trim();
+
+    if (!AGENT_AVATAR_SCHEME.test(avatar) && !isUploadRef(avatar)) {
+      res.status(400).json({ error: 'avatar must be a bottts:<seed> preset or an uploaded image reference' });
+      return;
+    }
+    if (!(await canEditAgentAvatar(req, agentName, instanceId))) {
+      res.status(403).json({ error: "Only the agent's installer or an admin can edit its avatar" });
+      return;
+    }
+
+    const user = await User.findOneAndUpdate(
+      { isBot: true, 'botMetadata.agentName': agentName, 'botMetadata.instanceId': instanceId },
+      { $set: { profilePicture: avatar } },
+      { new: true },
+    );
+    if (!user) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+
+    // The chat stream reads the PG mirror; skipping this line is exactly the
+    // July incident. Fire-and-log rather than fail the request: Mongo is the
+    // source of truth.
+    try {
+      await AgentIdentityService.syncUserToPostgreSQL(user);
+    } catch (syncErr) {
+      console.warn('[agent-avatar] pg mirror sync failed (mongo committed):', (syncErr as Error).message);
+    }
+
+    // Your-Team cards read AgentRegistry.iconUrl; move it in the same request.
+    try {
+      await AgentRegistry.updateOne({ agentName }, { $set: { iconUrl: avatar } });
+    } catch (regErr) {
+      console.warn('[agent-avatar] registry iconUrl update failed:', (regErr as Error).message);
+    }
+
+    res.json({ ok: true, avatar });
+  } catch (err) {
+    console.error('[agent-avatar] update failed:', err);
+    res.status(500).json({ error: 'Failed to update avatar' });
   }
 });
 

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -34,13 +34,12 @@ import KeyIcon from '@mui/icons-material/Key';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { avatarOptions, getAvatarColor, getAvatarSrc } from '../utils/avatarUtils';
+import { avatarOptions, getAvatarColor, getAvatarSrc, presetFaceOptions } from '../utils/avatarUtils';
 import { useAppContext } from '../context/AppContext';
 import { useAuth } from '../context/AuthContext';
 import { blurActiveElement } from '../utils/focusUtils';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import AppsManagement from './AppsManagement';
-import AvatarGenerator from './agents/AvatarGenerator';
 import AdminUsers from './admin/AdminUsers';
 import { useV2Embedded } from '../v2/hooks/useV2Embedded';
 
@@ -102,7 +101,6 @@ const UserProfile = () => {
     const [avatarFile, setAvatarFile] = useState<File | null>(null);
     const [avatarPreview, setAvatarPreview] = useState('');
     const [isUpdating, setIsUpdating] = useState(false);
-    const [avatarGeneratorOpen, setAvatarGeneratorOpen] = useState(false);
     const [currentTab, setCurrentTab] = useState('overview');
     const [apiToken, setApiToken] = useState<string | null>(null);
     const [apiTokenCreatedAt, setApiTokenCreatedAt] = useState<string | null>(null);
@@ -227,14 +225,6 @@ const UserProfile = () => {
         setSelectedAvatar(avatarId);
         setAvatarFile(null);
         setAvatarPreview('');
-    };
-
-    const handleGeneratedAvatarSelect = (avatarDataUri: string) => {
-        if (!avatarDataUri) return;
-        setSelectedAvatar(avatarDataUri);
-        setAvatarFile(null);
-        setAvatarPreview('');
-        setAvatarGeneratorOpen(false);
     };
 
     const handleAvatarFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -851,30 +841,27 @@ const UserProfile = () => {
                                     onChange={handleAvatarFileChange}
                                 />
                             </Button>
-                            <Button
-                                variant="outlined"
-                                onClick={() => setAvatarGeneratorOpen(true)}
-                            >
-                                Generate with AI
-                            </Button>
                         </Box>
                     </Box>
+                    {/* Generated face presets (Sam, 2026-08-20). Replaces the flat
+                        color circles AND the deprecated Generate-with-AI flow: eight
+                        deterministic bigSmile faces seeded off the user's identity, so
+                        this grid is personal and never reshuffles between visits. The
+                        pick is stored as 'bigsmile:<seed>' and regenerated locally by
+                        every renderer — no image hosting, no API spend, no 404s. */}
                     <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, justifyContent: 'center', my: 2 }}>
-                        {avatarOptions.map((avatar) => (
+                        {presetFaceOptions(user.username || 'user').map((face) => (
                             <Avatar
-                                key={avatar.id}
+                                key={face.id}
+                                src={face.src || undefined}
                                 sx={{
                                     width: 60,
                                     height: 60,
-                                    bgcolor: avatar.color,
-                                    fontSize: '1.5rem',
                                     cursor: 'pointer',
-                                    border: selectedAvatar === avatar.id ? '3px solid #1976d2' : 'none',
+                                    border: selectedAvatar === face.id ? '3px solid #1976d2' : 'none',
                                 }}
-                                onClick={() => handleAvatarSelect(avatar.id)}
-                            >
-                                {user.username.charAt(0).toUpperCase()}
-                            </Avatar>
+                                onClick={() => handleAvatarSelect(face.id)}
+                            />
                         ))}
                     </Box>
                 </DialogContent>
@@ -889,16 +876,6 @@ const UserProfile = () => {
                     </Button>
                 </DialogActions>
             </Dialog>
-            )}
-
-            {isOwnProfile && (
-            <AvatarGenerator
-                open={avatarGeneratorOpen}
-                onClose={() => setAvatarGeneratorOpen(false)}
-                onSelect={handleGeneratedAvatarSelect}
-                agentName={user.username || 'user'}
-                targetType="user"
-            />
             )}
 
             {/* Snackbar for notifications */}

--- a/frontend/src/components/agents/AgentsHub.tsx
+++ b/frontend/src/components/agents/AgentsHub.tsx
@@ -59,7 +59,6 @@ import {
 } from '@mui/icons-material';
 import AgentCard from './AgentCard';
 import ClawdbotConfigPanel from './ClawdbotConfigPanel';
-import AvatarGenerator from './AvatarGenerator';
 import AgentEventsDebugPage from '../admin/AgentEventsDebugPage';
 import axios from 'axios';
 import { useAuth } from '../../context/AuthContext';
@@ -250,7 +249,6 @@ const AgentsHub = ({ currentPodId: propPodId = null }) => {
   const [runtimeStatusLoading, setRuntimeStatusLoading] = useState(false);
   const [createAgentAvatarFile, setCreateAgentAvatarFile] = useState(null);
   const [createAgentAvatarPreview, setCreateAgentAvatarPreview] = useState('');
-  const [avatarGeneratorOpen, setAvatarGeneratorOpen] = useState(false);
   const [editTemplateOpen, setEditTemplateOpen] = useState(false);
   const [editTemplate, setEditTemplate] = useState(null);
   const [editTemplateAvatarFile, setEditTemplateAvatarFile] = useState(null);
@@ -996,7 +994,6 @@ const AgentsHub = ({ currentPodId: propPodId = null }) => {
 
     setCreateAgentAvatarFile(file);
     setCreateAgentAvatarPreview(avatarDataUri);
-    setAvatarGeneratorOpen(false);
   };
 
   /**
@@ -4753,14 +4750,6 @@ const AgentsHub = ({ currentPodId: propPodId = null }) => {
               src={createAgentAvatarPreview || undefined}
             />
             <Stack direction="row" spacing={1}>
-              <Button
-                variant="contained"
-                size="small"
-                onClick={() => setAvatarGeneratorOpen(true)}
-                disabled={!createAgentName}
-              >
-                🎨 Generate AI Avatar
-              </Button>
               <Button variant="outlined" size="small" component="label">
                 Upload
                 <input
@@ -4857,13 +4846,6 @@ const AgentsHub = ({ currentPodId: propPodId = null }) => {
       </Dialog>
 
       {/* AI Avatar Generator Modal */}
-      <AvatarGenerator
-        open={avatarGeneratorOpen}
-        onClose={() => setAvatarGeneratorOpen(false)}
-        onSelect={handleAvatarGenerated}
-        agentName={createAgentName}
-        targetType="agent"
-      />
     </Container>
   );
 };

--- a/frontend/src/utils/__tests__/avatarPresetFaces.test.ts
+++ b/frontend/src/utils/__tests__/avatarPresetFaces.test.ts
@@ -1,0 +1,46 @@
+import {
+  FACE_PRESET_PREFIX, getAvatarSrc, isFacePresetId, presetFaceOptions, avatarOptions,
+} from '../avatarUtils';
+
+/**
+ * The picked-face scheme (Sam, 2026-08-20): users select from generated
+ * presets, stored as 'bigsmile:<seed>' and regenerated locally everywhere.
+ * These pin the properties that make a picker trustworthy.
+ */
+describe('preset face avatars', () => {
+  test('the grid is personal and never reshuffles between visits', () => {
+    // A picker whose options change reads as broken — and "the face I picked
+    // last month" must still be in the grid when the user returns.
+    const a = presetFaceOptions('sam');
+    const b = presetFaceOptions('sam');
+    expect(a.map((f) => f.id)).toEqual(b.map((f) => f.id));
+    expect(a.map((f) => f.src)).toEqual(b.map((f) => f.src));
+    expect(a).toHaveLength(8);
+  });
+
+  test('different users see different grids', () => {
+    const sam = presetFaceOptions('sam').map((f) => f.src);
+    const lily = presetFaceOptions('lily').map((f) => f.src);
+    expect(sam).not.toEqual(lily);
+  });
+
+  test('a stored pick round-trips through getAvatarSrc to the exact same face', () => {
+    const picked = presetFaceOptions('sam')[2];
+    // What the profile stores is the id; what every renderer shows must be the
+    // identical face the user chose in the picker.
+    expect(getAvatarSrc(picked.id)).toBe(picked.src);
+    expect(getAvatarSrc(picked.id)).toMatch(/^data:image\/svg\+xml/);
+  });
+
+  test('the scheme cannot collide with legacy color ids or real URLs', () => {
+    expect(isFacePresetId(`${FACE_PRESET_PREFIX}x`)).toBe(true);
+    expect(isFacePresetId('default')).toBe(false);
+    expect(isFacePresetId('https://example.com/a.png')).toBe(false);
+    // Legacy color ids still resolve to null (initials/tint path) — existing
+    // users' stored values keep rendering even though the picker no longer
+    // offers colors.
+    for (const opt of avatarOptions) {
+      expect(getAvatarSrc(opt.id)).toBeNull();
+    }
+  });
+});

--- a/frontend/src/utils/avatarUtils.ts
+++ b/frontend/src/utils/avatarUtils.ts
@@ -1,4 +1,6 @@
 import { normalizeUploadUrl } from './apiBaseUrl';
+// eslint-disable-next-line import/no-cycle
+import { characterAvatarFor } from '../v2/utils/avatars';
 
 interface AvatarOption {
   id: string;
@@ -22,6 +24,39 @@ export const getAvatarColor = (avatarId: string | undefined | null): string => {
   return avatar ? avatar.color : 'primary.main';
 };
 
+
+// ── Generated face presets ──────────────────────────────────────────────────
+//
+// Sam's ruling (2026-08-20): users pick their avatar from a preset of
+// GENERATED faces (or upload); the AI image-generation feature is deprecated.
+// Deterministic presets beat AI generation on every axis that bit us this
+// week: no per-pick API cost, same face forever, and SVG that scales to any
+// surface.
+//
+// Storage scheme: profilePicture = 'bigsmile:<seed>'. The seed — not image
+// bytes or a URL — is the identity, so every renderer regenerates the exact
+// face locally and nothing 404s, expires, or needs hosting. getAvatarSrc
+// resolves the scheme, which means every existing consumer (v1 Avatar src,
+// V2Avatar) renders picked faces with zero per-component changes.
+export const FACE_PRESET_PREFIX = 'bigsmile:';
+
+export const isFacePresetId = (value: string | undefined | null): boolean => (
+  typeof value === 'string' && value.startsWith(FACE_PRESET_PREFIX)
+);
+
+/**
+ * Eight stable face options for a user. Seeded off their identity so the grid
+ * is personal and NEVER reshuffles — a picker whose options change between
+ * visits reads as broken, and "the face I picked last month" must still be in
+ * the grid when they come back.
+ */
+export const presetFaceOptions = (seedBase: string): Array<{ id: string; src: string | null }> => (
+  Array.from({ length: 8 }, (_, i) => {
+    const seed = `${seedBase}-v${i + 1}`;
+    return { id: `${FACE_PRESET_PREFIX}${seed}`, src: characterAvatarFor(seed, 'human') };
+  })
+);
+
 const isLikelyImageUrl = (value: string | undefined | null): boolean => {
   if (!value || typeof value !== 'string') return false;
   if (value.startsWith('data:image/')) return true;
@@ -33,5 +68,10 @@ const isLikelyImageUrl = (value: string | undefined | null): boolean => {
 export const getAvatarSrc = (avatarId: string | undefined | null): string | null | undefined => {
   if (!avatarId) return null;
   if (avatarOptions.some((option) => option.id === avatarId)) return null;
+  // Picked face preset: regenerate locally from the stored seed. Data-URI out,
+  // so every <img>-based consumer renders it with no network involved.
+  if (isFacePresetId(avatarId)) {
+    return characterAvatarFor(avatarId.slice(FACE_PRESET_PREFIX.length), 'human');
+  }
   return isLikelyImageUrl(avatarId) ? normalizeUploadUrl(avatarId) : null;
 };

--- a/frontend/src/utils/avatarUtils.ts
+++ b/frontend/src/utils/avatarUtils.ts
@@ -1,6 +1,6 @@
 import { normalizeUploadUrl } from './apiBaseUrl';
 // eslint-disable-next-line import/no-cycle
-import { characterAvatarFor } from '../v2/utils/avatars';
+import { characterAvatarFor, AvatarKind } from '../v2/utils/avatars';
 
 interface AvatarOption {
   id: string;
@@ -39,9 +39,23 @@ export const getAvatarColor = (avatarId: string | undefined | null): string => {
 // resolves the scheme, which means every existing consumer (v1 Avatar src,
 // V2Avatar) renders picked faces with zero per-component changes.
 export const FACE_PRESET_PREFIX = 'bigsmile:';
+// Agents use the same scheme with their own species (Sam: owners can edit an
+// agent's avatar too). One resolver, two prefixes — the prefix IS the kind.
+export const ROBOT_PRESET_PREFIX = 'bottts:';
+
+const PRESET_KINDS: Array<{ prefix: string; kind: AvatarKind }> = [
+  { prefix: FACE_PRESET_PREFIX, kind: 'human' },
+  { prefix: ROBOT_PRESET_PREFIX, kind: 'agent' },
+];
+
+const presetOf = (value: string | undefined | null) => (
+  typeof value === 'string'
+    ? PRESET_KINDS.find((p) => value.startsWith(p.prefix)) || null
+    : null
+);
 
 export const isFacePresetId = (value: string | undefined | null): boolean => (
-  typeof value === 'string' && value.startsWith(FACE_PRESET_PREFIX)
+  presetOf(value) !== null
 );
 
 /**
@@ -51,11 +65,19 @@ export const isFacePresetId = (value: string | undefined | null): boolean => (
  * the grid when they come back.
  */
 export const presetFaceOptions = (seedBase: string): Array<{ id: string; src: string | null }> => (
-  Array.from({ length: 8 }, (_, i) => {
-    const seed = `${seedBase}-v${i + 1}`;
-    return { id: `${FACE_PRESET_PREFIX}${seed}`, src: characterAvatarFor(seed, 'human') };
-  })
+  presetCharacterOptions(seedBase, 'human')
 );
+
+export const presetCharacterOptions = (
+  seedBase: string,
+  kind: AvatarKind,
+): Array<{ id: string; src: string | null }> => {
+  const prefix = kind === 'agent' ? ROBOT_PRESET_PREFIX : FACE_PRESET_PREFIX;
+  return Array.from({ length: 8 }, (_, i) => {
+    const seed = `${seedBase}-v${i + 1}`;
+    return { id: `${prefix}${seed}`, src: characterAvatarFor(seed, kind) };
+  });
+};
 
 const isLikelyImageUrl = (value: string | undefined | null): boolean => {
   if (!value || typeof value !== 'string') return false;
@@ -68,10 +90,12 @@ const isLikelyImageUrl = (value: string | undefined | null): boolean => {
 export const getAvatarSrc = (avatarId: string | undefined | null): string | null | undefined => {
   if (!avatarId) return null;
   if (avatarOptions.some((option) => option.id === avatarId)) return null;
-  // Picked face preset: regenerate locally from the stored seed. Data-URI out,
-  // so every <img>-based consumer renders it with no network involved.
-  if (isFacePresetId(avatarId)) {
-    return characterAvatarFor(avatarId.slice(FACE_PRESET_PREFIX.length), 'human');
+  // Picked character preset (face or robot): regenerate locally from the
+  // stored seed. Data-URI out, so every <img>-based consumer renders it with
+  // no network involved.
+  const preset = presetOf(avatarId);
+  if (preset) {
+    return characterAvatarFor(avatarId.slice(preset.prefix.length), preset.kind);
   }
   return isLikelyImageUrl(avatarId) ? normalizeUploadUrl(avatarId) : null;
 };

--- a/frontend/src/v2/agents/V2AgentProfile.tsx
+++ b/frontend/src/v2/agents/V2AgentProfile.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import axios from 'axios';
 import getApiBaseUrl from '../../utils/apiBaseUrl';
 import V2Avatar from '../components/V2Avatar';
+import { presetCharacterOptions } from '../../utils/avatarUtils';
 import '../v2.css';
 import './v2-agent-profile.css';
 
@@ -169,6 +170,40 @@ const V2AgentProfile: React.FC = () => {
 
   useEffect(() => { fetchProfile(); fetchMemoryIndex(); }, [fetchProfile, fetchMemoryIndex]);
 
+  // Owner-editable avatar (Sam, 2026-08-20): visible only when the caller is
+  // the agent's installer or an admin — the backend is the real gate; this
+  // check only decides whether to show the affordance.
+  const [canEditAvatar, setCanEditAvatar] = useState(false);
+  const [avatarDialogOpen, setAvatarDialogOpen] = useState(false);
+  const [savingAvatar, setSavingAvatar] = useState(false);
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token || !agentName) return;
+    getClient()
+      .get(`/api/agent-profile/${agentName}/${instanceId || 'default'}/avatar/can-edit`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      .then((r) => setCanEditAvatar(Boolean(r.data?.canEdit)))
+      .catch(() => setCanEditAvatar(false));
+  }, [agentName, instanceId]);
+
+  const saveAvatar = async (avatarId: string) => {
+    const token = localStorage.getItem('token');
+    if (!token || !agentName) return;
+    setSavingAvatar(true);
+    try {
+      await getClient().put(
+        `/api/agent-profile/${agentName}/${instanceId || 'default'}/avatar`,
+        { avatar: avatarId },
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      window.location.reload();
+    } catch {
+      setSavingAvatar(false);
+    }
+  };
+
+
   if (state === 'loading') {
     return (
       <div className="v2-root v2-aprofile">
@@ -211,6 +246,40 @@ const V2AgentProfile: React.FC = () => {
             kind="agent"
             seed={`${agent.agentName}:${agent.instanceId || 'default'}`}
           />
+          {canEditAvatar && (
+            <button
+              type="button"
+              className="v2-aprofile__avatar-edit"
+              onClick={() => setAvatarDialogOpen(true)}
+            >
+              Edit avatar
+            </button>
+          )}
+          {avatarDialogOpen && (
+            <div className="v2-aprofile__avatar-dialog" role="dialog" aria-label="Choose an avatar">
+              {/* Eight deterministic robots seeded off this agent's identity —
+                  same grid every visit, and the pick is stored as a seed so
+                  every surface regenerates it locally. Uploads keep working
+                  through the existing profile-picture path; AI generation is
+                  deprecated and deliberately absent here. */}
+              <div className="v2-aprofile__avatar-grid">
+                {presetCharacterOptions(`${agent.agentName}:${agent.instanceId || 'default'}`, 'agent').map((robot) => (
+                  <button
+                    key={robot.id}
+                    type="button"
+                    className="v2-aprofile__avatar-choice"
+                    disabled={savingAvatar}
+                    onClick={() => saveAvatar(robot.id)}
+                  >
+                    <img src={robot.src || ''} alt="robot avatar option" width={56} height={56} style={{ borderRadius: '50%' }} />
+                  </button>
+                ))}
+              </div>
+              <button type="button" className="v2-aprofile__avatar-cancel" onClick={() => setAvatarDialogOpen(false)}>
+                Cancel
+              </button>
+            </div>
+          )}
           <div className="v2-aprofile__hero-text">
             <div className="v2-aprofile__name-row">
               <h1 className="v2-aprofile__name">{agent.displayName}</h1>

--- a/frontend/src/v2/agents/v2-agent-profile.css
+++ b/frontend/src/v2/agents/v2-agent-profile.css
@@ -218,3 +218,51 @@
   border-color: #c0392b;
 }
 .v2-root button.v2-aprofile__pod-remove:disabled { opacity: 0.6; cursor: default; }
+
+/* Owner-editable avatar picker (visible only to installer/admin) */
+.v2-aprofile__avatar-edit {
+  align-self: flex-end;
+  margin-left: -14px;
+  padding: 4px 10px;
+  font-size: 12px;
+  color: var(--v2-text-secondary);
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-lg);
+  cursor: pointer;
+}
+.v2-aprofile__avatar-edit:hover { color: var(--v2-text); border-color: var(--v2-text-secondary); }
+.v2-aprofile__avatar-dialog {
+  position: absolute;
+  z-index: 30;
+  margin-top: 8px;
+  padding: 14px;
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-lg);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
+}
+.v2-aprofile__avatar-grid { display: grid; grid-template-columns: repeat(4, 56px); gap: 10px; }
+.v2-aprofile__avatar-choice {
+  padding: 2px;
+  background: none;
+  border: 2px solid transparent;
+  border-radius: 50%;
+  cursor: pointer;
+  line-height: 0;
+}
+.v2-aprofile__avatar-choice:hover, .v2-aprofile__avatar-choice:focus-visible { border-color: var(--v2-accent); }
+.v2-aprofile__avatar-choice:disabled { opacity: 0.5; cursor: wait; }
+.v2-aprofile__avatar-cancel {
+  display: block;
+  margin: 10px auto 0;
+  padding: 4px 12px;
+  font-size: 12px;
+  color: var(--v2-text-secondary);
+  background: none;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-lg);
+  cursor: pointer;
+}
+/* The picker dialog anchors to the hero card. */
+.v2-aprofile__hero { position: relative; }


### PR DESCRIPTION
Sam's ruling: users pick their avatar from a **preset of generated faces** (or upload); the AI-generation feature is deprecated. Extended mid-flight with the second half: **agents created by someone are avatar-editable by that someone.**

## The picker (humans)

Eight deterministic bigSmile faces, **seeded off the user's own identity** — so the grid is personal and never reshuffles between visits. A picker whose options change reads as broken, and "the face I picked last month" must still be in the grid when they return. That property has a test.

## The storage scheme is the design

`profilePicture = 'bigsmile:<seed>'` (humans) / `'bottts:<seed>'` (agents) — a **seed, not image bytes or a URL**. Every renderer regenerates the exact character locally via `getAvatarSrc`, which means:

- nothing 404s, expires, or needs hosting
- every existing consumer (v1 `Avatar`, `V2Avatar`) renders picks with **zero per-component changes**
- the round-trip is pinned: what the picker showed is byte-identical to what every surface renders

Legacy color values keep *rendering* for users who have them; they're simply no longer offered.

## Agent avatars — owner-editable (Sam: "if created by someone")

- **Gate is creation-shaped**: `PUT /api/agent-profile/:agentName/:instanceId?/avatar` allows an admin or the **installer of an active installation** — nobody else (403, no store touched). `GET …/avatar/can-edit` powers the UI affordance; the backend stays the real gate.
- **Scheme-validated**: `bottts:<seed>` presets or uploaded-image refs only. `bigsmile:` on an agent, data URIs, and `javascript:` all 400.
- **Three surfaces move atomically**: Mongo `User.profilePicture` (source of truth) → PG mirror via the one sanctioned door, `syncUserToPostgreSQL` (fire-and-log — the July half-write incident is why; if #1062 retires the mirror this endpoint stays correct unchanged) → `AgentRegistry.iconUrl` so Your-Team cards can't drift from the profile.
- **UI**: the agent profile hero grows an "Edit avatar" affordance for installer/admin — eight deterministic robots seeded off the agent's identity, same grid every visit.
- 8 backend tests pin gate + write order + validation + mirror-failure tolerance.

## The deprecation — both buttons

- **UserProfile "Generate with AI"** — button, dialog, state, handler: gone.
- **AgentsHub "🎨 Generate AI Avatar"** (agent creation) — gone. Agents get deterministic bottts by identity; the AI path bought a worse version of what already exists, for API spend. **Upload stays** on both surfaces — Commonly Support's hand-made C icon is the case for it.

Backend `agentAvatarService` (OpenAI/Gemini) is left in place this pass — publish-flow scripts reference it; removing it rides the next registry cleanup rather than this UI deprecation.

Why presets beat generation, in one line from this week's evidence: deterministic and local means install #10,000 costs what install #1 did, the same face renders forever, and there is no provider credential to silently die for seven weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8
