### PR TITLE
feat(threading): add human thread entry points

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -337,7 +337,9 @@
     "loadOlder": "Load older messages",
     "loadingOlder": "Loading…",
     "thread": {
+      "startThread": "Thread",
       "replyInThread": "Reply in thread",
+      "replyFromExpandedThread": "Reply from expanded thread",
       "replyingInThread": "Replying in thread ·"
     }
   },

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -337,7 +337,9 @@
     "loadOlder": "加载更早的消息",
     "loadingOlder": "加载中…",
     "thread": {
+      "startThread": "话题",
       "replyInThread": "在话题中回复",
+      "replyFromExpandedThread": "在已展开的话题中回复",
       "replyingInThread": "正在话题中回复："
     }
   },

--- a/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
@@ -170,11 +170,13 @@ describe('V2PodChat composer send button', () => {
     },
   ]);
 
-  test('"Reply in thread" sends threadRootId and no reply edge', async () => {
+  const replyFromExpandedThread = () => screen.getByRole('button', { name: /reply from expanded thread/i });
+
+  test('"Reply in thread" from the expanded rail sends threadRootId and no reply edge', async () => {
     const detail = makeDetail({ messages: threadMessages() });
     renderChat(detail);
 
-    fireEvent.click(screen.getByRole('button', { name: /reply in thread/i }));
+    fireEvent.click(replyFromExpandedThread());
     expect(screen.getByText(/replying in thread/i)).toBeInTheDocument();
     fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
       target: { value: 'Joining the thread.' },
@@ -192,7 +194,7 @@ describe('V2PodChat composer send button', () => {
     // Reply-to-person first, then "Reply in thread": the thread wins, the
     // reply edge is gone.
     fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
-    fireEvent.click(screen.getByRole('button', { name: /reply in thread/i }));
+    fireEvent.click(replyFromExpandedThread());
     fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
       target: { value: 'thread wins' },
     });
@@ -203,7 +205,7 @@ describe('V2PodChat composer send button', () => {
 
     // The other order: thread first, then reply-to-person. The reply edge
     // wins, the thread root is gone.
-    fireEvent.click(screen.getByRole('button', { name: /reply in thread/i }));
+    fireEvent.click(replyFromExpandedThread());
     fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
     fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
       target: { value: 'reply wins' },
@@ -230,7 +232,7 @@ describe('V2PodChat composer send button', () => {
     const detail = makeDetail({ messages: threadMessages() });
     const { container } = renderChat(detail);
 
-    fireEvent.click(screen.getByRole('button', { name: /reply in thread/i }));
+    fireEvent.click(replyFromExpandedThread());
 
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
     const file = new File(['x'], 'x.png', { type: 'image/png' });
@@ -282,7 +284,7 @@ describe('V2PodChat composer send button', () => {
     const detail = makeDetail({ messages: threadMessages() });
     const { container } = renderChat(detail);
 
-    fireEvent.click(screen.getByRole('button', { name: /reply in thread/i }));
+    fireEvent.click(replyFromExpandedThread());
     upload(container);
     await waitFor(() => expect(detail.sendMessage).toHaveBeenCalledTimes(1));
 
@@ -296,6 +298,67 @@ describe('V2PodChat composer send button', () => {
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
     await waitFor(() => {
       expect(detail.sendMessage).toHaveBeenLastCalledWith('unaimed', 'text', undefined, undefined);
+    });
+  });
+
+  test('Thread from a message without replies starts a thread without replying to its author', async () => {
+    const detail = makeDetail({ messages: [threadMessages()[0]] });
+    renderChat(detail);
+
+    fireEvent.click(screen.getByRole('button', { name: /thread from teammate/i }));
+    expect(screen.getByText(/replying in thread/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+      target: { value: 'Starting a thread.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    await waitFor(() => {
+      expect(detail.sendMessage).toHaveBeenCalledWith('Starting a thread.', 'text', undefined, 'm1');
+    });
+  });
+
+  test('Thread from a reply keeps its existing root instead of asking the server to nest it', async () => {
+    const detail = makeDetail({ messages: threadMessages() });
+    renderChat(detail);
+
+    fireEvent.click(screen.getByRole('button', { name: /thread from other/i }));
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+      target: { value: 'Still in the first thread.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    await waitFor(() => {
+      expect(detail.sendMessage).toHaveBeenCalledWith('Still in the first thread.', 'text', undefined, 'm1');
+    });
+  });
+
+  test('the headline card aims the same root without requiring an expand', async () => {
+    const detail = makeDetail({ messages: threadMessages() });
+    renderChat(detail);
+
+    fireEvent.click(screen.getByRole('button', { name: /^reply in thread$/i }));
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+      target: { value: 'Joining through the card.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    await waitFor(() => {
+      expect(detail.sendMessage).toHaveBeenCalledWith('Joining through the card.', 'text', undefined, 'm1');
+    });
+  });
+
+  test('Reply still sends only the reply edge', async () => {
+    const detail = makeDetail({ messages: threadMessages() });
+    renderChat(detail);
+
+    fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+      target: { value: 'Replying to a person.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    await waitFor(() => {
+      expect(detail.sendMessage).toHaveBeenCalledWith('Replying to a person.', 'text', 'm2', undefined);
     });
   });
 });

--- a/frontend/src/v2/__tests__/V2ThreadCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadCard.test.tsx
@@ -19,6 +19,7 @@ const people = [
 const setup = (over: Partial<React.ComponentProps<typeof V2ThreadCard>> = {}) => {
   const onToggleCollapsed = jest.fn();
   const onToggleFollowing = jest.fn();
+  const onReplyInThread = over.onReplyInThread || jest.fn();
   const utils = render(
     <V2ThreadCard
       replyCount={3}
@@ -28,11 +29,12 @@ const setup = (over: Partial<React.ComponentProps<typeof V2ThreadCard>> = {}) =>
       following={null}
       onToggleCollapsed={onToggleCollapsed}
       onToggleFollowing={onToggleFollowing}
+      onReplyInThread={onReplyInThread}
       now={NOW}
       {...over}
     />,
   );
-  return { ...utils, onToggleCollapsed, onToggleFollowing };
+  return { ...utils, onToggleCollapsed, onToggleFollowing, onReplyInThread };
 };
 
 describe('content is a count, faces and a time — and nothing else', () => {
@@ -99,6 +101,17 @@ describe('collapse is driven by the prop and reported to the caller', () => {
     const { onToggleCollapsed } = setup();
     fireEvent.click(screen.getByRole('button', { name: /Expand thread/ }));
     expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
+  });
+
+  test('Reply in thread is a sibling action that does not need an expand', () => {
+    const { container, onReplyInThread, onToggleCollapsed } = setup({ collapsed: true });
+    const main = container.querySelector('.v2-thread-card__main');
+    const reply = screen.getByRole('button', { name: /^reply in thread$/i });
+
+    expect(main?.contains(reply)).toBe(false);
+    fireEvent.click(reply);
+    expect(onReplyInThread).toHaveBeenCalledTimes(1);
+    expect(onToggleCollapsed).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -498,6 +498,18 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(addressed).toContain('var(--v2-accent)');
   });
 
+  test('thread entry actions retain 44px targets and become visible on touch layouts', () => {
+    // TASK-052: Thread has to be reachable from an unthreaded message, while
+    // Reply preserves its existing addressing meaning. Desktop may reveal the
+    // row on hover; a 390px touch surface cannot depend on hover.
+    const messageAction = ruleBody(v2, '.v2-root button.v2-msg__reply-btn,\n.v2-root button.v2-msg__thread-btn');
+    expect(messageAction).toContain('min-height: 44px');
+    const cardAction = ruleBody(v2, '.v2-root button.v2-thread-card__reply');
+    expect(cardAction).toContain('min-height: 44px');
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-root button\.v2-msg__reply-btn,[\s\S]*?\.v2-root button\.v2-msg__thread-btn[\s\S]*?opacity: 1/);
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-card\s*\{[\s\S]*?flex-wrap: wrap/);
+  });
+
   test('reduced motion actually reaches the thread transitions', () => {
     // The 300ms layout transition is a brief requirement AND a reduced-motion
     // hazard. Easy to add the transition and forget the opt-out; nothing in a

--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import V2Avatar from './V2Avatar';
 import V2GithubPrCard, { parseGithubPrUrls } from './V2GithubPrCard';
@@ -101,6 +102,10 @@ interface V2MessageBubbleProps {
   // Sets this message as the composer's reply target (reply threading —
   // backend replyToMessageId; agents already use it, this is the human side).
   onReply?: (message: V2Message) => void;
+  // Starts or joins the message's thread without creating a reply edge. The
+  // parent resolves an already-threaded message to its existing root before
+  // aiming the composer, so this control never asks the server for nesting.
+  onThread?: (message: V2Message) => void;
   // Consecutive-author grouping (craft audit finding 7): when the previous
   // message is the same author within the grouping window, the header row
   // (avatar / name / time) is suppressed and the row tightens. The avatar
@@ -304,8 +309,9 @@ const parseAgentDmEvent = (content: string | undefined): { headline: string; tar
 // columns in mobile shells.
 const REACTION_PALETTE = ['👍', '❤️', '🔥', '🤔', '👀', '🚀'];
 
-const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agentDisplayNames, agentAuthorKeys, onAuthorClick, onOpenFile, onReply, grouped, insideThreadRoot }) => {
+const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agentDisplayNames, agentAuthorKeys, onAuthorClick, onOpenFile, onReply, onThread, grouped, insideThreadRoot }) => {
   const { currentUser } = useAuth();
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const api = useV2Api();
   // Picker state per message. Open via "+ react"; close on first click
@@ -437,15 +443,29 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
         />
       )}
       <div className="v2-msg__body">
-        {grouped && onReply && (
-          <button
-            type="button"
-            className="v2-msg__reply-float"
-            aria-label={`Reply to ${author}`}
-            onClick={() => onReply(message)}
-          >
-            Reply
-          </button>
+        {grouped && (onReply || onThread) && (
+          <div className="v2-msg__thread-actions v2-msg__thread-actions--float">
+            {onReply && (
+              <button
+                type="button"
+                className="v2-msg__reply-float"
+                aria-label={`Reply to ${author}`}
+                onClick={() => onReply(message)}
+              >
+                Reply
+              </button>
+            )}
+            {onThread && (
+              <button
+                type="button"
+                className="v2-msg__thread-float"
+                aria-label={`${t('podChat.thread.startThread')} from ${author}`}
+                onClick={() => onThread(message)}
+              >
+                {t('podChat.thread.startThread')}
+              </button>
+            )}
+          </div>
         )}
         {!grouped && (
         <div className="v2-msg__head">
@@ -458,15 +478,29 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
           )}
           {isLead && <span className="v2-msg__lead-badge">Lead</span>}
           {time && <span className="v2-msg__time">{time}</span>}
-          {onReply && (
-            <button
-              type="button"
-              className="v2-msg__reply-btn"
-              aria-label={`Reply to ${author}`}
-              onClick={() => onReply(message)}
-            >
-              Reply
-            </button>
+          {(onReply || onThread) && (
+            <div className="v2-msg__thread-actions">
+              {onReply && (
+                <button
+                  type="button"
+                  className="v2-msg__reply-btn"
+                  aria-label={`Reply to ${author}`}
+                  onClick={() => onReply(message)}
+                >
+                  Reply
+                </button>
+              )}
+              {onThread && (
+                <button
+                  type="button"
+                  className="v2-msg__thread-btn"
+                  aria-label={`${t('podChat.thread.startThread')} from ${author}`}
+                  onClick={() => onThread(message)}
+                >
+                  {t('podChat.thread.startThread')}
+                </button>
+              )}
+            </div>
           )}
         </div>
         )}

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -277,6 +277,14 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
     setThreadTarget(null);
     setReplyTarget(m);
   }, []);
+  const aimAtMessageThread = useCallback((m: import('../hooks/useV2PodDetail').V2Message) => {
+    // The action is available on every visible message, including replies.
+    // Explicit roots may not themselves be inside a thread (#1128), so a
+    // reply joins its existing root while a standalone message starts one.
+    const rootId = String(m.thread_root_id ?? m.id);
+    const root = messages.find((candidate) => String(candidate.id) === rootId);
+    aimAtThread(rootId, String(root?.content || m.content || ''));
+  }, [aimAtThread, messages]);
 
   // Memoized: it was called in the render body, so every keystroke in the
   // composer re-folded the whole message list. @sprint-review on #1150.
@@ -1247,7 +1255,8 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                         agentAuthorKeys={agentAuthorKeys}
                         onAuthorClick={onOpenMember ? handleAuthorClick : undefined}
                         onOpenFile={onOpenFile}
-                        onReply={aimAtMessage}
+                        onReply={isReadOnly ? undefined : aimAtMessage}
+                        onThread={isReadOnly ? undefined : aimAtMessageThread}
                         grouped={isGroupedWithPrevious(
                           m,
                           prev && prev.kind === 'message' ? prev.message : undefined,
@@ -1281,6 +1290,10 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                       following={st ? st.following : null}
                       onToggleCollapsed={() => threadState.toggleCollapsed(item.rootId)}
                       onToggleFollowing={() => threadState.toggleFollowing(item.rootId)}
+                      onReplyInThread={isReadOnly ? undefined : () => aimAtThread(
+                        item.rootId,
+                        String(messages.find((x) => String(x.id) === item.rootId)?.content || ''),
+                      )}
                     />
                     {!collapsed && (
                       <div className="v2-thread-replies">
@@ -1292,7 +1305,8 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                             agentAuthorKeys={agentAuthorKeys}
                             onAuthorClick={onOpenMember ? handleAuthorClick : undefined}
                             onOpenFile={onOpenFile}
-                            onReply={aimAtMessage}
+                            onReply={isReadOnly ? undefined : aimAtMessage}
+                            onThread={isReadOnly ? undefined : aimAtMessageThread}
                             grouped={isGroupedWithPrevious(r, item.replies[ri - 1])}
                             // Only the rail passes this. The same message
                             // rendered flat keeps its quote, which is the
@@ -1304,6 +1318,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                           <button
                             type="button"
                             className="v2-thread-replies__aim"
+                            aria-label={t('podChat.thread.replyFromExpandedThread')}
                             onClick={() => aimAtThread(
                               item.rootId,
                               String(messages.find((x) => String(x.id) === item.rootId)?.content || ''),

--- a/frontend/src/v2/components/V2ThreadCard.tsx
+++ b/frontend/src/v2/components/V2ThreadCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import V2Avatar from './V2Avatar';
 import { shortTimeSince } from '../utils/shortTime';
 
@@ -37,6 +38,8 @@ interface V2ThreadCardProps {
   addressed?: boolean;
   onToggleCollapsed: () => void;
   onToggleFollowing: () => void;
+  /** Aim the composer at this card's root without first opening the rail. */
+  onReplyInThread?: () => void;
   /** Injected in tests so the stamp is about boundaries, not about the clock. */
   now?: Date;
 }
@@ -64,8 +67,10 @@ const V2ThreadCard: React.FC<V2ThreadCardProps> = ({
   addressed = false,
   onToggleCollapsed,
   onToggleFollowing,
+  onReplyInThread,
   now,
 }) => {
+  const { t } = useTranslation();
   const shown = participants.slice(0, MAX_AVATARS);
   const stamp = shortTimeSince(lastActivityAt, now);
   const countLabel = `${replyCount} ${replyCount === 1 ? 'reply' : 'replies'}`;
@@ -105,6 +110,16 @@ const V2ThreadCard: React.FC<V2ThreadCardProps> = ({
         {stamp && <span className="v2-thread-card__time">{stamp}</span>}
         {!collapsed && <span className="v2-thread-card__chevron" aria-hidden="true">⌄</span>}
       </button>
+
+      {onReplyInThread && (
+        <button
+          type="button"
+          className="v2-thread-card__reply"
+          onClick={onReplyInThread}
+        >
+          {t('podChat.thread.replyInThread')}
+        </button>
+      )}
 
       {/* Follow lives outside the expand button: nesting a control inside a
           control is invalid, and a mis-hit that silently muted a thread is the

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -2482,28 +2482,35 @@
 /* Consecutive-author grouping (craft baseline rule 3): grouped rows drop
    the 22px head + avatar and tighten padding, so a run of messages from one
    author reads as one block. The ghost keeps the grid's avatar column so
-   text alignment never shifts. Reply becomes a hover affordance pinned to
-   the row's top-right, since the head row (and its Reply button) is gone. */
+   text alignment never shifts. Reply and Thread become hover affordances
+   pinned to the row's top-right, since the head row is gone. */
 .v2-msg--grouped { padding: 2px 0; position: relative; }
 .v2-msg__avatar-ghost { width: 38px; }
-.v2-msg__reply-float {
+.v2-msg__thread-actions--float {
   position: absolute;
-  top: 0;
+  top: -11px;
   right: 8px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+}
+.v2-root button.v2-msg__reply-float,
+.v2-root button.v2-msg__thread-float {
   appearance: none;
   border: 1px solid var(--v2-border);
   background: var(--v2-surface);
   color: var(--v2-text-secondary);
   font-size: 11px;
   border-radius: 6px;
-  padding: 2px 8px;
+  min-height: 44px;
+  padding: 0 8px;
   cursor: pointer;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.12s ease;
 }
-.v2-msg--grouped:hover .v2-msg__reply-float,
-.v2-msg__reply-float:focus-visible {
+.v2-msg--grouped:hover .v2-msg__thread-actions--float,
+.v2-msg__thread-actions--float:focus-within {
   opacity: 1;
   pointer-events: auto;
 }
@@ -6402,10 +6409,23 @@
   }
 }
 
-/* Reply threading (human side of replyToMessageId). */
-.v2-root button.v2-msg__reply-btn {
+/* Reply and Thread are distinct composer targets. The 44px actions sit on a
+   22px desktop header using a negative vertical margin, then become a visible
+   row on touch-sized layouts below. This preserves channel density without
+   reducing the hit area (TASK-052). */
+.v2-msg__thread-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
   margin-left: 4px;
-  padding: 0 6px;
+}
+.v2-root button.v2-msg__reply-btn,
+.v2-root button.v2-msg__thread-btn {
+  margin-left: 4px;
+  min-height: 44px;
+  margin-top: -11px;
+  margin-bottom: -11px;
+  padding: 0 8px;
   font-size: 11.5px;
   font-weight: 600;
   color: var(--v2-text-secondary);
@@ -6417,10 +6437,13 @@
   transition: opacity 0.1s ease;
 }
 .v2-msg:hover .v2-msg__reply-btn,
-.v2-msg__reply-btn:focus-visible {
+.v2-msg:hover .v2-msg__thread-btn,
+.v2-msg__reply-btn:focus-visible,
+.v2-msg__thread-btn:focus-visible {
   opacity: 1;
 }
-.v2-root button.v2-msg__reply-btn:hover { color: var(--v2-accent); }
+.v2-root button.v2-msg__reply-btn:hover,
+.v2-root button.v2-msg__thread-btn:hover { color: var(--v2-accent); }
 
 .v2-msg__quote {
   display: flex;
@@ -7207,6 +7230,24 @@
   border-color: #d7dce7;
 }
 
+/* This is deliberately outside the expand button: it must aim the composer
+   without toggling the rail, and nested controls are invalid HTML. */
+.v2-root button.v2-thread-card__reply {
+  min-height: 44px;
+  padding: 6px 10px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: #7b8494;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.v2-root button.v2-thread-card__reply:hover {
+  color: var(--v2-accent);
+}
+
 .v2-thread-card__count {
   font-weight: 500;
   display: inline-flex;
@@ -7328,6 +7369,37 @@
 }
 
 @media (max-width: 640px) {
+  /* Touch has no hover. Keep Thread and Reply discoverable and keep their
+     44px hit areas in normal flow rather than over the message content. */
+  .v2-msg__head {
+    height: auto;
+    flex-wrap: wrap;
+  }
+
+  .v2-msg__thread-actions {
+    flex-basis: 100%;
+    margin-left: 0;
+    gap: 4px;
+  }
+
+  .v2-root button.v2-msg__reply-btn,
+  .v2-root button.v2-msg__thread-btn {
+    margin-top: 0;
+    margin-bottom: 0;
+    opacity: 1;
+  }
+
+  .v2-msg__thread-actions--float {
+    position: static;
+    margin: 0;
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .v2-thread-card {
+    flex-wrap: wrap;
+  }
+
   /* The axis does NOT move at 390 — no channel-row override exists at this
      breakpoint, so the root avatar centre is still x = 15. Only the inner
      padding tightens: 16 + 8 + 24 + 8 = x = 56. */
@@ -7337,6 +7409,7 @@
   }
 
   .v2-root button.v2-thread-card__main {
+    flex: 1 1 100%;
     flex-wrap: wrap; /* brief: card goes to two lines at 390 */
   }
 }


### PR DESCRIPTION
## Summary
- add **Thread** beside Reply on flat and grouped messages; starting from an existing reply preserves its root
- add card-level **Reply in thread** without requiring expansion and retain the in-rail action
- keep Reply semantics distinct, add localized strings, and make all entry targets 44px and touch-visible at 390px

## Verification
- `./node_modules/.bin/jest --watchAll=false --runInBand` — 78 suites / 429 tests passed
- focused composer/card/layout suite — 4 suites / 76 tests passed
- `tsc --noEmit`, ESLint, and `git diff --check` passed
- browser checked: 44px Thread/Reply targets at 1200px and 390px, no horizontal overflow
- mutation: removing the flat Thread handler makes the replies-less-message contract test fail

`npm ci` is currently blocked by a pre-existing lockfile mismatch; local dependencies were installed without touching the lockfile.