### PR TITLE
test(routes): /threads/state is protected by segment count, not by ordering

### DIFF
--- a/backend/__tests__/unit/routes/messages.threadStateOrdering.test.js
+++ b/backend/__tests__/unit/routes/messages.threadStateOrdering.test.js
@@ -1,0 +1,86 @@
+/**
+ * `GET /threads/state` is protected by SEGMENT COUNT, not by ordering.
+ *
+ * The comment above the registration says it is "registered above the greedy
+ * `GET /:podId` on purpose". It is not: `/:podId` is registered at :85 and
+ * `/threads/state` at :152, sixty-seven lines BELOW it. Express matches in
+ * registration order, so if ordering were the protection this route would
+ * already be dead.
+ *
+ * What actually protects it is that `/:podId` compiles to a single-segment
+ * pattern and `/threads/state` is two segments. That is the load-bearing fact
+ * the comment treats as incidental ("does not currently collide"), and the
+ * failure mode is quiet: rename this route to one segment and `getMessages`
+ * swallows it, under `auth` rather than `dualAuth` — so every agent caller
+ * gets a 401 for a route that looks registered and reads correct.
+ *
+ * Executing rather than grepping the source, per checklist rule 18: "does this
+ * path reach that handler" is behavioural, and only the real router can answer
+ * it. The controllers are stubbed to identify themselves; the router, its
+ * registration order, and its path patterns are the real ones.
+ */
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => next());
+jest.mock('../../../middleware/agentRuntimeAuth', () => (req, res, next) => next());
+
+const hit = (name) => (req, res) => res.json({ handler: name });
+
+jest.mock('../../../controllers/messageController', () => ({
+  getMessages: (req, res) => res.json({ handler: 'getMessages', podId: req.params.podId }),
+  createMessage: hit('createMessage'),
+  deleteMessage: hit('deleteMessage'),
+}));
+jest.mock('../../../controllers/reactionController', () => ({
+  addReaction: hit('addReaction'),
+  removeReaction: hit('removeReaction'),
+}));
+jest.mock('../../../controllers/threadStateController', () => ({
+  listThreadState: hit('listThreadState'),
+  followThread: hit('followThread'),
+  unfollowThread: hit('unfollowThread'),
+  setThreadCollapsed: hit('setThreadCollapsed'),
+}));
+
+const messagesRouter = require('../../../routes/messages');
+
+const app = express();
+app.use(express.json());
+app.use('/api/messages', messagesRouter);
+
+describe('the greedy single-segment route is registered FIRST, and that is fine', () => {
+  it('GET /threads/state reaches listThreadState, not getMessages', async () => {
+    const res = await request(app).get('/api/messages/threads/state?podId=p1');
+    expect(res.body.handler).toBe('listThreadState');
+  });
+
+  it('CONTROL: a single-segment path DOES land on the greedy route', async () => {
+    // Proves the assertion above is discriminating — the greedy route is live,
+    // reachable, and would have taken the request if the pattern let it.
+    const res = await request(app).get('/api/messages/threads');
+    expect(res.body).toEqual({ handler: 'getMessages', podId: 'threads' });
+  });
+
+  it('so a rename to one segment would be silently swallowed', async () => {
+    // The exact latent bug the comment mis-attributes to ordering. `/threadstate`
+    // is what a well-meaning tidy-up produces, and it is already taken.
+    const res = await request(app).get('/api/messages/threadstate');
+    expect(res.body.handler).toBe('getMessages');
+    expect(res.body.handler).not.toBe('listThreadState');
+  });
+});
+
+describe('the per-message thread toggles are below the greedy route too', () => {
+  it.each([
+    ['post', '/api/messages/42/follow', 'followThread'],
+    ['delete', '/api/messages/42/follow', 'unfollowThread'],
+    ['put', '/api/messages/42/collapsed', 'setThreadCollapsed'],
+  ])('%s %s reaches %s', async (method, path, handler) => {
+    // These are two segments as well, and they carry a VERB the greedy route
+    // does not register — GET/POST /:podId and DELETE /:id. Two independent
+    // reasons they survive, neither of them ordering.
+    const res = await request(app)[method](path);
+    expect(res.body.handler).toBe(handler);
+  });
+});

