### PR TITLE
fix(v2): chat measure without the centered island

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -72,12 +72,15 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).not.toContain('.v2-team-card__runtime {');
   });
 
-  test('chat messages hold a readable measure (craft audit rule 2)', () => {
-    // ~150 chars/line at full content width was the audit's largest
-    // rendering defect. The centered 820px column is load-bearing.
-    expect(v2).toContain('.v2-chat__messages > *');
-    const rule = ruleBody(v2, '.v2-chat__messages > *');
-    expect(rule).toContain('max-width: 820px');
+  test('chat text holds a readable measure WITHOUT centering (craft audit rule 2, corrected)', () => {
+    // ~150 chars/line was the defect; the first fix centered the whole
+    // message column and left it misaligned with the full-width composer and
+    // header — worse than the disease. The correct mechanic caps the text
+    // measure only, rows left-anchored. Both halves are load-bearing: the
+    // cap must exist, and the centering must never come back.
+    const body = ruleBody(v2, '.v2-msg__body');
+    expect(v2).toContain('max-width: 76ch');
+    expect(v2).not.toContain('.v2-chat__messages > *');
   });
 
   test('motion timing is tokenized and all three existing V2 animations consume it', () => {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -1528,14 +1528,14 @@
   gap: 0;
 }
 
-/* Craft audit 2026-08-22, rule 2: chat text holds a readable measure (~72ch
-   at 15px with the 38px avatar column) instead of running the full ~1090px
-   content width. Whitespace absorbs wide viewports; the column centers. */
-.v2-chat__messages > * {
-  max-width: 820px;
-  width: 100%;
-  margin-left: auto;
-  margin-right: auto;
+/* Craft audit 2026-08-22, rule 2 — corrected same day. The first cut
+   centered the message column, which left it misaligned with the full-width
+   header and composer ("a floating island" — Sam, accurately: a disaster).
+   The right mechanic caps the TEXT measure only: rows stay left-anchored so
+   messages, composer, and header share one edge; long lines still break at
+   a readable width. */
+.v2-msg__body {
+  max-width: 76ch;
 }
 
 /* Sender-only teaching cue shown once per pod/session when a message reaches


### PR DESCRIPTION
Sam's review of #1103's chat measure, verbatim: 'it is a disaster' — and he's right. Centering the message column left it misaligned with the full-width header and composer. This keeps the readable-measure rule (76ch cap on message text) and removes the centering entirely; rows stay left-anchored. Invariant updated to pin both the cap and the never-again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8