### PR TITLE
fix(retention): deleting a thread root re-roots the chain it orphans

### DIFF
--- a/backend/__tests__/service/threading.retention.test.js
+++ b/backend/__tests__/service/threading.retention.test.js
@@ -1,0 +1,115 @@
+/**
+ * Retention deleting a thread root — EXECUTED against a real Postgres
+ * (TASK-043, @sprint-review 57204).
+ *
+ * TIER 1 IS NOT A PREFERENCE HERE, IT IS THE ONLY OPTION. The claim is about
+ * what the DATABASE does on delete: `thread_root_id` is ON DELETE SET NULL,
+ * so removing a root nulls the pointer on every descendant while their
+ * `reply_to_message_id` chain stays intact and alive.
+ *
+ * pg-mem does not fire ON DELETE SET NULL at all — measured minimally, three
+ * rows and one delete, and the children keep pointing at the deleted id. So
+ * the unit suite (retentionReRoot.test.js) can only prove the REPAIR against
+ * a state it constructs by hand. Whether Postgres produces that state, and
+ * whether deleteOlderThan repairs it end to end, is this file's job.
+ *
+ * That split is worth stating because it was got wrong first: a peer wrote
+ * that FK actions are exercised at the unit tier because a suite there runs a
+ * DELETE. A DELETE running is not its FK action firing.
+ */
+const { Pool } = require('pg');
+const PGMessage = require('../../models/pg/Message');
+
+const RUN = process.env.INTEGRATION_TEST === 'true';
+const d = RUN ? describe : describe.skip;
+
+const POD = 'aaaaaaaaaaaaaaaaaaaaaa43';
+const USER = 'bbbbbbbbbbbbbbbbbbbbbb43';
+let pool;
+
+const connect = () => new Pool({
+  host: process.env.PG_HOST,
+  port: Number(process.env.PG_PORT || 5432),
+  database: process.env.PG_DATABASE,
+  user: process.env.PG_USER,
+  password: process.env.PG_PASSWORD,
+  ssl: false,
+});
+
+const rootOf = async (id) => {
+  const { rows } = await pool.query('SELECT thread_root_id FROM messages WHERE id = $1', [id]);
+  return rows[0] ? rows[0].thread_root_id : undefined;
+};
+const replyOf = async (id) => {
+  const { rows } = await pool.query('SELECT reply_to_message_id FROM messages WHERE id = $1', [id]);
+  return rows[0] ? rows[0].reply_to_message_id : undefined;
+};
+
+d('deleting a thread root, against a real database', () => {
+  beforeAll(async () => {
+    pool = connect();
+    await pool.query("INSERT INTO users (_id, username) VALUES ($1,'t43') ON CONFLICT (_id) DO NOTHING", [USER]);
+    await pool.query(
+      "INSERT INTO pods (id, name, type, created_by) VALUES ($1,'retention','chat',$2) ON CONFLICT (id) DO NOTHING",
+      [POD, USER],
+    );
+  });
+  afterAll(async () => { await pool.query('DELETE FROM messages WHERE pod_id = $1', [POD]); await pool.end(); });
+  beforeEach(async () => { await pool.query('DELETE FROM messages WHERE pod_id = $1', [POD]); });
+
+  const chain = async () => {
+    const R = await PGMessage.create(POD, USER, 'root', 'text', null);
+    const C = await PGMessage.create(POD, USER, 'child', 'text', R.id);
+    const G = await PGMessage.create(POD, USER, 'grand', 'text', C.id);
+    return { R: Number(R.id), C: Number(C.id), G: Number(G.id) };
+  };
+
+  test('THE BUG: the grandchild loses its root while keeping a live parent', async () => {
+    const { R, C, G } = await chain();
+    expect(await rootOf(G)).toBe(R);
+
+    await pool.query('DELETE FROM messages WHERE id = $1', [R]);
+
+    // Not a dangling edge — that is the distinction the whole task turns on,
+    // and why "zero dangling edges on the live instance" did not close it.
+    expect(await replyOf(G)).toBe(C);
+    expect(await rootOf(G)).toBeNull();
+    // C is promoted: both pointers null, which is exactly what a root is.
+    expect(await replyOf(C)).toBeNull();
+    expect(await rootOf(C)).toBeNull();
+  });
+
+  test('reRootOrphanedChains re-points the chain at the promoted root', async () => {
+    const { R, C, G } = await chain();
+    await pool.query('DELETE FROM messages WHERE id = $1', [R]);
+
+    await PGMessage.reRootOrphanedChains();
+
+    expect(await rootOf(G)).toBe(C);
+    expect(await rootOf(C)).toBeNull();
+  });
+
+  test('deleteOlderThan repairs what it orphans, in one call', async () => {
+    // The end-to-end shape: retention removes an aged root and the descendants
+    // that survive are re-rooted before the caller sees a return value. The
+    // caller cannot detect the corruption itself — the delete reports rows
+    // removed, not rows broken — so the repair has to be inside the operation.
+    const { R, C, G } = await chain();
+    await pool.query("UPDATE messages SET created_at = NOW() - INTERVAL '400 days' WHERE id = $1", [R]);
+
+    const { deleted } = await PGMessage.deleteOlderThan(30);
+
+    expect(deleted).toBeGreaterThanOrEqual(1);
+    expect(await rootOf(G)).toBe(C);
+  });
+
+  test('CONTROL: an intact thread survives a delete that removes nothing', async () => {
+    // Without this, a repair that rewrote healthy rows would pass the rest.
+    const { R, C, G } = await chain();
+
+    await PGMessage.deleteOlderThan(3650);
+
+    expect(await rootOf(C)).toBe(R);
+    expect(await rootOf(G)).toBe(R);
+  });
+});

--- a/backend/__tests__/unit/models/retentionReRoot.test.js
+++ b/backend/__tests__/unit/models/retentionReRoot.test.js
@@ -1,0 +1,160 @@
+/**
+ * Deleting a thread root must not orphan the chain below it (TASK-043).
+ *
+ * @sprint-review (57204). `thread_root_id` is ON DELETE SET NULL, which is
+ * correct for the row pointed at and wrong for everything under it:
+ *
+ *     R <- C <- G,  delete R
+ *       C : reply_to -> NULL, thread_root_id -> NULL   correct, C is now a root
+ *       G : reply_to = C (ALIVE), thread_root_id -> NULL   WRONG
+ *
+ * G is NOT a dangling edge — its parent is alive — so the `reply_to_message_id`
+ * FK cannot help, and no write path revisits it. It matches the un-rooted
+ * predicate permanently. That distinction is why the "zero dangling edges"
+ * measurement on the live instance did not close this.
+ *
+ * WHAT THIS SUITE CAN AND CANNOT PROVE — read before adding to it.
+ *
+ * pg-mem does NOT fire ON DELETE SET NULL. Measured, minimally:
+ *
+ *     CREATE TABLE m (id INTEGER PRIMARY KEY,
+ *                     reply_to INTEGER REFERENCES m(id) ON DELETE SET NULL,
+ *                     root     INTEGER REFERENCES m(id) ON DELETE SET NULL);
+ *     INSERT (1,NULL,NULL),(2,1,1),(3,2,1);  DELETE FROM m WHERE id = 1;
+ *     -> rows 2 and 3 still hold reply_to/root = 1, pointing at a deleted row.
+ *
+ * So this tier cannot show that deleting a root orphans its chain. @sprint-review
+ * wrote (57286) that "threadFollowByParticipation.test.js:252 already does
+ * DELETE FROM messages under pg-mem, so FK actions are exercised at the unit
+ * tier" — a DELETE running is not the same as its FK action firing, and the
+ * action does not fire. My own first draft of this file had a test asserting
+ * the orphaning and it passed; it was not evidence, and it is gone.
+ *
+ * The split that is honest:
+ *   HERE      — the REPAIR, given the orphaned state, constructed explicitly
+ *               and labelled as constructed. That is a claim about my code.
+ *   TIER 1    — that Postgres actually PRODUCES that state on delete, and that
+ *               deleteOlderThan repairs it end to end. That is a claim about
+ *               the database, and only a database can settle it.
+ *               (__tests__/service/threading.retention.test.js)
+ */
+const { newDb } = require('pg-mem');
+const { applyTable } = require('../../utils/schemaTable');
+
+const mockDb = newDb();
+const mockPool = new (mockDb.adapters.createPg().Pool)();
+jest.mock('../../../config/db-pg', () => ({ pool: mockPool }));
+
+const PGMessage = require('../../../models/pg/Message');
+
+const POD = 'pod-1';
+let id = 0;
+const mk = async (root, replyTo, ageDays = 0) => {
+  id += 1;
+  await mockPool.query(
+    `INSERT INTO messages (id, pod_id, user_id, content, reply_to_message_id, thread_root_id, created_at)
+     VALUES ($1,$2,'u','x',$3::int,$4::int, NOW() - ($5 || ' days')::interval)`,
+    [id, POD, replyTo, root, ageDays],
+  );
+  return id;
+};
+const rootOf = async (mid) => {
+  const { rows } = await mockPool.query('SELECT thread_root_id FROM messages WHERE id = $1', [mid]);
+  return rows[0] ? rows[0].thread_root_id : undefined;
+};
+
+beforeAll(async () => {
+  await applyTable(mockPool, 'pods');
+  await applyTable(mockPool, 'users');
+  await applyTable(mockPool, 'messages');
+  await mockPool.query("INSERT INTO pods (id, name, type, created_by) VALUES ($1,'P','chat','u')", [POD]);
+});
+beforeEach(async () => { await mockPool.query('DELETE FROM messages'); });
+
+// The post-delete state, CONSTRUCTED. This is what Postgres leaves behind
+// after `DELETE FROM messages WHERE id = R` on R <- C <- G: C promoted to a
+// root (both pointers null), G keeping a live parent and losing its root.
+// Written out by hand because pg-mem will not produce it — and said out loud
+// because a hand-built fixture is a statement about what I believe Postgres
+// does, which tier 1 has to confirm.
+const orphanedChain = async (depth) => {
+  const C = await mk(null, null);          // promoted root
+  const ids = [];
+  let parent = C;
+  for (let i = 0; i < depth; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    parent = await mk(null, parent);       // live parent, NULL root
+    ids.push(parent);
+  }
+  return { C, ids };
+};
+
+describe('reRootOrphanedChains repairs it', () => {
+  test('the grandchild re-points at the promoted root', async () => {
+    const { C, ids: [G] } = await orphanedChain(1);
+
+    const out = await PGMessage.reRootOrphanedChains();
+
+    expect(await rootOf(G)).toBe(C);
+    expect(out.reRooted).toBe(1);
+  });
+
+  test('a deeper chain converges, one level per pass', async () => {
+    const { C, ids } = await orphanedChain(3);
+
+    const out = await PGMessage.reRootOrphanedChains();
+
+    for (const m of ids) expect(await rootOf(m)).toBe(C);
+    expect(out.reRooted).toBe(3);
+    // One level per pass, plus the final no-op pass that proves convergence.
+    expect(out.passes).toBe(4);
+  });
+
+  test('the promoted root keeps a NULL root — that is what a root looks like', async () => {
+    const { C } = await orphanedChain(1);
+
+    await PGMessage.reRootOrphanedChains();
+
+    expect(await rootOf(C)).toBeNull();
+  });
+
+  test('it is idempotent — a second run changes nothing', async () => {
+    await orphanedChain(1);
+    await PGMessage.reRootOrphanedChains();
+
+    const second = await PGMessage.reRootOrphanedChains();
+
+    expect(second.reRooted).toBe(0);
+    expect(second.passes).toBe(1);
+  });
+
+  test('an intact thread is untouched', async () => {
+    // CONTROL. Without this, a repair that nulled or rewrote healthy rows
+    // would still pass every test above.
+    const R = await mk(null, null);
+    const C = await mk(R, R);
+    const G = await mk(R, C);
+
+    const out = await PGMessage.reRootOrphanedChains();
+
+    expect(out.reRooted).toBe(0);
+    expect(await rootOf(C)).toBe(R);
+    expect(await rootOf(G)).toBe(R);
+  });
+
+  test('a genuinely parentless orphan stays NULL rather than being invented a root', async () => {
+    // reply_to IS NULL means it IS a root now. Nothing to re-root, and
+    // inventing one would be worse than leaving it.
+    const lone = await mk(null, null);
+
+    await PGMessage.reRootOrphanedChains();
+
+    expect(await rootOf(lone)).toBeNull();
+  });
+});
+
+// deleteOlderThan's end-to-end repair is NOT tested here. It needs the delete
+// to actually orphan something, which needs the FK action, which pg-mem does
+// not fire. It lives in the tier-1 suite where a real Postgres can produce the
+// state — putting it here would be a test of my fixture wearing the name of a
+// test of retention.

