### PR TITLE
refactor(native-runtime): derive CommonlyTool from TOOLS instead of restating it

### DIFF
--- a/backend/config/native-agents/types.ts
+++ b/backend/config/native-agents/types.ts
@@ -1,14 +1,31 @@
 /**
  * Backend-local mirror of the NativeAgentDefinition contract.
  *
- * The source of truth lives in packages/commonly-apps/src/types.ts. This
- * file is duplicated here because backend/tsconfig.typescheck.json scopes
- * includes to backend/** — cross-package imports don't typecheck. Round 2
- * can consolidate via project references or a path alias; for Round 1 the
- * shapes are kept byte-identical so substitution is trivial.
+ * This file is duplicated from packages/commonly-apps/src/types.ts because
+ * backend/tsconfig.typescheck.json scopes includes to backend/** — cross-package
+ * imports don't typecheck. Round 2 can consolidate via project references or a
+ * path alias.
  *
- * DO NOT drift from packages/commonly-apps/src/types.ts without updating
- * both files.
+ * The previous version of this comment named packages/commonly-apps as "the
+ * source of truth", said the shapes were "kept byte-identical so substitution is
+ * trivial", and instructed readers not to drift from it. All three were false at
+ * the time of this change, and had been for a while:
+ *
+ *   - The shapes had ALREADY drifted. That file's `CommonlyTool` lists six
+ *     names; this one listed seven. The missing one is `commonly_agent_status`,
+ *     which scout declares, so substituting the "source of truth" would have
+ *     failed to type a shipped agent.
+ *   - Nothing imports the package. There are no non-comment imports of
+ *     commonly-apps anywhere in the repo, and it is not a workspace member, so
+ *     no compiler and no test has ever read it.
+ *   - A "DO NOT drift" instruction was therefore the only guard on that pairing,
+ *     which is to say there was none — it is addressed to a human who must
+ *     already know the other file exists.
+ *
+ * `CommonlyTool` below is now DERIVED from the runtime's own declarations
+ * rather than restated, so it cannot drift from the surface it describes.
+ * The remaining shapes here are still hand-mirrored; treat packages/commonly-apps
+ * as historical until someone deletes it or wires it up.
  */
 export type NativeAgentTrigger =
   | 'mention'
@@ -17,14 +34,22 @@ export type NativeAgentTrigger =
   | 'chat.message'
   | 'pod.join';
 
+/**
+ * DERIVED from the runtime's own tool declarations — never hand-maintained.
+ *
+ * This was a written-out union of the same seven names as `TOOLS` in
+ * services/nativeRuntimeService.ts, with no derivation between them. Two silent
+ * drift modes: add to TOOLS and forget the union, and no definition can declare
+ * the new tool, so `toolsForConfig` filters it out of every install (the tool
+ * exists and is unreachable); rename in TOOLS and not the union, and definitions
+ * still typecheck while `declared.includes(...)` drops the tool with nothing red
+ * (the agent silently loses a capability).
+ *
+ * Deriving retires the second copy: a rename in TOOLS now fails the build at
+ * every definition that declares the old name.
+ */
 export type CommonlyTool =
