### PR TITLE
fix(v2): author grouping in chat + sidebar names stop losing to timestamps

### DIFF
--- a/frontend/src/v2/__tests__/message-grouping.test.ts
+++ b/frontend/src/v2/__tests__/message-grouping.test.ts
@@ -1,0 +1,93 @@
+import { GROUPING_WINDOW_MS, isGroupedWithPrevious } from '../utils/messageGrouping';
+
+// Craft audit finding 7 / baseline rule 3: same author within the window
+// renders one header. The predicate is the whole behavior — the component
+// just maps it onto the `grouped` prop — so the boundaries live here.
+
+const at = (offsetMs: number) => new Date(1755864000000 + offsetMs).toISOString();
+
+const msg = (over: Partial<Parameters<typeof isGroupedWithPrevious>[0]> = {}) => ({
+  user_id: 'u1',
+  user: { username: 'sprint-review' },
+  created_at: at(0),
+  ...over,
+});
+
+describe('isGroupedWithPrevious', () => {
+  it('groups a same-author message inside the window', () => {
+    expect(isGroupedWithPrevious(msg({ created_at: at(60_000) }), msg())).toBe(true);
+  });
+
+  it('groups exactly at the window boundary, not one ms past it', () => {
+    expect(
+      isGroupedWithPrevious(msg({ created_at: at(GROUPING_WINDOW_MS) }), msg()),
+    ).toBe(true);
+    expect(
+      isGroupedWithPrevious(msg({ created_at: at(GROUPING_WINDOW_MS + 1) }), msg()),
+    ).toBe(false);
+  });
+
+  it('never groups across authors, even inside the window', () => {
+    expect(
+      isGroupedWithPrevious(
+        msg({ user_id: 'u2', created_at: at(1000) }),
+        msg(),
+      ),
+    ).toBe(false);
+  });
+
+  it('never groups when the same user_id renders under a different username', () => {
+    // Display-name overrides can change what the header would have said;
+    // a silent header suppression would mis-attribute the run.
+    expect(
+      isGroupedWithPrevious(
+        msg({ user: { username: 'renamed' }, created_at: at(1000) }),
+        msg(),
+      ),
+    ).toBe(false);
+  });
+
+  it('replies keep their header — the quote needs an owner', () => {
+    expect(
+      isGroupedWithPrevious(
+        msg({ reply_content: 'quoted', created_at: at(1000) }),
+        msg(),
+      ),
+    ).toBe(false);
+    expect(
+      isGroupedWithPrevious(
+        msg({ replyTo: { content: 'quoted' }, created_at: at(1000) }),
+        msg(),
+      ),
+    ).toBe(false);
+  });
+
+  it('payload cards never group, on either side of the pair', () => {
+    expect(
+      isGroupedWithPrevious(
+        msg({ payload: { kind: 'approval-card' }, created_at: at(1000) }),
+        msg(),
+      ),
+    ).toBe(false);
+    expect(
+      isGroupedWithPrevious(
+        msg({ created_at: at(1000) }),
+        msg({ payload: { kind: 'approval-card' } }),
+      ),
+    ).toBe(false);
+  });
+
+  it('out-of-order or unparsable timestamps never group', () => {
+    expect(
+      isGroupedWithPrevious(msg(), msg({ created_at: at(1000) })),
+    ).toBe(false);
+    expect(
+      isGroupedWithPrevious(msg({ created_at: 'not-a-date' }), msg()),
+    ).toBe(false);
+    expect(isGroupedWithPrevious(msg({ created_at: undefined }), msg())).toBe(false);
+  });
+
+  it('the first message of a list never groups', () => {
+    expect(isGroupedWithPrevious(msg(), undefined)).toBe(false);
+  });
+});

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -66,6 +66,27 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(rule).not.toContain('white-space: nowrap');
   });
 
