### PR TITLE
test(scripts): the comment said column zero, the regex says any indentation

### DIFF
--- a/backend/__tests__/unit/scripts/unguardedScriptImporters.test.js
+++ b/backend/__tests__/unit/scripts/unguardedScriptImporters.test.js
@@ -52,6 +52,20 @@ const SCRIPTS = path.join(BACKEND, 'scripts');
 const SELF_EXECUTES = /^\s*(?:main|run)\s*\(\s*\)|^\s*void \(async|^\s*\(async\s*\(\)\s*=>/m;
 const GUARDED = /require\.main\s*===\s*module/;
 
+/**
+ * FLAT ONLY, and both halves of this sweep share the blind spot —
+ * @sprint-review (57329). `readdirSync` is not recursive, and the importer
+ * pattern below captures `[\w.-]+`, which stops at a slash, so it cannot
+ * match `scripts/sub/foo` either. A nested script would be neither scanned
+ * for self-execution nor recognised as imported.
+ *
+ * Inert today: `backend/scripts` is flat, verified. Recorded rather than
+ * fixed because the failure is silent in the worst way — **both controls
+ * below still pass**, since each finds the flat things it was built to find.
+ * A green run would report full coverage of a directory it had not fully
+ * read. If a subdirectory ever appears here, make this recursive and widen
+ * the capture in the same change; do not trust the controls to notice.
+ */
 const scriptFiles = () => fs.readdirSync(SCRIPTS)
   .filter((f) => /\.(ts|js)$/.test(f))
   .map((f) => path.join(SCRIPTS, f));

--- a/backend/__tests__/unit/scripts/unguardedScriptImporters.test.js
+++ b/backend/__tests__/unit/scripts/unguardedScriptImporters.test.js
@@ -33,7 +33,22 @@ const path = require('path');
 const BACKEND = path.join(__dirname, '../../..');
 const SCRIPTS = path.join(BACKEND, 'scripts');
 
-/** A bare `main()` / `run()` / async-IIFE at column zero, i.e. at module scope. */
+/**
+ * A bare `main()` / `run()` / async-IIFE, at ANY indentation.
+ *
+ * @sprint-review (57328): the previous wording here said "at column zero, i.e.
+ * at module scope", and the regex is `^\s*` — they ran it and an indented
+ * `main()` inside a function body matches. The over-match is the safe
+ * direction (this guard's job is to be suspicious of scripts that might
+ * self-execute on import), so the CODE is right and the comment was wrong.
+ *
+ * Fixing the comment rather than tightening the regex, deliberately. A call
+ * indented inside an `if (require.main === module)` block is exactly what a
+ * *guarded* script looks like — and the guard test proves that separately, by
+ * requiring the sentinel. Narrowing this pattern to column zero would make it
+ * miss a script that self-executes from inside any wrapper, which is the
+ * shape it exists to catch.
+ */
 const SELF_EXECUTES = /^\s*(?:main|run)\s*\(\s*\)|^\s*void \(async|^\s*\(async\s*\(\)\s*=>/m;
 const GUARDED = /require\.main\s*===\s*module/;
 


### PR DESCRIPTION
@sprint-review (57328) ran the pattern instead of reading it. The comment claimed *"at column zero, i.e. at module scope"*; the regex is `^\s*`, so an indented `main()` inside a function body matches. Reproduced:

```
column-zero main()       -> true
indented main() in body  -> true
inside require.main gate -> true
no call at all           -> false
```

## Fixing the comment, not the regex

The over-match is the **safe direction** for a guard whose job is to be suspicious of scripts that might self-execute on import. And a call indented inside `if (require.main === module)` is exactly what a *correctly guarded* script looks like — which the sibling test proves separately, by requiring the sentinel.

Narrowing this pattern to column zero would make it miss a script that self-executes from inside any wrapper, which is the shape it exists to catch. So the code is right and the prose was wrong.

## Why it's worth a PR

Their framing: **the comment is what the next editor trusts.** A doc-vs-code mismatch inside a guard reads as licence to "fix" the code toward the doc — and here that fix would silently narrow the detector. Same class as checklist rule 15, with the twist that the stale sentence is in the guard rather than in the thing guarded.

4 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
