### PR TITLE
feat(seo): add agent pod guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -19,7 +19,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 32);
+  assert.equal(pages.length, 33);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -53,6 +53,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-heartbeats-and-scheduled-work/',
     '/guides/ai-agent-marketplace-roles/',
     '/guides/connect-a-custom-agent-http-api/',
+    '/guides/what-is-an-agent-pod/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
@@ -88,7 +89,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
   ]);
-  assert.equal(guidePages.length, 22);
+  assert.equal(guidePages.length, 23);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
@@ -330,6 +331,17 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(customHttpHtml, /runtime\/pods/);
   assert.match(customHttpHtml, /pending, claimed, blocked, and done/);
   assert.doesNotMatch(customHttpHtml, /cm_agent_[A-Za-z0-9]{8,}/);
+  const agentPodGuide = guidePages.find((page) => page.path === '/guides/what-is-an-agent-pod/');
+  assert.equal(agentPodGuide.title, 'What Is an Agent Pod? Shared Workspace for AI Teams | Commonly');
+  const agentPodHtml = renderStaticPage(guideTemplate, agentPodGuide);
+  assert.match(agentPodHtml, /An agent pod is a shared workspace/);
+  assert.match(agentPodHtml, /Commonly \(commonly\.me\), the shared workspace where humans and AI agents work together/);
+  assert.match(agentPodHtml, /agent-admin/);
+  assert.match(agentPodHtml, /invite-only/);
+  assert.match(agentPodHtml, /pending, claimed, blocked, and done/);
+  assert.match(agentPodHtml, /AgentInstallation/);
+  assert.match(agentPodHtml, /capped at 10 versions/);
+  assert.doesNotMatch(agentPodHtml, /cm_agent_[A-Za-z0-9]{8,}/);
   for (const guidePath of [
     '/guides/multi-agent-collaboration-platform/',
     '/guides/ai-agent-workspace/',
@@ -463,6 +475,15 @@ test('emits a canonical crawlable page for every public route', async () => {
   ]) {
     const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
     assert.match(html, /href="\/guides\/connect-a-custom-agent-http-api\//);
+  }
+  for (const guidePath of [
+    '/guides/ai-agent-workspace/',
+    '/guides/what-is-an-ai-agent-runtime/',
+    '/guides/ai-agent-memory/',
+    '/guides/ai-agent-collaboration-patterns/',
+  ]) {
+    const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
+    assert.match(html, /href="\/guides\/what-is-an-agent-pod\//);
   }
   const guidesIndex = pages.find((page) => page.path === '/guides/');
   assert.equal(guidesIndex.title, 'Guides for teams working with AI agents | Commonly');

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -329,6 +329,10 @@
         "path": "/guides/connect-cursor-shared-workspace/"
       },
       {
+        "label": "Learn what an agent pod is",
+        "path": "/guides/what-is-an-agent-pod/"
+      },
+      {
         "label": "Explore agent collaboration",
         "path": "/use-cases/agent-collab/"
       },
@@ -943,7 +947,8 @@
       { "label": "Learn about agent-to-agent messaging", "path": "/guides/agent-to-agent-messaging/" },
       { "label": "Evaluate a self-hosted AI agent platform", "path": "/guides/self-hosted-ai-agent-platform/" },
       { "label": "Learn about AI agent observability", "path": "/guides/ai-agent-observability/" },
-      { "label": "Learn about AI agent heartbeats", "path": "/guides/ai-agent-heartbeats-and-scheduled-work/" }
+      { "label": "Learn about AI agent heartbeats", "path": "/guides/ai-agent-heartbeats-and-scheduled-work/" },
+      { "label": "Learn what an agent pod is", "path": "/guides/what-is-an-agent-pod/" }
     ],
     "cta": {
       "title": "Make the next session start ahead",
@@ -3244,7 +3249,8 @@
       { "label": "Learn about human-in-the-loop review", "path": "/guides/human-in-the-loop-ai-agents/" },
       { "label": "Learn how to onboard an AI agent to your team", "path": "/guides/onboarding-an-ai-agent-to-your-team/" },
       { "label": "Learn about AI agent Discord integration", "path": "/guides/ai-agent-discord-integration/" },
-      { "label": "Learn about AI agent marketplace roles", "path": "/guides/ai-agent-marketplace-roles/" }
+      { "label": "Learn about AI agent marketplace roles", "path": "/guides/ai-agent-marketplace-roles/" },
+      { "label": "Learn what an agent pod is", "path": "/guides/what-is-an-agent-pod/" }
     ],
     "cta": {
       "title": "Use patterns to clarify work, not simulate a swarm",
@@ -3980,7 +3986,8 @@
       { "label": "Learn about AI agent events", "path": "/guides/ai-agent-events/" },
       { "label": "Learn about AI agent heartbeats", "path": "/guides/ai-agent-heartbeats-and-scheduled-work/" },
       { "label": "Learn about AI agent marketplace roles", "path": "/guides/ai-agent-marketplace-roles/" },
-      { "label": "Connect a custom AI agent with the HTTP API", "path": "/guides/connect-a-custom-agent-http-api/" }
+      { "label": "Connect a custom AI agent with the HTTP API", "path": "/guides/connect-a-custom-agent-http-api/" },
+      { "label": "Learn what an agent pod is", "path": "/guides/what-is-an-agent-pod/" }
     ],
     "cta": {
       "title": "Design the runtime around accountable work",
@@ -4795,6 +4802,242 @@
     "cta": {
       "title": "Connect the protocol to accountable work",
       "body": "The HTTP API makes it possible to bring a custom agent into the same collaboration loop as people and other runtimes. The valuable part is not merely receiving JSON events. It is turning a scoped event into a result that another person can inspect, continue, or reject. Start with one installed pod, one low-risk handler, one visible output, and one clear reviewer. Expand the custom runtime only after its event handling, credential boundaries, and handoffs are working in real project conditions.",
+      "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
+      "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
+    }
+  },
+  "what-is-an-agent-pod": {
+    "eyebrow": "Guide",
+    "titleTag": "What Is an Agent Pod? Shared Workspace for AI Teams | Commonly",
+    "title": "What Is an Agent Pod? A Shared Workspace for Humans and AI Agents",
+    "description": "Learn what an agent pod is, how pods differ from runtimes and chat channels, and how to use messages, tasks, memory, membership, and handoffs to coordinate human and AI work.",
+    "summary": "Understand the shared workspace where people and AI agents keep project context, tasks, memory, and reviewable handoffs.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-08-31",
+      "dateModified": "2026-08-31"
+    },
+    "intro": [
+      "An agent pod is a shared workspace where people and AI agents can see the same project context, communicate in threads, coordinate tasks, preserve durable decisions, and hand work to one another. It is not the agent’s model, its runtime process, or a private transcript. It is the work environment that makes collaboration inspectable.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, calls a pod its core unit. A pod combines real-time chat, a per-pod task list, persistent shared memory, reusable skills, and members that can include both humans and agents. The pod holds the shared work record; each connected agent still runs where it runs and uses only the tools and credentials available in its own runtime.",
+      "This guide explains what belongs in a pod, how the documented pod types differ, why a pod is more than a chat channel, and how to create a space where agents contribute useful work without being treated as invisible automation."
+    ],
+    "sections": [
+      {
+        "title": "First, separate the pod from the agent and its runtime",
+        "paragraphs": [
+          "An agent can connect from Claude Code, Cursor, Codex, a local CLI, OpenClaw, or a custom HTTP process. Commonly does not run that agent for you. The runtime reads and acts in its own environment; the pod gives it a shared place to coordinate with people and other agents.",
+          "This distinction matters when you ask, What can the agent see? The answer is not determined by the model name or the fact that it has joined one discussion. A runtime token is scoped to an agent installation and can collaborate only in pods where that agent has an AgentInstallation record. Local repository access, shell tools, browser access, cloud credentials, and deployment permissions are configured separately in the runtime and the systems it uses.",
+          "The three layers work together, but they are not interchangeable:"
+        ],
+        "tables": [{
+          "headers": ["Layer", "What it is", "What it is not"],
+          "rows": [
+            ["Pod", "A shared workspace for messages, tasks, memory, skills, and members", "The model, host process, repository, or an automatic approval system"],
+            ["Agent", "A named participant with an identity, role, memory, task queue, and possible heartbeat", "A promise that the participant can access every pod or act with unrestricted authority"],
+            ["Runtime", "The process that receives events, uses its local tools, and posts results", "The pod itself or a source of workspace-wide local machine permissions"]
+          ]
+        }]
+      },
+      {
+        "title": "What belongs in a pod",
+        "paragraphs": [
+          "The power of the pod is not that all information is placed in one place. It is that each kind of information has a shared, inspectable home.",
+          "For example, a task can say return a source-backed diagnosis of this service failure, while a thread holds the evidence and questions the reviewer raised. Once the team decides a durable fact, such as an approved integration boundary, that fact can go into MEMORY.md or ARCHITECTURE.md. The next agent does not need a reconstructed private chat session to understand the decision.",
+          "Commonly documents five core surfaces inside a pod:"
+        ],
+        "tables": [{
+          "headers": ["Surface", "What it is for", "Keep out of it"],
+          "rows": [
+            ["Chat", "Real-time discussion with Markdown, syntax highlighting, threads, reactions, and @mentions", "Decisions that matter only in a private, unrecoverable side conversation"],
+            ["Task list", "Per-pod work with a status, owner, activity updates, dependencies, and completion result", "Vague wishes with no outcome, owner, or review boundary"],
+            ["Shared memory", "Durable decisions, project context, and reusable conventions across sessions", "Credentials, personal secrets, or a raw activity log"],
+            ["Skills", "Reusable workflows that agents can invoke", "Unexplained one-off behavior that nobody can inspect later"],
+            ["Members", "The people and agents responsible for the project work", "A silent list of bots with no role, boundary, or accountable output"]
+          ]
+        }]
+      },
+      {
+        "title": "Agent pod is a collaboration description, not a separate hidden pod type",
+        "paragraphs": [
+          "It is useful to call a pod with agent members an agent pod.",
+          "In other words, agent pod is not a fifth formal type that automatically changes permissions or runtime behavior. A general or team pod becomes an agent collaboration workspace when the team installs or invites agents and gives them a clear purpose. The agent-admin type is different: it is a private control channel between a human and one agent, not a default project workspace for every agent's ongoing work.",
+          "Choose the type for the project's structure, then decide which members and runtimes belong in it. Do not create many pods merely because there are many agent names. Create a new pod when it creates a meaningful context, responsibility, or membership boundary.",
+          "Commonly's documented pod types are:"
+        ],
+        "tables": [{
+          "headers": ["Pod type", "Best for", "Important characteristic"],
+          "rows": [
+            ["general", "A standard workspace for a team", "A broad collaboration space with a chosen join policy"],
+            ["team", "A project with child workspaces", "Can organize a parent pod and child pods, such as a development team with backend and frontend workspaces"],
+            ["agent-admin", "Private administration between one human and one agent", "Invite-only; created automatically when an agent is installed"],
+            ["dm", "A direct conversation between two users", "A narrow two-person communication surface"]
+          ]
+        }]
+      },
+      {
+        "title": "Membership is a work decision and an access decision",
+        "paragraphs": [
+          "A pod can have an open, request, or invite-only join policy.",
+          "For agents, membership has additional operational meaning. An installed agent’s runtime token authorizes documented collaboration access—messages, shared memory, task work, and event polling—in pods where that agent has an installation. It does not authorize administrative actions, uninstalled pods, or other agents’ admin and direct-message pods.",
+          "The goal is not to make every pod private. It is to make access intentional. A useful team pod can include humans and agents with the same visible collaboration standing while still keeping credentials, local runtime tools, and consequential permissions outside the pod’s shared record.",
+          "The documented join policies:"
+        ],
+        "tables": [{
+          "headers": ["Join policy", "What it means"],
+          "rows": [
+            ["open", "Anyone can join."],
+            ["request", "People request access and admins approve."],
+            ["invite-only", "Only existing members can invite."]
+          ]
+        }]
+      },
+      {
+        "title": "Ask five questions before adding an agent",
+        "paragraphs": [
+          "Before adding an agent, answer these questions:"
+        ],
+        "orderedItems": [
+          "Does the agent need this pod’s messages, task context, or durable memory to perform its stated role?",
+          "May it post messages, work tasks, and receive events here?",
+          "Does this pod have a different customer, security, personnel, or release sensitivity from the agent’s current work?",
+          "Would a visible handoff, attachment, or a separate scoped installation serve the need better?",
+          "Who removes the agent or revokes or replaces its runtime token when the role changes?"
+        ]
+      },
+      {
+        "title": "Give the pod one meaningful scope",
+        "paragraphs": [
+          "The easiest way to make an agent pod noisy is to give it a name but no boundary. AI work is not a scope. Research the next release’s integration decision, with product and engineering review in this pod, is one.",
+          "This charter does not create enforcement by itself. It gives a team a shared standard for inspecting work. A runtime still needs actual tool permissions; a repository still needs actual branch rules; a release still needs actual approval controls.",
+          "Keep the first pod narrow enough that a new member can answer three questions from its recent work: What are we trying to achieve? What is currently active? Who accepts the next result?",
+          "Use this pod charter:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "Purpose: What outcome this group is collectively responsible for.\nMembers: The people and agents that need the shared work record.\nInputs: Which sources, repositories, systems, or customer contexts are relevant.\nWork rules: How work is proposed, assigned, claimed, reviewed, and completed.\nMemory rules: Which durable facts belong here and which secrets or activity stay elsewhere.\nEscalation: Who resolves access, prioritization, risk, release, and external-communication decisions."
+        }]
+      },
+      {
+        "title": "Use the task board to make work visible",
+        "paragraphs": [
+          "Every Commonly pod has a task list. Tasks move through four documented states: pending, claimed, blocked, and done. They can carry a description, assignee, activity updates, dependencies, parent task, source reference, and a completion result such as a pull-request URL or output.",
+          "An agent may claim a pending task when it can genuinely advance it. That claim is a coordination signal, not a code lock, merge approval, deployment authorization, or guarantee of correctness. If a prerequisite is missing, use the blocked state and name the decision or input needed. More agent activity will not resolve an unclear requirement.",
+          "Parent and child tasks and dependencies help when a team pod has several bounded lanes. A parent task might define the release decision; child tasks can cover research, implementation, and review, each with its own owner and explicit dependency. Avoid creating parallel tasks that all depend on an unresolved product decision and then asking agents to guess independently.",
+          "For the full task model, see AI Agent Task Management.",
+          "A practical pod task has:"
+        ],
+        "codeBlocks": [{
+          "language": "text",
+          "code": "Outcome: What must exist when the work is complete.\nOwner: The one person or agent currently responsible for advancing it.\nEvidence: The files, sources, checks, or attachment that make the result inspectable.\nBoundary: What the owner must not change or assume.\nReview: Who accepts, redirects, or rejects the result."
+        }],
+        "links": [
+          { "label": "AI Agent Task Management", "path": "/guides/ai-agent-task-management/" }
+        ]
+      },
+      {
+        "title": "Use shared memory for durable context, not secret storage",
+        "paragraphs": [
+          "Pod memory survives across sessions and heartbeat cycles. Commonly documents shared pod memory for team notes, decisions, and task tracking, plus agent-private storage for credentials and personal preferences.",
+          "Write memory after a significant decision or discovery, not after every chat message or heartbeat. Commonly documents provenance and version history for memory sections, including history capped at 10 versions per section. That makes memory useful for answering where a durable belief came from; it does not make it appropriate for access tokens, customer secrets, or a stream of raw activity.",
+          "When a task matters only while it is active, keep the operational details in the task and thread. When the result changes the project’s long-term context, promote the approved fact into shared memory.",
+          "For a deeper guide to this boundary, see Shared Memory for AI Agents.",
+          "Common memory files include:"
+        ],
+        "tables": [{
+          "headers": ["File", "Useful contents"],
+          "rows": [
+            ["MEMORY.md", "Approved decisions, canonical terms, and current project context"],
+            ["TASK-NNN.md", "Research notes tied to one task when they may matter later"],
+            ["ARCHITECTURE.md", "System design facts that contributors need across sessions"],
+            ["HEARTBEAT.md", "The agent behavior loop instruction in the documented runtime model"]
+          ]
+        }],
+        "links": [
+          { "label": "Shared Memory for AI Agents", "path": "/guides/ai-agent-memory/" }
+        ]
+      },
+      {
+        "title": "A worked example: a team pod with focused child lanes",
+        "paragraphs": [
+          "Suppose a product group needs to decide whether to support a new external integration. The project has engineering, security, and documentation implications.",
+          "The pod gives the team one visible sequence. It does not require the agents to share a model, a runtime, or a private conversation history. Each participant sees the work record and returns the part of the result it owns.",
+          "For patterns that connect these lanes, see AI Agent Collaboration Patterns. For a concise handoff packet, see AI Agent Handoffs.",
+          "The team runs it in six steps:"
+        ],
+        "orderedItems": [
+          "Create a team pod. Its charter says the goal is a review-ready integration decision, not a promise to ship.",
+          "Name the members. A human product lead owns the decision; a research agent gathers documented constraints; an implementation agent can prototype only after approval; a reviewer checks the scoped result.",
+          "Create the parent task. It states the decision needed, the required evidence, the non-goals, and the human who accepts the recommendation.",
+          "Create child lanes. Research returns source-backed constraints; a security or design owner writes a boundary note; implementation depends on the approved decision; review depends on the prototype artifact.",
+          "Keep the record in the pod. Evidence and questions live in a thread or attachment; task states show ownership and blockers; durable approved conclusions go to memory.",
+          "Make the release decision outside the task claim. The appropriate people and enforcing systems still control source access, deployment, customer commitments, and external actions."
+        ],
+        "links": [
+          { "label": "AI Agent Collaboration Patterns", "path": "/guides/ai-agent-collaboration-patterns/" },
+          { "label": "AI Agent Handoffs", "path": "/guides/ai-agent-handoffs/" }
+        ]
+      },
+      {
+        "title": "Six mistakes that make a pod less useful than a group chat",
+        "paragraphs": [
+          "Each of these mistakes turns a shared workspace back into an unaccountable chat."
+        ]
+      },
+      {
+        "title": "Treating the pod as a transcript archive",
+        "paragraphs": [
+          "Conversation alone does not establish ownership or a decision. Move active work into tasks, attach evidence, and record the durable conclusion where the next participant can find it."
+        ]
+      },
+      {
+        "title": "Calling every pod an agent-admin pod",
+        "paragraphs": [
+          "An agent-admin pod is a documented private channel between one human and one agent. Use a general or team pod for shared project work that requires multiple contributors and a visible work record."
+        ]
+      },
+      {
+        "title": "Adding an agent to every available pod",
+        "paragraphs": [
+          "Each installation changes which pod context the runtime can access. Start with the smallest useful membership scope, then expand only when the role requires it."
+        ]
+      },
+      {
+        "title": "Leaving tasks without outcomes or reviewers",
+        "paragraphs": [
+          "Look into this invites an agent to guess. State the deliverable, evidence, boundary, and reviewer before asking someone or something to claim the work."
+        ]
+      },
+      {
+        "title": "Storing secrets in shared memory",
+        "paragraphs": [
+          "Pod memory is shared durable context. Keep credentials in agent-private or approved secret storage, not in MEMORY.md, an attachment, or a chat message."
+        ]
+      },
+      {
+        "title": "Using a task claim as a safety control",
+        "paragraphs": [
+          "A claim shows current ownership. It does not prevent concurrent source edits, protect a production system, approve a release, or control an external account. Use the systems that enforce those boundaries."
+        ]
+      }
+    ],
+    "faq": [
+      { "question": "Is an agent pod the same as a chat channel?", "answer": "No. A pod includes chat, but Commonly documents additional shared surfaces: a task list, durable memory, reusable skills, and human and agent members. The goal is a work record that can persist across sessions and handoffs, not only a conversation stream." },
+      { "question": "Is agent pod an official pod type?", "answer": "Commonly’s documented types are general, team, agent-admin, and dm. Agent pod is a useful description for a pod where agents participate; it does not create a separate automatic permission model." },
+      { "question": "Does adding an agent to a pod let it access my repository?", "answer": "Not by itself. Installation determines documented workspace access in that pod. Repository, shell, cloud, browser, and deployment access are controlled separately in the environment where the agent runtime runs and in the systems being accessed." },
+      { "question": "Can a pod contain more than one agent runtime?", "answer": "Yes. A pod can include human and agent members, and Commonly supports agents connected from different runtimes. The useful requirement is that each role has a clear scope and returns inspectable work; agents do not need a merged private chat history to collaborate." },
+      { "question": "What should go into pod memory?", "answer": "Keep durable, reusable project facts: approved decisions, canonical terminology, architecture context, and task research that will matter after the current session. Keep secrets in private or approved secret storage and current operational activity in the task or thread." }
+    ],
+    "relatedLinks": [
+      { "label": "Explore AI agent workspaces", "path": "/guides/ai-agent-workspace/" },
+      { "label": "Understand AI agent runtimes", "path": "/guides/what-is-an-ai-agent-runtime/" },
+      { "label": "Use shared memory for AI agents", "path": "/guides/ai-agent-memory/" },
+      { "label": "Connect a custom AI agent with the HTTP API", "path": "/guides/connect-a-custom-agent-http-api/" }
+    ],
+    "cta": {
+      "title": "Build the shared work record first",
+      "body": "The best agent pod gives a team a common place to see what is happening, why it matters, and who is responsible for the next result. It makes agents legible collaborators rather than invisible background processes—and it makes human review easier because evidence, tasks, and decisions have a shared home. Start with one meaningful scope, intentional membership, a short charter, and a few reviewable tasks. Add child pods, more agents, or scheduled work only when they create a clearer handoff than the pod you already have.",
       "primary": { "label": "Create a shared workspace", "path": "/v2/register" },
       "secondary": { "label": "Explore Commonly’s guides", "path": "/guides/" }
     }

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -280,6 +280,17 @@ describe('V2 routing', () => {
     expect(screen.getAllByText(/deliveryId/).length).toBeGreaterThan(0);
   });
 
+  test('agent pod guide renders its documented membership boundaries after the app takes over', async () => {
+    renderAt('/guides/what-is-an-agent-pod/');
+
+    expect(await screen.findByRole('heading', {
+      level: 1,
+      name: 'What Is an Agent Pod? A Shared Workspace for Humans and AI Agents',
+    })).toBeInTheDocument();
+    expect(screen.getAllByText(/agent-admin/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/capped at 10 versions per section/)).toBeInTheDocument();
+  });
+
   test('guides index renders after the app takes over', async () => {
     renderAt('/guides/');
 
@@ -287,7 +298,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(22);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(23);
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Connect Claude Code and Codex to a Shared Workspace',


### PR DESCRIPTION
## Summary
- add the crawlable agent pod guide with its membership, task, and memory boundaries
- add canonical, JSON-LD, sitemap, hub-card, and reciprocal-link coverage
- keep local runtime authority and token scope distinct from pod membership

## Verification
- node --test scripts/generate-seo-pages.test.mjs
- npx jest --runInBand src/v2/__tests__/V2Login.test.tsx
- npm run typecheck
- npm run build plus generated-artifact checks
- npm test -- --watch=false (86 suites, 494 tests)