### PR TITLE
feat(seo): add AI agent audit trail guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -19,7 +19,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 63);
+  assert.equal(pages.length, 64);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -84,6 +84,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-escalation/',
     '/guides/ai-agent-acceptance-criteria/',
     '/guides/ai-agent-decision-packet/',
+    '/guides/ai-agent-audit-trail/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
@@ -119,7 +120,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
   ]);
-  assert.equal(guidePages.length, 53);
+  assert.equal(guidePages.length, 54);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
@@ -478,6 +479,27 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/context-engineering-for-ai-agents/',
   ]) {
     assert.match(renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath)), /href="\/guides\/ai-agent-decision-packet\//);
+  }
+  const auditTrailGuide = guidePages.find((page) => page.path === '/guides/ai-agent-audit-trail/');
+  assert.equal(auditTrailGuide.title, 'AI Agent Audit Trail: Make Work and Decisions Inspectable | Commonly');
+  assert.deepEqual(guides['ai-agent-audit-trail'].sections.flatMap((section) => (section.tables || []).map((table) => [table.headers.length, table.rows.length])), [[3, 6], [3, 6], [3, 8], [3, 6], [3, 6], [3, 6], [3, 6], [3, 5], [3, 6]]);
+  assert.deepEqual(guides['ai-agent-audit-trail'].sections.filter((section) => section.orderedItems).map((section) => section.orderedItems.length), [7]);
+  assert.equal(guides['ai-agent-audit-trail'].sections.flatMap((section) => section.links || []).length, 10);
+  const auditTrailHtml = renderStaticPage(guideTemplate, auditTrailGuide);
+  assert.match(auditTrailHtml, /href="https:\/\/commonly\.me\/guides\/ai-agent-audit-trail\//);
+  assert.match(auditTrailHtml, /An AI agent audit trail is a structured, linked account of a piece of work/);
+  assert.match(auditTrailHtml, /Commonly \(commonly\.me\), the shared workspace where humans and AI agents work together/);
+  assert.doesNotMatch(auditTrailHtml, /seo-page-dark/);
+  assert.match(auditTrailHtml, /source-of-record/);
+  assert.doesNotMatch(auditTrailHtml, /cm_agent_[A-Za-z0-9]{8,}/);
+  assert.equal((auditTrailHtml.match(/<h2>Frequently asked questions<\/h2>/g) || []).length, 1);
+  for (const guidePath of [
+    '/guides/ai-agent-governance/',
+    '/guides/ai-agent-memory/',
+    '/guides/ai-agent-acceptance-criteria/',
+    '/guides/ai-agent-task-management/',
+  ]) {
+    assert.match(renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath)), /href="\/guides\/ai-agent-audit-trail\//);
   }
   for (const guidePath of [
     '/guides/what-is-an-ai-agent-runtime/',

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -581,7 +581,11 @@
       }
     ,
       { "label": "AI agents for software development", "path": "/guides/ai-agents-for-software-development/" },
-      { "label": "AI agent escalation", "path": "/guides/ai-agent-escalation/" }],
+      { "label": "AI agent escalation", "path": "/guides/ai-agent-escalation/" },
+      {
+        "label": "AI agent audit trail",
+        "path": "/guides/ai-agent-audit-trail/"
+      }],
     "cta": {
       "title": "Give every agent task a place to continue",
       "body": "Start with one real project: create a pod, connect the agent you already use, write a task with an outcome and review point, and return the result to the shared record. Commonly gives humans and agents a practical place to coordinate from there.",
@@ -997,7 +1001,8 @@
       { "label": "AI agent tools", "path": "/guides/ai-agent-tools/" },
       { "label": "Context engineering for AI agents", "path": "/guides/context-engineering-for-ai-agents/" },
       { "label": "Human-AI collaboration", "path": "/guides/human-ai-collaboration/" }
-    ],
+    ,
+      { "label": "AI agent audit trail", "path": "/guides/ai-agent-audit-trail/" }],
     "cta": {
       "title": "Make the next session start ahead",
       "body": "Good shared memory saves a team from re-explaining the project without giving agents a hidden, unreviewable authority source. Start with one pod, one concise project memory file, and one rule: every durable note must help the next person or agent make a better decision.",
@@ -6840,7 +6845,8 @@
       {"label": "AI Agent Task Management", "path": "/guides/ai-agent-task-management/"},
       {"label": "AI Agent Handoffs", "path": "/guides/ai-agent-handoffs/"},
       {"label": "How to Evaluate AI Agents", "path": "/guides/how-to-evaluate-ai-agents/"}
-    ],
+    ,
+      { "label": "AI agent audit trail", "path": "/guides/ai-agent-audit-trail/" }],
     "cta": {
       "title": "Make authority clear before agents need it",
       "body": "Good AI agent governance does not slow a team down with ceremony. It removes the ambiguity that produces duplicate work, unsafe shortcuts, and late surprises. Define a narrow role, give it the smallest justified capability set, name the decision owner at consequential boundaries, let technical systems enforce access, and leave a record the next reviewer can understand.\n\nStart with one workflow and one reviewable handoff. As the team sees real outcomes, strengthen the boundaries that failed, remove capabilities the role did not need, and keep the useful work moving without making the agent an unowned source of authority.",
@@ -8825,7 +8831,11 @@
         "label": "AI Agent Governance",
         "path": "/guides/ai-agent-governance/"
       }
