### PR TITLE
fix(kernel): lease renewal from work, liveness-gated rescue, provenance (#1080)

### DIFF
--- a/backend/__tests__/unit/routes/tasksApi.updateRenewsLease.test.js
+++ b/backend/__tests__/unit/routes/tasksApi.updateRenewsLease.test.js
@@ -1,0 +1,207 @@
+/**
+ * A holder-authored task update renews the lease (#1080 part 1).
+ *
+ * Fable's ruling, verbatim: "renewal derives from work — any holder-authored
+ * task update renews the lease, kernel-side."
+ *
+ * The measurement that earned it (@sprint-review, 56203): @sprint-impl wrote a
+ * progress note on TASK-015 at 09:27:30 and the lease still lapsed at 09:51:11.
+ * The one signal a working holder naturally produces is exactly the one the
+ * lease ignored — so the row was rescued, its assignee cleared, and the board
+ * re-advertised work whose PR was already open.
+ *
+ * Real in-memory Mongo, not a mocked model: the holder match lives in the
+ * findOneAndUpdate FILTER, so it is Mongo that decides whether the renewing
+ * form applies. A mocked Task would only assert that the route passed a filter
+ * shaped like the one the test also wrote.
+ *
+ * The invariant that must never regress is the SECOND half of each case: the
+ * note lands either way. Gating the lease must never gate the audit trail.
+ */
+
+const request = require('supertest');
+const express = require('express');
+const mongoose = require('mongoose');
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.userId = req.get('x-test-user') || 'holder';
+  req.user = { id: req.userId, _id: req.userId };
+  next();
+});
+jest.mock('../../../middleware/agentRuntimeAuth', () => (req, res, next) => next());
+
+const POD_ID = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+
+jest.mock('../../../models/Pod', () => ({
+  findById: jest.fn(() => ({
+    lean: jest.fn().mockResolvedValue({
+      type: 'chat',
+      members: [{ toString: () => 'holder' }, { toString: () => 'stranger' }],
+    }),
+  })),
+}));
+
+jest.mock('../../../models/User', () => ({
+  findById: jest.fn(() => ({
+    select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue({ username: 'tester' }) })),
+  })),
+}));
+
+jest.mock('../../../services/githubAppService', () => ({ isPatConfigured: jest.fn(() => false) }));
+jest.mock('../../../services/taskEventService', () => ({ emitTaskUpdated: jest.fn() }));
+
+const Task = require('../../../models/Task');
+const tasksApi = require('../../../routes/tasksApi');
+
+const MIN = 60 * 1000;
+const LEASE_MS = 30 * MIN;
+
+let mongod;
+let app;
+
+const postUpdate = (as, taskId, text = 'rebased onto #1055') => request(app)
+  .post(`/api/v1/tasks/${POD_ID}/${taskId}/updates`)
+  .set('x-test-user', as)
+  .send({ text });
+
+const seed = (overrides) => Task.create({
+  podId: POD_ID,
+  taskNum: 1,
+  taskId: 'TASK-001',
+  title: 'decouple the schema',
+  status: 'claimed',
+  ...overrides,
+});
+
+// File-level, not per-describe: the second describe below would otherwise run
+// after the first one's afterAll had already disconnected mongoose.
+beforeAll(async () => {
+  // eslint-disable-next-line global-require
+  const { MongoMemoryServer } = require('mongodb-memory-server');
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  app = express();
+  app.use(express.json());
+  app.use('/api/v1/tasks', tasksApi);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongod) await mongod.stop();
+});
+
+beforeEach(async () => { await Task.deleteMany({}); });
+
+describe('POST /updates renews a holder-authored lease', () => {
+  it('the holder\'s note pushes the lease out by a full period', async () => {
+    const claimedAt = new Date(Date.now() - 25 * MIN);
+    const before = new Date(claimedAt.getTime() + LEASE_MS);
+    await seed({ claimedBy: 'holder', claimedAt, claimExpiresAt: before });
+
+    const res = await postUpdate('holder', 'TASK-001');
+    expect(res.status).toBe(200);
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    expect(new Date(row.claimExpiresAt).getTime()).toBeGreaterThan(before.getTime());
+    // A full period from NOW, not a nudge from the old expiry — a renewing
+    // holder must get the same lease a re-claim would have given them.
+    expect(new Date(row.claimExpiresAt).getTime()).toBeGreaterThan(Date.now() + 29 * MIN);
+    expect(row.updates.map((u) => u.text)).toContain('rebased onto #1055');
+  });
+
+  it('a peer\'s note is recorded and does NOT renew', async () => {
+    const claimedAt = new Date(Date.now() - 25 * MIN);
+    const before = new Date(claimedAt.getTime() + LEASE_MS);
+    await seed({ claimedBy: 'holder', claimedAt, claimExpiresAt: before });
+
+    const res = await postUpdate('stranger', 'TASK-001', 'reviewed at 9f91b9b0');
+    expect(res.status).toBe(200);
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    // Any passing peer could otherwise keep a dead seat's claim alive forever,
+    // which is the abandonment bar the lease exists to enforce.
+    expect(new Date(row.claimExpiresAt).getTime()).toBe(before.getTime());
+    expect(row.updates.map((u) => u.text)).toContain('reviewed at 9f91b9b0');
+  });
+
+  it('an ALREADY-LAPSED holder still renews — the row was theirs and they are working', async () => {
+    const claimedAt = new Date(Date.now() - 90 * MIN);
+    const before = new Date(claimedAt.getTime() + LEASE_MS);
+    await seed({ claimedBy: 'holder', claimedAt, claimExpiresAt: before });
+    expect(before.getTime()).toBeLessThan(Date.now());
+
+    await postUpdate('holder', 'TASK-001');
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    // The renewing filter matches on status+claimedBy, deliberately NOT on
+    // "lease still live". A holder whose lease lapsed while they worked is the
+    // exact population this rule exists for; requiring a live lease would make
+    // renewal available only to seats that did not need it.
+    expect(new Date(row.claimExpiresAt).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('a note on a pending row is recorded and creates no lease', async () => {
+    await seed({
+      status: 'pending', claimedBy: null, claimedAt: null, claimExpiresAt: null, 
+    });
+
+    const res = await postUpdate('holder', 'TASK-001', 'blocked on openclaw#12');
+    expect(res.status).toBe(200);
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    expect(row.status).toBe('pending');
+    expect(row.claimExpiresAt).toBeNull();
+    expect(row.updates.map((u) => u.text)).toContain('blocked on openclaw#12');
+  });
+
+  it('a note on a DONE row is recorded and does not resurrect a lease', async () => {
+    await seed({
+      status: 'done', claimedBy: 'holder', claimedAt: new Date(), claimExpiresAt: null, completedAt: new Date(),
+    });
+
+    await postUpdate('holder', 'TASK-001', 'follow-up filed');
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    expect(row.status).toBe('done');
+    expect(row.claimExpiresAt).toBeNull();
+    expect(row.updates.map((u) => u.text)).toContain('follow-up filed');
+  });
+
+  it('a missing task is still a 404 through the two-attempt path', async () => {
+    const res = await postUpdate('holder', 'TASK-404');
+    expect(res.status).toBe(404);
+  });
+
+  it('an empty note is still rejected before either write', async () => {
+    await seed({ claimedBy: 'holder', claimedAt: new Date(), claimExpiresAt: new Date(Date.now() + LEASE_MS) });
+    const res = await postUpdate('holder', 'TASK-001', '   ');
+    expect(res.status).toBe(400);
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    expect(row.updates).toHaveLength(0);
+  });
+});
+
+describe('claim resets the per-lease rescue budget', () => {
+  it('a fresh claim zeroes rescueDeferrals and clears lapsedFrom', async () => {
+    await seed({
+      status: 'pending',
+      claimedBy: null,
+      claimedAt: null,
+      claimExpiresAt: null,
+      rescueDeferrals: 3,
+      lapsedFrom: 'sprint-impl',
+    });
+
+    const res = await request(app)
+      .post(`/api/v1/tasks/${POD_ID}/TASK-001/claim`)
+      .set('x-test-user', 'stranger')
+      .send({});
+    expect(res.status).toBe(200);
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    // The budget is per-LEASE. Without the reset, the third holder of a hot
+    // task inherits a spent budget and gets rescued on their first lapse.
+    expect(row.rescueDeferrals).toBe(0);
+    expect(row.lapsedFrom).toBeNull();
+  });
+});

--- a/backend/__tests__/unit/services/kernelWorkSweepService.test.js
+++ b/backend/__tests__/unit/services/kernelWorkSweepService.test.js
@@ -13,12 +13,19 @@ jest.mock('../../../models/Task', () => ({
 }));
 
 jest.mock('../../../models/AgentRegistry', () => ({
-  AgentInstallation: { find: jest.fn() },
+  AgentInstallation: { find: jest.fn(), findOne: jest.fn() },
 }));
 
 const mockNotifyFoundWork = jest.fn();
+const mockNotifyLeaseWarning = jest.fn();
 jest.mock('../../../services/taskEventService', () => ({
   notifyFoundWork: (...args) => mockNotifyFoundWork(...args),
+  notifyLeaseWarning: (...args) => mockNotifyLeaseWarning(...args),
+}));
+
+const mockDeriveAgentState = jest.fn();
+jest.mock('../../../services/agentStateService', () => ({
+  deriveAgentState: (...args) => mockDeriveAgentState(...args),
 }));
 
 // The contract pin below requires routes/tasksApi for its claimableConditions
@@ -34,7 +41,32 @@ jest.mock('../../../models/User', () => ({ findById: jest.fn() }));
 jest.mock('../../../services/githubAppService', () => ({ isPatConfigured: jest.fn(() => false) }));
 
 const Task = require('../../../models/Task');
+const User = require('../../../models/User');
+const { AgentInstallation } = require('../../../models/AgentRegistry');
 const KernelWorkSweepService = require('../../../services/kernelWorkSweepService');
+
+const HOLDER_ID = new mongoose.Types.ObjectId().toString();
+
+// A holder that resolves to a real install. `state` is whatever
+// deriveAgentState is mocked to return — the point of the seam.
+const mockHolderResolves = (state) => {
+  User.findById.mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue({
+        username: 'sprint-impl',
+        isBot: true,
+        botMetadata: { agentName: 'claude-code', instanceId: 'sprint-impl' },
+        agentRuntimeTokens: [],
+      }),
+    }),
+  });
+  AgentInstallation.findOne.mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue({ agentName: 'claude-code', instanceId: 'sprint-impl' }),
+    }),
+  });
+  mockDeriveAgentState.mockReturnValue({ agentName: 'claude-code', instanceId: 'sprint-impl', state });
+};
 
 const POD_A = new mongoose.Types.ObjectId().toString();
 const NOW = new Date('2026-08-20T20:00:00Z');
