### PR TITLE
feat(telegram): live bridge — channel as attention surface

### DIFF
--- a/backend/__tests__/unit/services/telegramBridgeService.test.js
+++ b/backend/__tests__/unit/services/telegramBridgeService.test.js
@@ -1,0 +1,96 @@
+jest.mock('../../../models/Integration', () => ({
+  findOne: jest.fn(),
+  findByIdAndUpdate: jest.fn(),
+}));
+jest.mock('../../../services/telegramService', () => ({ sendMessage: jest.fn() }));
+
+const { shouldEscalate, routeReplyContent } = require('../../../services/telegramBridgeService');
+
+describe('telegramBridgeService — escalation gate', () => {
+  const integration = (config = {}) => ({ _id: 'i1', podId: 'p1', config });
+
+  it('relays nothing by default (the channel stays quiet)', () => {
+    expect(shouldEscalate({
+      content: 'refactored the parser, tests green',
+      agentUsername: 'worker-a',
+      integration: integration({}),
+    })).toBe(false);
+  });
+
+  it('escalates [BLOCKED] and [DECISION] markers', () => {
+    for (const marker of ['[BLOCKED]', '[ESCALATE]', '[DECISION]', '[NEEDS-HUMAN]', '[blocked]']) {
+      expect(shouldEscalate({
+        content: `${marker} waiting on scope confirmation`,
+        agentUsername: 'worker-a',
+        integration: integration({}),
+      })).toBe(true);
+    }
+  });
+
+  it('escalates a question addressed at someone', () => {
+    expect(shouldEscalate({
+      content: '@sam should the retention window stay at 30 days?',
+      agentUsername: 'worker-a',
+      integration: integration({}),
+    })).toBe(true);
+  });
+
+  it('always relays the designated lead agent, case-insensitively', () => {
+    expect(shouldEscalate({
+      content: 'daily digest: 3 tasks done, 1 in review',
+      agentUsername: 'Lead-Agent',
+      integration: integration({ leadAgentUsername: 'lead-agent' }),
+    })).toBe(true);
+  });
+
+  it('relayAllAgentMessages opts into verbose mode', () => {
+    expect(shouldEscalate({
+      content: 'minor progress note',
+      agentUsername: 'worker-a',
+      integration: integration({ relayAllAgentMessages: true }),
+    })).toBe(true);
+  });
+});
+
+describe('telegramBridgeService — quote-reply routing', () => {
+  const relayMap = [
+    { tgMessageId: '101', agentUsername: 'gene-fix-agent' },
+    { tgMessageId: '102', agentUsername: 'lead-agent' },
+  ];
+
+  it('prefixes the quoted agent as an @mention', () => {
+    const out = routeReplyContent({
+      content: 'looks wrong, use the v2 schema',
+      replyToTgMessageId: '101',
+      relayMap,
+    });
+    expect(out.routedAgent).toBe('gene-fix-agent');
+    expect(out.content).toBe('@gene-fix-agent looks wrong, use the v2 schema');
+  });
+
+  it('does not double-prefix when the mention is already present', () => {
+    const out = routeReplyContent({
+      content: '@gene-fix-agent try again with the v2 schema',
+      replyToTgMessageId: '101',
+      relayMap,
+    });
+    expect(out.routedAgent).toBe('gene-fix-agent');
+    expect(out.content).toBe('@gene-fix-agent try again with the v2 schema');
+  });
+
+  it('passes through untouched when the quote is not a relayed line', () => {
+    const out = routeReplyContent({
+      content: 'unrelated reply',
+      replyToTgMessageId: '999',
+      relayMap,
+    });
+    expect(out.routedAgent).toBeNull();
+    expect(out.content).toBe('unrelated reply');
+  });
+
+  it('passes through when there is no quote at all', () => {
+    const out = routeReplyContent({ content: 'plain message', replyToTgMessageId: null, relayMap });
+    expect(out.routedAgent).toBeNull();
+    expect(out.content).toBe('plain message');
+  });
+});

--- a/backend/models/Integration.ts
+++ b/backend/models/Integration.ts
@@ -79,6 +79,19 @@ export interface IIntegration extends Document {
     maxBufferSize?: number;
     agentAccessEnabled?: boolean;
     globalAgentAccess?: boolean;
+    // Telegram live bridge (telegramBridgeService). Undeclared config paths
+    // are silently stripped by Mongoose writes — these MUST stay declared or
+    // the enable path becomes a no-op that reports success (found by
+    // sprint-review on #1282 before first deploy).
+    liveRelay?: boolean;
+    linkedUserId?: string;
+    leadAgentUsername?: string;
+    relayAllAgentMessages?: boolean;
+    relayMap?: {
+      tgMessageId: string;
+      agentUsername: string;
+      podMessageId?: string | null;
+    }[];
   };
   ingestTokens: IIngestToken[];
   lastSync?: Date | null;
@@ -157,6 +170,18 @@ const IntegrationSchema = new Schema<IIntegration>(
         },
       ],
       maxBufferSize: { type: Number, default: 1000 },
+      // Telegram live bridge — see interface note above; keep in lockstep.
+      liveRelay: { type: Boolean, default: false },
+      linkedUserId: String,
+      leadAgentUsername: String,
+      relayAllAgentMessages: { type: Boolean, default: false },
+      relayMap: [
+        {
+          tgMessageId: String,
+          agentUsername: String,
+          podMessageId: String,
+        },
+      ],
       agentAccessEnabled: { type: Boolean, default: false },
       globalAgentAccess: { type: Boolean, default: false },
     },

--- a/backend/routes/webhooks/telegram.ts
+++ b/backend/routes/webhooks/telegram.ts
@@ -262,6 +262,19 @@ router.post('/', async (req: any, res: any) => {
 
     if (!integration) return res.sendStatus(200);
 
+    // Live bridge: linked chats with config.liveRelay relay straight into the
+    // pod as real messages (mentions fire, agents wake). Commands above keep
+    // their legacy handling; everything else here short-circuits the buffer.
+    if (integration.config?.liveRelay) {
+      // eslint-disable-next-line global-require
+      const bridge = require('../../services/telegramBridgeService');
+      await bridge.relayTelegramMessageToPod({
+        integration,
+        telegramMessage: message,
+      });
+      return res.sendStatus(200);
+    }
+
     const provider = registry.get('telegram', integration);
     const { events } = provider.getWebhookHandlers();
     return events(req, res);

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -1683,6 +1683,25 @@ class AgentMessageService {
       console.error('Failed to emit agent socket message:', socketError);
     }
 
+    // Telegram live bridge (fire-and-forget): pods with a live-relay telegram
+    // integration surface escalations and lead reports into the linked chat.
+    // The bridge no-ops in O(1 query) for every pod without one, and a bridge
+    // failure never fails the post.
+    try {
+      // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+      const bridge = require('./telegramBridgeService');
+      const bridgeUsername = AgentIdentityService.buildAgentUsername(agentName, instanceId);
+      void bridge.relayAgentMessageToTelegram({
+        podId: String(podId),
+        agentUsername: bridgeUsername,
+        displayName: senderDisplayName || bridgeUsername,
+        content: String((message as MessageNormalized)?.content ?? ''),
+        podMessageId: (message as MessageNormalized)?._id || (message as MessageNormalized)?.id || null,
+      });
+    } catch (bridgeError) {
+      console.warn('[tg-bridge] outbound hook failed:', (bridgeError as Error).message);
+    }
+
     return { message: message as MessageNormalized, summary: persistedSummary };
   }
 

--- a/backend/services/telegramBridgeService.ts
+++ b/backend/services/telegramBridgeService.ts
@@ -1,0 +1,294 @@
+// Telegram live bridge — the channel-as-attention-surface relay.
+//
+// Design (2026-08-26): the pod is the workspace, the messaging channel is the
+// human's attention surface. Only two things cross the bridge outward:
+//   1. escalations — an agent is blocked, asks the human a question, or a
+//      message passes the escalation rules below;
+//   2. attributed reports from the designated lead agent.
+// Everything else stays in the pod. Inbound, a Telegram message from a linked
+// chat lands in the pod as a real message (attributed to the linked user) and
+// rides the normal mention pipeline; a Telegram *quote-reply* to a relayed
+// agent line is routed back to that specific agent as an @mention.
+//
+// Scope guard: the bridge only fires for Integration rows with
+// `config.liveRelay === true`. Every other telegram integration keeps the
+// legacy buffer/summary behaviour untouched.
+//
+// The escalation policy is rule-based today (see shouldEscalate). The LLM
+// judge — an agent in the pod deciding what deserves the channel — is the
+// designed next step; these rules are its floor, not its replacement.
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const IntegrationModel = require('../models/Integration');
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const telegramSend = require('./telegramService');
+
+const RELAY_MAP_CAP = 100;
+const OUTBOUND_TEXT_CAP = 900;
+
+export interface RelayMapEntry {
+  tgMessageId: string;
+  agentUsername: string;
+  podMessageId?: string | null;
+}
+
+interface TelegramIntegrationDoc {
+  _id: unknown;
+  podId: unknown;
+  config?: {
+    chatId?: string;
+    liveRelay?: boolean;
+    linkedUserId?: string;
+    leadAgentUsername?: string;
+    relayMap?: RelayMapEntry[];
+    relayAllAgentMessages?: boolean;
+  };
+}
+
+const escapeHtml = (raw: string): string => String(raw)
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;');
+
+// Rule-based escalation gate. Deliberately structural and cheap — the same
+// shape as the cascade cap: no model call decides whether to interrupt a
+// human. A message crosses to the channel when it:
+//   - carries an explicit escalation/blocked/decision marker, or
+//   - asks the human something (question addressed at a person), or
+//   - comes from the designated lead agent (their reports are the digest), or
+//   - the integration opts into relay-everything (demo/verbose mode).
+const ESCALATION_MARKERS = /\[(BLOCKED|ESCALATE|DECISION|NEEDS[-_ ]?HUMAN|APPROVAL)\]/i;
+const QUESTION_AT_HUMAN = /@[a-z0-9_.-]+[^\n]{0,200}\?/i;
+
+export const shouldEscalate = (opts: {
+  content: string;
+  agentUsername: string;
+  integration: TelegramIntegrationDoc;
+}): boolean => {
+  const { content, agentUsername, integration } = opts;
+  const cfg = integration.config || {};
+  if (cfg.relayAllAgentMessages) return true;
+  if (cfg.leadAgentUsername
+    && agentUsername.toLowerCase() === String(cfg.leadAgentUsername).toLowerCase()) {
+    return true;
+  }
+  if (ESCALATION_MARKERS.test(content)) return true;
+  if (QUESTION_AT_HUMAN.test(content)) return true;
+  return false;
+};
+
+// Prefix an inbound Telegram quote-reply with the @mention of the agent whose
+// relayed line was quoted, so the normal mention pipeline routes it. Pure —
+// unit-tested without any I/O.
+export const routeReplyContent = (opts: {
+  content: string;
+  replyToTgMessageId?: string | null;
+  relayMap?: RelayMapEntry[];
+}): { content: string; routedAgent: string | null } => {
+  const { content, replyToTgMessageId, relayMap } = opts;
+  if (!replyToTgMessageId || !Array.isArray(relayMap)) {
+    return { content, routedAgent: null };
+  }
+  const hit = relayMap.find((e) => String(e.tgMessageId) === String(replyToTgMessageId));
+  if (!hit || !hit.agentUsername) return { content, routedAgent: null };
+  const mention = `@${hit.agentUsername}`;
+  if (content.toLowerCase().includes(mention.toLowerCase())) {
+    return { content, routedAgent: hit.agentUsername };
+  }
+  return { content: `${mention} ${content}`, routedAgent: hit.agentUsername };
+};
+
+const findLiveIntegration = async (podId: unknown): Promise<TelegramIntegrationDoc | null> => {
+  if (!podId) return null;
+  try {
+    return await IntegrationModel.findOne({
+      type: 'telegram',
+      isActive: true,
+      podId,
+      'config.liveRelay': true,
+      'config.chatId': { $exists: true, $ne: null },
+    }).lean();
+  } catch {
+    return null;
+  }
+};
+
+// Outbound: agent message → Telegram, attributed, with a deep link back into
+// the pod. Fire-and-forget from AgentMessageService.postMessage — a bridge
+// failure must never fail the post itself.
+export const relayAgentMessageToTelegram = async (opts: {
+  podId: string;
+  agentUsername: string;
+  displayName: string;
+  content: string;
+  podMessageId?: string | null;
+}): Promise<void> => {
+  const {
+    podId, agentUsername, displayName, content, podMessageId,
+  } = opts;
+  try {
+    const integration = await findLiveIntegration(podId);
+    if (!integration) return;
+    if (!shouldEscalate({ content, agentUsername, integration })) return;
+
+    const botToken = process.env.TELEGRAM_BOT_TOKEN;
+    const chatId = integration.config?.chatId;
+    if (!botToken || !chatId) return;
+
+    const base = (process.env.PUBLIC_APP_URL || 'https://commonly.me').replace(/\/$/, '');
+    const link = `${base}/v2/pods/${podId}`;
+    const body = escapeHtml(String(content).slice(0, OUTBOUND_TEXT_CAP));
+    const text = `<b>${escapeHtml(displayName || agentUsername)}</b>: ${body}`
+      + `\n\n<a href="${link}">open in Commonly</a>`;
+
+    const result = await telegramSend.sendMessage(botToken, chatId, text);
+    const tgMessageId = result && result.messageId != null ? String(result.messageId) : null;
+    if (!tgMessageId) return;
+
+    await IntegrationModel.findByIdAndUpdate(integration._id, {
+      $push: {
+        'config.relayMap': {
+          $each: [{ tgMessageId, agentUsername, podMessageId: podMessageId || null }],
+          $slice: -RELAY_MAP_CAP,
+        },
+      },
+    });
+  } catch (err) {
+    console.warn('[tg-bridge] outbound relay failed:', (err as Error).message);
+  }
+};
+
+// Inbound: Telegram message from a linked live-relay chat → pod message,
+// attributed to the integration's linked user, delivered through the same
+// seam both human routes use so mentions and wake behave identically.
+export const relayTelegramMessageToPod = async (opts: {
+  integration: TelegramIntegrationDoc;
+  telegramMessage: {
+    text?: string;
+    caption?: string;
+    message_id?: number;
+    from?: { first_name?: string; last_name?: string };
+    reply_to_message_id?: number;
+    reply_to_message?: { message_id?: number };
+  };
+}): Promise<{ relayed: boolean; routedAgent?: string | null }> => {
+  const { integration, telegramMessage } = opts;
+  const rawText = (telegramMessage.text || telegramMessage.caption || '').trim();
+  if (!rawText) return { relayed: false };
+  if (rawText.startsWith('/')) return { relayed: false }; // commands keep legacy handling
+
+  const podId = String(integration.podId);
+  const linkedUserId = integration.config?.linkedUserId;
+  if (!linkedUserId) {
+    console.warn('[tg-bridge] live relay without linkedUserId — inbound dropped');
+    return { relayed: false };
+  }
+
+  const replyToTgMessageId = telegramMessage.reply_to_message?.message_id
+    ?? telegramMessage.reply_to_message_id
+    ?? null;
+  const { content: routedText, routedAgent } = routeReplyContent({
+    content: rawText,
+    replyToTgMessageId: replyToTgMessageId != null ? String(replyToTgMessageId) : null,
+    relayMap: integration.config?.relayMap,
+  });
+
+  const senderName = [
+    telegramMessage.from?.first_name,
+    telegramMessage.from?.last_name,
+  ].filter(Boolean).join(' ').trim();
+  const content = senderName
+    ? `📱 ${senderName} (via Telegram): ${routedText}`
+    : `📱 (via Telegram): ${routedText}`;
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  const User = require('../models/User');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  const Pod = require('../models/Pod');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  const PGMessage = require('../models/pg/Message');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  const { deliverMessageToAgents } = require('./messageAgentDeliveryService');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  const socketConfig = require('../config/socket');
+
+  const [linkedUser, pod] = await Promise.all([
+    User.findById(linkedUserId).select('username profilePicture').lean(),
+    Pod.findById(podId).select('type').lean(),
+  ]);
+  if (!linkedUser || !pod) {
+    console.warn('[tg-bridge] inbound dropped — linked user or pod missing');
+    return { relayed: false };
+  }
+
+  // Same heal the human routes perform: Mongo-only pods have no PG row and
+  // the insert would FK-fail.
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+    const PGPod = require('../models/pg/Pod');
+    const pgPodExists = await PGPod.findById(podId);
+    if (!pgPodExists) {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+      const { syncPodFromMongo } = require('./pgPodSyncService');
+      await syncPodFromMongo(podId, String(linkedUserId));
+    }
+  } catch (syncErr) {
+    console.warn('[tg-bridge] PG pod backfill skipped:', (syncErr as Error).message);
+  }
+
+  const created = await PGMessage.create(podId, String(linkedUserId), content, 'text', null, null, null);
+  let message: Record<string, unknown> = created;
+  try {
+    const populated = created?.id ? await PGMessage.findById(created.id) : null;
+    if (populated) message = populated;
+  } catch (readErr) {
+    console.warn('[tg-bridge] post-write read failed:', (readErr as Error).message);
+  }
+
+  await deliverMessageToAgents({
+    podId,
+    podType: pod.type,
+    message,
+    userId: String(linkedUserId),
+    requestUser: { username: linkedUser.username },
+    replyToMessageId: null,
+  });
+
+  try {
+    const io = socketConfig.getIO();
+    if (io) {
+      io.to(`pod_${podId}`).emit('newMessage', {
+        _id: (message as { id?: unknown }).id,
+        id: (message as { id?: unknown }).id,
+        pod_id: podId,
+        podId,
+        content: (message as { content?: unknown }).content || content,
+        messageType: 'text',
+        userId: {
+          _id: linkedUserId,
+          username: linkedUser.username,
+          profilePicture: linkedUser.profilePicture,
+        },
+        username: linkedUser.username,
+        profile_picture: linkedUser.profilePicture,
+        createdAt: (message as { created_at?: unknown }).created_at || new Date(),
+        replyTo: null,
+        thread_root_id: null,
+        payload: null,
+      });
+    }
+  } catch (socketErr) {
+    console.warn('[tg-bridge] socket emit failed:', (socketErr as Error).message);
+  }
+
+  return { relayed: true, routedAgent };
+};
+
+module.exports = {
+  shouldEscalate,
+  routeReplyContent,
+  relayAgentMessageToTelegram,
+  relayTelegramMessageToPod,
+};
+
+export {};

