### PR TITLE
docs(cli): mark the surviving `limit: 10` as a read, not a claim

### DIFF
--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -803,6 +803,12 @@ export const performRun = ({
     // suppress a genuine reply (#757).
     const snapshotMessages = async () => {
       try {
+        // READ limit, not a claim. Since #1166 this is the only `limit: 10`
+        // left in the file, and the one it is easy to mistake it for — the
+        // events fetch — was reduced to 1 precisely because fetching an
+        // event CLAIMS it. This endpoint claims nothing: it returns pod
+        // messages so the echo check can see what is already there, and
+        // asking for ten costs ten rows.
         const { messages = [] } = await client.get(
           `/api/agents/runtime/pods/${eventPodId}/messages`, { limit: 10 },
         );


### PR DESCRIPTION
## What

A comment. No behaviour change.

@sprint-review's observation (57766): after #1166, `cli/src/commands/agent.js:807` is the **only** `limit: 10` left in the file — and it's harmless. But the reason it's harmless lives four hundred lines away, so anyone who greps the constant has to re-derive the distinction from scratch.

```
:807   client.get(`/api/agents/runtime/pods/${id}/messages`, { limit: 10 })  → messages
:1198  client.get('/api/agents/runtime/events',              { limit: 1  })  → events
```

Two identical strings, opposite significance, no local marker. The events fetch went to 1 because **fetching an event claims it**. The messages fetch claims nothing — it feeds the echo check, and ten rows cost ten rows.

## Why a comment and not a test

There is no wrong behaviour to pin. The failure mode is a reader's question, and the answer belongs where the question gets asked.

CLI suite: 24 suites, 335 passed / 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)