### PR TITLE
fix: make every Talk to action open the agent room

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -958,6 +958,7 @@
       "empty": "No artifacts yet — share Notion, Sheets, or Figma links and they'll appear here."
     },
     "members": {
+      "participants": "Participants",
       "invite": "Invite",
       "inviteTitle": "Invite people or add an agent to this pod",
       "manage": "Manage",
@@ -1436,7 +1437,9 @@
       "activeInPods_other": "Active in {{count}} pods",
       "memories_one": "{{count}} memory",
       "memories_other": "{{count}} memories",
-      "talkTo": "Talk to {{name}}"
+      "talkTo": "Talk to {{name}}",
+      "opening": "Opening…",
+      "openRoomFailed": "The 1:1 with this agent could not be opened."
     },
     "pods": {
       "title": "Pods",
@@ -1589,7 +1592,8 @@
     },
     "empty": {
       "noMatch": "No pods match your search.",
-      "noPods": "No pods yet. Create one to get started."
+      "noPods": "No pods yet. Create one to get started.",
+      "noDirectMessages": "No direct messages yet — open one from an agent's card."
     },
     "meta": {
       "directMessage": "Direct message",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -955,6 +955,7 @@
       "empty": "还没有产物 — 分享 Notion、Sheets 或 Figma 链接，它们会显示在这里。"
     },
     "members": {
+      "participants": "参与者",
       "invite": "邀请",
       "inviteTitle": "邀请他人或向此 Pod 添加智能体",
       "manage": "管理",
@@ -1430,7 +1431,9 @@
       "activeInPods_other": "活跃于 {{count}} 个 Pod",
       "memories_one": "{{count}} 条记忆",
       "memories_other": "{{count}} 条记忆",
-      "talkTo": "与 {{name}} 对话"
+      "talkTo": "与 {{name}} 对话",
+      "opening": "正在打开…",
+      "openRoomFailed": "无法打开与该智能体的一对一对话。"
     },
     "pods": {
       "title": "Pod",
@@ -1583,7 +1586,8 @@
     },
     "empty": {
       "noMatch": "没有匹配的 Pod。",
-      "noPods": "还没有 Pod。创建一个开始使用。"
+      "noPods": "还没有 Pod。创建一个开始使用。",
+      "noDirectMessages": "还没有私信——从智能体卡片打开一个。"
     },
     "meta": {
       "directMessage": "私信",

--- a/frontend/src/v2/__tests__/V2AgentProfileMemoryWrite.test.tsx
+++ b/frontend/src/v2/__tests__/V2AgentProfileMemoryWrite.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import V2AgentProfile from '../agents/V2AgentProfile';
 import i18n, { i18nReady } from '../../i18n';
 
 jest.mock('axios', () => {
-  const profileClient = { get: jest.fn() };
+  const profileClient = { get: jest.fn(), post: jest.fn() };
   return {
     __esModule: true,
     default: { create: jest.fn(() => profileClient) },
@@ -20,7 +20,7 @@ jest.mock('../components/V2Avatar', () => ({
   default: () => null,
 }));
 
-const profileClient = (jest.requireMock('axios') as { __profileClient: { get: jest.Mock } }).__profileClient;
+const profileClient = (jest.requireMock('axios') as { __profileClient: { get: jest.Mock; post: jest.Mock } }).__profileClient;
 
 const renderProfile = () => render(
   <MemoryRouter initialEntries={['/v2/agents/claude-code/observer']}>
@@ -61,9 +61,11 @@ describe('V2AgentProfile memory-write visibility', () => {
   beforeEach(() => {
     window.localStorage.clear();
     jest.clearAllMocks();
-    profileClient.get.mockResolvedValue(
-      profilePayload({ kind: 'durable', updatedAt: twoHoursAgo() }),
-    );
+    profileClient.get.mockImplementation((url: string) => {
+      if (url.startsWith('/api/agent-memory/')) return Promise.reject(new Error('not owner'));
+      return Promise.resolve(profilePayload({ kind: 'durable', updatedAt: twoHoursAgo() }));
+    });
+    profileClient.post.mockResolvedValue({ data: { room: { _id: 'room-scout' } } });
   });
 
   it('reports the kind of the latest agent-authored write', async () => {
@@ -73,13 +75,27 @@ describe('V2AgentProfile memory-write visibility', () => {
   });
 
   it('reports a housekeeping write without naming the section', async () => {
-    profileClient.get.mockResolvedValue(
-      profilePayload({ kind: 'bookkeeping', updatedAt: twoHoursAgo() }),
-    );
+    profileClient.get.mockImplementation((url: string) => {
+      if (url.startsWith('/api/agent-memory/')) return Promise.reject(new Error('not owner'));
+      return Promise.resolve(profilePayload({ kind: 'bookkeeping', updatedAt: twoHoursAgo() }));
+    });
     renderProfile();
 
     expect(await screen.findByText(/Last saved to internal bookkeeping \d+h ago\./)).toBeInTheDocument();
     // No section name reaches this page for any kind.
     expect(screen.queryByText(/Runtime metadata|Deduplication state|Long-term memory/)).toBeNull();
+  });
+
+  it('opens the same 1:1 room endpoint for a signed-in visitor', async () => {
+    window.localStorage.setItem('token', 'viewer-token');
+    renderProfile();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Talk to Observer' }));
+
+    await waitFor(() => expect(profileClient.post).toHaveBeenCalledWith(
+      '/api/agents/runtime/room',
+      { agentName: 'claude-code', instanceId: 'observer' },
+      { headers: { Authorization: 'Bearer viewer-token' } },
+    ));
   });
 });

--- a/frontend/src/v2/__tests__/V2LayoutSelection.test.tsx
+++ b/frontend/src/v2/__tests__/V2LayoutSelection.test.tsx
@@ -151,4 +151,17 @@ describe('V2Layout default pod selection', () => {
       expect(localStorage.getItem('v2:lastPodId')).toBe('workspace');
     });
   });
+
+  test('refreshes the membership-backed sidebar when navigation lands in a newly-created room', async () => {
+    mockPodsState.pods = [];
+    render(
+      <MemoryRouter initialEntries={['/v2/pods/new-room']}>
+        <Routes>
+          <Route path="/v2/pods/:podId" element={<V2Layout selectionMode="param" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(mockPodsState.refresh).toHaveBeenCalledTimes(1));
+  });
 });

--- a/frontend/src/v2/__tests__/V2PodInspectorAgentRoom.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodInspectorAgentRoom.test.tsx
@@ -1,0 +1,49 @@
+/* eslint-disable react/display-name */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2PodInspector from '../components/V2PodInspector';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+jest.mock('../hooks/useV2Api', () => ({
+  useV2Api: () => ({ get: jest.fn().mockResolvedValue({}), post: jest.fn(), patch: jest.fn(), del: jest.fn() }),
+}));
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ currentUser: { _id: 'human-1', username: 'sam' } }),
+}));
+jest.mock('../../context/SocketContext', () => ({
+  useSocket: () => ({ socket: null, connected: false }),
+}));
+jest.mock('../components/V2Avatar', () => () => <span data-testid="avatar" />);
+
+const detail = {
+  pod: { _id: 'room-1', name: 'Scout', type: 'agent-room', createdBy: { _id: 'human-1' } },
+  members: [
+    { _id: 'human-1', username: 'sam', isBot: false },
+    { _id: 'agent-1', username: 'scout', isBot: true },
+  ],
+  agents: [], messages: [], loading: false, error: null, sendError: null,
+  hasMore: false, loadingOlder: false, loadOlder: jest.fn(), refresh: jest.fn(), sendMessage: jest.fn(),
+};
+
+describe('V2PodInspector agent room', () => {
+  it('shows both 1:1 participants without exposing pod membership controls', () => {
+    render(
+      <MemoryRouter>
+        <V2PodInspector
+          detail={detail as any}
+          view={{ kind: 'overview' }}
+          onOpenMember={jest.fn()}
+          onOpenArtifact={jest.fn()}
+          onBack={jest.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('inspector-room-participants')).toHaveTextContent('sam');
+    expect(screen.getByTestId('inspector-room-participants')).toHaveTextContent('scout');
+    expect(screen.queryByRole('tab', { name: 'inspector.tabs.members' })).toBeNull();
+  });
+});

--- a/frontend/src/v2/__tests__/V2YourTeamTiers.test.tsx
+++ b/frontend/src/v2/__tests__/V2YourTeamTiers.test.tsx
@@ -1,4 +1,5 @@
 // @ts-nocheck
+/* eslint-disable react/display-name */
 // Wren spec §1 (Sam-ruled 2026-08-30): the roster renders as tiers, not a
 // wall. Pinned here: featured tier caps and is the ONLY place the liveness
 // dot exists; standard cards carry the always-visible talk icon (BEND-2
@@ -23,6 +24,8 @@ jest.mock('axios', () => {
 });
 
 const axios = jest.requireMock('axios').default;
+
+jest.mock('../components/V2Avatar', () => () => <span data-testid="team-avatar" />);
 
 const authValue = {
   currentUser: { _id: 'u1', username: 'sam', role: 'user' },
@@ -67,7 +70,10 @@ const renderPage = () => {
   );
 };
 
-afterEach(() => jest.clearAllMocks());
+afterEach(() => {
+  jest.clearAllMocks();
+  window.localStorage.clear();
+});
 
 describe('Your Team tiers', () => {
   test('recently active agents render featured — and only they carry the dot', async () => {
@@ -134,5 +140,18 @@ describe('Your Team tiers', () => {
     // — same verb, different concept was the confusion being removed.
     expect(screen.queryByRole('button', { name: 'Connect' })).toBeNull();
     expect(screen.queryByText('Connect your own agent')).toBeNull();
+  });
+
+  test('Talk to opens the agent-room endpoint directly instead of routing through the profile', async () => {
+    axios.post.mockResolvedValue({ data: { room: { _id: 'room-fable' } } });
+    window.localStorage.setItem('token', 'jwt');
+    renderPage();
+    fireEvent.click(await screen.findByRole('button', { name: 'Talk to' }));
+
+    await waitFor(() => expect(axios.post).toHaveBeenCalledWith(
+      '/api/agents/runtime/room',
+      { agentName: 'fable', instanceId: 'lead', podId: 'p1' },
+      { headers: { Authorization: 'Bearer jwt' } },
+    ));
   });
 });

--- a/frontend/src/v2/__tests__/useV2PodDetailPodChange.test.tsx
+++ b/frontend/src/v2/__tests__/useV2PodDetailPodChange.test.tsx
@@ -1,0 +1,59 @@
+// @ts-nocheck
+// A room switch must be a clean boundary: a previous room's response may land
+// late, but it must never paint under the new room header.
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useV2PodDetail } from '../hooks/useV2PodDetail';
+
+const mockApi = { get: jest.fn(), post: jest.fn() };
+jest.mock('../hooks/useV2Api', () => ({ useV2Api: () => mockApi }));
+jest.mock('../../context/SocketContext', () => ({
+  useSocket: () => ({ socket: null, connected: false, joinPod: jest.fn(), leavePod: jest.fn() }),
+}));
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ currentUser: { _id: 'human-1' } }),
+}));
+
+const deferred = () => {
+  let resolve;
+  const promise = new Promise((done) => { resolve = done; });
+  return { promise, resolve };
+};
+
+describe('useV2PodDetail room changes', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('clears immediately and rejects a late response from the previous room', async () => {
+    const oldMessages = deferred();
+    const newMessages = deferred();
+    mockApi.get.mockImplementation((url) => {
+      if (url === '/api/messages/old-room?limit=50') return oldMessages.promise;
+      if (url === '/api/messages/new-room?limit=50') return newMessages.promise;
+      if (url.includes('/agents')) return Promise.resolve({ agents: [] });
+      const id = url.includes('new-room') ? 'new-room' : 'old-room';
+      return Promise.resolve({ _id: id, name: id, members: [] });
+    });
+
+    const { result, rerender } = renderHook(({ podId }) => useV2PodDetail(podId), {
+      initialProps: { podId: 'old-room' },
+    });
+
+    act(() => rerender({ podId: 'new-room' }));
+    expect(result.current.messages).toEqual([]);
+
+    await act(async () => {
+      oldMessages.resolve([{
+        id: 'old-message', pod_id: 'old-room', content: 'must not leak', created_at: '2026-09-02T00:00:00Z',
+      }]);
+      await Promise.resolve();
+    });
+    expect(result.current.messages).toEqual([]);
+
+    await act(async () => {
+      newMessages.resolve([{
+        id: 'new-message', pod_id: 'new-room', content: 'new room only', created_at: '2026-09-02T00:00:01Z',
+      }]);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.messages.map((message) => message.id)).toEqual(['new-message']));
+  });
+});

--- a/frontend/src/v2/agents/V2AgentProfile.tsx
+++ b/frontend/src/v2/agents/V2AgentProfile.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import axios from 'axios';
 import getApiBaseUrl from '../../utils/apiBaseUrl';
@@ -114,9 +114,12 @@ const isAuthed = (): boolean =>
 const V2AgentProfile: React.FC = () => {
   const { t } = useTranslation();
   const { agentName, instanceId } = useParams<{ agentName: string; instanceId?: string }>();
+  const navigate = useNavigate();
   const [data, setData] = useState<AgentProfile | null>(null);
   const [state, setState] = useState<'loading' | 'ready' | 'error'>('loading');
   const [memIndex, setMemIndex] = useState<MemoryIndex | null>(null);
+  const [openingRoom, setOpeningRoom] = useState(false);
+  const [roomError, setRoomError] = useState<string | null>(null);
 
   const fetchProfile = useCallback(async () => {
     setState('loading');
@@ -208,6 +211,38 @@ const V2AgentProfile: React.FC = () => {
       setSavingAvatar(false);
     }
   };
+
+  // A public profile is a useful introduction, but it must not be a dead end
+  // for a signed-in teammate. The same room endpoint backs every first-DM
+  // entry point (Your Team, inspector, and this profile); it is idempotent, so
+  // this also returns an existing conversation without a fork in the flow.
+  const handleTalkTo = useCallback(async () => {
+    const token = typeof window !== 'undefined' ? window.localStorage.getItem('token') : null;
+    if (!token || !data?.agent) return;
+    setOpeningRoom(true);
+    setRoomError(null);
+    try {
+      const room = await getClient().post<{ room?: { _id?: string } }>(
+        '/api/agents/runtime/room',
+        {
+          agentName: data.agent.agentName,
+          instanceId: data.agent.instanceId || 'default',
+        },
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      const roomId = room.data?.room?._id;
+      if (!roomId) throw new Error('Agent room not returned');
+      navigate(`/v2/pods/${roomId}`);
+    } catch (err) {
+      const message = (err as { response?: { data?: { message?: string; error?: string; msg?: string } }; message?: string })
+        .response?.data?.message
+        || (err as { response?: { data?: { error?: string; msg?: string } } }).response?.data?.error
+        || (err as { response?: { data?: { msg?: string } } }).response?.data?.msg
+        || t('agentProfile.hero.openRoomFailed');
+      setRoomError(message);
+      setOpeningRoom(false);
+    }
+  }, [data, navigate, t]);
 
 
   if (state === 'loading') {
@@ -328,8 +363,22 @@ const V2AgentProfile: React.FC = () => {
               </div>
             )}
           </div>
-          <Link className="v2-aprofile__btn v2-aprofile__btn--primary" to={authed ? '/v2/agents' : '/v2/register'}>{t('agentProfile.hero.talkTo', { name: firstName })}</Link>
+          {authed ? (
+            <button
+              type="button"
+              className="v2-aprofile__btn v2-aprofile__btn--primary"
+              onClick={() => { void handleTalkTo(); }}
+              disabled={openingRoom}
+            >
+              {openingRoom
+                ? t('agentProfile.hero.opening')
+                : t('agentProfile.hero.talkTo', { name: firstName })}
+            </button>
+          ) : (
+            <Link className="v2-aprofile__btn v2-aprofile__btn--primary" to="/v2/register">{t('agentProfile.hero.talkTo', { name: firstName })}</Link>
+          )}
         </section>
+        {roomError && <div className="v2-aprofile__room-error" role="alert">{roomError}</div>}
 
         <div className="v2-aprofile__grid">
 

--- a/frontend/src/v2/agents/v2-agent-profile.css
+++ b/frontend/src/v2/agents/v2-agent-profile.css
@@ -58,6 +58,8 @@
 /* `.v2-root a { color: inherit }` (0,1,1) beats the single-class rules — re-assert. */
 .v2-root .v2-aprofile__btn--primary { color: #ffffff; }
 .v2-root .v2-aprofile__btn--ghost { color: var(--v2-text-primary); }
+.v2-root button.v2-aprofile__btn:disabled { cursor: wait; opacity: 0.72; }
+.v2-aprofile__room-error { margin: 12px 0 0; color: var(--v2-danger); font-size: 14px; }
 
 /* Main + centered states */
 .v2-aprofile__main { max-width: 1040px; margin: 0 auto; padding: 32px 24px 64px; }

--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import V2NavRail from './V2NavRail';
@@ -174,6 +174,20 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
 
   const selectedPodId = paramPodId || null;
   const detail = useV2PodDetail(selectedPodId);
+  // Agent-room creation happens outside this pod-list hook. After navigation,
+  // refresh the membership list once if that newly selected room is not in it
+  // yet, so it immediately appears in both All and DMs instead of waiting for
+  // a later full-shell refresh.
+  const refreshedMissingPodRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!selectedPodId || loading || pods.some((pod) => pod._id === selectedPodId)) {
+      if (pods.some((pod) => pod._id === selectedPodId)) refreshedMissingPodRef.current = null;
+      return;
+    }
+    if (refreshedMissingPodRef.current === selectedPodId) return;
+    refreshedMissingPodRef.current = selectedPodId;
+    void podsState.refresh();
+  }, [selectedPodId, pods, loading, podsState]);
   // Personal DMs are strictly 1:1. Keep agent-admin out of this set: it is
   // intentionally N:1 and remains invitable (ADR-001 §3.10).
   const inviteEnabled = Boolean(

--- a/frontend/src/v2/components/V2PodInspector.tsx
+++ b/frontend/src/v2/components/V2PodInspector.tsx
@@ -1473,6 +1473,28 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
     </section>
   );
 
+  // A room is deliberately 1:1, not a normal pod with an editable Members
+  // tab. That does not mean its participants disappear: showing both here is
+  // the confirmation that the "Talk to" action opened the intended private
+  // conversation without reintroducing invite/manage controls.
+  const roomParticipantsSection = isAgentRoom && (
+    <section className="v2-inspector__section v2-inspector__section--quiet" data-testid="inspector-room-participants">
+      <div className="v2-inspector__section-title">{t('inspector.members.participants')}</div>
+      {members.map((member) => {
+        const roleKey = memberRoleKey(member, ownerId, Boolean(member.isBot));
+        return (
+          <div key={`participant-${member._id || member.username}`} className="v2-inspector__member-row v2-inspector__member-row--static">
+            <V2Avatar name={member.username || t('inspector.unknownUser')} src={member.profilePicture || undefined} size="md" />
+            <span className="v2-inspector__member-meta">
+              <span className="v2-inspector__member-name">{member.username || t('inspector.unknownUser')}</span>
+              <span className="v2-inspector__member-role">{t(`inspector.roles.${roleKey}`)}</span>
+            </span>
+          </div>
+        );
+      })}
+    </section>
+  );
+
   const runStateSection = (
     <section className="v2-inspector__section">
       <div className="v2-inspector__section-title">{t('inspector.runState.title')}</div>
@@ -1894,6 +1916,7 @@ const V2PodInspector: React.FC<V2PodInspectorProps> = ({
                   )}
                   {progressSection}
                   {nowSection}
+                  {roomParticipantsSection}
                   {pod.description && goalSection}
                   {artifactsSection}
                 </>

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -620,7 +620,9 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
                       ? 'podsSidebar.discover.empty'
                       : 'podsSidebar.discover.joinedEmpty',
                   )
-                  : t('podsSidebar.empty.noPods'))}
+                  : (filter === 'private'
+                    ? t('podsSidebar.empty.noDirectMessages')
+                    : t('podsSidebar.empty.noPods')))}
             </div>
           )}
 

--- a/frontend/src/v2/hooks/useV2PodDetail.ts
+++ b/frontend/src/v2/hooks/useV2PodDetail.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useV2Api } from './useV2Api';
 import { V2Pod, V2PodMember } from './useV2Pods';
 import { useSocket } from '../../context/SocketContext';
@@ -231,10 +231,28 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
   const [sendError, setSendError] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
+  // A request for the room we just left can resolve after the next room has
+  // started loading. Keep both the pre-paint reset and every async write bound
+  // to the currently selected pod, so no previous room's messages can flash
+  // under a new DM header.
+  const activePodIdRef = useRef<string | null>(podId);
+  const refreshSequenceRef = useRef(0);
+
+  useLayoutEffect(() => {
+    activePodIdRef.current = podId;
+    refreshSequenceRef.current += 1;
+    setPod(null);
+    setMessages([]);
+    setAgents([]);
+    setError(null);
+    setSendError(null);
+    setHasMore(false);
+    setLoadingOlder(false);
+  }, [podId]);
 
   const fetchPod = useCallback(async (id: string) => {
     const result = await api.get<V2Pod>(`/api/pods/${id}`, { timeout: REQUEST_TIMEOUT_MS });
-    setPod(result);
+    if (activePodIdRef.current === id) setPod(result);
   }, [api]);
 
   const fetchMessages = useCallback(async (id: string) => {
@@ -244,13 +262,14 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
         { timeout: REQUEST_TIMEOUT_MS },
       );
       const list = Array.isArray(data) ? data : [];
+      if (activePodIdRef.current !== id) return;
       setMessages(chronologicalMessages(list.map(normalizeMessage)));
       // This endpoint returns a bare array with no envelope, so end-of-history
       // is inferred: a short page means there is nothing older behind it.
       setHasMore(list.length >= PAGE_SIZE);
     } catch (err) {
       const e = err as { response?: { status?: number } };
-      if (e.response?.status === 404) {
+      if (e.response?.status === 404 && activePodIdRef.current === id) {
         setMessages([]);
         setHasMore(false);
       } else throw err;
@@ -284,8 +303,10 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
         setHasMore(false);
         return;
       }
-      setMessages((prev) => mergeMessagesById(older, prev));
-      setHasMore(older.length >= PAGE_SIZE);
+      if (activePodIdRef.current === podId) {
+        setMessages((prev) => mergeMessagesById(older, prev));
+        setHasMore(older.length >= PAGE_SIZE);
+      }
     } catch {
       // Leave hasMore alone so the same button can be retried.
     } finally {
@@ -305,13 +326,14 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
         ...a,
         agentName: a.agentName || a.name || '',
       }));
-      setAgents(normalized);
+      if (activePodIdRef.current === id) setAgents(normalized);
     } catch {
-      setAgents([]);
+      if (activePodIdRef.current === id) setAgents([]);
     }
   }, [api]);
 
   const refresh = useCallback(async () => {
+    const refreshSequence = ++refreshSequenceRef.current;
     if (!podId) {
       setPod(null);
       setMessages([]);
@@ -328,6 +350,7 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
         fetchMessages(podId),
         fetchAgents(podId),
       ]);
+      if (refreshSequence !== refreshSequenceRef.current || activePodIdRef.current !== podId) return;
       if (messagesResult.status === 'rejected') {
         setMessages([]);
         const e = messagesResult.reason as { response?: { status?: number; data?: { error?: string; msg?: string } }; message?: string };
@@ -343,6 +366,7 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
         }
       }
     } catch (err) {
+      if (refreshSequence !== refreshSequenceRef.current || activePodIdRef.current !== podId) return;
       const e = err as { response?: { status?: number; data?: { error?: string; msg?: string } }; message?: string };
       const status = e.response?.status;
       if (status === 401 || status === 403) {
@@ -351,7 +375,9 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
         setError(e.response?.data?.error || e.response?.data?.msg || e.message || 'Failed to load pod');
       }
     } finally {
-      setLoading(false);
+      if (refreshSequence === refreshSequenceRef.current && activePodIdRef.current === podId) {
+        setLoading(false);
+      }
     }
   }, [podId, fetchPod, fetchMessages, fetchAgents]);
 


### PR DESCRIPTION
## Summary
- make the signed-in public agent-profile CTA open the same idempotent agent-room endpoint as Your Team
- refresh the sidebar after navigation to a newly-created room, add empty-DM guidance, and show both direct-room participants
- clear pod detail state before paint and reject late responses from a previous room

## Verification
- focused frontend suite: 18 tests passed
- frontend typecheck passed
- frontend production build passed

Follow-up for UX gate: confirm the direct DM lands in the composer within 1.5s and has no stale messages at t+300ms.