### PR TITLE
feat(threading): thread_root_id — schema, derivation on write, backfill (TASK-029, 1/4)

### DIFF
--- a/backend/TESTING.md
+++ b/backend/TESTING.md
@@ -45,6 +45,20 @@ cd backend && INTEGRATION_TEST=true \
 
 Schema source: `backend/config/schema.sql`. `testUtils.setupPgDb()` applies it verbatim after `CREATE EXTENSION IF NOT EXISTS pgcrypto`.
 
+> **Blind spot both tiers share: neither exercises an EXISTING database.**
+> Tier 1 provisions a fresh `postgres:16` per CI run, so `CREATE TABLE IF NOT
+> EXISTS` always takes the CREATE branch. Tier 0 reads `schema.sql` as text.
+> A column added to an existing table therefore needs a *third* arrangement to
+> be tested at all: start from the pre-threading table shape, apply the
+> retrofit `ALTER`s, assert the column appears. See
+> `__tests__/unit/models/threadingSchemaRetrofit.test.js`.
+>
+> This is not hypothetical. On 2026-08-22 `thread_root_id` shipped declared
+> only inside its `CREATE TABLE`; both tiers were green and the column would
+> never have existed on the live instance, throwing at boot on the index and
+> failing every INSERT that named it. Any PR adding a column to an existing
+> table should be read for both declarations.
+
 Tier-1 setup logs `[tier1] Connected to real MongoDB …` and `[tier1] Connected to real Postgres …` so the CI run log makes the mode obvious.
 
 ## Test helpers (`__tests__/utils/testUtils.js`)

--- a/backend/__tests__/service/threading.derivation.test.js
+++ b/backend/__tests__/service/threading.derivation.test.js
@@ -1,0 +1,208 @@
+/**
+ * Threading derivation — EXECUTED against a real Postgres (W-T, TASK-029, 1/4).
+ *
+ * @sprint-review blocked #1106 on exactly this: the unit tests are regexes over
+ * Message.ts and schema.sql as strings, and nothing runs the SQL. A regex
+ * proves the query was written; it cannot prove the query is correct, and the
+ * two claims that matter here are both about what Postgres DOES —
+ *
+ *   1. COALESCE(parent.thread_root_id, parent.id) collapses ANY depth to the
+ *      one true root, using a single parent lookup.
+ *   2. The backfill's recursive CTE produces the same roots as the write path.
+ *
+ * Tier 1 only. pg-mem cannot run this — probed 2026-08-22: it rejects
+ * `WITH RECURSIVE` outright ("your query failed to parse") and mistypes the
+ * parameterised INSERT. So there is no in-process shortcut; it is a real
+ * server or it is nothing. CI provides postgres:16 with INTEGRATION_TEST=true.
+ */
+
+const { Pool } = require('pg');
+// The SHIPPED model, not a copy of its SQL. Re-typing the INSERT here would
+// test the test: the derivation could be corrected in one place and stay wrong
+// in production. This is the same code path createMessage takes.
+const PGMessage = require('../../models/pg/Message');
+
+const RUN = process.env.INTEGRATION_TEST === 'true';
+// describe.skip would report "skipped" in a way that reads like coverage.
+// Skipping is honest; pretending is not.
+const d = RUN ? describe : describe.skip;
+
+let pool;
+// VARCHAR(24) — the pods PK is a Mongo ObjectId string, and messages.pod_id
+// has an FK to it. The first run of this suite failed on exactly that, which
+// is the point: a regex over the SQL cannot discover a foreign key.
+const POD = 'aaaaaaaaaaaaaaaaaaaaaa01';
+const USER = 'bbbbbbbbbbbbbbbbbbbbbb01';
+
+const connect = () => new Pool({
+  host: process.env.PG_HOST,
+  port: Number(process.env.PG_PORT || 5432),
+  database: process.env.PG_DATABASE,
+  user: process.env.PG_USER,
+  password: process.env.PG_PASSWORD,
+  ssl: false,
+});
+
+const seed = async () => {
+  await pool.query(
+    `INSERT INTO users (_id, username) VALUES ($1,'tester') ON CONFLICT (_id) DO NOTHING`, [USER],
+  );
+  await pool.query(
+    `INSERT INTO pods (id, name, type, created_by) VALUES ($1,'threading','chat',$2)
+     ON CONFLICT (id) DO NOTHING`, [POD, USER],
+  );
+};
+
+const insert = (content, replyTo = null) => PGMessage.create(POD, USER, content, 'text', replyTo);
+
+d('thread_root_id derivation, executed', () => {
+  beforeAll(async () => {
+    pool = connect();
+    const fs = require('fs');
+    const path = require('path');
+    await pool.query(fs.readFileSync(path.join(__dirname, '../../config/schema.sql'), 'utf8'));
+    await seed();
+  });
+
+  afterAll(async () => { if (pool) await pool.end(); });
+  beforeEach(async () => { await pool.query('DELETE FROM messages WHERE pod_id = $1', [POD]); });
+
+  test('a root has no thread_root_id — NULL, not self-referential', async () => {
+    const root = await insert('the root');
+    // A root pointing at itself would make "is this a root" a comparison
+    // instead of a null check, and every consumer would have to know that.
+    expect(root.thread_root_id).toBeNull();
+  });
+
+  test('a direct reply inherits the root id', async () => {
+    const root = await insert('the root');
+    const reply = await insert('first reply', root.id);
+    expect(reply.thread_root_id).toBe(root.id);
+    expect(reply.reply_to_message_id).toBe(root.id);
+  });
+
+  test('THE claim: one parent lookup collapses a 7-deep chain to one root', async () => {
+    // This is what a regex over the SQL cannot check. The subquery reads only
+    // the immediate parent, and the invariant is that this suffices at any
+    // depth because the parent already stored its own root.
+    const root = await insert('depth 1');
+    let prev = root;
+    const chain = [];
+    for (let i = 2; i <= 7; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      prev = await insert(`depth ${i}`, prev.id);
+      chain.push(prev);
+    }
+    for (const row of chain) expect(row.thread_root_id).toBe(root.id);
+    // And the deep rows genuinely differ from the addressing edge — the
+    // property the whole two-column design rests on.
+    expect(chain[chain.length - 1].reply_to_message_id).not.toBe(root.id);
+  });
+
+  test('two threads in one pod do not merge', async () => {
+    const a = await insert('root A');
+    const b = await insert('root B');
+    const ra = await insert('reply to A', a.id);
+    const rb = await insert('reply to B', b.id);
+    expect(ra.thread_root_id).toBe(a.id);
+    expect(rb.thread_root_id).toBe(b.id);
+    expect(ra.thread_root_id).not.toBe(rb.thread_root_id);
+  });
+
+  test('a reply to a missing parent is REJECTED, not silently rooted at NULL', async () => {
+    // Corrects the backfill script's own comment. It says orphaned chains
+    // "stay NULL by design", implying a bad edge can be written and later
+    // renders unthreaded. Executed, the FK on reply_to_message_id refuses the
+    // row outright — so an orphan can only be created by DELETING a parent
+    // afterwards, never by writing a bad edge. That is a stronger guarantee
+    // than the comment claimed, and the unit tests could not have found it
+    // because no regex over the SQL sees a foreign key.
+    // 999999 does not exist, so the FK on reply_to_message_id rejects the row
+    // outright — the derivation subquery never even gets to return NULL.
+    // Worth executing rather than assuming: it means an orphan can only be
+    // CREATED by deleting a parent later, never by writing a bad edge, which
+    // is a stronger guarantee than the script's comment claims.
+    // Must fail for the RIGHT reason. The suite's first run "passed" this
+    // assertion because pod_id's FK rejected every insert — a control that
+    // shares the failure mode proves nothing.
+    await expect(insert('reply to nothing', 999999))
+      .rejects.toThrow(/messages_reply_to_message_id_fkey|violates foreign key/);
+    // Positive control: the same call with a REAL parent succeeds, so the
+    // rejection above is about the missing parent and nothing else.
+    const root = await insert('a real root');
+    await expect(insert('a real reply', root.id)).resolves.toBeTruthy();
+  });
+
+  test('deleting a root nulls its replies\' roots rather than deleting them', async () => {
+    // ON DELETE SET NULL, executed. A CASCADE here would delete a whole
+    // conversation because one message was removed.
+    const root = await insert('the root');
+    const reply = await insert('a reply', root.id);
+    await pool.query('DELETE FROM messages WHERE id = $1', [root.id]);
+    const { rows } = await pool.query('SELECT * FROM messages WHERE id = $1', [reply.id]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].thread_root_id).toBeNull();
+  });
+});
+
+d('the backfill CTE agrees with the write path', () => {
+  beforeAll(async () => {
+    pool = connect();
+    await seed();
+  });
+  afterAll(async () => {
+    if (pool) await pool.end();
+    // PGMessage.create uses the module-level pool from config/db-pg — the same
+    // one production uses, which is why this suite exercises the real path.
+    // It has to be closed too or jest hangs on an open handle.
+    // eslint-disable-next-line global-require
+    const { pool: modelPool } = require('../../config/db-pg');
+    if (modelPool?.end) await modelPool.end();
+  });
+  beforeEach(async () => { await pool.query('DELETE FROM messages WHERE pod_id = $1', [POD]); });
+
+  test('the CTE recomputes exactly the roots the write path derived', async () => {
+    // The two implementations must not be able to disagree — one runs per
+    // message forever, the other ran once over history. A regex can confirm
+    // both exist; only execution can confirm they agree.
+    const root = await insert('root');
+    let prev = root;
+    for (let i = 0; i < 6; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      prev = await insert(`level ${i}`, prev.id);
+    }
+    const { rows } = await pool.query(
+      `WITH RECURSIVE chain AS (
+         SELECT id, reply_to_message_id, id AS root FROM messages
+          WHERE reply_to_message_id IS NULL AND pod_id = $1
+         UNION ALL
+         SELECT m.id, m.reply_to_message_id, c.root
+           FROM messages m JOIN chain c ON m.reply_to_message_id = c.id
+       )
+       SELECT m.id, m.thread_root_id AS written, chain.root AS recomputed
+         FROM messages m JOIN chain ON chain.id = m.id
+        WHERE m.reply_to_message_id IS NOT NULL`,
+      [POD],
+    );
+    expect(rows).toHaveLength(6);
+    for (const r of rows) expect(Number(r.written)).toBe(Number(r.recomputed));
+  });
+
+  test('the CTE is order-independent — inserting children before the walk changes nothing', async () => {
+    const root = await insert('root');
+    const a = await insert('a', root.id);
+    await insert('b', a.id);
+    await insert('c', root.id);
+    const { rows } = await pool.query(
+      `WITH RECURSIVE chain AS (
+         SELECT id, id AS root FROM messages WHERE reply_to_message_id IS NULL AND pod_id = $1
+         UNION ALL
+         SELECT m.id, c.root FROM messages m JOIN chain c ON m.reply_to_message_id = c.id
+       )
+       SELECT count(DISTINCT root)::int AS roots, count(*)::int AS n FROM chain`,
+      [POD],
+    );
+    expect(rows[0].roots).toBe(1);
+    expect(rows[0].n).toBe(4);
+  });
+});

