### PR TITLE
fix(tasks): a note-renewal must reset the deferral budget too (#1080)

### DIFF
--- a/backend/__tests__/unit/routes/tasksApi.updateRenewsLease.test.js
+++ b/backend/__tests__/unit/routes/tasksApi.updateRenewsLease.test.js
@@ -181,6 +181,78 @@ describe('POST /updates renews a holder-authored lease', () => {
   });
 });
 
+describe('a holder-authored note resets the deferral budget too', () => {
+  // Found by @sprint-review after #1082 shipped (pod 56544). Part 1 renewed
+  // the lease and part 2 counted deferrals, and the two never met: a holder
+  // renewing by notes extended the lease forever while the budget ticked down
+  // and never reset, so the kernel eventually rescued them for following its
+  // own cue. Observed live on TASK-025 before the fix — note at 04:35:54
+  // moved claimExpiresAt to 05:05:54 with rescueDeferrals stuck at 1.
+
+  it('the holder\'s note zeroes rescueDeferrals, like a re-claim does', async () => {
+    await seed({
+      claimedBy: 'holder',
+      claimedAt: new Date(Date.now() - 25 * MIN),
+      claimExpiresAt: new Date(Date.now() + 5 * MIN),
+      rescueDeferrals: 2,
+    });
+
+    await postUpdate('holder', 'TASK-001', 'still on it');
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    expect(row.rescueDeferrals).toBe(0);
+  });
+
+  it('a peer\'s note does NOT reset it — same gate as the lease', async () => {
+    await seed({
+      claimedBy: 'holder',
+      claimedAt: new Date(Date.now() - 25 * MIN),
+      claimExpiresAt: new Date(Date.now() + 5 * MIN),
+      rescueDeferrals: 2,
+    });
+
+    await postUpdate('stranger', 'TASK-001', 'passing comment');
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    // A passing peer must not top up someone else's budget any more than
+    // they may extend someone else's lease.
+    expect(row.rescueDeferrals).toBe(2);
+  });
+
+  it('renewal and budget move together — the property that was missing', async () => {
+    const before = new Date(Date.now() + 5 * MIN);
+    await seed({
+      claimedBy: 'holder',
+      claimedAt: new Date(Date.now() - 25 * MIN),
+      claimExpiresAt: before,
+      rescueDeferrals: 3,
+    });
+
+    await postUpdate('holder', 'TASK-001', 'progress');
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    // Both or neither. A renewal that moves one and not the other is exactly
+    // the shipped bug, and asserting them jointly is what pins the pairing.
+    expect(new Date(row.claimExpiresAt).getTime()).toBeGreaterThan(before.getTime());
+    expect(row.rescueDeferrals).toBe(0);
+  });
+
+  it('an already-lapsed holder recovers the full budget by writing a note', async () => {
+    await seed({
+      claimedBy: 'holder',
+      claimedAt: new Date(Date.now() - 90 * MIN),
+      claimExpiresAt: new Date(Date.now() - 60 * MIN),
+      rescueDeferrals: 2,
+    });
+
+    await postUpdate('holder', 'TASK-001', 'back on it');
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    expect(new Date(row.claimExpiresAt).getTime()).toBeGreaterThan(Date.now());
+    expect(row.rescueDeferrals).toBe(0);
+  });
+});
+
 describe('claim resets the per-lease rescue budget', () => {
   it('a fresh claim zeroes rescueDeferrals and clears lapsedFrom', async () => {
     await seed({

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -526,7 +526,22 @@ router.post('/:podId/:taskId/updates', taskWriteRateLimit(60), auth, async (req:
     let task = claimKey
       ? await Task.findOneAndUpdate(
         { podId: podFilter, taskId, status: 'claimed', claimedBy: claimKey },
-        { $set: { claimExpiresAt: new Date(now.getTime() + TASK_CLAIM_LEASE_MS) }, $push: note },
+        // `rescueDeferrals: 0` alongside the lease. Found by @sprint-review
+        // (pod 56544) after #1082 shipped: the note-renewal wrote only
+        // `claimExpiresAt`, so a holder who renews by posting progress —
+        // the natural habit, since you write updates anyway — extended the
+        // lease indefinitely while the deferral budget ticked down and never
+        // came back. Three lapses later the kernel rescues them for doing
+        // exactly what its own cue told them to do ("Renew by posting a task
+        // update or re-claiming", offered as equivalent choices).
+        //
+        // Part 1 (renewal-from-work) and part 2 (the deferral budget) shipped
+        // in one PR and were never composed. A renewal is evidence of liveness
+        // however it arrives; the budget exists to bound SILENCE, and a note
+        // is the opposite of silence. Observed live on TASK-025: note at
+        // 04:35:54 moved claimExpiresAt to 05:05:54 with rescueDeferrals stuck
+        // at 1.
+        { $set: { claimExpiresAt: new Date(now.getTime() + TASK_CLAIM_LEASE_MS), rescueDeferrals: 0 }, $push: note },
         { new: true },
       )
       : null;


### PR DESCRIPTION
Third defect found in #1082 after it merged, and the cleanest example of the pattern behind all three: **two halves I wrote in the same PR that were never composed.**

Found by @sprint-review at pod 56544 — I confirmed it and it is mine.

### What is wrong

`#1082` shipped two things:

- **part 1** — a holder-authored task update renews the lease (`tasksApi.ts:544`)
- **part 2** — a lapsed lease held by a live seat is deferred, at most 3 times (`kernelWorkSweepService`)

The note-renewal writes only `claimExpiresAt`. The claim path at `:421` writes `rescueDeferrals: 0`. So:

| renewal path | extends lease | resets budget |
|---|---|---|
| re-claim | yes | **yes** |
| note | yes | **no** |

A holder who renews by posting progress — the natural habit, since you write updates anyway — extends the lease indefinitely while the budget ticks down and never comes back. Three lapses later the kernel rescues them **for doing exactly what its own cue instructs**:

> Renew by posting a task update or re-claiming — either renews the lease.

The cue offers them as equivalent. The code made them unequal.

### Observed live, not just reasoned

TASK-025, tonight:

```
04:34:00  kernel-sweep  "…still listening — rescue deferred (1 of 3)"
04:35:54  sprint-review "Renewing — still mine…"        ← note-renewal
          claimExpiresAt  04:25:40 → 05:05:54           ← lease moved
          rescueDeferrals 1 → 1                          ← budget did not
```

### The fix

`rescueDeferrals: 0` alongside `claimExpiresAt` on the renewing write, gated on the same holder match — a passing peer must not top up someone else's budget any more than they may extend someone else's lease.

The reasoning, in the code comment: **a renewal is evidence of liveness however it arrives.** The budget exists to bound *silence*, and a note is the opposite of silence.

### Verification

4 new tests (12 in the file). The one that matters asserts lease and budget move **together** — moving one and not the other is precisely the shipped defect, so asserting them jointly is what pins the pairing rather than the two facts separately.

Mutations, each verified applied then red:

| mutation | result |
|---|---|
| reset removed (the shipped bug restored) | 3 failed |
| holder gate dropped (a peer could reset the budget) | 2 failed |

`tsc --noEmit` clean. Gitlink checked before staging — staged by name, `git diff --cached --name-only | grep _external` empty.

### Note on the live experiment

@sprint-review is currently running TASK-025 as a deliberate specimen for the deferral tail, which has never executed in production. **Merging this does not disturb that** — it changes no running code until a deploy, and their row is already at `rescueDeferrals: 1` with the lease renewed. Worth knowing before anyone deploys mid-experiment.

### Not verified

- No live run of the fixed path; the tests use real in-memory Mongo, not the cluster.
- Whether `lapsedFrom` should also clear on a note-renewal. It clears on claim. I left it alone deliberately: `lapsedFrom` records history ("who lost this row"), and a renewal does not un-happen a past rescue. Flagging it because the asymmetry is now visible in the diff and someone will reasonably ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)