### PR TITLE
feat(telegram): command surface — /mode /status /mute /tldr /help

### DIFF
--- a/backend/__tests__/unit/routes/telegram.webhook.test.js
+++ b/backend/__tests__/unit/routes/telegram.webhook.test.js
@@ -205,3 +205,63 @@ describe('Telegram webhook routes', () => {
     });
   });
 });
+
+describe('bridge command surface (/mode /status /mute /help)', () => {
+  const linked = () => ({
+    _id: 'integration-1',
+    podId: 'pod-1',
+    type: 'telegram',
+    config: { chatId: '42', chatType: 'private', liveRelay: true, relayAllAgentMessages: true },
+  });
+
+  const post = (text) => request(app)
+    .post('/api/webhooks/telegram')
+    .send({ message: { text, message_id: 900, chat: { id: 42, type: 'private' }, from: { id: 7, first_name: 'Sam' } } });
+
+  beforeEach(() => {
+    Integration.findOne = jest.fn().mockResolvedValue(linked());
+    Integration.findByIdAndUpdate = jest.fn().mockResolvedValue({});
+  });
+
+  it('/mode with no arg reports the current mode without writing', async () => {
+    const res = await post('/mode');
+    expect(res.status).toBe(200);
+    expect(Integration.findByIdAndUpdate).not.toHaveBeenCalled();
+    expect(telegramService.sendMessage).toHaveBeenCalledWith(
+      'bot-token', '42', expect.stringContaining('mirror'),
+    );
+  });
+
+  it('/mode attention writes relayAllAgentMessages=false', async () => {
+    const res = await post('/mode attention');
+    expect(res.status).toBe(200);
+    expect(Integration.findByIdAndUpdate).toHaveBeenCalledWith(
+      'integration-1',
+      { $set: { 'config.relayAllAgentMessages': false } },
+    );
+  });
+
+  it('/mute writes a future relayMutedUntil and caps at 24h', async () => {
+    const res = await post('/mute 99999');
+    expect(res.status).toBe(200);
+    const [, update] = Integration.findByIdAndUpdate.mock.calls[0];
+    const until = new Date(update.$set['config.relayMutedUntil']).getTime();
+    expect(until).toBeLessThanOrEqual(Date.now() + 24 * 60 * 60_000 + 5000);
+    expect(until).toBeGreaterThan(Date.now());
+  });
+
+  it('/help answers without an integration lookup dependency', async () => {
+    Integration.findOne = jest.fn().mockResolvedValue(null);
+    const res = await post('/help');
+    expect(res.status).toBe(200);
+    expect(telegramService.sendMessage).toHaveBeenCalledWith(
+      'bot-token', '42', expect.stringContaining('/mode'),
+    );
+  });
+
+  it('commands never fall through to the live relay', async () => {
+    const bridge = require('../../../services/telegramBridgeService');
+    await post('/status');
+    expect(bridge.relayTelegramMessageToPod).not.toHaveBeenCalled();
+  });
+});

