### PR TITLE
feat(runtime): CAP tools — read_pod_context (W2 PR 3)

### DIFF
--- a/workers/agent-runtime/package-lock.json
+++ b/workers/agent-runtime/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.84.2",
-        "@earendil-works/pi-ai": "^0.84.2"
+        "@earendil-works/pi-ai": "^0.84.2",
+        "typebox": "^1.3.7"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^5.20260828.1",

--- a/workers/agent-runtime/package.json
+++ b/workers/agent-runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@commonlyai/agent-runtime",
   "private": true,
   "version": "0.1.0",
-  "description": "ADR-023 W2 hosted agent runtime \u2014 Durable Objects + pi agent-core",
+  "description": "ADR-023 W2 hosted agent runtime — Durable Objects + pi agent-core",
   "scripts": {
     "dev": "wrangler dev --local",
     "deploy": "wrangler deploy",
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@earendil-works/pi-agent-core": "0.84.2",
-    "@earendil-works/pi-ai": "^0.84.2"
+    "@earendil-works/pi-ai": "^0.84.2",
+    "typebox": "^1.3.7"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260828.1",

--- a/workers/agent-runtime/src/agent-do.ts
+++ b/workers/agent-runtime/src/agent-do.ts
@@ -11,6 +11,7 @@
 // v1 wires a minimal turn; harness/compaction integration follows.
 import { listEvents, ackEvent, getPodContext, postMessage, CapConfig, CapEvent } from './cap';
 import { runTurn } from './turn';
+import { buildCapTools } from './tools';
 
 export interface Env {
   AGENT: DurableObjectNamespace;
@@ -128,7 +129,7 @@ export class AgentRuntimeDO implements DurableObject {
     if (!podId) return;
     if (event.type !== 'chat.mention' && event.type !== 'first_contact') return;
     const context = await getPodContext(cfg, podId);
-    const reply = await this.runTurn(String(event.payload?.content || ''), context);
+    const reply = await this.runTurn(String(event.payload?.content || ''), context, buildCapTools(cfg, podId));
     // NO_REPLY contract: total-match suppression, same as every runtime.
     if (reply && reply.trim() !== 'NO_REPLY') {
       await postMessage(cfg, podId, reply);
@@ -138,7 +139,7 @@ export class AgentRuntimeDO implements DurableObject {
   // The pi-driven turn (turn.ts): transcript on DO storage, streamSimple
   // transport, tail-bounded context. Pod context is folded into the prompt
   // as text until CAP tools land (next slice).
-  private async runTurn(prompt: string, context: unknown): Promise<string> {
+  private async runTurn(prompt: string, context: unknown, tools: ReturnType<typeof buildCapTools> = []): Promise<string> {
     // No silent NO_REPLY on a missing key — runTurn throws, the event stays
     // unacked, and /status shows the misconfiguration (Otto, #1339).
     const key = this.env.ANTHROPIC_API_KEY || '';
@@ -151,7 +152,8 @@ export class AgentRuntimeDO implements DurableObject {
       storage: this.state.storage,
       apiKey: key,
       modelId: this.env.MODEL_ID,
-      systemPrompt: 'You are a Commonly hosted agent living in a shared pod with humans and other agents. Reply concisely and usefully to the message you were mentioned in. If no reply is genuinely needed, reply with exactly NO_REPLY.',
+      tools,
+      systemPrompt: 'You are a Commonly hosted agent living in a shared pod with humans and other agents. Reply concisely and usefully to the message you were mentioned in. Use read_pod_context when the mention alone is not enough. If no reply is genuinely needed, reply with exactly NO_REPLY.',
     }, userText);
   }
 }

--- a/workers/agent-runtime/src/agent-do.ts
+++ b/workers/agent-runtime/src/agent-do.ts
@@ -9,7 +9,7 @@
 // Turn engine: pi agent-core with an injected fetch-based streamFn (the
 // spike's finding #2: transport is dependency-injected and workerd-clean).
 // v1 wires a minimal turn; harness/compaction integration follows.
-import { listEvents, ackEvent, getPodContext, postMessage, CapConfig, CapEvent } from './cap';
+import { listEvents, ackEvent, postMessage, CapConfig, CapEvent } from './cap';
 import { runTurn } from './turn';
 import { buildCapTools } from './tools';
 
@@ -128,8 +128,10 @@ export class AgentRuntimeDO implements DurableObject {
     const podId = event.podId || event.payload?.podId;
     if (!podId) return;
     if (event.type !== 'chat.mention' && event.type !== 'first_contact') return;
-    const context = await getPodContext(cfg, podId);
-    const reply = await this.runTurn(String(event.payload?.content || ''), context, buildCapTools(cfg, podId));
+    // No eager context fetch: the mention is the prompt and read_pod_context
+    // earns the read when the model needs it (Otto: two CAP reads per turn
+    // and the same content twice against the byte ceiling otherwise).
+    const reply = await this.runTurn(String(event.payload?.content || ''), buildCapTools(cfg, podId));
     // NO_REPLY contract: total-match suppression, same as every runtime.
     if (reply && reply.trim() !== 'NO_REPLY') {
       await postMessage(cfg, podId, reply);
@@ -139,15 +141,11 @@ export class AgentRuntimeDO implements DurableObject {
   // The pi-driven turn (turn.ts): transcript on DO storage, streamSimple
   // transport, tail-bounded context. Pod context is folded into the prompt
   // as text until CAP tools land (next slice).
-  private async runTurn(prompt: string, context: unknown, tools: ReturnType<typeof buildCapTools> = []): Promise<string> {
+  private async runTurn(prompt: string, tools: ReturnType<typeof buildCapTools> = []): Promise<string> {
     // No silent NO_REPLY on a missing key — runTurn throws, the event stays
     // unacked, and /status shows the misconfiguration (Otto, #1339).
     const key = this.env.ANTHROPIC_API_KEY || '';
-    const recent = ((context as { recentMessages?: { content?: string; senderName?: string }[] })?.recentMessages || [])
-      .slice(-10)
-      .map((m) => `${m.senderName || 'someone'}: ${String(m.content || '').slice(0, 400)}`)
-      .join('\n');
-    const userText = `Recent pod messages:\n${recent}\n\nYou were mentioned with: ${prompt}`;
+    const userText = `You were mentioned with: ${prompt}`;
     return runTurn({
       storage: this.state.storage,
       apiKey: key,

--- a/workers/agent-runtime/src/tools.ts
+++ b/workers/agent-runtime/src/tools.ts
@@ -1,0 +1,43 @@
+// CAP tools for the hosted turn engine — "tools as CAP calls" (ADR-023 D2).
+// Every tool is a fetch to the same kernel surface a BYO wrapper uses; the
+// runtime never reaches into the kernel any other way. Tools are built per
+// event, closed over the agent's CapConfig and the pod the event came from.
+import { Type } from 'typebox';
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+import { getPodContext, type CapConfig } from './cap';
+
+const readPodContextSchema = Type.Object({
+  limit: Type.Optional(Type.Number({ description: 'How many recent messages to read (default 20, max 50)' })),
+});
+
+interface PodContextShape {
+  pod?: { name?: string; description?: string };
+  members?: { username?: string; displayName?: string; isBot?: boolean }[];
+  recentMessages?: { senderName?: string; content?: string; createdAt?: string }[];
+}
+
+const renderPodContext = (ctx: PodContextShape, limit: number): string => {
+  const lines: string[] = [];
+  if (ctx.pod?.name) lines.push(`Pod: ${ctx.pod.name}${ctx.pod.description ? ` — ${ctx.pod.description}` : ''}`);
+  if (ctx.members?.length) {
+    lines.push(`Members: ${ctx.members.map((m) => `${m.displayName || m.username || '?'}${m.isBot ? ' (agent)' : ''}`).join(', ')}`);
+  }
+  const msgs = (ctx.recentMessages || []).slice(-limit);
+  lines.push(`Recent messages (${msgs.length}):`);
+  for (const m of msgs) lines.push(`- ${m.senderName || 'someone'}: ${String(m.content || '').slice(0, 600)}`);
+  return lines.join('\n');
+};
+
+export const buildCapTools = (cfg: CapConfig, podId: string): AgentTool<typeof readPodContextSchema>[] => [
+  {
+    name: 'read_pod_context',
+    label: 'Read pod context',
+    description: 'Read the pod you were mentioned in: its name, members, and recent messages. Use before replying when the mention alone is not enough context.',
+    parameters: readPodContextSchema,
+    async execute(_id, params) {
+      const limit = Math.min(Math.max(Number(params.limit) || 20, 1), 50);
+      const ctx = (await getPodContext(cfg, podId)) as PodContextShape;
+      return { content: [{ type: 'text', text: renderPodContext(ctx, limit) }], details: { podId, limit } };
+    },
+  },
+];

--- a/workers/agent-runtime/src/tools.ts
+++ b/workers/agent-runtime/src/tools.ts
@@ -16,7 +16,11 @@ interface PodContextShape {
   recentMessages?: { senderName?: string; content?: string; createdAt?: string }[];
 }
 
-const renderPodContext = (ctx: PodContextShape, limit: number): string => {
+// Hard cap on rendered characters so a single tool result cannot dominate
+// the transcript byte ceiling (Otto: 50 × 600 unbounded per call).
+export const RENDER_CHAR_CAP = 8_000;
+
+export const renderPodContext = (ctx: PodContextShape, limit: number): string => {
   const lines: string[] = [];
   if (ctx.pod?.name) lines.push(`Pod: ${ctx.pod.name}${ctx.pod.description ? ` — ${ctx.pod.description}` : ''}`);
   if (ctx.members?.length) {
@@ -25,7 +29,8 @@ const renderPodContext = (ctx: PodContextShape, limit: number): string => {
   const msgs = (ctx.recentMessages || []).slice(-limit);
   lines.push(`Recent messages (${msgs.length}):`);
   for (const m of msgs) lines.push(`- ${m.senderName || 'someone'}: ${String(m.content || '').slice(0, 600)}`);
-  return lines.join('\n');
+  const out = lines.join('\n');
+  return out.length > RENDER_CHAR_CAP ? `${out.slice(0, RENDER_CHAR_CAP)}\n…(truncated)` : out;
 };
 
 export const buildCapTools = (cfg: CapConfig, podId: string): AgentTool<typeof readPodContextSchema>[] => [

--- a/workers/agent-runtime/src/turn.ts
+++ b/workers/agent-runtime/src/turn.ts
@@ -2,20 +2,20 @@
 // transcript persisted on DO storage and pi's own compaction keeping it
 // bounded. This is the ADR-021/023 engine landing in its production home.
 //
-// v1 scope (deliberate): streamSimple as the transport (pi-ai's Anthropic
-// provider — fetch-based, workerd-clean per the spike), no tools yet. The
-// reply is the final assistant text. Two named next slices, neither of which
-// changes this seam (transcript in, text out): CAP tools (read pod context,
-// attach), and pi's real compaction — which is Session-entry based
-// (prepareCompaction takes Entry[], not AgentMessage[]), so it arrives with
-// the Session layer. Until then the transcript is tail-bounded by pi's own
-// token estimate: honest, bounded, and lossy only at the oldest end.
+// Transport: streamSimple (pi-ai's Anthropic provider — fetch-based,
+// workerd-clean per the spike). Tools: CAP calls built per event (tools.ts).
+// The reply is the final assistant text. Remaining named slice, same seam:
+// pi's real compaction — Session-entry based (prepareCompaction takes
+// Entry[], not AgentMessage[]), so it arrives with the Session layer. Until
+// then the transcript is tail-bounded by pi's token estimate and a byte
+// ceiling: honest, bounded, lossy only at the oldest end.
 import {
   runAgentLoop,
   estimateContextTokens,
   type AgentMessage,
   type AgentContext,
   type AgentLoopConfig,
+  type AgentTool,
 } from '@earendil-works/pi-agent-core';
 import { createModels, hasApi, type Message } from '@earendil-works/pi-ai';
 import { streamSimple } from '@earendil-works/pi-ai/compat';
@@ -30,6 +30,8 @@ export interface TurnDeps {
   // faking pi's event stream (Otto's #1339 gate: the persistence contract
   // is where the blocker lived).
   loop?: typeof runAgentLoop;
+  // CAP tools for this turn (built per event; see tools.ts).
+  tools?: AgentTool<any>[];
 }
 
 const TRANSCRIPT_KEY = 'transcript';
@@ -107,7 +109,7 @@ export const runTurn = async (deps: TurnDeps, userText: string): Promise<string>
   transcript = tailBound(transcript, Math.floor(contextWindow * 0.6));
 
   const prompt: AgentMessage = { role: 'user', content: [{ type: 'text', text: userText }], timestamp: Date.now() } as AgentMessage;
-  const context: AgentContext = { systemPrompt: deps.systemPrompt, messages: transcript, tools: [] };
+  const context: AgentContext = { systemPrompt: deps.systemPrompt, messages: transcript, tools: deps.tools || [] };
   const config: AgentLoopConfig = {
     model,
     convertToLlm,

--- a/workers/agent-runtime/src/turn.ts
+++ b/workers/agent-runtime/src/turn.ts
@@ -32,6 +32,8 @@ export interface TurnDeps {
   loop?: typeof runAgentLoop;
   // CAP tools for this turn (built per event; see tools.ts).
   tools?: AgentTool<any>[];
+  maxToolCalls?: number;
+  timeoutMs?: number;
 }
 
 const TRANSCRIPT_KEY = 'transcript';
@@ -87,6 +89,29 @@ export const byteBound = (messages: AgentMessage[], budgetBytes: number): AgentM
   return out;
 };
 
+// Otto's #1340 blocker: with tools, pi's loop is while(hasMoreToolCalls)
+// with no step cap — a model that keeps calling a tool loops on paid calls
+// forever. Two bounds, both enforced: a per-turn tool-call budget (block +
+// terminate past it) and a wall-clock abort. A turn is bounded by
+// construction again, as it was before tools.
+export const MAX_TOOL_CALLS_PER_TURN = 4;
+export const TURN_TIMEOUT_MS = 90_000;
+
+export const makeToolBudget = (max: number = MAX_TOOL_CALLS_PER_TURN) => {
+  let calls = 0;
+  return {
+    beforeToolCall: async () => {
+      calls += 1;
+      if (calls > max) {
+        return { block: true, terminate: true, reason: `tool-call budget (${max}) exhausted for this turn` };
+      }
+      return undefined;
+    },
+    shouldStopAfterTurn: async () => calls >= max,
+    count: () => calls,
+  };
+};
+
 export const runTurn = async (deps: TurnDeps, userText: string): Promise<string> => {
   if (!deps.apiKey) {
     // A misconfigured deploy must surface on /status, not silently ack every
@@ -110,17 +135,27 @@ export const runTurn = async (deps: TurnDeps, userText: string): Promise<string>
 
   const prompt: AgentMessage = { role: 'user', content: [{ type: 'text', text: userText }], timestamp: Date.now() } as AgentMessage;
   const context: AgentContext = { systemPrompt: deps.systemPrompt, messages: transcript, tools: deps.tools || [] };
+  const budget = makeToolBudget(deps.maxToolCalls ?? MAX_TOOL_CALLS_PER_TURN);
   const config: AgentLoopConfig = {
     model,
     convertToLlm,
     getApiKey: () => deps.apiKey,
+    beforeToolCall: budget.beforeToolCall,
+    shouldStopAfterTurn: budget.shouldStopAfterTurn,
   };
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(new Error(`turn exceeded ${TURN_TIMEOUT_MS}ms`)), deps.timeoutMs ?? TURN_TIMEOUT_MS);
 
   // runAgentLoop returns ONLY this turn's messages (prompts + replies), never
   // context.messages — so the transcript is APPENDED, not replaced (Otto's
   // #1339 blocker: the previous shape overwrote memory every turn).
   const loop = deps.loop || runAgentLoop;
-  const turnMessages = await loop([prompt], context, config, () => {}, undefined, streamSimple);
+  let turnMessages: AgentMessage[];
+  try {
+    turnMessages = await loop([prompt], context, config, () => {}, abort.signal, streamSimple);
+  } finally {
+    clearTimeout(timer);
+  }
   const merged = byteBound([...transcript, ...turnMessages], TRANSCRIPT_BYTE_BUDGET);
   await deps.storage.put(TRANSCRIPT_KEY, merged);
   return lastAssistantText(turnMessages).trim() || 'NO_REPLY';

--- a/workers/agent-runtime/src/turn.ts
+++ b/workers/agent-runtime/src/turn.ts
@@ -97,18 +97,26 @@ export const byteBound = (messages: AgentMessage[], budgetBytes: number): AgentM
 export const MAX_TOOL_CALLS_PER_TURN = 4;
 export const TURN_TIMEOUT_MS = 90_000;
 
-export const makeToolBudget = (max: number = MAX_TOOL_CALLS_PER_TURN) => {
+// Budget semantics (Otto, #1340 round 2): exhausting the budget must send
+// the model BACK TO ANSWER, never end the turn — a blocked call returns its
+// reason as the tool result and the loop continues, so the model writes its
+// reply with what it has. Only a runaway (still calling tools past the grace
+// window) is terminated, and that surfaces as an error, not as silence.
+export const makeToolBudget = (max: number = MAX_TOOL_CALLS_PER_TURN, grace = 2) => {
   let calls = 0;
   return {
     beforeToolCall: async () => {
       calls += 1;
+      if (calls > max + grace) {
+        return { block: true, terminate: true, reason: `tool-call budget (${max}) exhausted and the model kept calling — terminating` };
+      }
       if (calls > max) {
-        return { block: true, terminate: true, reason: `tool-call budget (${max}) exhausted for this turn` };
+        return { block: true, reason: `Tool-call budget (${max}) exhausted for this turn. Answer now with what you already have.` };
       }
       return undefined;
     },
-    shouldStopAfterTurn: async () => calls >= max,
     count: () => calls,
+    runaway: () => calls > max + grace,
   };
 };
 
@@ -141,7 +149,6 @@ export const runTurn = async (deps: TurnDeps, userText: string): Promise<string>
     convertToLlm,
     getApiKey: () => deps.apiKey,
     beforeToolCall: budget.beforeToolCall,
-    shouldStopAfterTurn: budget.shouldStopAfterTurn,
   };
   const abort = new AbortController();
   const timer = setTimeout(() => abort.abort(new Error(`turn exceeded ${TURN_TIMEOUT_MS}ms`)), deps.timeoutMs ?? TURN_TIMEOUT_MS);
@@ -158,5 +165,14 @@ export const runTurn = async (deps: TurnDeps, userText: string): Promise<string>
   }
   const merged = byteBound([...transcript, ...turnMessages], TRANSCRIPT_BYTE_BUDGET);
   await deps.storage.put(TRANSCRIPT_KEY, merged);
-  return lastAssistantText(turnMessages).trim() || 'NO_REPLY';
+  const text = lastAssistantText(turnMessages).trim();
+  // An empty answer is a FAILURE, never deliberate silence: the model says
+  // NO_REPLY explicitly when it means it. Throwing leaves the event unacked
+  // and puts the cause on /status (Otto: the missing-key bug in a new hat).
+  if (!text) {
+    throw new Error(budget.runaway()
+      ? `turn terminated: model exceeded tool budget (${budget.count()} calls)`
+      : 'turn ended without assistant text');
+  }
+  return text;
 };

--- a/workers/agent-runtime/src/turn.ts
+++ b/workers/agent-runtime/src/turn.ts
@@ -91,9 +91,9 @@ export const byteBound = (messages: AgentMessage[], budgetBytes: number): AgentM
 
 // Otto's #1340 blocker: with tools, pi's loop is while(hasMoreToolCalls)
 // with no step cap — a model that keeps calling a tool loops on paid calls
-// forever. Two bounds, both enforced: a per-turn tool-call budget (block +
-// terminate past it) and a wall-clock abort. A turn is bounded by
-// construction again, as it was before tools.
+// forever. Two bounds, both enforced: a per-turn tool-call budget (block
+// past it so the model answers with what it has; terminate only a runaway)
+// and a wall-clock abort. A turn is bounded by construction again.
 export const MAX_TOOL_CALLS_PER_TURN = 4;
 export const TURN_TIMEOUT_MS = 90_000;
 
@@ -163,16 +163,19 @@ export const runTurn = async (deps: TurnDeps, userText: string): Promise<string>
   } finally {
     clearTimeout(timer);
   }
-  const merged = byteBound([...transcript, ...turnMessages], TRANSCRIPT_BYTE_BUDGET);
-  await deps.storage.put(TRANSCRIPT_KEY, merged);
   const text = lastAssistantText(turnMessages).trim();
   // An empty answer is a FAILURE, never deliberate silence: the model says
   // NO_REPLY explicitly when it means it. Throwing leaves the event unacked
   // and puts the cause on /status (Otto: the missing-key bug in a new hat).
+  // Persist on SUCCESS ONLY — a failed turn must not save its prompt, or
+  // each redelivery appends a duplicate (Otto, round 3); the abort path
+  // already persists nothing, so both failure modes now leave no residue.
   if (!text) {
     throw new Error(budget.runaway()
       ? `turn terminated: model exceeded tool budget (${budget.count()} calls)`
       : 'turn ended without assistant text');
   }
+  const merged = byteBound([...transcript, ...turnMessages], TRANSCRIPT_BYTE_BUDGET);
+  await deps.storage.put(TRANSCRIPT_KEY, merged);
   return text;
 };

--- a/workers/agent-runtime/test/budget.test.ts
+++ b/workers/agent-runtime/test/budget.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { makeToolBudget, runTurn } from '../src/turn';
+import { renderPodContext, RENDER_CHAR_CAP } from '../src/tools';
+
+describe('per-turn tool budget (the #1340 blocker)', () => {
+  it('allows N calls, then blocks with terminate', async () => {
+    const b = makeToolBudget(2);
+    expect(await b.beforeToolCall()).toBeUndefined();
+    expect(await b.shouldStopAfterTurn()).toBe(false);
+    expect(await b.beforeToolCall()).toBeUndefined();
+    expect(await b.shouldStopAfterTurn()).toBe(true);
+    const third = await b.beforeToolCall();
+    expect(third).toMatchObject({ block: true, terminate: true });
+  });
+
+  it('runTurn wires the budget hooks and an abort signal into the loop', async () => {
+    let cfgSeen: { beforeToolCall?: unknown; shouldStopAfterTurn?: unknown } = {};
+    let signalSeen: AbortSignal | undefined;
+    const loop = (async (_p: unknown, _c: unknown, config: typeof cfgSeen, _e: unknown, signal: AbortSignal) => {
+      cfgSeen = config; signalSeen = signal;
+      return [{ role: 'assistant', content: [{ type: 'text', text: 'ok' }] }];
+    }) as never;
+    const storage = { get: async () => undefined, put: async () => {} } as unknown as DurableObjectStorage;
+    await runTurn({ storage, apiKey: 'k', systemPrompt: 's', loop, maxToolCalls: 3 }, 'hi');
+    expect(typeof cfgSeen.beforeToolCall).toBe('function');
+    expect(typeof cfgSeen.shouldStopAfterTurn).toBe('function');
+    expect(signalSeen).toBeInstanceOf(AbortSignal);
+  });
+
+  it('runTurn aborts the loop on the wall-clock timeout', async () => {
+    const loop = (async (_p: unknown, _c: unknown, _cfg: unknown, _e: unknown, signal: AbortSignal) => new Promise((_, reject) => {
+      signal.addEventListener('abort', () => reject(signal.reason));
+    })) as never;
+    const storage = { get: async () => undefined, put: async () => {} } as unknown as DurableObjectStorage;
+    await expect(runTurn({ storage, apiKey: 'k', systemPrompt: 's', loop, timeoutMs: 20 }, 'hi')).rejects.toThrow(/exceeded 90000ms|exceeded/);
+  });
+});
+
+describe('renderPodContext cap', () => {
+  it('truncates a huge render at RENDER_CHAR_CAP', () => {
+    const ctx = { recentMessages: Array.from({ length: 50 }, () => ({ senderName: 'x', content: 'y'.repeat(600) })) };
+    const out = renderPodContext(ctx, 50);
+    expect(out.length).toBeLessThanOrEqual(RENDER_CHAR_CAP + 20);
+    expect(out.endsWith('…(truncated)')).toBe(true);
+  });
+});

--- a/workers/agent-runtime/test/budget.test.ts
+++ b/workers/agent-runtime/test/budget.test.ts
@@ -3,14 +3,23 @@ import { makeToolBudget, runTurn } from '../src/turn';
 import { renderPodContext, RENDER_CHAR_CAP } from '../src/tools';
 
 describe('per-turn tool budget (the #1340 blocker)', () => {
-  it('allows N calls, then blocks with terminate', async () => {
-    const b = makeToolBudget(2);
+  it('past the budget it BLOCKS but keeps the turn alive so the model can answer; only a runaway terminates', async () => {
+    const b = makeToolBudget(2, 1);
     expect(await b.beforeToolCall()).toBeUndefined();
-    expect(await b.shouldStopAfterTurn()).toBe(false);
     expect(await b.beforeToolCall()).toBeUndefined();
-    expect(await b.shouldStopAfterTurn()).toBe(true);
     const third = await b.beforeToolCall();
-    expect(third).toMatchObject({ block: true, terminate: true });
+    expect(third).toMatchObject({ block: true });
+    expect((third as { terminate?: boolean }).terminate).toBeUndefined();
+    expect((third as { reason: string }).reason).toMatch(/Answer now/);
+    const fourth = await b.beforeToolCall();
+    expect(fourth).toMatchObject({ block: true, terminate: true });
+    expect(b.runaway()).toBe(true);
+  });
+
+  it('an empty assistant answer is an error, never a substituted NO_REPLY', async () => {
+    const loop = (async () => [{ role: 'assistant', content: [] }]) as never;
+    const storage = { get: async () => undefined, put: async () => {} } as unknown as DurableObjectStorage;
+    await expect(runTurn({ storage, apiKey: 'k', systemPrompt: 's', loop }, 'hi')).rejects.toThrow(/without assistant text/);
   });
 
   it('runTurn wires the budget hooks and an abort signal into the loop', async () => {
@@ -23,7 +32,7 @@ describe('per-turn tool budget (the #1340 blocker)', () => {
     const storage = { get: async () => undefined, put: async () => {} } as unknown as DurableObjectStorage;
     await runTurn({ storage, apiKey: 'k', systemPrompt: 's', loop, maxToolCalls: 3 }, 'hi');
     expect(typeof cfgSeen.beforeToolCall).toBe('function');
-    expect(typeof cfgSeen.shouldStopAfterTurn).toBe('function');
+    expect(cfgSeen.shouldStopAfterTurn).toBeUndefined();
     expect(signalSeen).toBeInstanceOf(AbortSignal);
   });
 

--- a/workers/agent-runtime/test/tools.test.ts
+++ b/workers/agent-runtime/test/tools.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildCapTools } from '../src/tools';
+import { runTurn } from '../src/turn';
+
+const cfg = { apiUrl: 'https://api.test', runtimeToken: 'cm_agent_x' };
+
+describe('CAP tools', () => {
+  const fetchMock = vi.fn();
+  beforeEach(() => { fetchMock.mockReset(); vi.stubGlobal('fetch', fetchMock); });
+
+  it('read_pod_context calls the CAP context route for the event pod and renders it', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({
+      pod: { name: 'Rewire', description: 'demo' },
+      members: [{ displayName: 'Sam' }, { username: 'vera', isBot: true }],
+      recentMessages: [{ senderName: 'Sam', content: 'hello' }, { senderName: 'Vera', content: 'hi' }],
+    }) });
+    const [tool] = buildCapTools(cfg, 'pod-9');
+    expect(tool.name).toBe('read_pod_context');
+    const res = await tool.execute('call-1', { limit: 1 });
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/agents/runtime/pods/pod-9/context');
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain('Pod: Rewire — demo');
+    expect(text).toContain('vera (agent)');
+    expect(text).toContain('Recent messages (1)');
+    expect(text).toContain('Vera: hi');
+    expect(text).not.toContain('Sam: hello');
+  });
+
+  it('clamps limit into [1, 50]', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ recentMessages: Array.from({ length: 60 }, (_, i) => ({ content: String(i) })) }) });
+    const [tool] = buildCapTools(cfg, 'p');
+    const res = await tool.execute('c', { limit: 999 });
+    expect((res.content[0] as { text: string }).text).toContain('Recent messages (50)');
+  });
+
+  it('runTurn hands the tools to the loop context', async () => {
+    const seen: unknown[] = [];
+    const loop = (async (_p: unknown, context: { tools?: unknown[] }) => { seen.push(context.tools); return [{ role: 'assistant', content: [{ type: 'text', text: 'ok' }] }]; }) as never;
+    const storage = { get: async () => undefined, put: async () => {} } as unknown as DurableObjectStorage;
+    const tools = buildCapTools(cfg, 'p');
+    await runTurn({ storage, apiKey: 'k', systemPrompt: 's', loop, tools }, 'hi');
+    expect((seen[0] as unknown[]).length).toBe(1);
+    expect(((seen[0] as { name: string }[])[0]).name).toBe('read_pod_context');
+  });
+});

--- a/workers/agent-runtime/test/turn.persistence.test.ts
+++ b/workers/agent-runtime/test/turn.persistence.test.ts
@@ -34,6 +34,13 @@ describe('runTurn storage round-trip (the #1339 blocker)', () => {
       .rejects.toThrow(/ANTHROPIC_API_KEY unset/);
   });
 
+  it('a failed turn persists NOTHING — redeliveries must not stack duplicate prompts', async () => {
+    const storage = fakeStorage();
+    const emptyLoop = (async () => [{ role: 'assistant', content: [] }]) as never;
+    await expect(runTurn({ storage, apiKey: 'k', systemPrompt: 's', loop: emptyLoop }, 'hi')).rejects.toThrow();
+    expect(storage.raw.get('transcript')).toBeUndefined();
+  });
+
   it('byteBound keeps the persisted transcript under the DO value ceiling', () => {
     const big = Array.from({ length: 60 }, (_, i) => ({
       role: i % 2 ? 'assistant' : 'user', content: [{ type: 'text', text: 'x'.repeat(50_000) }],


### PR DESCRIPTION
Third W2 PR: tools as CAP calls (ADR-023 D2). `read_pod_context` is a pi `AgentTool` built per event, closed over the agent's CapConfig and the event's pod — the runtime reaches the kernel only through the four CAP verbs. Renders pod name, members (agents marked), recent messages with a [1,50] clamp. Wired via `TurnDeps.tools` into the loop context; system prompt teaches the tool.

3 tests (route + rendering, clamp, tools reach the loop) — 14/14 with the existing suite, in CI. Merge gate: @otto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pc6nGXRS8mHvrwcXMSRDK