### PR TITLE
fix(byo): Wren's critique of #1368 — zh comma bug + three deltas

### DIFF
--- a/frontend/design-system/tokens.css
+++ b/frontend/design-system/tokens.css
@@ -39,6 +39,7 @@
 
   /* ---------- Semantic ---------- */
   --c-success:         #10b981;
+  --c-success-text: #0f7a53; /* text-on-soft success — mirrors --v2-success-text */
   --c-success-soft:    #e3f6ec;
   --c-success-ring:    rgba(16, 185, 129, 0.40); /* live-activity pulse */
   --c-success-ring-strong: rgba(16, 185, 129, 0.50);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1360,8 +1360,7 @@
       "meter": "Beta limits: {{turns}} turns a day, one hosted agent per account.",
       "statTurns": "turns / day",
       "statAgents": "hosted agent",
-      "statLatency": "typical reply",
-      "statLatencyValue": "~10s"
+      "latencyHint": "Replies typically land in about ten seconds."
     },
     "preview": {
       "title": "Your agent",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1354,8 +1354,7 @@
       "meter": "测试期限制：每天 {{turns}} 轮，每个账号一个托管智能体。",
       "statTurns": "轮 / 天",
       "statAgents": "托管智能体",
-      "statLatency": "典型响应",
-      "statLatencyValue": "约 10 秒"
+      "latencyHint": "回复通常约十秒内送达。"
     },
     "preview": {
       "title": "你的智能体",

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -558,11 +558,8 @@ const V2AgentBYO: React.FC = () => {
               <span className="v2-byo__stat-value">{hosting?.caps.agentsPerUser ?? 1}</span>
               <span className="v2-byo__stat-label">{t('agentByo.hosted.statAgents')}</span>
             </div>
-            <div className="v2-byo__stat">
-              <span className="v2-byo__stat-value">{t('agentByo.hosted.statLatencyValue')}</span>
-              <span className="v2-byo__stat-label">{t('agentByo.hosted.statLatency')}</span>
-            </div>
           </div>
+          <p className="v2-byo__hint">{t('agentByo.hosted.latencyHint')}</p>
           <div className="v2-byo__cta-row">
             <button
               type="button"

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -64,6 +64,10 @@ body.modern-ui.v2-canvas {
   --v2-platform-groupme-soft: #e3f5fd;
 
   --v2-success: #10b981;
+  /* Text-on-soft success — one canonical value (Wren on #1368: a second
+     ad-hoc success-text hex is how a third one happens). Mirrors
+     --c-success-text in design-system/tokens.css. */
+  --v2-success-text: #0f7a53;
   --v2-success-soft: #e3f6ec;
   --v2-success-ring: rgba(16, 185, 129, 0.40);
   --v2-success-ring-strong: rgba(16, 185, 129, 0.50);
@@ -6261,7 +6265,7 @@ body.modern-ui.v2-canvas {
 }
 .v2-byo__preview-status--starting .v2-byo__preview-dot { background: var(--v2-warning); }
 .v2-byo__preview-status--live {
-  color: #0f7a53;
+  color: var(--v2-success-text);
   background: var(--v2-success-soft);
 }
 .v2-byo__preview-status--live .v2-byo__preview-dot { background: var(--v2-success); }
@@ -6298,7 +6302,7 @@ body.modern-ui.v2-canvas {
 }
 .v2-byo__stat-value {
   font-size: 18px;
-  font-weight: 750;
+  font-weight: 700;
   letter-spacing: -0.02em;
   color: var(--v2-text-primary);
   font-variant-numeric: tabular-nums;
@@ -8320,7 +8324,7 @@ body.modern-ui.v2-canvas {
 .v2-root:lang(zh) .v2-activity__title,
 .v2-root:lang(zh) .v2-activity__section h2,
 .v2-root:lang(zh) .v2-activity__agent-card h3,
-.v2-root:lang(zh) .v2-activity__board-row h3
+.v2-root:lang(zh) .v2-activity__board-row h3,
 .v2-root:lang(zh) .v2-byo__mode-title,
 .v2-root:lang(zh) .v2-byo__preview-name,
 .v2-root:lang(zh) .v2-byo__stat-value,


### PR DESCRIPTION
Implements Wren's critique (squad pod, 22:04): the missing comma that silently dropped two selectors from the :lang(zh) tracking reset, the off-scale 750 weight, `--v2-success-text`/`--c-success-text` replacing the ad-hoc hex (both token files, same PR), and the static '~10s' moved out of the honest stat row into a hint sentence. Deferred as agreed: the <940px compact preview strip, and making the preview literally the §1.3 card component once Your Team's is extracted.

492/492, tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJ1bDdDQwWekHDqweiBhRN