### PR TITLE
docs(adr): renumber the ADR-018 identity stub to ADR-030

### DIFF
--- a/docs/adr/ADR-028-work-claims-and-decision-ledger.md
+++ b/docs/adr/ADR-028-work-claims-and-decision-ledger.md
@@ -94,10 +94,12 @@ This fleet has produced the evidence unprompted, in the repo, this week:
   surface #1234 had had open since 2026-08-25. Neither PR conflicted with the other — one inserts
   mid-file, one appends at EOF — so nothing went red to tell the reviewer that two entries covered
   one surface.
-- **`main` has carried two files named `ADR-018` for 22 days.** `ADR-018-agent-identity.md` (merged
+- **`main` carried two files named `ADR-018` for 22 days.** `ADR-018-agent-identity.md` (merged
   2026-08-04) and `ADR-018-agent-attention-claims.md` (merged 2026-08-11). Disjoint filenames share
   no text to conflict on, and `docs/adr/` has no index, so the collision is invisible by
-  construction.
+  construction. The stub is renumbered to ADR-030 in the same change that carries this sentence; the
+  finding stands, because nothing detected the collision for 22 days and a third instance (ADR-025)
+  arrived before it was resolved.
 - **A conflict resolution was silently discarded, twice in one hour.** #1291 was rebased out from
   under an EOF merge resolution; the only symptom was the PR going `DIRTY` again. Nothing names the
   lost work, because nothing recorded that the work existed.

--- a/docs/adr/ADR-030-agent-identity.md
+++ b/docs/adr/ADR-030-agent-identity.md
@@ -1,7 +1,11 @@
-# ADR-018 — Agent identity
+# ADR-030 — Agent identity
 
 **Status:** Proposed (stub — decision not yet made)
 **Date opened:** 2026-08-01
+**Renumbered:** 2026-09-01, from ADR-018. `main` carried two files at that number for 22 days
+(this one and `ADR-018-agent-attention-claims.md`, Accepted 2026-08-17). This document declares no
+D-numbered decisions, so every `ADR-018 D<n>` citation in the repo already resolves to
+attention-claims; moving this file breaks none of them.
 
 ## Why this is open
 


### PR DESCRIPTION
`main` has carried **two** files named ADR-018 since 2026-08-11:

- `ADR-018-agent-identity.md` — Proposed stub, merged 08-04 via #790
- `ADR-018-agent-attention-claims.md` — Accepted 08-17, merged 08-11 via #889

Disjoint filenames share no text to conflict on, and `docs/adr/` has no index, so nothing went red and nothing could. This is the same class as the ADR-025 pair now arriving on #1295, and #1142 / #1424.

## Which file moves is determined, not chosen

The stub declares **zero** `D<n>` tokens — its headings are "Why this is open" / "The shape of the decision" / "Open questions" / "Deliberately not decided here" / "Not yet decided". Verified at `f1e7a92c`:

```
$ git show origin/main:docs/adr/ADR-018-agent-identity.md | grep -coE '\bD[0-9]+\b'
0
```

So every `ADR-018 D<n>` citation in the repo — including the four in `agentMentionService.ts` and the three in `CLAUDE.md` — can only mean attention-claims. Renaming the stub breaks none of them and disambiguates the rest. Renaming attention-claims instead would break all of them.

## Scope

Exactly one reference names the stub by **filename** anywhere on main — ADR-028's evidence bullet, which cites the duplicate as a missing-record finding. It is updated in place: the finding stands (nothing detected the collision for 22 days, and a third instance arrived before it was resolved), and the tense is corrected.

`030` is free against both populations — main carries 001–028, open PRs claim 017/020/024/025. `029` is deliberately left for the Connections ADR.

## Why now

@sprint-review has a duplicate-number guard written (globs `docs/adr/`, groups by number, fails naming both files) and is holding it because it goes red on main today for exactly this pair. That is the whole blocker, and it is a one-file rename rather than a governance call. This is the cheapest form of the question — press it or close it.

Docs-only. After the rename, `ls docs/adr/ | grep -oE '^ADR-[0-9]+' | sort | uniq -d` returns empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)