### PR TITLE
chore(hosted): wire dev to the deployed runtime (after #1355)

### DIFF
--- a/k8s/helm/commonly/values-dev.yaml
+++ b/k8s/helm/commonly/values-dev.yaml
@@ -58,6 +58,8 @@ backend:
     # Must match the callback URL registered on the GitHub/Google OAuth apps.
     oauthCallbackBaseUrl: "https://api.commonly.me"
     commonlyApiUrl: ""
+    # ADR-023 W2 hosted runtime (workers/agent-runtime, deployed 2026-08-30).
+    hostedRuntimeUrl: "https://commonly-agent-runtime.commonlyai.workers.dev"
     clawdbotGatewayUrl: ""
     moltbotGatewayUrl: ""
     pgHost: "YOUR_PG_HOST"

--- a/workers/agent-runtime/wrangler.toml
+++ b/workers/agent-runtime/wrangler.toml
@@ -18,3 +18,5 @@ new_sqlite_classes = ["AgentRuntimeDO"]
 # The Commonly instance this runtime serves. Runtime tokens come per-agent
 # via the provision call, never from worker config.
 COMMONLY_API_URL = "https://api.commonly.me"
+# Provider decision 2026-08-29 (Sam): DeepSeek. Key is a secret (DEEPSEEK_API_KEY).
+MODEL_PROVIDER = "deepseek"


### PR DESCRIPTION
Worker deployed 2026-08-30 at https://commonly-agent-runtime.commonlyai.workers.dev with RUNTIME_ADMIN_TOKEN + DEEPSEEK_API_KEY as worker secrets; admin bearer mirrored to SM `commonly-dev-hosted-runtime-admin-token` for the `hosted-runtime` ExternalSecret that #1355 adds. This PR bakes `MODEL_PROVIDER=deepseek` into wrangler.toml and sets `backend.env.hostedRuntimeUrl` for dev.

Merge after #1355, then Deploy Dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJ1bDdDQwWekHDqweiBhRN