### PR TITLE
fix(webhooks): await the Telegram provider handler so the dedup claim is released

### DIFF
--- a/backend/__tests__/unit/routes/telegram.webhook.test.js
+++ b/backend/__tests__/unit/routes/telegram.webhook.test.js
@@ -165,6 +165,47 @@ describe('Telegram webhook routes', () => {
     expect(res.status).toBe(200);
     expect(events).toHaveBeenCalled();
   });
+
+  it('releases the dedup claim when the async provider handler rejects', async () => {
+    // The provider's real `events` is async (telegramProvider.ts:111 awaits a
+    // Mongo write), so it can reject AFTER the route has claimed the update_id.
+    // With a bare `return events(...)` the rejection escapes the try/catch —
+    // express 4 has no async error handling — so the claim is never released,
+    // no response is sent, and Telegram's redelivery is then acked 200 as a
+    // duplicate and dropped permanently. Stubbing `events` synchronously, as
+    // the tests above do, cannot see this.
+    const integration = {
+      _id: 'integration-1',
+      type: 'telegram',
+      config: { chatId: '42' },
+    };
+    Integration.findOne.mockResolvedValue(integration);
+    const events = jest.fn(async () => {
+      throw new Error('provider write failed');
+    });
+    registry.get.mockReturnValue({
+      getWebhookHandlers: () => ({ events }),
+    });
+
+    const res = await request(app)
+      .post('/api/webhooks/telegram')
+      .send({
+        update_id: 5150,
+        message: {
+          text: 'hello',
+          chat: { id: 42, title: 'Test Chat', type: 'group' },
+          from: { id: 7, first_name: 'Sam' },
+        },
+      });
+
+    const WebhookDelivery = require('../../../models/WebhookDelivery');
+    expect(events).toHaveBeenCalled();
+    expect(res.status).toBe(500);
+    expect(WebhookDelivery.deleteOne).toHaveBeenCalledWith({
+      provider: 'telegram',
+      deliveryId: '5150',
+    });
+  });
   describe('live relay ack', () => {
     const liveIntegration = {
       _id: 'integration-1',

--- a/backend/routes/webhooks/telegram.ts
+++ b/backend/routes/webhooks/telegram.ts
@@ -462,7 +462,7 @@ router.post('/', async (req: any, res: any) => {
 
     const provider = registry.get('telegram', integration);
     const { events } = provider.getWebhookHandlers();
-    return events(req, res);
+    return await events(req, res);
   } catch (error) {
     console.error('Telegram webhook error', error);
     // Forget-on-error: the 500 makes Telegram redeliver this update_id; the


### PR DESCRIPTION
Follow-up to #1422, which merged at `e794b1fc` with this outstanding. Verified present on `origin/main` at `backend/routes/webhooks/telegram.ts:465`.

## The defect

The last exit of the POST handler's `try` block is the only un-awaited return of the 14 in it:

```js
return events(req, res);
```

Four links, each measured rather than reasoned:

1. **`events` is async and can reject** — `telegramProvider.ts:111` declares it `async`, `:126` awaits `Integration.findByIdAndUpdate`.
2. **`return promise` inside a `try` does not reach that `catch`** — only `return await promise` does. Verified in isolation on node 22.
3. **Nothing else catches it** — express is 4.21.2, no `express-async-errors`, no `asyncHandler` wrapper anywhere in `backend/`.
4. **So the rejection escapes the route.** The forget-on-error release never runs, no response is sent, Telegram redelivers, `claimDelivery` returns `'duplicate'`, and the update is acked 200 and dropped permanently.

That is precisely what the release contract exists to prevent — the comment on the `catch` says it outright: *"the claim must not survive to swallow that retry."* And it is **new** behaviour: before the dedup claim existed, the redelivery just reprocessed. The `liveRelay` branch immediately above already awaits its bridge call, so this was the single escaping path.

## Why 15/15 was green

Every test that reaches this line stubs the handler **synchronously**:

```js
const events = jest.fn((req, res) => res.sendStatus(200));
```

while the real one is `async`. The mock differs from production in exactly the dimension the bug lives in, so the suite could not have caught it at any coverage level.

## The added test

Stubs `events` async and rejecting, then asserts the release fired and a 500 went out. The differential:

| | Result |
|---|---|
| without `await` | **fails** — times out, because no response is ever sent (the defect's own signature) |
| with `await` | **16/16 pass** |

Run on node 22. I reverted the one-word fix and re-ran to confirm the test actually discriminates, rather than trusting that a new test which passes is testing anything.

## Not fixed here

Two things I raised on #1422 that are deliberately out of scope for a one-word fix, both worth their own change:

- **Both `updateId !== undefined && updateId !== null` guards are unpinned** — deleting either one survives the suite. Without them an update with no `update_id` claims the literal key `'undefined'`, and every subsequent one is acked and dropped. Ten of the fifteen shipped tests post exactly that shape and all stay green.
- **The deploy prerequisite is still unmet.** `TELEGRAM_SECRET_TOKEN` and `TELEGRAM_WEBHOOK_ALLOW_UNVERIFIED` appear nowhere under `k8s/`, while `TELEGRAM_BOT_TOKEN` **is** wired (`backend-deployment.yaml:356`). The bridge is provisioned, so deploying as-is fail-closes every inbound update. Chart change and `setWebhook(secret_token=…)` need to land before this reaches the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

