### PR TITLE
fix(threading): a leftover row is a violation, not a design note

### DIFF
--- a/backend/__tests__/service/threading.derivation.test.js
+++ b/backend/__tests__/service/threading.derivation.test.js
@@ -10,10 +10,21 @@
  *      one true root, using a single parent lookup.
  *   2. The backfill's recursive CTE produces the same roots as the write path.
  *
- * Tier 1 only. pg-mem cannot run this — probed 2026-08-22: it rejects
- * `WITH RECURSIVE` outright ("your query failed to parse") and mistypes the
- * parameterised INSERT. So there is no in-process shortcut; it is a real
- * server or it is nothing. CI provides postgres:16 with INTEGRATION_TEST=true.
+ * Tier 1 for claim 2 — pg-mem rejects `WITH RECURSIVE` outright ("your query
+ * failed to parse"), so the backfill's CTE genuinely needs a real server. CI
+ * provides postgres:16 with INTEGRATION_TEST=true.
+ *
+ * CORRECTED: this comment used to say "pg-mem cannot run this… a real server
+ * or it is nothing", which was too broad and outlived the finding that
+ * disproved it. The mistyped parameterised INSERT was a missing cast, not a
+ * limitation — the write-path derivation now runs at the unit tier in
+ * threadRootDerivation.pgmem.test.js, in plain `npm test`, against the real
+ * production query string.
+ *
+ * So claim 1 is covered at BOTH tiers on purpose: fast feedback in-process,
+ * and once more here end to end. Claim 2 is only here. Anyone tempted to
+ * delete the fast suite as redundant should note it is the one that runs on
+ * every push.
  */
 
 const { Pool } = require('pg');

--- a/backend/__tests__/unit/models/threadRootDerivation.pgmem.test.js
+++ b/backend/__tests__/unit/models/threadRootDerivation.pgmem.test.js
@@ -8,14 +8,28 @@
  *
  * They were right and my first answer was too broad. I had probed pg-mem,
  * found `WITH RECURSIVE` unsupported, and generalised that to "pg-mem cannot
- * run this". Only the backfill's recursive CTE is out of reach — the write-path
- * derivation runs fine once the scalar subquery is cast (pg-mem otherwise
- * types it as `integer[]`). The production query now carries those casts,
- * which are inert in Postgres, so what runs below is the REAL string.
+ * run this". The write-path derivation runs fine once the scalar subquery is
+ * cast (pg-mem otherwise types it as `integer[]`). The production query now
+ * carries those casts, which are inert in Postgres, so what runs below is the
+ * REAL string.
+ *
+ * OF WHAT THIS CODEBASE NEEDS, the recursive CTE is the piece pg-mem cannot
+ * run. Scoped deliberately rather than "only X is unsupported" — that is a
+ * claim about pg-mem, and I know of at least one more limitation without
+ * having surveyed them: `WITH ... INSERT` also fails ("nested statement with
+ * query type 'insert'"), found while probing workarounds. Nothing shipped uses
+ * it, which is exactly why a completeness claim would have been untested.
  *
  * This is the fast tier and it runs in plain `npm test`. The tier-1 suite
- * (__tests__/service/threading.derivation.test.js) still exists for what needs
- * a real server: the recursive CTE, the foreign keys, ON DELETE SET NULL.
+ * (__tests__/service/threading.derivation.test.js) exists for the recursive
+ * CTE and for running against a real server end to end.
+ *
+ * It is NOT needed for foreign keys or ON DELETE CASCADE, which an earlier
+ * version of this comment claimed. pg-mem enforces both — see
+ * threadFollowByParticipation's "the constraints are the SHIPPED ones,
+ * enforced" block, which rejects a phantom root and observes a CASCADE. That
+ * line would have sent a reader to the slow tier for something the fast one
+ * already covers.
  */
 
 const { newDb } = require('pg-mem');

--- a/backend/__tests__/unit/models/threadingCutoffRecord.test.js
+++ b/backend/__tests__/unit/models/threadingCutoffRecord.test.js
@@ -193,3 +193,39 @@ describe('the ordering precondition is CHECKED, not only warned about', () => {
     expect(SRC).toMatch(/process\.exitCode = 3;/);
   });
 });
