### PR TITLE
fix(mentions): the handle regex was safe because of a character class 850 lines away

### DIFF
--- a/backend/__tests__/unit/services/agentMentionService.handleMatcher.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.handleMatcher.test.js
@@ -1,0 +1,61 @@
+/**
+ * @handle → Mongo matcher: escaped, not interpolated raw.
+ *
+ * @sprint-review's finding on #1157: `new RegExp(`^${username}$`, 'i')` was
+ * injection-safe only because `extractMentions` constrains handles to
+ * `[a-z0-9_-]` — and that same commit widened the character class the safety
+ * rested on. The precondition lives ~850 lines from the call site that relies
+ * on it.
+ *
+ * These cases deliberately feed metacharacters that `extractMentions` cannot
+ * currently produce. That is the point: a test restricted to today's reachable
+ * inputs passes identically before and after the fix, and would keep passing
+ * through the widening that breaks it. The property under test is the matcher's
+ * own contract, not the composition.
+ */
+
+const { handleMatcher } = require('../../../services/agentMentionService');
+
+describe('handleMatcher escapes the handle', () => {
+  it('anchors, so a prefix does not match a longer username', () => {
+    expect(handleMatcher('casey').test('casey-admin')).toBe(false);
+    expect(handleMatcher('casey').test('casey')).toBe(true);
+  });
+
+  it('is case-insensitive, because usernames are not normalized at write time', () => {
+    expect(handleMatcher('casey_dev').test('Casey_Dev')).toBe(true);
+  });
+
+  it('treats the characters extractMentions allows today as literals', () => {
+    expect(handleMatcher('a_b-c').test('a_b-c')).toBe(true);
+    expect(handleMatcher('a_b-c').test('aXbYc')).toBe(false);
+  });
+
+  // The four below are unreachable through extractMentions today. Each one
+  // fails against the raw-interpolation form and passes against the escaped
+  // one — they are the regression guard for the next time the class widens.
+  it('treats a dot as a literal, not as any-character', () => {
+    expect(handleMatcher('a.c').test('abc')).toBe(false);
+    expect(handleMatcher('a.c').test('a.c')).toBe(true);
+  });
+
+  it('treats an alternation as a literal', () => {
+    expect(handleMatcher('a|b').test('a')).toBe(false);
+    expect(handleMatcher('a|b').test('a|b')).toBe(true);
+  });
+
+  it('treats a quantifier as a literal', () => {
+    expect(handleMatcher('ab+').test('abbb')).toBe(false);
+    expect(handleMatcher('ab+').test('ab+')).toBe(true);
+  });
+
+  it('does not throw on an unbalanced bracket', () => {
+    expect(() => handleMatcher('a[b')).not.toThrow();
+    expect(handleMatcher('a[b').test('a[b')).toBe(true);
+  });
+
+  it('does not let a wildcard handle match every username', () => {
+    expect(handleMatcher('.*').test('someone-else')).toBe(false);
+    expect(handleMatcher('.*').test('.*')).toBe(true);
+  });
+});

--- a/backend/__tests__/unit/services/agentMentionService.handleMatcher.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.handleMatcher.test.js
@@ -31,9 +31,11 @@ describe('handleMatcher escapes the handle', () => {
     expect(handleMatcher('a_b-c').test('aXbYc')).toBe(false);
   });
 
-  // The four below are unreachable through extractMentions today. Each one
+  // The five below are unreachable through extractMentions today. Each one
   // fails against the raw-interpolation form and passes against the escaped
   // one — they are the regression guard for the next time the class widens.
