### PR TITLE
fix(activity): gate both pod-scoped write routes on membership (#1300)

### DIFF
--- a/backend/__tests__/unit/routes/activity.write-membership.test.js
+++ b/backend/__tests__/unit/routes/activity.write-membership.test.js
@@ -16,9 +16,11 @@ const mockAuth = () => jest.doMock('../../../middleware/auth', () => (req, res, 
   next();
 });
 
-const mockPod = (pod) => jest.doMock('../../../models/Pod', () => ({
-  findById: jest.fn(() => ({ select: () => ({ lean: async () => pod }) })),
-}));
+const podFindById = jest.fn();
+const mockPod = (pod) => {
+  podFindById.mockImplementation(() => ({ select: () => ({ lean: async () => pod }) }));
+  jest.doMock('../../../models/Pod', () => ({ findById: podFindById }));
+};
 
 const buildApp = () => {
   const app = express();
@@ -29,6 +31,7 @@ const buildApp = () => {
 
 const setup = (pod) => {
   mockAuth();
+  podFindById.mockReset();
   mockPod(pod);
   const create = jest.fn(async () => ({
     _id: { toString: () => 'act-1' }, type: 'message', action: 'message', content: 'x', createdAt: new Date(),
@@ -52,25 +55,25 @@ describe('POST /api/activity/create — pod membership', () => {
   afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
 
   it('refuses a non-member and writes nothing', async () => {
-    const { app, create } = setup({ createdBy: OTHER, members: [OTHER] });
+    const { app, create } = setup({ _id: 'pod-1', createdBy: OTHER, members: [OTHER] });
     await request(app).post('/api/activity/create').send(body()).expect(403);
     expect(create).not.toHaveBeenCalled();
   });
 
   it('allows a member', async () => {
-    const { app, create } = setup({ createdBy: OTHER, members: [OTHER, CALLER] });
+    const { app, create } = setup({ _id: 'pod-1', createdBy: OTHER, members: [OTHER, CALLER] });
     await request(app).post('/api/activity/create').send(body()).expect(200);
     expect(create).toHaveBeenCalledTimes(1);
   });
 
   it('allows the creator, who is not always listed in members', async () => {
-    const { app, create } = setup({ createdBy: CALLER, members: [] });
+    const { app, create } = setup({ _id: 'pod-1', createdBy: CALLER, members: [] });
     await request(app).post('/api/activity/create').send(body()).expect(200);
     expect(create).toHaveBeenCalledTimes(1);
   });
 
   it('accepts a member listed as a populated subdocument', async () => {
-    const { app, create } = setup({ createdBy: OTHER, members: [{ _id: CALLER }] });
+    const { app, create } = setup({ _id: 'pod-1', createdBy: OTHER, members: [{ _id: CALLER }] });
     await request(app).post('/api/activity/create').send(body()).expect(200);
     expect(create).toHaveBeenCalledTimes(1);
   });
@@ -82,6 +85,34 @@ describe('POST /api/activity/create — pod membership', () => {
   });
 });
 
+describe('POST /api/activity/create — the body\'s podId is untrusted input', () => {
+  afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+  // `podId` arrives as `unknown`. A raw object reaching findById would be read
+  // as Mongo operators rather than as an id.
+  // Asserted on the ARGUMENT rather than the status: what the mocked findById
+  // returns for a malformed id is a property of the mock, but what the route
+  // hands it is the thing under test.
+  it('coerces the body podId to a string before it reaches a query', async () => {
+    const { app } = setup({ _id: 'pod-1', createdBy: CALLER, members: [CALLER] });
+    await request(app).post('/api/activity/create').send(body({ podId: { $ne: null } }));
+    expect(podFindById).toHaveBeenCalledTimes(1);
+    expect(typeof podFindById.mock.calls[0][0]).toBe('string');
+  });
+
+  it('passes the params podId to the seeder lookup as a string too', async () => {
+    const { app } = setup({ _id: 'pod-1', createdBy: CALLER, members: [CALLER] });
+    await request(app).post('/api/activity/seed/pod-1').send({}).expect(200);
+    expect(typeof podFindById.mock.calls[0][0]).toBe('string');
+  });
+
+  it('stores the resolved pod id, not the body\'s copy of it', async () => {
+    const { app, create } = setup({ _id: 'resolved-pod', createdBy: CALLER, members: [CALLER] });
+    await request(app).post('/api/activity/create').send(body()).expect(200);
+    expect(create.mock.calls[0][0].podId).toBe('resolved-pod');
+  });
+});
+
 describe('POST /api/activity/create — the approval_needed kind', () => {
   afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
 
@@ -89,14 +120,14 @@ describe('POST /api/activity/create — the approval_needed kind', () => {
   // because this is the generic client-facing create and the approval kind is
   // what fills an admin decision queue.
   it('refuses approval_needed even from a member', async () => {
-    const { app, create } = setup({ createdBy: CALLER, members: [CALLER] });
+    const { app, create } = setup({ _id: 'pod-1', createdBy: CALLER, members: [CALLER] });
     await request(app).post('/api/activity/create')
       .send(body({ type: 'approval_needed' })).expect(400);
     expect(create).not.toHaveBeenCalled();
   });
 
   it('positive control — the same member may create an ordinary kind', async () => {
-    const { app, create } = setup({ createdBy: CALLER, members: [CALLER] });
+    const { app, create } = setup({ _id: 'pod-1', createdBy: CALLER, members: [CALLER] });
     await request(app).post('/api/activity/create').send(body()).expect(200);
     expect(create).toHaveBeenCalledTimes(1);
   });
@@ -108,13 +139,13 @@ describe('POST /api/activity/seed/:podId — pod membership', () => {
   // The seeder is the DESIGNED producer of approval_needed rows, so an ungated
   // seed route is the same injection by another door.
   it('refuses a non-member and never reaches the seeder', async () => {
-    const { app, seedPodActivities } = setup({ createdBy: OTHER, members: [OTHER] });
+    const { app, seedPodActivities } = setup({ _id: 'pod-1', createdBy: OTHER, members: [OTHER] });
     await request(app).post('/api/activity/seed/pod-1').send({}).expect(403);
     expect(seedPodActivities).not.toHaveBeenCalled();
   });
 
   it('allows a member', async () => {
-    const { app, seedPodActivities } = setup({ createdBy: OTHER, members: [CALLER] });
+    const { app, seedPodActivities } = setup({ _id: 'pod-1', createdBy: OTHER, members: [CALLER] });
     await request(app).post('/api/activity/seed/pod-1').send({}).expect(200);
     expect(seedPodActivities).toHaveBeenCalledTimes(1);
   });

--- a/backend/__tests__/unit/routes/activity.write-membership.test.js
+++ b/backend/__tests__/unit/routes/activity.write-membership.test.js
@@ -1,0 +1,127 @@
+const request = require('supertest');
+const express = require('express');
+
+// Both write routes on /api/activity landed a row into an arbitrary pod for any
+// authenticated caller. `/create` mattered most because `type` comes straight
+// off the body and `Activity.approval.status` defaults to 'pending', so the row
+// materialises exactly the two fields `getPendingApprovals` filters on — i.e. it
+// arrives in that pod's ADMINS' decision queue with attacker-chosen content.
+// Every case below asserts the write did not happen, not just the status code.
+
+const CALLER = 'caller-1';
+const OTHER = 'someone-else';
+
+const mockAuth = () => jest.doMock('../../../middleware/auth', () => (req, res, next) => {
+  req.userId = CALLER;
+  next();
+});
+
+const mockPod = (pod) => jest.doMock('../../../models/Pod', () => ({
+  findById: jest.fn(() => ({ select: () => ({ lean: async () => pod }) })),
+}));
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/activity', require('../../../routes/activity'));
+  return app;
+};
+
+const setup = (pod) => {
+  mockAuth();
+  mockPod(pod);
+  const create = jest.fn(async () => ({
+    _id: { toString: () => 'act-1' }, type: 'message', action: 'message', content: 'x', createdAt: new Date(),
+  }));
+  jest.doMock('../../../models/Activity', () => ({ create }));
+  jest.doMock('../../../models/User', () => ({
+    findById: jest.fn(() => ({ select: () => ({ lean: async () => ({ username: 'someone' }) }) })),
+  }));
+  const seedPodActivities = jest.fn(async () => ({ success: true, count: 4 }));
+  jest.doMock('../../../services/activityService', () => ({
+    seedPodActivities, isAgentUsername: jest.fn(() => false),
+  }));
+  return { app: buildApp(), create, seedPodActivities };
+};
+
+const body = (over = {}) => ({
+  type: 'message', action: 'message', content: 'hi', podId: 'pod-1', ...over,
+});
+
+describe('POST /api/activity/create — pod membership', () => {
+  afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+  it('refuses a non-member and writes nothing', async () => {
+    const { app, create } = setup({ createdBy: OTHER, members: [OTHER] });
+    await request(app).post('/api/activity/create').send(body()).expect(403);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('allows a member', async () => {
+    const { app, create } = setup({ createdBy: OTHER, members: [OTHER, CALLER] });
+    await request(app).post('/api/activity/create').send(body()).expect(200);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows the creator, who is not always listed in members', async () => {
+    const { app, create } = setup({ createdBy: CALLER, members: [] });
+    await request(app).post('/api/activity/create').send(body()).expect(200);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a member listed as a populated subdocument', async () => {
+    const { app, create } = setup({ createdBy: OTHER, members: [{ _id: CALLER }] });
+    await request(app).post('/api/activity/create').send(body()).expect(200);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('404s an unknown pod rather than writing an orphan row', async () => {
+    const { app, create } = setup(null);
+    await request(app).post('/api/activity/create').send(body()).expect(404);
+    expect(create).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/activity/create — the approval_needed kind', () => {
+  afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+  // Independent of membership: a member of the pod still cannot mint one here,
+  // because this is the generic client-facing create and the approval kind is
+  // what fills an admin decision queue.
+  it('refuses approval_needed even from a member', async () => {
+    const { app, create } = setup({ createdBy: CALLER, members: [CALLER] });
+    await request(app).post('/api/activity/create')
+      .send(body({ type: 'approval_needed' })).expect(400);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('positive control — the same member may create an ordinary kind', async () => {
+    const { app, create } = setup({ createdBy: CALLER, members: [CALLER] });
+    await request(app).post('/api/activity/create').send(body()).expect(200);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('POST /api/activity/seed/:podId — pod membership', () => {
+  afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+  // The seeder is the DESIGNED producer of approval_needed rows, so an ungated
+  // seed route is the same injection by another door.
+  it('refuses a non-member and never reaches the seeder', async () => {
+    const { app, seedPodActivities } = setup({ createdBy: OTHER, members: [OTHER] });
+    await request(app).post('/api/activity/seed/pod-1').send({}).expect(403);
+    expect(seedPodActivities).not.toHaveBeenCalled();
+  });
+
+  it('allows a member', async () => {
+    const { app, seedPodActivities } = setup({ createdBy: OTHER, members: [CALLER] });
+    await request(app).post('/api/activity/seed/pod-1').send({}).expect(200);
+    expect(seedPodActivities).toHaveBeenCalledTimes(1);
+  });
+
+  it('404s an unknown pod', async () => {
+    const { app, seedPodActivities } = setup(null);
+    await request(app).post('/api/activity/seed/pod-1').send({}).expect(404);
+    expect(seedPodActivities).not.toHaveBeenCalled();
+  });
+});

--- a/backend/routes/activity.ts
+++ b/backend/routes/activity.ts
@@ -16,6 +16,10 @@ const User = require('../models/User');
 const ActivityService = require('../services/activityService');
 // eslint-disable-next-line global-require
 const getAuthenticatedUserId = require('../utils/getAuthenticatedUserId');
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
+// eslint-disable-next-line global-require
+const isPodMember = require('../utils/isPodMember');
 
 interface Req {
   query?: Record<string, string>;
@@ -209,6 +213,9 @@ router.post('/seed/:podId', auth, async (req: Req, res: Res) => {
   try {
     const { podId } = req.params || {};
     const userId = getAuthenticatedUserId(req);
+    const pod = await Pod.findById(podId).select('members createdBy').lean();
+    if (!pod) return res.status(404).json({ error: 'Pod not found' });
+    if (!isPodMember(pod, userId)) return res.status(403).json({ error: 'Only pod members can seed activities' });
     const result = await ActivityService.seedPodActivities(podId, userId) as { success?: boolean; error?: string };
     if (!result.success) return res.status(400).json({ error: result.error });
     return res.json(result);
@@ -223,6 +230,16 @@ router.post('/create', auth, async (req: Req, res: Res) => {
     const { type, action, content, podId, target, agentMetadata } = (req.body || {}) as Record<string, unknown>;
     const userId = getAuthenticatedUserId(req);
     if (!type || !action || !podId) return res.status(400).json({ error: 'type, action, and podId are required' });
+    // `approval_needed` is what `getPendingApprovals` selects into a pod's
+    // admins' decision queue. This is the generic client-facing create, so it
+    // must not be able to mint one: the caller supplies no `approval` subdoc
+    // and does not need to, because `Activity.approval.status` defaults to
+    // 'pending' and Mongoose materialises exactly the two fields that filter
+    // selects on.
+    if (type === 'approval_needed') return res.status(400).json({ error: 'approval_needed activities cannot be created through this route' });
+    const pod = await Pod.findById(podId).select('members createdBy').lean();
+    if (!pod) return res.status(404).json({ error: 'Pod not found' });
+    if (!isPodMember(pod, userId)) return res.status(403).json({ error: 'Only pod members can create activities in a pod' });
     const user = await User.findById(userId).select('username').lean() as { username?: string } | null;
     const activity = await Activity.create({ type, actor: { id: userId, name: user?.username || 'Unknown', type: ActivityService.isAgentUsername(user?.username) ? 'agent' : 'human', verified: false }, action, content, podId, target, agentMetadata });
     return res.json({ success: true, activity: { id: activity._id.toString(), type: activity.type, action: activity.action, content: activity.content, createdAt: activity.createdAt } });

--- a/backend/routes/activity.ts
+++ b/backend/routes/activity.ts
@@ -213,7 +213,7 @@ router.post('/seed/:podId', auth, async (req: Req, res: Res) => {
   try {
     const { podId } = req.params || {};
     const userId = getAuthenticatedUserId(req);
-    const pod = await Pod.findById(podId).select('members createdBy').lean();
+    const pod = await Pod.findById(String(podId)).select('members createdBy').lean();
     if (!pod) return res.status(404).json({ error: 'Pod not found' });
     if (!isPodMember(pod, userId)) return res.status(403).json({ error: 'Only pod members can seed activities' });
     const result = await ActivityService.seedPodActivities(podId, userId) as { success?: boolean; error?: string };
@@ -237,11 +237,16 @@ router.post('/create', auth, async (req: Req, res: Res) => {
     // 'pending' and Mongoose materialises exactly the two fields that filter
     // selects on.
     if (type === 'approval_needed') return res.status(400).json({ error: 'approval_needed activities cannot be created through this route' });
-    const pod = await Pod.findById(podId).select('members createdBy').lean();
+    // `podId` arrives as `unknown` off the body, so it is coerced before it
+    // reaches a query: a raw object would otherwise be interpreted as Mongo
+    // operators rather than an id.
+    const pod = await Pod.findById(String(podId)).select('members createdBy').lean();
     if (!pod) return res.status(404).json({ error: 'Pod not found' });
     if (!isPodMember(pod, userId)) return res.status(403).json({ error: 'Only pod members can create activities in a pod' });
     const user = await User.findById(userId).select('username').lean() as { username?: string } | null;
-    const activity = await Activity.create({ type, actor: { id: userId, name: user?.username || 'Unknown', type: ActivityService.isAgentUsername(user?.username) ? 'agent' : 'human', verified: false }, action, content, podId, target, agentMetadata });
+    // Store the id of the pod that was actually resolved and authorised, not
+    // the body's copy of it.
+    const activity = await Activity.create({ type, actor: { id: userId, name: user?.username || 'Unknown', type: ActivityService.isAgentUsername(user?.username) ? 'agent' : 'human', verified: false }, action, content, podId: pod._id, target, agentMetadata });
     return res.json({ success: true, activity: { id: activity._id.toString(), type: activity.type, action: activity.action, content: activity.content, createdAt: activity.createdAt } });
   } catch (error) {
     console.error('Error creating activity:', error);

--- a/backend/routes/podInvites.ts
+++ b/backend/routes/podInvites.ts
@@ -44,13 +44,8 @@ const inviteWriteRateLimit = rateLimit({
   handler: (_req: any, res: any) => res.status(429).json({ msg: 'rate limit exceeded: 20 invite writes per 60s' }),
 });
 
-const isPodMember = (pod: any, userId: string) => {
-  if (!pod || !userId) return false;
-  if (pod.createdBy?.toString?.() === userId.toString()) return true;
-  return (pod.members || []).some((m: any) => (
-    (m?._id?.toString?.() || m?.toString?.() || '') === userId.toString()
-  ));
-};
+// eslint-disable-next-line global-require
+const isPodMember = require('../utils/isPodMember');
 
 // POST /api/pods/:podId/invites — issue a fresh invite token. Caller must
 // be a member or creator. Body: { expiresInHours?, maxUses? } — both

--- a/backend/utils/isPodMember.ts
+++ b/backend/utils/isPodMember.ts
@@ -1,0 +1,18 @@
+// Membership predicate for pod-scoped WRITES. Deliberately strict: it does
+// not carry the admin bypass `DMService.canViewPod` has, because that bypass
+// exists for read observability and would make "only members can write here"
+// untrue for the one account most able to do damage by accident.
+//
+// The creator counts as a member — `Pod.members` does not always list them.
+const isPodMember = (pod: any, userId: unknown): boolean => {
+  if (!pod || !userId) return false;
+  const id = String(userId);
+  if (pod.createdBy?.toString?.() === id) return true;
+  return (pod.members || []).some((m: any) => (
+    (m?._id?.toString?.() || m?.toString?.() || '') === id
+  ));
+};
+
+module.exports = isPodMember;
+
+export {};


### PR DESCRIPTION
Closes #1300.

## What was open

`POST /api/activity/create` was `auth`-only — no membership check, no pod-existence check, with `type` and `podId` taken straight off the body.

It matters beyond an ordinary missing gate because **the caller does not need to know the approval schema exists.** `models/Activity.ts` declares `approval.status` with `default: 'pending'`, so Mongoose materialises exactly the two fields `Activity.getPendingApprovals` filters on. A body of `{ type: 'approval_needed', action, podId }` therefore lands in an arbitrary pod's **admins' decision queue** with attacker-controlled content, and the request never mentions `approval` at all.

`POST /api/activity/seed/:podId` is the same hole by another door, and it is the *designed* producer of `approval_needed` rows: it checked that the pod exists and the user exists, then wrote four rows into any pod for any authenticated caller.

## What this changes

Both routes resolve the pod and refuse a non-member (404 for an unknown pod, 403 for a non-member). `/create` additionally refuses `approval_needed` outright — it is the generic client-facing create, and the approval kind is what fills a decision queue.

The membership predicate moves to `backend/utils/isPodMember.ts` rather than being copied. `routes/podInvites.ts` already had this exact function and now imports it, so there is **one** definition of who may write into a pod. It deliberately omits the admin bypass `DMService.canViewPod` carries — that bypass exists for read observability, and it would make "only members can write here" untrue for the account most able to do damage by accident.

## Proof

Every case asserts the write **did not happen**, not just the status code — `Activity.create` / `seedPodActivities` are checked for non-invocation. 13 cases in `activity.write-membership.test.js`, including the creator-not-in-`members` case, a populated-subdocument member, a positive control that the same member may create an ordinary kind, and three cases pinning that both routes hand `Pod.findById` a string rather than the body's copy.

Mutation table, exclusion arm on every row (86 suites / 523 tests with my file removed):

| Mutation | red with my file | red without |
|---|---|---|
| `/create` membership check deleted | 1 | 0 |
| `approval_needed` guard deleted | 1 | 0 |
| `/seed` membership check deleted | 1 | 0 |
| `isPodMember` always returns true | 2 | 2 (`podInvites`' own) |

Nothing else in the repo catches any of the first three. The fourth is the check that the extraction did not weaken `podInvites`.

Re-run at `51f7a13c`: `Tests: 13 total` on each mutation run, so each one compiled. The earlier revision of this table was anchored at 10, before the three injection cases were added in `51f7a13c`; the four rows are unchanged in substance. Row 4's named reds are `refuses a non-member and writes nothing` + `refuses a non-member and never reaches the seeder` (mine) and `refuses to list invites for a non-member` + `refuses to revoke an invite for a non-member` (`podInvites`'). Backend typecheck is the usual ~50 pre-existing errors and none name these files; lint on the new test file is 3 errors of the known `import/no-unresolved` + `import/extensions` class every `.js` test importing a `.ts` module inherits (the sibling `activity.identity.test.js` carries 6).

## Not done here

The `approval_needed` kind now has no reachable producer outside the seeder, which is the finding ADR-017's fact-source section records (#1256) — this PR closes the injection, it does not build the real producer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

