### PR TITLE
fix(onboarding): scan user-row runtime token episodes

### DIFF
--- a/backend/__tests__/unit/services/stalledConnectService.test.js
+++ b/backend/__tests__/unit/services/stalledConnectService.test.js
@@ -196,12 +196,35 @@ describe('stalledConnectService.scan', () => {
     expect(doc.producer).toBe('timer');
   });
 
+  it('finds the reachable User-token-only seat, even when the installation token store is empty', async () => {
+    // `issueRuntimeTokenForAgent` returns an existing User-row token without
+    // backfilling installation.runtimeTokens. Model Mongo's former existence
+    // predicate so restoring it makes this end-to-end scan regression fail.
+    const userTokenOnlyInstall = install({ runtimeTokens: [] });
+    setup({ installs: [userTokenOnlyInstall], userTokens: [{ createdAt: OLD_TOKEN }] });
+    mockInstallFind.mockImplementation((filter) => ({
+      limit: () => ({
+        lean: () => Promise.resolve(filter['runtimeTokens.0'] ? [] : [userTokenOnlyInstall]),
+      }),
+    }));
+
+    const r = await scan({ now: NOW });
+
+    expect(r.nudged).toHaveLength(1);
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(mockEpCreate.mock.calls[0][0]).toEqual(expect.objectContaining({
+      tokenIssuedAt: OLD_TOKEN,
+      tokenSource: 'user',
+    }));
+  });
+
   it('only considers BYO seats — nothing else can derive never-connected', async () => {
     setup();
     await scan({ now: NOW });
 
     const [filter] = mockInstallFind.mock.calls[0];
     expect(filter.status).toBe('active');
+    expect(filter).not.toHaveProperty('runtimeTokens.0');
     expect(filter.$or).toEqual(expect.arrayContaining([{ 'config.runtime.host': 'byo' }]));
   });
 });

--- a/backend/services/stalledConnectService.ts
+++ b/backend/services/stalledConnectService.ts
@@ -166,8 +166,9 @@ export const scan = async ({
   // second opinion. `deriveAgentState` can only answer 'never-connected' when
   // the install is BYO (host 'byo' or runtimeType 'local-cli'), so gating on
   // that here narrows the scan without being able to change a verdict. Seats
-  // with no token at all are excluded because a token-episode is the unit of
-  // work: no token issued means nothing was ever promised to connect.
+  // with no token at all are excluded below, after both token stores have
+  // been read. A token-episode is the unit of work: no token issued means
+  // nothing was ever promised to connect.
   //
   // `.lean()` is not optional — `config` is `{ type: Map }`, so on a live
   // Mongoose document `config.runtime` is undefined and every install would
@@ -176,7 +177,6 @@ export const scan = async ({
   // deriveAgentState reads.
   const candidates = await AgentInstallation.find({
     status: 'active',
-    'runtimeTokens.0': { $exists: true },
     $or: [
       { 'config.runtime.host': 'byo' },
       { 'config.runtime.runtimeType': 'local-cli' },


### PR DESCRIPTION
## Summary
- Remove the installation-only `runtimeTokens.0` pre-filter from stalled-connect scanning.
- Keep the existing two-store token-episode derivation as the sole token-presence decision.
- Pin the reachable shape: an empty installation store with an old token on the bot User row is nudged and recorded with source `user`.

## Verification
- `cd backend && ./node_modules/.bin/jest --runInBand __tests__/unit/services/stalledConnectService.test.js` (17 passed)
- `cd backend && npm run tsc:check`
- Mutation: restoring the old `runtimeTokens.0` predicate makes the new regression fail (0 nudges instead of 1).

Fixes the existing stalled-connect scanner; no new nudge system.