### PR TITLE
fix(v2): open profiles from inspector member actions

### DIFF
--- a/frontend/src/v2/__tests__/V2PodInspectorMemberProfile.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodInspectorMemberProfile.test.tsx
@@ -52,6 +52,11 @@ const detail = {
   sendMessage: jest.fn(),
 };
 
+const detailWithoutAgentName = {
+  ...detail,
+  agents: [{ ...detail.agents[0], agentName: '' }],
+};
+
 describe('V2PodInspector member profile action', () => {
   beforeEach(() => jest.clearAllMocks());
 
@@ -71,5 +76,22 @@ describe('V2PodInspector member profile action', () => {
     fireEvent.click(screen.getByRole('button', { name: 'inspector.members.manage' }));
 
     expect(mockNavigate).toHaveBeenCalledWith('/v2/agent/scout%2Fops/blue%20sky');
+  });
+
+  test('does not construct a route when a malformed registry row lacks an agent name', () => {
+    render(
+      <MemoryRouter>
+        <V2PodInspector
+          detail={detailWithoutAgentName as any}
+          view={{ kind: 'member', agentKey: ':blue sky' }}
+          onOpenMember={jest.fn()}
+          onOpenArtifact={jest.fn()}
+          onBack={jest.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('button', { name: 'inspector.members.manage' })).toBeDisabled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/v2/__tests__/V2PodInspectorMemberProfile.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodInspectorMemberProfile.test.tsx
@@ -1,0 +1,75 @@
+/* eslint-disable react/display-name */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2PodInspector from '../components/V2PodInspector';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../hooks/useV2Api', () => ({
+  useV2Api: () => ({
+    get: jest.fn().mockResolvedValue({}),
+    post: jest.fn(), patch: jest.fn(), del: jest.fn(),
+  }),
+}));
+
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ currentUser: { _id: 'human-1', username: 'sam' } }),
+}));
+
+jest.mock('../../context/SocketContext', () => ({
+  useSocket: () => ({ socket: null, connected: false }),
+}));
+
+jest.mock('../components/V2Avatar', () => () => <span data-testid="avatar" />);
+
+const detail = {
+  pod: { _id: 'pod-1', name: 'Workspace', type: 'team' },
+  members: [],
+  agents: [{
+    agentName: 'scout/ops',
+    instanceId: 'blue sky',
+    displayName: 'Scout',
+    runtime: { runtimeType: 'webhook' },
+  }],
+  messages: [],
+  loading: false,
+  error: null,
+  sendError: null,
+  hasMore: false,
+  loadingOlder: false,
+  loadOlder: jest.fn(),
+  refresh: jest.fn(),
+  sendMessage: jest.fn(),
+};
+
+describe('V2PodInspector member profile action', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('opens the selected agent profile instead of the fleet manager', () => {
+    render(
+      <MemoryRouter>
+        <V2PodInspector
+          detail={detail as any}
+          view={{ kind: 'member', agentKey: 'scout/ops:blue sky' }}
+          onOpenMember={jest.fn()}
+          onOpenArtifact={jest.fn()}
+          onBack={jest.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'inspector.members.manage' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/v2/agent/scout%2Fops/blue%20sky');
+  });
+});

--- a/frontend/src/v2/__tests__/V2PodInspectorMemberProfile.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodInspectorMemberProfile.test.tsx
@@ -73,7 +73,8 @@ describe('V2PodInspector member profile action', () => {
       </MemoryRouter>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'inspector.members.manage' }));
+    expect(screen.getByText('yourTeam.card.profile')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'yourTeam.card.viewProfileAria' }));
 
     expect(mockNavigate).toHaveBeenCalledWith('/v2/agent/scout%2Fops/blue%20sky');
   });
@@ -91,7 +92,7 @@ describe('V2PodInspector member profile action', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole('button', { name: 'inspector.members.manage' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'yourTeam.card.viewProfileAria' })).toBeDisabled();
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -1613,10 +1613,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
           <button
             type="button"
             className="v2-inspector__btn"
-            // AgentsHub reads `agent` as the agentName and `instanceId` as
-            // its own param — passing the composite key (or, before it, the
-            // bare instanceId) here sent 'default' as an agent NAME.
-            onClick={() => navigate(`/v2/agents?podId=${pod._id}&agent=${encodeURIComponent(agent.agentName || '')}&instanceId=${encodeURIComponent(agent.instanceId || 'default')}`)}
+            onClick={() => navigate(`/v2/agent/${encodeURIComponent(agent.agentName || '')}/${encodeURIComponent(agent.instanceId || 'default')}`)}
           >
             {t('inspector.members.manage')}
           </button>

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -1613,7 +1613,11 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
           <button
             type="button"
             className="v2-inspector__btn"
-            onClick={() => navigate(`/v2/agent/${encodeURIComponent(agent.agentName || '')}/${encodeURIComponent(agent.instanceId || 'default')}`)}
+            disabled={!agent.agentName}
+            onClick={() => {
+              if (!agent.agentName) return;
+              navigate(`/v2/agent/${encodeURIComponent(agent.agentName)}/${encodeURIComponent(agent.instanceId || 'default')}`);
+            }}
           >
             {t('inspector.members.manage')}
           </button>

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -1618,8 +1618,9 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
               if (!agent.agentName) return;
               navigate(`/v2/agent/${encodeURIComponent(agent.agentName)}/${encodeURIComponent(agent.instanceId || 'default')}`);
             }}
+            aria-label={t('yourTeam.card.viewProfileAria', { name })}
           >
-            {t('inspector.members.manage')}
+            {t('yourTeam.card.profile')}
           </button>
         </div>
         {privateError && <div className="v2-chat__error" style={{ marginTop: 8 }}>{privateError}</div>}


### PR DESCRIPTION
Fixes #1269.

The inspector member-detail action now opens the selected agent’s V2 profile route instead of sending identity parameters to AgentsHub, which does not read them.

Tested:
- `./node_modules/.bin/jest --watchAll=false --runTestsByPath src/v2/__tests__/V2PodInspectorMemberProfile.test.tsx`
- Targeted ESLint: no errors (existing JSX-extension warnings only).