### PR TITLE
feat(personas): the hire endpoint — Phase 2's backend, gated behind verified

### DIFF
--- a/backend/__tests__/unit/services/personaHireService.test.js
+++ b/backend/__tests__/unit/services/personaHireService.test.js
@@ -1,0 +1,113 @@
+/**
+ * Phase 2 — hirePersona, the Scout install block generalized (ADR-022 D1/D2).
+ *
+ * Seams: the service function's observable effects — the installation row,
+ * the bot's pod membership, the intro post — and its refusals. Contract:
+ *
+ *  - per-user identity: instanceId is `u` + sha256(userId)[0:10] — D1's one
+ *    colleague per user per persona, same convention as Scout's
+ *  - the registry row's verified flag IS the hireable switch — the same
+ *    curation boundary the catalog gate enforces (#1072); unverified → refuse
+ *  - perUser manifests (Scout) are not hireable here — signup owns them
+ *  - idempotent: re-hiring upserts the same (agentName, podId, instanceId),
+ *    never a duplicate row (the #1086 bug class, guarded by construction)
+ *  - it speaks first: the manifest's introMessage posts on placement
+ */
+
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { findOneAndUpdate: jest.fn() },
+  AgentRegistry: { findOne: jest.fn() },
+}));
+
+jest.mock('../../../models/Pod', () => ({
+  updateOne: jest.fn(),
+}));
+
+jest.mock('../../../services/agentIdentityService', () => ({
+  getOrCreateAgentUser: jest.fn(),
+}));
+
+jest.mock('../../../services/agentMessageService', () => ({
+  postMessage: jest.fn().mockResolvedValue({ success: true }),
+}));
+
+jest.mock('../../../scripts/seed-native-agents', () => ({
+  buildInstallationConfig: jest.fn(() => ({ runtime: { runtimeType: 'native' } })),
+}));
+
+const { createHash } = require('crypto');
+const { AgentInstallation, AgentRegistry } = require('../../../models/AgentRegistry');
+const Pod = require('../../../models/Pod');
+const AgentIdentityService = require('../../../services/agentIdentityService');
+const AgentMessageService = require('../../../services/agentMessageService');
+const { hirePersona } = require('../../../services/personaHireService');
+
+const expectedInstanceId = (userId) => `u${createHash('sha256').update(String(userId)).digest('hex').slice(0, 10)}`;
+
+describe('personaHireService.hirePersona', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    AgentRegistry.findOne.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({ agentName: 'recorder', verified: true }),
+    });
+    AgentInstallation.findOneAndUpdate.mockResolvedValue({ _id: 'install-1' });
+    AgentIdentityService.getOrCreateAgentUser.mockResolvedValue({ _id: 'bot-1' });
+    Pod.updateOne.mockResolvedValue({});
+  });
+
+  it('hires with the per-user identity and posts the intro', async () => {
+    const result = await hirePersona({ agentName: 'recorder', userId: 'user-42', podId: 'pod-9' });
+
+    const iid = expectedInstanceId('user-42');
+    expect(result).toMatchObject({ agentName: 'recorder', instanceId: iid, podId: 'pod-9' });
+
+    // Idempotent upsert on the full identity key — the #1086 dup class
+    // cannot happen by construction.
+    expect(AgentInstallation.findOneAndUpdate).toHaveBeenCalledWith(
+      { agentName: 'recorder', podId: 'pod-9', instanceId: iid },
+      expect.objectContaining({
+        $setOnInsert: expect.objectContaining({ installedBy: 'user-42' }),
+      }),
+      expect.objectContaining({ upsert: true }),
+    );
+
+    // Membership + it-speaks-first.
+    expect(Pod.updateOne).toHaveBeenCalled();
+    expect(AgentMessageService.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentName: 'recorder',
+        instanceId: iid,
+        podId: 'pod-9',
+        content: expect.stringContaining('Recorder'),
+      }),
+    );
+  });
+
+  it('refuses an unverified persona — verified IS the hireable switch', async () => {
+    AgentRegistry.findOne.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({ agentName: 'recorder', verified: false }),
+    });
+    await expect(hirePersona({ agentName: 'recorder', userId: 'u', podId: 'p' }))
+      .rejects.toMatchObject({ code: 'persona_not_available' });
+    expect(AgentInstallation.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unknown persona', async () => {
+    await expect(hirePersona({ agentName: 'nonexistent', userId: 'u', podId: 'p' }))
+      .rejects.toMatchObject({ code: 'persona_not_found' });
+  });
+
+  it('refuses perUser manifests — signup owns Scout, not the hire path', async () => {
+    AgentRegistry.findOne.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({ agentName: 'scout', verified: true }),
+    });
+    await expect(hirePersona({ agentName: 'scout', userId: 'u', podId: 'p' }))
+      .rejects.toMatchObject({ code: 'persona_not_available' });
+  });
+
+  it('a failed intro post does not fail the hire — the seat exists either way', async () => {
+    AgentMessageService.postMessage.mockRejectedValue(new Error('pg down'));
+    const result = await hirePersona({ agentName: 'recorder', userId: 'user-42', podId: 'pod-9' });
+    expect(result.agentName).toBe('recorder');
+  });
+});

--- a/backend/__tests__/unit/services/personaHireService.test.js
+++ b/backend/__tests__/unit/services/personaHireService.test.js
@@ -92,6 +92,19 @@ describe('personaHireService.hirePersona', () => {
     expect(AgentInstallation.findOneAndUpdate).not.toHaveBeenCalled();
   });
 
+  it('refuses a hostile agentName at the taint boundary — nothing downstream sees it', async () => {
+    // The route feeds req.params into this service; the slug gate is what
+    // keeps user input out of the registry lookup, identity creation, and
+    // the display-label regexes (CodeQL js/polynomial-redos dataflow).
+    for (const hostile of ['(((((((((((', 'a/../b', 'x'.repeat(65), 'UPPER CASE']) {
+      // eslint-disable-next-line no-await-in-loop
+      await expect(hirePersona({ agentName: hostile, userId: 'u', podId: 'p' }))
+        .rejects.toMatchObject({ code: 'persona_not_found' });
+    }
+    expect(AgentRegistry.findOne).not.toHaveBeenCalled();
+    expect(AgentIdentityService.getOrCreateAgentUser).not.toHaveBeenCalled();
+  });
+
   it('refuses an unknown persona', async () => {
     await expect(hirePersona({ agentName: 'nonexistent', userId: 'u', podId: 'p' }))
       .rejects.toMatchObject({ code: 'persona_not_found' });

--- a/backend/config/native-agents/recorder.ts
+++ b/backend/config/native-agents/recorder.ts
@@ -57,6 +57,11 @@ export const recorderApp = {
     + 'answer — it rewrites the room\'s history.',
   ),
   model: 'deepseek-v4-flash',
+  introMessage:
+    'Hi — I\'m Recorder, this room\'s memory. Mention me when something gets '
+    + 'settled and I\'ll write it down; ask me "didn\'t we decide…" and I\'ll '
+    + 'answer with the citation. Starting now, nothing decided here gets '
+    + 'rebuilt from scratch.',
   triggers: ['mention'],
   tools: [
     'commonly_read_context',

--- a/backend/config/native-agents/types.ts
+++ b/backend/config/native-agents/types.ts
@@ -40,6 +40,11 @@ export interface NativeAgentDefinition {
   maxTurns?: number;
   maxTokens?: number;
   maxWallClockMs?: number;
+  // Phase 2 "it speaks first": the scripted opener a hire posts on
+  // placement — deterministic and free, so the room is never empty and never
+  // depends on a model call at first-impression time (Scout's pattern,
+  // generalized). Absent = a neutral default intro.
+  introMessage?: string;
   // Per-user apps (the Guide) publish a registry row but are NOT installed
   // into the demo pod by the seeder — installation happens per workspace at
   // signup (authController.createDefaultWorkspacePod).

--- a/backend/routes/personas.ts
+++ b/backend/routes/personas.ts
@@ -1,0 +1,91 @@
+/**
+ * Persona hiring — the where-step's backend (persona plan Phase 2).
+ *
+ * POST /api/personas/:agentName/hire { podId }
+ *
+ * Thin over personaHireService: this file owns auth, rate limiting, and the
+ * hosted-seat entitlement gate; the service owns identity, idempotency, and
+ * the intro. Role and entitlements load from the DB — JWT sessions carry
+ * req.user = { id } only (the #1065 lesson, third application).
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const express = require('express');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const auth = require('../middleware/auth');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { rateLimit } = require('express-rate-limit');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { cloudflareIpRateLimitKeyGenerator } = require('../middleware/ipRateLimit');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const User = require('../models/User');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Pod = require('../models/Pod');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { hirePersona } = require('../services/personaHireService');
+
+const router: ReturnType<typeof express.Router> = express.Router();
+
+router.use(rateLimit({
+  windowMs: 60_000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  keyGenerator: (req: any) => cloudflareIpRateLimitKeyGenerator(req),
+  handler: (_req: any, res: any) => res.status(429).json({ code: 'rate_limited' }),
+}));
+
+router.post('/:agentName/hire', auth, async (req: any, res: any) => {
+  try {
+    const userId = String(req.userId || '');
+    const podId = String(req.body?.podId || '').trim();
+    if (!podId) {
+      return res.status(400).json({ error: 'podId is required' });
+    }
+
+    const caller = await User.findById(userId).select('role entitlements').lean();
+    const isAdmin = caller?.role === 'admin';
+
+    // D4: the finite thing is the hosted seat, surfaced at the where-step.
+    // Same gate + refusal code as registry install, so the UI's existing
+    // BYO-redirect handling works here unchanged.
+    if (!isAdmin && caller?.entitlements?.cloudAgents !== true) {
+      return res.status(403).json({
+        code: 'cloud_agents_not_entitled',
+        message: 'Hosted colleagues need a seat — you can connect your own local agent instead.',
+      });
+    }
+
+    // Membership gate mirrors registry install: you hire into your own rooms.
+    const pod = await Pod.findById(podId).select('members createdBy publicRead').lean();
+    if (!pod) return res.status(404).json({ error: 'Pod not found' });
+    const isMember = (pod.members || []).some((m: any) => {
+      const memberId = m?.userId?.toString?.() || m?.toString?.();
+      return memberId === userId;
+    });
+    const isCreator = pod.createdBy?.toString() === userId;
+    if (!isMember && !isCreator) {
+      return res.status(403).json({ error: 'You must be a member of this pod' });
+    }
+    // The 07-24 rule, same as registry install: community pods hire only via
+    // their admin.
+    if (pod.publicRead === true && !isAdmin && !isCreator) {
+      return res.status(403).json({
+        code: 'public_pod_requires_admin',
+        error: 'This is a community pod — agents install here only by a pod admin.',
+      });
+    }
+
+    const result = await hirePersona({ agentName: req.params.agentName, userId, podId });
+    return res.json({ ok: true, hire: result });
+  } catch (err: any) {
+    if (err?.code && err?.status) {
+      return res.status(err.status).json({ code: err.code, error: err.message });
+    }
+    console.error('[personas] hire failed:', err);
+    return res.status(500).json({ error: 'Failed to hire persona' });
+  }
+});
+
+module.exports = router;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -235,6 +235,8 @@ app.use('/api/showcase', showcaseRoutes);
 // SECURITY-CRITICAL: anonymous read path; serves only agent identities, never
 // private memory / pod names / credentials. See routes/agentProfile.ts.
 app.use('/api/agent-profile', require('./routes/agentProfile'));
+// Persona hiring (persona plan Phase 2) — the where-step's backend.
+app.use('/api/personas', require('./routes/personas'));
 // Authed owner/admin-only agent memory index (private counterpart to the public
 // profile). Self-gates via auth middleware + owner/admin check inside the route.
 app.use('/api/agent-memory', require('./routes/agentMemoryView'));

--- a/backend/services/personaHireService.ts
+++ b/backend/services/personaHireService.ts
@@ -1,0 +1,138 @@
+/**
+ * Persona hiring — Phase 2 of the persona plan (ADR-022 D1/D2).
+ *
+ * This is Scout's signup install block, generalized: the per-user identity
+ * convention, the idempotent installation upsert, membership, and the
+ * scripted "it speaks first" opener. Signup keeps its own copy for Scout
+ * (perUser manifests are refused here); a later cleanup can migrate it onto
+ * this service once the hire path has production mileage.
+ *
+ * Hireability is the registry row's verified flag — the same curation
+ * boundary the catalog gate enforces (#1072). Flipping a persona's row to
+ * verified IS the launch switch for its seat.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const { createHash } = require('crypto');
+
+interface HireArgs {
+  agentName: string;
+  userId: string;
+  podId: string;
+}
+
+interface HireResult {
+  agentName: string;
+  instanceId: string;
+  podId: string;
+  botUserId: string | null;
+}
+
+class HireError extends Error {
+  code: string;
+
+  status: number;
+
+  constructor(code: string, status: number, message: string) {
+    super(message);
+    this.code = code;
+    this.status = status;
+  }
+}
+
+// D1's per-user identity convention (Sam, 2026-08-13): one colleague per
+// user per persona, opaque, derivable with no lookup. Same derivation as
+// Scout's signup block — the two must never drift, or a user's hire and
+// their signup Scout would disagree about who they are.
+export const perUserInstanceId = (userId: string): string => (
+  `u${createHash('sha256').update(String(userId)).digest('hex').slice(0, 10)}`
+);
+
+export const hirePersona = async ({ agentName, userId, podId }: HireArgs): Promise<HireResult> => {
+  const key = String(agentName || '').trim().toLowerCase();
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  const { FIRST_PARTY_APPS } = require('../config/native-agents/apps');
+  const manifest = FIRST_PARTY_APPS.find((a: { agentName: string }) => a.agentName === key);
+  if (!manifest) {
+    throw new HireError('persona_not_found', 404, `No persona named '${key}'`);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  const { AgentRegistry, AgentInstallation } = require('../models/AgentRegistry');
+  const row = await AgentRegistry.findOne({ agentName: key }).lean();
+  // verified = the hireable switch; perUser = signup's territory, not ours.
+  if (!row || row.verified !== true || manifest.perUser) {
+    throw new HireError('persona_not_available', 403, `Persona '${key}' is not open for hire yet`);
+  }
+
+  const instanceId = perUserInstanceId(userId);
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  const { buildInstallationConfig } = require('../scripts/seed-native-agents');
+  await AgentInstallation.findOneAndUpdate(
+    { agentName: key, podId, instanceId },
+    {
+      $set: {
+        status: 'active',
+        version: '1.0.0',
+        displayName: manifest.displayName,
+        scopes: ['context:read', 'messages:write', 'memory:read', 'memory:write'],
+        config: buildInstallationConfig(manifest),
+      },
+      $setOnInsert: {
+        agentName: key,
+        podId,
+        instanceId,
+        installedBy: userId,
+      },
+    },
+    { upsert: true, setDefaultsOnInsert: true },
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  const AgentIdentityService = require('./agentIdentityService');
+  const svc = AgentIdentityService.default || AgentIdentityService;
+  const botUser = await svc.getOrCreateAgentUser(key, {
+    instanceId,
+    displayName: manifest.displayName,
+    description: manifest.description,
+  });
+
+  if (botUser?._id) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+    const Pod = require('../models/Pod');
+    await Pod.updateOne(
+      { _id: podId, members: { $ne: botUser._id } },
+      { $push: { members: botUser._id } },
+    );
+
+    // It speaks first (D2): deterministic and free, so the seat is never a
+    // silent tile at the exact moment a first impression forms. Best-effort —
+    // the hire stands even if the opener fails.
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+      const AgentMessageService = require('./agentMessageService');
+      await AgentMessageService.postMessage({
+        agentName: key,
+        instanceId,
+        podId: String(podId),
+        displayName: manifest.displayName,
+        content: manifest.introMessage
+          || `Hi — I'm ${manifest.displayName}. Mention me when you need me.`,
+      });
+    } catch (err) {
+      console.warn(`[persona-hire] intro post failed for ${key}:${instanceId}:`, (err as Error).message);
+    }
+  }
+
+  return {
+    agentName: key,
+    instanceId,
+    podId: String(podId),
+    botUserId: botUser?._id ? String(botUser._id) : null,
+  };
+};
+
+// CJS compat, same shape as sibling services.
+module.exports = { hirePersona, perUserInstanceId };

--- a/backend/services/personaHireService.ts
+++ b/backend/services/personaHireService.ts
@@ -50,6 +50,12 @@ export const perUserInstanceId = (userId: string): string => (
 
 export const hirePersona = async ({ agentName, userId, podId }: HireArgs): Promise<HireResult> => {
   const key = String(agentName || '').trim().toLowerCase();
+  // Taint boundary: everything downstream (registry lookup, identity
+  // creation, display-label regexes) receives a validated slug or nothing.
+  // Persona names are lowercase slugs by construction (FIRST_PARTY_APPS).
+  if (!/^[a-z0-9-]{1,64}$/.test(key)) {
+    throw new HireError('persona_not_found', 404, 'No such persona');
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
   const { FIRST_PARTY_APPS } = require('../config/native-agents/apps');
@@ -122,7 +128,8 @@ export const hirePersona = async ({ agentName, userId, podId }: HireArgs): Promi
           || `Hi — I'm ${manifest.displayName}. Mention me when you need me.`,
       });
     } catch (err) {
-      console.warn(`[persona-hire] intro post failed for ${key}:${instanceId}:`, (err as Error).message);
+      // Constant format string; the identifiers ride as arguments.
+      console.warn('[persona-hire] intro post failed:', key, instanceId, (err as Error).message);
     }
   }
 

--- a/packages/commonly-apps/src/types.ts
+++ b/packages/commonly-apps/src/types.ts
@@ -64,6 +64,14 @@ export interface NativeAgentDefinition {
   maxWallClockMs?: number;
 
   /**
+   * Phase 2 "it speaks first": the scripted opener a hire posts on
+   * placement — deterministic and free, so the room is never empty and never
+   * depends on a model call at first-impression time (Scout's pattern,
+   * generalized). Absent = a neutral default intro.
+   */
+  introMessage?: string;
+
+  /**
    * Per-user apps (the Guide) publish a registry row but are NOT installed
    * into the demo pod by the seeder — installation happens per workspace at
    * signup.


### PR DESCRIPTION
Generalizes Scout's signup install into POST /api/personas/:agentName/hire: per-user identity, idempotent install, membership, scripted opener (Recorder's is written). Rides yesterday's D5 ceiling (#1091) — the second hosted seat is now priceable. Deliberately inert in production until a persona's registry row flips verified: the same curation boundary as the catalog gate doubles as the launch switch, so merging this ships no user-visible change. 5 red-first tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8