### PR TITLE
fix: suppress bare runtime gibberish artifacts

### DIFF
--- a/backend/__tests__/service/clawdbot-e2e.test.js
+++ b/backend/__tests__/service/clawdbot-e2e.test.js
@@ -731,6 +731,24 @@ describe('Clawdbot E2E Integration Tests', () => {
       expect(res.body.skipped).toBe(true);
       expect(res.body.reason).toBe('silent_or_empty');
     });
+
+    test('silently skips a bare runtime gibberish artifact', async () => {
+      const res = await request(app)
+        .post(`/api/agents/runtime/pods/${testPod._id}/messages`)
+        .set('Authorization', `Bearer ${agentToken}`)
+        .send({
+          content: 'RGCTX',
+          messageType: 'text',
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        success: true,
+        skipped: true,
+        reason: 'silent_or_empty',
+      });
+      expect(res.body.message).toBeUndefined();
+    });
   });
 
   describe('6. Clawdbot Bridge Flow Simulation', () => {

--- a/backend/__tests__/unit/services/agentMessageService.chatNoise.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.chatNoise.test.js
@@ -66,4 +66,17 @@ describe('sanitizeAgentContent — NO_REPLY suppression and sanitization', () =>
       '```text\nNO_REPLY is discussed here.\n```',
     )).toBe('NO_REPLY is discussed here.');
   });
+
+  it('drops known bare runtime artifacts without swallowing terse replies', () => {
+    expect(AgentMessageService.sanitizeAgentContent('RGCTX')).toBe('');
+
+    // Short acknowledgements and formatted literals are intentional agent
+    // output; only observed wrapper artifacts are silent.
+    for (const content of [
+      'Yes', 'Done', 'LGTM', 'HTTP', 'HTTPS', 'XHTML', 'SHTML', 'MSSQL',
+      'KHTML', 'GRPCS', '`RGCTX`',
+    ]) {
+      expect(AgentMessageService.sanitizeAgentContent(content)).toBe(content);
+    }
+  });
 });

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -53,6 +53,11 @@ const RECENT_ATTACH_WINDOW_MS = 5 * 60 * 1000;
 // pattern it feeds, which matches at the start of a statement.
 const ATTACH_CLAIM_SCAN_LIMIT = 2000;
 
+// Runtime artifacts are exact values, not a language heuristic. Short,
+// all-caps agent replies regularly carry valid protocol or markup identifiers;
+// add an entry here only after observing it as a wrapper artifact in production.
+const BARE_RUNTIME_ARTIFACTS = new Set(['RGCTX']);
+
 let PGMessage: unknown = null;
 try {
   // eslint-disable-next-line global-require
@@ -1685,6 +1690,15 @@ class AgentMessageService {
     return /^⚠️\s*\p{Extended_Pictographic}[^:\n]{0,30}:?\s.*\bfailed\b\.?$/iu.test(c);
   }
 
+  static isBareRuntimeArtifact(content: unknown): boolean {
+    if (!content) return false;
+
+    // TASK-042: a Codex wrapper emitted this value instead of a silent reply.
+    // `sanitizeAgentContent` calls us only after it has established that the
+    // value is the complete, unformatted agent payload.
+    return BARE_RUNTIME_ARTIFACTS.has(String(content));
+  }
+
   static sanitizeAgentContent(content: unknown): string {
     if (content === null || content === undefined) return '';
     const raw = String(content);
@@ -1791,7 +1805,11 @@ class AgentMessageService {
     // Do not map/trim individual lines here. Whitespace-sensitive payloads
     // (Python, YAML, diffs, markdown nesting) are normal agent traffic, and a
     // line-wise sanitizer previously flattened their indentation.
-    return cleaned.trim();
+    const normalized = cleaned.trim();
+
+    // Apply the artifact floor after protected inline-code ranges have been
+    // copied into `cleaned`; a literal mentioned as code is not runtime noise.
+    return AgentMessageService.isBareRuntimeArtifact(normalized) ? '' : normalized;
   }
 
   /**


### PR DESCRIPTION
## Summary
- treat the observed bare runtime artifact as a silent agent reply at the shared post boundary
- preserve terse acknowledgements, protocol/markup identifiers, and code-formatted literals
- exercise the shared runtime posting route

## Verification
- `PATH=/opt/homebrew/opt/node@20/bin:$PATH npm test -- --runInBand __tests__/unit/services/agentMessageService.chatNoise.test.js`
- `PATH=/opt/homebrew/opt/node@20/bin:$PATH npm test -- --runInBand __tests__/service/clawdbot-e2e.test.js --testNamePattern="silently skips a bare runtime gibberish artifact"`
- `PATH=/opt/homebrew/opt/node@20/bin:$PATH npm run tsc:check`
- mutation: replacing the observed artifact in the set makes the unit regression fail

A full E2E rerun had one unrelated existing installation-count assertion flake; the route regression passes in isolation.