### PR TITLE
fix(tasks): a lease renewal wakes nobody — the board fan-out fires only on news

### DIFF
--- a/backend/__tests__/service/tasks.claim-lease.test.js
+++ b/backend/__tests__/service/tasks.claim-lease.test.js
@@ -15,8 +15,17 @@
 process.env.PG_HOST = '';
 process.env.JWT_SECRET = 'tasks-claim-lease-test-secret';
 
+// Partial mock so the renewal-gating tests below can assert WHO gets woken.
+// Everything else is the real module: emitTaskUpdated stays a socket no-op in
+// tests, and notifyPodAgents becomes observable without changing behavior.
+jest.mock('../../services/taskEventService', () => {
+  const actual = jest.requireActual('../../services/taskEventService');
+  return { ...actual, notifyPodAgents: jest.fn().mockResolvedValue(undefined) };
+});
+
 const express = require('express');
 const request = require('supertest');
+const { notifyPodAgents } = require('../../services/taskEventService');
 const Pod = require('../../models/Pod');
 const Task = require('../../models/Task');
 const User = require('../../models/User');
@@ -277,6 +286,51 @@ describe('POST /api/v1/tasks/:podId/:taskId/claim — lease semantics (ADR-018 D
       await liveHeld();
       const both = await list(rivalToken, '?status=claimed&claimable=true');
       expect(both.body.tasks.map((t) => t.taskId)).toEqual(['T-1']);
+    });
+  });
+
+  // A lease timestamp is not an event. Renewals fanned a wake to every seat
+  // in the pod, each burning a model turn to conclude "nothing new" — 4 wakes
+  // for one task in one session, with seats meta-discussing the noise
+  // (measured in Sharpen, 2026-08-25). The board UI still updates via the
+  // socket emit; only the agent fan-out is gated.
+  describe('renewal wakes nobody — the fan-out fires only on news', () => {
+    beforeEach(() => {
+      notifyPodAgents.mockClear();
+    });
+
+    test('a fresh claim fans out; the holder renewing does not', async () => {
+      await seedTask();
+      await claim(ownerToken);
+      expect(notifyPodAgents).toHaveBeenCalledTimes(1);
+
+      const renew = await claim(ownerToken);
+      expect(renew.status).toBe(200);
+      expect(notifyPodAgents).toHaveBeenCalledTimes(1); // unchanged
+    });
+
+    test('a takeover after a lapse fans out — a NEW holder is news', async () => {
+      await seedTask();
+      await claim(ownerToken);
+      await Task.updateOne(
+        { podId: pod._id, taskId: 'T-1' },
+        { $set: { claimExpiresAt: new Date(Date.now() - 1000) } },
+      );
+      notifyPodAgents.mockClear();
+      const res = await claim(rivalToken);
+      expect(res.status).toBe(200);
+      expect(notifyPodAgents).toHaveBeenCalledTimes(1);
+    });
+
+    test('re-taking a task you yourself lapsed from is a continuation, not news', async () => {
+      await seedTask({
+        status: 'pending',
+        claimedBy: null,
+        lapsedFrom: owner._id.toString(),
+      });
+      const res = await claim(ownerToken);
+      expect(res.status).toBe(200);
+      expect(notifyPodAgents).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -420,6 +420,17 @@ router.post('/:podId/:taskId/claim', rateLimit({
     const access = await requirePodMember(podId || '', userId, { write: true });
     if (access.error) return res.status(access.status || 500).json({ error: access.error });
     const now = new Date();
+    // Pre-read the current holder to classify this claim AFTER the CAS wins:
+    // a same-holder continuation (renewal, or re-take after the holder's own
+    // lapse) is no news to the room and must not fan out (the redundant wakes
+    // burned a model turn per seat per renewal and filled Sharpen with seats
+    // narrating why they won't act — measured 2026-08-25, 4 wakes in one
+    // session for one task). The read races the CAS by design: worst case is
+    // one wake mis-classified once, which beats a transaction on the hot path.
+    const preClaim = await Task.findOne({
+      podId: mongoose.Types.ObjectId.createFromHexString(podId || ''),
+      taskId,
+    }).select('claimedBy lapsedFrom').lean() as { claimedBy?: string | null; lapsedFrom?: string | null } | null;
     // `rescueDeferrals` and `lapsedFrom` reset on every claim (#1080 part 2/3).
     // The deferral budget is per-lease, not per-task: a seat that renews
     // normally must never inherit a predecessor's spent budget, or the third
@@ -449,7 +460,15 @@ router.post('/:podId/:taskId/claim', rateLimit({
       });
     }
     emitTaskUpdated(podId, task, 'updated');
-    notifyAgents(req, podId, task, 'updated');
+    // Same-holder continuation: the seat that already held (or just lapsed
+    // from) this task re-claimed it. The board UI still updates (socket emit
+    // above); the room is NOT woken — a lease timestamp is not an event.
+    // A fresh claim and a takeover both still fan out.
+    const isSameHolderContinuation = !!preClaim
+      && (preClaim.claimedBy === claimedBy || preClaim.lapsedFrom === claimedBy);
+    if (!isSameHolderContinuation) {
+      notifyAgents(req, podId, task, 'updated');
+    }
     return res.json({ task });
   } catch (err) {
     console.error('POST /tasks/claim error:', err);


### PR DESCRIPTION
Root cause of the Sharpen churn Sam flagged: every claim win fanned a board wake to every seat, including same-holder lease renewals — 4 wakes for one task in one session, each burning a model turn per seat to conclude 'nothing new', with Sprint Review then narrating the noise. The claim route now pre-reads the holder and skips notifyPodAgents for same-holder continuations (claimedBy or lapsedFrom match — the seats' own thread identified both shapes). Fresh claims and takeovers still fan out; the board-UI socket emit is untouched. Deliberately NOT touching wake policy semantics (TASK-058 stays with pod-architect) — this is delivery-side noise reduction on one producer. 48/48 across the three claim suites, incl. three new gating tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK