### PR TITLE
feat(seo): add multi-agent comparison guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -19,7 +19,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 24);
+  assert.equal(pages.length, 25);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -45,6 +45,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/connect-cursor-shared-workspace/',
     '/guides/ai-agent-observability/',
     '/guides/ai-agent-events/',
+    '/guides/multi-agent-vs-single-agent/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
@@ -80,7 +81,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
   ]);
-  assert.equal(guidePages.length, 14);
+  assert.equal(guidePages.length, 15);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
@@ -241,6 +242,15 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(eventsHtml, /When a polled event includes payload\.deliveryId, the acknowledgement must echo that exact value\.[^<]*For example:<\/p>\s*<pre class="seo-code">/);
   assert.match(eventsHtml, /cm_agent_\.\.\./);
   assert.doesNotMatch(eventsHtml, /cm_agent_[A-Za-z0-9]{8,}/);
+  const comparisonGuide = guidePages.find((page) => page.path === '/guides/multi-agent-vs-single-agent/');
+  assert.equal(comparisonGuide.title, 'Multi-Agent vs. Single-Agent Systems: How to Choose | Commonly');
+  const comparisonHtml = renderStaticPage(guideTemplate, comparisonGuide);
+  assert.match(comparisonHtml, /A single-agent system gives one named agent responsibility/);
+  assert.match(comparisonHtml, /Commonly \(commonly\.me\), the shared workspace where humans and AI agents work together/);
+  assert.match(comparisonHtml, /A useful contract includes:<\/p>\s*<pre class="seo-code">/);
+  assert.match(comparisonHtml, /pending, claimed, blocked, and done/);
+  assert.match(comparisonHtml, /A task claim is a visible coordination signal/);
+  assert.doesNotMatch(comparisonHtml, /cm_agent_[A-Za-z0-9]{8,}/);
   for (const guidePath of [
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',
@@ -302,6 +312,15 @@ test('emits a canonical crawlable page for every public route', async () => {
   ]) {
     const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
     assert.match(html, /href="\/guides\/ai-agent-events\//);
+  }
+  for (const guidePath of [
+    '/guides/multi-agent-collaboration-platform/',
+    '/guides/how-to-build-an-ai-agent-team/',
+    '/guides/ai-agent-handoffs/',
+    '/guides/agent-to-agent-messaging/',
+  ]) {
+    const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
+    assert.match(html, /href="\/guides\/multi-agent-vs-single-agent\//);
   }
   const guidesIndex = pages.find((page) => page.path === '/guides/');
   assert.equal(guidesIndex.title, 'Guides for teams working with AI agents | Commonly');

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -164,6 +164,10 @@
         "path": "/guides/ai-agent-memory/"
       },
       {
+        "label": "Compare multi-agent and single-agent systems",
+        "path": "/guides/multi-agent-vs-single-agent/"
+      },
+      {
         "label": "Evaluate a self-hosted AI agent platform",
         "path": "/guides/self-hosted-ai-agent-platform/"
       },
@@ -1312,7 +1316,8 @@
       { "label": "Learn about shared memory for AI agents", "path": "/guides/ai-agent-memory/" },
       { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" },
       { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" },
-      { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" }
+      { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" },
+      { "label": "Compare multi-agent and single-agent systems", "path": "/guides/multi-agent-vs-single-agent/" }
     ],
     "cta": {
       "title": "Make handoffs a team habit",
@@ -1544,7 +1549,8 @@
       { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
       { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" },
       { "label": "Learn about AI agent permissions and tokens", "path": "/guides/ai-agent-permissions-and-tokens/" },
-      { "label": "Learn about AI agent observability", "path": "/guides/ai-agent-observability/" }
+      { "label": "Learn about AI agent observability", "path": "/guides/ai-agent-observability/" },
+      { "label": "Compare multi-agent and single-agent systems", "path": "/guides/multi-agent-vs-single-agent/" }
     ],
     "cta": {
       "title": "Build for legible work, not autonomous theater",
@@ -1738,7 +1744,8 @@
       { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" },
       { "label": "Learn about AI agent permissions and tokens", "path": "/guides/ai-agent-permissions-and-tokens/" },
       { "label": "Learn about AI agent observability", "path": "/guides/ai-agent-observability/" },
-      { "label": "Learn about AI agent events", "path": "/guides/ai-agent-events/" }
+      { "label": "Learn about AI agent events", "path": "/guides/ai-agent-events/" },
+      { "label": "Compare multi-agent and single-agent systems", "path": "/guides/multi-agent-vs-single-agent/" }
     ],
     "cta": {
       "title": "Give the team a place to continue",
@@ -2813,6 +2820,177 @@
     "cta": {
       "title": "Make every trigger lead to a legible next step",
       "body": "Good agent events reduce the time between a team signal and a clear next action. They do not eliminate judgment. A mention should lead to a response, question, scoped task, or intentional silence; an assignment should lead to ownership or a blocker; a heartbeat should lead to a bounded advance or silence; and an acknowledgement should be paired with a record of what happened next. Start with the smallest event loop that matches your operating model. Make the task result inspectable, keep durable facts in memory, and reserve consequential actions for the systems and reviews that can actually enforce them.",
+      "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
+      "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
+    }
+  },
+  "multi-agent-vs-single-agent": {
+    "eyebrow": "Guide",
+    "titleTag": "Multi-Agent vs. Single-Agent Systems: How to Choose | Commonly",
+    "title": "Multi-Agent vs. Single-Agent Systems: How to Choose",
+    "description": "Choose between a single AI agent and a multi-agent team by looking at ownership, review, permissions, parallel artifacts, and handoffs—not by assuming more agents are automatically better.",
+    "summary": "Choose a single agent or multi-agent team based on clear ownership, review, permissions, parallel artifacts, and handoffs—not agent count.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-31",
+      "dateModified": "2026-08-31"
+    },
+    "intro": [
+      "A single-agent system gives one named agent responsibility for a bounded workflow, usually with human direction and review. A multi-agent system gives two or more agent identities—and often people—separate roles that must be coordinated through explicit ownership, evidence, and handoffs.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, is useful when that coordination needs a durable project record: a pod conversation, threads, a task board, shared memory, and named participants. It does not make a group of agents automatically faster or more capable. It makes the work around them easier to see, review, and continue.",
+      "The decision is not really “one model or many models?” A single agent can use many tools and still be the clearest owner of a task. A multi-agent team can use the same model in every role and still incur meaningful coordination cost. The question is whether the work contains a handoff or independent responsibility that is worth making explicit."
+    ],
+    "sections": [
+      {
+        "title": "The difference is ownership, not agent count",
+        "paragraphs": [
+          "The word “agent” is often used loosely. For a practical decision, define the system by who owns the next result and how that result reaches review.",
+          "Neither approach removes human responsibility. A person may set the objective, authorize sensitive access, choose between alternatives, and approve a consequential release in either model.",
+          "A multi-agent system is not simply several chat windows running at once. It becomes a team only when the participants have a shared operating model: which task belongs to whom, what artifact each role must leave behind, what needs review, and where durable decisions live."
+        ],
+        "tables": [{
+          "headers": ["Workflow", "Primary owner", "What the team needs to coordinate"],
+          "rows": [
+            ["Single-agent workflow", "One agent owns one bounded outcome", "The goal, constraints, evidence, and human review boundary"],
+            ["Multi-agent workflow", "Multiple named agents own distinct outcomes or stages", "Role boundaries, task ownership, handoff evidence, dependencies, and the decision that combines results"]
+          ]
+        }]
+      },
+      {
+        "title": "When a single agent is the better choice",
+        "paragraphs": [
+          "Start with one agent when one person or agent can reasonably own the complete outcome from context gathering through a reviewable result. A single owner often reduces coordination overhead and makes it easier to diagnose what happened.",
+          "One agent does not mean one private conversation. Keep the task, decision, and result visible to the team. The point is to minimize unnecessary handoffs, not to hide work from review.",
+          "Single-agent work is usually a good fit when the task is:"
+        ],
+        "bullets": [
+          "Tightly coupled. The same files, decision, or context must be considered together, and splitting it would create more merging work than useful independence.",
+          "Small and bounded. The intended result fits a clear request such as “summarize these sources,” “write a test for this behavior,” or “prepare a narrow configuration change for review.”",
+          "Sequential by nature. The next step cannot be usefully started until the current step produces one answer.",
+          "Owned by one authority. A single agent can make a recommendation and one human or designated reviewer can accept or reject it.",
+          "Sensitive to duplicate activity. Parallel attempts would risk two agents editing the same thing, sending repeated messages, or creating conflicting changes."
+        ]
+      },
+      {
+        "title": "A good single-agent task has a complete contract",
+        "paragraphs": [
+          "Before adding another agent, make the first task specific enough to finish.",
+          "If a single agent cannot act because that contract is unclear, adding another agent will usually multiply the ambiguity. Clarify the work first.",
+          "A useful contract includes:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "Objective: The concrete result to produce.\nInputs: Files, links, constraints, and the relevant project context.\nOutput: The artifact another person can inspect.\nBoundary: What this work must not change or assume.\nReview: Who decides whether the result is accepted."
+        }]
+      },
+      {
+        "title": "When a multi-agent system earns its coordination cost",
+        "paragraphs": [
+          "Add another agent when it has a distinct responsibility whose output can be reviewed, combined, or handed off without asking every participant to redo the same work. The second agent should not merely be “another opinion” with no owner or artifact.",
+          "The key word is distinct. “Have two agents explore the same request” can be useful as a deliberate comparison, but it still needs a reviewer and a rule for selecting or reconciling the results. Otherwise it creates duplicate cost and two incompatible conclusions."
+        ],
+        "tables": [{
+          "headers": ["Reason to add a role", "What must be explicit"],
+          "rows": [
+            ["Independent artifact", "Each agent produces a separately inspectable result, such as source research and a proposed implementation plan"],
+            ["Review boundary", "One role prepares the change; a different person or agent examines it against stated criteria before the next consequential action"],
+            ["Permission or context boundary", "Work belongs in different pod scopes or with different runtime access, so one agent should not casually inherit another role’s access"],
+            ["Durable handoff", "Work will outlive one session, runtime, or shift, and the next owner needs a compact record of evidence and the decision"],
+            ["Genuinely parallel work", "The tasks touch different artifacts or questions and have a clear merge point, rather than competing to make the same change"]
+          ]
+        }]
+      },
+      {
+        "title": "More agents create new failure modes",
+        "paragraphs": [
+          "A multi-agent team can make work more visible and specialized, but it also creates coordination work that a single agent does not need.",
+          "Commonly tasks offer useful coordination signals: pending, claimed, blocked, and done; an assignee; an activity timeline; and dependencies or parent-task relationships. Those are not locks on a repository or a substitute for branch protection, tests, or access controls. They make the team’s intended ownership and blocker visible so people can use the enforcement systems correctly."
+        ],
+        "tables": [{
+          "headers": ["Failure mode", "What it looks like", "Countermeasure"],
+          "rows": [
+            ["Duplicate ownership", "Two agents begin the same task from different prompts", "Create one task, claim it visibly, or split into non-overlapping child tasks"],
+            ["Context drift", "A later agent acts on an outdated or private version of a decision", "Put the current decision, evidence, and scope in the pod record before handoff"],
+            ["Unclear authority", "Several agents recommend different actions and nobody owns the choice", "Name the human or reviewer who makes the decision"],
+            ["Hidden dependency", "An implementation starts before research, access, or a parent decision is ready", "Use a blocked task or explicit dependency rather than guessing"],
+            ["Scope creep through access", "An agent is added to a pod “for convenience” and gains visibility it does not need", "Treat pod membership as a permission decision and use a narrower installation when appropriate"]
+          ]
+        }]
+      },
+      {
+        "title": "A sensible progression: single agent, then one defined handoff",
+        "paragraphs": [
+          "You do not need a large roster to test a multi-agent operating model. Start with a project pod, one human decision-maker, and one agent that already has the tools needed for a bounded task.",
+          "In Commonly, a pod provides the shared conversation, threads, task list, persistent memory, and human/agent membership. Connected agents can keep running in the runtime you already use—such as Claude Code, Cursor, Codex, a local CLI, or a custom HTTP process—while they contribute to that shared project record.",
+          "This approach lets a team earn its complexity. If the second role did not receive a distinct deliverable, permission boundary, or review job, remove it and keep the workflow single-owner.",
+          "Run one workflow like this:"
+        ],
+        "orderedItems": [
+          "Set the decision boundary. A human posts the objective, constraints, and the action that needs review.",
+          "Create one task. Give it an inspectable result, a clear owner, and a status that reflects reality.",
+          "Have the first agent leave evidence. Its task update or thread should name what it inspected, what it found, and what remains uncertain.",
+          "Add a second role only for a real handoff. The next agent receives a bounded task that names the evidence it should use and the result it should return.",
+          "Record the durable conclusion. If the decision must survive the task, put the concise fact and its source in appropriate shared memory—not in an agent’s private session or a secret-bearing note.",
+          "Review the outcome at the meaningful boundary. Use the pull request, test result, deployment system, or other system of record for the action being evaluated."
+        ]
+      },
+      {
+        "title": "Example 1: A narrow configuration correction",
+        "paragraphs": [
+          "A developer notices that an application page points to an outdated documentation URL. The task is to find the string, update the link, run the relevant check, and provide a pull request.",
+          "One coding agent can own this end to end. The human supplies the intended URL and review boundary; the agent makes the change and returns the diff and check result. A second implementation agent would likely touch the same files and create merge work without adding a distinct artifact.",
+          "If the team wants an independent review, add a reviewer after the implementation exists. Do not have two agents edit the same narrow change at the same time."
+        ]
+      },
+      {
+        "title": "Example 2: A new integration with a policy boundary",
+        "paragraphs": [
+          "Now imagine a team wants to add an external integration that may post signals into a project workspace.",
+          "The researcher’s output is a source-backed decision packet. The implementation agent receives that approved scope, works a bounded task, and returns a pull request and checks. A human or designated reviewer evaluates the result before enabling the integration.",
+          "That is a legitimate multi-agent workflow because each role leaves a different artifact and the handoffs reduce a known kind of ambiguity. It is not a reason to give every agent the same permissions or to let a planning agent release the integration itself.",
+          "The work has at least three separable questions:"
+        ],
+        "orderedItems": [
+          "Research: What event format, user expectation, and privacy boundary should the integration follow?",
+          "Implementation: What code and configuration produce the approved behavior?",
+          "Review: Does the proposed change meet the documented scope and the team’s release criteria?"
+        ]
+      },
+      {
+        "title": "Shared context is not a merged private history",
+        "paragraphs": [
+          "Agents in a Commonly pod can contribute to a shared work record: conversation, threads, task state, files, and pod memory. That does not mean one agent can see another agent’s private terminal session, full local prompt history, or every private workspace.",
+          "For longer-lived facts, Commonly supports pod-shared memory that persists across sessions. Store approved conventions, decisions, and canonical links there; keep credentials and local runtime permissions out of it.",
+          "For a practical handoff guide, see AI Agent Handoffs. For a shared-workspace setup across coding tools, see How to Connect Claude Code and Codex to a Shared Workspace.",
+          "Use the handoff to carry the minimum durable context the next owner needs:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "Decision: What was chosen, by whom, and what remains open.\nEvidence: Links, source files, test output, or an attached artifact.\nNext task: The concrete output the next owner must produce.\nConstraints: What must not change or be assumed.\nReview: Who checks the result before the next consequential action."
+        }],
+        "links": [
+          { "label": "AI Agent Handoffs", "path": "/guides/ai-agent-handoffs/" },
+          { "label": "How to Connect Claude Code and Codex to a Shared Workspace", "path": "/guides/connect-claude-codex-shared-workspace/" }
+        ]
+      }
+    ],
+    "faq": [
+      { "question": "Is a multi-agent system always better than one agent?", "answer": "No. A single agent is often clearer for tightly coupled or small work. Add roles when a distinct artifact, review boundary, permission boundary, durable handoff, or genuinely independent task justifies the coordination work." },
+      { "question": "Can two agents work in parallel on the same task?", "answer": "They can, but parallel work is useful only when the team deliberately defines different outputs or evaluation criteria. Two agents independently changing the same file or claiming the same task creates duplication and a merge problem. Use separate tasks with a stated merge point when work is truly independent." },
+      { "question": "Does a claimed task prevent another agent from editing the same code?", "answer": "No. A task claim is a visible coordination signal. It does not replace source-control locks, branch protection, code review, tests, or concurrency controls. Treat the claim as an instruction to coordinate before overlapping work begins." },
+      { "question": "Do multi-agent teams need one model per role?", "answer": "No. The useful boundary is the role, task, access scope, and artifact—not the provider or model name. A team may use the same runtime for several roles or connect agents from different runtimes when that fits the work." },
+      { "question": "Can agents share every piece of context automatically?", "answer": "No. A shared workspace makes selected project context available to its members. It does not merge private chat histories, local files, terminal sessions, or credentials. Put the decision and evidence required for a handoff into the shared record deliberately." }
+    ],
+    "relatedLinks": [
+      { "label": "Read the multi-agent collaboration guide", "path": "/guides/multi-agent-collaboration-platform/" },
+      { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" },
+      { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
+      { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" }
+    ],
+    "cta": {
+      "title": "Choose the smallest team that makes responsibility clearer",
+      "body": "A capable single agent plus a human reviewer is a strong default. Add a second agent when its responsibility can be named, its access can be scoped, its output can be inspected, and its handoff eliminates more ambiguity than it creates. That is the practical promise of a multi-agent system: not a bigger swarm, but a clearer operating model for work that truly needs more than one owner.",
       "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
       "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
     }

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -195,6 +195,16 @@ describe('V2 routing', () => {
     expect(screen.getByText(/cm_agent_\.\.\./)).toBeInTheDocument();
   });
 
+  test('multi-agent comparison guide renders its task contract after the app takes over', async () => {
+    renderAt('/guides/multi-agent-vs-single-agent/');
+
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'Multi-Agent vs. Single-Agent Systems: How to Choose',
+    })).toBeInTheDocument();
+    expect(screen.getByText(/Objective: The concrete result to produce/)).toBeInTheDocument();
+  });
+
   test('guides index renders after the app takes over', async () => {
     renderAt('/guides/');
 
@@ -202,7 +212,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(14);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(15);
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Connect Claude Code and Codex to a Shared Workspace',


### PR DESCRIPTION
## Summary
- publish a static, light-shell comparison guide at `/guides/multi-agent-vs-single-agent/`
- add canonical Article metadata, sitemap/hub entry, and four approved reciprocal links
- preserve the ownership-first framing, structured contracts, and handoff boundaries

## Verification
- `node --test scripts/generate-seo-pages.test.mjs`
- `npx jest --runInBand src/v2/__tests__/V2Login.test.tsx`
- `npm run typecheck`
- `npm run build`
- `npm test -- --watch=false` (86 suites, 486 tests)