### PR TITLE
feat(runtime): pi agent-core turn engine — W2 PR 2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,9 @@ jobs:
           npm ci --include=dev
           cd ../cli
           npm ci --include=dev
-          cd ..
+          cd ../workers/agent-runtime
+          npm ci --include=dev
+          cd ../..
 
       - name: Verify moltbot tool contract
         run: npm run verify:moltbot-tools
@@ -133,6 +135,12 @@ jobs:
       - name: Run CLI tests
         run: |
           cd cli
+          npm test
+
+      - name: Run hosted-runtime tests (ADR-023 W2)
+        run: |
+          cd workers/agent-runtime
+          npm run typecheck
           npm test
 
       - name: Upload coverage report

--- a/workers/agent-runtime/README.md
+++ b/workers/agent-runtime/README.md
@@ -18,9 +18,14 @@ Operator/CI only (Cloudflare account is operator-private):
 `npx wrangler deploy` with `ANTHROPIC_API_KEY` set as a secret.
 
 ## Deliberate v1 boundaries
-- Turn = single Anthropic call through the injected-transport seam; pi
-  AgentHarness + compaction is the next PR (spike proved it constructs
-  under workerd; the seam does not change).
+- Turn = pi agent-core's `runAgentLoop` with pi-ai's `streamSimple`
+  transport (Anthropic provider registered explicitly — `createModels()`
+  starts empty). The transcript persists on DO storage, APPENDED per turn
+  (the loop returns only the current turn's messages), bounded by pi's token
+  estimate at turn boundaries and by a 1 MB byte ceiling for the DO value
+  cap. No tools yet. Next slices, same seam: CAP tools, and pi's real
+  compaction (Session-entry based, arrives with the Session layer). A
+  missing model key throws — the event stays unacked and `/status` shows it.
 - Wake = alarm polling (wrapper-identical, zero kernel change). Push later.
 - **Metering ships WITH hosted agents, not after (ADR-023 D3.1)** — an
   unmetered public hosted runtime does not leave beta. Provision is

--- a/workers/agent-runtime/package-lock.json
+++ b/workers/agent-runtime/package-lock.json
@@ -8,7 +8,8 @@
       "name": "@commonlyai/agent-runtime",
       "version": "0.1.0",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "0.84.2"
+        "@earendil-works/pi-agent-core": "0.84.2",
+        "@earendil-works/pi-ai": "^0.84.2"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^5.20260828.1",
@@ -626,15 +627,16 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.4.tgz",
-      "integrity": "sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
+      "integrity": "sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.4",
+        "@earendil-works/pi-telemetry": "^0.84.2",
         "@google/genai": "1.52.0",
+        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
@@ -1736,6 +1738,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@poppinss/colors": {

--- a/workers/agent-runtime/package-lock.json
+++ b/workers/agent-runtime/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^5.20260828.1",
         "typescript": "^5.5.0",
+        "vitest": "^3.2.7",
         "wrangler": "^4.0.0"
       }
     },
@@ -1740,6 +1741,26 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -1834,6 +1855,395 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
@@ -1974,6 +2384,31 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "26.4.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
@@ -1989,6 +2424,121 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -1996,6 +2546,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/base64-js": {
@@ -2046,6 +2606,43 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -2086,6 +2683,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2123,6 +2730,13 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -2166,11 +2780,49 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -2311,6 +2963,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -2370,6 +3029,23 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/miniflare": {
       "version": "5.20260828.0-alpha",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260828.0-alpha.tgz",
