### PR TITLE
feat(byo): cloud-vs-BYO page — decision about a teammate, not a form

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1360,7 +1360,8 @@
       "meter": "Beta limits: {{turns}} turns a day, one hosted agent per account.",
       "statTurns": "turns / day",
       "statAgents": "hosted agent",
-      "statLatency": "typical reply"
+      "statLatency": "typical reply",
+      "statLatencyValue": "~10s"
     },
     "preview": {
       "title": "Your agent",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1345,7 +1345,11 @@
       "hosted": "Run it here",
       "hostedHint": "Commonly runs it for you. Nothing to install. Beta: {{turns}} turns a day.",
       "byo": "Bring your own runtime",
-      "byoHint": "Connect Claude Code, Cursor, or Codex from your machine."
+      "byoHint": "Connect Claude Code, Cursor, or Codex from your machine.",
+      "recommended": "RECOMMENDED",
+      "yours": "YOUR MACHINE",
+      "hostedMeta": "Live in ~10 seconds — no terminal, no keys",
+      "byoMeta": "MCP token + snippets for your editor"
     },
     "hosted": {
       "heading": "Running:",
@@ -1353,7 +1357,19 @@
       "starting": "Starting {{name}}…",
       "running": "✓ {{name}} is listening.",
       "slow": "{{name}} hasn't checked in yet. Mention it anyway; it picks up messages when it starts.",
-      "meter": "Beta limits: {{turns}} turns a day, one hosted agent per account."
+      "meter": "Beta limits: {{turns}} turns a day, one hosted agent per account.",
+      "statTurns": "turns / day",
+      "statAgents": "hosted agent",
+      "statLatency": "typical reply"
+    },
+    "preview": {
+      "title": "Your agent",
+      "inPod": "in {{pod}}",
+      "draft": "Not created yet",
+      "starting": "Starting…",
+      "live": "Listening",
+      "noteHosted": "This is how it will appear in the pod. The face follows the name.",
+      "noteByo": "Appears in the pod once your runtime connects with the token."
     }
   },
   "agentProfile": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1354,7 +1354,8 @@
       "meter": "测试期限制：每天 {{turns}} 轮，每个账号一个托管智能体。",
       "statTurns": "轮 / 天",
       "statAgents": "托管智能体",
-      "statLatency": "典型响应"
+      "statLatency": "典型响应",
+      "statLatencyValue": "约 10 秒"
     },
     "preview": {
       "title": "你的智能体",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1339,7 +1339,11 @@
       "hosted": "在这里运行",
       "hostedHint": "由 Commonly 代为运行，无需安装。测试期：每天 {{turns}} 轮。",
       "byo": "自带运行时",
-      "byoHint": "从你的电脑连接 Claude Code、Cursor 或 Codex。"
+      "byoHint": "从你的电脑连接 Claude Code、Cursor 或 Codex。",
+      "recommended": "推荐",
+      "yours": "你的电脑",
+      "hostedMeta": "约 10 秒上线——无需终端与密钥",
+      "byoMeta": "MCP 令牌 + 编辑器代码片段"
     },
     "hosted": {
       "heading": "运行中：",
@@ -1347,7 +1351,19 @@
       "starting": "正在启动 {{name}}…",
       "running": "✓ {{name}} 已在监听。",
       "slow": "{{name}} 尚未签到。可以先 @ 它，启动后会处理消息。",
-      "meter": "测试期限制：每天 {{turns}} 轮，每个账号一个托管智能体。"
+      "meter": "测试期限制：每天 {{turns}} 轮，每个账号一个托管智能体。",
+      "statTurns": "轮 / 天",
+      "statAgents": "托管智能体",
+      "statLatency": "典型响应"
+    },
+    "preview": {
+      "title": "你的智能体",
+      "inPod": "位于 {{pod}}",
+      "draft": "尚未创建",
+      "starting": "正在启动…",
+      "live": "监听中",
+      "noteHosted": "这就是它在 Pod 中的样子。头像跟随名字生成。",
+      "noteByo": "你的运行时使用令牌连接后即会出现在 Pod 中。"
     }
   },
   "agentProfile": {

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -19,6 +19,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import axios from '../../utils/axiosConfig';
 import V2FeaturePage from './V2FeaturePage';
+import V2Avatar from './V2Avatar';
 import { useV2Api } from '../hooks/useV2Api';
 import { useAuth } from '../../context/AuthContext';
 import { V2Pod } from '../hooks/useV2Pods';
@@ -189,6 +190,17 @@ const V2AgentBYO: React.FC = () => {
     })();
     return () => { cancelled = true; };
   }, [api, podId, currentUser?._id]);
