### PR TITLE
fix(activity): rank query cast, grouping-layer bot exclusion, attention-ordered queue

### DIFF
--- a/backend/__tests__/unit/services/activityService.decisionQueue.test.js
+++ b/backend/__tests__/unit/services/activityService.decisionQueue.test.js
@@ -97,6 +97,41 @@ describe('ActivityService.getDecisionQueue', () => {
     expect(approval.title).toContain('anvil');
   });
 
+  test('attention order beats recency: approval, press, mention, then standing decisions — capped at 12 with an honest total', async () => {
+    ActivityService.getPendingApprovals.mockResolvedValue([
+      { _id: 'act-1', content: 'approve?', podId: 'pod-1', createdAt: new Date('2026-08-20T00:00:00Z') },
+    ]);
+    ActivityService.getUserFeed.mockResolvedValue({
+      activities: [{
+        id: 'm-1', flags: { isMention: true }, actor: { name: 'anvil' }, preview: 'ping',
+        pod: { id: 'pod-1', name: 'Sprint HQ' }, timestamp: '2026-08-27T00:00:00.000Z',
+      }],
+      acknowledgedMentionIds: [],
+    });
+    const rows = [];
+    for (let i = 0; i < 13; i += 1) {
+      rows.push({
+        taskId: `TASK-${100 + i}`, podId: 'pod-1', status: 'blocked', title: `Old blocked ${i}`,
+        updates: [{ text: 'stuck', createdAt: new Date(`2026-08-2${i % 6}T0${i % 9}:00:00Z`) }],
+      });
+    }
+    rows.push({
+      taskId: 'TASK-059', podId: 'pod-1', status: 'claimed', title: 'Ledger',
+      updates: [{ text: 'held for the human merge press', createdAt: new Date('2026-08-19T00:00:00Z') }],
+    });
+    Task.find.mockReturnValue(taskChain(rows));
+
+    const result = await ActivityService.getDecisionQueue('u1');
+    expect(result.items).toHaveLength(12);
+    expect(result.count).toBe(16); // 1 approval + 1 mention + 13 blocked + 1 press
+    // Kind order wins over raw recency: the OLD approval and press outrank
+    // fresher blocked rows.
+    expect(result.items[0].kind).toBe('approval');
+    expect(result.items[1].kind).toBe('press');
+    expect(result.items[2].kind).toBe('mention');
+    expect(result.items[3].kind).toBe('decision');
+  });
+
   test('one failed source degrades, never blanks the queue', async () => {
     ActivityService.getPendingApprovals.mockRejectedValue(new Error('store down'));
     Task.find.mockReturnValue(taskChain([

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -170,6 +170,10 @@ class ActivityService {
 
     activities
       .filter((activity) => activity.actor?.type === 'agent' || activity.flags?.isAgentAction)
+      // Defense at the GROUPING layer too: commonly-bot's task echoes arrive
+      // via stored Activity docs as well as messages, so filtering only the
+      // message source left the recap 100% system bot (#1306's live verify).
+      .filter((activity) => !SYSTEM_BOT_NAMES.has(String(activity.actor?.name || '').toLowerCase()))
       .forEach((activity) => {
         const actorId = String(activity.actor?.id || activity.actor?.name || 'unknown-agent');
         const name = activity.actor?.name || 'Agent';
@@ -406,8 +410,14 @@ class ActivityService {
       };
       if (!pool) return podIds;
       const ids = podIds.map((id) => String(id));
+      // ::text[] is load-bearing: without the cast Postgres cannot infer the
+      // array's type from `= ANY($1)` and rejects the query — which this
+      // function's catch silently degraded to the OLD arbitrary order, so
+      // the ranking shipped as a no-op (caught live on #1306's verify:
+      // recap still commonly-bot-only because the working pods still never
+      // made the fetch window).
       const { rows } = await pool.query(
-        'SELECT pod_id, MAX(created_at) AS latest FROM messages WHERE pod_id = ANY($1) GROUP BY pod_id ORDER BY latest DESC',
+        'SELECT pod_id, MAX(created_at) AS latest FROM messages WHERE pod_id = ANY($1::text[]) GROUP BY pod_id ORDER BY latest DESC',
         [ids],
       );
       const ranked = rows.map((r) => String(r.pod_id));
@@ -530,8 +540,20 @@ class ActivityService {
       console.warn('[decision-queue] board read failed:', (err as Error).message);
     }
 
-    items.sort((a, b) => new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime());
-    return { items, count: items.length };
+    // Attention order, then recency, then a hard cap. Approvals and presses
+    // are actionable in one click; mentions need a reply; standing decisions
+    // (incl. the old blocked backlog) come last — 32 undifferentiated rows
+    // is a wall, not a queue (#1306's live verify). The count still reports
+    // the full total so the cap is visible, not silent.
+    const KIND_PRIORITY: Record<string, number> = {
+      approval: 0, press: 1, mention: 2, decision: 3,
+    };
+    items.sort((a, b) => {
+      const kindDelta = (KIND_PRIORITY[a.kind] ?? 9) - (KIND_PRIORITY[b.kind] ?? 9);
+      if (kindDelta !== 0) return kindDelta;
+      return new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime();
+    });
+    return { items: items.slice(0, 12), count: items.length };
   }
 
   static async getPodFeed(


### PR DESCRIPTION
Live verification of #1306 caught its own gaps: the ANY($1) rank query needed ::text[] (silent fallback made ranking a no-op — the exact degrade-hides-failure trap the fallback was designed for), commonly-bot leaks via stored Activity docs so exclusion moves to the recap grouping layer, and the 32-row queue gets attention ordering (approval > press > mention > decisions) with a 12-row cap and honest total. 20/20 backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK