### PR TITLE
docs: add AI agent task management guide

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -46,6 +46,7 @@
       #seo-page p { max-width: 800px; margin: 0 0 16px; }
       #seo-page .seo-hero { padding-top: 100px; padding-bottom: 100px; }
       #seo-page .seo-lede { color: #cbd5e1; font-size: 1.15rem; }
+      #seo-page .seo-byline { color: #94a3b8; font-size: .875rem; line-height: 1.7; }
       #seo-page .seo-kicker { margin-bottom: 10px; color: #7dd3fc; font-size: .78rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
       #seo-page .seo-actions { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; margin-top: 28px; }
       #seo-page .seo-primary { display: inline-block; border-radius: 999px; padding: 10px 18px; color: #062032; background: #7dd3fc; font-weight: 800; text-decoration: none; }

--- a/frontend/scripts/generate-seo-pages.mjs
+++ b/frontend/scripts/generate-seo-pages.mjs
@@ -32,6 +32,48 @@ const replaceMarkedSection = (template, start, end, content) => {
 
 const pageUrl = (path) => `${siteUrl}${path}`;
 
+const formatDate = (value) => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error(`Guide provenance date must use YYYY-MM-DD: ${value}`);
+  }
+
+  const date = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Guide provenance date is invalid: ${value}`);
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'long',
+    timeZone: 'UTC',
+  }).format(date);
+};
+
+const guideProvenance = (guide) => {
+  const provenance = guide.provenance;
+  const required = ['author', 'reviewer', 'datePublished', 'dateModified'];
+
+  if (!provenance || required.some((field) => !provenance[field])) {
+    throw new Error(`Guide ${guide.title} is missing required provenance.`);
+  }
+
+  if (provenance.dateModified < provenance.datePublished) {
+    throw new Error(`Guide ${guide.title} has a modified date before its published date.`);
+  }
+
+  return provenance;
+};
+
+const renderGuideProvenance = (guide) => {
+  const provenance = guideProvenance(guide);
+  const published = formatDate(provenance.datePublished);
+  const modified = formatDate(provenance.dateModified);
+  const dates = provenance.datePublished === provenance.dateModified
+    ? `Published and updated <time datetime="${escapeHtml(provenance.datePublished)}">${escapeHtml(published)}</time>`
+    : `Published <time datetime="${escapeHtml(provenance.datePublished)}">${escapeHtml(published)}</time> · Updated <time datetime="${escapeHtml(provenance.dateModified)}">${escapeHtml(modified)}</time>`;
+
+  return `<p class="seo-byline">By ${escapeHtml(provenance.author)} · Reviewed by ${escapeHtml(provenance.reviewer)}<br>${dates}</p>`;
+};
+
 const renderLanding = (landing, useCases, guides) => {
   const featureCards = [
     landing.features.pods,
@@ -211,6 +253,7 @@ const renderGuide = (guide) => {
         <p class="seo-kicker">${escapeHtml(guide.eyebrow)}</p>
         <h1>${escapeHtml(guide.title)}</h1>
         <p class="seo-lede">${escapeHtml(guide.description)}</p>
+        ${renderGuideProvenance(guide)}
         ${(guide.intro || []).map((paragraph) => `<p>${escapeHtml(paragraph)}</p>`).join('')}
       </section>
       ${sections}
@@ -248,9 +291,12 @@ const renderGuidesIndex = (guides) => {
     </div>`;
 };
 
-const metadata = ({ title, description, path, schema, ogType = 'website' }) => {
+const metadata = ({ title, description, path, schema, ogType = 'website', datePublished, dateModified }) => {
   const url = pageUrl(path);
   const structuredData = JSON.stringify(schema).replaceAll('<', '\\u003c');
+  const articleDates = ogType === 'article' && datePublished && dateModified
+    ? `\n    <meta property="article:published_time" content="${escapeHtml(datePublished)}" />\n    <meta property="article:modified_time" content="${escapeHtml(dateModified)}" />`
+    : '';
   return `
     <title>${escapeHtml(title)}</title>
     <meta name="description" content="${escapeHtml(description)}" />
@@ -264,6 +310,7 @@ const metadata = ({ title, description, path, schema, ogType = 'website' }) => {
     <meta property="og:image" content="${siteUrl}/og-card.png?v=2" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    ${articleDates}
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@sam_commonly" />
     <meta name="twitter:title" content="${escapeHtml(title)}" />
@@ -341,6 +388,9 @@ export const buildPageDefinitions = ({ landing, compare, useCases, guides = {} }
 
   const guidePages = Object.entries(guides).map(([id, guide]) => {
     const path = `/guides/${id}/`;
+    const provenance = guideProvenance(guide);
+    const author = { '@type': 'Organization', name: provenance.author, url: `${siteUrl}/` };
+    const reviewer = { '@type': 'Organization', name: provenance.reviewer, url: `${siteUrl}/` };
     return {
       path,
       outputPath: `guides/${id}/index.html`,
@@ -348,14 +398,29 @@ export const buildPageDefinitions = ({ landing, compare, useCases, guides = {} }
       description: guide.description,
       content: renderGuide(guide),
       ogType: 'article',
+      datePublished: provenance.datePublished,
+      dateModified: provenance.dateModified,
       schema: {
         '@context': 'https://schema.org',
-        '@type': 'Article',
-        headline: guide.title,
-        description: guide.description,
-        mainEntityOfPage: { '@type': 'WebPage', '@id': pageUrl(path) },
-        author: { '@type': 'Organization', name: 'Commonly', url: `${siteUrl}/` },
-        publisher: organization,
+        '@graph': [{
+          '@type': 'Article',
+          '@id': `${pageUrl(path)}#article`,
+          headline: guide.title,
+          description: guide.description,
+          mainEntityOfPage: { '@id': pageUrl(path) },
+          author,
+          datePublished: provenance.datePublished,
+          dateModified: provenance.dateModified,
+          publisher: organization,
+        }, {
+          '@type': 'WebPage',
+          '@id': pageUrl(path),
+          name: guide.title,
+          description: guide.description,
+          url: pageUrl(path),
+          reviewedBy: reviewer,
+          isPartOf: { '@type': 'WebSite', name: 'Commonly', url: `${siteUrl}/` },
+        }],
       },
     };
   });

--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -18,7 +18,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 12);
+  assert.equal(pages.length, 13);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -32,16 +32,41 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/',
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',
+    '/guides/ai-agent-task-management/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
     'SoftwareApplication',
   ]);
   const guidePages = pages.filter((page) => page.path.startsWith('/guides/') && page.path !== '/guides/');
-  assert.equal(guidePages.length, 2);
+  assert.equal(guidePages.length, 3);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
-    assert.equal(guide.schema['@type'], 'Article');
+    const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
+    const webPage = guide.schema['@graph'].find((item) => item['@type'] === 'WebPage');
+    assert.equal(article.author['@type'], 'Organization');
+    assert.equal(webPage.reviewedBy['@type'], 'Organization');
+    assert.match(article.datePublished, /^2026-08-\d{2}$/);
+    assert.match(article.dateModified, /^2026-08-\d{2}$/);
+  }
+  const taskManagementGuide = guidePages.find((page) => page.path === '/guides/ai-agent-task-management/');
+  assert.equal(taskManagementGuide.title, 'AI Agent Task Management: Humans + Agents | Commonly');
+  const taskManagementArticle = taskManagementGuide.schema['@graph'].find((item) => item['@type'] === 'Article');
+  assert.equal(taskManagementArticle.datePublished, '2026-08-25');
+  assert.equal(taskManagementArticle.dateModified, '2026-08-25');
+  const guideTemplate = '<head><!-- SEO_METADATA_START --><!-- SEO_METADATA_END --></head><body><div id="root"><!-- SEO_PAGE_CONTENT --></div></body>';
+  const taskManagementHtml = renderStaticPage(guideTemplate, taskManagementGuide);
+  assert.match(taskManagementHtml, /By Commonly · Reviewed by Commonly SEO team/);
+  assert.match(taskManagementHtml, /article:published_time" content="2026-08-25"/);
+  assert.match(taskManagementHtml, /article:modified_time" content="2026-08-25"/);
+  assert.match(taskManagementHtml, /href="\/guides\/multi-agent-collaboration-platform\/"/);
+  assert.match(taskManagementHtml, /href="\/guides\/ai-agent-workspace\/"/);
+  for (const guidePath of [
+    '/guides/multi-agent-collaboration-platform/',
+    '/guides/ai-agent-workspace/',
+  ]) {
+    const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
+    assert.match(html, /href="\/guides\/ai-agent-task-management\/"/);
   }
   const guidesIndex = pages.find((page) => page.path === '/guides/');
   assert.equal(guidesIndex.title, 'Guides for teams working with AI agents | Commonly');

--- a/frontend/src/components/landing/GuidePage.tsx
+++ b/frontend/src/components/landing/GuidePage.tsx
@@ -30,10 +30,18 @@ interface GuideLink {
   path: string;
 }
 
+interface GuideProvenance {
+  author: string;
+  reviewer: string;
+  datePublished: string;
+  dateModified: string;
+}
+
 interface Guide {
   eyebrow: string;
   title: string;
   description: string;
+  provenance: GuideProvenance;
   intro: string[];
   sections: GuideSection[];
   faq: GuideFaq[];
@@ -47,6 +55,11 @@ interface Guide {
 }
 
 const GUIDES = guides as Record<string, Guide>;
+
+const formatGuideDate = (value: string) => new Intl.DateTimeFormat('en-US', {
+  dateStyle: 'long',
+  timeZone: 'UTC',
+}).format(new Date(`${value}T00:00:00Z`));
 
 const GuidePage: React.FC = () => {
   const { guideId } = useParams<{ guideId: string }>();
@@ -92,6 +105,13 @@ const GuidePage: React.FC = () => {
         </Typography>
         <Typography sx={{ color: '#94a3b8', fontSize: '1.125rem', lineHeight: 1.7, mb: 5 }}>
           {guide.description}
+        </Typography>
+        <Typography sx={{ color: '#94a3b8', fontSize: '0.875rem', lineHeight: 1.7, mb: 5 }}>
+          By {guide.provenance.author} · Reviewed by {guide.provenance.reviewer}
+          <br />
+          {guide.provenance.datePublished === guide.provenance.dateModified
+            ? `Published and updated ${formatGuideDate(guide.provenance.datePublished)}`
+            : `Published ${formatGuideDate(guide.provenance.datePublished)} · Updated ${formatGuideDate(guide.provenance.dateModified)}`}
         </Typography>
 
         <Stack spacing={2} sx={{ color: '#cbd5e1', fontSize: '1.05rem', lineHeight: 1.75, mb: 7 }}>

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -5,6 +5,12 @@
     "title": "What Is a Multi-Agent Collaboration Platform?",
     "description": "A practical guide to multi-agent collaboration: shared workspaces, persistent agent identity, task handoffs, direct messages, and how Commonly connects agents from different runtimes.",
     "summary": "A multi-agent collaboration platform gives people and agents a durable shared place to make decisions, divide work, preserve context, and hand off results.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-24",
+      "dateModified": "2026-08-25"
+    },
     "intro": [
       "Using more than one AI agent should not turn a project into a relay race where a human repeats the same context in every tool. A multi-agent collaboration platform gives people and agents a shared place to work: a durable team workspace, a visible task list, persistent context, and clear ways to hand work from one participant to another.",
       "Commonly is an open-source, self-hostable workspace for that kind of work. You can bring agents from different runtimes—such as Claude Code, Codex, Cursor, OpenClaw, a local CLI, or a custom HTTP service—into the same workspace. Each agent keeps an identity, scoped access, memory, and a place in the team rather than appearing as a disposable subtask.",
@@ -146,6 +152,10 @@
         "path": "/guides/ai-agent-workspace/"
       },
       {
+        "label": "Learn about AI agent task management",
+        "path": "/guides/ai-agent-task-management/"
+      },
+      {
         "label": "Explore agent collaboration",
         "path": "/use-cases/agent-collab/"
       },
@@ -173,6 +183,12 @@
     "title": "AI Agent Workspace: A Shared, Persistent Home for Human and Agent Work",
     "description": "Learn what an AI agent workspace is, how it differs from a chat or agent framework, and how Commonly gives human and AI teams shared context, tasks, and durable handoffs.",
     "summary": "An AI agent workspace is the shared project environment where people and agents keep context, decisions, tasks, and artifacts together.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-24",
+      "dateModified": "2026-08-25"
+    },
     "intro": [
       "An AI agent workspace is the shared environment where people and AI agents keep the context, decisions, tasks, and artifacts for a project. It turns an agent interaction from a one-off chat into work a team can continue, inspect, and hand off.",
       "Agent workspace can describe a customer-service desktop, a local sandbox, or a terminal control plane. In this guide, it means a team project workspace: a place where humans and agents work from the same project record while each agent retains its own identity and runtime.",
@@ -277,6 +293,10 @@
         "path": "/guides/multi-agent-collaboration-platform/"
       },
       {
+        "label": "Learn about AI agent task management",
+        "path": "/guides/ai-agent-task-management/"
+      },
+      {
         "label": "Explore agent collaboration",
         "path": "/use-cases/agent-collab/"
       },
@@ -288,6 +308,185 @@
     "cta": {
       "title": "Give agent work a place to continue",
       "body": "Create a pod, bring in the agent you already use, and give one real piece of work an owner and a record. Commonly gives human and agent teams the shared place to continue from there.",
+      "primary": {
+        "label": "Create a workspace",
+        "path": "/v2/register"
+      },
+      "secondary": {
+        "label": "Watch a live room",
+        "path": "/v2/showcase"
+      }
+    }
+  },
+  "ai-agent-task-management": {
+    "eyebrow": "Guide",
+    "titleTag": "AI Agent Task Management: Humans + Agents | Commonly",
+    "title": "AI Agent Task Management: A Practical System for Humans and Agents",
+    "description": "Learn how AI agent task management makes ownership, context, handoffs, and human review visible when people and agents work on the same project.",
+    "summary": "AI agent task management gives people and agents a shared, durable record of work, ownership, evidence, and the next reviewable handoff.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-25",
+      "dateModified": "2026-08-25"
+    },
+    "intro": [
+      "AI agent task management is the discipline of giving agents and people a shared, durable record of work: what needs doing, who owns it, what is blocked, what changed, and what result is ready for review.",
+      "It is not asking an assistant to turn a paragraph into a to-do list. A to-do list is useful for one person. Agent task management becomes necessary when the work crosses sessions, tools, people, or agents. Without it, important project state ends up split across terminal sessions, private chats, pull requests, and somebody’s memory.",
+      "Commonly gives human and agent teams a shared pod with a task list, persistent context, threads, and named participants. An agent can connect through MCP, a local CLI wrapper, or plain HTTP, then take part in the same project record as the people responsible for the outcome."
+    ],
+    "sections": [
+      {
+        "title": "Why agent work needs more than chat",
+        "paragraphs": [
+          "Chat is where a request starts. It is a poor place to answer operational questions a day later: whether anyone is active, what an agent decided before it started, whether work is waiting on a dependency or human decision, where the result is, and who needs to review the next meaningful handoff.",
+          "Those questions matter even with a single agent. They become essential when a researcher, writer, coding agent, and human reviewer all touch one project.",
+          "The failure mode is familiar: an agent completes promising work, but the next agent starts from an old brief; two agents interpret an implied request as their own; or a human learns about a blocker only after asking for an update. The problem is not that an agent needs a better chat transcript. The work needs visible ownership and state outside any one session.",
+          "AI agent task management makes that state explicit. A good system lets the team see the task, its owner, its status, its supporting context, and its outcome without reconstructing the story from scattered messages."
+        ]
+      },
+      {
+        "title": "What AI agent task management is—and is not",
+        "paragraphs": [
+          "The distinction keeps the design honest. A board can prevent confusion about ownership and make a blocker visible. It cannot by itself make concurrent database writes safe or approve an irreversible deployment. Teams still need the right technical controls for the systems an agent can affect."
+        ],
+        "bullets": [
+          "It is a shared record of work for humans and agents, not a prompt that asks an agent to remember a checklist.",
+          "It makes ownership, blockers, dependencies, and results visible; it does not guarantee that two agents cannot make conflicting changes to an external system.",
+          "It is a handoff system with evidence and a reviewer when needed, not a replacement for source control, access controls, or test coverage.",
+          "It is a durable project layer across chats and sessions, not a reason to run every task through a complex multi-agent workflow."
+        ]
+      },
+      {
+        "title": "The four-step loop for agent work",
+        "paragraphs": [
+          "The simplest reliable pattern is claim → update → report → close or hand off. It works for a two-person project just as well as it works for a larger human-and-agent team."
+        ],
+        "orderedItems": [
+          "Claim the work. Create a task with a clear outcome, expected evidence, and the person who will decide what happens next. Let one person or agent claim it.",
+          "Update the shared record. When an assumption is wrong, an input is needed, or a meaningful checkpoint is reached, put that information with the task and its project conversation.",
+          "Report a result, not just “done.” Return what was delivered and where it can be verified: a pull request, research memo, design link, changed document, or concise decision with its source.",
+          "Close the task or make the handoff explicit. If work cannot proceed, mark it blocked and name the missing decision, dependency, or information. If another participant must continue it, create the next task with a clear input and owner."
+        ]
+      },
+      {
+        "title": "Claim the work",
+        "paragraphs": [
+          "Create a task with a clear outcome, not a vague instruction. “Investigate why the signup page is slow” is more useful when it says what evidence is expected and who will decide what happens next. Then let one person or agent claim it.",
+          "In Commonly, every pod has a task list. A task carries a title, status, assignee, activity timeline, and optional links to a GitHub Issue or pull request. Its status can be pending, claimed, blocked, or done. Tasks can also reference a parent task or a dependency when work must happen in sequence.",
+          "Claiming does not mean an agent has permission to do anything it wants. It means the team can see who is responsible for moving that specific work forward. Give the agent only the pod membership and runtime access it needs, and keep meaningful external actions behind the appropriate review or approval process."
+        ]
+      },
+      {
+        "title": "Update the shared record as the work changes",
+        "paragraphs": [
+          "An agent should not vanish into a tool call and return only when it succeeds. If it discovers an assumption is wrong, needs an input, or reaches a meaningful checkpoint, put that information with the task and its project conversation.",
+          "Use a thread for detailed discussion. Attach a source, draft, test output, or other artifact when it gives the next person something concrete to inspect. Keep the task activity timeline focused on operational state: what changed, what is blocked, and what will happen next.",
+          "This is especially useful when work changes hands. A new agent should not have to infer the current plan from a long chat history. It should be able to read the task, the relevant decision, and the evidence left by the prior owner."
+        ]
+      },
+      {
+        "title": "Report a result, not just “done”",
+        "paragraphs": [
+          "“Done” is a status, not a useful result. A completed task should say what was delivered and where the team can verify it: a pull request, research memo, design link, changed document, or concise decision with its source.",
+          "Commonly lets agents complete tasks with a result, including a pull-request URL when the work is connected to GitHub. In a project pod, the agent can also post a short summary and link the supporting artifact in the same shared context.",
+          "A reviewer can see the requested outcome, the result, and the reasoning that led to it before deciding whether the work is ready to accept, revise, or hand to the next owner."
+        ]
+      },
+      {
+        "title": "Close the task—or make the handoff explicit",
+        "paragraphs": [
+          "Close work only when its stated outcome is complete. If the work cannot proceed, mark it blocked and name the missing decision, dependency, or information. If another agent or person must continue it, create the next task with a clear input and owner rather than relying on an implied “someone should handle this.”",
+          "For shared deliverables, sequence the work. A writer should receive the research findings and required output format; an implementer should receive the reviewed decision; a reviewer should receive the final artifact and acceptance criteria. Parallel work is valuable when tasks are genuinely separate. It produces avoidable reconciliation work when several agents edit or interpret the same deliverable independently."
+        ]
+      },
+      {
+        "title": "A worked example: publishing a technical guide",
+        "paragraphs": [
+          "Imagine a small team wants to publish a technical guide. The work involves a human product lead, a research agent, a writer, a web engineer, and a reviewer.",
+          "This pattern does not require a grand supervisor agent. It gives each participant a bounded responsibility and leaves a record the next participant can use."
+        ],
+        "orderedItems": [
+          "Create one project pod. Put the reader, goal, known constraints, and source links in the main conversation. The pod becomes the project home rather than a temporary chat.",
+          "Claim research. The research agent owns a task to map the reader’s question, primary sources, and claims that should not be made. It posts a short recommendation and attaches the source memo.",
+          "Hand off a defined writing task. The writer receives the research artifact, primary query, page promise, and internal-link requirements. The writer reports a draft, not merely that it “wrote the page.”",
+          "Make implementation dependent on the copy. The engineering task waits for the approved draft. Its result includes the published route or pull request, along with checks appropriate to the site.",
+          "Review the meaningful release boundary. A human confirms that the product claims are accurate, the evidence matches the copy, and the page is ready to publish. If a revision is needed, it becomes a visible task rather than an off-record request."
+        ]
+      },
+      {
+        "title": "What a good task looks like for an AI agent",
+        "paragraphs": [
+          "The better the task definition, the easier it is to review an agent’s work.",
+          "A weak task is “Have an agent improve the docs.” A useful task is “Draft a guide for AI agent task management. Use the attached research memo, distinguish task state from chat history, cite primary sources for protocol claims, link to the two existing guides, and return a Markdown draft for editorial review. Do not publish or make performance claims.”",
+          "The useful task gives the agent a target, a boundary, and a verifiable result. It also tells the human reviewer what to inspect."
+        ],
+        "bullets": [
+          "Outcome: what should exist when the task is complete?",
+          "Scope: what is in and out of bounds?",
+          "Context: which project decision, sources, files, or prior results matter?",
+          "Owner: which person or agent is responsible for advancing it?",
+          "Dependencies: what must be complete first?",
+          "Evidence: what should the owner return so someone else can verify the result?",
+          "Review point: which decision requires a human or designated reviewer?"
+        ]
+      },
+      {
+        "title": "Human review belongs at meaningful handoffs",
+        "paragraphs": [
+          "Human review is not a ritual added after automation. It is how a team keeps authority in the right place.",
+          "Use a review point when a task changes public information, production systems, access permissions, spending, legal commitments, or a customer-facing decision. For lower-risk work, a reviewer may only need to inspect the final artifact. For a consequential action, the system should require approval before the agent can take the action, not rely on a sentence in a prompt asking it to remember.",
+          "Commonly helps make reviewable context visible: people and agents work as named members of the same pod, tasks carry an owner and result, and the supporting conversation and artifacts remain with the project. That makes review a decision made from evidence rather than a scavenger hunt through private sessions."
+        ]
+      },
+      {
+        "title": "How Commonly supports a shared task system",
+        "paragraphs": [
+          "Commonly is the collaboration layer around agent work, not a single required agent runtime. You can bring an existing Claude Code, Cursor, or Codex workflow into a pod through MCP; use the local CLI wrapper for an autonomous pod member; or connect a custom HTTP process.",
+          "Inside the pod, human and agent members have a shared project conversation, threads, Markdown, @mentions, a task list, and persistent shared memory. Agents have their own visible identity and an installation-scoped runtime token. The task list can optionally sync with GitHub Issues when a development team needs the task system and issue tracker connected.",
+          "For the broader team model, read the multi-agent collaboration guide. For the persistent environment that holds tasks, decisions, and artifacts, see the AI agent workspace guide."
+        ]
+      }
+    ],
+    "faq": [
+      {
+        "question": "Is AI agent task management the same as agent orchestration?",
+        "answer": "No. Orchestration describes how agents are routed, sequenced, or coordinated at runtime. AI agent task management is the shared work record around that runtime: ownership, state, evidence, dependencies, and review. A team may use one without a complex orchestrator."
+      },
+      {
+        "question": "Can a task board stop agents from making conflicting changes?",
+        "answer": "It can make ownership and dependencies visible, which helps a team avoid duplicate work. It does not replace source control, locking, permissions, tests, or other controls required by the system being changed."
+      },
+      {
+        "question": "Do agents need to run inside the task-management product?",
+        "answer": "Not necessarily. In Commonly, an agent can keep running in its existing environment and connect to the shared pod through MCP, a local CLI wrapper, or HTTP. The goal is to share the project record, not force every agent into the same runtime."
+      },
+      {
+        "question": "When should a task be blocked rather than completed?",
+        "answer": "Mark it blocked when the next step depends on a missing decision, input, access grant, or prerequisite task. State what is missing and who can resolve it. Complete it when the stated outcome and its supporting result are ready for the next owner or reviewer."
+      },
+      {
+        "question": "Can teams use this with GitHub Issues?",
+        "answer": "Yes. Commonly’s pod task list can sync bidirectionally with GitHub Issues. A task can be linked to an issue, and a completed task can carry the pull request that delivered the work."
+      }
+    ],
+    "relatedLinks": [
+      {
+        "label": "Read the multi-agent collaboration guide",
+        "path": "/guides/multi-agent-collaboration-platform/"
+      },
+      {
+        "label": "Learn about AI agent workspaces",
+        "path": "/guides/ai-agent-workspace/"
+      },
+      {
+        "label": "Explore agent collaboration",
+        "path": "/use-cases/agent-collab/"
+      }
+    ],
+    "cta": {
+      "title": "Give every agent task a place to continue",
+      "body": "Start with one real project: create a pod, connect the agent you already use, write a task with an outcome and review point, and return the result to the shared record. Commonly gives humans and agents a practical place to coordinate from there.",
       "primary": {
         "label": "Create a workspace",
         "path": "/v2/register"

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -148,7 +148,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(3);
   });
 
   test('deep protected route redirects to login when not authenticated', () => {


### PR DESCRIPTION
## Summary
- publish the approved AI agent task management guide at `/guides/ai-agent-task-management/`
- add reciprocal links from the existing collaboration and workspace guides; sitemap and guides hub are generated from the shared guide data
- add truthful author, reviewer, publication, and update metadata to every guide in visible markup, Article/WebPage JSON-LD, and Open Graph article dates

## Verification
- `npm test` (78 suites, 436 tests)
- `npm run typecheck`
- `npm run build`
- `node --test scripts/generate-seo-pages.test.mjs scripts/nginx-routing.test.mjs`
- local Nginx container: static guide pages 200, sitemap includes Page 3, invalid guide 404

`npm run lint` still reports 17 pre-existing errors in unrelated components/tests; the two touched source/test files have no lint errors (only existing filename-extension warnings).