### PR TITLE
[frontend] Add crawlable public pages

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,18 +9,17 @@
          favicons and will still probe /favicon.ico (harmless 404) until a
          proper .ico is generated. -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="description" content="The open-source workspace where agents and teammates share one project memory — any runtime, your infra, no per-agent fees." />
+    <!-- The production build replaces these markers with route-specific static HTML. -->
+    <!-- SEO_METADATA_START -->
     <title>Commonly — chat with your agents, ship real work</title>
-
-    <!-- Social link previews. Crawlers (X, Slack, Discord, iMessage) read this
-         static HTML only — the SPA never runs for them — so the tags live here,
-         and og:image must be an ABSOLUTE https URL. Card: 1200x630, generated
-         from the landing hero copy; regenerate when the wedge line changes. -->
+    <meta name="description" content="The open-source workspace where agents and teammates share one project memory — any runtime, your infra, no per-agent fees." />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="https://commonly.me/" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Commonly" />
     <meta property="og:url" content="https://commonly.me/" />
     <meta property="og:title" content="Commonly — chat with your agents, ship real work" />
-    <meta property="og:description" content="The open-source workspace where you and your agents share one project memory — so nothing gets re-explained. Any runtime, your infra, no per-agent fees." />
+    <meta property="og:description" content="The open-source workspace where agents and teammates share one project memory — so nothing gets re-explained. Any runtime, your infra, no per-agent fees." />
     <meta property="og:image" content="https://commonly.me/og-card.png?v=2" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -29,6 +28,39 @@
     <meta name="twitter:title" content="Commonly — chat with your agents, ship real work" />
     <meta name="twitter:description" content="The open-source workspace where you and your agents share one project memory — so nothing gets re-explained. Any runtime, your infra, no per-agent fees." />
     <meta name="twitter:image" content="https://commonly.me/og-card.png?v=2" />
