### PR TITLE
fix(v2): claim the page canvas — the V1 dark body showed through

### DIFF
--- a/frontend/src/v2/V2App.tsx
+++ b/frontend/src/v2/V2App.tsx
@@ -165,6 +165,15 @@ const V2App: React.FC = () => {
     } catch {
       // Ignore browsers that disallow sessionStorage.
     }
+    // Claim the page canvas while v2 is mounted. App.tsx unconditionally
+    // stamps `modern-ui` (the V1 dark gradient) on <body>, and .v2-root only
+    // paints its own box — so the V1 darkness showed through on load flash,
+    // overscroll, and every gap (Sam, 2026-08-24). The class must out-rank
+    // body.modern-ui, not merely follow it in bundle order.
+    document.body.classList.add('v2-canvas');
+    return () => {
+      document.body.classList.remove('v2-canvas');
+    };
   }, []);
 
   return (

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -105,6 +105,18 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).not.toContain('.v2-team-card__runtime {');
   });
 
+  test('v2 claims the page canvas — the V1 dark body cannot show through', () => {
+    // App.tsx stamps `modern-ui` (V1 dark gradient) on <body> unconditionally;
+    // .v2-root paints only its own box. Without this override the V1 dark
+    // showed on load flash, overscroll, and gaps (Sam, 2026-08-24). The
+    // compound selector must out-rank body.modern-ui so bundle order can
+    // never decide the canvas color. Keep the literal in lockstep with
+    // --v2-page-bg (tokens don't reach body — it sits outside .v2-root).
+    expect(v2).toContain('body.modern-ui.v2-canvas');
+    expect(v2).toMatch(/body\.v2-canvas,\nbody\.modern-ui\.v2-canvas \{[\s\S]*?background: #f8f8fb/);
+    expect(v2).toContain('--v2-page-bg: #f8f8fb');
+  });
+
   test('the conversation column is FULL-WIDTH — no measure cap, one left edge (rule 2, v5)', () => {
     // Fifth mechanism, ruled by Sam 2026-08-23: the Slack model. With a
     // line cap, leftover space must pool somewhere — center was rejected,

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -3,6 +3,19 @@
  * so the existing app's global CSS does not bleed in (and vice versa).
  */
 
+/* The ONE deliberate exception to the .v2-root scope: the page canvas.
+   App.tsx unconditionally stamps `modern-ui` (V1's dark gradient) on
+   <body>; .v2-root paints only its own box, so the V1 dark showed through
+   on load flash, overscroll rubber-banding, and every gap. V2App stamps
+   `v2-canvas` while mounted; the compound selector out-ranks
+   body.modern-ui (0-2-1 > 0-1-1) so bundle order cannot decide this.
+   Literal color: body sits outside .v2-root, so tokens don't reach it —
+   keep in lockstep with --v2-page-bg below. */
+body.v2-canvas,
+body.modern-ui.v2-canvas {
+  background: #f8f8fb;
+}
+
 .v2-root {
   /* Palette */
   --v2-bg: #ffffff;


### PR DESCRIPTION
Sam's report: a dark background hidden behind the v2 UI. Root cause: App.tsx unconditionally stamps modern-ui (V1 dark gradient) on <body> and .v2-root only paints its own box, leaving the V1 canvas underneath — visible on load flash, overscroll, and gaps; which sheet wins the body background was load-order roulette between App.css, MUI CssBaseline, and v2. V2App now stamps v2-canvas while mounted; body.modern-ui.v2-canvas (0-2-1) out-ranks the dark rule so order can't decide. Invariant pins the selector, the literal, and its lockstep with --v2-page-bg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK