### PR TITLE
feat: add crawlable guides hub

### DIFF
--- a/frontend/scripts/generate-seo-pages.mjs
+++ b/frontend/scripts/generate-seo-pages.mjs
@@ -114,6 +114,7 @@ const renderLanding = (landing, useCases, guides) => {
           <p class="seo-kicker">Guides</p>
           <h2>Learn how teams work with agents</h2>
           <div class="seo-grid">${guideCards}</div>
+          <p><a href="/guides/">Browse all guides</a></p>
         </section>
         <section>
           <p class="seo-kicker">${escapeHtml(landing.openSource.kicker)}</p>
@@ -204,7 +205,7 @@ const renderGuide = (guide) => {
 
   return `
   <div id="seo-page">
-    <header class="seo-header"><a class="seo-brand" href="/">Commonly</a><nav aria-label="Primary navigation"><a href="/">Home</a><a href="/use-cases/agent-collab/">Agent collaboration</a><a href="/compare/">Compare</a></nav></header>
+    <header class="seo-header"><a class="seo-brand" href="/">Commonly</a><nav aria-label="Primary navigation"><a href="/">Home</a><a href="/guides/">Guides</a><a href="/use-cases/agent-collab/">Agent collaboration</a><a href="/compare/">Compare</a></nav></header>
     <main>
       <section class="seo-hero">
         <p class="seo-kicker">${escapeHtml(guide.eyebrow)}</p>
@@ -219,6 +220,32 @@ const renderGuide = (guide) => {
     </main>
     <footer class="seo-footer"><a href="/">Back to Commonly</a></footer>
   </div>`;
+};
+
+const renderGuidesIndex = (guides) => {
+  const guideCards = Object.entries(guides).map(([id, guide]) => `
+    <article class="seo-card">
+      <p class="seo-kicker">${escapeHtml(guide.eyebrow)}</p>
+      <h2><a href="/guides/${encodeURIComponent(id)}/">${escapeHtml(guide.title)}</a></h2>
+      <p>${escapeHtml(guide.summary)}</p>
+      <p><a href="/guides/${encodeURIComponent(id)}/">Read the guide</a></p>
+    </article>`).join('');
+
+  return `
+    <div id="seo-page">
+      <header class="seo-header"><a class="seo-brand" href="/">Commonly</a><nav aria-label="Primary navigation"><a href="/">Home</a><a href="/use-cases/agent-collab/">Agent collaboration</a><a href="/compare/">Compare</a></nav></header>
+      <main>
+        <section class="seo-hero">
+          <p class="seo-kicker">Guides</p>
+          <h1>Guides for teams working with AI agents</h1>
+          <p class="seo-lede">Practical explanations of the shared context, ownership, and handoffs that help people and AI agents work together on real projects.</p>
+        </section>
+        <section>
+          <div class="seo-grid">${guideCards}</div>
+        </section>
+      </main>
+      <footer class="seo-footer"><a href="/">Back to Commonly</a></footer>
+    </div>`;
 };
 
 const metadata = ({ title, description, path, schema, ogType = 'website' }) => {
@@ -290,6 +317,16 @@ export const buildPageDefinitions = ({ landing, compare, useCases, guides = {} }
     schema: webPage(compare.title, compare.lede, '/compare/'),
   }];
 
+  const guidesIndexPath = '/guides/';
+  const guidesIndexPage = {
+    path: guidesIndexPath,
+    outputPath: 'guides/index.html',
+    title: 'Guides for teams working with AI agents | Commonly',
+    description: 'Practical guides for teams that work with AI agents: shared context, task ownership, human review, and durable handoffs.',
+    content: renderGuidesIndex(guides),
+    schema: webPage('Guides for teams working with AI agents', 'Practical guides for teams that work with AI agents: shared context, task ownership, human review, and durable handoffs.', guidesIndexPath),
+  };
+
   const useCasePages = Object.entries(useCases).map(([id, useCase]) => {
     const path = `/use-cases/${id}/`;
     return {
@@ -323,7 +360,7 @@ export const buildPageDefinitions = ({ landing, compare, useCases, guides = {} }
     };
   });
 
-  return pages.concat(useCasePages, guidePages);
+  return pages.concat(useCasePages, [guidesIndexPage], guidePages);
 };
 
 export const renderStaticPage = (template, page) => {

--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -18,7 +18,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 9);
+  assert.equal(pages.length, 10);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -28,6 +28,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/use-cases/community/',
     '/use-cases/pod-browser/',
     '/use-cases/app-marketplace/',
+    '/guides/',
     '/guides/multi-agent-collaboration-platform/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
@@ -37,6 +38,9 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guide = pages.at(-1);
   assert.equal(guide.ogType, 'article');
   assert.equal(guide.schema['@type'], 'Article');
+  const guidesIndex = pages.at(-2);
+  assert.equal(guidesIndex.title, 'Guides for teams working with AI agents | Commonly');
+  assert.equal(guidesIndex.schema['@type'], 'WebPage');
 });
 
 test('puts route content, canonical metadata, and structured data in the document', () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import Login from './components/Login';
 import Register from './components/Register';
 import RegistrationInviteRequired from './components/RegistrationInviteRequired';
 import GuidePage from './components/landing/GuidePage';
+import GuidesIndexPage from './components/landing/GuidesIndexPage';
 import UseCasePage from './components/landing/UseCasePage';
 import VerifyEmail from './components/VerifyEmail';
 import DiscordCallback from './components/DiscordCallback';
@@ -276,6 +277,7 @@ function App(): React.ReactElement {
                     {/* Canonical public routes also have static build output. */}
                     <Route path="/compare" element={<V2ComparePage />} />
                     {/* Legacy auth/OAuth entry points preserve their query strings. */}
+                    <Route path="/guides" element={<GuidesIndexPage />} />
                     <Route path="/guides/:guideId" element={<GuidePage />} />
                     <Route path="/use-cases/:useCaseId" element={<UseCasePage />} />
                     <Route path="/login" element={<Login />} />

--- a/frontend/src/components/landing/GuidesIndexPage.tsx
+++ b/frontend/src/components/landing/GuidesIndexPage.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Button,
+  Container,
+  Stack,
+  Typography,
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import commonlyLogo from '../../assets/commonly-logo.png';
+import guides from '../../content/guides.json';
+
+interface Guide {
+  eyebrow: string;
+  title: string;
+  summary: string;
+}
+
+const GUIDES = guides as Record<string, Guide>;
+
+const GuidesIndexPage: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Box sx={{ minHeight: '100vh', backgroundColor: '#0b1220', color: '#e2e8f0' }}>
+      <Container maxWidth="md" sx={{ pt: 5, pb: 10 }}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 6 }}>
+          <Button startIcon={<ArrowBackIcon />} onClick={() => navigate('/')}>
+            Back to landing
+          </Button>
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <img src={commonlyLogo} alt="Commonly Logo" width={26} height={26} />
+            <Typography sx={{ fontWeight: 700, letterSpacing: '-0.02em' }}>Commonly</Typography>
+          </Stack>
+        </Stack>
+
+        <Typography sx={{ color: '#7dd3fc', fontWeight: 700, letterSpacing: '0.08em', mb: 1 }}>
+          GUIDES
+        </Typography>
+        <Typography component="h1" variant="h2" sx={{ fontWeight: 800, lineHeight: 1.15, letterSpacing: '-0.03em', mb: 2 }}>
+          Guides for teams working with AI agents
+        </Typography>
+        <Typography sx={{ color: '#94a3b8', fontSize: '1.125rem', lineHeight: 1.7, mb: 6 }}>
+          Practical explanations of the shared context, ownership, and handoffs that help people and AI agents work together on real projects.
+        </Typography>
+
+        <Stack spacing={3}>
+          {Object.entries(GUIDES).map(([id, guide]) => (
+            <Box key={id} component="article" sx={{ p: { xs: 3, sm: 4 }, border: '1px solid rgba(148,163,184,0.18)', borderRadius: 3 }}>
+              <Typography sx={{ color: '#7dd3fc', fontWeight: 700, letterSpacing: '0.08em', mb: 1 }}>
+                {guide.eyebrow.toUpperCase()}
+              </Typography>
+              <Typography component="h2" variant="h4" sx={{ fontWeight: 750, lineHeight: 1.2, mb: 1.5 }}>
+                {guide.title}
+              </Typography>
+              <Typography sx={{ color: '#cbd5e1', lineHeight: 1.75, mb: 2.5 }}>
+                {guide.summary}
+              </Typography>
+              <Button endIcon={<ArrowForwardIcon />} onClick={() => navigate(`/guides/${id}/`)}>
+                Read the guide
+              </Button>
+            </Box>
+          ))}
+        </Stack>
+      </Container>
+    </Box>
+  );
+};
+
+export default GuidesIndexPage;

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -8,6 +8,7 @@ import V2App from '../V2App';
 import V2LandingPage from '../landing/V2LandingPage';
 import V2ComparePage from '../landing/V2ComparePage';
 import GuidePage from '../../components/landing/GuidePage';
+import GuidesIndexPage from '../../components/landing/GuidesIndexPage';
 import UseCasePage from '../../components/landing/UseCasePage';
 import i18n from '../../i18n';
 
@@ -51,6 +52,7 @@ const renderAt = (path: string, auth = baseAuth) => render(
         <Route path="/v2/*" element={<V2App />} />
         <Route path="/" element={<V2LandingPage />} />
         <Route path="/compare" element={<V2ComparePage />} />
+        <Route path="/guides" element={<GuidesIndexPage />} />
         <Route path="/guides/:guideId/*" element={<GuidePage />} />
         <Route path="/use-cases/:useCaseId/*" element={<UseCasePage />} />
       </Routes>
@@ -117,6 +119,16 @@ describe('V2 routing', () => {
     })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create a workspace' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Watch a live room' })).toBeInTheDocument();
+  });
+
+  test('guides index renders after the app takes over', async () => {
+    renderAt('/guides/');
+
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'Guides for teams working with AI agents',
+    })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Read the guide' })).toBeInTheDocument();
   });
 
   test('deep protected route redirects to login when not authenticated', () => {


### PR DESCRIPTION
## Summary
- add a canonical static `/guides/` index and WebPage metadata
- list guides from the shared source and link every article back to the hub
- add the matching browser route and regressions

## Verification
- `node frontend/scripts/generate-seo-pages.test.mjs`
- `npm --prefix frontend run typecheck`
- `npx jest src/v2/__tests__/V2Login.test.tsx --runInBand --watchAll=false --forceExit`
- `npm --prefix frontend run build`
- generated-output checks for the H1, canonical, guide card, and sitemap