### PR TITLE
test(backend): pin the widened req.agentUser contract in agentRuntimeAuth

### DIFF
--- a/backend/__tests__/unit/middleware/agentUserShapeContract.test.js
+++ b/backend/__tests__/unit/middleware/agentUserShapeContract.test.js
@@ -25,6 +25,17 @@ const path = require('path');
 const SRC = path.join(__dirname, '../../../middleware/agentRuntimeAuth.ts');
 const source = fs.readFileSync(SRC, 'utf8');
 
+// Comments are stripped before counting, because this file TALKS about
+// `.select()` in prose and would otherwise count its own documentation.
+// Deliberately crude — it is not a parser, and the assertions below are
+// designed so that it does not need to be one.
+const codeOnly = () => source
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^[ \t]*\/\/.*$/gm, '')
+  .replace(/([^:])\/\/.*$/gm, '$1');
+
+const selectCallCount = () => (codeOnly().match(/\.select\s*\(/g) || []).length;
+
 /** Statement starting at `User.findOne(`, up to the terminating semicolon. */
 const userFindOneStatements = () => {
   const out = [];
@@ -45,8 +56,40 @@ describe('the middleware reads the full User row', () => {
     expect(userFindOneStatements()).toHaveLength(2);
   });
 
-  it('projects neither of them', () => {
-    for (const stmt of userFindOneStatements()) {
+  it('the file contains exactly one projection, and it is the Pod.find', () => {
+    // THE LOAD-BEARING ASSERTION, and it fails CLOSED. @sprint-review found
+    // the statement-scoping below fails OPEN on the most likely edit: it ends
+    // a statement at the first `;` after `User.findOne(`, which is not the end
+    // of the statement whenever a semicolon appears inside it. The comment a
+    // developer writes when adding a projection is exactly that case —
+    //
+    //   const botUser = await User.findOne({
+    //     // legacy path; only the id is needed here
+    //     ...
+    //   }).select('_id');
+    //
+    // — and the pre-fix suite returned 7/7 green against it. Reproduced here
+    // before this rewrite. A semicolon inside a string value does the same.
+    // The guard was strongest against a bare projection and weakest against a
+    // projection someone bothered to explain, inverting the risk ordering.
+    //
+    // So do not ask "does this statement project?", which needs a parser this
+    // is not. Enumerate the protected item instead: ANY new `.select(`
+    // anywhere in the file trips this, and the author re-certifies it
+    // consciously. A guard that must parse correctly to fail is not a guard.
+    expect(selectCallCount()).toBe(1);
+    expect(codeOnly()).toMatch(/Pod\.find\([\s\S]{0,200}?\.select\('_id'\)/);
+  });
+
+  it('projects neither User.findOne', () => {
+    // Kept as the specific statement of the property, but it is no longer
+    // what defends it. Asserts its own population: iterating an empty array
+    // passes, so without this line the test is vacuous whenever the extractor
+    // finds nothing — and it used to borrow its non-vacuity from a DIFFERENT
+    // test, so weakening that one silently gutted this one.
+    const statements = userFindOneStatements();
+    expect(statements).toHaveLength(2);
+    for (const stmt of statements) {
       expect(stmt).not.toMatch(/\.select\s*\(/);
     }
   });
@@ -57,6 +100,17 @@ describe('the middleware reads the full User row', () => {
     const rigged = 'const x = await User.findOne({ a: 1 }).select(\'_id\').lean();';
     const stmt = rigged.slice(rigged.indexOf('User.findOne('), rigged.indexOf(';'));
     expect(stmt).toMatch(/\.select\s*\(/);
+  });
+
+  it('control: the projection count DOES move when a projection is added', () => {
+    // Same rider as the probe control below, applied to the counter: a
+    // `selectCallCount` that silently stopped matching would read exactly
+    // like a middleware that projects once. Also pins the comment-stripper,
+    // which is the one part that could quietly zero the count — this file's
+    // own prose mentions `.select()` three times and must not be counted.
+    const rigged = `${codeOnly()}\nawait User.findOne({ a: 1 }).select('_id');`;
+    expect((rigged.match(/\.select\s*\(/g) || []).length).toBe(selectCallCount() + 1);
+    expect(codeOnly()).not.toMatch(/Adding a `\.select\(\)`/);
   });
 
   it('control: the interleaved Pod.find projection is NOT attributed to a User query', () => {

--- a/backend/__tests__/unit/middleware/agentUserShapeContract.test.js
+++ b/backend/__tests__/unit/middleware/agentUserShapeContract.test.js
@@ -1,0 +1,86 @@
+/**
+ * `req.agentUser` must carry the whole User row, not a projection.
+ *
+ * THIS IS A SOURCE ASSERTION ON PURPOSE — reviewer-checklist rule 18. The
+ * property is structural, not behavioural: the claim is "no path projects
+ * these queries", and absence of code cannot be demonstrated by execution.
+ * A behavioural test cannot catch the regression either, because every suite
+ * that touches an agent-authenticated route constructs its own `req.agentUser`
+ * (or mocks `agentRuntimeAuth` to a bare `next()`), so a `.select()` added to
+ * the real middleware would empty `username` in production with the whole
+ * suite still green. That is the exact failure #1127 fixed — see rule 17.
+ *
+ * @sprint-review (57620) raised the gap: `agentRuntimeAuth.ts` documents the
+ * downstream contract as `req.agentUser?._id` only, while #1127 shipped a
+ * consumer reading `username`. Nothing enforced the widened contract.
+ *
+ * Positive control included, per rule 18's second rider: a grep that matches
+ * nothing because the pattern is wrong is indistinguishable from one that
+ * matches nothing because the code is gone.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SRC = path.join(__dirname, '../../../middleware/agentRuntimeAuth.ts');
+const source = fs.readFileSync(SRC, 'utf8');
+
+/** Statement starting at `User.findOne(`, up to the terminating semicolon. */
+const userFindOneStatements = () => {
+  const out = [];
+  let from = 0;
+  for (;;) {
+    const start = source.indexOf('User.findOne(', from);
+    if (start === -1) return out;
+    const end = source.indexOf(';', start);
+    out.push(source.slice(start, end === -1 ? source.length : end));
+    from = start + 1;
+  }
+};
+
+describe('the middleware reads the full User row', () => {
+  it('finds both User.findOne call sites', () => {
+    // Binds the rest of the suite to a known population. If this number
+    // changes, the new call site needs the same check, not a bumped constant.
+    expect(userFindOneStatements()).toHaveLength(2);
+  });
+
+  it('projects neither of them', () => {
+    for (const stmt of userFindOneStatements()) {
+      expect(stmt).not.toMatch(/\.select\s*\(/);
+    }
+  });
+
+  it('control: the probe DOES detect a projection when one is present', () => {
+    // Without this, a `.select(` regex that silently stopped matching would
+    // read exactly like a middleware that never projects.
+    const rigged = 'const x = await User.findOne({ a: 1 }).select(\'_id\').lean();';
+    const stmt = rigged.slice(rigged.indexOf('User.findOne('), rigged.indexOf(';'));
+    expect(stmt).toMatch(/\.select\s*\(/);
+  });
+
+  it('control: the interleaved Pod.find projection is NOT attributed to a User query', () => {
+    // The near-miss this file exists to prevent. `.select('_id')` at :98
+    // belongs to the DM-pod `Pod.find`, thirty-seven lines above the second
+    // `User.findOne`. If the statement-scoping above regressed to a
+    // proximity grep, this assertion is what would catch it.
+    expect(source).toMatch(/Pod\.find\([\s\S]{0,200}?\.select\('_id'\)/);
+    expect(userFindOneStatements().join('\n')).not.toMatch(/Pod\.find/);
+  });
+});
+
+describe('the fields a future .select() author would be dropping', () => {
+  // Not a behavioural assertion — a named inventory, so the reason this file
+  // exists is legible without a git blame. Each entry is grepped for the
+  // actual `agentUser` access in the file that depends on it, so the list
+  // cannot rot into decoration or pass on an unrelated mention of the word.
+  const consumers = [
+    ['username', 'routes/tasksApi.ts', /req\.agentUser\?\.username/],
+    ['username', 'routes/agentsRuntime.ts', /agentUser\?\.username/],
+    ['botMetadata', 'routes/agentsRuntime.ts', /agentUser\?\.botMetadata/],
+  ];
+  it.each(consumers)('%s is read off req.agentUser in %s', (field, rel, pattern) => {
+    const file = path.join(__dirname, '../../../', rel);
+    expect(fs.readFileSync(file, 'utf8')).toMatch(pattern);
+  });
+});

--- a/backend/middleware/agentRuntimeAuth.ts
+++ b/backend/middleware/agentRuntimeAuth.ts
@@ -181,6 +181,22 @@ export default async function agentRuntimeAuth(req: Request, res: Response, next
     // commonly_attach_file uploads — her runtime token had been issued to
     // `AgentInstallation.runtimeTokens` (legacy) and the upload route
     // checks `req.agentUser?._id` only.
+    //
+    // THE DOWNSTREAM CONTRACT IS WIDER THAN `_id`, AND BOTH `User.findOne`
+    // CALLS IN THIS FILE MUST STAY UNPROJECTED. `username` is load-bearing
+    // since #1127 (`tasksApi` labels a claim holder with it), and `isBot` /
+    // `botMetadata` are read by the lease-rescue sweep. Adding a `.select()`
+    // here for performance would silently empty those terms — and no test
+    // would go red, because the suites construct their own `req.agentUser`
+    // rather than calling this middleware. That is precisely the failure
+    // #1127 fixed, one middleware edit away from returning.
+    //
+    // Note the trap next door: the `.select('_id')` thirty-seven lines above
+    // belongs to the interleaved DM-pod `Pod.find`, not to the `User.findOne`.
+    // Grepping for a projection by line proximity finds the wrong query here.
+    // Guarded by `__tests__/unit/middleware/agentUserShapeContract.test.js`;
+    // reviewer-checklist rule 18 is why that guard reads source rather than
+    // running the middleware.
     try {
       const botUser = await User.findOne({
         isBot: true,


### PR DESCRIPTION
Closes @sprint-review's forward-looking note on #1127: `agentRuntimeAuth.ts` documented its downstream contract as `req.agentUser?._id` **only**, while #1127 shipped a consumer that reads `username`. Nothing enforced the widened contract — add a `.select('_id')` to either `User.findOne` for performance and the term goes silently dead, **with the tests still green**, because every suite constructs its own `req.agentUser` or mocks the middleware to a bare `next()`.

They asked for "a word in that comment". This is that word plus a guard.

## What's here

- **`backend/middleware/agentRuntimeAuth.ts`** — the contract comment now names the load-bearing fields (`username` since #1127, `isBot` / `botMetadata` for the lease-rescue sweep), says both `User.findOne` calls must stay unprojected, and states why no behavioural test would go red.
- **`backend/__tests__/unit/middleware/agentUserShapeContract.test.js`** — 7 tests. Statement-scoped extraction of both `User.findOne` calls (`:61 → :102`, `:185 → :191`), an assertion that neither is projected, and a grepped inventory of the three live consumers (`routes/tasksApi.ts` `req.agentUser?.username`; `routes/agentsRuntime.ts` `agentUser?.username` and `agentUser?.botMetadata`).

## Why a source assertion

Reviewer-checklist rule 18 — *absence of code cannot be demonstrated by execution*. The property here is structural (**no path projects these queries**), not behavioural, so it falls inside rule 18's carve-out rather than against it.

Two controls keep the assertion honest:
1. The `.select(` probe **does** detect a projection when one is present — so a passing run isn't a blind instrument.
2. The interleaved `Pod.find` `.select('_id').lean()` at `:98` is **not** attributed to a User query. That is @sprint-review's near-miss verbatim, and rule 17's rider: bind the projection to its own query, not to line proximity.

## Verification

Positive control against the real file — inject `.select('_id')` onto the legacy-path `User.findOne`:

```
✓ finds both User.findOne call sites
✕ projects neither of them
✓ control: the probe DOES detect a projection when one is present
✓ control: the interleaved Pod.find projection is NOT attributed to a User query
✓ username is read off req.agentUser in routes/tasksApi.ts
✓ username is read off req.agentUser in routes/agentsRuntime.ts
✓ botMetadata is read off req.agentUser in routes/agentsRuntime.ts
Tests: 1 failed, 6 passed
```

Restored: 7 passed. `__tests__/unit/middleware` + `__tests__/unit/routes` → 92 suites, 546 tests, all green. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)