### PR TITLE
fix(seo): use light shell for guide pages

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,9 +30,9 @@
     <meta name="twitter:image" content="https://commonly.me/og-card.png?v=2" />
     <!-- SEO_METADATA_END -->
     <!-- Progressive-enhancement gate for the prerendered SEO page below.
-         The dark #seo-page markup ships inside #root on EVERY route, so
+         The #seo-page markup ships inside #root on EVERY route, so
          every load painted it for the beat before React replaced it — the
-         "half-second dark flash" (Sam, 2026-08-24) that survived three CSS
+         "half-second flash" (Sam, 2026-08-24) that survived three CSS
          fixes because it is content, not a background rule. This head
          script runs before first paint: browsers (JS on) never show the
          prerender; crawlers without JS still get the full content. Not
@@ -40,7 +40,7 @@
     <!-- SEO_GATE_START -->
     <!-- Rev 2 (Sam re-sighted the flash, 2026-08-26): the script-gate had a
          timing dependency — anything that delays head-script execution
-         paints the dark prerender first. Hidden-by-default has NO timing
+         paints the prerender first. Hidden-by-default has NO timing
          window: JS-capable browsers never paint it, and the <noscript>
          below reveals it for text-only crawlers. Rendering crawlers
          (Googlebot) execute JS and index the real app instead. -->
@@ -48,38 +48,38 @@
     <!-- SEO_GATE_END -->
     <style>
       #seo-page { display: none; }
-      #seo-page { box-sizing: border-box; min-height: 100vh; color: #e5e7eb; background: #0b1220; font: 16px/1.6 Inter, ui-sans-serif, system-ui, sans-serif; }
+      #seo-page { box-sizing: border-box; min-height: 100vh; color: #111827; background: #f8f8fb; font: 16px/1.6 Inter, ui-sans-serif, system-ui, sans-serif; }
       #seo-page *, #seo-page *::before, #seo-page *::after { box-sizing: inherit; }
-      #seo-page a { color: #7dd3fc; text-decoration-thickness: 1px; text-underline-offset: 3px; }
-      #seo-page a:hover { color: #e0f2fe; }
+      #seo-page a { color: #2456c8; text-decoration-thickness: 1px; text-underline-offset: 3px; }
+      #seo-page a:hover { color: #14306f; }
       #seo-page .seo-header, #seo-page main, #seo-page .seo-footer { width: min(1120px, calc(100% - 40px)); margin: 0 auto; }
       #seo-page .seo-header { display: flex; align-items: center; justify-content: space-between; gap: 24px; min-height: 72px; }
       #seo-page .seo-header nav { display: flex; flex-wrap: wrap; gap: 16px; }
-      #seo-page .seo-brand { color: #fff; font-size: 20px; font-weight: 800; text-decoration: none; }
+      #seo-page .seo-brand { color: #111827; font-size: 20px; font-weight: 800; text-decoration: none; }
       #seo-page section { padding: 64px 0; }
-      #seo-page h1, #seo-page h2, #seo-page h3 { color: #fff; line-height: 1.12; }
+      #seo-page h1, #seo-page h2, #seo-page h3 { color: #111827; line-height: 1.12; }
       #seo-page h1 { max-width: 820px; margin: 0 0 20px; font-size: clamp(2.5rem, 7vw, 5rem); letter-spacing: -.055em; }
       #seo-page h2 { max-width: 760px; margin: 0 0 20px; font-size: clamp(1.75rem, 4vw, 2.75rem); letter-spacing: -.035em; }
       #seo-page h3 { margin: 0 0 12px; font-size: 1.2rem; }
       #seo-page p { max-width: 800px; margin: 0 0 16px; }
       #seo-page .seo-hero { padding-top: 100px; padding-bottom: 100px; }
-      #seo-page .seo-lede { color: #cbd5e1; font-size: 1.15rem; }
-      #seo-page .seo-byline { color: #94a3b8; font-size: .875rem; line-height: 1.7; }
-      #seo-page .seo-kicker { margin-bottom: 10px; color: #7dd3fc; font-size: .78rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+      #seo-page .seo-lede { color: #4b5563; font-size: 1.15rem; }
+      #seo-page .seo-byline { color: #7b8494; font-size: .875rem; line-height: 1.7; }
+      #seo-page .seo-kicker { margin-bottom: 10px; color: #2456c8; font-size: .78rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
       #seo-page .seo-actions { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; margin-top: 28px; }
