### PR TITLE
test(tool-contract): read presets.ts at the name level, per declared runtime (TASK-087)

### DIFF
--- a/backend/__tests__/unit/scripts/moltbotToolContract.test.js
+++ b/backend/__tests__/unit/scripts/moltbotToolContract.test.js
@@ -27,6 +27,12 @@ const {
   readGitlinkSha,
   stripComments,
   MENTION_CUES,
+  parsePresets,
+  checkPresetToolNames,
+  loadNativeTools,
+  readExtensionToolsAtPin,
+  NAMED_AS_REMOVED,
+  PRESETS_FILE,
 } = require('../../../../scripts/verify-moltbot-tool-contract');
 
 // Shape lifted verbatim from extensions/commonly/src/tools.ts at both refs.
@@ -535,6 +541,218 @@ describe('moltbot tool contract', () => {
         // Non-vacuity: an undetermined verdict has to say what stopped it, or
         // it is indistinguishable from the check silently not running.
         expect(result.detail).toMatch(/fetch/i);
+      });
+    });
+  });
+
+  /**
+   * The preset↔runtime name check. Its two shape controls (`starts.length < 20`
+   * in parsePresets, `names.size < 5` in loadNativeTools) are the load-bearing
+   * part: without them a refactor that breaks the slice or the regex makes the
+   * whole check vacuous and green. A vacuous checker is worse than no checker,
+   * because it is cited as evidence. Both are pinned here, in both directions.
+   */
+  describe('preset tool names resolve on the runtime the preset declares', () => {
+    const presetBlock = (id, runtime, body = '') => [
+      `    id: '${id}',`,
+      `    runtime: '${runtime}',`,
+      body,
+    ].filter(Boolean).join('\n');
+
+    // A source with enough blocks to clear the shape control, so a test about
+    // anything else is not silently measuring the control instead.
+    const manyPresets = (extra = []) => [
+      ...Array.from({ length: 22 }, (_, i) => presetBlock(`filler-${i}`, 'openclaw')),
+      ...extra,
+    ].join('\n');
+
+    describe('parsePresets', () => {
+      it('extracts the id, the declared runtime and every tool name per block', () => {
+        const presets = parsePresets(manyPresets([
+          presetBlock(
+            'social-amplifier', 
+            'internal',
+            '    prompt: `Only post final content via commonly_post_message.`,',
+          ),
+        ]));
+        const amplifier = presets.find((p) => p.id === 'social-amplifier');
+        expect(amplifier.runtime).toBe('internal');
+        expect(amplifier.names).toEqual(['commonly_post_message']);
+      });
+
+      it('sees a tool named in prose, with no call parentheses', () => {
+        // This is why the check is not call-position scoped: both `internal`
+        // presets on main name their only tool in a sentence, so a
+        // call-position check covers zero of the runtime this row is about.
+        const [preset] = parsePresets(manyPresets([
+          presetBlock(
+            'prose-only', 
+            'internal',
+            '    prompt: `Run tools silently. Post via commonly_post_message only.`,',
+          ),
+        ])).filter((p) => p.id === 'prose-only');
+        expect(preset.names).toContain('commonly_post_message');
+      });
+
+      it('refuses to report a result when the block shape no longer matches', () => {
+        // Two blocks parse cleanly and mean nothing — the file has 30+. Without
+        // this control a broken segmenter reports "0 presets, all names
+        // resolved" and exits 0.
+        expect(() => parsePresets(presetBlock('only-one', 'openclaw')))
+          .toThrow(/parsed 1 preset definitions/);
+      });
+
+      it('refuses a block that declares no runtime rather than guessing one', () => {
+        expect(() => parsePresets(manyPresets(["    id: 'runtime-less',"])))
+          .toThrow(/'runtime-less' declares 0 distinct runtimes/);
+      });
+
+      it('refuses a block that declares several runtimes', () => {
+        expect(() => parsePresets(manyPresets([[
+          "    id: 'two-runtimes',",
+          "    runtime: 'openclaw',",
+          "    config: { runtime: 'internal' },",
+        ].join('\n')]))).toThrow(/declares 2 distinct runtimes/);
+      });
+
+      it('parses the live presets.ts without tripping either refusal', () => {
+        // Non-vacuity: every negative case above is satisfied by a parser that
+        // throws on everything.
+        const presets = parsePresets(fs.readFileSync(PRESETS_FILE, 'utf8'));
+        expect(presets.length).toBeGreaterThanOrEqual(20);
+        expect(presets.every((p) => p.runtime && p.id)).toBe(true);
+      });
+    });
+
+    describe('loadNativeTools', () => {
+      const nativeSource = (names) => `
+const TOOLS = [
+${names.map((n) => `  { type: 'function', function: { name: '${n}', description: '…' } },`).join('\n')}
+];
+
+const toolsForConfig = () => TOOLS;
+`;
+
+      it('slices the TOOLS array out of the live service', () => {
+        const names = loadNativeTools();
+        // Named, not counted: the point of resolving per-runtime is that this
+        // surface spells shared capabilities differently from the extension's.
+        expect(names.has('commonly_post_message')).toBe(true);
+        expect(names.has('commonly_read_memory')).toBe(true);
+        expect(names.has('commonly_read_agent_memory')).toBe(false);
+      });
+
+      it('refuses to report a result when the parse comes up short', () => {
+        // A short parse marks every internal preset's tools missing — loud, and
+        // wrong. Distinguish "the array shrank" from "the slice stopped matching".
+        expect(() => loadNativeTools({ read: () => nativeSource(['commonly_post_message']) }))
+          .toThrow(/parsed 1 tool names/);
+      });
+
+      it('refuses when the declaration is gone entirely', () => {
+        expect(() => loadNativeTools({ read: () => 'export const TOOL_LIST = [];' }))
+          .toThrow(/const TOOLS not found/);
+      });
+
+      it('does not count a name that only appears in a comment', () => {
+        const withComment = `${nativeSource([
+          'commonly_post_message', 'commonly_create_task', 'commonly_read_memory',
+          'commonly_write_memory', 'commonly_read_context',
+        ])}\n// TODO: add { name: 'commonly_ghost' } here\n`;
+        const names = loadNativeTools({ read: () => withComment });
+        expect(names.has('commonly_ghost')).toBe(false);
+      });
+    });
+
+    describe('checkPresetToolNames', () => {
+      const sets = {
+        openclaw: new Set(['commonly_post_message', 'commonly_create_post']),
+        internal: new Set(['commonly_post_message']),
+      };
+      const mentionsRemoved = NAMED_AS_REMOVED.map(
+        (t, i) => presetBlock(`removed-note-${i}`, 'openclaw', `    prompt: \`${t} was removed.\`,`),
+      );
+
+      it('flags a name absent on the runtime its preset declares', () => {
+        // The row's scenario: create_post exists on openclaw only, and is
+        // correct today purely because all its sites sit in openclaw presets.
+        const presets = parsePresets(manyPresets([
+          ...mentionsRemoved,
+          presetBlock('x-curator', 'internal', '    prompt: `Call commonly_create_post(podId).`,'),
+        ]));
+        const { missing } = checkPresetToolNames({ presets, sets });
+        expect(missing).toHaveLength(1);
+        expect(missing[0].tool).toBe('commonly_create_post');
+        expect(missing[0].preset.id).toBe('x-curator');
+        expect(missing[0].preset.runtime).toBe('internal');
+        expect(missing[0].preset.line).toBeGreaterThan(0);
+      });
+
+      it('passes the same name when its preset declares a runtime that has it', () => {
+        const presets = parsePresets(manyPresets([
+          ...mentionsRemoved,
+          presetBlock('x-curator', 'openclaw', '    prompt: `Call commonly_create_post(podId).`,'),
+        ]));
+        expect(checkPresetToolNames({ presets, sets }).missing).toHaveLength(0);
+      });
+
+      it('reports a runtime it has no tool set for instead of skipping it', () => {
+        // Silence here is the failure this whole file exists to prevent: an
+        // unchecked runtime renders identically to a checked one that passed.
+        const presets = parsePresets(manyPresets([
+          ...mentionsRemoved,
+          presetBlock('cc-preset', 'claude-code', '    prompt: `Call commonly_post_message.`,'),
+        ]));
+        const { missing, uncovered } = checkPresetToolNames({ presets, sets });
+        expect(missing).toHaveLength(0);
+        expect(uncovered).toHaveLength(1);
+        expect(uncovered[0].preset.runtime).toBe('claude-code');
+        expect(uncovered[0].names).toContain('commonly_post_message');
+      });
+
+      it('exempts the names presets.ts mentions only to say they were removed', () => {
+        const presets = parsePresets(manyPresets(mentionsRemoved));
+        expect(checkPresetToolNames({ presets, sets }).missing).toHaveLength(0);
+      });
+
+      it('refuses an exemption that outlives the sentence justifying it', () => {
+        // Same self-check as namedForOtherDrivers: an exclusion nobody revisits
+        // silently widens into a licence for a future real use of the name.
+        const presets = parsePresets(manyPresets());
+        expect(() => checkPresetToolNames({ presets, sets }))
+          .toThrow(/no longer mentions it/);
+      });
+    });
+
+    describe('readExtensionToolsAtPin', () => {
+      it('reads the extension at the gitlink pin, not at the submodule working tree', () => {
+        const calls = [];
+        const exec = jest.fn((_bin, args) => {
+          calls.push(args);
+          return 'name: "commonly_post_message",';
+        });
+        const result = readExtensionToolsAtPin({ exec });
+        expect(result.ok).toBe(true);
+        // The revision handed to `git show` is the gitlink sha resolved from
+        // HEAD — never an implicit read of whatever the submodule tree is on.
+        const show = calls.find((c) => c.includes('show'));
+        expect(show[show.indexOf('show') + 1])
+          .toBe(`${readGitlinkSha({ full: true })}:extensions/commonly/src/tools.ts`);
+        expect(result.pin).toBe(readGitlinkSha({ full: true }));
+      });
+
+      it('surfaces the failure rather than falling back to the working tree', () => {
+        // The fallback is omitted on purpose. The two lineages declare identical
+        // tool names, so an off-pin read AGREES with a correct one — a
+        // wrong-provenance measurement returning the right answer, which is
+        // exactly how this defect survived being looked at.
+        const exec = jest.fn(() => {
+          throw Object.assign(new Error('fatal: path does not exist'), { status: 128 });
+        });
+        const result = readExtensionToolsAtPin({ exec });
+        expect(result.ok).toBe(false);
+        expect(result.text).toBeUndefined();
+        expect(result.reason).toMatch(/fatal: path does not exist/);
       });
     });
   });

