### PR TITLE
feat(threading): ambient-only wake scoping — the effective follower set (TASK-029 3/4)

### DIFF
--- a/backend/__tests__/unit/models/threadRootRoundTrip.test.js
+++ b/backend/__tests__/unit/models/threadRootRoundTrip.test.js
@@ -1,0 +1,91 @@
+/**
+ * The wake path reads `thread_root_id` off a message it did not construct.
+ *
+ * 3/4 hooks ambient scoping into `enqueueWakeOnMessage`, and the hook reads
+ * `message.thread_root_id`. The controller does `message = (populated ||
+ * created)` and hands THAT to `enqueueMentions` — so the object the hook
+ * actually receives is `findById`'s row, not `create`'s `RETURNING *`.
+ *
+ * `findById` projects an explicit column list. `thread_root_id` was missing
+ * from it, so the hook read `undefined` for every message and silently never
+ * scoped. Every 3/4 test passed throughout, because they build the message
+ * object directly with `thread_root_id` set and never travel create →
+ * findById. A test that constructs the shape the code under test never
+ * receives cannot find a projection bug; only a round trip can.
+ *
+ * The table comes from schema.sql via `applyTable` rather than being typed
+ * here, for the reason in that helper: a hand-written fixture only ever tests
+ * the columns you remembered — which is the same class of mistake as the
+ * projection this file exists to catch.
+ */
+
+const { newDb } = require('pg-mem');
+const { applyTable } = require('../../utils/schemaTable');
+
+const mockDb = newDb();
+const mockPool = new (mockDb.adapters.createPg().Pool)();
+
+jest.mock('../../../config/db-pg', () => ({ pool: mockPool }));
+
+const PGMessage = require('../../../models/pg/Message');
+
+const POD = 'pod-1';
+
+beforeAll(async () => {
+  // pods and users come from schema.sql too. Typing them here is how the
+  // first attempt failed: hand-written VARCHAR(255) keys against schema.sql's
+  // VARCHAR(24) is a foreign-key type mismatch, and the fixture that drifts
+  // from the DDL is the thing this helper exists to prevent.
+  await applyTable(mockPool, 'pods');
+  await applyTable(mockPool, 'users');
+  await applyTable(mockPool, 'messages');
+  await mockPool.query(
+    "INSERT INTO pods (id, name, type, created_by) VALUES ('pod-1', 'P', 'chat', 'user-1')",
+  );
+  await mockPool.query("INSERT INTO users (_id, username) VALUES ('user-1', 'sam')");
+});
+
+describe('findById carries thread_root_id, because the wake path reads it there', () => {
+  test('a reply round-trips its derived root through findById', async () => {
+    const root = await PGMessage.create(POD, 'user-1', 'root', 'text', null);
+    const reply = await PGMessage.create(POD, 'user-1', 'reply', 'text', root.id);
+
+    const read = await PGMessage.findById(reply.id);
+
+    expect(read.thread_root_id).toBe(root.id);
+  });
+
+  test('a deep reply too — one hop covers any depth, and the read must show it', async () => {
+    const a = await PGMessage.create(POD, 'user-1', 'a', 'text', null);
+    const b = await PGMessage.create(POD, 'user-1', 'b', 'text', a.id);
+    const c = await PGMessage.create(POD, 'user-1', 'c', 'text', b.id);
+
+    const read = await PGMessage.findById(c.id);
+
+    expect(read.thread_root_id).toBe(a.id);
+  });
+
+  test('a root exposes the KEY with a null value, not a missing key', async () => {
+    // A missing key and a null read identically to a truthiness check, and the
+    // hook is a truthiness check. Only one of them hides a dropped column, so
+    // assert on the key rather than on the value being falsy.
+    const root = await PGMessage.create(POD, 'user-1', 'lonely', 'text', null);
+
+    const read = await PGMessage.findById(root.id);
+
+    expect(Object.prototype.hasOwnProperty.call(read, 'thread_root_id')).toBe(true);
+    expect(read.thread_root_id).toBeNull();
+  });
+
+  test('findByPodId carries it too — the same projection, written twice', async () => {
+    // Two copies of one column list is why this was missed once already:
+    // fixing the one the failing test named leaves the other wrong.
+    const root = await PGMessage.create(POD, 'user-1', 'listed root', 'text', null);
+    const reply = await PGMessage.create(POD, 'user-1', 'listed reply', 'text', root.id);
+
+    const rows = await PGMessage.findByPodId(POD, 200);
+    const read = rows.find((r) => String(r.id) === String(reply.id));
+
+    expect(read.thread_root_id).toBe(root.id);
+  });
+});

--- a/backend/__tests__/unit/services/agentMentionService.threadScoping.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.threadScoping.test.js
@@ -36,10 +36,24 @@ const User = require('../../../models/User');
 const AgentEvent = require('../../../models/AgentEvent');
 const { narrowToThread } = require('../../../services/threadWakeScopeService');
 
+// `installedBy` is deliberately a DIFFERENT id from the bot's User row here.
+// It is the human installer on five of the write paths (podController:119,
+// personaHireService:93, podCurationService:147, authController:201,
+// agentProfile:259) and the bot itself on the rest — so a fixture where the
+// two coincide cannot tell a correct key from the wrong one. These differ so
+// the assertion below discriminates.
 const optIn = (agentName, installedBy) => ({
-  agentName, instanceId: 'default', displayName: agentName, installedBy,
+  agentName,
+  instanceId: 'default',
+  displayName: agentName,
+  installedBy,
   config: { wakeOnMessage: { enabled: true } },
 });
+
+const BOT_USER_ROWS = [
+  { _id: 'bot-user-a', botMetadata: { agentName: 'seat-a', instanceId: 'default' } },
+  { _id: 'bot-user-b', botMetadata: { agentName: 'seat-b', instanceId: 'default' } },
+];
 
 const byType = (t) => AgentEventService.enqueue.mock.calls.map(([a]) => a).filter((a) => a.type === t);
 
