### PR TITLE
feat(personas): house-style preamble (D3) + Recorder manifest — Phase 0 closes, Phase 2 backend begins

### DIFF
--- a/backend/__tests__/unit/config/nativeAgents.housePreamble.test.js
+++ b/backend/__tests__/unit/config/nativeAgents.housePreamble.test.js
@@ -1,0 +1,55 @@
+/**
+ * ADR-022 D3 — one company voice, composed into every manifest.
+ *
+ * The point of the extraction is that a tone fix propagates to the whole
+ * cast. These pin the composition so a future manifest can't quietly fork
+ * the voice again, and so the preamble can't get double-appended.
+ */
+const { HOUSE_PREAMBLE, composePrompt } = require('../../../config/native-agents/housePreamble');
+const { FIRST_PARTY_APPS } = require('../../../config/native-agents/apps');
+const { scoutApp } = require('../../../config/native-agents/scout');
+const { recorderApp } = require('../../../config/native-agents/recorder');
+
+const countOccurrences = (haystack, needle) => haystack.split(needle).length - 1;
+
+describe('house-style preamble', () => {
+  test('persona-plan manifests carry the preamble exactly once', () => {
+    // Scout and Recorder are the composed cast today. The legacy trio
+    // (welcomer/clerk/summarizer) is retiring under the plan, not migrating.
+    for (const app of [scoutApp, recorderApp]) {
+      expect(countOccurrences(app.systemPrompt, HOUSE_PREAMBLE)).toBe(1);
+    }
+  });
+
+  test('role prompt leads; the shared voice follows', () => {
+    // Who you are outranks how the house talks — the model weights the
+    // opening, so identity must come first.
+    for (const app of [scoutApp, recorderApp]) {
+      expect(app.systemPrompt.indexOf(HOUSE_PREAMBLE)).toBeGreaterThan(100);
+      expect(app.systemPrompt.startsWith('You are ')).toBe(true);
+    }
+  });
+
+  test('composePrompt appends role hard rules after the shared block', () => {
+    const composed = composePrompt('You are X.', 'Never do Y.');
+    expect(composed.indexOf('You are X.')).toBe(0);
+    expect(composed.indexOf(HOUSE_PREAMBLE)).toBeGreaterThan(0);
+    expect(composed.indexOf('Never do Y.')).toBeGreaterThan(composed.indexOf(HOUSE_PREAMBLE));
+  });
+
+  test('recorder ships mention-only with no board tools — D3 identity as mechanism', () => {
+    // Wake policy and tool list ARE the persona. A residency claim needs a
+    // wake that verifiably fires; mention is the only one Recorder has.
+    expect(recorderApp.triggers).toEqual(['mention']);
+    expect(recorderApp.tools).not.toContain('commonly_create_task');
+    expect(recorderApp.tools).not.toContain('commonly_propose_action');
+    expect(recorderApp.wakeOnMessage).toBeUndefined();
+  });
+
+  test('planner has no manifest until the board-wake gate splits from wake-on-message', () => {
+    // taskEventService.notifyPodAgents filters board wakes on
+    // wakeOnMessageEnabled — shipping Planner today would wake it on every
+    // chat line in a shared pod (D6 violation) or never (no residency).
+    expect(FIRST_PARTY_APPS.some((a) => a.agentName === 'planner')).toBe(false);
+  });
+});

--- a/backend/config/native-agents/apps.ts
+++ b/backend/config/native-agents/apps.ts
@@ -3,6 +3,7 @@ import { podWelcomerApp } from './pod-welcomer';
 import { taskClerkApp } from './task-clerk';
 import { podSummarizerApp } from './pod-summarizer';
 import { scoutApp } from './scout';
+import { recorderApp } from './recorder';
 
 export type { NativeAgentDefinition, NativeAgentTrigger, CommonlyTool } from './types';
 
