### PR TITLE
fix(messages): return delivery feedback from legacy PG route

### DIFF
--- a/backend/__tests__/service/pgMessages.test.js
+++ b/backend/__tests__/service/pgMessages.test.js
@@ -29,7 +29,7 @@ jest.mock('../../models/pg/Message', () => ({
 jest.mock('../../services/agentMentionService', () => {
   const { isAutoRoutedDmPod } = jest.requireActual('../../services/agentMentionService');
   return {
-    enqueueMentions: jest.fn(),
+    enqueueMentions: jest.fn(async () => ({ enqueued: [], implicit: [], woken: [] })),
     enqueueDmEvent: jest.fn(),
     isAutoRoutedDmPod,
   };
@@ -96,6 +96,12 @@ describe('PostgreSQL Message Routes', () => {
 
     expect(PGMessage.create).toHaveBeenCalledWith('pod1', 'user1', 'Hi there');
     expect(res.body.content).toBe('Hi there');
+    expect(res.body.agentDelivery).toEqual({
+      enqueued: 0,
+      implicit: [],
+      agentsInPod: expect.any(Number),
+      woken: 0,
+    });
   });
 
   it('dispatches a regular PG post through the mention pipeline with its joined author', async () => {
@@ -140,7 +146,15 @@ describe('PostgreSQL Message Routes', () => {
       .send({ content: persistedMessage.content })
       .expect(200);
 
-    expect(res.body).toEqual(persistedMessage);
+    expect(res.body).toEqual({
+      ...persistedMessage,
+      agentDelivery: {
+        enqueued: 0,
+        implicit: [],
+        agentsInPod: expect.any(Number),
+        woken: 0,
+      },
+    });
     expect(AgentMentionService.enqueueMentions).toHaveBeenCalledWith({
       podId: 'pod1', message: persistedMessage, userId: 'user1', username: 'sam',
     });

--- a/backend/__tests__/unit/controllers/pgMessageController.test.js
+++ b/backend/__tests__/unit/controllers/pgMessageController.test.js
@@ -1,9 +1,13 @@
 const controller = require('../../../controllers/pgMessageController');
 const PGPod = require('../../../models/pg/Pod');
 const PGMessage = require('../../../models/pg/Message');
+const AgentMentionService = require('../../../services/agentMentionService');
+const { AgentInstallation } = require('../../../models/AgentRegistry');
 
 jest.mock('../../../models/pg/Pod');
 jest.mock('../../../models/pg/Message');
+jest.mock('../../../services/agentMentionService');
+jest.mock('../../../models/AgentRegistry');
 
 describe('pgMessageController', () => {
   afterEach(() => jest.clearAllMocks());
@@ -26,5 +30,42 @@ describe('pgMessageController', () => {
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
     await controller.getMessages(req, res);
     expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns mention delivery feedback for a legacy PG message post', async () => {
+    const message = { id: 'm1', content: 'hello @recorder', userId: { username: 'sam' } };
+    PGPod.findById.mockResolvedValue({ type: 'chat' });
+    PGPod.isMember.mockResolvedValue(true);
+    PGMessage.create.mockResolvedValue({ id: 'm1', content: 'hello @recorder' });
+    PGMessage.findById.mockResolvedValue(message);
+    AgentMentionService.isAutoRoutedDmPod.mockReturnValue(false);
+    AgentMentionService.enqueueMentions.mockResolvedValue({
+      enqueued: [{ installationId: 'i1' }],
+      implicit: ['recorder'],
+      woken: [{ installationId: 'i2' }],
+    });
+    AgentInstallation.countDocuments.mockResolvedValue(2);
+    const req = {
+      params: { podId: 'p1' },
+      body: { content: 'hello @recorder' },
+      userId: 'u1',
+      user: { id: 'u1', username: 'sam' },
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await controller.createMessage(req, res);
+
+    expect(AgentMentionService.enqueueMentions).toHaveBeenCalledWith({
+      podId: 'p1', message, userId: 'u1', username: 'sam',
+    });
+    expect(res.json).toHaveBeenCalledWith({
+      ...message,
+      agentDelivery: {
+        enqueued: 1,
+        implicit: ['recorder'],
+        agentsInPod: 2,
+        woken: 1,
+      },
+    });
   });
 });

--- a/backend/controllers/pgMessageController.ts
+++ b/backend/controllers/pgMessageController.ts
@@ -9,6 +9,8 @@ const MongoPod = require('../models/Pod');
 // eslint-disable-next-line global-require
 const AgentMentionService = require('../services/agentMentionService');
 // eslint-disable-next-line global-require
+const { AgentInstallation } = require('../models/AgentRegistry');
+// eslint-disable-next-line global-require
 const { syncPodFromMongo } = require('../services/pgPodSyncService');
 
 interface AuthRequest extends Request {
@@ -28,6 +30,12 @@ type CreatedMessage = {
   username?: string;
   user?: { username?: string };
   userId?: { username?: string } | string;
+  agentDelivery?: {
+    enqueued: number;
+    implicit: string[];
+    agentsInPod: number;
+    woken: number;
+  };
 };
 
 function authorUsername(message: CreatedMessage | null | undefined, requestUser?: AuthRequest['user']): string | undefined {
@@ -157,13 +165,31 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
     // same mention/DM pipeline after persistence so a post here cannot be a
     // silent escape hatch around agent delivery.
     const username = authorUsername(message, req.user);
+    let responseMessage = message;
     if (AgentMentionService.isAutoRoutedDmPod(pod.type)) {
       await AgentMentionService.enqueueDmEvent({ podId, message, userId, username });
     } else {
-      await AgentMentionService.enqueueMentions({ podId, message, userId, username });
+      const mentionResult = await AgentMentionService.enqueueMentions({ podId, message, userId, username });
+      let agentsInPod = 0;
+      try {
+        agentsInPod = await AgentInstallation.countDocuments({ podId, status: 'active' });
+      } catch (countErr) {
+        // Delivery metadata is advisory feedback. Do not turn an already
+        // persisted message into a failed post when the count is unavailable.
+        console.warn('[pgMessageController] active-agent delivery count failed:', (countErr as Error).message);
+      }
+      responseMessage = {
+        ...message,
+        agentDelivery: {
+          enqueued: mentionResult.enqueued.length,
+          implicit: mentionResult.implicit || [],
+          agentsInPod,
+          woken: mentionResult.woken?.length ?? 0,
+        },
+      };
     }
 
-    res.json(message);
+    res.json(responseMessage);
   } catch (err) {
     const e = err as { message?: string; kind?: string };
     console.error('Error in PG createMessage:', e.message);


### PR DESCRIPTION
## Summary
- expose the legacy PG route’s mention dispatch result as `agentDelivery`, matching `/api/messages`
- include explicit enqueue, implicit, active-installation, and wake-on-message counts
- keep DM-shaped pods aligned with the primary route: delivery metadata remains limited to mention-routed posts
- pin the contract through the actual `POST /api/pg/messages/:podId` service test, including the post-write JOIN-miss fallback

## Verification
- `npm test -- --runInBand __tests__/service/pgMessages.test.js __tests__/unit/controllers/pgMessageController.test.js` — 10 passed
- `npm run tsc:check`
- Mutation control: returning the old bare message makes both HTTP response-contract assertions fail; restoring the enriched response passes.