### PR TITLE
feat(runtime): RUNTIME_STATUS_TOKEN — read-only /status bearer for watchers

### DIFF
--- a/workers/agent-runtime/src/agent-do.ts
+++ b/workers/agent-runtime/src/agent-do.ts
@@ -19,6 +19,7 @@ export interface Env {
   COMMONLY_API_URL: string;
   // Operator admin secret gating every worker route (wrangler secret).
   RUNTIME_ADMIN_TOKEN?: string;
+  RUNTIME_STATUS_TOKEN?: string; // optional read-only bearer: GET /status only
   // Optional model override (defaults in turn.ts).
   MODEL_ID?: string;
   // 'anthropic' (default) or 'deepseek' — which key/provider the runtime uses.

--- a/workers/agent-runtime/src/index.ts
+++ b/workers/agent-runtime/src/index.ts
@@ -14,12 +14,21 @@ export default {
     // asserted.
     const admin = env.RUNTIME_ADMIN_TOKEN;
     if (!admin) return Response.json({ error: 'runtime not configured (RUNTIME_ADMIN_TOKEN unset)' }, { status: 503 });
-    const bearer = req.headers.get('Authorization');
-    if (bearer !== `Bearer ${admin}`) return Response.json({ error: 'unauthorized' }, { status: 401 });
     const url = new URL(req.url);
     const match = url.pathname.match(/^\/agents\/([a-z0-9-]+)\/([a-z0-9-]+)(\/.*)$/);
     if (!match) return Response.json({ error: 'expected /agents/:agentName/:instanceId/...' }, { status: 404 });
     const [, agentName, instanceId, rest] = match;
+    // Two bearers, two capabilities. The admin token provisions, deprovisions
+    // and reads. The optional status token reads /status and nothing else —
+    // a watcher (Otto, a dashboard, an alert) needs health, not the power to
+    // kill or provision any agent by name. Unset means no second bearer.
+    const bearer = req.headers.get('Authorization');
+    const isAdmin = bearer === `Bearer ${admin}`;
+    const isStatusReader = Boolean(env.RUNTIME_STATUS_TOKEN) && bearer === `Bearer ${env.RUNTIME_STATUS_TOKEN}`;
+    const statusOnly = req.method === 'GET' && rest === '/status';
+    if (!isAdmin && !(isStatusReader && statusOnly)) {
+      return Response.json({ error: 'unauthorized' }, { status: 401 });
+    }
     const id = env.AGENT.idFromName(`${agentName}:${instanceId}`);
     const stub = env.AGENT.get(id);
     const forward = new Request(new URL(rest, url.origin), req);

--- a/workers/agent-runtime/test/index.test.ts
+++ b/workers/agent-runtime/test/index.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import worker from '../src/index';
+
+// The router's two bearers. Admin does everything; the optional status token
+// reads /status and nothing else. Every other route stays 401 for it, and an
+// unset status token grants nothing.
+const makeEnv = (overrides: Record<string, unknown> = {}) => {
+  const stubFetch = vi.fn(async (req: Request) => Response.json({ routed: new URL(req.url).pathname, method: req.method }));
+  const env = {
+    RUNTIME_ADMIN_TOKEN: 'admin-secret',
+    RUNTIME_STATUS_TOKEN: 'status-secret',
+    COMMONLY_API_URL: 'https://api.test',
+    AGENT: { idFromName: vi.fn(() => 'id'), get: vi.fn(() => ({ fetch: stubFetch })) },
+    ...overrides,
+  };
+  return { env, stubFetch };
+};
+
+const call = (env: unknown, method: string, path: string, bearer?: string) => worker.fetch(
+  new Request(`https://runtime.test${path}`, { method, headers: bearer ? { Authorization: `Bearer ${bearer}` } : {} }),
+  env as never,
+);
+
+describe('router bearers', () => {
+  it('503s when the admin token is unset, before any auth decision', async () => {
+    const { env } = makeEnv({ RUNTIME_ADMIN_TOKEN: undefined });
+    const res = await call(env, 'GET', '/agents/scout/default/status', 'status-secret');
+    expect(res.status).toBe(503);
+  });
+
+  it('admin bearer reaches every route', async () => {
+    const { env, stubFetch } = makeEnv();
+    for (const [method, tail] of [['POST', '/provision'], ['POST', '/deprovision'], ['GET', '/status']] as const) {
+      const res = await call(env, method, `/agents/scout/default${tail}`, 'admin-secret');
+      expect(res.status).toBe(200);
+    }
+    expect(stubFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('status bearer reads /status and nothing else', async () => {
+    const { env, stubFetch } = makeEnv();
+    expect((await call(env, 'GET', '/agents/scout/default/status', 'status-secret')).status).toBe(200);
+    expect((await call(env, 'POST', '/agents/scout/default/provision', 'status-secret')).status).toBe(401);
+    expect((await call(env, 'POST', '/agents/scout/default/deprovision', 'status-secret')).status).toBe(401);
+    expect((await call(env, 'POST', '/agents/scout/default/status', 'status-secret')).status).toBe(401);
+    expect(stubFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('an unset status token grants nothing; no bearer and a wrong bearer are 401', async () => {
+    const { env } = makeEnv({ RUNTIME_STATUS_TOKEN: undefined });
+    expect((await call(env, 'GET', '/agents/scout/default/status', 'status-secret')).status).toBe(401);
+    expect((await call(env, 'GET', '/agents/scout/default/status')).status).toBe(401);
+    expect((await call(env, 'GET', '/agents/scout/default/status', 'nope')).status).toBe(401);
+  });
+
+  it('404s an unrouted path (still behind the admin gate)', async () => {
+    const { env } = makeEnv();
+    expect((await call(env, 'GET', '/nope', 'admin-secret')).status).toBe(404);
+    expect((await call(env, 'GET', '/nope', 'status-secret')).status).toBe(404);
+  });
+});


### PR DESCRIPTION
Otto's finding on the deployed worker: the single admin bearer gates every route, so a health watcher holds provision + deprovision power too. This adds an optional `RUNTIME_STATUS_TOKEN` that authorizes `GET /agents/:name/:instance/status` only — every other route stays 401 for it; unset grants nothing; the 503-when-unconfigured branch still fires first.

Router tests (new `test/index.test.ts`): admin reaches all routes; status bearer reads /status and nothing else (POST /status included); unset status token grants nothing; unrouted path 404s behind the gate. Worker suite 30/30, tsc clean.

After merge: `wrangler secret put RUNTIME_STATUS_TOKEN` + deploy, then the watcher gets that token, not the admin one.

Review: Otto gates W2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJ1bDdDQwWekHDqweiBhRN