### PR TITLE
docs(bridge): name the other half of the attribution invariant

### DIFF
--- a/backend/services/telegramBridgeService.ts
+++ b/backend/services/telegramBridgeService.ts
@@ -185,6 +185,15 @@ export const relayTelegramMessageToPod = async (opts: {
     return { relayed: false };
   }
 
+  // The gate proves the Telegram sender IS the chat's counterpart. It does NOT
+  // prove the counterpart is `linkedUserId` — that half is held one layer out,
+  // by the guard in `routes/integrations.ts` (PATCH /:id), which derives
+  // `config.linkedUserId` from the authenticated caller when `liveRelay` flips
+  // on and rejects any client-supplied value. Relax that guard and this gate
+  // still passes while authoring under an identity the caller chose. No test
+  // joins the two: both bridge suites hand-build `config`, so a mutation to the
+  // route guard turns nothing here red.
+  //
   // Attribution gate. Every relayed message is authored as `linkedUserId`, so
   // relaying is only honest where Telegram itself guarantees the sender IS that
   // person: a `private` chat is 1:1 between the bot and one user. In a group,


### PR DESCRIPTION
Comment-only, on merged main (`e35d89e6`).

#1289's gate establishes that the Telegram sender IS the chat's counterpart (a `private` chat is 1:1). It does **not** establish that the counterpart is `config.linkedUserId`. That half is held one layer out, by the guard @sprint-review's review put into #1290 — `routes/integrations.ts` PATCH `/:id` derives `linkedUserId` from the authenticated caller when `liveRelay` flips on and 400s any client-supplied value.

Relax the route guard and the bridge gate still passes, while authoring pod messages under an identity the caller chose.

**Nothing joins them.** Both bridge suites hand-build `config`, so a mutation to the route guard turns nothing in `telegramBridgeService` red — and the route's own tests do not know the value is an authorship identity. Until a test spans the two tiers, the comment is the only link, which is why it is worth adding rather than assuming the next reader re-derives it.

No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)