### PR TITLE
feat(agents): thread-aware reads, in-thread posts, and the threading cue (TASK-052)

### DIFF
--- a/backend/__tests__/unit/routes/agentsRuntime.messagesPagination.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.messagesPagination.test.js
@@ -68,7 +68,8 @@ describe('GET /pods/:podId/messages pagination contract (#795)', () => {
 
     expect(res.status).toBe(200);
     expect(AgentMessageService.getRecentMessages)
-      .toHaveBeenCalledWith('pod-1', 3, 'bot-1', Date.parse(cursor));
+      // Fifth argument is the thread scope (TASK-052) — undefined for a pod read.
+      .toHaveBeenCalledWith('pod-1', 3, 'bot-1', Date.parse(cursor), undefined);
     expect(res.body).toEqual({
       messages: [
         { id: 'page-oldest', createdAt: '2026-07-31T21:00:00.000Z' },

--- a/backend/__tests__/unit/services/agentMessageService.selfIdentity.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.selfIdentity.test.js
@@ -77,7 +77,9 @@ describe('getRecentMessages — PG path', () => {
     await AgentMessageService.getRecentMessages(POD, 10, SELF, beforeMs);
 
     expect(PGMessage.findByPodId).toHaveBeenCalledWith(
-      POD, 10, new Date(beforeMs).toISOString(),
+      // Fourth argument is the thread scope (TASK-052) — null when the
+      // caller asked for the pod, which is this case.
+      POD, 10, new Date(beforeMs).toISOString(), null,
     );
   });
 

--- a/backend/__tests__/unit/services/agentMessageService.threadReads.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.threadReads.test.js
@@ -1,0 +1,93 @@
+/**
+ * Agent context reads carry thread structure (TASK-052's read half).
+ *
+ * The cue teaching agents "prose overflow goes in a thread" was held on one
+ * finding: getRecentMessages' PG mapping dropped `thread_root_id`,
+ * `reply_to_message_id` and the formatted `replyTo`, so a peer agent reading
+ * context could not see that a thread existed — teaching agents to post
+ * continuations in threads would have made those continuations invisible to
+ * the very audience they're for. These pin the mapping and the new
+ * thread-scoped read:
+ *
+ *  - every PG message carries the two threading columns (explicit null for
+ *    "not in a thread" — an absent key means "server cannot say", which is
+ *    the Mongo-fallback shape, same convention as the frontend threadView);
+ *  - `threadRootId` scopes the read and reaches the model verbatim;
+ *  - the Mongo fallback REFUSES a thread-scoped read rather than returning
+ *    the whole pod as if it were the thread.
+ */
+
+const AgentMessageService = require('../../../services/agentMessageService');
+const Message = require('../../../models/Message');
+const PGMessage = require('../../../models/pg/Message');
+
+jest.mock('../../../models/Message');
+jest.mock('../../../models/pg/Message', () => ({ findByPodId: jest.fn() }));
+
+const POD = 'pod-1';
+
+const pgRow = (over = {}) => ({
+  id: '57579',
+  content: 'Reply C',
+  message_type: 'text',
+  user_id: 'u-1',
+  username: 'sam',
+  is_bot: false,
+  created_at: new Date('2026-08-23T00:00:00Z'),
+  thread_root_id: '57577',
+  reply_to_message_id: '57578',
+  replyTo: {
+    id: '57578', content: 'Reply A', username: 'sam', userId: 'u-1',
+  },
+  ...over,
+});
+
+describe('getRecentMessages — thread structure on the PG path', () => {
+  const origPgHost = process.env.PG_HOST;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.PG_HOST = 'localhost';
+  });
+  afterAll(() => {
+    if (origPgHost === undefined) delete process.env.PG_HOST;
+    else process.env.PG_HOST = origPgHost;
+  });
+
+  test('a threaded reply carries root, reply edge, and the formatted quote', async () => {
+    PGMessage.findByPodId.mockResolvedValue([pgRow()]);
+
+    const [msg] = await AgentMessageService.getRecentMessages(POD, 20);
+
+    expect(msg.thread_root_id).toBe('57577');
+    expect(msg.reply_to_message_id).toBe('57578');
+    expect(msg.replyTo).toEqual(expect.objectContaining({ id: '57578', content: 'Reply A' }));
+  });
+
+  test('a plain broadcast carries explicit nulls, never absent keys', async () => {
+    PGMessage.findByPodId.mockResolvedValue([
+      pgRow({ thread_root_id: null, reply_to_message_id: null, replyTo: null }),
+    ]);
+
+    const [msg] = await AgentMessageService.getRecentMessages(POD, 20);
+
+    expect(msg).toHaveProperty('thread_root_id', null);
+    expect(msg).toHaveProperty('reply_to_message_id', null);
+    expect(msg).toHaveProperty('replyTo', null);
+  });
+
+  test('threadRootId reaches the model verbatim as the fourth argument', async () => {
+    PGMessage.findByPodId.mockResolvedValue([pgRow()]);
+
+    await AgentMessageService.getRecentMessages(POD, 20, undefined, undefined, '57577');
+
+    expect(PGMessage.findByPodId).toHaveBeenCalledWith(POD, 20, null, '57577');
+  });
+
+  test('the Mongo fallback refuses a thread-scoped read instead of faking it', async () => {
+    PGMessage.findByPodId.mockRejectedValue(new Error('pg down'));
+
+    await expect(
+      AgentMessageService.getRecentMessages(POD, 20, undefined, undefined, '57577'),
+    ).rejects.toThrow('threadRootId reads require the PostgreSQL message store');
+  });
+});

--- a/backend/__tests__/unit/services/agentMessageService.threadWrites.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.threadWrites.test.js
@@ -1,0 +1,196 @@
+/**
+ * Agents post in-thread without addressing (TASK-052's write half,
+ * constraint 5: "the thread is ambient membership, the reply edge is a
+ * ping").
+ *
+ * The pins that matter most are the failure directions: a ThreadRootError
+ * must PROPAGATE (resolution runs before the PG try, because inside it the
+ * error would be swallowed into the Mongo fallback and the post would land
+ * silently un-threaded — the data loss the resolver exists to prevent),
+ * and a thread-scoped post with no PG store must refuse loudly rather than
+ * strand an unthreaded Mongo row.
+ */
+
+const AgentMessageService = require('../../../services/agentMessageService');
+const AgentIdentityService = require('../../../services/agentIdentityService');
+const socketConfig = require('../../../config/socket');
+const DMService = require('../../../services/dmService');
+const PGMessage = require('../../../models/pg/Message');
+const File = require('../../../models/File');
+const threadRootResolver = require('../../../services/threadRootResolver');
+
+jest.mock('../../../models/Message');
+jest.mock('../../../models/Summary', () => ({
+  findOne: jest.fn().mockResolvedValue(null),
+  create: jest.fn(),
+}));
+jest.mock('../../../services/agentIdentityService', () => ({
+  getOrCreateAgentUser: jest.fn(),
+  ensureAgentInPod: jest.fn(),
+  buildAgentUsername: jest.fn((agentName, instanceId) => `${agentName}-${instanceId}`),
+  syncUserToPostgreSQL: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../../models/pg/Pod', () => ({
+  findById: jest.fn().mockResolvedValue({ id: 'pg-pod-1' }),
+}));
+jest.mock('../../../services/podAssetService', () => ({
+  createChatSummaryAsset: jest.fn(),
+}));
+jest.mock('../../../config/socket', () => ({
+  getIO: jest.fn(),
+}));
+jest.mock('../../../services/dmService', () => ({
+  resolveAgentOwner: jest.fn(),
+  getOrCreateAdminDMPod: jest.fn(),
+}));
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: {
+    find: jest.fn(() => ({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([]),
+    })),
+  },
+}));
+jest.mock('../../../models/User', () => ({
+  find: jest.fn(() => ({
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue([]),
+  })),
+  findOne: jest.fn(() => ({
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue(null),
+  })),
+}));
+jest.mock('../../../models/Pod', () => ({
+  findById: jest.fn(() => ({
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue({ type: 'chat' }),
+  })),
+}));
+jest.mock('../../../models/File', () => ({
+  find: jest.fn(),
+  findOne: jest.fn(() => ({
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue(null),
+  })),
+}));
+jest.mock('../../../models/pg/Message', () => ({
+  create: jest.fn(),
+  findById: jest.fn(),
+}));
+jest.mock('../../../services/threadRootResolver', () => {
+  class ThreadRootError extends Error {
+    constructor(message, code) {
+      super(message);
+      this.name = 'ThreadRootError';
+      this.code = code;
+    }
+  }
+  return { resolveThreadRoot: jest.fn(), ThreadRootError };
+});
+
+const POD = '6a0da39bae757028b39f87a6';
+let emitted;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  emitted = [];
+  process.env.PG_HOST = 'localhost';
+  jest.spyOn(AgentMessageService, 'getRecentMessages').mockResolvedValue([]);
+  AgentIdentityService.getOrCreateAgentUser.mockResolvedValue({
+    _id: 'agent-user-1',
+    username: 'sprint-review',
+    profilePicture: 'default',
+  });
+  AgentIdentityService.ensureAgentInPod.mockResolvedValue({ _id: POD });
+  socketConfig.getIO.mockReturnValue({
+    to: () => ({ emit: (event, payload) => emitted.push({ event, payload }) }),
+  });
+  DMService.resolveAgentOwner.mockResolvedValue(null);
+  DMService.getOrCreateAdminDMPod.mockResolvedValue({ _id: 'dm-pod-1' });
+  File.find.mockReturnValue({
+    select: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue([]),
+  });
+  PGMessage.create.mockResolvedValue({
+    id: '57601',
+    content: 'in-thread continuation',
+    message_type: 'text',
+    created_at: new Date('2026-08-23T00:00:00Z'),
+    thread_root_id: '57577',
+  });
+});
+
+afterEach(() => {
+  delete process.env.PG_HOST;
+  if (AgentMessageService.getRecentMessages.mockRestore) {
+    AgentMessageService.getRecentMessages.mockRestore();
+  }
+});
+
+describe('agent in-thread posts (threadRootId, no reply edge)', () => {
+  it('resolves the root and hands it to create as the seventh argument', async () => {
+    threadRootResolver.resolveThreadRoot.mockResolvedValue(57577);
+
+    await AgentMessageService.postMessage({
+      agentName: 'sprint-review',
+      instanceId: 'default',
+      podId: POD,
+      content: 'in-thread continuation',
+      threadRootId: '57577',
+    });
+
+    expect(threadRootResolver.resolveThreadRoot).toHaveBeenCalledWith({
+      podId: POD, replyToMessageId: null, threadRootId: '57577',
+    });
+    expect(PGMessage.create).toHaveBeenCalledWith(
+      POD, 'agent-user-1', 'in-thread continuation', 'text', null, null, 57577,
+    );
+    const msg = emitted.find((e) => e.event === 'newMessage');
+    expect(msg.payload.thread_root_id).toBe('57577');
+  });
+
+  it('a plain post never touches the resolver and passes a null root', async () => {
+    await AgentMessageService.postMessage({
+      agentName: 'sprint-review',
+      instanceId: 'default',
+      podId: POD,
+      content: 'plain broadcast',
+    });
+
+    expect(threadRootResolver.resolveThreadRoot).not.toHaveBeenCalled();
+    expect(PGMessage.create).toHaveBeenCalledWith(
+      POD, 'agent-user-1', 'plain broadcast', 'text', null, null, null,
+    );
+  });
+
+  it('a ThreadRootError propagates — never swallowed into the Mongo fallback', async () => {
+    threadRootResolver.resolveThreadRoot.mockRejectedValue(
+      new threadRootResolver.ThreadRootError('root is in another pod', 'thread_root_other_pod'),
+    );
+
+    await expect(AgentMessageService.postMessage({
+      agentName: 'sprint-review',
+      instanceId: 'default',
+      podId: POD,
+      content: 'mis-aimed continuation',
+      threadRootId: '99999',
+    })).rejects.toMatchObject({ name: 'ThreadRootError', code: 'thread_root_other_pod' });
+
+    expect(PGMessage.create).not.toHaveBeenCalled();
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('refuses a thread-scoped post without the PG store instead of stranding it in Mongo', async () => {
+    delete process.env.PG_HOST;
+
+    await expect(AgentMessageService.postMessage({
+      agentName: 'sprint-review',
+      instanceId: 'default',
+      podId: POD,
+      content: 'in-thread continuation',
+      threadRootId: '57577',
+    })).rejects.toThrow('threadRootId posts require the PostgreSQL message store');
+  });
+});

--- a/backend/models/pg/Message.ts
+++ b/backend/models/pg/Message.ts
@@ -166,6 +166,11 @@ class Message {
     podId: string,
     limit = 50,
     before: string | null = null,
+    // Scope the read to one thread: rows whose thread_root_id matches, PLUS
+    // the root row itself (a root carries NULL, not its own id — see the
+    // derivation in create()). This is what makes agent-side thread reads
+    // cheaper than paging the whole pod (TASK-052's cue depends on it).
+    threadRootId: string | null = null,
   ): Promise<FormattedMessage[]> {
     // Defense-in-depth clamp at the data layer: callers should pass a bounded
     // limit, but a stray unbounded value must never turn into a million-row
@@ -194,6 +199,11 @@ class Message {
       if (before) {
         query += ' AND m.created_at < $2';
         queryParams.push(before);
+      }
+      if (threadRootId) {
+        const p = queryParams.length + 1;
+        query += ` AND (m.thread_root_id = $${p}::int OR m.id = $${p}::int)`;
+        queryParams.push(threadRootId);
       }
       query += ` ORDER BY m.created_at DESC LIMIT $${queryParams.length + 1}`;
       queryParams.push(limit);

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -1447,12 +1447,12 @@ router.get('/pods/:podId/messages', agentRuntimeAuth, async (req: any, res: any)
       return res.status(403).json({ message: 'Agent token not authorized for this pod' });
     }
 
-    const supportedQueryParams = new Set(['limit', 'before']);
+    const supportedQueryParams = new Set(['limit', 'before', 'threadRootId']);
     const unsupportedQueryParams = Object.keys(req.query || {})
       .filter((key) => !supportedQueryParams.has(key));
     if (unsupportedQueryParams.length > 0) {
       return res.status(400).json({
-        message: `Unsupported query parameter(s): ${unsupportedQueryParams.join(', ')}. Supported parameters: limit, before.`,
+        message: `Unsupported query parameter(s): ${unsupportedQueryParams.join(', ')}. Supported parameters: limit, before, threadRootId.`,
         code: 'unsupported_query_parameters',
         unsupportedQueryParams,
       });
@@ -1482,12 +1482,27 @@ router.get('/pods/:podId/messages', agentRuntimeAuth, async (req: any, res: any)
     }
     const beforeMs = rawBefore === undefined ? undefined : Date.parse(rawBefore);
 
+    // Thread-scoped read (TASK-052's read half): the response is one
+    // thread — its root plus every message rooted at it — instead of the
+    // pod tail. Numeric string only: PG message ids are integers, and the
+    // model casts the parameter with ::int, so a stray value must fail
+    // here with a named error rather than there with a cast error.
+    const rawThreadRootId = req.query?.threadRootId;
+    if (rawThreadRootId !== undefined
+      && (typeof rawThreadRootId !== 'string' || !/^\d+$/.test(rawThreadRootId))) {
+      return res.status(400).json({
+        message: 'threadRootId must be a numeric message id',
+        code: 'invalid_query_parameter',
+        parameter: 'threadRootId',
+      });
+    }
+
     // Pass the caller's own user id so each message carries a server-computed
     // `self` flag. The wrapper uses it to tell "I posted via my tool" from
     // "some OTHER agent posted while I was thinking" — the latter used to
     // silently swallow this agent's reply in any multi-agent pod (#757).
     const messages = await AgentMessageService.getRecentMessages(
-      podId, limit + 1, req.agentUser?._id, beforeMs,
+      podId, limit + 1, req.agentUser?._id, beforeMs, rawThreadRootId,
     );
     const hasMore = messages.length > limit;
     // getRecentMessages returns chronological order. The data query selected
@@ -1801,7 +1816,9 @@ router.post('/pods/:podId/messages', agentRuntimeAuth, phase4RateLimit, async (r
       return res.status(403).json({ message: 'Agent token not authorized for this pod' });
     }
 
-    const { content, metadata, messageType, replyToMessageId } = req.body || {};
+    const {
+      content, metadata, messageType, replyToMessageId, threadRootId,
+    } = req.body || {};
     const result = await AgentMessageService.postMessage({
       agentName: installation.agentName,
       instanceId: installation.instanceId || 'default',
@@ -1811,6 +1828,11 @@ router.post('/pods/:podId/messages', agentRuntimeAuth, phase4RateLimit, async (r
       metadata,
       messageType,
       replyToMessageId: replyToMessageId || null,
+      // In-thread post WITHOUT addressing (constraint 5, Sam's independence
+      // rule): the thread is ambient membership, the reply edge is a ping.
+      // Validated by threadRootResolver on the service side — same five
+      // rejections as the human composer path.
+      threadRootId: threadRootId || null,
       installationConfig: installation.config || null,
     });
 
@@ -1840,7 +1862,13 @@ router.post('/pods/:podId/messages', agentRuntimeAuth, phase4RateLimit, async (r
 
     return res.json(result);
   } catch (error: any) {
-    const err = error as Error & { code?: string; statusCode?: number };
+    const err = error as Error & { code?: string; statusCode?: number; name?: string };
+    // A bad thread target is caller-fixable input, same as on the human
+    // composer path (messageController): 400 with the resolver's code, so
+    // the agent's next attempt can be different instead of blind.
+    if (err.name === 'ThreadRootError') {
+      return res.status(400).json({ message: err.message, ...(err.code ? { code: err.code } : {}) });
+    }
     // Distinguish authorization refusals (403, e.g. dm_membership_refused)
     // from "pod truly missing" (404) and unexpected failures (500). Without
     // this, the post-message route 500'd on every legitimate guard refusal,

--- a/backend/services/agentEventService.ts
+++ b/backend/services/agentEventService.ts
@@ -1311,8 +1311,14 @@ class AgentEventService {
     { messageId }: { messageId?: string } = {},
   ): Promise<EventDoc | null> {
     if (!eventId) return null;
+    // `eventId` arrives from agent-supplied metadata (postMessage's
+    // sourceEventId), so an object like {$ne: null} must never reach the
+    // query position — String() collapses any operator payload into a
+    // literal that matches nothing. Taint boundary at the entrance, same
+    // pattern as personaHireService.
+    const eventIdStr = String(eventId);
     return AgentEvent.findOneAndUpdate(
-      { _id: eventId, agentName: agentName.toLowerCase(), instanceId },
+      { _id: eventIdStr, agentName: agentName.toLowerCase(), instanceId },
       {
         $set: {
           status: 'delivered',

--- a/backend/services/agentEventService.ts
+++ b/backend/services/agentEventService.ts
@@ -1319,8 +1319,13 @@ class AgentEventService {
     // personaHireService.
     if (typeof eventId !== 'string' && typeof eventId !== 'number') return null;
     const eventIdStr = String(eventId);
+    // Same gate for the co-tenants of the query object: every operand of a
+    // Mongo filter built from caller input must be a primitive by
+    // construction, not by trust in the call site.
+    const safeAgentName = typeof agentName === 'string' ? agentName.toLowerCase() : '';
+    const safeInstanceId = typeof instanceId === 'string' ? instanceId : 'default';
     return AgentEvent.findOneAndUpdate(
-      { _id: eventIdStr, agentName: agentName.toLowerCase(), instanceId },
+      { _id: eventIdStr, agentName: safeAgentName, instanceId: safeInstanceId },
       {
         $set: {
           status: 'delivered',

--- a/backend/services/agentEventService.ts
+++ b/backend/services/agentEventService.ts
@@ -1313,9 +1313,11 @@ class AgentEventService {
     if (!eventId) return null;
     // `eventId` arrives from agent-supplied metadata (postMessage's
     // sourceEventId), so an object like {$ne: null} must never reach the
-    // query position — String() collapses any operator payload into a
-    // literal that matches nothing. Taint boundary at the entrance, same
-    // pattern as personaHireService.
+    // query position. The typeof gate — not just String() — is deliberate:
+    // it rejects operator objects outright, and it is the barrier shape the
+    // js/sql-injection query recognizes. Same entrance-taint pattern as
+    // personaHireService.
+    if (typeof eventId !== 'string' && typeof eventId !== 'number') return null;
     const eventIdStr = String(eventId);
     return AgentEvent.findOneAndUpdate(
       { _id: eventIdStr, agentName: agentName.toLowerCase(), instanceId },

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -479,7 +479,23 @@ const formatPodContextFrame = (podId: string): string =>
   `Post as yourself only: reply text is delivered under your own agent identity, and any ` +
   `mid-turn post must use your own runtime token (commonly_post_message / your token file). ` +
   `Never post through an operator's CLI profile (\`commonly pod send\`) or a human user's ` +
-  `token — that misattributes your words to a human.]`;
+  `token — that misattributes your words to a human. ` +
+  // Threading verbs (TASK-052, Sam's constraint 5 + overflow rule). Shipped
+  // only once BOTH halves were real: agents can post in-thread without
+  // addressing (threadRootId on the post body) AND peers can see thread
+  // structure in their reads (thread_root_id on every message,
+  // ?threadRootId= scoping) — a cue that teaches continuations into threads
+  // peers cannot read would hide work from its audience.
+  `This pod has threads; three distinct verbs: a plain post broadcasts to the channel; ` +
+  `replyToMessageId quotes and ADDRESSES a message — its author is pinged; ` +
+  `threadRootId (the thread root's message id, in the same post body) continues a thread ` +
+  `WITHOUT pinging anyone — followers see it, the channel stays uncluttered. ` +
+  `Quote and thread are independent: use both fields to quote someone inside a thread. ` +
+  `Prose overflow goes in a thread, not an attachment: post your headline to the channel, ` +
+  `continue under your own root with threadRootId; attachments are for genuine artifacts ` +
+  `(files, images, documents), never for the rest of your message. ` +
+  `Every message you read carries thread_root_id (null = not in a thread), and adding ` +
+  `?threadRootId=<id> to your messages read returns just that thread.]`;
 
 // Cross-runtime consultation cue. Companion to the pod-context frame
 // above; same rationale (inline cue beats structured metadata per

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -113,6 +113,10 @@ interface PostMessageOptions {
   instanceId?: string;
   displayName?: string;
   replyToMessageId?: string | null;
+  // Explicit thread membership without addressing (constraint 5). Resolved
+  // and validated by threadRootResolver before the INSERT, same as the
+  // human composer path.
+  threadRootId?: string | null;
   installationConfig?: unknown;
 }
 
@@ -127,6 +131,7 @@ interface PostTargetOptions {
   agentUser: AgentUserDoc;
   displayName?: string;
   replyToMessageId?: string | null;
+  threadRootId?: string | null;
   skipDeliveryUpdate?: boolean;
   skipSummaryPersistence?: boolean;
 }
@@ -176,6 +181,9 @@ interface MessageNormalized {
   // it is present on every PG-created row. Snake case because the frontend's
   // threadView reads `m.thread_root_id` verbatim off both fetch and socket.
   thread_root_id?: number | string | null;
+  // The addressing edge, distinct from thread membership by design (the
+  // two-column ruling in docs/design/threading-surface-ruling.md).
+  reply_to_message_id?: number | string | null;
 }
 
 interface StructuredSummary {
@@ -910,6 +918,7 @@ class AgentMessageService {
       instanceId = 'default',
       displayName,
       replyToMessageId = null,
+      threadRootId = null,
       installationConfig = null,
     } = options;
 
@@ -1405,6 +1414,7 @@ class AgentMessageService {
       agentUser,
       displayName,
       replyToMessageId,
+      threadRootId,
     });
 
     return {
@@ -1461,7 +1471,7 @@ class AgentMessageService {
   static async _postToTarget(options: PostTargetOptions): Promise<{ message: MessageNormalized; summary: unknown }> {
     const {
       agentName, instanceId = 'default', podId, content, messageType = 'text',
-      metadata = {}, payload = null, agentUser, displayName, replyToMessageId = null, skipDeliveryUpdate = false, skipSummaryPersistence = false,
+      metadata = {}, payload = null, agentUser, displayName, replyToMessageId = null, threadRootId = null, skipDeliveryUpdate = false, skipSummaryPersistence = false,
     } = options;
 
     // The installation label belongs to this pod; the User label belongs to
@@ -1469,6 +1479,25 @@ class AgentMessageService {
     // sibling pod's label cannot leak into this room through the shared User.
     const senderDisplayName = displayName || agentUser?.botMetadata?.displayName || agentUser?.username;
     let message: MessageNormalized | null = null;
+
+    // Resolve the explicit thread target BEFORE the PG try, and let a
+    // ThreadRootError propagate: inside the try it would be swallowed into
+    // the Mongo fallback and the post would land silently un-threaded —
+    // the exact data loss the resolver exists to prevent. Same five
+    // rejections as the human composer path (messageController). And a
+    // thread-scoped post cannot be honored without PG at all, so refuse
+    // loudly there too (mirror of the getRecentMessages read refusal).
+    let resolvedThreadRootId: number | null = null;
+    if (threadRootId != null && threadRootId !== '') {
+      if (!PGMessage || !process.env.PG_HOST) {
+        throw new Error('threadRootId posts require the PostgreSQL message store');
+      }
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+      const { resolveThreadRoot } = require('./threadRootResolver');
+      resolvedThreadRootId = await resolveThreadRoot({
+        podId: String(podId), replyToMessageId, threadRootId,
+      });
+    }
 
     if (PGMessage && process.env.PG_HOST) {
       try {
@@ -1496,7 +1525,7 @@ class AgentMessageService {
           console.warn('[agent-msg] PG pod backfill skipped:', (syncErr as Error).message);
         }
         const newMessage = await (PGMessage as {
-          create(podId: string, userId: string, content: string, type: string, replyToMessageId?: string | null, payload?: unknown): Promise<Record<string, unknown>>;
+          create(podId: string, userId: string, content: string, type: string, replyToMessageId?: string | null, payload?: unknown, resolvedThreadRootId?: number | null): Promise<Record<string, unknown>>;
         }).create(
           String(podId),
           String(agentUser._id),
@@ -1504,6 +1533,7 @@ class AgentMessageService {
           messageType,
           replyToMessageId,
           payload,
+          resolvedThreadRootId,
         );
 
         // The raw INSERT row carries no reply JOIN, so a replying agent's
@@ -1547,6 +1577,13 @@ class AgentMessageService {
       } catch (pgError) {
         console.error('PostgreSQL message creation failed, falling back to MongoDB:', pgError);
       }
+    }
+
+    if (!message && resolvedThreadRootId != null) {
+      // PG accepted the resolve but the INSERT failed. Falling to Mongo here
+      // would strand an explicitly-threaded post as an unthreaded row —
+      // fail the post instead; the caller can retry.
+      throw new Error('thread-scoped post failed at the PostgreSQL store');
     }
 
     if (!message) {
@@ -1850,6 +1887,11 @@ class AgentMessageService {
     limit = 20,
     selfUserId?: unknown,
     beforeMs?: number,
+    // PG-only thread scoping. On the Mongo fallback (no threading columns)
+    // this filter cannot be honored, so rather than silently returning the
+    // whole pod as if it were the thread, the fallback throws — an agent
+    // that asked for a thread must never mistake the pod for it.
+    threadRootId?: string,
   ): Promise<MessageNormalized[]> {
     if (!podId) {
       throw new Error('podId is required');
@@ -1873,9 +1915,15 @@ class AgentMessageService {
           findByPodId(
             id: string,
             limit: number,
-            before?: string,
+            before?: string | null,
+            threadRootId?: string | null,
           ): Promise<Array<Record<string, unknown>>>;
-        }).findByPodId(String(podId), limit, before?.toISOString());
+        }).findByPodId(
+          String(podId),
+          limit,
+          before?.toISOString() ?? null,
+          threadRootId ?? null,
+        );
 
         return messages.map((msg) => {
           const username = (msg.username as string) || 'Unknown';
@@ -1899,11 +1947,27 @@ class AgentMessageService {
             isBot,
             ...withSelf(msg.user_id),
             createdAt: msg.created_at as Date,
+            // Threading structure for agent readers (TASK-052's read half):
+            // the SELECT has carried these since #1106; this mapper was the
+            // last literal dropping them, which is why the cue teaching
+            // "continue in a thread" was held — a peer agent reading context
+            // could not see that a thread existed. Explicit null = "not in a
+            // thread"; the Mongo fallback below omits the keys entirely =
+            // "this server cannot say" (same convention as the frontend).
+            reply_to_message_id: (msg.reply_to_message_id as string | number | null) ?? null,
+            thread_root_id: (msg.thread_root_id as string | number | null) ?? null,
+            replyTo: (msg.replyTo as MessageNormalized['replyTo']) ?? null,
           };
         });
       } catch (pgError) {
         console.error('PostgreSQL message fetch failed, falling back to MongoDB:', pgError);
       }
+    }
+
+    if (threadRootId) {
+      // See the parameter comment: honoring this on Mongo is impossible and
+      // faking it (returning the pod) is worse than failing.
+      throw new Error('threadRootId reads require the PostgreSQL message store');
     }
 
     let messageQuery = Message.find({ podId: { $eq: podId } });


### PR DESCRIPTION
Completes TASK-052: the read gap that held the cue (sprint-review's degrades-open finding), the write half (in-thread without pinging, resolver-validated, fail-loud on both Mongo-fallback edges), and the cue itself — three verbs + quote-thread independence + Sam's overflow rule, shipped only now that every promise in it is kernel-enforced. 10 executing tests, 698/698 across the neighboring suites, ThreadRootError propagation pinned in the failure direction. Fleet is halted on Sam's order; ships on operator self-review with the evidence above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK