### PR TITLE
feat(team): header CTAs speak the user's model — hire + add a computer

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1626,8 +1626,7 @@
     },
     "actions": {
       "hire": "+ Hire an agent",
-      "connect": "Connect",
-      "connectOwn": "Connect your own agent",
+      "addComputer": "Add a computer",
       "cancel": "Cancel"
     },
     "redeem": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1620,8 +1620,7 @@
     },
     "actions": {
       "hire": "+ 雇佣智能体",
-      "connect": "连接",
-      "connectOwn": "连接你自己的智能体",
+      "addComputer": "添加电脑",
       "cancel": "取消"
     },
     "redeem": {

--- a/frontend/src/v2/__tests__/V2YourTeamTiers.test.tsx
+++ b/frontend/src/v2/__tests__/V2YourTeamTiers.test.tsx
@@ -124,4 +124,15 @@ describe('Your Team tiers', () => {
     // (hosted-smoke internal, excluded).
     expect(screen.getByText('6 agents · 3 active this week')).toBeInTheDocument();
   });
+
+  test('header offers exactly hire + add-a-computer — channels have no CTA here (Sam 2026-09-01)', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Fable')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: '+ Hire an agent' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add a computer' })).toBeInTheDocument();
+    // "Connect" (the channels page) must not sit next to an agent-runtime CTA
+    // — same verb, different concept was the confusion being removed.
+    expect(screen.queryByRole('button', { name: 'Connect' })).toBeNull();
+    expect(screen.queryByText('Connect your own agent')).toBeNull();
+  });
 });

--- a/frontend/src/v2/components/V2YourTeamPage.tsx
+++ b/frontend/src/v2/components/V2YourTeamPage.tsx
@@ -461,14 +461,13 @@ const V2YourTeamPage: React.FC = () => {
                   })}
           </p>
         </div>
+        {/* Sam's 2026-09-01 ruling: two CTAs, user's mental model, not our
+            architecture. Channels ("Connect") live ONLY in the nav rail's
+            Connectors item — "Connect" next to "Connect your own agent" was
+            the same verb for two different concepts. "Add a computer" is the
+            ADR-026 direction: today it opens the where-it-runs flow; when
+            daemon Phase 2 lands it becomes the machine surface. */}
         <div className="v2-team__actions">
-          <button
-            type="button"
-            className="v2-team__byo-cta"
-            onClick={() => navigate('/v2/connect')}
-          >
-            {t('yourTeam.actions.connect')}
-          </button>
           <button
             type="button"
             className="v2-team__hire-cta"
@@ -481,7 +480,7 @@ const V2YourTeamPage: React.FC = () => {
             className="v2-team__byo-cta"
             onClick={() => navigate('/v2/agents/byo')}
           >
-            {t('yourTeam.actions.connectOwn')}
+            {t('yourTeam.actions.addComputer')}
           </button>
         </div>
       </header>
@@ -546,7 +545,7 @@ const V2YourTeamPage: React.FC = () => {
               className="v2-team__byo-cta"
               onClick={() => navigate('/v2/agents/byo')}
             >
-              {t('yourTeam.actions.connectOwn')}
+              {t('yourTeam.actions.addComputer')}
             </button>
           </div>
         </div>


### PR DESCRIPTION
Sam's ruling (2026-09-01): the Your Team header exposed our architecture as three sibling buttons — "Connect" (channels page) next to "Connect your own agent" (runtime page) is the same verb for two different concepts, and on mobile they stack into three ambiguous buttons.

Now two CTAs speaking the user's model:
- **+ Hire an agent** (primary, unchanged)
- **Add a computer** — opens the where-it-runs flow today; becomes the ADR-026 machine surface when daemon Phase 2 lands (machine registration + heartbeat already exist: #1316/#1343)

Channels keep exactly one path: the nav rail's Connectors item. Empty-state CTA renamed to match. Retired `yourTeam.actions.connect`/`connectOwn` locale keys deleted in both locales (zh-CN: 添加电脑); header contract pinned by a new test (hire + add-a-computer present, "Connect"/"Connect your own agent" absent).

No CSS changes — existing button classes reused (the #1305 reset-specificity class needs new classes to bite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTfziSyx2DzuwmibZHHY4s