### PR TITLE
fix(v2): surface direct agent liveness

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -367,6 +367,13 @@
     "cancelReply": "Cancel reply",
     "replyingTo": "Replying to <author>{{author}}</author>:",
     "deliveryHint": "No agent was notified — @mention one to get a reply. Try <handle>@{{handle}}</handle>.",
+    "agentRoomLiveness": {
+      "neverConnected": "{{agentName}} isn't connected. Messages sent here will wait for this seat to connect.",
+      "goneDark": "{{agentName}} hasn't checked in recently. A reply may take longer.",
+      "unknown": "{{agentName}}'s availability is unknown. A reply may take longer.",
+      "waiting": "Waiting for {{agentName}} to reply…",
+      "timedOut": "{{agentName}} hasn't replied yet. Your message is still in this room."
+    },
     "typing": {
       "one": "{{name}} is thinking…",
       "two": "{{first}} and {{second}} are thinking…",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -367,6 +367,13 @@
     "cancelReply": "取消回复",
     "replyingTo": "回复 <author>{{author}}</author>：",
     "deliveryHint": "尚未通知任何智能体。@提及一个智能体即可让它回复，例如 <handle>@{{handle}}</handle>。",
+    "agentRoomLiveness": {
+      "neverConnected": "{{agentName}} 尚未连接。发送到这里的消息会等待该席位连接。",
+      "goneDark": "{{agentName}} 最近没有接入，回复可能需要更长时间。",
+      "unknown": "{{agentName}} 的可用状态未知，回复可能需要更长时间。",
+      "waiting": "正在等待 {{agentName}} 回复…",
+      "timedOut": "{{agentName}} 还没有回复。你的消息仍在此对话中。"
+    },
     "typing": {
       "one": "{{name}} 正在思考…",
       "two": "{{first}} 和 {{second}} 正在思考…",

--- a/frontend/src/v2/__tests__/V2PodChatStarter.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatStarter.test.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import React from 'react';
 import {
-  fireEvent, render, screen, waitFor,
+  act, fireEvent, render, screen, waitFor,
 } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
@@ -176,6 +176,106 @@ describe('V2PodChat starter prompts', () => {
 
     renderChat(makeAgentRoom(), { firstRunVisible: true });
     expect(screen.queryByRole('group', { name: 'Conversation starters' })).not.toBeInTheDocument();
+  });
+});
+
+describe('V2PodChat agent-room liveness', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    axios.get.mockResolvedValue({ data: { agents: [] } });
+  });
+
+  test('shows an unknown direct seat before the person sends a message', async () => {
+    axios.get.mockResolvedValue({
+      data: {
+        agents: [{
+          agentName: 'openclaw', instanceId: 'aria', displayName: 'Aria', state: 'unknown', isOwner: false,
+        }],
+      },
+    });
+    renderChat(makeAgentRoom());
+
+    expect(await screen.findByTestId('agent-room-liveness')).toHaveTextContent(
+      "Aria's availability is unknown",
+    );
+  });
+
+  test('a live direct seat shows a wait until it replies', async () => {
+    axios.get.mockResolvedValue({
+      data: {
+        agents: [{
+          agentName: 'openclaw', instanceId: 'aria', displayName: 'Aria', state: 'listening', isOwner: false,
+        }],
+      },
+    });
+    const sent = {
+      id: 'outgoing-1',
+      pod_id: 'agent-room-1',
+      user_id: 'u1',
+      content: 'Hello Aria',
+      message_type: 'text',
+      created_at: new Date().toISOString(),
+      user: { username: 'solo-user', isBot: false },
+    };
+    const detail = makeAgentRoom({ sendMessage: jest.fn().mockResolvedValue(sent) });
+    const view = renderChat(detail);
+
+    fireEvent.change(screen.getByPlaceholderText('Message Aria…'), { target: { value: 'Hello Aria' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+    expect(await screen.findByTestId('agent-reply-wait')).toHaveTextContent('Waiting for Aria to reply');
+    expect(screen.queryByTestId('agent-room-liveness')).not.toBeInTheDocument();
+
+    const reply = {
+      id: 'agent-reply-1',
+      pod_id: 'agent-room-1',
+      user_id: 'agent-1',
+      content: 'Hi!',
+      message_type: 'text',
+      created_at: new Date(Date.now() + 1_000).toISOString(),
+      user: { username: 'openclaw-aria', isBot: true },
+    };
+    view.rerender(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <V2PodChat detail={{ ...detail, messages: [sent, reply] }} />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+
+    await waitFor(() => expect(screen.queryByTestId('agent-reply-wait')).not.toBeInTheDocument());
+  });
+
+  test('turns an unanswered direct-message wait into a timeout message', async () => {
+    jest.useFakeTimers();
+    axios.get.mockResolvedValue({
+      data: {
+        agents: [{
+          agentName: 'openclaw', instanceId: 'aria', displayName: 'Aria', state: 'listening', isOwner: false,
+        }],
+      },
+    });
+    const sent = {
+      id: 'outgoing-timeout',
+      pod_id: 'agent-room-1',
+      user_id: 'u1',
+      content: 'Hello Aria',
+      message_type: 'text',
+      created_at: new Date().toISOString(),
+      user: { username: 'solo-user', isBot: false },
+    };
+    renderChat(makeAgentRoom({ sendMessage: jest.fn().mockResolvedValue(sent) }));
+
+    fireEvent.change(screen.getByPlaceholderText('Message Aria…'), { target: { value: 'Hello Aria' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('agent-reply-wait')).toHaveTextContent('Waiting for Aria to reply');
+
+    act(() => { jest.advanceTimersByTime(120_000); });
+    expect(screen.getByTestId('agent-reply-wait')).toHaveTextContent("Aria hasn't replied yet");
+    jest.useRealTimers();
   });
 });
 

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -99,6 +99,16 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).toContain('.v2-msg--grouped');
   });
 
+  test('direct-agent liveness stays above the composer as a stable, readable row', () => {
+    // A successful DM POST is not proof of an active seat. This row keeps
+    // liveness and the bounded reply wait outside the scrollable transcript
+    // and outside the textarea, so both remain visible while composing.
+    const status = ruleBody(v2, '.v2-chat__agent-room-status');
+    expect(status).toContain('margin: 8px 24px 0');
+    expect(status).toContain('font-size: 12px');
+    expect(ruleBody(v2, '.v2-chat__agent-room-status--wait')).toContain('background: var(--v2-accent-soft)');
+  });
+
   test('runtime vocabulary stays off Your Team cards (ADR-022 D1, ratified)', () => {
     // The chip shipped in violation of the ratified rule; the craft audit
     // (finding 2) removed it. This pins the removal against reintroduction.

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -26,6 +26,11 @@ import { agentKeyFor } from '../utils/agentKey';
 const PLAN_MODE_KEY = 'v2.podMode';
 const AGENT_DELIVERY_HINT_KEY = 'v2.agentDeliveryHint';
 const JUST_CREATED_POD_KEY = 'v2.justCreated';
+// A sent direct message is durable in the room, but it is not a reply. Give
+// the person a clear, bounded wait state instead of leaving the composer to
+// imply that the agent is working. Two minutes is long enough for a normal
+// turn and short enough to make an unavailable seat visible.
+const AGENT_REPLY_TIMEOUT_MS = 2 * 60 * 1000;
 
 const STARTER_PROMPT_KEYS = [
   'podChat.starters.introduce',
@@ -108,16 +113,33 @@ interface MentionItem {
 
 // #891 surface 1 — per-agent reachability from /api/pods/:podId/agent-states.
 // Only the states the kernel can derive HONESTLY for the agent's runtime
-// class arrive here; 'reachable'/'unknown' render nothing.
+// class arrive here. Shared-pod mention affordances stay quiet for
+// 'reachable'/'unknown'; a 1:1 room separately states returned uncertainty.
 type AgentReachState = 'listening' | 'gone-dark' | 'never-connected' | 'reachable' | 'unknown';
 interface AgentStateRow {
   agentName: string;
   instanceId: string;
+  displayName?: string;
   state: AgentReachState;
   isOwner: boolean;
   fixCommand?: string;
 }
 const REACH_NEEDS_WARNING = new Set<AgentReachState>(['gone-dark', 'never-connected']);
+const REACH_IS_ACTIVE = new Set<AgentReachState>(['listening', 'reachable']);
+
+interface DirectAgentIdentity {
+  username: string;
+  displayName: string;
+  state: AgentStateRow | null;
+}
+
+interface AwaitingAgentReply {
+  podId: string;
+  messageId: string;
+  agentName: string;
+  sentAt: number;
+  timedOut: boolean;
+}
 
 interface TypingAgentEntry {
   key: string;
@@ -236,6 +258,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
     messageId: string;
     mentionHandle: string;
   } | null>(null);
+  const [awaitingAgentReply, setAwaitingAgentReply] = useState<AwaitingAgentReply | null>(null);
   const deliveryHintShownPodsRef = useRef<Set<string>>(new Set());
   const [mode, setMode] = useState<PodMode>(pod ? readMode(pod._id) : 'plan');
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
@@ -343,6 +366,72 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
     });
     return map;
   }, [agentStates]);
+
+  // Agent rooms are exactly one human and one agent. Resolve that one agent
+  // through the same installation data that powers mentions, then attach the
+  // liveness row only when the status endpoint returned a matching row. An
+  // unavailable status read must never turn into a fabricated "offline" UI.
+  const directAgent = useMemo<DirectAgentIdentity | null>(() => {
+    if (pod?.type !== 'agent-room') return null;
+    // `isBot` is not reliable on every old member payload. Prefer a member
+    // that resolves against the active agent installation, then keep isBot as
+    // the backwards-compatible fallback.
+    const member = (members || []).find((candidate) => (agents || []).some((agent) => {
+      const rawName = ((agent as { name?: string; agentName?: string }).name || agent.agentName || '');
+      return buildAgentUsername(rawName, agent.instanceId) === (candidate?.username || '').toLowerCase();
+    })) || (members || []).find((candidate) => candidate?.isBot);
+    if (!member) return null;
+    const username = (member.username || '').toLowerCase();
+    const agent = (agents || []).find((candidate) => {
+      const rawName = ((candidate as { name?: string; agentName?: string }).name || candidate.agentName || '');
+      return buildAgentUsername(rawName, candidate.instanceId) === username;
+    });
+    const rawName = ((agent as { name?: string; agentName?: string } | undefined)?.name
+      || agent?.agentName
+      || username);
+    const rawInstance = agent?.instanceId || '';
+    const state = agentStateByHandle.get(rawInstance.toLowerCase())
+      || agentStateByHandle.get(rawName.toLowerCase())
+      || null;
+    return {
+      username,
+      displayName: agent?.displayName || agent?.profile?.displayName || state?.displayName || member.username || t('common.agent'),
+      state,
+    };
+  }, [pod?.type, members, agents, agentStateByHandle, t]);
+
+  // The direct-room wait ends only on the agent's actual reply (not when the
+  // POST succeeds) or after a bounded timeout. Clearing it on a pod change
+  // keeps a wait from one room from leaking into another.
+  useEffect(() => {
+    if (!awaitingAgentReply) return undefined;
+    if (pod?._id !== awaitingAgentReply.podId) {
+      setAwaitingAgentReply(null);
+      return undefined;
+    }
+    const receivedReply = messages.some((message) => {
+      if (String(message.id) === awaitingAgentReply.messageId) return false;
+      const sentOrLater = new Date(message.created_at || message.createdAt || 0).getTime()
+        >= awaitingAgentReply.sentAt;
+      const isDirectAgent = Boolean(message.user?.isBot)
+        || String(message.user?.username || '').toLowerCase() === directAgent?.username;
+      return sentOrLater && isDirectAgent;
+    });
+    if (receivedReply) {
+      setAwaitingAgentReply(null);
+      return undefined;
+    }
+    if (awaitingAgentReply.timedOut) return undefined;
+    const remaining = Math.max(0, AGENT_REPLY_TIMEOUT_MS - (Date.now() - awaitingAgentReply.sentAt));
+    const timeout = setTimeout(() => {
+      setAwaitingAgentReply((current) => (
+        current && current.messageId === awaitingAgentReply.messageId
+          ? { ...current, timedOut: true }
+          : current
+      ));
+    }, remaining);
+    return () => clearTimeout(timeout);
+  }, [awaitingAgentReply, pod?._id, messages, directAgent?.username]);
 
   useEffect(() => {
     if (pod) setMode(readMode(pod._id));
@@ -851,6 +940,18 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
   const botPair = isBotToBot
     ? botMembers.slice(0, 2).map((m) => m.username || t('common.agent'))
     : null;
+  const directAgentReach = directAgent?.state?.state;
+  const showDirectAgentLiveness = Boolean(
+    isAgentRoom && directAgent && directAgentReach && !REACH_IS_ACTIVE.has(directAgentReach),
+  );
+  const directAgentLivenessKey = directAgentReach === 'never-connected'
+    ? 'podChat.agentRoomLiveness.neverConnected'
+    : directAgentReach === 'gone-dark'
+      ? 'podChat.agentRoomLiveness.goneDark'
+      : 'podChat.agentRoomLiveness.unknown';
+  const showAwaitingAgentReply = Boolean(
+    isAgentRoom && awaitingAgentReply && awaitingAgentReply.podId === pod._id,
+  );
 
   const handleSend = async (override?: string) => {
     const text = (override ?? draft).trim();
@@ -886,6 +987,18 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
         threadTarget?.id || undefined,
       );
       if (created) {
+        // A direct-room post is not evidence that the agent is alive or
+        // working. Track the reply separately so the user gets a truthful
+        // "waiting" state until the agent speaks or the wait expires.
+        if (isAgentRoom && directAgent) {
+          setAwaitingAgentReply({
+            podId: pod._id,
+            messageId: String(created.id),
+            agentName: directAgent.displayName,
+            sentAt: Date.now(),
+            timedOut: false,
+          });
+        }
         const delivery = created.agentDelivery;
         const exampleAgent = agents.find((agent) => agent.status === 'active') || agents[0];
         // Same handle rule as the typeahead: human-chosen instanceId is the
@@ -1397,6 +1510,23 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                 </div>
               </div>
             ) : (
+            <>
+              {showDirectAgentLiveness && directAgent && (
+                <div className="v2-chat__agent-room-status" data-testid="agent-room-liveness" role="status">
+                  {t(directAgentLivenessKey, { agentName: directAgent.displayName })}
+                </div>
+              )}
+              {showAwaitingAgentReply && awaitingAgentReply && (
+                <div
+                  className={`v2-chat__agent-room-status v2-chat__agent-room-status--wait${awaitingAgentReply.timedOut ? ' v2-chat__agent-room-status--timeout' : ''}`}
+                  data-testid="agent-reply-wait"
+                  role="status"
+                >
+                  {awaitingAgentReply.timedOut
+                    ? t('podChat.agentRoomLiveness.timedOut', { agentName: awaitingAgentReply.agentName })
+                    : t('podChat.agentRoomLiveness.waiting', { agentName: awaitingAgentReply.agentName })}
+                </div>
+              )}
             <div className="v2-chat__composer">
               {threadTarget && (
                 <div className="v2-chat__reply-chip v2-chat__reply-chip--thread" role="status">
@@ -1562,6 +1692,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                 <span><kbd>{COMMAND_KEY}</kbd><kbd>{ENTER_KEY}</kbd> {t('podChat.composer.toSend')}</span>
               </div>
             </div>
+            </>
             )}
       </div>
     </main>

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -2034,6 +2034,35 @@ body.modern-ui.v2-canvas {
   flex-shrink: 0;
 }
 
+/* A 1:1 agent room must not make a successful POST look like an active
+   agent. The liveness row is deliberately adjacent to, but outside, the
+   composer: it remains visible while someone writes and never becomes part
+   of the scrollable transcript. */
+.v2-chat__agent-room-status {
+  margin: 8px 24px 0;
+  padding: 8px 10px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-bg-subtle);
+  color: var(--v2-text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.v2-chat__agent-room-status--wait {
+  border-color: var(--v2-accent-soft);
+  background: var(--v2-accent-soft);
+  color: var(--v2-accent-text);
+  font-weight: 600;
+}
+
+.v2-chat__agent-room-status--timeout {
+  border-color: var(--v2-border-strong);
+  background: var(--v2-bg-subtle);
+  color: var(--v2-text-secondary);
+  font-weight: 500;
+}
+
 .v2-chat__starter-prompts {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- show returned direct-seat liveness above the agent-room composer
- keep an explicit reply wait until the agent replies or two minutes pass
- cover unknown, live/reply, timeout, and CSS-presence paths

## Verification
- `./node_modules/.bin/jest src/v2/__tests__/V2PodChatStarter.test.tsx src/v2/__tests__/V2PodChatMentionState.test.tsx src/v2/__tests__/V2PodChatDeliveryHint.test.tsx src/v2/__tests__/v2-layout-invariants.test.ts --runInBand --silent`
- `npx tsc --noEmit`
- `npm run build`
- mutation: disabling the direct-room liveness condition fails exactly its new test