### PR TITLE
feat(seo): add Commonly entity schema

### DIFF
--- a/frontend/scripts/generate-seo-pages.mjs
+++ b/frontend/scripts/generate-seo-pages.mjs
@@ -453,17 +453,19 @@ export const buildPageDefinitions = ({ landing, compare, useCases, guides = {} }
     '@graph': [organization, website, webPageNode(title, description, path)],
   });
 
-  const pages = [{
+  const landingPage = {
     path: '/',
     outputPath: 'index.html',
     title: 'Commonly — chat with your agents, ship real work',
     description: 'The open-source workspace where agents and teammates share one project memory — any runtime, your infra, no per-agent fees.',
     content: renderLanding(landing, useCases, guides),
-    schema: {
-      '@context': 'https://schema.org',
-      '@graph': [organization, website, softwareApplication, webPageNode('Commonly — chat with your agents, ship real work', 'The open-source workspace where agents and teammates share one project memory — any runtime, your infra, no per-agent fees.', '/')],
-    },
-  }, {
+  };
+  landingPage.schema = {
+    '@context': 'https://schema.org',
+    '@graph': [organization, website, softwareApplication, webPageNode(landingPage.title, landingPage.description, landingPage.path)],
+  };
+
+  const pages = [landingPage, {
     path: '/compare/',
     outputPath: 'compare/index.html',
     title: 'Commonly vs the alternatives | Commonly',

--- a/frontend/scripts/generate-seo-pages.mjs
+++ b/frontend/scripts/generate-seo-pages.mjs
@@ -405,29 +405,52 @@ const metadata = ({ title, description, path, schema, ogType = 'website', datePu
 };
 
 export const buildPageDefinitions = ({ landing, compare, useCases, guides = {} }) => {
+  const organizationId = `${siteUrl}/#organization`;
+  const websiteId = `${siteUrl}/#website`;
   const organization = {
     '@type': 'Organization',
+    '@id': organizationId,
     name: 'Commonly',
+    alternateName: ['Commonly.me', 'commonly.me', 'Commonly AI'],
     url: `${siteUrl}/`,
     logo: `${siteUrl}/favicon.svg`,
-    sameAs: ['https://github.com/Team-Commonly/commonly'],
+    description: 'Commonly (commonly.me) is a shared workspace platform where humans and AI agents from any origin work together in pods with shared memory, tasks, and messaging.',
+    sameAs: [
+      'https://github.com/Team-Commonly/commonly',
+      'https://www.npmjs.com/package/@commonlyai/mcp',
+      'https://discord.gg/NsS3fzsJDw',
+    ],
+  };
+  const website = {
+    '@type': 'WebSite',
+    '@id': websiteId,
+    name: 'Commonly',
+    alternateName: 'Commonly.me',
+    url: `${siteUrl}/`,
+    publisher: { '@id': organizationId },
   };
   const softwareApplication = {
     '@type': 'SoftwareApplication',
     name: 'Commonly',
+    alternateName: ['Commonly.me', 'commonly.me', 'Commonly AI'],
     url: `${siteUrl}/`,
     applicationCategory: 'BusinessApplication',
     operatingSystem: 'Web',
     description: landing.hero.lede,
     license: 'https://www.apache.org/licenses/LICENSE-2.0',
+    publisher: { '@id': organizationId },
   };
-  const webPage = (title, description, path) => ({
-    '@context': 'https://schema.org',
+  const webPageNode = (title, description, path) => ({
     '@type': 'WebPage',
+    '@id': pageUrl(path),
     name: title,
     description,
     url: pageUrl(path),
-    isPartOf: { '@type': 'WebSite', name: 'Commonly', url: `${siteUrl}/` },
+    isPartOf: { '@id': websiteId },
+  });
+  const webPage = (title, description, path) => ({
+    '@context': 'https://schema.org',
+    '@graph': [organization, website, webPageNode(title, description, path)],
   });
 
   const pages = [{
@@ -438,7 +461,7 @@ export const buildPageDefinitions = ({ landing, compare, useCases, guides = {} }
     content: renderLanding(landing, useCases, guides),
     schema: {
       '@context': 'https://schema.org',
-      '@graph': [organization, softwareApplication],
+      '@graph': [organization, website, softwareApplication, webPageNode('Commonly — chat with your agents, ship real work', 'The open-source workspace where agents and teammates share one project memory — any runtime, your infra, no per-agent fees.', '/')],
     },
   }, {
     path: '/compare/',
@@ -475,7 +498,7 @@ export const buildPageDefinitions = ({ landing, compare, useCases, guides = {} }
   const guidePages = Object.entries(guides).map(([id, guide]) => {
     const path = `/guides/${id}/`;
     const provenance = guideProvenance(guide);
-    const author = { '@type': 'Organization', name: provenance.author, url: `${siteUrl}/` };
+    const author = { '@type': 'Organization', '@id': organizationId, name: provenance.author, url: `${siteUrl}/` };
     const reviewer = { '@type': 'Organization', name: provenance.reviewer, url: `${siteUrl}/` };
     return {
       path,
@@ -498,7 +521,7 @@ export const buildPageDefinitions = ({ landing, compare, useCases, guides = {} }
           author,
           datePublished: provenance.datePublished,
           dateModified: provenance.dateModified,
-          publisher: organization,
+          publisher: { '@id': organizationId },
         }, {
           '@type': 'WebPage',
           '@id': pageUrl(path),
@@ -506,8 +529,8 @@ export const buildPageDefinitions = ({ landing, compare, useCases, guides = {} }
           description: guide.description,
           url: pageUrl(path),
           reviewedBy: reviewer,
-          isPartOf: { '@type': 'WebSite', name: 'Commonly', url: `${siteUrl}/` },
-        }],
+          isPartOf: { '@id': websiteId },
+        }, organization, website],
       },
     };
   });

--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -39,8 +39,28 @@ test('emits a canonical crawlable page for every public route', async () => {
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
+    'WebSite',
     'SoftwareApplication',
+    'WebPage',
   ]);
+  const organization = pages[0].schema['@graph'].find((item) => item['@type'] === 'Organization');
+  const website = pages[0].schema['@graph'].find((item) => item['@type'] === 'WebSite');
+  const softwareApplication = pages[0].schema['@graph'].find((item) => item['@type'] === 'SoftwareApplication');
+  assert.equal(organization['@id'], 'https://commonly.me/#organization');
+  assert.deepEqual(organization.alternateName, ['Commonly.me', 'commonly.me', 'Commonly AI']);
+  assert.deepEqual(organization.sameAs, [
+    'https://github.com/Team-Commonly/commonly',
+    'https://www.npmjs.com/package/@commonlyai/mcp',
+    'https://discord.gg/NsS3fzsJDw',
+  ]);
+  assert.equal(website['@id'], 'https://commonly.me/#website');
+  assert.deepEqual(website.publisher, { '@id': organization['@id'] });
+  assert.deepEqual(softwareApplication.publisher, { '@id': organization['@id'] });
+  for (const page of pages) {
+    const graph = page.schema['@graph'] || [page.schema];
+    const webPage = graph.find((item) => item['@type'] === 'WebPage');
+    assert.deepEqual(webPage.isPartOf, { '@id': website['@id'] });
+  }
   const guidePages = pages.filter((page) => page.path.startsWith('/guides/') && page.path !== '/guides/');
   assert.equal(guidePages.length, 5);
   for (const guide of guidePages) {
@@ -105,7 +125,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   }
   const guidesIndex = pages.find((page) => page.path === '/guides/');
   assert.equal(guidesIndex.title, 'Guides for teams working with AI agents | Commonly');
-  assert.equal(guidesIndex.schema['@type'], 'WebPage');
+  assert.equal(guidesIndex.schema['@graph'].find((item) => item['@type'] === 'WebPage').name, 'Guides for teams working with AI agents');
   assert.match(indexHtml, /#seo-page \{[^}]*color: #111827; background: #f8f8fb;/);
   assert.match(indexHtml, /#seo-page \.seo-code \{[^}]*color: #111827; background: #f4f3f8;/);
 });

--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -56,12 +56,21 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.equal(website['@id'], 'https://commonly.me/#website');
   assert.deepEqual(website.publisher, { '@id': organization['@id'] });
   assert.deepEqual(softwareApplication.publisher, { '@id': organization['@id'] });
+  const landingWebPage = pages[0].schema['@graph'].find((item) => item['@type'] === 'WebPage');
+  assert.equal(landingWebPage.name, pages[0].title);
+  assert.equal(landingWebPage.description, pages[0].description);
   for (const page of pages) {
     const graph = page.schema['@graph'] || [page.schema];
     const webPage = graph.find((item) => item['@type'] === 'WebPage');
     assert.deepEqual(webPage.isPartOf, { '@id': website['@id'] });
   }
   const guidePages = pages.filter((page) => page.path.startsWith('/guides/') && page.path !== '/guides/');
+  const refreshedGuidePaths = new Set([
+    '/guides/multi-agent-collaboration-platform/',
+    '/guides/ai-agent-workspace/',
+    '/guides/ai-agent-task-management/',
+    '/guides/connect-claude-codex-shared-workspace/',
+  ]);
   assert.equal(guidePages.length, 5);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
@@ -71,22 +80,25 @@ test('emits a canonical crawlable page for every public route', async () => {
     assert.equal(webPage.reviewedBy['@type'], 'Organization');
     assert.match(article.datePublished, /^2026-08-\d{2}$/);
     assert.match(article.dateModified, /^2026-08-\d{2}$/);
+    if (refreshedGuidePaths.has(guide.path)) {
+      assert.equal(article.dateModified, '2026-08-30');
+    }
   }
   const taskManagementGuide = guidePages.find((page) => page.path === '/guides/ai-agent-task-management/');
   assert.equal(taskManagementGuide.title, 'AI Agent Task Management: Humans + Agents | Commonly');
   const taskManagementArticle = taskManagementGuide.schema['@graph'].find((item) => item['@type'] === 'Article');
   assert.equal(taskManagementArticle.datePublished, '2026-08-25');
-  assert.equal(taskManagementArticle.dateModified, '2026-08-25');
+  assert.equal(taskManagementArticle.dateModified, '2026-08-30');
   const guideTemplate = '<head><!-- SEO_METADATA_START --><!-- SEO_METADATA_END --><!-- SEO_GATE_START --><script>document.documentElement.className += \' js\';</script><!-- SEO_GATE_END --><style>#seo-page { color: #fff; }</style><!-- SEO_NAVIGATION_RUNTIME_START --><script>window.addEventListener(\'popstate\', () => {});</script><!-- SEO_NAVIGATION_RUNTIME_END --><link rel="modulepreload" href="/assets/chunk.js"><script type="module" crossorigin src="/assets/index-abcd.js"></script></head><body><div id="root"><!-- SEO_PAGE_CONTENT --></div></body>';
   const sharedWorkspaceGuide = guidePages.find((page) => page.path === '/guides/connect-claude-codex-shared-workspace/');
   assert.equal(sharedWorkspaceGuide.title, 'Connect Claude Code and Codex to a Shared Workspace | Commonly');
   const sharedWorkspaceArticle = sharedWorkspaceGuide.schema['@graph'].find((item) => item['@type'] === 'Article');
   assert.equal(sharedWorkspaceArticle.datePublished, '2026-08-26');
-  assert.equal(sharedWorkspaceArticle.dateModified, '2026-08-26');
+  assert.equal(sharedWorkspaceArticle.dateModified, '2026-08-30');
   const taskManagementHtml = renderStaticPage(guideTemplate, taskManagementGuide);
   assert.match(taskManagementHtml, /By Commonly · Reviewed by Commonly SEO team/);
   assert.match(taskManagementHtml, /article:published_time" content="2026-08-25"/);
-  assert.match(taskManagementHtml, /article:modified_time" content="2026-08-25"/);
+  assert.match(taskManagementHtml, /article:modified_time" content="2026-08-30"/);
   assert.match(taskManagementHtml, /href="\/guides\/multi-agent-collaboration-platform\/"/);
   assert.match(taskManagementHtml, /href="\/guides\/ai-agent-workspace\/"/);
   assert.doesNotMatch(taskManagementHtml, /document\.documentElement/);

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -9,11 +9,11 @@
       "author": "Commonly",
       "reviewer": "Commonly SEO team",
       "datePublished": "2026-08-24",
-      "dateModified": "2026-08-25"
+      "dateModified": "2026-08-30"
     },
     "intro": [
-      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, helps ensure that using more than one AI agent does not turn a project into a relay race where a human repeats the same context in every tool. A multi-agent collaboration platform gives people and agents a durable team workspace, a visible task list, persistent context, and clear ways to hand work from one participant to another.",
-      "Commonly is an open-source, self-hostable workspace for that kind of work. You can bring agents from different runtimes—such as Claude Code, Codex, Cursor, OpenClaw, a local CLI, or a custom HTTP service—into the same workspace. Each agent keeps an identity, scoped access, memory, and a place in the team rather than appearing as a disposable subtask.",
+      "Using more than one AI agent should not turn a project into a relay race where a human repeats the same context in every tool. A multi-agent collaboration platform gives people and agents a shared place to work: a durable team workspace, a visible task list, persistent context, and clear ways to hand work from one participant to another.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, is open-source and self-hostable, built for that kind of work. You can bring agents from different runtimes—such as Claude Code, Codex, Cursor, OpenClaw, a local CLI, or a custom HTTP service—into the same workspace. Each agent keeps an identity, scoped access, memory, and a place in the team rather than appearing as a disposable subtask.",
       "The useful question is not how many agents can I run? It is whether a person and several specialized agents can make a decision, divide the work, preserve the context, and see the result without recreating the project brief at every handoff."
     ],
     "sections": [
@@ -195,12 +195,12 @@
       "author": "Commonly",
       "reviewer": "Commonly SEO team",
       "datePublished": "2026-08-24",
-      "dateModified": "2026-08-25"
+      "dateModified": "2026-08-30"
     },
     "intro": [
-      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, is an AI agent workspace where people keep the context, decisions, tasks, and artifacts for a project. It turns an agent interaction from a one-off chat into work a team can continue, inspect, and hand off.",
-      "Agent workspace can describe a customer-service desktop, a local sandbox, or a terminal control plane. In this guide, it means a team project workspace: a place where humans and agents work from the same project record while each agent retains its own identity and runtime.",
-      "Commonly is an open-source, self-hostable AI agent workspace built for that model. Bring an agent from Claude Code, Codex, Cursor, OpenClaw, a local CLI, or a custom HTTP service into a shared pod. The agent can participate as a named teammate with its own memory, scoped access, and task work without requiring every participant to run through the same agent framework."
+      "An AI agent workspace is the shared environment where people and AI agents keep the context, decisions, tasks, and artifacts for a project. It turns an agent interaction from a one-off chat into work a team can continue, inspect, and hand off.",
+      "Agent workspace can describe a customer-service desktop, a local sandbox, or a terminal control plane. In this guide, it means a team project workspace: a place where humans and agents work from the same project record while each agent retains its own identity and runtime. Commonly (commonly.me), the shared workspace where humans and AI agents work together, is open-source and self-hostable, built for that model.",
+      "Bring an agent from Claude Code, Codex, Cursor, OpenClaw, a local CLI, or a custom HTTP service into a shared pod. The agent can participate as a named teammate with its own memory, scoped access, and task work without requiring every participant to run through the same agent framework."
     ],
     "sections": [
       {
@@ -344,12 +344,12 @@
       "author": "Commonly",
       "reviewer": "Commonly SEO team",
       "datePublished": "2026-08-25",
-      "dateModified": "2026-08-25"
+      "dateModified": "2026-08-30"
     },
     "intro": [
-      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, provides a practical system for AI agent task management: giving agents and people a shared, durable record of what needs doing, who owns it, what is blocked, what changed, and what result is ready for review.",
+      "AI agent task management is the discipline of giving agents and people a shared, durable record of work: what needs doing, who owns it, what is blocked, what changed, and what result is ready for review.",
       "It is not asking an assistant to turn a paragraph into a to-do list. A to-do list is useful for one person. Agent task management becomes necessary when the work crosses sessions, tools, people, or agents. Without it, important project state ends up split across terminal sessions, private chats, pull requests, and somebody’s memory.",
-      "Commonly gives human and agent teams a shared pod with a task list, persistent context, threads, and named participants. An agent can connect through MCP, a local CLI wrapper, or plain HTTP, then take part in the same project record as the people responsible for the outcome."
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, gives human and agent teams a shared pod with a task list, persistent context, threads, and named participants. An agent can connect through MCP, a local CLI wrapper, or plain HTTP, then take part in the same project record as the people responsible for the outcome."
     ],
     "sections": [
       {
@@ -531,11 +531,11 @@
       "author": "Commonly",
       "reviewer": "Commonly SEO team",
       "datePublished": "2026-08-26",
-      "dateModified": "2026-08-26"
+      "dateModified": "2026-08-30"
     },
     "intro": [
-      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, gives Claude Code and Codex a durable project record when they work on the same project. Each runtime still has its own session. A git repository holds code, but it does not necessarily hold the current task owner, a research finding, or the reason a team chose one approach over another.",
-      "A shared workspace solves the coordination part of that problem. In Commonly, you connect each runtime to the same pod: a workspace with a project conversation, threads, a task list, persistent shared memory, and human and agent members. Claude Code and Codex keep running where they already run. Both can read and contribute to the same project record through MCP.",
+      "Claude Code and Codex can both work on the same project, but they do not automatically share a durable record of what they learned, decided, or handed off. Each runtime has its own session. A git repository holds code, but it does not necessarily hold the current task owner, a research finding, or the reason a team chose one approach over another.",
+      "A shared workspace solves the coordination part of that problem. Commonly (commonly.me), the shared workspace where humans and AI agents work together, connects each runtime to the same pod: a workspace with a project conversation, threads, a task list, persistent shared memory, and human and agent members. Claude Code and Codex keep running where they already run. Both can read and contribute to the same project record through MCP.",
       "This guide shows how to set that up safely, verify that it works, and use it for a handoff without pretending that two agents now share one chat history."
     ],
     "sections": [

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -12,7 +12,7 @@
       "dateModified": "2026-08-25"
     },
     "intro": [
-      "Using more than one AI agent should not turn a project into a relay race where a human repeats the same context in every tool. A multi-agent collaboration platform gives people and agents a shared place to work: a durable team workspace, a visible task list, persistent context, and clear ways to hand work from one participant to another.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, helps ensure that using more than one AI agent does not turn a project into a relay race where a human repeats the same context in every tool. A multi-agent collaboration platform gives people and agents a durable team workspace, a visible task list, persistent context, and clear ways to hand work from one participant to another.",
       "Commonly is an open-source, self-hostable workspace for that kind of work. You can bring agents from different runtimes—such as Claude Code, Codex, Cursor, OpenClaw, a local CLI, or a custom HTTP service—into the same workspace. Each agent keeps an identity, scoped access, memory, and a place in the team rather than appearing as a disposable subtask.",
       "The useful question is not how many agents can I run? It is whether a person and several specialized agents can make a decision, divide the work, preserve the context, and see the result without recreating the project brief at every handoff."
     ],
@@ -198,7 +198,7 @@
       "dateModified": "2026-08-25"
     },
     "intro": [
-      "An AI agent workspace is the shared environment where people and AI agents keep the context, decisions, tasks, and artifacts for a project. It turns an agent interaction from a one-off chat into work a team can continue, inspect, and hand off.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, is an AI agent workspace where people keep the context, decisions, tasks, and artifacts for a project. It turns an agent interaction from a one-off chat into work a team can continue, inspect, and hand off.",
       "Agent workspace can describe a customer-service desktop, a local sandbox, or a terminal control plane. In this guide, it means a team project workspace: a place where humans and agents work from the same project record while each agent retains its own identity and runtime.",
       "Commonly is an open-source, self-hostable AI agent workspace built for that model. Bring an agent from Claude Code, Codex, Cursor, OpenClaw, a local CLI, or a custom HTTP service into a shared pod. The agent can participate as a named teammate with its own memory, scoped access, and task work without requiring every participant to run through the same agent framework."
     ],
@@ -347,7 +347,7 @@
       "dateModified": "2026-08-25"
     },
     "intro": [
-      "AI agent task management is the discipline of giving agents and people a shared, durable record of work: what needs doing, who owns it, what is blocked, what changed, and what result is ready for review.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, provides a practical system for AI agent task management: giving agents and people a shared, durable record of what needs doing, who owns it, what is blocked, what changed, and what result is ready for review.",
       "It is not asking an assistant to turn a paragraph into a to-do list. A to-do list is useful for one person. Agent task management becomes necessary when the work crosses sessions, tools, people, or agents. Without it, important project state ends up split across terminal sessions, private chats, pull requests, and somebody’s memory.",
       "Commonly gives human and agent teams a shared pod with a task list, persistent context, threads, and named participants. An agent can connect through MCP, a local CLI wrapper, or plain HTTP, then take part in the same project record as the people responsible for the outcome."
     ],
@@ -534,7 +534,7 @@
       "dateModified": "2026-08-26"
     },
     "intro": [
-      "Claude Code and Codex can both work on the same project, but they do not automatically share a durable record of what they learned, decided, or handed off. Each runtime has its own session. A git repository holds code, but it does not necessarily hold the current task owner, a research finding, or the reason a team chose one approach over another.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, gives Claude Code and Codex a durable project record when they work on the same project. Each runtime still has its own session. A git repository holds code, but it does not necessarily hold the current task owner, a research finding, or the reason a team chose one approach over another.",
       "A shared workspace solves the coordination part of that problem. In Commonly, you connect each runtime to the same pod: a workspace with a project conversation, threads, a task list, persistent shared memory, and human and agent members. Claude Code and Codex keep running where they already run. Both can read and contribute to the same project record through MCP.",
       "This guide shows how to set that up safely, verify that it works, and use it for a handoff without pretending that two agents now share one chat history."
     ],

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -467,7 +467,7 @@
       "ariaLabel": "Chat with your Claude Code, Cursor, Codex — your whole team.",
       "titlePrefix": "Chat with your",
       "titleSuffix": "",
-      "lede": "Commonly (commonly.me) is the shared workspace where humans and AI agents work together: each agent keeps its own memory and workstation while the team shares one room for handoffs. Open source, any runtime, your infra, no per-agent fees.",
+      "lede": "Get real work done with a team of AI agents — each with its own memory and workstation, all in one room where they hand off instead of making you re-explain. Open source, any runtime, your infra, no per-agent fees.",
       "selfHostInstall": "Self-host install",
       "builtBy": "Built in the open by",
       "demoAria": "Demo: Sam and three agents spec, build, and review a signup flow together in a Commonly pod",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -467,7 +467,7 @@
       "ariaLabel": "Chat with your Claude Code, Cursor, Codex — your whole team.",
       "titlePrefix": "Chat with your",
       "titleSuffix": "",
-      "lede": "Get real work done with a team of AI agents — each with its own memory and workstation, all in one room where they hand off instead of making you re-explain. Open source, any runtime, your infra, no per-agent fees.",
+      "lede": "Commonly (commonly.me) is the shared workspace where humans and AI agents work together: each agent keeps its own memory and workstation while the team shares one room for handoffs. Open source, any runtime, your infra, no per-agent fees.",
       "selfHostInstall": "Self-host install",
       "builtBy": "Built in the open by",
       "demoAria": "Demo: Sam and three agents spec, build, and review a signup flow together in a Commonly pod",


### PR DESCRIPTION
## Summary
- define stable Organization and WebSite entities with verified GitHub, npm, and Discord references
- make every static public page reference the shared WebSite entity and give the software entity the same publisher
- introduce Commonly by its entity phrase on the landing page and all four existing guides

## Validation
- node --test scripts/generate-seo-pages.test.mjs
- npm run typecheck
- npm run build
- generated schema verified in home, guide, and compare artifacts