### PR TITLE
fix(v2): mobile inputs stop triggering iOS auto-zoom; the inspector becomes a drawer

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -105,6 +105,30 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).not.toContain('.v2-team-card__runtime {');
   });
 
+  test('touch inputs are 16px — iOS auto-zoom never fires and never strands the page zoomed', () => {
+    // Every input under 16px makes iOS Safari zoom on focus and stay zoomed
+    // on blur (Sam, 2026-08-26). The floor lives in the touch media block and
+    // must keep its !important (it has to beat per-component sizes including
+    // a legacy 15px !important).
+    expect(v2).toMatch(/@media \(hover: none\), \(pointer: coarse\) \{[\s\S]*?\.v2-root input,\n\s*\.v2-root textarea,\n\s*\.v2-root select \{\n\s*font-size: 16px !important;/);
+  });
+
+  test('the mobile inspector is a drawer, never display:none — the header avatars button must do something', () => {
+    // Below 1024px the pane used display:none while V2Layout still mounted it
+    // on tap: the avatar-stack button looked broken and members/files were
+    // unreachable on phones (Sam, 2026-08-26). The pane's presence in the DOM
+    // is the open state, so the drawer needs no extra toggle class.
+    // Slice the 1023px block out rather than regex across it — a lazy
+    // [\s\S]*? happily crosses media-block boundaries and matches unrelated
+    // rules pages later.
+    const start = v2.indexOf('@media (max-width: 1023px)');
+    expect(start).toBeGreaterThan(-1);
+    const block = v2.slice(start, v2.indexOf('@media', start + 10));
+    expect(block).toContain('.v2-pane--inspector');
+    expect(block).toContain('position: fixed');
+    expect(block).not.toContain('display: none');
+  });
+
   test('v2 claims the page canvas — the V1 dark body cannot show through', () => {
     // App.tsx stamps `modern-ui` (V1 dark gradient) on <body> unconditionally;
     // .v2-root paints only its own box. Without this override the V1 dark

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -5335,8 +5335,23 @@ body.modern-ui.v2-canvas {
     grid-template-columns: var(--v2-rail-w) var(--v2-pods-w) minmax(0, 1fr);
   }
 
+  /* Below the 3-pane width the inspector becomes a right DRAWER, not a
+     casualty. Hiding the pane outright here made the avatar-stack button a
+     no-op on phones: V2Layout mounts the pane on tap, CSS hid it, and the
+     pod's members/files/artifacts were unreachable on mobile entirely
+     (Sam, 2026-08-26). The pane only exists in the DOM while open
+     (V2Layout mounts it conditionally), so its presence IS the open state;
+     the existing v2-inspector__close dismisses it. Shadow is allowed here:
+     the design system reserves shadows for floating UI, which this now is. */
   .v2-pane--inspector {
-    display: none;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(360px, calc(100vw - 48px));
+    z-index: 60;
+    border-left: 1px solid var(--v2-border);
+    box-shadow: -12px 0 32px rgba(17, 24, 39, 0.14);
   }
 }
 
@@ -6441,6 +6456,21 @@ body.modern-ui.v2-canvas {
    all row variants, zero layout shift. See the cluster block near .v2-msg.
    Touch layouts keep ≥44px targets via the media block below. */
 @media (hover: none), (pointer: coarse) {
+  /* iOS Safari auto-zooms on focusing any input under 16px and does not
+     zoom back on blur — the shell's inputs ranged 12–15px, so every tap on
+     the composer or a search field left the page stuck zoomed (Sam,
+     2026-08-26). 16px on touch devices removes the trigger entirely; this
+     is the root fix, NOT the viewport maximum-scale hack, which blocks
+     pinch-zoom on Android and is an accessibility regression. !important is
+     deliberate: it must beat every per-component size including the legacy
+     15px !important, and a device-scoped accessibility floor is the rare
+     case that earns it. */
+  .v2-root input,
+  .v2-root textarea,
+  .v2-root select {
+    font-size: 16px !important;
+  }
+
   /* No hover on touch — but always-on clusters over every message are
      chrome over content (Sam, 2026-08-23). A tap on the message toggles
      .v2-msg--reveal (V2MessageBubble.onBubbleTap, gated to hoverless


### PR DESCRIPTION
Sam's two mobile reports: (1) the stuck-zoom — every input ran 12–15px, under iOS Safari's 16px auto-zoom threshold, and the zoom never reverts on blur; touch devices now floor inputs at 16px (root fix — the viewport maximum-scale hack blocks Android pinch-zoom). (2) The right sidebar was unreachable on phones: below 1024px the inspector pane was hidden outright while the header avatar-stack button still mounted it — the mounted pane now renders as a fixed right drawer, dismissed by its existing close button. Both invariant-pinned; 299/299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK