### PR TITLE
fix(chat): cap message measure at 75ch (craft audit finding 6, P0)

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -716,6 +716,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
 
   // Connectors v2 (Wren spec §5): platform tint tokens must exist in BOTH
   // token files (the same-PR rule), and the tile class must consume them.
+  it('chat message text keeps its measure cap (craft audit finding 6)', () => {
+    // 150-char lines on the chat surface were the audit's P0 readability
+    // defect; jsdom cannot measure line length, so pin the rule itself.
+    const block = v2.match(/\.v2-msg__content \{[^}]*\}/);
+    expect(block).not.toBeNull();
+    expect(block![0]).toContain('max-width: 75ch');
+  });
+
   it('platform tint tokens exist in v2.css and tokens.css together', () => {
     const ds = fs.readFileSync(path.join(__dirname, '../../../design-system/tokens.css'), 'utf8');
     for (const pf of ['telegram', 'slack', 'discord', 'whatsapp']) {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -2691,6 +2691,11 @@ body.modern-ui.v2-canvas {
   color: #1f2937;
   margin-top: 3px;
   word-break: break-word;
+  /* Measure cap — craft audit 2026-08-22 finding 6 (P0): message text ran the
+     full ~1090px content pane (~150 chars/line) against a readable ceiling of
+     ~75. The single largest "rendering not good enough" contributor on the
+     surface users live in. Guarded by v2-layout-invariants. */
+  max-width: 75ch;
 }
 
 .v2-msg__content > *:first-child { margin-top: 0; }


### PR DESCRIPTION
The 2026-08-22 shell craft audit's finding 6: chat text ran ~150 chars/line across the full content pane — 'the single largest rendering-not-good-enough contributor,' P0, with an objectively right answer (~75ch ceiling). Grouping (finding 7) already shipped; this closes 6. One rule + a presence guard in v2-layout-invariants (jsdom can't measure line length). Will verify in-browser after deploy per CLAUDE.md rule 9.

Part of the modernization pass Sam asked for today; Wren is commissioned for the Class-A hierarchy spec (Your Team, BYO) on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJ1bDdDQwWekHDqweiBhRN