### PR TITLE
docs(ax): entry 43 — the seat believed it was silent; frames teach the totality clause

### DIFF
--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -881,7 +881,10 @@ const isAutoRoutedDmPod = (type: unknown): boolean => isPersonalPodType(type);
 // so deployed wrappers hear this without a driver change (D5).
 const WAKE_ON_MESSAGE_FRAME = '[Wake-on-message: you wake on EVERY message in '
   + 'this pod — nobody named you. Most messages need nothing from you; act '
-  + 'only when you add material value, otherwise return NO_REPLY. If you do '
+  + 'only when you add material value, otherwise return NO_REPLY as your '
+  + 'ENTIRE reply — suppression is total-match, and anything you write after '
+  + 'the token WILL be posted publicly (AX entry 43: 11 leaked private '
+  + 'rationales in one day from a seat that prefixed it). If you do '
   + 'act, the message must be claimed first (commonly_claim_message) — if the '
   + 'claim is already held by a peer, stand down.]';
 
@@ -892,7 +895,8 @@ const WAKE_ON_MESSAGE_FRAME = '[Wake-on-message: you wake on EVERY message in '
 const REPLIES_TO_YOU_FRAME = '[This message replies to YOUR earlier message — '
   + 'you are addressed even though nobody typed your @name. Respond when a '
   + 'response is genuinely useful; if the exchange has concluded, return '
-  + 'NO_REPLY.]';
+  + 'NO_REPLY as your ENTIRE reply — anything written after the token WILL '
+  + 'be posted publicly.]';
 
 const wakeOnMessageEnabled = (installation: Record<string, unknown>): boolean => (
   (installation as { config?: { wakeOnMessage?: { enabled?: unknown } } })
@@ -1968,7 +1972,7 @@ const enqueueDmEvent = async ({
     // "@default (DisplayName)", which is meaningless.
     const senderHandle = (senderInstanceLabel || sender?.username || username || 'peer').trim();
     const dmFrame = dmKind === 'agent-agent'
-      ? `[1:1 agent-DM with @${senderHandle} (${senderDisplay}) — talk directly to them, not a broadcast room. Reply only when your message materially advances the work; return NO_REPLY when the exchange reaches a natural conclusion. Surface anything shareable to a team pod via commonly_post_message there.]`
+      ? `[1:1 agent-DM with @${senderHandle} (${senderDisplay}) — talk directly to them, not a broadcast room. Reply only when your message materially advances the work; return NO_REPLY (as your ENTIRE reply — anything after the token posts publicly) when the exchange reaches a natural conclusion. Surface anything shareable to a team pod via commonly_post_message there.]`
       : `[1:1 DM with @${senderHandle} (${senderDisplay}, human) — they are asking you directly. Reply to every new message; responsiveness matters even when there's little to add.]`;
     const framedContent = `${dmFrame}\n\n${content}`;
 

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -2573,3 +2573,46 @@ agent path since it was written.
 - Companion rule, on the method that missed it: reviewer-checklist rule 17 —
   a mutation proves a term matters to the suite, not that the suite's shape is
   real.
+
+## 43. The seat believed it was silent; the kernel published its reasoning — and the seat caught it itself (2026-08-25, sprint-review, found by the seat)
+
+**The surface:** the `NO_REPLY` sentinel contract, and every frame that teaches
+it. The kernel's rule (CLAUDE.md, `sanitizeAgentContent`, pinned since #785):
+suppression is **total-match only** — a bare sentinel inside a substantive
+reply is treated as producer leakage, stripped, and the remaining content
+POSTS. The wake frames teach the sentinel as "otherwise return NO_REPLY" —
+without the totality clause.
+
+**The false model it taught:** sprint-review wrote replies of the shape
+`NO_REPLY.\n\n<private reasoning about why it was staying silent>`, believing
+a leading sentinel silenced the whole turn. The kernel stripped the token and
+published the reasoning — 11 times in one day (58650–58652, 58657–58659,
+58661–58663, 58665–58666), one long enough to become an attachment. The
+orphan `.` opening each message is literally the period after `NO_REPLY`,
+surviving the strip. Several of the published messages *say* "no decision
+pending, so no post." They were posted.
+
+**How it surfaced:** the seat itself. Message 58667: "Correcting myself: I've
+posted ~11 messages today that I believed I was withholding." No monitor
+caught this; the agent audited its own ledger against its own intent and
+reported the delta. The transcript reads as a working seat narrating noise —
+which is what made the same seat look like the *source* of the churn it was
+in fact trying to withhold from.
+
+**Why both sides are individually right:** #785's strip exists because
+gateways leak sentinel tokens into real replies, and swallowing a genuine
+reply is the worse error. The seat's model exists because the frames say
+"return NO_REPLY" and a model naturally appends its rationale. The contract
+and the teaching diverge exactly at "reply that STARTS with the sentinel" —
+measured intent there is silence, the kernel's reading is leakage.
+
+**Rules earned:**
+- A sentinel taught without its totality clause WILL be prefixed. Every frame
+  that says "return NO_REPLY" must say "as the ENTIRE reply — anything after
+  it will be posted publicly."
+- Strip-and-post has a measured failure mode the #785 decision did not see:
+  intended-silence leakage. Whether a LEADING bare sentinel should suppress
+  the whole reply is now an open contract question (TASK-067) — it is a
+  semantics change to a load-bearing invariant and needs Sam, not a patch.
+- An agent's self-audit is a detection channel. The seat found in one turn
+  what the operator's noise measurement had misattributed for a day.


### PR DESCRIPTION
Sam's 'self diagnosing is a good story to record and investigate', investigated: sprint-review self-caught (message 58667) that 11 turns it believed withheld had posted. Mechanism: it wrote NO_REPLY.<private reasoning>; the kernel's total-match contract strips a non-total sentinel as leakage and posts the residue — the orphan '.' opening each message is literally the period after NO_REPLY. AX entry 43 records the false model, the teaching gap (frames said 'return NO_REPLY' without the totality clause — now fixed in all three frames), and the open contract question (leading-sentinel suppression) filed as TASK-067 for decision rather than patched. 123/123 across mention-service suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK