### PR TITLE
fix(activity): per-kind soft cap — mentions ≤ 8 of 12 so decisions stay visible

### DIFF
--- a/backend/__tests__/unit/services/activityService.decisionQueue.test.js
+++ b/backend/__tests__/unit/services/activityService.decisionQueue.test.js
@@ -157,6 +157,23 @@ describe('ActivityService.getDecisionQueue', () => {
     expect(params[2]).toBe('@Sam(?![A-Za-z0-9_])');
   });
 
+  test('mentions take at most 8 of the 12 slots so standing decisions stay visible', async () => {
+    // Live after #1464: 40+ thread mentions filled the page and the four
+    // ADR-024 decisions vanished below the cap.
+    pool.query.mockResolvedValue({ rows: Array.from({ length: 10 }, (_, i) => ({
+      id: 100 + i, pod_id: 'pod-1', user_id: 'bot-1', content: '@Sam ping', created_at: new Date(Date.now() - i * 1000), thread_root_id: null, author: 'vale',
+    })) });
+    Task.find.mockReturnValue(taskChain(Array.from({ length: 4 }, (_, i) => ({
+      taskId: `TASK-${200 + i}`, podId: 'pod-1', status: 'blocked', title: `Standing ${i}`,
+      updates: [{ text: 'blocked', createdAt: new Date() }],
+    }))));
+    const result = await ActivityService.getDecisionQueue('u1');
+    const kinds = result.items.map((i) => i.kind);
+    expect(kinds.filter((k) => k === 'mention')).toHaveLength(8);
+    expect(kinds.filter((k) => k === 'decision')).toHaveLength(4);
+    expect(result.count).toBe(14);
+  });
+
   test('one failed source degrades, never blanks the queue', async () => {
     ActivityService.getPendingApprovals.mockRejectedValue(new Error('store down'));
     Task.find.mockReturnValue(taskChain([

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -617,7 +617,37 @@ class ActivityService {
       if (kindDelta !== 0) return kindDelta;
       return new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime();
     });
-    return { items: items.slice(0, 12), count: items.length };
+    // Per-kind soft cap. Live after #1464: 40+ thread mentions filled all
+    // 12 slots and the four standing decisions vanished below the cap —
+    // the opposite of "decision pending on me" being visible. Mentions
+    // take at most 8 of the 12; whatever is left goes to the other kinds
+    // in attention order. `count` still reports the full total.
+    const MENTION_SLOTS = 8;
+    const picked: QueueItem[] = [];
+    let mentionsPicked = 0;
+    const deferredMentions: QueueItem[] = [];
+    for (const it of items) {
+      if (picked.length >= 12) break;
+      if (it.kind === 'mention') {
+        if (mentionsPicked < MENTION_SLOTS) { picked.push(it); mentionsPicked += 1; } else deferredMentions.push(it);
+      } else {
+        picked.push(it);
+      }
+    }
+    for (const it of deferredMentions) {
+      if (picked.length >= 12) break;
+      picked.push(it);
+    }
+    // Restore attention order within the final page (approval, press,
+    // mention, decision), recency inside each kind — the loop above kept
+    // the sorted order for everything it picked, so a stable re-sort is
+    // enough.
+    picked.sort((a, b) => {
+      const kindDelta = (KIND_PRIORITY[a.kind] ?? 9) - (KIND_PRIORITY[b.kind] ?? 9);
+      if (kindDelta !== 0) return kindDelta;
+      return new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime();
+    });
+    return { items: picked, count: items.length };
   }
 
   static async getPodFeed(


### PR DESCRIPTION
After #1464 the mention flood (40+) pushed every decision below the 12-row cap. Mentions now take at most 8 slots; remaining slots go to approvals/press/decisions in attention order; count stays honest. Test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmApTnNd9VZRTE2Fi1gM6z