### PR TITLE
feat(personas): Phase 1 persona catalog — the hire page sells colleagues

### DIFF
--- a/frontend/src/v2/V2App.tsx
+++ b/frontend/src/v2/V2App.tsx
@@ -70,16 +70,33 @@ class V2ErrorBoundary extends React.Component<{ children: React.ReactNode }, { e
   }
 }
 
+// This is inline rather than an <img> so the mark's existing three dots can
+// use the product typing rhythm. Its geometry matches the canonical minimal
+// mark in frontend/design-system/assets/commonly-mark.svg: one C ring, then
+// dots at x=25/32/39 with r=2.4 in a 64px viewBox.
+const V2Boot: React.FC = () => (
+  <div className="v2-boot" role="status" aria-label="Loading Commonly">
+    <svg className="v2-boot__mark" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+      <path
+        d="M 50 17.7 A 22 22 0 1 0 50 46.3"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="9"
+        strokeLinecap="round"
+      />
+      <circle className="v2-boot__mark-dot" cx="25" cy="32" r="2.4" fill="currentColor" />
+      <circle className="v2-boot__mark-dot" cx="32" cy="32" r="2.4" fill="currentColor" />
+      <circle className="v2-boot__mark-dot" cx="39" cy="32" r="2.4" fill="currentColor" />
+    </svg>
+  </div>
+);
+
 const V2RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { isAuthenticated, loading } = useAuth();
   const location = useLocation();
 
   if (loading) {
-    return (
-      <div className="v2-empty">
-        <span className="v2-spinner" />
-      </div>
-    );
+    return <V2Boot />;
   }
 
   if (!isAuthenticated) {
@@ -97,11 +114,7 @@ const V2Home: React.FC = () => {
   const { isAuthenticated, loading } = useAuth();
 
   if (loading) {
-    return (
-      <div className="v2-empty">
-        <span className="v2-spinner" />
-      </div>
-    );
+    return <V2Boot />;
   }
 
   if (!isAuthenticated) {

--- a/frontend/src/v2/V2App.tsx
+++ b/frontend/src/v2/V2App.tsx
@@ -28,6 +28,7 @@ import V2MarketplacePage from './marketplace/V2MarketplacePage';
 import V2MarketplaceDetailPage from './marketplace/V2MarketplaceDetailPage';
 import './marketplace/V2MarketplaceDetailPage.css';
 import AgentsHub from '../components/agents/AgentsHub';
+import V2PersonaCatalog from './agents/V2PersonaCatalog';
 import V2AgentBYO from './components/V2AgentBYO';
 import V2PodBoard from './components/V2PodBoard';
 import SkillsCatalogPage from '../components/skills/SkillsCatalogPage';
@@ -69,33 +70,16 @@ class V2ErrorBoundary extends React.Component<{ children: React.ReactNode }, { e
   }
 }
 
-// This is inline rather than an <img> so the mark's existing three dots can
-// use the product typing rhythm. Its geometry matches the canonical minimal
-// mark in frontend/design-system/assets/commonly-mark.svg: one C ring, then
-// dots at x=25/32/39 with r=2.4 in a 64px viewBox.
-const V2Boot: React.FC = () => (
-  <div className="v2-boot" role="status" aria-label="Loading Commonly">
-    <svg className="v2-boot__mark" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
-      <path
-        d="M 50 17.7 A 22 22 0 1 0 50 46.3"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="9"
-        strokeLinecap="round"
-      />
-      <circle className="v2-boot__mark-dot" cx="25" cy="32" r="2.4" fill="currentColor" />
-      <circle className="v2-boot__mark-dot" cx="32" cy="32" r="2.4" fill="currentColor" />
-      <circle className="v2-boot__mark-dot" cx="39" cy="32" r="2.4" fill="currentColor" />
-    </svg>
-  </div>
-);
-
 const V2RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { isAuthenticated, loading } = useAuth();
   const location = useLocation();
 
   if (loading) {
-    return <V2Boot />;
+    return (
+      <div className="v2-empty">
+        <span className="v2-spinner" />
+      </div>
+    );
   }
 
   if (!isAuthenticated) {
@@ -113,7 +97,11 @@ const V2Home: React.FC = () => {
   const { isAuthenticated, loading } = useAuth();
 
   if (loading) {
-    return <V2Boot />;
+    return (
+      <div className="v2-empty">
+        <span className="v2-spinner" />
+      </div>
+    );
   }
 
   if (!isAuthenticated) {
@@ -261,9 +249,16 @@ const V2App: React.FC = () => {
                     false,
                   )}
                 />
+                {/* Phase 1 (ADR-022 D2): the browse route sells personas.
+                    The old hub survives at agents/manage for installed-agent
+                    ops until the where-step absorbs the rest of it. */}
                 <Route
                   path="agents/browse"
-                  element={feature('Hire an agent', 'Browse and install agents from the catalog.', <AgentsHub />)}
+                  element={feature('Hire a colleague', 'Pick who joins your team — where they run comes second.', <V2PersonaCatalog />, false, false)}
+                />
+                <Route
+                  path="agents/manage"
+                  element={feature('Manage agents', 'Installed agents and registry operations.', <AgentsHub />)}
                 />
                 <Route
                   path="agents/byo"

--- a/frontend/src/v2/__tests__/personaCatalog.test.ts
+++ b/frontend/src/v2/__tests__/personaCatalog.test.ts
@@ -1,0 +1,53 @@
+import { PERSONA_CARDS } from '../agents/personaCatalogData';
+
+/**
+ * The card discipline is ux-lead's checklist and fable-lead's two rulings
+ * (Sharpen, 2026-08-21) as CI assertions — so a future card edit cannot
+ * quietly drop the parts that make a card trustworthy.
+ */
+describe('persona catalog discipline', () => {
+  test('every card carries the full evidence shape', () => {
+    for (const card of PERSONA_CARDS) {
+      // First-person one-liner, first-thing, a real two-turn sample, the
+      // ALWAYS-rendered limits line, and the how-I-work disclosure.
+      expect(card.oneLiner.length).toBeGreaterThan(20);
+      expect(card.firstThing.length).toBeGreaterThan(10);
+      expect(card.sample.ask.length).toBeGreaterThan(5);
+      expect(card.sample.reply.length).toBeGreaterThan(5);
+      expect(card.limits.length).toBeGreaterThan(10);
+      expect(card.howIWork.length).toBeGreaterThan(20);
+      expect(card.skills.length).toBeGreaterThan(0);
+      expect(card.tiers.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('ruling 1: Code Reviewer is the only one-tier local persona', () => {
+    const oneTierLocal = PERSONA_CARDS.filter(
+      (c) => c.tiers.length === 1 && c.tiers[0] === 'local',
+    );
+    expect(oneTierLocal.map((c) => c.key)).toEqual(['code-reviewer']);
+  });
+
+  test('ruling 2: Host ships no earlier than its placement trigger', () => {
+    // Host is admitted to the ROSTER but banned from the grid until Phase 2
+    // builds the trigger it rides. Its presence here would be a card live
+    // before its producer fires — the exact thing the roster's rule bans.
+    expect(PERSONA_CARDS.some((c) => c.key === 'host')).toBe(false);
+  });
+
+  test("fable's veto as a test: no card's wake basis mentions pod.join", () => {
+    for (const card of PERSONA_CARDS) {
+      expect(card.howIWork).not.toMatch(/pod\.join/i);
+    }
+  });
+
+  test('no runtime vocabulary on cards, except ruling 1 handles local', () => {
+    // Card-facing copy never says moltbot/gateway/runtime/native/openclaw.
+    const banned = /moltbot|gateway|openclaw|runtime|native engine|litellm/i;
+    for (const card of PERSONA_CARDS) {
+      for (const text of [card.oneLiner, card.firstThing, card.limits, card.howIWork, ...card.skills]) {
+        expect(text).not.toMatch(banned);
+      }
+    }
+  });
+});

--- a/frontend/src/v2/agents/V2PersonaCatalog.tsx
+++ b/frontend/src/v2/agents/V2PersonaCatalog.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import V2Avatar from '../components/V2Avatar';
+import { PERSONA_CARDS, PersonaCard } from './personaCatalogData';
+import '../v2.css';
+import './v2-persona-catalog.css';
+
+// Phase 1 of the persona plan (ADR-022 D1/D2): the hire surface sells
+// COLLEAGUES, not runtimes. Cards are evidence-shaped — what this persona
+// does, what it will do first, a real exchange — and the only runtime word
+// on any card is ruling 1's named exception ("Runs on your machine").
+// The where-step (Phase 2) replaces the availability states below with a
+// real choice; until then every CTA is honest about what works today.
+
+const AVAILABILITY: Record<PersonaCard['availability'], { dot: string; label: string; cta: string | null }> = {
+  workspace: { dot: 'live', label: 'Answers now', cta: 'Open your workspace' },
+  connect: { dot: 'session', label: 'Answers while your session runs', cta: 'Connect' },
+  soon: { dot: 'soon', label: 'Hosted seat opens soon', cta: null },
+};
+
+const PersonaCardView: React.FC<{ card: PersonaCard }> = ({ card }) => {
+  const navigate = useNavigate();
+  const availability = AVAILABILITY[card.availability];
+
+  const onCta = () => {
+    if (card.availability === 'workspace') navigate('/v2');
+    if (card.availability === 'connect') navigate('/v2/agents/byo');
+  };
+
+  return (
+    <article className="v2-pcat__card">
+      <header className="v2-pcat__card-head">
+        <V2Avatar name={card.name} size="md" kind="agent" seed={card.avatarSeed} />
+        <div className="v2-pcat__card-title">
+          <h2 className="v2-pcat__name">{card.name}</h2>
+          <div className="v2-pcat__role">{card.role}</div>
+        </div>
+        <div className={`v2-pcat__liveness v2-pcat__liveness--${availability.dot}`} title={availability.label}>
+          <span className="v2-pcat__dot" />
+          {availability.label}
+        </div>
+      </header>
+
+      <p className="v2-pcat__oneliner">{card.oneLiner}</p>
+
+      <div className="v2-pcat__first">
+        <span className="v2-pcat__kicker">First thing I’ll do</span>
+        <p>{card.firstThing}</p>
+      </div>
+
+      <div className="v2-pcat__sample">
+        <div className="v2-pcat__sample-ask">{card.sample.ask}</div>
+        <div className="v2-pcat__sample-reply">{card.sample.reply}</div>
+      </div>
+
+      <div className="v2-pcat__chips">
+        {card.skills.map((skill) => (
+          <span key={skill} className="v2-pcat__chip">{skill}</span>
+        ))}
+      </div>
+
+      {/* The limits line always renders — a colleague that names its edges
+          reads as trustworthy; one that claims everything reads as the model
+          in a hat (roster card discipline). */}
+      <p className="v2-pcat__limits">{card.limits}</p>
+
+      <details className="v2-pcat__how">
+        <summary>How I work</summary>
+        <p>{card.howIWork}</p>
+      </details>
+
+      <footer className="v2-pcat__card-foot">
+        {card.tiers.length === 1 && card.tiers[0] === 'local' && (
+          <span className="v2-pcat__tier-note">Runs on your machine</span>
+        )}
+        {availability.cta ? (
+          <button type="button" className="v2-pcat__cta" onClick={onCta}>
+            {availability.cta}
+          </button>
+        ) : (
+          <span className="v2-pcat__soon-note">Arrives with hosted seats</span>
+        )}
+      </footer>
+    </article>
+  );
+};
+
+const V2PersonaCatalog: React.FC = () => (
+  <div className="v2-pcat">
+    <header className="v2-pcat__head">
+      <h1 className="v2-pcat__title">Hire a colleague</h1>
+      <p className="v2-pcat__sub">
+        Pick who joins your team. Where they run is a separate choice — and changing it later never changes who they are.
+      </p>
+    </header>
+
+    <div className="v2-pcat__grid">
+      {PERSONA_CARDS.map((card) => (
+        <PersonaCardView key={card.key} card={card} />
+      ))}
+    </div>
+
+    <footer className="v2-pcat__foot">
+      <span>More colleagues are on the way.</span>
+      <a className="v2-pcat__manage" href="/v2/agents/manage">Manage installed agents</a>
+    </footer>
+  </div>
+);
+
+export default V2PersonaCatalog;

--- a/frontend/src/v2/agents/personaCatalogData.ts
+++ b/frontend/src/v2/agents/personaCatalogData.ts
@@ -1,0 +1,118 @@
+/**
+ * The Phase 1 persona roster — ux-lead's proposal (Sharpen pod,
+ * persona-roster-proposal.md, 2026-08-21) as ruled by fable-lead:
+ *
+ * - Ruling 1: a one-tier persona states its availability at the card;
+ *   "Runs on your machine" is the named exception to zero-runtime-vocabulary.
+ * - Ruling 2: Host is admitted to the roster but its card ships NO EARLIER
+ *   than the placement trigger it rides (Phase 2) — a card live before its
+ *   producer fires recreates declared-and-unexercised. Host is therefore
+ *   deliberately absent from this array; the grid's visible room to grow is
+ *   itself the message.
+ *
+ * Card discipline (ux-lead's checklist): first-person one-liner · "what I'll
+ * do first when placed" · two-turn sample producible on the persona's own
+ * tier · limits line ALWAYS rendered · liveness honesty · zero runtime
+ * vocabulary except the ruling-1 exception.
+ */
+
+export type PersonaTier = 'hosted' | 'local';
+
+export interface PersonaSample {
+  ask: string;
+  reply: string;
+}
+
+export interface PersonaCard {
+  key: string;
+  /** Stable identity seed for the avatar — survives display renames. */
+  avatarSeed: string;
+  name: string;
+  role: string;
+  oneLiner: string;
+  firstThing: string;
+  sample: PersonaSample;
+  limits: string;
+  skills: string[];
+  /** 'How I work' disclosure — wake basis in plain words, no event names. */
+  howIWork: string;
+  tiers: PersonaTier[];
+  /**
+   * What the CTA honestly is today:
+   *  - 'workspace': already yours; the button opens the conversation.
+   *  - 'connect':   runs on your machine; the button starts the connect flow.
+   *  - 'soon':      hosted seat opens with the where-step; button disabled.
+   */
+  availability: 'workspace' | 'connect' | 'soon';
+}
+
+export const PERSONA_CARDS: PersonaCard[] = [
+  {
+    key: 'scout',
+    avatarSeed: 'scout:default',
+    name: 'Scout',
+    role: 'Your first teammate',
+    oneLiner: 'I live in your workspace. I answer questions about how things work here, set up your other agents, and do real work — tasks, memory — so you can see what a colleague on Commonly is like.',
+    firstThing: "I've already introduced myself in your workspace — come ask me anything.",
+    sample: {
+      ask: 'Can you keep track of what we decided about the launch date?',
+      reply: "Saved. You settled on the 14th, pending the pricing page — I'll bring it up if that slips.",
+    },
+    limits: "I work inside your workspace. For a shared room, hire a colleague who's built for it.",
+    skills: ['Answers about Commonly', 'Task board', 'Remembers decisions', 'Sets up teammates'],
+    howIWork: 'I answer every message in your private workspace — it is a 1:1 room, so nothing there is not for me. I keep memory of what we settle and I can create tasks and propose actions for your approval.',
+    tiers: ['hosted'],
+    availability: 'workspace',
+  },
+  {
+    key: 'code-reviewer',
+    avatarSeed: 'code-reviewer:default',
+    name: 'Code Reviewer',
+    role: 'Pull-request review',
+    oneLiner: 'I review pull requests and give you a verdict you can act on — findings first, each one anchored to the lines that earned it.',
+    firstThing: "I'll introduce myself and ask for the repository — and one line about your stack makes me your reviewer, not a generic one.",
+    sample: {
+      ask: '@reviewer can you look at #42?',
+      reply: 'Two findings. The token check at auth.ts:81 trusts a field this route never sets — repro inside. The rest is clean; approving once that one is addressed.',
+    },
+    limits: "I review what you show me. I don't merge, and I don't push.",
+    skills: ['PR review', 'Line-anchored findings', 'Your stack, your rules'],
+    howIWork: 'I wake when you mention me or assign me a review. I read the diff and the surrounding code, verify each finding before I report it, and give one verdict per review.',
+    tiers: ['local'],
+    availability: 'connect',
+  },
+  {
+    key: 'recorder',
+    avatarSeed: 'recorder:default',
+    name: 'Recorder',
+    role: 'The room’s memory',
+    oneLiner: 'I keep the record — decisions, corrections, who asked for what — so this room never rebuilds an answer it already earned.',
+    firstThing: "I'll read the recent history and post what's settled versus still open, with citations.",
+    sample: {
+      ask: 'Didn’t we already decide how retries should work?',
+      reply: 'Yes — three weeks ago: exponential backoff, cap at five. The correction from the 12th still applies: the cap is per endpoint, not global.',
+    },
+    limits: "I write the record and answer from it. I don't act on the board and I don't make decisions.",
+    skills: ['Cited recall', 'Decision log', 'Correction tracking'],
+    howIWork: 'I wake when mentioned and when the room settles something worth keeping. Everything I claim carries a citation back to where it was said.',
+    tiers: ['hosted'],
+    availability: 'soon',
+  },
+  {
+    key: 'planner',
+    avatarSeed: 'planner:default',
+    name: 'Planner',
+    role: 'Board sequencing',
+    oneLiner: 'I watch the board, not the clock — when the work changes, I sequence it: what runs in parallel, what blocks what, and who is waiting on whom.',
+    firstThing: "I'll read the open tasks and propose an order, with the reason for each dependency.",
+    sample: {
+      ask: 'What should we pick up next?',
+      reply: 'The schema change — two open tasks quietly depend on it. The copy pass can run in parallel; it touches nothing the schema does.',
+    },
+    limits: 'I propose sequencing and flag conflicts. Owners decide; I never reassign work myself.',
+    skills: ['Dependency mapping', 'Parallel lanes', 'Blocked-on-whom'],
+    howIWork: 'I wake when the board changes — a task lands, stalls, or completes — never on a timer. The change that woke me arrives with the wake, so I reason about what actually happened.',
+    tiers: ['hosted'],
+    availability: 'soon',
+  },
+];

--- a/frontend/src/v2/agents/v2-persona-catalog.css
+++ b/frontend/src/v2/agents/v2-persona-catalog.css
@@ -1,0 +1,199 @@
+/* Persona catalog — Phase 1 of the persona plan. Token-only per the design
+   system: one accent, borders not shadows, sentence case, calm motion. */
+
+.v2-pcat {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 8px 24px 40px;
+}
+
+.v2-pcat__head { margin-bottom: 24px; }
+.v2-pcat__title {
+  margin: 0 0 6px;
+  font-size: 24px;
+  font-weight: 850;
+  letter-spacing: -0.03em;
+  color: var(--v2-text);
+}
+.v2-pcat__sub {
+  margin: 0;
+  max-width: 56ch;
+  color: var(--v2-text-secondary);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.v2-pcat__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
+}
+
+.v2-pcat__card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-lg);
+  transition: border-color 120ms ease;
+}
+.v2-pcat__card:hover { border-color: var(--v2-text-secondary); }
+
+.v2-pcat__card-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.v2-pcat__card-title { flex: 1 1 auto; min-width: 0; }
+.v2-pcat__name {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--v2-text);
+}
+.v2-pcat__role {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--v2-text-secondary);
+}
+
+.v2-pcat__liveness {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--v2-text-secondary);
+  white-space: nowrap;
+}
+.v2-pcat__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--v2-border);
+}
+.v2-pcat__liveness--live .v2-pcat__dot { background: #15803d; }
+.v2-pcat__liveness--session .v2-pcat__dot { background: #b45309; }
+.v2-pcat__liveness--soon .v2-pcat__dot { background: var(--v2-border); }
+
+.v2-pcat__oneliner {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--v2-text);
+}
+
+.v2-pcat__kicker {
+  display: block;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--v2-text-secondary);
+  margin-bottom: 2px;
+}
+.v2-pcat__first p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--v2-text-secondary);
+}
+
+.v2-pcat__sample {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--v2-bg);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-md, 8px);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+.v2-pcat__sample-ask { color: var(--v2-text-secondary); }
+.v2-pcat__sample-ask::before { content: '“'; }
+.v2-pcat__sample-ask::after { content: '”'; }
+.v2-pcat__sample-reply {
+  color: var(--v2-text);
+  padding-left: 10px;
+  border-left: 2px solid var(--v2-accent);
+}
+
+.v2-pcat__chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.v2-pcat__chip {
+  font-size: 11px;
+  padding: 3px 9px;
+  border: 1px solid var(--v2-border);
+  border-radius: 999px;
+  color: var(--v2-text-secondary);
+  background: var(--v2-surface);
+}
+
+.v2-pcat__limits {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--v2-text-secondary);
+  font-style: italic;
+}
+
+.v2-pcat__how summary {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v2-text-secondary);
+  cursor: pointer;
+}
+.v2-pcat__how[open] summary { color: var(--v2-text); }
+.v2-pcat__how p {
+  margin: 8px 0 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--v2-text-secondary);
+}
+
+.v2-pcat__card-foot {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding-top: 4px;
+}
+.v2-pcat__tier-note {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--v2-text-secondary);
+}
+.v2-pcat__cta {
+  margin-left: auto;
+  padding: 7px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+  background: var(--v2-accent);
+  border: none;
+  border-radius: var(--v2-radius-md, 8px);
+  cursor: pointer;
+  transition: background 80ms ease;
+}
+.v2-pcat__cta:hover { background: var(--v2-accent-strong); }
+.v2-pcat__soon-note {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--v2-text-secondary);
+}
+
+.v2-pcat__foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 24px;
+  font-size: 12.5px;
+  color: var(--v2-text-secondary);
+}
+.v2-pcat__manage { color: var(--v2-text-secondary); }
+.v2-pcat__manage:hover { color: var(--v2-text); }


### PR DESCRIPTION
The big one Sam has been asking for: /v2/agents/browse now renders the persona catalog. Built directly on the fleet's work from this morning — ux-lead's roster proposal (persona-roster-proposal.md, Sharpen) and both fable rulings (one-tier cards say 'Runs on your machine'; Host admitted but ships no earlier than its placement trigger, pod.join veto now a test). Four evidence-shaped cards: persona, role, first-person one-liner, what-I'll-do-first, a two-turn sample, skills, an always-rendered limits line, and a 'How I work' disclosure — with honest availability per card (answers now / connect / seat opens soon). The old AgentsHub moves to /v2/agents/manage for ops. Card discipline is pinned by test so future edits can't hollow it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8