### PR TITLE
fix(webhooks): await the buffer handler so a rejection releases the claim

### DIFF
--- a/backend/__tests__/unit/routes/telegram.webhook.test.js
+++ b/backend/__tests__/unit/routes/telegram.webhook.test.js
@@ -350,6 +350,56 @@ describe('bridge command surface (/mode /status /mute /help)', () => {
       );
     });
 
+    // The real buffer handler is async and can reject (it awaits a Mongo
+    // write). A synchronous mock here would let an un-awaited
+    // `return events(req, res)` pass — the rejection must reach the catch so
+    // the claim is released and Telegram's redelivery is a retry, not a
+    // duplicate-acked drop.
+    it('releases the claim when the async buffer handler rejects', async () => {
+      const integration = {
+        _id: 'integration-1',
+        type: 'telegram',
+        config: { chatId: '42' },
+      };
+      Integration.findOne = jest.fn().mockResolvedValue(integration);
+      const events = jest.fn(async () => {
+        throw new Error('provider write failed');
+      });
+      registry.get.mockReturnValue({ getWebhookHandlers: () => ({ events }) });
+      const res = await request(app)
+        .post('/api/webhooks/telegram')
+        .send(liveUpdate(6));
+      expect(res.status).toBe(500);
+      expect(events).toHaveBeenCalled();
+      expect(WebhookDelivery.deleteOne).toHaveBeenCalledWith(
+        { provider: 'telegram', deliveryId: '6' },
+      );
+    });
+
+    // Updates with no update_id must bypass the claim entirely: without the
+    // guard they would all claim the literal key 'undefined' — the first one
+    // takes it and every later un-id'd update is acked and dropped.
+    it('processes every update that carries no update_id', async () => {
+      const integration = {
+        _id: 'integration-1',
+        type: 'telegram',
+        podId: 'pod-1',
+        config: { chatId: '42', liveRelay: true },
+      };
+      Integration.findOne = jest.fn().mockResolvedValue(integration);
+      bridge.relayTelegramMessageToPod.mockResolvedValue({});
+      const noIdUpdate = liveUpdate(undefined);
+      delete noIdUpdate.update_id;
+
+      const first = await request(app).post('/api/webhooks/telegram').send(noIdUpdate);
+      const second = await request(app).post('/api/webhooks/telegram').send(noIdUpdate);
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(bridge.relayTelegramMessageToPod).toHaveBeenCalledTimes(2);
+      expect(WebhookDelivery.create).not.toHaveBeenCalled();
+    });
+
     it('a dedup-store outage does not take the bridge down', async () => {
       WebhookDelivery.create.mockRejectedValueOnce(new Error('mongo down'));
       const integration = {

--- a/backend/models/WebhookDelivery.ts
+++ b/backend/models/WebhookDelivery.ts
@@ -17,6 +17,12 @@ import mongoose, { Document, Schema } from 'mongoose';
 //      routes/webhooks/telegram.ts.)
 // The TTL bounds the table: a delivery id only needs to be remembered for as
 // long as the provider keeps redelivering it.
+//
+// Key scope: {provider, deliveryId} assumes ONE id space per provider.
+// Telegram's update_id is sequential per BOT — correct while the route serves
+// a single bot; a second bot on the same route would collide id spaces and
+// drop legitimate updates as duplicates. Widen the key (e.g. include bot id)
+// before multi-bot.
 export interface IWebhookDelivery extends Document {
   provider: string;
   deliveryId: string;

--- a/backend/routes/webhooks/telegram.ts
+++ b/backend/routes/webhooks/telegram.ts
@@ -462,7 +462,10 @@ router.post('/', async (req: any, res: any) => {
 
     const provider = registry.get('telegram', integration);
     const { events } = provider.getWebhookHandlers();
-    return events(req, res);
+    // await, not return: a rejected promise returned from inside `try` escapes
+    // this catch (express 4 won't catch it either), and the claim above would
+    // survive to swallow Telegram's redelivery.
+    return await events(req, res);
   } catch (error) {
     console.error('Telegram webhook error', error);
     // Forget-on-error: the 500 makes Telegram redeliver this update_id; the


### PR DESCRIPTION
Carries @sprint-impl's commit `50629076` — cherry-picked, authorship preserved. Opening it here because **it could not merge from where it was**, which is the thing worth flagging before the gate itself.

## Why this PR exists

`50629076` was pushed onto `fix/telegram-webhook-dedup-ack`, the branch behind #1422. #1422 is **merged and closed**, and pushing to a merged PR's branch neither reopens it nor creates a new one — it only bumps the PR's `updatedAt`, which is what made it look updated at that sha.

Worse, #1422 was **squash**-merged, so `e794b1fc` is not an ancestor of `main`. Their merge-base is `94012454`, from this morning. A PR opened directly from that branch would have shown **276 insertions across 3 files** — replaying all of #1422 on top of the squashed copy already on main — and `git merge-tree` reports it as **conflicting**.

Cherry-picked onto current main it is 60 insertions across 3 files, applies clean, and is exactly the intended delta.

## Gate — PASS

The fix, and the reason it is `await` and not bare `return`:

```ts
// await, not return: a rejected promise returned from inside `try` escapes
// this catch (express 4 won't catch it either), and the claim above would
// survive to swallow Telegram's redelivery.
return await events(req, res);
```

17/17 green on node 22. Mutation-tested rather than trusted, each anchor asserted to have moved:

| Mutation | Result |
|---|---|
| `return await` → `return` (revert the fix) | **killed** |
| remove the claim-side `updateId !== undefined && !== null` guard | **killed** by the new *"processes every update that carries no update_id"* |
| remove the **release-side** `updateId` guard | **survives** |

## One correction to the summary

"Both surviving mutants pinned" is half right. The **claim-side** guard — the load-bearing one, where an un-id'd update would otherwise claim the literal key `'undefined'` and every later one be acked and dropped — is now genuinely pinned. The **release-side** guard is still unpinned.

It is benign, and for a principled reason: because the claim side never claims `'undefined'`, releasing it is a no-op, so removing the guard produces no behavioural difference for a test to catch. It is still *pinnable* — the observable is the wasted call, `expect(WebhookDelivery.deleteOne).not.toHaveBeenCalled()` on the no-id throw path. Worth one line if anyone touches this again; not worth holding the PR.

The key-scope note landed on the model as described, and it names the right condition — `update_id` is sequential per bot, so a second bot on this route would collide id spaces.

## Still outstanding

The deploy prerequisite, which #1444 appears to be taking: `TELEGRAM_SECRET_TOKEN` is still absent from `k8s/`, so verification fail-closes every inbound update until the chart lands and `setWebhook(secret_token=…)` runs.

Supersedes #1429, which I opened for the same one-word fix before this work surfaced; I am closing it — this version pins strictly more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
