### PR TITLE
fix(telegram): first-run defaults — mirror mode + /mode teaching in Connected reply

### DIFF
--- a/backend/__tests__/unit/routes/integrations.linkedUserId.test.js
+++ b/backend/__tests__/unit/routes/integrations.linkedUserId.test.js
@@ -20,7 +20,11 @@ jest.mock('../../../models/DiscordIntegration', () => function DiscordIntegratio
 });
 jest.mock('../../../services/discordService', () => jest.fn());
 jest.mock('../../../models/Integration', () => {
-  function Integration(data) { Object.assign(this, data); }
+  function Integration(data) {
+    Object.assign(this, data);
+    this._id = this._id || 'integration-new';
+    this.save = jest.fn().mockResolvedValue(this);
+  }
   Integration.findById = jest.fn();
   Integration.findByIdAndUpdate = jest.fn();
   Integration.aggregate = jest.fn().mockResolvedValue([]);
@@ -87,5 +91,36 @@ describe('PATCH /api/integrations/:id — linkedUserId guard', () => {
     const [, update] = Integration.findByIdAndUpdate.mock.calls[0];
     expect(update.config.liveRelay).toBe(false);
     expect(update.config.linkedUserId).toBeUndefined();
+  });
+});
+
+describe('POST /api/integrations — telegram first-run defaults', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const User = require('../../../models/User');
+    User.findById.mockResolvedValue({ _id: 'user-1', role: 'member' });
+  });
+
+  // A fresh connector must never default into the silence trap: attention
+  // mode with no lead configured relays nothing, so mirror is the first-run
+  // default and the Connected message teaches /mode attention.
+  it('defaults a new telegram connector to liveRelay + mirror', async () => {
+    const Integration = require('../../../models/Integration');
+    const res = await request(app)
+      .post('/api/integrations')
+      .send({ podId: 'pod-1', type: 'telegram', config: {} });
+    expect(res.status).toBe(201);
+    const created = res.body.integration;
+    expect(created.config.relayAllAgentMessages).toBe(true);
+    expect(created.config.liveRelay).toBe(true);
+    expect(created.config.connectCode).toBeTruthy();
+  });
+
+  it('respects an explicit attention-mode choice at create', async () => {
+    const res = await request(app)
+      .post('/api/integrations')
+      .send({ podId: 'pod-1', type: 'telegram', config: { relayAllAgentMessages: false } });
+    expect(res.status).toBe(201);
+    expect(res.body.integration.config.relayAllAgentMessages).toBe(false);
   });
 });

--- a/backend/routes/integrations.ts
+++ b/backend/routes/integrations.ts
@@ -240,6 +240,14 @@ router.post('/', auth, async (req: AuthReq, res: Res) => {
     if (!manifest) return res.status(400).json({ message: 'Unsupported integration type' });
     const nextConfig = { ...config };
     if (type === 'telegram' && !nextConfig.connectCode) nextConfig.connectCode = crypto.randomBytes(3).toString('hex');
+    // First-run default: mirror. A fresh connector has no leadAgentUsername
+    // and its agents use no escalation markers, so attention mode relays
+    // NOTHING — a new user's first experience of the bridge would be silence.
+    // Mirror shows everything; the Connected message teaches /mode attention.
+    if (type === 'telegram' && nextConfig.relayAllAgentMessages === undefined) {
+      nextConfig.relayAllAgentMessages = true;
+      if (nextConfig.liveRelay === undefined) nextConfig.liveRelay = true;
+    }
     const missingRequired = getMissingRequiredFields(type, nextConfig);
     if (type === 'discord' && missingRequired.length) return res.status(400).json({ message: `Missing required fields: ${missingRequired.join(', ')}`, missing: missingRequired });
     if (missingRequired.length && (req.body as { status?: string })?.status === 'connected') return res.status(400).json({ message: `Missing required fields: ${missingRequired.join(', ')}`, missing: missingRequired });

--- a/backend/routes/webhooks/telegram.ts
+++ b/backend/routes/webhooks/telegram.ts
@@ -116,7 +116,9 @@ const handleEnableCommand = async (chat: any, code: any) => {
   await telegramService.sendMessage(
     botToken,
     chatId,
-    `✅ Connected this chat to <b>${podName}</b> in Commonly.`,
+    `✅ Connected this chat to <b>${podName}</b> in Commonly.\n`
+    + 'Agent messages from the pod will appear here. Too chatty? Send '
+    + '/mode attention to only get what needs you. /help lists the rest.',
   );
 };
 


### PR DESCRIPTION
First-impression audit finding (the David-walks-in path): a fresh connector defaults into the silence trap — attention mode with no lead agent set relays only marker lines, and a new user's agents use no markers. Their first experience of the flagship feature is silence.

- New telegram connectors default to liveRelay:true + relayAllAgentMessages:true (mirror) — see everything first, quiet it second
- The bot's Connected message now teaches the escape hatch in the moment: 'Too chatty? Send /mode attention…'
- Explicit config at create is respected; existing rows untouched

2 new route tests (default + explicit-choice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pc6nGXRS8mHvrwcXMSRDK