### PR TITLE
feat(cli): register and heartbeat daemon machines

### DIFF
--- a/backend/__tests__/unit/middleware/auth.test.js
+++ b/backend/__tests__/unit/middleware/auth.test.js
@@ -126,6 +126,25 @@ describe('Auth Middleware Tests', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it.each(['cm_daemon_machine-bearer', 'cm_agent_runtime-bearer'])(
+    'rejects %s before the user API-token lookup',
+    async (token) => {
+      const req = { header: jest.fn().mockReturnValue(`Bearer ${token}`) };
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+      const next = jest.fn();
+      User.findOne.mockClear();
+
+      await authMiddleware(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        msg: expect.stringContaining('cannot authenticate user routes'),
+      }));
+      expect(User.findOne).not.toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+    },
+  );
+
   it('should return 401 when invalid token is provided', async () => {
     // Mock request, response, and next function
     const req = {

--- a/backend/__tests__/unit/middleware/daemonAuth.test.js
+++ b/backend/__tests__/unit/middleware/daemonAuth.test.js
@@ -69,4 +69,22 @@ describe('daemonAuth', () => {
     expect(res.statusCode).toBe(401);
     expect(req.machine).toBeUndefined();
   });
+
+  it('requires the route scope before exposing a machine identity', async () => {
+    const token = `cm_daemon_${'b'.repeat(32)}`;
+    await AgentCredential.create({
+      tokenHash: hash(token),
+      kind: 'daemon',
+      ownerUserId: new mongoose.Types.ObjectId(),
+      machineId: 'machine-2',
+      scopes: ['machine:heartbeat'],
+    });
+    const req = { header: (name) => (name === 'Authorization' ? `Bearer ${token}` : undefined) };
+    const res = makeRes();
+
+    await daemonAuth('machine:read')(req, res, () => {});
+
+    expect(res.statusCode).toBe(403);
+    expect(req.machine).toBeUndefined();
+  });
 });

--- a/backend/__tests__/unit/routes/machines.test.js
+++ b/backend/__tests__/unit/routes/machines.test.js
@@ -3,6 +3,7 @@ const express = require('express');
 
 const mockRegisterMachine = jest.fn();
 const mockListMachinesForOwner = jest.fn();
+const mockGetMachineForDaemon = jest.fn();
 const mockRecordMachineHeartbeat = jest.fn();
 const mockRemoveMachine = jest.fn();
 const mockFindMachine = jest.fn();
@@ -17,7 +18,7 @@ jest.mock('../../../middleware/daemonAuth', () => ({
     req.machine = {
       machineId: 'daemon-machine',
       ownerUserId: '0123456789abcdef01234567',
-      scopes: ['machine:heartbeat', 'agents:adopt'],
+      scopes: ['machine:heartbeat', 'machine:read', 'agents:adopt'],
     };
     next();
   },
@@ -31,6 +32,7 @@ jest.mock('../../../models/User', () => ({
 jest.mock('../../../services/machineService', () => ({
   registerMachine: (...args) => mockRegisterMachine(...args),
   listMachinesForOwner: (...args) => mockListMachinesForOwner(...args),
+  getMachineForDaemon: (...args) => mockGetMachineForDaemon(...args),
   recordMachineHeartbeat: (...args) => mockRecordMachineHeartbeat(...args),
   removeMachine: (...args) => mockRemoveMachine(...args),
 }));
@@ -90,6 +92,19 @@ describe('machine lifecycle routes', () => {
     }));
     expect(mockFindMachine).toHaveBeenCalledWith({
       _id: '0123456789abcdef01234567',
+      machineId: 'daemon-machine',
+      ownerUserId: '0123456789abcdef01234567',
+    });
+  });
+
+  it('returns only the credential-bound machine through daemon status', async () => {
+    mockGetMachineForDaemon.mockResolvedValue({ id: 'm1', name: 'Sam’s Mac', status: 'online' });
+
+    const res = await request(app).get('/api/machines/me');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ machine: { id: 'm1', name: 'Sam’s Mac', status: 'online' } });
+    expect(mockGetMachineForDaemon).toHaveBeenCalledWith({
       machineId: 'daemon-machine',
       ownerUserId: '0123456789abcdef01234567',
     });

--- a/backend/__tests__/unit/services/machineService.test.js
+++ b/backend/__tests__/unit/services/machineService.test.js
@@ -46,7 +46,7 @@ describe('ADR-026 machine lifecycle service', () => {
     expect(credential).toEqual(expect.objectContaining({
       kind: 'daemon',
       ownerUserId,
-      scopes: ['machine:heartbeat', 'agents:adopt'],
+      scopes: ['machine:heartbeat', 'machine:read', 'agents:adopt'],
     }));
     expect(credential.tokenHash).not.toContain(token);
     expect(credential.expiresAt.getTime()).toBeGreaterThan(Date.now());
@@ -61,6 +61,21 @@ describe('ADR-026 machine lifecycle service', () => {
 
     expect(result.status).toBe('online');
     expect(result.lastSeenAt).toBeInstanceOf(Date);
+  });
+
+  it('returns only the credential-bound machine for daemon status', async () => {
+    const ownerUserId = new mongoose.Types.ObjectId();
+    const first = await machineService.registerMachine({ ownerUserId, name: 'First Mac' });
+    const second = await machineService.registerMachine({ ownerUserId, name: 'Second Mac' });
+
+    await expect(machineService.getMachineForDaemon({
+      machineId: first.machine.machineId,
+      ownerUserId,
+    })).resolves.toMatchObject({ id: first.machine.id, name: 'First Mac' });
+    await expect(machineService.getMachineForDaemon({
+      machineId: second.machine.machineId,
+      ownerUserId: new mongoose.Types.ObjectId(),
+    })).resolves.toBeNull();
   });
 
   it('cascade-revokes the daemon’s descendants before removing its row', async () => {

--- a/backend/middleware/auth.ts
+++ b/backend/middleware/auth.ts
@@ -36,6 +36,13 @@ export default async function auth(req: Request, res: Response, next: NextFuncti
     return res.status(401).json({ msg: 'No token, authorization denied' });
   }
 
+  // Machine and runtime bearers live in AgentCredential, never on User. Make
+  // that boundary explicit instead of relying on their value never colliding
+  // with User.apiToken; those credentials must use daemonAuth/agentRuntimeAuth.
+  if (token.startsWith('cm_daemon_') || token.startsWith('cm_agent_')) {
+    return res.status(401).json({ msg: 'Daemon and agent tokens cannot authenticate user routes' });
+  }
+
   if (token.startsWith('cm_')) {
     try {
       const user = await User.findOne({ apiToken: token }).select(

--- a/backend/routes/machines.ts
+++ b/backend/routes/machines.ts
@@ -4,6 +4,7 @@ import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import { Types } from 'mongoose';
 import {
   listMachinesForOwner,
+  getMachineForDaemon,
   recordMachineHeartbeat,
   registerMachine,
   removeMachine,
@@ -89,6 +90,22 @@ router.get('/', machineRateLimit, auth, async (req: AuthReq, res: express.Respon
     return res.json(await listMachinesForOwner(ownerUserId));
   } catch (error) {
     console.error('Error listing machines:', error);
+    return res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// A daemon can read only its own machine view. This avoids coupling daemon
+// status to a renewable human JWT or exposing the owner's other machines.
+router.get('/me', machineRateLimit, daemonAuth('machine:read'), async (req: DaemonAuthedRequest, res: express.Response) => {
+  try {
+    const machine = await getMachineForDaemon({
+      machineId: req.machine!.machineId,
+      ownerUserId: req.machine!.ownerUserId,
+    });
+    if (!machine) return res.status(404).json({ message: 'Machine not found' });
+    return res.json({ machine });
+  } catch (error) {
+    console.error('Error reading daemon machine:', error);
     return res.status(500).json({ message: 'Server error' });
   }
 });

--- a/backend/services/daemonCredentialService.ts
+++ b/backend/services/daemonCredentialService.ts
@@ -12,6 +12,7 @@ const { hash, randomSecret } = require('../utils/secret') as {
 
 export const DAEMON_SCOPES = [
   'machine:heartbeat',
+  'machine:read',
   'agents:adopt',
 ] as const;
 

--- a/backend/services/machineService.ts
+++ b/backend/services/machineService.ts
@@ -90,6 +90,20 @@ export async function listMachinesForOwner(ownerUserId: Types.ObjectId | string)
   };
 }
 
+// The daemon's status call has no need to enumerate its owner's machines.
+// Match both credential-derived identifiers and return the same derived view
+// the owner list uses, never the credential-bearing document.
+export async function getMachineForDaemon({
+  machineId,
+  ownerUserId,
+}: {
+  machineId: string;
+  ownerUserId: Types.ObjectId | string;
+}): Promise<MachineView | null> {
+  const machine = await Machine.findOne({ machineId, ownerUserId }).lean();
+  return machine ? serializeMachine(machine) : null;
+}
+
 export async function recordMachineHeartbeat(machine: IMachine): Promise<MachineView> {
   machine.lastSeenAt = new Date();
   machine.status = 'online';
@@ -136,6 +150,7 @@ module.exports = {
   MACHINE_OFFLINE_AFTER_MS,
   MAX_MACHINES_PER_OWNER,
   listMachinesForOwner,
+  getMachineForDaemon,
   recordMachineHeartbeat,
   registerMachine,
   removeMachine,

--- a/cli/__tests__/command-registration.test.mjs
+++ b/cli/__tests__/command-registration.test.mjs
@@ -21,12 +21,14 @@
 
 import { Command } from 'commander';
 import { cascadeOverridesFromOpts, registerAgent } from '../src/commands/agent.js';
+import { registerDaemon } from '../src/commands/daemon.js';
 import { CASCADE_ENV_VARS } from '../src/lib/enforcement.js';
 
 const registerAll = () => {
   const program = new Command();
   program.exitOverride();
   registerAgent(program);
+  registerDaemon(program);
   return program;
 };
 
@@ -38,6 +40,16 @@ const findCommand = (program, path) => path.reduce(
 describe('command registration', () => {
   test('registerAgent evaluates every option definition without throwing', () => {
     expect(() => registerAll()).not.toThrow();
+  });
+
+  test('daemon registration commands are wired without starting a daemon', () => {
+    const daemon = findCommand(registerAll(), ['daemon']);
+    expect(daemon).toBeDefined();
+    expect(daemon.commands.map((command) => command.name())).toEqual(expect.arrayContaining([
+      'register', 'heartbeat', 'status',
+    ]));
+    expect(findCommand(registerAll(), ['daemon', 'register']).options.map((option) => option.long))
+      .toEqual(expect.arrayContaining(['--name', '--instance']));
   });
 
   test('agent run exposes the cascade knobs, each naming its env var', () => {

--- a/cli/__tests__/daemon.test.mjs
+++ b/cli/__tests__/daemon.test.mjs
@@ -52,7 +52,8 @@ describe('daemon credential storage', () => {
   });
 
   test('rejects a malformed local credential instead of minting another machine', () => {
-    fs.mkdirSync(path.dirname(daemonRecordPath()), { recursive: true });
+    fs.mkdirSync(path.dirname(daemonRecordPath()), { recursive: true, mode: 0o700 });
+    fs.chmodSync(path.dirname(daemonRecordPath()), 0o700);
     fs.writeFileSync(daemonRecordPath(), '{"machineDbId":"missing-token"}', 'utf8');
     fs.chmodSync(daemonRecordPath(), 0o600);
     expect(() => loadDaemonRecord()).toThrow(/credential file is invalid/i);
@@ -62,6 +63,12 @@ describe('daemon credential storage', () => {
     saveDaemonRecord(daemonRecord);
     fs.chmodSync(daemonRecordPath(), 0o644);
     expect(() => loadDaemonRecord()).toThrow(/permissions are insecure/i);
+  });
+
+  test('refuses a writable credential directory even when the file is 0600', () => {
+    saveDaemonRecord(daemonRecord);
+    fs.chmodSync(path.dirname(daemonRecordPath()), 0o755);
+    expect(() => loadDaemonRecord()).toThrow(/directory permissions are insecure/i);
   });
 });
 
@@ -123,13 +130,14 @@ describe('daemon machine calls', () => {
     expect(client.post).toHaveBeenCalledWith(`/api/machines/${daemonRecord.machineDbId}/heartbeat`);
   });
 
-  test('status selects this local machine from the owner-scoped server list', async () => {
+  test('status uses the daemon-scoped self route, not an owner machine listing', async () => {
     const client = {
       get: jest.fn().mockResolvedValue({
-        machines: [{ id: 'other' }, { id: daemonRecord.machineDbId, status: 'online' }],
+        machine: { id: daemonRecord.machineDbId, status: 'online' },
       }),
     };
     await expect(getDaemonMachineStatus({ client, record: daemonRecord }))
       .resolves.toEqual({ id: daemonRecord.machineDbId, status: 'online' });
+    expect(client.get).toHaveBeenCalledWith('/api/machines/me');
   });
 });

--- a/cli/__tests__/daemon.test.mjs
+++ b/cli/__tests__/daemon.test.mjs
@@ -1,0 +1,135 @@
+import { jest } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const daemonTmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'commonly-daemon-test-'));
+
+await jest.unstable_mockModule('os', () => {
+  const actual = os;
+  return {
+    ...actual,
+    default: { ...actual, homedir: () => daemonTmpHome },
+    homedir: () => daemonTmpHome,
+  };
+});
+
+const {
+  daemonRecordPath,
+  loadDaemonRecord,
+  saveDaemonRecord,
+} = await import('../src/lib/daemon-store.js');
+const {
+  getDaemonMachineStatus,
+  heartbeatDaemonMachine,
+  registerDaemonMachine,
+} = await import('../src/commands/daemon.js');
+
+const daemonRecord = {
+  machineDbId: '507f1f77bcf86cd799439011',
+  machineId: 'e7ee6405-bb61-4e62-85b9-7c7034086feb',
+  machineName: 'Sam’s MacBook',
+  instanceUrl: 'https://api.commonly.me',
+  daemonToken: 'cm_daemon_secret',
+  registeredAt: '2026-08-30T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  fs.rmSync(path.join(daemonTmpHome, '.commonly'), { recursive: true, force: true });
+});
+
+afterAll(() => {
+  fs.rmSync(daemonTmpHome, { recursive: true, force: true });
+});
+
+describe('daemon credential storage', () => {
+  test('writes a private directory and 0600 bearer record', () => {
+    saveDaemonRecord(daemonRecord);
+
+    expect(loadDaemonRecord()).toEqual(daemonRecord);
+    expect(fs.statSync(path.dirname(daemonRecordPath())).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(daemonRecordPath()).mode & 0o777).toBe(0o600);
+  });
+
+  test('rejects a malformed local credential instead of minting another machine', () => {
+    fs.mkdirSync(path.dirname(daemonRecordPath()), { recursive: true });
+    fs.writeFileSync(daemonRecordPath(), '{"machineDbId":"missing-token"}', 'utf8');
+    fs.chmodSync(daemonRecordPath(), 0o600);
+    expect(() => loadDaemonRecord()).toThrow(/credential file is invalid/i);
+  });
+
+  test('refuses to load a bearer from a group- or world-readable file', () => {
+    saveDaemonRecord(daemonRecord);
+    fs.chmodSync(daemonRecordPath(), 0o644);
+    expect(() => loadDaemonRecord()).toThrow(/permissions are insecure/i);
+  });
+});
+
+describe('daemon machine calls', () => {
+  test('persists the one-time daemon bearer without returning it in the machine view', async () => {
+    const client = {
+      post: jest.fn().mockResolvedValue({
+        machine: {
+          id: daemonRecord.machineDbId,
+          machineId: daemonRecord.machineId,
+          name: daemonRecord.machineName,
+        },
+        daemonToken: daemonRecord.daemonToken,
+      }),
+      del: jest.fn(),
+    };
+    const persist = jest.fn();
+
+    const result = await registerDaemonMachine({
+      client,
+      instanceUrl: daemonRecord.instanceUrl,
+      name: daemonRecord.machineName,
+      persist,
+    });
+
+    expect(client.post).toHaveBeenCalledWith('/api/machines', { name: daemonRecord.machineName });
+    expect(persist).toHaveBeenCalledWith(expect.objectContaining({
+      machineDbId: daemonRecord.machineDbId,
+      daemonToken: daemonRecord.daemonToken,
+    }));
+    expect(result.machine).not.toHaveProperty('daemonToken');
+  });
+
+  test('revokes the just-created machine if secure persistence fails', async () => {
+    const client = {
+      post: jest.fn().mockResolvedValue({
+        machine: {
+          id: daemonRecord.machineDbId,
+          machineId: daemonRecord.machineId,
+          name: daemonRecord.machineName,
+        },
+        daemonToken: daemonRecord.daemonToken,
+      }),
+      del: jest.fn().mockResolvedValue({ success: true }),
+    };
+
+    await expect(registerDaemonMachine({
+      client,
+      instanceUrl: daemonRecord.instanceUrl,
+      name: daemonRecord.machineName,
+      persist: () => { throw new Error('disk full'); },
+    })).rejects.toThrow(/registration was revoked/i);
+    expect(client.del).toHaveBeenCalledWith(`/api/machines/${daemonRecord.machineDbId}`);
+  });
+
+  test('heartbeats only the machine id held by the daemon credential record', async () => {
+    const client = { post: jest.fn().mockResolvedValue({ machine: { status: 'online' } }) };
+    await heartbeatDaemonMachine({ client, record: daemonRecord });
+    expect(client.post).toHaveBeenCalledWith(`/api/machines/${daemonRecord.machineDbId}/heartbeat`);
+  });
+
+  test('status selects this local machine from the owner-scoped server list', async () => {
+    const client = {
+      get: jest.fn().mockResolvedValue({
+        machines: [{ id: 'other' }, { id: daemonRecord.machineDbId, status: 'online' }],
+      }),
+    };
+    await expect(getDaemonMachineStatus({ client, record: daemonRecord }))
+      .resolves.toEqual({ id: daemonRecord.machineDbId, status: 'online' });
+  });
+});

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.22",
+  "version": "0.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commonlyai/cli",
-      "version": "0.1.22",
+      "version": "0.1.25",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "license": "Apache-2.0",
   "description": "The Commonly CLI \u2014 connect agents, manage pods, iterate fast",
   "type": "module",

--- a/cli/src/commands/daemon.js
+++ b/cli/src/commands/daemon.js
@@ -75,10 +75,9 @@ export const heartbeatDaemonMachine = async ({ client, record }) => (
   client.post(`/api/machines/${record.machineDbId}/heartbeat`)
 );
 
-export const getDaemonMachineStatus = async ({ client, record }) => {
-  const response = await client.get('/api/machines');
-  const machines = Array.isArray(response) ? response : response?.machines || [];
-  return machines.find((machine) => machine?.id === record.machineDbId) || null;
+export const getDaemonMachineStatus = async ({ client }) => {
+  const response = await client.get('/api/machines/me');
+  return response?.machine || null;
 };
 
 export const registerDaemon = (program) => {
@@ -154,10 +153,8 @@ Examples:
     .action(async () => {
       try {
         const record = requireDaemonRecord();
-        const userToken = requireUserToken(record.instanceUrl);
         const machine = await getDaemonMachineStatus({
-          client: createClient({ instance: record.instanceUrl, token: userToken }),
-          record,
+          client: createClient({ instance: record.instanceUrl, token: record.daemonToken }),
         });
         if (!machine) {
           console.log(`${record.machineName}: no longer registered on the server.`);

--- a/cli/src/commands/daemon.js
+++ b/cli/src/commands/daemon.js
@@ -1,0 +1,173 @@
+/**
+ * commonly daemon <subcommand>
+ *
+ * Phase 2, slice 1: register one machine, persist its scoped daemon bearer,
+ * and report/send heartbeats. Adoption and supervision deliberately arrive in
+ * later slices; this command never reads an agent runtime credential.
+ */
+
+import { hostname } from 'os';
+import { createClient } from '../lib/api.js';
+import { getToken, resolveInstanceUrl } from '../lib/config.js';
+import { loadDaemonRecord, saveDaemonRecord } from '../lib/daemon-store.js';
+
+const requireDaemonRecord = () => {
+  const record = loadDaemonRecord();
+  if (!record) {
+    throw new Error('No local daemon is registered. Run: commonly daemon register');
+  }
+  return record;
+};
+
+const requireUserToken = (instance) => {
+  const token = getToken(instance);
+  if (!token) throw new Error(`Not logged in to ${instance}. Run: commonly login --instance ${instance}`);
+  return token;
+};
+
+const requireRegistrationResponse = (response) => {
+  const machine = response?.machine;
+  if (!machine?.id || !machine?.machineId || !machine?.name || !response?.daemonToken) {
+    throw new Error('Server returned an incomplete machine registration. No daemon credential was stored.');
+  }
+  return { machine, daemonToken: response.daemonToken };
+};
+
+// Exported for a service-level test: persistence failure must revoke the
+// freshly-created machine because the raw bearer is not recoverable later.
+export const registerDaemonMachine = async ({
+  client,
+  instanceUrl,
+  name,
+  persist = saveDaemonRecord,
+}) => {
+  const { machine, daemonToken } = requireRegistrationResponse(
+    await client.post('/api/machines', { name }),
+  );
+  const record = {
+    machineDbId: machine.id,
+    machineId: machine.machineId,
+    machineName: machine.name,
+    instanceUrl,
+    daemonToken,
+    registeredAt: new Date().toISOString(),
+  };
+
+  try {
+    persist(record);
+  } catch (error) {
+    // The token is a one-time response. If it cannot be secured locally, tear
+    // down the server row so it cannot remain a live, unrecoverable bearer.
+    try {
+      await client.del(`/api/machines/${machine.id}`);
+    } catch (revokeError) {
+      throw new Error(
+        `Could not store the daemon credential and could not revoke machine ${machine.name}: ${revokeError.message}`,
+      );
+    }
+    throw new Error(`Could not store the daemon credential securely: ${error.message}. Machine registration was revoked.`);
+  }
+
+  return { machine, record };
+};
+
+export const heartbeatDaemonMachine = async ({ client, record }) => (
+  client.post(`/api/machines/${record.machineDbId}/heartbeat`)
+);
+
+export const getDaemonMachineStatus = async ({ client, record }) => {
+  const response = await client.get('/api/machines');
+  const machines = Array.isArray(response) ? response : response?.machines || [];
+  return machines.find((machine) => machine?.id === record.machineDbId) || null;
+};
+
+export const registerDaemon = (program) => {
+  const daemon = program.command('daemon').description('Manage the local Commonly daemon');
+
+  daemon.addHelpText('after', `
+The daemon token is scoped to this machine and stored in a 0600 file under
+~/.commonly/daemon/. It is never shown again after registration.
+
+Examples:
+  $ commonly daemon register --name "Sam's MacBook"
+  $ commonly daemon heartbeat
+  $ commonly daemon status
+`);
+
+  daemon
+    .command('register')
+    .description('Register this machine and securely store its daemon credential')
+    .option('--name <name>', 'Machine name (default: this computer\'s hostname)')
+    .option('--instance <url-or-key>', 'Target Commonly instance')
+    .action(async (opts) => {
+      try {
+        const existing = loadDaemonRecord();
+        if (existing) {
+          throw new Error(`A local daemon is already registered for ${existing.machineName}. Run: commonly daemon status`);
+        }
+        const instanceUrl = resolveInstanceUrl(opts.instance);
+        const client = createClient({ instance: instanceUrl, token: requireUserToken(opts.instance || instanceUrl) });
+        const { machine, record } = await registerDaemonMachine({
+          client,
+          instanceUrl,
+          name: String(opts.name || hostname()).trim(),
+        });
+        console.log(`Registered ${machine.name}. Daemon credential stored securely.`);
+
+        try {
+          await heartbeatDaemonMachine({
+            client: createClient({ instance: record.instanceUrl, token: record.daemonToken }),
+            record,
+          });
+          console.log('Initial heartbeat accepted.');
+        } catch (error) {
+          console.error(`Machine is registered, but its initial heartbeat failed: ${error.message}`);
+          console.error('Retry with: commonly daemon heartbeat');
+          process.exitCode = 1;
+        }
+      } catch (error) {
+        console.error(`Daemon registration failed: ${error.message}`);
+        process.exitCode = 1;
+      }
+    });
+
+  daemon
+    .command('heartbeat')
+    .description('Send a machine liveness heartbeat using the stored daemon credential')
+    .action(async () => {
+      try {
+        const record = requireDaemonRecord();
+        const response = await heartbeatDaemonMachine({
+          client: createClient({ instance: record.instanceUrl, token: record.daemonToken }),
+          record,
+        });
+        console.log(`Heartbeat accepted for ${response?.machine?.name || record.machineName}.`);
+      } catch (error) {
+        console.error(`Daemon heartbeat failed: ${error.message}`);
+        process.exitCode = 1;
+      }
+    });
+
+  daemon
+    .command('status')
+    .description('Show the server-derived liveness of this machine')
+    .action(async () => {
+      try {
+        const record = requireDaemonRecord();
+        const userToken = requireUserToken(record.instanceUrl);
+        const machine = await getDaemonMachineStatus({
+          client: createClient({ instance: record.instanceUrl, token: userToken }),
+          record,
+        });
+        if (!machine) {
+          console.log(`${record.machineName}: no longer registered on the server.`);
+          return;
+        }
+        const lastSeen = machine.lastSeenAt ? new Date(machine.lastSeenAt).toLocaleString() : 'never';
+        console.log(`${machine.name}: ${machine.status} (last heartbeat: ${lastSeen})`);
+      } catch (error) {
+        console.error(`Daemon status failed: ${error.message}`);
+        process.exitCode = 1;
+      }
+    });
+};

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'url';
 
 import { registerLogin, registerWhoami } from './commands/login.js';
 import { registerAgent } from './commands/agent.js';
+import { registerDaemon } from './commands/daemon.js';
 import { registerPod } from './commands/pod.js';
 import { registerDev } from './commands/dev.js';
 
@@ -37,6 +38,9 @@ registerWhoami(program);
 // Agent management
 registerAgent(program);
 
+// Local daemon lifecycle
+registerDaemon(program);
+
 // Pod management
 registerPod(program);
 
@@ -53,6 +57,8 @@ Quick start:
   $ commonly agent attach claude --pod <podId> --name my-claude
   $ commonly agent run my-claude                       # Ctrl+C to stop
   $ commonly agent detach my-claude                    # clean uninstall
+  $ commonly daemon register --name "My MacBook"
+  $ commonly daemon status
 
 Custom Python agent:
   $ commonly agent init --language python --name research-bot --pod <podId>

--- a/cli/src/lib/daemon-store.js
+++ b/cli/src/lib/daemon-store.js
@@ -1,0 +1,69 @@
+/**
+ * Local daemon credential storage.
+ *
+ * A daemon is one machine-level supervisor, not an agent token file. Keep its
+ * credential in its own 0700 directory and enforce 0600 on every write; the
+ * bearer must never be printed or placed in the ordinary CLI config file.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+const daemonDir = () => join(homedir(), '.commonly', 'daemon');
+export const daemonRecordPath = () => join(daemonDir(), 'machine.json');
+
+const validateRecord = (record) => {
+  if (!record
+    || typeof record.machineDbId !== 'string'
+    || typeof record.machineId !== 'string'
+    || typeof record.machineName !== 'string'
+    || typeof record.instanceUrl !== 'string'
+    || typeof record.daemonToken !== 'string'
+    || !record.daemonToken.startsWith('cm_daemon_')) {
+    throw new Error('Daemon credential file is invalid. Revoke the machine before registering again.');
+  }
+  return record;
+};
+
+export const loadDaemonRecord = () => {
+  const path = daemonRecordPath();
+  if (!existsSync(path)) return null;
+  if ((statSync(path).mode & 0o077) !== 0) {
+    throw new Error('Daemon credential file permissions are insecure. Set them to 0600 before running the daemon.');
+  }
+  try {
+    return validateRecord(JSON.parse(readFileSync(path, 'utf8')));
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Daemon credential file')) throw error;
+    throw new Error('Daemon credential file is unreadable. Revoke the machine before registering again.');
+  }
+};
+
+export const saveDaemonRecord = (record) => {
+  const safeRecord = validateRecord(record);
+  const dir = daemonDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  chmodSync(dir, 0o700);
+
+  const path = daemonRecordPath();
+  const temporaryPath = `${path}.${process.pid}.tmp`;
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify(safeRecord, null, 2)}\n`, { mode: 0o600 });
+    chmodSync(temporaryPath, 0o600);
+    renameSync(temporaryPath, path);
+    chmodSync(path, 0o600);
+  } catch (error) {
+    if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+    throw error;
+  }
+};

--- a/cli/src/lib/daemon-store.js
+++ b/cli/src/lib/daemon-store.js
@@ -37,15 +37,21 @@ const validateRecord = (record) => {
 
 export const loadDaemonRecord = () => {
   const path = daemonRecordPath();
+  const dir = daemonDir();
   if (!existsSync(path)) return null;
+  if ((statSync(dir).mode & 0o077) !== 0) {
+    throw new Error(`Daemon credential directory permissions are insecure at ${dir}. Set them to 0700 before running the daemon.`);
+  }
   if ((statSync(path).mode & 0o077) !== 0) {
-    throw new Error('Daemon credential file permissions are insecure. Set them to 0600 before running the daemon.');
+    throw new Error(`Daemon credential file permissions are insecure at ${path}. Set them to 0600 before running the daemon.`);
   }
   try {
     return validateRecord(JSON.parse(readFileSync(path, 'utf8')));
   } catch (error) {
-    if (error instanceof Error && error.message.startsWith('Daemon credential file')) throw error;
-    throw new Error('Daemon credential file is unreadable. Revoke the machine before registering again.');
+    if (error instanceof Error && error.message.startsWith('Daemon credential file')) {
+      throw new Error(`${error.message} (${path})`);
+    }
+    throw new Error(`Daemon credential file is unreadable at ${path}. Revoke the machine before registering again.`);
   }
 };
 


### PR DESCRIPTION
## Summary
- add daemon register, heartbeat, and status commands
- persist the one-time daemon bearer in a dedicated 0700/0600 local store
- revoke the server machine if secure local persistence fails

## Verification
- npm test -- --runInBand __tests__/daemon.test.mjs __tests__/command-registration.test.mjs
- npm run lint
- node src/index.js daemon --help

Full CLI tests: 372 passed; the unrelated mention-event contract test cannot load backend ts-node in this isolated worktree.