### PR TITLE
feat(daemon): adoption CAS + daemon auth — ADR-026 D3 (Phase 1 S2)

### DIFF
--- a/backend/__tests__/unit/routes/agentBinding.adoption.test.js
+++ b/backend/__tests__/unit/routes/agentBinding.adoption.test.js
@@ -1,0 +1,107 @@
+// ADR-026 D3 invariants on mongodb-memory-server: adoption is a CAS
+// (concurrent adopts produce exactly one winner and a clean 409), the
+// bound-agent predicate comes from the daemon credential (never the body),
+// ownership is enforced, and release is an explicit owner action.
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const mongoose = require('mongoose');
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../middleware/auth', () => {
+  const mw = (req, res, next) => { req.user = { id: global.__CALLER_ID }; next(); };
+  mw.touchLastActive = jest.fn();
+  return mw;
+});
+
+const { hash } = require('../../../utils/secret');
+
+let mongod; let app; let AgentCredential; let User; let AgentInstallation;
+const DAEMON_A = `cm_daemon_${'a'.repeat(32)}`;
+const DAEMON_B = `cm_daemon_${'b'.repeat(32)}`;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  AgentCredential = require('../../../models/AgentCredential');
+  User = require('../../../models/User');
+  AgentInstallation = require('../../../models/AgentRegistry').AgentInstallation;
+  app = express();
+  app.use(express.json());
+  app.use('/api/agent-binding', require('../../../routes/agentBinding'));
+});
+
+afterAll(async () => { await mongoose.disconnect(); await mongod.stop(); });
+
+let owner; let bot;
+beforeEach(async () => {
+  await Promise.all([
+    User.deleteMany({}), AgentCredential.deleteMany({}), AgentInstallation.deleteMany({}),
+  ]);
+  owner = await User.create({ username: `o${Date.now() % 1e6}`, email: `o${Date.now()}@x.com`, password: 'x'.repeat(12) });
+  global.__CALLER_ID = String(owner._id);
+  bot = await User.create({
+    username: `b${Date.now() % 1e6}`, email: `b${Date.now()}@agents.commonly.local`, password: 'x'.repeat(12),
+    isBot: true, botMetadata: { agentName: 'wren-test', instanceId: 'default' },
+  });
+  await AgentInstallation.create({
+    agentName: 'wren-test', instanceId: 'default', podId: new mongoose.Types.ObjectId(),
+    version: '1.0.0', status: 'active', installedBy: owner._id,
+  });
+  for (const [tok, mid] of [[DAEMON_A, 'machine-a'], [DAEMON_B, 'machine-b']]) {
+    await AgentCredential.create({ tokenHash: hash(tok), kind: 'daemon', ownerUserId: owner._id, machineId: mid });
+  }
+});
+
+const adopt = (tok) => request(app)
+  .post('/api/agent-binding/adopt')
+  .set('Authorization', `Bearer ${tok}`)
+  .send({ agentName: 'wren-test', instanceId: 'default' });
+
+describe('adoption CAS', () => {
+  it('adopts an unbound agent; machineId comes from the credential, not the body', async () => {
+    const res = await adopt(DAEMON_A);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ adopted: true, machineId: 'machine-a' });
+    const row = await User.findById(bot._id).lean();
+    expect(row.botMetadata.machineId).toBe('machine-a');
+  });
+
+  it('concurrent adopts: exactly one winner, loser gets 409 with the holder', async () => {
+    const [a, b] = await Promise.all([adopt(DAEMON_A), adopt(DAEMON_B)]);
+    const codes = [a.status, b.status].sort();
+    expect(codes).toEqual([200, 409]);
+    const loser = a.status === 409 ? a : b;
+    expect(loser.body.boundTo).toMatch(/machine-(a|b)/);
+  });
+
+  it('adopt is idempotent for the holding machine', async () => {
+    await adopt(DAEMON_A);
+    const again = await adopt(DAEMON_A);
+    expect(again.status).toBe(200);
+    expect(again.body.alreadyBound).toBe(true);
+  });
+
+  it('refuses adoption of an agent the daemon owner does not own', async () => {
+    const stranger = await User.create({ username: 'str', email: 's@x.com', password: 'x'.repeat(12) });
+    const tok = `cm_daemon_${'s'.repeat(32)}`;
+    await AgentCredential.create({ tokenHash: hash(tok), kind: 'daemon', ownerUserId: stranger._id, machineId: 'machine-s' });
+    const res = await adopt(tok);
+    expect(res.status).toBe(403);
+  });
+
+  it('a revoked daemon credential cannot adopt', async () => {
+    await AgentCredential.updateOne({ machineId: 'machine-a' }, { $set: { status: 'revoked' } });
+    const res = await adopt(DAEMON_A);
+    expect(res.status).toBe(401);
+  });
+
+  it('release (owner JWT) unbinds; a second machine can then adopt', async () => {
+    await adopt(DAEMON_A);
+    const rel = await request(app).post('/api/agent-binding/release')
+      .send({ agentName: 'wren-test', instanceId: 'default' });
+    expect(rel.status).toBe(200);
+    const res = await adopt(DAEMON_B);
+    expect(res.status).toBe(200);
+    expect(res.body.machineId).toBe('machine-b');
+  });
+});

--- a/backend/__tests__/unit/routes/agentBinding.adoption.test.js
+++ b/backend/__tests__/unit/routes/agentBinding.adoption.test.js
@@ -100,6 +100,18 @@ describe('adoption CAS', () => {
     expect(res.body.message).toMatch(/lacks scope/);
   });
 
+  it('sole-installer: an identity ALSO installed by someone else cannot be adopted (Vera ruling)', async () => {
+    const other = await User.create({ username: 'oth', email: 'oth@x.com', password: 'x'.repeat(12) });
+    await AgentInstallation.create({
+      agentName: 'wren-test', instanceId: 'default', podId: new mongoose.Types.ObjectId(),
+      version: '1.0.0', status: 'active', installedBy: other._id,
+    });
+    const res = await adopt(DAEMON_A);
+    expect(res.status).toBe(403);
+    const row = await User.findById(bot._id).lean();
+    expect(row.botMetadata.machineId ?? null).toBeNull();
+  });
+
   it('a revoked daemon credential cannot adopt', async () => {
     await AgentCredential.updateOne({ machineId: 'machine-a' }, { $set: { status: 'revoked' } });
     const res = await adopt(DAEMON_A);

--- a/backend/__tests__/unit/routes/agentBinding.adoption.test.js
+++ b/backend/__tests__/unit/routes/agentBinding.adoption.test.js
@@ -48,7 +48,7 @@ beforeEach(async () => {
     version: '1.0.0', status: 'active', installedBy: owner._id,
   });
   for (const [tok, mid] of [[DAEMON_A, 'machine-a'], [DAEMON_B, 'machine-b']]) {
-    await AgentCredential.create({ tokenHash: hash(tok), kind: 'daemon', ownerUserId: owner._id, machineId: mid });
+    await AgentCredential.create({ tokenHash: hash(tok), kind: 'daemon', ownerUserId: owner._id, machineId: mid, scopes: ['machine:heartbeat', 'agents:adopt'] });
   }
 });
 
