### PR TITLE
test(threading): positive control on the backfillPending absence probe

### DIFF
--- a/backend/__tests__/unit/models/threadUserState.test.js
+++ b/backend/__tests__/unit/models/threadUserState.test.js
@@ -223,6 +223,16 @@ describe('the pre-cutoff expanded default reaches the client', () => {
     // rule. It asserts the ABSENCE of code, which no execution can demonstrate:
     // a dead branch that never runs is invisible to a behavioural test and
     // still there for the next reader to revive.
+    //
+    // CONTROL: "matches nothing" has two causes, and only one of them is
+    // already closed here. An empty haystack cannot happen — `read()` is an
+    // unguarded `readFileSync`, so a bad path throws rather than yielding ''.
+    // A wrong needle is not covered by that: a typo'd identifier matches
+    // nothing against a file where the code is sitting in plain sight. So
+    // match a backfill-related identifier that IS present, chosen because it
+    // shares the substring — if this line goes red the probe below is reading
+    // something other than the controller, and its silence means nothing.
+    expect(CONTROLLER_SRC).toMatch(/THREADING_BACKFILL_MIGRATION/);
     expect(CONTROLLER_SRC).not.toMatch(/backfillPending/);
   });
 });


### PR DESCRIPTION
Follow-up to @sprint-review's note on #1209: rule 18's rider two asks every absence assertion for a positive control, and the exemplar the rule is built on hasn't got one.

They are right that it is sound anyway, and right that the reason is worth naming rather than assuming. `read()` in this suite is an unguarded `readFileSync`, so a bad path throws instead of yielding `''` — the source string can never quietly be empty.

**That closes one of the two ways to match nothing.** The other is untouched by anything the loader does: a wrong needle — a typo'd identifier, an over-anchored regex, or a haystack that is simply the wrong file — matches nothing against source where the code is sitting in plain sight, and the absence assertion passes vacuously.

So the control matches `THREADING_BACKFILL_MIGRATION`, picked because it shares the substring with the retired probe: if a backfill-named identifier *can* be found in this file, then the probe's silence about `backfillPending` is informative.

## Negative control

Run in isolation with a verified backup and restored afterwards (this suite's file, `CONTROLLER_SRC` repointed at `models/User.ts`):

```
✕ the retired backfillPending probe is gone from the source, not merely unused
    Expected pattern: /THREADING_BACKFILL_MIGRATION/
Tests: 1 failed, 20 passed, 21 total
```

The new line reddens; `not.toMatch(/backfillPending/)` stays green. That is exactly the vacuous pass this closes — reading the wrong file makes the absence assertion succeed for no reason at all.

21/21 on Node 22. #1209 carries the matching sharpening to rider two, so the rule now asks *which half* of "matches nothing" you closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)