### PR TITLE
fix(wakes): board + welcome frames also teach the sentinel totality clause

### DIFF
--- a/backend/services/taskEventService.ts
+++ b/backend/services/taskEventService.ts
@@ -159,7 +159,9 @@ export async function notifyPodAgents(
       'named you. Look at what is pending and decide what needs YOU:',
       '- Work you can genuinely do: claim it first, then start.',
       '- A claim that comes back 409: a peer has it. Leave it and move on.',
-      '- Nothing in your area: return NO_REPLY. That is the common case.',
+      '- Nothing in your area: return NO_REPLY as your ENTIRE reply. That is',
+      '  the common case. Suppression is total-match: anything you write after',
+      '  the token is posted publicly (AX entry 43).',
       '',
       'Do not narrate the board back to the pod. Post only if you are taking',
       'work, or a human needs a decision from you.',
@@ -315,7 +317,8 @@ export async function notifyFoundWork(
       '',
       'Nobody named you; the board did. If one of these is genuinely yours to',
       'do: claim it first (a 409 means a peer got there — move on), then start.',
-      'If none fit your role, return NO_REPLY. Do not narrate the list back.',
+      'If none fit your role, return NO_REPLY as your ENTIRE reply — anything',
+      'written after the token is posted publicly. Do not narrate the list back.',
     ].join('\n');
 
     let woken = 0;

--- a/backend/services/welcomeWakeService.ts
+++ b/backend/services/welcomeWakeService.ts
@@ -115,7 +115,8 @@ const WELCOME_CUE = (username: string | undefined, handle: string): string => [
   `End by telling them how to reach you again: they can @${handle} anytime, or reply`,
   'directly to your message. Say it once, plainly, as the last line — not as a menu.',
   '',
-  'If their message needs no reply at all, return NO_REPLY.]',
+  'If their message needs no reply at all, return NO_REPLY as your ENTIRE reply —',
+  'anything written after the token is posted publicly.]',
   '',
   username ? `${username} wrote:` : 'They wrote:',
 ].join('\n');


### PR DESCRIPTION
Follow-up to #1242, which added the totality clause to the three frames in `agentMentionService` (wake-on-message, replies-to-you, agent-DM).

Enumerating every NO_REPLY-instructing producer in `backend/` turned up two more that were missed:

| producer | sites | state before |
|---|---|---|
| `taskEventService` | 2 (both board-wake frames) | no clause |
| `welcomeWakeService` | 1 | no clause |
| `agentProvisionerServiceK8s` (moltbot HEARTBEAT.md) | 1 | already taught totality |
| `config/native-agents/housePreamble` | 1 | already taught totality |

`agentEnsembleService` and `systemExchangeTriggers` also match `NO_REPLY` but are consumer-side (they *detect* the sentinel), not instruction frames — unchanged.

The board frame is the one that matters most. Its own text is:

> `- Nothing in your area: return NO_REPLY. That is the common case.`

It declares itself the highest-frequency NO_REPLY instruction we ship, and it raises most implicit wakes — so it was the largest remaining surface for the AX-entry-43 failure mode.

**Verification.** String-literal edits inside existing array literals; both files parse clean (checked with a deliberately-broken positive control, which reports 2 parse errors). `grep` over `backend/__tests__/` finds no test asserting any of the three replaced strings.

**Not verified:** I did not run the backend suite in this worktree (no `node_modules`); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)