@@ -56,6 +88,15 @@ beforeEach(() => {
   });
   Task.aggregate.mockResolvedValue([]);
   mockNotifyFoundWork.mockResolvedValue({ woken: 1 });
+  mockNotifyLeaseWarning.mockResolvedValue({ warned: true });
+  // Default: the holder cannot be resolved at all, which is the pre-#1080
+  // behaviour — rescue as today. Tests that care opt in via mockHolderResolves.
+  User.findById.mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(null) }),
+  });
+  AgentInstallation.findOne.mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(null) }),
+  });
 });
 
 describe('rescueLapsed', () => {
@@ -66,7 +107,7 @@ describe('rescueLapsed', () => {
     });
     Task.findOneAndUpdate.mockResolvedValue({ ...t, status: 'pending' });
 
-    const rescued = await KernelWorkSweepService.rescueLapsed(NOW);
+    const { rescued } = await KernelWorkSweepService.rescueLapsed(NOW);
 
     expect(rescued).toHaveLength(1);
     const [filter, update] = Task.findOneAndUpdate.mock.calls[0];
@@ -89,7 +130,7 @@ describe('rescueLapsed', () => {
     // CAS misses: the holder renewed, no lapsed branch matches.
     Task.findOneAndUpdate.mockResolvedValue(null);
 
-    const rescued = await KernelWorkSweepService.rescueLapsed(NOW);
+    const { rescued } = await KernelWorkSweepService.rescueLapsed(NOW);
     expect(rescued).toHaveLength(0);
   });
 
@@ -105,6 +146,171 @@ describe('rescueLapsed', () => {
     const [, update] = Task.findOneAndUpdate.mock.calls[0];
     expect(update.$push.updates.author).toBe('kernel-sweep');
     expect(update.$push.updates.text).toContain('kernel sweep');
+  });
+});
+
+describe('#1080 part 2 — liveness gates the rescue, and only liveness', () => {
+  const withCandidate = (overrides = {}) => {
+    const t = lapsedTask({ claimedBy: HOLDER_ID, assignee: 'sprint-impl', ...overrides });
+    Task.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([t]) }),
+    });
+    Task.findOneAndUpdate.mockResolvedValue({ ...t });
+    return t;
+  };
+
+  it('a provably-live holder is deferred, not rescued', async () => {
+    withCandidate();
+    mockHolderResolves('listening');
+
+    const { rescued, deferred } = await KernelWorkSweepService.rescueLapsed(NOW);
+
+    expect(rescued).toHaveLength(0);
+    expect(deferred).toHaveLength(1);
+    const [, update] = Task.findOneAndUpdate.mock.calls[0];
+    // The deferring write must NOT touch status/assignee — the whole point is
+    // that the row stays exactly as the holder left it.
+    expect(update.$set.status).toBeUndefined();
+    expect(update.$set.assignee).toBeUndefined();
+    expect(update.$set.rescueDeferrals).toBe(1);
+  });
+
+  it('deferral does NOT extend the lease — the row stays claimable by peers', async () => {
+    withCandidate();
+    mockHolderResolves('listening');
+
+    await KernelWorkSweepService.rescueLapsed(NOW);
+
+    const [, update] = Task.findOneAndUpdate.mock.calls[0];
+    // "liveness isn't tenure" (fable, 56210). If deferral pushed
+    // claimExpiresAt forward, the kernel would be renewing on the holder's
+    // behalf — a seat that never renews would hold the row indefinitely, and
+    // a peer who legitimately needs it could no longer win the claim CAS.
+    expect(update.$set.claimExpiresAt).toBeUndefined();
+    expect(update.$set.claimedAt).toBeUndefined();
+  });
+
+  it('warns the holder it deferred for, naming the task and the budget', async () => {
+    const t = withCandidate();
+    mockHolderResolves('listening');
+
+    await KernelWorkSweepService.rescueLapsed(NOW);
+
+    expect(mockNotifyLeaseWarning).toHaveBeenCalledTimes(1);
+    const [podId, holder, task, used, max] = mockNotifyLeaseWarning.mock.calls[0];
+    expect(String(podId)).toBe(String(t.podId));
+    expect(holder.label).toBe('sprint-impl');
+    expect(task.taskId).toBe('TASK-007');
+    expect(used).toBe(1);
+    expect(max).toBe(3);
+  });
+
+  it('rescues once the deferral budget is spent, and says why', async () => {
+    withCandidate({ rescueDeferrals: 3 });
+    mockHolderResolves('listening');
+
+    const { rescued, deferred } = await KernelWorkSweepService.rescueLapsed(NOW);
+
+    expect(deferred).toHaveLength(0);
+    expect(rescued).toHaveLength(1);
+    const [, update] = Task.findOneAndUpdate.mock.calls[0];
+    expect(update.$set.status).toBe('pending');
+    expect(update.$push.updates.text).toContain('3 deferrals');
+    expect(mockNotifyLeaseWarning).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['gone-dark', 'the wrapper stopped polling'],
+    ['never-connected', 'the wrapper never polled'],
+    ['unknown', 'the gateway tier cannot say'],
+    ['reachable', 'asserted by construction, never measured'],
+  ])('%s rescues as today (%s)', async (state) => {
+    withCandidate();
+    mockHolderResolves(state);
+
+    const { rescued, deferred } = await KernelWorkSweepService.rescueLapsed(NOW);
+
+    // Only 'listening' is evidence. 'reachable' and 'unknown' are NOT the
+    // opposite of dead — they are the derivation declining to measure — and
+    // deferring on them would grant tenure to a class nobody checked.
+    expect(deferred).toHaveLength(0);
+    expect(rescued).toHaveLength(1);
+    expect(mockNotifyLeaseWarning).not.toHaveBeenCalled();
+  });
+
+  it('an unresolvable holder rescues as today', async () => {
+    withCandidate({ claimedBy: null, assignee: null });
+
+    const { rescued } = await KernelWorkSweepService.rescueLapsed(NOW);
+
+    expect(rescued).toHaveLength(1);
+    expect(mockDeriveAgentState).not.toHaveBeenCalled();
+  });
+
+  it('a warning that fails to deliver still leaves the deferral standing', async () => {
+    withCandidate();
+    mockHolderResolves('listening');
+    mockNotifyLeaseWarning.mockRejectedValue(new Error('queue down'));
+
+    const { rescued, deferred } = await KernelWorkSweepService.rescueLapsed(NOW);
+
+    // An undeliverable warning is a missing signal, not a verdict on the
+    // holder. Rescuing here would make a queue outage look like abandonment.
+    expect(deferred).toHaveLength(1);
+    expect(rescued).toHaveLength(0);
+  });
+});
+
+describe('#1080 part 3 — provenance survives the clearing', () => {
+  it('the rescue records who held it, in the field AND the audit trail', async () => {
+    const t = lapsedTask({ claimedBy: HOLDER_ID, assignee: 'sprint-impl' });
+    Task.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([t]) }),
+    });
+    Task.findOneAndUpdate.mockResolvedValue({ ...t, status: 'pending' });
+
+    await KernelWorkSweepService.rescueLapsed(NOW);
+
+    const [, update] = Task.findOneAndUpdate.mock.calls[0];
+    // assignee/claimedBy are cleared in the SAME write — that clearing is what
+    // erased the only record of ownership and let a finished PR be advertised
+    // as unclaimed work. lapsedFrom is the record that outlives it.
+    expect(update.$set.assignee).toBeNull();
+    expect(update.$set.claimedBy).toBeNull();
+    expect(update.$set.lapsedFrom).toBe('sprint-impl');
+    expect(update.$push.updates.text).toContain('was: sprint-impl');
+  });
+
+  it('falls back to claimedBy when the row carries no assignee', async () => {
+    const t = lapsedTask({ claimedBy: 'nova', assignee: null });
+    Task.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([t]) }),
+    });
+    Task.findOneAndUpdate.mockResolvedValue({ ...t, status: 'pending' });
+
+    await KernelWorkSweepService.rescueLapsed(NOW);
+
+    const [, update] = Task.findOneAndUpdate.mock.calls[0];
+    expect(update.$set.lapsedFrom).toBe('nova');
+  });
+
+  it('the found-work wake carries lapsedFrom out of the aggregate', async () => {
+    Task.aggregate.mockResolvedValue([
+      {
+        _id: POD_A,
+        tasks: [{ taskId: 'TASK-015', title: 'decouple', lapsedFrom: 'sprint-impl' }],
+        count: 1,
+      },
+    ]);
+
+    await KernelWorkSweepService.wakeForFoundWork(NOW);
+
+    const [, items] = mockNotifyFoundWork.mock.calls[0];
+    expect(items[0].lapsedFrom).toBe('sprint-impl');
+    // The projection is where this can silently die: $group must $push the
+    // field, or the wake renders "unclaimed" about work that has an owner.
+    const pipeline = Task.aggregate.mock.calls[0][0];
+    expect(JSON.stringify(pipeline)).toContain('lapsedFrom');
   });
 });
 
@@ -164,7 +370,9 @@ describe('sweep', () => {
 
     const result = await KernelWorkSweepService.sweep(NOW);
 
-    expect(result).toEqual({ scannedPods: 0, rescued: 0, woken: 0, skippedNoWork: 0 });
+    expect(result).toEqual({
+      scannedPods: 0, rescued: 0, deferred: 0, woken: 0, skippedNoWork: 0,
+    });
     expect(Task.find).not.toHaveBeenCalled();
     expect(mockNotifyFoundWork).not.toHaveBeenCalled();
   });

--- a/backend/models/Task.ts
+++ b/backend/models/Task.ts
@@ -24,6 +24,16 @@ export interface ITask extends Document {
   // ADR-018 D4: a claim is a lease, never permanent. Null on legacy claims —
   // readers derive their effective expiry from claimedAt + the route's lease.
   claimExpiresAt?: Date | null;
+  // Fable's #1080 ruling, part 2: a lapsed lease held by a PROVABLY LIVE seat
+  // is deferred rather than rescued, at most three times. The counter lives on
+  // the row so the sweep stays stateless; it resets on every claim, so a seat
+  // that renews normally never accumulates one.
+  rescueDeferrals?: number;
+  // Part 3: provenance always. Who held the lease when the kernel took it
+  // back. Survives the rescue precisely because `claimedBy` and `assignee` do
+  // not — clearing them is what makes the row findable again, and it is also
+  // what erased the only record of whose work it was.
+  lapsedFrom?: string | null;
   completedAt?: Date | null;
   prUrl?: string | null;
   notes?: string | null;
@@ -59,6 +69,8 @@ const TaskSchema = new Schema<ITask>(
     claimedBy: { type: String, default: null },
     claimedAt: { type: Date, default: null },
     claimExpiresAt: { type: Date, default: null },
+    rescueDeferrals: { type: Number, default: 0 },
+    lapsedFrom: { type: String, default: null },
     completedAt: { type: Date, default: null },
     prUrl: { type: String, default: null },
     notes: { type: String, default: null },

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -468,7 +468,11 @@ router.post('/:podId/:taskId/claim', rateLimit({
     const access = await requirePodMember(podId || '', userId, { write: true });
     if (access.error) return res.status(access.status || 500).json({ error: access.error });
     const now = new Date();
-    const update = { $set: { status: 'claimed', claimedBy, claimedAt: now, claimExpiresAt: new Date(now.getTime() + TASK_CLAIM_LEASE_MS) }, $push: { updates: { text: `Claimed by ${author}`, author, authorId: userId?.toString() || null, createdAt: now } } };
+    // `rescueDeferrals` and `lapsedFrom` reset on every claim (#1080 part 2/3).
+    // The deferral budget is per-lease, not per-task: a seat that renews
+    // normally must never inherit a predecessor's spent budget, or the third
+    // holder of a hot task gets rescued on its first lapse.
+    const update = { $set: { status: 'claimed', claimedBy, claimedAt: now, claimExpiresAt: new Date(now.getTime() + TASK_CLAIM_LEASE_MS), rescueDeferrals: 0, lapsedFrom: null }, $push: { updates: { text: `Claimed by ${author}`, author, authorId: userId?.toString() || null, createdAt: now } } };
     // One CAS, four ways to win: the task is unclaimed; the caller already
     // holds it (renewal); the holder's lease lapsed; or the claim predates
     // leases entirely (claimExpiresAt null) and is older than one lease —
@@ -579,7 +583,32 @@ router.post('/:podId/:taskId/updates', taskWriteRateLimit(60), auth, async (req:
     const access = await requirePodMember(podId || '', userId, { write: true });
     if (access.error) return res.status(access.status || 500).json({ error: access.error });
     const author = await resolveAuthor(req);
-    const task = await Task.findOneAndUpdate({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId }, { $push: { updates: { text: text.trim(), author, authorId: userId?.toString() || null, createdAt: new Date() } } }, { new: true });
+    const now = new Date();
+    const note = { updates: { text: text.trim(), author, authorId: userId?.toString() || null, createdAt: now } };
+    const podFilter = mongoose.Types.ObjectId.createFromHexString(podId || '');
+
+    // #1080 part 1 (fable's ruling; @sprint-impl's shape): renewal derives
+    // from WORK. A progress note is the signal a working holder naturally
+    // produces, and the lease ignored it — @sprint-review measured exactly
+    // that on TASK-015, where a 09:27:30 rebase note did not stop a 09:51:11
+    // lapse. So a note from the holder renews; a note from anyone else does
+    // not, or any passing peer could keep a dead seat's claim alive forever.
+    //
+    // Holder-match is evaluated SERVER-SIDE, in the filter, never from a
+    // snapshot — same rule the rescue CAS follows. Two attempts rather than
+    // one conditional write: the renewing form first, the note-only form as
+    // fallback. The note lands either way; only the lease extension is gated.
+    const claimKey = resolveAgentInstanceId(req) || userId?.toString() || '';
+    let task = claimKey
+      ? await Task.findOneAndUpdate(
+        { podId: podFilter, taskId, status: 'claimed', claimedBy: claimKey },
+        { $set: { claimExpiresAt: new Date(now.getTime() + TASK_CLAIM_LEASE_MS) }, $push: note },
+        { new: true },
+      )
+      : null;
+    if (!task) {
+      task = await Task.findOneAndUpdate({ podId: podFilter, taskId }, { $push: note }, { new: true });
+    }
     if (!task) return res.status(404).json({ error: 'Task not found' });
     emitTaskUpdated(podId, task, 'updated');
     notifyAgents(req, podId, task, 'updated');

--- a/backend/services/kernelWorkSweepService.ts
+++ b/backend/services/kernelWorkSweepService.ts
@@ -38,8 +38,39 @@ const Task = require('../models/Task');
 // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
 const { AgentInstallation } = require('../models/AgentRegistry');
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const User = require('../models/User');
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const { deriveAgentState } = require('./agentStateService');
+
 const KERNEL_ACTOR = 'kernel-sweep';
 const TASK_CLAIM_LEASE_MS = 30 * 60 * 1000;
+
+// #1080 part 2 (fable's ruling): "The rescue consults deriveAgentState: dead
+// seat -> rescue as today; live seat -> defer one sweep period and warn the
+// holder, at most three deferrals — liveness isn't tenure."
+//
+// LIVE means one state and one only. `deriveAgentState` returns five, and only
+// `listening` is backed by evidence: for BYO/wrapper installs the seat polls
+// every ~5s, so a fresh `lastUsedAt` is a measurement. The other four are not
+// the opposite of live, they are differently-shaped:
+//   - 'reachable' is asserted BY CONSTRUCTION for native + push-webhook
+//     installs. Deferring on it would defer forever on a class whose liveness
+//     was never checked.
+//   - 'unknown' is the gateway/cloud tier saying so out loud (one shared boot
+//     timestamp for a whole fleet). Deferring on an explicit "we don't know"
+//     converts an honest abstention into a tenure grant.
+// So both rescue as today. That is a READING of the ruling, not a quote from
+// it, and it is the one place this implementation had to choose: the ruling
+// says dead-vs-live and the derivation has a third answer. It fixes all three
+// cases fable named — TASK-008, TASK-029 and TASK-015 are wrapper seats and
+// derive 'listening' — while changing nothing for classes we cannot measure.
+const LIVE_STATES = new Set(['listening']);
+
+// "at most three deferrals" — verbatim. Per LEASE, not per task: the claim
+// route resets the counter, so this bounds one holder's silence at
+// 3 x SWEEP_INTERVAL_MS (~30 min) past a lapsed lease, never a task's lifetime.
+const MAX_RESCUE_DEFERRALS = 3;
 
 // MUST match the cron cadence in schedulerService ('4,14,24,... * * * *' =
 // every 10 minutes). The newly-actionable window is one sweep period: wider
@@ -55,6 +86,8 @@ const MAX_NAMED_ITEMS = 5;
 interface SweepResult {
   scannedPods: number;
   rescued: number;
+  /** Lapsed rows left alone this pass because their holder is provably live. */
+  deferred: number;
   woken: number;
   skippedNoWork: number;
 }
@@ -66,7 +99,74 @@ interface TaskRow {
   title?: string;
   status?: string;
   assignee?: string | null;
+  claimedBy?: string | null;
+  rescueDeferrals?: number;
+  lapsedFrom?: string | null;
 }
+
+interface HolderIdentity {
+  agentName: string;
+  instanceId: string;
+  /** Display label for the audit trail and the found-work wake. */
+  label: string;
+  /** `deriveAgentState`'s answer, or 'unknown' when the holder is unresolvable. */
+  state: string;
+}
+
+/**
+ * Who holds this lease, and can we prove they are alive?
+ *
+ * `claimedBy` is written by the claim route as
+ * `resolveAgentInstanceId(req) || userId.toString()`. In practice it is almost
+ * always the second branch: `resolveAgentInstanceId` reads `req.user.isBot`,
+ * and the agent runtime auth middleware populates `req.agentUser` rather than
+ * `req.user` (the documented gotcha in CLAUDE.md), so wrapper and MCP seats
+ * fall through to their bot User's ObjectId. Both shapes are handled — the
+ * id path first because it is the one live data actually uses.
+ *
+ * Returns null when the holder cannot be resolved to an install at all, which
+ * the caller treats as "not provably live" and rescues as today. An
+ * unresolvable holder is exactly the case the rescue exists for.
+ */
+const resolveHolder = async (
+  podId: unknown,
+  claimedBy: string | null | undefined,
+  assignee: string | null | undefined,
+  now: Date,
+): Promise<HolderIdentity | null> => {
+  if (!claimedBy) return null;
+  try {
+    const isObjectId = /^[0-9a-f]{24}$/i.test(claimedBy);
+    const holder = isObjectId
+      ? await User.findById(claimedBy).select('username isBot botMetadata agentRuntimeTokens').lean()
+      : null;
+
+    const agentName = String(holder?.botMetadata?.agentName || '').toLowerCase();
+    const instanceId = String(holder?.botMetadata?.instanceId || (isObjectId ? 'default' : claimedBy));
+    const label = assignee || holder?.username || claimedBy;
+
+    const query: Record<string, unknown> = { podId: String(podId), status: 'active' };
+    if (agentName) query.agentName = agentName;
+    query.instanceId = instanceId;
+    const install = await AgentInstallation.findOne(query)
+      .select('agentName instanceId displayName installedBy config runtimeTokens')
+      .lean();
+    if (!install) return { agentName, instanceId, label, state: 'unknown' };
+
+    const derived = deriveAgentState(install, holder?.agentRuntimeTokens || [], '', now.getTime());
+    return {
+      agentName: derived.agentName || agentName,
+      instanceId: derived.instanceId || instanceId,
+      label,
+      state: derived.state,
+    };
+  } catch (err) {
+    // Liveness is an optimization on top of the rescue, never a gate in front
+    // of it. If the lookup throws, the row rescues as it did before #1080.
+    console.warn('[kernel-sweep] holder lookup failed:', (err as Error).message);
+    return null;
+  }
+};
 
 class KernelWorkSweepService {
   /**
@@ -94,13 +194,69 @@ class KernelWorkSweepService {
    * alone returns the task to the lane of the seat that died holding it,
    * where no other seat's assignee-scoped fetch will ever see it.
    */
-  static async rescueLapsed(now: Date): Promise<TaskRow[]> {
+  static async rescueLapsed(now: Date): Promise<{ rescued: TaskRow[]; deferred: TaskRow[] }> {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const { notifyLeaseWarning } = require('./taskEventService');
+
     const candidates = await Task.find({ $or: KernelWorkSweepService.lapsedConditions(now) })
-      .select('_id podId taskId title status assignee claimedBy')
+      .select('_id podId taskId title status assignee claimedBy rescueDeferrals')
       .lean() as TaskRow[];
 
     const rescued: TaskRow[] = [];
+    const deferred: TaskRow[] = [];
     for (const t of candidates) {
+      // eslint-disable-next-line no-await-in-loop
+      const holder = await resolveHolder(t.podId, t.claimedBy, t.assignee, now);
+      const used = Number(t.rescueDeferrals || 0);
+      const canDefer = !!holder && LIVE_STATES.has(holder.state) && used < MAX_RESCUE_DEFERRALS;
+
+      if (canDefer) {
+        // Defer, warn, and count — one CAS, same lapsed predicate in the
+        // filter. A holder who renews between the find and this write wins and
+        // the deferral is simply not recorded, which is the correct outcome:
+        // there is nothing left to defer.
+        //
+        // The counter increments even though the lease is NOT extended. That
+        // is deliberate and it is what "liveness isn't tenure" buys: the row
+        // stays lapsed and claimable by the CAS's own expiry branch the whole
+        // time, so a peer who genuinely needs it can still take it. Deferral
+        // suppresses the KERNEL's rescue, not the board.
+        // eslint-disable-next-line no-await-in-loop
+        const held = await Task.findOneAndUpdate(
+          { _id: t._id, $or: KernelWorkSweepService.lapsedConditions(now) },
+          {
+            $set: { rescueDeferrals: used + 1 },
+            $push: {
+              updates: {
+                text: `Lease lapsed but ${holder.label} is still listening — rescue deferred (${used + 1} of ${MAX_RESCUE_DEFERRALS}). Renew by posting a task update or re-claiming.`,
+                author: KERNEL_ACTOR,
+                authorId: null,
+                createdAt: now,
+              },
+            },
+          },
+          { new: true },
+        ) as TaskRow | null;
+        if (held) {
+          deferred.push(held);
+          try {
+            // eslint-disable-next-line no-await-in-loop
+            await notifyLeaseWarning(t.podId, holder, held, used + 1, MAX_RESCUE_DEFERRALS, now);
+          } catch (err) {
+            // fable, 56213: "a dead seat ignoring it is the diagnosis, not the
+            // failure." A warning that cannot be DELIVERED is neither — it is
+            // just a missing signal, and it must not strand the row. The
+            // deferral still stands; the next sweep re-evaluates.
+            console.warn(`[kernel-sweep] lease warning failed for ${holder.label}:`, (err as Error).message);
+          }
+        }
+        continue;
+      }
+
+      const provenance = holder?.label || t.assignee || t.claimedBy || null;
+      const why = holder && LIVE_STATES.has(holder.state)
+        ? ` after ${MAX_RESCUE_DEFERRALS} deferrals`
+        : '';
       // eslint-disable-next-line no-await-in-loop
       const won = await Task.findOneAndUpdate(
         // The lapsed predicate travels INTO the filter: if the holder renewed
@@ -114,10 +270,19 @@ class KernelWorkSweepService {
             claimedBy: null,
             claimedAt: null,
             claimExpiresAt: null,
+            rescueDeferrals: 0,
+            // #1080 part 3: provenance always. The three fields that named the
+            // owner are all cleared on the next four lines, which is what makes
+            // the row findable again AND what made two reviewers hand-warn the
+            // room that a finished PR was being re-advertised as unclaimed.
+            // This field is the record that survives the clearing.
+            lapsedFrom: provenance,
           },
           $push: {
             updates: {
-              text: 'Lease lapsed — returned to pending by the kernel sweep',
+              text: provenance
+                ? `Lease lapsed — returned to pending by the kernel sweep${why} (was: ${provenance})`
+                : `Lease lapsed — returned to pending by the kernel sweep${why}`,
               author: KERNEL_ACTOR,
               authorId: null,
               createdAt: now,
@@ -128,7 +293,7 @@ class KernelWorkSweepService {
       ) as TaskRow | null;
       if (won) rescued.push(won);
     }
-    return rescued;
+    return { rescued, deferred };
   }
 
   /**
@@ -157,8 +322,12 @@ class KernelWorkSweepService {
           $or: [{ assignee: null }, { assignee: '' }, { assignee: { $exists: false } }],
         },
       },
-      { $group: { _id: '$podId', tasks: { $push: { taskId: '$taskId', title: '$title' } }, count: { $sum: 1 } } },
-    ]) as Array<{ _id: unknown; tasks: Array<{ taskId?: string; title?: string }>; count: number }>;
+      // `lapsedFrom` rides along so the wake can name who it lapsed from
+      // (#1080 part 3). The wake is the surface where the near-duplicate of
+      // #1078 nearly happened: a row advertised as unassigned, with its
+      // finished PR invisible because the rescue had cleared the assignee.
+      { $group: { _id: '$podId', tasks: { $push: { taskId: '$taskId', title: '$title', lapsedFrom: '$lapsedFrom' } }, count: { $sum: 1 } } },
+    ]) as Array<{ _id: unknown; tasks: Array<{ taskId?: string; title?: string; lapsedFrom?: string | null }>; count: number }>;
 
     let woken = 0;
     let skippedNoWork = 0;
@@ -172,19 +341,23 @@ class KernelWorkSweepService {
 
   static async sweep(now: Date = new Date()): Promise<SweepResult> {
     if (String(process.env.AGENT_WORK_SWEEP_DISABLED || '').toLowerCase() === 'true') {
-      return { scannedPods: 0, rescued: 0, woken: 0, skippedNoWork: 0 };
+      return {
+        scannedPods: 0, rescued: 0, deferred: 0, woken: 0, skippedNoWork: 0,
+      };
     }
-    const rescued = await KernelWorkSweepService.rescueLapsed(now);
+    const { rescued, deferred } = await KernelWorkSweepService.rescueLapsed(now);
     const { woken, skippedNoWork, scannedPods } = await KernelWorkSweepService.wakeForFoundWork(now);
-    if (rescued.length || woken) {
-      console.log(`[kernel-sweep] rescued=${rescued.length} woken=${woken} pods=${scannedPods}`);
+    if (rescued.length || deferred.length || woken) {
+      console.log(`[kernel-sweep] rescued=${rescued.length} deferred=${deferred.length} woken=${woken} pods=${scannedPods}`);
     }
-    return { scannedPods, rescued: rescued.length, woken, skippedNoWork };
+    return {
+      scannedPods, rescued: rescued.length, deferred: deferred.length, woken, skippedNoWork,
+    };
   }
 }
 
 // Re-exported so the wake path and any future consumer name the same actor.
-export { KERNEL_ACTOR };
+export { KERNEL_ACTOR, LIVE_STATES, MAX_RESCUE_DEFERRALS };
 export default KernelWorkSweepService;
 // CJS compat: let require() return the class directly
 // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/backend/services/taskEventService.ts
+++ b/backend/services/taskEventService.ts
@@ -278,7 +278,7 @@ export async function notifyPodAgents(
  */
 export async function notifyFoundWork(
   podId: unknown,
-  items: Array<{ taskId?: string; title?: string }>,
+  items: Array<{ taskId?: string; title?: string; lapsedFrom?: string | null }>,
   totalCount: number,
   now: Date = new Date(),
 ): Promise<{ woken: number }> {
@@ -296,8 +296,16 @@ export async function notifyFoundWork(
     const installs = (active || []).filter(wakeOnMessageEnabled);
     if (!installs.length) return { woken: 0 };
 
+    // #1080 part 3: a rescued row names who it lapsed from. Without it the wake
+    // says "unclaimed" about work that has an open PR against it, and the only
+    // thing standing between that and a duplicate implementation is whether a
+    // peer happens to be reading the pod. Two reviewers hand-warned the room
+    // about exactly this on TASK-015 within one minute of each other.
     const listed = items
-      .map((t) => `- ${t.taskId || '?'} — ${String(t.title || '(untitled)').slice(0, 80)}`)
+      .map((t) => {
+        const line = `- ${t.taskId || '?'} — ${String(t.title || '(untitled)').slice(0, 80)}`;
+        return t.lapsedFrom ? `${line}  [lapsed from ${t.lapsedFrom} — check their work before starting]` : line;
+      })
       .join('\n');
     const more = totalCount > items.length ? `\n…and ${totalCount - items.length} more on the board.` : '';
     const content = [
@@ -350,11 +358,92 @@ export async function notifyFoundWork(
   }
 }
 
+/**
+ * #1080 part 2: warn the holder of a lapsed lease that the kernel is about to
+ * take it back, instead of taking it back silently.
+ *
+ * Addressed to ONE seat — the holder — so unlike `notifyFoundWork` this does
+ * not consult `wakeOnMessageEnabled`. The holder's own claim is the address;
+ * an ambient opt-in is not what makes this relevant to them. It is also the
+ * reason the warning is only ever sent to a seat that derived 'listening':
+ * fable, 56213 — "the warning event works only BECAUSE it's gated on a live
+ * seat — a dead seat ignoring it is the diagnosis, not the failure."
+ *
+ * Priced 'kernel' like every other sweep wake: neutral in the cascade
+ * governor, counting toward nothing and clearing nothing.
+ */
+export async function notifyLeaseWarning(
+  podId: unknown,
+  holder: { agentName: string; instanceId: string; label: string },
+  task: { taskId?: string; title?: string },
+  deferralsUsed: number,
+  maxDeferrals: number,
+  now: Date = new Date(),
+): Promise<{ warned: boolean }> {
+  if (!podId || !holder?.agentName || !task?.taskId) return { warned: false };
+  /* eslint-disable global-require, @typescript-eslint/no-require-imports */
+  const AgentEventService = require('./agentEventService');
+  const AgentEvent = require('../models/AgentEvent');
+  /* eslint-enable global-require, @typescript-eslint/no-require-imports */
+
+  const normalizedPodId = String(podId);
+  const remaining = maxDeferrals - deferralsUsed;
+  const content = [
+    `[Your lease on ${task.taskId} has lapsed. You are still listening, so the kernel deferred the rescue — ${remaining} deferral${remaining === 1 ? '' : 's'} left.]`,
+    '',
+    `${task.taskId} — ${String(task.title || '(untitled)').slice(0, 80)}`,
+    '',
+    'The row is claimable by peers right now: deferral suppresses the kernel\'s',
+    'rescue, not the board. To keep it, post a task update or re-claim — either',
+    'renews the lease. If you have finished, complete it with the PR link. If it',
+    'is no longer yours, do nothing and it returns to the board named as yours.',
+  ].join('\n');
+
+  try {
+    // Fold rather than stack: three deferrals on one task must not become three
+    // pending events. Keyed on the task, so a seat holding two lapsed rows is
+    // warned once about each.
+    const folded = await AgentEvent.findOneAndUpdate(
+      {
+        agentName: holder.agentName,
+        instanceId: holder.instanceId || 'default',
+        podId: normalizedPodId,
+        status: 'pending',
+        'payload.leaseWarningTaskId': task.taskId,
+      },
+      { $set: { 'payload.content': content, 'payload.deferralsUsed': deferralsUsed } },
+      { new: true },
+    );
+    if (folded) return { warned: true };
+
+    await AgentEventService.enqueue({
+      agentName: holder.agentName,
+      instanceId: holder.instanceId || 'default',
+      podId: normalizedPodId,
+      type: 'message.posted',
+      payload: {
+        content,
+        podId: normalizedPodId,
+        leaseWarningTaskId: task.taskId,
+        deferralsUsed,
+        warnedAt: now,
+        // Same third pricing branch as the board wake. No dmKind, no messageId.
+        triggerAuthor: 'kernel',
+      },
+    });
+    return { warned: true };
+  } catch (err) {
+    console.warn('[task-event] lease warning failed:', (err as Error).message);
+    return { warned: false };
+  }
+}
+
 export default {
   bindSocketIO,
   emitTaskUpdated,
   notifyPodAgents,
   notifyFoundWork,
+  notifyLeaseWarning,
 };
 
 // CJS compat: let require() return the default export directly


### PR DESCRIPTION
Closes #1080. Implements @fable-lead's ruling (pod message 56210) in full — that message named this its spec.

### Part 1 — renewal derives from work

A holder-authored task update now renews the lease. @sprint-review measured the exact gap on TASK-015: a progress note at 09:27:30 did not stop a 09:51:11 lapse, so the one signal a working holder naturally produces was the one signal the lease ignored.

Shape is @sprint-impl's (56207): `POST /updates` already has the caller identity and the task write, so it renews atomically only when the caller's stable claim key equals `claimedBy`. Holder match travels **into the `findOneAndUpdate` filter** — server-arbitrated, never from a snapshot, same rule the rescue CAS follows. A peer's note is recorded and does **not** renew, or any passing agent could keep a dead seat's claim alive indefinitely.

Two attempts rather than one conditional write, because the note must land either way: gating the lease must never gate the audit trail. An already-lapsed holder still renews — requiring a live lease would make renewal available only to the seats that did not need it.

### Part 2 — the rescue consults `deriveAgentState`

A lapsed lease held by a provably live seat is deferred one sweep period and the holder warned, at most three times, then rescued anyway.

**Deferral does not extend the lease.** The row stays lapsed and claimable by the CAS's own expiry branch the entire time, so a peer who genuinely needs it can still take it. Deferral suppresses the *kernel's* rescue, not the board — that is what "liveness isn't tenure" buys, and it is pinned by a test.

**Only `listening` counts as live, and that is a reading of the ruling rather than a quote from it.** This is the one place the implementation had to choose: the ruling says dead-vs-live and the derivation has a third answer. `deriveAgentState` returns five states, and only `listening` is backed by evidence — a BYO/wrapper install polls every ~5s, so a fresh `lastUsedAt` is a measurement. `reachable` is asserted **by construction** for native and push-webhook installs, and `unknown` is the gateway/cloud tier saying out loud that one shared boot timestamp covers a whole fleet. Deferring on either would convert an honest abstention into a tenure grant for a class nobody checked, so both rescue as today. This still fixes all three cases fable named — TASK-008, TASK-029 and TASK-015 are wrapper seats and derive `listening`. Flagging it explicitly so the choice can be overruled without reading the diff.

The deferral budget is **per lease, not per task**: the claim route zeroes it, so the third holder of a hot task does not inherit a spent budget. An undeliverable warning leaves the deferral standing — a queue outage must not read as abandonment.

### Part 3 — provenance always

The rescue writes the prior holder into a new `lapsedFrom` field and names them in the audit trail, and the found-work wake renders `[lapsed from X — check their work before starting]`.

Clearing `assignee`/`claimedBy` is what makes a rescued row findable again (#1023, my own design) and it is also what erased the only record of ownership. TASK-015 was advertised as unclaimed while its work sat in open PR #1078; @sprint-review and I independently hand-warned the room within one minute of each other, which is itself the measurement — the board's ownership field is the thing that normally does that job, and the rescue clears it.

### Verification

30 tests across two suites. Every new assertion was mutation-probed red, with the mutation **verified applied** (grep count checked) before each run and the control re-run green after each restore:

| mutation | result |
|---|---|
| `LIVE_STATES` matches nothing | 5 failed |
| `LIVE_STATES` matches every state | 6 failed |
| `lapsedFrom` dropped from the rescue write | 2 failed |
| `lapsedFrom` dropped from the aggregate projection | 1 failed |
| deferral extends `claimExpiresAt` | 1 failed |
| renewal branch removed | 2 failed |
| holder gate dropped from the renewal filter | 1 failed |
| claim-time budget reset removed | 1 failed |

Worth recording: two earlier probe attempts compiled to `Tests: 0 total` rather than failing, because the mutation broke TypeScript narrowing and the suite could not load. A suite that cannot load is indistinguishable from one that passes if the only check is "did the number move" — both probes were rewritten into forms that compile.

Route tests run against real in-memory Mongo so the holder match is evaluated by Mongo, not by a second copy of the predicate written in the test.

`tasksApi.queryCoercion.test.js` fails to load locally on Node 26 (`jsonwebtoken`); confirmed identical on a clean tree via `git stash`, and CI pins Node 20.

### Not verified

- No live-cluster run. The liveness gate depends on `deriveAgentState` returning `listening` for the sprint seats in production, which follows from their `host: 'byo'` install shape but has not been observed end-to-end.
- The warning event's delivery is unmeasured — it is priced `triggerAuthor: 'kernel'` like every other sweep wake (neutral in the cascade governor), but no seat has received one yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)