@@ -84,9 +84,20 @@ describe('adoption CAS', () => {
   it('refuses adoption of an agent the daemon owner does not own', async () => {
     const stranger = await User.create({ username: 'str', email: 's@x.com', password: 'x'.repeat(12) });
     const tok = `cm_daemon_${'s'.repeat(32)}`;
-    await AgentCredential.create({ tokenHash: hash(tok), kind: 'daemon', ownerUserId: stranger._id, machineId: 'machine-s' });
+    await AgentCredential.create({ tokenHash: hash(tok), kind: 'daemon', ownerUserId: stranger._id, machineId: 'machine-s', scopes: ['machine:heartbeat', 'agents:adopt'] });
     const res = await adopt(tok);
     expect(res.status).toBe(403);
+  });
+
+  it('a heartbeat-only credential cannot adopt — scopes are enforced, not decorative', async () => {
+    const tok = `cm_daemon_${'h'.repeat(32)}`;
+    await AgentCredential.create({
+      tokenHash: hash(tok), kind: 'daemon', ownerUserId: owner._id, machineId: 'machine-h',
+      scopes: ['machine:heartbeat'],
+    });
+    const res = await adopt(tok);
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/lacks scope/);
   });
 
   it('a revoked daemon credential cannot adopt', async () => {

--- a/backend/middleware/daemonAuth.ts
+++ b/backend/middleware/daemonAuth.ts
@@ -3,13 +3,22 @@
 // it deliberately does NOT pass agentRuntimeAuth and cannot act as any agent
 // (Vera's scope ruling on #1312/S1). Sets req.daemonCredential.
 import { Request, Response, NextFunction } from 'express';
-import AgentCredential, { IAgentCredential } from '../models/AgentCredential';
+import AgentCredential from '../models/AgentCredential';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { hash } = require('../utils/secret') as { hash: (value: string) => string };
 
+// The contract (Vera's S1 ruling): routes see req.machine and NOTHING else —
+// a minimal projection, never the credential document. Keeps the ledger's
+// internals (hashes, lineage ids) out of route handlers by construction.
+export interface MachineContext {
+  machineId: string;
+  ownerUserId: string;
+  scopes: string[];
+}
+
 export interface DaemonAuthedRequest extends Request {
-  daemonCredential?: IAgentCredential;
+  machine?: MachineContext;
 }
 
 // Factory: daemonAuth('agents:adopt') returns middleware that requires the
@@ -42,7 +51,11 @@ export default function daemonAuth(requiredScope?: string) {
       }
       AgentCredential.updateOne({ _id: credential._id }, { $set: { lastUsedAt: new Date() } })
         .catch((err: Error) => console.warn('Failed to stamp daemon credential usage:', err.message));
-      req.daemonCredential = credential;
+      req.machine = {
+        machineId: String(credential.machineId || ''),
+        ownerUserId: String(credential.ownerUserId),
+        scopes: credential.scopes || [],
+      };
       return next();
     } catch (err) {
       console.error('daemonAuth error:', err);

--- a/backend/middleware/daemonAuth.ts
+++ b/backend/middleware/daemonAuth.ts
@@ -1,0 +1,44 @@
+// ADR-026 D4: authenticates cm_daemon_* bearers against the AgentCredential
+// ledger. A daemon credential authorizes agent-LIFECYCLE operations only —
+// it deliberately does NOT pass agentRuntimeAuth and cannot act as any agent
+// (Vera's scope ruling on #1312/S1). Sets req.daemonCredential.
+import { Request, Response, NextFunction } from 'express';
+import AgentCredential, { IAgentCredential } from '../models/AgentCredential';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { hash } = require('../utils/secret') as { hash: (value: string) => string };
+
+export interface DaemonAuthedRequest extends Request {
+  daemonCredential?: IAgentCredential;
+}
+
+export default async function daemonAuth(
+  req: DaemonAuthedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void | Response> {
+  try {
+    const authHeader = req.header('Authorization');
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : undefined;
+    if (!token || !token.startsWith('cm_daemon_')) {
+      return res.status(401).json({ message: 'Missing daemon token' });
+    }
+    const credential = await AgentCredential.findOne({ tokenHash: hash(token), kind: 'daemon' });
+    if (!credential || credential.status !== 'active') {
+      return res.status(401).json({ message: 'Daemon token revoked or unknown' });
+    }
+    if (credential.expiresAt && credential.expiresAt < new Date()) {
+      return res.status(401).json({ message: 'Daemon token expired' });
+    }
+    AgentCredential.updateOne({ _id: credential._id }, { $set: { lastUsedAt: new Date() } })
+      .catch((err: Error) => console.warn('Failed to stamp daemon credential usage:', err.message));
+    req.daemonCredential = credential;
+    return next();
+  } catch (err) {
+    console.error('daemonAuth error:', err);
+    return res.status(500).json({ message: 'Server error' });
+  }
+}
+// CJS compat
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/middleware/daemonAuth.ts
+++ b/backend/middleware/daemonAuth.ts
@@ -12,32 +12,43 @@ export interface DaemonAuthedRequest extends Request {
   daemonCredential?: IAgentCredential;
 }
 
-export default async function daemonAuth(
-  req: DaemonAuthedRequest,
-  res: Response,
-  next: NextFunction,
-): Promise<void | Response> {
-  try {
-    const authHeader = req.header('Authorization');
-    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : undefined;
-    if (!token || !token.startsWith('cm_daemon_')) {
-      return res.status(401).json({ message: 'Missing daemon token' });
+// Factory: daemonAuth('agents:adopt') returns middleware that requires the
+// credential to CARRY that scope. Scopes are enforced, not decorative
+// (Vera on #1315: "a scope nobody reads doesn't hold the claim"). There are
+// no legacy daemon credentials to grandfather — a credential without the
+// required scope is a 403, full stop. This is THE daemon middleware; do not
+// grow a second copy (the podWriteAccessService copy-drift rule).
+export default function daemonAuth(requiredScope?: string) {
+  return async function daemonAuthMw(
+    req: DaemonAuthedRequest,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void | Response> {
+    try {
+      const authHeader = req.header('Authorization');
+      const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : undefined;
+      if (!token || !token.startsWith('cm_daemon_')) {
+        return res.status(401).json({ message: 'Missing daemon token' });
+      }
+      const credential = await AgentCredential.findOne({ tokenHash: hash(token), kind: 'daemon' });
+      if (!credential || credential.status !== 'active') {
+        return res.status(401).json({ message: 'Daemon token revoked or unknown' });
+      }
+      if (credential.expiresAt && credential.expiresAt < new Date()) {
+        return res.status(401).json({ message: 'Daemon token expired' });
+      }
+      if (requiredScope && !(credential.scopes || []).includes(requiredScope)) {
+        return res.status(403).json({ message: `Daemon token lacks scope ${requiredScope}` });
+      }
+      AgentCredential.updateOne({ _id: credential._id }, { $set: { lastUsedAt: new Date() } })
+        .catch((err: Error) => console.warn('Failed to stamp daemon credential usage:', err.message));
+      req.daemonCredential = credential;
+      return next();
+    } catch (err) {
+      console.error('daemonAuth error:', err);
+      return res.status(500).json({ message: 'Server error' });
     }
-    const credential = await AgentCredential.findOne({ tokenHash: hash(token), kind: 'daemon' });
-    if (!credential || credential.status !== 'active') {
-      return res.status(401).json({ message: 'Daemon token revoked or unknown' });
-    }
-    if (credential.expiresAt && credential.expiresAt < new Date()) {
-      return res.status(401).json({ message: 'Daemon token expired' });
-    }
-    AgentCredential.updateOne({ _id: credential._id }, { $set: { lastUsedAt: new Date() } })
-      .catch((err: Error) => console.warn('Failed to stamp daemon credential usage:', err.message));
-    req.daemonCredential = credential;
-    return next();
-  } catch (err) {
-    console.error('daemonAuth error:', err);
-    return res.status(500).json({ message: 'Server error' });
-  }
+  };
 }
 // CJS compat
 // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/backend/models/User.ts
+++ b/backend/models/User.ts
@@ -116,6 +116,8 @@ export interface IUser extends Document {
     capabilities?: string[];
     agentName?: string;
     instanceId?: string;
+    // ADR-026 D3: the machine this identity is bound to (adoption CAS).
+    machineId?: string | null;
     runtime?: string;
     icon?: string;
   };
@@ -249,6 +251,8 @@ const userSchema = new Schema<IUser>({
     capabilities: [{ type: String }],
     agentName: { type: String },
     instanceId: { type: String },
+    // ADR-026 D3 — declared or Mongoose strips it (the #1282 lesson).
+    machineId: { type: String, default: null },
   },
   avatarMetadata: {
     style: {

--- a/backend/routes/agentBinding.ts
+++ b/backend/routes/agentBinding.ts
@@ -35,19 +35,24 @@ const bindingRateLimit = rateLimit({
 
 const normalize = (v: unknown): string => String(v ?? '').trim().toLowerCase();
 
-// Ownership predicate: the daemon's owner must own the agent. Agent
-// ownership = an active installation installedBy the owner (the #609
-// owner-scoping surface); registry rows do not carry an owner field.
+// Ownership predicate — SOLE-INSTALLER (Vera's ruling on #1315). Two clauses,
+// both must hold: an active installation of (agentName, instanceId)
+// installedBy the owner exists, AND no active installation of that identity
+// exists installedBy anyone else. The negative clause is what stops a shared
+// identity (two humans each installed it) from being bound to one person's
+// machine; once #609 gives per-owner identities it becomes redundant rather
+// than wrong, so it stays.
 const ownsAgent = async (ownerUserId: unknown, agentName: string, instanceId: string): Promise<boolean> => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { AgentInstallation } = require('../models/AgentRegistry');
-  const row = await AgentInstallation.findOne({
-    agentName,
-    instanceId,
-    installedBy: ownerUserId,
-    status: 'active',
+  const mine = await AgentInstallation.findOne({
+    agentName, instanceId, installedBy: ownerUserId, status: 'active',
   }).select('_id').lean();
-  return Boolean(row);
+  if (!mine) return false;
+  const others = await AgentInstallation.findOne({
+    agentName, instanceId, status: 'active', installedBy: { $ne: ownerUserId },
+  }).select('_id').lean();
+  return !others;
 };
 
 router.post('/adopt', bindingRateLimit, daemonAuth('agents:adopt'), async (req: DaemonAuthedRequest, res: express.Response) => {

--- a/backend/routes/agentBinding.ts
+++ b/backend/routes/agentBinding.ts
@@ -50,7 +50,7 @@ const ownsAgent = async (ownerUserId: unknown, agentName: string, instanceId: st
   return Boolean(row);
 };
 
-router.post('/adopt', bindingRateLimit, daemonAuth, async (req: DaemonAuthedRequest, res: express.Response) => {
+router.post('/adopt', bindingRateLimit, daemonAuth('agents:adopt'), async (req: DaemonAuthedRequest, res: express.Response) => {
   try {
     const agentName = normalize(req.body?.agentName);
     const instanceId = normalize(req.body?.instanceId) || 'default';

--- a/backend/routes/agentBinding.ts
+++ b/backend/routes/agentBinding.ts
@@ -55,9 +55,9 @@ router.post('/adopt', bindingRateLimit, daemonAuth('agents:adopt'), async (req: 
     const agentName = normalize(req.body?.agentName);
     const instanceId = normalize(req.body?.instanceId) || 'default';
     if (!agentName) return res.status(400).json({ message: 'agentName required' });
-    const cred = req.daemonCredential!;
-    if (!cred.machineId) return res.status(400).json({ message: 'Daemon credential carries no machineId' });
-    if (!(await ownsAgent(cred.ownerUserId, agentName, instanceId))) {
+    const machine = req.machine!;
+    if (!machine.machineId) return res.status(400).json({ message: 'Daemon credential carries no machineId' });
+    if (!(await ownsAgent(machine.ownerUserId, agentName, instanceId))) {
       return res.status(403).json({ message: 'Agent is not owned by this daemon\'s owner' });
     }
     // The CAS: only an UNBOUND identity transitions. matchedCount 0 with an
@@ -69,17 +69,17 @@ router.post('/adopt', bindingRateLimit, daemonAuth('agents:adopt'), async (req: 
         'botMetadata.instanceId': instanceId,
         $or: [{ 'botMetadata.machineId': null }, { 'botMetadata.machineId': { $exists: false } }],
       },
-      { $set: { 'botMetadata.machineId': cred.machineId } },
+      { $set: { 'botMetadata.machineId': machine.machineId } },
     );
     if (result.modifiedCount === 1) {
-      return res.json({ adopted: true, agentName, instanceId, machineId: cred.machineId });
+      return res.json({ adopted: true, agentName, instanceId, machineId: machine.machineId });
     }
     const identity = await User.findOne({
       isBot: true, 'botMetadata.agentName': agentName, 'botMetadata.instanceId': instanceId,
     }).select('botMetadata.machineId').lean();
     if (!identity) return res.status(404).json({ message: 'Agent identity not found' });
-    if (identity.botMetadata?.machineId === cred.machineId) {
-      return res.json({ adopted: true, alreadyBound: true, agentName, instanceId, machineId: cred.machineId });
+    if (identity.botMetadata?.machineId === machine.machineId) {
+      return res.json({ adopted: true, alreadyBound: true, agentName, instanceId, machineId: machine.machineId });
     }
     return res.status(409).json({
       message: 'Agent is bound to another machine — release it first',

--- a/backend/routes/agentBinding.ts
+++ b/backend/routes/agentBinding.ts
@@ -1,0 +1,119 @@
+// ADR-026 D3: identity-level machine binding. Adoption is an atomic
+// conditional transition (unbound → bound(machineId)) on the agent's bot
+// User row — the loser of a concurrent adopt gets a clean 409, never a
+// second runner. Rebinding is explicit release-then-adopt. The bound-agent
+// predicate is enforced HERE from the daemon credential's server-side
+// machineId — never from a caller-supplied value.
+import express from 'express';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import { createHash } from 'crypto';
+import daemonAuth, { DaemonAuthedRequest } from '../middleware/daemonAuth';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const auth = require('../middleware/auth');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const User = require('../models/User');
+
+const router = express.Router();
+
+const bindingRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req: { get?: (h: string) => string | undefined; ip?: string }) => {
+    const authHeader = req.get?.('authorization');
+    if (authHeader) {
+      return `tok:${createHash('sha256').update(authHeader).digest('hex').slice(0, 16)}`;
+    }
+    return req.ip ? ipKeyGenerator(req.ip) : 'anon';
+  },
+  handler: (_req: unknown, res: { status: (n: number) => { json: (b: unknown) => void } }) => {
+    res.status(429).json({ msg: 'rate limit exceeded: 120 binding ops per 60s' });
+  },
+});
+
+const normalize = (v: unknown): string => String(v ?? '').trim().toLowerCase();
+
+// Ownership predicate: the daemon's owner must own the agent. Agent
+// ownership = an active installation installedBy the owner (the #609
+// owner-scoping surface); registry rows do not carry an owner field.
+const ownsAgent = async (ownerUserId: unknown, agentName: string, instanceId: string): Promise<boolean> => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { AgentInstallation } = require('../models/AgentRegistry');
+  const row = await AgentInstallation.findOne({
+    agentName,
+    instanceId,
+    installedBy: ownerUserId,
+    status: 'active',
+  }).select('_id').lean();
+  return Boolean(row);
+};
+
+router.post('/adopt', bindingRateLimit, daemonAuth, async (req: DaemonAuthedRequest, res: express.Response) => {
+  try {
+    const agentName = normalize(req.body?.agentName);
+    const instanceId = normalize(req.body?.instanceId) || 'default';
+    if (!agentName) return res.status(400).json({ message: 'agentName required' });
+    const cred = req.daemonCredential!;
+    if (!cred.machineId) return res.status(400).json({ message: 'Daemon credential carries no machineId' });
+    if (!(await ownsAgent(cred.ownerUserId, agentName, instanceId))) {
+      return res.status(403).json({ message: 'Agent is not owned by this daemon\'s owner' });
+    }
+    // The CAS: only an UNBOUND identity transitions. matchedCount 0 with an
+    // existing identity means someone else holds the binding → 409.
+    const result = await User.updateOne(
+      {
+        isBot: true,
+        'botMetadata.agentName': agentName,
+        'botMetadata.instanceId': instanceId,
+        $or: [{ 'botMetadata.machineId': null }, { 'botMetadata.machineId': { $exists: false } }],
+      },
+      { $set: { 'botMetadata.machineId': cred.machineId } },
+    );
+    if (result.modifiedCount === 1) {
+      return res.json({ adopted: true, agentName, instanceId, machineId: cred.machineId });
+    }
+    const identity = await User.findOne({
+      isBot: true, 'botMetadata.agentName': agentName, 'botMetadata.instanceId': instanceId,
+    }).select('botMetadata.machineId').lean();
+    if (!identity) return res.status(404).json({ message: 'Agent identity not found' });
+    if (identity.botMetadata?.machineId === cred.machineId) {
+      return res.json({ adopted: true, alreadyBound: true, agentName, instanceId, machineId: cred.machineId });
+    }
+    return res.status(409).json({
+      message: 'Agent is bound to another machine — release it first',
+      boundTo: identity.botMetadata?.machineId || null,
+    });
+  } catch (err) {
+    console.error('adopt error:', err);
+    return res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// Release: the OWNER (human JWT) releases explicitly — rebinding is a
+// deliberate two-step, never a daemon-side race (D3).
+router.post('/release', bindingRateLimit, auth, async (req: express.Request & { user?: { id?: string } }, res: express.Response) => {
+  try {
+    const agentName = normalize(req.body?.agentName);
+    const instanceId = normalize(req.body?.instanceId) || 'default';
+    if (!agentName) return res.status(400).json({ message: 'agentName required' });
+    if (!(await ownsAgent(req.user?.id, agentName, instanceId))) {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const caller = await User.findById(req.user?.id).select('role').lean();
+      if (caller?.role !== 'admin') return res.status(403).json({ message: 'Access denied' });
+    }
+    const result = await User.updateOne(
+      { isBot: true, 'botMetadata.agentName': agentName, 'botMetadata.instanceId': instanceId },
+      { $set: { 'botMetadata.machineId': null } },
+    );
+    if (!result.matchedCount) return res.status(404).json({ message: 'Agent identity not found' });
+    return res.json({ released: true, agentName, instanceId });
+  } catch (err) {
+    console.error('release error:', err);
+    return res.status(500).json({ message: 'Server error' });
+  }
+});
+
+module.exports = router;
+export {};

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -212,6 +212,7 @@ app.use('/api/v1', contextApiRoutes); // Context API for MCP and external agents
 app.use('/api/v1/tasks', tasksApiRoutes); // Task management for dev agents
 app.use('/api/registry', registryRoutes); // Agent Registry (package manager for agents)
 app.use('/api/credentials', require('./routes/credentials')); // ADR-026 Phase 0: credential lineage + revocation
+app.use('/api/agent-binding', require('./routes/agentBinding')); // ADR-026 D3: machine adoption CAS
 app.use('/api/agents/runtime', agentsRuntimeRoutes); // Runtime endpoints for external agents
 app.use('/api/federation', federationRoutes); // Cross-pod federation
 app.use('/api/providers/moltbot', moltbotProviderRoutes); // Moltbot provider integration


### PR DESCRIPTION
Phase 1 S2, on the #1312 substrate:

- **daemonAuth middleware**: cm_daemon_* bearers validated against the ledger (kind, status, expiry). Lifecycle-scoped by construction — a daemon token cannot pass agentRuntimeAuth and cannot act as any agent.
- **botMetadata.machineId** declared on interface + schema (the Mongoose-stripping lesson applied preemptively)
- **POST /api/agent-binding/adopt** (daemon-authed): atomic `unbound → bound(machineId)` conditional update. machineId is read from the daemon credential server-side — a caller-supplied value is ignored by construction. Ownership predicate: the daemon's owner must hold an active installation of the agent. Concurrent adopts: one winner, loser 409s with the holder. Idempotent re-adopt for the holder.
- **POST /api/agent-binding/release** (owner JWT or admin): explicit unbind — rebinding is a deliberate two-step per D3, never a daemon-side race.

6 invariant tests incl. the concurrent-race case. Merge gate: @vera's S3 verdict. Pairs with Kai's S1 (Machine rows); adoption references machineId as an opaque string so the two merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pc6nGXRS8mHvrwcXMSRDK