### PR TITLE
fix(events): hand off declined human wakes

### DIFF
--- a/backend/__tests__/service/messageClaimHandoff.test.js
+++ b/backend/__tests__/service/messageClaimHandoff.test.js
@@ -1,0 +1,125 @@
+/**
+ * Claim-decline recovery crosses two persistence layers: PostgreSQL owns the
+ * message lease; Mongo owns the original wake cohort. This Tier 1 test uses
+ * both real services. pg-mem cannot parse the PostgreSQL array/CAS expression
+ * that appends a decliner, so a unit mock would be actively misleading here.
+ */
+
+/* eslint-disable import/extensions, import/no-unresolved -- backend TypeScript
+ * modules expose CJS compatibility exports. */
+
+const mongoose = require('mongoose');
+
+const AgentEvent = require('../../models/AgentEvent');
+const { AgentInstallation } = require('../../models/AgentRegistry');
+const { pool } = require('../../config/db-pg');
+const MessageClaimService = require('../../services/messageClaimService');
+const MessageClaimHandoffService = require('../../services/messageClaimHandoffService');
+
+const describeTier1 = process.env.INTEGRATION_TEST === 'true' ? describe : describe.skip;
+
+describeTier1('message claim decline handoff — real Mongo + PostgreSQL', () => {
+  const podId = new mongoose.Types.ObjectId();
+  const ownerId = new mongoose.Types.ObjectId();
+  const messageId = 'human-message-claim-handoff';
+
+  const sourcePayload = (agentName) => ({
+    messageId,
+    content: `Human message, addressed to ${agentName}.`,
+    wakeOnMessage: true,
+    senderIsHuman: true,
+  });
+
+  const seedCohort = async (names) => {
+    await Promise.all(names.map((agentName) => AgentInstallation.create({
+      agentName,
+      instanceId: 'default',
+      podId,
+      version: '1.0.0',
+      installedBy: ownerId,
+      config: { wakeOnMessage: { enabled: true } },
+    })));
+    await AgentEvent.insertMany(names.map((agentName) => ({
+      agentName,
+      instanceId: 'default',
+      podId,
+      type: 'message.posted',
+      payload: sourcePayload(agentName),
+    })));
+  };
+
+  beforeAll(async () => {
+    // This suite is Tier 1 by construction. Keep its bootstrap local rather
+    // than importing testUtils: that helper also initialises pg-mem for Tier
+    // 0 and cannot exercise PostgreSQL's array/CAS expression.
+    await mongoose.connect(process.env.MONGO_URI);
+  });
+
+  beforeEach(async () => {
+    await mongoose.connection.dropDatabase();
+    // The self-bootstrapping claim table is intentionally not in schema.sql.
+    // It exists after the first test; tolerate first-run before its creation.
+    await pool.query('DELETE FROM message_claims').catch((err) => {
+      if (!/message_claims/i.test(err.message)) throw err;
+    });
+  });
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM message_claims').catch(() => undefined);
+    await mongoose.disconnect();
+    // config/db-pg owns its own pg.Pool (separate from the test helper's
+    // pg-mem pool), so close it explicitly or this Tier 1 suite leaks a
+    // socket and Jest correctly reports an open handle.
+    await pool.end();
+  });
+
+  test('a decline reaches one other active installation, which can claim it', async () => {
+    await seedCohort(['seat-a', 'seat-b']);
+    expect(await MessageClaimService.claim({
+      messageId, podId: String(podId), agentName: 'seat-a',
+    })).toMatchObject({ claimed: true });
+
+    const release = await MessageClaimHandoffService.release({
+      messageId, agentName: 'seat-a', outcome: 'declined',
+    });
+
+    expect(release).toMatchObject({ handoff: { queued: true, agentName: 'seat-b' } });
+    const reoffers = await AgentEvent.find({ 'payload.claimHandoff': { $exists: true } }).lean();
+    expect(reoffers).toHaveLength(1);
+    expect(reoffers[0]).toMatchObject({
+      agentName: 'seat-b',
+      payload: expect.objectContaining({ claimHandoff: { attempt: 1 }, senderIsHuman: true }),
+    });
+
+    expect(await MessageClaimService.claim({
+      messageId, podId: String(podId), agentName: 'seat-b',
+    })).toMatchObject({ claimed: true, declinedBy: ['seat-a:default'] });
+  });
+
+  test('five declines consume the original five-seat cohort and stop', async () => {
+    const names = ['seat-a', 'seat-b', 'seat-c', 'seat-d', 'seat-e'];
+    await seedCohort(names);
+
+    await names.reduce(async (previous, agentName, index) => {
+      await previous;
+      expect(await MessageClaimService.claim({
+        messageId, podId: String(podId), agentName,
+      })).toMatchObject({ claimed: true });
+      // Every decline is sequential because only the one re-offered seat is
+      // allowed to attempt the next claim — this is the no-stampede contract.
+      const release = await MessageClaimHandoffService.release({
+        messageId, agentName, outcome: 'declined',
+      });
+      if (index < names.length - 1) {
+        expect(release).toMatchObject({ handoff: { queued: true, agentName: names[index + 1] } });
+      } else {
+        expect(release).toMatchObject({ handoff: { queued: false, reason: 'no_remaining_wake_target' } });
+      }
+    }, Promise.resolve());
+
+    const reoffers = await AgentEvent.find({ 'payload.claimHandoff': { $exists: true } })
+      .sort({ createdAt: 1 }).lean();
+    expect(reoffers.map((event) => event.agentName)).toEqual(names.slice(1));
+    expect(reoffers).toHaveLength(4);
+  });
+});

--- a/backend/__tests__/unit/routes/agentsRuntime.claims.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.claims.test.js
@@ -42,6 +42,11 @@ jest.mock('../../../services/messageClaimService', () => ({
   release: (...a) => mockRelease(...a),
 }));
 
+const mockDeclineRelease = jest.fn();
+jest.mock('../../../services/messageClaimHandoffService', () => ({
+  release: (...a) => mockDeclineRelease(...a),
+}));
+
 const mockTypingStart = jest.fn();
 const mockTypingStop = jest.fn();
 jest.mock('../../../services/agentTypingService', () => ({
@@ -59,6 +64,7 @@ describe('claim routes', () => {
     mockFindOne.mockResolvedValue({ status: 'active' });
     mockClaim.mockResolvedValue({ claimed: true });
     mockRelease.mockResolvedValue({ released: true });
+    mockDeclineRelease.mockResolvedValue({ released: true, podId: 'p1', handoff: { queued: true } });
   });
 
   test('claims with token-derived identity, lowercased', async () => {
@@ -85,6 +91,28 @@ describe('claim routes', () => {
     const res = await request(app).delete('/api/agents/runtime/messages/52907/claim');
     expect(res.status).toBe(200);
     expect(mockRelease).toHaveBeenCalledWith(expect.objectContaining({ agentName: 'ux-lead' }));
+  });
+
+  test('a declared decline is handed to one remaining human-wake seat', async () => {
+    const res = await request(app)
+      .delete('/api/agents/runtime/messages/52907/claim')
+      .send({ outcome: 'declined' });
+
+    expect(res.status).toBe(200);
+    expect(mockDeclineRelease).toHaveBeenCalledWith(expect.objectContaining({
+      messageId: '52907', agentName: 'ux-lead', instanceId: 'default', outcome: 'declined',
+    }));
+    expect(mockRelease).not.toHaveBeenCalled();
+  });
+
+  test('rejects an invented release outcome', async () => {
+    const res = await request(app)
+      .delete('/api/agents/runtime/messages/52907/claim')
+      .send({ outcome: 'retry-everyone' });
+
+    expect(res.status).toBe(400);
+    expect(mockRelease).not.toHaveBeenCalled();
+    expect(mockDeclineRelease).not.toHaveBeenCalled();
   });
 
   // ── ADR-018 D7: the claim IS the visibility signal ─────────────────────────

--- a/backend/__tests__/unit/services/agentMentionService.wakeOnMessage.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.wakeOnMessage.test.js
@@ -146,6 +146,7 @@ describe('wake-on-message (ADR-018 D8)', () => {
       type: 'message.posted',
     });
     expect(wakes[0].payload.wakeOnMessage).toBe(true);
+    expect(wakes[0].payload.senderIsHuman).toBe(true);
     expect(wakes[0].payload.messageId).toBe('msg-9');
     // The inline cue is the contract: not named, silence default, claim first.
     expect(wakes[0].payload.content).toContain('Wake-on-message');
@@ -224,6 +225,7 @@ describe('wake-on-message (ADR-018 D8)', () => {
 
     expect(res.woken).toEqual(['seat-b']);
     expect(wakeCalls().map((c) => c.agentName)).toEqual(['seat-b']);
+    expect(wakeCalls()[0].payload.senderIsHuman).toBe(false);
   });
 
   test('bot-authored wake storms are dampened on the message.posted count', async () => {

--- a/backend/__tests__/unit/services/messageClaimHandoffService.test.js
+++ b/backend/__tests__/unit/services/messageClaimHandoffService.test.js
@@ -1,0 +1,151 @@
+/**
+ * Claim-decline recovery is intentionally a service boundary: it joins the
+ * PostgreSQL claim row to the original Mongo delivery cohort. A claim-only
+ * unit test cannot prove that a decline reaches exactly one other seat.
+ */
+
+const mockEventFind = jest.fn();
+jest.mock('../../../models/AgentEvent', () => ({ find: (...args) => mockEventFind(...args) }));
+
+const mockInstallationFindOne = jest.fn();
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { findOne: (...args) => mockInstallationFindOne(...args) },
+}));
+
+const mockEnqueue = jest.fn();
+jest.mock('../../../services/agentEventService', () => ({ enqueue: (...args) => mockEnqueue(...args) }));
+
+const mockRelease = jest.fn();
+jest.mock('../../../services/messageClaimService', () => ({ release: (...args) => mockRelease(...args) }));
+
+const { release, enqueueNextDeclineHandoff } = require('../../../services/messageClaimHandoffService');
+
+const sourceEvent = (agentName, instanceId = 'default', payload = {}) => ({
+  agentName,
+  instanceId,
+  payload: {
+    messageId: 'message-1',
+    content: `wake for ${agentName}`,
+    wakeOnMessage: true,
+    senderIsHuman: true,
+    ...payload,
+  },
+});
+
+const sourceEvents = (events) => {
+  const lean = jest.fn().mockResolvedValue(events);
+  const sort = jest.fn().mockReturnValue({ lean });
+  mockEventFind.mockReturnValue({ sort });
+  return { sort, lean };
+};
+
+const activeInstallation = (value = { _id: 'install-1' }) => ({
+  lean: jest.fn().mockResolvedValue(value),
+});
+
+describe('messageClaimHandoffService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEnqueue.mockResolvedValue({ _id: 'new-event' });
+  });
+
+  test('a human decline re-offers the original payload to exactly one next, active seat', async () => {
+    sourceEvents([
+      sourceEvent('seat-a'),
+      sourceEvent('seat-b'),
+      sourceEvent('seat-c'),
+    ]);
+    mockInstallationFindOne.mockReturnValue(activeInstallation());
+    mockRelease.mockResolvedValue({
+      released: true,
+      podId: 'pod-1',
+      state: 'declined',
+      declinedBy: ['seat-a:default'],
+    });
+
+    const result = await release({
+      messageId: 'message-1', agentName: 'seat-a', outcome: 'declined',
+    });
+
+    expect(mockEventFind).toHaveBeenCalledWith(expect.objectContaining({
+      podId: 'pod-1',
+      type: 'message.posted',
+      'payload.messageId': 'message-1',
+      'payload.wakeOnMessage': true,
+      'payload.senderIsHuman': true,
+      'payload.claimHandoff': { $exists: false },
+    }));
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    expect(mockEnqueue).toHaveBeenCalledWith(expect.objectContaining({
+      agentName: 'seat-b',
+      instanceId: 'default',
+      podId: 'pod-1',
+      type: 'message.posted',
+      payload: expect.objectContaining({
+        content: 'wake for seat-b',
+        senderIsHuman: true,
+        claimHandoff: { attempt: 1 },
+      }),
+    }));
+    expect(result).toMatchObject({ handoff: { queued: true, agentName: 'seat-b' } });
+  });
+
+  test('five prior declines exhaust their original five-seat cohort instead of looping', async () => {
+    sourceEvents([
+      sourceEvent('seat-a'), sourceEvent('seat-b'), sourceEvent('seat-c'),
+      sourceEvent('seat-d'), sourceEvent('seat-e'),
+    ]);
+
+    const result = await enqueueNextDeclineHandoff({
+      messageId: 'message-1',
+      podId: 'pod-1',
+      declinedBy: [
+        'seat-a:default', 'seat-b:default', 'seat-c:default',
+        'seat-d:default', 'seat-e:default',
+      ],
+    });
+
+    expect(result).toEqual({ queued: false, reason: 'no_remaining_wake_target' });
+    expect(mockInstallationFindOne).not.toHaveBeenCalled();
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  test('preserves instance-id casing when excluding a prior decliner', async () => {
+    sourceEvents([sourceEvent('seat-a', 'Blue'), sourceEvent('seat-b', 'default')]);
+    mockInstallationFindOne.mockReturnValue(activeInstallation());
+
+    const result = await enqueueNextDeclineHandoff({
+      messageId: 'message-1', podId: 'pod-1', declinedBy: ['seat-a:Blue'],
+    });
+
+    expect(result).toMatchObject({ queued: true, agentName: 'seat-b' });
+    expect(mockEnqueue).toHaveBeenCalledWith(expect.objectContaining({
+      agentName: 'seat-b', instanceId: 'default',
+    }));
+  });
+
+  test('an inactive or wake-disabled original target is skipped rather than revived', async () => {
+    sourceEvents([sourceEvent('seat-a'), sourceEvent('seat-b'), sourceEvent('seat-c')]);
+    mockInstallationFindOne
+      .mockReturnValueOnce(activeInstallation(null))
+      .mockReturnValueOnce(activeInstallation({ _id: 'install-c' }));
+
+    const result = await enqueueNextDeclineHandoff({
+      messageId: 'message-1', podId: 'pod-1', declinedBy: ['seat-a:default'],
+    });
+
+    expect(mockEnqueue).toHaveBeenCalledWith(expect.objectContaining({ agentName: 'seat-c' }));
+    expect(result).toMatchObject({ queued: true, agentName: 'seat-c' });
+  });
+
+  test('bot and pre-stamp wake events are never selected for a human decline', async () => {
+    sourceEvents([]);
+
+    const result = await enqueueNextDeclineHandoff({
+      messageId: 'message-1', podId: 'pod-1', declinedBy: ['seat-a:default'],
+    });
+
+    expect(result).toEqual({ queued: false, reason: 'no_remaining_wake_target' });
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+});

--- a/backend/__tests__/unit/services/messageClaimService.test.js
+++ b/backend/__tests__/unit/services/messageClaimService.test.js
@@ -11,7 +11,7 @@ jest.mock('../../../config/db-pg', () => ({ pool: { query: jest.fn() } }));
 const { pool } = require('../../../config/db-pg');
 const MessageClaimService = require('../../../services/messageClaimService');
 
-const CAS = /INSERT INTO message_claims[\s\S]*ON CONFLICT \(message_id\) DO UPDATE[\s\S]*WHERE message_claims\.expires_at < NOW\(\)/;
+const CAS = /INSERT INTO message_claims[\s\S]*ON CONFLICT \(message_id\) DO UPDATE[\s\S]*message_claims\.state = 'declined'[\s\S]*message_claims\.expires_at < NOW\(\)/;
 
 describe('messageClaimService', () => {
   beforeEach(() => {
@@ -32,6 +32,23 @@ describe('messageClaimService', () => {
     expect(r.claimedBy).toBe('ux-lead'); // lowercased — one identity casing, learned the hard way (#804)
     const cas = pool.query.mock.calls.find(([sql]) => /INSERT INTO message_claims/.test(sql));
     expect(cas[0]).toMatch(CAS);
+    expect(pool.query.mock.calls.some(([sql]) => /ADD COLUMN IF NOT EXISTS state/.test(sql))).toBe(true);
+    expect(pool.query.mock.calls.some(([sql]) => /ADD COLUMN IF NOT EXISTS declined_by/.test(sql))).toBe(true);
+  });
+
+  test('prunes expired completed and abandoned-decline handoff history', async () => {
+    pool.query.mockImplementation((sql) => {
+      if (/DELETE FROM message_claims/.test(sql)) {
+        expect(sql).toContain("state IN ('completed', 'declined')");
+      }
+      if (/INSERT INTO message_claims/.test(sql)) {
+        return Promise.resolve({ rows: [{ claimed_by: 'ux-lead', instance_id: 'default', expires_at: new Date() }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await MessageClaimService.claim({ messageId: 'prune-me', podId: 'p1', agentName: 'ux-lead' });
+    expect(pool.query.mock.calls.some(([sql]) => /DELETE FROM message_claims/.test(sql))).toBe(true);
   });
 
   test('the CAS also lets the current holder win — renewal is the same call', async () => {
@@ -83,6 +100,46 @@ describe('messageClaimService', () => {
     });
     const r = await MessageClaimService.release({ messageId: 'm', agentName: 'a' });
     expect(r.released).toBe(false); // reported, not thrown — claim-then-decline is a normal path (D6)
+  });
+
+  test('a decline preserves a bounded handoff record instead of deleting the claim', async () => {
+    pool.query.mockImplementation((sql, params) => {
+      if (/UPDATE message_claims/.test(sql)) {
+        expect(sql).toMatch(/SET state = 'declined'/);
+        expect(sql).toMatch(/expires_at = NOW\(\) \+ make_interval\(secs => \$5\)/);
+        expect(sql).toMatch(/array_append\(declined_by, \$4\)/);
+        expect(params).toEqual(['m', 'seat-a', 'default', 'seat-a:default', 3600]);
+        return Promise.resolve({
+          rows: [{ pod_id: 'p1', state: 'declined', declined_by: ['seat-a:default'] }],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const r = await MessageClaimService.release({
+      messageId: 'm', agentName: 'seat-a', outcome: 'declined',
+    });
+
+    expect(r).toEqual({
+      released: true, podId: 'p1', state: 'declined', declinedBy: ['seat-a:default'],
+    });
+  });
+
+  test('a completed claim remains terminal: a later seat cannot take it', async () => {
+    pool.query.mockImplementation((sql) => {
+      if (/INSERT INTO message_claims/.test(sql)) return Promise.resolve({ rows: [] });
+      if (/SELECT claimed_by/.test(sql)) {
+        return Promise.resolve({
+          rows: [{
+            claimed_by: 'seat-a', instance_id: 'default', expires_at: new Date(), state: 'completed', declined_by: [],
+          }],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const r = await MessageClaimService.claim({ messageId: 'm', podId: 'p1', agentName: 'seat-b' });
+    expect(r).toMatchObject({ claimed: false, state: 'completed', claimedBy: 'seat-a' });
   });
 
   test('an expired lease reads as unheld', async () => {

--- a/backend/__tests__/unit/services/nativeRuntimeService.claims.test.js
+++ b/backend/__tests__/unit/services/nativeRuntimeService.claims.test.js
@@ -44,9 +44,15 @@ jest.mock('../../../services/messageClaimService', () => ({
   release: jest.fn(),
 }));
 
+jest.mock('../../../services/messageClaimHandoffService', () => ({
+  release: jest.fn(),
+}));
+
 const axios = require('axios').default;
 const AgentRun = require('../../../models/AgentRun');
 const MessageClaimService = require('../../../services/messageClaimService');
+const MessageClaimHandoffService = require('../../../services/messageClaimHandoffService');
+const AgentMessageService = require('../../../services/agentMessageService');
 const typing = require('../../../services/agentTypingService');
 const { runAgent } = require('../../../services/nativeRuntimeService');
 
@@ -75,6 +81,7 @@ describe('nativeRuntimeService claim-before-act (ADR-018 D3)', () => {
     process.env.LITELLM_MASTER_KEY = 'test-key';
     MessageClaimService.claim.mockResolvedValue({ claimed: true, expiresAt: new Date() });
     MessageClaimService.release.mockResolvedValue({ released: true });
+    MessageClaimHandoffService.release.mockResolvedValue({ released: true, handoff: { queued: true } });
     AgentRun.create.mockImplementation(async (doc) => ({
       _id: 'run-1',
       ...doc,
@@ -111,7 +118,7 @@ describe('nativeRuntimeService claim-before-act (ADR-018 D3)', () => {
     expect(AgentRun.create).toHaveBeenCalledTimes(1);
     expect(result.status).toBe('succeeded');
     expect(MessageClaimService.release).toHaveBeenCalledWith({
-      messageId: 'msg-77', agentName: 'pod-summarizer', instanceId: 'default',
+      messageId: 'msg-77', agentName: 'pod-summarizer', instanceId: 'default', outcome: 'completed',
     });
     expect(typing.emitAgentTypingStop).toHaveBeenCalled();
   });
@@ -125,6 +132,24 @@ describe('nativeRuntimeService claim-before-act (ADR-018 D3)', () => {
     expect(AgentRun.create).not.toHaveBeenCalled();
     expect(axios.post).not.toHaveBeenCalled();
     expect(typing.emitAgentTypingStart).not.toHaveBeenCalled();
+    expect(MessageClaimService.release).not.toHaveBeenCalled();
+  });
+
+  test('a human wake that ends NO_REPLY declines into the shared one-seat handoff', async () => {
+    AgentMessageService.postMessage.mockResolvedValueOnce({ success: true, skipped: true });
+    const result = await runAgent(installation, {
+      type: 'message.posted',
+      eventId: 'evt-human-wake',
+      payload: { messageId: 'msg-human', content: 'human update', senderIsHuman: true },
+    });
+
+    expect(result.status).toBe('succeeded');
+    expect(MessageClaimHandoffService.release).toHaveBeenCalledWith({
+      messageId: 'msg-human',
+      agentName: 'pod-summarizer',
+      instanceId: 'default',
+      outcome: 'declined',
+    });
     expect(MessageClaimService.release).not.toHaveBeenCalled();
   });
 

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -351,10 +351,19 @@ router.delete('/messages/:messageId/claim', agentRuntimeAuth, phase4RateLimit, a
   try {
     const { agentName, instanceId } = resolveClaimIdentity(req);
     if (!agentName) return res.status(400).json({ error: 'agent identity unresolved' });
+    const outcome = req.body?.outcome;
+    if (outcome !== undefined && outcome !== 'declined' && outcome !== 'completed') {
+      return res.status(400).json({ error: 'outcome must be declined or completed' });
+    }
+    // An explicit decline advances a human wake to exactly one original
+    // listener. Completion is terminal; omitting outcome retains the legacy
+    // holder-only DELETE for old drivers and failed turns.
     // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
-    const MessageClaimService = require('../services/messageClaimService');
-    const result = await MessageClaimService.release({
-      messageId: req.params.messageId, agentName, instanceId,
+    const ClaimReleaseService = outcome === 'declined'
+      ? require('../services/messageClaimHandoffService')
+      : require('../services/messageClaimService');
+    const result = await ClaimReleaseService.release({
+      messageId: req.params.messageId, agentName, instanceId, ...(outcome ? { outcome } : {}),
     });
     // D7 mirror: releasing the lease ends "someone's on it" immediately
     // (claim-then-decline is a normal, frequent path per D6 — the indicator

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -1364,6 +1364,10 @@ const enqueueWakeOnMessage = async ({
           messageType: message?.messageType || message?.message_type || 'text',
           createdAt: message?.createdAt || message?.created_at || new Date(),
           wakeOnMessage: true,
+          // Claim-decline handoff is deliberately human-only. This stamp is
+          // the cross-layer proof the wrapper and kernel need; absent remains
+          // non-human/unknown for old events rather than widening a bot loop.
+          senderIsHuman: sender?.isBot === false,
           ...(repliesToYou ? { repliesToYourMessage: true } : {}),
         },
       });

--- a/backend/services/messageClaimHandoffService.ts
+++ b/backend/services/messageClaimHandoffService.ts
@@ -1,0 +1,147 @@
+/**
+ * One-seat recovery for ADR-018's claim-then-decline path.
+ *
+ * A wake-on-message fan-out has already delivered one event per opted-in
+ * installation. If the winner declines, those other deliveries have normally
+ * stood down and acknowledged. Re-enqueueing the entire fan-out would make
+ * every seat race again; doing nothing makes the human's message disappear.
+ *
+ * Instead, reuse one of the original, human-authored wake payloads and enqueue
+ * it for the next distinct seat only. `message_claims.declined_by` makes the
+ * chain finite: every seat that actually declines is excluded from every later
+ * handoff, including across a CLI wrapper and the native runtime.
+ */
+
+// eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+const AgentEvent = require('../models/AgentEvent');
+// eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+const { AgentInstallation } = require('../models/AgentRegistry');
+// eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+const AgentEventService = require('./agentEventService');
+// eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+const MessageClaimService = require('./messageClaimService');
+
+type HandoffResult = {
+  queued: boolean;
+  agentName?: string;
+  instanceId?: string;
+  reason?: 'no_remaining_wake_target' | 'enqueue_failed';
+};
+
+const identityKey = (agentName: unknown, instanceId: unknown): string => (
+  // agentName is canonicalized by both Mongo schemas and the claim service;
+  // instanceId is not. Lowercasing it here would make `seat:Blue` from the
+  // PostgreSQL decline history fail to exclude the `Blue` Mongo installation,
+  // reopening a decline loop for a mixed-case instance id.
+  `${String(agentName || '').toLowerCase()}:${String(instanceId || 'default')}`
+);
+
+/**
+ * Re-offer one human wake to the next original target that has not declined.
+ * Old events without `senderIsHuman` deliberately do not qualify: treating an
+ * unknown sender as human would turn a compatibility gap into an agent loop.
+ */
+async function enqueueNextDeclineHandoff({
+  messageId,
+  podId,
+  declinedBy,
+}: {
+  messageId: string;
+  podId: string;
+  declinedBy: string[];
+}): Promise<HandoffResult> {
+  const sourceEvents = await AgentEvent.find({
+    podId,
+    type: 'message.posted',
+    'payload.messageId': String(messageId),
+    'payload.wakeOnMessage': true,
+    'payload.senderIsHuman': true,
+    'payload.claimHandoff': { $exists: false },
+  }).sort({ createdAt: 1, _id: 1 }).lean();
+
+  const declined = new Set((declinedBy || []).map(String));
+  const seen = new Set<string>();
+  for (const sourceEvent of sourceEvents) {
+    const agentName = String(sourceEvent.agentName || '').toLowerCase();
+    const instanceId = String(sourceEvent.instanceId || 'default');
+    const key = identityKey(agentName, instanceId);
+    if (!agentName || declined.has(key) || seen.has(key)) continue;
+    seen.add(key);
+
+    // An original wake is evidence that this seat once opted in. Recheck the
+    // live installation before re-offering: a user who turned wake-off (or
+    // uninstalled the seat) while the first agent was thinking must not be
+    // resurrected by an old event payload.
+    const installation = await AgentInstallation.findOne({
+      agentName,
+      instanceId,
+      podId,
+      status: 'active',
+      'config.wakeOnMessage.enabled': true,
+    }).lean();
+    if (!installation) continue;
+
+    const payload = (sourceEvent.payload && typeof sourceEvent.payload === 'object')
+      ? sourceEvent.payload
+      : {};
+    try {
+      await AgentEventService.enqueue({
+        agentName,
+        instanceId,
+        podId,
+        type: 'message.posted',
+        payload: {
+          ...payload,
+          claimHandoff: { attempt: declined.size },
+        },
+      });
+      return { queued: true, agentName, instanceId };
+    } catch (err) {
+      console.warn('[message-claim] handoff enqueue failed', {
+        agent: key,
+        messageId,
+        error: (err as Error).message,
+      });
+      return { queued: false, reason: 'enqueue_failed' };
+    }
+  }
+
+  return { queued: false, reason: 'no_remaining_wake_target' };
+}
+
+/**
+ * Release a claim and, only for an explicit human-message decline, advance it
+ * to one remaining original wake target. `completed` is deliberately terminal
+ * and the omitted outcome retains legacy DELETE semantics for older drivers
+ * and failure paths that must still be eligible for normal event redelivery.
+ */
+async function release(options: {
+  messageId: string;
+  agentName: string;
+  instanceId?: string;
+  outcome?: 'declined' | 'completed';
+}): Promise<Record<string, unknown>> {
+  const result = await MessageClaimService.release(options);
+  if (!result?.released || options.outcome !== 'declined' || !result.podId) return result;
+
+  try {
+    const handoff = await enqueueNextDeclineHandoff({
+      messageId: String(options.messageId),
+      podId: String(result.podId),
+      declinedBy: Array.isArray(result.declinedBy) ? result.declinedBy : [],
+    });
+    return { ...result, handoff };
+  } catch (err) {
+    // A release must remain successful even if Mongo is unavailable: holding a
+    // 90-second typing indicator is worse than missing a best-effort handoff.
+    // The structured result makes the loss observable to the caller and logs.
+    console.warn('[message-claim] handoff lookup failed:', (err as Error).message);
+    return { ...result, handoff: { queued: false, reason: 'enqueue_failed' } };
+  }
+}
+
+module.exports = {
+  release,
+  enqueueNextDeclineHandoff,
+};
+export {};

--- a/backend/services/messageClaimService.ts
+++ b/backend/services/messageClaimService.ts
@@ -27,12 +27,20 @@ const { pool } = require('../config/db-pg');
 
 const DEFAULT_LEASE_SECONDS = 90; // D4's number — a rationale, not a measurement; reviewers asked to attack it.
 const MAX_LEASE_SECONDS = 600; // Nobody gets to park a claim for an hour by passing a big number.
+// A re-offered event can requeue three times at ten-minute intervals. Keep
+// handoff history for double that window: a delayed child still needs its
+// prior declines and completion tombstone, but an exhausted or abandoned
+// chain must not become permanent claim-table storage. Ordinary successful
+// claims still DELETE immediately.
+const HANDOFF_HISTORY_RETENTION_SECONDS = 60 * 60;
 
 interface ClaimResult {
   claimed: boolean;
   claimedBy?: string;
   instanceId?: string;
   expiresAt?: Date;
+  state?: 'claimed' | 'declined' | 'completed';
+  declinedBy?: string[];
 }
 
 let bootstrapped = false;
@@ -46,12 +54,26 @@ async function ensureTable(): Promise<void> {
       claimed_by TEXT NOT NULL,
       instance_id TEXT NOT NULL DEFAULT 'default',
       expires_at TIMESTAMPTZ NOT NULL,
+      state TEXT NOT NULL DEFAULT 'claimed',
+      declined_by TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
       created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
   `);
+  // The table self-bootstraps rather than being part of schema.sql, so this
+  // retrofit is required for instances that created it before decline
+  // handoff existed. CREATE TABLE IF NOT EXISTS alone never adds columns.
+  await pool.query(
+    "ALTER TABLE message_claims ADD COLUMN IF NOT EXISTS state TEXT NOT NULL DEFAULT 'claimed'",
+  );
+  await pool.query(
+    'ALTER TABLE message_claims ADD COLUMN IF NOT EXISTS declined_by TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[]',
+  );
   // Expired rows are dead weight; the CAS treats them as absent. A small
   // index makes the pod-scoped sweep cheap if one is ever added.
   await pool.query('CREATE INDEX IF NOT EXISTS idx_message_claims_pod ON message_claims (pod_id)');
+  await pool.query(
+    'CREATE INDEX IF NOT EXISTS idx_message_claims_terminal_expiry ON message_claims (state, expires_at)',
+  );
   bootstrapped = true;
 }
 
@@ -82,26 +104,41 @@ class MessageClaimService {
       throw new Error('messageId, podId, and agentName are required');
     }
     await ensureTable();
+    // Handoff rows are short-lived history, not an ever-growing ledger.
+    // Pruning happens on the same claim traffic that creates them; the
+    // retention window outlives the requeue cap so attempted-seat history
+    // survives every legitimate delayed delivery.
+    await pool.query(
+      "DELETE FROM message_claims WHERE state IN ('completed', 'declined') AND expires_at < NOW()",
+    );
     const lease = clampLease(options.leaseSeconds);
 
     const win = await pool.query(
-      `INSERT INTO message_claims (message_id, pod_id, claimed_by, instance_id, expires_at)
-       VALUES ($1, $2, $3, $4, NOW() + make_interval(secs => $5))
+      `INSERT INTO message_claims (message_id, pod_id, claimed_by, instance_id, expires_at, state)
+       VALUES ($1, $2, $3, $4, NOW() + make_interval(secs => $5), 'claimed')
        ON CONFLICT (message_id) DO UPDATE
          SET claimed_by = EXCLUDED.claimed_by,
              instance_id = EXCLUDED.instance_id,
              expires_at = EXCLUDED.expires_at,
+             state = 'claimed',
              created_at = NOW()
-         WHERE message_claims.expires_at < NOW()
-            OR (message_claims.claimed_by = EXCLUDED.claimed_by
+         WHERE message_claims.state = 'declined'
+            OR (message_claims.state = 'claimed' AND message_claims.expires_at < NOW())
+            OR (message_claims.state = 'claimed'
+                AND message_claims.claimed_by = EXCLUDED.claimed_by
                 AND message_claims.instance_id = EXCLUDED.instance_id)
-       RETURNING claimed_by, instance_id, expires_at`,
+       RETURNING claimed_by, instance_id, expires_at, state, declined_by`,
       [String(messageId), String(podId), agentName.toLowerCase(), instanceId, lease],
     );
     if (win.rows.length > 0) {
       const r = win.rows[0];
       return {
-        claimed: true, claimedBy: r.claimed_by, instanceId: r.instance_id, expiresAt: r.expires_at,
+        claimed: true,
+        claimedBy: r.claimed_by,
+        instanceId: r.instance_id,
+        expiresAt: r.expires_at,
+        state: r.state,
+        declinedBy: r.declined_by || [],
       };
     }
 
@@ -109,13 +146,18 @@ class MessageClaimService {
     // the CAS and this read just looks like a nearly-expired claim — harmless,
     // the caller's next attempt will win.)
     const holder = await pool.query(
-      'SELECT claimed_by, instance_id, expires_at FROM message_claims WHERE message_id = $1',
+      'SELECT claimed_by, instance_id, expires_at, state, declined_by FROM message_claims WHERE message_id = $1',
       [String(messageId)],
     );
     const h = holder.rows[0];
     return h
       ? {
-        claimed: false, claimedBy: h.claimed_by, instanceId: h.instance_id, expiresAt: h.expires_at,
+        claimed: false,
+        claimedBy: h.claimed_by,
+        instanceId: h.instance_id,
+        expiresAt: h.expires_at,
+        state: h.state,
+        declinedBy: h.declined_by || [],
       }
       : { claimed: false };
   }
@@ -127,11 +169,78 @@ class MessageClaimService {
    * have expired and been re-won while you were deciding.
    */
   static async release(options: {
-    messageId: string; agentName: string; instanceId?: string;
-  }): Promise<{ released: boolean; podId?: string }> {
+    messageId: string;
+    agentName: string;
+    instanceId?: string;
+    outcome?: 'declined' | 'completed';
+  }): Promise<{
+    released: boolean;
+    podId?: string;
+    state?: 'declined' | 'completed';
+    declinedBy?: string[];
+  }> {
     const { messageId, agentName, instanceId = 'default' } = options;
     if (!messageId || !agentName) throw new Error('messageId and agentName are required');
     await ensureTable();
+    const canonicalAgentName = agentName.toLowerCase();
+    const outcome = options.outcome;
+    if (outcome === 'declined') {
+      // A decline is immediately claimable by the one re-offered seat.
+      // Keeping its history on the message, rather than in a driver-local
+      // retry loop, bounds a chain to the original wake cohort even across
+      // CLI and native runtimes. Its expiry is retention, not availability:
+      // the CAS accepts `state = 'declined'` immediately, while an abandoned
+      // or exhausted chain reaps after every legitimate requeue has elapsed.
+      const res = await pool.query(
+        `UPDATE message_claims
+         SET state = 'declined',
+             expires_at = NOW() + make_interval(secs => $5),
+             declined_by = CASE
+               WHEN NOT ($4 = ANY(declined_by))
+                 THEN array_append(declined_by, $4)
+               ELSE declined_by
+             END
+         WHERE message_id = $1 AND claimed_by = $2 AND instance_id = $3
+         RETURNING message_id, pod_id, state, declined_by`,
+        [
+          String(messageId), canonicalAgentName, instanceId,
+          `${canonicalAgentName}:${instanceId}`,
+          HANDOFF_HISTORY_RETENTION_SECONDS,
+        ],
+      );
+      return res.rows.length > 0
+        ? {
+          released: true,
+          podId: res.rows[0].pod_id,
+          state: res.rows[0].state,
+          declinedBy: res.rows[0].declined_by || [],
+        }
+        : { released: false };
+    }
+    if (outcome === 'completed') {
+      // Only a message that already handed off needs a completion tombstone.
+      // Normal claims retain the old DELETE path, otherwise every answered
+      // message would become permanent claim-table storage.
+      const terminal = await pool.query(
+        `UPDATE message_claims
+         SET state = 'completed',
+             expires_at = NOW() + make_interval(secs => $4)
+         WHERE message_id = $1
+           AND claimed_by = $2
+           AND instance_id = $3
+           AND cardinality(declined_by) > 0
+         RETURNING message_id, pod_id, state, declined_by`,
+        [String(messageId), canonicalAgentName, instanceId, HANDOFF_HISTORY_RETENTION_SECONDS],
+      );
+      if (terminal.rows.length > 0) {
+        return {
+          released: true,
+          podId: terminal.rows[0].pod_id,
+          state: terminal.rows[0].state,
+          declinedBy: terminal.rows[0].declined_by || [],
+        };
+      }
+    }
     // pod_id rides back so the route can clear the D7 typing indicator —
     // the DELETE takes no podId (holder-only delete is the guard), and the
     // claim row is the only place the pod is recorded.
@@ -139,7 +248,7 @@ class MessageClaimService {
       `DELETE FROM message_claims
        WHERE message_id = $1 AND claimed_by = $2 AND instance_id = $3
        RETURNING message_id, pod_id`,
-      [String(messageId), agentName.toLowerCase(), instanceId],
+      [String(messageId), canonicalAgentName, instanceId],
     );
     return res.rows.length > 0
       ? { released: true, podId: res.rows[0].pod_id }
@@ -150,14 +259,19 @@ class MessageClaimService {
   static async holder(messageId: string): Promise<ClaimResult> {
     await ensureTable();
     const res = await pool.query(
-      `SELECT claimed_by, instance_id, expires_at FROM message_claims
-       WHERE message_id = $1 AND expires_at >= NOW()`,
+      `SELECT claimed_by, instance_id, expires_at, state, declined_by FROM message_claims
+       WHERE message_id = $1 AND state = 'claimed' AND expires_at >= NOW()`,
       [String(messageId)],
     );
     const h = res.rows[0];
     return h
       ? {
-        claimed: true, claimedBy: h.claimed_by, instanceId: h.instance_id, expiresAt: h.expires_at,
+        claimed: true,
+        claimedBy: h.claimed_by,
+        instanceId: h.instance_id,
+        expiresAt: h.expires_at,
+        state: h.state,
+        declinedBy: h.declined_by || [],
       }
       : { claimed: false };
   }

--- a/backend/services/nativeRuntimeService.ts
+++ b/backend/services/nativeRuntimeService.ts
@@ -816,7 +816,7 @@ export async function runAgent(
   // The claim releases in the same cleanup: typing-stops and lease-release
   // are one moment (D7 — "someone's on it" ends when the turn ends), and
   // emitStop is already called on every terminal path of this function.
-  const emitStop = () => {
+  const emitStop = (claimOutcome?: 'declined' | 'completed') => {
     try {
       const typing = require('./agentTypingService');
       typing.emitAgentTypingStop({ podId, agentName, instanceId });
@@ -828,9 +828,21 @@ export async function runAgent(
       try {
         // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
         const MessageClaimService = require('./messageClaimService');
+        // A native runtime shares the kernel handoff contract with the CLI:
+        // only a normal, silent human broadcast advances to another original
+        // wake target. Failure keeps legacy release semantics so event
+        // redelivery remains possible.
+        const ClaimReleaseService = claimOutcome === 'declined'
+          ? require('./messageClaimHandoffService')
+          : MessageClaimService;
         // Fire-and-forget: a miss just means the lease already lapsed.
         Promise.resolve(
-          MessageClaimService.release({ messageId: claimMessageId, agentName, instanceId }),
+          ClaimReleaseService.release({
+            messageId: claimMessageId,
+            agentName,
+            instanceId,
+            ...(claimOutcome ? { outcome: claimOutcome } : {}),
+          }),
         ).catch(() => {});
       } catch (err) {
         console.warn('[native-runtime] claim release failed:', (err as Error).message);
@@ -1048,7 +1060,7 @@ export async function runAgent(
         // Post it anyway so the human actually sees a reply.
         try {
           const AgentMessageService = require('./agentMessageService');
-          await AgentMessageService.postMessage({
+          const postResult = await AgentMessageService.postMessage({
             agentName,
             instanceId,
             podId,
@@ -1058,7 +1070,11 @@ export async function runAgent(
             installationConfig: cfg,
             metadata: { source: 'native-runtime', fallback: true },
           });
-          finalMessage = textOut;
+          // The message service suppresses a bare NO_REPLY (and other
+          // silent output) without throwing. That is a normal declined turn,
+          // not a user-visible final message; retaining textOut here would
+          // complete the claim and swallow the human wake a second time.
+          if (!postResult?.skipped) finalMessage = textOut;
         } catch (postErr) {
           run.errorMessage = (postErr as Error).message;
           run.errorKind = 'tool_error';
@@ -1081,7 +1097,17 @@ export async function runAgent(
     console.error('[native-runtime] failed to persist AgentRun:', (saveErr as Error).message);
   }
 
-  emitStop();
+  const completedSilently = run.status === 'succeeded'
+    && !finalMessage
+    && !postedViaTool;
+  const claimOutcome = run.status === 'succeeded'
+    ? (trigger.type === 'message.posted'
+      && (trigger.payload as { senderIsHuman?: unknown } | null)?.senderIsHuman === true
+      && completedSilently
+        ? 'declined'
+        : 'completed')
+    : undefined;
+  emitStop(claimOutcome);
 
   return {
     runId,

--- a/cli/__tests__/api-expiry.test.mjs
+++ b/cli/__tests__/api-expiry.test.mjs
@@ -32,3 +32,25 @@ test.each(['Token is not valid', 'Invalid API token', 'Account no longer exists'
   );
   },
 );
+
+test('DELETE forwards an explicit body through the profile-aware client', async () => {
+  saveInstance({
+    key: 'dev', url: 'https://api.commonly.me', token: 'current-token', userId: 'u1', username: 'lily',
+  });
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify({ released: true }),
+  });
+
+  await expect(createClient({ instance: 'dev' }).del('/api/claims/message-1', { outcome: 'declined' }))
+    .resolves.toEqual({ released: true });
+
+  const [url, init] = global.fetch.mock.calls[0];
+  expect(url).toBe('https://api.commonly.me/api/claims/message-1');
+  expect(init).toMatchObject({
+    method: 'DELETE',
+    headers: { Authorization: 'Bearer current-token', 'Content-Type': 'application/json' },
+  });
+  expect(JSON.parse(init.body)).toEqual({ outcome: 'declined' });
+});

--- a/cli/__tests__/enforcement.test.mjs
+++ b/cli/__tests__/enforcement.test.mjs
@@ -363,6 +363,17 @@ describe('createClaimKeeper', () => {
     expect(del).toHaveBeenCalledWith('/api/agents/runtime/messages/msg-1/claim');
   });
 
+  test('release forwards an explicit outcome for the decline handoff contract', async () => {
+    const post = jest.fn().mockResolvedValue({ claimed: true });
+    const del = jest.fn().mockResolvedValue({ released: true });
+    const keeper = createClaimKeeper({ post, del }, keeperOpts());
+    await keeper.acquire();
+    await keeper.release('declined');
+    expect(del).toHaveBeenCalledWith('/api/agents/runtime/messages/msg-1/claim', {
+      outcome: 'declined',
+    });
+  });
+
   test('release is a no-op when the claim was never acquired or was lost', async () => {
     const del = jest.fn();
     // Never acquired (lost the CAS).

--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -1577,7 +1577,7 @@ describe('performRun — ADR-018 enforcement', () => {
     expect(spawn).toHaveBeenCalledTimes(1);
     expect(post).toHaveBeenCalledWith(CLAIM_PATH, { podId: 'pod-abc', leaseSeconds: 90 });
     expect(post).toHaveBeenCalledWith('/api/agents/runtime/pods/pod-abc/messages', { content: 'on it' });
-    expect(del).toHaveBeenCalledWith(CLAIM_PATH);
+    expect(del).toHaveBeenCalledWith(CLAIM_PATH, { outcome: 'completed' });
     expect(post).toHaveBeenCalledWith(
       '/api/agents/runtime/events/evt-1/ack',
       { result: { outcome: 'posted' } },
@@ -1608,6 +1608,40 @@ describe('performRun — ADR-018 enforcement', () => {
       '/api/agents/runtime/events/evt-1/ack',
       { result: { outcome: 'no_action', reason: 'claim-held' } },
     );
+  });
+
+  test('a human broadcast NO_REPLY declares decline, so the kernel may hand off one seat', async () => {
+    const { post, del } = makeClient({
+      events: [makeClaimEvent({
+        type: 'message.posted',
+        payload: { content: 'human question', messageId: 'msg-1', senderIsHuman: true },
+      })],
+    });
+    const spawn = jest.fn(async () => ({ text: 'NO_REPLY' }));
+    const { stop } = run({ name: 'stub', detect: stubAdapter.detect, spawn });
+    await drainMicrotasks();
+    stop();
+
+    expect(del).toHaveBeenCalledWith(CLAIM_PATH, { outcome: 'declined' });
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-1/ack',
+      { result: { outcome: 'no_action' } },
+    );
+  });
+
+  test('a bot broadcast NO_REPLY completes normally and never opens a human handoff', async () => {
+    const { del } = makeClient({
+      events: [makeClaimEvent({
+        type: 'message.posted',
+        payload: { content: 'peer chatter', messageId: 'msg-1', senderIsHuman: false },
+      })],
+    });
+    const spawn = jest.fn(async () => ({ text: 'NO_REPLY' }));
+    const { stop } = run({ name: 'stub', detect: stubAdapter.detect, spawn });
+    await drainMicrotasks();
+    stop();
+
+    expect(del).toHaveBeenCalledWith(CLAIM_PATH, { outcome: 'completed' });
   });
 
   test('a claim-route failure fails OPEN: the turn proceeds unguarded (#887 rule)', async () => {

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.26",
+  "version": "0.1.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commonlyai/cli",
-      "version": "0.1.26",
+      "version": "0.1.28",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "license": "Apache-2.0",
   "description": "The Commonly CLI \u2014 connect agents, manage pods, iterate fast",
   "type": "module",

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -1001,8 +1001,9 @@ export const performRun = ({
       }
     }
 
+    let turnResult;
     try {
-      return await runTurn({
+      turnResult = await runTurn({
         event,
         eventPodId,
         prompt: peerFrame ? `${peerFrame}\n\n${prompt}` : prompt,
@@ -1011,8 +1012,20 @@ export const performRun = ({
         claimKeeper,
         trigger,
       });
+      return turnResult;
     } finally {
-      await claimKeeper?.release();
+      // A silent, normally completed human wake is an explicit decline, not
+      // a successful answer. Tell the kernel so it can hand the message to
+      // exactly one remaining original listener. Any posted reply, refusal
+      // with a reason, or thrown spawn retains completion/legacy semantics:
+      // re-offering those would duplicate a visible response or defeat normal
+      // at-least-once redelivery after an infrastructure failure.
+      const claimOutcome = event.type === 'message.posted'
+        && event.payload?.senderIsHuman === true
+        && turnResult?.outcome === 'no_action' && !turnResult?.reason
+        ? 'declined'
+        : (turnResult ? 'completed' : undefined);
+      await claimKeeper?.release(claimOutcome);
     }
   };
 

--- a/cli/src/lib/api.js
+++ b/cli/src/lib/api.js
@@ -63,9 +63,10 @@ export const createClient = ({ instance = null, token = undefined } = {}) => {
     body: JSON.stringify(body),
   }).then((res) => handleResponse(res, session));
 
-  const del = (path) => fetch(`${baseUrl}${path}`, {
+  const del = (path, body) => fetch(`${baseUrl}${path}`, {
     method: 'DELETE',
     headers: headers(authToken),
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
   }).then((res) => handleResponse(res, session));
 
   // Multipart upload via native FormData/Blob (Node 18+) — no runtime deps.

--- a/cli/src/lib/enforcement.js
+++ b/cli/src/lib/enforcement.js
@@ -420,11 +420,15 @@ export const createClaimKeeper = (client, {
       if (timer && typeof timer.unref === 'function') timer.unref();
     },
 
-    async release() {
+    async release(outcome) {
       stopRenewal();
       if (!acquired || lost) return;
       try {
-        await client.del(path);
+        // Preserve the one-argument legacy call when there is no explicit
+        // outcome. Besides keeping old clients' DELETE shape intact, callers
+        // that assert their transport arguments must not see a synthetic
+        // `undefined` body. An explicit outcome is the new D6.1 contract.
+        await (outcome ? client.del(path, { outcome }) : client.del(path));
       } catch {
         // Best-effort: a miss just means the lease already expired.
       }

--- a/commonly-mcp/__tests__/tools.test.mjs
+++ b/commonly-mcp/__tests__/tools.test.mjs
@@ -441,8 +441,21 @@ describe('attention claims (ADR-018)', () => {
     const d = byName.commonly_claim_message.description;
     expect(d).toMatch(/STAND DOWN/);
     expect(d).toMatch(/right to DECIDE, not a duty to reply/);
+    expect(d).toMatch(/outcome `declined`/);
   });
   it('release is a result, not an error', () => {
     expect(byName.commonly_release_claim.description).toMatch(/result, not an error/);
+  });
+
+  it('sends an explicit decline outcome so human broadcasts can hand off', async () => {
+    const fetchSpy = installFetch(async () => okResponse({ released: true }));
+    await byName.commonly_release_claim.call({ messageId: 'm-1', outcome: 'declined' });
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://x.example/api/agents/runtime/messages/m-1/claim');
+    expect(init.method).toBe('DELETE');
+    expect(JSON.parse(init.body)).toEqual({ outcome: 'declined' });
+    expect(byName.commonly_release_claim.inputSchema.properties.outcome)
+      .toEqual({ type: 'string', enum: ['declined', 'completed'] });
   });
 });

--- a/commonly-mcp/package-lock.json
+++ b/commonly-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commonlyai/mcp",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4"
       },

--- a/commonly-mcp/package.json
+++ b/commonly-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -58,6 +58,7 @@ const reqWith = (props, requiredKeys) => ({ ...required(props), required: requir
 
 const STRING = { type: 'string' };
 const INT = { type: 'integer' };
+const CLAIM_OUTCOME = { type: 'string', enum: ['declined', 'completed'] };
 
 /**
  * Orientation served by `commonly_get_started`.
@@ -167,7 +168,7 @@ export const buildTools = (config) => {
     },
     {
       name: 'commonly_claim_message',
-      description: 'Claim a message before acting on it (ADR-018). Atomic: exactly one agent wins; if you lose, the response names who holds it and until when — STAND DOWN and do not act on that message. Winning grants ~90s; call again to renew while still working (same call). A claim is the right to DECIDE, not a duty to reply: claim, evaluate, and if you have nothing to add, release it and stay silent. Claims also cover replies in the same replyToMessageId chain.',
+      description: 'Claim a message before acting on it (ADR-018). Atomic: exactly one agent wins; if you lose, the response names who holds it and until when — STAND DOWN and do not act on that message. Winning grants ~90s; call again to renew while still working (same call). A claim is the right to DECIDE, not a duty to reply: claim, evaluate, and if you have nothing to add after a human broadcast, release it with outcome `declined` so exactly one remaining original wake listener can decide. After posting, release with outcome `completed`. Claims also cover replies in the same replyToMessageId chain.',
       inputSchema: reqWith({
         messageId: STRING,
         podId: STRING,
@@ -181,11 +182,12 @@ export const buildTools = (config) => {
     },
     {
       name: 'commonly_release_claim',
-      description: 'Release a message claim you hold — the normal end of claim-then-decline, and good hygiene after finishing early. A miss (someone re-won after your lease lapsed) is a result, not an error.',
-      inputSchema: reqWith({ messageId: STRING }, ['messageId']),
-      call: wrap(async ({ messageId }) => request(config, {
+      description: 'Release a message claim you hold. Set outcome to `declined` when you decide not to post a human-visible reply: on a human broadcast, Commonly hands it to exactly one remaining original wake listener. Set `completed` after posting a reply. Omitting outcome preserves legacy release behaviour for old drivers and failed turns. A miss (someone re-won after your lease lapsed) is a result, not an error.',
+      inputSchema: reqWith({ messageId: STRING, outcome: CLAIM_OUTCOME }, ['messageId']),
+      call: wrap(async ({ messageId, outcome }) => request(config, {
         method: 'DELETE',
         path: `/api/agents/runtime/messages/${encodeURIComponent(messageId)}/claim`,
+        body: outcome === undefined ? undefined : { outcome },
       })),
     },
     {


### PR DESCRIPTION
## Summary
- add an explicit `declined` / `completed` outcome to message-claim release
- re-enqueue exactly one remaining original human wake when the winner returns silent, with per-seat history bounding the chain
- preserve terminal completion after a handoff and stamp human origin on wake events
- make the native runtime recognize a message-service silent skip as a decline

## Verification
- `cd backend && npm test -- --runInBand __tests__/unit/services/messageClaimService.test.js __tests__/unit/services/messageClaimHandoffService.test.js __tests__/unit/routes/agentsRuntime.claims.test.js __tests__/unit/services/agentMentionService.wakeOnMessage.test.js __tests__/unit/services/nativeRuntimeService.claims.test.js`
- `cd backend && INTEGRATION_TEST=true ... npm test -- --runInBand __tests__/service/messageClaimHandoff.test.js` (real MongoDB + PostgreSQL; two-seat handoff and five-seat bound)
- `cd backend && npm run tsc:check`
- `cd cli && npm test -- --runInBand __tests__/run-loop.test.mjs`

The full backend JS lint command remains red on existing TypeScript resolver/parser failures; targeted TypeScript lint is error-free.