### PR TITLE
feat(wake): a reply to an agent's own message carries evidence, not just ambience

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.wakeOnMessage.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.wakeOnMessage.test.js
@@ -51,6 +51,10 @@ jest.mock('../../../models/AgentEvent', () => ({
   countDocuments: jest.fn(),
 }));
 
+jest.mock('../../../models/pg/Message', () => ({
+  findById: jest.fn(),
+}));
+
 jest.mock('../../../services/welcomeWakeService', () => ({
   maybeFireWelcomeWake: jest.fn(),
 }));
@@ -377,5 +381,107 @@ describe('wake-on-message (ADR-018 D8)', () => {
       expect(specialist).not.toContain('Collaboration: for code-heavy work');
       expect(specialist).toContain('Wake-on-message:');
     });
+  });
+});
+
+// Reply-evidence flag (interim for TASK-058): a bot's reply reaches the
+// replied-to agent as message.posted (the isBot gate keeps the implicit
+// chat.mention path human-only), but the fan-out stamps per-target evidence
+// so the wrapper can treat "replies to MY message" as addressed instead of
+// standing down on the replier's own claim (Sage stood down twice on
+// Anvil's thread replies, observed live 2026-08-24).
+const PGMessage = require('../../../models/pg/Message');
+
+describe('wake-on-message reply evidence (repliesToYourMessage)', () => {
+  const mockBotUserRows = (rows) => {
+    User.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue(rows),
+      }),
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPod('chat');
+    AgentEvent.countDocuments.mockResolvedValue(0);
+    // Bot sender: anvil replies to sage's message.
+    mockBotSender('anvil', 'anvil-seo-engineer');
+    PGMessage.findById.mockResolvedValue({ user_id: 'sage-bot-user-id' });
+    mockBotUserRows([
+      { _id: 'sage-bot-user-id', botMetadata: { agentName: 'sage', instanceId: 'sage-seo-lead' } },
+      { _id: 'quill-bot-user-id', botMetadata: { agentName: 'quill', instanceId: 'quill-seo-writer' } },
+    ]);
+  });
+
+  test('the parent author gets the flag and the inline frame; bystanders get neither', async () => {
+    mockInstallations([
+      install('sage', { optIn: true, instanceId: 'sage-seo-lead' }),
+      install('quill', { optIn: true, instanceId: 'quill-seo-writer' }),
+    ]);
+
+    await AgentMentionService.enqueueMentions({
+      podId: 'pod-1',
+      message: { content: 'audit follow-up detail', id: 'm-77' },
+      userId: 'anvil-bot-user-id',
+      username: 'Anvil (SEO engineer)',
+      replyToMessageId: 'm-root-42',
+    });
+
+    const wakes = wakeCalls();
+    const sage = wakes.find((w) => w.agentName === 'sage');
+    const quill = wakes.find((w) => w.agentName === 'quill');
+    expect(sage).toBeDefined();
+    expect(quill).toBeDefined();
+    // The flag is the wrapper's claim-decision input…
+    expect(sage.payload.repliesToYourMessage).toBe(true);
+    expect(quill.payload.repliesToYourMessage).toBeUndefined();
+    // …and the inline frame is what the model actually reads.
+    expect(sage.payload.content).toContain('replies to YOUR earlier message');
+    expect(sage.payload.content).toContain('NO_REPLY');
+    expect(quill.payload.content).not.toContain('replies to YOUR earlier message');
+  });
+
+  test('a parent-author lookup failure degrades to plain ambient wakes, never to silence', async () => {
+    PGMessage.findById.mockRejectedValue(new Error('pg down'));
+    mockInstallations([install('sage', { optIn: true, instanceId: 'sage-seo-lead' })]);
+
+    const res = await AgentMentionService.enqueueMentions({
+      podId: 'pod-1',
+      message: { content: 'still delivered', id: 'm-78' },
+      userId: 'anvil-bot-user-id',
+      username: 'Anvil (SEO engineer)',
+      replyToMessageId: 'm-root-42',
+    });
+
+    expect(res.woken).toEqual(['sage']);
+    const wake = wakeCalls()[0];
+    expect(wake.payload.repliesToYourMessage).toBeUndefined();
+    expect(wake.payload.content).toContain('Wake-on-message');
+  });
+
+  test('a human reply still routes via the implicit mention path, not the flag', async () => {
+    // findById serves TWO lookups here: the sender (human) and the reply
+    // author (sage's bot row, so resolveImplicitReplyTarget can address it).
+    User.findById.mockImplementation((id) => ({
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue(id === 'sage-bot-user-id'
+        ? { _id: 'sage-bot-user-id', isBot: true, botMetadata: { agentName: 'sage', instanceId: 'sage-seo-lead' } }
+        : { _id: 'user-1', isBot: false }),
+    }));
+    mockInstallations([install('sage', { optIn: true, instanceId: 'sage-seo-lead' })]);
+
+    await AgentMentionService.enqueueMentions({
+      podId: 'pod-1',
+      message: { content: 'what do you think?', id: 'm-79', replyTo: { userId: 'sage-bot-user-id' } },
+      userId: 'user-1',
+      username: 'sam',
+      replyToMessageId: 'm-root-42',
+    });
+
+    // The mention path claimed the target (stronger cue), so the fan-out
+    // excluded it: no double delivery, and the flag never fires for humans.
+    expect(mentionCalls()).toHaveLength(1);
+    expect(wakeCalls()).toHaveLength(0);
   });
 });

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -885,6 +885,15 @@ const WAKE_ON_MESSAGE_FRAME = '[Wake-on-message: you wake on EVERY message in '
   + 'act, the message must be claimed first (commonly_claim_message) — if the '
   + 'claim is already held by a peer, stand down.]';
 
+// Stronger than the ambient frame, weaker than an @mention: the sender did
+// not name this agent, but they replied to (or threaded on) ITS message —
+// the conversational equivalent of turning toward someone mid-meeting.
+// Interim for TASK-058; the principled ADR-018 amendment supersedes this.
+const REPLIES_TO_YOU_FRAME = '[This message replies to YOUR earlier message — '
+  + 'you are addressed even though nobody typed your @name. Respond when a '
+  + 'response is genuinely useful; if the exchange has concluded, return '
+  + 'NO_REPLY.]';
+
 const wakeOnMessageEnabled = (installation: Record<string, unknown>): boolean => (
   (installation as { config?: { wakeOnMessage?: { enabled?: unknown } } })
     ?.config?.wakeOnMessage?.enabled === true
@@ -1080,6 +1089,7 @@ const followMentionedThreadUsers = async (
  */
 const enqueueWakeOnMessage = async ({
   podId, message, rawContent, userId, username, source, installations, sender, excludeKeys, authorFrame, resolvedBotUserIds,
+  replyToMessageId = null,
 }: {
   podId: string;
   message: EnqueueMentionsOptions['message'];
@@ -1092,6 +1102,7 @@ const enqueueWakeOnMessage = async ({
   excludeKeys: Set<string> | null;
   authorFrame: { username: string; createdAt: unknown; messageId: string | undefined };
   resolvedBotUserIds?: Map<string, string>;
+  replyToMessageId?: string | null;
 }): Promise<string[]> => {
   const woken: string[] = [];
   let targets = (installations || []).filter(wakeOnMessageEnabled);
@@ -1132,10 +1143,15 @@ const enqueueWakeOnMessage = async ({
   // narrowToThread rather than dropped — an unclassifiable target must
   // degrade to today's behaviour, never to silence.
   const threadRootId = resolveThreadRootId(message);
+  // Resolved at most ONCE per fan-out whoever needs it first — the thread
+  // narrowing and the reply-evidence stamp share this (a suite pins the
+  // single User.find).
+  let cachedBotUserIds: Map<string, string> | undefined = resolvedBotUserIds;
   if (threadRootId) {
     // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
     const { narrowToThread } = require('./threadWakeScopeService');
-    const botUserIds = resolvedBotUserIds ?? await resolveBotUserIds(targets);
+    cachedBotUserIds = cachedBotUserIds ?? await resolveBotUserIds(targets);
+    const botUserIds = cachedBotUserIds;
     targets = await narrowToThread(
       threadRootId,
       targets,
@@ -1164,6 +1180,42 @@ const enqueueWakeOnMessage = async ({
     ? `${String(sender.botMetadata?.agentName || '').toLowerCase()}:${String(sender.botMetadata?.instanceId || 'default').toLowerCase()}`
     : null;
 
+  // Reply-evidence flag (interim for TASK-058). The #703 implicit-reply path
+  // is gated on `sender.isBot === false`, so a BOT's reply to an agent's
+  // message reaches its author as plain ambient activity — and the claim
+  // layer then orders that author to stand down from its own conversation
+  // (observed live: Sage stood down twice on Anvil's thread replies,
+  // 2026-08-24). This does NOT widen ADDRESSED_EVENT_TYPES or add events:
+  // the same message.posted fan-out carries per-target EVIDENCE — "this
+  // message replies to something you wrote" — and the wrapper decides what
+  // that evidence is worth. Loop bound: the isWakeLoopDampened gate above
+  // already caps bot-authored wakes per target per window, and the frame
+  // teaches NO_REPLY as the exit.
+  const parentMessageId = String(
+    replyToMessageId || (message as { reply_to_message_id?: unknown })?.reply_to_message_id || threadRootId || '',
+  ) || null;
+  let parentAuthorUserId: string | null = null;
+  if (parentMessageId) {
+    const isReplyParent = parentMessageId !== String(threadRootId || '');
+    parentAuthorUserId = isReplyParent ? normalizeUserId(message?.replyTo?.userId) : null;
+    if (!parentAuthorUserId) {
+      try {
+        // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+        const PGMessage = require('../models/pg/Message') as {
+          findById: (id: string) => Promise<{ user_id?: unknown; userId?: unknown } | null>;
+        };
+        const parentRow = await PGMessage.findById(parentMessageId);
+        parentAuthorUserId = normalizeUserId(parentRow?.user_id || parentRow?.userId);
+      } catch {
+        parentAuthorUserId = null; // evidence is best-effort; ambient behaviour is the floor
+      }
+    }
+  }
+  if (parentAuthorUserId && !cachedBotUserIds) {
+    cachedBotUserIds = await resolveBotUserIds(targets);
+  }
+  const parentBotUserIds = parentAuthorUserId ? (cachedBotUserIds ?? null) : null;
+
   await Promise.all(targets.map(async (inst) => {
     const agentName = String(inst.agentName || '').toLowerCase();
     if (!agentName) return;
@@ -1172,7 +1224,18 @@ const enqueueWakeOnMessage = async ({
     if (key === senderKey) return;
     if (excludeKeys?.has(key)) return;
     if (senderKey && await isWakeLoopDampened({ agentName, instanceId }, podId)) return;
+    const repliesToYou = !!(parentAuthorUserId
+      && parentBotUserIds
+      && parentBotUserIds.get(installKey(inst)) === parentAuthorUserId);
     try {
+      const built = buildContentForTarget(
+        podId,
+        rawContent,
+        'message.posted',
+        agentName,
+        collaborativePod,
+        authorFrame,
+      );
       await AgentEventService.enqueue({
         agentName,
         instanceId,
@@ -1180,20 +1243,16 @@ const enqueueWakeOnMessage = async ({
         type: 'message.posted',
         payload: {
           messageId: authorFrame.messageId,
-          content: buildContentForTarget(
-            podId,
-            rawContent,
-            'message.posted',
-            agentName,
-            collaborativePod,
-            authorFrame,
-          ),
+          // Inline cue, not only metadata — the flag below is for the
+          // wrapper's claim decision; the model reads the content.
+          content: repliesToYou ? `${REPLIES_TO_YOU_FRAME}\n${built}` : built,
           userId,
           username,
           source,
           messageType: message?.messageType || message?.message_type || 'text',
           createdAt: message?.createdAt || message?.created_at || new Date(),
           wakeOnMessage: true,
+          ...(repliesToYou ? { repliesToYourMessage: true } : {}),
         },
       });
       woken.push(agentName);
@@ -1318,7 +1377,7 @@ const enqueueMentions = async ({
     let woken: string[] = [];
     try {
       woken = await enqueueWakeOnMessage({
-        podId, message, rawContent, userId, username, source, installations, sender, excludeKeys: null, authorFrame,
+        podId, message, rawContent, userId, username, source, installations, sender, excludeKeys: null, authorFrame, replyToMessageId,
       });
     } catch (error) {
       // The message is already persisted — a wake failure must never turn a
@@ -1680,7 +1739,7 @@ const enqueueMentions = async ({
   let woken: string[] = [];
   try {
     woken = await enqueueWakeOnMessage({
-      podId, message, rawContent, userId, username, source, installations, sender, excludeKeys: enqueuedIdentityKeys, authorFrame, resolvedBotUserIds,
+      podId, message, rawContent, userId, username, source, installations, sender, excludeKeys: enqueuedIdentityKeys, authorFrame, resolvedBotUserIds, replyToMessageId,
     });
   } catch (error) {
     console.warn('[wake-on-message] fan-out failed:', (error as Error).message);

--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -2068,6 +2068,39 @@ describe('performRun — ADR-018 enforcement', () => {
     );
   });
 
+  test('reply evidence: a broadcast wake that replies to THIS seat proceeds peer-aware past a lost claim', async () => {
+    // Interim for TASK-058: the backend stamps repliesToYourMessage when the
+    // woken message replies to (or threads on) a message this seat authored.
+    // Without honoring it, a peer's claim on its own reply ordered the
+    // replied-to author out of its own conversation (Sage stood down twice
+    // on Anvil's thread replies, 2026-08-24). Deliberately NOT a widening of
+    // ADDRESSED_EVENT_TYPES — the flag is per-event evidence.
+    const { post, del } = makeClient({
+      events: [makeClaimEvent({
+        type: 'message.posted',
+        payload: {
+          content: 'a follow-up on your point', messageId: 'msg-1', repliesToYourMessage: true,
+        },
+      })],
+      claimResult: { claimed: false, claimedBy: 'anvil' },
+    });
+    const spawn = jest.fn(async () => ({ text: 'glad you picked that up — one addition' }));
+    const { stop } = run({ name: 'stub', detect: stubAdapter.detect, spawn });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(del).not.toHaveBeenCalled(); // nothing was held
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/pods/pod-abc/messages',
+      { content: 'glad you picked that up — one addition' },
+    );
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-1/ack',
+      { result: { outcome: 'posted' } },
+    );
+  });
+
   test('fairness: winning a broadcast race handicaps the NEXT race in that pod', async () => {
     const sleeps = [];
     const { post } = makeClient({

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "description": "The Commonly CLI \u2014 connect agents, manage pods, iterate fast",
   "type": "module",

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -947,10 +947,20 @@ export const performRun = ({
       });
       const claim = await claimKeeper.acquire();
       if (!claim.claimed && !claim.failOpen) {
-        if (ADDRESSED_EVENT_TYPES.has(event.type)) {
+        // Per-event EVIDENCE, deliberately not a widening of
+        // ADDRESSED_EVENT_TYPES (that set is a pricing table): the backend
+        // stamps repliesToYourMessage when the woken message replies to or
+        // threads on a message THIS seat authored. Without it, a peer's
+        // claim on its own reply ordered the replied-to author out of its
+        // own conversation (Sage stood down twice on Anvil's thread
+        // replies, 2026-08-24). Interim for TASK-058.
+        const repliesToThisSeat = event.payload?.repliesToYourMessage === true;
+        if (ADDRESSED_EVENT_TYPES.has(event.type) || repliesToThisSeat) {
           log(
             `[${event.type}] message ${claimMessageId} held by ${claim.holder} — `
-            + 'proceeding peer-aware (this seat was directly addressed)',
+            + (repliesToThisSeat
+              ? 'proceeding peer-aware (the message replies to this seat\'s own message)'
+              : 'proceeding peer-aware (this seat was directly addressed)'),
           );
           peerFrame = peerHoldsFrame(claim.holder, claimMessageId);
           claimKeeper = null; // nothing held: no renewal, no release, no isLost gate


### PR DESCRIPTION
Sam's ask: threads must not sink when a bot replies to a bot, without reopening ping-pong. Interim for TASK-058 (the ADR-018 amendment stays with pod-architect). Mechanism: the existing message.posted fan-out stamps per-target evidence — repliesToYourMessage — when the woken message replies to or threads on a message that seat authored, plus an inline frame teaching NO_REPLY as the exit; the CLI wrapper honors the flag like direct addressing at the claim gate, so a replier's claim no longer orders the replied-to author out of its own conversation. No new events, no ADDRESSED_EVENT_TYPES widening, dampener bounds loops, lookup failure degrades to ambient. Backend 16/16 + cli 59/59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK