### PR TITLE
test(threading): the read-failure safety property had no executing test

### DIFF
--- a/backend/__tests__/unit/models/threadStateReadContract.test.js
+++ b/backend/__tests__/unit/models/threadStateReadContract.test.js
@@ -319,3 +319,57 @@ describe('unknown resolves to expand, never to collapse', () => {
 // The reasoning it carried survives where it is still true: in
 // docs/design/threading-surface-ruling.md, and in the three-state cutoff
 // comments on readThreadingCutoff and effectiveStateForPod.
+
+describe('a read failure degrades toward EXPAND, never toward collapse', () => {
+  // CONVERTED from a source regex. @sprint-review (57150) on that block: every
+  // test in it was `expect(CONTROLLER_SRC).toMatch(...)`, reading the
+  // controller's text rather than running it — and their clearest proof was
+  // that one went red on the catch block's FORMATTING while the behaviour was
+  // intact. The old assertion here matched the literal shape of the catch, so
+  // a reformat broke it and a behavioural regression could slip past.
+  //
+  // Nothing executed a read failure anywhere, so this was the one property in
+  // that block with no behavioural coverage at all — and it is the safety
+  // direction: collapsed hides history invisibly, expanded is noisy and one
+  // click from fixed.
+  const readWith = async (queryImpl) => {
+    const original = mockPool.query.bind(mockPool);
+    mockPool.query = queryImpl(original);
+    try {
+      return await read();
+    } finally {
+      mockPool.query = original;
+    }
+  };
+  const failLedger = (orig) => (sql, params) => (
+    String(sql).includes('migration_records')
+      ? Promise.reject(new Error('connection reset'))
+      : orig(sql, params)
+  );
+
+  beforeEach(async () => {
+    await mockPool.query('DELETE FROM migration_records');
+    await seedPastCutoff();
+  });
+
+  test('the ledger query throwing renders every root EXPANDED', async () => {
+    const p = await readWith(failLedger);
+
+    expect(p.threads.length).toBeGreaterThan(0);
+    expect(p.threads.every((t) => t.collapsed === false)).toBe(true);
+  });
+
+  test('CONTROL: the same ledger row without a failure collapses them', async () => {
+    // Without this, the test above passes from any state that happens to
+    // expand — including a read so broken it returns nothing meaningful.
+    const p = await read();
+
+    expect(p.threads.length).toBeGreaterThan(0);
+    expect(p.threads.every((t) => t.collapsed === true)).toBe(true);
+  });
+
+  test('the failure does not surface as an error to the caller', async () => {
+    const p = await readWith(failLedger);
+    expect(p.podId).toBe(POD);
+  });
+});

--- a/backend/__tests__/unit/models/threadUserState.test.js
+++ b/backend/__tests__/unit/models/threadUserState.test.js
@@ -204,18 +204,25 @@ describe('the pre-cutoff expanded default reaches the client', () => {
   // fail if the code were wrong rather than merely reworded.
 
 
-  it('a read failure degrades toward EXPAND, not toward collapse', () => {
-    // Not just "does not throw": the direction matters. Collapsed hides
-    // history invisibly; expanded is noisy and recoverable by one click.
-    expect(CONTROLLER_SRC).toMatch(/} catch \{[\s\S]{0,400}return \{ cutoff: null, cutoffUnknown: true \};/);
-  });
+  // MOVED to execution, @sprint-review (57150). Two source regexes lived here:
+  // "a read failure degrades toward EXPAND" matched the literal shape of the
+  // catch block, so a reformat broke it while the behaviour was intact — their
+  // example of why this whole block was reading text instead of running code.
+  // And "a missing row is UNKNOWN and unknown expands" asserted that two
+  // strings appear in the file, which the executing suite already proves by
+  // rendering the payload.
+  //
+  // Both now live in threadStateReadContract.test.js, which runs the handler:
+  // the read-failure case forces the ledger query to reject and asserts every
+  // root comes back expanded, with a control that the same ledger row without
+  // a failure collapses them. That control matters — an "expanded" assertion
+  // passes from any sufficiently broken read.
 
-  it('a missing row is UNKNOWN and unknown expands', () => {
-    // Two earlier shapes of mine were wrong in the same direction. The merged
-    // ruling settles it: absence of a ledger row never licenses collapse.
-    expect(CONTROLLER_SRC).toMatch(/cutoffUnknown/);
-    expect(CONTROLLER_SRC).toMatch(/EXPAND EVERYTHING/);
-    // and the retired probe is really gone, not just unused
+  it('the retired backfillPending probe is gone from the source, not merely unused', () => {
+    // This one stays textual ON PURPOSE and is the exception that shows the
+    // rule. It asserts the ABSENCE of code, which no execution can demonstrate:
+    // a dead branch that never runs is invisible to a behavioural test and
+    // still there for the next reader to revive.
     expect(CONTROLLER_SRC).not.toMatch(/backfillPending/);
   });
 });


### PR DESCRIPTION
@sprint-review's read of the source-regex block in `threadUserState.test.js` (57150): all five tests were `expect(CONTROLLER_SRC).toMatch(...)`. Their clearest proof was the one asserting the literal shape of a catch block — reformat it and the test goes red while the behaviour is intact; regress the behaviour and it stays green.

Checking what that block was the *only* cover for turned up a gap rather than a redundancy: **nothing anywhere executed a failing ledger read.** That is the safety direction. A collapsed thread hides history invisibly; an expanded one is noisy and one click from fixed. So a DB error must expand.

## What this does

Converts it in `threadStateReadContract.test.js`, which runs the real handler: force the `migration_records` query to reject, assert every root comes back expanded, assert the caller sees a payload rather than an error.

The **CONTROL** is load-bearing. "Everything expanded" also passes from a read broken badly enough to return junk, so the control seeds the same ledger row *without* the failure and asserts those roots collapse. Only the injected failure flips them.

## Probe

Ran both directions before trusting it:

| mutation | result |
|---|---|
| catch returns `cutoffUnknown: false` (behaviour flipped) | **1 failed** — `the ledger query throwing renders every root EXPANDED` |
| catch reformatted across three lines (behaviour intact) | 19 passed |

That is the inverse of what the regex did.

## One textual assertion stays

`not.toMatch(/backfillPending/)` — the exception that shows the rule. It claims code is **absent**, which no execution can demonstrate: a dead branch that never runs is invisible to a behavioural test and still sitting there for the next reader to revive.

`npx jest __tests__/unit/models/thread __tests__/unit/controllers/thread` → 10 suites, 143 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)