+  // (Counted, not eyeballed: reverting handleMatcher to the raw form fails
+  // exactly these five and leaves the three reachable-input cases above green.)
   it('treats a dot as a literal, not as any-character', () => {
     expect(handleMatcher('a.c').test('abc')).toBe(false);
     expect(handleMatcher('a.c').test('a.c')).toBe(true);

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -1030,6 +1030,24 @@ const resolveBotUserIds = async (
  * the message is already durable. A Mongo failure must not turn a successful
  * send into a 500; it only leaves this one implicit follow unmaterialized.
  */
+/**
+ * Anchored, case-insensitive matcher for one @handle — escaped, not
+ * interpolated raw.
+ *
+ * This is not a live injection fix. `extractMentions` constrains handles to
+ * `[a-z0-9_-]`, and none of those are regex metacharacters, so the raw form
+ * was safe. It is a LOCALITY fix (@sprint-review on #1157): the safety rested
+ * on a character class defined ~850 lines away, and the very commit that added
+ * this lookup also widened that class. A precondition maintained in another
+ * function is one edit away from not holding, and nothing at this call site
+ * would fail when it stops — the query would just silently match the wrong
+ * users. Escaping makes the guarantee local and survives the next widening.
+ */
+const handleMatcher = (username: string): RegExp => new RegExp(
+  `^${String(username).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`,
+  'i',
+);
+
 const resolveHumanMentionUserIds = async (
   mentions: Iterable<string>,
   podMemberIds: Set<string>,
@@ -1039,7 +1057,7 @@ const resolveHumanMentionUserIds = async (
   try {
     const rows = await User.find({
       isBot: false,
-      $or: handles.map((username) => ({ username: new RegExp(`^${username}$`, 'i') })),
+      $or: handles.map((username) => ({ username: handleMatcher(username) })),
     }).select('_id username').lean() as Array<{ _id?: unknown }>;
     return new Set(
       rows
@@ -2003,6 +2021,12 @@ const enqueueDmEvent = async ({
 
 export {
   extractMentions,
+  // Exported for the escaping test: the property that matters — a metacharacter
+  // in a handle matches literally — is unreachable through `enqueueMentions`
+  // while `extractMentions` still excludes metacharacters. A test that can only
+  // observe the safe inputs cannot fail when the class widens, which is the
+  // whole defect this guards.
+  handleMatcher,
   enqueueMentions,
   enqueueDmEvent,
   MENTION_ALIASES,

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -1017,20 +1017,6 @@ const resolveBotUserIds = async (
 };
 
 /**
- * Resolve explicit @handles that belong to humans, not installed agents.
- *
- * The composer inserts a member's real username, while `extractMentions`
- * normalizes that handle to lowercase for the agent resolver. Usernames are
- * not themselves case-normalized at write time, so the lookup is anchored and
- * case-insensitive rather than assuming a lowercased stored value. Handles
- * are extracted from `[a-z0-9_-]`, but anchoring keeps a prefix such as
- * `@casey` from following `casey-admin` too.
- *
- * This is deliberately best-effort for the same reason as bot resolution:
- * the message is already durable. A Mongo failure must not turn a successful
- * send into a 500; it only leaves this one implicit follow unmaterialized.
- */
-/**
  * Anchored, case-insensitive matcher for one @handle — escaped, not
  * interpolated raw.
  *
@@ -1048,6 +1034,20 @@ const handleMatcher = (username: string): RegExp => new RegExp(
   'i',
 );
 
+/**
+ * Resolve explicit @handles that belong to humans, not installed agents.
+ *
+ * The composer inserts a member's real username, while `extractMentions`
+ * normalizes that handle to lowercase for the agent resolver. Usernames are
+ * not themselves case-normalized at write time, so the lookup is anchored and
+ * case-insensitive rather than assuming a lowercased stored value. Handles
+ * are extracted from `[a-z0-9_-]`, but anchoring keeps a prefix such as
+ * `@casey` from following `casey-admin` too.
+ *
+ * This is deliberately best-effort for the same reason as bot resolution:
+ * the message is already durable. A Mongo failure must not turn a successful
+ * send into a 500; it only leaves this one implicit follow unmaterialized.
+ */
 const resolveHumanMentionUserIds = async (
   mentions: Iterable<string>,
   podMemberIds: Set<string>,


### PR DESCRIPTION
@sprint-review raised this as the one finding worth acting on before #1157 merged. #1157 merged without it, so it is live on `main`.

## The defect

`resolveHumanMentionUserIds` built its Mongo matcher by raw interpolation:

```ts
$or: handles.map((username) => ({ username: new RegExp(`^${username}$`, 'i') })),
```

That is injection-safe **only** because `extractMentions` constrains handles to `[a-z0-9_-]`, none of which are regex metacharacters — and the same commit that introduced this lookup also widened that character class. The precondition the safety rests on is maintained ~850 lines away, in a different function, by a different concern.

It is not a live injection today. It is a locality defect, and the failure mode is quiet: nothing at this call site errors when the class widens. The query simply starts matching the wrong users, on a path whose entire job is deciding who gets followed into a thread.

## The fix

Escape the interpolation, so the guarantee is local and survives the next widening.

## Why the matcher is exported

The property that matters — a metacharacter in a handle matches literally — is **unreachable through `enqueueMentions`** while `extractMentions` still excludes metacharacters. A test driven through the public path can only exercise safe inputs, so it passes identically before and after the fix, and would keep passing straight through the widening that breaks it. Testing the matcher's own contract is the only way the guard can fail when it should.

## Verification

Ran the new suite against the **pre-fix** form as a positive control:

```
✓ anchors, so a prefix does not match a longer username
✓ is case-insensitive, because usernames are not normalized at write time
✓ treats the characters extractMentions allows today as literals
✕ treats a dot as a literal, not as any-character
✕ treats an alternation as a literal
✕ treats a quantifier as a literal
✕ does not throw on an unbalanced bracket
✕ does not let a wildcard handle match every username
Tests: 5 failed, 3 passed
```

The three that pass either way are exactly the reachable-input cases — the demonstration of why they are not sufficient on their own.

Post-fix: 8/8. Full `agentMentionService` suites: 115/115 on Node 22. `tsc --noEmit`: no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)