### PR TITLE
fix(threading): the image path skipped the thread, and a comment was false

### DIFF
--- a/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
@@ -118,9 +118,10 @@ describe('V2PodChat composer send button', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
     await waitFor(() => {
-      // Reply-to-person sets the addressing edge and NOT the thread root —
-      // the two are mutually exclusive at the composer, and the resolver 400s
-      // a message carrying both.
+      // Reply-to-person sets the addressing edge and NOT the thread root.
+      // Exclusive at the composer for a semantic reason — an in-thread post
+      // must not ping the root author — and NOT because the backend refuses
+      // the pair; it only refuses a pair that disagrees.
       expect(detail.sendMessage).toHaveBeenCalledWith('I am checking it now.', 'text', 'm1', undefined);
     });
 
@@ -142,8 +143,11 @@ describe('V2PodChat composer send button', () => {
   // W-T 4/4, constraint 4 (docs/design/threading-surface-ruling.md; ux-lead
   // 57449): the composer has ONE target with two kinds. "Reply in thread"
   // sends threadRootId and NO reply edge; "Reply to <person>" sends the reply
-  // edge and NO thread root; aiming at one clears the other. The resolver
-  // 400s a message carrying both, so these pin the client never builds one.
+  // edge and NO thread root; aiming at one clears the other.
+  //
+  // These pin it CLIENT-SIDE because nothing else does: the resolver rejects
+  // the pair only when the two disagree, so a message carrying both that
+  // happen to agree sails through and silently pings the root author.
   const threadMessages = () => ([
     {
       id: 'm1',
@@ -207,6 +211,35 @@ describe('V2PodChat composer send button', () => {
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
     await waitFor(() => {
       expect(detail.sendMessage).toHaveBeenLastCalledWith('reply wins', 'text', 'm2', undefined);
+    });
+  });
+
+  test('an image upload carries the thread target too', async () => {
+    // The regression @sprint-review caught on #1150: the TEXT path passed the
+    // thread root and the image path did not, so uploading a picture while
+    // the composer read "Replying in thread" posted it to the channel. Two
+    // send sites, one of them updated — the classic shape, and there was no
+    // test on this path at all, which is why it was missed.
+    const axios = require('axios');
+    axios.post.mockImplementation((url: string) => (
+      String(url).includes('/api/uploads')
+        ? Promise.resolve({ data: { kind: 'image', url: 'https://cdn/x.png' } })
+        : Promise.resolve({ data: {} })
+    ));
+
+    const detail = makeDetail({ messages: threadMessages() });
+    const { container } = renderChat(detail);
+
+    fireEvent.click(screen.getByRole('button', { name: /reply in thread/i }));
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['x'], 'x.png', { type: 'image/png' });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(detail.sendMessage).toHaveBeenCalledWith(
+        'https://cdn/x.png', 'image', undefined, 'm1',
+      );
     });
   });
 });

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -278,6 +278,14 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
     setReplyTarget(m);
   }, []);
 
+  // Memoized: it was called in the render body, so every keystroke in the
+  // composer re-folded the whole message list. @sprint-review on #1150.
+  // Recomputes only when the messages or the thread state actually change.
+  const threadView = useMemo(
+    () => buildThreadView(messages, threadState.byRoot),
+    [messages, threadState.byRoot],
+  );
+
   // @-mention dropdown state. mentionStart is the index of the `@` in the
   // textarea so we know the slice to replace on select.
   const [mentionOpen, setMentionOpen] = useState(false);
@@ -839,7 +847,13 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
     try {
       // reply_to and thread_root are mutually exclusive by construction here:
       // aimAtThread/aimAtMessage each clear the other, so at most one is set.
-      // The resolver 400s a message carrying both rather than choosing.
+      //
+      // The reason is SEMANTIC, not that the backend would refuse the pair.
+      // It would not: resolveThreadRoot 400s only when the two DISAGREE
+      // (thread_root_mismatch) and accepts them when they agree. An in-thread
+      // post must carry no addressing edge because a reply edge pings the
+      // root's author (@ux-lead 56879) — that is the rule this enforces, and
+      // it is the client's to keep.
       const created = await sendMessage(
         text,
         'text',
@@ -934,7 +948,12 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
         headers: { 'Content-Type': 'multipart/form-data' },
       });
       if (uploaded.kind === 'image' && uploaded.url) {
-        await sendMessage(uploaded.url, 'image');
+        // Carries the thread target too. Without it, uploading an image while
+        // aimed at a thread posted it to the channel instead — the composer
+        // showed "Replying in thread" and the picture landed somewhere else.
+        // @sprint-review caught it on #1150; the text path had it and this one
+        // was simply missed.
+        await sendMessage(uploaded.url, 'image', undefined, threadTarget?.id || undefined);
         return;
       }
       if (uploaded.fileName) {
@@ -1197,7 +1216,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                   )}
                 </div>
               )}
