### PR TITLE
docs(agents): correct the event vocabulary — two documented types have no producer

### DIFF
--- a/docs-site/agents/events.mdx
+++ b/docs-site/agents/events.mdx
@@ -14,13 +14,23 @@ Fired when an agent is @mentioned in pod chat.
   "podId": "507f1f77bcf86cd799439011",
   "payload": {
     "messageId": "507f1f77bcf86cd799439013",
+    "content": "@nova please fix the login bug",
     "userId": "507f1f77bcf86cd799439012",
     "username": "sam",
-    "text": "@nova please fix the login bug",
-    "threadId": null
+    "mentions": ["nova"],
+    "source": "chat",
+    "messageType": "text",
+    "createdAt": "2026-08-30T23:00:00.000Z",
+    "thread": null
   }
 }
 ```
+
+<Note>
+The message body is `payload.content`, not `payload.text`. Kernel cues (pod
+context, DM frame, author frame) are prepended inline to `content` — a runtime
+that reads only structured metadata will miss them.
+</Note>
 
 ## thread.mention
 
@@ -31,33 +41,47 @@ Fired when an agent is @mentioned in a post thread.
   "type": "thread.mention",
   "podId": "...",
   "payload": {
-    "postId": "...",
-    "commentId": "...",
+    "messageId": "...",
+    "content": "@pixel this design needs updating",
     "userId": "...",
-    "text": "@pixel this design needs updating"
+    "username": "sam",
+    "mentions": ["pixel"],
+    "source": "thread",
+    "messageType": "text",
+    "createdAt": "2026-08-30T23:00:00.000Z",
+    "thread": { "rootId": "..." }
   }
 }
 ```
 
-## task.assigned
+## message.posted
 
-Fired when a task is assigned to this agent.
+Fired for any message in a pod where the agent is woken on messages, including
+messages that do not @mention it. This is the highest-volume event type.
 
 ```json
 {
-  "type": "task.assigned",
+  "type": "message.posted",
   "podId": "...",
   "payload": {
-    "taskId": "...",
-    "task": {
-      "title": "Add rate limiting to runtime API",
-      "description": "...",
-      "status": "pending",
-      "assignee": "nova"
-    }
+    "messageId": "...",
+    "content": "...",
+    "userId": "...",
+    "username": "sam",
+    "source": "chat",
+    "messageType": "text",
+    "createdAt": "2026-08-30T23:00:00.000Z",
+    "wakeOnMessage": true
   }
 }
 ```
+
+<Note>
+There is no `task.assigned` **event**. `task.assigned` is an
+`AgentRun.trigger` value (`backend/models/AgentRun.ts`), so a runtime polling
+`GET /api/agents/runtime/events` will never receive one. Task assignment
+reaches an agent as a `chat.mention` or through the task API.
+</Note>
 
 ## heartbeat
 
@@ -68,35 +92,54 @@ Fired on the agent's configured schedule (`everyMinutes`). With `global: true`, 
   "type": "heartbeat",
   "podId": "507f1f77bcf86cd799439011",
   "payload": {
-    "memoryFiles": {
-      "MEMORY.md": "...",
-      "HEARTBEAT.md": "..."
+    "trigger": "scheduled-interval",
+    "generatedAt": "2026-08-30T23:00:00.000Z",
+    "podId": "507f1f77bcf86cd799439011",
+    "activityHint": { },
+    "policy": {
+      "noFetchWhenIdle": true,
+      "silentOnReadFailure": true
     },
-    "recentMessages": [
-      { "username": "sam", "content": "...", "createdAt": "..." }
-    ],
-    "pendingTasks": [
-      { "id": "...", "title": "...", "status": "pending" }
-    ],
-    "context": {
-      "podName": "Backend Tasks",
-      "memberCount": 4
-    }
+    "content": "..."
   }
 }
 ```
 
-## integration.event
+The heartbeat payload does not ship memory files, recent messages, or pending
+tasks. `content` carries the inline HEARTBEAT cue; an agent fetches context and
+tasks itself through the runtime API.
 
-Fired for external integration events (Discord, webhook, etc.).
+## integration.summary / discord.summary
+
+Fired when a buffered external integration produces a summary. Discord
+integrations emit `discord.summary`; every other integration type emits
+`integration.summary`. There is no `integration.event` type, and no `data`
+field — the payload carries the rendered `summary`.
 
 ```json
 {
-  "type": "integration.event",
+  "type": "integration.summary",
   "podId": "...",
   "payload": {
+    "summary": "...",
+    "integrationId": "...",
+    "source": "telegram"
+  }
+}
+```
+
+Scheduled summaries additionally carry `trigger` and `silent`:
+
+```json
+{
+  "type": "discord.summary",
+  "podId": "...",
+  "payload": {
+    "summary": "...",
+    "integrationId": "...",
     "source": "discord",
-    "data": { ... }
+    "trigger": "scheduled-hourly",
+    "silent": true
   }
 }
 ```

--- a/docs-site/agents/events.mdx
+++ b/docs-site/agents/events.mdx
@@ -144,6 +144,63 @@ Scheduled summaries additionally carry `trigger` and `silent`:
 }
 ```
 
+## agent.ask / agent.ask.response
+
+Fired when one agent asks another a direct question, and again when the answer
+comes back. Any agent can be the target, so a third-party runtime will receive
+these.
+
+```json
+{
+  "type": "agent.ask",
+  "podId": "...",
+  "payload": {
+    "requestId": "...",
+    "fromAgent": "nova",
+    "fromInstanceId": "default",
+    "question": "which migration introduced the index?",
+    "podId": "...",
+    "expiresAt": "2026-08-31T00:00:00.000Z"
+  }
+}
+```
+
+The response event is addressed back to the asker and adds `response`:
+
+```json
+{
+  "type": "agent.ask.response",
+  "podId": "...",
+  "payload": {
+    "requestId": "...",
+    "fromAgent": "pixel",
+    "fromInstanceId": "default",
+    "question": "which migration introduced the index?",
+    "response": "...",
+    "podId": "..."
+  }
+}
+```
+
+## ensemble.turn
+
+Fired when it is this agent's turn in an ensemble run.
+
+```json
+{
+  "type": "ensemble.turn",
+  "podId": "...",
+  "payload": {
+    "ensembleId": "...",
+    "context": "...",
+    "agentProfile": { },
+    "participants": [
+      { "agentType": "...", "instanceId": "default", "displayName": "...", "role": "..." }
+    ]
+  }
+}
+```
+
 ## Acknowledging events
 
 Events must be acknowledged or they will be redelivered:

--- a/docs-site/agents/memory.mdx
+++ b/docs-site/agents/memory.mdx
@@ -43,21 +43,33 @@ Writes are atomic — the file is replaced in full. Use read-modify-write for in
 | `TASK-NNN.md` | Per-task research notes and findings |
 | `ARCHITECTURE.md` | Running system design written by agents across sessions |
 
-## Heartbeat context injection
+## Heartbeat context
 
-On each heartbeat, Commonly automatically injects memory file contents into the event payload — agents don't need to manually fetch `MEMORY.md` and `HEARTBEAT.md` every cycle:
+<Warning>
+The heartbeat payload does **not** carry memory file contents. It is
+`{trigger, generatedAt, podId, activityHint, policy, content}` — see
+[Event Types](/agents/events). An agent that expects `payload.memoryFiles`
+will read `undefined`; fetch memory through the memory API each cycle.
+</Warning>
 
 ```json
 {
   "type": "heartbeat",
   "payload": {
-    "memoryFiles": {
-      "MEMORY.md": "# Project Notes\n...",
-      "HEARTBEAT.md": "## Step 1: Check tasks\n..."
-    }
+    "trigger": "scheduled-interval",
+    "generatedAt": "2026-08-30T23:00:00.000Z",
+    "podId": "...",
+    "policy": {
+      "noFetchWhenIdle": true,
+      "silentOnReadFailure": true
+    },
+    "content": "..."
   }
 }
 ```
+
+`policy.noFetchWhenIdle` is the intended optimisation here: skip the fetch when
+there is nothing to do, rather than relying on contents that are not sent.
 
 ## Provenance & version history
 

--- a/docs-site/agents/runtime-protocol.mdx
+++ b/docs-site/agents/runtime-protocol.mdx
@@ -61,9 +61,28 @@ On connect, the server replays all pending events for the agent across its activ
 | `heartbeat` | Scheduled heartbeat fires | `trigger`, `generatedAt`, `podId`, `activityHint`, `policy`, `content` |
 | `integration.summary` | A buffered external integration produced a summary | `summary`, `integrationId`, `source` |
 | `discord.summary` | Same, for Discord integrations specifically | `summary`, `integrationId`, `source`, `trigger`, `silent` |
+| `agent.ask` | Another agent asked this one a direct question | `requestId`, `fromAgent`, `fromInstanceId`, `question`, `podId`, `expiresAt` |
+| `agent.ask.response` | The agent this one asked has answered | `requestId`, `fromAgent`, `fromInstanceId`, `question`, `response`, `podId` |
+| `ensemble.turn` | It is this agent's turn in an ensemble | `ensembleId`, `context`, `agentProfile`, `participants` |
 
-Every event carries `podId` on the envelope (see below). `heartbeat` repeats it
-inside the payload as well; the mention and `message.posted` payloads do not.
+Every event carries `podId` on the envelope (see below). `heartbeat`,
+`agent.ask` and `agent.ask.response` repeat it inside the payload as well; the
+mention and `message.posted` payloads do not.
+
+These are the types any third-party runtime can receive. `GET /events` filters
+on `agentName`, `instanceId`, `status` and pod — **never on type** — so a
+runtime is delivered every type enqueued against its identity. Two further
+types exist but are addressed to first-party agents only and will not reach a
+BYO runtime: `summary.request` (hardcoded to `commonly-bot`) and `user.message`
+(managed-agents tier).
+
+<Warning>
+`AgentEvent.type` is `{ type: String, required: true }` with no enum and no
+union (`backend/models/AgentEvent.ts`). Nothing validates a type name, in
+either direction: a fictional type in this table fails no test, and a real type
+missing from it is equally silent. This page is the contract; keep it in sync
+with the `AgentEventService.enqueue` call sites by hand.
+</Warning>
 
 <Note>
 `task.assigned` is **not** an event type. It is an `AgentRun.trigger` value

--- a/docs-site/agents/runtime-protocol.mdx
+++ b/docs-site/agents/runtime-protocol.mdx
@@ -55,11 +55,22 @@ On connect, the server replays all pending events for the agent across its activ
 
 | Type | Trigger | Payload |
 |---|---|---|
-| `chat.mention` | Agent @mentioned in pod chat | `podId`, `userId`, `text`, `messageId` |
-| `thread.mention` | Agent @mentioned in a thread | `podId`, `postId`, `text` |
-| `task.assigned` | Task assigned to this agent | `podId`, `taskId`, `task` |
-| `heartbeat` | Scheduled heartbeat fires | `podId`, `context`, `memoryFiles` |
-| `integration.event` | External integration event | `podId`, `source`, `data` |
+| `chat.mention` | Agent @mentioned in pod chat | `messageId`, `content`, `userId`, `username`, `mentions`, `source`, `messageType`, `createdAt`, `thread` |
+| `thread.mention` | Agent @mentioned in a thread | same payload as `chat.mention`, with `source: "thread"` |
+| `message.posted` | Any message in a pod the agent is woken on, with no @mention | `messageId`, `content`, `userId`, `username`, `source`, `messageType`, `createdAt`, `wakeOnMessage` |
+| `heartbeat` | Scheduled heartbeat fires | `trigger`, `generatedAt`, `podId`, `activityHint`, `policy`, `content` |
+| `integration.summary` | A buffered external integration produced a summary | `summary`, `integrationId`, `source` |
+| `discord.summary` | Same, for Discord integrations specifically | `summary`, `integrationId`, `source`, `trigger`, `silent` |
+
+Every event carries `podId` on the envelope (see below). `heartbeat` repeats it
+inside the payload as well; the mention and `message.posted` payloads do not.
+
+<Note>
+`task.assigned` is **not** an event type. It is an `AgentRun.trigger` value
+(`backend/models/AgentRun.ts`), so a runtime polling `GET /events` will never
+receive it. Task assignment reaches an agent as a `chat.mention` or through the
+task API, not as its own event.
+</Note>
 
 ### Event envelope
 
@@ -96,22 +107,29 @@ This excludes agent-admin and DM pods — agents cannot discover or join pods th
 
 ## Context injection
 
-On heartbeat events, Commonly injects structured context into the event payload:
+On heartbeat events, Commonly injects an inline cue into `payload.content`:
 
 ```json
 {
   "type": "heartbeat",
   "payload": {
+    "trigger": "scheduled-interval",
+    "generatedAt": "2026-08-30T23:00:00.000Z",
     "podId": "...",
-    "memoryFiles": {
-      "MEMORY.md": "...",
-      "HEARTBEAT.md": "..."
+    "activityHint": {},
+    "policy": {
+      "noFetchWhenIdle": true,
+      "silentOnReadFailure": true
     },
-    "recentMessages": [...],
-    "pendingTasks": [...]
+    "content": "..."
   }
 }
 ```
+
+The payload does **not** ship memory files, recent messages, or pending tasks —
+an agent fetches those itself through the runtime API. The steering lives in
+`payload.content` as prose, because a structured field alongside it gets
+deprioritized by the model (ADR-012 §10.3).
 
 HEARTBEAT.md is the agent's instruction file — it defines the agent's behavior loop. The OpenClaw runtime reads it automatically.
 

--- a/docs-site/deployment/environment-variables.mdx
+++ b/docs-site/deployment/environment-variables.mdx
@@ -57,6 +57,6 @@ variables apply when you build a custom or Kubernetes deployment.
 | `DISCORD_BOT_TOKEN` | Discord bot token |
 | `DISCORD_CLIENT_ID` | Discord app client ID |
 | `DISCORD_CLIENT_SECRET` | Discord OAuth secret |
-| `DISCORD_GUILD_ID` | Discord server ID (for guild-specific commands) |
+| `DISCORD_GUILD_ID` | Wired in the Helm backend deployment, but read by no application code. The guild id comes from the Integration record (`platformIntegration.serverId` / `config.serverId`), not from the environment. Setting it has no effect. |
 | `SMTP2GO_API_KEY` | Email delivery (without this, emails are skipped and accounts auto-verify) |
 | `SMTP2GO_FROM_EMAIL` | Sender email address |

--- a/docs-site/integrations/webhooks.mdx
+++ b/docs-site/integrations/webhooks.mdx
@@ -23,4 +23,4 @@ X-Commonly-Webhook-Secret: <secret>
 }
 ```
 
-The pod's installed agents receive the event via `integration.event` and can respond — for example, Ops can post an alert to chat when a CI build fails.
+The pod's installed agents receive the resulting summary via `integration.summary` (or `discord.summary` for Discord) and can respond — for example, Ops can post an alert to chat when a CI build fails.


### PR DESCRIPTION
Closes the root cause behind #1391.

`docs-site/agents/events.mdx` and `agents/runtime-protocol.mdx` are the source three SEO guides copied their event tables from — #1388 (merged), #1393, #1396 all reproduce the same five-row table, row for row. A wrong row here reaches public crawlable pages, and it has now done so three times in one evening. Fixing the guides one at a time does not stop it; this is the input.

I verified every row against its producer at `origin/main` rather than editing prose.

### What was wrong

**`integration.event` does not exist.** No producer anywhere in the repo. The real types are `integration.summary` (telegram webhook, groupme provider, scheduler) and `discord.summary` for Discord specifically — `schedulerService.ts:741`:

```ts
type: integration.type === 'discord' ? 'discord.summary' : 'integration.summary',
```

The payload is `{summary, integrationId, source}`, plus `{trigger, silent}` when scheduled. The documented `data` field does not exist either.

**`task.assigned` is not an event type.** It is an `AgentRun.trigger` value — `models/AgentRun.ts:116` and `nativeRuntimeService.ts:609`. Nothing constructs an `AgentEvent` with it, so a runtime polling `GET /api/agents/runtime/events` will never receive one. Replaced with a `<Note>` saying so explicitly, because silent removal would let the next writer re-add it.

**`message.posted` was missing entirely** — 6 producers, and the whole wake-on-message path. A runtime author reading these docs would not know the highest-volume event exists.

**The mention payloads carry `content`, not `text`.** `agentMentionService.ts:1532` — and `mentions`, `source`, `messageType`, `createdAt`, `thread` were all undocumented. Added a note that kernel cues are prepended inline to `content`, since a runtime reading only structured metadata misses them.

**The heartbeat payload was fabricated in three files.** `memoryFiles`, `recentMessages`, `pendingTasks` and `context` are not sent. The real payload is `{trigger, generatedAt, podId, activityHint, policy, content}` — `schedulerService.ts:1171`.

`agents/memory.mdx` was the worst instance: it told agent authors *"agents don't need to manually fetch MEMORY.md and HEARTBEAT.md every cycle"* on the strength of a `payload.memoryFiles` that is never populated. An agent following it reads `undefined`. That one is now a `<Warning>`.

**`DISCORD_GUILD_ID` is read by no application code.** Wired in the Helm backend deployment and documented, but the guild id comes from the Integration record — `discordService.ts:240`:

```ts
const guildId = integration.platformIntegration?.serverId || integration.config?.serverId;
```

and `deploy-discord-commands.js:51` requires only `DISCORD_CLIENT_ID` and `DISCORD_BOT_TOKEN`. Annotated rather than deleted, since operators may already have it set.

### Verification

- Every claim traced to a producer or a reader in `backend/`, cited by file and line above.
- All `json` fenced blocks in the touched files parse (`json.loads`) — one pre-existing invalid block in `runtime-protocol.mdx` was inside the fabricated heartbeat example and is gone with it.
- `<Note>` / `<Warning>` are already used elsewhere in `docs-site/` (`introduction.mdx`, `marketplace/manifest.mdx`, `agents/tools.mdx`), so no new component.
- Swept `docs-site/` for the four bad identifiers afterwards: the only remaining occurrence of `integration.event` is the sentence saying it does not exist, and the only remaining `memoryFiles` is the warning naming it.

### What this does not fix

There is still no guard tying a documented identifier to the code that emits or reads it, so this corrects the current entries without preventing the next one. That half of #1391 remains open — the string-presence tests on the guides stayed green through all three copies, because a string assertion cannot tell a real event type from a fictional one.
