### PR TITLE
fix(v2): remove the 75ch cap (third full-width ruling) + avatar is its own edit control

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -194,6 +194,13 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // No revision may reintroduce a conversation measure token: that is
     // the corner-of-the-triangle debate re-opening by accident.
     expect(v2).not.toContain('--v2-conv-measure');
+    // v6 (2026-09-01): the var ban was not enough — #1367 reintroduced the
+    // cap as a LITERAL (`max-width: 75ch`) via a craft audit that called it
+    // a P0, and even claimed this test guarded it. Sam's third ruling:
+    // full-width stands. Ban any ch-unit max-width inside the message
+    // content block, not just the token.
+    const msgContentBlock = v2.slice(v2.indexOf('.v2-msg__content {'), v2.indexOf('.v2-msg__content p'));
+    expect(msgContentBlock).not.toMatch(/max-width:\s*\d+ch/);
     // What survives every revision is COHERENCE: messages' and composer's
     // children share the pane's full width and one explicit left edge.
     // margin-inline stays an explicit 0 — a stray auto re-centers a subset

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -737,12 +737,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
 
   // Connectors v2 (Wren spec §5): platform tint tokens must exist in BOTH
   // token files (the same-PR rule), and the tile class must consume them.
-  it('chat message text keeps its measure cap (craft audit finding 6)', () => {
-    // 150-char lines on the chat surface were the audit's P0 readability
-    // defect; jsdom cannot measure line length, so pin the rule itself.
+  it('chat message text has NO measure cap (Sam overruled craft finding 6, 2026-09-01)', () => {
+    // #1367 pinned a 75ch cap here as the audit's P0. Sam overruled it —
+    // third full-width ruling; worst case was a large screen with the
+    // sidebar collapsed. The rule-2 v6 assertion above owns the ban; this
+    // test flips to the same polarity so the two can never disagree.
     const block = v2.match(/\.v2-msg__content \{[^}]*\}/);
     expect(block).not.toBeNull();
-    expect(block![0]).toContain('max-width: 75ch');
+    expect(block![0]).not.toMatch(/max-width:\s*\d+ch/);
   });
 
   it('the BEND-1 feature type step exists in v2.css and tokens.css together', () => {

--- a/frontend/src/v2/agents/V2AgentProfile.tsx
+++ b/frontend/src/v2/agents/V2AgentProfile.tsx
@@ -253,21 +253,35 @@ const V2AgentProfile: React.FC = () => {
       <main className="v2-aprofile__main">
         {/* Identity header */}
         <section className="v2-aprofile__hero">
-          <V2Avatar
-            name={agent.displayName}
-            src={agent.profilePicture}
-            size="lg"
-            kind="agent"
-            seed={`${agent.agentName}:${agent.instanceId || 'default'}`}
-          />
-          {canEditAvatar && (
+          {/* The avatar IS the edit control (Sam, 2026-09-01: "a button called
+              change avatar … should be enough just clicking the avatar").
+              Non-owners get the plain avatar; owners get the same avatar as a
+              button with a hover hint, no separate text button. */}
+          {canEditAvatar ? (
             <button
               type="button"
-              className="v2-aprofile__avatar-edit"
+              className="v2-aprofile__avatar-button"
               onClick={() => setAvatarDialogOpen(true)}
+              aria-label="Change avatar"
+              title="Change avatar"
             >
-              Edit avatar
+              <V2Avatar
+                name={agent.displayName}
+                src={agent.profilePicture}
+                size="lg"
+                kind="agent"
+                seed={`${agent.agentName}:${agent.instanceId || 'default'}`}
+              />
+              <span className="v2-aprofile__avatar-hint" aria-hidden="true">Edit</span>
             </button>
+          ) : (
+            <V2Avatar
+              name={agent.displayName}
+              src={agent.profilePicture}
+              size="lg"
+              kind="agent"
+              seed={`${agent.agentName}:${agent.instanceId || 'default'}`}
+            />
           )}
           {avatarDialogOpen && (
             <div className="v2-aprofile__avatar-dialog" role="dialog" aria-label="Choose an avatar">

--- a/frontend/src/v2/agents/v2-agent-profile.css
+++ b/frontend/src/v2/agents/v2-agent-profile.css
@@ -219,19 +219,42 @@
 }
 .v2-root button.v2-aprofile__pod-remove:disabled { opacity: 0.6; cursor: default; }
 
-/* Owner-editable avatar picker (visible only to installer/admin) */
-.v2-aprofile__avatar-edit {
-  align-self: flex-end;
-  margin-left: -14px;
-  padding: 4px 10px;
-  font-size: 12px;
-  color: var(--v2-text-secondary);
-  background: var(--v2-surface);
-  border: 1px solid var(--v2-border);
-  border-radius: var(--v2-radius-lg);
+/* Owner-editable avatar: the avatar itself is the button (Sam, 2026-09-01).
+   Bare reset base per the button-reset trap (3rd hit) — scope with .v2-root. */
+.v2-root button.v2-aprofile__avatar-button {
+  position: relative;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 50%;
   cursor: pointer;
+  line-height: 0;
 }
-.v2-aprofile__avatar-edit:hover { color: var(--v2-text); border-color: var(--v2-text-secondary); }
+.v2-root button.v2-aprofile__avatar-button:focus-visible {
+  outline: 2px solid var(--v2-accent);
+  outline-offset: 2px;
+}
+.v2-aprofile__avatar-hint {
+  position: absolute;
+  inset: auto 0 0 0;
+  padding: 2px 0 4px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #fff;
+  background: rgba(17, 24, 39, 0.55);
+  border-radius: 0 0 999px 999px;
+  opacity: 0;
+  transition: opacity 120ms ease;
+  pointer-events: none;
+}
+.v2-root button.v2-aprofile__avatar-button:hover .v2-aprofile__avatar-hint,
+.v2-root button.v2-aprofile__avatar-button:focus-visible .v2-aprofile__avatar-hint { opacity: 1; }
+/* Touch devices have no hover: show the hint faintly so the affordance exists. */
+@media (hover: none), (pointer: coarse) {
+  .v2-aprofile__avatar-hint { opacity: 0.75; }
+}
 .v2-aprofile__avatar-dialog {
   position: absolute;
   z-index: 30;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -2762,11 +2762,12 @@ body.modern-ui.v2-canvas {
   color: #1f2937;
   margin-top: 3px;
   word-break: break-word;
-  /* Measure cap — craft audit 2026-08-22 finding 6 (P0): message text ran the
-     full ~1090px content pane (~150 chars/line) against a readable ceiling of
-     ~75. The single largest "rendering not good enough" contributor on the
-     surface users live in. Guarded by v2-layout-invariants. */
-  max-width: 75ch;
+  /* NO measure cap — Sam's THIRD ruling on this (2026-08-24 full-width Slack
+     model; #1367's craft-audit 75ch reverted 2026-09-01 by explicit request:
+     "I still don't like the char limit, looks really bad on desktop").
+     Typographic best practice loses to the product decision here; the
+     invariants test now bans ch-unit max-widths on message content so an
+     audit can't re-litigate this silently. */
 }
 
 .v2-msg__content > *:first-child { margin-top: 0; }


### PR DESCRIPTION
Two Sam taste rulings 2026-09-01: (1) #1367's craft-audit measure cap reverted — full-width stands, worst-case was big screen + collapsed sidebar; invariant now bans ch-unit max-widths in the msg-content block, not just the token. (2) Agent-profile avatar becomes the edit control for owners; separate button removed; a11y kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfkbK