### PR TITLE
fix(v2): conversation goes full-width; mentions and threads join the shared grid

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -248,18 +248,26 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // capped box for the longest) and scattered zh-CN's four 2-character
     // labels across phantom cells. Chips hug their labels with uniform
     // padding, so both locales read as one segmented control. The intent
-    // from 2026-08-13 is unchanged: one row, no wrap — pinned here as
-    // flex + nowrap + no width-allocating grid.
+    // Superseded 2026-08-23 (Sam): equal cells beat one row. Four equal
+    // chips can't share the 239px rail (EN "Community" needs 84px alone),
+    // so equal means the same 2×2 grid the community-tabs below use.
     const rule = ruleBody(v2, '.v2-pods__filters');
-    expect(rule).toContain('display: flex');
-    expect(rule).not.toContain('grid-template-columns');
+    expect(rule).toContain('display: grid');
+    expect(rule).toContain('grid-template-columns: repeat(2, minmax(0, 1fr))');
     expect(rule).toContain('overflow: visible');
     // The `.v2-root button.` prefix is load-bearing: the global button reset
     // (0-1-1) zeroes padding on a bare-class rule (0-1-0), which shipped as
     // 25px chips hugging bare text — the third hit of this exact trap.
     const chip = ruleBody(v2, '.v2-root button.v2-pods__filter');
     expect(chip).toContain('white-space: nowrap');
-    expect(chip).toContain('padding: 0 9px');
+    expect(chip).toContain('padding: 0 10px');
+    // The active rule must FOLLOW the base chip rule: both weigh 0-2-1, so
+    // source order decides the selected chip's color — the wrong order
+    // shipped grey-on-blue (measured live 2026-08-23).
+    const active = ruleBody(v2, '.v2-root button.v2-pods__filter--active');
+    expect(active).toContain('color: var(--v2-surface)');
+    expect(v2.indexOf('.v2-root button.v2-pods__filter--active'))
+      .toBeGreaterThan(v2.indexOf('.v2-root button.v2-pods__filter {'));
   });
 
   test('accent treatment is a wash, never a message rail', () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -105,20 +105,32 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).not.toContain('.v2-team-card__runtime {');
   });
 
-  test('the conversation column centers as a WHOLE — messages and composer share one measure (rule 2, v3)', () => {
-    // Third mechanism, ruled by Sam 2026-08-23 ("message still halved after
-    // right sidebar closed"). v1 centered messages alone (the island — a
-    // disaster); v2 capped 76ch left-anchored, which reads as a half-empty
-    // page at wide widths. v3's load-bearing property is COHERENCE: the
-    // messages' children AND the composer's children must share the same
-    // measure token — centering one without the other recreates the island.
-    expect(v2).toContain('--v2-conv-measure:');
-    expect(ruleBody(v2, '.v2-chat__messages > *')).toContain('max-width: var(--v2-conv-measure)');
-    expect(ruleBody(v2, '.v2-chat__messages > *')).toContain('margin-inline: auto');
-    expect(ruleBody(v2, '.v2-chat__composer > *')).toContain('max-width: var(--v2-conv-measure)');
-    expect(ruleBody(v2, '.v2-chat__composer > *')).toContain('margin-inline: auto');
-    // Text measure inside the column stays readable.
-    expect(v2).toContain('max-width: 76ch');
+  test('the conversation column is FULL-WIDTH — no measure cap, one left edge (rule 2, v5)', () => {
+    // Fifth mechanism, ruled by Sam 2026-08-23: the Slack model. With a
+    // line cap, leftover space must pool somewhere — center was rejected,
+    // and left-anchor pools it all on the right — so the cap itself goes.
+    // No revision may reintroduce a conversation measure token: that is
+    // the corner-of-the-triangle debate re-opening by accident.
+    expect(v2).not.toContain('--v2-conv-measure');
+    // What survives every revision is COHERENCE: messages' and composer's
+    // children share the pane's full width and one explicit left edge.
+    // margin-inline stays an explicit 0 — a stray auto re-centers a subset
+    // of rows and recreates the v1 island.
+    expect(ruleBody(v2, '.v2-chat__messages > *')).toContain('width: 100%');
+    expect(ruleBody(v2, '.v2-chat__messages > *')).toContain('margin-inline: 0');
+    expect(ruleBody(v2, '.v2-chat__composer > *')).toContain('margin-inline: 0');
+    // Nothing in the column may escape the shared edge (Sam, 2026-08-23:
+    // mentions and threads sat off-grid while messages aligned).
+    // Mentions: the wash bleed must equal the padding (the old -12px against
+    // 10px padding put mention TEXT 2px off-grid), widening the wash by one
+    // padding per side into the pane gutter.
+    expect(ruleBody(v2, '.v2-chat__messages > .v2-msg--mention'))
+      .toContain('margin-inline: -10px');
+    expect(ruleBody(v2, '.v2-chat__messages > .v2-msg--mention'))
+      .toContain('width: calc(100% + 20px)');
+    // Threads: card + rail travel inside one block-level child, whose
+    // bottom margin terminates the rail before the next outer message.
+    expect(ruleBody(v2, '.v2-thread-block')).toContain('margin-bottom');
   });
 
   test('motion timing is tokenized and all three existing V2 animations consume it', () => {
@@ -345,9 +357,9 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     const row = ruleBody(v2, '.v2-chat__starter-prompts');
     const chip = ruleBody(v2, '.v2-root button.v2-chat__starter-prompt');
     expect(row).toContain('flex-wrap: wrap');
-    // min(measure, 100%): shares the conversation column's centerline at
-    // desktop widths while keeping the 390px shrink this pin exists for.
-    expect(row).toContain('max-width: min(var(--v2-conv-measure), 100%)');
+    // Full pane width (rule 2 v5) while keeping the 390px shrink this pin
+    // exists for.
+    expect(row).toContain('max-width: 100%');
     expect(chip).toContain('max-width: 100%');
     expect(chip).toContain('white-space: normal');
   });

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -1281,7 +1281,10 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                 // collapsed card around them — absence is not "collapsed".
                 const collapsed = st ? st.collapsed : false;
                 return (
-                  <React.Fragment key={`thread-${item.rootId}`}>
+                  // One block, not loose siblings: the conversation column
+                  // centers direct children, and a bare card + rail escaped
+                  // it (measured left-anchored at 24px vs the column's 186px).
+                  <div className="v2-thread-block" key={`thread-${item.rootId}`}>
                     <V2ThreadCard
                       replyCount={item.replyCount}
                       participants={item.participants}
@@ -1329,7 +1332,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                         )}
                       </div>
                     )}
