### PR TITLE
fix: make LLM fallbacks fail closed

### DIFF
--- a/backend/__tests__/service/summaries.test.js
+++ b/backend/__tests__/service/summaries.test.js
@@ -275,21 +275,18 @@ describe('Summaries Routes Integration Tests', () => {
   });
 
   describe('GET /api/summaries/all-posts', () => {
-    test('should get all posts summary', async () => {
+    test('fails closed with 503 when no LLM can generate the summary', async () => {
+      // No LLM is reachable in tests. The old behaviour fabricated a
+      // "Community Overview" filler summary here; fail-closed means the route
+      // reports unavailability and never invents content.
       const response = await request(app)
         .get('/api/summaries/all-posts')
         .set('Authorization', `Bearer ${authToken}`);
 
-      expect(response.status).toBe(200);
-      expect(response.body).toHaveProperty('title');
-      expect(response.body.title).toContain('Community Overview');
-      expect(response.body.title).toContain('3 recent posts'); // We created 3 test posts
-      expect(response.body).toHaveProperty('content');
-      expect(response.body.metadata.totalItems).toBe(3);
-      // Since Gemini API is not available in tests, the fallback won't have tags
-      expect(response.body.metadata).toHaveProperty('topTags');
-      expect(response.body.metadata).toHaveProperty('topUsers');
-      expect(response.body.metadata.timeRange).toBe('Recent posts');
+      expect(response.status).toBe(503);
+      expect(response.body).toEqual({ error: 'summary_unavailable' });
+      expect(response.body).not.toHaveProperty('title');
+      expect(response.body).not.toHaveProperty('content');
     });
   });
 

--- a/backend/__tests__/unit/routes/admin.globalIntegrations.test.js
+++ b/backend/__tests__/unit/routes/admin.globalIntegrations.test.js
@@ -25,6 +25,7 @@ jest.mock('../../../services/socialPolicyService', () => ({
 }));
 jest.mock('../../../services/globalModelConfigService', () => ({
   getConfig: jest.fn(),
+  isSupportedLlmServiceProvider: jest.fn(),
   setConfig: jest.fn(),
 }));
 jest.mock('../../../services/externalFeedService', () => ({
@@ -73,6 +74,7 @@ describe('admin global integrations route', () => {
         fallbackModels: ['google/gemini-2.5-flash-lite', 'google/gemini-2.0-flash'],
       },
     });
+    GlobalModelConfigService.isSupportedLlmServiceProvider.mockReturnValue(true);
   });
 
   it('uses follows.read in default OAuth scopes for X OAuth start', async () => {
@@ -304,6 +306,24 @@ describe('admin global integrations route', () => {
           fallbackModels: ['google/gemini-2.5-flash-lite'],
         },
       },
+    });
+  });
+
+  it('rejects a backend provider that the LLM service cannot execute', async () => {
+    const handler = getRouteHandler('/model-policy', 'post');
+    const req = {
+      userId: 'admin-1',
+      body: { llmService: { provider: 'anthropic' } },
+    };
+    const res = createRes();
+    GlobalModelConfigService.isSupportedLlmServiceProvider.mockReturnValueOnce(false);
+
+    await handler(req, res);
+
+    expect(GlobalModelConfigService.setConfig).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Unsupported backend LLM provider. Use auto, gemini, litellm, or openrouter.',
     });
   });
 });

--- a/backend/__tests__/unit/routes/registry.persona.test.js
+++ b/backend/__tests__/unit/routes/registry.persona.test.js
@@ -79,4 +79,33 @@ describe('registry persona generator', () => {
     expect(res.body.persona.specialties).toEqual(['analysis', 'summaries']);
     expect(res.body.exampleInstructions).toContain('Start with a quick summary');
   });
