### PR TITLE
feat(byo): "Run it here" — zero-terminal path on the BYO page (ADR-023 W2)

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1287,7 +1287,9 @@
       "copy": "Copy",
       "copied": "Copied!",
       "goToPod": "Go to your pod",
-      "installAnother": "Install another"
+      "installAnother": "Install another",
+      "runHere": "Run it here",
+      "starting": "Starting…"
     },
     "footnote": {
       "preferCli": "Prefer the CLI?",
@@ -1325,7 +1327,9 @@
       "tokenEmpty": "Install succeeded but token issuance returned empty. Retry, or contact ops.",
       "installFailed": "Install failed.",
       "fileTooLarge": "That file is over the 256KB import ceiling — trim it or paste the relevant part.",
-      "importFailed": "Import failed."
+      "importFailed": "Import failed.",
+      "hostedCap": "You already have a hosted agent (beta allows {{cap}}). Connect your own runtime for more.",
+      "hostedUnavailable": "Hosting isn't available on this instance yet. Connect your own runtime instead."
     },
     "listen": {
       "title": "One more step, or it can't answer you",
@@ -1335,6 +1339,21 @@
       "verified": "✓ {{name}} is listening — mentions will wake it.",
       "stillWaiting": "Still no check-in from {{name}}. Run the command above on the machine where your agent lives, then this page will confirm it.",
       "ctaWarning": "{{name}} isn't listening yet — mentions won't get answers until the wrapper above is running."
+    },
+    "mode": {
+      "label": "How it runs",
+      "hosted": "Run it here",
+      "hostedHint": "Commonly runs it for you. Nothing to install. Beta: {{turns}} turns a day.",
+      "byo": "Bring your own runtime",
+      "byoHint": "Connect Claude Code, Cursor, or Codex from your machine."
+    },
+    "hosted": {
+      "heading": "Running:",
+      "live": "{{name}} is live in {{pod}}. Mention it there and it answers.",
+      "starting": "Starting {{name}}…",
+      "running": "✓ {{name}} is listening.",
+      "slow": "{{name}} hasn't checked in yet. Mention it anyway; it picks up messages when it starts.",
+      "meter": "Beta limits: {{turns}} turns a day, one hosted agent per account."
     }
   },
   "agentProfile": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1281,7 +1281,9 @@
       "copy": "复制",
       "copied": "已复制！",
       "goToPod": "前往你的 Pod",
-      "installAnother": "再安装一个"
+      "installAnother": "再安装一个",
+      "runHere": "在这里运行",
+      "starting": "正在启动…"
     },
     "footnote": {
       "preferCli": "更喜欢用 CLI？",
@@ -1319,7 +1321,9 @@
       "tokenEmpty": "安装成功，但令牌签发返回为空。请重试，或联系运维。",
       "installFailed": "安装失败。",
       "fileTooLarge": "该文件超过 256KB 的导入上限——请精简，或只粘贴相关部分。",
-      "importFailed": "导入失败。"
+      "importFailed": "导入失败。",
+      "hostedCap": "你已有一个托管智能体（测试期允许 {{cap}} 个）。如需更多，请自带运行时。",
+      "hostedUnavailable": "此实例暂未开放托管。请改用自带运行时。"
     },
     "listen": {
       "title": "还差一步，否则它无法回复你",
@@ -1329,6 +1333,21 @@
       "verified": "✓ {{name}} 已在监听 —— @提及 会唤醒它。",
       "stillWaiting": "仍未收到 {{name}} 的接入信号。请在 agent 所在的机器上运行上面的命令，本页会自动确认。",
       "ctaWarning": "{{name}} 还没有在监听 —— 在上面的命令运行起来之前，@提及 不会得到回复。"
+    },
+    "mode": {
+      "label": "运行方式",
+      "hosted": "在这里运行",
+      "hostedHint": "由 Commonly 代为运行，无需安装。测试期：每天 {{turns}} 轮。",
+      "byo": "自带运行时",
+      "byoHint": "从你的电脑连接 Claude Code、Cursor 或 Codex。"
+    },
+    "hosted": {
+      "heading": "运行中：",
+      "live": "{{name}} 已在 {{pod}} 上线。在那里 @ 它即可得到回复。",
+      "starting": "正在启动 {{name}}…",
+      "running": "✓ {{name}} 已在监听。",
+      "slow": "{{name}} 尚未签到。可以先 @ 它，启动后会处理消息。",
+      "meter": "测试期限制：每天 {{turns}} 轮，每个账号一个托管智能体。"
     }
   },
   "agentProfile": {

--- a/frontend/src/v2/__tests__/V2AgentBYOHosted.test.tsx
+++ b/frontend/src/v2/__tests__/V2AgentBYOHosted.test.tsx
@@ -1,0 +1,131 @@
+// @ts-nocheck
+// ADR-023 W2 "Run it here" on the BYO page. The instance reports whether it
+// can host; when it can, the page defaults to the hosted path, installs with
+// runtimeType 'hosted', asks the kernel to provision, and never renders a
+// token. When it cannot, the page is exactly the BYO page it was.
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2AgentBYO from '../components/V2AgentBYO';
+import { AuthContext } from '../../context/AuthContext';
+
+jest.mock('axios', () => {
+  const mock = {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  };
+  return { __esModule: true, default: mock, ...mock };
+});
+
+const axios = jest.requireMock('axios').default;
+
+const authValue = {
+  currentUser: { _id: 'u1', username: 'sam' },
+  user: { _id: 'u1', username: 'sam' },
+  token: 'user-jwt',
+  loading: false,
+  error: null,
+  isAuthenticated: true,
+  register: jest.fn(),
+  login: jest.fn(),
+  logout: jest.fn(),
+  updateProfile: jest.fn(),
+};
+
+const pods = [{ _id: 'p1', name: 'Workspace', type: 'chat', createdBy: { _id: 'u1' } }];
+
+const mockGet = ({ configured, status }) => {
+  axios.get.mockImplementation((url) => {
+    if (url.startsWith('/api/hosted/availability')) {
+      return Promise.resolve({ data: { configured, caps: { agentsPerUser: 1, turnsPerDay: 200 } } });
+    }
+    if (url.startsWith('/api/hosted/status')) return Promise.resolve({ data: status || { runtime: {} } });
+    if (url === '/api/pods') return Promise.resolve({ data: pods });
+    return Promise.resolve({ data: {} });
+  });
+};
+
+const renderPage = () => render(
+  <AuthContext.Provider value={authValue}>
+    <MemoryRouter>
+      <V2AgentBYO />
+    </MemoryRouter>
+  </AuthContext.Provider>,
+);
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+describe('V2AgentBYO — Run it here', () => {
+  test('defaults to hosted when available: install hosted → provision → live screen, no token shown', async () => {
+    mockGet({ configured: true, status: { runtime: { lastPollAt: 1 } } });
+    axios.post.mockResolvedValue({ data: { ok: true } });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId('byo-mode-hosted')).toHaveAttribute('aria-pressed', 'true'));
+    expect(screen.getByText(/beta: 200 turns a day/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^run it here$/i }));
+
+    await screen.findByTestId('byo-hosted-result');
+    const installCall = axios.post.mock.calls.find(([url]) => url === '/api/registry/install');
+    expect(installCall[1]).toMatchObject({ agentName: 'sam-agent', podId: 'p1', config: { runtime: { runtimeType: 'hosted' } } });
+    expect(axios.post).toHaveBeenCalledWith('/api/hosted/provision', { agentName: 'sam-agent' }, expect.anything());
+    expect(axios.post.mock.calls.some(([url]) => /runtime-tokens/.test(url))).toBe(false);
+    expect(screen.queryByText(/cm_agent/)).not.toBeInTheDocument();
+    expect(screen.getByText(/sam-agent is live in Workspace/i)).toBeInTheDocument();
+  });
+
+  test('flips from starting to listening once the runtime reports a poll', async () => {
+    jest.useFakeTimers();
+    mockGet({ configured: true, status: { runtime: { lastPollAt: null } } });
+    axios.post.mockResolvedValue({ data: { ok: true } });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('byo-mode-hosted')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /^run it here$/i }));
+    await screen.findByTestId('byo-hosted-starting');
+
+    await act(async () => { jest.advanceTimersByTime(4000); });
+    expect(screen.getByTestId('byo-hosted-starting')).toBeInTheDocument();
+
+    mockGet({ configured: true, status: { runtime: { lastPollAt: 123 } } });
+    await act(async () => { jest.advanceTimersByTime(4000); });
+    expect(screen.getByTestId('byo-hosted-running')).toBeInTheDocument();
+  });
+
+  test('surfaces the beta cap from the install gate instead of a generic failure', async () => {
+    mockGet({ configured: true });
+    axios.post.mockImplementation((url) => {
+      if (url === '/api/registry/install') {
+        return Promise.reject({ response: { data: { code: 'hosted_cap_reached', used: 1, cap: 1 } } });
+      }
+      return Promise.resolve({ data: { ok: true } });
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('byo-mode-hosted')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /^run it here$/i }));
+    await screen.findByText(/already have a hosted agent \(beta allows 1\)/i);
+    expect(axios.post.mock.calls.some(([url]) => url === '/api/hosted/provision')).toBe(false);
+  });
+
+  test('without hosting the page is the BYO page: no mode picker, webhook install', async () => {
+    mockGet({ configured: false });
+    axios.post
+      .mockResolvedValueOnce({ data: { ok: true } })
+      .mockResolvedValueOnce({ data: { token: 'cm_agent_test_token' } });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Workspace (chat)')).toBeInTheDocument());
+    expect(screen.queryByTestId('byo-mode-hosted')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /install \+ generate token/i }));
+    await screen.findByText(/token issued for/i);
+    expect(axios.post.mock.calls[0][1]).toMatchObject({ config: { runtime: { runtimeType: 'webhook' } } });
+  });
+});

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -35,6 +35,13 @@ const DEFAULT_POD_TYPE = 'chat';
 const CLI_INSTALL_COMMAND = 'npm i -g @commonlyai/cli@latest';
 const CLI_INIT_COMMAND = 'commonly agent init --name <n> --pod <podId>';
 const MEMORY_FILE_NAME = 'MEMORY.md';
+const HOSTED_STATUS_POLL_MS = 4000;
+const HOSTED_STATUS_MAX_TICKS = 15;
+
+type HostedAvailability = {
+  configured: boolean;
+  caps: { agentsPerUser: number; turnsPerDay: number };
+};
 const CLAUDE_FILE_NAME = 'CLAUDE.md';
 
 const sanitizeAgentName = (raw: string): string => raw
@@ -85,10 +92,53 @@ const V2AgentBYO: React.FC = () => {
   // finish the page, mention the agent, and get silence with no way to know
   // which step they missed. 'waiting' → 'listening' | 'timeout'.
   const [listenState, setListenState] = useState<'waiting' | 'listening' | 'timeout'>('waiting');
+  // ADR-023 W2 "Run it here" — the zero-terminal path. Offered only when the
+  // instance reports a configured hosted runtime, and the default there: the
+  // stranger this page exists for has no runtime to bring. The kernel mints
+  // the token and hands it to the runtime server-side; nothing secret is
+  // ever rendered on this screen.
+  const [hosting, setHosting] = useState<HostedAvailability | null>(null);
+  const [mode, setMode] = useState<'hosted' | 'byo'>('byo');
+  const [hosted, setHosted] = useState<{ agentName: string; podId: string } | null>(null);
+  const [hostedState, setHostedState] = useState<'starting' | 'running' | 'slow'>('starting');
+
+  // Same shape as the listening check below, against the runtime's own
+  // status: the DO reports lastPollAt once its alarm loop has run. ~60s cap,
+  // then honest copy — the agent still picks messages up when it starts.
+  useEffect(() => {
+    if (!hosted) return undefined;
+    let cancelled = false;
+    let ticks = 0;
+    setHostedState('starting');
+    const timer = setInterval(async () => {
+      ticks += 1;
+      try {
+        const data = await api.get<{ runtime?: { lastPollAt?: number | null } }>(
+          `/api/hosted/status?agentName=${encodeURIComponent(hosted.agentName)}`,
+        );
+        if (cancelled) return;
+        if (data?.runtime?.lastPollAt) {
+          setHostedState('running');
+          clearInterval(timer);
+          return;
+        }
+      } catch {
+        // keep polling — a transient status failure is not a stopped runtime
+      }
+      if (ticks >= HOSTED_STATUS_MAX_TICKS) {
+        setHostedState('slow');
+        clearInterval(timer);
+      }
+    }, HOSTED_STATUS_POLL_MS);
+    return () => { cancelled = true; clearInterval(timer); };
+  }, [api, hosted]);
 
   // Load the user's pods so they can pick which one to install into.
   // We only show pods they're a member of — install requires membership
-  // per the backend's `userHasPodAccess` check.
+  // per the backend's `userHasPodAccess` check. Hosting availability is
+  // fetched AFTER pods in the same effect, deliberately: the request order
+  // at mount is part of this page's test contract (order-based mocks), and
+  // the picker matters more than the mode cards if only one can load.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -126,9 +176,55 @@ const V2AgentBYO: React.FC = () => {
       } catch {
         // Defensive: keep the form usable; user will see the error on submit.
       }
+      try {
+        const availability = await api.get<HostedAvailability>('/api/hosted/availability');
+        if (cancelled) return;
+        if (availability && typeof availability.configured === 'boolean') {
+          setHosting(availability);
+          if (availability.configured) setMode('hosted');
+        }
+      } catch {
+        if (!cancelled) setHosting({ configured: false, caps: { agentsPerUser: 0, turnsPerDay: 0 } });
+      }
     })();
     return () => { cancelled = true; };
   }, [api, podId, currentUser?._id]);
+
+  // Hosted path: install with runtimeType 'hosted' (the kernel's cap gate
+  // answers 403 hosted_cap_reached), then ask the kernel to provision. No
+  // token round-trips through the browser.
+  const submitHosted = async (cleanName: string) => {
+    setSubmitting(true);
+    try {
+      try {
+        await api.post('/api/registry/install', {
+          agentName: cleanName,
+          podId,
+          scopes: DEFAULT_SCOPES,
+          config: { runtime: { runtimeType: 'hosted' } },
+          displayName: cleanName,
+        });
+      } catch (installErr) {
+        const data = (installErr as { response?: { data?: { error?: string; code?: string; cap?: number } } })
+          ?.response?.data;
+        if (data?.code === 'hosted_cap_reached') {
+          setError(t('agentByo.errors.hostedCap', { cap: data.cap ?? hosting?.caps.agentsPerUser ?? 1 }));
+          return;
+        }
+        if (!/already installed/i.test(data?.error || '')) throw installErr;
+      }
+      await api.post('/api/hosted/provision', { agentName: cleanName });
+      setHosted({ agentName: cleanName, podId });
+    } catch (err) {
+      const e = err as { response?: { data?: { error?: string; message?: string; code?: string } }; message?: string };
+      const code = e.response?.data?.code;
+      setError(code === 'hosted_runtime_unconfigured'
+        ? t('agentByo.errors.hostedUnavailable')
+        : (e.response?.data?.message || e.response?.data?.error || e.message || t('agentByo.errors.installFailed')));
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   const submit = async () => {
     setError(null);
@@ -139,6 +235,10 @@ const V2AgentBYO: React.FC = () => {
     }
     if (!podId) {
       setError(t('agentByo.errors.podRequired'));
+      return;
+    }
+    if (mode === 'hosted') {
+      await submitHosted(cleanName);
       return;
     }
     setSubmitting(true);
@@ -335,8 +435,32 @@ const V2AgentBYO: React.FC = () => {
       description={t('agentByo.description')}
       showPodsSidebar={false}
     >
-      {!issued && (
+      {!issued && !hosted && (
         <div className="v2-byo__form">
+          {hosting?.configured && (
+            <div className="v2-byo__modes" role="group" aria-label={t('agentByo.mode.label')}>
+              <button
+                type="button"
+                className="v2-byo__mode"
+                aria-pressed={mode === 'hosted'}
+                onClick={() => setMode('hosted')}
+                data-testid="byo-mode-hosted"
+              >
+                <span className="v2-byo__mode-title">{t('agentByo.mode.hosted')}</span>
+                <span className="v2-byo__hint">{t('agentByo.mode.hostedHint', { turns: hosting.caps.turnsPerDay })}</span>
+              </button>
+              <button
+                type="button"
+                className="v2-byo__mode"
+                aria-pressed={mode === 'byo'}
+                onClick={() => setMode('byo')}
+                data-testid="byo-mode-byo"
+              >
+                <span className="v2-byo__mode-title">{t('agentByo.mode.byo')}</span>
+                <span className="v2-byo__hint">{t('agentByo.mode.byoHint')}</span>
+              </button>
+            </div>
+          )}
           <label className="v2-byo__field">
             <span className="v2-byo__label">{t('agentByo.form.nameLabel')}</span>
             <input
@@ -373,7 +497,9 @@ const V2AgentBYO: React.FC = () => {
             disabled={submitting || !podId}
             className="v2-byo__submit"
           >
-            {submitting ? t('agentByo.actions.issuing') : t('agentByo.actions.install')}
+            {mode === 'hosted'
+              ? (submitting ? t('agentByo.actions.starting') : t('agentByo.actions.runHere'))
+              : (submitting ? t('agentByo.actions.issuing') : t('agentByo.actions.install'))}
           </button>
           <p className="v2-byo__footnote">
             {t('agentByo.footnote.preferCli')} <code>{CLI_INSTALL_COMMAND}</code>, {t('agentByo.footnote.then')}{' '}
@@ -383,6 +509,41 @@ const V2AgentBYO: React.FC = () => {
             {' · '}
             <a href="https://github.com/Team-Commonly/commonly/blob/main/docs/MCP_INTEGRATION.md" target="_blank" rel="noopener noreferrer">{t('agentByo.footnote.fullWalkthrough')}</a>.
           </p>
+        </div>
+      )}
+
+      {hosted && (
+        <div className="v2-byo__result" data-testid="byo-hosted-result">
+          <h2>{t('agentByo.hosted.heading')} <code>{hosted.agentName}</code></h2>
+          <p>
+            {t('agentByo.hosted.live', {
+              name: hosted.agentName,
+              pod: pods.find((p) => p._id === hosted.podId)?.name || '',
+            })}
+          </p>
+          <p
+            className={hostedState === 'running' ? 'v2-byo__memory-done' : 'v2-byo__listen-note'}
+            data-testid={`byo-hosted-${hostedState}`}
+          >
+            {t(`agentByo.hosted.${hostedState}`, { name: hosted.agentName })}
+          </p>
+          <p className="v2-byo__hint">{t('agentByo.hosted.meter', { turns: hosting?.caps.turnsPerDay ?? 0 })}</p>
+          <div className="v2-byo__cta-row">
+            <button
+              type="button"
+              onClick={() => navigate(`/v2/pods/${hosted.podId}`)}
+              className="v2-byo__submit"
+            >
+              {t('agentByo.actions.goToPod')}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setHosted(null); }}
+              className="v2-byo__secondary"
+            >
+              {t('agentByo.actions.installAnother')}
+            </button>
+          </div>
         </div>
       )}
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -6032,6 +6032,38 @@ body.modern-ui.v2-canvas {
   color: #1e6b2a;
   font-size: 13px;
 }
+/* ADR-023 W2 — "Run it here" vs BYO choice cards. Borders, not shadows;
+   the accent border + focus ring marks the pressed card. */
+.v2-byo__modes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+.v2-root button.v2-byo__mode {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  text-align: left;
+  padding: 12px 14px;
+  border: 1px solid var(--v2-border);
+  border-radius: 8px;
+  background: var(--v2-surface, #fff);
+  color: var(--v2-text-primary);
+  cursor: pointer;
+  transition: border-color 0.08s ease;
+}
+.v2-root button.v2-byo__mode:hover {
+  background: var(--v2-surface-hover);
+}
+.v2-root button.v2-byo__mode[aria-pressed="true"] {
+  border-color: var(--v2-accent);
+  box-shadow: var(--v2-focus-ring);
+}
+.v2-byo__mode-title {
+  font-size: 14px;
+  font-weight: 600;
+}
 .v2-root button.v2-byo__submit {
   align-self: flex-start;
   padding: 10px 18px;


### PR DESCRIPTION
## What
Consumes #1355. Where the instance reports a configured hosted runtime, the BYO page offers two choice cards — **Run it here** (default) and **Bring your own runtime** — and the hosted path is: install with `runtimeType: 'hosted'` → `POST /api/hosted/provision` → "Running: `name` is live in `pod`", with a status poll that flips to "listening" once the runtime reports `lastPollAt` (~60s, then honest copy). No token is ever rendered on this path. The beta cap from the install gate is surfaced as its own message. Without hosting, the page is byte-for-byte the BYO page it was (no picker, webhook install).

## Proof
- New `V2AgentBYOHosted` suite (hosted default + install/provision wiring + no token, starting→listening flip, cap message, unconfigured = old page).
- Full frontend run: 472/472. `tsc --noEmit` clean. eslint 0 errors.
- Availability is fetched **after** pods in the same effect, on purpose — mount request order is part of this page's test contract (three suites use order-based `mockResolvedValueOnce`); the first cut fetched it first and broke all three.

## Not verified here
- Real-browser layout of the two cards (grid on tokens, borders only). Will check on commonly.me after deploy — it's not an overflow/scroll rule, so the presence-test tier doesn't apply.

Depends on #1355 (API). Merge after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJ1bDdDQwWekHDqweiBhRN
