### PR TITLE
fix(helm): pin LLMSERVICE_GUARDRAILS=injection-guard — the moderation guardrail 401'd every llmService call

### DIFF
--- a/k8s/helm/commonly/templates/core/backend-deployment.yaml
+++ b/k8s/helm/commonly/templates/core/backend-deployment.yaml
@@ -418,6 +418,14 @@ spec:
               optional: true
         - name: LITELLM_BASE_URL
           value: "http://litellm:4000"
+        # injection-guard only (Sam, 2026-09-01): openai-moderation-enforce
+        # carries a PLACEHOLDER OpenAI key in litellm and 401s EVERY
+        # platform llmService call — summaries emitted the hardcoded
+        # template since the guardrail shipped. Fail-closed proved the
+        # guardrail wiring works; restore moderation only WITH a real
+        # key (see the Sharpen board task).
+        - name: LLMSERVICE_GUARDRAILS
+          value: "injection-guard"
         - name: LITELLM_CHAT_MODEL
           # deepseek-v4-flash (Sam, 2026-09-01): summary quality on
           # gpt-5.4-mini was "no good info at all"; the DeepSeek flash


### PR DESCRIPTION
Root cause of 'summaries reveal no good info': openai-moderation-enforce carries a placeholder OpenAI key in litellm, 401s every platform LLM call, generateText fails closed, dead-Gemini fallback 401s too, hardcoded template ships. Applied live via the designed env off-switch; this pins it through helm so the next deploy keeps it. Moderation restore (with a real key) tracked on the Sharpen board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdEJoXUmbHmW5TFk7hfbK