### PR TITLE
fix(v2): zh-CN body copy takes line-height 1.6 and a 12px floor (TASK-055 class 2)

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -663,4 +663,20 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     }
   });
 
+  test('zh-CN: body copy takes line-height 1.6 and a 12px floor under :lang(zh) (TASK-055)', () => {
+    // Measured in a real browser: .v2-msg__content rendered Chinese at 1.55,
+    // the composer hint at 1.45/11px. CJK glyphs fill the em box, so Latin
+    // leading leaves no white between lines and 11px is below legibility.
+    const lhStart = v2.indexOf('.v2-root:lang(zh) .v2-msg__content,');
+    expect(lhStart).toBeGreaterThan(-1);
+    const lhBlock = v2.slice(lhStart, v2.indexOf('}', lhStart));
+    expect(lhBlock).toContain('line-height: 1.6');
+    for (const sel of ['.v2-msg__content', '.v2-chat__composer-hint', '.v2-inspector__pod-meta']) {
+      expect(lhBlock).toContain(`.v2-root:lang(zh) ${sel}`);
+    }
+    const floorStart = v2.indexOf('.v2-root:lang(zh) .v2-chat__composer-hint,\n.v2-root:lang(zh) button.v2-inspector__tab');
+    expect(floorStart).toBeGreaterThan(-1);
+    expect(v2.slice(floorStart, v2.indexOf('}', floorStart))).toContain('font-size: 12px');
+  });
+
 });

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -7512,3 +7512,44 @@ body.modern-ui.v2-canvas {
 .v2-root:lang(zh) .v2-team__title {
   letter-spacing: 0;
 }
+
+/* ---------------------------------------------------------------------------
+ * zh-CN: CJK body line-height 1.6 and a 12px floor (TASK-055, rule class 2).
+ * Latin body copy sits at 1.45–1.55 here; CJK glyphs fill the em box, so the
+ * same leading leaves no white between lines. Measured in the real browser
+ * (.dev/task-055-zh-harness.html): .v2-msg__content 21.7px/14px = 1.55,
+ * .v2-chat__composer-hint 1.45, .v2-inspector__pod-meta 1.45, and the
+ * composer hint (11px) / inspector tab (11.5px) render CJK below the 12px
+ * legibility floor. Single-line nowrap+ellipsis rows are not touched — their
+ * height is not text-driven. Guarded by v2-layout-invariants.test.ts.
+ * ------------------------------------------------------------------------ */
+.v2-root:lang(zh) .v2-msg__content,
+.v2-root:lang(zh) .v2-msg__content pre,
+.v2-root:lang(zh) .v2-chat__composer-hint,
+.v2-root:lang(zh) .v2-chat__delivery-hint,
+.v2-root:lang(zh) .v2-chat__readonly-text,
+.v2-root:lang(zh) .v2-chat__new-pod-text,
+.v2-root:lang(zh) .v2-first-run__lede,
+.v2-root:lang(zh) .v2-first-run__step-body,
+.v2-root:lang(zh) .v2-pods__join-notice,
+.v2-root:lang(zh) .v2-pods__discover-description,
+.v2-root:lang(zh) .v2-pods__community-copy,
+.v2-root:lang(zh) .v2-inspector__pod-meta,
+.v2-root:lang(zh) .v2-inspector__now-meta,
+.v2-root:lang(zh) .v2-inspector__goal-text,
+.v2-root:lang(zh) .v2-inspector__empty,
+.v2-root:lang(zh) .v2-inspector__danger-text,
+.v2-root:lang(zh) .v2-inspector__detail-body,
+.v2-root:lang(zh) .v2-modal__hint,
+.v2-root:lang(zh) .v2-invite-card__description,
+.v2-root:lang(zh) .v2-login__field-hint,
+.v2-root:lang(zh) .v2-billing__note,
+.v2-root:lang(zh) .v2-approval__summary,
+.v2-root:lang(zh) .v2-approval__action {
+  line-height: 1.6;
+}
+
+.v2-root:lang(zh) .v2-chat__composer-hint,
+.v2-root:lang(zh) button.v2-inspector__tab {
+  font-size: 12px;
+}


### PR DESCRIPTION
## TASK-055 — rule class 2 of 3: CJK body line-height 1.6 + 12px floor

Sam cleared these as repair under the UI freeze (TASK-055 row, 2026-08-26 07:07Z). Scoped to `:lang(zh)`; English renders byte-for-byte the same.

**Measured (real browser, `.dev/task-055-zh-harness.html`, real `v2.css`, zh-CN strings, 1200 / 390):** `.v2-msg__content` 14px at `21.7px` (1.55), `.v2-chat__composer-hint` 11px at 1.45, `.v2-inspector__pod-meta` 12px at 1.45; the composer hint (11px) and inspector tab (11.5px) render CJK below the 12px legibility floor.

**Fix:** one `:lang(zh)` block lifts the body-copy selectors (message content, composer/delivery/readonly hints, first-run lede, inspector meta/goal/empty/detail, modal/invite/login hints, billing note, approval summary) to `line-height: 1.6`, and floors the composer hint + inspector tab at 12px. Single-line `nowrap` + ellipsis rows are untouched — their height is not text-driven.

**Guard:** presence test in `v2-layout-invariants.test.ts`.

Sibling PRs: #1253 (class 1, tracking reset); class 3 (i18n literals) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)