### PR TITLE
fix(helm): wire TELEGRAM_SECRET_TOKEN for #1422 fail-closed verification

### DIFF
--- a/k8s/helm/commonly/templates/core/backend-deployment.yaml
+++ b/k8s/helm/commonly/templates/core/backend-deployment.yaml
@@ -355,6 +355,12 @@ spec:
               name: api-keys
               key: telegram-bot-token
               optional: true
+        - name: TELEGRAM_SECRET_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: api-keys
+              key: telegram-secret-token
+              optional: true
         - name: BRAVE_API_KEY
           valueFrom:
             secretKeyRef:

--- a/k8s/helm/commonly/templates/secrets/api-keys.yaml
+++ b/k8s/helm/commonly/templates/secrets/api-keys.yaml
@@ -175,6 +175,11 @@ spec:
   - secretKey: telegram-bot-token
     remoteRef:
       key: commonly-dev-telegram-bot-token
+  # Webhook secret_token (#1422 fail-closed verification): must match the
+  # value registered with Telegram via setWebhook, or every delivery 401s.
+  - secretKey: telegram-secret-token
+    remoteRef:
+      key: commonly-dev-telegram-secret-token
   - secretKey: brave-api-key
     remoteRef:
       key: commonly-dev-brave-api-key


### PR DESCRIPTION
#1422 (merged, not yet deployed) makes Telegram webhook verification fail-closed — and the cluster had **no** `TELEGRAM_SECRET_TOKEN` configured, so the next `Deploy Dev` from main would have 401'd every delivery and silently killed the live bridge.

Operator steps already done (in order, downtime-free because live pre-#1422 code ignores the header):
1. `commonly-dev-telegram-secret-token` created in Secret Manager (random 48-char, never left the pipe).
2. Webhook re-registered via `setWebhook` with the matching `secret_token` (`getWebhookInfo`: same URL, ok:true).

This PR wires the last leg: ESO mapping in `api-keys.yaml` + `TELEGRAM_SECRET_TOKEN` env on the backend deployment (optional, same shape as its siblings). After merge: force-sync ESO, then deploy ships #1422 with its config present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTfziSyx2DzuwmibZHHY4s