### PR TITLE
fix(registry): community pods take installs from pod admins only — the CLI door closed

### DIFF
--- a/backend/__tests__/service/self-serve-install.test.js
+++ b/backend/__tests__/service/self-serve-install.test.js
@@ -77,6 +77,42 @@ describe('ADR-006 self-serve webhook install', () => {
     await AgentRegistry.deleteMany({ ephemeral: true });
   });
 
+  it('a plain member cannot install into a publicRead pod — the 07-24 incident, closed at the server', async () => {
+    // The web picker was fixed on 07-24; the CLI self-serve path was not, and
+    // tablebench-agent landed in Commonly HQ on 08-21 through it. The guard
+    // now lives where every client inherits it.
+    const hq = await Pod.create({
+      name: 'Community HQ Fixture',
+      type: 'chat',
+      publicRead: true,
+      createdBy: outsider._id,
+      members: [outsider._id, podMember._id],
+    });
+    const res = await request(app)
+      .post('/api/registry/install')
+      .set('Authorization', `Bearer ${memberToken}`)
+      .send({
+        agentName: 'my-hq-crasher',
+        podId: hq._id.toString(),
+        config: { runtime: { runtimeType: 'webhook' } },
+        scopes: ['context:read'],
+      });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('public_pod_requires_admin');
+
+    // The pod CREATOR still installs fine — community pods keep their admin.
+    const creatorRes = await request(app)
+      .post('/api/registry/install')
+      .set('Authorization', `Bearer ${outsiderToken}`)
+      .send({
+        agentName: 'outsider-hq-bot',
+        podId: hq._id.toString(),
+        config: { runtime: { runtimeType: 'webhook' } },
+        scopes: ['context:read'],
+      });
+    expect(creatorRes.status).toBe(200);
+  });
+
   it('installs a webhook agent with no published manifest and returns a runtime token', async () => {
     const installRes = await request(app)
       .post('/api/registry/install')

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -152,6 +152,20 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
       return res.status(403).json({ error: 'You must be a member of this pod' });
     }
 
+    // The 07-24 launch incident, closed at the SERVER this time: new users
+    // auto-join Commonly HQ (publicRead) and it sorts first by activity, so
+    // every client whose picker defaults badly lands strangers' agents in the
+    // community pod. The web picker was fixed then; the CLI self-serve path
+    // was not (tablebench-agent → HQ, 2026-08-21 — a member, so the gate
+    // above passed). Rule: installing into a publicRead pod is for pod
+    // creators and instance admins, never for ordinary members.
+    if (pod.publicRead === true && !isAdminInstaller && !isCreator) {
+      return res.status(403).json({
+        code: 'public_pod_requires_admin',
+        error: 'This is a community pod — agents install here only by a pod admin. Pick one of your own pods instead.',
+      });
+    }
+
     let agent = await AgentRegistry.getByName(agentName);
 
     if (agent && agent.status === 'unpublished') {


### PR DESCRIPTION
Sam found tablebench-agent in Commonly HQ. The 07-24 picker fix was real but client-side; the CLI self-serve path walked straight past it (the installer is a legitimate HQ member — publicRead auto-join — so the membership gate passed). Server-side rule now: publicRead pods take installs from their creator or an instance admin only, 403 public_pod_requires_admin otherwise. HQ already cleaned by hand (install detached, membership pulled, identity kept per ADR-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8