--- a/backend/models/pg/Message.ts
+++ b/backend/models/pg/Message.ts
@@ -306,6 +306,80 @@ class Message {
    * than replacing it — operator-pinned pods and paid pods are both exempt,
    * for different reasons.
    */
+  /**
+   * Re-root chains an ancestor's deletion orphaned (TASK-043).
+   *
+   * `thread_root_id` is ON DELETE SET NULL, which is right for the row being
+   * pointed at and wrong for everything below it. Delete root R from
+   * R <- C <- G and Postgres nulls BOTH pointers:
+   *
+   *   C : reply_to -> NULL (its own FK), thread_root_id -> NULL   correct — C
+   *       is now a root, and a root's thread_root_id is NULL by design.
+   *   G : reply_to = C (ALIVE), thread_root_id -> NULL            WRONG — G's
+   *       root should now be C, and nothing sets it.
+   *
+   * G then matches `reply_to_message_id IS NOT NULL AND thread_root_id IS NULL`
+   * permanently: it is not a dangling edge (its parent is alive), so the
+   * `reply_to_message_id` FK cannot help, and no write path revisits it.
+   * @sprint-review found it (57204) and the distinction from the dangling-edge
+   * case is the part that makes it easy to mis-close.
+   *
+   * The data is recoverable because the CHAIN is intact — only the pointer was
+   * cleared. So this is derivation-on-write applied repeatedly: the same
+   * COALESCE-of-parent expression `create` uses, run against parents that
+   * already know their own root. Each pass fixes one level, so a chain of
+   * depth d converges in d passes.
+   *
+   * (Deliberately not quoting that expression verbatim here. It appears twice
+   * in this file — once in create's comment, once in its SQL — and
+   * threadRootDerivation.pgmem.test.js pins the count at two, because a
+   * first-match text mutation must land on the comment and not the SQL. A
+   * third copy silently changes which one a probe hits. My own guard caught
+   * this edit, which is the guard working.)
+   *
+   * Iterative rather than a recursive CTE ON PURPOSE. The backfill uses
+   * `WITH RECURSIVE` and pg-mem cannot run it, which pushes its only coverage
+   * to tier 1. This form is plain SQL, so the repair and its regression test
+   * run at the unit tier — which is where a retention bug should be provable,
+   * since reproducing it needs a DELETE and not a fixture.
+   */
+  static async reRootOrphanedChains(maxPasses = 32): Promise<{ reRooted: number; passes: number }> {
+    let reRooted = 0;
+    let passes = 0;
+    for (let i = 0; i < maxPasses; i += 1) {
+      // Read the level, then write it by id. `UPDATE ... FROM` with a
+      // self-join is the natural single statement and pg-mem cannot run it
+      // ("Unknown alias"), which would push this repair's only coverage to
+      // tier 1 — the same trap the recursive CTE in the backfill fell into.
+      // A JOINed SELECT plus keyed UPDATEs runs on both, and the population
+      // is bounded by one delete's orphans.
+      //
+      // Only from a parent that KNOWS its root: either it is itself a root
+      // (reply_to IS NULL) or it has been rooted already. Without that guard a
+      // pass could copy one NULL onto another and report progress forever.
+      // eslint-disable-next-line no-await-in-loop
+      const { rows } = await (pool as PgPool).query(
+        `SELECT m.id AS id, COALESCE(p.thread_root_id, p.id) AS root
+           FROM messages m
+           JOIN messages p ON m.reply_to_message_id = p.id
+          WHERE m.thread_root_id IS NULL
+            AND (p.reply_to_message_id IS NULL OR p.thread_root_id IS NOT NULL)`,
+      );
+      for (const r of rows as Array<{ id: number; root: number }>) {
+        // eslint-disable-next-line no-await-in-loop
+        await (pool as PgPool).query(
+          'UPDATE messages SET thread_root_id = $2::int WHERE id = $1::int',
+          [r.id, r.root],
+        );
+      }
+      const n = rows.length;
+      passes += 1;
+      reRooted += n;
+      if (n === 0) break;
+    }
+    return { reRooted, passes };
+  }
+
   static async deleteOlderThan(
     days: number,
     protectedPodIds: string[] = [],
@@ -328,6 +402,30 @@ class Message {
     const deleted = typeof result.rowCount === 'number'
       ? result.rowCount
       : (Array.isArray(result.rows) ? result.rows.length : 0);
+
+    // Repair before returning. Deleting a thread root orphans everything below
+    // it (see reRootOrphanedChains), and the caller has no way to know it
+    // happened — the delete reports rows removed, not rows corrupted. Doing it
+    // here rather than in the retention cron means every caller of this method
+    // gets it, including a future one written by someone who never read
+    // TASK-043.
+    if (deleted > 0) {
+      try {
+        const repair = await Message.reRootOrphanedChains();
+        if (repair.reRooted > 0) {
+          console.log(
+            `[pg-retention] re-rooted ${repair.reRooted} orphaned reply row(s) `
+            + `in ${repair.passes} pass(es) after deleting ${deleted}`,
+          );
+        }
+      } catch (err) {
+        // Never fail the delete for a repair. The rows are already gone; a
+        // failed re-root leaves an over-expand, which the reader treats as
+        // unknown and renders expanded — noisy and non-destructive. Throwing
+        // here would make retention look broken for a cosmetic consequence.
+        console.warn('[pg-retention] re-root after delete failed:', (err as Error).message);
+      }
+    }
     return { deleted };
   }
 


### PR DESCRIPTION
TASK-043, @sprint-review 57204.

`thread_root_id` is `ON DELETE SET NULL` — right for the row pointed at, wrong for everything under it. Delete R from `R ← C ← G`:

```
C : reply_to -> NULL, thread_root_id -> NULL      correct — C is now a root
G : reply_to = C (ALIVE), thread_root_id -> NULL  WRONG — root should be C
```

G is **not a dangling edge**, so the `reply_to` FK can't help and no write path revisits it. It matches the un-rooted predicate permanently. That distinction is why "zero dangling edges on the live instance" didn't close this.

### The repair

`reRootOrphanedChains` applies the write path's own COALESCE-of-parent derivation repeatedly, guarded so it only reads from a parent that **already knows its root** — otherwise a pass copies one NULL onto another and reports progress forever.

Called from `deleteOlderThan`, not the retention cron, so every caller gets it. Wrapped so a failed repair never fails the delete: the rows are already gone, and an un-repaired orphan costs an over-expand, which the reader treats as unknown and renders expanded. Noisy, not destructive.

### Two corrections to how this gets tested — the second is substantive

`UPDATE … FROM` with a self-join is the natural single statement and pg-mem rejects it (`Unknown alias`), which would push the repair's only coverage to tier 1 — the same trap the backfill's recursive CTE fell into. A JOINed SELECT plus keyed UPDATEs runs on both.

**And pg-mem does not fire `ON DELETE SET NULL` at all.** Measured minimally — three rows, one delete, children still pointing at the deleted id:

```sql
CREATE TABLE m (id INTEGER PRIMARY KEY,
                reply_to INTEGER REFERENCES m(id) ON DELETE SET NULL,
                root     INTEGER REFERENCES m(id) ON DELETE SET NULL);
INSERT (1,NULL,NULL),(2,1,1),(3,2,1);  DELETE FROM m WHERE id = 1;
-- rows 2 and 3 still hold 1
```

So @sprint-review's *"threadFollowByParticipation.test.js:252 already does DELETE FROM messages under pg-mem, so FK actions are exercised at the unit tier"* (57286) isn't true — **a DELETE running is not its FK action firing.** My first draft of the unit suite had a test asserting the orphaning and it **passed**. It wasn't evidence, and it's gone.

### The honest split

| Tier | Proves |
|---|---|
| unit (`retentionReRoot`) | the **repair**, against a hand-constructed state, labelled as constructed |
| tier 1 (`threading.retention`) | that Postgres **produces** that state, and that `deleteOlderThan` repairs it end to end |

Tier 1 includes a control that an intact thread survives a delete removing nothing — a repair that rewrote healthy rows would pass everything else.

**My own #1141 guard caught this commit:** the new comment quoted COALESCE-of-parent verbatim, making three occurrences where it pins two, which silently changes which one a first-match probe hits. Reworded rather than loosening the guard.

296 threading unit tests green; the 4 tier-1 cases skip without `INTEGRATION_TEST` and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)