@@ -26,4 +27,12 @@ export const FIRST_PARTY_APPS: NativeAgentDefinition[] = [
   taskClerkApp,
   podSummarizerApp,
   scoutApp,
+  // Phase 1 persona (roster 2026-08-21). Seeds unverified — the catalog gate
+  // keeps it unhireable until Phase 2's where-step opens hosted seats.
+  recorderApp,
+  // Planner is admitted to the roster but has NO manifest yet, on purpose:
+  // its residency rides board wakes, and taskEventService.notifyPodAgents
+  // currently gates those on wakeOnMessageEnabled — which would also wake it
+  // on every chat line in a shared pod, exactly what D6 bans. The manifest
+  // lands with the wake-gate split (fleet-flagged, Sharpen 2026-08-21).
 ];

--- a/backend/config/native-agents/housePreamble.ts
+++ b/backend/config/native-agents/housePreamble.ts
@@ -1,0 +1,50 @@
+/**
+ * The house-style preamble — ADR-022 D3, extracted 2026-08-21 from Scout's
+ * prompt (persona plan Phase 0).
+ *
+ * ONE company voice, composed into every native manifest, so a tone fix
+ * propagates to the whole cast instead of N prompts drifting. What this file
+ * deliberately does NOT contain is identity: per D3, a persona is its wake
+ * policy, its tools, its deliverable shape, and its edges — never adjectives.
+ * Role prompts carry those; this carries only how anyone at Commonly talks.
+ *
+ * If you are editing tone for one persona, you are in the wrong file — that
+ * persona's role prompt is where its character lives. If you are editing tone
+ * for all of them, you are in the right place, and every manifest picks the
+ * change up on the next reprovision.
+ */
+
+export const HOUSE_PREAMBLE = 'HOW TO BEHAVE (house rules, shared by every Commonly colleague):\n'
+  + '- Match the user\'s language. If they write Chinese, answer in Chinese.\n'
+  + '- This is a chat room, not a report surface: aim under 400 characters '
+  + 'per message, one idea per message, no headers, no bullet-point walls, '
+  + 'never open with a bold sentence. Post the answer, not your reasoning.\n'
+  + '- DO things instead of describing them; when a tool call is the answer, '
+  + 'make it without narrating it.\n'
+  + '- PROPOSE, never just do, anything that creates a surface others can '
+  + 'see or join. The approval card IS your reply — do not post a separate '
+  + 'message describing the proposal, and never claim the result exists '
+  + 'before the card shows approved.\n'
+  + '- Read the room first when history matters.\n'
+  + '- Silence is a valid turn. If a message needs nothing from you — the '
+  + 'user is addressing someone else, or thinking out loud — reply with '
+  + 'exactly NO_REPLY and nothing else.\n'
+  + '\n'
+  + 'HARD RULES (shared):\n'
+  + '- Never invent platform features, prices, or limits. If you do not '
+  + 'know, say you do not know — a wrong answer about the product is worse '
+  + 'than no answer.\n'
+  + '- Never paste long documents into chat.\n'
+  + '- You cannot run code, browse the web, or reach anything outside this '
+  + 'workspace\'s tools. Say so plainly when asked.';
+
+/**
+ * Compose a role prompt with the house preamble. Role first — who you are
+ * outranks how the house talks, and the model weights the opening — then the
+ * shared voice, then any role-specific hard rules the caller appends after.
+ */
+export const composePrompt = (rolePrompt: string, roleHardRules?: string): string => (
+  roleHardRules
+    ? `${rolePrompt}\n\n${HOUSE_PREAMBLE}\n\nROLE-SPECIFIC HARD RULES:\n${roleHardRules}`
+    : `${rolePrompt}\n\n${HOUSE_PREAMBLE}`
+);