--- a/backend/__tests__/unit/models/threadRootDerivation.pgmem.test.js
+++ b/backend/__tests__/unit/models/threadRootDerivation.pgmem.test.js
@@ -1,0 +1,103 @@
+/**
+ * thread_root_id derivation, EXECUTED at the unit tier (W-T, TASK-029, 1/4).
+ *
+ * @sprint-review (56787): the depth claim was asserted by grepping for the
+ * COALESCE substring that implements it — assertion and thing asserted are the
+ * same text, so it cannot discriminate. They proposed pg-mem: insert A, B→A,
+ * C→B, assert C's root is A; mutate COALESCE to `parent.id` and it must go red.
+ *
+ * They were right and my first answer was too broad. I had probed pg-mem,
+ * found `WITH RECURSIVE` unsupported, and generalised that to "pg-mem cannot
+ * run this". Only the backfill's recursive CTE is out of reach — the write-path
+ * derivation runs fine once the scalar subquery is cast (pg-mem otherwise
+ * types it as `integer[]`). The production query now carries those casts,
+ * which are inert in Postgres, so what runs below is the REAL string.
+ *
+ * This is the fast tier and it runs in plain `npm test`. The tier-1 suite
+ * (__tests__/service/threading.derivation.test.js) still exists for what needs
+ * a real server: the recursive CTE, the foreign keys, ON DELETE SET NULL.
+ */
+
+const { newDb } = require('pg-mem');
+
+// `mock`-prefixed so jest's hoisted factory below may reference it — the
+// factory runs before ordinary module scope, and jest only exempts names it
+// can see are mocks.
+const mockDb = newDb();
+const mockPool = new (mockDb.adapters.createPg().Pool)();
+
+// The model reads its pool from here. Pointing that at pg-mem is what makes
+// this exercise the shipped code path rather than a re-typed copy of its SQL.
+jest.mock('../../../config/db-pg', () => ({ pool: mockPool }));
+
+const PGMessage = require('../../../models/pg/Message');
+
+const POD = 'pod-1';
+const insert = (content, replyTo = null) => PGMessage.create(POD, 'user-1', content, 'text', replyTo);
+
+beforeAll(async () => {
+  // Only the columns the derivation touches. No FKs to pods/users: those are
+  // real and are covered by the tier-1 suite, and adding them here would make
+  // this a slower copy of that instead of a fast complement to it.
+  await mockPool.query(`CREATE TABLE messages (
+    id SERIAL PRIMARY KEY,
+    pod_id VARCHAR(255) NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    content TEXT,
+    message_type VARCHAR(50) DEFAULT 'text',
+    payload JSONB,
+    reply_to_message_id INTEGER REFERENCES messages(id) ON DELETE SET NULL,
+    thread_root_id INTEGER REFERENCES messages(id) ON DELETE SET NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+  )`);
+  await mockPool.query(`CREATE TABLE pods (
+    id VARCHAR(255) PRIMARY KEY, updated_at TIMESTAMP WITH TIME ZONE
+  )`);
+  await mockPool.query("INSERT INTO pods (id) VALUES ('pod-1')");
+});
+
+describe('the derivation runs, and depth is the thing it proves', () => {
+  test('a root gets NULL, not itself', async () => {
+    const root = await insert('root');
+    expect(root.thread_root_id).toBeNull();
+  });
+
+  test('a direct reply inherits the root id', async () => {
+    const root = await insert('root');
+    const reply = await insert('reply', root.id);
+    expect(reply.thread_root_id).toBe(root.id);
+  });
+
+  test("sprint-review's case: A, B→A, C→B — C's root is A, not B", async () => {
+    const a = await insert('A');
+    const b = await insert('B', a.id);
+    const c = await insert('C', b.id);
+    expect(b.thread_root_id).toBe(a.id);
+    expect(c.thread_root_id).toBe(a.id);
+    // The discriminating half. With `parent.id` instead of COALESCE, C's root
+    // would be B — which is also C's reply edge, so the two columns would
+    // collapse and the whole design would be redundant.
+    expect(c.thread_root_id).not.toBe(c.reply_to_message_id);
+  });
+
+  test('depth 7 — the deepest chain on live data — still resolves to one root', async () => {
+    const root = await insert('depth 1');
+    let prev = root;
+    const chain = [];
+    for (let i = 2; i <= 7; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      prev = await insert(`depth ${i}`, prev.id);
+      chain.push(prev);
+    }
+    for (const row of chain) expect(row.thread_root_id).toBe(root.id);
+  });
+
+  test('two chains in one pod stay separate', async () => {
+    const a = await insert('root A');
+    const b = await insert('root B');
+    const deepA = await insert('a2', (await insert('a1', a.id)).id);
+    const deepB = await insert('b2', (await insert('b1', b.id)).id);
+    expect(deepA.thread_root_id).toBe(a.id);
+    expect(deepB.thread_root_id).toBe(b.id);
+  });
+});

--- a/backend/__tests__/unit/models/threadRootDerivation.test.js
+++ b/backend/__tests__/unit/models/threadRootDerivation.test.js
@@ -1,0 +1,81 @@
+/**
+ * thread_root_id is derived on write and carries no addressing (W-T, TASK-029).
+ *
+ * The property that matters most is the SEPARATION, not the derivation: the
+ * root must never acquire the addressing semantics reply_to_message_id has.
+ * `reply_to_message_id` feeds `isRouted` (agentMentionService:1025) and the
+ * implicit-reply chat.mention (:1356), so if thread membership rode that
+ * column, joining a thread would ping the parent's author — the opposite of
+ * what ambient scoping is for.
+ *
+ * These assert the SQL the write path actually issues, because the derivation
+ * is a subquery inside the INSERT rather than JS: there is no function to call.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const SRC = fs.readFileSync(
+  path.join(__dirname, '../../../models/pg/Message.ts'),
+  'utf8',
+);
+const SCHEMA = fs.readFileSync(
+  path.join(__dirname, '../../../config/schema.sql'),
+  'utf8',
+);
+
+describe('schema', () => {
+  it('thread_root_id exists and is a separate column from the reply edge', () => {
+    expect(SCHEMA).toMatch(/thread_root_id INTEGER REFERENCES messages\(id\) ON DELETE SET NULL/);
+    expect(SCHEMA).toMatch(/reply_to_message_id INTEGER REFERENCES messages\(id\) ON DELETE SET NULL/);
+  });
+
+  it('is indexed — the reason the root is stored rather than walked', () => {
+    expect(SCHEMA).toMatch(/CREATE INDEX IF NOT EXISTS idx_messages_thread_root_id ON messages\(thread_root_id\)/);
+  });
+
+  it('ON DELETE SET NULL, so deleting a root unthreads rather than orphaning', () => {
+    const line = SCHEMA.split('\n').find((l) => l.includes('thread_root_id INTEGER'));
+    expect(line).toContain('ON DELETE SET NULL');
+  });
+});
+
+describe('derivation on write', () => {
+  it('takes COALESCE(parent.thread_root_id, parent.id) — one level covers any depth', () => {
+    // A reply to a root gets that root's id; a reply to a reply inherits the
+    // root its parent already stored. Without the COALESCE, depth-3+ replies
+    // would take their immediate parent as the root and split one thread into
+    // many. Measured max depth on live data: 7.
+    expect(SRC).toMatch(/COALESCE\(parent\.thread_root_id, parent\.id\)/);
+  });
+
+  it('derives from the reply edge and nothing else', () => {
+    const insert = SRC.slice(SRC.indexOf('INSERT INTO messages'), SRC.indexOf('RETURNING *'));
+    expect(insert).toContain('thread_root_id');
+    expect(insert).toMatch(/WHERE parent\.id = \$5/); // $5 is replyToMessageId
+  });
+
+  it('a message with no reply edge gets a NULL root, not its own id', () => {
+    // A root's own thread_root_id stays NULL. If roots pointed at themselves,
+    // "is this threaded" would stop being expressible as IS NULL, and every
+    // ambient message in the pod would look like a one-message thread.
+    const insert = SRC.slice(SRC.indexOf('INSERT INTO messages'), SRC.indexOf('RETURNING *'));
+    expect(insert).not.toMatch(/COALESCE\([^)]*\bid\b[^)]*\)\s*AS\s+thread_root/i);
+    expect(insert).toContain('SELECT COALESCE(parent.thread_root_id, parent.id)');
+  });
+});
+
+describe('the separation from addressing', () => {
+  it('the schema records WHY the two columns cannot be one', () => {
+    // This comment is the guard. A future reader seeing two columns that both
+    // reference messages(id) will reasonably try to collapse them.
+    expect(SCHEMA).toMatch(/ADDRESSING edge/);
+    expect(SCHEMA).toMatch(/thread_root_id carries no\s*--?\s*addressing/);
+  });
+
+  it('the write path does not touch reply_to_message_id semantics', () => {
+    // Derivation READS the parent's root; it must not write or alter any
+    // addressing field.
+    const insert = SRC.slice(SRC.indexOf('INSERT INTO messages'), SRC.indexOf('RETURNING *'));
+    expect(insert).not.toMatch(/UPDATE|SET reply_to/);
+  });
+});

--- a/backend/__tests__/unit/models/threadingCutoffRecord.test.js
+++ b/backend/__tests__/unit/models/threadingCutoffRecord.test.js
@@ -1,0 +1,85 @@
+/**
+ * The threading cutoff has somewhere to live, and the backfill records it
+ * (W-T, TASK-029, 1/4).
+ *
+ * #1115 rules that pre-cutoff thread roots render expanded, with the cutoff
+ * "read from the migration record". @sprint-review (56859) found there is no
+ * such record: no migrations table anywhere under backend/, schema.sql is
+ * idempotent boot DDL, and the backfill wrote nothing. The ruling referenced a
+ * thing that did not exist.
+ *
+ * These pin the two decisions that make it exist correctly, both of which are
+ * ordering/semantics rather than SQL mechanics.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const read = (p) => fs.readFileSync(path.join(__dirname, '../../../', p), 'utf8');
+const SCHEMA = read('config/schema.sql');
+const SCRIPT = read('scripts/backfill-thread-root-id.ts');
+
+describe('the ledger is general, not threading-shaped', () => {
+  it('exists at all', () => {
+    expect(SCHEMA).toMatch(/CREATE TABLE IF NOT EXISTS migration_records/);
+  });
+
+  it('is keyed by migration name with a JSONB details column', () => {
+    // details is what lets a migration record something only IT knew. Without
+    // it, the threading cutoff needs its own table and the next one needs
+    // another.
+    expect(SCHEMA).toMatch(/name VARCHAR\(255\) PRIMARY KEY/);
+    expect(SCHEMA).toMatch(/details JSONB/);
+  });
+
+  it('is not a threading-specific table', () => {
+    // The one-off version is the thing that has to be generalised later, and
+    // later is when it gets done wrong.
+    expect(SCHEMA).not.toMatch(/CREATE TABLE IF NOT EXISTS threading_migration/);
+    expect(SCHEMA).not.toMatch(/threading_cutoff\s+TIMESTAMP/);
+  });
+
+  it('says in the schema that it is a ledger, not a runner', () => {
+    // A reader must never infer "migration X has not run" from a missing row.
+    expect(SCHEMA).toMatch(/NOT a migration RUNNER/);
+  });
+});
+
+describe('the cutoff is measured before it becomes unmeasurable', () => {
+  it('is defined as the newest row with a reply edge and no root', () => {
+    // That predicate IS "written before derivation-on-write shipped" — exact,
+    // not a deploy timestamp guessed after the fact.
+    expect(SCRIPT).toMatch(/SELECT MAX\(created_at\) AS cutoff[\s\S]{0,120}reply_to_message_id IS NOT NULL AND thread_root_id IS NULL/);
+  });
+
+  it('is read BEFORE the UPDATE, because the UPDATE destroys the predicate', () => {
+    const cutoffRead = SCRIPT.indexOf('const { rows: [boundary] } = await pool.query(CUTOFF_SQL);\n\n    const result');
+    const update = SCRIPT.indexOf('UPDATE messages m');
+    expect(cutoffRead).toBeGreaterThan(-1);
+    expect(cutoffRead).toBeLessThan(update);
+  });
+
+  it('is written to the ledger with the row counts that produced it', () => {
+    expect(SCRIPT).toMatch(/INSERT INTO migration_records \(name, details\)/);
+    expect(SCRIPT).toMatch(/threadingCutoff: boundary\.cutoff/);
+  });
+
+  it('a second run does NOT move the boundary', () => {
+    // DO NOTHING, not DO UPDATE. By the second run the population the first
+    // one measured no longer exists, so re-deriving would overwrite a true
+    // boundary the surface is already rendering against with a false one.
+    expect(SCRIPT).toMatch(/ON CONFLICT \(name\) DO NOTHING/);
+    expect(SCRIPT).not.toMatch(/ON CONFLICT \(name\) DO UPDATE/);
+  });
+
+  it('the dry run reports the cutoff it would record', () => {
+    // A boundary that only appears after --apply cannot be checked first.
+    const dry = SCRIPT.slice(SCRIPT.indexOf('if (!APPLY)'), SCRIPT.indexOf('DRY RUN — nothing written'));
+    expect(dry).toMatch(/CUTOFF_SQL/);
+  });
+
+  it('NULL is documented as "no pre-cutoff roots", not "unknown"', () => {
+    // The dangerous misreading: a fresh instance has no pre-threading history,
+    // and treating NULL as unknown would expand every thread on it.
+    expect(SCRIPT).toMatch(/never as "unknown, assume everything is pre-cutoff"/);
+  });
+});

--- a/backend/__tests__/unit/models/threadingSchemaRetrofit.test.js
+++ b/backend/__tests__/unit/models/threadingSchemaRetrofit.test.js
@@ -1,0 +1,111 @@
+/**
+ * schema.sql must reach an EXISTING database, not only a fresh one
+ * (W-T, TASK-029, 1/4).
+ *
+ * The bug this exists for was live in #1106 and would have broken chat posting
+ * on every existing instance. `thread_root_id` was declared only inside
+ * `CREATE TABLE IF NOT EXISTS messages`, which is a no-op where the table
+ * already exists — so the column would never have been created, the index
+ * would have thrown at boot, and every PGMessage.create INSERT would have
+ * named a column that does not exist.
+ *
+ * Nothing I ran could catch it. The unit tests read the DDL as text and saw a
+ * column declaration; the tier-1 suite provisions a FRESH postgres:16 per CI
+ * run, so it exercises the CREATE path and never the ALTER path. Both were
+ * green. It was found by @sprint-review's caveat that CREATE TABLE IF NOT
+ * EXISTS cannot retrofit a constraint — the same sentence applies to columns,
+ * and I had verified the FK claim without noticing the column claim rode on it.
+ *
+ * So this suite starts from the OLD table shape and applies the schema on top.
+ * That is the only arrangement in which the defect is visible.
+ */
+const fs = require('fs');
+const path = require('path');
+const { newDb } = require('pg-mem');
+
+const SCHEMA = fs.readFileSync(path.join(__dirname, '../../../config/schema.sql'), 'utf8');
+
+// The messages table as it existed BEFORE threading — what a real instance has.
+const OLD_MESSAGES = `
+  CREATE TABLE messages (
+    id SERIAL PRIMARY KEY,
+    pod_id VARCHAR(255) NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    content TEXT,
+    message_type VARCHAR(50) DEFAULT 'text',
+    reply_to_message_id INTEGER REFERENCES messages(id) ON DELETE SET NULL,
+    payload JSONB,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+  )`;
+
+const columnsOf = async (pool, table) => {
+  const { rows } = await pool.query(
+    `SELECT column_name FROM information_schema.columns WHERE table_name = '${table}'`,
+  );
+  return rows.map((r) => r.column_name);
+};
+
+// pg-mem cannot run all of schema.sql (extensions, some DDL), so apply only the
+// statements that matter here: the retrofit ALTERs. Extracting them by pattern
+// is deliberate — it means a retrofit that is never written is a retrofit this
+// test cannot find, which is exactly the failure being guarded.
+const alters = SCHEMA.split('\n')
+  .filter((l) => /^ALTER TABLE messages ADD COLUMN IF NOT EXISTS/i.test(l.trim()))
+  .map((l) => l.trim());
+const multiLineAlters = [...SCHEMA.matchAll(/ALTER TABLE messages\s*\n\s*ADD COLUMN IF NOT EXISTS[^;]*;/gi)]
+  .map((m) => m[0].replace(/\s+/g, ' '));
+
+describe('every late column on messages is retrofitted, not just declared', () => {
+  test('thread_root_id has an ALTER — the CREATE TABLE alone cannot reach an existing instance', () => {
+    const all = [...alters, ...multiLineAlters].join('\n');
+    expect(all).toMatch(/thread_root_id/);
+  });
+
+  test('applied to a PRE-EXISTING messages table, the column appears', async () => {
+    // The discriminating case. On a fresh database the CREATE TABLE supplies
+    // the column and this passes for the wrong reason, which is precisely how
+    // the defect survived CI.
+    const db = newDb();
+    const pool = new (db.adapters.createPg().Pool)();
+    await pool.query(OLD_MESSAGES);
+    expect(await columnsOf(pool, 'messages')).not.toContain('thread_root_id');
+
+    for (const stmt of [...alters, ...multiLineAlters]) {
+      // eslint-disable-next-line no-await-in-loop
+      await pool.query(stmt);
+    }
+
+    expect(await columnsOf(pool, 'messages')).toContain('thread_root_id');
+  });
+
+  test('CONTROL: the old shape genuinely lacks it, so the test above measures something', async () => {
+    const db = newDb();
+    const pool = new (db.adapters.createPg().Pool)();
+    await pool.query(OLD_MESSAGES);
+    const cols = await columnsOf(pool, 'messages');
+    expect(cols).toContain('reply_to_message_id');
+    expect(cols).not.toContain('thread_root_id');
+  });
+
+  test('the retrofits are idempotent — boot DDL runs on every start', async () => {
+    const db = newDb();
+    const pool = new (db.adapters.createPg().Pool)();
+    await pool.query(OLD_MESSAGES);
+    for (let i = 0; i < 3; i += 1) {
+      for (const stmt of [...alters, ...multiLineAlters]) {
+        // eslint-disable-next-line no-await-in-loop
+        await pool.query(stmt);
+      }
+    }
+    expect(await columnsOf(pool, 'messages')).toContain('thread_root_id');
+  });
+
+  test('the index on thread_root_id is created AFTER the retrofit that adds it', () => {
+    // Ordering is load-bearing: CREATE INDEX on a column that does not exist
+    // yet throws at boot, taking the whole backend down rather than degrading.
+    const alterAt = SCHEMA.search(/ADD COLUMN IF NOT EXISTS thread_root_id/i);
+    const indexAt = SCHEMA.indexOf('idx_messages_thread_root_id ON messages(thread_root_id)');
+    expect(alterAt).toBeGreaterThan(-1);
+    expect(indexAt).toBeGreaterThan(alterAt);
+  });
+});

--- a/backend/__tests__/unit/services/agentMentionService.threadingIsNotAddressing.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.threadingIsNotAddressing.test.js
@@ -1,0 +1,206 @@
+/**
+ * Threading is not addressing (W-T, TASK-029, 1/4).
+ *
+ * `thread_root_id` and `reply_to_message_id` are deliberately separate columns.
+ * The reason is a behaviour, not a preference: `reply_to_message_id` is an
+ * ADDRESSING edge — it feeds `isRouted` (agentMentionService:1061) and resolves
+ * an implicit-reply `chat.mention` (:1392). Express thread membership through
+ * it and joining a thread becomes identical to pinging the parent's author,
+ * which is the opposite of what ambient-only scoping is for (#1045).
+ *
+ * @sprint-review (56773/56777): a comment saying "these can't be one column" is
+ * exactly what a later refactor deletes. The discriminating assertion is that
+ * setting a thread root alone enqueues NO chat.mention — that fails the moment
+ * someone routes threading back through the addressing edge, which prose can't.
+ *
+ * Every "nothing was enqueued" case here is paired with a control that DOES
+ * enqueue. An assertion that nothing happened is worthless from an instrument
+ * that cannot make anything happen.
+ */
+
+jest.mock('../../../services/agentEventService', () => ({ enqueue: jest.fn() }));
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { find: jest.fn(), findOne: jest.fn() },
+}));
+jest.mock('../../../models/AgentProfile', () => ({ find: jest.fn() }));
+jest.mock('../../../models/Pod', () => ({ findById: jest.fn(), find: jest.fn() }));
+jest.mock('../../../models/User', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../../../services/chatSummarizerService', () => ({
+  constructor: { getLatestPodSummary: jest.fn() },
+  summarizePodMessages: jest.fn(),
+}));
+jest.mock('../../../models/AgentEvent', () => ({ countDocuments: jest.fn() }));
+jest.mock('../../../services/welcomeWakeService', () => ({ maybeFireWelcomeWake: jest.fn() }));
+
+const AgentMentionService = require('../../../services/agentMentionService');
+const AgentEventService = require('../../../services/agentEventService');
+const { AgentInstallation } = require('../../../models/AgentRegistry');
+const AgentProfile = require('../../../models/AgentProfile');
+const Pod = require('../../../models/Pod');
+const User = require('../../../models/User');
+const AgentEvent = require('../../../models/AgentEvent');
+
+const SEAT = { agentName: 'seat-a', instanceId: 'default', displayName: 'Seat A' };
+const SEAT_OPTED_IN = { ...SEAT, config: { wakeOnMessage: { enabled: true } } };
+
+const mockInstallations = (installations) => {
+  AgentInstallation.find.mockReturnValue({ lean: jest.fn().mockResolvedValue(installations) });
+  AgentProfile.find.mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+};
+
+// Dispatches on id: the SENDER is human, the message being replied to was
+// authored by the bot. A single blanket mock cannot express that, and the
+// implicit-reply path only fires when the two differ in exactly this way.
+const mockUsers = () => {
+  User.findById.mockImplementation((id) => ({
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue(
+      String(id) === 'bot-1'
+        ? { _id: 'bot-1', isBot: true, botMetadata: { agentName: 'seat-a', instanceId: 'default' } }
+        : { _id: 'user-1', isBot: false },
+    ),
+  }));
+};
+
+const byType = (t) => AgentEventService.enqueue.mock.calls.map(([a]) => a).filter((a) => a.type === t);
+const mentions = () => byType('chat.mention');
+const wakes = () => byType('message.posted');
+
+const send = (message) => AgentMentionService.enqueueMentions({
+  podId: 'pod-1', userId: 'user-1', username: 'alice', ...message,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUsers();
+  Pod.findById.mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue({ type: 'chat', members: ['user-1', 'bot-1'] }),
+    }),
+    lean: jest.fn().mockResolvedValue({ _id: 'pod-1', type: 'chat', members: ['user-1', 'bot-1'] }),
+  });
+  AgentEvent.countDocuments.mockResolvedValue(0);
+});
+
+describe('a thread root alone addresses nobody', () => {
+  test('a threaded message with no reply edge and no mention enqueues NO chat.mention', async () => {
+    mockInstallations([SEAT]);
+
+    await send({
+      message: {
+        id: 'msg-2',
+        content: 'adding a thought to this thread',
+        // The thread root is carried on the row. It must reach the mention
+        // pipeline as inert data, or as nothing at all.
+        thread_root_id: 101,
+        threadRootId: 101,
+      },
+    });
+
+    expect(mentions()).toHaveLength(0);
+  });
+
+  test('CONTROL: the same message WITH a reply edge to the bot DOES enqueue one', async () => {
+    // Without this the test above passes just as well from a broken harness.
+    mockInstallations([SEAT]);
+
+    await send({
+      message: {
+        id: 'msg-2',
+        content: 'adding a thought to this thread',
+        thread_root_id: 101,
+        replyTo: { userId: 'bot-1' },
+      },
+      replyToMessageId: '101',
+    });
+
+    const got = mentions();
+    expect(got).toHaveLength(1);
+    expect(got[0]).toMatchObject({ agentName: 'seat-a', type: 'chat.mention' });
+  });
+
+  test('a deep thread root — many levels in — still addresses nobody', async () => {
+    // The derivation collapses depth: every reply in a 7-deep chain carries the
+    // SAME root. If a root ever addressed its author, one message would ping
+    // them on behalf of an entire conversation.
+    mockInstallations([SEAT]);
+
+    await send({
+      message: { id: 'msg-90', content: 'seven levels deep', thread_root_id: 101, threadRootId: 101 },
+    });
+
+    expect(mentions()).toHaveLength(0);
+  });
+});
+
+describe('threading does not suppress addressing either', () => {
+  test('an explicit @mention inside a threaded message still enqueues', async () => {
+    // The mirror failure. Separating the columns must not make a threaded
+    // message unaddressable — ambient-only scopes the AMBIENT case only.
+    mockInstallations([SEAT]);
+
+    await send({
+      message: { id: 'msg-3', content: '@seat-a what do you think', thread_root_id: 101 },
+    });
+
+    expect(mentions()).toHaveLength(1);
+  });
+
+  test('a threaded message is still unrouted, so wake-on-message opt-ins hear it', async () => {
+    // isRouted is `mentions.length > 0 || !!replyToMessageId`. A thread root
+    // must not make a message look routed, or ADR-018 D8 delivery silently
+    // stops for every threaded message.
+    mockInstallations([SEAT_OPTED_IN]);
+
+    const res = await send({
+      message: { id: 'msg-4', content: 'thinking out loud in a thread', thread_root_id: 101 },
+    });
+
+    expect(res.woken).toEqual(['seat-a']);
+    expect(wakes()).toHaveLength(1);
+    expect(mentions()).toHaveLength(0);
+  });
+
+  test('CONTROL: adding a reply edge makes it routed, so the opt-in does NOT get a wake', async () => {
+    mockInstallations([SEAT_OPTED_IN]);
+
+    await send({
+      message: { id: 'msg-5', content: 'replying', thread_root_id: 101, replyTo: { userId: 'bot-1' } },
+      replyToMessageId: '101',
+    });
+
+    // Proves the previous test's `wakes()` is sensitive to routedness rather
+    // than always returning one.
+    expect(wakes()).toHaveLength(0);
+    expect(mentions()).toHaveLength(1);
+  });
+});
+
+describe('the pipeline has no thread-root input at all', () => {
+  test('enqueueMentions takes replyToMessageId and no thread-root parameter', () => {
+    // Structural, and the earliest possible warning. The moment someone adds a
+    // threadRootId parameter here, this fails and the change gets looked at —
+    // which is the whole point, since the behavioural tests above would still
+    // pass for a parameter that is accepted and then ignored.
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../services/agentMentionService.ts'), 'utf8',
+    );
+    const sig = src.slice(
+      src.indexOf('const enqueueMentions = async ({'),
+      src.indexOf('}: EnqueueMentionsOptions)'),
+    );
+    expect(sig).toContain('replyToMessageId');
+    expect(sig).not.toMatch(/thread_?[Rr]oot/);
+  });
+
+  test('isRouted is derived from mentions and the reply edge only', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../services/agentMentionService.ts'), 'utf8',
+    );
+    expect(src).toContain('const isRouted = rawMentions.length > 0 || !!replyToMessageId;');
+  });
+});

