### PR TITLE
feat(registry): server-side internal seat flag on the agent listing

### DIFF
--- a/backend/__tests__/unit/routes/registry.internal-seat-flag.test.js
+++ b/backend/__tests__/unit/routes/registry.internal-seat-flag.test.js
@@ -1,0 +1,40 @@
+/**
+ * #1377 — the agent listing classifies internal ops/smoke/demo seats at the
+ * boundary (`internal: true` on the payload) so no consumer curates its own
+ * name list. The one-release client constant in V2YourTeamPage is deleted;
+ * this is the contract that replaced it.
+ */
+
+const { buildAgentInstallationPayload, isInternalSeat } = require('../../../routes/registry/helpers');
+
+const install = (agentName, config = undefined) => ({
+  agentName,
+  instanceId: 'default',
+  status: 'active',
+  scopes: [],
+  createdAt: new Date('2026-08-30'),
+  config,
+});
+
+describe('internal seat classification (#1377)', () => {
+  test('known ops seats and script prefixes are flagged', () => {
+    for (const name of ['hosted-smoke', 'run-here-smoke', 'commonly-summarizer',
+      'smoke-stranger-abc', 'recorder-demo1', 'adr-023-probe', 'demo-pelican']) {
+      expect(buildAgentInstallationPayload(install(name)).internal).toBe(true);
+    }
+  });
+
+  test('an ordinary agent is not flagged', () => {
+    for (const name of ['scout', 'hairui-yu-agent', 'smokey', 'fable']) {
+      expect(buildAgentInstallationPayload(install(name)).internal).toBe(false);
+    }
+  });
+
+  test('an explicit config.internal: true wins regardless of name', () => {
+    expect(buildAgentInstallationPayload(install('scout', { internal: true })).internal).toBe(true);
+  });
+
+  test('config.internal must be boolean true — truthy strings do not flag', () => {
+    expect(isInternalSeat('scout', { internal: 'yes' })).toBe(false);
+  });
+});

--- a/backend/routes/registry/helpers.ts
+++ b/backend/routes/registry/helpers.ts
@@ -338,6 +338,21 @@ const resolveDisplayLabelFromUser = (user: any, fallback: string): string => {
   return fallback;
 };
 
