### PR TITLE
fix(registry): hire catalog lists verified rows only for non-admins (ADR-022 Phase 0)

### DIFF
--- a/backend/__tests__/service/self-serve-install.test.js
+++ b/backend/__tests__/service/self-serve-install.test.js
@@ -217,6 +217,11 @@ describe('ADR-006 self-serve webhook install', () => {
       agentName: 'public-marketplace-bot',
       displayName: 'Public Bot',
       description: 'Catalog-visible',
+      // The hire catalog is verified-only for non-admins since the ADR-022
+      // Phase 0 gate — a listable fixture must say so explicitly, exactly as
+      // a real listing does. The ephemeral row below stays unverified AND
+      // ephemeral; its exclusion is what this test actually pins.
+      verified: true,
       registry: 'commonly-community',
       manifest: {
         name: 'public-marketplace-bot',

--- a/backend/__tests__/unit/routes/registry.catalog-verified-gate.test.js
+++ b/backend/__tests__/unit/routes/registry.catalog-verified-gate.test.js
@@ -1,0 +1,118 @@
+/**
+ * ADR-022 Phase 0 — the hire catalog's verified gate.
+ *
+ * 31 of 45 active registry rows are smoke seats, fleet internals, and
+ * personal wrappers; the verified flag is the curation boundary already
+ * present in the data. Non-admins get verified-only REGARDLESS of query
+ * params — passing ?verified=false must not reopen the leak. Admins keep the
+ * full view for registry ops. Role loads from the DB because JWT sessions
+ * carry req.user = { id } only (the #1065 lesson).
+ */
+
+jest.mock('../../../middleware/auth', () => jest.fn((req, res, next) => {
+  req.userId = 'caller-1';
+  req.user = { id: 'caller-1' };
+  next();
+}));
+jest.mock('../../../models/Pod', () => ({}));
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentRegistry: { search: jest.fn() },
+  AgentInstallation: { find: jest.fn(), getInstalledAgents: jest.fn() },
+}));
+jest.mock('../../../models/User', () => ({
+  findById: jest.fn(),
+  findOne: jest.fn(),
+}));
+jest.mock('../../../services/agentIdentityService', () => ({
+  getAgentTypeConfig: jest.fn(),
+  buildAgentUsername: jest.fn(() => 'bot-x'),
+  default: { getAgentTypeConfig: jest.fn() },
+}));
+jest.mock('../../../services/agentProvisionerService', () => ({
+  listOpenClawBundledSkills: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../../../routes/registry/helpers', () => ({
+  parseVerifiedFilter: jest.fn((v) => {
+    if (v === 'true' || v === true) return true;
+    if (v === 'false' || v === false) return false;
+    return null;
+  }),
+  resolveGatewayForRequest: jest.fn(),
+  userHasPodAccess: jest.fn(),
+}));
+
+const { AgentRegistry } = require('../../../models/AgentRegistry');
+const User = require('../../../models/User');
+const AgentIdentityService = require('../../../services/agentIdentityService');
+const catalogRouter = require('../../../routes/registry/catalog');
+
+const getHandler = (method, path) => {
+  const router = catalogRouter.default || catalogRouter;
+  const layer = router.stack.find((entry) => (
+    entry.route && entry.route.path === path && entry.route.methods[method]
+  ));
+  if (!layer) throw new Error(`${method.toUpperCase()} ${path} handler not found`);
+  return layer.route.stack[layer.route.stack.length - 1].handle;
+};
+
+const response = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn(),
+});
+
+const roleLookup = (role) => {
+  User.findById.mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(role ? { role } : null) }),
+  });
+};
+
+const listAgents = getHandler('get', '/agents');
+
+describe('hire catalog verified gate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    AgentRegistry.search.mockResolvedValue([]);
+    AgentIdentityService.getAgentTypeConfig.mockReturnValue(null);
+    roleLookup('user');
+  });
+
+  it('defaults a regular user to verified-only when no param is passed', async () => {
+    await listAgents({ query: {}, userId: 'caller-1' }, response());
+    expect(AgentRegistry.search).toHaveBeenCalledWith(undefined,
+      expect.objectContaining({ verified: true }));
+  });
+
+  it('a regular user passing verified=false must NOT reopen the leak', async () => {
+    await listAgents({ query: { verified: 'false' }, userId: 'caller-1' }, response());
+    expect(AgentRegistry.search).toHaveBeenCalledWith(undefined,
+      expect.objectContaining({ verified: true }));
+  });
+
+  it('an admin may list unverified rows for registry ops', async () => {
+    roleLookup('admin');
+    await listAgents({ query: { verified: 'false' }, userId: 'caller-1' }, response());
+    expect(AgentRegistry.search).toHaveBeenCalledWith(undefined,
+      expect.objectContaining({ verified: false }));
+  });
+
+  it('an explicit verified=true request skips the role lookup entirely', async () => {
+    await listAgents({ query: { verified: 'true' }, userId: 'caller-1' }, response());
+    expect(User.findById).not.toHaveBeenCalled();
+    expect(AgentRegistry.search).toHaveBeenCalledWith(undefined,
+      expect.objectContaining({ verified: true }));
+  });
+
+  it('parked moltbot rows stay excluded even when verified', async () => {
+    AgentRegistry.search.mockResolvedValue([
+      { agentName: 'newshound', verified: true },
+      { agentName: 'claude-code', verified: true },
+    ]);
+    AgentIdentityService.getAgentTypeConfig.mockImplementation((name) => (
+      name === 'newshound' ? { runtime: 'moltbot' } : null
+    ));
+    const res = response();
+    await listAgents({ query: {}, userId: 'caller-1' }, res);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.agents.map((a) => a.name)).toEqual(['claude-code']);
+  });
+});

--- a/backend/routes/registry/catalog.ts
+++ b/backend/routes/registry/catalog.ts
@@ -14,7 +14,25 @@ const {
   userHasPodAccess,
 } = require('./helpers');
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const { rateLimit } = require('express-rate-limit');
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const { cloudflareIpRateLimitKeyGenerator } = require('../../middleware/ipRateLimit');
+
 const catalogRouter = express.Router();
+
+// ~120 req/min/IP, same shape as agentProfile's limiter: generous for a
+// human browsing the catalog, low enough to blunt scrapers now that every
+// listing request may also cost a role lookup. Skipped in tests.
+catalogRouter.use(rateLimit({
+  windowMs: 60_000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  keyGenerator: (req: any) => cloudflareIpRateLimitKeyGenerator(req),
+  handler: (_req: any, res: any) => res.status(429).json({ code: 'rate_limited' }),
+}));
 
 const findExistingAgentInstance = async (agentName: any, instanceId: any) => {
   const installations = await AgentInstallation.find({

--- a/backend/routes/registry/catalog.ts
+++ b/backend/routes/registry/catalog.ts
@@ -46,9 +46,21 @@ catalogRouter.get('/agents', auth, async (req: any, res: any) => {
       q, category, verified, registry, limit = 20, offset = 0,
     } = req.query;
 
+    // ADR-022 leak, Phase 0 fix: 31 of 45 active registry rows are smoke
+    // seats, fleet internals, and personal wrappers — never a hire option.
+    // The verified flag is already the curation boundary in the data, so
+    // non-admins get verified-only REGARDLESS of query params; only admins
+    // (registry ops tooling) may list the rest. Role comes from the DB, not
+    // req.user — JWT sessions carry { id } only (the #1065 lesson).
+    let verifiedFilter = parseVerifiedFilter(verified);
+    if (verifiedFilter !== true) {
+      const caller = await User.findById(req.userId).select('role').lean();
+      if ((caller as { role?: string } | null)?.role !== 'admin') verifiedFilter = true;
+    }
+
     const agents = await AgentRegistry.search(q, {
       category,
-      verified: parseVerifiedFilter(verified),
+      verified: verifiedFilter,
       registry: registry || null,
       limit: parseInt(limit, 10),
       offset: parseInt(offset, 10),


### PR DESCRIPTION
Second Phase 0 item from the merged persona plan (#1063). The raw endpoint leaked 31 internal/smoke/wrapper rows to any authenticated user (and ?verified=false bypassed the UI's own filter). The verified flag already partitions the data correctly — 14 deliberate rows vs 31 leak rows, verified live against production Mongo — so the gate enforces it server-side, with an admin escape for registry ops (role from DB per the #1065 req.user lesson). 5 tests pin both directions plus the existing moltbot exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8