### PR TITLE
fix: serve prerendered SEO routes

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -6,9 +6,11 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Handle React Router routes by redirecting all requests to index.html
+    # Serve pre-rendered public route directories before falling back to the
+    # React app. This keeps their crawlable index.html available at the
+    # canonical trailing-slash URL while preserving client-side app routes.
     location / {
-        try_files $uri /index.html;
+        try_files $uri $uri/ /index.html;
     }
 
     # index.html must NEVER be browser-cached. It's the only file that names the

--- a/smoke-tests/run.js
+++ b/smoke-tests/run.js
@@ -99,6 +99,23 @@ async function main() {
       'Frontend HTML does not contain React root element');
   });
 
+  // 7. Pre-rendered public routes must win over the SPA fallback in nginx.
+  await run('GET public SEO routes → their pre-rendered canonical pages', async () => {
+    const routes = [
+      ['/compare/', 'Commonly vs the alternatives | Commonly', 'https://commonly.me/compare/', 'Commonly vs the alternatives'],
+      ['/use-cases/agent-collab/', 'Orchestrate secure, customizable multi-agent workflows | Commonly', 'https://commonly.me/use-cases/agent-collab/', 'Orchestrate secure, customizable multi-agent workflows'],
+    ];
+
+    for (const [path, title, canonical, heading] of routes) {
+      const res = await fetch(`${BASE_URL}${path}`);
+      assert(res.status === 200, `${path}: expected 200, got ${res.status}`);
+      const html = await res.text();
+      assert(html.includes(`<title>${title}</title>`), `${path}: missing page-specific title`);
+      assert(html.includes(`rel="canonical" href="${canonical}"`), `${path}: missing canonical URL`);
+      assert(html.includes(`<h1>${heading}</h1>`), `${path}: missing pre-rendered heading`);
+    }
+  });
+
   // Summary
   console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);
   if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary
- serve static public route directories before the React SPA fallback
- add smoke coverage for one-level and nested crawlable SEO routes

## Verification
- `npm run build`
- `node scripts/generate-seo-pages.test.mjs`
- `npm run typecheck`
- built the production Docker image and verified `/compare/` plus `/use-cases/agent-collab/` return their page-specific title, canonical, and H1