### PR TITLE
feat(threading): resolve collapsed in the payload, not in every client

### DIFF
--- a/backend/__tests__/unit/models/threadEffectiveCollapsed.test.js
+++ b/backend/__tests__/unit/models/threadEffectiveCollapsed.test.js
@@ -1,0 +1,181 @@
+/**
+ * `collapsed` is resolved in the payload, not by the client — @ux-lead's
+ * ruling (56996), EXECUTED against pg-mem rather than asserted about source.
+ *
+ * The rule being pinned: every root in the pod appears, and each carries a
+ * concrete boolean. The client never sees absence and is never told the
+ * threading cutoff. Three cutoff states, and the order of the CASE arms is
+ * the #1115 ruling — unknown expands, and it outranks everything.
+ *
+ * MUTATION PROBE, derived expectation vs actual, per @sprint-review (56999):
+ * a kill count only means something against a number you committed to first.
+ *
+ *   mutation                              expected  actual
+ *   CASE arms swapped                        3        1
+ *   COALESCE dropped (default always wins)   4        4
+ *   join loses `AND s.user_id = $1`          1+       1
+ *   `>=` inverted to `<`                     1        2
+ *
+ * Two mismatches, and both are worth more than the eight that matched.
+ *
+ * FEWER (3 -> 1): my expectation was wrong, not the suite. Swapping the arms
+ * only changes an answer when the cutoff IS NULL — with a cutoff present, the
+ * `cutoffUnknown` arm is reached either way. So "cutoffUnknown: EXPAND
+ * EVERYTHING" cannot discriminate arm order at all, and the single test that
+ * does is "outranks a cutoff being present", which compares the null and
+ * non-null cases against each other. Deriving the number first is what
+ * surfaced that; a bare "1 failed" would have read as a thin suite.
+ *
+ * MORE (1 -> 2): the second kill is "another user's row does not leak into
+ * mine", whose control half asserts MY default for a post-cutoff root. That
+ * assertion legitimately spans two behaviours, so a default-flipping mutation
+ * reaches it. Not a shared-property flaw in the fixtures — the wider mutation
+ * simply touches more than the one test named for it.
+ */
+
+const { newDb } = require('pg-mem');
+const { applyTable } = require('../../utils/schemaTable');
+
+const mockDb = newDb();
+const mockPool = new (mockDb.adapters.createPg().Pool)();
+jest.mock('../../../config/db-pg', () => ({ pool: mockPool }));
+
+const ThreadUserState = require('../../../models/pg/ThreadUserState');
+
+const POD = 'pod-1';
+const OTHER = 'pod-2';
+const USER = 'user-1';
+const PEER = 'user-2';
+
+// Two roots either side of a cutoff, each with a reply so they are real roots.
+const OLD_ROOT = '2026-08-01T00:00:00Z';
+const NEW_ROOT = '2026-08-20T00:00:00Z';
+const CUTOFF = '2026-08-10T00:00:00Z';
+
+let oldRootId; let newRootId; let lonelyId;
+
+beforeAll(async () => {
+  await applyTable(mockPool, 'pods');
+  await applyTable(mockPool, 'users');
+  await applyTable(mockPool, 'messages');
+  await applyTable(mockPool, 'thread_user_state');
+  for (const p of [POD, OTHER]) {
+    // eslint-disable-next-line no-await-in-loop
+    await mockPool.query(
+      `INSERT INTO pods (id, name, type, created_by) VALUES ('${p}', 'P', 'chat', '${USER}')`,
+    );
+  }
+  await mockPool.query(`INSERT INTO users (_id, username) VALUES ('${USER}', 'a'), ('${PEER}', 'b')`);
+
+  const mk = async (pod, created, root = null) => {
+    const { rows } = await mockPool.query(
+      `INSERT INTO messages (pod_id, user_id, content, message_type, thread_root_id, created_at)
+       VALUES ($1, $2, 'x', 'text', $3::int, $4::timestamptz) RETURNING id`,
+      [pod, USER, root, created],
+    );
+    return Number(rows[0].id);
+  };
+
+  oldRootId = await mk(POD, OLD_ROOT);
+  await mk(POD, OLD_ROOT, oldRootId);          // reply -> oldRoot is a root
+  newRootId = await mk(POD, NEW_ROOT);
+  await mk(POD, NEW_ROOT, newRootId);          // reply -> newRoot is a root
+  lonelyId = await mk(POD, NEW_ROOT);          // no replies -> NOT a root
+  const otherRoot = await mk(OTHER, NEW_ROOT);
+  await mk(OTHER, NEW_ROOT, otherRoot);        // a root in a DIFFERENT pod
+});
+
+afterEach(async () => {
+  await mockPool.query('DELETE FROM thread_user_state');
+});
+
+const call = (cutoff, unknown, user = USER) => ThreadUserState
+  .effectiveStateForPod(user, POD, cutoff, unknown);
+
+describe('every root in the pod comes back with a concrete boolean', () => {
+  test('both roots appear even though the user has touched neither', async () => {
+    const rows = await call(CUTOFF, false);
+    expect(rows.map((r) => r.thread_root_id).sort((a, b) => a - b)).toEqual([oldRootId, newRootId]);
+    for (const r of rows) expect(typeof r.collapsed).toBe('boolean');
+  });
+
+  test('a message nobody replied to is not a root and is not returned', async () => {
+    // Otherwise every message in the pod would arrive as a collapsed thread.
+    const rows = await call(CUTOFF, false);
+    expect(rows.map((r) => r.thread_root_id)).not.toContain(lonelyId);
+  });
+
+  test('roots in other pods are not returned', async () => {
+    const rows = await call(CUTOFF, false);
+    expect(rows).toHaveLength(2);
+  });
+});
+
+describe('the three cutoff states, resolved server-side', () => {
+  test('cutoff set: pre-cutoff root expands, post-cutoff root collapses', async () => {
+    const rows = await call(CUTOFF, false);
+    const by = Object.fromEntries(rows.map((r) => [r.thread_root_id, r.collapsed]));
+    expect(by[oldRootId]).toBe(false);
+    expect(by[newRootId]).toBe(true);
+  });
+
+  test('cutoff null and KNOWN: nothing pre-dates threading, so all collapse', async () => {
+    const rows = await call(null, false);
+    expect(rows.map((r) => r.collapsed)).toEqual([true, true]);
+  });
+
+  test('cutoffUnknown: EXPAND EVERYTHING, including the post-cutoff root', async () => {
+    // #1115's load-bearing case. Never collapse on an unknown — a wrong
+    // collapse hides history that was visible yesterday.
+    const rows = await call(CUTOFF, true);
+    expect(rows.map((r) => r.collapsed)).toEqual([false, false]);
+  });
+
+  test('cutoffUnknown outranks a cutoff being present at all', async () => {
+    const withCutoff = await call(CUTOFF, true);
+    const without = await call(null, true);
+    expect(withCutoff.map((r) => r.collapsed)).toEqual(without.map((r) => r.collapsed));
+  });
+});
+
+describe('an explicit row outranks the default, in both directions', () => {
+  test('explicitly collapsing a PRE-cutoff root sticks', async () => {
+    await ThreadUserState.setCollapsed(oldRootId, USER, POD, true);
+    const rows = await call(CUTOFF, false);
+    expect(rows.find((r) => r.thread_root_id === oldRootId).collapsed).toBe(true);
+  });
+
+  test('explicitly expanding a POST-cutoff root sticks', async () => {
+    await ThreadUserState.setCollapsed(newRootId, USER, POD, false);
+    const rows = await call(CUTOFF, false);
+    expect(rows.find((r) => r.thread_root_id === newRootId).collapsed).toBe(false);
+  });
+
+  test('an explicit row survives cutoffUnknown, which otherwise expands all', async () => {
+    await ThreadUserState.setCollapsed(oldRootId, USER, POD, true);
+    const rows = await call(CUTOFF, true);
+    expect(rows.find((r) => r.thread_root_id === oldRootId).collapsed).toBe(true);
+    expect(rows.find((r) => r.thread_root_id === newRootId).collapsed).toBe(false);
+  });
+
+  test("another user's row does not leak into mine", async () => {
+    await ThreadUserState.setCollapsed(newRootId, PEER, POD, false);
+    const mine = await call(CUTOFF, false);
+    expect(mine.find((r) => r.thread_root_id === newRootId).collapsed).toBe(true);
+    const theirs = await call(CUTOFF, false, PEER);
+    expect(theirs.find((r) => r.thread_root_id === newRootId).collapsed).toBe(false);
+  });
+});
+
+describe('following is NOT collapsed to a boolean', () => {
+  test('absence stays null, because null means defer-to-participation', async () => {
+    const rows = await call(CUTOFF, false);
+    for (const r of rows) expect(r.following).toBeNull();
+  });
+
+  test('an explicit mute comes back as false, not as absence', async () => {
+    await ThreadUserState.unfollow(newRootId, USER, POD);
+    const rows = await call(CUTOFF, false);
+    expect(rows.find((r) => r.thread_root_id === newRootId).following).toBe(false);
+  });
+});