-      #seo-page .seo-primary { display: inline-block; border-radius: 999px; padding: 10px 18px; color: #062032; background: #7dd3fc; font-weight: 800; text-decoration: none; }
-      #seo-page .seo-primary:hover { color: #062032; background: #bae6fd; }
-      #seo-page .seo-install { color: #cbd5e1; }
-      #seo-page .seo-install code { display: inline-block; overflow-wrap: anywhere; padding: 10px 12px; border: 1px solid #334155; border-radius: 8px; background: #111827; }
-      #seo-page .seo-band { width: 100%; max-width: none; margin-left: calc((100vw - min(1120px, calc(100vw - 40px))) / -2); padding-right: max(20px, calc((100vw - 1120px) / 2)); padding-left: max(20px, calc((100vw - 1120px) / 2)); color: #e0f2fe; background: #0c4a6e; }
+      #seo-page .seo-primary { display: inline-block; border-radius: 999px; padding: 10px 18px; color: #fff; background: #2f6feb; font-weight: 800; text-decoration: none; }
+      #seo-page .seo-primary:hover { color: #fff; background: #1f55c9; }
+      #seo-page .seo-install { color: #4b5563; }
+      #seo-page .seo-install code { display: inline-block; overflow-wrap: anywhere; padding: 10px 12px; border: 1px solid #eef0f6; border-radius: 8px; color: #111827; background: #f4f3f8; }
+      #seo-page .seo-band { width: 100%; max-width: none; margin-left: calc((100vw - min(1120px, calc(100vw - 40px))) / -2); padding-right: max(20px, calc((100vw - 1120px) / 2)); padding-left: max(20px, calc((100vw - 1120px) / 2)); color: #14306f; background: #e8efff; }
       #seo-page .seo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 16px; }
-      #seo-page .seo-card { padding: 24px; border: 1px solid #334155; border-radius: 12px; background: #111827; }
+      #seo-page .seo-card { padding: 24px; border: 1px solid #eef0f6; border-radius: 12px; background: #fff; }
       #seo-page .seo-card p:last-child, #seo-page .seo-card ul:last-child { margin-bottom: 0; }
-      #seo-page .seo-code { overflow-x: auto; margin: 20px 0; padding: 16px; border: 1px solid #334155; border-radius: 8px; color: #e5e7eb; background: #111827; font: .875rem/1.6 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+      #seo-page .seo-code { overflow-x: auto; margin: 20px 0; padding: 16px; border: 1px solid #eef0f6; border-radius: 8px; color: #111827; background: #f4f3f8; font: .875rem/1.6 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
       #seo-page .seo-code code { font: inherit; }
-      #seo-page li { margin-bottom: 8px; color: #cbd5e1; }
-      #seo-page .seo-note { color: #94a3b8; font-size: .875rem; }
-      #seo-page .seo-footer { padding: 40px 0; color: #94a3b8; border-top: 1px solid #334155; }
+      #seo-page li { margin-bottom: 8px; color: #4b5563; }
+      #seo-page .seo-note { color: #7b8494; font-size: .875rem; }
+      #seo-page .seo-footer { padding: 40px 0; color: #7b8494; border-top: 1px solid #e5e7eb; }
       @media (max-width: 640px) { #seo-page .seo-header { align-items: flex-start; flex-direction: column; padding: 20px 0; } #seo-page section { padding: 44px 0; } #seo-page .seo-hero { padding-top: 56px; padding-bottom: 56px; } }
     </style>
     <!-- SEO_NAVIGATION_RUNTIME_START -->

--- a/frontend/scripts/generate-seo-pages.mjs
+++ b/frontend/scripts/generate-seo-pages.mjs
@@ -94,7 +94,16 @@ const staticDocument = (template) => {
     navigationRuntimeEnd,
   );
 
-  return removeModulePreloads(removeRuntimeEntryScript(withoutNavigationRuntime));
+  const withoutRuntime = removeModulePreloads(removeRuntimeEntryScript(withoutNavigationRuntime));
+  const headEnd = withoutRuntime.indexOf('</head>');
+  if (headEnd < 0) {
+    throw new Error('Missing closing head tag in the static SEO page template.');
+  }
+
+  // Static-only pages deliberately omit the React bundle. The regular template
+  // hides #seo-page until React takes over, so reveal that real page content
+  // again for browsers as well as text-only crawlers.
+  return `${withoutRuntime.slice(0, headEnd)}<style>#seo-page { display: block !important; }</style>${withoutRuntime.slice(headEnd)}`;
 };
 
 const pageUrl = (path) => `${siteUrl}${path}`;

--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -8,10 +8,11 @@ import { buildPageDefinitions, renderStaticPage } from './generate-seo-pages.mjs
 const frontendDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 test('emits a canonical crawlable page for every public route', async () => {
-  const [translationText, useCaseText, guideText] = await Promise.all([
+  const [translationText, useCaseText, guideText, indexHtml] = await Promise.all([
     readFile(resolve(frontendDir, 'src/i18n/locales/en.json'), 'utf8'),
     readFile(resolve(frontendDir, 'src/content/use-cases.json'), 'utf8'),
     readFile(resolve(frontendDir, 'src/content/guides.json'), 'utf8'),
+    readFile(resolve(frontendDir, 'index.html'), 'utf8'),
   ]);
   const translations = JSON.parse(translationText);
   const useCases = JSON.parse(useCaseText);
@@ -72,6 +73,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.doesNotMatch(taskManagementHtml, /modulepreload/);
   assert.doesNotMatch(taskManagementHtml, /type="module"/);
   assert.doesNotMatch(taskManagementHtml, /src="\/assets\/index-/);
+  assert.match(taskManagementHtml, /#seo-page \{ display: block !important; \}/);
   assert.match(taskManagementHtml, /#seo-page \{ color: #fff; \}/);
   const sharedWorkspaceHtml = renderStaticPage(guideTemplate, sharedWorkspaceGuide);
   assert.match(sharedWorkspaceHtml, /codex mcp add commonly/);
@@ -87,6 +89,8 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guidesIndex = pages.find((page) => page.path === '/guides/');
   assert.equal(guidesIndex.title, 'Guides for teams working with AI agents | Commonly');
   assert.equal(guidesIndex.schema['@type'], 'WebPage');
+  assert.match(indexHtml, /#seo-page \{[^}]*color: #111827; background: #f8f8fb;/);
+  assert.match(indexHtml, /#seo-page \.seo-code \{[^}]*color: #111827; background: #f4f3f8;/);
 });
 
 test('puts route content, canonical metadata, and structured data in the document', () => {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -57,6 +57,14 @@ body.modern-ui {
   color: #e2e8f0;
 }
 
+/* Public guides live outside V2's component tree but use its light shell.
+   The compound selector also overrides the legacy body.modern-ui gradient. */
+body.guide-canvas,
+body.modern-ui.guide-canvas {
+  background: #f8f8fb;
+  color: #111827;
+}
+
 body.modern-ui ::-webkit-scrollbar {
   width: 10px;
   height: 10px;

--- a/frontend/src/components/landing/GuidePage.tsx
+++ b/frontend/src/components/landing/GuidePage.tsx
@@ -12,6 +12,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import commonlyLogo from '../../assets/commonly-logo.png';
 import guides from '../../content/guides.json';
+import { guidePalette, useGuideCanvas } from './guideShell';
 
 interface GuideSection {
   title: string;
@@ -70,17 +71,19 @@ const GuidePage: React.FC = () => {
   const navigate = useNavigate();
   const guide = guideId ? GUIDES[guideId] : undefined;
 
+  useGuideCanvas();
+
   if (!guide) {
     return (
-      <Box sx={{ minHeight: '100vh', backgroundColor: '#0b1220', color: '#e2e8f0', py: 10 }}>
+      <Box sx={{ minHeight: '100vh', backgroundColor: guidePalette.page, color: guidePalette.textPrimary, py: 10 }}>
         <Container maxWidth="md">
-          <Button startIcon={<ArrowBackIcon />} onClick={() => navigate('/')}>
+          <Button sx={{ color: guidePalette.accentText }} startIcon={<ArrowBackIcon />} onClick={() => navigate('/')}>
             Back to landing
           </Button>
-          <Typography variant="h4" sx={{ mt: 3, mb: 1, fontWeight: 700 }}>
+          <Typography variant="h4" sx={{ mt: 3, mb: 1, color: guidePalette.textPrimary, fontWeight: 700 }}>
             Guide not found
           </Typography>
-          <Typography color="#94a3b8">
+          <Typography color={guidePalette.textSecondary}>
             This guide does not exist yet. Return to the landing page to explore Commonly.
           </Typography>
         </Container>
@@ -89,28 +92,28 @@ const GuidePage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ minHeight: '100vh', backgroundColor: '#0b1220', color: '#e2e8f0' }}>
+    <Box sx={{ minHeight: '100vh', backgroundColor: guidePalette.page, color: guidePalette.textPrimary }}>
       <Container maxWidth="md" sx={{ pt: 5, pb: 10 }}>
         <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 6 }}>
-          <Button startIcon={<ArrowBackIcon />} onClick={() => navigate('/')}>
+          <Button sx={{ color: guidePalette.accentText }} startIcon={<ArrowBackIcon />} onClick={() => navigate('/')}>
             Back to landing
           </Button>
           <Stack direction="row" alignItems="center" spacing={1}>
             <img src={commonlyLogo} alt="Commonly Logo" width={26} height={26} />
-            <Typography sx={{ fontWeight: 700, letterSpacing: '-0.02em' }}>Commonly</Typography>
+            <Typography sx={{ color: guidePalette.textPrimary, fontWeight: 700, letterSpacing: '-0.02em' }}>Commonly</Typography>
           </Stack>
         </Stack>
 
-        <Typography sx={{ color: '#7dd3fc', fontWeight: 700, letterSpacing: '0.08em', mb: 1 }}>
+        <Typography sx={{ color: guidePalette.accentText, fontWeight: 700, letterSpacing: '0.08em', mb: 1 }}>
           {guide.eyebrow.toUpperCase()}
         </Typography>
-        <Typography component="h1" variant="h2" sx={{ fontWeight: 800, lineHeight: 1.15, letterSpacing: '-0.03em', mb: 2 }}>
+        <Typography component="h1" variant="h2" sx={{ color: guidePalette.textPrimary, fontWeight: 800, lineHeight: 1.15, letterSpacing: '-0.03em', mb: 2 }}>
           {guide.title}
         </Typography>
-        <Typography sx={{ color: '#94a3b8', fontSize: '1.125rem', lineHeight: 1.7, mb: 5 }}>
+        <Typography sx={{ color: guidePalette.textSecondary, fontSize: '1.125rem', lineHeight: 1.7, mb: 5 }}>
           {guide.description}
         </Typography>
-        <Typography sx={{ color: '#94a3b8', fontSize: '0.875rem', lineHeight: 1.7, mb: 5 }}>
+        <Typography sx={{ color: guidePalette.textTertiary, fontSize: '0.875rem', lineHeight: 1.7, mb: 5 }}>
           By {guide.provenance.author} · Reviewed by {guide.provenance.reviewer}
           <br />
           {guide.provenance.datePublished === guide.provenance.dateModified
@@ -118,26 +121,26 @@ const GuidePage: React.FC = () => {
             : `Published ${formatGuideDate(guide.provenance.datePublished)} · Updated ${formatGuideDate(guide.provenance.dateModified)}`}
         </Typography>
 
-        <Stack spacing={2} sx={{ color: '#cbd5e1', fontSize: '1.05rem', lineHeight: 1.75, mb: 7 }}>
+        <Stack spacing={2} sx={{ color: guidePalette.textSecondary, fontSize: '1.05rem', lineHeight: 1.75, mb: 7 }}>
           {guide.intro.map((paragraph) => <Typography key={paragraph}>{paragraph}</Typography>)}
         </Stack>
 
         <Stack spacing={7}>
           {guide.sections.map((section) => (
             <Box component="section" key={section.title}>
-              <Typography component="h2" variant="h4" sx={{ fontWeight: 750, lineHeight: 1.2, mb: 2.5 }}>
+              <Typography component="h2" variant="h4" sx={{ color: guidePalette.textPrimary, fontWeight: 750, lineHeight: 1.2, mb: 2.5 }}>
                 {section.title}
               </Typography>
-              <Stack spacing={2} sx={{ color: '#cbd5e1', lineHeight: 1.75 }}>
+              <Stack spacing={2} sx={{ color: guidePalette.textSecondary, lineHeight: 1.75 }}>
                 {section.paragraphs?.map((paragraph) => <Typography key={paragraph}>{paragraph}</Typography>)}
               </Stack>
               {section.bullets && (
-                <Box component="ul" sx={{ color: '#cbd5e1', lineHeight: 1.75, pl: 3, my: 2.5 }}>
+                <Box component="ul" sx={{ color: guidePalette.textSecondary, lineHeight: 1.75, pl: 3, my: 2.5 }}>
                   {section.bullets.map((item) => <li key={item}><Typography component="span">{item}</Typography></li>)}
                 </Box>
               )}
               {section.orderedItems && (
-                <Box component="ol" sx={{ color: '#cbd5e1', lineHeight: 1.75, pl: 3, my: 2.5 }}>
+                <Box component="ol" sx={{ color: guidePalette.textSecondary, lineHeight: 1.75, pl: 3, my: 2.5 }}>
                   {section.orderedItems.map((item) => <li key={item}><Typography component="span">{item}</Typography></li>)}
                 </Box>
               )}
@@ -150,10 +153,10 @@ const GuidePage: React.FC = () => {
                     m: 0,
                     mt: 2.5,
                     p: 2,
-                    border: '1px solid rgba(148,163,184,0.22)',
+                    border: `1px solid ${guidePalette.borderSoft}`,
                     borderRadius: 2,
-                    backgroundColor: '#111827',
-                    color: '#e5e7eb',
+                    backgroundColor: guidePalette.surfaceTint,
+                    color: guidePalette.textPrimary,
                     fontSize: '0.875rem',
                     lineHeight: 1.6,
                   }}
@@ -167,30 +170,30 @@ const GuidePage: React.FC = () => {
           ))}
         </Stack>
 
-        <Divider sx={{ borderColor: 'rgba(148,163,184,0.18)', my: 7 }} />
+        <Divider sx={{ borderColor: guidePalette.border, my: 7 }} />
 
         <Box component="section">
-          <Typography component="h2" variant="h4" sx={{ fontWeight: 750, mb: 3 }}>
+          <Typography component="h2" variant="h4" sx={{ color: guidePalette.textPrimary, fontWeight: 750, mb: 3 }}>
             Frequently asked questions
           </Typography>
           <Stack spacing={3}>
             {guide.faq.map((item) => (
-              <Box key={item.question} sx={{ p: 3, border: '1px solid rgba(148,163,184,0.18)', borderRadius: 3 }}>
-                <Typography component="h3" sx={{ fontWeight: 700, mb: 1 }}>{item.question}</Typography>
-                <Typography sx={{ color: '#cbd5e1', lineHeight: 1.75 }}>{item.answer}</Typography>
+              <Box key={item.question} sx={{ p: 3, border: `1px solid ${guidePalette.borderSoft}`, borderRadius: 3, backgroundColor: guidePalette.surface }}>
+                <Typography component="h3" sx={{ color: guidePalette.textPrimary, fontWeight: 700, mb: 1 }}>{item.question}</Typography>
+                <Typography sx={{ color: guidePalette.textSecondary, lineHeight: 1.75 }}>{item.answer}</Typography>
               </Box>
             ))}
           </Stack>
         </Box>
 
-        <Box component="section" sx={{ mt: 7, p: { xs: 3, sm: 5 }, borderRadius: 4, background: 'rgba(14,116,144,0.22)' }}>
-          <Typography component="h2" variant="h4" sx={{ fontWeight: 750, mb: 1.5 }}>{guide.cta.title}</Typography>
-          <Typography sx={{ color: '#e0f2fe', lineHeight: 1.75, mb: 3 }}>{guide.cta.body}</Typography>
+        <Box component="section" sx={{ mt: 7, p: { xs: 3, sm: 5 }, borderRadius: 4, background: guidePalette.accentSoft }}>
+          <Typography component="h2" variant="h4" sx={{ color: guidePalette.accentDeep, fontWeight: 750, mb: 1.5 }}>{guide.cta.title}</Typography>
+          <Typography sx={{ color: guidePalette.accentDeep, lineHeight: 1.75, mb: 3 }}>{guide.cta.body}</Typography>
           <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-            <Button variant="contained" endIcon={<ArrowForwardIcon />} onClick={() => navigate(guide.cta.primary.path)}>
+            <Button variant="contained" sx={{ backgroundColor: guidePalette.accent, '&:hover': { backgroundColor: guidePalette.accentStrong } }} endIcon={<ArrowForwardIcon />} onClick={() => navigate(guide.cta.primary.path)}>
               {guide.cta.primary.label}
             </Button>
-            <Button variant="outlined" onClick={() => navigate(guide.cta.secondary.path)}>
+            <Button variant="outlined" sx={{ borderColor: guidePalette.accent, color: guidePalette.accentText, '&:hover': { borderColor: guidePalette.accentStrong, backgroundColor: guidePalette.surface } }} onClick={() => navigate(guide.cta.secondary.path)}>
               {guide.cta.secondary.label}
             </Button>
           </Stack>
@@ -198,7 +201,7 @@ const GuidePage: React.FC = () => {
 
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mt: 4 }}>
           {guide.relatedLinks.map((link) => (
-            <Button key={link.path} variant="text" onClick={() => navigate(link.path)}>{link.label}</Button>
+            <Button key={link.path} variant="text" sx={{ color: guidePalette.accentText }} onClick={() => navigate(link.path)}>{link.label}</Button>
           ))}
         </Stack>
       </Container>

--- a/frontend/src/components/landing/GuidesIndexPage.tsx
+++ b/frontend/src/components/landing/GuidesIndexPage.tsx
@@ -11,6 +11,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import commonlyLogo from '../../assets/commonly-logo.png';
 import guides from '../../content/guides.json';
+import { guidePalette, useGuideCanvas } from './guideShell';
 
 interface Guide {
   eyebrow: string;
@@ -22,43 +23,44 @@ const GUIDES = guides as Record<string, Guide>;
 
 const GuidesIndexPage: React.FC = () => {
   const navigate = useNavigate();
+  useGuideCanvas();
 
   return (
-    <Box sx={{ minHeight: '100vh', backgroundColor: '#0b1220', color: '#e2e8f0' }}>
+    <Box sx={{ minHeight: '100vh', backgroundColor: guidePalette.page, color: guidePalette.textPrimary }}>
       <Container maxWidth="md" sx={{ pt: 5, pb: 10 }}>
         <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 6 }}>
-          <Button startIcon={<ArrowBackIcon />} onClick={() => navigate('/')}>
+          <Button sx={{ color: guidePalette.accentText }} startIcon={<ArrowBackIcon />} onClick={() => navigate('/')}>
             Back to landing
           </Button>
           <Stack direction="row" alignItems="center" spacing={1}>
             <img src={commonlyLogo} alt="Commonly Logo" width={26} height={26} />
-            <Typography sx={{ fontWeight: 700, letterSpacing: '-0.02em' }}>Commonly</Typography>
+            <Typography sx={{ color: guidePalette.textPrimary, fontWeight: 700, letterSpacing: '-0.02em' }}>Commonly</Typography>
           </Stack>
         </Stack>
 
-        <Typography sx={{ color: '#7dd3fc', fontWeight: 700, letterSpacing: '0.08em', mb: 1 }}>
+        <Typography sx={{ color: guidePalette.accentText, fontWeight: 700, letterSpacing: '0.08em', mb: 1 }}>
           GUIDES
         </Typography>
-        <Typography component="h1" variant="h2" sx={{ fontWeight: 800, lineHeight: 1.15, letterSpacing: '-0.03em', mb: 2 }}>
+        <Typography component="h1" variant="h2" sx={{ color: guidePalette.textPrimary, fontWeight: 800, lineHeight: 1.15, letterSpacing: '-0.03em', mb: 2 }}>
           Guides for teams working with AI agents
         </Typography>
-        <Typography sx={{ color: '#94a3b8', fontSize: '1.125rem', lineHeight: 1.7, mb: 6 }}>
+        <Typography sx={{ color: guidePalette.textSecondary, fontSize: '1.125rem', lineHeight: 1.7, mb: 6 }}>
           Practical explanations of the shared context, ownership, and handoffs that help people and AI agents work together on real projects.
         </Typography>
 
         <Stack spacing={3}>
           {Object.entries(GUIDES).map(([id, guide]) => (
-            <Box key={id} component="article" sx={{ p: { xs: 3, sm: 4 }, border: '1px solid rgba(148,163,184,0.18)', borderRadius: 3 }}>
-              <Typography sx={{ color: '#7dd3fc', fontWeight: 700, letterSpacing: '0.08em', mb: 1 }}>
+            <Box key={id} component="article" sx={{ p: { xs: 3, sm: 4 }, border: `1px solid ${guidePalette.borderSoft}`, borderRadius: 3, backgroundColor: guidePalette.surface }}>
+              <Typography sx={{ color: guidePalette.accentText, fontWeight: 700, letterSpacing: '0.08em', mb: 1 }}>
                 {guide.eyebrow.toUpperCase()}
               </Typography>
-              <Typography component="h2" variant="h4" sx={{ fontWeight: 750, lineHeight: 1.2, mb: 1.5 }}>
+              <Typography component="h2" variant="h4" sx={{ color: guidePalette.textPrimary, fontWeight: 750, lineHeight: 1.2, mb: 1.5 }}>
                 {guide.title}
               </Typography>
-              <Typography sx={{ color: '#cbd5e1', lineHeight: 1.75, mb: 2.5 }}>
+              <Typography sx={{ color: guidePalette.textSecondary, lineHeight: 1.75, mb: 2.5 }}>
                 {guide.summary}
               </Typography>
-              <Button endIcon={<ArrowForwardIcon />} onClick={() => navigate(`/guides/${id}/`)}>
+              <Button sx={{ color: guidePalette.accentText }} endIcon={<ArrowForwardIcon />} onClick={() => navigate(`/guides/${id}/`)}>
                 Read the guide
               </Button>
             </Box>

--- a/frontend/src/components/landing/guideShell.ts
+++ b/frontend/src/components/landing/guideShell.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+export const guidePalette = {
+  page: '#f8f8fb',
+  surface: '#ffffff',
+  surfaceTint: '#f4f3f8',
+  border: '#e5e7eb',
+  borderSoft: '#eef0f6',
+  textPrimary: '#111827',
+  textSecondary: '#4b5563',
+  textTertiary: '#7b8494',
+  accent: '#2f6feb',
+  accentStrong: '#1f55c9',
+  accentSoft: '#e8efff',
+  accentText: '#2456c8',
+  accentDeep: '#14306f',
+} as const;
+
+// Guides render outside V2's component tree, so keep their page canvas light
+// while the rest of the legacy application continues to use its dark shell.
+export const useGuideCanvas = () => {
+  useEffect(() => {
+    document.body.classList.add('guide-canvas');
+    return () => document.body.classList.remove('guide-canvas');
+  }, []);
+};

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -21,6 +21,9 @@ const bootPath = window.location.pathname;
 if (bootPath === '/' || bootPath.startsWith('/v2')) {
   document.body.classList.add('v2-canvas');
 }
+if (bootPath === '/guides' || bootPath.startsWith('/guides/')) {
+  document.body.classList.add('guide-canvas');
+}
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -139,6 +139,7 @@ describe('V2 routing', () => {
     })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create a workspace' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Watch a live room' })).toBeInTheDocument();
+    expect(document.body).toHaveClass('guide-canvas');
   });
 
   test('shared workspace guide retains its MCP setup commands after the app takes over', async () => {


### PR DESCRIPTION
Summary: Gives every guide and the guide hub the established light shell palette in both static and React render paths. Also fixes the static-only build so its real article content is visible to JavaScript-enabled browsers after the runtime bundle is intentionally removed.

Verification: static-page tests, guide-route Jest test, typecheck, lint, and production build passed. Browser check confirmed a visible light guide and light code block from the built NGINX artifact.

@Sage (SEO lead): SEO-only P1, ready for review.