### PR TITLE
feat(runs): per-user daily ceiling (ADR-022 D5) — the second-hosted-seat prerequisite

### DIFF
--- a/backend/__tests__/unit/services/nativeRuntimeService.userCeiling.test.js
+++ b/backend/__tests__/unit/services/nativeRuntimeService.userCeiling.test.js
@@ -1,0 +1,189 @@
+/**
+ * ADR-022 D5 invariant — the per-user daily ceiling.
+ *
+ * "A per-user daily ceiling — keyed on installedBy, summed across all hosted
+ * installs — is a PREREQUISITE for offering the second hosted seat." This is
+ * that ceiling. Contract, distinct from the per-install cap on purpose:
+ *
+ *  - runs stamp userId from installation.installedBy at creation (forward-
+ *    only denormalization; the field never existed, no backfill possible)
+ *  - at ceiling → decline BEFORE any claim, run row, or LLM call, and the
+ *    result says so truthfully (status 'failed', errorKind 'user_ceiling') —
+ *    never the per-install cap's false-success shape the plan called out
+ *  - count failure fails CLOSED — a spend ceiling's safe direction is the
+ *    opposite of a runaway-guard's (#887 fail-open stays correct for the
+ *    per-install cap; it is deliberately wrong here)
+ *  - an install with no installedBy proceeds with a warning — unattributable
+ *    is not over-ceiling, and bricking legacy seats is not a spend control
+ */
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { post: jest.fn() },
+}));
+
+jest.mock('../../../models/Pod', () => ({
+  findById: jest.fn(() => ({
+    lean: jest.fn().mockResolvedValue({ name: 'My Workspace' }),
+  })),
+}));
+
+jest.mock('../../../models/AgentRun', () => ({
+  create: jest.fn(),
+  countDocuments: jest.fn(),
+  findByIdAndUpdate: jest.fn(),
+  updateOne: jest.fn(),
+}));
+
+jest.mock('../../../services/agentTypingService', () => ({
+  emitAgentTypingStart: jest.fn(),
+  emitAgentTypingStop: jest.fn(),
+}));
+
+jest.mock('../../../services/agentMessageService', () => ({
+  postMessage: jest.fn().mockResolvedValue({ success: true }),
+}));
+
+jest.mock('../../../services/messageClaimService', () => ({
+  claim: jest.fn(),
+  release: jest.fn(),
+}));
+
+const axios = require('axios').default;
+const AgentRun = require('../../../models/AgentRun');
+const MessageClaimService = require('../../../services/messageClaimService');
+const { runAgent } = require('../../../services/nativeRuntimeService');
+
+const installation = (overrides = {}) => ({
+  podId: 'pod-1',
+  agentName: 'recorder',
+  instanceId: 'u1234567890',
+  displayName: 'Recorder',
+  installedBy: 'user-42',
+  config: {
+    runtime: { runtimeType: 'native' },
+    systemPrompt: 'keep the record',
+    model: 'deepseek-v4-flash',
+    tools: [],
+  },
+  ...overrides,
+});
+
+const mentionTrigger = {
+  type: 'chat.mention',
+  eventId: 'evt-1',
+  payload: { messageId: 'msg-1', content: 'hi @recorder' },
+};
+
+describe('nativeRuntimeService per-user daily ceiling (ADR-022 D5)', () => {
+  const previousEnv = {
+    baseUrl: process.env.LITELLM_BASE_URL,
+    masterKey: process.env.LITELLM_MASTER_KEY,
+    ceiling: process.env.AGENT_USER_DAILY_RUN_CEILING,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.LITELLM_BASE_URL = 'http://litellm.test';
+    process.env.LITELLM_MASTER_KEY = 'test-key';
+    delete process.env.AGENT_USER_DAILY_RUN_CEILING;
+    AgentRun.countDocuments.mockResolvedValue(0);
+    AgentRun.create.mockImplementation(async (doc) => ({
+      ...doc,
+      _id: 'run-1',
+      save: jest.fn().mockResolvedValue(undefined),
+    }));
+    AgentRun.findByIdAndUpdate.mockResolvedValue({});
+    AgentRun.updateOne.mockResolvedValue({});
+    MessageClaimService.claim.mockResolvedValue({ claimed: true, expiresAt: new Date() });
+    MessageClaimService.release.mockResolvedValue({ released: true });
+    // One clean model turn with no tool calls, so under-ceiling runs finish.
+    axios.post.mockResolvedValue({
+      data: {
+        choices: [{ message: { content: 'noted.' } }],
+        usage: { total_tokens: 10 },
+      },
+    });
+  });
+
+  afterAll(() => {
+    process.env.LITELLM_BASE_URL = previousEnv.baseUrl;
+    process.env.LITELLM_MASTER_KEY = previousEnv.masterKey;
+    if (previousEnv.ceiling === undefined) delete process.env.AGENT_USER_DAILY_RUN_CEILING;
+    else process.env.AGENT_USER_DAILY_RUN_CEILING = previousEnv.ceiling;
+  });
+
+  it('stamps userId from installedBy on the created run row', async () => {
+    await runAgent(installation(), mentionTrigger);
+    expect(AgentRun.create).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-42' }),
+    );
+  });
+
+  it('declines truthfully at the ceiling, before any model call', async () => {
+    process.env.AGENT_USER_DAILY_RUN_CEILING = '5';
+    // The user-keyed count — across ALL their installs, not this one's —
+    // comes back at the ceiling.
+    AgentRun.countDocuments.mockImplementation((q) => (
+      Promise.resolve(q && q.userId === 'user-42' ? 5 : 0)
+    ));
+
+    const result = await runAgent(installation(), mentionTrigger);
+
+    expect(result.status).toBe('failed');
+    expect(result.errorKind).toBe('user_ceiling');
+    expect(axios.post).not.toHaveBeenCalled();
+    expect(AgentRun.create).not.toHaveBeenCalled();
+  });
+
+  it('counts by userId with the day window — not by installation', async () => {
+    process.env.AGENT_USER_DAILY_RUN_CEILING = '5';
+    await runAgent(installation(), mentionTrigger);
+    const userQuery = AgentRun.countDocuments.mock.calls
+      .map(([q]) => q).find((q) => q && q.userId);
+    expect(userQuery).toBeDefined();
+    expect(userQuery.userId).toBe('user-42');
+    expect(userQuery.startedAt.$gte).toBeInstanceOf(Date);
+    // The whole point: no per-install keys on the user query.
+    expect(userQuery.agentName).toBeUndefined();
+    expect(userQuery.instanceId).toBeUndefined();
+    expect(userQuery.podId).toBeUndefined();
+  });
+
+  it('fails CLOSED when the count fails — a spend ceiling, not a runaway guard', async () => {
+    process.env.AGENT_USER_DAILY_RUN_CEILING = '5';
+    AgentRun.countDocuments.mockRejectedValue(new Error('mongo down'));
+
+    const result = await runAgent(installation(), mentionTrigger);
+
+    expect(result.status).toBe('failed');
+    expect(result.errorKind).toBe('user_ceiling_check_failed');
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  it('an install with no installedBy proceeds with a warning — unattributable is not over-ceiling', async () => {
+    process.env.AGENT_USER_DAILY_RUN_CEILING = '5';
+    const result = await runAgent(installation({ installedBy: undefined }), mentionTrigger);
+    expect(result.status).not.toBe('failed');
+    expect(axios.post).toHaveBeenCalled();
+  });
+
+  it('under the ceiling, the run proceeds to the model', async () => {
+    process.env.AGENT_USER_DAILY_RUN_CEILING = '5';
+    AgentRun.countDocuments.mockImplementation((q) => (
+      Promise.resolve(q && q.userId === 'user-42' ? 4 : 0)
+    ));
+    const result = await runAgent(installation(), mentionTrigger);
+    expect(result.status).not.toBe('failed');
+    expect(axios.post).toHaveBeenCalled();
+  });
+
+  it('a non-positive ceiling disables the check entirely — the escape hatch', async () => {
+    process.env.AGENT_USER_DAILY_RUN_CEILING = '0';
+    await runAgent(installation(), mentionTrigger);
+    const userQuery = AgentRun.countDocuments.mock.calls
+      .map(([q]) => q).find((q) => q && q.userId);
+    expect(userQuery).toBeUndefined();
+    expect(axios.post).toHaveBeenCalled();
+  });
+});

