### PR TITLE
feat(team): featured card line 2 quotes the agent's last message

### DIFF
--- a/backend/__tests__/unit/routes/registry.last-message-snippet.test.js
+++ b/backend/__tests__/unit/routes/registry.last-message-snippet.test.js
@@ -1,0 +1,32 @@
+/**
+ * Wren spec §1.1 line 2 — the agent listing carries what the agent last said,
+ * trimmed at the boundary. The median agent message is ~2,700 chars; the card
+ * shows one line, so the payload must never ship the full body.
+ */
+
+const { buildAgentInstallationPayload, toSnippet } = require('../../../routes/registry/helpers');
+
+const install = { agentName: 'scout', instanceId: 'default', status: 'active', scopes: [], createdAt: new Date() };
+
+describe('agent listing last-message snippet', () => {
+  test('snippet is collapsed, trimmed, and capped at 200 chars with an ellipsis', () => {
+    expect(toSnippet('  hello\n\n  world  ')).toBe('hello world');
+    const long = 'x'.repeat(500);
+    const s = toSnippet(long);
+    expect(s.length).toBe(200);
+    expect(s.endsWith('…')).toBe(true);
+  });
+
+  test('payload carries { snippet, at } when a last message exists', () => {
+    const at = new Date('2026-09-01T08:00:00Z');
+    const p = buildAgentInstallationPayload(install, {
+      lastMessage: { content: 'Deployed the fix.\nAll green.', createdAt: at },
+    });
+    expect(p.lastMessage).toEqual({ snippet: 'Deployed the fix. All green.', at });
+  });
+
+  test('payload lastMessage is null when the agent never spoke — or said only whitespace', () => {
+    expect(buildAgentInstallationPayload(install).lastMessage).toBeNull();
+    expect(buildAgentInstallationPayload(install, { lastMessage: { content: '  \n ' } }).lastMessage).toBeNull();
+  });
+});

--- a/backend/models/pg/Message.ts
+++ b/backend/models/pg/Message.ts
@@ -511,6 +511,37 @@ class Message {
     }
   }
 
+  // One row per user: each given user's most-recent non-system message in ONE
+  // pod. Powers the Your Team featured card's line 2 (last-message snippet) —
+  // the inverse shape of findLastMessageByUserPerPod below.
+  static async findLastMessagePerUserInPod(
+    podId: unknown,
+    userIds: unknown[],
+  ): Promise<Array<{ userId: string; content: string; createdAt: unknown }>> {
+    if (!podId || !userIds || !userIds.length) return [];
+    try {
+      const pid = (podId as { toString(): string }).toString();
+      const userIdStrs = userIds.map((id) => (id as { toString(): string } | undefined)?.toString()).filter(Boolean);
+      if (!userIdStrs.length) return [];
+      const result = await (pool as PgPool).query(
+        `SELECT DISTINCT ON (user_id) user_id, content, created_at
+         FROM messages
+         WHERE pod_id = $1 AND user_id = ANY($2) AND message_type != 'system'
+         ORDER BY user_id, created_at DESC`,
+        [pid, userIdStrs],
+      );
+      return (result.rows as Array<{ user_id: string; content: string; created_at: unknown }>).map((r) => ({
+        userId: r.user_id,
+        content: r.content,
+        createdAt: r.created_at,
+      }));
+    } catch (error) {
+      const e = error as { message?: string };
+      console.error('Error in findLastMessagePerUserInPod:', e.message);
+      return [];
+    }
+  }
+
   // One row per pod: the given user's most-recent non-system message in each pod.
   // Powers the agent-profile "pods" list (their last message + when, per pod).
   static async findLastMessageByUserPerPod(

--- a/backend/routes/registry/helpers.ts
+++ b/backend/routes/registry/helpers.ts
@@ -353,14 +353,25 @@ const isInternalSeat = (agentName: any, normalizedConfig: any): boolean => {
   return INTERNAL_SEAT_EXACT.has(n) || INTERNAL_SEAT_PREFIXES.some((p) => n.startsWith(p));
 };
 
+// The card shows one line of it; shipping the median 2,700-char agent message
+// per roster row is payload waste, so trim at the boundary.
+const SNIPPET_MAX = 200;
+const toSnippet = (content: any): string => {
+  const collapsed = String(content || '').replace(/\s+/g, ' ').trim();
+  if (!collapsed) return '';
+  return collapsed.length > SNIPPET_MAX ? `${collapsed.slice(0, SNIPPET_MAX - 1)}…` : collapsed;
+};
+
 const buildAgentInstallationPayload = (installation: any, {
   profile = null,
   iconUrl = '',
   lastHeartbeatAt = null,
   lastActiveAt = null,
   user = null,
+  lastMessage = null,
 }: {
   profile?: any; iconUrl?: string; lastHeartbeatAt?: any; lastActiveAt?: any; user?: any;
+  lastMessage?: { content?: any; createdAt?: any } | null;
 } = {}) => {
   if (!installation) return null;
   const normalizedConfig = normalizeConfigMap(installation.config);
@@ -397,6 +408,12 @@ const buildAgentInstallationPayload = (installation: any, {
     lastActiveAt: lastActiveAt || lastHeartbeatAt,
     usage: installation.usage,
     internal: isInternalSeat(installation.agentName, normalizedConfig),
+    // Wren spec §1.1 line 2: what the agent last said, pre-trimmed. Null when
+    // it has never spoken in this pod (or the PG lookup was skipped/failed —
+    // the roster never fails over a snippet).
+    lastMessage: lastMessage && toSnippet(lastMessage.content)
+      ? { snippet: toSnippet(lastMessage.content), at: lastMessage.createdAt || null }
+      : null,
     installedBy: installation.installedBy?.toString?.() || installation.installedBy,
     runtime: runtimeConfig,
     // Resolved at the boundary so the frontend doesn't need to know
@@ -629,6 +646,7 @@ module.exports = {
   buildOpenClawIntegrationChannels,
   buildAgentInstallationPayload,
   isInternalSeat,
+  toSnippet,
   normalizePluginIdentifier,
   getPluginSpecBase,
   normalizeInstanceId,

--- a/backend/routes/registry/pod-agents.ts
+++ b/backend/routes/registry/pod-agents.ts
@@ -224,6 +224,24 @@ podAgentsRouter.get('/pods/:podId/agents', auth, async (req: any, res: any) => {
       (userRows as any[]).map((u: any) => [u.username, u]),
     );
 
+    // Last thing each agent said in THIS pod (Wren spec §1.1 line 2).
+    // Advisory like the activity map: a PG hiccup must never fail the roster.
+    let lastMessageByUserId = new Map<string, { content: string; createdAt: unknown }>();
+    try {
+      // eslint-disable-next-line global-require
+      const PgMessage = require('../../models/pg/Message');
+      const rows = await PgMessage.findLastMessagePerUserInPod(
+        String(podId),
+        (userRows as any[]).map((u: any) => u._id),
+      );
+      lastMessageByUserId = new Map(
+        (rows as Array<{ userId: string; content: string; createdAt: unknown }>)
+          .map((r) => [r.userId, { content: r.content, createdAt: r.createdAt }]),
+      );
+    } catch (snippetErr) {
+      console.warn('[pod-agents] last-message lookup failed:', (snippetErr as Error).message);
+    }
+
     res.json({
       agents: installations.map((i: any) => {
         const profile = profiles.find(
@@ -240,6 +258,7 @@ podAgentsRouter.get('/pods/:podId/agents', auth, async (req: any, res: any) => {
           lastHeartbeatAt: heartbeatMap.get(instanceKey) || null,
           lastActiveAt,
           user,
+          lastMessage: (user && lastMessageByUserId.get(String(user._id))) || null,
         });
       }),
     });

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1650,6 +1650,7 @@
     },
     "card": {
       "inProject": "in",
+      "lastSaid": "“{{snippet}}”",
       "roleTitle": "Role: {{role}}",
       "profile": "Profile",
       "viewProfileAria": "View {{name}}'s profile",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1644,6 +1644,7 @@
     },
     "card": {
       "inProject": "属于",
+      "lastSaid": "“{{snippet}}”",
       "roleTitle": "角色：{{role}}",
       "profile": "资料页",
       "viewProfileAria": "查看 {{name}} 的资料页",

--- a/frontend/src/v2/__tests__/V2YourTeamTiers.test.tsx
+++ b/frontend/src/v2/__tests__/V2YourTeamTiers.test.tsx
@@ -40,7 +40,7 @@ const authValue = {
 const minutesAgo = (m) => new Date(Date.now() - m * 60000).toISOString();
 
 const agents = [
-  { name: 'fable', instanceId: 'lead', displayName: 'Fable', lastActiveAt: minutesAgo(4) },
+  { name: 'fable', instanceId: 'lead', displayName: 'Fable', lastActiveAt: minutesAgo(4), lastMessage: { snippet: 'Shipped the fix to main.', at: minutesAgo(4) } },
   { name: 'sage', instanceId: 'default', displayName: 'Sage', lastActiveAt: minutesAgo(2 * 24 * 60) },
   { name: 'dusty', instanceId: 'default', displayName: 'Dusty', lastActiveAt: minutesAgo(30 * 24 * 60) },
   { name: 'ghost', instanceId: 'default', displayName: 'Ghost', lastActiveAt: null },
@@ -78,6 +78,8 @@ describe('Your Team tiers', () => {
     expect(featured[0]).toHaveTextContent('Fable');
     // The dot exists exactly once on the page: in the featured tier.
     expect(screen.getAllByTestId('team-dot')).toHaveLength(1);
+    // Line 2 quotes what the agent last said (server-trimmed snippet).
+    expect(featured[0]).toHaveTextContent('“Shipped the fix to main.”');
   });
 
   test('standard cards carry the always-visible talk icon, no dot, no button pair', async () => {

--- a/frontend/src/v2/components/V2YourTeamPage.tsx
+++ b/frontend/src/v2/components/V2YourTeamPage.tsx
@@ -30,6 +30,8 @@ interface AgentInstallationSummary {
   podCount?: number;
   // Server-classified ops/smoke/demo seat (#1377) — drives the internal tier.
   internal?: boolean;
+  // What the agent last said in this pod, pre-trimmed by the server.
+  lastMessage?: { snippet?: string; at?: string | null } | null;
 }
 
 // Runtime labels removed from cards 2026-08-22: ADR-022 D1 (ratified) bans
@@ -338,9 +340,18 @@ const V2YourTeamPage: React.FC = () => {
             <span className="v2-team-feature__name">{display}</span>
             <span className="v2-team-feature__dot" data-testid="team-dot" />
           </div>
-          <div className="v2-team-feature__doing">
-            {t('yourTeam.card.inProject')} <em>{a.podName || t('yourTeam.untitledProject')}</em>
-          </div>
+          {a.lastMessage?.snippet ? (
+            // Line 2 is what the agent last said (Wren spec §1.1) — quoted,
+            // one line, ellipsized. The project line is the fallback for an
+            // agent that has not spoken in this pod yet.
+            <div className="v2-team-feature__doing v2-team-feature__doing--snippet" title={a.lastMessage.snippet}>
+              {t('yourTeam.card.lastSaid', { snippet: a.lastMessage.snippet })}
+            </div>
+          ) : (
+            <div className="v2-team-feature__doing">
+              {t('yourTeam.card.inProject')} <em>{a.podName || t('yourTeam.untitledProject')}</em>
+            </div>
+          )}
           <div className="v2-team-feature__meta">
             {t('yourTeam.tiers.activeMeta', { time: lastSeen, count: a.podCount || 1 })}
           </div>

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -4019,6 +4019,13 @@ body.modern-ui.v2-canvas {
   margin-top: 2px;
 }
 .v2-team-feature__doing em { font-style: normal; font-weight: 600; }
+/* Snippet variant: one line, ellipsized — a 200-char quote must not
+   change the card's height (grid column is already minmax(0,1fr)). */
+.v2-team-feature__doing--snippet {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .v2-team-feature__meta {
   font-size: 12px;
   color: var(--v2-text-tertiary);


### PR DESCRIPTION
The other half of Wren spec §1.1's data ask — #1377 shipped the `internal` flag, this ships the last-message snippet (called out as deferred in #1423's body).

- `Message.findLastMessagePerUserInPod(podId, userIds)` — `DISTINCT ON (user_id)`, the inverse shape of the existing `findLastMessageByUserPerPod`.
- Listing payload carries `lastMessage: { snippet, at } | null` — collapsed whitespace, capped at 200 chars **at the boundary** (median agent message is ~2,700 chars; that must not ride the roster). Lookup is advisory: a PG failure logs and the roster still renders.
- Featured card line 2 quotes the snippet on one ellipsized line (`--snippet` modifier; the grid column is already `minmax(0,1fr)` so a long quote cannot reflow the card), falling back to the existing project line for an agent that has not spoken.
- zh-CN change is punctuation-only (curly quotes around the interpolation), no translatable words.
- Tests: 3 backend (trim/cap/null contract), tiers suite asserts the quoted line renders.

Real-browser pass on the deployed page follows the merge per the CSS rule; the new rule is 3 declarations on a new modifier class, guarded by the brace-balance invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTfziSyx2DzuwmibZHHY4s