### PR TITLE
fix: add branded static 404 page

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -6,6 +6,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Keep the correct HTTP status while giving people a useful recovery path.
+    # `internal` prevents /404.html itself from becoming a crawlable public URL.
+    error_page 404 /404.html;
+    location = /404.html {
+        internal;
+    }
+
     # Serve pre-rendered public route directories and real files. Unknown
     # public URLs must return a real 404: sending the homepage with a 200
     # creates soft-404 signals for crawlers and a misleading page for people.

--- a/frontend/public/404.html
+++ b/frontend/public/404.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <meta name="theme-color" content="#0b1220" />
+    <title>Page not found | Commonly</title>
+    <style>
+      :root { color-scheme: dark; }
+      * { box-sizing: border-box; }
+      body {
+        align-items: center;
+        background: #0b1220;
+        color: #e2e8f0;
+        display: flex;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        justify-content: center;
+        margin: 0;
+        min-height: 100vh;
+        padding: 32px;
+      }
+      main { max-width: 640px; text-align: center; }
+      .eyebrow { color: #7dd3fc; font-size: .78rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+      h1 { font-size: clamp(2.25rem, 7vw, 4.5rem); letter-spacing: -.045em; line-height: 1.03; margin: 16px 0; }
+      p { color: #94a3b8; font-size: 1.125rem; line-height: 1.7; margin: 0 auto; max-width: 540px; }
+      nav { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; margin-top: 32px; }
+      a { border: 1px solid #334155; border-radius: 999px; color: #e2e8f0; font-weight: 700; padding: 11px 18px; text-decoration: none; }
+      a:first-child { background: #7dd3fc; border-color: #7dd3fc; color: #062032; }
+      a:hover { border-color: #7dd3fc; }
+      a:focus-visible { outline: 3px solid #facc15; outline-offset: 4px; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="eyebrow">404 · Commonly</div>
+      <h1>We couldn’t find that page</h1>
+      <p>It may have moved, or the link may be out of date. Start from Commonly’s homepage or browse the guides for practical ways to work with AI agents.</p>
+      <nav aria-label="Recovery links">
+        <a href="/">Go to homepage</a>
+        <a href="/guides/">Browse guides</a>
+      </nav>
+    </main>
+  </body>
+</html>

--- a/frontend/scripts/nginx-routing.test.mjs
+++ b/frontend/scripts/nginx-routing.test.mjs
@@ -8,10 +8,16 @@ const frontendDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 test('unknown public routes are real 404s while documented app routes retain SPA fallback', async () => {
   const config = await readFile(resolve(frontendDir, 'nginx.conf'), 'utf8');
+  const notFoundPage = await readFile(resolve(frontendDir, 'public/404.html'), 'utf8');
 
   assert.match(config, /location \/ \{\s*try_files \$uri \$uri\/ =404;/s);
+  assert.match(config, /error_page\s+404\s+\/404\.html;/);
+  assert.match(config, /location = \/404\.html\s*\{\s*internal;/s);
   assert.doesNotMatch(config, /error_page\s+404\s+\/index\.html/);
   assert.match(config, /location ~ \^\/\(\?:v2\(\?:\/\|\$\).*try_files \$uri \$uri\/ \/index\.html;/s);
   assert.match(config, /login\/\?\$/);
   assert.match(config, /pods\(\?:\/\|\$\)/);
+  assert.match(notFoundPage, /<title>Page not found \| Commonly<\/title>/);
+  assert.match(notFoundPage, /<h1>We couldn’t find that page<\/h1>/);
+  assert.match(notFoundPage, /href="\/guides\/"/);
 });


### PR DESCRIPTION
## Summary
- replace the default Nginx error screen with a static Commonly-branded 404 page
- preserve HTTP 404 for unknown public routes while keeping the known SPA fallback
- provide recovery links to the homepage and guides hub; prevent `/404.html` from being crawlable directly

## Verification
- `node --test scripts/nginx-routing.test.mjs scripts/generate-seo-pages.test.mjs`
- `npm run build`
- Nginx container: unknown root/guide routes return 404 + branded HTML, static guide remains 200, `/v2/agents` retains SPA fallback
- Browser snapshot and screenshot of the rendered 404