### PR TITLE
perf(seo): keep public guides static in browsers

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -37,7 +37,9 @@
          script runs before first paint: browsers (JS on) never show the
          prerender; crawlers without JS still get the full content. Not
          cloaking — JS-running crawlers see the real app. -->
+    <!-- SEO_GATE_START -->
     <script>document.documentElement.className += ' js';</script>
+    <!-- SEO_GATE_END -->
     <style>
       html.js #seo-page { display: none; }
       #seo-page { box-sizing: border-box; min-height: 100vh; color: #e5e7eb; background: #0b1220; font: 16px/1.6 Inter, ui-sans-serif, system-ui, sans-serif; }
@@ -72,6 +74,7 @@
       #seo-page .seo-footer { padding: 40px 0; color: #94a3b8; border-top: 1px solid #334155; }
       @media (max-width: 640px) { #seo-page .seo-header { align-items: flex-start; flex-direction: column; padding: 20px 0; } #seo-page section { padding: 44px 0; } #seo-page .seo-hero { padding-top: 56px; padding-bottom: 56px; } }
     </style>
+    <!-- SEO_NAVIGATION_RUNTIME_START -->
     <script>
       // Force re-render on navigation
       window.addEventListener('popstate', function() {
@@ -81,6 +84,7 @@
         }, 0);
       });
     </script>
+    <!-- SEO_NAVIGATION_RUNTIME_END -->
   </head>
   <body>
     <div id="root"><!-- SEO_PAGE_CONTENT --></div>

--- a/frontend/scripts/generate-seo-pages.mjs
+++ b/frontend/scripts/generate-seo-pages.mjs
@@ -9,6 +9,10 @@ const siteUrl = 'https://commonly.me';
 const metadataStart = '<!-- SEO_METADATA_START -->';
 const metadataEnd = '<!-- SEO_METADATA_END -->';
 const pageContentMarker = '<!-- SEO_PAGE_CONTENT -->';
+const gateRuntimeStart = '<!-- SEO_GATE_START -->';
+const gateRuntimeEnd = '<!-- SEO_GATE_END -->';
+const navigationRuntimeStart = '<!-- SEO_NAVIGATION_RUNTIME_START -->';
+const navigationRuntimeEnd = '<!-- SEO_NAVIGATION_RUNTIME_END -->';
 
 const escapeHtml = (value) => String(value)
   .replaceAll('&', '&amp;')
@@ -29,6 +33,25 @@ const replaceMarkedSection = (template, start, end, content) => {
 
   return `${template.slice(0, startIndex)}${start}\n${content}\n${end}${template.slice(endIndex + end.length)}`;
 };
+
+const removeMarkedSection = (template, start, end) => {
+  const startIndex = template.indexOf(start);
+  const endIndex = template.indexOf(end);
+
+  if (startIndex < 0 || endIndex < 0 || endIndex < startIndex) {
+    throw new Error(`Missing or malformed ${start} marker in the Vite output.`);
+  }
+
+  return `${template.slice(0, startIndex)}${template.slice(endIndex + end.length)}`;
+};
+
+const staticDocument = (template) => removeMarkedSection(
+  removeMarkedSection(template, gateRuntimeStart, gateRuntimeEnd),
+  navigationRuntimeStart,
+  navigationRuntimeEnd,
+)
+  .replaceAll(/<link\b(?=[^>]*\brel="modulepreload")[^>]*>\s*/g, '')
+  .replaceAll(/<script\b[^>]*\btype="module"[^>]*>\s*<\/script>\s*/g, '');
 
 const pageUrl = (path) => `${siteUrl}${path}`;
 
@@ -371,6 +394,7 @@ export const buildPageDefinitions = ({ landing, compare, useCases, guides = {} }
     title: 'Guides for teams working with AI agents | Commonly',
     description: 'Practical guides for teams that work with AI agents: shared context, task ownership, human review, and durable handoffs.',
     content: renderGuidesIndex(guides),
+    staticOnly: true,
     schema: webPage('Guides for teams working with AI agents', 'Practical guides for teams that work with AI agents: shared context, task ownership, human review, and durable handoffs.', guidesIndexPath),
   };
 
