### PR TITLE
docs(ax): name which sha a provenance check needs

### DIFF
--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -2482,6 +2482,26 @@ workflow's clock instead of the pod's, the parent commit instead of the head.
   entirely. If the count of check runs is zero, that is the loudest possible
   signal, and it prints as silence.
 
+  **Rider — which sha, for a provenance check.** "By sha" is not yet specific
+  enough, because `gh pr view` hands you two real ones and the wrong choice
+  answers rather than errors. This repo squash-merges, so a merged PR's
+  `headRefOid` is **never** an ancestor of `main`:
+
+  ```
+  gh pr view 1161 --json mergeCommit,headRefOid
+  39032b7c  mergeCommit.oid  merge-base --is-ancestor origin/main → yes
+  7f677235  headRefOid       merge-base --is-ancestor origin/main → NO
+  ```
+
+  Both commits exist, both belong to #1161, and `--is-ancestor` fed the head
+  exits non-zero — which reads as *the fix was never deployed*, inverting the
+  conclusion of the exact check used to establish that #1161 **is** live in the
+  running image. There is no error state to notice. Use `mergeCommit.oid` for
+  "did this land / is it in that image"; use `headRefOid` only for "what did CI
+  run against." Caught by @sprint-review (2026-08-25) in a close-out that was
+  right on every other fact — the merge timestamp included, which is what made
+  the wrong sha survive a re-read.
+
   **And if that comparison keeps failing, stop pushing rather than
   re-dispatching.** @sprint-review (57014) caught this branch taking four heads
   in twelve minutes against a `tests.yml` that runs 5–6 — a cadence under the


### PR DESCRIPTION
The AX audit already carries **"Verify by sha, not by PR."** It is one step short of actionable, and @sprint-review caught the gap on a #1161 close-out today.

`gh pr view` returns **two real shas** for a merged PR. Because this repo squash-merges, the branch head never lands on `main`:

```
gh pr view 1161 --json mergeCommit,headRefOid
39032b7c  mergeCommit.oid  merge-base --is-ancestor origin/main → yes
7f677235  headRefOid       merge-base --is-ancestor origin/main → NO
```

Verified independently at `origin/main` before writing this.

Both commits are real and both belong to #1161. `merge-base --is-ancestor` fed the head **exits non-zero**, which reads as *the fix was never deployed* — precisely inverting the conclusion of the check that had been used earlier the same day to establish that #1161 **is** live in the running image.

There is no error state. That puts it in the family the doc already names in this section — *"every instance is a status read against the wrong object"* (entries 34, 35, 37) — and makes it the fifth.

What made it survive: the close-out carrying the wrong sha was correct on every other fact, merge timestamp included. A re-read confirms the surrounding claims and never touches the one that is wrong.

**The rider:** `mergeCommit.oid` for *"did this land / is it in that image"*; `headRefOid` only for *"what did CI run against."*

## Placement

Appended under the existing bullet at `:2479`, **deliberately not** at the end-of-file anchor where #1142, #1143, #1204, #1213 and #1221 already collide five ways. This hunk does not touch that region.

Rendered through `gh api /markdown` (`mode: gfm`) — the fenced block nests correctly inside the list item and the bold spans close.

**Not verified:** I did not check whether every merged PR in this repo took the squash path; the rule is stated for the repo's configured merge strategy, and a PR merged by another method would put a different commit on `main`.

Credit: @sprint-review found this; I am folding it from TASK-059 into the repo, since a board row is not greppable by the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)