### PR TITLE
fix(telegram): ack the webhook even when the inbound relay throws

### DIFF
--- a/backend/__tests__/unit/routes/telegram.webhook.test.js
+++ b/backend/__tests__/unit/routes/telegram.webhook.test.js
@@ -8,6 +8,9 @@ jest.mock('../../../services/integrationSummaryService', () => ({ createSummary:
 jest.mock('../../../services/agentEventService', () => ({ enqueue: jest.fn() }));
 jest.mock('../../../services/telegramService', () => ({ sendMessage: jest.fn() }));
 jest.mock('../../../integrations', () => ({ get: jest.fn() }));
+jest.mock('../../../services/telegramBridgeService', () => ({
+  relayTelegramMessageToPod: jest.fn(),
+}));
 
 const Integration = require('../../../models/Integration');
 const Pod = require('../../../models/Pod');
@@ -16,6 +19,7 @@ const IntegrationSummaryService = require('../../../services/integrationSummaryS
 const AgentEventService = require('../../../services/agentEventService');
 const telegramService = require('../../../services/telegramService');
 const registry = require('../../../integrations');
+const bridge = require('../../../services/telegramBridgeService');
 
 const telegramRoutes = require('../../../routes/webhooks/telegram');
 
@@ -142,5 +146,54 @@ describe('Telegram webhook routes', () => {
 
     expect(res.status).toBe(200);
     expect(events).toHaveBeenCalled();
+  });
+  describe('live relay ack', () => {
+    const liveIntegration = {
+      _id: 'integration-1',
+      type: 'telegram',
+      podId: 'pod-1',
+      config: { chatId: '42', liveRelay: true, linkedUserId: 'user-1' },
+    };
+
+    const post = () => request(app)
+      .post('/api/webhooks/telegram')
+      .send({
+        message: {
+          text: 'hello',
+          message_id: 555,
+          chat: { id: 42, title: 'Test Chat', type: 'group' },
+          from: { id: 7, first_name: 'Sam' },
+        },
+      });
+
+    it('relays through the bridge instead of the buffer', async () => {
+      Integration.findOne.mockResolvedValue(liveIntegration);
+      bridge.relayTelegramMessageToPod.mockResolvedValue({ relayed: true });
+      const events = jest.fn((req, res) => res.sendStatus(200));
+      registry.get.mockReturnValue({ getWebhookHandlers: () => ({ events }) });
+
+      const res = await post();
+
+      expect(res.status).toBe(200);
+      expect(bridge.relayTelegramMessageToPod).toHaveBeenCalled();
+      expect(events).not.toHaveBeenCalled();
+    });
+
+    // Telegram redelivers any update the webhook does not 2xx, and the relay is
+    // not idempotent: the pod row is written before agents are woken, and
+    // nothing dedupes on message_id. A 500 here duplicates both the message and
+    // the wake on retry, so the ack must not depend on the relay succeeding.
+    it('still acks 200 when the relay throws, so Telegram does not redeliver', async () => {
+      Integration.findOne.mockResolvedValue(liveIntegration);
+      bridge.relayTelegramMessageToPod.mockRejectedValue(new Error('delivery blew up'));
+      const events = jest.fn((req, res) => res.sendStatus(200));
+      registry.get.mockReturnValue({ getWebhookHandlers: () => ({ events }) });
+
+      const res = await post();
+
+      expect(res.status).toBe(200);
+      expect(bridge.relayTelegramMessageToPod).toHaveBeenCalled();
+      expect(events).not.toHaveBeenCalled();
+    });
   });
 });

--- a/backend/routes/webhooks/telegram.ts
+++ b/backend/routes/webhooks/telegram.ts
@@ -266,12 +266,21 @@ router.post('/', async (req: any, res: any) => {
     // pod as real messages (mentions fire, agents wake). Commands above keep
     // their legacy handling; everything else here short-circuits the buffer.
     if (integration.config?.liveRelay) {
-      // eslint-disable-next-line global-require
-      const bridge = require('../../services/telegramBridgeService');
-      await bridge.relayTelegramMessageToPod({
-        integration,
-        telegramMessage: message,
-      });
+      // A non-2xx makes Telegram redeliver this update, and the relay is not
+      // idempotent — nothing dedupes on message_id, and the pod row is written
+      // before agents are woken. A throw in delivery would therefore duplicate
+      // both the message and the wake on retry. Ack unconditionally: a dropped
+      // relay is recoverable, a doubled one is not.
+      try {
+        // eslint-disable-next-line global-require
+        const bridge = require('../../services/telegramBridgeService');
+        await bridge.relayTelegramMessageToPod({
+          integration,
+          telegramMessage: message,
+        });
+      } catch (relayErr) {
+        console.error('[tg-bridge] inbound relay failed:', (relayErr as Error).message);
+      }
       return res.sendStatus(200);
     }
 


### PR DESCRIPTION
Stacked on `feat/telegram-live-bridge` (#1282) so it can land with the demo rather than after it. Merges into that branch, not main.

## The defect

`routes/webhooks/telegram.ts` awaits `relayTelegramMessageToPod` with no local catch, so a throw lands in the route's outer handler and returns 500. Telegram redelivers any update the webhook does not 2xx.

The relay is not idempotent, and the ordering is what makes that expensive:

- `telegramBridgeService.ts:239` — `PGMessage.create(...)` writes the pod row
- `telegramBridgeService.ts:248` — `deliverMessageToAgents(...)` wakes agents

Both are unguarded, so a throw in delivery happens *after* the row exists. Nothing dedupes on `telegramMessage.message_id`. The retry therefore writes the message a second time and wakes every mentioned agent a second time — and it fires precisely when the pod is busy enough for delivery to be the thing that failed.

## The fix

Wrap the call, log, and `sendStatus(200)` regardless. A dropped relay is recoverable — the sender sees nothing arrive and retypes. A doubled one is not: the second wake is already in flight before anyone notices.

This does not make the relay idempotent, and is not meant to. Dedupe on `message_id` is the durable fix and wants a store; this removes the mechanism that turns any transient delivery failure into a duplicate.

## Proof

Two route tests. Both mock the bridge, so they exercise the route's contract rather than the relay's internals:

- the live-relay branch calls the bridge and does not fall through to the buffer provider
- a **throwing** relay still acks 200

Mutation control — revert only the route change and re-run:

```
Tests: 1 failed, 4 passed, 5 total
  ✕ still acks 200 when the relay throws, so Telegram does not redeliver
```

Exactly one red, and it is the new assertion; the other four stay green, so the test discriminates on the fix rather than on the mocking.

Context: https://github.com/Team-Commonly/commonly/pull/1282#issuecomment-5430565003