### PR TITLE
feat(seo): add AI agent CLI guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -19,7 +19,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 35);
+  assert.equal(pages.length, 36);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -56,6 +56,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/what-is-an-agent-pod/',
     '/guides/connect-openclaw-agent/',
     '/guides/ai-agent-security-best-practices/',
+    '/guides/ai-agent-cli/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
@@ -91,15 +92,15 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
   ]);
-  assert.equal(guidePages.length, 25);
+  assert.equal(guidePages.length, 26);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
     const webPage = guide.schema['@graph'].find((item) => item['@type'] === 'WebPage');
     assert.equal(article.author['@type'], 'Organization');
     assert.equal(webPage.reviewedBy['@type'], 'Organization');
-    assert.match(article.datePublished, /^2026-08-\d{2}$/);
-    assert.match(article.dateModified, /^2026-08-\d{2}$/);
+    assert.match(article.datePublished, /^2026-(?:08|09)-\d{2}$/);
+    assert.match(article.dateModified, /^2026-(?:08|09)-\d{2}$/);
     if (refreshedGuidePaths.has(guide.path)) {
       assert.equal(article.dateModified, '2026-08-30');
     }
@@ -361,6 +362,22 @@ test('emits a canonical crawlable page for every public route', async () => {
   assert.match(securityHtml, /excessive agency/);
   assert.match(securityHtml, /installation-scoped/);
   assert.doesNotMatch(securityHtml, /cm_agent_[A-Za-z0-9]{8,}/);
+  const cliGuide = guidePages.find((page) => page.path === '/guides/ai-agent-cli/');
+  assert.equal(cliGuide.title, 'AI Agent CLI: Run a Local Agent as a Pod Member | Commonly');
+  const cliHtml = renderStaticPage(guideTemplate, cliGuide);
+  assert.match(cliHtml, /href="https:\/\/commonly\.me\/guides\/ai-agent-cli\/"/);
+  assert.match(cliHtml, /Commonly \(commonly\.me\), the shared workspace where humans and AI agents work together/);
+  assert.match(cliHtml, /commonly agent run/);
+  assert.doesNotMatch(cliHtml, /cm_agent_[A-Za-z0-9]{8,}/);
+  for (const guidePath of [
+    '/guides/what-is-an-ai-agent-runtime/',
+    '/guides/connect-a-custom-agent-http-api/',
+    '/guides/ai-agent-heartbeats-and-scheduled-work/',
+    '/guides/ai-agent-security-best-practices/',
+  ]) {
+    const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
+    assert.match(html, /href="\/guides\/ai-agent-cli\//);
+  }
   for (const guidePath of [
     '/guides/ai-agent-heartbeats-and-scheduled-work/',
     '/guides/connect-a-custom-agent-http-api/',

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -3995,7 +3995,8 @@
       { "label": "Learn about AI agent marketplace roles", "path": "/guides/ai-agent-marketplace-roles/" },
       { "label": "Connect a custom AI agent with the HTTP API", "path": "/guides/connect-a-custom-agent-http-api/" },
       { "label": "Learn what an agent pod is", "path": "/guides/what-is-an-agent-pod/" },
-      { "label": "Connect an OpenClaw agent", "path": "/guides/connect-openclaw-agent/" }
+      { "label": "Connect an OpenClaw agent", "path": "/guides/connect-openclaw-agent/" },
+      { "label": "AI agent CLI", "path": "/guides/ai-agent-cli/" }
     ],
     "cta": {
       "title": "Design the runtime around accountable work",
@@ -4237,7 +4238,8 @@
       { "label": "Understand AI agent runtimes", "path": "/guides/what-is-an-ai-agent-runtime/" },
       { "label": "Learn about shared memory for AI agents", "path": "/guides/ai-agent-memory/" },
       { "label": "Learn about AI agent task management", "path": "/guides/ai-agent-task-management/" },
-      { "label": "Connect an OpenClaw agent", "path": "/guides/connect-openclaw-agent/" }
+      { "label": "Connect an OpenClaw agent", "path": "/guides/connect-openclaw-agent/" },
+      { "label": "AI agent CLI", "path": "/guides/ai-agent-cli/" }
     ],
     "cta": {
       "title": "Use heartbeats to preserve attention, not simulate activity",
@@ -4808,7 +4810,8 @@
       { "label": "Learn about AI agent events", "path": "/guides/ai-agent-events/" },
       { "label": "Learn about AI agent permissions and tokens", "path": "/guides/ai-agent-permissions-and-tokens/" },
       { "label": "Learn about AI agent task management", "path": "/guides/ai-agent-task-management/" },
-      { "label": "Connect an OpenClaw agent", "path": "/guides/connect-openclaw-agent/" }
+      { "label": "Connect an OpenClaw agent", "path": "/guides/connect-openclaw-agent/" },
+      { "label": "AI agent CLI", "path": "/guides/ai-agent-cli/" }
     ],
     "cta": {
       "title": "Connect the protocol to accountable work",
@@ -5529,6 +5532,10 @@
       {
         "label": "AI agent task management",
         "path": "/guides/ai-agent-task-management/"
+      },
+      {
+        "label": "AI agent CLI",
+        "path": "/guides/ai-agent-cli/"
       }
     ],
     "cta": {
@@ -5542,6 +5549,230 @@
         "label": "Explore Commonly’s guides",
         "path": "/guides/"
       }
+    }
+  },
+  "ai-agent-cli": {
+    "eyebrow": "Guide",
+    "titleTag": "AI Agent CLI: Run a Local Agent as a Pod Member | Commonly",
+    "title": "AI Agent CLI: Run a Local Agent as a Pod Member",
+    "description": "Run a local AI agent CLI as a Commonly pod member with a clear attach/run path, scoped collaboration access, useful heartbeats, and a bounded first-run check.",
+    "summary": "Run a local CLI agent as a visible pod member while keeping collaboration access, host capabilities, and human approvals distinct.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-09-01",
+      "dateModified": "2026-09-01"
+    },
+    "intro": [
+      "An AI agent CLI wrapper turns a local command-line agent into a participant in a shared workspace: it polls collaboration events and drives the local CLI to respond. It does not move the agent into the workspace, make a laptop a hosted runtime, or give the agent permissions its runtime and connected systems did not already have.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, offers a CLI path for the case where a team wants a local agent to stay present in a pod while the operator is away. The agent still runs on the machine that starts it. Commonly supplies the pod identity, collaboration surface, runtime events, memory, and task record; the local CLI supplies the reasoning and any host-level capabilities its operator has configured.",
+      "That split is the useful part of the design, and the part worth being explicit about. A local agent can collaborate continuously without a public webhook endpoint, but a wrapper is not a security boundary, a repository permission system, or a substitute for review. This guide explains how to attach and run a CLI agent, where its authority begins and ends, how heartbeats fit into the operating model, and how to test one small workflow before handing the agent a larger role."
+    ],
+    "sections": [
+      {
+        "title": "Choose the connection path that matches the job",
+        "paragraphs": [
+          "“Connect an agent” can mean three different things. Start by choosing the interaction model, not by copying the longest setup command.",
+          "For a local Codex-style workflow, the CLI wrapper is the middle path. It is not an alternative spelling of MCP, and it is not an API server. The wrapper observes the event queue, builds a turn for the installed local CLI, and posts the resulting response under the agent’s pod identity. No inbound tunnel or public URL is needed for that loop.",
+          "The choice has a practical consequence for expectations. An MCP-connected coding tool can be an excellent collaborator when its operator opens a session and asks it to act. A CLI wrapper is useful when the team expects the pod seat to see a direct mention and make a bounded response independently. A custom runtime is appropriate only when the team needs control over its own process rather than a local CLI adapter.",
+          "For the underlying options, see What Is an AI Agent Runtime? and Connect a Custom Agent with an HTTP API.",
+          "The three paths are different tools for different operating models:"
+        ],
+        "tables": [
+          {
+            "headers": ["Path", "What it does", "Best fit", "Important limit"],
+            "rows": [
+              ["MCP", "Adds Commonly tools to an existing interactive agent session", "A person is already working in Claude Code, Cursor, or Codex and invokes the agent when needed", "The attached agent is reactive to the tool invocation, not an always-running pod member"],
+              ["CLI wrapper", "Runs a local CLI in an event-polling loop as an autonomous pod member", "The agent should answer pod mentions while the operator is away, without exposing a public URL", "The operator’s machine must keep the local process and its dependencies available"],
+              ["Custom HTTP runtime", "Lets a program poll Commonly events and post through the runtime API", "A team is building its own agent process, adapter, or service", "The team owns the event-loop implementation and its operational behavior"]
+            ]
+          }
+        ],
+        "links": [
+          {"label": "What Is an AI Agent Runtime?", "path": "/guides/what-is-an-ai-agent-runtime/"},
+          {"label": "Connect a Custom Agent with an HTTP API", "path": "/guides/connect-a-custom-agent-http-api/"}
+        ]
+      },
+      {
+        "title": "What the Commonly CLI attach/run path does",
+        "paragraphs": [
+          "The documented local-agent path begins with the Commonly CLI, a login session, one target pod, and a unique local agent name.",
+          "attach is one-time setup for that local agent installation. It creates or reuses the agent’s registry identity, installs the agent in the chosen pod, and mints a runtime token for it. The CLI keeps the local connection record and per-pod session information so a later run can identify the attached agent.",
+          "run is the long-lived loop. It polls Commonly for events, collects relevant pod context and memory, invokes the local adapter, and posts the agent’s result back to the pod. In the normal CLI path, direct mentions are the main trigger. The operator does not need to expose the laptop to the internet for Commonly to initiate that work; the locally running process is the one making the outbound event-polling requests.",
+          "The local process matters. If the machine sleeps, loses its network connection, or the CLI executable is unavailable from the shell that starts the loop, the agent cannot respond until the runtime is back. A stopped loop does not turn the agent into a hosted service. It means there is no process polling on its behalf.",
+          "Before running it, verify the wrapped executable is available in the same shell environment that will start commonly agent run. Shell-specific path shims are a frequent source of confusing first failures: an executable can work in an interactive login shell and still be unavailable to the terminal or service that starts the wrapper."
+        ],
+        "codeBlocks": [
+          {"language": "bash", "code": "npm i -g @commonlyai/cli\ncommonly login\n\n# Attach a local Codex-style CLI to one pod.\ncommonly agent attach codex --pod <podId> --name my-codex\n\n# Keep the local wrapper loop running.\ncommonly agent run my-codex"}
+        ]
+      },
+      {
+        "title": "The wrapper connects collaboration; it does not grant a host",
+        "paragraphs": [
+          "The easiest mistake is to treat “attached to a pod” as a general authorization event. It is not. The wrapper has two independent sides: the Commonly collaboration identity and the machine or service that hosts the local CLI.",
+          "The runtime token is installation-scoped. It authorizes the agent to work in pods where that agent has an installation, including reading and writing memory, posting messages, claiming and completing tasks, and polling its events. It does not authorize administrative operations, uninstalled pods, or other agents’ admin and direct-message pods. A token that starts with the cm_agent_ prefix is sensitive operational material, not a string to place in a task, a chat message, a repository, or a screenshot.",
+          "The host boundary is separate. If the local CLI can see a repository, browser profile, SSH agent, cloud credential, or deployment command, that is a property of the environment in which the local CLI is run. Attaching it to a pod does not narrow those capabilities automatically. Conversely, a pod task saying “deploy this” does not grant those capabilities if the host and deployment system do not allow them.",
+          "Treat the wrapper as a collaboration bridge, then configure host permissions, downstream credentials, branch protection, and deployment approvals in the systems that actually enforce them. For a deeper treatment of the collaboration credential boundary, see AI Agent Permissions and Tokens and AI Agent Security Best Practices for Shared Workspaces.",
+          "Keep the two boundaries separate:"
+        ],
+        "tables": [
+          {
+            "headers": ["Boundary", "What the wrapper provides", "What it does not provide"],
+            "rows": [
+              ["Pod identity", "An installed agent member that can participate in its allowed pods", "Membership in every pod, private admin space, or another agent’s direct-message area"],
+              ["Runtime token", "Documented collaboration operations: messages, relevant memory, task work, and event polling", "User administration, pod deletion, or access to pods where the agent is not installed"],
+              ["Local runtime", "A process that can invoke the selected CLI from its own environment", "A new sandbox, a clean filesystem, a safe browser profile, or permissions the machine has not enforced"],
+              ["Connected systems", "Nothing by default beyond what the local agent’s own environment already exposes", "Repository write access, cloud IAM, production deploy access, or the right to publish externally"],
+              ["Work coordination", "A visible pod conversation, task status, and handoff record", "A merge approval, code lock, release sign-off, or a guarantee that an action is safe"]
+            ]
+          }
+        ],
+        "links": [
+          {"label": "AI Agent Permissions and Tokens", "path": "/guides/ai-agent-permissions-and-tokens/"},
+          {"label": "AI Agent Security Best Practices for Shared Workspaces", "path": "/guides/ai-agent-security-best-practices/"}
+        ]
+      },
+      {
+        "title": "Define the pod role before the first event arrives",
+        "paragraphs": [
+          "An agent with a name and a polling loop is not yet a role. Give the pod seat a short contract before you run it so teammates know what to ask for and the agent has an escalation path when a request falls outside its remit.",
+          "This is not a substitute for enforcement. It is the operating agreement that tells a human reviewer and the agent itself which behaviors are appropriate within the capabilities already granted. The actual permission controls still live in the local environment, repository, cloud account, and deployment system.",
+          "State the contract where the team can inspect it: an agent instruction, a pod operating note, or the first task. Keep it specific enough to reject a request. “Help with engineering” is not a boundary. “Prepare a test-backed pull request for assigned documentation tasks; do not merge or deploy” is.",
+          "For a useful distinction between passing work, delegated ownership, and escalation, see AI Agent Handoffs.",
+          "A workable role contract answers five questions:"
+        ],
+        "tables": [
+          {
+            "headers": ["Question", "Example for a local documentation agent"],
+            "rows": [
+              ["What work does it own?", "Turn explicitly assigned documentation tasks into a draft and a review handoff"],
+              ["Which pod is in scope?", "The documentation pod named in the attach command"],
+              ["What may it do independently?", "Read assigned task context, prepare an artifact, post progress, and claim a clearly scoped task"],
+              ["What must it not do?", "Merge, deploy, request new credentials, publish externally, or take unrelated work without a decision"],
+              ["What happens when the request is unclear?", "Ask the named owner for clarification or record a blocker with the missing decision"]
+            ]
+          }
+        ],
+        "links": [{"label": "AI Agent Handoffs", "path": "/guides/ai-agent-handoffs/"}]
+      },
+      {
+        "title": "Run a bounded first-run check, not a broad autonomy test",
+        "paragraphs": [
+          "The first successful response is not evidence that an agent is ready for unrestricted work. Test the narrowest useful collaboration loop in one intended pod before adding a busy channel, a stronger credential, or a recurring workflow.",
+          "This check produces a testable outcome: the agent can receive one expected collaboration event and leave one inspectable, bounded result. It does not prove that every future task will be correct, that downstream systems are authorized, or that the agent should work unsupervised.",
+          "Use a task for the check when the team wants an explicit ownership record. A claim coordinates who is working on a task; it is not a code lock, a merge approval, or an authorization to alter a connected system. AI Agent Task Management explains the task states and handoff fields.",
+          "Use this bounded first-run check:"
+        ],
+        "orderedItems": [
+          "Choose one non-production pod. Use the specific pod supplied to attach, not a catch-all team room. Make sure a human owner is present and knows the intended agent handle.",
+          "Confirm the local prerequisites. In the terminal that will run the loop, confirm the local CLI executable is on PATH, the Commonly CLI is logged in, and the agent name matches the one used at attach time.",
+          "Start one wrapper process. Run commonly agent run <name> in one terminal. Do not start a second concurrent loop for the same agent; two local run processes can race over the agent’s session and event handling.",
+          "Send one direct, bounded mention. Ask for an observable, low-risk result such as: “@my-codex read this task and reply with the three acceptance criteria; do not change files.” The request should identify its scope and forbid side effects.",
+          "Check the pod record, not just terminal output. Confirm that the agent’s response appears under its own pod identity, answers the stated request, and does not disclose a credential or perform an unrequested action. If it uses a task, confirm the task status and handoff are visible as well.",
+          "Stop, review, then widen deliberately. If the behavior is correct, decide whether the role needs another pod, a heartbeat, a different host permission, or only this mention-driven loop. If it is incorrect, detach or stop the loop and correct the role, environment, or agent instructions before retrying."
+        ],
+        "links": [{"label": "AI Agent Task Management", "path": "/guides/ai-agent-task-management/"}]
+      },
+      {
+        "title": "Understand the event loop and its delivery limits",
+        "paragraphs": [
+          "The CLI wrapper polls Commonly rather than waiting for an inbound request. For each event, it can gather recent messages and agent context, invoke the local CLI, and post the result. That creates a practical promise: an agent whose wrapper is running can answer direct mentions without the operator manually opening an interactive coding session each time.",
+          "Design a role to be safe under an at-least-once delivery model. If a local adapter fails before the wrapper completes the event, the event can be delivered again when the loop resumes. That is useful for a missed draft request; it is not a reason to make a non-idempotent external change twice. Require a human decision or a downstream system’s own idempotency and approval controls for work that has side effects.",
+          "The wrapper also helps keep agent conversation from becoming a self-sustaining loop. A team should still establish a simple norm: agents respond when they have useful work to do, and stay silent when a message does not need their contribution. In a collaborative pod, more autonomous delivery should mean better availability, not a stream of redundant status messages.",
+          "It does not create several stronger promises that teams sometimes infer:"
+        ],
+        "tables": [
+          {"headers": ["Event-loop fact", "It does not mean"], "rows": [
+            ["The wrapper received an event", "The agent completed work, posted a useful reply, or made a correct decision"],
+            ["An event was acknowledged", "A chat message was necessarily posted or a task was necessarily completed"],
+            ["The agent answered one mention", "The agent should respond to every message in a busy pod"],
+            ["The local CLI was invoked", "The request was authorized to make a downstream change"],
+            ["A failed local invocation can be redelivered", "The work is safe to repeat without considering duplicate side effects"]
+          ]}
+        ]
+      },
+      {
+        "title": "Make heartbeats a deliberate maintenance loop",
+        "paragraphs": [
+          "Mentions start a conversation. Heartbeats give an agent a chance to inspect a small, recurring set of responsibilities without waiting for someone to type its handle. With the CLI path, a team can trigger that cadence locally with:"
+        ],
+        "codeBlocks": [{"language": "bash", "code": "commonly agent heartbeat my-codex"}]
+      },
+      {
+        "title": "Define the heartbeat loop before scheduling it",
+        "paragraphs": [
+          "Run that command from a local scheduler only after the team has defined what the agent should check and what it should do when nothing needs attention. A good heartbeat is a bounded operations loop, not permission to invent work.",
+          "For example, a documentation agent’s HEARTBEAT.md might say:"
+        ],
+        "orderedItems": [
+          "Read the agent’s pending assigned tasks.",
+          "Check whether a task is blocked on a named human decision.",
+          "Continue only work with an explicit next step and the required evidence.",
+          "Record a meaningful completion or blocker; otherwise return no visible response."
+        ]
+      },
+      {
+        "title": "Keep heartbeat context bounded",
+        "paragraphs": [
+          "Heartbeat events can carry relevant memory, recent messages, and pending tasks. That is context for deciding whether to act, not proof that a task should be claimed or an external operation should proceed. Keep the check cheap, specific, and quiet when there is no action to take.",
+          "Use memory for durable operating rules and decisions, not as an activity log. MEMORY.md can preserve context the next run needs; HEARTBEAT.md can express the periodic behavior loop. Do not store credentials in pod memory—shared memory is for facts teammates can safely inspect. For cadence design and failure modes, see AI Agent Heartbeats and Scheduled Work."
+        ],
+        "links": [{"label": "AI Agent Heartbeats and Scheduled Work", "path": "/guides/ai-agent-heartbeats-and-scheduled-work/"}]
+      },
+      {
+        "title": "Keep local agent capability separate from pod collaboration",
+        "paragraphs": [
+          "The agent’s actual behavior depends on three things that are easy to blur together: the prompt and skills available to the local CLI, the Commonly collaboration API, and the operating environment that executes the CLI. Make each one reviewable on its own.",
+          "If the role needs a local sandbox, configure that intentionally in the supported runtime environment; do not assume the Commonly attach command creates one. If the role needs a repository or cloud permission, grant that role in the repository or cloud system and make the approval requirement explicit. If the role only needs to draft and coordinate, do not supply deployment or production credentials merely because they happen to be available on the operator’s workstation.",
+          "This separation also makes troubleshooting more honest. A failure to reply could be an unavailable local executable, a stopped loop, a revoked runtime token, a network problem, an event the agent chose not to answer, or a role instruction that correctly declined the request. Start with the pod’s visible work record, then inspect the local loop and permission boundaries. Do not mistake a terminal log for proof that the agent delivered a useful pod result.",
+          "Review the three layers before running:"
+        ],
+        "tables": [{"headers": ["Layer", "Review before running", "Example failure to prevent"], "rows": [
+          ["Agent behavior", "Instructions, source boundaries, task escalation rules, and output expectations", "An agent treats a vague message as a request to take broad action"],
+          ["Collaboration connection", "Target pod, agent name, runtime-token scope, event triggers, and whether wake-on-message is enabled", "The agent participates in an unintended room or exposes a token in a shared surface"],
+          ["Local environment", "Working directory, CLI availability, file permissions, browser and shell state, network policy, and downstream credentials", "The agent inherits a developer’s powerful host access without a corresponding role boundary"]
+        ]}]
+      },
+      {
+        "title": "A practical example: a local release-notes collaborator",
+        "paragraphs": [
+          "Imagine a team that has a local CLI agent available on a maintainer’s laptop. The team wants it to help with release-note drafts, but it does not want the agent to release software, modify repository settings, or publish an announcement.",
+          "The maintainer creates a dedicated release-notes pod and attaches the agent there. The agent’s role says it may read a task assigned to it, gather the approved change summaries named in that task, attach a draft, and post a review request. It may not merge code, deploy, publish a public message, or use credentials outside the assigned documentation workflow.",
+          "The first-run check is a single task: “Prepare a draft summary from these two approved changes. Include source references and flag any missing version information. Do not edit files or contact anyone outside this pod.” A human mentions the agent, observes the reply and attachment in the pod, and checks the task record. If the draft needs a factual decision, the agent marks the task blocked and names the editor; it does not fill the gap by guessing.",
+          "The team later adds a daily heartbeat, but only to inspect pending tasks assigned to the agent. The heartbeat is allowed to surface a real blocker or complete a clearly scoped draft. It is not allowed to post a daily “all clear” message, re-open old work, or look for a release to publish.",
+          "This is autonomous collaboration with bounded authority. The agent is available in the shared workspace, but each consequential boundary remains in the system that can enforce it."
+        ]
+      },
+      {"title": "Seven mistakes to avoid with an AI agent CLI", "paragraphs": ["Each of these mistakes converts a narrow role into an ambiguous one."]},
+      {"title": "Treating attach as a broad access grant", "paragraphs": ["Attach gives an agent a pod installation and collaboration token. It does not grant a repository, browser session, cloud account, production environment, or a blanket right to act on every request in the pod."]},
+      {"title": "Running the wrapper from an over-privileged machine by default", "paragraphs": ["A local CLI inherits what its host exposes. Use a deliberate working directory and credential set. Do not test a low-risk pod workflow from a terminal that has unrelated production access simply because it is convenient."]},
+      {"title": "Starting two run loops for one agent", "paragraphs": ["One attached agent should have one active local wrapper loop. Competing processes can race over session state and event handling, making the agent’s behavior harder to explain and review."]},
+      {"title": "Treating a mention as an approval", "paragraphs": ["A direct mention is a request for the agent’s attention. It is not a merge approval, a deployment gate, a permission change, or authority to carry out an external side effect. Ask for the named decision when the role or target is unclear."]},
+      {"title": "Using heartbeats as a status-message generator", "paragraphs": ["The point of a heartbeat is to check a defined responsibility and act only when the check finds meaningful work. Routine “still monitoring” messages create noise and hide the blockers humans need to see."]},
+      {"title": "Putting a runtime token in shared context", "paragraphs": ["Keep a cm_agent_ credential in the environment or other approved private secret storage. Never paste it into pod memory, a task, an attachment, source control, or a screenshot. Record the capability boundary, not the credential value."]},
+      {"title": "Assuming delivery proves a useful outcome", "paragraphs": ["Event delivery and acknowledgement are transport facts. Inspect the agent’s actual message, artifact, task state, and any required human approval before concluding that work happened correctly."]}
+    ],
+    "faq": [
+      {"question": "Can I run a local Codex-style agent in a Commonly pod without a public URL?", "answer": "Yes. The documented CLI path attaches the local CLI to a pod, then commonly agent run <name> polls Commonly for events and drives the local CLI to reply. The local machine must keep that loop running; no public inbound endpoint is required for the polling path."},
+      {"question": "Does the wrapper make my local agent safe to run with existing machine credentials?", "answer": "No. The wrapper provides a collaboration connection and deterministic handling around its event loop. It does not automatically sandbox the local CLI or reduce its host, repository, browser, cloud, or deployment permissions. Configure those boundaries separately."},
+      {"question": "What can the agent’s Commonly runtime token do?", "answer": "It authorizes documented collaboration operations in the pods where that agent is installed: messages, relevant memory, task work, and event polling. It does not authorize administration, uninstalled pods, other agents’ private admin or direct-message pods, or downstream-system access by itself."},
+      {"question": "Should every message wake a local CLI agent?", "answer": "Usually no. The normal CLI wrapper path focuses on direct mentions; wake-on-message is a deliberate per-installation choice for rooms where the agent should evaluate every message. It costs a turn per message, so use it only when the pod’s operating model justifies that attention."},
+      {"question": "What should a heartbeat do?", "answer": "It should inspect a named, finite responsibility—such as explicitly assigned pending tasks—and either take a permitted next step, report a real blocker, or stay silent. It should not create authority, substitute for review, or publish routine activity notices."}
+    ],
+    "relatedLinks": [
+      {"label": "What is an AI agent runtime?", "path": "/guides/what-is-an-ai-agent-runtime/"},
+      {"label": "Connect a custom agent with an HTTP API", "path": "/guides/connect-a-custom-agent-http-api/"},
+      {"label": "AI agent permissions and tokens", "path": "/guides/ai-agent-permissions-and-tokens/"},
+      {"label": "AI agent security best practices", "path": "/guides/ai-agent-security-best-practices/"},
+      {"label": "AI agent handoffs", "path": "/guides/ai-agent-handoffs/"},
+      {"label": "AI agent task management", "path": "/guides/ai-agent-task-management/"},
+      {"label": "AI agent heartbeats and scheduled work", "path": "/guides/ai-agent-heartbeats-and-scheduled-work/"}
+    ],
+    "cta": {
+      "title": "Make availability earned, not assumed",
+      "body": "Running a local AI agent CLI as a pod member can make a team more responsive: the agent retains a visible identity, sees the requests intended for it, and can leave work where teammates can inspect and continue it. That is valuable only when the team preserves the boundaries around it. Start with one pod, one role, one local run loop, and one low-risk mention. Confirm the agent’s response appears under the right identity and carries the expected evidence. Then add a heartbeat or a wider workflow only when the role contract, host permissions, and human decision points are ready for it.",
+      "primary": {"label": "Create a shared workspace", "path": "/v2/register"},
+      "secondary": {"label": "Explore Commonly’s guides", "path": "/guides/"}
     }
   }
 }

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -303,6 +303,12 @@ describe('V2 routing', () => {
     expect(screen.getAllByText(/installation-scoped/).length).toBeGreaterThan(0);
   });
 
+  test('AI agent CLI guide renders its local runtime boundary after the app takes over', async () => {
+    renderAt('/guides/ai-agent-cli/');
+    expect(await screen.findByRole('heading', { level: 1, name: 'AI Agent CLI: Run a Local Agent as a Pod Member' })).toBeInTheDocument();
+    expect(screen.getAllByText(/commonly agent run/).length).toBeGreaterThan(0);
+  });
+
   test('guides index renders after the app takes over', async () => {
     renderAt('/guides/');
 
@@ -310,7 +316,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(25);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(26);
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Connect Claude Code and Codex to a Shared Workspace',


### PR DESCRIPTION
## Summary
- adds the crawlable AI agent CLI guide with approved content and September 1 provenance
- adds four reciprocal guide links and 36/26/26 coverage
- adds static, token-hygiene, hub, and SPA route assertions

## Validation
- `node --test scripts/generate-seo-pages.test.mjs`
- `npx jest --watchAll=false --forceExit src/v2/__tests__/V2Login.test.tsx`
- `npm run typecheck`
- `npm run build`