### PR TITLE
fix(threading): the backfill records the first rooted reply as the cutoff, not the newest un-rooted one (TASK-046)

### DIFF
--- a/backend/__tests__/unit/models/threadingCutoffRecord.test.js
+++ b/backend/__tests__/unit/models/threadingCutoffRecord.test.js
@@ -78,6 +78,18 @@ describe('the cutoff is measured before it becomes unmeasurable', () => {
     expect(SCRIPT).toMatch(/threadingCutoff: boundary\.cutoff/);
   });
 
+  it('a run that finds the ledger row reports it and never re-measures', () => {
+    // sprint-review 57397: after the backfill, MIN over rooted replies is the
+    // oldest reply ever written — plausible and wrong. The ledger read comes
+    // before the population count and returns before CUTOFF_SQL runs.
+    const ledgerRead = SCRIPT.indexOf("FROM migration_records WHERE name = $1");
+    const populationRead = SCRIPT.indexOf('count(*)::int AS needs_root');
+    expect(ledgerRead).toBeGreaterThan(-1);
+    expect(ledgerRead).toBeLessThan(populationRead);
+    expect(SCRIPT).toMatch(/already recorded at \$\{ledger\.applied_at\}/);
+    expect(SCRIPT).toMatch(/the boundary is not re-measured/);
+  });
+
   it('the UPDATE and the ledger INSERT are one transaction', () => {
     // sprint-review (TASK-046 note): losing the INSERT after the UPDATE leaves
     // every chain rooted and no cutoff recorded. BEGIN precedes the UPDATE,

--- a/backend/__tests__/unit/models/threadingCutoffRecord.test.js
+++ b/backend/__tests__/unit/models/threadingCutoffRecord.test.js
@@ -58,6 +58,10 @@ describe('the cutoff is measured before it becomes unmeasurable', () => {
     // Without a rooted reply there is no evidence derivation is deployed, and
     // DO NOTHING would freeze a growing population's boundary.
     expect(SCRIPT).toMatch(/MAX\(created_at\) AS newest_unrooted/);
+    // The dry run shows WHY the fallback fired (sprint-review 57398): the
+    // primary's row count, not only the chosen value.
+    expect(SCRIPT).toMatch(/count\(\*\)::int AS rooted_replies/);
+    expect(SCRIPT).toMatch(/rooted replies \(derivation-written\): \$\{boundary\.rooted_replies\}/);
     expect(SCRIPT).toMatch(/if \(!boundary\.from_rooted && !ASSUME_DERIVATION_LIVE\)/);
     expect(SCRIPT).toMatch(/REFUSING to record a fallback cutoff/);
     expect(SCRIPT).toMatch(/cutoffSource: boundary\.from_rooted \? 'first-rooted-reply' : 'newest-unrooted-fallback'/);

--- a/backend/__tests__/unit/models/threadingCutoffRecord.test.js
+++ b/backend/__tests__/unit/models/threadingCutoffRecord.test.js
@@ -78,6 +78,22 @@ describe('the cutoff is measured before it becomes unmeasurable', () => {
     expect(SCRIPT).toMatch(/threadingCutoff: boundary\.cutoff/);
   });
 
+  it('the UPDATE and the ledger INSERT are one transaction', () => {
+    // sprint-review (TASK-046 note): losing the INSERT after the UPDATE leaves
+    // every chain rooted and no cutoff recorded. BEGIN precedes the UPDATE,
+    // COMMIT follows the INSERT, and the catch rolls back.
+    const begin = SCRIPT.indexOf("await client.query('BEGIN')");
+    const update = SCRIPT.indexOf('UPDATE messages m');
+    const insert = SCRIPT.lastIndexOf('INSERT INTO migration_records (name, details)');
+    const commit = SCRIPT.indexOf("await client.query('COMMIT')");
+    expect(begin).toBeGreaterThan(-1);
+    expect(begin).toBeLessThan(update);
+    expect(update).toBeLessThan(insert);
+    expect(insert).toBeLessThan(commit);
+    expect(SCRIPT).toMatch(/await client\.query\('ROLLBACK'\)/);
+    expect(SCRIPT).toMatch(/client\.release\(\)/);
+  });
+
   it('a second run does NOT move the boundary', () => {
     // DO NOTHING, not DO UPDATE. By the second run the population the first
     // one measured no longer exists, so re-deriving would overwrite a true

--- a/backend/__tests__/unit/models/threadingCutoffRecord.test.js
+++ b/backend/__tests__/unit/models/threadingCutoffRecord.test.js
@@ -45,14 +45,29 @@ describe('the ledger is general, not threading-shaped', () => {
 });
 
 describe('the cutoff is measured before it becomes unmeasurable', () => {
-  it('is defined as the newest row with a reply edge and no root', () => {
-    // That predicate IS "written before derivation-on-write shipped" — exact,
-    // not a deploy timestamp guessed after the fact.
-    expect(SCRIPT).toMatch(/SELECT MAX\(created_at\) AS cutoff[\s\S]{0,120}reply_to_message_id IS NOT NULL AND thread_root_id IS NULL/);
+  it('is defined as the FIRST reply that carries a root, not the newest un-rooted one', () => {
+    // TASK-046: MAX over un-rooted rows is poisoned by retention orphans (a
+    // descendant of a deleted root keeps a live parent and loses its root), and
+    // a hardcoded deploy instant is wrong on every self-hosted instance. The
+    // first rooted reply is exact per instance and orphan-immune.
+    expect(SCRIPT).toMatch(/MIN\(created_at\) AS first_rooted[\s\S]{0,120}reply_to_message_id IS NOT NULL AND thread_root_id IS NOT NULL/);
+    expect(SCRIPT).not.toMatch(/SELECT MAX\(created_at\) AS cutoff/);
+  });
+
+  it('falls back to the newest un-rooted reply ONLY behind --derivation-live', () => {
+    // Without a rooted reply there is no evidence derivation is deployed, and
+    // DO NOTHING would freeze a growing population's boundary.
+    expect(SCRIPT).toMatch(/MAX\(created_at\) AS newest_unrooted/);
+    expect(SCRIPT).toMatch(/if \(!boundary\.from_rooted && !ASSUME_DERIVATION_LIVE\)/);
+    expect(SCRIPT).toMatch(/REFUSING to record a fallback cutoff/);
+    expect(SCRIPT).toMatch(/cutoffSource: boundary\.from_rooted \? 'first-rooted-reply' : 'newest-unrooted-fallback'/);
   });
 
   it('is read BEFORE the UPDATE, because the UPDATE destroys the predicate', () => {
-    const cutoffRead = SCRIPT.indexOf('const { rows: [boundary] } = await pool.query(CUTOFF_SQL);\n\n    const result');
+    // The apply-path read is the LAST occurrence (the dry run reads it too);
+    // the fallback guard now sits between the read and the UPDATE, which is
+    // why this no longer pins the two as adjacent lines.
+    const cutoffRead = SCRIPT.lastIndexOf('const { rows: [boundary] } = await pool.query(CUTOFF_SQL);');
     const update = SCRIPT.indexOf('UPDATE messages m');
     expect(cutoffRead).toBeGreaterThan(-1);
     expect(cutoffRead).toBeLessThan(update);
@@ -77,10 +92,12 @@ describe('the cutoff is measured before it becomes unmeasurable', () => {
     expect(dry).toMatch(/CUTOFF_SQL/);
   });
 
-  it('NULL is documented as "no pre-cutoff roots", not "unknown"', () => {
-    // The dangerous misreading: a fresh instance has no pre-threading history,
-    // and treating NULL as unknown would expand every thread on it.
-    expect(SCRIPT).toMatch(/never as "unknown, assume everything is pre-cutoff"/);
+  it('a MISSING row is unknown (expand); a NULL cutoff in a written row is knowledge', () => {
+    // The sentence this test used to pin said the opposite — "never as
+    // unknown" — and the ruling (docs/design/threading-surface-ruling.md)
+    // rejected it: collapsed hides history, so unknown must never resolve there.
+    expect(SCRIPT).not.toMatch(/never as "unknown, assume everything is pre-cutoff"/);
+    expect(SCRIPT).toMatch(/A MISSING ledger row means "cutoff unknown"/);
   });
 });
 

--- a/backend/scripts/backfill-thread-root-id.ts
+++ b/backend/scripts/backfill-thread-root-id.ts
@@ -126,8 +126,11 @@ export const MIGRATION_NAME = THREADING_BACKFILL_MIGRATION;
  * rooted reply there is no evidence derivation is deployed and the fallback
  * would freeze a growing population's boundary under ON CONFLICT DO NOTHING.
  *
- * Read BEFORE the UPDATE so the fallback, which depends on the un-rooted
- * predicate, is still measurable. A MISSING ledger row means "cutoff unknown"
+ * Read BEFORE the UPDATE — and only when no ledger row exists. After the
+ * UPDATE every pre-threading reply also carries a root, so this MIN would
+ * return the oldest reply ever written: a plausible wrong answer, which is
+ * worse than the old query's useless one. The ledger row is the only true
+ * boundary once it exists; a later run reports it and never re-measures. A MISSING ledger row means "cutoff unknown"
  * and the surface expands everything; a row with a NULL cutoff (the zero-edges
  * branch) means "ran, and there was no pre-threading history".
  */
@@ -189,6 +192,22 @@ async function main(): Promise<void> {
   });
 
   try {
+    // LEDGER FIRST (sprint-review 57397). After a backfill every pre-threading
+    // reply has BOTH fields set, so re-measuring the boundary returns the
+    // oldest reply ever written — a plausible wrong answer, not a useless one.
+    // The recorded value is the only true one; a second run reports it and
+    // stops, and never prints a recomputed number an operator could act on.
+    const { rows: [ledger] } = await pool.query(
+      `SELECT details->>'threadingCutoff' AS cutoff, applied_at
+         FROM migration_records WHERE name = $1`,
+      [MIGRATION_NAME],
+    );
+    if (ledger) {
+      console.log(`${MIGRATION_NAME} already recorded at ${ledger.applied_at}: `
+        + `cutoff = ${ledger.cutoff ?? '(none)'}. Nothing to do — the boundary is not re-measured.`);
+      return;
+    }
+
     const { rows: [before] } = await pool.query(
       `SELECT count(*)::int AS needs_root
          FROM messages

--- a/backend/scripts/backfill-thread-root-id.ts
+++ b/backend/scripts/backfill-thread-root-id.ts
@@ -108,19 +108,28 @@ const { THREADING_BACKFILL_MIGRATION } = require('../constants/migrations');
 export const MIGRATION_NAME = THREADING_BACKFILL_MIGRATION;
 
 /**
- * The threading cutoff: the newest message that carries a reply edge and no
- * root. "Has a reply edge and no root" IS the definition of "written before
- * derivation-on-write shipped", so this boundary is exact rather than
- * approximate — not a deploy timestamp guessed after the fact.
+ * The threading cutoff: the FIRST reply that derivation-on-write ever wrote —
+ * the oldest message that carries a reply edge AND a root. Every such row was
+ * written by the deployed backend, so this boundary is exact to within one
+ * reply, per instance, and it is immune to retention orphans (a descendant of
+ * a deleted root loses its root and cannot move a MIN over rooted rows).
  *
- * Read BEFORE the UPDATE. The UPDATE eliminates the predicate, so afterwards
- * there is nothing left to measure. A hardcoded date would be wrong on every
- * instance that migrates on a different day, and self-hosting is in scope.
+ * It is NOT the newest un-rooted reply. That older definition (TASK-046) was
+ * poisoned by retention: delete a root and its descendants lose thread_root_id
+ * while keeping a live parent, so a recent orphan set the boundary days late.
+ * And it is NOT a hardcoded deploy instant: that is wrong on every
+ * self-hosted instance that ships derivation on a different day. The
+ * deploy instant is the cross-check for one instance, never the source.
  *
- * NULL when there is nothing to backfill — a fresh instance has no
- * pre-threading history, so no root is pre-cutoff and the surface rule is
- * simply inert. Consumers must treat NULL as "no pre-cutoff roots exist",
- * never as "unknown, assume everything is pre-cutoff".
+ * Only when no rooted reply exists yet does the script fall back to the newest
+ * un-rooted reply — and only behind --derivation-live, because without a
+ * rooted reply there is no evidence derivation is deployed and the fallback
+ * would freeze a growing population's boundary under ON CONFLICT DO NOTHING.
+ *
+ * Read BEFORE the UPDATE so the fallback, which depends on the un-rooted
+ * predicate, is still measurable. A MISSING ledger row means "cutoff unknown"
+ * and the surface expands everything; a row with a NULL cutoff (the zero-edges
+ * branch) means "ran, and there was no pre-threading history".
  */
 /**
  * POSITIVE evidence that derivation-on-write is live: any message that has a
@@ -139,9 +148,14 @@ export const DERIVATION_LIVE_SQL = `
    LIMIT 1`;
 
 export const CUTOFF_SQL = `
-  SELECT MAX(created_at) AS cutoff
-    FROM messages
-   WHERE reply_to_message_id IS NOT NULL AND thread_root_id IS NULL`;
+  SELECT COALESCE(rooted.first_rooted, unrooted.newest_unrooted) AS cutoff,
+         rooted.first_rooted IS NOT NULL AS from_rooted
+    FROM (SELECT MIN(created_at) AS first_rooted
+            FROM messages
+           WHERE reply_to_message_id IS NOT NULL AND thread_root_id IS NOT NULL) rooted,
+         (SELECT MAX(created_at) AS newest_unrooted
+            FROM messages
+           WHERE reply_to_message_id IS NOT NULL AND thread_root_id IS NULL) unrooted`;
 
 async function main(): Promise<void> {
   if (!process.env.PG_HOST) {
@@ -266,7 +280,12 @@ async function main(): Promise<void> {
         );
       }
       const { rows: [boundary] } = await pool.query(CUTOFF_SQL);
-      console.log(`would record cutoff = ${boundary.cutoff ?? '(none)'} (newest pre-threading reply)`);
+      console.log(`would record cutoff = ${boundary.cutoff ?? '(none)'} `
+        + `(${boundary.from_rooted ? 'first derivation-written reply' : 'newest un-rooted reply — FALLBACK, needs --derivation-live'})`);
+      if (!boundary.from_rooted && !ASSUME_DERIVATION_LIVE) {
+        console.error('--apply would REFUSE: no message has both a reply edge and a root, so the boundary '
+          + 'cannot be measured from derivation. Deploy derivation-on-write first, or pass --derivation-live.');
+      }
       console.log('DRY RUN — nothing written. Re-run with --apply.');
       return;
     }
@@ -276,6 +295,19 @@ async function main(): Promise<void> {
     // shipped" — every row written after carries a root. The UPDATE destroys
     // that predicate, so afterwards the boundary is unrecoverable.
     const { rows: [boundary] } = await pool.query(CUTOFF_SQL);
+
+    if (!boundary.from_rooted && !ASSUME_DERIVATION_LIVE) {
+      // No rooted reply means no evidence derivation is deployed. The fallback
+      // boundary (newest un-rooted reply) is only right if the population has
+      // stopped growing, and DO NOTHING makes a wrong answer permanent.
+      console.error(
+        'REFUSING to record a fallback cutoff: no message has both a reply edge '
+        + 'and a root, so derivation-on-write is not observed. Deploy it first, '
+        + 'or re-run with --derivation-live to record the newest un-rooted reply.',
+      );
+      process.exitCode = 3;
+      return;
+    }
 
     const result = await pool.query(
       `WITH RECURSIVE chain AS (
@@ -311,6 +343,7 @@ async function main(): Promise<void> {
         MIGRATION_NAME,
         JSON.stringify({
           threadingCutoff: boundary.cutoff,
+          cutoffSource: boundary.from_rooted ? 'first-rooted-reply' : 'newest-unrooted-fallback',
           rowsUpdated: result.rowCount,
           rowsEligible: before.needs_root,
         }),

--- a/backend/scripts/backfill-thread-root-id.ts
+++ b/backend/scripts/backfill-thread-root-id.ts
@@ -309,47 +309,62 @@ async function main(): Promise<void> {
       return;
     }
 
-    const result = await pool.query(
-      `WITH RECURSIVE chain AS (
-         SELECT id, reply_to_message_id, id AS root
-           FROM messages WHERE reply_to_message_id IS NULL
-         UNION ALL
-         SELECT m.id, m.reply_to_message_id, c.root
-           FROM messages m JOIN chain c ON m.reply_to_message_id = c.id
-       )
-       UPDATE messages m
-          SET thread_root_id = chain.root
-         FROM chain
-        WHERE m.id = chain.id
-          AND m.reply_to_message_id IS NOT NULL
-          AND m.thread_root_id IS NULL
-          AND chain.root <> m.id`,
-    );
-    console.log(`APPLIED — ${result.rowCount} of ${before.needs_root} rows updated.`);
+    // ONE TRANSACTION for the UPDATE and the ledger INSERT (sprint-review,
+    // TASK-046 note). Losing the INSERT after the UPDATE would leave every
+    // chain rooted and no cutoff recorded — and 'the backfill always writes
+    // the ledger row' is the only remaining guarantee between a partial run
+    // and a permanently unknown cutoff. Aspiration becomes property here.
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await client.query(
+        `WITH RECURSIVE chain AS (
+           SELECT id, reply_to_message_id, id AS root
+             FROM messages WHERE reply_to_message_id IS NULL
+           UNION ALL
+           SELECT m.id, m.reply_to_message_id, c.root
+             FROM messages m JOIN chain c ON m.reply_to_message_id = c.id
+         )
+         UPDATE messages m
+            SET thread_root_id = chain.root
+           FROM chain
+          WHERE m.id = chain.id
+            AND m.reply_to_message_id IS NOT NULL
+            AND m.thread_root_id IS NULL
+            AND chain.root <> m.id`,
+      );
+      console.log(`APPLIED — ${result.rowCount} of ${before.needs_root} rows updated.`);
 
-    // The ruling in #1115 says pre-cutoff roots render expanded, with the
-    // cutoff "read from the migration record". This script is the only process
-    // that ever knows it, and until now it discarded it (@sprint-review 56860).
-    //
-    // ON CONFLICT DO NOTHING, not DO UPDATE: a second run must not move a
-    // boundary the surface has already been rendering against. The script stays
-    // idempotent; the FIRST run's answer is the true one, because by the second
-    // run the population it measured no longer exists.
-    await pool.query(
-      `INSERT INTO migration_records (name, details)
-       VALUES ($1, $2::jsonb)
-       ON CONFLICT (name) DO NOTHING`,
-      [
-        MIGRATION_NAME,
-        JSON.stringify({
-          threadingCutoff: boundary.cutoff,
-          cutoffSource: boundary.from_rooted ? 'first-rooted-reply' : 'newest-unrooted-fallback',
-          rowsUpdated: result.rowCount,
-          rowsEligible: before.needs_root,
-        }),
-      ],
-    );
-    console.log(`recorded ${MIGRATION_NAME}: cutoff = ${boundary.cutoff ?? '(none)'}`);
+      // The ruling in #1115 says pre-cutoff roots render expanded, with the
+      // cutoff "read from the migration record". This script is the only process
+      // that ever knows it, and until now it discarded it (@sprint-review 56860).
+      //
+      // ON CONFLICT DO NOTHING, not DO UPDATE: a second run must not move a
+      // boundary the surface has already been rendering against. The script stays
+      // idempotent; the FIRST run's answer is the true one, because by the second
+      // run the population it measured no longer exists.
+      await client.query(
+        `INSERT INTO migration_records (name, details)
+         VALUES ($1, $2::jsonb)
+         ON CONFLICT (name) DO NOTHING`,
+        [
+          MIGRATION_NAME,
+          JSON.stringify({
+            threadingCutoff: boundary.cutoff,
+            cutoffSource: boundary.from_rooted ? 'first-rooted-reply' : 'newest-unrooted-fallback',
+            rowsUpdated: result.rowCount,
+            rowsEligible: before.needs_root,
+          }),
+        ],
+      );
+      console.log(`recorded ${MIGRATION_NAME}: cutoff = ${boundary.cutoff ?? '(none)'}`);
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
 
     const { rows: [after] } = await pool.query(
       `SELECT count(*)::int AS still_null

--- a/backend/scripts/backfill-thread-root-id.ts
+++ b/backend/scripts/backfill-thread-root-id.ts
@@ -152,8 +152,9 @@ export const DERIVATION_LIVE_SQL = `
 
 export const CUTOFF_SQL = `
   SELECT COALESCE(rooted.first_rooted, unrooted.newest_unrooted) AS cutoff,
-         rooted.first_rooted IS NOT NULL AS from_rooted
-    FROM (SELECT MIN(created_at) AS first_rooted
+         rooted.first_rooted IS NOT NULL AS from_rooted,
+         rooted.rooted_replies
+    FROM (SELECT MIN(created_at) AS first_rooted, count(*)::int AS rooted_replies
             FROM messages
            WHERE reply_to_message_id IS NOT NULL AND thread_root_id IS NOT NULL) rooted,
          (SELECT MAX(created_at) AS newest_unrooted
@@ -299,6 +300,7 @@ async function main(): Promise<void> {
         );
       }
       const { rows: [boundary] } = await pool.query(CUTOFF_SQL);
+      console.log(`rooted replies (derivation-written): ${boundary.rooted_replies}`);
       console.log(`would record cutoff = ${boundary.cutoff ?? '(none)'} `
         + `(${boundary.from_rooted ? 'first derivation-written reply' : 'newest un-rooted reply — FALLBACK, needs --derivation-live'})`);
       if (!boundary.from_rooted && !ASSUME_DERIVATION_LIVE) {


### PR DESCRIPTION
TASK-046 (pod 57374 → 57395). The 22:28Z dry run on the live pod recorded `cutoff 2026-08-22T12:21:11Z` — `MAX(created_at)` over un-rooted edges. Two things wrong with that source, and one with the obvious replacement:

- **un-rooted MAX is poisoned by retention orphans** (sprint-review 57205): delete a root and its descendants keep a live parent but lose `thread_root_id`; a recent orphan sets the boundary days late.
- **a hardcoded deploy instant is wrong for self-hosted instances** — the script's own header said so before the ruling caught up.

**Boundary that survives both:** `MIN(created_at)` over messages with a reply edge AND a root — the first reply derivation-on-write ever wrote. Exact to within one reply, per instance, orphan-immune. The un-rooted `MAX` remains only as a fallback when no rooted reply exists, and only behind `--derivation-live`; otherwise `--apply` refuses (exit 3), because without a rooted reply there is no evidence derivation is deployed and `ON CONFLICT DO NOTHING` would make a wrong boundary permanent. The ledger row records `cutoffSource`.

Also removes the header sentence the ruling rejected ("never as unknown"): a MISSING row is unknown and expands; a NULL cutoff in a written row is knowledge.

**Proof:** `threadingCutoffRecord`, `migrationScriptIsInert`, `unguardedScriptImporters` — 36/36 after flipping the pins to the new contract; `tsc:check` clean. (`eslint` parse errors on `.ts` scripts are pre-existing — CI lints `--ext .js`.)

**Operational:** dry-run again on the live pod before Sam's `--apply`; expect 245 rows / 172 threads and a cutoff just after `2026-08-22T16:01:52Z` (first derivation-written reply), not 12:21:11Z. Ruling text: `docs/design/threading-surface-ruling.md` (#1147).

🤖 Generated with [Claude Code](https://claude.com/claude-code)