### PR TITLE
feat(cli): environment.effort → claude --effort (0.1.29)

### DIFF
--- a/cli/__tests__/adapters.claude.effort.test.mjs
+++ b/cli/__tests__/adapters.claude.effort.test.mjs
@@ -1,0 +1,101 @@
+/**
+ * `effort` is the reasoning budget a seat runs at. Sam's 2026-09-01 order:
+ * "flip all fable agents into fable 5.1 with high or above effort." The
+ * wrapper had no way to say it — `--effort` never left the operator's own
+ * terminal — so every Fable seat ran at the CLI default while nothing
+ * recorded that it did. Same shape as the model-pin gap (#774): a fact that
+ * lived only in a process environment, dropped by every restart.
+ *
+ * Two assertions carry the weight: the retry one (a session-recovery spawn
+ * must not silently run at a different effort than the turn it replaces —
+ * the drifting-copy failure this codebase keeps re-learning), and the
+ * validator one (a closed set fails at attach, not at first spawn).
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import claude from '../src/lib/adapters/claude.js';
+import { validateEnvironmentSpec } from '../src/lib/environment.js';
+
+const makeSpawnImpl = (behaviours = []) => {
+  const calls = [];
+  let n = 0;
+  const impl = (cmd, args) => {
+    calls.push({ cmd, args });
+    const behaviour = behaviours[n] || 'ok';
+    n += 1;
+    const listeners = {};
+    const proc = {
+      stdout: { on: (e, cb) => { if (e === 'data' && behaviour === 'ok') cb('done'); } },
+      stderr: { on: (e, cb) => { if (e === 'data' && behaviour === 'session-conflict') cb('session id already in use'); } },
+      on: (e, cb) => { listeners[e] = cb; },
+    };
+    setImmediate(() => {
+      if (listeners.close) listeners.close(behaviour === 'session-conflict' ? 1 : 0);
+    });
+    return proc;
+  };
+  return { impl, calls };
+};
+
+const flagValue = (args, flag) => {
+  const i = args.indexOf(flag);
+  return i === -1 ? undefined : args[i + 1];
+};
+
+describe('claude adapter — effort passthrough', () => {
+  let cwd;
+  beforeEach(() => {
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-claude-effort-'));
+  });
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  test('passes --effort next to --model when the environment sets both', async () => {
+    const { impl, calls } = makeSpawnImpl();
+    await claude.spawn('hi', {
+      sessionId: null,
+      cwd,
+      environment: { model: 'claude-fable-5-1', effort: 'high' },
+      _spawnImpl: impl,
+    });
+    expect(flagValue(calls[0].args, '--model')).toBe('claude-fable-5-1');
+    expect(flagValue(calls[0].args, '--effort')).toBe('high');
+  });
+
+  test('passes no --effort when the environment omits it', async () => {
+    const { impl, calls } = makeSpawnImpl();
+    await claude.spawn('hi', { sessionId: null, cwd, environment: { model: 'claude-fable-5-1' }, _spawnImpl: impl });
+    expect(calls[0].args).not.toContain('--effort');
+  });
+
+  test('carries the same --effort into the session-recovery retry', async () => {
+    const { impl, calls } = makeSpawnImpl(['session-conflict', 'ok']);
+    await claude.spawn('hi', {
+      sessionId: 'existing-session',
+      cwd,
+      environment: { model: 'claude-fable-5-1', effort: 'high' },
+      _spawnImpl: impl,
+    });
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    for (const call of calls) {
+      expect(flagValue(call.args, '--effort')).toBe('high');
+      expect(flagValue(call.args, '--model')).toBe('claude-fable-5-1');
+    }
+  });
+});
+
+describe('environment spec — effort validation', () => {
+  test('accepts the five documented levels', () => {
+    for (const effort of ['low', 'medium', 'high', 'xhigh', 'max']) {
+      expect(validateEnvironmentSpec({ version: 1, effort }).ok).toBe(true);
+    }
+  });
+
+  test('rejects an unknown level at attach time, naming the set', () => {
+    const result = validateEnvironmentSpec({ version: 1, effort: 'ultra' });
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/effort must be one of: low, medium, high, xhigh, max/);
+  });
+});

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "license": "Apache-2.0",
   "description": "The Commonly CLI \u2014 connect agents, manage pods, iterate fast",
   "type": "module",

--- a/cli/src/lib/adapters/claude.js
+++ b/cli/src/lib/adapters/claude.js
@@ -488,7 +488,15 @@ export default {
     // present in one but not the other means a retry silently runs a different
     // model than the turn it is replacing — the same drifting-copy shape that
     // has bitten this codebase repeatedly.
-    const modelArgs = ctx.environment?.model ? ['--model', String(ctx.environment.model)] : [];
+    // `effort` rides in the same array for the same reason: Sam's 2026-09-01
+    // order ("flip all fable agents into fable 5.1 with high or above
+    // effort") needs both facts to reach every spawn, including the
+    // session-recovery retry, or a retry runs at a different effort than the
+    // turn it replaces.
+    const modelArgs = [
+      ...(ctx.environment?.model ? ['--model', String(ctx.environment.model)] : []),
+      ...(ctx.environment?.effort ? ['--effort', String(ctx.environment.effort)] : []),
+    ];
     const baseArgs = ['-p', fullPrompt, '--output-format', 'text', sessionFlag, sessionId, ...modelArgs];
 
     if (ctx.environment && ctx.cwd) {

--- a/cli/src/lib/environment.js
+++ b/cli/src/lib/environment.js
@@ -41,7 +41,7 @@ import { homedir } from 'os';
 // "persona and runtime are chosen separately" requires to mean anything for a
 // BYO seat, and what lets an identity card answer "what is this running".
 const ALLOWED_TOP_KEYS = new Set([
-  'version', 'workspace', 'sandbox', 'skills', 'mcp', 'model',
+  'version', 'workspace', 'sandbox', 'skills', 'mcp', 'model', 'effort',
 ]);
 const ALLOWED_SANDBOX_MODES = new Set([
   'none', 'workspace', 'read-only', 'bwrap', 'firejail', 'container', 'managed',
@@ -132,6 +132,16 @@ export const validateEnvironmentSpec = (spec) => {
   if (spec.model !== undefined) {
     if (typeof spec.model !== 'string' || spec.model.trim() === '') {
       errors.push('model must be a non-empty string');
+    }
+  }
+
+  // `effort` is the reasoning budget the claude adapter passes to `--effort`.
+  // Unlike `model` it IS a closed set — the CLI documents exactly these — so a
+  // typo fails here at attach time, not silently at the first spawn.
+  if (spec.effort !== undefined) {
+    const EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'];
+    if (typeof spec.effort !== 'string' || !EFFORTS.includes(spec.effort)) {
+      errors.push(`effort must be one of: ${EFFORTS.join(', ')}`);
     }
   }
 


### PR DESCRIPTION
Sam's order: Fable seats to fable-5.1 at effort ≥ high. The env spec gains `effort` (low|medium|high|xhigh|max, validated at attach); the claude adapter passes it beside --model in the one args array both spawn paths share, so a session-recovery retry cannot run at a different effort. Tests: passthrough, omission, retry carry, validator accept/reject (20/20 across the adapter suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmApTnNd9VZRTE2Fi1gM6z