@@ -2415,6 +3091,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -2505,6 +3200,65 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.6.6",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
@@ -2535,6 +3289,52 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -2615,6 +3415,50 @@
         "@img/sharp-win32-x64": "0.35.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -2626,6 +3470,67 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-algebra": {
@@ -2686,6 +3591,177 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -2693,6 +3769,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workerd": {

--- a/workers/agent-runtime/package.json
+++ b/workers/agent-runtime/package.json
@@ -2,14 +2,15 @@
   "name": "@commonlyai/agent-runtime",
   "private": true,
   "version": "0.1.0",
-  "description": "ADR-023 W2 hosted agent runtime \u2014 Durable Objects + pi agent-core",
+  "description": "ADR-023 W2 hosted agent runtime — Durable Objects + pi agent-core",
   "scripts": {
     "dev": "wrangler dev --local",
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "0.84.2"
+    "@earendil-works/pi-agent-core": "0.84.2",
+    "@earendil-works/pi-ai": "^0.84.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260828.1",

--- a/workers/agent-runtime/package.json
+++ b/workers/agent-runtime/package.json
@@ -2,11 +2,12 @@
   "name": "@commonlyai/agent-runtime",
   "private": true,
   "version": "0.1.0",
-  "description": "ADR-023 W2 hosted agent runtime — Durable Objects + pi agent-core",
+  "description": "ADR-023 W2 hosted agent runtime \u2014 Durable Objects + pi agent-core",
   "scripts": {
     "dev": "wrangler dev --local",
     "deploy": "wrangler deploy",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@earendil-works/pi-agent-core": "0.84.2",
@@ -15,6 +16,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260828.1",
     "typescript": "^5.5.0",
+    "vitest": "^3.2.7",
     "wrangler": "^4.0.0"
   }
 }

--- a/workers/agent-runtime/src/agent-do.ts
+++ b/workers/agent-runtime/src/agent-do.ts
@@ -139,8 +139,9 @@ export class AgentRuntimeDO implements DurableObject {
   // transport, tail-bounded context. Pod context is folded into the prompt
   // as text until CAP tools land (next slice).
   private async runTurn(prompt: string, context: unknown): Promise<string> {
-    const key = this.env.ANTHROPIC_API_KEY;
-    if (!key) return 'NO_REPLY';
+    // No silent NO_REPLY on a missing key — runTurn throws, the event stays
+    // unacked, and /status shows the misconfiguration (Otto, #1339).
+    const key = this.env.ANTHROPIC_API_KEY || '';
     const recent = ((context as { recentMessages?: { content?: string; senderName?: string }[] })?.recentMessages || [])
       .slice(-10)
       .map((m) => `${m.senderName || 'someone'}: ${String(m.content || '').slice(0, 400)}`)

--- a/workers/agent-runtime/src/agent-do.ts
+++ b/workers/agent-runtime/src/agent-do.ts
@@ -10,12 +10,15 @@
 // spike's finding #2: transport is dependency-injected and workerd-clean).
 // v1 wires a minimal turn; harness/compaction integration follows.
 import { listEvents, ackEvent, getPodContext, postMessage, CapConfig, CapEvent } from './cap';
+import { runTurn } from './turn';
 
 export interface Env {
   AGENT: DurableObjectNamespace;
   COMMONLY_API_URL: string;
   // Operator admin secret gating every worker route (wrangler secret).
   RUNTIME_ADMIN_TOKEN?: string;
+  // Optional model override (defaults in turn.ts).
+  MODEL_ID?: string;
   // Model transport for the injected streamFn. BYOK per instance; metering
   // ships WITH hosted agents, not after (ADR-023 D3.1) — see TODO below.
   ANTHROPIC_API_KEY?: string;
@@ -132,28 +135,22 @@ export class AgentRuntimeDO implements DurableObject {
     }
   }
 
-  // v1 turn: direct Anthropic call through the injected-transport seam the
-  // spike proved. pi AgentHarness + compaction integration is the next PR —
-  // the seam (string in, string out, context available) does not change.
-  private async runTurn(prompt: string, _context: unknown): Promise<string> {
+  // The pi-driven turn (turn.ts): transcript on DO storage, streamSimple
+  // transport, tail-bounded context. Pod context is folded into the prompt
+  // as text until CAP tools land (next slice).
+  private async runTurn(prompt: string, context: unknown): Promise<string> {
     const key = this.env.ANTHROPIC_API_KEY;
     if (!key) return 'NO_REPLY';
-    const res = await fetch('https://api.anthropic.com/v1/messages', {
-      method: 'POST',
-      headers: {
-        'x-api-key': key,
-        'anthropic-version': '2023-06-01',
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: 'claude-sonnet-5',
-        max_tokens: 1024,
-        messages: [{ role: 'user', content: prompt || 'You were woken with no content.' }],
-        system: 'You are a Commonly hosted agent. Reply concisely and usefully to the pod message you were mentioned in. If no reply is genuinely needed, reply with exactly NO_REPLY.',
-      }),
-    });
-    if (!res.ok) throw new Error(`anthropic ${res.status}`);
-    const body = (await res.json()) as { content?: { text?: string }[] };
-    return body.content?.map((c) => c.text || '').join('') || 'NO_REPLY';
+    const recent = ((context as { recentMessages?: { content?: string; senderName?: string }[] })?.recentMessages || [])
+      .slice(-10)
+      .map((m) => `${m.senderName || 'someone'}: ${String(m.content || '').slice(0, 400)}`)
+      .join('\n');
+    const userText = `Recent pod messages:\n${recent}\n\nYou were mentioned with: ${prompt}`;
+    return runTurn({
+      storage: this.state.storage,
+      apiKey: key,
+      modelId: this.env.MODEL_ID,
+      systemPrompt: 'You are a Commonly hosted agent living in a shared pod with humans and other agents. Reply concisely and usefully to the message you were mentioned in. If no reply is genuinely needed, reply with exactly NO_REPLY.',
+    }, userText);
   }
 }

--- a/workers/agent-runtime/src/turn.ts
+++ b/workers/agent-runtime/src/turn.ts
@@ -1,0 +1,82 @@
+// The turn engine: pi agent-core driven directly (runAgentLoop), with the
+// transcript persisted on DO storage and pi's own compaction keeping it
+// bounded. This is the ADR-021/023 engine landing in its production home.
+//
+// v1 scope (deliberate): streamSimple as the transport (pi-ai's Anthropic
+// provider — fetch-based, workerd-clean per the spike), no tools yet. The
+// reply is the final assistant text. Two named next slices, neither of which
+// changes this seam (transcript in, text out): CAP tools (read pod context,
+// attach), and pi's real compaction — which is Session-entry based
+// (prepareCompaction takes Entry[], not AgentMessage[]), so it arrives with
+// the Session layer. Until then the transcript is tail-bounded by pi's own
+// token estimate: honest, bounded, and lossy only at the oldest end.
+import {
+  runAgentLoop,
+  estimateContextTokens,
+  type AgentMessage,
+  type AgentContext,
+  type AgentLoopConfig,
+} from '@earendil-works/pi-agent-core';
+import { createModels, hasApi, type Message } from '@earendil-works/pi-ai';
+import { streamSimple } from '@earendil-works/pi-ai/compat';
+
+export interface TurnDeps {
+  storage: DurableObjectStorage;
+  apiKey: string;
+  modelId?: string;
+  systemPrompt: string;
+}
+
+const TRANSCRIPT_KEY = 'transcript';
+const DEFAULT_MODEL = 'claude-sonnet-5';
+
+// Identity conversion: AgentMessage ⊇ Message; anything that is not a plain
+// LLM message (custom agent messages) is dropped. Contract: never throws.
+const convertToLlm = (messages: AgentMessage[]): Message[] => messages.filter(
+  (m): m is Message => m && typeof (m as { role?: unknown }).role === 'string'
+    && ['user', 'assistant', 'toolResult'].includes(String((m as { role: string }).role)),
+);
+
+const lastAssistantText = (messages: AgentMessage[]): string => {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const m = messages[i] as { role?: string; content?: unknown };
+    if (m.role !== 'assistant') continue;
+    const content = m.content;
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content)) {
+      return content.map((c) => (c && (c as { type?: string }).type === 'text' ? String((c as { text?: string }).text || '') : '')).join('');
+    }
+  }
+  return '';
+};
+
+export const runTurn = async (deps: TurnDeps, userText: string): Promise<string> => {
+  const models = createModels();
+  const model = models.getModel('anthropic', deps.modelId || DEFAULT_MODEL);
+  if (!model || !hasApi(model, 'anthropic-messages')) {
+    throw new Error(`model unavailable: anthropic/${deps.modelId || DEFAULT_MODEL}`);
+  }
+
+  let transcript = (await deps.storage.get<AgentMessage[]>(TRANSCRIPT_KEY)) || [];
+
+  // Tail-bound the transcript to ~60% of the window using pi's estimator,
+  // dropping from the oldest end at turn boundaries (a user message).
+  const contextWindow = (model as { contextWindow?: number }).contextWindow || 200_000;
+  const budget = Math.floor(contextWindow * 0.6);
+  while (transcript.length > 2 && estimateContextTokens(transcript).tokens > budget) {
+    const nextUser = transcript.findIndex((m, i) => i > 0 && (m as { role?: string }).role === 'user');
+    transcript = nextUser > 0 ? transcript.slice(nextUser) : transcript.slice(1);
+  }
+
+  const prompt: AgentMessage = { role: 'user', content: [{ type: 'text', text: userText }], timestamp: Date.now() } as AgentMessage;
+  const context: AgentContext = { systemPrompt: deps.systemPrompt, messages: transcript, tools: [] };
+  const config: AgentLoopConfig = {
+    model,
+    convertToLlm,
+    getApiKey: () => deps.apiKey,
+  };
+
+  const updated = await runAgentLoop([prompt], context, config, () => {}, undefined, streamSimple);
+  await deps.storage.put(TRANSCRIPT_KEY, updated);
+  return lastAssistantText(updated).trim() || 'NO_REPLY';
+};

--- a/workers/agent-runtime/src/turn.ts
+++ b/workers/agent-runtime/src/turn.ts
@@ -19,16 +19,24 @@ import {
 } from '@earendil-works/pi-agent-core';
 import { createModels, hasApi, type Message } from '@earendil-works/pi-ai';
 import { streamSimple } from '@earendil-works/pi-ai/compat';
+import { anthropicProvider } from '@earendil-works/pi-ai/providers/anthropic';
 
 export interface TurnDeps {
   storage: DurableObjectStorage;
   apiKey: string;
   modelId?: string;
   systemPrompt: string;
+  // Injectable loop runner so the storage round-trip is testable without
+  // faking pi's event stream (Otto's #1339 gate: the persistence contract
+  // is where the blocker lived).
+  loop?: typeof runAgentLoop;
 }
 
 const TRANSCRIPT_KEY = 'transcript';
 const DEFAULT_MODEL = 'claude-sonnet-5';
+// DO storage caps a value at ~2 MiB on the SQLite backend (128 KiB on KV).
+// A token budget alone is denominated wrong for that (Otto): bound bytes too.
+export const TRANSCRIPT_BYTE_BUDGET = 1_000_000;
 
 // Identity conversion: AgentMessage ⊇ Message; anything that is not a plain
 // LLM message (custom agent messages) is dropped. Contract: never throws.
@@ -66,8 +74,28 @@ export const tailBound = (
   return out;
 };
 
+// Byte-bound after the token bound: drop oldest turns until the serialized
+// transcript fits DO storage. Same turn-boundary rule, same floor of two.
+export const byteBound = (messages: AgentMessage[], budgetBytes: number): AgentMessage[] => {
+  let out = messages;
+  while (out.length > 2 && JSON.stringify(out).length > budgetBytes) {
+    const nextUser = out.findIndex((m, i) => i > 0 && (m as { role?: string }).role === 'user');
+    out = nextUser > 0 ? out.slice(nextUser) : out.slice(1);
+  }
+  return out;
+};
+
 export const runTurn = async (deps: TurnDeps, userText: string): Promise<string> => {
+  if (!deps.apiKey) {
+    // A misconfigured deploy must surface on /status, not silently ack every
+    // mention as NO_REPLY (Otto). Throwing leaves the event unacked → lastError.
+    throw new Error('ANTHROPIC_API_KEY unset — refusing to run a turn');
+  }
+  // createModels() starts EMPTY — providers are registered, never assumed.
+  // (The round-trip test caught getModel returning nothing; the model leg
+  // would have failed at first contact.)
   const models = createModels();
+  models.setProvider(anthropicProvider());
   const model = models.getModel('anthropic', deps.modelId || DEFAULT_MODEL);
   if (!model || !hasApi(model, 'anthropic-messages')) {
     throw new Error(`model unavailable: anthropic/${deps.modelId || DEFAULT_MODEL}`);
@@ -86,7 +114,12 @@ export const runTurn = async (deps: TurnDeps, userText: string): Promise<string>
     getApiKey: () => deps.apiKey,
   };
 
-  const updated = await runAgentLoop([prompt], context, config, () => {}, undefined, streamSimple);
-  await deps.storage.put(TRANSCRIPT_KEY, updated);
-  return lastAssistantText(updated).trim() || 'NO_REPLY';
+  // runAgentLoop returns ONLY this turn's messages (prompts + replies), never
+  // context.messages — so the transcript is APPENDED, not replaced (Otto's
+  // #1339 blocker: the previous shape overwrote memory every turn).
+  const loop = deps.loop || runAgentLoop;
+  const turnMessages = await loop([prompt], context, config, () => {}, undefined, streamSimple);
+  const merged = byteBound([...transcript, ...turnMessages], TRANSCRIPT_BYTE_BUDGET);
+  await deps.storage.put(TRANSCRIPT_KEY, merged);
+  return lastAssistantText(turnMessages).trim() || 'NO_REPLY';
 };

--- a/workers/agent-runtime/src/turn.ts
+++ b/workers/agent-runtime/src/turn.ts
@@ -32,12 +32,12 @@ const DEFAULT_MODEL = 'claude-sonnet-5';
 
 // Identity conversion: AgentMessage ⊇ Message; anything that is not a plain
 // LLM message (custom agent messages) is dropped. Contract: never throws.
-const convertToLlm = (messages: AgentMessage[]): Message[] => messages.filter(
+export const convertToLlm = (messages: AgentMessage[]): Message[] => messages.filter(
   (m): m is Message => m && typeof (m as { role?: unknown }).role === 'string'
     && ['user', 'assistant', 'toolResult'].includes(String((m as { role: string }).role)),
 );
 
-const lastAssistantText = (messages: AgentMessage[]): string => {
+export const lastAssistantText = (messages: AgentMessage[]): string => {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     const m = messages[i] as { role?: string; content?: unknown };
     if (m.role !== 'assistant') continue;
@@ -50,6 +50,22 @@ const lastAssistantText = (messages: AgentMessage[]): string => {
   return '';
 };
 
+// Tail-bound the transcript to a token budget using pi's estimator, dropping
+// from the oldest end at turn boundaries (the next user message) so a turn is
+// never split. Always keeps at least the last two messages.
+export const tailBound = (
+  messages: AgentMessage[],
+  budgetTokens: number,
+  estimate: (m: AgentMessage[]) => number = (m) => estimateContextTokens(m).tokens,
+): AgentMessage[] => {
+  let out = messages;
+  while (out.length > 2 && estimate(out) > budgetTokens) {
+    const nextUser = out.findIndex((m, i) => i > 0 && (m as { role?: string }).role === 'user');
+    out = nextUser > 0 ? out.slice(nextUser) : out.slice(1);
+  }
+  return out;
+};
+
 export const runTurn = async (deps: TurnDeps, userText: string): Promise<string> => {
   const models = createModels();
   const model = models.getModel('anthropic', deps.modelId || DEFAULT_MODEL);
@@ -59,14 +75,8 @@ export const runTurn = async (deps: TurnDeps, userText: string): Promise<string>
 
   let transcript = (await deps.storage.get<AgentMessage[]>(TRANSCRIPT_KEY)) || [];
 
-  // Tail-bound the transcript to ~60% of the window using pi's estimator,
-  // dropping from the oldest end at turn boundaries (a user message).
   const contextWindow = (model as { contextWindow?: number }).contextWindow || 200_000;
-  const budget = Math.floor(contextWindow * 0.6);
-  while (transcript.length > 2 && estimateContextTokens(transcript).tokens > budget) {
-    const nextUser = transcript.findIndex((m, i) => i > 0 && (m as { role?: string }).role === 'user');
-    transcript = nextUser > 0 ? transcript.slice(nextUser) : transcript.slice(1);
-  }
+  transcript = tailBound(transcript, Math.floor(contextWindow * 0.6));
 
   const prompt: AgentMessage = { role: 'user', content: [{ type: 'text', text: userText }], timestamp: Date.now() } as AgentMessage;
   const context: AgentContext = { systemPrompt: deps.systemPrompt, messages: transcript, tools: [] };

--- a/workers/agent-runtime/test/cap.test.ts
+++ b/workers/agent-runtime/test/cap.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { listEvents, ackEvent, postMessage, getPodContext } from '../src/cap';
+
+const cfg = { apiUrl: 'https://api.test', runtimeToken: 'cm_agent_x' };
+
+describe('CAP client — the four verbs a BYO wrapper speaks', () => {
+  const fetchMock = vi.fn();
+  beforeEach(() => { fetchMock.mockReset(); vi.stubGlobal('fetch', fetchMock); });
+
+  it('lists pending events with the bearer + a non-default UA (Cloudflare 1010 lesson)', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ events: [{ _id: 'e1', type: 'chat.mention' }] }) });
+    const events = await listEvents(cfg);
+    expect(events).toEqual([{ _id: 'e1', type: 'chat.mention' }]);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.test/api/agents/runtime/events?status=pending');
+    expect(init.headers.Authorization).toBe('Bearer cm_agent_x');
+    expect(init.headers['User-Agent']).toMatch(/commonly-hosted-runtime/);
+  });
+
+  it('accepts a bare-array events response too', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => [{ _id: 'e2', type: 'first_contact' }] });
+    expect(await listEvents(cfg)).toHaveLength(1);
+  });
+
+  it('throws on non-2xx so the DO records lastError instead of acking blindly', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 401 });
+    await expect(listEvents(cfg)).rejects.toThrow('listEvents 401');
+    await expect(ackEvent(cfg, 'e1')).rejects.toThrow('ackEvent 401');
+    await expect(postMessage(cfg, 'p1', 'hi')).rejects.toThrow('postMessage 401');
+    await expect(getPodContext(cfg, 'p1')).rejects.toThrow('getPodContext 401');
+  });
+
+  it('posts a message as JSON to the pod route', async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+    await postMessage(cfg, 'pod-1', 'hello');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.test/api/agents/runtime/pods/pod-1/messages');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({ content: 'hello' });
+  });
+});

