### PR TITLE
fix(v2): kill the dark load flash — the V1 body default scopes under modern-ui

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -19,11 +19,17 @@ img {
   height: auto;
 }
 
+/* No dark default on bare body: it painted EVERY page load dark for the
+   beat before React mounts — including v2, whose canvas is light — and
+   that flash read as "a dark background hidden behind" (Sam, 2026-08-24).
+   The V1 dark palette lives under body.modern-ui below, which App.tsx
+   stamps at mount; v2 out-ranks it with body.v2-canvas (v2.css). The
+   pre-mount canvas matches v2's --v2-page-bg because v2 is the front
+   door — / routes there. */
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-  background-color: #0b1220;
-  color: #e2e8f0;
+  background-color: #f8f8fb;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -47,6 +53,8 @@ body {
 
 body.modern-ui {
   background: var(--app-bg);
+  background-color: #0b1220; /* the old bare-body dark, now V1-scoped */
+  color: #e2e8f0;
 }
 
 body.modern-ui ::-webkit-scrollbar {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -115,6 +115,16 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).toContain('body.modern-ui.v2-canvas');
     expect(v2).toMatch(/body\.v2-canvas,\nbody\.modern-ui\.v2-canvas \{[\s\S]*?background: #f8f8fb/);
     expect(v2).toContain('--v2-page-bg: #f8f8fb');
+    // The flash half of the same bug: App.css's BARE body rule painted every
+    // load dark before React could stamp any class. The dark default is
+    // V1-scoped under body.modern-ui; the bare default matches v2's canvas.
+    const appCss = read('../../App.css');
+    // The standalone `body {` rule, not the `html,\nbody {` reset above it —
+    // hence the no-comma-before lookbehind.
+    const bareBody = appCss.match(/(?<!,)\nbody \{([^}]*)\}/)?.[1] ?? '';
+    expect(bareBody).toContain('background-color: #f8f8fb');
+    expect(bareBody).not.toContain('#0b1220');
+    expect(ruleBody(appCss, 'body.modern-ui')).toContain('#0b1220');
   });
 
   test('the conversation column is FULL-WIDTH — no measure cap, one left edge (rule 2, v5)', () => {


### PR DESCRIPTION
The flash half of Sam's dark-background report: #1188 covers the mounted state, but App.css's bare body { background-color: #0b1220 } painted every load dark before React could stamp a class. The dark default (background + light text) is now V1-scoped under body.modern-ui; the bare default matches v2's --v2-page-bg since / routes to v2. The canvas invariant now reads App.css too, pinning the bare body light and the dark under modern-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK