### PR TITLE
fix(v2): four taste rulings — centered conversation, action cluster, filter chips, zh-CN headers

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1379,7 +1379,11 @@
     "groups": {
       "pinned": "Pinned",
       "directMessages": "Direct messages",
-      "betweenAgents": "Between agents · {{count}}"
+      "betweenAgents": "Between agents · {{count}}",
+      "today": "Today",
+      "yesterday": "Yesterday",
+      "thisWeek": "This week",
+      "earlier": "Earlier"
     },
     "create": {
       "teamOption": "Open to join",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1373,7 +1373,11 @@
     "groups": {
       "pinned": "已置顶",
       "directMessages": "私信",
-      "betweenAgents": "智能体之间 · {{count}}"
+      "betweenAgents": "智能体之间 · {{count}}",
+      "today": "今天",
+      "yesterday": "昨天",
+      "thisWeek": "本周",
+      "earlier": "更早"
     },
     "create": {
       "teamOption": "开放加入",

--- a/frontend/src/v2/__tests__/V2MessageBubble.test.tsx
+++ b/frontend/src/v2/__tests__/V2MessageBubble.test.tsx
@@ -43,10 +43,11 @@ describe('V2MessageBubble', () => {
     );
   });
 
-  // The reactions row must not reserve layout space when it holds only the
-  // hover "+" trigger — the invisible band under every message pushed
-  // approval cards visibly away from their trigger text (2026-08-13).
-  it('collapses the reactions row (--bare) when a message has no reactions', () => {
+  // A message with no reactions renders NO reactions row at all — the
+  // trigger lives in the hover action cluster (2026-08-23), so the 2026-08-13
+  // phantom-band bug cannot recur structurally. The trigger must still be
+  // reachable, just from the cluster.
+  it('renders no reactions row when a message has no reactions — the trigger lives in the cluster', () => {
     render(
       <MemoryRouter>
         <V2MessageBubble
@@ -64,8 +65,8 @@ describe('V2MessageBubble', () => {
       </MemoryRouter>,
     );
 
-    const row = screen.getByLabelText('Reactions');
-    expect(row.className).toContain('v2-msg__reactions--bare');
+    expect(screen.queryByLabelText('Reactions')).toBeNull();
+    // Reachability is preserved: the cluster carries the trigger.
     expect(screen.getByRole('button', { name: 'Add reaction' })).toBeInTheDocument();
   });
 

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -105,15 +105,20 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).not.toContain('.v2-team-card__runtime {');
   });
 
-  test('chat text holds a readable measure WITHOUT centering (craft audit rule 2, corrected)', () => {
-    // ~150 chars/line was the defect; the first fix centered the whole
-    // message column and left it misaligned with the full-width composer and
-    // header — worse than the disease. The correct mechanic caps the text
-    // measure only, rows left-anchored. Both halves are load-bearing: the
-    // cap must exist, and the centering must never come back.
-    const body = ruleBody(v2, '.v2-msg__body');
+  test('the conversation column centers as a WHOLE — messages and composer share one measure (rule 2, v3)', () => {
+    // Third mechanism, ruled by Sam 2026-08-23 ("message still halved after
+    // right sidebar closed"). v1 centered messages alone (the island — a
+    // disaster); v2 capped 76ch left-anchored, which reads as a half-empty
+    // page at wide widths. v3's load-bearing property is COHERENCE: the
+    // messages' children AND the composer's children must share the same
+    // measure token — centering one without the other recreates the island.
+    expect(v2).toContain('--v2-conv-measure:');
+    expect(ruleBody(v2, '.v2-chat__messages > *')).toContain('max-width: var(--v2-conv-measure)');
+    expect(ruleBody(v2, '.v2-chat__messages > *')).toContain('margin-inline: auto');
+    expect(ruleBody(v2, '.v2-chat__composer > *')).toContain('max-width: var(--v2-conv-measure)');
+    expect(ruleBody(v2, '.v2-chat__composer > *')).toContain('margin-inline: auto');
+    // Text measure inside the column stays readable.
     expect(v2).toContain('max-width: 76ch');
-    expect(v2).not.toContain('.v2-chat__messages > *');
   });
 
   test('motion timing is tokenized and all three existing V2 animations consume it', () => {
@@ -238,18 +243,18 @@ describe('v2 layout invariants (CSS rule presence)', () => {
   });
 
   test('the four pod filters stay on one row in the narrow sidebar', () => {
-    // The desktop sidebar leaves only ~240px inside its gutter (less than the
-    // mobile drawer). A four-column grid keeps Community beside the existing
-    // filters without horizontal scrolling or wrapping in either locale.
-    // Pattern updated 2026-08-13 (Sam's raggedness flag): three EQUAL
-    // segments + one content-sized, capped Community column — the per-label
-    // hand-tuned fractions read as four random widths. The invariant's intent
-    // (one row, no wrap) is unchanged.
+    // Third mechanism (Sam, 2026-08-23): content-sized chips. The equal-grid
+    // versions allocated width backwards (wide boxes for short words, a
+    // capped box for the longest) and scattered zh-CN's four 2-character
+    // labels across phantom cells. Chips hug their labels with uniform
+    // padding, so both locales read as one segmented control. The intent
+    // from 2026-08-13 is unchanged: one row, no wrap — pinned here as
+    // flex + nowrap + no width-allocating grid.
     const rule = ruleBody(v2, '.v2-pods__filters');
-    expect(rule).toContain('display: grid');
-    expect(rule).toContain('grid-template-columns: repeat(3, minmax(0, 1fr)) fit-content(92px)');
+    expect(rule).toContain('display: flex');
+    expect(rule).not.toContain('grid-template-columns');
     expect(rule).toContain('overflow: visible');
-    expect(ruleBody(v2, '.v2-pods__filter')).toContain('text-overflow: ellipsis');
+    expect(ruleBody(v2, '.v2-pods__filter')).toContain('white-space: nowrap');
   });
 
   test('accent treatment is a wash, never a message rail', () => {
@@ -327,7 +332,9 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     const row = ruleBody(v2, '.v2-chat__starter-prompts');
     const chip = ruleBody(v2, '.v2-root button.v2-chat__starter-prompt');
     expect(row).toContain('flex-wrap: wrap');
-    expect(row).toContain('max-width: 100%');
+    // min(measure, 100%): shares the conversation column's centerline at
+    // desktop widths while keeping the 390px shrink this pin exists for.
+    expect(row).toContain('max-width: min(var(--v2-conv-measure), 100%)');
     expect(chip).toContain('max-width: 100%');
     expect(chip).toContain('white-space: normal');
   });
@@ -390,17 +397,23 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(v2, '.v2-msg__reaction-emoji')).toContain('line-height: 22px');
   });
 
-  test('the bare reactions row collapses instead of reserving a blank band', () => {
-    // A no-chips row holds only the opacity-0 hover "+", but it used to keep
-    // 24px + 6px of layout space under EVERY message — the phantom band that
-    // pushed approval cards visibly away from their trigger text (2026-08-13).
-    // Both halves are load-bearing: height 0 removes the band; the absolute
-    // add-wrap keeps the trigger reachable without re-expanding the row. The
-    // rule looks inert in isolation — do not "clean it up".
-    expect(ruleBody(v2, '.v2-msg__reactions--bare')).toContain('height: 0');
-    expect(ruleBody(v2, '.v2-msg__reactions--bare .v2-msg__reaction-add-wrap')).toContain(
-      'position: absolute',
-    );
+  test('message actions live in ONE hover cluster, and its picker opens downward', () => {
+    // 2026-08-23 (Sam's placement rulings): Reply, Thread, and the reaction
+    // trigger share a floating pill at the row's top-right — no inline head
+    // buttons (layout shift), no orphaned "+" in an empty reactions band
+    // (the 2026-08-13 phantom-band bug cannot recur because a chip-less row
+    // no longer renders at all). The picker anchor override is load-bearing:
+    // the base picker opens UPWARD (bottom: 100%) for the old in-row anchor;
+    // from the cluster at the message's top edge it must open downward or it
+    // clips under the previous message.
+    const cluster = ruleBody(v2, '.v2-msg__actions');
+    expect(cluster).toContain('position: absolute');
+    expect(v2).toContain('.v2-msg:hover .v2-msg__actions');
+    const pickerInCluster = ruleBody(v2, '.v2-msg__actions .v2-msg__reaction-picker');
+    expect(pickerInCluster).toContain('top: calc(100% + 6px)');
+    expect(pickerInCluster).toContain('bottom: auto');
+    // Touch keeps the 44px floor with the cluster always visible.
+    expect(v2).toContain('.v2-root button.v2-msg__action');
   });
 
   test('create-pod panel no longer ships audience options (ADR-016 / #768)', () => {
@@ -498,15 +511,15 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(addressed).toContain('var(--v2-accent)');
   });
 
-  test('thread entry actions retain 44px targets and become visible on touch layouts', () => {
-    // TASK-052: Thread has to be reachable from an unthreaded message, while
-    // Reply preserves its existing addressing meaning. Desktop may reveal the
-    // row on hover; a 390px touch surface cannot depend on hover.
-    const messageAction = ruleBody(v2, '.v2-root button.v2-msg__reply-btn,\n.v2-root button.v2-msg__thread-btn');
-    expect(messageAction).toContain('min-height: 44px');
+  test('message actions retain 44px targets and become visible on touch layouts', () => {
+    // TASK-052 intent, third mechanism: the hover cluster carries
+    // Reply/Thread/React. Desktop reveals it on hover; a 390px touch
+    // surface cannot depend on hover, so both touch blocks (pointer:coarse
+    // and max-width:640px) force it visible with 44px targets.
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-msg__actions[\s\S]*?opacity: 1/);
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-root button\.v2-msg__action[\s\S]*?height: 44px/);
     const cardAction = ruleBody(v2, '.v2-root button.v2-thread-card__reply');
     expect(cardAction).toContain('min-height: 44px');
-    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-root button\.v2-msg__reply-btn,[\s\S]*?\.v2-root button\.v2-msg__thread-btn[\s\S]*?opacity: 1/);
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-card\s*\{[\s\S]*?flex-wrap: wrap/);
   });
 

--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -414,6 +414,43 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
     && !!meUsername
     && new RegExp(`@${meUsername.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(stripped);
 
+  // --- reactions state, hoisted from the render tail so the hover cluster
+  // owns the trigger while the chips row keeps rendering below the text ---
+  const liveReactions = message.reactions;
+  const hasLive = Array.isArray(liveReactions);
+  const reactMessageId = String(message.id || '');
+  const canInteract = !!(hasLive && reactMessageId && /^\d+$/.test(reactMessageId));
+  const renderList = hasLive
+    ? liveReactions!
+    : reactions.map((r) => ({ emoji: r.emoji, count: r.count, mine: false }));
+  const toggleReaction = async (emoji: string, mine: boolean) => {
+    if (!canInteract) return;
+    try {
+      if (mine) {
+        await api.del(`/api/messages/${reactMessageId}/reactions/${encodeURIComponent(emoji)}`);
+      } else {
+        await api.post(`/api/messages/${reactMessageId}/reactions`, { emoji });
+      }
+      // Optimistic update is unnecessary — the socket `messageReaction`
+      // event from the backend updates the message list in place.
+    } catch (err) {
+      const e = err as { response?: { status?: number; data?: { msg?: string; error?: string } } };
+      const status = e.response?.status;
+      const serverMsg = e.response?.data?.msg || e.response?.data?.error;
+      setReactionError(
+        serverMsg
+        || (status === 403 ? "You're not a member of this pod." : '')
+        || (status === 429 ? 'Too many reactions — give it a moment.' : '')
+        || 'Could not add that reaction.',
+      );
+      window.setTimeout(() => setReactionError(null), 4000);
+      // eslint-disable-next-line no-console
+      console.warn('[reactions] toggle failed:', (err as Error).message);
+    } finally {
+      setPickerOpen(false);
+    }
+  };
+
   return (
     <div className={`v2-msg${mentionsMe ? ' v2-msg--mention' : ''}${grouped ? ' v2-msg--grouped' : ''}`}>
       {grouped ? (
@@ -442,31 +479,83 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
           seed={message.user_id || undefined}
         />
       )}
+      {/* One hover cluster for every row variant (Sam's taste rulings
+          2026-08-23): Reply, Thread, and the reaction trigger live together
+          in a floating pill at the message's top-right — visible on hover
+          or keyboard focus, never in the head's text flow (the inline text
+          buttons crowded the head and shifted layout), and identical for
+          headed and grouped rows. The reaction picker anchors here too, so
+          the trigger sits with its siblings instead of orphaned at the far
+          edge of an empty reactions band. */}
+      {(onReply || onThread || canInteract) && (
+        <div className="v2-msg__actions" role="toolbar" aria-label="Message actions">
+          {onReply && (
+            <button
+              type="button"
+              className="v2-msg__action"
+              aria-label={`Reply to ${author}`}
+              title={`Reply to ${author}`}
+              onClick={() => onReply(message)}
+            >
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <polyline points="9 17 4 12 9 7" />
+                <path d="M20 18v-2a4 4 0 0 0-4-4H4" />
+              </svg>
+            </button>
+          )}
+          {onThread && (
+            <button
+              type="button"
+              className="v2-msg__action"
+              aria-label={`${t('podChat.thread.startThread')} from ${author}`}
+              title={t('podChat.thread.startThread')}
+              onClick={() => onThread(message)}
+            >
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+              </svg>
+            </button>
+          )}
+          {canInteract && (
+            <span className="v2-msg__action-wrap">
+              <button
+                type="button"
+                className="v2-msg__action"
+                aria-label="Add reaction"
+                title="Add reaction"
+                onClick={() => setPickerOpen((v) => !v)}
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <circle cx="12" cy="12" r="10" />
+                  <path d="M8 14s1.5 2 4 2 4-2 4-2" />
+                  <line x1="9" y1="9" x2="9.01" y2="9" />
+                  <line x1="15" y1="9" x2="15.01" y2="9" />
+                </svg>
+              </button>
+              {pickerOpen && (
+                <span className="v2-msg__reaction-picker" role="menu">
+                  {REACTION_PALETTE.map((e) => {
+                    const existing = renderList.find((x) => x.emoji === e);
+                    const mine = !!existing?.mine;
+                    return (
+                      <button
+                        key={e}
+                        type="button"
+                        role="menuitem"
+                        className={`v2-msg__reaction-picker-item${mine ? ' v2-msg__reaction-picker-item--mine' : ''}`}
+                        onClick={() => toggleReaction(e, mine)}
+                      >
+                        {e}
+                      </button>
+                    );
+                  })}
+                </span>
+              )}
+            </span>
+          )}
+        </div>
+      )}
       <div className="v2-msg__body">
-        {grouped && (onReply || onThread) && (
-          <div className="v2-msg__thread-actions v2-msg__thread-actions--float">
-            {onReply && (
-              <button
-                type="button"
-                className="v2-msg__reply-float"
-                aria-label={`Reply to ${author}`}
-                onClick={() => onReply(message)}
-              >
-                Reply
-              </button>
-            )}
-            {onThread && (
-              <button
-                type="button"
-                className="v2-msg__thread-float"
-                aria-label={`${t('podChat.thread.startThread')} from ${author}`}
-                onClick={() => onThread(message)}
-              >
-                {t('podChat.thread.startThread')}
-              </button>
-            )}
-          </div>
-        )}
         {!grouped && (
         <div className="v2-msg__head">
           {isClickable ? (
@@ -478,30 +567,6 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
           )}
           {isLead && <span className="v2-msg__lead-badge">Lead</span>}
           {time && <span className="v2-msg__time">{time}</span>}
-          {(onReply || onThread) && (
-            <div className="v2-msg__thread-actions">
-              {onReply && (
-                <button
-                  type="button"
-                  className="v2-msg__reply-btn"
-                  aria-label={`Reply to ${author}`}
-                  onClick={() => onReply(message)}
-                >
-                  Reply
-                </button>
-              )}
-              {onThread && (
-                <button
-                  type="button"
-                  className="v2-msg__thread-btn"
-                  aria-label={`${t('podChat.thread.startThread')} from ${author}`}
-                  onClick={() => onThread(message)}
-                >
-                  {t('podChat.thread.startThread')}
-                </button>
-              )}
-            </div>
-          )}
         </div>
         )}
         {(() => {
@@ -567,54 +632,13 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
         ))}
         {(() => {
           // Sprint B5: real reactions come from message.reactions (server-
-          // aggregated `[{emoji, count, mine}]`). Legacy fixtures use the
-          // token-parsed `reactions` from parseReactions above. Real wins
-          // when present; tokens are the demo-recording stand-in.
-          const liveReactions = message.reactions;
-          const hasLive = Array.isArray(liveReactions);
-          const messageId = String(message.id || '');
-          const canInteract = hasLive && messageId && /^\d+$/.test(messageId);
-
-          const toggle = async (emoji: string, mine: boolean) => {
-            if (!canInteract) return;
-            try {
-              if (mine) {
-                await api.del(`/api/messages/${messageId}/reactions/${encodeURIComponent(emoji)}`);
-              } else {
-                await api.post(`/api/messages/${messageId}/reactions`, { emoji });
-              }
-              // Optimistic update is unnecessary — the socket `messageReaction`
-              // event from the backend updates the message list in place.
-            } catch (err) {
-              const e = err as { response?: { status?: number; data?: { msg?: string; error?: string } } };
-              const status = e.response?.status;
-              const serverMsg = e.response?.data?.msg || e.response?.data?.error;
-              setReactionError(
-                serverMsg
-                || (status === 403 ? "You're not a member of this pod." : '')
-                || (status === 429 ? 'Too many reactions — give it a moment.' : '')
-                || 'Could not add that reaction.',
-              );
-              window.setTimeout(() => setReactionError(null), 4000);
-              // eslint-disable-next-line no-console
-              console.warn('[reactions] toggle failed:', (err as Error).message);
-            } finally {
-              setPickerOpen(false);
-            }
-          };
-
-          if (hasLive && liveReactions!.length === 0 && !canInteract) {
-            // Token-fixture path with no parsed entries: render nothing.
-            if (reactions.length === 0) return null;
-          }
-
-          // Decide which list to render. If the server gave us a real
-          // reactions array (even empty) use it; else fall back to tokens.
-          const renderList = hasLive
-            ? liveReactions!
-            : reactions.map((r) => ({ emoji: r.emoji, count: r.count, mine: false }));
-
-          if (renderList.length === 0 && !canInteract) return null;
+          // aggregated `[{emoji, count, mine}]`); legacy fixtures use the
+          // token-parsed list. Both are hoisted above as `renderList` so the
+          // hover cluster shares the trigger. This row now renders ONLY when
+          // there are chips (or a transient error) to show — the trigger
+          // lives in the cluster, so the empty "bare band" state no longer
+          // exists at all rather than being collapsed by CSS.
+          if (renderList.length === 0 && !reactionError) return null;
 
           // Google-Chat-style attribution: build a names-line for the
           // reaction-chip tooltip from the decorated `users` array when
@@ -635,61 +659,21 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
             return `${names.join(', ')} reacted with ${r.emoji}${r.mine ? ' (you)' : ''}`;
           };
 
-          // A row with no chips holds only the hover "+" trigger; --bare
-          // collapses it out of layout so it stops reserving a blank band
-          // under the message. A transient error line re-expands the row —
-          // it's real content the user must be able to read.
-          const bare = renderList.length === 0 && !reactionError;
-
           return (
-            <div
-              className={`v2-msg__reactions${bare ? ' v2-msg__reactions--bare' : ''}`}
-              aria-label="Reactions"
-            >
+            <div className="v2-msg__reactions" aria-label="Reactions">
               {renderList.map((r, idx) => (
                 <button
                   key={`${r.emoji}-${idx}`}
                   type="button"
                   className={`v2-msg__reaction${r.mine ? ' v2-msg__reaction--mine' : ''}`}
                   title={formatReactionTitle(r)}
-                  onClick={() => toggle(r.emoji, !!r.mine)}
+                  onClick={() => toggleReaction(r.emoji, !!r.mine)}
                   disabled={!canInteract}
                 >
                   <span className="v2-msg__reaction-emoji">{r.emoji}</span>
                   <span className="v2-msg__reaction-count">{r.count}</span>
                 </button>
               ))}
-              {canInteract && (
-                <span className="v2-msg__reaction-add-wrap">
-                  <button
-                    type="button"
-                    className="v2-msg__reaction-add"
-                    aria-label="Add reaction"
-                    onClick={() => setPickerOpen((v) => !v)}
-                  >
-                    +
-                  </button>
-                  {pickerOpen && (
-                    <span className="v2-msg__reaction-picker" role="menu">
-                      {REACTION_PALETTE.map((e) => {
-                        const existing = renderList.find((x) => x.emoji === e);
-                        const mine = !!existing?.mine;
-                        return (
-                          <button
-                            key={e}
-                            type="button"
-                            role="menuitem"
-                            className={`v2-msg__reaction-picker-item${mine ? ' v2-msg__reaction-picker-item--mine' : ''}`}
-                            onClick={() => toggle(e, mine)}
-                          >
-                            {e}
-                          </button>
-                        );
-                      })}
-                    </span>
-                  )}
-                </span>
-              )}
               {reactionError && (
                 <span className="v2-msg__reaction-error" role="alert">{reactionError}</span>
               )}

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -370,7 +370,23 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
   // doubles as a count of how many a2a conversations are happening.
   const grouped = useMemo(() => {
     if (filter === 'community' && communityView === 'discover') return [];
-    if (filter !== 'private') return groupPods(filtered, pinned);
+    if (filter !== 'private') {
+      // groupPods returns stable PodGroup KEYS ('Today', 'This week', …);
+      // rendering them raw shipped English headers into zh-CN (Sam's
+      // "cn version is messed up" report, 2026-08-23). Translate at this
+      // boundary, exactly like the DM buckets below already do.
+      const chronoKeys: Record<string, string> = {
+        Pinned: 'podsSidebar.groups.pinned',
+        Today: 'podsSidebar.groups.today',
+        Yesterday: 'podsSidebar.groups.yesterday',
+        'This week': 'podsSidebar.groups.thisWeek',
+        Earlier: 'podsSidebar.groups.earlier',
+      };
+      return groupPods(filtered, pinned).map((g) => ({
+        ...g,
+        label: chronoKeys[g.label] ? t(chronoKeys[g.label]) : g.label,
+      }));
+    }
     const sortByRecency = <T extends { lastMessage?: { createdAt?: string | Date | null } | null; updatedAt?: string | Date; createdAt?: string | Date }>(items: T[]): T[] => {
       const ts = (it: T) => {
         const raw = it.lastMessage?.createdAt || it.updatedAt || it.createdAt;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -822,11 +822,16 @@
 }
 
 .v2-pods__filters {
-  display: grid;
-  /* Community is product vocabulary, not a layout compromise. The first
-     three filters share the available width; Community keeps its readable
-     content width but is capped so it cannot consume a narrow rail. */
-  grid-template-columns: repeat(3, minmax(0, 1fr)) fit-content(92px);
+  /* Third mechanism for this row (Sam's taste ruling 2026-08-23). The grid
+     of three equal cells + one capped cell allocated width exactly
+     backwards — the short words got wide boxes, the longest word got the
+     capped one, and in zh-CN four 2-character labels floated as scattered
+     text. Content-sized chips fix both locales by construction: every box
+     hugs its own label with identical padding, so the row reads as one
+     segmented control whatever the strings are. Measured to fit the 240px
+     rail in both locales at 12px (EN ≈ 217px, zh-CN ≈ 180px incl. gaps).
+     Intent preserved from the 2026-08-13 invariant: one row, no wrap. */
+  display: flex;
   gap: 4px;
   padding: 0;
   margin-bottom: 18px;
@@ -836,16 +841,13 @@
 
 .v2-pods__filter {
   height: 32px;
-  min-width: 0;
-  padding: 0 2px;
+  padding: 0 9px;
   font-size: 12px;
   font-weight: 500;
   color: #4b5563;
   border-radius: var(--v2-radius-sm);
   text-align: center;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   transition: background 80ms ease, color 80ms ease;
 }
 
@@ -1551,12 +1553,32 @@
   gap: 0;
 }
 
-/* Craft audit 2026-08-22, rule 2 — corrected same day. The first cut
-   centered the message column, which left it misaligned with the full-width
-   header and composer ("a floating island" — Sam, accurately: a disaster).
-   The right mechanic caps the TEXT measure only: rows stay left-anchored so
-   messages, composer, and header share one edge; long lines still break at
-   a readable width. */
+/* Conversation measure — third revision of craft rule 2, ruled by Sam
+   2026-08-23 ("message still halved after right sidebar closed").
+   History matters here: v1 centered ONLY the messages ("a floating island"
+   — a disaster, because the composer and header kept a different edge);
+   v2 capped text at 76ch left-anchored, which reads correctly at narrow
+   widths and as a half-empty page once the inspector closes (~420px of
+   dead space at 1092px). v3 centers the WHOLE conversation: messages,
+   typing indicator, delivery hint, starter prompts, and the composer's
+   inner content all share one measure and one centerline — the coherence
+   v1 lacked. Header stays full-bleed; it is chrome, not conversation.
+   The measure = 76ch of text + the 50px avatar column. */
+.v2-root {
+  --v2-conv-measure: calc(76ch + 50px);
+}
+
+.v2-chat__messages > * {
+  width: 100%;
+  max-width: var(--v2-conv-measure);
+  margin-inline: auto;
+}
+
+.v2-chat__composer > * {
+  max-width: var(--v2-conv-measure);
+  margin-inline: auto;
+}
+
 .v2-msg__body {
   max-width: 76ch;
 }
@@ -1832,7 +1854,13 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  max-width: 100%;
+  /* Part of the conversation column (see --v2-conv-measure): siblings of
+     the messages list must share its centerline or they read as a second
+     edge — the v1-island lesson applied to every conversation element.
+     min(…, 100%) keeps the mobile-shrink property the 390px pane needs. */
+  width: 100%;
+  max-width: min(var(--v2-conv-measure), 100%);
+  margin-inline: auto;
   padding: 10px 24px 0;
   background: var(--v2-surface);
   flex-shrink: 0;
@@ -2484,35 +2512,63 @@
    author reads as one block. The ghost keeps the grid's avatar column so
    text alignment never shifts. Reply and Thread become hover affordances
    pinned to the row's top-right, since the head row is gone. */
-.v2-msg--grouped { padding: 2px 0; position: relative; }
+.v2-msg--grouped { padding: 2px 0; }
 .v2-msg__avatar-ghost { width: 38px; }
-.v2-msg__thread-actions--float {
+
+/* The message action cluster (Sam's taste rulings 2026-08-23): Reply,
+   Thread, and the reaction trigger share ONE floating pill at the row's
+   top-right, identical for headed and grouped rows. Absolute + hover means
+   zero layout shift; icon buttons instead of text keep it quiet at rest and
+   compact under the cursor. The reaction picker anchors to the cluster so
+   the trigger sits with its siblings instead of orphaned in an empty band
+   below the message (the old absolute "+"). */
+.v2-msg { position: relative; }
+.v2-msg__actions {
   position: absolute;
-  top: -11px;
+  top: -12px;
   right: 8px;
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 1px;
+  padding: 2px;
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-border);
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(16, 20, 30, 0.08);
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.12s ease;
+  transition: opacity 0.1s ease;
+  z-index: 6;
 }
-.v2-root button.v2-msg__reply-float,
-.v2-root button.v2-msg__thread-float {
-  appearance: none;
-  border: 1px solid var(--v2-border);
-  background: var(--v2-surface);
-  color: var(--v2-text-secondary);
-  font-size: 11px;
-  border-radius: 6px;
-  min-height: 44px;
-  padding: 0 8px;
-  cursor: pointer;
-}
-.v2-msg--grouped:hover .v2-msg__thread-actions--float,
-.v2-msg__thread-actions--float:focus-within {
+.v2-msg:hover .v2-msg__actions,
+.v2-msg__actions:focus-within {
   opacity: 1;
   pointer-events: auto;
+}
+.v2-root button.v2-msg__action {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--v2-text-secondary);
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.v2-root button.v2-msg__action:hover {
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
+}
+.v2-msg__action-wrap { position: relative; display: inline-flex; }
+.v2-msg__actions .v2-msg__reaction-picker {
+  position: absolute;
+  top: calc(100% + 6px);
+  bottom: auto;
+  right: 0;
+  left: auto;
 }
 
 .v2-msg__body {
@@ -5783,74 +5839,13 @@
   opacity: 0.8;
 }
 
-.v2-msg__reaction-add-wrap {
-  position: relative;
-  display: inline-flex;
-}
-.v2-root button.v2-msg__reaction-add {
-  height: 24px;
-  width: 28px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: 1px dashed #d1d5db;
-  border-radius: 999px;
-  font-size: 14px;
-  color: #6b7280;
-  cursor: pointer;
-}
-.v2-root button.v2-msg__reaction-add:hover {
-  background: #f9fafb;
-  border-color: #9ca3af;
-  color: #111827;
-}
-
-/* Hover-only "+" reaction trigger on devices with a pointer.
- * Fade the wrapper (not display:none) so layout stays stable and the
- * picker keeps anchoring correctly. :focus-within keeps the wrap visible
- * while the emoji-picker popover is open (picker buttons inside hold
- * focus). Mobile (hover: none) keeps the trigger always visible — there's
- * no hover affordance to lean on. Reaction count badges
- * (.v2-msg__reaction) are unaffected and always render when count > 0. */
-@media (hover: hover) {
-  .v2-msg .v2-msg__reaction-add-wrap {
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.12s ease;
-  }
-  .v2-msg:hover .v2-msg__reaction-add-wrap,
-  .v2-msg__reaction-add-wrap:focus-within {
-    opacity: 1;
-    pointer-events: auto;
-  }
-}
-
-/* A reactions row with no chips (--bare) holds only the invisible hover
- * "+" — but it still reserved 24px + 6px margin under EVERY message, and
- * that phantom band is what made the approval card sit visibly far from
- * the text that triggered it (Sam, 2026-08-13). Bare rows collapse to
- * zero height and the trigger floats at the row's top-right, in the empty
- * space beside the author line — no layout shift on hover, nothing
- * overlapped (head content is all left-aligned). Rows with chips, or a
- * transient error line, stay in flow: those are content, not chrome.
- * The picker keeps anchoring to the add-wrap and opens above it. */
-.v2-msg {
-  position: relative;
-}
-.v2-msg__reactions--bare {
-  height: 0;
-  margin-top: 0;
-}
-.v2-msg__reactions--bare .v2-msg__reaction-add-wrap {
-  position: absolute;
-  top: 10px;
-  right: 4px;
-}
-/* With the trigger at the row's right edge, a left-anchored picker grows
- * rightward out of the chat column (measured jutting over the inspector);
- * anchor it right so it opens leftward into the chat area instead. */
-.v2-msg__reactions--bare .v2-msg__reaction-picker {
+/* The standalone "+" trigger, its hover wrap, and the --bare collapsed row
+ * were retired 2026-08-23: the reaction trigger lives in the
+ * .v2-msg__actions hover cluster (Sam's placement ruling), and a reactions
+ * row with no chips simply does not render — the phantom-band problem the
+ * --bare machinery solved cannot occur at all now. The picker below is
+ * shared by the cluster (which overrides its anchor to open downward). */
+.v2-msg__reaction-picker {
   left: auto;
   right: 0;
 }
@@ -6409,41 +6404,24 @@
   }
 }
 
-/* Reply and Thread are distinct composer targets. The 44px actions sit on a
-   22px desktop header using a negative vertical margin, then become a visible
-   row on touch-sized layouts below. This preserves channel density without
-   reducing the hit area (TASK-052). */
-.v2-msg__thread-actions {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-  margin-left: 4px;
+/* Reply/Thread inline head buttons retired 2026-08-23 (Sam's taste ruling):
+   the actions live in the .v2-msg__actions hover cluster now — one pill,
+   all row variants, zero layout shift. See the cluster block near .v2-msg.
+   Touch layouts keep ≥44px targets via the media block below. */
+@media (hover: none), (pointer: coarse) {
+  /* No hover on touch: the cluster stays in its absolute top-right slot
+     but is always visible, and its targets grow to the 44px floor (craft
+     baseline rule 9). Keeping it absolute preserves the .v2-msg grid —
+     a static third child would break the avatar|body columns. */
+  .v2-msg__actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .v2-root button.v2-msg__action {
+    width: 44px;
+    height: 44px;
+  }
 }
-.v2-root button.v2-msg__reply-btn,
-.v2-root button.v2-msg__thread-btn {
-  margin-left: 4px;
-  min-height: 44px;
-  margin-top: -11px;
-  margin-bottom: -11px;
-  padding: 0 8px;
-  font-size: 11.5px;
-  font-weight: 600;
-  color: var(--v2-text-secondary);
-  background: transparent;
-  border: none;
-  border-radius: var(--v2-radius-sm);
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.1s ease;
-}
-.v2-msg:hover .v2-msg__reply-btn,
-.v2-msg:hover .v2-msg__thread-btn,
-.v2-msg__reply-btn:focus-visible,
-.v2-msg__thread-btn:focus-visible {
-  opacity: 1;
-}
-.v2-root button.v2-msg__reply-btn:hover,
-.v2-root button.v2-msg__thread-btn:hover { color: var(--v2-accent); }
 
 .v2-msg__quote {
   display: flex;
@@ -7369,31 +7347,23 @@
 }
 
 @media (max-width: 640px) {
-  /* Touch has no hover. Keep Thread and Reply discoverable and keep their
-     44px hit areas in normal flow rather than over the message content. */
+  /* Touch has no hover: the action cluster (Reply/Thread/React) is always
+     visible at its top-right anchor with 44px targets — see the
+     hover:none/pointer:coarse block by the cluster rules. The old inline
+     head buttons this block used to force visible were retired 2026-08-23. */
   .v2-msg__head {
     height: auto;
     flex-wrap: wrap;
   }
 
-  .v2-msg__thread-actions {
-    flex-basis: 100%;
-    margin-left: 0;
-    gap: 4px;
-  }
-
-  .v2-root button.v2-msg__reply-btn,
-  .v2-root button.v2-msg__thread-btn {
-    margin-top: 0;
-    margin-bottom: 0;
-    opacity: 1;
-  }
-
-  .v2-msg__thread-actions--float {
-    position: static;
-    margin: 0;
+  .v2-msg__actions {
     opacity: 1;
     pointer-events: auto;
+  }
+
+  .v2-root button.v2-msg__action {
+    width: 44px;
+    height: 44px;
   }
 
   .v2-thread-card {


### PR DESCRIPTION
Sam's four morning reports in one pass: the half-empty chat at wide widths (conversation column now centers as a whole — the coherence the rejected island lacked), the Reply/Thread hover rendering and the reaction trigger placement (one icon cluster, zero layout shift, picker anchored, phantom-band machinery structurally retired), the filter row's backwards width allocation in both locales (content-sized chips), and zh-CN's untranslated group headers. 297/297 v2+i18n; invariants re-pinned with history. Browser verification in both locales + 390px follows the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK