### PR TITLE
feat(cli): batch agent inbox turns

### DIFF
--- a/backend/__tests__/service/clawdbot-e2e.test.js
+++ b/backend/__tests__/service/clawdbot-e2e.test.js
@@ -548,6 +548,7 @@ describe('Clawdbot E2E Integration Tests', () => {
       expect(res.status).toBe(200);
       expect(res.body.events).toBeDefined();
       expect(res.body.events.length).toBe(2);
+      expect(res.body.inboxCount).toBe(2);
       // ADR-012 §3: GET /events is mutate-on-claim — events return as
       // 'delivered' (claimed, awaiting ack), not 'pending'. The ack route
       // transitions them to 'acked'.

--- a/backend/__tests__/unit/routes/agentsRuntime.dm-events.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.dm-events.test.js
@@ -3,9 +3,14 @@ jest.mock('../../../middleware/auth', () => (req, res, next) => next());
 jest.mock('../../../middleware/apiTokenScopes', () => ({
   requireApiTokenScopes: () => (req, res, next) => next(),
 }));
+// The route's authentication middleware is mocked above. Its import graph
+// still reaches uploads.ts, which imports jsonwebtoken; keep that unrelated
+// Node-26-incompatible dependency out of this polling-scope unit test.
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(), verify: jest.fn(), decode: jest.fn() }));
 
 jest.mock('../../../services/agentEventService', () => ({
   list: jest.fn(),
+  listInboxPage: jest.fn(),
 }));
 jest.mock('../../../services/agentIdentityService', () => ({
   buildAgentUsername: jest.fn((agentName, instanceId = 'default') => (
@@ -65,7 +70,7 @@ describe('agentsRuntime DM and event pod coverage', () => {
       select: jest.fn().mockReturnThis(),
       lean: jest.fn().mockResolvedValue([{ _id: 'dm-pod-1' }]),
     });
-    AgentEventService.list.mockResolvedValue([]);
+    AgentEventService.listInboxPage.mockResolvedValue({ events: [], inboxCount: 0 });
 
     const req = {
       query: {},
@@ -80,12 +85,12 @@ describe('agentsRuntime DM and event pod coverage', () => {
 
     await handler(req, res);
 
-    expect(AgentEventService.list).toHaveBeenCalledWith(expect.objectContaining({
+    expect(AgentEventService.listInboxPage).toHaveBeenCalledWith(expect.objectContaining({
       agentName: 'openclaw',
       instanceId: 'liz',
       podIds: ['pod-1', 'dm-pod-1'],
     }));
-    expect(res.json).toHaveBeenCalledWith({ events: [] });
+    expect(res.json).toHaveBeenCalledWith({ events: [], inboxCount: 0 });
   });
 
   it('creates or returns DM pod via POST /dm', async () => {

--- a/backend/__tests__/unit/services/agentEventService.lifecycle.test.js
+++ b/backend/__tests__/unit/services/agentEventService.lifecycle.test.js
@@ -24,6 +24,7 @@
  */
 
 jest.mock('../../../models/AgentEvent', () => ({
+  countDocuments: jest.fn(),
   create: jest.fn(),
   findOneAndUpdate: jest.fn(),
   findByIdAndUpdate: jest.fn(),
@@ -76,6 +77,7 @@ const lastCall = (mockFn) => mockFn.mock.calls[mockFn.mock.calls.length - 1];
 describe('attempts is a delivery counter with exactly one writer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    AgentEvent.countDocuments.mockResolvedValue(1);
     AgentMemory.findOne.mockReturnValue({
       select: () => ({ lean: () => Promise.resolve({ revision: 3, lastSeenRevision: 1 }) }),
     });

--- a/backend/__tests__/unit/services/agentEventService.test.js
+++ b/backend/__tests__/unit/services/agentEventService.test.js
@@ -311,6 +311,53 @@ describe('AgentEventService', () => {
     expect(page.events.map((event) => event.podId)).toEqual(['pod-a', 'pod-a']);
   });
 
+  test('listInboxPage leaves a malformed no-pod head pending instead of widening into a mixed-pod batch', async () => {
+    const query = (rows) => ({
+      sort: () => ({
+        limit: () => ({
+          select: () => ({ lean: jest.fn().mockResolvedValue(rows) }),
+        }),
+      }),
+    });
+    AgentEvent.find.mockReturnValue(query([{ _id: 'missing-pod', podId: null }]));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const page = await AgentEventService.listInboxPage({
+      agentName: 'inbox', instanceId: 'default', podIds: ['pod-a', 'pod-b'], limit: 10,
+    });
+
+    expect(page).toEqual({ events: [], inboxCount: 0 });
+    expect(AgentEvent.find).toHaveBeenCalledTimes(1);
+    expect(AgentEvent.countDocuments).not.toHaveBeenCalled();
+    expect(AgentEvent.findOneAndUpdate).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Inbox head has no podId'),
+      expect.objectContaining({ eventId: 'missing-pod' }),
+    );
+    warn.mockRestore();
+  });
+
+  test('listInboxPage preserves its pre-claim count when a sibling wins every candidate', async () => {
+    const query = (rows) => ({
+      sort: () => ({
+        limit: () => ({
+          select: () => ({ lean: jest.fn().mockResolvedValue(rows) }),
+        }),
+      }),
+    });
+    AgentEvent.find
+      .mockReturnValueOnce(query([{ _id: 'head', podId: 'pod-a' }]))
+      .mockReturnValueOnce(query([]));
+    AgentEvent.countDocuments.mockResolvedValue(3);
+
+    const page = await AgentEventService.listInboxPage({
+      agentName: 'inbox', instanceId: 'default', podIds: ['pod-a', 'pod-b'], limit: 10,
+    });
+
+    expect(page).toEqual({ events: [], inboxCount: 3 });
+    expect(AgentEvent.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
   test('legacy list preserves its cross-pod replay contract', async () => {
     const AgentMemory = require('../../../models/AgentMemory');
     const query = (rows) => ({

--- a/backend/__tests__/unit/services/agentEventService.test.js
+++ b/backend/__tests__/unit/services/agentEventService.test.js
@@ -304,14 +304,17 @@ describe('AgentEventService', () => {
     });
 
     expect(AgentEvent.find).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      podId: { $in: ['pod-a', 'pod-b'] },
+      $and: expect.arrayContaining([
+        expect.objectContaining({ podId: { $in: ['pod-a', 'pod-b'] } }),
+        { podId: { $exists: true, $ne: null } },
+      ]),
     }));
     expect(AgentEvent.find).toHaveBeenNthCalledWith(2, expect.objectContaining({ podId: 'pod-a' }));
     expect(page.inboxCount).toBe(2);
     expect(page.events.map((event) => event.podId)).toEqual(['pod-a', 'pod-a']);
   });
 
-  test('listInboxPage leaves a malformed no-pod head pending instead of widening into a mixed-pod batch', async () => {
+  test('listInboxPage excludes malformed no-pod rows when selecting its one-pod head', async () => {
     const query = (rows) => ({
       sort: () => ({
         limit: () => ({
@@ -319,8 +322,7 @@ describe('AgentEventService', () => {
         }),
       }),
     });
-    AgentEvent.find.mockReturnValue(query([{ _id: 'missing-pod', podId: null }]));
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    AgentEvent.find.mockReturnValue(query([]));
 
     const page = await AgentEventService.listInboxPage({
       agentName: 'inbox', instanceId: 'default', podIds: ['pod-a', 'pod-b'], limit: 10,
@@ -328,13 +330,19 @@ describe('AgentEventService', () => {
 
     expect(page).toEqual({ events: [], inboxCount: 0 });
     expect(AgentEvent.find).toHaveBeenCalledTimes(1);
+    expect(AgentEvent.find).toHaveBeenCalledWith({
+      $and: [
+        {
+          agentName: 'inbox',
+          instanceId: 'default',
+          status: 'pending',
+          podId: { $in: ['pod-a', 'pod-b'] },
+        },
+        { podId: { $exists: true, $ne: null } },
+      ],
+    });
     expect(AgentEvent.countDocuments).not.toHaveBeenCalled();
     expect(AgentEvent.findOneAndUpdate).not.toHaveBeenCalled();
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('Inbox head has no podId'),
-      expect.objectContaining({ eventId: 'missing-pod' }),
-    );
-    warn.mockRestore();
   });
 
   test('listInboxPage preserves its pre-claim count when a sibling wins every candidate', async () => {

--- a/backend/__tests__/unit/services/agentEventService.test.js
+++ b/backend/__tests__/unit/services/agentEventService.test.js
@@ -1,5 +1,6 @@
 jest.mock('../../../models/AgentEvent', () => ({
   create: jest.fn(),
+  countDocuments: jest.fn(),
   findOneAndUpdate: jest.fn(),
   find: jest.fn(),
 }));
@@ -50,6 +51,7 @@ describe('AgentEventService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.AGENT_CONTEXT_OVERFLOW_RETRY_LIMIT;
+    AgentEvent.countDocuments.mockResolvedValue(1);
   });
 
   test('acknowledge auto-recovers OpenClaw context overflow and re-enqueues once', async () => {
@@ -262,6 +264,89 @@ describe('AgentEventService', () => {
       cyclesDigest: expect.any(Array),
       longTermDigest: 'durable',
     }));
+  });
+
+  test('list chooses one pod before claiming a batch, so a driver never receives mixed private context', async () => {
+    const AgentMemory = require('../../../models/AgentMemory');
+    const query = (rows) => ({
+      sort: () => ({
+        limit: () => ({
+          select: () => ({ lean: jest.fn().mockResolvedValue(rows) }),
+        }),
+      }),
+    });
+    // The oldest row selects pod-a. The second query deliberately contains
+    // only pod-a candidates even though the authenticated installation scope
+    // covers pod-b too.
+    AgentEvent.find
+      .mockReturnValueOnce(query([{ _id: 'head', podId: 'pod-a' }]))
+      .mockReturnValueOnce(query([{ _id: 'head' }, { _id: 'same-pod' }]));
+    AgentEvent.countDocuments.mockResolvedValue(2);
+    AgentMemory.findOne.mockReturnValue({
+      select: () => ({ lean: jest.fn().mockResolvedValue({ revision: 1, lastSeenRevision: 0 }) }),
+    });
+    AgentEvent.findOneAndUpdate
+      .mockReturnValueOnce({
+        lean: jest.fn().mockResolvedValue({
+          _id: 'head', agentName: 'inbox', instanceId: 'default', podId: 'pod-a',
+          type: 'message.posted', payload: {}, status: 'delivered',
+        }),
+      })
+      .mockReturnValueOnce({
+        lean: jest.fn().mockResolvedValue({
+          _id: 'same-pod', agentName: 'inbox', instanceId: 'default', podId: 'pod-a',
+          type: 'chat.mention', payload: {}, status: 'delivered',
+        }),
+      });
+
+    const page = await AgentEventService.listInboxPage({
+      agentName: 'inbox', instanceId: 'default', podIds: ['pod-a', 'pod-b'], limit: 10,
+    });
+
+    expect(AgentEvent.find).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      podId: { $in: ['pod-a', 'pod-b'] },
+    }));
+    expect(AgentEvent.find).toHaveBeenNthCalledWith(2, expect.objectContaining({ podId: 'pod-a' }));
+    expect(page.inboxCount).toBe(2);
+    expect(page.events.map((event) => event.podId)).toEqual(['pod-a', 'pod-a']);
+  });
+
+  test('legacy list preserves its cross-pod replay contract', async () => {
+    const AgentMemory = require('../../../models/AgentMemory');
+    const query = (rows) => ({
+      sort: () => ({
+        limit: () => ({
+          select: () => ({ lean: jest.fn().mockResolvedValue(rows) }),
+        }),
+      }),
+    });
+    AgentEvent.find.mockReturnValue(query([{ _id: 'pod-a-event' }, { _id: 'pod-b-event' }]));
+    AgentMemory.findOne.mockReturnValue({
+      select: () => ({ lean: jest.fn().mockResolvedValue({ revision: 1, lastSeenRevision: 0 }) }),
+    });
+    AgentEvent.findOneAndUpdate
+      .mockReturnValueOnce({
+        lean: jest.fn().mockResolvedValue({
+          _id: 'pod-a-event', agentName: 'inbox', instanceId: 'default', podId: 'pod-a',
+          type: 'message.posted', payload: {}, status: 'delivered',
+        }),
+      })
+      .mockReturnValueOnce({
+        lean: jest.fn().mockResolvedValue({
+          _id: 'pod-b-event', agentName: 'inbox', instanceId: 'default', podId: 'pod-b',
+          type: 'message.posted', payload: {}, status: 'delivered',
+        }),
+      });
+
+    const events = await AgentEventService.list({
+      agentName: 'inbox', instanceId: 'default', podIds: ['pod-a', 'pod-b'], limit: 10,
+    });
+
+    expect(AgentEvent.find).toHaveBeenCalledTimes(1);
+    expect(AgentEvent.find).toHaveBeenCalledWith(expect.objectContaining({
+      podId: { $in: ['pod-a', 'pod-b'] },
+    }));
+    expect(events.map((event) => event.podId)).toEqual(['pod-a', 'pod-b']);
   });
 
   test('list returns [] when no candidates are pending (no envelope read)', async () => {

--- a/backend/models/AgentEvent.ts
+++ b/backend/models/AgentEvent.ts
@@ -104,6 +104,10 @@ const AgentEventSchema = new Schema<IAgentEvent>(
 );
 
 AgentEventSchema.index({ agentName: 1, instanceId: 1, status: 1, createdAt: 1 });
+// ADR-024 D3 reads one pod-scoped inbox page after finding the global head.
+// This keeps that bounded page and its true-count query from scanning pending
+// work in every other pod for the same agent installation.
+AgentEventSchema.index({ agentName: 1, instanceId: 1, status: 1, podId: 1, createdAt: 1 });
 
 export const AgentEvent: Model<IAgentEvent> = mongoose.model<IAgentEvent>(
   'AgentEvent',

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -498,7 +498,7 @@ router.get('/events', agentRuntimeAuth, async (req: any, res: any) => {
       }
     }
 
-    const events = await AgentEventService.list({
+    const { events, inboxCount } = await AgentEventService.listInboxPage({
       agentName,
       instanceId,
       podId: fallbackPodId,
@@ -520,7 +520,7 @@ router.get('/events', agentRuntimeAuth, async (req: any, res: any) => {
       }
     }
 
-    return res.json({ events });
+    return res.json({ events, inboxCount });
   } catch (error: any) {
     console.error('Error listing agent events:', error);
     return res.status(500).json({ message: 'Failed to list agent events' });

--- a/backend/services/agentEventService.ts
+++ b/backend/services/agentEventService.ts
@@ -1270,7 +1270,15 @@ class AgentEventService {
       // This first read is deliberately non-mutating. The conditional updates
       // below remain the claim: a sibling poller may still win either the head
       // or any later candidate, in which case it is filtered out normally.
-      const [head] = await AgentEvent.find(query)
+      // `podId` is required by the schema, but legacy/corrupt rows can still
+      // exist in Mongo. Never let one become the chronological head: it has
+      // no safe one-pod partition and would otherwise strand this inbox
+      // behind a row no poller can process. Keep the caller's scope inside
+      // the same `$and` so this exclusion only narrows access.
+      const headQuery = {
+        $and: [query, { podId: { $exists: true, $ne: null } }],
+      };
+      const [head] = await AgentEvent.find(headQuery)
         .sort({ createdAt: 1 })
         .limit(1)
         .select({ _id: 1, podId: 1 })
@@ -1278,19 +1286,9 @@ class AgentEventService {
 
       if (!head) return { events: [], inboxCount: 0 };
 
-      // `head` came from the already-access-checked query above, so replacing
-      // a possible `$in` pod filter with its stored pod id narrows rather than
-      // widens the caller's scope. A malformed head has no safe partition:
-      // returning `query` here would turn one model turn into mixed private
-      // context. Leave it pending and log for repair rather than fail open.
-      if (head.podId == null) {
-        console.warn('[agent-events] Inbox head has no podId; left pending rather than widening a one-pod batch', {
-          eventId: String(head._id || ''),
-          agentName: safeAgentName,
-          instanceId: safeInstanceId,
-        });
-        return { events: [], inboxCount: 0 };
-      }
+      // `head` came from the already-access-checked and pod-qualified query
+      // above, so replacing a possible `$in` pod filter with its stored pod id
+      // narrows rather than widens the caller's scope.
       batchQuery = { ...query, podId: head.podId };
       // Count before this driver's conditional claims. The number is advisory
       // metadata (other pollers may win a race immediately after it), but it

--- a/backend/services/agentEventService.ts
+++ b/backend/services/agentEventService.ts
@@ -1223,9 +1223,9 @@ class AgentEventService {
   // revision captured per event reflects the moment of claim, not the moment
   // of fetch-batch-start; bounded staleness — see ADR-012 §3 last paragraph).
   static async list(options: ListOptions): Promise<EventDoc[]> {
-    // WebSocket and bot consumers intentionally replay across every pod in
-    // their access scope. The one-pod partition below belongs specifically to
-    // the CLI inbox, whose batch becomes one pod-contextual model turn.
+    // Legacy consumers intentionally replay across every pod in their access
+    // scope. The one-pod partition is opt-in through listInboxPage(), for any
+    // HTTP poller whose batch becomes one pod-contextual model turn.
     return (await this.claimPage(options)).events;
   }
 
@@ -1280,10 +1280,18 @@ class AgentEventService {
 
       // `head` came from the already-access-checked query above, so replacing
       // a possible `$in` pod filter with its stored pod id narrows rather than
-      // widens the caller's scope. Keep the fallback for old/malformed rows:
-      // it preserves legacy delivery rather than turning a bad row into a
-      // stuck pending event.
-      batchQuery = head.podId != null ? { ...query, podId: head.podId } : query;
+      // widens the caller's scope. A malformed head has no safe partition:
+      // returning `query` here would turn one model turn into mixed private
+      // context. Leave it pending and log for repair rather than fail open.
+      if (head.podId == null) {
+        console.warn('[agent-events] Inbox head has no podId; left pending rather than widening a one-pod batch', {
+          eventId: String(head._id || ''),
+          agentName: safeAgentName,
+          instanceId: safeInstanceId,
+        });
+        return { events: [], inboxCount: 0 };
+      }
+      batchQuery = { ...query, podId: head.podId };
       // Count before this driver's conditional claims. The number is advisory
       // metadata (other pollers may win a race immediately after it), but it
       // is truthful at the batch boundary and never crosses pod boundaries.
@@ -1296,7 +1304,11 @@ class AgentEventService {
       .select({ _id: 1 })
       .lean() as Array<{ _id: unknown }>;
 
-    if (candidates.length === 0) return { events: [], inboxCount: 0 };
+    // A sibling poller can claim every candidate after our pre-claim count.
+    // The page is empty, but the count still describes what this reader saw
+    // at the batch boundary; returning zero would falsely say the inbox was
+    // empty under contention.
+    if (candidates.length === 0) return { events: [], inboxCount };
 
     // Read AgentMemory once for the digest bundle. The envelope captured here
     // reflects the state at the moment of claim — close enough to the per-doc

--- a/backend/services/agentEventService.ts
+++ b/backend/services/agentEventService.ts
@@ -199,6 +199,11 @@ interface ListOptions {
   instanceId?: string;
 }
 
+interface InboxPage {
+  events: EventDoc[];
+  inboxCount: number;
+}
+
 interface AvailableIntegration {
   id?: string;
   type?: string;
@@ -1217,9 +1222,22 @@ class AgentEventService {
   // and moves on. AgentMemory.revision is read once per fetch batch (the
   // revision captured per event reflects the moment of claim, not the moment
   // of fetch-batch-start; bounded staleness — see ADR-012 §3 last paragraph).
-  static async list({
+  static async list(options: ListOptions): Promise<EventDoc[]> {
+    // WebSocket and bot consumers intentionally replay across every pod in
+    // their access scope. The one-pod partition below belongs specifically to
+    // the CLI inbox, whose batch becomes one pod-contextual model turn.
+    return (await this.claimPage(options)).events;
+  }
+
+  // The HTTP poller needs the true pending count for its inbox header even
+  // when it copies only a bounded number of event bodies into one turn.
+  static async listInboxPage(options: ListOptions): Promise<InboxPage> {
+    return this.claimPage(options, { onePod: true, includeInboxCount: true });
+  }
+
+  private static async claimPage({
     agentName, podId, podIds, limit = 20, instanceId = 'default',
-  }: ListOptions): Promise<EventDoc[]> {
+  }: ListOptions, { onePod = false, includeInboxCount = false } = {}): Promise<InboxPage> {
     // Coerce caller-supplied identifiers to plain strings before they reach
     // any Mongo query — guards against NoSQL-injection-shaped inputs (e.g.
     // `{$ne: null}`) sneaking through. CodeQL flags any data flow from
@@ -1240,17 +1258,45 @@ class AgentEventService {
       query.podId = podId;
     }
 
-    // First collect candidate _ids (non-mutating). We then claim them one by
-    // one with status-gated findOneAndUpdate so concurrent pollers can't
-    // double-claim. Limit applies to candidates; the actually-claimed set may
-    // be smaller if a sibling poller wins some races.
-    const candidates = await AgentEvent.find(query)
+    let batchQuery = query;
+    let inboxCount = 0;
+    if (onePod) {
+      // An agent's inbox is scoped to a place. Pick its oldest pending event,
+      // then claim a batch from THAT pod only. Returning a mixed-pod batch
+      // would force a driver to either leak one pod's context into another or
+      // launch multiple turns after having marked all of them delivered — the
+      // over-claim/requeue failure ADR-024 D3 was written to remove.
+      //
+      // This first read is deliberately non-mutating. The conditional updates
+      // below remain the claim: a sibling poller may still win either the head
+      // or any later candidate, in which case it is filtered out normally.
+      const [head] = await AgentEvent.find(query)
+        .sort({ createdAt: 1 })
+        .limit(1)
+        .select({ _id: 1, podId: 1 })
+        .lean() as Array<{ _id: unknown, podId?: unknown }>;
+
+      if (!head) return { events: [], inboxCount: 0 };
+
+      // `head` came from the already-access-checked query above, so replacing
+      // a possible `$in` pod filter with its stored pod id narrows rather than
+      // widens the caller's scope. Keep the fallback for old/malformed rows:
+      // it preserves legacy delivery rather than turning a bad row into a
+      // stuck pending event.
+      batchQuery = head.podId != null ? { ...query, podId: head.podId } : query;
+      // Count before this driver's conditional claims. The number is advisory
+      // metadata (other pollers may win a race immediately after it), but it
+      // is truthful at the batch boundary and never crosses pod boundaries.
+      inboxCount = await AgentEvent.countDocuments(batchQuery);
+    }
+
+    const candidates = await AgentEvent.find(batchQuery)
       .sort({ createdAt: 1 })
       .limit(limit)
       .select({ _id: 1 })
       .lean() as Array<{ _id: unknown }>;
 
-    if (candidates.length === 0) return [];
+    if (candidates.length === 0) return { events: [], inboxCount: 0 };
 
     // Read AgentMemory once for the digest bundle. The envelope captured here
     // reflects the state at the moment of claim — close enough to the per-doc
@@ -1305,7 +1351,7 @@ class AgentEventService {
       if (updated) claimed.push(updated);
     }
 
-    return claimed.map((event) => {
+    const events = claimed.map((event) => {
       const messageId = event?.payload?.messageId;
       const basePayload = event?.payload || {};
       // Spread digest bundle into payload. Each sub-field is undefined when
@@ -1324,6 +1370,7 @@ class AgentEventService {
       }
       return { ...event, payload: enrichedPayload };
     });
+    return { events, inboxCount: includeInboxCount ? inboxCount : events.length };
   }
 
   // ADR-012 §3: acknowledge is status-gated. Lifecycle:

--- a/cli/__tests__/run-loop.test.mjs
+++ b/cli/__tests__/run-loop.test.mjs
@@ -105,15 +105,13 @@ describe('performRun', () => {
       expect.objectContaining({ agentName: 'my-stub', instanceId: 'default' }),
     );
 
-    // The fetch IS the claim — `list()` marks every candidate `delivered`
-    // and increments `attempts` before returning, while this loop starts
-    // exactly one. Asking for more claims work it cannot begin, and the
-    // backend's requeue sweep then reclaims the remainder at `attempts + 1`
-    // until the poison cap retires them unread. Pinned as its own assertion
-    // because the previous value (10) looked like a harmless batch size.
-    expect(mockGet.mock.calls[0][1].limit).toBe(1);
+    // ADR-024 D3: the server now chooses one pod before claiming this page,
+    // so the whole page reaches one composite turn instead of aging untouched
+    // behind a prior single-event turn.
+    expect(mockGet.mock.calls[0][1].limit).toBe(10);
     expect(spawn).toHaveBeenCalledTimes(1);
-    expect(spawn.mock.calls[0][0]).toBe('hello from tester');
+    expect(spawn.mock.calls[0][0]).toContain('[Inbox batch: 1 new event');
+    expect(spawn.mock.calls[0][0]).toContain('hello from tester');
 
     expect(mockPost).toHaveBeenCalledWith(
       '/api/agents/runtime/pods/pod-abc/messages',
@@ -122,6 +120,93 @@ describe('performRun', () => {
     expect(mockPost).toHaveBeenCalledWith(
       '/api/agents/runtime/events/evt-1/ack',
       { result: { outcome: 'posted' }, deliveryId: 'delivery-abc' },
+    );
+  });
+
+  test('one same-pod inbox page becomes one turn, carries the true count, and claims binding items before spawn', async () => {
+    const events = [
+      makeEvent({ _id: 'evt-batch-a', type: 'message.posted', payload: { content: 'first context', messageId: 'msg-a' } }),
+      makeEvent({ _id: 'evt-batch-b', type: 'message.posted', payload: { content: 'second context', messageId: 'msg-b' } }),
+    ];
+    const post = jest.fn(async (route) => {
+      if (route.endsWith('/claim')) return { claimed: true, expiresAt: 'later' };
+      return {};
+    });
+    const del = jest.fn(async () => ({ released: true }));
+    const get = jest.fn(async (route) => {
+      if (route === '/api/agents/runtime/memory') return { sections: {} };
+      if (route.endsWith('/messages')) return { messages: [] };
+      return { events, inboxCount: 7 };
+    });
+    createClient.mockReturnValue({ get, post, del });
+    const spawn = jest.fn(async () => {
+      expect(post.mock.calls.filter(([route]) => route.endsWith('/claim'))).toHaveLength(2);
+      return { text: 'one considered response' };
+    });
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter: { name: 'stub', detect: stubAdapter.detect, spawn },
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn.mock.calls[0][0]).toContain('[Inbox batch: 7 new events');
+    expect(spawn.mock.calls[0][0]).toContain('first context');
+    expect(spawn.mock.calls[0][0]).toContain('second context');
+    expect(spawn.mock.calls[0][0]).toContain('[5 more events arrived.');
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-batch-a/ack', { result: { outcome: 'posted' } },
+    );
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-batch-b/ack', { result: { outcome: 'posted' } },
+    );
+  });
+
+  test('a lost binding item stays read-only context while another batch item may run', async () => {
+    const events = [
+      makeEvent({
+        _id: 'evt-held', type: 'message.posted',
+        payload: { content: 'peer owns this decision', messageId: 'msg-held' },
+      }),
+      makeEvent({ _id: 'evt-heartbeat', type: 'heartbeat', payload: { content: 'check the rest of the inbox' } }),
+    ];
+    const post = jest.fn(async (route) => {
+      if (route.endsWith('/claim')) return { claimed: false, claimedBy: 'nova' };
+      return {};
+    });
+    const get = jest.fn(async (route) => {
+      if (route === '/api/agents/runtime/memory') return { sections: {} };
+      if (route.endsWith('/messages')) return { messages: [] };
+      return { events };
+    });
+    createClient.mockReturnValue({ get, post, del: jest.fn() });
+    const spawn = jest.fn(async () => ({ text: 'handled the heartbeat' }));
+
+    const { stop } = performRun({
+      instanceUrl: 'http://localhost:5000',
+      token: 'cm_agent_test',
+      adapter: { name: 'stub', detect: stubAdapter.detect, spawn },
+      agentName: 'my-stub',
+      setTimeoutImpl: noopTimeout,
+    });
+    await drainMicrotasks();
+    stop();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn.mock.calls[0][0]).toContain('@nova holds message msg-held');
+    expect(spawn.mock.calls[0][0]).toContain('read-only context');
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-held/ack',
+      { result: { outcome: 'no_action', reason: 'claim-held' } },
+    );
+    expect(post).toHaveBeenCalledWith(
+      '/api/agents/runtime/events/evt-heartbeat/ack',
+      { result: { outcome: 'posted' } },
     );
   });
 
@@ -216,8 +301,10 @@ describe('performRun', () => {
     stop();
 
     expect(spawn).toHaveBeenCalledWith(
-      'Make a warm first impression.',
-      expect.objectContaining({ metadata: { event: events[0] } }),
+      expect.stringContaining('Make a warm first impression.'),
+      expect.objectContaining({ metadata: { event: expect.objectContaining({
+        type: 'inbox.batch', payload: expect.objectContaining({ batchEventIds: ['evt-first-contact'] }),
+      }) } }),
     );
     expect(mockPost).toHaveBeenCalledWith(
       '/api/agents/runtime/pods/pod-abc/messages',
@@ -492,8 +579,10 @@ describe('performRun', () => {
     stop();
 
     expect(spawn).toHaveBeenCalledWith(
-      'Run your heartbeat checklist.',
-      expect.objectContaining({ metadata: { event: events[0] } }),
+      expect.stringContaining('Run your heartbeat checklist.'),
+      expect.objectContaining({ metadata: { event: expect.objectContaining({
+        type: 'inbox.batch', payload: expect.objectContaining({ hasHeartbeat: true }),
+      }) } }),
     );
     expect(mockPost).not.toHaveBeenCalledWith(
       '/api/agents/runtime/pods/pod-abc/messages',
@@ -846,6 +935,7 @@ describe('performRun', () => {
       adapter,
       agentName: 'my-stub',
       retryJitterRatio: 0,
+      inboxBatchLimit: 1,
       setTimeoutImpl: (callback, delayMs) => {
         scheduled.push({ callback, delayMs });
         return 0;
@@ -937,7 +1027,7 @@ describe('performRun', () => {
     expect(errors[0]).toMatchObject({ failureClass: 'quota', circuitOpen: true });
   });
 
-  test('a no-op event does not erase the model failure streak', async () => {
+  test('a batch spawn failure leaves its no-op sibling unacked for coherent retry', async () => {
     let poll = 0;
     const mockGet = jest.fn(async (route) => {
       if (route === '/api/agents/runtime/events') {
@@ -979,7 +1069,10 @@ describe('performRun', () => {
 
     expect(spawn).toHaveBeenCalledTimes(2);
     expect(scheduled[0].delayMs).toBe(10000);
-    expect(mockPost).toHaveBeenCalledWith(
+    // Acknowledge happens after the single composite turn. The no-op sibling
+    // must therefore remain pending with the failed spawn, not disappear
+    // while the rest of the batch is retried.
+    expect(mockPost).not.toHaveBeenCalledWith(
       '/api/agents/runtime/events/evt-no-prompt/ack',
       { result: { outcome: 'no_action', reason: 'no-prompt' } },
     );
@@ -1048,6 +1141,7 @@ describe('performRun', () => {
       token: 'cm_agent_test',
       adapter,
       agentName: 'my-stub',
+      inboxBatchLimit: 1,
       setTimeoutImpl: noopTimeout,
     });
     await drainMicrotasks();
@@ -1076,6 +1170,7 @@ describe('performRun', () => {
       token: 'cm_agent_test',
       adapter,
       agentName: 'my-stub',
+      inboxBatchLimit: 1,
       setTimeoutImpl: noopTimeout,
     });
     await drainMicrotasks();
@@ -1453,7 +1548,7 @@ describe('performRun', () => {
     expect(call).toBeGreaterThan(1);
   });
 
-  test('stop() prevents subsequent events within the same cycle from being processed', async () => {
+  test('stop() does not create a second spawn inside a fetched inbox batch', async () => {
     const events = [makeEvent({ _id: 'e1' }), makeEvent({ _id: 'e2' })];
     const mockGet = jest.fn().mockResolvedValue({ events });
     const mockPost = jest.fn().mockResolvedValue({});
@@ -1476,12 +1571,12 @@ describe('performRun', () => {
     });
     await drainMicrotasks();
 
-    // Only the first event was processed; the second skipped due to stop().
+    // One spawn saw both items before stop. There is no second per-event turn.
     expect(spawn).toHaveBeenCalledTimes(1);
     const ackCalls = mockPost.mock.calls.filter(
       ([route]) => route.includes('/events/') && route.endsWith('/ack'),
     );
-    expect(ackCalls).toHaveLength(1);
+    expect(ackCalls).toHaveLength(2);
     expect(ackCalls[0][0]).toContain('/events/e1/ack');
   });
 
@@ -1559,6 +1654,11 @@ describe('performRun — ADR-018 enforcement', () => {
     token: 'cm_agent_test',
     adapter,
     agentName: 'my-stub',
+    // The ADR-018 unit cases below exercise per-event claim/cascade semantics.
+    // D3's composite behavior has dedicated tests; pinning this seam at one
+    // keeps those historical contracts readable instead of duplicating each
+    // assertion against a batch prompt.
+    inboxBatchLimit: 1,
     setTimeoutImpl: noopTimeout,
     ...opts,
   });
@@ -1707,7 +1807,7 @@ describe('performRun — ADR-018 enforcement', () => {
     expect(post.mock.calls.some(([r]) => r.endsWith('/claim'))).toBe(false);
   });
 
-  test('cascade cap: agent-DM chat.mentions beyond the cap are declined without a spawn or a claim', async () => {
+  test('cascade cap prices an agent-DM inbox page as one turn, not one turn per item', async () => {
     const { post } = makeClient({
       events: [
         makeClaimEvent({ _id: 'evt-a', payload: { content: 'hello', messageId: 'msg-1', dmKind: 'agent-agent' } }),
@@ -1720,7 +1820,8 @@ describe('performRun — ADR-018 enforcement', () => {
       ],
     });
     const spawn = jest.fn(async () => ({ text: 'NO_REPLY' }));
-    // DM-backed chat.mentions stay locally bounded when grace is disabled.
+    // DM-backed chat.mentions stay locally bounded when grace is disabled,
+    // but this pair is one inbox turn.
     const { stop } = run(
       { name: 'stub', detect: stubAdapter.detect, spawn },
       { cascadeCap: 1, cascadeAddressedGrace: 0 },
@@ -1728,35 +1829,19 @@ describe('performRun — ADR-018 enforcement', () => {
     await drainMicrotasks();
     stop();
 
-    // First agent-triggered turn runs; the second hits the cap.
+    // Both claim CASes happen before the one turn; neither is dropped merely
+    // because it was the second event in the page.
     expect(spawn).toHaveBeenCalledTimes(1);
     expect(post).toHaveBeenCalledWith(
       '/api/agents/runtime/events/evt-b/ack',
-      {
-        result: {
-          outcome: 'no_action',
-          reason: 'cascade-cap',
-          details: {
-            messageId: 'msg-2',
-            streak: 1,
-            cap: 1,
-            addressedGrace: 0,
-            resetMs: 600000,
-            addressed: true,
-            graceApplied: false,
-          },
-        },
-      },
+      { result: { outcome: 'no_action' } },
     );
-    // The declined event never reached the claim step.
-    expect(post.mock.calls.filter(([r]) => r.endsWith('/claim'))).toHaveLength(1);
+    expect(post.mock.calls.filter(([r]) => r.endsWith('/claim'))).toHaveLength(2);
   });
 
-  test('cascade cap: the env vars reach the governor, not just the run() params', async () => {
-    // Pins the DELIVERY, not the constant. Extracting the literals into a
-    // resolver is worth nothing if the run loop keeps its own copy — and a
-    // resolver-only unit test cannot tell the difference. Same scenario as the
-    // test above, with the two values arriving from the environment instead.
+  test('a batch avoids manufacturing cascade refusals from its own sibling events', async () => {
+    // Two legacy direct-address events used to create two turns and price the
+    // second against the first. The page now has one admission decision.
     const prior = {
       cap: process.env.COMMONLY_CASCADE_CAP,
       grace: process.env.COMMONLY_CASCADE_ADDRESSED_GRACE,
@@ -1781,22 +1866,7 @@ describe('performRun — ADR-018 enforcement', () => {
 
       expect(spawn).toHaveBeenCalledTimes(1);
       expect(post).toHaveBeenCalledWith(
-        '/api/agents/runtime/events/evt-b/ack',
-        {
-          result: {
-            outcome: 'no_action',
-            reason: 'cascade-cap',
-            details: {
-              messageId: 'msg-2',
-              streak: 1,
-              cap: 1,
-              addressedGrace: 0,
-              resetMs: 600000,
-              addressed: true,
-              graceApplied: false,
-            },
-          },
-        },
+        '/api/agents/runtime/events/evt-b/ack', { result: { outcome: 'no_action' } },
       );
     } finally {
       if (prior.cap === undefined) delete process.env.COMMONLY_CASCADE_CAP;
@@ -1806,7 +1876,7 @@ describe('performRun — ADR-018 enforcement', () => {
     }
   });
 
-  test('cascade cap: a legacy direct-address event gets a bounded grace, then is capped too', async () => {
+  test('one composite turn admits all legacy direct-address items in its page', async () => {
     // Mention types are producer-dampened and exempted separately. Legacy
     // direct-address vocabulary remains on the local bounded-grace path.
     const { post } = makeClient({
@@ -1829,25 +1899,10 @@ describe('performRun — ADR-018 enforcement', () => {
     await drainMicrotasks();
     stop();
 
-    // cap 1 + grace 1 = two addressed turns admitted, the third declined.
-    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(spawn).toHaveBeenCalledTimes(1);
     expect(post).toHaveBeenCalledWith(
       '/api/agents/runtime/events/evt-c/ack',
-      {
-        result: {
-          outcome: 'no_action',
-          reason: 'cascade-cap',
-          details: {
-            messageId: 'msg-3',
-            streak: 2,
-            cap: 1,
-            addressedGrace: 1,
-            resetMs: 600000,
-            addressed: true,
-            graceApplied: true,
-          },
-        },
-      },
+      { result: { outcome: 'no_action' } },
     );
   });
 
@@ -1882,15 +1937,11 @@ describe('performRun — ADR-018 enforcement', () => {
     await drainMicrotasks();
     stop();
 
-    // The mention is the second spawn. Before the exemption it was refused at
-    // the cap; without the completion-time record the final broadcast would
-    // instead be admitted.
-    expect(spawn).toHaveBeenCalledTimes(2);
+    // The whole page is one turn. The named item still remains visible beside
+    // both broadcasts, rather than arriving through a special blind path.
+    expect(spawn).toHaveBeenCalledTimes(1);
     expect(post).toHaveBeenCalledWith(
-      '/api/agents/runtime/events/evt-broadcast-after/ack',
-      expect.objectContaining({
-        result: expect.objectContaining({ outcome: 'no_action', reason: 'cascade-cap' }),
-      }),
+      '/api/agents/runtime/events/evt-broadcast-after/ack', { result: { outcome: 'no_action' } },
     );
   });
 
@@ -1933,10 +1984,9 @@ describe('performRun — ADR-018 enforcement', () => {
     await drainMicrotasks();
     stop();
 
-    // Two agent turns run: the first builds the streak, the third is admitted
-    // because the lost-claim human turn in between reset it. Before the fix
-    // the third was refused and this was 1.
-    expect(spawn).toHaveBeenCalledTimes(2);
+    // The human item resets before claim partition; the two remaining agent
+    // items share the single composite turn.
+    expect(spawn).toHaveBeenCalledTimes(1);
     expect(post).not.toHaveBeenCalledWith(
       '/api/agents/runtime/events/evt-c/ack',
       { result: { outcome: 'no_action', reason: 'cascade-cap' } },
@@ -1966,29 +2016,13 @@ describe('performRun — ADR-018 enforcement', () => {
     await drainMicrotasks();
     stop();
 
-    // The refusal happened — without this the assertion below passes vacuously
-    // on a run where nothing was ever capped.
+    // One page is one turn, so no sibling is refused by the cap.
     expect(post).toHaveBeenCalledWith(
       '/api/agents/runtime/events/evt-b/ack',
-      {
-        result: {
-          outcome: 'no_action',
-          reason: 'cascade-cap',
-          details: {
-            messageId: 'msg-2',
-            streak: 1,
-            cap: 1,
-            addressedGrace: 0,
-            resetMs: 600000,
-            addressed: true,
-            graceApplied: false,
-          },
-        },
-      },
+      { result: { outcome: 'no_action' } },
     );
     const refusal = log.mock.calls.map(([l]) => l).find((l) => l.includes('cascade cap:'));
-    expect(refusal).toBeDefined();
-    expect(refusal).not.toContain('addressed grace');
+    expect(refusal).toBeUndefined();
   });
 
   test('cascade: the resolved triple is logged at boot, marked as defaults', async () => {
@@ -2065,7 +2099,7 @@ describe('performRun — ADR-018 enforcement', () => {
     await drainMicrotasks();
     stop();
 
-    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(spawn).toHaveBeenCalledTimes(1);
     expect(post).toHaveBeenCalledWith(
       '/api/agents/runtime/events/evt-b/ack',
       { result: { outcome: 'no_action' } },
@@ -2218,10 +2252,10 @@ describe('performRun — ADR-018 enforcement', () => {
     await drainMicrotasks();
     stop();
 
-    // First race: no handicap. Second race, same pod, after a win: yielded.
-    expect(spawn).toHaveBeenCalledTimes(2);
-    expect(sleeps).toHaveLength(1);
-    expect(sleeps[0]).toBeGreaterThanOrEqual(3000);
+    // Both races entered the same batch before either could become a prior
+    // winner; the handicap applies to the NEXT inbox page, not a sibling.
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(sleeps).toHaveLength(0);
     expect(post.mock.calls.filter(([r]) => r.endsWith('/claim'))).toHaveLength(2);
   });
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "license": "Apache-2.0",
   "description": "The Commonly CLI \u2014 connect agents, manage pods, iterate fast",
   "type": "module",

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -223,6 +223,11 @@ const PROMPT_EVENT_TYPES = new Set([
   'first_contact',
 ]);
 
+// Consultations have a per-request private response channel, rather than a
+// pod-chat delivery. They stay on their existing single-event path; every
+// event that represents the shared pod inbox is batched below.
+const PRIVATE_RESPONSE_EVENT_TYPES = new Set(['agent.ask', 'agent.ask.response']);
+
 // ── default environment for adapters that benefit from auto-MCP wiring ─────
 
 // Adapters that can consume `mcp[]` from the resolved environment spec.
@@ -746,6 +751,10 @@ export const performRun = ({
   chatCharLimit = 400,
   maxChatChunks = 3,
   claimYieldDelayMs = 3000,
+  // ADR-024 D3: a poll is an inbox batch, not ten independent interrupts.
+  // Kept injectable for small-page regression cases; the runtime ships with
+  // the server's ordinary ten-event page.
+  inboxBatchLimit = 10,
   sleepImpl = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); }),
 }) => {
   const client = createClient({ instance: instanceUrl, token });
@@ -793,6 +802,7 @@ export const performRun = ({
   // workspace path replaces the /tmp default.
   const agentCwd = workspacePath || join(tmpdir(), 'commonly-agents', agentName);
   if (!existsSync(agentCwd)) mkdirSync(agentCwd, { recursive: true });
+  const batchLimit = Math.min(50, Math.max(1, Number(inboxBatchLimit) || 10));
 
   const processEvent = async (event) => {
     const eventPodId = event.podId || podId;
@@ -1102,7 +1112,7 @@ export const performRun = ({
         }
       }
     }
-    const heartbeatControlReply = event.type === 'heartbeat'
+    const heartbeatControlReply = (event.type === 'heartbeat' || event.payload?.hasHeartbeat === true)
       && /^(HEARTBEAT_OK|HEARTBEAT_NOOP)$/i.test(replyText);
     const silentReply = !replyText || replyText === 'NO_REPLY' || heartbeatControlReply;
     let delivered = agentPostedItself;
@@ -1253,38 +1263,322 @@ export const performRun = ({
     return { outcome: delivered ? 'posted' : 'no_action' };
   };
 
+  // ADR-024 D3: the batch header states the real inbox count even when we cap
+  // copied bodies. The cap is the fetched page itself: never acknowledge a
+  // claimed event whose body the one turn did not receive. Additional pending
+  // events stay in the kernel queue and are cued in the header for a later
+  // pull, rather than being silently consumed here.
+  const buildInboxPrompt = (entries, inboxCount = entries.length) => {
+    const BODY_LIMIT = batchLimit;
+    const bodies = entries.slice(0, BODY_LIMIT).map((entry, index) => {
+      const messageId = entry.event.payload?.messageId;
+      const prefix = [
+        `Event ${index + 1}/${entries.length}: ${entry.event.type}`,
+        messageId ? `message ${messageId}` : null,
+      ].filter(Boolean).join(' — ');
+      const claimContext = entry.readOnly
+        ? `${peerHoldsFrame(entry.holder, messageId)}\n`
+          + '[This item is read-only context: a peer won its binding claim. Do not act on it.]\n'
+        : (entry.peerFrame ? `${entry.peerFrame}\n` : '');
+      const body = entry.prompt || '[No usable prompt was delivered for this item.]';
+      return `${prefix}\n${claimContext}${body}`;
+    });
+    const omitted = Math.max(0, inboxCount - bodies.length);
+    return [
+      `[Inbox batch: ${inboxCount} new event${inboxCount === 1 ? '' : 's'} in this pod. `
+        + 'This is one turn: read the included items together, then decide what needs YOU.]',
+      ...bodies,
+      ...(omitted > 0
+        ? [`[${omitted} more event${omitted === 1 ? '' : 's'} arrived. Their count is real; pull pod context if needed.]`]
+        : []),
+      'Do not narrate the inbox. Post only an action or a materially useful response; otherwise return NO_REPLY.',
+    ].join('\n\n');
+  };
+
+  const batchAdmissionResult = (event, admission) => ({
+    outcome: 'no_action',
+    reason: 'cascade-cap',
+    details: {
+      messageId: event?.payload?.messageId || null,
+      streak: admission.streak,
+      cap: cascadeSettings.cap,
+      addressedGrace: cascadeSettings.addressedGrace,
+      resetMs: cascadeSettings.resetMs,
+      addressed: admission.addressed,
+      graceApplied: admission.graceApplied,
+    },
+  });
+
+  // Claim the binding portion before the ONE composite spawn. A lost binding
+  // claim is not discarded: it remains in the model's context with the same
+  // peer frame the single-event path already uses, but is explicitly read-only.
+  // Advisory losses retain their existing peer-aware behaviour.
+  const processEventBatch = async (events, inboxCount = events.length) => {
+    const eventPodId = events[0]?.podId || podId;
+    if (!eventPodId || events.some((event) => (event.podId || podId) !== eventPodId)) {
+      throw new Error('Inbox batch crossed pod boundaries; refusing to mix private pod context');
+    }
+
+    const entries = events.map((event) => ({
+      event,
+      prompt: extractPrompt(event),
+      result: null,
+      claimKeeper: null,
+      peerFrame: null,
+      readOnly: false,
+      holder: null,
+    }));
+
+    // Duplicate deliveries have already completed locally. Re-ack them but do
+    // not spend the new batch turn displaying old work as if it were new.
+    const seenEventIds = new Set();
+    for (const entry of entries) {
+      const eventId = String(entry.event._id);
+      if (seenEventIds.has(eventId) || wasEventHandled(agentName, entry.event._id)) {
+        entry.result = { outcome: 'no_action', reason: 'duplicate-delivery' };
+        log(`[${entry.event.type}] duplicate delivery ${entry.event._id} — re-acking without batch spawn`);
+      } else {
+        seenEventIds.add(eventId);
+      }
+      if (entry.result?.reason === 'duplicate-delivery') {
+        continue;
+      }
+      if (!entry.prompt) {
+        entry.result = { outcome: 'no_action', reason: 'no-prompt' };
+        log(`[${entry.event.type}] no prompt — no-op`);
+        onError?.(Object.assign(
+          new Error(
+            `${entry.event.type} event ${entry.event._id} was acked WITHOUT a spawn: `
+            + 'payload carried no content and no messageId. If this wake mattered, its producer is sending an unusable payload.',
+          ),
+          { code: 'agent_event_skipped_no_prompt', eventId: entry.event._id },
+        ));
+      }
+    }
+
+    const snapshotMessages = async () => {
+      try {
+        const { messages = [] } = await client.get(
+          `/api/agents/runtime/pods/${eventPodId}/messages`, { limit: 10 },
+        );
+        return messages;
+      } catch {
+        return null;
+      }
+    };
+    const preSpawn = await snapshotMessages();
+    const preSpawnIds = preSpawn
+      ? new Set(preSpawn.map((message) => String(message._id || message.id)))
+      : null;
+    const activeEntries = entries.filter((entry) => !entry.result);
+    const triggers = activeEntries.map((entry) => classifyTrigger(entry.event, preSpawn));
+    const trigger = triggers.includes('human') ? 'human'
+      : (triggers.includes('agent') ? 'agent' : 'unknown');
+    if (trigger === 'human') cascadeGovernor.record(eventPodId, trigger);
+    const admissionEvent = activeEntries.find((entry) => ADDRESSED_EVENT_TYPES.has(entry.event.type))
+      || activeEntries[0];
+    if (admissionEvent) {
+      const admission = cascadeGovernor.admit(
+        eventPodId,
+        trigger,
+        admissionEvent.event.type,
+        admissionEvent.event.payload,
+      );
+      if (!admission.allowed) {
+        for (const entry of activeEntries) {
+          entry.result = batchAdmissionResult(entry.event, admission);
+        }
+        return { entries };
+      }
+    }
+
+    const bindingEntries = activeEntries.filter((entry) => (
+      entry.event.type === 'message.posted' && entry.event.payload?.messageId
+    ));
+    if (bindingEntries.length > 0) {
+      const yieldMs = claimHandicap.yieldDelayMs(eventPodId);
+      if (yieldMs > 0) {
+        log(`[inbox.batch] yielding ${yieldMs}ms before claiming ${bindingEntries.length} binding event${bindingEntries.length === 1 ? '' : 's'}`);
+        await sleepImpl(yieldMs);
+      }
+    }
+
+    for (const entry of activeEntries) {
+      const messageId = entry.event.payload?.messageId;
+      if (!messageId || !CLAIMABLE_EVENT_TYPES.has(entry.event.type)) continue;
+      const claimKeeper = createClaimKeeper(client, {
+        messageId,
+        podId: eventPodId,
+        leaseSeconds: claimLeaseSeconds,
+        log: (line) => log(`[${entry.event.type}] ${line}`),
+        setIntervalImpl,
+        clearIntervalImpl,
+      });
+      const claim = await claimKeeper.acquire();
+      if (claim.claimed) {
+        entry.claimKeeper = claimKeeper;
+        claimKeeper.startRenewal();
+        if (entry.event.type === 'message.posted') claimHandicap.recordWin(eventPodId);
+      } else if (!claim.failOpen) {
+        entry.holder = claim.holder;
+        if (entry.event.type === 'message.posted') {
+          // A reply to this seat's own message is direct-address evidence,
+          // even though its transport type is the broadcast-shaped
+          // `message.posted`. Preserve the existing ADR-018/TASK-058
+          // peer-aware exception; D3a otherwise partitions lost bindings as
+          // read-only so a generic broadcast cannot widen itself after CAS.
+          if (entry.event.payload?.repliesToYourMessage === true) {
+            entry.peerFrame = peerHoldsFrame(claim.holder, messageId);
+            continue;
+          }
+          // D3a's partition: no later model judgement can widen this item's
+          // authority after a peer won the binding CAS.
+          entry.readOnly = true;
+          entry.result = { outcome: 'no_action', reason: 'claim-held' };
+          claimHandicap.recordLoss(eventPodId);
+        } else {
+          entry.peerFrame = peerHoldsFrame(claim.holder, messageId);
+        }
+      } else {
+        log(`[${entry.event.type}] claim unavailable (${claim.error?.message || 'unknown error'}) — proceeding unguarded`);
+      }
+    }
+
+    const actionEntries = activeEntries.filter((entry) => !entry.result);
+    if (actionEntries.length === 0) return { entries };
+
+    const claimKeepers = actionEntries
+      .map((entry) => entry.claimKeeper)
+      .filter(Boolean);
+    const compositeClaimKeeper = claimKeepers.length > 0 ? {
+      isLost: () => claimKeepers.some((keeper) => keeper.isLost()),
+      getHolder: () => claimKeepers.find((keeper) => keeper.isLost())?.getHolder(),
+    } : null;
+    const batchEvent = {
+      ...actionEntries[0].event,
+      _id: `batch-${actionEntries[0].event._id}`,
+      type: 'inbox.batch',
+      payload: {
+        ...actionEntries[0].event.payload,
+        batchEventIds: entries.map((entry) => String(entry.event._id)),
+        hasHeartbeat: entries.some((entry) => entry.event.type === 'heartbeat'),
+      },
+    };
+    let turnResult;
+    try {
+      turnResult = await runTurn({
+        event: batchEvent,
+        eventPodId,
+        prompt: buildInboxPrompt(entries, inboxCount),
+        preSpawnIds,
+        snapshotMessages,
+        claimKeeper: compositeClaimKeeper,
+        trigger,
+      });
+      for (const entry of actionEntries) entry.result = turnResult;
+      return { entries };
+    } finally {
+      await Promise.all(actionEntries
+        .filter((entry) => entry.claimKeeper)
+        .map(async (entry) => {
+          // Preserve ADR-018 D6.1 per binding message: a silent human
+          // broadcast may be handed to one remaining listener, while every
+          // other completed batch item closes normally.
+          const claimOutcome = entry.event.type === 'message.posted'
+            && entry.event.payload?.senderIsHuman === true
+            && turnResult?.outcome === 'no_action' && !turnResult?.reason
+            ? 'declined'
+            : (turnResult ? 'completed' : undefined);
+          await entry.claimKeeper.release(claimOutcome);
+        }));
+    }
+  };
+
   const tick = async () => {
     if (!running) return;
     let nextPollDelayMs = intervalMs;
     try {
-      // ONE event per fetch, because the fetch IS the claim.
-      //
-      // `AgentEventService.list()` does not hand back a preview — it marks
-      // every candidate `delivered` with `$inc: { attempts: 1 }` before
-      // returning. This loop then processes them SERIALLY, one full model
-      // turn each. So asking for 10 claims 10 and starts 1.
-      //
-      // The nine it cannot start are then reclaimed out from under it: the
-      // backend requeues `delivered` rows older than
-      // `requeueDeliveredMinutes` (default 10, swept on `*/10`), and turns
-      // routinely outlast that — measured on the pod-architect seat over
-      // 11.5h: median 128s, p90 669s, 13 turns over 600s, max 1153s. Each
-      // sweep returns the untouched siblings to `pending` at `attempts + 1`,
-      // and `attempts >= 3` retires an event to `failed`, which is terminal
-      // and invisible to `list()`. That cap exists to bound POISON events;
-      // over-claiming feeds it work no model ever saw, so a mention can be
-      // dropped without once being read.
-      //
-      // `limit: 1` costs nothing: capacity here is one turn at a time
-      // regardless, and the poll interval is 5s. It only stops the loop
-      // claiming work it has no way to begin.
-      const { events = [] } = await client.get('/api/agents/runtime/events', {
-        agentName, instanceId, limit: 1,
+      // ADR-024 D3: this is an inbox fetch, not a stream of interrupts. The
+      // backend returns one pod's oldest pending batch, so every delivered row
+      // below reaches the SAME composite turn before it can age into the
+      // requeue sweep. The service selects the pod before claiming any row;
+      // do not reintroduce a mixed-pod `limit: 10` here.
+      const { events = [], inboxCount } = await client.get('/api/agents/runtime/events', {
+        agentName, instanceId, limit: batchLimit,
       });
       consecutiveAuthErrors = 0;
       consecutivePollFailures = 0;
+      // A deployed CLI can briefly run against an older server that still
+      // returns multiple pods in one page. Preserve pod privacy in that
+      // migration window by partitioning locally. Current servers produce one
+      // group, so the normal path remains one tick → one turn.
+      const eventGroups = new Map();
       for (const event of events) {
+        const eventPodId = event.podId || podId;
+        const key = PRIVATE_RESPONSE_EVENT_TYPES.has(event.type)
+          ? `private:${event._id}`
+          : (eventPodId || `private:${event._id}`);
+        const group = eventGroups.get(key) || [];
+        group.push(event);
+        eventGroups.set(key, group);
+      }
+      for (const group of eventGroups.values()) {
         if (!running) break;
+        if ((group[0].podId || podId) && !PRIVATE_RESPONSE_EVENT_TYPES.has(group[0].type)) {
+          let batch;
+          try {
+            batch = await processEventBatch(group, inboxCount);
+          } catch (err) {
+            consecutiveSpawnFailures += 1;
+            const retry = spawnRetryPolicy({
+              error: err,
+              consecutiveFailures: consecutiveSpawnFailures,
+              intervalMs,
+              jitterRatio: spawnJitterRatio,
+            });
+            nextPollDelayMs = retry.delayMs;
+            const event = group[0];
+            const wrapped = new Error(
+              `inbox batch processing failed (${retry.failureClass}; ${consecutiveSpawnFailures} consecutive) `
+              + `— ${group.length} events remain unacked; ${retry.circuitOpen ? 'circuit open' : 'retry scheduled'}, `
+              + `next probe in ${formatRetryDelay(retry.delayMs)}: ${err.message}`,
+              { cause: err },
+            );
+            Object.assign(wrapped, {
+              code: 'agent_spawn_retry_scheduled',
+              failureClass: retry.failureClass,
+              consecutiveFailures: consecutiveSpawnFailures,
+              retryAfterMs: retry.delayMs,
+              circuitOpen: retry.circuitOpen,
+              eventId: event._id,
+            });
+            if (onError) onError(wrapped);
+            else log(`[inbox.batch] ${wrapped.message}`);
+            break;
+          }
+          const batchSpawned = batch.entries.some((entry) => (
+            entry.result?.outcome === 'posted'
+            || (entry.result?.outcome === 'no_action' && !entry.result?.reason)
+          ));
+          if (batchSpawned) consecutiveSpawnFailures = 0;
+          for (const entry of batch.entries) {
+            const event = entry.event;
+            if (entry.result?.reason !== 'duplicate-delivery') {
+              recordHandledEvent(agentName, event._id);
+            }
+            try {
+              const deliveryId = event.payload?.deliveryId;
+              await client.post(`/api/agents/runtime/events/${event._id}/ack`, {
+                result: entry.result,
+                ...(typeof deliveryId === 'string' && deliveryId ? { deliveryId } : {}),
+              });
+            } catch (ackErr) {
+              onError?.(new Error(`Ack failed for ${event._id}: ${ackErr.message}`));
+            }
+          }
+          continue;
+        }
+        const [event] = group;
         let result;
         if (wasEventHandled(agentName, event._id)) {
           result = { outcome: 'no_action', reason: 'duplicate-delivery' };


### PR DESCRIPTION
Implements ADR-024 D3/D3a in the deployed agent run loop.

- Serves the runtime HTTP poller one Pod-scoped page with a true inbox count; legacy bot and WebSocket replay stays cross-pod.
- Runs each shared-pod page as one composite turn, with all fetched bodies, a true-count header, and per-event ack only after that turn.
- Claims binding message.posted items before the turn; a lost generic binding stays read-only, while direct reply evidence retains the existing peer-aware exception.
- Preserves private consultation routing and heartbeat control semantics.
- Adds the query index, route/service contracts, and CLI batch/claim regression coverage.

Validation:
- cli npm test -- --runInBand (29 suites, 401 passed, 10 skipped)
- backend focused AgentEvent service/lifecycle/delivery-nonce tests (51 passed)
- backend npm run tsc:check
- backend clawdbot E2E remains blocked locally before tests load by the shared Node 26 dependency error in buffer-equal-constant-time via jsonwebtoken; the added E2E assertion is therefore covered by service/unit contracts here.