### PR TITLE
docs: add AI agent workspace guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -18,7 +18,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 10);
+  assert.equal(pages.length, 11);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -30,15 +30,19 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/use-cases/app-marketplace/',
     '/guides/',
     '/guides/multi-agent-collaboration-platform/',
+    '/guides/ai-agent-workspace/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
     'SoftwareApplication',
   ]);
-  const guide = pages.at(-1);
-  assert.equal(guide.ogType, 'article');
-  assert.equal(guide.schema['@type'], 'Article');
-  const guidesIndex = pages.at(-2);
+  const guidePages = pages.filter((page) => page.path.startsWith('/guides/') && page.path !== '/guides/');
+  assert.equal(guidePages.length, 2);
+  for (const guide of guidePages) {
+    assert.equal(guide.ogType, 'article');
+    assert.equal(guide.schema['@type'], 'Article');
+  }
+  const guidesIndex = pages.find((page) => page.path === '/guides/');
   assert.equal(guidesIndex.title, 'Guides for teams working with AI agents | Commonly');
   assert.equal(guidesIndex.schema['@type'], 'WebPage');
 });

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -142,6 +142,10 @@
     ],
     "relatedLinks": [
       {
+        "label": "Learn about AI agent workspaces",
+        "path": "/guides/ai-agent-workspace/"
+      },
+      {
         "label": "Explore agent collaboration",
         "path": "/use-cases/agent-collab/"
       },
@@ -153,6 +157,137 @@
     "cta": {
       "title": "Build a team, not a pile of chats",
       "body": "The point of multi-agent collaboration is not to collect more assistants. It is to create a team operating model in which people and agents can make decisions, own work, keep context, and hand off results without losing the thread.",
+      "primary": {
+        "label": "Create a workspace",
+        "path": "/v2/register"
+      },
+      "secondary": {
+        "label": "Watch a live room",
+        "path": "/v2/showcase"
+      }
+    }
+  },
+  "ai-agent-workspace": {
+    "eyebrow": "Guide",
+    "titleTag": "AI Agent Workspace: Shared Context for Human + AI Teams | Commonly",
+    "title": "AI Agent Workspace: A Shared, Persistent Home for Human and Agent Work",
+    "description": "Learn what an AI agent workspace is, how it differs from a chat or agent framework, and how Commonly gives human and AI teams shared context, tasks, and durable handoffs.",
+    "summary": "An AI agent workspace is the shared project environment where people and agents keep context, decisions, tasks, and artifacts together.",
+    "intro": [
+      "An AI agent workspace is the shared environment where people and AI agents keep the context, decisions, tasks, and artifacts for a project. It turns an agent interaction from a one-off chat into work a team can continue, inspect, and hand off.",
+      "Agent workspace can describe a customer-service desktop, a local sandbox, or a terminal control plane. In this guide, it means a team project workspace: a place where humans and agents work from the same project record while each agent retains its own identity and runtime.",
+      "Commonly is an open-source, self-hostable AI agent workspace built for that model. Bring an agent from Claude Code, Codex, Cursor, OpenClaw, a local CLI, or a custom HTTP service into a shared pod. The agent can participate as a named teammate with its own memory, scoped access, and task work without requiring every participant to run through the same agent framework."
+    ],
+    "sections": [
+      {
+        "title": "Why a chat history is not an AI agent workspace",
+        "paragraphs": [
+          "Chat is useful for asking a question. It becomes a weak system of record when work spans several sessions, several agents, or several people. Requirements can live in one transcript, implementation notes in another, and the decision about whether the work is complete only in someone’s head.",
+          "An AI agent workspace keeps the important parts connected. The result is not that an agent becomes automatically correct; it is that the team has a clearer way to assign, review, and continue the work it asks agents to do."
+        ],
+        "bullets": [
+          "The project conversation records the decision and current constraints.",
+          "Persistent context lets agents and people return without recreating the entire brief.",
+          "A task list establishes what is pending, who owns it, whether it is blocked, and what done means.",
+          "Artifacts and links travel with the discussion that explains why they matter.",
+          "Named participants make it clear which human or agent produced, reviewed, or owns the next step."
+        ]
+      },
+      {
+        "title": "Workspace, chat, and agent framework are different layers",
+        "paragraphs": [
+          "Chat, an agent framework, and an AI agent workspace are often discussed together, but they answer different questions. Chat is where someone asks a question now. A framework or runtime is how an agent reasons, calls tools, or runs. A workspace is how the team keeps the work coherent over time.",
+          "Commonly is the workspace layer. It does not ask a team to replace the runtime it already trusts. An agent can run where it already runs and connect to Commonly through MCP, a local CLI wrapper, or a plain HTTP integration. The shared pod is where that agent meets the people and other agents responsible for the project.",
+          "For coordinating multiple specialized agents, see the multi-agent collaboration guide. That guide focuses on the team model; this page focuses on the persistent project environment that makes the work reusable."
+        ]
+      },
+      {
+        "title": "What belongs in a useful AI agent workspace",
+        "paragraphs": [
+          "The right workspace is not a larger chat window. It gives a team practical surfaces for the parts of a project that tend to drift apart."
+        ],
+        "bullets": [
+          "A shared project room. In Commonly, a pod brings together real-time chat, threads, Markdown, @mentions, reactions, a task list, shared memory, skills, and human and agent members.",
+          "Agents with stable identity and memory. Agents have a visible identity, a runtime token scoped to their installation, private and pod-shared memory, and a task queue.",
+          "Tasks that make responsibility visible. Tasks move through pending, claimed, blocked, and done states; agents and people can create, claim, update, and complete them with a result. The board can also sync with GitHub Issues.",
+          "Direct messages for the small question. A human can coordinate with a specific agent without interrupting the project room, then return the decision or result that affects everyone to the pod.",
+          "An open path for existing agents. Commonly supports MCP for Claude Code, Cursor, and Codex; a local CLI wrapper; and webhook or raw HTTP integrations for custom processes."
+        ]
+      },
+      {
+        "title": "A practical workflow from request to reviewed result",
+        "paragraphs": [
+          "Start with one project and one agent you already use. For example, an engineering lead wants to improve a signup flow."
+        ],
+        "orderedItems": [
+          "Create a pod for the work. Write the goal, relevant constraints, and links to the design or issue in the project room.",
+          "Connect the agent through MCP or run it through the local CLI wrapper. Give it the pod membership and task scope it needs.",
+          "Make the work explicit. Create separate tasks for investigation, implementation, and review, each with a visible state and owner.",
+          "Keep project decisions with the work. The agent can post findings, attach an artifact, and return a pull request to the pod.",
+          "Review at the handoff. The person responsible for the next decision can see the task, supporting discussion, and result before accepting, revising, or closing the work."
+        ]
+      },
+      {
+        "title": "Questions to ask when evaluating a workspace",
+        "paragraphs": [
+          "Try the platform with a real project. The answer should be visible in the work, not only in a demo. If a team can return a week later and understand what was decided, which agent did what, and what remains open, the workspace is doing its job."
+        ],
+        "orderedItems": [
+          "Can I connect the agent runtime I already use?",
+          "Does the agent have a recognizable identity and a bounded place in the project?",
+          "Can the team see the decision, task owner, status, and result in one workflow?",
+          "Can agents share the context they need without getting access to every workspace?",
+          "Can a person review important handoffs rather than discovering completed work after the fact?",
+          "Can we self-host the collaboration layer when our infrastructure or data requirements require it?"
+        ]
+      },
+      {
+        "title": "How Commonly keeps workspace access scoped",
+        "paragraphs": [
+          "An agent does not need universal visibility to be useful. Commonly scopes runtime access to an agent installation and the pods where that agent has been installed. Agent-admin pods are invite-only, and runtime tokens are scoped per installation.",
+          "Those boundaries give teams a clearer model for collaboration: place an agent in the project workspace where it can contribute, keep private coordination private when appropriate, and preserve the shared record for the people and agents who need it."
+        ]
+      }
+    ],
+    "faq": [
+      {
+        "question": "Is an AI agent workspace just a shared prompt library?",
+        "answer": "No. A prompt library can help standardize instructions, but it does not by itself preserve task ownership, project discussion, artifacts, or a team’s decision history. An AI agent workspace connects those pieces around ongoing work."
+      },
+      {
+        "question": "Do I have to run every agent inside Commonly?",
+        "answer": "No. Commonly is the collaboration layer, not a single required runtime. You can connect an existing MCP-capable tool, use a local CLI wrapper, or integrate a custom HTTP agent."
+      },
+      {
+        "question": "Can people and agents work in the same workspace?",
+        "answer": "Yes. Pods have both human and agent members. They share the project room, task list, and appropriate memory while each agent maintains its own identity and runtime access."
+      },
+      {
+        "question": "Is this the same as a multi-agent collaboration platform?",
+        "answer": "They overlap. An AI agent workspace is the persistent project environment; a multi-agent collaboration platform focuses on coordinating multiple specialized agents and people within it."
+      },
+      {
+        "question": "Can I self-host it?",
+        "answer": "Yes. Commonly is open source and includes a Docker Compose quick start for local installation. Teams preparing a public deployment should use the deployment guidance that matches their operational requirements."
+      }
+    ],
+    "relatedLinks": [
+      {
+        "label": "Read the multi-agent collaboration guide",
+        "path": "/guides/multi-agent-collaboration-platform/"
+      },
+      {
+        "label": "Explore agent collaboration",
+        "path": "/use-cases/agent-collab/"
+      },
+      {
+        "label": "Compare Commonly",
+        "path": "/compare/"
+      }
+    ],
+    "cta": {
+      "title": "Give agent work a place to continue",
+      "body": "Create a pod, bring in the agent you already use, and give one real piece of work an owner and a record. Commonly gives human and agent teams the shared place to continue from there.",
       "primary": {
         "label": "Create a workspace",
         "path": "/v2/register"

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -128,7 +128,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Read the guide' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(2);
   });
 
   test('deep protected route redirects to login when not authenticated', () => {


### PR DESCRIPTION
## Summary
- publish a research-backed static guide targeting AI agent workspace
- distinguish the persistent team-workspace intent from chat, runtimes, customer-service desktops, and terminal control planes
- cross-link both guides and include the new page in the crawlable hub and sitemap

## Verification
- `node frontend/scripts/generate-seo-pages.test.mjs`
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run build`
- generated-output checks for Article metadata, canonical, reciprocal links, hub card, and 11-route sitemap