--- a/backend/__tests__/unit/models/threadStateReadContract.test.js
+++ b/backend/__tests__/unit/models/threadStateReadContract.test.js
@@ -13,6 +13,25 @@
  *
  * Executed end-to-end through the real controller handler, because the mapping
  * from row to payload is where the contract is actually expressed.
+ *
+ * CONTRACT CHANGED, @ux-lead's ruling (56996). The payload used to be sparse —
+ * only rows that exist — plus a `defaults` block carrying the threading cutoff,
+ * leaving the client to notice absence and compare timestamps. Now every root
+ * in the pod is returned with `collapsed` already resolved, and the cutoff
+ * never crosses the wire.
+ *
+ * These tests are the executable record of a decided behaviour, so they are
+ * rewritten rather than deleted, and every one keeps its original intent —
+ * reviewer-checklist rule 3: an inverted assertion cites the ruling that
+ * authorises it. What changes is WHERE the answer is read: a rendered
+ * `collapsed` per thread instead of a `defaults` field the client applies.
+ *
+ * The fixture changed too, and the reason is load-bearing. It used to seed
+ * lone messages as "roots" because root-ness did not matter — the payload
+ * keyed off `thread_user_state`, and the message rows existed only to satisfy
+ * the FK. Now the payload is driven by the pod's roots, so a root must be
+ * something a reply actually points at, and the fixture has to build real
+ * threads. A lone message is not a thread and must not render as one.
  */
 const { newDb } = require('pg-mem');
 
@@ -62,50 +81,94 @@ beforeAll(async () => {
 });
 // Roots must be real message rows — thread_user_state has a live FK to
 // messages in the shipped schema, which the old hand-written fixture omitted.
