### PR TITLE
fix(messages): preserve PG author in agent wakes

### DIFF
--- a/backend/__tests__/unit/controllers/messageController.test.js
+++ b/backend/__tests__/unit/controllers/messageController.test.js
@@ -149,6 +149,30 @@ describe('messageController', () => {
       }));
     });
 
+    it('uses the raw PG username for a JWT-posted chat wake without a joined author', async () => {
+      const pgMessage = {
+        id: 33,
+        content: '@aria please review this',
+        username: 'sam',
+      };
+      Pod.findById.mockResolvedValue({ members: ['u1'], type: 'chat' });
+      PGMessage.create.mockResolvedValue({ id: 33 });
+      PGMessage.findById.mockResolvedValueOnce(pgMessage);
+      const req = {
+        params: { podId: 'p1' },
+        body: { content: pgMessage.content },
+        user: { id: 'u1' },
+      };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await messageController.createMessage(req, res);
+
+      expect(AgentMentionService.enqueueMentions).toHaveBeenCalledWith(expect.objectContaining({
+        message: pgMessage,
+        username: 'sam',
+      }));
+    });
+
     it('counts wake-on-message targets so the composer hint stays truthful (#914)', async () => {
       const mockMessage = { id: 4, content: 'hello with no mention' };
       Pod.findById.mockResolvedValue({ members: ['u1'], type: 'chat' });

--- a/backend/__tests__/unit/controllers/messageController.test.js
+++ b/backend/__tests__/unit/controllers/messageController.test.js
@@ -124,6 +124,31 @@ describe('messageController', () => {
       });
     });
 
+    it('uses the joined PG author for a JWT-posted chat wake', async () => {
+      const pgMessage = {
+        id: 31,
+        content: '@aria please review this',
+        userId: { _id: 'u1', username: 'sam' },
+      };
+      Pod.findById.mockResolvedValue({ members: ['u1'], type: 'chat' });
+      PGMessage.create.mockResolvedValue({ id: 31 });
+      PGMessage.findById.mockResolvedValueOnce(pgMessage);
+      const req = {
+        params: { podId: 'p1' },
+        body: { content: pgMessage.content },
+        // JWT auth supplies the id, not the username.
+        user: { id: 'u1' },
+      };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await messageController.createMessage(req, res);
+
+      expect(AgentMentionService.enqueueMentions).toHaveBeenCalledWith(expect.objectContaining({
+        message: pgMessage,
+        username: 'sam',
+      }));
+    });
+
     it('counts wake-on-message targets so the composer hint stays truthful (#914)', async () => {
       const mockMessage = { id: 4, content: 'hello with no mention' };
       Pod.findById.mockResolvedValue({ members: ['u1'], type: 'chat' });
@@ -173,6 +198,30 @@ describe('messageController', () => {
       const response = res.json.mock.calls[0][0];
       expect(response).not.toHaveProperty('agentDelivery');
       expect(AgentInstallation.countDocuments).not.toHaveBeenCalled();
+    });
+
+    it('uses the joined PG author for a JWT-posted DM wake', async () => {
+      const pgMessage = {
+        id: 32,
+        content: 'hello from the web UI',
+        userId: { _id: 'u1', username: 'sam' },
+      };
+      Pod.findById.mockResolvedValue({ members: ['u1'], type: 'agent-room' });
+      PGMessage.create.mockResolvedValue({ id: 32 });
+      PGMessage.findById.mockResolvedValueOnce(pgMessage);
+      const req = {
+        params: { podId: 'p2' },
+        body: { content: pgMessage.content },
+        user: { id: 'u1' },
+      };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await messageController.createMessage(req, res);
+
+      expect(AgentMentionService.enqueueDmEvent).toHaveBeenCalledWith(expect.objectContaining({
+        message: pgMessage,
+        username: 'sam',
+      }));
     });
 
     it.each(['agent-room', 'agent-dm'])('omits agentDelivery for %s pods', async (type) => {

--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -25,6 +25,11 @@ interface NormalizedMessage {
   id: string;
   pod_id: string;
   user_id: string;
+  // PG normalizes its joined author onto userId; the Mongo fallback keeps the
+  // historical user shape below. Agent wake author resolution must accept both
+  // stores so a JWT-posted human message never becomes "raised by unknown".
+  userId?: { username?: string } | string;
+  username?: string;
   content: string;
   message_type: string;
   // ADR-020 D3: structured card payload — must survive the Mongo fallback's
@@ -277,8 +282,11 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
     // new high-severity js/missing-rate-limiting alerts, one per authed route.
     // Those routes were already unrate-limited and the read already happened —
     // but drowning the real alerts is its own harm.
+    const pgAuthor = message.userId;
     const username = req.user?.username
-      || (message as { user?: { username?: string } } | undefined)?.user?.username;
+      || (pgAuthor && typeof pgAuthor === 'object' ? pgAuthor.username : undefined)
+      || message.username
+      || message.user?.username;
     // agent-admin (legacy 1:1 admin DM), agent-room (1:1 user↔agent DM), and
     // agent-dm (any 2-member DM, including agent↔agent) all auto-route every
     // human message to the agent — no @mention needed. Other pod types only


### PR DESCRIPTION
Summary
- Resolve a human author from the PG normalized message userId.username before falling through to the raw username and Mongo user.username shapes.
- Keep request-provided usernames first for API-token callers.
- Add JWT-on-PG regression coverage for both mention wakes and automatic DM wakes.

Verification
- backend controller unit suite: 16 tests pass.
- backend tsc:check passes.
- Mutation control: removing the PG fallback makes exactly the two added wake tests fail.