### PR TITLE
test(threading): the writer/reader seam had no reader, and one side faked it

### DIFF
--- a/backend/__tests__/unit/services/threadScopingSeam.test.js
+++ b/backend/__tests__/unit/services/threadScopingSeam.test.js
@@ -1,0 +1,129 @@
+/**
+ * The one edge nothing read: does the id the WAKE PATH keys on match the id
+ * the WRITER stored? (W-T, TASK-029, 3/4.)
+ *
+ * @sprint-review (57122): both existing suites are blind to this join.
+ * `agentMentionService.threadScoping.test.js` mocks `threadWakeScopeService`
+ * outright, so it never runs the real narrowing. `threadWakeScope.test.js`
+ * runs the real narrowing but supplies its OWN `identify` — and that stand-in
+ * is `(t) => t.installedBy`, which is the keying production stopped using
+ * after it turned out `installedBy` is the human installer on half the write
+ * paths. So the algebra is verified against a function embodying the exact
+ * defect the production code was fixed for.
+ *
+ * Writer well tested. Narrowing well tested. Join untested, and one side's
+ * test double still encodes the bug. That is review-checklist §7's phantom
+ * cross-layer contract: each layer is correct against its own idea of the
+ * other.
+ *
+ * This suite runs BOTH real halves against one pg-mem database:
+ *   ThreadUserState.follow / unfollow / followByParticipation  (writer)
+ *   effectiveFollowerIds + narrowToThread                      (reader)
+ * with the keying function shaped like the production one — resolving a bot
+ * User row id — rather than reaching for `installedBy`.
+ */
+const { newDb } = require('pg-mem');
+const { applyTable } = require('../../utils/schemaTable');
+
+const mockDb = newDb();
+const mockPool = new (mockDb.adapters.createPg().Pool)();
+jest.mock('../../../config/db-pg', () => ({ pool: mockPool }));
+
+const ThreadUserState = require('../../../models/pg/ThreadUserState');
+const { narrowToThread } = require('../../../services/threadWakeScopeService');
+
+const POD = 'pod-1';
+// The two identity spaces the production bug confused. They must stay
+// DIFFERENT here or this suite cannot discriminate a correct key either.
+const SEAT = { agentName: 'seat-a', instanceId: 'default', installedBy: 'human-who-installed-it' };
+const SEAT_BOT_USER = 'bot-user-a';
+const OTHER = { agentName: 'seat-b', instanceId: 'default', installedBy: 'another-human' };
+const OTHER_BOT_USER = 'bot-user-b';
+
+// Production shape: map an install to its BOT's User row id. Never installedBy.
+const botUserIds = new Map([
+  ['seat-a:default', SEAT_BOT_USER],
+  ['seat-b:default', OTHER_BOT_USER],
+]);
+const identify = (inst) => botUserIds.get(
+  `${String(inst.agentName || '').toLowerCase()}:${String(inst.instanceId || 'default')}`,
+) ?? null;
+
+let root = 500;
+const nextRoot = async () => {
+  root += 1;
+  await mockPool.query(
+    "INSERT INTO messages (id, pod_id, user_id, content) VALUES ($1,$2,'someone','root')",
+    [root, POD],
+  );
+  return root;
+};
+
+beforeAll(async () => {
+  await applyTable(mockPool, 'pods');
+  await applyTable(mockPool, 'users');
+  await applyTable(mockPool, 'messages');
+  await applyTable(mockPool, 'thread_user_state');
+  await mockPool.query(
+    "INSERT INTO pods (id, name, type, created_by) VALUES ($1,'P','chat','u')", [POD],
+  );
+});
+
+describe('the writer and the wake path agree on the key', () => {
+  test('a follow written under the BOT user id is honoured by the narrowing', async () => {
+    const r = await nextRoot();
+    await ThreadUserState.follow(r, SEAT_BOT_USER, POD);
+
+    const kept = await narrowToThread(r, [SEAT, OTHER], identify);
+
+    expect(kept).toEqual([SEAT]);
+  });
+
+  test('a mute written under the BOT user id removes that seat', async () => {
+    const r = await nextRoot();
+    await ThreadUserState.follow(r, SEAT_BOT_USER, POD);
+    await ThreadUserState.follow(r, OTHER_BOT_USER, POD);
+    await ThreadUserState.unfollow(r, SEAT_BOT_USER, POD);
+
+    const kept = await narrowToThread(r, [SEAT, OTHER], identify);
+
+    expect(kept).toEqual([OTHER]);
+  });
+
+  test('participation written by the mention path is honoured too', async () => {
+    // followByParticipation is the write #1136 wired; it must key the same way.
+    const r = await nextRoot();
+    await ThreadUserState.followByParticipation(r, SEAT_BOT_USER, POD);
+
+    const kept = await narrowToThread(r, [SEAT, OTHER], identify);
+
+    expect(kept).toEqual([SEAT]);
+  });
+
+  test('THE JOIN: writing under installedBy does NOT reach the seat', async () => {
+    // The discriminating case, and the reason this file exists. If the writer
+    // and the reader disagreed about the key — which is exactly what shipped
+    // before #1120's fix, and what threadWakeScope.test.js's local `identify`
+    // still assumes — the row would be written somewhere the narrowing never
+    // looks, and the seat would be silently dropped from its own thread.
+    const r = await nextRoot();
+    await ThreadUserState.follow(r, SEAT.installedBy, POD);
+
+    const kept = await narrowToThread(r, [SEAT, OTHER], identify);
+
+    expect(kept).toEqual([]);
+    // And to be explicit about which direction the failure runs: the seat is
+    // not merely un-followed, it is invisible to a thread it opted into.
+    expect(kept).not.toContain(SEAT);
+  });
+
+  test('an unresolvable seat is KEPT, so a keying gap degrades to noise not silence', async () => {
+    const r = await nextRoot();
+    await ThreadUserState.follow(r, SEAT_BOT_USER, POD);
+    const unknown = { agentName: 'seat-c', instanceId: 'default', installedBy: 'x' };
+
+    const kept = await narrowToThread(r, [SEAT, unknown], identify);
+
+    expect(kept).toEqual([SEAT, unknown]);
+  });
+});

