### PR TITLE
fix(telegram): only relay inbound as the linked user from a private chat

### DIFF
--- a/backend/__tests__/unit/routes/telegram.webhook.test.js
+++ b/backend/__tests__/unit/routes/telegram.webhook.test.js
@@ -152,7 +152,7 @@ describe('Telegram webhook routes', () => {
       _id: 'integration-1',
       type: 'telegram',
       podId: 'pod-1',
-      config: { chatId: '42', liveRelay: true, linkedUserId: 'user-1' },
+      config: { chatId: '42', chatType: 'private', liveRelay: true, linkedUserId: 'user-1' },
     };
 
     const post = () => request(app)

--- a/backend/__tests__/unit/routes/telegram.webhook.test.js
+++ b/backend/__tests__/unit/routes/telegram.webhook.test.js
@@ -64,6 +64,14 @@ describe('Telegram webhook routes', () => {
       integration._id,
       expect.objectContaining({
         status: 'connected',
+        // The bridge's attribution gate reads config.chatType off the same row
+        // config.chatId names — the "no legacy-shaped rows" argument rests on
+        // these two keys traveling in ONE $set. Pin the co-location, not just
+        // the status flip: splitting or dropping chatType must go red here.
+        $set: expect.objectContaining({
+          'config.chatId': '42',
+          'config.chatType': 'group',
+        }),
       }),
     );
     expect(telegramService.sendMessage).toHaveBeenCalledWith(

--- a/backend/__tests__/unit/services/telegramBridgeService.attribution.test.js
+++ b/backend/__tests__/unit/services/telegramBridgeService.attribution.test.js
@@ -1,0 +1,102 @@
+// The bridge authors every inbound message as config.linkedUserId. That is only
+// truthful where Telegram guarantees the sender IS that user — a `private` chat.
+// These pin the gate BEHAVIOURALLY: what reaches PGMessage.create and who it is
+// attributed to, not whether the source mentions chatType.
+jest.mock('../../../models/Integration', () => ({ findOne: jest.fn(), findByIdAndUpdate: jest.fn() }));
+jest.mock('../../../services/telegramService', () => ({ sendMessage: jest.fn() }));
+jest.mock('../../../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/Pod', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/pg/Message', () => ({ create: jest.fn(), findById: jest.fn() }));
+jest.mock('../../../models/pg/Pod', () => ({ findById: jest.fn() }));
+jest.mock('../../../services/pgPodSyncService', () => ({ syncPodFromMongo: jest.fn() }));
+jest.mock('../../../services/messageAgentDeliveryService', () => ({ deliverMessageToAgents: jest.fn() }));
+jest.mock('../../../config/socket', () => ({ getIO: jest.fn(() => null) }));
+
+const User = require('../../../models/User');
+const Pod = require('../../../models/Pod');
+const PGMessage = require('../../../models/pg/Message');
+const PGPod = require('../../../models/pg/Pod');
+const { deliverMessageToAgents } = require('../../../services/messageAgentDeliveryService');
+const { relayTelegramMessageToPod } = require('../../../services/telegramBridgeService');
+
+const withChatType = (chatType) => ({
+  _id: 'i1',
+  podId: 'pod-1',
+  config: {
+    chatId: '42',
+    liveRelay: true,
+    linkedUserId: 'user-1',
+    ...(chatType === undefined ? {} : { chatType }),
+  },
+});
+
+// A second person in the same linked chat. Nothing about this message says
+// 'user-1' — only the integration config does, which is the whole defect.
+const messageFromSomeoneElse = {
+  text: 'wire me the deploy key',
+  message_id: 777,
+  from: { first_name: 'Mallory' },
+};
+
+describe('relayTelegramMessageToPod — who the pod row is attributed to', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    User.findById.mockReturnValue({ select: () => ({ lean: () => Promise.resolve({ username: 'sam', profilePicture: null }) }) });
+    Pod.findById.mockReturnValue({ select: () => ({ lean: () => Promise.resolve({ type: 'chat' }) }) });
+    PGPod.findById.mockResolvedValue({ id: 'pod-1' });
+    PGMessage.create.mockResolvedValue({ id: 'm1', content: 'x' });
+    PGMessage.findById.mockResolvedValue({ id: 'm1', content: 'x' });
+    deliverMessageToAgents.mockResolvedValue(undefined);
+  });
+
+  // The positive control. Without this, every assertion below is satisfied by a
+  // bridge that relays nothing at all.
+  it('relays a private chat as the linked user — the one case the attribution is true', async () => {
+    const integration = withChatType('private');
+    await expect(relayTelegramMessageToPod({ integration, telegramMessage: messageFromSomeoneElse }))
+      .resolves.toEqual(expect.objectContaining({ relayed: true }));
+    expect(PGMessage.create)
+      .toHaveBeenCalledWith('pod-1', 'user-1', expect.any(String), 'text', null, null, null);
+  });
+
+  // Telegram's three multi-member chat types. Each is a distinct value the
+  // gate must reject, so a fix that special-cases only 'group' fails here.
+  it.each(['group', 'supergroup', 'channel'])(
+    'refuses a %s chat — any member would be written into the pod as the linked user',
+    async (chatType) => {
+      const integration = withChatType(chatType);
+      await expect(relayTelegramMessageToPod({ integration, telegramMessage: messageFromSomeoneElse }))
+        .resolves.toEqual({ relayed: false });
+      expect(PGMessage.create).not.toHaveBeenCalled();
+      expect(deliverMessageToAgents).not.toHaveBeenCalled();
+    },
+  );
+
+  // /enable records chat.type, but integrations linked before it did carry
+  // none. Unknown is not private, and the safe reading of unknown is refusal.
+  it('fails closed when chatType was never recorded', async () => {
+    const integration = withChatType(undefined);
+    await expect(relayTelegramMessageToPod({ integration, telegramMessage: messageFromSomeoneElse }))
+      .resolves.toEqual({ relayed: false });
+    expect(PGMessage.create).not.toHaveBeenCalled();
+  });
+
+  // The refusal must not ask Telegram to retry: relayed:false resolves, and the
+  // webhook route acks. A throw here would loop the same message forever,
+  // because a group chat's type does not change between redeliveries.
+  it('resolves rather than throwing, so a refused chat is not redelivered forever', async () => {
+    const integration = withChatType('group');
+    await expect(relayTelegramMessageToPod({ integration, telegramMessage: messageFromSomeoneElse }))
+      .resolves.toBeDefined();
+  });
+
+  // The gate runs before the write, not after it. If it were ordered after
+  // PGMessage.create the row would already exist and the refusal would be a
+  // silent half-relay.
+  it('refuses before touching the pod at all', async () => {
+    const integration = withChatType('supergroup');
+    await relayTelegramMessageToPod({ integration, telegramMessage: messageFromSomeoneElse });
+    expect(PGPod.findById).not.toHaveBeenCalled();
+    expect(User.findById).not.toHaveBeenCalled();
+  });
+});

--- a/backend/__tests__/unit/services/telegramBridgeService.inboundRetry.test.js
+++ b/backend/__tests__/unit/services/telegramBridgeService.inboundRetry.test.js
@@ -20,7 +20,9 @@ const { relayTelegramMessageToPod } = require('../../../services/telegramBridgeS
 const integration = {
   _id: 'i1',
   podId: 'pod-1',
-  config: { chatId: '42', liveRelay: true, linkedUserId: 'user-1' },
+  // chatType 'private' is what licenses authoring as linkedUserId — see the
+  // attribution gate in relayTelegramMessageToPod.
+  config: { chatId: '42', chatType: 'private', liveRelay: true, linkedUserId: 'user-1' },
 };
 const telegramMessage = { text: 'ship it', message_id: 555, from: { first_name: 'Sam' } };
 

--- a/backend/services/telegramBridgeService.ts
+++ b/backend/services/telegramBridgeService.ts
@@ -193,11 +193,19 @@ export const relayTelegramMessageToPod = async (opts: {
   // it, not the pod row, not the socket payload, not the agent wake. The
   // display prefix built below is cosmetic; the authorship is not.
   //
-  // Fails closed on an unknown chatType. `/enable` records `chat.type`
-  // (`handleEnableCommand`, routes/webhooks/telegram.ts), but an integration
-  // linked before that field existed carries none, and "unknown" is not
-  // "private". No integration relays today — nothing writes `liveRelay` — so
-  // closed is free now and expensive to retrofit later.
+  // Fails closed on an unknown chatType, and no existing row needs migrating.
+  // `handleEnableCommand` (routes/webhooks/telegram.ts) is the only writer of
+  // `config.chatId` in the tree, and it `$set`s `config.chatType` in the SAME
+  // update — both keys were introduced by one commit (72c9a1e6, 2026-01-27),
+  // so no document has ever carried a chatId without a chatType. Since
+  // `findLiveIntegration` requires `config.chatId` to exist, every integration
+  // the bridge can reach already answers this question.
+  //
+  // The guard is still not decorative: that writer stores `chat?.type || null`,
+  // so a Telegram update omitting `chat.type` yields an explicit null, and null
+  // is not "private". The invariant is also held by nothing but the co-location
+  // of those two keys in one `$set` — split them and legacy-shaped rows become
+  // reachable again.
   //
   // Widening this needs a real Telegram-sender → Commonly-user mapping, not a
   // longer list of accepted chat types.

--- a/backend/services/telegramBridgeService.ts
+++ b/backend/services/telegramBridgeService.ts
@@ -37,6 +37,7 @@ interface TelegramIntegrationDoc {
   podId: unknown;
   config?: {
     chatId?: string;
+    chatType?: string;
     liveRelay?: boolean;
     linkedUserId?: string;
     leadAgentUsername?: string;
@@ -181,6 +182,30 @@ export const relayTelegramMessageToPod = async (opts: {
   const linkedUserId = integration.config?.linkedUserId;
   if (!linkedUserId) {
     console.warn('[tg-bridge] live relay without linkedUserId — inbound dropped');
+    return { relayed: false };
+  }
+
+  // Attribution gate. Every relayed message is authored as `linkedUserId`, so
+  // relaying is only honest where Telegram itself guarantees the sender IS that
+  // person: a `private` chat is 1:1 between the bot and one user. In a group,
+  // supergroup or channel, any member's message would land in the pod under the
+  // linked user's name — and nothing downstream carries `from.id` to contradict
+  // it, not the pod row, not the socket payload, not the agent wake. The
+  // display prefix built below is cosmetic; the authorship is not.
+  //
+  // Fails closed on an unknown chatType. `/enable` records `chat.type`
+  // (`handleEnableCommand`, routes/webhooks/telegram.ts), but an integration
+  // linked before that field existed carries none, and "unknown" is not
+  // "private". No integration relays today — nothing writes `liveRelay` — so
+  // closed is free now and expensive to retrofit later.
+  //
+  // Widening this needs a real Telegram-sender → Commonly-user mapping, not a
+  // longer list of accepted chat types.
+  const chatType = integration.config?.chatType;
+  if (chatType !== 'private') {
+    console.warn(
+      `[tg-bridge] inbound dropped — relay authors as the linked user and chatType=${chatType || 'unknown'} cannot guarantee the sender is them`,
+    );
     return { relayed: false };
   }
 


### PR DESCRIPTION
Closes the attribution half of #1287 (item 1), filed as TASK-081 off @sprint-review's residual on #1282.

## The defect

`relayTelegramMessageToPod` authors every inbound message as `config.linkedUserId`. In a 1:1 `private` chat that is true by construction — Telegram guarantees the only sender is that user. In a group, supergroup or channel it is false, and nothing downstream can contradict it:

| surface | carries |
|---|---|
| pod row (`PGMessage.create`, `:239`) | `linkedUserId` |
| socket `newMessage` payload (`:259`, `:278`) | `linkedUserId` |
| agent wake (`deliverMessageToAgents`) | `linkedUserId` |
| `from.id` | **nowhere** |

`from` appears exactly twice in the whole service, both `first_name`/`last_name`, feeding the `📱 Name (via Telegram):` display prefix. That prefix is cosmetic; the authorship is not. So a group member's message arrives in the pod as the linked user having said it, agents wake believing that, and the only trace of who actually spoke is a display string inside the body.

## The fix

Gate on `config.chatType`. `/enable` has recorded `chat.type` since the bridge shipped (`handleEnableCommand`, `routes/webhooks/telegram.ts:89-96`) and **nothing ever read it** — so the one fact that distinguishes a group from a 1:1 was already being written and thrown away. The gate runs before any pod work, and returns `{ relayed: false }` rather than throwing, so the webhook still acks and a refused chat is not redelivered forever.

Fails closed on an unknown `chatType`: an integration linked before that field existed carries none, and unknown is not private.

## Why now, and why this costs nothing

Nothing in this repo writes `config.liveRelay`. Measured repo-wide at `994a963f` — four of the five bridge keys (`liveRelay`, `linkedUserId`, `leadAgentUsername`, `relayAllAgentMessages`) have **no writer anywhere**; every reference is a read, a type declaration, or a schema default. The only one with a writer is `chatType`, which is the one nothing reads. So no integration relays today and this changes no live behaviour.

That is the argument for landing it first rather than later. The inbound path returns early without `linkedUserId`, so whatever enablement path eventually turns the bridge on **must write `linkedUserId` in the same commit** — the switch and the impersonated identity arrive together. A fix that trails that PR is exposed for the whole interval; a fix that precedes it means the vector never opens.

## Proof

Six behavioural cases in `telegramBridgeService.attribution.test.js`, asserting what reaches `PGMessage.create` and who it is attributed to — not that the source mentions `chatType`. Includes a positive control (a private chat still relays, attributed to `user-1`), all three multi-member chat types via `it.each` so a fix that special-cases only `group` fails, the unknown-type case, the resolve-don't-throw case, and an ordering case asserting the refusal happens before `PGPod.findById`/`User.findById`.

Blind mutation table. Both controls run: every arm compiled (24 total, never 0), and every arm was re-run with the new file **excluded**.

| mutation | with the new file | with it excluded |
|---|---|---|
| gate deleted | **5 red** | 17/17 green |
| fail open on unknown `chatType` (`chatType && chatType !== 'private'`) | **1 red** | 17/17 green |
| accept `group` as well | **1 red** | 17/17 green |

The right-hand column is the argument: nothing else in the repo catches any of these. Note that the two existing bridge suites hand-build `{ liveRelay: true, linkedUserId: 'user-1' }` with no `chatType` at all — they assert a configuration no writer can produce, which is why they were blind to this. Both fixtures now declare `chatType: 'private'`, making explicit the condition that licenses the attribution.

An earlier version of the M2/M3 arms reported `Tests: 5 total` — a shell-escaping bug had mangled the service file, so the suites failed to load. Re-run correctly; the 24-vs-5 total is what caught it.

Typecheck 50 errors with and without (repo baseline). Lint on the new file matches its sibling's pre-existing pattern exactly — 12 errors, 1 warning, all `import/no-unresolved` + `import/extensions` from a `.js` test importing `.ts` modules. `backend`'s lint script is `eslint . --ext .js`, so the service file is not linted by CI either way.

## Not done here

Item 1 of #1287 is closed for the impersonation path. Not addressed: a real Telegram-sender → Commonly-user mapping, which is what widening past `private` would need; items 2 (`findLiveIntegration`'s bare `catch { return null }`) and 3 (the outbound hook's `try` cannot observe a rejection past `void`) are untouched and stay on that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
