### PR TITLE
fix(v2): thread card and rail indent to the text column, like an attachment

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -128,8 +128,11 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       .toContain('margin-inline: -10px');
     expect(ruleBody(v2, '.v2-chat__messages > .v2-msg--mention'))
       .toContain('width: calc(100% + 20px)');
-    // Threads: card + rail travel inside one block-level child, whose
-    // bottom margin terminates the rail before the next outer message.
+    // Threads: card + rail travel inside one block-level child, indented
+    // to the message TEXT column like an attachment (38px avatar + 12px
+    // gap), whose bottom margin terminates the rail before the next
+    // outer message.
+    expect(ruleBody(v2, '.v2-thread-block')).toContain('margin-left: 50px');
     expect(ruleBody(v2, '.v2-thread-block')).toContain('margin-bottom');
   });
 
@@ -494,13 +497,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // correct rail from a missing one — the card and replies still appear,
     // just unindented and with no rule. This pins the three numbers that a
     // reader would otherwise have to take from a comment.
-    // REV 2 (@ux-lead, thread-reply-row-alignment rev 2, TASK-049 item 3).
-    // These numbers are inverted from rev 1 and the ruling authorises it:
-    // the root avatar is .v2-avatar--md = 30px inside a 38px column, so its
-    // centre is x = 15, not 19. margin-left 14 + the 2px border puts the rule
-    // through that centre. rev 1 measured the column and not the avatar.
+    // REV 3 (Sam, 2026-08-23): the whole thread block is indented to the
+    // message TEXT column like an attachment (margin-left 50px, pinned in
+    // the column test above), so the rail sits AT the block edge — margin 0
+    // — and card, rail, and message text share one line. Rev 2's
+    // avatar-centre axis (margin 14 → x = 15) is superseded: the block no
+    // longer starts at the avatar edge, so there is no avatar to aim at.
     const rail = ruleBody(v2, '.v2-thread-replies');
-    expect(rail).toContain('margin-left: 14px');
+    expect(rail).toContain('margin-left: 0');
     expect(rail).toContain('padding-left: 12px');
     expect(rail).toContain('border-left: 2px solid #eef0f6');
 
@@ -511,9 +515,10 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(railRow).toContain('grid-template-columns: 24px minmax(0, 1fr)');
     expect(railRow).toContain('gap: 8px');
 
-    // 390: the AXIS does not move (no channel-row override at this
-    // breakpoint), only the inner padding tightens to give x = 56.
-    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-replies\s*\{[\s\S]*?margin-left: 14px[\s\S]*?padding-left: 8px/);
+    // 390 (rev 3): the block's 50px attachment indent tightens to 24px,
+    // the rail stays on the block edge, and the inner padding tightens.
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-block\s*\{[\s\S]*?margin-left: 24px/);
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-replies\s*\{[\s\S]*?margin-left: 0[\s\S]*?padding-left: 8px/);
   });
 
   test('the thread card has no shadow and no accent at rest', () => {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -7198,12 +7198,14 @@
    secondary with the count at 500; rail 2px #eef0f6 at 28px, replies +40px,
    dropping to 24px at 390; layout transition 300ms. */
 
-/* Card + rail travel as ONE column row. As loose siblings their margin
-   shorthands beat the column's `> *` centering on source order, so threads
-   sat left-anchored while messages centered (Sam, 2026-08-23). The bottom
-   margin is the rail's terminator: without it the rail's last pixel abuts
-   the next outer message and reads as connected to it. */
+/* Card + rail travel as ONE column row, indented to the message TEXT
+   column like an attachment (Sam, 2026-08-23): 38px avatar column + 12px
+   gap = 50px, so the thread visibly belongs to the message above it
+   rather than starting a new row at the avatar edge. The bottom margin is
+   the rail's terminator: without it the rail's last pixel abuts the next
+   outer message and reads as connected to it. */
 .v2-thread-block {
+  margin-left: 50px;
   margin-bottom: 14px;
 }
 
@@ -7305,14 +7307,14 @@
   color: var(--v2-accent);
 }
 
-/* Expanded replies hang off a left rail at the root avatar's centre. */
-/* Rail ON the root avatar's axis. The root avatar is .v2-avatar--md = 30px in
-   a 38px grid column, so its centre is x = 15; margin-left 14 + the 2px border
-   puts the rule through that centre. Rev 1 used 19 and was measuring the
-   column, not the avatar (@ux-lead, thread-reply-row-alignment rev 2). */
+/* Expanded replies hang off a left rail at the thread block's own edge.
+   The rail used to aim at the root avatar's centre (margin-left 14, rev 2);
+   with the whole block indented to the text column like an attachment
+   (Sam, 2026-08-23), the rail sits AT that column edge — margin 0 — so
+   card, rail, and message text share one line. */
 .v2-thread-replies {
   position: relative;
-  margin-left: 14px;
+  margin-left: 0;
   padding-left: 12px;
   border-left: 2px solid #eef0f6;
   transition: height 300ms ease;
@@ -7397,11 +7399,15 @@
     flex-wrap: wrap;
   }
 
-  /* The axis does NOT move at 390 — no channel-row override exists at this
-     breakpoint, so the root avatar centre is still x = 15. Only the inner
-     padding tightens: 16 + 8 + 24 + 8 = x = 56. */
+  /* The block's 50px attachment indent is expensive at 390 — tighten it,
+     but keep the rail on the block edge (aligned with the card), and the
+     inner padding tightens with it. */
+  .v2-thread-block {
+    margin-left: 24px;
+  }
+
   .v2-thread-replies {
-    margin-left: 14px;
+    margin-left: 0;
     padding-left: 8px;
   }
 


### PR DESCRIPTION
Sam's follow-up on #1181: the thread block hangs off the message TEXT column (50px — the same edge attachments render at), so it visibly belongs to the message above instead of starting a new row at the avatar edge. The rail moves to the block's own edge (rev 3 of the rail geometry — the avatar-centre axis has no avatar to aim at once the block is indented). 390px tightens the indent to 24px. All pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK