### PR TITLE
docs(agents): cite installedBy's writers by symbol, and stop implying five

### DIFF
--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -1126,13 +1126,25 @@ const enqueueWakeOnMessage = async ({
   //
   // NOT `installedBy`. @sprint-review's blocker (57291) was right and the
   // comment that used to sit here was wrong. `installedBy` is written with
-  // two different identities depending on who installed the agent — the bot
-  // itself at agentAutoJoinService:80, podWriteAccessService:48 and three
-  // sites in agentsRuntime, but the HUMAN installer at podController:119,
-  // personaHireService:93, podCurationService:147, authController:201 and
-  // agentProfile:259 (AgentRun.ts:65 calls it "the hiring user" outright).
-  // The schema declares a bare ObjectId with no ref, so nothing at the type
-  // level distinguishes them.
+  // two different identities depending on who installed the agent — the BOT
+  // itself in `agentAutoJoinService`, `podWriteAccessService` and three
+  // sites in `agentsRuntime`, but the HUMAN installer in `podController`,
+  // `authController`, `personaHireService`, `podCurationService`,
+  // `agentProfile`, `registry/install`, `registry/admin`, `dmService`
+  // (twice) — and in THIS file, at the auto-install inside
+  // `resolveMentionTarget`, which writes `senderUserId`. `AgentRun.ts` calls
+  // the field "the hiring user" outright. The schema declares a bare
+  // ObjectId with no ref, so nothing at the type level distinguishes them.
+  //
+  // No line numbers and no total, deliberately, per the rule #1165 earned:
+  // cite by symbol, never by a position the next edit rewrites silently. An
+  // earlier draft of this comment listed five human-side sites as though
+  // that were the set; there are at least ten, and @sprint-review's recount
+  // (57771) found the gap only because the number had been frozen into
+  // prose. `grep -rn 'installedBy:' backend | grep -v __tests__` is the
+  // reader that stays correct — note it also returns queries
+  // (`agentMemoryView`, `approvalActionService`) and propagations of an
+  // existing value, which are not writes of an identity.
   //
   // Keying on it would have read a human-installed agent's thread state off
   // its INSTALLER's row: the human's mute would silence the agent, and the

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -1131,7 +1131,8 @@ const enqueueWakeOnMessage = async ({
   // sites in `agentsRuntime`, but the HUMAN installer in `podController`,
   // `authController`, `personaHireService`, `podCurationService`,
   // `agentProfile`, `registry/install`, `registry/admin`, `dmService`
-  // (twice) — and in THIS file, at the auto-install inside
+  // (twice), `approvalActionService` (twice, via `$setOnInsert` of the
+  // stored `ownerUserId`) — and in THIS file, at the auto-install inside
   // `resolveMentionTarget`, which writes `senderUserId`. `AgentRun.ts` calls
   // the field "the hiring user" outright. The schema declares a bare
   // ObjectId with no ref, so nothing at the type level distinguishes them.
@@ -1139,12 +1140,15 @@ const enqueueWakeOnMessage = async ({
   // No line numbers and no total, deliberately, per the rule #1165 earned:
   // cite by symbol, never by a position the next edit rewrites silently. An
   // earlier draft of this comment listed five human-side sites as though
-  // that were the set; there are at least ten, and @sprint-review's recount
-  // (57771) found the gap only because the number had been frozen into
-  // prose. `grep -rn 'installedBy:' backend | grep -v __tests__` is the
+  // that were the set; the enumeration above reaches twelve and is still a
+  // floor, not a census. @sprint-review's recount (57771) found the gap only
+  // because the number had been frozen into prose. `grep -rn 'installedBy:' backend | grep -v __tests__` is the
   // reader that stays correct — note it also returns queries
-  // (`agentMemoryView`, `approvalActionService`) and propagations of an
-  // existing value, which are not writes of an identity.
+  // (`agentMemoryView`, `users`, `registry/install`'s `$ne` filter) and
+  // propagations of an existing value (`registry/provision`,
+  // `stalledConnectService`, `registry/helpers`), neither of which writes an
+  // identity. `approvalActionService` does BOTH, which is why an earlier
+  // draft of this line filed it under queries alone.
   //
   // Keying on it would have read a human-installed agent's thread state off
   // its INSTALLER's row: the human's mute would silence the agent, and the

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -803,6 +803,12 @@ export const performRun = ({
     // suppress a genuine reply (#757).
     const snapshotMessages = async () => {
       try {
+        // READ limit, not a claim. Since #1166 this is the only `limit: 10`
+        // left in the file, and the one it is easy to mistake it for — the
+        // events fetch — was reduced to 1 precisely because fetching an
+        // event CLAIMS it. This endpoint claims nothing: it returns pod
+        // messages so the echo check can see what is already there, and
+        // asking for ten costs ten rows.
         const { messages = [] } = await client.get(
           `/api/agents/runtime/pods/${eventPodId}/messages`, { limit: 10 },
         );


### PR DESCRIPTION
## What

Comment only. No behaviour change.

@sprint-review recounted the `installedBy` writers (57771). **The bot half holds at exactly five.** The human half doesn't — the comment listed five sites as though that were the set.

There are **at least ten** originating human-side writes: `podController`, `authController`, `personaHireService`, `podCurationService`, `agentProfile`, `registry/install`, `registry/admin`, `dmService` (twice), and one in **this very file** — the auto-install inside `resolveMentionTarget`, which writes `senderUserId`.

## Two changes

**Line numbers → symbols.** Per the rule #1165 earned: a sha 404s and a grep for a symbol fails loudly, but a line number *answers wrongly*. Five of the six positions this comment cited had already moved.

**The count is now a floor, with the grep that reproduces it.** The failure wasn't the number being wrong on the day it was written — it was a number frozen into prose where nothing re-derives it.

## Residue, stated in the comment

`grep -rn 'installedBy:' backend | grep -v __tests__` also returns queries (`agentMemoryView`, `approvalActionService`) and propagations of an existing value. Neither writes an identity. Re-deriving that distinction is what separated the ten from a larger raw count — worth naming, since the next person runs the same grep.

## Note for whoever merges

Touches the same comment block as #1216, a few lines apart. Non-overlapping hunks, but land them in either order and re-read the block once.

`agentMentionService` suite green, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)