### PR TITLE
fix(v2): four live bugs from Sam's mobile review — flash, thread sink, live threads, sideways swipe

### DIFF
--- a/backend/__tests__/unit/controllers/messageController.test.js
+++ b/backend/__tests__/unit/controllers/messageController.test.js
@@ -25,8 +25,12 @@ jest.mock('../../../models/AgentRegistry', () => ({
 jest.mock('../../../config/socket', () => ({
   getIO: jest.fn(),
 }));
+jest.mock('../../../services/threadRootResolver', () => ({
+  resolveThreadRoot: jest.fn(),
+}));
 
 const socketConfig = require('../../../config/socket');
+const { resolveThreadRoot } = require('../../../services/threadRootResolver');
 
 describe('messageController', () => {
   beforeEach(() => {
@@ -391,6 +395,34 @@ describe('messageController', () => {
       await messageController.createMessage(req, res);
 
       expect(emit).toHaveBeenCalledWith('newMessage', expect.objectContaining({ replyTo }));
+    });
+
+    // #646's lesson one field over (Sam's live repro 2026-08-24): without
+    // thread_root_id on the broadcast, every live viewer rendered an
+    // in-thread reply as a TOP-LEVEL message until refresh, and open
+    // threads never updated live. The agent path (#1175) carries it; the
+    // human path was the gap.
+    it('broadcasts thread_root_id on the newMessage socket emit', async () => {
+      Pod.findById.mockResolvedValue({ members: ['u1'], type: 'chat' });
+      resolveThreadRoot.mockResolvedValue(57577);
+      PGMessage.create.mockResolvedValue({ id: 'm10' });
+      PGMessage.findById.mockResolvedValue({
+        id: 'm10', content: 'thread detail', thread_root_id: 57577, reply_to_message_id: null,
+      });
+      const emit = jest.fn();
+      socketConfig.getIO.mockReturnValue({ to: jest.fn(() => ({ emit })) });
+
+      const req = {
+        params: { podId: 'p1' },
+        body: { content: 'thread detail', threadRootId: '57577' },
+        user: { id: 'u1', username: 'alice' },
+      };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+      await messageController.createMessage(req, res);
+
+      expect(emit).toHaveBeenCalledWith('newMessage', expect.objectContaining({
+        thread_root_id: 57577,
+      }));
     });
   });
 

--- a/backend/controllers/messageController.ts
+++ b/backend/controllers/messageController.ts
@@ -381,6 +381,13 @@ exports.createMessage = async (req: AuthRequest, res: Response): Promise<void> =
           // viewer renders the reply without its quoted context until a
           // reload re-fetches the joined row (#646).
           replyTo: m.replyTo ?? null,
+          // #646's lesson, one field over: without the thread root every
+          // live viewer rendered an in-thread reply as a TOP-LEVEL message
+          // until refresh, and the thread never updated live (Sam,
+          // 2026-08-24). The agent path (#1175) carries it; this human
+          // path was the gap.
+          thread_root_id: (m as { thread_root_id?: number | string | null }).thread_root_id ?? null,
+          reply_to_message_id: (m as { reply_to_message_id?: number | string | null }).reply_to_message_id ?? null,
         };
         io.to(`pod_${podId}`).emit('newMessage', formattedMessage);
       }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,7 +29,17 @@
     <meta name="twitter:description" content="The open-source workspace where you and your agents share one project memory — so nothing gets re-explained. Any runtime, your infra, no per-agent fees." />
     <meta name="twitter:image" content="https://commonly.me/og-card.png?v=2" />
     <!-- SEO_METADATA_END -->
+    <!-- Progressive-enhancement gate for the prerendered SEO page below.
+         The dark #seo-page markup ships inside #root on EVERY route, so
+         every load painted it for the beat before React replaced it — the
+         "half-second dark flash" (Sam, 2026-08-24) that survived three CSS
+         fixes because it is content, not a background rule. This head
+         script runs before first paint: browsers (JS on) never show the
+         prerender; crawlers without JS still get the full content. Not
+         cloaking — JS-running crawlers see the real app. -->
+    <script>document.documentElement.className += ' js';</script>
     <style>
+      html.js #seo-page { display: none; }
       #seo-page { box-sizing: border-box; min-height: 100vh; color: #e5e7eb; background: #0b1220; font: 16px/1.6 Inter, ui-sans-serif, system-ui, sans-serif; }
       #seo-page *, #seo-page *::before, #seo-page *::after { box-sizing: inherit; }
       #seo-page a { color: #7dd3fc; text-decoration-thickness: 1px; text-underline-offset: 3px; }

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -133,6 +133,17 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(entry).toContain("classList.add('v2-canvas')");
     expect(entry.indexOf("classList.add('v2-canvas')"))
       .toBeLessThan(entry.indexOf('createRoot'));
+    // The FOURTH and largest dark source: index.html ships the dark
+    // prerendered #seo-page INSIDE #root on every route, painted for the
+    // beat before React replaces it. The head script stamps `js` on <html>
+    // before first paint and CSS hides the prerender; crawlers without JS
+    // still see the content. The script must PRECEDE the style block that
+    // uses it, and both must precede </head>.
+    const indexHtml = read('../../../index.html');
+    expect(indexHtml).toContain("documentElement.className += ' js'");
+    expect(indexHtml).toContain('html.js #seo-page { display: none; }');
+    expect(indexHtml.indexOf("className += ' js'"))
+      .toBeLessThan(indexHtml.indexOf('html.js #seo-page'));
   });
 
   test('the conversation column is FULL-WIDTH — no measure cap, one left edge (rule 2, v5)', () => {
@@ -163,6 +174,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // gap), whose bottom margin terminates the rail before the next
     // outer message.
     expect(ruleBody(v2, '.v2-thread-block')).toContain('margin-left: 50px');
+    // Indent + width must sum to 100%: the column's `> *` width:100% plus
+    // the 50px indent pushed every thread 50px past the pane's right edge,
+    // making the transcript horizontally swipeable — worst on phones
+    // (Sam, 2026-08-24; measured 350 vs 326 scrollWidth at 390px).
+    expect(ruleBody(v2, '.v2-thread-block')).toContain('width: calc(100% - 50px)');
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-block \{[\s\S]*?width: calc\(100% - 24px\)/);
+    // Belt-and-braces: the transcript itself never scrolls sideways.
+    expect(ruleBody(v2, '.v2-chat__messages')).toContain('overflow-x: hidden');
     expect(ruleBody(v2, '.v2-thread-block')).toContain('margin-bottom');
   });
 

--- a/frontend/src/v2/hooks/useV2PodDetail.ts
+++ b/frontend/src/v2/hooks/useV2PodDetail.ts
@@ -445,7 +445,17 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
       setMessages((prev) => {
         if (prev.some((m) => m.id && m.id === normalized.id)) {
           return prev.map((m) => (
-            m.id === normalized.id ? { ...m, replyTo: m.replyTo ?? normalized.replyTo ?? null } : m
+            m.id === normalized.id
+              ? {
+                ...m,
+                replyTo: m.replyTo ?? normalized.replyTo ?? null,
+                // #646's graft, one field over: when the socket copy wins
+                // the race and lacks the thread root (older server), keep
+                // the POST copy's — or the sender's own in-thread reply
+                // renders top-level until refresh (Sam, 2026-08-24).
+                thread_root_id: m.thread_root_id ?? normalized.thread_root_id ?? null,
+              }
+              : m
           ));
         }
         return chronologicalMessages([...prev, normalized]);

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -1575,6 +1575,11 @@ body.modern-ui.v2-canvas {
 .v2-chat__messages {
   flex: 1;
   overflow-y: auto;
+  /* The transcript never scrolls sideways — wide content (code, tables)
+     manages its own overflow-x inside its message. Without this, any
+     mis-sized row makes the whole pane horizontally swipeable (the
+     thread-block did exactly that; Sam's mobile report 2026-08-24). */
+  overflow-x: hidden;
   padding: 0 24px 12px;
   display: flex;
   flex-direction: column;
@@ -7219,6 +7224,12 @@ body.modern-ui.v2-canvas {
    outer message and reads as connected to it. */
 .v2-thread-block {
   margin-left: 50px;
+  /* The column's `> *` rule sets width: 100%; with the 50px indent that
+     put every thread 50px past the pane's right edge — the pane became
+     horizontally swipeable, worst on phones (Sam, 2026-08-24; measured
+     scrollWidth 350 vs clientWidth 326 at 390px). Indent + width must sum
+     to 100%. */
+  width: calc(100% - 50px);
   margin-bottom: 14px;
 }
 
@@ -7417,6 +7428,7 @@ body.modern-ui.v2-canvas {
      inner padding tightens with it. */
   .v2-thread-block {
     margin-left: 24px;
+    width: calc(100% - 24px); /* same indent+width=100% invariant as desktop */
   }
 
   .v2-thread-replies {


### PR DESCRIPTION
All four measured live before fixing. (1) The half-second dark flash was content, not CSS: index.html prerenders the dark #seo-page inside #root on every route — a head script now stamps .js before first paint and CSS hides the prerender (crawlers without JS still get it). (2+3) In-thread sends rendered top-level until refresh and threads never updated live: the human-path newMessage broadcast omitted thread_root_id (the agent path has carried it since #1175), and the sender's dedupe graft dropped it when the socket copy won the race — both are #646's bug one field over. (4) The transcript was horizontally swipeable: .v2-thread-block carried width:100% plus its 50px indent (350 vs 326 scrollWidth at 390px); indent+width now sum to 100% and the transcript pins overflow-x:hidden. 297/297 frontend + 21/21 controller, all four pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK