### PR TITLE
refactor: share message delivery policy

### DIFF
--- a/backend/__tests__/unit/services/messageAgentDeliveryService.test.js
+++ b/backend/__tests__/unit/services/messageAgentDeliveryService.test.js
@@ -1,0 +1,122 @@
+jest.mock('../../../services/agentMentionService', () => ({
+  isAutoRoutedDmPod: jest.fn(),
+  enqueueDmEvent: jest.fn(),
+  enqueueMentions: jest.fn(),
+}));
+
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { countDocuments: jest.fn() },
+}));
+
+const AgentMentionService = require('../../../services/agentMentionService');
+const { AgentInstallation } = require('../../../models/AgentRegistry');
+const {
+  authorUsername,
+  deliverMessageToAgents,
+} = require('../../../services/messageAgentDeliveryService');
+
+describe('messageAgentDeliveryService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    AgentMentionService.isAutoRoutedDmPod.mockReturnValue(false);
+    AgentMentionService.enqueueMentions.mockResolvedValue({
+      enqueued: [{ installationId: 'mention-1' }],
+      implicit: ['recorder'],
+      woken: [{ installationId: 'wake-1' }],
+    });
+    AgentInstallation.countDocuments.mockResolvedValue(2);
+  });
+
+  test.each([
+    ['request user', { username: 'joined', user: { username: 'legacy' } }, { username: 'request' }, 'request'],
+    ['joined PG author', { userId: { username: 'joined' }, username: 'raw' }, undefined, 'joined'],
+    ['raw message author', { username: 'raw', user: { username: 'legacy' } }, undefined, 'raw'],
+    ['legacy Mongo author', { user: { username: 'legacy' } }, undefined, 'legacy'],
+  ])('uses the %s in the sender frame', (_case, message, requestUser, expected) => {
+    expect(authorUsername(message, requestUser)).toBe(expected);
+  });
+
+  it('enriches explicit-mention delivery and preserves an explicit root-post null', async () => {
+    const message = { id: 'm1', userId: { username: 'joined' }, content: 'hello @recorder' };
+
+    const response = await deliverMessageToAgents({
+      podId: 'p1',
+      podType: 'chat',
+      message,
+      userId: 'u1',
+      requestUser: { username: 'request' },
+      replyToMessageId: null,
+    });
+
+    expect(AgentMentionService.enqueueMentions).toHaveBeenCalledWith({
+      podId: 'p1',
+      message,
+      userId: 'u1',
+      username: 'request',
+      replyToMessageId: null,
+    });
+    expect(response).toEqual({
+      ...message,
+      agentDelivery: {
+        enqueued: 1,
+        implicit: ['recorder'],
+        agentsInPod: 2,
+        woken: 1,
+      },
+    });
+  });
+
+  it('omits a reply edge for a route that cannot receive one', async () => {
+    const message = { id: 'm1', userId: { username: 'joined' } };
+
+    await deliverMessageToAgents({
+      podId: 'p1',
+      podType: 'chat',
+      message,
+      userId: 'u1',
+    });
+
+    expect(AgentMentionService.enqueueMentions).toHaveBeenCalledWith({
+      podId: 'p1',
+      message,
+      userId: 'u1',
+      username: 'joined',
+    });
+  });
+
+  it('sends automatic DM delivery without advisory metadata', async () => {
+    const message = { id: 'm1', user: { username: 'mongo-author' } };
+    AgentMentionService.isAutoRoutedDmPod.mockReturnValue(true);
+
+    const response = await deliverMessageToAgents({
+      podId: 'p1',
+      podType: 'agent-admin',
+      message,
+      userId: 'u1',
+    });
+
+    expect(AgentMentionService.enqueueDmEvent).toHaveBeenCalledWith({
+      podId: 'p1', message, userId: 'u1', username: 'mongo-author',
+    });
+    expect(AgentMentionService.enqueueMentions).not.toHaveBeenCalled();
+    expect(AgentInstallation.countDocuments).not.toHaveBeenCalled();
+    expect(response).toBe(message);
+  });
+
+  it('keeps a persisted post successful when the advisory count fails', async () => {
+    const countError = new Error('database unavailable');
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    AgentInstallation.countDocuments.mockRejectedValue(countError);
+
+    const response = await deliverMessageToAgents({
+      podId: 'p1', podType: 'chat', message: { id: 'm1' }, userId: 'u1',
+    });
+
+    expect(response.agentDelivery.agentsInPod).toBe(0);
+    expect(warn).toHaveBeenCalledWith(
+      '[messageAgentDelivery] active-agent delivery count failed:',
+      'database unavailable',
+    );
+    warn.mockRestore();
+  });
+});

--- a/backend/__tests__/unit/services/podTypePolicyService.test.js
+++ b/backend/__tests__/unit/services/podTypePolicyService.test.js
@@ -1,0 +1,21 @@
+const {
+  PERSONAL_POD_TYPES,
+  isPersonalPodType,
+} = require('../../../services/podTypePolicyService');
+
+describe('podTypePolicyService', () => {
+  it.each(['agent-admin', 'agent-room', 'agent-dm'])(
+    'marks %s as a personal conversation type',
+    (type) => {
+      expect(isPersonalPodType(type)).toBe(true);
+      expect(PERSONAL_POD_TYPES.has(type)).toBe(true);
+    },
+  );
+
+  it.each(['chat', 'study', 'games', 'agent-ensemble', 'team'])(
+    'does not treat %s as personal',
+    (type) => {
+      expect(isPersonalPodType(type)).toBe(false);
+    },
+  );
+});

--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -9,9 +9,7 @@ const PGMessage = require('../models/pg/Message');
 // eslint-disable-next-line global-require
 const PGPod = require('../models/pg/Pod');
 // eslint-disable-next-line global-require
-const AgentMentionService = require('../services/agentMentionService');
-// eslint-disable-next-line global-require
-const { AgentInstallation } = require('../models/AgentRegistry');
+const { deliverMessageToAgents } = require('../services/messageAgentDeliveryService');
 const DMService = require('../services/dmService');
 // eslint-disable-next-line global-require
 const { syncPodFromMongo } = require('../services/pgPodSyncService');
@@ -297,71 +295,17 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
       message = normalizeMongo(populated || mongoMsg);
     }
 
-    // The author's username, for agentMentionService's author frame — the
-    // line a woken agent reads to learn WHO raised its turn. Without it the
-    // frame says 'raised by **unknown**' for every real user, because the JWT
-    // auth path sets `req.user = { id }` while the API-token path sets id +
-    // username. The web UI is JWT, so the fallback fired fleet-wide.
-    //
-    // Sourced from the message rather than from `req.user` deliberately. Both
-    // write paths above already re-fetch with the author joined — PGMessage
-    // .findById for the JOIN, MongoMessage .populate('userId', 'username
-    // profilePicture') — precisely so the response carries the author. Reading
-    // it here costs nothing extra.
-    //
-    // Putting it on `req.user` instead connects a DB read to every route that
-    // uses the auth middleware, and CodeQL follows that edge: it produced 225
-    // new high-severity js/missing-rate-limiting alerts, one per authed route.
-    // Those routes were already unrate-limited and the read already happened —
-    // but drowning the real alerts is its own harm.
-    const pgAuthor = message.userId;
-    const username = req.user?.username
-      || (pgAuthor && typeof pgAuthor === 'object' ? pgAuthor.username : undefined)
-      || message.username
-      || message.user?.username;
-    // agent-admin (legacy 1:1 admin DM), agent-room (1:1 user↔agent DM), and
-    // agent-dm (any 2-member DM, including agent↔agent) all auto-route every
-    // human message to the agent — no @mention needed. Other pod types only
-    // fire on explicit @mentions. `isAutoRoutedDmPod` owns that allow-list so
-    // the legacy PG endpoint cannot silently drift from this primary path.
-    const isDmPod = AgentMentionService.isAutoRoutedDmPod(pod.type);
-    let responseMessage: NormalizedMessage | (NormalizedMessage & {
-      agentDelivery: {
-        enqueued: number; implicit: string[]; agentsInPod: number; woken: number;
-      };
-    }) = message;
-    if (isDmPod) {
-      await AgentMentionService.enqueueDmEvent({ podId, message, userId, username });
-    } else {
-      const mentionResult = await AgentMentionService.enqueueMentions({
-        podId,
-        message,
-        userId,
-        username,
-        replyToMessageId: replyToMessageId || null,
-      });
-      let agentsInPod = 0;
-      try {
-        agentsInPod = await AgentInstallation.countDocuments({ podId, status: 'active' });
-      } catch (countErr) {
-        // Delivery metadata is advisory UI feedback. A count failure must
-        // never turn an already-persisted message into a failed send.
-        console.warn('[messageController] active-agent delivery count failed:', (countErr as Error).message);
-      }
-      responseMessage = {
-        ...message,
-        agentDelivery: {
-          enqueued: mentionResult.enqueued.length,
-          implicit: mentionResult.implicit || [],
-          agentsInPod,
-          // Wake-on-message targets (ADR-018 D8). Without this count the
-          // composer's "No agent was notified" hint fires in the one pod
-          // every new user starts in — while the Guide is already waking on
-          // the very same message (#914).
-          woken: mentionResult.woken?.length ?? 0,
-        },
-      };
-    }
+    const responseMessage = await deliverMessageToAgents({
+      podId,
+      podType: pod.type,
+      message,
+      userId,
+      requestUser: req.user,
+      // This route owns reply edges. Passing null for a root post preserves
+      // the existing enqueueMentions contract; the legacy PG route omits the
+      // field altogether because it cannot receive one.
+      replyToMessageId: replyToMessageId || null,
+    });
 
     // Live-broadcast the new message to every connected client in this pod's
     // Socket.io room. Without this emit, V2 chat surfaces only see the new

--- a/backend/controllers/pgMessageController.ts
+++ b/backend/controllers/pgMessageController.ts
@@ -7,9 +7,7 @@ const PGMessage = require('../models/pg/Message');
 // eslint-disable-next-line global-require
 const MongoPod = require('../models/Pod');
 // eslint-disable-next-line global-require
-const AgentMentionService = require('../services/agentMentionService');
-// eslint-disable-next-line global-require
-const { AgentInstallation } = require('../models/AgentRegistry');
+const { deliverMessageToAgents } = require('../services/messageAgentDeliveryService');
 // eslint-disable-next-line global-require
 const { syncPodFromMongo } = require('../services/pgPodSyncService');
 
@@ -30,21 +28,7 @@ type CreatedMessage = {
   username?: string;
   user?: { username?: string };
   userId?: { username?: string } | string;
-  agentDelivery?: {
-    enqueued: number;
-    implicit: string[];
-    agentsInPod: number;
-    woken: number;
-  };
 };
-
-function authorUsername(message: CreatedMessage | null | undefined, requestUser?: AuthRequest['user']): string | undefined {
-  const joinedAuthor = message?.userId;
-  return requestUser?.username
-    || (joinedAuthor && typeof joinedAuthor === 'object' ? joinedAuthor.username : undefined)
-    || message?.username
-    || message?.user?.username;
-}
 
 // Check if user is a member via PG, falling back to MongoDB as source of truth
 async function isMemberWithFallback(podId: string, userId: string): Promise<boolean> {
@@ -161,33 +145,16 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
     const message = ((await PGMessage.findById(newMessage.id)) || newMessage) as CreatedMessage;
 
     // This endpoint is older than the PG-primary /api/messages path, but it
-    // still writes the same user-authored messages. Dispatch them through the
-    // same mention/DM pipeline after persistence so a post here cannot be a
-    // silent escape hatch around agent delivery.
-    const username = authorUsername(message, req.user);
-    let responseMessage = message;
-    if (AgentMentionService.isAutoRoutedDmPod(pod.type)) {
-      await AgentMentionService.enqueueDmEvent({ podId, message, userId, username });
-    } else {
-      const mentionResult = await AgentMentionService.enqueueMentions({ podId, message, userId, username });
-      let agentsInPod = 0;
-      try {
-        agentsInPod = await AgentInstallation.countDocuments({ podId, status: 'active' });
-      } catch (countErr) {
-        // Delivery metadata is advisory feedback. Do not turn an already
-        // persisted message into a failed post when the count is unavailable.
-        console.warn('[pgMessageController] active-agent delivery count failed:', (countErr as Error).message);
-      }
-      responseMessage = {
-        ...message,
-        agentDelivery: {
-          enqueued: mentionResult.enqueued.length,
-          implicit: mentionResult.implicit || [],
-          agentsInPod,
-          woken: mentionResult.woken?.length ?? 0,
-        },
-      };
-    }
+    // still writes the same user-authored messages. It has no reply-edge
+    // request field, so deliberately omit replyToMessageId here; the shared
+    // delivery service distinguishes omission from the primary route's null.
+    const responseMessage = await deliverMessageToAgents({
+      podId,
+      podType: pod.type,
+      message,
+      userId,
+      requestUser: req.user,
+    });
 
     res.json(responseMessage);
   } catch (err) {

--- a/backend/controllers/podController.ts
+++ b/backend/controllers/podController.ts
@@ -8,6 +8,7 @@ const Integration = require('../models/Integration');
 const { AgentRegistry, AgentInstallation } = require('../models/AgentRegistry');
 const AgentProfile = require('../models/AgentProfile');
 const AgentIdentityService = require('../services/agentIdentityService');
+const { isPersonalPodType } = require('../services/podTypePolicyService');
 const {
   COMMUNITY_LISTING_QUERY,
   NON_LISTABLE_POD_TYPES,
@@ -219,7 +220,7 @@ exports.getAllPods = async (req: any, res: any) => {
     // their own pod list must be their own pods, otherwise every
     // private DM in the instance leaks into their sidebar (which made
     // xcjsam see — and try to post into — sam-demo's agent-rooms).
-    const isPersonal = type === 'agent-admin' || type === 'agent-room' || type === 'agent-dm';
+    const isPersonal = isPersonalPodType(type);
     if (req.userId && !isCommunityScope && !isDiscoverScope) {
       const wantsAll = scope === 'all';
       const isAdmin = wantsAll ? await isGlobalAdminRequest(req) : false;
@@ -288,7 +289,7 @@ exports.getPodsByType = async (req: any, res: any) => {
     // Personal pod types (agent-admin, agent-room, agent-dm) are always
     // filtered to caller membership — admins included. The instance-wide
     // moderation view is a separate admin tool, not this typed listing.
-    if ((type === 'agent-admin' || type === 'agent-room' || type === 'agent-dm') && req.userId) {
+    if (isPersonalPodType(type) && req.userId) {
       const uid = String(req.userId);
       const memberPods = pods.filter((p: any) => p.members.some((m: any) => String(m._id || m) === uid));
       return res.json(memberPods);
@@ -340,8 +341,7 @@ exports.getPodById = async (req: any, res: any) => {
     // `agent-room` and `agent-admin` keep strict membership: those are
     // truly private surfaces (user↔agent rooms; ops admin pods) and we
     // don't want admins resolving someone else's agent-room by ID either.
-    const personalTypes = new Set(['agent-room', 'agent-dm', 'agent-admin']);
-    if (personalTypes.has(pod.type) && req.userId) {
+    if (isPersonalPodType(pod.type) && req.userId) {
       const uid = String(req.userId);
       const isMember = (pod.members || []).some(
         (m: any) => String(m?._id || m) === uid,
@@ -384,10 +384,10 @@ exports.createPod = async (req: any, res: any) => {
       return res.status(400).json({ msg: 'Invalid pod type' });
     }
 
-    // ADR-001 §3.10 / ADR-016 invariant 3: DM pods are strictly 1:1 and are
-    // created only by paths that establish BOTH members (dmService
+    // ADR-001 §3.10 / ADR-016 invariant 3: agent-room and agent-dm are
+    // strictly 1:1 and are created only by paths that establish BOTH members (dmService
     // .getOrCreateAgentDmRoom, ensureAgentInPod, commonly_open_dm). This
-    // endpoint writes `members: [req.userId]`, so allowing a DM type here
+    // endpoint writes `members: [req.userId]`, so allowing a strict-DM type here
     // mints a one-member DM pod — and every later guard is an *entrance*
     // guard (join, invite create, invite redeem, install), so none of them
     // can repair a pod that was born malformed.
@@ -395,8 +395,8 @@ exports.createPod = async (req: any, res: any) => {
     // Derived from DM_POD_TYPES_GUARD rather than by narrowing
     // VALID_POD_TYPES: that constant is also the read filter for
     // getPodsByType above, so narrowing it for a creation reason would
-    // silently 400 a read endpoint. The guard is the thing that *is* the DM
-    // predicate; a hand-maintained allowlist only happens to agree with it.
+    // silently 400 a read endpoint. The guard is the strict-DM predicate; a
+    // hand-maintained allowlist only happens to agree with it.
     const { DM_POD_TYPES_GUARD } = require('../services/agentIdentityService');
     if (DM_POD_TYPES_GUARD.has(String(type))) {
       return res.status(400).json({
@@ -489,8 +489,8 @@ exports.joinPod = async (req: any, res: any) => {
     // effectively dead for agent-rooms because `pod.createdBy` is the
     // host *agent*, not a human user. For multi-party human↔agent
     // surfaces, use `type: 'chat'` instead.
-    // DM pods (agent-room / agent-dm / agent-admin) are strictly 1:1.
-    // ADR-001 §3.10. Third-party joins must spawn a NEW DM pod with the
+    // Only agent-room and agent-dm are strictly 1:1. Third-party joins must
+    // spawn a NEW DM pod with the
     // requesting party + the relevant agent — see dmService
     // .getOrCreateAgentDmRoom. Same invariant lives in
     // agentIdentityService.DM_POD_TYPES_GUARD.

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -2775,9 +2775,11 @@ router.post('/pods', phase4RateLimit, agentRuntimeAuth, async (req: any, res: an
       return res.status(400).json({ message: 'name and type are required' });
     }
 
-    // Keep parity with the Pod model and human creation route. `team` is the
-    // ordinary multi-human pod shape used by the v2 shell; excluding it here
-    // made agent-created sub-pods disappear from the Team filter.
+    // This is the agent-create policy, not the Pod model's full enum or the
+    // human creation route's read filter. Agent DMs are created only through
+    // the dedicated rails that establish both members, while `agent-room` is
+    // human-initiated; keeping those out here is intentional. `team` is the
+    // ordinary multi-human pod shape used by the v2 shell.
     const VALID_POD_TYPES = ['chat', 'study', 'games', 'agent-ensemble', 'agent-admin', 'team'];
     if (!VALID_POD_TYPES.includes(type)) {
       return res.status(400).json({ message: `Invalid pod type. Must be one of: ${VALID_POD_TYPES.join(', ')}` });

--- a/backend/services/agentIdentityService.ts
+++ b/backend/services/agentIdentityService.ts
@@ -535,8 +535,8 @@ class AgentIdentityService {
       // into an existing DM. A new conversation between a third party and
       // either of the two existing members spawns a NEW DM pod via
       // dmService.getOrCreateAgentDmRoom — never widens the existing one.
-      // The same rule applies symmetrically to agent-room (1:1 user↔agent)
-      // and agent-admin (1:1 admin↔agent).
+      // The same rule applies to agent-room (1:1 user↔agent) and agent-dm.
+      // agent-admin is deliberately N:1 and does not use this guard.
       if (DM_POD_TYPES_GUARD.has(String(pod.type))) {
         console.warn(
           `[ensureAgentInPod] refused: pod ${pod._id} is type=${pod.type} (1:1 DM) `

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -23,6 +23,10 @@ const { resolveAgentDisplayLabel } = require('./agentIdentityService') as {
     fallback?: string,
   ) => string;
 };
+// eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+const { isPersonalPodType } = require('./podTypePolicyService') as {
+  isPersonalPodType: (type: unknown) => boolean;
+};
 
 const ChatSummarizerService = chatSummarizerService.constructor as {
   getLatestPodSummary: (podId: string) => Promise<unknown>;
@@ -835,13 +839,10 @@ const resolveImplicitReplyTarget = async (
   };
 };
 
-// Pod types that auto-route every message to non-sender members as a
-// chat.mention event. Adding a new private 1:1 type without listing it
-// here silently drops every message; controllers call the predicate below
-// rather than maintaining a second copy of this delivery rule.
-const DM_POD_TYPES = new Set(['agent-admin', 'agent-room', 'agent-dm']);
-
-const isAutoRoutedDmPod = (type: unknown): boolean => DM_POD_TYPES.has(String(type));
+// Personal pods auto-route every message to non-sender members as a
+// chat.mention event. This is intentionally broader than the strict-1:1
+// DM guard: agent-admin is N:1 but still has personal delivery semantics.
+const isAutoRoutedDmPod = (type: unknown): boolean => isPersonalPodType(type);
 
 // ── ADR-018 D8: wake-on-message ─────────────────────────────────────────────
 //
@@ -1473,8 +1474,8 @@ const enqueueDmEvent = async ({
     .select('_id isBot username botMetadata')
     .lean() as { _id: unknown; isBot?: boolean; username?: string; botMetadata?: { displayName?: string; instanceId?: string; agentName?: string } } | null;
   // Bot senders are allowed in agent-dm (the whole point) but still blocked
-  // in agent-admin/agent-room — those are operator-driven 1:1 with one
-  // agent; a bot posting there shouldn't auto-route to itself.
+  // in agent-admin/agent-room — those are operator-driven personal surfaces;
+  // a bot posting there shouldn't auto-route to itself.
   if (sender?.isBot && pod.type !== 'agent-dm') {
     return { enqueued: false, reason: 'sender_is_bot' };
   }

--- a/backend/services/dmService.ts
+++ b/backend/services/dmService.ts
@@ -92,8 +92,9 @@ class DMService {
   }
 
   /**
-   * Find or create a 1:1 agent-admin DM pod between an agent user and its
-   * installer (the owner who installed the agent into a pod).
+   * Find or create a private agent-admin pod between an agent user and its
+   * installer (the owner who installed the agent into a pod). Agent-admin is
+   * N:1, unlike the strict 1:1 agent-room and agent-dm shapes.
    */
   static async getOrCreateAgentDM(agentUserId: unknown, ownerUserId: unknown, { agentName, instanceId }: DMOptions = {}): Promise<InstanceType<typeof Pod>> {
     const agentId = String(agentUserId);

--- a/backend/services/messageAgentDeliveryService.ts
+++ b/backend/services/messageAgentDeliveryService.ts
@@ -1,0 +1,92 @@
+// eslint-disable-next-line global-require
+const AgentMentionService = require('./agentMentionService');
+// eslint-disable-next-line global-require
+const { AgentInstallation } = require('../models/AgentRegistry');
+
+export interface MessageForAgentDelivery {
+  userId?: { username?: string } | string;
+  username?: string;
+  user?: { username?: string };
+}
+
+interface DeliveryOptions<T extends MessageForAgentDelivery> {
+  podId: string;
+  podType: unknown;
+  message: T;
+  userId: string;
+  requestUser?: { username?: string };
+  // Undefined means this endpoint has no reply-edge field (the legacy PG
+  // route). Null is meaningful: the primary route explicitly sends it for a
+  // root post, preserving the existing enqueueMentions call shape.
+  replyToMessageId?: string | null;
+}
+
+interface AgentDelivery {
+  enqueued: number;
+  implicit: string[];
+  agentsInPod: number;
+  woken: number;
+}
+
+type DeliveredMessage<T> = T | (T & { agentDelivery: AgentDelivery });
+
+// The persisted message is the authoritative sender frame. Request auth can
+// have only an id (JWT) while either PG or Mongo may have joined the author.
+// Keep the historical precedence stable across both create routes.
+export const authorUsername = (
+  message: MessageForAgentDelivery | null | undefined,
+  requestUser?: { username?: string },
+): string | undefined => {
+  const joinedAuthor = message?.userId;
+  return requestUser?.username
+    || (joinedAuthor && typeof joinedAuthor === 'object' ? joinedAuthor.username : undefined)
+    || message?.username
+    || message?.user?.username;
+};
+
+// Both user-message controllers persist first, then deliver the same message
+// to either the automatic DM route or the explicit-mention route. Centralizing
+// this seam keeps the response metadata and sender identity in lockstep while
+// leaving route-specific write semantics (including reply edges) at the edge.
+export const deliverMessageToAgents = async <T extends MessageForAgentDelivery>({
+  podId,
+  podType,
+  message,
+  userId,
+  requestUser,
+  replyToMessageId,
+}: DeliveryOptions<T>): Promise<DeliveredMessage<T>> => {
+  const username = authorUsername(message, requestUser);
+
+  if (AgentMentionService.isAutoRoutedDmPod(podType)) {
+    await AgentMentionService.enqueueDmEvent({ podId, message, userId, username });
+    return message;
+  }
+
+  const mentionOptions = {
+    podId,
+    message,
+    userId,
+    username,
+    ...(replyToMessageId !== undefined ? { replyToMessageId } : {}),
+  };
+  const mentionResult = await AgentMentionService.enqueueMentions(mentionOptions);
+  let agentsInPod = 0;
+  try {
+    agentsInPod = await AgentInstallation.countDocuments({ podId, status: 'active' });
+  } catch (countErr) {
+    // Delivery metadata is advisory UI feedback. A count failure must never
+    // turn an already-persisted message into a failed send.
+    console.warn('[messageAgentDelivery] active-agent delivery count failed:', (countErr as Error).message);
+  }
+
+  return {
+    ...message,
+    agentDelivery: {
+      enqueued: mentionResult.enqueued.length,
+      implicit: mentionResult.implicit || [],
+      agentsInPod,
+      woken: mentionResult.woken?.length ?? 0,
+    },
+  };
+};

--- a/backend/services/podTypePolicyService.ts
+++ b/backend/services/podTypePolicyService.ts
@@ -1,0 +1,16 @@
+// Personal pods are private conversation surfaces. They all require caller
+// membership for read/list access and auto-route participant messages to an
+// agent. This is deliberately broader than DM_POD_TYPES_GUARD in
+// agentIdentityService: agent-admin is an N:1 admin↔agent surface, so it is
+// personal and auto-routed without being a strict two-member DM.
+//
+// Keep this taxonomy separate from the VALID_POD_TYPES lists in the model and
+// creation routes. Those answer which shapes a particular writer accepts;
+// this answers which persisted pods have personal-conversation behaviour.
+export const PERSONAL_POD_TYPES = new Set<string>([
+  'agent-admin',
+  'agent-room',
+  'agent-dm',
+]);
+
+export const isPersonalPodType = (type: unknown): boolean => PERSONAL_POD_TYPES.has(String(type));


### PR DESCRIPTION
## Summary
- centralize the duplicated sender-resolution, DM/mention dispatch, and delivery metadata contract used by both user-message controllers
- share personal-pod policy between routing and access checks while keeping strict 1:1 DM membership separate from agent-admin
- correct stale pod-type comments that implied the different writer allow-lists were one taxonomy

## Verification
- `npm run tsc:check`
- focused Jest: 134 tests across the shared service, both controllers, route service, pod policy, and mention delivery
- mutation check: removing the raw-message username fallback makes the shared-service regression test fail
- CI at `e8072230`: Test & Coverage, Chart Lint, Service Tests (Tier 1 — real DBs), and E2E Tests passed
- `Source changed ⇒ version bumped` is unrelated infrastructure: it exits before evaluating packages with `fatal: origin/main...HEAD: no merge base` (the known shallow-fetch defect tracked separately)