### PR TITLE
test(cues): pin mention-cue tool signatures against the live MCP schema (TASK-086)

### DIFF
--- a/commonly-mcp/__tests__/cue-signatures.test.mjs
+++ b/commonly-mcp/__tests__/cue-signatures.test.mjs
@@ -125,15 +125,42 @@ describe('inline mention cues teach signatures the MCP tools accept', () => {
     expect(wrong).toEqual([]);
   });
 
+  /**
+   * Both the requirement assertion and its control read THIS, so a control
+   * that passes cannot be describing a different set than the assertion walks.
+   */
+  const requiredPairs = signatures
+    .filter((s) => !OPENCLAW_ONLY.includes(s.tool))
+    .flatMap(({ tool, params }) =>
+      (byName[tool]?.inputSchema?.required || []).map((param) => ({
+        tool,
+        param,
+        named: params.includes(param),
+      })));
+
+  it('has a required-parameter set to check at all', () => {
+    // The empty-parse control above guards the CUE side of the comparison.
+    // This is the same control for the SCHEMA side, and it was missing:
+    // a comparison has two inputs, and guarding one is not guarding the
+    // comparison. Drop the `required` array from `reqWith` in `src/tools.js`
+    // and the assertion below walks an empty list and passes — going inert
+    // exactly where the docblock's historical `commonly_read_file({ fileName })`
+    // defect lives. Measured: that mutation left all 54 tests green.
+    //
+    // Its mirror image is safe by accident rather than by care. The
+    // properties half accumulates on a MISS, so an empty `properties` reds
+    // three tests; this half accumulates on a HIT, so an empty `required`
+    // reds none. Identical `|| []` / `|| {}` idiom, opposite failure
+    // direction, and reading them tells you nothing about which is which.
+    expect(requiredPairs.length).toBeGreaterThanOrEqual(4);
+    expect(requiredPairs.map((p) => `${p.tool}.${p.param}`))
+      .toContain('commonly_attach_file.filePath');
+  });
+
   it('names every parameter the tool requires', () => {
     // The historical defect, in assertion form: the cue taught
     // `commonly_read_file({ fileName })` while `podId` was required.
-    const missing = [];
-    for (const { tool, params } of signatures) {
-      if (OPENCLAW_ONLY.includes(tool)) continue;
-      const required = byName[tool]?.inputSchema?.required || [];
-      required.filter((r) => !params.includes(r)).forEach((r) => missing.push(`${tool}.${r}`));
-    }
+    const missing = requiredPairs.filter((p) => !p.named).map((p) => `${p.tool}.${p.param}`);
     expect(missing).toEqual([]);
   });
 

