### PR TITLE
docs(ax): a stacked PR runs no static analysis, and CodeQL is not in the repo

### DIFF
--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -2535,17 +2535,35 @@ scanned. That is a second reason the retarget is load-bearing, alongside the
 auto-close hazard.
 
 **Not every absence is a stacking absence, and E2E is the one that fools you.**
-Measured on a second pair (#1170 at 11 checks, the stacked #1132 at 4), seven
-are absent rather than six, and the extra one is `E2E Tests`. It is tempting to
-add it to the stacking gap; it does not belong there. `playwright.yml` carries
-no `branches` filter on `pull_request` — the line above it says so outright,
-*"No branches filter: stacked PRs must get E2E too"* — so E2E is absent from
-#1132 because that PR touches only `docs/`, which the path filter excludes.
-@sprint-review made exactly this attribution and retracted it, which is the
-evidence that it is worth writing down: the stacking gap is **four**, and any
-other absence has to be traced to a filter before it is counted. Two absences
-with the same appearance can have different causes, and the count is only
-portable if each one is attributed.
+Two axes move the denominator independently — **paths** and **base** — and
+folding one into the other is how a count stops being portable. Three PRs
+measured 2026-08-25 separate them, because the middle one holds content
+constant and varies only the base:
+
+| PR | content | base | checks |
+|---|---|---|---|
+| #1170 | `backend/` | `main` | 11 |
+| #1122 | `docs/` | `main` | 10 |
+| #1132 | `docs/` | stacked | 4 |
+
+`#1170 → #1122` isolates the **paths** axis and moves exactly one check:
+`E2E Tests`. `playwright.yml` carries no `branches` filter on `pull_request` —
+the line above it says so outright, *"No branches filter: stacked PRs must get
+E2E too"* — so E2E is absent from a docs-only PR whether or not it is stacked.
+
+`#1122 → #1132` isolates the **base** axis and moves six: the four CodeQL-family
+jobs plus the two base-scoped merge guards (`Source changed ⇒ version bumped`,
+`Stale-base merge guard`). The guards are correctly filtered rather than lost,
+so **what stacking actually costs you is the CodeQL family, entire and nothing
+else** — which is a sharper claim than a raw "seven missing", and a falsifiable
+one.
+
+@sprint-review first decomposed #1132's seven as "4 analysis, 1 E2E, 2 by-design
+guards" and put the E2E in the stacking gap, then retracted it and supplied the
+#1122 measurement that settles it. Worth recording because the misattribution
+was made by the person who found the CodeQL scoping in the first place: two
+absences render identically in the checks list, so an absence has to be traced
+to its filter before it is counted.
 
 **The scoping of those three cannot be checked from inside a checkout.** The
 entry above notes there is no `codeql.yml`; the sharper form is that the

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -2526,8 +2526,10 @@ membership; two consequences of it are worth stating outright rather than
 leaving to be re-derived.
 
 **A stacked PR is not differently checked, it is LESS checked, and the missing
-set is weighted toward analysis.** Three of the six extras are CodeQL's. So
-until its base is `main`, a stacked PR gets **no static analysis at all** — a
+set is weighted toward analysis.** Four of the six extras are CodeQL's — the
+umbrella check plus `Analyze (actions)`, `(javascript-typescript)` and
+`(python)`. So until its base is `main`, a stacked PR gets **no static
+analysis at all** — a
 change can be reviewed, gated, and merged into its parent having never been
 scanned. That is a second reason the retarget is load-bearing, alongside the
 auto-close hazard.

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -2534,6 +2534,19 @@ change can be reviewed, gated, and merged into its parent having never been
 scanned. That is a second reason the retarget is load-bearing, alongside the
 auto-close hazard.
 
+**Not every absence is a stacking absence, and E2E is the one that fools you.**
+Measured on a second pair (#1170 at 11 checks, the stacked #1132 at 4), seven
+are absent rather than six, and the extra one is `E2E Tests`. It is tempting to
+add it to the stacking gap; it does not belong there. `playwright.yml` carries
+no `branches` filter on `pull_request` — the line above it says so outright,
+*"No branches filter: stacked PRs must get E2E too"* — so E2E is absent from
+#1132 because that PR touches only `docs/`, which the path filter excludes.
+@sprint-review made exactly this attribution and retracted it, which is the
+evidence that it is worth writing down: the stacking gap is **four**, and any
+other absence has to be traced to a filter before it is counted. Two absences
+with the same appearance can have different causes, and the count is only
+portable if each one is attributed.
+
 **The scoping of those three cannot be checked from inside a checkout.** The
 entry above notes there is no `codeql.yml`; the sharper form is that the
 configuration lives *only* behind an API call:

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -2529,10 +2529,38 @@ leaving to be re-derived.
 set is weighted toward analysis.** Four of the six extras are CodeQL's — the
 umbrella check plus `Analyze (actions)`, `(javascript-typescript)` and
 `(python)`. So until its base is `main`, a stacked PR gets **no static
-analysis at all** — a
-change can be reviewed, gated, and merged into its parent having never been
-scanned. That is a second reason the retarget is load-bearing, alongside the
-auto-close hazard.
+analysis at all**.
+
+**What that costs, measured rather than assumed (2026-08-25).** The first
+draft of this addendum said such a change "can be reviewed, gated, and merged
+having never been scanned." The merge half does not survive checking:
+
+    last 200 merged PRs with base != main ........ 0
+    18 most recent merged, carrying CodeQL ....... 18 / 18
+       incl. #1187 (commonly-mcp only), #1185 (scripts + dev.sh + docs),
+             #1189 (backend + cli)
+    open stacked PRs at time of writing .......... 2, both docs-only
+
+GitHub auto-retargets a stacked PR to `main` when its parent lands, and the
+retargeted head then draws the full main-based set. Where the child merges into
+the parent branch instead, that merge is a `synchronize` on the parent's own
+main-based PR, so the combined content is analysed there before it reaches
+`main`. Nothing in the sampled window reached `main` unanalysed.
+
+So the harm is **not merge safety — it is a review-time verdict hazard**. A
+reviewer reads green on a stacked PR and cannot tell from the checks that
+nothing has been scanned yet. That is entry-worthy on its own: by the
+cheap/expensive split, a stale observation costs a paragraph, while an approval
+issued against an unanalysed head is the expensive kind, and the reviewer has
+no signal distinguishing the two. The retarget stays load-bearing for the
+auto-close hazard and for moving the verdict onto scanned ground; it is not
+what stands between unscanned code and `main`.
+
+Window, since a negative is only as good as its range: 200 merged PRs by
+`baseRefName`, 18 by check history, all open PRs as of 2026-08-25. `baseRefName`
+reports the **final** base, so a PR that was stacked and then retargeted is
+indistinguishable from one never stacked — which is why the CodeQL-presence
+sample is the load-bearing half here and the base count is not.
 
 **Not every absence is a stacking absence, and E2E is the one that fools you.**
 Two axes move the denominator independently — **paths** and **base** — and
@@ -2550,6 +2578,24 @@ constant and varies only the base:
 `E2E Tests`. `playwright.yml` carries no `branches` filter on `pull_request` —
 the line above it says so outright, *"No branches filter: stacked PRs must get
 E2E too"* — so E2E is absent from a docs-only PR whether or not it is stacked.
+
+The docs-only case is the *weak* form of the paths axis, and reading it as the
+whole of it under-states the gap — @sprint-review, 2026-08-25. `playwright.yml`
+is gated on `frontend/** | backend/** | e2e/** | playwright.config.*`, so a
+stacked PR **carrying code** in `cli/`, `scripts/`, `k8s/`, `commonly-mcp/`,
+`packages/` or `_external/clawdbot` gets `Tests` + `Detect secrets` and
+**neither E2E nor static analysis**. That is the case this entry is really
+about. The two axes bite independently, confirmed on merged history: #1187
+(`commonly-mcp` only) and #1185 (`scripts`, `dev.sh`, `install.sh`, docs) each
+ran CodeQL and neither ran E2E; stack either and the remaining coverage is two
+checks.
+
+Worth naming why it is easy to miss: `playwright.yml`'s `pull_request` block
+carries the comment *"No branches filter: stacked PRs must get E2E too"*, which
+is true about the **base** dimension and is silently undone for a whole class of
+code by the `paths:` clause three lines below it. A comment asserting coverage
+that a sibling clause in the same `on:` block removes — in the file that
+documents the fix.
 
 `#1122 → #1132` isolates the **base** axis and moves six: the four CodeQL-family
 jobs plus the two base-scoped merge guards (`Source changed ⇒ version bumped`,
@@ -2580,9 +2626,21 @@ produce the wrong denominator, with the *security* jobs as the omission it has
 no way to see. The failure is silent and points the wrong way: the checks that
 are hardest to notice missing are the ones you would most want to notice.
 
+**One exclusion, stated so nobody "fixes" it later** — @sprint-review,
+2026-08-25. Counting `branches`-scoped `pull_request` workflows in
+`.github/workflows/` returns **three**, not two: `package-version-guard.yml`,
+`pr-base-freshness.yml`, and `release-safety.yml`. The third is
+`branches: [ v1.0.x ]` — a different release line, not a main-PR skip. It is
+absent from a `main`-based PR and from a stacked one alike, so it belongs
+**outside** this denominator entirely. Anyone recomputing the gap from the
+workflow files will find it and, without this note, will either count it as a
+fourth base-scoped guard or "correct" it to `main`.
+
 **Practical rule**, the mirror of the base-scoped-guard tell above: `Analyze
 (…)` jobs are a second certificate that a run happened against `main`. Their
-absence means the PR is stacked — and that nothing has scanned it yet.
+absence means the PR is stacked — and that nothing has scanned it yet. Read it
+as a fact about the *verdict you are about to issue*, not about what will reach
+`main`: the code will be scanned, later, on someone else's PR.
 
 ## 42. A dual-auth route degrades to the other identity silently, so a test can name a shape it never exercises (2026-08-22, sprint-review + pod-architect)
 

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -2542,7 +2542,19 @@ having never been scanned." The merge half does not survive checking:
     open stacked PRs at time of writing .......... 2, both docs-only
 
 GitHub auto-retargets a stacked PR to `main` when its parent lands, and the
-retargeted head then draws the full main-based set. Where the child merges into
+retargeted head then draws the full main-based set. **That second clause is too
+strong, and #1251 is what caught it** — @sprint-review, 2026-08-26. Being *in*
+the main-based population and being *checked* by its full set are two claims,
+and this sentence ran them together. The two base-scoped guards list
+`opened, synchronize, reopened[, ready_for_review]`; retargeting fires `edited`,
+which is in neither list, so neither guard runs on the transition itself — only
+on the next push, if one comes. What the retarget reliably does is move the head
+into the population, not subject it to the checks. The CodeQL family is
+configured outside any `on:` block in this repo, so whether *it* fires on a
+retarget cannot be answered from a checkout either — this entry's own complaint,
+pointed back at the entry. The measurement above is unaffected: it samples
+CodeQL presence on merged heads, and that observation stands however the
+transition is triggered. Where the child merges into
 the parent branch instead, that merge is a `synchronize` on the parent's own
 main-based PR, so the combined content is analysed there before it reaches
 `main`. Nothing in the sampled window reached `main` unanalysed.

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -2519,38 +2519,37 @@ workflow's clock instead of the pod's, the parent commit instead of the head.
   retarget. Reading the check *names* answers a question the check *count*
   cannot.
 
-### Addendum: the missing checks include the security ones, and they are invisible to the repo
+### Addendum: what the six absent checks mean, and why one of them is unfalsifiable from a checkout
 
-@sprint-review, 2026-08-22. A stacked PR does not merely run a *different*
-check set than a main-based one — it runs a **smaller** one, and the difference
-is weighted toward analysis rather than tests. `#1109` (base `main`) showed 11
-checks; `#1120` (stacked) showed 5. The six absent were the two base-scoped
-merge guards plus **CodeQL: `Analyze (actions)`, `Analyze (javascript-typescript)`,
-`Analyze (python)`**.
+@sprint-review, 2026-08-22. The table above establishes the counts and the
+membership; two consequences of it are worth stating outright rather than
+leaving to be re-derived.
 
-So the retarget is load-bearing for a second reason beyond a green tick being
-about the right tree: until its base is `main`, a stacked PR gets **no static
-analysis at all**. A change can be reviewed, gated, and merged into its parent
-having never been scanned.
+**A stacked PR is not differently checked, it is LESS checked, and the missing
+set is weighted toward analysis.** Three of the six extras are CodeQL's. So
+until its base is `main`, a stacked PR gets **no static analysis at all** — a
+change can be reviewed, gated, and merged into its parent having never been
+scanned. That is a second reason the retarget is load-bearing, alongside the
+auto-close hazard.
 
-**The part that makes this agent-experience rather than trivia:** you cannot
-discover any of it by reading the repository. There is no `codeql.yml` in
-`.github/workflows/` — the scan is GitHub *default setup*, configured through
-the web UI, and `gh api repos/<owner>/<repo>/code-scanning/default-setup`
-is the only place its state and language list exist:
+**The scoping of those three cannot be checked from inside a checkout.** The
+entry above notes there is no `codeql.yml`; the sharper form is that the
+configuration lives *only* behind an API call:
 
-    state: configured
-    languages: actions, javascript, javascript-typescript, python, typescript
+    gh api repos/<owner>/<repo>/code-scanning/default-setup
+      state: configured
+      languages: actions, javascript, javascript-typescript, python, typescript
 
-Every other check in this repo can be traced to a file with a `on:` block a
-reader can inspect. This one cannot, so its trigger scoping is unfalsifiable
-from inside a checkout — and an agent reasoning about "which checks should this
-PR have" from `.github/workflows/` will confidently compute the wrong
-denominator, with the security checks as the omission it cannot see.
+Every other check in this repo traces to a file with an `on:` block a reader
+can inspect and falsify. This one does not — so an agent computing "which
+checks should this PR have?" from `.github/workflows/` will confidently
+produce the wrong denominator, with the *security* jobs as the omission it has
+no way to see. The failure is silent and points the wrong way: the checks that
+are hardest to notice missing are the ones you would most want to notice.
 
-Practical rule, matching the base-scoped-guard tell above: **`Analyze (…)` jobs
-are a second certificate that a run happened against `main`.** Their absence
-means the PR is stacked, and it means nothing has been scanned yet.
+**Practical rule**, the mirror of the base-scoped-guard tell above: `Analyze
+(…)` jobs are a second certificate that a run happened against `main`. Their
+absence means the PR is stacked — and that nothing has scanned it yet.
 
 ## 42. A dual-auth route degrades to the other identity silently, so a test can name a shape it never exercises (2026-08-22, sprint-review + pod-architect)
 

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -2519,6 +2519,39 @@ workflow's clock instead of the pod's, the parent commit instead of the head.
   retarget. Reading the check *names* answers a question the check *count*
   cannot.
 
+### Addendum: the missing checks include the security ones, and they are invisible to the repo
+
+@sprint-review, 2026-08-22. A stacked PR does not merely run a *different*
+check set than a main-based one — it runs a **smaller** one, and the difference
+is weighted toward analysis rather than tests. `#1109` (base `main`) showed 11
+checks; `#1120` (stacked) showed 5. The six absent were the two base-scoped
+merge guards plus **CodeQL: `Analyze (actions)`, `Analyze (javascript-typescript)`,
+`Analyze (python)`**.
+
+So the retarget is load-bearing for a second reason beyond a green tick being
+about the right tree: until its base is `main`, a stacked PR gets **no static
+analysis at all**. A change can be reviewed, gated, and merged into its parent
+having never been scanned.
+
+**The part that makes this agent-experience rather than trivia:** you cannot
+discover any of it by reading the repository. There is no `codeql.yml` in
+`.github/workflows/` — the scan is GitHub *default setup*, configured through
+the web UI, and `gh api repos/<owner>/<repo>/code-scanning/default-setup`
+is the only place its state and language list exist:
+
+    state: configured
+    languages: actions, javascript, javascript-typescript, python, typescript
+
+Every other check in this repo can be traced to a file with a `on:` block a
+reader can inspect. This one cannot, so its trigger scoping is unfalsifiable
+from inside a checkout — and an agent reasoning about "which checks should this
+PR have" from `.github/workflows/` will confidently compute the wrong
+denominator, with the security checks as the omission it cannot see.
+
+Practical rule, matching the base-scoped-guard tell above: **`Analyze (…)` jobs
+are a second certificate that a run happened against `main`.** Their absence
+means the PR is stacked, and it means nothing has been scanned yet.
+
 ## 42. A dual-auth route degrades to the other identity silently, so a test can name a shape it never exercises (2026-08-22, sprint-review + pod-architect)
 
 > Numbering follows entry 41's caveat: 39 and 40 are still reserved by #1122


### PR DESCRIPTION
@sprint-review (57274) noticed #1109 showed **11** checks and #1120 showed **5**, and named the six: the two base-scoped merge guards plus three CodeQL jobs — `Analyze (actions)`, `Analyze (javascript-typescript)`, `Analyze (python)`.

**Two measurements, and the count is content-dependent — cite the PR with it.** The pair above is #1109 (11) vs #1120 (5). A second pair measured 2026-08-25 on different PRs gives a different gap: #1170 shows **11**, the stacked #1132 shows **4**, and the CodeQL family there is *four* jobs, not three (`CodeQL` itself alongside the three `Analyze` jobs). Path filters move the denominator with the content, so a bare "N checks missing" is not portable between PRs. The seventh absence on the second pair is `E2E Tests`, and it is **not** part of the stacking gap: `playwright.yml` has no `branches` filter on `pull_request` ("No branches filter: stacked PRs must get E2E too"), so it is absent because #1132 is `docs/`-only. The stacking gap is **four**. What is stable across both pairs is the weighting: the missing set is dominated by analysis, and two of the absences — the version-bump and stale-base guards — are base-scoped and correctly filtered rather than lost.

That makes the retarget load-bearing for a second reason beyond AX 41's original one. A stacked PR isn't *differently* checked, it's **less** checked, and the gap is weighted toward analysis: until its base is `main`, **no CodeQL analysis runs against it**. A change can be reviewed, gated, and merged into its parent having never been statically analysed.

*Corrected from "nothing scans it", which was too strong: @sprint-review measured `Detect secrets` running on the stacked PR (57822). Secret scanning is not the omission; static analysis is.*

## Why it's agent-experience and not trivia

None of it is discoverable from a checkout. There is no `codeql.yml` in `.github/workflows/` — the scan is GitHub **default setup**, configured through the web UI, and the only place its state and language list exist is:

```
gh api repos/Team-Commonly/commonly/code-scanning/default-setup
  state: configured
  languages: actions, javascript, javascript-typescript, python, typescript
```

Every other check in this repo traces to a file with an `on:` block a reader can inspect. This one doesn't, so its trigger scoping is unfalsifiable from inside a checkout — and an agent computing "which checks should this PR have?" from `.github/workflows/` will confidently get the wrong denominator, with the *security* checks as the omission it cannot see.

**Practical rule**, matching the base-scoped-guard tell already in entry 41: `Analyze (…)` jobs are a second certificate that a run happened against `main`. Their absence means the PR is stacked — and that nothing has been scanned yet.

Filed as an addendum to entry 41 rather than a new entry: same incident, same defect class, and 41 is already where the `(base, paths)` denominator is recorded. No new number, so no collision with #1122/#1132/#1142/#1143.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