--- a/workers/agent-runtime/test/turn.persistence.test.ts
+++ b/workers/agent-runtime/test/turn.persistence.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { runTurn, TRANSCRIPT_BYTE_BUDGET, byteBound } from '../src/turn';
+
+// A Map-backed DurableObjectStorage double: only get/put are exercised.
+const fakeStorage = () => {
+  const m = new Map<string, unknown>();
+  return {
+    get: async (k: string) => m.get(k),
+    put: async (k: string, v: unknown) => { m.set(k, v); },
+    raw: m,
+  } as unknown as DurableObjectStorage & { raw: Map<string, unknown> };
+};
+
+// A fake loop runner shaped like runAgentLoop: returns ONLY this turn's
+// messages (prompt + one assistant reply), exactly as pi 0.84.2 does.
+const fakeLoop = (reply: string) => (async (prompts: unknown[]) => [
+  ...prompts,
+  { role: 'assistant', content: [{ type: 'text', text: reply }], timestamp: Date.now() },
+]) as never;
+
+describe('runTurn storage round-trip (the #1339 blocker)', () => {
+  it('APPENDS each turn to the persisted transcript instead of overwriting it', async () => {
+    const storage = fakeStorage();
+    const deps = { storage, apiKey: 'k', systemPrompt: 's' };
+    expect(await runTurn({ ...deps, loop: fakeLoop('one') }, 'first')).toBe('one');
+    expect(await runTurn({ ...deps, loop: fakeLoop('two') }, 'second')).toBe('two');
+    const transcript = storage.raw.get('transcript') as { role: string }[];
+    expect(transcript).toHaveLength(4);
+    expect(transcript.map((m) => m.role)).toEqual(['user', 'assistant', 'user', 'assistant']);
+  });
+
+  it('throws on a missing API key so the event stays unacked and lastError records it', async () => {
+    await expect(runTurn({ storage: fakeStorage(), apiKey: '', systemPrompt: 's', loop: fakeLoop('x') }, 'hi'))
+      .rejects.toThrow(/ANTHROPIC_API_KEY unset/);
+  });
+
+  it('byteBound keeps the persisted transcript under the DO value ceiling', () => {
+    const big = Array.from({ length: 60 }, (_, i) => ({
+      role: i % 2 ? 'assistant' : 'user', content: [{ type: 'text', text: 'x'.repeat(50_000) }],
+    })) as never[];
+    const out = byteBound(big, TRANSCRIPT_BYTE_BUDGET);
+    expect(JSON.stringify(out).length).toBeLessThanOrEqual(TRANSCRIPT_BYTE_BUDGET);
+    expect(out.length).toBeGreaterThanOrEqual(2);
+    expect((out[0] as { role: string }).role).toBe('user');
+  });
+});