+
+  it('returns a service error instead of inventing a persona when generation fails', async () => {
+    Pod.findById.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({
+        _id: 'pod-1',
+        createdBy: 'user-1',
+        members: ['user-1'],
+      }),
+    });
+    AgentInstallation.findOne.mockResolvedValue({
+      agentName: 'openclaw',
+      podId: 'pod-1',
+      instanceId: 'default',
+      displayName: 'Cuz',
+    });
+    AgentProfile.findOne.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({ name: 'Cuz', purpose: 'Helpful teammate' }),
+    });
+    generateText.mockRejectedValueOnce(new Error('LLM unavailable'));
+
+    const res = await request(app)
+      .post('/api/registry/pods/pod-1/agents/openclaw/persona/generate')
+      .send({ instanceId: 'default' });
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({
+      error: 'Persona generation is temporarily unavailable. Please try again.',
+    });
+  });
 });

--- a/backend/__tests__/unit/services/discordCommandService.test.js
+++ b/backend/__tests__/unit/services/discordCommandService.test.js
@@ -6,6 +6,7 @@ jest.mock('../../../services/summarizerService');
 
 const Integration = require('../../../models/Integration');
 const DiscordCommandService = require('../../../services/discordCommandService');
+const summarizerService = require('../../../services/summarizerService');
 
 describe('DiscordCommandService', () => {
   beforeEach(() => {
@@ -92,5 +93,22 @@ describe('DiscordCommandService', () => {
         }),
       );
     });
+  });
+
+  it('reports an unavailable AI summary instead of fabricating a Discord recap', async () => {
+    const service = new DiscordCommandService({});
+    summarizerService.generateSummary.mockRejectedValueOnce(new Error('LLM unavailable'));
+
+    const summary = await service.createDiscordSummary(
+      [
+        { author: 'lily', content: 'A real discussion happened.' },
+        { author: 'kai', content: 'Here is a second real message.' },
+        { author: 'juno', content: 'A third message makes this a summary request.' },
+      ],
+      new Date('2026-09-02T00:00:00Z'),
+      new Date('2026-09-02T01:00:00Z'),
+    );
+
+    expect(summary.content).toBe('⚠️ AI summary is temporarily unavailable. Please try again shortly.');
   });
 });

--- a/backend/__tests__/unit/services/globalModelConfigService.test.js
+++ b/backend/__tests__/unit/services/globalModelConfigService.test.js
@@ -103,4 +103,13 @@ describe('globalModelConfigService', () => {
     const updateArg = SystemSetting.findOneAndUpdate.mock.calls[0][1];
     expect(updateArg.$set.value.openclaw.model).toBe('openrouter/arcee-ai/trinity-large-preview:free');
   });
+
+  it('rejects an unsupported backend LLM provider instead of silently routing it to Gemini', async () => {
+    await expect(GlobalModelConfigService.setConfig({
+      llmService: { provider: 'openai' },
+    }, 'u1')).rejects.toThrow('Unsupported backend LLM provider');
+
+    expect(SystemSetting.findOne).not.toHaveBeenCalled();
+    expect(SystemSetting.findOneAndUpdate).not.toHaveBeenCalled();
+  });
 });

--- a/backend/__tests__/unit/services/llmFallbacks.failClosed.test.ts
+++ b/backend/__tests__/unit/services/llmFallbacks.failClosed.test.ts
@@ -1,0 +1,70 @@
+// @ts-nocheck
+// LLM outages must be visible to callers. These services used to return generic prose
+// that looked generated even though the LLM request had failed.
+
+jest.mock('../../../models/Summary', () => ({}));
+jest.mock('../../../models/Post', () => ({ find: jest.fn() }));
+jest.mock('../../../config/db-pg', () => ({ pool: { query: jest.fn() } }));
+jest.mock('../../../models/Pod', () => ({}));
+jest.mock('../../../services/podAssetService', () => ({}));
+jest.mock('../../../models/User', () => ({}));
+jest.mock('../../../services/digestTemplateService', () => ({
+  createDigestPrompt: jest.fn(() => 'digest prompt'),
+}));
+jest.mock('../../../services/llmService', () => ({ generateText: jest.fn() }));
+
+const { generateText } = require('../../../services/llmService');
+const Post = require('../../../models/Post');
+const summarizerService = require('../../../services/summarizerService');
+const chatSummarizerService = require('../../../services/chatSummarizerService');
+const dailyDigestService = require('../../../services/dailyDigestService');
+
+describe('LLM summaries fail closed', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not fabricate a post summary after an LLM failure', async () => {
+    generateText.mockRejectedValueOnce(new Error('LLM unavailable'));
+
+    await expect(summarizerService.generateSummary('A real post', 'posts'))
+      .rejects.toThrow('LLM unavailable');
+  });
+
+  it('does not cache a generic community overview after an LLM failure', async () => {
+    const query = {
+      populate: jest.fn(),
+      sort: jest.fn(),
+      limit: jest.fn(),
+      lean: jest.fn(),
+    };
+    query.populate.mockReturnValue(query);
+    query.sort.mockReturnValue(query);
+    query.limit.mockReturnValue(query);
+    query.lean.mockResolvedValue([
+      { content: 'A real post', tags: [], userId: { username: 'lily' } },
+    ]);
+    Post.find.mockReturnValueOnce(query);
+    generateText.mockRejectedValueOnce(new Error('LLM unavailable'));
+
+    await expect(summarizerService.summarizeAllPosts())
+      .rejects.toThrow('LLM unavailable');
+  });
+
+  it('does not fabricate chat analytics when enhanced generation returns invalid JSON', async () => {
+    generateText.mockResolvedValueOnce('not json');
+
+    await expect(chatSummarizerService.generateEnhancedSummary(
+      'A real message',
+      'General',
+      [{ content: 'A real message', username: 'lily' }],
+    )).rejects.toThrow('Enhanced chat summary generation returned invalid JSON');
+  });
+
+  it('does not create a generic digest after an LLM failure', async () => {
+    generateText.mockRejectedValueOnce(new Error('LLM unavailable'));
+
+    await expect(dailyDigestService.generateDigestContent({}, { username: 'lily' }))
+      .rejects.toThrow('LLM unavailable');
+  });
+});