--- a/backend/__tests__/unit/services/threadWakeScope.test.js
+++ b/backend/__tests__/unit/services/threadWakeScope.test.js
@@ -121,8 +121,17 @@ describe('the three terms', () => {
 });
 
 describe('narrowToThread only ever narrows', () => {
-  const inst = (name, uid) => ({ agentName: name, installedBy: uid });
-  const identify = (t) => t.installedBy || null;
+  const inst = (name, uid) => ({ agentName: name, botUserId: uid });
+  // NOT `installedBy`. Production keys on the bot's User row id, resolved from
+  // botMetadata — `installedBy` is the HUMAN installer on half the write paths,
+  // which is the bug #1120 fixed. A local stand-in that still says installedBy
+  // makes this suite's algebra correct against a keying nothing uses.
+  //
+  // Kept as an opaque per-target id here, because this file is about the SET
+  // ARITHMETIC and should not care what the key means. Whether the key matches
+  // what the writer stored is a different question, and it now has its own
+  // reader: threadScopingSeam.test.js (@sprint-review 57122).
+  const identify = (t) => t.botUserId || null;
 
   test('an unthreaded message is untouched', async () => {
     const targets = [inst('a', 'u1'), inst('b', 'u2')];


### PR DESCRIPTION
@sprint-review (57122) named this gap and it is **still open on main eleven hours later**.

Both suites that touch `narrowToThread` are blind to the join:
- `agentMentionService.threadScoping.test.js` **mocks `threadWakeScopeService` outright** — never runs the real narrowing.
- `threadWakeScope.test.js` runs the real narrowing but supplies its **own `identify`**.

### Worse than reported

That local stand-in was `(t) => t.installedBy` — the keying production **stopped using**. `installedBy` is the human installer on half the write paths; that's the bug #1120 fixed. So the narrowing algebra was verified against a function embodying the exact defect the production code was corrected for, and nothing anywhere asked whether the id the reader keys on matches the id the writer stored.

Writer tested. Narrowing tested. **Join untested, with one side's double still encoding the bug.** Review-checklist §7's phantom cross-layer contract: each layer correct against its own idea of the other.

### The seam test

`threadScopingSeam.test.js` runs **both real halves against one pg-mem database** — `ThreadUserState.follow / unfollow / followByParticipation` writing, `effectiveFollowerIds + narrowToThread` reading — with the two identity spaces held deliberately **distinct**, because a fixture where they coincide can't discriminate a correct key from a wrong one. Same discipline #1152 added one layer down.

The discriminating case writes the row under `installedBy` and asserts the seat is **not** reached. If writer and reader disagreed, the row would land where the narrowing never looks and the seat would go **silently invisible inside a thread it opted into**.

**Probe:** reverting `identify` to `installedBy` kills all five — the derived expectation, since every case depends on the two spaces differing.

### Also

Retired the stand-in in `threadWakeScope.test.js`; its fixture field is now `botUserId`, opaque on purpose. That suite is about set arithmetic and shouldn't have an opinion about what the key *means* — whether it matches the writer is now a different file's job.

**287 tests across 20 threading suites green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)