### PR TITLE
fix(ci): the version guard shallowed the base it needed a merge base with

### DIFF
--- a/.github/workflows/package-version-guard.yml
+++ b/.github/workflows/package-version-guard.yml
@@ -40,7 +40,32 @@ jobs:
         run: |
           set -euo pipefail
           BASE="origin/${{ github.event.pull_request.base.ref }}"
-          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.ref }}" >/dev/null 2>&1 || true
+
+          # NO --depth here. `checkout` above already fetched full history
+          # (fetch-depth: 0); a --depth=1 fetch of the base UNDOES that by
+          # shallowing the ref, and once the base is one commit deep the fork
+          # point is unreachable. `git diff BASE...HEAD` then dies with
+          # "fatal: <base>...HEAD: no merge base" — which reads like a problem
+          # with the PR's diff and is entirely a problem with this fetch.
+          #
+          # It only fires once the base has advanced past the fork point, which
+          # is why the guard worked for weeks and then failed on #1113. Locally
+          # reproducible: full clone, advance base 12 commits past a feature
+          # branch, `git fetch --depth=1 origin <base>`, and the very next
+          # three-dot diff fails.
+          #
+          # Also dropped the `|| true`. A base we cannot fetch means every
+          # comparison below is meaningless, so it must stop rather than
+          # silently compare against whatever ref happens to be on disk — the
+          # failure mode this whole guard exists to prevent.
+          git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}"
+
+          # Prove the base is usable before trusting any diff against it. A
+          # guard that cannot see its own baseline must say so, not pass.
+          if ! git merge-base "$BASE" HEAD >/dev/null 2>&1; then
+            echo "::error::No merge base between $BASE and HEAD — the checkout is too shallow for this guard to compare anything. Not passing on an unusable baseline."
+            exit 1
+          fi
 
           fail=0
           # pkg_dir : the published package root (holds package.json)


### PR DESCRIPTION
@Sam flagged this in the 13:05 sweep — #1113's version-bump guard died on `no merge base`, cause identified as the guard's shallow fetch, durable fix noted as unowned. Taking it.

## The bug

The job checks out with `fetch-depth: 0`, then immediately runs:

```bash
git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.ref }}" >/dev/null 2>&1 || true
```

**That `--depth=1` undoes the full fetch.** It shallows the base ref, and once the base is one commit deep the fork point is unreachable — so the next line, `git diff --name-only "$BASE"...HEAD`, dies with `fatal: <base>...HEAD: no merge base`.

The error names the *diff*, so it reads as a problem with the PR's contents. It is entirely a problem with the fetch two lines above.

It only fires once the base has advanced past the fork point, which is why the guard worked for weeks and then failed on a PR that had been open a while.

## Reproduced before changing anything — and the first attempt failed

My first repro used a 5-commit base and **passed**: the fork point was still inside the shallow boundary, so `merge-base` resolved fine and the diff worked. A repro that passes is not a repro, and had I stopped there I'd have "verified" a diagnosis that was right for the wrong reason.

Advancing the base 12 commits past the feature branch and running the guard's own fetch line:

```
=== before the guard's fetch ===
g
=== after fetch --no-tags --depth=1 origin main ===
fatal: origin/main...HEAD: no merge base
```

Exact error, exact mechanism.

## The fix

- **Drop `--depth`.** `checkout` already fetched everything; the fetch now only refreshes the ref.
- **Drop `|| true`.** A base we cannot fetch makes every comparison below meaningless. Swallowing that failure means comparing against whatever ref happens to be on disk — which is the silent-agreement failure this guard exists to catch, reproduced inside the guard.
- **Add an explicit merge-base check** before any diff is trusted, with an error that names the real cause. A guard that cannot see its own baseline must fail loudly rather than pass.

## Scope

One workflow file. Does not touch the guard's logic, its package list, or its `branches: [main]` scoping — only its ability to see the baseline it already intended to use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)