--- a/backend/services/telegramService.ts
+++ b/backend/services/telegramService.ts
@@ -3,6 +3,10 @@ import axios from 'axios';
 interface SendResult {
   success: boolean;
   error?: string;
+  // Telegram's message_id for the sent message — the bridge stores it to
+  // route quote-replies back to the agent whose line was quoted. Absent on
+  // failure; existing callers that only read `success` are unaffected.
+  messageId?: number;
 }
 
 async function sendMessage(botToken: string, chatId: string | number, text: string): Promise<SendResult> {
@@ -11,7 +15,7 @@ async function sendMessage(botToken: string, chatId: string | number, text: stri
   }
 
   try {
-    const response = await axios.post<{ ok: boolean }>(
+    const response = await axios.post<{ ok: boolean; result?: { message_id?: number } }>(
       `https://api.telegram.org/bot${botToken}/sendMessage`,
       {
         chat_id: chatId,
@@ -21,7 +25,10 @@ async function sendMessage(botToken: string, chatId: string | number, text: stri
       },
     );
 
-    return { success: response.data?.ok === true };
+    return {
+      success: response.data?.ok === true,
+      messageId: response.data?.result?.message_id,
+    };
   } catch (error) {
     const err = error as { response?: { data: unknown }; message: string };
     console.error(


### PR DESCRIPTION
Live Telegram↔pod relay for integrations with `config.liveRelay=true`.

- **Outbound**: agent messages pass a rule-based escalation gate (`[BLOCKED]`/`[ESCALATE]`/`[DECISION]`/question-at-a-person/designated lead agent) before crossing to the linked chat, attributed per-agent with a deep link into the pod. Telegram message ids are stored (capped at 100) for reply routing.
- **Inbound**: non-command messages from a linked chat land in the pod as real messages attributed to the linked user, delivered through `deliverMessageToAgents` — the same seam both human routes use, so mentions fire and wake works. A Telegram quote-reply to a relayed agent line is prefixed with that agent's @mention.
- Legacy integrations (no `liveRelay`) keep buffer/summary behaviour bit-for-bit.
- `telegramService.sendMessage` now returns `messageId` (additive).

Tests: 9 new unit tests on the pure gate/routing helpers; existing webhook tests pass. Backend lint error count unchanged vs main (2205→2205).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pc6nGXRS8mHvrwcXMSRDK