--- a/backend/models/Integration.ts
+++ b/backend/models/Integration.ts
@@ -87,6 +87,7 @@ export interface IIntegration extends Document {
     linkedUserId?: string;
     leadAgentUsername?: string;
     relayAllAgentMessages?: boolean;
+    relayMutedUntil?: Date;
     relayMap?: {
       tgMessageId: string;
       agentUsername: string;
@@ -175,6 +176,7 @@ const IntegrationSchema = new Schema<IIntegration>(
       linkedUserId: String,
       leadAgentUsername: String,
       relayAllAgentMessages: { type: Boolean, default: false },
+      relayMutedUntil: Date,
       relayMap: [
         {
           tgMessageId: String,

--- a/backend/routes/webhooks/telegram.ts
+++ b/backend/routes/webhooks/telegram.ts
@@ -10,8 +10,17 @@ const telegramService = require('../../services/telegramService');
 const router = express.Router({ mergeParams: true });
 
 const ENABLE_COMMAND = '/commonly-enable';
+// Underscore alias: Telegram's registered-command menu forbids hyphens, so
+// the menu carries /commonly_enable while typed /commonly-enable keeps working.
+const ENABLE_COMMAND_ALIAS = '/commonly_enable';
 const SUMMARY_COMMAND = '/summary';
 const POD_SUMMARY_COMMAND = '/pod_summary';
+const TLDR_COMMAND = '/tldr';
+const MODE_COMMAND = '/mode';
+const STATUS_COMMAND = '/status';
+const MUTE_COMMAND = '/mute';
+const UNMUTE_COMMAND = '/unmute';
+const HELP_COMMAND = '/help';
 
 const normalizeCommand = (raw = '') => raw.split('@')[0].toLowerCase();
 
@@ -220,6 +229,84 @@ const handlePodSummaryCommand = async (chat: any, integration: any) => {
   );
 };
 
+const sendToChat = async (chatId: string, text: string) => {
+  const botToken = process.env.TELEGRAM_BOT_TOKEN;
+  if (!botToken || !chatId) return;
+  await telegramService.sendMessage(botToken, chatId, text);
+};
+
+const NOT_LINKED = 'This chat is not linked. Use /commonly-enable &lt;code&gt; first.';
+
+const HELP_TEXT = [
+  '<b>Commonly bridge commands</b>',
+  '/mode — show the relay mode; /mode mirror | attention to switch',
+  '  • <b>mirror</b>: every agent message in the pod is copied here',
+  '  • <b>attention</b>: only escalations and the lead agent reach you',
+  '/status — pod, mode, and mute state for this chat',
+  '/mute [minutes] — pause relay to this chat (default 60); /unmute to resume',
+  '/tldr — latest pod summary',
+  '/summary — summarize recent chat here into the pod',
+].join('\n');
+
+// /mode [mirror|attention] — the two relay modes are one stored flag:
+// mirror ⇔ config.relayAllAgentMessages. Attention mode leaves the
+// escalation gate (markers + lead agent) as the only path to the phone.
+const handleModeCommand = async (chat: any, integration: any, arg?: string) => {
+  const chatId = chat?.id?.toString();
+  if (!integration) return sendToChat(chatId, NOT_LINKED);
+  const current = integration.config?.relayAllAgentMessages === true ? 'mirror' : 'attention';
+  const wanted = (arg || '').toLowerCase();
+  if (!wanted) {
+    return sendToChat(chatId, `Relay mode: <b>${current}</b>. Switch with /mode mirror or /mode attention.`);
+  }
+  if (wanted !== 'mirror' && wanted !== 'attention') {
+    return sendToChat(chatId, 'Usage: /mode mirror | attention');
+  }
+  await Integration.findByIdAndUpdate(integration._id, {
+    $set: { 'config.relayAllAgentMessages': wanted === 'mirror' },
+  });
+  return sendToChat(chatId, wanted === 'mirror'
+    ? 'Mode: <b>mirror</b> — every agent message in the pod is copied here.'
+    : 'Mode: <b>attention</b> — only escalations and the lead agent reach you.');
+};
+
+const handleStatusCommand = async (chat: any, integration: any) => {
+  const chatId = chat?.id?.toString();
+  if (!integration) return sendToChat(chatId, NOT_LINKED);
+  const pod = await Pod.findById(integration.podId).lean();
+  const mode = integration.config?.relayAllAgentMessages === true ? 'mirror' : 'attention';
+  const mutedUntil = integration.config?.relayMutedUntil;
+  const muted = mutedUntil && new Date(mutedUntil) > new Date()
+    ? `muted until ${new Date(mutedUntil).toISOString().slice(11, 16)} UTC`
+    : 'not muted';
+  const lead = integration.config?.leadAgentUsername;
+  return sendToChat(chatId, [
+    `Pod: <b>${pod?.name || 'unknown'}</b>`,
+    `Mode: <b>${mode}</b> · Relay: ${integration.config?.liveRelay ? 'on' : 'off'} · ${muted}`,
+    lead ? `Lead agent: ${lead}` : null,
+  ].filter(Boolean).join('\n'));
+};
+
+const handleMuteCommand = async (chat: any, integration: any, arg?: string) => {
+  const chatId = chat?.id?.toString();
+  if (!integration) return sendToChat(chatId, NOT_LINKED);
+  const minutes = Math.min(Math.max(parseInt(arg || '60', 10) || 60, 1), 24 * 60);
+  const until = new Date(Date.now() + minutes * 60_000);
+  await Integration.findByIdAndUpdate(integration._id, {
+    $set: { 'config.relayMutedUntil': until },
+  });
+  return sendToChat(chatId, `Muted for ${minutes} min — nothing relays here until then. /unmute to resume.`);
+};
+
+const handleUnmuteCommand = async (chat: any, integration: any) => {
+  const chatId = chat?.id?.toString();
+  if (!integration) return sendToChat(chatId, NOT_LINKED);
+  await Integration.findByIdAndUpdate(integration._id, {
+    $unset: { 'config.relayMutedUntil': '' },
+  });
+  return sendToChat(chatId, 'Unmuted — relay resumes.');
+};
+
 // Universal Telegram webhook (single bot, many chats)
 router.post('/', async (req: any, res: any) => {
   try {
@@ -239,7 +326,7 @@ router.post('/', async (req: any, res: any) => {
     const [rawCommand, ...args] = text.split(/\s+/);
     const command = rawCommand?.startsWith('/') ? normalizeCommand(rawCommand) : null;
 
-    if (command === ENABLE_COMMAND) {
+    if (command === ENABLE_COMMAND || command === ENABLE_COMMAND_ALIAS) {
       await handleEnableCommand(chat, args[0]);
       return res.sendStatus(200);
     }
@@ -255,8 +342,33 @@ router.post('/', async (req: any, res: any) => {
       return res.sendStatus(200);
     }
 
-    if (command === POD_SUMMARY_COMMAND) {
+    if (command === POD_SUMMARY_COMMAND || command === TLDR_COMMAND) {
       await handlePodSummaryCommand(chat, integration);
+      return res.sendStatus(200);
+    }
+
+    if (command === MODE_COMMAND) {
+      await handleModeCommand(chat, integration, args[0]);
+      return res.sendStatus(200);
+    }
+
+    if (command === STATUS_COMMAND) {
+      await handleStatusCommand(chat, integration);
+      return res.sendStatus(200);
+    }
+
+    if (command === MUTE_COMMAND) {
+      await handleMuteCommand(chat, integration, args[0]);
+      return res.sendStatus(200);
+    }
+
+    if (command === UNMUTE_COMMAND) {
+      await handleUnmuteCommand(chat, integration);
+      return res.sendStatus(200);
+    }
+
+    if (command === HELP_COMMAND) {
+      await sendToChat(chatId, HELP_TEXT);
       return res.sendStatus(200);
     }
 

--- a/backend/services/telegramBridgeService.ts
+++ b/backend/services/telegramBridgeService.ts
@@ -130,6 +130,10 @@ export const relayAgentMessageToTelegram = async (opts: {
   try {
     const integration = await findLiveIntegration(podId);
     if (!integration) return;
+    // /mute pauses ALL outbound relay to the chat, escalations included —
+    // mute means mute; /status shows it, and it self-expires.
+    const mutedUntil = (integration.config as { relayMutedUntil?: Date | string })?.relayMutedUntil;
+    if (mutedUntil && new Date(mutedUntil) > new Date()) return;
     if (!shouldEscalate({ content, agentUsername, integration })) return;
 
     const botToken = process.env.TELEGRAM_BOT_TOKEN;


### PR DESCRIPTION
Sam's two-mode design made real: **mirror** (deep copy — every agent message relays) vs **attention** (only the escalation gate + lead agent reach the phone), switchable from the chat with /mode. Underneath it's the existing relayAllAgentMessages flag — no new mode machinery.

- /mode [mirror|attention] — show or switch
- /status — pod, mode, relay + mute state, lead agent
- /mute [min] (24h cap, self-expiring, schema-declared) + /unmute — mute gates ALL outbound relay incl. escalations
- /tldr — alias for pod_summary
- /help, /commonly_enable alias (registered menu forbids hyphens)

5 new route tests; mute gate in relayAgentMessageToTelegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pc6nGXRS8mHvrwcXMSRDK