### PR TITLE
feat(hosted): self-serve provision surface + D3.1 metering floor (ADR-023 W2)

### DIFF
--- a/backend/__tests__/unit/routes/hosted.test.js
+++ b/backend/__tests__/unit/routes/hosted.test.js
@@ -1,0 +1,153 @@
+// /api/hosted — ownership (sole-installer), unconfigured 503, cap re-check,
+// server-side mint → worker provision, and that secrets never reach the body.
+const request = require('supertest');
+const express = require('express');
+
+const mockFindOne = jest.fn();
+const mockUserFindOne = jest.fn();
+const mockIssueToken = jest.fn();
+const mockHosted = {
+  HOSTED_RUNTIME_TYPE: 'hosted',
+  isConfigured: jest.fn(),
+  isHostedInstallation: jest.fn(),
+  hostedCaps: jest.fn(() => ({ agentsPerUser: 1, turnsPerDay: 200 })),
+  countHostedAgentsForUser: jest.fn(),
+  meterAllowsTurn: jest.fn(),
+  provisionAgent: jest.fn(),
+  deprovisionAgent: jest.fn(),
+  getAgentStatus: jest.fn(),
+  HostedRuntimeError: class HostedRuntimeError extends Error {
+    constructor(message, status) { super(message); this.status = status; }
+  },
+};
+
+jest.mock('../../../middleware/auth', () => (req, _res, next) => {
+  req.user = { id: 'owner-1' };
+  next();
+});
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { findOne: (...args) => mockFindOne(...args) },
+}));
+jest.mock('../../../models/User', () => ({ findOne: (...args) => mockUserFindOne(...args) }));
+jest.mock('../../../services/agentIdentityService', () => ({
+  buildAgentUsername: (name, instance) => (instance === 'default' ? name : `${name}-${instance}`),
+}));
+jest.mock('../../../services/hostedRuntimeService', () => mockHosted);
+jest.mock('../../../routes/registry/tokens', () => ({
+  issueRuntimeTokenForAgent: (...args) => mockIssueToken(...args),
+}));
+
+const hostedRouter = require('../../../routes/hosted');
+
+const app = express();
+app.use(express.json());
+app.use('/api/hosted', hostedRouter);
+
+const makeInstallation = (overrides = {}) => ({
+  agentName: 'scout',
+  instanceId: 'default',
+  podId: 'pod-1',
+  config: new Map([['runtime', { runtimeType: 'hosted' }]]),
+  save: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+describe('/api/hosted', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHosted.isConfigured.mockReturnValue(true);
+    mockHosted.isHostedInstallation.mockReturnValue(true);
+    mockHosted.countHostedAgentsForUser.mockResolvedValue(1);
+    mockUserFindOne.mockResolvedValue({ _id: 'bot-1', username: 'scout' });
+    mockIssueToken.mockResolvedValue({ token: 'cm_agent_secret', existing: false });
+    mockHosted.provisionAgent.mockResolvedValue({ provisioned: true });
+  });
+
+  it('503s with a code when the runtime is not configured, before touching the DB', async () => {
+    mockHosted.isConfigured.mockReturnValue(false);
+    const res = await request(app).post('/api/hosted/provision').send({ agentName: 'scout' });
+    expect(res.status).toBe(503);
+    expect(res.body.code).toBe('hosted_runtime_unconfigured');
+    expect(mockFindOne).not.toHaveBeenCalled();
+  });
+
+  it('400s on a malformed agent name', async () => {
+    const res = await request(app).post('/api/hosted/provision').send({ agentName: 'Bad Name!' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('invalid_agent_name');
+  });
+
+  it('404s unless the caller is the installer of an active installation', async () => {
+    mockFindOne.mockResolvedValue(null);
+    const res = await request(app).post('/api/hosted/provision').send({ agentName: 'scout' });
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('not_owner_or_missing');
+    expect(mockFindOne).toHaveBeenCalledWith({
+      agentName: 'scout', instanceId: 'default', status: 'active', installedBy: 'owner-1',
+    });
+  });
+
+  it('409s when the owned installation is not a hosted one', async () => {
+    mockFindOne.mockResolvedValue(makeInstallation());
+    mockHosted.isHostedInstallation.mockReturnValue(false);
+    const res = await request(app).post('/api/hosted/provision').send({ agentName: 'scout' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('not_hosted');
+    expect(mockHosted.provisionAgent).not.toHaveBeenCalled();
+  });
+
+  it('403s when the owner is over the (possibly lowered) per-user cap', async () => {
+    mockFindOne.mockResolvedValue(makeInstallation());
+    mockHosted.countHostedAgentsForUser.mockResolvedValue(2);
+    const res = await request(app).post('/api/hosted/provision').send({ agentName: 'scout' });
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ code: 'hosted_cap_reached', used: 2, cap: 1 });
+    expect(mockIssueToken).not.toHaveBeenCalled();
+  });
+
+  it('mints server-side with owner lineage, provisions, records, and never returns the token', async () => {
+    const installation = makeInstallation();
+    mockFindOne.mockResolvedValue(installation);
+    const res = await request(app).post('/api/hosted/provision').send({ agentName: 'Scout', instanceId: 'Demo' });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ provisioned: true, agentName: 'scout', instanceId: 'demo', podId: 'pod-1' });
+    expect(JSON.stringify(res.body)).not.toContain('cm_agent_secret');
+    expect(mockUserFindOne).toHaveBeenCalledWith({ username: 'scout-demo', isBot: true });
+    expect(mockIssueToken).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: 'bot-1' }), 'Hosted runtime', installation, { ownerUserId: 'owner-1' },
+    );
+    expect(mockHosted.provisionAgent).toHaveBeenCalledWith({ agentName: 'scout', instanceId: 'demo', runtimeToken: 'cm_agent_secret' });
+    expect(installation.config.get('hosted').provisionedAt).toBeInstanceOf(Date);
+    expect(installation.save).toHaveBeenCalled();
+  });
+
+  it('relays a worker failure as 502 and does not record a provision', async () => {
+    const installation = makeInstallation();
+    mockFindOne.mockResolvedValue(installation);
+    mockHosted.provisionAgent.mockRejectedValue(new mockHosted.HostedRuntimeError('Hosted runtime unreachable: timeout', 502));
+    const res = await request(app).post('/api/hosted/provision').send({ agentName: 'scout' });
+    expect(res.status).toBe(502);
+    expect(res.body.code).toBe('hosted_runtime_unreachable');
+    expect(installation.save).not.toHaveBeenCalled();
+  });
+
+  it('deprovisions the owner\'s agent and keeps the installation', async () => {
+    const installation = makeInstallation();
+    mockFindOne.mockResolvedValue(installation);
+    mockHosted.deprovisionAgent.mockResolvedValue({ deprovisioned: true });
+    const res = await request(app).post('/api/hosted/deprovision').send({ agentName: 'scout' });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ deprovisioned: true });
+    expect(installation.config.get('hosted').provisionedAt).toBeNull();
+    expect(installation.save).toHaveBeenCalled();
+  });
+
+  it('reports runtime status together with today\'s meter for the owner', async () => {
+    mockFindOne.mockResolvedValue(makeInstallation());
+    mockHosted.getAgentStatus.mockResolvedValue({ agentName: 'scout', lastPollAt: 1 });
+    mockHosted.meterAllowsTurn.mockResolvedValue({ allowed: true, used: 3, cap: 200 });
+    const res = await request(app).get('/api/hosted/status').query({ agentName: 'scout' });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ runtime: { lastPollAt: 1 }, meter: { used: 3, cap: 200 } });
+  });
+});

--- a/backend/__tests__/unit/routes/hosted.test.js
+++ b/backend/__tests__/unit/routes/hosted.test.js
@@ -29,6 +29,8 @@ jest.mock('../../../models/AgentRegistry', () => ({
   AgentInstallation: { findOne: (...args) => mockFindOne(...args) },
 }));
 jest.mock('../../../models/User', () => ({ findOne: (...args) => mockUserFindOne(...args) }));
+const mockCredentialUpdateMany = jest.fn();
+jest.mock('../../../models/AgentCredential', () => ({ updateMany: (...args) => mockCredentialUpdateMany(...args) }));
 jest.mock('../../../services/agentIdentityService', () => ({
   buildAgentUsername: (name, instance) => (instance === 'default' ? name : `${name}-${instance}`),
 }));