--- a/commonly-mcp/__tests__/cue-signatures.test.mjs
+++ b/commonly-mcp/__tests__/cue-signatures.test.mjs
@@ -1,0 +1,146 @@
+/**
+ * The inline mention cues name TOOL SIGNATURES, and nothing spanned the cue
+ * text and the tool schema until this file.
+ *
+ * WHAT WAS ALREADY COVERED, verified at `ccacf0235`:
+ *   - `moltbotToolContract.test.js` requires every `commonly_*` NAME a cue
+ *     mentions to be declared by the pinned openclaw extension.
+ *   - `agentMentionService.wakeOnMessage.test.js:315` pins the attach_file cue
+ *     as far as `commonly_attach_file({ podId: "pod-1"`.
+ *   - `agentMentionService.test.js:1310` already pins ONE signature to full
+ *     arity — `commonly_read_file({ podId: "pod-1", fileName })`.
+ *
+ * Both existing guards answer "does this name exist". Neither answers "does
+ * this call still typecheck against the tool", and the two questions come
+ * apart on a parameter rename: rename `filePath` to `path` in `src/tools.js`
+ * and the name still exists, the prefix assertion still matches, and every
+ * woken agent is taught a call the tool rejects.
+ *
+ * THE PARAMETER SIDE IS NOT A CROSS-REPO PROBLEM, which is why this is worth
+ * building. `@commonlyai/mcp` is `commonly-mcp/` in THIS repo, so cue and
+ * schema are two files one `fs.readFileSync` apart — a rename lands in a diff
+ * a single suite can read. (The openclaw half genuinely is cross-repo and
+ * arrives as one line of submodule hex; that is what the contract script is
+ * for, and it is why the openclaw-only names below are skipped here rather
+ * than checked twice.)
+ *
+ * The arity half is NOT hypothetical. The comment block above the cue records
+ * this exact failure already firing: the frame taught
+ * `commonly_read_file({ fileName })` while the live schema required `podId`
+ * too. A name-matching guard cannot see a wrong arity, so it stayed green.
+ *
+ * SCOPE, stated rather than implied: this reads the BRACED named-parameter
+ * form `tool({ a, b })` only. `formatConsultationCue` also writes
+ * `commonly_post_message(podId, question)` — a positional prose shorthand
+ * whose tokens are value placeholders, not schema keys (`question` is not a
+ * key; `content` is). Treating those as parameter names would red the build
+ * over a sentence, so they are deliberately out. Their risk is real but it is
+ * a copy question, not a schema one.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { buildTools } from '../src/tools.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MENTION_SERVICE = join(HERE, '..', '..', 'backend', 'services', 'agentMentionService.ts');
+
+const tools = buildTools({ baseUrl: 'https://x.example', token: 'cm_agent_t' });
+const byName = Object.fromEntries(tools.map((t) => [t.name, t]));
+
+/**
+ * Comments are not delivered to agents, and the comments around these cues
+ * quote WRONG signatures on purpose as history — including the very
+ * `commonly_read_file({ fileName })` arity bug this file exists to prevent.
+ * Counting one would red the build over a paragraph. Blank them out rather
+ * than deleting so nothing downstream shifts. (`[^:]` keeps `https://` from
+ * reading as a line comment.)
+ */
+const stripComments = (src) => src
+  .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+  .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) => lead + m.slice(lead.length).replace(/[^\n]/g, ' '));
+
+/**
+ * Discovered from the whole (comment-stripped) file rather than from a
+ * registered list of cue names: a cue added tomorrow is covered without anyone
+ * remembering this file exists. An unregistered surface reads exactly like a
+ * passing one, which is the failure mode all of this is about.
+ */
+const collectCueSignatures = () => {
+  const src = stripComments(readFileSync(MENTION_SERVICE, 'utf8'));
+  const found = [];
+  // `\$\{podId\}` inside the cue's own template carries a `}`, so a naive
+  // `[^}]*` body stops mid-signature and silently drops the tools whose first
+  // argument is interpolated — which is every one that matters here.
+  for (const m of src.matchAll(/commonly_([a-z_]+)\(\{((?:[^{}]|\$\{[^}]*\})*)\}\)/g)) {
+    const params = m[2]
+      .split(',')
+      .map((p) => p.split(':')[0].trim())
+      .filter(Boolean);
+    found.push({ tool: `commonly_${m[1]}`, params });
+  }
+  return found;
+};
+
+/**
+ * Named on purpose for openclaw seats, beside the MCP name for the same
+ * capability — the cue ships to every driver class unconditionally. The MCP
+ * package neither has nor owes these. Same exemption shape as the contract
+ * script's `namedForOtherDrivers`, including the check that the list cannot
+ * outlive the line justifying it.
+ */
+// `commonly_open_dm` is deliberately NOT here: the consultation cue names it
+// bare ("or commonly_open_dm on openclaw runtimes"), never in a call form, so
+// it carries no signature for this file to check. Listing it would have been
+// an exemption for something that was never in scope — the inventory
+// assertion below is what caught that.
+const OPENCLAW_ONLY = ['commonly_read_attachment'];
+
+describe('inline mention cues teach signatures the MCP tools accept', () => {
+  const signatures = collectCueSignatures();
+
+  it('finds signatures to check at all', () => {
+    // A parser that silently matched nothing would pass every assertion below
+    // by having nothing to look at — the same empty-parse hole the contract
+    // script guards with its own control.
+    expect(signatures.length).toBeGreaterThanOrEqual(4);
+    expect(signatures.map((s) => s.tool)).toContain('commonly_attach_file');
+  });
+
+  it.each(OPENCLAW_ONLY)('%s is skipped because it is an openclaw name, and is still named by a cue', (tool) => {
+    // If a cue stops naming it, the exemption is a hole with no remaining
+    // justification and would excuse a future MCP use of the same name.
+    expect(signatures.map((s) => s.tool)).toContain(tool);
+    expect(byName[tool]).toBeUndefined();
+  });
+
+  it('names no parameter the tool does not accept', () => {
+    const wrong = [];
+    for (const { tool, params } of signatures) {
+      if (OPENCLAW_ONLY.includes(tool)) continue;
+      const props = Object.keys(byName[tool]?.inputSchema?.properties || {});
+      params.filter((p) => !props.includes(p)).forEach((p) => wrong.push(`${tool}.${p}`));
+    }
+    expect(wrong).toEqual([]);
+  });
+
+  it('names every parameter the tool requires', () => {
+    // The historical defect, in assertion form: the cue taught
+    // `commonly_read_file({ fileName })` while `podId` was required.
+    const missing = [];
+    for (const { tool, params } of signatures) {
+      if (OPENCLAW_ONLY.includes(tool)) continue;
+      const required = byName[tool]?.inputSchema?.required || [];
+      required.filter((r) => !params.includes(r)).forEach((r) => missing.push(`${tool}.${r}`));
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('every cue-named tool that is not openclaw-only is a real MCP tool', () => {
+    const unknown = signatures
+      .map((s) => s.tool)
+      .filter((t) => !OPENCLAW_ONLY.includes(t) && !byName[t]);
+    expect(unknown).toEqual([]);
+  });
+});


### PR DESCRIPTION
Narrow residual of TASK-074, filed by @sprint-review and scoped small on purpose. Their filing is accurate about the gap and I confirmed each of its "already guarded" claims at `ccacf0235`; two things came out differently on inspection.

**The suggested fix does not close the titled risk.** The row's title is "a param rename in `@commonlyai/mcp` leaves the inline cue teaching a wrong call with nothing red", and the suggestion was to extend the `wakeOnMessage` assertion from the prefix to the full signature. But that assertion reads the cue against a *literal in the test*. Rename `filePath` to `path` in `commonly-mcp/src/tools.js` and the cue text is untouched, so a fuller `toContain` stays green too. Pinning the cue harder pins the cue; it never reaches the schema.

**And it is not a cross-repo problem.** `@commonlyai/mcp` is `commonly-mcp/` in *this* repo — cue and schema are two files one `readFileSync` apart, so a single suite can span them. (The openclaw half genuinely is cross-repo and arrives as one line of submodule hex; that is what `verify-moltbot-tool-contract.js` is for, and it is why the openclaw-only name is skipped here rather than checked twice.)

So this asserts the cue against `buildTools()` in both directions: no parameter the tool does not accept, and every parameter the tool requires.

### One correction to the filing
The guards do not uniformly stop at name + first param. `agentMentionService.test.js:1310` already pins `commonly_read_file({ podId: "pod-1", fileName })` to full arity — a sibling tool in the *same* cue. The residual is that `attach_file` was left at the prefix while `read_file` next to it was not; an inconsistency inside one frame, not a systemic limit.

### Not latent
The comment above the cue records this exact class already firing: the frame taught `commonly_read_file({ fileName })` while the live schema required `podId` too. A name-matching guard cannot see a wrong arity, so it stayed green.

### The sweep the filing left open
"Whether any *other* cue names a tool signature" — swept at `origin/main`. Four braced signatures reach agents, in two cues, not one:

| cue | signature |
|---|---|
| `formatPodContextFrame` | `commonly_attach_file({ podId, filePath, message })` |
| `formatPodContextFrame` | `commonly_read_file({ podId, fileName })` |
| `formatPodContextFrame` | `commonly_read_attachment({ fileName })` (openclaw) |
| `formatConsultationCue` | `commonly_dm_agent({ agentName })` |

All four are correct against the live schemas today. Note that `commonly_read_file` and `commonly_dm_agent` are exactly the two names on the contract script's `namedForOtherDrivers` exemption — deliberately unchecked against the pin, and until now unchecked against anything else either. This file is their only reader.

Signatures are discovered from the comment-stripped source rather than a registered list, so a cue added later is covered without anyone remembering this file exists.

### Mutations
| mutation | this file | MCP pkg suite | the 3 existing guards |
|---|---|---|---|
| `filePath`→`path` in the MCP schema | **2 red** | 0 red (49/49) | 0 red (113/113) |
| cue drops the required `podId` | **1 red** | — | **1 red** (`agentMentionService.test.js`) |

Only the schema-rename direction is new coverage; the arity direction is co-detected by the existing full-arity pin, and I would rather say that than let the table read as two wins. `Tests: 54 total` on every run (compile control). Exemption list carries its own inventory check — my first draft listed `commonly_open_dm`, and that assertion caught that the cue names it bare, never in a call form.

### Stated scope
Braced named-parameter form only. `formatConsultationCue` also writes `commonly_post_message(podId, question)` — positional prose whose tokens are value placeholders, not schema keys (`question` is not a key; `content` is). Treating those as parameter names would red the build over a sentence, so they are out. **Separately worth someone's judgement, not fixed here:** that shorthand may still teach a model to pass `question:`.

**Also not covered, and larger than this row:** `presets.ts` carries ~20 positional tool signatures in preset prompts, and the contract script reads only `CYCLES_REFLECTION_TRAILER` from that file — so those cues have no reader at the *name* level either, which is the script's own stated purpose. Not filed as a row yet; flagging it here rather than widening a deliberately small PR.

Base at `ccacf0235`. Collision-swept: #1216/#1206/#1223/#1321 touch `agentMentionService*`, #1090 touches the contract script, #1218 touches `commonly-mcp/src/tools.js` — this adds one new file and edits none of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)