### PR TITLE
fix(webhooks): Telegram fail-closed verification + atomic update_id dedup

### DIFF
--- a/backend/__tests__/unit/routes/telegram.webhook.test.js
+++ b/backend/__tests__/unit/routes/telegram.webhook.test.js
@@ -11,6 +11,10 @@ jest.mock('../../../integrations', () => ({ get: jest.fn() }));
 jest.mock('../../../services/telegramBridgeService', () => ({
   relayTelegramMessageToPod: jest.fn(),
 }));
+jest.mock('../../../models/WebhookDelivery', () => ({
+  create: jest.fn(),
+  deleteOne: jest.fn(),
+}));
 
 const Integration = require('../../../models/Integration');
 const Pod = require('../../../models/Pod');
@@ -32,6 +36,12 @@ describe('Telegram webhook routes', () => {
     jest.clearAllMocks();
     process.env.TELEGRAM_BOT_TOKEN = 'bot-token';
     delete process.env.TELEGRAM_SECRET_TOKEN;
+    // Verification is fail-closed now; the pre-existing tests exercise
+    // handlers, not auth, so they run with the explicit dev override.
+    process.env.TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED = 'true';
+    const WebhookDelivery = require('../../../models/WebhookDelivery');
+    WebhookDelivery.create.mockResolvedValue({});
+    WebhookDelivery.deleteOne.mockResolvedValue({});
   });
 
   it('handles /commonly-enable and links chat', async () => {
@@ -263,5 +273,98 @@ describe('bridge command surface (/mode /status /mute /help)', () => {
     const bridge = require('../../../services/telegramBridgeService');
     await post('/status');
     expect(bridge.relayTelegramMessageToPod).not.toHaveBeenCalled();
+  });
+
+  describe('hardening: fail-closed verification + update_id dedup', () => {
+    const WebhookDelivery = require('../../../models/WebhookDelivery');
+
+    beforeEach(() => {
+      // Env leaks between tests in this file (the reject-test deletes the
+      // override, the secret-test sets a secret) — pin the default state.
+      process.env.TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED = 'true';
+      delete process.env.TELEGRAM_SECRET_TOKEN;
+      WebhookDelivery.create.mockResolvedValue({});
+      WebhookDelivery.deleteOne.mockResolvedValue({});
+    });
+
+    const liveUpdate = (updateId) => ({
+      update_id: updateId,
+      message: {
+        text: 'hello from telegram',
+        chat: { id: 42, title: 'Test Chat', type: 'group' },
+        from: { id: 7, first_name: 'Sam' },
+      },
+    });
+
+    it('rejects when TELEGRAM_SECRET_TOKEN is unset and no explicit override', async () => {
+      delete process.env.TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED;
+      const res = await request(app)
+        .post('/api/webhooks/telegram')
+        .send(liveUpdate(1));
+      expect(res.status).toBe(401);
+      expect(WebhookDelivery.create).not.toHaveBeenCalled();
+    });
+
+    it('still accepts a correct secret header when the secret is set', async () => {
+      delete process.env.TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED;
+      process.env.TELEGRAM_SECRET_TOKEN = 's3cret';
+      Integration.findOne = jest.fn().mockResolvedValue(null);
+      const res = await request(app)
+        .post('/api/webhooks/telegram')
+        .set('x-telegram-bot-api-secret-token', 's3cret')
+        .send(liveUpdate(2));
+      expect(res.status).toBe(200);
+    });
+
+    it('acks a duplicate update_id without processing it', async () => {
+      const dup = new Error('dup');
+      dup.code = 11000;
+      WebhookDelivery.create.mockRejectedValueOnce(dup);
+      Integration.findOne = jest.fn();
+      const res = await request(app)
+        .post('/api/webhooks/telegram')
+        .send(liveUpdate(3));
+      expect(res.status).toBe(200);
+      expect(Integration.findOne).not.toHaveBeenCalled();
+      expect(bridge.relayTelegramMessageToPod).not.toHaveBeenCalled();
+    });
+
+    it('releases the claim when processing throws, so redelivery retries', async () => {
+      const integration = {
+        _id: 'integration-1',
+        type: 'telegram',
+        podId: 'pod-1',
+        config: { chatId: '42', liveRelay: true },
+      };
+      Integration.findOne = jest.fn().mockResolvedValue(integration);
+      bridge.relayTelegramMessageToPod.mockRejectedValueOnce(new Error('pod write failed'));
+      const res = await request(app)
+        .post('/api/webhooks/telegram')
+        .send(liveUpdate(4));
+      expect(res.status).toBe(500);
+      expect(WebhookDelivery.create).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: 'telegram', deliveryId: '4' }),
+      );
+      expect(WebhookDelivery.deleteOne).toHaveBeenCalledWith(
+        { provider: 'telegram', deliveryId: '4' },
+      );
+    });
+
+    it('a dedup-store outage does not take the bridge down', async () => {
+      WebhookDelivery.create.mockRejectedValueOnce(new Error('mongo down'));
+      const integration = {
+        _id: 'integration-1',
+        type: 'telegram',
+        podId: 'pod-1',
+        config: { chatId: '42', liveRelay: true },
+      };
+      Integration.findOne = jest.fn().mockResolvedValue(integration);
+      bridge.relayTelegramMessageToPod.mockResolvedValueOnce({});
+      const res = await request(app)
+        .post('/api/webhooks/telegram')
+        .send(liveUpdate(5));
+      expect(res.status).toBe(200);
+      expect(bridge.relayTelegramMessageToPod).toHaveBeenCalled();
+    });
   });
 });

--- a/backend/models/WebhookDelivery.ts
+++ b/backend/models/WebhookDelivery.ts
@@ -1,0 +1,42 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+// Atomic claim-based webhook dedup (connector hardening, 2026-08-31 study §gap 2).
+// Providers redeliver: Telegram re-sends an update until it gets a 200, Slack
+// retries on slow acks. Without a claim on the provider's delivery id, every
+// redelivery of an already-processed update becomes a duplicate pod message and
+// a duplicate agent wake (admitted in the bridge's own comments).
+//
+// Contract (claim-before-run, forget-on-error):
+//   1. On receipt, atomically create {provider, deliveryId}. A duplicate-key
+//      error means another delivery of the same update is processing or done —
+//      ack 200 and stop.
+//   2. If processing THROWS after the claim, release the claim before the
+//      non-2xx response, so the provider's redelivery is a retry rather than
+//      a swallowed drop. (A post-write failure must NOT release — the writer
+//      handles its own partial-failure semantics; see the liveRelay comment in
+//      routes/webhooks/telegram.ts.)
+// The TTL bounds the table: a delivery id only needs to be remembered for as
+// long as the provider keeps redelivering it.
+export interface IWebhookDelivery extends Document {
+  provider: string;
+  deliveryId: string;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const WebhookDeliverySchema = new Schema<IWebhookDelivery>(
+  {
+    provider: { type: String, required: true },
+    deliveryId: { type: String, required: true },
+    expiresAt: { type: Date, required: true, index: { expires: 0 } },
+  },
+  { timestamps: true, collection: 'webhook_deliveries' },
+);
+
+WebhookDeliverySchema.index({ provider: 1, deliveryId: 1 }, { unique: true });
+
+export default mongoose.model<IWebhookDelivery>('WebhookDelivery', WebhookDeliverySchema);
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"]; Object.assign(module.exports, exports);

--- a/backend/routes/webhooks/telegram.ts
+++ b/backend/routes/webhooks/telegram.ts
@@ -1,4 +1,5 @@
 const express = require('express');
+const WebhookDelivery = require('../../models/WebhookDelivery');
 const Integration = require('../../models/Integration');
 const Pod = require('../../models/Pod');
 const Summary = require('../../models/Summary');
@@ -33,9 +34,30 @@ const getChatTitle = (chat: any) => (
   || 'Telegram chat'
 );
 
+// Fail CLOSED (hardening study 2026-08-31, gap 4): with no TELEGRAM_SECRET_TOKEN
+// configured this used to accept anything — anyone who found the URL could post
+// updates that wake agents and drive /mode //mute. Now a missing secret rejects,
+// unless the operator explicitly opts out (TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED=true,
+// for local dev only). Deploy note: set TELEGRAM_SECRET_TOKEN and re-register the
+// webhook with setWebhook(secret_token=...) BEFORE shipping this to an env with a
+// live bridge, or Telegram's deliveries (sent without the header) will 401.
+let warnedUnverified = false;
 const verifyTelegramHeader = (req: any) => {
   const expectedToken = process.env.TELEGRAM_SECRET_TOKEN;
-  if (!expectedToken) return true;
+  if (!expectedToken) {
+    if (process.env.TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED === 'true') {
+      if (!warnedUnverified) {
+        warnedUnverified = true;
+        console.warn('Telegram webhook: TELEGRAM_SECRET_TOKEN unset and verification explicitly disabled — accepting unverified updates');
+      }
+      return true;
+    }
+    if (!warnedUnverified) {
+      warnedUnverified = true;
+      console.error('Telegram webhook: TELEGRAM_SECRET_TOKEN is not set — rejecting all updates (set the secret and re-register via setWebhook, or set TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED=true for local dev)');
+    }
+    return false;
+  }
   const headerToken = req.headers['x-telegram-bot-api-secret-token'];
   return headerToken && headerToken === expectedToken;
 };
@@ -309,11 +331,53 @@ const handleUnmuteCommand = async (chat: any, integration: any) => {
   return sendToChat(chatId, 'Unmuted — relay resumes.');
 };
 
+// Dedup TTL: Telegram redelivers an unacked update for well under this window;
+// after it, a reused update_id would be a new update anyway (ids are sequential
+// per bot but survive restarts on Telegram's side).
+const DEDUP_TTL_MS = 10 * 60_000;
+
+// Atomic claim on this update's delivery id (claim-before-run; see
+// models/WebhookDelivery.ts for the contract). Returns 'claimed' | 'duplicate'.
+const claimDelivery = async (updateId: any) => {
+  try {
+    await WebhookDelivery.create({
+      provider: 'telegram',
+      deliveryId: String(updateId),
+      expiresAt: new Date(Date.now() + DEDUP_TTL_MS),
+    });
+    return 'claimed';
+  } catch (err: any) {
+    if (err?.code === 11000) return 'duplicate';
+    // A dedup-store failure must not take the bridge down: proceed unclaimed
+    // (worst case is the pre-existing duplicate behavior, loudly).
+    console.error('Telegram webhook: dedup claim failed, processing without a claim', err);
+    return 'claimed';
+  }
+};
+
+const releaseDelivery = async (updateId: any) => {
+  try {
+    await WebhookDelivery.deleteOne({ provider: 'telegram', deliveryId: String(updateId) });
+  } catch (err) {
+    console.error('Telegram webhook: failed to release dedup claim', err);
+  }
+};
+
 // Universal Telegram webhook (single bot, many chats)
 router.post('/', async (req: any, res: any) => {
+  const updateId = req.body?.update_id;
   try {
     if (!verifyTelegramHeader(req)) {
       return res.status(401).send('invalid secret token');
+    }
+
+    // Redelivery of an update we already claimed (processed, or processing on
+    // a parallel delivery): ack and stop, or it becomes a duplicate pod
+    // message and a duplicate agent wake.
+    if (updateId !== undefined && updateId !== null) {
+      if ((await claimDelivery(updateId)) === 'duplicate') {
+        return res.sendStatus(200);
+      }
     }
 
     const message = getMessageFromUpdate(req.body);
@@ -401,6 +465,12 @@ router.post('/', async (req: any, res: any) => {
     return events(req, res);
   } catch (error) {
     console.error('Telegram webhook error', error);
+    // Forget-on-error: the 500 makes Telegram redeliver this update_id; the
+    // claim must not survive to swallow that retry. (Per the liveRelay comment
+    // above, anything that threw did so before the pod write persisted.)
+    if (updateId !== undefined && updateId !== null) {
+      await releaseDelivery(updateId);
+    }
     return res.status(500).json({ error: 'Internal server error' });
   }
 });


### PR DESCRIPTION
## What

First build from the ruled connector-hardening list (2026-08-31 connector engineering patterns study — gaps 2 "no webhook dedup" and 4 "fail-open verification"):

1. **Fail-closed secret verification.** Previously a missing `TELEGRAM_SECRET_TOKEN` meant every webhook post was accepted unverified. Now missing config **rejects** (401) unless `TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED=true` is set explicitly (dev/test escape hatch; warn-once logged either way).
2. **Atomic `update_id` dedup** via a new `WebhookDelivery` model — unique `{provider, deliveryId}` index + TTL (10 min, matching Telegram's redelivery window). Contract is claim-before-run, forget-on-error:
   - duplicate redelivery → ack 200 immediately, no duplicate pod message / agent wake
   - processing throws after the claim → claim is **released** before the 500, so Telegram's redelivery is a retry rather than a swallowed drop
   - dedup-store outage → degrades to unclaimed processing (the bridge stays up; a rare duplicate beats an outage)

## Deploy note (read before merging to a live-bridge env)

Set `TELEGRAM_SECRET_TOKEN` **and re-register the webhook** via `setWebhook` with `secret_token` before deploying — otherwise the fail-closed check will reject Telegram's (headerless) deliveries. For envs without a secret, set `TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED=true` deliberately.

## Tests

`telegram.webhook.test.js`: 15/15 passing (5 new: reject-when-unset, accept-correct-secret, duplicate-acks-200-without-processing, claim-released-on-throw, store-outage-doesn't-take-bridge-down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8MxGhdgPini3Q14ay2vXS