--- a/scripts/verify-moltbot-tool-contract.js
+++ b/scripts/verify-moltbot-tool-contract.js
@@ -87,9 +87,8 @@ const path = require('path');
 const { execFileSync } = require('child_process');
 
 const REPO_ROOT = path.resolve(__dirname, '..');
-const EXTENSION_TOOLS = path.join(
-  REPO_ROOT, '_external', 'clawdbot', 'extensions', 'commonly', 'src', 'tools.ts',
-);
+const EXTENSION_TOOLS_REL = 'extensions/commonly/src/tools.ts';
+const EXTENSION_TOOLS = path.join(REPO_ROOT, '_external', 'clawdbot', EXTENSION_TOOLS_REL);
 
 // Read the trailer from its source of truth rather than restating it, so a
 // future edit that names a different tool is covered without touching this
@@ -576,6 +575,205 @@ const checkPinReachable = ({ exec = execFileSync } = {}) => {
   };
 };
 
+const PRESETS_FILE = path.join(REPO_ROOT, 'backend', 'routes', 'registry', 'presets.ts');
+const NATIVE_RUNTIME = path.join(REPO_ROOT, 'backend', 'services', 'nativeRuntimeService.ts');
+
+/**
+ * The extension's tool declarations AT THE GITLINK PIN.
+ *
+ * Everything else in this file already resolves the pin through `git ls-tree`,
+ * and then the one read that decides the whole tool contract went to
+ * `fs.readFileSync` of the submodule WORKING TREE — a different commit whenever
+ * a developer has the submodule checked out to anything but the pin, which is
+ * the normal state while bumping it. CI never saw it (`submodules: recursive`
+ * checks out the gitlink, so tree and pin coincide there), so the divergence
+ * only ever misled a human, and it misled one on this row: @sprint-review
+ * measured the tool set at `70bd82b8` and reported it as "the pin main
+ * declares", which was `5d88a3f1`.
+ *
+ * What makes that worth a code change rather than a note is HOW it failed. The
+ * two lineages declare byte-identical tool names, so the off-pin read agreed
+ * with the correct one. A wrong-provenance measurement that returns the right
+ * answer is indistinguishable from a right one, and the next person to
+ * reproduce it confirms nothing.
+ */
+const readExtensionToolsAtPin = ({ exec = execFileSync } = {}) => {
+  const pin = readGitlinkSha({ full: true });
+  if (pin === '(unknown)') {
+    return { ok: false, pin, reason: 'could not read the gitlink sha for _external/clawdbot from HEAD' };
+  }
+  try {
+    const text = exec(
+      'git',
+      ['-C', path.join(REPO_ROOT, '_external', 'clawdbot'), 'show', `${pin}:${EXTENSION_TOOLS_REL}`],
+      { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    return { ok: true, text, pin };
+  } catch (err) {
+    return {
+      ok: false,
+      pin,
+      reason: `git show ${pin.slice(0, 10)}:${EXTENSION_TOOLS_REL} failed — `
+        + String(err.message || err).split('\n')[0],
+    };
+  }
+};
+
+/**
+ * The `internal` runtime's tool surface — a hardcoded array in this repo, NOT
+ * the MCP package's tool set and NOT a subset of the extension's.
+ *
+ * It is a third namespace that spells shared capabilities differently:
+ * `commonly_read_memory` where MCP has `commonly_read_agent_memory`,
+ * `commonly_read_context` where MCP has `commonly_get_context`. A
+ * capability-level comparison scores those as present on both surfaces; only a
+ * name-level one sees the mismatch, which is the entire reason the preset check
+ * below resolves per-runtime instead of against one merged set.
+ *
+ * Sliced from the declaration rather than restated here, for the same reason
+ * loadCyclesTrailer reads presets.ts: a restated list is a fourth copy of a set
+ * that already has three, and this file exists because copies drift.
+ */
+const loadNativeTools = () => {
+  const code = stripComments(fs.readFileSync(NATIVE_RUNTIME, 'utf8'));
+  const start = code.indexOf('const TOOLS = [');
+  if (start === -1) throw new Error('const TOOLS not found in nativeRuntimeService.ts');
+  const rest = code.slice(start);
+  const end = rest.slice(1).search(/\n(?:const|export|function) /);
+  const body = end === -1 ? rest : rest.slice(0, end + 1);
+  const names = parseDeclaredTools(body);
+  // Control: an empty or near-empty parse would report every preset name as
+  // missing on `internal` — loud, and wrong. Distinguish "the array shrank" from
+  // "the slice or the regex stopped matching" by refusing to proceed.
+  if (names.size < 5) {
+    throw new Error(
+      `parsed ${names.size} tool names from nativeRuntimeService.ts's TOOLS array `
+      + `(${body.length} chars sliced). The declaration shape has changed; fix the slice `
+      + 'before trusting a result.',
+    );
+  }
+  return names;
+};
+
+/**
+ * Names that presets.ts mentions in order to say they are GONE.
+ *
+ * One live site, in the dev-pm preset's prompt: "(The former `commonly_pr_diff`
+ * /`commonly_pr_review` tools were removed — they spent a shared server
+ * credential on a caller-chosen repo.)" That sentence is correct, and a
+ * name-matching check fires on it. Excluding by name is the honest handling;
+ * trying to detect negated prose is not something a regex should be asked to do.
+ *
+ * Self-checked below on the same principle as `namedForOtherDrivers`: an
+ * exemption for a name the file no longer mentions is a hole with no remaining
+ * justification, and it would silently excuse that tool if a preset later
+ * started cueing it for real.
+ */
+const NAMED_AS_REMOVED = ['commonly_pr_diff', 'commonly_pr_review'];
+
+/**
+ * presets.ts split into its preset definitions, each with the runtime it
+ * declares and every `commonly_*` name its text hands an agent.
+ *
+ * Comments are stripped FIRST, and that is load-bearing rather than tidy. Three
+ * of the file's twenty names live only in `//` comments — including
+ * `commonly_save_my_memory`, which appears in call-with-parens shape inside a
+ * comment and nowhere else. So the "names in `name(` position" set is not a
+ * subset of the agent-facing set; it both admits a comment and, more
+ * importantly, drops real instructions. social-amplifier's prompt says "Only
+ * post final conversational content via commonly_post_message" — an instruction
+ * to call a tool, written as a sentence, with no parens. It is also the ONLY
+ * tool named by either `internal` preset, so a call-position check would cover
+ * zero of the presets on the runtime whose namespace actually differs.
+ */
+const parsePresets = (source) => {
+  const code = stripComments(source);
+  const lines = code.split('\n');
+  const starts = [];
+  lines.forEach((line, i) => { if (/^ {4}id: '/.test(line)) starts.push(i); });
+
+  // Control, same shape as the empty-parse guard above: zero or a handful of
+  // blocks means the file's indentation or shape moved, and a check that looks
+  // at almost nothing passes almost everything.
+  if (starts.length < 20) {
+    throw new Error(
+      `parsed ${starts.length} preset definitions from presets.ts (expected 30+). `
+      + 'The block shape has changed; fix parsePresets before trusting a result.',
+    );
+  }
+
+  return starts.map((start, k) => {
+    const end = k + 1 < starts.length ? starts[k + 1] : lines.length;
+    const body = lines.slice(start, end).join('\n');
+    const id = (body.match(/^ {4}id: '([^']+)'/) || [])[1];
+    const runtimes = [...new Set([...body.matchAll(/runtime: '([a-z-]+)'/g)].map((m) => m[1]))];
+    if (!id) throw new Error(`preset block at line ${start + 1} has no parseable id`);
+    if (runtimes.length !== 1) {
+      throw new Error(
+        `preset '${id}' declares ${runtimes.length} distinct runtimes (${runtimes.join(', ') || 'none'}). `
+        + 'This check resolves tool names against exactly one runtime per preset; '
+        + 'a block with none or several needs a deliberate rule, not a guess.',
+      );
+    }
+    return {
+      id,
+      line: start + 1,
+      runtime: runtimes[0],
+      names: [...new Set(body.match(/commonly_[a-z_]+/g) || [])],
+    };
+  });
+};
+
+/**
+ * Does every tool a preset teaches exist on the runtime that preset declares?
+ *
+ * This is the check the row TASK-087 was filed for. presets.ts ships heartbeat
+ * and soul prompts to real seats, naming twenty distinct tools, and nothing read
+ * them at the name level — this script read exactly one symbol out of the file
+ * (CYCLES_REFLECTION_TRAILER) and nothing else.
+ *
+ * Correct today, and correct by placement rather than by anything that checks:
+ * `commonly_create_post` exists on openclaw and on neither other surface, and
+ * all five of its sites happen to sit in `runtime: 'openclaw'` presets. Flip one
+ * preset to `internal` and every woken seat reads a prompt teaching a tool its
+ * driver does not have, with nothing red.
+ *
+ * The blast radius is a wasted turn rather than a bad write — the native
+ * dispatcher's `default` returns `unknown_tool`, so that surface fails closed
+ * and legibly. This check is worth its weight because the failure is silent, not
+ * because it is dangerous.
+ */
+const checkPresetToolNames = ({ presets, sets }) => {
+  const mentioned = new Set(presets.flatMap((p) => p.names));
+  NAMED_AS_REMOVED.forEach((tool) => {
+    if (!mentioned.has(tool)) {
+      throw new Error(
+        `NAMED_AS_REMOVED lists ${tool}, but presets.ts no longer mentions it. Delete the `
+        + 'exemption rather than leaving it to excuse a future use.',
+      );
+    }
+  });
+
+  const exempt = new Set(NAMED_AS_REMOVED);
+  const missing = [];
+  const uncovered = [];
+
+  presets.forEach((preset) => {
+    const names = preset.names.filter((n) => !exempt.has(n));
+    const set = sets[preset.runtime];
+    if (!set) {
+      // `claude-code` and `webhook` presets name no tools today. If one starts
+      // to, that is a decision about which tool surface those runtimes expose —
+      // and this check must say it cannot answer rather than skip quietly.
+      if (names.length) uncovered.push({ preset, names });
+      return;
+    }
+    names.filter((n) => !set.has(n)).forEach((tool) => missing.push({ preset, tool }));
+  });
+
+  return { missing, uncovered, mentioned, presetCount: presets.length };
+};
+
 const main = () => {
   let required;
   try {
@@ -594,17 +792,22 @@ const main = () => {
   }
   const pin = readGitlinkSha();
 
-  if (!fs.existsSync(EXTENSION_TOOLS)) {
+  const extension = readExtensionToolsAtPin();
+  if (!extension.ok) {
     console.error(
-      `[moltbot-tool-contract] CANNOT VERIFY — ${path.relative(REPO_ROOT, EXTENSION_TOOLS)} is absent.\n`
-      + `  The submodule is pinned at ${pin} but not checked out.\n`
-      + '  Run: git submodule update --init --recursive _external/clawdbot\n'
-      + '  Exiting 2 (cannot verify), NOT 0 — an unrun check is not a passing one.',
+      `[moltbot-tool-contract] CANNOT VERIFY — could not read ${EXTENSION_TOOLS_REL} at the pin.\n`
+      + `  ${extension.reason}\n`
+      + `  The submodule is pinned at ${pin}. Check it out with:\n`
+      + '    git submodule update --init --recursive _external/clawdbot\n'
+      + '  Exiting 2 (cannot verify), NOT 0 — an unrun check is not a passing one.\n'
+      + '  Falling back to the working-tree copy is NOT the safe move here: it would answer\n'
+      + '  against whatever commit that tree is on, and the lineages declare identical tool\n'
+      + '  names, so a wrong-provenance read agrees with a correct one and looks like a pass.',
     );
     process.exit(2);
   }
 
-  const declared = parseDeclaredTools(fs.readFileSync(EXTENSION_TOOLS, 'utf8'));
+  const declared = parseDeclaredTools(extension.text);
 
   // Control: a parse that finds nothing would satisfy no assertion below by
   // emptiness, and would report every required tool as missing — a loud but
@@ -613,8 +816,23 @@ const main = () => {
   if (declared.size === 0) {
     console.error(
       '[moltbot-tool-contract] CANNOT VERIFY — parsed 0 tool declarations from a file '
-      + `of ${fs.statSync(EXTENSION_TOOLS).size} bytes.\n`
+      + `of ${extension.text.length} bytes.\n`
       + '  The declaration shape has changed; fix parseDeclaredTools before trusting a result.',
+    );
+    process.exit(2);
+  }
+
+  let presetCheck;
+  try {
+    presetCheck = checkPresetToolNames({
+      presets: parsePresets(fs.readFileSync(PRESETS_FILE, 'utf8')),
+      sets: { openclaw: declared, internal: loadNativeTools() },
+    });
+  } catch (err) {
+    console.error(
+      '[moltbot-tool-contract] CANNOT VERIFY — could not resolve preset tool names.\n'
+      + `  ${err.message}\n`
+      + '  Exiting 2. The check did not run; it did not pass.',
     );
     process.exit(2);
   }
@@ -673,14 +891,47 @@ const main = () => {
     );
   }
 
+  if (presetCheck.missing.length) {
+    console.error(
+      `[moltbot-tool-contract] FAIL — ${presetCheck.missing.length} tool name(s) in presets.ts `
+      + 'do not exist on the runtime the preset declares:\n'
+      + presetCheck.missing
+        .map(({ preset, tool }) => `    ${tool}   (runtime: '${preset.runtime}' — preset '${preset.id}', block opens at presets.ts:${preset.line})`)
+        .join('\n')
+      + '\n\n  These are soul and heartbeat prompts shipped to real seats. A name that does not\n'
+      + '  resolve on the preset\'s own runtime sends every woken agent hunting a tool its\n'
+      + '  driver does not have. The three surfaces spell shared capabilities differently\n'
+      + '  (commonly_read_memory vs commonly_read_agent_memory vs commonly_get_context), so\n'
+      + '  the fix is usually the right SPELLING for that runtime, not a new tool.',
+    );
+  } else {
+    console.log(
+      `[moltbot-tool-contract] OK — presets.ts teaches ${presetCheck.mentioned.size} distinct `
+      + `commonly_* names across ${presetCheck.presetCount} presets, and every one resolves on the `
+      + 'runtime its preset declares.',
+    );
+  }
+
+  if (presetCheck.uncovered.length) {
+    console.error(
+      '[moltbot-tool-contract] CANNOT VERIFY — a preset now cues tools on a runtime this check\n'
+      + '  has no tool set for:\n'
+      + presetCheck.uncovered
+        .map(({ preset, names }) => `    '${preset.id}' (runtime: '${preset.runtime}') names ${names.join(', ')}`)
+        .join('\n')
+      + '\n  Add that runtime to the `sets` map with the surface it actually exposes. Exiting 2:\n'
+      + '  skipping it quietly is how presets.ts went unread at the name level to begin with.',
+    );
+  }
+
   if (reach.state === 'contained') {
     console.log(`[moltbot-tool-contract] OK — ${reach.detail}, the branch .gitmodules declares.`);
   }
 
   // Severity order: a proven violation (1) outranks an unrun check (2) only
   // because a violation is actionable now. Both are non-zero; neither is a pass.
-  if (missing.length || reach.state === 'orphaned') process.exit(1);
-  if (reach.state === 'undetermined') process.exit(2);
+  if (missing.length || presetCheck.missing.length || reach.state === 'orphaned') process.exit(1);
+  if (presetCheck.uncovered.length || reach.state === 'undetermined') process.exit(2);
 };
 
 if (require.main === module) main();
@@ -688,5 +939,7 @@ if (require.main === module) main();
 module.exports = {
   parseDeclaredTools, collectRequiredTools, loadCyclesTrailer, loadMentionCues,
   readDeclaredBranch, checkPinReachable, readGitlinkSha,
+  parsePresets, checkPresetToolNames, loadNativeTools, readExtensionToolsAtPin,
+  NAMED_AS_REMOVED, PRESETS_FILE,
   MENTION_CUES, REQUIRED_TOOL_SOURCES, stripComments,
 };

--- a/scripts/verify-moltbot-tool-contract.js
+++ b/scripts/verify-moltbot-tool-contract.js
@@ -634,8 +634,8 @@ const readExtensionToolsAtPin = ({ exec = execFileSync } = {}) => {
  * loadCyclesTrailer reads presets.ts: a restated list is a fourth copy of a set
  * that already has three, and this file exists because copies drift.
  */
-const loadNativeTools = () => {
-  const code = stripComments(fs.readFileSync(NATIVE_RUNTIME, 'utf8'));
+const loadNativeTools = ({ read = fs.readFileSync } = {}) => {
+  const code = stripComments(read(NATIVE_RUNTIME, 'utf8'));
   const start = code.indexOf('const TOOLS = [');
   if (start === -1) throw new Error('const TOOLS not found in nativeRuntimeService.ts');
   const rest = code.slice(start);


### PR DESCRIPTION
`scripts/verify-moltbot-tool-contract.js` read exactly one symbol out of `presets.ts` — `CYCLES_REFLECTION_TRAILER` — while the same file ships soul and heartbeat prompts naming **18 distinct `commonly_*` tools across 33 presets** to real seats, with nothing checking any of them at the name level. That is this script's own stated purpose, one file over.

It is correct today, and correct **by placement rather than by anything that checks**. `commonly_create_post` exists on openclaw and on neither other surface; all five of its sites happen to sit in `runtime: 'openclaw'` presets. Flip one preset to `internal` and every woken seat reads a prompt teaching a tool its driver does not have, with nothing red.

## Why per-runtime, and why there are three namespaces

The `internal` runtime's surface is a hardcoded 7-entry `TOOLS` array in `nativeRuntimeService.ts` — not the MCP set, and **not a subset** of the extension's. It spells shared capabilities differently: `commonly_read_memory` vs `commonly_read_agent_memory`, `commonly_read_context` vs `commonly_get_context`. A capability-level comparison scores those as present on both. Only a name-level one sees it.

## Two decisions worth defending

**Comments are stripped before names are collected, and that is load-bearing.** Three of the file's twenty names live only in `//` comments — including `commonly_save_my_memory`, whose only occurrence is in call-with-parens shape *inside a comment*. So "names in `name(` position" is not a subset of the agent-facing set: it admits a comment and it drops real instructions. social-amplifier's prompt says *"Only post final conversational content via commonly_post_message"* — an instruction to call a tool, written as a sentence, no parens — and it is the **only** tool named by either `internal` preset. A call-position check would have covered **zero** of the presets on the runtime whose namespace actually differs, and gone green over the surface it was written for.

**The extension tool set is now read AT THE GITLINK PIN.** Every other pin fact in this file already came from `git ls-tree`, and then the one read deciding the tool contract went to `fs.readFileSync` of the submodule **working tree**. CI never saw it (`submodules: recursive` checks out the gitlink, so tree and pin coincide there); it only ever misled a human, and it misled one on this row — a measurement taken at `70bd82b8` was reported as "the pin `main` declares", which was `5d88a3f1`. The two lineages declare **byte-identical** tool names, so the off-pin read *agreed* with the correct one. A wrong-provenance measurement that returns the right answer is indistinguishable from a right one, and the next person to reproduce it confirms nothing. There is deliberately **no working-tree fallback** — it would restore exactly that.

## Proven by mutation — six arms, each restored after

| arm | mutation | result |
|---|---|---|
| 1 | `x-curator` flipped to `runtime: 'internal'` | **exit 1**, all 5 names, with preset id + line + runtime. The row's exact scenario. |
| 2 | `commonly_post_message` renamed in the native `TOOLS` array alone | **exit 1** on `social-amplifier` — the parens-less sentence a call-position check cannot see |
| 3 | presets.ts stops mentioning `commonly_pr_diff` | **exit 2**, stale exemption named |
| 4 | a `claude-code` preset starts naming a tool | **exit 2**, uncovered runtime named rather than skipped |
| 5 | `const TOOLS` renamed in `nativeRuntimeService.ts` | **exit 2** |
| 6 | submodule absent | **exit 2**, no fallback |

Baseline before and after every arm: **exit 0**, `18 distinct commonly_* names across 33 presets, and every one resolves on the runtime its preset declares`.

`NAMED_AS_REMOVED` covers the one true negative: dev-pm's prompt names `commonly_pr_diff`/`commonly_pr_review` in order to say they were **removed**. It is self-checked the same way `namedForOtherDrivers` is — an exemption for a name the file no longer mentions is a hole with no remaining justification — and arm 3 proves that fires.

## Scope

One file. No behaviour change to any runtime; this only adds a reader and corrects where an existing reader reads from. Exit-code discipline is unchanged: **1** = proven violation, **2** = could not verify, and **2 is not 0**.

**Not in this PR, and ready:** @sprint-review verified on the row that deriving `CommonlyTool` from `TOOLS` (`as const` + a `readonly (typeof TOOLS)[number][]` return on `toolsForConfig`) typechecks clean and discriminates under a rename — and found a *third* copy of the name set in `packages/commonly-apps/src/types.ts` that has already drifted (6 names; missing `commonly_agent_status`, which `scout.ts` declares and teaches). That retires a name set rather than checking it, and belongs in its own PR by whoever measured it.

Filed by @sprint-review as TASK-087, off TASK-074/086.

🤖 Generated with [Claude Code](https://claude.com/claude-code)