### PR TITLE
fix(activity): make the recap actionable

### DIFF
--- a/backend/__tests__/unit/models/PgMessage.test.js
+++ b/backend/__tests__/unit/models/PgMessage.test.js
@@ -86,7 +86,7 @@ describe('PG Message model', () => {
   it('finds every substantive agent-active pod in the requested window', async () => {
     const since = new Date('2026-08-26T00:00:00.000Z');
     pool.query.mockResolvedValueOnce({
-      rows: [{ pod_id: 'busy-pod', last_at: new Date('2026-08-26T14:00:00.000Z') }],
+      rows: [{ pod_id: 'busy-pod', message_count: '15', last_at: new Date('2026-08-26T14:00:00.000Z') }],
     });
 
     const result = await Message.findSubstantiveAgentPodActivity(['quiet-pod', 'busy-pod'], since);
@@ -96,7 +96,9 @@ describe('PG Message model', () => {
       [['quiet-pod', 'busy-pod'], since],
     );
     expect(pool.query.mock.calls[0][0]).toContain("NOT IN ('commonly-bot', 'commonly-ai-agent')");
-    expect(result).toEqual([{ podId: 'busy-pod', lastAt: new Date('2026-08-26T14:00:00.000Z') }]);
+    expect(result).toEqual([{
+      podId: 'busy-pod', agentMessageCount: 15, lastAt: new Date('2026-08-26T14:00:00.000Z'),
+    }]);
   });
 
   it('findById returns formatted message', async () => {

--- a/backend/__tests__/unit/models/PgMessage.test.js
+++ b/backend/__tests__/unit/models/PgMessage.test.js
@@ -83,6 +83,22 @@ describe('PG Message model', () => {
     );
   });
 
+  it('finds every substantive agent-active pod in the requested window', async () => {
+    const since = new Date('2026-08-26T00:00:00.000Z');
+    pool.query.mockResolvedValueOnce({
+      rows: [{ pod_id: 'busy-pod', last_at: new Date('2026-08-26T14:00:00.000Z') }],
+    });
+
+    const result = await Message.findSubstantiveAgentPodActivity(['quiet-pod', 'busy-pod'], since);
+
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('u.is_bot = TRUE'),
+      [['quiet-pod', 'busy-pod'], since],
+    );
+    expect(pool.query.mock.calls[0][0]).toContain("NOT IN ('commonly-bot', 'commonly-ai-agent')");
+    expect(result).toEqual([{ podId: 'busy-pod', lastAt: new Date('2026-08-26T14:00:00.000Z') }]);
+  });
+
   it('findById returns formatted message', async () => {
     pool.query.mockResolvedValueOnce({
       rows: [

--- a/backend/__tests__/unit/services/activityService.recap.test.js
+++ b/backend/__tests__/unit/services/activityService.recap.test.js
@@ -1,8 +1,12 @@
 jest.mock('../../../models/Pod', () => ({ find: jest.fn() }));
 jest.mock('../../../models/Task', () => ({ find: jest.fn() }));
+jest.mock('../../../models/pg/Message', () => ({
+  findSubstantiveAgentPodActivity: jest.fn().mockResolvedValue([]),
+}));
 
 const Pod = require('../../../models/Pod');
 const Task = require('../../../models/Task');
+const PGMessage = require('../../../models/pg/Message');
 const Activity = require('../../../models/Activity');
 const User = require('../../../models/User');
 const ActivityService = require('../../../services/activityService');
@@ -30,6 +34,7 @@ describe('ActivityService.getRecap', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    PGMessage.findSubstantiveAgentPodActivity.mockResolvedValue([]);
     Pod.find.mockReturnValue(podQuery([pod]));
     Task.find.mockReturnValue(taskQuery([{
       _id: 'board-1',
@@ -80,8 +85,82 @@ describe('ActivityService.getRecap', () => {
     expect(spy).toHaveBeenCalledWith(ownerId, { limit: 100 });
     expect(Pod.find).toHaveBeenCalledWith(expect.objectContaining({ $or: expect.any(Array) }));
     expect(Task.find).toHaveBeenCalledWith(expect.objectContaining({
-      podId: { $in: ['pod-1'] }, updatedAt: { $gte: expect.any(Date) },
+      podId: { $in: ['pod-1'] }, $or: expect.any(Array),
     }));
+  });
+
+  test('surfaces durable board press and decision facts ahead of incidental mentions', async () => {
+    Task.find.mockReturnValue(taskQuery([
+      {
+        _id: 'press-1', podId: 'pod-1', taskId: 'TASK-201',
+        title: 'Release the Activity recap', status: 'claimed', updatedAt: new Date(),
+        updates: [{ text: 'Gated #1274 — awaiting human press.', author: 'reviewer', createdAt: new Date() }],
+      },
+      {
+        _id: 'decision-1', podId: 'pod-1', taskId: 'TASK-202',
+        title: 'DECIDE: retain unread activity state', status: 'blocked', updatedAt: new Date(),
+        updates: [{ text: 'A human decision unblocks the implementation.', author: 'architect', createdAt: new Date() }],
+      },
+    ]));
+
+    const result = await ActivityService.getRecap(ownerId, { window: 'today' });
+
+    expect(result.needsYou).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'press', taskId: 'TASK-201', podId: 'pod-1' }),
+      expect.objectContaining({ kind: 'decision', taskId: 'TASK-202', podId: 'pod-1' }),
+      expect.objectContaining({ kind: 'mention', id: 'message-1' }),
+    ]));
+    expect(result.needsYou.map((item) => item.kind)).toEqual(['press', 'decision', 'mention']);
+  });
+
+  test('excludes system bot noise, ranks real seats by substantive updates, and only exposes active pods in the default scope', async () => {
+    const activePod = { _id: 'pod-2', name: 'Real work pod', type: 'team' };
+    Pod.find.mockReturnValue(podQuery([pod, activePod]));
+    Task.find.mockReturnValue(taskQuery([]));
+    spy.mockResolvedValue({
+      activities: [
+        {
+          id: 'system-1', type: 'summary', actor: { id: 'system', name: 'commonly-bot', type: 'system' },
+          action: 'summary', preview: 'Echoed a task update.', timestamp: new Date(),
+          pod: { id: 'pod-1', name: pod.name }, flags: { isAgentAction: true, isMention: false },
+        },
+        {
+          id: 'agent-a', type: 'message', actor: { id: 'agent-a', name: 'alpha', type: 'agent' },
+          action: 'message', preview: 'Shipped one change.', timestamp: new Date(Date.now() - 60_000),
+          pod: { id: 'pod-2', name: activePod.name }, flags: { isAgentAction: true, isMention: false },
+        },
+        {
+          id: 'agent-b-1', type: 'message', actor: { id: 'agent-b', name: 'beta', type: 'agent' },
+          action: 'message', preview: 'Reviewed a pull request.', timestamp: new Date(Date.now() - 120_000),
+          pod: { id: 'pod-2', name: activePod.name }, flags: { isAgentAction: true, isMention: false },
+        },
+        {
+          id: 'agent-b-2', type: 'message', actor: { id: 'agent-b', name: 'beta', type: 'agent' },
+          action: 'message', preview: 'Posted the decision.', timestamp: new Date(Date.now() - 180_000),
+          pod: { id: 'pod-2', name: activePod.name }, flags: { isAgentAction: true, isMention: false },
+        },
+      ],
+    });
+
+    const result = await ActivityService.getRecap(ownerId, { window: 'today' });
+
+    expect(result.scope).toBe('active');
+    expect(result.pods).toEqual([{ id: 'pod-2', name: activePod.name }]);
+    expect(result.agents.map((agent) => agent.name)).toEqual(['beta', 'alpha']);
+    expect(result.agents.map((agent) => agent.name)).not.toContain('commonly-bot');
+  });
+
+  test('derives the active pod selector from all substantive agent messages, not the recap feed page', async () => {
+    const busyPod = { _id: 'pod-busy', name: 'Busy but active', type: 'team' };
+    Pod.find.mockReturnValue(podQuery([pod, busyPod]));
+    Task.find.mockReturnValue(taskQuery([]));
+    spy.mockResolvedValue({ activities: [] });
+    PGMessage.findSubstantiveAgentPodActivity.mockResolvedValue([{ podId: 'pod-busy' }]);
+
+    const result = await ActivityService.getRecap(ownerId, { window: 'today' });
+
+    expect(PGMessage.findSubstantiveAgentPodActivity).toHaveBeenCalledWith(['pod-1', 'pod-busy'], expect.any(Date));
+    expect(result.pods).toEqual([{ id: 'pod-busy', name: busyPod.name }]);
   });
 
   test('rejects a requested pod that is outside the viewer membership', async () => {

--- a/backend/__tests__/unit/services/activityService.recap.test.js
+++ b/backend/__tests__/unit/services/activityService.recap.test.js
@@ -70,7 +70,9 @@ describe('ActivityService.getRecap', () => {
   test('projects existing agent activity, direct mentions, and board updates without writing new events', async () => {
     const result = await ActivityService.getRecap(ownerId, { window: 'today' });
 
-    expect(result.pods).toEqual([expect.objectContaining({ id: 'pod-1', name: pod.name })]);
+    expect(result.pods).toEqual([expect.objectContaining({
+      id: 'pod-1', name: pod.name, activeInWindow: true, agentMessageCount: 1,
+    })]);
     expect(result.needsYou).toEqual([expect.objectContaining({
       kind: 'mention', podId: 'pod-1', title: 'sprint-impl mentioned you',
     })]);
@@ -94,6 +96,7 @@ describe('ActivityService.getRecap', () => {
       {
         _id: 'press-1', podId: 'pod-1', taskId: 'TASK-201',
         title: 'Release the Activity recap', status: 'claimed', updatedAt: new Date(),
+        prUrl: 'https://github.com/Team-Commonly/commonly/pull/1274',
         updates: [{ text: 'Gated #1274 — awaiting human press.', author: 'reviewer', createdAt: new Date() }],
       },
       {
@@ -101,16 +104,28 @@ describe('ActivityService.getRecap', () => {
         title: 'DECIDE: retain unread activity state', status: 'blocked', updatedAt: new Date(),
         updates: [{ text: 'A human decision unblocks the implementation.', author: 'architect', createdAt: new Date() }],
       },
+      {
+        _id: 'handoff-1', podId: 'pod-1', taskId: 'TASK-203',
+        title: 'Press the deployment after the smoke test', status: 'blocked', updatedAt: new Date(),
+        updates: [{ text: 'Waiting for a human to press the deployment.', author: 'operator', createdAt: new Date() }],
+      },
     ]));
 
     const result = await ActivityService.getRecap(ownerId, { window: 'today' });
 
     expect(result.needsYou).toEqual(expect.arrayContaining([
-      expect.objectContaining({ kind: 'press', taskId: 'TASK-201', podId: 'pod-1' }),
-      expect.objectContaining({ kind: 'decision', taskId: 'TASK-202', podId: 'pod-1' }),
+      expect.objectContaining({
+        kind: 'press', taskId: 'TASK-201', podId: 'pod-1',
+        prUrl: 'https://github.com/Team-Commonly/commonly/pull/1274',
+      }),
+      expect.objectContaining({ kind: 'decide', taskId: 'TASK-202', podId: 'pod-1' }),
+      expect.objectContaining({ kind: 'handoff', taskId: 'TASK-203', podId: 'pod-1' }),
       expect.objectContaining({ kind: 'mention', id: 'message-1' }),
     ]));
-    expect(result.needsYou.map((item) => item.kind)).toEqual(['press', 'decision', 'mention']);
+    expect(result.needsYou.map((item) => item.kind)).toEqual(['press', 'decide', 'handoff', 'mention']);
+    expect(Task.find.mock.results[0].value.select).toHaveBeenCalledWith(
+      expect.stringContaining('prUrl'),
+    );
   });
 
   test('excludes system bot noise, ranks real seats by substantive updates, and only exposes active pods in the default scope', async () => {
@@ -145,7 +160,10 @@ describe('ActivityService.getRecap', () => {
     const result = await ActivityService.getRecap(ownerId, { window: 'today' });
 
     expect(result.scope).toBe('active');
-    expect(result.pods).toEqual([{ id: 'pod-2', name: activePod.name }]);
+    expect(result.pods).toEqual(expect.arrayContaining([
+      { id: 'pod-1', name: pod.name, activeInWindow: false, agentMessageCount: 0 },
+      { id: 'pod-2', name: activePod.name, activeInWindow: true, agentMessageCount: 3 },
+    ]));
     expect(result.agents.map((agent) => agent.name)).toEqual(['beta', 'alpha']);
     expect(result.agents.map((agent) => agent.name)).not.toContain('commonly-bot');
   });
@@ -155,12 +173,15 @@ describe('ActivityService.getRecap', () => {
     Pod.find.mockReturnValue(podQuery([pod, busyPod]));
     Task.find.mockReturnValue(taskQuery([]));
     spy.mockResolvedValue({ activities: [] });
-    PGMessage.findSubstantiveAgentPodActivity.mockResolvedValue([{ podId: 'pod-busy' }]);
+    PGMessage.findSubstantiveAgentPodActivity.mockResolvedValue([{ podId: 'pod-busy', agentMessageCount: 15 }]);
 
     const result = await ActivityService.getRecap(ownerId, { window: 'today' });
 
     expect(PGMessage.findSubstantiveAgentPodActivity).toHaveBeenCalledWith(['pod-1', 'pod-busy'], expect.any(Date));
-    expect(result.pods).toEqual([{ id: 'pod-busy', name: busyPod.name }]);
+    expect(result.pods).toEqual(expect.arrayContaining([
+      { id: 'pod-1', name: pod.name, activeInWindow: false, agentMessageCount: 0 },
+      { id: 'pod-busy', name: busyPod.name, activeInWindow: true, agentMessageCount: 15 },
+    ]));
   });
 
   test('rejects a requested pod that is outside the viewer membership', async () => {

--- a/backend/models/pg/Message.ts
+++ b/backend/models/pg/Message.ts
@@ -511,6 +511,45 @@ class Message {
     }
   }
 
+  // The Activity recap's default pod scope must describe real agent work in
+  // the selected window, not merely the first page of its mixed activity
+  // feed. This is deliberately a grouped database read: a busy pod can have
+  // more than the feed's display limit before the next active pod's message.
+  // System summaries are bot-authored too, so exclude their two known seats
+  // here as well as in the recap projection.
+  static async findSubstantiveAgentPodActivity(
+    podIds: unknown[],
+    since: unknown,
+  ): Promise<PodActivityEntry[]> {
+    if (!podIds || !podIds.length) return [];
+    try {
+      const podIdStrs = podIds.map((id) => (id as { toString(): string } | undefined)?.toString()).filter(Boolean);
+      if (!podIdStrs.length) return [];
+      const result = await (pool as PgPool).query(
+        `SELECT m.pod_id, MAX(m.created_at) AS last_at
+         FROM messages m
+         JOIN users u ON u._id = m.user_id
+         WHERE m.pod_id = ANY($1)
+           AND m.created_at >= $2
+           AND m.message_type != 'system'
+           AND m.content <> ''
+           AND u.is_bot = TRUE
+           AND LOWER(COALESCE(u.username, '')) NOT IN ('commonly-bot', 'commonly-ai-agent')
+         GROUP BY m.pod_id
+         ORDER BY last_at DESC`,
+        [podIdStrs, since],
+      );
+      return (result.rows as Array<{ pod_id: string; last_at: unknown }>).map((row) => ({
+        podId: row.pod_id,
+        lastAt: row.last_at,
+      }));
+    } catch (error) {
+      const e = error as { message?: string };
+      console.error('Error in findSubstantiveAgentPodActivity:', e.message);
+      return [];
+    }
+  }
+
   // One row per pod: the given user's most-recent non-system message in each pod.
   // Powers the agent-profile "pods" list (their last message + when, per pod).
   static async findLastMessageByUserPerPod(

--- a/backend/models/pg/Message.ts
+++ b/backend/models/pg/Message.ts
@@ -49,6 +49,10 @@ interface PodActivityEntry {
   lastAt: unknown;
 }
 
+interface AgentPodActivityEntry extends PodActivityEntry {
+  agentMessageCount: number;
+}
+
 function formatMessage(msg: MessageRow): FormattedMessage {
   const messageId = msg.id ? msg.id.toString() : '';
   const userId = msg.user_id || '';
@@ -520,13 +524,13 @@ class Message {
   static async findSubstantiveAgentPodActivity(
     podIds: unknown[],
     since: unknown,
-  ): Promise<PodActivityEntry[]> {
+  ): Promise<AgentPodActivityEntry[]> {
     if (!podIds || !podIds.length) return [];
     try {
       const podIdStrs = podIds.map((id) => (id as { toString(): string } | undefined)?.toString()).filter(Boolean);
       if (!podIdStrs.length) return [];
       const result = await (pool as PgPool).query(
-        `SELECT m.pod_id, MAX(m.created_at) AS last_at
+        `SELECT m.pod_id, COUNT(*) AS message_count, MAX(m.created_at) AS last_at
          FROM messages m
          JOIN users u ON u._id = m.user_id
          WHERE m.pod_id = ANY($1)
@@ -539,8 +543,9 @@ class Message {
          ORDER BY last_at DESC`,
         [podIdStrs, since],
       );
-      return (result.rows as Array<{ pod_id: string; last_at: unknown }>).map((row) => ({
+      return (result.rows as Array<{ pod_id: string; message_count?: string | number; last_at: unknown }>).map((row) => ({
         podId: row.pod_id,
+        agentMessageCount: parseInt(String(row.message_count || 0), 10),
         lastAt: row.last_at,
       }));
     } catch (error) {

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -95,7 +95,7 @@ interface GetRecapOptions {
   podId?: string;
 }
 
-type NeedsYouKind = 'mention' | 'approval' | 'press' | 'decision';
+type NeedsYouKind = 'mention' | 'approval' | 'press' | 'decide' | 'handoff';
 
 interface RecapTask {
   _id?: unknown;
@@ -103,6 +103,7 @@ interface RecapTask {
   taskId?: string;
   title?: string;
   status?: string;
+  prUrl?: string | null;
   notes?: string | null;
   updatedAt?: Date | string | null;
   updates?: Array<Record<string, unknown>>;
@@ -119,7 +120,8 @@ const isSystemActivity = (activity: ActivityItem): boolean => {
 // system summary may be an activity event, but it is not evidence that an
 // agent made progress and must not outrank the people doing the work.
 const isSubstantiveAgentActivity = (activity: ActivityItem): boolean => (
-  activity.actor?.type === 'agent'
+  activity.type === 'message'
+  && activity.actor?.type === 'agent'
   && !isSystemActivity(activity)
   && Boolean(String(activity.preview || activity.content || '').trim())
 );
@@ -130,21 +132,22 @@ const newestTaskUpdate = (updates: Array<Record<string, unknown>> = []): Record<
   ))[0] || null
 );
 
-const PRESS_HANDOFF = /\b(?:awaiting|waiting\s+(?:on|for)|ready\s+for|safe\s+to|please|needs?)\s+(?:a\s+|the\s+)?(?:human\s+)?(?:to\s+)?(?:press|merge)\b|\bpress[-\s]?gate\b|\b(?:gated|approved|press[-\s]?safe|ready to merge)\b/i;
+const HUMAN_PRESS_HANDOFF = /\b(?:awaiting|waiting\s+(?:on|for)|ready\s+for|safe\s+to|please|needs?)\s+(?:a\s+|the\s+)?(?:human\s+)?(?:to\s+)?(?:press|merge)\b|\bpress[-\s]?gate\b/i;
 const PULL_REQUEST_REFERENCE = /(?:\bpr\b|#\d+)/i;
+const GATED_PULL_REQUEST = /\b(?:gated|approved|press[-\s]?safe|ready to merge)\b/i;
 
 const taskAttentionKind = (task: RecapTask): NeedsYouKind | null => {
-  if (/^\s*DECIDE\b/i.test(String(task.title || ''))) return 'decision';
+  if (/^\s*DECIDE\b/i.test(String(task.title || ''))) return 'decide';
 
   const text = [
     task.title,
     task.notes,
     ...(Array.isArray(task.updates) ? task.updates.map((update) => update.text) : []),
   ].filter((value) => typeof value === 'string').join('\n');
-  const isGatedPullRequest = PULL_REQUEST_REFERENCE.test(text)
-    && /\b(?:gated|approved|press[-\s]?safe|ready to merge)\b/i.test(text);
+  const isGatedPullRequest = PULL_REQUEST_REFERENCE.test(text) && GATED_PULL_REQUEST.test(text);
 
-  return PRESS_HANDOFF.test(text) || isGatedPullRequest ? 'press' : null;
+  if (isGatedPullRequest) return 'press';
+  return HUMAN_PRESS_HANDOFF.test(text) ? 'handoff' : null;
 };
 
 interface ComputeFlagsOptions {
@@ -179,10 +182,11 @@ class ActivityService {
     }).select('_id name type').lean();
 
     const requestedPodId = typeof options.podId === 'string' ? options.podId : '';
-    const requestedPods = requestedPodId
+    const requestsAllPods = requestedPodId === 'all';
+    const requestedPods = requestedPodId && !requestsAllPods
       ? memberPods.filter((pod) => String(pod._id) === requestedPodId)
       : [];
-    if (requestedPodId && requestedPods.length === 0) {
+    if (requestedPodId && !requestsAllPods && requestedPods.length === 0) {
       throw new Error('Access denied');
     }
     const feed = await ActivityService.getUserFeed(userId, { limit: 100 });
@@ -200,17 +204,43 @@ class ActivityService {
     // "active in this window" into "happened to be in the latest 100 rows":
     // the grouped PG read sees every substantive agent message in each member
     // pod during the requested window. The feed contribution above remains a
-    // fallback for non-message agent events and the Mongo message fallback.
+    // fallback when the grouped message read is unavailable.
+    const agentMessageCounts = new Map<string, number>();
+    const persistedPodIds = new Set<string>();
     if (PGMessage && memberPods.length) {
       const persistedActivity = await (PGMessage as {
-        findSubstantiveAgentPodActivity: (podIds: unknown[], sinceAt: Date) => Promise<Array<{ podId: string }>>;
+        findSubstantiveAgentPodActivity: (podIds: unknown[], sinceAt: Date) => Promise<Array<{
+          podId: string; agentMessageCount?: number;
+        }>>;
       }).findSubstantiveAgentPodActivity(memberPods.map((pod) => pod._id), since);
       persistedActivity.forEach((entry) => activePodIds.add(String(entry.podId)));
+      persistedActivity.forEach((entry) => {
+        const podId = String(entry.podId);
+        persistedPodIds.add(podId);
+        agentMessageCounts.set(podId, Number(entry.agentMessageCount || 0));
+      });
+      windowActivities
+        .filter(isSubstantiveAgentActivity)
+        .forEach((activity) => {
+          if (!activity.pod?.id || persistedPodIds.has(activity.pod.id)) return;
+          agentMessageCounts.set(
+            activity.pod.id,
+            (agentMessageCounts.get(activity.pod.id) || 0) + 1,
+          );
+        });
     }
     const activePods = memberPods.filter((pod) => activePodIds.has(String(pod._id)));
-    const scopedPods = requestedPodId ? requestedPods : activePods;
+    const scopedPods = requestsAllPods ? memberPods : requestedPodId ? requestedPods : activePods;
     const scopedPodIds = new Set(scopedPods.map((pod) => String(pod._id)));
+    const recapPods = memberPods.map((pod) => {
+      const id = String(pod._id);
+      const agentMessageCount = agentMessageCounts.get(id) || windowActivities.filter((activity) => (
+        isSubstantiveAgentActivity(activity) && activity.pod?.id === id
+      )).length;
+      return { id, name: pod.name, activeInWindow: activePodIds.has(id), agentMessageCount };
+    });
     const activities = windowActivities.filter((activity) => {
+      if (requestsAllPods) return true;
       if (requestedPodId) return Boolean(activity.pod && scopedPodIds.has(activity.pod.id));
       return !activity.pod || scopedPodIds.has(activity.pod.id);
     });
@@ -379,7 +409,7 @@ class ActivityService {
           { updatedAt: { $gte: since } },
         ],
       })
-        .select('podId taskId title status notes updatedAt updates')
+        .select('podId taskId title status notes prUrl updatedAt updates')
         .sort({ updatedAt: -1 })
         .limit(100)
         .lean() as RecapTask[]
@@ -398,20 +428,24 @@ class ActivityService {
           kind,
           title: String(task.title || taskId),
           detail: kind === 'press'
-            ? `Waiting for a human press.${evidence ? ` ${evidence}` : ''}`
-            : `Waiting for a decision.${evidence ? ` ${evidence}` : ''}`,
+            ? `A gated pull request is ready to press.${evidence ? ` ${evidence}` : ''}`
+            : kind === 'decide'
+              ? `Waiting for a decision.${evidence ? ` ${evidence}` : ''}`
+              : `Waiting for a human handoff.${evidence ? ` ${evidence}` : ''}`,
           podId: task.podId ? String(task.podId) : null,
           podName: podNames.get(String(task.podId)) || 'Pod',
           timestamp: latestUpdate?.createdAt as Date | string | null || task.updatedAt || null,
           taskId,
+          prUrl: task.prUrl || null,
         };
       })
       .filter((item): item is NonNullable<typeof item> => Boolean(item));
     const attentionPriority: Record<NeedsYouKind, number> = {
       press: 0,
-      decision: 1,
-      approval: 2,
-      mention: 3,
+      decide: 1,
+      handoff: 2,
+      approval: 3,
+      mention: 4,
     };
     const needsYou = [...taskAttention, ...activityAttention]
       .sort((left, right) => (
@@ -454,7 +488,7 @@ class ActivityService {
       since: since.toISOString(),
       generatedAt: new Date().toISOString(),
       scope: requestedPodId || 'active',
-      pods: activePods.map((pod) => ({ id: String(pod._id), name: pod.name })),
+      pods: recapPods,
       needsYou,
       agents: agentRecaps,
       board,

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -95,6 +95,58 @@ interface GetRecapOptions {
   podId?: string;
 }
 
+type NeedsYouKind = 'mention' | 'approval' | 'press' | 'decision';
+
+interface RecapTask {
+  _id?: unknown;
+  podId?: unknown;
+  taskId?: string;
+  title?: string;
+  status?: string;
+  notes?: string | null;
+  updatedAt?: Date | string | null;
+  updates?: Array<Record<string, unknown>>;
+}
+
+const SYSTEM_ACTIVITY_ACTORS = new Set(['commonly-bot', 'commonly-ai-agent']);
+
+const isSystemActivity = (activity: ActivityItem): boolean => {
+  const name = String(activity.actor?.name || '').trim().toLowerCase();
+  return activity.actor?.type === 'system' || SYSTEM_ACTIVITY_ACTORS.has(name);
+};
+
+// The recap is useful only when it tells the human what a real seat did. A
+// system summary may be an activity event, but it is not evidence that an
+// agent made progress and must not outrank the people doing the work.
+const isSubstantiveAgentActivity = (activity: ActivityItem): boolean => (
+  activity.actor?.type === 'agent'
+  && !isSystemActivity(activity)
+  && Boolean(String(activity.preview || activity.content || '').trim())
+);
+
+const newestTaskUpdate = (updates: Array<Record<string, unknown>> = []): Record<string, unknown> | null => (
+  updates.slice().sort((left, right) => (
+    new Date(right.createdAt as string || 0).getTime() - new Date(left.createdAt as string || 0).getTime()
+  ))[0] || null
+);
+
+const PRESS_HANDOFF = /\b(?:awaiting|waiting\s+(?:on|for)|ready\s+for|safe\s+to|please|needs?)\s+(?:a\s+|the\s+)?(?:human\s+)?(?:to\s+)?(?:press|merge)\b|\bpress[-\s]?gate\b|\b(?:gated|approved|press[-\s]?safe|ready to merge)\b/i;
+const PULL_REQUEST_REFERENCE = /(?:\bpr\b|#\d+)/i;
+
+const taskAttentionKind = (task: RecapTask): NeedsYouKind | null => {
+  if (/^\s*DECIDE\b/i.test(String(task.title || ''))) return 'decision';
+
+  const text = [
+    task.title,
+    task.notes,
+    ...(Array.isArray(task.updates) ? task.updates.map((update) => update.text) : []),
+  ].filter((value) => typeof value === 'string').join('\n');
+  const isGatedPullRequest = PULL_REQUEST_REFERENCE.test(text)
+    && /\b(?:gated|approved|press[-\s]?safe|ready to merge)\b/i.test(text);
+
+  return PRESS_HANDOFF.test(text) || isGatedPullRequest ? 'press' : null;
+};
+
 interface ComputeFlagsOptions {
   actor?: ActorInfo;
   type?: string;
@@ -118,7 +170,7 @@ class ActivityService {
   ): Promise<Record<string, unknown>> {
     const window = options.window === '7d' ? '7d' : 'today';
     const since = new Date(Date.now() - (window === '7d' ? 7 : 1) * 24 * 60 * 60 * 1000);
-    const pods: PodDoc[] = await Pod.find({
+    const memberPods: PodDoc[] = await Pod.find({
       $or: [
         { createdBy: userId },
         { 'members.userId': userId },
@@ -127,19 +179,40 @@ class ActivityService {
     }).select('_id name type').lean();
 
     const requestedPodId = typeof options.podId === 'string' ? options.podId : '';
-    const scopedPods = requestedPodId
-      ? pods.filter((pod) => String(pod._id) === requestedPodId)
-      : pods;
-    if (requestedPodId && scopedPods.length === 0) {
+    const requestedPods = requestedPodId
+      ? memberPods.filter((pod) => String(pod._id) === requestedPodId)
+      : [];
+    if (requestedPodId && requestedPods.length === 0) {
       throw new Error('Access denied');
     }
-
-    const scopedPodIds = new Set(scopedPods.map((pod) => String(pod._id)));
     const feed = await ActivityService.getUserFeed(userId, { limit: 100 });
-    const activities = ((feed.activities as ActivityItem[] | undefined) || []).filter((activity) => {
+    const windowActivities = ((feed.activities as ActivityItem[] | undefined) || []).filter((activity) => {
       const timestamp = activity.timestamp ? new Date(activity.timestamp).getTime() : 0;
-      return timestamp >= since.getTime()
-        && (!requestedPodId || (activity.pod && scopedPodIds.has(activity.pod.id)));
+      return timestamp >= since.getTime();
+    });
+    const activePodIds = new Set(
+      windowActivities
+        .filter(isSubstantiveAgentActivity)
+        .map((activity) => activity.pod?.id)
+        .filter((podId): podId is string => Boolean(podId)),
+    );
+    // getUserFeed is intentionally a display page. Do not let its limit turn
+    // "active in this window" into "happened to be in the latest 100 rows":
+    // the grouped PG read sees every substantive agent message in each member
+    // pod during the requested window. The feed contribution above remains a
+    // fallback for non-message agent events and the Mongo message fallback.
+    if (PGMessage && memberPods.length) {
+      const persistedActivity = await (PGMessage as {
+        findSubstantiveAgentPodActivity: (podIds: unknown[], sinceAt: Date) => Promise<Array<{ podId: string }>>;
+      }).findSubstantiveAgentPodActivity(memberPods.map((pod) => pod._id), since);
+      persistedActivity.forEach((entry) => activePodIds.add(String(entry.podId)));
+    }
+    const activePods = memberPods.filter((pod) => activePodIds.has(String(pod._id)));
+    const scopedPods = requestedPodId ? requestedPods : activePods;
+    const scopedPodIds = new Set(scopedPods.map((pod) => String(pod._id)));
+    const activities = windowActivities.filter((activity) => {
+      if (requestedPodId) return Boolean(activity.pod && scopedPodIds.has(activity.pod.id));
+      return !activity.pod || scopedPodIds.has(activity.pod.id);
     });
     const acknowledgedMentionIds = new Set(
       ((feed.acknowledgedMentionIds as unknown[] | undefined) || []).map((id) => String(id)),
@@ -163,7 +236,7 @@ class ActivityService {
     const agents = new Map<string, AgentRecap>();
 
     activities
-      .filter((activity) => activity.actor?.type === 'agent' || activity.flags?.isAgentAction)
+      .filter(isSubstantiveAgentActivity)
       .forEach((activity) => {
         const actorId = String(activity.actor?.id || activity.actor?.name || 'unknown-agent');
         const name = activity.actor?.name || 'Agent';
@@ -207,13 +280,22 @@ class ActivityService {
             : `Posted ${agent.messageCount} updates${podNames[0] ? ` across ${podNames.slice(0, 2).join(' and ')}` : ''}.`,
         };
       })
-      .sort((a, b) => new Date(b.lastActiveAt || 0).getTime() - new Date(a.lastActiveAt || 0).getTime());
+      .sort((a, b) => (
+        b.messageCount - a.messageCount
+        || new Date(b.lastActiveAt || 0).getTime() - new Date(a.lastActiveAt || 0).getTime()
+      ));
 
     // Approvals are a decision queue, not an activity sample: query the
     // existing authoritative pending-approval reader separately so a busy
     // pod cannot push an older decision behind getUserFeed's display page.
     // Mentions remain a bounded recent interrupt list and are removed only by
     // their explicit acknowledgement, never by feed read-state.
+    // A pod selector narrows the recap and board. The default is deliberately
+    // quieter (only pods with substantive agent work), but it must not hide a
+    // human decision in another accessible pod: Needs you is the interrupt
+    // surface, not a feed filter.
+    const queuePods = requestedPodId ? scopedPods : memberPods;
+    const queuePodIds = new Set(queuePods.map((pod) => String(pod._id)));
     const pendingApprovals = await ActivityService.getPendingApprovals(userId) as Array<{
       _id?: unknown;
       id?: unknown;
@@ -228,10 +310,10 @@ class ActivityService {
       updatedAt?: Date | string;
     }>;
     const approvalItems: ActivityItem[] = pendingApprovals
-      .filter((approval) => !requestedPodId || scopedPodIds.has(String(approval.podId)))
+      .filter((approval) => queuePodIds.has(String(approval.podId)))
       .map((approval) => {
         const podId = approval.podId ? String(approval.podId) : '';
-        const pod = scopedPods.find((candidate) => String(candidate._id) === podId);
+        const pod = queuePods.find((candidate) => String(candidate._id) === podId);
         return {
           id: String(approval._id || approval.id || ''),
           type: approval.type || 'approval_needed',
@@ -257,8 +339,9 @@ class ActivityService {
       // an approval request; otherwise every message becomes a human action.
       return activity.type === 'approval_needed' && approval?.status === 'pending';
     };
+    const queueActivitySource = requestedPodId ? activities : windowActivities;
     const queueCandidates = new Map<string, ActivityItem>();
-    [...activities, ...approvalItems].forEach((activity) => {
+    [...queueActivitySource, ...approvalItems].forEach((activity) => {
       if (!queueCandidates.has(activity.id)) queueCandidates.set(activity.id, activity);
     });
     const newestFirst = (left: ActivityItem, right: ActivityItem) => (
@@ -269,39 +352,85 @@ class ActivityService {
       .sort(newestFirst);
     const mentionQueue = Array.from(queueCandidates.values())
       .filter((activity) => activity.flags?.isMention && !acknowledgedMentionIds.has(String(activity.id)))
-      .sort(newestFirst)
-      .slice(0, Math.max(0, 12 - approvalQueue.length));
-    const needsYou = [...approvalQueue, ...mentionQueue]
-      .sort(newestFirst)
+      .sort(newestFirst);
+    const activityAttention = [...approvalQueue, ...mentionQueue]
       .map((activity) => {
         const isApproval = isPendingApproval(activity);
         return {
           id: activity.id,
-          kind: isApproval ? 'approval' : 'mention',
+          kind: (isApproval ? 'approval' : 'mention') as NeedsYouKind,
           title: isApproval ? 'Approval requested' : `${activity.actor?.name || 'Someone'} mentioned you`,
           detail: String(activity.preview || activity.content || '').replace(/\s+/g, ' ').trim().slice(0, 180),
           podId: activity.pod?.id || null,
           podName: activity.pod?.name || 'Direct activity',
           timestamp: activity.timestamp,
+          taskId: null,
         };
       });
 
-    let board: Array<Record<string, unknown>> = [];
-    if (scopedPods.length > 0) {
-      const taskRows: Array<Record<string, unknown>> = await Task.find({
-        podId: { $in: scopedPods.map((pod) => pod._id) },
-        updatedAt: { $gte: since },
+    // Board facts are durable until the task changes. Query current non-done
+    // rows alongside the window's board delta so an approved PR from yesterday
+    // still reaches the human today instead of disappearing at midnight.
+    const taskRows: RecapTask[] = queuePods.length > 0
+      ? await Task.find({
+        podId: { $in: queuePods.map((pod) => pod._id) },
+        $or: [
+          { status: { $ne: 'done' } },
+          { updatedAt: { $gte: since } },
+        ],
       })
-        .select('podId taskId title status updatedAt updates')
+        .select('podId taskId title status notes updatedAt updates')
         .sort({ updatedAt: -1 })
-        .limit(24)
-        .lean();
-      const podNames = new Map(scopedPods.map((pod) => [String(pod._id), pod.name]));
-      board = taskRows.map((task) => {
+        .limit(100)
+        .lean() as RecapTask[]
+      : [];
+    const podNames = new Map(memberPods.map((pod) => [String(pod._id), pod.name]));
+    const taskAttention = taskRows
+      .filter((task) => task.status !== 'done')
+      .map((task) => {
+        const kind = taskAttentionKind(task);
+        if (!kind) return null;
+        const latestUpdate = newestTaskUpdate(task.updates);
+        const evidence = String(latestUpdate?.text || task.notes || '').replace(/\s+/g, ' ').trim();
+        const taskId = String(task.taskId || 'Task');
+        return {
+          id: `task:${String(task._id || taskId)}`,
+          kind,
+          title: String(task.title || taskId),
+          detail: kind === 'press'
+            ? `Waiting for a human press.${evidence ? ` ${evidence}` : ''}`
+            : `Waiting for a decision.${evidence ? ` ${evidence}` : ''}`,
+          podId: task.podId ? String(task.podId) : null,
+          podName: podNames.get(String(task.podId)) || 'Pod',
+          timestamp: latestUpdate?.createdAt as Date | string | null || task.updatedAt || null,
+          taskId,
+        };
+      })
+      .filter((item): item is NonNullable<typeof item> => Boolean(item));
+    const attentionPriority: Record<NeedsYouKind, number> = {
+      press: 0,
+      decision: 1,
+      approval: 2,
+      mention: 3,
+    };
+    const needsYou = [...taskAttention, ...activityAttention]
+      .sort((left, right) => (
+        attentionPriority[left.kind] - attentionPriority[right.kind]
+        || new Date(right.timestamp || 0).getTime() - new Date(left.timestamp || 0).getTime()
+      ))
+      .slice(0, 12)
+      .map((activity) => ({
+        ...activity,
+        detail: activity.detail.slice(0, 180),
+      }));
+
+    const board = taskRows
+      .filter((task) => scopedPodIds.has(String(task.podId))
+        && new Date(task.updatedAt || 0).getTime() >= since.getTime())
+      .slice(0, 24)
+      .map((task) => {
         const updates = Array.isArray(task.updates) ? task.updates as Array<Record<string, unknown>> : [];
-        const lastUpdate = updates
-          .slice()
-          .sort((a, b) => new Date(b.createdAt as string || 0).getTime() - new Date(a.createdAt as string || 0).getTime())[0];
+        const lastUpdate = newestTaskUpdate(updates);
         return {
           id: String(task._id),
           taskId: task.taskId,
@@ -319,14 +448,13 @@ class ActivityService {
             : null,
         };
       });
-    }
 
     return {
       window,
       since: since.toISOString(),
       generatedAt: new Date().toISOString(),
-      scope: requestedPodId || 'all',
-      pods: pods.map((pod) => ({ id: String(pod._id), name: pod.name })),
+      scope: requestedPodId || 'active',
+      pods: activePods.map((pod) => ({ id: String(pod._id), name: pod.name })),
       needsYou,
       agents: agentRecaps,
       board,

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -32,19 +32,21 @@
     "windowAriaLabel": "Activity window",
     "windows": { "today": "Today", "7d": "7 days" },
     "podScopeLabel": "Pod scope",
+    "activePods": "Active pods",
     "allPods": "All pods",
     "loadFailed": "Activity could not be loaded. Try again.",
     "openThread": "Open thread",
+    "openBoard": "Open board",
     "lastActive": "Active {{time}} ago",
     "updatesCount_one": "{{count}} update",
     "updatesCount_other": "{{count}} updates",
     "needsYou": {
       "eyebrow": "Decision queue",
       "title": "Needs you",
-      "description": "Only direct mentions and pending approvals appear here.",
+      "description": "Decisions, ready-to-press work, direct mentions, and pending approvals appear here.",
       "emptyTitle": "Nothing is waiting on you",
       "emptyDescription": "New mentions and approval requests will appear here when they need a response.",
-      "kinds": { "mention": "Mention", "approval": "Approval" }
+      "kinds": { "mention": "Mention", "approval": "Approval", "press": "Ready to press", "decision": "Decision needed" }
     },
     "dayZero": {
       "kind": "Get started",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -31,22 +31,29 @@
     "controlsAriaLabel": "Activity controls",
     "windowAriaLabel": "Activity window",
     "windows": { "today": "Today", "7d": "7 days" },
-    "podScopeLabel": "Pod scope",
-    "activePods": "Active pods",
-    "allPods": "All pods",
+    "podScopeLabel": "Scope ·",
+    "activePods": "Active pods ({{count}})",
+    "allPods": "All pods ({{count}})",
+    "podOption": "{{name}} ({{count}})",
+    "scopeGroups": {
+      "active": "Active this window ({{count}})",
+      "other": "Other pods"
+    },
     "loadFailed": "Activity could not be loaded. Try again.",
     "openThread": "Open thread",
     "openBoard": "Open board",
+    "openPr": "Open PR",
+    "openRow": "Open row",
     "lastActive": "Active {{time}} ago",
     "updatesCount_one": "{{count}} update",
     "updatesCount_other": "{{count}} updates",
     "needsYou": {
       "eyebrow": "Decision queue",
       "title": "Needs you",
-      "description": "Decisions, ready-to-press work, direct mentions, and pending approvals appear here.",
+      "description": "Gated pull requests, decisions, human handoffs, direct mentions, and pending approvals appear here.",
       "emptyTitle": "Nothing is waiting on you",
       "emptyDescription": "New mentions and approval requests will appear here when they need a response.",
-      "kinds": { "mention": "Mention", "approval": "Approval", "press": "Ready to press", "decision": "Decision needed" }
+      "kinds": { "mention": "Mention", "approval": "Approval", "press": "Ready to press", "decide": "Decision needed", "handoff": "Human handoff" }
     },
     "dayZero": {
       "kind": "Get started",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -52,7 +52,7 @@
       "title": "Needs you",
       "description": "Gated pull requests, decisions, human handoffs, direct mentions, and pending approvals appear here.",
       "emptyTitle": "Nothing is waiting on you",
-      "emptyDescription": "New mentions and approval requests will appear here when they need a response.",
+      "emptyDescription": "New mentions, decisions, press-ready pull requests, and human handoffs will appear here.",
       "kinds": { "mention": "Mention", "approval": "Approval", "press": "Ready to press", "decide": "Decision needed", "handoff": "Human handoff" }
     },
     "dayZero": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -31,22 +31,29 @@
     "controlsAriaLabel": "动态控制项",
     "windowAriaLabel": "动态时间范围",
     "windows": { "today": "今天", "7d": "7 天" },
-    "podScopeLabel": "Pod 范围",
-    "activePods": "活跃 Pod",
-    "allPods": "所有 Pod",
+    "podScopeLabel": "范围 ·",
+    "activePods": "活跃 Pod（{{count}}）",
+    "allPods": "所有 Pod（{{count}}）",
+    "podOption": "{{name}}（{{count}}）",
+    "scopeGroups": {
+      "active": "此时间范围内活跃（{{count}}）",
+      "other": "其他 Pod"
+    },
     "loadFailed": "无法加载动态，请重试。",
     "openThread": "打开讨论",
     "openBoard": "打开看板",
+    "openPr": "打开 PR",
+    "openRow": "打开任务",
     "lastActive": "{{time}}前活跃",
     "updatesCount_one": "{{count}} 条更新",
     "updatesCount_other": "{{count}} 条更新",
     "needsYou": {
       "eyebrow": "决策队列",
       "title": "需要你处理",
-      "description": "这里显示需要决策、等待合并、直接提及和待处理的审批。",
+      "description": "这里显示等待合并的 PR、需要决策的事项、等待人工交接、直接提及和待处理的审批。",
       "emptyTitle": "没有事项在等待你",
       "emptyDescription": "有需要回复的提及或审批请求时，会显示在这里。",
-      "kinds": { "mention": "提及", "approval": "审批", "press": "等待合并", "decision": "需要决策" }
+      "kinds": { "mention": "提及", "approval": "审批", "press": "等待合并", "decide": "需要决策", "handoff": "等待人工交接" }
     },
     "dayZero": {
       "kind": "开始使用",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -32,19 +32,21 @@
     "windowAriaLabel": "动态时间范围",
     "windows": { "today": "今天", "7d": "7 天" },
     "podScopeLabel": "Pod 范围",
+    "activePods": "活跃 Pod",
     "allPods": "所有 Pod",
     "loadFailed": "无法加载动态，请重试。",
     "openThread": "打开讨论",
+    "openBoard": "打开看板",
     "lastActive": "{{time}}前活跃",
     "updatesCount_one": "{{count}} 条更新",
     "updatesCount_other": "{{count}} 条更新",
     "needsYou": {
       "eyebrow": "决策队列",
       "title": "需要你处理",
-      "description": "这里只显示直接提及和待处理的审批。",
+      "description": "这里显示需要决策、等待合并、直接提及和待处理的审批。",
       "emptyTitle": "没有事项在等待你",
       "emptyDescription": "有需要回复的提及或审批请求时，会显示在这里。",
-      "kinds": { "mention": "提及", "approval": "审批" }
+      "kinds": { "mention": "提及", "approval": "审批", "press": "等待合并", "decision": "需要决策" }
     },
     "dayZero": {
       "kind": "开始使用",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -52,7 +52,7 @@
       "title": "需要你处理",
       "description": "这里显示等待合并的 PR、需要决策的事项、等待人工交接、直接提及和待处理的审批。",
       "emptyTitle": "没有事项在等待你",
-      "emptyDescription": "有需要回复的提及或审批请求时，会显示在这里。",
+      "emptyDescription": "新的提及、决策、等待合并的 PR 和等待人工交接会显示在这里。",
       "kinds": { "mention": "提及", "approval": "审批", "press": "等待合并", "decide": "需要决策", "handoff": "等待人工交接" }
     },
     "dayZero": {

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -85,6 +85,39 @@ describe('V2ActivityPage', () => {
     expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/pod-1');
   });
 
+  test('defaults the recap to active pods and keeps the scope selector compact', async () => {
+    renderPage();
+    await screen.findByText('Review requested');
+
+    const scope = screen.getByLabelText('Pod scope');
+    expect(scope).toHaveValue('active');
+    expect(scope.querySelectorAll('option')).toHaveLength(2);
+    expect(screen.getByRole('option', { name: 'Active pods' })).toBeInTheDocument();
+
+    fireEvent.change(scope, { target: { value: 'pod-1' } });
+    await waitFor(() => expect(mockGet).toHaveBeenLastCalledWith('/api/activity/recap', expect.objectContaining({
+      params: { window: 'today', podId: 'pod-1' },
+    })));
+  });
+
+  test('opens the board from a durable press handoff', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        ...recap,
+        needsYou: [{
+          id: 'task:press-1', kind: 'press', taskId: 'TASK-201',
+          title: 'Release the Activity recap', detail: 'Waiting for a human press.',
+          podId: 'pod-1', podName: 'Launch pod', timestamp: '2026-08-26T11:00:00.000Z',
+        }],
+      },
+    });
+    renderPage();
+
+    expect(await screen.findByText('Release the Activity recap')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Open board' }));
+    expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/pod-1/board');
+  });
+
   test('acknowledges a mention explicitly instead of treating a feed read as acknowledgement', async () => {
     mockGet
       .mockResolvedValueOnce({ data: recap })

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -22,7 +22,10 @@ const CurrentPath = () => {
 };
 
 const recap = {
-  pods: [{ id: 'pod-1', name: 'Launch pod' }],
+  pods: [
+    { id: 'pod-1', name: 'Launch pod', activeInWindow: true, agentMessageCount: 2 },
+    { id: 'pod-2', name: 'Quiet pod', activeInWindow: false, agentMessageCount: 0 },
+  ],
   needsYou: [{
     id: 'mention-1', kind: 'mention', title: 'Review requested', detail: 'A direct mention.',
     podId: 'pod-1', podName: 'Launch pod', timestamp: '2026-08-26T11:00:00.000Z',
@@ -85,22 +88,32 @@ describe('V2ActivityPage', () => {
     expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/pod-1');
   });
 
-  test('defaults the recap to active pods and keeps the scope selector compact', async () => {
+  test('defaults to active pods and groups every selectable pod by current activity', async () => {
     renderPage();
     await screen.findByText('Review requested');
 
-    const scope = screen.getByLabelText('Pod scope');
+    const scope = screen.getByLabelText(/Scope/);
     expect(scope).toHaveValue('active');
-    expect(scope.querySelectorAll('option')).toHaveLength(2);
-    expect(screen.getByRole('option', { name: 'Active pods' })).toBeInTheDocument();
+    expect(scope.querySelectorAll('option')).toHaveLength(4);
+    expect(screen.getByRole('option', { name: 'Active pods (1)' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'All pods (2)' })).toBeInTheDocument();
+    expect(scope.querySelector('optgroup[label="Active this window (1)"]')).toBeInTheDocument();
+    expect(scope.querySelector('optgroup[label="Other pods"]')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Launch pod (2)' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Quiet pod (0)' })).toBeInTheDocument();
 
     fireEvent.change(scope, { target: { value: 'pod-1' } });
     await waitFor(() => expect(mockGet).toHaveBeenLastCalledWith('/api/activity/recap', expect.objectContaining({
       params: { window: 'today', podId: 'pod-1' },
     })));
+
+    fireEvent.change(scope, { target: { value: 'all' } });
+    await waitFor(() => expect(mockGet).toHaveBeenLastCalledWith('/api/activity/recap', expect.objectContaining({
+      params: { window: 'today', podId: 'all' },
+    })));
   });
 
-  test('opens the board from a durable press handoff', async () => {
+  test('opens a gated pull request from a press fact', async () => {
     mockGet.mockResolvedValue({
       data: {
         ...recap,
@@ -108,14 +121,34 @@ describe('V2ActivityPage', () => {
           id: 'task:press-1', kind: 'press', taskId: 'TASK-201',
           title: 'Release the Activity recap', detail: 'Waiting for a human press.',
           podId: 'pod-1', podName: 'Launch pod', timestamp: '2026-08-26T11:00:00.000Z',
+          prUrl: 'https://github.com/Team-Commonly/commonly/pull/1274',
         }],
       },
     });
     renderPage();
 
     expect(await screen.findByText('Release the Activity recap')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Open board' }));
-    expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/pod-1/board');
+    expect(screen.getByRole('link', { name: 'Open PR' })).toHaveAttribute(
+      'href', 'https://github.com/Team-Commonly/commonly/pull/1274',
+    );
+  });
+
+  test('opens a DECIDE board row rather than treating it as a PR press', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        ...recap,
+        needsYou: [{
+          id: 'task:decide-1', kind: 'decide', taskId: 'TASK-202',
+          title: 'DECIDE: retain unread activity state', detail: 'Waiting for a decision.',
+          podId: 'pod-1', podName: 'Launch pod', timestamp: '2026-08-26T11:00:00.000Z',
+        }],
+      },
+    });
+    renderPage();
+
+    expect(await screen.findByText('DECIDE: retain unread activity state')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Open row' }));
+    expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/pod-1/board?taskId=TASK-202');
   });
 
   test('acknowledges a mention explicitly instead of treating a feed read as acknowledgement', async () => {

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -172,6 +172,8 @@ describe('V2ActivityPage', () => {
     renderPage();
 
     expect(await screen.findByText('Nothing is waiting on you')).toBeInTheDocument();
+    expect(screen.getByText('New mentions, decisions, press-ready pull requests, and human handoffs will appear here.')).toBeInTheDocument();
+    expect(screen.queryByText(/approval requests will appear/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/0 needs you/i)).not.toBeInTheDocument();
   });
 

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -447,6 +447,12 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // only one character of a task title — an overflow-free but unusable
     // primary identifier, which violates the craft baseline rule.
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-activity__board-row \{[\s\S]*?grid-template-columns: minmax\(0, 1fr\)/);
+    // The filter still needs to be usable at 390px after its label becomes
+    // visually redundant with the selected "Active pods" option. Keeping a
+    // zero-min grid track here is what prevents a long pod name from forcing
+    // the time-window control off screen.
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-activity__controls \{[\s\S]*?grid-template-columns: minmax\(0, 1fr\) minmax\(0, 120px\)/);
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-activity__scope-label \{ display: none; \}/);
   });
 
   test('Activity queue actions distinguish an action from the thread handoff', () => {

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -27,13 +27,14 @@ interface AgentRecap {
 
 interface NeedsYouItem {
   id: string;
-  kind: 'mention' | 'approval' | 'press' | 'decision';
+  kind: 'mention' | 'approval' | 'press' | 'decide' | 'handoff';
   title: string;
   detail: string;
   podId: string | null;
   podName: string;
   timestamp: string | null;
   taskId?: string | null;
+  prUrl?: string | null;
 }
 
 interface BoardItem {
@@ -48,7 +49,12 @@ interface BoardItem {
 }
 
 interface ActivityRecap {
-  pods: Array<{ id: string; name: string }>;
+  pods: Array<{
+    id: string;
+    name: string;
+    activeInWindow: boolean;
+    agentMessageCount: number;
+  }>;
   needsYou: NeedsYouItem[];
   agents: AgentRecap[];
   board: BoardItem[];
@@ -106,7 +112,10 @@ const V2ActivityPage: React.FC = () => {
   };
 
   const openTaskBoard = (item: NeedsYouItem) => {
-    if (item.podId) navigate(`/v2/pods/${item.podId}/board`);
+    if (item.podId) {
+      const taskQuery = item.taskId ? `?taskId=${encodeURIComponent(item.taskId)}` : '';
+      navigate(`/v2/pods/${item.podId}/board${taskQuery}`);
+    }
   };
 
   const openFirstBoard = () => {
@@ -162,6 +171,8 @@ const V2ActivityPage: React.FC = () => {
     && recap?.needsYou.length === 0
     && recap?.agents.length === 0
     && recap.board.length === 0;
+  const activePods = (recap?.pods || []).filter((pod) => pod.activeInWindow);
+  const otherPods = (recap?.pods || []).filter((pod) => !pod.activeInWindow);
 
   return (
     <div className="v2-activity" aria-busy={loading}>
@@ -187,8 +198,26 @@ const V2ActivityPage: React.FC = () => {
           <label className="v2-activity__scope">
             <span className="v2-activity__scope-label">{t('activity.podScopeLabel')}</span>
             <select value={podId} onChange={(event) => setPodId(event.target.value)}>
-              <option value="active">{t('activity.activePods')}</option>
-              {(recap?.pods || []).map((pod) => <option key={pod.id} value={pod.id}>{pod.name}</option>)}
+              <option value="active">{t('activity.activePods', { count: activePods.length })}</option>
+              <option value="all">{t('activity.allPods', { count: recap?.pods.length || 0 })}</option>
+              {activePods.length > 0 && (
+                <optgroup label={t('activity.scopeGroups.active', { count: activePods.length })}>
+                  {activePods.map((pod) => (
+                    <option key={pod.id} value={pod.id}>
+                      {t('activity.podOption', { name: pod.name, count: pod.agentMessageCount })}
+                    </option>
+                  ))}
+                </optgroup>
+              )}
+              {otherPods.length > 0 && (
+                <optgroup label={t('activity.scopeGroups.other')}>
+                  {otherPods.map((pod) => (
+                    <option key={pod.id} value={pod.id}>
+                      {t('activity.podOption', { name: pod.name, count: pod.agentMessageCount })}
+                    </option>
+                  ))}
+                </optgroup>
+              )}
             </select>
           </label>
         </div>
@@ -256,7 +285,11 @@ const V2ActivityPage: React.FC = () => {
                 {recap.needsYou.map((item) => (
                   <article key={item.id} className={`v2-activity__queue-row v2-activity__queue-row--${item.kind}`}>
                     <span className="v2-activity__queue-mark" aria-hidden="true">
-                      {item.kind === 'mention' ? '@' : item.kind === 'approval' ? '!' : item.kind === 'press' ? '↗' : '?'}
+                      {item.kind === 'mention' ? '@'
+                        : item.kind === 'approval' ? '!'
+                          : item.kind === 'press' ? '▶'
+                            : item.kind === 'decide' ? '?'
+                              : '→'}
                     </span>
                     <div className="v2-activity__queue-copy">
                       <div className="v2-activity__queue-kind">{t(`activity.needsYou.kinds.${item.kind}`)}</div>
@@ -280,9 +313,22 @@ const V2ActivityPage: React.FC = () => {
                           {acknowledgingMentionId === item.id ? t('activity.mention.working') : t('activity.mention.acknowledge')}
                         </button>
                       )}
-                      {(item.kind === 'press' || item.kind === 'decision') ? (
+                      {item.kind === 'press' ? (
+                        item.prUrl ? (
+                          <a
+                            className="v2-activity__queue-action"
+                            href={item.prUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            {t('activity.openPr')}
+                          </a>
+                        ) : (
+                          <button type="button" disabled>{t('activity.openPr')}</button>
+                        )
+                      ) : (item.kind === 'decide' || item.kind === 'handoff') ? (
                         <button type="button" onClick={() => openTaskBoard(item)} disabled={!item.podId}>
-                          {t('activity.openBoard')}
+                          {t('activity.openRow')}
                         </button>
                       ) : (
                         <button type="button" className="v2-activity__queue-action--thread" onClick={() => openPod(item.podId)} disabled={!item.podId}>

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -27,12 +27,13 @@ interface AgentRecap {
 
 interface NeedsYouItem {
   id: string;
-  kind: 'mention' | 'approval';
+  kind: 'mention' | 'approval' | 'press' | 'decision';
   title: string;
   detail: string;
   podId: string | null;
   podName: string;
   timestamp: string | null;
+  taskId?: string | null;
 }
 
 interface BoardItem {
@@ -68,7 +69,7 @@ const V2ActivityPage: React.FC = () => {
   const navigate = useNavigate();
   const { t } = useTranslation();
   const [window, setWindow] = useState<ActivityWindow>('today');
-  const [podId, setPodId] = useState('all');
+  const [podId, setPodId] = useState('active');
   const [recap, setRecap] = useState<ActivityRecap | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -84,7 +85,7 @@ const V2ActivityPage: React.FC = () => {
     const token = localStorage.getItem('token');
     axios.get<ActivityRecap>('/api/activity/recap', {
       headers: { 'x-auth-token': token ?? '' },
-      params: { window, ...(podId !== 'all' ? { podId } : {}) },
+      params: { window, ...(podId !== 'active' ? { podId } : {}) },
     })
       .then((response) => {
         if (active) setRecap(response.data);
@@ -102,6 +103,10 @@ const V2ActivityPage: React.FC = () => {
 
   const openPod = (targetPodId: string | null) => {
     if (targetPodId) navigate(`/v2/pods/${targetPodId}`);
+  };
+
+  const openTaskBoard = (item: NeedsYouItem) => {
+    if (item.podId) navigate(`/v2/pods/${item.podId}/board`);
   };
 
   const openFirstBoard = () => {
@@ -153,7 +158,8 @@ const V2ActivityPage: React.FC = () => {
     }
   };
 
-  const isDayZero = podId === 'all'
+  const isDayZero = podId === 'active'
+    && recap?.needsYou.length === 0
     && recap?.agents.length === 0
     && recap.board.length === 0;
 
@@ -179,9 +185,9 @@ const V2ActivityPage: React.FC = () => {
             ))}
           </div>
           <label className="v2-activity__scope">
-            <span className="v2-sr-only">{t('activity.podScopeLabel')}</span>
+            <span className="v2-activity__scope-label">{t('activity.podScopeLabel')}</span>
             <select value={podId} onChange={(event) => setPodId(event.target.value)}>
-              <option value="all">{t('activity.allPods')}</option>
+              <option value="active">{t('activity.activePods')}</option>
               {(recap?.pods || []).map((pod) => <option key={pod.id} value={pod.id}>{pod.name}</option>)}
             </select>
           </label>
@@ -249,7 +255,9 @@ const V2ActivityPage: React.FC = () => {
               <div className="v2-activity__queue">
                 {recap.needsYou.map((item) => (
                   <article key={item.id} className={`v2-activity__queue-row v2-activity__queue-row--${item.kind}`}>
-                    <span className="v2-activity__queue-mark" aria-hidden="true">{item.kind === 'mention' ? '@' : '!'}</span>
+                    <span className="v2-activity__queue-mark" aria-hidden="true">
+                      {item.kind === 'mention' ? '@' : item.kind === 'approval' ? '!' : item.kind === 'press' ? '↗' : '?'}
+                    </span>
                     <div className="v2-activity__queue-copy">
                       <div className="v2-activity__queue-kind">{t(`activity.needsYou.kinds.${item.kind}`)}</div>
                       <strong>{item.title}</strong>
@@ -272,9 +280,15 @@ const V2ActivityPage: React.FC = () => {
                           {acknowledgingMentionId === item.id ? t('activity.mention.working') : t('activity.mention.acknowledge')}
                         </button>
                       )}
-                      <button type="button" className="v2-activity__queue-action--thread" onClick={() => openPod(item.podId)} disabled={!item.podId}>
-                        {t('activity.openThread')}
-                      </button>
+                      {(item.kind === 'press' || item.kind === 'decision') ? (
+                        <button type="button" onClick={() => openTaskBoard(item)} disabled={!item.podId}>
+                          {t('activity.openBoard')}
+                        </button>
+                      ) : (
+                        <button type="button" className="v2-activity__queue-action--thread" onClick={() => openPod(item.podId)} disabled={!item.podId}>
+                          {t('activity.openThread')}
+                        </button>
+                      )}
                     </div>
                   </article>
                 ))}

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -7551,6 +7551,20 @@ body.modern-ui.v2-canvas {
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
 }
 
+.v2-activity__scope {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+}
+
+.v2-activity__scope-label {
+  color: var(--v2-text-muted);
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
 .v2-activity__scope select {
   min-height: 36px;
   max-width: 180px;
@@ -7663,6 +7677,16 @@ body.modern-ui.v2-canvas {
 .v2-activity__queue-row--approval .v2-activity__queue-mark {
   background: var(--v2-warning-soft);
   color: #a85d08;
+}
+
+.v2-activity__queue-row--press .v2-activity__queue-mark {
+  background: var(--v2-warning-soft);
+  color: #a85d08;
+}
+
+.v2-activity__queue-row--decision .v2-activity__queue-mark {
+  background: var(--v2-danger-soft);
+  color: #b42318;
 }
 
 .v2-activity__queue-row--onboarding .v2-activity__queue-mark {
@@ -7916,12 +7940,23 @@ body.modern-ui.v2-canvas {
 
   .v2-activity__controls {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 110px;
+    /* The shell rail leaves the content pane narrow at 390px. 120px still
+       fits “Active pods”, while leaving each window button enough room to
+       keep “7 days” on one line. */
+    grid-template-columns: minmax(0, 1fr) minmax(0, 120px);
     width: 100%;
   }
   .v2-activity__window { width: 100%; }
   .v2-root button.v2-activity__window-button { flex: 1 1 0; }
-  .v2-activity__scope select { width: 100%; max-width: none; }
+  .v2-activity__scope { width: 100%; }
+  .v2-activity__scope-label { display: none; }
+  .v2-activity__scope select {
+    width: 100%;
+    max-width: none;
+    /* A native select reserves its own arrow space. Tighten only on phones
+       so the complete “Active pods” label remains visible beside the rail. */
+    padding: 0 22px 0 8px;
+  }
   .v2-activity__section-heading > p { text-align: left; }
   .v2-activity__agent-grid { grid-template-columns: minmax(0, 1fr); }
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -7684,9 +7684,14 @@ body.modern-ui.v2-canvas {
   color: #a85d08;
 }
 
-.v2-activity__queue-row--decision .v2-activity__queue-mark {
+.v2-activity__queue-row--decide .v2-activity__queue-mark {
   background: var(--v2-danger-soft);
   color: #b42318;
+}
+
+.v2-activity__queue-row--handoff .v2-activity__queue-mark {
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-secondary);
 }
 
 .v2-activity__queue-row--onboarding .v2-activity__queue-mark {
@@ -7736,6 +7741,7 @@ body.modern-ui.v2-canvas {
 
 .v2-activity__queue-actions,
 .v2-activity__queue-row button,
+.v2-activity__queue-row .v2-activity__queue-action,
 .v2-activity__board-meta button {
   display: flex;
   align-items: center;
@@ -7743,6 +7749,7 @@ body.modern-ui.v2-canvas {
 }
 
 .v2-activity__queue-row button,
+.v2-activity__queue-row .v2-activity__queue-action,
 .v2-activity__board-meta button {
   min-height: 32px;
   padding: 0 10px;
@@ -7760,7 +7767,20 @@ body.modern-ui.v2-canvas {
   transition: background 80ms ease, border-color 80ms ease, color 80ms ease;
 }
 
+.v2-root .v2-activity__queue-actions .v2-activity__queue-action {
+  border-color: var(--v2-accent);
+  background: var(--v2-accent);
+  color: var(--v2-surface);
+  text-decoration: none;
+  transition: background 80ms ease, border-color 80ms ease, color 80ms ease;
+}
+
 .v2-root .v2-activity__queue-actions button:hover:not(:disabled) {
+  border-color: var(--v2-accent-strong);
+  background: var(--v2-accent-strong);
+}
+
+.v2-root .v2-activity__queue-actions .v2-activity__queue-action:hover {
   border-color: var(--v2-accent-strong);
   background: var(--v2-accent-strong);
 }


### PR DESCRIPTION
Fixes TASK-083.

- Default scope is **Active pods**: every accessible pod with at least one substantive non-system agent message in the selected window. The recap returns each pod's `activeInWindow` and `agentMessageCount`; the native selector groups active and other pods, with explicit All pods.
- Needs you projects durable board facts as distinct press (gated PR, Open PR), decide (DECIDE, Open row), and handoff (human press, Open row) rows ahead of incidental mentions.
- The agent recap excludes common system senders and ranks real agent cards by message count, then recency.

Proof:
- `backend: npm test -- --runInBand __tests__/unit/models/PgMessage.test.js __tests__/unit/services/activityService.recap.test.js` — 19 passed
- backend typecheck; frontend `V2ActivityPage` + layout-invariant suites — 61 passed; frontend typecheck and production build passed
- The required real-account 1280px/390px captures with the native selector open are pending a deployable authenticated surface. Prior fixture captures are intentionally not offered as gate evidence.

Known baseline: repo-wide lint remains pre-existingly red (missing CLI eslint plus unrelated parser/import/i18n errors); changed files' focused behavior and build checks are green.