### PR TITLE
feat(wakes): split board wakes from wake-on-message (#1071, TASK-033)

### DIFF
--- a/backend/__tests__/unit/services/boardWakeSplit.test.js
+++ b/backend/__tests__/unit/services/boardWakeSplit.test.js
@@ -1,0 +1,69 @@
+/**
+ * Board wakes are a separate subscription from ambient chat (#1071, TASK-033).
+ *
+ * The property that matters is not "the new flag works" — it is that turning
+ * the split on changed NOTHING for the installs that already existed. All 263
+ * active installs carry no `boardWake` key, so the inherit branch is the whole
+ * live population; a regression there is invisible in any test that only
+ * exercises the new explicit branch.
+ */
+const { boardWakeEnabled, wakeOnMessageEnabled } = require('../../../services/agentMentionService');
+
+const inst = (config) => ({ agentName: 'planner', instanceId: 'default', config });
+
+describe('boardWakeEnabled — the four-cell matrix', () => {
+  it.each([
+    ['boardWake absent, wakeOnMessage on  -> inherits on', { wakeOnMessage: { enabled: true } }, true],
+    ['boardWake absent, wakeOnMessage off -> inherits off', { wakeOnMessage: { enabled: false } }, false],
+    ['boardWake true  overrides chat off', { boardWake: { enabled: true }, wakeOnMessage: { enabled: false } }, true],
+    ['boardWake false overrides chat on', { boardWake: { enabled: false }, wakeOnMessage: { enabled: true } }, false],
+  ])('%s', (_label, config, expected) => {
+    expect(boardWakeEnabled(inst(config))).toBe(expected);
+  });
+
+  it('the Planner shape: board wakes without ambient chat', () => {
+    const planner = inst({ boardWake: { enabled: true } });
+    expect(boardWakeEnabled(planner)).toBe(true);
+    // The whole point of the split — subscribing to the board must NOT
+    // subscribe the seat to every message in the pod.
+    expect(wakeOnMessageEnabled(planner)).toBe(false);
+  });
+
+  it('the inverse shape: ambient chat without board wakes', () => {
+    const talker = inst({ wakeOnMessage: { enabled: true }, boardWake: { enabled: false } });
+    expect(wakeOnMessageEnabled(talker)).toBe(true);
+    expect(boardWakeEnabled(talker)).toBe(false);
+  });
+});
+
+describe('backward compatibility — the branch the entire live fleet is on', () => {
+  // Measured 2026-08-22 against the running instance: 263 active installs,
+  // 34 with wakeOnMessage.enabled, ZERO carrying a boardWake key. So every
+  // real install resolves through inherit, and these are the only cells that
+  // describe production today.
+  it.each([
+    ['no config at all', undefined],
+    ['empty config', {}],
+    ['wakeOnMessage present but empty', { wakeOnMessage: {} }],
+    ['boardWake present but empty', { boardWake: {} }],
+  ])('%s -> false, same as wakeOnMessageEnabled', (_label, config) => {
+    const i = inst(config);
+    expect(boardWakeEnabled(i)).toBe(wakeOnMessageEnabled(i));
+    expect(boardWakeEnabled(i)).toBe(false);
+  });
+
+  it('a truthy-but-not-true enabled does NOT subscribe, on either predicate', () => {
+    // wakeOnMessageEnabled uses === true deliberately; the split must not
+    // quietly widen that. 'true' the string is the shape a manifest typo takes.
+    const i = inst({ boardWake: { enabled: 'true' } });
+    expect(boardWakeEnabled(i)).toBe(false);
+    expect(wakeOnMessageEnabled(i)).toBe(false);
+  });
+
+  it('inherit is a delegation, not a copy — it tracks wakeOnMessage exactly', () => {
+    for (const enabled of [true, false, undefined, null, 1, 0, 'yes']) {
+      const i = inst({ wakeOnMessage: { enabled } });
+      expect(boardWakeEnabled(i)).toBe(wakeOnMessageEnabled(i));
+    }
+  });
+});

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -866,6 +866,42 @@ const wakeOnMessageEnabled = (installation: Record<string, unknown>): boolean =>
     ?.config?.wakeOnMessage?.enabled === true
 );
 
+/**
+ * Board wakes (task-board deltas and the #1055 kernel found-work sweep) are a
+ * SEPARATE subscription from ambient chat, and this predicate is the split.
+ *
+ * They were one flag until now, which made the two indistinguishable at
+ * install time: a persona whose whole job is the board — Planner is the case
+ * that forced this (#1071, TASK-033) — could only subscribe by also taking
+ * every chat message in the pod. That is the opposite of what a board-shaped
+ * card wants, and "just set wakeOnMessage" was the only available answer.
+ *
+ * Backward compatibility is the load-bearing half. `boardWake` ABSENT inherits
+ * `wakeOnMessage`, so every existing install keeps exactly the delivery it has
+ * today — measured at 34 of 263 active installs with wakeOnMessage on and zero
+ * carrying a boardWake key, so the inherit branch is the entire live
+ * population and the explicit branch is currently unreachable. Setting
+ * `boardWake.enabled` explicitly overrides in either direction:
+ *
+ *   boardWake absent, wakeOnMessage on   -> board wakes  (today's behaviour)
+ *   boardWake absent, wakeOnMessage off  -> no board wakes (today's behaviour)
+ *   boardWake.enabled true               -> board wakes, whatever chat says
+ *   boardWake.enabled false              -> no board wakes, whatever chat says
+ *
+ * The fourth row is the one that did not exist before: a seat can now hear the
+ * room without hearing the board, and a seat can hear the board without
+ * hearing the room.
+ */
+const boardWakeEnabled = (installation: Record<string, unknown>): boolean => {
+  const cfg = (installation as {
+    config?: { boardWake?: { enabled?: unknown } };
+  })?.config;
+  const explicit = cfg?.boardWake?.enabled;
+  if (explicit === true) return true;
+  if (explicit === false) return false;
+  return wakeOnMessageEnabled(installation);
+};
+
 // #508's shape, pointed at the wake path: a BOT-authored message that would
 // wake a target already woken >MENTION_LOOP_MAX times in the window is a wake
 // storm, not collaboration. Human-authored messages are never dampened —
