### PR TITLE
test(threading): one identity per seat in the scoping fixture, and a guard

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.threadScoping.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.threadScoping.test.js
@@ -20,7 +20,7 @@ jest.mock('../../../services/chatSummarizerService', () => ({
 jest.mock('../../../models/AgentEvent', () => ({ countDocuments: jest.fn() }));
 jest.mock('../../../services/welcomeWakeService', () => ({ maybeFireWelcomeWake: jest.fn() }));
 jest.mock('../../../models/pg/Message', () => ({
-  findById: jest.fn(async (id) => (String(id) === '101' ? { id: 101, user_id: 'bot-1' } : null)),
+  findById: jest.fn(async (id) => (String(id) === '101' ? { id: 101, user_id: 'bot-user-a' } : null)),
 }));
 jest.mock('../../../models/pg/ThreadUserState', () => ({
   followByParticipation: jest.fn(),
@@ -39,6 +39,7 @@ const User = require('../../../models/User');
 const AgentEvent = require('../../../models/AgentEvent');
 const { narrowToThread } = require('../../../services/threadWakeScopeService');
 const ThreadUserState = require('../../../models/pg/ThreadUserState');
+const PGMessage = require('../../../models/pg/Message');
 
 // `installedBy` is deliberately a DIFFERENT id from the bot's User row here.
 // It is the human installer on five of the write paths (podController:119,
@@ -54,6 +55,17 @@ const optIn = (agentName, installedBy) => ({
   config: { wakeOnMessage: { enabled: true } },
 });
 
+// ONE id per agent across the whole fixture. @sprint-review (57037): seat-a
+// used to be `bot-1` through User.findById (as the thread root's author) and
+// `bot-user-a` through User.find (as a wake target) — the same agent with two
+// identities depending on which lookup you went through. Nothing asserted the
+// difference, so nothing failed; but a later test asking "is the seat that
+// authored the root scoped out?" would have got contradictory answers from
+// the two paths and read it as a scoping bug rather than a fixture bug.
+//
+// That is the same shape as the defect this suite exists for: an identity
+// fixture that quietly disagrees with itself cannot discriminate a correct
+// key from a wrong one.
 const BOT_USER_ROWS = [
   { _id: 'bot-user-a', botMetadata: { agentName: 'seat-a', instanceId: 'default' } },
   { _id: 'bot-user-b', botMetadata: { agentName: 'seat-b', instanceId: 'default' } },
@@ -79,18 +91,42 @@ beforeEach(() => {
   AgentProfile.find.mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
   Pod.findById.mockReturnValue({
     select: jest.fn().mockReturnValue({
-      lean: jest.fn().mockResolvedValue({ type: 'chat', members: ['user-1', 'bot-1'] }),
+      lean: jest.fn().mockResolvedValue({ type: 'chat', members: ['user-1', 'bot-user-a'] }),
     }),
     lean: jest.fn().mockResolvedValue({ _id: 'pod-1', type: 'chat', members: ['user-1'] }),
   });
   User.findById.mockImplementation((id) => ({
     select: jest.fn().mockReturnThis(),
-    lean: jest.fn().mockResolvedValue(String(id) === 'bot-1'
-      ? { _id: 'bot-1', isBot: true, botMetadata: { agentName: 'seat-a', instanceId: 'default' } }
+    lean: jest.fn().mockResolvedValue(String(id) === 'bot-user-a'
+      ? { _id: 'bot-user-a', isBot: true, botMetadata: { agentName: 'seat-a', instanceId: 'default' } }
       : { _id: 'user-1', isBot: false }),
   }));
   AgentEvent.countDocuments.mockResolvedValue(0);
   ThreadUserState.followByParticipation.mockResolvedValue(true);
+});
+
+describe('the fixture agrees with itself about who seat-a is', () => {
+  // @sprint-review (57037) found seat-a carrying two ids: `bot-1` through
+  // User.findById and `bot-user-a` through User.find. Renaming them to match
+  // is hygiene, and hygiene drifts — probed it, and reintroducing the split
+  // passes 18/18, so nothing here would have caught it coming back.
+  //
+  // This is that consistency made executable. It is a test ABOUT THE FIXTURE,
+  // which is unusual and deliberate: the suite's whole subject is which id a
+  // seat is keyed by, so a fixture that disagrees with itself cannot tell a
+  // correct key from a wrong one — exactly the defect that let `installedBy`
+  // look right for as long as it did.
+  test('the root author resolves to the same id User.find maps seat-a to', async () => {
+    const viaFind = BOT_USER_ROWS
+      .find((r) => r.botMetadata.agentName === 'seat-a')._id;
+
+    const rootAuthorId = (await PGMessage.findById('101')).user_id;
+    const viaFindById = await User.findById(rootAuthorId).select().lean();
+
+    expect(viaFindById.botMetadata.agentName).toBe('seat-a');
+    expect(viaFindById._id).toBe(viaFind);
+    expect(rootAuthorId).toBe(viaFind);
+  });
 });
 
 describe('the hook fires only for threaded messages', () => {
@@ -202,7 +238,7 @@ describe('scoping cannot reach the addressing path', () => {
     narrowToThread.mockImplementation(async () => []);
     await send(
       {
-        id: 'm8', content: 'replying', thread_root_id: 101, replyTo: { userId: 'bot-1' }, 
+        id: 'm8', content: 'replying', thread_root_id: 101, replyTo: { userId: 'bot-user-a' }, 
       },
       { replyToMessageId: '101' },
     );
@@ -270,7 +306,7 @@ describe('a delivered thread mention follows by participation', () => {
   test('a reply edge is addressing, not an explicit mention, so it does not create a follow', async () => {
     await send(
       {
-        id: 'm13', content: 'replying', thread_root_id: 101, replyTo: { userId: 'bot-1' },
+        id: 'm13', content: 'replying', thread_root_id: 101, replyTo: { userId: 'bot-user-a' },
       },
       { replyToMessageId: '101' },
     );


### PR DESCRIPTION
@sprint-review (57037) found seat-a carrying **two user ids in one fixture**: `bot-1` through `User.findById`, where it authors the thread root, and `bot-user-a` through `User.find`, where it's a wake target. Same agent, two identities, depending which lookup you went through.

Nothing asserted the difference, so nothing failed. But this suite's entire subject is *which id a seat is keyed by*, and **a fixture that disagrees with itself cannot tell a correct key from a wrong one** — which is the same shape as the defect it was written for. `installedBy` looked right for as long as it did precisely because the fixture gave it the same value as the bot's row.

### The rename alone wasn't enough

Unified to `bot-user-a`, then probed it — because a rename that changes no outcome might mean the fixture never exercised identity at all. It didn't: **reintroducing the split passed 18/18.** Hygiene that cannot fail is a comment.

So the consistency is now executable: one test asserts the root author's id equals the id `User.find` maps seat-a to, reached *through the mocked lookups* rather than by reading the constants back.

| Probe | Result |
|---|---|
| Split `findById`'s id | kills exactly the new guard |
| Split `BOT_USER_ROWS` | kills the guard **plus three behaviour tests** |

That asymmetry is right: the second is a genuine mis-keying and should take more with it.

A test *about a fixture* is unusual, and deliberate. 19 pass.

### Not established

A full `__tests__/unit/{services,models}` run on my machine reports **14 failed suites / 18 failed tests**. I have not shown whether any are mine.

They're almost certainly the Node 26 class in AX entry 43 — this diff is one test file, and the failing suites don't import it — but "almost certainly" is exactly the reasoning that entry warns about, and my background runs to confirm it were killed. CI at Node 22 gets to answer rather than me. If it's green, that's the answer; if not, I'll chase whatever it names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)