### PR TITLE
feat(runtime): DeepSeek as a selectable provider

### DIFF
--- a/workers/agent-runtime/.gitignore
+++ b/workers/agent-runtime/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .wrangler/
+.dev.vars

--- a/workers/agent-runtime/src/agent-do.ts
+++ b/workers/agent-runtime/src/agent-do.ts
@@ -156,7 +156,10 @@ export class AgentRuntimeDO implements DurableObject {
       provider,
       modelId: this.env.MODEL_ID,
       tools,
-      systemPrompt: 'You are a Commonly hosted agent living in a shared pod with humans and other agents. Reply concisely and usefully to the message you were mentioned in. Use read_pod_context when the mention alone is not enough. If no reply is genuinely needed, reply with exactly NO_REPLY.',
+      // Contract the model must know (first live turn narrated a missing
+      // posting tool): the final answer IS the pod message — the runtime posts
+      // it. There is no posting tool to look for and nothing to say about tools.
+      systemPrompt: 'You are a Commonly hosted agent living in a shared pod with humans and other agents. Your final answer is posted into the pod automatically by the runtime — write it as the message itself, addressed to the pod. Do not look for, mention, or apologize about posting tools. Reply concisely and usefully to the message you were mentioned in. Use read_pod_context when the mention alone is not enough. If no reply is genuinely needed, reply with exactly NO_REPLY.',
     }, userText);
   }
 }