@@ -1675,4 +1711,5 @@ export {
   // config shape is a Mongoose Map on some paths and a plain object on others,
   // which is exactly the kind of detail a second copy gets subtly wrong.
   wakeOnMessageEnabled,
+  boardWakeEnabled,
 };

--- a/backend/services/taskEventService.ts
+++ b/backend/services/taskEventService.ts
@@ -127,7 +127,7 @@ export async function notifyPodAgents(
     const { AgentInstallation } = require('../models/AgentRegistry');
     const AgentEventService = require('./agentEventService');
     // Lazy so this never forms a load-time cycle with the mention service.
-    const { wakeOnMessageEnabled } = require('./agentMentionService');
+    const { boardWakeEnabled } = require('./agentMentionService');
     /* eslint-enable global-require, @typescript-eslint/no-require-imports */
 
     const normalizedPodId = String(podId);
@@ -144,7 +144,7 @@ export async function notifyPodAgents(
     // (including every sprint seat), and the 169 that do not are `commonly-bot`
     // and `openclaw` — user-facing and community seats where an unrequested
     // wake is a noise incident, not a feature.
-    const installs = (active || []).filter(wakeOnMessageEnabled);
+    const installs = (active || []).filter(boardWakeEnabled);
     if (!installs.length) return;
 
     const taskId = String(task.taskId || task.id || task._id || 'unknown');
@@ -287,13 +287,13 @@ export async function notifyFoundWork(
     /* eslint-disable global-require, @typescript-eslint/no-require-imports */
     const { AgentInstallation } = require('../models/AgentRegistry');
     const AgentEventService = require('./agentEventService');
-    const { wakeOnMessageEnabled } = require('./agentMentionService');
+    const { boardWakeEnabled } = require('./agentMentionService');
     const AgentEvent = require('../models/AgentEvent');
     /* eslint-enable global-require, @typescript-eslint/no-require-imports */
 
     const normalizedPodId = String(podId);
     const active = await AgentInstallation.find({ podId: normalizedPodId, status: 'active' }).lean();
-    const installs = (active || []).filter(wakeOnMessageEnabled);
+    const installs = (active || []).filter(boardWakeEnabled);
     if (!installs.length) return { woken: 0 };
 
     // #1080 part 3: a rescued row names who it lapsed from. Without it the wake


### PR DESCRIPTION
TASK-033, assigned by @Sam. Closes the admission-condition problem #1071 filed against the Planner card.

### The coupling

One config key gated three different subscriptions:

| | producer | gate |
|---|---|---|
| ambient chat | `enqueueWakeOnMessage` | `config.wakeOnMessage.enabled` |
| board deltas | `notifyPodAgents` (`taskEventService:147`) | same key |
| kernel found-work | `notifyFoundWork` (`taskEventService:296`) | same key |

So a persona whose defining behaviour is the board could only subscribe by also taking every message in the pod. #1071's recommendation — *"the manifest must set `wakeOnMessage` at install, or the card ships a persona whose defining behaviour never fires"* — was the only answer available, and it is the wrong shape for a board-shaped card.

### The split

`boardWakeEnabled` in `agentMentionService`, used by both board producers. The ambient path keeps `wakeOnMessageEnabled` unchanged.

```
boardWake absent, wakeOnMessage on   -> board wakes      (today's behaviour)
boardWake absent, wakeOnMessage off  -> no board wakes   (today's behaviour)
boardWake.enabled true               -> board wakes, whatever chat says
boardWake.enabled false              -> no board wakes, whatever chat says
```

The third row is what unblocks the Planner manifest. The fourth did not previously exist either: a seat can now hear the room without the board.

### Backward compatibility is the load-bearing half

Absent `boardWake` **inherits** `wakeOnMessage`, so nothing that exists today changes. Measured against the running instance rather than assumed: **263 active installs, 34 with `wakeOnMessage.enabled`, zero carrying a `boardWake` key.** The inherit branch is therefore the entire live population and both explicit branches are currently unreachable — which is exactly why a test that only exercised the new flag would prove nothing about production.

The backward-compat cells assert `boardWakeEnabled(i) === wakeOnMessageEnabled(i)` rather than a hard-coded `false`, so they track the old predicate rather than a snapshot of it. If someone changes `wakeOnMessageEnabled`, they move together or the test fails.

### Verification

12 tests, all green; adjacent suites (`taskEventService`, `kernelWorkSweepService`, `agentMention*`) 110 green; `tsc --noEmit` clean on both changed files.

Three mutations, each verified applied then red:

| mutation | result |
|---|---|
| inherit removed (absent → false) | 2 failed |
| explicit-`false` override removed | 2 failed |
| `=== true` widened to truthy | 1 failed |

That last one guards a manifest typo: `enabled: "true"` as a string must not subscribe, because `wakeOnMessageEnabled` uses strict equality and the split must not quietly widen it.

### Not verified

- **No manifest sets the new key yet.** This makes the Planner shape *expressible*; it does not install anything. #1071's second recommendation — a ship-time probe asserting an `AgentEvent` row actually arrives for the seat — is still the check that would prove delivery, and it is not in this PR.
- I have not run the four-cell matrix against a live install, only the predicate. The producers' filter change is covered by the existing `taskEventService` suite continuing to pass, not by a new integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)