### PR TITLE
fix(i18n): translate thread reply controls

### DIFF
--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -335,7 +335,11 @@
       "uploadFailed": "文件上传失败，请重试。"
     },
     "loadOlder": "加载更早的消息",
-    "loadingOlder": "加载中…"
+    "loadingOlder": "加载中…",
+    "thread": {
+      "replyInThread": "在线程中回复",
+      "replyingInThread": "正在在线程中回复 ·"
+    }
   },
   "landing": {
     "nav": {


### PR DESCRIPTION
## Summary\n- add Simplified Chinese strings for the thread reply action and composer chip\n- restore locale key parity with the 4/4 render branch\n\n## Verification\n- 
> frontend@1.1.0 test
> jest --watchAll=false --forceExit --runInBand src/i18n/__tests__/translationKeys.test.ts