-    ],
+    ,
+      {
+        "label": "AI agent audit trail",
+        "path": "/guides/ai-agent-audit-trail/"
+      }],
     "cta": {
       "title": "Evaluate the next decision, not the agent's performance theater",
       "body": "Good acceptance criteria make an agent's contribution easy to inspect and hard to overstate. They define the result a next owner needs, the evidence that supports it, the boundary that limits it, and the decision that follows. They also make stopping useful when the evidence, scope, or authority is not there.\n\nStart with one role and one handoff. Write the observable artifact, source and scope boundary, evidence, owner, and stop condition before the agent begins. Then test the real cases where the agent should clarify, block, escalate, or remain silent. That is how a team gets useful automation without making fluency look like acceptance.",
@@ -9530,6 +9540,707 @@
     "cta": {
       "title": "Make the decision easy, then keep the authority where it belongs",
       "body": "AI agents are most useful when they turn scattered context into a choice the right person can make with confidence. A clear decision packet names the question, owner, scope, facts, uncertainty, options, impact, and next action. It gives people the benefit of the agent's preparation without asking them to surrender judgment.\n\nStart with one recurring decision boundary in a real workflow. Require a small evidence packet and a named owner. Preserve the accepted answer where the next role can find it, keep enforcement in the systems that execute the action, and reward the agent for blocking or escalating honestly when the evidence or authority is not there.",
+      "primary": {
+        "label": "Create a shared workspace",
+        "path": "/v2/register"
+      },
+      "secondary": {
+        "label": "Explore Commonly’s guides",
+        "path": "/guides/"
+      }
+    }
+  },
+  "ai-agent-audit-trail": {
+    "eyebrow": "Guide",
+    "titleTag": "AI Agent Audit Trail: Make Work and Decisions Inspectable | Commonly",
+    "title": "AI Agent Audit Trail: Make Work and Decisions Inspectable",
+    "description": "Learn what an AI agent audit trail is, which records belong in it, and how to preserve evidence, ownership, and accepted decisions without confusing visibility with enforcement.",
+    "summary": "An AI agent audit trail is a structured, linked account of a piece of work: what outcome was requested, who owned each decision, what evidence informed it, what the agent did or proposed, what was reviewed, and what result was accepted.",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-09-02",
+      "dateModified": "2026-09-02"
+    },
+    "intro": [
+      "An AI agent audit trail is a structured, linked account of a piece of work: what outcome was requested, who owned each decision, what evidence informed it, what the agent did or proposed, what was reviewed, and what result was accepted. It lets a teammate reconstruct a bounded decision or handoff without treating a chat transcript, a task claim, or an agent statement as proof that a target system changed.",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, gives a team several useful records for that trail: task state and activity, focused message threads, attached artifacts, selected shared memory, and the people or agents participating in a pod. Those records make collaboration visible. They do not replace the repository's commit history, an identity system's permission record, a deployment platform's release history, or another target system's own authoritative log.",
+      "An audit trail is not a surveillance feed and it is not a claim that every interaction must be retained forever. Its job is narrower: preserve the evidence and decisions a later reviewer needs to understand why a bounded action happened, where its result belongs, and what still needs verification.",
+      "This guide explains what belongs in an AI agent audit trail, how to connect work records without duplicating everything, and how to make the trail useful at review time."
+    ],
+    "sections": [
+      {
+        "title": "An audit trail is an explanation of work, not a pile of messages",
+        "paragraphs": [
+          "A busy agent team can leave thousands of messages, repeated status notes, browser output, drafts, and task updates. Activity alone is not an audit trail. A usable trail tells a reviewer which records matter, how they relate, and which system can confirm the final effect."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Record",
+              "What it can establish",
+              "What it cannot establish by itself"
+            ],
+            "rows": [
+              [
+                "Task",
+                "The requested outcome, owner, state, dependency, and reported result",
+                "That an external change actually occurred or was authorized"
+              ],
+              [
+                "Focused thread",
+                "The reasoning, questions, review comments, and decision discussion",
+                "That every side conversation or execution event is captured"
+              ],
+              [
+                "Artifact",
+                "The exact draft, evidence packet, test result, or proposed change that was reviewed",
+                "That the artifact was applied in the target system"
+              ],
+              [
+                "Shared memory",
+                "A selected durable note, decision, or working context with provenance",
+                "A complete, unlimited history of every conversation or private file"
+              ],
+              [
+                "Target-system record",
+                "A commit, deployment entry, approval record, permission change, ticket, or other system-native fact",
+                "Why the team chose that action unless the collaboration records point to it"
+              ],
+              [
+                "Audit trail",
+                "The links among request, evidence, decision, action, and result",
+                "A new enforcement mechanism or substitute for the source system"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Treat the records as a linked explanation",
+        "paragraphs": [
+          "For example, a task may say that an agent prepared a proposed change, a thread may show a maintainer's review, and an attached test report may show the evidence considered. The repository or deployment system remains the place to confirm whether that change was merged or released. The trail should connect those facts rather than restating them as an unsupported conclusion.",
+          "For the work lifecycle that anchors this record, see AI Agent Task Management."
+        ],
+        "links": [
+          {
+            "label": "AI Agent Task Management",
+            "path": "/guides/ai-agent-task-management/"
+          }
+        ]
+      },
+      {
+        "title": "Begin with the question a future reviewer should be able to answer",
+        "paragraphs": [
+          "Designing an audit trail gets easier when the team starts with a bounded review question. \"What happened?\" is too broad. A stronger question ties a record to an outcome, owner, evidence, and external source of truth."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Review question",
+              "Records that should be linked",
+              "System that confirms the final state"
+            ],
+            "rows": [
+              [
+                "Why did this task move to done?",
+                "Task result, reviewed artifact, decision or completion note",
+                "The target system named in the result, when one exists"
+              ],
+              [
+                "Why was this recommendation accepted?",
+                "Evidence packet, decision owner, alternatives, accepted answer",
+                "The decision record and any system-native follow-on action"
+              ],
+              [
+                "Who approved the next step?",
+                "Focused thread or decision packet naming the owner and answer",
+                "The team’s designated approval or target-system record"
+              ],
+              [
+                "What did the agent receive and produce?",
+                "Task scope, safe inputs, attached output, review note",
+                "The output’s actual destination or source system"
+              ],
+              [
+                "Why did work stop or escalate?",
+                "Blocker, missing authority or evidence, escalation packet, next owner",
+                "The owner’s answer or the subsequently created work record"
+              ],
+              [
+                "Which version was reviewed?",
+                "Stable artifact reference, task update, review comment",
+                "The repository, document store, or other version-owning system"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Start with a bounded question",
+        "paragraphs": [
+          "If the team cannot name the question, the trail may be collecting detail without a reason to inspect it. Start smaller: identify the decision, result, incident, or handoff that needs reconstruction, then keep only the evidence that supports it.",
+          "For a collaboration surface that keeps the question and reviewer visible, see Human–AI Collaboration."
+        ],
+        "links": [
+          {
+            "label": "Human–AI Collaboration",
+            "path": "/guides/human-ai-collaboration/"
+          }
+        ]
+      },
+      {
+        "title": "Link the minimum records that explain the work",
+        "paragraphs": [
+          "An audit trail does not need a duplicate of every record in every place. It needs a reliable path from the task to the evidence, review, answer, and final source of record. The exact shape varies by work, but the components below cover most bounded agent tasks."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Trail component",
+              "Useful content",
+              "Good linking practice"
+            ],
+            "rows": [
+              [
+                "Outcome and scope",
+                "Requested result, non-goals, constraints, dependency, and owner",
+                "Start from one task or other durable work record"
+              ],
+              [
+                "Inputs and evidence",
+                "Sources, provided files, observed facts, checks, and uncertainty",
+                "Link to the specific evidence rather than paraphrasing a long transcript"
+              ],
+              [
+                "Agent contribution",
+                "Draft, analysis, triage result, proposed change, or no-op conclusion",
+                "State what was prepared or observed, not what is assumed to have executed"
+              ],
+              [
+                "Review boundary",
+                "Who must inspect, approve, narrow, or route the work",
+                "Name the role and the question rather than an ambient audience"
+              ],
+              [
+                "Decision",
+                "Accepted option, rejected option, deferral, or escalation",
+                "Record the answer with enough context to interpret it later"
+              ],
+              [
+                "Handoff",
+                "Next owner, expected artifact, and conditions for completion",
+                "Make the receiving responsibility explicit"
+              ],
+              [
+                "Result reference",
+                "PR, document version, ticket, deployment, or other external outcome",
+                "Point to the system that owns the result instead of copying its status"
+              ],
+              [
+                "Open issue",
+                "Missing evidence, conflicting source, failed check, or unsupported claim",
+                "Keep it visible until it is resolved, rerouted, or deliberately accepted"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Keep the trail proportionate",
+        "paragraphs": [
+          "The trail is strongest when every component is proportionate. A small editorial clarification might connect a task, two source links, a reviewer answer, and the final document. A sensitive access or release decision needs a more careful evidence set, appropriate reviewers, and a direct link to the system that enforces the outcome.",
+          "For a handoff that makes the next owner and expected result explicit, see AI Agent Handoffs."
+        ],
+        "links": [
+          {
+            "label": "AI Agent Handoffs",
+            "path": "/guides/ai-agent-handoffs/"
+          }
+        ]
+      },
+      {
+        "title": "Label evidence so a reader can see what is known and what is proposed",
+        "paragraphs": [
+          "An audit trail becomes misleading when a fluent summary collapses a source, an interpretation, and a recommendation into one apparent fact. Use simple labels so a reviewer can tell why an entry is present and how much weight it can carry."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Label",
+              "Meaning",
+              "Example use in a trail"
+            ],
+            "rows": [
+              [
+                "Verified fact",
+                "A checkable observation linked to a source or system record",
+                "\"The task has an unresolved dependency\" with the task reference"
+              ],
+              [
+                "Reported status",
+                "A person or agent stated something, but the source system has not been checked",
+                "\"The agent reports tests passed\" pending the test result or CI record"
+              ],
+              [
+                "Inference",
+                "A reasoned interpretation of the available evidence",
+                "\"This change may affect the documented workflow\""
+              ],
+              [
+                "Recommendation",
+                "A proposed course of action, clearly separated from the decision",
+                "\"Recommend routing this to the policy owner\""
+              ],
+              [
+                "Open question",
+                "Missing information that prevents a bounded conclusion",
+                "\"Which source governs the conflicting requirement?\""
+              ],
+              [
+                "Accepted decision",
+                "The answer made by the named decision owner",
+                "\"Keep scope unchanged and create a separate task\""
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Make evidence strength visible",
+        "paragraphs": [
+          "Labels do not make weak evidence strong. They make the strength and role of an entry visible, so the reviewer can inspect the right source or ask for more before relying on it.",
+          "For source-bound research and explicit evidence labels, see AI Agents for Research."
+        ],
+        "links": [
+          {
+            "label": "AI Agents for Research",
+            "path": "/guides/ai-agents-for-research/"
+          }
+        ]
+      },
+      {
+        "title": "Keep collaboration records separate from enforcement records",
+        "paragraphs": [
+          "This is the most important boundary in an AI agent audit trail. A pod can show that an agent was assigned a task, a reviewer commented, or a decision was recorded. That does not give the pod the power to merge code, publish content, grant an entitlement, or change a production service. The system that performs and enforces an action remains authoritative for that action."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Question",
+              "Collaboration record can show",
+              "Authoritative record should come from"
+            ],
+            "rows": [
+              [
+                "Who was asked to review?",
+                "Task owner, thread mention, or named decision owner",
+                "The team process or system that governs approval"
+              ],
+              [
+                "Was a recommendation accepted?",
+                "Recorded answer and the evidence considered",
+                "The designated decision record, plus any applied result"
+              ],
+              [
+                "Did code change?",
+                "A linked draft, review discussion, or pull-request reference",
+                "The repository’s commit and merge history"
+              ],
+              [
+                "Did a release occur?",
+                "Preparation work and a release decision",
+                "The deployment or release system"
+              ],
+              [
+                "Was access granted or revoked?",
+                "A request and review boundary",
+                "The identity or permission system"
+              ],
+              [
+                "Was customer content sent?",
+                "A prepared response and review note",
+                "The support, messaging, or other delivery system"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Use collaboration records for coordination",
+        "paragraphs": [
+          "Treat the collaboration trail as evidence of coordination and reasoning. Treat the target system as evidence of execution and current state. Connecting them gives a reviewer a fuller account without inventing authority where none exists.",
+          "For an operating model that distinguishes visibility, responsibility, and real control, see AI Agent Governance."
+        ],
+        "links": [
+          {
+            "label": "AI Agent Governance",
+            "path": "/guides/ai-agent-governance/"
+          }
+        ]
+      },
+      {
+        "title": "Preserve durable context deliberately",
+        "paragraphs": [
+          "Not every useful record should become shared memory, and shared memory should not be treated as a complete archive. Durable context is for selected facts, decisions, and working knowledge that will help the next participant act safely. It should retain source context and avoid carrying private credentials, incidental conversation, or material with no ongoing purpose."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Information",
+              "Where it often belongs",
+              "Why"
+            ],
+            "rows": [
+              [
+                "Current task state and completion result",
+                "Task record",
+                "It follows the work lifecycle and identifies ownership"
+              ],
+              [
+                "Narrow decision discussion",
+                "Focused thread",
+                "It preserves the questions and responses around one topic"
+              ],
+              [
+                "Substantial evidence or exact output",
+                "Attachment or the target system’s versioned artifact",
+                "It keeps the reviewed material identifiable"
+              ],
+              [
+                "Reusable, selected conclusion",
+                "Shared memory with provenance",
+                "It gives future participants durable context without replaying the entire thread"
+              ],
+              [
+                "Personal preference or credential",
+                "Agent-private storage or the appropriate identity system",
+                "It is not automatically team-wide audit material"
+              ],
+              [
+                "External execution state",
+                "The repository, deployment, ticketing, identity, or delivery system",
+                "That system owns its facts and current state"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Preserve conclusions with their supporting record",
+        "paragraphs": [
+          "When a conclusion is important enough to preserve, write it as a concise, sourced statement: what was decided, by whom or under what role, when it applies, and where the supporting record lives. Do not turn memory into an unbounded transcript.",
+          "For the distinction between pod-shared and agent-private context, see AI Agent Memory."
+        ],
+        "links": [
+          {
+            "label": "AI Agent Memory",
+            "path": "/guides/ai-agent-memory/"
+          }
+        ]
+      },
+      {
+        "title": "Build a trail as work moves, not after details disappear",
+        "paragraphs": [
+          "Reconstructing a trail at the end of a project invites guesswork. The team does not need a ceremonial update for every message, but it should add links and labels at meaningful boundaries: when scope is accepted, evidence changes, a reviewer decides, work is handed off, or a result is completed."
+        ],
+        "orderedItems": [
+          "Create or identify the durable task or work record with outcome, scope, and owner.",
+          "Link the evidence that materially informs the next decision; note conflicts and missing checks.",
+          "Store the agent’s bounded artifact or proposal where a reviewer can inspect the exact version.",
+          "Name the review boundary and the person or role that can answer the decision question.",
+          "Record the accepted answer, rejection, deferral, or escalation with its next owner.",
+          "Link the result in the target system once it exists, without replacing that system’s own record.",
+          "Preserve only the reusable conclusion and source reference needed for future work."
+        ]
+      },
+      {
+        "title": "Preserve traceability at meaningful boundaries",
+        "paragraphs": [
+          "This sequence produces enough traceability for review while preserving the difference between preparatory work and completed external action.",
+          "For routing a missing decision or unsafe next step rather than guessing, see AI Agent Escalation."
+        ],
+        "links": [
+          {
+            "label": "AI Agent Escalation",
+            "path": "/guides/ai-agent-escalation/"
+          }
+        ]
+      },
+      {
+        "title": "Use the trail to review a handoff, not merely to assign blame",
+        "paragraphs": [
+          "The best audit trails help a team improve the work before an error becomes costly. A reviewer can inspect a handoff for missing evidence, unclear ownership, scope creep, an unsupported recommendation, or a claimed result with no source-of-record link. That makes the trail part of quality control, not just a retrospective artifact."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Review point",
+              "Useful question",
+              "Evidence to inspect"
+            ],
+            "rows": [
+              [
+                "Scope",
+                "Is the proposed work inside the approved outcome and non-goals?",
+                "Task description, dependency, and decision note"
+              ],
+              [
+                "Evidence",
+                "Can the key factual claims be traced to a source?",
+                "Attached evidence, source links, test output, or target-system record"
+              ],
+              [
+                "Authority",
+                "Does the named reviewer actually own this decision?",
+                "Role contract, team process, or designated system owner"
+              ],
+              [
+                "Safety",
+                "Is untrusted content treated as data rather than instructions?",
+                "Input description, constraints, and the agent’s stated boundary"
+              ],
+              [
+                "Result",
+                "Is the claimed completion linked to the system that owns it?",
+                "PR, document, ticket, deployment, or other target-system record"
+              ],
+              [
+                "Continuity",
+                "Can the next owner understand what remains open?",
+                "Decision, open questions, handoff, and selected durable context"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Review work across roles",
+        "paragraphs": [
+          "This is especially useful when a task crosses roles. A research agent can prepare source-linked findings, a project-management role can maintain the coordination record, and a human owner can decide the next action. The audit trail makes the seams reviewable without pretending the roles have the same authority.",
+          "For role-specific boundaries and reviewable outputs, see AI Agent Roles."
+        ],
+        "links": [
+          {
+            "label": "AI Agent Roles",
+            "path": "/guides/ai-agent-roles/"
+          }
+        ]
+      },
+      {
+        "title": "Protect the trail from untrusted instructions and accidental overcollection",
+        "paragraphs": [
+          "An audit trail should explain what happened without creating a new route for untrusted text to control the work. Content from a ticket, customer message, uploaded file, web page, or pull-request discussion can be evidence. It is not automatically an instruction to the agent or the decision owner. Record relevant content with its source and treat it according to the task’s permitted operations."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Risk",
+              "Safer trail practice",
+              "What to avoid"
+            ],
+            "rows": [
+              [
+                "Hostile instruction in an input",
+                "Label the source, preserve only relevant evidence, and route unsafe requests for review",
+                "Copying the instruction into a task as if it were an authorized command"
+              ],
+              [
+                "Sensitive or unnecessary data",
+                "Keep the record focused on the decision and use the appropriate restricted system for sensitive material",
+                "Turning every message or private datum into shared memory"
+              ],
+              [
+                "Ambiguous ownership",
+                "Record the missing owner and escalate the decision",
+                "Letting the most active agent or commenter silently become approver"
+              ],
+              [
+                "Unverified completion",
+                "Link the target-system record or leave the result pending verification",
+                "Reporting a draft, green check, or message as a completed external action"
+              ],
+              [
+                "Conflicting evidence",
+                "State the conflict and its effect on the decision",
+                "Selecting the most convenient source without recording the uncertainty"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Keep trail records resistant to untrusted instructions",
+        "paragraphs": [
+          "The same clarity that helps a reviewer trace a decision also helps the team notice when the work should stop, narrow, or escalate.",
+          "For techniques that keep untrusted content from becoming an instruction, see Prompt Injection Defense for AI Agents."
+        ],
+        "links": [
+          {
+            "label": "Prompt Injection Defense for AI Agents",
+            "path": "/guides/prompt-injection-defense-for-ai-agents/"
+          }
+        ]
+      },
+      {
+        "title": "Test whether the trail is actually useful",
+        "paragraphs": [
+          "Before treating a trail as complete, give a teammate who did not perform the work a small review task. If they cannot answer the core questions without reading every message, the trail needs better links or a more precise conclusion.",
+          "For turning quality expectations into reviewable conditions, see AI Agent Acceptance Criteria."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Test",
+              "A useful trail lets a reviewer answer",
+              "If the answer is missing"
+            ],
+            "rows": [
+              [
+                "Outcome test",
+                "What result was requested and what was out of scope?",
+                "Add or correct the work record"
+              ],
+              [
+                "Ownership test",
+                "Who could decide, review, or perform the next action?",
+                "Name the accountable role and route ambiguity"
+              ],
+              [
+                "Evidence test",
+                "Which facts are verified, inferred, or unresolved?",
+                "Link sources and label the uncertainty"
+              ],
+              [
+                "Version test",
+                "Which exact artifact or proposal was reviewed?",
+                "Add a stable artifact or target-system reference"
+              ],
+              [
+                "Authority test",
+                "Which system confirms the claimed execution?",
+                "Replace assertions with the source-of-record link"
+              ],
+              [
+                "Continuity test",
+                "What remains open, and who owns it now?",
+                "Create a bounded handoff or escalation"
+              ]
+            ]
+          }
+        ],
+        "links": [
+          {
+            "label": "AI Agent Acceptance Criteria",
+            "path": "/guides/ai-agent-acceptance-criteria/"
+          }
+        ]
+      },
+      {
+        "title": "Seven audit-trail mistakes that make agent work harder to review"
+      },
+      {
+        "title": "Treating a task claim as proof of authority",
+        "paragraphs": [
+          "Claiming work coordinates ownership; it does not grant permission to approve, merge, publish, or change another system. Name the real decision owner and source of control."
+        ]
+      },
+      {
+        "title": "Using a chat transcript as the only record",
+        "paragraphs": [
+          "Conversation can contain valuable reasoning, but a reviewer should not have to infer outcome, evidence, and next owner from dozens of messages. Link the decisive records and write the accepted conclusion."
+        ]
+      },
+      {
+        "title": "Recording conclusions without their evidence",
+        "paragraphs": [
+          "\"The agent found this\" is not enough for consequential work. Preserve the relevant source, check, artifact, or uncertainty so a reviewer can assess the claim."
+        ]
+      },
+      {
+        "title": "Calling a proposed artifact a completed external action",
+        "paragraphs": [
+          "A draft, pull-request comment, or test summary may be useful evidence. It is not proof of a merge, deployment, access change, or sent message. Link the target system or say the state is unverified."
+        ]
+      },
+      {
+        "title": "Copying everything into shared memory",
+        "paragraphs": [
+          "Shared memory is for selected durable context, not a complete archive. Retain the conclusion and its source; keep large evidence or private material in the appropriate place."
+        ]
+      },
+      {
+        "title": "Hiding open questions behind a confident recommendation",
+        "paragraphs": [
+          "An agent can recommend a path while stating the missing evidence, conflict, or assumption that limits it. A trail is more trustworthy when it makes uncertainty inspectable."
+        ]
+      },
+      {
+        "title": "Collecting sensitive or irrelevant details by default",
+        "paragraphs": [
+          "The trail should be proportionate to the decision. Capture the record needed for review and use restricted systems for information that does not belong in a shared collaboration artifact."
+        ]
+      }
+    ],
+    "faq": [
+      {
+        "question": "Is an AI agent audit trail the same as an activity log?",
+        "answer": "No. An activity log can list events. An audit trail selects and links the records needed to reconstruct a specific outcome, decision, handoff, or result."
+      },
+      {
+        "question": "Does a pod record prove that an agent completed an external action?",
+        "answer": "No. It can show the agent’s report, artifact, or coordination history. The repository, deployment platform, identity system, or other target system should confirm the external action."
+      },
+      {
+        "question": "What is the smallest useful audit trail?",
+        "answer": "For a low-risk task, it may be a task with clear scope, a linked artifact or source, a reviewer answer, and a result reference. Add detail only as the decision’s impact, uncertainty, or sensitivity requires."
+      },
+      {
+        "question": "Should every agent message be retained as audit evidence?",
+        "answer": "No. Keep the evidence and decisions that support review. A complete message archive can obscure the important record and may include information that should not be broadly retained."
+      },
+      {
+        "question": "Who owns an audit trail?",
+        "answer": "The person or role responsible for the work should maintain its coordination record, while each target system owns its own execution facts. Reviewers should be named at meaningful decision boundaries."
+      },
+      {
+        "question": "Can an audit trail enforce permissions or prevent unsafe actions?",
+        "answer": "No. It can make a request, decision, or exception visible. Permission enforcement and action controls belong in the systems that grant access or execute the action."
+      }
+    ],
+    "relatedLinks": [
+      {
+        "label": "AI Agent Governance",
+        "path": "/guides/ai-agent-governance/"
+      },
+      {
+        "label": "AI Agent Task Management",
+        "path": "/guides/ai-agent-task-management/"
+      },
+      {
+        "label": "AI Agent Handoffs",
+        "path": "/guides/ai-agent-handoffs/"
+      },
+      {
+        "label": "AI Agent Memory",
+        "path": "/guides/ai-agent-memory/"
+      },
+      {
+        "label": "AI Agent Escalation",
+        "path": "/guides/ai-agent-escalation/"
+      },
+      {
+        "label": "AI Agent Acceptance Criteria",
+        "path": "/guides/ai-agent-acceptance-criteria/"
+      },
+      {
+        "label": "AI Agent Roles",
+        "path": "/guides/ai-agent-roles/"
+      }
+    ],
+    "cta": {
+      "title": "Make the answer easy to inspect",
+      "body": "An AI agent audit trail earns its keep when a new reviewer can trace a bounded result from requested outcome to evidence, decision, handoff, and authoritative system record. It should make collaboration legible without mistaking coordination for control. Build the trail at the moments that change work, keep uncertainty explicit, and leave each external system responsible for proving its own state.",
       "primary": {
         "label": "Create a shared workspace",
         "path": "/v2/register"

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -471,6 +471,12 @@ describe('V2 routing', () => {
     expect(screen.getAllByText(/answerable choice/).length).toBeGreaterThan(0);
   });
 
+  test('AI agent audit-trail guide renders its linked account after the app takes over', async () => {
+    renderAt('/guides/ai-agent-audit-trail/');
+    expect(await screen.findByRole('heading', { level: 1, name: 'AI Agent Audit Trail: Make Work and Decisions Inspectable' })).toBeInTheDocument();
+    expect(screen.getAllByText(/structured, linked account/).length).toBeGreaterThan(0);
+  });
+
   test('guides index renders after the app takes over', async () => {
     renderAt('/guides/');
 
@@ -478,7 +484,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(53);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(54);
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Connect Claude Code and Codex to a Shared Workspace',


### PR DESCRIPTION
## Summary
- adds the crawlable AI Agent Audit Trail guide at `/guides/ai-agent-audit-trail/`
- preserves all approved source copy and adds the corrected `prompt-injection-defense-for-ai-agents` body link
- adds the four specified reciprocal related links and static/client coverage

## Structural notes
- 9 three-column tables and the 7-step trail sequence use `orderedItems`
- eight post-table prose blocks are rendered as follow-on H2s; the acceptance-criteria pointer remains before its table as specified

## Validation
- `node --test scripts/generate-seo-pages.test.mjs`
- `npx jest --watchAll=false --forceExit src/v2/__tests__/V2Login.test.tsx`
- `npm run typecheck`
- `npm run build`
- static output, reciprocal coverage, and verbatim source preservation checks