### PR TITLE
fix(telegram): split the webhook ack on which side of the pod write failed

### DIFF
--- a/backend/__tests__/unit/routes/telegram.webhook.test.js
+++ b/backend/__tests__/unit/routes/telegram.webhook.test.js
@@ -8,6 +8,9 @@ jest.mock('../../../services/integrationSummaryService', () => ({ createSummary:
 jest.mock('../../../services/agentEventService', () => ({ enqueue: jest.fn() }));
 jest.mock('../../../services/telegramService', () => ({ sendMessage: jest.fn() }));
 jest.mock('../../../integrations', () => ({ get: jest.fn() }));
+jest.mock('../../../services/telegramBridgeService', () => ({
+  relayTelegramMessageToPod: jest.fn(),
+}));
 
 const Integration = require('../../../models/Integration');
 const Pod = require('../../../models/Pod');
@@ -16,6 +19,7 @@ const IntegrationSummaryService = require('../../../services/integrationSummaryS
 const AgentEventService = require('../../../services/agentEventService');
 const telegramService = require('../../../services/telegramService');
 const registry = require('../../../integrations');
+const bridge = require('../../../services/telegramBridgeService');
 
 const telegramRoutes = require('../../../routes/webhooks/telegram');
 
@@ -142,5 +146,54 @@ describe('Telegram webhook routes', () => {
 
     expect(res.status).toBe(200);
     expect(events).toHaveBeenCalled();
+  });
+  describe('live relay ack', () => {
+    const liveIntegration = {
+      _id: 'integration-1',
+      type: 'telegram',
+      podId: 'pod-1',
+      config: { chatId: '42', liveRelay: true, linkedUserId: 'user-1' },
+    };
+
+    const post = () => request(app)
+      .post('/api/webhooks/telegram')
+      .send({
+        message: {
+          text: 'hello',
+          message_id: 555,
+          chat: { id: 42, title: 'Test Chat', type: 'group' },
+          from: { id: 7, first_name: 'Sam' },
+        },
+      });
+
+    it('relays through the bridge instead of the buffer', async () => {
+      Integration.findOne.mockResolvedValue(liveIntegration);
+      bridge.relayTelegramMessageToPod.mockResolvedValue({ relayed: true });
+      const events = jest.fn((req, res) => res.sendStatus(200));
+      registry.get.mockReturnValue({ getWebhookHandlers: () => ({ events }) });
+
+      const res = await post();
+
+      expect(res.status).toBe(200);
+      expect(bridge.relayTelegramMessageToPod).toHaveBeenCalled();
+      expect(events).not.toHaveBeenCalled();
+    });
+
+    // Telegram redelivers any update the webhook does not 2xx, and the relay is
+    // not idempotent: the pod row is written before agents are woken, and
+    // nothing dedupes on message_id. A 500 here duplicates both the message and
+    // the wake on retry, so the ack must not depend on the relay succeeding.
+    it('still acks 200 when the relay throws, so Telegram does not redeliver', async () => {
+      Integration.findOne.mockResolvedValue(liveIntegration);
+      bridge.relayTelegramMessageToPod.mockRejectedValue(new Error('delivery blew up'));
+      const events = jest.fn((req, res) => res.sendStatus(200));
+      registry.get.mockReturnValue({ getWebhookHandlers: () => ({ events }) });
+
+      const res = await post();
+
+      expect(res.status).toBe(200);
+      expect(bridge.relayTelegramMessageToPod).toHaveBeenCalled();
+      expect(events).not.toHaveBeenCalled();
+    });
   });
 });

--- a/backend/__tests__/unit/routes/telegram.webhook.test.js
+++ b/backend/__tests__/unit/routes/telegram.webhook.test.js
@@ -179,19 +179,19 @@ describe('Telegram webhook routes', () => {
       expect(events).not.toHaveBeenCalled();
     });
 
-    // Telegram redelivers any update the webhook does not 2xx, and the relay is
-    // not idempotent: the pod row is written before agents are woken, and
-    // nothing dedupes on message_id. A 500 here duplicates both the message and
-    // the wake on retry, so the ack must not depend on the relay succeeding.
-    it('still acks 200 when the relay throws, so Telegram does not redeliver', async () => {
+    // The bridge swallows its own post-write failures, so anything that throws
+    // out of it failed BEFORE the pod row existed. There is nothing to
+    // duplicate and Telegram's redelivery is the only repair — the route must
+    // NOT ack. A blanket catch + sendStatus(200) here drops those silently.
+    it('does not ack when the relay throws, so Telegram redelivers', async () => {
       Integration.findOne.mockResolvedValue(liveIntegration);
-      bridge.relayTelegramMessageToPod.mockRejectedValue(new Error('delivery blew up'));
+      bridge.relayTelegramMessageToPod.mockRejectedValue(new Error('pg down'));
       const events = jest.fn((req, res) => res.sendStatus(200));
       registry.get.mockReturnValue({ getWebhookHandlers: () => ({ events }) });
 
       const res = await post();
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(500);
       expect(bridge.relayTelegramMessageToPod).toHaveBeenCalled();
       expect(events).not.toHaveBeenCalled();
     });

--- a/backend/__tests__/unit/services/telegramBridgeService.inboundRetry.test.js
+++ b/backend/__tests__/unit/services/telegramBridgeService.inboundRetry.test.js
@@ -1,0 +1,62 @@
+// Which side of the pod write a failure lands on decides whether Telegram's
+// redelivery is a repair or a duplicate. These pin that split.
+jest.mock('../../../models/Integration', () => ({ findOne: jest.fn(), findByIdAndUpdate: jest.fn() }));
+jest.mock('../../../services/telegramService', () => ({ sendMessage: jest.fn() }));
+jest.mock('../../../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/Pod', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/pg/Message', () => ({ create: jest.fn(), findById: jest.fn() }));
+jest.mock('../../../models/pg/Pod', () => ({ findById: jest.fn() }));
+jest.mock('../../../services/pgPodSyncService', () => ({ syncPodFromMongo: jest.fn() }));
+jest.mock('../../../services/messageAgentDeliveryService', () => ({ deliverMessageToAgents: jest.fn() }));
+jest.mock('../../../config/socket', () => ({ getIO: jest.fn(() => null) }));
+
+const User = require('../../../models/User');
+const Pod = require('../../../models/Pod');
+const PGMessage = require('../../../models/pg/Message');
+const PGPod = require('../../../models/pg/Pod');
+const { deliverMessageToAgents } = require('../../../services/messageAgentDeliveryService');
+const { relayTelegramMessageToPod } = require('../../../services/telegramBridgeService');
+
+const integration = {
+  _id: 'i1',
+  podId: 'pod-1',
+  config: { chatId: '42', liveRelay: true, linkedUserId: 'user-1' },
+};
+const telegramMessage = { text: 'ship it', message_id: 555, from: { first_name: 'Sam' } };
+
+describe('relayTelegramMessageToPod — failures either side of the pod write', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    User.findById.mockReturnValue({ select: () => ({ lean: () => Promise.resolve({ username: 'sam', profilePicture: null }) }) });
+    Pod.findById.mockReturnValue({ select: () => ({ lean: () => Promise.resolve({ type: 'chat' }) }) });
+    PGPod.findById.mockResolvedValue({ id: 'pod-1' });
+    PGMessage.create.mockResolvedValue({ id: 'm1', content: 'x' });
+    PGMessage.findById.mockResolvedValue({ id: 'm1', content: 'x' });
+    deliverMessageToAgents.mockResolvedValue(undefined);
+  });
+
+  it('relays and reports it', async () => {
+    await expect(relayTelegramMessageToPod({ integration, telegramMessage }))
+      .resolves.toEqual(expect.objectContaining({ relayed: true }));
+    expect(PGMessage.create).toHaveBeenCalledTimes(1);
+    expect(deliverMessageToAgents).toHaveBeenCalledTimes(1);
+  });
+
+  // Nothing was persisted, so the webhook must NOT ack — Telegram's redelivery
+  // is the only thing that saves the update, and there is no row to duplicate.
+  it('propagates a failure BEFORE the write, so the retry can repair it', async () => {
+    PGMessage.create.mockRejectedValue(new Error('pg down'));
+    await expect(relayTelegramMessageToPod({ integration, telegramMessage }))
+      .rejects.toThrow('pg down');
+    expect(deliverMessageToAgents).not.toHaveBeenCalled();
+  });
+
+  // The row exists. A redelivery here would re-run create and duplicate both
+  // the message and every wake, because nothing dedupes on message_id.
+  it('swallows a failure AFTER the write, so the retry cannot duplicate it', async () => {
+    deliverMessageToAgents.mockRejectedValue(new Error('wake blew up'));
+    await expect(relayTelegramMessageToPod({ integration, telegramMessage }))
+      .resolves.toEqual(expect.objectContaining({ relayed: true }));
+    expect(PGMessage.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/routes/webhooks/telegram.ts
+++ b/backend/routes/webhooks/telegram.ts
@@ -266,12 +266,21 @@ router.post('/', async (req: any, res: any) => {
     // pod as real messages (mentions fire, agents wake). Commands above keep
     // their legacy handling; everything else here short-circuits the buffer.
     if (integration.config?.liveRelay) {
-      // eslint-disable-next-line global-require
-      const bridge = require('../../services/telegramBridgeService');
-      await bridge.relayTelegramMessageToPod({
-        integration,
-        telegramMessage: message,
-      });
+      // A non-2xx makes Telegram redeliver this update, and the relay is not
+      // idempotent — nothing dedupes on message_id, and the pod row is written
+      // before agents are woken. A throw in delivery would therefore duplicate
+      // both the message and the wake on retry. Ack unconditionally: a dropped
+      // relay is recoverable, a doubled one is not.
+      try {
+        // eslint-disable-next-line global-require
+        const bridge = require('../../services/telegramBridgeService');
+        await bridge.relayTelegramMessageToPod({
+          integration,
+          telegramMessage: message,
+        });
+      } catch (relayErr) {
+        console.error('[tg-bridge] inbound relay failed:', (relayErr as Error).message);
+      }
       return res.sendStatus(200);
     }
 

--- a/backend/routes/webhooks/telegram.ts
+++ b/backend/routes/webhooks/telegram.ts
@@ -266,21 +266,19 @@ router.post('/', async (req: any, res: any) => {
     // pod as real messages (mentions fire, agents wake). Commands above keep
     // their legacy handling; everything else here short-circuits the buffer.
     if (integration.config?.liveRelay) {
-      // A non-2xx makes Telegram redeliver this update, and the relay is not
-      // idempotent — nothing dedupes on message_id, and the pod row is written
-      // before agents are woken. A throw in delivery would therefore duplicate
-      // both the message and the wake on retry. Ack unconditionally: a dropped
-      // relay is recoverable, a doubled one is not.
-      try {
-        // eslint-disable-next-line global-require
-        const bridge = require('../../services/telegramBridgeService');
-        await bridge.relayTelegramMessageToPod({
-          integration,
-          telegramMessage: message,
-        });
-      } catch (relayErr) {
-        console.error('[tg-bridge] inbound relay failed:', (relayErr as Error).message);
-      }
+      // Deliberately NOT wrapped: a non-2xx makes Telegram redeliver, and
+      // whether that retry is a repair or a duplicate depends on which side of
+      // the pod write we failed on. relayTelegramMessageToPod swallows its own
+      // post-write failures and resolves, so anything that reaches here threw
+      // before the message was persisted — nothing exists to duplicate, and the
+      // redelivery is the only thing that saves the update. Adding a blanket
+      // catch + sendStatus(200) here silently drops those.
+      // eslint-disable-next-line global-require
+      const bridge = require('../../services/telegramBridgeService');
+      await bridge.relayTelegramMessageToPod({
+        integration,
+        telegramMessage: message,
+      });
       return res.sendStatus(200);
     }
 

--- a/backend/services/telegramBridgeService.ts
+++ b/backend/services/telegramBridgeService.ts
@@ -245,14 +245,24 @@ export const relayTelegramMessageToPod = async (opts: {
     console.warn('[tg-bridge] post-write read failed:', (readErr as Error).message);
   }
 
-  await deliverMessageToAgents({
-    podId,
-    podType: pod.type,
-    message,
-    userId: String(linkedUserId),
-    requestUser: { username: linkedUser.username },
-    replyToMessageId: null,
-  });
+  // Past this point the pod row exists. A throw here would reach the webhook
+  // route, return non-2xx, and Telegram would redeliver — re-running
+  // PGMessage.create and duplicating both the message and every wake it
+  // triggers, because nothing dedupes on telegramMessage.message_id. Swallow
+  // instead: the record survives and a human can re-poke. Failures BEFORE the
+  // write are left to propagate, where the same redelivery is the repair.
+  try {
+    await deliverMessageToAgents({
+      podId,
+      podType: pod.type,
+      message,
+      userId: String(linkedUserId),
+      requestUser: { username: linkedUser.username },
+      replyToMessageId: null,
+    });
+  } catch (deliverErr) {
+    console.error('[tg-bridge] agent delivery failed after pod write:', (deliverErr as Error).message);
+  }
 
   try {
     const io = socketConfig.getIO();


### PR DESCRIPTION
> **Corrected at `b581f344`.** The original body claimed "a dropped relay is recoverable, a doubled one is not" and acked 200 unconditionally. That is backwards for half the cases — sprint-review caught it. The diff below is the corrected shape.

## Why one ack policy can't be right

`relayTelegramMessageToPod` writes the pod row before it wakes agents:

- `telegramBridgeService.ts` — `PGMessage.create(...)`
- then `deliverMessageToAgents(...)`

Telegram redelivers any update the webhook does not 2xx, and nothing dedupes on `telegramMessage.message_id` — the field is declared in the payload type and never read. So the redelivery means two opposite things:

| failure lands | what the retry does | correct response |
|---|---|---|
| **before** the write | repairs it — nothing was persisted | non-2xx, let it redeliver |
| **after** the write | duplicates the message *and* every wake | 200, don't redeliver |

A blanket `try/catch` + `sendStatus(200)` on the route fixes the second and breaks the first, and the broken one is the quieter failure: no pod message, no wake, one `console.error`, and the sender has to retype with no signal that anything went wrong.

## The shape

Guard only the post-write step, and put the guard where that step is:

- `deliverMessageToAgents` is wrapped inside the bridge — the row already exists, so swallowing keeps the record and costs only the wake.
- Everything earlier propagates to the route's outer handler and 500s.
- The route keeps a bare `await` plus a comment stating the bareness is deliberate, because re-adding a blanket catch there is precisely the next edit someone makes.

The split now falls out of where the code sits rather than a runtime decision about which side failed.

## Proof

`__tests__/unit/services/telegramBridgeService.inboundRetry.test.js` — three cases: relays normally; **propagates** when `PGMessage.create` rejects (and never reaches delivery); **resolves** when `deliverMessageToAgents` rejects (with the create still counted once). Route test inverted to assert the non-ack.

Two mutations, each producing exactly one red, and a different one:

```
remove the post-write guard   -> 1 failed / 16 passed
   ✕ swallows a failure AFTER the write, so the retry cannot duplicate it

re-add a blanket catch on the route -> 1 failed / 16 passed
   ✕ does not ack when the relay throws, so Telegram redelivers
```

## Not done

Dedupe on `message_id` is the better fix — it gives retry safety without depending on where the throw landed — and it wants somewhere to keep seen ids. Deliberately not added hours before a live demo. This change is free and removes the duplication path either way.

Correction credit: sprint-review.