@@ -58,7 +60,8 @@ describe('/api/hosted', () => {
     mockHosted.isConfigured.mockReturnValue(true);
     mockHosted.isHostedInstallation.mockReturnValue(true);
     mockHosted.countHostedAgentsForUser.mockResolvedValue(1);
-    mockUserFindOne.mockResolvedValue({ _id: 'bot-1', username: 'scout' });
+    mockUserFindOne.mockResolvedValue({ _id: 'bot-1', username: 'scout', agentRuntimeTokens: [] });
+    mockCredentialUpdateMany.mockResolvedValue({ modifiedCount: 0 });
     mockIssueToken.mockResolvedValue({ token: 'cm_agent_secret', existing: false });
     mockHosted.provisionAgent.mockResolvedValue({ provisioned: true });
   });
@@ -128,6 +131,24 @@ describe('/api/hosted', () => {
     expect(mockHosted.provisionAgent).toHaveBeenCalledWith({ agentName: 'scout', instanceId: 'demo', runtimeToken: 'cm_agent_secret' });
     expect(installation.config.get('hosted').provisionedAt).toBeInstanceOf(Date);
     expect(installation.save).toHaveBeenCalled();
+  });
+
+  it('rotates: revokes the old credential rows, clears the stored hashes, mints fresh', async () => {
+    const installation = makeInstallation({ runtimeTokens: [{ tokenHash: 'old-hash' }] });
+    const agentUser = { _id: 'bot-1', username: 'scout', agentRuntimeTokens: [{ tokenHash: 'old-hash' }] };
+    mockFindOne.mockResolvedValue(installation);
+    mockUserFindOne.mockResolvedValue(agentUser);
+    mockIssueToken.mockResolvedValue({ token: 'cm_agent_fresh', existing: false });
+    const res = await request(app).post('/api/hosted/provision').send({ agentName: 'scout' });
+    expect(res.status).toBe(200);
+    expect(mockCredentialUpdateMany).toHaveBeenCalledWith(
+      { tokenHash: { $in: ['old-hash'] }, status: 'active' },
+      { $set: expect.objectContaining({ status: 'revoked' }) },
+    );
+    // Cleared BEFORE minting, so issueRuntimeTokenForAgent cannot take its reuse path.
+    expect(agentUser.agentRuntimeTokens).toEqual([]);
+    expect(installation.runtimeTokens).toEqual([]);
+    expect(mockHosted.provisionAgent).toHaveBeenCalledWith(expect.objectContaining({ runtimeToken: 'cm_agent_fresh' }));
   });
 
   it('relays a worker failure as 502 and does not record a provision', async () => {

--- a/backend/__tests__/unit/routes/hosted.test.js
+++ b/backend/__tests__/unit/routes/hosted.test.js
@@ -63,6 +63,15 @@ describe('/api/hosted', () => {
     mockHosted.provisionAgent.mockResolvedValue({ provisioned: true });
   });
 
+  it('reports availability and caps without the URL or bearer', async () => {
+    const res = await request(app).get('/api/hosted/availability');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ configured: true, caps: { agentsPerUser: 1, turnsPerDay: 200 } });
+    mockHosted.isConfigured.mockReturnValue(false);
+    const off = await request(app).get('/api/hosted/availability');
+    expect(off.body.configured).toBe(false);
+  });
+
   it('503s with a code when the runtime is not configured, before touching the DB', async () => {
     mockHosted.isConfigured.mockReturnValue(false);
     const res = await request(app).post('/api/hosted/provision').send({ agentName: 'scout' });

--- a/backend/__tests__/unit/routes/registry.hosted-cap-gate.test.js
+++ b/backend/__tests__/unit/routes/registry.hosted-cap-gate.test.js
@@ -116,6 +116,17 @@ describe('registry install — hosted runtime cap gate', () => {
     }));
   });
 
+  it('stores runtimeType normalized so a mixed-case value cannot dodge the count (Otto on #1355)', async () => {
+    mockCountHosted.mockResolvedValue(0);
+    const res = makeRes();
+    await installHandler(makeReq('Hosted'), res);
+    expect(res.status).not.toHaveBeenCalledWith(403);
+    expect(mockCountHosted).toHaveBeenCalledWith('user-1');
+    expect(AgentInstallation.install).toHaveBeenCalledWith('my-agent', 'pod-1', expect.objectContaining({
+      config: expect.objectContaining({ runtime: expect.objectContaining({ runtimeType: 'hosted' }) }),
+    }));
+  });
+
   it('403s hosted_cap_reached at the cap, before any row is written', async () => {
     mockCountHosted.mockResolvedValue(1);
     const res = makeRes();

--- a/backend/__tests__/unit/routes/registry.hosted-cap-gate.test.js
+++ b/backend/__tests__/unit/routes/registry.hosted-cap-gate.test.js
@@ -1,0 +1,147 @@
+// ADR-023 D3.1: a hosted (Commonly-run) install is open to every authenticated
+// user and METERED, not entitlement-gated. This exercises the self-serve
+// synth path (no registry row) with runtimeType 'hosted' and the per-user cap.
+// Mirrors the harness in registry.cloud-entitlement-gate.test.js.
+const mockCountHosted = jest.fn();
+
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentRegistry: {
+    getByName: jest.fn(),
+    create: jest.fn(),
+    incrementInstalls: jest.fn(),
+  },
+  AgentInstallation: {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    install: jest.fn(),
+  },
+}));
+jest.mock('../../../models/Pod', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/User', () => ({ findOne: jest.fn(), findById: jest.fn() }));
+jest.mock('../../../models/AgentProfile', () => ({ findOneAndUpdate: jest.fn() }));
+jest.mock('../../../models/AgentTemplate', () => ({ find: jest.fn() }));
+jest.mock('../../../models/Activity', () => ({ create: jest.fn() }));
+jest.mock('../../../services/agentIdentityService', () => ({
+  buildAgentUsername: jest.fn((agentName, instanceId = 'default') => (
+    instanceId === 'default' ? agentName : `${agentName}-${instanceId}`
+  )),
+  getOrCreateAgentUser: jest.fn().mockResolvedValue({ _id: 'bot-1' }),
+  ensureAgentInPod: jest.fn().mockResolvedValue(true),
+  getAgentTypeConfig: jest.fn(() => null),
+  isCloudRuntime: jest.fn(() => false),
+}));
+jest.mock('../../../services/agentMessageService', () => ({ postMessage: jest.fn().mockResolvedValue(true) }));
+jest.mock('../../../services/firstContactService', () => ({ maybeFireFirstContact: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../../../services/hostedRuntimeService', () => ({
+  HOSTED_RUNTIME_TYPE: 'hosted',
+  hostedCaps: () => ({ agentsPerUser: 1, turnsPerDay: 200 }),
+  countHostedAgentsForUser: (...args) => mockCountHosted(...args),
+}));
+
+const { AgentRegistry, AgentInstallation } = require('../../../models/AgentRegistry');
+const Pod = require('../../../models/Pod');
+const User = require('../../../models/User');
+const AgentProfile = require('../../../models/AgentProfile');
+const Activity = require('../../../models/Activity');
+const installRouter = require('../../../routes/registry/install');
+
+const getInstallHandler = () => {
+  const layer = installRouter.stack.find((entry) => (
+    entry.route && entry.route.path === '/install' && entry.route.methods.post
+  ));
+  if (!layer) throw new Error('Install route handler not found');
+  return layer.route.stack[layer.route.stack.length - 1].handle;
+};
+
+const buildLeanChain = (result) => ({ lean: jest.fn().mockResolvedValue(result) });
+const buildSelectLeanChain = (result) => ({
+  select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(result) }),
+});
+const makeRes = () => ({ status: jest.fn().mockReturnThis(), json: jest.fn() });
+
+const makeReq = (runtimeType, overrides = {}) => ({
+  body: {
+    agentName: 'my-agent',
+    podId: 'pod-1',
+    displayName: 'My agent',
+    config: { runtime: { runtimeType } },
+    scopes: [],
+  },
+  user: { id: 'user-1', username: 'installer' },
+  userId: 'user-1',
+  ...overrides,
+});
+
+describe('registry install — hosted runtime cap gate', () => {
+  const installHandler = getInstallHandler();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Pod.findById.mockReturnValue(buildLeanChain({
+      _id: 'pod-1', createdBy: 'user-1', members: ['user-1'], type: 'chat',
+    }));
+    AgentRegistry.getByName.mockResolvedValue(null); // no manifest → self-serve synth path
+    AgentRegistry.create.mockImplementation(async (doc) => ({
+      ...doc, latestVersion: '1.0.0', manifest: { ...doc.manifest, context: { required: [] } },
+    }));
+    AgentRegistry.incrementInstalls.mockResolvedValue({ acknowledged: true });
+    AgentInstallation.findOne.mockResolvedValue(null);
+    AgentInstallation.find.mockReturnValue(buildLeanChain([]));
+    AgentInstallation.install.mockImplementation(async (agentName, _podId, options) => ({
+      _id: { toString: () => 'install-1' },
+      agentName,
+      instanceId: options.instanceId || 'default',
+      displayName: options.displayName || 'Agent',
+      version: options.version,
+      status: 'active',
+      scopes: options.scopes || [],
+    }));
+    User.findOne.mockImplementation(() => buildSelectLeanChain(null));
+    User.findById.mockReturnValue(buildSelectLeanChain({ username: 'installer', role: 'user' }));
+    AgentProfile.findOneAndUpdate.mockResolvedValue(true);
+    Activity.create.mockResolvedValue(true);
+  });
+
+  it('synthesizes an ephemeral row for runtimeType hosted (no entitlement needed) when under cap', async () => {
+    mockCountHosted.mockResolvedValue(0);
+    const res = makeRes();
+    await installHandler(makeReq('hosted'), res);
+
+    expect(res.status).not.toHaveBeenCalledWith(403);
+    expect(res.status).not.toHaveBeenCalledWith(404);
+    expect(AgentRegistry.create).toHaveBeenCalledWith(expect.objectContaining({ agentName: 'my-agent', ephemeral: true }));
+    expect(mockCountHosted).toHaveBeenCalledWith('user-1');
+    expect(AgentInstallation.install).toHaveBeenCalledWith('my-agent', 'pod-1', expect.objectContaining({
+      config: expect.objectContaining({ runtime: expect.objectContaining({ runtimeType: 'hosted' }) }),
+    }));
+  });
+
+  it('403s hosted_cap_reached at the cap, before any row is written', async () => {
+    mockCountHosted.mockResolvedValue(1);
+    const res = makeRes();
+    await installHandler(makeReq('hosted'), res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'hosted_cap_reached', used: 1, cap: 1 }));
+    expect(AgentInstallation.install).not.toHaveBeenCalled();
+  });
+
+  it('lets an admin past the cap', async () => {
+    mockCountHosted.mockResolvedValue(5);
+    User.findById.mockReturnValue(buildSelectLeanChain({ username: 'admin', role: 'admin' }));
+    const res = makeRes();
+    await installHandler(makeReq('hosted'), res);
+
+    expect(res.status).not.toHaveBeenCalledWith(403);
+    expect(mockCountHosted).not.toHaveBeenCalled();
+    expect(AgentInstallation.install).toHaveBeenCalled();
+  });
+
+  it('still 404s an unknown agent whose runtimeType is neither webhook nor hosted', async () => {
+    const res = makeRes();
+    await installHandler(makeReq('claude-code'), res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(AgentRegistry.create).not.toHaveBeenCalled();
+    expect(mockCountHosted).not.toHaveBeenCalled();
+  });
+});

--- a/backend/__tests__/unit/services/hostedRuntimeService.test.js
+++ b/backend/__tests__/unit/services/hostedRuntimeService.test.js
@@ -1,0 +1,123 @@
+// ADR-023 W2 hosted runtime — kernel-side half: config, Map-vs-lean reads,
+// the two D3.1 caps, and the worker client (auth header, timeout, non-2xx).
+const mockInstallationCount = jest.fn();
+const mockEventCount = jest.fn();
+
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { countDocuments: (...args) => mockInstallationCount(...args) },
+}));
+jest.mock('../../../models/AgentEvent', () => ({
+  countDocuments: (...args) => mockEventCount(...args),
+}));
+
+const hosted = require('../../../services/hostedRuntimeService');
+
+const ENV_KEYS = ['HOSTED_RUNTIME_URL', 'HOSTED_RUNTIME_ADMIN_TOKEN', 'HOSTED_AGENTS_PER_USER', 'HOSTED_TURNS_PER_DAY'];
+
+describe('hostedRuntimeService', () => {
+  const saved = {};
+  beforeEach(() => {
+    ENV_KEYS.forEach((k) => { saved[k] = process.env[k]; delete process.env[k]; });
+    mockInstallationCount.mockReset();
+    mockEventCount.mockReset();
+    global.fetch = jest.fn();
+  });
+  afterEach(() => {
+    ENV_KEYS.forEach((k) => { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; });
+    delete global.fetch;
+  });
+
+  describe('configuration', () => {
+    it('is unconfigured unless both URL and admin token are present', () => {
+      expect(hosted.isConfigured()).toBe(false);
+      process.env.HOSTED_RUNTIME_URL = 'https://runtime.example';
+      expect(hosted.isConfigured()).toBe(false);
+      process.env.HOSTED_RUNTIME_ADMIN_TOKEN = 'secret';
+      expect(hosted.isConfigured()).toBe(true);
+    });
+
+    it('applies defaults and ignores garbage cap values', () => {
+      expect(hosted.hostedCaps()).toEqual({ agentsPerUser: 1, turnsPerDay: 200 });
+      process.env.HOSTED_AGENTS_PER_USER = '3';
+      process.env.HOSTED_TURNS_PER_DAY = 'lots';
+      expect(hosted.hostedCaps()).toEqual({ agentsPerUser: 3, turnsPerDay: 200 });
+    });
+  });
+
+  describe('readRuntimeConfig / isHostedInstallation', () => {
+    it('reads a hydrated Map config and a lean object config identically', () => {
+      const hydrated = { config: new Map([['runtime', { runtimeType: 'hosted' }]]) };
+      const lean = { config: { runtime: { runtimeType: 'HOSTED' } } };
+      expect(hosted.isHostedInstallation(hydrated)).toBe(true);
+      expect(hosted.isHostedInstallation(lean)).toBe(true);
+      expect(hosted.isHostedInstallation({ config: { runtime: { runtimeType: 'webhook' } } })).toBe(false);
+      expect(hosted.isHostedInstallation({ config: new Map() })).toBe(false);
+      expect(hosted.isHostedInstallation(null)).toBe(false);
+    });
+  });
+
+  describe('caps', () => {
+    it('counts active hosted installs by the path the install route writes', async () => {
+      mockInstallationCount.mockResolvedValue(2);
+      await expect(hosted.countHostedAgentsForUser('user-1')).resolves.toBe(2);
+      expect(mockInstallationCount).toHaveBeenCalledWith({
+        installedBy: 'user-1',
+        status: 'active',
+        'config.runtime.runtimeType': 'hosted',
+      });
+    });
+
+    it('meters acked events since the UTC day start and reports the reset', async () => {
+      process.env.HOSTED_TURNS_PER_DAY = '2';
+      mockEventCount.mockResolvedValue(1);
+      const meter = await hosted.meterAllowsTurn('Scout', 'default');
+      expect(meter).toMatchObject({ allowed: true, used: 1, cap: 2 });
+      const filter = mockEventCount.mock.calls[0][0];
+      expect(filter).toMatchObject({ agentName: 'scout', instanceId: 'default', status: 'acked' });
+      expect(filter.createdAt.$gte.toISOString()).toMatch(/T00:00:00\.000Z$/);
+      expect(new Date(meter.resetsAt).getTime() - filter.createdAt.$gte.getTime()).toBe(24 * 3600 * 1000);
+
+      mockEventCount.mockResolvedValue(2);
+      await expect(hosted.meterAllowsTurn('scout', 'default')).resolves.toMatchObject({ allowed: false, used: 2 });
+    });
+  });
+
+  describe('worker client', () => {
+    beforeEach(() => {
+      process.env.HOSTED_RUNTIME_URL = 'https://runtime.example/';
+      process.env.HOSTED_RUNTIME_ADMIN_TOKEN = 'admin-secret';
+    });
+
+    const okResponse = (body) => ({ ok: true, status: 200, text: async () => JSON.stringify(body) });
+
+    it('provisions with the admin bearer, a non-default UA, and the DO path', async () => {
+      global.fetch.mockResolvedValue(okResponse({ provisioned: true }));
+      await expect(hosted.provisionAgent({ agentName: 'scout', instanceId: 'default', runtimeToken: 'cm_agent_x' }))
+        .resolves.toEqual({ provisioned: true });
+      const [url, init] = global.fetch.mock.calls[0];
+      expect(url).toBe('https://runtime.example/agents/scout/default/provision');
+      expect(init.method).toBe('POST');
+      expect(init.headers.Authorization).toBe('Bearer admin-secret');
+      expect(init.headers['User-Agent']).toMatch(/^commonly-backend/);
+      expect(JSON.parse(init.body)).toEqual({ agentName: 'scout', instanceId: 'default', runtimeToken: 'cm_agent_x' });
+    });
+
+    it('throws 503 when unconfigured, 502 on non-2xx, 502 on network failure', async () => {
+      delete process.env.HOSTED_RUNTIME_ADMIN_TOKEN;
+      await expect(hosted.getAgentStatus('scout', 'default')).rejects.toMatchObject({ status: 503 });
+      expect(global.fetch).not.toHaveBeenCalled();
+
+      process.env.HOSTED_RUNTIME_ADMIN_TOKEN = 'admin-secret';
+      global.fetch.mockResolvedValue({ ok: false, status: 401, text: async () => JSON.stringify({ error: 'unauthorized' }) });
+      await expect(hosted.getAgentStatus('scout', 'default')).rejects.toMatchObject({ status: 502, message: expect.stringContaining('401') });
+
+      global.fetch.mockRejectedValue(new Error('ECONNREFUSED'));
+      await expect(hosted.deprovisionAgent('scout', 'default')).rejects.toMatchObject({ status: 502, message: expect.stringContaining('ECONNREFUSED') });
+    });
+
+    it('never leaks the admin token into the error message', async () => {
+      global.fetch.mockResolvedValue({ ok: false, status: 500, text: async () => 'boom' });
+      await expect(hosted.getAgentStatus('scout', 'default')).rejects.not.toMatchObject({ message: expect.stringContaining('admin-secret') });
+    });
+  });
+});

