### PR TITLE
feat(seo): add AI agent handoffs guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -19,7 +19,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 16);
+  assert.equal(pages.length, 17);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -37,6 +37,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/connect-claude-codex-shared-workspace/',
     '/guides/ai-agent-memory/',
     '/guides/human-in-the-loop-ai-agents/',
+    '/guides/ai-agent-handoffs/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
@@ -72,7 +73,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
   ]);
-  assert.equal(guidePages.length, 6);
+  assert.equal(guidePages.length, 7);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
@@ -127,6 +128,15 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(humanReviewHtml, /It is not a person reading every token an agent produces\./);
   assert.match(humanReviewHtml, /href="\/guides\/ai-agent-memory\//);
   assert.match(humanReviewHtml, /https:\/\/learn\.microsoft\.com\/en-us\/agent-framework\/workflows\/human-in-the-loop/);
+  assert.match(humanReviewHtml, /href="\/guides\/ai-agent-handoffs\//);
+  const handoffsGuide = guidePages.find((page) => page.path === '/guides/ai-agent-handoffs/');
+  assert.equal(handoffsGuide.title, 'AI Agent Handoffs: Transfer Work Without Losing Context | Commonly');
+  const handoffsHtml = renderStaticPage(guideTemplate, handoffsGuide);
+  assert.match(handoffsHtml, /An AI agent handoff is the transfer of a piece of work to a new owner/);
+  assert.match(handoffsHtml, /href="\/guides\/ai-agent-memory\//);
+  assert.match(handoffsHtml, /href="\/guides\/human-in-the-loop-ai-agents\//);
+  assert.match(handoffsHtml, /https:\/\/openai\.com\/business\/guides-and-resources\/a-practical-guide-to-building-ai-agents\//);
+  assert.match(handoffsHtml, /https:\/\/learn\.microsoft\.com\/en-us\/agent-framework\/workflows\/orchestrations\/handoff/);
   for (const guidePath of [
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -877,7 +877,8 @@
       { "label": "Learn about AI agent workspaces", "path": "/guides/ai-agent-workspace/" },
       { "label": "Learn about AI agent task management", "path": "/guides/ai-agent-task-management/" },
       { "label": "Connect Claude Code and Codex to one workspace", "path": "/guides/connect-claude-codex-shared-workspace/" },
-      { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" }
+      { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" },
+      { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" }
     ],
     "cta": {
       "title": "Make the next session start ahead",
@@ -1071,11 +1072,207 @@
     "relatedLinks": [
       { "label": "Read the multi-agent collaboration guide", "path": "/guides/multi-agent-collaboration-platform/" },
       { "label": "Learn about AI agent task management", "path": "/guides/ai-agent-task-management/" },
-      { "label": "Learn about shared memory for AI agents", "path": "/guides/ai-agent-memory/" }
+      { "label": "Learn about shared memory for AI agents", "path": "/guides/ai-agent-memory/" },
+      { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" }
     ],
     "cta": {
       "title": "Build review into the way the team works",
       "body": "Human-in-the-loop AI teams work best when agents have room to execute and humans have a clear place to decide. Define the handoffs, require a useful decision packet, preserve the outcome, and keep technical controls in the systems that can actually enforce them.",
+      "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
+      "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
+    }
+  },
+  "ai-agent-handoffs": {
+    "eyebrow": "Guide",
+    "titleTag": "AI Agent Handoffs: Transfer Work Without Losing Context | Commonly",
+    "title": "AI Agent Handoffs: Transfer Work Without Losing Context",
+    "description": "Learn how to hand work from one AI agent or human teammate to another: when to delegate, when ownership actually changes, and the context packet that makes the next step clear.",
+    "summary": "AI agent handoffs make a new owner, the next action, the evidence, and the constraints explicit so work can continue without repeating or guessing.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-30",
+      "dateModified": "2026-08-30"
+    },
+    "intro": [
+      "An AI agent handoff is the transfer of a piece of work to a new owner with the context needed to continue it. It is not a vague message that says “please take over,” and it is not a dump of every tool call the first agent made.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, gives a team the surfaces for a useful handoff: a named task owner, a visible status and activity timeline, a thread for the decision, attached evidence, and shared memory for durable context.",
+      "The goal is simple: the receiving person or agent should know what outcome matters, what is already true, what must happen next, and where to verify it. When those things are missing, the receiving owner either repeats the work or makes a fresh guess—both of which look like progress until they produce a contradiction."
+    ],
+    "sections": [
+      {
+        "title": "A handoff is different from delegation",
+        "paragraphs": [
+          "“Handoff” is used for several patterns, and the distinction matters because the team needs to know who is accountable after the message is sent.",
+          "OpenAI’s practical guide to building agents separates a manager pattern from a decentralized handoff pattern. In the manager pattern, a central agent calls specialists as tools and retains control. In a decentralized pattern, peers transfer execution to one another based on their specializations.",
+          "For a human-and-agent team, use three plain-language categories:",
+          "Delegation can happen inside a single task. A handoff should make the new owner unmistakable. Escalation is a handoff to a decision-maker, not an invitation for the agent to keep trying until it can manufacture certainty."
+        ],
+        "tables": [{
+          "headers": ["Pattern", "Who owns the result?", "What moves?", "Example"],
+          "rows": [
+            ["Delegation", "The original owner", "A bounded subtask or answer", "A coordinator asks a research agent to verify two sources, then synthesizes the answer itself."],
+            ["Handoff", "The receiving owner", "The next stage of work plus usable context", "A researcher hands a verified brief to a writer, who now owns the draft."],
+            ["Escalation", "A human or designated decision-maker", "A question that exceeds the agent’s authority or confidence", "An agent surfaces conflicting policy sources and asks the editor to decide which one governs."]
+          ]
+        }],
+        "links": [
+          { "label": "OpenAI: a practical guide to building agents", "path": "https://openai.com/business/guides-and-resources/a-practical-guide-to-building-ai-agents/", "external": true },
+          { "label": "Microsoft Agent Framework: handoff orchestration", "path": "https://learn.microsoft.com/en-us/agent-framework/workflows/orchestrations/handoff", "external": true }
+        ]
+      },
+      {
+        "title": "When should an agent hand work off?",
+        "paragraphs": [
+          "Handoffs are useful when the nature of the work changes. Four moments are especially common."
+        ]
+      },
+      {
+        "title": "The task needs a different specialty",
+        "paragraphs": [
+          "One agent may be good at collecting source material; another may own code changes; a human may own the public claim or production decision. Do not ask one generalist to impersonate every specialty when the work has an obvious boundary.",
+          "The handoff should state why the next owner is needed: “The source evidence is complete; this now needs an editorial decision,” or “The draft is approved; the remaining work is a static-page implementation and verification.”"
+        ]
+      },
+      {
+        "title": "The work moves from exploration to execution",
+        "paragraphs": [
+          "Research, writing, implementation, and release checks need different artifacts. A research handoff should transfer sources and claim boundaries. An implementation handoff should transfer the approved copy, route, metadata requirements, and checks. A release handoff should transfer the deployed artifact and acceptance criteria.",
+          "Treating all of this as one free-form conversation makes it difficult to tell whether the team has moved forward or merely changed speakers."
+        ]
+      },
+      {
+        "title": "The owner reaches a decision boundary",
+        "paragraphs": [
+          "An agent should hand off when it encounters a changed scope, weak evidence, a sensitive action, or an accountable acceptance decision. The receiving person may be a reviewer rather than an implementer.",
+          "This is the point of human-in-the-loop review: a team pauses at a meaningful handoff, not after every low-consequence step. A decision record should preserve the answer so later agents do not reopen a settled question."
+        ]
+      },
+      {
+        "title": "The original owner is no longer the right owner",
+        "paragraphs": [
+          "Sometimes the initial agent has done the work it was assigned. Continuing because it happens to have the current context is not a reason to keep ownership. A good handoff is how the team avoids hidden, accidental ownership."
+        ]
+      },
+      {
+        "title": "The context packet: what the next owner needs",
+        "paragraphs": [
+          "The receiver does not need a novel. They need a compact packet that makes the next action safe and testable.",
+          "Two details are worth emphasizing.",
+          "First, distinguish facts from requests. “The route returns 404 in production” is a fact with a check behind it. “Please make the route work” is a request. The next owner needs both, but should not have to infer which is which.",
+          "Second, link to the source of record. If the code lives in a repository, the pull request and tests are the source of record. If a task owns status, do not copy the status into three notes. If a research memo contains the evidence, attach or link it rather than paraphrasing it until the sources disappear."
+        ],
+        "tables": [{
+          "headers": ["Include", "Why it matters", "A useful example"],
+          "rows": [
+            ["Outcome and scope", "Stops the next owner from solving a different problem", "Publish a crawler-readable guide; do not change the app authentication flow."],
+            ["Current state", "Tells them what is actually done, not just what was attempted", "Draft approved; static route has not been implemented."],
+            ["New owner and next action", "Makes the ownership transfer explicit", "Implementation agent: add the guide entry and run the static-output checks."],
+            ["Evidence and artifacts", "Lets the receiver verify instead of trust a recap", "Source memo, approved draft, screenshot, pull request, or test output"],
+            ["Constraints and decisions", "Preserves the rules that shaped the work", "Use only verified product claims; retain the trailing-slash canonical."],
+            ["Checks, blocker, or rollback", "Explains how to continue and when to stop", "Verify initial HTML, sitemap, and canonical; block if production serves the SPA fallback."]
+          ]
+        }]
+      },
+      {
+        "title": "A practical handoff in Commonly",
+        "paragraphs": [
+          "Commonly does not need to implement an agent-framework handoff API for a team to make work transferable. It provides a shared place for the coordination record around the transfer: pods include chat with threads and @mentions, a task list, files, shared memory, and named human and agent members.",
+          "Here is a practical research-to-release flow."
+        ]
+      },
+      {
+        "title": "1. Research owner hands off to the writer",
+        "paragraphs": [
+          "The research task contains the reader, the question, and the source constraints. When research is complete, the owner attaches a short memo and leaves a handoff in the task thread:",
+          "The writer now owns the draft. The research agent does not need to keep revising the outline simply because it was first in the thread."
+        ],
+        "codeBlocks": [{
+          "language": "markdown",
+          "code": "Handoff: research → writing\\n\\n- Outcome: draft an AI-agent handoffs guide for builders.\\n- Verified: manager delegation and ownership handoff are different patterns.\\n- Evidence: attached source memo; product documentation links included.\\n- Constraints: do not claim framework-level routing or runtime-state transfer.\\n- New owner: writer.\\n- Next action: produce a reviewable draft with one worked team flow."
+        }]
+      },
+      {
+        "title": "2. Writer hands off to the reviewer and implementer",
+        "paragraphs": [
+          "The writer attaches the draft, identifies the primary query and proposed route, and asks for a bounded editorial decision. Once the copy is accepted, the implementation task names the implementation owner and lists the mechanical requirements: static article output, canonical, sitemap entry, hub card, internal links, and acceptance checks.",
+          "The approval thread is not a substitute for code review. It tells the implementation owner which copy was accepted and which facts must remain true while the repository and deployment checks determine whether the page is technically correct."
+        ]
+      },
+      {
+        "title": "3. Implementation owner closes the loop",
+        "paragraphs": [
+          "Commonly task records have an assignee, status, and activity timeline. The status flow—pending → claimed → blocked → done—helps the team see whether the work has actually moved to a new owner.",
+          "After implementation, link the pull request and the relevant checks. If a deploy or external dependency is missing, use a visible blocker rather than quietly assuming the handoff finished. When the page is live, record the public route and any durable editorial decision that will guide the next page."
+        ]
+      },
+      {
+        "title": "Put shared context in the right place",
+        "paragraphs": [
+          "A handoff often fails because the only context exists inside an agent’s session. The next owner cannot read it, cannot verify it, and should not have to reconstruct it from an unbounded conversation.",
+          "Use the shared surfaces by their purpose:",
+          "Commonly’s documented pod-memory conventions—MEMORY.md for project context, TASK-NNN.md for task-specific research, and ARCHITECTURE.md for durable design decisions—make a useful division. Write a short, sourced handoff record where the next owner can find it; do not turn shared memory into a duplicate task board or an archive of every chat message."
+        ],
+        "tables": [{
+          "headers": ["Information", "Best home", "Why"],
+          "rows": [
+            ["Who owns the next action and what is blocked", "Task board", "Ownership and status have a visible lifecycle."],
+            ["The transfer discussion and attached artifact", "Pod thread", "The team can ask questions next to the proposed work."],
+            ["A durable rule, decision, or source summary", "Shared pod memory", "It survives a new session or a new team member."],
+            ["Code and implementation history", "Repository and pull request", "Those systems are responsible for the change record."],
+            ["An individual agent’s transient working notes", "Private agent context", "The team does not need every intermediate observation."]
+          ]
+        }]
+      },
+      {
+        "title": "What a shared workspace does not transfer automatically",
+        "paragraphs": [
+          "Be precise about the boundary. A thread, task assignment, or direct message can coordinate a handoff, but it does not automatically transfer every private runtime detail from one agent to another. It also does not guarantee the receiving agent has the permissions, tools, or authority to perform the next action.",
+          "That is why the packet needs explicit evidence, constraints, and checks. Runtime credentials belong in approved runtime configuration or a secret manager, not in a handoff note. Production access, branch protection, tool approvals, and deployment controls belong in the systems that enforce them.",
+          "The workspace makes the transfer legible and attributable. The execution environment must still authorize and enforce the action."
+        ]
+      },
+      {
+        "title": "Someone should take this has no owner",
+        "paragraphs": [
+          "A broad request can sound collaborative while leaving everyone free to assume someone else owns it. Name the receiving person or agent, the next action, and the condition for completion."
+        ]
+      },
+      {
+        "title": "The handoff contains conclusions but no sources",
+        "paragraphs": [
+          "“The research is done” is not enough for a writer, reviewer, or engineer to rely on. Attach the memo, link the source, and identify what was verified. If a claim remains uncertain, preserve the uncertainty."
+        ]
+      },
+      {
+        "title": "The team copies state instead of linking the source of record",
+        "paragraphs": [
+          "Repeated status updates become stale. Let the task board own task state, let the repository own code history, and let shared memory point to durable decisions. The handoff should connect those systems rather than trying to replace them."
+        ]
+      },
+      {
+        "title": "The scope quietly expands mid-transfer",
+        "paragraphs": [
+          "An implementation agent may discover a missing route rule or a product claim that needs a new source. That is a new decision boundary. Record the changed scope, return it to the appropriate owner, and ask for an explicit decision rather than treating the expanded work as implied."
+        ]
+      }
+    ],
+    "faq": [
+      { "question": "Does an AI-agent handoff require a complex orchestration framework?", "answer": "No. Framework-level handoffs can route execution between agents, but a team still needs an ownership and context record that humans can inspect. Start with a clear receiver, a task, a source-linked handoff packet, and a way to record the outcome." },
+      { "question": "What is the difference between an agent handoff and an agent-as-tool call?", "answer": "In a manager pattern, the original agent remains responsible and uses a specialist for a bounded result. In an ownership handoff, the receiving agent becomes responsible for the next stage. The distinction should be visible in the task owner and the requested outcome." },
+      { "question": "Should every handoff create a new task?", "answer": "No. Keep a bounded subtask inside the existing task when the same owner still owns the overall outcome. Create a new task when ownership, deliverable, dependency, or acceptance criteria genuinely change. The important part is that the board makes the boundary visible." },
+      { "question": "What should happen when the next owner cannot continue?", "answer": "Do not discard the context or silently restart. Mark the work blocked when it is waiting on a real dependency, attach the evidence, and route the decision to the person or agent who can resolve it. A clear blocker is a successful handoff outcome when proceeding would require a guess." }
+    ],
+    "relatedLinks": [
+      { "label": "Read the multi-agent collaboration guide", "path": "/guides/multi-agent-collaboration-platform/" },
+      { "label": "Learn about AI agent task management", "path": "/guides/ai-agent-task-management/" },
+      { "label": "Connect Claude Code and Codex to one workspace", "path": "/guides/connect-claude-codex-shared-workspace/" },
+      { "label": "Learn about shared memory for AI agents", "path": "/guides/ai-agent-memory/" },
+      { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" }
+    ],
+    "cta": {
+      "title": "Make handoffs a team habit",
+      "body": "Agent teams gain speed from specialization only when work crosses specialties without losing the reason it exists. Define the outcome, name the next owner, transfer the evidence and constraints, and preserve the decision where the next session can find it.",
       "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
       "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
     }

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -159,7 +159,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(6);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(7);
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Connect Claude Code and Codex to a Shared Workspace',
@@ -171,6 +171,10 @@ describe('V2 routing', () => {
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'Human-in-the-Loop Review for AI Agent Teams',
+    })).toBeInTheDocument();
+    expect(screen.getByRole('heading', {
+      level: 2,
+      name: 'AI Agent Handoffs: Transfer Work Without Losing Context',
     })).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary\n- publish the static AI Agent Handoffs guide at /guides/ai-agent-handoffs/\n- add hub and sitemap coverage, Article/WebPage metadata, and real 2026-08-30 provenance\n- add reciprocal links with the published memory and human-review guides; no Page 8 link\n\n## Verification\n- npm test (85 suites, 473 tests)\n- npm run typecheck\n- npm run build\n\n@samxu01?