### PR TITLE
fix(runtime): status token equal to admin token treated as unset

### DIFF
--- a/workers/agent-runtime/src/index.ts
+++ b/workers/agent-runtime/src/index.ts
@@ -24,7 +24,14 @@ export default {
     // kill or provision any agent by name. Unset means no second bearer.
     const bearer = req.headers.get('Authorization');
     const isAdmin = bearer === `Bearer ${admin}`;
-    const isStatusReader = Boolean(env.RUNTIME_STATUS_TOKEN) && bearer === `Bearer ${env.RUNTIME_STATUS_TOKEN}`;
+    // A status token EQUAL to the admin token is treated as unset (Otto on
+    // #1360): an operator pasting the wrong secret would otherwise silently
+    // collapse the two capabilities back into one — the exact split this
+    // token exists to enforce.
+    const statusToken = env.RUNTIME_STATUS_TOKEN && env.RUNTIME_STATUS_TOKEN !== admin
+      ? env.RUNTIME_STATUS_TOKEN
+      : undefined;
+    const isStatusReader = Boolean(statusToken) && bearer === `Bearer ${statusToken}`;
     const statusOnly = req.method === 'GET' && rest === '/status';
     if (!isAdmin && !(isStatusReader && statusOnly)) {
       return Response.json({ error: 'unauthorized' }, { status: 401 });

--- a/workers/agent-runtime/src/index.ts
+++ b/workers/agent-runtime/src/index.ts
@@ -24,14 +24,15 @@ export default {
     // kill or provision any agent by name. Unset means no second bearer.
     const bearer = req.headers.get('Authorization');
     const isAdmin = bearer === `Bearer ${admin}`;
-    // A status token EQUAL to the admin token is treated as unset (Otto on
-    // #1360): an operator pasting the wrong secret would otherwise silently
-    // collapse the two capabilities back into one — the exact split this
-    // token exists to enforce.
-    const statusToken = env.RUNTIME_STATUS_TOKEN && env.RUNTIME_STATUS_TOKEN !== admin
-      ? env.RUNTIME_STATUS_TOKEN
-      : undefined;
-    const isStatusReader = Boolean(statusToken) && bearer === `Bearer ${statusToken}`;
+    // A status token EQUAL to the admin token is a refused CONFIGURATION
+    // (Otto on #1374, round 2): nulling the reader path closes nothing,
+    // because the byte-identical bearer still authenticates as admin — no
+    // logic here can tell the two holders apart. The only remedy is to
+    // refuse to serve until the operator fixes the secrets.
+    if (env.RUNTIME_STATUS_TOKEN && env.RUNTIME_STATUS_TOKEN === admin) {
+      return Response.json({ error: 'misconfigured: RUNTIME_STATUS_TOKEN must differ from RUNTIME_ADMIN_TOKEN' }, { status: 503 });
+    }
+    const isStatusReader = Boolean(env.RUNTIME_STATUS_TOKEN) && bearer === `Bearer ${env.RUNTIME_STATUS_TOKEN}`;
     const statusOnly = req.method === 'GET' && rest === '/status';
     if (!isAdmin && !(isStatusReader && statusOnly)) {
       return Response.json({ error: 'unauthorized' }, { status: 401 });

--- a/workers/agent-runtime/test/index.test.ts
+++ b/workers/agent-runtime/test/index.test.ts
@@ -58,4 +58,14 @@ describe('router bearers', () => {
     expect((await call(env, 'GET', '/nope', 'admin-secret')).status).toBe(404);
     expect((await call(env, 'GET', '/nope', 'status-secret')).status).toBe(404);
   });
+
+  it('a status token equal to the admin token is treated as unset (no capability collapse)', async () => {
+    const { env, stubFetch } = makeEnv({ RUNTIME_STATUS_TOKEN: 'admin-secret' });
+    // Admin bearer still works — as ADMIN, on every route.
+    expect((await call(env, 'POST', '/agents/scout/default/provision', 'admin-secret')).status).toBe(200);
+    expect(stubFetch).toHaveBeenCalledTimes(1);
+    // A real reader token would be refused now: the reader path is OFF, so a
+    // non-admin bearer gets 401 even on GET /status.
+    expect((await call(env, 'GET', '/agents/scout/default/status', 'status-secret')).status).toBe(401);
+  });
 });

--- a/workers/agent-runtime/test/index.test.ts
+++ b/workers/agent-runtime/test/index.test.ts
@@ -59,13 +59,14 @@ describe('router bearers', () => {
     expect((await call(env, 'GET', '/nope', 'status-secret')).status).toBe(404);
   });
 
-  it('a status token equal to the admin token is treated as unset (no capability collapse)', async () => {
+  it('a status token equal to the admin token refuses the configuration outright (503, every route, every bearer)', async () => {
+    // Otto, #1374 round 2: when the secrets are byte-identical, the admin
+    // check accepts the "status" bearer anyway — nothing downstream can
+    // distinguish the holders. So the router refuses to serve at all.
     const { env, stubFetch } = makeEnv({ RUNTIME_STATUS_TOKEN: 'admin-secret' });
-    // Admin bearer still works — as ADMIN, on every route.
-    expect((await call(env, 'POST', '/agents/scout/default/provision', 'admin-secret')).status).toBe(200);
-    expect(stubFetch).toHaveBeenCalledTimes(1);
-    // A real reader token would be refused now: the reader path is OFF, so a
-    // non-admin bearer gets 401 even on GET /status.
-    expect((await call(env, 'GET', '/agents/scout/default/status', 'status-secret')).status).toBe(401);
+    expect((await call(env, 'POST', '/agents/scout/default/provision', 'admin-secret')).status).toBe(503);
+    expect((await call(env, 'GET', '/agents/scout/default/status', 'admin-secret')).status).toBe(503);
+    expect((await call(env, 'GET', '/agents/scout/default/status', 'status-secret')).status).toBe(503);
+    expect(stubFetch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Otto's non-blocking note on #1360, as its own PR so his approved sha merged exactly as reviewed: `RUNTIME_STATUS_TOKEN === RUNTIME_ADMIN_TOKEN` now disables the reader path instead of silently collapsing the capability split. Test added; worker suite green. Otto gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJ1bDdDQwWekHDqweiBhRN