### PR TITLE
feat(avatars): 16-option picker — full skin-tone x hair-presentation matrix

### DIFF
--- a/frontend/src/utils/__tests__/avatarPresetFaces.test.ts
+++ b/frontend/src/utils/__tests__/avatarPresetFaces.test.ts
@@ -15,7 +15,7 @@ describe('preset face avatars', () => {
     const b = presetFaceOptions('sam');
     expect(a.map((f) => f.id)).toEqual(b.map((f) => f.id));
     expect(a.map((f) => f.src)).toEqual(b.map((f) => f.src));
-    expect(a).toHaveLength(8);
+    expect(a).toHaveLength(16);
   });
 
   test('different users see different grids', () => {

--- a/frontend/src/utils/avatarUtils.ts
+++ b/frontend/src/utils/avatarUtils.ts
@@ -1,6 +1,6 @@
 import { normalizeUploadUrl } from './apiBaseUrl';
 // eslint-disable-next-line import/no-cycle
-import { characterAvatarFor, AvatarKind } from '../v2/utils/avatars';
+import { characterAvatarFor, AvatarKind, PICKER_CELL_COUNT } from '../v2/utils/avatars';
 
 interface AvatarOption {
   id: string;
@@ -59,10 +59,12 @@ export const isFacePresetId = (value: string | undefined | null): boolean => (
 );
 
 /**
- * Eight stable face options for a user. Seeded off their identity so the grid
- * is personal and NEVER reshuffles — a picker whose options change between
- * visits reads as broken, and "the face I picked last month" must still be in
- * the grid when they come back.
+ * Sixteen stable face options for a user — the full skin-tone × hair-
+ * presentation matrix (traits derive from the -v<n> suffix in v2/utils/
+ * avatars). Seeded off their identity so the grid is personal and NEVER
+ * reshuffles — a picker whose options change between visits reads as broken,
+ * and "the face I picked last month" must still be in the grid when they
+ * come back.
  */
 export const presetFaceOptions = (seedBase: string): Array<{ id: string; src: string | null }> => (
   presetCharacterOptions(seedBase, 'human')
@@ -73,7 +75,7 @@ export const presetCharacterOptions = (
   kind: AvatarKind,
 ): Array<{ id: string; src: string | null }> => {
   const prefix = kind === 'agent' ? ROBOT_PRESET_PREFIX : FACE_PRESET_PREFIX;
-  return Array.from({ length: 8 }, (_, i) => {
+  return Array.from({ length: PICKER_CELL_COUNT }, (_, i) => {
     const seed = `${seedBase}-v${i + 1}`;
     return { id: `${prefix}${seed}`, src: characterAvatarFor(seed, kind) };
   });

--- a/frontend/src/v2/__tests__/avatarCharacter.test.ts
+++ b/frontend/src/v2/__tests__/avatarCharacter.test.ts
@@ -48,19 +48,24 @@ describe('characterAvatarFor', () => {
     expect(uri).toMatch(/^data:image\/svg\+xml/);
   });
 
-  test('the 8 picker cells span the full skin-tone range, every grid, every user', () => {
+  test('the 16 picker cells cover the full tone × presentation matrix, every user', () => {
     // Sam's rule (2026-08-21): the grid is deliberately diverse, not rolled —
-    // 8 random rolls can hand a user 8 similar faces and nothing that looks
-    // like them. Cell i pins tone i, so every user's grid covers lightest to
-    // deepest. The tone must appear in the rendered SVG itself; if dicebear
+    // random rolls can hand a user 16 similar faces and nothing that looks
+    // like them. Cell i pins tone i%8, and the back half revisits each tone
+    // with the opposite hair presentation, so every tone appears twice and
+    // with both. The tone must appear in the rendered SVG itself; if dicebear
     // ever renames its skinColor enum this fails loudly instead of silently
     // rolling random tones again.
     for (const base of ['sam', 'someone-else']) {
-      PICKER_SKIN_TONES.forEach((tone, i) => {
+      for (let i = 0; i < 16; i += 1) {
         const uri = characterAvatarFor(`${base}-v${i + 1}`, 'human');
         expect(uri).not.toBeNull();
-        expect(decodeURIComponent(String(uri))).toContain(tone);
-      });
+        expect(decodeURIComponent(String(uri))).toContain(PICKER_SKIN_TONES[i % 8]);
+      }
+      // v1 and v9 share a tone but must not be the same face — the back half
+      // exists to change the presentation, not to duplicate the front.
+      expect(characterAvatarFor(`${base}-v1`, 'human'))
+        .not.toBe(characterAvatarFor(`${base}-v9`, 'human'));
     }
   });
 

--- a/frontend/src/v2/utils/avatars.ts
+++ b/frontend/src/v2/utils/avatars.ts
@@ -173,19 +173,29 @@ const HAIR_COLORS = ['220f00', '3a1a00', '71472d', 'd56c0c', 'e9b729'] as const;
 // ears, which is the wrong register for a colleague's face.
 const ACCESSORIES = ['glasses', 'sunglasses', 'mustache'] as const;
 
-// Picker cells are seeded `<base>-v1` … `<base>-v8` (see presetCharacterOptions
-// in utils/avatarUtils). Deriving the pinned traits from that suffix keeps the
-// stored value a plain seed — the id round-trips through the existing scheme
-// with zero storage or backend changes. (`as const` + spreads throughout:
-// dicebear types these fields as literal-union arrays, so a widened string[]
-// does not compile.)
+// Picker cells are seeded `<base>-v1` … `<base>-v16` (see
+// presetCharacterOptions in utils/avatarUtils). Deriving the pinned traits
+// from that suffix keeps the stored value a plain seed — the id round-trips
+// through the existing scheme with zero storage or backend changes.
+// (`as const` + spreads throughout: dicebear types these fields as
+// literal-union arrays, so a widened string[] does not compile.)
+//
+// 16 cells = the full tone × presentation matrix. v1–v8 keep the meaning they
+// shipped with (tone i, alternating groups) so picks already stored render
+// identically; v9–v16 revisit each tone with the OPPOSITE presentation, so
+// every tone appears with both.
+export const PICKER_CELL_COUNT = 16;
+
 const variantTraits = (key: string) => {
-  const m = /-v([1-8])$/.exec(key);
+  const m = /-v([1-9]|1[0-6])$/.exec(key);
   if (!m) return {};
   const idx = Number(m[1]) - 1;
+  const tone = idx % PICKER_SKIN_TONES.length;
+  const flip = idx >= PICKER_SKIN_TONES.length;
+  const longer = (tone % 2 === 0) !== flip;
   return {
-    skinColor: [PICKER_SKIN_TONES[idx]],
-    hair: idx % 2 === 0 ? [...HAIR_LONGER] : [...HAIR_SHORTER],
+    skinColor: [PICKER_SKIN_TONES[tone]],
+    hair: longer ? [...HAIR_LONGER] : [...HAIR_SHORTER],
   };
 };
 


### PR DESCRIPTION
Sam: more options. Doubles the grid to the complete matrix: every tone with both hair presentations. Backwards-exact: v1-v8 mappings unchanged, so picks stored since #1067 render identically; v9-v16 fill in each tone's opposite look. Mapping smoke-tested against real dicebear (all 32 tone pins + v1!=v9, two users) before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8