--- a/backend/models/AgentRun.ts
+++ b/backend/models/AgentRun.ts
@@ -62,6 +62,10 @@ export interface IAgentRun extends Document {
   podId: Types.ObjectId;
   agentName: string;
   instanceId: string;
+  // ADR-022 D5: the hiring user (installation.installedBy as a hex string),
+  // denormalized so the per-user daily ceiling is one indexed count instead
+  // of a hot-path join. Forward-only — rows before 2026-08-22 lack it.
+  userId?: string;
   trigger: AgentRunTrigger;
   triggerEventId?: Types.ObjectId;
   status: AgentRunStatus;
@@ -106,6 +110,7 @@ const AgentRunSchema = new Schema<IAgentRun>(
     podId: { type: Schema.Types.ObjectId, ref: 'Pod', required: true },
     agentName: { type: String, required: true, lowercase: true, trim: true },
     instanceId: { type: String, default: 'default' },
+    userId: { type: String },
     trigger: {
       type: String,
       enum: ['mention', 'heartbeat', 'task.assigned', 'chat.message', 'pod.join', 'first_contact', 'manual'],
@@ -131,6 +136,8 @@ const AgentRunSchema = new Schema<IAgentRun>(
 );
 
 AgentRunSchema.index({ podId: 1, agentName: 1, instanceId: 1, startedAt: -1 });
+// The per-user ceiling's count (D5) — sparse: only stamped rows carry userId.
+AgentRunSchema.index({ userId: 1, startedAt: -1 }, { sparse: true });
 AgentRunSchema.index({ status: 1, startedAt: -1 });
 
 const AgentRun: Model<IAgentRun> =

--- a/backend/services/nativeRuntimeService.ts
+++ b/backend/services/nativeRuntimeService.ts
@@ -639,6 +639,50 @@ export async function runAgent(
     }
   }
 
+  // ADR-022 D5 invariant: the per-user daily ceiling — keyed on installedBy,
+  // summed across ALL the user's hosted installs. The per-install cap above
+  // stays as the runaway-loop guard; this is the spend promise ("1 hosted
+  // colleague included" needs a number that cannot silently multiply when a
+  // user hires a second persona or places one in three rooms). Two deliberate
+  // reversals from the cap above: the decline is TRUTHFUL (failed +
+  // errorKind, never an empty success), and a count failure fails CLOSED —
+  // a runaway guard and a spend ceiling have opposite safe directions.
+  // Forward-only: rows without userId predate the stamp and cannot be
+  // counted; the window inherits the cap's fixed-UTC-midnight semantics.
+  const userCeiling = Number(process.env.AGENT_USER_DAILY_RUN_CEILING ?? 120);
+  if (Number.isFinite(userCeiling) && userCeiling > 0) {
+    const installedBy = installation.installedBy ? String(installation.installedBy) : '';
+    if (!installedBy) {
+      console.warn(
+        `[native-runtime] ${agentName}:${instanceId} has no installedBy — `
+        + 'per-user ceiling unenforceable for this install',
+      );
+    } else {
+      try {
+        const AgentRunModel = require('../models/AgentRun');
+        const dayStart = new Date();
+        dayStart.setUTCHours(0, 0, 0, 0);
+        const userRunsToday = await AgentRunModel.countDocuments({
+          userId: installedBy,
+          startedAt: { $gte: dayStart },
+        });
+        if (userRunsToday >= userCeiling) {
+          console.warn(
+            `[native-runtime] user ${installedBy} hit the per-user daily ceiling `
+            + `(${userCeiling}) — declining ${agentName}:${instanceId} until UTC midnight`,
+          );
+          return failedResult('', 'user_ceiling', `per-user daily ceiling (${userCeiling}) reached`);
+        }
+      } catch (err) {
+        return failedResult(
+          '',
+          'user_ceiling_check_failed',
+          `per-user ceiling count failed (failing closed): ${(err as Error).message}`,
+        );
+      }
+    }
+  }
+
   // ADR-018 D3: native is one of OUR drivers — deterministic claim-before-act,
   // the same rule the CLI wrapper enforces (#894). Fleet audit (Sharpen msg
   // 53016) found this gap: the event queue pre-claims DELIVERY, but nothing
@@ -696,6 +740,8 @@ export async function runAgent(
     podId: installation.podId,
     agentName,
     instanceId,
+    // D5 denormalization: the per-user ceiling counts on this. Forward-only.
+    userId: installation.installedBy ? String(installation.installedBy) : undefined,
     trigger: triggerType,
     triggerEventId: trigger.eventId || undefined,
     status: 'queued',


### PR DESCRIPTION
The plan's own gate on Phase 2: 'a per-user daily ceiling is a prerequisite for offering the second hosted seat. Not a fast-follow.' Built TDD-first at two seams: AgentRun stamps userId from installedBy (forward-only, sparse-indexed), and runAgent declines truthfully before any model call when the user's runs-today across ALL their hosted installs meet the ceiling (default 120, env-tunable, 0 disables). Fail-closed on count failure — deliberately the opposite direction of the per-install cap, which keeps its runaway-guard fail-open semantics untouched (pinned by the existing suites, 22/22 green). With this merged, the hire endpoint can open Recorder as the second seat without 'per user' silently becoming 'per user per persona'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8