### PR TITLE
test(runtime): pin the reply-staging ordering in handleEvent (#1366)

### DIFF
--- a/workers/agent-runtime/test/agent-do.staging-ordering.test.ts
+++ b/workers/agent-runtime/test/agent-do.staging-ordering.test.ts
@@ -1,0 +1,101 @@
+// The ordering in handleEvent IS #1344's fix: commitStagedReply must run
+// AFTER a successful post and must NOT run when the post throws — that is
+// what leaves the stage intact so a redelivery replays it instead of paying
+// for the model again. sprint-review proved (#1366) that moving the commit
+// above the post re-introduces #1344 with the whole suite green: staging.ts
+// is well covered, but nothing exercised the CALL SITE where the order lives.
+//
+// This drives the DO through alarm() twice — post throws, then succeeds —
+// and asserts the model ran ONCE across both deliveries. A refactor tidying
+// this to "clear the stage, then post" reads as equivalent and goes red here.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cap = vi.hoisted(() => ({
+  listEvents: vi.fn(),
+  ackEvent: vi.fn(),
+  postMessage: vi.fn(),
+}));
+const turn = vi.hoisted(() => ({ runTurn: vi.fn() }));
+
+vi.mock('../src/cap', () => ({
+  ...cap,
+  StaleDeliveryError: class StaleDeliveryError extends Error {},
+}));
+vi.mock('../src/turn', () => turn);
+
+import { AgentRuntimeDO } from '../src/agent-do';
+import { stagedKey } from '../src/staging';
+
+const cfg = { apiUrl: 'https://api.test', runtimeToken: 'cm_agent_x' };
+const EVENT = {
+  _id: 'event-1',
+  type: 'chat.mention',
+  podId: 'pod-1',
+  payload: { content: 'ping' },
+};
+
+const stateWith = (values: Record<string, unknown>) => {
+  const data = new Map(Object.entries(values));
+  const storage = {
+    get: vi.fn(async (key: string) => data.get(key)),
+    put: vi.fn(async (key: string | Record<string, unknown>, value?: unknown) => {
+      if (typeof key === 'string') data.set(key, value);
+      else Object.entries(key).forEach(([entry, stored]) => data.set(entry, stored));
+    }),
+    delete: vi.fn(async (key: string) => data.delete(key)),
+    // pruneStaged lists on every stage; the existing harness predates it.
+    list: vi.fn(async ({ prefix }: { prefix: string }) => {
+      const out = new Map<string, unknown>();
+      for (const [key, value] of data) if (key.startsWith(prefix)) out.set(key, value);
+      return out;
+    }),
+    setAlarm: vi.fn(async () => undefined),
+  };
+  return { data, storage, state: { storage } as unknown as DurableObjectState };
+};
+
+describe('handleEvent reply-staging ordering (#1344 / #1366)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cap.listEvents.mockResolvedValue([EVENT]);
+    cap.ackEvent.mockResolvedValue(undefined);
+    turn.runTurn.mockResolvedValue('the reply');
+  });
+
+  it('a failed post leaves the stage intact and the event unprocessed', async () => {
+    const { data, state } = stateWith({ runtimeToken: cfg.runtimeToken, pollSeconds: 5 });
+    cap.postMessage.mockRejectedValue(new Error('502 from CAP'));
+
+    await new AgentRuntimeDO(state, { COMMONLY_API_URL: cfg.apiUrl } as never).alarm();
+
+    expect(data.get(stagedKey(EVENT._id))).toMatchObject({ reply: 'the reply' });
+    expect(data.get('processedEventIds')).toBeUndefined();
+    expect(cap.ackEvent).not.toHaveBeenCalled();
+  });
+
+  it('the redelivery replays the staged reply without re-running the model', async () => {
+    const { data, state } = stateWith({ runtimeToken: cfg.runtimeToken, pollSeconds: 5 });
+    const runtime = new AgentRuntimeDO(state, { COMMONLY_API_URL: cfg.apiUrl } as never);
+
+    cap.postMessage.mockRejectedValueOnce(new Error('502 from CAP'));
+    await runtime.alarm();
+    cap.postMessage.mockResolvedValue(undefined);
+    await runtime.alarm();
+
+    // The whole point of #1344: one paid turn across two deliveries.
+    expect(turn.runTurn).toHaveBeenCalledTimes(1);
+    expect(cap.postMessage).toHaveBeenLastCalledWith(cfg, 'pod-1', 'the reply');
+    // And the stage is cleared only once the post actually succeeded.
+    expect(data.get(stagedKey(EVENT._id))).toBeUndefined();
+  });
+
+  it('a NO_REPLY turn posts nothing and still clears its stage', async () => {
+    const { data, state } = stateWith({ runtimeToken: cfg.runtimeToken, pollSeconds: 5 });
+    turn.runTurn.mockResolvedValue('NO_REPLY');
+
+    await new AgentRuntimeDO(state, { COMMONLY_API_URL: cfg.apiUrl } as never).alarm();
+
+    expect(cap.postMessage).not.toHaveBeenCalled();
+    expect(data.get(stagedKey(EVENT._id))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #1366.

@sprint-review proved the gap rather than asserting it: moving `commitStagedReply` above the post in `handleEvent` re-introduces #1344 with all 30 tests green. `staging.test.ts`'s six cases drive `staging.ts` through an injected `Map` and pin the primitives well — stage, resolve, commit, prune, shape-guard. None pins the call site, and the call site is where the ordering lives.

This adds the one assertion neither existing suite makes, through the mock harness `agent-do.delivery-nonce.test.ts` already established (mock `../src/cap`, construct the DO over a fake `DurableObjectState`, drive it with `alarm()`).

Three cases:

- **a failed post leaves the stage intact** — `staged:event-1` still holds the reply, `processedEventIds` is unset, `ackEvent` was never called;
- **the redelivery replays it without re-running the model** — post throws on the first `alarm()`, succeeds on the second, and `runTurn` is called **once** across both. That is #1344's contract stated directly: one paid turn across two deliveries;
- **a NO_REPLY turn posts nothing and still clears its stage** — the branch that skips the post must not leak an orphan.

## Mutation control

node 22, clean worktree at `374f4c7c`, `vitest run`.

| tree | result |
|---|---|
| main | 30 passed (30) |
| main + this file | 33 passed (33) |
| mutated (commit moved above the post), **without** this file | 30 passed (30) — the exclusion arm |
| mutated, with this file | **2 failed** — `expected "spy" to be called 1 times, but got 2 times` |

The discriminating assertion is the `runTurn` call count, which is the paid resource #1344 is about. Source restored afterwards (`git diff` empty on `src/`), `tsc --noEmit` exits 0.

## Not addressed here, deliberately

#1366's two smaller notes are untouched: the `STAGE_TTL_MS` justification is a claim about kernel redelivery cadence asserted in a worker comment with no reader, and `pruneStaged` does a full prefix `list` on every staged turn. Both are about `staging.ts`, not the call site, and neither is what the issue's title names.

**NOT VERIFIED:** same caveat as the issue — this runs under vitest with an injected storage object, not under `workerd`/`wrangler`, so real Durable Object `get`/`put`/`delete`/`list` semantics remain unexercised. The harness gains a `list` stub because the existing one predates `pruneStaged`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)