--- a/workers/agent-runtime/test/turn.test.ts
+++ b/workers/agent-runtime/test/turn.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { convertToLlm, lastAssistantText, tailBound } from '../src/turn';
+
+const user = (text: string) => ({ role: 'user', content: [{ type: 'text', text }], timestamp: 1 }) as never;
+const assistant = (text: string) => ({ role: 'assistant', content: [{ type: 'text', text }], timestamp: 2 }) as never;
+
+describe('turn helpers', () => {
+  it('convertToLlm keeps LLM messages and drops custom agent messages, never throws', () => {
+    const out = convertToLlm([user('a'), { role: 'custom', customType: 'ui' } as never, assistant('b'), null as never]);
+    expect(out.map((m) => (m as { role: string }).role)).toEqual(['user', 'assistant']);
+  });
+
+  it('lastAssistantText returns the final assistant text, joining text blocks', () => {
+    const msgs = [user('q'), assistant('first'), user('q2'), { role: 'assistant', content: [{ type: 'text', text: 'a' }, { type: 'text', text: 'b' }] } as never];
+    expect(lastAssistantText(msgs)).toBe('ab');
+    expect(lastAssistantText([user('only')])).toBe('');
+  });
+
+  it('tailBound drops from the oldest end at user-message boundaries until under budget', () => {
+    const msgs = [user('1'), assistant('1'), user('2'), assistant('2'), user('3'), assistant('3')];
+    // pretend each message costs 10 tokens; budget allows 4 messages
+    const out = tailBound(msgs, 40, (m) => m.length * 10);
+    expect(out).toHaveLength(4);
+    expect((out[0] as { role: string }).role).toBe('user');
+  });
+
+  it('tailBound never drops below the last two messages', () => {
+    const msgs = [user('1'), assistant('1'), user('2'), assistant('2')];
+    expect(tailBound(msgs, 1, (m) => m.length * 10)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Second W2 PR on the merged scaffold (#1318). The ADR-021/023 engine lands in its production home:

- **turn.ts**: `runAgentLoop` driven directly with pi-ai's `streamSimple` (Anthropic provider via `@earendil-works/pi-ai/compat` — fetch-based, workerd-clean per the spike); model via `createModels().getModel('anthropic', …)` + `hasApi` guard; API key through `getApiKey`
- **Transcript on DO storage**, tail-bounded at turn boundaries with pi's own `estimateContextTokens` (floor of two messages). pi's real compaction is Session-entry based (`prepareCompaction` takes `Entry[]`) and arrives with the Session layer — named, not hand-waved
- Pod context folded into the prompt as text; CAP tools are the next slice (same seam)
- **Tests (Otto's gate)**: 8 vitest cases — CAP client (bearer + non-default UA, bare-array tolerance, non-2xx throws so lastError is recorded instead of blind-acking, POST shape) and turn helpers (never-throw LLM filter, final-assistant extraction, tail-bounding + floor). **Now wired into CI** (Test & Coverage runs the worker's typecheck + vitest)
- **Plumbing E2E passed against production** with a throwaway agent before this PR: real mention → DO poll → handle → ack, queue empty. Model leg pending an operator-supplied key.

Merge gate: @otto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pc6nGXRS8mHvrwcXMSRDK