### PR TITLE
ci(version-guard): require an increase, not merely a difference

### DIFF
--- a/.github/workflows/package-version-guard.yml
+++ b/.github/workflows/package-version-guard.yml
@@ -84,11 +84,21 @@ jobs:
             base_v=$(git show "$BASE:$pkg/package.json" 2>/dev/null | sed -n 's/.*"version": "\([^"]*\)".*/\1/p' | head -1)
             head_v=$(sed -n 's/.*"version": "\([^"]*\)".*/\1/p' "$pkg/package.json" | head -1)
 
+            # An INCREASE, not merely a difference. A long-lived branch that
+            # bumped while the base moved further ahead leaves head_v BELOW
+            # base_v — different, so an equality test passes it, and merging
+            # then walks the version backwards on the base. Observed on two
+            # open PRs at once (base 0.1.21, heads 0.1.20 and 0.1.19), both
+            # showing this check green.
+            newest=$(printf '%s\n%s\n' "$base_v" "$head_v" | sort -V | tail -1)
             if [ "$base_v" = "$head_v" ]; then
               echo "::error file=$pkg/package.json::$pkg/src changed ($changed file(s)) but version is still $head_v. A published version that maps to two different artifacts defeats the only check available from outside this repo — bump it, or move the change out of $pkg/src."
               fail=1
+            elif [ "$newest" != "$head_v" ]; then
+              echo "::error file=$pkg/package.json::$pkg/src changed ($changed file(s)) and $head_v is BELOW the base's $base_v. Merging would walk the published version backwards. Rebase and bump above $base_v."
+              fail=1
             else
-              echo "✓ $pkg: src changed and version moved $base_v → $head_v"
+              echo "✓ $pkg: src changed and version rose $base_v → $head_v"
             fi
           done
 

--- a/.github/workflows/package-version-guard.yml
+++ b/.github/workflows/package-version-guard.yml
@@ -84,6 +84,24 @@ jobs:
             base_v=$(git show "$BASE:$pkg/package.json" 2>/dev/null | sed -n 's/.*"version": "\([^"]*\)".*/\1/p' | head -1)
             head_v=$(sed -n 's/.*"version": "\([^"]*\)".*/\1/p' "$pkg/package.json" | head -1)
 
+            # `sort -V` is not semver. It orders 1.0.0 BEFORE 1.0.0-beta.1,
+            # reading a prerelease as NEWER than its own release, and it
+            # inverts in both directions: base=1.0.0 head=1.0.0-beta.1 would
+            # PASS — the exact backwards walk this check exists to stop — and
+            # the legitimate promotion 1.0.0-beta.1 → 1.0.0 would FAIL.
+            # No version ever committed to either package carries a
+            # prerelease, so this is latent today. It fails OPEN in the
+            # direction that matters, so the guard refuses to judge rather
+            # than guessing, on the same principle as the merge-base check
+            # above: a guard that cannot compare its inputs must say so.
+            case "$base_v$head_v" in
+              *-*)
+                echo "::error file=$pkg/package.json::$pkg version comparison involves a prerelease ($base_v → $head_v). \`sort -V\` orders a prerelease as NEWER than its release, so this guard reaches the wrong answer in BOTH directions. Teach it semver before landing a prerelease; do not merge on this check alone."
+                fail=1
+                continue
+                ;;
+            esac
+
             # An INCREASE, not merely a difference. A long-lived branch that
             # bumped while the base moved further ahead leaves head_v BELOW
             # base_v — different, so an equality test passes it, and merging


### PR DESCRIPTION
`Source changed ⇒ version bumped` tested `base_v != head_v`. A branch that bumped its version while `main` moved further ahead leaves the head version *below* the base — different, so the check passed, and merging walks the recorded version backwards.

**Observed, not hypothetical.** `main`'s `cli/package.json` is at `0.1.21`. Right now:

| PR | head version | this check |
|---|---|---|
| #1217 | 0.1.20 | SUCCESS |
| #1215 | 0.1.19 | SUCCESS |

Nothing publishes from `main` automatically, so the consequence is a base whose recorded version is lower than what was last shipped — the same "one version, two artifacts" failure the guard exists to prevent, arriving from the other direction.

**Fix:** keep the equality case with its existing message, add a second case that fails when the head version is not the greater of the two. `sort -V`, not a lexical compare, so `0.1.9 → 0.1.10` counts as an increase.

Truth table exercised under `bash` (the job's shell):

| base | head | result |
|---|---|---|
| 0.1.21 | 0.1.21 | fail — same |
| 0.1.21 | 0.1.20 | fail — backwards |
| 0.1.21 | 0.1.19 | fail — backwards |
| 0.1.21 | 0.1.22 | pass |
| 0.1.9 | 0.1.10 | pass |
| 0.1.21 | *(empty)* | fail — backwards |

**This turns #1217 and #1215 red.** That is the point, and both need the same remedy: rebase and bump above `main`'s current version. Commented on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)