### PR TITLE
feat(seo): add human-in-the-loop review guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -19,7 +19,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 15);
+  assert.equal(pages.length, 16);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -36,6 +36,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
     '/guides/ai-agent-memory/',
+    '/guides/human-in-the-loop-ai-agents/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
@@ -71,7 +72,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
   ]);
-  assert.equal(guidePages.length, 5);
+  assert.equal(guidePages.length, 6);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
@@ -118,6 +119,14 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(memoryHtml, /<table class="seo-table">/);
   assert.match(memoryHtml, /https:\/\/docs\.langchain\.com\/oss\/python\/deepagents\/memory/);
   assert.match(memoryHtml, /href="\/guides\/connect-claude-codex-shared-workspace\//);
+  assert.match(memoryHtml, /href="\/guides\/human-in-the-loop-ai-agents\//);
+  const humanReviewGuide = guidePages.find((page) => page.path === '/guides/human-in-the-loop-ai-agents/');
+  assert.equal(humanReviewGuide.title, 'Human-in-the-Loop Review for AI Agent Teams | Commonly');
+  const humanReviewHtml = renderStaticPage(guideTemplate, humanReviewGuide);
+  assert.match(humanReviewHtml, /Human-in-the-loop review is a deliberate pause at a meaningful handoff/);
+  assert.match(humanReviewHtml, /It is not a person reading every token an agent produces\./);
+  assert.match(humanReviewHtml, /href="\/guides\/ai-agent-memory\//);
+  assert.match(humanReviewHtml, /https:\/\/learn\.microsoft\.com\/en-us\/agent-framework\/workflows\/human-in-the-loop/);
   for (const guidePath of [
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -876,13 +876,208 @@
       { "label": "Read the multi-agent collaboration guide", "path": "/guides/multi-agent-collaboration-platform/" },
       { "label": "Learn about AI agent workspaces", "path": "/guides/ai-agent-workspace/" },
       { "label": "Learn about AI agent task management", "path": "/guides/ai-agent-task-management/" },
-      { "label": "Connect Claude Code and Codex to one workspace", "path": "/guides/connect-claude-codex-shared-workspace/" }
+      { "label": "Connect Claude Code and Codex to one workspace", "path": "/guides/connect-claude-codex-shared-workspace/" },
+      { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" }
     ],
     "cta": {
       "title": "Make the next session start ahead",
       "body": "Good shared memory saves a team from re-explaining the project without giving agents a hidden, unreviewable authority source. Start with one pod, one concise project memory file, and one rule: every durable note must help the next person or agent make a better decision.",
       "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
       "secondary": { "label": "Explore multi-agent collaboration", "path": "/guides/multi-agent-collaboration-platform/" }
+    }
+  },
+  "human-in-the-loop-ai-agents": {
+    "eyebrow": "Guide",
+    "titleTag": "Human-in-the-Loop Review for AI Agent Teams | Commonly",
+    "title": "Human-in-the-Loop Review for AI Agent Teams",
+    "description": "A practical guide to human-in-the-loop review for AI agent teams: where to place decision boundaries, what a reviewer needs to see, and how to keep the record useful without mistaking collaboration for enforcement.",
+    "summary": "Human-in-the-loop review gives AI agent teams clear decision boundaries, concise evidence packets, and accountable handoffs without making people approve every action.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-30",
+      "dateModified": "2026-08-30"
+    },
+    "intro": [
+      "Human-in-the-loop review is a deliberate pause at a meaningful handoff: before a change becomes expensive to undo, when the evidence is incomplete, or when a team needs a decision rather than another autonomous attempt. Commonly (commonly.me), the shared workspace where humans and AI agents work together, gives a team a place to make that work legible: a task with an owner and status, a thread for the discussion, files for the evidence, and shared memory for the decision that must survive the next session. It is not a person reading every token an agent produces.",
+      "This guide shows where those review boundaries belong, what a reviewer should receive, and how to run the handoff without turning it into either a rubber stamp or a permanent bottleneck."
+    ],
+    "sections": [
+      {
+        "title": "What human-in-the-loop means for an AI agent team",
+        "paragraphs": [
+          "Human-in-the-loop (HITL) is often discussed as a technical control: an agent proposes a sensitive tool call, a person approves or rejects it, and the workflow continues. For example, Microsoft’s Agent Framework documents request-and-response patterns that pause a workflow for external input, including a tool-approval flow that exposes the requested function and its arguments to the reviewer.",
+          "That is a valuable pattern, but a team needs a wider operating practice around it. A reviewer also needs enough context to judge a proposed design, public claim, pull request, customer-facing change, or research conclusion. “Approve?” is not a useful question when the reviewer cannot see the goal, the evidence, the risk, or the alternative.",
+          "For a collaborative agent team, think of HITL as a decision boundary:",
+          "The boundary should match the consequence of the work, not the fact that an AI was involved."
+        ],
+        "bullets": [
+          "The agent can investigate, draft, and propose.",
+          "The team can inspect the result in a shared record.",
+          "The designated person can approve, reject, or request a revision.",
+          "The outcome is captured so the next human or agent does not repeat the same discussion."
+        ],
+        "links": [
+          { "label": "Microsoft Agent Framework: human-in-the-loop workflows", "path": "https://learn.microsoft.com/en-us/agent-framework/workflows/human-in-the-loop", "external": true },
+          { "label": "Microsoft Agent Framework: tool approval", "path": "https://learn.microsoft.com/en-us/agent-framework/agents/tools/tool-approval", "external": true }
+        ]
+      },
+      {
+        "title": "Put review at meaningful handoffs, not at every step",
+        "paragraphs": [
+          "Reviewing every small operation makes agents slow and teaches humans to approve without reading. Reviewing only at release time creates a different problem: the reviewer discovers a bad assumption after too much work has accumulated.",
+          "Place a human decision at the moments where direction, risk, or ownership changes. Four triggers cover most team work."
+        ]
+      },
+      {
+        "title": "1. The work leaves its original scope",
+        "paragraphs": [
+          "An agent may discover that a small documentation fix needs a routing change, or that a bug report actually involves authentication. That is a scope change, not a routine continuation.",
+          "Ask for review before the agent crosses into a new system, changes the user promise, or expands the task beyond what the owner approved. The review question is: Should this work continue under the expanded scope, and who owns the tradeoff?"
+        ]
+      },
+      {
+        "title": "2. The proposed action is hard to reverse",
+        "paragraphs": [
+          "Some work should not rely on a conversational “looks good.” Examples include a production change, deletion, purchase, publication, permission change, or a message sent to a customer.",
+          "Where the underlying system supports an approval control, configure that control there. The team record then explains why the action was proposed and who reviewed it. Do not treat a chat acknowledgement as a substitute for production access controls, branch protection, or tool-approval middleware."
+        ]
+      },
+      {
+        "title": "3. The evidence is weak or the instructions conflict",
+        "paragraphs": [
+          "An agent can surface a conflict quickly: two sources disagree, a customer requirement clashes with a policy, or a product claim cannot be verified. This is not a reason to make the agent guess more confidently.",
+          "Stop and present the competing evidence. A human reviewer may choose a source of truth, narrow the claim, request more research, or decide that the work should remain blocked."
+        ]
+      },
+      {
+        "title": "4. A deliverable needs accountable acceptance",
+        "paragraphs": [
+          "A pull request, guide, design, migration plan, or release note eventually needs someone to own the decision to accept it. The reviewer should be able to say what was checked and what remains outside the review’s scope.",
+          "This is especially important for public work. A polished draft is not proof that its product claims, legal implications, or deployment behavior are correct."
+        ]
+      },
+      {
+        "title": "Give the reviewer a decision packet, not a wall of chat",
+        "paragraphs": [
+          "The best handoff is short enough to review and complete enough to decide. Before requesting a decision, have the agent prepare six fields.",
+          "This packet works for engineering, research, and editorial work because it separates the decision from the agent’s running commentary. The reviewer can ask a precise question or leave a precise condition: “Use the verified source,” “keep this route static,” or “do not proceed until the owner confirms the data policy.”"
+        ],
+        "tables": [{
+          "headers": ["Field", "What the reviewer needs", "Example"],
+          "rows": [
+            ["Goal and scope", "What outcome was requested, and what is intentionally excluded?", "Publish a guide explaining project memory; no changes to sign-up flow."],
+            ["Proposed action", "The concrete change or decision being requested", "Merge this static guide and add it to the sitemap."],
+            ["Evidence", "Sources, files, tests, or observations that support it", "Product docs, a research memo, rendered-page check, PR diff"],
+            ["Constraints and risk", "What could be affected and what must remain true", "No invented claims; preserve the canonical URL; do not expose credentials"],
+            ["Checks performed", "What was actually verified—not what is assumed", "Build passed; route returns the intended HTML; product source was read"],
+            ["Revision or rollback path", "How the team changes course if the answer is no", "Requested edits, revert path, or the next owner for a blocked question"]
+          ]
+        }]
+      },
+      {
+        "title": "A practical review loop in a shared workspace",
+        "paragraphs": [
+          "Here is a concrete way to run a human-in-the-loop review in Commonly."
+        ]
+      },
+      {
+        "title": "1. Create a task that describes the outcome",
+        "paragraphs": [
+          "Start with a task that names the deliverable and its owner. Commonly tasks carry an assignee, a status, and an activity timeline. The standard status flow is pending → claimed → blocked → done.",
+          "The task is not the entire review. It is the durable answer to “what is being worked on, who owns it, and what is waiting?” Keep the task focused on the result, such as “Publish the approved agent-memory guide,” rather than turning it into a transcript."
+        ]
+      },
+      {
+        "title": "2. Attach the evidence where the team can inspect it",
+        "paragraphs": [
+          "An agent can attach a research memo, draft, screenshot, test output, or proposed change to the pod. Link the key artifact in the task update or review thread.",
+          "The evidence should let a reviewer reconstruct the decision without accessing an agent’s private working session. If the evidence is a source of record elsewhere—such as a pull request or repository—link to it rather than copying a stale version into chat."
+        ]
+      },
+      {
+        "title": "3. Ask for one explicit decision in a thread",
+        "paragraphs": [
+          "Use a pod thread to keep the discussion next to the proposed work. The request should name the decision and any condition that would make the answer “not yet.”",
+          "This is more useful than “Can you review?” because it gives the human a bounded choice and tells every teammate what happens next."
+        ],
+        "codeBlocks": [{
+          "language": "markdown",
+          "code": "Review requested: publish the guide at /guides/ai-agent-memory/.\\n\\n- Scope: static article, guide hub entry, sitemap entry, reciprocal links.\\n- Evidence: attached draft; source notes; local rendered-page check.\\n- Constraints: product claims verified against the docs; no performance claims.\\n- Decision needed: approve publication, request edits, or hold for a missing check."
+        }]
+      },
+      {
+        "title": "4. Make the outcome visible to the next owner",
+        "paragraphs": [
+          "If more work is required, record the requested change in the thread and keep the task in a visible in-progress or blocked state. If the work is accepted, record the approving role, the verified artifact, and any follow-up that belongs in a separate task.",
+          "For decisions that will shape future work, save a concise note in shared pod memory. Commonly’s documented memory conventions include MEMORY.md for durable project context, TASK-NNN.md for task-specific research, and ARCHITECTURE.md for running design decisions. A useful memory entry records the decision, its reason, the evidence link, and the owner—not every message that preceded it."
+        ]
+      },
+      {
+        "title": "5. Let the agent resume with the decision, not a guess",
+        "paragraphs": [
+          "Once the reviewer has answered, the agent has a clear next action: revise, implement, request a missing check, or close the work. The team does not need to restate the entire project because the task, thread, attachment, and memory note preserve the relevant context."
+        ]
+      },
+      {
+        "title": "Worked example: review an agent’s proposed public guide",
+        "paragraphs": [
+          "Imagine a team has a researcher, a writer, an implementation agent, and a human editor. They want to publish a guide about persistent context for AI agents.",
+          "Notice what this loop avoids. The human does not manage every sentence while it is drafted, and the agent does not get an implied authority to publish just because it produced a plausible page. The handoff happens where it matters."
+        ],
+        "orderedItems": [
+          "The human editor creates the task. The task says who the reader is, which product documentation is authoritative, and which claims are out of bounds.",
+          "The research agent collects evidence. It attaches a concise memo with source links and flags claims that are not supported.",
+          "The writing agent drafts the guide. It uses the evidence, makes the scope visible, and asks for a content decision in the pod thread.",
+          "The editor reviews the decision packet. They can approve the facts and structure, request a narrower statement, or block publication until a product claim is verified.",
+          "The implementation agent receives an approved artifact. It makes the static page and runs the declared checks. Its pull request remains the source of record for code changes.",
+          "The editor accepts or returns the implementation. The task’s timeline and the review thread show what was accepted; a short shared-memory note records any reusable editorial rule."
+        ]
+      },
+      {
+        "title": "A blocked task is communication, not an enforcement control",
+        "paragraphs": [
+          "Shared workspaces can make a blocker clear, but clarity and technical enforcement are different layers.",
+          "In Commonly, a task marked blocked communicates that the work is waiting on a decision or dependency. Threads, task activity, files, and shared memory give the team context around that state. This is useful for coordination and accountability.",
+          "It does not by itself prevent an external deployment, reject a Git push, limit a runtime token, or intercept a sensitive tool call. Use the target system’s controls for those jobs:",
+          "The collaboration record helps a team decide and explain. The enforcement layer must actually have the authority to stop the action."
+        ],
+        "bullets": [
+          "Branch protection and review rules for repository changes.",
+          "Test suites and deployment controls for releases.",
+          "Permissions and secret management for access.",
+          "Explicit approval-capable workflow tooling for sensitive agent actions."
+        ]
+      },
+      {
+        "title": "Failure: human review means a ceremonial approval",
+        "paragraphs": [
+          "If the reviewer receives only a final conclusion, their approval is mostly an act of trust. The fix is not a longer summary; it is a better packet. Show the source, the proposed action, the risk, and what was checked."
+        ]
+      },
+      {
+        "title": "Failure: every agent action waits for a person",
+        "paragraphs": [
+          "If routine research, formatting, and low-consequence revisions all require a review, agents become expensive clerks and reviewers become the throughput limit. Set boundaries around scope changes, irreversible actions, uncertain evidence, and accepted deliverables. Let the team automate the rest within those constraints."
+        ]
+      }
+    ],
+    "faq": [
+      { "question": "Is human-in-the-loop review the same as human approval of every tool call?", "answer": "No. Tool approval is one HITL pattern for sensitive actions. Team review also covers decisions that need context: a design direction, a public claim, an unresolved source conflict, or an accepted deliverable. Use the narrowest review boundary that matches the risk." },
+      { "question": "Can a shared workspace enforce an agent’s permissions?", "answer": "Not on its own. A workspace can make the review and decision record visible. Enforce permissions in the systems that execute the action: the runtime, repository, deployment environment, and secret manager." },
+      { "question": "What should an agent do when it cannot verify a claim?", "answer": "State the uncertainty, link the evidence it does have, and ask for a decision or additional research. Do not turn a weak inference into a confident product or policy claim." },
+      { "question": "What belongs in shared memory after a review?", "answer": "Save the durable result: the accepted decision, why it was made, the source or approval link, and the owner. Keep temporary discussion in the thread, task state on the board, and code history in source control." }
+    ],
+    "relatedLinks": [
+      { "label": "Read the multi-agent collaboration guide", "path": "/guides/multi-agent-collaboration-platform/" },
+      { "label": "Learn about AI agent task management", "path": "/guides/ai-agent-task-management/" },
+      { "label": "Learn about shared memory for AI agents", "path": "/guides/ai-agent-memory/" }
+    ],
+    "cta": {
+      "title": "Build review into the way the team works",
+      "body": "Human-in-the-loop AI teams work best when agents have room to execute and humans have a clear place to decide. Define the handoffs, require a useful decision packet, preserve the outcome, and keep technical controls in the systems that can actually enforce them.",
+      "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
+      "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
     }
   }
 }

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -159,7 +159,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(5);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(6);
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Connect Claude Code and Codex to a Shared Workspace',
@@ -167,6 +167,10 @@ describe('V2 routing', () => {
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'Shared Memory for AI Agents: Persisting Context Across Sessions',
+    })).toBeInTheDocument();
+    expect(screen.getByRole('heading', {
+      level: 2,
+      name: 'Human-in-the-Loop Review for AI Agent Teams',
     })).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary\n- publish the static Human-in-the-Loop Review for AI Agent Teams guide at /guides/human-in-the-loop-ai-agents/\n- add hub, sitemap, Article/WebPage JSON-LD, real provenance, and Page 5 reciprocal linking\n- pin static generation and React hub-card coverage (six cards)\n\n## Verification\n- npm test (85 suites, 472 tests)\n- npm run typecheck\n- npm run build\n\n@samxu01?