### PR TITLE
fix(kernel): lapsedFrom is polymorphic — matching one shape matched none

### DIFF
--- a/backend/__tests__/unit/routes/tasksApi.updateRenewsLease.test.js
+++ b/backend/__tests__/unit/routes/tasksApi.updateRenewsLease.test.js
@@ -25,7 +25,16 @@ const mongoose = require('mongoose');
 
 jest.mock('../../../middleware/auth', () => (req, res, next) => {
   req.userId = req.get('x-test-user') || 'holder';
-  req.user = { id: req.userId, _id: req.userId };
+  // A separate USERNAME header, because the whole point of the shape tests
+  // below is that a caller's id and their username are different strings and
+  // `lapsedFrom` may hold either. The original fixture set them equal, which
+  // is exactly why it passed against a filter that only matched one.
+  req.user = {
+    id: req.userId,
+    _id: req.userId,
+    username: req.get('x-test-username') || undefined,
+    isBot: Boolean(req.get('x-test-username')),
+  };
   next();
 });
 jest.mock('../../../middleware/agentRuntimeAuth', () => (req, res, next) => next());
@@ -36,7 +45,15 @@ jest.mock('../../../models/Pod', () => ({
   findById: jest.fn(() => ({
     lean: jest.fn().mockResolvedValue({
       type: 'chat',
-      members: [{ toString: () => 'holder' }, { toString: () => 'stranger' }],
+      members: [
+        { toString: () => 'holder' },
+        { toString: () => 'stranger' },
+        // Distinct id/username pair for the lapsedFrom shape tests below — the
+        // point of those is that the two strings differ, so both must be able
+        // to reach the handler rather than 403 at membership.
+        { toString: () => '6a693bfbe833c668acdce53b' },
+        { toString: () => 'someone-else-id' },
+      ],
     }),
   })),
 }));
