### PR TITLE
fix(kernel): a note from the lapsed holder restores the claim, and says so

### DIFF
--- a/backend/__tests__/unit/routes/tasksApi.updateRenewsLease.test.js
+++ b/backend/__tests__/unit/routes/tasksApi.updateRenewsLease.test.js
@@ -277,3 +277,98 @@ describe('claim resets the per-lease rescue budget', () => {
     expect(row.lapsedFrom).toBeNull();
   });
 });
+
+/**
+ * The sweep-race half, found live on TASK-029 (2026-08-22).
+ *
+ * The deferral warning says "post a task update or re-claim — either renews
+ * the lease". Those two were NOT equivalent: the renewing filter requires
+ * `status: 'claimed'`, so once the sweep returned the row to `pending` a note
+ * fell through to the note-only path — 200, note recorded, no lease, and no
+ * way for the caller to tell.
+ *
+ * Delivery latency makes this the common case rather than the rare one: the
+ * warning routinely arrives after the sweep it was warning about. On TASK-029
+ * the warning was written at 12:24 and the note landed at 12:56, two minutes
+ * after the 12:54 sweep.
+ */
+describe('POST /updates after the sweep has already taken the row', () => {
+  it('the lapsed holder\'s note restores their claim', async () => {
+    await seed({
+      status: 'pending', claimedBy: null, claimedAt: null, claimExpiresAt: null,
+      lapsedFrom: 'holder', rescueDeferrals: 3,
+    });
+
+    const res = await postUpdate('holder', 'TASK-001', 'still mine, 2 of 4 shipped');
+    expect(res.status).toBe(200);
+    expect(res.body.leaseRenewed).toBe(true);
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    expect(row.status).toBe('claimed');
+    expect(row.claimedBy).toBe('holder');
+    expect(new Date(row.claimExpiresAt).getTime()).toBeGreaterThan(Date.now() + 29 * MIN);
+    // The budget resets with the lease, same as #1096 — a restored claim that
+    // kept a spent budget would be swept again within one orbit.
+    expect(row.rescueDeferrals).toBe(0);
+    expect(row.lapsedFrom).toBeNull();
+    expect(row.updates.map((u) => u.text)).toContain('still mine, 2 of 4 shipped');
+  });
+
+  it('but NOT if a peer won the race — the board beat them to it', async () => {
+    // This is the case that makes returning the row to the board mean anything.
+    await seed({
+      status: 'claimed', claimedBy: 'stranger', claimedAt: new Date(),
+      claimExpiresAt: new Date(Date.now() + LEASE_MS), lapsedFrom: 'holder',
+    });
+
+    const res = await postUpdate('holder', 'TASK-001', 'picking this back up');
+    expect(res.status).toBe(200);
+    expect(res.body.leaseRenewed).toBe(false);
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    expect(row.claimedBy).toBe('stranger');
+    // The note still lands. Gating the lease must never gate the audit trail.
+    expect(row.updates.map((u) => u.text)).toContain('picking this back up');
+  });
+
+  it('and NOT for a seat the row was never taken from', async () => {
+    // lapsedFrom names one seat. Without that filter, any peer could convert a
+    // pending row into their own claim by writing a note — which is a claim
+    // without the claim endpoint's rate limit or its atomicity contract.
+    await seed({
+      status: 'pending', claimedBy: null, claimedAt: null, claimExpiresAt: null,
+      lapsedFrom: 'holder',
+    });
+
+    const res = await postUpdate('stranger', 'TASK-001', 'drive-by note');
+    expect(res.status).toBe(200);
+    expect(res.body.leaseRenewed).toBe(false);
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    expect(row.status).toBe('pending');
+    expect(row.claimedBy).toBeFalsy();
+    expect(row.updates.map((u) => u.text)).toContain('drive-by note');
+  });
+
+  it('a pending row with no lapsedFrom is claimable by nobody via a note', async () => {
+    // A never-claimed row. `lapsedFrom: null` must not match a caller whose
+    // claimKey is also falsy — the filter has to require a real match.
+    await seed({ status: 'pending', claimedBy: null, claimExpiresAt: null, lapsedFrom: null });
+
+    const res = await postUpdate('holder', 'TASK-001', 'thoughts on this one');
+    expect(res.status).toBe(200);
+    expect(res.body.leaseRenewed).toBe(false);
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    expect(row.status).toBe('pending');
+    expect(row.updates.map((u) => u.text)).toContain('thoughts on this one');
+  });
+
+  it('the holder path still reports leaseRenewed on an ordinary renewal', async () => {
+    const claimedAt = new Date(Date.now() - 25 * MIN);
+    await seed({ claimedBy: 'holder', claimedAt, claimExpiresAt: new Date(claimedAt.getTime() + LEASE_MS) });
+
+    const res = await postUpdate('holder', 'TASK-001', 'progress');
+    expect(res.body.leaseRenewed).toBe(true);
+  });
+});

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -545,13 +545,55 @@ router.post('/:podId/:taskId/updates', taskWriteRateLimit(60), auth, async (req:
         { new: true },
       )
       : null;
+    let leaseRenewed = Boolean(task);
+
+    // Second attempt: the row was already swept back to `pending` before the
+    // note arrived. The renewing filter above requires `status: 'claimed'`, so
+    // it misses — and the note-only fallback below then returns 200 with no
+    // lease, leaving the caller believing it renewed when it did not.
+    //
+    // That is not a hypothetical. The deferral warning tells the holder "post a
+    // task update or re-claim — either renews the lease", and delivery latency
+    // means the warning routinely ARRIVES after the sweep it was warning about.
+    // Observed on TASK-029, 2026-08-22: warning written 12:24 (2 deferrals
+    // left), row swept to pending 12:54, note posted 12:56 landed with
+    // status still `pending` and claimedBy null. The seat only noticed because
+    // it read the response body.
+    //
+    // `lapsedFrom` names the seat the sweep took it from, so this restores the
+    // claim to its former holder and NOBODY else. If a peer claimed the row in
+    // between, status is `claimed` with their id and both filters miss — the
+    // race is won by the peer, which is the whole point of returning it to the
+    // board. This makes the cue's two options actually equivalent.
+    if (!task && claimKey) {
+      task = await Task.findOneAndUpdate(
+        { podId: podFilter, taskId, status: 'pending', lapsedFrom: claimKey },
+        {
+          $set: {
+            status: 'claimed',
+            claimedBy: claimKey,
+            claimedAt: now,
+            claimExpiresAt: new Date(now.getTime() + TASK_CLAIM_LEASE_MS),
+            rescueDeferrals: 0,
+            lapsedFrom: null,
+          },
+          $push: note,
+        },
+        { new: true },
+      );
+      leaseRenewed = Boolean(task);
+    }
+
     if (!task) {
       task = await Task.findOneAndUpdate({ podId: podFilter, taskId }, { $push: note }, { new: true });
     }
     if (!task) return res.status(404).json({ error: 'Task not found' });
     emitTaskUpdated(podId, task, 'updated');
     notifyAgents(req, podId, task, 'updated');
-    return res.json({ task });
+    // Reported explicitly. A note that did not renew is a legitimate outcome
+    // (a peer now holds the row, or you never did), but it must never be
+    // indistinguishable from one that did — that silence is the whole bug.
+    return res.json({ task, leaseRenewed });
   } catch (err) {
     console.error('POST /tasks/updates error:', err);
     return res.status(500).json({ error: 'Failed to add update' });


### PR DESCRIPTION
The deferral warning tells a holder:

> To keep it, post a task update or re-claim — **either renews the lease**.

Those two are not equivalent, and the difference is silent.

## The defect

`POST /tasks/:podId/:taskId/updates` tries the renewing write first, filtered on `status: 'claimed'` (`tasksApi.ts:527-528`). Once the sweep has returned the row to `pending`, that filter misses and the note falls through to the note-only fallback: **200, note recorded, no lease, and nothing in the response to distinguish it from a successful renewal.**

**Delivery latency makes this the common case rather than the rare one** — the warning routinely arrives *after* the sweep it was warning about.

Observed live on TASK-029 today, in this seat:

| time | event |
|---|---|
| 12:24 | deferral warning written — "2 deferrals left" |
| 12:34, 12:44 | deferrals 2 and 3 |
| **12:54** | **sweep returns the row to `pending`** |
| 12:56 | warning delivered; seat posts a task update as instructed |
| | note appended · `status: pending` · `claimedBy: null` |

The seat only noticed because it read the response body. The instruction the kernel gave was, at that moment, false.

This is the remaining half of the pair `#1096` fixed. That one composed renewal with the deferral budget; this one composes renewal with the sweep that ends the budget. The code comment above the renewing write already names the shape — *"the kernel rescues them for doing exactly what its own cue told them to do"* — it just didn't extend past the sweep.

## The fix

A second attempt between the two existing ones, filtered on `status: 'pending'` **AND** `lapsedFrom: <caller>`:

```js
{ podId, taskId, status: 'pending', lapsedFrom: claimKey }
→ { status: 'claimed', claimedBy, claimedAt, claimExpiresAt, rescueDeferrals: 0, lapsedFrom: null }
```

`lapsedFrom` names the one seat the sweep took the row from, which is exactly the authorization this needs:

- **A peer who won the race keeps it.** Their claim sets `status: 'claimed'` with their id, so both filters miss and the note is recorded without touching the lease. That race is the entire point of returning the row to the board.
- **A drive-by note cannot become a claim.** Without the `lapsedFrom` term, any peer could convert a pending row into their own claim by writing a note — a claim without the claim endpoint's rate limit or its atomicity contract.
- **A never-claimed row stays claimable by nobody this way.** `lapsedFrom: null` must not match a caller with a falsy `claimKey`; the filter requires a real match.

Budget resets with the lease, per #1096 — a restored claim carrying a spent budget gets swept again within one orbit.

## `leaseRenewed` in the response

The response now carries `{ task, leaseRenewed }`.

Not renewing is a legitimate outcome — a peer holds the row, or you never did. **Being unable to tell is the bug.** A caller that follows the cue and gets a 200 currently has no way to learn it is no longer the holder, which is how a seat keeps working a row the board has already re-advertised.

## Tests

Five cases appended to the existing `tasksApi.updateRenewsLease` suite, which runs against real in-memory Mongo rather than a mocked model — deliberately, because the authorization lives in the `findOneAndUpdate` *filter*, so it is Mongo that decides whether the restoring form applies. A mocked `Task` would only assert that the route passed a filter shaped like the one the test also wrote.

| case | asserts |
|---|---|
| lapsed holder's note restores the claim | `status`, `claimedBy`, full lease, `rescueDeferrals: 0`, `lapsedFrom: null`, `leaseRenewed: true` |
| a peer won the race | peer keeps the claim, `leaseRenewed: false` |
| a seat the row was never taken from | stays `pending`, no claim |
| a pending row with no `lapsedFrom` | stays `pending` |
| ordinary holder renewal | still reports `leaseRenewed: true` |

Every case also asserts **the note landed** — gating the lease must never gate the audit trail, which is the invariant the original suite was built around.

64 tests green across all six `tasksApi` suites.

## Not in scope

The warning text itself is fine and is *not* stale — `taskEventService` refreshes `payload.content` on fold, so "2 deferrals left" was an honest statement when written at 12:24. The problem was never the wording; it was that the API did not honour it. This makes the cue true rather than rewording it to be weaker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)