### PR TITLE
fix(threading): 4/4 render follow-ups — image targets, quote rule, alignment

### DIFF
--- a/frontend/src/v2/__tests__/V2MessageBubbleQuote.test.tsx
+++ b/frontend/src/v2/__tests__/V2MessageBubbleQuote.test.tsx
@@ -1,0 +1,83 @@
+// @ts-nocheck
+// Quote suppression inside a thread rail — TASK-049 item 2, ruling
+// constraint 5 (Sam 57491): hide the quote IFF it points at the root of the
+// rail we are already inside.
+//
+// Four cells, because the predicate is a conjunction and neither half is
+// sufficient. The two that matter are the ones where a careless version
+// (`inThread ? hide : show`) gets it wrong: quoting a PERSON inside a rail,
+// and quoting the root while rendered FLAT.
+//
+// Asymmetric on purpose: a redundant quote is noise, a missing one loses the
+// only pointer to what a message answers.
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2MessageBubble from '../components/V2MessageBubble';
+
+jest.mock('../components/V2Avatar', () => () => <span data-testid="avatar" />);
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ currentUser: { _id: 'u1', username: 'me' }, token: 't' }),
+}));
+jest.mock('../hooks/useV2Api', () => ({ useV2Api: () => ({ get: jest.fn(), post: jest.fn() }) }));
+
+const msg = (replyToId, replyAuthor) => ({
+  id: 'm9',
+  pod_id: 'p1',
+  user_id: 'u2',
+  content: 'the reply body',
+  message_type: 'text',
+  created_at: '2026-08-23T00:00:00Z',
+  user: { username: 'other', isBot: false },
+  replyTo: { id: replyToId, content: 'the quoted text', username: replyAuthor },
+});
+
+const show = (props) => render(
+  <MemoryRouter><V2MessageBubble message={msg('root-1', 'rootauthor')} {...props} /></MemoryRouter>,
+);
+
+describe('the quote is hidden only when the rail already supplies its context', () => {
+  test('inside the rail, quoting THAT root — hidden', () => {
+    show({ insideThreadRoot: 'root-1' });
+    expect(screen.queryByText(/the quoted text/)).not.toBeInTheDocument();
+    // The message itself still renders; only the quote is suppressed.
+    expect(screen.getByText(/the reply body/)).toBeInTheDocument();
+  });
+
+  test('inside the rail, quoting SOMEONE ELSE — shown', () => {
+    // A reply-to-person within a thread. The quote is the only thing naming
+    // who is being answered, so suppressing it would lose the addressee.
+    render(
+      <MemoryRouter>
+        <V2MessageBubble message={msg('m-other', 'someoneelse')} insideThreadRoot="root-1" />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/the quoted text/)).toBeInTheDocument();
+  });
+
+  test('quoting the root but rendered FLAT in the channel — shown', () => {
+    // No rail supplying context. Hiding here strands the reply.
+    show({});
+    expect(screen.getByText(/the quoted text/)).toBeInTheDocument();
+  });
+
+  test('no quote at all is still no quote', () => {
+    render(
+      <MemoryRouter>
+        <V2MessageBubble message={{ ...msg('root-1', 'a'), replyTo: null }} insideThreadRoot="root-1" />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText(/the quoted text/)).not.toBeInTheDocument();
+  });
+
+  test('a numeric id from the wire still matches a string root', () => {
+    // thread_root_id arrives as a number from PG and rootId is stringified in
+    // the view. An === on mixed types would silently never suppress.
+    render(
+      <MemoryRouter>
+        <V2MessageBubble message={msg(101, 'rootauthor')} insideThreadRoot="101" />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText(/the quoted text/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
@@ -242,4 +242,60 @@ describe('V2PodChat composer send button', () => {
       );
     });
   });
+
+  // ── TASK-049 items 1 and 4: the image path is a second send site ──────────
+  const mockUpload = () => {
+    const axios = require('axios');
+    axios.post.mockImplementation((url: string) => (
+      String(url).includes('/api/uploads')
+        ? Promise.resolve({ data: { kind: 'image', url: 'https://cdn/x.png' } })
+        : Promise.resolve({ data: {} })
+    ));
+  };
+  const upload = (container: HTMLElement) => {
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [new File(['x'], 'x.png', { type: 'image/png' })] } });
+  };
+
+  test('an image upload carries the REPLY edge when aimed at a person', async () => {
+    // @ux-lead 57473. #1150 wired the thread root on this line and left the
+    // reply edge hardcoded undefined, so the chip read "Replying to {name}"
+    // and the picture posted unrouted. The other half of the same line.
+    mockUpload();
+    const detail = makeDetail({ messages: threadMessages() });
+    const { container } = renderChat(detail);
+
+    fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
+    upload(container);
+
+    await waitFor(() => {
+      expect(detail.sendMessage).toHaveBeenCalledWith(
+        'https://cdn/x.png', 'image', 'm2', undefined,
+      );
+    });
+  });
+
+  test('a successful image send consumes the target, so it cannot leak to the next send', async () => {
+    // The ruling says a send consumes the target on EVERY path. The image path
+    // did not, so an aim survived a completed send and silently applied again.
+    mockUpload();
+    const detail = makeDetail({ messages: threadMessages() });
+    const { container } = renderChat(detail);
+
+    fireEvent.click(screen.getByRole('button', { name: /reply in thread/i }));
+    upload(container);
+    await waitFor(() => expect(detail.sendMessage).toHaveBeenCalledTimes(1));
+
+    // The chip is gone, and a following text send carries no target at all.
+    await waitFor(() => {
+      expect(screen.queryByText(/replying in thread/i)).not.toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+      target: { value: 'unaimed' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+    await waitFor(() => {
+      expect(detail.sendMessage).toHaveBeenLastCalledWith('unaimed', 'text', undefined, undefined);
+    });
+  });
 });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -456,14 +456,26 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // correct rail from a missing one — the card and replies still appear,
     // just unindented and with no rule. This pins the three numbers that a
     // reader would otherwise have to take from a comment.
+    // REV 2 (@ux-lead, thread-reply-row-alignment rev 2, TASK-049 item 3).
+    // These numbers are inverted from rev 1 and the ruling authorises it:
+    // the root avatar is .v2-avatar--md = 30px inside a 38px column, so its
+    // centre is x = 15, not 19. margin-left 14 + the 2px border puts the rule
+    // through that centre. rev 1 measured the column and not the avatar.
     const rail = ruleBody(v2, '.v2-thread-replies');
-    expect(rail).toContain('margin-left: 28px');
-    expect(rail).toContain('padding-left: 40px');
+    expect(rail).toContain('margin-left: 14px');
+    expect(rail).toContain('padding-left: 12px');
     expect(rail).toContain('border-left: 2px solid #eef0f6');
 
-    // The 390 override lives in a media block, so read the file rather than
-    // the rule body — ruleBody stops at the first closing brace.
-    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-replies\s*\{[\s\S]*?margin-left: 24px/);
+    // ONE inner column for every reply: 16 + 12 + 24 + 8 = x = 60. Reusing the
+    // channel's 38px+12px grid is what opened a second text column, so the
+    // override is the fix and pinning it is the point.
+    const railRow = ruleBody(v2, '.v2-thread-replies .v2-msg');
+    expect(railRow).toContain('grid-template-columns: 24px minmax(0, 1fr)');
+    expect(railRow).toContain('gap: 8px');
+
+    // 390: the AXIS does not move (no channel-row override at this
+    // breakpoint), only the inner padding tightens to give x = 56.
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-replies\s*\{[\s\S]*?margin-left: 14px[\s\S]*?padding-left: 8px/);
   });
 
   test('the thread card has no shadow and no accent at rest', () => {

--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -84,6 +84,17 @@ interface V2MessageBubbleProps {
   // Clicking the author avatar / name opens the inspector to that member's
   // detail sub-page. Passed in by V2PodChat; only fires for agent authors.
   onAuthorClick?: (author: string) => void;
+  /**
+   * The root this bubble is being rendered UNDER, when it sits inside an
+   * expanded thread rail. Undefined everywhere else, including for the same
+   * message rendered flat in the channel.
+   *
+   * Only used to suppress a quote that would restate the context the rail
+   * already provides — see the predicate at the quote block. Deliberately not
+   * a boolean like `inThread`: the suppression has to compare the quote's
+   * target to THIS root, and a boolean cannot express "the right root".
+   */
+  insideThreadRoot?: string;
   // Clicking a file pill routes to the inspector artifact preview by
   // ObjectStore filename (or originalName for static demo tokens).
   onOpenFile?: (fileName: string) => void;
@@ -293,7 +304,7 @@ const parseAgentDmEvent = (content: string | undefined): { headline: string; tar
 // columns in mobile shells.
 const REACTION_PALETTE = ['👍', '❤️', '🔥', '🤔', '👀', '🚀'];
 
-const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agentDisplayNames, agentAuthorKeys, onAuthorClick, onOpenFile, onReply, grouped }) => {
+const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agentDisplayNames, agentAuthorKeys, onAuthorClick, onOpenFile, onReply, grouped, insideThreadRoot }) => {
   const { currentUser } = useAuth();
   const navigate = useNavigate();
   const api = useV2Api();
@@ -411,7 +422,7 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
           <V2Avatar
             name={author}
             src={message.user?.profile_picture || undefined}
-            size="md"
+            size={insideThreadRoot ? 'sm' : 'md'}
             kind={typeof message.user?.isBot === 'boolean' ? (message.user.isBot ? 'agent' : 'human') : undefined}
             seed={message.user_id || undefined}
           />
@@ -420,7 +431,7 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
         <V2Avatar
           name={author}
           src={message.user?.profile_picture || undefined}
-          size="md"
+          size={insideThreadRoot ? 'sm' : 'md'}
           kind={typeof message.user?.isBot === 'boolean' ? (message.user.isBot ? 'agent' : 'human') : undefined}
           seed={message.user_id || undefined}
         />
@@ -470,6 +481,27 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
             : rawQuote;
           const quoteAuthor = message.replyTo?.username ?? message.reply_username;
           if (!quoteContent) return null;
+
+          // Suppress the quote IFF it points at the root of the rail we are
+          // already inside (Sam 57491, ruling constraint 5). Both halves are
+          // required and neither is sufficient:
+          //
+          //   - inside a rail, quoting SOMEONE ELSE in the thread  -> show.
+          //     That is a reply-to-person and the quote is the only thing
+          //     naming who.
+          //   - quoting the root but rendered FLAT in the channel   -> show.
+          //     There is no rail supplying the context, so removing the quote
+          //     would strand the reply.
+          //
+          // The failure mode of getting this wrong is asymmetric: showing a
+          // redundant quote is visual noise, hiding a needed one loses the
+          // only pointer to what a message answers.
+          const quoteTargetId = message.replyTo?.id ?? message.reply_msg_id;
+          const quotesTheRailRoot = insideThreadRoot !== undefined
+            && quoteTargetId !== undefined
+            && quoteTargetId !== null
+            && String(quoteTargetId) === String(insideThreadRoot);
+          if (quotesTheRailRoot) return null;
           return (
             <div className="v2-msg__quote">
               <span className="v2-msg__quote-author">{quoteAuthor || 'earlier message'}</span>

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -948,12 +948,31 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
         headers: { 'Content-Type': 'multipart/form-data' },
       });
       if (uploaded.kind === 'image' && uploaded.url) {
-        // Carries the thread target too. Without it, uploading an image while
-        // aimed at a thread posted it to the channel instead — the composer
-        // showed "Replying in thread" and the picture landed somewhere else.
-        // @sprint-review caught it on #1150; the text path had it and this one
-        // was simply missed.
-        await sendMessage(uploaded.url, 'image', undefined, threadTarget?.id || undefined);
+        // BOTH targets, and consumed on success — the image path is a second
+        // send site and has now been half-updated twice. #1150 gave it the
+        // thread root and left `replyTarget` hardcoded undefined (@ux-lead
+        // 57473), so aiming at a person and uploading posted the picture
+        // unrouted while the chip still read "Replying to {name}". And it
+        // never cleared its targets, so the aim survived a completed send and
+        // silently applied to the next one.
+        //
+        // Safe by construction rather than by care: aimAtThread and
+        // aimAtMessage each clear the other, so the two can never both be set
+        // and the resolver never sees a pair.
+        //
+        // The rule the ruling states is "a send consumes the target on EVERY
+        // path" — written that way precisely because per-path wiring is what
+        // keeps going wrong here.
+        const created = await sendMessage(
+          uploaded.url,
+          'image',
+          replyTarget?.id || undefined,
+          threadTarget?.id || undefined,
+        );
+        if (created) {
+          setReplyTarget(null);
+          setThreadTarget(null);
+        }
         return;
       }
       if (uploaded.fileName) {
@@ -1275,6 +1294,10 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                             onOpenFile={onOpenFile}
                             onReply={aimAtMessage}
                             grouped={isGroupedWithPrevious(r, item.replies[ri - 1])}
+                            // Only the rail passes this. The same message
+                            // rendered flat keeps its quote, which is the
+                            // half of constraint 5 that is easy to lose.
+                            insideThreadRoot={item.rootId}
                           />
                         ))}
                         {!isReadOnly && (

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -7261,12 +7261,50 @@
 }
 
 /* Expanded replies hang off a left rail at the root avatar's centre. */
+/* Rail ON the root avatar's axis. The root avatar is .v2-avatar--md = 30px in
+   a 38px grid column, so its centre is x = 15; margin-left 14 + the 2px border
+   puts the rule through that centre. Rev 1 used 19 and was measuring the
+   column, not the avatar (@ux-lead, thread-reply-row-alignment rev 2). */
 .v2-thread-replies {
   position: relative;
-  margin-left: 28px;
-  padding-left: 40px;
+  margin-left: 14px;
+  padding-left: 12px;
   border-left: 2px solid #eef0f6;
   transition: height 300ms ease;
+}
+
+/* Replies are SMALLER rows, not channel rows. Reusing the channel's
+   38px + 12px column opened a second text column 70px right of the root's —
+   two columns and an off-axis rail was the raggedness. One inner column:
+   16 (rail) + 12 (padding) + 24 (sm avatar) + 8 (gap) = x = 60, the same for
+   every reply, grouped or not. */
+.v2-thread-replies .v2-msg {
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: 8px;
+  padding: 6px 0;
+}
+
+.v2-thread-replies .v2-msg:first-child {
+  margin-top: 4px;
+}
+
+.v2-thread-replies .v2-msg--grouped {
+  padding: 2px 0;
+}
+
+/* Tighter head inside the rail. The root keeps 700 — weight is hierarchy, so
+   the reply author must not match it. */
+.v2-thread-replies .v2-msg__head {
+  height: 18px;
+}
+
+.v2-thread-replies .v2-msg__author {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.v2-thread-replies .v2-msg__time {
+  font-size: 12px;
 }
 
 .v2-root button.v2-thread-replies__aim {
@@ -7275,7 +7313,10 @@
   color: #7b8494;
   font-size: 12px;
   cursor: pointer;
-  padding: 6px 0;
+  /* Same x = 60 column as every reply: 24px avatar + 8px gap of dead space,
+     so it reads as an affordance on the column rather than a message. */
+  margin-left: 32px;
+  padding: 8px 0 4px;
 }
 
 .v2-root button.v2-thread-replies__aim:hover {
@@ -7287,8 +7328,12 @@
 }
 
 @media (max-width: 640px) {
+  /* The axis does NOT move at 390 — no channel-row override exists at this
+     breakpoint, so the root avatar centre is still x = 15. Only the inner
+     padding tightens: 16 + 8 + 24 + 8 = x = 56. */
   .v2-thread-replies {
-    margin-left: 24px; /* brief: rail offset drops to 24px at 390 */
+    margin-left: 14px;
+    padding-left: 8px;
   }
 
   .v2-root button.v2-thread-card__main {


### PR DESCRIPTION
TASK-049, all four items, against @ux-lead's rev-2 alignment spec and Sam's constraint 5.

### (1) + (4) The image path, both halves

It's a second send site and has now been **half-updated twice**. #1150 gave it the thread root and left `replyTarget` hardcoded `undefined` (@ux-lead 57473) — so aiming at a person and uploading posted the picture unrouted while the chip still read "Replying to {name}". It also never cleared its targets, so an aim **survived a completed send** and silently applied to the next one.

Both fixed on one line, with the ruling's phrasing — *"a send consumes the target on every path"* — quoted where the next person will edit it, because per-path wiring is what keeps going wrong here. Safe by construction rather than by care: `aimAtThread` and `aimAtMessage` clear each other, so the pair can never both be set.

### (2) Quote suppression is a conjunction

Hide **iff** the quote points at the root of the rail we're inside. Neither half is sufficient:

| Case | Result |
|---|---|
| Inside the rail, quoting **that root** | hidden |
| Inside the rail, quoting **someone else** | **shown** — reply-to-person; the quote is the only thing naming who |
| Quoting the root, rendered **flat** | **shown** — no rail supplies the context |

Failure is asymmetric: a redundant quote is noise, a missing one loses the only pointer to what a message answers.

Passed as `insideThreadRoot`, not a boolean `inThread` — the predicate must compare the quote's target to *this* root, and a boolean can't express "the right root". **Probed both wrong forms:** naive `inThread → hide` kills the quoting-a-person case; a strict `===` on mixed types kills the numeric-id case, which is real since `thread_root_id` arrives from PG as a number.

### (3) Alignment rev 2

Rail on the avatar axis (`margin-left: 14` so the 2px border centres on x=15); replies as smaller rows with their own `24px + 8px` column rather than reusing the channel's `38px + 12px` — that reuse is what opened a second text column 70px right of the root's.

**Real-browser readings, relative to the row origin (which is what the spec's numbers are):**

```
1200   rail 15 · reply avatar 28 · reply text 60     expected 15/28/60
 390   rail 15 · reply avatar 24 · reply text 56     expected 15/24/56
```

Both exact. Also confirmed rather than assumed: rail axis and root-avatar centre are the same x at both widths (15/15), root text 50 vs reply text 60 is the 10px "inside" step, the grouped reply and the aim control share the column, and 390 doesn't overflow.

**My own layout guard caught the geometry change and was right to** — it pinned rev 1's numbers. Updated to rev 2's pins with the ruling cited, per reviewer-checklist rule 3.

**423 frontend tests, 78 suites, green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)