### PR TITLE
fix(messages): reject reply fallback data loss

### DIFF
--- a/backend/__tests__/unit/controllers/messageController.test.js
+++ b/backend/__tests__/unit/controllers/messageController.test.js
@@ -1,10 +1,15 @@
 const messageController = require('../../../controllers/messageController');
 const Pod = require('../../../models/Pod');
+const MongoMessage = require('../../../models/Message');
 const PGMessage = require('../../../models/pg/Message');
 const AgentMentionService = require('../../../services/agentMentionService');
 const { AgentInstallation } = require('../../../models/AgentRegistry');
 
 jest.mock('../../../models/Pod');
+jest.mock('../../../models/Message', () => ({
+  create: jest.fn(),
+  findById: jest.fn(),
+}));
 jest.mock('../../../models/pg/Message');
 jest.mock('../../../services/agentMentionService', () => {
   const { isAutoRoutedDmPod } = jest.requireActual('../../../services/agentMentionService');
@@ -26,6 +31,11 @@ const socketConfig = require('../../../config/socket');
 describe('messageController', () => {
   beforeEach(() => {
     AgentInstallation.countDocuments.mockResolvedValue(0);
+    // The reply-rejection mutation control deliberately prepares a Mongo
+    // fallback that the correct path must not consume. Reset these two mocks
+    // so that unused one-shot values cannot leak into the next case.
+    MongoMessage.create.mockReset();
+    MongoMessage.findById.mockReset();
   });
 
   afterEach(() => {
@@ -126,6 +136,96 @@ describe('messageController', () => {
           enqueued: 1, implicit: [], agentsInPod: 2, woken: 0,
         },
       });
+    });
+
+    it('rejects a reply when PostgreSQL is unavailable instead of silently dropping its parent edge', async () => {
+      const unsafeFallbackRow = {
+        _id: { toString: () => 'mongo-reply' },
+        podId: { toString: () => 'p1' },
+        userId: { toString: () => 'u1' },
+        content: 'a reply',
+        messageType: 'text',
+      };
+      Pod.findById.mockResolvedValue({ members: ['u1'], type: 'chat' });
+      PGMessage.create.mockRejectedValueOnce(new Error('PostgreSQL unavailable'));
+      // If the guard is removed, this is the real-looking Mongo row the old
+      // fallback would return; the test must then fail rather than masking the
+      // silent data loss behind a mock error.
+      MongoMessage.create.mockResolvedValueOnce(unsafeFallbackRow);
+      MongoMessage.findById.mockReturnValueOnce({
+        populate: jest.fn().mockResolvedValue(unsafeFallbackRow),
+      });
+      const req = {
+        params: { podId: 'p1' },
+        body: { content: 'a reply', replyToMessageId: 'parent-1' },
+        user: { id: 'u1' },
+      };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await messageController.createMessage(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(503);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Replies are temporarily unavailable. Please try again shortly.',
+        code: 'REPLY_REQUIRES_POSTGRES',
+      });
+      expect(MongoMessage.create).not.toHaveBeenCalled();
+      expect(AgentMentionService.enqueueMentions).not.toHaveBeenCalled();
+    });
+
+    it('does not reject or duplicate a reply when PG INSERT succeeded but its post-write read fails', async () => {
+      const createdReply = { id: 'pg-reply', content: 'a reply' };
+      Pod.findById.mockResolvedValue({ members: ['u1'], type: 'chat' });
+      PGMessage.create.mockResolvedValueOnce(createdReply);
+      PGMessage.findById.mockRejectedValueOnce(new Error('PostgreSQL read unavailable'));
+      const req = {
+        params: { podId: 'p1' },
+        body: { content: createdReply.content, replyToMessageId: 'parent-1' },
+        user: { id: 'u1' },
+      };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await messageController.createMessage(req, res);
+
+      expect(MongoMessage.create).not.toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        id: createdReply.id, content: createdReply.content,
+      }));
+    });
+
+    it('keeps the Mongo availability fallback for a non-reply when PostgreSQL is unavailable', async () => {
+      const mongoFallbackRow = {
+        _id: { toString: () => 'mongo-message' },
+        podId: { toString: () => 'p1' },
+        userId: {
+          _id: { toString: () => 'u1' }, username: 'alice', profilePicture: 'default',
+        },
+        content: 'ordinary message',
+        messageType: 'text',
+      };
+      Pod.findById.mockResolvedValue({ members: ['u1'], type: 'chat' });
+      PGMessage.create.mockRejectedValueOnce(new Error('PostgreSQL unavailable'));
+      MongoMessage.create.mockResolvedValueOnce(mongoFallbackRow);
+      MongoMessage.findById.mockReturnValueOnce({
+        populate: jest.fn().mockResolvedValue(mongoFallbackRow),
+      });
+      const req = {
+        params: { podId: 'p1' },
+        body: { content: mongoFallbackRow.content },
+        user: { id: 'u1' },
+      };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+      await messageController.createMessage(req, res);
+
+      expect(MongoMessage.create).toHaveBeenCalledWith({
+        podId: 'p1', userId: 'u1', content: mongoFallbackRow.content, messageType: 'text',
+      });
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'mongo-message', content: mongoFallbackRow.content,
+      }));
     });
 
     it('uses the joined PG author for a JWT-posted chat wake', async () => {

--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -248,12 +248,30 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
       // response would lack username/profile_picture and the v2 chat would
       // render the author as "Unknown" until a refresh pulled the joined
       // row. findById re-fetches with the JOIN so the optimistic render
-      // already has the right author identity.
-      const populated = created?.id ? await PGMessage.findById(created.id) : null;
+      // already has the right author identity. A JOIN failure is not a write
+      // failure: falling into the Mongo fallback after INSERT would duplicate
+      // the message (or falsely reject an already-persisted reply).
+      let populated = null;
+      try {
+        populated = created?.id ? await PGMessage.findById(created.id) : null;
+      } catch (readErr) {
+        console.warn('[messageController] PG post-write read failed:', (readErr as Error).message);
+      }
       message = (populated || created) as NormalizedMessage;
     } catch (pgErr) {
       const e = pgErr as { message?: string };
       console.warn('PG unavailable for createMessage, falling back to MongoDB:', e.message);
+      // Mongo messages have no reply_to_message_id column and are never
+      // reconciled into PG. A reply written here would look successful while
+      // permanently losing its parent edge, so only non-replies may use this
+      // availability fallback.
+      if (replyToMessageId) {
+        res.status(503).json({
+          error: 'Replies are temporarily unavailable. Please try again shortly.',
+          code: 'REPLY_REQUIRES_POSTGRES',
+        });
+        return;
+      }
       const mongoMsg = await MongoMessage.create({
         podId,
         userId,


### PR DESCRIPTION
## Summary
- reject a reply with `503 REPLY_REQUIRES_POSTGRES` when its PostgreSQL INSERT fails, rather than write an unthreaded Mongo fallback row that cannot be reconciled later
- retain the Mongo availability fallback for ordinary messages
- isolate the post-write PG join: a successful INSERT stays successful if its response enrichment read fails, preventing both duplicate fallback writes and a false reply rejection

## Verification
- `PATH=/opt/homebrew/opt/node@20/bin:$PATH npm test -- --runInBand __tests__/unit/controllers/messageController.test.js __tests__/service/pgMessages.test.js __tests__/unit/services/agentMentionService.test.js` (89 tests)
- `PATH=/opt/homebrew/opt/node@20/bin:$PATH npm run tsc:check`
- Mutation control: removed the reply guard; the reply-outage test failed because the old Mongo fallback returned `200` instead of `503`. Restored the guard and reran green.

No Mongo schema widening: the fallback store has no reply-edge field, and these records are not reconciled into PostgreSQL.