-const seedRoot = async (id) => mockPool.query(
-  'INSERT INTO messages (id, pod_id, user_id, content) VALUES ($1,$2,$3,$4)',
-  [id, POD, 'author', 'root'],
-);
+// A root plus the reply that makes it one. `id + 1000` keeps reply ids clear
+// of the root ids the tests name.
+const seedRoot = async (id, pod = POD) => {
+  await mockPool.query(
+    'INSERT INTO messages (id, pod_id, user_id, content) VALUES ($1,$2,$3,$4)',
+    [id, pod, 'author', 'root'],
+  );
+  await mockPool.query(
+    `INSERT INTO messages (id, pod_id, user_id, content, thread_root_id)
+     VALUES ($1,$2,$3,$4,$5)`,
+    [id + 1000, pod, 'author', 'reply', id],
+  );
+};
 
 beforeAll(async () => {
   await mockPool.query("INSERT INTO pods (id, name, type, created_by) VALUES ($1,'p','chat','u')", [POD]);
   await mockPool.query("INSERT INTO pods (id, name, type, created_by) VALUES ($1,'p2','chat','u')", [OTHER_POD]);
-  for (const id of [10, 11, 20, 21, 22, 30, 31, 32, 40, 41]) await seedRoot(id);
+  for (const id of [10, 11, 20, 21, 22, 31, 32, 40, 41]) await seedRoot(id);
+  // 30 lives in the OTHER pod — the scoping tests need a root that is not ours.
+  await seedRoot(30, OTHER_POD);
+  // 99 is a lone message with no reply: present in `messages`, not a thread.
+  await mockPool.query(
+    "INSERT INTO messages (id, pod_id, user_id, content) VALUES (99,$1,'author','lonely')",
+    [POD],
+  );
 });
 
 beforeEach(async () => { await mockPool.query('DELETE FROM thread_user_state'); });
 
+// A ledger row with a past cutoff: every fixture root is created "now", so
+// this makes them all post-cutoff and therefore collapsed-by-default. Without
+// it the instance reads as cutoffUnknown, which expands everything — correct,
+// and the wrong baseline for testing the collapse default.
+const seedPastCutoff = () => mockPool.query(
+  `INSERT INTO migration_records (name, details)
+   VALUES ('threading-thread-root-id-backfill', '{"threadingCutoff":"2020-01-01T00:00:00Z"}'::jsonb)`,
+);
+
 describe('a thread with no row', () => {
-  test('is ABSENT from the payload — the read never fabricates a row', async () => {
-    // Returning a synthesised row per thread would mean the server enumerating
-    // every root in the pod, and would make "has expressed nothing" and "chose
-    // the default" indistinguishable downstream.
-    const p = await read();
-    expect(p.threads).toEqual([]);
+  const collapsedOf = (p, id) => p.threads.find((t) => t.threadRootId === id)?.collapsed;
+  beforeEach(async () => {
+    await mockPool.query('DELETE FROM migration_records');
+    await seedPastCutoff();
   });
 
-  test('and the payload states the default it should be read with', async () => {
-    // The contract has to be on the wire. If it lives only in a comment, the
-    // client hardcodes it and the two drift silently.
+  test('APPEARS in the payload, resolved — the client never sees absence', async () => {
+    // Inverted from "is ABSENT", per @ux-lead 56996. The old shape made
+    // "expressed nothing" and "chose the default" distinguishable downstream,
+    // and charged every client the threading cutoff for the privilege.
     const p = await read();
-    expect(p.defaults.collapsed).toBe(true);
+    expect(p.threads.map((t) => t.threadRootId).sort((a, b) => a - b))
+      .toEqual([10, 11, 20, 21, 22, 31, 32, 40, 41]);
+    for (const t of p.threads) expect(typeof t.collapsed).toBe('boolean');
+  });
+
+  test('a lone message is not a thread and does not appear', async () => {
+    // Otherwise every message in the pod arrives as a collapsed thread.
+    expect((await read()).threads.map((t) => t.threadRootId)).not.toContain(99);
+  });
+
+  test('and the payload no longer states a collapsed default, because none is needed', async () => {
+    // The contract used to have to be on the wire so the client could apply
+    // it. There is no case left in which the client supplies `collapsed`, so
+    // shipping a default would be shipping a rule nobody runs.
+    const p = await read();
+    expect(p.defaults.collapsed).toBeUndefined();
+    expect(p.defaults.expandedForRootsCreatedBefore).toBeUndefined();
+    expect(p.defaults.cutoffUnknown).toBeUndefined();
+    // `following` still has one, because null is a value the client interprets.
     expect(p.defaults.following).toBeNull();
   });
 
-  test('so absence and an explicit collapsed:true differ in payload, not in meaning', async () => {
-    // Both must render collapsed. This is the pair a client is most likely to
-    // treat differently by accident.
+  test('so absence and an explicit collapsed:true are now identical in payload too', async () => {
+    // Same meaning as before — both render collapsed. The difference is that
+    // the payload no longer exposes which one you are looking at, which is the
+    // point: it was never information a renderer should act on.
     await ThreadUserState.setCollapsed(10, 'u1', POD, true);
     const p = await read();
-    expect(p.threads).toEqual([{ threadRootId: 10, following: null, collapsed: true }]);
-    expect(p.defaults.collapsed).toBe(true);
+    expect(collapsedOf(p, 10)).toBe(true);
+    expect(collapsedOf(p, 11)).toBe(true);
   });
 
-  test('while absence and an explicit collapsed:false differ in BOTH', async () => {
+  test('while absence and an explicit collapsed:false still differ', async () => {
     // The case that makes the row worth storing at all.
     await ThreadUserState.setCollapsed(11, 'u1', POD, false);
     const p = await read();
-    expect(p.threads).toEqual([{ threadRootId: 11, following: null, collapsed: false }]);
+    expect(collapsedOf(p, 11)).toBe(false);
+    expect(collapsedOf(p, 10)).toBe(true);
   });
 });
 
@@ -139,7 +202,10 @@ describe('an agent caller resolves through the real identity chain', () => {
     await listThreadState(
       { agentUser: { _id: 'bot-user-1' }, query: { podId: POD }, params: {} }, res,
     );
-    expect(payload.threads.map((t) => t.threadRootId)).toEqual([40]);
+    // Every root is in the payload now, so identity shows in the VALUES, not
+    // in the row list: only this caller's follow is visible as following=true.
+    const followed = payload.threads.filter((t) => t.following === true).map((t) => t.threadRootId);
+    expect(followed).toEqual([40]);
   });
 
   test('req.user._id wins over req.userId, as the real chain orders them', async () => {
@@ -149,25 +215,37 @@ describe('an agent caller resolves through the real identity chain', () => {
     await listThreadState(
       { user: { _id: 'preferred-id' }, userId: 'ignored-id', query: { podId: POD }, params: {} }, res,
     );
-    expect(payload.threads.map((t) => t.threadRootId)).toEqual([41]);
+    const followed = payload.threads.filter((t) => t.following === true).map((t) => t.threadRootId);
+    expect(followed).toEqual([41]);
   });
 });
 
 describe('the read is scoped', () => {
-  test('another pod\'s rows do not appear', async () => {
-    await ThreadUserState.follow(30, 'u1', OTHER_POD);
-    expect((await read('u1', POD)).threads).toEqual([]);
+  const idsIn = async (u, pod) => (await read(u, pod)).threads.map((t) => t.threadRootId);
+
+  test("another pod's roots do not appear", async () => {
+    // 30 is the OTHER pod's root. Scoping is now by the ROOT's pod, not by the
+    // state row's — the payload is a view of this pod's threads.
+    expect(await idsIn('u1', POD)).not.toContain(30);
+    expect(await idsIn('u1', OTHER_POD)).toEqual([30]);
   });
 
-  test('another user\'s rows do not appear', async () => {
+  test("another user's state does not leak into mine", async () => {
+    // Their row no longer changes WHICH threads I see — every root is mine to
+    // render — so the leak would now be in the VALUE. That is the sharper
+    // test: with their follow present, mine must still read null.
     await ThreadUserState.follow(31, 'someone-else', POD);
-    expect((await read('u1', POD)).threads).toEqual([]);
+    const mine = (await read('u1', POD)).threads.find((t) => t.threadRootId === 31);
+    expect(mine.following).toBeNull();
+    const theirs = (await read('someone-else', POD)).threads.find((t) => t.threadRootId === 31);
+    expect(theirs.following).toBe(true);
   });
 
-  test('CONTROL: the same row DOES appear for its own owner and pod', async () => {
-    // Without this the two tests above pass from a read that returns nothing.
+  test('CONTROL: my own row DOES reach me', async () => {
+    // Without this the test above passes from a read that resolves nothing.
     await ThreadUserState.follow(32, 'u1', POD);
-    expect((await read('u1', POD)).threads.map((t) => t.threadRootId)).toEqual([32]);
+    const mine = (await read('u1', POD)).threads.find((t) => t.threadRootId === 32);
+    expect(mine.following).toBe(true);
   });
 });
 
@@ -176,105 +254,68 @@ describe('unknown resolves to expand, never to collapse', () => {
   // earlier attempts, and both were wrong in the same direction — toward
   // collapsing. Collapsed hides history and the user cannot tell; expanded is
   // noisy and one click fixes it.
+  //
+  // Read through the RENDER now rather than through a `defaults` field, per
+  // @ux-lead 56996. That is a strictly better test of the same rule: it
+  // exercises migration_records -> readThreadingCutoff -> resolved boolean,
+  // where the old one stopped at the intermediate value and trusted the client
+  // to finish the job correctly.
 
-  const readDefaults = async () => (await read()).defaults;
+  const collapsedValues = async () => (await read()).threads.map((t) => t.collapsed);
+
   beforeEach(async () => { await mockPool.query('DELETE FROM migration_records'); });
 
-  test('no ledger row => cutoffUnknown, whatever the history looks like', async () => {
-    // Previously this returned pending:false when no un-rooted edges existed,
-    // which told the client to collapse everything. On an already-backfilled
-    // instance whose row was lost, that hides all history.
+  test('no ledger row => expand everything, whatever the history looks like', async () => {
+    // Previously this collapsed everything when no un-rooted edges existed.
+    // On an already-backfilled instance whose row was lost, that hides all
+    // history — which is the case #1115 exists to prevent.
     await mockPool.query('UPDATE messages SET reply_to_message_id = NULL');
-    const d = await readDefaults();
-    expect(d.cutoffUnknown).toBe(true);
-    expect(d.expandedForRootsCreatedBefore).toBeNull();
+    const vals = await collapsedValues();
+    expect(vals.length).toBeGreaterThan(0);
+    expect(vals.every((c) => c === false)).toBe(true);
   });
 
-  test('and still unknown when un-rooted history exists', async () => {
+  test('and still expanded when un-rooted history exists', async () => {
     await mockPool.query('UPDATE messages SET reply_to_message_id = 10 WHERE id = 11');
-    expect((await readDefaults()).cutoffUnknown).toBe(true);
+    expect((await collapsedValues()).every((c) => c === false)).toBe(true);
   });
 
-  test('a row with a NULL cutoff is KNOWLEDGE, not absence', async () => {
-    // The backfill ran and rooted nothing. That is a migrated instance with no
-    // pre-threading history — collapse is correct here, and it is the one case
-    // where a null cutoff does not mean unknown.
+  test('a row with a NULL cutoff is KNOWLEDGE, not absence — so collapse', async () => {
+    // The backfill ran and rooted nothing. A migrated instance with no
+    // pre-threading history: collapse is correct, and it is the one case where
+    // a null cutoff does not mean unknown.
     await mockPool.query(
       `INSERT INTO migration_records (name, details)
        VALUES ('threading-thread-root-id-backfill', '{"threadingCutoff":null}'::jsonb)`,
     );
-    const d = await readDefaults();
-    expect(d.cutoffUnknown).toBe(false);
-    expect(d.expandedForRootsCreatedBefore).toBeNull();
+    expect((await collapsedValues()).every((c) => c === true)).toBe(true);
   });
 
   test('a row with a cutoff governs, and un-rooted orphans do not override it', async () => {
-    // Orphans stay un-rooted forever by design. The retired probe counted them,
-    // so one dead row would have pinned the instance to expand permanently.
+    // Orphans stay un-rooted forever by design. The retired probe counted
+    // them, so one dead row would have pinned the instance to expand
+    // permanently. Fixture roots are created now, so a past cutoff collapses
+    // them all — and the point is that it decides at all.
     await mockPool.query('UPDATE messages SET reply_to_message_id = 10 WHERE id = 11');
     await mockPool.query(
       `INSERT INTO migration_records (name, details)
-       VALUES ('threading-thread-root-id-backfill', '{"threadingCutoff":"2026-08-22T12:21:11Z"}'::jsonb)`,
+       VALUES ('threading-thread-root-id-backfill', '{"threadingCutoff":"2020-01-01T00:00:00Z"}'::jsonb)`,
     );
-    const d = await readDefaults();
-    expect(d.expandedForRootsCreatedBefore).toBe('2026-08-22T12:21:11Z');
-    expect(d.cutoffUnknown).toBe(false);
+    expect((await collapsedValues()).every((c) => c === true)).toBe(true);
   });
 });
 
-describe.skip('SUPERSEDED by the merged ruling — the pending-probe shape', () => {
-  // Left skipped rather than deleted for one release: these encode the
-  // behaviour the ruling replaced (un-rooted count as the discriminator), and
-  // a reader who finds only the new tests cannot tell that the old shape was
-  // considered and rejected.
-
-  // @sprint-review 56862 asked whether the pre-cutoff comparison resolves
-  // server-side. It does — via one timestamp. Following that through against
-  // the live instance exposed an ambiguity in my own answer: a missing ledger
-  // row meant BOTH "fresh instance, no history" and "backfill has not run",
-  // and those need opposite renders. Collapsing everything is right for the
-  // first and buries existing conversation for the second, which is exactly
-  // what #1115's carve-out prevents.
-
-  const readDefaults = async () => (await read()).defaults;
-
-  beforeEach(async () => { await mockPool.query('DELETE FROM migration_records'); });
-
-  test('no ledger row and NO un-rooted history: not pending, collapse all', async () => {
-    // Fresh instance. Nothing is pre-cutoff, so collapsing everything is right.
-    await mockPool.query('UPDATE messages SET reply_to_message_id = NULL');
-    const d = await readDefaults();
-    expect(d.expandedForRootsCreatedBefore).toBeNull();
-    expect(d.threadingBackfillPending).toBe(false);
-  });
-
-  test('no ledger row WITH un-rooted history: pending, do not collapse history', async () => {
-    // Today's live state: 245 reply edges, empty ledger. The dangerous case.
-    await mockPool.query('UPDATE messages SET reply_to_message_id = 10 WHERE id = 11');
-    const d = await readDefaults();
-    expect(d.expandedForRootsCreatedBefore).toBeNull();
-    expect(d.threadingBackfillPending).toBe(true);
-  });
-
-  test('once the ledger row exists, pending is false and the cutoff is served', async () => {
-    await mockPool.query('UPDATE messages SET reply_to_message_id = 10 WHERE id = 11');
-    await mockPool.query(
-      `INSERT INTO migration_records (name, details)
-       VALUES ('threading-thread-root-id-backfill', '{"threadingCutoff":"2026-08-22T12:21:11Z"}'::jsonb)`,
-    );
-    const d = await readDefaults();
-    expect(d.expandedForRootsCreatedBefore).toBe('2026-08-22T12:21:11Z');
-    expect(d.threadingBackfillPending).toBe(false);
-  });
-
-  test('the cutoff wins even if un-rooted rows remain — a partial run is not pending', async () => {
-    // Orphans legitimately stay NULL forever, so their presence must not make
-    // the ledger look unwritten. The row is the authority once it exists.
-    await mockPool.query('UPDATE messages SET reply_to_message_id = 10 WHERE id = 11');
-    await mockPool.query(
-      `INSERT INTO migration_records (name, details)
-       VALUES ('threading-thread-root-id-backfill', '{"threadingCutoff":"2026-08-22T12:21:11Z"}'::jsonb)`,
-    );
-    expect((await readDefaults()).threadingBackfillPending).toBe(false);
-  });
-});
+// REMOVED: the skipped `threadingBackfillPending` block.
+//
+// It was kept "for one release" so a reader could see that the un-rooted-count
+// discriminator had been considered and rejected. Two contract changes later
+// it asserts on `defaults.expandedForRootsCreatedBefore` and a
+// `threadingBackfillPending` field, neither of which exists — so it no longer
+// documents a rejected alternative to the CURRENT design, it documents a
+// rejected alternative to a design that is itself gone. A skipped test that
+// cannot run against the code is not a record, it is a fossil, and the next
+// reader has to reconstruct two migrations to find that out.
+//
+// The reasoning it carried survives where it is still true: in
+// docs/design/threading-surface-ruling.md, and in the three-state cutoff
+// comments on readThreadingCutoff and effectiveStateForPod.

--- a/backend/__tests__/unit/models/threadUserState.test.js
+++ b/backend/__tests__/unit/models/threadUserState.test.js
@@ -183,34 +183,26 @@ describe('the pre-cutoff expanded default reaches the client', () => {
   // discovered that while wiring the component.
   const CONTROLLER_SRC = read('controllers/threadStateController.ts');
 
-  it('the response carries the cutoff, not just a boolean default', () => {
-    // Matches the KEY, not the local variable feeding it. Pinning the local
-    // broke on a rename of my own making.
-    expect(CONTROLLER_SRC).toMatch(/expandedForRootsCreatedBefore:/);
-  });
+  // REPLACED by execution, per @ux-lead's ruling (56996). Two tests lived
+  // here: "the response carries the cutoff, not just a boolean default" and
+  // "one timestamp, not a per-thread resolution". Both pinned the shape the
+  // ruling overturned — the second by name.
+  //
+  // They are not rewritten in place because they were regex over
+  // CONTROLLER_SRC, which is the pattern @sprint-review blocked on #1106: a
+  // source match cannot tell you what the endpoint returns. The properties
+  // they were reaching for are now asserted by running the thing:
+  //
+  //   threadStateReadContract.test.js  — the payload carries no cutoff, no
+  //                                      collapsed default, and every root
+  //                                      arrives already resolved
+  //   threadEffectiveCollapsed.test.js — the per-thread resolution itself,
+  //                                      across all three cutoff states
+  //
+  // Deleting a test is worth more scrutiny than editing one, so: the
+  // behaviour is covered strictly better than before, and by tests that would
+  // fail if the code were wrong rather than merely reworded.
 
-  it('it is read from the migration ledger, by the shared constant', () => {
-    // Not a hardcoded date, and not a second definition of the name.
-    //
-    // This assertion originally required the name to come from the backfill
-    // SCRIPT. That was the bug: the script calls main() at module scope, so
-    // importing it to read one string executed the migration on the server
-    // boot path. The name now lives in constants/migrations.ts, which has no
-    // imports and no side effects — and this test must assert the script is
-    // NOT imported, or it would pin the defect it used to describe.
-    expect(CONTROLLER_SRC).toMatch(/require\('\.\.\/constants\/migrations'\)/);
-    expect(CONTROLLER_SRC).not.toMatch(/require\('\.\.\/scripts\//);
-    expect(CONTROLLER_SRC).toMatch(/FROM migration_records WHERE name = \$1/);
-    expect(CONTROLLER_SRC).not.toMatch(/threadingCutoff = '20\d\d-/);
-  });
-
-  it('one timestamp, not a per-thread resolution', () => {
-    // Resolving server-side would enumerate every root and join
-    // messages.created_at — data the client already has, since it is
-    // rendering those messages.
-    expect(CONTROLLER_SRC).not.toMatch(/JOIN messages[\s\S]{0,80}created_at[\s\S]{0,80}thread_user_state/);
-    expect(CONTROLLER_SRC).toMatch(/Promise\.all\(\[/);
-  });
 
   it('a read failure degrades toward EXPAND, not toward collapse', () => {
     // Not just "does not throw": the direction matters. Collapsed hides

--- a/backend/controllers/threadStateController.ts
+++ b/backend/controllers/threadStateController.ts
@@ -150,10 +150,21 @@ export async function unfollowThread(req: Req, res: Res): Promise<void> {
 
 /**
  * The render path's question: my state for every thread in this pod, in one
- * query. Only rows that EXIST are returned — a thread the caller has never
- * touched is absent and the client applies the defaults (collapsed, and
- * following resolved from participation). Sending a row per thread would mean
- * materialising state nobody has expressed.
+ * query, with `collapsed` ALREADY RESOLVED — @ux-lead's ruling (56996).
+ *
+ * The client never sees absence and never learns the threading cutoff. Both
+ * used to be its job: notice that a root has no row, then compare that root's
+ * createdAt against a migration timestamp it had to be told. That is a
+ * migration detail in every client's model of the system, permanently, for one
+ * boolean. The row is storage; the payload is meaning.
+ *
+ * `following` is deliberately NOT resolved the same way. Its absence is a
+ * VALUE — `null` means "defer to participation", which the wake path computes
+ * against live authorship (threadWakeScopeService). Collapsing it to a boolean
+ * here would either lie or force this endpoint to recompute participation on
+ * the read path. Flagged to @ux-lead, whose 56996 assumed following was
+ * already effective; it is not, and the asymmetry is intentional rather than
+ * an oversight to be tidied.
  */
 export async function listThreadState(req: Req, res: Res): Promise<void> {
   try {
@@ -171,46 +182,17 @@ export async function listThreadState(req: Req, res: Res): Promise<void> {
       res.status(403).json({ msg: 'not a member of this pod' });
       return;
     }
-    const [rows, threadingCutoff] = await Promise.all([
-      ThreadUserState.stateForPod(userId, podId),
-      readThreadingCutoff(),
-    ]);
-    const { cutoff, cutoffUnknown } = threadingCutoff;
+    const { cutoff, cutoffUnknown } = await readThreadingCutoff();
+    const threads = await ThreadUserState.effectiveStateForPod(userId, podId, cutoff, cutoffUnknown);
     res.status(200).json({
       podId,
-      // Defaults are stated in the response so a client never has to hardcode
-      // them, and so a change to them is visible at the wire rather than only
-      // in two codebases that have to agree.
-      //
-      // `expandedForRootsCreatedBefore` is the #1115 carve-out: a thread whose
-      // root pre-dates the threading migration renders expanded, so nothing
-      // visible in history disappears under a headline card on ship day.
-      //
-      // Returned as ONE timestamp rather than resolved per thread. Resolving
-      // server-side would mean enumerating every root in the pod and joining
-      // messages.created_at — duplicating data the client already has, since
-      // it is rendering those messages. This is O(1) and the comparison is a
-      // date compare. @sprint-review (56862) was right that the shipped
-      // contract could not express the rule; this is the smallest thing that
-      // can.
-      //
-      // Three states, and the third is the one that matters:
-      //   cutoff set                    -> roots at or before it render expanded
-      //   cutoff null, unknown false    -> the backfill ran and rooted nothing;
-      //                                    there is no pre-cutoff history
-      //   cutoffUnknown true            -> no ledger row. EXPAND EVERYTHING;
-      //                                    never collapse on an unknown.
+      // `following: null` is still a value the client must interpret, so its
+      // default stays stated at the wire. `collapsed` no longer appears here
+      // because there is no case left in which the client supplies it.
       defaults: {
-        collapsed: true,
         following: null,
-        expandedForRootsCreatedBefore: cutoff,
-        cutoffUnknown,
       },
-      threads: rows.map((r: any) => ({
-        threadRootId: Number(r.thread_root_id),
-        following: r.following === null ? null : Boolean(r.following),
-        collapsed: Boolean(r.collapsed),
-      })),
+      threads,
     });
   } catch (err: any) {
     res.status(500).json({ msg: 'failed to list thread state', error: err?.message });

--- a/backend/controllers/threadStateController.ts
+++ b/backend/controllers/threadStateController.ts
@@ -183,7 +183,7 @@ export async function listThreadState(req: Req, res: Res): Promise<void> {
       return;
     }
     const { cutoff, cutoffUnknown } = await readThreadingCutoff();
-    const threads = await ThreadUserState.effectiveStateForPod(userId, podId, cutoff, cutoffUnknown);
+    const rows = await ThreadUserState.effectiveStateForPod(userId, podId, cutoff, cutoffUnknown);
     res.status(200).json({
       podId,
       // `following: null` is still a value the client must interpret, so its
@@ -192,7 +192,17 @@ export async function listThreadState(req: Req, res: Res): Promise<void> {
       defaults: {
         following: null,
       },
-      threads,
+      // Mapped, not passed through. The model speaks the table's language
+      // (`thread_root_id`); the wire has said `threadRootId` since 2/4 shipped
+      // and no ruling changed that. Handing the rows straight out silently
+      // renamed a public field — caught by threadStateReadContract, which is
+      // the reason that suite reads through the controller rather than the
+      // model.
+      threads: rows.map((r: { thread_root_id: number; following: boolean | null; collapsed: boolean }) => ({
+        threadRootId: r.thread_root_id,
+        following: r.following,
+        collapsed: r.collapsed,
+      })),
     });
   } catch (err: any) {
     res.status(500).json({ msg: 'failed to list thread state', error: err?.message });

--- a/backend/models/pg/ThreadUserState.ts
+++ b/backend/models/pg/ThreadUserState.ts
@@ -173,9 +173,77 @@ class ThreadUserState {
   }
 
   /**
-   * Everything the render path needs for one pod in one query. Returns only
-   * rows that exist — a thread the user has never touched is absent, and the
-   * caller applies the defaults (collapsed true, following from participation).
+   * Everything the render path needs for one pod, with `collapsed` ALREADY
+   * RESOLVED for every root in the pod — @ux-lead's ruling (56996).
+   *
+   * The sparse version below returns only rows that exist, which pushes two
+   * jobs onto the client: notice absence, and know the threading cutoff to
+   * interpret it (`collapsed = row?.collapsed ?? (root.createdAt >= cutoff)`).
+   * That makes the cutoff part of every client's model of the system for the
+   * sake of one boolean. The row is storage; the payload is meaning.
+   *
+   * So this enumerates the pod's roots and left-joins the caller's state. A
+   * root is a message something else points at, which is exactly when a thread
+   * starts existing. Written as an uncorrelated `IN (SELECT DISTINCT …)`
+   * rather than a correlated `EXISTS`: pg-mem cannot resolve the outer alias
+   * inside a correlated subquery here ("column root.id does not exist"), and
+   * the uncorrelated form is equivalent, runs on both, and keeps this query
+   * exercisable at the unit tier instead of only against a real server.
+   *
+   * The three-state cutoff is resolved here rather than at the wire, and the
+   * ORDER of the CASE arms is the whole #1115 ruling:
+   *   cutoffUnknown          -> false. Never collapse on an unknown.
+   *   cutoff NULL, known     -> true. The backfill ran and rooted nothing, so
+   *                             there is no pre-cutoff history to protect.
+   *   otherwise              -> created_at >= cutoff.
+   *
+   * Cost, since a comment on the old shape argued against paying it: this is
+   * one extra join bounded by the pod's THREAD count, not its message count,
+   * and the caller is already rendering those messages. The argument that it
+   * "duplicates data the client already has" was mine and it was the wrong
+   * trade — it bought an O(1) payload by making every future client carry a
+   * migration detail.
+   */
+  static async effectiveStateForPod(
+    userId: string,
+    podId: string,
+    cutoff: Date | string | null,
+    cutoffUnknown: boolean,
+  ): Promise<Array<{ thread_root_id: number; following: boolean | null; collapsed: boolean }>> {
+    const { rows } = await (pool as PgPool).query(
+      `SELECT root.id AS thread_root_id,
+              s.following AS following,
+              COALESCE(
+                s.collapsed,
+                CASE WHEN $4::boolean THEN false
+                     WHEN $3::timestamptz IS NULL THEN true
+                     ELSE root.created_at >= $3::timestamptz
+                END
+              ) AS collapsed
+         FROM messages root
+         LEFT JOIN thread_user_state s
+           ON s.thread_root_id = root.id AND s.user_id = $1
+        WHERE root.pod_id = $2
+          AND root.id IN (
+                SELECT DISTINCT child.thread_root_id
+                  FROM messages child
+                 WHERE child.pod_id = $2 AND child.thread_root_id IS NOT NULL
+              )
+        ORDER BY root.id`,
+      [userId, podId, cutoff, cutoffUnknown],
+    );
+    return rows.map((r: any) => ({
+      thread_root_id: Number(r.thread_root_id),
+      following: r.following === null || r.following === undefined ? null : Boolean(r.following),
+      collapsed: Boolean(r.collapsed),
+    }));
+  }
+
+  /**
+   * The sparse read: only rows that exist. Retained because the wake path and
+   * the state-setters reason about the ROW, where absence is meaningful —
+   * `following IS NULL` is "defer to participation", which is not a value the
+   * effective read can express. Do not use it for the render payload.
    */
   static async stateForPod(userId: string, podId: string): Promise<ThreadUserStateRow[]> {
     const { rows } = await (pool as PgPool).query(


### PR DESCRIPTION
@ux-lead's ruling (56996), implemented before 4/4 bakes the old contract in. No frontend consumes this endpoint yet, so this is the window they named.

### What changes

The shipped shape returns only rows that **exist**, plus a single `expandedForRootsCreatedBefore` timestamp — which pushes two jobs onto the client: notice absence, then know the threading cutoff to interpret it.

```js
collapsed = row?.collapsed ?? (root.createdAt >= cutoff)   // every client, forever
```

`effectiveStateForPod` enumerates the pod's roots, left-joins the caller's state, and resolves `collapsed` in SQL. The client never sees absence and is never told the cutoff. **The row is storage; the payload is meaning.**

The CASE arm order *is* the #1115 ruling: `cutoffUnknown` → false (never collapse on an unknown), cutoff NULL and known → true (the backfill ran and rooted nothing), otherwise `created_at >= cutoff`.

### The argument I'm reversing was mine

The old comment argued against exactly this, on the grounds that resolving per-thread "duplicates data the client already has, since it is rendering those messages." That was the wrong trade — it bought an O(1) payload by making every future client carry a migration detail. The join is bounded by the pod's **thread** count, not its message count.

### One thing I did NOT do

`following` is deliberately not given the same treatment. Its absence is a **value**: `null` means defer-to-participation, which the wake path computes against live authorship. Flattening it here would either lie or force this endpoint to recompute participation on the read path.

56996 assumed `following` was already effective. It isn't. Flagged rather than tidied, since @ux-lead gates the shape — say the word if you want it resolved too and I'll do it as a follow-up.

### Tests

13 executing cases against pg-mem, including the three cutoff states, explicit-overrides-default in both directions, and cross-user isolation.

Mutation probe with expectations derived **before** running, per @sprint-review (56999):

| mutation | expected | actual |
|---|---|---|
| CASE arms swapped | 3 | **1** |
| COALESCE dropped | 4 | 4 |
| join loses `AND s.user_id = $1` | 1+ | 1 |
| `>=` inverted to `<` | 1 | **2** |

Both mismatches taught more than the matches, and both are recorded in the suite header. **Fewer (3→1):** my expectation was wrong — swapping the arms only changes an answer when the cutoff is NULL, so the test named for that rule can't discriminate it and a different one does. **More (1→2):** the leak test's control half asserts a default, so a default-flipping mutation reaches it.

Written as an uncorrelated `IN (SELECT DISTINCT …)` rather than a correlated `EXISTS` — pg-mem can't resolve the outer alias in the correlated form, and the uncorrelated one is equivalent, runs on both, and keeps the production query exercisable at the unit tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)