### PR TITLE
test(scripts): the guard had two blind spots, and its controls shared them

### DIFF
--- a/backend/__tests__/unit/scripts/unguardedScriptImporters.test.js
+++ b/backend/__tests__/unit/scripts/unguardedScriptImporters.test.js
@@ -33,20 +33,60 @@ const path = require('path');
 const BACKEND = path.join(__dirname, '../../..');
 const SCRIPTS = path.join(BACKEND, 'scripts');
 
-/** A bare `main()` / `run()` / async-IIFE at column zero, i.e. at module scope. */
-const SELF_EXECUTES = /^\s*(?:main|run)\s*\(\s*\)|^\s*void \(async|^\s*\(async\s*\(\)\s*=>/m;
+/**
+ * A bare `main()` / `run()` / async-IIFE at COLUMN ZERO.
+ *
+ * @sprint-review (57328): the previous comment said column zero and the regex
+ * said `^\s*`, which also matches an indented `main()` inside a function body.
+ * That over-flags in the safe direction, so nothing broke — but a false
+ * positive here points someone at a file that is fine, and the honest way to
+ * make the test pass again is to weaken it. Anchored properly; the control
+ * below proves an indented call is not counted.
+ */
+const SELF_EXECUTES = /^(?:main|run)\s*\(\s*\)|^void \(async|^\(async\s*\(\)\s*=>/m;
 const GUARDED = /require\.main\s*===\s*module/;
 
-const scriptFiles = () => fs.readdirSync(SCRIPTS)
-  .filter((f) => /\.(ts|js)$/.test(f))
-  .map((f) => path.join(SCRIPTS, f));
+/**
+ * An import of something under scripts/, capturing the path BELOW it.
+ *
+ * `[\w./-]+` rather than `[\w.-]+`: the capture has to cross slashes, or
+ * `scripts/sub/foo` reads as an import of nothing at all. Defined once and
+ * used by both the scan and its control — a control that retypes the pattern
+ * is testing the copy, which is the same mistake as asserting a claim by
+ * grepping for the string that makes it.
+ */
+const IMPORT_OF_SCRIPT = /(?:require\(|from\s*)['"][^'"]*scripts\/([\w./-]+)['"]/g;
+
+/**
+ * Every script, RECURSIVELY, keyed by its path under scripts/ without the
+ * extension — `sub/foo`, not `foo`.
+ *
+ * @sprint-review (57329): `readdirSync` is not recursive and the importer
+ * pattern stopped its capture at the first slash, so a script in a
+ * subdirectory was invisible to both halves at once — and both controls would
+ * still have passed while it went unscanned. `backend/scripts` is flat today,
+ * which is exactly what makes that the kind of gap nobody notices: the guard
+ * would keep reporting success on the day the first subdirectory appeared.
+ */
+const scriptFiles = (dir = SCRIPTS) => fs.readdirSync(dir, { withFileTypes: true })
+  .flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return scriptFiles(full);
+    return /\.(ts|js)$/.test(entry.name) ? [full] : [];
+  });
+
+const keyOf = (full) => path
+  .relative(SCRIPTS, full)
+  .replace(/\.(ts|js)$/, '')
+  .split(path.sep)
+  .join('/');
 
 const selfExecutingScripts = () => scriptFiles()
   .filter((full) => {
     const src = fs.readFileSync(full, 'utf8');
     return SELF_EXECUTES.test(src) && !GUARDED.test(src);
   })
-  .map((full) => path.basename(full, path.extname(full)));
+  .map(keyOf);
 
 /** Production modules outside scripts/ that `require`/`import` from scripts/. */
 const importersOfScripts = () => {
@@ -61,7 +101,7 @@ const importersOfScripts = () => {
       }
       if (!/\.(ts|js)$/.test(entry.name)) continue;
       const src = fs.readFileSync(full, 'utf8');
-      for (const m of src.matchAll(/(?:require\(|from\s*)['"][^'"]*scripts\/([\w.-]+)['"]/g)) {
+      for (const m of src.matchAll(new RegExp(IMPORT_OF_SCRIPT.source, 'g'))) {
         found.push({ importer: path.relative(BACKEND, full), script: m[1] });
       }
     }
@@ -95,6 +135,43 @@ describe('a script that self-executes must not be importable', () => {
     // and is safe because it only exports. If this goes empty the scan broke.
     const scripts = importersOfScripts().map((e) => e.script);
     expect(scripts).toContain('seed-native-agents');
+  });
+
+  test('CONTROL: an indented call inside a function body is NOT module scope', () => {
+    // The blind spot @sprint-review found. `^\\s*` matched this, which means
+    // the detector called an ordinary helper a self-executing script.
+    expect(SELF_EXECUTES.test('function f() {\n  main();\n}\n')).toBe(false);
+    expect(SELF_EXECUTES.test('if (x) {\n  run();\n}\n')).toBe(false);
+    // ...while the real thing still trips it, or the fix would be a mute.
+    expect(SELF_EXECUTES.test('main();\n')).toBe(true);
+    expect(SELF_EXECUTES.test('void (async () => {})();\n')).toBe(true);
+  });
+
+  describe('CONTROL: a script in a subdirectory is visible to both halves', () => {
+    const SUB = path.join(SCRIPTS, '__probe_sub');
+    const FILE = path.join(SUB, 'nested.ts');
+
+    beforeEach(() => {
+      fs.mkdirSync(SUB, { recursive: true });
+      fs.writeFileSync(FILE, 'export const f = () => 1;\nmain();\n');
+    });
+
+    afterEach(() => {
+      fs.rmSync(SUB, { recursive: true, force: true });
+      // Asserted, not assumed. A cleanup that silently does nothing is how a
+      // probe leaves the tree dirty and the next run lies about why.
+      expect(fs.existsSync(SUB)).toBe(false);
+    });
+
+    test('the walk reaches it and keys it by subpath', () => {
+      expect(selfExecutingScripts()).toContain('__probe_sub/nested');
+    });
+
+    test('and an importer of it is matched across the slash', () => {
+      const line = "require('../scripts/__probe_sub/nested')";
+      const m = [...line.matchAll(new RegExp(IMPORT_OF_SCRIPT.source, 'g'))];
+      expect(m.map((x) => x[1])).toEqual(['__probe_sub/nested']);
+    });
   });
 
   test('the backfill that taught us this stays guarded', () => {


### PR DESCRIPTION
@sprint-review's two notes on #1138 (57328, 57329). Both real, both now carry a control that fails without the fix.

**1. Doc-vs-code mismatch.** The comment said "column zero, i.e. at module scope"; the regex said `^\s*`, which also matches an indented `main()` inside a function body. Over-flagging is the safe direction, so nothing broke — but a false positive points someone at a file that is fine, and the tidy way to make the test pass again is to weaken it. Anchored to column zero.

**2. Subdirectories were invisible to both halves at once.** `readdirSync` is not recursive, and the importer capture `[\w.-]+` stops at the first slash. So a script in `scripts/sub/` would be missed by the walk *and* unmatched by the scan — **and both controls would have kept passing while it went unscanned.** `backend/scripts` is flat today, which is exactly what makes this the kind of gap nobody notices: the guard would go on reporting success on the day the first subdirectory appeared.

Walk is recursive and keys by subpath (`sub/foo`, not `foo`); the capture crosses slashes.

### Controls, each probed against the original bug

| Probe | Expected | Result |
|---|---|---|
| Revert `SELF_EXECUTES` to `^\s*` | indented-call control fails | ✅ 1 failed |
| Revert the walk to non-recursive | subpath control fails | ✅ 1 failed |
| Revert the capture to `[\w.-]+` | slash control fails | ✅ 1 failed |

One failure each, the right one each time.

### Two smaller things

The slash control I first wrote **retyped the regex**, so it was testing its own copy — the same mistake as asserting a claim by grepping for the string that makes it, which is the error this suite's whole lineage started from. Hoisted to one definition used by both.

The subdirectory control creates a real file and removes it in `afterEach`, and **asserts the removal**. A cleanup that silently does nothing is the third instance of that shape today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)