### PR TITLE
feat(byo): funnel telemetry — split never-tried from tried-and-died-locally

### DIFF
--- a/backend/routes/stats.ts
+++ b/backend/routes/stats.ts
@@ -52,6 +52,52 @@ router.get('/public', async (_req: unknown, res: { json: (d: unknown) => void; s
   }
 });
 
+// ── BYO funnel telemetry ────────────────────────────────────────────────────
+//
+// Measured 2026-08-21: 7 of 14 recent signups created a BYO seat and 0 ever
+// made one authenticated call — the loss is at the paste-into-terminal step,
+// and the server cannot see whether the user even copied the command. These
+// two client pings (copy-clicked, listen-timeout) close exactly that gap.
+// Auth'd so events attribute to a user; body is a fixed enum, nothing free-
+// form; fire-and-forget on the client so the flow never waits on telemetry.
+// eslint-disable-next-line global-require
+const auth = require('../middleware/auth');
+// eslint-disable-next-line global-require
+const { rateLimit } = require('express-rate-limit');
+// eslint-disable-next-line global-require
+const { cloudflareIpRateLimitKeyGenerator } = require('../middleware/ipRateLimit');
+// eslint-disable-next-line global-require
+const mongoose = require('mongoose');
+
+const BYO_STEPS = new Set([
+  'page-viewed', 'seat-created', 'mcp-command-copied', 'cli-command-copied',
+  'token-copied', 'listen-confirmed', 'listen-timeout',
+]);
+
+router.post('/byo-step', rateLimit({
+  windowMs: 60_000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  keyGenerator: (req: any) => cloudflareIpRateLimitKeyGenerator(req),
+  handler: (_req: any, res: any) => res.status(429).json({ code: 'rate_limited' }),
+}), auth, async (req: any, res: any) => {
+  const step = String(req.body?.step || '');
+  if (!BYO_STEPS.has(step)) return res.status(400).json({ error: 'unknown step' });
+  try {
+    await mongoose.connection.db.collection('byo_telemetry').insertOne({
+      userId: req.userId,
+      step,
+      at: new Date(),
+    });
+  } catch (err: any) {
+    // Telemetry must never fail the caller's flow.
+    console.warn('[byo-telemetry] write failed:', err?.message);
+  }
+  return res.json({ ok: true });
+});
+
 module.exports = router;
 
 export {};

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -257,6 +257,7 @@ const V2AgentBYO: React.FC = () => {
       if (cancelled) return;
       if (Date.now() - startedAt > 15 * 60 * 1000) {
         setListenState('timeout');
+        byoStep('listen-timeout');
         return;
       }
       try {
@@ -266,7 +267,10 @@ const V2AgentBYO: React.FC = () => {
           === issued.agentName.toLowerCase();
         const afterIssue = data.lastUsedAt
           && new Date(data.lastUsedAt).getTime() >= issued.issuedAt - 60_000; // clock-skew slack
-        if (sameAgent && afterIssue) setListenState('listening');
+        if (sameAgent && afterIssue) {
+          setListenState('listening');
+          byoStep('listen-confirmed');
+        }
       } catch {
         // Transient read failure — keep polling; the checkmark can only be
         // late, never wrong.
@@ -275,11 +279,21 @@ const V2AgentBYO: React.FC = () => {
     return () => { cancelled = true; clearInterval(timer); };
   }, [issued, listenState]);
 
+  // BYO funnel telemetry: 7 of 7 recent seats died between token issuance and
+  // the first authenticated call, and the server cannot see whether the user
+  // even copied a command. Fire-and-forget; the flow never waits on it.
+  const byoStep = (step: string) => {
+    axios.post('/api/stats/byo-step', { step }).catch(() => {});
+  };
+
   const copy = async (key: string, value: string) => {
     try {
       await navigator.clipboard.writeText(value);
       setCopied(key);
       setTimeout(() => setCopied((c) => (c === key ? null : c)), 1500);
+      if (key === 'claude' || key === 'cursor') byoStep('mcp-command-copied');
+      else if (key === 'listen') byoStep('cli-command-copied');
+      else if (key === 'tok') byoStep('token-copied');
     } catch {
       // Clipboard may be unavailable (non-HTTPS, sandbox); user can select manually.
     }


### PR DESCRIPTION
Follow-up to the 0-for-7 BYO measurement. The server-side evidence (lastActive == createdAt on every seat) proves nobody's wrapper ever called home, but can't distinguish a user who closed the tab from one whose npx died locally. Five fixed-enum client pings close that gap: command copied (MCP vs CLI), token copied, listen confirmed/timeout. Auth'd, rate-limited, fire-and-forget, one Mongo collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8