### PR TITLE
fix(registry): publisher.name is undefined for every browser-session publish

### DIFF
--- a/backend/__tests__/unit/routes/registry.publisherNameJwtPath.test.js
+++ b/backend/__tests__/unit/routes/registry.publisherNameJwtPath.test.js
@@ -1,0 +1,82 @@
+// `middleware/auth.ts` dispatches on the token and the two branches leave
+// DIFFERENT shapes on `req.user`: the `cm_` API-token path assigns
+// `{ id, username, email, role }` (`:51`); the browser-JWT path assigns
+// `{ id }` (`:81`). Neither errors. So the registry writers, which read
+// `req.user.username` directly, persisted `publisher.name: undefined` for
+// every browser-session publish — a silent data defect with nothing to go red.
+//
+// Per AX audit entry 42, the auth middleware is mocked to `next()` here on
+// purpose and the shape is CONSTRUCTED on the request instead: the subject is
+// the consumer's handling of each shape, not the dispatcher's choice between
+// them, and a test that let the route pick would only ever exercise one.
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => next());
+
+const mockFindById = jest.fn();
+jest.mock('../../../models/User', () => ({ findById: (...a) => mockFindById(...a) }));
+
+const mockCreate = jest.fn();
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentRegistry: {
+    getByName: jest.fn().mockResolvedValue(null),
+    create: (...a) => mockCreate(...a),
+  },
+  AgentInstallation: {},
+}));
+
+const publishRouter = require('../../../routes/registry/publish');
+
+const handler = (() => {
+  const layer = publishRouter.stack.find((e) => e.route && e.route.path === '/publish' && e.route.methods.post);
+  if (!layer) throw new Error('POST /publish not found');
+  return layer.route.stack[layer.route.stack.length - 1].handle;
+})();
+
+const manifest = { name: 'demo-agent', version: '1.0.0', description: 'd' };
+
+const run = async (user) => {
+  mockCreate.mockClear();
+  mockCreate.mockResolvedValue({ agentName: 'demo-agent' });
+  const req = {
+    user,
+    body: {
+      manifest, displayName: 'Demo', readme: null, categories: [], tags: [], 
+    }, 
+  };
+  const res = { status: () => res, json: () => res };
+  await handler(req, res);
+  expect(mockCreate).toHaveBeenCalledTimes(1);
+  return mockCreate.mock.calls[0][0].publisher;
+};
+
+describe('registry publish — publisher.name across both auth shapes', () => {
+  beforeEach(() => {
+    mockFindById.mockReset();
+    mockFindById.mockReturnValue({ select: () => ({ lean: async () => ({ username: 'lily' }) }) });
+  });
+
+  // The regression case. Pre-fix this yielded `name: undefined`.
+  it('resolves the username on the browser-JWT shape, which carries only { id }', async () => {
+    const publisher = await run({ id: 'u1' });
+    expect(publisher.name).toBe('lily');
+    expect(mockFindById).toHaveBeenCalledWith('u1');
+  });
+
+  it('uses the token-supplied username on the cm_ shape without a DB read', async () => {
+    const publisher = await run({
+      id: 'u1', username: 'sam', email: 'e', role: 'user', 
+    });
+    expect(publisher.name).toBe('sam');
+    expect(mockFindById).not.toHaveBeenCalled();
+  });
+
+  // A publisher row whose name is `undefined` is the defect itself, so no
+  // shape may produce one: an unresolvable user must persist null, not a
+  // missing key that reads as "not yet written".
+  it('persists null rather than undefined when the user cannot be resolved', async () => {
+    mockFindById.mockReturnValue({ select: () => ({ lean: async () => null }) });
+    const publisher = await run({ id: 'u1' });
+    expect(publisher.name).toBeNull();
+    expect('name' in publisher).toBe(true);
+  });
+});

--- a/backend/routes/registry/helpers.ts
+++ b/backend/routes/registry/helpers.ts
@@ -54,6 +54,24 @@ const escapeRegExp = (value: any) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'
 
 const getUserId = (req: any) => req.userId || req.user?.id || req.user?._id;
 
+// `middleware/auth.ts` dispatches on the token and the two branches leave
+// DIFFERENT shapes on `req.user`: the `cm_` API-token path assigns
+// `{ id, username, email, role }` (`:51`), the browser-JWT path assigns
+// `{ id }` (`:81`). Neither errors, so `req.user.username` is simply
+// `undefined` for every browser session — and `publisher.name: undefined`
+// persists into the registry with nothing going red. Load it when the token
+// did not carry it. `routes/marketplace-api.ts` already resolves the same way;
+// this is that resolution moved next to `getUserId`, which both registry
+// writers already import. See AX audit entry 42.
+const resolveUsername = async (req: any): Promise<string | null> => {
+  if (req.user?.username) return req.user.username;
+  if (req.agentUser?.username) return req.agentUser.username;
+  const userId = getUserId(req);
+  if (!userId) return null;
+  const user = await User.findById(userId).select('username').lean();
+  return user?.username || null;
+};
+
 const normalizeConfigMap = (config: any) => {
   if (!config) return null;
   if (config instanceof Map) {
@@ -606,6 +624,7 @@ module.exports = {
   parseVerifiedFilter,
   escapeRegExp,
   getUserId,
+  resolveUsername,
   normalizeConfigMap,
   normalizeRuntimeAuthProfiles,
   normalizeSkillEnvEntries,

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -16,6 +16,7 @@ const FirstContactService = require('../../services/firstContactService');
 const { normalizeAvatarUrl } = require('../../services/avatarService');
 const {
   getUserId,
+  resolveUsername,
   normalizeInstanceId,
   normalizeConfigMap,
   normalizeRuntimeAuthProfiles,
@@ -218,7 +219,7 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
         latestVersion: synthManifest.version,
         versions: [{ version: synthManifest.version, manifest: synthManifest, publishedAt: new Date() }],
         registry: 'private',
-        publisher: { userId, name: req.user?.username },
+        publisher: { userId, name: await resolveUsername(req) },
         ephemeral: true,
       });
       console.log('[cap self-serve-install]', {

--- a/backend/routes/registry/publish.ts
+++ b/backend/routes/registry/publish.ts
@@ -4,7 +4,7 @@ const express = require('express');
 const auth = require('../../middleware/auth');
 const { AgentRegistry } = require('../../models/AgentRegistry');
 const AgentIdentityService = require('../../services/agentIdentityService');
-const { getUserId } = require('./helpers');
+const { getUserId, resolveUsername } = require('./helpers');
 const {
   ManifestValidationError,
   normalizePublishPayload,
@@ -69,7 +69,7 @@ publishRouter.post('/publish', auth, async (req: any, res: any) => {
         registry: 'commonly-community',
         publisher: {
           userId,
-          name: req.user.username,
+          name: await resolveUsername(req),
         },
         categories,
         tags,


### PR DESCRIPTION
Found by following @sprint-review's note on AX entry 42 downstream. Their point: the dual-auth dispatch in `middleware/auth.ts` doesn't just pick an identity, the two branches produce **different shapes**.

```
:51  req.user = { id, username, email, role }   // cm_ API token
:81  req.user = { id }                          // browser JWT
```

Neither errors. So a consumer reading `req.user.username` works on one path and is `undefined` on the other, silently. I censused the consumers of the wide fields on main and two of them have no fallback.

## Fixed here

`registry/publish.ts:72` reads `req.user.username` — not even optional-chained — and `registry/install.ts:221` reads `req.user?.username`. Both feed `publisher.name` straight into an `AgentRegistry.create`. Every publish from a browser session has been persisting `publisher.name: undefined`, which surfaces as an unattributed listing in the marketplace and never fails anything.

`resolveUsername` goes in `routes/registry/helpers.ts` next to `getUserId`, which both writers already import. `routes/marketplace-api.ts` already resolved exactly this way — this is that resolution moved somewhere the other two can reach it, not a fourth copy of it.

## Not fixed, stated

- Rows already carrying a null publisher name are not repaired on update. The update branch doesn't touch `publisher` at all, and backfilling it is a separate decision about whose name goes on an existing listing.
- **`routes/github.ts:146`** gates `GET /api/github/status` on `req.user?.role !== 'admin'` with no fallback, and no browser session carries `role` — so that endpoint answers `403 Admin only` to a real admin. It's a curl/ops endpoint with no frontend caller, so the blast radius is small, but it is live. That line sits inside a hunk of **#809** (open, mine, stale since 2026-08-04), so touching it here would guarantee a conflict; reported on #809 instead.
- `routes/podController.ts:43`, `routes/agentProfile.ts:252` and `routes/marketplace-api.ts:12` all already carry the DB fallback — `agentProfile`'s has a comment citing #1065 as "the third application" of this lesson. This is the fifth and sixth.

## Verification

Negative control — revert `publish.ts` to `req.user.username`:

```
✕ resolves the username on the browser-JWT shape, which carries only { id }
✓ uses the token-supplied username on the cm_ shape without a DB read
✕ persists null rather than undefined when the user cannot be resolved
```

The case that passes either way is exactly the shape that was never broken. Restored: 3 passed. `__tests__/unit/routes` → 86 suites / 511 tests green; `tsc --noEmit` clean.

Per AX entry 42's own rule, the test mocks auth to `next()` **on purpose** and constructs each shape on the request: the subject is the consumer's handling of both shapes, and a test that let the route choose would only ever exercise one of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)