### PR TITLE
test(threading): the agreement set has two members, and only one was pinned

### DIFF
--- a/backend/__tests__/unit/models/threadRootResolver.test.js
+++ b/backend/__tests__/unit/models/threadRootResolver.test.js
@@ -67,6 +67,30 @@ describe('explicit, the in-thread post shape', () => {
   test('explicit wins over derivation when both agree', async () => {
     expect(await resolveThreadRoot({ podId: POD, replyToMessageId: 101, threadRootId: 100 })).toBe(100);
   });
+
+  // @sprint-review 56879. "Agree" is a set with two members and this file only
+  // held one: above, the parent is a reply INSIDE the thread. The other member
+  // is the parent BEING the root, and it is the one V2PodChat's handleSend
+  // comment is written about, because it is the only shape where the reply
+  // edge pings the ROOT's author rather than some mid-thread author.
+  //
+  // It is also the one the resolver structurally cannot refuse. derived is
+  // COALESCE(parent.thread_root_id, parent.id), and a root's thread_root_id is
+  // NULL, so derived falls through to parent.id — which IS the named root. The
+  // two statements are equal by construction; thread_root_mismatch can never
+  // fire here no matter what the client sends. Nothing server-side stops it,
+  // so the client rule is the only thing that does, and this test is what
+  // makes that dependency visible rather than assumed.
+  test('replying to the root while aimed at its thread: accepted, and unrefusable', async () => {
+    expect(await resolveThreadRoot({ podId: POD, replyToMessageId: 100, threadRootId: 100 })).toBe(100);
+  });
+
+  test('CONTROL: the same pair one message over DOES disagree and 400s', async () => {
+    // Proves the acceptance above is the COALESCE fall-through and not a
+    // resolver that waves through any pair naming the same pod.
+    await expect(resolveThreadRoot({ podId: POD, replyToMessageId: 100, threadRootId: 200 }))
+      .rejects.toMatchObject({ code: 'thread_root_mismatch' });
+  });
 });
 
 describe('validation — each of these is a 400, not a silent choice', () => {

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -860,8 +860,20 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
       // It would not: resolveThreadRoot 400s only when the two DISAGREE
       // (thread_root_mismatch) and accepts them when they agree. An in-thread
       // post must carry no addressing edge because a reply edge pings the
-      // root's author (@ux-lead 56879) — that is the rule this enforces, and
-      // it is the client's to keep.
+      // author of whatever it points at (@ux-lead 56879) — that is the rule
+      // this enforces, and it is the client's to keep.
+      //
+      // "Agree" is a set, not a point: the backend accepts the pair whenever
+      // explicit === COALESCE(parent.thread_root_id, parent.id), i.e. whenever
+      // the parent is anywhere IN the thread being aimed at. Two members, and
+      // they differ in WHO gets pinged, because resolveImplicitReplyTarget
+      // resolves the author of replyToMessageId — the parent, not the root:
+      //   parent mid-thread (reply 101 in thread 100) -> pings 101's author
+      //   parent IS the root (replyTo 100, root 100)  -> pings the root's author
+      // Only the second collapses onto "the root's author", which is why that
+      // is the shape this comment is really about — and it is structurally
+      // unrefusable: a root's COALESCE falls through to its own id, so the two
+      // statements can never disagree. @sprint-review 56879.
       const created = await sendMessage(
         text,
         'text',


### PR DESCRIPTION
From @sprint-review's read of the `handleSend` invariant note (56879).

`resolveThreadRoot` accepts `replyToMessageId` + `threadRootId` together whenever `explicit === COALESCE(parent.thread_root_id, parent.id)` — whenever the parent is anywhere **in** the thread being aimed at. That is a set with two members, and they differ in who gets pinged, because `resolveImplicitReplyTarget` resolves the author of `replyToMessageId` (the parent), not the root:

| shape | accepted | pinged |
|---|---|---|
| parent mid-thread — `replyTo 101`, `root 100` | yes | 101's author |
| parent **is** the root — `replyTo 100`, `root 100` | yes | the root's author |

`threadRootResolver.test.js` held only the first (`explicit wins over derivation when both agree`, seeded with 101 = a reply inside thread 100).

**The second is the one worth having.** It is the shape `V2PodChat`'s `handleSend` comment is written about — the only one where the reply edge pings the *root's* author — and the resolver **structurally cannot refuse it**: a root's `thread_root_id` is NULL, so `derived` falls through to `parent.id`, which is the named root. The two statements are equal by construction and `thread_root_mismatch` can never fire. `aimAtThread`/`aimAtMessage` clearing each other is the only thing preventing it, and nothing made that dependency visible.

Adds the accept case and a CONTROL one message over (`replyTo 100`, `root 200`) that still 400s, so the acceptance is demonstrably the COALESCE fall-through rather than a resolver waving through any same-pod pair.

**Mutation-checked**, per rule 1: gating the accept path with `|| parentId === explicit` reddens exactly the new test, 1 failed / 19 passed, no collateral. Restored after.

Also corrects the `handleSend` comment's stated reason — a reply edge pings the author of whatever it points at, which collapses onto "the root's author" only in the second shape. Rule 15: the rule stands, the reason was narrow.

20 tests green (was 18). No production code changed.