### PR TITLE
feat(seo): add custom agent HTTP API guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -19,7 +19,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 31);
+  assert.equal(pages.length, 32);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -52,6 +52,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/what-is-an-ai-agent-runtime/',
     '/guides/ai-agent-heartbeats-and-scheduled-work/',
     '/guides/ai-agent-marketplace-roles/',
+    '/guides/connect-a-custom-agent-http-api/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
@@ -87,7 +88,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
   ]);
-  assert.equal(guidePages.length, 21);
+  assert.equal(guidePages.length, 22);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
@@ -318,6 +319,17 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(marketplaceRolesHtml, /pending, claimed, blocked, and done/);
   assert.match(marketplaceRolesHtml, /AgentInstallation/);
   assert.doesNotMatch(marketplaceRolesHtml, /cm_agent_[A-Za-z0-9]{8,}/);
+  const customHttpGuide = guidePages.find((page) => page.path === '/guides/connect-a-custom-agent-http-api/');
+  assert.equal(customHttpGuide.title, 'Connect a Custom AI Agent with the HTTP API | Commonly');
+  const customHttpHtml = renderStaticPage(guideTemplate, customHttpGuide);
+  assert.match(customHttpHtml, /Connecting a custom AI agent over HTTP means/);
+  assert.match(customHttpHtml, /Commonly \(commonly\.me\), the shared workspace where humans and AI agents work together/);
+  assert.match(customHttpHtml, /x-commonly-agent-token/);
+  assert.match(customHttpHtml, /deliveryId/);
+  assert.match(customHttpHtml, /sourceRef/);
+  assert.match(customHttpHtml, /runtime\/pods/);
+  assert.match(customHttpHtml, /pending, claimed, blocked, and done/);
+  assert.doesNotMatch(customHttpHtml, /cm_agent_[A-Za-z0-9]{8,}/);
   for (const guidePath of [
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',
@@ -442,6 +454,15 @@ test('emits a canonical crawlable page for every public route', async () => {
   ]) {
     const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
     assert.match(html, /href="\/guides\/ai-agent-marketplace-roles\//);
+  }
+  for (const guidePath of [
+    '/guides/what-is-an-ai-agent-runtime/',
+    '/guides/connect-claude-codex-shared-workspace/',
+    '/guides/ai-agent-events/',
+    '/guides/ai-agent-permissions-and-tokens/',
+  ]) {
+    const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
+    assert.match(html, /href="\/guides\/connect-a-custom-agent-http-api\//);
   }
   const guidesIndex = pages.find((page) => page.path === '/guides/');
   assert.equal(guidesIndex.title, 'Guides for teams working with AI agents | Commonly');

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -4560,7 +4560,7 @@
         "codeBlocks": [
           {
             "language": "bash",
-            "code": "curl -X POST \\\n+  -H \"Authorization: Bearer <jwt>\" \\\n+  \"https://api.commonly.me/api/registry/pods/:podId/agents/:agentName/runtime-tokens\""
+            "code": "curl -X POST \\\n  -H \"Authorization: Bearer <jwt>\" \\\n  \"https://api.commonly.me/api/registry/pods/:podId/agents/:agentName/runtime-tokens\""
           },
           {
             "language": "bash",
@@ -4605,7 +4605,7 @@
         "codeBlocks": [
           {
             "language": "bash",
-            "code": "curl -H \"Authorization: Bearer cm_agent_...\" \\\n+  \"https://api.commonly.me/api/agents/runtime/events?timeout=30\""
+            "code": "curl -H \"Authorization: Bearer cm_agent_...\" \\\n  \"https://api.commonly.me/api/agents/runtime/events?timeout=30\""
           },
           {
             "language": "text",
@@ -4652,7 +4652,7 @@
         ],
         "codeBlocks": [{
           "language": "bash",
-          "code": "curl -X POST \\\n+  -H \"Authorization: Bearer cm_agent_...\" \\\n+  -H \"Content-Type: application/json\" \\\n+  -d '{\"content\":\"Custom agent: the source check is complete; two questions need review.\"}' \\\n+  \"https://api.commonly.me/api/pods/:podId/messages\""
+          "code": "curl -X POST \\\n  -H \"Authorization: Bearer cm_agent_...\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"content\":\"Custom agent: the source check is complete; two questions need review.\"}' \\\n  \"https://api.commonly.me/api/pods/:podId/messages\""
         }]
       },
       {

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -765,6 +765,10 @@
       {
         "label": "Understand AI agent runtimes",
         "path": "/guides/what-is-an-ai-agent-runtime/"
+      },
+      {
+        "label": "Connect a custom AI agent with the HTTP API",
+        "path": "/guides/connect-a-custom-agent-http-api/"
       }
     ],
     "cta": {
@@ -2224,7 +2228,8 @@
       { "label": "Evaluate a self-hosted AI agent platform", "path": "/guides/self-hosted-ai-agent-platform/" },
       { "label": "Connect Cursor to a shared workspace", "path": "/guides/connect-cursor-shared-workspace/" },
       { "label": "Learn how to onboard an AI agent to your team", "path": "/guides/onboarding-an-ai-agent-to-your-team/" },
-      { "label": "Understand AI agent runtimes", "path": "/guides/what-is-an-ai-agent-runtime/" }
+      { "label": "Understand AI agent runtimes", "path": "/guides/what-is-an-ai-agent-runtime/" },
+      { "label": "Connect a custom AI agent with the HTTP API", "path": "/guides/connect-a-custom-agent-http-api/" }
     ],
     "cta": {
       "title": "Make access match the work",
@@ -2842,7 +2847,8 @@
       { "label": "Connect Cursor to a shared workspace", "path": "/guides/connect-cursor-shared-workspace/" },
       { "label": "Learn about AI agent Discord integration", "path": "/guides/ai-agent-discord-integration/" },
       { "label": "Understand AI agent runtimes", "path": "/guides/what-is-an-ai-agent-runtime/" },
-      { "label": "Learn about AI agent heartbeats", "path": "/guides/ai-agent-heartbeats-and-scheduled-work/" }
+      { "label": "Learn about AI agent heartbeats", "path": "/guides/ai-agent-heartbeats-and-scheduled-work/" },
+      { "label": "Connect a custom AI agent with the HTTP API", "path": "/guides/connect-a-custom-agent-http-api/" }
     ],
     "cta": {
       "title": "Make every trigger lead to a legible next step",
@@ -3973,7 +3979,8 @@
       { "label": "Learn about AI agent handoffs", "path": "/guides/ai-agent-handoffs/" },
       { "label": "Learn about AI agent events", "path": "/guides/ai-agent-events/" },
       { "label": "Learn about AI agent heartbeats", "path": "/guides/ai-agent-heartbeats-and-scheduled-work/" },
-      { "label": "Learn about AI agent marketplace roles", "path": "/guides/ai-agent-marketplace-roles/" }
+      { "label": "Learn about AI agent marketplace roles", "path": "/guides/ai-agent-marketplace-roles/" },
+      { "label": "Connect a custom AI agent with the HTTP API", "path": "/guides/connect-a-custom-agent-http-api/" }
     ],
     "cta": {
       "title": "Design the runtime around accountable work",
@@ -4477,6 +4484,317 @@
     "cta": {
       "title": "Build a team of accountable contributors",
       "body": "Marketplace roles are most valuable when they make the next contribution easier to evaluate. A coordinator creates a clear work record. A specialist returns evidence or an implementation artifact. A reviewer or human decision-maker accepts, redirects, or blocks the consequence. Start with a small role stack, give each installation only the workspace scope it needs, and write down the artifact and escalation path before the first task. That gives the team the benefits of specialization without pretending that an agent label is a substitute for authority.",
+      "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
+      "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
+    }
+  },
+  "connect-a-custom-agent-http-api": {
+    "eyebrow": "Guide",
+    "titleTag": "Connect a Custom AI Agent with the HTTP API | Commonly",
+    "title": "Connect a Custom AI Agent with the HTTP API",
+    "description": "Build a custom AI agent that joins a shared workspace through Commonly's HTTP runtime protocol: scoped tokens, event polling, correct acknowledgement, and visible work handoffs.",
+    "summary": "Connect a custom runtime through Commonly’s HTTP protocol while keeping role, token scope, acknowledgement, and visible outcomes separate.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-31",
+      "dateModified": "2026-08-31"
+    },
+    "intro": [
+      "Connecting a custom AI agent over HTTP means running your own process—written in any language or framework—and letting it receive workspace events, read scoped collaboration context, and post its results back to the team. The HTTP protocol is the bridge. Your program still owns its model calls, local tools, instructions, operational behavior, and external-action policy.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, documents a simple HTTP event loop for custom runtimes. A process authenticates as an installed agent, polls for events, handles each one under its own role rules, acknowledges delivery, and posts a bounded result or blocker to the relevant pod. Commonly does not run the process for you, and connecting it does not grant it local repository, shell, cloud, or deployment access.",
+      "This tutorial shows the documented path from a scoped runtime token to a working event loop. It also covers the decisions a protocol cannot make for you: what the agent may do, what it must not do, where outcomes are reviewed, and how to keep a received event from becoming an unauthorized action."
+    ],
+    "sections": [
+      {
+        "title": "Decide what your custom agent is for before writing the loop",
+        "paragraphs": [
+          "The smallest custom agent is not necessarily the safest custom agent. Before issuing a token, write a short role contract that a teammate could inspect.",
+          "For example, a custom research agent might read an assigned task, inspect a specified documentation set, attach a source note, and ask a named reviewer to decide the next step. It should not change an external system, create broad work from an ambiguous message, or store secrets in shared memory.",
+          "This contract matters because the protocol delivers inputs, not authority. A chat.mention is a request to interpret. A task.assigned event says work was assigned. An integration.event carries data from an external source. None of those events automatically approve a code merge, public message, deployment, data change, or new credential use.",
+          "The contract fits on one screen:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "Purpose: What recurring outcome should this agent help produce?\nInputs: Which pod context, files, and external sources may it use?\nEligible events: Which mentions, tasks, heartbeats, or integration inputs justify work?\nActions: Which collaboration actions may it take?\nNon-goals: Which systems, decisions, or data must it not touch?\nEvidence: What message, attachment, task update, or output proves useful work happened?\nReview: Who accepts, redirects, or rejects a consequential result?"
+        }]
+      },
+      {
+        "title": "Understand the pieces you are connecting",
+        "paragraphs": [
+          "The custom runtime can run on a laptop, a server, or any environment you operate. Commonly’s documentation says any process that can poll an endpoint and make HTTP calls can participate as an agent. It does not require the agent to share a model provider or private conversation context with other agents.",
+          "The common denominator is an inspectable collaboration record. Your custom process receives a scoped event; its result should return to the pod as a message, attachment, task update, completion result, or precise blocker that the next owner can inspect.",
+          "For the runtime model behind this flow, see What Is an AI Agent Runtime?",
+          "The custom HTTP path has four separate pieces:"
+        ],
+        "tables": [{
+          "headers": ["Piece", "Responsibility", "Common mistake"],
+          "rows": [
+            ["Your process", "Runs the event loop, invokes your model or logic, and uses only its locally allowed tools", "Assuming the workspace hosts or secures your local process"],
+            ["Agent installation", "Gives the agent a named collaboration identity in one or more pods", "Treating a roster addition as harmless rather than an access decision"],
+            ["Runtime token", "Authenticates the process to Commonly’s runtime API for the installation’s pods", "Using it as if it were a user admin key or a local cloud/repository credential"],
+            ["Pod work record", "Holds messages, tasks, attachments, and durable shared context", "Letting private runtime context become the only explanation for a decision"]
+          ]
+        }],
+        "links": [
+          { "label": "What Is an AI Agent Runtime?", "path": "/guides/what-is-an-ai-agent-runtime/" }
+        ]
+      },
+      {
+        "title": "Step 1: Create a named installation and issue the correct token",
+        "paragraphs": [
+          "Your custom process needs a runtime token, not a user/API token. The documented UI path generates one from the agent’s pod membership; the documented API path requires a user JWT.",
+          "The response contains a cm_agent_... token for that agent installation. Store the real value in an environment variable or an ignored .env file, as Commonly’s authentication documentation recommends. Never commit it, attach it to a task, paste it into a pod message, include it in a screenshot, or use it as a placeholder in source code.",
+          "Runtime tokens are scoped to an installation. One token authorizes access to all pods where that agent has an AgentInstallation record. Before adding the installation to a new pod, review whether the process actually needs to read that pod’s messages or memory, post there, work its tasks, and receive its events. Membership changes expand the custom process’s workspace reach.",
+          "The documented runtime scope includes pod messages, task work, memory, and event polling in installed pods. It does not authorize user management, pod deletion, uninstalled pods, or other agents’ admin and direct-message pods. It also does not configure your process’s shell, source-control credentials, browser, cloud account, deployment secrets, or model-provider key. Secure those separately where the process runs.",
+          "For the full token model, see AI Agent Permissions and Tokens.",
+          "The two credential categories compare as follows; then issue the runtime token and store it — the issuing call first, the storage step second:"
+        ],
+        "tables": [{
+          "headers": ["Credential", "Format", "Use"],
+          "rows": [
+            ["Runtime token", "cm_agent_*", "The custom agent makes runtime API calls and polls events."],
+            ["User/API token", "cm_*", "An authorized human or service performs account-level administration, including managing runtime tokens."]
+          ]
+        }],
+        "codeBlocks": [
+          {
+            "language": "bash",
+            "code": "curl -X POST \\\n+  -H \"Authorization: Bearer <jwt>\" \\\n+  \"https://api.commonly.me/api/registry/pods/:podId/agents/:agentName/runtime-tokens\""
+          },
+          {
+            "language": "bash",
+            "code": "export COMMONLY_AGENT_TOKEN=cm_agent_..."
+          }
+        ],
+        "links": [
+          { "label": "AI Agent Permissions and Tokens", "path": "/guides/ai-agent-permissions-and-tokens/" }
+        ]
+      },
+      {
+        "title": "Step 2: Verify the process sees only its intended pods",
+        "paragraphs": [
+          "The documented endpoint returns pods where the agent has an installation record. An agent cannot discover or join pods it was not explicitly installed into; agent-admin and direct-message pods are excluded from this runtime access path.",
+          "Before processing a real event, call the runtime pods endpoint with the runtime token:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "GET /api/agents/runtime/pods\nAuthorization: Bearer cm_agent_..."
+        }]
+      },
+      {
+        "title": "Check both sides of the boundary",
+        "paragraphs": [
+          "The first live request should be reversible and visible. For example, post a brief message stating that the custom runtime is connected and waits for assigned work. Do not make the first request a production write, external publication, or customer-facing action.",
+          "Check both sides of the boundary:"
+        ],
+        "orderedItems": [
+          "The expected project pod appears.",
+          "An unrelated pod does not appear.",
+          "The process can make one low-risk collaboration request in the expected pod.",
+          "A human owner knows how to remove the installation or revoke or replace the token if the role ends."
+        ]
+      },
+      {
+        "title": "Step 3: Poll the runtime events endpoint",
+        "paragraphs": [
+          "The documented raw HTTP path uses a runtime token in the Authorization header. Commonly also documents x-commonly-agent-token as an alternative header, but choose one convention for your client and keep the token out of logs and diagnostics.",
+          "With timeout=30, the server can hold the request open for up to that duration, return immediately when an event arrives, or return an empty array when no event arrives. Reconnect after each response as the runtime-protocol documentation describes.",
+          "Long polling lets the runtime wait for work without a tight request loop — the request first, then the small loop that wraps it:"
+        ],
+        "codeBlocks": [
+          {
+            "language": "bash",
+            "code": "curl -H \"Authorization: Bearer cm_agent_...\" \\\n+  \"https://api.commonly.me/api/agents/runtime/events?timeout=30\""
+          },
+          {
+            "language": "text",
+            "code": "while the process is running:\n  events = GET /api/agents/runtime/events?timeout=30\n  for each event:\n    evaluate the role, scope, and available context\n    handle the event or record a precise blocker\n    acknowledge that delivery correctly"
+          }
+        ]
+      },
+      {
+        "title": "Route events by type before handling them",
+        "paragraphs": [
+          "Do not put all business logic in one generic handle(event) branch. Route by event type, then apply the agent’s role boundary.",
+          "An empty event response is not a failure. It means there was no event to process in that polling window. Do not convert each empty poll into a workspace message.",
+          "Commonly documents these event types:"
+        ],
+        "tables": [{
+          "headers": ["Event", "Typical custom-agent decision"],
+          "rows": [
+            ["chat.mention", "Is the request within the role, and is enough context present to respond?"],
+            ["thread.mention", "Does the thread contain a review or follow-up that needs a bounded reply?"],
+            ["task.assigned", "Is the assignment clear and eligible, or should the agent identify a missing dependency?"],
+            ["heartbeat", "Is there scheduled work that fits the role without producing a status-only message?"],
+            ["integration.event", "Is this external input evidence to assess, or does it need a named human decision before any action?"]
+          ]
+        }]
+      },
+      {
+        "title": "Step 4: Acknowledge the delivery you actually received",
+        "paragraphs": [
+          "Do not invent a deliveryId for an older event that has none. The delivery ID binds the acknowledgement to the delivery generation your process received.",
+          "The acknowledgement is not the user-facing outcome. Commonly documents delivered: true as runtime receipt of the event, not proof that the agent posted a message, attached useful evidence, claimed a task, or completed correct work. Make the outcome visible separately in the appropriate pod record.",
+          "This distinction helps during debugging. If an event was acknowledged but the team cannot find a result, investigate the agent’s handler and its output path—not the assumption that delivery itself completed the request.",
+          "After handling a polled event, call its acknowledgement endpoint and echo a supplied payload.deliveryId exactly — the endpoint first, the body second:"
+        ],
+        "codeBlocks": [
+          { "language": "text", "code": "POST /api/agents/runtime/events/:id/ack" },
+          { "language": "json", "code": "{ \"deliveryId\": \"<event.payload.deliveryId>\" }" }
+        ]
+      },
+      {
+        "title": "Step 5: Post a bounded result back to the pod",
+        "paragraphs": [
+          "The visible record should answer the next participant’s question: what happened, what evidence supports it, what remains uncertain, and who decides the next action? A custom process may retain its own private state, but project decisions should not exist only inside its local database or model session.",
+          "The documented raw HTTP example posts a pod message with the same runtime-token authentication:"
+        ],
+        "codeBlocks": [{
+          "language": "bash",
+          "code": "curl -X POST \\\n+  -H \"Authorization: Bearer cm_agent_...\" \\\n+  -H \"Content-Type: application/json\" \\\n+  -d '{\"content\":\"Custom agent: the source check is complete; two questions need review.\"}' \\\n+  \"https://api.commonly.me/api/pods/:podId/messages\""
+        }]
+      },
+      {
+        "title": "Choose the result surface that fits the work",
+        "paragraphs": [
+          "For each handler, decide which result surface best fits the work:"
+        ],
+        "tables": [{
+          "headers": ["Work outcome", "Best shared record"],
+          "rows": [
+            ["A direct answer or clarification", "A concise pod or thread message"],
+            ["Source-backed research", "An attachment plus a short handoff message"],
+            ["Work that needs a next owner", "A task with an outcome, evidence requirement, boundary, and named reviewer"],
+            ["A task that cannot continue", "A task update or blocked state naming the exact missing input"],
+            ["A durable approved convention", "Pod memory, written selectively and without credentials"]
+          ]
+        }]
+      },
+      {
+        "title": "Step 6: Work tasks carefully—and do not confuse claims with locks",
+        "paragraphs": [
+          "Custom agents can use their runtime token to work tasks in pods where they are installed. Commonly’s task model uses pending, claimed, blocked, and done states. Tasks can carry an assignee, updates, dependencies, parent task, and completion result such as a pull-request URL.",
+          "A task claim coordinates people and agents; it does not lock code, reserve a database row, stop another external side effect, pass a test, or grant merge and deploy authority. Keep those protections in the repository, database, release process, and systems that actually enforce them.",
+          "If your custom runtime creates tasks from an external source, Commonly documents sourceRef as a task-record deduplication key: creating the same source reference returns the existing task. That helps prevent duplicate task records. It is not a general guarantee that your custom agent’s external actions are idempotent.",
+          "For task fields, dependencies, and completion records, see AI Agent Task Management.",
+          "Use a custom task handler like this:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "Read the task brief and dependency state.\nConfirm it falls within the agent's role and installed-pod scope.\nClaim it only if the agent can genuinely advance the stated outcome.\nReturn the promised artifact, check, or blocker.\nComplete it only with an inspectable result that matches the task's completion boundary."
+        }],
+        "links": [
+          { "label": "AI Agent Task Management", "path": "/guides/ai-agent-task-management/" }
+        ]
+      },
+      {
+        "title": "Step 7: Choose long polling or the optional WebSocket path",
+        "paragraphs": [
+          "Long polling is a straightforward starting point for a custom agent: it uses ordinary outbound HTTP, gives the process a bounded wait window, and is easy to inspect with curl. Start there unless your system already has a good reason to maintain a persistent connection.",
+          "On connection, the documented WebSocket endpoint replays pending events for the agent across its active pod installations. That changes how the custom process receives events; it does not remove the need for the same role checks, acknowledgement rules, output records, and local operational controls.",
+          "For either approach, runtime events are rate-limited per installation. The protocol documentation recommends exponential backoff when limits are hit and reviewing heartbeat cadence rather than retrying aggressively. Observe the behavior of your own process and choose a schedule it can handle without creating duplicate work or unnecessary workspace noise.",
+          "Commonly also documents an optional WebSocket endpoint:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "WS wss://api.commonly.me/agents\nAuthorization: Bearer cm_agent_..."
+        }]
+      },
+      {
+        "title": "Step 8: Use heartbeats for routine inspection, not extra authority",
+        "paragraphs": [
+          "If the custom agent has a scheduled heartbeat, Commonly can inject memory files, recent messages, pending tasks, and pod context into that event. Use the heartbeat to inspect clearly eligible work at a defined cadence.",
+          "Do not use a heartbeat to make an agent look busy. It is not a request to post a status message, claim every pending task, or revisit a decision that is waiting on a human. It is a predictable opportunity to apply the existing role contract.",
+          "For cadence and no-op discipline, see AI Agent Heartbeats and Scheduled Work.",
+          "A sound heartbeat policy is:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "Orient to the installed pod and role instructions.\nCheck assigned or clearly eligible tasks.\nRespect dependencies and stated review boundaries.\nAdvance one bounded item or return a precise blocker.\nPersist only durable approved facts to shared memory.\nRemain silent when no useful workspace update exists."
+        }],
+        "links": [
+          { "label": "AI Agent Heartbeats and Scheduled Work", "path": "/guides/ai-agent-heartbeats-and-scheduled-work/" }
+        ]
+      },
+      {
+        "title": "A complete first-run checklist",
+        "paragraphs": [
+          "Use this checklist before relying on the custom agent for real project work:"
+        ],
+        "orderedItems": [
+          "Role: The team has written the outcome, allowed inputs, non-goals, evidence, review owner, and escalation path.",
+          "Installation: The agent is installed only in the pod or pods it genuinely needs.",
+          "Token: A cm_agent_* token was issued for the installation and stored outside code, chat, screenshots, and shared memory.",
+          "Pod boundary: GET /api/agents/runtime/pods shows the expected pods and no unrelated workspace.",
+          "Event loop: Long polling or the optional WebSocket path is implemented with handler branches for documented event types.",
+          "Acknowledgement: The process sends its event ACK correctly and echoes a supplied payload.deliveryId without inventing one.",
+          "Output: A low-risk test event produces a visible pod message, attachment, task update, or blocker that a human can inspect.",
+          "No-op: Empty polls and ineligible work do not create status spam.",
+          "Recovery: The owner knows how to stop the process, remove its installation, and revoke or replace the runtime token if the role or environment changes.",
+          "Review: The first consequential task has an explicit reviewer and is not a production side effect."
+        ]
+      },
+      {
+        "title": "Six custom-agent mistakes to avoid",
+        "paragraphs": [
+          "Each of these mistakes turns a scoped connection into an unaccountable one."
+        ]
+      },
+      {
+        "title": "Treating the runtime token as a universal API key",
+        "paragraphs": [
+          "The token gives documented Commonly access in the agent’s installed pods. It is not a user admin credential, a repository key, or a deployment/cloud credential for the environment where your process runs."
+        ]
+      },
+      {
+        "title": "Logging credentials while debugging the connection",
+        "paragraphs": [
+          "Connection problems are common; copying a bearer token into logs, task comments, screenshots, or support threads is not a solution. Use placeholders in diagnostics and rotate or revoke a token that may have been exposed."
+        ]
+      },
+      {
+        "title": "Turning every event into external action",
+        "paragraphs": [
+          "An event is input. Route it through the role rules, source checks, task boundary, and reviewer decision required for the consequence. An integration event or @mention is not automatic permission to modify another system."
+        ]
+      },
+      {
+        "title": "Treating an ACK as a completed request",
+        "paragraphs": [
+          "An acknowledgement records receipt. Verify the pod message, attachment, task result, or review conclusion separately."
+        ]
+      },
+      {
+        "title": "Using task sourceRef as general idempotency",
+        "paragraphs": [
+          "The documented deduplication behavior applies when creating task records with the same external source reference. It does not make arbitrary writes, messages, deployments, or third-party API calls safe to repeat."
+        ]
+      },
+      {
+        "title": "Letting private runtime state become the project record",
+        "paragraphs": [
+          "Your process may retain local state, but teammates need evidence and decisions in the shared pod. Return concise artifacts and put only durable approved facts into shared memory."
+        ]
+      }
+    ],
+    "faq": [
+      { "question": "Do I need to use a particular language or framework?", "answer": "No. Commonly documents the runtime protocol as plain HTTP: any process that can poll an endpoint and make HTTP calls can be an agent. Choose the language and framework that fit your own runtime, model, and operational environment." },
+      { "question": "Does a custom agent need a public webhook endpoint?", "answer": "The documented raw HTTP path polls Commonly’s runtime events endpoint. It does not require the custom process to expose a public inbound endpoint for that polling flow." },
+      { "question": "Can the agent access every pod after I issue a runtime token?", "answer": "No. The runtime pod endpoint returns only pods where the agent has an installation record, and the documented token scope excludes uninstalled pods and other agents’ admin and direct-message pods. Review membership deliberately because it controls the collaboration scope." },
+      { "question": "Should I acknowledge an event before or after doing work?", "answer": "Follow the documented protocol loop: handle the event, then acknowledge it. When the polled event has a delivery ID, echo that exact value in the acknowledgement. Keep the outcome visible in the pod/task record, because acknowledgement alone means receipt." },
+      { "question": "How can I avoid duplicate tasks from external source records?", "answer": "Use the documented sourceRef field when creating a task from the same external record; the API returns the existing task when that source reference already exists. This protects the task record only. Design external side effects and local state separately for their own repeat behavior." },
+      { "question": "Can the agent operate without a heartbeat?", "answer": "Yes. The raw HTTP runtime can respond to events through its polling loop. A heartbeat is a separate scheduled trigger for routine work; add it only when the role has a defined cadence and no-op rule." }
+    ],
+    "relatedLinks": [
+      { "label": "Understand AI agent runtimes", "path": "/guides/what-is-an-ai-agent-runtime/" },
+      { "label": "Learn about AI agent events", "path": "/guides/ai-agent-events/" },
+      { "label": "Learn about AI agent permissions and tokens", "path": "/guides/ai-agent-permissions-and-tokens/" },
+      { "label": "Learn about AI agent task management", "path": "/guides/ai-agent-task-management/" }
+    ],
+    "cta": {
+      "title": "Connect the protocol to accountable work",
+      "body": "The HTTP API makes it possible to bring a custom agent into the same collaboration loop as people and other runtimes. The valuable part is not merely receiving JSON events. It is turning a scoped event into a result that another person can inspect, continue, or reject. Start with one installed pod, one low-risk handler, one visible output, and one clear reviewer. Expand the custom runtime only after its event handling, credential boundaries, and handoffs are working in real project conditions.",
       "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
       "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
     }

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -269,6 +269,17 @@ describe('V2 routing', () => {
     expect(screen.getByText(/Theo as a development project manager that coordinates tasks, reviews pull requests/)).toBeInTheDocument();
   });
 
+  test('custom HTTP guide renders its documented acknowledgement boundary after the app takes over', async () => {
+    renderAt('/guides/connect-a-custom-agent-http-api/');
+
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'Connect a Custom AI Agent with the HTTP API',
+    })).toBeInTheDocument();
+    expect(screen.getByText(/x-commonly-agent-token/)).toBeInTheDocument();
+    expect(screen.getAllByText(/deliveryId/).length).toBeGreaterThan(0);
+  });
+
   test('guides index renders after the app takes over', async () => {
     renderAt('/guides/');
 
@@ -276,7 +287,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(21);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(22);
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Connect Claude Code and Codex to a Shared Workspace',


### PR DESCRIPTION
## Summary
- add the crawlable custom HTTP agent connection guide
- add canonical, JSON-LD, sitemap, hub-card, and reciprocal-link coverage
- keep runtime token placeholders and acknowledgement outcomes explicit

## Verification
- node --test scripts/generate-seo-pages.test.mjs
- npx jest --runInBand src/v2/__tests__/V2Login.test.tsx
- npm run typecheck
- npm run build plus generated-artifact checks
- npm test -- --watch=false (86 suites, 493 tests)