--- a/backend/routes/messages.ts
+++ b/backend/routes/messages.ts
@@ -139,9 +139,19 @@ router.delete('/:messageId/reactions/:emoji', reactionRateLimit, dualAuth, remov
 // reactions use it: an agent following a thread is first-class, and gating on
 // req.userId alone silently excludes every agent.
 //
-// Registered above the greedy `GET /:podId` on purpose. `/threads/following`
-// is two segments so it does not currently collide, but the collision is one
-// route rename away and the ordering costs nothing.
+// NOT protected by ordering — `GET /:podId` is registered at :85, sixty-odd
+// lines ABOVE this, and Express matches in registration order. An earlier
+// version of this comment claimed the opposite and named `/threads/following`,
+// a path that has never existed on this router (the closest real thing is
+// `/following/threads` on posts.ts, different router, `auth` not `dualAuth`).
+//
+// What protects it is SEGMENT COUNT: `/:podId` compiles to a single-segment
+// pattern and `/threads/state` is two. Rename this to one segment and
+// `getMessages` swallows it under `auth`, so agents get a 401 on a route that
+// looks registered and reads correct. The toggles below survive for a second
+// independent reason — their verbs (POST/DELETE/PUT on two segments) are not
+// ones the greedy route registers. Pinned, executing, in
+// __tests__/unit/routes/messages.threadStateOrdering.test.js.
 //
 // Any message in a thread may be followed — the root is resolved server-side.
 // Reuses reactionRateLimit: same shape of cheap, spammable, per-message toggle.


### PR DESCRIPTION
@sprint-review's sweep: `/threads/following` has exactly one hit repo-wide — the comment at `routes/messages.ts:142` naming it. Pulling that thread found the comment's **central claim** is false, not just its route name.

## The claim

> Registered above the greedy `GET /:podId` on purpose.

```
:85   router.get('/:podId', readMessageRateLimit, auth, getMessages)
:152  router.get('/threads/state', reactionRateLimit, dualAuth, listThreadState)
```

It is registered sixty-seven lines **below** it, and Express matches in registration order. If ordering were the protection, this route would already be dead.

## What actually protects it

Segment count. `/:podId` compiles to a single-segment pattern; `/threads/state` is two. The comment lists that as the *incidental* reason ("is two segments so it does not currently collide") and the false one as load-bearing — so a reader tidying the path to one segment is told they are safe by an ordering that does not exist. `getMessages` swallows it under `auth` rather than `dualAuth`: **every agent caller gets a 401 on a route that looks registered and reads correct.**

`/threads/following` never existed on this router. The nearest real path is `/following/threads` on `posts.ts:29` — different router, reversed segments, `auth`, different controller — so a reader chasing the name lands somewhere plausible and wrong.

## The test

Executes rather than greps, per rule 18 — "does this path reach that handler" is behavioural, and only the real router can answer it. Real router, real registration order, real path patterns; only the controllers are stubbed, to identify themselves.

| case | asserts |
|---|---|
| `GET /threads/state` | reaches `listThreadState` |
| CONTROL `GET /threads` | lands on `getMessages` with `podId: 'threads'` — the greedy route is live and would have taken it |
| `GET /threadstate` | swallowed by `getMessages` — the latent bug, demonstrated |
| the three toggles | reach their handlers; they survive for a *second* independent reason, since their verbs are not ones the greedy route registers |

The CONTROL is what makes the first assertion discriminating rather than vacuous — without it, "reaches `listThreadState`" is equally consistent with a greedy route that never matches anything.

Comment rewritten per rule 15: the rule stands (keep it above, keep it two segments), the stated reason was false. 27 tests green across this and `threadUserState`.