### PR TITLE
fix(v2): unread dot no longer clipped by the rounded row corner

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -77,6 +77,18 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).toContain('.v2-pods__item-snippet-row');
   });
 
+  test('the unread dot stays clear of the rounded row corner (name-wrap side effect)', () => {
+    // The title-row is align-items: flex-start (for the 2-line name wrap),
+    // which parks the dot flush at the row's top-right — inside the row's
+    // border-radius + overflow:hidden clip, where the rounding visibly
+    // shaved it (reported live 2026-08-22). Both margins are load-bearing:
+    // top centers it on the first text line, right clears the 10px curve.
+    // jsdom cannot see corner clipping — presence pin per this file's rule.
+    const dot = ruleBody(v2, '.v2-pods__item-dot');
+    expect(dot).toContain('margin-top: 6px');
+    expect(dot).toContain('margin-right: 4px');
+  });
+
   test('grouped messages keep the avatar column so text never shifts (craft audit rule 3)', () => {
     // Consecutive same-author messages within the grouping window drop the
     // header row; the ghost cell must match the .v2-msg grid's 38px avatar

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -1095,6 +1095,13 @@
   border-radius: 50%;
   background: var(--v2-accent);
   flex-shrink: 0;
+  /* The title-row went align-items: flex-start for the 2-line name wrap
+     (#1110), which parked this dot flush at the row's top-right corner —
+     inside the row's border-radius + overflow:hidden clip, so the rounding
+     visibly shaved the dot (Sam, 2026-08-22). Center it on the first 20px
+     text line and inset it clear of the 10px corner curve. */
+  margin-top: 6px;
+  margin-right: 4px;
 }
 
 .v2-pods__item-snippet--typing {


### PR DESCRIPTION
Sam's live report: after the sidebar rounding, the notification dot renders truncated. Root cause is #1110's own `align-items: flex-start` on the title-row — measured in the real browser, the dot sat flush at the row's top-right (top inset 0, right inset 0), inside the `border-radius: 10px` + `overflow: hidden` corner clip. Fix centers it on the first text line and insets it 4px clear of the curve; re-measured post-fix: top inset 6, right inset 4, outside the clip zone. Invariant pin added (jsdom can't see corner clipping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK