### PR TITLE
fix(v2): rail tooltip, community redirect, drawer aria-label and Lead badge through i18n (TASK-055 class 3)

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -10,6 +10,17 @@
       "label": "Language",
       "switchToEnglish": "Switch to English",
       "switchToChinese": "Switch to Simplified Chinese"
+    },
+    "nav": {
+      "pods": "Pods",
+      "agents": "Agents",
+      "community": "Community",
+      "settings": "Settings"
+    },
+    "closePodsList": "Close pods list",
+    "communityRedirect": {
+      "title": "Opening Community",
+      "text": "Checking your access…"
     }
   },
   "auth": {
@@ -341,7 +352,8 @@
       "replyInThread": "Reply in thread",
       "replyFromExpandedThread": "Reply from expanded thread",
       "replyingInThread": "Replying in thread ·"
-    }
+    },
+    "leadBadge": "Lead"
   },
   "landing": {
     "nav": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -10,6 +10,17 @@
       "label": "语言",
       "switchToEnglish": "切换到英文",
       "switchToChinese": "切换到简体中文"
+    },
+    "nav": {
+      "pods": "Pod",
+      "agents": "智能体",
+      "community": "社区",
+      "settings": "设置"
+    },
+    "closePodsList": "关闭 Pod 列表",
+    "communityRedirect": {
+      "title": "正在打开社区",
+      "text": "正在检查你的访问权限…"
     }
   },
   "auth": {
@@ -341,7 +352,8 @@
       "replyInThread": "在话题中回复",
       "replyFromExpandedThread": "在已展开的话题中回复",
       "replyingInThread": "正在话题中回复："
-    }
+    },
+    "leadBadge": "负责人"
   },
   "landing": {
     "nav": {

--- a/frontend/src/v2/components/V2CommunityRedirect.tsx
+++ b/frontend/src/v2/components/V2CommunityRedirect.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 const V2CommunityRedirect: React.FC = () => {
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   React.useEffect(() => {
     const communityPodId = process.env.REACT_APP_COMMUNITY_POD_ID || '';
@@ -34,8 +36,8 @@ const V2CommunityRedirect: React.FC = () => {
 
   return (
     <div className="v2-empty" role="status">
-      <div className="v2-empty__title">Opening Community</div>
-      <div className="v2-empty__text">Checking your access…</div>
+      <div className="v2-empty__title">{t('common.communityRedirect.title')}</div>
+      <div className="v2-empty__text">{t('common.communityRedirect.text')}</div>
     </div>
   );
 };

--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import V2NavRail from './V2NavRail';
 import V2PodsSidebar from './V2PodsSidebar';
 import V2PodChat from './V2PodChat';
@@ -67,6 +68,7 @@ const createdAtTime = (createdAt?: string): number => {
 };
 
 const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
+  const { t } = useTranslation();
   const { podId: paramPodId } = useParams<{ podId: string }>();
   const navigate = useNavigate();
   const { currentUser } = useAuth();
@@ -193,7 +195,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
         <button
           type="button"
           className="v2-mobile-backdrop"
-          aria-label="Close pods list"
+          aria-label={t('common.closePodsList')}
           onClick={closeMobileNav}
         />
       )}

--- a/frontend/src/v2/components/V2MessageBubble.tsx
+++ b/frontend/src/v2/components/V2MessageBubble.tsx
@@ -593,7 +593,7 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
           ) : (
             <span className="v2-msg__author">{author}</span>
           )}
-          {isLead && <span className="v2-msg__lead-badge">Lead</span>}
+          {isLead && <span className="v2-msg__lead-badge">{t('podChat.leadBadge')}</span>}
           {time && <span className="v2-msg__time">{time}</span>}
         </div>
         )}

--- a/frontend/src/v2/components/V2NavRail.tsx
+++ b/frontend/src/v2/components/V2NavRail.tsx
@@ -4,6 +4,7 @@ import V2Avatar from './V2Avatar';
 import V2FeedbackMenu from './V2FeedbackMenu';
 import V2LangSwitch from './V2LangSwitch';
 import { useAuth } from '../../context/AuthContext';
+import { useTranslation } from 'react-i18next';
 
 interface NavItem {
   key: string;
@@ -49,6 +50,10 @@ const V2NavRail: React.FC<V2NavRailProps> = ({ onPodsMobileNav }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { currentUser, logout } = useAuth();
+  const { t } = useTranslation();
+  // Labels resolve at render so the rail tooltip (v2.css attr(data-label))
+  // follows the active locale — NAV_ITEMS.label is the English fallback.
+  const navLabel = (item: NavItem) => t(`common.nav.${item.key}`, { defaultValue: item.label });
   const visibleNavItems = NAV_ITEMS.filter(
     (item) => item.key !== 'community' || Boolean(process.env.REACT_APP_COMMUNITY_POD_ID),
   );
@@ -90,11 +95,11 @@ const V2NavRail: React.FC<V2NavRailProps> = ({ onPodsMobileNav }) => {
                 type="button"
                 className={`v2-rail__item${isActive(item) ? ' v2-rail__item--active' : ''}`}
                 onClick={() => handleNavClick(item)}
-                title={item.label}
-                data-label={item.label}
+                title={navLabel(item)}
+                data-label={navLabel(item)}
               >
                 <span className="v2-rail__item-icon">{item.icon}</span>
-                <span className="v2-rail__item-label">{item.label}</span>
+                <span className="v2-rail__item-label">{navLabel(item)}</span>
               </button>
               {item.dividerAfter && <span className="v2-rail__divider" aria-hidden="true" />}
             </React.Fragment>


### PR DESCRIPTION
## TASK-055 — rule class 3 of 3: English that never reached i18n

Sam cleared these as repair under the UI freeze (TASK-055 row, 2026-08-26 07:07Z). Copy only — no CSS; English strings are unchanged.

**Found (harness + component sweep):** under zh-CN the nav-rail hover tooltip renders English because `v2.css:531` draws `attr(data-label)` from the hardcoded `Pods / Agents / Community / Settings` labels in `V2NavRail.tsx`, which never passed through `t()`. Same class: `Opening Community` / `Checking your access…` (`V2CommunityRedirect`), the mobile backdrop `aria-label="Close pods list"` (`V2Layout`), and the chat `Lead` badge (`V2MessageBubble`). The other ~55 literals in the sweep are integration/file-type proper nouns and stay.

**Fix:** keys added to both locales — `common.nav.*`, `common.closePodsList`, `common.communityRedirect.{title,text}`, `podChat.leadBadge` — and the four sites read them. `NAV_ITEMS.label` stays as the `defaultValue` fallback.

**Verification:** `tsc` clean on the touched files; the i18n parity suite passes. `V2MessageBubble` / `V2PodsSidebar.community` suites fail identically on untouched `main` in this environment (`@dicebear/core` missing from local node_modules), so CI is the check for those.

Sibling PRs: #1253 (class 1, tracking reset), #1254 (class 2, line-height + 12px floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)