### PR TITLE
feat(seo): add AI agent marketplace roles guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -19,7 +19,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 30);
+  assert.equal(pages.length, 31);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -51,6 +51,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-discord-integration/',
     '/guides/what-is-an-ai-agent-runtime/',
     '/guides/ai-agent-heartbeats-and-scheduled-work/',
+    '/guides/ai-agent-marketplace-roles/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
@@ -86,7 +87,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
   ]);
-  assert.equal(guidePages.length, 20);
+  assert.equal(guidePages.length, 21);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
@@ -306,6 +307,17 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(heartbeatsHtml, /pending, claimed, blocked, and done/);
   assert.match(heartbeatsHtml, /crash-loops the gateway/);
   assert.doesNotMatch(heartbeatsHtml, /cm_agent_[A-Za-z0-9]{8,}/);
+  const marketplaceRolesGuide = guidePages.find((page) => page.path === '/guides/ai-agent-marketplace-roles/');
+  assert.equal(marketplaceRolesGuide.title, 'AI Agent Marketplace Roles: Build a Clear Team | Commonly');
+  const marketplaceRolesHtml = renderStaticPage(guideTemplate, marketplaceRolesGuide);
+  assert.match(marketplaceRolesHtml, /AI agent marketplace roles are reusable starting points/);
+  assert.match(marketplaceRolesHtml, /Commonly \(commonly\.me\), the shared workspace where humans and AI agents work together/);
+  assert.match(marketplaceRolesHtml, /Theo/);
+  assert.match(marketplaceRolesHtml, /X-Curator/);
+  assert.match(marketplaceRolesHtml, /coordinates tasks, reviews/);
+  assert.match(marketplaceRolesHtml, /pending, claimed, blocked, and done/);
+  assert.match(marketplaceRolesHtml, /AgentInstallation/);
+  assert.doesNotMatch(marketplaceRolesHtml, /cm_agent_[A-Za-z0-9]{8,}/);
   for (const guidePath of [
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',
@@ -421,6 +433,15 @@ test('emits a canonical crawlable page for every public route', async () => {
   ]) {
     const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
     assert.match(html, /href="\/guides\/ai-agent-heartbeats-and-scheduled-work\//);
+  }
+  for (const guidePath of [
+    '/guides/what-is-an-ai-agent-runtime/',
+    '/guides/onboarding-an-ai-agent-to-your-team/',
+    '/guides/how-to-build-an-ai-agent-team/',
+    '/guides/ai-agent-collaboration-patterns/',
+  ]) {
+    const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
+    assert.match(html, /href="\/guides\/ai-agent-marketplace-roles\//);
   }
   const guidesIndex = pages.find((page) => page.path === '/guides/');
   assert.equal(guidesIndex.title, 'Guides for teams working with AI agents | Commonly');

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -1571,7 +1571,8 @@
       { "label": "Learn about AI agent observability", "path": "/guides/ai-agent-observability/" },
       { "label": "Compare multi-agent and single-agent systems", "path": "/guides/multi-agent-vs-single-agent/" },
       { "label": "Learn about AI agent collaboration patterns", "path": "/guides/ai-agent-collaboration-patterns/" },
-      { "label": "Learn how to onboard an AI agent to your team", "path": "/guides/onboarding-an-ai-agent-to-your-team/" }
+      { "label": "Learn how to onboard an AI agent to your team", "path": "/guides/onboarding-an-ai-agent-to-your-team/" },
+      { "label": "Learn about AI agent marketplace roles", "path": "/guides/ai-agent-marketplace-roles/" }
     ],
     "cta": {
       "title": "Build for legible work, not autonomous theater",
@@ -3236,7 +3237,8 @@
       { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
       { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" },
       { "label": "Learn how to onboard an AI agent to your team", "path": "/guides/onboarding-an-ai-agent-to-your-team/" },
-      { "label": "Learn about AI agent Discord integration", "path": "/guides/ai-agent-discord-integration/" }
+      { "label": "Learn about AI agent Discord integration", "path": "/guides/ai-agent-discord-integration/" },
+      { "label": "Learn about AI agent marketplace roles", "path": "/guides/ai-agent-marketplace-roles/" }
     ],
     "cta": {
       "title": "Use patterns to clarify work, not simulate a swarm",
@@ -3510,7 +3512,8 @@
       { "label": "Learn about AI agent events", "path": "/guides/ai-agent-events/" },
       { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
       { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" },
-      { "label": "Learn about AI agent Discord integration", "path": "/guides/ai-agent-discord-integration/" }
+      { "label": "Learn about AI agent Discord integration", "path": "/guides/ai-agent-discord-integration/" },
+      { "label": "Learn about AI agent marketplace roles", "path": "/guides/ai-agent-marketplace-roles/" }
     ],
     "cta": {
       "title": "Onboard the work, not just the runtime",
@@ -3969,7 +3972,8 @@
       { "label": "Learn about AI agent permissions and tokens", "path": "/guides/ai-agent-permissions-and-tokens/" },
       { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
       { "label": "Learn about AI agent events", "path": "/guides/ai-agent-events/" },
-      { "label": "Learn about AI agent heartbeats", "path": "/guides/ai-agent-heartbeats-and-scheduled-work/" }
+      { "label": "Learn about AI agent heartbeats", "path": "/guides/ai-agent-heartbeats-and-scheduled-work/" },
+      { "label": "Learn about AI agent marketplace roles", "path": "/guides/ai-agent-marketplace-roles/" }
     ],
     "cta": {
       "title": "Design the runtime around accountable work",
@@ -4215,6 +4219,264 @@
     "cta": {
       "title": "Use heartbeats to preserve attention, not simulate activity",
       "body": "A well-designed heartbeat makes routine work less dependent on someone remembering to ask. It gives the runtime enough context to recognize a qualified task, return a bounded result, and stay out of the way when it has no meaningful contribution. Begin with one role, one explicit work contract, and a conservative cadence. Make results and blockers visible, keep durable memory selective, and treat every scheduled run as a prompt to apply existing boundaries—not as a new source of authority.",
+      "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
+      "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
+    }
+  },
+  "ai-agent-marketplace-roles": {
+    "eyebrow": "Guide",
+    "titleTag": "AI Agent Marketplace Roles: Build a Clear Team | Commonly",
+    "title": "AI Agent Marketplace Roles: Build a Team with Clear Boundaries",
+    "description": "Choose AI agent marketplace roles for engineering, operations, community, and content work—then give each installed agent a narrow scope, review path, and accountable handoff.",
+    "summary": "Turn marketplace role labels into narrow, reviewable work contracts instead of treating them as automatic authority.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-31",
+      "dateModified": "2026-08-31"
+    },
+    "intro": [
+      "AI agent marketplace roles are reusable starting points for responsibilities such as task coordination, backend engineering, frontend work, operations, community management, and content curation. A role is useful when it tells the team what result to expect, which work belongs to the agent, and where a person or reviewer takes the next decision—not when it makes an agent sound generally in charge.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, provides a marketplace for agents that can be installed into pods with an identity, memory, and heartbeat. The role card is only one layer of the setup. The installation’s pod membership scopes collaboration access, the runtime’s local environment governs its tools, and the team’s operating rules determine what must be reviewed before a consequential action.",
+      "This guide explains the documented marketplace roles, how to select a small useful team, and how to turn a role label into an accountable work contract. The goal is not to install an artificial AI department. It is to make a real team’s work more legible and easier to hand off."
+    ],
+    "sections": [
+      {
+        "title": "A role is a responsibility, not a permission set",
+        "paragraphs": [
+          "Start by separating four questions that are often collapsed into what an agent can do.",
+          "The first layer is what an AI agent marketplace entry is mainly for: it helps a team discover a useful responsibility and expected specialty. The other three layers must still be configured deliberately.",
+          "For example, Commonly’s marketplace describes Theo as a development project manager that coordinates tasks, reviews pull requests, and sources issues from GitHub. That describes a meaningful role in a workflow. It does not by itself give every Theo installation permission to merge a pull request, change repository settings, or make release decisions. Those powers live in the systems that enforce them.",
+          "The same rule holds for every role. Ops does not mean has production access. Community manager does not mean may make public promises. Content curator does not mean may publish externally. The role tells the team where to aim the agent’s contribution; the work contract and actual permission boundaries determine the safe path.",
+          "The four layers separate like this:"
+        ],
+        "tables": [{
+          "headers": ["Layer", "Question", "Example"],
+          "rows": [
+            ["Role", "What outcome should this agent help produce?", "A backend agent returns a tested, reviewable change for a stated service boundary."],
+            ["Installation scope", "Which pods may the agent collaborate in?", "The agent is installed only in the implementation pod, not a customer or leadership pod."],
+            ["Runtime tools", "What can the local process access?", "A coding runtime may have a repository checkout but no deployment credential."],
+            ["Decision authority", "Who can approve, merge, publish, or accept a result?", "A human maintainer or separately configured source-control policy accepts a release."]
+          ]
+        }]
+      },
+      {
+        "title": "The documented marketplace roles",
+        "paragraphs": [
+          "Commonly’s marketplace documentation lists six pre-built agents. Treat their specialties as starting points for a narrower local brief.",
+          "The first bounded use column is deliberately more specific than the marketplace description. It gives a newly installed agent a task that can be inspected before the team expands its responsibilities.",
+          "You do not need all six roles. A small product project may begin with one human lead and one specialist agent. A team can add a coordinator or reviewer only when a real coordination problem emerges. More installations do not automatically create more capacity; they can create duplicate research, unclear authority, and unnecessary status traffic.",
+          "The six documented agents:"
+        ],
+        "tables": [{
+          "headers": ["Marketplace agent", "Documented role", "Works best for", "First bounded use"],
+          "rows": [
+            ["Theo", "Development PM—coordinates tasks, reviews PRs, and sources issues from GitHub", "Engineering teams", "Turn an approved brief into a task breakdown with dependencies and named reviewers."],
+            ["Nova", "Backend engineer—writes tests, fixes bugs, and opens PRs", "Node.js / Express projects", "Investigate one service behavior and return a tested pull request or a precise blocker."],
+            ["Pixel", "Frontend engineer—builds UI and reviews CSS/React PRs", "React projects", "Implement one reviewed screen or component change within defined visual and accessibility constraints."],
+            ["Ops", "DevOps—works on CI/CD configuration, Kubernetes, and infrastructure monitoring", "Deployed projects", "Inspect a stated deployment or CI issue and attach a diagnosis for a named operator."],
+            ["Liz", "Community manager—monitors discussions and replies to threads", "Public communities", "Classify a small set of feedback into source-backed themes for human review."],
+            ["X-Curator", "Content curator—surfaces relevant content and shares it", "Developer communities", "Assemble a reviewable content brief from approved sources without publishing it."]
+          ]
+        }]
+      },
+      {
+        "title": "Choose a role from the bottleneck, not from the title",
+        "paragraphs": [
+          "This is not a claim that a role is limited to one kind of project forever. It is a way to prevent the first assignment from being “be our engineering team.” A clear bottleneck lets the team evaluate whether the agent’s scope, context, and review path are working.",
+          "Ask what is delaying the next trustworthy decision. The answer points to the smallest role that might help:"
+        ],
+        "tables": [{
+          "headers": ["Current bottleneck", "Start with", "What success looks like"],
+          "rows": [
+            ["Work requests are vague or dependencies are hidden", "A coordination role such as Theo, or a human lead using the same pattern", "Tasks have one outcome, owner, evidence requirement, dependency, and reviewer."],
+            ["A service issue needs code-level investigation", "A backend specialist such as Nova", "A source-backed diagnosis, tested change, or explicit blocker."],
+            ["A product surface needs a constrained UI change", "A frontend specialist such as Pixel", "A reviewable implementation that respects the agreed component and styling boundary."],
+            ["Deployment or environment work needs a careful diagnosis", "An operations role such as Ops", "An evidence packet and a scoped operational recommendation; not an unreviewed production change."],
+            ["A team needs to understand recurring discussion themes", "A community or content role such as Liz or X-Curator", "A visible summary with sources, category, and questions for a human owner."]
+          ]
+        }]
+      },
+      {
+        "title": "Turn a marketplace listing into a local work contract",
+        "paragraphs": [
+          "After installation, write a short role contract in the pod’s shared work record. The contract should be specific to the project, not copied wholesale from an agent card.",
+          "The contract makes two healthy things possible. The agent can act confidently inside a bounded lane, and it can stop honestly when the task leaves that lane. A request to change a production setting, for example, becomes an escalation rather than an opportunity to improvise.",
+          "Use the contract template, then adapt it — the template first, a worked backend example second:"
+        ],
+        "codeBlocks": [
+          {
+            "language": "text",
+            "code": "Role: What outcome this installed agent is responsible for advancing.\nInputs: The pod, tasks, source files, or evidence it may use.\nEligible work: Which task types or stated requests it may claim.\nNon-goals: What it must not decide, publish, merge, deploy, or access.\nEvidence: The artifact it returns—note, diff, test result, task update, or pull request.\nReview: Who inspects and accepts, rejects, or redirects the result.\nEscalation: The exact conditions that require a human or another named role."
+          },
+          {
+            "language": "text",
+            "code": "Role: Investigate and implement narrowly scoped fixes in the billing service.\nInputs: Tasks assigned in this pod, the service repository, approved architecture notes, and attached source material.\nEligible work: Reproduction, diagnosis, unit tests, and code changes that have an explicit acceptance criterion.\nNon-goals: No customer-data access, production configuration changes, dependency upgrades outside the task, or merges.\nEvidence: Pull request, stated checks, and a note on remaining risk or assumptions.\nReview: A named maintainer reviews the diff and controls the merge.\nEscalation: Missing product behavior, access requirement, security concern, or cross-service impact."
+          }
+        ]
+      },
+      {
+        "title": "Install for the smallest useful workspace scope",
+        "paragraphs": [
+          "Commonly documents agents as first-class participants with identity, runtime token, memory, a task queue, and a heartbeat. Installing one into a pod creates a collaboration relationship; it is not merely adding a name to a roster.",
+          "A runtime token is scoped to an agent installation and can access all pods where that agent has an AgentInstallation record. Its documented workspace actions include reading and writing pod memory, posting messages, working tasks, and polling events in those pods. It does not authorize user management, pod deletion, pods where the agent is not installed, or other agents’ admin and direct-message pods.",
+          "The token does not configure the local runtime’s repository access, shell, browser, cloud account, deployment credential, or model-provider key. Configure those separately. A role description should not hide the difference between can post a task update and can alter an external system.",
+          "For the installation and token boundary, see AI Agent Permissions and Tokens.",
+          "That means each installation decision deserves three checks:"
+        ],
+        "orderedItems": [
+          "Need: Does this role genuinely need the pod’s messages, tasks, or shared memory?",
+          "Sensitivity: Does the pod contain a different customer, security, personnel, or release boundary than the agent’s current work?",
+          "Removal: Who removes the installation or revokes or replaces its runtime token when the role ends or changes?"
+        ],
+        "links": [
+          { "label": "AI Agent Permissions and Tokens", "path": "/guides/ai-agent-permissions-and-tokens/" }
+        ]
+      },
+      {
+        "title": "Build a small role stack around explicit handoffs",
+        "paragraphs": [
+          "When more than one role is useful, connect them through artifacts and decisions rather than assumptions about private context.",
+          "For context that survives a cross-role handoff, see AI Agent Handoffs. For a deliberate review pause, see Human-in-the-Loop Review for AI Agent Teams."
+        ],
+        "links": [
+          { "label": "AI Agent Handoffs", "path": "/guides/ai-agent-handoffs/" },
+          { "label": "Human-in-the-Loop Review for AI Agent Teams", "path": "/guides/human-in-the-loop-ai-agents/" }
+        ]
+      },
+      {
+        "title": "Pattern: coordinator, then specialist, then reviewer",
+        "paragraphs": [
+          "Use this pattern when a team has a defined outcome but needs a visible sequence.",
+          "For example, Theo can coordinate the task breakdown, Nova can return a backend pull request, and a human maintainer can review and merge it. The listing’s reviews PRs capability makes it reasonable for Theo to help assess a change against a task brief, but it does not replace the person or system with actual merge authority.",
+          "The sequence:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "Coordinator: states the outcome, creates bounded tasks, and names dependencies.\nSpecialist: returns the requested evidence or implementation artifact.\nReviewer: compares the artifact with acceptance criteria and chooses the next action.\nHuman decision-maker: resolves tradeoffs, external commitments, access changes, and releases when required."
+        }]
+      },
+      {
+        "title": "Pattern: research, then implementation, then operations",
+        "paragraphs": [
+          "Use this when a team needs to understand a problem before changing a system.",
+          "This pattern keeps an early observation from turning directly into a production change. It also lets each specialist report the evidence that their next teammate needs instead of handing over a conclusion with no trail.",
+          "The sequence:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "Research/triage: identify the documented behavior, reproduction steps, and unknowns.\nImplementation: propose a scoped code or configuration change with checks.\nOperations: assess the deployment or runtime consequence against the approved plan.\nReviewer: accepts, redirects, or blocks the next step."
+        }]
+      },
+      {
+        "title": "Pattern: community signal, then decision packet, then owned response",
+        "paragraphs": [
+          "Use this for Liz or X-Curator when an external discussion matters to the project.",
+          "The community or content role can help a team see a pattern. It should not silently promise a feature, disclose information, or publish externally unless the team has separately provided that authority and review path.",
+          "The sequence:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "Community/content role: gathers source references, themes, and open questions.\nProduct or project owner: decides priority, message, and follow-up.\nSpecialist: works a scoped task only after the intended outcome is defined.\nReviewer: checks the artifact or draft before consequential publication or release."
+        }]
+      },
+      {
+        "title": "Use the task board as a coordination record, not a permission system",
+        "paragraphs": [
+          "Marketplace roles become useful only when the next work is visible. In Commonly, tasks can carry a title, description, status, assignee, updates, dependencies, and a completion result such as a pull-request URL. Their documented statuses are pending, claimed, blocked, and done.",
+          "A task claim makes current ownership visible. It does not lock a repository, create a security boundary, guarantee the result is correct, or grant merge, deploy, or publishing authority. Put enforcement in source control, access management, release tooling, and the external systems affected by the work.",
+          "For task fields and dependencies, see AI Agent Task Management.",
+          "Use those fields to answer practical questions:"
+        ],
+        "bullets": [
+          "What is the outcome this role is responsible for now?",
+          "Which sources, files, or acceptance criteria must the specialist use?",
+          "Is there a prerequisite task or a human decision that blocks it?",
+          "What result will make the next reviewer’s decision easy?",
+          "Which agent or person owns the next step after this task?"
+        ],
+        "links": [
+          { "label": "AI Agent Task Management", "path": "/guides/ai-agent-task-management/" }
+        ]
+      },
+      {
+        "title": "What the manifest does—and does not—tell an installer",
+        "paragraphs": [
+          "The current Commonly agent manifest format describes an agent’s marketplace identity and configuration: name, displayName, description, version, author, runtime, avatar, tags, config.heartbeat, heartbeatTemplate, requiredEnvVars, links.github, and links.docs. This is useful installation information, but it is not a security assessment or a complete operating manual.",
+          "The manifest specification is documented as a current working format under active development. The marketplace publishing documentation also labels its publishing flow as planned. Do not assume a self-service publishing step, a particular review automation, or a manifest field automatically enforces local policy unless the current product flow documents it.",
+          "Before installing a marketplace role—or any custom agent—review:"
+        ],
+        "tables": [{
+          "headers": ["Installer question", "Why it matters"],
+          "rows": [
+            ["What runtime will execute the agent?", "Runtime affects how it receives work and what host environment needs to be secured."],
+            ["What does the role actually return?", "A concrete artifact is easier to review than helps with operations."],
+            ["Which environment variables or credentials are required?", "Secrets need an approved storage and revocation path, not a task comment."],
+            ["What tools are expected?", "Workspace scope and local tool power are separate decisions."],
+            ["What is the heartbeat behavior?", "Cadence should match a narrow role and the actual host configuration schema."],
+            ["Where are source and usage docs?", "The team needs a way to inspect expectations before it installs or expands scope."]
+          ]
+        }]
+      },
+      {
+        "title": "Six role mistakes that lead to an agent-shaped org chart",
+        "paragraphs": [
+          "Each of these mistakes swaps a bounded contribution for an org-chart illusion."
+        ]
+      },
+      {
+        "title": "Installing every specialty before finding the bottleneck",
+        "paragraphs": [
+          "An oversized agent roster can hide the fact that no one owns the next decision. Start with the smallest role that removes a real constraint, then add another only when the handoff and review boundary are clear."
+        ]
+      },
+      {
+        "title": "Giving a role a title but no artifact",
+        "paragraphs": [
+          "Ops monitors infrastructure is not a task. Ask for a diagnosis, checklist, configuration diff, review note, or other result someone can inspect."
+        ]
+      },
+      {
+        "title": "Treating a coordinator as the final decision-maker",
+        "paragraphs": [
+          "Coordination can make choices visible and sequence work. It does not replace the person or policy that approves a customer commitment, security change, merge, deployment, or publication."
+        ]
+      },
+      {
+        "title": "Treating a specialist as a full project boundary",
+        "paragraphs": [
+          "A backend, frontend, or operations specialty is not a license to change every adjacent system. Give each task an explicit non-goal and escalation route."
+        ]
+      },
+      {
+        "title": "Sharing an installation across unrelated pods because the role is convenient",
+        "paragraphs": [
+          "Agent installation changes workspace access. Use a visible handoff or a separate scoped installation when one project’s context should not become another project’s runtime context."
+        ]
+      },
+      {
+        "title": "Reading a manifest as a guarantee",
+        "paragraphs": [
+          "A manifest helps describe an agent. It does not eliminate the need to review its runtime, credentials, local tool policy, role contract, and consequence path."
+        ]
+      }
+    ],
+    "faq": [
+      { "question": "Do I need to install the whole marketplace team?", "answer": "No. Start with the role that addresses the current bottleneck. Many teams can begin with one human lead and one clearly scoped agent, adding coordination or specialty roles only when an inspectable handoff justifies them." },
+      { "question": "Can Theo merge pull requests automatically?", "answer": "The documented Theo role includes coordinating tasks and reviewing pull requests. Whether an installation can merge depends on separately configured source-control permissions and team policy. A marketplace role label does not grant that authority." },
+      { "question": "Does installing a role give it access to every pod?", "answer": "No. Runtime access is scoped to pods where the agent has an installation record. Review each added membership because it expands the collaboration context that installation can access." },
+      { "question": "Is a marketplace agent the same as its runtime?", "answer": "No. The role and marketplace identity describe what the agent is for. The runtime is the process that receives triggers, context, and tools. The installation connects that runtime identity to the relevant pods." },
+      { "question": "Can I publish my own marketplace role now?", "answer": "Commonly documents the manifest format as active development and its publishing flow as planned. Follow the current documented product path rather than assuming a self-service submission or a particular automated review behavior is available." }
+    ],
+    "relatedLinks": [
+      { "label": "Understand AI agent runtimes", "path": "/guides/what-is-an-ai-agent-runtime/" },
+      { "label": "Learn about AI agent permissions and tokens", "path": "/guides/ai-agent-permissions-and-tokens/" },
+      { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
+      { "label": "Learn about AI agent task management", "path": "/guides/ai-agent-task-management/" }
+    ],
+    "cta": {
+      "title": "Build a team of accountable contributors",
+      "body": "Marketplace roles are most valuable when they make the next contribution easier to evaluate. A coordinator creates a clear work record. A specialist returns evidence or an implementation artifact. A reviewer or human decision-maker accepts, redirects, or blocks the consequence. Start with a small role stack, give each installation only the workspace scope it needs, and write down the artifact and escalation path before the first task. That gives the team the benefits of specialization without pretending that an agent label is a substitute for authority.",
       "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
       "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
     }

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -259,6 +259,16 @@ describe('V2 routing', () => {
     expect(screen.getByText(/crash-loops the gateway/)).toBeInTheDocument();
   });
 
+  test('marketplace roles guide renders its documented role boundary after the app takes over', async () => {
+    renderAt('/guides/ai-agent-marketplace-roles/');
+
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'AI Agent Marketplace Roles: Build a Team with Clear Boundaries',
+    })).toBeInTheDocument();
+    expect(screen.getByText(/Theo as a development project manager that coordinates tasks, reviews pull requests/)).toBeInTheDocument();
+  });
+
   test('guides index renders after the app takes over', async () => {
     renderAt('/guides/');
 
@@ -266,7 +276,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(20);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(21);
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Connect Claude Code and Codex to a Shared Workspace',


### PR DESCRIPTION
## Summary
- add the crawlable AI agent marketplace roles guide
- add canonical, JSON-LD, sitemap, hub-card, and reciprocal-link coverage
- cover role boundaries, workspace scope, handoffs, task records, and manifest limits without granting implied authority

## Verification
- node --test scripts/generate-seo-pages.test.mjs
- npx jest --runInBand src/v2/__tests__/V2Login.test.tsx
- npm run typecheck
- npm run build plus generated-artifact checks
- npm test -- --watch=false (86 suites, 492 tests)