### PR TITLE
fix(css): unclosed brace from #1376's doubled insertion anchor (prod-visible)

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -731,6 +731,17 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).toContain('var(--v2-fs-feature)');
   });
 
+  it('v2.css braces balance — an unclosed block silently swallows every later rule', () => {
+    // Shipped 2026-08-30: a doubled selector anchor ('.v2-team__tabs {.v2-team__tabs {')
+    // left one brace unclosed; the build tolerated it, the browser dropped
+    // every rule after line ~4023 (header CTAs unstyled, avatar sizing gone).
+    // jsdom can't see the breakage; brace balance is the cheap structural pin.
+    const opens = (v2.match(/\{/g) || []).length;
+    const closes = (v2.match(/\}/g) || []).length;
+    expect(opens).toBe(closes);
+    expect(v2).not.toMatch(/\{[^\n}]*\{/); // two opens on one line = doubled anchor
+  });
+
   it('platform tint tokens exist in v2.css and tokens.css together', () => {
     const ds = fs.readFileSync(path.join(__dirname, '../../../design-system/tokens.css'), 'utf8');
     for (const pf of ['telegram', 'slack', 'discord', 'whatsapp']) {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4020,7 +4020,7 @@ body.modern-ui.v2-canvas {
 }
 .v2-team-quiet__profile { font-size: 12px; }
 
-.v2-team__tabs {.v2-team__tabs {
+.v2-team__tabs {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;


### PR DESCRIPTION
The tier CSS insertion in #1376 doubled its anchor ('.v2-team__tabs {' twice on one line), leaving one brace unclosed. postcss tolerated it at build time; the browser dropped every rule after ~line 4023 — header CTAs rendered as bare inline text, avatar sizing broke. Found by the spec-mandated real-browser pass minutes after deploy.

One-line fix; the new layout invariant pins brace balance and the doubled-anchor shape. Deploying on green — the live page is visibly broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJ1bDdDQwWekHDqweiBhRN