### PR TITLE
fix(tasks): make blocked tasks resumable

### DIFF
--- a/backend/__tests__/unit/routes/tasksApi.leaseState.test.js
+++ b/backend/__tests__/unit/routes/tasksApi.leaseState.test.js
@@ -189,15 +189,18 @@ const ROWS = [
   },
 ];
 
-// Terminal rows: no lease is held, so `unleased` is literally true — and the CAS
-// still refuses them. This pair is the whole reason the field is not named
-// `claimable`.
+// `done` is terminal: no lease is held, so `unleased` is literally true — and
+// the CAS still refuses it. `blocked` is deliberately absent: it is also
+// unleased, but an explicit claim resumes it into active work.
 const TERMINAL = [
   {
     taskId: 'TASK-007', label: 'done', doc: { status: 'done' }, leaseState: 'unleased', strangerWins: false,
   },
+];
+
+const RESUMABLE = [
   {
-    taskId: 'TASK-008', label: 'blocked', doc: { status: 'blocked' }, leaseState: 'unleased', strangerWins: false,
+    taskId: 'TASK-008', label: 'blocked', doc: { status: 'blocked' }, leaseState: 'unleased', strangerWins: true,
   },
 ];
 
@@ -240,10 +243,10 @@ describe('task leaseState', () => {
 
   beforeEach(async () => {
     await Task.deleteMany({});
-    await Task.create([...ROWS, ...TERMINAL].map((r, i) => materialize(r, i + 1)));
+    await Task.create([...ROWS, ...TERMINAL, ...RESUMABLE].map((r, i) => materialize(r, i + 1)));
   });
 
-  it.each([...ROWS, ...TERMINAL])('$label → leaseState $leaseState', async (row) => {
+  it.each([...ROWS, ...TERMINAL, ...RESUMABLE])('$label → leaseState $leaseState', async (row) => {
     const byId = await listed();
     expect(byId.get(row.taskId).leaseState).toBe(row.leaseState);
   });
@@ -285,6 +288,54 @@ describe('task leaseState', () => {
     expect(res.status).toBe(409);
   });
 
+  it('a blocked row resumes through claim and receives a lease', async () => {
+    const res = await request(app)
+      .post(`/api/v1/tasks/${POD_ID}/TASK-008/claim`)
+      .set('x-test-user', 'stranger')
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.task.status).toBe('claimed');
+    expect(res.body.task.claimedBy).toBe('stranger');
+    expect(new Date(res.body.task.claimExpiresAt).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('teaches a blocked row to claim before completing it', async () => {
+    const res = await request(app)
+      .post(`/api/v1/tasks/${POD_ID}/TASK-008/complete`)
+      .set('x-test-user', 'stranger')
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      error: 'Task is blocked; claim it first to resume work before completing it',
+      status: 'blocked',
+    });
+    const row = await Task.findOne({ taskId: 'TASK-008' }).lean();
+    expect(row.status).toBe('blocked');
+    expect(row.completedAt).toBeNull();
+  });
+
+  it('reports the actual legacy status when completion cannot transition it', async () => {
+    // Mongoose would reject this enum value, but older direct writes can exist.
+    // The fallback must not label every failed CAS as "already done".
+    await Task.collection.updateOne({ taskId: 'TASK-007' }, { $set: { status: 'archived' } });
+
+    const res = await request(app)
+      .post(`/api/v1/tasks/${POD_ID}/TASK-007/complete`)
+      .set('x-test-user', 'stranger')
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      error: "Task cannot be completed from status 'archived'",
+      status: 'archived',
+    });
+    const row = await Task.findOne({ taskId: 'TASK-007' }).lean();
+    expect(row.status).toBe('archived');
+    expect(row.completedAt).toBeNull();
+  });
+
   // The two-fetch shape theo depends on, pinned. Rescue asks for
   // `{ status: 'claimed' }` and assign asks for `{ status: 'pending' }`, and that
   // split is only correct while a lapsed row is INVISIBLE to the pending fetch —
@@ -309,6 +360,16 @@ describe('task leaseState', () => {
     const lapsed = claimed.body.tasks.find((t) => t.taskId === 'TASK-003');
     expect(lapsed).toBeDefined();
     expect(lapsed.leaseState).toBe('lapsed');
+  });
+
+  it('does not advertise a blocked row through the claimable discovery query', async () => {
+    const res = await request(app)
+      .get(`/api/v1/tasks/${POD_ID}`)
+      .query({ claimable: 'true' })
+      .set('x-test-user', 'stranger');
+
+    expect(res.status).toBe(200);
+    expect(res.body.tasks.map((task) => task.taskId)).not.toContain('TASK-008');
   });
 
   // The branch a per-row field structurally cannot carry. If someone ever reads

--- a/backend/routes/tasksApi.ts
+++ b/backend/routes/tasksApi.ts
@@ -436,15 +436,20 @@ router.post('/:podId/:taskId/claim', rateLimit({
     // normally must never inherit a predecessor's spent budget, or the third
     // holder of a hot task gets rescued on its first lapse.
     const update = { $set: { status: 'claimed', claimedBy, claimedAt: now, claimExpiresAt: new Date(now.getTime() + TASK_CLAIM_LEASE_MS), rescueDeferrals: 0, lapsedFrom: null }, $push: { updates: { text: `Claimed by ${author}`, author, authorId: userId?.toString() || null, createdAt: now } } };
-    // One CAS, four ways to win: the task is unclaimed; the caller already
-    // holds it (renewal); the holder's lease lapsed; or the claim predates
-    // leases entirely (claimExpiresAt null) and is older than one lease —
-    // legacy claims get their effective expiry derived from claimedAt, so no
-    // migration and no instant steal of work someone claimed minutes ago.
+    // One CAS, five ways to win: the task is unclaimed; the caller already
+    // holds it (renewal); the holder's lease lapsed; the claim predates
+    // leases entirely (claimExpiresAt null) and is older than one lease; or
+    // this named task is blocked. Legacy claims get their effective expiry
+    // derived from claimedAt, so no migration and no instant steal of work
+    // someone claimed minutes ago.
     const task = await Task.findOneAndUpdate({
       podId: mongoose.Types.ObjectId.createFromHexString(podId || ''),
       taskId,
-      $or: claimableConditions(now, claimedBy),
+      // A blocked row is deliberately resumable only when a seat names its
+      // task id. Do not add it to claimableConditions: that predicate also
+      // drives the discovery query, where a parked dependency is not work a
+      // peer may pick up speculatively.
+      $or: [...claimableConditions(now, claimedBy), { status: 'blocked' }],
     }, update, { new: true });
     if (!task) {
       const existing = await Task.findOne({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId }).lean() as { claimedBy?: string; status?: string; claimExpiresAt?: Date | null } | null;
@@ -485,12 +490,18 @@ router.post('/:podId/:taskId/complete', taskWriteRateLimit(30), auth, async (req
     const access = await requirePodMember(podId || '', userId, { write: true });
     if (access.error) return res.status(access.status || 500).json({ error: access.error });
     const updateText = prUrl ? `Completed by ${author} · PR: ${prUrl}` : `Completed by ${author}`;
-    const update = { $set: { status: 'done', completedAt: new Date(), ...(prUrl && { prUrl }), ...(notes && { notes }) }, $push: { updates: { text: updateText, author, authorId: userId?.toString() || null, createdAt: new Date() } } };
+    const now = new Date();
+    const update = { $set: { status: 'done', completedAt: now, ...(prUrl && { prUrl }), ...(notes && { notes }) }, $push: { updates: { text: updateText, author, authorId: userId?.toString() || null, createdAt: now } } };
     const task = await Task.findOneAndUpdate({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId, status: { $in: ['claimed', 'pending'] } }, update, { new: true }) as { taskId?: string; updates?: unknown[] } | null;
     if (!task) {
       const existing = await Task.findOne({ podId: mongoose.Types.ObjectId.createFromHexString(podId || ''), taskId }).lean() as { status?: string } | null;
       if (!existing) return res.status(404).json({ error: 'Task not found' });
-      return res.status(409).json({ error: 'Task is already done', status: existing.status });
+      const error = existing.status === 'done'
+        ? 'Task is already done'
+        : existing.status === 'blocked'
+          ? 'Task is blocked; claim it first to resume work before completing it'
+          : `Task cannot be completed from status '${existing.status || 'unknown'}'`;
+      return res.status(409).json({ error, status: existing.status });
     }
     // ADR-012 §4: task-completed trigger. Fire-and-forget; only writes when
     // the assignee is a recognized agent member of the pod.

--- a/commonly-mcp/__tests__/tools.test.mjs
+++ b/commonly-mcp/__tests__/tools.test.mjs
@@ -211,6 +211,12 @@ describe('commonly_get_tasks / create / claim / complete / update', () => {
     expect(url).toBe('https://x.example/api/v1/tasks/POD/TASK-001/claim');
   });
 
+  it('teaches that blocked tasks resume through claim', () => {
+    expect(byName.commonly_claim_task.description).toContain('pending or blocked');
+    expect(byName.commonly_claim_task.description).toContain('resumes it into active work');
+    expect(byName.commonly_get_tasks.description).toContain('pending,claimed,blocked');
+  });
+
   it('complete_task hits /:podId/:taskId/complete with prUrl + notes', async () => {
     const fetchSpy = installFetch(async () => okResponse({ ok: true }));
     await byName.commonly_complete_task.call({

--- a/commonly-mcp/package-lock.json
+++ b/commonly-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.1.10",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commonlyai/mcp",
-      "version": "0.1.10",
+      "version": "0.3.5",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4"
       },

--- a/commonly-mcp/package.json
+++ b/commonly-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Commonly MCP Server \u2014 exposes the kernel HTTP surface (CAP per ADR-004) as standard MCP tools so any MCP-capable runtime can consume `commonly_*` tools without driver-specific code.",
   "type": "module",
   "bin": {

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -284,7 +284,7 @@ export const buildTools = (config) => {
     },
     {
       name: 'commonly_get_tasks',
-      description: 'List tasks in a pod. Filter by `assignee` (e.g. "nova") and/or `status` (e.g. "pending,claimed" — comma-separated).',
+      description: 'List tasks in a pod. Filter by `assignee` (e.g. "nova") and/or `status` (e.g. "pending,claimed,blocked" — comma-separated).',
       inputSchema: reqWith({
         podId: STRING,
         assignee: STRING,
@@ -316,7 +316,7 @@ export const buildTools = (config) => {
     },
     {
       name: 'commonly_claim_task',
-      description: 'Claim a pending task — atomic: exactly one claimant wins. The claim is a ~30-minute renewable LEASE, not a tenure (ADR-018 D4): call again to renew while genuinely working; a lapsed lease makes the task claimable by peers, so a dead claimant never holds work forever. A 409 names the live holder and when their lease frees.',
+      description: 'Claim a pending or blocked task — atomic: exactly one claimant wins. Claiming a blocked task resumes it into active work. The claim is a ~30-minute renewable LEASE, not a tenure (ADR-018 D4): call again to renew while genuinely working; a lapsed lease makes the task claimable by peers, so a dead claimant never holds work forever. A 409 names the live holder and when their lease frees.',
       inputSchema: reqWith({ podId: STRING, taskId: STRING }, ['podId', 'taskId']),
       call: wrap(async ({ podId, taskId }) => request(config, {
         method: 'POST',

--- a/docs/agents/COMMONLY_MCP.md
+++ b/docs/agents/COMMONLY_MCP.md
@@ -97,7 +97,7 @@ All tools are namespaced `commonly_*`. Names match the OpenClaw extension's exis
 | `commonly_post_thread_comment` | Comment on a post-thread (optionally reply to a specific comment) | `threadId`, `content` |
 | `commonly_get_tasks` | List tasks (filter by `assignee`/`status`) | `podId` |
 | `commonly_create_task` | Create a task | `podId`, `title` |
-| `commonly_claim_task` | Atomically claim a pending task | `podId`, `taskId` |
+| `commonly_claim_task` | Atomically claim a pending or blocked task | `podId`, `taskId` |
 | `commonly_complete_task` | Mark a task done with PR URL + notes | `podId`, `taskId` |
 | `commonly_update_task` | Append a note (no status change) | `podId`, `taskId`, `text` |
 | `commonly_create_pod` | Create or join a standard team pod by name (backend dedupes globally) | `name` |


### PR DESCRIPTION
## Summary
- Let an explicitly named `blocked` task resume through the claim CAS; it is intentionally excluded from the shared claimable-discovery predicate.
- Keep the two-step transition (`claim` → `complete`) and make a blocked completion refusal name that remedy; legacy statuses are reported accurately.
- Teach MCP agents that blocked tasks can be listed and resumed by claim; publish this contract as `@commonlyai/mcp` 0.3.5.

## Verification
- `cd backend && npx jest __tests__/unit/routes/tasksApi.leaseState.test.js __tests__/unit/routes/tasksApi.status-vocabulary.test.js __tests__/unit/services/kernelWorkSweepService.test.js --runInBand` (61 passed)
- `cd backend && npm run tsc:check`
- `cd commonly-mcp && npm test` (49 passed)
- Mutation proof: removing blocked’s explicit claim branch, restoring the misleading refusal, or adding blocked to discovery each made its focused test fail.

`cd backend && npm test -- --runInBand` remains blocked locally by Node 26 loading `jsonwebtoken`/`buffer-equal-constant-time`; the focused suites above execute this change and CI runs Node 22.