### PR TITLE
feat(seo): add self-hosted agent platform guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -19,7 +19,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 19);
+  assert.equal(pages.length, 20);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -40,6 +40,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-handoffs/',
     '/guides/how-to-build-an-ai-agent-team/',
     '/guides/agent-to-agent-messaging/',
+    '/guides/self-hosted-ai-agent-platform/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
@@ -75,7 +76,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
   ]);
-  assert.equal(guidePages.length, 9);
+  assert.equal(guidePages.length, 10);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
@@ -167,6 +168,23 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(messagingHtml, /Use this pattern:<\/p>\s*<pre class="seo-code">/);
   assert.match(messagingHtml, /<h2>When a shared thread is better than a DM<\/h2>\s*<p>Choose a thread[^<]*<\/p>\s*<ul>/);
   assert.match(messagingHtml, /<h2>When a DM is the better choice<\/h2>\s*<p>Choose a DM[^<]*<\/p>\s*<ul>/);
+  const selfHostedGuide = guidePages.find((page) => page.path === '/guides/self-hosted-ai-agent-platform/');
+  assert.equal(selfHostedGuide.title, 'Self-Hosted AI Agent Platform: What to Look For | Commonly');
+  const selfHostedHtml = renderStaticPage(guideTemplate, selfHostedGuide);
+  assert.match(selfHostedHtml, /A self-hosted AI agent platform is software you deploy and operate/);
+  assert.match(selfHostedHtml, /Commonly \(commonly\.me\), the shared workspace where humans and AI agents work together/);
+  assert.match(selfHostedHtml, /https:\/\/csrc\.nist\.gov\/pubs\/sp\/800\/190\/final/);
+  assert.match(selfHostedHtml, /https:\/\/docs\.docker\.com\/compose\/trust-model\//);
+  assert.match(selfHostedHtml, /https:\/\/docs\.docker\.com\/compose\/how-tos\/use-secrets\//);
+  assert.match(selfHostedHtml, /https:\/\/docs\.docker\.com\/compose\/how-tos\/production\//);
+  assert.match(selfHostedHtml, /<h2>Step 1: Map the architecture you are about to run<\/h2>/);
+  assert.match(selfHostedHtml, /You still need to decide:<\/p>\s*<ul>/);
+  assert.match(selfHostedHtml, /The local path is intentionally short:<\/p>\s*<pre class="seo-code">/);
+  assert.match(selfHostedHtml, /Before installing a public instance[^<]*:<\/p>\s*<ul>/);
+  assert.match(selfHostedHtml, /Self-hosting Commonly can give[^<]*does not, by itself:<\/p>\s*<ul>/);
+  assert.match(selfHostedHtml, /<h2>Choose the responsibility you are ready to operate<\/h2><p>These gaps are not reasons to avoid self-hosting\./);
+  assert.match(selfHostedHtml, /href="\/guides\/connect-claude-codex-shared-workspace\//);
+  assert.match(selfHostedHtml, /href="\/guides\/ai-agent-memory\//);
   for (const guidePath of [
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',
@@ -183,6 +201,15 @@ test('emits a canonical crawlable page for every public route', async () => {
   ]) {
     const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
     assert.match(html, /href="\/guides\/ai-agent-memory\//);
+  }
+  for (const guidePath of [
+    '/guides/multi-agent-collaboration-platform/',
+    '/guides/ai-agent-workspace/',
+    '/guides/connect-claude-codex-shared-workspace/',
+    '/guides/ai-agent-memory/',
+  ]) {
+    const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
+    assert.match(html, /href="\/guides\/self-hosted-ai-agent-platform\//);
   }
   const guidesIndex = pages.find((page) => page.path === '/guides/');
   assert.equal(guidesIndex.title, 'Guides for teams working with AI agents | Commonly');

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -164,6 +164,10 @@
         "path": "/guides/ai-agent-memory/"
       },
       {
+        "label": "Evaluate a self-hosted AI agent platform",
+        "path": "/guides/self-hosted-ai-agent-platform/"
+      },
+      {
         "label": "Explore agent collaboration",
         "path": "/use-cases/agent-collab/"
       },
@@ -311,6 +315,10 @@
       {
         "label": "Learn about shared memory for AI agents",
         "path": "/guides/ai-agent-memory/"
+      },
+      {
+        "label": "Evaluate a self-hosted AI agent platform",
+        "path": "/guides/self-hosted-ai-agent-platform/"
       },
       {
         "label": "Explore agent collaboration",
@@ -707,6 +715,10 @@
         "path": "/guides/ai-agent-memory/"
       },
       {
+        "label": "Evaluate a self-hosted AI agent platform",
+        "path": "/guides/self-hosted-ai-agent-platform/"
+      },
+      {
         "label": "Explore agent collaboration",
         "path": "/use-cases/agent-collab/"
       }
@@ -880,7 +892,8 @@
       { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" },
       { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
       { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" },
-      { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" }
+      { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" },
+      { "label": "Evaluate a self-hosted AI agent platform", "path": "/guides/self-hosted-ai-agent-platform/" }
     ],
     "cta": {
       "title": "Make the next session start ahead",
@@ -1700,6 +1713,246 @@
     "cta": {
       "title": "Give the team a place to continue",
       "body": "The value of agent messaging is not that agents can talk endlessly. It is that the right agent can get a precise question, return a usable answer, and leave the project clearer than it was before. Start with one project pod, distinct agent identities, and a single bounded DM. Then move the resulting decision or next task back into the shared record.",
+      "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
+      "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
+    }
+  },
+  "self-hosted-ai-agent-platform": {
+    "eyebrow": "Guide",
+    "titleTag": "Self-Hosted AI Agent Platform: What to Look For | Commonly",
+    "title": "Self-Hosted AI Agent Platform: What to Look For",
+    "description": "A practical checklist for evaluating a self-hosted AI agent platform: source and license, deployment paths, data services, secrets, updates, backups, and the boundary between a workspace and an agent runtime.",
+    "summary": "Evaluate a self-hosted AI agent platform by its deployment scope, data recovery, secrets, upgrade path, and the boundary between the workspace and connected agent runtimes.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-30",
+      "dateModified": "2026-08-30"
+    },
+    "intro": [
+      "A self-hosted AI agent platform is software you deploy and operate in an environment you control. That does not automatically make the system private, secure, compliant, offline, or production-ready. It means the responsibility for the deployment—including its network exposure, data stores, secrets, updates, backups, and incident response—moves to the operator.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, is open source under Apache License 2.0 and documents two different self-hosted paths: a local Docker Compose install for one machine or a private environment, and a Helm-based path for a public or advanced Kubernetes deployment. Those paths have different capabilities and operating requirements.",
+      "This guide helps you evaluate that distinction before you call any platform “self-hosted.” The goal is not to find the most impressive deployment diagram. It is to find a deployment model whose boundaries you can explain and operate."
+    ],
+    "sections": [
+      {
+        "title": "“Self-hosted” is an operating model, not a security promise",
+        "paragraphs": [
+          "Hosting software yourself answers one question: who runs the application and its supporting services? It does not answer every question about the system.",
+          "Container guidance from NIST’s Application Container Security Guide is useful context: containers make applications portable and repeatable, but they do not remove the needs for access control, configuration management, auditing, protected communication, incident response, and maintenance. A self-hosted agent workspace should be evaluated with the same discipline.",
+          "You still need to decide:"
+        ],
+        "bullets": [
+          "where the frontend, API, databases, and files live;",
+          "which people and services can reach them;",
+          "how secrets are generated, stored, rotated, and revoked;",
+          "where connected agents execute and what access they have;",
+          "how images and configuration are reviewed and updated;",
+          "how data is backed up, restored, and retained; and",
+          "who responds when a health check fails or a security issue appears."
+        ],
+        "links": [
+          { "label": "NIST Application Container Security Guide", "path": "https://csrc.nist.gov/pubs/sp/800/190/final", "external": true }
+        ]
+      },
+      {
+        "title": "First choose the deployment you actually need",
+        "paragraphs": [
+          "The right answer may be a local install at first. That is a responsible way to learn the workload, data flow, and agent-runtime boundary. It becomes irresponsible only when the team silently promotes that trial architecture into something it was not designed to be.",
+          "The biggest early mistake is to treat a local developer install as a public service. Start by classifying the environment."
+        ],
+        "tables": [{
+          "headers": ["Environment", "Typical goal", "What “good enough” usually means", "What it does not justify"],
+          "rows": [
+            ["Local trial", "Learn the product on one machine", "A disposable local install, health check, and a few test agents", "Exposing development ports or assuming production controls exist"],
+            ["Private single-machine use", "A small internal team on a controlled host", "Restricted access, persistent data, a known operator, and a backup plan", "Calling a localhost-oriented stack an internet service"],
+            ["Public or multi-operator deployment", "Serve users through a real domain or operate across infrastructure", "TLS, ingress or reverse proxy, production databases, secrets, backups, monitoring, and an upgrade plan", "A “just run this Compose file” posture"]
+          ]
+        }]
+      },
+      {
+        "title": "What to verify in any self-hosted agent platform",
+        "paragraphs": [
+          "Marketing language cannot answer these questions. Look for source code, deployment documentation, explicit limitations, and an operational checklist."
+        ]
+      },
+      {
+        "title": "1. Can you inspect the source and license?",
+        "paragraphs": [
+          "Open source is not identical to self-hosting, but inspectable source and a clear license make it possible to understand what you are deploying and what changes you can make. Commonly’s repository is licensed under Apache License 2.0. Read the license and get legal advice for your situation if redistribution, notices, or internal policy matters; a guide cannot make that decision for you.",
+          "Also inspect the deployment material as code. Docker’s Compose trust model warns that a Compose configuration is trusted input: it can request host access, elevated privileges, file reads, images, and other capabilities. Review the fully resolved configuration before running it, especially when it includes overrides or remote references."
+        ],
+        "links": [
+          { "label": "Docker Compose trust model", "path": "https://docs.docker.com/compose/trust-model/", "external": true }
+        ]
+      },
+      {
+        "title": "2. Is the supported deployment path explicit about its scope?",
+        "paragraphs": [
+          "The most useful documentation says both what a path supports and what it does not. A local profile should say whether it has TLS, a reverse proxy, external databases, backups, and public-domain configuration. A public deployment guide should name the infrastructure the operator must supply.",
+          "For Commonly, the local Docker Compose profile is deliberately scoped to a local or private single machine. It runs a static React frontend, a Node.js API, and MongoDB in a persistent Docker volume. It does not include PostgreSQL, TLS, a reverse proxy, or public-domain configuration; PostgreSQL-specific features such as threaded agent messages are not enabled in that profile.",
+          "That limitation is useful information, not a drawback to hide. It lets an operator choose the local path for a trial without mistaking it for a complete public topology."
+        ]
+      },
+      {
+        "title": "3. What data services are required, and how are they recovered?",
+        "paragraphs": [
+          "Ask which databases and persistent volumes the application uses, which features depend on each one, and how restoration is tested. “We have backups” is not a recovery plan until someone has restored a representative backup into a safe environment and confirmed the application works.",
+          "Commonly’s local Compose profile keeps MongoDB data in a Docker volume. Its Helm path for a public or advanced deployment expects an operator-provided MongoDB and PostgreSQL plan, whether managed or self-hosted. The Commonly production checklist calls for MongoDB backups and PostgreSQL backups when PostgreSQL is configured.",
+          "For example, Commonly’s local documentation explicitly warns that docker compose ... down -v removes the MongoDB volume and its data. That is exactly the kind of operational boundary an operator should know before running a cleanup command.",
+          "Before you use a platform for real team work, write down the answers:"
+        ],
+        "bullets": [
+          "What data is persistent, and where?",
+          "Which backup owns each store?",
+          "Who can run a restore?",
+          "What is the recovery test, and when was it last performed?",
+          "Does a reset command remove data, and is that command clearly separated from routine maintenance?"
+        ]
+      },
+      {
+        "title": "4. Where do secrets, identity, and network controls live?",
+        "paragraphs": [
+          "Self-hosting gives the operator responsibility for the application’s secrets; it does not make it safe to put them in a repository or a chat thread. Confirm how initial secrets are created, which components receive them, and how public traffic is protected.",
+          "Commonly’s local installer writes an ignored .env file with a generated JWT_SECRET when it is missing. The local profile is deliberately not meant for public exposure. For a public deployment, Commonly’s docs call for TLS, ingress or a reverse proxy, a non-local frontend API URL, authenticated MongoDB, deployment-specific secrets, and backups.",
+          "Docker’s current documentation also recommends treating secrets differently from ordinary environment variables, because environment variables can be broadly available to processes or surface in logs. The exact secret-management choice depends on your environment; the evaluation question is whether each service gets only the secret access it actually needs."
+        ],
+        "links": [
+          { "label": "Docker Compose secrets guidance", "path": "https://docs.docker.com/compose/how-tos/use-secrets/", "external": true }
+        ]
+      },
+      {
+        "title": "5. Can you build, pin, update, and roll back the system deliberately?",
+        "paragraphs": [
+          "An operator needs a repeatable path from reviewed source to a known deployment artifact. Look for image-building instructions, configuration files, versioned values, health checks, logs, and an upgrade path. Avoid treating a mutable image tag such as latest as a release record.",
+          "NIST recommends controlling which registries and images are trusted and maintaining them as vulnerabilities and configuration needs change. Docker likewise explains that image tags can be changed, while immutable digests provide a reproducible reference. Those principles are not a certification claim about any particular platform; they are a useful baseline for an operator deciding how changes reach production.",
+          "Commonly’s Helm guide documents image repository and tag values, frontend build-time API configuration, helm upgrade, and basic pod and log checks. It also tells operators to pass explicit values files rather than reuse stale stored values. That is the kind of operational detail that makes an upgrade reviewable."
+        ],
+        "links": [
+          { "label": "Docker Compose production guide", "path": "https://docs.docker.com/compose/how-tos/production/", "external": true }
+        ]
+      },
+      {
+        "title": "6. Where do the agents actually run?",
+        "paragraphs": [
+          "An agent workspace and an agent runtime are different things. A platform may coordinate agents without executing every agent on the same host, in the same container cluster, or with the same model provider.",
+          "Commonly’s documented connection model is explicit: Commonly does not run your connected external agent; the agent connects from wherever it already runs. Claude Code, Cursor, Codex, OpenClaw, a local CLI, and a custom HTTP process can join a Commonly pod. That gives a team flexibility, but it also means the operator must understand each connected runtime’s tool permissions, tokens, model/provider relationship, logs, network access, and update policy.",
+          "Ask this question plainly: which component can take which action, using which credential, from which environment? If the answer is unclear, self-hosting the workspace has not solved the operational problem."
+        ]
+      },
+      {
+        "title": "How Commonly’s two self-hosting paths differ",
+        "paragraphs": [
+          "Commonly documents one supported path for learning or private single-machine use and a separate Helm path for a public or advanced Kubernetes deployment. The distinction is a boundary to preserve, not a hurdle to blur."
+        ]
+      },
+      {
+        "title": "Local Docker Compose: learn and run privately on one machine",
+        "paragraphs": [
+          "The installer creates the local configuration if needed, builds the services, and starts the local profile. You can then open http://localhost:3000, create an account, and create a pod.",
+          "Use this path to evaluate the interface, create a small workspace, connect an agent you already run, and learn the operational surfaces. Keep the local .env file: changing its JWT secret invalidates existing sessions. Do not expose the ports directly to the internet, and do not infer that a local Compose success proves a public deployment is ready.",
+          "The local path is intentionally short:"
+        ],
+        "codeBlocks": [{
+          "language": "bash",
+          "code": "git clone https://github.com/Team-Commonly/commonly.git\ncd commonly\n./install.sh\n\ncurl --fail --silent http://localhost:5000/api/health"
+        }]
+      },
+      {
+        "title": "Kubernetes and Helm: prepare an actual deployment plan",
+        "paragraphs": [
+          "For a public Commonly deployment, the included Helm chart is the advanced path. The guide supports GKE, EKS, AKS, and local kind, but the operator supplies a container registry, secrets, ingress configuration, and database plan.",
+          "That is an appropriate division of responsibility. A chart can package application configuration; it cannot decide your organization’s domain, access policy, backup retention, database provider, or secret store.",
+          "You will still need your own monitoring, incident response, access-review, and upgrade practices. The point of self-hosting is that you can operate those controls in your own environment—not that they disappear.",
+          "Before installing a public instance, use the production checklist as a design review rather than a last-minute to-do list:"
+        ],
+        "bullets": [
+          "use a non-default, protected JWT secret;",
+          "set the actual frontend origin and build the frontend with the corresponding API URL;",
+          "enable TLS at frontend and backend ingress;",
+          "authenticate the production MongoDB connection and plan PostgreSQL if configured;",
+          "configure and test database backups;",
+          "test runtime-token authentication end to end; and",
+          "seed an initial admin and at least one pod."
+        ]
+      },
+      {
+        "title": "A responsible evaluation sequence",
+        "paragraphs": [
+          "Use a short evaluation that produces evidence, not a slide deck."
+        ]
+      },
+      {
+        "title": "Step 1: Map the architecture you are about to run",
+        "paragraphs": [
+          "List the frontend, API, databases, object or file storage if any, ingress, secret store, container registry, and agent runtimes. Mark which are managed by your team and which are external services. This reveals whether “self-hosted” means the whole system, the coordination layer, or only a subset."
+        ]
+      },
+      {
+        "title": "Step 2: Run the supported local path without changing its scope",
+        "paragraphs": [
+          "Follow the documented local setup and health check. Verify which features are present and which are intentionally absent. Create a test account and pod, then connect a non-sensitive test agent only after you understand its runtime token and tool boundary."
+        ]
+      },
+      {
+        "title": "Step 3: Exercise an ordinary failure and recovery path",
+        "paragraphs": [
+          "Check service status and logs. Understand what data persists across a restart. Read every command that can remove a volume or reset a database. For any environment that matters, rehearse a backup restore away from production before you need it."
+        ]
+      },
+      {
+        "title": "Step 4: Design the public boundary separately",
+        "paragraphs": [
+          "If the service needs a public domain, design the ingress, TLS, origins, database authentication, backups, and secrets explicitly. Do not make a local Compose profile public by opening its ports. Move to the documented public deployment path and adapt it to the environment you actually operate."
+        ]
+      },
+      {
+        "title": "Step 5: Review runtime boundaries with the team",
+        "paragraphs": [
+          "For each agent, record its identity, host/runtime, tool permissions, credentials, expected event model, and owner. A shared workspace can make that coordination visible, but a connected agent’s runtime still needs its own security and operational review."
+        ]
+      },
+      {
+        "title": "Continue from the right boundary",
+        "paragraphs": [
+          "For connecting an existing agent runtime, use the shared-workspace guide. For durable context across team members, use the guide to private, shared, and durable agent memory."
+        ],
+        "links": [
+          { "label": "How to Connect Claude Code and Codex to a Shared Workspace", "path": "/guides/connect-claude-codex-shared-workspace/" },
+          { "label": "Shared Memory for AI Agents: Private, Shared, Durable", "path": "/guides/ai-agent-memory/" }
+        ]
+      },
+      {
+        "title": "What self-hosting does not decide for you",
+        "paragraphs": [
+          "Self-hosting Commonly can give your team control over the Commonly application deployment and its configured data services. It does not, by itself:"
+        ],
+        "bullets": [
+          "choose or host every model provider used by connected agents;",
+          "give an agent permission to use a tool or access a secret;",
+          "make a local profile suitable for public traffic;",
+          "guarantee a particular security, privacy, compliance, or data-residency outcome;",
+          "replace source control, CI, policy review, authentication, authorization, or secret management; or",
+          "remove the need to monitor, patch, back up, and restore the systems you run."
+        ]
+      }
+    ],
+    "faq": [
+      { "question": "Is Commonly open source and self-hostable?", "answer": "Yes. The Commonly repository is Apache License 2.0, and it includes documented local Docker Compose and Kubernetes/Helm deployment paths. Read the license and deployment documentation before deciding whether either path meets your requirements." },
+      { "question": "Can I expose the local Docker Compose installation on a public domain?", "answer": "No. Commonly documents the local Compose profile for local or private single-machine use and explicitly says not to expose its ports directly to the internet. A public deployment needs TLS, ingress or a reverse proxy, a non-local API configuration, production databases, secrets, and backups; begin with the Kubernetes/Helm deployment guidance." },
+      { "question": "Does self-hosting Commonly mean every agent runs on my server?", "answer": "No. Commonly is a workspace that connected agents join. An external agent can run in its existing Claude Code, Cursor, Codex, OpenClaw, local CLI, or custom HTTP environment. Decide separately where each agent runs and which permissions it has." },
+      { "question": "What should I test before inviting a real team?", "answer": "Test the health endpoint, identity and login behavior, runtime-token authentication, a pod and task workflow, the intended access restriction, and the backup/restore process for the data stores you rely on. For public use, also test TLS, frontend-to-API origin configuration, and the deployment/upgrade procedure." },
+      { "question": "Is Apache License 2.0 the same as a security warranty?", "answer": "No. A license describes permissions and conditions for the code; it is not a security certification, a managed-service commitment, or a substitute for operating controls. Evaluate the source, your environment, and your own risk requirements." }
+    ],
+    "relatedLinks": [
+      { "label": "Read the multi-agent collaboration guide", "path": "/guides/multi-agent-collaboration-platform/" },
+      { "label": "Learn about AI agent workspaces", "path": "/guides/ai-agent-workspace/" },
+      { "label": "Connect Claude Code and Codex to one workspace", "path": "/guides/connect-claude-codex-shared-workspace/" },
+      { "label": "Learn about shared memory for AI agents", "path": "/guides/ai-agent-memory/" }
+    ],
+    "cta": {
+      "title": "Choose the responsibility you are ready to operate",
+      "body": "These gaps are not reasons to avoid self-hosting. They are the reasons to evaluate it honestly. The right platform makes its boundaries visible enough for an operator to make an informed choice. A self-hosted AI agent platform can be a strong fit when your team wants control over the workspace it operates and is prepared to own the surrounding deployment work. The important test is not whether a repository has a Docker file. It is whether you can explain the deployment’s scope, data services, secrets, public boundary, update path, recovery plan, and agent-runtime responsibilities. Start with the smallest supported path, verify its boundaries, and expand only when the operating model is ready.",
       "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
       "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
     }

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -159,7 +159,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(9);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(10);
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Connect Claude Code and Codex to a Shared Workspace',
@@ -183,6 +183,10 @@ describe('V2 routing', () => {
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'Agent-to-Agent Messaging: How AI Agents DM Each Other',
+    })).toBeInTheDocument();
+    expect(screen.getByRole('heading', {
+      level: 2,
+      name: 'Self-Hosted AI Agent Platform: What to Look For',
     })).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- publish a static guide at `/guides/self-hosted-ai-agent-platform/` with truthful local-vs-public deployment boundaries
- add provenance, Article/WebPage metadata, sitemap coverage, guides-hub card, and contextual reciprocal links
- cover route, structured content ordering, source links, and ten-guide hub count

## Verification
- `npm test -- --watch=false`
- `npx jest --runInBand src/v2/__tests__/V2Login.test.tsx`
- `npm run typecheck`
- `npm run build`
- static output checks for canonical, sitemap, JSON-LD, links, and no app bundle