### PR TITLE
fix(v2): anchor reactions to message actions

### DIFF
--- a/frontend/src/v2/__tests__/V2MessageBubble.test.tsx
+++ b/frontend/src/v2/__tests__/V2MessageBubble.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import V2MessageBubble from '../components/V2MessageBubble';
 
@@ -71,7 +71,7 @@ describe('V2MessageBubble', () => {
   });
 
   it('keeps the reactions row in flow when chips exist', () => {
-    render(
+    const { container } = render(
       <MemoryRouter>
         <V2MessageBubble
           message={{
@@ -91,5 +91,47 @@ describe('V2MessageBubble', () => {
     const row = screen.getByLabelText('Reactions');
     expect(row.className).not.toContain('v2-msg__reactions--bare');
     expect(screen.getByText('👍')).toBeInTheDocument();
+
+    // TASK-053: the chips and the body share a content-column parent. This
+    // is the structural half of "same text axis"; a visual test measures
+    // their actual x positions at desktop and mobile widths.
+    const column = container.querySelector('.v2-msg__content-column');
+    const body = container.querySelector('.v2-msg__body');
+    expect(column).not.toBeNull();
+    expect(body?.parentElement).toBe(column);
+    expect(row.parentElement).toBe(column);
+    expect(body?.contains(row)).toBe(false);
+  });
+
+  it('keeps React with Reply and Thread in the message action row', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <V2MessageBubble
+          message={{
+            id: '44',
+            pod_id: 'pod-1',
+            user_id: 'sender-1',
+            content: 'hello',
+            message_type: 'text',
+            created_at: '2026-08-13T00:00:00.000Z',
+            user: { username: 'sender' },
+            reactions: [{ emoji: '👍', count: 2, mine: true }],
+          }}
+          onReply={jest.fn()}
+          onThread={jest.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    const actions = screen.getByRole('toolbar', { name: 'Message actions' });
+    expect(actions.parentElement).toBe(container.querySelector('.v2-msg__content-column'));
+    expect(actions).toContainElement(screen.getByRole('button', { name: 'Reply to sender' }));
+    expect(actions).toContainElement(screen.getByRole('button', { name: /thread from sender/i }));
+    const addReaction = screen.getByRole('button', { name: 'Add reaction' });
+    expect(actions).toContainElement(addReaction);
+    expect(container.querySelector('.v2-msg__reaction--mine')).not.toBeNull();
+
+    fireEvent.click(addReaction);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
   });
 });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -455,23 +455,24 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(v2, '.v2-msg__reaction-emoji')).toContain('line-height: 22px');
   });
 
-  test('message actions live in ONE hover cluster, and its picker opens downward', () => {
-    // 2026-08-23 (Sam's placement rulings): Reply, Thread, and the reaction
-    // trigger share a floating pill at the row's top-right — no inline head
-    // buttons (layout shift), no orphaned "+" in an empty reactions band
-    // (the 2026-08-13 phantom-band bug cannot recur because a chip-less row
-    // no longer renders at all). The picker anchor override is load-bearing:
-    // the base picker opens UPWARD (bottom: 100%) for the old in-row anchor;
-    // from the cluster at the message's top edge it must open downward or it
-    // clips under the previous message.
-    const cluster = ruleBody(v2, '.v2-msg__actions');
-    expect(cluster).toContain('position: absolute');
+  test('message actions and reactions stay on the body column, never the row corner', () => {
+    // TASK-053 corrects the prior top-right pill: it was grouped with Reply
+    // and Thread but 1000px away from the text it acted on. The action row
+    // now unfolds from the body column; chips are its next sibling, 4px below
+    // the body, so both channel and rail inherit the same x axis.
+    expect(ruleBody(v2, '.v2-msg__content-column')).toContain('flex-direction: column');
+    expect(ruleBody(v2, '.v2-msg__body')).toContain('order: 1');
+    const actions = ruleBody(v2, '.v2-msg__actions');
+    expect(actions).not.toContain('position: absolute');
+    expect(actions).toContain('order: 2');
+    expect(actions).toContain('max-height: 0');
+    expect(actions).toContain('80ms');
     expect(v2).toContain('.v2-msg:hover .v2-msg__actions');
-    const pickerInCluster = ruleBody(v2, '.v2-msg__actions .v2-msg__reaction-picker');
-    expect(pickerInCluster).toContain('top: calc(100% + 6px)');
-    expect(pickerInCluster).toContain('bottom: auto');
-    // Touch keeps the 44px floor with the cluster always visible.
-    expect(v2).toContain('.v2-root button.v2-msg__action');
+    const reactions = v2.slice(v2.lastIndexOf('.v2-msg__reactions {'));
+    expect(reactions).toContain('order: 3');
+    expect(reactions).toContain('margin-top: 4px');
+    // A self reaction needs a distinct accent rim, not only a soft fill.
+    expect(ruleBody(v2, '.v2-root button.v2-msg__reaction--mine')).toContain('border-color: var(--v2-accent)');
   });
 
   test('create-pod panel no longer ships audience options (ADR-016 / #768)', () => {
@@ -572,16 +573,17 @@ describe('v2 layout invariants (CSS rule presence)', () => {
   });
 
   test('message actions retain 44px targets and become visible on touch layouts', () => {
-    // TASK-052 intent, third mechanism: the hover cluster carries
-    // Reply/Thread/React. Desktop reveals it on hover; a 390px touch
-    // surface cannot depend on hover, so both touch blocks (pointer:coarse
-    // and max-width:640px) force it visible with 44px targets.
+    // Reply/Thread/React share one body-anchored row. Desktop reveals it on
+    // hover; a 390px touch surface cannot depend on hover, so tap reveal
+    // keeps the same 44px targets.
     // Tap-reveal, not always-on: the touch blocks must gate visibility on
     // .v2-msg--reveal (set by the bubble's tap handler) — an ungated
     // `.v2-msg__actions { opacity: 1 }` here would put chrome over every
     // message by default (Sam's report, 2026-08-23).
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-msg--reveal \.v2-msg__actions[\s\S]*?opacity: 1/);
-    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-root button\.v2-msg__action[\s\S]*?height: 44px/);
+    const action = ruleBody(v2, '.v2-root button.v2-msg__action');
+    expect(action).toContain('width: 44px');
+    expect(action).toContain('height: 44px');
     const cardAction = ruleBody(v2, '.v2-root button.v2-thread-card__reply');
     expect(cardAction).toContain('min-height: 44px');
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-card\s*\{[\s\S]*?flex-wrap: wrap/);

--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -468,6 +468,40 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
     }
   };
 
+  // The reaction row is intentionally a sibling of the message body. Both
+  // channel rows and threaded rails then keep chips on their text column,
+  // rather than treating them as part of the last paragraph or attachment.
+  const reactionRow = (() => {
+    if (renderList.length === 0 && !reactionError) return null;
+
+    const formatReactionTitle = (r: typeof renderList[number]): string => {
+      const live = r as { users?: Array<{ username: string; displayName?: string }> };
+      const users = Array.isArray(live.users) ? live.users : [];
+      if (!users.length) return `${r.count} ${r.emoji}${r.mine ? ' (you)' : ''}`;
+      const names = users.map((u) => u.displayName || u.username);
+      return `${names.join(', ')} reacted with ${r.emoji}${r.mine ? ' (you)' : ''}`;
+    };
+
+    return (
+      <div className="v2-msg__reactions" aria-label="Reactions">
+        {renderList.map((r, idx) => (
+          <button
+            key={`${r.emoji}-${idx}`}
+            type="button"
+            className={`v2-msg__reaction${r.mine ? ' v2-msg__reaction--mine' : ''}`}
+            title={formatReactionTitle(r)}
+            onClick={() => toggleReaction(r.emoji, !!r.mine)}
+            disabled={!canInteract}
+          >
+            <span className="v2-msg__reaction-emoji">{r.emoji}</span>
+            <span className="v2-msg__reaction-count">{r.count}</span>
+          </button>
+        ))}
+        {reactionError && <span className="v2-msg__reaction-error" role="alert">{reactionError}</span>}
+      </div>
+    );
+  })();
+
   return (
     <div
       className={`v2-msg${mentionsMe ? ' v2-msg--mention' : ''}${grouped ? ' v2-msg--grouped' : ''}${actionsRevealed ? ' v2-msg--reveal' : ''}`}
@@ -499,14 +533,11 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
           seed={message.user_id || undefined}
         />
       )}
-      {/* One hover cluster for every row variant (Sam's taste rulings
-          2026-08-23): Reply, Thread, and the reaction trigger live together
-          in a floating pill at the message's top-right — visible on hover
-          or keyboard focus, never in the head's text flow (the inline text
-          buttons crowded the head and shifted layout), and identical for
-          headed and grouped rows. The reaction picker anchors here too, so
-          the trigger sits with its siblings instead of orphaned at the far
-          edge of an empty reactions band. */}
+      <div className="v2-msg__content-column">
+      {/* The hover action row follows the body, so Reply, Thread and React
+          stay attached to the message they act on instead of floating in the
+          row's far corner. CSS ordering keeps it after body content for both
+          headed and grouped rows. */}
       {(onReply || onThread || canInteract) && (
         /* stopPropagation: on touch, the bubble's own tap toggles reveal —
            without this, tapping any action would immediately re-hide the
@@ -658,56 +689,8 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
             number={pr.number}
           />
         ))}
-        {(() => {
-          // Sprint B5: real reactions come from message.reactions (server-
-          // aggregated `[{emoji, count, mine}]`); legacy fixtures use the
-          // token-parsed list. Both are hoisted above as `renderList` so the
-          // hover cluster shares the trigger. This row now renders ONLY when
-          // there are chips (or a transient error) to show — the trigger
-          // lives in the cluster, so the empty "bare band" state no longer
-          // exists at all rather than being collapsed by CSS.
-          if (renderList.length === 0 && !reactionError) return null;
-
-          // Google-Chat-style attribution: build a names-line for the
-          // reaction-chip tooltip from the decorated `users` array when
-          // the backend includes it (reactionAttributionService). Falls
-          // back to count-only on older servers / fixtures.
-          const formatReactionTitle = (r: typeof renderList[number]): string => {
-            const live = r as { users?: Array<{ username: string; displayName?: string }> };
-            const users = Array.isArray(live.users) ? live.users : [];
-            if (!users.length) {
-              return `${r.count} ${r.emoji}${r.mine ? ' (you)' : ''}`;
-            }
-            const names = users.map((u) => u.displayName || u.username);
-            // Caller's user ID isn't threaded down here; rather than
-            // guessing which entry in `users` is the caller, append a
-            // single "(you)" suffix to the whole line when r.mine —
-            // matches Google Chat's behavior on its own reaction
-            // tooltips and avoids mis-labelling an arbitrary entry.
-            return `${names.join(', ')} reacted with ${r.emoji}${r.mine ? ' (you)' : ''}`;
-          };
-
-          return (
-            <div className="v2-msg__reactions" aria-label="Reactions">
-              {renderList.map((r, idx) => (
-                <button
-                  key={`${r.emoji}-${idx}`}
-                  type="button"
-                  className={`v2-msg__reaction${r.mine ? ' v2-msg__reaction--mine' : ''}`}
-                  title={formatReactionTitle(r)}
-                  onClick={() => toggleReaction(r.emoji, !!r.mine)}
-                  disabled={!canInteract}
-                >
-                  <span className="v2-msg__reaction-emoji">{r.emoji}</span>
-                  <span className="v2-msg__reaction-count">{r.count}</span>
-                </button>
-              ))}
-              {reactionError && (
-                <span className="v2-msg__reaction-error" role="alert">{reactionError}</span>
-              )}
-            </div>
-          );
-        })()}
+      </div>
+      {reactionRow}
       </div>
     </div>
   );

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -2532,33 +2532,34 @@ body.modern-ui.v2-canvas {
 .v2-msg--grouped { padding: 2px 0; }
 .v2-msg__avatar-ghost { width: 38px; }
 
-/* The message action cluster (Sam's taste rulings 2026-08-23): Reply,
-   Thread, and the reaction trigger share ONE floating pill at the row's
-   top-right, identical for headed and grouped rows. Absolute + hover means
-   zero layout shift; icon buttons instead of text keep it quiet at rest and
-   compact under the cursor. The reaction picker anchors to the cluster so
-   the trigger sits with its siblings instead of orphaned in an empty band
-   below the message (the old absolute "+"). */
-.v2-msg { position: relative; }
+/* TASK-053: the action row belongs to the message's text column, not the
+   row's far corner. Body, actions, and chips are siblings so their shared
+   x-axis survives both the channel and an indented thread rail. */
+.v2-msg__content-column {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
 .v2-msg__actions {
-  position: absolute;
-  top: -12px;
-  right: 8px;
   display: flex;
   align-items: center;
-  gap: 1px;
-  padding: 2px;
-  background: var(--v2-surface);
-  border: 1px solid var(--v2-border);
-  border-radius: 8px;
-  box-shadow: 0 1px 4px rgba(16, 20, 30, 0.08);
+  order: 2;
+  gap: 4px;
+  max-height: 0;
+  margin-top: 0;
+  /* Keep the picker outside the 44px reveal while the collapsed row itself
+     still owns no height. Opacity + pointer-events make its children inert
+     until hover, focus, or tap reveal. */
+  overflow: visible;
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.1s ease;
-  z-index: 6;
+  transition: max-height 80ms ease, margin-top 80ms ease, opacity 80ms ease;
 }
 .v2-msg:hover .v2-msg__actions,
-.v2-msg__actions:focus-within {
+.v2-msg__actions:focus-within,
+.v2-msg--reveal .v2-msg__actions {
+  max-height: 44px;
+  margin-top: 4px;
   opacity: 1;
   pointer-events: auto;
 }
@@ -2567,8 +2568,8 @@ body.modern-ui.v2-canvas {
   border: none;
   background: transparent;
   color: var(--v2-text-secondary);
-  width: 26px;
-  height: 26px;
+  width: 44px;
+  height: 44px;
   border-radius: 6px;
   display: inline-flex;
   align-items: center;
@@ -2584,12 +2585,12 @@ body.modern-ui.v2-canvas {
   position: absolute;
   top: calc(100% + 6px);
   bottom: auto;
-  right: 0;
-  left: auto;
+  right: auto;
+  left: 0;
 }
 
 .v2-msg__body {
-  flex: 1;
+  order: 1;
   min-width: 0;
 }
 
@@ -2837,8 +2838,9 @@ body.modern-ui.v2-canvas {
 
 .v2-msg__reactions {
   display: flex;
+  order: 3;
   gap: 6px;
-  margin-top: 6px;
+  margin-top: 4px;
 }
 
 .v2-msg__reaction {
@@ -5786,9 +5788,10 @@ body.modern-ui.v2-canvas {
    tokens populated by the demo seed. */
 .v2-msg__reactions {
   display: flex;
+  order: 3;
   flex-wrap: wrap;
   gap: 6px;
-  margin-top: 6px;
+  margin-top: 4px;
 }
 .v2-msg__reaction {
   display: inline-flex;
@@ -5854,7 +5857,7 @@ body.modern-ui.v2-canvas {
 }
 .v2-root button.v2-msg__reaction--mine {
   background: var(--v2-accent-soft);
-  border-color: var(--v2-accent-soft);
+  border-color: var(--v2-accent);
   color: var(--v2-accent-text);
 }
 .v2-root button.v2-msg__reaction:hover:not(:disabled) {
@@ -5867,11 +5870,9 @@ body.modern-ui.v2-canvas {
 }
 
 /* The standalone "+" trigger, its hover wrap, and the --bare collapsed row
- * were retired 2026-08-23: the reaction trigger lives in the
- * .v2-msg__actions hover cluster (Sam's placement ruling), and a reactions
- * row with no chips simply does not render — the phantom-band problem the
- * --bare machinery solved cannot occur at all now. The picker below is
- * shared by the cluster (which overrides its anchor to open downward). */
+ * were retired: React is part of the message action row, while a reactions
+ * row with no chips simply does not render. That removes the phantom-band
+ * state structurally; the picker is shared by the action row. */
 .v2-msg__reaction-picker {
   left: auto;
   right: 0;
@@ -6431,17 +6432,15 @@ body.modern-ui.v2-canvas {
   }
 }
 
-/* Reply/Thread inline head buttons retired 2026-08-23 (Sam's taste ruling):
-   the actions live in the .v2-msg__actions hover cluster now — one pill,
-   all row variants, zero layout shift. See the cluster block near .v2-msg.
-   Touch layouts keep ≥44px targets via the media block below. */
+/* The message action row follows the text body on every row variant. The
+   content-column wrapper preserves the avatar|body grid while letting Reply,
+   Thread, and React reveal together under the message. Touch layouts keep
+   ≥44px targets via the media block below. */
 @media (hover: none), (pointer: coarse) {
-  /* No hover on touch — but always-on clusters over every message are
-     chrome over content (Sam, 2026-08-23). A tap on the message toggles
-     .v2-msg--reveal (V2MessageBubble.onBubbleTap, gated to hoverless
-     devices); only then does the cluster appear, at the 44px floor (craft
-     baseline rule 9). Absolute positioning preserved — a static third
-     child would break the avatar|body grid. */
+  /* No hover on touch — but always-on action rows are chrome over content.
+     A tap on the message toggles .v2-msg--reveal
+     (V2MessageBubble.onBubbleTap, gated to hoverless devices); only then
+     does the row appear at the 44px floor (craft baseline rule 9). */
   .v2-msg--reveal .v2-msg__actions,
   .v2-msg__actions:focus-within {
     opacity: 1;


### PR DESCRIPTION
## Summary
- move Reply, Thread, and React from the far-corner pill to the message text action row
- keep reaction chips as a body sibling on the same text axis, 4px below the body, with an accent rim for your reaction
- preserve the 80ms reveal and 44px action targets; add structural and CSS invariant coverage

## Verification
- `cd frontend && npm test` (78 suites, 433 tests + 2 SEO tests)
- `cd frontend && npm run typecheck`
- focused ESLint: 0 errors (2 pre-existing JSX warnings)
- browser harness: 1200px x=50 channel / x=60 rail; 390px x=50 channel / x=56 rail; all actions 44px, no horizontal overflow
- mutation: removing the accent rim fails the TASK-053 layout invariant

Repository-wide lint remains red on 17 pre-existing errors outside this diff.