### PR TITLE
feat(threading): the collapsed render — headline card, rail, one composer (TASK-029 4/4)

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -335,7 +335,11 @@
       "uploadFailed": "Failed to upload file. Please try again."
     },
     "loadOlder": "Load older messages",
-    "loadingOlder": "Loading…"
+    "loadingOlder": "Loading…",
+    "thread": {
+      "replyInThread": "Reply in thread",
+      "replyingInThread": "Replying in thread ·"
+    }
   },
   "landing": {
     "nav": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -335,7 +335,11 @@
       "uploadFailed": "文件上传失败，请重试。"
     },
     "loadOlder": "加载更早的消息",
-    "loadingOlder": "加载中…"
+    "loadingOlder": "加载中…",
+    "thread": {
+      "replyInThread": "在话题中回复",
+      "replyingInThread": "正在话题中回复："
+    }
   },
   "landing": {
     "nav": {

--- a/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
@@ -138,4 +138,75 @@ describe('V2PodChat composer send button', () => {
     expect(screen.getByPlaceholderText(/message my workspace/i)).toHaveValue('I am checking it now.');
     expect(screen.getByRole('button', { name: /cancel reply/i }).closest('.v2-chat__reply-chip')).not.toBeNull();
   });
+
+  // W-T 4/4, constraint 4 (docs/design/threading-surface-ruling.md; ux-lead
+  // 57449): the composer has ONE target with two kinds. "Reply in thread"
+  // sends threadRootId and NO reply edge; "Reply to <person>" sends the reply
+  // edge and NO thread root; aiming at one clears the other. The resolver
+  // 400s a message carrying both, so these pin the client never builds one.
+  const threadMessages = () => ([
+    {
+      id: 'm1',
+      pod_id: 'p1',
+      user_id: 'u2',
+      content: 'Root of the thread',
+      message_type: 'text',
+      created_at: '2026-08-22T13:00:00Z',
+      user: { username: 'teammate' },
+    },
+    {
+      id: 'm2',
+      pod_id: 'p1',
+      user_id: 'u3',
+      thread_root_id: 'm1',
+      content: 'First reply in the thread',
+      message_type: 'text',
+      created_at: '2026-08-22T13:05:00Z',
+      user: { username: 'other' },
+    },
+  ]);
+
+  test('"Reply in thread" sends threadRootId and no reply edge', async () => {
+    const detail = makeDetail({ messages: threadMessages() });
+    renderChat(detail);
+
+    fireEvent.click(screen.getByRole('button', { name: /reply in thread/i }));
+    expect(screen.getByText(/replying in thread/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+      target: { value: 'Joining the thread.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+    await waitFor(() => {
+      expect(detail.sendMessage).toHaveBeenCalledWith('Joining the thread.', 'text', undefined, 'm1');
+    });
+  });
+
+  test('aiming at a thread clears a prior reply target, and vice versa', async () => {
+    const detail = makeDetail({ messages: threadMessages() });
+    renderChat(detail);
+
+    // Reply-to-person first, then "Reply in thread": the thread wins, the
+    // reply edge is gone.
+    fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
+    fireEvent.click(screen.getByRole('button', { name: /reply in thread/i }));
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+      target: { value: 'thread wins' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+    await waitFor(() => {
+      expect(detail.sendMessage).toHaveBeenLastCalledWith('thread wins', 'text', undefined, 'm1');
+    });
+
+    // The other order: thread first, then reply-to-person. The reply edge
+    // wins, the thread root is gone.
+    fireEvent.click(screen.getByRole('button', { name: /reply in thread/i }));
+    fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+      target: { value: 'reply wins' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+    await waitFor(() => {
+      expect(detail.sendMessage).toHaveBeenLastCalledWith('reply wins', 'text', 'm2', undefined);
+    });
+  });
 });

--- a/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
@@ -85,7 +85,10 @@ describe('V2PodChat composer send button', () => {
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
 
     await waitFor(() => {
-      expect(detail.sendMessage).toHaveBeenCalledWith('hello team', 'text', undefined);
+      // 4th arg is threadRootId (W-T 4/4). Both trailing args are undefined
+      // for an ordinary send, and that IS the assertion: a plain message must
+      // carry neither an addressing edge nor a thread membership.
+      expect(detail.sendMessage).toHaveBeenCalledWith('hello team', 'text', undefined, undefined);
     });
   });
 
@@ -115,7 +118,10 @@ describe('V2PodChat composer send button', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
     await waitFor(() => {
-      expect(detail.sendMessage).toHaveBeenCalledWith('I am checking it now.', 'text', 'm1');
+      // Reply-to-person sets the addressing edge and NOT the thread root —
+      // the two are mutually exclusive at the composer, and the resolver 400s
+      // a message carrying both.
+      expect(detail.sendMessage).toHaveBeenCalledWith('I am checking it now.', 'text', 'm1', undefined);
     });
 
     rerender(

--- a/frontend/src/v2/__tests__/V2ThreadCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadCard.test.tsx
@@ -1,0 +1,145 @@
+// The thread headline card (W-T 4/4) against @ux-lead's render brief.
+//
+// Checklist items 1 and 5 are asserted here; the geometry half of item 2 is a
+// real-browser check, because jsdom has no layout engine and a rail offset
+// asserted in jsdom would be a test of my own CSS string.
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import V2ThreadCard from '../components/V2ThreadCard';
+
+const NOW = new Date('2026-08-22T12:00:00Z');
+
+const people = [
+  { userId: 'u1', name: 'Ada', isBot: false },
+  { userId: 'u2', name: 'Grace', isBot: false },
+  { userId: 'u3', name: 'Recorder', isBot: true },
+  { userId: 'u4', name: 'Fourth', isBot: false },
+];
+
+const setup = (over: Partial<React.ComponentProps<typeof V2ThreadCard>> = {}) => {
+  const onToggleCollapsed = jest.fn();
+  const onToggleFollowing = jest.fn();
+  const utils = render(
+    <V2ThreadCard
+      replyCount={3}
+      participants={people.slice(0, 2)}
+      lastActivityAt={new Date(NOW.getTime() - 2 * 60000).toISOString()}
+      collapsed
+      following={null}
+      onToggleCollapsed={onToggleCollapsed}
+      onToggleFollowing={onToggleFollowing}
+      now={NOW}
+      {...over}
+    />,
+  );
+  return { ...utils, onToggleCollapsed, onToggleFollowing };
+};
+
+describe('content is a count, faces and a time — and nothing else', () => {
+  test('renders the count, pluralised', () => {
+    setup();
+    expect(screen.getByText('3 replies')).toBeInTheDocument();
+  });
+
+  test('one reply is singular', () => {
+    setup({ replyCount: 1 });
+    expect(screen.getByText('1 reply')).toBeInTheDocument();
+  });
+
+  test('the short activity stamp is shown', () => {
+    setup();
+    expect(screen.getByText('2m')).toBeInTheDocument();
+  });
+
+  test('at most three avatars, however many participants', () => {
+    const { container } = setup({ participants: people });
+    expect(container.querySelectorAll('.v2-thread-card__faces .v2-avatar')).toHaveLength(3);
+  });
+
+  test('no reply bodies and no participant names leak into the card', () => {
+    // The brief is explicit: the card is a door, not a preview. Names are the
+    // easy thing to add later "for context" and the reason it is written down.
+    setup({ participants: people });
+    expect(screen.queryByText('Ada')).not.toBeInTheDocument();
+    expect(screen.queryByText('Grace')).not.toBeInTheDocument();
+  });
+});
+
+describe('accent is reserved for being addressed', () => {
+  test('a resting card carries no accent modifier', () => {
+    const { container } = setup();
+    expect(container.querySelector('.v2-thread-card--addressed')).toBeNull();
+    expect(container.querySelector('.v2-thread-card__dot')).toBeNull();
+  });
+
+  test('an addressed thread gets the modifier and the dot', () => {
+    const { container } = setup({ addressed: true });
+    expect(container.querySelector('.v2-thread-card--addressed')).not.toBeNull();
+    expect(container.querySelector('.v2-thread-card__dot')).not.toBeNull();
+  });
+});
+
+describe('collapse is driven by the prop and reported to the caller', () => {
+  test('collapsed hides the chevron and reads as not expanded', () => {
+    const { container } = setup({ collapsed: true });
+    expect(container.querySelector('.v2-thread-card__chevron')).toBeNull();
+    expect(screen.getByRole('button', { name: /Expand thread/ })).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('expanded shows the chevron and says so', () => {
+    const { container } = setup({ collapsed: false });
+    expect(container.querySelector('.v2-thread-card__chevron')).not.toBeNull();
+    expect(screen.getByRole('button', { name: /Collapse thread/ })).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('clicking asks the caller to toggle — the card holds no state', () => {
+    // If the card owned `collapsed` it would drift from the server value the
+    // moment a write failed, and the persistence in constraint 2 would be a
+    // local illusion.
+    const { onToggleCollapsed } = setup();
+    fireEvent.click(screen.getByRole('button', { name: /Expand thread/ }));
+    expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('the follow toggle renders three states from the raw value', () => {
+  test('null reads Follow — an invitation, not a state', () => {
+    setup({ collapsed: false, following: null });
+    expect(screen.getByRole('button', { name: 'Follow' })).toBeInTheDocument();
+  });
+
+  test('true reads Following and is pressed', () => {
+    setup({ collapsed: false, following: true });
+    expect(screen.getByRole('button', { name: 'Following' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('false reads Muted, and is NOT the same rendering as null', () => {
+    // Boolean(null) is false, and false is a mute. The whole tri-state exists
+    // so these two do not collapse into one another.
+    setup({ collapsed: false, following: false });
+    const muted = screen.getByRole('button', { name: 'Muted' });
+    expect(muted).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.queryByRole('button', { name: 'Follow' })).not.toBeInTheDocument();
+  });
+
+  test('the toggle is absent while collapsed, per the brief', () => {
+    setup({ collapsed: true, following: true });
+    expect(screen.queryByRole('button', { name: 'Following' })).not.toBeInTheDocument();
+  });
+
+  test('follow is a sibling of the expand control, not nested inside it', () => {
+    // A button inside a button is invalid HTML and, here, a mis-hit that
+    // silently mutes a thread — the expensive direction.
+    const { container } = setup({ collapsed: false });
+    const main = container.querySelector('.v2-thread-card__main');
+    expect(main?.querySelector('.v2-thread-card__follow')).toBeNull();
+    expect(container.querySelector('.v2-thread-card__follow')).not.toBeNull();
+  });
+
+  test('clicking follow does not also toggle collapse', () => {
+    const { onToggleCollapsed, onToggleFollowing } = setup({ collapsed: false });
+    fireEvent.click(screen.getByRole('button', { name: 'Follow' }));
+    expect(onToggleFollowing).toHaveBeenCalledTimes(1);
+    expect(onToggleCollapsed).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/v2/__tests__/shortTime.test.ts
+++ b/frontend/src/v2/__tests__/shortTime.test.ts
@@ -1,0 +1,49 @@
+import { shortTimeSince } from '../utils/shortTime';
+
+const NOW = new Date('2026-08-22T12:00:00Z');
+const ago = (ms: number) => new Date(NOW.getTime() - ms);
+const MIN = 60000;
+const HOUR = 60 * MIN;
+
+describe('shortTimeSince', () => {
+  test('under a minute reads "now", not "0m"', () => {
+    expect(shortTimeSince(ago(30000), NOW)).toBe('now');
+  });
+
+  test('minutes below an hour', () => {
+    expect(shortTimeSince(ago(2 * MIN), NOW)).toBe('2m');
+    expect(shortTimeSince(ago(59 * MIN), NOW)).toBe('59m');
+  });
+
+  test('the minute/hour boundary is exactly 60', () => {
+    expect(shortTimeSince(ago(60 * MIN), NOW)).toBe('1h');
+  });
+
+  test('hours below a day', () => {
+    expect(shortTimeSince(ago(23 * HOUR), NOW)).toBe('23h');
+  });
+
+  test('past a day falls to the calendar comparison', () => {
+    // 25h before noon is 11:00 the previous date.
+    expect(shortTimeSince(ago(25 * HOUR), NOW)).toBe('Yesterday');
+  });
+
+  test('two days back is not Yesterday', () => {
+    expect(shortTimeSince(ago(49 * HOUR), NOW)).toBe('2d');
+  });
+
+  test('a week or more reads in weeks', () => {
+    expect(shortTimeSince(ago(8 * 24 * HOUR), NOW)).toBe('1w');
+  });
+
+  test('a future timestamp reads "now" rather than a negative age', () => {
+    // Server/browser clock skew, not an error worth surfacing in six chars.
+    expect(shortTimeSince(new Date(NOW.getTime() + 5 * MIN), NOW)).toBe('now');
+  });
+
+  test('missing or unparseable input renders nothing', () => {
+    expect(shortTimeSince(undefined, NOW)).toBe('');
+    expect(shortTimeSince(null, NOW)).toBe('');
+    expect(shortTimeSince('not a date', NOW)).toBe('');
+  });
+});

--- a/frontend/src/v2/__tests__/threadView.test.ts
+++ b/frontend/src/v2/__tests__/threadView.test.ts
@@ -1,0 +1,104 @@
+import { buildThreadView } from '../utils/threadView';
+import { V2ThreadState } from '../hooks/useV2ThreadState';
+
+const msg = (id: number, opts: Partial<any> = {}) => ({
+  id: String(id),
+  pod_id: 'pod-1',
+  user_id: opts.user_id || 'u1',
+  content: `m${id}`,
+  message_type: 'text',
+  created_at: opts.created_at || `2026-08-22T10:0${id % 10}:00Z`,
+  thread_root_id: opts.thread_root_id ?? null,
+  user: opts.user,
+} as any);
+
+const state = (ids: number[]): Map<string, V2ThreadState> => new Map(
+  ids.map((i) => [String(i), { threadRootId: i, following: null, collapsed: true }]),
+);
+
+describe('replies fold under their root', () => {
+  test('a root with replies yields the root then a card', () => {
+    const items = buildThreadView([msg(1), msg(2, { thread_root_id: 1 })], state([1]));
+    expect(items.map((i) => i.kind)).toEqual(['message', 'card']);
+    expect(items[0]).toMatchObject({ message: { id: '1' } });
+    expect(items[1]).toMatchObject({ rootId: '1', replyCount: 1 });
+  });
+
+  test('replies do not also appear flat', () => {
+    const items = buildThreadView([msg(1), msg(2, { thread_root_id: 1 })], state([1]));
+    const flat = items.filter((i) => i.kind === 'message').map((i: any) => i.message.id);
+    expect(flat).toEqual(['1']);
+  });
+
+  test('a message with no replies gets no card', () => {
+    const items = buildThreadView([msg(1), msg(9)], state([]));
+    expect(items.map((i) => i.kind)).toEqual(['message', 'message']);
+  });
+
+  test('two threads stay separate and keep root order', () => {
+    const items = buildThreadView(
+      [msg(1), msg(2), msg(3, { thread_root_id: 1 }), msg(4, { thread_root_id: 2 })],
+      state([1, 2]),
+    );
+    const cards = items.filter((i) => i.kind === 'card') as any[];
+    expect(cards.map((c) => c.rootId)).toEqual(['1', '2']);
+    expect(cards[0].replies.map((r: any) => r.id)).toEqual(['3']);
+    expect(cards[1].replies.map((r: any) => r.id)).toEqual(['4']);
+  });
+});
+
+describe('a reply whose root is not in the page is not lost', () => {
+  test('it renders flat rather than disappearing', () => {
+    // Paged out, or the root was deleted. Hiding it would be the one outcome
+    // worse than showing it in the wrong place.
+    const items = buildThreadView([msg(5, { thread_root_id: 999 })], state([]));
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ kind: 'message', message: { id: '5' } });
+  });
+});
+
+describe('card metadata', () => {
+  test('participants are deduped, in first-appearance order, root author first', () => {
+    const items = buildThreadView(
+      [
+        msg(1, { user_id: 'root-author' }),
+        msg(2, { thread_root_id: 1, user_id: 'b' }),
+        msg(3, { thread_root_id: 1, user_id: 'root-author' }),
+        msg(4, { thread_root_id: 1, user_id: 'c' }),
+      ],
+      state([1]),
+    );
+    const card = items.find((i) => i.kind === 'card') as any;
+    expect(card.participants.map((p: any) => p.userId)).toEqual(['root-author', 'b', 'c']);
+  });
+
+  test('lastActivityAt is the newest reply, not the root', () => {
+    const items = buildThreadView(
+      [
+        msg(1, { created_at: '2026-08-22T10:00:00Z' }),
+        msg(2, { thread_root_id: 1, created_at: '2026-08-22T11:00:00Z' }),
+        msg(3, { thread_root_id: 1, created_at: '2026-08-22T10:30:00Z' }),
+      ],
+      state([1]),
+    );
+    const card = items.find((i) => i.kind === 'card') as any;
+    expect(card.lastActivityAt).toBe('2026-08-22T11:00:00Z');
+  });
+
+  test('replyCount counts replies, not the root', () => {
+    const items = buildThreadView(
+      [msg(1), msg(2, { thread_root_id: 1 }), msg(3, { thread_root_id: 1 })],
+      state([1]),
+    );
+    expect((items.find((i) => i.kind === 'card') as any).replyCount).toBe(2);
+  });
+
+  test('bot-ness is carried through for the avatar tier', () => {
+    const items = buildThreadView(
+      [msg(1, { user_id: 'bot', user: { username: 'Recorder', isBot: true } }), msg(2, { thread_root_id: 1 })],
+      state([1]),
+    );
+    const card = items.find((i) => i.kind === 'card') as any;
+    expect(card.participants[0]).toMatchObject({ name: 'Recorder', isBot: true });
+  });
+});

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -449,4 +449,43 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(photo).toContain('box-shadow');
     expect(photo).toContain('none');
   });
+
+  test('the thread rail geometry survives, because jsdom cannot see it', () => {
+    // @ux-lead's brief fixes the rail at 28px with replies 40px off it, and
+    // 24px at 390. jsdom has no layout engine, so a render test cannot tell a
+    // correct rail from a missing one — the card and replies still appear,
+    // just unindented and with no rule. This pins the three numbers that a
+    // reader would otherwise have to take from a comment.
+    const rail = ruleBody(v2, '.v2-thread-replies');
+    expect(rail).toContain('margin-left: 28px');
+    expect(rail).toContain('padding-left: 40px');
+    expect(rail).toContain('border-left: 2px solid #eef0f6');
+
+    // The 390 override lives in a media block, so read the file rather than
+    // the rule body — ruleBody stops at the first closing brace.
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-replies\s*\{[\s\S]*?margin-left: 24px/);
+  });
+
+  test('the thread card has no shadow and no accent at rest', () => {
+    // Two separate brief constraints that both fail silently: a shadow reads
+    // as "slightly wrong depth" and an accent at rest destroys the ONE signal
+    // the card has for being addressed.
+    const card = ruleBody(v2, '.v2-thread-card__main');
+    expect(card).toContain('box-shadow: none');
+    expect(card).toContain('min-height: 44px');
+    expect(card).not.toContain('var(--v2-accent)');
+
+    // Accent is reachable only through the addressed modifier.
+    const addressed = ruleBody(v2, '.v2-thread-card--addressed .v2-thread-card__count');
+    expect(addressed).toContain('var(--v2-accent)');
+  });
+
+  test('reduced motion actually reaches the thread transitions', () => {
+    // The 300ms layout transition is a brief requirement AND a reduced-motion
+    // hazard. Easy to add the transition and forget the opt-out; nothing in a
+    // render test notices, and the people it affects are not the ones testing.
+    expect(v2).toMatch(
+      /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.v2-thread-replies[\s\S]*?transition: none/,
+    );
+  });
 });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -470,9 +470,15 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // Two separate brief constraints that both fail silently: a shadow reads
     // as "slightly wrong depth" and an accent at rest destroys the ONE signal
     // the card has for being addressed.
-    const card = ruleBody(v2, '.v2-thread-card__main');
+    // Selector carries the `.v2-root button.` prefix ON PURPOSE: the global
+    // reset `.v2-root button:not(.MuiButtonBase-root)` is 0-2-1 and sets
+    // `color: inherit`, so a bare class rule loses and the card renders at
+    // body colour. Pinning the prefixed selector means dropping the prefix
+    // fails here rather than silently in production (#870's trap).
+    const card = ruleBody(v2, '.v2-root button.v2-thread-card__main');
     expect(card).toContain('box-shadow: none');
     expect(card).toContain('min-height: 44px');
+    expect(card).toContain('color: #4b5563');
     expect(card).not.toContain('var(--v2-accent)');
 
     // Accent is reachable only through the addressed modifier.

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -17,6 +17,10 @@ import { Trans, useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import type { V2InviteTab } from './V2InviteModal';
 
+import V2ThreadCard from './V2ThreadCard';
+import { useV2ThreadState } from '../hooks/useV2ThreadState';
+import { buildThreadView } from '../utils/threadView';
+
 const PLAN_MODE_KEY = 'v2.podMode';
 const AGENT_DELIVERY_HINT_KEY = 'v2.agentDeliveryHint';
 const JUST_CREATED_POD_KEY = 'v2.justCreated';
@@ -252,6 +256,27 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
   // placing it after broke the hook order (React #310) and crashed the pod
   // page on first load (caught in post-deploy browser verification).
   const [replyTarget, setReplyTarget] = useState<import('../hooks/useV2PodDetail').V2Message | null>(null);
+
+  // The thread the composer is aimed at (constraint 4). ONE composer, two chip
+  // states, never both: setting either target clears the other. Kept beside
+  // replyTarget and above the `if (!pod)` return for the same hook-order
+  // reason recorded above — this file has crashed on that once already.
+  const [threadTarget, setThreadTarget] = useState<{ id: string; preview: string } | null>(null);
+
+  // Per-user thread state for this pod (#1145). `collapsed` arrives resolved;
+  // this component must never compute it.
+  const threadState = useV2ThreadState(detail?.pod?._id);
+
+  // Setting one composer target clears the other. Two chips would be two
+  // meanings for one send, and the resolver rejects a message carrying both.
+  const aimAtThread = useCallback((rootId: string, preview: string) => {
+    setReplyTarget(null);
+    setThreadTarget({ id: rootId, preview });
+  }, []);
+  const aimAtMessage = useCallback((m: import('../hooks/useV2PodDetail').V2Message) => {
+    setThreadTarget(null);
+    setReplyTarget(m);
+  }, []);
 
   // @-mention dropdown state. mentionStart is the index of the `@` in the
   // textarea so we know the slice to replace on select.
@@ -812,7 +837,15 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
     setSending(true);
     setComposerError(null);
     try {
-      const created = await sendMessage(text, 'text', replyTarget?.id || undefined);
+      // reply_to and thread_root are mutually exclusive by construction here:
+      // aimAtThread/aimAtMessage each clear the other, so at most one is set.
+      // The resolver 400s a message carrying both rather than choosing.
+      const created = await sendMessage(
+        text,
+        'text',
+        replyTarget?.id || undefined,
+        threadTarget?.id || undefined,
+      );
       if (created) {
         const delivery = created.agentDelivery;
         const exampleAgent = agents.find((agent) => agent.status === 'active') || agents[0];
@@ -856,6 +889,10 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
         }
         setDraft('');
         setReplyTarget(null);
+        // Cleared only on SUCCESS, alongside the draft. #1118's rule: a send
+        // failure keeps the draft and its target, so a retry still lands in
+        // the thread the user aimed at.
+        setThreadTarget(null);
       }
     } finally {
       setSending(false);
@@ -1160,28 +1197,84 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                   )}
                 </div>
               )}
-              {messages.map((m, i) => (
-                <React.Fragment key={m.id}>
-                  <V2MessageBubble
-                    message={m}
-                    agentDisplayNames={agentDisplayNames}
-                    agentAuthorKeys={agentAuthorKeys}
-                    onAuthorClick={onOpenMember ? handleAuthorClick : undefined}
-                    onOpenFile={onOpenFile}
-                    onReply={setReplyTarget}
-                    grouped={isGroupedWithPrevious(m, messages[i - 1])}
-                  />
-                  {agentDeliveryHint?.messageId === m.id && (
-                    <div className="v2-chat__delivery-hint" role="status">
-                      <Trans
-                        i18nKey="podChat.deliveryHint"
-                        values={{ handle: agentDeliveryHint.mentionHandle }}
-                        components={{ handle: <strong /> }}
+              {buildThreadView(messages, threadState.byRoot).map((item, i, view) => {
+                if (item.kind === 'message') {
+                  const m = item.message;
+                  const prev = view[i - 1];
+                  return (
+                    <React.Fragment key={m.id}>
+                      <V2MessageBubble
+                        message={m}
+                        agentDisplayNames={agentDisplayNames}
+                        agentAuthorKeys={agentAuthorKeys}
+                        onAuthorClick={onOpenMember ? handleAuthorClick : undefined}
+                        onOpenFile={onOpenFile}
+                        onReply={aimAtMessage}
+                        grouped={isGroupedWithPrevious(
+                          m,
+                          prev && prev.kind === 'message' ? prev.message : undefined,
+                        )}
                       />
-                    </div>
-                  )}
-                </React.Fragment>
-              ))}
+                      {agentDeliveryHint?.messageId === m.id && (
+                        <div className="v2-chat__delivery-hint" role="status">
+                          <Trans
+                            i18nKey="podChat.deliveryHint"
+                            values={{ handle: agentDeliveryHint.mentionHandle }}
+                            components={{ handle: <strong /> }}
+                          />
+                        </div>
+                      )}
+                    </React.Fragment>
+                  );
+                }
+
+                const st = threadState.byRoot.get(item.rootId);
+                // No state row means the server does not consider this a
+                // thread. Render the replies flat rather than inventing a
+                // collapsed card around them — absence is not "collapsed".
+                const collapsed = st ? st.collapsed : false;
+                return (
+                  <React.Fragment key={`thread-${item.rootId}`}>
+                    <V2ThreadCard
+                      replyCount={item.replyCount}
+                      participants={item.participants}
+                      lastActivityAt={item.lastActivityAt}
+                      collapsed={collapsed}
+                      following={st ? st.following : null}
+                      onToggleCollapsed={() => threadState.toggleCollapsed(item.rootId)}
+                      onToggleFollowing={() => threadState.toggleFollowing(item.rootId)}
+                    />
+                    {!collapsed && (
+                      <div className="v2-thread-replies">
+                        {item.replies.map((r, ri) => (
+                          <V2MessageBubble
+                            key={r.id}
+                            message={r}
+                            agentDisplayNames={agentDisplayNames}
+                            agentAuthorKeys={agentAuthorKeys}
+                            onAuthorClick={onOpenMember ? handleAuthorClick : undefined}
+                            onOpenFile={onOpenFile}
+                            onReply={aimAtMessage}
+                            grouped={isGroupedWithPrevious(r, item.replies[ri - 1])}
+                          />
+                        ))}
+                        {!isReadOnly && (
+                          <button
+                            type="button"
+                            className="v2-thread-replies__aim"
+                            onClick={() => aimAtThread(
+                              item.rootId,
+                              String(messages.find((x) => String(x.id) === item.rootId)?.content || ''),
+                            )}
+                          >
+                            {t('podChat.thread.replyInThread')}
+                          </button>
+                        )}
+                      </div>
+                    )}
+                  </React.Fragment>
+                );
+              })}
               <div ref={messagesEndRef} />
             </div>
 
@@ -1226,6 +1319,22 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
               </div>
             ) : (
             <div className="v2-chat__composer">
+              {threadTarget && (
+                <div className="v2-chat__reply-chip v2-chat__reply-chip--thread" role="status">
+                  <span className="v2-chat__reply-chip-label">
+                    {t('podChat.thread.replyingInThread')}{' '}
+                    {threadTarget.preview.replace(/\[\[upload:[^\]]*\]\]/g, '📎').slice(0, 40)}
+                  </span>
+                  <button
+                    type="button"
+                    className="v2-chat__reply-chip-cancel"
+                    aria-label={t('podChat.cancelReply')}
+                    onClick={() => setThreadTarget(null)}
+                  >
+                    {CLOSE_MARK}
+                  </button>
+                </div>
+              )}
               {replyTarget && (
                 <div className="v2-chat__reply-chip" role="status">
                   <span className="v2-chat__reply-chip-label">

--- a/frontend/src/v2/components/V2ThreadCard.tsx
+++ b/frontend/src/v2/components/V2ThreadCard.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import V2Avatar from './V2Avatar';
+import { shortTimeSince } from '../utils/shortTime';
+
+/**
+ * The thread headline card (W-T, TASK-029 4/4) — @ux-lead's render brief.
+ *
+ * Sits directly under its root message, in the channel column, and renders
+ * INSTEAD of that root's replies while collapsed. Content is count, up to
+ * three participant avatars, and a short last-activity stamp — deliberately no
+ * reply bodies and no names, so the card is a door and not a preview.
+ *
+ * `collapsed` is a prop, never derived here. It arrives already resolved from
+ * the payload (#1145, @ux-lead 56996): a client that computed it would need
+ * the threading cutoff, which is the migration detail that ruling removed from
+ * the wire. If you find yourself wanting a date comparison in this file, the
+ * bug is upstream.
+ *
+ * `following` is the raw tri-state and renders three labels. Null is NOT
+ * "not following" — it means the server will decide from participation — so it
+ * reads "Follow" (an invitation) rather than "Muted" (a state).
+ */
+export interface V2ThreadParticipant {
+  userId: string;
+  name: string;
+  avatarUrl?: string | null;
+  isBot?: boolean;
+}
+
+interface V2ThreadCardProps {
+  replyCount: number;
+  participants: V2ThreadParticipant[];
+  lastActivityAt?: string | null;
+  collapsed: boolean;
+  following: boolean | null;
+  /** An item in this thread addresses me. The card's only use of accent. */
+  addressed?: boolean;
+  onToggleCollapsed: () => void;
+  onToggleFollowing: () => void;
+  /** Injected in tests so the stamp is about boundaries, not about the clock. */
+  now?: Date;
+}
+
+const MAX_AVATARS = 3;
+
+const followLabel = (following: boolean | null): string => {
+  if (following === true) return 'Following';
+  if (following === false) return 'Muted';
+  return 'Follow';
+};
+
+const followClass = (following: boolean | null): string => {
+  if (following === true) return 'v2-thread-card__follow v2-thread-card__follow--on';
+  if (following === false) return 'v2-thread-card__follow v2-thread-card__follow--muted';
+  return 'v2-thread-card__follow';
+};
+
+const V2ThreadCard: React.FC<V2ThreadCardProps> = ({
+  replyCount,
+  participants,
+  lastActivityAt,
+  collapsed,
+  following,
+  addressed = false,
+  onToggleCollapsed,
+  onToggleFollowing,
+  now,
+}) => {
+  const shown = participants.slice(0, MAX_AVATARS);
+  const stamp = shortTimeSince(lastActivityAt, now);
+  const countLabel = `${replyCount} ${replyCount === 1 ? 'reply' : 'replies'}`;
+
+  return (
+    <div
+      className={`v2-thread-card${collapsed ? '' : ' v2-thread-card--expanded'}${addressed ? ' v2-thread-card--addressed' : ''}`}
+      data-testid="v2-thread-card"
+    >
+      <button
+        type="button"
+        className="v2-thread-card__main"
+        onClick={onToggleCollapsed}
+        aria-expanded={!collapsed}
+        // The accessible name carries the state, because the visual cue for it
+        // is a rotated chevron and a rotation is not announced.
+        aria-label={`${collapsed ? 'Expand' : 'Collapse'} thread, ${countLabel}`}
+      >
+        <span className="v2-thread-card__count">
+          {addressed && <span className="v2-thread-card__dot" aria-hidden="true" />}
+          {countLabel}
+        </span>
+        {shown.length > 0 && (
+          <span className="v2-thread-card__faces" aria-hidden="true">
+            {shown.map((p) => (
+              <V2Avatar
+                key={p.userId}
+                name={p.name}
+                src={p.avatarUrl || undefined}
+                size="sm"
+                kind={typeof p.isBot === 'boolean' ? (p.isBot ? 'agent' : 'human') : undefined}
+                seed={p.userId}
+              />
+            ))}
+          </span>
+        )}
+        {stamp && <span className="v2-thread-card__time">{stamp}</span>}
+        {!collapsed && <span className="v2-thread-card__chevron" aria-hidden="true">⌄</span>}
+      </button>
+
+      {/* Follow lives outside the expand button: nesting a control inside a
+          control is invalid, and a mis-hit that silently muted a thread is the
+          expensive direction. Only shown expanded, per the brief. */}
+      {!collapsed && (
+        <button
+          type="button"
+          className={followClass(following)}
+          onClick={onToggleFollowing}
+          aria-pressed={following === true}
+        >
+          {followLabel(following)}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default V2ThreadCard;

--- a/frontend/src/v2/hooks/useV2Api.ts
+++ b/frontend/src/v2/hooks/useV2Api.ts
@@ -6,6 +6,11 @@ export interface V2ApiClient {
   get: <T = unknown>(url: string, config?: AxiosRequestConfig) => Promise<T>;
   post: <T = unknown>(url: string, body?: unknown, config?: AxiosRequestConfig) => Promise<T>;
   patch: <T = unknown>(url: string, body?: unknown, config?: AxiosRequestConfig) => Promise<T>;
+  // PUT, because `SET collapsed` is an idempotent set of one field and the
+  // shipped route (#1109) is PUT /api/messages/:id/collapsed. Added rather
+  // than routed through `patch`: the verb the server registered is the verb
+  // the client should send.
+  put: <T = unknown>(url: string, body?: unknown, config?: AxiosRequestConfig) => Promise<T>;
   del: <T = unknown>(url: string, config?: AxiosRequestConfig) => Promise<T>;
 }
 
@@ -31,6 +36,11 @@ export const useV2Api = (): V2ApiClient => {
     return res.data;
   }, [headers]);
 
+  const put = useCallback(async <T,>(url: string, body?: unknown, config: AxiosRequestConfig = {}) => {
+    const res = await axios.put<T>(url, body, { ...config, headers: { ...headers, ...(config.headers || {}) } });
+    return res.data;
+  }, [headers]);
+
   const del = useCallback(async <T,>(url: string, config: AxiosRequestConfig = {}) => {
     const res = await axios.delete<T>(url, { ...config, headers: { ...headers, ...(config.headers || {}) } });
     return res.data;
@@ -40,6 +50,7 @@ export const useV2Api = (): V2ApiClient => {
     get,
     post,
     patch,
+    put,
     del,
-  }), [get, post, patch, del]);
+  }), [get, post, patch, put, del]);
 };

--- a/frontend/src/v2/hooks/useV2PodDetail.ts
+++ b/frontend/src/v2/hooks/useV2PodDetail.ts
@@ -30,6 +30,11 @@ export interface V2Message {
   // the normalized `replyTo` object or the raw reply_* columns; the bubble
   // renders whichever is present.
   replyTo?: { id: string; content: string; username: string; userId?: string } | null;
+  // Threading (PG thread_root_id, #1106). Present on every message the PG
+  // reads return; null on a root and on anything predating the backfill.
+  // Distinct from reply_to_message_id ON PURPOSE — that one is ADDRESSING and
+  // wakes the parent's author, this one is membership and wakes nobody.
+  thread_root_id?: number | string | null;
   reply_msg_id?: string | null;
   reply_content?: string | null;
   reply_username?: string | null;
@@ -133,7 +138,16 @@ export interface UseV2PodDetailResult {
   loadingOlder: boolean;
   loadOlder: () => Promise<void>;
   refresh: () => Promise<void>;
-  sendMessage: (content: string, messageType?: string, replyToMessageId?: string) => Promise<V2Message | null>;
+  // `threadRootId` posts INTO a thread without addressing anyone: the backend
+  // takes it as membership and leaves reply_to null, so joining a thread does
+  // not ping the root's author (@ux-lead 56879, resolver in #1128). Passing
+  // both is a caller bug and the resolver 400s it rather than picking.
+  sendMessage: (
+    content: string,
+    messageType?: string,
+    replyToMessageId?: string,
+    threadRootId?: string,
+  ) => Promise<V2Message | null>;
 }
 
 const REQUEST_TIMEOUT_MS = 8000;
@@ -395,13 +409,23 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
     };
   }, [podId, socket, connected, joinPod, leavePod, currentUser?._id]);
 
-  const sendMessage = useCallback(async (content: string, messageType = 'text', replyToMessageId?: string): Promise<V2Message | null> => {
+  const sendMessage = useCallback(async (
+    content: string,
+    messageType = 'text',
+    replyToMessageId?: string,
+    threadRootId?: string,
+  ): Promise<V2Message | null> => {
     if (!podId || !content.trim()) return null;
     try {
       setSendError(null);
       const created = await api.post<V2Message>(
         `/api/messages/${podId}`,
-        { content: content.trim(), messageType, ...(replyToMessageId ? { replyToMessageId } : {}) },
+        {
+          content: content.trim(),
+          messageType,
+          ...(replyToMessageId ? { replyToMessageId } : {}),
+          ...(threadRootId ? { threadRootId } : {}),
+        },
         { timeout: SEND_TIMEOUT_MS },
       );
       const normalized = normalizeMessage(created);

--- a/frontend/src/v2/hooks/useV2ThreadState.ts
+++ b/frontend/src/v2/hooks/useV2ThreadState.ts
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useV2Api } from './useV2Api';
+
+const REQUEST_TIMEOUT_MS = 15000;
+
+/**
+ * Per-user thread state for one pod (W-T, TASK-029 4/4).
+ *
+ * `collapsed` arrives ALREADY RESOLVED — @ux-lead's ruling (56996), shipped in
+ * #1145. The server folds the explicit row and the pre-cutoff default into one
+ * boolean per root, so this hook must never compute it. There is deliberately
+ * no cutoff in the payload to compute it FROM: a client that could derive
+ * `collapsed` would be carrying a migration detail forever.
+ *
+ * `following` is the opposite and stays raw: `true | false | null`, where null
+ * means "defer to participation". The wake path resolves that against live
+ * authorship; the render shows three states and never guesses which way null
+ * would resolve.
+ */
+export interface V2ThreadState {
+  threadRootId: number;
+  following: boolean | null;
+  collapsed: boolean;
+}
+
+interface ThreadStateResponse {
+  podId: string;
+  defaults: { following: boolean | null };
+  threads: V2ThreadState[];
+}
+
+export interface UseV2ThreadState {
+  byRoot: Map<string, V2ThreadState>;
+  loading: boolean;
+  /** Roots the server told us about — a message not in here is not a thread. */
+  isThreadRoot: (messageId: string) => boolean;
+  toggleCollapsed: (messageId: string) => void;
+  toggleFollowing: (messageId: string) => void;
+}
+
+const key = (id: number | string) => String(id);
+
+export const useV2ThreadState = (podId: string | undefined): UseV2ThreadState => {
+  const api = useV2Api();
+  const [byRoot, setByRoot] = useState<Map<string, V2ThreadState>>(new Map());
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!podId) {
+      setByRoot(new Map());
+      return undefined;
+    }
+    let cancelled = false;
+    setLoading(true);
+    api.get<ThreadStateResponse>(
+      `/api/messages/threads/state?podId=${encodeURIComponent(podId)}`,
+      { timeout: REQUEST_TIMEOUT_MS },
+    )
+      .then((data) => {
+        if (cancelled) return;
+        const next = new Map<string, V2ThreadState>();
+        for (const t of data?.threads || []) next.set(key(t.threadRootId), t);
+        setByRoot(next);
+      })
+      .catch(() => {
+        // Degrade to "no threads known", which renders every message flat —
+        // the pre-threading view. Never invent collapsed:true on a failure:
+        // that would hide replies the user could see a moment ago, and they
+        // would have no way to tell a fetch failure from an empty pod.
+        if (!cancelled) setByRoot(new Map());
+      })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [api, podId]);
+
+  const patch = useCallback((messageId: string, change: Partial<V2ThreadState>) => {
+    setByRoot((prev) => {
+      const row = prev.get(key(messageId));
+      if (!row) return prev;
+      const next = new Map(prev);
+      next.set(key(messageId), { ...row, ...change });
+      return next;
+    });
+  }, []);
+
+  const toggleCollapsed = useCallback((messageId: string) => {
+    const row = byRoot.get(key(messageId));
+    if (!row) return;
+    const target = !row.collapsed;
+    patch(messageId, { collapsed: target });
+    api.put(`/api/messages/${messageId}/collapsed`, { collapsed: target })
+      .catch(() => patch(messageId, { collapsed: row.collapsed }));
+  }, [api, byRoot, patch]);
+
+  const toggleFollowing = useCallback((messageId: string) => {
+    const row = byRoot.get(key(messageId));
+    if (!row) return;
+    // Three states, two transitions, ONE column written either way — the
+    // endpoints are separate precisely so a client cannot clobber `collapsed`
+    // while touching follow. null and false both mean "start following".
+    const target = row.following !== true;
+    patch(messageId, { following: target });
+    const revert = () => patch(messageId, { following: row.following });
+    if (target) api.post(`/api/messages/${messageId}/follow`).catch(revert);
+    else api.del(`/api/messages/${messageId}/follow`).catch(revert);
+  }, [api, byRoot, patch]);
+
+  const isThreadRoot = useCallback(
+    (messageId: string) => byRoot.has(key(messageId)),
+    [byRoot],
+  );
+
+  return useMemo(
+    () => ({ byRoot, loading, isThreadRoot, toggleCollapsed, toggleFollowing }),
+    [byRoot, loading, isThreadRoot, toggleCollapsed, toggleFollowing],
+  );
+};
+
+export default useV2ThreadState;

--- a/frontend/src/v2/utils/shortTime.ts
+++ b/frontend/src/v2/utils/shortTime.ts
@@ -1,0 +1,48 @@
+/**
+ * Short-form "last activity" for the thread card (W-T 4/4).
+ *
+ * The brief asks for `2m / 1h / Yesterday`. Deliberately NOT a general
+ * relative-time helper: it is the card's one line, where the whole budget is a
+ * few characters and precision past the unit is noise.
+ *
+ * `now` is injected rather than read from the clock so the tests can be about
+ * the boundaries instead of about timing. A helper that reads Date.now()
+ * internally can only be tested loosely, and the boundaries are the part that
+ * has an off-by-one in it.
+ */
+export const shortTimeSince = (
+  raw: string | Date | undefined | null,
+  now: Date = new Date(),
+): string => {
+  if (!raw) return '';
+  const then = raw instanceof Date ? raw : new Date(raw);
+  const ms = then.getTime();
+  if (Number.isNaN(ms)) return '';
+
+  const diffMs = now.getTime() - ms;
+  // A clock skew between server and browser can put "last activity" slightly
+  // in the future. Render that as "now" rather than a negative age.
+  if (diffMs < 0) return 'now';
+
+  const minutes = Math.floor(diffMs / 60000);
+  if (minutes < 1) return 'now';
+  if (minutes < 60) return `${minutes}m`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+
+  // Calendar-day comparison, not a 48h window: "Yesterday" means the previous
+  // date, so 23:00 yesterday read at 01:00 today is Yesterday and not "2h".
+  // (2h wins on the hours branch above, which is correct — this branch only
+  // sees ages past a day.)
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const startOfYesterday = new Date(startOfToday);
+  startOfYesterday.setDate(startOfYesterday.getDate() - 1);
+  if (ms >= startOfYesterday.getTime()) return 'Yesterday';
+
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d`;
+  return `${Math.floor(days / 7)}w`;
+};
+
+export default shortTimeSince;

--- a/frontend/src/v2/utils/threadView.ts
+++ b/frontend/src/v2/utils/threadView.ts
@@ -1,0 +1,96 @@
+import { V2Message } from '../hooks/useV2PodDetail';
+import { V2ThreadState } from '../hooks/useV2ThreadState';
+import { V2ThreadParticipant } from '../components/V2ThreadCard';
+
+/**
+ * Fold a flat message list into the threaded render order (W-T 4/4).
+ *
+ * Pure, and separate from V2PodChat, because this is the part with the edge
+ * cases and the component is 1,300 lines of surface. Everything here is
+ * decided from data the server sent: `thread_root_id` on each message and the
+ * per-root state from #1145. Nothing is derived from timestamps.
+ */
+export type ThreadViewItem =
+  | { kind: 'message'; message: V2Message }
+  | {
+    kind: 'card';
+    rootId: string;
+    replyCount: number;
+    participants: V2ThreadParticipant[];
+    lastActivityAt: string | null;
+    replies: V2Message[];
+  };
+
+const idOf = (m: V2Message): string => String(m.id);
+const rootOf = (m: V2Message): string | null => (
+  m.thread_root_id === null || m.thread_root_id === undefined ? null : String(m.thread_root_id)
+);
+const whenOf = (m: V2Message): string => String(m.created_at || m.createdAt || '');
+
+const participantOf = (m: V2Message): V2ThreadParticipant => {
+  const uid = String(m.user_id || '');
+  const nested = typeof m.userId === 'object' && m.userId ? m.userId : undefined;
+  return {
+    userId: uid,
+    name: m.user?.username || nested?.username || uid,
+    avatarUrl: m.user?.profile_picture ?? nested?.profilePicture ?? null,
+    isBot: typeof m.user?.isBot === 'boolean' ? m.user.isBot : nested?.isBot,
+  };
+};
+
+export const buildThreadView = (
+  messages: V2Message[],
+  byRoot: Map<string, V2ThreadState>,
+): ThreadViewItem[] => {
+  const repliesByRoot = new Map<string, V2Message[]>();
+  for (const m of messages) {
+    const root = rootOf(m);
+    if (!root) continue;
+    // A message whose root is not in this list (paged out, or deleted) is NOT
+    // hidden. It renders flat rather than vanishing — losing a message is the
+    // one outcome worse than showing it in the wrong place.
+    if (!messages.some((x) => idOf(x) === root)) continue;
+    const bucket = repliesByRoot.get(root);
+    if (bucket) bucket.push(m);
+    else repliesByRoot.set(root, [m]);
+  }
+
+  const out: ThreadViewItem[] = [];
+  for (const m of messages) {
+    const root = rootOf(m);
+    if (root && repliesByRoot.has(root)) continue; // rendered under its card
+
+    out.push({ kind: 'message', message: m });
+
+    const replies = repliesByRoot.get(idOf(m));
+    if (!replies || replies.length === 0) continue;
+
+    // Participants in first-appearance order, deduped, root author included:
+    // they started it and their face belongs on the card.
+    const seen = new Set<string>();
+    const participants: V2ThreadParticipant[] = [];
+    for (const p of [m, ...replies]) {
+      const uid = String(p.user_id || '');
+      if (!uid || seen.has(uid)) continue;
+      seen.add(uid);
+      participants.push(participantOf(p));
+    }
+
+    const lastActivityAt = replies.reduce<string>(
+      (acc, r) => (whenOf(r) > acc ? whenOf(r) : acc),
+      whenOf(m),
+    ) || null;
+
+    out.push({
+      kind: 'card',
+      rootId: idOf(m),
+      replyCount: replies.length,
+      participants,
+      lastActivityAt,
+      replies,
+    });
+  }
+  return out;
+};
+
+export default buildThreadView;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -7168,6 +7168,14 @@
 
 /* ── Threading: headline card + reply rail (W-T 4/4) ────────────────────────
    Built to @ux-lead's render brief. Numbers here are theirs, not invented:
+   NOTE the `.v2-root button.` prefix on every button rule below. The global
+   reset `.v2-root button:not(.MuiButtonBase-root)` is 0-2-1 and sets
+   `color: inherit`, so a bare `.v2-thread-card__main` (0-1-0) loses and the
+   card renders at body colour with no accent on the follow state. Same trap
+   as #870, recorded in the note above that reset. Caught here by measuring in
+   a real browser — computed colour was rgb(17,24,39) while the rule said
+   #4b5563 — which no presence guard can see, because the rule IS present.
+
    card radius 10 / border #e5e7eb / hover #d7dce7 / no shadow; type 13px
    secondary with the count at 500; rail 2px #eef0f6 at 28px, replies +40px,
    dropping to 24px at 390; layout transition 300ms. */
@@ -7179,7 +7187,7 @@
   margin: 4px 0 0 0; /* brief: no gap > 8px between root and card */
 }
 
-.v2-thread-card__main {
+.v2-root button.v2-thread-card__main {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -7195,7 +7203,7 @@
   transition: border-color 300ms ease;
 }
 
-.v2-thread-card__main:hover {
+.v2-root button.v2-thread-card__main:hover {
   border-color: #d7dce7;
 }
 
@@ -7239,7 +7247,7 @@
   line-height: 1;
 }
 
-.v2-thread-card__follow {
+.v2-root button.v2-thread-card__follow {
   border: none;
   background: transparent;
   cursor: pointer;
@@ -7248,7 +7256,7 @@
   padding: 4px 6px;
 }
 
-.v2-thread-card__follow--on {
+.v2-root button.v2-thread-card__follow--on {
   color: var(--v2-accent);
 }
 
@@ -7261,7 +7269,7 @@
   transition: height 300ms ease;
 }
 
-.v2-thread-replies__aim {
+.v2-root button.v2-thread-replies__aim {
   border: none;
   background: transparent;
   color: #7b8494;
@@ -7270,7 +7278,7 @@
   padding: 6px 0;
 }
 
-.v2-thread-replies__aim:hover {
+.v2-root button.v2-thread-replies__aim:hover {
   color: var(--v2-accent);
 }
 
@@ -7283,13 +7291,13 @@
     margin-left: 24px; /* brief: rail offset drops to 24px at 390 */
   }
 
-  .v2-thread-card__main {
+  .v2-root button.v2-thread-card__main {
     flex-wrap: wrap; /* brief: card goes to two lines at 390 */
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .v2-thread-card__main,
+  .v2-root button.v2-thread-card__main,
   .v2-thread-card__chevron,
   .v2-thread-replies {
     transition: none;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -7165,3 +7165,133 @@
   color: var(--v2-text-muted);
   font-style: italic;
 }
+
+/* ── Threading: headline card + reply rail (W-T 4/4) ────────────────────────
+   Built to @ux-lead's render brief. Numbers here are theirs, not invented:
+   card radius 10 / border #e5e7eb / hover #d7dce7 / no shadow; type 13px
+   secondary with the count at 500; rail 2px #eef0f6 at 28px, replies +40px,
+   dropping to 24px at 390; layout transition 300ms. */
+
+.v2-thread-card {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0 0 0; /* brief: no gap > 8px between root and card */
+}
+
+.v2-thread-card__main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 44px; /* brief: 44px min hit height */
+  padding: 6px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: transparent;
+  box-shadow: none;
+  cursor: pointer;
+  font-size: 13px;
+  color: #4b5563;
+  transition: border-color 300ms ease;
+}
+
+.v2-thread-card__main:hover {
+  border-color: #d7dce7;
+}
+
+.v2-thread-card__count {
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* The card's ONLY accent, and only when something in the thread addresses me.
+   Ambient activity never colours it — that is the whole point of 3/4's
+   ambient/addressed split being visible in the UI rather than only in the
+   wake path. */
+.v2-thread-card--addressed .v2-thread-card__count {
+  color: var(--v2-accent);
+}
+
+.v2-thread-card__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--v2-accent);
+}
+
+.v2-thread-card__faces {
+  display: inline-flex;
+}
+
+.v2-thread-card__faces > * + * {
+  margin-left: -6px; /* brief: overlapping −6px */
+}
+
+.v2-thread-card__time {
+  color: #7b8494;
+}
+
+.v2-thread-card__chevron {
+  transform: rotate(180deg);
+  transition: transform 300ms ease;
+  line-height: 1;
+}
+
+.v2-thread-card__follow {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 12px;
+  color: #7b8494; /* tertiary — the null "Follow" and the false "Muted" */
+  padding: 4px 6px;
+}
+
+.v2-thread-card__follow--on {
+  color: var(--v2-accent);
+}
+
+/* Expanded replies hang off a left rail at the root avatar's centre. */
+.v2-thread-replies {
+  position: relative;
+  margin-left: 28px;
+  padding-left: 40px;
+  border-left: 2px solid #eef0f6;
+  transition: height 300ms ease;
+}
+
+.v2-thread-replies__aim {
+  border: none;
+  background: transparent;
+  color: #7b8494;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 6px 0;
+}
+
+.v2-thread-replies__aim:hover {
+  color: var(--v2-accent);
+}
+
+.v2-chat__reply-chip--thread .v2-chat__reply-chip-label {
+  color: #4b5563;
+}
+
+@media (max-width: 640px) {
+  .v2-thread-replies {
+    margin-left: 24px; /* brief: rail offset drops to 24px at 390 */
+  }
+
+  .v2-thread-card__main {
+    flex-wrap: wrap; /* brief: card goes to two lines at 390 */
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .v2-thread-card__main,
+  .v2-thread-card__chevron,
+  .v2-thread-replies {
+    transition: none;
+  }
+}


### PR DESCRIPTION
TASK-029 **4/4**, the last piece of the threading build order, built to @ux-lead's render brief (57421). Answering their six checklist items directly.

### 1. Card at the root's position, count/avatars/time only, 44px, accent only when addressed
`V2ThreadCard`. No reply bodies, no names — the card is a door, not a preview, and a test asserts the names *don't* leak because that's the thing someone adds later "for context". Measured: `min-height 44px`, `box-shadow none`, border `#e5e7eb`, radius 10, resting colour `#4b5563`, addressed count `#2f6feb`.

### 2. Expand in place, rail geometry, no scroll-jump, 300ms, reduced motion
Rail measured in a real browser at both widths: **28px/40px at 1200, 24px/40px at 390**, border `2px #eef0f6`, chevron `matrix(-1,0,0,-1,0,0)` = 180°. Reduced-motion opt-out present and guarded.

### 3. `collapsed` from the payload, never derived
`useV2ThreadState` takes it straight off #1145. There is deliberately no cutoff in the payload to derive it *from*. A fetch failure degrades to "no threads known" → renders flat; inventing `collapsed:true` on an error would hide replies the user could see a second earlier.

### 4. Composer re-targets, `reply_to` null in-thread, never both chips
One composer, two chip states. `aimAtThread`/`aimAtMessage` each clear the other, so a send carries a thread root **or** an addressing edge — the resolver 400s both, and joining a thread must not ping the root author. Targets clear on success only, so a failed send keeps its aim (#1118).

### 5. Follow renders three states from the raw value, writes one column
`null` → "Follow" (an invitation), `false` → "Muted" (a state), `true` → "Following". `Boolean(null)` collapsing the first two is precisely the bug the tri-state exists to prevent. Follow is a **sibling** of the expand control, not nested — a button inside a button is invalid, and a mis-hit that silently mutes is the expensive direction.

### 6. Real-browser check + presence guard

**The browser check found a real bug that no presence guard could.** Computed colour on `.v2-thread-card__main` was `rgb(17,24,39)` while the rule said `#4b5563`, and `follow--on` rendered at body colour — so Following looked identical to Muted. Cause: `.v2-root button:not(.MuiButtonBase-root)` is 0-2-1 and sets `color: inherit`; my rules were 0-1-0. The repo already documents this trap and its fix next to that reset (#870) — the `.v2-root button.` prefix. **The rule was present, spelled right, with the right value; only the cascade defeated it.**

The guard now pins the *prefixed* selector plus the colour, so dropping the prefix fails in CI instead of silently in production.

Also checked rather than reported: the harness showed horizontal overflow at 390. Removing the harness's own 24px body padding eliminated it (scrollWidth 390 = clientWidth 390) — my test page, not the components. "Probably the harness" is how a real 390 overflow ships.

> Scope note: the browser pass ran against a static harness loading the real `v2.css`, because this code isn't deployed yet — pointing Playwright at commonly.me would have measured the old UI. That covers the geometry and cascade claims and does **not** cover the React integration in a live pod. Worth a post-deploy look.

### Tests

**286 v2 tests green, 34 new.** `shortTime` (boundaries, with `now` injected so the test is about the boundary and not the clock) · `threadView` (fold, dedupe, orphan-renders-flat, newest-reply stamp) · `V2ThreadCard` (items 1 and 5) · `v2-layout-invariants` (rail, no-shadow, no-accent-at-rest, reduced-motion).

`sendMessage` gains a 4th positional. Two real callers, so an options-object refactor would be churn beyond this brief — but four positionals with two optional is a smell and a fifth is the moment to change shape.

`frontend/package-lock.json` was rewritten by my local `npm install` (16,631 insertions) and is deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)