### PR TITLE
docs(adr-025): the private-chat binding supersedes D7; D7 narrows to team-group bridging

### DIFF
--- a/docs/adr/ADR-025-connector-substrate.md
+++ b/docs/adr/ADR-025-connector-substrate.md
@@ -300,6 +300,27 @@ shipping a seventh plaintext credential is a decision too, and it should be take
 **D7 — Connectors scope like Installables.** One connector record projected to N pods, per ADR-001's
 one-install-fans-out, so an enterprise install is one administrative act rather than twenty.
 
+> **Superseded for the private-chat case — the reconciliation position (pod-architect, 2026-09-01).**
+> Sam's 2026-08-31 01:44Z ruling folds #1295 into this document and delegates "whose text is
+> canonical" to cl-strategist and me. This is my half of that call, filed as an artifact rather than
+> a comment so it carries its own answer.
+>
+> The two texts overlap on exactly one decision. #1295's **"The private chat binds to the USER, not
+> to a pod"** — `Integration.scope: 'user'`, `linkedUserId` the owner, no `podId` — **replaces D7**
+> for that case, and lands as the first folded decision (D8 under the D8+ numbering, so no slot is
+> contested). D7's own evidence is what argues for it: Finding 6 measures `podId` as required and
+> singular, and reads that as an N-pod projection problem, because a projection is what ADR-001
+> supplies. But an enterprise install and a person's private chat want opposite things from the same
+> field. A projection to N pods keeps the pod as the binding unit and multiplies it; the user-scoped
+> record removes the binding unit instead, which is the shape a private chat actually has — one
+> human, every pod they are in, one credential. Finding 6 stays as written; only the decision it
+> feeds changes.
+>
+> D7 is **not** withdrawn: team-group bridging still wants one record across many pods, and #1295
+> keeps the pod-scoped connector for exactly that, dormant until per-sender attribution exists. So
+> the two are a case split, not a contest — D7 for the shared channel, the folded D8 for the private
+> one. Read D7 as scoped to team-group bridging from here.
+
 ---
 
 ## What this ADR does not decide


### PR DESCRIPTION
Sam's 2026-08-31 01:44Z ruling folded #1295 into the merged ADR-025 and delegated **whose text is canonical** to @cl-strategist and me. This is my half, filed as a PR rather than another comment because #1295 is cl-strategist's branch and I cannot push to it — a reversible artifact carries its own answer, a comment asks for one.

**The position.** The two texts overlap on exactly one decision. #1295's D1 — *the private chat binds to the USER, not to a pod* (`Integration.scope: 'user'`, `linkedUserId` the owner, no `podId`) — **replaces D7** for that case, and lands as **D8** under the agreed D8+ numbering (sprint-review's fix: make the collision unconstructable rather than detectable), so no existing slot is contested.

**Why D7's own evidence argues for it.** Finding 6 measures `models/Integration.ts:95` — `podId` required and singular — and reads it as an N-pod projection problem, because ADR-001 supplies a projection. But an enterprise install and a person's private chat want opposite things from that field. A projection keeps the pod as the binding unit and multiplies it; the user-scoped record removes the binding unit, which is the shape a private chat actually has: one human, every pod they are in, one credential. **Finding 6 stays as written; only the decision it feeds changes.**

**D7 is not withdrawn.** Team-group bridging still wants one record across many pods, and #1295 explicitly keeps the pod-scoped connector for that, dormant until per-sender attribution exists. So this is a case split, not a contest — D7 for the shared channel, D8 for the private one. The note narrows D7's scope in place.

Docs-only, +21/-0, inserted **in place under D7** so it does not queue behind the EOF-append PRs. Path-checked first: #1295 is the only other open PR touching an `ADR-025` file, and it adds a differently-named file, so no textual conflict.

This does not ratify anything — ADR-025 is still `Status: Draft` and D1–D7 are still proposals for @Sam. It records a delegated decision so the fold has a canonical text to fold *into*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)