### PR TITLE
feat(activity): thread-aware mention queue + reply in place

### DIFF
--- a/backend/__tests__/unit/services/activityService.decisionQueue.test.js
+++ b/backend/__tests__/unit/services/activityService.decisionQueue.test.js
@@ -21,6 +21,7 @@ jest.mock('../../../models/User', () => ({
   find: jest.fn(),
   findById: jest.fn(),
 }));
+jest.mock('../../../config/db-pg', () => ({ pool: { query: jest.fn().mockResolvedValue({ rows: [] }) } }));
 jest.mock('../../../models/Activity', () => ({}));
 jest.mock('../../../models/Summary', () => ({}));
 jest.mock('../../../models/Post', () => ({}));
@@ -28,6 +29,10 @@ jest.mock('../../../models/Post', () => ({}));
 const ActivityService = require('../../../services/activityService');
 const Pod = require('../../../models/Pod');
 const Task = require('../../../models/Task');
+const User = require('../../../models/User');
+const { pool } = require('../../../config/db-pg');
+
+const userChain = (doc) => ({ select: () => ({ lean: async () => doc }) });
 
 const POD = { _id: 'pod-1', name: 'Sprint HQ', type: 'team' };
 
@@ -42,6 +47,8 @@ describe('ActivityService.getDecisionQueue', () => {
     jest.spyOn(ActivityService, 'getPendingApprovals').mockResolvedValue([]);
     jest.spyOn(ActivityService, 'getUserFeed').mockResolvedValue({ activities: [], acknowledgedMentionIds: [] });
     Task.find.mockReturnValue(taskChain([]));
+    User.findById.mockReturnValue(userChain({ username: 'Sam', activityQueue: { acknowledgedMentionIds: [] } }));
+    pool.query.mockResolvedValue({ rows: [] });
   });
 
   test('a DECIDE-titled open row and a blocked row are decisions; a human-handoff update is a press', async () => {
@@ -101,13 +108,10 @@ describe('ActivityService.getDecisionQueue', () => {
     ActivityService.getPendingApprovals.mockResolvedValue([
       { _id: 'act-1', content: 'approve?', podId: 'pod-1', createdAt: new Date('2026-08-20T00:00:00Z') },
     ]);
-    ActivityService.getUserFeed.mockResolvedValue({
-      activities: [{
-        id: 'm-1', flags: { isMention: true }, actor: { name: 'anvil' }, preview: 'ping',
-        pod: { id: 'pod-1', name: 'Sprint HQ' }, timestamp: '2026-08-27T00:00:00.000Z',
-      }],
-      acknowledgedMentionIds: [],
-    });
+    pool.query.mockResolvedValue({ rows: [{
+      id: 501, pod_id: 'pod-1', user_id: 'bot-1', content: '@Sam ping', created_at: new Date('2026-08-27T00:00:00Z'),
+      thread_root_id: 480, author: 'anvil',
+    }] });
     const rows = [];
     for (let i = 0; i < 13; i += 1) {
       rows.push({
@@ -130,6 +134,27 @@ describe('ActivityService.getDecisionQueue', () => {
     expect(result.items[1].kind).toBe('press');
     expect(result.items[2].kind).toBe('mention');
     expect(result.items[3].kind).toBe('decision');
+  });
+
+  test('mentions come from a dedicated thread-aware query: acked rows drop, reply coordinates ride along', async () => {
+    // Sam, 2026-09-01: 15 @Sam mentions in 36h, 14 inside threads, feed saw
+    // zero. The queue asks the store directly and keeps the thread root so
+    // the tab can reply IN the thread.
+    User.findById.mockReturnValue(userChain({ username: 'Sam', activityQueue: { acknowledgedMentionIds: ['msg_7'] } }));
+    pool.query.mockResolvedValue({ rows: [
+      { id: 9, pod_id: 'pod-1', user_id: 'bot-1', content: '@Sam in a thread', created_at: new Date(), thread_root_id: 4, author: 'vale' },
+      { id: 7, pod_id: 'pod-1', user_id: 'bot-2', content: '@Sam already handled', created_at: new Date(), thread_root_id: null, author: 'juno' },
+      { id: 5, pod_id: 'pod-1', user_id: 'bot-3', content: '@Sam top-level', created_at: new Date(), thread_root_id: null, author: 'kai' },
+    ] });
+    const result = await ActivityService.getDecisionQueue('u1');
+    const mentions = result.items.filter((i) => i.kind === 'mention');
+    expect(mentions.map((m) => m.id)).toEqual(['msg_9', 'msg_5']);
+    expect(mentions[0]).toMatchObject({ threadRootId: 4, messageId: 9, title: 'vale mentioned you' });
+    // A top-level mention is its own thread root.
+    expect(mentions[1]).toMatchObject({ threadRootId: 5, messageId: 5 });
+    const [sql, params] = pool.query.mock.calls[0];
+    expect(sql).toMatch(/ANY\(\$1::text\[\]\)/);
+    expect(params[2]).toBe('@Sam(?![A-Za-z0-9_])');
   });
 
   test('one failed source degrades, never blanks the queue', async () => {

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -444,6 +444,49 @@ class ActivityService {
    * latest update hands off to a human press/ruling. No inference, no
    * name-matching heuristics (TASK-070b stays open by design).
    */
+  /**
+   * Every message in the user's pods that @mentions them, threads included,
+   * minus their own and minus acknowledged ones. Ids are `msg_<pg id>` —
+   * the same shape the feed emits, so acknowledgedMentionIds keeps working.
+   */
+  static async getMentionsForUser(userId: unknown, podIds: unknown[]): Promise<Array<{
+    id: string; messageId: number; threadRootId: number; podId: string;
+    authorName: string; content: string; createdAt: Date;
+  }>> {
+    const user = await (User as {
+      findById(id: unknown): { select(f: string): { lean(): Promise<{ username?: string; activityQueue?: { acknowledgedMentionIds?: unknown[] } } | null> } };
+    }).findById(userId).select('username activityQueue.acknowledgedMentionIds').lean();
+    const username = String(user?.username || '').trim();
+    if (!username || !podIds.length) return [];
+    const acked = new Set(((user?.activityQueue?.acknowledgedMentionIds as unknown[]) || []).map(String));
+    const { pool } = require('../config/db-pg') as { pool: { query(q: string, p: unknown[]): Promise<{ rows: Array<Record<string, unknown>> }> } };
+    // ILIKE on the handle; the trailing boundary keeps @sam from matching
+    // @samantha. ::text[] is load-bearing (the rank query lesson, #1307).
+    const { rows } = await pool.query(
+      `SELECT m.id, m.pod_id, m.user_id, m.content, m.created_at, m.thread_root_id, u.username AS author
+         FROM messages m
+         LEFT JOIN users u ON u._id = m.user_id
+        WHERE m.pod_id = ANY($1::text[])
+          AND m.user_id <> $2
+          AND m.created_at > now() - interval '7 days'
+          AND m.content ~* $3
+        ORDER BY m.created_at DESC
+        LIMIT 40`,
+      [podIds.map(String), String(userId), `@${username.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![A-Za-z0-9_])`],
+    );
+    return rows
+      .map((r) => ({
+        id: `msg_${r.id}`,
+        messageId: Number(r.id),
+        threadRootId: Number(r.thread_root_id || r.id),
+        podId: String(r.pod_id),
+        authorName: String(r.author || 'Someone'),
+        content: String(r.content || ''),
+        createdAt: r.created_at as Date,
+      }))
+      .filter((m) => !acked.has(m.id));
+  }
+
   static async getDecisionQueue(userId: unknown): Promise<Record<string, unknown>> {
     const pods: PodDoc[] = await Pod.find({
       $or: [
@@ -490,20 +533,28 @@ class ActivityService {
       console.warn('[decision-queue] approvals read failed:', (err as Error).message);
     }
 
-    // 2. Unacknowledged direct mentions, from the feed's existing flags.
+    // 2. Unacknowledged direct mentions — a DEDICATED query, not the feed.
+    // Sam, 2026-09-01: "pods mentioning me… but activity tab is not showing
+    // properly." Measured: 15 @Sam mentions in 36h, 14 inside THREADS, and
+    // the feed path saw zero — it samples ~20 recent rows per pod through
+    // the generic aggregator, so thread traffic (where agents now do most
+    // of their talking) never reaches the mention flag. The mention query
+    // asks the store the actual question, across every pod, threads
+    // included, for the last 7 days.
     try {
-      const feed = await ActivityService.getUserFeed(userId, { limit: 60, filter: 'mentions' });
-      const acked = new Set(((feed.acknowledgedMentionIds as unknown[]) || []).map(String));
-      for (const a of ((feed.activities as ActivityItem[]) || [])) {
-        if (!a.flags?.isMention || acked.has(String(a.id))) continue;
+      const mentions = await ActivityService.getMentionsForUser(userId, podIds);
+      for (const m of mentions) {
         items.push({
           kind: 'mention',
-          id: String(a.id),
-          title: `${a.actor?.name || 'Someone'} mentioned you`,
-          detail: String(a.preview || a.content || '').slice(0, 160),
-          podId: a.pod?.id || null,
-          podName: a.pod?.name,
-          createdAt: (a.timestamp as Date) || null,
+          id: m.id,
+          title: `${m.authorName} mentioned you`,
+          detail: m.content.slice(0, 220),
+          podId: m.podId,
+          podName: podName.get(m.podId),
+          createdAt: m.createdAt,
+          // Reply-in-place needs the thread root (or the message itself, as
+          // the root of a new thread) and the message to address.
+          ...({ threadRootId: m.threadRootId, messageId: m.messageId } as Record<string, unknown>),
         });
       }
     } catch (err) {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -39,6 +39,12 @@
     "loadFailed": "Activity could not be loaded. Try again.",
     "openThread": "Open thread",
     "openBoard": "Open board",
+    "reply": {
+      "placeholder": "Reply in thread…",
+      "send": "Send",
+      "working": "Sending…",
+      "sent": "Reply posted"
+    },
     "lastActive": "Active {{time}} ago",
     "updatesCount_one": "{{count}} update",
     "updatesCount_other": "{{count}} updates",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -39,6 +39,12 @@
     "loadFailed": "无法加载动态，请重试。",
     "openThread": "打开讨论",
     "openBoard": "打开看板",
+    "reply": {
+      "placeholder": "在话题中回复…",
+      "send": "发送",
+      "working": "发送中…",
+      "sent": "已回复"
+    },
     "lastActive": "{{time}}前活跃",
     "updatesCount_one": "{{count}} 条更新",
     "updatesCount_other": "{{count}} 条更新",

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -37,6 +37,9 @@ interface NeedsYouItem {
   podName: string;
   taskId?: string;
   timestamp: string | null;
+  // Mention rows carry where they live so a reply can land IN the thread.
+  messageId?: number;
+  threadRootId?: number;
 }
 
 interface BoardItem {
@@ -164,6 +167,37 @@ const V2ActivityPage: React.FC = () => {
       setActionError(t('activity.approval.actionFailed'));
     } finally {
       setActingApprovalId(null);
+    }
+  };
+
+  // Reply-in-place (Sam, 2026-09-01: "a way to really work with these agents
+  // more easily… and tell them what is on my mind"). The reply posts into
+  // the SAME thread the mention came from, addressed to the message, through
+  // the ordinary messages route — so the agent gets the normal implicit-reply
+  // wake — and then the mention is acknowledged.
+  const [replyDrafts, setReplyDrafts] = useState<Record<string, string>>({});
+  const [replyingId, setReplyingId] = useState<string | null>(null);
+  const [repliedIds, setRepliedIds] = useState<Set<string>>(new Set());
+  const sendReply = async (item: NeedsYouItem) => {
+    const content = (replyDrafts[item.id] || '').trim();
+    if (!content || replyingId || !item.podId) return;
+    setReplyingId(item.id);
+    setActionError(null);
+    try {
+      const token = localStorage.getItem('token');
+      await axios.post(
+        `/api/messages/${item.podId}`,
+        { content, threadRootId: item.threadRootId, replyToMessageId: item.messageId },
+        { headers: { 'x-auth-token': token ?? '' } },
+      );
+      setRepliedIds((prev) => new Set(prev).add(item.id));
+      setReplyDrafts((prev) => ({ ...prev, [item.id]: '' }));
+      await axios.post(`/api/activity/${item.id}/acknowledge`, {}, { headers: { 'x-auth-token': token ?? '' } }).catch(() => null);
+      setReloadKey((value) => value + 1);
+    } catch {
+      setActionError(t('activity.mention.actionFailed'));
+    } finally {
+      setReplyingId(null);
     }
   };
 
@@ -309,9 +343,29 @@ const V2ActivityPage: React.FC = () => {
                         </>
                       )}
                       {item.kind === 'mention' && (
-                        <button type="button" onClick={() => acknowledgeMention(item)} disabled={acknowledgingMentionId === item.id}>
-                          {acknowledgingMentionId === item.id ? t('activity.mention.working') : t('activity.mention.acknowledge')}
-                        </button>
+                        <>
+                          <div className="v2-activity__reply" data-testid="queue-reply">
+                            <textarea
+                              className="v2-activity__reply-input"
+                              rows={2}
+                              placeholder={t('activity.reply.placeholder')}
+                              value={replyDrafts[item.id] || ''}
+                              onChange={(e) => setReplyDrafts((prev) => ({ ...prev, [item.id]: e.target.value }))}
+                              onKeyDown={(e) => { if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') sendReply(item); }}
+                              disabled={replyingId === item.id}
+                            />
+                            <button
+                              type="button"
+                              onClick={() => sendReply(item)}
+                              disabled={replyingId === item.id || !(replyDrafts[item.id] || '').trim()}
+                            >
+                              {replyingId === item.id ? t('activity.reply.working') : repliedIds.has(item.id) ? t('activity.reply.sent') : t('activity.reply.send')}
+                            </button>
+                          </div>
+                          <button type="button" className="v2-activity__queue-action--secondary" onClick={() => acknowledgeMention(item)} disabled={acknowledgingMentionId === item.id}>
+                            {acknowledgingMentionId === item.id ? t('activity.mention.working') : t('activity.mention.acknowledge')}
+                          </button>
+                        </>
                       )}
                       {(item.kind === 'decision' || item.kind === 'press') && (
                         <button type="button" onClick={() => openBoard(item)} disabled={!item.podId}>

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -9038,3 +9038,34 @@ body.modern-ui.v2-canvas {
   .v2-connector__controls { flex-direction: column; align-items: flex-start; gap: 8px; }
   .v2-connector__row { flex-wrap: wrap; }
 }
+
+/* Activity queue: reply-in-place on mention rows (Sam, 2026-09-01). The
+   textarea shares the row's action cluster; on narrow screens it takes the
+   full width of the row so the thumb has something to hit. */
+.v2-activity__reply {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  flex: 1 1 260px;
+  min-width: 0;
+}
+.v2-root textarea.v2-activity__reply-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  resize: vertical;
+  padding: 6px 8px;
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--v2-text);
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius);
+}
+.v2-root textarea.v2-activity__reply-input:focus-visible {
+  outline: 2px solid var(--v2-accent);
+  outline-offset: 1px;
+}
+@media (max-width: 640px) {
+  .v2-activity__reply { flex-basis: 100%; }
+}


### PR DESCRIPTION
Sam: pods mention him, the tab shows nothing. Measured 15 @Sam mentions in 36h (14 in threads); the feed-based path saw zero. New getMentionsForUser PG query (all pods, threads included, 7d, minus own/acked) feeds the decision queue with thread root + message id; mention rows get an inline reply box that posts into that thread via /api/messages and then acknowledges. Live-validated SQL (40 rows). Tests updated for the new source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmApTnNd9VZRTE2Fi1gM6z