### PR TITLE
fix(activity): include member pods in approval queue

### DIFF
--- a/backend/__tests__/unit/services/activityService.pendingApprovals.test.js
+++ b/backend/__tests__/unit/services/activityService.pendingApprovals.test.js
@@ -1,0 +1,48 @@
+jest.mock('../../../models/Pod', () => ({
+  find: jest.fn(),
+}));
+jest.mock('../../../models/User', () => ({}));
+jest.mock('../../../models/Activity', () => ({
+  getPendingApprovals: jest.fn(),
+}));
+jest.mock('../../../models/Summary', () => ({}));
+jest.mock('../../../models/Post', () => ({}));
+
+const ActivityService = require('../../../services/activityService');
+const Pod = require('../../../models/Pod');
+const Activity = require('../../../models/Activity');
+
+const podFindResult = (rows) => ({
+  select: jest.fn(() => ({
+    lean: jest.fn().mockResolvedValue(rows),
+  })),
+});
+
+describe('ActivityService.getPendingApprovals', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('includes a pod where the user is a member but not its creator', async () => {
+    const userId = 'member-only-user';
+    Pod.find.mockReturnValue(podFindResult([{ _id: 'member-pod' }]));
+    Activity.getPendingApprovals.mockResolvedValue([{ _id: 'approval-1' }]);
+
+    await expect(ActivityService.getPendingApprovals(userId)).resolves.toEqual([
+      { _id: 'approval-1' },
+    ]);
+
+    // Pod.members is an ObjectId[], while a small number of legacy rows use
+    // the embedded-member shape. The queue must accept both, just as the
+    // activity feed does; restricting the latter to an imaginary admin role
+    // hides a decision from the human it is waiting on.
+    expect(Pod.find).toHaveBeenCalledWith({
+      $or: [
+        { createdBy: userId },
+        { 'members.userId': userId },
+        { members: userId },
+      ],
+    });
+    expect(Activity.getPendingApprovals).toHaveBeenCalledWith(['member-pod']);
+  });
+});

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -1362,7 +1362,11 @@ class ActivityService {
       const pods: Array<{ _id: unknown }> = await Pod.find({
         $or: [
           { createdBy: userId },
-          { 'members.userId': userId, 'members.role': 'admin' },
+          // Pod.members is an ObjectId[] (not a role-bearing membership
+          // object). Keep the legacy embedded-member branch for old rows,
+          // but include ordinary members so decisions reach their audience.
+          { 'members.userId': userId },
+          { members: userId },
         ],
       })
         .select('_id')


### PR DESCRIPTION
## Summary
- include ordinary `Pod.members: ObjectId[]` matches when selecting pending approvals
- retain the embedded-member branch used by legacy rows
- add a member-but-not-creator regression test for the decision-queue reader

## Verification
- `npx jest --runInBand __tests__/unit/services/activityService.pendingApprovals.test.js __tests__/unit/services/activityService.decisionQueue.test.js`
- `npm run tsc:check`
- `npm run lint:ts`
- Mutation: restoring the impossible `members.role: admin` predicate fails the new test.