### PR TITLE
fix(dm): atomically create agent DM rooms

### DIFF
--- a/backend/__tests__/services/dmService.agentDm.test.ts
+++ b/backend/__tests__/services/dmService.agentDm.test.ts
@@ -37,6 +37,7 @@ describe('DMService — agent-dm + sharePod', () => {
       instance: { dbName: 'dm-service-agent-dm-test' },
     });
     await mongoose.connect(mongoServer.getUri());
+    await Pod.init();
   });
 
   afterAll(async () => {
@@ -159,6 +160,42 @@ describe('DMService — agent-dm + sharePod', () => {
       expect(room1._id.toString()).toBe(room2._id.toString());
       const all = await Pod.find({ type: 'agent-dm' });
       expect(all).toHaveLength(1);
+    });
+
+    it('claims a legacy room before creating a room for the same pair', async () => {
+      const legacy = await Pod.create({
+        name: 'aria ↔ codex',
+        type: 'agent-dm',
+        joinPolicy: 'invite-only',
+        createdBy: aria._id,
+        members: [aria._id, codex._id],
+      });
+
+      const room = await DMService.getOrCreateAgentDmRoom(memberFor(codex), memberFor(aria));
+
+      expect(room._id.toString()).toBe(legacy._id.toString());
+      expect(room.agentDmPairKey).toBe(
+        [aria._id.toString(), codex._id.toString()].sort().join(':'),
+      );
+      expect(await Pod.countDocuments({ type: 'agent-dm' })).toBe(1);
+    });
+
+    it('atomically creates one room when callers race on the same pair', async () => {
+      const calls = Array.from(
+        { length: 16 },
+        (_, index) => DMService.getOrCreateAgentDmRoom(
+          index % 2 === 0 ? memberFor(aria) : memberFor(codex),
+          index % 2 === 0 ? memberFor(codex) : memberFor(aria),
+        ),
+      );
+      const rooms = await Promise.all(calls);
+
+      expect(new Set(rooms.map((room) => room._id.toString())).size).toBe(1);
+      const stored = await Pod.find({ type: 'agent-dm' });
+      expect(stored).toHaveLength(1);
+      expect(stored[0].agentDmPairKey).toBe(
+        [aria._id.toString(), codex._id.toString()].sort().join(':'),
+      );
     });
 
     it('creates AgentInstallation rows for both bot members', async () => {

--- a/backend/models/Pod.ts
+++ b/backend/models/Pod.ts
@@ -67,6 +67,11 @@ export interface IPod extends Document {
   };
   createdBy: Types.ObjectId;
   members: Types.ObjectId[];
+  // Canonical unordered two-member key for agent-dm pods. The partial unique
+  // index below is the storage-level backstop for concurrent DM creation.
+  // Optional because legacy pods predate the key and are claimed lazily by
+  // DMService rather than being rewritten by a schema migration at startup.
+  agentDmPairKey?: string;
   messages: Types.ObjectId[];
   announcements: Types.ObjectId[];
   externalLinks: Types.ObjectId[];
@@ -136,6 +141,7 @@ const PodSchema = new Schema<IPod>(
     },
     createdBy: { type: Schema.Types.ObjectId, ref: 'User', required: true },
     members: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+    agentDmPairKey: { type: String, trim: true },
     messages: [{ type: Schema.Types.ObjectId, ref: 'Message' }],
     announcements: [{ type: Schema.Types.ObjectId, ref: 'Announcement' }],
     externalLinks: [{ type: Schema.Types.ObjectId, ref: 'ExternalLink' }],
@@ -166,6 +172,22 @@ PodSchema.pre<IPod>('save', function (next) {
   }
   next();
 });
+
+// `members` is a multikey array, so it cannot express uniqueness of an
+// unordered two-member pair. DMService writes the canonical scalar key and
+// this index elects one winner when two callers create the same agent DM at
+// once. Keep the index partial: legacy pods have no key, and an explicit null
+// would otherwise collide under a unique index.
+PodSchema.index(
+  { agentDmPairKey: 1 },
+  {
+    unique: true,
+    partialFilterExpression: {
+      type: 'agent-dm',
+      agentDmPairKey: { $type: 'string' },
+    },
+  },
+);
 
 export default mongoose.model<IPod>('Pod', PodSchema);
 // CJS compat: let require() return the default export directly

--- a/backend/services/dmService.ts
+++ b/backend/services/dmService.ts
@@ -15,6 +15,13 @@ interface DMOptions {
   instanceId?: string;
 }
 
+interface AgentDmUpsertResult {
+  value: InstanceType<typeof Pod> | null;
+  lastErrorObject?: {
+    updatedExisting?: boolean;
+  };
+}
+
 // Mirror of agentIdentityService.resolveAgentDisplayLabel — duplicated here
 // to avoid a service-to-service import cycle (dmService is required by
 // agentMessageService, which is required by agentIdentityService callers).
@@ -37,6 +44,10 @@ const resolveAgentDisplayLabel = (
 };
 
 class DMService {
+  static agentDmPairKey(a: unknown, b: unknown): string {
+    return [String(a), String(b)].sort().join(':');
+  }
+
   static escapeRegex(value = ''): string {
     return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
@@ -482,13 +493,32 @@ class DMService {
       throw new Error('getOrCreateAgentDmRoom requires two distinct user ids');
     }
 
-    // Idempotent on the unordered pair: $all matches regardless of order
-    // and the index path `members` already exists for any pod query.
-    const existing = await Pod.findOne({
+    const pairKey = DMService.agentDmPairKey(aId, bId);
+
+    // Existing rooms created before agentDmPairKey must win over a new
+    // insert. Claim the oldest matching legacy room so the next call uses the
+    // atomic key path; if a concurrent claimant wins, read its winner below.
+    const legacy = await Pod.findOne({
       type: 'agent-dm',
       members: { $all: [aId, bId] },
-    });
-    if (existing) return existing;
+      agentDmPairKey: { $exists: false },
+      $expr: { $eq: [{ $size: '$members' }, 2] },
+    }).sort({ createdAt: 1, _id: 1 });
+    if (legacy) {
+      try {
+        const claimed = await Pod.findOneAndUpdate(
+          { _id: legacy._id, agentDmPairKey: { $exists: false } },
+          { $set: { agentDmPairKey: pairKey } },
+          { new: true },
+        );
+        if (claimed) return claimed;
+      } catch (error) {
+        if ((error as { code?: number })?.code !== 11000) throw error;
+      }
+
+      const winner = await Pod.findOne({ type: 'agent-dm', agentDmPairKey: pairKey });
+      if (winner) return winner;
+    }
 
     // Defense-in-depth: if a caller forgot to populate `displayName` we
     // fall through to the instanceId (identity-bearing) before agentName
@@ -510,15 +540,47 @@ class DMService {
 
     const creatorId = String(options.creatorUserId || aId);
 
-    const dmPod = new Pod({
-      name,
-      description,
-      type: 'agent-dm',
-      joinPolicy: 'invite-only',
-      createdBy: creatorId,
-      members: [aId, bId],
-    });
-    await dmPod.save();
+    let result: AgentDmUpsertResult;
+    try {
+      result = await Pod.findOneAndUpdate(
+        { type: 'agent-dm', agentDmPairKey: pairKey },
+        {
+          $setOnInsert: {
+            name,
+            description,
+            type: 'agent-dm',
+            joinPolicy: 'invite-only',
+            createdBy: creatorId,
+            members: [aId, bId],
+            agentDmPairKey: pairKey,
+          },
+        },
+        {
+          upsert: true,
+          new: true,
+          includeResultMetadata: true,
+          setDefaultsOnInsert: true,
+        },
+      ) as unknown as AgentDmUpsertResult;
+    } catch (error) {
+      // The unique index is the race arbiter. A competing upsert may lose
+      // after both callers missed the read; return the inserted room instead
+      // of surfacing a duplicate-key error to the caller.
+      if ((error as { code?: number })?.code !== 11000) throw error;
+      const winner = await Pod.findOne({ type: 'agent-dm', agentDmPairKey: pairKey });
+      if (winner) return winner;
+      throw error;
+    }
+
+    const dmPod = result.value;
+    if (!dmPod) {
+      throw new Error('agent-dm upsert returned no room');
+    }
+
+    // Only the insert winner owns cross-store provisioning. Replaying those
+    // side effects for an existing room would make every DM open attempt a
+    // duplicate PG INSERT and needless AgentInstallation writes.
+    if (result.lastErrorObject?.updatedExisting !== false) return dmPod;
 
     // Sync to PG so chat queries don't 404 on the new room.
     try {


### PR DESCRIPTION
## Summary

- add a canonical unordered pair key with a partial unique Mongo index for `agent-dm` rooms
- replace the read-then-save creation path with an atomic upsert; only the insert winner provisions PG and agent installations
- lazily claim a matching legacy two-member room before creating, so rollout does not add another room for an existing pair

## Verification

- `npm test -- --runInBand __tests__/services/dmService.agentDm.test.ts` — 19/19
- Mutation proof: restoring the prior read-then-save path made the 16-way race regression fail with 14 distinct rooms.

## Scope

This prevents new duplicate pairs and deterministically reuses a legacy two-member room. It deliberately does not delete or merge the one existing duplicate pair: safely reconciling its Mongo/PG message history and installations needs a separately approved data repair.