### PR TITLE
docs(threading): the mutation probe edits the comment, not the SQL

### DIFF
--- a/backend/__tests__/unit/models/threadRootDerivation.pgmem.test.js
+++ b/backend/__tests__/unit/models/threadRootDerivation.pgmem.test.js
@@ -1,6 +1,29 @@
 /**
  * thread_root_id derivation, EXECUTED at the unit tier (W-T, TASK-029, 1/4).
  *
+ * BEFORE YOU RUN THE MUTATION THIS SUITE EXISTS FOR, read this.
+ *
+ * `COALESCE(parent.thread_root_id, parent.id)` appears TWICE in Message.ts:
+ * once at :110 in the comment that explains the rule, once at :124 in the SQL
+ * that implements it. A text-based mutation without /g, or any first-match
+ * edit, rewrites the COMMENT and leaves the behaviour untouched.
+ *
+ * The result is not a silent no-op — it is worse. The suite passes 5/5, which
+ * reads as "these tests cannot detect the thing they were built to detect",
+ * and the honest-looking response is to strengthen tests that were already
+ * fine. @sprint-review identified the mechanism (56937); both runs measured
+ * against main afterwards:
+ *
+ *   first-match mutation (hits :110, the comment) -> 5 passed  [MEANINGLESS]
+ *   line-targeted mutation (hits :124, the SQL)   -> 3 failed  [THE REAL KILL]
+ *
+ * So the derivation IS covered — sprint-review's A/B/C case, depth 7, and
+ * two-chains-in-one-pod all die when the code actually changes. Anchor the
+ * mutation to the SQL line, then assert the file changed where you meant it
+ * to, before reading the test result. A probe that cannot show it hit its
+ * target is measuring nothing, and it will tell you so in the voice of a
+ * passing suite.
+ *
  * @sprint-review (56787): the depth claim was asserted by grepping for the
  * COALESCE substring that implements it — assertion and thing asserted are the
  * same text, so it cannot discriminate. They proposed pg-mem: insert A, B→A,


### PR DESCRIPTION
@sprint-review found the mechanism (56937): `COALESCE(parent.thread_root_id, parent.id)` appears **twice** in `Message.ts` — `:110` in the comment explaining the rule, `:124` in the SQL implementing it. A first-match text mutation rewrites the comment and leaves behaviour intact.

**The failure mode is an inverted reading, not a silent no-op.** The suite returns 5/5, which says *"these tests cannot detect the thing they were built to detect"* — and the diligent response to that is to go strengthen tests that were already correct.

Measured both runs against `main` rather than reasoning about them:

| Mutation | Hits | Result |
|---|---|---|
| First-match text | `:110`, the comment | **5 passed** — meaningless |
| Line-targeted | `:124`, the SQL | **3 failed** — the real kill |

**So the derivation is genuinely covered.** sprint-review's own A/B/C case, depth 7, and two-chains-in-one-pod all die when the code actually changes. That was the open question underneath their note, and it now has an answer rather than an assumption.

Recorded in the suite header, where the next person reaching for this probe will be standing. No behaviour change; comment only.

The rule generalises past this expression: anywhere a comment quotes the code it explains, a text mutation has two targets and will take the wrong one. Anchor to the line, assert the file changed where you meant it to, and only then read the test result. A probe that cannot show it hit its target is measuring nothing — and it will tell you so in the voice of a passing suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)