### PR TITLE
feat(design): neumorphism pilot — token layer + persona catalog (LOCAL-VERIFIED, review-gated)

### DIFF
--- a/frontend/design-system/README.md
+++ b/frontend/design-system/README.md
@@ -106,6 +106,7 @@ Commonly speaks to developers building with AI agents. The voice is **plainly te
 
 ### Borders & elevation
 
+- **Neumorphic surfaces (accepted direction, 2026-08-22): the two rules below are superseded THERE, deliberately.** Sam ruled the shell migrates to the neumorphism recipe (`commonly-skills/skillsui/neumorphism`): ground `--neo-surface` (#d8dce6), depth via the dual-shadow token sets (`--neo-raised*` / `--neo-inset*`), element background ALWAYS equal to the page ground, cobalt reserved for action. On a migrated surface, shadows ARE the structure and borders disappear; on un-migrated surfaces the flat rules below still bind until their conversion PR. Never mix the two languages inside one surface.
 - **Borders, not shadows.** Cards are `1px solid #e5e7eb`. Hairlines between sections use `#eef0f6`. Hovered borders deepen to `#d7dce7`.
 - The v2 token explicitly sets `--v2-shadow: none` and `--v2-shadow-sm: none`. **Shadows are reserved for floating UI** — mention dropdowns (`0 8px 24px rgba(15,23,42,.12)`), login card, dialogs.
 - **No "inner shadow" / inset effects** on chrome surfaces. Avatars again excepted: the initials plate carries a 1px inset highlight/shade pair so the seeded gradient reads as a lit sphere rather than a flat disc — removed via `:has(img)` when a photo is present, so shading never sits on a face.

--- a/frontend/design-system/preview/neumorphism-components.html
+++ b/frontend/design-system/preview/neumorphism-components.html
@@ -1,0 +1,248 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Neumorphic component kit — Commonly design system</title>
+<style>
+  /* The complete primitive inventory under the accepted neumorphism direction
+     (Sam, 2026-08-22). One treatment per primitive, states included. This
+     page is the review artifact; sign-off codifies these into v2.css
+     component classes, and surface migrations then consume them mechanically.
+
+     Grammar (three rules cover everything):
+       RAISED  = things you can act on or pick up (buttons, cards, knobs)
+       INSET   = places content lives or goes into (inputs, wells, tracks)
+       FLAT    = quiet metadata riding the surface (labels, dividers, text)
+     Cobalt appears only on action/active. Focus is ALWAYS the accent ring —
+     depth alone never signals focus (accessibility, craft baseline). */
+  :root {
+    --surface: #d8dce6;
+    --surface-deep: #cbd0dd;
+    --ink: #2a2e38;
+    --ink-2: #6a7183;
+    --accent: #2f6feb;
+    --accent-strong: #1f55c9;
+    --sl: rgba(255, 255, 255, 0.85);
+    --sd: rgba(146, 156, 176, 0.55);
+    --raised: -6px -6px 14px var(--sl), 6px 6px 14px var(--sd);
+    --raised-soft: -3px -3px 8px var(--sl), 3px 3px 8px var(--sd);
+    --raised-lg: -8px -8px 18px var(--sl), 8px 8px 18px var(--sd);
+    --inset: inset -4px -4px 10px var(--sl), inset 4px 4px 10px var(--sd);
+    --inset-soft: inset -2px -2px 5px var(--sl), inset 2px 2px 5px var(--sd);
+    --focus: 0 0 0 3px rgba(47, 111, 235, 0.35);
+  }
+  * { margin: 0; box-sizing: border-box; font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  body { background: var(--surface); color: var(--ink); padding: 48px 40px 80px; -webkit-font-smoothing: antialiased; }
+  .kit { max-width: 1080px; margin: 0 auto; }
+  h1 { font-family: "SF Pro Display", -apple-system, sans-serif; font-size: 28px; font-weight: 850; letter-spacing: -0.02em; }
+  .intro { color: var(--ink-2); font-size: 14px; margin-top: 6px; max-width: 62ch; line-height: 1.5; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 34px; margin-top: 40px; }
+  .cell h2 { font-size: 12px; font-weight: 700; letter-spacing: 0.07em; text-transform: uppercase; color: var(--ink-2); margin-bottom: 14px; }
+  .cell .note { font-size: 11.5px; color: var(--ink-2); margin-top: 10px; line-height: 1.45; }
+  .row { display: flex; gap: 14px; align-items: center; flex-wrap: wrap; }
+
+  /* Buttons */
+  .btn { border: none; cursor: pointer; border-radius: 12px; padding: 10px 20px; font-size: 13.5px; font-weight: 700; transition: box-shadow 100ms ease, transform 100ms ease, background 80ms ease; background: var(--surface); color: var(--ink); box-shadow: var(--raised-soft); }
+  .btn:active { box-shadow: var(--inset-soft); transform: translateY(1px); }
+  .btn:focus-visible { outline: none; box-shadow: var(--raised-soft), var(--focus); }
+  .btn--primary { background: var(--accent); color: #fff; box-shadow: -4px -4px 10px var(--sl), 4px 4px 12px rgba(47, 111, 235, 0.35); }
+  .btn--primary:hover { background: var(--accent-strong); }
+  .btn--primary:active { box-shadow: inset 3px 3px 8px rgba(0, 0, 0, 0.25); }
+  .btn--ghost { color: var(--ink-2); font-weight: 600; }
+  .btn:disabled { color: var(--ink-2); opacity: 0.55; box-shadow: none; cursor: not-allowed; }
+  .btn--icon { width: 42px; height: 42px; padding: 0; border-radius: 50%; display: grid; place-items: center; font-size: 16px; }
+
+  /* Inputs */
+  .input { width: 100%; border: none; outline: none; border-radius: 12px; padding: 12px 16px; font-size: 14px; color: var(--ink); background: var(--surface); box-shadow: var(--inset-soft); }
+  .input::placeholder { color: var(--ink-2); }
+  .input:focus-visible { box-shadow: var(--inset-soft), var(--focus); }
+  textarea.input { resize: vertical; min-height: 72px; }
+  .search { display: flex; align-items: center; gap: 10px; border-radius: 999px; padding: 10px 18px; background: var(--surface); box-shadow: var(--inset-soft); color: var(--ink-2); font-size: 13.5px; }
+  .search input { border: none; background: none; outline: none; flex: 1; font-size: 13.5px; color: var(--ink); }
+
+  /* Cards & panels */
+  .card { background: var(--surface); border-radius: 18px; box-shadow: var(--raised); padding: 20px; }
+  .panel-inset { background: var(--surface); border-radius: 14px; box-shadow: var(--inset); padding: 16px; font-size: 13px; color: var(--ink-2); }
+
+  /* Chips */
+  .chip { display: inline-flex; align-items: center; gap: 6px; font-size: 11.5px; padding: 5px 12px; border-radius: 999px; background: var(--surface); color: var(--ink-2); box-shadow: -2px -2px 5px var(--sl), 2px 2px 5px var(--sd); }
+  .chip--active { color: var(--accent); font-weight: 700; box-shadow: var(--inset-soft); }
+
+  /* Tabs / segmented control: inset track, raised active thumb */
+  .tabs { display: inline-flex; gap: 4px; padding: 5px; border-radius: 999px; background: var(--surface); box-shadow: var(--inset-soft); }
+  .tab { border: none; cursor: pointer; background: none; border-radius: 999px; padding: 8px 18px; font-size: 13px; font-weight: 600; color: var(--ink-2); }
+  .tab--active { background: var(--surface); color: var(--ink); box-shadow: var(--raised-soft); }
+  .tab:focus-visible { outline: none; box-shadow: var(--focus); }
+
+  /* Toggle: inset track, raised knob, accent when on */
+  .toggle { position: relative; width: 52px; height: 30px; border-radius: 999px; background: var(--surface); box-shadow: var(--inset-soft); border: none; cursor: pointer; transition: background 120ms ease; }
+  .toggle::after { content: ""; position: absolute; top: 3px; left: 3px; width: 24px; height: 24px; border-radius: 50%; background: var(--surface); box-shadow: var(--raised-soft); transition: left 140ms ease, background 120ms ease; }
+  .toggle[aria-pressed="true"] { background: var(--accent); }
+  .toggle[aria-pressed="true"]::after { left: 25px; background: #fff; }
+  .toggle:focus-visible { outline: none; box-shadow: var(--inset-soft), var(--focus); }
+
+  /* Checkbox & radio */
+  .check { width: 24px; height: 24px; border-radius: 8px; background: var(--surface); box-shadow: var(--inset-soft); border: none; cursor: pointer; display: grid; place-items: center; color: transparent; font-size: 14px; font-weight: 800; }
+  .check[aria-checked="true"] { color: var(--accent); }
+  .radio { border-radius: 50%; }
+  .radio[aria-checked="true"]::after { content: ""; width: 10px; height: 10px; border-radius: 50%; background: var(--accent); }
+  .radio[aria-checked="true"] { color: transparent; display: grid; place-items: center; }
+
+  /* Avatar well */
+  .well { border-radius: 50%; background: var(--surface); box-shadow: var(--inset-soft); padding: 5px; display: inline-grid; place-items: center; }
+  .face { width: 44px; height: 44px; border-radius: 50%; display: grid; place-items: center; color: #fff; font-weight: 700; }
+
+  /* Dropdown / menu / dialog: floating = strongest relief */
+  .menu { display: inline-flex; flex-direction: column; background: var(--surface); border-radius: 14px; box-shadow: var(--raised-lg); padding: 8px; min-width: 190px; }
+  .menu button { border: none; background: none; text-align: left; border-radius: 9px; padding: 9px 12px; font-size: 13.5px; color: var(--ink); cursor: pointer; }
+  .menu button:hover { box-shadow: var(--inset-soft); }
+  .menu .danger { color: #b3261e; }
+
+  /* Progress + slider: inset track, accent fill, raised knob */
+  .track { position: relative; height: 12px; border-radius: 999px; background: var(--surface); box-shadow: var(--inset-soft); }
+  .fill { position: absolute; inset: 3px auto 3px 3px; width: 62%; border-radius: 999px; background: var(--accent); }
+  .knob { position: absolute; top: 50%; left: 62%; transform: translate(-50%, -50%); width: 24px; height: 24px; border-radius: 50%; background: var(--surface); box-shadow: var(--raised-soft); }
+
+  /* List rows: flat on surface, inset divider, raised on hover */
+  .list { display: flex; flex-direction: column; }
+  .list .rowi { display: flex; align-items: center; gap: 12px; padding: 12px 14px; border-radius: 12px; font-size: 13.5px; transition: box-shadow 120ms ease; }
+  .list .rowi:hover { box-shadow: var(--raised-soft); }
+  .list .rowi + .rowi { margin-top: 2px; }
+  .list .meta { margin-left: auto; color: var(--ink-2); font-size: 12px; }
+
+  /* Message bubbles (chat on a neo surface) */
+  .msgwell { border-radius: 16px; box-shadow: var(--inset); padding: 16px; display: flex; flex-direction: column; gap: 12px; }
+  .m { display: flex; gap: 10px; font-size: 13.5px; line-height: 1.5; }
+  .m .a { width: 32px; height: 32px; border-radius: 50%; flex: none; box-shadow: var(--raised-soft); display: grid; place-items: center; color: #fff; font-weight: 700; font-size: 12px; }
+  .m .who { font-size: 11.5px; font-weight: 700; margin-bottom: 1px; }
+
+  /* Toast + badge + tooltip */
+  .toast { display: inline-flex; align-items: center; gap: 10px; border-radius: 12px; background: var(--surface); box-shadow: var(--raised-lg); padding: 12px 18px; font-size: 13px; font-weight: 600; }
+  .toast::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: #15803d; }
+  .badge { display: inline-grid; place-items: center; min-width: 20px; height: 20px; padding: 0 6px; border-radius: 999px; background: var(--accent); color: #fff; font-size: 11px; font-weight: 800; }
+  .tip { display: inline-block; background: var(--ink); color: #fff; font-size: 12px; padding: 6px 10px; border-radius: 8px; box-shadow: 4px 4px 12px var(--sd); }
+</style>
+</head>
+<body>
+<div class="kit">
+  <h1>Neumorphic component kit</h1>
+  <p class="intro">Every primitive, one treatment, states included. The grammar: <b>raised</b> = actable, <b>inset</b> = container, <b>flat</b> = metadata. Cobalt only on action/active; focus is always the accent ring — depth alone never signals focus.</p>
+
+  <div class="grid">
+    <div class="cell">
+      <h2>Buttons</h2>
+      <div class="row">
+        <button class="btn btn--primary">Hire</button>
+        <button class="btn">Profile</button>
+        <button class="btn btn--ghost">Cancel</button>
+        <button class="btn" disabled>Disabled</button>
+        <button class="btn btn--icon">＋</button>
+      </div>
+      <div class="note">Raised idle → pressed on :active. Primary carries cobalt with a blue-tinted drop; disabled loses depth entirely — no depth, no promise.</div>
+    </div>
+
+    <div class="cell">
+      <h2>Inputs</h2>
+      <input class="input" placeholder="Agent name…" style="margin-bottom:10px">
+      <div class="search">⌕ <input placeholder="Search pods…"></div>
+      <div class="note">Content goes INTO the surface: inset wells. Focus adds the accent ring to the well.</div>
+    </div>
+
+    <div class="cell">
+      <h2>Tabs / segmented</h2>
+      <div class="tabs">
+        <button class="tab tab--active">All</button>
+        <button class="tab">Team</button>
+        <button class="tab">DMs</button>
+        <button class="tab">Community</button>
+      </div>
+      <div class="note">Inset track, raised active thumb — the physical radio-bank metaphor. Replaces the flat pill filters.</div>
+    </div>
+
+    <div class="cell">
+      <h2>Toggle · checkbox · radio</h2>
+      <div class="row">
+        <button class="toggle" aria-pressed="true"></button>
+        <button class="toggle" aria-pressed="false"></button>
+        <button class="check" aria-checked="true">✓</button>
+        <button class="check" aria-checked="false">✓</button>
+        <button class="check radio" aria-checked="true"></button>
+      </div>
+      <div class="note">Inset receptacles, raised knobs; cobalt only when ON.</div>
+    </div>
+
+    <div class="cell">
+      <h2>Chips & filters</h2>
+      <div class="row">
+        <span class="chip">Cited recall</span>
+        <span class="chip">Decision log</span>
+        <span class="chip chip--active">Active filter</span>
+        <span class="badge">3</span>
+      </div>
+      <div class="note">Quiet raised (half-strength shadow). Active = pressed in + cobalt text. Count badges stay solid cobalt.</div>
+    </div>
+
+    <div class="cell">
+      <h2>Avatar well</h2>
+      <div class="row">
+        <span class="well"><span class="face" style="background:#0f766e">R</span></span>
+        <span class="well"><span class="face" style="background:#0e7490">FL</span></span>
+        <span class="well" style="padding:4px"><span class="face" style="width:32px;height:32px;font-size:12px;background:#b45309">S</span></span>
+      </div>
+      <div class="note">The coin pressed into the surface — identity's frame everywhere: cards, chat headers, member strips.</div>
+    </div>
+
+    <div class="cell">
+      <h2>Menu / dropdown</h2>
+      <div class="menu">
+        <button>Open profile</button>
+        <button>Move to another room</button>
+        <button class="danger">Uninstall</button>
+      </div>
+      <div class="note">Floating UI gets the strongest relief (raised-lg). Hover presses the row in — the inverse of flat systems.</div>
+    </div>
+
+    <div class="cell">
+      <h2>Progress / slider</h2>
+      <div class="track" style="margin-bottom:18px"><span class="fill"></span></div>
+      <div class="track"><span class="fill" style="width:38%"></span><span class="knob" style="left:38%"></span></div>
+      <div class="note">Inset track, cobalt fill, raised knob. Same anatomy serves progress bars, sliders, and usage meters.</div>
+    </div>
+
+    <div class="cell">
+      <h2>List rows</h2>
+      <div class="list card" style="padding:10px">
+        <div class="rowi"><span class="well" style="padding:3px"><span class="face" style="width:26px;height:26px;font-size:11px;background:#0f766e">R</span></span> Recorder <span class="meta">2m ago</span></div>
+        <div class="rowi"><span class="well" style="padding:3px"><span class="face" style="width:26px;height:26px;font-size:11px;background:#475569">P</span></span> Planner <span class="meta">1h ago</span></div>
+      </div>
+      <div class="note">Rows ride flat on their card; hover raises the row you're about to pick up. Sidebar pods use the same anatomy.</div>
+    </div>
+
+    <div class="cell">
+      <h2>Chat</h2>
+      <div class="msgwell">
+        <div class="m"><span class="a" style="background:#b45309">S</span><span><span class="who">Sam</span>Didn't we decide the retry cap already?</span></div>
+        <div class="m"><span class="a" style="background:#0f766e">R</span><span><span class="who">Recorder</span>Yes — cap five, per endpoint. The 12th's correction still applies.</span></div>
+      </div>
+      <div class="note">The conversation is an inset well; voices ride flat inside it, avatars raised. Composer = the input well + primary send.</div>
+    </div>
+
+    <div class="cell">
+      <h2>Toast · tooltip</h2>
+      <div class="row" style="align-items:flex-start; flex-direction:column; gap:12px">
+        <span class="toast">Recorder hired into Sharpen</span>
+        <span class="tip">Answers while your session runs</span>
+      </div>
+      <div class="note">Toasts float (raised-lg + status dot). Tooltips are the one solid-ink surface — legibility beats material purity at 12px.</div>
+    </div>
+
+    <div class="cell">
+      <h2>Cards & inset panels</h2>
+      <div class="card" style="margin-bottom:14px; font-size:13.5px">Raised card — the actable unit.</div>
+      <div class="panel-inset">Inset panel — samples, code, quotes, empty states live pressed into the surface.</div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/frontend/design-system/preview/neumorphism-components.html
+++ b/frontend/design-system/preview/neumorphism-components.html
@@ -3,244 +3,271 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Neumorphic component kit — Commonly design system</title>
+<title>Neumorphic component kit v2 — recipe-faithful</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
 <style>
-  /* The complete primitive inventory under the accepted neumorphism direction
-     (Sam, 2026-08-22). One treatment per primitive, states included. This
-     page is the review artifact; sign-off codifies these into v2.css
-     component classes, and surface migrations then consume them mechanically.
-
-     Grammar (three rules cover everything):
-       RAISED  = things you can act on or pick up (buttons, cards, knobs)
-       INSET   = places content lives or goes into (inputs, wells, tracks)
-       FLAT    = quiet metadata riding the surface (labels, dividers, text)
-     Cobalt appears only on action/active. Focus is ALWAYS the accent ring —
-     depth alone never signals focus (accessibility, craft baseline). */
+  /* Kit v2 — faithful to skillsui/neumorphism after the full-skill audit.
+     Exactly TWO deviations, both ruled by Sam: accent is OUR cobalt (not
+     lavender), with accent-light/glow recomputed at the recipe's alphas.
+     Everything else is the recipe: its text palette (ink is soft slate — part
+     of the material, never near-black), Nunito+Inter, its radius scale, its
+     transition curves, scale-press feedback, knob-accent toggle, thin-stroke
+     SVG icons, reduced-motion fallback, dark palette. */
   :root {
-    --surface: #d8dce6;
+    --surface: #d8dce6;            /* Slate Mist — Sam's accepted ground */
     --surface-deep: #cbd0dd;
-    --ink: #2a2e38;
-    --ink-2: #6a7183;
-    --accent: #2f6feb;
-    --accent-strong: #1f55c9;
-    --sl: rgba(255, 255, 255, 0.85);
-    --sd: rgba(146, 156, 176, 0.55);
-    --raised: -6px -6px 14px var(--sl), 6px 6px 14px var(--sd);
-    --raised-soft: -3px -3px 8px var(--sl), 3px 3px 8px var(--sd);
-    --raised-lg: -8px -8px 18px var(--sl), 8px 8px 18px var(--sd);
-    --inset: inset -4px -4px 10px var(--sl), inset 4px 4px 10px var(--sd);
-    --inset-soft: inset -2px -2px 5px var(--sl), inset 2px 2px 5px var(--sd);
-    --focus: 0 0 0 3px rgba(47, 111, 235, 0.35);
-  }
-  * { margin: 0; box-sizing: border-box; font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
-  body { background: var(--surface); color: var(--ink); padding: 48px 40px 80px; -webkit-font-smoothing: antialiased; }
-  .kit { max-width: 1080px; margin: 0 auto; }
-  h1 { font-family: "SF Pro Display", -apple-system, sans-serif; font-size: 28px; font-weight: 850; letter-spacing: -0.02em; }
-  .intro { color: var(--ink-2); font-size: 14px; margin-top: 6px; max-width: 62ch; line-height: 1.5; }
-  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 34px; margin-top: 40px; }
-  .cell h2 { font-size: 12px; font-weight: 700; letter-spacing: 0.07em; text-transform: uppercase; color: var(--ink-2); margin-bottom: 14px; }
-  .cell .note { font-size: 11.5px; color: var(--ink-2); margin-top: 10px; line-height: 1.45; }
-  .row { display: flex; gap: 14px; align-items: center; flex-wrap: wrap; }
+    --shadow-light: rgba(255, 255, 255, 0.80);
+    --shadow-dark:  rgba(146, 156, 176, 0.60);
 
-  /* Buttons */
-  .btn { border: none; cursor: pointer; border-radius: 12px; padding: 10px 20px; font-size: 13.5px; font-weight: 700; transition: box-shadow 100ms ease, transform 100ms ease, background 80ms ease; background: var(--surface); color: var(--ink); box-shadow: var(--raised-soft); }
-  .btn:active { box-shadow: var(--inset-soft); transform: translateY(1px); }
-  .btn:focus-visible { outline: none; box-shadow: var(--raised-soft), var(--focus); }
-  .btn--primary { background: var(--accent); color: #fff; box-shadow: -4px -4px 10px var(--sl), 4px 4px 12px rgba(47, 111, 235, 0.35); }
-  .btn--primary:hover { background: var(--accent-strong); }
-  .btn--primary:active { box-shadow: inset 3px 3px 8px rgba(0, 0, 0, 0.25); }
-  .btn--ghost { color: var(--ink-2); font-weight: 600; }
-  .btn:disabled { color: var(--ink-2); opacity: 0.55; box-shadow: none; cursor: not-allowed; }
-  .btn--icon { width: 42px; height: 42px; padding: 0; border-radius: 50%; display: grid; place-items: center; font-size: 16px; }
+    --shadow-soft-raised:  -6px -6px 14px var(--shadow-light),  6px  6px 14px var(--shadow-dark);
+    --shadow-soft-flat:    -2px -2px 5px  var(--shadow-light),  2px  2px 5px  var(--shadow-dark);
+    --shadow-soft-inset: inset -4px -4px 10px var(--shadow-light), inset 4px 4px 10px var(--shadow-dark);
+    --shadow-md-raised:  -8px -8px 18px var(--shadow-light),  8px  8px 18px var(--shadow-dark);
+    --shadow-md-inset: inset -6px -6px 14px var(--shadow-light), inset 6px 6px 14px var(--shadow-dark);
+
+    /* Deviation 1+2 (ruled): cobalt, with recipe-alpha derivatives */
+    --accent: #2f6feb;
+    --accent-light: rgba(47, 111, 235, 0.20);
+    --accent-glow: 0 0 12px rgba(47, 111, 235, 0.30);
+
+    /* Recipe text palette — soft slate, never near-black */
+    --text-primary:   #4a5568;
+    --text-secondary: #718096;
+    --text-muted:     #a0aec0;
+
+    --r-sm: 8px; --r-md: 14px; --r-lg: 20px; --r-xl: 28px; --r-pill: 999px;
+
+    --t-press: 0.12s cubic-bezier(0.4, 0, 0.2, 1);
+    --t-lift:  0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+    --t-smooth: 0.25s ease;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --surface: #1e2228;
+      --surface-deep: #181c22;
+      --shadow-light: rgba(50, 60, 75, 0.70);
+      --shadow-dark:  rgba(0, 0, 0, 0.50);
+      --text-primary:   #c8d0e7;
+      --text-secondary: #8892a4;
+      --text-muted:     #5a6478;
+    }
+  }
+  * { margin: 0; box-sizing: border-box; }
+  body {
+    background: var(--surface);
+    color: var(--text-primary);
+    font-family: 'Inter', -apple-system, sans-serif;
+    font-weight: 400;
+    padding: 48px 40px 80px;
+    -webkit-font-smoothing: antialiased;
+  }
+  h1, h2, .nunito { font-family: 'Nunito', -apple-system, sans-serif; }
+  .kit { max-width: 1080px; margin: 0 auto; }
+  h1 { font-size: clamp(2rem, 4.5vw, 3rem); font-weight: 800; letter-spacing: -0.02em; color: var(--text-primary); }
+  .intro { color: var(--text-secondary); font-size: 1rem; line-height: 1.75; margin-top: 8px; max-width: 62ch; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 36px; margin-top: 44px; }
+  .cell h2 { font-size: 0.8rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-muted); margin-bottom: 16px; }
+  .cell .note { font-size: 0.8rem; color: var(--text-muted); margin-top: 12px; line-height: 1.6; }
+  .row { display: flex; gap: 16px; align-items: center; flex-wrap: wrap; }
+  svg.i { width: 20px; height: 20px; fill: none; stroke: currentColor; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }
+
+  /* Buttons — recipe spec */
+  .neu-btn {
+    background: var(--surface); border: none; border-radius: var(--r-md);
+    box-shadow: var(--shadow-soft-raised); color: var(--text-secondary);
+    cursor: pointer; font-family: 'Inter', sans-serif; font-weight: 600; letter-spacing: 0.03em;
+    padding: 12px 28px; font-size: 0.9rem;
+    transition: box-shadow var(--t-press), transform var(--t-press), color var(--t-smooth);
+  }
+  .neu-btn:hover { color: var(--text-primary); }
+  .neu-btn:active, .neu-btn.is-active { box-shadow: var(--shadow-soft-inset); transform: scale(0.98); color: var(--accent); }
+  .neu-btn:focus-visible { outline: none; box-shadow: var(--shadow-soft-raised), 0 0 0 3px var(--accent-light); }
+  .neu-btn:disabled { color: var(--text-muted); opacity: 0.6; box-shadow: none; cursor: not-allowed; }
+  .neu-btn-primary {
+    background: var(--accent); border: none; border-radius: var(--r-md);
+    box-shadow: var(--shadow-soft-flat), var(--accent-glow);
+    color: #fff; cursor: pointer; font-family: 'Inter', sans-serif; font-weight: 700;
+    padding: 13px 30px; font-size: 0.9rem;
+    transition: box-shadow var(--t-press), transform var(--t-press);
+  }
+  .neu-btn-primary:active { transform: scale(0.97); box-shadow: var(--shadow-soft-inset); }
+  .neu-btn-primary:focus-visible { outline: none; box-shadow: var(--shadow-soft-flat), var(--accent-glow), 0 0 0 3px var(--accent-light); }
+  .neu-btn-icon { width: 46px; height: 46px; padding: 0; border-radius: 50%; display: grid; place-items: center; }
 
   /* Inputs */
-  .input { width: 100%; border: none; outline: none; border-radius: 12px; padding: 12px 16px; font-size: 14px; color: var(--ink); background: var(--surface); box-shadow: var(--inset-soft); }
-  .input::placeholder { color: var(--ink-2); }
-  .input:focus-visible { box-shadow: var(--inset-soft), var(--focus); }
-  textarea.input { resize: vertical; min-height: 72px; }
-  .search { display: flex; align-items: center; gap: 10px; border-radius: 999px; padding: 10px 18px; background: var(--surface); box-shadow: var(--inset-soft); color: var(--ink-2); font-size: 13.5px; }
-  .search input { border: none; background: none; outline: none; flex: 1; font-size: 13.5px; color: var(--ink); }
+  .neu-input {
+    background: var(--surface); border: none; border-radius: var(--r-md);
+    box-shadow: var(--shadow-soft-inset); color: var(--text-primary);
+    font-family: 'Inter', sans-serif; font-size: 0.95rem; outline: none;
+    padding: 14px 18px; width: 100%; transition: box-shadow var(--t-smooth);
+  }
+  .neu-input::placeholder { color: var(--text-muted); }
+  .neu-input:focus { box-shadow: var(--shadow-soft-inset), 0 0 0 3px var(--accent-light); }
 
-  /* Cards & panels */
-  .card { background: var(--surface); border-radius: 18px; box-shadow: var(--raised); padding: 20px; }
-  .panel-inset { background: var(--surface); border-radius: 14px; box-shadow: var(--inset); padding: 16px; font-size: 13px; color: var(--ink-2); }
+  /* Card */
+  .neu-card {
+    background: var(--surface); border-radius: var(--r-lg); border: none;
+    box-shadow: var(--shadow-soft-raised); padding: 28px;
+    transition: box-shadow var(--t-smooth), transform var(--t-smooth);
+  }
+  .neu-card:hover { transform: translateY(-3px); box-shadow: var(--shadow-md-raised); }
+  .neu-panel-inset { background: var(--surface); border-radius: var(--r-md); box-shadow: var(--shadow-soft-inset); padding: 18px; font-size: 0.9rem; line-height: 1.75; color: var(--text-secondary); }
 
-  /* Chips */
-  .chip { display: inline-flex; align-items: center; gap: 6px; font-size: 11.5px; padding: 5px 12px; border-radius: 999px; background: var(--surface); color: var(--ink-2); box-shadow: -2px -2px 5px var(--sl), 2px 2px 5px var(--sd); }
-  .chip--active { color: var(--accent); font-weight: 700; box-shadow: var(--inset-soft); }
+  /* Tabs */
+  /* DESIGN.md tab spec: a row of RAISED buttons; the selected one presses IN
+     with accent label (the analog radio-bank: the pushed key stays down). */
+  .neu-tabs { display: inline-flex; gap: 10px; }
+  .neu-tab { border: none; cursor: pointer; background: var(--surface); border-radius: var(--r-pill); padding: 9px 20px; font-family: 'Inter', sans-serif; font-size: 0.85rem; font-weight: 600; color: var(--text-muted); box-shadow: var(--shadow-soft-raised); transition: box-shadow var(--t-press), color var(--t-smooth); }
+  .neu-tab.is-active { color: var(--accent); box-shadow: var(--shadow-soft-inset); }
+  .neu-tab:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--accent-light); }
 
-  /* Tabs / segmented control: inset track, raised active thumb */
-  .tabs { display: inline-flex; gap: 4px; padding: 5px; border-radius: 999px; background: var(--surface); box-shadow: var(--inset-soft); }
-  .tab { border: none; cursor: pointer; background: none; border-radius: 999px; padding: 8px 18px; font-size: 13px; font-weight: 600; color: var(--ink-2); }
-  .tab--active { background: var(--surface); color: var(--ink); box-shadow: var(--raised-soft); }
-  .tab:focus-visible { outline: none; box-shadow: var(--focus); }
+  /* Toggle — recipe: knob travels AND turns accent; track stays inset */
+  .neu-toggle { width: 56px; height: 28px; background: var(--surface); border-radius: var(--r-pill); box-shadow: var(--shadow-soft-inset); position: relative; cursor: pointer; border: none; transition: box-shadow var(--t-smooth); }
+  .neu-toggle::after { content: ''; position: absolute; top: 4px; left: 4px; width: 20px; height: 20px; border-radius: 50%; background: var(--surface); box-shadow: var(--shadow-soft-raised); transition: transform var(--t-lift), background var(--t-smooth), box-shadow var(--t-smooth); }
+  .neu-toggle[aria-pressed="true"]::after { transform: translateX(28px); background: var(--accent); box-shadow: 0 2px 8px var(--accent-light); }
+  .neu-toggle:focus-visible { outline: none; box-shadow: var(--shadow-soft-inset), 0 0 0 3px var(--accent-light); }
 
-  /* Toggle: inset track, raised knob, accent when on */
-  .toggle { position: relative; width: 52px; height: 30px; border-radius: 999px; background: var(--surface); box-shadow: var(--inset-soft); border: none; cursor: pointer; transition: background 120ms ease; }
-  .toggle::after { content: ""; position: absolute; top: 3px; left: 3px; width: 24px; height: 24px; border-radius: 50%; background: var(--surface); box-shadow: var(--raised-soft); transition: left 140ms ease, background 120ms ease; }
-  .toggle[aria-pressed="true"] { background: var(--accent); }
-  .toggle[aria-pressed="true"]::after { left: 25px; background: #fff; }
-  .toggle:focus-visible { outline: none; box-shadow: var(--inset-soft), var(--focus); }
+  /* Checkbox / radio */
+  .neu-check { width: 26px; height: 26px; border-radius: var(--r-sm); background: var(--surface); box-shadow: var(--shadow-soft-inset); border: none; cursor: pointer; display: grid; place-items: center; color: transparent; transition: color var(--t-smooth); }
+  .neu-check[aria-checked="true"] { color: var(--accent); }
+  .neu-radio { border-radius: 50%; }
+  .neu-radio[aria-checked="true"]::after { content: ''; width: 10px; height: 10px; border-radius: 50%; background: var(--accent); }
 
-  /* Checkbox & radio */
-  .check { width: 24px; height: 24px; border-radius: 8px; background: var(--surface); box-shadow: var(--inset-soft); border: none; cursor: pointer; display: grid; place-items: center; color: transparent; font-size: 14px; font-weight: 800; }
-  .check[aria-checked="true"] { color: var(--accent); }
-  .radio { border-radius: 50%; }
-  .radio[aria-checked="true"]::after { content: ""; width: 10px; height: 10px; border-radius: 50%; background: var(--accent); }
-  .radio[aria-checked="true"] { color: transparent; display: grid; place-items: center; }
+  /* Slider */
+  .neu-slider { -webkit-appearance: none; width: 100%; height: 8px; background: var(--surface); border-radius: var(--r-pill); box-shadow: var(--shadow-soft-inset); outline: none; border: none; }
+  .neu-slider::-webkit-slider-thumb { -webkit-appearance: none; width: 22px; height: 22px; border-radius: 50%; background: var(--surface); box-shadow: var(--shadow-soft-raised); cursor: pointer; transition: box-shadow var(--t-press); }
+  .neu-slider::-webkit-slider-thumb:active { box-shadow: var(--shadow-soft-inset); }
 
-  /* Avatar well */
-  .well { border-radius: 50%; background: var(--surface); box-shadow: var(--inset-soft); padding: 5px; display: inline-grid; place-items: center; }
-  .face { width: 44px; height: 44px; border-radius: 50%; display: grid; place-items: center; color: #fff; font-weight: 700; }
+  /* Progress — recipe gradient fill */
+  .neu-progress { height: 6px; border-radius: var(--r-pill); background: var(--surface); box-shadow: var(--shadow-soft-inset); overflow: hidden; }
+  .neu-progress-fill { height: 100%; width: 62%; border-radius: var(--r-pill); background: linear-gradient(90deg, var(--accent), color-mix(in srgb, var(--accent) 60%, #fff)); transition: width 0.6s var(--t-lift); }
 
-  /* Dropdown / menu / dialog: floating = strongest relief */
-  .menu { display: inline-flex; flex-direction: column; background: var(--surface); border-radius: 14px; box-shadow: var(--raised-lg); padding: 8px; min-width: 190px; }
-  .menu button { border: none; background: none; text-align: left; border-radius: 9px; padding: 9px 12px; font-size: 13.5px; color: var(--ink); cursor: pointer; }
-  .menu button:hover { box-shadow: var(--inset-soft); }
-  .menu .danger { color: #b3261e; }
+  /* Knob / dial — the recipe's signature control */
+  .neu-knob { width: 72px; height: 72px; border-radius: 50%; background: var(--surface); box-shadow: var(--shadow-md-raised); position: relative; cursor: pointer; }
+  .neu-knob::before { content: ''; position: absolute; inset: 10px; border-radius: 50%; background: var(--surface); box-shadow: var(--shadow-soft-inset); }
+  .neu-knob::after { content: ''; position: absolute; top: 14px; left: 50%; transform: translateX(-50%); width: 4px; height: 4px; border-radius: 50%; background: var(--accent); }
 
-  /* Progress + slider: inset track, accent fill, raised knob */
-  .track { position: relative; height: 12px; border-radius: 999px; background: var(--surface); box-shadow: var(--inset-soft); }
-  .fill { position: absolute; inset: 3px auto 3px 3px; width: 62%; border-radius: 999px; background: var(--accent); }
-  .knob { position: absolute; top: 50%; left: 62%; transform: translate(-50%, -50%); width: 24px; height: 24px; border-radius: 50%; background: var(--surface); box-shadow: var(--raised-soft); }
+  /* Avatar well (ours, restated in recipe grammar) */
+  .well { border-radius: 50%; background: var(--surface); box-shadow: var(--shadow-soft-inset); padding: 5px; display: inline-grid; place-items: center; }
+  .face { width: 44px; height: 44px; border-radius: 50%; display: grid; place-items: center; color: #fff; font-family: 'Nunito', sans-serif; font-weight: 800; }
 
-  /* List rows: flat on surface, inset divider, raised on hover */
-  .list { display: flex; flex-direction: column; }
-  .list .rowi { display: flex; align-items: center; gap: 12px; padding: 12px 14px; border-radius: 12px; font-size: 13.5px; transition: box-shadow 120ms ease; }
-  .list .rowi:hover { box-shadow: var(--raised-soft); }
-  .list .rowi + .rowi { margin-top: 2px; }
-  .list .meta { margin-left: auto; color: var(--ink-2); font-size: 12px; }
+  /* Menu */
+  .neu-menu { display: inline-flex; flex-direction: column; background: var(--surface); border-radius: var(--r-md); box-shadow: var(--shadow-md-raised); padding: 8px; min-width: 200px; }
+  .neu-menu button { border: none; background: none; text-align: left; border-radius: var(--r-sm); padding: 10px 12px; font-family: 'Inter', sans-serif; font-size: 0.9rem; color: var(--text-primary); cursor: pointer; display: flex; align-items: center; gap: 10px; transition: box-shadow var(--t-press); }
+  .neu-menu button:hover { box-shadow: var(--shadow-soft-inset); }
 
-  /* Message bubbles (chat on a neo surface) */
-  .msgwell { border-radius: 16px; box-shadow: var(--inset); padding: 16px; display: flex; flex-direction: column; gap: 12px; }
-  .m { display: flex; gap: 10px; font-size: 13.5px; line-height: 1.5; }
-  .m .a { width: 32px; height: 32px; border-radius: 50%; flex: none; box-shadow: var(--raised-soft); display: grid; place-items: center; color: #fff; font-weight: 700; font-size: 12px; }
-  .m .who { font-size: 11.5px; font-weight: 700; margin-bottom: 1px; }
+  /* Chat */
+  .msgwell { border-radius: var(--r-lg); box-shadow: var(--shadow-soft-inset); padding: 18px; display: flex; flex-direction: column; gap: 14px; }
+  .m { display: flex; gap: 12px; font-size: 0.9rem; line-height: 1.75; color: var(--text-primary); }
+  .m .who { font-size: 0.8rem; font-weight: 600; color: var(--text-secondary); }
 
-  /* Toast + badge + tooltip */
-  .toast { display: inline-flex; align-items: center; gap: 10px; border-radius: 12px; background: var(--surface); box-shadow: var(--raised-lg); padding: 12px 18px; font-size: 13px; font-weight: 600; }
-  .toast::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: #15803d; }
-  .badge { display: inline-grid; place-items: center; min-width: 20px; height: 20px; padding: 0 6px; border-radius: 999px; background: var(--accent); color: #fff; font-size: 11px; font-weight: 800; }
-  .tip { display: inline-block; background: var(--ink); color: #fff; font-size: 12px; padding: 6px 10px; border-radius: 8px; box-shadow: 4px 4px 12px var(--sd); }
+  /* Type specimen */
+  .spec h1 { margin-bottom: 4px; }
+  .spec h3 { font-family: 'Nunito', sans-serif; font-size: 1.25rem; font-weight: 700; color: var(--text-primary); margin: 10px 0 4px; }
+  .spec p { font-size: 1rem; line-height: 1.75; color: var(--text-secondary); }
+  .spec label { display: block; font-size: 0.8rem; font-weight: 600; color: var(--text-muted); letter-spacing: 0.08em; text-transform: uppercase; margin-top: 12px; }
+
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
+  }
 </style>
 </head>
 <body>
 <div class="kit">
-  <h1>Neumorphic component kit</h1>
-  <p class="intro">Every primitive, one treatment, states included. The grammar: <b>raised</b> = actable, <b>inset</b> = container, <b>flat</b> = metadata. Cobalt only on action/active; focus is always the accent ring — depth alone never signals focus.</p>
+  <h1>Soft, but ours.</h1>
+  <p class="intro">Kit v2, recipe-faithful after the full-skill audit: the recipe's slate ink and Nunito-plus-Inter voice, its radius scale and press curves, its toggle and knob semantics — with exactly two ruled deviations, our cobalt and its derived glow.</p>
 
   <div class="grid">
     <div class="cell">
+      <h2>Type — the voice Sam flagged</h2>
+      <div class="spec">
+        <h3>Recorder keeps the record</h3>
+        <p>Body is Inter at 1.75 line-height in soft slate — ink belongs to the material, never near-black. Headings are Nunito, round like the surfaces.</p>
+        <label>First thing I'll do</label>
+      </div>
+    </div>
+
+    <div class="cell">
       <h2>Buttons</h2>
       <div class="row">
-        <button class="btn btn--primary">Hire</button>
-        <button class="btn">Profile</button>
-        <button class="btn btn--ghost">Cancel</button>
-        <button class="btn" disabled>Disabled</button>
-        <button class="btn btn--icon">＋</button>
+        <button class="neu-btn-primary">Hire</button>
+        <button class="neu-btn">Profile</button>
+        <button class="neu-btn" disabled>Disabled</button>
+        <button class="neu-btn neu-btn-icon"><svg class="i" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg></button>
       </div>
-      <div class="note">Raised idle → pressed on :active. Primary carries cobalt with a blue-tinted drop; disabled loses depth entirely — no depth, no promise.</div>
+      <div class="note">Primary = flat shadow + cobalt glow (the recipe's intentional contrast), scale-press. Neutral buttons color-shift on hover, press in and turn accent on :active.</div>
     </div>
 
     <div class="cell">
       <h2>Inputs</h2>
-      <input class="input" placeholder="Agent name…" style="margin-bottom:10px">
-      <div class="search">⌕ <input placeholder="Search pods…"></div>
-      <div class="note">Content goes INTO the surface: inset wells. Focus adds the accent ring to the well.</div>
+      <input class="neu-input" placeholder="Agent name…" style="margin-bottom:12px">
+      <input class="neu-input" placeholder="Focused" autofocus>
+      <div class="note">Inset wells; focus = inset + the 20%-alpha accent ring, per spec.</div>
     </div>
 
     <div class="cell">
-      <h2>Tabs / segmented</h2>
-      <div class="tabs">
-        <button class="tab tab--active">All</button>
-        <button class="tab">Team</button>
-        <button class="tab">DMs</button>
-        <button class="tab">Community</button>
+      <h2>Tabs</h2>
+      <div class="neu-tabs">
+        <button class="neu-tab is-active">All</button>
+        <button class="neu-tab">Team</button>
+        <button class="neu-tab">DMs</button>
       </div>
-      <div class="note">Inset track, raised active thumb — the physical radio-bank metaphor. Replaces the flat pill filters.</div>
+      <div class="note">Per DESIGN.md: raised row, the SELECTED tab presses in with accent label — the pushed key stays down.</div>
     </div>
 
     <div class="cell">
-      <h2>Toggle · checkbox · radio</h2>
+      <h2>Toggle · check · radio</h2>
       <div class="row">
-        <button class="toggle" aria-pressed="true"></button>
-        <button class="toggle" aria-pressed="false"></button>
-        <button class="check" aria-checked="true">✓</button>
-        <button class="check" aria-checked="false">✓</button>
-        <button class="check radio" aria-checked="true"></button>
+        <button class="neu-toggle" aria-pressed="true" onclick="this.setAttribute('aria-pressed', this.getAttribute('aria-pressed')==='true'?'false':'true')"></button>
+        <button class="neu-toggle" aria-pressed="false" onclick="this.setAttribute('aria-pressed', this.getAttribute('aria-pressed')==='true'?'false':'true')"></button>
+        <button class="neu-check" aria-checked="true"><svg class="i" style="width:16px;height:16px" viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg></button>
+        <button class="neu-check neu-radio" aria-checked="true"></button>
       </div>
-      <div class="note">Inset receptacles, raised knobs; cobalt only when ON.</div>
+      <div class="note">Corrected to spec: the KNOB turns cobalt and travels; the track stays inset. (v1 had it backwards.)</div>
     </div>
 
     <div class="cell">
-      <h2>Chips & filters</h2>
-      <div class="row">
-        <span class="chip">Cited recall</span>
-        <span class="chip">Decision log</span>
-        <span class="chip chip--active">Active filter</span>
-        <span class="badge">3</span>
+      <h2>Knob & slider — the signature</h2>
+      <div class="row" style="align-items:center">
+        <div class="neu-knob"></div>
+        <div style="flex:1"><input type="range" class="neu-slider" value="62"></div>
       </div>
-      <div class="note">Quiet raised (half-strength shadow). Active = pressed in + cobalt text. Count badges stay solid cobalt.</div>
+      <div class="note">The recessed-ring dial is the style's identity piece — reserved for rate/volume-like controls (daily caps, allowance meters).</div>
     </div>
 
     <div class="cell">
-      <h2>Avatar well</h2>
-      <div class="row">
+      <h2>Progress</h2>
+      <div class="neu-progress"><div class="neu-progress-fill"></div></div>
+      <div class="note">Gradient fill accent→60% white, spring transition — per spec, replaces v1's flat fill.</div>
+    </div>
+
+    <div class="cell">
+      <h2>Menu</h2>
+      <div class="neu-menu">
+        <button><svg class="i" viewBox="0 0 24 24"><path d="M12 12m-3 0a3 3 0 1 0 6 0a3 3 0 1 0-6 0M5 20c1.5-3 4-4 7-4s5.5 1 7 4"/></svg> Open profile</button>
+        <button><svg class="i" viewBox="0 0 24 24"><path d="M4 12h16M13 5l7 7-7 7"/></svg> Move to another room</button>
+      </div>
+      <div class="note">Thin-stroke inline SVG icons (1.5px), never glyph characters, never boxed — recipe Step 5.</div>
+    </div>
+
+    <div class="cell">
+      <h2>Avatar well · chat</h2>
+      <div class="row" style="margin-bottom:14px">
         <span class="well"><span class="face" style="background:#0f766e">R</span></span>
-        <span class="well"><span class="face" style="background:#0e7490">FL</span></span>
-        <span class="well" style="padding:4px"><span class="face" style="width:32px;height:32px;font-size:12px;background:#b45309">S</span></span>
+        <span class="well"><span class="face" style="background:#0e7490">F</span></span>
       </div>
-      <div class="note">The coin pressed into the surface — identity's frame everywhere: cards, chat headers, member strips.</div>
-    </div>
-
-    <div class="cell">
-      <h2>Menu / dropdown</h2>
-      <div class="menu">
-        <button>Open profile</button>
-        <button>Move to another room</button>
-        <button class="danger">Uninstall</button>
-      </div>
-      <div class="note">Floating UI gets the strongest relief (raised-lg). Hover presses the row in — the inverse of flat systems.</div>
-    </div>
-
-    <div class="cell">
-      <h2>Progress / slider</h2>
-      <div class="track" style="margin-bottom:18px"><span class="fill"></span></div>
-      <div class="track"><span class="fill" style="width:38%"></span><span class="knob" style="left:38%"></span></div>
-      <div class="note">Inset track, cobalt fill, raised knob. Same anatomy serves progress bars, sliders, and usage meters.</div>
-    </div>
-
-    <div class="cell">
-      <h2>List rows</h2>
-      <div class="list card" style="padding:10px">
-        <div class="rowi"><span class="well" style="padding:3px"><span class="face" style="width:26px;height:26px;font-size:11px;background:#0f766e">R</span></span> Recorder <span class="meta">2m ago</span></div>
-        <div class="rowi"><span class="well" style="padding:3px"><span class="face" style="width:26px;height:26px;font-size:11px;background:#475569">P</span></span> Planner <span class="meta">1h ago</span></div>
-      </div>
-      <div class="note">Rows ride flat on their card; hover raises the row you're about to pick up. Sidebar pods use the same anatomy.</div>
-    </div>
-
-    <div class="cell">
-      <h2>Chat</h2>
       <div class="msgwell">
-        <div class="m"><span class="a" style="background:#b45309">S</span><span><span class="who">Sam</span>Didn't we decide the retry cap already?</span></div>
-        <div class="m"><span class="a" style="background:#0f766e">R</span><span><span class="who">Recorder</span>Yes — cap five, per endpoint. The 12th's correction still applies.</span></div>
+        <div class="m"><span class="well" style="padding:3px"><span class="face" style="width:28px;height:28px;font-size:12px;background:#b45309">S</span></span><span><span class="who">Sam</span><br>Didn't we decide the retry cap?</span></div>
       </div>
-      <div class="note">The conversation is an inset well; voices ride flat inside it, avatars raised. Composer = the input well + primary send.</div>
+      <div class="note">Conversation = inset well; voices flat inside; avatars in wells.</div>
     </div>
 
     <div class="cell">
-      <h2>Toast · tooltip</h2>
-      <div class="row" style="align-items:flex-start; flex-direction:column; gap:12px">
-        <span class="toast">Recorder hired into Sharpen</span>
-        <span class="tip">Answers while your session runs</span>
-      </div>
-      <div class="note">Toasts float (raised-lg + status dot). Tooltips are the one solid-ink surface — legibility beats material purity at 12px.</div>
-    </div>
-
-    <div class="cell">
-      <h2>Cards & inset panels</h2>
-      <div class="card" style="margin-bottom:14px; font-size:13.5px">Raised card — the actable unit.</div>
-      <div class="panel-inset">Inset panel — samples, code, quotes, empty states live pressed into the surface.</div>
+      <h2>Cards & panels</h2>
+      <div class="neu-card" style="font-size:0.9rem; line-height:1.6; margin-bottom:14px">Raised card, 28px padding, −3px hover lift on the smooth curve.</div>
+      <div class="neu-panel-inset">Inset panel — samples and quotes press into the surface.</div>
     </div>
   </div>
 </div>

--- a/frontend/design-system/tokens.css
+++ b/frontend/design-system/tokens.css
@@ -28,6 +28,24 @@
   /* ---------- Borders ---------- */
   --c-border:          #e5e7eb;   /* default */
   --c-border-soft:     #eef0f6;   /* dividers */
+
+  /* ── Neumorphic layer (Sam's shell direction, accepted 2026-08-22) ──
+     skillsui neumorphism recipe with OUR constants: Slate Mist ground,
+     cobalt on action only, SF stack. Core physics: an element's background
+     MUST equal its page ground — depth comes only from the dual shadow.
+     Additive: surfaces migrate one at a time (persona catalog is the
+     pilot); un-migrated surfaces keep the flat token set above. */
+  --c-neo-surface: #d8dce6;
+  --c-neo-surface-deep: #cbd0dd;
+  --c-neo-ink: #2a2e38;
+  --c-neo-ink-2: #6a7183;
+  --c-neo-shadow-light: rgba(255, 255, 255, 0.85);
+  --c-neo-shadow-dark: rgba(146, 156, 176, 0.55);
+  --c-neo-raised: -6px -6px 14px var(--c-neo-shadow-light), 6px 6px 14px var(--c-neo-shadow-dark);
+  --c-neo-raised-soft: -3px -3px 8px var(--c-neo-shadow-light), 3px 3px 8px var(--c-neo-shadow-dark);
+  --c-neo-raised-lg: -8px -8px 18px var(--c-neo-shadow-light), 8px 8px 18px var(--c-neo-shadow-dark);
+  --c-neo-inset: inset -4px -4px 10px var(--c-neo-shadow-light), inset 4px 4px 10px var(--c-neo-shadow-dark);
+  --c-neo-inset-soft: inset -2px -2px 5px var(--c-neo-shadow-light), inset 2px 2px 5px var(--c-neo-shadow-dark);
   --c-border-strong:   #d7dce7;   /* hover/focus */
 
   /* ---------- Text ---------- */

--- a/frontend/src/v2/agents/V2PersonaCatalog.tsx
+++ b/frontend/src/v2/agents/V2PersonaCatalog.tsx
@@ -30,7 +30,9 @@ const PersonaCardView: React.FC<{ card: PersonaCard }> = ({ card }) => {
   return (
     <article className="v2-pcat__card">
       <header className="v2-pcat__card-head">
-        <V2Avatar name={card.name} size="md" kind="agent" seed={card.avatarSeed} />
+        <span className="v2-pcat__avatar-well">
+          <V2Avatar name={card.name} size="md" kind="agent" seed={card.avatarSeed} />
+        </span>
         <div className="v2-pcat__card-title">
           <h2 className="v2-pcat__name">{card.name}</h2>
           <div className="v2-pcat__role">{card.role}</div>

--- a/frontend/src/v2/agents/v2-persona-catalog.css
+++ b/frontend/src/v2/agents/v2-persona-catalog.css
@@ -5,13 +5,17 @@
    cobalt appears on action alone. Un-migrated surfaces keep the flat system —
    never mix languages inside one surface. */
 
+/* The WHOLE pane is the material — the recipe's core rule holds at page
+   level or nowhere. A rounded slab on the white shell reads as broken
+   neumorphism (first local cut proved it; Sam called it). The nav rail is a
+   separate fixed plane, like a dock — it keeps the flat system. */
+.v2-feature:has(.v2-pcat) { background: var(--neo-surface); }
+
 .v2-pcat {
   max-width: 1040px;
   margin: 0 auto;
-  padding: 8px 24px 40px;
-  background: var(--neo-surface);
+  padding: 16px 8px 48px;
   color: var(--neo-ink);
-  border-radius: 20px;
 }
 
 .v2-pcat__head { margin-bottom: 24px; }
@@ -33,7 +37,7 @@
 .v2-pcat__grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 24px;
+  gap: 30px;
 }
 
 /* At phone width the 300px column minimum exceeds what the nav rail leaves;
@@ -47,11 +51,11 @@
 .v2-pcat__card {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 20px;
+  gap: 14px;
+  padding: 26px 24px 22px;
   background: var(--neo-surface);
   border: none;
-  border-radius: 18px;
+  border-radius: 20px;
   box-shadow: var(--neo-raised);
   transition: box-shadow 140ms ease, transform 140ms ease;
 }
@@ -60,7 +64,21 @@
 .v2-pcat__card-head {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
+  /* When a long name wraps, the liveness chip drops to its own line instead
+     of crushing the title column. */
+  flex-wrap: wrap;
+}
+/* The mock's signature: the avatar sits in an inset well, a coin pressed
+   into the surface. */
+.v2-pcat__avatar-well {
+  border-radius: 50%;
+  background: var(--neo-surface);
+  box-shadow: var(--neo-inset-soft);
+  padding: 5px;
+  flex: none;
+  display: grid;
+  place-items: center;
 }
 .v2-pcat__card-title { flex: 1 1 auto; min-width: 0; }
 .v2-pcat__name {
@@ -75,9 +93,13 @@
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--neo-ink-2);
+  /* Kickers never hyphen-break ("PULL-" / "REQUEST" read as two words). */
+  hyphens: none;
+  overflow-wrap: normal;
 }
 
 .v2-pcat__liveness {
+  margin-left: auto;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -149,7 +171,7 @@
   border-radius: 999px;
   color: var(--neo-ink-2);
   background: var(--neo-surface);
-  box-shadow: var(--neo-raised-soft);
+  box-shadow: -2px -2px 5px var(--neo-shadow-light), 2px 2px 5px var(--neo-shadow-dark);
 }
 
 .v2-pcat__limits {

--- a/frontend/src/v2/agents/v2-persona-catalog.css
+++ b/frontend/src/v2/agents/v2-persona-catalog.css
@@ -1,10 +1,17 @@
-/* Persona catalog — Phase 1 of the persona plan. Token-only per the design
-   system: one accent, borders not shadows, sentence case, calm motion. */
+/* Persona catalog — the NEUMORPHIC PILOT SURFACE (Sam's direction, accepted
+   2026-08-22 from the neumorphic-commonly proof). First surface migrated to
+   the --neo-* token layer; the recipe's physics govern: every element's
+   background equals the page ground, depth comes only from the dual shadow,
+   cobalt appears on action alone. Un-migrated surfaces keep the flat system —
+   never mix languages inside one surface. */
 
 .v2-pcat {
   max-width: 1040px;
   margin: 0 auto;
   padding: 8px 24px 40px;
+  background: var(--neo-surface);
+  color: var(--neo-ink);
+  border-radius: 20px;
 }
 
 .v2-pcat__head { margin-bottom: 24px; }
@@ -13,12 +20,12 @@
   font-size: 24px;
   font-weight: 850;
   letter-spacing: -0.03em;
-  color: var(--v2-text);
+  color: var(--neo-ink);
 }
 .v2-pcat__sub {
   margin: 0;
   max-width: 56ch;
-  color: var(--v2-text-secondary);
+  color: var(--neo-ink-2);
   font-size: 14px;
   line-height: 1.5;
 }
@@ -26,7 +33,7 @@
 .v2-pcat__grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 16px;
+  gap: 24px;
 }
 
 /* At phone width the 300px column minimum exceeds what the nav rail leaves;
@@ -41,13 +48,14 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 18px;
-  background: var(--v2-surface);
-  border: 1px solid var(--v2-border);
-  border-radius: var(--v2-radius-lg);
-  transition: border-color 120ms ease;
+  padding: 20px;
+  background: var(--neo-surface);
+  border: none;
+  border-radius: 18px;
+  box-shadow: var(--neo-raised);
+  transition: box-shadow 140ms ease, transform 140ms ease;
 }
-.v2-pcat__card:hover { border-color: var(--v2-text-secondary); }
+.v2-pcat__card:hover { transform: translateY(-2px); box-shadow: var(--neo-raised-lg); }
 
 .v2-pcat__card-head {
   display: flex;
@@ -59,14 +67,14 @@
   margin: 0;
   font-size: 17px;
   font-weight: 700;
-  color: var(--v2-text);
+  color: var(--neo-ink);
 }
 .v2-pcat__role {
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--v2-text-secondary);
+  color: var(--neo-ink-2);
 }
 
 .v2-pcat__liveness {
@@ -74,24 +82,24 @@
   align-items: center;
   gap: 6px;
   font-size: 11px;
-  color: var(--v2-text-secondary);
+  color: var(--neo-ink-2);
   white-space: nowrap;
 }
 .v2-pcat__dot {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--v2-border);
+  background: var(--neo-surface-deep);
 }
-.v2-pcat__liveness--live .v2-pcat__dot { background: #15803d; }
+.v2-pcat__liveness--live .v2-pcat__dot { background: #15803d; box-shadow: 0 0 4px rgba(21, 128, 61, 0.5); }
 .v2-pcat__liveness--session .v2-pcat__dot { background: #b45309; }
-.v2-pcat__liveness--soon .v2-pcat__dot { background: var(--v2-border); }
+.v2-pcat__liveness--soon .v2-pcat__dot { background: var(--neo-surface-deep); box-shadow: var(--neo-inset-soft); }
 
 .v2-pcat__oneliner {
   margin: 0;
   font-size: 14px;
   line-height: 1.55;
-  color: var(--v2-text);
+  color: var(--neo-ink);
 }
 
 .v2-pcat__kicker {
@@ -100,66 +108,70 @@
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--v2-text-secondary);
+  color: var(--neo-ink-2);
   margin-bottom: 2px;
 }
 .v2-pcat__first p {
   margin: 0;
   font-size: 13px;
   line-height: 1.5;
-  color: var(--v2-text-secondary);
+  color: var(--neo-ink-2);
 }
 
+/* The sample exchange is the card's centerpiece — pressed INTO the surface,
+   the accepted mock's signature move. */
 .v2-pcat__sample {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 10px 12px;
-  background: var(--v2-bg);
-  border: 1px solid var(--v2-border);
-  border-radius: var(--v2-radius-md, 8px);
+  padding: 12px 14px;
+  background: var(--neo-surface);
+  border: none;
+  border-radius: 14px;
+  box-shadow: var(--neo-inset);
   font-size: 12.5px;
   line-height: 1.45;
 }
-.v2-pcat__sample-ask { color: var(--v2-text-secondary); }
+.v2-pcat__sample-ask { color: var(--neo-ink-2); }
 .v2-pcat__sample-ask::before { content: '“'; }
 .v2-pcat__sample-ask::after { content: '”'; }
 .v2-pcat__sample-reply {
-  color: var(--v2-text);
+  color: var(--neo-ink);
   padding-left: 10px;
   border-left: 2px solid var(--v2-accent);
 }
 
-.v2-pcat__chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.v2-pcat__chips { display: flex; flex-wrap: wrap; gap: 8px; }
 .v2-pcat__chip {
   font-size: 11px;
-  padding: 3px 9px;
-  border: 1px solid var(--v2-border);
+  padding: 4px 11px;
+  border: none;
   border-radius: 999px;
-  color: var(--v2-text-secondary);
-  background: var(--v2-surface);
+  color: var(--neo-ink-2);
+  background: var(--neo-surface);
+  box-shadow: var(--neo-raised-soft);
 }
 
 .v2-pcat__limits {
   margin: 0;
   font-size: 12px;
   line-height: 1.45;
-  color: var(--v2-text-secondary);
+  color: var(--neo-ink-2);
   font-style: italic;
 }
 
 .v2-pcat__how summary {
   font-size: 12px;
   font-weight: 600;
-  color: var(--v2-text-secondary);
+  color: var(--neo-ink-2);
   cursor: pointer;
 }
-.v2-pcat__how[open] summary { color: var(--v2-text); }
+.v2-pcat__how[open] summary { color: var(--neo-ink); }
 .v2-pcat__how p {
   margin: 8px 0 0;
   font-size: 12.5px;
   line-height: 1.5;
-  color: var(--v2-text-secondary);
+  color: var(--neo-ink-2);
 }
 
 .v2-pcat__card-foot {
@@ -173,25 +185,32 @@
 .v2-pcat__tier-note {
   font-size: 11px;
   font-weight: 600;
-  color: var(--v2-text-secondary);
+  color: var(--neo-ink-2);
 }
-.v2-pcat__cta {
+/* Cobalt on action only — raised idle, pressed on :active (the recipe's
+   raised→pressed interaction, the thing that makes buttons feel real).
+   Selector is `.v2-root button.` per the documented reset trap (v2.css:755,
+   #870): the global button reset is 0-2-1 and anything weaker renders as
+   plain prose — this file's first cut proved it locally, again. */
+.v2-root button.v2-pcat__cta {
   margin-left: auto;
-  padding: 7px 16px;
+  padding: 9px 18px;
   font-size: 13px;
-  font-weight: 600;
+  font-weight: 700;
   color: #fff;
   background: var(--v2-accent);
   border: none;
-  border-radius: var(--v2-radius-md, 8px);
+  border-radius: 12px;
   cursor: pointer;
-  transition: background 80ms ease;
+  box-shadow: -4px -4px 10px var(--neo-shadow-light), 4px 4px 12px rgba(47, 111, 235, 0.35);
+  transition: box-shadow 100ms ease, transform 100ms ease, background 80ms ease;
 }
-.v2-pcat__cta:hover { background: var(--v2-accent-strong); }
+.v2-root button.v2-pcat__cta:hover { background: var(--v2-accent-strong); }
+.v2-root button.v2-pcat__cta:active { transform: translateY(1px); box-shadow: inset 3px 3px 8px rgba(0, 0, 0, 0.25); }
 .v2-pcat__soon-note {
   margin-left: auto;
   font-size: 12px;
-  color: var(--v2-text-secondary);
+  color: var(--neo-ink-2);
 }
 
 .v2-pcat__foot {
@@ -201,7 +220,10 @@
   gap: 12px;
   margin-top: 24px;
   font-size: 12.5px;
-  color: var(--v2-text-secondary);
+  color: var(--neo-ink-2);
 }
-.v2-pcat__manage { color: var(--v2-text-secondary); }
-.v2-pcat__manage:hover { color: var(--v2-text); }
+.v2-pcat__manage { color: var(--neo-ink-2); }
+.v2-pcat__manage:hover { color: var(--neo-ink); }
+
+/* Owner avatar-edit affordances (agent profile shares this sheet) keep their
+   flat styling on that un-migrated surface. */

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -14,6 +14,24 @@
   --v2-border: #e5e7eb;
   --v2-border-soft: #eef0f6;
   --v2-border-strong: #d7dce7;
+
+  /* ── Neumorphic layer (Sam's shell direction, accepted 2026-08-22) ──
+     skillsui neumorphism recipe with OUR constants: Slate Mist ground,
+     cobalt on action only, SF stack. Core physics: an element's background
+     MUST equal its page ground — depth comes only from the dual shadow.
+     Additive: surfaces migrate one at a time (persona catalog is the
+     pilot); un-migrated surfaces keep the flat token set above. */
+  --neo-surface: #d8dce6;
+  --neo-surface-deep: #cbd0dd;
+  --neo-ink: #2a2e38;
+  --neo-ink-2: #6a7183;
+  --neo-shadow-light: rgba(255, 255, 255, 0.85);
+  --neo-shadow-dark: rgba(146, 156, 176, 0.55);
+  --neo-raised: -6px -6px 14px var(--neo-shadow-light), 6px 6px 14px var(--neo-shadow-dark);
+  --neo-raised-soft: -3px -3px 8px var(--neo-shadow-light), 3px 3px 8px var(--neo-shadow-dark);
+  --neo-raised-lg: -8px -8px 18px var(--neo-shadow-light), 8px 8px 18px var(--neo-shadow-dark);
+  --neo-inset: inset -4px -4px 10px var(--neo-shadow-light), inset 4px 4px 10px var(--neo-shadow-dark);
+  --neo-inset-soft: inset -2px -2px 5px var(--neo-shadow-light), inset 2px 2px 5px var(--neo-shadow-dark);
   --v2-text-primary: #111827;
   --v2-text-secondary: #4b5563;
   --v2-text-tertiary: #7b8494;


### PR DESCRIPTION
Sam accepted the direction proof verbatim ('Perfect, we take it') and set the process rule: new visual work develops separately and verifies locally first. This PR is exactly that: the additive --neo-* token layer in both design-system files + the persona catalog as pilot surface, verified on a clean local clone against the prod API (vite + Playwright, computed-style checks) BEFORE any deploy — which caught the #870 button-reset trap eating the CTA fill, on localhost instead of production. Draft on purpose: merges after Sam/ux-lead review, not by watcher. Rollout order for remaining surfaces belongs to ux-lead's TASK-036 direction doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeUH4HVDsDHYPsHJthXjB8