### PR TITLE
fix(activity): the tab shows real work — ranked pod scope, no system bots, a decision queue built from facts

### DIFF
--- a/backend/__tests__/unit/services/activityService.decisionQueue.test.js
+++ b/backend/__tests__/unit/services/activityService.decisionQueue.test.js
@@ -1,0 +1,111 @@
+/**
+ * TASK-083 — the decision queue reads FACTS, not heuristics.
+ *
+ * The Activity tab's "Waiting on you" rendered empty while seven PRs sat at
+ * the human press, because its only wired source was direct @mentions (empty
+ * — agents write the human's bare name, TASK-070). This suite pins the three
+ * concrete fact sources and their classification:
+ *   - pending approvals (raw activity id — the act endpoints key on it)
+ *   - unacknowledged direct mentions
+ *   - board rows: DECIDE-titles and blocked rows -> 'decision';
+ *     an explicit human-handoff in the LATEST update -> 'press'
+ */
+
+jest.mock('../../../models/Pod', () => ({
+  find: jest.fn(),
+}));
+jest.mock('../../../models/Task', () => ({
+  find: jest.fn(),
+}));
+jest.mock('../../../models/User', () => ({
+  find: jest.fn(),
+  findById: jest.fn(),
+}));
+jest.mock('../../../models/Activity', () => ({}));
+jest.mock('../../../models/Summary', () => ({}));
+jest.mock('../../../models/Post', () => ({}));
+
+const ActivityService = require('../../../services/activityService');
+const Pod = require('../../../models/Pod');
+const Task = require('../../../models/Task');
+
+const POD = { _id: 'pod-1', name: 'Sprint HQ', type: 'team' };
+
+const taskChain = (rows) => ({
+  sort: () => ({ limit: () => ({ lean: async () => rows }) }),
+});
+
+describe('ActivityService.getDecisionQueue', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    Pod.find.mockReturnValue({ select: () => ({ lean: async () => [POD] }) });
+    jest.spyOn(ActivityService, 'getPendingApprovals').mockResolvedValue([]);
+    jest.spyOn(ActivityService, 'getUserFeed').mockResolvedValue({ activities: [], acknowledgedMentionIds: [] });
+    Task.find.mockReturnValue(taskChain([]));
+  });
+
+  test('a DECIDE-titled open row and a blocked row are decisions; a human-handoff update is a press', async () => {
+    Task.find.mockReturnValue(taskChain([
+      {
+        taskId: 'TASK-024', podId: 'pod-1', status: 'pending', title: 'DECIDE: backend eslint reaches 0 files',
+        updates: [{ text: 'filed', createdAt: new Date('2026-08-26T01:00:00Z') }],
+      },
+      {
+        taskId: 'TASK-016', podId: 'pod-1', status: 'blocked', title: 'REGRESSION: isOneToOneShapedPod counts bots',
+        updates: [{ text: 'blocked on decision', createdAt: new Date('2026-08-26T02:00:00Z') }],
+      },
+      {
+        taskId: 'TASK-059', podId: 'pod-1', status: 'claimed', title: 'Retention ledger',
+        updates: [{ text: '#1208 is green — held for the human merge press.', createdAt: new Date('2026-08-26T03:00:00Z') }],
+      },
+      {
+        taskId: 'TASK-068', podId: 'pod-1', status: 'claimed', title: 'Activity tab',
+        updates: [{ text: 'iterating on the design', createdAt: new Date('2026-08-26T04:00:00Z') }],
+      },
+    ]));
+
+    const result = await ActivityService.getDecisionQueue('u1');
+    const byTask = Object.fromEntries(result.items.map((i) => [i.taskId, i.kind]));
+    expect(byTask['TASK-024']).toBe('decision');
+    expect(byTask['TASK-016']).toBe('decision');
+    expect(byTask['TASK-059']).toBe('press');
+    // An ordinary in-flight row is NOT waiting on the human.
+    expect(byTask['TASK-068']).toBeUndefined();
+  });
+
+  test('the handoff match reads the LATEST update only — an old handoff already resolved does not resurrect', async () => {
+    Task.find.mockReturnValue(taskChain([
+      {
+        taskId: 'TASK-100', podId: 'pod-1', status: 'claimed', title: 'Some feature',
+        updates: [
+          { text: 'ready for the human press', createdAt: new Date('2026-08-25T00:00:00Z') },
+          { text: 'pressed; follow-ups in progress', createdAt: new Date('2026-08-26T00:00:00Z') },
+        ],
+      },
+    ]));
+    const result = await ActivityService.getDecisionQueue('u1');
+    expect(result.items).toHaveLength(0);
+  });
+
+  test('approvals carry the RAW activity id, because /api/activity/:id/approve keys on it', async () => {
+    ActivityService.getPendingApprovals.mockResolvedValue([
+      { _id: 'act-77', content: 'May I merge?', podId: 'pod-1', createdAt: new Date(), agentMetadata: { agentName: 'anvil' } },
+    ]);
+    const result = await ActivityService.getDecisionQueue('u1');
+    const approval = result.items.find((i) => i.kind === 'approval');
+    expect(approval.id).toBe('act-77');
+    expect(approval.title).toContain('anvil');
+  });
+
+  test('one failed source degrades, never blanks the queue', async () => {
+    ActivityService.getPendingApprovals.mockRejectedValue(new Error('store down'));
+    Task.find.mockReturnValue(taskChain([
+      {
+        taskId: 'TASK-024', podId: 'pod-1', status: 'pending', title: 'DECIDE: something',
+        updates: [{ text: 'filed', createdAt: new Date() }],
+      },
+    ]));
+    const result = await ActivityService.getDecisionQueue('u1');
+    expect(result.items.map((i) => i.taskId)).toEqual(['TASK-024']);
+  });
+});

--- a/backend/routes/activity.ts
+++ b/backend/routes/activity.ts
@@ -94,6 +94,19 @@ router.get('/pods/:podId', auth, async (req: Req, res: Res) => {
   }
 });
 
+// Everything concretely waiting on this human: approvals + unacked mentions +
+// board decision/handoff rows. TASK-083: the queue reads FACTS that exist,
+// never name-matching heuristics (TASK-070b stays a design decision).
+router.get('/decision-queue', auth, async (req: Req, res: Res) => {
+  try {
+    const userId = getAuthenticatedUserId(req);
+    res.json(await ActivityService.getDecisionQueue(userId));
+  } catch (error) {
+    console.error('Error fetching decision queue:', error);
+    res.status(500).json({ error: 'Failed to fetch decision queue' });
+  }
+});
+
 router.get('/approvals', auth, async (req: Req, res: Res) => {
   try {
     const userId = getAuthenticatedUserId(req);

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -105,6 +105,12 @@ interface ComputeFlagsOptions {
   followingIds?: Set<string>;
 }
 
+// System actors whose posts are plumbing, not work. The recap and the feed
+// exist to answer "what did MY agents do" — commonly-bot's task-echo volume
+// (95 updates in one window, TASK-083) drowned every real seat, which is what
+// made the Activity tab read as empty of real agent activity.
+const SYSTEM_BOT_NAMES = new Set(['commonly-bot', 'commonly-ai-agent']);
+
 class ActivityService {
   /**
    * Read-side projection for the v2 Activity surface. The source events stay
@@ -359,8 +365,11 @@ class ActivityService {
         .select('_id name type')
         .lean();
 
-      const podIds = pods.map((p) => p._id);
       const podMap = new Map(pods.map((p) => [String(p._id), p]));
+      // Rank pods by most-recent message so downstream per-pod fetches (which
+      // are bounded) always cover the rooms where work is actually happening,
+      // not five arbitrary rows of a 40-pod membership (TASK-083 defect 1).
+      const podIds = await ActivityService.rankPodsByRecentActivity(pods.map((p) => p._id));
 
       const activities = await ActivityService.aggregateActivities(podIds, podMap, user, {
         limit, before, filter, mode,
@@ -380,6 +389,149 @@ class ActivityService {
       console.error('Error in getUserFeed:', error);
       throw error;
     }
+  }
+
+  /**
+   * Order podIds by their most recent chat message, newest first. One PG
+   * query for the whole membership; pods with no PG messages (or when PG is
+   * unavailable) keep their original relative order at the tail — degrading
+   * to today's arbitrary order, never to a smaller pod set.
+   */
+  static async rankPodsByRecentActivity(podIds: unknown[]): Promise<unknown[]> {
+    if (!podIds.length) return podIds;
+    try {
+      // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+      const { pool } = require('../config/db-pg') as {
+        pool: { query(sql: string, params?: unknown[]): Promise<{ rows: Array<{ pod_id: string }> }> } | null;
+      };
+      if (!pool) return podIds;
+      const ids = podIds.map((id) => String(id));
+      const { rows } = await pool.query(
+        'SELECT pod_id, MAX(created_at) AS latest FROM messages WHERE pod_id = ANY($1) GROUP BY pod_id ORDER BY latest DESC',
+        [ids],
+      );
+      const ranked = rows.map((r) => String(r.pod_id));
+      const rankIndex = new Map(ranked.map((id, i) => [id, i]));
+      return [...podIds].sort((a, b) => {
+        const ia = rankIndex.has(String(a)) ? (rankIndex.get(String(a)) as number) : Number.MAX_SAFE_INTEGER;
+        const ib = rankIndex.has(String(b)) ? (rankIndex.get(String(b)) as number) : Number.MAX_SAFE_INTEGER;
+        return ia - ib;
+      });
+    } catch {
+      return podIds;
+    }
+  }
+
+  /**
+   * The decision queue: everything concretely waiting on THIS human, from
+   * facts that exist today (TASK-083 defect 1's fix): pending approval
+   * requests, unacknowledged direct mentions, and board rows that name a
+   * human decision — DECIDE-titled tasks, blocked tasks, and tasks whose
+   * latest update hands off to a human press/ruling. No inference, no
+   * name-matching heuristics (TASK-070b stays open by design).
+   */
+  static async getDecisionQueue(userId: unknown): Promise<Record<string, unknown>> {
+    const pods: PodDoc[] = await Pod.find({
+      $or: [
+        { createdBy: userId },
+        { 'members.userId': userId },
+        { members: userId },
+      ],
+    }).select('_id name type').lean();
+    const podIds = pods.map((p) => p._id);
+    const podName = new Map(pods.map((p) => [String(p._id), p.name as string]));
+
+    type QueueItem = {
+      kind: 'approval' | 'mention' | 'decision' | 'press';
+      id: string;
+      title: string;
+      detail?: string;
+      podId: string | null;
+      podName?: string;
+      taskId?: string;
+      createdAt: Date | string | null;
+    };
+    const items: QueueItem[] = [];
+
+    // 1. Pending approvals — the authoritative reader already exists.
+    try {
+      const approvals = await ActivityService.getPendingApprovals(userId) as Array<{
+        _id: { toString(): string }; content?: string; podId?: unknown; createdAt?: Date;
+        agentMetadata?: { agentName?: string };
+      }>;
+      for (const a of approvals) {
+        items.push({
+          kind: 'approval',
+          // RAW activity id — the act endpoints (/api/activity/:id/approve)
+          // key on it, so a prefixed id here would break the buttons.
+          id: String(a._id),
+          title: a.agentMetadata?.agentName ? `${a.agentMetadata.agentName} requests approval` : 'Approval requested',
+          detail: String(a.content || '').slice(0, 160),
+          podId: a.podId ? String(a.podId) : null,
+          podName: a.podId ? podName.get(String(a.podId)) : undefined,
+          createdAt: a.createdAt || null,
+        });
+      }
+    } catch (err) {
+      console.warn('[decision-queue] approvals read failed:', (err as Error).message);
+    }
+
+    // 2. Unacknowledged direct mentions, from the feed's existing flags.
+    try {
+      const feed = await ActivityService.getUserFeed(userId, { limit: 60, filter: 'mentions' });
+      const acked = new Set(((feed.acknowledgedMentionIds as unknown[]) || []).map(String));
+      for (const a of ((feed.activities as ActivityItem[]) || [])) {
+        if (!a.flags?.isMention || acked.has(String(a.id))) continue;
+        items.push({
+          kind: 'mention',
+          id: String(a.id),
+          title: `${a.actor?.name || 'Someone'} mentioned you`,
+          detail: String(a.preview || a.content || '').slice(0, 160),
+          podId: a.pod?.id || null,
+          podName: a.pod?.name,
+          createdAt: (a.timestamp as Date) || null,
+        });
+      }
+    } catch (err) {
+      console.warn('[decision-queue] mentions read failed:', (err as Error).message);
+    }
+
+    // 3. Board facts. Concrete, not inferred: a DECIDE-titled open row IS a
+    // decision request; a blocked row is waiting on someone; a latest update
+    // that says "human press" / "Sam's ruling" is an explicit handoff.
+    try {
+      const HANDOFF_RE = /human\s+(merge\s+)?press|ready for (the\s+)?(human|sam)|sam'?s?\s+(ruling|call|decision)|awaiting\s+(sam|human)/i;
+      const tasks = await (Task as {
+        find(q: unknown): { sort(s: unknown): { limit(n: number): { lean(): Promise<Array<Record<string, unknown>>> } } };
+      }).find({
+        podId: { $in: podIds },
+        status: { $in: ['pending', 'claimed', 'blocked'] },
+      }).sort({ updatedAt: -1 }).limit(120).lean();
+      for (const t of tasks) {
+        const title = String(t.title || '');
+        const updates = (t.updates as Array<{ text?: string; createdAt?: Date }> | undefined) || [];
+        const last = updates[updates.length - 1];
+        const isDecide = /^DECIDE\b/i.test(title);
+        const isBlocked = t.status === 'blocked';
+        const isHandoff = !!(last && HANDOFF_RE.test(String(last.text || '')));
+        if (!isDecide && !isBlocked && !isHandoff) continue;
+        items.push({
+          kind: isHandoff && !isDecide ? 'press' : 'decision',
+          id: `task_${t.taskId}`,
+          title,
+          detail: last ? String(last.text || '').slice(0, 160) : undefined,
+          podId: String(t.podId),
+          podName: podName.get(String(t.podId)),
+          taskId: String(t.taskId || ''),
+          createdAt: (last?.createdAt as Date) || (t.updatedAt as Date) || null,
+        });
+      }
+    } catch (err) {
+      console.warn('[decision-queue] board read failed:', (err as Error).message);
+    }
+
+    items.sort((a, b) => new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime());
+    return { items, count: items.length };
   }
 
   static async getPodFeed(
@@ -605,8 +757,15 @@ class ActivityService {
 
       if (PGMessage) {
         try {
+          // TASK-083 defect 1's root cause lived here: `.slice(0, 5)` over
+          // podIds in ARBITRARY Mongo order meant a member of ~40 pods got
+          // messages from five random rooms — the working pods never made
+          // the cut and the feed read as empty of real agent activity. The
+          // caller (getUserFeed) now ranks podIds by recent message time
+          // before this runs; the slice widens to the ranked top 12, which
+          // bounds the fan-out while guaranteeing the ACTIVE rooms are in.
           const podMessagesList = await Promise.all(
-            podIds.slice(0, 5).map((podId) => (PGMessage as { findByPodId(id: unknown, limit: number): Promise<unknown[]> }).findByPodId(podId, limit)),
+            podIds.slice(0, 12).map((podId) => (PGMessage as { findByPodId(id: unknown, limit: number): Promise<unknown[]> }).findByPodId(podId, limit)),
           );
           messages = podMessagesList.flat() as Array<Record<string, unknown>>;
         } catch (e) {
@@ -633,6 +792,8 @@ class ActivityService {
         const authorName = (msg.username as string) || (userId?.username as string) || 'Unknown';
         const isAgent = userId?.isBot === true || ActivityService.isAgentUsername(authorName);
 
+        // System plumbing is not activity (TASK-083 defect 2).
+        if (SYSTEM_BOT_NAMES.has(authorName.toLowerCase())) return;
         if (filter === 'humans' && isAgent) return;
         if (filter === 'agents' && !isAgent) return;
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -38,6 +38,7 @@
     "allPods": "All pods",
     "loadFailed": "Activity could not be loaded. Try again.",
     "openThread": "Open thread",
+    "openBoard": "Open board",
     "lastActive": "Active {{time}} ago",
     "updatesCount_one": "{{count}} update",
     "updatesCount_other": "{{count}} updates",
@@ -49,7 +50,9 @@
       "emptyDescription": "New mentions and approval requests will appear here when they need a response.",
       "kinds": {
         "mention": "Mention",
-        "approval": "Approval"
+        "approval": "Approval",
+        "decision": "Decision needed",
+        "press": "Ready for your press"
       }
     },
     "dayZero": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -38,6 +38,7 @@
     "allPods": "所有 Pod",
     "loadFailed": "无法加载动态，请重试。",
     "openThread": "打开讨论",
+    "openBoard": "打开看板",
     "lastActive": "{{time}}前活跃",
     "updatesCount_one": "{{count}} 条更新",
     "updatesCount_other": "{{count}} 条更新",
@@ -49,7 +50,9 @@
       "emptyDescription": "有需要回复的提及或审批请求时，会显示在这里。",
       "kinds": {
         "mention": "提及",
-        "approval": "审批"
+        "approval": "审批",
+        "decision": "待你决策",
+        "press": "待你合并"
       }
     },
     "dayZero": {

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -21,6 +21,26 @@ const CurrentPath = () => {
   return <div data-testid="current-path">{location.pathname}{location.search}</div>;
 };
 
+// The queue now arrives from /decision-queue (TASK-083) — recap.needsYou is
+// only the degrade path when that endpoint fails.
+const decisionQueue = {
+  items: [
+    {
+      id: 'mention-1', kind: 'mention', title: 'Review requested', detail: 'A direct mention.',
+      podId: 'pod-1', podName: 'Launch pod', createdAt: '2026-08-26T11:00:00.000Z',
+    },
+    {
+      id: 'task_TASK-059', kind: 'press', title: 'Retention ledger', detail: '#1208 held for the human merge press.',
+      podId: 'pod-1', podName: 'Launch pod', taskId: 'TASK-059', createdAt: '2026-08-26T10:00:00.000Z',
+    },
+    {
+      id: 'task_TASK-024', kind: 'decision', title: 'DECIDE: eslint scope', detail: 'filed',
+      podId: 'pod-1', podName: 'Launch pod', taskId: 'TASK-024', createdAt: '2026-08-26T09:00:00.000Z',
+    },
+  ],
+  count: 3,
+};
+
 const recap = {
   pods: [{ id: 'pod-1', name: 'Launch pod' }],
   needsYou: [{
@@ -53,16 +73,38 @@ describe('V2ActivityPage', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    mockGet.mockResolvedValue({ data: recap });
+    // Default: the decision-queue endpoint FAILS, exercising the designed
+    // degrade path (fall back to recap.needsYou) — which also keeps the
+    // pre-existing tests' order-based mockResolvedValueOnce chains valid,
+    // since their Once values feed the recap call and this implementation
+    // catches the queue call. The first test overrides with real items.
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/activity/decision-queue') return Promise.reject(new Error('queue down'));
+      return Promise.resolve({ data: recap });
+    });
     await act(async () => { await i18n.changeLanguage('en'); });
   });
 
   test('projects existing activity, direct interrupts, and board changes without inventing a queue count', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: decisionQueue });
+      return Promise.resolve({ data: recap });
+    });
     renderPage();
 
     expect(await screen.findByRole('heading', { name: 'Activity' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Needs you' })).toBeInTheDocument();
+    // findBy, not getBy: the header renders unconditionally, so awaiting it
+    // proves nothing about data arrival — and the queue+recap Promise.all
+    // adds a microtask hop the old single-request race happened to win.
+    expect(await screen.findByRole('heading', { name: 'Needs you' })).toBeInTheDocument();
     expect(screen.getByText('Review requested')).toBeInTheDocument();
+    // TASK-083: board facts land in the queue — a human-press handoff and a
+    // DECIDE row, each with an Open board action.
+    expect(screen.getByText('Retention ledger')).toBeInTheDocument();
+    expect(screen.getByText('Ready for your press')).toBeInTheDocument();
+    expect(screen.getByText('DECIDE: eslint scope')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Open board' })).toHaveLength(2);
+    expect(mockGet).toHaveBeenCalledWith('/api/activity/decision-queue', expect.anything());
     expect(screen.getByRole('heading', { name: 'What your agents did' })).toBeInTheDocument();
     expect(screen.getByText('release-agent')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Board' })).toBeInTheDocument();
@@ -77,11 +119,14 @@ describe('V2ActivityPage', () => {
     await screen.findByText('Review requested');
 
     fireEvent.click(screen.getByRole('button', { name: '7 days' }));
-    await waitFor(() => expect(mockGet).toHaveBeenLastCalledWith('/api/activity/recap', expect.objectContaining({
+    // toHaveBeenCalledWith, not Last: the decision-queue request now fires
+    // alongside recap, so "last call" is no longer the recap by construction.
+    await waitFor(() => expect(mockGet).toHaveBeenCalledWith('/api/activity/recap', expect.objectContaining({
       params: { window: '7d' },
     })));
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Open thread' })[0]);
+    // findAll: the window change reloads both requests and the rows remount.
+    fireEvent.click((await screen.findAllByRole('button', { name: 'Open thread' }))[0]);
     expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/pod-1');
   });
 

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -27,11 +27,15 @@ interface AgentRecap {
 
 interface NeedsYouItem {
   id: string;
-  kind: 'mention' | 'approval';
+  // decision = a DECIDE-titled or blocked board row; press = an explicit
+  // human-handoff in a task's latest update. Both come from the
+  // /decision-queue endpoint's board facts (TASK-083).
+  kind: 'mention' | 'approval' | 'decision' | 'press';
   title: string;
   detail: string;
   podId: string | null;
   podName: string;
+  taskId?: string;
   timestamp: string | null;
 }
 
@@ -77,17 +81,47 @@ const V2ActivityPage: React.FC = () => {
   const [acknowledgingMentionId, setAcknowledgingMentionId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
+  const [queue, setQueue] = useState<NeedsYouItem[]>([]);
+
   useEffect(() => {
     let active = true;
     setLoading(true);
     setError(null);
     const token = localStorage.getItem('token');
-    axios.get<ActivityRecap>('/api/activity/recap', {
-      headers: { 'x-auth-token': token ?? '' },
-      params: { window, ...(podId !== 'all' ? { podId } : {}) },
-    })
-      .then((response) => {
-        if (active) setRecap(response.data);
+    const headers = { 'x-auth-token': token ?? '' };
+    // The recap paints the room; the decision queue is the reason the page
+    // exists (TASK-083). They load together, but a queue failure must not
+    // blank the recap — degrade to recap.needsYou (mentions + approvals).
+    Promise.all([
+      axios.get<ActivityRecap>('/api/activity/recap', {
+        headers,
+        params: { window, ...(podId !== 'all' ? { podId } : {}) },
+      }),
+      axios.get<{ items: Array<NeedsYouItem & { createdAt?: string | null }> }>(
+        '/api/activity/decision-queue',
+        { headers },
+      ).catch(() => null),
+    ])
+      .then(([recapResponse, queueResponse]) => {
+        if (!active) return;
+        setRecap(recapResponse.data);
+        // A well-formed queue response has an items ARRAY. Anything else —
+        // endpoint failed (null), older server, malformed body — degrades to
+        // recap.needsYou (mentions + approvals) rather than an empty queue.
+        const rawItems = queueResponse?.data?.items;
+        if (!Array.isArray(rawItems)) {
+          setQueue(recapResponse.data.needsYou || []);
+          return;
+        }
+        const queueItems = rawItems.map((item) => ({
+          ...item,
+          detail: item.detail || '',
+          podName: item.podName || '',
+          timestamp: item.timestamp ?? item.createdAt ?? null,
+        }));
+        setQueue(podId !== 'all'
+          ? queueItems.filter((item) => item.podId === podId)
+          : queueItems);
       })
       .catch(() => {
         if (active) setError(t('activity.loadFailed'));
@@ -153,7 +187,12 @@ const V2ActivityPage: React.FC = () => {
     }
   };
 
+  const openBoard = (item: NeedsYouItem) => {
+    if (item.podId) navigate(`/v2/pods/${item.podId}/board`);
+  };
+
   const isDayZero = podId === 'all'
+    && queue.length === 0
     && recap?.agents.length === 0
     && recap.board.length === 0;
 
@@ -240,16 +279,18 @@ const V2ActivityPage: React.FC = () => {
                   </div>
                 </article>
               </div>
-            ) : recap.needsYou.length === 0 ? (
+            ) : queue.length === 0 ? (
               <div className="v2-activity__empty">
                 <strong>{t('activity.needsYou.emptyTitle')}</strong>
                 <span>{t('activity.needsYou.emptyDescription')}</span>
               </div>
             ) : (
               <div className="v2-activity__queue">
-                {recap.needsYou.map((item) => (
+                {queue.map((item) => (
                   <article key={item.id} className={`v2-activity__queue-row v2-activity__queue-row--${item.kind}`}>
-                    <span className="v2-activity__queue-mark" aria-hidden="true">{item.kind === 'mention' ? '@' : '!'}</span>
+                    <span className="v2-activity__queue-mark" aria-hidden="true">
+                      {item.kind === 'mention' ? '@' : item.kind === 'approval' ? '!' : item.kind === 'press' ? '▸' : '?'}
+                    </span>
                     <div className="v2-activity__queue-copy">
                       <div className="v2-activity__queue-kind">{t(`activity.needsYou.kinds.${item.kind}`)}</div>
                       <strong>{item.title}</strong>
@@ -270,6 +311,11 @@ const V2ActivityPage: React.FC = () => {
                       {item.kind === 'mention' && (
                         <button type="button" onClick={() => acknowledgeMention(item)} disabled={acknowledgingMentionId === item.id}>
                           {acknowledgingMentionId === item.id ? t('activity.mention.working') : t('activity.mention.acknowledge')}
+                        </button>
+                      )}
+                      {(item.kind === 'decision' || item.kind === 'press') && (
+                        <button type="button" onClick={() => openBoard(item)} disabled={!item.podId}>
+                          {t('activity.openBoard')}
                         </button>
                       )}
                       <button type="button" className="v2-activity__queue-action--thread" onClick={() => openPod(item.podId)} disabled={!item.podId}>


### PR DESCRIPTION
TASK-083, Sam's second escalation. Three root causes measured on prod: (1) the feed read podIds.slice(0,5) in arbitrary Mongo order — a 40-pod member got five random rooms and the working pods never made the cut; pods now rank by most-recent message (one PG GROUP BY, graceful degrade) with the bounded fetch over the ranked top 12. (2) commonly-bot's 95-update task-echo owned the recap; system bots excluded. (3) 'Waiting on you' had one wired fact source (mentions, empty via TASK-070's bare-name gap); new /decision-queue endpoint reads facts that exist — approvals, unacked mentions, DECIDE/blocked board rows, and latest-update human handoffs ('ready for your press') — with per-kind actions and fallback if the endpoint fails. 19 backend + 323 frontend green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK