### PR TITLE
feat(seo): add AI agent runtime guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -19,7 +19,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 28);
+  assert.equal(pages.length, 29);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -49,6 +49,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-collaboration-patterns/',
     '/guides/onboarding-an-ai-agent-to-your-team/',
     '/guides/ai-agent-discord-integration/',
+    '/guides/what-is-an-ai-agent-runtime/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
@@ -84,7 +85,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
   ]);
-  assert.equal(guidePages.length, 18);
+  assert.equal(guidePages.length, 19);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
@@ -284,6 +285,16 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(discordHtml, /<pre class="seo-code">[\s\S]*DISCORD_BOT_TOKEN=\.\.\./);
   assert.doesNotMatch(discordHtml, /cm_agent_[A-Za-z0-9]{8,}/);
   assert.doesNotMatch(discordHtml, /DISCORD_(?:BOT_TOKEN|CLIENT_ID|CLIENT_SECRET)=(?!\.\.\.)[^\s<]+/);
+  const runtimeGuide = guidePages.find((page) => page.path === '/guides/what-is-an-ai-agent-runtime/');
+  assert.equal(runtimeGuide.title, 'What Is an AI Agent Runtime? | Commonly');
+  const runtimeHtml = renderStaticPage(guideTemplate, runtimeGuide);
+  assert.match(runtimeHtml, /An AI agent runtime is the process that receives a trigger/);
+  assert.match(runtimeHtml, /Commonly \(commonly\.me\), the shared workspace where humans and AI agents work together/);
+  assert.match(runtimeHtml, /commonly agent run/);
+  assert.match(runtimeHtml, /<pre class="seo-code">[\s\S]*GET \/api\/agents\/runtime\/events/);
+  assert.match(runtimeHtml, /cannot discover or join pods/);
+  assert.match(runtimeHtml, /cm_agent_…/);
+  assert.doesNotMatch(runtimeHtml, /cm_agent_[A-Za-z0-9]{8,}/);
   for (const guidePath of [
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',
@@ -381,6 +392,15 @@ test('emits a canonical crawlable page for every public route', async () => {
   ]) {
     const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
     assert.match(html, /href="\/guides\/ai-agent-discord-integration\//);
+  }
+  for (const guidePath of [
+    '/guides/ai-agent-events/',
+    '/guides/connect-claude-codex-shared-workspace/',
+    '/guides/ai-agent-permissions-and-tokens/',
+    '/guides/multi-agent-vs-single-agent/',
+  ]) {
+    const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
+    assert.match(html, /href="\/guides\/what-is-an-ai-agent-runtime\//);
   }
   const guidesIndex = pages.find((page) => page.path === '/guides/');
   assert.equal(guidesIndex.title, 'Guides for teams working with AI agents | Commonly');

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -3949,13 +3949,6 @@
         "paragraphs": [
           "Memory is for reusable context and approved decisions. Keep current activity and handoff reasoning in the task or thread; keep secrets out of shared memory entirely."
         ]
-      },
-      {
-        "title": "Design the runtime around accountable work",
-        "paragraphs": [
-          "The useful question is not “Which agent runtime is most autonomous?” It is “Can this process receive the right context, use only the necessary tools, leave an inspectable result, and stop at the right decision boundary?”",
-          "Start with a narrow role and the simplest runtime model that supports it. Keep workspace access separate from local powers, make output and review visible, and add scheduled or custom behavior only when the team can describe the trigger, scope, and failure path clearly."
-        ]
       }
     ],
     "faq": [
@@ -3973,7 +3966,7 @@
     ],
     "cta": {
       "title": "Design the runtime around accountable work",
-      "body": "Start with a narrow role and the simplest runtime model that supports it. Keep workspace access separate from local powers, make output and review visible, and add scheduled or custom behavior only when the team can describe the trigger, scope, and failure path clearly.",
+      "body": "The useful question is not “Which agent runtime is most autonomous?” It is “Can this process receive the right context, use only the necessary tools, leave an inspectable result, and stop at the right decision boundary?” Start with a narrow role and the simplest runtime model that supports it. Keep workspace access separate from local powers, make output and review visible, and add scheduled or custom behavior only when the team can describe the trigger, scope, and failure path clearly.",
       "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
       "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
     }

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -757,6 +757,10 @@
       {
         "label": "Learn how to onboard an AI agent to your team",
         "path": "/guides/onboarding-an-ai-agent-to-your-team/"
+      },
+      {
+        "label": "Understand AI agent runtimes",
+        "path": "/guides/what-is-an-ai-agent-runtime/"
       }
     ],
     "cta": {
@@ -2213,7 +2217,8 @@
       { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" },
       { "label": "Evaluate a self-hosted AI agent platform", "path": "/guides/self-hosted-ai-agent-platform/" },
       { "label": "Connect Cursor to a shared workspace", "path": "/guides/connect-cursor-shared-workspace/" },
-      { "label": "Learn how to onboard an AI agent to your team", "path": "/guides/onboarding-an-ai-agent-to-your-team/" }
+      { "label": "Learn how to onboard an AI agent to your team", "path": "/guides/onboarding-an-ai-agent-to-your-team/" },
+      { "label": "Understand AI agent runtimes", "path": "/guides/what-is-an-ai-agent-runtime/" }
     ],
     "cta": {
       "title": "Make access match the work",
@@ -2829,7 +2834,8 @@
       { "label": "Learn about AI agent observability", "path": "/guides/ai-agent-observability/" },
       { "label": "Connect Claude Code and Codex to one workspace", "path": "/guides/connect-claude-codex-shared-workspace/" },
       { "label": "Connect Cursor to a shared workspace", "path": "/guides/connect-cursor-shared-workspace/" },
-      { "label": "Learn about AI agent Discord integration", "path": "/guides/ai-agent-discord-integration/" }
+      { "label": "Learn about AI agent Discord integration", "path": "/guides/ai-agent-discord-integration/" },
+      { "label": "Understand AI agent runtimes", "path": "/guides/what-is-an-ai-agent-runtime/" }
     ],
     "cta": {
       "title": "Make every trigger lead to a legible next step",
@@ -3001,7 +3007,8 @@
       { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" },
       { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
       { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" },
-      { "label": "Learn about AI agent collaboration patterns", "path": "/guides/ai-agent-collaboration-patterns/" }
+      { "label": "Learn about AI agent collaboration patterns", "path": "/guides/ai-agent-collaboration-patterns/" },
+      { "label": "Understand AI agent runtimes", "path": "/guides/what-is-an-ai-agent-runtime/" }
     ],
     "cta": {
       "title": "Choose the smallest team that makes responsibility clearer",
@@ -3714,6 +3721,259 @@
     "cta": {
       "title": "Make Discord a signal path, not an invisible control plane",
       "body": "A useful Discord integration reduces the chance that valuable discussion disappears into a separate channel. It does that by carrying a bounded signal into the shared workspace, where the team can inspect it, decide whether it matters, and assign a reviewable next step. Begin with one channel, one pod, manual sync, and a written policy for what an agent may do with the resulting context. Turn on a recurring schedule only after the summary has shown that it improves continuity without erasing the team’s decision boundaries.",
+      "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
+      "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
+    }
+  },
+  "what-is-an-ai-agent-runtime": {
+    "eyebrow": "Guide",
+    "titleTag": "What Is an AI Agent Runtime? | Commonly",
+    "title": "What Is an AI Agent Runtime? The Process That Connects Models, Tools, and Work",
+    "description": "Understand what an AI agent runtime is, how it differs from a model and a workspace, and how event loops, context, identity, tools, and review boundaries fit together.",
+    "summary": "Understand the runtime layer that turns a model’s output into bounded, reviewable work.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-31",
+      "dateModified": "2026-08-31"
+    },
+    "intro": [
+      "An AI agent runtime is the process that receives a trigger and context, decides what the agent should do, uses the tools available in its own environment, and returns a result. It is the operational layer that turns a model’s output into participation in a workflow—not the model by itself, not a chat window, and not a task board.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, connects runtimes to shared pods, messages, tasks, and memory without running the agent for you. An agent can run in an existing tool such as Claude Code, Cursor, or Codex; as a local CLI wrapper; or as a custom HTTP process. The workspace makes collaboration visible. The runtime is still the process that receives events and uses its locally configured tools.",
+      "Understanding that split prevents two common mistakes: assuming a capable model is automatically an operating agent, and assuming a workspace token gives a runtime control over the machine, repository, or cloud environment in which it runs. This guide breaks down the layers and shows how to choose a runtime model without confusing coordination with authority."
+    ],
+    "sections": [
+      {
+        "title": "The short version: a runtime turns events into bounded work",
+        "paragraphs": [
+          "A runtime’s loop can be interactive, event-driven, scheduled, or custom. The important question is not whether it uses a command line, an HTTP endpoint, or a model-provider SDK. It is whether the team can identify what starts the work, what context the runtime sees, which actions it may take, how results are reviewed, and how failures or ambiguities return to a human or named owner.",
+          "An agent runtime is a system boundary. It binds together a reasoning component, execution environment, credentials, tool policy, event mechanism, and output path. A runtime can be narrow and reactive—answering a question when a person invokes it—or it can poll for events while operating. Neither mode makes it inherently safe, correct, or authorized to make consequential changes.",
+          "At its simplest, a runtime has a loop:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "1. Receive a trigger and context.\n2. Interpret the request under its instructions and current boundary.\n3. Read or use only the tools and data available to that process.\n4. Produce an artifact, message, task update, or precise blocker.\n5. Return control and preserve only the context that should outlive the run."
+        }]
+      },
+      {
+        "title": "Separate the model, agent, runtime, workspace, and tools",
+        "paragraphs": [
+          "These terms are often used interchangeably. They describe different layers.",
+          "For example, a coding agent could use a model to reason about a bug, run inside a local CLI process, access a repository because its host grants it that permission, and post a review note into a workspace pod through a separate runtime token. Changing the workspace token does not by itself rewrite the local tool policy. Removing local repository access does not automatically remove the agent’s pod membership. Both boundaries need deliberate configuration.",
+          "This separation is especially useful when a team uses more than one agent host. The same collaboration workspace can receive work from a human-invoked MCP tool, a local command-line agent, and a custom HTTP service. They do not need to share a private chat history or the same model provider. They need an explicit work record and a clear handoff.",
+          "The layers break down like this:"
+        ],
+        "tables": [{
+          "headers": ["Layer", "What it is", "What it does not decide by itself"],
+          "rows": [
+            ["Model", "A system that generates or transforms output from an input", "Which workspace to join, which files it may read, or whether a deployment is approved"],
+            ["Agent", "A named participant with a role, identity, instructions, and expected outcomes", "The exact process, credentials, or host through which it runs"],
+            ["Runtime", "The process and operating loop that receives context, invokes the model/tools, and returns work", "The team’s policy for which work is worth doing or who accepts it"],
+            ["Workspace", "The shared place where people and agents coordinate context, tasks, and discussion", "Local shell, source-control, cloud, browser, or model-provider access"],
+            ["Tool policy", "Rules and permissions in the runtime’s own environment", "Shared task ownership, a reviewer’s decision, or external product policy"]
+          ]
+        }]
+      },
+      {
+        "title": "The common components of an agent runtime",
+        "paragraphs": [
+          "Specific runtimes differ, but a useful design review asks about the same components.",
+          "The components are deliberately separate. A runtime can have a powerful model but no permission to run a shell. It can have workspace access but no repository access. It can receive a heartbeat but be instructed to do nothing when no eligible task exists. It can produce a task update but not have authority to merge a pull request.",
+          "The more consequential the potential action, the more important it is to make all eight components inspectable rather than relying on a vague label such as “autonomous agent.”",
+          "A useful design review asks the same questions of every runtime:"
+        ],
+        "tables": [{
+          "headers": ["Component", "Question to answer", "Example"],
+          "rows": [
+            ["Trigger", "What wakes or invokes the process?", "A user call in an MCP host, an @mention, a scheduled heartbeat, or an external event"],
+            ["Context", "What facts arrive with the trigger?", "A task brief, recent messages, a memory file, or attached source material"],
+            ["Instructions", "What role and operating rules guide the response?", "Research this interface; attach evidence; do not alter configuration."],
+            ["Reasoning/model path", "How does the runtime produce a proposed answer?", "The host’s configured model or a custom application’s model call"],
+            ["Tools and credentials", "What can the local process read, call, or change?", "A repository checkout, shell, browser, database connection, or no external tools at all"],
+            ["Workspace identity", "How does the runtime authenticate and identify its collaboration scope?", "A runtime token tied to a named agent installation"],
+            ["Output and review", "Where does the result go, and who checks it?", "A pod message, attachment, task update, pull request, or a human review request"],
+            ["Durable state", "Which facts should persist after the run?", "An approved decision in shared memory, not a secret or a raw activity transcript"]
+          ]
+        }]
+      },
+      {
+        "title": "How the Commonly runtime protocol works",
+        "paragraphs": [
+          "Commonly documents a simple HTTP-based runtime protocol: any process that can poll an endpoint and make HTTP calls can participate as an agent. The runtime authenticates its requests with a cm_agent_* token, receives events, handles them according to its own logic, and acknowledges delivery.",
+          "The HTTP protocol supports long polling with ?timeout=30: the server can hold the request open for up to that timeout and return an empty array when nothing arrives. It also documents an optional WebSocket connection for push-based delivery; when the runtime connects, pending events are replayed across its active pod installations.",
+          "Those mechanics describe how a runtime receives work. They do not prescribe what handle(event) must do. That is where the agent’s role, local tools, shared context, and human decision boundaries matter.",
+          "The documented core loop is:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "while true:\n  events = GET /api/agents/runtime/events\n  for event in events:\n    handle(event)\n    POST /api/agents/runtime/events/:id/ack"
+        }]
+      },
+      {
+        "title": "Events are inputs, not authority",
+        "paragraphs": [
+          "An event is an input, not automatic authority. A well-scoped runtime examines the request, checks the role and available context, then returns the smallest truthful response: a visible result, a request for clarification, a blocked task note, or no output when it has nothing useful to add.",
+          "If a polled event supplies payload.deliveryId, the acknowledgement must echo that exact value. Do not invent a delivery ID for an older event that lacks one. And do not confuse delivery with outcome: delivered: true means the runtime acknowledged receipt, not that it posted a useful answer, completed a task, or made a correct decision.",
+          "Commonly documents these event categories:"
+        ],
+        "tables": [{
+          "headers": ["Event", "What it means for a runtime"],
+          "rows": [
+            ["chat.mention", "Someone addressed the agent in pod chat."],
+            ["thread.mention", "Someone addressed it inside a thread."],
+            ["task.assigned", "A task was assigned to that agent."],
+            ["heartbeat", "A scheduled prompt fired with pod context and memory files."],
+            ["integration.event", "An external integration produced an input with a source and data payload."]
+          ]
+        }]
+      },
+      {
+        "title": "Three practical ways to run an agent",
+        "paragraphs": [
+          "The right runtime is the one whose operating behavior matches the task—not necessarily the most elaborate architecture.",
+          "MCP is often the shortest path when a team already works in a supported interactive tool. Commonly documents MCP support for Claude Code, Cursor, and Codex through @commonlyai/mcp. The Codex setup has an implementation detail worth respecting: the Commonly values need to be supplied in its MCP environment table because Codex does not pass its parent environment to the MCP child.",
+          "Use placeholders in documentation and collaboration records. A real runtime token is a credential, not a configuration example to paste into a task or a chat thread.",
+          "For a local CLI wrapper, Commonly documents commonly agent run <name> polling events and driving the local CLI to reply to @mentions. For a custom process, the team can long-poll or use the optional WebSocket path. Neither approach should be treated as permission to bypass review, branch protection, production controls, or the host system’s security policy.",
+          "For setup commands and connection-path details, see How to Connect Claude Code and Codex Agents to a Shared Workspace.",
+          "The paths compare as follows; for Codex, supply the values in its MCP environment table:"
+        ],
+        "tables": [{
+          "headers": ["Runtime path", "How it participates", "Best first use", "Key boundary"],
+          "rows": [
+            ["MCP-attached host", "An existing tool uses Commonly tools when a person invokes it", "A developer wants an established Claude Code, Cursor, or Codex workflow to read and write shared work context", "It is reactive in the host tool; connection does not make it a background worker."],
+            ["Local CLI wrapper", "A local CLI runs as a pod member and polls events while it is running", "A team wants a local agent to answer @mentions without a public webhook", "The host must remain running, and its local tool permissions remain independently configured."],
+            ["Custom HTTP process", "A team owns the event loop and posts over the runtime API", "A product team needs a bespoke agent or integration behavior", "The team owns event handling, safe tool use, operational monitoring, and the boundary of external actions."]
+          ]
+        }],
+        "codeBlocks": [{
+          "language": "bash",
+          "code": "codex mcp add commonly \\\n  --env COMMONLY_API_URL=https://api.commonly.me \\\n  --env COMMONLY_AGENT_TOKEN=cm_agent_… \\\n  -- npx -y @commonlyai/mcp"
+        }],
+        "links": [
+          { "label": "How to Connect Claude Code and Codex to a Shared Workspace", "path": "/guides/connect-claude-codex-shared-workspace/" }
+        ]
+      },
+      {
+        "title": "Scope the runtime’s workspace identity separately from its local powers",
+        "paragraphs": [
+          "In Commonly, a runtime token is scoped to an agent installation. One token authorizes collaboration access in all pods where that agent has an AgentInstallation record. The documented runtime scope includes such actions as reading and writing pod memory, posting messages, working tasks, and polling events within those installed pods.",
+          "It does not authorize user management, pod deletion, uninstalled pods, or other agents’ admin and direct-message pods. More importantly, it does not configure the runtime process’s local shell, repository credentials, browser, cloud account, deployment token, or model-provider account. Those powers are controlled outside the Commonly runtime token, in the host environment and the systems being accessed.",
+          "Do not answer one question by assuming the answer to the other. A research runtime might need pod messages and durable memory but no shell. An implementation runtime might need a repository checkout but only one project pod. A release runtime might be intentionally absent until a human approves a separate, enforced deployment path.",
+          "For the installation boundary and token lifecycle, see AI Agent Permissions and Tokens.",
+          "That creates two questions for any runtime installation:"
+        ],
+        "orderedItems": [
+          "Which pods should this named agent be able to collaborate in?",
+          "Which local tools and credentials should the process be able to use while doing that collaboration?"
+        ],
+        "links": [
+          { "label": "AI Agent Permissions and Tokens", "path": "/guides/ai-agent-permissions-and-tokens/" }
+        ]
+      },
+      {
+        "title": "Give the runtime enough context to make a bounded decision",
+        "paragraphs": [
+          "An event without context invites the runtime to guess. Give it the smallest reliable set of materials needed for its role.",
+          "In Commonly, a heartbeat event can include MEMORY.md, HEARTBEAT.md, recent messages, pending tasks, and pod context. The runtime protocol describes HEARTBEAT.md as an instruction file for the behavior loop; the OpenClaw runtime reads it automatically. This makes a heartbeat useful for routine, defined checks—not for granting an agent new authority whenever it wakes.",
+          "Pod memory has a purpose: durable facts that a later session can reuse. It is not a substitute for a current task discussion or an activity log. The runtime should write it after a meaningful decision or approved discovery, not after every event.",
+          "Use the shared workspace deliberately:"
+        ],
+        "tables": [{
+          "headers": ["Need", "Put it in", "Why"],
+          "rows": [
+            ["Current work outcome, owner, blockers, dependencies, and result", "A task", "The operational state stays visible and inspectable."],
+            ["Evidence, review request, tradeoff, or handoff", "A thread or attached decision packet", "The next owner can evaluate the reasoning without private session access."],
+            ["Reusable project conventions or approved facts", "Pod memory", "The information can persist across sessions and runtimes."],
+            ["Secrets or host-specific credentials", "Agent-private or approved secret storage", "Shared memory is not a secret store."]
+          ]
+        }]
+      },
+      {
+        "title": "A worked example: a runtime that researches before implementation",
+        "paragraphs": [
+          "Suppose a team wants an agent to investigate a third-party API before an engineer changes production code.",
+          "No layer is impersonating another. The model produces analysis, the runtime follows its local tool policy, the workspace exposes the evidence and task state, and a human or named reviewer accepts the consequence.",
+          "For a reviewable cross-runtime handoff, see AI Agent Handoffs.",
+          "The sequence looks like this:"
+        ],
+        "orderedItems": [
+          "Define the agent role. The runtime may inspect supplied documentation and repository code, attach a source-backed finding, and identify open questions. It must not alter configuration, call the third-party write API, or merge a change.",
+          "Select a runtime. The team uses an MCP-attached coding host while a developer is present, because the work is exploratory and benefits from interactive direction rather than unattended polling.",
+          "Scope context. A task states the question, acceptance criteria, input sources, non-goals, and named reviewer. Relevant durable architecture notes are in shared memory.",
+          "Run the work. The host invokes the agent, which reads the task and sources, returns an attached research note, and posts a concise completion message.",
+          "Review the result. The technical lead evaluates the sources and chooses whether to create an implementation task, ask for more research, or close the question.",
+          "Persist only the durable outcome. If the team makes an approved integration decision, it records that decision in shared memory; the exploratory transcript stays with the task or thread."
+        ],
+        "links": [
+          { "label": "AI Agent Handoffs", "path": "/guides/ai-agent-handoffs/" }
+        ]
+      },
+      {
+        "title": "Six runtime design mistakes",
+        "paragraphs": [
+          "Each of these mistakes hides a boundary that a reviewer needs to see."
+        ]
+      },
+      {
+        "title": "Calling the model the runtime",
+        "paragraphs": [
+          "A model produces output; a runtime receives events, supplies context, invokes the model and tools, and returns results. Treating these as identical hides the environment and permission boundary where most operational risk lives."
+        ]
+      },
+      {
+        "title": "Treating a workspace connection as local machine access",
+        "paragraphs": [
+          "The runtime token scopes documented Commonly collaboration access. It does not turn on shell, source-control, cloud, browser, or deployment access for the process where the agent runs."
+        ]
+      },
+      {
+        "title": "Treating MCP as a background automation service",
+        "paragraphs": [
+          "An MCP-attached agent is reactive when invoked in its host tool. If the team needs an agent to poll events while it is running, a documented CLI-wrapper or custom runtime path is a different operating model."
+        ]
+      },
+      {
+        "title": "Acknowledging an event before defining the outcome boundary",
+        "paragraphs": [
+          "An acknowledgement records receipt of a delivery. It does not demonstrate that the runtime understood the request, produced an artifact, or completed an authorized action. Track those outcomes in the appropriate task, thread, review, and enforcing system."
+        ]
+      },
+      {
+        "title": "Giving one runtime every role and credential",
+        "paragraphs": [
+          "Combining research, code changes, public communication, release decisions, and broad secrets into a first runtime makes incidents and reviews harder to reason about. Start with one bounded role and expand only when the work proves the need."
+        ]
+      },
+      {
+        "title": "Writing every transient event into durable memory",
+        "paragraphs": [
+          "Memory is for reusable context and approved decisions. Keep current activity and handoff reasoning in the task or thread; keep secrets out of shared memory entirely."
+        ]
+      },
+      {
+        "title": "Design the runtime around accountable work",
+        "paragraphs": [
+          "The useful question is not “Which agent runtime is most autonomous?” It is “Can this process receive the right context, use only the necessary tools, leave an inspectable result, and stop at the right decision boundary?”",
+          "Start with a narrow role and the simplest runtime model that supports it. Keep workspace access separate from local powers, make output and review visible, and add scheduled or custom behavior only when the team can describe the trigger, scope, and failure path clearly."
+        ]
+      }
+    ],
+    "faq": [
+      { "question": "Is an AI agent runtime the same as an LLM?", "answer": "No. An LLM is one possible reasoning component. The runtime is the operating process around it: triggers, context, instructions, tools, credentials, output, and state. A runtime may use one model, different models, or a host tool’s configured model path." },
+      { "question": "Does Commonly host or run my agent runtime?", "answer": "No. Commonly documents that your agent connects to Commonly from wherever it runs. It supports MCP-attached tools, a local CLI wrapper, and custom HTTP processes; each runtime remains responsible for its own local environment." },
+      { "question": "What makes a runtime autonomous?", "answer": "Autonomy is an operating behavior, not a label attached by a token. An MCP-attached tool is reactive when invoked. A CLI wrapper can poll events while it is running, and a custom process can implement its own event loop. The team should still state which tasks and actions the runtime may advance without a new instruction." },
+      { "question": "Can a runtime token let an agent access every workspace pod?", "answer": "No. Commonly documents runtime tokens as scoped to an installation, with access to pods where that agent has an installation record. An agent cannot discover or join pods it was not explicitly installed into. Review each added membership because it changes the runtime’s collaboration reach." },
+      { "question": "Should a runtime automatically work every event it receives?", "answer": "No. An event can be a request, an external signal, or a scheduled check. The runtime should apply its role, context, and boundaries, then return the smallest truthful action: work a clearly eligible task, ask for clarification, record a blocker, or remain silent when it has nothing useful to add." }
+    ],
+    "relatedLinks": [
+      { "label": "Connect Claude Code and Codex to one workspace", "path": "/guides/connect-claude-codex-shared-workspace/" },
+      { "label": "Learn about AI agent permissions and tokens", "path": "/guides/ai-agent-permissions-and-tokens/" },
+      { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
+      { "label": "Learn about AI agent events", "path": "/guides/ai-agent-events/" }
+    ],
+    "cta": {
+      "title": "Design the runtime around accountable work",
+      "body": "Start with a narrow role and the simplest runtime model that supports it. Keep workspace access separate from local powers, make output and review visible, and add scheduled or custom behavior only when the team can describe the trigger, scope, and failure path clearly.",
       "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
       "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
     }

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -237,6 +237,17 @@ describe('V2 routing', () => {
     expect(screen.getByText(/@commonly-bot/)).toBeInTheDocument();
   });
 
+  test('runtime guide renders its documented event loop after the app takes over', async () => {
+    renderAt('/guides/what-is-an-ai-agent-runtime/');
+
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'What Is an AI Agent Runtime? The Process That Connects Models, Tools, and Work',
+    })).toBeInTheDocument();
+    expect(screen.getByText(/GET \/api\/agents\/runtime\/events/)).toBeInTheDocument();
+    expect(screen.getByText(/cm_agent_…/)).toBeInTheDocument();
+  });
+
   test('guides index renders after the app takes over', async () => {
     renderAt('/guides/');
 
@@ -244,7 +255,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(18);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(19);
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Connect Claude Code and Codex to a Shared Workspace',


### PR DESCRIPTION
## Summary
- add the static and SPA-visible AI agent runtime guide at /guides/what-is-an-ai-agent-runtime/
- add the guides-hub card, sitemap route, Article/WebPage metadata, and four approved reciprocal links
- cover generator ordering, runtime-token placeholders, and direct SPA route rendering

## Verification
- static SEO generator test
- direct V2 guide-route test
- TypeScript typecheck
- production build and generated artifact checks
- full frontend suite: 86 suites / 490 tests

## Release readiness
Ready with follow-ups: additive static/SPA content only; no migration or runtime permission change. Rollback is a revert. CI must be green before merge.