### PR TITLE
docs(plans): in-pod browser view — scoping note (TASK-060)

### DIFF
--- a/docs/plans/2026-08-25-in-pod-browser-view.md
+++ b/docs/plans/2026-08-25-in-pod-browser-view.md
@@ -1,0 +1,112 @@
+# In-pod browser view — scoping note (TASK-060)
+
+**Status:** proposal, not a design ruling. Written under the 2026-08-24 UI
+freeze, so it deliberately proposes no v2 visual or layout change; it answers
+the architectural question in the task title and stops there.
+
+**Task:** *"Idea (Sam): in-app browser view — render a live localhost/URL pane
+inside a pod (Widget component type?)"*
+
+---
+
+## The short answer to the title question
+
+**Yes, `Widget` is the right taxonomic home — and it has no runtime today.**
+
+`Widget` is already a declared `ComponentType` in `backend/models/Installable.ts`,
+and ADR-001 §Component types describes it as `Widget { location, url, scopes }` —
+which is, almost exactly, this feature. Nothing else in the taxonomy fits: it is
+not an Agent, a SlashCommand, an EventHandler, a ScheduledJob, a Webhook, or a
+DataSchema.
+
+But `Installable.ts` is explicitly *"pure scaffolding: schema + types + indexes.
+No services, routes, adapters."* There is no widget renderer, no widget route,
+no projection, and no surface that reads `components[].type === 'widget'`. And
+the Installable taxonomy refactor is **paused** under ADR-011, with a stated
+reactivation trigger that this task does not meet.
+
+So the real choice is not *"which component type"*. It is:
+
+1. un-pause enough of ADR-001 to make `Widget` real, with this as its first
+   consumer; or
+2. build a one-off pane that does not go through the taxonomy, and accept that
+   the second widget will have to be migrated.
+
+(1) is the honest answer if widgets are coming anyway. (2) is defensible only
+if this is a single operator affordance that will never have siblings — and the
+task title's question mark suggests it is not being framed that way.
+
+## The part that decides the feature, and it is not rendering
+
+**An iframe runs on the viewer's machine.** That single fact splits "render a
+live localhost/URL pane" into two features that look identical in a mock and
+behave nothing alike:
+
+| what the URL is | what the viewer actually sees |
+|---|---|
+| `http://localhost:3000` | **the viewer's own** localhost — a different machine from whoever posted it |
+| a public/tunneled URL | the intended page, *if* the target permits framing |
+| a Commonly-hosted URL | the intended page, always |
+
+The `localhost` case is the dangerous one, because it **works perfectly for a
+solo operator and silently shows the wrong thing to everyone else.** For Sam
+alone in a pod with an agent editing Sam's dev server, an iframe of
+`localhost:3000` renders Sam's dev server and looks like a triumph. The moment a
+second human opens that pod, they see their own localhost — or a connection
+error, which is the *lucky* outcome, because the unlucky one is that they are
+also running something on 3000 and see an unrelated app presented as the
+agent's work.
+
+That is not a bug to fix later. It is the feature meaning two different things
+depending on who is looking, which is the class of defect this repo's audit
+keeps calling *"correct and insufficient"*.
+
+**The remote case is bounded by someone else's headers, not ours.** Framing is
+controlled by the *target's* `X-Frame-Options` / CSP `frame-ancestors`, and the
+common default on anything worth embedding is `DENY` or `SAMEORIGIN`. So a
+generic "paste any URL" pane will fail on a large fraction of real URLs, with no
+recourse from our side. (Note the converse, checked while writing this: this
+repo configures no `helmet`, no CSP, and no `frame-ancestors` — so *Commonly* is
+framable. That is about us being embedded, not about us embedding, and it is
+worth a separate look.)
+
+## The reframe
+
+The question worth answering is not *"can we render a pane"* but **"whose
+browser is running it, and does the viewer see what the author saw?"**
+
+Once put that way, a cheaper option appears that has no security surface at all
+and works today: **agents already have a browser.** MCP Playwright is live on at
+least one seat in this pod — verified 2026-08-25 by navigating to
+`https://commonly.me` and getting a real accessibility snapshot back. An agent
+can already screenshot a page and attach it.
+
+So a first version could be:
+
+- agent renders the page **in its own browser** and attaches the image;
+- the pod shows it inline as an artifact, with the URL and a timestamp;
+- a refresh action re-runs the capture.
+
+Every viewer sees the same pixels, because there is exactly one browser and it
+is the agent's. No iframe, no cross-origin question, no localhost ambiguity, no
+new component type. It is strictly less capable than a live pane — not
+interactive, not continuously live — and that is the trade to put in front of
+Sam rather than to decide here.
+
+## What this note does not decide
+
+- Whether widgets are coming (an ADR-011 / ADR-001 sequencing call, not mine).
+- Whether the snapshot version is enough, or whether interactivity is the point.
+- Any visual or layout treatment — out of scope under the freeze.
+
+## Open question for Sam
+
+Which of these is the actual want?
+
+- **"Let me watch the thing the agent is building, live, on my screen"** — that
+  is the localhost case, and it is a per-viewer feature that cannot be shared.
+- **"Let the pod see what the agent sees"** — that is the snapshot case, it is
+  shareable, and it is buildable now.
+
+They pull in opposite directions, and picking the wrong one costs a component
+type.

--- a/docs/plans/2026-08-25-in-pod-browser-view.md
+++ b/docs/plans/2026-08-25-in-pod-browser-view.md
@@ -19,18 +19,53 @@ which is, almost exactly, this feature. Nothing else in the taxonomy fits: it is
 not an Agent, a SlashCommand, an EventHandler, a ScheduledJob, a Webhook, or a
 DataSchema.
 
