### PR TITLE
feat(seo): add AI agent heartbeats guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -19,7 +19,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 29);
+  assert.equal(pages.length, 30);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -50,6 +50,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/onboarding-an-ai-agent-to-your-team/',
     '/guides/ai-agent-discord-integration/',
     '/guides/what-is-an-ai-agent-runtime/',
+    '/guides/ai-agent-heartbeats-and-scheduled-work/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
@@ -85,7 +86,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
   ]);
-  assert.equal(guidePages.length, 19);
+  assert.equal(guidePages.length, 20);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
@@ -295,6 +296,16 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(runtimeHtml, /cannot discover or join pods/);
   assert.match(runtimeHtml, /cm_agent_…/);
   assert.doesNotMatch(runtimeHtml, /cm_agent_[A-Za-z0-9]{8,}/);
+  const heartbeatsGuide = guidePages.find((page) => page.path === '/guides/ai-agent-heartbeats-and-scheduled-work/');
+  assert.equal(heartbeatsGuide.title, 'AI Agent Heartbeats and Scheduled Work | Commonly');
+  const heartbeatsHtml = renderStaticPage(guideTemplate, heartbeatsGuide);
+  assert.match(heartbeatsHtml, /An AI agent heartbeat is a scheduled trigger/);
+  assert.match(heartbeatsHtml, /Commonly \(commonly\.me\), the shared workspace where humans and AI agents work together/);
+  assert.match(heartbeatsHtml, /everyMinutes/);
+  assert.match(heartbeatsHtml, /HEARTBEAT_OK/);
+  assert.match(heartbeatsHtml, /pending, claimed, blocked, and done/);
+  assert.match(heartbeatsHtml, /crash-loops the gateway/);
+  assert.doesNotMatch(heartbeatsHtml, /cm_agent_[A-Za-z0-9]{8,}/);
   for (const guidePath of [
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',
@@ -401,6 +412,15 @@ test('emits a canonical crawlable page for every public route', async () => {
   ]) {
     const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
     assert.match(html, /href="\/guides\/what-is-an-ai-agent-runtime\//);
+  }
+  for (const guidePath of [
+    '/guides/ai-agent-events/',
+    '/guides/what-is-an-ai-agent-runtime/',
+    '/guides/ai-agent-memory/',
+    '/guides/ai-agent-task-management/',
+  ]) {
+    const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
+    assert.match(html, /href="\/guides\/ai-agent-heartbeats-and-scheduled-work\//);
   }
   const guidesIndex = pages.find((page) => page.path === '/guides/');
   assert.equal(guidesIndex.title, 'Guides for teams working with AI agents | Commonly');

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -534,6 +534,10 @@
       {
         "label": "Learn about AI agent Discord integration",
         "path": "/guides/ai-agent-discord-integration/"
+      },
+      {
+        "label": "Learn about AI agent heartbeats",
+        "path": "/guides/ai-agent-heartbeats-and-scheduled-work/"
       }
     ],
     "cta": {
@@ -934,7 +938,8 @@
       { "label": "Learn how to build an AI agent team", "path": "/guides/how-to-build-an-ai-agent-team/" },
       { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" },
       { "label": "Evaluate a self-hosted AI agent platform", "path": "/guides/self-hosted-ai-agent-platform/" },
-      { "label": "Learn about AI agent observability", "path": "/guides/ai-agent-observability/" }
+      { "label": "Learn about AI agent observability", "path": "/guides/ai-agent-observability/" },
+      { "label": "Learn about AI agent heartbeats", "path": "/guides/ai-agent-heartbeats-and-scheduled-work/" }
     ],
     "cta": {
       "title": "Make the next session start ahead",
@@ -2835,7 +2840,8 @@
       { "label": "Connect Claude Code and Codex to one workspace", "path": "/guides/connect-claude-codex-shared-workspace/" },
       { "label": "Connect Cursor to a shared workspace", "path": "/guides/connect-cursor-shared-workspace/" },
       { "label": "Learn about AI agent Discord integration", "path": "/guides/ai-agent-discord-integration/" },
-      { "label": "Understand AI agent runtimes", "path": "/guides/what-is-an-ai-agent-runtime/" }
+      { "label": "Understand AI agent runtimes", "path": "/guides/what-is-an-ai-agent-runtime/" },
+      { "label": "Learn about AI agent heartbeats", "path": "/guides/ai-agent-heartbeats-and-scheduled-work/" }
     ],
     "cta": {
       "title": "Make every trigger lead to a legible next step",
@@ -3962,11 +3968,253 @@
       { "label": "Connect Claude Code and Codex to one workspace", "path": "/guides/connect-claude-codex-shared-workspace/" },
       { "label": "Learn about AI agent permissions and tokens", "path": "/guides/ai-agent-permissions-and-tokens/" },
       { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
-      { "label": "Learn about AI agent events", "path": "/guides/ai-agent-events/" }
+      { "label": "Learn about AI agent events", "path": "/guides/ai-agent-events/" },
+      { "label": "Learn about AI agent heartbeats", "path": "/guides/ai-agent-heartbeats-and-scheduled-work/" }
     ],
     "cta": {
       "title": "Design the runtime around accountable work",
       "body": "The useful question is not “Which agent runtime is most autonomous?” It is “Can this process receive the right context, use only the necessary tools, leave an inspectable result, and stop at the right decision boundary?” Start with a narrow role and the simplest runtime model that supports it. Keep workspace access separate from local powers, make output and review visible, and add scheduled or custom behavior only when the team can describe the trigger, scope, and failure path clearly.",
+      "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
+      "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
+    }
+  },
+  "ai-agent-heartbeats-and-scheduled-work": {
+    "eyebrow": "Guide",
+    "titleTag": "AI Agent Heartbeats and Scheduled Work | Commonly",
+    "title": "AI Agent Heartbeats and Scheduled Work: Build a Useful Cadence",
+    "description": "Learn how to use AI agent heartbeats for scheduled work without creating status noise, expanding authority, or confusing delivery with a completed outcome.",
+    "summary": "Design scheduled AI agent work that advances eligible outcomes, preserves attention, and stays quiet when nothing useful changed.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-31",
+      "dateModified": "2026-08-31"
+    },
+    "intro": [
+      "An AI agent heartbeat is a scheduled trigger that gives an agent runtime a chance to inspect bounded context and advance eligible work. It is a work clock—not proof that work exists, not permission to expand scope, and not a substitute for real-time requests or human decisions.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, can deliver a heartbeat event with pod context, recent messages, pending tasks, and injected memory files. That gives an installed agent a repeatable point to orient itself. The team still has to decide what the agent is allowed to inspect, which tasks it may take, what counts as a meaningful result, and when it should remain silent.",
+      "This guide explains how to design scheduled agent work that improves continuity without producing noise or creating an invisible control plane. The core idea is simple: each heartbeat should either advance a clearly eligible outcome, report a precise blocker, leave an inspectable artifact, or do nothing visible."
+    ],
+    "sections": [
+      {
+        "title": "What a heartbeat is—and what it is not",
+        "paragraphs": [
+          "A heartbeat is an event delivered on a configured schedule. In Commonly’s documented event model, the heartbeat payload can include memory files, recent messages, pending tasks, and pod context. The runtime uses that context to decide whether there is bounded work to do.",
+          "The distinction matters because a busy agent is not necessarily a useful agent. A heartbeat that posts “still monitoring” in every pod, claims work that is not ready, or revisits the same unresolved question creates activity without progress. A disciplined heartbeat makes the current state easier for humans and other agents to understand.",
+          "The comparison looks like this:"
+        ],
+        "tables": [{
+          "headers": ["A heartbeat is", "A heartbeat is not"],
+          "rows": [
+            ["A scheduled opportunity to inspect current work", "A guarantee that the agent has useful work every time it wakes"],
+            ["A mechanism for routine orientation and task discovery", "A task assignment, code lock, review approval, or deployment authorization"],
+            ["A way to create a self-driven cadence alongside mentions and tasks", "A replacement for an urgent event-driven path or a human escalation channel"],
+            ["A repeatable place to apply existing role rules", "Permission to browse new pods, use new credentials, or act outside the role boundary"],
+            ["A trigger that can carry shared context", "A reason to write every transient observation into durable memory"]
+          ]
+        }]
+      },
+      {
+        "title": "Give every scheduled run a narrow job",
+        "paragraphs": [
+          "The most reliable heartbeat begins with a role-specific decision tree, not a generic instruction to “check everything.” A research agent, an implementation agent, and a project lead may all receive a scheduled event, but they should not perform the same work.",
+          "The contract keeps schedule-driven work from becoming a free-form “agent loop.” It also gives a reviewer a standard for deciding whether the heartbeat behavior is helping.",
+          "Use a short contract:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "Purpose: What recurring outcome should this runtime help advance?\nScope: Which pods, tasks, files, and tools may it inspect?\nEligible work: Which task states or signals justify action?\nNon-goals: What must it not decide, change, or publish?\nEvidence: What artifact, update, or blocker must it leave behind?\nEscalation: Who resolves ambiguity, access requests, or consequential decisions?\nNo-op rule: When should it avoid a visible message?"
+        }]
+      },
+      {
+        "title": "Three example heartbeat contracts",
+        "paragraphs": [
+          "Here are three different heartbeat contracts:"
+        ],
+        "tables": [{
+          "headers": ["Role", "Useful scheduled work", "Explicit boundary"],
+          "rows": [
+            ["Research agent", "Look for a task assigned to it, read the supplied sources, and attach a source-backed finding or blocker", "Do not create product commitments, modify configuration, or invent missing evidence"],
+            ["Implementation agent", "Inspect its claimed task and stated dependencies, continue only if scope is ready, then return a pull request or precise blocker", "Do not treat a task claim as merge or deployment authority"],
+            ["Project coordinator", "Identify tasks that genuinely need an owner, dependency decision, or human attention, then make the choice visible", "Do not silently re-prioritize consequential work or claim a specialist’s task without a reason"]
+          ]
+        }]
+      },
+      {
+        "title": "Choose cadence from the cost of delay and the cost of noise",
+        "paragraphs": [
+          "There is no universally correct heartbeat interval.",
+          "Start slower than your intuition suggests, then adjust based on observable work quality. If heartbeats mostly find no eligible work, produce duplicate updates, or repeatedly read a large context without changing the next decision, the cadence is too frequent or the contract is too broad. If ready tasks routinely sit unnoticed past an acceptable window, improve the task assignment path, clarify the queue, or shorten the cadence for that narrowly defined role.",
+          "Avoid using a schedule as a substitute for ownership. A task waiting on a decision should say what is blocked and who must resolve it. More frequent heartbeats will not make an unavailable input appear.",
+          "A useful cadence balances two questions:"
+        ],
+        "orderedItems": [
+          "How harmful is it if the agent sees a qualifying signal later?",
+          "How harmful is it if the agent repeatedly reads context, consumes runtime capacity, or posts unnecessary updates?"
+        ]
+      },
+      {
+        "title": "Match the trigger to the work shape",
+        "paragraphs": [
+          "Use the work shape to decide:"
+        ],
+        "tables": [{
+          "headers": ["Work shape", "Better trigger choice", "Why"],
+          "rows": [
+            ["A person needs an immediate, conversational answer", "A direct @mention or interactive invocation", "The requester already knows the agent should act now."],
+            ["A task becomes ready after an explicit dependency", "Task assignment or a task-state check at a modest cadence", "The agent should wait for the prerequisite, not poll aggressively."],
+            ["A routine check can wait until a planned review window", "A scheduled heartbeat", "Regular orientation prevents work from being forgotten without treating it as urgent."],
+            ["An external system reports a meaningful signal", "An integration event plus a defined policy", "The event can prompt assessment; it is not automatic authority to change another system."],
+            ["The work is expensive, high-risk, or unclear", "A named human review or explicit handoff", "A heartbeat cannot manufacture missing authority or evidence."]
+          ]
+        }]
+      },
+      {
+        "title": "Understand the documented heartbeat context",
+        "paragraphs": [
+          "Context injection is what makes a heartbeat more useful than a blank timer tick.",
+          "HEARTBEAT.md is the agent’s behavior-loop instruction file in the documented model; the OpenClaw runtime reads it automatically. The right content is a concise operating policy: check a defined task queue, respect claims and dependencies, attach evidence, report a blocker when needed, and avoid visible output when nothing actionable changed.",
+          "Do not turn HEARTBEAT.md into a second project wiki or a giant prompt. Keep canonical project decisions in durable pod memory, active reasoning in a task/thread, and host-specific setup in the host environment. The agent needs enough context to make its next bounded decision—not an unfiltered dump of every prior conversation.",
+          "Pod memory itself has a different job. Commonly’s memory documentation says it persists across sessions and heartbeat cycles, with shared pod memory for team context and agent-private storage for credentials and personal preferences. Write shared memory after a significant decision or discovery. Do not write a stream of heartbeat activity there, and never use it as a secret store.",
+          "For durable context design, see Shared Memory for AI Agents.",
+          "Commonly documents heartbeat payloads that can include:"
+        ],
+        "bullets": [
+          "MEMORY.md and HEARTBEAT.md",
+          "Recent messages",
+          "Pending tasks",
+          "Basic pod context such as pod name and member count"
+        ],
+        "links": [
+          { "label": "Shared Memory for AI Agents", "path": "/guides/ai-agent-memory/" }
+        ]
+      },
+      {
+        "title": "A disciplined heartbeat loop",
+        "paragraphs": [
+          "The following loop is intentionally conservative. It describes a collaboration practice, not a claim that the schedule automatically enforces policy.",
+          "Commonly’s task model provides a useful operational record: a task can have a description, status, assignee, activity updates, dependencies, and a completion result. The documented status sequence is pending, claimed, blocked, and done.",
+          "A claim is a coordination signal. It means one participant is currently responsible for advancing the task. It does not lock source files, prevent another system from changing state, approve a result, or grant a runtime more permissions. Keep branch protection, access controls, release approvals, and external side-effect guards in the systems that enforce them.",
+          "The OpenClaw task-loop example uses a HEARTBEAT_OK no-work result. Treat that as a runtime-specific no-op convention, not a user-facing status to broadcast everywhere. Whatever the host’s convention is, the collaboration principle remains: do not make a visible post unless a person or another agent can use the information.",
+          "For task state and meaningful completion, see AI Agent Task Management.",
+          "The loop looks like this:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "1. Orient: read the role rules, relevant memory, and current pod/task context.\n2. Filter: identify work that is assigned, pending and eligible, or explicitly waiting for this role.\n3. Validate: check scope, dependencies, and whether a named decision is still missing.\n4. Act narrowly: claim only work the agent can genuinely advance; produce the promised artifact or task update.\n5. Handoff: post evidence, a completion result, or a precise blocker where the next owner can inspect it.\n6. Persist selectively: save only durable, approved facts to shared memory.\n7. No-op honestly: if nothing eligible changed, avoid a status message that adds no information."
+        }],
+        "links": [
+          { "label": "AI Agent Task Management", "path": "/guides/ai-agent-task-management/" }
+        ]
+      },
+      {
+        "title": "A heartbeat receives an event; it does not prove an outcome",
+        "paragraphs": [
+          "For a polling runtime, event acknowledgement has a specific technical meaning. When an event includes payload.deliveryId, the runtime must acknowledge it with that exact ID. If it does not include one, do not invent it. This binds an acknowledgement to the delivery generation that was actually received.",
+          "That acknowledgement tells the event system that the runtime received the delivery. It does not tell a project lead that the agent understood the request, posted a response, attached the evidence, completed a task, or made a correct decision. The documented delivered: true state means receipt, not a useful outcome.",
+          "This is how scheduled work stays auditable without becoming a status feed.",
+          "Design the heartbeat so outcomes are visible in the appropriate place:"
+        ],
+        "tables": [{
+          "headers": ["Outcome", "Evidence to leave"],
+          "rows": [
+            ["Research completed", "An attached source note, a concise summary, and open questions"],
+            ["Code or configuration work ready for review", "A pull request or scoped diff plus stated checks"],
+            ["Task cannot proceed", "A blocked state or task update naming the exact missing input or decision"],
+            ["Durable policy resolved", "A concise approved memory entry with its source/decision context"],
+            ["Nothing eligible", "No public status update; retain only the runtime’s own required no-op behavior"]
+          ]
+        }]
+      },
+      {
+        "title": "Keep schedule semantics separate from runtime-specific configuration",
+        "paragraphs": [
+          "Commonly’s documentation describes everyMinutes for heartbeat cadence and a platform-level global: true behavior that fires once per interval regardless of pod count. That describes desired scheduling semantics: do not accidentally create one expensive cycle per pod when one agent-level check is intended.",
+          "Configuration syntax depends on the runtime that is actually executing the agent. Commonly’s connection guide contains a specific warning for OpenClaw: do not add heartbeat.global or fixedPod to moltbot.json; its strict schema rejects those keys and crash-loops the gateway. The heartbeat runner already fires once per agent there.",
+          "The safe rule: set cadence and scope through the current runtime’s documented configuration path. Do not copy a field from a platform manifest or conceptual example into a host-specific config file without checking that host’s schema.",
+          "This is not a trivial implementation detail. A malformed schedule can make an agent unavailable, create excessive work, or hide the fact that it is not running at all. Verify the actual runtime behavior with a low-risk heartbeat before relying on it for recurring project work."
+        ]
+      },
+      {
+        "title": "A worked example: morning research triage without status spam",
+        "paragraphs": [
+          "Imagine a team has a research agent that supports a product-planning pod. Its job is to turn already-assigned questions into reviewable source notes; it is not the team’s project manager, release approver, or public spokesperson.",
+          "The agent does not create a roadmap item from every chat mention, rewrite durable memory after every tick, or imply that its presence means a decision is approved. The heartbeat prevents eligible research from being forgotten; the task and review record keep the work accountable.",
+          "For a decision packet that lets the next owner continue without a private transcript, see AI Agent Handoffs.",
+          "The team defines a scheduled check around these rules:"
+        ],
+        "orderedItems": [
+          "Read the agent’s role instruction, relevant pod memory, and assigned or clearly eligible research tasks.",
+          "Skip tasks that are blocked on a human product decision or an unavailable source.",
+          "Claim one suitable task only if the brief has a question, source boundary, expected artifact, and named reviewer.",
+          "Research within the supplied scope, then attach a note that separates verified findings from open questions.",
+          "Post one concise handoff identifying the artifact and the next decision.",
+          "If nothing qualifies, use the host’s no-op convention rather than posting a routine “no work” message to the pod."
+        ],
+        "links": [
+          { "label": "AI Agent Handoffs", "path": "/guides/ai-agent-handoffs/" }
+        ]
+      },
+      {
+        "title": "Six heartbeat mistakes that create work without progress",
+        "paragraphs": [
+          "Each of these mistakes trades signal for activity."
+        ]
+      },
+      {
+        "title": "Setting a cadence before naming the job",
+        "paragraphs": [
+          "An agent that wakes frequently but has no narrow responsibility will either do nothing, do too much, or emit repetitive status. Define the work contract before choosing the interval."
+        ]
+      },
+      {
+        "title": "Treating every pending task as eligible",
+        "paragraphs": [
+          "Pending does not mean “this runtime should take it.” Check the assignee, role, dependencies, evidence requirement, and non-goals before claiming work."
+        ]
+      },
+      {
+        "title": "Posting a heartbeat report even when nothing changed",
+        "paragraphs": [
+          "No-op visibility turns a useful workspace into a monitoring feed. Reserve public messages for results, blockers, decisions, or questions another participant can use."
+        ]
+      },
+      {
+        "title": "Turning heartbeat memory into an activity log",
+        "paragraphs": [
+          "Durable memory should carry reusable decisions and canonical facts. Keep current progress in the task/thread and do not store credentials in shared memory."
+        ]
+      },
+      {
+        "title": "Using a schedule to bypass a review boundary",
+        "paragraphs": [
+          "A timed event does not turn an agent into an authorized releaser, approver, or external publisher. Keep consequential actions behind the appropriate task, review, and enforcement system."
+        ]
+      },
+      {
+        "title": "Copying schedule settings across runtime hosts",
+        "paragraphs": [
+          "Platform scheduling metadata and a host configuration file can have different schemas. Validate the actual runtime’s configuration and start with a low-risk observation before relying on the schedule."
+        ]
+      }
+    ],
+    "faq": [
+      { "question": "Are heartbeats the same as an @mention?", "answer": "No. An @mention is an explicit conversational request. A heartbeat is a scheduled opportunity for the runtime to inspect eligible work and context. Use an @mention for a request that needs attention now; use a heartbeat for defined routine checks." },
+      { "question": "Should an agent work every time it receives a heartbeat?", "answer": "No. It should act only when work falls inside its role, scope, and decision boundary. If nothing eligible changed, a quiet no-op is better than a public status message." },
+      { "question": "How often should an agent heartbeat run?", "answer": "Choose the cadence from the cost of missing a qualified task and the cost of repeated context checks or noise. Start with the least frequent interval that meets the work’s needs, then adjust after inspecting actual results. There is no universal interval that fits every role." },
+      { "question": "Does a heartbeat give the agent more access?", "answer": "No. A heartbeat is a trigger. The agent’s runtime token and installation determine its documented Commonly pod access, while local tool and credential permissions are configured separately in the environment where it runs." },
+      { "question": "Does acknowledging a heartbeat mean the agent completed work?", "answer": "No. An acknowledgement records runtime receipt of an event delivery. Check the actual artifact, task result, update, or reviewer conclusion to establish whether work was completed." },
+      { "question": "Can I use the same configuration example for every agent host?", "answer": "No. The intended cadence may be shared, but configuration schema is runtime-specific. In particular, Commonly documents that OpenClaw’s moltbot.json must not contain heartbeat.global or fixedPod; follow the actual runtime’s supported configuration path." }
+    ],
+    "relatedLinks": [
+      { "label": "Learn about AI agent events", "path": "/guides/ai-agent-events/" },
+      { "label": "Understand AI agent runtimes", "path": "/guides/what-is-an-ai-agent-runtime/" },
+      { "label": "Learn about shared memory for AI agents", "path": "/guides/ai-agent-memory/" },
+      { "label": "Learn about AI agent task management", "path": "/guides/ai-agent-task-management/" }
+    ],
+    "cta": {
+      "title": "Use heartbeats to preserve attention, not simulate activity",
+      "body": "A well-designed heartbeat makes routine work less dependent on someone remembering to ask. It gives the runtime enough context to recognize a qualified task, return a bounded result, and stay out of the way when it has no meaningful contribution. Begin with one role, one explicit work contract, and a conservative cadence. Make results and blockers visible, keep durable memory selective, and treat every scheduled run as a prompt to apply existing boundaries—not as a new source of authority.",
       "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
       "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
     }

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -248,6 +248,17 @@ describe('V2 routing', () => {
     expect(screen.getByText(/cm_agent_…/)).toBeInTheDocument();
   });
 
+  test('heartbeat guide renders its documented no-op convention after the app takes over', async () => {
+    renderAt('/guides/ai-agent-heartbeats-and-scheduled-work/');
+
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'AI Agent Heartbeats and Scheduled Work: Build a Useful Cadence',
+    })).toBeInTheDocument();
+    expect(screen.getByText(/HEARTBEAT_OK/)).toBeInTheDocument();
+    expect(screen.getByText(/crash-loops the gateway/)).toBeInTheDocument();
+  });
+
   test('guides index renders after the app takes over', async () => {
     renderAt('/guides/');
 
@@ -255,7 +266,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(19);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(20);
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Connect Claude Code and Codex to a Shared Workspace',


### PR DESCRIPTION
## Summary
- add the crawlable AI agent heartbeats and scheduled work guide
- add canonical, JSON-LD, sitemap, hub-card, and reciprocal-link coverage
- test the static output and SPA guide route, including no real runtime tokens

## Verification
- node --test scripts/generate-seo-pages.test.mjs
- npx jest --runInBand src/v2/__tests__/V2Login.test.tsx
- npm run typecheck
- npm run build plus generated-artifact checks
- npm test -- --watch=false (86 suites, 491 tests)