### PR TITLE
fix(scheduler): drop the activity-hint query nothing has read since March

### DIFF
--- a/backend/__tests__/unit/models/pg/message.activityHint.test.js
+++ b/backend/__tests__/unit/models/pg/message.activityHint.test.js
@@ -1,0 +1,68 @@
+/**
+ * Message.findActivityHint — metadata only, one query.
+ *
+ * Why this exists: for five months this ran a SECOND query per pod per
+ * heartbeat tick — the three most recent messages, joined to `users` for a
+ * username — whose result nothing in the repo read. 089d0058 shipped those
+ * rows into `activityHint.recentMessages` for the model; 8608060d removed the
+ * field 23 minutes later from the CONSUMER only, and the producer kept going.
+ *
+ * The dead join was found by @sprint-review (57711) auditing this query for a
+ * missing column. Nothing failed while it was there, which is exactly why it
+ * survived — a query with no reader cannot break. These tests give it one.
+ */
+
+jest.mock('../../../../config/db-pg', () => ({
+  pool: { query: jest.fn() },
+}));
+
+const { pool } = require('../../../../config/db-pg');
+const Message = require('../../../../models/pg/Message');
+
+const POD = '6a507c9b792f1ed2cbfec648';
+const SINCE = new Date('2026-08-25T06:00:00.000Z');
+
+describe('Message.findActivityHint', () => {
+  beforeEach(() => {
+    pool.query.mockReset();
+    pool.query.mockResolvedValue({ rows: [{ count: '7', last_at: SINCE }], rowCount: 1 });
+  });
+
+  it('issues exactly one query', async () => {
+    await Message.findActivityHint(POD, SINCE);
+    expect(pool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('that query is the aggregate, with no join to users', async () => {
+    await Message.findActivityHint(POD, SINCE);
+    const [sql, params] = pool.query.mock.calls[0];
+    expect(sql).toMatch(/COUNT\(\*\)/);
+    expect(sql).toMatch(/MAX\(created_at\)/);
+    expect(params).toEqual([POD, SINCE]);
+    // Across EVERY call, not just calls[0]. The dead query ran in a
+    // Promise.all beside the aggregate, so the aggregate was still first —
+    // asserting on calls[0] alone stayed green against the exact code this
+    // test exists to reject, and was the one assertion of five that the
+    // negative control did not redden.
+    const everySql = pool.query.mock.calls.map(([q]) => q).join('\n');
+    expect(everySql).not.toMatch(/JOIN users/);
+    expect(everySql).not.toMatch(/LIMIT 3/);
+  });
+
+  it('returns count and lastAt, and nothing per-message', async () => {
+    const hint = await Message.findActivityHint(POD, SINCE);
+    expect(hint).toEqual({ count: 7, lastAt: SINCE });
+  });
+
+  it('a missing podId short-circuits without touching the pool', async () => {
+    const hint = await Message.findActivityHint(undefined, SINCE);
+    expect(hint).toEqual({ count: 0, lastAt: null });
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  it('a query failure degrades to a zero hint rather than throwing', async () => {
+    // The heartbeat's pod-selection pass must not die because the hint did.
+    pool.query.mockRejectedValueOnce(new Error('connection terminated'));
+    await expect(Message.findActivityHint(POD, SINCE)).resolves.toEqual({ count: 0, lastAt: null });
+  });
+});

--- a/backend/models/pg/Message.ts
+++ b/backend/models/pg/Message.ts
@@ -41,7 +41,6 @@ interface FormattedMessage extends MessageRow {
 interface ActivityHintResult {
   count: number;
   lastAt: unknown;
-  recentMessages: Array<{ id: string; username: string; content: string; createdAt: unknown }>;
 }
 
 interface PodActivityEntry {
@@ -439,43 +438,41 @@ class Message {
     return { deleted };
   }
 
+  /**
+   * Counts and a last-seen stamp for the heartbeat's pod-selection pass.
+   *
+   * Metadata ONLY, and deliberately so. This used to run a second query — the
+   * three most recent messages, joined to `users` for a username — because
+   * 089d0058 shipped them into `activityHint.recentMessages` for the model to
+   * read. 8608060d removed that field 23 minutes later ("agents fetch chat
+   * messages themselves via commonly_get_messages"), but removed it only from
+   * the CONSUMER. The producer kept running the join, per pod, per heartbeat
+   * tick, for five months, and nothing in the repo ever read the result.
+   *
+   * Found by @sprint-review (57711) auditing this query for a MISSING column
+   * (`thread_root_id`). The right answer was that adding one would have been
+   * adding a field to dead code. Worth remembering when a projection looks
+   * incomplete: check that it has a reader before deciding what it owes them.
+   */
   static async findActivityHint(podId: unknown, since: unknown): Promise<ActivityHintResult> {
     const podIdStr = (podId as { toString(): string } | undefined)?.toString();
-    if (!podIdStr) return { count: 0, lastAt: null, recentMessages: [] };
+    if (!podIdStr) return { count: 0, lastAt: null };
     try {
-      const [statsResult, recentResult] = await Promise.all([
-        (pool as PgPool).query(
-          `SELECT COUNT(*) AS count, MAX(created_at) AS last_at
+      const statsResult = await (pool as PgPool).query(
+        `SELECT COUNT(*) AS count, MAX(created_at) AS last_at
            FROM messages
-           WHERE pod_id = $1 AND created_at >= $2 AND message_type != 'system'`,
-          [podIdStr, since],
-        ),
-        (pool as PgPool).query(
-          `SELECT m.id, m.content, u.username, m.created_at
-           FROM messages m
-           LEFT JOIN users u ON m.user_id = u._id
-           WHERE m.pod_id = $1 AND m.created_at >= $2 AND m.message_type != 'system'
-           ORDER BY m.created_at DESC LIMIT 3`,
-          [podIdStr, since],
-        ),
-      ]);
+          WHERE pod_id = $1 AND created_at >= $2 AND message_type != 'system'`,
+        [podIdStr, since],
+      );
       const stats = (statsResult.rows[0] || {}) as { count?: string; last_at?: unknown };
-      const recentMessages = (recentResult.rows as Array<{ id?: unknown; username?: string; content?: string; created_at?: unknown }>)
-        .slice().reverse().map((m) => ({
-          id: m.id?.toString() || '',
-          username: m.username || 'unknown',
-          content: (m.content || '').slice(0, 120),
-          createdAt: m.created_at,
-        }));
       return {
         count: parseInt(String(stats.count || 0), 10),
         lastAt: stats.last_at || null,
-        recentMessages,
       };
     } catch (error) {
       const e = error as { message?: string };
       console.error('Error in findActivityHint:', e.message);
-      return { count: 0, lastAt: null, recentMessages: [] };
+      return { count: 0, lastAt: null };
     }
   }
 


### PR DESCRIPTION
## What

`Message.findActivityHint` issued **two** queries per pod per heartbeat tick. The second one — the three most recent messages, `LEFT JOIN`ed to `users` for a username — has had **no reader anywhere in the repo since 2026-03-07**.

## Why it survived five months

- `089d0058` added it: the heartbeat's Mongo-backed query returned nothing, so "agents never saw pod chat activity". The rows went into `activityHint.recentMessages` for the model to read.
- `8608060d` removed `recentMessages` **23 minutes later** — agents fetch chat themselves via `commonly_get_messages` — but removed it from the **consumer** only. `buildHeartbeatActivityHint` reads `.count` and `.lastAt`; the producer kept running the join.

A query with no reader cannot break, which is why nothing ever flagged it.

## How it was found

Sideways. @sprint-review audited this query for a **missing** column — `thread_root_id`, which the two real read paths (`findById`, `findByPodId`) carry and this one does not. The right answer was that adding it would have been adding a field to dead code.

Worth generalizing: when a projection looks incomplete, check that it has a reader before deciding what it owes them.

## Tests

Five guards where there were none. One note on the control, because it caught a weak assertion:

The join/`LIMIT 3` assertion matches across **every** recorded call rather than `calls[0]`. The dead query ran inside a `Promise.all` beside the aggregate, so the aggregate was still first — the `calls[0]` form stayed green against the exact code the test exists to reject, and was the one assertion of five the negative control did not redden.

Corrected: all five fail against the pre-fix model, all five pass after. `__tests__/unit/models/pg/` 14/14, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)