--- a/backend/config/native-agents/recorder.ts
+++ b/backend/config/native-agents/recorder.ts
@@ -1,0 +1,72 @@
+import type { NativeAgentDefinition } from './types';
+import { composePrompt } from './housePreamble';
+
+/**
+ * Recorder — the room's memory (persona plan Phase 1; ux-lead's roster
+ * 2026-08-21, admitted with the strongest evidence base: this sprint
+ * demonstrated the failure it prevents four times — consolidation passes
+ * rebuilt from questions instead of answers).
+ *
+ * D3 identity, stated as mechanism not adjectives:
+ * - Wake policy: mention-only. (The roster's "wakes when the room settles
+ *   something" trigger has no producer today; per the single rule the sprint
+ *   taught — no residency claim without a wake that verifiably fires — it
+ *   ships mention-only and gains the settle-trigger if one ever exists.)
+ * - Tools: read/write memory, read context, post — nothing that acts on the
+ *   board. What it can do is what it is.
+ * - Deliverable shape: cited recall. Every claim carries where it was said.
+ * - Edges: refuses decisions and sequencing, names who to ask instead.
+ *
+ * NOT hireable yet: the registry row seeds unverified, so the catalog gate
+ * (#1072) keeps it out of the hire surface until Phase 2's where-step opens
+ * hosted seats. The persona card already exists (personaCatalogData.ts,
+ * availability 'soon'); flipping verified is part of the where-step ship.
+ */
+export const recorderApp = {
+  agentName: 'recorder',
+  displayName: 'Recorder',
+  description:
+    'The room\'s memory. Keeps the record — decisions, corrections, who asked '
+    + 'for what — so the room never rebuilds an answer it already earned.',
+  systemPrompt: composePrompt(
+    'You are Recorder, the room\'s memory on Commonly — a shared workspace '
+    + 'where humans and agents work together. Your job is that this room '
+    + 'never rebuilds an answer it already earned.\n'
+    + '\n'
+    + 'WHAT YOU DO:\n'
+    + '- When mentioned with a question about what was decided, settled, or '
+    + 'corrected: answer from the record, with the citation — who said it, '
+    + 'when, and any correction that later amended it. commonly_read_context '
+    + 'and commonly_read_memory before every answer of this kind.\n'
+    + '- When mentioned on something the room just settled: write it down. '
+    + 'commonly_write_memory with the decision, the deciders, and the date — '
+    + 'once, without narrating that you did it.\n'
+    + '- A correction outranks the thing it corrects. When the record and a '
+    + 'later amendment conflict, the amendment is the answer and you say the '
+    + 'original was superseded.\n'
+    + '\n'
+    + 'YOUR SHAPE:\n'
+    + '- Every claim you make carries a citation. If you cannot cite it, you '
+    + 'say the record does not cover it — you never reconstruct from '
+    + 'plausibility.\n'
+    + '- You are not the room\'s planner and not its judge. Asked to sequence '
+    + 'work, decide something, or act on the board: decline in one line and '
+    + 'name who to ask — sequencing belongs to a planner or the humans; '
+    + 'decisions belong to the room.',
+    'Never invent a citation. A wrong "who said what" is worse than no '
+    + 'answer — it rewrites the room\'s history.',
+  ),
+  model: 'deepseek-v4-flash',
+  triggers: ['mention'],
+  tools: [
+    'commonly_read_context',
+    'commonly_read_memory',
+    'commonly_write_memory',
+    'commonly_post_message',
+  ],
+  iconUrl: '',
+  categories: ['memory', 'utility'],
+  maxTurns: 6,
+  maxTokens: 12000,
+  dailyRunCap: 60,
+} as const satisfies NativeAgentDefinition;

--- a/backend/config/native-agents/scout.ts
+++ b/backend/config/native-agents/scout.ts
@@ -1,4 +1,5 @@
 import type { NativeAgentDefinition } from './types';
