### PR TITLE
docs(messages): the reply 503 depends on "nothing reconciles Mongo into PG"

### DIFF
--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -265,6 +265,20 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
       // reconciled into PG. A reply written here would look successful while
       // permanently losing its parent edge, so only non-replies may use this
       // availability fallback.
+      //
+      // "NEVER RECONCILED" IS A CURRENT FACT, NOT AN INVARIANT — and this
+      // guard is correct only while it holds (@sprint-review, pod 56881).
+      // Reconciling Mongo into PG was the other option considered on TASK-040;
+      // #1116 chose this one instead, so nothing reconciles today and the 503
+      // is the resolution rather than a stopgap.
+      //
+      // If reconciliation is ever built, this stops being a data-loss guard
+      // and becomes a rejection with no remaining reason: a user told
+      // "Replies are temporarily unavailable" about a path that would now
+      // preserve their reply. Whoever builds it must remove or relax this in
+      // the same change. The dependency runs both ways and appears in neither
+      // diff, which is why it is written at both ends — TASK-040 carries the
+      // pointer back here.
       if (replyToMessageId) {
         res.status(503).json({
           error: 'Replies are temporarily unavailable. Please try again shortly.',


### PR DESCRIPTION
@sprint-review's forward-looking note on #1116 (pod 56881), taken as a change rather than left in chat.

The guard is correct **because** nothing reconciles Mongo into PG. That is a *current fact*, not an invariant, and the dependency appears in neither diff — so a future reader sees a hard rule where there is a conditional one.

Reconciliation was the other option considered on TASK-040. #1116 chose fail-loudly instead, so nothing reconciles today and the 503 is the **resolution**, not a stopgap. If reconciliation is ever built, the guard stops protecting against data loss and becomes a rejection with no remaining reason — a user told *"Replies are temporarily unavailable"* about a path that would then preserve their reply fine.

**Written at both ends**, because a one-way pointer is the half that rots: this comment names the dependency, and TASK-040 now carries a note pointing back here for anyone who reads the task before proposing reconciliation.

One correction I made to my own TASK-040 note while doing this: I first wrote it as though both options were still open. They are not — sprint-impl shipped option (b) and closed the row. A note that mis-states which options are live is exactly the thing someone acts on six weeks later.

Comment only. No behaviour change; `messageController` suite green (20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)