### PR TITLE
feat(avatars): bigSmile faces for both species — species reads from background family

### DIFF
--- a/frontend/src/v2/__tests__/avatarCharacter.test.ts
+++ b/frontend/src/v2/__tests__/avatarCharacter.test.ts
@@ -1,10 +1,11 @@
 import { characterAvatarFor } from '../utils/avatars';
 
 /**
- * The character tier: humans render bigSmile faces, agents render bottts
- * robots (Sam's ruling, 2026-08-20). Everything here defends the properties
- * that make it shippable at all — determinism, distinctness, and a fallback
- * that cannot strand a render.
+ * The character tier: bigSmile faces for BOTH species (Sam's 2026-08-21
+ * revision — the robots were rejected on looks), with species carried by
+ * disjoint background families instead of art style. Everything here defends
+ * the properties that make it shippable at all — determinism, distinctness,
+ * species legibility, and a fallback that cannot strand a render.
  */
 describe('characterAvatarFor', () => {
   test('is deterministic — same identity, same face, forever', () => {
@@ -14,17 +15,18 @@ describe('characterAvatarFor', () => {
       .toBe(characterAvatarFor('user-123', 'human'));
   });
 
-  test('kinds render different species from the same seed', () => {
-    // A human and an agent must never be confusable by avatar even if their
-    // seeds collide — the species IS the badge.
-    const robot = characterAvatarFor('same-seed', 'agent');
-    const face = characterAvatarFor('same-seed', 'human');
-    expect(robot).not.toBeNull();
-    expect(face).not.toBeNull();
-    expect(robot).not.toBe(face);
+  test('same seed still renders differently across kinds', () => {
+    // The species signal moved from art style to background family, but the
+    // rule is unchanged: a human and an agent must never be confusable by
+    // avatar even if their seeds collide. Disjoint palettes guarantee it.
+    const agent = characterAvatarFor('same-seed', 'agent');
+    const human = characterAvatarFor('same-seed', 'human');
+    expect(agent).not.toBeNull();
+    expect(human).not.toBeNull();
+    expect(agent).not.toBe(human);
   });
 
-  test('distinct agents get distinct robots across the real roster', () => {
+  test('distinct agents get distinct characters across the real roster', () => {
     const roster = [
       'fable-lead:default', 'sprint-review:default', 'pod-architect:default',
       'sprint-impl:default', 'ux-lead:default', 'scout:default',

--- a/frontend/src/v2/agents/V2AgentProfile.tsx
+++ b/frontend/src/v2/agents/V2AgentProfile.tsx
@@ -257,21 +257,22 @@ const V2AgentProfile: React.FC = () => {
           )}
           {avatarDialogOpen && (
             <div className="v2-aprofile__avatar-dialog" role="dialog" aria-label="Choose an avatar">
-              {/* Eight deterministic robots seeded off this agent's identity —
-                  same grid every visit, and the pick is stored as a seed so
-                  every surface regenerates it locally. Uploads keep working
-                  through the existing profile-picture path; AI generation is
-                  deprecated and deliberately absent here. */}
+              {/* Eight deterministic characters seeded off this agent's
+                  identity — same grid every visit, and the pick is stored as a
+                  seed so every surface regenerates it locally. Uploads keep
+                  working through the existing profile-picture path; AI
+                  generation is deprecated and deliberately absent here. */}
+              <div className="v2-aprofile__avatar-title">Choose an avatar</div>
               <div className="v2-aprofile__avatar-grid">
-                {presetCharacterOptions(`${agent.agentName}:${agent.instanceId || 'default'}`, 'agent').map((robot) => (
+                {presetCharacterOptions(`${agent.agentName}:${agent.instanceId || 'default'}`, 'agent').map((option) => (
                   <button
-                    key={robot.id}
+                    key={option.id}
                     type="button"
                     className="v2-aprofile__avatar-choice"
                     disabled={savingAvatar}
-                    onClick={() => saveAvatar(robot.id)}
+                    onClick={() => saveAvatar(option.id)}
                   >
-                    <img src={robot.src || ''} alt="robot avatar option" width={56} height={56} style={{ borderRadius: '50%' }} />
+                    <img src={option.src || ''} alt="avatar option" width={56} height={56} style={{ borderRadius: '50%' }} />
                   </button>
                 ))}
               </div>

--- a/frontend/src/v2/agents/v2-agent-profile.css
+++ b/frontend/src/v2/agents/v2-agent-profile.css
@@ -266,3 +266,9 @@
 }
 /* The picker dialog anchors to the hero card. */
 .v2-aprofile__hero { position: relative; }
+.v2-aprofile__avatar-title {
+  margin-bottom: 10px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--v2-text);
+}

--- a/frontend/src/v2/components/V2Avatar.tsx
+++ b/frontend/src/v2/components/V2Avatar.tsx
@@ -13,10 +13,11 @@ interface V2AvatarProps {
   online?: boolean;
   title?: string;
   /**
-   * Renders the character tier: 'agent' → bottts robot, 'human' → bigSmile
-   * face. Omitted → gradient+initials, unchanged — callers that cannot tell
-   * who they are drawing must not guess, because mislabelling the tier
-   * mislabels the PERSON (a robot face on a human, or vice versa).
+   * Renders the character tier: bigSmile faces for both kinds, with the
+   * species carried by disjoint background families ('human' warm, 'agent'
+   * cool — Sam's 2026-08-21 revision). Omitted → gradient+initials, unchanged
+   * — callers that cannot tell who they are drawing must not guess, because
+   * mislabelling the tier mislabels the PERSON's species tint.
    * An uploaded photo always wins over both tiers.
    */
   kind?: AvatarKind;

--- a/frontend/src/v2/components/V2Login.tsx
+++ b/frontend/src/v2/components/V2Login.tsx
@@ -127,7 +127,7 @@ const V2Login: React.FC = () => {
         <div className="v2-login__hint" style={{ fontSize: 11, opacity: 0.7 }}>
           {'Avatars: '}
           <a className="v2-login__link" href="https://www.dicebear.com" target="_blank" rel="noreferrer">DiceBear</a>
-          {' — “Big Smile” (CC BY 4.0), “Bottts”'}
+          {' — “Big Smile” (CC BY 4.0)'}
         </div>
       </form>
     </div>

--- a/frontend/src/v2/utils/avatars.ts
+++ b/frontend/src/v2/utils/avatars.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createAvatar } from '@dicebear/core';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { bottts, bigSmile } from '@dicebear/collection';
+import { bigSmile } from '@dicebear/collection';
 
 // Avatar tints. Blue-forward and cohesive with the design system's single
 // accent (#2f6feb) — deliberately purple-free (the old palette led with two
@@ -115,9 +115,17 @@ export const initialsFor = (name: string | undefined | null): string => {
 
 // ── Character tier ──────────────────────────────────────────────────────────
 //
-// Sam's ruling (2026-08-20): humans render bigSmile faces, agents render
-// bottts robots. The semantics read with zero badges — face = person, robot =
-// agent — which most agent-team products need a label for.
+// Sam's ruling (2026-08-21, revising 2026-08-20): bigSmile faces for BOTH
+// species — the bottts robots read as ugly in practice. Species still has to
+// be legible at a glance in mixed chat, so the kind now selects the
+// BACKGROUND family instead of the art style: humans sit on warm tints,
+// agents on cool ones. The two sets are disjoint on purpose.
+//
+// The stored prefixes ('bigsmile:' / 'bottts:') are SPECIES TAGS on the wire,
+// not artwork names — 'bottts:<seed>' means "agent-styled character", and
+// after this revision that renders a bigSmile face on an agent tint. Keeping
+// the tag stable is what let this revision ship with zero backend changes and
+// zero data migration.
 //
 // Deterministic, local, SVG: same seed, same face, forever. No image API and
 // no art pipeline, so install #10,000 costs what install #1 did. That is what
@@ -125,10 +133,20 @@ export const initialsFor = (name: string | undefined | null): string => {
 // those costs.
 //
 // License note that must not rot: bigSmile is CC BY 4.0 — the visible credit
-// in the login footer is a LICENSE REQUIREMENT, not decoration. bottts is
-// free for personal and commercial use. If either style is ever swapped,
-// re-check the license and the credit line together.
+// in the login footer is a LICENSE REQUIREMENT, not decoration. If the style
+// is ever swapped, re-check the license and the credit line together.
 export type AvatarKind = 'human' | 'agent';
+
+// Disjoint background families — the species signal now that both kinds share
+// one art style. Indexes into AVATAR_PALETTE: humans get brand blue / green /
+// amber / rose (warm-forward), agents get cyan / teal / steel / slate (cool).
+const HUMAN_BG = [0, 3, 4, 5];
+const AGENT_BG = [1, 2, 6, 7];
+
+const backgroundFor = (key: string, kind: AvatarKind): string => {
+  const family = kind === 'agent' ? AGENT_BG : HUMAN_BG;
+  return AVATAR_PALETTE[family[hashString(key) % family.length]].base;
+};
 
 /**
  * Data-URI for the character avatar, or null when generation fails — callers
@@ -147,15 +165,12 @@ export const characterAvatarFor = (
 ): string | null => {
   const key = String(seed || '').trim();
   if (!key) return null;
-  // Branched calls rather than a ternary on the style argument: each style
-  // module carries its own Options generic, and the union of the two is not
-  // assignable to createAvatar's Style<Options> parameter.
-  const options = { seed: key, backgroundColor: [colorFor(key).slice(1)] };
+  // Same-seed human and agent still must never render identically (the
+  // species-legibility rule) — the disjoint background families guarantee it
+  // even on a face collision.
+  const options = { seed: key, backgroundColor: [backgroundFor(key, kind).slice(1)] };
   try {
-    return (kind === 'agent'
-      ? createAvatar(bottts, options)
-      : createAvatar(bigSmile, options)
-    ).toDataUri();
+    return createAvatar(bigSmile, options).toDataUri();
   } catch {
     return null;
   }


### PR DESCRIPTION
Sam's call on seeing the robots live: too ugly. Both kinds now render bigSmile; species legibility is preserved by disjoint background palettes (humans warm, agents cool). Stored prefixes are species tags, so zero backend change, zero migration — #1065's gate and every stored value stay valid. bottts import removed; its footer credit dropped (Big Smile's CC BY credit stays).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8