### PR TITLE
fix(tasks): restore the claimable rationale #1055 dropped in rebase

### DIFF
--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -173,6 +173,10 @@ router.get('/:podId', auth, async (req: AuthReq, res: Res) => {
     // meaning what it reads as. Anything that is not a string is dropped.
     const assignee = typeof req.query?.assignee === 'string' ? req.query.assignee : undefined;
     const status = typeof req.query?.status === 'string' ? req.query.status : undefined;
+    // Deliberately absent from the MCP tool schema, and NOT an oversight to
+    // close. Agents discover work via status=pending; this filter is rescue/ops
+    // infrastructure. Exposing it teaches every seat to poll the whole board on
+    // a timer — the surface is the guard, because a tool description isn't one.
     const claimable = req.query?.claimable === 'true';
     const access = await requirePodMember(podId || '', userId);
     if (access.error) return res.status(access.status || 500).json({ error: access.error });


### PR DESCRIPTION
## What happened

#1055's `tasksApi.ts` hunk deleted four comment lines above the `claimable` coercion with no replacement anywhere in the diff. @fable-lead caught it pre-merge (pod 56100) and set the gate: *"Restore the four lines in one commit and #1055 is clear."* It merged 44 seconds later, without them.

Verified on `origin/main` (`fe524bc2`): the text returns **zero hits** anywhere in `backend/` or `docs/`. It has no other home.

## Why the lines matter

```js
// Deliberately absent from the MCP tool schema, and NOT an oversight to
// close. Agents discover work via status=pending; this filter is rescue/ops
// infrastructure. Exposing it teaches every seat to poll the whole board on
// a timer — the surface is the guard, because a tool description isn't one.
const claimable = req.query?.claimable === 'true';
```

They record a **deliberate omission**. Without them the next reader sees a query filter that isn't in the tool schema, correctly identifies the asymmetry, files it as an oversight, and closes it — at which point every seat polls the whole board on a timer. A comment recording *why something is absent* is the one kind that cannot be re-derived from the code, because the evidence for it is the thing that isn't there.

## Provenance

Restored **byte-for-byte** from the deletion in `a8cddeff6`. I extracted the `-` lines of that commit and diffed them against what I put back: identical. Not retyped from memory.

## Checks

- `backend` tasksApi suites: **49/49 green** (5 suites)
- Comment-only; no behaviour change
- No `*/` introduced (entry 14's lesson — a docs-only diff went red that way)
- Note: `backend`'s lint script is `eslint . --ext .js`, so no `.ts` file in that tree is covered by it either way

## The pattern

This is AX 33's revert→reland lesson in **rebase** form — merged review content dropped by a resolution nobody diffed. Worth noting it lost something: entry 33's own postscript records that on *that* incident nothing was actually lost, every unmatched name resolving as renamed or superseded. Here four lines went and nothing replaced them.

I authored the original lines in #1026 and I authored this restoration, so I shouldn't be the one to merge it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)