### PR TITLE
docs(ax): entry 42 — the dispatcher picks a shape, not just an identity

### DIFF
--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -2540,6 +2540,34 @@ And the fallback is unconditional: a request with no `cm_agent_` prefix does
 not fail, it takes the human branch and succeeds. Omitting the header is
 indistinguishable, from the response, from supplying it.
 
+**And the same divergence runs one level down, inside `middleware/auth.ts`
+itself** (@sprint-review, 2026-08-23). That middleware is a second dispatcher,
+on a second prefix, and its two branches both assign `req.user` — with
+different shapes:
+
+```ts
+:51  req.user = { id, username, email, role };   // cm_ API token
+:81  req.user = { id };                          // browser JWT
+```
+
+So a consumer reading `req.user.username` or `req.user.role` works on one path
+and is `undefined` on the other, with no error either way. That is not a
+hypothetical: `agentProfile.ts:249` carries a comment calling it "the third
+application" of the lesson, and a census of the wide-field consumers on main
+found two more with no fallback — `registry/publish.ts` persisted
+`publisher.name: undefined` for every browser-session publish (#1211), and
+`github.ts:146` answers `403 Admin only` to a real admin because no browser
+session carries `role`. The entry above names the cause; #1124 shipping inert,
+the term #1127 replaced, and these two are what it produced.
+
+**The generalization is the one worth carrying:** a dispatcher that picks an
+identity is easy to reason about, because you can ask which identity you are.
+A dispatcher that picks a *shape* is not, because the failure is a field that
+is merely absent — and absence is the one thing neither branch reports. Count
+the assignment sites, not the branches: `grep -n 'req.user = ' backend` returns
+two lines, and they are not the same object.
+
+
 **What that costs a test author.** Every case in
 `tasksApi.updateRenewsLease.test.js` went through the human mock, so
 `req.user` was always populated and the agent branch had never run — across


### PR DESCRIPTION
@sprint-review's amendment to entry 42, plus the census it prompted.

Entry 42 documented the `/api/v1/tasks` dispatcher choosing between `req.user` and `req.agentUser`. Their addition is that the same divergence runs one level down, inside `middleware/auth.ts` itself — a second dispatcher, on a second prefix, whose two branches *both* assign `req.user`, with different shapes:

```
:51  req.user = { id, username, email, role }   // cm_ API token
:81  req.user = { id }                          // browser JWT
```

So a consumer reading `req.user.username` works on one path and is `undefined` on the other, with no error either way. Their framing — "the entry names the cause; #1124 shipping inert and the term #1127 replaced are what it produced" — is the amendment.

I censused the wide-field consumers on main before writing it down, and two are still unguarded: `registry/publish.ts` persisted `publisher.name: undefined` for every browser-session publish (fixed in **#1211**), and `github.ts:146` answers `403 Admin only` to a real admin because no browser session carries `role` (reported on #809, whose hunk contains that line). `agentProfile.ts:249` already carries a comment calling this "the third application" of the #1065 lesson — these are the fourth and fifth.

The generalization added at the end is the part worth keeping: a dispatcher that picks an **identity** is easy to reason about, because you can ask which identity you are. One that picks a **shape** is not, because the failure is a field that is merely absent, and absence is the one thing neither branch reports.

## Placement

Inserted mid-entry, after the "different request shapes" paragraph, rather than at the end of entry 42 — which is the file's last line and the anchor seven open PRs all append at. Verified: clean against #1122, #1132, #1142, #1143, #1171, #1202, #1204. Positive control — a rival append at that tail anchor produces `CONFLICT` against #1204 — so the nine-clean result is sensitivity-backed rather than an instrument that never fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)