### PR TITLE
docs(adr-020): D3's substrate shipped — amend the parenthetical that says it did not

### DIFF
--- a/docs/adr/ADR-020-admin-guide-delegated-authority.md
+++ b/docs/adr/ADR-020-admin-guide-delegated-authority.md
@@ -52,8 +52,20 @@ all (an agent-created pod is owned by the bot, the human isn't even a member); t
 No parallel primitive. v1 implements the ADR-017 lifecycle (`flagged → resolved / expired /
 moot`) with its invariants intact: **only a human writes `resolved`; retiring a card is
 never an approval; fail closed**. Concretely:
-- Messages gain a real structured `payload` (Mongo + PG both — today neither store has a
-  metadata column and every "card" is a regex sentinel in the content string).
+- Messages gain a real structured `payload` (Mongo + PG both). **Shipped (amended
+  2026-09-01) — the parenthetical here used to read "today neither store has a metadata
+  column and every card is a regex sentinel in the content string", and that is no longer
+  true of either store.** `models/Message.ts` declares `MessageType` including `'card'`
+  plus `payload` (`Schema.Types.Mixed`); `models/pg/Message.ts` carries `payload` as JSONB,
+  written by the INSERT and rewritten on status transitions by `updatePayload`. The posting
+  half is live too: `approvalActionService.ts` posts `messageType: 'card'` with
+  `buildCardPayload(row)`, and `resolveApproval` does the authenticated resolve and stamps
+  `decidedAfterExpiry`. **What is NOT built is the chat renderer this bullet implies**:
+  `V2MessageBubble` branches on message type exactly once, for `'image'`, so a card lands in
+  a pod as the plain-text `content` fallback `approvalActionService` sets beside the payload
+  — invisible rather than broken. Scope work off the code, not off this bullet's old tense.
+  (Beware `v2/utils/threadView.ts`'s `kind: 'card'` — an unrelated thread rollup with its
+  own tests, not this card.)
 - Cards are actionable by the workspace owner only; execution is idempotent (a card executes
   at most once — double-taps and concurrent resolves lose cleanly with honest copy).
 - **Expiry is advisory age, not refusal** (amended 2026-08-13, fleet review): per


### PR DESCRIPTION
ADR-020 is `Accepted`, and its D3 bullet describes the structured message `payload` as work not yet done:

> Messages gain a real structured `payload` (Mongo + PG both — today neither store has a metadata column and every "card" is a regex sentinel in the content string).

Measured at `origin/main` `da867f1b`, every clause of that parenthetical is now false.

**Shipped:**
- `backend/models/Message.ts` — `MessageType` includes `'card'`; `payload?: unknown` declared, `payload: { type: Schema.Types.Mixed }` in the schema.
- `backend/models/pg/Message.ts` — `payload` as JSONB, written by the `INSERT` at `:135` and rewritten on card status transitions by `updatePayload` (`:267`).
- `backend/services/approvalActionService.ts` — posts `messageType: 'card'` with `payload: buildCardPayload(row)` (`:317`); `resolveApproval` (`:401`) does the authenticated resolve and stamps `decidedAfterExpiry` (`:434`).

**Not shipped, and this is the half worth naming:** nothing renders the card in chat. `frontend/src/v2/components/V2MessageBubble.tsx` branches on message type exactly once, at `:397`, and only for `'image'`. A D3 card lands in a pod as the plain-text `content` fallback (`"[approval needed] …"`) that `approvalActionService` sets beside the payload — invisible rather than broken, which is why it has gone unnoticed.

So the bullet is wrong in both directions at once: a reader scoping work off it builds a substrate that exists and assumes a renderer that does not. This came up live — TASK-095 (options on decision items) is scoped against exactly this bullet.

The amendment also flags a trap: `frontend/src/v2/utils/threadView.ts:16` declares `kind: 'card'` for thread rollups, unrelated to `messageType: 'card'`, with its own passing tests in `threadView.test.ts` that read like coverage of this feature.

Docs-only, +14/-2, in place in the existing D3 section — same amendment style as the 2026-08-13 expiry correction already in that section, so it does not join the EOF-append queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)