### PR TITLE
feat(v2): Connectors page redesign — Wren spec rev 5 subset

### DIFF
--- a/frontend/design-system/tokens.css
+++ b/frontend/design-system/tokens.css
@@ -142,6 +142,25 @@
   --c-lh-tight:    1.25;
   --c-lh-base:     1.45;
   --c-lh-comfy:    1.55;
+  /* Platform brand + tint tokens (connectors) — mirror of --v2-platform-* in
+     src/v2/v2.css; the two move together. */
+  --c-platform-telegram: #2aabee;
+  --c-platform-telegram-soft: #e4f3fb;
+  --c-platform-slack: #611f69;
+  --c-platform-slack-soft: #f3e9f4;
+  --c-platform-discord: #5865f2;
+  --c-platform-discord-soft: #eaecfe;
+  --c-platform-whatsapp: #1fa855;
+  --c-platform-whatsapp-soft: #e5f6ec;
+  --c-platform-x: #111827;
+  --c-platform-x-soft: #eef0f3;
+  --c-platform-instagram: #d62976;
+  --c-platform-instagram-soft: #fbe9f1;
+  --c-platform-messenger: #0084ff;
+  --c-platform-messenger-soft: #e5f2ff;
+  --c-platform-groupme: #00aff0;
+  --c-platform-groupme-soft: #e3f5fd;
+
 }
 
 /* ============================================================

--- a/frontend/src/v2/__tests__/V2ConnectorsPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ConnectorsPage.test.tsx
@@ -1,7 +1,8 @@
 // @ts-nocheck
-// Connectors page: lists the user's channel bridges, surfaces the one-time
-// /commonly-enable code while pending, and toggles live relay via PATCH with
-// linkedUserId set to the toggler (the bridge's attribution identity).
+// Connectors page (Wren spec rev 5 subset): platform cards with dot-status,
+// grouped enable code + copy-command, add-flow tiles with an open-relay pod
+// guard, and the relay controls — liveRelay toggle plus the mirror/attention
+// segment. linkedUserId stays server-derived (never sent by the client).
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
@@ -81,17 +82,18 @@ const renderPage = () => render(
 describe('V2ConnectorsPage', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('lists connectors with pod, status, and the enable code while pending', async () => {
+  it('lists connectors with grouped code, copy command, and dot status', async () => {
     mockGets();
     renderPage();
-    // The pod name renders in the card AND as a picker option — assert on both.
     expect((await screen.findAllByText('Rewire Live Demo')).length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText(/\/commonly-enable abc123/)).toBeInTheDocument();
-    expect(screen.getByText('Connected')).toBeInTheDocument();
+    // Code renders grouped in 4s (spec §2.3) under a copy-command primary.
+    expect(screen.getByText('abc1 23')).toBeInTheDocument();
+    expect(screen.getByText('Copy command')).toBeInTheDocument();
+    expect(screen.getByText(/Connected · Relay off/)).toBeInTheDocument();
     expect(screen.getByText(/Rewire crew/)).toBeInTheDocument();
   });
 
-  it('toggling live relay PATCHes liveRelay only — linkedUserId is server-derived', async () => {
+  it('toggling relay PATCHes liveRelay only — linkedUserId is server-derived', async () => {
     mockGets();
     axios.patch.mockResolvedValue({ data: {} });
     renderPage();
@@ -99,17 +101,37 @@ describe('V2ConnectorsPage', () => {
     fireEvent.click(toggle);
     await waitFor(() => expect(axios.patch).toHaveBeenCalledWith(
       '/api/integrations/i-live',
-      // No linkedUserId: the server stamps the authenticated caller and
-      // rejects a client-supplied value (impersonation guard, #1290 review).
       { config: { liveRelay: true } },
       expect.anything(),
     ));
   });
 
-  it('excludes public pods from the bridge target picker', async () => {
+  it('mirror/attention segment PATCHes relayAllAgentMessages', async () => {
+    mockGets([
+      {
+        _id: 'i-live',
+        type: 'telegram',
+        status: 'connected',
+        config: { chatTitle: 'Rewire crew', liveRelay: true, relayAllAgentMessages: false },
+        podId: { _id: 'p2', name: 'Ops' },
+      },
+    ]);
+    axios.patch.mockResolvedValue({ data: {} });
+    renderPage();
+    const mirrorBtn = await screen.findByRole('button', { name: 'Mirror' });
+    fireEvent.click(mirrorBtn);
+    await waitFor(() => expect(axios.patch).toHaveBeenCalledWith(
+      '/api/integrations/i-live',
+      { config: { relayAllAgentMessages: true } },
+      expect.anything(),
+    ));
+  });
+
+  it('ghost empty state opens the add flow and excludes public pods', async () => {
     mockGets([]);
     renderPage();
-    await screen.findByText(/No connectors yet/);
+    await screen.findByText(/Link a channel/);
+    fireEvent.click(screen.getByRole('button', { name: /Telegram/ }));
     const picker = screen.getByLabelText('Pod to bridge');
     const options = Array.from(picker.querySelectorAll('option')).map((o) => o.textContent);
     expect(options).toContain('Rewire Live Demo');
@@ -120,12 +142,21 @@ describe('V2ConnectorsPage', () => {
     mockGets([]);
     axios.post.mockResolvedValue({ data: { integration: { _id: 'new' } } });
     renderPage();
-    await screen.findByText(/No connectors yet/);
+    await screen.findByText(/Link a channel/);
+    fireEvent.click(screen.getByRole('button', { name: /Telegram/ }));
     fireEvent.click(screen.getByText('New Telegram connector'));
     await waitFor(() => expect(axios.post).toHaveBeenCalledWith(
       '/api/integrations',
       { podId: 'p1', type: 'telegram', config: {} },
       expect.anything(),
     ));
+  });
+
+  it('SOON platforms are not buttons', async () => {
+    mockGets([]);
+    renderPage();
+    await screen.findByText(/Link a channel/);
+    expect(screen.queryByRole('button', { name: /Slack/ })).toBeNull();
+    expect(screen.getAllByText('SOON').length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -714,4 +714,16 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2.slice(floorStart, v2.indexOf('}', floorStart))).toContain('font-size: 12px');
   });
 
+  // Connectors v2 (Wren spec §5): platform tint tokens must exist in BOTH
+  // token files (the same-PR rule), and the tile class must consume them.
+  it('platform tint tokens exist in v2.css and tokens.css together', () => {
+    const ds = fs.readFileSync(path.join(__dirname, '../../../design-system/tokens.css'), 'utf8');
+    for (const pf of ['telegram', 'slack', 'discord', 'whatsapp']) {
+      expect(v2).toContain(`--v2-platform-${pf}-soft`);
+      expect(ds).toContain(`--c-platform-${pf}-soft`);
+    }
+    expect(v2).toContain('.v2-connector__tile--telegram');
+    expect(v2).toContain('var(--v2-platform-telegram-soft)');
+  });
+
 });

--- a/frontend/src/v2/components/V2ConnectorsPage.tsx
+++ b/frontend/src/v2/components/V2ConnectorsPage.tsx
@@ -1,31 +1,31 @@
-// Connectors — the v2 surface for channel bridges (Telegram today; Slack and
-// Discord rows render read-only from the same catalog when they exist).
-//
-// The page is pure wiring over routes that already exist:
-//   GET  /api/integrations/user/all   — my integrations, pod populated
-//   POST /api/integrations            — telegram create auto-mints connectCode
-//   PATCH /api/integrations/:id       — config merge (liveRelay persists since
-//                                       the Integration schema declared it)
-//
-// Live relay is the demoed "channel = attention surface" mode: inbound chat
-// messages post into the pod as the linked user and wake mentioned agents;
-// outbound agent messages cross back only through the escalation gate.
+// Connectors — channel bridges, per Wren's connectors-v2 design spec rev 5
+// (Connectors v2 pod, 2026-08-26). This ships the spec subset the deployed
+// kernel supports today: platform tiles + tint tokens, dot-status with last
+// activity, the relay-mode control (attention | mirror — the live
+// relayAllAgentMessages flag), copy-command code treatment, SOON tiles, the
+// ghost empty state, manage/disconnect, and 3s polling while a code is
+// pending. The Commander card and per-pod gates (spec §2.0/§2.2) land with
+// their kernel slices — per the spec's honesty rule, the page never renders a
+// control the server does not enforce.
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useV2Api } from '../hooks/useV2Api';
 import { V2Pod } from '../hooks/useV2Pods';
+import { PlatformGlyph } from '../icons/platforms';
 
 interface ConnectorConfig {
   chatTitle?: string;
   connectCode?: string;
   liveRelay?: boolean;
+  relayAllAgentMessages?: boolean;
 }
 
 interface Connector {
   _id: string;
   type: string;
   status: string;
+  updatedAt?: string;
   config?: ConnectorConfig;
   podId?: { _id: string; name?: string } | string | null;
 }
@@ -41,11 +41,26 @@ const TYPE_LABELS: Record<string, string> = {
   instagram: 'Instagram',
 };
 
+// Spec §2.3 — only Telegram is self-serve today; the rest render as SOON
+// tiles (45% opacity, not buttons — no dead clicks).
+const ADD_PLATFORMS: { type: string; enabled: boolean }[] = [
+  { type: 'telegram', enabled: true },
+  { type: 'slack', enabled: false },
+  { type: 'discord', enabled: false },
+  { type: 'whatsapp', enabled: false },
+];
+
 const BOT_HANDLE = process.env.REACT_APP_TELEGRAM_BOT_HANDLE || '';
 
 const podName = (c: Connector): string => (
   typeof c.podId === 'object' && c.podId ? (c.podId.name || 'Untitled pod') : 'Untitled pod'
 );
+
+// Codes are 32 hex now (128-bit) — grouped in 4s, wrapping; legacy short
+// codes flow through the same grouping (spec §2.3 step 2).
+const groupCode = (code: string): string => (code.match(/.{1,4}/g) || [code]).join(' ');
+
+const RECENT_MS = 10 * 60_000;
 
 const V2ConnectorsPage: React.FC = () => {
   const { t } = useTranslation();
@@ -53,15 +68,21 @@ const V2ConnectorsPage: React.FC = () => {
   const [connectors, setConnectors] = useState<Connector[]>([]);
   const [pods, setPods] = useState<V2Pod[]>([]);
   const [newPodId, setNewPodId] = useState('');
+  const [adding, setAdding] = useState(false);
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
+  const [manageId, setManageId] = useState<string | null>(null);
+  const [confirmDisconnect, setConfirmDisconnect] = useState<string | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const load = useCallback(async () => {
     try {
       const data = await api.get<Connector[]>('/api/integrations/user/all');
       setConnectors(Array.isArray(data) ? data : []);
+      setError(null);
     } catch {
       setError(t('connectors.loadError', { defaultValue: 'Could not load connectors.' }));
     } finally {
@@ -71,13 +92,25 @@ const V2ConnectorsPage: React.FC = () => {
 
   useEffect(() => { load(); }, [load]);
 
+  // Spec §2.3 step 3: poll while any code is pending; stop when it connects.
+  const hasPending = connectors.some((c) => c.status !== 'connected' && c.config?.connectCode);
+  useEffect(() => {
+    if (hasPending && !pollRef.current) {
+      pollRef.current = setInterval(load, 3000);
+    }
+    if (!hasPending && pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    return () => { if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; } };
+  }, [hasPending, load]);
+
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
         const data = await api.get<V2Pod[]>('/api/pods');
-        // Same guard as the BYO picker: never offer public/community pods as a
-        // bridge target — a channel bridge into a public room is an open relay.
+        // Open-relay guard: never offer public/community pods as bridge targets.
         const eligible = (Array.isArray(data) ? data : []).filter(
           (p) => !['community', 'showcase'].includes((p as { type?: string }).type || ''),
         );
@@ -85,7 +118,7 @@ const V2ConnectorsPage: React.FC = () => {
           setPods(eligible);
           setNewPodId((prev) => prev || eligible[0]?._id || '');
         }
-      } catch { /* pod picker just stays empty */ }
+      } catch { /* picker stays empty */ }
     })();
     return () => { cancelled = true; };
   }, [api]);
@@ -96,6 +129,7 @@ const V2ConnectorsPage: React.FC = () => {
     setError(null);
     try {
       await api.post('/api/integrations', { podId: newPodId, type: 'telegram', config: {} });
+      setAdding(false);
       await load();
     } catch {
       setError(t('connectors.createError', { defaultValue: 'Could not create the connector.' }));
@@ -104,104 +138,232 @@ const V2ConnectorsPage: React.FC = () => {
     }
   };
 
-  const toggleLiveRelay = async (c: Connector) => {
+  const patchConfig = async (c: Connector, config: Record<string, unknown>, errKey: string, errDefault: string) => {
     if (busyId) return;
     setBusyId(c._id);
     setError(null);
-    const next = !c.config?.liveRelay;
     try {
-      // linkedUserId is deliberately NOT sent: the server derives the bridge's
-      // attribution identity from the authenticated caller when liveRelay flips
-      // on, and rejects any client-supplied value (impersonation guard).
-      await api.patch(`/api/integrations/${c._id}`, {
-        config: { liveRelay: next },
-      });
+      await api.patch(`/api/integrations/${c._id}`, { config });
       await load();
     } catch {
-      setError(t('connectors.toggleError', { defaultValue: 'Could not update live relay.' }));
+      setError(t(errKey, { defaultValue: errDefault }));
     } finally {
       setBusyId(null);
     }
   };
 
-  return (
-    <div className="v2-connectors">
-      <section className="v2-connectors__list" aria-label="Your connectors">
-        {loading && (
-          <div className="v2-connectors__empty">{t('connectors.loading', { defaultValue: 'Loading connectors…' })}</div>
-        )}
-        {!loading && connectors.length === 0 && (
-          <div className="v2-connectors__empty">
-            {t('connectors.empty', { defaultValue: 'No connectors yet. Link a channel below — your pod gets a voice where your team already talks.' })}
+  const disconnect = async (c: Connector) => {
+    setBusyId(c._id);
+    try {
+      await api.patch(`/api/integrations/${c._id}`, { isActive: false });
+      setConfirmDisconnect(null);
+      setManageId(null);
+      await load();
+    } catch {
+      setError(t('connectors.disconnectError', { defaultValue: 'Could not disconnect.' }));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const copyCommand = async (code: string) => {
+    const cmd = `/commonly-enable ${code}`;
+    try {
+      await navigator.clipboard.writeText(cmd);
+      setCopied(code);
+      setTimeout(() => setCopied(null), 2000);
+    } catch { /* clipboard unavailable — the code is selectable */ }
+  };
+
+  const statusLine = (c: Connector): { dot: string; pulse: boolean; text: string } => {
+    if (c.status === 'error') {
+      return { dot: 'danger', pulse: false, text: t('connectors.statusError', { defaultValue: 'Connection error — reconnect' }) };
+    }
+    if (c.status !== 'connected') {
+      return { dot: 'warning', pulse: false, text: t('connectors.pending', { defaultValue: 'Waiting for the channel' }) };
+    }
+    const recent = c.updatedAt && (Date.now() - new Date(c.updatedAt).getTime()) < RECENT_MS;
+    if (c.config?.liveRelay) {
+      return recent
+        ? { dot: 'success', pulse: true, text: t('connectors.statusLive', { defaultValue: 'Live · Active in the last few minutes' }) }
+        : { dot: 'success', pulse: false, text: t('connectors.statusIdle', { defaultValue: 'Live · Quiet lately' }) };
+    }
+    return { dot: 'success', pulse: false, text: t('connectors.statusConnected', { defaultValue: 'Connected · Relay off' }) };
+  };
+
+  const renderCard = (c: Connector) => {
+    const st = statusLine(c);
+    const isTelegram = c.type === 'telegram';
+    const connected = c.status === 'connected';
+    const mirror = c.config?.relayAllAgentMessages === true;
+    return (
+      <article key={c._id} className={`v2-connector v2-connector--${c.type}`}>
+        <div className="v2-connector__row">
+          <span className={`v2-connector__tile v2-connector__tile--${c.type}`} aria-hidden="true">
+            <PlatformGlyph type={c.type} />
+          </span>
+          <div className="v2-connector__body">
+            <div className="v2-connector__title">
+              <strong>{TYPE_LABELS[c.type] || c.type}</strong>
+              <span className="v2-connector__meta">{podName(c)}{c.config?.chatTitle ? ` · ${c.config.chatTitle}` : ''}</span>
+            </div>
+            <div className="v2-connector__status">
+              <span className={`v2-connector__dot v2-connector__dot--${st.dot}${st.pulse ? ' v2-connector__dot--pulse' : ''}`} />
+              {st.text}
+            </div>
           </div>
-        )}
-        {connectors.map((c) => (
-          <article key={c._id} className="v2-connectors__card">
-            <div className="v2-connectors__card-head">
-              <span className="v2-connectors__type">{TYPE_LABELS[c.type] || c.type}</span>
-              <span className={`v2-connectors__status v2-connectors__status--${c.status === 'connected' ? 'connected' : 'pending'}`}>
-                {c.status === 'connected'
-                  ? t('connectors.connected', { defaultValue: 'Connected' })
-                  : t('connectors.pending', { defaultValue: 'Waiting for the channel' })}
-              </span>
-            </div>
-            <div className="v2-connectors__meta">
-              <span>{podName(c)}</span>
-              {c.config?.chatTitle && <span className="v2-connectors__chat">↔ {c.config.chatTitle}</span>}
-            </div>
-            {c.status !== 'connected' && c.type === 'telegram' && c.config?.connectCode && (
-              <div className="v2-connectors__enable">
-                {t('connectors.enableHint', { defaultValue: 'Open a private chat with the Commonly bot' })}
-                {BOT_HANDLE ? ` (@${BOT_HANDLE.replace(/^@/, '')})` : ''}
-                {t('connectors.enableHintSend', { defaultValue: ' and send:' })}
-                <code>/commonly-enable {c.config.connectCode}</code>
+          {connected && isTelegram && (
+            <button
+              type="button"
+              className="v2-connector__manage"
+              onClick={() => { setManageId(manageId === c._id ? null : c._id); setConfirmDisconnect(null); }}
+            >
+              {t('connectors.manage', { defaultValue: 'Manage' })}
+            </button>
+          )}
+        </div>
+
+        {connected && isTelegram && (
+          <div className="v2-connector__controls">
+            <label className="v2-connector__relay">
+              <input
+                type="checkbox"
+                checked={Boolean(c.config?.liveRelay)}
+                disabled={busyId === c._id}
+                onChange={() => patchConfig(c, { liveRelay: !c.config?.liveRelay }, 'connectors.toggleError', 'Could not update live relay.')}
+              />
+              <span>{t('connectors.liveRelay', { defaultValue: 'Relay' })}</span>
+            </label>
+            {c.config?.liveRelay && (
+              <div className="v2-connector__mode" role="group" aria-label={t('connectors.mode', { defaultValue: 'Relay mode' })}>
+                <button
+                  type="button"
+                  className={`v2-connector__mode-opt${!mirror ? ' v2-connector__mode-opt--on' : ''}`}
+                  disabled={busyId === c._id || !mirror}
+                  onClick={() => patchConfig(c, { relayAllAgentMessages: false }, 'connectors.modeError', 'Could not switch mode.')}
+                >
+                  {t('connectors.modeAttention', { defaultValue: 'Attention' })}
+                </button>
+                <button
+                  type="button"
+                  className={`v2-connector__mode-opt${mirror ? ' v2-connector__mode-opt--on' : ''}`}
+                  disabled={busyId === c._id || mirror}
+                  onClick={() => patchConfig(c, { relayAllAgentMessages: true }, 'connectors.modeError', 'Could not switch mode.')}
+                >
+                  {t('connectors.modeMirror', { defaultValue: 'Mirror' })}
+                </button>
               </div>
             )}
-            {c.type === 'telegram' && c.status === 'connected' && (
-              <label className="v2-connectors__relay">
-                <input
-                  type="checkbox"
-                  checked={Boolean(c.config?.liveRelay)}
-                  disabled={busyId === c._id}
-                  onChange={() => toggleLiveRelay(c)}
-                />
-                <span>
-                  <strong>{t('connectors.liveRelay', { defaultValue: 'Live relay' })}</strong>
-                  {' — '}
-                  {t('connectors.liveRelayHint', { defaultValue: 'chat messages post into the pod and wake mentioned agents; agent escalations reach the channel.' })}
-                </span>
-              </label>
-            )}
-          </article>
-        ))}
-      </section>
+            <span className="v2-connector__mode-hint">
+              {c.config?.liveRelay
+                ? (mirror
+                  ? t('connectors.mirrorHint', { defaultValue: 'Every agent message reaches the channel.' })
+                  : t('connectors.attentionHint', { defaultValue: 'Only escalations and the lead agent reach the channel.' }))
+                : t('connectors.relayOffHint', { defaultValue: 'Messages stay in the pod.' })}
+            </span>
+          </div>
+        )}
 
-      <section className="v2-connectors__new" aria-label="Connect a channel">
-        <h2>{t('connectors.newTitle', { defaultValue: 'Connect a channel' })}</h2>
-        <div className="v2-connectors__new-row">
-          <select
-            className="v2-byo__input v2-connectors__select"
-            value={newPodId}
-            onChange={(e) => setNewPodId(e.target.value)}
-            aria-label={t('connectors.podPicker', { defaultValue: 'Pod to bridge' })}
-          >
-            {pods.map((p) => <option key={p._id} value={p._id}>{p.name}</option>)}
-          </select>
-          <button
-            type="button"
-            className="v2-connectors__create"
-            disabled={!newPodId || creating}
-            onClick={createTelegram}
-          >
-            {creating
-              ? t('connectors.creating', { defaultValue: 'Creating…' })
-              : t('connectors.createTelegram', { defaultValue: 'New Telegram connector' })}
-          </button>
+        {manageId === c._id && connected && (
+          <div className="v2-connector__manage-panel">
+            {confirmDisconnect === c._id ? (
+              <button type="button" className="v2-connector__danger" disabled={busyId === c._id} onClick={() => disconnect(c)}>
+                {t('connectors.disconnectConfirm', { defaultValue: 'Really disconnect — the channel goes quiet' })}
+              </button>
+            ) : (
+              <button type="button" className="v2-connector__danger" onClick={() => setConfirmDisconnect(c._id)}>
+                {t('connectors.disconnect', { defaultValue: 'Disconnect' })}
+              </button>
+            )}
+          </div>
+        )}
+
+        {!connected && isTelegram && c.config?.connectCode && (
+          <div className="v2-connector__code-step">
+            <div className="v2-connector__code-hint">
+              {t('connectors.enableHint', { defaultValue: 'Open a private chat with the Commonly bot' })}
+              {BOT_HANDLE ? ` (@${BOT_HANDLE.replace(/^@/, '')})` : ''}
+              {t('connectors.enableHintSend', { defaultValue: ' and send:' })}
+            </div>
+            <button type="button" className="v2-connector__copy" onClick={() => copyCommand(c.config?.connectCode || '')}>
+              {copied === c.config?.connectCode
+                ? t('connectors.copied', { defaultValue: 'Copied' })
+                : t('connectors.copyCommand', { defaultValue: 'Copy command' })}
+            </button>
+            <code className="v2-connector__code">{groupCode(c.config.connectCode)}</code>
+          </div>
+        )}
+      </article>
+    );
+  };
+
+  const addTiles = (
+    <div className="v2-connector-add__tiles">
+      {ADD_PLATFORMS.map((p) => (p.enabled ? (
+        <button key={p.type} type="button" className="v2-connector-add__tile" onClick={() => setAdding(true)}>
+          <span className={`v2-connector__tile v2-connector__tile--${p.type}`}><PlatformGlyph type={p.type} /></span>
+          <span>{TYPE_LABELS[p.type]}</span>
+        </button>
+      ) : (
+        <span key={p.type} className="v2-connector-add__tile v2-connector-add__tile--soon">
+          <span className={`v2-connector__tile v2-connector__tile--${p.type}`}><PlatformGlyph type={p.type} /></span>
+          <span>{TYPE_LABELS[p.type]}</span>
+          <span className="v2-connector-add__soon">SOON</span>
+        </span>
+      )))}
+    </div>
+  );
+
+  return (
+    <div className="v2-connectors">
+      {loading && <div className="v2-connectors__loading">{t('connectors.loading', { defaultValue: 'Loading connectors…' })}</div>}
+
+      {!loading && connectors.length > 0 && (
+        <section aria-label={t('connectors.channels', { defaultValue: 'Your channels' })}>
+          <h2 className="v2-connectors__section">{t('connectors.channels', { defaultValue: 'Your channels' })}</h2>
+          <div className="v2-connectors__list">{connectors.map(renderCard)}</div>
+        </section>
+      )}
+
+      {!loading && connectors.length === 0 && (
+        // Spec §2.4: the ghost card IS the add flow's pick state.
+        <div className="v2-connector v2-connector--ghost">
+          <p className="v2-connectors__empty-line">
+            {t('connectors.empty', { defaultValue: 'Link a channel — every pod you’re in gets a voice where you already talk.' })}
+          </p>
+          {addTiles}
         </div>
-        <p className="v2-connectors__foot">
-          {t('connectors.footnote', { defaultValue: 'You get a one-time code to send to the bot. More platforms are on the way.' })}
-        </p>
-      </section>
+      )}
+
+      {!loading && connectors.length > 0 && (
+        <section aria-label={t('connectors.add', { defaultValue: 'Add a channel' })}>
+          <h2 className="v2-connectors__section">{t('connectors.add', { defaultValue: 'Add a channel' })}</h2>
+          {addTiles}
+        </section>
+      )}
+
+      {adding && (
+        <div className="v2-connector v2-connector--add-form">
+          <div className="v2-connectors__new-row">
+            <select
+              className="v2-byo__input v2-connectors__select"
+              value={newPodId}
+              onChange={(e) => setNewPodId(e.target.value)}
+              aria-label={t('connectors.podPicker', { defaultValue: 'Pod to bridge' })}
+            >
+              {pods.map((p) => <option key={p._id} value={p._id}>{p.name}</option>)}
+            </select>
+            <button type="button" className="v2-connectors__create" disabled={!newPodId || creating} onClick={createTelegram}>
+              {creating
+                ? t('connectors.creating', { defaultValue: 'Creating…' })
+                : t('connectors.createTelegram', { defaultValue: 'New Telegram connector' })}
+            </button>
+          </div>
+          <p className="v2-connectors__foot">
+            {t('connectors.footnote', { defaultValue: 'You get a one-time code to send to the bot. More platforms are on the way.' })}
+          </p>
+        </div>
+      )}
 
       {error && <div className="v2-connectors__error" role="alert">{error}</div>}
     </div>

--- a/frontend/src/v2/icons/platforms/index.tsx
+++ b/frontend/src/v2/icons/platforms/index.tsx
@@ -1,0 +1,68 @@
+// Platform glyphs for connector tiles — single inline SVG per platform, no
+// CDN, no PNG (Wren's connectors-v2 spec §2.1). Drawn as simplified marks:
+// recognizable at 18px, one brand color via currentColor. Tile tint + brand
+// color come from the --v2-platform-* tokens added in the same PR.
+import React from 'react';
+
+const S = ({ children }: { children: React.ReactNode }) => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    {children}
+  </svg>
+);
+
+const Telegram = () => (
+  <S><path d="M21.9 4.1c.3-1.1-.8-2-1.9-1.6L2.7 9.2c-1.2.5-1.1 2.2.1 2.5l4.4 1.2 1.7 5.4c.3 1 1.6 1.3 2.3.5l2.4-2.5 4.5 3.3c.9.7 2.2.2 2.4-.9l3.4-14.6zM9.4 13.6l8.7-6.5c.3-.2.6.2.4.4l-7 6.9-.3 3-1.8-3.8z" /></S>
+);
+
+const Slack = () => (
+  <S>
+    <rect x="9.5" y="2" width="4" height="9" rx="2" transform="rotate(90 11.5 6.5)" />
+    <rect x="13" y="9.5" width="9" height="4" rx="2" transform="rotate(90 17.5 11.5)" />
+    <rect x="2" y="13" width="9" height="4" rx="2" />
+    <rect x="10.5" y="13" width="4" height="9" rx="2" />
+  </S>
+);
+
+const Discord = () => (
+  <S><path d="M19.3 5.3A16.9 16.9 0 0 0 15.1 4l-.5 1a15.5 15.5 0 0 0-5.2 0L8.9 4a16.9 16.9 0 0 0-4.2 1.3C2 9.4 1.3 13.4 1.6 17.3A17 17 0 0 0 6.8 20l1.1-1.8a11 11 0 0 1-1.7-.8l.4-.3a12.2 12.2 0 0 0 10.8 0l.4.3c-.5.3-1.1.6-1.7.8L17.2 20a17 17 0 0 0 5.2-2.7c.4-4.5-.6-8.4-3.1-12zM8.7 14.9c-1 0-1.9-1-1.9-2.1s.8-2.1 1.9-2.1 1.9 1 1.9 2.1-.9 2.1-1.9 2.1zm6.6 0c-1 0-1.9-1-1.9-2.1s.8-2.1 1.9-2.1 1.9 1 1.9 2.1-.8 2.1-1.9 2.1z" /></S>
+);
+
+const WhatsApp = () => (
+  <S><path d="M12 2a10 10 0 0 0-8.6 15L2 22l5.2-1.4A10 10 0 1 0 12 2zm0 18.2c-1.5 0-3-.4-4.2-1.1l-.3-.2-3.1.8.8-3-.2-.3A8.2 8.2 0 1 1 12 20.2zm4.5-6.1c-.2-.1-1.5-.7-1.7-.8-.2-.1-.4-.1-.6.1l-.8 1c-.1.2-.3.2-.5.1a6.7 6.7 0 0 1-3.3-2.9c-.3-.4 0-.5.2-.8l.4-.5c.1-.2.1-.4 0-.5l-.8-1.9c-.2-.5-.4-.4-.6-.4h-.5c-.2 0-.5.1-.7.3-.9.9-1.2 2.2-.2 3.9a12 12 0 0 0 4.6 4.3c1.8.8 2.5.9 3.4.7.5-.1 1.5-.6 1.7-1.2.2-.6.2-1.1.1-1.2l-.7-.2z" /></S>
+);
+
+const XPlatform = () => (
+  <S><path d="M17.8 3h3l-6.7 7.7L22 21h-6.2l-4.8-6.3L5.4 21h-3l7.2-8.2L2 3h6.3l4.4 5.8L17.8 3zm-1.1 16h1.7L7.2 4.7H5.4L16.7 19z" /></S>
+);
+
+const Instagram = () => (
+  <S>
+    <path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5zm0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3H7z" />
+    <path d="M12 7.5a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9zm0 2a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5z" />
+    <circle cx="17.3" cy="6.7" r="1.2" />
+  </S>
+);
+
+const Messenger = () => (
+  <S><path d="M12 2C6.5 2 2 6.1 2 11.2c0 2.9 1.4 5.5 3.7 7.2V22l3.4-1.9c.9.3 1.9.4 2.9.4 5.5 0 10-4.1 10-9.2S17.5 2 12 2zm1.1 12.4-2.6-2.7-5 2.7 5.5-5.8 2.6 2.7 4.9-2.7-5.4 5.8z" /></S>
+);
+
+const GroupMe = () => (
+  <S><path d="M5 3h14a3 3 0 0 1 3 3v9a3 3 0 0 1-3 3h-6.6L8 21.8V18H5a3 3 0 0 1-3-3V6a3 3 0 0 1 3-3zm4.3 4.5-.4 1.8H7l-.3 1.6h1.8l-.4 1.9H6.3L6 14.4h1.8l-.4 1.8h1.7l.4-1.8h1.9l-.4 1.8h1.7l.4-1.8h1.9l.3-1.6H14l.4-1.9h1.8l.3-1.6h-1.8l.4-1.8h-1.7l-.4 1.8h-1.9l.4-1.8H9.3zm1.4 3.4h1.9l-.4 1.9h-1.9l.4-1.9z" /></S>
+);
+
+export const PLATFORM_GLYPHS: Record<string, React.FC> = {
+  telegram: Telegram,
+  slack: Slack,
+  discord: Discord,
+  whatsapp: WhatsApp,
+  x: XPlatform,
+  instagram: Instagram,
+  messenger: Messenger,
+  groupme: GroupMe,
+};
+
+export const PlatformGlyph: React.FC<{ type: string }> = ({ type }) => {
+  const G = PLATFORM_GLYPHS[type];
+  return G ? <G /> : <S><circle cx="12" cy="12" r="9" /></S>;
+};

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -39,6 +39,25 @@ body.modern-ui.v2-canvas {
   --v2-accent-deep: #14306f;
   --v2-focus-ring: 0 0 0 3px rgba(47, 111, 235, 0.18);
 
+  /* Platform brand + tint tokens (connectors) — mirror of --c-platform-* in
+     design-system/tokens.css; the two move together. */
+  --v2-platform-telegram: #2aabee;
+  --v2-platform-telegram-soft: #e4f3fb;
+  --v2-platform-slack: #611f69;
+  --v2-platform-slack-soft: #f3e9f4;
+  --v2-platform-discord: #5865f2;
+  --v2-platform-discord-soft: #eaecfe;
+  --v2-platform-whatsapp: #1fa855;
+  --v2-platform-whatsapp-soft: #e5f6ec;
+  --v2-platform-x: #111827;
+  --v2-platform-x-soft: #eef0f3;
+  --v2-platform-instagram: #d62976;
+  --v2-platform-instagram-soft: #fbe9f1;
+  --v2-platform-messenger: #0084ff;
+  --v2-platform-messenger-soft: #e5f2ff;
+  --v2-platform-groupme: #00aff0;
+  --v2-platform-groupme-soft: #e3f5fd;
+
   --v2-success: #10b981;
   --v2-success-soft: #e3f6ec;
   --v2-success-ring: rgba(16, 185, 129, 0.40);
@@ -8033,78 +8052,199 @@ body.modern-ui.v2-canvas {
 }
 
 /* ── Connectors ─────────────────────────────────────────────────────────── */
-/* Channel bridges (Telegram live relay et al). Cards follow the system:
-   1px border, no shadow, tokens only. */
+/* Channel bridges — Wren's connectors-v2 spec rev 5. Tokens only, 1px
+   borders, no shadows. Platform brand + tint tokens live on .v2-root below
+   and mirror design-system/tokens.css (same-PR rule). */
 .v2-connectors {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 24px;
   max-width: 720px;
 }
-.v2-connectors__list { display: flex; flex-direction: column; gap: 12px; }
-.v2-connectors__empty {
-  border: 1px dashed var(--v2-border-strong);
-  border-radius: var(--v2-radius);
-  padding: 20px;
-  color: var(--v2-text-tertiary);
-  font-size: 14px;
+.v2-connectors__section {
+  font-size: 13px;
+  font-weight: 650;
+  color: var(--v2-text-secondary);
+  margin: 0 0 10px;
 }
-.v2-connectors__card {
+.v2-connectors__loading { color: var(--v2-text-tertiary); font-size: 14px; }
+.v2-connectors__list { display: flex; flex-direction: column; gap: 12px; }
+
+.v2-connector {
   border: 1px solid var(--v2-border);
-  border-radius: var(--v2-radius);
+  border-radius: var(--v2-radius-lg);
   background: var(--v2-surface);
   padding: 14px 16px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-}
-.v2-connectors__card-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-.v2-connectors__type { font-weight: 650; color: var(--v2-text-primary); font-size: 14px; }
-.v2-connectors__status {
-  font-size: 12px;
-  border-radius: var(--v2-radius-pill);
-  padding: 2px 10px;
-  white-space: nowrap;
-}
-.v2-connectors__status--connected { background: var(--v2-success-soft); color: var(--v2-success); }
-.v2-connectors__status--pending { background: var(--v2-warning-soft); color: var(--v2-warning); }
-.v2-connectors__meta {
-  display: flex;
   gap: 10px;
-  color: var(--v2-text-secondary);
-  font-size: 13px;
-  flex-wrap: wrap;
 }
-.v2-connectors__chat { color: var(--v2-text-tertiary); }
-.v2-connectors__enable {
-  font-size: 13px;
-  color: var(--v2-text-secondary);
-  background: var(--v2-bg-subtle);
-  border: 1px solid var(--v2-border-soft);
+.v2-connector--ghost {
+  border: 1px solid var(--v2-border-strong);
+  background: transparent;
+  gap: 14px;
+}
+.v2-connectors__empty-line { margin: 0; color: var(--v2-text-secondary); font-size: 14px; }
+
+.v2-connector__row { display: flex; align-items: center; gap: 12px; }
+.v2-connector__tile {
+  width: 34px;
+  height: 34px;
   border-radius: var(--v2-radius-sm);
-  padding: 10px 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
 }
-.v2-connectors__enable code {
-  display: block;
-  margin-top: 6px;
-  font-family: var(--v2-font-mono);
-  font-size: 13px;
-  color: var(--v2-text-primary);
-  user-select: all;
-}
-.v2-connectors__relay {
+.v2-connector__tile--telegram { background: var(--v2-platform-telegram-soft); color: var(--v2-platform-telegram); }
+.v2-connector__tile--slack { background: var(--v2-platform-slack-soft); color: var(--v2-platform-slack); }
+.v2-connector__tile--discord { background: var(--v2-platform-discord-soft); color: var(--v2-platform-discord); }
+.v2-connector__tile--whatsapp { background: var(--v2-platform-whatsapp-soft); color: var(--v2-platform-whatsapp); }
+.v2-connector__tile--x { background: var(--v2-platform-x-soft); color: var(--v2-platform-x); }
+.v2-connector__tile--instagram { background: var(--v2-platform-instagram-soft); color: var(--v2-platform-instagram); }
+.v2-connector__tile--messenger { background: var(--v2-platform-messenger-soft); color: var(--v2-platform-messenger); }
+.v2-connector__tile--groupme { background: var(--v2-platform-groupme-soft); color: var(--v2-platform-groupme); }
+
+.v2-connector__body { min-width: 0; flex: 1; }
+.v2-connector__title { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.v2-connector__title strong { font-size: 14px; font-weight: 650; color: var(--v2-text-primary); }
+.v2-connector__meta { font-size: 13px; color: var(--v2-text-tertiary); }
+.v2-connector__status {
   display: flex;
-  gap: 10px;
-  align-items: flex-start;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  color: var(--v2-text-secondary);
+  margin-top: 3px;
+}
+.v2-connector__dot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+.v2-connector__dot--success { background: var(--v2-success); }
+.v2-connector__dot--warning { background: var(--v2-warning); }
+.v2-connector__dot--danger { background: var(--v2-danger); }
+.v2-connector__dot--pulse { animation: v2-connector-pulse 2s ease-out infinite; }
+@keyframes v2-connector-pulse {
+  0% { box-shadow: 0 0 0 0 var(--v2-success-ring); }
+  70% { box-shadow: 0 0 0 6px rgba(16, 185, 129, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .v2-connector__dot--pulse { animation: none; }
+}
+
+.v2-connector__manage {
+  border: none;
+  background: none;
+  color: var(--v2-accent-text);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  padding: 4px 6px;
+}
+.v2-connector__manage-panel { border-top: 1px solid var(--v2-border-soft); padding-top: 10px; }
+.v2-connector__danger {
+  border: none;
+  background: none;
+  color: var(--v2-danger);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  padding: 2px 0;
+}
+
+.v2-connector__controls { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; }
+.v2-connector__relay {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   font-size: 13px;
   color: var(--v2-text-secondary);
   cursor: pointer;
 }
-.v2-connectors__relay input { margin-top: 2px; accent-color: var(--v2-accent); }
-.v2-connectors__new h2 { font-size: 15px; font-weight: 650; color: var(--v2-text-primary); margin: 0 0 10px; }
+.v2-connector__relay input { accent-color: var(--v2-accent); }
+.v2-connector__mode {
+  display: inline-flex;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-pill);
+  overflow: hidden;
+}
+.v2-connector__mode-opt {
+  border: none;
+  background: var(--v2-surface);
+  color: var(--v2-text-secondary);
+  font: inherit;
+  font-size: 12px;
+  padding: 4px 12px;
+  cursor: pointer;
+  transition: background 80ms ease;
+}
+.v2-connector__mode-opt--on {
+  background: var(--v2-accent);
+  color: #fff;
+  cursor: default;
+}
+.v2-connector__mode-hint { font-size: 12px; color: var(--v2-text-muted); }
+
+.v2-connector__code-step {
+  border-top: 1px solid var(--v2-border-soft);
+  padding-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+}
+.v2-connector__code-hint { font-size: 13px; color: var(--v2-text-secondary); }
+.v2-connector__copy {
+  border: none;
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-accent);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 7px 14px;
+  cursor: pointer;
+  transition: background 80ms ease;
+}
+.v2-connector__copy:hover { background: var(--v2-accent-strong); }
+.v2-connector__code {
+  font-family: var(--v2-font-mono);
+  font-size: 14px;
+  letter-spacing: 0.06em;
+  color: var(--v2-text-primary);
+  user-select: all;
+  overflow-wrap: anywhere;
+}
+
+.v2-connector-add__tiles { display: flex; gap: 14px; flex-wrap: wrap; }
+.v2-connector-add__tile {
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius);
+  background: var(--v2-surface);
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 16px 10px;
+  font: inherit;
+  font-size: 12px;
+  color: var(--v2-text-secondary);
+  cursor: pointer;
+  position: relative;
+  transition: border-color 80ms ease;
+}
+.v2-connector-add__tile:hover:not(.v2-connector-add__tile--soon) { border-color: var(--v2-border-strong); }
+.v2-connector-add__tile .v2-connector__tile { width: 48px; height: 48px; }
+.v2-connector-add__tile--soon { opacity: 0.45; cursor: default; }
+.v2-connector-add__soon {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--v2-text-muted);
+}
+
 .v2-connectors__new-row { display: flex; gap: 10px; flex-wrap: wrap; }
-/* Visuals come from .v2-byo__input (same control as the BYO pod picker) —
-   this only carries the row layout. */
 .v2-connectors__select { flex: 1; min-width: 200px; }
 .v2-connectors__create {
   border: none;
@@ -8127,4 +8267,8 @@ body.modern-ui.v2-canvas {
   border-radius: var(--v2-radius-sm);
   padding: 10px 12px;
   font-size: 13px;
+}
+@media (max-width: 760px) {
+  .v2-connector__controls { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .v2-connector__row { flex-wrap: wrap; }
 }


### PR DESCRIPTION
Implements the deployed-kernel subset of Wren's connectors-v2 design spec rev 5 (Connectors v2 pod):

- Platform tiles: inline SVG glyphs (no CDN/PNG), brand + soft tint tokens added to **both** v2.css and design-system/tokens.css in this PR
- Status = dot + last event (pulse honors prefers-reduced-motion), never a text chip
- **Mode segment: Attention | Mirror** — drives config.relayAllAgentMessages, same flag as the /mode Telegram command
- Enable code: Copy command as the filled primary; code mono, grouped in 4s, user-select all (128-bit codes)
- Add flow: platform tiles, SOON platforms at 45% and not buttons; ghost empty state IS the pick state
- Manage → Disconnect (two-click confirm, PATCH isActive:false); 3s poll while a code is pending, stops on connect
- Deliberately NOT shipped (kernel absent, spec honesty rule): Commander card, Talks-to control, per-pod gates, digest, expiry countdown

6 RTL tests + a layout-invariants presence test pinning the token same-PR rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pc6nGXRS8mHvr9cXMSRDK