### PR TITLE
fix(v2): stamp the canvas at boot — CssBaseline's dark body beat the effect to first paint

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -9,6 +9,19 @@ if (process.env.REACT_APP_SENTRY_DSN) {
   import('./sentry');
 }
 
+// Stamp the v2 canvas BEFORE React renders. Three dark sources layered on
+// <body> (App.css bare default — fixed; body.modern-ui — V1-scoped; MUI
+// CssBaseline's palette.background.default #0b1220 — injected at render),
+// and a class added in V2App's useEffect wins only AFTER first paint, so
+// every v2 load still flashed dark for a frame (Sam, 2026-08-24). '/' and
+// '/v2*' are the v2 front door; V2App's effect keeps the class in sync for
+// SPA navigation after boot. Legacy deep links that redirect into /v2 may
+// still flash once — the exception, not the entry path.
+const bootPath = window.location.pathname;
+if (bootPath === '/' || bootPath.startsWith('/v2')) {
+  document.body.classList.add('v2-canvas');
+}
+
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -125,6 +125,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(bareBody).toContain('background-color: #f8f8fb');
     expect(bareBody).not.toContain('#0b1220');
     expect(ruleBody(appCss, 'body.modern-ui')).toContain('#0b1220');
+    // The render-time half: MUI CssBaseline injects the V1 palette's dark
+    // body at render, and V2App's useEffect class lands only after first
+    // paint — so the entry file must stamp v2-canvas synchronously at boot
+    // for the v2 front door, or every load flashes one dark frame.
+    const entry = read('../../index.tsx');
+    expect(entry).toContain("classList.add('v2-canvas')");
+    expect(entry.indexOf("classList.add('v2-canvas')"))
+      .toBeLessThan(entry.indexOf('createRoot'));
   });
 
   test('the conversation column is FULL-WIDTH — no measure cap, one left edge (rule 2, v5)', () => {


### PR DESCRIPTION
The third and final source of Sam's dark-background report: App.tsx's MUI theme (background.default #0b1220) is injected by CssBaseline as a runtime body rule at render, and V2App's useEffect class only lands after first paint — one guaranteed dark frame per v2 load even after #1188 + #1190. The entry file now stamps v2-canvas synchronously before createRoot for '/' and '/v2*'; V2App's effect keeps it in sync for SPA navigation; the V1 palette is untouched. Invariant pins the boot stamp preceding createRoot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK