### PR TITLE
docs(ax): mechanism 4 said the base decides, without the condition that makes it true

### DIFF
--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -2394,12 +2394,14 @@ considered and declined, or the next reader re-derives it.
 
 4. *The base branch predates the workflow fix* → the fix never applies. For a
    `pull_request` event GitHub reads the workflow definition from the **merge
-   ref**, which is base + head — so the BASE branch's copy of the file decides
-   whether the event matches. `#1123` dropped `branches: [main]` from
-   `tests.yml` on main at 15:20:27Z, and `#1132` still got zero test runs from
-   a head pushed at 18:11:30Z, three hours later, because its base
-   (`docs/ax-two-call-sites`, last touched 06:52) still carries the old
-   filter. Verified by reading `tests.yml` on that branch.
+   ref**, which is base + head — so when the head does not touch that workflow
+   file, the BASE branch's copy of it decides whether the event matches. A head
+   that edits the workflow itself contributes its version to the merge ref and
+   can fix its own triggering; that is not the case below. `#1123` dropped
+   `branches: [main]` from `tests.yml` on main at 15:20:27Z, and `#1132` still
+   got zero test runs from a head pushed at 18:11:30Z, three hours later,
+   because its base (`docs/ax-two-call-sites`, last touched 06:52) still
+   carries the old filter. Verified by reading `tests.yml` on that branch.
 
    Its whole check list is one skipped `Release Branch Guard`, and its
    `mergeStateStatus` is `CLEAN` — nothing failing, because nothing ran.

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -2401,7 +2401,19 @@ considered and declined, or the next reader re-derives it.
    `branches: [main]` from `tests.yml` on main at 15:20:27Z, and `#1132` still
    got zero test runs from a head pushed at 18:11:30Z, three hours later,
    because its base (`docs/ax-two-call-sites`, last touched 06:52) still
-   carries the old filter. Verified by reading `tests.yml` on that branch.
+   carries the old filter.
+
+   **Evidence classes differ across this mechanism, and the difference is worth
+   marking.** The example is verified *here*: pre-`#1123` the block was
+   `pull_request: branches: [main, v1.0.x]` with no `paths:` at all, so the
+   filter is the sole candidate cause rather than merely a present one — an
+   earlier basis established only that it was present, which a competing cause
+   would survive. The qualifying clause is different: *"a head that edits the
+   workflow contributes its version to the merge ref"* is a **GitHub platform
+   rule, unverified in this repo** — no PR here has edited a workflow its own
+   base would have excluded, so nothing in this history reads it. It is
+   documentation of the platform, not a measurement of us. (@sprint-review,
+   58118/58119. Same standing as the `edited` line elsewhere in this entry.)
 
    Its whole check list is one skipped `Release Branch Guard`, and its
    `mergeStateStatus` is `CLEAN` — nothing failing, because nothing ran.


### PR DESCRIPTION
Entry 41's mechanism 4 stated that "the BASE branch's copy of the file decides whether the event matches" without qualification. That holds for `#1132` — its head touched one file and it wasn't `tests.yml` — and it is false in general. The merge ref is base + head, so a head that edits the workflow contributes its own version and can fix its own triggering.

The unqualified sentence is the one a reader lifts. Someone with a stacked PR that *does* edit a workflow would conclude their head can't help, and reach for the wrong remedy: a rebase they don't need, or a manual dispatch — which manufactures the very artifact whose absence was the symptom.

The precise version was already inside the same sentence ("merge ref, which is base + head"), so this adds a clause rather than rewriting the mechanism. The example and its timings are untouched.

Caught by sprint-review (message 57534). The qualifier was stated at 57497 and didn't survive into the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## The example's basis, strengthened after the fact

@sprint-review (58118) pushed on how the example was verified. My original basis was reading `tests.yml` on that branch and finding the `paths:` filter present — which establishes presence, not sole cause: some *other* condition could equally have zeroed the runs, and a present filter would still look like the explanation.

They checked the stronger form: pre-#1123 the block was `pull_request: branches: [main, v1.0.x]` with **no `paths:` at all**. So the filter is the only candidate cause, and the example holds for the reason the entry gives.

Recorded here rather than left in a pod message, so the claim ships with the evidence that actually supports it. The entry text is unchanged — this changes what the example rests on, not what it says.