### PR TITLE
fix(activity): remove inert approval-admin predicate

### DIFF
--- a/backend/__tests__/unit/services/activityService.pendingApprovals.test.js
+++ b/backend/__tests__/unit/services/activityService.pendingApprovals.test.js
@@ -1,0 +1,41 @@
+jest.mock('../../../models/Pod', () => ({
+  find: jest.fn(),
+}));
+jest.mock('../../../models/User', () => ({}));
+jest.mock('../../../models/Activity', () => ({
+  getPendingApprovals: jest.fn(),
+}));
+jest.mock('../../../models/Summary', () => ({}));
+jest.mock('../../../models/Post', () => ({}));
+
+const ActivityService = require('../../../services/activityService');
+const Pod = require('../../../models/Pod');
+const Activity = require('../../../models/Activity');
+
+const podFindResult = (rows) => ({
+  select: jest.fn(() => ({
+    lean: jest.fn().mockResolvedValue(rows),
+  })),
+});
+
+describe('ActivityService.getPendingApprovals', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('queries only pods created by the queue owner', async () => {
+    const ownerUserId = 'queue-owner';
+    Pod.find.mockReturnValue(podFindResult([{ _id: 'owner-pod' }]));
+    Activity.getPendingApprovals.mockResolvedValue([{ _id: 'approval-1' }]);
+
+    await expect(ActivityService.getPendingApprovals(ownerUserId)).resolves.toEqual([
+      { _id: 'approval-1' },
+    ]);
+
+    // ADR-020 D3 and TASK-095 v1.4 keep this legacy queue owner-scoped. Do
+    // not reintroduce the removed members.role branch: Pod.members is an
+    // ObjectId[] and has no role-bearing member objects.
+    expect(Pod.find).toHaveBeenCalledWith({ createdBy: ownerUserId });
+    expect(Activity.getPendingApprovals).toHaveBeenCalledWith(['owner-pod']);
+  });
+});

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -1369,10 +1369,10 @@ class ActivityService {
   static async getPendingApprovals(userId: unknown): Promise<unknown[]> {
     try {
       const pods: Array<{ _id: unknown }> = await Pod.find({
-        $or: [
-          { createdBy: userId },
-          { 'members.userId': userId, 'members.role': 'admin' },
-        ],
+        // Pod.members is an ObjectId[] with no role field. This owner lookup
+        // replaces the inert members.role branch, which implied a nonexistent
+        // admin audience for pending approvals.
+        createdBy: userId,
       })
         .select('_id')
         .lean();


### PR DESCRIPTION
## Summary
- remove the impossible role-bearing `Pod.members` query from the legacy Activity pending-approval reader
- preserve its explicit `createdBy` lookup
- pin the owner-only query so the dead admin audience cannot return

`Pod.members` is `ObjectId[]`; it has no `userId` or `role` fields. This is maintenance on the old Activity approval reader only. TASK-095 v1.5 correctly derives its decision queue from `ApprovalAction`, not this Activity path; this PR does not couple the two stores or address #1452.

## Verification
- `npx jest --runInBand __tests__/unit/services/activityService.pendingApprovals.test.js`
- `npm run tsc:check`
- `npm run lint:ts`

Mutation: restoring the former `$or` predicate makes the new assertion fail.