### PR TITLE
fix(v2): filter-chip reset prefix + mobile tap-reveal action cluster

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -254,7 +254,12 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(rule).toContain('display: flex');
     expect(rule).not.toContain('grid-template-columns');
     expect(rule).toContain('overflow: visible');
-    expect(ruleBody(v2, '.v2-pods__filter')).toContain('white-space: nowrap');
+    // The `.v2-root button.` prefix is load-bearing: the global button reset
+    // (0-1-1) zeroes padding on a bare-class rule (0-1-0), which shipped as
+    // 25px chips hugging bare text — the third hit of this exact trap.
+    const chip = ruleBody(v2, '.v2-root button.v2-pods__filter');
+    expect(chip).toContain('white-space: nowrap');
+    expect(chip).toContain('padding: 0 9px');
   });
 
   test('accent treatment is a wash, never a message rail', () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -521,7 +521,11 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // Reply/Thread/React. Desktop reveals it on hover; a 390px touch
     // surface cannot depend on hover, so both touch blocks (pointer:coarse
     // and max-width:640px) force it visible with 44px targets.
-    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-msg__actions[\s\S]*?opacity: 1/);
+    // Tap-reveal, not always-on: the touch blocks must gate visibility on
+    // .v2-msg--reveal (set by the bubble's tap handler) — an ungated
+    // `.v2-msg__actions { opacity: 1 }` here would put chrome over every
+    // message by default (Sam's report, 2026-08-23).
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-msg--reveal \.v2-msg__actions[\s\S]*?opacity: 1/);
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-root button\.v2-msg__action[\s\S]*?height: 44px/);
     const cardAction = ruleBody(v2, '.v2-root button.v2-thread-card__reply');
     expect(cardAction).toContain('min-height: 44px');

--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -317,6 +317,23 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
   // Picker state per message. Open via "+ react"; close on first click
   // (no need for outside-click handling — the picker hides after action).
   const [pickerOpen, setPickerOpen] = useState(false);
+  // Touch reveal (Sam, 2026-08-23): on hoverless devices the action cluster
+  // must NOT sit on every message by default — that is chrome over content.
+  // A tap on the message reveals it (CSS shows .v2-msg--reveal only inside
+  // the hover:none media block); a second tap or the picker closing hides
+  // it again. Desktop hover behavior is untouched — the class is inert
+  // wherever hover exists.
+  const [actionsRevealed, setActionsRevealed] = useState(false);
+  const onBubbleTap = () => {
+    if (typeof window !== 'undefined'
+      && window.matchMedia
+      && window.matchMedia('(hover: none)').matches) {
+      setActionsRevealed((v) => {
+        if (v) setPickerOpen(false);
+        return !v;
+      });
+    }
+  };
   // Surface why a reaction failed instead of swallowing it. Before this, a
   // rejected reaction (bad emoji 400, non-member 403, rate-limit 429) did
   // nothing visible — which made the ❤️-validation bug read as "reactions
@@ -452,7 +469,10 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
   };
 
   return (
-    <div className={`v2-msg${mentionsMe ? ' v2-msg--mention' : ''}${grouped ? ' v2-msg--grouped' : ''}`}>
+    <div
+      className={`v2-msg${mentionsMe ? ' v2-msg--mention' : ''}${grouped ? ' v2-msg--grouped' : ''}${actionsRevealed ? ' v2-msg--reveal' : ''}`}
+      onClick={onBubbleTap}
+    >
       {grouped ? (
         <div className="v2-msg__avatar-ghost" aria-hidden="true" />
       ) : isClickable ? (
@@ -488,7 +508,15 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
           the trigger sits with its siblings instead of orphaned at the far
           edge of an empty reactions band. */}
       {(onReply || onThread || canInteract) && (
-        <div className="v2-msg__actions" role="toolbar" aria-label="Message actions">
+        /* stopPropagation: on touch, the bubble's own tap toggles reveal —
+           without this, tapping any action would immediately re-hide the
+           cluster (and close the picker it just opened). */
+        <div
+          className="v2-msg__actions"
+          role="toolbar"
+          aria-label="Message actions"
+          onClick={(e) => e.stopPropagation()}
+        >
           {onReply && (
             <button
               type="button"

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -6412,11 +6412,14 @@
    all row variants, zero layout shift. See the cluster block near .v2-msg.
    Touch layouts keep ≥44px targets via the media block below. */
 @media (hover: none), (pointer: coarse) {
-  /* No hover on touch: the cluster stays in its absolute top-right slot
-     but is always visible, and its targets grow to the 44px floor (craft
-     baseline rule 9). Keeping it absolute preserves the .v2-msg grid —
-     a static third child would break the avatar|body columns. */
-  .v2-msg__actions {
+  /* No hover on touch — but always-on clusters over every message are
+     chrome over content (Sam, 2026-08-23). A tap on the message toggles
+     .v2-msg--reveal (V2MessageBubble.onBubbleTap, gated to hoverless
+     devices); only then does the cluster appear, at the 44px floor (craft
+     baseline rule 9). Absolute positioning preserved — a static third
+     child would break the avatar|body grid. */
+  .v2-msg--reveal .v2-msg__actions,
+  .v2-msg__actions:focus-within {
     opacity: 1;
     pointer-events: auto;
   }
@@ -7350,16 +7353,17 @@
 }
 
 @media (max-width: 640px) {
-  /* Touch has no hover: the action cluster (Reply/Thread/React) is always
-     visible at its top-right anchor with 44px targets — see the
-     hover:none/pointer:coarse block by the cluster rules. The old inline
-     head buttons this block used to force visible were retired 2026-08-23. */
+  /* Touch has no hover: the action cluster appears on TAP-REVEAL
+     (.v2-msg--reveal, set by the bubble's tap handler) with 44px targets —
+     never by default; always-on clusters over every message are chrome
+     over content. The old inline head buttons this block used to force
+     visible were retired 2026-08-23. */
   .v2-msg__head {
     height: auto;
     flex-wrap: wrap;
   }
 
-  .v2-msg__actions {
+  .v2-msg--reveal .v2-msg__actions {
     opacity: 1;
     pointer-events: auto;
   }

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -839,7 +839,10 @@
   overflow: visible;
 }
 
-.v2-pods__filter {
+/* `.v2-root button.` prefix is REQUIRED: the global button reset (0-1-1)
+   zeroes padding on any bare-class button rule (0-1-0). Third documented
+   hit of this trap — measured live as 25px chips hugging bare text. */
+.v2-root button.v2-pods__filter {
   height: 32px;
   padding: 0 9px;
   font-size: 12px;


### PR DESCRIPTION
Sam's follow-up on #1177: the touch fallback made the cluster always visible — chrome over every message. Now a tap reveals it (matchMedia-gated, desktop hover untouched), a second tap hides it, and the invariant pins the reveal gate so ungated opacity:1 can't return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK