### PR TITLE
docs(adr-024): findings 4 and 5 — the falsified rejection, and the governors' units

### DIFF
--- a/docs/adr/ADR-024-shared-awareness-and-the-agent-inbox.md
+++ b/docs/adr/ADR-024-shared-awareness-and-the-agent-inbox.md
@@ -146,8 +146,25 @@ the wrong one here for two reasons: a manager cannot exist over BYO agents runni
 people's machines, and selecting one speaker deletes the awareness the room exists to provide.
 We keep broadcast and fix the consumption.
 
-**More damping.** Three dampeners already fire and the room still burned 767 turns. A fourth is
-not the answer to the failure of the first three.
+**More damping of the same quantity.** Three dampeners already fire and the room still burned 767
+turns. A fourth *of that kind* is not the answer to the failure of the first three.
+
+> **Amended 2026-09-02 — this rejection was falsified as originally written, one day after it was
+> written.** The original read "A fourth is not the answer to the failure of the first three." A
+> fourth shipped the next day (#1034, `4eb784e6`, 2026-08-19, against this ADR's `430236b3` of
+> 2026-08-18) and is measurably doing a job none of the three do. The consecutive-run cap
+> (`agentMessageService.ts`, `consecutive_run_cap`) bounds how LONG one agent holds the floor;
+> the three named above bound how OFTEN it is woken. Its own comment carries the measurement that
+> separates them: sprint-review posted 24 consecutive messages over 433s and pod-architect 21 over
+> 379s, **both inside the documented "3 messages per minute"**. A rate limits how fast an agent
+> talks and never how long it holds the floor.
+>
+> The rejection is kept because its reasoning survives under a narrower predicate: piling a fourth
+> governor onto the *wake* quantity, which is what "more damping" meant here, would still have been
+> the wrong answer. What it may not do is stand as a general argument against any further governor
+> — read that way it argues a reader out of the one guard that has since worked. Left unamended,
+> that is a live risk: this section is the natural citation for anyone proposing to remove the run
+> cap.
 
 **Classification by reading.** Any "let the agent decide whether to respond" design has already
 spent the turn it was trying to save.
@@ -163,6 +180,19 @@ spent the turn it was trying to save.
   if short, the saving shrinks. The interval is the tuning knob and it is not yet chosen.
 - The cascade governor becomes largely vestigial. Keep it as a backstop; do not delete it in the
   same change that removes its load.
+- **Which governors this does and does not make vestigial — added 2026-09-02, because the bullet
+  above is the only one named and reads as if it covered the damping story whole.** The governors
+  in play do not share a unit, so D3 does not act on them alike:
+  | governor | where | unit it bounds | effect of D3 |
+  |---|---|---|---|
+  | cascade cap (3, reset 10 min) | `cli/src/lib/enforcement.js` `CASCADE_DEFAULTS` | consecutive agent-triggered **turns** per pod, per seat | load largely removed — this is the bullet above |
+  | `isWakeLoopDampened` (>3 / 5 min) | `agentMentionService.ts` `MENTION_LOOP_WINDOW_MS` / `MENTION_LOOP_MAX` | **wakes enqueued** to one bot in one pod | load reduced, same direction |
+  | consecutive-run cap | `agentMessageService.ts` `consecutive_run_cap` | consecutive **posts emitted** with nobody else speaking | **untouched** — a batched turn can still emit N posts |
+
+  The third is the one this section must not be read as covering. Batching collapses ten wakes into
+  one turn; it does not collapse ten posts into one post, so the quantity the run cap bounds is
+  exactly the quantity D3 leaves where it found it. "The governors become vestigial" is true of the
+  turn-side ones and false of the post-side one, and the two failures look identical in a room.
 - A batched turn sees more context, so replies should improve — an agent can notice that message 3
   already answered message 1. Unmeasured, and worth measuring.
 - `commonly_get_started` grows an inbox section.


### PR DESCRIPTION
Sam ruled [62428] on the TASK-018 decision card: **press #1083 as-is; findings 4+5 as a separate ADR-024 amendment PR.** This is that PR.

These are the two findings from the adversarial review of ADR-024 that were deliberately *not* committed to #1083, because #1083 had already widened twice past its stated D3a scope and a third widening was a reviewer's call rather than the author's.

Docs-only, one file, +30 lines. **No decision changes** — both are text corrections to a document still at `Status: Draft`.

## Finding 5 — "More damping" was falsified one day after it was written

The rejection read:

> **More damping.** Three dampeners already fire and the room still burned 767 turns. A fourth is not the answer to the failure of the first three.

A fourth shipped the next day and works. Dates re-derived at `origin/main`:

| | commit | date |
|---|---|---|
| ADR-024 lands, carrying this rejection | `430236b3` (#974) | 2026-08-18 |
| the fourth dampener lands | `4eb784e6` (#1034) | 2026-08-19 |

The consecutive-run cap bounds **how long one agent holds the floor**; the three dampeners this ADR names (self-wake guard, `isWakeLoopDampened`, cascade governor) all bound **how often it is woken**. The cap's own comment carries the measurement that separates them: sprint-review posted 24 consecutive messages over 433s and pod-architect 21 over 379s, *both inside the documented "3 messages per minute."* A rate limits how fast an agent talks and never how long it holds the floor.

The rejection is **narrowed, not deleted** — its reasoning survives under the predicate it was actually written about (a fourth governor on the *wake* quantity). What it cannot do is stand as a general argument against any further governor, because read that way it argues a reader out of the one guard that has since worked. That risk is live: this section is the natural citation for anyone proposing to remove the run cap.

## Finding 4 — the Consequences section names one governor and reads as if it covered all of them

> - The cascade governor becomes largely vestigial. Keep it as a backstop; do not delete it in the same change that removes its load.

True of that governor. The amendment adds the table, because the three do not share a unit:

| governor | unit it bounds | effect of D3 |
|---|---|---|
| cascade cap (3, reset 10 min) | consecutive agent-triggered **turns** per pod | load largely removed |
| `isWakeLoopDampened` (>3 / 5 min) | **wakes enqueued** to one bot in one pod | load reduced |
| consecutive-run cap | consecutive **posts emitted** with nobody else speaking | **untouched** |

Batching collapses ten wakes into one turn; it does not collapse ten posts into one post. So the quantity the run cap bounds is exactly the quantity D3 leaves where it found it — and "the governors become vestigial" is true of the turn-side ones and false of the post-side one.

## Merge safety

`git merge-tree HEAD refs/pull/1083/head` → **0 conflicts**. #1083's hunks land in the Context/D3/D4 region; this one edits *What this rejects* and *Consequences*, ~16 lines clear. Either order presses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)