+// Internal ops/smoke/demo seats (Wren spec §1.1, BEND-3 follow-up #1377):
+// the roster hides these behind a disclosure. The classification lives HERE,
+// at the boundary, so every consumer reads one `internal: true` flag instead
+// of curating its own name list — the client-side constant this replaces was
+// accepted for exactly one release. An explicit `config.internal: true` on
+// the installation wins; the name patterns cover the seats scripts already
+// create without the flag.
+const INTERNAL_SEAT_EXACT = new Set(['hosted-smoke', 'run-here-smoke', 'commonly-summarizer']);
+const INTERNAL_SEAT_PREFIXES = ['smoke-', 'recorder-', 'adr-', 'demo-'];
+const isInternalSeat = (agentName: any, normalizedConfig: any): boolean => {
+  if (normalizedConfig?.internal === true) return true;
+  const n = String(agentName || '').toLowerCase();
+  return INTERNAL_SEAT_EXACT.has(n) || INTERNAL_SEAT_PREFIXES.some((p) => n.startsWith(p));
+};
+
 const buildAgentInstallationPayload = (installation: any, {
   profile = null,
   iconUrl = '',
@@ -381,6 +396,7 @@ const buildAgentInstallationPayload = (installation: any, {
     // connected" for native agents that talked minutes ago (#915).
     lastActiveAt: lastActiveAt || lastHeartbeatAt,
     usage: installation.usage,
+    internal: isInternalSeat(installation.agentName, normalizedConfig),
     installedBy: installation.installedBy?.toString?.() || installation.installedBy,
     runtime: runtimeConfig,
     // Resolved at the boundary so the frontend doesn't need to know
@@ -612,6 +628,7 @@ module.exports = {
   sanitizeRuntimeConfig,
   buildOpenClawIntegrationChannels,
   buildAgentInstallationPayload,
+  isInternalSeat,
   normalizePluginIdentifier,
   getPluginSpecBase,
   normalizeInstanceId,

--- a/frontend/src/v2/__tests__/V2YourTeamTiers.test.tsx
+++ b/frontend/src/v2/__tests__/V2YourTeamTiers.test.tsx
@@ -44,7 +44,12 @@ const agents = [
   { name: 'sage', instanceId: 'default', displayName: 'Sage', lastActiveAt: minutesAgo(2 * 24 * 60) },
   { name: 'dusty', instanceId: 'default', displayName: 'Dusty', lastActiveAt: minutesAgo(30 * 24 * 60) },
   { name: 'ghost', instanceId: 'default', displayName: 'Ghost', lastActiveAt: null },
-  { name: 'hosted-smoke', instanceId: 'default', displayName: 'Hosted Smoke', lastActiveAt: minutesAgo(1) },
+  // internal comes from the server listing (#1377) — the page must not
+  // re-derive it from the name.
+  { name: 'hosted-smoke', instanceId: 'default', displayName: 'Hosted Smoke', lastActiveAt: minutesAgo(1), internal: true },
+  // Matches the RETIRED client name pattern but carries no server flag — must
+  // render like any other agent, proving the page no longer curates names.
+  { name: 'smoke-widget', instanceId: 'default', displayName: 'Smoke Widget', lastActiveAt: minutesAgo(3 * 24 * 60) },
 ];
 
 const renderPage = () => {
@@ -103,6 +108,9 @@ describe('Your Team tiers', () => {
     expect(screen.queryByText('Hosted Smoke')).not.toBeInTheDocument();
     const toggle = screen.getByTestId('team-internal-toggle');
     expect(toggle).toHaveTextContent('Internal seats (1)');
+    // smoke-widget matches the old client-side name pattern but has no server
+    // flag: it stays on the open roster, not behind the disclosure.
+    expect(screen.getByText('Smoke Widget')).toBeInTheDocument();
     fireEvent.click(toggle);
     expect(screen.getByText('Hosted Smoke')).toBeInTheDocument();
   });
@@ -110,7 +118,8 @@ describe('Your Team tiers', () => {
   test('header kicker reports real numbers: total and active this week, internal excluded', async () => {
     renderPage();
     await waitFor(() => expect(screen.getByText('Fable')).toBeInTheDocument());
-    // 5 agents total; active this week = Fable + Sage (hosted-smoke internal, excluded).
-    expect(screen.getByText('5 agents · 2 active this week')).toBeInTheDocument();
+    // 6 agents total; active this week = Fable + Sage + Smoke Widget
+    // (hosted-smoke internal, excluded).
+    expect(screen.getByText('6 agents · 3 active this week')).toBeInTheDocument();
   });
 });

--- a/frontend/src/v2/components/V2YourTeamPage.tsx
+++ b/frontend/src/v2/components/V2YourTeamPage.tsx
@@ -28,6 +28,8 @@ interface AgentInstallationSummary {
   podName?: string;
   // Derived at dedupe time: how many of the user's pods carry this identity.
   podCount?: number;
+  // Server-classified ops/smoke/demo seat (#1377) — drives the internal tier.
+  internal?: boolean;
 }
 
 // Runtime labels removed from cards 2026-08-22: ADR-022 D1 (ratified) bans
@@ -35,17 +37,10 @@ interface AgentInstallationSummary {
 // violating it on every card. Owner-facing runtime detail lives on the agent
 // profile, not the roster.
 
-// BEND-3 (Wren spec §1.1, Sam-approved 2026-08-30): internal ops/smoke/demo
-// seats hide behind a disclosure. A client-side curated list is exactly the
-// drift the taxonomy forbids, accepted for ONE release; the server-side
-// `internal: true` flag replaces this constant (follow-up filed with the
-// spec). Match by exact name or prefix, lowercased.
-const INTERNAL_SEAT_EXACT = new Set(['hosted-smoke', 'run-here-smoke', 'commonly-summarizer']);
-const INTERNAL_SEAT_PREFIXES = ['smoke-', 'recorder-', 'adr-', 'demo-'];
-const isInternalSeat = (a: AgentInstallationSummary): boolean => {
-  const n = (a.name || '').toLowerCase();
-  return INTERNAL_SEAT_EXACT.has(n) || INTERNAL_SEAT_PREFIXES.some((p) => n.startsWith(p));
-};
+// BEND-3 (Wren spec §1.1): internal ops/smoke/demo seats hide behind a
+// disclosure. Classification is the server's (`internal: true` on the agent
+// listing, #1377) — the one-release client constant this replaced is gone;
+// never reintroduce a curated name list here.
 
 const AGENT_KIND = 'agent' as const;
 const seedOf = (a: AgentInstallationSummary): string => `${a.name}:${a.instanceId || 'default'}`;
@@ -113,7 +108,7 @@ const dedupeAgents = (agents: AgentInstallationSummary[]): AgentInstallationSumm
 // rule 6); everywhere else the relative time carries the signal.
 type Tier = 'workingNow' | 'team' | 'quiet' | 'internal';
 const tierOf = (a: AgentInstallationSummary, now: number): Tier => {
-  if (isInternalSeat(a)) return 'internal';
+  if (a.internal === true) return 'internal';
   const seen = lastSeenTime(a);
   if (!seen || now - seen > QUIET_MS) return 'quiet';
   if (now - seen < WORKING_NOW_MS) return 'workingNow';
@@ -269,7 +264,7 @@ const V2YourTeamPage: React.FC = () => {
     const now = Date.now();
     return sortedAgents.filter((a) => {
       const seen = lastSeenTime(a);
-      return seen > 0 && now - seen < QUIET_MS && !isInternalSeat(a);
+      return seen > 0 && now - seen < QUIET_MS && a.internal !== true;
     }).length;
   }, [sortedAgents]);
 


### PR DESCRIPTION
Closes #1377.

The Your Team internal tier (Wren spec §1.1, BEND-3) shipped behind a client-curated name constant in V2YourTeamPage — accepted for exactly one release. This moves classification to the boundary.

- `buildAgentInstallationPayload` now emits `internal: true`, from an explicit `config.internal === true` (boolean-strict) or the ops/smoke/demo name patterns (`hosted-smoke`, `run-here-smoke`, `commonly-summarizer`; prefixes `smoke-`/`recorder-`/`adr-`/`demo-`), which now live in exactly one place.
- V2YourTeamPage reads `a.internal` and the client constant is deleted. New regression guard: an agent whose name matches the retired pattern but carries no server flag renders on the open roster.
- Tests: 4 new backend unit tests on the derivation; the tiers suite updated to flag-driven mocks (6 agents, kicker recount).

Not in scope (second half of the issue, needs its own data plumb): the featured card's last-message snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTfziSyx2DzuwmibZHHY4s