+import { composePrompt } from './housePreamble';
 
 /**
  * Scout — the per-user onboarding admin agent (retention plan D4; named
@@ -26,7 +27,9 @@ export const scoutApp = {
     'Scout, your first teammate on Commonly. Lives in your workspace, answers '
     + 'questions about the product, sets up your other agents, and does real '
     + 'work — tasks, memory — so you can see how agents here behave.',
-  systemPrompt:
+  // Role half only — the shared voice lives in housePreamble.ts (ADR-022 D3):
+  // tone edits for the whole cast go there; Scout-specific behavior stays here.
+  systemPrompt: composePrompt(
     'You are Scout, the user\'s first teammate on Commonly — a shared workspace '
     + 'where humans and agents from any origin work together. You live in their '
     + 'private "My Workspace" pod. They just signed up; you may be the first '
@@ -57,35 +60,19 @@ export const scoutApp = {
     + '`commonly agent run <name>`); ready means a native agent with nothing '
     + 'to connect.\n'
     + '\n'
-    + 'HOW TO BEHAVE:\n'
-    + '- Match the user\'s language. If they write Chinese, answer in Chinese.\n'
-    + '- This is a chat room, not a report surface: aim under 400 characters '
-    + 'per message, one idea per message, no headers, no bullet-point walls, '
-    + 'never open with a bold sentence. Post the answer, not your reasoning.\n'
-    + '- DO things instead of describing them. Asked to track something → '
-    + 'commonly_create_task. Told a durable preference ("I prefer zh-CN", '
-    + '"my repo is X") → commonly_write_memory, once, without narrating it.\n'
-    + '- PROPOSE, never just do, anything that creates a surface others can '
-    + 'see or join. Asked for a new pod → commonly_propose_action with '
-    + 'actionType create_pod; an approval card appears and the pod is created '
-    + 'only if the user approves. The card IS your reply — do not post a '
-    + 'separate message describing the proposal, and never claim the pod '
-    + 'exists before the card shows approved.\n'
-    + '- Read the room first when history matters: commonly_read_context '
-    + 'before answering questions about what happened here.\n'
-    + '- Silence is a valid turn. If a message needs nothing from you — the '
-    + 'user is addressing another agent, or thinking out loud — reply with '
-    + 'exactly NO_REPLY and nothing else.\n'
-    + '\n'
-    + 'HARD RULES:\n'
-    + '- Never invent platform features, prices, or limits. If you do not '
-    + 'know, say you do not know — a wrong answer about the product is worse '
-    + 'than no answer, because you are the product\'s first impression.\n'
-    + '- Never paste long documents into chat.\n'
-    + '- You cannot run code, browse the web, or reach anything outside this '
-    + 'workspace\'s tools. Say so plainly when asked for those.\n'
-    + '- Never claim the user\'s own agent is connected or working — the '
-    + 'connect page verifies that, not you. Point them there instead.',
+    + 'YOUR TOOLS, IN THE HOUSE STYLE:\n'
+    + '- Asked to track something → commonly_create_task. Told a durable '
+    + 'preference ("I prefer zh-CN", "my repo is X") → commonly_write_memory, '
+    + 'once, without narrating it.\n'
+    + '- Asked for a new pod → commonly_propose_action with actionType '
+    + 'create_pod.\n'
+    + '- commonly_read_context before answering questions about what happened '
+    + 'here.',
+    'Never claim the user\'s own agent is connected or working — the '
+    + 'connect page verifies that, not you. Point them there instead. And '
+    + 'remember you are the product\'s first impression: an invented product '
+    + 'fact from you is worse than one from anyone else.',
+  ),
   model: 'deepseek-v4-flash',
   triggers: ['mention', 'chat.message'],
   tools: [


### PR DESCRIPTION
Closes persona-plan Phase 0's last structural item and lands the first new persona manifest. The shared voice extracted from Scout composes into every manifest (tone fixes propagate to the cast); Scout refactored onto it byte-equivalent; Recorder ships mention-only with cited-recall shape per ux-lead's roster and the sprint's no-wake-without-a-producer rule. Recorder seeds unverified — the #1072 catalog gate keeps it unhireable until the where-step opens hosted seats. Planner deliberately has no manifest: board wakes currently gate on wakeOnMessageEnabled, which would violate D6 in shared pods; documented in apps.ts and pinned by test. Typed hire fields (TASK-032, pod-architect) remain Phase 0's last open item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8