### PR TITLE
feat(activity): add sectioned Activity layout

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -73,7 +73,6 @@
     },
     "views": {
       "ariaLabel": "Activity view",
-      "label": "Show",
       "sections": "Sections",
       "timeline": "Timeline"
     },

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -71,6 +71,21 @@
         "press": "Ready for your press"
       }
     },
+    "views": {
+      "ariaLabel": "Activity view",
+      "label": "Show",
+      "sections": "Sections",
+      "timeline": "Timeline"
+    },
+    "timeline": {
+      "eyebrow": "Chronological view",
+      "title": "Timeline",
+      "description": "Agent updates and board changes together, newest first.",
+      "emptyTitle": "No activity in this window",
+      "emptyDescription": "Agent updates and board changes will appear here as they happen.",
+      "agentUpdate": "Agent update",
+      "boardChange": "Board change"
+    },
     "dayZero": {
       "kind": "Get started",
       "guide": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -73,7 +73,6 @@
     },
     "views": {
       "ariaLabel": "动态视图",
-      "label": "显示",
       "sections": "分区",
       "timeline": "时间线"
     },

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -71,6 +71,21 @@
         "press": "待你合并"
       }
     },
+    "views": {
+      "ariaLabel": "动态视图",
+      "label": "显示",
+      "sections": "分区",
+      "timeline": "时间线"
+    },
+    "timeline": {
+      "eyebrow": "按时间查看",
+      "title": "时间线",
+      "description": "智能体更新和看板变更按时间合并，最新在前。",
+      "emptyTitle": "此时间范围内没有动态",
+      "emptyDescription": "智能体更新和看板变更发生时会显示在这里。",
+      "agentUpdate": "智能体更新",
+      "boardChange": "看板变更"
+    },
     "dayZero": {
       "kind": "开始使用",
       "guide": {

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -100,7 +100,12 @@ describe('V2ActivityPage', () => {
     // findBy, not getBy: the header renders unconditionally, so awaiting it
     // proves nothing about data arrival — and the queue+recap Promise.all
     // adds a microtask hop the old single-request race happened to win.
-    expect(await screen.findByRole('heading', { name: 'Needs you' })).toBeInTheDocument();
+    const needsYouHeading = await screen.findByRole('heading', { name: 'Needs you' });
+    expect(needsYouHeading).toBeInTheDocument();
+    // The human decision queue is the first activity surface; composing a
+    // new message must not bury an existing ask below another card.
+    const composeHeading = screen.getByRole('heading', { name: 'Tell your agents what is on your mind' });
+    expect(needsYouHeading.compareDocumentPosition(composeHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(screen.getByText('Review requested')).toBeInTheDocument();
     // A board press remains an Open-board action; DecisionRequest cards use
     // their declared options rather than deriving actions from task prose.
@@ -135,6 +140,37 @@ describe('V2ActivityPage', () => {
     // findAll: the window change reloads both requests and the rows remount.
     fireEvent.click((await screen.findAllByRole('button', { name: 'Open thread' }))[0]);
     expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/pod-1');
+  });
+
+  test('keeps the sectioned evidence view as the default and projects the same facts into an opt-in timeline', async () => {
+    const timelineRecap = {
+      ...recap,
+      agents: [{
+        ...recap.agents[0],
+        updates: [{ ...recap.agents[0].updates[0], timestamp: '2026-08-26T10:00:00.000Z' }],
+      }],
+      board: [{ ...recap.board[0], updatedAt: '2026-08-26T11:00:00.000Z' }],
+    };
+    mockGet.mockImplementation((url: string) => Promise.resolve({
+      data: url === '/api/activity/decision-queue' ? decisionQueue : timelineRecap,
+    }));
+    renderPage();
+    await screen.findByText('Review requested');
+
+    expect(screen.getByRole('button', { name: 'Sections' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('heading', { name: 'What your agents did' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Board' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Timeline' }));
+    expect(screen.getByRole('button', { name: 'Timeline' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('heading', { name: 'Timeline' })).toBeInTheDocument();
+    expect(screen.getByText('Agent update')).toBeInTheDocument();
+    expect(screen.getByText('Board change')).toBeInTheDocument();
+    expect(screen.getByText('Checks passed.')).toBeInTheDocument();
+    expect(screen.getByText('Activity tab')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'What your agents did' })).not.toBeInTheDocument();
+    const timelineText = screen.getByRole('list').textContent || '';
+    expect(timelineText.indexOf('Activity tab')).toBeLessThan(timelineText.indexOf('Checks passed.'));
   });
 
   test('acknowledges a mention explicitly instead of treating a feed read as acknowledgement', async () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -492,12 +492,11 @@ describe('v2 layout invariants (CSS rule presence)', () => {
 
   test('Activity keeps attention first and uses a responsive sectioned evidence layout', () => {
     // Needs-you remains a full-width first section. The lower evidence lenses
-    // earn two balanced desktop tracks, then collapse before a 390px capture
-    // can turn either agent recap or board change into a narrow side column.
+    // stack full-width too: a split makes long agent evidence and board titles
+    // truncate at desktop widths before the user has any reason to expect it.
     const sectioned = ruleBody(v2, '.v2-activity__sectioned');
-    expect(sectioned).toContain('repeat(2, minmax(0, 1fr))');
+    expect(sectioned).toContain('grid-template-columns: minmax(0, 1fr)');
     expect(sectioned).toContain('align-items: start');
-    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-activity__sectioned \{ grid-template-columns: minmax\(0, 1fr\); \}/);
 
     // Timeline is an opt-in projection that stays in the same shrinkable
     // column grammar as the sectioned surface; it cannot create page-wide

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -490,6 +490,23 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-activity__board-row \{[\s\S]*?grid-template-columns: minmax\(0, 1fr\)/);
   });
 
+  test('Activity keeps attention first and uses a responsive sectioned evidence layout', () => {
+    // Needs-you remains a full-width first section. The lower evidence lenses
+    // earn two balanced desktop tracks, then collapse before a 390px capture
+    // can turn either agent recap or board change into a narrow side column.
+    const sectioned = ruleBody(v2, '.v2-activity__sectioned');
+    expect(sectioned).toContain('repeat(2, minmax(0, 1fr))');
+    expect(sectioned).toContain('align-items: start');
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-activity__sectioned \{ grid-template-columns: minmax\(0, 1fr\); \}/);
+
+    // Timeline is an opt-in projection that stays in the same shrinkable
+    // column grammar as the sectioned surface; it cannot create page-wide
+    // horizontal scrolling from a long pod, task, or agent name.
+    const timelineRow = ruleBody(v2, '.v2-activity__timeline-row');
+    expect(timelineRow).toContain('14px minmax(0, 1fr)');
+    expect(timelineRow).toContain('min-width: 0');
+  });
+
   test('Activity queue actions distinguish an action from the thread handoff', () => {
     expect(ruleBody(v2, '.v2-root .v2-activity__queue-actions button')).toContain('background: var(--v2-accent)');
     expect(ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__queue-action--secondary')).toContain('background: var(--v2-surface-hover)');

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -6,6 +6,7 @@ import V2Avatar from './V2Avatar';
 import { requestFirstRunGuide } from '../firstRunGuide';
 
 type ActivityWindow = 'today' | '7d';
+type ActivityView = 'sections' | 'timeline';
 
 interface ActivityUpdate {
   id: string;
@@ -53,6 +54,17 @@ interface BoardItem {
   lastUpdate: { text: string; author: string; createdAt: string | null } | null;
 }
 
+interface TimelineItem {
+  id: string;
+  kind: 'agent' | 'board';
+  title: string;
+  detail: string;
+  podId: string | null;
+  podName: string;
+  timestamp: string | null;
+  status?: BoardItem['status'];
+}
+
 interface ActivityRecap {
   pods: Array<{ id: string; name: string }>;
   needsYou: NeedsYouItem[];
@@ -75,6 +87,7 @@ const V2ActivityPage: React.FC = () => {
   const navigate = useNavigate();
   const { t } = useTranslation();
   const [window, setWindow] = useState<ActivityWindow>('today');
+  const [view, setView] = useState<ActivityView>('sections');
   const [podId, setPodId] = useState('all');
   const [recap, setRecap] = useState<ActivityRecap | null>(null);
   const [loading, setLoading] = useState(true);
@@ -304,6 +317,35 @@ const V2ActivityPage: React.FC = () => {
     && recap?.agents.length === 0
     && recap.board.length === 0;
 
+  // The timeline is a second projection of the existing recap facts. It
+  // deliberately adds no feed endpoint or event semantics: the sectioned
+  // view remains the default because it preserves the agent and board lens.
+  const timeline: TimelineItem[] = recap ? [
+    ...recap.agents.flatMap((agent) => agent.updates.map((update) => ({
+      id: `agent-${agent.id}-${update.id}`,
+      kind: 'agent' as const,
+      title: agent.name,
+      detail: update.content,
+      podId: update.podId,
+      podName: update.podName,
+      timestamp: update.timestamp,
+    }))),
+    ...recap.board.map((item) => ({
+      id: `board-${item.id}`,
+      kind: 'board' as const,
+      title: item.title,
+      detail: item.lastUpdate
+        ? `${item.lastUpdate.author ? `${item.lastUpdate.author}: ` : ''}${item.lastUpdate.text}`
+        : item.taskId,
+      podId: item.podId,
+      podName: item.podName,
+      timestamp: item.updatedAt,
+      status: item.status,
+    })),
+  ].sort((left, right) => (
+    new Date(right.timestamp || 0).getTime() - new Date(left.timestamp || 0).getTime()
+  )) : [];
+
   return (
     <div className="v2-activity" aria-busy={loading}>
       <header className="v2-activity__header">
@@ -339,36 +381,6 @@ const V2ActivityPage: React.FC = () => {
       {!loading && error && <div className="v2-activity__error" role="alert">{error}</div>}
       {!loading && !error && recap && (
         <>
-          <section className="v2-activity__compose" aria-labelledby="activity-compose-title">
-            <div className="v2-activity__compose-heading">
-              <div>
-                <div className="v2-activity__eyebrow">{t('activity.compose.eyebrow')}</div>
-                <h2 id="activity-compose-title">{t('activity.compose.title')}</h2>
-              </div>
-              <label className="v2-activity__compose-pod">
-                <span>{t('activity.compose.podLabel')}</span>
-                <select value={composePodId} onChange={(event) => setComposePodId(event.target.value)}>
-                  {(recap.pods || []).map((pod) => <option key={pod.id} value={pod.id}>{pod.name}</option>)}
-                </select>
-              </label>
-            </div>
-            <div className="v2-activity__compose-entry">
-              <textarea
-                aria-label={t('activity.compose.placeholder')}
-                rows={3}
-                placeholder={t('activity.compose.placeholder')}
-                value={composeDraft}
-                onChange={(event) => setComposeDraft(event.target.value)}
-                onKeyDown={(event) => { if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') sendCompose(); }}
-                disabled={composing || !composePodId}
-              />
-              <button type="button" aria-label={t('activity.compose.sendAriaLabel')} onClick={sendCompose} disabled={composing || !composePodId || !composeDraft.trim()}>
-                {composing ? t('activity.compose.working') : t('activity.compose.send')}
-              </button>
-            </div>
-            {composeError && <div className="v2-activity__action-error" role="alert">{composeError}</div>}
-          </section>
-
           <div className="v2-activity__sections">
           <section className="v2-activity__section" aria-labelledby="activity-needs-you">
             <div className="v2-activity__section-heading">
@@ -544,6 +556,53 @@ const V2ActivityPage: React.FC = () => {
             {actionError && <div className="v2-activity__action-error" role="alert">{actionError}</div>}
           </section>
 
+          <section className="v2-activity__compose" aria-labelledby="activity-compose-title">
+            <div className="v2-activity__compose-heading">
+              <div>
+                <div className="v2-activity__eyebrow">{t('activity.compose.eyebrow')}</div>
+                <h2 id="activity-compose-title">{t('activity.compose.title')}</h2>
+              </div>
+              <label className="v2-activity__compose-pod">
+                <span>{t('activity.compose.podLabel')}</span>
+                <select value={composePodId} onChange={(event) => setComposePodId(event.target.value)}>
+                  {(recap.pods || []).map((pod) => <option key={pod.id} value={pod.id}>{pod.name}</option>)}
+                </select>
+              </label>
+            </div>
+            <div className="v2-activity__compose-entry">
+              <textarea
+                aria-label={t('activity.compose.placeholder')}
+                rows={3}
+                placeholder={t('activity.compose.placeholder')}
+                value={composeDraft}
+                onChange={(event) => setComposeDraft(event.target.value)}
+                onKeyDown={(event) => { if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') sendCompose(); }}
+                disabled={composing || !composePodId}
+              />
+              <button type="button" aria-label={t('activity.compose.sendAriaLabel')} onClick={sendCompose} disabled={composing || !composePodId || !composeDraft.trim()}>
+                {composing ? t('activity.compose.working') : t('activity.compose.send')}
+              </button>
+            </div>
+            {composeError && <div className="v2-activity__action-error" role="alert">{composeError}</div>}
+          </section>
+
+          <div className="v2-activity__view-switcher" role="group" aria-label={t('activity.views.ariaLabel')}>
+            <span>{t('activity.views.label')}</span>
+            {(['sections', 'timeline'] as ActivityView[]).map((value) => (
+              <button
+                key={value}
+                type="button"
+                className={`v2-activity__view-button${view === value ? ' v2-activity__view-button--active' : ''}`}
+                onClick={() => setView(value)}
+                aria-pressed={view === value}
+              >
+                {t(`activity.views.${value}`)}
+              </button>
+            ))}
+          </div>
+
+          {view === 'sections' ? (
+          <div className="v2-activity__sectioned">
           <section className="v2-activity__section" aria-labelledby="activity-agents">
             <div className="v2-activity__section-heading">
               <div>
@@ -620,6 +679,46 @@ const V2ActivityPage: React.FC = () => {
               </div>
             )}
           </section>
+          </div>
+          ) : (
+          <section className="v2-activity__section v2-activity__timeline-section" aria-labelledby="activity-timeline">
+            <div className="v2-activity__section-heading">
+              <div>
+                <div className="v2-activity__eyebrow">{t('activity.timeline.eyebrow')}</div>
+                <h2 id="activity-timeline">{t('activity.timeline.title')}</h2>
+              </div>
+              <p>{t('activity.timeline.description')}</p>
+            </div>
+            {timeline.length === 0 ? (
+              <div className="v2-activity__empty">
+                <strong>{t('activity.timeline.emptyTitle')}</strong>
+                <span>{t('activity.timeline.emptyDescription')}</span>
+              </div>
+            ) : (
+              <ol className="v2-activity__timeline">
+                {timeline.map((item) => (
+                  <li key={item.id} className={`v2-activity__timeline-row v2-activity__timeline-row--${item.kind}`}>
+                    <span className="v2-activity__timeline-mark" aria-hidden="true" />
+                    <button type="button" onClick={() => openPod(item.podId)} disabled={!item.podId}>
+                      <span className="v2-activity__timeline-meta">
+                        {item.kind === 'board' && item.status && (
+                          <span className={`v2-activity__status v2-activity__status--${item.status}`}>
+                            {t(`activity.board.status.${item.status}`)}
+                          </span>
+                        )}
+                        <span>{item.kind === 'agent' ? t('activity.timeline.agentUpdate') : t('activity.timeline.boardChange')}</span>
+                        <span>{item.podName}</span>
+                        {item.timestamp && <span>{relativeTime(item.timestamp)}</span>}
+                      </span>
+                      <strong>{item.title}</strong>
+                      <span className="v2-activity__timeline-detail">{item.detail}</span>
+                    </button>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </section>
+          )}
           </div>
         </>
       )}

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -367,6 +367,19 @@ const V2ActivityPage: React.FC = () => {
               </button>
             ))}
           </div>
+          <div className="v2-activity__window" role="group" aria-label={t('activity.views.ariaLabel')}>
+            {(['sections', 'timeline'] as ActivityView[]).map((value) => (
+              <button
+                key={value}
+                type="button"
+                className={`v2-activity__window-button${view === value ? ' v2-activity__window-button--active' : ''}`}
+                onClick={() => setView(value)}
+                aria-pressed={view === value}
+              >
+                {t(`activity.views.${value}`)}
+              </button>
+            ))}
+          </div>
           <label className="v2-activity__scope">
             <span className="v2-sr-only">{t('activity.podScopeLabel')}</span>
             <select value={podId} onChange={(event) => setPodId(event.target.value)}>
@@ -585,21 +598,6 @@ const V2ActivityPage: React.FC = () => {
             </div>
             {composeError && <div className="v2-activity__action-error" role="alert">{composeError}</div>}
           </section>
-
-          <div className="v2-activity__view-switcher" role="group" aria-label={t('activity.views.ariaLabel')}>
-            <span>{t('activity.views.label')}</span>
-            {(['sections', 'timeline'] as ActivityView[]).map((value) => (
-              <button
-                key={value}
-                type="button"
-                className={`v2-activity__view-button${view === value ? ' v2-activity__view-button--active' : ''}`}
-                onClick={() => setView(value)}
-                aria-pressed={view === value}
-              >
-                {t(`activity.views.${value}`)}
-              </button>
-            ))}
-          </div>
 
           {view === 'sections' ? (
           <div className="v2-activity__sectioned">

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -8372,8 +8372,62 @@ body.modern-ui.v2-canvas {
   margin-top: 30px;
 }
 
+/* The page's default is the scannable, sectioned surface: attention first,
+   then two independent evidence lenses. Timeline is an opt-in projection of
+   those same facts, not a competing feed or a second activity data source. */
+.v2-activity__view-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  margin-top: -18px;
+  color: var(--v2-text-muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.v2-root button.v2-activity__view-button {
+  min-height: 30px;
+  padding: 0 9px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-surface);
+  color: var(--v2-text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.v2-root button.v2-activity__view-button:hover:not(:disabled) {
+  border-color: var(--v2-border-strong);
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
+}
+
+.v2-root button.v2-activity__view-button--active {
+  border-color: var(--v2-accent);
+  background: var(--v2-accent-soft);
+  color: var(--v2-accent-text);
+}
+
+.v2-activity__sectioned {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+  gap: 30px;
+}
+
+.v2-activity__sectioned .v2-activity__section-heading {
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.v2-activity__sectioned .v2-activity__section-heading > p {
+  text-align: left;
+}
+
 .v2-activity__compose {
-  margin-top: 22px;
+  margin-top: 0;
   padding: 16px;
   border: 1px solid var(--v2-border-soft);
   border-radius: var(--v2-radius);
@@ -8832,6 +8886,89 @@ body.modern-ui.v2-canvas {
   white-space: nowrap;
 }
 
+.v2-activity__timeline {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--v2-border-soft);
+  border-radius: var(--v2-radius);
+  list-style: none;
+  overflow: hidden;
+}
+
+.v2-activity__timeline-row {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  gap: 12px;
+  min-width: 0;
+  padding: 14px 16px;
+  background: var(--v2-surface);
+}
+
+.v2-activity__timeline-row + .v2-activity__timeline-row {
+  border-top: 1px solid var(--v2-border-soft);
+}
+
+.v2-activity__timeline-mark {
+  width: 8px;
+  height: 8px;
+  margin-top: 6px;
+  border-radius: 50%;
+  background: var(--v2-accent);
+}
+
+.v2-activity__timeline-row--board .v2-activity__timeline-mark {
+  background: var(--v2-text-muted);
+}
+
+.v2-root .v2-activity__timeline button {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 0;
+  color: var(--v2-text-primary);
+  text-align: left;
+}
+
+.v2-root .v2-activity__timeline button:hover:not(:disabled) strong {
+  color: var(--v2-accent-text);
+}
+
+.v2-activity__timeline-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  color: var(--v2-text-muted);
+  font-size: 12px;
+}
+
+.v2-activity__timeline-meta > span + span::before {
+  margin-right: 6px;
+  color: var(--v2-border-strong);
+  content: '·';
+}
+
+.v2-activity__timeline-meta .v2-activity__status + span::before {
+  content: none;
+}
+
+.v2-activity__timeline button strong,
+.v2-activity__timeline-detail {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.v2-activity__timeline button strong {
+  font-size: 14px;
+}
+
+.v2-activity__timeline-detail {
+  color: var(--v2-text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
 .v2-activity__footer {
   margin-top: 34px;
   color: var(--v2-text-muted);
@@ -8864,6 +9001,11 @@ body.modern-ui.v2-canvas {
   .v2-root .v2-activity__compose button { width: 100%; }
   .v2-activity__section-heading > p { text-align: left; }
   .v2-activity__agent-grid { grid-template-columns: minmax(0, 1fr); }
+  .v2-activity__sectioned { grid-template-columns: minmax(0, 1fr); }
+  .v2-activity__view-switcher {
+    justify-content: flex-start;
+    margin-top: -22px;
+  }
 
   .v2-activity__queue-row { grid-template-columns: 28px minmax(0, 1fr); }
   .v2-activity__board-row { grid-template-columns: minmax(0, 1fr); }

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -8304,6 +8304,8 @@ body.modern-ui.v2-canvas {
 .v2-activity__controls {
   gap: 8px;
   flex-shrink: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .v2-activity__window {
@@ -8375,55 +8377,11 @@ body.modern-ui.v2-canvas {
 /* The page's default is the scannable, sectioned surface: attention first,
    then two independent evidence lenses. Timeline is an opt-in projection of
    those same facts, not a competing feed or a second activity data source. */
-.v2-activity__view-switcher {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 4px;
-  margin-top: -18px;
-  color: var(--v2-text-muted);
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.v2-root button.v2-activity__view-button {
-  min-height: 30px;
-  padding: 0 9px;
-  border: 1px solid var(--v2-border);
-  border-radius: var(--v2-radius-sm);
-  background: var(--v2-surface);
-  color: var(--v2-text-secondary);
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.v2-root button.v2-activity__view-button:hover:not(:disabled) {
-  border-color: var(--v2-border-strong);
-  background: var(--v2-surface-hover);
-  color: var(--v2-text-primary);
-}
-
-.v2-root button.v2-activity__view-button--active {
-  border-color: var(--v2-accent);
-  background: var(--v2-accent-soft);
-  color: var(--v2-accent-text);
-}
-
 .v2-activity__sectioned {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1fr);
   align-items: start;
-  gap: 30px;
-}
-
-.v2-activity__sectioned .v2-activity__section-heading {
-  align-items: flex-start;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.v2-activity__sectioned .v2-activity__section-heading > p {
-  text-align: left;
+  gap: 38px;
 }
 
 .v2-activity__compose {
@@ -8989,11 +8947,12 @@ body.modern-ui.v2-canvas {
 
   .v2-activity__controls {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 110px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     width: 100%;
   }
   .v2-activity__window { width: 100%; }
   .v2-root button.v2-activity__window-button { flex: 1 1 0; }
+  .v2-activity__scope { grid-column: 1 / -1; }
   .v2-activity__scope select { width: 100%; max-width: none; }
   .v2-activity__compose-heading,
   .v2-activity__compose-entry { align-items: stretch; flex-direction: column; }
@@ -9001,11 +8960,6 @@ body.modern-ui.v2-canvas {
   .v2-root .v2-activity__compose button { width: 100%; }
   .v2-activity__section-heading > p { text-align: left; }
   .v2-activity__agent-grid { grid-template-columns: minmax(0, 1fr); }
-  .v2-activity__sectioned { grid-template-columns: minmax(0, 1fr); }
-  .v2-activity__view-switcher {
-    justify-content: flex-start;
-    margin-top: -22px;
-  }
 
   .v2-activity__queue-row { grid-template-columns: 28px minmax(0, 1fr); }
   .v2-activity__board-row { grid-template-columns: minmax(0, 1fr); }


### PR DESCRIPTION
## Summary
- put the Needs you queue before the compose card and split agent recaps from board changes into responsive evidence sections
- add a Timeline toggle that chronologically projects the same recap facts without a second feed or endpoint
- add English and Simplified Chinese copy plus Activity behavior and load-bearing CSS layout tests

## Verification
- `frontend: jest --runInBand src/i18n/__tests__/translationKeys.test.ts src/v2/__tests__/V2ActivityPage.test.tsx src/v2/__tests__/v2-layout-invariants.test.ts` (75 passing)
- `frontend: npx tsc --noEmit --pretty false`
- `frontend: npm run lint -- --quiet`
- Local browser shell check at 1280 and 390: no horizontal overflow. The local API was not available, so the populated-content real-account 1280/390 gate remains with @ux-lead.