+
+  // Live preview rail — you see the agent you are about to create. The
+  // avatar is the same character render the pod will show (seeded by
+  // name:instanceId, so the preview face IS the final face), which is what
+  // turns this page from a form into a decision about a teammate.
+  const previewName = sanitizeAgentName(name) || DEFAULT_AGENT_NAME;
+  const previewPodName = pods.find((p) => p._id === (hosted?.podId || issued?.podId || podId))?.name || '';
+  const previewStatus: 'draft' | 'starting' | 'live' = hosted
+    ? (hostedState === 'running' ? 'live' : 'starting')
+    : (issued && listenState === 'listening' ? 'live' : 'draft');
+  const previewDisplayName = hosted?.agentName || issued?.agentName || previewName;
 
   // Hosted path: install with runtimeType 'hosted' (the kernel's cap gate
   // answers 403 hosted_cap_reached), then ask the kernel to provision. No
@@ -435,6 +447,8 @@ const V2AgentBYO: React.FC = () => {
       description={t('agentByo.description')}
       showPodsSidebar={false}
     >
+      <div className="v2-byo__layout">
+      <div className="v2-byo__main">
       {!issued && !hosted && (
         <div className="v2-byo__form">
           {hosting?.configured && (
@@ -446,8 +460,10 @@ const V2AgentBYO: React.FC = () => {
                 onClick={() => setMode('hosted')}
                 data-testid="byo-mode-hosted"
               >
+                <span className="v2-byo__mode-kicker">{t('agentByo.mode.recommended')}</span>
                 <span className="v2-byo__mode-title">{t('agentByo.mode.hosted')}</span>
                 <span className="v2-byo__hint">{t('agentByo.mode.hostedHint', { turns: hosting.caps.turnsPerDay })}</span>
+                <span className="v2-byo__mode-meta">{t('agentByo.mode.hostedMeta')}</span>
               </button>
               <button
                 type="button"
@@ -456,8 +472,10 @@ const V2AgentBYO: React.FC = () => {
                 onClick={() => setMode('byo')}
                 data-testid="byo-mode-byo"
               >
+                <span className="v2-byo__mode-kicker v2-byo__mode-kicker--quiet">{t('agentByo.mode.yours')}</span>
                 <span className="v2-byo__mode-title">{t('agentByo.mode.byo')}</span>
                 <span className="v2-byo__hint">{t('agentByo.mode.byoHint')}</span>
+                <span className="v2-byo__mode-meta">{t('agentByo.mode.byoMeta')}</span>
               </button>
             </div>
           )}
@@ -514,7 +532,10 @@ const V2AgentBYO: React.FC = () => {
 
       {hosted && (
         <div className="v2-byo__result" data-testid="byo-hosted-result">
-          <h2>{t('agentByo.hosted.heading')} <code>{hosted.agentName}</code></h2>
+          <div className="v2-byo__result-hero">
+            <V2Avatar name={hosted.agentName} size="lg" kind="agent" seed={`${hosted.agentName}:default`} online={hostedState === 'running'} />
+            <h2>{t('agentByo.hosted.heading')} <code>{hosted.agentName}</code></h2>
+          </div>
           <p>
             {t('agentByo.hosted.live', {
               name: hosted.agentName,
@@ -527,7 +548,20 @@ const V2AgentBYO: React.FC = () => {
           >
             {t(`agentByo.hosted.${hostedState}`, { name: hosted.agentName })}
           </p>
-          <p className="v2-byo__hint">{t('agentByo.hosted.meter', { turns: hosting?.caps.turnsPerDay ?? 0 })}</p>
+          <div className="v2-byo__stats">
+            <div className="v2-byo__stat">
+              <span className="v2-byo__stat-value">{hosting?.caps.turnsPerDay ?? 0}</span>
+              <span className="v2-byo__stat-label">{t('agentByo.hosted.statTurns')}</span>
+            </div>
+            <div className="v2-byo__stat">
+              <span className="v2-byo__stat-value">{hosting?.caps.agentsPerUser ?? 1}</span>
+              <span className="v2-byo__stat-label">{t('agentByo.hosted.statAgents')}</span>
+            </div>
+            <div className="v2-byo__stat">
+              <span className="v2-byo__stat-value">~10s</span>
+              <span className="v2-byo__stat-label">{t('agentByo.hosted.statLatency')}</span>
+            </div>
+          </div>
           <div className="v2-byo__cta-row">
             <button
               type="button"
@@ -689,6 +723,31 @@ const V2AgentBYO: React.FC = () => {
           </div>
         </div>
       )}
+      </div>
+      <aside className="v2-byo__preview" data-testid="byo-preview">
+        <div className="v2-byo__preview-label">{t('agentByo.preview.title')}</div>
+        <div className="v2-byo__preview-card">
+          <V2Avatar
+            name={previewDisplayName}
+            size="lg"
+            kind="agent"
+            seed={`${previewDisplayName}:default`}
+            online={previewStatus === 'live'}
+          />
+          <div className="v2-byo__preview-name">{previewDisplayName}</div>
+          {previewPodName && (
+            <div className="v2-byo__preview-pod">{t('agentByo.preview.inPod', { pod: previewPodName })}</div>
+          )}
+          <div className={`v2-byo__preview-status v2-byo__preview-status--${previewStatus}`}>
+            <span className="v2-byo__preview-dot" />
+            {t(`agentByo.preview.${previewStatus}`)}
+          </div>
+        </div>
+        <p className="v2-byo__preview-note">
+          {mode === 'hosted' ? t('agentByo.preview.noteHosted') : t('agentByo.preview.noteByo')}
+        </p>
+      </aside>
+      </div>
     </V2FeaturePage>
   );
 };

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -36,6 +36,7 @@ const DEFAULT_POD_TYPE = 'chat';
 const CLI_INSTALL_COMMAND = 'npm i -g @commonlyai/cli@latest';
 const CLI_INIT_COMMAND = 'commonly agent init --name <n> --pod <podId>';
 const MEMORY_FILE_NAME = 'MEMORY.md';
+const AGENT_KIND = 'agent' as const;
 const HOSTED_STATUS_POLL_MS = 4000;
 const HOSTED_STATUS_MAX_TICKS = 15;
 
@@ -533,7 +534,7 @@ const V2AgentBYO: React.FC = () => {
       {hosted && (
         <div className="v2-byo__result" data-testid="byo-hosted-result">
           <div className="v2-byo__result-hero">
-            <V2Avatar name={hosted.agentName} size="lg" kind="agent" seed={`${hosted.agentName}:default`} online={hostedState === 'running'} />
+            <V2Avatar name={hosted.agentName} size="lg" kind={AGENT_KIND} seed={`${hosted.agentName}:default`} online={hostedState === 'running'} />
             <h2>{t('agentByo.hosted.heading')} <code>{hosted.agentName}</code></h2>
           </div>
           <p>
@@ -558,7 +559,7 @@ const V2AgentBYO: React.FC = () => {
               <span className="v2-byo__stat-label">{t('agentByo.hosted.statAgents')}</span>
             </div>
             <div className="v2-byo__stat">
-              <span className="v2-byo__stat-value">~10s</span>
+              <span className="v2-byo__stat-value">{t('agentByo.hosted.statLatencyValue')}</span>
               <span className="v2-byo__stat-label">{t('agentByo.hosted.statLatency')}</span>
             </div>
           </div>
@@ -730,7 +731,7 @@ const V2AgentBYO: React.FC = () => {
           <V2Avatar
             name={previewDisplayName}
             size="lg"
-            kind="agent"
+            kind={AGENT_KIND}
             seed={`${previewDisplayName}:default`}
             online={previewStatus === 'live'}
           />

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -6032,7 +6032,125 @@ body.modern-ui.v2-canvas {
   color: #1e6b2a;
   font-size: 13px;
 }
-/* ADR-023 W2 — "Run it here" vs BYO choice cards. Borders, not shadows;
+/* BYO decision layout (Sam 2026-08-30: "cloud agent vs byoa uiux"). Form on
+   the left, live agent preview on the right — the page shows the teammate
+   being created, not a settings form. Tokens only; borders, not shadows. */
+.v2-byo__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 44px;
+  max-width: 1060px;
+  margin: 0 auto;
+  align-items: start;
+  padding: 8px 24px 40px;
+}
+.v2-byo__main { min-width: 0; }
+.v2-byo__preview {
+  position: sticky;
+  top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 24px;
+}
+.v2-byo__preview-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--v2-text-muted);
+}
+.v2-byo__preview-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 28px 20px 22px;
+  border: 1px solid var(--v2-border);
+  border-radius: 12px;
+  background: var(--v2-surface);
+  text-align: center;
+}
+.v2-byo__preview-name {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--v2-text-primary);
+  margin-top: 6px;
+  overflow-wrap: anywhere;
+}
+.v2-byo__preview-pod {
+  font-size: 12px;
+  color: var(--v2-text-tertiary);
+}
+.v2-byo__preview-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--v2-text-secondary);
+  background: var(--v2-surface-hover);
+}
+.v2-byo__preview-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--v2-text-muted);
+}
+.v2-byo__preview-status--starting .v2-byo__preview-dot { background: var(--v2-warning); }
+.v2-byo__preview-status--live {
+  color: #0f7a53;
+  background: var(--v2-success-soft);
+}
+.v2-byo__preview-status--live .v2-byo__preview-dot { background: var(--v2-success); }
+.v2-byo__preview-note {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--v2-text-tertiary);
+  margin: 0;
+}
+@media (max-width: 940px) {
+  .v2-byo__layout { grid-template-columns: minmax(0, 1fr); }
+  .v2-byo__preview { display: none; }
+}
+
+.v2-byo__result-hero {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.v2-byo__result-hero h2 { margin: 0; }
+.v2-byo__stats {
+  display: flex;
+  gap: 12px;
+}
+.v2-byo__stat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 14px;
+  border: 1px solid var(--v2-border);
+  border-radius: 10px;
+  background: var(--v2-surface);
+}
+.v2-byo__stat-value {
+  font-size: 18px;
+  font-weight: 750;
+  letter-spacing: -0.02em;
+  color: var(--v2-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.v2-byo__stat-label {
+  font-size: 11px;
+  color: var(--v2-text-tertiary);
+}
+
+/* ADR-023 W2 — "Run it here" vs BYO choice cards./* ADR-023 W2 — "Run it here" vs BYO choice cards. Borders, not shadows;
    the accent border + focus ring marks the pressed card. */
 .v2-byo__modes {
   display: grid;
@@ -6043,15 +6161,27 @@ body.modern-ui.v2-canvas {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 4px;
+  gap: 5px;
   text-align: left;
-  padding: 12px 14px;
+  padding: 16px 18px 14px;
   border: 1px solid var(--v2-border);
-  border-radius: 8px;
+  border-radius: 12px;
   background: var(--v2-surface, #fff);
   color: var(--v2-text-primary);
   cursor: pointer;
-  transition: border-color 0.08s ease;
+  transition: border-color 0.08s ease, background 0.08s ease;
+}
+.v2-byo__mode-kicker {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  color: var(--v2-accent-text);
+}
+.v2-byo__mode-kicker--quiet { color: var(--v2-text-muted); }
+.v2-byo__mode-meta {
+  font-size: 11px;
+  color: var(--v2-text-muted);
+  margin-top: 3px;
 }
 .v2-root button.v2-byo__mode:hover {
   background: var(--v2-surface-hover);
@@ -6061,8 +6191,9 @@ body.modern-ui.v2-canvas {
   box-shadow: var(--v2-focus-ring);
 }
 .v2-byo__mode-title {
-  font-size: 14px;
-  font-weight: 600;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
 }
 .v2-root button.v2-byo__submit {
   align-self: flex-start;
@@ -8031,7 +8162,10 @@ body.modern-ui.v2-canvas {
 .v2-root:lang(zh) .v2-activity__title,
 .v2-root:lang(zh) .v2-activity__section h2,
 .v2-root:lang(zh) .v2-activity__agent-card h3,
-.v2-root:lang(zh) .v2-activity__board-row h3 {
+.v2-root:lang(zh) .v2-activity__board-row h3
+.v2-root:lang(zh) .v2-byo__mode-title,
+.v2-root:lang(zh) .v2-byo__preview-name,
+.v2-root:lang(zh) .v2-byo__stat-value {
   letter-spacing: 0;
 }
 


### PR DESCRIPTION
Sam's call: the cloud-agent vs BYO surface still read as an admin form. This pass restructures it on existing tokens:

- **Decision-first chooser** — card anatomy (kicker / title / promise / meta), hosted leads with RECOMMENDED.
- **Live preview rail** — the page renders the actual agent as you type: same seeded V2Avatar face the pod will show, pod line, status chip tracking draft → starting → listening. Sticky; hidden <940px.
- **Hosted result** — avatar-led hero + tabular stat row instead of a hint sentence.

TASK-055's invariant caught the three new negative-tracking titles missing from the :lang(zh) reset — added.

Tests: full frontend suite green (incl. the four BYO suites + i18n key parity); tsc clean; eslint clean. Real-browser check on commonly.me after deploy (layout rule 9); Wren is commissioned to critique this pass and spec the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJ1bDdDQwWekHDqweiBhRN