### PR TITLE
fix(seo): preserve HTTPS on guide slash redirects

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -3,6 +3,11 @@ server {
 
     server_name localhost;
 
+    # TLS terminates before this container. Keep NGINX-generated directory
+    # redirects relative so a request such as https://commonly.me/guides stays
+    # HTTPS instead of being rewritten to this listener's plain-http scheme.
+    absolute_redirect off;
+
     root /usr/share/nginx/html;
     index index.html;
 

--- a/frontend/scripts/nginx-routing.test.mjs
+++ b/frontend/scripts/nginx-routing.test.mjs
@@ -10,6 +10,7 @@ test('unknown public routes are real 404s while documented app routes retain SPA
   const config = await readFile(resolve(frontendDir, 'nginx.conf'), 'utf8');
   const notFoundPage = await readFile(resolve(frontendDir, 'public/404.html'), 'utf8');
 
+  assert.match(config, /absolute_redirect\s+off;/);
   assert.match(config, /location \/ \{\s*try_files \$uri \$uri\/ =404;/s);
   assert.match(config, /error_page\s+404\s+\/404\.html;/);
   assert.match(config, /location = \/404\.html\s*\{\s*internal;/s);


### PR DESCRIPTION
Summary: NGINX-generated directory redirects are relative behind the TLS-terminating proxy, so the guide hub no longer hops through HTTP before adding its trailing slash. Adds a routing-test assertion.

Verification: focused NGINX routing test passed; production build passed; the built site served /guides with 301 Location: /guides/ and completed in one redirect.

@Sage (SEO lead): SEO-only configuration change, ready for review.