-But `Installable.ts` is explicitly *"pure scaffolding: schema + types + indexes.
-No services, routes, adapters."* There is no widget renderer, no widget route,
-no projection, and no surface that reads `components[].type === 'widget'`. And
-the Installable taxonomy refactor is **paused** under ADR-011, with a stated
-reactivation trigger that this task does not meet.
+`Widget` has no runtime: `widgetLocation` appears exactly twice on `main`
+(`8a674ac3`), both inside its own declaration in `Installable.ts` (`:173`,
+`:397`). There is no widget renderer, no widget route, no projection, and no
+surface that reads `components[].type === 'widget'`.
 
-So the real choice is not *"which component type"*. It is:
+> **Corrected 2026-08-25 by @sprint-review.** An earlier version of this
+> paragraph reached that conclusion from a false premise — it quoted the file's
+> own header, *"pure scaffolding: schema + types + indexes. No services,
+> routes, adapters,"* and inferred that nothing reads the file. Four things do,
+> one of them a live production route: `backend/routes/marketplace-api.ts`
+> (findOne / create / deleteOne), `backend/scripts/seed-native-agents.ts`, and
+> two test suites. **The render side is inert; the storage-and-publish side is
+> live and dual-writing against `AgentRegistry`.** I checked the surface the
+> feature would read from and treated its emptiness as a fact about the file.
+> The conclusion survives the correction; the reasoning did not.
+
+That distinction is load-bearing rather than pedantic, because **the write path
+for this exact feature is already reachable by untrusted input.** Marketplace
+publish destructures `components` straight from `req.body` (`marketplace-api.ts:111`),
+applies one check — `components.length > 50` (`:133`) — and persists it verbatim
+(`:250`). The schema enum-validates `type` (`'widget'` is accepted) and
+`widgetLocation`, but `widgetUrl` is a bare `{ type: String }` (`:401`): no
+scheme check, no origin allowlist, no length bound.
+
+So a publisher can persist `type: 'widget'`, `widgetLocation: 'message-inline'`,
+and an arbitrary `widgetUrl` today. Those rows are inert **only because no
+renderer exists to read them**, which inverts the natural build order: the
+instinct is renderer first and hardening second, but here every `widgetUrl`
+already in the catalog goes live the day a renderer ships. The validation has to
+land first and separately — and it is worth doing even if option B below wins
+and no renderer is ever built.
+
+The Installable taxonomy refactor is **paused** under ADR-011, with a stated
+reactivation trigger that this task does not meet. But that pause covers the
+read path only, so the choice below is not the clean either/or it looks like:
+the persistence layer is not paused, it is shipping, and a one-off still writes
+into the live schema.
 
 1. un-pause enough of ADR-001 to make `Widget` real, with this as its first
    consumer; or
 2. build a one-off pane that does not go through the taxonomy, and accept that
    the second widget will have to be migrated.
+
+**Open, and it decides whether the above is hypothetical or already-accrued:**
+whether any widget-typed component exists in the live catalog now. That needs a
+Mongo read neither @sprint-review nor I can run. Worth one query before Sam
+picks.
 
 (1) is the honest answer if widgets are coming anyway. (2) is defensible only
 if this is a single operator affordance that will never have siblings — and the


### PR DESCRIPTION
TASK-060, Sam's idea, assigned to this seat. A scoping note rather than a design — written under the 2026-08-24 UI freeze, so it proposes no v2 visual or layout change and says so up front.

## The title's question mark is the right instinct

`Widget` **is** the correct taxonomic home — it's a declared `ComponentType` in `backend/models/Installable.ts` and ADR-001 describes it as `Widget { location, url, scopes }`, which is almost literally this feature. Nothing else in the taxonomy fits.

But that file is explicitly *"pure scaffolding: schema + types + indexes. No services, routes, adapters"*, nothing reads `components[].type === 'widget'`, and the Installable refactor is **paused** under ADR-011 with a reactivation trigger this task doesn't meet. So the decision isn't *which component type* — it's **un-pause ADR-001 with this as the first widget, or build a one-off and migrate later.**

## The part that decides the feature isn't rendering

**An iframe runs on the viewer's machine.** That splits "render a live localhost/URL pane" into two features that look identical in a mock:

| URL | what the viewer sees |
|---|---|
| `localhost:3000` | **their own** localhost — a different machine |
| public/tunneled | the page, *if* the target permits framing |
| Commonly-hosted | the page |

The localhost case works perfectly for a solo operator and **silently shows a second viewer the wrong thing** — their own dev server, or worse, an unrelated app on the same port presented as the agent's work. That's not a bug to fix later; it's the feature meaning two different things depending on who's looking.

The remote case is bounded by the *target's* `X-Frame-Options` / `frame-ancestors`, not ours, and `DENY` is the common default.

## The reframe, and a cheaper first version

The question is *"whose browser is running it, and does the viewer see what the author saw?"* — and **agents already have a browser.** MCP Playwright is live on this seat (verified today by navigating to `commonly.me` and getting a real snapshot). So: the agent renders in *its* browser, attaches the image, a refresh action re-captures. One browser, same pixels for everyone, no iframe, no cross-origin question, no new component type.

Strictly less capable — not interactive, not continuously live. That trade is Sam's to make, which is why the note ends on the question rather than answering it:

> **"Let me watch the thing being built, live, on my screen"** (per-viewer, unshareable) or **"let the pod see what the agent sees"** (shareable, buildable now)?

They pull in opposite directions, and the wrong pick costs a component type.

## Incidental

This repo configures no `helmet`, no CSP, no `frame-ancestors` — so Commonly itself is framable. That's about us being embedded rather than us embedding, and it's noted in the doc as deserving a separate look, not folded into this.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)