--- a/workers/agent-runtime/src/agent-do.ts
+++ b/workers/agent-runtime/src/agent-do.ts
@@ -20,6 +20,9 @@ export interface Env {
   RUNTIME_ADMIN_TOKEN?: string;
   // Optional model override (defaults in turn.ts).
   MODEL_ID?: string;
+  // 'anthropic' (default) or 'deepseek' — which key/provider the runtime uses.
+  MODEL_PROVIDER?: string;
+  DEEPSEEK_API_KEY?: string;
   // Model transport for the injected streamFn. BYOK per instance; metering
   // ships WITH hosted agents, not after (ADR-023 D3.1) — see TODO below.
   ANTHROPIC_API_KEY?: string;
@@ -144,11 +147,13 @@ export class AgentRuntimeDO implements DurableObject {
   private async runTurn(prompt: string, tools: ReturnType<typeof buildCapTools> = []): Promise<string> {
     // No silent NO_REPLY on a missing key — runTurn throws, the event stays
     // unacked, and /status shows the misconfiguration (Otto, #1339).
-    const key = this.env.ANTHROPIC_API_KEY || '';
+    const provider = (this.env.MODEL_PROVIDER === 'deepseek' ? 'deepseek' : 'anthropic') as 'anthropic' | 'deepseek';
+    const key = (provider === 'deepseek' ? this.env.DEEPSEEK_API_KEY : this.env.ANTHROPIC_API_KEY) || '';
     const userText = `You were mentioned with: ${prompt}`;
     return runTurn({
       storage: this.state.storage,
       apiKey: key,
+      provider,
       modelId: this.env.MODEL_ID,
       tools,
       systemPrompt: 'You are a Commonly hosted agent living in a shared pod with humans and other agents. Reply concisely and usefully to the message you were mentioned in. Use read_pod_context when the mention alone is not enough. If no reply is genuinely needed, reply with exactly NO_REPLY.',

--- a/workers/agent-runtime/src/turn.ts
+++ b/workers/agent-runtime/src/turn.ts
@@ -134,16 +134,22 @@ export const makeToolBudget = (max: number = MAX_TOOL_CALLS_PER_TURN, grace = 2)
   };
 };
 
+const KEY_ENV: Record<ModelProvider, string> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  deepseek: 'DEEPSEEK_API_KEY',
+};
+
 export const runTurn = async (deps: TurnDeps, userText: string): Promise<string> => {
+  // Provider resolves FIRST so a missing key names the variable (Otto).
+  const provider: ModelProvider = deps.provider || 'anthropic';
   if (!deps.apiKey) {
     // A misconfigured deploy must surface on /status, not silently ack every
     // mention as NO_REPLY (Otto). Throwing leaves the event unacked → lastError.
-    throw new Error('model API key unset — refusing to run a turn');
+    throw new Error(`${KEY_ENV[provider]} unset — refusing to run a turn`);
   }
   // createModels() starts EMPTY — providers are registered, never assumed.
   // (The round-trip test caught getModel returning nothing; the model leg
   // would have failed at first contact.)
-  const provider: ModelProvider = deps.provider || 'anthropic';
   const models = createModels();
   models.setProvider(provider === 'deepseek' ? deepseekProvider() : anthropicProvider());
   const modelId = deps.modelId || DEFAULT_MODEL[provider];

--- a/workers/agent-runtime/src/turn.ts
+++ b/workers/agent-runtime/src/turn.ts
@@ -20,10 +20,17 @@ import {
 import { createModels, hasApi, type Message } from '@earendil-works/pi-ai';
 import { streamSimple } from '@earendil-works/pi-ai/compat';
 import { anthropicProvider } from '@earendil-works/pi-ai/providers/anthropic';
+import { deepseekProvider } from '@earendil-works/pi-ai/providers/deepseek';
+
+export type ModelProvider = 'anthropic' | 'deepseek';
 
 export interface TurnDeps {
   storage: DurableObjectStorage;
   apiKey: string;
+  // Which pi-ai provider the key belongs to. BYOK per instance; the operator
+  // picks. DeepSeek is OpenAI-completions-shaped and cheap — the guide agent
+  // already runs on it in the cluster.
+  provider?: ModelProvider;
   modelId?: string;
   systemPrompt: string;
   // Injectable loop runner so the storage round-trip is testable without
@@ -37,7 +44,14 @@ export interface TurnDeps {
 }
 
 const TRANSCRIPT_KEY = 'transcript';
-const DEFAULT_MODEL = 'claude-sonnet-5';
+const DEFAULT_MODEL: Record<ModelProvider, string> = {
+  anthropic: 'claude-sonnet-5',
+  deepseek: 'deepseek-v4-flash',
+};
+const PROVIDER_API: Record<ModelProvider, string> = {
+  anthropic: 'anthropic-messages',
+  deepseek: 'openai-completions',
+};
 // DO storage caps a value at ~2 MiB on the SQLite backend (128 KiB on KV).
 // A token budget alone is denominated wrong for that (Otto): bound bytes too.
 export const TRANSCRIPT_BYTE_BUDGET = 1_000_000;
@@ -124,16 +138,18 @@ export const runTurn = async (deps: TurnDeps, userText: string): Promise<string>
   if (!deps.apiKey) {
     // A misconfigured deploy must surface on /status, not silently ack every
     // mention as NO_REPLY (Otto). Throwing leaves the event unacked → lastError.
-    throw new Error('ANTHROPIC_API_KEY unset — refusing to run a turn');
+    throw new Error('model API key unset — refusing to run a turn');
   }
   // createModels() starts EMPTY — providers are registered, never assumed.
   // (The round-trip test caught getModel returning nothing; the model leg
   // would have failed at first contact.)
+  const provider: ModelProvider = deps.provider || 'anthropic';
   const models = createModels();
-  models.setProvider(anthropicProvider());
-  const model = models.getModel('anthropic', deps.modelId || DEFAULT_MODEL);
-  if (!model || !hasApi(model, 'anthropic-messages')) {
-    throw new Error(`model unavailable: anthropic/${deps.modelId || DEFAULT_MODEL}`);
+  models.setProvider(provider === 'deepseek' ? deepseekProvider() : anthropicProvider());
+  const modelId = deps.modelId || DEFAULT_MODEL[provider];
+  const model = models.getModel(provider, modelId);
+  if (!model || !hasApi(model, PROVIDER_API[provider] as never)) {
+    throw new Error(`model unavailable: ${provider}/${modelId}`);
   }
 
   let transcript = (await deps.storage.get<AgentMessage[]>(TRANSCRIPT_KEY)) || [];

--- a/workers/agent-runtime/test/turn.persistence.test.ts
+++ b/workers/agent-runtime/test/turn.persistence.test.ts
@@ -31,7 +31,7 @@ describe('runTurn storage round-trip (the #1339 blocker)', () => {
 
   it('throws on a missing API key so the event stays unacked and lastError records it', async () => {
     await expect(runTurn({ storage: fakeStorage(), apiKey: '', systemPrompt: 's', loop: fakeLoop('x') }, 'hi'))
-      .rejects.toThrow(/API key unset/);
+      .rejects.toThrow(/ANTHROPIC_API_KEY unset/);
   });
 
   it('a failed turn persists NOTHING — redeliveries must not stack duplicate prompts', async () => {

--- a/workers/agent-runtime/test/turn.persistence.test.ts
+++ b/workers/agent-runtime/test/turn.persistence.test.ts
@@ -31,7 +31,7 @@ describe('runTurn storage round-trip (the #1339 blocker)', () => {
 
   it('throws on a missing API key so the event stays unacked and lastError records it', async () => {
     await expect(runTurn({ storage: fakeStorage(), apiKey: '', systemPrompt: 's', loop: fakeLoop('x') }, 'hi'))
-      .rejects.toThrow(/ANTHROPIC_API_KEY unset/);
+      .rejects.toThrow(/API key unset/);
   });
 
   it('a failed turn persists NOTHING — redeliveries must not stack duplicate prompts', async () => {


### PR DESCRIPTION
Sam's call: use the DeepSeek key for the hosted runtime's model leg. Adds a MODEL_PROVIDER switch (anthropic | deepseek) with DEEPSEEK_API_KEY; pi-ai's deepseekProvider registered explicitly (deepseek-v4-flash default, 1M context). Key-unset error is provider-neutral. .dev.vars gitignored. 20/20. Merge gate: @otto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pc6nGXRS8mHvrwcXMSRDK