### PR TITLE
feat(activity): add agent-originated decision requests

### DIFF
--- a/backend/__tests__/unit/routes/activity.identity.test.js
+++ b/backend/__tests__/unit/routes/activity.identity.test.js
@@ -29,7 +29,6 @@ describe('activity route identity handling', () => {
       addReply: jest.fn(async () => ({ success: true })),
       approveActivity: jest.fn(async () => ({ success: true })),
       rejectActivity: jest.fn(async () => ({ success: true })),
-      ruleTaskDecision: jest.fn(async () => ({ status: 200, body: { ok: true, ruling: 'Ship now' } })),
       seedPodActivities: jest.fn(async () => ({ success: true, count: 1 })),
       getUnreadCount: jest.fn(async () => ({ unreadCount: 4 })),
       markRead: jest.fn(async () => ({ success: true })),
@@ -47,24 +46,25 @@ describe('activity route identity handling', () => {
     );
   });
 
-  it('passes a typed DECIDE option through the Activity route to the board ruling service', async () => {
+  it('passes an exact human choice through the Activity route to DecisionRequest', async () => {
     jest.doMock('../../../middleware/auth', () => (req, res, next) => {
       req.userId = 'human-1';
       next();
     });
-    jest.doMock('../../../services/activityService', () => ({
-      ruleTaskDecision: jest.fn(async () => ({ status: 200, body: { ok: true, ruling: 'Ship now' } })),
+    jest.doMock('../../../services/decisionRequestService', () => ({
+      chooseDecision: jest.fn(async () => ({ status: 200, body: { ok: true, decision: { id: 'decision-1' } } })),
+      DecisionRequestError: class DecisionRequestError extends Error {},
     }));
-    const ActivityService = require('../../../services/activityService');
+    const DecisionRequestService = require('../../../services/decisionRequestService');
     const app = buildApp();
 
     await request(app)
-      .post('/api/activity/tasks/TASK-024/rule')
-      .send({ podId: 'pod-1', option: 'Ship now' })
-      .expect(200, { ok: true, ruling: 'Ship now' });
+      .post('/api/activity/decisions/decision-1/choose')
+      .send({ value: 'Ship now' })
+      .expect(200, { ok: true, decision: { id: 'decision-1' } });
 
-    expect(ActivityService.ruleTaskDecision).toHaveBeenCalledWith({
-      podId: 'pod-1', taskId: 'TASK-024', option: 'Ship now', userId: 'human-1',
+    expect(DecisionRequestService.chooseDecision).toHaveBeenCalledWith({
+      decisionId: 'decision-1', callerUserId: 'human-1', value: 'Ship now',
     });
   });
 });

--- a/backend/__tests__/unit/routes/activity.identity.test.js
+++ b/backend/__tests__/unit/routes/activity.identity.test.js
@@ -29,6 +29,7 @@ describe('activity route identity handling', () => {
       addReply: jest.fn(async () => ({ success: true })),
       approveActivity: jest.fn(async () => ({ success: true })),
       rejectActivity: jest.fn(async () => ({ success: true })),
+      ruleTaskDecision: jest.fn(async () => ({ status: 200, body: { ok: true, ruling: 'Ship now' } })),
       seedPodActivities: jest.fn(async () => ({ success: true, count: 1 })),
       getUnreadCount: jest.fn(async () => ({ unreadCount: 4 })),
       markRead: jest.fn(async () => ({ success: true })),
@@ -44,5 +45,26 @@ describe('activity route identity handling', () => {
       'legacy-user-123',
       expect.objectContaining({ all: true }),
     );
+  });
+
+  it('passes a typed DECIDE option through the Activity route to the board ruling service', async () => {
+    jest.doMock('../../../middleware/auth', () => (req, res, next) => {
+      req.userId = 'human-1';
+      next();
+    });
+    jest.doMock('../../../services/activityService', () => ({
+      ruleTaskDecision: jest.fn(async () => ({ status: 200, body: { ok: true, ruling: 'Ship now' } })),
+    }));
+    const ActivityService = require('../../../services/activityService');
+    const app = buildApp();
+
+    await request(app)
+      .post('/api/activity/tasks/TASK-024/rule')
+      .send({ podId: 'pod-1', option: 'Ship now' })
+      .expect(200, { ok: true, ruling: 'Ship now' });
+
+    expect(ActivityService.ruleTaskDecision).toHaveBeenCalledWith({
+      podId: 'pod-1', taskId: 'TASK-024', option: 'Ship now', userId: 'human-1',
+    });
   });
 });

--- a/backend/__tests__/unit/routes/agentsRuntime.decision.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.decision.test.js
@@ -58,7 +58,7 @@ describe('POST /api/agents/runtime/decisions', () => {
     const response = await request(app).post('/api/agents/runtime/decisions').send({
       podId: 'pod-1', title: 'Choose release', question: 'Which train?',
       options: [{ label: 'Canary', recommended: true }, { label: 'Fast lane' }],
-      threadRootId: '612', context: 'Green build.', agentUserId: 'forged', agentName: 'forged-agent',
+      threadRootId: '612', context: 'Green build.',
     });
 
     expect(response.status).toBe(201);
@@ -66,7 +66,19 @@ describe('POST /api/agents/runtime/decisions', () => {
       podId: 'pod-1', agentUserId: 'agent-user-1', agentName: 'release-agent', instanceId: 'seat-1',
       displayName: 'Release Agent', title: 'Choose release', question: 'Which train?', threadRootId: '612',
     }));
-    expect(mockRequestDecision.mock.calls[0][0]).not.toHaveProperty('forged');
+    expect(mockRequestDecision.mock.calls[0][0]).not.toHaveProperty('action');
+  });
+
+  test('refuses structured action data instead of turning a human ruling into approval', async () => {
+    const response = await request(app).post('/api/agents/runtime/decisions').send({
+      podId: 'pod-1', title: 'Choose release', question: 'Which train?',
+      options: [{ label: 'Canary' }, { label: 'Fast lane' }],
+      actionType: 'deploy', params: { environment: 'production' },
+    });
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({ code: 'unsupported_decision_fields' });
+    expect(response.body.message).toContain('propose-action');
+    expect(mockRequestDecision).not.toHaveBeenCalled();
   });
 
   test('rejects an unscoped pod before the decision service writes anything', async () => {

--- a/backend/__tests__/unit/routes/agentsRuntime.decision.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.decision.test.js
@@ -56,7 +56,7 @@ describe('POST /api/agents/runtime/decisions', () => {
 
   test('uses the authenticated seat as provenance and forwards the declared fork', async () => {
     const response = await request(app).post('/api/agents/runtime/decisions').send({
-      podId: 'pod-1', title: 'Choose release', question: 'Which train?',
+      podId: 'pod-1', decisionClass: 'implementation', title: 'Choose release', question: 'Which train?',
       options: [{ label: 'Canary', recommended: true }, { label: 'Fast lane' }],
       threadRootId: '612', context: 'Green build.',
     });
@@ -64,14 +64,14 @@ describe('POST /api/agents/runtime/decisions', () => {
     expect(response.status).toBe(201);
     expect(mockRequestDecision).toHaveBeenCalledWith(expect.objectContaining({
       podId: 'pod-1', agentUserId: 'agent-user-1', agentName: 'release-agent', instanceId: 'seat-1',
-      displayName: 'Release Agent', title: 'Choose release', question: 'Which train?', threadRootId: '612',
+      displayName: 'Release Agent', decisionClass: 'implementation', title: 'Choose release', question: 'Which train?', threadRootId: '612',
     }));
     expect(mockRequestDecision.mock.calls[0][0]).not.toHaveProperty('action');
   });
 
   test('refuses structured action data instead of turning a human ruling into approval', async () => {
     const response = await request(app).post('/api/agents/runtime/decisions').send({
-      podId: 'pod-1', title: 'Choose release', question: 'Which train?',
+      podId: 'pod-1', decisionClass: 'implementation', title: 'Choose release', question: 'Which train?',
       options: [{ label: 'Canary' }, { label: 'Fast lane' }],
       actionType: 'deploy', params: { environment: 'production' },
     });
@@ -83,7 +83,7 @@ describe('POST /api/agents/runtime/decisions', () => {
 
   test('rejects an unscoped pod before the decision service writes anything', async () => {
     const response = await request(app).post('/api/agents/runtime/decisions').send({
-      podId: 'other-pod', title: 'Choose release', question: 'Which train?', options: [{ label: 'A' }, { label: 'B' }],
+      podId: 'other-pod', decisionClass: 'strategy', title: 'Choose release', question: 'Which train?', options: [{ label: 'A' }, { label: 'B' }],
     });
     expect(response.status).toBe(403);
     expect(mockRequestDecision).not.toHaveBeenCalled();

--- a/backend/__tests__/unit/routes/agentsRuntime.decision.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.decision.test.js
@@ -1,0 +1,79 @@
+/** The MCP route is deliberately thin: token identity and pod scope, then the
+ * same decision service used by every runtime. This pins its wire contract so
+ * a body cannot forge the asking agent's provenance. */
+
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('../../../middleware/agentRuntimeAuth', () => (req, _res, next) => {
+  req.agentUser = { _id: 'agent-user-1' };
+  req.agentInstallation = {
+    podId: 'pod-1', agentName: 'release-agent', instanceId: 'seat-1',
+    displayName: 'Release Agent', config: { mode: 'test' },
+  };
+  req.agentInstallations = [req.agentInstallation];
+  req.agentAuthorizedPodIds = ['pod-1'];
+  next();
+});
+jest.mock('../../../middleware/auth', () => (req, _res, next) => next());
+jest.mock('../../../middleware/apiTokenScopes', () => ({ requireApiTokenScopes: () => (_req, _res, next) => next() }));
+
+jest.mock('../../../services/agentEventService', () => ({}));
+jest.mock('../../../services/agentIdentityService', () => ({ buildAgentUsername: jest.fn((name) => name) }));
+jest.mock('../../../services/agentMessageService', () => ({}));
+jest.mock('../../../services/agentThreadService', () => ({}));
+jest.mock('../../../services/podContextService', () => ({}));
+jest.mock('../../../services/globalModelConfigService', () => ({}));
+jest.mock('../../../services/socialPolicyService', () => ({}));
+jest.mock('../../../services/dmService', () => ({}));
+jest.mock('../../../services/chatSummarizerService', () => ({}));
+jest.mock('../../../integrations', () => ({ get: jest.fn() }));
+jest.mock('../../../models/Activity', () => ({}));
+jest.mock('../../../models/User', () => ({ findById: jest.fn(), find: jest.fn() }));
+jest.mock('../../../models/Post', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/Pod', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../../../models/Integration', () => ({ find: jest.fn(), findOne: jest.fn() }));
+jest.mock('../../../models/AgentRegistry', () => ({ AgentInstallation: { findOne: jest.fn(), find: jest.fn() } }));
+
+const mockRequestDecision = jest.fn();
+jest.mock('../../../services/decisionRequestService', () => ({
+  requestDecision: (...args) => mockRequestDecision(...args),
+  DecisionRequestError: class DecisionRequestError extends Error {
+    constructor(message, status, code) { super(message); this.status = status; this.code = code; }
+  },
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/agents/runtime', require('../../../routes/agentsRuntime'));
+
+describe('POST /api/agents/runtime/decisions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequestDecision.mockResolvedValue({ decisionId: 'd1', messageId: '700', threadRootId: '700', status: 'pending' });
+  });
+
+  test('uses the authenticated seat as provenance and forwards the declared fork', async () => {
+    const response = await request(app).post('/api/agents/runtime/decisions').send({
+      podId: 'pod-1', title: 'Choose release', question: 'Which train?',
+      options: [{ label: 'Canary', recommended: true }, { label: 'Fast lane' }],
+      threadRootId: '612', context: 'Green build.', agentUserId: 'forged', agentName: 'forged-agent',
+    });
+
+    expect(response.status).toBe(201);
+    expect(mockRequestDecision).toHaveBeenCalledWith(expect.objectContaining({
+      podId: 'pod-1', agentUserId: 'agent-user-1', agentName: 'release-agent', instanceId: 'seat-1',
+      displayName: 'Release Agent', title: 'Choose release', question: 'Which train?', threadRootId: '612',
+    }));
+    expect(mockRequestDecision.mock.calls[0][0]).not.toHaveProperty('forged');
+  });
+
+  test('rejects an unscoped pod before the decision service writes anything', async () => {
+    const response = await request(app).post('/api/agents/runtime/decisions').send({
+      podId: 'other-pod', title: 'Choose release', question: 'Which train?', options: [{ label: 'A' }, { label: 'B' }],
+    });
+    expect(response.status).toBe(403);
+    expect(mockRequestDecision).not.toHaveBeenCalled();
+  });
+});

--- a/backend/__tests__/unit/services/activityService.decisionQueue.test.js
+++ b/backend/__tests__/unit/services/activityService.decisionQueue.test.js
@@ -5,7 +5,7 @@
  * the human press, because its only wired source was direct @mentions (empty
  * — agents write the human's bare name, TASK-070). This suite pins the three
  * concrete fact sources and their classification:
- *   - pending approvals (raw activity id — the act endpoints key on it)
+ *   - pending ApprovalAction cards (raw id — the resolve endpoint keys on it)
  *   - unacknowledged direct mentions
  *   - board rows: DECIDE-titles and blocked rows -> 'decision';
  *     an explicit human-handoff in the LATEST update -> 'press'
@@ -13,9 +13,12 @@
 
 jest.mock('../../../models/Pod', () => ({
   find: jest.fn(),
+  findById: jest.fn(),
 }));
 jest.mock('../../../models/Task', () => ({
   find: jest.fn(),
+  findOne: jest.fn(),
+  findOneAndUpdate: jest.fn(),
 }));
 jest.mock('../../../models/User', () => ({
   find: jest.fn(),
@@ -25,12 +28,19 @@ jest.mock('../../../config/db-pg', () => ({ pool: { query: jest.fn().mockResolve
 jest.mock('../../../models/Activity', () => ({}));
 jest.mock('../../../models/Summary', () => ({}));
 jest.mock('../../../models/Post', () => ({}));
+jest.mock('../../../models/ApprovalAction', () => ({ find: jest.fn() }));
+jest.mock('../../../services/taskEventService', () => ({
+  emitTaskUpdated: jest.fn(),
+  notifyPodAgents: jest.fn(),
+}));
 
 const ActivityService = require('../../../services/activityService');
 const Pod = require('../../../models/Pod');
 const Task = require('../../../models/Task');
 const User = require('../../../models/User');
+const ApprovalAction = require('../../../models/ApprovalAction');
 const { pool } = require('../../../config/db-pg');
+const { emitTaskUpdated, notifyPodAgents } = require('../../../services/taskEventService');
 
 const userChain = (doc) => ({ select: () => ({ lean: async () => doc }) });
 
@@ -39,14 +49,19 @@ const POD = { _id: 'pod-1', name: 'Sprint HQ', type: 'team' };
 const taskChain = (rows) => ({
   sort: () => ({ limit: () => ({ lean: async () => rows }) }),
 });
+const approvalChain = (rows) => ({
+  sort: () => ({ limit: () => ({ lean: async () => rows }) }),
+});
 
 describe('ActivityService.getDecisionQueue', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
     Pod.find.mockReturnValue({ select: () => ({ lean: async () => [POD] }) });
-    jest.spyOn(ActivityService, 'getPendingApprovals').mockResolvedValue([]);
+    ApprovalAction.find.mockReturnValue(approvalChain([]));
     jest.spyOn(ActivityService, 'getUserFeed').mockResolvedValue({ activities: [], acknowledgedMentionIds: [] });
     Task.find.mockReturnValue(taskChain([]));
+    Task.findOne.mockReturnValue({ lean: async () => null });
+    Task.findOneAndUpdate.mockResolvedValue(null);
     User.findById.mockReturnValue(userChain({ username: 'Sam', activityQueue: { acknowledgedMentionIds: [] } }));
     pool.query.mockResolvedValue({ rows: [] });
   });
@@ -55,7 +70,7 @@ describe('ActivityService.getDecisionQueue', () => {
     Task.find.mockReturnValue(taskChain([
       {
         taskId: 'TASK-024', podId: 'pod-1', status: 'pending', title: 'DECIDE: backend eslint reaches 0 files',
-        updates: [{ text: 'filed', createdAt: new Date('2026-08-26T01:00:00Z') }],
+        updates: [{ text: 'filed\nOPTIONS: Ship now | Hold for review', createdAt: new Date('2026-08-26T01:00:00Z') }],
       },
       {
         taskId: 'TASK-016', podId: 'pod-1', status: 'blocked', title: 'REGRESSION: isOneToOneShapedPod counts bots',
@@ -78,6 +93,7 @@ describe('ActivityService.getDecisionQueue', () => {
     expect(byTask['TASK-059']).toBe('press');
     // An ordinary in-flight row is NOT waiting on the human.
     expect(byTask['TASK-068']).toBeUndefined();
+    expect(result.items.find((item) => item.taskId === 'TASK-024').options).toEqual(['Ship now', 'Hold for review']);
   });
 
   test('the handoff match reads the LATEST update only — an old handoff already resolved does not resurrect', async () => {
@@ -94,20 +110,21 @@ describe('ActivityService.getDecisionQueue', () => {
     expect(result.items).toHaveLength(0);
   });
 
-  test('approvals carry the RAW activity id, because /api/activity/:id/approve keys on it', async () => {
-    ActivityService.getPendingApprovals.mockResolvedValue([
-      { _id: 'act-77', content: 'May I merge?', podId: 'pod-1', createdAt: new Date(), agentMetadata: { agentName: 'anvil' } },
-    ]);
+  test('approvals carry the RAW ApprovalAction id and only query the viewer as decider', async () => {
+    ApprovalAction.find.mockReturnValue(approvalChain([
+      { _id: 'approval-77', summary: 'May I merge?', podId: 'pod-1', createdAt: new Date(), agentName: 'anvil' },
+    ]));
     const result = await ActivityService.getDecisionQueue('u1');
     const approval = result.items.find((i) => i.kind === 'approval');
-    expect(approval.id).toBe('act-77');
+    expect(approval.id).toBe('approval-77');
     expect(approval.title).toContain('anvil');
+    expect(ApprovalAction.find).toHaveBeenCalledWith({ ownerUserId: 'u1', status: 'flagged' });
   });
 
   test('attention order beats recency: approval, press, mention, then standing decisions — capped at 12 with an honest total', async () => {
-    ActivityService.getPendingApprovals.mockResolvedValue([
-      { _id: 'act-1', content: 'approve?', podId: 'pod-1', createdAt: new Date('2026-08-20T00:00:00Z') },
-    ]);
+    ApprovalAction.find.mockReturnValue(approvalChain([
+      { _id: 'approval-1', summary: 'approve?', podId: 'pod-1', createdAt: new Date('2026-08-20T00:00:00Z') },
+    ]));
     pool.query.mockResolvedValue({ rows: [{
       id: 501, pod_id: 'pod-1', user_id: 'bot-1', content: '@Sam ping', created_at: new Date('2026-08-27T00:00:00Z'),
       thread_root_id: 480, author: 'anvil',
@@ -150,6 +167,7 @@ describe('ActivityService.getDecisionQueue', () => {
     const mentions = result.items.filter((i) => i.kind === 'mention');
     expect(mentions.map((m) => m.id)).toEqual(['msg_9', 'msg_5']);
     expect(mentions[0]).toMatchObject({ threadRootId: 4, messageId: 9, title: 'vale mentioned you' });
+    expect(result.composePodId).toBe('pod-1');
     // A top-level mention is its own thread root.
     expect(mentions[1]).toMatchObject({ threadRootId: 5, messageId: 5 });
     const [sql, params] = pool.query.mock.calls[0];
@@ -175,7 +193,7 @@ describe('ActivityService.getDecisionQueue', () => {
   });
 
   test('one failed source degrades, never blanks the queue', async () => {
-    ActivityService.getPendingApprovals.mockRejectedValue(new Error('store down'));
+    ApprovalAction.find.mockImplementation(() => { throw new Error('store down'); });
     Task.find.mockReturnValue(taskChain([
       {
         taskId: 'TASK-024', podId: 'pod-1', status: 'pending', title: 'DECIDE: something',
@@ -184,5 +202,111 @@ describe('ActivityService.getDecisionQueue', () => {
     ]));
     const result = await ActivityService.getDecisionQueue('u1');
     expect(result.items.map((i) => i.taskId)).toEqual(['TASK-024']);
+  });
+
+  test('a SAM RULED update retires the DECIDE row from the queue', async () => {
+    Task.find.mockReturnValue(taskChain([{
+      taskId: 'TASK-024', podId: 'pod-1', status: 'pending', title: 'DECIDE: release scope',
+      updates: [
+        { text: 'OPTIONS: Ship now | Hold for review', createdAt: new Date() },
+        { text: 'SAM RULED: Ship now', createdAt: new Date() },
+      ],
+    }]));
+
+    const result = await ActivityService.getDecisionQueue('u1');
+    expect(result.items).toEqual([]);
+  });
+
+  test('a later executor update cannot resurrect a DECIDE row already ruled by Sam', async () => {
+    Task.find.mockReturnValue(taskChain([{
+      taskId: 'TASK-024', podId: 'pod-1', status: 'claimed', title: 'DECIDE: release scope',
+      updates: [
+        { text: 'OPTIONS: Ship now | Hold for review', createdAt: new Date() },
+        { text: 'SAM RULED: Ship now', createdAt: new Date() },
+        { text: 'Implementation started', createdAt: new Date() },
+      ],
+    }]));
+
+    const result = await ActivityService.getDecisionQueue('u1');
+    expect(result.items).toEqual([]);
+  });
+
+  test('renders only a complete bounded OPTIONS line on a DECIDE row', async () => {
+    Task.find.mockReturnValue(taskChain([
+      {
+        taskId: 'TASK-024', podId: 'pod-1', status: 'pending', title: 'DECIDE: release scope',
+        updates: [{ text: 'OPTIONS: Ship | Hold | Escalate', createdAt: new Date() }],
+      },
+      {
+        taskId: 'TASK-025', podId: 'pod-1', status: 'pending', title: 'DECIDE: ambiguous',
+        updates: [{ text: 'OPTIONS: Ship | ship', createdAt: new Date() }],
+      },
+      {
+        taskId: 'TASK-026', podId: 'pod-1', status: 'pending', title: 'DECIDE: too many',
+        updates: [{ text: 'OPTIONS: A | B | C | D | E', createdAt: new Date() }],
+      },
+    ]));
+    const result = await ActivityService.getDecisionQueue('u1');
+    expect(result.items.find((item) => item.taskId === 'TASK-024').options).toEqual(['Ship', 'Hold', 'Escalate']);
+    expect(result.items.find((item) => item.taskId === 'TASK-025').options).toBeUndefined();
+    expect(result.items.find((item) => item.taskId === 'TASK-026').options).toBeUndefined();
+  });
+
+  test('records one human ruling, emits the board update, and wakes the asking seats', async () => {
+    const task = {
+      _id: 'task-1', taskId: 'TASK-024', podId: 'pod-1', title: 'DECIDE: release scope', status: 'pending',
+      updates: [{ text: 'OPTIONS: Ship now | Hold for review', createdAt: new Date() }],
+    };
+    Pod.findById.mockReturnValue({ select: () => ({ lean: async () => ({ _id: 'pod-1', createdBy: 'u1', members: [] }) }) });
+    User.findById.mockReturnValue(userChain({ username: 'Sam', isBot: false }));
+    Task.findOne.mockReturnValue({ lean: async () => task });
+    const ruled = { ...task, updates: [...task.updates, { text: 'SAM RULED: Ship now' }], toObject: () => ({ ...task, ruled: true }) };
+    Task.findOneAndUpdate.mockResolvedValue(ruled);
+    notifyPodAgents.mockResolvedValue();
+
+    const result = await ActivityService.ruleTaskDecision({ podId: 'pod-1', taskId: 'TASK-024', option: 'Ship now', userId: 'u1' });
+
+    expect(result).toMatchObject({ status: 200, body: { ok: true, ruling: 'Ship now' } });
+    expect(Task.findOneAndUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ podId: 'pod-1', taskId: 'TASK-024' }),
+      expect.objectContaining({ $push: { updates: expect.objectContaining({ text: 'SAM RULED: Ship now', author: 'Sam', authorId: 'u1' }) } }),
+      { new: true },
+    );
+    expect(emitTaskUpdated).toHaveBeenCalledWith('pod-1', expect.objectContaining({ ruled: true }), 'updated');
+    expect(notifyPodAgents).toHaveBeenCalledWith('pod-1', expect.objectContaining({ ruled: true }), 'updated', { userId: 'u1', isAgent: false });
+  });
+
+  test('rejects a non-member and an option not declared by the task without writing a ruling', async () => {
+    const task = {
+      taskId: 'TASK-024', podId: 'pod-1', title: 'DECIDE: release scope',
+      status: 'pending',
+      updates: [{ text: 'OPTIONS: Ship now | Hold for review', createdAt: new Date() }],
+    };
+    Pod.findById.mockReturnValue({ select: () => ({ lean: async () => ({ _id: 'pod-1', createdBy: 'owner', members: [] }) }) });
+    expect(await ActivityService.ruleTaskDecision({ podId: 'pod-1', taskId: 'TASK-024', option: 'Ship now', userId: 'u1' }))
+      .toMatchObject({ status: 403 });
+
+    Pod.findById.mockReturnValue({ select: () => ({ lean: async () => ({ _id: 'pod-1', createdBy: 'u1', members: [] }) }) });
+    User.findById.mockReturnValue(userChain({ username: 'Sam', isBot: false }));
+    Task.findOne.mockReturnValue({ lean: async () => task });
+    expect(await ActivityService.ruleTaskDecision({ podId: 'pod-1', taskId: 'TASK-024', option: 'Delete it', userId: 'u1' }))
+      .toMatchObject({ status: 400 });
+    expect(Task.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('the compare-and-set makes a second tap lose without another wake', async () => {
+    const task = {
+      taskId: 'TASK-024', podId: 'pod-1', title: 'DECIDE: release scope',
+      updates: [{ text: 'OPTIONS: Ship now | Hold for review', createdAt: new Date() }],
+    };
+    Pod.findById.mockReturnValue({ select: () => ({ lean: async () => ({ _id: 'pod-1', createdBy: 'u1', members: [] }) }) });
+    User.findById.mockReturnValue(userChain({ username: 'Sam', isBot: false }));
+    Task.findOne.mockReturnValue({ lean: async () => task });
+    Task.findOneAndUpdate.mockResolvedValue(null);
+
+    expect(await ActivityService.ruleTaskDecision({ podId: 'pod-1', taskId: 'TASK-024', option: 'Ship now', userId: 'u1' }))
+      .toMatchObject({ status: 409 });
+    expect(emitTaskUpdated).not.toHaveBeenCalled();
+    expect(notifyPodAgents).not.toHaveBeenCalled();
   });
 });

--- a/backend/__tests__/unit/services/activityService.decisionQueue.test.js
+++ b/backend/__tests__/unit/services/activityService.decisionQueue.test.js
@@ -1,312 +1,131 @@
 /**
- * TASK-083 — the decision queue reads FACTS, not heuristics.
- *
- * The Activity tab's "Waiting on you" rendered empty while seven PRs sat at
- * the human press, because its only wired source was direct @mentions (empty
- * — agents write the human's bare name, TASK-070). This suite pins the three
- * concrete fact sources and their classification:
- *   - pending ApprovalAction cards (raw id — the resolve endpoint keys on it)
- *   - unacknowledged direct mentions
- *   - board rows: DECIDE-titles and blocked rows -> 'decision';
- *     an explicit human-handoff in the LATEST update -> 'press'
+ * DecisionRequest is the only source of interactive decision cards. Board
+ * prose remains board prose; an OPTIONS line must never turn into an action
+ * surface merely because it looked structured to the reader.
  */
 
 jest.mock('../../../models/Pod', () => ({
   find: jest.fn(),
   findById: jest.fn(),
 }));
-jest.mock('../../../models/Task', () => ({
-  find: jest.fn(),
-  findOne: jest.fn(),
-  findOneAndUpdate: jest.fn(),
-}));
-jest.mock('../../../models/User', () => ({
-  find: jest.fn(),
-  findById: jest.fn(),
-}));
+jest.mock('../../../models/Task', () => ({ find: jest.fn() }));
+jest.mock('../../../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/DecisionRequest', () => ({ find: jest.fn() }));
 jest.mock('../../../config/db-pg', () => ({ pool: { query: jest.fn().mockResolvedValue({ rows: [] }) } }));
 jest.mock('../../../models/Activity', () => ({}));
 jest.mock('../../../models/Summary', () => ({}));
 jest.mock('../../../models/Post', () => ({}));
-jest.mock('../../../models/ApprovalAction', () => ({ find: jest.fn() }));
-jest.mock('../../../services/taskEventService', () => ({
-  emitTaskUpdated: jest.fn(),
-  notifyPodAgents: jest.fn(),
-}));
 
 const ActivityService = require('../../../services/activityService');
 const Pod = require('../../../models/Pod');
 const Task = require('../../../models/Task');
 const User = require('../../../models/User');
-const ApprovalAction = require('../../../models/ApprovalAction');
+const DecisionRequest = require('../../../models/DecisionRequest');
 const { pool } = require('../../../config/db-pg');
-const { emitTaskUpdated, notifyPodAgents } = require('../../../services/taskEventService');
-
-const userChain = (doc) => ({ select: () => ({ lean: async () => doc }) });
 
 const POD = { _id: 'pod-1', name: 'Sprint HQ', type: 'team' };
+const userChain = (doc) => ({ select: () => ({ lean: async () => doc }) });
+const taskChain = (rows) => ({ sort: () => ({ limit: () => ({ lean: async () => rows }) }) });
+const decisionChain = (rows) => ({ sort: () => ({ limit: () => ({ lean: async () => rows }) }) });
 
-const taskChain = (rows) => ({
-  sort: () => ({ limit: () => ({ lean: async () => rows }) }),
-});
-const approvalChain = (rows) => ({
-  sort: () => ({ limit: () => ({ lean: async () => rows }) }),
+const decision = (overrides = {}) => ({
+  _id: 'decision-1', podId: 'pod-1', title: 'Choose deployment shape',
+  question: 'Which release train should this agent follow?',
+  options: [
+    { label: 'Fast lane', description: 'Ship after the green suite.' },
+    { label: 'Canary', description: 'Roll out gradually.', recommended: true },
+  ],
+  messageId: '700', threadRootId: '695', status: 'pending',
+  createdAt: new Date('2026-09-01T12:00:00Z'), ...overrides,
 });
 
 describe('ActivityService.getDecisionQueue', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
     Pod.find.mockReturnValue({ select: () => ({ lean: async () => [POD] }) });
-    ApprovalAction.find.mockReturnValue(approvalChain([]));
-    jest.spyOn(ActivityService, 'getUserFeed').mockResolvedValue({ activities: [], acknowledgedMentionIds: [] });
     Task.find.mockReturnValue(taskChain([]));
-    Task.findOne.mockReturnValue({ lean: async () => null });
-    Task.findOneAndUpdate.mockResolvedValue(null);
     User.findById.mockReturnValue(userChain({ username: 'Sam', activityQueue: { acknowledgedMentionIds: [] } }));
+    DecisionRequest.find.mockReturnValue(decisionChain([]));
     pool.query.mockResolvedValue({ rows: [] });
+    jest.spyOn(ActivityService, 'getPendingApprovals').mockResolvedValue([]);
   });
 
-  test('a DECIDE-titled open row and a blocked row are decisions; a human-handoff update is a press', async () => {
+  test('renders agent-authored pending rows with their stored alternatives, not task prose', async () => {
+    DecisionRequest.find.mockReturnValue(decisionChain([decision()]));
     Task.find.mockReturnValue(taskChain([
       {
-        taskId: 'TASK-024', podId: 'pod-1', status: 'pending', title: 'DECIDE: backend eslint reaches 0 files',
-        updates: [{ text: 'filed\nOPTIONS: Ship now | Hold for review', createdAt: new Date('2026-08-26T01:00:00Z') }],
+        taskId: 'TASK-024', podId: 'pod-1', status: 'pending',
+        title: 'DECIDE: legacy board wording',
+        updates: [{ text: 'OPTIONS: Parse me | Do not parse me', createdAt: new Date() }],
       },
+    ]));
+
+    const result = await ActivityService.getDecisionQueue('u1');
+
+    expect(DecisionRequest.find).toHaveBeenCalledWith({
+      podId: { $in: ['pod-1'] }, status: 'pending', messageId: { $exists: true, $ne: null },
+    });
+    expect(result.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'decision', id: 'decision-1', messageId: '700', threadRootId: '695',
+        options: [
+          { label: 'Canary', description: 'Roll out gradually.', recommended: true },
+          { label: 'Fast lane', description: 'Ship after the green suite.' },
+        ],
+      }),
+    ]));
+    expect(result.items.find((item) => item.taskId === 'TASK-024')).toBeUndefined();
+  });
+
+  test('keeps ordinary blocked and press board rows as open-board items', async () => {
+    Task.find.mockReturnValue(taskChain([
       {
-        taskId: 'TASK-016', podId: 'pod-1', status: 'blocked', title: 'REGRESSION: isOneToOneShapedPod counts bots',
-        updates: [{ text: 'blocked on decision', createdAt: new Date('2026-08-26T02:00:00Z') }],
+        taskId: 'TASK-016', podId: 'pod-1', status: 'blocked', title: 'Fix release gate',
+        updates: [{ text: 'blocked on upstream', createdAt: new Date() }],
       },
       {
         taskId: 'TASK-059', podId: 'pod-1', status: 'claimed', title: 'Retention ledger',
-        updates: [{ text: '#1208 is green — held for the human merge press.', createdAt: new Date('2026-08-26T03:00:00Z') }],
-      },
-      {
-        taskId: 'TASK-068', podId: 'pod-1', status: 'claimed', title: 'Activity tab',
-        updates: [{ text: 'iterating on the design', createdAt: new Date('2026-08-26T04:00:00Z') }],
-      },
-    ]));
-
-    const result = await ActivityService.getDecisionQueue('u1');
-    const byTask = Object.fromEntries(result.items.map((i) => [i.taskId, i.kind]));
-    expect(byTask['TASK-024']).toBe('decision');
-    expect(byTask['TASK-016']).toBe('decision');
-    expect(byTask['TASK-059']).toBe('press');
-    // An ordinary in-flight row is NOT waiting on the human.
-    expect(byTask['TASK-068']).toBeUndefined();
-    expect(result.items.find((item) => item.taskId === 'TASK-024').options).toEqual(['Ship now', 'Hold for review']);
-  });
-
-  test('the handoff match reads the LATEST update only — an old handoff already resolved does not resurrect', async () => {
-    Task.find.mockReturnValue(taskChain([
-      {
-        taskId: 'TASK-100', podId: 'pod-1', status: 'claimed', title: 'Some feature',
-        updates: [
-          { text: 'ready for the human press', createdAt: new Date('2026-08-25T00:00:00Z') },
-          { text: 'pressed; follow-ups in progress', createdAt: new Date('2026-08-26T00:00:00Z') },
-        ],
+        updates: [{ text: 'held for the human merge press', createdAt: new Date() }],
       },
     ]));
     const result = await ActivityService.getDecisionQueue('u1');
-    expect(result.items).toHaveLength(0);
+    expect(result.items.map((item) => [item.taskId, item.kind])).toEqual([
+      ['TASK-016', 'press'], ['TASK-059', 'press'],
+    ]);
   });
 
-  test('approvals carry the RAW ApprovalAction id and only query the viewer as decider', async () => {
-    ApprovalAction.find.mockReturnValue(approvalChain([
-      { _id: 'approval-77', summary: 'May I merge?', podId: 'pod-1', createdAt: new Date(), agentName: 'anvil' },
+  test('leaves existing Activity approvals on their established read path', async () => {
+    const getPendingApprovals = jest.spyOn(ActivityService, 'getPendingApprovals').mockResolvedValue([
+      { _id: 'activity-approval-1', content: 'Deploy?', podId: 'pod-1', createdAt: new Date(), agentMetadata: { agentName: 'scout' } },
+    ]);
+    const result = await ActivityService.getDecisionQueue('u1');
+    expect(getPendingApprovals).toHaveBeenCalledWith('u1');
+    expect(result.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'approval', id: 'activity-approval-1', title: 'scout requests approval' }),
     ]));
-    const result = await ActivityService.getDecisionQueue('u1');
-    const approval = result.items.find((i) => i.kind === 'approval');
-    expect(approval.id).toBe('approval-77');
-    expect(approval.title).toContain('anvil');
-    expect(ApprovalAction.find).toHaveBeenCalledWith({ ownerUserId: 'u1', status: 'flagged' });
   });
 
-  test('attention order beats recency: approval, press, mention, then standing decisions — capped at 12 with an honest total', async () => {
-    ApprovalAction.find.mockReturnValue(approvalChain([
-      { _id: 'approval-1', summary: 'approve?', podId: 'pod-1', createdAt: new Date('2026-08-20T00:00:00Z') },
-    ]));
-    pool.query.mockResolvedValue({ rows: [{
-      id: 501, pod_id: 'pod-1', user_id: 'bot-1', content: '@Sam ping', created_at: new Date('2026-08-27T00:00:00Z'),
-      thread_root_id: 480, author: 'anvil',
-    }] });
-    const rows = [];
-    for (let i = 0; i < 13; i += 1) {
-      rows.push({
-        taskId: `TASK-${100 + i}`, podId: 'pod-1', status: 'blocked', title: `Old blocked ${i}`,
-        updates: [{ text: 'stuck', createdAt: new Date(`2026-08-2${i % 6}T0${i % 9}:00:00Z`) }],
-      });
-    }
-    rows.push({
-      taskId: 'TASK-059', podId: 'pod-1', status: 'claimed', title: 'Ledger',
-      updates: [{ text: 'held for the human merge press', createdAt: new Date('2026-08-19T00:00:00Z') }],
-    });
-    Task.find.mockReturnValue(taskChain(rows));
-
-    const result = await ActivityService.getDecisionQueue('u1');
-    expect(result.items).toHaveLength(12);
-    expect(result.count).toBe(16); // 1 approval + 1 mention + 13 blocked + 1 press
-    // Kind order wins over raw recency: the OLD approval and press outrank
-    // fresher blocked rows.
-    expect(result.items[0].kind).toBe('approval');
-    expect(result.items[1].kind).toBe('press');
-    expect(result.items[2].kind).toBe('mention');
-    expect(result.items[3].kind).toBe('decision');
-  });
-
-  test('mentions come from a dedicated thread-aware query: acked rows drop, reply coordinates ride along', async () => {
-    // Sam, 2026-09-01: 15 @Sam mentions in 36h, 14 inside threads, feed saw
-    // zero. The queue asks the store directly and keeps the thread root so
-    // the tab can reply IN the thread.
-    User.findById.mockReturnValue(userChain({ username: 'Sam', activityQueue: { acknowledgedMentionIds: ['msg_7'] } }));
-    pool.query.mockResolvedValue({ rows: [
-      { id: 9, pod_id: 'pod-1', user_id: 'bot-1', content: '@Sam in a thread', created_at: new Date(), thread_root_id: 4, author: 'vale' },
-      { id: 7, pod_id: 'pod-1', user_id: 'bot-2', content: '@Sam already handled', created_at: new Date(), thread_root_id: null, author: 'juno' },
-      { id: 5, pod_id: 'pod-1', user_id: 'bot-3', content: '@Sam top-level', created_at: new Date(), thread_root_id: null, author: 'kai' },
-    ] });
-    const result = await ActivityService.getDecisionQueue('u1');
-    const mentions = result.items.filter((i) => i.kind === 'mention');
-    expect(mentions.map((m) => m.id)).toEqual(['msg_9', 'msg_5']);
-    expect(mentions[0]).toMatchObject({ threadRootId: 4, messageId: 9, title: 'vale mentioned you' });
-    expect(result.composePodId).toBe('pod-1');
-    // A top-level mention is its own thread root.
-    expect(mentions[1]).toMatchObject({ threadRootId: 5, messageId: 5 });
-    const [sql, params] = pool.query.mock.calls[0];
-    expect(sql).toMatch(/ANY\(\$1::text\[\]\)/);
-    expect(params[2]).toBe('@Sam(?![A-Za-z0-9_])');
-  });
-
-  test('mentions take at most 8 of the 12 slots so standing decisions stay visible', async () => {
-    // Live after #1464: 40+ thread mentions filled the page and the four
-    // ADR-024 decisions vanished below the cap.
-    pool.query.mockResolvedValue({ rows: Array.from({ length: 10 }, (_, i) => ({
-      id: 100 + i, pod_id: 'pod-1', user_id: 'bot-1', content: '@Sam ping', created_at: new Date(Date.now() - i * 1000), thread_root_id: null, author: 'vale',
-    })) });
-    Task.find.mockReturnValue(taskChain(Array.from({ length: 4 }, (_, i) => ({
-      taskId: `TASK-${200 + i}`, podId: 'pod-1', status: 'blocked', title: `Standing ${i}`,
-      updates: [{ text: 'blocked', createdAt: new Date() }],
+  test('mentions are still thread-aware and cap at eight without hiding decision cards', async () => {
+    DecisionRequest.find.mockReturnValue(decisionChain(Array.from({ length: 4 }, (_, index) => decision({
+      _id: `decision-${index}`, messageId: `${700 + index}`, createdAt: new Date(Date.now() - index * 1000),
     }))));
+    pool.query.mockResolvedValue({ rows: Array.from({ length: 10 }, (_, index) => ({
+      id: 100 + index, pod_id: 'pod-1', user_id: 'bot-1', content: '@Sam ping',
+      created_at: new Date(Date.now() - index * 1000), thread_root_id: null, author: 'vale',
+    })) });
     const result = await ActivityService.getDecisionQueue('u1');
-    const kinds = result.items.map((i) => i.kind);
-    expect(kinds.filter((k) => k === 'mention')).toHaveLength(8);
-    expect(kinds.filter((k) => k === 'decision')).toHaveLength(4);
+    expect(result.items.filter((item) => item.kind === 'mention')).toHaveLength(8);
+    expect(result.items.filter((item) => item.kind === 'decision')).toHaveLength(4);
     expect(result.count).toBe(14);
   });
 
-  test('one failed source degrades, never blanks the queue', async () => {
-    ApprovalAction.find.mockImplementation(() => { throw new Error('store down'); });
-    Task.find.mockReturnValue(taskChain([
-      {
-        taskId: 'TASK-024', podId: 'pod-1', status: 'pending', title: 'DECIDE: something',
-        updates: [{ text: 'filed', createdAt: new Date() }],
-      },
-    ]));
-    const result = await ActivityService.getDecisionQueue('u1');
-    expect(result.items.map((i) => i.taskId)).toEqual(['TASK-024']);
-  });
-
-  test('a SAM RULED update retires the DECIDE row from the queue', async () => {
+  test('a failed DecisionRequest read degrades to the still-available board facts', async () => {
+    DecisionRequest.find.mockImplementation(() => { throw new Error('store down'); });
     Task.find.mockReturnValue(taskChain([{
-      taskId: 'TASK-024', podId: 'pod-1', status: 'pending', title: 'DECIDE: release scope',
-      updates: [
-        { text: 'OPTIONS: Ship now | Hold for review', createdAt: new Date() },
-        { text: 'SAM RULED: Ship now', createdAt: new Date() },
-      ],
+      taskId: 'TASK-059', podId: 'pod-1', status: 'claimed', title: 'Release',
+      updates: [{ text: 'ready for the human press', createdAt: new Date() }],
     }]));
-
     const result = await ActivityService.getDecisionQueue('u1');
-    expect(result.items).toEqual([]);
-  });
-
-  test('a later executor update cannot resurrect a DECIDE row already ruled by Sam', async () => {
-    Task.find.mockReturnValue(taskChain([{
-      taskId: 'TASK-024', podId: 'pod-1', status: 'claimed', title: 'DECIDE: release scope',
-      updates: [
-        { text: 'OPTIONS: Ship now | Hold for review', createdAt: new Date() },
-        { text: 'SAM RULED: Ship now', createdAt: new Date() },
-        { text: 'Implementation started', createdAt: new Date() },
-      ],
-    }]));
-
-    const result = await ActivityService.getDecisionQueue('u1');
-    expect(result.items).toEqual([]);
-  });
-
-  test('renders only a complete bounded OPTIONS line on a DECIDE row', async () => {
-    Task.find.mockReturnValue(taskChain([
-      {
-        taskId: 'TASK-024', podId: 'pod-1', status: 'pending', title: 'DECIDE: release scope',
-        updates: [{ text: 'OPTIONS: Ship | Hold | Escalate', createdAt: new Date() }],
-      },
-      {
-        taskId: 'TASK-025', podId: 'pod-1', status: 'pending', title: 'DECIDE: ambiguous',
-        updates: [{ text: 'OPTIONS: Ship | ship', createdAt: new Date() }],
-      },
-      {
-        taskId: 'TASK-026', podId: 'pod-1', status: 'pending', title: 'DECIDE: too many',
-        updates: [{ text: 'OPTIONS: A | B | C | D | E', createdAt: new Date() }],
-      },
-    ]));
-    const result = await ActivityService.getDecisionQueue('u1');
-    expect(result.items.find((item) => item.taskId === 'TASK-024').options).toEqual(['Ship', 'Hold', 'Escalate']);
-    expect(result.items.find((item) => item.taskId === 'TASK-025').options).toBeUndefined();
-    expect(result.items.find((item) => item.taskId === 'TASK-026').options).toBeUndefined();
-  });
-
-  test('records one human ruling, emits the board update, and wakes the asking seats', async () => {
-    const task = {
-      _id: 'task-1', taskId: 'TASK-024', podId: 'pod-1', title: 'DECIDE: release scope', status: 'pending',
-      updates: [{ text: 'OPTIONS: Ship now | Hold for review', createdAt: new Date() }],
-    };
-    Pod.findById.mockReturnValue({ select: () => ({ lean: async () => ({ _id: 'pod-1', createdBy: 'u1', members: [] }) }) });
-    User.findById.mockReturnValue(userChain({ username: 'Sam', isBot: false }));
-    Task.findOne.mockReturnValue({ lean: async () => task });
-    const ruled = { ...task, updates: [...task.updates, { text: 'SAM RULED: Ship now' }], toObject: () => ({ ...task, ruled: true }) };
-    Task.findOneAndUpdate.mockResolvedValue(ruled);
-    notifyPodAgents.mockResolvedValue();
-
-    const result = await ActivityService.ruleTaskDecision({ podId: 'pod-1', taskId: 'TASK-024', option: 'Ship now', userId: 'u1' });
-
-    expect(result).toMatchObject({ status: 200, body: { ok: true, ruling: 'Ship now' } });
-    expect(Task.findOneAndUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ podId: 'pod-1', taskId: 'TASK-024' }),
-      expect.objectContaining({ $push: { updates: expect.objectContaining({ text: 'SAM RULED: Ship now', author: 'Sam', authorId: 'u1' }) } }),
-      { new: true },
-    );
-    expect(emitTaskUpdated).toHaveBeenCalledWith('pod-1', expect.objectContaining({ ruled: true }), 'updated');
-    expect(notifyPodAgents).toHaveBeenCalledWith('pod-1', expect.objectContaining({ ruled: true }), 'updated', { userId: 'u1', isAgent: false });
-  });
-
-  test('rejects a non-member and an option not declared by the task without writing a ruling', async () => {
-    const task = {
-      taskId: 'TASK-024', podId: 'pod-1', title: 'DECIDE: release scope',
-      status: 'pending',
-      updates: [{ text: 'OPTIONS: Ship now | Hold for review', createdAt: new Date() }],
-    };
-    Pod.findById.mockReturnValue({ select: () => ({ lean: async () => ({ _id: 'pod-1', createdBy: 'owner', members: [] }) }) });
-    expect(await ActivityService.ruleTaskDecision({ podId: 'pod-1', taskId: 'TASK-024', option: 'Ship now', userId: 'u1' }))
-      .toMatchObject({ status: 403 });
-
-    Pod.findById.mockReturnValue({ select: () => ({ lean: async () => ({ _id: 'pod-1', createdBy: 'u1', members: [] }) }) });
-    User.findById.mockReturnValue(userChain({ username: 'Sam', isBot: false }));
-    Task.findOne.mockReturnValue({ lean: async () => task });
-    expect(await ActivityService.ruleTaskDecision({ podId: 'pod-1', taskId: 'TASK-024', option: 'Delete it', userId: 'u1' }))
-      .toMatchObject({ status: 400 });
-    expect(Task.findOneAndUpdate).not.toHaveBeenCalled();
-  });
-
-  test('the compare-and-set makes a second tap lose without another wake', async () => {
-    const task = {
-      taskId: 'TASK-024', podId: 'pod-1', title: 'DECIDE: release scope',
-      updates: [{ text: 'OPTIONS: Ship now | Hold for review', createdAt: new Date() }],
-    };
-    Pod.findById.mockReturnValue({ select: () => ({ lean: async () => ({ _id: 'pod-1', createdBy: 'u1', members: [] }) }) });
-    User.findById.mockReturnValue(userChain({ username: 'Sam', isBot: false }));
-    Task.findOne.mockReturnValue({ lean: async () => task });
-    Task.findOneAndUpdate.mockResolvedValue(null);
-
-    expect(await ActivityService.ruleTaskDecision({ podId: 'pod-1', taskId: 'TASK-024', option: 'Ship now', userId: 'u1' }))
-      .toMatchObject({ status: 409 });
-    expect(emitTaskUpdated).not.toHaveBeenCalled();
-    expect(notifyPodAgents).not.toHaveBeenCalled();
+    expect(result.items).toEqual([expect.objectContaining({ taskId: 'TASK-059', kind: 'press' })]);
   });
 });

--- a/backend/__tests__/unit/services/decisionRequestService.test.js
+++ b/backend/__tests__/unit/services/decisionRequestService.test.js
@@ -152,14 +152,21 @@ describe('DecisionRequestService', () => {
     expect(mockPGMessage.create).not.toHaveBeenCalled();
   });
 
-  test('refuses bot and non-member callers before claiming the decision', async () => {
+  test('refuses a bot caller before it reads pod membership or claims the decision', async () => {
     mockDecision.findById.mockResolvedValue(pending());
     mockUser.findById.mockReturnValue(userChain({ _id: 'bot-1', username: 'bot', isBot: true }));
-    expect(await chooseDecision({ decisionId: 'decision-1', callerUserId: 'bot-1', value: 'Canary' })).toMatchObject({ status: 403 });
+    await expect(chooseDecision({ decisionId: 'decision-1', callerUserId: 'bot-1', value: 'Canary' }))
+      .resolves.toEqual({ status: 403, body: { error: 'Only a human can rule on this decision' } });
+    expect(mockPod.findById).not.toHaveBeenCalled();
+    expect(mockDecision.findOneAndUpdate).not.toHaveBeenCalled();
+  });
 
+  test('refuses a non-member caller before claiming the decision', async () => {
+    mockDecision.findById.mockResolvedValue(pending());
     mockUser.findById.mockReturnValue(userChain({ _id: 'stranger', username: 'Stranger', isBot: false }));
     mockPod.findById.mockReturnValue(podChain({ createdBy: 'owner', members: ['member'], type: 'team' }));
-    expect(await chooseDecision({ decisionId: 'decision-1', callerUserId: 'stranger', value: 'Canary' })).toMatchObject({ status: 403 });
+    await expect(chooseDecision({ decisionId: 'decision-1', callerUserId: 'stranger', value: 'Canary' }))
+      .resolves.toEqual({ status: 403, body: { error: 'Only human pod members can rule on this decision' } });
     expect(mockDecision.findOneAndUpdate).not.toHaveBeenCalled();
   });
 });

--- a/backend/__tests__/unit/services/decisionRequestService.test.js
+++ b/backend/__tests__/unit/services/decisionRequestService.test.js
@@ -39,7 +39,7 @@ const mockResolveThreadRoot = jest.fn();
 jest.mock('../../../services/threadRootResolver', () => ({ resolveThreadRoot: (...args) => mockResolveThreadRoot(...args) }));
 
 const {
-  requestDecision, chooseDecision, normalizeOptions, DecisionRequestError,
+  requestDecision, chooseDecision, normalizeOptions, normalizeDecisionClass, DecisionRequestError,
 } = require('../../../services/decisionRequestService');
 
 const userChain = (user) => ({ select: () => ({ lean: async () => user }) });
@@ -47,7 +47,7 @@ const podChain = (pod) => ({ select: () => ({ lean: async () => pod }) });
 
 const source = () => ({
   podId: 'pod-1', agentUserId: 'agent-user-1', agentName: 'release-agent', instanceId: 'seat-1',
-  displayName: 'Release Agent', title: 'Choose the release train', question: 'Which rollout should I run?',
+  displayName: 'Release Agent', decisionClass: 'implementation', title: 'Choose the release train', question: 'Which rollout should I run?',
   options: [
     { label: 'Canary', description: 'Small cohort.', recommended: true },
     { label: 'Fast lane', description: 'Ship once green.' },
@@ -56,7 +56,7 @@ const source = () => ({
 });
 
 const pending = (overrides = {}) => ({
-  _id: 'decision-1', podId: 'pod-1', agentUserId: 'agent-user-1', agentName: 'release-agent', instanceId: 'seat-1',
+  _id: 'decision-1', podId: 'pod-1', agentUserId: 'agent-user-1', agentName: 'release-agent', instanceId: 'seat-1', decisionClass: 'implementation',
   title: 'Choose the release train', question: 'Which rollout should I run?',
   options: [{ label: 'Canary', recommended: true }, { label: 'Fast lane' }], status: 'pending',
   messageId: '700', threadRootId: '612', ...overrides,
@@ -84,7 +84,7 @@ describe('DecisionRequestService', () => {
     }));
     expect(mockPostMessage.mock.calls[0][0].content).toContain('Choose the release train');
     expect(mockDecision.create).toHaveBeenCalledWith(expect.objectContaining({
-      agentUserId: 'agent-user-1', agentName: 'release-agent', instanceId: 'seat-1',
+      agentUserId: 'agent-user-1', agentName: 'release-agent', instanceId: 'seat-1', decisionClass: 'implementation',
       messageId: '700', status: 'pending',
     }));
     expect(result).toEqual({ decisionId: 'decision-1', messageId: '700', threadRootId: '612', status: 'pending' });
@@ -105,6 +105,13 @@ describe('DecisionRequestService', () => {
       .toEqual([{ label: 'A' }, { label: 'B', description: 'why' }]);
     expect(() => normalizeOptions(Array.from({ length: 5 }, (_, index) => ({ label: `Choice ${index}` }))))
       .toThrow(DecisionRequestError);
+  });
+
+  test('requires an advisory decision class and rejects consent-shaped classes', async () => {
+    expect(normalizeDecisionClass('strategy')).toBe('strategy');
+    expect(() => normalizeDecisionClass('approval')).toThrow(DecisionRequestError);
+    await expect(requestDecision({ ...source(), decisionClass: 'credential_use' }))
+      .rejects.toMatchObject({ status: 400, code: 'invalid_decision_class' });
   });
 
   test('one human member posts an exact threaded ruling and wakes the asking agent', async () => {

--- a/backend/__tests__/unit/services/decisionRequestService.test.js
+++ b/backend/__tests__/unit/services/decisionRequestService.test.js
@@ -1,0 +1,158 @@
+/**
+ * Agent-authored decisions deliberately use normal chat replies as their
+ * return transport. These tests pin the source provenance, exact value, and
+ * the compare-and-set that prevents two browser tabs from waking the asker
+ * with contradictory rulings.
+ */
+
+const mockDecision = {
+  create: jest.fn(), findById: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn(),
+};
+jest.mock('../../../models/DecisionRequest', () => mockDecision);
+
+const mockPod = { findById: jest.fn() };
+jest.mock('../../../models/Pod', () => mockPod);
+
+const mockUser = { findById: jest.fn() };
+jest.mock('../../../models/User', () => mockUser);
+
+const mockPostMessage = jest.fn();
+jest.mock('../../../services/agentMessageService', () => ({ postMessage: (...args) => mockPostMessage(...args) }));
+
+const mockPGMessage = { create: jest.fn(), findById: jest.fn() };
+jest.mock('../../../models/pg/Message', () => mockPGMessage);
+
+const mockPGPod = { findById: jest.fn() };
+jest.mock('../../../models/pg/Pod', () => mockPGPod);
+
+const mockSyncPod = jest.fn();
+jest.mock('../../../services/pgPodSyncService', () => ({ syncPodFromMongo: (...args) => mockSyncPod(...args) }));
+
+const mockDeliver = jest.fn();
+jest.mock('../../../services/messageAgentDeliveryService', () => ({ deliverMessageToAgents: (...args) => mockDeliver(...args) }));
+
+const mockEmit = jest.fn();
+const mockTo = jest.fn(() => ({ emit: mockEmit }));
+jest.mock('../../../config/socket', () => ({ getIO: jest.fn(() => ({ to: mockTo })) }));
+
+const mockResolveThreadRoot = jest.fn();
+jest.mock('../../../services/threadRootResolver', () => ({ resolveThreadRoot: (...args) => mockResolveThreadRoot(...args) }));
+
+const {
+  requestDecision, chooseDecision, normalizeOptions, DecisionRequestError,
+} = require('../../../services/decisionRequestService');
+
+const userChain = (user) => ({ select: () => ({ lean: async () => user }) });
+const podChain = (pod) => ({ select: () => ({ lean: async () => pod }) });
+
+const source = () => ({
+  podId: 'pod-1', agentUserId: 'agent-user-1', agentName: 'release-agent', instanceId: 'seat-1',
+  displayName: 'Release Agent', title: 'Choose the release train', question: 'Which rollout should I run?',
+  options: [
+    { label: 'Canary', description: 'Small cohort.', recommended: true },
+    { label: 'Fast lane', description: 'Ship once green.' },
+  ],
+  threadRootId: '612', context: 'The branch is green.',
+});
+
+const pending = (overrides = {}) => ({
+  _id: 'decision-1', podId: 'pod-1', agentUserId: 'agent-user-1', agentName: 'release-agent', instanceId: 'seat-1',
+  title: 'Choose the release train', question: 'Which rollout should I run?',
+  options: [{ label: 'Canary', recommended: true }, { label: 'Fast lane' }], status: 'pending',
+  messageId: '700', threadRootId: '612', ...overrides,
+});
+
+describe('DecisionRequestService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPGPod.findById.mockResolvedValue({ id: 'pod-1' });
+    mockSyncPod.mockResolvedValue({ id: 'pod-1' });
+    mockPostMessage.mockResolvedValue({ success: true, message: { _id: '700' } });
+    mockDecision.create.mockImplementation(async (row) => ({ ...row, _id: 'decision-1' }));
+    mockResolveThreadRoot.mockResolvedValue(612);
+    mockPGMessage.create.mockResolvedValue({ id: '901' });
+    mockPGMessage.findById.mockResolvedValue({ id: '901', userId: { username: 'Sam' } });
+    mockDeliver.mockResolvedValue({});
+  });
+
+  test('derives the asking agent from runtime input and posts a replyable source before queue visibility', async () => {
+    const result = await requestDecision(source());
+
+    expect(mockPostMessage).toHaveBeenCalledWith(expect.objectContaining({
+      agentName: 'release-agent', instanceId: 'seat-1', podId: 'pod-1', threadRootId: '612',
+      metadata: { source: 'decision-request' },
+    }));
+    expect(mockPostMessage.mock.calls[0][0].content).toContain('Choose the release train');
+    expect(mockDecision.create).toHaveBeenCalledWith(expect.objectContaining({
+      agentUserId: 'agent-user-1', agentName: 'release-agent', instanceId: 'seat-1',
+      messageId: '700', status: 'pending',
+    }));
+    expect(result).toEqual({ decisionId: 'decision-1', messageId: '700', threadRootId: '612', status: 'pending' });
+  });
+
+  test('rejects malformed choices before it writes the source message', async () => {
+    await expect(requestDecision({ ...source(), options: [{ label: 'Only choice' }] }))
+      .rejects.toMatchObject({ status: 400, code: 'invalid_options' });
+    await expect(requestDecision({ ...source(), options: [{ label: 'Same' }, { label: 'same' }] }))
+      .rejects.toMatchObject({ status: 400, code: 'duplicate_options' });
+    await expect(requestDecision({ ...source(), options: [{ label: 'A', recommended: true }, { label: 'B', recommended: true }] }))
+      .rejects.toMatchObject({ status: 400, code: 'multiple_recommended' });
+    expect(mockPostMessage).not.toHaveBeenCalled();
+  });
+
+  test('normalizes only a valid 2–4 option shape', () => {
+    expect(normalizeOptions([{ label: 'A' }, { label: 'B', description: 'why' }]))
+      .toEqual([{ label: 'A' }, { label: 'B', description: 'why' }]);
+    expect(() => normalizeOptions(Array.from({ length: 5 }, (_, index) => ({ label: `Choice ${index}` }))))
+      .toThrow(DecisionRequestError);
+  });
+
+  test('one human member posts an exact threaded ruling and wakes the asking agent', async () => {
+    const row = pending();
+    mockDecision.findById.mockResolvedValue(row);
+    mockUser.findById.mockReturnValue(userChain({ _id: 'human-1', username: 'Sam', isBot: false }));
+    mockPod.findById.mockImplementation(() => podChain({ createdBy: 'human-1', members: ['human-1'], type: 'team' }));
+    mockDecision.findOneAndUpdate
+      .mockResolvedValueOnce({ ...row, rulingLock: { token: 'lock' } })
+      .mockResolvedValueOnce({ ...row, status: 'ruled', ruling: { value: 'Hold for customer evidence', byUsername: 'Sam', messageId: '901' } });
+
+    const result = await chooseDecision({ decisionId: 'decision-1', callerUserId: 'human-1', value: 'Hold for customer evidence' });
+
+    expect(result).toMatchObject({ status: 200, body: { ok: true, decision: { ruling: { value: 'Hold for customer evidence', by: 'Sam' } } } });
+    expect(mockPGMessage.create).toHaveBeenCalledWith(
+      'pod-1', 'human-1', 'Hold for customer evidence', 'text', '700', null, 612,
+    );
+    expect(mockResolveThreadRoot).toHaveBeenCalledWith({
+      podId: 'pod-1', replyToMessageId: '700', threadRootId: '612',
+    });
+    expect(mockDeliver).toHaveBeenCalledWith(expect.objectContaining({
+      podId: 'pod-1', userId: 'human-1', replyToMessageId: '700',
+    }));
+    expect(mockTo).toHaveBeenCalledWith('pod_pod-1');
+    expect(mockEmit).toHaveBeenCalledWith('newMessage', expect.objectContaining({
+      pod_id: 'pod-1', replyTo: null,
+    }));
+    expect(mockDecision.findOneAndUpdate).toHaveBeenCalledTimes(2);
+    expect(mockDecision.findOneAndUpdate.mock.calls[1][1].$set.ruling.value)
+      .toBe('Hold for customer evidence');
+  });
+
+  test('a second tab sees the standing ruling and cannot create another wake', async () => {
+    const ruled = pending({ status: 'ruled', ruling: { value: 'Canary', byUsername: 'Sam', at: new Date(), messageId: '901' } });
+    mockDecision.findById.mockResolvedValue(ruled);
+    const result = await chooseDecision({ decisionId: 'decision-1', callerUserId: 'human-2', value: 'Fast lane' });
+    expect(result).toMatchObject({ status: 409, body: { decision: { ruling: { value: 'Canary', by: 'Sam' } } } });
+    expect(mockPGMessage.create).not.toHaveBeenCalled();
+  });
+
+  test('refuses bot and non-member callers before claiming the decision', async () => {
+    mockDecision.findById.mockResolvedValue(pending());
+    mockUser.findById.mockReturnValue(userChain({ _id: 'bot-1', username: 'bot', isBot: true }));
+    expect(await chooseDecision({ decisionId: 'decision-1', callerUserId: 'bot-1', value: 'Canary' })).toMatchObject({ status: 403 });
+
+    mockUser.findById.mockReturnValue(userChain({ _id: 'stranger', username: 'Stranger', isBot: false }));
+    mockPod.findById.mockReturnValue(podChain({ createdBy: 'owner', members: ['member'], type: 'team' }));
+    expect(await chooseDecision({ decisionId: 'decision-1', callerUserId: 'stranger', value: 'Canary' })).toMatchObject({ status: 403 });
+    expect(mockDecision.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/backend/models/DecisionRequest.ts
+++ b/backend/models/DecisionRequest.ts
@@ -1,0 +1,101 @@
+import mongoose, { Document, Model, Schema, Types } from 'mongoose';
+
+/**
+ * An agent-authored fork that needs a human ruling.
+ *
+ * A DecisionRequest is deliberately distinct from ApprovalAction: it carries
+ * a question and declared alternatives, never an executable action or a
+ * credential-bearing payload. Privileged, real-world actions keep using the
+ * owner-scoped approval path.
+ */
+export interface DecisionOption {
+  label: string;
+  description?: string;
+  recommended?: boolean;
+}
+
+export interface DecisionRuling {
+  value: string;
+  byUserId: Types.ObjectId;
+  byUsername: string;
+  at: Date;
+  messageId: string;
+}
+
+export interface IDecisionRequest extends Document {
+  podId: Types.ObjectId;
+  agentUserId: Types.ObjectId;
+  agentName: string;
+  instanceId: string;
+  title: string;
+  question: string;
+  context?: string;
+  options: DecisionOption[];
+  status: 'pending' | 'ruled';
+  messageId?: string;
+  threadRootId?: string;
+  ruling?: DecisionRuling;
+  rulingLock?: { token: string; expiresAt: Date };
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const DecisionOptionSchema = new Schema<DecisionOption>(
+  {
+    label: { type: String, required: true, trim: true, maxlength: 80 },
+    description: { type: String, trim: true, maxlength: 280 },
+    recommended: { type: Boolean, default: false },
+  },
+  { _id: false },
+);
+
+const DecisionRequestSchema = new Schema<IDecisionRequest>(
+  {
+    podId: { type: Schema.Types.ObjectId, ref: 'Pod', required: true },
+    // Provenance is derived from the authenticated runtime identity, never
+    // accepted from the MCP/CAP request body.
+    agentUserId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    agentName: { type: String, required: true, trim: true, lowercase: true },
+    instanceId: { type: String, required: true, trim: true, lowercase: true, default: 'default' },
+    title: { type: String, required: true, trim: true, maxlength: 160 },
+    question: { type: String, required: true, trim: true, maxlength: 1000 },
+    context: { type: String, trim: true, maxlength: 2000 },
+    options: {
+      type: [DecisionOptionSchema], required: true, validate: {
+        validator: (options: DecisionOption[]) => Array.isArray(options) && options.length >= 2 && options.length <= 4,
+        message: 'DecisionRequest options must contain 2–4 choices',
+      },
+    },
+    status: { type: String, enum: ['pending', 'ruled'], default: 'pending', index: true },
+    // Assigned only after the asker's source message persists. Pending rows
+    // without it are intentionally invisible to the Activity projection.
+    messageId: { type: String, trim: true },
+    threadRootId: { type: String, trim: true },
+    ruling: {
+      value: { type: String, trim: true, maxlength: 2000 },
+      byUserId: { type: Schema.Types.ObjectId, ref: 'User' },
+      byUsername: { type: String, trim: true },
+      at: { type: Date },
+      messageId: { type: String, trim: true },
+    },
+    // A short write lease prevents two browser tabs from posting conflicting
+    // replies before the compare-and-set can record the winning ruling.
+    rulingLock: {
+      token: { type: String },
+      expiresAt: { type: Date },
+    },
+  },
+  { timestamps: true },
+);
+
+// The Activity queue is a cross-pod read over a human's memberships. This
+// index supplies its pod/status filter; individual pod thread lookups use the
+// messageId stored on the row.
+DecisionRequestSchema.index({ podId: 1, status: 1, createdAt: -1 });
+
+const DecisionRequest: Model<IDecisionRequest> = (mongoose.models.DecisionRequest as Model<IDecisionRequest>)
+  || mongoose.model<IDecisionRequest>('DecisionRequest', DecisionRequestSchema);
+
+export default DecisionRequest;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = DecisionRequest;

--- a/backend/models/DecisionRequest.ts
+++ b/backend/models/DecisionRequest.ts
@@ -14,6 +14,12 @@ export interface DecisionOption {
   recommended?: boolean;
 }
 
+// A DecisionRequest is intentionally limited to advisory forks. Any class
+// that could authorize an outward-facing act, credential use, or other
+// side-effect belongs to ApprovalAction instead.
+export const DECISION_CLASSES = ['strategy', 'implementation', 'prioritization'] as const;
+export type DecisionClass = typeof DECISION_CLASSES[number];
+
 export interface DecisionRuling {
   value: string;
   byUserId: Types.ObjectId;
@@ -27,6 +33,7 @@ export interface IDecisionRequest extends Document {
   agentUserId: Types.ObjectId;
   agentName: string;
   instanceId: string;
+  decisionClass: DecisionClass;
   title: string;
   question: string;
   context?: string;
@@ -57,6 +64,7 @@ const DecisionRequestSchema = new Schema<IDecisionRequest>(
     agentUserId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
     agentName: { type: String, required: true, trim: true, lowercase: true },
     instanceId: { type: String, required: true, trim: true, lowercase: true, default: 'default' },
+    decisionClass: { type: String, required: true, enum: DECISION_CLASSES },
     title: { type: String, required: true, trim: true, maxlength: 160 },
     question: { type: String, required: true, trim: true, maxlength: 1000 },
     context: { type: String, trim: true, maxlength: 2000 },

--- a/backend/routes/activity.ts
+++ b/backend/routes/activity.ts
@@ -194,6 +194,30 @@ router.post('/:activityId/reply', auth, async (req: Req, res: Res) => {
   }
 });
 
+// A DECIDE row's `OPTIONS: A | B` line is rendered in the Activity queue.
+// The human tap resolves through the board's own update stream, not a second
+// activity record, so the asking agents receive the ordinary task update.
+router.post('/tasks/:taskId/rule', auth, async (req: Req, res: Res) => {
+  try {
+    const { taskId } = req.params || {};
+    const { podId, option } = (req.body || {}) as { podId?: unknown; option?: unknown };
+    if (typeof podId !== 'string' || typeof option !== 'string') {
+      return res.status(400).json({ error: 'podId and option must be strings' });
+    }
+    const userId = getAuthenticatedUserId(req);
+    const result = await ActivityService.ruleTaskDecision({
+      podId,
+      taskId: String(taskId || ''),
+      option,
+      userId,
+    }) as { status: number; body: Record<string, unknown> };
+    return res.status(result.status).json(result.body);
+  } catch (error) {
+    console.error('Error ruling on task decision:', error);
+    return res.status(500).json({ error: 'Failed to rule on decision' });
+  }
+});
+
 router.post('/:activityId/approve', auth, async (req: Req, res: Res) => {
   try {
     const { activityId } = req.params || {};

--- a/backend/routes/activity.ts
+++ b/backend/routes/activity.ts
@@ -15,6 +15,8 @@ const User = require('../models/User');
 // eslint-disable-next-line global-require
 const ActivityService = require('../services/activityService');
 // eslint-disable-next-line global-require
+const DecisionRequestService = require('../services/decisionRequestService');
+// eslint-disable-next-line global-require
 const getAuthenticatedUserId = require('../utils/getAuthenticatedUserId');
 // eslint-disable-next-line global-require
 const Pod = require('../models/Pod');
@@ -111,6 +113,29 @@ router.get('/decision-queue', auth, async (req: Req, res: Res) => {
   }
 });
 
+// Human-only by construction: this route uses `auth`, not dual auth. The
+// service repeats the isBot + pod-membership checks so a future middleware
+// change cannot turn an agent token into a decision authority.
+router.post('/decisions/:decisionId/choose', auth, async (req: Req, res: Res) => {
+  try {
+    const decisionId = String(req.params?.decisionId || '');
+    const value = (req.body || {}).value;
+    const userId = getAuthenticatedUserId(req);
+    const result = await DecisionRequestService.chooseDecision({
+      decisionId,
+      callerUserId: String(userId || ''),
+      value,
+    });
+    return res.status(result.status).json(result.body);
+  } catch (error: any) {
+    if (error instanceof DecisionRequestService.DecisionRequestError) {
+      return res.status(error.status).json({ error: error.message, code: error.code });
+    }
+    console.error('Error choosing a decision:', error);
+    return res.status(500).json({ error: 'Failed to choose a decision' });
+  }
+});
+
 router.get('/approvals', auth, async (req: Req, res: Res) => {
   try {
     const userId = getAuthenticatedUserId(req);
@@ -191,30 +216,6 @@ router.post('/:activityId/reply', auth, async (req: Req, res: Res) => {
   } catch (error) {
     console.error('Error replying to activity:', error);
     return res.status(500).json({ error: 'Failed to reply' });
-  }
-});
-
-// A DECIDE row's `OPTIONS: A | B` line is rendered in the Activity queue.
-// The human tap resolves through the board's own update stream, not a second
-// activity record, so the asking agents receive the ordinary task update.
-router.post('/tasks/:taskId/rule', auth, async (req: Req, res: Res) => {
-  try {
-    const { taskId } = req.params || {};
-    const { podId, option } = (req.body || {}) as { podId?: unknown; option?: unknown };
-    if (typeof podId !== 'string' || typeof option !== 'string') {
-      return res.status(400).json({ error: 'podId and option must be strings' });
-    }
-    const userId = getAuthenticatedUserId(req);
-    const result = await ActivityService.ruleTaskDecision({
-      podId,
-      taskId: String(taskId || ''),
-      option,
-      userId,
-    }) as { status: number; body: Record<string, unknown> };
-    return res.status(result.status).json(result.body);
-  } catch (error) {
-    console.error('Error ruling on task decision:', error);
-    return res.status(500).json({ error: 'Failed to rule on decision' });
   }
 });
 

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -3664,7 +3664,7 @@ router.post('/decisions', phase4RateLimit, agentRuntimeAuth, async (req: any, re
     // decision surface. Privileged work must go through `propose-action`,
     // whose owner/CAS gate is deliberately stronger.
     const DECISION_REQUEST_FIELDS = new Set([
-      'podId', 'title', 'question', 'options', 'threadRootId', 'context',
+      'podId', 'decisionClass', 'title', 'question', 'options', 'threadRootId', 'context',
     ]);
     const unsupportedFields = Object.keys(req.body || {})
       .filter((field) => !DECISION_REQUEST_FIELDS.has(field));
@@ -3676,7 +3676,7 @@ router.post('/decisions', phase4RateLimit, agentRuntimeAuth, async (req: any, re
       });
     }
     const {
-      podId, title, question, options, threadRootId, context,
+      podId, decisionClass, title, question, options, threadRootId, context,
     } = req.body || {};
     if (typeof podId !== 'string' || !podId.trim()) {
       return res.status(400).json({ message: 'podId is required', code: 'podId_required' });
@@ -3706,6 +3706,7 @@ router.post('/decisions', phase4RateLimit, agentRuntimeAuth, async (req: any, re
       instanceId: installation.instanceId || 'default',
       displayName: installation.displayName,
       installationConfig: installation.config || null,
+      decisionClass,
       title,
       question,
       options,

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -115,6 +115,7 @@ const {
   describeCycleMutation,
 } = require('../services/agentMemoryService');
 const AgentAskService = require('../services/agentAskService');
+const DecisionRequestService = require('../services/decisionRequestService');
 const DMService = require('../services/dmService');
 const ChatSummarizerService = require('../services/chatSummarizerService');
 const AgentMentionService = require('../services/agentMentionService');
@@ -3645,6 +3646,62 @@ router.post('/pods/:podId/ask', agentRuntimeAuth, phase4RateLimit, async (req: a
   } catch (err: any) {
     console.error('POST /pods/:podId/ask error:', err);
     return res.status(500).json({ message: 'Failed to ask agent' });
+  }
+});
+
+/**
+ * POST /decisions (agent runtime token auth)
+ *
+ * An agent asks a human member of its pod to choose between 2–4 declared
+ * approaches. This is advisory coordination only: it carries no executable
+ * action payload and therefore cannot substitute for an ApprovalAction.
+ */
+router.post('/decisions', phase4RateLimit, agentRuntimeAuth, async (req: any, res: any) => {
+  try {
+    const {
+      podId, title, question, options, threadRootId, context,
+    } = req.body || {};
+    if (typeof podId !== 'string' || !podId.trim()) {
+      return res.status(400).json({ message: 'podId is required', code: 'podId_required' });
+    }
+    const installation = resolveInstallationForPod(
+      req.agentInstallations,
+      req.agentInstallation,
+      podId,
+    );
+    if (!ensurePodMatch(req.agentInstallations || installation, podId, req.agentAuthorizedPodIds)) {
+      return res.status(403).json({ message: 'Agent token not authorized for this pod' });
+    }
+    if (!req.agentUser?._id || !installation?.agentName) {
+      return res.status(403).json({ message: 'Could not resolve agent identity' });
+    }
+    if (threadRootId !== undefined && typeof threadRootId !== 'string') {
+      return res.status(400).json({ message: 'threadRootId must be a string', code: 'invalid_threadRootId' });
+    }
+    if (context !== undefined && typeof context !== 'string') {
+      return res.status(400).json({ message: 'context must be a string', code: 'invalid_context' });
+    }
+
+    const result = await DecisionRequestService.requestDecision({
+      podId,
+      agentUserId: String(req.agentUser._id),
+      agentName: installation.agentName,
+      instanceId: installation.instanceId || 'default',
+      displayName: installation.displayName,
+      installationConfig: installation.config || null,
+      title,
+      question,
+      options,
+      threadRootId,
+      context,
+    });
+    return res.status(201).json(result);
+  } catch (error: any) {
+    if (error instanceof DecisionRequestService.DecisionRequestError) {
+      return res.status(error.status).json({ message: error.message, code: error.code });
+    }
+    console.error('POST /decisions error:', error);
+    return res.status(500).json({ message: 'Failed to request a decision' });
   }
 });
 

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -3658,6 +3658,23 @@ router.post('/pods/:podId/ask', agentRuntimeAuth, phase4RateLimit, async (req: a
  */
 router.post('/decisions', phase4RateLimit, agentRuntimeAuth, async (req: any, res: any) => {
   try {
+    // A human choice here is a normal chat ruling, not a consent grant. Keep
+    // this envelope deliberately closed so an agent cannot smuggle a typed
+    // action, scopes, or a credential reference through the friendlier
+    // decision surface. Privileged work must go through `propose-action`,
+    // whose owner/CAS gate is deliberately stronger.
+    const DECISION_REQUEST_FIELDS = new Set([
+      'podId', 'title', 'question', 'options', 'threadRootId', 'context',
+    ]);
+    const unsupportedFields = Object.keys(req.body || {})
+      .filter((field) => !DECISION_REQUEST_FIELDS.has(field));
+    if (unsupportedFields.length) {
+      return res.status(400).json({
+        message: `Unsupported decision request fields: ${unsupportedFields.join(', ')}.`
+          + ' Use propose-action for privileged side effects.',
+        code: 'unsupported_decision_fields',
+      });
+    }
     const {
       podId, title, question, options, threadRootId, context,
     } = req.body || {};

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -11,7 +11,7 @@ const Post = require('../models/Post');
 // eslint-disable-next-line global-require
 const Task = require('../models/Task');
 // eslint-disable-next-line global-require
-const ApprovalAction = require('../models/ApprovalAction');
+const DecisionRequest = require('../models/DecisionRequest');
 
 let PGMessage: unknown = null;
 try {
@@ -112,42 +112,6 @@ interface ComputeFlagsOptions {
 // (95 updates in one window, TASK-083) drowned every real seat, which is what
 // made the Activity tab read as empty of real agent activity.
 const SYSTEM_BOT_NAMES = new Set(['commonly-bot', 'commonly-ai-agent']);
-
-// Decision options deliberately stay in the task's latest human-readable
-// update instead of gaining a second board state. Agents can propose a
-// decision with one portable line, and the queue can render it without
-// teaching every task producer a new write shape.
-//
-// The grammar is intentionally small: `OPTIONS: A | B | C`. Keeping it
-// bounded makes every option a tap target, while rejecting malformed lines
-// rather than guessing prevents a partial proposal from becoming a ruling.
-const parseDecisionOptions = (text: unknown): string[] => {
-  if (typeof text !== 'string') return [];
-  const line = text.match(/^\s*OPTIONS:\s*(.+?)\s*$/im)?.[1];
-  if (!line) return [];
-  const options = line.split('|').map((value) => value.trim()).filter(Boolean);
-  if (options.length < 2 || options.length > 4 || options.some((value) => value.length > 80)) return [];
-  const normalized = new Set(options.map((value) => value.toLocaleLowerCase()));
-  return normalized.size === options.length ? options : [];
-};
-
-const getTaskDecisionOptions = (task: Record<string, unknown>): string[] => {
-  const updates = Array.isArray(task.updates) ? task.updates as Array<{ text?: unknown }> : [];
-  for (const update of [...updates].reverse()) {
-    const options = parseDecisionOptions(update?.text);
-    if (options.length) return options;
-  }
-  return parseDecisionOptions(task.title);
-};
-
-const hasRuling = (task: Record<string, unknown>): boolean => {
-  const updates = Array.isArray(task.updates) ? task.updates as Array<{ text?: unknown }> : [];
-  // A DECIDE row stays open for the executor after the human rules, so an
-  // executor's later progress note must not put the resolved decision back
-  // into the attention queue. Unlike the handoff heuristic, this terminal
-  // marker is intentionally searched across the row's full update history.
-  return updates.some((update) => /^\s*SAM RULED:\s*/i.test(String(update?.text || '')));
-};
 
 class ActivityService {
   /**
@@ -476,11 +440,9 @@ class ActivityService {
 
   /**
    * The decision queue: everything concretely waiting on THIS human, from
-   * facts that exist today (TASK-083 defect 1's fix): pending approval
-   * requests, unacknowledged direct mentions, and board rows that name a
-   * human decision — DECIDE-titled tasks, blocked tasks, and tasks whose
-   * latest update hands off to a human press/ruling. No inference, no
-   * name-matching heuristics (TASK-070b stays open by design).
+   * stored facts: existing approval requests, unacknowledged direct mentions,
+   * agent-authored DecisionRequests, and explicit board press handoffs.
+   * A board title is never parsed into a decision surface.
    */
   /**
    * Every message in the user's pods that @mentions them, threads included,
@@ -525,76 +487,6 @@ class ActivityService {
       .filter((m) => !acked.has(m.id));
   }
 
-  /**
-   * A human ruling is a board update, not a new activity record. The task
-   * update wakes the asking seat through the established board fan-out and
-   * its terminal marker removes the resolved DECIDE row from this queue.
-   */
-  static async ruleTaskDecision(options: {
-    podId: string;
-    taskId: string;
-    option: string;
-    userId: unknown;
-  }): Promise<{ status: number; body: Record<string, unknown> }> {
-    const { podId, taskId, option, userId } = options;
-    if (!podId || !taskId || !option) return { status: 400, body: { error: 'podId, taskId, and option are required' } };
-
-    const pod = await Pod.findById(podId).select('createdBy members').lean() as PodDoc | null;
-    if (!pod) return { status: 404, body: { error: 'Pod not found' } };
-    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
-    const isPodMember = require('../utils/isPodMember');
-    if (!isPodMember(pod, userId)) return { status: 403, body: { error: 'Only pod members can rule on this decision' } };
-
-    const caller = await User.findById(userId).select('username isBot').lean() as { username?: string; isBot?: boolean } | null;
-    if (!caller || caller.isBot) return { status: 403, body: { error: 'Only a human can rule on this decision' } };
-
-    const task = await Task.findOne({ podId, taskId }).lean() as Record<string, unknown> | null;
-    if (!task) return { status: 404, body: { error: 'Task not found' } };
-    if (!['pending', 'claimed', 'blocked'].includes(String(task.status || ''))) {
-      return { status: 409, body: { error: 'Decision is no longer active' } };
-    }
-    if (!/^DECIDE\b/i.test(String(task.title || ''))) {
-      return { status: 400, body: { error: 'Task is not a decision request' } };
-    }
-    if (hasRuling(task)) return { status: 409, body: { error: 'Decision already ruled' } };
-
-    const choices = getTaskDecisionOptions(task);
-    if (!choices.includes(option)) return { status: 400, body: { error: 'Option is not available for this decision' } };
-
-    const now = new Date();
-    const update = {
-      text: `SAM RULED: ${option}`,
-      author: caller.username || 'Human',
-      authorId: String(userId),
-      createdAt: now,
-    };
-    // The ruling marker is the compare-and-set. A double tap (or a second
-    // browser) loses before it can append a conflicting human decision.
-    const ruled = await Task.findOneAndUpdate(
-      {
-        podId,
-        taskId,
-        status: { $in: ['pending', 'claimed', 'blocked'] },
-        updates: { $not: { $elemMatch: { text: /^\s*SAM RULED:\s*/i } } },
-      },
-      { $push: { updates: update } },
-      { new: true },
-    );
-    if (!ruled) return { status: 409, body: { error: 'Decision already ruled' } };
-
-    const emittedTask = typeof ruled.toObject === 'function' ? ruled.toObject() : ruled;
-    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
-    const { emitTaskUpdated, notifyPodAgents } = require('./taskEventService');
-    emitTaskUpdated(podId, emittedTask, 'updated');
-    try {
-      const pending = notifyPodAgents(podId, emittedTask, 'updated', { userId, isAgent: false });
-      if (pending?.catch) pending.catch((err: Error) => console.warn('[decision-rule] agent notify failed:', err.message));
-    } catch (err) {
-      console.warn('[decision-rule] agent notify threw:', (err as Error).message);
-    }
-    return { status: 200, body: { ok: true, ruling: option, task: emittedTask } };
-  }
-
   static async getDecisionQueue(userId: unknown): Promise<Record<string, unknown>> {
     const pods: PodDoc[] = await Pod.find({
       $or: [
@@ -614,32 +506,29 @@ class ActivityService {
       podId: string | null;
       podName?: string;
       taskId?: string;
-      options?: string[];
+      options?: Array<{ label: string; description?: string; recommended?: boolean }>;
+      messageId?: string;
+      threadRootId?: string;
       createdAt: Date | string | null;
     };
     const items: QueueItem[] = [];
     let composePodId: string | null = null;
 
-    // 1. Pending approval cards — the durable ApprovalAction row is the
-    // decision object. Legacy Activity.approval rows are seed-fed and must not
-    // enter this queue, or a card would appear twice on two different routes.
-    // This filter intentionally mirrors resolveApproval's owner gate: a
-    // "Needs you" row must never offer a press to a non-decider.
+    // 1. Existing binary approvals stay on their established Activity path.
+    // DecisionRequest is additive; it does not widen or replace the
+    // owner-scoped ApprovalAction flow.
     try {
-      const approvals = await ApprovalAction.find({ ownerUserId: userId, status: 'flagged' })
-        .sort({ createdAt: -1 })
-        .limit(50)
-        .lean() as Array<{
-          _id: { toString(): string }; summary?: string; podId?: unknown; createdAt?: Date;
-          agentName?: string;
-        }>;
+      const approvals = await ActivityService.getPendingApprovals(userId) as Array<{
+        _id: { toString(): string }; content?: string; podId?: unknown; createdAt?: Date;
+        agentMetadata?: { agentName?: string };
+      }>;
       for (const a of approvals) {
         items.push({
           kind: 'approval',
-          // RAW ApprovalAction id — /api/approvals/:id/resolve keys on it.
+          // RAW Activity id — the existing Activity actions key on it.
           id: String(a._id),
-          title: a.agentName ? `${a.agentName} requests approval` : 'Approval requested',
-          detail: String(a.summary || '').slice(0, 160),
+          title: a.agentMetadata?.agentName ? `${a.agentMetadata.agentName} requests approval` : 'Approval requested',
+          detail: String(a.content || '').slice(0, 160),
           podId: a.podId ? String(a.podId) : null,
           podName: a.podId ? podName.get(String(a.podId)) : undefined,
           createdAt: a.createdAt || null,
@@ -680,9 +569,47 @@ class ActivityService {
       console.warn('[decision-queue] mentions read failed:', (err as Error).message);
     }
 
-    // 3. Board facts. Concrete, not inferred: a DECIDE-titled open row IS a
-    // decision request; a blocked row is waiting on someone; a latest update
-    // that says "human press" / "Sam's ruling" is an explicit handoff.
+    // 3. Agent-authored DecisionRequest rows. The asking runtime supplied
+    // the title, question, and alternatives at the fork; this reader neither
+    // parses task prose nor reconstructs context from a board title.
+    try {
+      const decisions = await DecisionRequest.find({
+        podId: { $in: podIds },
+        status: 'pending',
+        messageId: { $exists: true, $ne: null },
+      }).sort({ createdAt: -1 }).limit(50).lean() as Array<{
+        _id: { toString(): string }; podId?: unknown; title?: string; question?: string;
+        context?: string; options?: Array<{ label?: string; description?: string; recommended?: boolean }>;
+        messageId?: string; threadRootId?: string; createdAt?: Date;
+      }>;
+      for (const decision of decisions) {
+        const options = (decision.options || [])
+          .filter((option) => option && typeof option.label === 'string')
+          .sort((a, b) => Number(Boolean(b.recommended)) - Number(Boolean(a.recommended)))
+          .map((option) => ({
+            label: String(option.label),
+            ...(option.description ? { description: String(option.description) } : {}),
+            ...(option.recommended ? { recommended: true } : {}),
+          }));
+        items.push({
+          kind: 'decision',
+          id: String(decision._id),
+          title: String(decision.title || 'Decision requested'),
+          detail: String(decision.question || decision.context || '').slice(0, 1000),
+          podId: decision.podId ? String(decision.podId) : null,
+          podName: decision.podId ? podName.get(String(decision.podId)) : undefined,
+          options,
+          messageId: decision.messageId,
+          threadRootId: decision.threadRootId || decision.messageId,
+          createdAt: decision.createdAt || null,
+        });
+      }
+    } catch (err) {
+      console.warn('[decision-queue] decision request read failed:', (err as Error).message);
+    }
+
+    // 4. Board handoffs still need an open-board affordance, but task prose
+    // is never an option source. DECIDE rows remain ordinary board rows.
     try {
       const HANDOFF_RE = /human\s+(merge\s+)?press|ready for (the\s+)?(human|sam)|sam'?s?\s+(ruling|call|decision)|awaiting\s+(sam|human)/i;
       // Freshness cutoff (Sam, 2026-09-01: "some of those activities seem
@@ -704,15 +631,11 @@ class ActivityService {
         const title = String(t.title || '');
         const updates = (t.updates as Array<{ text?: string; createdAt?: Date }> | undefined) || [];
         const last = updates[updates.length - 1];
-        const isDecide = /^DECIDE\b/i.test(title);
         const isBlocked = t.status === 'blocked';
         const isHandoff = !!(last && HANDOFF_RE.test(String(last.text || '')));
-        // A ruling belongs in Task.updates. It is final for this decision, so
-        // the queue must not keep offering the same buttons after refresh.
-        if ((!isDecide || hasRuling(t)) && !isBlocked && !isHandoff) continue;
-        const decisionOptions = isDecide && !hasRuling(t) ? getTaskDecisionOptions(t) : [];
+        if (!isBlocked && !isHandoff) continue;
         items.push({
-          kind: isHandoff && !isDecide ? 'press' : 'decision',
+          kind: 'press',
           id: `task_${t.taskId}`,
           title,
           detail: last ? String(last.text || '').slice(0, 160) : undefined,
@@ -720,20 +643,17 @@ class ActivityService {
           podName: podName.get(String(t.podId)),
           taskId: String(t.taskId || ''),
           createdAt: (last?.createdAt as Date) || (t.updatedAt as Date) || null,
-          ...(decisionOptions.length ? { options: decisionOptions } : {}),
         });
       }
     } catch (err) {
       console.warn('[decision-queue] board read failed:', (err as Error).message);
     }
 
-    // Attention order, then recency, then a hard cap. Approvals and presses
-    // are actionable in one click; mentions need a reply; standing decisions
-    // (incl. the old blocked backlog) come last — 32 undifferentiated rows
-    // is a wall, not a queue (#1306's live verify). The count still reports
-    // the full total so the cap is visible, not silent.
+    // Attention order, then recency, then a hard cap. The option card is the
+    // direct decision surface; existing approvals and board presses retain
+    // their prior precedence and mentions stay bounded below action rows.
     const KIND_PRIORITY: Record<string, number> = {
-      approval: 0, press: 1, mention: 2, decision: 3,
+      approval: 0, decision: 1, press: 2, mention: 3,
     };
     items.sort((a, b) => {
       const kindDelta = (KIND_PRIORITY[a.kind] ?? 9) - (KIND_PRIORITY[b.kind] ?? 9);
@@ -741,9 +661,9 @@ class ActivityService {
       return new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime();
     });
     // Per-kind soft cap. Live after #1464: 40+ thread mentions filled all
-    // 12 slots and the four standing decisions vanished below the cap —
-    // the opposite of "decision pending on me" being visible. Mentions
-    // take at most 8 of the 12; whatever is left goes to the other kinds
+    // 12 slots and direct decision cards vanished below the cap — the
+    // opposite of "decision pending on me" being visible. Mentions take at
+    // most 8 of the 12; whatever is left goes to the other kinds
     // in attention order. `count` still reports the full total.
     const MENTION_SLOTS = 8;
     const picked: QueueItem[] = [];
@@ -761,10 +681,9 @@ class ActivityService {
       if (picked.length >= 12) break;
       picked.push(it);
     }
-    // Restore attention order within the final page (approval, press,
-    // mention, decision), recency inside each kind — the loop above kept
-    // the sorted order for everything it picked, so a stable re-sort is
-    // enough.
+    // Restore attention order within the final page, recency inside each
+    // kind — the loop above kept the sorted order for everything it picked,
+    // so a stable re-sort is enough.
     picked.sort((a, b) => {
       const kindDelta = (KIND_PRIORITY[a.kind] ?? 9) - (KIND_PRIORITY[b.kind] ?? 9);
       if (kindDelta !== 0) return kindDelta;

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -10,6 +10,8 @@ const Summary = require('../models/Summary');
 const Post = require('../models/Post');
 // eslint-disable-next-line global-require
 const Task = require('../models/Task');
+// eslint-disable-next-line global-require
+const ApprovalAction = require('../models/ApprovalAction');
 
 let PGMessage: unknown = null;
 try {
@@ -110,6 +112,42 @@ interface ComputeFlagsOptions {
 // (95 updates in one window, TASK-083) drowned every real seat, which is what
 // made the Activity tab read as empty of real agent activity.
 const SYSTEM_BOT_NAMES = new Set(['commonly-bot', 'commonly-ai-agent']);
+
+// Decision options deliberately stay in the task's latest human-readable
+// update instead of gaining a second board state. Agents can propose a
+// decision with one portable line, and the queue can render it without
+// teaching every task producer a new write shape.
+//
+// The grammar is intentionally small: `OPTIONS: A | B | C`. Keeping it
+// bounded makes every option a tap target, while rejecting malformed lines
+// rather than guessing prevents a partial proposal from becoming a ruling.
+const parseDecisionOptions = (text: unknown): string[] => {
+  if (typeof text !== 'string') return [];
+  const line = text.match(/^\s*OPTIONS:\s*(.+?)\s*$/im)?.[1];
+  if (!line) return [];
+  const options = line.split('|').map((value) => value.trim()).filter(Boolean);
+  if (options.length < 2 || options.length > 4 || options.some((value) => value.length > 80)) return [];
+  const normalized = new Set(options.map((value) => value.toLocaleLowerCase()));
+  return normalized.size === options.length ? options : [];
+};
+
+const getTaskDecisionOptions = (task: Record<string, unknown>): string[] => {
+  const updates = Array.isArray(task.updates) ? task.updates as Array<{ text?: unknown }> : [];
+  for (const update of [...updates].reverse()) {
+    const options = parseDecisionOptions(update?.text);
+    if (options.length) return options;
+  }
+  return parseDecisionOptions(task.title);
+};
+
+const hasRuling = (task: Record<string, unknown>): boolean => {
+  const updates = Array.isArray(task.updates) ? task.updates as Array<{ text?: unknown }> : [];
+  // A DECIDE row stays open for the executor after the human rules, so an
+  // executor's later progress note must not put the resolved decision back
+  // into the attention queue. Unlike the handoff heuristic, this terminal
+  // marker is intentionally searched across the row's full update history.
+  return updates.some((update) => /^\s*SAM RULED:\s*/i.test(String(update?.text || '')));
+};
 
 class ActivityService {
   /**
@@ -487,6 +525,76 @@ class ActivityService {
       .filter((m) => !acked.has(m.id));
   }
 
+  /**
+   * A human ruling is a board update, not a new activity record. The task
+   * update wakes the asking seat through the established board fan-out and
+   * its terminal marker removes the resolved DECIDE row from this queue.
+   */
+  static async ruleTaskDecision(options: {
+    podId: string;
+    taskId: string;
+    option: string;
+    userId: unknown;
+  }): Promise<{ status: number; body: Record<string, unknown> }> {
+    const { podId, taskId, option, userId } = options;
+    if (!podId || !taskId || !option) return { status: 400, body: { error: 'podId, taskId, and option are required' } };
+
+    const pod = await Pod.findById(podId).select('createdBy members').lean() as PodDoc | null;
+    if (!pod) return { status: 404, body: { error: 'Pod not found' } };
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const isPodMember = require('../utils/isPodMember');
+    if (!isPodMember(pod, userId)) return { status: 403, body: { error: 'Only pod members can rule on this decision' } };
+
+    const caller = await User.findById(userId).select('username isBot').lean() as { username?: string; isBot?: boolean } | null;
+    if (!caller || caller.isBot) return { status: 403, body: { error: 'Only a human can rule on this decision' } };
+
+    const task = await Task.findOne({ podId, taskId }).lean() as Record<string, unknown> | null;
+    if (!task) return { status: 404, body: { error: 'Task not found' } };
+    if (!['pending', 'claimed', 'blocked'].includes(String(task.status || ''))) {
+      return { status: 409, body: { error: 'Decision is no longer active' } };
+    }
+    if (!/^DECIDE\b/i.test(String(task.title || ''))) {
+      return { status: 400, body: { error: 'Task is not a decision request' } };
+    }
+    if (hasRuling(task)) return { status: 409, body: { error: 'Decision already ruled' } };
+
+    const choices = getTaskDecisionOptions(task);
+    if (!choices.includes(option)) return { status: 400, body: { error: 'Option is not available for this decision' } };
+
+    const now = new Date();
+    const update = {
+      text: `SAM RULED: ${option}`,
+      author: caller.username || 'Human',
+      authorId: String(userId),
+      createdAt: now,
+    };
+    // The ruling marker is the compare-and-set. A double tap (or a second
+    // browser) loses before it can append a conflicting human decision.
+    const ruled = await Task.findOneAndUpdate(
+      {
+        podId,
+        taskId,
+        status: { $in: ['pending', 'claimed', 'blocked'] },
+        updates: { $not: { $elemMatch: { text: /^\s*SAM RULED:\s*/i } } },
+      },
+      { $push: { updates: update } },
+      { new: true },
+    );
+    if (!ruled) return { status: 409, body: { error: 'Decision already ruled' } };
+
+    const emittedTask = typeof ruled.toObject === 'function' ? ruled.toObject() : ruled;
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const { emitTaskUpdated, notifyPodAgents } = require('./taskEventService');
+    emitTaskUpdated(podId, emittedTask, 'updated');
+    try {
+      const pending = notifyPodAgents(podId, emittedTask, 'updated', { userId, isAgent: false });
+      if (pending?.catch) pending.catch((err: Error) => console.warn('[decision-rule] agent notify failed:', err.message));
+    } catch (err) {
+      console.warn('[decision-rule] agent notify threw:', (err as Error).message);
+    }
+    return { status: 200, body: { ok: true, ruling: option, task: emittedTask } };
+  }
+
   static async getDecisionQueue(userId: unknown): Promise<Record<string, unknown>> {
     const pods: PodDoc[] = await Pod.find({
       $or: [
@@ -506,24 +614,32 @@ class ActivityService {
       podId: string | null;
       podName?: string;
       taskId?: string;
+      options?: string[];
       createdAt: Date | string | null;
     };
     const items: QueueItem[] = [];
+    let composePodId: string | null = null;
 
-    // 1. Pending approvals — the authoritative reader already exists.
+    // 1. Pending approval cards — the durable ApprovalAction row is the
+    // decision object. Legacy Activity.approval rows are seed-fed and must not
+    // enter this queue, or a card would appear twice on two different routes.
+    // This filter intentionally mirrors resolveApproval's owner gate: a
+    // "Needs you" row must never offer a press to a non-decider.
     try {
-      const approvals = await ActivityService.getPendingApprovals(userId) as Array<{
-        _id: { toString(): string }; content?: string; podId?: unknown; createdAt?: Date;
-        agentMetadata?: { agentName?: string };
-      }>;
+      const approvals = await ApprovalAction.find({ ownerUserId: userId, status: 'flagged' })
+        .sort({ createdAt: -1 })
+        .limit(50)
+        .lean() as Array<{
+          _id: { toString(): string }; summary?: string; podId?: unknown; createdAt?: Date;
+          agentName?: string;
+        }>;
       for (const a of approvals) {
         items.push({
           kind: 'approval',
-          // RAW activity id — the act endpoints (/api/activity/:id/approve)
-          // key on it, so a prefixed id here would break the buttons.
+          // RAW ApprovalAction id — /api/approvals/:id/resolve keys on it.
           id: String(a._id),
-          title: a.agentMetadata?.agentName ? `${a.agentMetadata.agentName} requests approval` : 'Approval requested',
-          detail: String(a.content || '').slice(0, 160),
+          title: a.agentName ? `${a.agentName} requests approval` : 'Approval requested',
+          detail: String(a.summary || '').slice(0, 160),
           podId: a.podId ? String(a.podId) : null,
           podName: a.podId ? podName.get(String(a.podId)) : undefined,
           createdAt: a.createdAt || null,
@@ -544,6 +660,9 @@ class ActivityService {
     try {
       const mentions = await ActivityService.getMentionsForUser(userId, podIds);
       for (const m of mentions) {
+        // The query is newest-first, so its first result is the closest
+        // factual default for "tell them what is on my mind".
+        if (!composePodId) composePodId = m.podId;
         items.push({
           kind: 'mention',
           id: m.id,
@@ -588,7 +707,10 @@ class ActivityService {
         const isDecide = /^DECIDE\b/i.test(title);
         const isBlocked = t.status === 'blocked';
         const isHandoff = !!(last && HANDOFF_RE.test(String(last.text || '')));
-        if (!isDecide && !isBlocked && !isHandoff) continue;
+        // A ruling belongs in Task.updates. It is final for this decision, so
+        // the queue must not keep offering the same buttons after refresh.
+        if ((!isDecide || hasRuling(t)) && !isBlocked && !isHandoff) continue;
+        const decisionOptions = isDecide && !hasRuling(t) ? getTaskDecisionOptions(t) : [];
         items.push({
           kind: isHandoff && !isDecide ? 'press' : 'decision',
           id: `task_${t.taskId}`,
@@ -598,6 +720,7 @@ class ActivityService {
           podName: podName.get(String(t.podId)),
           taskId: String(t.taskId || ''),
           createdAt: (last?.createdAt as Date) || (t.updatedAt as Date) || null,
+          ...(decisionOptions.length ? { options: decisionOptions } : {}),
         });
       }
     } catch (err) {
@@ -647,7 +770,12 @@ class ActivityService {
       if (kindDelta !== 0) return kindDelta;
       return new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime();
     });
-    return { items: picked, count: items.length };
+    return {
+      items: picked,
+      count: items.length,
+      // No mention yet is not an error; the page falls back to its first pod.
+      composePodId,
+    };
   }
 
   static async getPodFeed(

--- a/backend/services/decisionRequestService.ts
+++ b/backend/services/decisionRequestService.ts
@@ -1,0 +1,382 @@
+import crypto from 'crypto';
+
+// eslint-disable-next-line global-require
+const DecisionRequest = require('../models/DecisionRequest');
+// eslint-disable-next-line global-require
+const Pod = require('../models/Pod');
+// eslint-disable-next-line global-require
+const User = require('../models/User');
+// eslint-disable-next-line global-require
+const AgentMessageService = require('./agentMessageService');
+// eslint-disable-next-line global-require
+const PGMessage = require('../models/pg/Message');
+// eslint-disable-next-line global-require
+const PGPod = require('../models/pg/Pod');
+// eslint-disable-next-line global-require
+const { syncPodFromMongo } = require('./pgPodSyncService');
+// eslint-disable-next-line global-require
+const { deliverMessageToAgents } = require('./messageAgentDeliveryService');
+// eslint-disable-next-line global-require
+const isPodMember = require('../utils/isPodMember');
+// eslint-disable-next-line global-require
+const socketConfig = require('../config/socket');
+
+const RULE_LOCK_MS = 2 * 60 * 1000;
+
+export class DecisionRequestError extends Error {
+  status: number;
+
+  code: string;
+
+  constructor(message: string, status: number, code: string) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export interface DecisionOptionInput {
+  label: string;
+  description?: string;
+  recommended?: boolean;
+}
+
+interface RequestDecisionOptions {
+  podId: string;
+  agentUserId: string;
+  agentName: string;
+  instanceId?: string;
+  displayName?: string;
+  installationConfig?: Record<string, unknown> | null;
+  title: string;
+  question: string;
+  options: DecisionOptionInput[];
+  threadRootId?: string | null;
+  context?: string;
+}
+
+interface ChooseDecisionOptions {
+  decisionId: string;
+  callerUserId: string;
+  value: string;
+}
+
+const cleanText = (value: unknown, field: string, max: number): string => {
+  if (typeof value !== 'string') {
+    throw new DecisionRequestError(`${field} must be a string`, 400, `invalid_${field}`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) throw new DecisionRequestError(`${field} is required`, 400, `${field}_required`);
+  if (trimmed.length > max) {
+    throw new DecisionRequestError(`${field} must be at most ${max} characters`, 400, `invalid_${field}`);
+  }
+  return trimmed;
+};
+
+export const normalizeOptions = (value: unknown): DecisionOptionInput[] => {
+  if (!Array.isArray(value) || value.length < 2 || value.length > 4) {
+    throw new DecisionRequestError('options must contain 2 to 4 choices', 400, 'invalid_options');
+  }
+  let recommendedCount = 0;
+  const labels = new Set<string>();
+  return value.map((raw, index) => {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new DecisionRequestError(`options[${index}] must be an object`, 400, 'invalid_options');
+    }
+    const option = raw as Record<string, unknown>;
+    const label = cleanText(option.label, `options[${index}].label`, 80);
+    const labelKey = label.toLocaleLowerCase();
+    if (labels.has(labelKey)) {
+      throw new DecisionRequestError('option labels must be unique', 400, 'duplicate_options');
+    }
+    labels.add(labelKey);
+    if (option.recommended !== undefined && typeof option.recommended !== 'boolean') {
+      throw new DecisionRequestError(`options[${index}].recommended must be a boolean`, 400, 'invalid_options');
+    }
+    if (option.recommended === true) recommendedCount += 1;
+    if (recommendedCount > 1) {
+      throw new DecisionRequestError('only one option may be recommended', 400, 'multiple_recommended');
+    }
+    let description: string | undefined;
+    if (option.description !== undefined) {
+      description = cleanText(option.description, `options[${index}].description`, 280);
+    }
+    return {
+      label,
+      ...(description ? { description } : {}),
+      ...(option.recommended === true ? { recommended: true } : {}),
+    };
+  });
+};
+
+const formatDecisionMessage = (
+  title: string,
+  question: string,
+  options: DecisionOptionInput[],
+  context?: string,
+): string => {
+  const optionsText = options.map((option) => {
+    const recommendation = option.recommended ? ' (recommended)' : '';
+    const description = option.description ? ` — ${option.description}` : '';
+    return `- ${option.label}${recommendation}${description}`;
+  }).join('\n');
+  return [title, question, context, `Options:\n${optionsText}`].filter(Boolean).join('\n\n');
+};
+
+const requirePgReply = async (podId: string, userId: string): Promise<void> => {
+  const pgPod = await PGPod.findById(podId);
+  if (!pgPod) {
+    const synced = await syncPodFromMongo(podId, userId);
+    if (!synced) throw new DecisionRequestError('Pod not found', 404, 'pod_not_found');
+  }
+};
+
+/**
+ * Store a fork and post the asker's own question into the pod. The source
+ * message is created before the row becomes visible in the queue, so every
+ * card has a reply target and human rulings always have a normal wake path.
+ */
+export const requestDecision = async (input: RequestDecisionOptions): Promise<Record<string, unknown>> => {
+  const podId = cleanText(input.podId, 'podId', 128);
+  const agentUserId = cleanText(input.agentUserId, 'agentUserId', 128);
+  const agentName = cleanText(input.agentName, 'agentName', 120).toLowerCase();
+  const instanceId = String(input.instanceId || 'default').trim().toLowerCase() || 'default';
+  const title = cleanText(input.title, 'title', 160);
+  const question = cleanText(input.question, 'question', 1000);
+  const options = normalizeOptions(input.options);
+  const context = input.context === undefined ? undefined : cleanText(input.context, 'context', 2000);
+  const threadRootId = input.threadRootId === undefined || input.threadRootId === null
+    ? null
+    : cleanText(input.threadRootId, 'threadRootId', 32);
+
+  // Thread replies require PostgreSQL. Check before posting the source: a
+  // Mongo-only source could never receive the implicit reply that wakes the
+  // asker, which would make the card appear to work while dropping its answer.
+  try {
+    await requirePgReply(podId, agentUserId);
+  } catch (error) {
+    if (error instanceof DecisionRequestError) throw error;
+    throw new DecisionRequestError(
+      'Decision requests need the message service to be available',
+      503,
+      'message_service_unavailable',
+    );
+  }
+
+  const posted = await AgentMessageService.postMessage({
+    agentName,
+    instanceId,
+    displayName: input.displayName,
+    podId,
+    content: formatDecisionMessage(title, question, options, context),
+    metadata: { source: 'decision-request' },
+    threadRootId,
+    installationConfig: input.installationConfig || null,
+  });
+  if (!posted?.success || !posted?.message) {
+    throw new DecisionRequestError('Decision request could not be posted', 503, 'message_not_posted');
+  }
+  const messageId = String(posted.message._id || posted.message.id || '');
+  if (!/^\d+$/.test(messageId)) {
+    throw new DecisionRequestError('Decision request needs a threaded message store', 503, 'message_not_threadable');
+  }
+
+  const row = await DecisionRequest.create({
+    podId,
+    agentUserId,
+    agentName,
+    instanceId,
+    title,
+    question,
+    ...(context ? { context } : {}),
+    options,
+    status: 'pending',
+    messageId,
+    ...(threadRootId ? { threadRootId } : {}),
+  });
+  return {
+    decisionId: String(row._id),
+    messageId,
+    threadRootId: threadRootId || messageId,
+    status: row.status,
+  };
+};
+
+const decisionPayload = (row: any): Record<string, unknown> => ({
+  id: String(row._id),
+  status: row.status,
+  title: row.title,
+  question: row.question,
+  options: row.options,
+  ruling: row.ruling ? {
+    value: row.ruling.value,
+    by: row.ruling.byUsername,
+    at: row.ruling.at,
+    messageId: row.ruling.messageId,
+  } : null,
+});
+
+// The decision service bypasses messageController because it must make the
+// decision-row CAS and the normal reply one operation. Preserve the ordinary
+// human-message live contract here: without this broadcast, the ruling is
+// durable and wakes the agent but other open thread views do not see it until
+// their next fetch.
+const broadcastRulingReply = (podId: string, message: any): void => {
+  try {
+    const io = socketConfig.getIO();
+    if (!io) return;
+    const messageId = String(message._id || message.id || '');
+    io.to(`pod_${podId}`).emit('newMessage', {
+      _id: messageId,
+      id: messageId,
+      pod_id: podId,
+      podId,
+      content: message.content,
+      messageType: message.messageType || 'text',
+      userId: message.userId,
+      username: message.username,
+      profile_picture: message.profile_picture,
+      createdAt: message.createdAt,
+      replyTo: message.replyTo ?? null,
+      thread_root_id: message.thread_root_id ?? null,
+      reply_to_message_id: message.reply_to_message_id ?? null,
+    });
+  } catch (error) {
+    // The ruling and the wake have already committed. Socket fan-out is a
+    // best-effort projection, never a reason to retry and duplicate a reply.
+    console.warn('[decision-request] ruling socket emit failed:', (error as Error).message);
+  }
+};
+
+const postRulingReply = async (row: any, callerUserId: string, value: string): Promise<string> => {
+  await requirePgReply(String(row.podId), callerUserId);
+  let resolvedThreadRootId: number | null = null;
+  if (row.threadRootId) {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const { resolveThreadRoot } = require('./threadRootResolver');
+    resolvedThreadRootId = await resolveThreadRoot({
+      podId: String(row.podId),
+      replyToMessageId: String(row.messageId),
+      threadRootId: String(row.threadRootId),
+    });
+  }
+
+  // We intentionally require PG here rather than falling back to Mongo. A
+  // ruling without reply_to_message_id is not an implicit reply and would not
+  // wake the asking agent — failing is more honest than acknowledging it.
+  const created = await PGMessage.create(
+    String(row.podId),
+    callerUserId,
+    value,
+    'text',
+    String(row.messageId),
+    null,
+    resolvedThreadRootId,
+  );
+  const message = created?.id ? await PGMessage.findById(String(created.id)) : null;
+  if (!message) throw new Error('Ruling reply could not be read after write');
+
+  const pod = await Pod.findById(String(row.podId)).select('type').lean();
+  await deliverMessageToAgents({
+    podId: String(row.podId),
+    podType: pod?.type,
+    message,
+    userId: callerUserId,
+    replyToMessageId: String(row.messageId),
+  });
+  broadcastRulingReply(String(row.podId), message);
+  return String(message.id || message._id || created.id);
+};
+
+/**
+ * First human member to claim the row posts the ruling. The short lock covers
+ * the durable chat write, and is cleared on failure so a transient PG outage
+ * cannot strand an undecided card.
+ */
+export const chooseDecision = async (
+  input: ChooseDecisionOptions,
+): Promise<{ status: number; body: Record<string, unknown> }> => {
+  const decisionId = cleanText(input.decisionId, 'decisionId', 128);
+  const callerUserId = cleanText(input.callerUserId, 'callerUserId', 128);
+  const value = cleanText(input.value, 'value', 2000);
+
+  const row = await DecisionRequest.findById(decisionId);
+  if (!row) return { status: 404, body: { error: 'Decision request not found' } };
+  if (row.status === 'ruled') {
+    return { status: 409, body: { error: 'Decision already ruled', decision: decisionPayload(row) } };
+  }
+
+  const caller = await User.findById(callerUserId).select('username isBot').lean();
+  if (!caller || caller.isBot) return { status: 403, body: { error: 'Only a human can rule on this decision' } };
+  const pod = await Pod.findById(String(row.podId)).select('members createdBy type').lean();
+  if (!pod) return { status: 404, body: { error: 'Pod not found' } };
+  if (!isPodMember(pod, callerUserId)) {
+    return { status: 403, body: { error: 'Only human pod members can rule on this decision' } };
+  }
+
+  const now = new Date();
+  const lockToken = crypto.randomUUID();
+  const claimed = await DecisionRequest.findOneAndUpdate(
+    {
+      _id: row._id,
+      status: 'pending',
+      $or: [
+        { rulingLock: { $exists: false } },
+        { 'rulingLock.expiresAt': { $lt: now } },
+      ],
+    },
+    { $set: { rulingLock: { token: lockToken, expiresAt: new Date(now.getTime() + RULE_LOCK_MS) } } },
+    { new: true },
+  );
+  if (!claimed) {
+    const current = await DecisionRequest.findById(decisionId);
+    if (current?.status === 'ruled') {
+      return { status: 409, body: { error: 'Decision already ruled', decision: decisionPayload(current) } };
+    }
+    return { status: 409, body: { error: 'Decision is being ruled; retry shortly' } };
+  }
+
+  let rulingMessageId: string;
+  try {
+    rulingMessageId = await postRulingReply(claimed, callerUserId, value);
+  } catch {
+    await DecisionRequest.updateOne(
+      { _id: claimed._id, status: 'pending', 'rulingLock.token': lockToken },
+      { $unset: { rulingLock: 1 } },
+    );
+    throw new DecisionRequestError('Ruling could not be posted; the decision remains open', 503, 'ruling_not_posted');
+  }
+
+  const ruledAt = new Date();
+  const ruled = await DecisionRequest.findOneAndUpdate(
+    { _id: claimed._id, status: 'pending', 'rulingLock.token': lockToken },
+    {
+      $set: {
+        status: 'ruled',
+        ruling: {
+          value,
+          byUserId: callerUserId,
+          byUsername: caller.username || 'Human',
+          at: ruledAt,
+          messageId: rulingMessageId,
+        },
+      },
+      $unset: { rulingLock: 1 },
+    },
+    { new: true },
+  );
+  if (!ruled) {
+    // The human reply is durable and will wake the agent. Do not manufacture
+    // a second reply trying to recover a rare lock-expiry race.
+    throw new DecisionRequestError(
+      'Ruling posted but could not be finalized; refresh this decision',
+      409,
+      'ruling_finalize_conflict',
+    );
+  }
+  return { status: 200, body: { ok: true, decision: decisionPayload(ruled) } };
+};
+
+export default { requestDecision, chooseDecision, normalizeOptions, DecisionRequestError };
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = { requestDecision, chooseDecision, normalizeOptions, DecisionRequestError };

--- a/backend/services/decisionRequestService.ts
+++ b/backend/services/decisionRequestService.ts
@@ -41,11 +41,17 @@ export interface DecisionOptionInput {
   recommended?: boolean;
 }
 
+export type DecisionClass = 'strategy' | 'implementation' | 'prioritization';
+const ADVISORY_DECISION_CLASSES: readonly DecisionClass[] = [
+  'strategy', 'implementation', 'prioritization',
+];
+
 interface RequestDecisionOptions {
   podId: string;
   agentUserId: string;
   agentName: string;
   instanceId?: string;
+  decisionClass: DecisionClass;
   displayName?: string;
   installationConfig?: Record<string, unknown> | null;
   title: string;
@@ -71,6 +77,18 @@ const cleanText = (value: unknown, field: string, max: number): string => {
     throw new DecisionRequestError(`${field} must be at most ${max} characters`, 400, `invalid_${field}`);
   }
   return trimmed;
+};
+
+export const normalizeDecisionClass = (value: unknown): DecisionClass => {
+  const decisionClass = cleanText(value, 'decisionClass', 40).toLowerCase() as DecisionClass;
+  if (!ADVISORY_DECISION_CLASSES.includes(decisionClass)) {
+    throw new DecisionRequestError(
+      'decisionClass must be strategy, implementation, or prioritization',
+      400,
+      'invalid_decision_class',
+    );
+  }
+  return decisionClass;
 };
 
 export const normalizeOptions = (value: unknown): DecisionOptionInput[] => {
@@ -141,6 +159,7 @@ export const requestDecision = async (input: RequestDecisionOptions): Promise<Re
   const agentUserId = cleanText(input.agentUserId, 'agentUserId', 128);
   const agentName = cleanText(input.agentName, 'agentName', 120).toLowerCase();
   const instanceId = String(input.instanceId || 'default').trim().toLowerCase() || 'default';
+  const decisionClass = normalizeDecisionClass(input.decisionClass);
   const title = cleanText(input.title, 'title', 160);
   const question = cleanText(input.question, 'question', 1000);
   const options = normalizeOptions(input.options);
@@ -186,6 +205,7 @@ export const requestDecision = async (input: RequestDecisionOptions): Promise<Re
     agentUserId,
     agentName,
     instanceId,
+    decisionClass,
     title,
     question,
     ...(context ? { context } : {}),
@@ -377,6 +397,10 @@ export const chooseDecision = async (
   return { status: 200, body: { ok: true, decision: decisionPayload(ruled) } };
 };
 
-export default { requestDecision, chooseDecision, normalizeOptions, DecisionRequestError };
+export default {
+  requestDecision, chooseDecision, normalizeOptions, normalizeDecisionClass, DecisionRequestError,
+};
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-module.exports = { requestDecision, chooseDecision, normalizeOptions, DecisionRequestError };
+module.exports = {
+  requestDecision, chooseDecision, normalizeOptions, normalizeDecisionClass, DecisionRequestError,
+};

--- a/commonly-mcp/README.md
+++ b/commonly-mcp/README.md
@@ -57,7 +57,7 @@ Add to `~/.cursor/mcp.json` or `.cursor/mcp.json`:
 
 - **Messaging + files** — `commonly_post_message`, `commonly_get_messages`, `commonly_get_context`, `commonly_get_posts`, `commonly_post_thread_comment`, `commonly_react_to_message`, `commonly_list_files`, `commonly_read_file`, `commonly_attach_file`
 - **Tasks** — `commonly_get_tasks`, `commonly_create_task`, `commonly_claim_task`, `commonly_complete_task`, `commonly_update_task`
-- **Pods + agent network** — `commonly_create_pod`, `commonly_list_pods`, `commonly_self_install_into_pod`, `commonly_dm_agent`, `commonly_ask_agent`, `commonly_respond_to_ask`
+- **Pods + agent network** — `commonly_create_pod`, `commonly_list_pods`, `commonly_self_install_into_pod`, `commonly_dm_agent`, `commonly_ask_agent`, `commonly_respond_to_ask`, `commonly_request_decision`
 - **Memory** — `commonly_read_agent_memory`, `commonly_write_agent_memory`, `commonly_save_my_memory`, `commonly_log_cycle`
 There are deliberately no GitHub tools. `commonly_pr_diff` / `commonly_pr_review`
 existed and were removed: they spent a shared server-side credential on a

--- a/commonly-mcp/__tests__/tools.test.mjs
+++ b/commonly-mcp/__tests__/tools.test.mjs
@@ -179,6 +179,7 @@ describe('commonly_request_decision', () => {
     expect(tool.inputSchema.properties.options).toMatchObject({ minItems: 2, maxItems: 4 });
     expect(tool.description).toContain('genuine fork');
     expect(tool.description).toContain('not for status updates');
+    expect(tool.description).toMatch(/never approval|not approval/i);
     expect(tool.description).toContain('never encode an executable');
   });
 });

--- a/commonly-mcp/__tests__/tools.test.mjs
+++ b/commonly-mcp/__tests__/tools.test.mjs
@@ -30,7 +30,8 @@ describe('tool registry shape', () => {
     // + 1 orientation tool (commonly_get_started) so a BYO agent connecting
     //   from outside has a model of the place before it acts.
     // + 2 attention-claim tools (ADR-018: claim-or-renew, release).
-    expect(tools).toHaveLength(27);
+    // + 1 agent-originated decision request (TASK-095 rev 2).
+    expect(tools).toHaveLength(28);
   });
 
   it('exposes no GitHub PR tool — that surface is `gh`, not the kernel', () => {
@@ -145,6 +146,40 @@ describe('commonly_get_context', () => {
     const [url, init] = fetchSpy.mock.calls[0];
     expect(url).toBe('https://x.example/api/agents/runtime/pods/POD/context');
     expect(init.method).toBe('GET');
+  });
+});
+
+describe('commonly_request_decision', () => {
+  it('POSTs the declared alternatives to the CAP decision route', async () => {
+    const fetchSpy = installFetch(async () => okResponse({ decisionId: 'd1', status: 'pending' }));
+    const result = await byName.commonly_request_decision.call({
+      podId: 'POD', title: 'Choose a release', question: 'Which train?',
+      options: [
+        { label: 'Canary', description: 'Small rollout first.', recommended: true },
+        { label: 'Fast lane', description: 'Ship on green.' },
+      ],
+      threadRootId: '88', context: 'Tests are green.',
+    });
+    expect(result.isError).toBeUndefined();
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://x.example/api/agents/runtime/decisions');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({
+      podId: 'POD', title: 'Choose a release', question: 'Which train?',
+      options: [
+        { label: 'Canary', description: 'Small rollout first.', recommended: true },
+        { label: 'Fast lane', description: 'Ship on green.' },
+      ],
+      threadRootId: '88', context: 'Tests are green.',
+    });
+  });
+
+  it('teaches when this tool is appropriate and keeps executable consent out of it', () => {
+    const tool = byName.commonly_request_decision;
+    expect(tool.inputSchema.properties.options).toMatchObject({ minItems: 2, maxItems: 4 });
+    expect(tool.description).toContain('genuine fork');
+    expect(tool.description).toContain('not for status updates');
+    expect(tool.description).toContain('never encode an executable');
   });
 });
 

--- a/commonly-mcp/__tests__/tools.test.mjs
+++ b/commonly-mcp/__tests__/tools.test.mjs
@@ -153,7 +153,7 @@ describe('commonly_request_decision', () => {
   it('POSTs the declared alternatives to the CAP decision route', async () => {
     const fetchSpy = installFetch(async () => okResponse({ decisionId: 'd1', status: 'pending' }));
     const result = await byName.commonly_request_decision.call({
-      podId: 'POD', title: 'Choose a release', question: 'Which train?',
+      podId: 'POD', decisionClass: 'implementation', title: 'Choose a release', question: 'Which train?',
       options: [
         { label: 'Canary', description: 'Small rollout first.', recommended: true },
         { label: 'Fast lane', description: 'Ship on green.' },
@@ -165,7 +165,7 @@ describe('commonly_request_decision', () => {
     expect(url).toBe('https://x.example/api/agents/runtime/decisions');
     expect(init.method).toBe('POST');
     expect(JSON.parse(init.body)).toEqual({
-      podId: 'POD', title: 'Choose a release', question: 'Which train?',
+      podId: 'POD', decisionClass: 'implementation', title: 'Choose a release', question: 'Which train?',
       options: [
         { label: 'Canary', description: 'Small rollout first.', recommended: true },
         { label: 'Fast lane', description: 'Ship on green.' },
@@ -177,6 +177,9 @@ describe('commonly_request_decision', () => {
   it('teaches when this tool is appropriate and keeps executable consent out of it', () => {
     const tool = byName.commonly_request_decision;
     expect(tool.inputSchema.properties.options).toMatchObject({ minItems: 2, maxItems: 4 });
+    expect(tool.inputSchema.properties.decisionClass).toMatchObject({
+      enum: ['strategy', 'implementation', 'prioritization'],
+    });
     expect(tool.description).toContain('genuine fork');
     expect(tool.description).toContain('not for status updates');
     expect(tool.description).toMatch(/never approval|not approval/i);

--- a/commonly-mcp/package-lock.json
+++ b/commonly-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commonlyai/mcp",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4"
       },

--- a/commonly-mcp/package.json
+++ b/commonly-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -59,6 +59,12 @@ const reqWith = (props, requiredKeys) => ({ ...required(props), required: requir
 const STRING = { type: 'string' };
 const INT = { type: 'integer' };
 const CLAIM_OUTCOME = { type: 'string', enum: ['declined', 'completed'] };
+const DECISION_OPTION = {
+  type: 'object',
+  properties: { label: STRING, description: STRING, recommended: { type: 'boolean' } },
+  required: ['label'],
+  additionalProperties: false,
+};
 
 /**
  * Orientation served by `commonly_get_started`.
@@ -110,6 +116,9 @@ messages a minute, and attach a file instead of pasting a document.
 - \`@mention\` someone to ask for a response. Mentioning an agent wakes it.
 - \`commonly_dm_agent\` for a focused 1:1 instead of cluttering a team room.
 - \`commonly_ask_agent\` for a private question that returns an answer later.
+- \`commonly_request_decision\` only at a genuine fork where a human must
+  choose among 2–4 concrete alternatives. It posts the question in the pod;
+  their ruling comes back as an ordinary threaded reply that wakes you.
 - Read and write memory with \`commonly_read_agent_memory\` /
   \`commonly_save_my_memory\`. Write what a teammate would need next week, not a
   transcript.
@@ -480,6 +489,27 @@ export const buildTools = (config) => {
         path: `/api/agents/runtime/pods/${encodeURIComponent(podId)}/ask`,
         body: {
           targetAgent, targetInstanceId, question, requestId,
+        },
+      })),
+    },
+    {
+      name: 'commonly_request_decision',
+      description: 'Ask the human members of a pod to resolve a genuine fork in your work. Use only when you cannot safely continue without their choice — not for status updates, routine execution, or a question you can answer from the pod. Supply 2–4 concrete options; put the recommended one first and mark it `recommended: true` (at most one). Commonly posts your question as your own message, renders an option card, and delivers the human’s choice back as a normal threaded reply that wakes you. This is advisory coordination only: never encode an executable or privileged action here; use the approval surface for actions that need consent.',
+      inputSchema: reqWith({
+        podId: STRING,
+        title: STRING,
+        question: STRING,
+        options: { type: 'array', items: DECISION_OPTION, minItems: 2, maxItems: 4 },
+        threadRootId: STRING,
+        context: STRING,
+      }, ['podId', 'title', 'question', 'options']),
+      call: wrap(async ({
+        podId, title, question, options, threadRootId, context,
+      }) => request(config, {
+        method: 'POST',
+        path: '/api/agents/runtime/decisions',
+        body: {
+          podId, title, question, options, threadRootId, context,
         },
       })),
     },

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -494,7 +494,7 @@ export const buildTools = (config) => {
     },
     {
       name: 'commonly_request_decision',
-      description: 'Ask the human members of a pod to resolve a genuine fork in your work. Use only when you cannot safely continue without their choice — not for status updates, routine execution, or a question you can answer from the pod. Supply 2–4 concrete options; put the recommended one first and mark it `recommended: true` (at most one). Commonly posts your question as your own message, renders an option card, and delivers the human’s choice back as a normal threaded reply that wakes you. This is advisory coordination only: never encode an executable or privileged action here; use the approval surface for actions that need consent.',
+      description: 'Ask the human members of a pod to resolve a genuine fork in your work. Use only when you cannot safely continue without their choice — not for status updates, routine execution, or a question you can answer from the pod. Supply 2–4 concrete options; put the recommended one first and mark it `recommended: true` (at most one). Commonly posts your question as your own message, renders an option card, and delivers the human’s choice back as a normal threaded reply that wakes you. This is advisory coordination only, never approval or authority to act: never encode an executable or privileged action here; use propose-action for side effects that need consent.',
       inputSchema: reqWith({
         podId: STRING,
         title: STRING,

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -59,6 +59,7 @@ const reqWith = (props, requiredKeys) => ({ ...required(props), required: requir
 const STRING = { type: 'string' };
 const INT = { type: 'integer' };
 const CLAIM_OUTCOME = { type: 'string', enum: ['declined', 'completed'] };
+const DECISION_CLASS = { type: 'string', enum: ['strategy', 'implementation', 'prioritization'] };
 const DECISION_OPTION = {
   type: 'object',
   properties: { label: STRING, description: STRING, recommended: { type: 'boolean' } },
@@ -494,22 +495,23 @@ export const buildTools = (config) => {
     },
     {
       name: 'commonly_request_decision',
-      description: 'Ask the human members of a pod to resolve a genuine fork in your work. Use only when you cannot safely continue without their choice — not for status updates, routine execution, or a question you can answer from the pod. Supply 2–4 concrete options; put the recommended one first and mark it `recommended: true` (at most one). Commonly posts your question as your own message, renders an option card, and delivers the human’s choice back as a normal threaded reply that wakes you. This is advisory coordination only, never approval or authority to act: never encode an executable or privileged action here; use propose-action for side effects that need consent.',
+      description: 'Ask the human members of a pod to resolve a genuine fork in your work. Choose an advisory class: strategy, implementation, or prioritization. Use only when you cannot safely continue without their choice — not for status updates, routine execution, or a question you can answer from the pod. Supply 2–4 concrete options; put the recommended one first and mark it `recommended: true` (at most one). Commonly posts your question as your own message, renders an option card, and delivers the human’s choice back as a normal threaded reply that wakes you. This is advisory coordination only, never approval or authority to act: never encode an executable or privileged action here; use propose-action for side effects that need consent.',
       inputSchema: reqWith({
         podId: STRING,
+        decisionClass: DECISION_CLASS,
         title: STRING,
         question: STRING,
         options: { type: 'array', items: DECISION_OPTION, minItems: 2, maxItems: 4 },
         threadRootId: STRING,
         context: STRING,
-      }, ['podId', 'title', 'question', 'options']),
+      }, ['podId', 'decisionClass', 'title', 'question', 'options']),
       call: wrap(async ({
-        podId, title, question, options, threadRootId, context,
+        podId, decisionClass, title, question, options, threadRootId, context,
       }) => request(config, {
         method: 'POST',
         path: '/api/agents/runtime/decisions',
         body: {
-          podId, title, question, options, threadRootId, context,
+          podId, decisionClass, title, question, options, threadRootId, context,
         },
       })),
     },

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -24,7 +24,7 @@ A single MCP server entry exposes 26 tools, grouped:
 | Messaging | `commonly_post_message`, `commonly_get_messages`, `commonly_get_context`, `commonly_get_posts`, `commonly_post_thread_comment` |
 | Files | `commonly_list_files`, `commonly_read_file`, `commonly_attach_file` |
 | Tasks | `commonly_get_tasks`, `commonly_create_task`, `commonly_claim_task`, `commonly_complete_task`, `commonly_update_task` |
-| Pods + agent network | `commonly_create_pod`, `commonly_list_pods`, `commonly_self_install_into_pod`, `commonly_dm_agent`, `commonly_ask_agent`, `commonly_respond_to_ask` |
+| Pods + agent network | `commonly_create_pod`, `commonly_list_pods`, `commonly_self_install_into_pod`, `commonly_dm_agent`, `commonly_ask_agent`, `commonly_respond_to_ask`, `commonly_request_decision` |
 | Memory | `commonly_read_agent_memory`, `commonly_write_agent_memory`, `commonly_save_my_memory`, `commonly_log_cycle` |
 | Social presence | `commonly_react_to_message` |
 

--- a/docs/adr/ADR-004-commonly-agent-protocol.md
+++ b/docs/adr/ADR-004-commonly-agent-protocol.md
@@ -88,15 +88,18 @@ Covered in full by ADR-003. Summary for CAP: `GET /memory` returns the envelope 
 ### Agent-originated decision request
 
 `POST /api/agents/runtime/decisions` is an additive CAP convenience route for
-a genuine agent fork: `{ podId, title, question, options[2..4],
-threadRootId?, context? }`. The runtime token supplies the asking agent's
+a genuine agent fork: `{ podId, decisionClass: strategy | implementation |
+prioritization, title, question, options[2..4], threadRootId?, context? }`.
+The runtime token supplies the asking agent's
 identity; callers cannot nominate another agent as provenance. The kernel
 persists a `DecisionRequest`, posts the question as that agent, and the shell
 renders the declared alternatives to human pod members. A selected value is
 persisted as an ordinary threaded human reply to that source message, so the
 existing implicit-reply event wakes the asking runtime. It carries advisory
 text only — never a privileged action, credential-bearing payload, or approval
-grant. The route rejects extra structured fields; those remain on the
+grant. Its declared class is constrained to advisory strategy, implementation,
+or prioritization; the route rejects extra structured fields. Outward-facing
+acts, credential use, and all other real-world effects remain on the
 owner-scoped ApprovalAction consent surface.
 
 ### Install + token lifecycle

--- a/docs/adr/ADR-004-commonly-agent-protocol.md
+++ b/docs/adr/ADR-004-commonly-agent-protocol.md
@@ -95,8 +95,9 @@ persists a `DecisionRequest`, posts the question as that agent, and the shell
 renders the declared alternatives to human pod members. A selected value is
 persisted as an ordinary threaded human reply to that source message, so the
 existing implicit-reply event wakes the asking runtime. It carries advisory
-text only — never a privileged action or credential-bearing payload; those
-remain on the ApprovalAction consent surface.
+text only — never a privileged action, credential-bearing payload, or approval
+grant. The route rejects extra structured fields; those remain on the
+owner-scoped ApprovalAction consent surface.
 
 ### Install + token lifecycle
 

--- a/docs/adr/ADR-004-commonly-agent-protocol.md
+++ b/docs/adr/ADR-004-commonly-agent-protocol.md
@@ -85,6 +85,19 @@ All four concepts are **pull-only** from the agent's side (driver always initiat
 
 Covered in full by ADR-003. Summary for CAP: `GET /memory` returns the envelope (v1 `content` + v2 `sections` + `sourceRuntime` + `schemaVersion`); `PUT /memory` accepts v1 or v2 shape with per-key merge; `POST /memory/sync` takes `{ sections, mode: 'full' | 'patch', sourceRuntime? }` and is idempotent within a UTC-day + canonical-stringify hash.
 
+### Agent-originated decision request
+
+`POST /api/agents/runtime/decisions` is an additive CAP convenience route for
+a genuine agent fork: `{ podId, title, question, options[2..4],
+threadRootId?, context? }`. The runtime token supplies the asking agent's
+identity; callers cannot nominate another agent as provenance. The kernel
+persists a `DecisionRequest`, posts the question as that agent, and the shell
+renders the declared alternatives to human pod members. A selected value is
+persisted as an ordinary threaded human reply to that source message, so the
+existing implicit-reply event wakes the asking runtime. It carries advisory
+text only — never a privileged action or credential-bearing payload; those
+remain on the ApprovalAction consent surface.
+
 ### Install + token lifecycle
 
 Installation is the moment a `(agent, pod)` pair goes from "published manifest" to "live runtime-token-holding driver." It is **not** part of CAP (drivers don't install themselves — a human or admin agent installs them via the registry routes). But it frames CAP:

--- a/docs/adr/ADR-010-commonly-mcp-server.md
+++ b/docs/adr/ADR-010-commonly-mcp-server.md
@@ -125,7 +125,7 @@ added memory, reactions, PR review, pod files, and the #773 network primitives.
 | `commonly_log_cycle` | `POST /api/agents/runtime/memory/sync` (cycles.append) | `{ content, podId? } → { ok, schemaVersion }` — append-only cycles writer per ADR-012 §10.1. Added to MCP 2026-05-10 (ADR-012 Phase 4). **Correction 2026-08-04: NOT in openclaw as shipped.** It was added to the branch `.gitmodules` declares, never to the lineage `_external/clawdbot`'s pin tracks; the live gateway declares 25 `commonly_*` tools without it. See the pin-skew entry in `CLAUDE.md`. |
 | `commonly_dm_agent` | `POST /api/agents/runtime/agent-dm` | `{ agentName, instanceId?, originPodId? } → { room }` |
 | `commonly_ask_agent` | `POST /api/agents/runtime/pods/:podId/ask` | `{ podId, targetAgent, question, targetInstanceId?, requestId? } → { requestId, expiresAt }` |
-| `commonly_request_decision` | `POST /api/agents/runtime/decisions` | `{ podId, title, question, options[2..4], threadRootId?, context? } → { decisionId, messageId, threadRootId, status }` |
+| `commonly_request_decision` | `POST /api/agents/runtime/decisions` | `{ podId, decisionClass: strategy \| implementation \| prioritization, title, question, options[2..4], threadRootId?, context? } → { decisionId, messageId, threadRootId, status }` |
 | `commonly_respond_to_ask` | `POST /api/agents/runtime/asks/:requestId/respond` | `{ requestId, content } → { ok }` |
 
 `commonly_pr_diff` / `commonly_pr_review` were part of this surface and have

--- a/docs/adr/ADR-010-commonly-mcp-server.md
+++ b/docs/adr/ADR-010-commonly-mcp-server.md
@@ -125,6 +125,7 @@ added memory, reactions, PR review, pod files, and the #773 network primitives.
 | `commonly_log_cycle` | `POST /api/agents/runtime/memory/sync` (cycles.append) | `{ content, podId? } → { ok, schemaVersion }` — append-only cycles writer per ADR-012 §10.1. Added to MCP 2026-05-10 (ADR-012 Phase 4). **Correction 2026-08-04: NOT in openclaw as shipped.** It was added to the branch `.gitmodules` declares, never to the lineage `_external/clawdbot`'s pin tracks; the live gateway declares 25 `commonly_*` tools without it. See the pin-skew entry in `CLAUDE.md`. |
 | `commonly_dm_agent` | `POST /api/agents/runtime/agent-dm` | `{ agentName, instanceId?, originPodId? } → { room }` |
 | `commonly_ask_agent` | `POST /api/agents/runtime/pods/:podId/ask` | `{ podId, targetAgent, question, targetInstanceId?, requestId? } → { requestId, expiresAt }` |
+| `commonly_request_decision` | `POST /api/agents/runtime/decisions` | `{ podId, title, question, options[2..4], threadRootId?, context? } → { decisionId, messageId, threadRootId, status }` |
 | `commonly_respond_to_ask` | `POST /api/agents/runtime/asks/:requestId/respond` | `{ requestId, content } → { ok }` |
 
 `commonly_pr_diff` / `commonly_pr_review` were part of this surface and have

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -102,6 +102,10 @@
     "decision": {
       "ruleOption": "Rule: {{option}}",
       "working": "Ruling…",
+      "other": "Other…",
+      "otherPlaceholder": "Write your ruling…",
+      "sendOther": "Send ruling",
+      "ruled": "✓ {{by}} ruled: {{value}}",
       "actionFailed": "That ruling could not be saved. Try again."
     },
     "mention": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -39,6 +39,16 @@
     "loadFailed": "Activity could not be loaded. Try again.",
     "openThread": "Open thread",
     "openBoard": "Open board",
+    "compose": {
+      "eyebrow": "Start a conversation",
+      "title": "Tell your agents what is on your mind",
+      "podLabel": "Post in",
+      "placeholder": "Write a message. Mention an agent to wake it…",
+      "send": "Send",
+      "sendAriaLabel": "Send message",
+      "working": "Sending…",
+      "actionFailed": "Your message could not be sent. Try again."
+    },
     "reply": {
       "placeholder": "Reply in thread…",
       "send": "Send",
@@ -51,7 +61,7 @@
     "needsYou": {
       "eyebrow": "Decision queue",
       "title": "Needs you",
-      "description": "Only direct mentions and pending approvals appear here.",
+      "description": "Direct mentions, approvals, and active decisions that need your call.",
       "emptyTitle": "Nothing is waiting on you",
       "emptyDescription": "New mentions and approval requests will appear here when they need a response.",
       "kinds": {
@@ -85,9 +95,14 @@
     },
     "approval": {
       "approve": "Approve",
-      "reject": "Reject",
+      "deny": "Deny",
       "working": "Saving…",
       "actionFailed": "That approval could not be updated. Try again."
+    },
+    "decision": {
+      "ruleOption": "Rule: {{option}}",
+      "working": "Ruling…",
+      "actionFailed": "That ruling could not be saved. Try again."
     },
     "mention": {
       "acknowledge": "Acknowledge",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -102,6 +102,10 @@
     "decision": {
       "ruleOption": "裁定：{{option}}",
       "working": "正在裁定…",
+      "other": "其他…",
+      "otherPlaceholder": "写下你的裁定…",
+      "sendOther": "发送裁定",
+      "ruled": "✓ {{by}} 已裁定：{{value}}",
       "actionFailed": "无法保存该裁定，请重试。"
     },
     "mention": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -39,6 +39,16 @@
     "loadFailed": "无法加载动态，请重试。",
     "openThread": "打开讨论",
     "openBoard": "打开看板",
+    "compose": {
+      "eyebrow": "发起对话",
+      "title": "告诉你的智能体你在想什么",
+      "podLabel": "发布到",
+      "placeholder": "写一条消息。提及智能体即可唤醒它…",
+      "send": "发送",
+      "sendAriaLabel": "发送消息",
+      "working": "发送中…",
+      "actionFailed": "无法发送消息，请重试。"
+    },
     "reply": {
       "placeholder": "在话题中回复…",
       "send": "发送",
@@ -51,7 +61,7 @@
     "needsYou": {
       "eyebrow": "决策队列",
       "title": "需要你处理",
-      "description": "这里只显示直接提及和待处理的审批。",
+      "description": "这里只显示需要你回应的直接提及、审批和待决事项。",
       "emptyTitle": "没有事项在等待你",
       "emptyDescription": "有需要回复的提及或审批请求时，会显示在这里。",
       "kinds": {
@@ -85,9 +95,14 @@
     },
     "approval": {
       "approve": "批准",
-      "reject": "拒绝",
+      "deny": "拒绝",
       "working": "正在保存…",
       "actionFailed": "无法更新该审批，请重试。"
+    },
+    "decision": {
+      "ruleOption": "裁定：{{option}}",
+      "working": "正在裁定…",
+      "actionFailed": "无法保存该裁定，请重试。"
     },
     "mention": {
       "acknowledge": "确认",

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -108,6 +108,7 @@ describe('V2ActivityPage', () => {
     expect(screen.getByText('Ready for your press')).toBeInTheDocument();
     expect(screen.getByText('Choose the eslint scope')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Rule: Ship now' })).toBeInTheDocument();
+    expect(screen.getByText('Release the bounded change.')).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: 'Open board' })).toHaveLength(1);
     expect(screen.getByRole('button', { name: 'Other…' })).toBeInTheDocument();
     expect(mockGet).toHaveBeenCalledWith('/api/activity/decision-queue', expect.anything());

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -35,10 +35,11 @@ const decisionQueue = {
     },
     {
       id: 'task_TASK-024', kind: 'decision', title: 'DECIDE: eslint scope', detail: 'filed',
-      podId: 'pod-1', podName: 'Launch pod', taskId: 'TASK-024', createdAt: '2026-08-26T09:00:00.000Z',
+      podId: 'pod-1', podName: 'Launch pod', taskId: 'TASK-024', options: ['Ship now', 'Hold for review'], createdAt: '2026-08-26T09:00:00.000Z',
     },
   ],
   count: 3,
+  composePodId: 'pod-1',
 };
 
 const recap = {
@@ -103,6 +104,7 @@ describe('V2ActivityPage', () => {
     expect(screen.getByText('Retention ledger')).toBeInTheDocument();
     expect(screen.getByText('Ready for your press')).toBeInTheDocument();
     expect(screen.getByText('DECIDE: eslint scope')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Rule: Ship now' })).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: 'Open board' })).toHaveLength(2);
     expect(mockGet).toHaveBeenCalledWith('/api/activity/decision-queue', expect.anything());
     expect(screen.getByRole('heading', { name: 'What your agents did' })).toBeInTheDocument();
@@ -173,45 +175,88 @@ describe('V2ActivityPage', () => {
   });
 
   test('keeps an approval actionable and refreshes the fact after approval', async () => {
-    const approvalRecap = {
-      ...recap,
-      needsYou: [{
+    const approvalQueue = {
+      items: [{
         id: 'approval-1', kind: 'approval', title: 'Approval requested', detail: 'Deploy the change.',
-        podId: 'pod-1', podName: 'Launch pod', timestamp: '2026-08-26T11:00:00.000Z',
+        podId: 'pod-1', podName: 'Launch pod', createdAt: '2026-08-26T11:00:00.000Z',
       }],
+      count: 1,
+      composePodId: 'pod-1',
     };
-    mockGet
-      .mockResolvedValueOnce({ data: approvalRecap })
-      .mockResolvedValue({ data: { ...approvalRecap, needsYou: [] } });
-    mockPost.mockResolvedValue({ data: { success: true } });
+    let queueReads = 0;
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/activity/decision-queue') {
+        queueReads += 1;
+        return Promise.resolve({ data: queueReads === 1 ? approvalQueue : { items: [], count: 0, composePodId: 'pod-1' } });
+      }
+      return Promise.resolve({ data: { ...recap, needsYou: [] } });
+    });
+    mockPost.mockResolvedValue({ data: { ok: true } });
     renderPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Approve' }));
     await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
-      '/api/activity/approval-1/approve',
-      { notes: 'Approved via Activity' },
+      '/api/approvals/approval-1/resolve',
+      { decision: 'approved' },
       expect.objectContaining({ headers: expect.any(Object) }),
     ));
     expect(await screen.findByText('Nothing is waiting on you')).toBeInTheDocument();
   });
 
   test('offers Reject as the approval secondary action', async () => {
-    const approvalRecap = {
-      ...recap,
-      needsYou: [{
+    const approvalQueue = {
+      items: [{
         id: 'approval-2', kind: 'approval', title: 'Approval requested', detail: 'Deploy the change.',
-        podId: 'pod-1', podName: 'Launch pod', timestamp: '2026-08-26T11:00:00.000Z',
+        podId: 'pod-1', podName: 'Launch pod', createdAt: '2026-08-26T11:00:00.000Z',
       }],
+      count: 1,
+      composePodId: 'pod-1',
     };
-    mockGet.mockResolvedValue({ data: approvalRecap });
-    mockPost.mockResolvedValue({ data: { success: true } });
+    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? approvalQueue : { ...recap, needsYou: [] } }));
+    mockPost.mockResolvedValue({ data: { ok: true } });
     renderPage();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Reject' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Deny' }));
     await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
-      '/api/activity/approval-2/reject',
-      { notes: 'Rejected via Activity' },
+      '/api/approvals/approval-2/resolve',
+      { decision: 'declined' },
       expect.objectContaining({ headers: expect.any(Object) }),
     ));
+  });
+
+  test('posts a one-tap decision ruling and refreshes the factual queue', async () => {
+    let queueReads = 0;
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/activity/decision-queue') {
+        queueReads += 1;
+        return Promise.resolve({ data: queueReads === 1 ? decisionQueue : { items: [], count: 0, composePodId: 'pod-1' } });
+      }
+      return Promise.resolve({ data: recap });
+    });
+    mockPost.mockResolvedValue({ data: { ok: true } });
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Rule: Ship now' }));
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
+      '/api/activity/tasks/TASK-024/rule',
+      { podId: 'pod-1', option: 'Ship now' },
+      expect.objectContaining({ headers: expect.any(Object) }),
+    ));
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Rule: Ship now' })).not.toBeInTheDocument());
+  });
+
+  test('composes an ordinary pod message into the most recently addressed pod', async () => {
+    mockPost.mockResolvedValue({ data: { id: 123 } });
+    renderPage();
+
+    const composer = await screen.findByRole('textbox', { name: 'Write a message. Mention an agent to wake it…' });
+    fireEvent.change(composer, { target: { value: '@release-agent please check this' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
+      '/api/messages/pod-1',
+      { content: '@release-agent please check this' },
+      expect.objectContaining({ headers: expect.any(Object) }),
+    ));
+    expect(composer).toHaveValue('');
   });
 });

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -34,8 +34,11 @@ const decisionQueue = {
       podId: 'pod-1', podName: 'Launch pod', taskId: 'TASK-059', createdAt: '2026-08-26T10:00:00.000Z',
     },
     {
-      id: 'task_TASK-024', kind: 'decision', title: 'DECIDE: eslint scope', detail: 'filed',
-      podId: 'pod-1', podName: 'Launch pod', taskId: 'TASK-024', options: ['Ship now', 'Hold for review'], createdAt: '2026-08-26T09:00:00.000Z',
+      id: 'decision-024', kind: 'decision', title: 'Choose the eslint scope', detail: 'What should the agent do?',
+      podId: 'pod-1', podName: 'Launch pod', messageId: '700', threadRootId: '695', options: [
+        { label: 'Ship now', description: 'Release the bounded change.', recommended: true },
+        { label: 'Hold for review', description: 'Wait for a second pass.' },
+      ], createdAt: '2026-08-26T09:00:00.000Z',
     },
   ],
   count: 3,
@@ -99,13 +102,14 @@ describe('V2ActivityPage', () => {
     // adds a microtask hop the old single-request race happened to win.
     expect(await screen.findByRole('heading', { name: 'Needs you' })).toBeInTheDocument();
     expect(screen.getByText('Review requested')).toBeInTheDocument();
-    // TASK-083: board facts land in the queue — a human-press handoff and a
-    // DECIDE row, each with an Open board action.
+    // A board press remains an Open-board action; DecisionRequest cards use
+    // their declared options rather than deriving actions from task prose.
     expect(screen.getByText('Retention ledger')).toBeInTheDocument();
     expect(screen.getByText('Ready for your press')).toBeInTheDocument();
-    expect(screen.getByText('DECIDE: eslint scope')).toBeInTheDocument();
+    expect(screen.getByText('Choose the eslint scope')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Rule: Ship now' })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Open board' })).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: 'Open board' })).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Other…' })).toBeInTheDocument();
     expect(mockGet).toHaveBeenCalledWith('/api/activity/decision-queue', expect.anything());
     expect(screen.getByRole('heading', { name: 'What your agents did' })).toBeInTheDocument();
     expect(screen.getByText('release-agent')).toBeInTheDocument();
@@ -191,13 +195,13 @@ describe('V2ActivityPage', () => {
       }
       return Promise.resolve({ data: { ...recap, needsYou: [] } });
     });
-    mockPost.mockResolvedValue({ data: { ok: true } });
+    mockPost.mockResolvedValue({ data: { success: true } });
     renderPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Approve' }));
     await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
-      '/api/approvals/approval-1/resolve',
-      { decision: 'approved' },
+      '/api/activity/approval-1/approve',
+      { notes: 'Approved via Activity' },
       expect.objectContaining({ headers: expect.any(Object) }),
     ));
     expect(await screen.findByText('Nothing is waiting on you')).toBeInTheDocument();
@@ -213,13 +217,13 @@ describe('V2ActivityPage', () => {
       composePodId: 'pod-1',
     };
     mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? approvalQueue : { ...recap, needsYou: [] } }));
-    mockPost.mockResolvedValue({ data: { ok: true } });
+    mockPost.mockResolvedValue({ data: { success: true } });
     renderPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Deny' }));
     await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
-      '/api/approvals/approval-2/resolve',
-      { decision: 'declined' },
+      '/api/activity/approval-2/reject',
+      { notes: 'Rejected via Activity' },
       expect.objectContaining({ headers: expect.any(Object) }),
     ));
   });
@@ -238,11 +242,30 @@ describe('V2ActivityPage', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'Rule: Ship now' }));
     await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
-      '/api/activity/tasks/TASK-024/rule',
-      { podId: 'pod-1', option: 'Ship now' },
+      '/api/activity/decisions/decision-024/choose',
+      { value: 'Ship now' },
       expect.objectContaining({ headers: expect.any(Object) }),
     ));
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Rule: Ship now' })).not.toBeInTheDocument());
+  });
+
+  test('sends an Other ruling verbatim to the same DecisionRequest endpoint', async () => {
+    mockGet.mockImplementation((url: string) => Promise.resolve({
+      data: url === '/api/activity/decision-queue' ? decisionQueue : recap,
+    }));
+    mockPost.mockResolvedValue({ data: { ok: true } });
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Other…' }));
+    const input = screen.getByRole('textbox', { name: 'Write your ruling…' });
+    fireEvent.change(input, { target: { value: 'Hold for customer evidence' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send ruling' }));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
+      '/api/activity/decisions/decision-024/choose',
+      { value: 'Hold for customer evidence' },
+      expect.objectContaining({ headers: expect.any(Object) }),
+    ));
   });
 
   test('composes an ordinary pod message into the most recently addressed pod', async () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -121,6 +121,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // eligible for ruleBody's exact-selector helper.
     expect(v2).toMatch(/\.v2-activity__queue-actions,\n\.v2-activity__queue-row button,[\s\S]*?\{\n\s*display: flex;[\s\S]*?gap: 6px;/);
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-activity__queue-actions \{ grid-column: 2; \}[\s\S]*?\.v2-activity__queue-actions \{ flex-wrap: wrap; \}/);
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-root \.v2-activity__queue-actions button \{ min-height: 44px; \}/);
   });
 
   test('the mobile inspector is a drawer, never display:none — the header avatars button must do something', () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -124,6 +124,25 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-root \.v2-activity__queue-actions button \{ min-height: 44px; \}/);
   });
 
+  test('DecisionRequest options are full-width content with one recommended primary choice', () => {
+    // The first build left options inside the narrow actions column. Generic
+    // queue-button CSS then made every non-recommended option blue while the
+    // recommended one looked secondary — exactly backwards for a fork card.
+    const decisionActions = ruleBody(v2, '.v2-activity__queue-row--decision .v2-activity__queue-actions');
+    expect(decisionActions).toContain('grid-column: 1 / -1');
+    expect(decisionActions).toContain('justify-content: flex-start');
+
+    const neutralOption = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option');
+    expect(neutralOption).toContain('border: 1px solid var(--v2-border)');
+    expect(neutralOption).toContain('background: var(--v2-surface)');
+    expect(neutralOption).toContain('border-radius: 999px');
+
+    const recommendedOption = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option--recommended');
+    expect(recommendedOption).toContain('background: var(--v2-accent)');
+    expect(recommendedOption).toContain('color: var(--v2-surface)');
+    expect(v2).toContain('.v2-activity__option-description');
+  });
+
   test('the mobile inspector is a drawer, never display:none — the header avatars button must do something', () => {
     // Below 1024px the pane used display:none while V2Layout still mounted it
     // on tap: the avatar-stack button looked broken and members/files were
@@ -482,7 +501,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // recommended state and the free-text escape hatch visible in the CSS
     // source because jsdom has no layout engine to catch a narrow regression.
     expect(ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option--recommended'))
-      .toContain('background: var(--v2-accent-soft)');
+      .toContain('background: var(--v2-accent)');
     expect(ruleBody(v2, '.v2-activity__decision-other')).toContain('flex-basis: 100%');
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-root \.v2-activity__queue-actions button \{ min-height: 44px; \}/);
   });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -477,6 +477,16 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__queue-action--thread')).toContain('background: transparent');
   });
 
+  test('DecisionRequest options remain 44px touch targets when they wrap at 390px', () => {
+    // Options are agent-authored data, not compact task metadata. Keep the
+    // recommended state and the free-text escape hatch visible in the CSS
+    // source because jsdom has no layout engine to catch a narrow regression.
+    expect(ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option--recommended'))
+      .toContain('background: var(--v2-accent-soft)');
+    expect(ruleBody(v2, '.v2-activity__decision-other')).toContain('flex-basis: 100%');
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-root \.v2-activity__queue-actions button \{ min-height: 44px; \}/);
+  });
+
   test('the shared filter segment uses an unmistakable token-backed selected state', () => {
     const active = ruleBody(v2, '.v2-root button.v2-filter-segment__item--active');
 

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -36,6 +36,7 @@ interface NeedsYouItem {
   podId: string | null;
   podName: string;
   taskId?: string;
+  options?: string[];
   timestamp: string | null;
   // Mention rows carry where they live so a reply can land IN the thread.
   messageId?: number;
@@ -83,6 +84,11 @@ const V2ActivityPage: React.FC = () => {
   const [actingApprovalId, setActingApprovalId] = useState<string | null>(null);
   const [acknowledgingMentionId, setAcknowledgingMentionId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [rulingId, setRulingId] = useState<string | null>(null);
+  const [composePodId, setComposePodId] = useState('');
+  const [composeDraft, setComposeDraft] = useState('');
+  const [composing, setComposing] = useState(false);
+  const [composeError, setComposeError] = useState<string | null>(null);
 
   const [queue, setQueue] = useState<NeedsYouItem[]>([]);
 
@@ -100,7 +106,10 @@ const V2ActivityPage: React.FC = () => {
         headers,
         params: { window, ...(podId !== 'all' ? { podId } : {}) },
       }),
-      axios.get<{ items: Array<NeedsYouItem & { createdAt?: string | null }> }>(
+      axios.get<{
+        items: Array<NeedsYouItem & { createdAt?: string | null }>;
+        composePodId?: string | null;
+      }>(
         '/api/activity/decision-queue',
         { headers },
       ).catch(() => null),
@@ -112,8 +121,16 @@ const V2ActivityPage: React.FC = () => {
         // endpoint failed (null), older server, malformed body — degrades to
         // recap.needsYou (mentions + approvals) rather than an empty queue.
         const rawItems = queueResponse?.data?.items;
+        const availablePods = recapResponse.data.pods || [];
+        const setComposeDefault = (candidate = '') => {
+          const fallback = candidate || availablePods[0]?.id || '';
+          setComposePodId((current) => (
+            current && availablePods.some((pod) => pod.id === current) ? current : fallback
+          ));
+        };
         if (!Array.isArray(rawItems)) {
           setQueue(recapResponse.data.needsYou || []);
+          setComposeDefault();
           return;
         }
         const queueItems = rawItems.map((item) => ({
@@ -125,6 +142,10 @@ const V2ActivityPage: React.FC = () => {
         setQueue(podId !== 'all'
           ? queueItems.filter((item) => item.podId === podId)
           : queueItems);
+        // Preserve an intentional target choice across queue refreshes. On
+        // first load, anchor the composer to the most recent direct traffic;
+        // no traffic simply falls back to the user's first available pod.
+        setComposeDefault(queueResponse?.data?.composePodId || '');
       })
       .catch(() => {
         if (active) setError(t('activity.loadFailed'));
@@ -150,23 +171,64 @@ const V2ActivityPage: React.FC = () => {
     navigate('/v2');
   };
 
-  const actOnApproval = async (item: NeedsYouItem, action: 'approve' | 'reject') => {
+  const actOnApproval = async (item: NeedsYouItem, action: 'approved' | 'declined') => {
     if (actingApprovalId) return;
     setActingApprovalId(item.id);
     setActionError(null);
     try {
       const token = localStorage.getItem('token');
-      const response = await axios.post<{ success?: boolean }>(
-        `/api/activity/${item.id}/${action}`,
-        { notes: `${action === 'approve' ? 'Approved' : 'Rejected'} via Activity` },
+      const response = await axios.post<{ ok?: boolean }>(
+        `/api/approvals/${encodeURIComponent(item.id)}/resolve`,
+        { decision: action },
         { headers: { 'x-auth-token': token ?? '' } },
       );
-      if (!response.data?.success) throw new Error('Activity action failed');
+      if (!response.data?.ok) throw new Error('Approval action failed');
       setReloadKey((value) => value + 1);
     } catch {
       setActionError(t('activity.approval.actionFailed'));
     } finally {
       setActingApprovalId(null);
+    }
+  };
+
+  const ruleDecision = async (item: NeedsYouItem, option: string) => {
+    if (!item.taskId || !item.podId || rulingId) return;
+    setRulingId(item.id);
+    setActionError(null);
+    try {
+      const token = localStorage.getItem('token');
+      const response = await axios.post<{ ok?: boolean }>(
+        `/api/activity/tasks/${encodeURIComponent(item.taskId)}/rule`,
+        { podId: item.podId, option },
+        { headers: { 'x-auth-token': token ?? '' } },
+      );
+      if (!response.data?.ok) throw new Error('Decision ruling failed');
+      setReloadKey((value) => value + 1);
+    } catch {
+      setActionError(t('activity.decision.actionFailed'));
+    } finally {
+      setRulingId(null);
+    }
+  };
+
+  const sendCompose = async () => {
+    const content = composeDraft.trim();
+    if (!content || !composePodId || composing) return;
+    setComposing(true);
+    setComposeError(null);
+    try {
+      const token = localStorage.getItem('token');
+      await axios.post(
+        `/api/messages/${encodeURIComponent(composePodId)}`,
+        { content },
+        { headers: { 'x-auth-token': token ?? '' } },
+      );
+      setComposeDraft('');
+      setReloadKey((value) => value + 1);
+    } catch {
+      setComposeError(t('activity.compose.actionFailed'));
+    } finally {
+      setComposing(false);
     }
   };
 
@@ -264,7 +326,38 @@ const V2ActivityPage: React.FC = () => {
       {loading && <div className="v2-activity__loading"><span className="v2-spinner" /></div>}
       {!loading && error && <div className="v2-activity__error" role="alert">{error}</div>}
       {!loading && !error && recap && (
-        <div className="v2-activity__sections">
+        <>
+          <section className="v2-activity__compose" aria-labelledby="activity-compose-title">
+            <div className="v2-activity__compose-heading">
+              <div>
+                <div className="v2-activity__eyebrow">{t('activity.compose.eyebrow')}</div>
+                <h2 id="activity-compose-title">{t('activity.compose.title')}</h2>
+              </div>
+              <label className="v2-activity__compose-pod">
+                <span>{t('activity.compose.podLabel')}</span>
+                <select value={composePodId} onChange={(event) => setComposePodId(event.target.value)}>
+                  {(recap.pods || []).map((pod) => <option key={pod.id} value={pod.id}>{pod.name}</option>)}
+                </select>
+              </label>
+            </div>
+            <div className="v2-activity__compose-entry">
+              <textarea
+                aria-label={t('activity.compose.placeholder')}
+                rows={3}
+                placeholder={t('activity.compose.placeholder')}
+                value={composeDraft}
+                onChange={(event) => setComposeDraft(event.target.value)}
+                onKeyDown={(event) => { if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') sendCompose(); }}
+                disabled={composing || !composePodId}
+              />
+              <button type="button" aria-label={t('activity.compose.sendAriaLabel')} onClick={sendCompose} disabled={composing || !composePodId || !composeDraft.trim()}>
+                {composing ? t('activity.compose.working') : t('activity.compose.send')}
+              </button>
+            </div>
+            {composeError && <div className="v2-activity__action-error" role="alert">{composeError}</div>}
+          </section>
+
+          <div className="v2-activity__sections">
           <section className="v2-activity__section" aria-labelledby="activity-needs-you">
             <div className="v2-activity__section-heading">
               <div>
@@ -334,11 +427,11 @@ const V2ActivityPage: React.FC = () => {
                     <div className="v2-activity__queue-actions">
                       {item.kind === 'approval' && (
                         <>
-                          <button type="button" onClick={() => actOnApproval(item, 'approve')} disabled={actingApprovalId === item.id}>
+                          <button type="button" onClick={() => actOnApproval(item, 'approved')} disabled={actingApprovalId === item.id}>
                             {actingApprovalId === item.id ? t('activity.approval.working') : t('activity.approval.approve')}
                           </button>
-                          <button type="button" className="v2-activity__queue-action--secondary" onClick={() => actOnApproval(item, 'reject')} disabled={actingApprovalId === item.id}>
-                            {t('activity.approval.reject')}
+                          <button type="button" className="v2-activity__queue-action--secondary" onClick={() => actOnApproval(item, 'declined')} disabled={actingApprovalId === item.id}>
+                            {t('activity.approval.deny')}
                           </button>
                         </>
                       )}
@@ -368,9 +461,22 @@ const V2ActivityPage: React.FC = () => {
                         </>
                       )}
                       {(item.kind === 'decision' || item.kind === 'press') && (
-                        <button type="button" onClick={() => openBoard(item)} disabled={!item.podId}>
-                          {t('activity.openBoard')}
-                        </button>
+                        <>
+                          {item.kind === 'decision' && item.options?.map((option) => (
+                            <button
+                              key={option}
+                              type="button"
+                              onClick={() => ruleDecision(item, option)}
+                              disabled={rulingId === item.id}
+                              aria-label={t('activity.decision.ruleOption', { option })}
+                            >
+                              {rulingId === item.id ? t('activity.decision.working') : option}
+                            </button>
+                          ))}
+                          <button type="button" className={item.options?.length ? 'v2-activity__queue-action--secondary' : ''} onClick={() => openBoard(item)} disabled={!item.podId}>
+                            {t('activity.openBoard')}
+                          </button>
+                        </>
                       )}
                       <button type="button" className="v2-activity__queue-action--thread" onClick={() => openPod(item.podId)} disabled={!item.podId}>
                         {t('activity.openThread')}
@@ -459,7 +565,8 @@ const V2ActivityPage: React.FC = () => {
               </div>
             )}
           </section>
-        </div>
+          </div>
+        </>
       )}
       <footer className="v2-activity__footer">{t('activity.footer')}</footer>
     </div>

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -27,20 +27,19 @@ interface AgentRecap {
 
 interface NeedsYouItem {
   id: string;
-  // decision = a DECIDE-titled or blocked board row; press = an explicit
-  // human-handoff in a task's latest update. Both come from the
-  // /decision-queue endpoint's board facts (TASK-083).
+  // Decision cards are agent-authored DecisionRequest rows. `press` remains
+  // an ordinary board handoff and never parses a task title into options.
   kind: 'mention' | 'approval' | 'decision' | 'press';
   title: string;
   detail: string;
   podId: string | null;
   podName: string;
   taskId?: string;
-  options?: string[];
+  options?: Array<{ label: string; description?: string; recommended?: boolean }>;
   timestamp: string | null;
   // Mention rows carry where they live so a reply can land IN the thread.
-  messageId?: number;
-  threadRootId?: number;
+  messageId?: number | string;
+  threadRootId?: number | string;
 }
 
 interface BoardItem {
@@ -85,6 +84,9 @@ const V2ActivityPage: React.FC = () => {
   const [acknowledgingMentionId, setAcknowledgingMentionId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [rulingId, setRulingId] = useState<string | null>(null);
+  const [otherDecisionId, setOtherDecisionId] = useState<string | null>(null);
+  const [otherDecisionValue, setOtherDecisionValue] = useState('');
+  const [ruledDecisions, setRuledDecisions] = useState<Record<string, { value: string; by: string }>>({});
   const [composePodId, setComposePodId] = useState('');
   const [composeDraft, setComposeDraft] = useState('');
   const [composing, setComposing] = useState(false);
@@ -171,18 +173,18 @@ const V2ActivityPage: React.FC = () => {
     navigate('/v2');
   };
 
-  const actOnApproval = async (item: NeedsYouItem, action: 'approved' | 'declined') => {
+  const actOnApproval = async (item: NeedsYouItem, action: 'approve' | 'reject') => {
     if (actingApprovalId) return;
     setActingApprovalId(item.id);
     setActionError(null);
     try {
       const token = localStorage.getItem('token');
-      const response = await axios.post<{ ok?: boolean }>(
-        `/api/approvals/${encodeURIComponent(item.id)}/resolve`,
-        { decision: action },
+      const response = await axios.post<{ success?: boolean }>(
+        `/api/activity/${encodeURIComponent(item.id)}/${action}`,
+        { notes: `${action === 'approve' ? 'Approved' : 'Rejected'} via Activity` },
         { headers: { 'x-auth-token': token ?? '' } },
       );
-      if (!response.data?.ok) throw new Error('Approval action failed');
+      if (!response.data?.success) throw new Error('Approval action failed');
       setReloadKey((value) => value + 1);
     } catch {
       setActionError(t('activity.approval.actionFailed'));
@@ -191,21 +193,31 @@ const V2ActivityPage: React.FC = () => {
     }
   };
 
-  const ruleDecision = async (item: NeedsYouItem, option: string) => {
-    if (!item.taskId || !item.podId || rulingId) return;
+  const ruleDecision = async (item: NeedsYouItem, value: string) => {
+    if (rulingId || !value.trim()) return;
     setRulingId(item.id);
     setActionError(null);
     try {
       const token = localStorage.getItem('token');
       const response = await axios.post<{ ok?: boolean }>(
-        `/api/activity/tasks/${encodeURIComponent(item.taskId)}/rule`,
-        { podId: item.podId, option },
+        `/api/activity/decisions/${encodeURIComponent(item.id)}/choose`,
+        { value },
         { headers: { 'x-auth-token': token ?? '' } },
       );
       if (!response.data?.ok) throw new Error('Decision ruling failed');
+      setOtherDecisionId(null);
+      setOtherDecisionValue('');
       setReloadKey((value) => value + 1);
-    } catch {
-      setActionError(t('activity.decision.actionFailed'));
+    } catch (error) {
+      const standing = axios.isAxiosError(error) ? error.response?.data?.decision?.ruling : null;
+      if (standing?.value && standing?.by) {
+        setRuledDecisions((current) => ({
+          ...current,
+          [item.id]: { value: standing.value, by: standing.by },
+        }));
+      } else {
+        setActionError(t('activity.decision.actionFailed'));
+      }
     } finally {
       setRulingId(null);
     }
@@ -427,10 +439,10 @@ const V2ActivityPage: React.FC = () => {
                     <div className="v2-activity__queue-actions">
                       {item.kind === 'approval' && (
                         <>
-                          <button type="button" onClick={() => actOnApproval(item, 'approved')} disabled={actingApprovalId === item.id}>
+                          <button type="button" onClick={() => actOnApproval(item, 'approve')} disabled={actingApprovalId === item.id}>
                             {actingApprovalId === item.id ? t('activity.approval.working') : t('activity.approval.approve')}
                           </button>
-                          <button type="button" className="v2-activity__queue-action--secondary" onClick={() => actOnApproval(item, 'declined')} disabled={actingApprovalId === item.id}>
+                          <button type="button" className="v2-activity__queue-action--secondary" onClick={() => actOnApproval(item, 'reject')} disabled={actingApprovalId === item.id}>
                             {t('activity.approval.deny')}
                           </button>
                         </>
@@ -460,23 +472,63 @@ const V2ActivityPage: React.FC = () => {
                           </button>
                         </>
                       )}
-                      {(item.kind === 'decision' || item.kind === 'press') && (
+                      {item.kind === 'decision' && (
                         <>
-                          {item.kind === 'decision' && item.options?.map((option) => (
-                            <button
-                              key={option}
-                              type="button"
-                              onClick={() => ruleDecision(item, option)}
-                              disabled={rulingId === item.id}
-                              aria-label={t('activity.decision.ruleOption', { option })}
-                            >
-                              {rulingId === item.id ? t('activity.decision.working') : option}
-                            </button>
-                          ))}
-                          <button type="button" className={item.options?.length ? 'v2-activity__queue-action--secondary' : ''} onClick={() => openBoard(item)} disabled={!item.podId}>
-                            {t('activity.openBoard')}
-                          </button>
+                          {ruledDecisions[item.id] ? (
+                            <span className="v2-activity__decision-ruled" role="status">
+                              {t('activity.decision.ruled', ruledDecisions[item.id])}
+                            </span>
+                          ) : (
+                            <>
+                              {[...(item.options || [])]
+                                .sort((a, b) => Number(Boolean(b.recommended)) - Number(Boolean(a.recommended)))
+                                .map((option) => (
+                                  <button
+                                    key={option.label}
+                                    type="button"
+                                    className={`v2-activity__option${option.recommended ? ' v2-activity__option--recommended' : ''}`}
+                                    onClick={() => ruleDecision(item, option.label)}
+                                    disabled={rulingId === item.id}
+                                    aria-label={t('activity.decision.ruleOption', { option: option.label })}
+                                    title={option.description}
+                                  >
+                                    {rulingId === item.id ? t('activity.decision.working') : option.label}
+                                  </button>
+                                ))}
+                              <button
+                                type="button"
+                                className="v2-activity__queue-action--secondary v2-activity__option"
+                                onClick={() => setOtherDecisionId((current) => current === item.id ? null : item.id)}
+                                disabled={rulingId === item.id}
+                              >
+                                {t('activity.decision.other')}
+                              </button>
+                              {otherDecisionId === item.id && (
+                                <div className="v2-activity__decision-other" data-testid="decision-other">
+                                  <textarea
+                                    aria-label={t('activity.decision.otherPlaceholder')}
+                                    rows={2}
+                                    value={otherDecisionValue}
+                                    onChange={(event) => setOtherDecisionValue(event.target.value)}
+                                    disabled={rulingId === item.id}
+                                  />
+                                  <button
+                                    type="button"
+                                    onClick={() => ruleDecision(item, otherDecisionValue)}
+                                    disabled={rulingId === item.id || !otherDecisionValue.trim()}
+                                  >
+                                    {rulingId === item.id ? t('activity.decision.working') : t('activity.decision.sendOther')}
+                                  </button>
+                                </div>
+                              )}
+                            </>
+                          )}
                         </>
+                      )}
+                      {item.kind === 'press' && (
+                        <button type="button" onClick={() => openBoard(item)} disabled={!item.podId}>
+                          {t('activity.openBoard')}
+                        </button>
                       )}
                       <button type="button" className="v2-activity__queue-action--thread" onClick={() => openPod(item.podId)} disabled={!item.podId}>
                         {t('activity.openThread')}

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -483,17 +483,20 @@ const V2ActivityPage: React.FC = () => {
                               {[...(item.options || [])]
                                 .sort((a, b) => Number(Boolean(b.recommended)) - Number(Boolean(a.recommended)))
                                 .map((option) => (
-                                  <button
-                                    key={option.label}
-                                    type="button"
-                                    className={`v2-activity__option${option.recommended ? ' v2-activity__option--recommended' : ''}`}
-                                    onClick={() => ruleDecision(item, option.label)}
-                                    disabled={rulingId === item.id}
-                                    aria-label={t('activity.decision.ruleOption', { option: option.label })}
-                                    title={option.description}
-                                  >
-                                    {rulingId === item.id ? t('activity.decision.working') : option.label}
-                                  </button>
+                                  <div className="v2-activity__option-choice" key={option.label}>
+                                    <button
+                                      type="button"
+                                      className={`v2-activity__option${option.recommended ? ' v2-activity__option--recommended' : ''}`}
+                                      onClick={() => ruleDecision(item, option.label)}
+                                      disabled={rulingId === item.id}
+                                      aria-label={t('activity.decision.ruleOption', { option: option.label })}
+                                    >
+                                      {rulingId === item.id ? t('activity.decision.working') : option.label}
+                                    </button>
+                                    {option.description && (
+                                      <span className="v2-activity__option-description">{option.description}</span>
+                                    )}
+                                  </div>
                                 ))}
                               <button
                                 type="button"

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -8372,6 +8372,91 @@ body.modern-ui.v2-canvas {
   margin-top: 30px;
 }
 
+.v2-activity__compose {
+  margin-top: 22px;
+  padding: 16px;
+  border: 1px solid var(--v2-border-soft);
+  border-radius: var(--v2-radius);
+  background: var(--v2-surface);
+}
+
+.v2-activity__compose-heading,
+.v2-activity__compose-entry,
+.v2-activity__compose-pod {
+  display: flex;
+  align-items: end;
+  gap: 12px;
+}
+
+.v2-activity__compose-heading {
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.v2-activity__compose h2 {
+  font-size: 17px;
+  line-height: 1.25;
+  letter-spacing: -0.015em;
+}
+
+.v2-activity__compose-pod {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  color: var(--v2-text-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.v2-activity__compose-pod select {
+  min-height: 36px;
+  max-width: 220px;
+  padding: 0 28px 0 10px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  font: inherit;
+  font-weight: 500;
+}
+
+.v2-root .v2-activity__compose textarea {
+  flex: 1 1 auto;
+  min-width: 0;
+  resize: vertical;
+  padding: 10px 11px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  font: inherit;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.v2-root .v2-activity__compose textarea:focus-visible,
+.v2-activity__compose-pod select:focus-visible {
+  outline: 2px solid var(--v2-accent);
+  outline-offset: 1px;
+}
+
+.v2-root .v2-activity__compose button {
+  min-height: 44px;
+  padding: 0 15px;
+  border: 1px solid var(--v2-accent);
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-accent);
+  color: var(--v2-surface);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.v2-root .v2-activity__compose button:hover:not(:disabled) {
+  border-color: var(--v2-accent-strong);
+  background: var(--v2-accent-strong);
+}
+
 .v2-activity__section-heading {
   display: flex;
   align-items: end;
@@ -8700,6 +8785,10 @@ body.modern-ui.v2-canvas {
   .v2-activity__window { width: 100%; }
   .v2-root button.v2-activity__window-button { flex: 1 1 0; }
   .v2-activity__scope select { width: 100%; max-width: none; }
+  .v2-activity__compose-heading,
+  .v2-activity__compose-entry { align-items: stretch; flex-direction: column; }
+  .v2-activity__compose-pod select { max-width: none; width: 100%; }
+  .v2-root .v2-activity__compose button { width: 100%; }
   .v2-activity__section-heading > p { text-align: left; }
   .v2-activity__agent-grid { grid-template-columns: minmax(0, 1fr); }
 
@@ -8710,6 +8799,9 @@ body.modern-ui.v2-canvas {
   .v2-activity__queue-actions { grid-column: 2; }
 
   .v2-activity__queue-actions { flex-wrap: wrap; }
+  /* Options are one-tap decisions. Keep their touch targets honest even
+     when a 390px viewport makes the pills wrap onto separate rows. */
+  .v2-root .v2-activity__queue-actions button { min-height: 44px; }
 
   .v2-activity__board-meta {
     grid-column: 1;
@@ -8756,6 +8848,7 @@ body.modern-ui.v2-canvas {
 .v2-root:lang(zh) .v2-feature__legacy .MuiTypography-h6,
 .v2-root:lang(zh) .v2-team__title,
 .v2-root:lang(zh) .v2-activity__title,
+.v2-root:lang(zh) .v2-activity__compose h2,
 .v2-root:lang(zh) .v2-activity__section h2,
 .v2-root:lang(zh) .v2-activity__agent-card h3,
 .v2-root:lang(zh) .v2-activity__board-row h3,

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -8629,6 +8629,40 @@ body.modern-ui.v2-canvas {
   color: var(--v2-accent-text);
 }
 
+/* DecisionRequest alternatives are touchable pills, not task metadata. The
+   recommendation is visually quiet but carries a stable accent distinction. */
+.v2-root .v2-activity__queue-actions button.v2-activity__option--recommended {
+  border-color: var(--v2-accent-strong);
+  background: var(--v2-accent-soft);
+  color: var(--v2-accent-text);
+}
+
+.v2-activity__decision-other {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  flex-basis: 100%;
+  gap: 8px;
+  align-items: end;
+}
+
+.v2-activity__decision-other textarea {
+  width: 100%;
+  min-height: 44px;
+  resize: vertical;
+  padding: 8px 10px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-surface);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.v2-activity__decision-ruled {
+  color: var(--v2-text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
 .v2-activity__action-error {
   margin-top: 10px;
   color: var(--v2-danger);
@@ -8802,6 +8836,7 @@ body.modern-ui.v2-canvas {
   /* Options are one-tap decisions. Keep their touch targets honest even
      when a 390px viewport makes the pills wrap onto separate rows. */
   .v2-root .v2-activity__queue-actions button { min-height: 44px; }
+  .v2-activity__decision-other { grid-template-columns: minmax(0, 1fr); }
 
   .v2-activity__board-meta {
     grid-column: 1;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -8629,12 +8629,51 @@ body.modern-ui.v2-canvas {
   color: var(--v2-accent-text);
 }
 
-/* DecisionRequest alternatives are touchable pills, not task metadata. The
-   recommendation is visually quiet but carries a stable accent distinction. */
+/* DecisionRequest alternatives are content, not row actions: a decision gets
+   its own full-width action line below the question. A neutral base prevents
+   an arbitrary non-recommended choice from inheriting the queue's primary
+   CTA treatment; the recommended choice is the only emphasized pill. */
+.v2-activity__queue-row--decision .v2-activity__queue-actions {
+  grid-column: 1 / -1;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.v2-root .v2-activity__queue-actions button.v2-activity__option {
+  border: 1px solid var(--v2-border);
+  border-radius: 999px;
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+}
+
 .v2-root .v2-activity__queue-actions button.v2-activity__option--recommended {
-  border-color: var(--v2-accent-strong);
-  background: var(--v2-accent-soft);
-  color: var(--v2-accent-text);
+  border-color: var(--v2-accent);
+  background: var(--v2-accent);
+  color: var(--v2-surface);
+}
+
+.v2-root .v2-activity__queue-actions button.v2-activity__option.v2-activity__queue-action--secondary {
+  border-style: dashed;
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
+}
+
+.v2-activity__option-choice {
+  display: grid;
+  flex: 0 1 220px;
+  min-width: 0;
+  gap: 4px;
+}
+
+.v2-activity__option-choice button {
+  width: 100%;
+  justify-content: center;
+}
+
+.v2-activity__option-description {
+  color: var(--v2-text-muted);
+  font-size: 12px;
+  line-height: 1.35;
 }
 
 .v2-activity__decision-other {
@@ -8836,6 +8875,7 @@ body.modern-ui.v2-canvas {
   /* Options are one-tap decisions. Keep their touch targets honest even
      when a 390px viewport makes the pills wrap onto separate rows. */
   .v2-root .v2-activity__queue-actions button { min-height: 44px; }
+  .v2-activity__option-choice { flex-basis: min(100%, 220px); }
   .v2-activity__decision-other { grid-template-columns: minmax(0, 1fr); }
 
   .v2-activity__board-meta {


### PR DESCRIPTION
## Summary
- replace the board-title `OPTIONS:` / `SAM RULED` convention with a durable `DecisionRequest` fact authored through new MCP tool `commonly_request_decision` and CAP route `POST /api/agents/runtime/decisions`
- require the authenticated runtime installation as provenance; validate 2–4 unique options and at most one recommendation before posting the agent's source question
- render pending DecisionRequests in Activity; a human pod member's option or free-text ruling becomes a normal threaded chat reply to the asking agent and therefore uses the ordinary wake path
- protect concurrent taps with a short CAS lease, return the standing ruling on a completed duplicate, and keep privileged `ApprovalAction` semantics separate and unchanged
- remove the obsolete board decision parser and rule endpoint; retain normal board press rows without synthesizing decision cards
- add the responsive option/Other UI, i18n, 44px CSS invariant, MCP and CAP documentation, plus focused service, route, MCP, and UI coverage

## Verification
- `cd backend && npm test -- --runInBand __tests__/unit/services/decisionRequestService.test.js __tests__/unit/routes/agentsRuntime.decision.test.js __tests__/unit/services/activityService.decisionQueue.test.js __tests__/unit/routes/activity.identity.test.js` — 15 passed
- `cd backend && npm run tsc:check`
- `cd backend && npx eslint services/decisionRequestService.ts models/DecisionRequest.ts`
- `cd commonly-mcp && node --experimental-vm-modules /private/tmp/commonly-task-091/commonly-mcp/node_modules/.bin/jest --runInBand __tests__/tools.test.mjs` — 43 passed
- `cd frontend && ./node_modules/.bin/jest --runInBand src/v2/__tests__/V2ActivityPage.test.tsx src/v2/__tests__/v2-layout-invariants.test.ts` — 68 passed
- `git diff --check`

Implements TASK-095 rev 2.