-  | 'commonly_read_context'
-  | 'commonly_read_memory'
-  | 'commonly_write_memory'
-  | 'commonly_post_message'
-  | 'commonly_create_task'
-  | 'commonly_propose_action'
-  | 'commonly_agent_status';
+  (typeof import('../../services/nativeRuntimeService').TOOLS)[number]['function']['name'];
 
 export interface NativeAgentDefinition {
   agentName: string;

--- a/backend/services/nativeRuntimeService.ts
+++ b/backend/services/nativeRuntimeService.ts
@@ -103,9 +103,19 @@ export function isNativeRuntimeAvailable(): boolean {
   return resolveLiteLLM() !== null;
 }
 
-// --- tool schema (exactly 5 tools, OpenAI function-calling format) --------
+// --- tool schema (OpenAI function-calling format) -------------------------
+//
+// SOURCE OF TRUTH for the `internal` runtime's tool names. `CommonlyTool`
+// in config/native-agents/types.ts is DERIVED from this array, so adding or
+// renaming an entry here immediately reaches every agent definition that
+// declares tools. Do not restate these names anywhere; a second copy is what
+// this derivation exists to prevent.
+//
+// The count is deliberately not stated here — the previous comment said
+// "exactly 5 tools" while the array held 7, and it was the only prose
+// describing this surface.
 
-const TOOLS = [
+export const TOOLS = [
   {
     type: 'function',
     function: {
@@ -234,7 +244,7 @@ const TOOLS = [
       parameters: { type: 'object', properties: {} },
     },
   },
-];
+] as const;
 
 // ADR-020 D1: the manifest's `tools` list is the capability boundary, and it
 // must be ENFORCED here, not just declared. Before this filter, TOOLS went
@@ -242,7 +252,7 @@ const TOOLS = [
 // was decorative (caught in the 2026-08-13 build recon). Installs that
 // predate tool lists (no cfg.tools) keep the pre-gate surface minus
 // approval proposing, which is opt-in by declaration only.
-export const toolsForConfig = (cfg: { tools?: unknown } | null | undefined): typeof TOOLS => {
+export const toolsForConfig = (cfg: { tools?: unknown } | null | undefined): readonly (typeof TOOLS)[number][] => {
   const declared = Array.isArray(cfg?.tools) ? (cfg?.tools as string[]) : null;
   if (!declared) {
     return TOOLS.filter((t) => t.function.name !== 'commonly_propose_action');


### PR DESCRIPTION
Derives `CommonlyTool` from the runtime's own tool declarations instead of restating them. Found by @pod-architect while reviewing TASK-087; measured and built here at their suggestion, since the measurement was already done.

## The defect

The `internal` runtime's tool names lived in **two** places with no derivation between them — `TOOLS` in `services/nativeRuntimeService.ts` and a hand-written union in `config/native-agents/types.ts`. Same seven names, same order, written out twice. `NativeAgentDefinition.tools` is `CommonlyTool[]`, so all five agent definitions were name-checked at compile time **against the copy, not the source**.

Both drift modes are silent:

- **Add to `TOOLS`, forget the union** — no definition can declare the new tool, so `toolsForConfig` filters it out of every install. The tool exists and is unreachable.
- **Rename in `TOOLS`, not the union** — definitions still typecheck, and `declared.includes(t.function.name)` drops the tool with nothing red. The agent silently loses a capability.

## What ships

`export type CommonlyTool = (typeof TOOLS)[number]['function']['name']`, with `TOOLS` exported and `as const`.

**`as const` alone does not compile**, which is the non-obvious part. It makes `TOOLS` a fixed-length 7-tuple, and `toolsForConfig` was declared `: typeof TOOLS` while its body is a `.filter()` — *"Target requires 7 element(s) but source may have fewer."* The signature is widened to `readonly (typeof TOOLS)[number][]`.

## Proof

| check | result |
|---|---|
| `tsc -p tsconfig.typescheck.json --noEmit` at `origin/main` | exit 0 |
| same, with this change | **exit 0**, zero output |
| **positive control** — rename `commonly_agent_status` in `TOOLS` alone | **exit 2**, fails on scout's `tools` in `apps.ts` |
| native-runtime suites (8 files) at `origin/main` | 8 passed / 44 tests |
| same, with this change | **8 passed / 44 tests** — no delta |

The control is the point: before this change that rename was silent, and it is drift mode 2 above.

## Runtime impact, measured rather than asserted

Compiled both trees with `tsconfig.build.json` and diffed the emit. **`as const` is fully erased — the array literal is byte-identical in the output.** The only runtime delta comes from `export`: a new `exports.TOOLS` binding, and the two internal reads becoming `exports.TOOLS.filter(...)` — the same array object. No other emitted file changes.

So this is not a "types only, no runtime change" PR, and I would rather say so precisely: it adds one module export that nothing currently imports.

## Two comments corrected, because both were false rather than merely stale

- `nativeRuntimeService.ts` said **"exactly 5 tools"** above an array of **7**, and was the only prose describing that surface.
- `types.ts` named `packages/commonly-apps/src/types.ts` as the source of truth, said the shapes were *"kept byte-identical so substitution is trivial"*, and instructed readers not to drift from it. **They had already drifted, and the declared source of truth is the stale one** — its `CommonlyTool` lists **6** names to this file's 7, missing `commonly_agent_status`, which `scout.ts` declares at :87 and teaches in its prompt at :56. Substituting it would have failed to type a shipped agent.

  Nothing caught it because **nothing imports the package**: no non-comment imports of `commonly-apps` anywhere in `.ts`/`.tsx`, and the root `package.json` has no `workspaces` key. A `DO NOT drift` comment was the only guard on that pairing, which is to say there was none.

## Deliberately not in scope

The third copy in `packages/commonly-apps` is left alone. Nothing imports it, so deleting it is plausibly right, but that is a call for whoever owns `packages/` — and if anything outside this repo consumes it, deletion is breaking. The docblock now describes it as historical rather than authoritative, which stops it misleading the next reader without pre-empting that decision.

## Not verified

I ran the native-runtime suites and the typecheck, not the full backend suite — CI is the stronger signal. And the emit comparison used `tsconfig.build.json`; if anything runs the `.ts` sources through a different transpiler at runtime, that path is unmeasured here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