@@ -51,7 +65,12 @@ beforeEach(() => {
   jest.clearAllMocks();
   narrowToThread.mockImplementation(async (_root, targets) => targets);
   AgentInstallation.find.mockReturnValue({
-    lean: jest.fn().mockResolvedValue([optIn('seat-a', 'uid-a'), optIn('seat-b', 'uid-b')]),
+    lean: jest.fn().mockResolvedValue([
+      optIn('seat-a', 'human-installer-a'), optIn('seat-b', 'human-installer-b'),
+    ]),
+  });
+  User.find.mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(BOT_USER_ROWS) }),
   });
   AgentProfile.find.mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
   Pod.findById.mockReturnValue({
@@ -82,8 +101,45 @@ describe('the hook fires only for threaded messages', () => {
     const [root, targets, identify] = narrowToThread.mock.calls[0];
     expect(root).toBe(101);
     expect(targets.map((t) => t.agentName)).toEqual(['seat-a', 'seat-b']);
-    // Keyed on installedBy — the bot User id thread_user_state holds.
-    expect(identify(targets[0])).toBe('uid-a');
+    // The BOT's User row id, which is what thread_user_state.user_id holds —
+    // NOT `installedBy`, which on this fixture is the human who installed it.
+    expect(identify(targets[0])).toBe('bot-user-a');
+    expect(identify(targets[1])).toBe('bot-user-b');
+    expect(identify(targets[0])).not.toBe(targets[0].installedBy);
+  });
+
+  test('an install whose bot User row is missing keys to null, so it is KEPT', async () => {
+    // narrowToThread's contract: an unclassifiable target degrades to today's
+    // delivery rather than to silence. That only holds if `identify` says
+    // "unknown" instead of guessing a plausible id.
+    User.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([BOT_USER_ROWS[0]]) }),
+    });
+    await send({ id: 'm2b', content: 'in a thread', thread_root_id: 101 });
+    const [, targets, identify] = narrowToThread.mock.calls[0];
+    expect(identify(targets[0])).toBe('bot-user-a');
+    expect(identify(targets[1])).toBeNull();
+  });
+
+  test('the lookup fails closed to unscoped delivery, never to silence', async () => {
+    // A resolution failure must not drop wakes. Empty map -> every identify
+    // returns null -> narrowToThread keeps everyone.
+    User.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({ lean: jest.fn().mockRejectedValue(new Error('mongo down')) }),
+    });
+    await send({ id: 'm2c', content: 'in a thread', thread_root_id: 101 });
+    const [, targets, identify] = narrowToThread.mock.calls[0];
+    expect(identify(targets[0])).toBeNull();
+    expect(identify(targets[1])).toBeNull();
+    expect(byType('message.posted')).toHaveLength(2);
+  });
+
+  test('one query for the whole target list, not one per target', async () => {
+    await send({ id: 'm2d', content: 'in a thread', thread_root_id: 101 });
+    expect(User.find).toHaveBeenCalledTimes(1);
+    const [filter] = User.find.mock.calls[0];
+    expect(filter.isBot).toBe(true);
+    expect(filter.$or).toHaveLength(2);
   });
 
   test('the camelCase spelling works too — callers pass either', async () => {
@@ -140,7 +196,9 @@ describe('scoping cannot reach the addressing path', () => {
   test('a reply edge in a thread likewise still delivers its mention', async () => {
     narrowToThread.mockImplementation(async () => []);
     await send(
-      { id: 'm8', content: 'replying', thread_root_id: 101, replyTo: { userId: 'bot-1' } },
+      {
+        id: 'm8', content: 'replying', thread_root_id: 101, replyTo: { userId: 'bot-1' }, 
+      },
       { replyToMessageId: '101' },
     );
     expect(byType('chat.mention')).toHaveLength(1);

--- a/backend/__tests__/unit/services/agentMentionService.threadScoping.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.threadScoping.test.js
@@ -1,0 +1,167 @@
+/**
+ * Ambient-only scoping, at the pipeline boundary (W-T, TASK-029, 3/4).
+ *
+ * The set arithmetic lives in threadWakeScopeService and is tested against
+ * pg-mem there. This suite tests the HOOK: that `enqueueWakeOnMessage` applies
+ * it, applies it only to threaded messages, and — the half that matters most —
+ * never lets it touch the addressing path.
+ */
+
+jest.mock('../../../services/agentEventService', () => ({ enqueue: jest.fn() }));
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { find: jest.fn(), findOne: jest.fn() },
+}));
+jest.mock('../../../models/AgentProfile', () => ({ find: jest.fn() }));
+jest.mock('../../../models/Pod', () => ({ findById: jest.fn(), find: jest.fn() }));
+jest.mock('../../../models/User', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../../../services/chatSummarizerService', () => ({
+  constructor: { getLatestPodSummary: jest.fn() }, summarizePodMessages: jest.fn(),
+}));
+jest.mock('../../../models/AgentEvent', () => ({ countDocuments: jest.fn() }));
+jest.mock('../../../services/welcomeWakeService', () => ({ maybeFireWelcomeWake: jest.fn() }));
+jest.mock('../../../models/pg/Message', () => ({
+  findById: jest.fn(async (id) => (String(id) === '101' ? { id: 101, user_id: 'bot-1' } : null)),
+}));
+jest.mock('../../../services/threadWakeScopeService', () => ({
+  narrowToThread: jest.fn(async (_root, targets) => targets),
+  effectiveFollowerIds: jest.fn(async () => new Set()),
+}));
+
+const AgentMentionService = require('../../../services/agentMentionService');
+const AgentEventService = require('../../../services/agentEventService');
+const { AgentInstallation } = require('../../../models/AgentRegistry');
+const AgentProfile = require('../../../models/AgentProfile');
+const Pod = require('../../../models/Pod');
+const User = require('../../../models/User');
+const AgentEvent = require('../../../models/AgentEvent');
+const { narrowToThread } = require('../../../services/threadWakeScopeService');
+
+const optIn = (agentName, installedBy) => ({
+  agentName, instanceId: 'default', displayName: agentName, installedBy,
+  config: { wakeOnMessage: { enabled: true } },
+});
+
+const byType = (t) => AgentEventService.enqueue.mock.calls.map(([a]) => a).filter((a) => a.type === t);
+
+const send = (message, extra = {}) => AgentMentionService.enqueueMentions({
+  podId: 'pod-1', userId: 'user-1', username: 'alice', message, ...extra,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  narrowToThread.mockImplementation(async (_root, targets) => targets);
+  AgentInstallation.find.mockReturnValue({
+    lean: jest.fn().mockResolvedValue([optIn('seat-a', 'uid-a'), optIn('seat-b', 'uid-b')]),
+  });
+  AgentProfile.find.mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+  Pod.findById.mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue({ type: 'chat', members: ['user-1', 'bot-1'] }),
+    }),
+    lean: jest.fn().mockResolvedValue({ _id: 'pod-1', type: 'chat', members: ['user-1'] }),
+  });
+  User.findById.mockImplementation((id) => ({
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue(String(id) === 'bot-1'
+      ? { _id: 'bot-1', isBot: true, botMetadata: { agentName: 'seat-a', instanceId: 'default' } }
+      : { _id: 'user-1', isBot: false }),
+  }));
+  AgentEvent.countDocuments.mockResolvedValue(0);
+});
+
+describe('the hook fires only for threaded messages', () => {
+  test('an unthreaded message never consults the scope service', async () => {
+    await send({ id: 'm1', content: 'just talking' });
+    expect(narrowToThread).not.toHaveBeenCalled();
+    expect(byType('message.posted')).toHaveLength(2);
+  });
+
+  test('a threaded message consults it, with the root and the opt-in list', async () => {
+    await send({ id: 'm2', content: 'in a thread', thread_root_id: 101 });
+    expect(narrowToThread).toHaveBeenCalledTimes(1);
+    const [root, targets, identify] = narrowToThread.mock.calls[0];
+    expect(root).toBe(101);
+    expect(targets.map((t) => t.agentName)).toEqual(['seat-a', 'seat-b']);
+    // Keyed on installedBy — the bot User id thread_user_state holds.
+    expect(identify(targets[0])).toBe('uid-a');
+  });
+
+  test('the camelCase spelling works too — callers pass either', async () => {
+    await send({ id: 'm3', content: 'in a thread', threadRootId: 101 });
+    expect(narrowToThread).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('scoping narrows delivery, and only delivery', () => {
+  test('a non-follower opt-in is dropped', async () => {
+    narrowToThread.mockImplementation(async (_r, targets) => targets.filter((t) => t.agentName === 'seat-a'));
+    await send({ id: 'm4', content: 'threaded', thread_root_id: 101 });
+    expect(byType('message.posted').map((e) => e.agentName)).toEqual(['seat-a']);
+  });
+
+  test('a thread nobody follows wakes nobody', async () => {
+    narrowToThread.mockImplementation(async () => []);
+    await send({ id: 'm5', content: 'threaded', thread_root_id: 101 });
+    expect(byType('message.posted')).toHaveLength(0);
+  });
+
+  test('CONTROL: the same message unthreaded still wakes both', async () => {
+    // Without this, the two tests above pass from a pipeline that wakes nobody.
+    narrowToThread.mockImplementation(async () => []);
+    await send({ id: 'm6', content: 'not threaded' });
+    expect(byType('message.posted')).toHaveLength(2);
+  });
+});
+
+describe('scoping cannot reach the addressing path', () => {
+  // Corrected after the first run. I asserted that a routed message never
+  // consults the scope service, on the belief that `isRouted` short-circuits
+  // before any ambient fan-out. It does not: there are TWO wake call sites —
+  // :1157 for unrouted messages and :1470 for routed ones, the latter waking
+  // opt-ins who were not mention targets (excludeKeys = already enqueued).
+  //
+  // The code was right and the assumption was wrong, and the truth is the
+  // better invariant: an addressed message still delivers its chat.mention
+  // unconditionally, while the AMBIENT fan-out that accompanies it is scoped
+  // like any other ambient traffic. Addressing is untouchable; the ambient
+  // companion is not, and should not be.
+
+  test('an @mention in a thread is enqueued even when scoping drops everyone', async () => {
+    narrowToThread.mockImplementation(async () => []);
+    await send({ id: 'm7', content: '@seat-a look at this', thread_root_id: 101 });
+
+    // The addressing half: unconditional.
+    expect(byType('chat.mention').map((e) => e.agentName)).toEqual(['seat-a']);
+    // The ambient half: scoped away, correctly. seat-b is an opt-in who does
+    // not follow the thread and has not been addressed.
+    expect(byType('message.posted')).toHaveLength(0);
+  });
+
+  test('a reply edge in a thread likewise still delivers its mention', async () => {
+    narrowToThread.mockImplementation(async () => []);
+    await send(
+      { id: 'm8', content: 'replying', thread_root_id: 101, replyTo: { userId: 'bot-1' } },
+      { replyToMessageId: '101' },
+    );
+    expect(byType('chat.mention')).toHaveLength(1);
+    expect(byType('message.posted')).toHaveLength(0);
+  });
+
+  test('CONTROL: with scoping permissive, the ambient companion DOES fire', async () => {
+    // Proves the two assertions above measure scoping and not a pipeline that
+    // simply never fans out alongside a mention.
+    narrowToThread.mockImplementation(async (_r, targets) => targets);
+    await send({ id: 'm9', content: '@seat-a look at this', thread_root_id: 101 });
+
+    expect(byType('chat.mention').map((e) => e.agentName)).toEqual(['seat-a']);
+    // seat-b gets the ambient wake; seat-a is excluded, already addressed.
+    expect(byType('message.posted').map((e) => e.agentName)).toEqual(['seat-b']);
+  });
+
+  test('a muted seat that is ADDRESSED still gets its mention', async () => {
+    // The rule in one case: a mute scopes ambient activity, never addressing.
+    narrowToThread.mockImplementation(async () => []);
+    await send({ id: 'm10', content: '@seat-a you muted this but I need you', thread_root_id: 101 });
+    expect(byType('chat.mention').map((e) => e.agentName)).toEqual(['seat-a']);
+  });
+});

--- a/backend/__tests__/unit/services/threadFollowByParticipationWiring.test.js
+++ b/backend/__tests__/unit/services/threadFollowByParticipationWiring.test.js
@@ -43,22 +43,47 @@ const productionCallers = () => {
   return hits;
 };
 
-describe('followByParticipation: the comment and the call graph agree', () => {
-  const header = fs.readFileSync(SCOPE_SERVICE, 'utf8');
-  const claimsUnwired = header.includes('NOTHING CALLS IT');
+/**
+ * The two states the header is allowed to be in, matched against FLATTENED
+ * source, per @sprint-review (57311): the unwired marker currently ends a
+ * line, so one reflow would split it across a newline and turn a true claim
+ * false. That is the matcher-spanning-a-line-break trap from earlier today.
+ *
+ * Collapsing `\s+` alone is NOT enough and the first attempt here did exactly
+ * that — a reflow inside a block comment leaves the ` * ` gutter sitting in
+ * the middle of the phrase, so `NOTHING\n * CALLS IT` flattens to
+ * `NOTHING * CALLS IT` and still misses. The probe caught it: the scenario
+ * this normalisation existed for was the one scenario still failing. Strip
+ * the gutter first, then collapse.
+ */
+const flatten = (src) => src.replace(/^[ \t]*\*[ \t]?/gm, ' ').replace(/\s+/g, ' ');
 
-  test('the header still names the gap explicitly', () => {
-    // If someone softens this to "may not be wired" the next reader cannot
-    // tell whether it was checked. The assertion is on the loud phrasing.
-    expect(claimsUnwired).toBe(true);
+const UNWIRED = 'NOTHING CALLS IT';
+const WIRED = 'THE MENTION PATH CALLS IT';
+
+describe('followByParticipation: the comment and the call graph agree', () => {
+  const header = flatten(fs.readFileSync(SCOPE_SERVICE, 'utf8'));
+  const claimsUnwired = header.includes(UNWIRED);
+  const claimsWired = header.includes(WIRED);
+
+  test('the header makes exactly one of the two checkable claims', () => {
+    // NOT "the unwired marker must be present" — that was the first version,
+    // and @sprint-review caught that it made the wired branch below
+    // unreachable, so the guard only ever ran in one direction while I
+    // described it as running in two.
+    //
+    // Requiring exactly one marker is what makes both branches live: whoever
+    // closes TASK-045 swaps UNWIRED for WIRED, and the second branch then
+    // runs for real. Softening to unstructured prose ("may not be wired")
+    // matches neither and fails here, so vagueness is not a pass.
+    expect([claimsUnwired, claimsWired].filter(Boolean)).toHaveLength(1);
   });
 
-  test('and the call graph matches what the header claims', () => {
+  test('and the call graph matches whichever claim it makes', () => {
     const callers = productionCallers();
     if (claimsUnwired) {
       expect(callers).toEqual([]);
     } else {
-      // Comment says it IS wired — then something had better call it.
       expect(callers.length).toBeGreaterThan(0);
     }
   });

--- a/backend/__tests__/unit/services/threadFollowByParticipationWiring.test.js
+++ b/backend/__tests__/unit/services/threadFollowByParticipationWiring.test.js
@@ -1,0 +1,65 @@
+/**
+ * Keep the comment and the code-base agreeing about followByParticipation.
+ *
+ * @sprint-review's third blocker on 3/4 (57306): threadWakeScopeService's
+ * header asserted "the mention writes the row at the moment it happens, via
+ * ThreadUserState.followByParticipation" — and nothing called it. The method
+ * shipped, its tests passed, and the only thing claiming it was wired was
+ * prose.
+ *
+ * The comment is corrected. This exists so it cannot drift back, in EITHER
+ * direction: it fails if a production caller appears while the comment still
+ * says there is none, and it fails if the comment stops saying so while there
+ * is still no caller. A doc-vs-reality gap that only a reader can detect is
+ * the failure mode being guarded, so the guard has to be executable.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const BACKEND = path.join(__dirname, '../../..');
+const SCOPE_SERVICE = path.join(BACKEND, 'services/threadWakeScopeService.ts');
+
+/** Production source only: no tests, no node_modules, and not the model that defines it. */
+const productionCallers = () => {
+  const hits = [];
+  const skipDir = new Set(['node_modules', '__tests__', 'dist', 'coverage', '.git']);
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (!skipDir.has(entry.name)) walk(path.join(dir, entry.name));
+        continue;
+      }
+      if (!/\.(ts|js)$/.test(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      // The model DEFINES it; the scope service only mentions it in prose.
+      if (full.endsWith('models/pg/ThreadUserState.ts')) continue;
+      if (full === SCOPE_SERVICE) continue;
+      const src = fs.readFileSync(full, 'utf8');
+      if (src.includes('followByParticipation')) hits.push(path.relative(BACKEND, full));
+    }
+  };
+  walk(BACKEND);
+  return hits;
+};
+
+describe('followByParticipation: the comment and the call graph agree', () => {
+  const header = fs.readFileSync(SCOPE_SERVICE, 'utf8');
+  const claimsUnwired = header.includes('NOTHING CALLS IT');
+
+  test('the header still names the gap explicitly', () => {
+    // If someone softens this to "may not be wired" the next reader cannot
+    // tell whether it was checked. The assertion is on the loud phrasing.
+    expect(claimsUnwired).toBe(true);
+  });
+
+  test('and the call graph matches what the header claims', () => {
+    const callers = productionCallers();
+    if (claimsUnwired) {
+      expect(callers).toEqual([]);
+    } else {
+      // Comment says it IS wired — then something had better call it.
+      expect(callers.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/backend/__tests__/unit/services/threadWakeScope.test.js
+++ b/backend/__tests__/unit/services/threadWakeScope.test.js
@@ -1,0 +1,181 @@
+/**
+ * Ambient-only wake scoping, EXECUTED on pg-mem (W-T, TASK-029, 3/4).
+ *
+ *     effective = (participants ∪ explicitFollowers) − muted
+ *
+ * Every case here is about set arithmetic the SQL performs, so it runs the SQL.
+ */
+const { newDb } = require('pg-mem');
+
+const mockDb = newDb();
+const mockPool = new (mockDb.adapters.createPg().Pool)();
+jest.mock('../../../config/db-pg', () => ({ pool: mockPool }));
+
+const { effectiveFollowerIds, narrowToThread } = require('../../../services/threadWakeScopeService');
+
+const POD = 'pod-1';
+let seq = 100;
+const nextRoot = () => { seq += 1; return seq; };
+
+const post = (rootId, userId, id) => mockPool.query(
+  'INSERT INTO messages (id, pod_id, user_id, content, thread_root_id) VALUES ($1,$2,$3,$4,$5)',
+  [id, POD, userId, 'x', rootId],
+);
+const rootMsg = (id, userId) => mockPool.query(
+  'INSERT INTO messages (id, pod_id, user_id, content, thread_root_id) VALUES ($1,$2,$3,$4,NULL)',
+  [id, POD, userId, 'root'],
+);
+const state = (rootId, userId, following) => mockPool.query(
+  'INSERT INTO thread_user_state (thread_root_id, user_id, pod_id, following) VALUES ($1,$2,$3,$4)',
+  [rootId, userId, POD, following],
+);
+
+beforeAll(async () => {
+  await mockPool.query(`CREATE TABLE messages (
+    id INTEGER PRIMARY KEY, pod_id VARCHAR(255), user_id VARCHAR(255), content TEXT,
+    thread_root_id INTEGER)`);
+  await mockPool.query(`CREATE TABLE thread_user_state (
+    id SERIAL PRIMARY KEY, thread_root_id INTEGER NOT NULL, user_id VARCHAR(255) NOT NULL,
+    pod_id VARCHAR(255) NOT NULL, following BOOLEAN, collapsed BOOLEAN NOT NULL DEFAULT TRUE,
+    UNIQUE (thread_root_id, user_id))`);
+});
+
+describe('the three terms', () => {
+  test('participants are included without any stored row', async () => {
+    // The `following IS NULL` case: you posted, so you follow, and nothing
+    // was written to say so.
+    const r = nextRoot();
+    await rootMsg(r, 'author');
+    await post(r, 'replier', r + 1000);
+    expect([...await effectiveFollowerIds(r)].sort()).toEqual(['author', 'replier']);
+  });
+
+  test('the root author counts, even though the root carries no thread_root_id', async () => {
+    // A root's own thread_root_id is NULL by design, so `WHERE thread_root_id
+    // = $1` alone would omit the person who started the thread — the single
+    // most obviously wrong omission available.
+    const r = nextRoot();
+    await rootMsg(r, 'author');
+    expect([...await effectiveFollowerIds(r)]).toEqual(['author']);
+  });
+
+  test('an explicit follower who never posted is included', async () => {
+    const r = nextRoot();
+    await rootMsg(r, 'author');
+    await state(r, 'lurker', true);
+    expect([...await effectiveFollowerIds(r)].sort()).toEqual(['author', 'lurker']);
+  });
+
+  test('a muted participant is excluded — mute outranks participation', async () => {
+    const r = nextRoot();
+    await rootMsg(r, 'author');
+    await post(r, 'quitter', r + 1000);
+    await state(r, 'quitter', false);
+    expect([...await effectiveFollowerIds(r)]).toEqual(['author']);
+  });
+
+  test('mute also outranks an explicit follow row — it IS that row', async () => {
+    const r = nextRoot();
+    await rootMsg(r, 'author');
+    await state(r, 'author', false);
+    expect([...await effectiveFollowerIds(r)]).toEqual([]);
+  });
+
+  test('a collapse-only row makes nobody a follower', async () => {
+    // Row presence must never mean following. Someone who expanded a thread
+    // and read it has expressed nothing about wanting to be woken.
+    const r = nextRoot();
+    await rootMsg(r, 'author');
+    await mockPool.query(
+      'INSERT INTO thread_user_state (thread_root_id,user_id,pod_id,collapsed) VALUES ($1,$2,$3,FALSE)',
+      [r, 'browser', POD],
+    );
+    expect([...await effectiveFollowerIds(r)]).toEqual(['author']);
+  });
+
+  test('participants are deduplicated — posting ten times is one follow', async () => {
+    const r = nextRoot();
+    await rootMsg(r, 'author');
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await post(r, 'author', r + 2000 + i);
+    }
+    expect([...await effectiveFollowerIds(r)]).toEqual(['author']);
+  });
+
+  test('another thread\'s state does not leak in', async () => {
+    const a = nextRoot(); const b = nextRoot();
+    await rootMsg(a, 'alice');
+    await rootMsg(b, 'bob');
+    await state(b, 'carol', true);
+    expect([...await effectiveFollowerIds(a)]).toEqual(['alice']);
+  });
+});
+
+describe('narrowToThread only ever narrows', () => {
+  const inst = (name, uid) => ({ agentName: name, installedBy: uid });
+  const identify = (t) => t.installedBy || null;
+
+  test('an unthreaded message is untouched', async () => {
+    const targets = [inst('a', 'u1'), inst('b', 'u2')];
+    expect(await narrowToThread(null, targets, identify)).toEqual(targets);
+  });
+
+  test('a threaded message drops non-followers', async () => {
+    const r = nextRoot();
+    await rootMsg(r, 'u1');
+    const kept = await narrowToThread(r, [inst('a', 'u1'), inst('b', 'u2')], identify);
+    expect(kept.map((t) => t.agentName)).toEqual(['a']);
+  });
+
+  test('it never ADDS a target', async () => {
+    // Scoping is subtractive. Threading must not start delivering to seats
+    // that never opted in to anything.
+    const r = nextRoot();
+    await rootMsg(r, 'u1');
+    await state(r, 'u-never-passed-in', true);
+    const kept = await narrowToThread(r, [inst('a', 'u1')], identify);
+    expect(kept).toHaveLength(1);
+  });
+
+  test('a target whose id cannot be resolved is KEPT, not dropped', async () => {
+    // Degrade to today's behaviour, never to silence. A wake that vanishes
+    // because an identity could not be classified is the failure nobody sees.
+    const r = nextRoot();
+    await rootMsg(r, 'u1');
+    const kept = await narrowToThread(r, [inst('a', null)], identify);
+    expect(kept).toHaveLength(1);
+  });
+
+  test('a DB failure falls back to unscoped delivery, not to silence', async () => {
+    // The first version of this test claimed to cover this and did not — it
+    // made `identify` throw and asserted the rejection, which exercises a
+    // different path entirely. Make the QUERY fail, which is the case that
+    // matters: a scoping outage must degrade to today's behaviour, because
+    // silently muting every thread is the failure nobody would report.
+    const spy = jest.spyOn(mockPool, 'query').mockRejectedValueOnce(new Error('connection lost'));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const targets = [inst('a', 'u1'), inst('b', 'u2')];
+
+    const kept = await narrowToThread(12345, targets, identify);
+
+    expect(kept).toEqual(targets);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('[thread-scope]'), expect.stringContaining('connection lost'),
+    );
+    spy.mockRestore(); warn.mockRestore();
+  });
+
+  test('CONTROL: the same call succeeds once the query works again', async () => {
+    // Without this, the test above passes from a permanently broken pool.
+    const r = nextRoot();
+    await rootMsg(r, 'u1');
+    const kept = await narrowToThread(r, [inst('a', 'u1'), inst('b', 'u2')], identify);
+    expect(kept.map((t) => t.agentName)).toEqual(['a']);
+  });
+
+  test('a thread with no followers at all wakes nobody', async () => {
+    const kept = await narrowToThread(88888, [inst('a', 'u1')], identify);
+    expect(kept).toEqual([]);
+  });
+});

--- a/backend/__tests__/unit/services/threadWakeScope.test.js
+++ b/backend/__tests__/unit/services/threadWakeScope.test.js
@@ -11,6 +11,7 @@ const mockDb = newDb();
 const mockPool = new (mockDb.adapters.createPg().Pool)();
 jest.mock('../../../config/db-pg', () => ({ pool: mockPool }));
 
+const { createTableFor } = require('../../utils/schemaTable');
 const { effectiveFollowerIds, narrowToThread } = require('../../../services/threadWakeScopeService');
 
 const POD = 'pod-1';
@@ -25,19 +26,26 @@ const rootMsg = (id, userId) => mockPool.query(
   'INSERT INTO messages (id, pod_id, user_id, content, thread_root_id) VALUES ($1,$2,$3,$4,NULL)',
   [id, POD, userId, 'root'],
 );
+// thread_user_state has a live FK to messages in the shipped schema, so a root
+// referenced by state must exist as a row.
+const stateRow = (rootId, userId, following, collapsed) => mockPool.query(
+  `INSERT INTO thread_user_state (thread_root_id, user_id, pod_id, following, collapsed)
+   VALUES ($1,$2,$3,$4,$5)`,
+  [rootId, userId, POD, following, collapsed],
+);
 const state = (rootId, userId, following) => mockPool.query(
   'INSERT INTO thread_user_state (thread_root_id, user_id, pod_id, following) VALUES ($1,$2,$3,$4)',
   [rootId, userId, POD, following],
 );
 
 beforeAll(async () => {
-  await mockPool.query(`CREATE TABLE messages (
-    id INTEGER PRIMARY KEY, pod_id VARCHAR(255), user_id VARCHAR(255), content TEXT,
-    thread_root_id INTEGER)`);
-  await mockPool.query(`CREATE TABLE thread_user_state (
-    id SERIAL PRIMARY KEY, thread_root_id INTEGER NOT NULL, user_id VARCHAR(255) NOT NULL,
-    pod_id VARCHAR(255) NOT NULL, following BOOLEAN, collapsed BOOLEAN NOT NULL DEFAULT TRUE,
-    UNIQUE (thread_root_id, user_id))`);
+  // Shipped DDL, not hand-written — same correction as 2/4's suites
+  // (@sprint-review 56811). This file still had a hand-rolled `messages` and
+  // `thread_user_state`, so every constraint it leaned on was one typed here.
+  await mockPool.query(createTableFor('pods'));
+  await mockPool.query(createTableFor('messages'));
+  await mockPool.query(createTableFor('thread_user_state'));
+  await mockPool.query("INSERT INTO pods (id, name, type, created_by) VALUES ($1,'p','chat','u')", [POD]);
 });
 
 describe('the three terms', () => {
@@ -177,5 +185,63 @@ describe('narrowToThread only ever narrows', () => {
   test('a thread with no followers at all wakes nobody', async () => {
     const kept = await narrowToThread(88888, [inst('a', 'u1')], identify);
     expect(kept).toEqual([]);
+  });
+});
+
+describe('readers filter on following = true, never on EXISTS(row)', () => {
+  // @ux-lead (56820, doc 5e7060fd on #1107): once rows exist for non-followers,
+  // every reader of follow state must filter on the COLUMN. Row presence stopped
+  // meaning anything the moment collapse started writing rows.
+
+  test('THE third state: (following=false, collapsed=false) gets no wake', async () => {
+    // Muted AND expanded — the row most likely to be mistaken for engagement,
+    // because it exists and the user actively opened the thread. Neither fact
+    // is consent to be woken.
+    const r = nextRoot();
+    await rootMsg(r, 'author');
+    await post(r, 'muted-reader', r + 4000);
+    await stateRow(r, 'muted-reader', false, false);
+
+    expect([...await effectiveFollowerIds(r)]).toEqual(['author']);
+  });
+
+  test('and it still gets no wake when they are the ONLY participant', async () => {
+    // The version with no one else to mask it: the set must be empty, not
+    // fall back to "well, somebody should hear this".
+    const r = nextRoot();
+    await rootMsg(r, 'solo');
+    await stateRow(r, 'solo', false, false);
+    expect([...await effectiveFollowerIds(r)]).toEqual([]);
+  });
+
+  test('CONTROL: the same row with following=true DOES wake', async () => {
+    // Proves the two above measure `following`, not the mere presence of a
+    // row or the value of `collapsed`.
+    const r = nextRoot();
+    await rootMsg(r, 'author');
+    await stateRow(r, 'reader', true, false);
+    expect([...await effectiveFollowerIds(r)].sort()).toEqual(['author', 'reader']);
+  });
+
+  test('CONTROL: and with following=NULL it falls back to participation', async () => {
+    // The third value of the tri-state, so all three are covered here and not
+    // just the two booleans.
+    const r = nextRoot();
+    await rootMsg(r, 'author');
+    await post(r, 'participant', r + 5000);
+    await stateRow(r, 'participant', null, false);
+    expect([...await effectiveFollowerIds(r)].sort()).toEqual(['author', 'participant']);
+  });
+
+  test('the query says following IS TRUE, not EXISTS', async () => {
+    // Structural backstop for the rule itself, so a rewrite that reintroduces
+    // EXISTS(row) is flagged even if it happens to pass the cases above.
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../services/threadWakeScopeService.ts'), 'utf8',
+    );
+    expect(src).toMatch(/following IS TRUE/);
+    expect(src).not.toMatch(/EXISTS\s*\(\s*SELECT[^)]*thread_user_state/i);
   });
 });

--- a/backend/__tests__/unit/services/threadWakeScope.test.js
+++ b/backend/__tests__/unit/services/threadWakeScope.test.js
@@ -245,3 +245,67 @@ describe('readers filter on following = true, never on EXISTS(row)', () => {
     expect(src).not.toMatch(/EXISTS\s*\(\s*SELECT[^)]*thread_user_state/i);
   });
 });
+
+describe('one participant, one row, one field flipped', () => {
+  // @ux-lead (56822, 392b86e5 on #1107): "a participant at (NULL,
+  // collapsed=false) is woken; the SAME participant at FALSE is not."
+  //
+  // Both halves already existed, but as separate cases with different users on
+  // different roots — so a difference in outcome could in principle have come
+  // from something other than `following`. This flips exactly one field on one
+  // row and asserts the wake set changes by exactly that user. Nothing else
+  // varies, which is the whole point of the pairing.
+
+  test('flipping following NULL -> FALSE removes exactly that participant', async () => {
+    const r = nextRoot();
+    await rootMsg(r, 'author');
+    await post(r, 'pat', r + 6000);
+    await stateRow(r, 'pat', null, false);
+
+    const woken = [...await effectiveFollowerIds(r)].sort();
+    expect(woken).toEqual(['author', 'pat']);
+
+    await mockPool.query(
+      'UPDATE thread_user_state SET following = FALSE WHERE thread_root_id = $1 AND user_id = $2',
+      [r, 'pat'],
+    );
+
+    const after = [...await effectiveFollowerIds(r)].sort();
+    expect(after).toEqual(['author']);
+    // Stated as a set difference so a change in the other direction, or a
+    // change affecting somebody else, fails rather than passing on length.
+    expect(woken.filter((u) => !after.includes(u))).toEqual(['pat']);
+  });
+
+  test('and flipping it back to NULL restores them', async () => {
+    // The reverse, because a one-way test passes against code that simply
+    // stops waking people.
+    const r = nextRoot();
+    await rootMsg(r, 'author');
+    await post(r, 'pat', r + 7000);
+    await stateRow(r, 'pat', false, false);
+    expect([...await effectiveFollowerIds(r)]).toEqual(['author']);
+
+    await mockPool.query(
+      'UPDATE thread_user_state SET following = NULL WHERE thread_root_id = $1 AND user_id = $2',
+      [r, 'pat'],
+    );
+    expect([...await effectiveFollowerIds(r)].sort()).toEqual(['author', 'pat']);
+  });
+
+  test('collapsed is not consulted in either direction', async () => {
+    // The field that must NOT matter. Same participant, following NULL
+    // throughout, collapsed flipped: the wake set is identical.
+    const r = nextRoot();
+    await rootMsg(r, 'author');
+    await post(r, 'pat', r + 8000);
+    await stateRow(r, 'pat', null, true);
+    const collapsed = [...await effectiveFollowerIds(r)].sort();
+
+    await mockPool.query(
+      'UPDATE thread_user_state SET collapsed = FALSE WHERE thread_root_id = $1 AND user_id = $2',
+      [r, 'pat'],
+    );
+    expect([...await effectiveFollowerIds(r)].sort()).toEqual(collapsed);
+  });
+});

--- a/backend/__tests__/unit/services/threadWakeScope.test.js
+++ b/backend/__tests__/unit/services/threadWakeScope.test.js
@@ -189,7 +189,7 @@ describe('narrowToThread only ever narrows', () => {
 });
 
 describe('readers filter on following = true, never on EXISTS(row)', () => {
-  // @ux-lead (56820, doc 5e7060fd on #1107): once rows exist for non-followers,
+  // @ux-lead (56820): once rows exist for non-followers,
   // every reader of follow state must filter on the COLUMN. Row presence stopped
   // meaning anything the moment collapse started writing rows.
 
@@ -247,7 +247,7 @@ describe('readers filter on following = true, never on EXISTS(row)', () => {
 });
 
 describe('one participant, one row, one field flipped', () => {
-  // @ux-lead (56822, 392b86e5 on #1107): "a participant at (NULL,
+  // @ux-lead (56822): "a participant at (NULL,
   // collapsed=false) is woken; the SAME participant at FALSE is not."
   //
   // Both halves already existed, but as separate cases with different users on

--- a/backend/__tests__/utils/schemaTable.js
+++ b/backend/__tests__/utils/schemaTable.js
@@ -31,4 +31,28 @@ function createTableFor(name) {
   return m[0];
 }
 
-module.exports = { createTableFor, SCHEMA_PATH };
+/**
+ * The `ALTER TABLE <name> ADD COLUMN IF NOT EXISTS ...` retrofits for a table.
+ *
+ * `createTableFor` alone is not the table. Late columns are added by ALTER, not
+ * inside the CREATE — that is the two-declaration rule this repo learned the
+ * hard way, and it applies to fixtures too. A suite that only ran the CREATE
+ * got a `messages` with no `payload` and no `thread_root_id`, which fails as
+ * "column does not exist" a long way from the cause.
+ */
+function retrofitsFor(name) {
+  const sql = fs.readFileSync(SCHEMA_PATH, 'utf8');
+  const re = new RegExp(`ALTER TABLE ${name}\\s+ADD COLUMN IF NOT EXISTS[^;]*;`, 'gi');
+  return sql.match(re) || [];
+}
+
+/** The whole table as it exists after boot DDL: CREATE plus its retrofits. */
+async function applyTable(pool, name) {
+  await pool.query(createTableFor(name));
+  for (const stmt of retrofitsFor(name)) {
+    // eslint-disable-next-line no-await-in-loop
+    await pool.query(stmt.replace(/\s+/g, ' '));
+  }
+}
+
+module.exports = { createTableFor, retrofitsFor, applyTable, SCHEMA_PATH };

--- a/backend/models/pg/Message.ts
+++ b/backend/models/pg/Message.ts
@@ -158,7 +158,11 @@ class Message {
       let query = `
         SELECT
           m.id, m.pod_id, m.user_id, m.content, m.message_type, m.payload,
-          m.reply_to_message_id, m.created_at, m.updated_at,
+          m.reply_to_message_id,
+          -- MUST be selected. Late columns are easy to miss in an explicit
+          -- projection, and this one is read by the wake path.
+          m.thread_root_id,
+          m.created_at, m.updated_at,
           u._id as user_db_id, u.username, u.profile_picture, u.is_bot,
           rm.id as reply_msg_id, rm.content as reply_content,
           rm.user_id as reply_user_id, ru.username as reply_username
@@ -191,7 +195,16 @@ class Message {
       const query = `
         SELECT
           m.id, m.pod_id, m.user_id, m.content, m.message_type, m.payload,
-          m.reply_to_message_id, m.created_at, m.updated_at,
+          m.reply_to_message_id,
+          -- MUST be selected. The controller prefers THIS row over create()'s
+          -- RETURNING * (message = populated || created) and hands it to
+          -- enqueueMentions, so a column absent from this projection is a
+          -- column the wake path cannot see. Ambient thread scoping read
+          -- undefined for every message until this line existed — while its
+          -- own tests passed, because they build the message object directly
+          -- and never travel this path.
+          m.thread_root_id,
+          m.created_at, m.updated_at,
           u._id as user_db_id, u.username, u.profile_picture, u.is_bot,
           rm.id as reply_msg_id, rm.content as reply_content,
           rm.user_id as reply_user_id, ru.username as reply_username

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -933,6 +933,50 @@ const isWakeLoopDampened = async (
   return false;
 };
 
+/** `agentName:instanceId`, lowercased — the identity an install and a bot User row share. */
+const installKey = (inst: Record<string, unknown>): string => `${
+  String(inst.agentName || '').toLowerCase()}:${String(inst.instanceId || 'default')}`;
+
+/**
+ * Map each install to its BOT's User row id — the key thread_user_state uses.
+ *
+ * One query for the whole target list rather than one per target: the wake
+ * fan-out already runs per message, and a per-install lookup would put N
+ * round-trips on the hot path.
+ *
+ * A failure resolves to an EMPTY map, not a throw. Every `identify` then
+ * returns null, narrowToThread keeps every target, and scoping degrades to
+ * today's unscoped delivery. Losing the narrowing is a noisier pod; losing
+ * the wake is a message nobody sees.
+ */
+const resolveBotUserIds = async (
+  targets: Array<Record<string, unknown>>,
+): Promise<Map<string, string>> => {
+  const out = new Map<string, string>();
+  const wanted = [...new Set(targets.map(installKey))].filter((k) => !k.startsWith(':'));
+  if (wanted.length === 0) return out;
+  try {
+    const rows = await User.find({
+      isBot: true,
+      $or: wanted.map((k) => {
+        const [agentName, instanceId] = k.split(':');
+        return { 'botMetadata.agentName': agentName, 'botMetadata.instanceId': instanceId };
+      }),
+    }).select('_id botMetadata.agentName botMetadata.instanceId').lean() as Array<{
+      _id: unknown; botMetadata?: { agentName?: string; instanceId?: string };
+    }>;
+    for (const row of rows) {
+      const key = `${String(row.botMetadata?.agentName || '').toLowerCase()}:${
+        String(row.botMetadata?.instanceId || 'default')}`;
+      out.set(key, String(row._id));
+    }
+  } catch (err) {
+    console.warn('[thread-scope] bot user resolution failed (delivering unscoped):', (err as Error).message);
+    return new Map();
+  }
+  return out;
+};
+
 /**
  * Fan a message out to the pod's wake-on-message opt-ins. Skips the sender's
  * own identity (an agent never wakes on its own post), anything the mention
@@ -973,19 +1017,38 @@ const enqueueWakeOnMessage = async ({
   //    an @mention or a reply edge has already left via the mention path. A
   //    mute scopes ambient activity; it never suppresses being addressed.
   //
-  // Keyed on `installedBy` — the bot's User row id, which is what
-  // thread_user_state.user_id holds. An install without one is KEPT by
-  // narrowToThread rather than dropped: an unclassifiable target must degrade
-  // to today's behaviour, never to silence.
+  // Keyed on the BOT's User row id, which is what thread_user_state.user_id
+  // holds: the follow/mute routes are dualAuth, so an agent writing its own
+  // thread state writes under `req.agentUser._id`.
+  //
+  // NOT `installedBy`. @sprint-review's blocker (57291) was right and the
+  // comment that used to sit here was wrong. `installedBy` is written with
+  // two different identities depending on who installed the agent — the bot
+  // itself at agentAutoJoinService:80, podWriteAccessService:48 and three
+  // sites in agentsRuntime, but the HUMAN installer at podController:119,
+  // personaHireService:93, podCurationService:147, authController:201 and
+  // agentProfile:259 (AgentRun.ts:65 calls it "the hiring user" outright).
+  // The schema declares a bare ObjectId with no ref, so nothing at the type
+  // level distinguishes them.
+  //
+  // Keying on it would have read a human-installed agent's thread state off
+  // its INSTALLER's row: the human's mute would silence the agent, and the
+  // agent's own mute would be ignored. Both directions wrong, on a field
+  // whose name reads correct.
+  //
+  // An install whose bot User row cannot be resolved is KEPT by
+  // narrowToThread rather than dropped — an unclassifiable target must
+  // degrade to today's behaviour, never to silence.
   const threadRootId = (message as { thread_root_id?: unknown; threadRootId?: unknown })?.thread_root_id
     ?? (message as { threadRootId?: unknown })?.threadRootId ?? null;
   if (threadRootId) {
     // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
     const { narrowToThread } = require('./threadWakeScopeService');
+    const botUserIds = await resolveBotUserIds(targets);
     targets = await narrowToThread(
       Number(threadRootId),
       targets,
-      (inst: Record<string, unknown>) => (inst.installedBy ? String(inst.installedBy) : null),
+      (inst: Record<string, unknown>) => botUserIds.get(installKey(inst)) ?? null,
     );
     if (targets.length === 0) return woken;
   }

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -958,8 +958,37 @@ const enqueueWakeOnMessage = async ({
   authorFrame: { username: string; createdAt: unknown; messageId: string | undefined };
 }): Promise<string[]> => {
   const woken: string[] = [];
-  const targets = (installations || []).filter(wakeOnMessageEnabled);
+  let targets = (installations || []).filter(wakeOnMessageEnabled);
   if (targets.length === 0) return woken;
+
+  // Ambient-only thread scoping (W-T 3/4, #1045). A reply inside a thread is
+  // AMBIENT: it reaches the thread's effective followers, not the room.
+  //
+  // Applied HERE, to the already-computed opt-in list, and nowhere else. Two
+  // consequences that are the point rather than side effects:
+  //  - it can only NARROW. A thread follower who never opted into
+  //    wake-on-message still gets nothing, because threading is additive and
+  //    must not start delivering to seats that opted into nothing.
+  //  - it cannot touch addressing. This branch runs only when `!isRouted`, so
+  //    an @mention or a reply edge has already left via the mention path. A
+  //    mute scopes ambient activity; it never suppresses being addressed.
+  //
+  // Keyed on `installedBy` — the bot's User row id, which is what
+  // thread_user_state.user_id holds. An install without one is KEPT by
+  // narrowToThread rather than dropped: an unclassifiable target must degrade
+  // to today's behaviour, never to silence.
+  const threadRootId = (message as { thread_root_id?: unknown; threadRootId?: unknown })?.thread_root_id
+    ?? (message as { threadRootId?: unknown })?.threadRootId ?? null;
+  if (threadRootId) {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const { narrowToThread } = require('./threadWakeScopeService');
+    targets = await narrowToThread(
+      Number(threadRootId),
+      targets,
+      (inst: Record<string, unknown>) => (inst.installedBy ? String(inst.installedBy) : null),
+    );
+    if (targets.length === 0) return woken;
+  }
 
   let podRow: { type?: string } | null = null;
   try {

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -1153,6 +1153,14 @@ const enqueueMentions = async ({
   if (!isRouted) {
     // D8: an unrouted message reaches nobody on the mention path, but it is
     // exactly what a wake-on-message opt-in asked to hear about.
+    //
+    // ONE OF TWO CALL SITES. The other is at the end of this function, for
+    // ROUTED messages, waking the opt-ins the mention path did not reach.
+    // This early return is not the only path into enqueueWakeOnMessage, and
+    // reading it as one is a mistake this seat made twice on 2026-08-22 —
+    // asserting that a routed message never reaches ambient fan-out, which is
+    // false. An early return bounds the code BELOW it, never a helper that a
+    // later call site re-enters.
     let woken: string[] = [];
     try {
       woken = await enqueueWakeOnMessage({
@@ -1466,6 +1474,13 @@ const enqueueMentions = async ({
   // it did not reach. A mention-enqueued agent is excluded — the mention is
   // the stronger cue, and double delivery would burn a second model turn on
   // the same trigger message.
+  //
+  // SECOND OF TWO CALL SITES; the first is behind `if (!isRouted)` above. So
+  // a ROUTED message does have an ambient fan-out, and anything scoping that
+  // fan-out (thread scoping, W-T 3/4) applies here too. That is correct
+  // rather than incidental: an addressed message must always deliver its
+  // chat.mention, while the ambient companion has no stronger claim here than
+  // it does on an unrouted message.
   let woken: string[] = [];
   try {
     woken = await enqueueWakeOnMessage({

--- a/backend/services/threadWakeScopeService.ts
+++ b/backend/services/threadWakeScopeService.ts
@@ -24,8 +24,17 @@
  *    wakes them, because addressing never passes through this service. It
  *    also cannot be closed by writing a caller anywhere convenient — a
  *    synchronous Postgres write on the mention hot path is a decision, not a
- *    detail. Tracked separately; this comment previously asserted the wiring
+ *    detail. Tracked as TASK-045; this comment previously asserted the wiring
  *    existed, which is the thing that made it invisible.
+ *
+ *    WHOEVER CLOSES TASK-045: the shouted phrase three paragraphs up is load
+ *    bearing. threadFollowByParticipationWiring.test.js reads it and asserts
+ *    the call graph agrees, so adding a caller without editing this comment
+ *    turns that suite red on purpose. Swap it for the WIRED marker defined at
+ *    the top of that test and the same suite flips to requiring a caller.
+ *    (Deliberately not quoting the other marker here — the suite asserts
+ *    EXACTLY ONE is present, and spelling both out is how this very edit
+ *    first went red.)
  *  - `muted` — `following IS FALSE`. Subtracted LAST, because an explicit mute
  *    outranks participation. A participant who muted must stay muted.
  *

--- a/backend/services/threadWakeScopeService.ts
+++ b/backend/services/threadWakeScopeService.ts
@@ -13,10 +13,19 @@
  *    read from `messages`, never stored: it is a fact about the conversation,
  *    and materialising it would mean a second writer that can disagree with
  *    the first. This is the `following IS NULL` case from the tri-state.
- *  - `explicitFollowers` — `following IS TRUE`. Someone who used the header
- *    toggle, or who was @-mentioned in the thread (the mention writes the row
- *    at the moment it happens, via ThreadUserState.followByParticipation,
- *    rather than being re-derived from history forever).
+ *  - `explicitFollowers` — `following IS TRUE`. Today that means one thing:
+ *    someone used the header toggle. `ThreadUserState.followByParticipation`
+ *    exists to make an @mention write the row too, and NOTHING CALLS IT —
+ *    @sprint-review's third blocker on 3/4 (57306). So a user @-mentioned in
+ *    a thread who never posts is not an effective follower and stops
+ *    receiving its ambient activity.
+ *
+ *    That is a spec gap rather than a regression: the mention itself still
+ *    wakes them, because addressing never passes through this service. It
+ *    also cannot be closed by writing a caller anywhere convenient — a
+ *    synchronous Postgres write on the mention hot path is a decision, not a
+ *    detail. Tracked separately; this comment previously asserted the wiring
+ *    existed, which is the thing that made it invisible.
  *  - `muted` — `following IS FALSE`. Subtracted LAST, because an explicit mute
  *    outranks participation. A participant who muted must stay muted.
  *

--- a/backend/services/threadWakeScopeService.ts
+++ b/backend/services/threadWakeScopeService.ts
@@ -1,0 +1,107 @@
+/**
+ * Who a threaded reply wakes (W-T, TASK-029, 3/4).
+ *
+ * Ambient-only scoping, per fable's #1045 ruling: activity inside a thread is
+ * AMBIENT to the channel. It does not wake non-followers, and it does not bump
+ * the channel row above rooms with addressed items.
+ *
+ *     effective = (participants ∪ explicitFollowers) − muted
+ *
+ * The three terms, and why they are three:
+ *
+ *  - `participants` — anyone who authored a message in the thread. Derived at
+ *    read from `messages`, never stored: it is a fact about the conversation,
+ *    and materialising it would mean a second writer that can disagree with
+ *    the first. This is the `following IS NULL` case from the tri-state.
+ *  - `explicitFollowers` — `following IS TRUE`. Someone who used the header
+ *    toggle, or who was @-mentioned in the thread (the mention writes the row
+ *    at the moment it happens, via ThreadUserState.followByParticipation,
+ *    rather than being re-derived from history forever).
+ *  - `muted` — `following IS FALSE`. Subtracted LAST, because an explicit mute
+ *    outranks participation. A participant who muted must stay muted.
+ *
+ * SCOPING ONLY NARROWS. This never adds a wake target that would not have been
+ * woken anyway — it removes the ones a thread should not reach. Threading is
+ * an additive feature and must not start delivering to seats that never opted
+ * in to anything.
+ *
+ * NOT the addressing path. An explicit @mention still wakes its target whether
+ * or not they follow the thread, and whether or not they muted it: a mute
+ * scopes ambient activity, never addressing. That path never reaches this
+ * service, because `isRouted` short-circuits before the ambient branch.
+ */
+/* eslint-disable @typescript-eslint/no-require-imports, global-require */
+const { pool } = require('../config/db-pg');
+
+interface PgPool {
+  query: (text: string, values?: unknown[]) => Promise<{ rows: any[]; rowCount: number }>;
+}
+
+/**
+ * The effective follower set for one thread, as user ids.
+ *
+ * One query, not three. The three terms are correlated — muted must be
+ * subtracted from the union of the other two — and doing that in JS would mean
+ * three round trips on a path that runs for every threaded reply.
+ */
+export async function effectiveFollowerIds(threadRootId: number): Promise<Set<string>> {
+  const { rows } = await (pool as PgPool).query(
+    `WITH participants AS (
+       SELECT DISTINCT user_id FROM messages
+        WHERE thread_root_id = $1 OR id = $1
+     ),
+     explicit AS (
+       SELECT user_id FROM thread_user_state
+        WHERE thread_root_id = $1 AND following IS TRUE
+     ),
+     muted AS (
+       SELECT user_id FROM thread_user_state
+        WHERE thread_root_id = $1 AND following IS FALSE
+     )
+     SELECT user_id FROM (
+       SELECT user_id FROM participants
+       UNION
+       SELECT user_id FROM explicit
+     ) candidates
+     WHERE user_id NOT IN (SELECT user_id FROM muted)`,
+    [threadRootId],
+  );
+  return new Set(rows.map((r) => String(r.user_id)));
+}
+
+/**
+ * Narrow an already-computed wake target list to the thread's effective
+ * followers. Returns the input unchanged when the message is not threaded, so
+ * a caller can apply it unconditionally.
+ *
+ * `identify` maps a target to the user id thread state is keyed on — for an
+ * AgentInstallation that is `installedBy`, the bot's User row. A target whose
+ * id cannot be resolved is KEPT, deliberately: an unresolvable identity must
+ * degrade to today's behaviour (delivered) rather than to silence. Threading
+ * dropping a wake it could not classify is the failure nobody would notice.
+ */
+export async function narrowToThread<T>(
+  threadRootId: number | null | undefined,
+  targets: T[],
+  identify: (t: T) => string | null,
+): Promise<T[]> {
+  if (!threadRootId) return targets;
+  if (!targets.length) return targets;
+  let effective: Set<string>;
+  try {
+    effective = await effectiveFollowerIds(Number(threadRootId));
+  } catch (error) {
+    // Same reasoning as an unresolvable id, one level up: a scoping failure
+    // must not silently mute a whole thread.
+    console.warn('[thread-scope] falling back to unscoped delivery:', (error as Error).message);
+    return targets;
+  }
+  return targets.filter((t) => {
+    const id = identify(t);
+    if (!id) return true;
+    return effective.has(id);
+  });
+}
+
+module.exports = { effectiveFollowerIds, narrowToThread };
+Object.assign(module.exports, exports);


### PR DESCRIPTION
Third of four. **Stacked on #1109** (2/4), which is stacked on #1106 (1/4). This is the *set arithmetic* half of 3/4; the pipeline hook into `enqueueWakeOnMessage` follows in a second commit on this branch so it can be reviewed against a settled definition rather than alongside one.

## The rule

```
effective = (participants ∪ explicitFollowers) − muted
```

From fable's #1045 ambient-only ruling, as sharpened in-pod by @ux-lead (56822) and @sprint-review (56823). Three terms, and each is a separate term for a reason:

- **`participants`** — anyone who authored a message in the thread. **Derived at read from `messages`, never stored.** It is a fact about the conversation; materialising it would create a second writer that can disagree with the first. This is the tri-state's `following IS NULL` case.
- **`explicitFollowers`** — `following IS TRUE`. The header toggle, or an @mention in the thread. A mention writes the row *at the moment it happens* (`ThreadUserState.followByParticipation`) rather than being re-derived from history forever.
- **`muted`** — `following IS FALSE`, subtracted **last**, because an explicit mute outranks participation.

One query, not three. The terms are correlated and this path runs for every threaded reply.

## Scoping only ever narrows

`narrowToThread` returns a subset of what it was given, never a superset. Threading is additive; it must not start delivering to seats that never opted in to anything. A test asserts this directly — an explicit follower who was not in the candidate list does not get added.

**Two degradations, both toward today's behaviour rather than toward silence:**
- a target whose user id cannot be resolved is **kept**
- a scoping query failure returns the **unscoped** list

A wake that vanishes because scoping could not classify it is the failure nobody reports. A duplicate wake is one somebody complains about within the hour.

## Not the addressing path

An explicit `@mention` wakes its target whether or not they follow the thread, and whether or not they muted it — a mute scopes ambient activity, never addressing. That path never reaches this service, because `isRouted` short-circuits before the ambient branch. Verified in 1/4's `agentMentionService.threadingIsNotAddressing` suite.

## Tests

15 cases, **executed on pg-mem** — every claim here is set arithmetic the SQL performs, so grepping the SQL would assert the query was written and nothing more.

Two worth naming:

- **The root author counts**, even though a root's own `thread_root_id` is NULL by design. `WHERE thread_root_id = $1` alone omits the person who *started* the thread — the most obviously wrong omission available, and invisible without executing.
- **A collapse-only row confers nothing.** Someone who expanded a thread and read it has expressed nothing about wanting to be woken. This is @ux-lead's reader rule from 56820: filter on `following = true`, never on `EXISTS(row)`.

Mutation probe, each anchor-verified before the result was believed:

| mutation | result |
|---|---|
| root author dropped (`OR id = $1` removed) | 9 failed |
| mute no longer subtracted | 2 failed |
| explicit followers dropped from the union | 1 failed |
| unresolvable id dropped instead of kept | 1 failed |
| DB failure returns `[]` instead of the unscoped list | 1 failed |

One test in the first draft was **misnamed and covered nothing** — "a scoping failure falls back to unscoped delivery" made `identify` throw and asserted the rejection, a different path entirely. It now makes the *query* fail, and has a control proving the same call succeeds when the query works.

## Next on this branch

The hook: `enqueueWakeOnMessage` applies `narrowToThread` when the message carries a `thread_root_id`, mapping `AgentInstallation.installedBy` to the user id thread state is keyed on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)