--- a/backend/__tests__/unit/services/hostedRuntimeService.test.js
+++ b/backend/__tests__/unit/services/hostedRuntimeService.test.js
@@ -67,15 +67,16 @@ describe('hostedRuntimeService', () => {
       });
     });
 
-    it('meters acked events since the UTC day start and reports the reset', async () => {
+    it('meters acked events by ACK time (deliveredAt) since the UTC day start and reports the reset', async () => {
       process.env.HOSTED_TURNS_PER_DAY = '2';
       mockEventCount.mockResolvedValue(1);
       const meter = await hosted.meterAllowsTurn('Scout', 'default');
       expect(meter).toMatchObject({ allowed: true, used: 1, cap: 2 });
       const filter = mockEventCount.mock.calls[0][0];
       expect(filter).toMatchObject({ agentName: 'scout', instanceId: 'default', status: 'acked' });
-      expect(filter.createdAt.$gte.toISOString()).toMatch(/T00:00:00\.000Z$/);
-      expect(new Date(meter.resetsAt).getTime() - filter.createdAt.$gte.getTime()).toBe(24 * 3600 * 1000);
+      expect(filter.createdAt).toBeUndefined();
+      expect(filter.deliveredAt.$gte.toISOString()).toMatch(/T00:00:00\.000Z$/);
+      expect(new Date(meter.resetsAt).getTime() - filter.deliveredAt.$gte.getTime()).toBe(24 * 3600 * 1000);
 
       mockEventCount.mockResolvedValue(2);
       await expect(hosted.meterAllowsTurn('scout', 'default')).resolves.toMatchObject({ allowed: false, used: 2 });

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -11,6 +11,7 @@ const express = require('express');
 const agentRuntimeAuth = require('../middleware/agentRuntimeAuth');
 const auth = require('../middleware/auth');
 const AgentEventService = require('../services/agentEventService');
+const HostedRuntimeMeter = require('../services/hostedRuntimeService');
 const AgentIdentityService = require('../services/agentIdentityService');
 const AgentMessageService = require('../services/agentMessageService');
 const AgentThreadService = require('../services/agentThreadService');
@@ -476,6 +477,16 @@ router.get('/events', agentRuntimeAuth, async (req: any, res: any) => {
     const fallbackPodId = podIds.length === 0 && installation?.podId
       ? installation.podId
       : undefined;
+
+    // Hosted-runtime meter (ADR-023 D3.1): once a hosted agent has used its
+    // daily turn budget the feed goes empty for it — the worker idles instead
+    // of spending. Events stay pending and deliver after the UTC reset.
+    if (installation && HostedRuntimeMeter.isHostedInstallation(installation)) {
+      const meter = await HostedRuntimeMeter.meterAllowsTurn(agentName, instanceId);
+      if (!meter.allowed) {
+        return res.json({ events: [], meter });
+      }
+    }
 
     const events = await AgentEventService.list({
       agentName,

--- a/backend/routes/hosted.ts
+++ b/backend/routes/hosted.ts
@@ -190,7 +190,9 @@ router.post('/provision', hostedRateLimit, auth, async (req: any, res: any) => {
 /**
  * POST /api/hosted/deprovision { agentName, instanceId? }
  * Stops the runtime. The installation and identity stay — ADR-001 §3 identity
- * continuity; re-provisioning finds the same memory and the same token.
+ * continuity; re-provisioning finds the same memory. The token does NOT
+ * survive: provision rotates on every call (Otto on #1355), so a
+ * re-provision mints fresh and orphans anything still holding the old one.
  */
 router.post('/deprovision', hostedRateLimit, auth, async (req: any, res: any) => {
   try {

--- a/backend/routes/hosted.ts
+++ b/backend/routes/hosted.ts
@@ -18,6 +18,7 @@ import { createHash } from 'crypto';
 
 const auth = require('../middleware/auth');
 const { AgentInstallation } = require('../models/AgentRegistry');
+const AgentCredential = require('../models/AgentCredential');
 const User = require('../models/User');
 const AgentIdentityService = require('../services/agentIdentityService');
 const hostedRuntime = require('../services/hostedRuntimeService');
@@ -144,12 +145,31 @@ router.post('/provision', hostedRateLimit, auth, async (req: any, res: any) => {
       return res.status(409).json({ code: 'identity_missing', message: 'Agent identity has not been created yet; reinstall the agent' });
     }
 
+    // ROTATE, never reuse (Otto on #1355). Two pollers on one token is the
+    // case D6 does not cover — both post before either acks, duplicates land
+    // in the pod, nothing errors. A fresh token turns an orphaned poller (a
+    // still-running CLI wrapper, a DO that was never deprovisioned) into a
+    // 401 it dies on, and self-heals the case where the old runtime is gone.
+    const staleHashes = (agentUser.agentRuntimeTokens || [])
+      .map((entry: any) => entry?.tokenHash)
+      .filter(Boolean);
+    if (staleHashes.length) {
+      await AgentCredential.updateMany(
+        { tokenHash: { $in: staleHashes }, status: 'active' },
+        { $set: { status: 'revoked', revokedAt: new Date() } },
+      );
+    }
+    agentUser.agentRuntimeTokens = [];
+    installation.runtimeTokens = [];
     const token = await issueRuntimeTokenForAgent(
       agentUser,
       'Hosted runtime',
       installation,
       { ownerUserId: userId },
     );
+    if (!token?.token) {
+      return res.status(500).json({ code: 'token_mint_failed', message: 'Runtime token rotation returned no token' });
+    }
     await hostedRuntime.provisionAgent({ agentName, instanceId, runtimeToken: token.token });
 
     installation.config.set('hosted', { provisionedAt: new Date() });

--- a/backend/routes/hosted.ts
+++ b/backend/routes/hosted.ts
@@ -102,6 +102,17 @@ const relayWorkerError = (res: express.Response, error: any) => {
 };
 
 /**
+ * GET /api/hosted/availability
+ * Whether this instance can host, plus the caps — so the BYO page offers
+ * "Run it here" only where it will work, instead of failing after install.
+ * Caps are public knowledge (the install gate quotes them); the URL and
+ * bearer are not returned.
+ */
+router.get('/availability', hostedRateLimit, auth, async (_req: any, res: any) => (
+  res.json({ configured: hostedRuntime.isConfigured(), caps: hostedRuntime.hostedCaps() })
+));
+
+/**
  * POST /api/hosted/provision { agentName, instanceId? }
  */
 router.post('/provision', hostedRateLimit, auth, async (req: any, res: any) => {

--- a/backend/routes/hosted.ts
+++ b/backend/routes/hosted.ts
@@ -1,0 +1,200 @@
+/**
+ * /api/hosted — the "Run it here" surface (ADR-023 W2).
+ *
+ * A user installs an agent with `config.runtime.runtimeType: 'hosted'` through
+ * the ordinary registry install (which is where the per-user agent cap is
+ * enforced), then calls POST /provision here. This route mints the agent's
+ * runtime token server-side and hands it to the hosted runtime with the
+ * operator's admin bearer — the browser never sees either secret, and the
+ * terminal step a stranger would otherwise hit simply is not there.
+ *
+ * Ownership is the sole-installer predicate: the caller must be the
+ * `installedBy` of an active installation for that identity. Admins get no
+ * bypass here; provisioning someone else's agent is not an ops action.
+ */
+import express from 'express';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import { createHash } from 'crypto';
+
+const auth = require('../middleware/auth');
+const { AgentInstallation } = require('../models/AgentRegistry');
+const User = require('../models/User');
+const AgentIdentityService = require('../services/agentIdentityService');
+const hostedRuntime = require('../services/hostedRuntimeService');
+const { issueRuntimeTokenForAgent } = require('./registry/tokens');
+
+const router = express.Router();
+
+const hostedRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req: { get?: (header: string) => string | undefined; ip?: string }) => {
+    const authHeader = req.get?.('authorization');
+    if (authHeader) {
+      return `tok:${createHash('sha256').update(authHeader).digest('hex').slice(0, 16)}`;
+    }
+    return req.ip ? ipKeyGenerator(req.ip) : 'anon';
+  },
+  handler: (_req: unknown, res: express.Response) => {
+    res.status(429).json({ message: 'rate limit exceeded: 30 hosted-runtime requests per 60s' });
+  },
+});
+
+const AGENT_NAME_RE = /^(@[a-z0-9-]+\/)?[a-z0-9-]+$/;
+const INSTANCE_RE = /^[a-z0-9-]+$/;
+
+const getUserId = (req: any) => req.userId || req.user?.id || req.user?._id;
+
+/**
+ * Resolve the identity the caller may act on. Returns the hydrated
+ * installation (the token path saves onto it) or an error tuple.
+ */
+const resolveOwnedHostedInstallation = async (req: any, source: Record<string, any>) => {
+  // Strip-via-replace is the shape CodeQL recognises as a sanitizer for the
+  // Mongoose filter below; the round-trip check keeps validation strict
+  // (a name that lost characters had invalid ones → 400, never a lookup of
+  // a different identity). Same pattern as registry/install.
+  const rawAgentName = String(source.agentName || '').toLowerCase();
+  const rawInstanceId = String(source.instanceId || 'default').toLowerCase();
+  const agentName = rawAgentName.replace(/[^a-z0-9@/-]/g, '');
+  const instanceId = rawInstanceId.replace(/[^a-z0-9-]/g, '');
+  if (!agentName || agentName !== rawAgentName || !AGENT_NAME_RE.test(agentName)) {
+    return { error: { status: 400, body: { code: 'invalid_agent_name', message: 'agentName must match /^(@[a-z0-9-]+\\/)?[a-z0-9-]+$/' } } };
+  }
+  if (!instanceId || instanceId !== rawInstanceId || !INSTANCE_RE.test(instanceId)) {
+    return { error: { status: 400, body: { code: 'invalid_instance_id', message: 'instanceId must match /^[a-z0-9-]+$/' } } };
+  }
+  const installation = await AgentInstallation.findOne({
+    agentName,
+    instanceId,
+    status: 'active',
+    installedBy: getUserId(req),
+  });
+  if (!installation) {
+    return { error: { status: 404, body: { code: 'not_owner_or_missing', message: 'No active installation of that agent is owned by you' } } };
+  }
+  if (!hostedRuntime.isHostedInstallation(installation)) {
+    return { error: { status: 409, body: { code: 'not_hosted', message: 'That agent was not installed with runtimeType "hosted"' } } };
+  }
+  return { installation, agentName, instanceId };
+};
+
+const requireConfigured = (res: express.Response): boolean => {
+  if (hostedRuntime.isConfigured()) return true;
+  res.status(503).json({
+    code: 'hosted_runtime_unconfigured',
+    message: 'Hosted runtime is not configured on this instance; connect your own agent instead.',
+  });
+  return false;
+};
+
+const relayWorkerError = (res: express.Response, error: any) => {
+  if (error instanceof hostedRuntime.HostedRuntimeError) {
+    return res.status(error.status).json({
+      code: error.status === 503 ? 'hosted_runtime_unconfigured' : 'hosted_runtime_unreachable',
+      message: error.message,
+    });
+  }
+  console.error('[hosted] unexpected error:', error);
+  return res.status(500).json({ message: 'Hosted runtime request failed' });
+};
+
+/**
+ * POST /api/hosted/provision { agentName, instanceId? }
+ */
+router.post('/provision', hostedRateLimit, auth, async (req: any, res: any) => {
+  try {
+    if (!requireConfigured(res)) return undefined;
+    const resolved = await resolveOwnedHostedInstallation(req, req.body || {});
+    if (resolved.error) return res.status(resolved.error.status).json(resolved.error.body);
+    const { installation, agentName, instanceId } = resolved;
+    const userId = getUserId(req);
+
+    // Defense in depth: the install route already refused the (N+1)th hosted
+    // install, but a cap lowered after the fact must still stop provisioning.
+    const { agentsPerUser } = hostedRuntime.hostedCaps();
+    const owned = await hostedRuntime.countHostedAgentsForUser(userId);
+    if (owned > agentsPerUser) {
+      return res.status(403).json({
+        code: 'hosted_cap_reached',
+        message: `Hosted agents are capped at ${agentsPerUser} per user in beta`,
+        used: owned,
+        cap: agentsPerUser,
+      });
+    }
+
+    const agentUser = await User.findOne({
+      username: AgentIdentityService.buildAgentUsername(agentName, instanceId),
+      isBot: true,
+    });
+    if (!agentUser) {
+      return res.status(409).json({ code: 'identity_missing', message: 'Agent identity has not been created yet; reinstall the agent' });
+    }
+
+    const token = await issueRuntimeTokenForAgent(
+      agentUser,
+      'Hosted runtime',
+      installation,
+      { ownerUserId: userId },
+    );
+    await hostedRuntime.provisionAgent({ agentName, instanceId, runtimeToken: token.token });
+
+    installation.config.set('hosted', { provisionedAt: new Date() });
+    await installation.save();
+
+    return res.json({
+      provisioned: true,
+      agentName,
+      instanceId,
+      podId: installation.podId,
+      caps: hostedRuntime.hostedCaps(),
+    });
+  } catch (error) {
+    return relayWorkerError(res, error);
+  }
+});
+
+/**
+ * POST /api/hosted/deprovision { agentName, instanceId? }
+ * Stops the runtime. The installation and identity stay — ADR-001 §3 identity
+ * continuity; re-provisioning finds the same memory and the same token.
+ */
+router.post('/deprovision', hostedRateLimit, auth, async (req: any, res: any) => {
+  try {
+    if (!requireConfigured(res)) return undefined;
+    const resolved = await resolveOwnedHostedInstallation(req, req.body || {});
+    if (resolved.error) return res.status(resolved.error.status).json(resolved.error.body);
+    const { installation, agentName, instanceId } = resolved;
+    await hostedRuntime.deprovisionAgent(agentName, instanceId);
+    installation.config.set('hosted', { provisionedAt: null, deprovisionedAt: new Date() });
+    await installation.save();
+    return res.json({ deprovisioned: true, agentName, instanceId });
+  } catch (error) {
+    return relayWorkerError(res, error);
+  }
+});
+
+/**
+ * GET /api/hosted/status?agentName=&instanceId=
+ * Runtime status plus today's meter, for the owner only.
+ */
+router.get('/status', hostedRateLimit, auth, async (req: any, res: any) => {
+  try {
+    if (!requireConfigured(res)) return undefined;
+    const resolved = await resolveOwnedHostedInstallation(req, req.query || {});
+    if (resolved.error) return res.status(resolved.error.status).json(resolved.error.body);
+    const { agentName, instanceId } = resolved;
+    const [runtime, meter] = await Promise.all([
+      hostedRuntime.getAgentStatus(agentName, instanceId),
+      hostedRuntime.meterAllowsTurn(agentName, instanceId),
+    ]);
+    return res.json({ agentName, instanceId, runtime, meter });
+  } catch (error) {
+    return relayWorkerError(res, error);
+  }
+});
+
+module.exports = router;
+export {};

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -13,6 +13,7 @@ const AgentIdentityService = require('../../services/agentIdentityService');
 const AgentMessageService = require('../../services/agentMessageService');
 const { deriveAgentState } = require('../../services/agentStateService');
 const FirstContactService = require('../../services/firstContactService');
+const HostedRuntime = require('../../services/hostedRuntimeService');
 const { normalizeAvatarUrl } = require('../../services/avatarService');
 const {
   getUserId,
@@ -182,7 +183,10 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
       const requestedRuntimeType = String(
         (config && config.runtime && (config.runtime as any).runtimeType) || '',
       ).toLowerCase();
-      if (requestedRuntimeType !== 'webhook') {
+      // Self-serve identities: BYO webhook (ADR-006) and Commonly-hosted
+      // (ADR-023). Both synthesize an ephemeral row; the hosted one is metered
+      // by the cap gate below rather than by entitlement.
+      if (requestedRuntimeType !== 'webhook' && requestedRuntimeType !== HostedRuntime.HOSTED_RUNTIME_TYPE) {
         return res.status(404).json({ error: 'Agent not found in registry' });
       }
       // ADR-006 §invariant 7 — self-serve is pod-scope only. The route
@@ -225,7 +229,7 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
         user: String(userId),
         pod: String(podId),
         agent: synthManifest.name,
-        runtime: 'webhook',
+        runtime: requestedRuntimeType,
       });
     }
 
@@ -377,6 +381,24 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
         return res.status(403).json({
           code: 'cloud_agents_not_entitled',
           message: 'Hosted (cloud) agents require entitlement; you can connect your own local/BYO agent instead.',
+        });
+      }
+    }
+
+    // Hosted runtime (ADR-023 D3.1): open to every authenticated user, metered
+    // instead of entitlement-gated. isCloudRuntime() deliberately does not
+    // classify 'hosted' as cloud — the gate above is for operator-run tiers
+    // (moltbot/codex/...), this one is the per-user beta cap. Admins bypass
+    // the cap the same way they bypass the entitlement.
+    if (effectiveRuntimeType === HostedRuntime.HOSTED_RUNTIME_TYPE && !isAdminInstaller) {
+      const { agentsPerUser } = HostedRuntime.hostedCaps();
+      const used = await HostedRuntime.countHostedAgentsForUser(userId);
+      if (used >= agentsPerUser) {
+        return res.status(403).json({
+          code: 'hosted_cap_reached',
+          message: `Hosted agents are capped at ${agentsPerUser} per user in beta; connect your own agent for more.`,
+          used,
+          cap: agentsPerUser,
         });
       }
     }

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -352,8 +352,16 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
     // route ever writes that field, it only ever arrives in caller config — so
     // webhook-typed WITHOUT a URL is a polling seat. Never overwrite an
     // explicit host; the CLI attach path already sets it correctly.
+    // Store runtimeType NORMALIZED. Every gate below lowercases its own copy;
+    // the stored value was whatever the caller sent, so `runtimeType: "Hosted"`
+    // passed the hosted gate, got metered as hosted, and was never counted by
+    // countHostedAgentsForUser (exact 'hosted') — the per-user cap failed open
+    // (Otto on #1355). Query the field the code writes: write it normalized.
+    if (runtimeConfig.runtimeType !== undefined && runtimeConfig.runtimeType !== null) {
+      runtimeConfig.runtimeType = String(runtimeConfig.runtimeType).trim().toLowerCase();
+    }
     if (!runtimeConfig.host
-      && String(runtimeConfig.runtimeType || '').toLowerCase() === 'webhook'
+      && runtimeConfig.runtimeType === 'webhook'
       && !runtimeConfig.webhookUrl) {
       runtimeConfig.host = 'byo';
     }

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -214,6 +214,7 @@ app.use('/api/registry', registryRoutes); // Agent Registry (package manager for
 app.use('/api/credentials', require('./routes/credentials')); // ADR-026 Phase 0: credential lineage + revocation
 app.use('/api/agent-binding', require('./routes/agentBinding')); // ADR-026 D3: machine adoption CAS
 app.use('/api/machines', require('./routes/machines')); // ADR-026 Phase 1: local daemon lifecycle
+app.use('/api/hosted', require('./routes/hosted')); // ADR-023 W2: hosted runtime provision surface (metered)
 app.use('/api/agents/runtime', agentsRuntimeRoutes); // Runtime endpoints for external agents
 app.use('/api/federation', federationRoutes); // Cross-pod federation
 app.use('/api/providers/moltbot', moltbotProviderRoutes); // Moltbot provider integration

--- a/backend/services/hostedRuntimeService.ts
+++ b/backend/services/hostedRuntimeService.ts
@@ -1,0 +1,205 @@
+/**
+ * Hosted runtime (ADR-023 W2) — the kernel-side half of "Run it here".
+ *
+ * The runtime itself is `workers/agent-runtime` (one Durable Object per
+ * agent, polling CAP with a runtime token). This service is the only place
+ * the backend talks to it, and the only place hosted METERING lives. ADR-023
+ * D3.1 is explicit that a per-user provision surface ships together with
+ * metering; the two caps below are that floor — not billing, the thing that
+ * makes an unmetered public runtime safe to expose:
+ *
+ *   HOSTED_AGENTS_PER_USER  active hosted installations per owner (default 1)
+ *   HOSTED_TURNS_PER_DAY    acked events per hosted agent per UTC day (200)
+ *
+ * A "turn" is counted as an acked AgentEvent for the agent — the kernel sees
+ * deliveries, not model calls, and one delivered event is one worker turn.
+ * When the daily cap is reached the events feed returns empty for that agent
+ * (see agentsRuntime GET /events), so the worker idles rather than spends.
+ *
+ * Configuration: HOSTED_RUNTIME_URL + HOSTED_RUNTIME_ADMIN_TOKEN. Unset means
+ * the surface reports 503 `hosted_runtime_unconfigured` — never a silent
+ * fallback to a different runtime.
+ */
+import { AgentInstallation } from '../models/AgentRegistry';
+import AgentEvent from '../models/AgentEvent';
+
+export const HOSTED_RUNTIME_TYPE = 'hosted';
+
+const DEFAULT_AGENTS_PER_USER = 1;
+const DEFAULT_TURNS_PER_DAY = 200;
+const WORKER_TIMEOUT_MS = 10_000;
+
+const intEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+};
+
+export const hostedCaps = () => ({
+  agentsPerUser: intEnv('HOSTED_AGENTS_PER_USER', DEFAULT_AGENTS_PER_USER),
+  turnsPerDay: intEnv('HOSTED_TURNS_PER_DAY', DEFAULT_TURNS_PER_DAY),
+});
+
+export const hostedRuntimeConfig = () => ({
+  url: String(process.env.HOSTED_RUNTIME_URL || '').trim().replace(/\/+$/, ''),
+  adminToken: String(process.env.HOSTED_RUNTIME_ADMIN_TOKEN || '').trim(),
+});
+
+export const isConfigured = (): boolean => {
+  const { url, adminToken } = hostedRuntimeConfig();
+  return Boolean(url && adminToken);
+};
+
+/**
+ * `AgentInstallation.config` is a Mongoose Map of Mixed, so the runtime block
+ * is reached with `.get('runtime')` on a hydrated doc and as a plain property
+ * on a `.lean()` row. Accept both — every caller that forgot the Map shape so
+ * far read `undefined` and reported success (see the Map-vs-object memory).
+ */
+export const readRuntimeConfig = (installation: any): Record<string, any> => {
+  const config = installation?.config;
+  if (!config) return {};
+  const runtime = typeof config.get === 'function' ? config.get('runtime') : config.runtime;
+  return runtime && typeof runtime === 'object' ? runtime : {};
+};
+
+export const isHostedInstallation = (installation: any): boolean => (
+  String(readRuntimeConfig(installation).runtimeType || '').trim().toLowerCase() === HOSTED_RUNTIME_TYPE
+);
+
+/** Active hosted installations owned by a user. Same path the install route writes. */
+export const countHostedAgentsForUser = async (userId: any): Promise<number> => (
+  AgentInstallation.countDocuments({
+    installedBy: userId,
+    status: 'active',
+    'config.runtime.runtimeType': HOSTED_RUNTIME_TYPE,
+  })
+);
+
+const utcDayStart = (now = new Date()): Date => new Date(Date.UTC(
+  now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(),
+));
+
+export const turnsToday = async (agentName: string, instanceId: string): Promise<number> => (
+  AgentEvent.countDocuments({
+    agentName: String(agentName).toLowerCase(),
+    instanceId: instanceId || 'default',
+    status: 'acked',
+    createdAt: { $gte: utcDayStart() },
+  })
+);
+
+export interface MeterResult {
+  allowed: boolean;
+  used: number;
+  cap: number;
+  resetsAt: string;
+}
+
+export const meterAllowsTurn = async (agentName: string, instanceId: string): Promise<MeterResult> => {
+  const { turnsPerDay } = hostedCaps();
+  const used = await turnsToday(agentName, instanceId);
+  const tomorrow = new Date(utcDayStart().getTime() + 24 * 60 * 60 * 1000);
+  return {
+    allowed: used < turnsPerDay,
+    used,
+    cap: turnsPerDay,
+    resetsAt: tomorrow.toISOString(),
+  };
+};
+
+export class HostedRuntimeError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'HostedRuntimeError';
+    this.status = status;
+  }
+}
+
+const workerRequest = async (
+  path: string,
+  init: { method: 'GET' | 'POST'; body?: Record<string, unknown> },
+): Promise<any> => {
+  const { url, adminToken } = hostedRuntimeConfig();
+  if (!url || !adminToken) {
+    throw new HostedRuntimeError('Hosted runtime is not configured', 503);
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), WORKER_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(`${url}${path}`, {
+      method: init.method,
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'commonly-backend/hosted-runtime',
+      },
+      body: init.body ? JSON.stringify(init.body) : undefined,
+      signal: controller.signal,
+    });
+  } catch (error: any) {
+    throw new HostedRuntimeError(
+      `Hosted runtime unreachable: ${error?.name === 'AbortError' ? 'timeout' : error?.message}`,
+      502,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+  const text = await response.text();
+  let data: any = null;
+  try { data = text ? JSON.parse(text) : null; } catch { data = { raw: text }; }
+  if (!response.ok) {
+    throw new HostedRuntimeError(
+      `Hosted runtime responded ${response.status}: ${data?.error || text || 'no body'}`,
+      502,
+    );
+  }
+  return data;
+};
+
+const agentPath = (agentName: string, instanceId: string, tail: string) => (
+  `/agents/${encodeURIComponent(agentName)}/${encodeURIComponent(instanceId || 'default')}/${tail}`
+);
+
+export const provisionAgent = async (params: {
+  agentName: string;
+  instanceId: string;
+  runtimeToken: string;
+  pollSeconds?: number;
+}): Promise<any> => workerRequest(agentPath(params.agentName, params.instanceId, 'provision'), {
+  method: 'POST',
+  body: {
+    agentName: params.agentName,
+    instanceId: params.instanceId || 'default',
+    runtimeToken: params.runtimeToken,
+    ...(params.pollSeconds ? { pollSeconds: params.pollSeconds } : {}),
+  },
+});
+
+export const deprovisionAgent = async (agentName: string, instanceId: string): Promise<any> => (
+  workerRequest(agentPath(agentName, instanceId, 'deprovision'), { method: 'POST' })
+);
+
+export const getAgentStatus = async (agentName: string, instanceId: string): Promise<any> => (
+  workerRequest(agentPath(agentName, instanceId, 'status'), { method: 'GET' })
+);
+
+module.exports = {
+  HOSTED_RUNTIME_TYPE,
+  hostedCaps,
+  hostedRuntimeConfig,
+  isConfigured,
+  readRuntimeConfig,
+  isHostedInstallation,
+  countHostedAgentsForUser,
+  turnsToday,
+  meterAllowsTurn,
+  HostedRuntimeError,
+  provisionAgent,
+  deprovisionAgent,
+  getAgentStatus,
+};

--- a/backend/services/hostedRuntimeService.ts
+++ b/backend/services/hostedRuntimeService.ts
@@ -11,10 +11,17 @@
  *   HOSTED_AGENTS_PER_USER  active hosted installations per owner (default 1)
  *   HOSTED_TURNS_PER_DAY    acked events per hosted agent per UTC day (200)
  *
- * A "turn" is counted as an acked AgentEvent for the agent — the kernel sees
- * deliveries, not model calls, and one delivered event is one worker turn.
+ * The daily cap is a RATE LIMIT ON REQUESTS, not a spend meter: it counts
+ * acked AgentEvents by ack time (`deliveredAt`, which ack() stamps). One
+ * acked event is up to the worker's tool budget in model calls, and a turn
+ * that fails every retry is never acked — metered zero. Good enough as the
+ * D3.1 beta floor; charging against credits needs the worker's own counts.
+ * Counting by ack time rather than createdAt matters at the UTC boundary:
+ * an event created 23:59 and acked 00:01 must land in today's bucket, or
+ * anything queued across midnight is free (Otto on #1355).
  * When the daily cap is reached the events feed returns empty for that agent
- * (see agentsRuntime GET /events), so the worker idles rather than spends.
+ * BEFORE list() claims anything (see agentsRuntime GET /events), so capped
+ * events stay pending and un-attempted; GC only touches 'delivered' rows.
  *
  * Configuration: HOSTED_RUNTIME_URL + HOSTED_RUNTIME_ADMIN_TOKEN. Unset means
  * the surface reports 503 `hosted_runtime_unconfigured` — never a silent
@@ -86,7 +93,7 @@ export const turnsToday = async (agentName: string, instanceId: string): Promise
     agentName: String(agentName).toLowerCase(),
     instanceId: instanceId || 'default',
     status: 'acked',
-    createdAt: { $gte: utcDayStart() },
+    deliveredAt: { $gte: utcDayStart() },
   })
 );
 

--- a/docs/adr/ADR-023-agent-runtime-substrate.md
+++ b/docs/adr/ADR-023-agent-runtime-substrate.md
@@ -65,7 +65,7 @@ That tension is the real reason the substrate matters, and it is not "GKE is exp
 
 Two obligations follow, and they are conditions of accepting this ADR rather than notes:
 
-1. **Pricing ships with hosted agents, not after them.** Free-during-beta on credits is coherent only if something charges before the term ends. An ADR section on metering belongs in the W2 work, not in a later document.
+1. **Pricing ships with hosted agents, not after them.** *Status 2026-08-30: the metering floor shipped with the self-serve surface (`/api/hosted`; per-user agent cap + per-agent daily turn cap enforced in the kernel, see `docs/runbooks/hosted-agent-provisioning.md`). Charging against credits remains open.* Free-during-beta on credits is coherent only if something charges before the term ends. An ADR section on metering belongs in the W2 work, not in a later document.
 2. **Spend credits toward a returning user, not toward completeness.** The credits reward using Cloudflare; they do not reward using it for everything. Rebuilding what already works consumes the term without moving the number that ends the company.
 
 **Unchanged from the earlier draft: the moat is not Cloudflare.** It is portable agent identity, memory, and the social graph — CAP. Cloudflare hosts that; it does not create it. DO economics may become a genuine cost advantage at scale, but that is a late-game edge, and YC declined this on wedge.

--- a/docs/runbooks/hosted-agent-provisioning.md
+++ b/docs/runbooks/hosted-agent-provisioning.md
@@ -1,20 +1,51 @@
 # Runbook: provisioning a hosted agent (ADR-023 W2)
 
-Operator-invoked until metering lands (ADR-023 D3.1). Everything below is a
-five-minute operation once a model key exists; nothing here touches the
-kernel — the hosted runtime speaks the same four CAP verbs a BYO wrapper does.
+Two paths. **Self-serve** (`/api/hosted`, metered — ADR-023 D3.1) is what a
+user reaches from the product; **operator-invoked** (direct worker calls) is
+the escape hatch and the smoke path. Nothing here touches the kernel — the
+hosted runtime speaks the same four CAP verbs a BYO wrapper does.
 
 ## One-time: deploy the worker
 
     cd workers/agent-runtime
     npm ci
     npx wrangler secret put RUNTIME_ADMIN_TOKEN     # operator-chosen, gates every route
-    npx wrangler secret put ANTHROPIC_API_KEY       # BYOK; never in config or chat
-    npx wrangler deploy                             # → https://commonly-agent-runtime.<account>.workers.dev
+    npx wrangler secret put DEEPSEEK_API_KEY        # provider key; never in config or chat
+    npx wrangler deploy --var MODEL_PROVIDER:deepseek   # → https://commonly-agent-runtime.<account>.workers.dev
 
-Optional: `MODEL_ID` var (defaults to `claude-sonnet-5` in `turn.ts`).
+`MODEL_PROVIDER` is `deepseek` (decision 2026-08-29) or `anthropic` (then
+`ANTHROPIC_API_KEY`). Optional `MODEL_ID` overrides the provider default in
+`turn.ts` (`deepseek-v4-flash` / `claude-sonnet-5`).
 
-## Per agent
+Then point the backend at it — `backend.env.hostedRuntimeUrl` in the Helm
+values, and the admin bearer as GCP SM secret
+`commonly-dev-hosted-runtime-admin-token` (its own ExternalSecret,
+`hosted-runtime`, rendered only when the URL is set). Until both exist the
+self-serve surface answers `503 hosted_runtime_unconfigured` — it never falls
+back to another runtime.
+
+## Self-serve (what a user does)
+
+1. Install with `POST /api/registry/install` and
+   `config.runtime.runtimeType: 'hosted'` (the BYO page's "Run it here").
+   No entitlement — the install gate enforces `HOSTED_AGENTS_PER_USER`
+   (default 1; admins bypass) and answers `403 hosted_cap_reached`.
+2. `POST /api/hosted/provision { agentName, instanceId? }` — the backend mints
+   the runtime token itself (credential ledger, owner lineage) and calls the
+   worker with the admin bearer. Neither secret reaches the browser. Owner
+   only: the caller must be `installedBy` of the active installation
+   (`404 not_owner_or_missing`, `409 not_hosted`).
+3. `GET /api/hosted/status?agentName=` — worker status plus today's meter
+   `{ used, cap, resetsAt }`; `POST /api/hosted/deprovision` stops it,
+   installation and identity stay.
+
+Metering: `HOSTED_TURNS_PER_DAY` (default 200) counts acked events per agent
+per UTC day; at the cap `GET /api/agents/runtime/events` returns
+`{ events: [], meter }` for that agent so the worker idles — events stay
+pending and deliver after the reset. Both caps are env-overridable through
+`backend.env.hostedAgentsPerUser` / `hostedTurnsPerDay`.
+
+## Operator-invoked (escape hatch / smoke)
 
 1. Register the identity + installation as for any BYO agent (Agents → BYO,
    or `POST /api/registry/install` with `runtimeType: 'webhook'`) and mint
@@ -37,7 +68,7 @@ Optional: `MODEL_ID` var (defaults to `claude-sonnet-5` in `turn.ts`).
 | `lastError` | meaning |
 |---|---|
 | `listEvents 401` | runtime token invalid/revoked (or the fake one from a smoke) |
-| `ANTHROPIC_API_KEY unset` | secret missing — the event stays unacked, nothing is silently eaten |
+| `DEEPSEEK_API_KEY unset` (or `ANTHROPIC_API_KEY`) | provider secret missing — the event stays unacked, nothing is silently eaten |
 | `turn ended without assistant text` / `model exceeded tool budget` | model failure or runaway; event unacked, redelivered ≤3× by the kernel |
 | `model unavailable: anthropic/<id>` | `MODEL_ID` not in pi-ai's Anthropic catalog |
 
@@ -51,7 +82,7 @@ untouched (rule 8).
 
 ## Known boundaries (tracked)
 
-- Metering: none yet — provision stays operator-invoked (#D3.1).
+- Metering is the D3.1 floor (per-user agent cap + daily turn cap), not billing; credits/charging is still open.
 - A `postMessage` failure after a successful turn re-runs the model on
   redelivery (#1344).
 - Real compaction (pi Session layer) not yet wired; transcripts are

--- a/k8s/helm/commonly/templates/core/backend-deployment.yaml
+++ b/k8s/helm/commonly/templates/core/backend-deployment.yaml
@@ -150,6 +150,24 @@ spec:
         - name: COMMUNITY_POD_ID
           value: {{ .Values.backend.env.communityPodId | quote }}
         {{- end }}
+        {{- if .Values.backend.env.hostedRuntimeUrl }}
+        - name: HOSTED_RUNTIME_URL
+          value: {{ .Values.backend.env.hostedRuntimeUrl | quote }}
+        - name: HOSTED_RUNTIME_ADMIN_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hosted-runtime
+              key: HOSTED_RUNTIME_ADMIN_TOKEN
+              optional: true
+        {{- end }}
+        {{- if .Values.backend.env.hostedAgentsPerUser }}
+        - name: HOSTED_AGENTS_PER_USER
+          value: {{ .Values.backend.env.hostedAgentsPerUser | quote }}
+        {{- end }}
+        {{- if .Values.backend.env.hostedTurnsPerDay }}
+        - name: HOSTED_TURNS_PER_DAY
+          value: {{ .Values.backend.env.hostedTurnsPerDay | quote }}
+        {{- end }}
         {{- if .Values.backend.env.retentionExemptPodIds }}
         # Pods the 30-day PG message-retention cron must never touch —
         # publicly-linked rooms (showcase, community HQ) whose history IS the

--- a/k8s/helm/commonly/templates/secrets/hosted-runtime.yaml
+++ b/k8s/helm/commonly/templates/secrets/hosted-runtime.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.externalSecrets.enabled .Values.backend.env.hostedRuntimeUrl }}
+# ADR-023 W2 hosted runtime admin bearer. Its own ExternalSecret, deliberately
+# not a key inside api-keys: a remoteRef that does not exist yet fails the
+# whole ExternalSecret it belongs to, and api-keys carries every other
+# credential. Rendered only once the runtime URL is configured, so an
+# unconfigured instance never carries a failing object.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hosted-runtime
+  namespace: {{ include "commonly.namespace" . }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStore.name }}
+    kind: SecretStore
+  target:
+    name: hosted-runtime
+    creationPolicy: Owner
+  data:
+  - secretKey: HOSTED_RUNTIME_ADMIN_TOKEN
+    remoteRef:
+      key: commonly-dev-hosted-runtime-admin-token
+{{- end }}

--- a/k8s/helm/commonly/values.yaml
+++ b/k8s/helm/commonly/values.yaml
@@ -95,6 +95,13 @@ backend:
     # Empty = derive from the request host (fine when the API has one host).
     oauthCallbackBaseUrl: ""
     commonlyApiUrl: ""
+    # ADR-023 W2 hosted runtime (workers/agent-runtime). Empty = surface
+    # reports 503 hosted_runtime_unconfigured. The admin bearer comes from the
+    # `hosted-runtime` secret (ExternalSecret, own object so a missing remote
+    # key never stalls api-keys). Caps are the D3.1 metering floor.
+    hostedRuntimeUrl: ""
+    hostedAgentsPerUser: ""
+    hostedTurnsPerDay: ""
     clawdbotGatewayUrl: ""
     moltbotGatewayUrl: ""
     pgHost: "YOUR_PG_HOST"


### PR DESCRIPTION
## What
The hosted runtime replied, remembered, and used tools — but only when the operator provisioned it by hand. This is the product path, shipped **with** the metering ADR-023 D3.1 requires.

- `POST /api/hosted/provision` — mints the runtime token server-side and hands it to the worker with the admin bearer. Neither secret reaches the browser. Owner-only (sole-installer). `/deprovision` keeps identity (rule 8). `/status` = worker status + today's meter.
- Registry install accepts `runtimeType: 'hosted'` on the self-serve synth path: open to every authenticated user, **metered instead of entitlement-gated** — `HOSTED_AGENTS_PER_USER` (default 1, admin bypass) → `403 hosted_cap_reached`.
- `HOSTED_TURNS_PER_DAY` (default 200; acked events per agent per UTC day). At the cap `GET /api/agents/runtime/events` returns `{ events: [], meter }` for that agent so the worker idles; events stay pending and deliver after the reset.
- Unconfigured → `503 hosted_runtime_unconfigured`, never a silent fallback.
- Helm: env plumbing + a separate `hosted-runtime` ExternalSecret (own object, so a not-yet-created remote key can't stall `api-keys`), rendered only when the URL is set.

## Proof
- 31/31 across the three new suites + the adjacent gate/runtime-type/dm-events suites on Node 20.
- `helm template` verified with the URL unset (no hosted env/objects) and set (env, secretKeyRef, ExternalSecret).
- `tsc:check` clean; `eslint --ext .ts` on touched files: 0 errors.

## Not in this PR
- The "Run it here" button on the BYO page (next PR, wires the two calls).
- Charging against credits — the caps are the safety floor, not billing.
- The worker deploy itself is operator-side (`wrangler deploy` + secrets), then `backend.env.hostedRuntimeUrl` + the SM secret.

Review: Otto gates W2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJ1bDdDQwWekHDqweiBhRN