--- a/backend/__tests__/unit/services/agentMentionService.threadingIsNotAddressing.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.threadingIsNotAddressing.test.js
@@ -32,6 +32,21 @@ jest.mock('../../../services/chatSummarizerService', () => ({
 jest.mock('../../../models/AgentEvent', () => ({ countDocuments: jest.fn() }));
 jest.mock('../../../services/welcomeWakeService', () => ({ maybeFireWelcomeWake: jest.fn() }));
 
+// The PG lookup resolveImplicitReplyTarget falls back to when the caller did
+// not pass a populated `replyTo`. MOCKED DELIBERATELY, and the suite is worth
+// nothing without it: message 101 is a real, bot-authored row, so if anything
+// ever hands a thread root to that resolver it WILL find a target and enqueue.
+//
+// Learned the hard way. The first version of this file left it unmocked, and
+// the negative cases passed because the lookup died in the harness rather than
+// because the code declined to make it. A mutation that routed thread roots
+// through resolveImplicitReplyTarget went completely undetected — the exact
+// refactor these tests exist to stop. The controls hid it too, because they
+// pass `replyTo` inline and never touch this path at all.
+jest.mock('../../../models/pg/Message', () => ({
+  findById: jest.fn(async (id) => (String(id) === '101' ? { id: 101, user_id: 'bot-1' } : null)),
+}));
+
 const AgentMentionService = require('../../../services/agentMentionService');
 const AgentEventService = require('../../../services/agentEventService');
 const { AgentInstallation } = require('../../../models/AgentRegistry');
@@ -39,6 +54,7 @@ const AgentProfile = require('../../../models/AgentProfile');
 const Pod = require('../../../models/Pod');
 const User = require('../../../models/User');
 const AgentEvent = require('../../../models/AgentEvent');
+const PGMessage = require('../../../models/pg/Message');
 
 const SEAT = { agentName: 'seat-a', instanceId: 'default', displayName: 'Seat A' };
 const SEAT_OPTED_IN = { ...SEAT, config: { wakeOnMessage: { enabled: true } } };
@@ -98,6 +114,11 @@ describe('a thread root alone addresses nobody', () => {
     });
 
     expect(mentions()).toHaveLength(0);
+    // And it declined to make the lookup at all — not merely failed to find a
+    // target. Asserting only "no mention" would pass from a harness where the
+    // resolver is dead, which is exactly how the first draft of this file
+    // missed the mutation it was written to catch.
+    expect(PGMessage.findById).not.toHaveBeenCalled();
   });
 
   test('CONTROL: the same message WITH a reply edge to the bot DOES enqueue one', async () => {
@@ -130,6 +151,7 @@ describe('a thread root alone addresses nobody', () => {
     });
 
     expect(mentions()).toHaveLength(0);
+    expect(PGMessage.findById).not.toHaveBeenCalled();
   });
 });
 