+
+describe('a leftover is a violation where the FK binds, not a design note', () => {
+  // @sprint-review 56936 carried my FK finding further. I had the write half
+  // (the FK refuses a reply to a missing parent); they added the delete half
+  // (ON DELETE SET NULL clears the child's edge rather than orphaning it). So
+  // both routes to a dangling edge are shut and the leftover set should be
+  // empty — which makes the old unconditional "(orphaned chains stay NULL by
+  // design)" a diagnosis printed on every trigger, explaining away a failed
+  // walk at exit 0.
+  const SRC = fs.readFileSync(
+    path.join(__dirname, '../../../scripts/backfill-thread-root-id.ts'), 'utf8',
+  );
+
+  it('no longer calls a leftover by-design unconditionally', () => {
+    expect(SRC).not.toMatch(/still_null\} \(orphaned chains stay NULL by design\)/);
+  });
+
+  it('reports a leftover as an INVARIANT VIOLATION and exits non-zero', () => {
+    expect(SRC).toMatch(/INVARIANT VIOLATION/);
+    expect(SRC).toMatch(/process\.exitCode = 4;/);
+  });
+
+  it('but asks the database whether the FK actually binds first', () => {
+    // Their caveat: CREATE TABLE IF NOT EXISTS never retrofits a constraint,
+    // so a pre-FK instance genuinely can hold orphans and "by design" is then
+    // the honest wording. Conditional, not a hard error.
+    expect(SRC).toMatch(/FROM pg_constraint[\s\S]{0,200}reply_to_message_id%REFERENCES messages/);
+    expect(SRC).toMatch(/predates `?\n?\s*\+?\s*'?the reply_to_message_id FK/);
+  });
+
+  it('and says why the cutoff depends on it', () => {
+    // The consequence, not just the fact: a non-empty leftover set means the
+    // recorded boundary was computed over rows the walk did not reach.
+    expect(SRC).toMatch(/the recorded boundary[\s\S]{0,40}assumes this set is empty/);
+  });
+});

--- a/backend/scripts/backfill-thread-root-id.ts
+++ b/backend/scripts/backfill-thread-root-id.ts
@@ -323,7 +323,50 @@ async function main(): Promise<void> {
          FROM messages
         WHERE reply_to_message_id IS NOT NULL AND thread_root_id IS NULL`,
     );
-    console.log(`remaining with a reply edge and no root: ${after.still_null} (orphaned chains stay NULL by design)`);
+    // A LEFTOVER IS AN INVARIANT VIOLATION, NOT A DESIGN NOTE — where the FK
+    // binds. This line used to read "(orphaned chains stay NULL by design)"
+    // unconditionally, which is a diagnosis written for one cause printed on
+    // every trigger: it would have explained away a recursive CTE that failed
+    // to reach rows it should have, in a parenthesis, at exit 0.
+    //
+    // @sprint-review (56936) carried my FK finding further than I had. I showed
+    // the write half — the FK refuses a reply to a missing parent. They showed
+    // the delete half closes the other direction: ON DELETE SET NULL means
+    // deleting a parent NULLs the child's reply edge, so the child stops
+    // matching this predicate entirely rather than becoming an orphan. Both
+    // routes to a dangling edge are shut, so the leftover set should be empty.
+    //
+    // Their caveat is the reason this is conditional rather than a hard error:
+    // schema.sql is CREATE TABLE IF NOT EXISTS, so the FK binds only databases
+    // created after it entered the file, and no ALTER retrofits it. On an older
+    // instance orphans really are possible and "by design" is the honest words.
+    // So ask the database which world it is in rather than assuming either.
+    if (after.still_null > 0) {
+      const { rows: fk } = await pool.query(
+        `SELECT 1 FROM pg_constraint
+          WHERE conrelid = 'messages'::regclass AND contype = 'f'
+            AND pg_get_constraintdef(oid) LIKE '%reply_to_message_id%REFERENCES messages%'
+          LIMIT 1`,
+      );
+      if (fk.length > 0) {
+        console.error(
+          `INVARIANT VIOLATION: ${after.still_null} row(s) still have a reply edge and no root, `
+          + 'but this database enforces the reply_to_message_id foreign key — a dangling edge '
+          + 'cannot be written (FK refuses it) and cannot be created by deletion (ON DELETE SET '
+          + 'NULL clears the edge instead). So these rows are reachable from a root and the walk '
+          + 'did not reach them. Investigate before trusting the cutoff: the recorded boundary '
+          + 'assumes this set is empty.',
+        );
+        process.exitCode = 4;
+      } else {
+        console.log(
+          `remaining with a reply edge and no root: ${after.still_null} — this database predates `
+          + 'the reply_to_message_id FK, so genuinely orphaned chains are possible and stay NULL.',
+        );
+      }
+    } else {
+      console.log('remaining with a reply edge and no root: 0');
+    }
   } catch (error) {
     console.error('backfill failed:', (error as Error).message);
     process.exitCode = 1;


### PR DESCRIPTION
Two commits that landed on `feat/threading-2-follow-state` about four minutes
after #1109 squash-merged. The PR was already closed, so they never reached
`main` and nothing tested them. Recovered here off current `main`, unchanged.

### 1. A leftover row is an invariant violation, not a design note

The backfill used to close with:

```
remaining with a reply edge and no root: N (orphaned chains stay NULL by design)
```

@sprint-review showed that on this database that sentence cannot be true.
I had checked the write direction — the `reply_to_message_id` FK refuses a
reply whose parent does not exist. They pointed out the delete direction is
also shut: `ON DELETE SET NULL` means deleting a parent *clears* the child's
reply edge rather than orphaning it, so the child stops matching the
predicate entirely. Both routes to a dangling edge are closed.

So where the FK binds, a non-zero `N` is not orphaned history. It is the
recursive walk failing to reach rows it should have — reported as by-design,
in a parenthesis, at exit 0. **And the cutoff recorded on that same run would
have been computed over the rows the walk missed.**

Verified against the live instance rather than assumed: all three FKs are
present, including `messages_reply_to_message_id_fkey … ON DELETE SET NULL`,
and there are zero dangling edges.

The line is now conditional on the constraint actually being installed, asked
of `pg_constraint` rather than assumed in either direction:

- **FK present** → `INVARIANT VIOLATION` on stderr, `exitCode = 4`, naming why
  the cutoff is not trustworthy on that run.
- **FK absent** → the old wording, which is accurate on an instance predating
  the constraint, where genuine orphans are possible.

Asking the database is the point. `CREATE TABLE IF NOT EXISTS` never retrofits
a constraint onto an existing table — the same gap that nearly shipped
`thread_root_id` as a column that would never have existed on any live
instance. A self-hosted deployment can legitimately be in either world.

### 2. Two stale claims in my own test headers

Both were completeness claims that were true of the cases I had hit and false
of the space:

- "only the recursive CTE is out of reach at this tier" — `WITH … INSERT` is
  also unsupported by pg-mem.
- "tier 1 is where foreign keys and `ON DELETE CASCADE` get exercised" —
  pg-mem enforces both.

### Tests

4 new cases in `threadingCutoffRecord.test.js` (26 pass): that the
unconditional by-design wording is gone, that a leftover reports as a
violation and exits non-zero, that the FK is *checked* rather than presumed,
and that the message says why the cutoff depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
