### PR TITLE
fix(activity): the recap shows real seats — PG is_bot read + agents filter on the feed budget

### DIFF
--- a/backend/__tests__/unit/services/activityService.recap.test.js
+++ b/backend/__tests__/unit/services/activityService.recap.test.js
@@ -77,7 +77,10 @@ describe('ActivityService.getRecap', () => {
       taskId: 'TASK-068', title: 'Activity tab', status: 'claimed',
       lastUpdate: expect.objectContaining({ text: 'Implementation began.' }),
     })]);
-    expect(spy).toHaveBeenCalledWith(ownerId, { limit: 100 });
+    // filter: 'agents' is load-bearing — without it the 100-slot budget was
+    // consumed entirely by summary activities and no agent message ever
+    // reached the recap grouping (measured live: 30/30 summaries, #1307).
+    expect(spy).toHaveBeenCalledWith(ownerId, { limit: 100, filter: 'agents' });
     expect(Pod.find).toHaveBeenCalledWith(expect.objectContaining({ $or: expect.any(Array) }));
     expect(Task.find).toHaveBeenCalledWith(expect.objectContaining({
       podId: { $in: ['pod-1'] }, updatedAt: { $gte: expect.any(Date) },

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -141,7 +141,11 @@ class ActivityService {
     }
 
     const scopedPodIds = new Set(scopedPods.map((pod) => String(pod._id)));
-    const feed = await ActivityService.getUserFeed(userId, { limit: 100 });
+    // filter: 'agents' — the recap is about agent WORK. Without it, the
+    // 100-slot feed budget was consumed entirely by `summary` activities
+    // (30/30 measured live), which are newer and more numerous than any
+    // message, so zero agent messages ever reached the grouping below.
+    const feed = await ActivityService.getUserFeed(userId, { limit: 100, filter: 'agents' });
     const activities = ((feed.activities as ActivityItem[] | undefined) || []).filter((activity) => {
       const timestamp = activity.timestamp ? new Date(activity.timestamp).getTime() : 0;
       return timestamp >= since.getTime()
@@ -812,7 +816,13 @@ class ActivityService {
       messages.forEach((msg) => {
         const userId = msg.userId as Record<string, unknown> | undefined;
         const authorName = (msg.username as string) || (userId?.username as string) || 'Unknown';
-        const isAgent = userId?.isBot === true || ActivityService.isAgentUsername(authorName);
+        // PG rows carry `is_bot` as a COLUMN; only Mongo rows populate the
+        // userId object. Checking only `userId?.isBot` classified every
+        // PG-authored agent message as human, and the agent-only recap
+        // dropped all of them (#1307's live verify: recap empty).
+        const isAgent = msg.is_bot === true
+          || userId?.isBot === true
+          || ActivityService.isAgentUsername(authorName);
 
         // System plumbing is not activity (TASK-083 defect 2).
         if (SYSTEM_BOT_NAMES.has(authorName.toLowerCase())) return;


### PR DESCRIPTION
Third verify-fix loop on the Activity data path: PG rows carry is_bot as a column (the classifier only read Mongo's userId.isBot, so every PG-authored agent message counted as human and the agent-only recap dropped them all), and summary activities consumed the entire 100-slot feed budget (30/30 measured live) before any message arrived — filter:'agents' skips summary fetching so the budget reaches agent messages. 20/20 backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK