### PR TITLE
fix(v2): show send errors at composer

### DIFF
--- a/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
@@ -13,6 +13,11 @@ jest.mock('../../context/SocketContext', () => ({
   useSocket: () => ({ socket: null, connected: false }),
 }));
 
+// Composer behavior does not depend on avatar rendering. Keep this test
+// isolated from the external DiceBear package graph used by V2Avatar.
+jest.mock('../components/V2Avatar', () => () => <span data-testid="avatar" />);
+jest.mock('../utils/avatars', () => ({ initialsFor: (name: string) => name.slice(0, 2) }));
+
 // jsdom has no scrollIntoView; the component auto-scrolls on mount.
 beforeAll(() => {
   Element.prototype.scrollIntoView = jest.fn();
@@ -56,6 +61,7 @@ const makeDetail = (overrides = {}) => ({
   sendMessage: jest.fn(() => Promise.resolve({ _id: 'm1' })),
   loading: false,
   error: null,
+  sendError: null,
   refresh: jest.fn(),
   ...overrides,
 });
@@ -86,5 +92,44 @@ describe('V2PodChat composer send button', () => {
   test('send button is disabled while the draft is empty', () => {
     renderChat(makeDetail());
     expect(screen.getByRole('button', { name: /send message/i })).toBeDisabled();
+  });
+
+  test('shows send failures by the composer and keeps the reply draft intact', async () => {
+    const detail = makeDetail({
+      messages: [{
+        id: 'm1',
+        pod_id: 'p1',
+        user_id: 'u2',
+        content: 'Can you check this?',
+        message_type: 'text',
+        created_at: '2026-08-22T13:00:00Z',
+        user: { username: 'teammate' },
+      }],
+      sendMessage: jest.fn(() => Promise.resolve(null)),
+    });
+    const { rerender } = renderChat(detail);
+
+    fireEvent.click(screen.getByRole('button', { name: /reply to teammate/i }));
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+      target: { value: 'I am checking it now.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+    await waitFor(() => {
+      expect(detail.sendMessage).toHaveBeenCalledWith('I am checking it now.', 'text', 'm1');
+    });
+
+    rerender(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <V2PodChat detail={{ ...detail, sendError: 'Replies are temporarily unavailable. Please try again shortly.' }} />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+
+    const sendError = screen.getByText('Replies are temporarily unavailable. Please try again shortly.');
+    expect(sendError.closest('.v2-chat__composer')).not.toBeNull();
+    expect(sendError.closest('.v2-chat__messages')).toBeNull();
+    expect(screen.getByPlaceholderText(/message my workspace/i)).toHaveValue('I am checking it now.');
+    expect(screen.getByRole('button', { name: /cancel reply/i }).closest('.v2-chat__reply-chip')).not.toBeNull();
   });
 });

--- a/frontend/src/v2/__tests__/useV2PodDetailReply.test.tsx
+++ b/frontend/src/v2/__tests__/useV2PodDetailReply.test.tsx
@@ -98,4 +98,20 @@ describe('useV2PodDetail reply threading (#646)', () => {
     expect(sent).toHaveLength(1);
     expect(sent[0].replyTo).toEqual(replyTo);
   });
+
+  it('keeps a send failure separate from pod load errors', async () => {
+    mockApi.post.mockRejectedValue({
+      response: { data: { error: 'Replies are temporarily unavailable. Please try again shortly.' } },
+    });
+
+    const { result } = renderHook(() => useV2PodDetail('p1'));
+    await waitFor(() => expect(socketHandlers.newMessage).toBeDefined());
+
+    await act(async () => {
+      await result.current.sendMessage('a reply', 'text', 'm1');
+    });
+
+    expect(result.current.sendError).toBe('Replies are temporarily unavailable. Please try again shortly.');
+    expect(result.current.error).toBeNull();
+  });
 });

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -211,7 +211,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
   const { t, i18n } = useTranslation();
   const numberFormatter = new Intl.NumberFormat(i18n.resolvedLanguage || i18n.language || 'en');
   const {
-    pod, members, messages, agents, sendMessage, loading, error,
+    pod, members, messages, agents, sendMessage, loading, error, sendError,
     hasMore, loadingOlder, loadOlder,
   } = detail;
   const api = useV2Api();
@@ -1349,9 +1349,9 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                   </svg>
                 </button>
               </div>
-              {composerError && (
+              {(composerError || sendError) && (
                 <div className="v2-chat__composer-footer">
-                  <span className="v2-chat__composer-error">{composerError}</span>
+                  <span className="v2-chat__composer-error">{composerError || sendError}</span>
                 </div>
               )}
               {unreachableMentioned.length > 0 && (

--- a/frontend/src/v2/hooks/useV2PodDetail.ts
+++ b/frontend/src/v2/hooks/useV2PodDetail.ts
@@ -126,6 +126,8 @@ export interface UseV2PodDetailResult {
   agents: V2Agent[];
   loading: boolean;
   error: string | null;
+  /** Send failures belong beside the composer; load failures use `error`. */
+  sendError: string | null;
   /** A full page came back, so older history probably exists. */
   hasMore: boolean;
   loadingOlder: boolean;
@@ -207,6 +209,7 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
   const [agents, setAgents] = useState<V2Agent[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [sendError, setSendError] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
 
@@ -294,10 +297,12 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
       setPod(null);
       setMessages([]);
       setAgents([]);
+      setSendError(null);
       return;
     }
     setLoading(true);
     setError(null);
+    setSendError(null);
     try {
       await fetchPod(podId);
       const [messagesResult] = await Promise.allSettled([
@@ -393,7 +398,7 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
   const sendMessage = useCallback(async (content: string, messageType = 'text', replyToMessageId?: string): Promise<V2Message | null> => {
     if (!podId || !content.trim()) return null;
     try {
-      setError(null);
+      setSendError(null);
       const created = await api.post<V2Message>(
         `/api/messages/${podId}`,
         { content: content.trim(), messageType, ...(replyToMessageId ? { replyToMessageId } : {}) },
@@ -419,7 +424,7 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
       return normalized;
     } catch (err) {
       const e = err as { response?: { data?: { error?: string; msg?: string } }; message?: string };
-      setError(e.response?.data?.error || e.response?.data?.msg || e.message || 'Failed to send message');
+      setSendError(e.response?.data?.error || e.response?.data?.msg || e.message || 'Failed to send message');
       return null;
     }
   }, [api, podId]);
@@ -429,7 +434,7 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
   );
 
   return {
-    pod, members, messages, agents, loading, error, hasMore, loadingOlder, loadOlder, refresh, sendMessage,
+    pod, members, messages, agents, loading, error, sendError, hasMore, loadingOlder, loadOlder, refresh, sendMessage,
   };
 };
 


### PR DESCRIPTION
## Summary
- separate message-send failures from pod load errors in `useV2PodDetail`
- render send failures in the existing composer-error slot while preserving the draft and reply target
- retain message-column errors for pod/history loading failures

## Verification
- `node node_modules/typescript/bin/tsc --noEmit`
- `node node_modules/jest/bin/jest.js --runInBand src/v2/__tests__/V2PodChatComposer.test.tsx src/v2/__tests__/useV2PodDetailReply.test.tsx` — 6 passed
- Mutation control: removing the `sendError` composer render makes the new reply-failure placement test fail; restoring it passes.

No copy or CSS change: the server error string and existing `v2-chat__composer-error` styling remain the source of truth.