### PR TITLE
fix: correct research use-case routing

### DIFF
--- a/frontend/scripts/generate-seo-pages.mjs
+++ b/frontend/scripts/generate-seo-pages.mjs
@@ -181,8 +181,8 @@ const renderUseCase = (useCase) => `
       </section>
       <section>
         <div class="seo-grid">
-          <article class="seo-card"><h2>Commonly solves</h2>${list(useCase.problems)}</article>
-          <article class="seo-card"><h2>Expected outcomes</h2>${list(useCase.outcomes)}</article>
+          <article class="seo-card"><h2>Common challenges</h2>${list(useCase.problems)}</article>
+          <article class="seo-card"><h2>What you can do</h2>${list(useCase.outcomes)}</article>
         </div>
       </section>
       <section><h2>Example flow</h2><ol>${useCase.exampleFlow.map((step) => `<li>${escapeHtml(step)}</li>`).join('')}</ol></section>

--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -18,12 +18,13 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 11);
+  assert.equal(pages.length, 12);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
     '/use-cases/team-chat/',
     '/use-cases/agent-collab/',
+    '/use-cases/research-desk/',
     '/use-cases/daily-digest/',
     '/use-cases/community/',
     '/use-cases/pod-browser/',

--- a/frontend/src/components/landing/UseCasePage.tsx
+++ b/frontend/src/components/landing/UseCasePage.tsx
@@ -83,7 +83,7 @@ const UseCasePage: React.FC = () => {
           }}
         >
           <Box sx={{ p: 3, border: '1px solid rgba(148,163,184,0.16)', borderRadius: 3, background: 'rgba(15,23,42,0.55)' }}>
-            <Typography sx={{ mb: 2, fontWeight: 700 }}>Commonly solves</Typography>
+            <Typography sx={{ mb: 2, fontWeight: 700 }}>Common challenges</Typography>
             <Stack spacing={1.25}>
               {useCase.problems.map((item) => (
                 <Typography key={item} sx={{ color: '#cbd5e1' }}>
@@ -93,7 +93,7 @@ const UseCasePage: React.FC = () => {
             </Stack>
           </Box>
           <Box sx={{ p: 3, border: '1px solid rgba(125,211,252,0.28)', borderRadius: 3, background: 'rgba(14,116,144,0.16)' }}>
-            <Typography sx={{ mb: 2, fontWeight: 700 }}>Expected outcomes</Typography>
+            <Typography sx={{ mb: 2, fontWeight: 700 }}>What you can do</Typography>
             <Stack spacing={1.25}>
               {useCase.outcomes.map((item) => (
                 <Typography key={item} sx={{ color: '#e0f2fe' }}>

--- a/frontend/src/content/use-cases.json
+++ b/frontend/src/content/use-cases.json
@@ -46,6 +46,32 @@
       }
     ]
   },
+  "research-desk": {
+    "eyebrow": "Research Workspace",
+    "title": "Run research and market analysis without losing the project context",
+    "summary": "Use a shared pod to keep questions, source notes, findings, and review conversations together while people and research agents contribute over time.",
+    "problems": [
+      "Research questions, sources, and conclusions become separated across one-off chats",
+      "New contributors have to reconstruct decisions before they can evaluate a finding",
+      "Work needs human review before a recommendation guides the next decision"
+    ],
+    "outcomes": [
+      "A shared pod for conversations, threads, files, and project context",
+      "Persistent pod and per-agent memory for notes and context across sessions",
+      "Visible task ownership and status for research, review, and follow-up work"
+    ],
+    "exampleFlow": [
+      "The team opens a pod for a market question and records the scope, sources, and decision criteria.",
+      "Research agents contribute notes and artifacts while the task board makes the work and reviewer visible.",
+      "A human reviews the evidence in context, captures the recommendation, and assigns the next step."
+    ],
+    "relatedGuides": [
+      {
+        "title": "What Is an AI Agent Workspace?",
+        "path": "/guides/ai-agent-workspace/"
+      }
+    ]
+  },
   "daily-digest": {
     "eyebrow": "Daily Digest",
     "title": "Convert noisy activity into digestible updates",

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -92,6 +92,15 @@ describe('V2 routing', () => {
     );
   });
 
+  test('research card opens the dedicated research workspace use case', async () => {
+    renderAt('/');
+
+    expect(await screen.findByRole('link', { name: /market & research desk/i })).toHaveAttribute(
+      'href',
+      '/use-cases/research-desk/',
+    );
+  });
+
   test('legacy use-case routes redirect to their canonical public URL', async () => {
     renderAt('/v2/use-cases/team-chat');
 
@@ -99,6 +108,17 @@ describe('V2 routing', () => {
       level: 2,
       name: 'Run pod conversations with searchable shared context',
     })).toBeInTheDocument();
+  });
+
+  test('research workspace use case explains capabilities rather than promising outcomes', async () => {
+    renderAt('/use-cases/research-desk/');
+
+    expect(await screen.findByRole('heading', {
+      level: 2,
+      name: 'Run research and market analysis without losing the project context',
+    })).toBeInTheDocument();
+    expect(screen.getByText('Common challenges')).toBeInTheDocument();
+    expect(screen.getByText('What you can do')).toBeInTheDocument();
   });
 
   test('canonical comparison URL renders after the app takes over', async () => {

--- a/frontend/src/v2/landing/V2LandingPage.tsx
+++ b/frontend/src/v2/landing/V2LandingPage.tsx
@@ -576,7 +576,7 @@ const V2LandingPage: React.FC = () => {
               <div className="v2-landing__usecase-title">{t('landing.useCases.chat.title')}</div>
               <p className="v2-landing__usecase-text">{t('landing.useCases.chat.text')}</p>
             </Link>
-            <Link className="v2-landing__usecase" to="/use-cases/community/">
+            <Link className="v2-landing__usecase" to="/use-cases/research-desk/">
               <div className="v2-landing__usecase-title">{t('landing.useCases.research.title')}</div>
               <p className="v2-landing__usecase-text">{t('landing.useCases.research.text')}</p>
             </Link>


### PR DESCRIPTION
Fixes the landing-page “Market & research desk” card, which currently opens the unrelated Integrations use case.

- adds a dedicated static `/use-cases/research-desk/` page with only documented pod, memory, task, and review workflows
- changes detail-page labels from product claims / vague outcomes to `Common challenges` and `What you can do`
- covers the browser route and the 12-route static sitemap

Validated: frontend typecheck, static page generator test, targeted V2 routing test (12 passing), production build, and static route/canonical/sitemap assertions.