### PR TITLE
fix(personas): catalog single-column under 640px

### DIFF
--- a/frontend/src/v2/agents/v2-persona-catalog.css
+++ b/frontend/src/v2/agents/v2-persona-catalog.css
@@ -29,6 +29,14 @@
   gap: 16px;
 }
 
+/* At phone width the 300px column minimum exceeds what the nav rail leaves;
+   a single fluid column keeps every card fully inside the viewport. */
+@media (max-width: 640px) {
+  .v2-pcat { padding: 8px 14px 32px; }
+  .v2-pcat__grid { grid-template-columns: 1fr; }
+  .v2-pcat__card { min-width: 0; }
+}
+
 .v2-pcat__card {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
The jsdom-can't-see-layout rule doing its job: the 390px browser check caught the 300px card minimum clipping against the nav rail. One media query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8