### PR TITLE
fix(seo): the prerender is hidden by default — the script-gate's timing window is gone

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,10 +38,16 @@
          prerender; crawlers without JS still get the full content. Not
          cloaking — JS-running crawlers see the real app. -->
     <!-- SEO_GATE_START -->
-    <script>document.documentElement.className += ' js';</script>
+    <!-- Rev 2 (Sam re-sighted the flash, 2026-08-26): the script-gate had a
+         timing dependency — anything that delays head-script execution
+         paints the dark prerender first. Hidden-by-default has NO timing
+         window: JS-capable browsers never paint it, and the <noscript>
+         below reveals it for text-only crawlers. Rendering crawlers
+         (Googlebot) execute JS and index the real app instead. -->
+    <noscript><style>#seo-page { display: block !important; }</style></noscript>
     <!-- SEO_GATE_END -->
     <style>
-      html.js #seo-page { display: none; }
+      #seo-page { display: none; }
       #seo-page { box-sizing: border-box; min-height: 100vh; color: #e5e7eb; background: #0b1220; font: 16px/1.6 Inter, ui-sans-serif, system-ui, sans-serif; }
       #seo-page *, #seo-page *::before, #seo-page *::after { box-sizing: inherit; }
       #seo-page a { color: #7dd3fc; text-decoration-thickness: 1px; text-underline-offset: 3px; }

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -168,10 +168,13 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // still see the content. The script must PRECEDE the style block that
     // uses it, and both must precede </head>.
     const indexHtml = read('../../../index.html');
-    expect(indexHtml).toContain("documentElement.className += ' js'");
-    expect(indexHtml).toContain('html.js #seo-page { display: none; }');
-    expect(indexHtml.indexOf("className += ' js'"))
-      .toBeLessThan(indexHtml.indexOf('html.js #seo-page'));
+    // Rev 2 (Sam re-sighted the flash, 2026-08-26): the script-gate had a
+    // timing window — delayed head-script execution painted the prerender.
+    // Hidden-by-default has none: #seo-page is display:none from the first
+    // byte, and <noscript> reveals it only for text-only crawlers. The
+    // noscript override must carry !important to beat the base rule.
+    expect(indexHtml).toContain('#seo-page { display: none; }');
+    expect(indexHtml).toMatch(/<noscript><style>#seo-page \{ display: block !important; \}<\/style><\/noscript>/);
   });
 
   test('the conversation column is FULL-WIDTH — no measure cap, one left edge (rule 2, v5)', () => {


### PR DESCRIPTION
Sam re-sighted the flash on refresh. The js-gate was timing-dependent: anything delaying head-script execution paints the dark prerender first — a 'sometimes' bug by construction. Rev 2: #seo-page is display:none from byte one; noscript (!important) reveals it for text-only crawlers; JS-rendering crawlers index the real app. Static guides + branded 404 unaffected. 305/305, invariant re-pinned to the noscript contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK