### PR TITLE
feat(seo): add AI agent observability guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -19,7 +19,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 22);
+  assert.equal(pages.length, 23);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -43,6 +43,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/self-hosted-ai-agent-platform/',
     '/guides/ai-agent-permissions-and-tokens/',
     '/guides/connect-cursor-shared-workspace/',
+    '/guides/ai-agent-observability/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
@@ -78,7 +79,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
   ]);
-  assert.equal(guidePages.length, 12);
+  assert.equal(guidePages.length, 13);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
@@ -219,6 +220,15 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(cursorHtml, /In Cursor, invoke the agent with a request like this:<\/p>\s*<pre class="seo-code">/);
   assert.match(cursorHtml, /<h2>Verify both sides of the access boundary<\/h2>\s*<p>[^<]*<\/p>\s*<p>Confirm all four:<\/p>\s*<ol>/);
   assert.match(cursorHtml, /<h2>Give the first task a boundary<\/h2>/);
+  const observabilityGuide = guidePages.find((page) => page.path === '/guides/ai-agent-observability/');
+  assert.equal(observabilityGuide.title, 'AI Agent Observability: Make Work, Handoffs, and Decisions Visible | Commonly');
+  const observabilityHtml = renderStaticPage(guideTemplate, observabilityGuide);
+  assert.match(observabilityHtml, /AI agent observability is the ability to answer a practical set of questions/);
+  assert.match(observabilityHtml, /Commonly \(commonly\.me\), the shared workspace where humans and AI agents work together/);
+  assert.match(observabilityHtml, /pending, claimed, blocked, and done/);
+  assert.match(observabilityHtml, /A strong thread update has five parts:<\/p>\s*<pre class="seo-code">/);
+  assert.match(observabilityHtml, /Objective: The outcome this work is intended to produce\.[\s\S]*Owner: The person or agent responsible for that action\./);
+  assert.match(observabilityHtml, /The right response is to connect the signals:<\/p>\s*<div class="seo-table-wrap">/);
   for (const guidePath of [
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',
@@ -262,6 +272,15 @@ test('emits a canonical crawlable page for every public route', async () => {
   ]) {
     const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
     assert.match(html, /href="\/guides\/connect-cursor-shared-workspace\//);
+  }
+  for (const guidePath of [
+    '/guides/ai-agent-task-management/',
+    '/guides/ai-agent-memory/',
+    '/guides/how-to-build-an-ai-agent-team/',
+    '/guides/agent-to-agent-messaging/',
+  ]) {
+    const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
+    assert.match(html, /href="\/guides\/ai-agent-observability\//);
   }
   const guidesIndex = pages.find((page) => page.path === '/guides/');
   assert.equal(guidesIndex.title, 'Guides for teams working with AI agents | Commonly');

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -520,6 +520,10 @@
         "path": "/guides/ai-agent-permissions-and-tokens/"
       },
       {
+        "label": "Learn about AI agent observability",
+        "path": "/guides/ai-agent-observability/"
+      },
+      {
         "label": "Explore agent collaboration",
         "path": "/use-cases/agent-collab/"
       }
@@ -909,7 +913,8 @@
       { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
       { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" },
       { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" },
-      { "label": "Evaluate a self-hosted AI agent platform", "path": "/guides/self-hosted-ai-agent-platform/" }
+      { "label": "Evaluate a self-hosted AI agent platform", "path": "/guides/self-hosted-ai-agent-platform/" },
+      { "label": "Learn about AI agent observability", "path": "/guides/ai-agent-observability/" }
     ],
     "cta": {
       "title": "Make the next session start ahead",
@@ -1534,7 +1539,8 @@
       { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" },
       { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
       { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" },
-      { "label": "Learn about AI agent permissions and tokens", "path": "/guides/ai-agent-permissions-and-tokens/" }
+      { "label": "Learn about AI agent permissions and tokens", "path": "/guides/ai-agent-permissions-and-tokens/" },
+      { "label": "Learn about AI agent observability", "path": "/guides/ai-agent-observability/" }
     ],
     "cta": {
       "title": "Build for legible work, not autonomous theater",
@@ -1726,7 +1732,8 @@
       { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" },
       { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
       { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" },
-      { "label": "Learn about AI agent permissions and tokens", "path": "/guides/ai-agent-permissions-and-tokens/" }
+      { "label": "Learn about AI agent permissions and tokens", "path": "/guides/ai-agent-permissions-and-tokens/" },
+      { "label": "Learn about AI agent observability", "path": "/guides/ai-agent-observability/" }
     ],
     "cta": {
       "title": "Give the team a place to continue",
@@ -2387,6 +2394,205 @@
     "cta": {
       "title": "Connect one agent, then prove one useful handoff",
       "body": "The fastest way to discover whether a shared workspace helps is not to connect every tool at once. Create one named Cursor agent, add it only to the pod it needs, verify the MCP configuration with a visible post, and give it one bounded task with a clear review boundary. If the next person can find the objective, evidence, decision, and owner without reopening your private Cursor session, the connection is doing its job.",
+      "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
+      "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
+    }
+  },
+  "ai-agent-observability": {
+    "eyebrow": "Guide",
+    "titleTag": "AI Agent Observability: Make Work, Handoffs, and Decisions Visible | Commonly",
+    "title": "AI Agent Observability: Make Work, Handoffs, and Decisions Visible",
+    "description": "Build a visible work record for AI agents with tasks, threaded evidence, durable memory provenance, and honest event signals—without confusing collaboration visibility with runtime telemetry.",
+    "summary": "Make AI-agent work inspectable with tasks, threaded evidence, durable memory, and honest event signals—without mistaking collaboration visibility for systems telemetry.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-30",
+      "dateModified": "2026-08-30"
+    },
+    "intro": [
+      "AI agent observability is the ability to answer a practical set of questions after work has started: what was the agent asked to do, who owns it now, what changed, what evidence supports the result, and where did a durable team fact come from. It is less about watching an agent think than making consequential work legible to the people and agents who need to continue it.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, provides a visible collaboration record through pods: project conversations and threads, tasks with ownership and activity, attached artifacts, shared memory, and agent event signals. It helps a team make its work record inspectable. It does not replace application logs, traces, metrics, source control, test reports, deployment systems, or a human review process.",
+      "This guide explains what a useful AI-agent work record contains, where to keep it, and how to avoid treating a status update or event acknowledgement as proof that a real-world outcome occurred."
+    ],
+    "sections": [
+      {
+        "title": "The useful distinction: work visibility versus systems telemetry",
+        "paragraphs": [
+          "“Observability” can describe several different things. Separating them prevents an agent team from building a detailed project conversation while missing the signals that an application is unhealthy—or from collecting piles of technical telemetry with no clear record of who owns the next decision.",
+          "Use both where appropriate. A pod should point people to the test report, incident timeline, pull request, or monitoring view that matters. It should not claim to replace the system that produced that evidence."
+        ],
+        "tables": [{
+          "headers": ["Question", "A visible work record answers", "Runtime or systems telemetry answers"],
+          "rows": [
+            ["What are we trying to accomplish?", "Task title, description, constraint, and decision thread", "Usually not applicable"],
+            ["Who owns the next action?", "Task assignee, claim status, and blocker note", "Usually not applicable"],
+            ["What did the agent say it checked?", "Threaded update, attached artifact, links to files or test output", "Possibly logs or traces, depending on the system"],
+            ["Did the deployed service behave correctly?", "A link to the verification and the reviewer’s conclusion", "Metrics, traces, logs, probes, and the system under test"],
+            ["Why does the team retain this fact?", "Memory entry and its provenance/history", "Usually not applicable"]
+          ]
+        }]
+      },
+      {
+        "title": "Five questions every agent team should be able to answer",
+        "paragraphs": [
+          "These are modest questions, but they are the difference between a team that can take over an interrupted agent task and a team that must reconstruct work from a private prompt or terminal.",
+          "Before adding more automation, check whether the team can answer these questions from a shared project record:"
+        ],
+        "orderedItems": [
+          "What is the current objective and its boundary? A task description or a clearly scoped project post should state the outcome, constraints, and required review.",
+          "Who is actively responsible? A claimed task names the current owner; a blocked task names the missing decision, access, or prerequisite.",
+          "What has actually happened? Updates, threads, and attachments should contain the relevant evidence—not just “working on it” or “done.”",
+          "What result is available to inspect? A completed task should point to a pull request, output, document, or another concrete result.",
+          "Which facts should survive the task? Shared memory should retain the durable decision, assumption, or project constraint, with enough context to revisit it later."
+        ]
+      },
+      {
+        "title": "Use the right Commonly surface for each kind of evidence",
+        "paragraphs": [
+          "A Commonly pod combines several record types. They work best when each carries the information it is suited for."
+        ],
+        "tables": [{
+          "headers": ["Surface", "Best use", "What to avoid"],
+          "rows": [
+            ["Task", "A bounded outcome, owner, status, dependency, blocker, and completion result", "A vague work bucket that stays claimed forever"],
+            ["Thread", "Questions, reasoning, review discussion, and a handoff tied to a specific post", "Posting consequential conclusions only in a private agent session"],
+            ["Attachment or linked artifact", "Research note, test output, decision packet, screenshot, or pull-request link", "Treating an attachment filename as an explanation of its relevance"],
+            ["Pod memory", "Durable facts, decisions, conventions, and task notes that should survive sessions", "Credentials, secrets, or a chronological dump of every action"],
+            ["Agent event signal", "A trigger the runtime received, such as a mention, assignment, heartbeat, or integration event", "Treating delivery as proof that an agent completed useful work"]
+          ]
+        }]
+      },
+      {
+        "title": "Tasks make ownership and state inspectable",
+        "paragraphs": [
+          "Commonly tasks move through four documented states: pending, claimed, blocked, and done. They also carry an assignee and an activity timeline. A completed task can include a result such as a pull-request URL, while a blocked task can name the condition preventing progress.",
+          "That is enough to answer a useful operational question: who should act next, and why? It is not enough to infer that a task’s underlying work is correct. “Done” should mean the stated result exists and can be inspected against acceptance criteria—not that an agent’s output is automatically approved."
+        ]
+      },
+      {
+        "title": "Threads keep reasoning next to the decision",
+        "paragraphs": [
+          "Use a pod thread for the discussion that explains a recommendation, a disagreement, or a review boundary. Threads are a better location than a bare task title when the next owner needs to see why the team chose one path and rejected another.",
+          "This is not a demand for a transcript. It is a compact handoff packet. The next agent should not have to infer whether “I looked into it” means a hypothesis, a code change, or a verified release.",
+          "A strong thread update has five parts:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "Objective: The outcome this work is intended to produce.\nEvidence: Files, test output, source links, or an attached artifact examined.\nFinding: What the evidence supports—and what remains uncertain.\nNext action: The precise decision, task, or review required next.\nOwner: The person or agent responsible for that action."
+        }]
+      },
+      {
+        "title": "Memory preserves durable facts and their source",
+        "paragraphs": [
+          "Pod memory persists across sessions and is appropriate for information a team expects to reuse: a stable architecture choice, a product constraint, a canonical document, or per-task research notes. Common patterns include MEMORY.md for shared context, TASK-NNN.md for task research, and ARCHITECTURE.md for a running system-design record.",
+          "Commonly’s memory model also records provenance for each blob-section write and keeps a capped history of replaced content. That allows a team to ask where a current fact came from and see the earlier value and source when it has been superseded. A same-section race preserves the losing write in the section’s history with its author.",
+          "Use that capability for decisions that deserve a durable record. Do not turn memory into a firehose of heartbeat messages, raw logs, or secrets. Activity belongs in the task and thread; the memory entry should state the fact that still matters after the activity has passed."
+        ]
+      },
+      {
+        "title": "A minimal work-record pattern for agent teams",
+        "paragraphs": [
+          "The following sequence gives a team enough visibility without imposing a reporting ritual on every tool call.",
+          "This pattern works for a human-led project, an MCP-attached agent working interactively, or a CLI-wrapper agent that polls events. The runtime differs; the record the team leaves for the next owner should remain understandable.",
+          "For task ownership and handoffs in more detail, see AI Agent Task Management and AI Agent Handoffs.",
+          "Use this sequence:"
+        ],
+        "orderedItems": [
+          "Create a task with an inspectable outcome. State the result, constraints, dependencies, and who must review it.",
+          "Claim the task before beginning overlapping work. The claim gives the team a visible current owner.",
+          "Post an update when the work changes the team’s options. Include evidence and the next decision; do not update merely to say that a process is still running.",
+          "Attach or link the result. A research note, test result, pull request, or screenshot should be reachable from the work record.",
+          "Complete the task with the result. The task’s completion should make the artifact inspectable, not merely announce success.",
+          "Write durable facts to shared memory only when they survive the task. Include the decision, source, scope, and date when those details matter."
+        ],
+        "links": [
+          { "label": "AI Agent Task Management", "path": "/guides/ai-agent-task-management/" },
+          { "label": "AI Agent Handoffs", "path": "/guides/ai-agent-handoffs/" }
+        ]
+      },
+      {
+        "title": "Worked example: investigate a production symptom without losing the thread",
+        "paragraphs": [
+          "Imagine a team sees a user-reported failure after a release. A human opens a task: “Objective: Identify whether the login failure is a client regression, an API response issue, or an environment configuration problem. Do not deploy a fix without review.”",
+          "The team assigns an investigation agent. Its first update says which files, logs, test environment, or reproduction steps it inspected, then attaches a short note with the observed behavior and remaining uncertainty. If the agent finds a likely configuration mismatch, it does not quietly change production. It creates a defined follow-up task or asks for the required human decision.",
+          "An implementation agent can then claim a separate task: change the named configuration, add a regression test, and provide a pull request. The reviewer uses the original evidence, the implementation diff, the test result, and the deployment system’s own verification to decide whether to release.",
+          "After the result is settled, the team writes a short memory entry only if it will help later:"
+        ],
+        "codeBlocks": [{
+          "language": "markdown",
+          "code": "## 2026-08-30: Login redirect configuration\n\n- Decision: Use the canonical public application URL for redirect handling.\n- Evidence: Link to the investigation task, pull request, and deployment verification.\n- Scope: Applies to the public production environment; revisit if the domain changes."
+        }]
+      },
+      {
+        "title": "Read event signals honestly",
+        "paragraphs": [
+          "Agent runtime events can help a team understand why an agent woke up or what it was expected to consider. Commonly documents events for pod-chat mentions, thread mentions, task assignments, scheduled heartbeats, and external integrations. A connected runtime can also receive pending events when it reconnects.",
+          "Those signals are useful for diagnosing the handoff between a collaboration surface and an agent runtime. They are not an outcome report.",
+          "For example, an event with delivered: true means the runtime acknowledged that delivery. It does not mean the agent posted a message, used the correct tools, changed a repository, ran a test, or solved the assigned task. An agent can receive a mention and still need more context, be blocked on access, choose an incorrect path, or produce output that needs review.",
+          "Do not use one row as a substitute for the next. This is how a team avoids confusing an event transport fact with a completed piece of work.",
+          "The right response is to connect the signals:"
+        ],
+        "tables": [{
+          "headers": ["Signal", "What it can tell you", "What to check next"],
+          "rows": [
+            ["Task is claimed", "Someone or an agent has taken visible responsibility", "The task update and its expected acceptance criteria"],
+            ["Task is blocked", "Progress needs a named input or prerequisite", "The blocker note, owner, and decision required"],
+            ["Task is done with a result", "There is an artifact to inspect", "The pull request, output, tests, and reviewer conclusion"],
+            ["Mention or assignment event", "The runtime was given a reason to act", "The agent’s visible response and work record"],
+            ["Event delivery acknowledged", "The runtime received that delivery generation", "Whether the agent acted and produced a verified result"],
+            ["Heartbeat event", "The scheduled agent loop was triggered", "The task state, message/update, and resulting artifact"]
+          ]
+        }]
+      },
+      {
+        "title": "Four observability anti-patterns",
+        "paragraphs": [
+          "The recurring mistakes are simple: treating a conversation, task state, memory entry, or delivery acknowledgement as evidence for a different kind of fact."
+        ]
+      },
+      {
+        "title": "Treating chat as the only record",
+        "paragraphs": [
+          "Important decisions vanish into a fast conversation when they do not become a task result, a linked artifact, or a durable memory entry. Put the conclusion where the next owner will look for it."
+        ]
+      },
+      {
+        "title": "Leaving a task claimed with no meaningful update",
+        "paragraphs": [
+          "A claim makes ownership visible, but it does not explain whether work is progressing. Add an update when evidence changes the next action, and mark the task blocked when a named prerequisite stops progress."
+        ]
+      },
+      {
+        "title": "Writing every activity into shared memory",
+        "paragraphs": [
+          "Memory is for reusable facts, not an unbounded event log. Keeping it focused improves the quality of heartbeat context and makes the next session easier to orient."
+        ]
+      },
+      {
+        "title": "Calling a delivered event a successful outcome",
+        "paragraphs": [
+          "Acknowledgement proves receipt by the runtime, not a useful response. Review the result in the appropriate system: a task artifact, a test result, a pull request, a deployment check, or a human decision."
+        ]
+      }
+    ],
+    "faq": [
+      { "question": "Is a Commonly pod an AI-agent monitoring dashboard?", "answer": "No. A pod provides a collaborative work record: conversations, tasks, memory, and agent participation. It is useful for understanding ownership, evidence, and decisions. Use application telemetry, logs, traces, and deployment systems for the technical signals they are designed to collect." },
+      { "question": "Does a completed task prove that the agent’s work is correct?", "answer": "No. A done task should point to an inspectable result. Correctness still depends on the acceptance criteria, reviewer judgment, tests, and the systems that verify or enforce the relevant outcome." },
+      { "question": "Can memory show who changed a durable fact?", "answer": "Commonly records provenance on memory writes and keeps a capped history of replaced section content. That makes it useful for tracing a shared fact across agent runtimes. It is not a reason to place credentials or noisy runtime logs in shared memory." },
+      { "question": "If an event was delivered, why did no one get a useful reply?", "answer": "Delivery acknowledgement only shows that the runtime received that event generation. Inspect the agent’s visible response, task state, and any artifact. The agent may be reactive rather than actively polling, be blocked, need a decision, or require review before it can complete consequential work." },
+      { "question": "Should every agent update every task after every tool call?", "answer": "No. Update when the team’s understanding, options, ownership, blocker, or evidence changes. A few specific updates are more useful than a noisy activity transcript." }
+    ],
+    "relatedLinks": [
+      { "label": "Learn about AI agent task management", "path": "/guides/ai-agent-task-management/" },
+      { "label": "Learn about shared memory for AI agents", "path": "/guides/ai-agent-memory/" },
+      { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" },
+      { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" },
+      { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" }
+    ],
+    "cta": {
+      "title": "Make the next owner’s job possible",
+      "body": "The point of AI agent observability is not to watch every internal step. It is to leave a project in a state that another person or agent can understand: the goal, current owner, evidence, decision, durable facts, and the boundary before a consequential action. Start with one project pod. Require a clear task result, one useful update when the work changes direction, and a durable memory note only for facts the team will need again. Then let source control, test infrastructure, deployments, and telemetry do the enforcement and measurement work they are built for.",
       "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
       "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
     }

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -174,6 +174,16 @@ describe('V2 routing', () => {
     expect(screen.getAllByText(/cm_agent_\.\.\./).length).toBeGreaterThan(0);
   });
 
+  test('observability guide renders its durable work-record pattern after the app takes over', async () => {
+    renderAt('/guides/ai-agent-observability/');
+
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'AI Agent Observability: Make Work, Handoffs, and Decisions Visible',
+    })).toBeInTheDocument();
+    expect(screen.getByText(/Objective: The outcome this work is intended to produce/)).toBeInTheDocument();
+  });
+
   test('guides index renders after the app takes over', async () => {
     renderAt('/guides/');
 
@@ -181,7 +191,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(12);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(13);
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Connect Claude Code and Codex to a Shared Workspace',


### PR DESCRIPTION
## Summary
- publish the static observability guide at `/guides/ai-agent-observability/`
- add its hub card, sitemap/canonical/Article metadata, and approved reciprocal links from task management, memory, team, and messaging guides
- preserve the distinction between collaboration visibility and systems telemetry/outcome proof

## Verification
- `npm test -- --watch=false` (86 suites, 484 tests)
- `node --test scripts/generate-seo-pages.test.mjs`
- `npx jest --runInBand src/v2/__tests__/V2Login.test.tsx`
- `npm run typecheck`
- `npm run build`
- generated HTML inspection: route, JSON-LD, sitemap, task states, handoff packet, and no app bundle