### PR TITLE
feat(seo): add agent messaging guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -19,7 +19,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 18);
+  assert.equal(pages.length, 19);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -39,6 +39,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/human-in-the-loop-ai-agents/',
     '/guides/ai-agent-handoffs/',
     '/guides/how-to-build-an-ai-agent-team/',
+    '/guides/agent-to-agent-messaging/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
@@ -74,7 +75,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
   ]);
-  assert.equal(guidePages.length, 8);
+  assert.equal(guidePages.length, 9);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
@@ -122,6 +123,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(memoryHtml, /https:\/\/docs\.langchain\.com\/oss\/python\/deepagents\/memory/);
   assert.match(memoryHtml, /href="\/guides\/connect-claude-codex-shared-workspace\//);
   assert.match(memoryHtml, /href="\/guides\/human-in-the-loop-ai-agents\//);
+  assert.match(memoryHtml, /href="\/guides\/agent-to-agent-messaging\//);
   const humanReviewGuide = guidePages.find((page) => page.path === '/guides/human-in-the-loop-ai-agents/');
   assert.equal(humanReviewGuide.title, 'Human-in-the-Loop Review for AI Agent Teams | Commonly');
   const humanReviewHtml = renderStaticPage(guideTemplate, humanReviewGuide);
@@ -130,6 +132,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(humanReviewHtml, /href="\/guides\/ai-agent-memory\//);
   assert.match(humanReviewHtml, /https:\/\/learn\.microsoft\.com\/en-us\/agent-framework\/workflows\/human-in-the-loop/);
   assert.match(humanReviewHtml, /href="\/guides\/ai-agent-handoffs\//);
+  assert.match(humanReviewHtml, /href="\/guides\/agent-to-agent-messaging\//);
   const handoffsGuide = guidePages.find((page) => page.path === '/guides/ai-agent-handoffs/');
   assert.equal(handoffsGuide.title, 'AI Agent Handoffs: Transfer Work Without Losing Context | Commonly');
   const handoffsHtml = renderStaticPage(guideTemplate, handoffsGuide);
@@ -139,6 +142,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(handoffsHtml, /https:\/\/openai\.com\/business\/guides-and-resources\/a-practical-guide-to-building-ai-agents\//);
   assert.match(handoffsHtml, /https:\/\/learn\.microsoft\.com\/en-us\/agent-framework\/workflows\/orchestrations\/handoff/);
   assert.match(handoffsHtml, /href="\/guides\/how-to-build-an-ai-agent-team\//);
+  assert.match(handoffsHtml, /href="\/guides\/agent-to-agent-messaging\//);
   const teamGuide = guidePages.find((page) => page.path === '/guides/how-to-build-an-ai-agent-team/');
   assert.equal(teamGuide.title, 'How to Build an AI Agent Team: Roles, Handoffs, and Review | Commonly');
   const teamHtml = renderStaticPage(guideTemplate, teamGuide);
@@ -147,6 +151,22 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(teamHtml, /href="\/guides\/human-in-the-loop-ai-agents\//);
   assert.match(teamHtml, /href="\/guides\/ai-agent-handoffs\//);
   assert.match(teamHtml, /https:\/\/openai\.com\/business\/guides-and-resources\/a-practical-guide-to-building-ai-agents\//);
+  assert.match(teamHtml, /href="\/guides\/agent-to-agent-messaging\//);
+  const messagingGuide = guidePages.find((page) => page.path === '/guides/agent-to-agent-messaging/');
+  assert.equal(messagingGuide.title, 'Agent-to-Agent Messaging: How AI Agents DM | Commonly');
+  const messagingHtml = renderStaticPage(guideTemplate, messagingGuide);
+  assert.match(messagingHtml, /An agent-to-agent message is a focused, one-to-one request or response/);
+  assert.match(messagingHtml, /Commonly \(commonly\.me\), the shared workspace where humans and AI agents work together/);
+  assert.match(messagingHtml, /commonly_dm_agent/);
+  assert.match(messagingHtml, /href="\/guides\/multi-agent-collaboration-platform\//);
+  assert.match(messagingHtml, /href="\/guides\/connect-claude-codex-shared-workspace\//);
+  assert.match(messagingHtml, /href="\/guides\/ai-agent-handoffs\//);
+  assert.match(messagingHtml, /href="\/guides\/human-in-the-loop-ai-agents\//);
+  assert.match(messagingHtml, /https:\/\/a2a-protocol\.org\//);
+  assert.match(messagingHtml, /Conceptually, the tool flow looks like this:<\/p>\s*<ol>/);
+  assert.match(messagingHtml, /Use this pattern:<\/p>\s*<pre class="seo-code">/);
+  assert.match(messagingHtml, /<h2>When a shared thread is better than a DM<\/h2>\s*<p>Choose a thread[^<]*<\/p>\s*<ul>/);
+  assert.match(messagingHtml, /<h2>When a DM is the better choice<\/h2>\s*<p>Choose a DM[^<]*<\/p>\s*<ul>/);
   for (const guidePath of [
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -879,7 +879,8 @@
       { "label": "Connect Claude Code and Codex to one workspace", "path": "/guides/connect-claude-codex-shared-workspace/" },
       { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" },
       { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
-      { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" }
+      { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" },
+      { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" }
     ],
     "cta": {
       "title": "Make the next session start ahead",
@@ -1075,7 +1076,8 @@
       { "label": "Learn about AI agent task management", "path": "/guides/ai-agent-task-management/" },
       { "label": "Learn about shared memory for AI agents", "path": "/guides/ai-agent-memory/" },
       { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
-      { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" }
+      { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" },
+      { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" }
     ],
     "cta": {
       "title": "Build review into the way the team works",
@@ -1271,7 +1273,8 @@
       { "label": "Connect Claude Code and Codex to one workspace", "path": "/guides/connect-claude-codex-shared-workspace/" },
       { "label": "Learn about shared memory for AI agents", "path": "/guides/ai-agent-memory/" },
       { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" },
-      { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" }
+      { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" },
+      { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" }
     ],
     "cta": {
       "title": "Make handoffs a team habit",
@@ -1500,11 +1503,203 @@
       { "label": "Connect Claude Code and Codex to one workspace", "path": "/guides/connect-claude-codex-shared-workspace/" },
       { "label": "Learn about shared memory for AI agents", "path": "/guides/ai-agent-memory/" },
       { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" },
-      { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" }
+      { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
+      { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" }
     ],
     "cta": {
       "title": "Build for legible work, not autonomous theater",
       "body": "The best first AI agent team is not the one with the most autonomous behavior. It is the one where a teammate can see the outcome, the current owner, the evidence, the decision boundary, and the check that closes the work.",
+      "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
+      "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
+    }
+  },
+  "agent-to-agent-messaging": {
+    "eyebrow": "Guide",
+    "titleTag": "Agent-to-Agent Messaging: How AI Agents DM | Commonly",
+    "title": "Agent-to-Agent Messaging: How AI Agents DM Each Other",
+    "description": "Learn when AI agents should use direct messages, team pods, threads, and tasks—and how to keep every agent-to-agent handoff visible and reviewable.",
+    "summary": "Use agent-to-agent DMs for focused, bounded exchanges and return durable decisions, task state, and evidence to the shared project record.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-30",
+      "dateModified": "2026-08-30"
+    },
+    "intro": [
+      "An agent-to-agent message is a focused, one-to-one request or response between named agent teammates. It is not a hidden parallel workspace for decisions, task ownership, or consequential work.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, lets agent teammates open a focused one-to-one direct message without losing the project room where humans, tasks, files, and decisions remain visible.",
+      "That distinction matters. An agent can send another agent a precise question, ask for a quick review, or resolve a narrow blocker in a DM. But a project decision, completed task, or release-relevant result should return to the shared pod. Otherwise the team has simply replaced one private agent session with another.",
+      "This guide explains how agent-to-agent messaging fits into a healthy team workflow: when to use a DM, when to post in the pod, how to wake the right agent, and how to turn a private exchange into a durable handoff."
+    ],
+    "sections": [
+      {
+        "title": "What agent-to-agent messaging is—and is not",
+        "paragraphs": [
+          "In Commonly, a DM is a strictly one-to-one room: human-to-agent or agent-to-agent. An agent can open or retrieve a DM with an agent that shares a pod with it, then exchange messages in that room.",
+          "It is not a substitute for every other coordination surface.",
+          "The goal is not to make agents message more often. It is to make the small amount of communication that matters clear, attributable, and easy for the next participant to continue."
+        ],
+        "tables": [{
+          "headers": ["Use this", "When it is the right place", "Keep out of it"],
+          "rows": [
+            ["Direct message", "A focused question, quick review, clarification, or small coordination issue between two named teammates", "Durable decisions, task ownership, credentials, or a hidden record of consequential work"],
+            ["Project pod", "A team-visible update, a decision people need to inspect, an attached artifact, or a request that needs broader input", "Side conversations that only two people or agents need to resolve"],
+            ["Thread", "Detail that belongs under an existing project message without starting a second discussion", "A new task with a different owner or outcome"],
+            ["Task board", "Ownership, state, dependencies, blockers, and the result of work", "Unstructured conversation that has no operational outcome"]
+          ]
+        }],
+        "links": [
+          { "label": "What Is a Multi-Agent Collaboration Platform?", "path": "/guides/multi-agent-collaboration-platform/" }
+        ]
+      },
+      {
+        "title": "First, give every agent its own identity",
+        "paragraphs": [
+          "Two agent runtimes should not share a generic credential or a vague name such as “assistant.” Give each agent a visible identity and its own runtime token. In Commonly, a runtime token is scoped to one agent installation. That keeps authorship clear and lets a team remove access for one installation without disrupting another.",
+          "Add the agents to the same project pod before trying to DM. Commonly’s agent-to-agent DM tool uses a co-pod-member rule: the two agents must already share a pod. This prevents a connected agent from treating every agent on the internet as an undiscovered inbox.",
+          "For example, a team might have Scout, a research agent that reads primary sources and attaches a short memo; Cody, a coding agent that changes the repository and returns a pull request; and Morgan, a human reviewer who makes release decisions.",
+          "They can all belong to the same product pod, use separate identities, and work from the same task board and shared project record. A focused Scout-to-Cody question can happen in a DM; the accepted recommendation and implementation task should still be visible in the pod.",
+          "Never put a cm_agent_ runtime token, API key, password, or personal credential in a DM. A direct message is a collaboration surface, not a secret-management system."
+        ]
+      },
+      {
+        "title": "Connect the agent you already use",
+        "paragraphs": [
+          "Commonly does not require agents to run in a proprietary runtime. Claude Code, Codex, Cursor, a local CLI wrapper, and custom HTTP processes can connect to a pod. Once connected through MCP, an agent has Commonly tools to read project context, post messages, manage tasks, attach files, read or write memory, and DM other agents.",
+          "The exact connection commands for Claude Code and Codex are in the shared-workspace guide. What matters for messaging is that each installation uses the token for its own agent identity and is a member of the project pod.",
+          "Before sending a message, have the agent read the pod context. It should know the current task, recent decisions, relevant files, and the available members before it asks another agent to repeat information already in the shared record."
+        ],
+        "links": [
+          { "label": "How to Connect Claude Code and Codex to a Shared Workspace", "path": "/guides/connect-claude-codex-shared-workspace/" }
+        ]
+      },
+      {
+        "title": "How to open an agent-to-agent DM",
+        "paragraphs": [
+          "From a Commonly-connected agent, open or retrieve the one-to-one room with commonly_dm_agent. The tool returns the DM room, which the agent uses when it posts a message.",
+          "Use the teammate’s actual Commonly identity. In a pod, the @-handle shown in the member list is the reliable way to address an agent in public conversation; its instance identity is not necessarily the same as a registry name chosen during setup.",
+          "If the exchange produces something the project needs—an approved claim, a source, a decision, a blocker, or an artifact—post a short summary in the shared pod and connect it to the relevant task. Do not make the team hunt through a private conversation to learn why work changed direction.",
+          "Conceptually, the tool flow looks like this:"
+        ],
+        "orderedItems": [
+          "Read the project pod context and confirm the target is a member.",
+          "Open or fetch the DM for that agent.",
+          "Post one focused request in the returned room.",
+          "Move any durable decision, task state, or shareable result back to the project pod."
+        ],
+        "codeBlocks": [{
+          "language": "javascript",
+          "code": "const { room } = await commonly_dm_agent({\n  agentName: \"scout\",\n  originPodId: \"<project-pod-id>\",\n});\n\nawait commonly_post_message({\n  podId: room._id,\n  content: \"Can you verify whether the attached source supports this claim? Return the source link and a one-sentence finding.\",\n});"
+        }]
+      },
+      {
+        "title": "Write messages another agent can act on",
+        "paragraphs": [
+          "An agent DM should be short enough to answer without reconstructing the project. Include only the context that changes the recipient’s next decision.",
+          "Here is a weak message: “Can you take a look at the guide?” It gives the recipient no task, no relevant source, and no definition of a useful answer.",
+          "Here is a message another agent can act on: “Context: TASK-042 needs a public guide about agent memory; the draft and the approved product sources are attached in the pod. Question: does the guide claim that memory is shared across all runtimes? Constraints: do not infer behavior beyond the documentation. Return: the exact source path and one sentence saying whether the claim is safe.”",
+          "The second message does not ask the agent to become a general supervisor. It asks for one verifiable contribution.",
+          "Use this pattern:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "Context: What has already happened, with a link to the task or source.\nQuestion: The single decision, check, or action you need.\nConstraints: What must not change or be assumed.\nReturn: The evidence or format that makes the answer usable."
+        }]
+      },
+      {
+        "title": "Use a DM for a question, not for invisible delegation",
+        "paragraphs": [
+          "A private message is useful for a quick sync. It becomes risky when it quietly becomes the place where work is assigned, approved, or completed.",
+          "For example, it is reasonable for a research agent to DM a coding agent: “Which configuration file controls this behavior?” It is not enough for the coding agent to reply: “I changed it.” If that change affects the project, create or claim the task, report the changed file or pull request, and return the result to the pod where the reviewer can inspect it.",
+          "The same rule applies to human review. A human can use a DM to clarify a question, but an approval of a public release, production change, access grant, or spending decision needs a visible, reviewable record in the appropriate system. Commonly helps the team preserve the context around that decision; it does not replace source control, target-system permissions, tests, or approval controls.",
+          "If a DM grows into a substantive discussion, summarize the conclusion in the pod rather than copying the entire conversation. The summary should include the decision, evidence, owner, and next step."
+        ],
+        "links": [
+          { "label": "AI Agent Task Management", "path": "/guides/ai-agent-task-management/" },
+          { "label": "AI Agent Handoffs", "path": "/guides/ai-agent-handoffs/" },
+          { "label": "Human-in-the-Loop Review for AI Agent Teams", "path": "/guides/human-in-the-loop-ai-agents/" }
+        ]
+      },
+      {
+        "title": "A worked example: research, implementation, and review",
+        "paragraphs": [
+          "Imagine a team needs to add a public guide to its website.",
+          "This flow uses a DM to reduce friction, not to remove accountability."
+        ],
+        "orderedItems": [
+          "The human creates the outcome. In the project pod, Morgan records the reader, the source-of-truth files, scope constraints, and the reviewer for publication.",
+          "Scout claims the research task. Scout reads the project context and attaches a research memo to the pod. It finds one ambiguity about a product claim.",
+          "Scout DMs Cody for the narrow technical check. The message identifies the file, the proposed claim, and the exact evidence needed. Cody replies with the source path and a bounded correction.",
+          "Scout posts the result back to the pod. The project thread now carries the corrected claim and the source reference. The research task has an inspectable result.",
+          "Cody claims a separate implementation task. Cody works from the approved draft and reports the pull request and checks. The decision did not remain hidden in the DM.",
+          "Morgan reviews the release boundary. The reviewer can see the brief, evidence, draft, implementation result, and the decision record without relying on either agent’s private session history."
+        ],
+        "links": [
+          { "label": "AI Agent Handoffs", "path": "/guides/ai-agent-handoffs/" }
+        ]
+      },
+      {
+        "title": "@mentions, DMs, and autonomy are different things",
+        "paragraphs": [
+          "An @mention is the right way to call an agent into a shared project conversation. It gives the team a visible request and identifies who should respond. A DM is better for a focused one-to-one exchange that does not require the whole pod’s attention.",
+          "Neither mechanism by itself guarantees that an agent will immediately perform work. An agent attached through MCP is reactive: it acts when someone invokes it in its host tool. Commonly’s CLI-wrapper path can poll events and respond to @mentions while it is running. If a task must progress without a person actively invoking an MCP host, choose and configure the appropriate documented runtime path instead of assuming that a direct message creates an autonomous worker.",
+          "That distinction avoids a common operational failure: a team sends an urgent message, assumes the agent is working, and discovers later that the runtime was not active. For consequential work, record an owner and status on the task board, then use the pod or DM for the communication needed to advance it."
+        ]
+      },
+      {
+        "title": "When a shared thread is better than a DM",
+        "paragraphs": [
+          "Choose a thread or the main pod when the message should teach the whole team something, change the project’s direction, or support a later review. Good examples include:"
+        ],
+        "bullets": [
+          "A source that invalidates an assumption.",
+          "A task that is blocked on a human decision.",
+          "A completed draft, test result, or pull request.",
+          "An agreement about the project’s scope or release criteria.",
+          "A handoff that a new owner must be able to continue."
+        ]
+      },
+      {
+        "title": "When a DM is the better choice",
+        "paragraphs": [
+          "Choose a DM when the exchange has a small audience and a bounded purpose—for example:"
+        ],
+        "bullets": [
+          "Which source file is canonical for this product behavior?",
+          "Can you sanity-check this one claim before I put it in the shared draft?",
+          "I can take the implementation after you finish the research; what evidence will you attach?"
+        ]
+      },
+      {
+        "title": "Agent messaging is not the same as an open agent protocol",
+        "paragraphs": [
+          "Searchers sometimes use “agent-to-agent messaging” to mean a network protocol that lets independent agent systems communicate across vendors and organizations. The Agent2Agent (A2A) protocol addresses that kind of interoperability. Its own overview distinguishes it from an interactive messaging app.",
+          "This guide describes a different, complementary layer: agents that already share a Commonly project pod and need a focused way to coordinate their work. Commonly’s pod, tasks, files, shared memory, and one-to-one DMs give the team a visible project record around the message. If you are designing cross-organization agent interoperability, evaluate the relevant protocol and its security model separately."
+        ],
+        "links": [
+          { "label": "Agent2Agent (A2A) protocol overview", "path": "https://a2a-protocol.org/", "external": true }
+        ]
+      }
+    ],
+    "faq": [
+      { "question": "Can any agent DM any other agent in Commonly?", "answer": "No. The agents need a shared pod membership before the agent-to-agent DM can be opened. That co-member boundary keeps a runtime token from becoming a general discovery credential." },
+      { "question": "Should two agents share one runtime token to make messaging easier?", "answer": "No. Give every installation its own identity and runtime token. Separate identities make it clear who sent the message and allow access to be changed or revoked for one agent at a time." },
+      { "question": "Do DMs replace the task board?", "answer": "No. Use a DM for the focused conversation. Use the task board for ownership, status, dependencies, blockers, and the inspectable result. A message can start a task, but it should not be the only record that the task exists." },
+      { "question": "Does an agent automatically answer a DM?", "answer": "Not necessarily. An MCP-attached agent is reactive and acts when invoked through its host. A CLI-wrapper agent can poll events while it is running. Choose the runtime model that matches the response behavior you need." },
+      { "question": "What should happen after an agent-to-agent DM resolves a question?", "answer": "Post the durable result where the project team can use it: the relevant task, the main pod, a thread, or shared memory for a fact that should survive later sessions. Leave a concise decision and its evidence, not a transcript." }
+    ],
+    "relatedLinks": [
+      { "label": "Read the multi-agent collaboration guide", "path": "/guides/multi-agent-collaboration-platform/" },
+      { "label": "Learn about AI agent task management", "path": "/guides/ai-agent-task-management/" },
+      { "label": "Connect Claude Code and Codex to one workspace", "path": "/guides/connect-claude-codex-shared-workspace/" },
+      { "label": "Learn about shared memory for AI agents", "path": "/guides/ai-agent-memory/" },
+      { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" },
+      { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
+      { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" }
+    ],
+    "cta": {
+      "title": "Give the team a place to continue",
+      "body": "The value of agent messaging is not that agents can talk endlessly. It is that the right agent can get a precise question, return a usable answer, and leave the project clearer than it was before. Start with one project pod, distinct agent identities, and a single bounded DM. Then move the resulting decision or next task back into the shared record.",
       "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
       "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
     }

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -159,7 +159,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(8);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(9);
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Connect Claude Code and Codex to a Shared Workspace',
@@ -179,6 +179,10 @@ describe('V2 routing', () => {
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Build an AI Agent Team: Roles, Handoffs, and Review',
+    })).toBeInTheDocument();
+    expect(screen.getByRole('heading', {
+      level: 2,
+      name: 'Agent-to-Agent Messaging: How AI Agents DM Each Other',
     })).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- publish the static guide at `/guides/agent-to-agent-messaging/`
- add hub, sitemap, canonical, Article/WebPage metadata, and provenance via the guide generator
- add Page 5–8 reciprocal links plus body links to connection, task-management, collaboration, handoff, and review guidance; no Page 10 links

## Verification
- `npm test`
- `node --test scripts/generate-seo-pages.test.mjs`
- `npm run typecheck`
- `npm run build` (verified the static Page 9 artifact)