+    <!-- SEO_METADATA_END -->
+    <style>
+      #seo-page { box-sizing: border-box; min-height: 100vh; color: #e5e7eb; background: #0b1220; font: 16px/1.6 Inter, ui-sans-serif, system-ui, sans-serif; }
+      #seo-page *, #seo-page *::before, #seo-page *::after { box-sizing: inherit; }
+      #seo-page a { color: #7dd3fc; text-decoration-thickness: 1px; text-underline-offset: 3px; }
+      #seo-page a:hover { color: #e0f2fe; }
+      #seo-page .seo-header, #seo-page main, #seo-page .seo-footer { width: min(1120px, calc(100% - 40px)); margin: 0 auto; }
+      #seo-page .seo-header { display: flex; align-items: center; justify-content: space-between; gap: 24px; min-height: 72px; }
+      #seo-page .seo-header nav { display: flex; flex-wrap: wrap; gap: 16px; }
+      #seo-page .seo-brand { color: #fff; font-size: 20px; font-weight: 800; text-decoration: none; }
+      #seo-page section { padding: 64px 0; }
+      #seo-page h1, #seo-page h2, #seo-page h3 { color: #fff; line-height: 1.12; }
+      #seo-page h1 { max-width: 820px; margin: 0 0 20px; font-size: clamp(2.5rem, 7vw, 5rem); letter-spacing: -.055em; }
+      #seo-page h2 { max-width: 760px; margin: 0 0 20px; font-size: clamp(1.75rem, 4vw, 2.75rem); letter-spacing: -.035em; }
+      #seo-page h3 { margin: 0 0 12px; font-size: 1.2rem; }
+      #seo-page p { max-width: 800px; margin: 0 0 16px; }
+      #seo-page .seo-hero { padding-top: 100px; padding-bottom: 100px; }
+      #seo-page .seo-lede { color: #cbd5e1; font-size: 1.15rem; }
+      #seo-page .seo-kicker { margin-bottom: 10px; color: #7dd3fc; font-size: .78rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+      #seo-page .seo-actions { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; margin-top: 28px; }
+      #seo-page .seo-primary { display: inline-block; border-radius: 999px; padding: 10px 18px; color: #062032; background: #7dd3fc; font-weight: 800; text-decoration: none; }
+      #seo-page .seo-primary:hover { color: #062032; background: #bae6fd; }
+      #seo-page .seo-install { color: #cbd5e1; }
+      #seo-page .seo-install code { display: inline-block; overflow-wrap: anywhere; padding: 10px 12px; border: 1px solid #334155; border-radius: 8px; background: #111827; }
+      #seo-page .seo-band { width: 100%; max-width: none; margin-left: calc((100vw - min(1120px, calc(100vw - 40px))) / -2); padding-right: max(20px, calc((100vw - 1120px) / 2)); padding-left: max(20px, calc((100vw - 1120px) / 2)); color: #e0f2fe; background: #0c4a6e; }
+      #seo-page .seo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 16px; }
+      #seo-page .seo-card { padding: 24px; border: 1px solid #334155; border-radius: 12px; background: #111827; }
+      #seo-page .seo-card p:last-child, #seo-page .seo-card ul:last-child { margin-bottom: 0; }
+      #seo-page li { margin-bottom: 8px; color: #cbd5e1; }
+      #seo-page .seo-note { color: #94a3b8; font-size: .875rem; }
+      #seo-page .seo-footer { padding: 40px 0; color: #94a3b8; border-top: 1px solid #334155; }
+      @media (max-width: 640px) { #seo-page .seo-header { align-items: flex-start; flex-direction: column; padding: 20px 0; } #seo-page section { padding: 44px 0; } #seo-page .seo-hero { padding-top: 56px; padding-bottom: 56px; } }
+    </style>
     <script>
       // Force re-render on navigation
       window.addEventListener('popstate', function() {
@@ -40,7 +72,7 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root"><!-- SEO_PAGE_CONTENT --></div>
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,9 +34,9 @@
   },
   "scripts": {
     "start": "vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/generate-seo-pages.mjs",
     "preview": "vite preview",
-    "test": "jest --watchAll=false --forceExit",
+    "test": "jest --watchAll=false --forceExit && node --test scripts/generate-seo-pages.test.mjs",
     "test:coverage": "jest --coverage --watchAll=false --forceExit",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://commonly.me/sitemap.xml

--- a/frontend/scripts/generate-seo-pages.mjs
+++ b/frontend/scripts/generate-seo-pages.mjs
@@ -1,0 +1,295 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const frontendDir = resolve(scriptDir, '..');
+const buildDir = resolve(frontendDir, 'build');
+const siteUrl = 'https://commonly.me';
+const metadataStart = '<!-- SEO_METADATA_START -->';
+const metadataEnd = '<!-- SEO_METADATA_END -->';
+const pageContentMarker = '<!-- SEO_PAGE_CONTENT -->';
+
+const escapeHtml = (value) => String(value)
+  .replaceAll('&', '&amp;')
+  .replaceAll('<', '&lt;')
+  .replaceAll('>', '&gt;')
+  .replaceAll('"', '&quot;')
+  .replaceAll("'", '&#39;');
+
+const list = (items) => `<ul>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`;
+
+const replaceMarkedSection = (template, start, end, content) => {
+  const startIndex = template.indexOf(start);
+  const endIndex = template.indexOf(end);
+
+  if (startIndex < 0 || endIndex < 0 || endIndex < startIndex) {
+    throw new Error(`Missing or malformed ${start} marker in the Vite output.`);
+  }
+
+  return `${template.slice(0, startIndex)}${start}\n${content}\n${end}${template.slice(endIndex + end.length)}`;
+};
+
+const pageUrl = (path) => `${siteUrl}${path}`;
+
+const renderLanding = (landing, useCases) => {
+  const featureCards = [
+    landing.features.pods,
+    landing.features.team,
+    landing.features.dm,
+    landing.features.identity,
+  ].map((feature) => `
+    <article class="seo-card">
+      <p class="seo-kicker">${escapeHtml(feature.kicker)}</p>
+      <h3>${escapeHtml(feature.title)}</h3>
+      <p>${escapeHtml(feature.text)}</p>
+      ${list(Object.values(feature.points))}
+    </article>`).join('');
+
+  const howItWorks = [
+    landing.how.steps.install,
+    landing.how.steps.teammate,
+    landing.how.steps.swap,
+  ].map((step, index) => `
+    <article class="seo-card">
+      <p class="seo-kicker">Step ${index + 1}</p>
+      <h3>${escapeHtml(step.title)}</h3>
+      <p>${escapeHtml(step.text)}</p>
+    </article>`).join('');
+
+  const useCaseCards = Object.entries(useCases).map(([id, useCase]) => `
+    <article class="seo-card">
+      <p class="seo-kicker">${escapeHtml(useCase.eyebrow)}</p>
+      <h3><a href="/use-cases/${encodeURIComponent(id)}/">${escapeHtml(useCase.title)}</a></h3>
+      <p>${escapeHtml(useCase.summary)}</p>
+    </article>`).join('');
+
+  return `
+    <div id="seo-page">
+      <header class="seo-header">
+        <a class="seo-brand" href="/" aria-label="Commonly home">Commonly</a>
+        <nav aria-label="Primary navigation">
+          <a href="#features">Features</a>
+          <a href="#use-cases">Use cases</a>
+          <a href="/compare/">Compare</a>
+          <a href="https://github.com/Team-Commonly/commonly">GitHub</a>
+        </nav>
+      </header>
+      <main>
+        <section class="seo-hero">
+          <p class="seo-kicker">${escapeHtml(landing.hero.eyebrow)}</p>
+          <h1>${escapeHtml(landing.hero.ariaLabel)}</h1>
+          <p class="seo-lede">${escapeHtml(landing.hero.lede)}</p>
+          <p class="seo-actions"><a class="seo-primary" href="/v2/register">${escapeHtml(landing.actions.getStarted)}</a><a href="/v2/showcase">${escapeHtml(landing.actions.watchLiveRoom)}</a></p>
+          <p class="seo-install"><code>$ git clone github.com/Team-Commonly/commonly &amp;&amp; docker compose up</code></p>
+        </section>
+        <section class="seo-band">
+          <h2>${escapeHtml(landing.wedge.title)}</h2>
+          <p>${escapeHtml(landing.wedge.copy)}</p>
+        </section>
+        <section id="features">
+          <p class="seo-kicker">${escapeHtml(landing.features.kicker)}</p>
+          <h2>${escapeHtml(landing.features.title)}</h2>
+          <div class="seo-grid">${featureCards}</div>
+        </section>
+        <section>
+          <p class="seo-kicker">${escapeHtml(landing.how.kicker)}</p>
+          <h2>${escapeHtml(landing.how.title)}</h2>
+          <div class="seo-grid">${howItWorks}</div>
+        </section>
+        <section id="use-cases">
+          <p class="seo-kicker">${escapeHtml(landing.useCases.kicker)}</p>
+          <h2>${escapeHtml(landing.useCases.title)}</h2>
+          <div class="seo-grid">${useCaseCards}</div>
+        </section>
+        <section>
+          <p class="seo-kicker">${escapeHtml(landing.openSource.kicker)}</p>
+          <h2>${escapeHtml(landing.openSource.title)}</h2>
+          <p>${escapeHtml(landing.openSource.lede)}</p>
+          <p><a href="https://github.com/Team-Commonly/commonly">${escapeHtml(landing.actions.readSource)}</a></p>
+        </section>
+      </main>
+      <footer class="seo-footer">Commonly is open source under Apache-2.0.</footer>
+    </div>`;
+};
+
+const renderCompare = (compare) => {
+  const alternativeCards = Object.values(compare.alts).map((alternative) => `
+    <article class="seo-card">
+      <h3>${escapeHtml(alternative.name)}</h3>
+      <p>${escapeHtml(alternative.what)}</p>
+      <p>${escapeHtml(alternative.accept)}</p>
+    </article>`).join('');
+  const commonlyCards = Object.values(compare.us).map((item) => `
+    <article class="seo-card">
+      <h3>${escapeHtml(item.title)}</h3>
+      <p>${escapeHtml(item.body)}</p>
+    </article>`).join('');
+
+  return `
+    <div id="seo-page">
+      <header class="seo-header"><a class="seo-brand" href="/">Commonly</a><nav aria-label="Primary navigation"><a href="/">Home</a><a href="https://github.com/Team-Commonly/commonly">GitHub</a></nav></header>
+      <main>
+        <section class="seo-hero">
+          <p class="seo-kicker">${escapeHtml(compare.kicker)}</p>
+          <h1>${escapeHtml(compare.title)}</h1>
+          <p class="seo-lede">${escapeHtml(compare.lede)}</p>
+          <p class="seo-actions"><a class="seo-primary" href="/v2/register">${escapeHtml(compare.actions.getStarted)}</a></p>
+        </section>
+        <section>
+          <h2>${escapeHtml(compare.sameTitle)}</h2>
+          <p>${escapeHtml(compare.same)}</p>
+        </section>
+        <section>
+          <h2>${escapeHtml(compare.altsTitle)}</h2>
+          <div class="seo-grid">${alternativeCards}</div>
+        </section>
+        <section>
+          <h2>${escapeHtml(compare.usTitle)}</h2>
+          <div class="seo-grid">${commonlyCards}</div>
+        </section>
+        <section class="seo-band"><h2>${escapeHtml(compare.closeTitle)}</h2><p>${escapeHtml(compare.close)}</p><p>${escapeHtml(compare.closeUs)}</p></section>
+        <p class="seo-note">${escapeHtml(compare.note)}</p>
+      </main>
+      <footer class="seo-footer"><a href="/">Commonly</a> · <a href="https://github.com/Team-Commonly/commonly">GitHub</a></footer>
+    </div>`;
+};
+
+const renderUseCase = (useCase) => `
+  <div id="seo-page">
+    <header class="seo-header"><a class="seo-brand" href="/">Commonly</a><nav aria-label="Primary navigation"><a href="/">Home</a><a href="/compare/">Compare</a></nav></header>
+    <main>
+      <section class="seo-hero">
+        <p class="seo-kicker">${escapeHtml(useCase.eyebrow)}</p>
+        <h1>${escapeHtml(useCase.title)}</h1>
+        <p class="seo-lede">${escapeHtml(useCase.summary)}</p>
+        <p class="seo-actions"><a class="seo-primary" href="/v2/register">Start with this use case</a><a href="/v2/agents">Explore Agent Hub</a></p>
+      </section>
+      <section>
+        <div class="seo-grid">
+          <article class="seo-card"><h2>Commonly solves</h2>${list(useCase.problems)}</article>
+          <article class="seo-card"><h2>Expected outcomes</h2>${list(useCase.outcomes)}</article>
+        </div>
+      </section>
+      <section><h2>Example flow</h2><ol>${useCase.exampleFlow.map((step) => `<li>${escapeHtml(step)}</li>`).join('')}</ol></section>
+    </main>
+    <footer class="seo-footer"><a href="/">Back to Commonly</a></footer>
+  </div>`;
+
+const metadata = ({ title, description, path, schema }) => {
+  const url = pageUrl(path);
+  const structuredData = JSON.stringify(schema).replaceAll('<', '\\u003c');
+  return `
+    <title>${escapeHtml(title)}</title>
+    <meta name="description" content="${escapeHtml(description)}" />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="${url}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Commonly" />
+    <meta property="og:url" content="${url}" />
+    <meta property="og:title" content="${escapeHtml(title)}" />
+    <meta property="og:description" content="${escapeHtml(description)}" />
+    <meta property="og:image" content="${siteUrl}/og-card.png?v=2" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@sam_commonly" />
+    <meta name="twitter:title" content="${escapeHtml(title)}" />
+    <meta name="twitter:description" content="${escapeHtml(description)}" />
+    <meta name="twitter:image" content="${siteUrl}/og-card.png?v=2" />
+    <script type="application/ld+json">${structuredData}</script>`;
+};
+
+export const buildPageDefinitions = ({ landing, compare, useCases }) => {
+  const organization = {
+    '@type': 'Organization',
+    name: 'Commonly',
+    url: `${siteUrl}/`,
+    logo: `${siteUrl}/favicon.svg`,
+    sameAs: ['https://github.com/Team-Commonly/commonly'],
+  };
+  const softwareApplication = {
+    '@type': 'SoftwareApplication',
+    name: 'Commonly',
+    url: `${siteUrl}/`,
+    applicationCategory: 'BusinessApplication',
+    operatingSystem: 'Web',
+    description: landing.hero.lede,
+    license: 'https://www.apache.org/licenses/LICENSE-2.0',
+  };
+  const webPage = (title, description, path) => ({
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: title,
+    description,
+    url: pageUrl(path),
+    isPartOf: { '@type': 'WebSite', name: 'Commonly', url: `${siteUrl}/` },
+  });
+
+  const pages = [{
+    path: '/',
+    outputPath: 'index.html',
+    title: 'Commonly — chat with your agents, ship real work',
+    description: 'The open-source workspace where agents and teammates share one project memory — any runtime, your infra, no per-agent fees.',
+    content: renderLanding(landing, useCases),
+    schema: {
+      '@context': 'https://schema.org',
+      '@graph': [organization, softwareApplication],
+    },
+  }, {
+    path: '/compare/',
+    outputPath: 'compare/index.html',
+    title: 'Commonly vs the alternatives | Commonly',
+    description: compare.lede,
+    content: renderCompare(compare),
+    schema: webPage(compare.title, compare.lede, '/compare/'),
+  }];
+
+  return pages.concat(Object.entries(useCases).map(([id, useCase]) => {
+    const path = `/use-cases/${id}/`;
+    return {
+      path,
+      outputPath: `use-cases/${id}/index.html`,
+      title: `${useCase.title} | Commonly`,
+      description: useCase.summary,
+      content: renderUseCase(useCase),
+      schema: webPage(useCase.title, useCase.summary, path),
+    };
+  }));
+};
+
+export const renderStaticPage = (template, page) => {
+  const withMetadata = replaceMarkedSection(template, metadataStart, metadataEnd, metadata(page));
+  if (!withMetadata.includes(pageContentMarker)) {
+    throw new Error('Missing SEO page-content marker in the Vite output.');
+  }
+  return withMetadata.replace(pageContentMarker, page.content);
+};
+
+export const generateSeoPages = async ({ outputDir = buildDir } = {}) => {
+  const [template, translationText, useCaseText] = await Promise.all([
+    readFile(resolve(outputDir, 'index.html'), 'utf8'),
+    readFile(resolve(frontendDir, 'src/i18n/locales/en.json'), 'utf8'),
+    readFile(resolve(frontendDir, 'src/content/use-cases.json'), 'utf8'),
+  ]);
+  const translations = JSON.parse(translationText);
+  const useCases = JSON.parse(useCaseText);
+  const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases });
+
+  await Promise.all(pages.map(async (page) => {
+    const outputPath = resolve(outputDir, page.outputPath);
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, renderStaticPage(template, page));
+  }));
+
+  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${pages.map((page) => `  <url><loc>${pageUrl(page.path)}</loc></url>`).join('\n')}\n</urlset>\n`;
+  await writeFile(resolve(outputDir, 'sitemap.xml'), sitemap);
+  return pages;
+};
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  generateSeoPages().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildPageDefinitions, renderStaticPage } from './generate-seo-pages.mjs';
+
+const frontendDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+test('emits a canonical crawlable page for every public route', async () => {
+  const [translationText, useCaseText] = await Promise.all([
+    readFile(resolve(frontendDir, 'src/i18n/locales/en.json'), 'utf8'),
+    readFile(resolve(frontendDir, 'src/content/use-cases.json'), 'utf8'),
+  ]);
+  const translations = JSON.parse(translationText);
+  const useCases = JSON.parse(useCaseText);
+  const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases });
+
+  assert.equal(pages.length, 8);
+  assert.deepEqual(pages.map((page) => page.path), [
+    '/',
+    '/compare/',
+    '/use-cases/team-chat/',
+    '/use-cases/agent-collab/',
+    '/use-cases/daily-digest/',
+    '/use-cases/community/',
+    '/use-cases/pod-browser/',
+    '/use-cases/app-marketplace/',
+  ]);
+  assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
+    'Organization',
+    'SoftwareApplication',
+  ]);
+});
+
+test('puts route content, canonical metadata, and structured data in the document', () => {
+  const page = {
+    path: '/example/',
+    title: 'Example page | Commonly',
+    description: 'An example description.',
+    content: '<main><h1>Example page</h1><a href="/">Home</a></main>',
+    schema: { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Example page' },
+  };
+  const template = '<head><!-- SEO_METADATA_START --><!-- SEO_METADATA_END --></head><body><div id="root"><!-- SEO_PAGE_CONTENT --></div></body>';
+  const rendered = renderStaticPage(template, page);
+
+  assert.match(rendered, /<h1>Example page<\/h1>/);
+  assert.match(rendered, /<link rel="canonical" href="https:\/\/commonly\.me\/example\/"/);
+  assert.match(rendered, /application\/ld\+json/);
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,10 +2,10 @@ import React, { useEffect } from 'react';
 import { BrowserRouter, Navigate, Routes, Route, useLocation, useNavigate } from 'react-router-dom';
 import { ThemeProvider, CssBaseline } from '@mui/material';
 import { createTheme } from '@mui/material/styles';
-// Auth, OAuth, and use-case entry stubs remain so hard-loaded external links
-// (and their query strings) still resolve. The former v1 shell and marketing
-// surfaces have been deleted; NavigationHandler redirects their old paths to
-// the v2 shell.
+// Auth and OAuth entry stubs remain so hard-loaded external links (and their
+// query strings) still resolve. The canonical public landing, comparison, and
+// use-case routes stay outside the v2 shell so their static HTML is also the
+// route users see after JavaScript loads.
 import Login from './components/Login';
 import Register from './components/Register';
 import RegistrationInviteRequired from './components/RegistrationInviteRequired';
@@ -14,10 +14,11 @@ import VerifyEmail from './components/VerifyEmail';
 import DiscordCallback from './components/DiscordCallback';
 import V2ComparePage from './v2/landing/V2ComparePage';
 import { AppProvider } from './context/AppContext';
-import { AuthProvider } from './context/AuthContext';
+import { AuthProvider, useAuth } from './context/AuthContext';
 import { SocketProvider } from './context/SocketContext';
 import { LayoutProvider } from './context/LayoutContext';
 import V2App from './v2/V2App';
+import V2LandingPage from './v2/landing/V2LandingPage';
 import { setupFocusManagement } from './utils/focusUtils';
 import { checkAndRefresh } from './utils/refreshUtils';
 import './App.css';
@@ -180,12 +181,10 @@ const theme = createTheme({
 });
 
 const getV2EquivalentPath = (pathname: string, search: string): string | null => {
-  if (pathname === '/') return '/v2';
   if (pathname === '/login') return '/v2/login';
   if (pathname === '/register' || pathname === '/register/invite-required') return `/v2${pathname}${search}`;
   if (pathname === '/verify-email') return `/v2${pathname}${search}`;
   if (pathname.startsWith('/discord/')) return `/v2${pathname}${search}`;
-  if (pathname.startsWith('/use-cases/')) return `/v2${pathname}${search}`;
   if (pathname === '/feed') return `/v2/feed${search}`;
   if (pathname.startsWith('/thread/')) return `/v2${pathname}${search}`;
   if (pathname === '/dashboard') return `/v2/dashboard${search}`;
@@ -204,15 +203,22 @@ const getV2EquivalentPath = (pathname: string, search: string): string | null =>
   return null;
 };
 
+const PublicHome: React.FC = () => {
+  const { isAuthenticated, loading } = useAuth();
+
+  if (loading || !isAuthenticated) return <V2LandingPage />;
+  return <Navigate to="/v2" replace />;
+};
+
 // Component to handle navigation events
 function NavigationHandler(): null {
   const location = useLocation();
   const navigate = useNavigate();
 
   useEffect(() => {
-    // v2 is the default UI: redirect any non-/v2 path that has a v2
-    // equivalent into the v2 shell. /v2/* stays directly routable; remaining
-    // unmatched paths fall through to the router's v2 catch-all.
+    // Public marketing routes deliberately stay canonical outside /v2. Legacy
+    // app paths still redirect into the v2 shell, which remains directly
+    // routable for authenticated work.
     if (!location.pathname.startsWith('/v2')) {
       const v2Path = getV2EquivalentPath(location.pathname, location.search);
       if (v2Path) {
@@ -265,13 +271,10 @@ function App(): React.ReactElement {
                   <div className="App">
                     <Routes>
                     <Route path="/v2/*" element={<V2App />} />
-                    <Route path="/" element={<Navigate to="/v2" replace />} />
-                    {/* Public marketing page — no v2 equivalent, renders as-is. */}
+                    <Route path="/" element={<PublicHome />} />
+                    {/* Canonical public routes also have static build output. */}
                     <Route path="/compare" element={<V2ComparePage />} />
-                    {/* v1 auth / OAuth / use-case entry stubs. Kept so hard-loaded
-                        external links resolve with their query strings intact; in-app
-                        navigation to these paths is redirected into the v2 shell by
-                        NavigationHandler. */}
+                    {/* Legacy auth/OAuth entry points preserve their query strings. */}
                     <Route path="/use-cases/:useCaseId" element={<UseCasePage />} />
                     <Route path="/login" element={<Login />} />
                     <Route path="/register" element={<Register />} />

--- a/frontend/src/components/landing/UseCasePage.tsx
+++ b/frontend/src/components/landing/UseCasePage.tsx
@@ -11,6 +11,7 @@ import {
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import commonlyLogo from '../../assets/commonly-logo.png';
+import useCases from '../../content/use-cases.json';
 
 interface UseCase {
   eyebrow: string;
@@ -21,135 +22,7 @@ interface UseCase {
   exampleFlow: string[];
 }
 
-const USE_CASES: Record<string, UseCase> = {
-  'team-chat': {
-    eyebrow: 'Team Chat',
-    title: 'Run pod conversations with searchable shared context',
-    summary:
-      'Use pods, feed categories, and activity summaries together so your team builds a self-growing knowledge base from daily collaboration.',
-    problems: [
-      'Important updates get split between chat, posts, and side channels',
-      'Teams lose track of decisions when conversations move quickly',
-      'Follow-ups are easy to miss without a shared activity stream',
-    ],
-    outcomes: [
-      'Pod chat and feed workflows in one place',
-      'Agent mentions in chat and threads for faster context lookups',
-      'Hourly summaries and activity views that accumulate reusable knowledge',
-    ],
-    exampleFlow: [
-      'You post a planning update in pod chat.',
-      'A teammate mentions an agent to pull last week\u2019s related summary.',
-      'The decision is captured in-thread and appears in your next digest.',
-    ],
-  },
-  'agent-collab': {
-    eyebrow: 'Agent Collaboration',
-    title: 'Orchestrate secure, customizable multi-agent workflows',
-    summary:
-      'Use Agent Hub to create templates, deploy agent instances to pods, and connect containerized or self-hosted agents with scoped access.',
-    problems: [
-      'Teams need more than one assistant with different responsibilities',
-      'Runtime setup and configuration often lives outside daily workflows',
-      'Security and publish guardrails are hard to enforce across many agent runtimes',
-    ],
-    outcomes: [
-      'Discover, Presets, Installed, and Admin tabs in Agent Hub',
-      'Create/edit template-based agents and install them per pod',
-      'Runtime tokens + scoped integration permissions for controlled access',
-      'Support OpenClaw plus external/self-hosted CLI-style agents via secure agent APIs',
-    ],
-    exampleFlow: [
-      'You install a coding partner agent to one pod and a curator agent to another.',
-      'Each agent gets scoped runtime access based on pod needs.',
-      'Agents respond in-context without mixing identities or permissions.',
-    ],
-  },
-  'daily-digest': {
-    eyebrow: 'Daily Digest',
-    title: 'Convert noisy activity into digestible updates',
-    summary:
-      'Generate AI digests from recent activity, review history, and track digest analytics in one workflow.',
-    problems: [
-      'Too many updates to review manually',
-      'Teams need a quick readout before jumping into detailed threads',
-      'It is difficult to maintain continuity across daily check-ins',
-    ],
-    outcomes: [
-      'Latest, History, and Generate digest controls',
-      'Structured highlights, notable moments, and key insights',
-      'Digest analytics for activity volume and trend visibility',
-    ],
-    exampleFlow: [
-      'Messages and social updates accumulate through the day.',
-      'You generate a digest before standup or check-in.',
-      'Everyone starts with the same concise context and clear action points.',
-    ],
-  },
-  community: {
-    eyebrow: 'Integrations',
-    title: 'Operate one social feed across connected apps',
-    summary:
-      'Connect official providers, aggregate external social activity into Commonly feeds, and coordinate team response from one workspace.',
-    problems: [
-      'Community signals are spread across multiple provider dashboards',
-      'Manual copying between channels and internal discussion is slow',
-      'External publishing needs clear policy controls',
-    ],
-    outcomes: [
-      'Official integration cards for Discord, Slack, Telegram, GroupMe, X, and Instagram',
-      'Global social feed configuration for X and Instagram ingestion',
-      'Policy controls for external publishing behavior and attribution',
-    ],
-    exampleFlow: [
-      'Connected social feeds bring external posts into Commonly.',
-      'Your team curates and discusses what matters in one pod.',
-      'Publishing follows admin guardrails and attribution policy.',
-    ],
-  },
-  'pod-browser': {
-    eyebrow: 'Pod Browser',
-    title: 'Find the right room before entering chat',
-    summary:
-      'Browse pods by category, preview room details, and jump into conversations with Open Chat from a single index view.',
-    problems: [
-      'Users waste time jumping into the wrong room',
-      'Teams need a quick view of joined vs discoverable pods',
-      'Unread activity is easy to miss without room-level indicators',
-    ],
-    outcomes: [
-      'Category routes for Chat, Study, Games, and Ensemble pods',
-      'All, Joined, and Discover filters for faster room triage',
-      'Room cards with membership counts, badges, and direct Open Chat actions',
-    ],
-    exampleFlow: [
-      'A new member opens pod browser and checks Discover.',
-      'They preview room type and activity before joining.',
-      'Open Chat drops them into the right space with context ready.',
-    ],
-  },
-  'app-marketplace': {
-    eyebrow: 'App Marketplace',
-    title: 'Install official apps and discover advanced connectors',
-    summary:
-      'Use the Apps marketplace to connect official integrations, review capability tags, and discover optional advanced connectors.',
-    problems: [
-      'Teams cannot easily see which providers are officially supported',
-      'Setup paths are unclear when integrations live in different admin screens',
-      'Advanced connector discovery is fragmented without a shared catalog view',
-    ],
-    outcomes: [
-      'Official Marketplace cards for Discord, Slack, Telegram, GroupMe, X, and Instagram',
-      'Connect in Pod calls-to-action with direct docs links',
-      'Advanced connector preview block with setup requirements made explicit',
-    ],
-    exampleFlow: [
-      'You open Apps marketplace and select the provider your pod needs.',
-      'Connect in Pod links setup directly to pod context.',
-      'You add optional advanced connectors for specialized workflows later.',
-    ],
-  },
-};
+const USE_CASES = useCases as Record<string, UseCase>;
 
 const UseCasePage: React.FC = () => {
   const { useCaseId } = useParams<{ useCaseId: string }>();

--- a/frontend/src/content/use-cases.json
+++ b/frontend/src/content/use-cases.json
@@ -1,0 +1,123 @@
+{
+  "team-chat": {
+    "eyebrow": "Team Chat",
+    "title": "Run pod conversations with searchable shared context",
+    "summary": "Use pods, feed categories, and activity summaries together so your team builds a self-growing knowledge base from daily collaboration.",
+    "problems": [
+      "Important updates get split between chat, posts, and side channels",
+      "Teams lose track of decisions when conversations move quickly",
+      "Follow-ups are easy to miss without a shared activity stream"
+    ],
+    "outcomes": [
+      "Pod chat and feed workflows in one place",
+      "Agent mentions in chat and threads for faster context lookups",
+      "Hourly summaries and activity views that accumulate reusable knowledge"
+    ],
+    "exampleFlow": [
+      "You post a planning update in pod chat.",
+      "A teammate mentions an agent to pull last week’s related summary.",
+      "The decision is captured in-thread and appears in your next digest."
+    ]
+  },
+  "agent-collab": {
+    "eyebrow": "Agent Collaboration",
+    "title": "Orchestrate secure, customizable multi-agent workflows",
+    "summary": "Use Agent Hub to create templates, deploy agent instances to pods, and connect containerized or self-hosted agents with scoped access.",
+    "problems": [
+      "Teams need more than one assistant with different responsibilities",
+      "Runtime setup and configuration often lives outside daily workflows",
+      "Security and publish guardrails are hard to enforce across many agent runtimes"
+    ],
+    "outcomes": [
+      "Discover, Presets, Installed, and Admin tabs in Agent Hub",
+      "Create/edit template-based agents and install them per pod",
+      "Runtime tokens + scoped integration permissions for controlled access",
+      "Support OpenClaw plus external/self-hosted CLI-style agents via secure agent APIs"
+    ],
+    "exampleFlow": [
+      "You install a coding partner agent to one pod and a curator agent to another.",
+      "Each agent gets scoped runtime access based on pod needs.",
+      "Agents respond in-context without mixing identities or permissions."
+    ]
+  },
+  "daily-digest": {
+    "eyebrow": "Daily Digest",
+    "title": "Convert noisy activity into digestible updates",
+    "summary": "Generate AI digests from recent activity, review history, and track digest analytics in one workflow.",
+    "problems": [
+      "Too many updates to review manually",
+      "Teams need a quick readout before jumping into detailed threads",
+      "It is difficult to maintain continuity across daily check-ins"
+    ],
+    "outcomes": [
+      "Latest, History, and Generate digest controls",
+      "Structured highlights, notable moments, and key insights",
+      "Digest analytics for activity volume and trend visibility"
+    ],
+    "exampleFlow": [
+      "Messages and social updates accumulate through the day.",
+      "You generate a digest before standup or check-in.",
+      "Everyone starts with the same concise context and clear action points."
+    ]
+  },
+  "community": {
+    "eyebrow": "Integrations",
+    "title": "Operate one social feed across connected apps",
+    "summary": "Connect official providers, aggregate external social activity into Commonly feeds, and coordinate team response from one workspace.",
+    "problems": [
+      "Community signals are spread across multiple provider dashboards",
+      "Manual copying between channels and internal discussion is slow",
+      "External publishing needs clear policy controls"
+    ],
+    "outcomes": [
+      "Official integration cards for Discord, Slack, Telegram, GroupMe, X, and Instagram",
+      "Global social feed configuration for X and Instagram ingestion",
+      "Policy controls for external publishing behavior and attribution"
+    ],
+    "exampleFlow": [
+      "Connected social feeds bring external posts into Commonly.",
+      "Your team curates and discusses what matters in one pod.",
+      "Publishing follows admin guardrails and attribution policy."
+    ]
+  },
+  "pod-browser": {
+    "eyebrow": "Pod Browser",
+    "title": "Find the right room before entering chat",
+    "summary": "Browse pods by category, preview room details, and jump into conversations with Open Chat from a single index view.",
+    "problems": [
+      "Users waste time jumping into the wrong room",
+      "Teams need a quick view of joined vs discoverable pods",
+      "Unread activity is easy to miss without room-level indicators"
+    ],
+    "outcomes": [
+      "Category routes for Chat, Study, Games, and Ensemble pods",
+      "All, Joined, and Discover filters for faster room triage",
+      "Room cards with membership counts, badges, and direct Open Chat actions"
+    ],
+    "exampleFlow": [
+      "A new member opens pod browser and checks Discover.",
+      "They preview room type and activity before joining.",
+      "Open Chat drops them into the right space with context ready."
+    ]
+  },
+  "app-marketplace": {
+    "eyebrow": "App Marketplace",
+    "title": "Install official apps and discover advanced connectors",
+    "summary": "Use the Apps marketplace to connect official integrations, review capability tags, and discover optional advanced connectors.",
+    "problems": [
+      "Teams cannot easily see which providers are officially supported",
+      "Setup paths are unclear when integrations live in different admin screens",
+      "Advanced connector discovery is fragmented without a shared catalog view"
+    ],
+    "outcomes": [
+      "Official Marketplace cards for Discord, Slack, Telegram, GroupMe, X, and Instagram",
+      "Connect in Pod calls-to-action with direct docs links",
+      "Advanced connector preview block with setup requirements made explicit"
+    ],
+    "exampleFlow": [
+      "You open Apps marketplace and select the provider your pod needs.",
+      "Connect in Pod links setup directly to pod context.",
+      "You add optional advanced connectors for specialized workflows later."
+    ]
+  }
+}

--- a/frontend/src/v2/V2App.tsx
+++ b/frontend/src/v2/V2App.tsx
@@ -14,11 +14,9 @@ import V2ResetPassword from './components/V2ResetPassword';
 import RegistrationInviteRequired from '../components/RegistrationInviteRequired';
 import VerifyEmail from '../components/VerifyEmail';
 import DiscordCallback from '../components/DiscordCallback';
-import V2LandingPage from './landing/V2LandingPage';
 import V2Showcase from './showcase/V2Showcase';
 import V2BillingPanel from './components/V2BillingPanel';
 import V2AgentProfile from './agents/V2AgentProfile';
-import UseCasePage from '../components/landing/UseCasePage';
 import PostFeed from '../components/PostFeed';
 import Thread from '../components/Thread';
 import UserProfile from '../components/UserProfile';
@@ -118,10 +116,15 @@ const V2Home: React.FC = () => {
   }
 
   if (!isAuthenticated) {
-    return <Navigate to="/v2/landing" replace />;
+    return <Navigate to="/" replace />;
   }
 
   return <V2Layout selectionMode="auto" />;
+};
+
+const V2UseCaseRedirect: React.FC = () => {
+  const { useCaseId } = useParams<{ useCaseId: string }>();
+  return <Navigate to={useCaseId ? `/use-cases/${encodeURIComponent(useCaseId)}/` : '/'} replace />;
 };
 
 const feature = (
@@ -169,7 +172,7 @@ const V2App: React.FC = () => {
       <V2ErrorBoundary>
         <Routes>
           <Route index element={<V2Home />} />
-          <Route path="landing" element={<V2LandingPage />} />
+          <Route path="landing" element={<Navigate to="/" replace />} />
           {/* Public read-only showcase — a logged-out visitor's window onto a
               real room. MUST sit OUTSIDE V2RequireAuth (the `*` branch below)
               so anonymous visitors reach it without bouncing to /v2/login. */}
@@ -180,7 +183,7 @@ const V2App: React.FC = () => {
               /v2/agents (Your Team). Outside V2RequireAuth, like the showcase. */}
           <Route path="agent/:agentName" element={<V2AgentProfile />} />
           <Route path="agent/:agentName/:instanceId" element={<V2AgentProfile />} />
-          <Route path="use-cases/:useCaseId" element={<UseCasePage />} />
+          <Route path="use-cases/:useCaseId" element={<V2UseCaseRedirect />} />
           <Route path="login" element={<V2Login />} />
           <Route path="register" element={<V2Register />} />
           <Route path="register/invite-required" element={<RegistrationInviteRequired />} />

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -5,6 +5,9 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import axios from 'axios';
 import { AuthContext } from '../../context/AuthContext';
 import V2App from '../V2App';
+import V2LandingPage from '../landing/V2LandingPage';
+import V2ComparePage from '../landing/V2ComparePage';
+import UseCasePage from '../../components/landing/UseCasePage';
 import i18n from '../../i18n';
 
 // Mock surface includes `defaults` and `interceptors` so the transitive
@@ -45,6 +48,9 @@ const renderAt = (path: string, auth = baseAuth) => render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="/v2/*" element={<V2App />} />
+        <Route path="/" element={<V2LandingPage />} />
+        <Route path="/compare" element={<V2ComparePage />} />
+        <Route path="/use-cases/:useCaseId/*" element={<UseCasePage />} />
       </Routes>
     </MemoryRouter>
   </AuthContext.Provider>,
@@ -68,7 +74,7 @@ describe('V2 routing', () => {
 
   test('index route shows the public landing when not authenticated', async () => {
     renderAt('/v2');
-    // V2Home sends logged-out visitors to /v2/landing (the public front door),
+    // V2Home sends logged-out visitors to the canonical public front door,
     // not the login wall. The hero H1 is word-split for the entrance stagger,
     // so match on the heading's accessible name (the aria-label carries the
     // full sentence) — this also pins the screen-reader contract.
@@ -80,6 +86,24 @@ describe('V2 routing', () => {
       'href',
       'https://github.com/Team-Commonly/commonly/issues/new/choose',
     );
+  });
+
+  test('legacy use-case routes redirect to their canonical public URL', async () => {
+    renderAt('/v2/use-cases/team-chat');
+
+    expect(await screen.findByRole('heading', {
+      level: 2,
+      name: 'Run pod conversations with searchable shared context',
+    })).toBeInTheDocument();
+  });
+
+  test('canonical comparison URL renders after the app takes over', async () => {
+    renderAt('/compare/');
+
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'Commonly vs the alternatives',
+    })).toBeInTheDocument();
   });
 
   test('deep protected route redirects to login when not authenticated', () => {

--- a/frontend/src/v2/landing/V2ComparePage.tsx
+++ b/frontend/src/v2/landing/V2ComparePage.tsx
@@ -50,12 +50,12 @@ const V2ComparePage: React.FC = () => {
   return (
     <div className="v2-root v2-landing">
       <header className="v2-landing__bar">
-        <Link className="v2-landing__brand" to="/v2/landing" style={{ textDecoration: 'none' }}>
+        <Link className="v2-landing__brand" to="/" style={{ textDecoration: 'none' }}>
           <span className="v2-landing__mark"><Mark size={26} /></span>
           <span className="v2-landing__brand-name">{t('common.brandName')}</span>
         </Link>
         <nav className="v2-landing__nav" aria-label={t('compare.nav.primaryLabel')}>
-          <Link className="v2-landing__navlink" to="/v2/landing">{t('compare.nav.home')}</Link>
+          <Link className="v2-landing__navlink" to="/">{t('compare.nav.home')}</Link>
           <a className="v2-landing__navlink" href={REPO} target="_blank" rel="noreferrer">{GITHUB_BRAND}</a>
           {!isAuthenticated && (
             <Link className="v2-landing__navlink" to="/v2/login">{t('compare.nav.signIn')}</Link>
@@ -128,7 +128,7 @@ const V2ComparePage: React.FC = () => {
         <div className="v2-landing__footer-cols">
           <div className="v2-landing__footer-col">
             <div className="v2-landing__footer-title">{t('compare.footer.product')}</div>
-            <Link className="v2-landing__footer-link" to="/v2/landing">{t('compare.nav.home')}</Link>
+            <Link className="v2-landing__footer-link" to="/">{t('compare.nav.home')}</Link>
             <Link className="v2-landing__footer-link" to={appHref}>{primaryLabel}</Link>
           </div>
           <div className="v2-landing__footer-col">

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -275,7 +275,7 @@ const V2LandingPage: React.FC = () => {
           <a className="v2-landing__navlink" href="#features">{t('landing.nav.features')}</a>
           <a className="v2-landing__navlink" href="#use-cases">{t('landing.nav.useCases')}</a>
           <a className="v2-landing__navlink" href="#pricing">{t('landing.nav.pricing')}</a>
-          <Link className="v2-landing__navlink" to="/compare">{t('landing.nav.compare')}</Link>
+          <Link className="v2-landing__navlink" to="/compare/">{t('landing.nav.compare')}</Link>
           <a className="v2-landing__navlink" href={REPO} target="_blank" rel="noreferrer">{t('landing.nav.github')}</a>
           {!isAuthenticated && (
             <Link className="v2-landing__navlink" to="/v2/login">{t('landing.nav.signIn')}</Link>
@@ -519,7 +519,7 @@ const V2LandingPage: React.FC = () => {
               <p className="v2-landing__open-lede">{t('landing.openSource.lede')}</p>
               <div className="v2-landing__cta-row">
                 <a className="v2-landing__btn v2-landing__btn--primary" href={REPO} target="_blank" rel="noreferrer">{t('landing.actions.readSource')}</a>
-                <Link className="v2-landing__btn v2-landing__btn--ghost" to="/compare">{t('landing.actions.compare')}</Link>
+                <Link className="v2-landing__btn v2-landing__btn--ghost" to="/compare/">{t('landing.actions.compare')}</Link>
               </div>
             </div>
             <ul className="v2-landing__open-list">
@@ -568,27 +568,27 @@ const V2LandingPage: React.FC = () => {
             <h2 className="v2-landing__h2">{t('landing.useCases.title')}</h2>
           </div>
           <div className="v2-landing__usecases" data-reveal data-reveal-stagger>
-            <Link className="v2-landing__usecase" to="/v2/use-cases/agent-collab">
+            <Link className="v2-landing__usecase" to="/use-cases/agent-collab/">
               <div className="v2-landing__usecase-title">{t('landing.useCases.coding.title')}</div>
               <p className="v2-landing__usecase-text">{t('landing.useCases.coding.text')}</p>
             </Link>
-            <Link className="v2-landing__usecase" to="/v2/use-cases/team-chat">
+            <Link className="v2-landing__usecase" to="/use-cases/team-chat/">
               <div className="v2-landing__usecase-title">{t('landing.useCases.chat.title')}</div>
               <p className="v2-landing__usecase-text">{t('landing.useCases.chat.text')}</p>
             </Link>
-            <Link className="v2-landing__usecase" to="/v2/use-cases/community">
+            <Link className="v2-landing__usecase" to="/use-cases/community/">
               <div className="v2-landing__usecase-title">{t('landing.useCases.research.title')}</div>
               <p className="v2-landing__usecase-text">{t('landing.useCases.research.text')}</p>
             </Link>
-            <Link className="v2-landing__usecase" to="/v2/use-cases/pod-browser">
+            <Link className="v2-landing__usecase" to="/use-cases/pod-browser/">
               <div className="v2-landing__usecase-title">{t('landing.useCases.browse.title')}</div>
               <p className="v2-landing__usecase-text">{t('landing.useCases.browse.text')}</p>
             </Link>
-            <Link className="v2-landing__usecase" to="/v2/use-cases/app-marketplace">
+            <Link className="v2-landing__usecase" to="/use-cases/app-marketplace/">
               <div className="v2-landing__usecase-title">{t('landing.useCases.marketplace.title')}</div>
               <p className="v2-landing__usecase-text">{t('landing.useCases.marketplace.text')}</p>
             </Link>
-            <Link className="v2-landing__usecase" to="/v2/use-cases/daily-digest">
+            <Link className="v2-landing__usecase" to="/use-cases/daily-digest/">
               <div className="v2-landing__usecase-title">{t('landing.useCases.digest.title')}</div>
               <p className="v2-landing__usecase-text">{t('landing.useCases.digest.text')}</p>
             </Link>
@@ -716,7 +716,7 @@ const V2LandingPage: React.FC = () => {
             <Link className="v2-landing__btn v2-landing__btn--onaccent" to={appHref}>{primaryLabel}</Link>
             <Link className="v2-landing__btn v2-landing__btn--onaccent-ghost" to="/v2/showcase">{t('landing.actions.watchLiveRoom')}</Link>
             <a className="v2-landing__btn v2-landing__btn--onaccent-ghost" href={REPO} target="_blank" rel="noreferrer">{t('landing.actions.starGithub')}</a>
-            <Link className="v2-landing__btn v2-landing__btn--onaccent-ghost" to="/compare">{t('landing.actions.compare')}</Link>
+            <Link className="v2-landing__btn v2-landing__btn--onaccent-ghost" to="/compare/">{t('landing.actions.compare')}</Link>
           </div>
         </section>
       </main>
@@ -733,7 +733,7 @@ const V2LandingPage: React.FC = () => {
             <Link className="v2-landing__footer-link" to={appHref}>{primaryLabel}</Link>
             <Link className="v2-landing__footer-link" to="/v2/marketplace">{t('landing.footer.marketplace')}</Link>
             <Link className="v2-landing__footer-link" to="/v2/agents/browse">{t('landing.footer.hireAgent')}</Link>
-            <Link className="v2-landing__footer-link" to="/compare">{t('landing.actions.compare')}</Link>
+            <Link className="v2-landing__footer-link" to="/compare/">{t('landing.actions.compare')}</Link>
             <a
               className="v2-landing__footer-link"
               href={`${REPO}/issues/new/choose`}


### PR DESCRIPTION
## Summary
- emit no-JS HTML for the canonical landing, comparison, and six use-case pages at build time
- add crawler discovery via `robots.txt` and generated `sitemap.xml`
- provide route-specific canonicals, social metadata, and JSON-LD; route legacy `/v2` marketing URLs to their canonical public paths
- share use-case content between the React UI and static-page generator

## Validation
- `npm test`
- `npm run typecheck`
- `npm run build`
- focused ESLint run: no errors (existing repo-wide lint errors remain outside this diff)
- verified the built no-JS routes, robots file, and sitemap through Vite preview