### PR TITLE
ci: run test tiers on stacked PRs — drop the pull_request branches filter

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,8 +8,8 @@ on:
       - 'backend/**'
       - 'e2e/**'
       - 'playwright.config.*'
+  # No branches filter: stacked PRs must get E2E too (see tests.yml note).
   pull_request:
-    branches: [main]
     paths:
       - 'frontend/**'
       - 'backend/**'

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -3,8 +3,9 @@ name: Secret Scan
 on:
   push:
     branches: [ main, v1.0.x ]
+  # No branches filter: a stacked PR skipping SECRET scan is a worse gap
+  # than skipping tests (sprint-review's fold-in on #1123; see tests.yml).
   pull_request:
-    branches: [ main, v1.0.x ]
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,13 @@ name: Tests
 on:
   push:
     branches: [ main, v1.0.x ]
+  # No branches filter on pull_request: stacked PRs (base = another feature
+  # branch) previously got ZERO test runs — every number on them was
+  # single-sourced to the author's local sweep, and the 2026-08-22 threading
+  # train shipped two real failures that only surfaced once CI was dispatched
+  # by hand. Merge-to-main guards (base-freshness, version-guard) stay scoped
+  # to main; the test tiers run for every PR regardless of base.
   pull_request:
-    branches: [ main, v1.0.x ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Closes the gap pod-architect named at 14:05/15:01: stacked PRs get zero checks, and a local sweep can't substitute (57 suites fail locally by design). tests.yml and playwright.yml now run on every PR regardless of base; the merge-to-main guards (pr-base-freshness, package-version-guard) deliberately keep their main scope.

Evidence this pays: hand-dispatched CI on the threading branches immediately caught a server.ts boot-path crash and a jest suite-collection failure that targeted local runs missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK