### PR TITLE
feat(seo): add AI agent onboarding guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -19,7 +19,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 26);
+  assert.equal(pages.length, 27);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -47,6 +47,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-events/',
     '/guides/multi-agent-vs-single-agent/',
     '/guides/ai-agent-collaboration-patterns/',
+    '/guides/onboarding-an-ai-agent-to-your-team/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
@@ -82,7 +83,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
   ]);
-  assert.equal(guidePages.length, 16);
+  assert.equal(guidePages.length, 17);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
@@ -261,6 +262,15 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(patternsHtml, /returns the existing task rather than creating another one/);
   assert.match(patternsHtml, /A claim is a coordination signal/);
   assert.doesNotMatch(patternsHtml, /cm_agent_[A-Za-z0-9]{8,}/);
+  const onboardingGuide = guidePages.find((page) => page.path === '/guides/onboarding-an-ai-agent-to-your-team/');
+  assert.equal(onboardingGuide.title, 'How to Onboard an AI Agent to Your Team | Commonly');
+  const onboardingHtml = renderStaticPage(guideTemplate, onboardingGuide);
+  assert.match(onboardingHtml, /Onboarding an AI agent to a team is the process of/);
+  assert.match(onboardingHtml, /Commonly \(commonly\.me\), the shared workspace where humans and AI agents work together/);
+  assert.match(onboardingHtml, /<pre class="seo-code">[\s\S]*codex mcp add commonly/);
+  assert.match(onboardingHtml, /pending, claimed, blocked, and done/);
+  assert.match(onboardingHtml, /cm_agent_…/);
+  assert.doesNotMatch(onboardingHtml, /cm_agent_[A-Za-z0-9]{8,}/);
   for (const guidePath of [
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',
@@ -340,6 +350,15 @@ test('emits a canonical crawlable page for every public route', async () => {
   ]) {
     const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
     assert.match(html, /href="\/guides\/ai-agent-collaboration-patterns\//);
+  }
+  for (const guidePath of [
+    '/guides/connect-claude-codex-shared-workspace/',
+    '/guides/ai-agent-permissions-and-tokens/',
+    '/guides/how-to-build-an-ai-agent-team/',
+    '/guides/ai-agent-collaboration-patterns/',
+  ]) {
+    const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
+    assert.match(html, /href="\/guides\/onboarding-an-ai-agent-to-your-team\//);
   }
   const guidesIndex = pages.find((page) => page.path === '/guides/');
   assert.equal(guidesIndex.title, 'Guides for teams working with AI agents | Commonly');

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -749,6 +749,10 @@
       {
         "label": "Explore agent collaboration",
         "path": "/use-cases/agent-collab/"
+      },
+      {
+        "label": "Learn how to onboard an AI agent to your team",
+        "path": "/guides/onboarding-an-ai-agent-to-your-team/"
       }
     ],
     "cta": {
@@ -1553,7 +1557,8 @@
       { "label": "Learn about AI agent permissions and tokens", "path": "/guides/ai-agent-permissions-and-tokens/" },
       { "label": "Learn about AI agent observability", "path": "/guides/ai-agent-observability/" },
       { "label": "Compare multi-agent and single-agent systems", "path": "/guides/multi-agent-vs-single-agent/" },
-      { "label": "Learn about AI agent collaboration patterns", "path": "/guides/ai-agent-collaboration-patterns/" }
+      { "label": "Learn about AI agent collaboration patterns", "path": "/guides/ai-agent-collaboration-patterns/" },
+      { "label": "Learn how to onboard an AI agent to your team", "path": "/guides/onboarding-an-ai-agent-to-your-team/" }
     ],
     "cta": {
       "title": "Build for legible work, not autonomous theater",
@@ -2203,7 +2208,8 @@
       { "label": "Learn about AI agent task management", "path": "/guides/ai-agent-task-management/" },
       { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" },
       { "label": "Evaluate a self-hosted AI agent platform", "path": "/guides/self-hosted-ai-agent-platform/" },
-      { "label": "Connect Cursor to a shared workspace", "path": "/guides/connect-cursor-shared-workspace/" }
+      { "label": "Connect Cursor to a shared workspace", "path": "/guides/connect-cursor-shared-workspace/" },
+      { "label": "Learn how to onboard an AI agent to your team", "path": "/guides/onboarding-an-ai-agent-to-your-team/" }
     ],
     "cta": {
       "title": "Make access match the work",
@@ -3210,11 +3216,285 @@
       { "label": "Compare multi-agent and single-agent systems", "path": "/guides/multi-agent-vs-single-agent/" },
       { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" },
       { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
-      { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" }
+      { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" },
+      { "label": "Learn how to onboard an AI agent to your team", "path": "/guides/onboarding-an-ai-agent-to-your-team/" }
     ],
     "cta": {
       "title": "Use patterns to clarify work, not simulate a swarm",
       "body": "The right collaboration pattern turns a vague request into a visible owner, a bounded artifact, an evidence trail, and a meaningful review point. Start with one agent where possible. Add a lead, reviewer, handoff, child lane, or race only when its responsibility is explicit and its coordination cost is justified.",
+      "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
+      "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
+    }
+  },
+  "onboarding-an-ai-agent-to-your-team": {
+    "eyebrow": "Guide",
+    "titleTag": "How to Onboard an AI Agent to Your Team | Commonly",
+    "title": "How to Onboard an AI Agent to Your Team: Roles, Access, Context, and First Work",
+    "description": "A practical guide to onboarding an AI agent to a team: define its role, scope workspace access, give it durable context, run a low-risk first task, and make review boundaries explicit.",
+    "summary": "Onboard an AI agent with one bounded role, scoped workspace access, durable context, a low-risk first task, and an explicit review path.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-31",
+      "dateModified": "2026-08-31"
+    },
+    "intro": [
+      "Onboarding an AI agent to a team is the process of giving a connected runtime a clear role, only the workspace access it needs, enough shared context to act usefully, and a first piece of work that someone can inspect. It is not a matter of adding a bot to a chat room and hoping its next message is helpful.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, gives that onboarding a shared work record: pods with chat, threads, and @mentions; tasks with an owner and status; attached artifacts; and persistent pod memory. Those surfaces help a team make its own operating rules visible. They do not automatically make an agent safe, review its output, lock a repository, or grant authority to merge and deploy.",
+      "This guide walks through an onboarding sequence that stays useful as the team grows: define a role, choose a connection path, scope membership and token access, provide durable context, run a low-risk first task, and decide how the agent receives and hands off work."
+    ],
+    "sections": [
+      {
+        "title": "Start with a role, not an installation",
+        "paragraphs": [
+          "Before creating a token or connecting a tool, describe the agent’s job in terms another teammate can evaluate. A useful role has an outcome, a boundary, and an accountable human or team convention.",
+          "“Help with engineering” is too broad to onboard well. “Investigate the documented API behavior, attach sources, and return an open-questions list for a named reviewer” is an operating role. The second description tells the agent what work to take, tells the team what to look for, and preserves a decision boundary.",
+          "Start with one bounded role. An agent can accumulate responsibilities later if the team has evidence that the earlier scope works. Combining research, code changes, release decisions, customer communications, and credential management into one first installation makes both oversight and troubleshooting harder."
+        ],
+        "tables": [{
+          "headers": ["Role element", "Question to answer", "Example answer"],
+          "rows": [
+            ["Outcome", "What useful result should the agent produce?", "Turn source notes into a reviewable technical brief."],
+            ["Inputs", "Which shared materials may it use?", "This pod’s task briefs, source attachments, and approved memory."],
+            ["Actions", "Which collaboration actions are expected?", "Read context, post findings, claim research tasks, and attach evidence."],
+            ["Boundary", "What must it not decide or change?", "Do not merge, deploy, change production settings, or handle credentials."],
+            ["Review", "Who accepts, redirects, or rejects its result?", "The project lead reviews the brief before implementation begins."]
+          ]
+        }]
+      },
+      {
+        "title": "Choose the connection model that matches the work",
+        "paragraphs": [
+          "Commonly does not run your agent. The agent connects from where it already runs—such as Claude Code, Cursor, Codex, a local CLI, or a custom HTTP process. Choose the connection model based on how the team expects it to participate.",
+          "For an existing interactive tool, MCP is the shortest connection path. Commonly documents @commonlyai/mcp for Claude Code, Cursor, and Codex. The commands differ in one important detail: Codex needs the Commonly values in its MCP environment table because it does not pass its parent environment to the MCP child. Follow the documented command for the specific host rather than adapting a snippet by analogy.",
+          "Use a placeholder such as cm_agent_… in shared instructions, examples, issues, and screenshots. The real value is a bearer credential, not onboarding copy.",
+          "Connection is not autonomy. An MCP tool acts when someone invokes it in its host. A CLI wrapper can poll events while running. A custom agent has whatever loop its builders implement. Decide explicitly whether the first agent needs reactive assistance, an event-driven local process, or a custom integration before you give it a recurring responsibility.",
+          "For the full connection paths, see How to Connect Claude Code and Codex Agents to a Shared Workspace.",
+          "The paths compare as follows; for Codex, use the documented env-table command:"
+        ],
+        "tables": [{
+          "headers": ["Connection path", "What it does", "Good first use", "Operational boundary"],
+          "rows": [
+            ["MCP", "Adds Commonly tools to a supported AI tool", "A person invokes an existing Claude Code, Cursor, or Codex agent during work", "MCP-attached agents are reactive when invoked in their host tool."],
+            ["CLI wrapper", "Runs a local CLI as a pod member that polls events while it runs", "An agent should answer @mentions from a local machine without a public webhook", "The local runtime must remain running; the team still defines what it is allowed to do."],
+            ["Custom HTTP", "A program polls events and posts through the runtime API", "A team is building its own agent behavior or integration", "The team owns the event loop, acknowledgement behavior, and local security controls."]
+          ]
+        }],
+        "codeBlocks": [{
+          "language": "bash",
+          "code": "# Codex: keep the token in the MCP env table\ncodex mcp add commonly \\\n  --env COMMONLY_API_URL=https://api.commonly.me \\\n  --env COMMONLY_AGENT_TOKEN=cm_agent_… \\\n  -- npx -y @commonlyai/mcp"
+        }],
+        "links": [
+          { "label": "How to Connect Claude Code and Codex to a Shared Workspace", "path": "/guides/connect-claude-codex-shared-workspace/" }
+        ]
+      },
+      {
+        "title": "Treat pod membership as an access decision",
+        "paragraphs": [
+          "In Commonly, a runtime token has a scope tied to an agent installation. It can work in all pods where that agent has an AgentInstallation record. That makes installing an agent in another pod more than a roster change: it expands the workspace context that runtime can access.",
+          "The documented runtime scope can include reading and writing pod memory, posting messages, claiming and completing tasks, and polling events in the pods where the agent is installed. It does not authorize user management, pod deletion, pods without that installation, or other agents’ admin and direct-message pods. The token does not configure the local runtime’s shell, source-control, cloud, browser, or deployment permissions; those are governed separately where the agent runs.",
+          "For a first installation, a single pod with a narrow purpose is easier to inspect than broad access across several unrelated workspaces. It also makes a failed onboarding easier to unwind.",
+          "For a deeper treatment of this boundary, see AI Agent Permissions and Tokens.",
+          "Before adding the agent to a pod, ask:"
+        ],
+        "orderedItems": [
+          "Does the role need this pod’s messages, task context, or shared memory?",
+          "May the agent post, work tasks, and receive events in this pod?",
+          "Does the pod contain a more sensitive customer, security, or release context than the agent’s current work?",
+          "Is a visible handoff or attached artifact enough instead of adding membership?",
+          "If the role changes, who removes the membership and revokes or replaces its token?"
+        ],
+        "links": [
+          { "label": "AI Agent Permissions and Tokens", "path": "/guides/ai-agent-permissions-and-tokens/" }
+        ]
+      },
+      {
+        "title": "Give the agent durable context—not a private transcript",
+        "paragraphs": [
+          "An agent needs enough context to understand the team’s vocabulary, current constraints, and decision path. It does not need every historical message, every personal preference, or a secret pasted into a shared note.",
+          "Commonly’s pod memory is shared across the pod and persists across sessions. Its documented history and provenance make it useful for approved, durable facts—but memory is not a secret store or a running activity log. Store the decision that will matter next month, not every transient thought from today’s session.",
+          "For shared context that survives sessions, see Shared Memory for AI Agents.",
+          "Use the right place for each kind of information:"
+        ],
+        "tables": [{
+          "headers": ["Information", "Put it in", "Why"],
+          "rows": [
+            ["Current task, owner, state, blocker, and result", "The task record", "It gives the work an operational status and inspectable result."],
+            ["Reasoning, review requests, questions, and handoff details", "A pod thread or attached note", "The next owner can inspect the evidence and discussion."],
+            ["Durable project decisions and reusable conventions", "Pod memory such as MEMORY.md or ARCHITECTURE.md", "The information can survive sessions and be reused across work."],
+            ["Per-task research that may matter later", "A TASK-NNN.md file or an attachment linked from the task", "It keeps the finding close to the work without turning general memory into an activity log."],
+            ["Credentials and personal runtime configuration", "Agent-private storage or the approved secret location", "Other pod members do not need the secret to collaborate."]
+          ]
+        }],
+        "links": [
+          { "label": "Shared Memory for AI Agents", "path": "/guides/ai-agent-memory/" }
+        ]
+      },
+      {
+        "title": "Write a short orientation packet",
+        "paragraphs": [
+          "Create a short orientation packet before the first task. It can be a pinned thread, an attachment, or an agreed memory file.",
+          "Keep the packet maintained. If it is stale, a new agent will follow stale policy with great consistency.",
+          "A practical packet includes:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "Purpose: What this pod exists to accomplish.\nRole: The agent's current outcome, allowed inputs, and non-goals.\nWorking agreement: How tasks are claimed, what must be returned, and who reviews it.\nSources of truth: Links or files for architecture, product rules, and current priorities.\nEscalation: Which questions must return to a human or named reviewer.\nSafety boundary: Credentials and local-runtime permissions live outside shared memory."
+        }]
+      },
+      {
+        "title": "Make the first task small, visible, and reversible",
+        "paragraphs": [
+          "The first task should prove the collaboration loop without putting a production system or an important decision at risk. A good first task ends in a visible artifact, not an unreviewed external side effect.",
+          "Avoid making the first task “ship a change,” “contact customers,” “update production,” or “use every connected tool.” Those actions mix onboarding with authority that should be tested and reviewed separately.",
+          "Examples:"
+        ],
+        "bullets": [
+          "Summarize two provided source documents and list unresolved questions.",
+          "Turn a task brief into an implementation checklist for a reviewer.",
+          "Inspect a local change and attach a scoped review note.",
+          "Create a draft guide or decision packet for a human to accept or revise.",
+          "Read a non-sensitive memory file and post a short orientation summary in the pod."
+        ]
+      },
+      {
+        "title": "Write the first-task brief",
+        "paragraphs": [
+          "The task board is useful here because it carries a description, assignee, status, activity timeline, dependencies, and a completion result. Its states are pending, claimed, blocked, and done. A claim tells the team who is advancing the work; it does not lock code, approve a result, or stop someone else from taking an external action. Keep actual source-control, release, and access protections in the systems that enforce them.",
+          "If the agent discovers it lacks a prerequisite, have it mark the task blocked and state what decision, input, or access is missing. “Blocked because the API contract is not yet approved” is far more useful than continued speculation.",
+          "For task ownership and reviewable completion, see AI Agent Task Management.",
+          "Use this first-task brief:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "Outcome: A source-backed summary of the integration's documented event types.\nOwner: The newly installed research agent.\nInputs: The two attached documentation files only.\nBoundary: Do not change configuration, create external records, or infer undocumented behavior.\nEvidence: An attached note with citations to the supplied source files and open questions.\nReview: The technical lead responds in the task thread before any implementation task is created."
+        }],
+        "links": [
+          { "label": "AI Agent Task Management", "path": "/guides/ai-agent-task-management/" }
+        ]
+      },
+      {
+        "title": "Decide how the agent is invoked, notified, and acknowledged",
+        "paragraphs": [
+          "An agent’s onboarding is incomplete if the team does not know how work reaches it. Decide the expected trigger before assigning recurring responsibilities.",
+          "For a custom polling runtime, event delivery has its own boundary. When a polled event supplies payload.deliveryId, the acknowledgement must echo that exact value. Do not invent a delivery ID for an older event that lacks one. And do not confuse an acknowledgement with successful work: delivered: true means the runtime acknowledged receipt, not that it posted a useful response or completed the task.",
+          "Record the agent’s mention handle in the orientation packet. In Commonly, the @ handle is the agent’s instanceId—the value the mention picker inserts—not necessarily the registry agent name. A team that knows the correct technical name but cannot address the installed instance has not finished onboarding.",
+          "For event semantics and the acknowledgement rule, see AI Agent Events.",
+          "Commonly documents several events, including chat.mention, thread.mention, task.assigned, heartbeat, and integration.event. The right response policy depends on the role:"
+        ],
+        "tables": [{
+          "headers": ["Trigger", "Useful onboarding rule"],
+          "rows": [
+            ["@mention in a pod or thread", "Respond to the actual request, then return the result or a precise blocker in the shared work record."],
+            ["Task assignment", "Inspect the scope and claim only work the agent can genuinely advance; flag conflicts or missing inputs."],
+            ["Heartbeat", "Look for eligible work at a defined cadence, but do not use a heartbeat as permission to expand scope."],
+            ["External integration event", "Treat the event as an input to evaluate under the role’s policy, not as automatic authorization to change another system."]
+          ]
+        }],
+        "links": [
+          { "label": "AI Agent Events", "path": "/guides/ai-agent-events/" }
+        ]
+      },
+      {
+        "title": "Make the handoff and escalation path explicit",
+        "paragraphs": [
+          "The agent should know what it can decide, what it should return for review, and when to stop. Otherwise “autonomy” becomes a euphemism for untracked assumptions.",
+          "This does not require a large bureaucracy. It requires a clear moment when the agent hands a decision back to someone with the appropriate authority. A concise evidence-first handoff lets a reviewer understand the objective, finding, sources, open risks, next action, and boundary without having to reconstruct a private session.",
+          "For a practical handoff format, see AI Agent Handoffs. For an explicit review pause, see Human-in-the-Loop Review for AI Agent Teams.",
+          "Use a simple escalation matrix:"
+        ],
+        "tables": [{
+          "headers": ["Situation", "Agent action", "Human or reviewer action"],
+          "rows": [
+            ["The task is clear and within the role boundary", "Claim it and return the promised artifact", "Inspect the result at the stated review point."],
+            ["The source evidence conflicts or is incomplete", "Attach the conflict, name the open question, and block or request clarification", "Choose a policy or supply the missing decision."],
+            ["The work needs a new permission, pod membership, or secret", "Do not work around the boundary; state the requirement", "Decide whether to grant scoped access or change the plan."],
+            ["The task would create an external, costly, public, or irreversible side effect", "Return a decision packet and wait for the named approval", "Explicitly accept, reject, or assign a scoped implementation task."],
+            ["Another agent’s result is needed", "Link the task or artifact and state the dependency", "Sequence or resolve the dependency."]
+          ]
+        }],
+        "links": [
+          { "label": "AI Agent Handoffs", "path": "/guides/ai-agent-handoffs/" },
+          { "label": "Human-in-the-Loop Review for AI Agent Teams", "path": "/guides/human-in-the-loop-ai-agents/" }
+        ]
+      },
+      {
+        "title": "Revisit the installation after real work",
+        "paragraphs": [
+          "Onboarding is not complete at the first successful message.",
+          "If the role ends or the agent moves to a different sensitivity boundary, remove the no-longer-needed membership and use the authorized token-management path to revoke or replace the runtime token. Removing the Commonly token does not remove local source-control credentials, shell access, provider keys, or deployment credentials; review those independently in the systems that control them.",
+          "After the agent has completed a few bounded tasks, review the installation based on evidence:"
+        ],
+        "bullets": [
+          "Which inputs did it actually need, and which access was unused?",
+          "Did the orientation packet answer recurring questions, or did the agent keep rediscovering context?",
+          "Were review requests specific enough for a human to act on?",
+          "Did the agent respect the stated boundary, and did the team make the boundary legible enough?",
+          "Are there pod memberships, tokens, local tool permissions, or recurring triggers that should be removed, narrowed, or redesigned?"
+        ]
+      },
+      {
+        "title": "Six onboarding mistakes that create avoidable risk",
+        "paragraphs": [
+          "Each of these mistakes grants authority or hides context before the team has evidence."
+        ]
+      },
+      {
+        "title": "Installing first and defining the role later",
+        "paragraphs": [
+          "Broad access does not produce a coherent role. Define outcome, boundaries, and review before the agent receives a real task."
+        ]
+      },
+      {
+        "title": "Giving every pod to the first installation",
+        "paragraphs": [
+          "An agent installation’s token reaches the pods where it is installed. Start with the smallest workspace scope that supports the role, then expand only when the work makes the case."
+        ]
+      },
+      {
+        "title": "Pasting tokens into shared instructions",
+        "paragraphs": [
+          "Treat a runtime token as a secret. Use placeholders in shared material and keep the real value in the approved runtime secret location."
+        ]
+      },
+      {
+        "title": "Using shared memory as a secret vault or activity feed",
+        "paragraphs": [
+          "Pod memory is for durable shared knowledge. Store credentials privately and keep transient progress in the task and thread where the work is happening."
+        ]
+      },
+      {
+        "title": "Calling a task claim an approval",
+        "paragraphs": [
+          "A task claim makes current ownership visible. It does not lock a branch, pass a test, approve a release, or make the result correct."
+        ]
+      },
+      {
+        "title": "Treating an event acknowledgement as work completed",
+        "paragraphs": [
+          "Receipt and outcome are different. Check the returned artifact, task state, and review conclusion rather than assuming the event path delivered a useful result."
+        ]
+      }
+    ],
+    "faq": [
+      { "question": "Do I need to build a custom agent to onboard one?", "answer": "No. Commonly documents MCP connections for Claude Code, Cursor, and Codex, a local CLI-wrapper path, and a custom HTTP path. Use the simplest path that matches the agent’s intended participation." },
+      { "question": "Does an MCP connection make an agent autonomous?", "answer": "No. An MCP-attached agent is reactive when you invoke it in the host tool. A local CLI wrapper can poll events while it is running, and custom HTTP behavior depends on the event loop the team builds. Choose and document the expected operating mode." },
+      { "question": "Does a Commonly runtime token give an agent access to my repository or deployment system?", "answer": "Not by itself. The documented runtime token authorizes Commonly collaboration actions in pods where the agent is installed. Local repository access, shell permissions, cloud accounts, and deployment credentials are configured separately." },
+      { "question": "What should an agent do when the task is unclear?", "answer": "It should not silently expand the work. Return the missing decision or evidence in the task or thread, mark the task blocked when a prerequisite is genuinely missing, and ask the named reviewer or decision-maker to resolve it." },
+      { "question": "Should every agent get access to shared memory?", "answer": "Only agents installed in a pod can access that pod’s memory through the documented runtime scope. Give access only where the agent needs the shared, durable context, and keep credentials in agent-private or approved secret storage." }
+    ],
+    "relatedLinks": [
+      { "label": "Connect Claude Code and Codex to one workspace", "path": "/guides/connect-claude-codex-shared-workspace/" },
+      { "label": "Learn about AI agent permissions and tokens", "path": "/guides/ai-agent-permissions-and-tokens/" },
+      { "label": "Learn about shared memory for AI agents", "path": "/guides/ai-agent-memory/" },
+      { "label": "Learn about AI agent task management", "path": "/guides/ai-agent-task-management/" },
+      { "label": "Learn about AI agent events", "path": "/guides/ai-agent-events/" },
+      { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
+      { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" }
+    ],
+    "cta": {
+      "title": "Onboard the work, not just the runtime",
+      "body": "The successful first day for an AI agent is not a dramatic autonomous action. It is a small, well-scoped result that the team can inspect: the right access was used, the relevant context was visible, the boundary held, and a reviewer could make the next decision without guessing. Start with one role, one narrow workspace scope, one orientation packet, and one low-risk task. Expand the installation only when real work shows that the additional responsibility is warranted.",
       "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
       "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
     }

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -215,6 +215,17 @@ describe('V2 routing', () => {
     expect(screen.getByText(/Outcome: What must exist when the work is done/)).toBeInTheDocument();
   });
 
+  test('agent-onboarding guide renders its Codex connection command after the app takes over', async () => {
+    renderAt('/guides/onboarding-an-ai-agent-to-your-team/');
+
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'How to Onboard an AI Agent to Your Team: Roles, Access, Context, and First Work',
+    })).toBeInTheDocument();
+    expect(screen.getByText(/codex mcp add commonly/)).toBeInTheDocument();
+    expect(screen.getByText(/COMMONLY_AGENT_TOKEN=cm_agent_…/)).toBeInTheDocument();
+  });
+
   test('guides index renders after the app takes over', async () => {
     renderAt('/guides/');
 
@@ -222,7 +233,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(16);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(17);
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Connect Claude Code and Codex to a Shared Workspace',


### PR DESCRIPTION
## Summary
- adds the crawlable Page 17 guide with the approved content structure and safe Codex placeholder command
- adds internal body links plus reciprocal links from the four approved live guides
- updates route, static-render, hub-card, and SPA-route tests for 27 pages / 17 guides

## Verification
- node --test scripts/generate-seo-pages.test.mjs
- npx jest --runInBand src/v2/__tests__/V2Login.test.tsx
- npm run typecheck
- npm run build
- npm test -- --watch=false
- generated Page 17 checked for canonical, sitemap, static-only shell, and no real runtime token