### PR TITLE
fix: return real 404s for unknown public routes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,6 +118,7 @@ jobs:
         run: |
           cd frontend
           npx jest --coverage --watchAll=false --forceExit
+          node --test scripts/generate-seo-pages.test.mjs scripts/nginx-routing.test.mjs
 
       - name: Run commonly-mcp tests
         run: |

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -6,10 +6,18 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Serve pre-rendered public route directories before falling back to the
-    # React app. This keeps their crawlable index.html available at the
-    # canonical trailing-slash URL while preserving client-side app routes.
+    # Serve pre-rendered public route directories and real files. Unknown
+    # public URLs must return a real 404: sending the homepage with a 200
+    # creates soft-404 signals for crawlers and a misleading page for people.
     location / {
+        try_files $uri $uri/ =404;
+    }
+
+    # Preserve hard-load support for the authenticated SPA and the documented
+    # legacy application routes. Public marketing, guide, and use-case routes
+    # are intentionally excluded because they have pre-rendered static output
+    # and should 404 when no matching directory exists.
+    location ~ ^/(?:v2(?:/|$)|login/?$|register(?:/|$)|verify-email/?$|discord/(?:callback|success|error)/?$|feed/?$|thread/|dashboard/?$|digest/?$|agents/?$|skills/?$|activity/?$|apps/?$|profile(?:/|$)|admin/(?:users|integrations/global)/?$|dev/(?:api|pod-context)/?$|pods(?:/|$)|chat/) {
         try_files $uri $uri/ /index.html;
     }
 
@@ -22,9 +30,6 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         expires -1;
     }
-
-    # Error handling for 404
-    error_page 404 /index.html;
 
     # Hashed static assets are content-addressed and immutable — a given URL's
     # bytes never change, so cache hard and skip revalidation. A new build emits

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,7 @@
     "start": "vite",
     "build": "vite build && node scripts/generate-seo-pages.mjs",
     "preview": "vite preview",
-    "test": "jest --watchAll=false --forceExit && node --test scripts/generate-seo-pages.test.mjs",
+    "test": "jest --watchAll=false --forceExit && node --test scripts/generate-seo-pages.test.mjs scripts/nginx-routing.test.mjs",
     "test:coverage": "jest --coverage --watchAll=false --forceExit",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",

--- a/frontend/scripts/nginx-routing.test.mjs
+++ b/frontend/scripts/nginx-routing.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const frontendDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+test('unknown public routes are real 404s while documented app routes retain SPA fallback', async () => {
+  const config = await readFile(resolve(frontendDir, 'nginx.conf'), 'utf8');
+
+  assert.match(config, /location \/ \{\s*try_files \$uri \$uri\/ =404;/s);
+  assert.doesNotMatch(config, /error_page\s+404\s+\/index\.html/);
+  assert.match(config, /location ~ \^\/\(\?:v2\(\?:\/\|\$\).*try_files \$uri \$uri\/ \/index\.html;/s);
+  assert.match(config, /login\/\?\$/);
+  assert.match(config, /pods\(\?:\/\|\$\)/);
+});


### PR DESCRIPTION
Fixes the public soft-404 issue: unknown paths were served the homepage as HTTP 200 by the frontend Nginx fallback.

- unknown public URLs now return Nginx 404
- pre-rendered landing, guide, and use-case pages still serve normally
- documented SPA and legacy app routes retain hard-load fallback
- adds an Nginx routing contract test to local and CI test commands

Validated locally: 436 frontend tests, static tests, TypeScript check, Nginx config validation, a full frontend Docker image build, and HTTP assertions against that image for unknown/public/app routes.