### PR TITLE
Fix duplicate scheduled agent heartbeats during rollout

### DIFF
--- a/backend/__tests__/unit/services/schedulerService.heartbeatLease.test.js
+++ b/backend/__tests__/unit/services/schedulerService.heartbeatLease.test.js
@@ -1,0 +1,99 @@
+// The lease is a correctness boundary between backend replicas, so these use
+// MongoMemoryServer instead of a mocked model. In particular, the duplicate
+// key race is Mongo's compare-and-set behavior, not a predicate copied into a
+// Jest mock.
+jest.mock('jsonwebtoken', () => ({}));
+
+const {
+  setupMongoDb,
+  closeMongoDb,
+  clearMongoDb,
+} = require('../../utils/testUtils');
+const { AgentInstallation } = require('../../../models/AgentRegistry');
+const SchedulerHeartbeatLease = require('../../../models/SchedulerHeartbeatLease');
+const schedulerServiceInstance = require('../../../services/schedulerService');
+
+const SchedulerService = schedulerServiceInstance.constructor;
+
+const LEASE_ID = 'agent-heartbeat-dispatch';
+const NOW = new Date('2026-08-21T08:00:00.000Z');
+
+describe('SchedulerService automatic heartbeat dispatch lease', () => {
+  beforeAll(async () => {
+    await setupMongoDb();
+  });
+
+  afterAll(async () => {
+    await closeMongoDb();
+  });
+
+  afterEach(async () => {
+    await clearMongoDb();
+    jest.restoreAllMocks();
+  });
+
+  it('admits exactly one of two simultaneous scheduler replicas', async () => {
+    const acquired = await Promise.all([
+      SchedulerService.tryAcquireHeartbeatDispatchLease(NOW),
+      SchedulerService.tryAcquireHeartbeatDispatchLease(NOW),
+    ]);
+
+    expect(acquired.filter(Boolean)).toHaveLength(1);
+    const lease = await SchedulerHeartbeatLease.findById(LEASE_ID).lean();
+    expect(lease).toEqual(expect.objectContaining({
+      _id: LEASE_ID,
+      expiresAt: expect.any(Date),
+    }));
+  });
+
+  it('does not admit another scheduler until the stored lease expires', async () => {
+    await expect(SchedulerService.tryAcquireHeartbeatDispatchLease(NOW)).resolves.toBe(true);
+    const lease = await SchedulerHeartbeatLease.findById(LEASE_ID).lean();
+    const expiresAt = new Date(lease.expiresAt);
+
+    await expect(
+      SchedulerService.tryAcquireHeartbeatDispatchLease(new Date(expiresAt.getTime() - 1)),
+    ).resolves.toBe(false);
+    await expect(SchedulerService.tryAcquireHeartbeatDispatchLease(expiresAt)).resolves.toBe(true);
+  });
+
+  it('runs the scheduled wrapper once', async () => {
+    const directDispatch = jest.spyOn(SchedulerService, 'dispatchAgentHeartbeats').mockResolvedValue({
+      scanned: 3,
+      enqueued: 2,
+      skippedByInterval: 1,
+    });
+
+    const results = await Promise.all([
+      SchedulerService.dispatchScheduledAgentHeartbeats({ now: NOW }),
+      SchedulerService.dispatchScheduledAgentHeartbeats({ now: NOW }),
+    ]);
+
+    expect(directDispatch).toHaveBeenCalledTimes(1);
+    expect(results.filter((result) => result.skippedByLease)).toEqual([
+      { scanned: 0, enqueued: 0, skippedByInterval: 0, skippedByLease: true },
+    ]);
+    expect(results.find((result) => !result.skippedByLease)).toEqual({
+      scanned: 3,
+      enqueued: 2,
+      skippedByInterval: 1,
+      skippedByLease: false,
+    });
+  });
+
+  it('keeps direct dispatch available while an automatic lease is held', async () => {
+    await expect(SchedulerService.tryAcquireHeartbeatDispatchLease(NOW)).resolves.toBe(true);
+    const lean = jest.fn().mockResolvedValue([]);
+    const select = jest.fn().mockReturnValue({ lean });
+    jest.spyOn(AgentInstallation, 'find').mockReturnValue({
+      select,
+    });
+
+    await expect(SchedulerService.dispatchAgentHeartbeats()).resolves.toEqual({
+      scanned: 0,
+      enqueued: 0,
+      skippedByInterval: 0,
+    });
+    expect(AgentInstallation.find).toHaveBeenCalledWith({ status: 'active' });
+  });
+});

--- a/backend/models/SchedulerHeartbeatLease.ts
+++ b/backend/models/SchedulerHeartbeatLease.ts
@@ -1,0 +1,34 @@
+import mongoose, { Document, Model, Schema } from 'mongoose';
+
+/**
+ * A short-lived, cluster-wide lease for one agent-heartbeat dispatch. The
+ * fixed _id is the natural key: MongoDB's primary-key uniqueness makes the
+ * acquire compare-and-set atomic without depending on index build timing.
+ */
+export interface ISchedulerHeartbeatLease extends Document {
+  _id: string;
+  ownerId: string;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const SchedulerHeartbeatLeaseSchema = new Schema<ISchedulerHeartbeatLease>(
+  {
+    _id: { type: String, required: true },
+    ownerId: { type: String, required: true },
+    // Cleanup only; correctness comes from the conditional acquisition query.
+    expiresAt: { type: Date, required: true, index: { expires: 0 } },
+  },
+  { timestamps: true, collection: 'scheduler_heartbeat_leases' },
+);
+
+export const SchedulerHeartbeatLease: Model<ISchedulerHeartbeatLease> = mongoose.model<ISchedulerHeartbeatLease>(
+  'SchedulerHeartbeatLease',
+  SchedulerHeartbeatLeaseSchema,
+);
+
+export default SchedulerHeartbeatLease;
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/services/schedulerService.ts
+++ b/backend/services/schedulerService.ts
@@ -20,6 +20,8 @@ const { AgentInstallation } = require('../models/AgentRegistry');
 // eslint-disable-next-line global-require
 const AgentEvent = require('../models/AgentEvent');
 // eslint-disable-next-line global-require
+const SchedulerHeartbeatLease = require('../models/SchedulerHeartbeatLease');
+// eslint-disable-next-line global-require
 const AgentEnsembleService = require('./agentEnsembleService');
 // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
 const { buildHeartbeatContent } = require('./heartbeatCue') as {
@@ -91,6 +93,10 @@ interface DispatchHeartbeatsResult {
   skippedByInterval: number;
 }
 
+interface ScheduledDispatchHeartbeatsResult extends DispatchHeartbeatsResult {
+  skippedByLease: boolean;
+}
+
 interface DispatchPodSummaryOptions {
   trigger?: string;
   windowMinutes?: number;
@@ -106,6 +112,13 @@ interface CodexRefreshResult {
   suffix?: string;
   expiresAt: number;
 }
+
+const HEARTBEAT_DISPATCH_LEASE_ID = 'agent-heartbeat-dispatch';
+// A rollout briefly runs the old and new schedulers together (~40 seconds).
+// Keep the lease long enough to cover that overlap, but shorter than the
+// one-minute cron cadence so an otherwise healthy tick is never skipped.
+const HEARTBEAT_DISPATCH_LEASE_MS = 55 * 1000;
+const SCHEDULER_INSTANCE_ID = `${process.pid}:${crypto.randomUUID()}`;
 
 // Cron jobs are process-local. Keep one module-private owner so a second
 // SchedulerService instance cannot start a duplicate job set in this process.
@@ -251,11 +264,12 @@ class SchedulerService {
       async () => {
         console.log('Dispatching agent heartbeat events...');
         try {
-          const result = await SchedulerService.dispatchAgentHeartbeats({
+          const result = await SchedulerService.dispatchScheduledAgentHeartbeats({
             trigger: 'scheduled-interval',
             respectIntervals: true,
           });
-          console.log(`Agent heartbeats enqueued: ${result.enqueued}`);
+          const leaseSuffix = result.skippedByLease ? ' (another scheduler holds the lease)' : '';
+          console.log(`Agent heartbeats enqueued: ${result.enqueued}${leaseSuffix}`);
         } catch (error) {
           console.error('Error dispatching agent heartbeats:', error);
         }
@@ -505,7 +519,7 @@ class SchedulerService {
     }, 9000);
 
     setTimeout(() => {
-      SchedulerService.dispatchAgentHeartbeats({
+      SchedulerService.dispatchScheduledAgentHeartbeats({
         trigger: 'startup',
         respectIntervals: true,
       }).catch((error: unknown) => {
@@ -895,6 +909,59 @@ class SchedulerService {
       lastPostAt: postStats?.[0]?.lastAt ? new Date(postStats[0].lastAt).toISOString() : null,
       generatedAt: now.toISOString(),
     };
+  }
+
+  /**
+   * Atomically take the cluster-wide heartbeat slot. A duplicate-key error is
+   * the normal losing result when two scheduler pods try to create the lease
+   * during a rollout; every other database error must still surface. We do
+   * not release early: that would let the other rollout replica run the same
+   * automatic tick after this dispatcher finishes.
+   */
+  static async tryAcquireHeartbeatDispatchLease(now = new Date()): Promise<boolean> {
+    const expiresAt = new Date(now.getTime() + HEARTBEAT_DISPATCH_LEASE_MS);
+    try {
+      await SchedulerHeartbeatLease.findOneAndUpdate(
+        {
+          _id: HEARTBEAT_DISPATCH_LEASE_ID,
+          expiresAt: { $lte: now },
+        },
+        {
+          $set: {
+            ownerId: SCHEDULER_INSTANCE_ID,
+            expiresAt,
+          },
+        },
+        { new: true, upsert: true, setDefaultsOnInsert: true },
+      );
+      return true;
+    } catch (error: unknown) {
+      if ((error as { code?: number })?.code === 11000) return false;
+      throw error;
+    }
+  }
+
+  /**
+   * Scheduler-only wrapper. Direct/manual dispatch intentionally stays
+   * available through dispatchAgentHeartbeats; only automatic triggers need
+   * the distributed lease that survives two backend replicas during rollout.
+   */
+  static async dispatchScheduledAgentHeartbeats(
+    options: DispatchHeartbeatsOptions = {},
+  ): Promise<ScheduledDispatchHeartbeatsResult> {
+    const now = options.now || new Date();
+    const acquired = await SchedulerService.tryAcquireHeartbeatDispatchLease(now);
+    if (!acquired) {
+      return {
+        scanned: 0,
+        enqueued: 0,
+        skippedByInterval: 0,
+        skippedByLease: true,
+      };
+    }
+
+    const result = await SchedulerService.dispatchAgentHeartbeats({ ...options, now });
+    return { ...result, skippedByLease: false };
   }
 
   static async dispatchAgentHeartbeats(


### PR DESCRIPTION
## Summary
- add a Mongo compare-and-set lease around automatic agent-heartbeat dispatches
- route both the minute cron and startup dispatch through that lease while preserving direct/manual dispatch
- cover simultaneous acquisition, expiry, wrapper behavior, and manual bypass against MongoMemoryServer

## Validation
- `npm test -- --runInBand __tests__/unit/services/schedulerService.heartbeatCue.test.js __tests__/unit/services/schedulerService.heartbeatOptIn.test.js __tests__/unit/services/schedulerService.heartbeatLease.test.js` (13 passed)
- `npm run tsc:check`
- `npm test -- --runInBand` was attempted but remains blocked by the repository's Node 26/jsonwebtoken transitive `buffer-equal-constant-time` failure in unrelated suites before they execute.