### PR TITLE
fix(mcp): reaction tool no longer teaches thumbs-up-only (0.3.3)

### DIFF
--- a/commonly-mcp/package.json
+++ b/commonly-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Commonly MCP Server \u2014 exposes the kernel HTTP surface (CAP per ADR-004) as standard MCP tools so any MCP-capable runtime can consume `commonly_*` tools without driver-specific code.",
   "type": "module",
   "bin": {

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -494,7 +494,7 @@ export const buildTools = (config) => {
     },
     {
       name: 'commonly_react_to_message',
-      description: "React to a chat message with an emoji AS the agent identity. Use for social-presence signal on a peer's contribution (👍 / 🎉 / 👀) or as a micro-ack for a one-liner that doesn't need a worded reply ('thanks' / 'got it' / 'agreed'). DON'T use as a substitute for a substantive reply when @-mentioned with a real request — post words then (or NO_REPLY when there's truly nothing to add). Reactions are bounded social presence, not bulk noise. Pass remove=true to remove a previously-added reaction of the same emoji. Same kernel endpoint humans use; observers see the badge appear live via socket.",
+      description: "React to a chat message with an emoji AS the agent identity. Pick the emoji that carries the MEANING, not a default: ✅ verified/confirmed-done, 🎉 shipped/milestone, 👀 I'll-look-at-this, 💡 good idea, 🔥 impressive work, ❤️ appreciation, 👍 plain agreement — 👍 is the weakest signal, so prefer a more specific one whenever it applies. Also usable as a micro-ack for a one-liner that doesn't need a worded reply ('thanks' / 'got it'). DON'T use as a substitute for a substantive reply when @-mentioned with a real request — post words then (or NO_REPLY when there's truly nothing to add). Reactions are bounded social presence, not bulk noise. Pass remove=true to remove a previously-added reaction of the same emoji. Same kernel endpoint humans use; observers see the badge appear live via socket.",
       inputSchema: reqWith({
         messageId: STRING,
         emoji: STRING,


### PR DESCRIPTION
Answers Sam's 'why do agents only react 👍': the tool description's exemplar list '(👍 / 🎉 / 👀)' IS the observed ledger distribution (👍×37 of 50 agent reactions). Reworded to lead with semantic emoji choice and call 👍 the weakest signal. Version bumped — a description change is a behavior change for every consumer. Reaches seats on next npm publish + staging refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8