### PR TITLE
ci: run the merge-to-main guards when a PR is retargeted

### DIFF
--- a/.github/workflows/package-version-guard.yml
+++ b/.github/workflows/package-version-guard.yml
@@ -17,7 +17,11 @@ name: Package Version Guard
 on:
   pull_request:
     branches: [ main ]
-    types: [opened, synchronize, reopened, ready_for_review]
+    # `edited` catches base-branch retargeting — see the note in
+    # pr-base-freshness.yml. A stacked PR retargeted to main after its parent
+    # merges enters this guard's population without any event in the list
+    # below ever firing for it.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-base-freshness.yml
+++ b/.github/workflows/pr-base-freshness.yml
@@ -20,7 +20,16 @@ name: PR Base Freshness
 on:
   pull_request:
     branches: [ main ]
-    types: [opened, synchronize, reopened]
+    # `edited` is load-bearing, not tidiness. This guard is deliberately
+    # scoped to base=main (see tests.yml) — a stacked PR's base freshness is
+    # meaningless while it targets a feature branch. But when its parent
+    # merges, GitHub RETARGETS the child to main, and that is the exact moment
+    # the stale-base footgun applies. Retargeting fires `edited`, never
+    # `synchronize`, so without this the child crosses into the guard's
+    # population and is never inspected: it arrives already-passing on a check
+    # set it was never subject to. Cost is a re-run on title/body edits too —
+    # one fetch and a merge-base, seconds.
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read


### PR DESCRIPTION
`pr-base-freshness.yml` and `package-version-guard.yml` are scoped to `base=main` deliberately — `tests.yml` records the reasoning and it is correct: a stacked PR's base freshness is meaningless while it targets a feature branch, so the test tiers run for every PR and the merge-to-main guards do not. This PR does not change that scoping.

**The gap is the transition into it.** When the parent merges, GitHub retargets the child PR to `main` — and that is precisely the moment the stale-base squash footgun these guards exist for applies. Retargeting fires `edited`, never `synchronize`, so today the child crosses into the guard's population without any listed event firing for it. It arrives at main's doorstep already green, on a check set it was never subject to.

## Measured on the live stack

| PR | base | checks |
|---|---|---|
| #1216 | `main` | 11 |
| #1244 | `docs/three-verbs-decision-rule` | 5 |

Missing on the stacked PR: `Stale-base merge guard`, `Source changed ⇒ version bumped`, `CodeQL`, `Analyze` ×3. Both PRs read **CLEAN**, and `CLEAN` on five checks is visually identical to `CLEAN` on eleven. When #1216 merges, #1244 inherits `main` as its base and still shows five.

This is not hypothetical for that pair: I measured earlier that squash-merging #1216 conflicts #1244 on two files. The conflict is loud, which is the good case — but it is loud at merge time, not at guard time, and nothing re-inspects the child in between.

## Change

Adds `edited` to the trigger `types` on both workflows, with the reasoning inline so the next reader does not mistake it for tidiness.

Cost: the guards also re-run on title/body edits. For base-freshness that is one `git fetch` and a `merge-base` — seconds. Both jobs are pure-git or near it.

## Not in scope

`CodeQL` / `Analyze` also skip stacked PRs. Those come from GitHub's default code-scanning setup rather than a workflow file in this repo, so closing that gap is a repo-settings change and a different decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)