### PR TITLE
fix(v2): craft baseline pass 1 — chat measure, name wrap, runtime chips off cards

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -57,6 +57,29 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(rule).toContain('min-width: 0');
   });
 
+  test('Your Team card name WRAPS — a primary identifier never one-line-ellipsizes (craft audit rule 1)', () => {
+    // At 1440px half the fleet's names truncated ("Commonly…", "Pod Summ…").
+    // The name wraps to two lines; single-line nowrap+ellipsis was the defect.
+    const rule = ruleBody(v2, '.v2-team-card__name');
+    expect(rule).toContain('white-space: normal');
+    expect(rule).toContain('-webkit-line-clamp: 2');
+    expect(rule).not.toContain('white-space: nowrap');
+  });
+
+  test('runtime vocabulary stays off Your Team cards (ADR-022 D1, ratified)', () => {
+    // The chip shipped in violation of the ratified rule; the craft audit
+    // (finding 2) removed it. This pins the removal against reintroduction.
+    expect(v2).not.toContain('.v2-team-card__runtime {');
+  });
+
+  test('chat messages hold a readable measure (craft audit rule 2)', () => {
+    // ~150 chars/line at full content width was the audit's largest
+    // rendering defect. The centered 820px column is load-bearing.
+    expect(v2).toContain('.v2-chat__messages > *');
+    const rule = ruleBody(v2, '.v2-chat__messages > *');
+    expect(rule).toContain('max-width: 820px');
+  });
+
   test('motion timing is tokenized and all three existing V2 animations consume it', () => {
     expect(tokens).toContain('--motion-stagger:    0.18s');
     expect(tokens).toContain('--motion-breath:     1.2s');

--- a/frontend/src/v2/components/V2YourTeamPage.tsx
+++ b/frontend/src/v2/components/V2YourTeamPage.tsx
@@ -28,20 +28,10 @@ interface AgentInstallationSummary {
   podName?: string;
 }
 
-const RUNTIME_LABEL_KEY: Record<string, string> = {
-  internal: 'yourTeam.runtime.native',
-  moltbot: 'yourTeam.runtime.openclaw',
-  webhook: 'yourTeam.runtime.webhook',
-  cli: 'yourTeam.runtime.cli',
-  managed: 'yourTeam.runtime.cloudSandbox',
-};
-
-const formatRuntime = (a: AgentInstallationSummary, t: (key: string) => string): string => {
-  const rt = a.runtime?.runtimeType;
-  if (!rt) return t('yourTeam.runtime.native');
-  const key = RUNTIME_LABEL_KEY[rt];
-  return key ? t(key) : rt;
-};
+// Runtime labels removed from cards 2026-08-22: ADR-022 D1 (ratified) bans
+// runtime vocabulary on user-facing cards; the craft audit found this surface
+// violating it on every card. Owner-facing runtime detail lives on the agent
+// profile, not the roster.
 
 const formatRelative = (
   iso: string | null | undefined,
@@ -373,7 +363,7 @@ const V2YourTeamPage: React.FC = () => {
         {filteredAgents.map((a) => {
           const display = a.displayName || a.name;
           const podLabel = a.podName || t('yourTeam.untitledProject');
-          const runtimeLabel = formatRuntime(a, t);
+
           const lastSeen = formatRelative(lastSeenIso(a), t);
           const cardKey = `${a.name}:${a.instanceId}`;
           const isOpening = opening === cardKey;
@@ -403,7 +393,6 @@ const V2YourTeamPage: React.FC = () => {
                   {a.category && (
                     <span className="v2-role-chip" title={t('yourTeam.card.roleTitle', { role: a.category })}>{a.category}</span>
                   )}
-                  <span className="v2-team-card__runtime">{runtimeLabel}</span>
                 </div>
                 <div className="v2-team-card__pod">{t('yourTeam.card.inProject')} <em>{podLabel}</em></div>
                 <div className="v2-team-card__activity">

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -1528,6 +1528,16 @@
   gap: 0;
 }
 
+/* Craft audit 2026-08-22, rule 2: chat text holds a readable measure (~72ch
+   at 15px with the 38px avatar column) instead of running the full ~1090px
+   content width. Whitespace absorbs wide viewports; the column centers. */
+.v2-chat__messages > * {
+  max-width: 820px;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 /* Sender-only teaching cue shown once per pod/session when a message reaches
    a pod with agents but addresses none of them. Aligns with message text,
    stays quiet/secondary, and disappears naturally with transcript scroll. */
@@ -5568,22 +5578,20 @@
   font-weight: 600;
   font-size: 15px;
   color: #1a1c22;
-  white-space: nowrap;
+  /* Craft audit 2026-08-22, rule 1: a primary identifier never ellipsizes at
+     one line — at 1440px HALF the fleet's names truncated. Wrap to two lines;
+     clamp only pathological lengths. */
+  white-space: normal;
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   overflow: hidden;
-  text-overflow: ellipsis;
+  line-height: 1.3;
 }
 
-.v2-team-card__runtime {
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  color: #6b6f7a;
-  background: #f1f2f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  white-space: nowrap;
-}
+/* .v2-team-card__runtime removed 2026-08-22: runtime vocabulary on cards
+   violated ratified ADR-022 D1 (craft audit finding 2). */
 
 .v2-team-card__pod {
   font-size: 13px;


### PR DESCRIPTION
The three fixes the craft audit (#1101) scoped as not-waiting for the direction doc: (1) chat holds a centered readable measure (~72ch) instead of 150-char lines; (2) Your Team names wrap to two lines — half of them ellipsized at desktop width; (3) runtime chips come off the cards, closing a shipped violation of ratified ADR-022 D1. Each pinned in the layout-invariants suite so none can silently regress. Browser verification after deploy per the jsdom rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8