### PR TITLE
feat(auth): AgentCredential substrate — ADR-026 Phase 0

### DIFF
--- a/backend/__tests__/services/agentWebSocketService.test.js
+++ b/backend/__tests__/services/agentWebSocketService.test.js
@@ -10,9 +10,18 @@ jest.mock('../../models/User', () => ({
   updateOne: jest.fn(),
 }));
 
+// ADR-026 Phase 0: WS validation consults the credential ledger first.
+// Default null = legacy token with no row (the fallback the older cases
+// exercise); the revoked-credential case overrides per test.
+jest.mock('../../models/AgentCredential', () => ({
+  findOne: jest.fn().mockResolvedValue(null),
+  findById: jest.fn().mockResolvedValue(null),
+}));
+
 const { hash } = require('../../utils/secret');
 let AgentInstallation = require('../../models/AgentRegistry').AgentInstallation;
 let User = require('../../models/User');
+let AgentCredential = require('../../models/AgentCredential');
 
 describe('agentWebSocketService', () => {
   let agentWebSocketService;
@@ -25,9 +34,28 @@ describe('agentWebSocketService', () => {
     // Re-grab mock references after resetModules to avoid reference drift
     AgentInstallation = require('../../models/AgentRegistry').AgentInstallation;
     User = require('../../models/User');
+    AgentCredential = require('../../models/AgentCredential');
+    AgentCredential.findOne.mockResolvedValue(null);
+    AgentCredential.findById.mockResolvedValue(null);
   });
 
   describe('validateAgentToken', () => {
+    it('rejects a token whose credential row is revoked (ledger gates WS too)', async () => {
+      AgentCredential.findOne.mockResolvedValue({ _id: 'cred-1', status: 'revoked' });
+      const result = await agentWebSocketService.validateAgentToken('cm_agent_revokedtoken');
+      expect(result).toBeNull();
+      expect(User.findOne).not.toHaveBeenCalled();
+    });
+
+    it('rejects a child token whose issuing credential is revoked', async () => {
+      AgentCredential.findOne.mockResolvedValue({ _id: 'cred-2', status: 'active', parentId: 'daemon-1' });
+      AgentCredential.findById.mockReturnValue({
+        select: () => ({ lean: () => Promise.resolve({ status: 'revoked' }) }),
+      });
+      const result = await agentWebSocketService.validateAgentToken('cm_agent_childtoken');
+      expect(result).toBeNull();
+    });
+
     it('validates cm_agent tokens using hashed runtime tokens', async () => {
       User.findOne.mockResolvedValue(null);
       AgentInstallation.findOne.mockResolvedValue({

--- a/backend/__tests__/unit/middleware/agentRuntimeAuth.test.js
+++ b/backend/__tests__/unit/middleware/agentRuntimeAuth.test.js
@@ -30,6 +30,16 @@ jest.mock('../../../models/User', () => {
   User.updateOne = (...args) => mockUserUpdateOne(...args);
   return User;
 });
+// ADR-026 Phase 0: the middleware consults AgentCredential before the
+// legacy paths. Default to no credential row — these tests exercise the
+// legacy fallback; the credential paths have their own suite
+// (agentCredential.substrate.test.js on mongodb-memory-server).
+jest.mock('../../../models/AgentCredential', () => ({
+  findOne: jest.fn().mockResolvedValue(null),
+  findById: jest.fn().mockResolvedValue(null),
+  updateOne: jest.fn().mockResolvedValue({}),
+}));
+
 jest.mock('../../../models/AgentRegistry', () => ({
   AgentInstallation: {
     findOne: (...args) => mockInstallationFindOne(...args),

--- a/backend/__tests__/unit/services/agentCredential.substrate.test.js
+++ b/backend/__tests__/unit/services/agentCredential.substrate.test.js
@@ -1,0 +1,110 @@
+// ADR-026 Phase 0 invariants, pinned against mongodb-memory-server:
+// lineage-aware auth (a child of a revoked parent is dead even though the
+// bearer string is intact), cascade revocation, and the legacy fallback
+// (embedded-only tokens keep working — the additive-migration guarantee).
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const mongoose = require('mongoose');
+
+jest.mock('../../../middleware/auth', () => {
+  const touchLastActive = jest.fn();
+  const mw = (req, res, next) => { req.user = { id: 'user-1' }; next(); };
+  mw.touchLastActive = touchLastActive;
+  return mw;
+});
+
+const { hash } = require('../../../utils/secret');
+
+let mongod;
+let AgentCredential;
+let User;
+let agentRuntimeAuth;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  AgentCredential = require('../../../models/AgentCredential');
+  User = require('../../../models/User');
+  agentRuntimeAuth = require('../../../middleware/agentRuntimeAuth').default;
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+const makeRes = () => {
+  const res = { statusCode: 200, body: null };
+  res.status = (c) => { res.statusCode = c; return res; };
+  res.json = (b) => { res.body = b; return res; };
+  return res;
+};
+
+const runAuth = async (rawToken) => {
+  const req = { header: (h) => (h === 'Authorization' ? `Bearer ${rawToken}` : undefined) };
+  const res = makeRes();
+  let nexted = false;
+  await agentRuntimeAuth(req, res, () => { nexted = true; });
+  return { req, res, nexted };
+};
+
+const makeBot = async (rawToken) => User.create({
+  username: `bot-${Math.random().toString(36).slice(2, 8)}`,
+  email: `${Math.random().toString(36).slice(2, 8)}@agents.commonly.local`,
+  password: 'x'.repeat(12),
+  isBot: true,
+  botMetadata: { agentName: 'testbot', instanceId: 'default' },
+  agentRuntimeTokens: [{ tokenHash: hash(rawToken), label: 't', createdAt: new Date() }],
+});
+
+describe('AgentCredential substrate', () => {
+  it('legacy embedded-only tokens still authenticate (additive guarantee)', async () => {
+    const raw = `cm_agent_${'l'.repeat(32)}`;
+    await makeBot(raw);
+    const { nexted } = await runAuth(raw);
+    expect(nexted).toBe(true);
+  });
+
+  it('a revoked credential is rejected even though the embedded hash remains', async () => {
+    const raw = `cm_agent_${'r'.repeat(32)}`;
+    const bot = await makeBot(raw);
+    const cred = await AgentCredential.create({
+      tokenHash: hash(raw), kind: 'runtime', ownerUserId: bot._id, agentUserId: bot._id,
+    });
+    expect((await runAuth(raw)).nexted).toBe(true);
+    await AgentCredential.revokeCascade(cred._id);
+    const { res, nexted } = await runAuth(raw);
+    expect(nexted).toBe(false);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('a child of a revoked daemon credential is rejected — lineage enforced at auth', async () => {
+    const raw = `cm_agent_${'c'.repeat(32)}`;
+    const bot = await makeBot(raw);
+    const daemon = await AgentCredential.create({
+      tokenHash: hash(`cm_daemon_${'d'.repeat(32)}`), kind: 'daemon', ownerUserId: bot._id, machineId: 'm1',
+    });
+    await AgentCredential.create({
+      tokenHash: hash(raw), kind: 'runtime', ownerUserId: bot._id, agentUserId: bot._id, parentId: daemon._id,
+    });
+    expect((await runAuth(raw)).nexted).toBe(true);
+    await AgentCredential.updateOne({ _id: daemon._id }, { $set: { status: 'revoked', revokedAt: new Date() } });
+    const { res, nexted } = await runAuth(raw);
+    expect(nexted).toBe(false);
+    expect(res.statusCode).toBe(401);
+    expect(res.body.message).toMatch(/Issuing credential revoked/);
+  });
+
+  it('revokeCascade revokes the parent and every descendant', async () => {
+    const owner = new mongoose.Types.ObjectId();
+    const daemon = await AgentCredential.create({
+      tokenHash: hash(`cm_daemon_${'x'.repeat(32)}`), kind: 'daemon', ownerUserId: owner, machineId: 'm2',
+    });
+    const kids = await Promise.all([1, 2, 3].map((i) => AgentCredential.create({
+      tokenHash: hash(`cm_agent_${String(i).repeat(32)}`), kind: 'runtime', ownerUserId: owner, parentId: daemon._id,
+    })));
+    const revoked = await AgentCredential.revokeCascade(daemon._id);
+    expect(revoked).toBe(4);
+    const after = await AgentCredential.find({ _id: { $in: [daemon._id, ...kids.map((k) => k._id)] } });
+    expect(after.every((c) => c.status === 'revoked')).toBe(true);
+  });
+});

--- a/backend/middleware/agentRuntimeAuth.ts
+++ b/backend/middleware/agentRuntimeAuth.ts
@@ -6,6 +6,7 @@ import User, { IUser } from '../models/User';
 // its creation date, so profiles/rosters show working agents as never active.
 import { touchLastActive } from './auth';
 import Pod from '../models/Pod';
+import AgentCredential from '../models/AgentCredential';
 
 // eslint-disable-next-line global-require
 const { hash } = require('../utils/secret') as { hash: (value: string) => string };
@@ -57,6 +58,29 @@ export default async function agentRuntimeAuth(req: Request, res: Response, next
     }
 
     const tokenHash = hash(token);
+
+    // ADR-026 Phase 0: the credential collection is consulted FIRST. A
+    // credential-backed token enforces status + expiry + issuer lineage —
+    // a child whose parent daemon credential is revoked is dead, even
+    // though the bearer string itself is intact. Legacy embedded tokens
+    // (no credential row) fall through to the original path unchanged.
+    const credential = await AgentCredential.findOne({ tokenHash, kind: 'runtime' });
+    if (credential) {
+      if (credential.status !== 'active') {
+        return res.status(401).json({ message: 'Token revoked' });
+      }
+      if (credential.expiresAt && credential.expiresAt < new Date()) {
+        return res.status(401).json({ message: 'Session token expired' });
+      }
+      if (credential.parentId) {
+        const parent = await AgentCredential.findById(credential.parentId).select('status').lean();
+        if (!parent || parent.status !== 'active') {
+          return res.status(401).json({ message: 'Issuing credential revoked' });
+        }
+      }
+      AgentCredential.updateOne({ _id: credential._id }, { $set: { lastUsedAt: new Date() } })
+        .catch((err: Error) => console.warn('Failed to update credential usage:', err.message));
+    }
 
     const agentUser = await User.findOne({
       'agentRuntimeTokens.tokenHash': tokenHash,

--- a/backend/models/AgentCredential.ts
+++ b/backend/models/AgentCredential.ts
@@ -1,0 +1,87 @@
+// ADR-026 Phase 0: the credential substrate. Per-token records with issuer
+// lineage and cascade revocation — the thing the embedded
+// User.agentRuntimeTokens hash-list cannot express (review on #1310: on the
+// embedded model, revoking an issuer leaves its minted children live, and a
+// removed machine keeps operating its agents).
+//
+// Additive by design: agentRuntimeAuth consults this collection FIRST and
+// falls back to the embedded records, so every existing token keeps working
+// untouched. New mints dual-write here; nothing migrates destructively.
+import mongoose, { Document, Schema, Types } from 'mongoose';
+
+export type AgentCredentialKind = 'runtime' | 'daemon';
+export type AgentCredentialStatus = 'active' | 'revoked';
+
+export interface IAgentCredential extends Document {
+  tokenHash: string;
+  kind: AgentCredentialKind;
+  // The human who authorized this credential's existence.
+  ownerUserId: Types.ObjectId;
+  // runtime: the bot User this token authenticates as. daemon: null.
+  agentUserId?: Types.ObjectId | null;
+  // ADR-026 D3: set for daemon credentials and for runtime tokens minted by
+  // a daemon. Server-assigned, never trusted from a caller.
+  machineId?: string | null;
+  // Issuer lineage (D4.5): a runtime token minted by a daemon carries that
+  // daemon credential's id. Auth rejects a child whose parent is revoked.
+  parentId?: Types.ObjectId | null;
+  label?: string;
+  scopes: string[];
+  status: AgentCredentialStatus;
+  createdAt: Date;
+  lastUsedAt?: Date | null;
+  expiresAt?: Date | null;
+  revokedAt?: Date | null;
+}
+
+const AgentCredentialSchema = new Schema<IAgentCredential>(
+  {
+    tokenHash: { type: String, required: true, unique: true },
+    kind: { type: String, required: true, enum: ['runtime', 'daemon'] },
+    ownerUserId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    agentUserId: { type: Schema.Types.ObjectId, ref: 'User', default: null },
+    machineId: { type: String, default: null },
+    parentId: { type: Schema.Types.ObjectId, ref: 'AgentCredential', default: null },
+    label: { type: String },
+    scopes: { type: [String], default: [] },
+    status: { type: String, enum: ['active', 'revoked'], default: 'active' },
+    lastUsedAt: { type: Date, default: null },
+    expiresAt: { type: Date, default: null },
+    revokedAt: { type: Date, default: null },
+  },
+  { timestamps: true, collection: 'agentcredentials' },
+);
+
+AgentCredentialSchema.index({ ownerUserId: 1, status: 1 });
+AgentCredentialSchema.index({ parentId: 1 });
+AgentCredentialSchema.index({ agentUserId: 1 });
+
+// Revoke a credential AND every descendant, breadth-first. One level deep
+// today (daemon → runtime), but written as a walk so a deeper chain can
+// never orphan a live child.
+AgentCredentialSchema.statics.revokeCascade = async function revokeCascade(
+  credentialId: Types.ObjectId | string,
+): Promise<number> {
+  const now = new Date();
+  let frontier: (Types.ObjectId | string)[] = [credentialId];
+  let revoked = 0;
+  while (frontier.length) {
+    const res = await this.updateMany(
+      { _id: { $in: frontier }, status: 'active' },
+      { $set: { status: 'revoked', revokedAt: now } },
+    );
+    revoked += res.modifiedCount || 0;
+    const children = await this.find({ parentId: { $in: frontier } }).select('_id').lean();
+    frontier = children.map((c: { _id: Types.ObjectId }) => c._id);
+  }
+  return revoked;
+};
+
+export interface AgentCredentialModel extends mongoose.Model<IAgentCredential> {
+  revokeCascade(credentialId: Types.ObjectId | string): Promise<number>;
+}
+
+export default mongoose.model<IAgentCredential, AgentCredentialModel>('AgentCredential', AgentCredentialSchema);
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/routes/credentials.ts
+++ b/backend/routes/credentials.ts
@@ -1,0 +1,50 @@
+// ADR-026 Phase 0: credential listing + revocation. Revocation cascades to
+// every descendant (daemon → minted runtime tokens) — the property the
+// embedded token records could never provide. Owner or instance admin only.
+import express from 'express';
+import { Types } from 'mongoose';
+import AgentCredential from '../models/AgentCredential';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const auth = require('../middleware/auth');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const User = require('../models/User');
+
+const router = express.Router();
+
+type AuthReq = express.Request & { user?: { id?: string } };
+
+router.get('/', auth, async (req: AuthReq, res: express.Response) => {
+  try {
+    const rows = await AgentCredential.find({ ownerUserId: req.user?.id })
+      .select('-tokenHash')
+      .sort({ createdAt: -1 })
+      .lean();
+    return res.json(rows);
+  } catch (err) {
+    console.error('Error listing credentials:', err);
+    return res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.delete('/:id', auth, async (req: AuthReq, res: express.Response) => {
+  try {
+    const { id } = req.params;
+    if (!Types.ObjectId.isValid(id)) return res.status(400).json({ message: 'Invalid credential id' });
+    const credential = await AgentCredential.findById(id);
+    if (!credential) return res.status(404).json({ message: 'Credential not found' });
+    const caller = await User.findById(req.user?.id).select('role').lean();
+    const isOwner = String(credential.ownerUserId) === String(req.user?.id);
+    if (!isOwner && caller?.role !== 'admin') {
+      return res.status(403).json({ message: 'Access denied' });
+    }
+    const revoked = await AgentCredential.revokeCascade(credential._id as Types.ObjectId);
+    return res.json({ revoked });
+  } catch (err) {
+    console.error('Error revoking credential:', err);
+    return res.status(500).json({ message: 'Server error' });
+  }
+});
+
+module.exports = router;
+export {};

--- a/backend/routes/credentials.ts
+++ b/backend/routes/credentials.ts
@@ -3,6 +3,10 @@
 // embedded token records could never provide. Owner or instance admin only.
 import express from 'express';
 import { Types } from 'mongoose';
+// ESM import (not require) so CodeQL's js/missing-rate-limiting query
+// recognizes the limiter (same pattern as routes/messages.ts).
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import { createHash } from 'crypto';
 import AgentCredential from '../models/AgentCredential';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -12,9 +16,28 @@ const User = require('../models/User');
 
 const router = express.Router();
 
+// Token-hash/IP keyed, same shape as the messages read limiter. Credential
+// operations are rare; tight caps are free safety.
+const credentialRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req: { get?: (h: string) => string | undefined; ip?: string }) => {
+    const authHeader = req.get?.('authorization');
+    if (authHeader) {
+      return `tok:${createHash('sha256').update(authHeader).digest('hex').slice(0, 16)}`;
+    }
+    return req.ip ? ipKeyGenerator(req.ip) : 'anon';
+  },
+  handler: (_req: unknown, res: { status: (n: number) => { json: (b: unknown) => void } }) => {
+    res.status(429).json({ msg: 'rate limit exceeded: 60 credential ops per 60s' });
+  },
+});
+
 type AuthReq = express.Request & { user?: { id?: string } };
 
-router.get('/', auth, async (req: AuthReq, res: express.Response) => {
+router.get('/', credentialRateLimit, auth, async (req: AuthReq, res: express.Response) => {
   try {
     const rows = await AgentCredential.find({ ownerUserId: req.user?.id })
       .select('-tokenHash')
@@ -27,7 +50,7 @@ router.get('/', auth, async (req: AuthReq, res: express.Response) => {
   }
 });
 
-router.delete('/:id', auth, async (req: AuthReq, res: express.Response) => {
+router.delete('/:id', credentialRateLimit, auth, async (req: AuthReq, res: express.Response) => {
   try {
     const { id } = req.params;
     if (!Types.ObjectId.isValid(id)) return res.status(400).json({ message: 'Invalid credential id' });

--- a/backend/routes/registry/provision.ts
+++ b/backend/routes/registry/provision.ts
@@ -184,6 +184,7 @@ provisionRouter.post('/pods/:podId/agents/:name/provision', provisionRateLimit, 
       agentUser,
       label || `Provisioned ${normalizedInstanceId}`,
       installation,
+      { ownerUserId: req.user?.id || req.user?._id },
     );
 
     if (runtimeIssued.existing && force) {
@@ -192,6 +193,7 @@ provisionRouter.post('/pods/:podId/agents/:name/provision', provisionRateLimit, 
         agentUser,
         label || `Provisioned ${normalizedInstanceId}`,
         installation,
+        { ownerUserId: req.user?.id || req.user?._id },
       );
       Object.assign(runtimeIssued, freshToken);
     }

--- a/backend/routes/registry/tokens.ts
+++ b/backend/routes/registry/tokens.ts
@@ -53,7 +53,12 @@ const normalizeContextPolicy = (policy: any) => {
  * @param {Object} installation - Optional installation to also store token on (for backward compat)
  * @returns {Object} - { token, label, existing, createdAt }
  */
-const issueRuntimeTokenForAgent = async (agentUser: any, label: any, installation: any = null) => {
+// issuer (ADR-026 Phase 0): { ownerUserId, parentId?, machineId? } — when
+// present, the mint dual-writes an AgentCredential row alongside the legacy
+// embedded record, giving the token per-record status, lineage, and
+// revocability. Callers that do not pass it keep minting legacy-only tokens
+// (additive migration; auth falls back for those).
+const issueRuntimeTokenForAgent = async (agentUser: any, label: any, installation: any = null, issuer: any = null) => {
   // Check if agent already has a runtime token (reuse existing)
   if (agentUser.agentRuntimeTokens?.length > 0) {
     const existingToken = agentUser.agentRuntimeTokens[0];
@@ -78,6 +83,24 @@ const issueRuntimeTokenForAgent = async (agentUser: any, label: any, installatio
   agentUser.agentRuntimeTokens = agentUser.agentRuntimeTokens || [];
   agentUser.agentRuntimeTokens.push(tokenRecord);
   await agentUser.save();
+
+  if (issuer?.ownerUserId) {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const AgentCredential = require('../../models/AgentCredential');
+    try {
+      await AgentCredential.create({
+        tokenHash: tokenRecord.tokenHash,
+        kind: 'runtime',
+        ownerUserId: issuer.ownerUserId,
+        agentUserId: agentUser._id,
+        parentId: issuer.parentId || null,
+        machineId: issuer.machineId || null,
+        label: tokenRecord.label,
+      });
+    } catch (err) {
+      console.warn('AgentCredential dual-write failed (token still valid via legacy path):', (err as Error).message);
+    }
+  }
 
   // Also store on installation for backward compatibility
   if (installation) {

--- a/backend/routes/registry/tokens.ts
+++ b/backend/routes/registry/tokens.ts
@@ -62,6 +62,27 @@ const issueRuntimeTokenForAgent = async (agentUser: any, label: any, installatio
   // Check if agent already has a runtime token (reuse existing)
   if (agentUser.agentRuntimeTokens?.length > 0) {
     const existingToken = agentUser.agentRuntimeTokens[0];
+    // Backfill a credential row for the pre-substrate token so the existing
+    // fleet becomes listable and cascade-revocable (Vera on #1312: without
+    // this the collection stays near-empty while coverage looks fine).
+    // Provenance is unknown, so no parent lineage is claimed.
+    if (issuer?.ownerUserId) {
+      // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+      const AgentCredential = require('../../models/AgentCredential');
+      await AgentCredential.updateOne(
+        { tokenHash: existingToken.tokenHash },
+        {
+          $setOnInsert: {
+            kind: 'runtime',
+            ownerUserId: issuer.ownerUserId,
+            agentUserId: agentUser._id,
+            label: existingToken.label || 'Runtime token',
+            status: 'active',
+          },
+        },
+        { upsert: true },
+      ).catch((err: Error) => console.warn('Credential backfill failed:', err.message));
+    }
     return {
       existing: true,
       label: existingToken.label,
@@ -79,28 +100,29 @@ const issueRuntimeTokenForAgent = async (agentUser: any, label: any, installatio
     createdAt: new Date(),
   };
 
+  // Credential row FIRST, then the embedded record (Vera on #1312:
+  // warn-and-continue after issuing would hand out a working token with no
+  // row — invisible to listing, unreachable by cascade, lineage-free. If
+  // the ledger write fails, the mint fails; no token exists without a row
+  // when an issuer is known).
+  if (issuer?.ownerUserId) {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const AgentCredential = require('../../models/AgentCredential');
+    await AgentCredential.create({
+      tokenHash: tokenRecord.tokenHash,
+      kind: 'runtime',
+      ownerUserId: issuer.ownerUserId,
+      agentUserId: agentUser._id,
+      parentId: issuer.parentId || null,
+      machineId: issuer.machineId || null,
+      label: tokenRecord.label,
+    });
+  }
+
   // Store on User model (primary - shared across pods)
   agentUser.agentRuntimeTokens = agentUser.agentRuntimeTokens || [];
   agentUser.agentRuntimeTokens.push(tokenRecord);
   await agentUser.save();
-
-  if (issuer?.ownerUserId) {
-    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
-    const AgentCredential = require('../../models/AgentCredential');
-    try {
-      await AgentCredential.create({
-        tokenHash: tokenRecord.tokenHash,
-        kind: 'runtime',
-        ownerUserId: issuer.ownerUserId,
-        agentUserId: agentUser._id,
-        parentId: issuer.parentId || null,
-        machineId: issuer.machineId || null,
-        label: tokenRecord.label,
-      });
-    } catch (err) {
-      console.warn('AgentCredential dual-write failed (token still valid via legacy path):', (err as Error).message);
-    }
-  }
 
   // Also store on installation for backward compatibility
   if (installation) {

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -211,6 +211,7 @@ app.use('/api/analytics', analyticsRoutes);
 app.use('/api/v1', contextApiRoutes); // Context API for MCP and external agents
 app.use('/api/v1/tasks', tasksApiRoutes); // Task management for dev agents
 app.use('/api/registry', registryRoutes); // Agent Registry (package manager for agents)
+app.use('/api/credentials', require('./routes/credentials')); // ADR-026 Phase 0: credential lineage + revocation
 app.use('/api/agents/runtime', agentsRuntimeRoutes); // Runtime endpoints for external agents
 app.use('/api/federation', federationRoutes); // Cross-pod federation
 app.use('/api/providers/moltbot', moltbotProviderRoutes); // Moltbot provider integration

--- a/backend/services/agentWebSocketService.ts
+++ b/backend/services/agentWebSocketService.ts
@@ -304,6 +304,21 @@ class AgentWebSocketService {
     if (token.startsWith('cm_agent_')) {
       try {
         const tokenHash = hash(token);
+        // ADR-026 Phase 0: the credential ledger gates the WS transport with
+        // the same semantics as the HTTP middleware — a revoked credential
+        // (or a child of a revoked issuer) must not connect over WS either
+        // (Vera's bypass finding on #1312).
+        // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+        const AgentCredential = require('../models/AgentCredential');
+        const credential = await AgentCredential.findOne({ tokenHash, kind: 'runtime' });
+        if (credential) {
+          if (credential.status !== 'active') return null;
+          if (credential.expiresAt && credential.expiresAt < new Date()) return null;
+          if (credential.parentId) {
+            const parent = await AgentCredential.findById(credential.parentId).select('status').lean();
+            if (!parent || parent.status !== 'active') return null;
+          }
+        }
         const agentUser = await User.findOne({
           'agentRuntimeTokens.tokenHash': tokenHash,
           isBot: true,


### PR DESCRIPTION
The token substrate the #1310 review made a hard prerequisite, additive by design:

- **AgentCredential collection**: per-token records — kind (runtime|daemon), owner, agent identity, machineId, parentId lineage, scopes, status
- **Auth**: consults the collection FIRST — active status, expiry, and **parent-revocation rejection** (a runtime token minted by a revoked daemon credential is dead even though the bearer string is intact) — then falls back to legacy embedded tokens unchanged
- **revokeCascade**: breadth-first descendant walk, so revoking a daemon credential kills everything it minted
- **Dual-write at mint** (provision path wired; other call sites keep legacy-only until touched)
- **GET/DELETE /api/credentials**: list own, revoke with cascade (owner or admin)

4 invariant tests on mongodb-memory-server: legacy fallback, revoked-credential rejection, lineage rejection, cascade completeness.

Phase 1 (machine rows, CAS adoption, daemon mint) builds on this. @vera's D4 threat model is the reference: this PR is the 'nothing to build on' blocker cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pc6nGXRS8mHvrwcXMSRDK