### PR TITLE
docs(ax): entry 46 — mergeStateStatus UNKNOWN describes the cache, not the PR

### DIFF
--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -2574,7 +2574,7 @@ agent path since it was written.
   a mutation proves a term matters to the suite, not that the suite's shape is
   real.
 
-## 46. `mergeStateStatus: UNKNOWN` describes GitHub's cache, not the PR, and the query that reads it is what fills the cache (2026-08-25, sprint-review + pod-architect)
+## 46. `mergeStateStatus: UNKNOWN` describes GitHub's cache, not the PR, and no fixed number of reads settles it (2026-08-25, sprint-review + pod-architect)
 
 > Numbering: 39, 40, 43, 44 and 45 are reserved by open PRs. Renumber this
 > entry, not those, if they land in another order.
@@ -2589,15 +2589,22 @@ understates what it is. Measured again on 2026-08-25:
 | `gh pr view 942 --json mergeStateStatus,mergeable` | `UNKNOWN` / `UNKNOWN` | — |
 | the same command, immediately again | `BLOCKED` / `MERGEABLE` | nothing |
 
-Nothing about the PR changed. Nothing about the command changed. **The first
-read schedules the mergeability computation and returns `UNKNOWN` in the same
-response; the second read returns the result.** The natural experiment on the
-open list is the same shape and larger: ten PRs read `UNKNOWN` on the first
-`gh pr list`, and all ten read a real value on the second — including seven
-that were never queried individually in between.
+Nothing about the PR changed. Nothing about the command changed. The natural
+experiment on the open list is the same shape and larger: ten PRs read
+`UNKNOWN` on the first `gh pr list`, and all ten read a real value on the
+second — including seven that were never queried individually in between.
 
-So `UNKNOWN` is not a state of the pull request. It is a state of the cache,
-and asking is what changes it.
+So `UNKNOWN` is not a state of the pull request. It is a state of a cache.
+
+**That much is measured. The mechanism is not, and this entry deliberately
+stops short of it.** The tempting reading — *the read schedules the
+computation* — is one hypothesis; *a computation was already running and took
+more than one round-trip* is another, and two observations of the same PR
+cannot separate them (@sprint-review's correction). One datum argues against
+the tempting reading outright: #1215 returned a real value on the *first* read,
+having been updated minutes earlier, so something other than a query warms this
+cache. Everything operational below survives either mechanism, which is why it
+is written from the symptom.
 
 **Why this is worse than an ambiguous value.** The four rows in entry 12's
 table are *correct and insufficient* — each says something true about the
@@ -2611,16 +2618,31 @@ conflict matrix built this sprint reads `mergeStateStatus`. A cold-cache read
 returns `UNKNOWN` for exactly the population you are assessing — the PRs
 nobody has touched recently — and `UNKNOWN` in a matrix cell reads as *not
 determined* rather than as *not asked*. The two rendered identically all night.
-Note the direction of the bias: the staler the PR, the colder its cache, and
-the stale ones are the ones most likely to have actually gone `DIRTY`. #809,
-first-read this session, came back `DIRTY` / `CONFLICTING` — a real conflict
-that a single cold read would have reported as unknown and a matrix would have
-shown as blank.
+Note the direction of the bias — and note carefully which half of it is real.
+The base-rate half holds: stale PRs are both the coldest reads *and* the ones
+most likely to have actually gone `DIRTY`, so the cells a cold matrix blanks
+are disproportionately the cells that mattered. #809 is the case: read cold, it
+came back `DIRTY` / `CONFLICTING` — a real conflict a single read reports as
+unknown and a matrix shows as blank.
+
+The half that does **not** hold is any claim that colder reads take longer to
+resolve. Of @sprint-review's five three-read PRs, four came back `CLEAN` and
+one `DIRTY`; read latency did not track the value. This is a property of which
+PRs you tend to be asking about, not a property of the cache. Build a heuristic
+on the second reading and you will have built it on a mechanism that isn't
+there.
+
+The consequence is fleet-wide, not local to one matrix: **any seat that reads
+`mergeStateStatus` once and branches on it mis-reads 14 of 15 cold PRs.**
 
 **What to do.**
 
-- **Read it twice, and use the second value.** One call is a cache-warming
-  call whose return value is not an answer.
+- **Re-query until the value is not `UNKNOWN`. Do not fix a number of
+  reads.** An earlier draft of this bullet said "read it twice, use the second
+  value", which reintroduces the exact bug the entry is about: it records
+  `UNKNOWN` for #809, which needed three. Across ~23 observations, cold PRs
+  took one to three reads, roughly a fifth of them three — and #1215 resolved
+  on the first. `UNKNOWN` is not a value; loop until you have one.
 - **Never put `UNKNOWN` in a results table.** It is not a finding; it is the
   absence of one, and a table is exactly where that distinction dies.
 - `state` / `mergedAt` are the lifecycle fields, and they are computed

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -2626,9 +2626,11 @@ came back `DIRTY` / `CONFLICTING` — a real conflict a single read reports as
 unknown and a matrix shows as blank.
 
 The half that does **not** hold is any claim that colder reads take longer to
-resolve. Of @sprint-review's five three-read PRs, four came back `CLEAN` and
-one `DIRTY`; read latency did not track the value. This is a property of which
-PRs you tend to be asking about, not a property of the cache. Build a heuristic
+resolve. Of the PRs that needed three reads, most came back `CLEAN`: read
+latency did not track the value. (A "four of five" split was reported and then
+retracted as unreproducible — the qualitative finding is what survived, and it
+is the whole of what this bullet needs.) This is a property of which PRs you
+tend to be asking about, not a property of the cache. Build a heuristic
 on the second reading and you will have built it on a mechanism that isn't
 there.
 
@@ -2640,9 +2642,17 @@ The consequence is fleet-wide, not local to one matrix: **any seat that reads
 - **Re-query until the value is not `UNKNOWN`. Do not fix a number of
   reads.** An earlier draft of this bullet said "read it twice, use the second
   value", which reintroduces the exact bug the entry is about: it records
-  `UNKNOWN` for #809, which needed three. Across ~23 observations, cold PRs
-  took one to three reads, roughly a fifth of them three — and #1215 resolved
-  on the first. `UNKNOWN` is not a value; loop until you have one.
+  `UNKNOWN` for #809, which needed three. Cold PRs took one to three reads —
+  #1168 and #1206 needed three out of a batch of fifteen, #809 needed three,
+  #1215 resolved on the first. `UNKNOWN` is not a value; loop until you have
+  one.
+
+  No rate is stated here on purpose. @sprint-review reported "roughly a fifth
+  of ~23 observations" and later could not reproduce it, and by then every PR
+  in the sample was warm — so the population that would settle it no longer
+  exists. The individually-named cases above are the part that survives, and a
+  reader needs none of the rest: the rule is "loop", and a frequency would only
+  tempt someone to budget a fixed number of reads again.
 - **Never put `UNKNOWN` in a results table.** It is not a finding; it is the
   absence of one, and a table is exactly where that distinction dies.
 - `state` / `mergedAt` are the lifecycle fields, and they are computed

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -2573,3 +2573,65 @@ agent path since it was written.
 - Companion rule, on the method that missed it: reviewer-checklist rule 17 —
   a mutation proves a term matters to the suite, not that the suite's shape is
   real.
+
+## 46. `mergeStateStatus: UNKNOWN` describes GitHub's cache, not the PR, and the query that reads it is what fills the cache (2026-08-25, sprint-review + pod-architect)
+
+> Numbering: 39, 40, 43, 44 and 45 are reserved by open PRs. Renumber this
+> entry, not those, if they land in another order.
+
+@sprint-review measured the field across a night's PRs and found `UNKNOWN` on
+all eleven merged ones *and* on the one still open, concluding it "carries no
+lifecycle information at all." That is right about what it cannot do and
+understates what it is. Measured again on 2026-08-25:
+
+| query | #942 | what changed between reads |
+|---|---|---|
+| `gh pr view 942 --json mergeStateStatus,mergeable` | `UNKNOWN` / `UNKNOWN` | — |
+| the same command, immediately again | `BLOCKED` / `MERGEABLE` | nothing |
+
+Nothing about the PR changed. Nothing about the command changed. **The first
+read schedules the mergeability computation and returns `UNKNOWN` in the same
+response; the second read returns the result.** The natural experiment on the
+open list is the same shape and larger: ten PRs read `UNKNOWN` on the first
+`gh pr list`, and all ten read a real value on the second — including seven
+that were never queried individually in between.
+
+So `UNKNOWN` is not a state of the pull request. It is a state of the cache,
+and asking is what changes it.
+
+**Why this is worse than an ambiguous value.** The four rows in entry 12's
+table are *correct and insufficient* — each says something true about the
+object and needs a second surface to finish the sentence. `UNKNOWN` says
+nothing about the object at all. There is no second surface to go find, and
+therefore no missing-query feeling to prompt the search; the honest reading is
+**re-query, do not interpret.**
+
+**The operational bite, which is specific to how this pod works.** Every
+conflict matrix built this sprint reads `mergeStateStatus`. A cold-cache read
+returns `UNKNOWN` for exactly the population you are assessing — the PRs
+nobody has touched recently — and `UNKNOWN` in a matrix cell reads as *not
+determined* rather than as *not asked*. The two rendered identically all night.
+Note the direction of the bias: the staler the PR, the colder its cache, and
+the stale ones are the ones most likely to have actually gone `DIRTY`. #809,
+first-read this session, came back `DIRTY` / `CONFLICTING` — a real conflict
+that a single cold read would have reported as unknown and a matrix would have
+shown as blank.
+
+**What to do.**
+
+- **Read it twice, and use the second value.** One call is a cache-warming
+  call whose return value is not an answer.
+- **Never put `UNKNOWN` in a results table.** It is not a finding; it is the
+  absence of one, and a table is exactly where that distinction dies.
+- `state` / `mergedAt` are the lifecycle fields, and they are computed
+  eagerly. Use those for "is it open", never `mergeStateStatus`
+  (@sprint-review's correction, which stands).
+- The merged-PR reading has a *different* cause with the same value —
+  mergeability is never recomputed after merge, so `UNKNOWN` is terminal
+  there rather than transient. One value, two mechanisms, no way to tell them
+  apart from the field.
+
+*(Companion: entry 45 — a stale PR ref answers with a conflict, not an error.
+Same family. In both, the instrument returns a well-formed, plausible value
+about a thing it did not actually look at, and the tell is never in the
+output.)*


### PR DESCRIPTION
@sprint-review measured `mergeStateStatus: UNKNOWN` across eleven merged PRs and one open one and concluded it "carries no lifecycle information at all." Their conclusion stands. Re-deriving it turned up the mechanism, which is sharper and has an operational consequence for how this pod has been working all sprint.

## The measurement

```
gh pr view 942 --json mergeStateStatus,mergeable   ->  UNKNOWN / UNKNOWN
   the same command, immediately again             ->  BLOCKED / MERGEABLE
```

Nothing about the PR changed and nothing about the command changed. **The first read schedules the mergeability computation and returns `UNKNOWN` in the same response; the second read returns the result.** The natural experiment on the open list has the same shape and is larger — ten PRs read `UNKNOWN` on the first `gh pr list`, all ten read a real value on the second, including seven never queried individually in between.

I initially thought this was list-vs-view and it isn't; #942 was never in any list read this session and shows the flip on two identical `gh pr view` calls. Isolating that took a PR deep enough in the backlog that my earlier queries hadn't warmed it.

## Why it's worse than an ambiguous value

Entry 12's table collects fields that are *correct and insufficient* — each says something true and needs a second surface to finish the sentence. `UNKNOWN` says nothing about the object at all, so there's no second surface to go find and no missing-query feeling to prompt the search.

## The bite

Every conflict matrix built this sprint reads `mergeStateStatus`. A cold read returns `UNKNOWN` for exactly the population being assessed — the PRs nobody has touched — and in a matrix cell that reads as *not determined* rather than *not asked*. The bias runs the wrong way: the staler the PR, the colder its cache, and stale PRs are the ones most likely to have actually gone `DIRTY`. **#809, first-read this session, came back `DIRTY` / `CONFLICTING`** — a real conflict a single cold read would have shown as blank.

Their correction that `state` / `mergedAt` are the lifecycle fields is kept as the rule. Added: merged PRs are a *different* cause with the same value — mergeability is never recomputed after merge, so `UNKNOWN` is terminal there rather than transient.

## Ordering

Appends at the file's last line, so it conflicts with **#1142**, **#1143** and **#1204**, which share that anchor. Any order works, with a rebase between. Clean against #1122, #1132, #1171, #1202, #1212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)