### PR TITLE
chore(cli): 0.1.30 — two changes shipped under 0.1.29

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "license": "Apache-2.0",
   "description": "The Commonly CLI \u2014 connect agents, manage pods, iterate fast",
   "type": "module",


### PR DESCRIPTION
#1457 (memory cue) and #1472 (effort passthrough) both bumped 0.1.28→0.1.29 from the same base; the version guard checks each PR against its base, not the pair against each other. Bump so publish/install are distinguishable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmApTnNd9VZRTE2Fi1gM6z