@@ -397,6 +421,7 @@ export const buildPageDefinitions = ({ landing, compare, useCases, guides = {} }
       title: guide.titleTag,
       description: guide.description,
       content: renderGuide(guide),
+      staticOnly: true,
       ogType: 'article',
       datePublished: provenance.datePublished,
       dateModified: provenance.dateModified,
@@ -429,7 +454,8 @@ export const buildPageDefinitions = ({ landing, compare, useCases, guides = {} }
 };
 
 export const renderStaticPage = (template, page) => {
-  const withMetadata = replaceMarkedSection(template, metadataStart, metadataEnd, metadata(page));
+  const staticTemplate = page.staticOnly ? staticDocument(template) : template;
+  const withMetadata = replaceMarkedSection(staticTemplate, metadataStart, metadataEnd, metadata(page));
   if (!withMetadata.includes(pageContentMarker)) {
     throw new Error('Missing SEO page-content marker in the Vite output.');
   }

--- a/frontend/scripts/generate-seo-pages.mjs
+++ b/frontend/scripts/generate-seo-pages.mjs
@@ -13,6 +13,7 @@ const gateRuntimeStart = '<!-- SEO_GATE_START -->';
 const gateRuntimeEnd = '<!-- SEO_GATE_END -->';
 const navigationRuntimeStart = '<!-- SEO_NAVIGATION_RUNTIME_START -->';
 const navigationRuntimeEnd = '<!-- SEO_NAVIGATION_RUNTIME_END -->';
+const viteEntryAssetPrefix = 'src="/assets/index-';
 
 const escapeHtml = (value) => String(value)
   .replaceAll('&', '&amp;')
@@ -45,13 +46,56 @@ const removeMarkedSection = (template, start, end) => {
   return `${template.slice(0, startIndex)}${template.slice(endIndex + end.length)}`;
 };
 
-const staticDocument = (template) => removeMarkedSection(
-  removeMarkedSection(template, gateRuntimeStart, gateRuntimeEnd),
-  navigationRuntimeStart,
-  navigationRuntimeEnd,
-)
-  .replaceAll(/<link\b(?=[^>]*\brel="modulepreload")[^>]*>\s*/g, '')
-  .replaceAll(/<script\b[^>]*\btype="module"[^>]*>\s*<\/script>\s*/g, '');
+const removeRuntimeEntryScript = (template) => {
+  const entryIndex = template.indexOf(viteEntryAssetPrefix);
+  const tagStart = template.lastIndexOf('<', entryIndex);
+  const tagEnd = template.indexOf('>', entryIndex);
+
+  if (
+    entryIndex < 0
+    || tagStart < 0
+    || tagEnd < entryIndex
+    || !template.startsWith('<script', tagStart)
+  ) {
+    throw new Error('Missing or malformed SEO runtime entry script in the Vite output.');
+  }
+
+  return `${template.slice(0, tagStart)}${template.slice(tagEnd + 1)}`;
+};
+
+const removeModulePreloads = (template) => {
+  let document = template;
+  let preloadIndex = document.indexOf('rel="modulepreload"');
+
+  while (preloadIndex >= 0) {
+    const tagStart = document.lastIndexOf('<', preloadIndex);
+    const tagEnd = document.indexOf('>', preloadIndex);
+
+    if (
+      tagStart < 0
+      || tagEnd < preloadIndex
+      || !document.startsWith('<link', tagStart)
+    ) {
+      throw new Error('Missing or malformed module preload in the Vite output.');
+    }
+
+    document = `${document.slice(0, tagStart)}${document.slice(tagEnd + 1)}`;
+    preloadIndex = document.indexOf('rel="modulepreload"');
+  }
+
+  return document;
+};
+
+const staticDocument = (template) => {
+  const withoutGateRuntime = removeMarkedSection(template, gateRuntimeStart, gateRuntimeEnd);
+  const withoutNavigationRuntime = removeMarkedSection(
+    withoutGateRuntime,
+    navigationRuntimeStart,
+    navigationRuntimeEnd,
+  );
+
+  return removeModulePreloads(removeRuntimeEntryScript(withoutNavigationRuntime));
+};
 
 const pageUrl = (path) => `${siteUrl}${path}`;
 

--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -54,7 +54,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const taskManagementArticle = taskManagementGuide.schema['@graph'].find((item) => item['@type'] === 'Article');
   assert.equal(taskManagementArticle.datePublished, '2026-08-25');
   assert.equal(taskManagementArticle.dateModified, '2026-08-25');
-  const guideTemplate = '<head><!-- SEO_METADATA_START --><!-- SEO_METADATA_END --><!-- SEO_GATE_START --><script>document.documentElement.className += \' js\';</script><!-- SEO_GATE_END --><style>#seo-page { color: #fff; }</style><!-- SEO_NAVIGATION_RUNTIME_START --><script>window.addEventListener(\'popstate\', () => {});</script><!-- SEO_NAVIGATION_RUNTIME_END --><link rel="modulepreload" href="/assets/chunk.js"><script type="module" crossorigin src="/assets/index.js"></script></head><body><div id="root"><!-- SEO_PAGE_CONTENT --></div></body>';
+  const guideTemplate = '<head><!-- SEO_METADATA_START --><!-- SEO_METADATA_END --><!-- SEO_GATE_START --><script>document.documentElement.className += \' js\';</script><!-- SEO_GATE_END --><style>#seo-page { color: #fff; }</style><!-- SEO_NAVIGATION_RUNTIME_START --><script>window.addEventListener(\'popstate\', () => {});</script><!-- SEO_NAVIGATION_RUNTIME_END --><link rel="modulepreload" href="/assets/chunk.js"><script type="module" crossorigin src="/assets/index-abcd.js"></script></head><body><div id="root"><!-- SEO_PAGE_CONTENT --></div></body>';
   const taskManagementHtml = renderStaticPage(guideTemplate, taskManagementGuide);
   assert.match(taskManagementHtml, /By Commonly · Reviewed by Commonly SEO team/);
   assert.match(taskManagementHtml, /article:published_time" content="2026-08-25"/);
@@ -65,6 +65,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.doesNotMatch(taskManagementHtml, /popstate/);
   assert.doesNotMatch(taskManagementHtml, /modulepreload/);
   assert.doesNotMatch(taskManagementHtml, /type="module"/);
+  assert.doesNotMatch(taskManagementHtml, /src="\/assets\/index-/);
   assert.match(taskManagementHtml, /#seo-page \{ color: #fff; \}/);
   for (const guidePath of [
     '/guides/multi-agent-collaboration-platform/',
@@ -86,7 +87,7 @@ test('puts route content, canonical metadata, and structured data in the documen
     content: '<main><h1>Example page</h1><a href="/">Home</a></main>',
     schema: { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Example page' },
   };
-  const template = '<head><!-- SEO_METADATA_START --><!-- SEO_METADATA_END --><!-- SEO_GATE_START --><script>document.documentElement.className += \' js\';</script><!-- SEO_GATE_END --><!-- SEO_NAVIGATION_RUNTIME_START --><script>window.addEventListener(\'popstate\', () => {});</script><!-- SEO_NAVIGATION_RUNTIME_END --><script type="module" src="/assets/index.js"></script></head><body><div id="root"><!-- SEO_PAGE_CONTENT --></div></body>';
+  const template = '<head><!-- SEO_METADATA_START --><!-- SEO_METADATA_END --><!-- SEO_GATE_START --><script>document.documentElement.className += \' js\';</script><!-- SEO_GATE_END --><!-- SEO_NAVIGATION_RUNTIME_START --><script>window.addEventListener(\'popstate\', () => {});</script><!-- SEO_NAVIGATION_RUNTIME_END --><script type="module" src="/assets/index-abcd.js"></script></head><body><div id="root"><!-- SEO_PAGE_CONTENT --></div></body>';
   const rendered = renderStaticPage(template, page);
 
   assert.match(rendered, /<h1>Example page<\/h1>/);

--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -54,13 +54,18 @@ test('emits a canonical crawlable page for every public route', async () => {
   const taskManagementArticle = taskManagementGuide.schema['@graph'].find((item) => item['@type'] === 'Article');
   assert.equal(taskManagementArticle.datePublished, '2026-08-25');
   assert.equal(taskManagementArticle.dateModified, '2026-08-25');
-  const guideTemplate = '<head><!-- SEO_METADATA_START --><!-- SEO_METADATA_END --></head><body><div id="root"><!-- SEO_PAGE_CONTENT --></div></body>';
+  const guideTemplate = '<head><!-- SEO_METADATA_START --><!-- SEO_METADATA_END --><!-- SEO_GATE_START --><script>document.documentElement.className += \' js\';</script><!-- SEO_GATE_END --><style>#seo-page { color: #fff; }</style><!-- SEO_NAVIGATION_RUNTIME_START --><script>window.addEventListener(\'popstate\', () => {});</script><!-- SEO_NAVIGATION_RUNTIME_END --><link rel="modulepreload" href="/assets/chunk.js"><script type="module" crossorigin src="/assets/index.js"></script></head><body><div id="root"><!-- SEO_PAGE_CONTENT --></div></body>';
   const taskManagementHtml = renderStaticPage(guideTemplate, taskManagementGuide);
   assert.match(taskManagementHtml, /By Commonly · Reviewed by Commonly SEO team/);
   assert.match(taskManagementHtml, /article:published_time" content="2026-08-25"/);
   assert.match(taskManagementHtml, /article:modified_time" content="2026-08-25"/);
   assert.match(taskManagementHtml, /href="\/guides\/multi-agent-collaboration-platform\/"/);
   assert.match(taskManagementHtml, /href="\/guides\/ai-agent-workspace\/"/);
+  assert.doesNotMatch(taskManagementHtml, /document\.documentElement/);
+  assert.doesNotMatch(taskManagementHtml, /popstate/);
+  assert.doesNotMatch(taskManagementHtml, /modulepreload/);
+  assert.doesNotMatch(taskManagementHtml, /type="module"/);
+  assert.match(taskManagementHtml, /#seo-page \{ color: #fff; \}/);
   for (const guidePath of [
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',
@@ -81,10 +86,12 @@ test('puts route content, canonical metadata, and structured data in the documen
     content: '<main><h1>Example page</h1><a href="/">Home</a></main>',
     schema: { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Example page' },
   };
-  const template = '<head><!-- SEO_METADATA_START --><!-- SEO_METADATA_END --></head><body><div id="root"><!-- SEO_PAGE_CONTENT --></div></body>';
+  const template = '<head><!-- SEO_METADATA_START --><!-- SEO_METADATA_END --><!-- SEO_GATE_START --><script>document.documentElement.className += \' js\';</script><!-- SEO_GATE_END --><!-- SEO_NAVIGATION_RUNTIME_START --><script>window.addEventListener(\'popstate\', () => {});</script><!-- SEO_NAVIGATION_RUNTIME_END --><script type="module" src="/assets/index.js"></script></head><body><div id="root"><!-- SEO_PAGE_CONTENT --></div></body>';
   const rendered = renderStaticPage(template, page);
 
   assert.match(rendered, /<h1>Example page<\/h1>/);
   assert.match(rendered, /<link rel="canonical" href="https:\/\/commonly\.me\/example\/"/);
   assert.match(rendered, /application\/ld\+json/);
+  assert.match(rendered, /document\.documentElement/);
+  assert.match(rendered, /type="module"/);
 });


### PR DESCRIPTION
## Summary
- stop booting the React runtime on the guides hub and three published guides
- retain the same static HTML, metadata, JSON-LD, and guide styling for every visitor
- leave the app shell and other public/app routes unchanged

## Validation
- `npm test -- --runInBand`
- `npm run build`
- verified all four generated guide documents retain `<h1>` and metadata while containing no module runtime or preload
- local browser verification of `/guides/ai-agent-task-management/` confirms styled content and zero module scripts

@ sage-seo-lead: SEO review requested.