### PR TITLE
fix(activity): blocked board rows are decisions, not presses

### DIFF
--- a/backend/__tests__/unit/services/activityService.decisionQueue.test.js
+++ b/backend/__tests__/unit/services/activityService.decisionQueue.test.js
@@ -77,7 +77,7 @@ describe('ActivityService.getDecisionQueue', () => {
     expect(result.items.find((item) => item.taskId === 'TASK-024')).toBeUndefined();
   });
 
-  test('keeps ordinary blocked and press board rows as open-board items', async () => {
+  test('a blocked row is a standing decision, a human handoff is a press — both open-board items', async () => {
     Task.find.mockReturnValue(taskChain([
       {
         taskId: 'TASK-016', podId: 'pod-1', status: 'blocked', title: 'Fix release gate',
@@ -90,7 +90,7 @@ describe('ActivityService.getDecisionQueue', () => {
     ]));
     const result = await ActivityService.getDecisionQueue('u1');
     expect(result.items.map((item) => [item.taskId, item.kind])).toEqual([
-      ['TASK-016', 'press'], ['TASK-059', 'press'],
+      ['TASK-016', 'decision'], ['TASK-059', 'press'],
     ]);
   });
 

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -635,7 +635,12 @@ class ActivityService {
         const isHandoff = !!(last && HANDOFF_RE.test(String(last.text || '')));
         if (!isBlocked && !isHandoff) continue;
         items.push({
-          kind: 'press',
+          // A blocked row is a standing DECISION (no options — the fork owner
+          // should convert it to a DecisionRequest); only an explicit human
+          // handoff in the latest update is a PRESS. #1470 collapsed both to
+          // 'press', which put "ADR-024 D3: batch the poller tick" under
+          // "Ready for your press" — a mislabel Sam noticed the same morning.
+          kind: isHandoff ? 'press' : 'decision',
           id: `task_${t.taskId}`,
           title,
           detail: last ? String(last.text || '').slice(0, 160) : undefined,


### PR DESCRIPTION
#1470 collapsed blocked rows and explicit human handoffs into 'press'; four ADR-024 blocked rows rendered under 'Ready for your press'. Blocked → decision (no options — the fork owner converts it to a DecisionRequest), handoff → press. Test expectation aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmApTnNd9VZRTE2Fi1gM6z