### PR TITLE
test(backend): re-certify the agentRuntimeAuth projection guard — main is red

### DIFF
--- a/backend/__tests__/unit/middleware/agentUserShapeContract.test.js
+++ b/backend/__tests__/unit/middleware/agentUserShapeContract.test.js
@@ -36,6 +36,25 @@ const codeOnly = () => source
 
 const selectCallCount = () => (codeOnly().match(/\.select\s*\(/g) || []).length;
 
+/**
+ * The model each `.select(` is called on, sorted. Walks back from every
+ * projection to the nearest preceding `Model.find*(` — crude on purpose, in
+ * the same spirit as the counter: it does not have to be right for the guard
+ * to fail closed, because `selectCallCount` already trips on any new
+ * projection. This exists so the failure names the receiver instead of only
+ * a number, which is what turns "bump the constant" into "re-certify".
+ */
+const selectReceivers = () => {
+  const code = codeOnly();
+  const queries = [...code.matchAll(/\b([A-Z]\w*)\s*\.\s*(?:findOne|findById|find)\s*\(/g)];
+  return [...code.matchAll(/\.select\s*\(/g)]
+    .map((m) => {
+      const preceding = queries.filter((q) => q.index < m.index);
+      return preceding.length ? preceding[preceding.length - 1][1] : '(none)';
+    })
+    .sort();
+};
+
 /** Statement starting at `User.findOne(`, up to the terminating semicolon. */
 const userFindOneStatements = () => {
   const out = [];
@@ -56,7 +75,7 @@ describe('the middleware reads the full User row', () => {
     expect(userFindOneStatements()).toHaveLength(2);
   });
 
-  it('the file contains exactly one projection, and it is the Pod.find', () => {
+  it('every projection in the file is certified, and none is on a User query', () => {
     // THE LOAD-BEARING ASSERTION, and it fails CLOSED. @sprint-review found
     // the statement-scoping below fails OPEN on the most likely edit: it ends
     // a statement at the first `;` after `User.findOne(`, which is not the end
@@ -77,8 +96,17 @@ describe('the middleware reads the full User row', () => {
     // is not. Enumerate the protected item instead: ANY new `.select(`
     // anywhere in the file trips this, and the author re-certifies it
     // consciously. A guard that must parse correctly to fail is not a guard.
-    expect(selectCallCount()).toBe(1);
+    expect(selectCallCount()).toBe(2);
     expect(codeOnly()).toMatch(/Pod\.find\([\s\S]{0,200}?\.select\('_id'\)/);
+    expect(codeOnly()).toMatch(/AgentCredential\.findById\([\s\S]{0,120}?\.select\('status'\)/);
+    // Re-certification, not a bumped constant. The count above is the
+    // fail-closed backstop; this is the record of WHICH projections are
+    // certified and on what. #1312 (ADR-026 Phase 0) added the
+    // AgentCredential one on 2026-08-27 and it is fine — the property is
+    // "no USER query is projected", and AgentCredential is not the User row.
+    // Bumping 1 to 2 without this list is the escape hatch the guard exists
+    // to close, so the receivers are enumerated below and asserted.
+    expect(selectReceivers()).toEqual(['AgentCredential', 'Pod']);
   });
 
   it('projects neither User.findOne', () => {


### PR DESCRIPTION
**`main` is red.** `Test & Coverage` fails at `origin/main` (`396bf8f1`) — 1 failed, 2790 passed. Every open PR inherits it; my #1429 is how I found it.

```
● the middleware reads the full User row › the file contains exactly one projection, and it is the Pod.find
    Expected: 1
    Received: 2
```

## Nothing is actually broken

#1312 (AgentCredential substrate, ADR-026 Phase 0, merged 2026-08-27) added to `agentRuntimeAuth.ts:82`:

```ts
const parent = await AgentCredential.findById(credential.parentId).select('status').lean();
```

That is a projection on **AgentCredential**, not on the User row. The property the guard defends — *no User query is projected, so `req.agentUser` carries the whole row* — is intact. The guard trips on **any** new `.select(` in the file on purpose, so the author re-certifies consciously. Its own comment says why a smarter check was rejected:

> Enumerate the protected item instead: ANY new `.select(` anywhere in the file trips this, and the author re-certifies it consciously. A guard that must parse correctly to fail is not a guard.

So this is the guard working. It just never got its re-certification.

## Why it reached main, and why no check could have caught it

| Ref | `.select(` in `agentRuntimeAuth.ts` | Guard |
|---|---|---|
| #1210's base `799e0d7d` | 1 | passes — **CI was green** |
| #1210's merge `78e7c97e` (= main) | 2 | fails |

#1210 was green on a tree that had stopped existing four days earlier. Merging it at `11:05:07Z` today produced a tree **neither PR's CI had ever run**.

The part worth generalising: these two PRs never conflicted and never could. **#1312 edits the middleware; #1210 adds a test that *reads* the middleware.** Disjoint paths — `git merge-tree` calls them clean, the stale-base guard passes, and nothing in the merge machinery models "this file's assertions depend on that file's contents." A source-assertion guard is coupled to files it does not modify, and that coupling is invisible to every conflict check we run. Textually clean, semantically contradictory.

## The fix

Re-certification, not a bumped constant — a bump is precisely the escape hatch the guard exists to close. The count stays as the fail-closed backstop, and on top of it:

- both certified projections pinned to their receivers by regex;
- `selectReceivers()`, which walks each `.select(` back to the model it is called on and asserts the set is exactly `{AgentCredential, Pod}`. A future projection on `User` now fails **by name**, not just by count.

**Verified it still discriminates.** Adding `.select('_id username')` to the `User.findOne` in the middleware fails two tests — the count (2→3) and the statement-level assertion — and I reverted the mutation afterwards. `unit/middleware` is 45/45 green.

Also renamed the test: it said "exactly one projection, and it is the Pod.find", which this diff makes untrue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