-                  </React.Fragment>
+                  </div>
                 );
               })}
               <div ref={messagesEndRef} />

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -822,16 +822,15 @@
 }
 
 .v2-pods__filters {
-  /* Third mechanism for this row (Sam's taste ruling 2026-08-23). The grid
-     of three equal cells + one capped cell allocated width exactly
-     backwards — the short words got wide boxes, the longest word got the
-     capped one, and in zh-CN four 2-character labels floated as scattered
-     text. Content-sized chips fix both locales by construction: every box
-     hugs its own label with identical padding, so the row reads as one
-     segmented control whatever the strings are. Measured to fit the 240px
-     rail in both locales at 12px (EN ≈ 217px, zh-CN ≈ 180px incl. gaps).
-     Intent preserved from the 2026-08-13 invariant: one row, no wrap. */
-  display: flex;
+  /* Fourth mechanism for this row (Sam's ruling 2026-08-23): every chip the
+     SAME size, at least as roomy as the widest label. Content-sized chips
+     read ragged (EN measured 33/49/44/84px), and four equal cells cannot
+     share one 239px rail — "Community" alone needs 84px. Equal therefore
+     means a 2×2 grid, the exact mechanism .v2-pods__community-tabs below
+     already uses, so the two stacked sections align by construction. This
+     retires the 2026-08-13 one-row intent deliberately. */
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 4px;
   padding: 0;
   margin-bottom: 18px;
@@ -844,19 +843,32 @@
    hit of this trap — measured live as 25px chips hugging bare text. */
 .v2-root button.v2-pods__filter {
   height: 32px;
-  padding: 0 9px;
+  min-width: 0;
+  padding: 0 10px;
   font-size: 12px;
   font-weight: 500;
   color: #4b5563;
   border-radius: var(--v2-radius-sm);
   text-align: center;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   transition: background 80ms ease, color 80ms ease;
 }
 
 .v2-pods__filter:hover {
   color: var(--v2-text-primary);
   background: var(--v2-surface-hover);
+}
+
+/* Must sit AFTER the base chip rule: both this and the shared
+   .v2-root button.v2-filter-segment__item--active rule weigh 0-2-1, so
+   source order decides — with the base chip rule later in the file, the
+   selected chip shipped grey-on-blue (measured live 2026-08-23). */
+.v2-root button.v2-pods__filter--active {
+  background: var(--v2-accent);
+  color: var(--v2-surface);
+  font-weight: 700;
 }
 
 .v2-pods__community-tabs {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -1568,34 +1568,23 @@
   gap: 0;
 }
 
-/* Conversation measure — third revision of craft rule 2, ruled by Sam
-   2026-08-23 ("message still halved after right sidebar closed").
-   History matters here: v1 centered ONLY the messages ("a floating island"
-   — a disaster, because the composer and header kept a different edge);
-   v2 capped text at 76ch left-anchored, which reads correctly at narrow
-   widths and as a half-empty page once the inspector closes (~420px of
-   dead space at 1092px). v3 centers the WHOLE conversation: messages,
-   typing indicator, delivery hint, starter prompts, and the composer's
-   inner content all share one measure and one centerline — the coherence
-   v1 lacked. Header stays full-bleed; it is chrome, not conversation.
-   The measure = 76ch of text + the 50px avatar column. */
-.v2-root {
-  --v2-conv-measure: calc(76ch + 50px);
-}
-
+/* Conversation width — FIFTH revision of craft rule 2, ruled by Sam
+   2026-08-23: FULL-WIDTH, the Slack/Discord model. The measure cap died
+   with its last corner: v1 centered messages alone (island), v2/v4
+   left-anchored the cap (dead space on the right once the inspector
+   closes), v3 centered the whole column (rejected outright). With a line
+   cap, leftover space must pool somewhere — so the cap goes. Rows and
+   text span the pane and wrap at its edge; lines run long on wide
+   windows, the familiar chat tradeoff. What survives every revision:
+   one shared left edge for every conversation row, and margin-inline
+   stays an EXPLICIT 0 so a stray auto cannot re-center a subset. */
 .v2-chat__messages > * {
   width: 100%;
-  max-width: var(--v2-conv-measure);
-  margin-inline: auto;
+  margin-inline: 0;
 }
 
 .v2-chat__composer > * {
-  max-width: var(--v2-conv-measure);
-  margin-inline: auto;
-}
-
-.v2-msg__body {
-  max-width: 76ch;
+  margin-inline: 0;
 }
 
 /* Sender-only teaching cue shown once per pod/session when a message reaches
@@ -1869,13 +1858,13 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  /* Part of the conversation column (see --v2-conv-measure): siblings of
-     the messages list must share its centerline or they read as a second
-     edge — the v1-island lesson applied to every conversation element.
-     min(…, 100%) keeps the mobile-shrink property the 390px pane needs. */
+  /* Part of the conversation column: siblings of the messages list share
+     its full pane width and left edge (rule 2 v5, full-width) — a second
+     edge here recreates the v1 island. max-width keeps the mobile-shrink
+     property the 390px pane needs. */
   width: 100%;
-  max-width: min(var(--v2-conv-measure), 100%);
-  margin-inline: auto;
+  max-width: 100%;
+  margin-inline: 0;
   padding: 10px 24px 0;
   background: var(--v2-surface);
   flex-shrink: 0;
@@ -2694,7 +2683,17 @@
   background: var(--v2-accent-soft);
   border-radius: var(--v2-radius-sm);
   padding: 8px 10px 8px 10px;
-  margin-left: -12px;
+}
+
+/* The wash bleeds one padding past the row on BOTH sides so the mention
+   TEXT sits exactly on the shared grid like every other row (Sam,
+   2026-08-23 — mentions sat off-grid while messages aligned; the old
+   bleed was -12px against 10px padding, 2px off). The bleed lands inside
+   the pane's 24px gutter. 0-2-0 beats the `> *` width rule regardless of
+   source order. */
+.v2-chat__messages > .v2-msg--mention {
+  width: calc(100% + 20px);
+  margin-inline: -10px;
 }
 
 .v2-msg__content ul,
@@ -7198,6 +7197,15 @@
    card radius 10 / border #e5e7eb / hover #d7dce7 / no shadow; type 13px
    secondary with the count at 500; rail 2px #eef0f6 at 28px, replies +40px,
    dropping to 24px at 390; layout transition 300ms. */
+
+/* Card + rail travel as ONE column row. As loose siblings their margin
+   shorthands beat the column's `> *` centering on source order, so threads
+   sat left-anchored while messages centered (Sam, 2026-08-23). The bottom
+   margin is the rail's terminator: without it the rail's last pixel abuts
+   the next outer message and reads as connected to it. */
+.v2-thread-block {
+  margin-bottom: 14px;
+}
 
 .v2-thread-card {
   display: flex;


### PR DESCRIPTION
Sam's rulings, live review round 3: the conversation column drops the measure cap entirely (full-width, the Slack model — center was rejected, left-anchor pools dead space on the right). Mentions rejoin the shared grid with a symmetric one-padding wash bleed, thread card + rail travel as one centered-rule-immune block, and that block's bottom margin stops the rail from visually connecting to the next outer message. Invariants re-pinned; the conv-measure token is banned by test so the triangle debate can't re-open by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK