### PR TITLE
fix(agents): avatar admin gate must load role from DB — req.user has no role on JWT sessions

### DIFF
--- a/backend/__tests__/unit/routes/agentProfile.avatar.test.js
+++ b/backend/__tests__/unit/routes/agentProfile.avatar.test.js
@@ -10,6 +10,7 @@
 
 jest.mock('../../../models/User', () => ({
   findOneAndUpdate: jest.fn(),
+  findById: jest.fn(),
 }));
 jest.mock('../../../models/Pod', () => ({}));
 jest.mock('../../../models/AgentMemory', () => ({}));
@@ -52,6 +53,12 @@ const installationLookup = (result) => {
   });
 };
 
+const callerRoleLookup = (role) => {
+  User.findById.mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(role ? { role } : null) }),
+  });
+};
+
 const putAvatar = getHandler('put', '/:agentName/:instanceId?/avatar');
 const canEdit = getHandler('get', '/:agentName/:instanceId?/avatar/can-edit');
 
@@ -59,6 +66,7 @@ describe('agent avatar editing', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     User.findOneAndUpdate.mockResolvedValue({ _id: 'bot-1', profilePicture: 'bottts:theo:v3' });
+    callerRoleLookup(null);
     AgentRegistry.updateOne.mockResolvedValue({});
     AgentIdentityService.syncUserToPostgreSQL.mockResolvedValue(undefined);
   });
@@ -104,13 +112,27 @@ describe('agent avatar editing', () => {
     expect(AgentRegistry.updateOne).not.toHaveBeenCalled();
   });
 
-  it('lets an admin edit without owning an installation', async () => {
+  it('lets an admin edit without owning an installation (API-token shape: role on req.user)', async () => {
     const res = response();
 
     await putAvatar(reqFor({ id: 'admin-1', role: 'admin' }), res);
 
     expect(AgentInstallation.findOne).not.toHaveBeenCalled();
     expect(User.findOneAndUpdate).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+  });
+
+  it('lets an admin edit on a JWT session, where req.user carries NO role', async () => {
+    // middleware/auth.ts sets req.user = { id } for JWT logins — the browser
+    // shape. The gate must load the role from DB or the admin path is dead for
+    // every human session (the bug found live on fc-verify, 2026-08-21).
+    callerRoleLookup('admin');
+    installationLookup(null);
+    const res = response();
+
+    await putAvatar(reqFor({ id: 'admin-1' }), res);
+
+    expect(AgentInstallation.findOne).not.toHaveBeenCalled();
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
   });
 

--- a/backend/routes/agentProfile.ts
+++ b/backend/routes/agentProfile.ts
@@ -246,7 +246,12 @@ router.get('/:agentName/:instanceId?', async (req: Req, res: Res) => {
 const canEditAgentAvatar = async (req: any, agentName: string, instanceId: string): Promise<boolean> => {
   const callerId = req.userId || req.user?._id || req.user?.id;
   if (!callerId) return false;
+  // JWT auth populates req.user = { id } WITHOUT role (middleware/auth.ts:81)
+  // — only the cm_ API-token branch carries role. Trusting req.user.role here
+  // silently disabled the admin path for every browser session, so load it.
   if (req.user?.role === 'admin') return true;
+  const caller = await User.findById(callerId).select('role').lean();
+  if (caller?.role === 'admin') return true;
   const owned = await AgentInstallation.findOne({
     agentName,
     instanceId,


### PR DESCRIPTION
Follow-up to #1061, found during live verification: the admin branch of the avatar-edit gate tested req.user.role, but middleware/auth.ts sets req.user = { id } for JWT (browser) sessions — role exists only on the cm_ API-token path. Net effect: admins without an installation saw no edit affordance (reproduced on fc-verify). Fix loads the caller's role with one indexed read; test suite now pins both req shapes. Installer path was and remains correct (E2E-proven live on codex-impl: PUT → public profile → inline-SVG render, then restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8