+  test('sidebar pod name WRAPS — it never loses to its own timestamp (craft audit finding 8)', () => {
+    // "Sharpen — pod m…", "Team Orchestra…": the name shared its line with the
+    // relative time and ellipsized at desktop width. Same primary-identifier
+    // rule as the team-card name: wrap to two lines, and the timestamp lives
+    // on the snippet row so it never competes with the name at all.
+    const title = ruleBody(v2, '.v2-pods__item-title');
+    expect(title).toContain('-webkit-line-clamp: 2');
+    expect(title).not.toContain('white-space: nowrap');
+    expect(v2).toContain('.v2-pods__item-snippet-row');
+  });
+
+  test('grouped messages keep the avatar column so text never shifts (craft audit rule 3)', () => {
+    // Consecutive same-author messages within the grouping window drop the
+    // header row; the ghost cell must match the .v2-msg grid's 38px avatar
+    // column or grouped text mis-aligns with headed text by exactly the
+    // avatar width — a defect jsdom cannot see.
+    expect(ruleBody(v2, '.v2-msg')).toContain('grid-template-columns: 38px');
+    expect(ruleBody(v2, '.v2-msg__avatar-ghost')).toContain('width: 38px');
+    expect(v2).toContain('.v2-msg--grouped');
+  });
+
   test('runtime vocabulary stays off Your Team cards (ADR-022 D1, ratified)', () => {
     // The chip shipped in violation of the ratified rule; the craft audit
     // (finding 2) removed it. This pins the removal against reintroduction.

--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -90,6 +90,12 @@ interface V2MessageBubbleProps {
   // Sets this message as the composer's reply target (reply threading —
   // backend replyToMessageId; agents already use it, this is the human side).
   onReply?: (message: V2Message) => void;
+  // Consecutive-author grouping (craft audit finding 7): when the previous
+  // message is the same author within the grouping window, the header row
+  // (avatar / name / time) is suppressed and the row tightens. The avatar
+  // column is kept as an empty grid cell so text stays aligned. Reply moves
+  // to a hover affordance since the head row is gone.
+  grouped?: boolean;
 }
 
 interface ParsedFile {
@@ -287,7 +293,7 @@ const parseAgentDmEvent = (content: string | undefined): { headline: string; tar
 // columns in mobile shells.
 const REACTION_PALETTE = ['👍', '❤️', '🔥', '🤔', '👀', '🚀'];
 
-const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agentDisplayNames, agentAuthorKeys, onAuthorClick, onOpenFile, onReply }) => {
+const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agentDisplayNames, agentAuthorKeys, onAuthorClick, onOpenFile, onReply, grouped }) => {
   const { currentUser } = useAuth();
   const navigate = useNavigate();
   const api = useV2Api();
@@ -392,8 +398,10 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
     && new RegExp(`@${meUsername.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(stripped);
 
   return (
-    <div className={`v2-msg${mentionsMe ? ' v2-msg--mention' : ''}`}>
-      {isClickable ? (
+    <div className={`v2-msg${mentionsMe ? ' v2-msg--mention' : ''}${grouped ? ' v2-msg--grouped' : ''}`}>
+      {grouped ? (
+        <div className="v2-msg__avatar-ghost" aria-hidden="true" />
+      ) : isClickable ? (
         <button
           type="button"
           className="v2-msg__avatar-btn"
@@ -418,6 +426,17 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
         />
       )}
       <div className="v2-msg__body">
+        {grouped && onReply && (
+          <button
+            type="button"
+            className="v2-msg__reply-float"
+            aria-label={`Reply to ${author}`}
+            onClick={() => onReply(message)}
+          >
+            Reply
+          </button>
+        )}
+        {!grouped && (
         <div className="v2-msg__head">
           {isClickable ? (
             <button type="button" className="v2-msg__author-btn" onClick={handleAuthorClick}>
@@ -439,6 +458,7 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
             </button>
           )}
         </div>
+        )}
         {(() => {
           // Quoted context for replies. POST responses carry a normalized
           // `replyTo` object; list rows may carry raw reply_* columns instead.

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -12,6 +12,7 @@ import { UseV2PodsResult, V2PodMember } from '../hooks/useV2Pods';
 import { useSocket } from '../../context/SocketContext';
 import { useAuth } from '../../context/AuthContext';
 import { initialsFor } from '../utils/avatars';
+import { isGroupedWithPrevious } from '../utils/messageGrouping';
 import { Trans, useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import type { V2InviteTab } from './V2InviteModal';
@@ -1159,7 +1160,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                   )}
                 </div>
               )}
-              {messages.map((m) => (
+              {messages.map((m, i) => (
                 <React.Fragment key={m.id}>
                   <V2MessageBubble
                     message={m}
@@ -1168,6 +1169,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                     onAuthorClick={onOpenMember ? handleAuthorClick : undefined}
                     onOpenFile={onOpenFile}
                     onReply={setReplyTarget}
+                    grouped={isGroupedWithPrevious(m, messages[i - 1])}
                   />
                   {agentDeliveryHint?.messageId === m.id && (
                     <div className="v2-chat__delivery-hint" role="status">

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -671,10 +671,12 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
                         <span className="v2-pods__item-title-row">
                           <span className="v2-pods__item-title">{pod.name}</span>
                           {unread && <span className="v2-pods__item-dot" aria-label={t('podsSidebar.unreadAriaLabel')} />}
-                          <span className="v2-pods__item-time">{time}</span>
                         </span>
-                        <span className={`v2-pods__item-snippet${typing ? ' v2-pods__item-snippet--typing' : ''}`}>
-                          {typing ? t('podsSidebar.typing') : snippet}
+                        <span className="v2-pods__item-snippet-row">
+                          <span className={`v2-pods__item-snippet${typing ? ' v2-pods__item-snippet--typing' : ''}`}>
+                            {typing ? t('podsSidebar.typing') : snippet}
+                          </span>
+                          <span className="v2-pods__item-time">{time}</span>
                         </span>
                       </span>
                     </button>

--- a/frontend/src/v2/utils/messageGrouping.ts
+++ b/frontend/src/v2/utils/messageGrouping.ts
@@ -1,0 +1,33 @@
+// Consecutive-author grouping (craft audit finding 7 / baseline rule 3).
+// A message joins the previous one's group — header suppressed, row
+// tightened — when it's the same author within the window and neither side
+// breaks the run: replies keep their header (the quote needs an owner),
+// payload cards render their own chrome, and a missing or unparsable
+// timestamp never groups.
+export const GROUPING_WINDOW_MS = 3 * 60 * 1000;
+
+// Structural subset of V2Message — only the fields the predicate reads.
+// Kept loose so both the live V2Message and test literals satisfy it.
+export interface GroupableMessage {
+  user_id?: string | null;
+  user?: { username?: string | null } | null;
+  created_at?: string;
+  replyTo?: unknown;
+  reply_content?: unknown;
+  payload?: { kind?: string } | null;
+}
+
+export const isGroupedWithPrevious = (
+  m: GroupableMessage,
+  prev?: GroupableMessage,
+): boolean => {
+  if (!prev) return false;
+  if (!m.user_id || m.user_id !== prev.user_id) return false;
+  if ((m.user?.username || '') !== (prev.user?.username || '')) return false;
+  if (m.replyTo || m.reply_content) return false;
+  if (m.payload?.kind || prev.payload?.kind) return false;
+  const a = new Date(m.created_at ?? NaN).getTime();
+  const b = new Date(prev.created_at ?? NaN).getTime();
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return false;
+  return a - b >= 0 && a - b <= GROUPING_WINDOW_MS;
+};

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -1012,12 +1012,17 @@
 
 .v2-pods__item-title-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 6px;
   min-width: 0;
-  height: 20px;
+  min-height: 20px;
 }
 
+/* Craft baseline rule 1: the pod name is the row's primary identifier and
+   never loses to its own timestamp — wrap to two lines instead of
+   ellipsizing (same idiom as the team-card name fix, #1104). The clamp
+   keeps pathological names from unbounding the row; the timestamp lives on
+   the snippet row so it never shares a line with the name. */
 .v2-pods__item-title {
   flex: 1;
   min-width: 0;
@@ -1025,10 +1030,21 @@
   line-height: 20px;
   font-weight: 600;
   color: var(--v2-text-primary);
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-wrap: anywhere;
 }
+
+.v2-pods__item-snippet-row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+}
+
+.v2-pods__item-snippet-row .v2-pods__item-snippet { flex: 1; min-width: 0; }
 
 .v2-pods__status {
   height: 18px;
@@ -2454,6 +2470,35 @@
   align-items: start;
   gap: 12px;
   padding: 10px 0;
+}
+
+/* Consecutive-author grouping (craft baseline rule 3): grouped rows drop
+   the 22px head + avatar and tighten padding, so a run of messages from one
+   author reads as one block. The ghost keeps the grid's avatar column so
+   text alignment never shifts. Reply becomes a hover affordance pinned to
+   the row's top-right, since the head row (and its Reply button) is gone. */
+.v2-msg--grouped { padding: 2px 0; position: relative; }
+.v2-msg__avatar-ghost { width: 38px; }
+.v2-msg__reply-float {
+  position: absolute;
+  top: 0;
+  right: 8px;
+  appearance: none;
+  border: 1px solid var(--v2-border);
+  background: var(--v2-surface);
+  color: var(--v2-text-secondary);
+  font-size: 11px;
+  border-radius: 6px;
+  padding: 2px 8px;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+}
+.v2-msg--grouped:hover .v2-msg__reply-float,
+.v2-msg__reply-float:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .v2-msg__body {


### PR DESCRIPTION
Craft audit findings **7** (author grouping) and **8** (sidebar truncation) from `docs/design/shell-craft-audit-2026-08-22.md` — both mechanical-craft class B, browser-verified on live Sharpen data before this PR (21 of 50 visible messages grouped; every real pod name renders in full, only genuinely-long titles clamp at 2 lines).

**Chat:** same author within 3 min → one header; grouped rows keep the 38px avatar column as a ghost cell so text never shifts; Reply becomes a hover affordance. Replies, payload cards, renamed authors and out-of-order timestamps never group. Predicate extracted to `utils/messageGrouping.ts`; every boundary pinned in `message-grouping.test.ts` (8 cases).

**Sidebar:** pod name wraps to 2 lines (the #1104 team-card idiom) and the timestamp moves down to the snippet row — the primary identifier never shares a line with it. Existing 64px row height fits exactly.

**Guards:** two new layout invariants — ghost cell width must match the grid's avatar column; sidebar title must clamp-wrap, never nowrap.

Screenshots are in Sam's stash (author-grouping-sharpen.png, sidebar-truncation-fix.png).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK