### PR TITLE
fix(webhooks): await the Telegram buffer handler so a rejection releases the dedup claim

### DIFF
--- a/backend/__tests__/unit/routes/telegram.webhook.test.js
+++ b/backend/__tests__/unit/routes/telegram.webhook.test.js
@@ -350,6 +350,56 @@ describe('bridge command surface (/mode /status /mute /help)', () => {
       );
     });
 
+    // The real buffer handler is async and can reject (it awaits a Mongo
+    // write). A synchronous mock here would let an un-awaited
+    // `return events(req, res)` pass — the rejection must reach the catch so
+    // the claim is released and Telegram's redelivery is a retry, not a
+    // duplicate-acked drop.
+    it('releases the claim when the async buffer handler rejects', async () => {
+      const integration = {
+        _id: 'integration-1',
+        type: 'telegram',
+        config: { chatId: '42' },
+      };
+      Integration.findOne = jest.fn().mockResolvedValue(integration);
+      const events = jest.fn(async () => {
+        throw new Error('provider write failed');
+      });
+      registry.get.mockReturnValue({ getWebhookHandlers: () => ({ events }) });
+      const res = await request(app)
+        .post('/api/webhooks/telegram')
+        .send(liveUpdate(6));
+      expect(res.status).toBe(500);
+      expect(events).toHaveBeenCalled();
+      expect(WebhookDelivery.deleteOne).toHaveBeenCalledWith(
+        { provider: 'telegram', deliveryId: '6' },
+      );
+    });
+
+    // Updates with no update_id must bypass the claim entirely: without the
+    // guard they would all claim the literal key 'undefined' — the first one
+    // takes it and every later un-id'd update is acked and dropped.
+    it('processes every update that carries no update_id', async () => {
+      const integration = {
+        _id: 'integration-1',
+        type: 'telegram',
+        podId: 'pod-1',
+        config: { chatId: '42', liveRelay: true },
+      };
+      Integration.findOne = jest.fn().mockResolvedValue(integration);
+      bridge.relayTelegramMessageToPod.mockResolvedValue({});
+      const noIdUpdate = liveUpdate(undefined);
+      delete noIdUpdate.update_id;
+
+      const first = await request(app).post('/api/webhooks/telegram').send(noIdUpdate);
+      const second = await request(app).post('/api/webhooks/telegram').send(noIdUpdate);
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(bridge.relayTelegramMessageToPod).toHaveBeenCalledTimes(2);
+      expect(WebhookDelivery.create).not.toHaveBeenCalled();
+    });
+
     it('a dedup-store outage does not take the bridge down', async () => {
       WebhookDelivery.create.mockRejectedValueOnce(new Error('mongo down'));
       const integration = {

--- a/backend/models/WebhookDelivery.ts
+++ b/backend/models/WebhookDelivery.ts
@@ -17,6 +17,12 @@ import mongoose, { Document, Schema } from 'mongoose';
 //      routes/webhooks/telegram.ts.)
 // The TTL bounds the table: a delivery id only needs to be remembered for as
 // long as the provider keeps redelivering it.
+//
+// Key scope: {provider, deliveryId} assumes ONE id space per provider.
+// Telegram's update_id is sequential per BOT — correct while the route serves
+// a single bot; a second bot on the same route would collide id spaces and
+// drop legitimate updates as duplicates. Widen the key (e.g. include bot id)
+// before multi-bot.
 export interface IWebhookDelivery extends Document {
   provider: string;
   deliveryId: string;

--- a/backend/routes/webhooks/telegram.ts
+++ b/backend/routes/webhooks/telegram.ts
@@ -462,7 +462,10 @@ router.post('/', async (req: any, res: any) => {
 
     const provider = registry.get('telegram', integration);
     const { events } = provider.getWebhookHandlers();
-    return events(req, res);
+    // await, not return: a rejected promise returned from inside `try` escapes
+    // this catch (express 4 won't catch it either), and the claim above would
+    // survive to swallow Telegram's redelivery.
+    return await events(req, res);
   } catch (error) {
     console.error('Telegram webhook error', error);
     // Forget-on-error: the 500 makes Telegram redeliver this update_id; the


### PR DESCRIPTION
Follow-up to #1422, which was merged from its first commit before the sprint-review gate fix landed (the branch was auto-deleted, so the fix commit never reached main).

**Bug on main right now:** `return events(req, res)` inside the `try` is not awaited, so a rejection from the async buffer handler escapes the `catch`. The dedup claim survives, no response is sent, Telegram times out and redelivers, the redelivery hits the claim and is acked 200 as a duplicate. The update is dropped permanently. This is a hazard #1422 introduced (before it, the redelivery was simply reprocessed).

**Fix:** `return await events(req, res)`, with a comment stating why.

**Pinned:** two tests for the gate's surviving mutants: an async-rejecting buffer handler must release the claim (the old synchronous mock could never exercise the escape), and updates without `update_id` must bypass the claim rather than dedup against the literal key `'undefined'`. Mutation-checked: removing the await hangs the new test, the exact production symptom. Also records the per-bot `update_id` key scope in the model comment.

17/17 in `telegram.webhook.test.js`. Deploy wiring is tracked in #1467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8MxGhdgPini3Q14ay2vXS