### PR TITLE
feat(cli): cue memory at fresh session boundaries

### DIFF
--- a/cli/__tests__/adapters.claude.test.mjs
+++ b/cli/__tests__/adapters.claude.test.mjs
@@ -148,6 +148,9 @@ describe('claude adapter — spawn()', () => {
     // Second attempt used --session-id with a FRESH UUID (not the stale one)
     expect(calls[1].args).toContain('--session-id');
     expect(calls[1].args).not.toContain('abc-123');
+    // Recovery creates an underlying session, so it must receive the same
+    // fresh-session memory cues as an initial spawn.
+    expect(calls[1].args[1]).toContain('=== Fresh session ===');
     // newSessionId returned is the fresh one so the wrapper persists it next turn
     expect(res.newSessionId).not.toBe('abc-123');
     expect(res.newSessionId).toMatch(/^[0-9a-f]{8}-/);
@@ -176,6 +179,21 @@ describe('claude adapter — spawn()', () => {
     expect(promptArg).toContain('I remember the user prefers dark mode.');
     expect(promptArg).toContain('=== Current turn ===');
     expect(promptArg).toContain('current message');
+    expect(promptArg).not.toContain('=== Fresh session ===');
+  });
+
+  test('a fresh Claude session receives read-first and durable-state cues', async () => {
+    const { impl, calls } = makeSpawnImpl({ stdout: 'ok' });
+    await claude.spawn('current message', {
+      memoryLongTerm: 'open gate: #123',
+      _spawnImpl: impl,
+    });
+
+    const promptArg = calls[0].args[1];
+    expect(promptArg).toContain('=== Fresh session ===');
+    expect(promptArg).toMatch(/Read the persistent memory context above before acting/i);
+    expect(promptArg).toMatch(/At a natural end to meaningful work/i);
+    expect(promptArg).toContain("section: 'long_term'");
   });
 
   // Replaces an assertion that empty memory passed the prompt verbatim. That

--- a/cli/__tests__/adapters.codex.test.mjs
+++ b/cli/__tests__/adapters.codex.test.mjs
@@ -138,9 +138,12 @@ describe('codex adapter — spawn()', () => {
     expect(calls[0].args).toContain('--skip-git-repo-check');
     expect(calls[0].args).toContain('-o');
     // The invariant is that the prompt occupies the FINAL slot, not that it is
-    // byte-identical: empty memory now carries the empty-memory cue, which
-    // prepends. Anchored to the end so a stray arg still fails this.
-    expect(calls[0].args[calls[0].args.length - 1]).toMatch(/hi$/);
+    // The prompt remains the final argv item. Fresh sessions now also append
+    // the durable-state reminder after the current turn, so pin the turn's
+    // position inside that one prompt rather than falsely requiring it to be
+    // the prompt's final bytes.
+    expect(calls[0].args[calls[0].args.length - 1])
+      .toContain('=== Current turn ===\nhi\n=== Before this session ends ===');
   });
 
   test('environment.mcp servers become -c mcp_servers.* overrides with substituted token/env', async () => {
@@ -190,7 +193,8 @@ describe('codex adapter — spawn()', () => {
     expect(calls[0].opts.env.COMMONLY_AGENT_TOKEN).toBe('cm_agent_secret');
     // Overrides must precede the prompt (last arg) and not disturb -o pairing.
     expect(findOutputFile(args)).toBeTruthy();
-    expect(args[args.length - 1]).toMatch(/hi$/);
+    expect(args[args.length - 1])
+      .toContain('=== Current turn ===\nhi\n=== Before this session ends ===');
   });
 
   test('public workspace mode uses a deny-by-default permission profile and never the legacy sandbox or bypass', async () => {
@@ -365,6 +369,24 @@ describe('codex adapter — spawn()', () => {
     expect(promptArg).toContain('I remember the user prefers dark mode.');
     expect(promptArg).toContain('=== Current turn ===');
     expect(promptArg).toContain('current message');
+    expect(promptArg).toContain('=== Fresh session ===');
+    expect(promptArg).toMatch(/Read the persistent memory context above before acting/i);
+    expect(promptArg).toMatch(/At a natural end to meaningful work/i);
+    expect(promptArg).toContain("section: 'long_term'");
+  });
+
+  test('a resumed Codex session does not repeat fresh-session cues', async () => {
+    const { impl, calls } = makeSpawnImpl({
+      stdoutChunks: ['{"type":"thread.started","thread_id":"sid-1"}\n'],
+      outputContents: 'ok',
+    });
+    await codex.spawn('current message', {
+      sessionId: 'sid-1',
+      memoryLongTerm: 'open gate: #123',
+      _spawnImpl: impl,
+    });
+
+    expect(calls[0].args[calls[0].args.length - 1]).not.toContain('=== Fresh session ===');
   });
 
   // Same swap as the claude adapter: both delegate to `buildMemoryPreamble`, so

--- a/cli/__tests__/memory-bridge.test.mjs
+++ b/cli/__tests__/memory-bridge.test.mjs
@@ -178,6 +178,26 @@ describe('buildMemoryPreamble', () => {
     expect(empty).toMatch(/section:\s*'long_term'/);
   });
 
+  it('adds read-first and save-at-natural-boundary cues only for a fresh session', () => {
+    const fresh = buildMemoryPreamble('turn', 'prior gate: waiting', { freshSession: true });
+    const resumed = buildMemoryPreamble('turn', 'prior gate: waiting');
+
+    expect(fresh).toContain('=== Fresh session ===');
+    expect(fresh).toMatch(/Read the persistent memory context above before acting/i);
+    expect(fresh).toMatch(/At a natural end to meaningful work/i);
+    expect(fresh).toContain('gates held, decisions pending, and task context, not a transcript');
+    expect(fresh).toMatch(/section:\s*'long_term'/);
+    expect(resumed).not.toContain('=== Fresh session ===');
+    expect(resumed).not.toMatch(/At a natural end to meaningful work/i);
+    expect(fresh.indexOf('=== Current turn ===')).toBeLessThan(fresh.indexOf('=== Before this session ends ==='));
+  });
+
+  it('does not duplicate the write call when an empty fresh session already carries it', () => {
+    const fresh = buildMemoryPreamble('turn', '', { freshSession: true });
+    expect(fresh.match(/commonly_save_my_memory/g)).toHaveLength(1);
+    expect(fresh).toMatch(/using the long_term write above/i);
+  });
+
   it.each([undefined, ''])('treats %p as empty', (value) => {
     expect(buildMemoryPreamble('turn', value)).toContain('(empty');
   });
@@ -198,5 +218,12 @@ describe('buildMemoryPreamble', () => {
   // overwrite state it still holds.
   it('does not prompt a write on the unreadable path', () => {
     expect(buildMemoryPreamble('turn', null)).not.toContain('commonly_save_my_memory');
+  });
+
+  it('does not prompt a replacement write on an unreadable fresh session', () => {
+    const fresh = buildMemoryPreamble('turn', null, { freshSession: true });
+    expect(fresh).toContain('=== Fresh session ===');
+    expect(fresh).toMatch(/Do not treat it as empty or write a replacement/i);
+    expect(fresh).not.toContain('commonly_save_my_memory');
   });
 });

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "license": "Apache-2.0",
   "description": "The Commonly CLI \u2014 connect agents, manage pods, iterate fast",
   "type": "module",

--- a/cli/src/lib/adapters/claude.js
+++ b/cli/src/lib/adapters/claude.js
@@ -3,8 +3,9 @@
  *
  * Contract: ADR-005 §Adapter pattern.
  *
- * Memory preamble: if ctx.memoryLongTerm is non-empty, the adapter prepends
- * it to the prompt as a system-context preamble (§Memory bridge).
+ * Memory preamble: the adapter prepends the kernel's long-term memory context
+ * on every turn. A fresh underlying session additionally receives the
+ * read-first and durable-state-at-boundary cues (§Memory bridge).
  *
  * Environment (ADR-008 Phase 1): if ctx.environment is present, the adapter
  * symlinks declared Claude skills into `<cwd>/.claude/skills/`, writes an MCP
@@ -476,7 +477,7 @@ export default {
     // the only two paths that build a real prompt. buildPrompt handles
     // undefined and '' as absence itself; it does not need a guard, it needs
     // the value.
-    const fullPrompt = buildPrompt(prompt, ctx.memoryLongTerm);
+    const fullPrompt = buildPrompt(prompt, ctx.memoryLongTerm, { freshSession: !isResume });
     const sessionFlag = isResume ? '--resume' : '--session-id';
     // Model pin from the ADR-008 environment spec. Absent it, claude picks its
     // own default — which is how a fleet of ten agents ended up running three
@@ -544,7 +545,11 @@ export default {
       // session id poisons every subsequent event re-delivery.
       if (isResume && /already in use|no conversation|no session/i.test(String(err.message))) {
         const freshId = randomUUID();
-        const retryBase = ['-p', fullPrompt, '--output-format', 'text', '--session-id', freshId, ...modelArgs];
+        // The retry creates a new underlying CLI session. Rebuild its prompt
+        // as fresh too: otherwise a session-recovery path is the one fresh
+        // session that misses the durable-state cue.
+        const freshPrompt = buildPrompt(prompt, ctx.memoryLongTerm, { freshSession: true });
+        const retryBase = ['-p', freshPrompt, '--output-format', 'text', '--session-id', freshId, ...modelArgs];
         const retry = await prepareArgv(retryBase, {
           ...ctx,
           mcpConfigPath: mcpConfig?.file || null,

--- a/cli/src/lib/adapters/codex.js
+++ b/cli/src/lib/adapters/codex.js
@@ -20,10 +20,10 @@
  * `--output-last-message` short alias) — cleaner than parsing every
  * event-type variant the model can emit.
  *
- * Memory preamble: if ctx.memoryLongTerm is non-empty, the adapter prepends
- * it to the prompt as a system-context preamble (§Memory bridge), matching
- * the claude adapter's shape so the run loop's per-event memory plumbing
- * works identically across drivers.
+ * Memory preamble: the adapter prepends the kernel's long-term memory context
+ * on every turn. A fresh underlying session additionally receives the
+ * read-first and durable-state-at-boundary cues, matching the Claude adapter
+ * so the run loop's memory plumbing works identically across drivers.
  *
  * Purity (§Load-bearing invariants #1): input = argv + env + prompt;
  * output = text + session id. No direct network, no direct CAP calls.
@@ -421,7 +421,9 @@ export default {
     // the only two paths that build a real prompt. buildPrompt handles
     // undefined and '' as absence itself; it does not need a guard, it needs
     // the value.
-    const fullPrompt = buildPrompt(prompt, ctx.memoryLongTerm);
+    const fullPrompt = buildPrompt(prompt, ctx.memoryLongTerm, {
+      freshSession: !ctx.sessionId,
+    });
 
     // Per-spawn temp dir for --output-last-message. Cleaned up in `finally`
     // so a crash in the middle of the spawn doesn't leak files in $TMPDIR.

--- a/cli/src/lib/memory-bridge.js
+++ b/cli/src/lib/memory-bridge.js
@@ -39,29 +39,54 @@ export const SOURCE_RUNTIME = 'local-cli';
  * and is never seen again; the write and the silence are indistinguishable from
  * a correct round trip. Naming the section is the whole point of the cue.
  */
-export const buildMemoryPreamble = (prompt, memoryLongTerm) => {
+export const buildMemoryPreamble = (prompt, memoryLongTerm, { freshSession = false } = {}) => {
   // `null` is the UNREADABLE signal, and it is deliberately not the same value
   // as `''`. Telling a seat whose token was revoked that "nothing has ever been
   // saved here" is a false claim about its own history, and it is the same
   // defect this cue exists to fix — one state over. When we could not read, say
   // that, and say nothing about what is stored.
+  let context;
   if (memoryLongTerm === null) {
-    return `=== Context (your persistent memory) ===\n`
+    context = `=== Context (your persistent memory) ===\n`
       + `(unreadable this turn — the memory read failed, so this says NOTHING `
       + `about what you have saved. Do not treat it as empty and do not re-save `
-      + `state you may already hold.)\n`
-      + `=== Current turn ===\n${prompt}`;
+      + `state you may already hold.)`;
+  } else if (memoryLongTerm) {
+    context = `=== Context (your persistent memory) ===\n${memoryLongTerm}`;
+  } else {
+    context = `=== Context (your persistent memory) ===\n`
+      + `(empty — nothing has ever been saved here)\n`
+      + `Only the \`long_term\` section is read back into this prompt. To make `
+      + `something survive your next session, call commonly_save_my_memory({ `
+      + `section: 'long_term', content: '...' }). A write to any other section `
+      + `succeeds and is never shown to you again.`;
   }
-  if (memoryLongTerm) {
-    return `=== Context (your persistent memory) ===\n${memoryLongTerm}\n=== Current turn ===\n${prompt}`;
+
+  if (!freshSession) return `${context}\n=== Current turn ===\n${prompt}`;
+
+  // This belongs on a fresh underlying CLI session, rather than every turn:
+  // a resumed session already carries the earlier instruction in its own
+  // transcript. Repeating it on each wake spends prompt budget while making
+  // the cue easier to ignore. The wrapper cannot know the final event of a
+  // session in advance, so it gives the end-of-session reminder while the
+  // agent can still act on it.
+  const freshReadCue = '=== Fresh session ===\n'
+    + 'This is a fresh session. Read the persistent memory context above before acting; '
+    + 'it carries durable state from prior sessions.\n';
+  let sessionEndCue = '=== Before this session ends ===\n';
+  if (memoryLongTerm === null) {
+    sessionEndCue += 'Memory was unreadable on this fresh session. Do not treat it as empty or '
+      + 'write a replacement based on this cue.';
+  } else if (memoryLongTerm) {
+    sessionEndCue += 'At a natural end to meaningful work, save durable working state — '
+      + 'gates held, decisions pending, and task context, not a transcript — with '
+      + "commonly_save_my_memory({ section: 'long_term', content: '...' }).";
+  } else {
+    sessionEndCue += 'At a natural end to meaningful work, save durable working state — '
+      + 'gates held, decisions pending, and task context, not a transcript — using '
+      + 'the long_term write above.';
   }
-  return `=== Context (your persistent memory) ===\n`
-    + `(empty — nothing has ever been saved here)\n`
-    + `Only the \`long_term\` section is read back into this prompt. To make `
-    + `something survive your next session, call commonly_save_my_memory({ `
-    + `section: 'long_term', content: '...' }). A write to any other section `
-    + `succeeds and is never shown to you again.\n`
-    + `=== Current turn ===\n${prompt}`;
+  return `${context}\n${freshReadCue}\n=== Current turn ===\n${prompt}\n${sessionEndCue}`;
 };
 
 export const readLongTerm = async (client, { onError } = {}) => {


### PR DESCRIPTION
## Summary
- add a fresh-session read-first cue before the current turn and a durable-state reminder after it
- keep resumed-session prompts byte-for-byte unchanged; Claude session-recovery retries are fresh and receive both cues
- retain the existing empty/unreadable safeguards, so an unreadable memory response never prompts a replacement write
- bump `@commonlyai/cli` to `0.1.29`

Implements the remaining CLI scope from TASK-076’s 2026-08-28 re-point: cue a fresh session to read memory first and preserve durable working state at a natural boundary. No automatic transcript-to-memory write is introduced.

## Verification
- `cd cli && npm run lint`
- `cd cli && npm test -- --runInBand` — 28 suites, 394 passed, 10 skipped
- mutation: bypassing the fresh-session branch made 6 assertions fail across the bridge and both adapters; restored code passes
- `git diff --check`