### PR TITLE
docs(adr-025): cite the fold ruling by date and message id, not by time alone

### DIFF
--- a/docs/adr/ADR-025-connector-substrate.md
+++ b/docs/adr/ADR-025-connector-substrate.md
@@ -301,9 +301,9 @@ shipping a seventh plaintext credential is a decision too, and it should be take
 one-install-fans-out, so an enterprise install is one administrative act rather than twenty.
 
 > **Superseded for the private-chat case — the reconciliation position (pod-architect, 2026-09-01).**
-> Sam's 2026-08-31 01:44Z ruling folds #1295 into this document and delegates "whose text is
-> canonical" to cl-strategist and me. This is my half of that call, filed as an artifact rather than
-> a comment so it carries its own answer.
+> Sam's ruling of 2026-08-30T01:44:52Z (pod message 60455) folds #1295 into this document and
+> delegates "whose text is canonical" to cl-strategist and me. This is my half of that call, filed
+> as an artifact rather than a comment so it carries its own answer.
 >
 > The two texts overlap on exactly one decision. #1295's **"The private chat binds to the USER, not
 > to a pod"** — `Integration.scope: 'user'`, `linkedUserId` the owner, no `podId` — **replaces D7**


### PR DESCRIPTION
`ADR-025`'s D8 block cited **"Sam's 2026-08-31 01:44Z ruling"**. The ruling is pod message **60455**, **2026-08-30T01:44:52Z** — one day earlier.

My own notes carried the time without the day, and I propagated it that way. @sprint-review then went to verify the citation before relaying it to Sam, searched 2026-08-31, found no pod message in that hour, and reported a false negative on a real ruling — recovering it only once I supplied the correct day. Their formulation is the transferable one: **a window search is only as good as the window.**

This replaces the time-only citation with the full timestamp and the message id, so a reader can check it rather than take it. No decision text changes — D8 still supersedes D7 for the private-chat case, D7 still narrows to team-group bridging, Finding 6 stands as written.

The same wrong date is in #1473's squash subject and is frozen in the git log. The file is the copy the fleet reads, so this is the half that is worth fixing.

Docs-only, +3/-3, one paragraph. Verified: file stays 375 lines, only the two cited lines move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)