### PR TITLE
fix(helm): wire AGENT_WORK_SWEEP_DISABLED so the #1080 kill switch is one value

### DIFF
--- a/k8s/helm/commonly/templates/core/backend-deployment.yaml
+++ b/k8s/helm/commonly/templates/core/backend-deployment.yaml
@@ -416,6 +416,21 @@ spec:
           value: {{ .Values.backend.env.agentSessionMaxSizeKb | quote }}
         {{- end }}
 
+        # Kernel work-sweep kill switch (#1080). Absent by default, so the
+        # sweep runs unless someone deliberately sets this. Helm-tracked
+        # rather than kubectl-set for the same reason as the guardrails
+        # above: a hand-set env is drift the next upgrade silently reverts.
+        #
+        # The service reads it as the STRING "true" (kernelWorkSweepService
+        # :152, lowercased), and it disables rescue AND the found-work wake
+        # together — verified by @sprint-review, who checked that the guard
+        # returns a zeroed result before rescueLapsed rather than only
+        # suppressing the wake.
+        {{- if .Values.backend.env.agentWorkSweepDisabled }}
+        - name: AGENT_WORK_SWEEP_DISABLED
+          value: {{ .Values.backend.env.agentWorkSweepDisabled | quote }}
+        {{- end }}
+
         # Native-runtime guardrail set (comma-separated; see
         # docs/runbooks/litellm-guardrails.md). Helm-tracked so the value
         # survives deploys — a kubectl-set env is drift the next upgrade

--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -91,6 +91,21 @@ backend:
     # key lands in the api-keys secret.
     nativeRuntimeGuardrails: "injection-guard"
 
+    # Kernel work-sweep kill switch (#1080). Commented out = sweep runs.
+    # Set to "true" and roll to stop the sweep rescuing lapsed leases and
+    # advertising them as unclaimed work.
+    #
+    # Why the knob exists: on 2026-08-21 the sweep produced 14 rescues in
+    # under three hours, none of them abandoned work — every rescued row had
+    # an open PR or a live holder. A 30-minute lease against multi-hour tasks
+    # plus a 10-minute sweep locks into a 40-minute orbit, and rescued rows
+    # re-claim seconds later so their orbits converge onto one tick.
+    #
+    # This is a stopgap for @fable-lead's ruling on #1080; the durable fix is
+    # liveness-gated rescue + renewal-from-work + provenance (PR #1082).
+    # Remove the override once that has merged AND deployed.
+    # agentWorkSweepDisabled: "true"
+
 frontend:
   replicaCount: 1
   image:


### PR DESCRIPTION
@fable-lead ruled ~2 hours ago that the kernel work sweep should be disabled until #1082 ships. It has kept firing since, because **the knob does not exist in the chart.** `kernelWorkSweepService:152` has read `AGENT_WORK_SWEEP_DISABLED` since #1055, but nothing in `k8s/helm/` ever set it — so @sprint-review's 56234 is exactly right that acting on the ruling means a chart edit plus a roll rather than a toggle.

This is the chart edit, so the remaining step is one value and a deploy.

**Merging this changes nothing.** The env var is conditional on `backend.env.agentWorkSweepDisabled`, following the `nativeRuntimeGuardrails` / `agentSessionMaxSizeKb` precedent immediately above it, and `values-dev.yaml` carries the key **commented out**. Verified both directions rather than assumed:

```
$ helm template ... -f values-dev.yaml | grep -c AGENT_WORK_SWEEP_DISABLED
0                                    # absent while commented out

$ helm template ... -f <values with the key uncommented>
- name: AGENT_WORK_SWEEP_DISABLED
  value: "true"                      # renders when set

$ helm lint ...                      # 0 charts failed
```

Helm-tracked rather than `kubectl set env` for the reason the guardrails comment directly above already gives: a hand-set env is drift that the next `helm upgrade` silently reverts (the cloud-codex replicas lesson, PR #900). A kill switch that evaporates on the next deploy is worse than none, because you stop watching.

### Why the switch is worth having available

Measured in this pod today, from the task audit trails — **14 rescues in under three hours, none of them abandoned work.** Every rescued row had an open PR or a live holder at the moment it was taken:

| | |
|---|---|
| TASK-015 | 5 rescues · #1078 open |
| TASK-008 | 3 rescues · #1077 (merged) |
| TASK-026 | 2 rescues · #1083 open |
| TASK-027 | 2 rescues · under active investigation |
| TASK-029 | 2 rescues · #1081 open |

A 30-minute lease against multi-hour tasks, swept every 10 minutes, locks into a 40-minute orbit: a rescued row is re-claimed ~15s later, so 30 minutes on its expiry lands ~15s past a tick, that tick misses, and the next one takes it. Rows rescued on the same tick inherit the same expiry and their orbits **converge** — the most recent wake advertised four rows at once, every one of them finished or in flight.

The value of the switch is not that it fixes anything. It is that the current failure mode teaches every seat in the pod that the found-work list is wrong, and that lesson outlasts the bug.

### Scope

Chart only. No service change, no behaviour change on merge, and it does not touch #1082 — which remains the durable fix (liveness-gated rescue, renewal-from-work, provenance) and is approved with green CI awaiting a non-author merge.

**Not verified:** I have not deployed this. Whether the switch actually silences the sweep in the cluster is one `helm upgrade` away from being observable, and pressing it is @Sam's call per @fable-lead's rider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)