--- a/backend/routes/admin/globalIntegrations.ts
+++ b/backend/routes/admin/globalIntegrations.ts
@@ -469,6 +469,11 @@ router.post('/model-policy', auth, adminAuth, async (req: any, res: any) => {
     if (!userId) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
+    if (!GlobalModelConfigService.isSupportedLlmServiceProvider(req.body?.llmService?.provider)) {
+      return res.status(400).json({
+        error: 'Unsupported backend LLM provider. Use auto, gemini, litellm, or openrouter.',
+      });
+    }
     const modelPolicy = await GlobalModelConfigService.setConfig(req.body || {}, userId);
     return res.json({ success: true, modelPolicy });
   } catch (error) {

--- a/backend/routes/registry/files.ts
+++ b/backend/routes/registry/files.ts
@@ -164,26 +164,18 @@ filesRouter.post('/pods/:podId/agents/:name/persona/generate', auth, async (req:
       'Keep specialties and boundaries concrete and short. Avoid emojis.',
     ].join('\n');
 
-    let generated = null;
+    let generated: Record<string, unknown> | null = null;
     try {
       const text = await generateText(prompt, { temperature: 0.7 });
-      generated = parseJsonFromText(text);
+      generated = parseJsonFromText(text) as Record<string, unknown> | null;
     } catch (error: unknown) {
-      console.warn('Persona generation failed, using fallback:', (error as Error).message);
+      console.error('Persona generation failed:', (error as Error).message);
+      return res.status(503).json({ error: 'Persona generation is temporarily unavailable. Please try again.' });
     }
 
     if (!generated || typeof generated !== 'object') {
-      generated = {
-        tone: 'friendly',
-        specialties: ['insight synthesis', 'clear explanations', 'actionable next steps'],
-        boundaries: ['avoid speculation', 'ask clarifying questions when unsure', 'be concise'],
-        customInstructions: 'Keep answers practical and structured.',
-        exampleInstructions: [
-          '- Summarize the key points first.',
-          '- Ask one clarifying question if needed.',
-          '- Offer a concrete next step.',
-        ].join('\n'),
-      };
+      console.error('Persona generation returned invalid JSON');
+      return res.status(502).json({ error: 'Persona generation returned an invalid response. Please try again.' });
     }
 
     return res.json({

--- a/backend/routes/summaries.ts
+++ b/backend/routes/summaries.ts
@@ -257,8 +257,10 @@ router.get('/all-posts', summariesReadRateLimit, auth, async (_req: AuthReq, res
     const allPostsSummary = await summarizerService.summarizeAllPosts();
     res.json(allPostsSummary);
   } catch (error) {
-    console.error('Error generating all posts summary:', error);
-    res.status(500).json({ error: 'Failed to generate all posts summary' });
+    // Fail closed: the summarizer no longer fabricates filler when the LLM is
+    // unavailable, so this is a service-unavailable, not a server bug.
+    console.error('All posts summary unavailable:', (error as Error).message);
+    res.status(503).json({ error: 'summary_unavailable' });
   }
 });
 

--- a/backend/services/chatSummarizerService.ts
+++ b/backend/services/chatSummarizerService.ts
@@ -16,17 +16,9 @@ interface MessageRow {
   username?: string;
 }
 
-interface FallbackAnalyticsResult {
-  timeline: unknown[];
-  quotes: unknown[];
-  insights: unknown[];
-  atmosphere: Record<string, unknown>;
-  participation: Record<string, unknown>;
-}
-
 interface EnhancedSummaryResult {
   summary: string;
-  analytics: FallbackAnalyticsResult | Record<string, unknown>;
+  analytics: Record<string, unknown>;
 }
 
 class ChatSummarizerService {
@@ -36,14 +28,14 @@ class ChatSummarizerService {
       return await generateText(prompt, { temperature: 0.4 }) as string;
     } catch (error) {
       console.error('Error generating chat summary with LLM:', error);
-      return ChatSummarizerService.generateFallbackSummary(content, podName);
+      throw error;
     }
   }
 
   async generateEnhancedSummary(
     content: string,
     podName: string,
-    messages: MessageRow[],
+    _messages: MessageRow[],
   ): Promise<EnhancedSummaryResult> {
     try {
       const prompt = ChatSummarizerService.createEnhancedPrompt(content, podName);
@@ -53,14 +45,8 @@ class ChatSummarizerService {
       try {
         analyticsData = JSON.parse(responseText) as Record<string, unknown>;
       } catch (parseError) {
-        console.warn(
-          'Failed to parse enhanced summary JSON, falling back to basic summary:',
-          parseError,
-        );
-        return {
-          summary: await this.generateSummary(content, podName),
-          analytics: ChatSummarizerService.generateFallbackAnalytics(messages, podName),
-        };
+        console.error('Failed to parse enhanced summary JSON:', parseError);
+        throw new Error('Enhanced chat summary generation returned invalid JSON');
       }
 
       return {
@@ -69,51 +55,8 @@ class ChatSummarizerService {
       };
     } catch (error) {
       console.error('Error generating enhanced chat summary with Gemini:', error);
-      return {
-        summary: ChatSummarizerService.generateFallbackSummary(content, podName),
-        analytics: ChatSummarizerService.generateFallbackAnalytics(messages, podName),
-      };
+      throw error;
     }
-  }
-
-  static generateFallbackAnalytics(messages: MessageRow[], _podName: string): FallbackAnalyticsResult {
-    const userCounts: Record<string, number> = {};
-    messages.forEach((msg) => {
-      if (msg.username) {
-        userCounts[msg.username] = (userCounts[msg.username] || 0) + 1;
-      }
-    });
-
-    const sortedUsers = Object.entries(userCounts)
-      .sort(([, a], [, b]) => b - a)
-      .slice(0, 5);
-
-    return {
-      timeline: [],
-      quotes: [],
-      insights: [],
-      atmosphere: {
-        overall_sentiment: 'neutral',
-        energy_level: messages.length > 10 ? 'medium' : 'low',
-        engagement_quality: 'moderate',
-        community_cohesion: 0.5,
-        topics_diversity: 0.5,
-        dominant_emotions: ['neutral'],
-      },
-      participation: {
-        most_active_users: sortedUsers.map(([username, count]) => ({
-          username,
-          message_count: count,
-          engagement_score: Math.min(count / messages.length, 1),
-          role: 'contributor',
-        })),
-        engagement_patterns: {
-          peak_hours: [],
-          discussion_length_avg: messages.length,
-          response_time_avg: 5,
-        },
-      },
-    };
   }
 
   static createPrompt(content: string, podName: string): string {
@@ -192,11 +135,6 @@ Please provide a JSON response with the following structure:
 }
 
 Focus on extracting meaningful insights, notable quotes, discussion pivots, and community dynamics.`;
-  }
-
-  static generateFallbackSummary(content: string, podName: string): string {
-    const messageCount = content.split('\n').filter((line) => line.trim()).length;
-    return `${messageCount} messages were exchanged in ${podName}, featuring active conversations and community interactions.`;
   }
 
   static async getActivePods(): Promise<string[]> {

--- a/backend/services/dailyDigestService.ts
+++ b/backend/services/dailyDigestService.ts
@@ -194,8 +194,7 @@ export class DailyDigestService {
       return await generateText(prompt, { temperature: 0.4 }) as string;
     } catch (error) {
       console.error('Error generating digest content with AI:', error);
-      const insights = DailyDigestService.extractCrossConversationInsights([]);
-      return DigestTemplateService.createFallbackDigest(user, insights, new Date(), new Date());
+      throw error;
     }
   }
 
@@ -450,38 +449,6 @@ This might be a great time to start a new conversation or share something intere
     return 'evening';
   }
 
-  static generateFallbackDigest(organizedData: OrganizedData, user: { username: string }): string {
-    const { byPod } = organizedData;
-    const podCount = Object.keys(byPod).length;
-    const totalMessages = Object.values(byPod).reduce(
-      (sum, pod) => sum + pod.totalMessages,
-      0,
-    );
-
-    const engagementLabel = (() => {
-      if (totalMessages > 50) return 'High';
-      if (totalMessages > 20) return 'Medium';
-      return 'Low';
-    })();
-
-    return `# Daily Digest - ${new Date().toDateString()}
-
-Good ${DailyDigestService.getTimeOfDayGreeting()}, ${user.username}!
-
-## Community Overview
-- **Active Communities**: ${podCount}
-- **Total Messages**: ${totalMessages}
-- **Engagement**: ${engagementLabel}
-
-${Object.entries(byPod)
-    .map(
-      ([podName, data]) => `### ${podName}\n${data.summaries.map((s) => `- ${s.content}`).join('\n')}`,
-    )
-    .join('\n\n')}
-
----
-*Your personalized daily digest • Generated with love by Commonly AI*`;
-  }
 }
 
 export default new DailyDigestService();

--- a/backend/services/digestTemplateService.ts
+++ b/backend/services/digestTemplateService.ts
@@ -145,37 +145,6 @@ Extract and return ONLY a valid JSON object with this structure:
 IMPORTANT: Return ONLY the JSON object, no additional text or explanation.`;
   }
 
-  static createFallbackDigest(user: UserLike, insights: InsightsLike, _startTime: Date, endTime: Date): string {
-    const { username } = user;
-    const date = endTime.toDateString();
-
-    return `# 🌅 Daily Digest - ${date}
-
-Good morning, ${username}!
-
-Ready for your daily community catch-up? Here's what's been happening.
-
-## ✨ Today's Highlights
-
-- **Community Activity**: ${insights.totalItems || 0} conversations and updates across your communities
-- **Active Discussions**: Your communities maintained ${insights.overallAtmosphere?.energy_level || 'moderate'} energy levels
-- **Community Engagement**: ${insights.topUsers?.length || 0} active community members contributing
-
-## 📊 Community Pulse
-
-- **Overall Mood**: 😊 ${insights.overallAtmosphere?.overall_sentiment || 'Positive'}
-- **Energy Level**: ⚡ ${insights.overallAtmosphere?.energy_level || 'Moderate'}
-- **Engagement Quality**: 🎯 ${insights.overallAtmosphere?.engagement_quality || 'Good'} discussions
-- **Active Communities**: Your subscribed communities are staying connected
-
-## 🔮 Looking Ahead
-
-Your communities continue to grow and evolve. Keep an eye out for new conversations and opportunities to connect with fellow members.
-
----
-*Your personalized digest • Generated with ❤️ by Commonly AI*`;
-  }
-
   static getPersonalizedGreeting(user: UserLike, timeOfDay: string, activityLevel: string): string {
     const { username } = user;
 

--- a/backend/services/discordCommandService.ts
+++ b/backend/services/discordCommandService.ts
@@ -326,7 +326,6 @@ class DiscordCommandService {
     endTime: Date,
   ): Promise<DiscordSummaryData> {
     const userMessages = messages.filter((msg) => msg.author && msg.content);
-    const uniqueUsers = [...new Set(userMessages.map((msg) => msg.author as string))];
 
     let content: string;
     if (userMessages.length === 0) {
@@ -342,8 +341,7 @@ class DiscordCommandService {
         content = await summarizerService.generateSummary(messageContent, 'discord') as string;
       } catch (error) {
         console.error('Failed to generate AI summary for Discord messages:', error);
-        const topUsers = uniqueUsers.slice(0, 3);
-        content = `Active discussion with ${uniqueUsers.length} participants (${topUsers.join(', ')}${uniqueUsers.length > 3 ? ' and others' : ''}).`;
+        content = '⚠️ AI summary is temporarily unavailable. Please try again shortly.';
       }
     }
 

--- a/backend/services/globalModelConfigService.ts
+++ b/backend/services/globalModelConfigService.ts
@@ -67,11 +67,15 @@ const DEFAULT_CONFIG: GlobalModelConfig = {
 const CACHE_TTL_MS = 15000;
 let cachedConfig: GlobalModelConfig | null = null;
 let cachedAt = 0;
+const LLM_SERVICE_PROVIDERS = new Set(['auto', 'gemini', 'litellm', 'openrouter']);
 
 const normalizeProvider = (value: unknown): string => {
   const normalized = String(value || '').trim().toLowerCase();
-  if (['auto', 'gemini', 'litellm', 'openrouter', 'openai', 'anthropic'].includes(normalized)) {
+  if (LLM_SERVICE_PROVIDERS.has(normalized)) {
     return normalized;
+  }
+  if (normalized) {
+    console.error(`[model-config] Unsupported persisted backend LLM provider "${normalized}"; using auto.`);
   }
   return DEFAULT_CONFIG.llmService.provider;
 };
@@ -204,6 +208,11 @@ class GlobalModelConfigService {
     cachedAt = 0;
   }
 
+  static isSupportedLlmServiceProvider(value: unknown): boolean {
+    const normalized = String(value || '').trim().toLowerCase();
+    return !normalized || LLM_SERVICE_PROVIDERS.has(normalized);
+  }
+
   static async getConfig({ includeSecrets = false, forceRefresh = false }: GetConfigOptions = {}): Promise<GlobalModelConfig> {
     void includeSecrets;
     if (!forceRefresh && cachedConfig && (Date.now() - cachedAt) < CACHE_TTL_MS) {
@@ -237,6 +246,11 @@ class GlobalModelConfigService {
   }
 
   static async setConfig(patch: Partial<GlobalModelConfig> = {}, userId: string | null = null): Promise<GlobalModelConfig> {
+    if (!GlobalModelConfigService.isSupportedLlmServiceProvider(
+      patch?.llmService?.provider,
+    )) {
+      throw new Error('Unsupported backend LLM provider. Use auto, gemini, litellm, or openrouter.');
+    }
     const current = await GlobalModelConfigService.getConfig({ includeSecrets: true, forceRefresh: true });
     const mergedCandidate: GlobalModelConfig = {
       ...current,

--- a/backend/services/summarizerService.ts
+++ b/backend/services/summarizerService.ts
@@ -59,8 +59,7 @@ class SummarizerService {
       return summaryText;
     } catch (error) {
       console.error('Error generating summary with LLM:', error);
-      console.log(`Falling back to simple summary for ${type}`);
-      return SummarizerService.generateFallbackSummary(content, type);
+      throw error;
     }
   }
 
@@ -122,17 +121,6 @@ Please create an engaging 2-3 sentence overview that:
 - Uses a friendly, welcoming tone
 
 Focus on what people are actually talking about rather than just activity levels.`;
-  }
-
-  static generateFallbackSummary(content: string, type: string): string {
-    const itemCount = content.split('\n').filter((line) => line.trim()).length;
-    if (type === 'posts') {
-      return `${itemCount} posts were shared in the last hour, covering various topics and discussions in the community.`;
-    }
-    if (type === 'integration') {
-      return `${itemCount} messages were shared recently across the linked external channel.`;
-    }
-    return `Activity in ${itemCount} chat rooms with various conversations and community interactions.`;
   }
 
   async summarizePosts(): Promise<unknown> {
@@ -405,16 +393,14 @@ Please create an engaging 3-4 sentence community overview that:
 
 This is for new visitors to understand what the community is all about. Focus on the content and conversations, not just statistics.`;
 
-      let summaryText: string;
       if (now < cache.cooldownUntil) {
-        summaryText = SummarizerService.generateFallbackSummary(content, 'posts');
-      } else {
-        console.log('Generating all-posts summary with LLM...');
-        summaryText = await generateText(prompt, { temperature: 0.4 }) as string;
-        console.log(
-          `✓ LLM returned all-posts summary: "${summaryText.substring(0, 100)}..."`,
-        );
+        throw new Error('All-posts summary generation is cooling down after an LLM rate limit');
       }
+      console.log('Generating all-posts summary with LLM...');
+      const summaryText = await generateText(prompt, { temperature: 0.4 }) as string;
+      console.log(
+        `✓ LLM returned all-posts summary: "${summaryText.substring(0, 100)}..."`,
+      );
 
       const allTags = posts.flatMap((post) => (post.tags as string[]) || []);
       const topTags = SummarizerService.getTopItems(allTags, 8);
@@ -452,23 +438,7 @@ This is for new visitors to understand what the community is all about. Focus on
         SummarizerService.allPostsCache.cooldownUntil = Date.now() + 10 * 60 * 1000;
       }
 
-      const postCount = await Post.find({}).countDocuments() as number;
-      const summary: AllPostsSummary = {
-        title: `Community Overview • ${Math.min(postCount, 10)} recent posts`,
-        content: 'Our community has shared various thoughts, ideas, and discussions. Join the conversation and see what everyone is talking about!',
-        metadata: {
-          totalItems: Math.min(postCount, 10),
-          topTags: [],
-          topUsers: [],
-          timeRange: 'Recent posts',
-        },
-      };
-      SummarizerService.allPostsCache = {
-        summary,
-        createdAt: Date.now(),
-        cooldownUntil: SummarizerService.allPostsCache.cooldownUntil,
-      };
-      return summary;
+      throw error;
     }
   }
 }

--- a/frontend/src/components/admin/GlobalIntegrations.tsx
+++ b/frontend/src/components/admin/GlobalIntegrations.tsx
@@ -67,8 +67,6 @@ const ANTHROPIC_MODELS = [
 // Backend LLM service model options (provider → model list)
 const LLM_SERVICE_MODEL_OPTIONS = {
   gemini: GEMINI_MODELS,
-  openai: OPENAI_MODELS,
-  anthropic: ANTHROPIC_MODELS,
 };
 
 // OpenClaw gateway model options (provider → model list)
@@ -874,8 +872,6 @@ const GlobalIntegrations = () => {
                 >
                   <MenuItem value="auto">Auto (LiteLLM then Gemini)</MenuItem>
                   <MenuItem value="gemini">Gemini</MenuItem>
-                  <MenuItem value="openai">OpenAI</MenuItem>
-                  <MenuItem value="anthropic">Anthropic</MenuItem>
                   <MenuItem value="litellm">LiteLLM</MenuItem>
                   <MenuItem value="openrouter">OpenRouter</MenuItem>
                 </Select>


### PR DESCRIPTION
## Summary
- Reject backend LLM providers the service cannot execute instead of silently routing them to auto/Gemini.
- Remove fabricated LLM summaries, digests, analytics, and personas after generation errors.
- Preserve explicit zero-data states and return/log an honest unavailable error where callers can surface one.
- Add regression coverage for provider rejection and LLM outage paths.

## Verification
- Focused Jest suite: 22 passed.
- Backend TypeScript check: passed.
- Frontend type check: passed.

Full backend Jest is blocked before application suites load by the shared dependency trees jsonwebtoken/Node 26 incompatibility in buffer-equal-constant-time; this is unrelated to the diff.