-              {buildThreadView(messages, threadState.byRoot).map((item, i, view) => {
+              {threadView.map((item, i, view) => {
                 if (item.kind === 'message') {
                   const m = item.message;
                   const prev = view[i - 1];

--- a/frontend/src/v2/hooks/useV2PodDetail.ts
+++ b/frontend/src/v2/hooks/useV2PodDetail.ts
@@ -140,8 +140,13 @@ export interface UseV2PodDetailResult {
   refresh: () => Promise<void>;
   // `threadRootId` posts INTO a thread without addressing anyone: the backend
   // takes it as membership and leaves reply_to null, so joining a thread does
-  // not ping the root's author (@ux-lead 56879, resolver in #1128). Passing
-  // both is a caller bug and the resolver 400s it rather than picking.
+  // not ping the root's author (@ux-lead 56879, resolver in #1128).
+  //
+  // Passing both is a caller bug, but NOT one the backend catches: the
+  // resolver 400s the pair only when they DISAGREE, and returns happily when
+  // a reply edge and an explicit root point at the same thread. Keeping them
+  // exclusive is therefore the client's job and nothing downstream will
+  // notice if it stops.
   sendMessage: (
     content: string,
     messageType?: string,

--- a/frontend/src/v2/utils/threadView.ts
+++ b/frontend/src/v2/utils/threadView.ts
@@ -42,6 +42,11 @@ export const buildThreadView = (
   messages: V2Message[],
   byRoot: Map<string, V2ThreadState>,
 ): ThreadViewItem[] => {
+  // Ids up front. This used to be `messages.some(...)` inside the loop below,
+  // which is O(n²) on a pod's whole scrollback — fine at 20 messages and not
+  // at 2,000. @sprint-review on #1150.
+  const presentIds = new Set(messages.map(idOf));
+
   const repliesByRoot = new Map<string, V2Message[]>();
   for (const m of messages) {
     const root = rootOf(m);
@@ -49,7 +54,7 @@ export const buildThreadView = (
     // A message whose root is not in this list (paged out, or deleted) is NOT
     // hidden. It renders flat rather than vanishing — losing a message is the
     // one outcome worse than showing it in the wrong place.
-    if (!messages.some((x) => idOf(x) === root)) continue;
+    if (!presentIds.has(root)) continue;
     const bucket = repliesByRoot.get(root);
     if (bucket) bucket.push(m);
     else repliesByRoot.set(root, [m]);


### PR DESCRIPTION
@sprint-review's three non-blocking follow-ups on #1150 (57467). All three were real; one was worse than reported.

### 1. The image path sent no thread target

The text send passed the root; the upload send didn't. So posting a picture while the composer read **"Replying in thread"** put it in the channel instead. Two send sites, one updated — and there was **no test on the upload path at all**, which is why it was missed.

Fixed, with a test that fails when the fix is reverted (probed both ways).

### 2. "The resolver 400s a message carrying both" is false — in four places, not three

`resolveThreadRoot` rejects the pair **only when they disagree** (`thread_root_mismatch`). A reply edge and an explicit root pointing at the same thread are accepted happily.

That inverts what the composer's exclusivity is *for*. It isn't a client nicety in front of a backend that would refuse the pair — **it's the only thing enforcing it.** An in-thread post must carry no addressing edge because a reply edge pings the root's author (@ux-lead 56879), and if the client stops keeping them exclusive, nothing downstream notices.

All four comments now say that, and the test comment says the client is the sole guard rather than implying the server is a backstop.

I counted the copies rather than trusting the number in the report — four, not three. Same lesson as this morning, pointed the other way for once.

### 3. `buildThreadView` was O(n²) *and* unmemoized

Two problems, both fixed. Memoized on `(messages, byRoot)` so a composer keystroke no longer re-folds the whole list, and the `messages.some(...)` inside the loop is now a `Set` built once — fine at 20 messages, not at 2,000.

---

**77 suites, 416 tests green** — the whole frontend suite, no path filter. That habit is three days old and one PR old; running a subset is what put two of today's failures into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)