--- a/backend/config/schema.sql
+++ b/backend/config/schema.sql
@@ -1,3 +1,23 @@
+-- Boot DDL. Applied verbatim on every backend start, and by testUtils at tier 1.
+--
+-- ADDING A COLUMN TO AN EXISTING TABLE NEEDS TWO DECLARATIONS, NOT ONE.
+-- `CREATE TABLE IF NOT EXISTS` is a NO-OP wherever the table already exists,
+-- so a column written only inside a CREATE TABLE below reaches fresh
+-- databases and NO existing instance. Put it in the CREATE TABLE (for new
+-- installs) AND in an `ALTER TABLE <t> ADD COLUMN IF NOT EXISTS ...` (for
+-- every install that already ran). `payload` and `is_bot` are the pattern.
+--
+-- The failure is total, not partial: any index on the missing column throws at
+-- boot, and any INSERT naming it fails, so the feature does not degrade — the
+-- table stops accepting writes. Costed live on 2026-08-22, when
+-- `thread_root_id` shipped with only the CREATE TABLE declaration and would
+-- have stopped chat on every existing instance.
+--
+-- NEITHER TEST TIER CAN SEE THIS. Tier 0 reads this file as text and finds the
+-- column declared; tier 1 provisions a FRESH postgres per CI run and only ever
+-- exercises the CREATE path. A retrofit needs a test that starts from the OLD
+-- table shape — see `__tests__/unit/models/threadingSchemaRetrofit.test.js`.
+
 -- Create pods table
 CREATE TABLE IF NOT EXISTS pods (
   id VARCHAR(24) PRIMARY KEY,

--- a/backend/config/schema.sql
+++ b/backend/config/schema.sql
@@ -57,6 +57,25 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS is_bot BOOLEAN DEFAULT false;
 -- as is_bot above. NULL for ordinary messages.
 ALTER TABLE messages ADD COLUMN IF NOT EXISTS payload JSONB;
 
+-- Threading (W-T, TASK-029). MUST be retrofitted, not only declared in the
+-- CREATE TABLE above — `CREATE TABLE IF NOT EXISTS` is a no-op on an existing
+-- table, so a column declared only there NEVER reaches an instance that
+-- already has a messages table. Verified on the live dev instance 2026-08-22:
+-- 7,001 rows, oldest 2026-07-07, and thread_root_id absent while `payload`
+-- (which has this retrofit) is present.
+--
+-- Without this line the failure is not subtle: the index below throws at boot
+-- and every PGMessage.create fails, because the INSERT names a column that
+-- does not exist. Chat posting stops on every existing instance.
+--
+-- The tier-1 test suite could not catch it — CI provisions a FRESH postgres:16
+-- per run, where the CREATE TABLE path is the one exercised. Any new column on
+-- an existing table needs BOTH declarations, and a test that starts from the
+-- old shape (see threadingSchemaRetrofit.test.js). Caught by @sprint-review's
+-- caveat on #1106, not by anything I ran.
+ALTER TABLE messages
+  ADD COLUMN IF NOT EXISTS thread_root_id INTEGER REFERENCES messages(id) ON DELETE SET NULL;
+
 -- Migration records. There was no such table anywhere under backend/ before
 -- this (@sprint-review, 56859, checked with a positive control): schema.sql is
 -- idempotent boot DDL, which says what the shape IS and never when it changed.

--- a/backend/config/schema.sql
+++ b/backend/config/schema.sql
@@ -26,6 +26,15 @@ CREATE TABLE IF NOT EXISTS messages (
   content TEXT NOT NULL,
   message_type VARCHAR(20) DEFAULT 'text' NOT NULL,
   reply_to_message_id INTEGER REFERENCES messages(id) ON DELETE SET NULL,
+  -- Threading (W-T, TASK-029). DELIBERATELY separate from reply_to_message_id,
+  -- which is an ADDRESSING edge: it feeds `isRouted` and the implicit-reply
+  -- chat.mention (agentMentionService :1025 / :1356), so a human replying to an
+  -- agent addresses that agent. If thread membership rode the same column,
+  -- joining a thread would ping the parent's author — the opposite of what
+  -- ambient scoping is for (fable's #1045 ruling). thread_root_id carries no
+  -- addressing. NULL means "not in a thread"; a root is an ordinary message
+  -- other messages point at, and a root's own thread_root_id stays NULL.
+  thread_root_id INTEGER REFERENCES messages(id) ON DELETE SET NULL,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
@@ -64,6 +73,10 @@ CREATE INDEX IF NOT EXISTS idx_message_reactions_message_id ON message_reactions
 -- Create indexes for better performance
 CREATE INDEX IF NOT EXISTS idx_messages_pod_id ON messages(pod_id);
 CREATE INDEX IF NOT EXISTS idx_messages_created_at ON messages(created_at);
+-- Threading reads are "give me this thread" and "how many replies has it", both
+-- keyed on the root. reply_to_message_id has no index, which is why the root is
+-- stored rather than walked: deriving it per read is a seq-scan per level.
+CREATE INDEX IF NOT EXISTS idx_messages_thread_root_id ON messages(thread_root_id);
 CREATE INDEX IF NOT EXISTS idx_pod_members_pod_id ON pod_members(pod_id);
 CREATE INDEX IF NOT EXISTS idx_pod_members_user_id ON pod_members(user_id);
 CREATE INDEX IF NOT EXISTS idx_pods_created_by ON pods(created_by);

--- a/backend/config/schema.sql
+++ b/backend/config/schema.sql
@@ -57,6 +57,30 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS is_bot BOOLEAN DEFAULT false;
 -- as is_bot above. NULL for ordinary messages.
 ALTER TABLE messages ADD COLUMN IF NOT EXISTS payload JSONB;
 
+-- Migration records. There was no such table anywhere under backend/ before
+-- this (@sprint-review, 56859, checked with a positive control): schema.sql is
+-- idempotent boot DDL, which says what the shape IS and never when it changed.
+-- That is fine until a RULE needs to reference the change — the threading
+-- surface ruling (#1115) says pre-cutoff thread roots default to expanded,
+-- "cutoff = the migration timestamp, read from the migration record", and that
+-- record did not exist.
+--
+-- Deliberately general rather than a threading-specific row. A one-off
+-- `threading_migration` table is the thing that has to be generalised the
+-- second time someone needs this, and the second time is when it gets done
+-- wrong. `details` is JSONB so a migration can record what only IT knew — for
+-- the threading backfill, the boundary timestamp it would otherwise discard.
+--
+-- NOT a migration RUNNER. Nothing reads this to decide what to apply; boot DDL
+-- still owns that. It is a ledger, and the distinction matters: a reader must
+-- never infer "migration X has not run" from a missing row — it may have run
+-- on an instance that predates this table.
+CREATE TABLE IF NOT EXISTS migration_records (
+  name VARCHAR(255) PRIMARY KEY,
+  applied_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  details JSONB
+);
+
 -- Sprint B5: message reactions. One row per (message, user, emoji) — a user
 -- can stack different emojis on the same message but each emoji is binary
 -- (toggle on/off). PG-only; Mongo fallback path doesn't get reactions in v1.

--- a/backend/models/pg/Message.ts
+++ b/backend/models/pg/Message.ts
@@ -96,9 +96,28 @@ class Message {
     console.log('Creating message with params:', {
       podId, userId, content, messageType, podIdType: typeof podId,
     });
+    // Threading (W-T, TASK-029). The root is DERIVED from the reply edge on
+    // write and stored, never walked on read: `reply_to_message_id` carries no
+    // index (schema.sql indexes pod_id and created_at only), so resolving a
+    // root per read is a sequential scan per level of the chain.
+    //
+    // One level of derivation is enough for any depth. A reply to a root takes
+    // that root's id; a reply to a reply inherits the root the parent already
+    // stored. Measured on the live instance before this shipped: 227 reply
+    // edges, max chain depth 7, and every one of those deeper links resolves
+    // by this same inheritance because the parent was written first.
+    //
+    // COALESCE(parent.thread_root_id, parent.id) is the whole rule — a parent
+    // that is itself a root has NULL there and contributes its own id.
+    //
+    // Deliberately NOT derived from anything but the reply edge: thread_root_id
+    // must never acquire addressing semantics (see schema.sql).
     const query = `
-      INSERT INTO messages (pod_id, user_id, content, message_type, reply_to_message_id, payload)
-      VALUES ($1, $2, $3, $4, $5, $6)
+      INSERT INTO messages (pod_id, user_id, content, message_type, reply_to_message_id, payload, thread_root_id)
+      SELECT $1, $2, $3, $4, $5, $6,
+             (SELECT COALESCE(parent.thread_root_id, parent.id)
+                FROM messages parent
+               WHERE parent.id = $5)
       RETURNING *
     `;
     try {

--- a/backend/models/pg/Message.ts
+++ b/backend/models/pg/Message.ts
@@ -112,12 +112,18 @@ class Message {
     //
     // Deliberately NOT derived from anything but the reply edge: thread_root_id
     // must never acquire addressing semantics (see schema.sql).
+    //
+    // The `::int` casts are explicit on purpose. Postgres infers them fine
+    // either way, but without them the scalar subquery is typed as an array by
+    // pg-mem — which is what lets this exact query be exercised at the unit
+    // tier instead of only against a real server. A cast that costs nothing in
+    // production and buys a fast test everywhere is worth writing down.
     const query = `
       INSERT INTO messages (pod_id, user_id, content, message_type, reply_to_message_id, payload, thread_root_id)
-      SELECT $1, $2, $3, $4, $5, $6,
+      SELECT $1, $2, $3, $4, $5::int, $6,
              (SELECT COALESCE(parent.thread_root_id, parent.id)
                 FROM messages parent
-               WHERE parent.id = $5)
+               WHERE parent.id = $5::int)::int
       RETURNING *
     `;
     try {

--- a/backend/scripts/backfill-thread-root-id.ts
+++ b/backend/scripts/backfill-thread-root-id.ts
@@ -21,6 +21,49 @@
  *
  * IDEMPOTENT. Only touches rows with a reply edge and a NULL root, so a second
  * run is a no-op. DRY RUN BY DEFAULT — pass --apply to write.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT THIS DOES ONCE WAKE-SCOPING LANDS. Read this before running --apply.
+ *
+ * On its own this script is inert: it writes a column nothing reads, and no
+ * behaviour changes. The composition is what matters, and it is visible in
+ * neither this diff nor the wake-scoping one (raised by @sprint-review, 56773).
+ *
+ * Wake-scoping makes thread membership decide who is woken by a reply:
+ * ambient-only, so an un-addressed reply inside a thread reaches
+ * (participants ∪ explicit followers) − muted, instead of the room. Composed
+ * with this backfill, THE ROWS WRITTEN HERE RETROACTIVELY DECIDE THE WAKE SET
+ * OF EVERY CONVERSATION THAT PREDATES THE FEATURE. Nobody in those threads
+ * opted into being scoped by them.
+ *
+ * Measured on the live instance 2026-08-22, one day after the population
+ * figures above (the counts drift; the script is idempotent, so re-measure
+ * rather than trusting either number):
+ *
+ *   245 reply edges · 172 threads · 0 orphaned edges · 6 pods
+ *   participants per thread: min 1, median 2, max 3
+ *   20 threads have exactly ONE participant — a self-reply chain
+ *
+ * Two consequences worth a reviewer's attention:
+ *
+ * 1. REACH DROPS RETROACTIVELY. In the busiest affected pod (135 of the 172
+ *    threads, 9 distinct authors), a reply into a backfilled thread reaches a
+ *    median of 2 of 9 — where before threading it reached all 9.
+ *
+ * 2. THE SELF-REPLY CHAINS ARE THE SHARP EDGE. 20 threads across 2 pods
+ *    (19 threads / 59 messages in one, 1 thread / 2 messages in the other)
+ *    have a single participant. Their wake set after scoping is one person:
+ *    the author replying to themselves. An un-addressed reply into one of
+ *    those reaches nobody.
+ *
+ * NOT overstated: ambient-only scoping does NOT suppress explicit @mentions,
+ * so an addressed reply still wakes its target in every case above. The
+ * exposure is un-addressed replies into backfilled threads.
+ *
+ * The orphan branch below (parent missing => leave NULL) currently has a live
+ * population of ZERO, so it is an untested safety branch rather than a
+ * measured behaviour. Do not cite it as verified.
+ * ---------------------------------------------------------------------------
  */
 /* eslint-disable no-console */
 import { Pool } from 'pg';

--- a/backend/scripts/backfill-thread-root-id.ts
+++ b/backend/scripts/backfill-thread-root-id.ts
@@ -1,0 +1,118 @@
+/**
+ * backfill-thread-root-id — one-shot, for the reply edges that predate
+ * threading (W-T, TASK-029).
+ *
+ * `Message.create` derives `thread_root_id` on write from the parent's
+ * COALESCE(thread_root_id, id). Rows written before that shipped have a
+ * `reply_to_message_id` and a NULL root, so a thread that began yesterday
+ * would render as a set of unrelated messages.
+ *
+ * WHY BACKFILL RATHER THAN DERIVE ON READ. The root is computable at any time
+ * by walking the reply chain — that is how the population below was measured.
+ * But `reply_to_message_id` carries no index, so each walk is a sequential
+ * scan per level, and threading exists to be read. Two fields that can
+ * disagree about what a thread is will eventually disagree; one write now
+ * costs less than reconciling them later.
+ *
+ * POPULATION, measured on the live instance 2026-08-21: 6,304 messages, of
+ * which 227 carry a reply edge, forming 153 distinct threads — mean 2.48
+ * messages, largest 7, chain depths 205/14/5/1/1 at levels 2-6. So this is a
+ * ~227-row UPDATE, not a table rewrite.
+ *
+ * IDEMPOTENT. Only touches rows with a reply edge and a NULL root, so a second
+ * run is a no-op. DRY RUN BY DEFAULT — pass --apply to write.
+ */
+/* eslint-disable no-console */
+import { Pool } from 'pg';
+
+const APPLY = process.argv.includes('--apply');
+
+async function main(): Promise<void> {
+  if (!process.env.PG_HOST) {
+    console.error('PG_HOST is required');
+    process.exit(2);
+  }
+  const pool = new Pool({
+    host: process.env.PG_HOST,
+    port: Number(process.env.PG_PORT) || 5432,
+    user: process.env.PG_USER,
+    password: process.env.PG_PASSWORD,
+    database: process.env.PG_DATABASE,
+    ssl: { rejectUnauthorized: false },
+  });
+
+  try {
+    const { rows: [before] } = await pool.query(
+      `SELECT count(*)::int AS needs_root
+         FROM messages
+        WHERE reply_to_message_id IS NOT NULL AND thread_root_id IS NULL`,
+    );
+    console.log(`rows with a reply edge and no root: ${before.needs_root}`);
+    if (before.needs_root === 0) {
+      console.log('nothing to do.');
+      return;
+    }
+
+    if (!APPLY) {
+      // Show what the walk WOULD produce, so the number can be checked before
+      // it is written — the recursive CTE is the same one that measured the
+      // population, and it is the only place the chain is walked.
+      const { rows } = await pool.query(
+        `WITH RECURSIVE chain AS (
+           SELECT id, reply_to_message_id, id AS root
+             FROM messages WHERE reply_to_message_id IS NULL
+           UNION ALL
+           SELECT m.id, m.reply_to_message_id, c.root
+             FROM messages m JOIN chain c ON m.reply_to_message_id = c.id
+         )
+         SELECT count(*)::int AS resolvable,
+                count(DISTINCT root)::int AS threads
+           FROM chain
+          WHERE id IN (SELECT id FROM messages
+                        WHERE reply_to_message_id IS NOT NULL AND thread_root_id IS NULL)`,
+      );
+      console.log(`would set a root on ${rows[0].resolvable} rows across ${rows[0].threads} threads`);
+      if (rows[0].resolvable !== before.needs_root) {
+        console.warn(
+          `WARNING: ${before.needs_root - rows[0].resolvable} row(s) have a reply edge whose `
+          + 'chain does not terminate at a root — orphaned parents, deleted mid-chain. '
+          + 'Those stay NULL and render unthreaded, which is correct: an unreachable root is not a thread.',
+        );
+      }
+      console.log('DRY RUN — nothing written. Re-run with --apply.');
+      return;
+    }
+
+    const result = await pool.query(
+      `WITH RECURSIVE chain AS (
+         SELECT id, reply_to_message_id, id AS root
+           FROM messages WHERE reply_to_message_id IS NULL
+         UNION ALL
+         SELECT m.id, m.reply_to_message_id, c.root
+           FROM messages m JOIN chain c ON m.reply_to_message_id = c.id
+       )
+       UPDATE messages m
+          SET thread_root_id = chain.root
+         FROM chain
+        WHERE m.id = chain.id
+          AND m.reply_to_message_id IS NOT NULL
+          AND m.thread_root_id IS NULL
+          AND chain.root <> m.id`,
+    );
+    console.log(`APPLIED — ${result.rowCount} of ${before.needs_root} rows updated.`);
+
+    const { rows: [after] } = await pool.query(
+      `SELECT count(*)::int AS still_null
+         FROM messages
+        WHERE reply_to_message_id IS NOT NULL AND thread_root_id IS NULL`,
+    );
+    console.log(`remaining with a reply edge and no root: ${after.still_null} (orphaned chains stay NULL by design)`);
+  } catch (error) {
+    console.error('backfill failed:', (error as Error).message);
+    process.exitCode = 1;
+  } finally {
+    await pool.end();
+  }
+}
+
+main();

--- a/backend/scripts/backfill-thread-root-id.ts
+++ b/backend/scripts/backfill-thread-root-id.ts
@@ -70,6 +70,28 @@ import { Pool } from 'pg';
 
 const APPLY = process.argv.includes('--apply');
 
+export const MIGRATION_NAME = 'threading-thread-root-id-backfill';
+
+/**
+ * The threading cutoff: the newest message that carries a reply edge and no
+ * root. "Has a reply edge and no root" IS the definition of "written before
+ * derivation-on-write shipped", so this boundary is exact rather than
+ * approximate — not a deploy timestamp guessed after the fact.
+ *
+ * Read BEFORE the UPDATE. The UPDATE eliminates the predicate, so afterwards
+ * there is nothing left to measure. A hardcoded date would be wrong on every
+ * instance that migrates on a different day, and self-hosting is in scope.
+ *
+ * NULL when there is nothing to backfill — a fresh instance has no
+ * pre-threading history, so no root is pre-cutoff and the surface rule is
+ * simply inert. Consumers must treat NULL as "no pre-cutoff roots exist",
+ * never as "unknown, assume everything is pre-cutoff".
+ */
+export const CUTOFF_SQL = `
+  SELECT MAX(created_at) AS cutoff
+    FROM messages
+   WHERE reply_to_message_id IS NOT NULL AND thread_root_id IS NULL`;
+
 async function main(): Promise<void> {
   if (!process.env.PG_HOST) {
     console.error('PG_HOST is required');
@@ -122,9 +144,17 @@ async function main(): Promise<void> {
           + 'Those stay NULL and render unthreaded, which is correct: an unreachable root is not a thread.',
         );
       }
+      const { rows: [boundary] } = await pool.query(CUTOFF_SQL);
+      console.log(`would record cutoff = ${boundary.cutoff ?? '(none)'} (newest pre-threading reply)`);
       console.log('DRY RUN — nothing written. Re-run with --apply.');
       return;
     }
+
+    // MUST be read BEFORE the UPDATE. The predicate is "has a reply edge and
+    // no root", which is precisely "written before derivation-on-write
+    // shipped" — every row written after carries a root. The UPDATE destroys
+    // that predicate, so afterwards the boundary is unrecoverable.
+    const { rows: [boundary] } = await pool.query(CUTOFF_SQL);
 
     const result = await pool.query(
       `WITH RECURSIVE chain AS (
@@ -143,6 +173,29 @@ async function main(): Promise<void> {
           AND chain.root <> m.id`,
     );
     console.log(`APPLIED — ${result.rowCount} of ${before.needs_root} rows updated.`);
+
+    // The ruling in #1115 says pre-cutoff roots render expanded, with the
+    // cutoff "read from the migration record". This script is the only process
+    // that ever knows it, and until now it discarded it (@sprint-review 56860).
+    //
+    // ON CONFLICT DO NOTHING, not DO UPDATE: a second run must not move a
+    // boundary the surface has already been rendering against. The script stays
+    // idempotent; the FIRST run's answer is the true one, because by the second
+    // run the population it measured no longer exists.
+    await pool.query(
+      `INSERT INTO migration_records (name, details)
+       VALUES ($1, $2::jsonb)
+       ON CONFLICT (name) DO NOTHING`,
+      [
+        MIGRATION_NAME,
+        JSON.stringify({
+          threadingCutoff: boundary.cutoff,
+          rowsUpdated: result.rowCount,
+          rowsEligible: before.needs_root,
+        }),
+      ],
+    );
+    console.log(`recorded ${MIGRATION_NAME}: cutoff = ${boundary.cutoff ?? '(none)'}`);
 
     const { rows: [after] } = await pool.query(
       `SELECT count(*)::int AS still_null


### PR DESCRIPTION
**1 of 4** for the W-T walking skeleton, per @sprint-impl's build order. Schema and write path only — follow state (2/4), wake-scoping (3/4) and render (4/4) follow separately so each can be reviewed against one question.

Design settled in #1081; this implements it.

### `thread_root_id` is a separate column, and that is the load-bearing decision

`reply_to_message_id` is an **addressing** edge today: it feeds `isRouted` (`agentMentionService:1025`) and resolves the implicit-reply `chat.mention` (`:1356`), so a human replying to an agent addresses that agent. If thread membership rode the same column, **joining a thread would ping the parent's author** — the opposite of what ambient scoping is for under @fable-lead's #1045 ruling.

The root carries no addressing. A message may have both, either, or neither.

This is the piece most likely to look redundant to a reviewer — two columns, both `REFERENCES messages(id)` — so the reason is in `schema.sql` next to the column, and a test asserts the comment survives.

### Derived on write, not walked on read

```sql
(SELECT COALESCE(parent.thread_root_id, parent.id) FROM messages parent WHERE parent.id = $5)
```

One level covers any depth: a reply to a root takes that root's id; a reply to a reply inherits the root its parent already stored. Without the `COALESCE`, depth-3+ replies would take their immediate parent as root and split one thread into many — live data has chains to depth 7.

Stored rather than derived because **`reply_to_message_id` carries no index** (`schema.sql` indexes `pod_id` and `created_at` only), so resolving a root per read is a sequential scan per level. `idx_messages_thread_root_id` added, since threading reads are all keyed on the root.

A root's own `thread_root_id` stays `NULL` — if roots pointed at themselves, "is this threaded" would stop being `IS NULL` and every ambient message would look like a one-message thread.

### Backfill: separate, idempotent, dry-run by default

`backend/scripts/backfill-thread-root-id.ts`. Touches only rows with a reply edge and a `NULL` root, so a second run is a no-op. Requires `--apply`; the default prints what it *would* set, using the same recursive CTE that measured the population, and warns if the two counts differ.

Population measured on the live instance 2026-08-21: **227 reply edges across 153 threads**, mean 2.48 messages, max depth 7. A ~227-row `UPDATE`, not a table rewrite.

Orphaned chains — a reply whose parent was deleted mid-chain — stay `NULL` by design. An unreachable root is not a thread.

### Verification

8 tests, green. They assert the **emitted SQL** rather than calling a function, because the derivation is a subquery inside the `INSERT` and there is nothing to call — stated plainly since that is a weaker instrument than a behaviour test and a reviewer should know which they are getting.

`tsc --noEmit` clean on all changed files. Branch verified against main after push: four files, no gitlink.

### Not verified

- **No live run.** The derivation has not executed against a real Postgres — the tests read the SQL, they do not run it. A service-tier test with a real DB would be the honest next rung and is not in this PR.
- **The backfill has not been run anywhere**, not even dry. It is written to be safe by default rather than proven safe by execution.
- Whether the Mongo message store (10,428 documents, newest 2026-08-05, no reply field) needs anything. #1081 §1 flags it as the one open substrate question and it stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)