@@ -370,5 +387,78 @@ describe('POST /updates after the sweep has already taken the row', () => {
 
     const res = await postUpdate('holder', 'TASK-001', 'progress');
     expect(res.body.leaseRenewed).toBe(true);
+  });
+});
+
+/**
+ * `lapsedFrom` is polymorphic, and matching one shape is matching none.
+ *
+ * The sweep writes `provenance = holder?.label || t.assignee || t.claimedBy`,
+ * where `label` is itself `assignee || holder?.username || claimedBy`. So the
+ * field holds an assignee NAME, a bot USERNAME, or a User ObjectId string.
+ *
+ * The first restore filter matched `lapsedFrom: claimKey` — the id — and the
+ * tests passed because the fixture set lapsedFrom to the SAME value it sent as
+ * the caller. Live on TASK-029 the field held "pod-architect" while claimedBy
+ * had been an ObjectId, so the restore silently never fired.
+ */
+describe('the restore matches every shape lapsedFrom can hold', () => {
+  const postAs = (userId, username, text = 'still mine') => request(app)
+    .post(`/api/v1/tasks/${POD_ID}/TASK-001/updates`)
+    .set('x-test-user', userId)
+    .set('x-test-username', username)
+    .send({ text });
+
+  it('restores when lapsedFrom holds the USERNAME and the caller authed by id', async () => {
+    // The live case. These two strings are different and must both resolve to
+    // the same seat.
+    await seed({
+      status: 'pending', claimedBy: null, claimExpiresAt: null,
+      lapsedFrom: 'pod-architect',
+    });
+
+    const res = await postAs('6a693bfbe833c668acdce53b', 'pod-architect');
+    expect(res.body.leaseRenewed).toBe(true);
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    expect(row.status).toBe('claimed');
+    expect(row.claimedBy).toBe('6a693bfbe833c668acdce53b');
+    expect(row.lapsedFrom).toBeNull();
+  });
+
+  it('restores when lapsedFrom holds the ID', async () => {
+    // The shape the original filter handled. Kept so the widening is additive.
+    await seed({
+      status: 'pending', claimedBy: null, claimExpiresAt: null,
+      lapsedFrom: '6a693bfbe833c668acdce53b',
+    });
+    const res = await postAs('6a693bfbe833c668acdce53b', 'pod-architect');
+    expect(res.body.leaseRenewed).toBe(true);
+  });
+
+  it('does NOT restore for a seat whose username merely resembles nothing', async () => {
+    // Widening must not become "any caller restores any lapsed row".
+    await seed({
+      status: 'pending', claimedBy: null, claimExpiresAt: null,
+      lapsedFrom: 'pod-architect',
+    });
+    const res = await postAs('someone-else-id', 'ux-lead');
+    expect(res.body.leaseRenewed).toBe(false);
+
+    const row = await Task.findOne({ taskId: 'TASK-001' }).lean();
+    expect(row.status).toBe('pending');
+    expect(row.updates.map((u) => u.text)).toContain('still mine');
+  });
+
+  it('does NOT restore a row with no lapsedFrom, even for a caller with no username', async () => {
+    // The empty-matches-empty hazard: a filter built from a list must never
+    // let undefined match null.
+    await seed({ status: 'pending', claimedBy: null, claimExpiresAt: null, lapsedFrom: null });
+    const res = await request(app)
+      .post(`/api/v1/tasks/${POD_ID}/TASK-001/updates`)
+      .set('x-test-user', 'holder')
+      .send({ text: 'drive-by' });
+    expect(res.body.leaseRenewed).toBe(false);
+    expect((await Task.findOne({ taskId: 'TASK-001' }).lean()).status).toBe('pending');
   });
 });

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -67,7 +67,10 @@ const notifyAgents = (req: any, podId: unknown, task: unknown, kind: string) => 
 
 interface AuthReq {
   userId?: string;
-  user?: { id?: string; _id?: unknown; isBot?: boolean; botMetadata?: { instanceId?: string; agentName?: string } };
+  // `username` is here because the sweep can write it into `lapsedFrom`
+  // (provenance falls back through holder.label = assignee || username ||
+  // claimedBy), so the restore path must be able to match on it.
+  user?: { id?: string; _id?: unknown; isBot?: boolean; username?: string; botMetadata?: { instanceId?: string; agentName?: string } };
   agentUser?: { _id?: unknown };
   params?: Record<string, string>;
   query?: Record<string, string>;
@@ -565,9 +568,33 @@ router.post('/:podId/:taskId/updates', taskWriteRateLimit(60), auth, async (req:
     // between, status is `claimed` with their id and both filters miss — the
     // race is won by the peer, which is the whole point of returning it to the
     // board. This makes the cue's two options actually equivalent.
-    if (!task && claimKey) {
+    // `lapsedFrom` is POLYMORPHIC by design and must be matched as such. The
+    // sweep writes `provenance = holder?.label || t.assignee || t.claimedBy`,
+    // and `label` is itself `assignee || holder?.username || claimedBy`. So the
+    // field can hold an assignee NAME, a bot USERNAME, or a User ObjectId
+    // string, depending on which fallback fired.
+    //
+    // The first version of this matched `lapsedFrom: claimKey` — one shape —
+    // and claimKey is the ObjectId for MCP-authenticated agents. Verified live
+    // on TASK-029: lapsedFrom was "pod-architect" (the username) while
+    // claimedBy had been "6a693bfb…", so the restore never fired and the
+    // response honestly reported leaseRenewed:false. Dead code in the common
+    // case, and it only had a test because the fixture set lapsedFrom to the
+    // same value the test passed as the caller.
+    //
+    // Same name-vs-id trap as `assignee` (a name) versus `claimedBy` (an id):
+    // two string fields in one document whose value spaces never overlap.
+    const identities = [
+      claimKey,
+      userId?.toString(),
+      resolveAgentInstanceId(req),
+      req.user?.botMetadata?.agentName,
+      req.user?.username,
+    ].filter((v): v is string => typeof v === 'string' && v.length > 0);
+
+    if (!task && identities.length) {
       task = await Task.findOneAndUpdate(
-        { podId: podFilter, taskId, status: 'pending', lapsedFrom: claimKey },
+        { podId: podFilter, taskId, status: 'pending', lapsedFrom: { $in: identities } },
         {
           $set: {
             status: 'claimed',


### PR DESCRIPTION
**#1114's restore path was dead code in the common case.** Found by using it, not by reading it: TASK-029 lapsed at 15:04, I posted a note expecting the restore to fire, and the response honestly reported `leaseRenewed: false`.

## The defect

The sweep writes:

```js
const provenance = holder?.label || t.assignee || t.claimedBy || null;
// and, one level up:
const label = assignee || holder?.username || claimedBy;
```

So `lapsedFrom` holds **an assignee NAME, a bot USERNAME, or a User ObjectId string** — whichever fallback fired. I matched it against `claimKey`, which for MCP-authenticated agents is the ObjectId.

Live on TASK-029: `lapsedFrom` was `"pod-architect"` while `claimedBy` had been `"6a693bfbe833c668acdce53b"`. Different value spaces, never equal.

This is the same name-vs-id trap as `assignee` (a name) versus `claimedBy` (an id) — two string fields in one document whose values never overlap. I walked into it while writing the fix for the adjacent bug.

## The fix

Match `lapsedFrom` against every identity the caller can present: `userId`, `instanceId`, `agentName`, `username`. Still scoped to one seat — a caller whose identities don't include the stored value gets `leaseRenewed: false` and the note only.

`AuthReq.user` gains `username`, with a comment saying why it's needed rather than leaving a mystery field.

## Why the original tests couldn't catch it

**The fixture set `lapsedFrom` to the same string it sent as the caller.** With id and username identical, a filter matching either one passes. The test agreed with the code because both were built from the same assumption — the control shared the failure mode.

The new cases give the caller an ObjectId **and** a distinct username, which is the live shape:

| case | asserts |
|---|---|
| `lapsedFrom` = username, caller authed by id | restores — the live case |
| `lapsedFrom` = id | still restores — the widening is additive |
| a different seat entirely | `leaseRenewed: false`, note lands, row stays pending |
| `lapsedFrom` = null, caller has no username | no restore — undefined must not match null |

Probe: reverting to `lapsedFrom: claimKey` turns **exactly the live case** red (1 of 21). Under the old tests that same revert turned nothing red, which is the whole point.

## Note on #1114

Its other half — reporting `leaseRenewed` on the response — works and is confirmed live; it's how this was found at all. A fix that reports its own outcome told me it hadn't worked. That part earned its keep on the first use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)