### PR TITLE
docs(design): the two threading-state rulings that missed #1107's squash

### DIFF
--- a/docs/design/threading-surface-ruling.md
+++ b/docs/design/threading-surface-ruling.md
@@ -35,6 +35,10 @@ Skeleton implication: the follow-state migration in the walking skeleton adds th
 
 **The mirror risk (sprint-review 56807): one write for two meanings.** `following` is durable and `collapsed` flips constantly; if the collapse toggle upserts the whole record, an expand silently rewrites follow state (the #1082 shape). Ruling: **each writer touches only its own column** — the collapse gesture is `SET collapsed = ?` on the existing key (insert-if-missing with `following` left at its default, never supplied), the follow writers are `SET following = ?` likewise. The discriminating tests, one per direction: toggling collapse on a followed thread leaves `following` unchanged; a participation-driven follow on an expanded thread leaves `collapsed` unchanged.
 
+**Row presence is not follow state (pod-architect, #1109: `thread_follows` → `thread_user_state`).** Because a collapse write creates rows for non-followers, every reader of follow state — wake-scoping above all — must filter `following = true`, never `EXISTS (row)`. Third test: a user whose row is `(following=false, collapsed=false)` receives no wake from thread activity.
+
+**`following` is tri-state (pod-architect 56817, accepted).** "Defaults from participation" cannot be a column default: `NOT NULL DEFAULT false` would silently unfollow a participant the moment a collapse-only row is created for them. So: `following` is nullable — **NULL = defer to participation** (derived at read time from posts and @-mentions in the thread; participation never writes this column), **TRUE = explicit follow**, **FALSE = explicit mute that outranks participation**. Unfollow writes FALSE rather than deleting the row, for the same reason. Readers compute `effective = COALESCE(following, participated)`; the wake-scoping filter is on the effective value, not the column. Fourth test: a participant whose row is `(following=NULL, collapsed=false)` is woken; the same participant with `following=FALSE` is not.
+
 ## Provenance of each line
 
 - Constraints 1–3, persisted collapse, and the three reasons: 55852 (above).


### PR DESCRIPTION
#1107 squash-merged at 12:42:42Z; two rulings pushed to its branch afterwards never reached main (verified by content on `origin/main`, not by sha — a squash rewrites them):

- **Row presence is not follow state** — readers filter `following = true`, never `EXISTS (row)`; third test (pod 56816/56820)
- **`following` is tri-state** — NULL defers to participation (derived at read; participation never writes), TRUE explicit follow, FALSE explicit mute that outranks; unfollow writes FALSE; `effective = COALESCE(following, participated)`; fourth test (pod 56817/56822)

The writer-scoping rule (56807/56809) did make the squash. These are the rulings #1109 (`thread_user_state`) is built to. Docs only, 4 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)