### PR TITLE
fix(threading): follow delivered thread mentions

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.threadScoping.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.threadScoping.test.js
@@ -22,6 +22,9 @@ jest.mock('../../../services/welcomeWakeService', () => ({ maybeFireWelcomeWake:
 jest.mock('../../../models/pg/Message', () => ({
   findById: jest.fn(async (id) => (String(id) === '101' ? { id: 101, user_id: 'bot-1' } : null)),
 }));
+jest.mock('../../../models/pg/ThreadUserState', () => ({
+  followByParticipation: jest.fn(),
+}));
 jest.mock('../../../services/threadWakeScopeService', () => ({
   narrowToThread: jest.fn(async (_root, targets) => targets),
   effectiveFollowerIds: jest.fn(async () => new Set()),
@@ -35,6 +38,7 @@ const Pod = require('../../../models/Pod');
 const User = require('../../../models/User');
 const AgentEvent = require('../../../models/AgentEvent');
 const { narrowToThread } = require('../../../services/threadWakeScopeService');
+const ThreadUserState = require('../../../models/pg/ThreadUserState');
 
 // `installedBy` is deliberately a DIFFERENT id from the bot's User row here.
 // It is the human installer on five of the write paths (podController:119,
@@ -86,6 +90,7 @@ beforeEach(() => {
       : { _id: 'user-1', isBot: false }),
   }));
   AgentEvent.countDocuments.mockResolvedValue(0);
+  ThreadUserState.followByParticipation.mockResolvedValue(true);
 });
 
 describe('the hook fires only for threaded messages', () => {
@@ -221,5 +226,63 @@ describe('scoping cannot reach the addressing path', () => {
     narrowToThread.mockImplementation(async () => []);
     await send({ id: 'm10', content: '@seat-a you muted this but I need you', thread_root_id: 101 });
     expect(byType('chat.mention').map((e) => e.agentName)).toEqual(['seat-a']);
+  });
+});
+
+describe('a delivered thread mention follows by participation', () => {
+  test('the shared delivery record follows the BOT user only after its mention enqueues', async () => {
+    await send({ id: 'm11', content: '@seat-a please review', thread_root_id: 101 });
+
+    expect(ThreadUserState.followByParticipation).toHaveBeenCalledTimes(1);
+    expect(ThreadUserState.followByParticipation).toHaveBeenCalledWith(101, 'bot-user-a', 'pod-1');
+
+    const mentionCall = AgentEventService.enqueue.mock.calls.find(
+      ([event]) => event.type === 'chat.mention' && event.agentName === 'seat-a',
+    );
+    expect(mentionCall).toBeDefined();
+    expect(ThreadUserState.followByParticipation.mock.invocationCallOrder[0])
+      .toBeGreaterThan(AgentEventService.enqueue.mock.invocationCallOrder[
+        AgentEventService.enqueue.mock.calls.indexOf(mentionCall)
+      ]);
+  });
+
+  test('a delivery failure cannot create a follow for an address that was never delivered', async () => {
+    AgentEventService.enqueue.mockRejectedValueOnce(new Error('queue down'));
+    await send({ id: 'm12', content: '@seat-a please review', thread_root_id: 101 });
+
+    expect(ThreadUserState.followByParticipation).not.toHaveBeenCalled();
+  });
+
+  test('a follow-write failure is visible but cannot fail a send whose address already delivered', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    ThreadUserState.followByParticipation.mockRejectedValueOnce(new Error('pg down'));
+
+    await expect(send({ id: 'm12b', content: '@seat-a please review', thread_root_id: 101 }))
+      .resolves.toMatchObject({ enqueued: ['seat-a'] });
+
+    expect(warn).toHaveBeenCalledWith(
+      '[thread-follow] mention delivery succeeded but follow write failed:',
+      'pg down',
+    );
+    warn.mockRestore();
+  });
+
+  test('a reply edge is addressing, not an explicit mention, so it does not create a follow', async () => {
+    await send(
+      {
+        id: 'm13', content: 'replying', thread_root_id: 101, replyTo: { userId: 'bot-1' },
+      },
+      { replyToMessageId: '101' },
+    );
+
+    expect(byType('chat.mention')).toHaveLength(1);
+    expect(ThreadUserState.followByParticipation).not.toHaveBeenCalled();
+  });
+
+  test('CONTROL: the same successful mention outside a thread does not create thread state', async () => {
+    await send({ id: 'm14', content: '@seat-a please review' });
+
+    expect(byType('chat.mention')).toHaveLength(1);
+    expect(ThreadUserState.followByParticipation).not.toHaveBeenCalled();
   });
 });

--- a/backend/__tests__/unit/services/agentMentionService.threadingIsNotAddressing.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.threadingIsNotAddressing.test.js
@@ -46,6 +46,9 @@ jest.mock('../../../services/welcomeWakeService', () => ({ maybeFireWelcomeWake:
 jest.mock('../../../models/pg/Message', () => ({
   findById: jest.fn(async (id) => (String(id) === '101' ? { id: 101, user_id: 'bot-1' } : null)),
 }));
+jest.mock('../../../models/pg/ThreadUserState', () => ({
+  followByParticipation: jest.fn().mockResolvedValue(true),
+}));
 
 const AgentMentionService = require('../../../services/agentMentionService');
 const AgentEventService = require('../../../services/agentEventService');

--- a/backend/__tests__/unit/services/threadFollowByParticipationWiring.test.js
+++ b/backend/__tests__/unit/services/threadFollowByParticipationWiring.test.js
@@ -1,17 +1,15 @@
 /**
  * Keep the comment and the code-base agreeing about followByParticipation.
  *
- * @sprint-review's third blocker on 3/4 (57306): threadWakeScopeService's
- * header asserted "the mention writes the row at the moment it happens, via
- * ThreadUserState.followByParticipation" — and nothing called it. The method
- * shipped, its tests passed, and the only thing claiming it was wired was
- * prose.
+ * @sprint-review's third blocker on 3/4 (57306) caught a doc-vs-reality gap:
+ * threadWakeScopeService said a mention wrote the row, while nothing called
+ * this method. The implementation is intentionally at agentMentionService's
+ * successful-delivery choke point, not at one of its four resolution branches.
  *
- * The comment is corrected. This exists so it cannot drift back, in EITHER
- * direction: it fails if a production caller appears while the comment still
- * says there is none, and it fails if the comment stops saying so while there
- * is still no caller. A doc-vs-reality gap that only a reader can detect is
- * the failure mode being guarded, so the guard has to be executable.
+ * This exists so the comment cannot drift from that call graph in either
+ * direction. Behaviour is asserted at the delivery consumer in
+ * agentMentionService.threadScoping.test.js; this test protects the human
+ * contract and its one designated production writer.
  */
 
 const fs = require('fs');
@@ -84,7 +82,9 @@ describe('followByParticipation: the comment and the call graph agree', () => {
     if (claimsUnwired) {
       expect(callers).toEqual([]);
     } else {
-      expect(callers.length).toBeGreaterThan(0);
+      // A non-empty list would let a second, unreviewed writer appear. The
+      // mention-delivery choke point is deliberately the only caller.
+      expect(callers).toEqual(['services/agentMentionService.ts']);
     }
   });
 });

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -9,6 +9,10 @@ const Pod = require('../models/Pod');
 // eslint-disable-next-line global-require
 const User = require('../models/User');
 // eslint-disable-next-line global-require
+const ThreadUserState = require('../models/pg/ThreadUserState') as {
+  followByParticipation: (threadRootId: number, userId: string, podId: string) => Promise<boolean | null>;
+};
+// eslint-disable-next-line global-require
 const AgentEvent = require('../models/AgentEvent');
 // eslint-disable-next-line global-require
 const chatSummarizerService = require('./chatSummarizerService');
@@ -57,6 +61,8 @@ interface EnqueueMentionsOptions {
     message_type?: string;
     createdAt?: unknown;
     created_at?: unknown;
+    thread_root_id?: unknown;
+    threadRootId?: unknown;
     thread?: unknown;
     replyTo?: { userId?: unknown } | null;
   };
@@ -935,8 +941,15 @@ const isWakeLoopDampened = async (
 };
 
 /** `agentName:instanceId`, lowercased — the identity an install and a bot User row share. */
-const installKey = (inst: Record<string, unknown>): string => `${
+const installKey = (inst: { agentName?: unknown; instanceId?: unknown }): string => `${
   String(inst.agentName || '').toLowerCase()}:${String(inst.instanceId || 'default')}`;
+
+/** A thread root arrives from PG as either its numeric column or JSON spelling. */
+const resolveThreadRootId = (message: EnqueueMentionsOptions['message']): number | null => {
+  const raw = message.thread_root_id ?? message.threadRootId;
+  const id = Number(raw);
+  return Number.isSafeInteger(id) && id > 0 ? id : null;
+};
 
 /**
  * Map each install to its BOT's User row id — the key thread_user_state uses.
@@ -951,7 +964,7 @@ const installKey = (inst: Record<string, unknown>): string => `${
  * the wake is a message nobody sees.
  */
 const resolveBotUserIds = async (
-  targets: Array<Record<string, unknown>>,
+  targets: Array<{ agentName?: unknown; instanceId?: unknown }>,
 ): Promise<Map<string, string>> => {
   const out = new Map<string, string>();
   const wanted = [...new Set(targets.map(installKey))].filter((k) => !k.startsWith(':'));
@@ -979,6 +992,38 @@ const resolveBotUserIds = async (
 };
 
 /**
+ * Persist the follow implied by a DELIVERED explicit mention in a thread.
+ *
+ * This is deliberately awaited after the agent event has been enqueued: the
+ * participation state becomes durable before this mention operation completes,
+ * but a PG failure cannot turn an already-persisted post or delivered address
+ * into a 500. `followByParticipation` itself preserves an explicit mute by
+ * writing only where `following IS NULL`.
+ */
+const followDeliveredThreadMentions = async (
+  threadRootId: number,
+  podId: string,
+  targets: Iterable<MentionTarget>,
+  botUserIds: Map<string, string>,
+): Promise<void> => {
+  const userIds = new Set(
+    Array.from(targets)
+      .map((target) => botUserIds.get(installKey(target)))
+      .filter((userId): userId is string => Boolean(userId)),
+  );
+
+  await Promise.all([...userIds].map(async (userId) => {
+    try {
+      await ThreadUserState.followByParticipation(threadRootId, userId, podId);
+    } catch (error) {
+      // The message and its address are already durable. Keep the failure
+      // visible without making a successful send look failed to the author.
+      console.warn('[thread-follow] mention delivery succeeded but follow write failed:', (error as Error).message);
+    }
+  }));
+};
+
+/**
  * Fan a message out to the pod's wake-on-message opt-ins. Skips the sender's
  * own identity (an agent never wakes on its own post), anything the mention
  * path already enqueued this message (a mention is the stronger cue — double
@@ -989,7 +1034,7 @@ const resolveBotUserIds = async (
  * caller already loaded — no queries, no pod lookup.
  */
 const enqueueWakeOnMessage = async ({
-  podId, message, rawContent, userId, username, source, installations, sender, excludeKeys, authorFrame,
+  podId, message, rawContent, userId, username, source, installations, sender, excludeKeys, authorFrame, resolvedBotUserIds,
 }: {
   podId: string;
   message: EnqueueMentionsOptions['message'];
@@ -1001,6 +1046,7 @@ const enqueueWakeOnMessage = async ({
   sender: SenderRow | null;
   excludeKeys: Set<string> | null;
   authorFrame: { username: string; createdAt: unknown; messageId: string | undefined };
+  resolvedBotUserIds?: Map<string, string>;
 }): Promise<string[]> => {
   const woken: string[] = [];
   let targets = (installations || []).filter(wakeOnMessageEnabled);
@@ -1040,14 +1086,13 @@ const enqueueWakeOnMessage = async ({
   // An install whose bot User row cannot be resolved is KEPT by
   // narrowToThread rather than dropped — an unclassifiable target must
   // degrade to today's behaviour, never to silence.
-  const threadRootId = (message as { thread_root_id?: unknown; threadRootId?: unknown })?.thread_root_id
-    ?? (message as { threadRootId?: unknown })?.threadRootId ?? null;
+  const threadRootId = resolveThreadRootId(message);
   if (threadRootId) {
     // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
     const { narrowToThread } = require('./threadWakeScopeService');
-    const botUserIds = await resolveBotUserIds(targets);
+    const botUserIds = resolvedBotUserIds ?? await resolveBotUserIds(targets);
     targets = await narrowToThread(
-      Number(threadRootId),
+      threadRootId,
       targets,
       (inst: Record<string, unknown>) => botUserIds.get(installKey(inst)) ?? null,
     );
@@ -1244,12 +1289,21 @@ const enqueueMentions = async ({
   const implicit: string[] = [];
   const skipped: string[] = [];
   const enqueuedIdentityKeys = new Set<string>();
+  // This is deliberately distinct from `enqueuedIdentityKeys`: the latter
+  // also records a reply-edge delivery, which is addressing but not an
+  // explicit @mention and therefore must not create a follow.
+  const deliveredMentionTargets = new Map<string, MentionTarget>();
   const identityKey = (target: MentionTarget): string => (
     `${target.agentName.toLowerCase()}:${(target.instanceId || 'default').toLowerCase()}`
   );
-  const recordEnqueued = (target: MentionTarget, resultLabel = target.agentName): void => {
+  const recordEnqueued = (
+    target: MentionTarget,
+    resultLabel = target.agentName,
+    isExplicitMention = true,
+  ): void => {
     enqueuedIdentityKeys.add(identityKey(target));
     enqueued.push(resultLabel);
+    if (isExplicitMention) deliveredMentionTargets.set(identityKey(target), target);
   };
 
   const { map: mentionMap, byAgent } = buildMentionMap(installations, profiles);
@@ -1487,6 +1541,24 @@ const enqueueMentions = async ({
     }),
   );
 
+  // One BOT User lookup serves both the delivered mention below and the
+  // routed message's ambient wake fan-out. An auto-joined target is not in
+  // the initial installation list yet, so include the actual delivery set.
+  const threadRootId = resolveThreadRootId(message);
+  let resolvedBotUserIds: Map<string, string> | undefined;
+  if (threadRootId && deliveredMentionTargets.size > 0) {
+    resolvedBotUserIds = await resolveBotUserIds([
+      ...installations,
+      ...deliveredMentionTargets.values(),
+    ]);
+    await followDeliveredThreadMentions(
+      threadRootId,
+      podId,
+      deliveredMentionTargets.values(),
+      resolvedBotUserIds,
+    );
+  }
+
   // Human replies to an agent are an addressing signal even when the human
   // does not repeat an @mention. Bot replies are deliberately excluded: if
   // A's reply to B implicitly notified B (and vice versa), two agents could
@@ -1523,7 +1595,7 @@ const enqueueMentions = async ({
             implicitReply: true,
           },
         });
-        recordEnqueued(target);
+        recordEnqueued(target, target.agentName, false);
         implicit.push(target.agentName);
       }
     } catch (error) {
@@ -1548,7 +1620,7 @@ const enqueueMentions = async ({
   let woken: string[] = [];
   try {
     woken = await enqueueWakeOnMessage({
-      podId, message, rawContent, userId, username, source, installations, sender, excludeKeys: enqueuedIdentityKeys, authorFrame,
+      podId, message, rawContent, userId, username, source, installations, sender, excludeKeys: enqueuedIdentityKeys, authorFrame, resolvedBotUserIds,
     });
   } catch (error) {
     console.warn('[wake-on-message] fan-out failed:', (error as Error).message);

--- a/backend/services/threadWakeScopeService.ts
+++ b/backend/services/threadWakeScopeService.ts
@@ -13,28 +13,18 @@
  *    read from `messages`, never stored: it is a fact about the conversation,
  *    and materialising it would mean a second writer that can disagree with
  *    the first. This is the `following IS NULL` case from the tri-state.
- *  - `explicitFollowers` — `following IS TRUE`. Today that means one thing:
- *    someone used the header toggle. `ThreadUserState.followByParticipation`
- *    exists to make an @mention write the row too, and NOTHING CALLS IT —
- *    @sprint-review's third blocker on 3/4 (57306). So a user @-mentioned in
- *    a thread who never posts is not an effective follower and stops
- *    receiving its ambient activity.
- *
- *    That is a spec gap rather than a regression: the mention itself still
- *    wakes them, because addressing never passes through this service. It
- *    also cannot be closed by writing a caller anywhere convenient — a
- *    synchronous Postgres write on the mention hot path is a decision, not a
- *    detail. Tracked as TASK-045; this comment previously asserted the wiring
- *    existed, which is the thing that made it invisible.
- *
- *    WHOEVER CLOSES TASK-045: the shouted phrase three paragraphs up is load
- *    bearing. threadFollowByParticipationWiring.test.js reads it and asserts
- *    the call graph agrees, so adding a caller without editing this comment
- *    turns that suite red on purpose. Swap it for the WIRED marker defined at
- *    the top of that test and the same suite flips to requiring a caller.
- *    (Deliberately not quoting the other marker here — the suite asserts
- *    EXACTLY ONE is present, and spelling both out is how this very edit
- *    first went red.)
+  *  - `explicitFollowers` — `following IS TRUE`. The header toggle writes it,
+  *    and THE MENTION PATH CALLS IT after a delivered agent @mention in a
+  *    thread. That writes TRUE only where it is NULL through
+  *    `ThreadUserState.followByParticipation`, so a queue failure never creates
+  *    a follow for an address that did not happen and a mute (FALSE) is never
+  *    overwritten.
+  *
+  *    This row only makes later AMBIENT activity reach an agent who was
+  *    explicitly addressed and never posts. The mention itself still wakes the
+  *    target whether or not they follow the thread. The executable guard in
+  *    threadFollowByParticipationWiring.test.js keeps this header and its one
+  *    production caller agreeing.
  *  - `muted` — `following IS FALSE`. Subtracted LAST, because an explicit mute
  *    outranks participation. A participant who muted must stay muted.
  *
@@ -45,8 +35,9 @@
  *
  * NOT the addressing path. An explicit @mention still wakes its target whether
  * or not they follow the thread, and whether or not they muted it: a mute
- * scopes ambient activity, never addressing. That path never reaches this
- * service, because `isRouted` short-circuits before the ambient branch.
+ * scopes ambient activity, never addressing. A routed message's ambient
+ * companion DOES reach this service, but its already-delivered mention target
+ * is excluded before this narrowing runs.
  */
 /* eslint-disable @typescript-eslint/no-require-imports, global-require */
 const { pool } = require('../config/db-pg');


### PR DESCRIPTION
## Summary
- follow a bot user when its explicit @mention in a threaded message is successfully enqueued
- preserve reply edges as addressing only; they do not create follows
- reuse one bot-user lookup for follow persistence and routed ambient scoping

## Delivery decision
The bounded, deduplicated follow writes are awaited after the event enqueue. A write failure is logged but cannot fail the already-persisted message or delivered address. `followByParticipation` continues to preserve explicit mutes.

## Verification
- `npm test -- --runInBand __tests__/unit/services/agentMentionService.test.js __tests__/unit/services/agentMentionService.wakeOnMessage.test.js __tests__/unit/services/agentMentionService.threadScoping.test.js __tests__/unit/services/agentMentionService.threadingIsNotAddressing.test.js __tests__/unit/services/threadFollowByParticipationWiring.test.js __tests__/unit/models/threadFollowByParticipation.test.js`
- `npm run tsc:check`

Stacked on #1120 (thread wake scoping).