### PR TITLE
fix(activity): String(podId) at the PG boundary — message activities were empty since the path shipped

### DIFF
--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -790,8 +790,16 @@ class ActivityService {
           // caller (getUserFeed) now ranks podIds by recent message time
           // before this runs; the slice widens to the ranked top 12, which
           // bounds the fan-out while guaranteeing the ACTIVE rooms are in.
+          // String(podId) is the WHOLE fix for a bug older than this file's
+          // v2 rework: callers pass Mongo ObjectId OBJECTS, and pg serializes
+          // an object into something that matches no VARCHAR pod_id — zero
+          // rows, silently, for every pod, forever. Message activities have
+          // been empty since this path shipped; the summary flood and bot
+          // noise the earlier TASK-083 fixes removed were just what grew in
+          // the vacuum. (Verified live: findByPodId(oid) -> 0 rows,
+          // findByPodId(String(oid)) -> rows.)
           const podMessagesList = await Promise.all(
-            podIds.slice(0, 12).map((podId) => (PGMessage as { findByPodId(id: unknown, limit: number): Promise<unknown[]> }).findByPodId(podId, limit)),
+            podIds.slice(0, 12).map((podId) => (PGMessage as { findByPodId(id: unknown, limit: number): Promise<unknown[]> }).findByPodId(String(podId), limit)),
           );
           messages = podMessagesList.flat() as Array<Record<string, unknown>>;
         } catch (e) {


### PR DESCRIPTION
The root of the whole Activity saga: findByPodId(ObjectId) silently returns 0 rows while findByPodId(String(oid)) returns data — verified live both ways. getUserFeed always passed raw _ids, so message activities were empty on v1 and v2 alike; every earlier symptom was scar tissue around this. One-line stringify at the PG call site only (Mongo $in queries elsewhere require the ObjectIds). 20/20 backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK