### PR TITLE
fix(messages): dispatch legacy PG posts to agents

### DIFF
--- a/backend/__tests__/service/pgMessages.test.js
+++ b/backend/__tests__/service/pgMessages.test.js
@@ -119,6 +119,30 @@ describe('PostgreSQL Message Routes', () => {
     expect(AgentMentionService.enqueueDmEvent).not.toHaveBeenCalled();
   });
 
+  it('delivers the persisted row when the post-write author join is unavailable', async () => {
+    const persistedMessage = {
+      id: 'message-join-miss',
+      content: '@recorder capture this',
+      username: 'sam',
+    };
+    PGPod.findById.mockResolvedValue({ id: 'pod1', type: 'chat' });
+    PGPod.isMember.mockResolvedValue(true);
+    PGMessage.create.mockResolvedValue(persistedMessage);
+    PGMessage.findById.mockResolvedValue(null);
+    const token = generateTestToken('user1');
+
+    const res = await request(app)
+      .post('/api/pg/messages/pod1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ content: persistedMessage.content })
+      .expect(200);
+
+    expect(res.body).toEqual(persistedMessage);
+    expect(AgentMentionService.enqueueMentions).toHaveBeenCalledWith({
+      podId: 'pod1', message: persistedMessage, userId: 'user1', username: 'sam',
+    });
+  });
+
   it('dispatches a PG post in an agent DM through the DM pipeline', async () => {
     const message = {
       id: 'message-2',

--- a/backend/__tests__/service/pgMessages.test.js
+++ b/backend/__tests__/service/pgMessages.test.js
@@ -26,8 +26,15 @@ jest.mock('../../models/pg/Message', () => ({
   findById: jest.fn(),
 }));
 
+jest.mock('../../services/agentMentionService', () => ({
+  enqueueMentions: jest.fn(),
+  enqueueDmEvent: jest.fn(),
+  isAutoRoutedDmPod: (type) => ['agent-admin', 'agent-room', 'agent-dm'].includes(type),
+}));
+
 const PGPod = require('../../models/pg/Pod');
 const PGMessage = require('../../models/pg/Message');
+const AgentMentionService = require('../../services/agentMentionService');
 
 let app;
 
@@ -86,6 +93,54 @@ describe('PostgreSQL Message Routes', () => {
 
     expect(PGMessage.create).toHaveBeenCalledWith('pod1', 'user1', 'Hi there');
     expect(res.body.content).toBe('Hi there');
+  });
+
+  it('dispatches a regular PG post through the mention pipeline with its joined author', async () => {
+    const message = {
+      id: 'message-1',
+      content: '@recorder capture this',
+      userId: { _id: 'user1', username: 'sam' },
+    };
+    PGPod.findById.mockResolvedValue({ id: 'pod1', type: 'chat' });
+    PGPod.isMember.mockResolvedValue(true);
+    PGMessage.create.mockResolvedValue({ id: message.id });
+    PGMessage.findById.mockResolvedValue(message);
+    const token = generateTestToken('user1');
+
+    await request(app)
+      .post('/api/pg/messages/pod1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ content: message.content })
+      .expect(200);
+
+    expect(AgentMentionService.enqueueMentions).toHaveBeenCalledWith({
+      podId: 'pod1', message, userId: 'user1', username: 'sam',
+    });
+    expect(AgentMentionService.enqueueDmEvent).not.toHaveBeenCalled();
+  });
+
+  it('dispatches a PG post in an agent DM through the DM pipeline', async () => {
+    const message = {
+      id: 'message-2',
+      content: 'hello directly',
+      userId: { _id: 'user1', username: 'sam' },
+    };
+    PGPod.findById.mockResolvedValue({ id: 'pod1', type: 'agent-room' });
+    PGPod.isMember.mockResolvedValue(true);
+    PGMessage.create.mockResolvedValue({ id: message.id });
+    PGMessage.findById.mockResolvedValue(message);
+    const token = generateTestToken('user1');
+
+    await request(app)
+      .post('/api/pg/messages/pod1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ content: message.content })
+      .expect(200);
+
+    expect(AgentMentionService.enqueueDmEvent).toHaveBeenCalledWith({
+      podId: 'pod1', message, userId: 'user1', username: 'sam',
+    });
+    expect(AgentMentionService.enqueueMentions).not.toHaveBeenCalled();
   });
 
   it('rejects message creation for non-members', async () => {

--- a/backend/__tests__/service/pgMessages.test.js
+++ b/backend/__tests__/service/pgMessages.test.js
@@ -26,11 +26,14 @@ jest.mock('../../models/pg/Message', () => ({
   findById: jest.fn(),
 }));
 
-jest.mock('../../services/agentMentionService', () => ({
-  enqueueMentions: jest.fn(),
-  enqueueDmEvent: jest.fn(),
-  isAutoRoutedDmPod: (type) => ['agent-admin', 'agent-room', 'agent-dm'].includes(type),
-}));
+jest.mock('../../services/agentMentionService', () => {
+  const { isAutoRoutedDmPod } = jest.requireActual('../../services/agentMentionService');
+  return {
+    enqueueMentions: jest.fn(),
+    enqueueDmEvent: jest.fn(),
+    isAutoRoutedDmPod,
+  };
+});
 
 const PGPod = require('../../models/pg/Pod');
 const PGMessage = require('../../models/pg/Message');

--- a/backend/__tests__/unit/controllers/messageController.test.js
+++ b/backend/__tests__/unit/controllers/messageController.test.js
@@ -6,11 +6,14 @@ const { AgentInstallation } = require('../../../models/AgentRegistry');
 
 jest.mock('../../../models/Pod');
 jest.mock('../../../models/pg/Message');
-jest.mock('../../../services/agentMentionService', () => ({
-  enqueueMentions: jest.fn().mockResolvedValue({ enqueued: [], implicit: [], skipped: [] }),
-  enqueueDmEvent: jest.fn().mockResolvedValue({ enqueued: [], skipped: [] }),
-  isAutoRoutedDmPod: (type) => ['agent-admin', 'agent-room', 'agent-dm'].includes(type),
-}));
+jest.mock('../../../services/agentMentionService', () => {
+  const { isAutoRoutedDmPod } = jest.requireActual('../../../services/agentMentionService');
+  return {
+    enqueueMentions: jest.fn().mockResolvedValue({ enqueued: [], implicit: [], skipped: [] }),
+    enqueueDmEvent: jest.fn().mockResolvedValue({ enqueued: [], skipped: [] }),
+    isAutoRoutedDmPod,
+  };
+});
 jest.mock('../../../models/AgentRegistry', () => ({
   AgentInstallation: { countDocuments: jest.fn() },
 }));

--- a/backend/__tests__/unit/controllers/messageController.test.js
+++ b/backend/__tests__/unit/controllers/messageController.test.js
@@ -9,6 +9,7 @@ jest.mock('../../../models/pg/Message');
 jest.mock('../../../services/agentMentionService', () => ({
   enqueueMentions: jest.fn().mockResolvedValue({ enqueued: [], implicit: [], skipped: [] }),
   enqueueDmEvent: jest.fn().mockResolvedValue({ enqueued: [], skipped: [] }),
+  isAutoRoutedDmPod: (type) => ['agent-admin', 'agent-room', 'agent-dm'].includes(type),
 }));
 jest.mock('../../../models/AgentRegistry', () => ({
   AgentInstallation: { countDocuments: jest.fn() },

--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -76,6 +76,16 @@ describe('AgentMentionService', () => {
     expect(result).toEqual(['someoneelse']);
   });
 
+  test.each([
+    ['agent-admin', true],
+    ['agent-room', true],
+    ['agent-dm', true],
+    ['chat', false],
+    ['team', false],
+  ])('classifies %s as an auto-routed DM pod: %s', (type, expected) => {
+    expect(AgentMentionService.isAutoRoutedDmPod(type)).toBe(expected);
+  });
+
   test('enqueueMentions skips when not installed', async () => {
     AgentInstallation.find.mockReturnValue({
       lean: jest.fn().mockResolvedValue([]),

--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -290,11 +290,9 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
     // agent-admin (legacy 1:1 admin DM), agent-room (1:1 user↔agent DM), and
     // agent-dm (any 2-member DM, including agent↔agent) all auto-route every
     // human message to the agent — no @mention needed. Other pod types only
-    // fire on explicit @mentions. Adding a new private 1:1 pod type without
-    // updating this allow-list silently drops every message; see
-    // docs/agents/AGENT_RUNTIME.md "Routing Invariants" for the canonical
-    // version of this rule.
-    const isDmPod = pod.type === 'agent-admin' || pod.type === 'agent-room' || pod.type === 'agent-dm';
+    // fire on explicit @mentions. `isAutoRoutedDmPod` owns that allow-list so
+    // the legacy PG endpoint cannot silently drift from this primary path.
+    const isDmPod = AgentMentionService.isAutoRoutedDmPod(pod.type);
     let responseMessage: NormalizedMessage | (NormalizedMessage & {
       agentDelivery: {
         enqueued: number; implicit: string[]; agentsInPod: number; woken: number;

--- a/backend/controllers/pgMessageController.ts
+++ b/backend/controllers/pgMessageController.ts
@@ -147,7 +147,10 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
     }
 
     const newMessage = await PGMessage.create(podId, userId, content);
-    const message = await PGMessage.findById(newMessage.id) as CreatedMessage | null;
+    // Match the primary controller: the post-write JOIN supplies the author
+    // for the response and wake frame, while the INSERT row remains a valid
+    // persisted-message fallback if that re-read is unavailable.
+    const message = ((await PGMessage.findById(newMessage.id)) || newMessage) as CreatedMessage;
 
     // This endpoint is older than the PG-primary /api/messages path, but it
     // still writes the same user-authored messages. Dispatch them through the

--- a/backend/controllers/pgMessageController.ts
+++ b/backend/controllers/pgMessageController.ts
@@ -7,11 +7,35 @@ const PGMessage = require('../models/pg/Message');
 // eslint-disable-next-line global-require
 const MongoPod = require('../models/Pod');
 // eslint-disable-next-line global-require
+const AgentMentionService = require('../services/agentMentionService');
+// eslint-disable-next-line global-require
 const { syncPodFromMongo } = require('../services/pgPodSyncService');
 
 interface AuthRequest extends Request {
   userId?: string;
-  user?: { id: string };
+  user?: { id: string; username?: string };
+}
+
+type CreatedMessage = {
+  _id?: string;
+  id?: string;
+  content?: string;
+  text?: string;
+  messageType?: string;
+  message_type?: string;
+  createdAt?: unknown;
+  created_at?: unknown;
+  username?: string;
+  user?: { username?: string };
+  userId?: { username?: string } | string;
+};
+
+function authorUsername(message: CreatedMessage | null | undefined, requestUser?: AuthRequest['user']): string | undefined {
+  const joinedAuthor = message?.userId;
+  return requestUser?.username
+    || (joinedAuthor && typeof joinedAuthor === 'object' ? joinedAuthor.username : undefined)
+    || message?.username
+    || message?.user?.username;
 }
 
 // Check if user is a member via PG, falling back to MongoDB as source of truth
@@ -123,7 +147,19 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
     }
 
     const newMessage = await PGMessage.create(podId, userId, content);
-    const message = await PGMessage.findById(newMessage.id);
+    const message = await PGMessage.findById(newMessage.id) as CreatedMessage | null;
+
+    // This endpoint is older than the PG-primary /api/messages path, but it
+    // still writes the same user-authored messages. Dispatch them through the
+    // same mention/DM pipeline after persistence so a post here cannot be a
+    // silent escape hatch around agent delivery.
+    const username = authorUsername(message, req.user);
+    if (AgentMentionService.isAutoRoutedDmPod(pod.type)) {
+      await AgentMentionService.enqueueDmEvent({ podId, message, userId, username });
+    } else {
+      await AgentMentionService.enqueueMentions({ podId, message, userId, username });
+    }
+
     res.json(message);
   } catch (err) {
     const e = err as { message?: string; kind?: string };

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -837,10 +837,11 @@ const resolveImplicitReplyTarget = async (
 
 // Pod types that auto-route every message to non-sender members as a
 // chat.mention event. Adding a new private 1:1 type without listing it
-// here silently drops every message; mirrored in
-// `messageController.createMessage` and called out in
-// docs/agents/AGENT_RUNTIME.md "Routing Invariants".
+// here silently drops every message; controllers call the predicate below
+// rather than maintaining a second copy of this delivery rule.
 const DM_POD_TYPES = new Set(['agent-admin', 'agent-room', 'agent-dm']);
+
+const isAutoRoutedDmPod = (type: unknown): boolean => DM_POD_TYPES.has(String(type));
 
 // ── ADR-018 D8: wake-on-message ─────────────────────────────────────────────
 //
@@ -968,7 +969,7 @@ const enqueueWakeOnMessage = async ({
     // into a DM pod that enqueueDmEvent already covers.
     return woken;
   }
-  if (podRow?.type && DM_POD_TYPES.has(podRow.type)) return woken;
+  if (podRow?.type && isAutoRoutedDmPod(podRow.type)) return woken;
 
   // Truthful inputs, not a hardcoded false: the collab cue is held off
   // wakes by its own event-type gate inside buildContentForTarget, so
@@ -1461,7 +1462,7 @@ const enqueueDmEvent = async ({
   podId, message, userId, username,
 }: EnqueueDmOptions): Promise<EnqueueDmResult> => {
   const pod = await Pod.findById(podId).lean() as Record<string, unknown> | null;
-  if (!pod || !DM_POD_TYPES.has(pod.type as string)) {
+  if (!pod || !isAutoRoutedDmPod(pod.type)) {
     return { enqueued: false, reason: 'not_dm_pod' };
   }
 
@@ -1706,6 +1707,7 @@ export {
   enqueueMentions,
   enqueueDmEvent,
   MENTION_ALIASES,
+  isAutoRoutedDmPod,
   // Exported so the ADR-024 D1 board fan-out (taskEventService.notifyPodAgents)
   // gates on the SAME opt-in rather than reimplementing the predicate. The
   // config shape is a Mongoose Map on some paths and a plain object on others,


### PR DESCRIPTION
## Summary
- route `POST /api/pg/messages/:podId` through the same post-persistence agent delivery pipeline as the PG-primary message endpoint
- preserve the PG response contract while resolving the joined message author for the event frame; safely fall back to the persisted INSERT row if that join is unavailable
- centralize the auto-routed DM-pod predicate so the two write endpoints cannot drift

## Verification
- `PATH=/opt/homebrew/opt/node@20/bin:$PATH npm test -- --runInBand __tests__/service/pgMessages.test.js __tests__/unit/controllers/messageController.test.js __tests__/unit/services/agentMentionService.test.js` (86 tests)
- `PATH=/opt/homebrew/opt/node@20/bin:$PATH npm run tsc:check`
- Mutation control: removed the new post-write delivery branch; exactly the two new regular/DM route tests failed (4 passing, 2 failing). Restored the branch and reran green.

The machine-default Node 26 cannot load the repository's older `buffer-equal-constant-time` dependency (`SlowBuffer` was removed), so verification used installed Node 20.