### PR TITLE
fix(v2): repair the unbalanced brace that dropped 734 selectors from v2.css

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -731,6 +731,22 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).toContain('var(--v2-fs-feature)');
   });
 
+  // Every presence assertion in this file greps a STRING. A stylesheet whose
+  // braces do not balance still contains every string, so the whole suite
+  // stayed green while a stray brace (#1376, `.v2-team__tabs {.v2-team__tabs {`)
+  // folded 734 selectors — Avatar, Login, empty states, admin users, billing —
+  // into one unparseable rule that ran to EOF. Browsers recover silently: no
+  // console error, no failed build, 11/11 CI checks green. This is the cheapest
+  // check that discriminates, and the only one here that is about SYNTAX rather
+  // than content.
+  it('v2.css braces balance and no line opens two rules', () => {
+    expect(v2.split('{').length).toBe(v2.split('}').length);
+    const doubled = v2.split('\n')
+      .map((line, i) => [i + 1, line] as const)
+      .filter(([, line]) => (line.match(/{/g) || []).length > 1);
+    expect(doubled).toEqual([]);
+  });
+
   it('platform tint tokens exist in v2.css and tokens.css together', () => {
     const ds = fs.readFileSync(path.join(__dirname, '../../../design-system/tokens.css'), 'utf8');
     for (const pf of ['telegram', 'slack', 'discord', 'whatsapp']) {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4020,7 +4020,7 @@ body.modern-ui.v2-canvas {
 }
 .v2-team-quiet__profile { font-size: 12px; }
 
-.v2-team__tabs {.v2-team__tabs {
+.v2-team__tabs {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;


### PR DESCRIPTION
**On main now** (`046f6e406`, merged 22:21Z via #1376). `frontend/src/v2/v2.css:4023` reads:

```css
.v2-team__tabs {.v2-team__tabs {
```

Two opening braces on one line. Browsers recover by treating everything that follows as declarations of the enclosing block, so the rest of the file collapses into one unparseable rule.

## Measured, not reasoned

Both stylesheets served over http and read with `getComputedStyle` / `document.styleSheets` in a real browser — jsdom has no CSS parser, which is exactly why all 11 checks passed on #1376.

| | parsed rules | `.v2-team__tabs` computed `display` |
|---|---|---|
| `main` before #1376 | **1094** | `flex` |
| `main` after #1376 | **495** | `block` |

After the merge `.v2-team__tabs` is the **last** rule in the sheet, with a `cssText` of **96,689 characters** — it swallowed the remaining ~4,500 lines. `.v2-team-card` (defined at line 5807) does not exist in the parsed sheet at all.

**734 top-level selectors from line 4023 to EOF never reach the page**, including the Avatar, Login, empty/loading states, invite modal, admin users, and billing sections — and the Your Team card CSS #1376 itself was restyling.

## The guard

Every assertion in `v2-layout-invariants` greps a **string**, and a stylesheet with a stray brace still contains every string — so the suite stayed green through this. Added the cheapest check that discriminates, and the only one in that file about syntax rather than content:

```
BROKEN (046f6e406)  balanced: false   doubled-lines: [[4023, ".v2-team__tabs {.v2-team__tabs {"]]
FIXED               balanced: true    doubled-lines: []
```

Both assertions fail on the current main and pass here.

## Not in scope

Three smaller things noted while reviewing #1376, left for its author rather than folded into a P0 fix:

1. `v2-role-chip` is now dead CSS — the category chip was removed from every card while the category **filter** above it remains, so you can filter by a category you can no longer see. `yourTeam.card.roleTitle`, `yourTeam.subtitle.summary`, and `subtitle.projectCount*` are orphaned in `en.json` and `zh-CN.json` alongside it.
2. In `tokens.css` the `/* sidebar titles */` comment migrated off `--c-fs-xl: 16px` onto the new `--c-fs-feature: 17px`, mislabelling both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)