### PR TITLE
fix(v2): member identity is a composite key — instanceId 'default' collapsed nine agents into one profile

### DIFF
--- a/frontend/src/v2/__tests__/agentKey.test.ts
+++ b/frontend/src/v2/__tests__/agentKey.test.ts
@@ -1,0 +1,23 @@
+import { agentKeyFor } from '../utils/agentKey';
+
+describe('agentKeyFor — the member-identity key', () => {
+  test('two agents sharing instanceId "default" get DISTINCT keys', () => {
+    // The regression this file exists for: nine BYO fleet seats all carry
+    // instanceId 'default'; the pre-2026-08-26 key (`instanceId || agentName`)
+    // collapsed them onto one entry, so clicking ANY agent's byline or member
+    // row rendered the same seat's profile.
+    const a = agentKeyFor({ agentName: 'fable-lead', instanceId: 'default' });
+    const b = agentKeyFor({ agentName: 'ux-lead', instanceId: 'default' });
+    expect(a).not.toBe(b);
+    expect(a).toBe('fable-lead:default');
+    expect(b).toBe('ux-lead:default');
+  });
+
+  test('missing instanceId normalizes to default, matching backend identity keys', () => {
+    expect(agentKeyFor({ agentName: 'sage' })).toBe('sage:default');
+  });
+
+  test('registry rows that carry name instead of agentName still key correctly', () => {
+    expect(agentKeyFor({ name: 'sage', instanceId: 'sage-seo-lead' })).toBe('sage:sage-seo-lead');
+  });
+});

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -127,6 +127,10 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(block).toContain('.v2-pane--inspector');
     expect(block).toContain('position: fixed');
     expect(block).not.toContain('display: none');
