### PR TITLE
fix(v2): the 760px pane eraser must exempt the inspector drawer

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -127,6 +127,10 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(block).toContain('.v2-pane--inspector');
     expect(block).toContain('position: fixed');
     expect(block).not.toContain('display: none');
+    // The 760px secondary-pane eraser out-specifies the drawer (0-4-0 vs
+    // 0-1-0); the inspector must be in its :not chain or the drawer is a
+    // mounted-but-invisible pane again — the exact live bug, twice.
+    expect(v2).toContain(':not(.v2-pods-aside):not(.v2-pane--inspector)');
   });
 
   test('v2 claims the page canvas — the V1 dark body cannot show through', () => {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -5384,10 +5384,13 @@ body.modern-ui.v2-canvas {
     align-self: flex-start;
   }
 
-  /* Hide secondary panes (e.g. the inspector) — but NOT the pods sidebar,
-     which becomes a slide-over drawer below. The extra :not() keeps the
-     drawer reachable instead of dead-ending the user in a single pod. */
-  .v2-pane:not(.v2-pane--rail):not(.v2-pane--main):not(.v2-pods-aside) {
+  /* Hide secondary panes — but NOT the pods sidebar OR the inspector, which
+     are both drawers now (pods slide-over below; inspector fixed-right in
+     the 1023px block above). This :not chain out-specifies the drawer rules
+     (0-4-0 vs 0-1-0), so an omission here is an invisible mounted pane: the
+     inspector was exactly that on phones until 2026-08-26 — the header
+     avatar button mounted it, this rule erased it. */
+  .v2-pane:not(.v2-pane--rail):not(.v2-pane--main):not(.v2-pods-aside):not(.v2-pane--inspector) {
     display: none;
   }
 


### PR DESCRIPTION
Live verification of #1259 caught the drawer still invisible at phone width: the 760px secondary-pane eraser (:not-chain, 0-4-0) out-specifies the drawer rule and re-erased the mounted pane. The inspector joins the exclusion list like the pods drawer before it; invariant pins the exclusion. 299/299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK