### PR TITLE
fix(v2): connectors buttons vs the global button reset + Relay label

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -30,7 +30,10 @@
     "subtitle": "What needs your attention and what your agents moved forward.",
     "controlsAriaLabel": "Activity controls",
     "windowAriaLabel": "Activity window",
-    "windows": { "today": "Today", "7d": "7 days" },
+    "windows": {
+      "today": "Today",
+      "7d": "7 days"
+    },
     "podScopeLabel": "Pod scope",
     "allPods": "All pods",
     "loadFailed": "Activity could not be loaded. Try again.",
@@ -44,7 +47,10 @@
       "description": "Only direct mentions and pending approvals appear here.",
       "emptyTitle": "Nothing is waiting on you",
       "emptyDescription": "New mentions and approval requests will appear here when they need a response.",
-      "kinds": { "mention": "Mention", "approval": "Approval" }
+      "kinds": {
+        "mention": "Mention",
+        "approval": "Approval"
+      }
     },
     "dayZero": {
       "kind": "Get started",
@@ -92,7 +98,12 @@
       "description": "Tasks that changed in this window.",
       "emptyTitle": "No board changes in this window",
       "emptyDescription": "Task changes will appear here without creating a second board.",
-      "status": { "pending": "Pending", "claimed": "In progress", "blocked": "Blocked", "done": "Done" }
+      "status": {
+        "pending": "Pending",
+        "claimed": "In progress",
+        "blocked": "Blocked",
+        "done": "Done"
+      }
     },
     "footer": "Open the source thread to act; this recap leaves when the underlying fact changes."
   },
@@ -1641,7 +1652,7 @@
     "pending": "Waiting for the channel",
     "enableHint": "Open a private chat with the Commonly bot",
     "enableHintSend": " and send:",
-    "liveRelay": "Live relay",
+    "liveRelay": "Relay",
     "liveRelayHint": "chat messages post into the pod and wake mentioned agents; agent escalations reach the channel.",
     "newTitle": "Connect a channel",
     "podPicker": "Pod to bridge",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -30,7 +30,10 @@
     "subtitle": "需要你处理的事项，以及智能体推动的工作。",
     "controlsAriaLabel": "动态控制项",
     "windowAriaLabel": "动态时间范围",
-    "windows": { "today": "今天", "7d": "7 天" },
+    "windows": {
+      "today": "今天",
+      "7d": "7 天"
+    },
     "podScopeLabel": "Pod 范围",
     "allPods": "所有 Pod",
     "loadFailed": "无法加载动态，请重试。",
@@ -44,7 +47,10 @@
       "description": "这里只显示直接提及和待处理的审批。",
       "emptyTitle": "没有事项在等待你",
       "emptyDescription": "有需要回复的提及或审批请求时，会显示在这里。",
-      "kinds": { "mention": "提及", "approval": "审批" }
+      "kinds": {
+        "mention": "提及",
+        "approval": "审批"
+      }
     },
     "dayZero": {
       "kind": "开始使用",
@@ -92,7 +98,12 @@
       "description": "此时间范围内发生变化的任务。",
       "emptyTitle": "此时间范围内没有看板变更",
       "emptyDescription": "任务变更会显示在这里，不会创建第二个看板。",
-      "status": { "pending": "待处理", "claimed": "进行中", "blocked": "已阻塞", "done": "已完成" }
+      "status": {
+        "pending": "待处理",
+        "claimed": "进行中",
+        "blocked": "已阻塞",
+        "done": "已完成"
+      }
     },
     "footer": "请在源讨论中行动；底层事实变化后，这份回顾会自动离开。"
   },
@@ -1635,7 +1646,7 @@
     "pending": "等待频道确认",
     "enableHint": "打开与 Commonly 机器人的私聊",
     "enableHintSend": "，然后发送：",
-    "liveRelay": "实时中继",
+    "liveRelay": "中继",
     "liveRelayHint": "聊天消息会发布到 Pod 并唤醒被提及的智能体；智能体的升级消息会回到频道。",
     "newTitle": "连接频道",
     "podPicker": "要桥接的 Pod",

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -8131,7 +8131,7 @@ body.modern-ui.v2-canvas {
   .v2-connector__dot--pulse { animation: none; }
 }
 
-.v2-connector__manage {
+.v2-root button.v2-connector__manage {
   border: none;
   background: none;
   color: var(--v2-accent-text);
@@ -8141,7 +8141,7 @@ body.modern-ui.v2-canvas {
   padding: 4px 6px;
 }
 .v2-connector__manage-panel { border-top: 1px solid var(--v2-border-soft); padding-top: 10px; }
-.v2-connector__danger {
+.v2-root button.v2-connector__danger {
   border: none;
   background: none;
   color: var(--v2-danger);
@@ -8167,7 +8167,7 @@ body.modern-ui.v2-canvas {
   border-radius: var(--v2-radius-pill);
   overflow: hidden;
 }
-.v2-connector__mode-opt {
+.v2-root button.v2-connector__mode-opt {
   border: none;
   background: var(--v2-surface);
   color: var(--v2-text-secondary);
@@ -8177,7 +8177,7 @@ body.modern-ui.v2-canvas {
   cursor: pointer;
   transition: background 80ms ease;
 }
-.v2-connector__mode-opt--on {
+.v2-root button.v2-connector__mode-opt--on {
   background: var(--v2-accent);
   color: #fff;
   cursor: default;
@@ -8193,7 +8193,7 @@ body.modern-ui.v2-canvas {
   align-items: flex-start;
 }
 .v2-connector__code-hint { font-size: 13px; color: var(--v2-text-secondary); }
-.v2-connector__copy {
+.v2-root button.v2-connector__copy {
   border: none;
   border-radius: var(--v2-radius-sm);
   background: var(--v2-accent);
@@ -8204,7 +8204,7 @@ body.modern-ui.v2-canvas {
   cursor: pointer;
   transition: background 80ms ease;
 }
-.v2-connector__copy:hover { background: var(--v2-accent-strong); }
+.v2-root button.v2-connector__copy:hover { background: var(--v2-accent-strong); }
 .v2-connector__code {
   font-family: var(--v2-font-mono);
   font-size: 14px;
@@ -8215,7 +8215,8 @@ body.modern-ui.v2-canvas {
 }
 
 .v2-connector-add__tiles { display: flex; gap: 14px; flex-wrap: wrap; }
-.v2-connector-add__tile {
+.v2-root button.v2-connector-add__tile,
+.v2-root span.v2-connector-add__tile {
   border: 1px solid var(--v2-border);
   border-radius: var(--v2-radius);
   background: var(--v2-surface);
@@ -8231,9 +8232,9 @@ body.modern-ui.v2-canvas {
   position: relative;
   transition: border-color 80ms ease;
 }
-.v2-connector-add__tile:hover:not(.v2-connector-add__tile--soon) { border-color: var(--v2-border-strong); }
+.v2-root button.v2-connector-add__tile:hover { border-color: var(--v2-border-strong); }
 .v2-connector-add__tile .v2-connector__tile { width: 48px; height: 48px; }
-.v2-connector-add__tile--soon { opacity: 0.45; cursor: default; }
+.v2-root span.v2-connector-add__tile--soon { opacity: 0.45; cursor: default; }
 .v2-connector-add__soon {
   position: absolute;
   top: 6px;
@@ -8246,7 +8247,7 @@ body.modern-ui.v2-canvas {
 
 .v2-connectors__new-row { display: flex; gap: 10px; flex-wrap: wrap; }
 .v2-connectors__select { flex: 1; min-width: 200px; }
-.v2-connectors__create {
+.v2-root button.v2-connectors__create {
   border: none;
   border-radius: var(--v2-radius-sm);
   background: var(--v2-accent);
@@ -8257,8 +8258,8 @@ body.modern-ui.v2-canvas {
   cursor: pointer;
   transition: background 80ms ease;
 }
-.v2-connectors__create:hover:not(:disabled) { background: var(--v2-accent-strong); }
-.v2-connectors__create:disabled { opacity: 0.55; cursor: default; }
+.v2-root button.v2-connectors__create:hover:not(:disabled) { background: var(--v2-accent-strong); }
+.v2-root button.v2-connectors__create:disabled { opacity: 0.55; cursor: default; }
 .v2-connectors__foot { font-size: 12px; color: var(--v2-text-muted); margin: 8px 0 0; }
 .v2-connectors__error {
   border: 1px solid var(--v2-danger);


### PR DESCRIPTION
Real-browser pass on the deployed #1304 caught the v2 button-reset specificity trap (third occurrence — see memory feedback-v2-button-reset-specificity): the Attention|Mirror segment rendered as bare text and Copy command lost its fill. All connector button selectors now carry .v2-root button. prefix (the v2-pods__new-btn pattern). Also: label copy per Wren's spec — 'Relay', not 'Live relay' (en + zh-CN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pc6nGXRS8mHvrwcXMSRDK