+    // The 760px secondary-pane eraser out-specifies the drawer (0-4-0 vs
+    // 0-1-0); the inspector must be in its :not chain or the drawer is a
+    // mounted-but-invisible pane again — the exact live bug, twice.
+    expect(v2).toContain(':not(.v2-pods-aside):not(.v2-pane--inspector)');
   });
 
   test('v2 claims the page canvas — the V1 dark body cannot show through', () => {

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -20,6 +20,7 @@ import type { V2InviteTab } from './V2InviteModal';
 import V2ThreadCard from './V2ThreadCard';
 import { useV2ThreadState } from '../hooks/useV2ThreadState';
 import { buildThreadView } from '../utils/threadView';
+import { agentKeyFor } from '../utils/agentKey';
 
 const PLAN_MODE_KEY = 'v2.podMode';
 const AGENT_DELIVERY_HINT_KEY = 'v2.agentDeliveryHint';
@@ -504,8 +505,11 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
       const username = !instance || instance === 'default' || instance === name
         ? name
         : `${name}-${instance}`;
-      const key = agent.instanceId || agent.agentName;
-      if (!key) continue;
+      // Shared composite key (agentKey.ts): instanceId alone collapsed every
+      // 'default'-instance fleet seat onto one key, so every author click
+      // opened the same member's profile (Sam, 2026-08-26).
+      const key = agentKeyFor(agent);
+      if (!rawName) continue;
       if (username) map.set(username, key);
       const display = agent.displayName || agent.profile?.displayName;
       if (display) map.set(display.toLowerCase(), key);

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -12,6 +12,7 @@ import { useSocket } from '../../context/SocketContext';
 import { getSignedAttachmentUrl } from '../../utils/signedAttachmentUrl';
 import getApiBaseUrl from '../../utils/apiBaseUrl';
 import type { InspectorView } from './V2Layout';
+import { agentKeyFor } from '../utils/agentKey';
 
 interface V2PodInspectorProps {
   detail: UseV2PodDetailResult;
@@ -742,7 +743,10 @@ const Icon = ({ d, size = 14 }: { d: string; size?: number }) => (
   </svg>
 );
 
-const agentKeyOf = (agent: V2Agent): string => agent.instanceId || agent.agentName;
+// Shared with V2PodChat's author map — see agentKey.ts for why the key is
+// composite (the 'default'-instanceId collision that sent every member click
+// to one seat's profile).
+const agentKeyOf = (agent: V2Agent): string => agentKeyFor(agent);
 
 // Driver badge for the agent runtime — letterform monogram + label, no emoji.
 // `runtimeType` carries identity (codex / claude-code / openclaw / etc.);
@@ -1609,7 +1613,10 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
           <button
             type="button"
             className="v2-inspector__btn"
-            onClick={() => navigate(`/v2/agents?podId=${pod._id}&agent=${encodeURIComponent(agentKeyOf(agent))}`)}
+            // AgentsHub reads `agent` as the agentName and `instanceId` as
+            // its own param — passing the composite key (or, before it, the
+            // bare instanceId) here sent 'default' as an agent NAME.
+            onClick={() => navigate(`/v2/agents?podId=${pod._id}&agent=${encodeURIComponent(agent.agentName || '')}&instanceId=${encodeURIComponent(agent.instanceId || 'default')}`)}
           >
             {t('inspector.members.manage')}
           </button>

--- a/frontend/src/v2/utils/agentKey.ts
+++ b/frontend/src/v2/utils/agentKey.ts
@@ -1,0 +1,20 @@
+/**
+ * The ONE key for "which pod member is this agent" across chat author clicks
+ * and the inspector's member map/detail view.
+ *
+ * COMPOSITE, because instanceId alone is not an identity: every BYO fleet
+ * seat carries instanceId 'default', so the previous `instanceId || agentName`
+ * collapsed nine agents onto the key 'default' — the member map's last writer
+ * won, and clicking ANY agent's byline or member row rendered the same seat's
+ * profile (Sam, 2026-08-26: "clicking any agent's profile goes to fable").
+ *
+ * Producers (V2PodChat author map) and consumers (V2PodInspector member map)
+ * MUST both import this — the collision existed precisely because each side
+ * derived its own key.
+ */
+export const agentKeyFor = (
+  agent: { agentName?: string; name?: string; instanceId?: string },
+): string => {
+  const name = agent.agentName || agent.name || '';
+  return `${name}:${agent.instanceId || 'default'}`;
+};

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -5384,10 +5384,13 @@ body.modern-ui.v2-canvas {
     align-self: flex-start;
   }
 
-  /* Hide secondary panes (e.g. the inspector) — but NOT the pods sidebar,
-     which becomes a slide-over drawer below. The extra :not() keeps the
-     drawer reachable instead of dead-ending the user in a single pod. */
-  .v2-pane:not(.v2-pane--rail):not(.v2-pane--main):not(.v2-pods-aside) {
+  /* Hide secondary panes — but NOT the pods sidebar OR the inspector, which
+     are both drawers now (pods slide-over below; inspector fixed-right in
+     the 1023px block above). This :not chain out-specifies the drawer rules
+     (0-4-0 vs 0-1-0), so an omission here is an invisible mounted pane: the
+     inspector was exactly that on phones until 2026-08-26 — the header
+     avatar button mounted it, this rule erased it. */
+  .v2-pane:not(.v2-pane--rail):not(.v2-pane--main):not(.v2-pods-aside):not(.v2-pane--inspector) {
     display: none;
   }
 


### PR DESCRIPTION
Sam's report: clicking any agent's profile (inspector sidebar render) shows Fable. Diagnosed from the key derivation: agentKeyOf = instanceId || agentName, and all nine BYO fleet seats share instanceId 'default' — one key, last-writer-wins, every click resolves to the same member. Key becomes agentName:instanceId via a shared util imported by both producer (chat author map) and consumer (inspector member map), unit-tested for the exact collision; the manage button also stops sending an instanceId as AgentsHub's ?agent= name param. 302/302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK