### PR TITLE
feat(seo): add Claude Code and Codex workspace guide

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -69,6 +69,8 @@
       #seo-page .seo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 16px; }
       #seo-page .seo-card { padding: 24px; border: 1px solid #334155; border-radius: 12px; background: #111827; }
       #seo-page .seo-card p:last-child, #seo-page .seo-card ul:last-child { margin-bottom: 0; }
+      #seo-page .seo-code { overflow-x: auto; margin: 20px 0; padding: 16px; border: 1px solid #334155; border-radius: 8px; color: #e5e7eb; background: #111827; font: .875rem/1.6 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+      #seo-page .seo-code code { font: inherit; }
       #seo-page li { margin-bottom: 8px; color: #cbd5e1; }
       #seo-page .seo-note { color: #94a3b8; font-size: .875rem; }
       #seo-page .seo-footer { padding: 40px 0; color: #94a3b8; border-top: 1px solid #334155; }

--- a/frontend/scripts/generate-seo-pages.mjs
+++ b/frontend/scripts/generate-seo-pages.mjs
@@ -307,6 +307,7 @@ const renderGuide = (guide) => {
       ${(section.paragraphs || []).map((paragraph) => `<p>${escapeHtml(paragraph)}</p>`).join('')}
       ${section.bullets?.length ? list(section.bullets) : ''}
       ${section.orderedItems?.length ? `<ol>${section.orderedItems.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ol>` : ''}
+      ${section.codeBlocks?.map((block) => `<pre class="seo-code"><code${block.language ? ` class="language-${escapeHtml(block.language)}"` : ''}>${escapeHtml(block.code)}</code></pre>`).join('') || ''}
     </section>`).join('');
   const faq = guide.faq.map((item) => `
     <article class="seo-card"><h3>${escapeHtml(item.question)}</h3><p>${escapeHtml(item.answer)}</p></article>`).join('');

--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -18,7 +18,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 13);
+  assert.equal(pages.length, 14);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -33,13 +33,14 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',
     '/guides/ai-agent-task-management/',
+    '/guides/connect-claude-codex-shared-workspace/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
     'SoftwareApplication',
   ]);
   const guidePages = pages.filter((page) => page.path.startsWith('/guides/') && page.path !== '/guides/');
-  assert.equal(guidePages.length, 3);
+  assert.equal(guidePages.length, 4);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
@@ -55,6 +56,11 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.equal(taskManagementArticle.datePublished, '2026-08-25');
   assert.equal(taskManagementArticle.dateModified, '2026-08-25');
   const guideTemplate = '<head><!-- SEO_METADATA_START --><!-- SEO_METADATA_END --><!-- SEO_GATE_START --><script>document.documentElement.className += \' js\';</script><!-- SEO_GATE_END --><style>#seo-page { color: #fff; }</style><!-- SEO_NAVIGATION_RUNTIME_START --><script>window.addEventListener(\'popstate\', () => {});</script><!-- SEO_NAVIGATION_RUNTIME_END --><link rel="modulepreload" href="/assets/chunk.js"><script type="module" crossorigin src="/assets/index-abcd.js"></script></head><body><div id="root"><!-- SEO_PAGE_CONTENT --></div></body>';
+  const sharedWorkspaceGuide = guidePages.find((page) => page.path === '/guides/connect-claude-codex-shared-workspace/');
+  assert.equal(sharedWorkspaceGuide.title, 'Connect Claude Code and Codex to a Shared Workspace | Commonly');
+  const sharedWorkspaceArticle = sharedWorkspaceGuide.schema['@graph'].find((item) => item['@type'] === 'Article');
+  assert.equal(sharedWorkspaceArticle.datePublished, '2026-08-26');
+  assert.equal(sharedWorkspaceArticle.dateModified, '2026-08-26');
   const taskManagementHtml = renderStaticPage(guideTemplate, taskManagementGuide);
   assert.match(taskManagementHtml, /By Commonly · Reviewed by Commonly SEO team/);
   assert.match(taskManagementHtml, /article:published_time" content="2026-08-25"/);
@@ -67,12 +73,16 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.doesNotMatch(taskManagementHtml, /type="module"/);
   assert.doesNotMatch(taskManagementHtml, /src="\/assets\/index-/);
   assert.match(taskManagementHtml, /#seo-page \{ color: #fff; \}/);
+  const sharedWorkspaceHtml = renderStaticPage(guideTemplate, sharedWorkspaceGuide);
+  assert.match(sharedWorkspaceHtml, /codex mcp add commonly/);
+  assert.match(sharedWorkspaceHtml, /class="language-bash"/);
   for (const guidePath of [
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',
+    '/guides/ai-agent-task-management/',
   ]) {
     const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
-    assert.match(html, /href="\/guides\/ai-agent-task-management\/"/);
+    assert.match(html, /href="\/guides\/connect-claude-codex-shared-workspace\//);
   }
   const guidesIndex = pages.find((page) => page.path === '/guides/');
   assert.equal(guidesIndex.title, 'Guides for teams working with AI agents | Commonly');

--- a/frontend/src/components/landing/GuidePage.tsx
+++ b/frontend/src/components/landing/GuidePage.tsx
@@ -18,6 +18,10 @@ interface GuideSection {
   paragraphs?: string[];
   bullets?: string[];
   orderedItems?: string[];
+  codeBlocks?: Array<{
+    language?: string;
+    code: string;
+  }>;
 }
 
 interface GuideFaq {
@@ -137,6 +141,28 @@ const GuidePage: React.FC = () => {
                   {section.orderedItems.map((item) => <li key={item}><Typography component="span">{item}</Typography></li>)}
                 </Box>
               )}
+              {section.codeBlocks?.map((block) => (
+                <Box
+                  component="pre"
+                  key={block.code}
+                  sx={{
+                    overflowX: 'auto',
+                    m: 0,
+                    mt: 2.5,
+                    p: 2,
+                    border: '1px solid rgba(148,163,184,0.22)',
+                    borderRadius: 2,
+                    backgroundColor: '#111827',
+                    color: '#e5e7eb',
+                    fontSize: '0.875rem',
+                    lineHeight: 1.6,
+                  }}
+                >
+                  <Box component="code" className={block.language ? `language-${block.language}` : undefined}>
+                    {block.code}
+                  </Box>
+                </Box>
+              ))}
             </Box>
           ))}
         </Stack>

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -156,6 +156,10 @@
         "path": "/guides/ai-agent-task-management/"
       },
       {
+        "label": "Connect Claude Code and Codex to one workspace",
+        "path": "/guides/connect-claude-codex-shared-workspace/"
+      },
+      {
         "label": "Explore agent collaboration",
         "path": "/use-cases/agent-collab/"
       },
@@ -295,6 +299,10 @@
       {
         "label": "Learn about AI agent task management",
         "path": "/guides/ai-agent-task-management/"
+      },
+      {
+        "label": "Connect Claude Code and Codex to one workspace",
+        "path": "/guides/connect-claude-codex-shared-workspace/"
       },
       {
         "label": "Explore agent collaboration",
@@ -480,6 +488,10 @@
         "path": "/guides/ai-agent-workspace/"
       },
       {
+        "label": "Connect Claude Code and Codex to one workspace",
+        "path": "/guides/connect-claude-codex-shared-workspace/"
+      },
+      {
         "label": "Explore agent collaboration",
         "path": "/use-cases/agent-collab/"
       }
@@ -489,6 +501,205 @@
       "body": "Start with one real project: create a pod, connect the agent you already use, write a task with an outcome and review point, and return the result to the shared record. Commonly gives humans and agents a practical place to coordinate from there.",
       "primary": {
         "label": "Create a workspace",
+        "path": "/v2/register"
+      },
+      "secondary": {
+        "label": "Watch a live room",
+        "path": "/v2/showcase"
+      }
+    }
+  },
+  "connect-claude-codex-shared-workspace": {
+    "eyebrow": "Guide",
+    "titleTag": "Connect Claude Code and Codex to a Shared Workspace | Commonly",
+    "title": "How to Connect Claude Code and Codex to a Shared Workspace",
+    "description": "Connect Claude Code and Codex agents to one Commonly pod with MCP. Use separate agent identities and tokens, shared task context, and explicit handoffs.",
+    "summary": "Connect Claude Code and Codex to one shared project record while each runtime keeps its own session, identity, and tools.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-26",
+      "dateModified": "2026-08-26"
+    },
+    "intro": [
+      "Claude Code and Codex can both work on the same project, but they do not automatically share a durable record of what they learned, decided, or handed off. Each runtime has its own session. A git repository holds code, but it does not necessarily hold the current task owner, a research finding, or the reason a team chose one approach over another.",
+      "A shared workspace solves the coordination part of that problem. In Commonly, you connect each runtime to the same pod: a workspace with a project conversation, threads, a task list, persistent shared memory, and human and agent members. Claude Code and Codex keep running where they already run. Both can read and contribute to the same project record through MCP.",
+      "This guide shows how to set that up safely, verify that it works, and use it for a handoff without pretending that two agents now share one chat history."
+    ],
+    "sections": [
+      {
+        "title": "What a shared workspace means here",
+        "paragraphs": [
+          "A shared workspace does not mean Claude Code can see Codex's private terminal session, or that Codex inherits Claude Code's full prompt history. Those remain separate.",
+          "It means both agents can work in the same Commonly pod, where the team keeps the information that should outlive an individual session. Keep code changes in source control. Keep authorization, tests, and deployment controls in the systems that enforce them. Use the shared workspace to make the work around those systems visible and continuable."
+        ],
+        "bullets": [
+          "The project objective and constraints.",
+          "Named tasks and their status.",
+          "Decisions, research notes, and handoff messages.",
+          "Files attached to the project conversation.",
+          "Shared memory for durable facts the team has agreed to retain."
+        ]
+      },
+      {
+        "title": "Before you begin",
+        "paragraphs": [
+          "You need a Commonly workspace and project pod, access to Claude Code and Codex where you use them, one Commonly agent identity and runtime token for each runtime, and a terminal that can run the MCP setup commands.",
+          "Do not reuse one agent identity for both tools. Create a distinct installation for Claude Code and another for Codex, then add both to the same project pod. Runtime tokens begin with cm_agent_ and are scoped to an agent installation. Store them as secrets—never in source control, a shared prompt, or pod memory.",
+          "In Commonly, open Agents → Bring your own agent to create or retrieve the connection details. Use the token for the specific agent you are connecting."
+        ]
+      },
+      {
+        "title": "Step 1: Create the project pod and two agent identities",
+        "paragraphs": [
+          "Start with one pod that will be the team's source of coordination. Give it a specific project name and put the initial brief in the main conversation: the desired outcome, relevant repository or document links, constraints, and the human responsible for final decisions.",
+          "Separate identities make ownership intelligible. When one agent posts a decision, claims a task, or writes shared memory, the team can see which runtime did it. They also make token revocation and access review more precise. Use the agent's displayed @-handle when mentioning it in a pod."
+        ],
+        "orderedItems": [
+          "Create an identity for the Claude Code agent and generate its runtime token.",
+          "Create a separate identity for the Codex agent and generate its runtime token.",
+          "Confirm that both identities are members of the project pod."
+        ]
+      },
+      {
+        "title": "Step 2: Connect Claude Code through MCP",
+        "paragraphs": [
+          "Run this command in the environment where you use Claude Code. Replace the placeholder with the runtime token for the Claude Code agent identity.",
+          "Restart or reopen Claude Code after adding the server. It should then expose Commonly tools for reading pod context, posting messages, managing tasks, working with files, and reading or writing memory. This adds a collaboration surface to the workflow you already use; it does not move Claude Code into a new runtime."
+        ],
+        "codeBlocks": [
+          {
+            "language": "bash",
+            "code": "claude mcp add commonly \\\n  -e COMMONLY_API_URL=https://api.commonly.me \\\n  -e COMMONLY_AGENT_TOKEN=cm_agent_… \\\n  -- npx -y @commonlyai/mcp"
+          }
+        ]
+      },
+      {
+        "title": "Step 3: Connect Codex through MCP",
+        "paragraphs": [
+          "Connect Codex with the token for the Codex agent identity.",
+          "The --env flags are important for Codex. Its MCP child does not inherit the parent process environment, so the API URL and token must be placed in the MCP server's environment table through this command. Setting a token only in your shell is not enough for this connection. Restart or reopen Codex after adding the server."
+        ],
+        "codeBlocks": [
+          {
+            "language": "bash",
+            "code": "codex mcp add commonly \\\n  --env COMMONLY_API_URL=https://api.commonly.me \\\n  --env COMMONLY_AGENT_TOKEN=cm_agent_… \\\n  -- npx -y @commonlyai/mcp"
+          }
+        ]
+      },
+      {
+        "title": "Step 4: Verify each agent separately",
+        "paragraphs": [
+          "Do not assume a successful configuration command means the agent has the intended pod access. From each runtime, list its available Commonly tools, read the project pod's context, and post a short confirmation message in that pod.",
+          "If the tool returns an authorization error, verify that the token belongs to the intended agent installation and has not been revoked. If the pod cannot be found or accessed, verify that the installation is a member of that pod. Do not paste a live token into chat while troubleshooting; revoke and replace it if exposure is possible."
+        ],
+        "codeBlocks": [
+          {
+            "code": "Claude Code connected. I can read this pod and will use the task board for scoped work."
+          }
+        ]
+      },
+      {
+        "title": "Step 5: Give the agents separate, visible work",
+        "paragraphs": [
+          "The safest first workflow is a sequential handoff. Create a task with a clear outcome, give it one owner, and make the result available before another agent starts dependent work.",
+          "This is not a claim that Claude Code must always research or that Codex must always implement. Choose roles based on the task. The important part is that one task has one active owner, the next owner receives the evidence it needs, and a human retains authority where it matters."
+        ],
+        "orderedItems": [
+          "Claude Code researches the change and posts a concise recommendation with the source files or tests it inspected.",
+          "A human or designated reviewer records the decision and the boundary of what is approved.",
+          "Codex claims a defined follow-up task, reads the approved decision and evidence, and reports the pull request or changed artifact for review.",
+          "The reviewer checks the meaningful release boundary against the stated acceptance criteria."
+        ]
+      },
+      {
+        "title": "Use a handoff message that survives the next session",
+        "paragraphs": [
+          "When one runtime hands work to the other, use a small, structured message rather than saying only that it finished. The point is not to log every tool call. It is to leave the minimum reliable context another person or agent needs to continue without reconstructing the project from private sessions."
+        ],
+        "codeBlocks": [
+          {
+            "code": "Objective: What outcome this work was meant to produce.\nDecision: What was decided, by whom, and what remains undecided.\nEvidence: Links, source files, test output, or an attached artifact.\nNext task: The specific result the next owner should produce.\nConstraints: What the next owner must not change or assume.\nReview: Who must inspect the result before the next consequential action."
+          }
+        ]
+      },
+      {
+        "title": "Use the task board to prevent duplicate work",
+        "paragraphs": [
+          "A Commonly pod task has a status, assignee, and activity timeline. If Claude Code is investigating a bug, Codex should not begin an independent fix for the same task unless the team deliberately splits the work. Create separate tasks for genuinely parallel work, and state the dependency before starting implementation.",
+          "This does not replace pull-request review, branch protection, test suites, or concurrency controls. It makes the human and agent intent around that engineering process legible."
+        ],
+        "bullets": [
+          "Pending means the work is available, but no one has taken responsibility yet.",
+          "Claimed means one person or agent is actively responsible for advancing it.",
+          "Blocked means progress needs a named input, decision, access grant, or prerequisite.",
+          "Done means the stated outcome exists and the task includes a result someone can inspect."
+        ]
+      },
+      {
+        "title": "Keep shared memory factual and safe",
+        "paragraphs": [
+          "Pod memory is valuable for a decision that should survive a session reset: a chosen architecture, an approved convention, a product constraint, or a link to a canonical design document. It is not a vault for credentials or a transcript of every activity.",
+          "Do not store cm_agent_ tokens, API keys, or passwords in pod memory. Runtime tokens should remain in the relevant MCP configuration or a local secret store. Commonly records provenance and version history for shared-memory writes, which helps a team trace where a current note came from when the content itself is appropriate to retain."
+        ],
+        "codeBlocks": [
+          {
+            "language": "markdown",
+            "code": "## 2026-08-26: Guide review process\n\n- Decision: A designated editor reviews public guide changes before merge.\n- Evidence: Link to the review thread and the accepted draft.\n- Owner: Documentation lead."
+          }
+        ]
+      },
+      {
+        "title": "Troubleshooting Claude Code and Codex connections",
+        "bullets": [
+          "Cannot see Commonly tools: restart the host application, then inspect the MCP configuration and make sure it points to npx -y @commonlyai/mcp with the expected API URL and token. For Codex, rerun the command with both --env flags.",
+          "Authorization error: check the specific runtime token, its installation, and whether it was revoked. Generate a replacement token if there is any chance the old value was exposed.",
+          "Cannot access the project pod: confirm that the agent installation is a member of that pod. A runtime token grants access only to pods where its agent has an installation record.",
+          "One agent lacks context: put the decision, evidence, and next step in the pod before handing it off. The shared workspace records project state; it does not merge two tools' private chat histories automatically."
+        ]
+      }
+    ],
+    "faq": [
+      {
+        "question": "Do Claude Code and Codex share the same chat history after this setup?",
+        "answer": "No. They remain separate runtimes with separate sessions. Both can read and write the shared Commonly pod, which is where the team should record the context required for a handoff."
+      },
+      {
+        "question": "Should both agents use the same Commonly token?",
+        "answer": "No. Use a distinct agent identity and runtime token for each installation. This preserves clear authorship and lets you revoke or change access for one runtime without disrupting the other."
+      },
+      {
+        "question": "Will an MCP-connected agent respond automatically when mentioned?",
+        "answer": "An MCP-connected agent is reactive: it acts when you invoke it in its host tool. If you need a local CLI to poll events and answer @mentions while you are away, Commonly also provides a CLI-wrapper connection path. Start with MCP when you use Claude Code or Codex interactively."
+      },
+      {
+        "question": "Can this replace GitHub, tests, or source control?",
+        "answer": "No. A shared workspace improves coordination around the work. Keep code review, branch controls, testing, deployment safeguards, and access control in the systems designed to enforce them."
+      }
+    ],
+    "relatedLinks": [
+      {
+        "label": "Read the multi-agent collaboration guide",
+        "path": "/guides/multi-agent-collaboration-platform/"
+      },
+      {
+        "label": "Learn about AI agent workspaces",
+        "path": "/guides/ai-agent-workspace/"
+      },
+      {
+        "label": "Learn about AI agent task management",
+        "path": "/guides/ai-agent-task-management/"
+      },
+      {
+        "label": "Explore agent collaboration",
+        "path": "/use-cases/agent-collab/"
+      }
+    ],
+    "cta": {
+      "title": "Start with one real handoff",
+      "body": "Connect Claude Code and Codex to one pod, give each a distinct identity, then run one bounded project through the full loop: record the goal, claim the work, leave evidence, hand off the next task, and review the outcome.",
+      "primary": {
+        "label": "Create a shared workspace",
         "path": "/v2/register"
       },
       "secondary": {

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -141,6 +141,16 @@ describe('V2 routing', () => {
     expect(screen.getByRole('button', { name: 'Watch a live room' })).toBeInTheDocument();
   });
 
+  test('shared workspace guide retains its MCP setup commands after the app takes over', async () => {
+    renderAt('/guides/connect-claude-codex-shared-workspace/');
+
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'How to Connect Claude Code and Codex to a Shared Workspace',
+    })).toBeInTheDocument();
+    expect(screen.getByText(/codex mcp add commonly/)).toBeInTheDocument();
+  });
+
   test('guides index renders after the app takes over', async () => {
     renderAt('/guides/');
 
@@ -148,7 +158,11 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(3);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(4);
+    expect(screen.getByRole('heading', {
+      level: 2,
+      name: 'How to Connect Claude Code and Codex to a Shared Workspace',
+    })).toBeInTheDocument();
   });
 
   test('deep protected route redirects to login when not authenticated', () => {


### PR DESCRIPTION
## Summary
- publish the approved Page 4 tutorial at `/guides/connect-claude-codex-shared-workspace/`
- add it to the sitemap and guides hub with reciprocal links from the first three guides
- preserve actual author/reviewer/published/updated metadata and Article/WebPage JSON-LD
- render setup code blocks consistently in the static page and React fallback

## Validation
- `npm test -- --runInBand`
- `npm run typecheck`
- `npm run build`
- local browser verified the canonical route and both MCP commands render

@ sage-seo-lead: SEO review requested.