### PR TITLE
fix(cli): the poller claims one event, because the fetch IS the claim

### DIFF
--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -104,6 +104,14 @@ describe('performRun', () => {
       '/api/agents/runtime/events',
       expect.objectContaining({ agentName: 'my-stub', instanceId: 'default' }),
     );
+
+    // The fetch IS the claim — `list()` marks every candidate `delivered`
+    // and increments `attempts` before returning, while this loop starts
+    // exactly one. Asking for more claims work it cannot begin, and the
+    // backend's requeue sweep then reclaims the remainder at `attempts + 1`
+    // until the poison cap retires them unread. Pinned as its own assertion
+    // because the previous value (10) looked like a harmless batch size.
+    expect(mockGet.mock.calls[0][1].limit).toBe(1);
     expect(spawn).toHaveBeenCalledTimes(1);
     expect(spawn.mock.calls[0][0]).toBe('hello from tester');
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "license": "Apache-2.0",
   "description": "The Commonly CLI \u2014 connect agents, manage pods, iterate fast",
   "type": "module",

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -1173,8 +1173,29 @@ export const performRun = ({
     if (!running) return;
     let nextPollDelayMs = intervalMs;
     try {
+      // ONE event per fetch, because the fetch IS the claim.
+      //
+      // `AgentEventService.list()` does not hand back a preview — it marks
+      // every candidate `delivered` with `$inc: { attempts: 1 }` before
+      // returning. This loop then processes them SERIALLY, one full model
+      // turn each. So asking for 10 claims 10 and starts 1.
+      //
+      // The nine it cannot start are then reclaimed out from under it: the
+      // backend requeues `delivered` rows older than
+      // `requeueDeliveredMinutes` (default 10, swept on `*/10`), and turns
+      // routinely outlast that — measured on the pod-architect seat over
+      // 11.5h: median 128s, p90 669s, 13 turns over 600s, max 1153s. Each
+      // sweep returns the untouched siblings to `pending` at `attempts + 1`,
+      // and `attempts >= 3` retires an event to `failed`, which is terminal
+      // and invisible to `list()`. That cap exists to bound POISON events;
+      // over-claiming feeds it work no model ever saw, so a mention can be
+      // dropped without once being read.
+      //
+      // `limit: 1` costs nothing: capacity here is one turn at a time
+      // regardless, and the poll interval is 5s. It only stops the loop
+      // claiming work it has no way to begin.
       const { events = [] } = await client.get('/api/agents/runtime/events', {
-        agentName, instanceId, limit: 10,
+        agentName, instanceId, limit: 1,
       });
       consecutiveAuthErrors = 0;
       consecutivePollFailures = 0;


### PR DESCRIPTION
TASK-051, root cause. A seat ran **~11.5 hours behind** — every wake carried a stamp from the previous evening, 260 events queued, **18% acked** against 96–100% for every peer (@sprint-review's measurement, 57638).

## The bug

`AgentEventService.list()` does not hand back a preview. It marks every candidate `delivered` with `$inc: { attempts: 1 }` **before returning**. The run loop then processes them **serially**, one full model turn each.

So `limit: 10` claimed ten and started one.

The nine it couldn't start were reclaimed out from under it. The backend requeues `delivered` rows older than `requeueDeliveredMinutes` (default 10, swept on `*/10`), and turns routinely outlast that. Measured on this seat over 11.5h from its own log:

| | |
|---|---|
| spawns | 115 (10.0/hour) |
| median turn | 128s |
| p90 turn | 669s |
| turns over 600s | 13 |
| max turn | 1153s |

Each sweep returned the untouched siblings to `pending` at `attempts + 1`. That is sprint-review's otherwise-unexplained **12 at `attempts:1` / 9 at `attempts:2`** — a re-claim, not a redelivery.

## Why it's more than latency

`attempts >= attemptCap` (default 3) retires an event to `status: 'failed'` — terminal, invisible to `list()`. That cap exists to bound **poison** events: three deliveries, no ack, presumed undeliverable. Fed claims no model ever saw, it drops mentions **unread**, silently. Its own comment says it's there so a poison event can't "silently reproduce the exact Task #67 symptom — stuck, unretried, unsurfaced"; over-claiming turns the remedy into the disease.

## The fix

`limit: 1`. It costs nothing — capacity is one turn at a time regardless and the poll interval is 5s. It only stops the loop claiming work it has no way to begin.

Pinned as its own assertion rather than folded into the existing `objectContaining`, because `10` read as a harmless batch size, which is exactly why it survived review.

**Probe:** reverting to `10` fails that one test and nothing else. Full CLI suite: 334 passed, 24 suites.

## What this does NOT fix

The other half isn't a bug: this pod produces events ~3× faster than one serial seat retires them. The existing 260-event backlog needs an operator decision (clear, re-ack, or accept ~14h of drain), and **per-seat queue depth is surfaced nowhere** — 922 events are pending instance-wide, oldest 2026-08-18, and nothing alerts on any of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)