### PR TITLE
fix: scope pending approvals to pod members

### DIFF
--- a/backend/__tests__/unit/routes/activity.read.test.js
+++ b/backend/__tests__/unit/routes/activity.read.test.js
@@ -59,4 +59,17 @@ describe('activity read routes', () => {
     await request(app).post('/api/activity/mention-1/acknowledge').expect(200);
     expect(ActivityService.acknowledgeMention).toHaveBeenCalledWith('user123', 'mention-1');
   });
+
+  it('preserves an owner-gate 403 from the approval writer', async () => {
+    ActivityService.approveActivity.mockResolvedValueOnce({
+      success: false,
+      status: 403,
+      error: 'Only the workspace owner can decide this',
+    });
+
+    await request(app)
+      .post('/api/activity/approval-1/approve')
+      .send({ notes: 'Approve via Activity' })
+      .expect(403, { error: 'Only the workspace owner can decide this' });
+  });
 });

--- a/backend/__tests__/unit/routes/activity.read.test.js
+++ b/backend/__tests__/unit/routes/activity.read.test.js
@@ -60,16 +60,16 @@ describe('activity read routes', () => {
     expect(ActivityService.acknowledgeMention).toHaveBeenCalledWith('user123', 'mention-1');
   });
 
-  it('preserves an owner-gate 403 from the approval writer', async () => {
+  it('preserves a membership-gate 403 from the approval writer', async () => {
     ActivityService.approveActivity.mockResolvedValueOnce({
       success: false,
       status: 403,
-      error: 'Only the workspace owner can decide this',
+      error: 'Only pod members can decide this',
     });
 
     await request(app)
       .post('/api/activity/approval-1/approve')
       .send({ notes: 'Approve via Activity' })
-      .expect(403, { error: 'Only the workspace owner can decide this' });
+      .expect(403, { error: 'Only pod members can decide this' });
   });
 });

--- a/backend/__tests__/unit/services/activityService.decisionQueue.test.js
+++ b/backend/__tests__/unit/services/activityService.decisionQueue.test.js
@@ -23,7 +23,7 @@ const User = require('../../../models/User');
 const DecisionRequest = require('../../../models/DecisionRequest');
 const { pool } = require('../../../config/db-pg');
 
-const POD = { _id: 'pod-1', name: 'Sprint HQ', type: 'team' };
+const POD = { _id: 'pod-1', name: 'Sprint HQ', type: 'team', createdBy: 'u1' };
 const userChain = (doc) => ({ select: () => ({ lean: async () => doc }) });
 const taskChain = (rows) => ({ sort: () => ({ limit: () => ({ lean: async () => rows }) }) });
 const decisionChain = (rows) => ({ sort: () => ({ limit: () => ({ lean: async () => rows }) }) });
@@ -102,6 +102,19 @@ describe('ActivityService.getDecisionQueue', () => {
     expect(getPendingApprovals).toHaveBeenCalledWith('u1');
     expect(result.items).toEqual(expect.arrayContaining([
       expect.objectContaining({ kind: 'approval', id: 'activity-approval-1', title: 'scout requests approval' }),
+    ]));
+  });
+
+  test('does not present a member with an approval they cannot decide', async () => {
+    Pod.find.mockReturnValue({ select: () => ({ lean: async () => [{ ...POD, createdBy: 'owner-1' }] }) });
+    jest.spyOn(ActivityService, 'getPendingApprovals').mockResolvedValue([
+      { _id: 'activity-approval-1', content: 'Deploy?', podId: 'pod-1', createdAt: new Date() },
+    ]);
+
+    const result = await ActivityService.getDecisionQueue('member-1');
+
+    expect(result.items).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'approval', id: 'activity-approval-1' }),
     ]));
   });
 

--- a/backend/__tests__/unit/services/activityService.decisionQueue.test.js
+++ b/backend/__tests__/unit/services/activityService.decisionQueue.test.js
@@ -23,7 +23,7 @@ const User = require('../../../models/User');
 const DecisionRequest = require('../../../models/DecisionRequest');
 const { pool } = require('../../../config/db-pg');
 
-const POD = { _id: 'pod-1', name: 'Sprint HQ', type: 'team', createdBy: 'u1' };
+const POD = { _id: 'pod-1', name: 'Sprint HQ', type: 'team' };
 const userChain = (doc) => ({ select: () => ({ lean: async () => doc }) });
 const taskChain = (rows) => ({ sort: () => ({ limit: () => ({ lean: async () => rows }) }) });
 const decisionChain = (rows) => ({ sort: () => ({ limit: () => ({ lean: async () => rows }) }) });
@@ -105,15 +105,15 @@ describe('ActivityService.getDecisionQueue', () => {
     ]));
   });
 
-  test('does not present a member with an approval they cannot decide', async () => {
-    Pod.find.mockReturnValue({ select: () => ({ lean: async () => [{ ...POD, createdBy: 'owner-1' }] }) });
+  test('presents a member with an approval they can decide', async () => {
+    Pod.find.mockReturnValue({ select: () => ({ lean: async () => [POD] }) });
     jest.spyOn(ActivityService, 'getPendingApprovals').mockResolvedValue([
       { _id: 'activity-approval-1', content: 'Deploy?', podId: 'pod-1', createdAt: new Date() },
     ]);
 
     const result = await ActivityService.getDecisionQueue('member-1');
 
-    expect(result.items).not.toEqual(expect.arrayContaining([
+    expect(result.items).toEqual(expect.arrayContaining([
       expect.objectContaining({ kind: 'approval', id: 'activity-approval-1' }),
     ]));
   });

--- a/backend/__tests__/unit/services/activityService.pendingApprovals.test.js
+++ b/backend/__tests__/unit/services/activityService.pendingApprovals.test.js
@@ -23,19 +23,21 @@ describe('ActivityService.getPendingApprovals', () => {
     jest.clearAllMocks();
   });
 
-  it('queries only pods created by the queue owner', async () => {
-    const ownerUserId = 'queue-owner';
+  it('queries approvals from both creator and membership pods', async () => {
+    const memberUserId = 'queue-member';
     Pod.find.mockReturnValue(podFindResult([{ _id: 'owner-pod' }]));
     Activity.getPendingApprovals.mockResolvedValue([{ _id: 'approval-1' }]);
 
-    await expect(ActivityService.getPendingApprovals(ownerUserId)).resolves.toEqual([
+    await expect(ActivityService.getPendingApprovals(memberUserId)).resolves.toEqual([
       { _id: 'approval-1' },
     ]);
 
-    // ADR-020 D3 and TASK-095 v1.4 keep this legacy queue owner-scoped. Do
-    // not reintroduce the removed members.role branch: Pod.members is an
-    // ObjectId[] and has no role-bearing member objects.
-    expect(Pod.find).toHaveBeenCalledWith({ createdBy: ownerUserId });
+    expect(Pod.find).toHaveBeenCalledWith({
+      $or: [
+        { createdBy: memberUserId },
+        { members: memberUserId },
+      ],
+    });
     expect(Activity.getPendingApprovals).toHaveBeenCalledWith(['owner-pod']);
   });
 });

--- a/backend/__tests__/unit/services/activityService.recap.test.js
+++ b/backend/__tests__/unit/services/activityService.recap.test.js
@@ -1,4 +1,4 @@
-jest.mock('../../../models/Pod', () => ({ find: jest.fn() }));
+jest.mock('../../../models/Pod', () => ({ find: jest.fn(), findById: jest.fn() }));
 jest.mock('../../../models/Task', () => ({ find: jest.fn() }));
 
 const Pod = require('../../../models/Pod');
@@ -8,7 +8,7 @@ const User = require('../../../models/User');
 const ActivityService = require('../../../services/activityService');
 
 const ownerId = 'owner-1';
-const pod = { _id: 'pod-1', name: 'Activity source pod', type: 'team' };
+const pod = { _id: 'pod-1', name: 'Activity source pod', type: 'team', createdBy: ownerId };
 
 const podQuery = (pods) => ({
   select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(pods) }),
@@ -31,6 +31,7 @@ describe('ActivityService.getRecap', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     Pod.find.mockReturnValue(podQuery([pod]));
+    Pod.findById.mockReturnValue({ select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue(pod) })) });
     Task.find.mockReturnValue(taskQuery([{
       _id: 'board-1',
       podId: 'pod-1',
@@ -144,6 +145,22 @@ describe('ActivityService.getRecap', () => {
     })]);
   });
 
+  test('does not put another workspace owner’s approval in a member’s needs-you queue', async () => {
+    Pod.find.mockReturnValue(podQuery([{ ...pod, createdBy: 'other-owner' }]));
+    spy.mockResolvedValue({
+      activities: [{
+        id: 'approval-1', type: 'approval_needed', actor: { id: 'agent-1', name: 'release-agent', type: 'agent' },
+        action: 'approval_needed', preview: 'Approve access to Production.', timestamp: new Date(),
+        pod: { id: 'pod-1', name: pod.name }, approval: { status: 'pending' },
+        flags: { isAgentAction: true, isMention: false },
+      }],
+    });
+
+    const result = await ActivityService.getRecap(ownerId, { window: 'today' });
+
+    expect(result.needsYou).toEqual([]);
+  });
+
   test('keeps a pending approval older than the recap window and absent from the sampled feed', async () => {
     spy.mockResolvedValue({ activities: [] });
     pendingApprovalsSpy.mockResolvedValue([{
@@ -228,5 +245,31 @@ describe('ActivityService.getRecap', () => {
 
     expect(result).toEqual({ success: true, status: 'approved' });
     expect(approve).toHaveBeenCalledWith(ownerId, 'Approved in Activity');
+  });
+
+  test('fails closed when a non-owner attempts a legacy Activity approval', async () => {
+    const storedApproval = new Activity({ type: 'approval_needed', action: 'approval_needed', podId: pod._id });
+    const approve = jest.fn().mockResolvedValue();
+    storedApproval.approve = approve;
+    findByIdSpy = jest.spyOn(Activity, 'findById').mockResolvedValue(storedApproval);
+    Pod.findById.mockReturnValue({ select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue(pod) })) });
+
+    const result = await ActivityService.approveActivity(String(storedApproval._id), 'member-2', 'Nope');
+
+    expect(result).toEqual({ success: false, status: 403, error: 'Only the workspace owner can decide this' });
+    expect(approve).not.toHaveBeenCalled();
+  });
+
+  test('fails closed when a non-owner attempts a legacy Activity rejection', async () => {
+    const storedApproval = new Activity({ type: 'approval_needed', action: 'approval_needed', podId: pod._id });
+    const reject = jest.fn().mockResolvedValue();
+    storedApproval.reject = reject;
+    findByIdSpy = jest.spyOn(Activity, 'findById').mockResolvedValue(storedApproval);
+    Pod.findById.mockReturnValue({ select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue(pod) })) });
+
+    const result = await ActivityService.rejectActivity(String(storedApproval._id), 'member-2', 'Nope');
+
+    expect(result).toEqual({ success: false, status: 403, error: 'Only the workspace owner can decide this' });
+    expect(reject).not.toHaveBeenCalled();
   });
 });

--- a/backend/__tests__/unit/services/activityService.recap.test.js
+++ b/backend/__tests__/unit/services/activityService.recap.test.js
@@ -8,7 +8,7 @@ const User = require('../../../models/User');
 const ActivityService = require('../../../services/activityService');
 
 const ownerId = 'owner-1';
-const pod = { _id: 'pod-1', name: 'Activity source pod', type: 'team', createdBy: ownerId };
+const pod = { _id: 'pod-1', name: 'Activity source pod', type: 'team', createdBy: ownerId, members: [ownerId, 'member-1'] };
 
 const podQuery = (pods) => ({
   select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(pods) }),
@@ -145,7 +145,7 @@ describe('ActivityService.getRecap', () => {
     })]);
   });
 
-  test('does not put another workspace owner’s approval in a member’s needs-you queue', async () => {
+  test('puts a member’s approval in the needs-you queue', async () => {
     Pod.find.mockReturnValue(podQuery([{ ...pod, createdBy: 'other-owner' }]));
     spy.mockResolvedValue({
       activities: [{
@@ -156,9 +156,9 @@ describe('ActivityService.getRecap', () => {
       }],
     });
 
-    const result = await ActivityService.getRecap(ownerId, { window: 'today' });
+    const result = await ActivityService.getRecap('member-1', { window: 'today' });
 
-    expect(result.needsYou).toEqual([]);
+    expect(result.needsYou).toEqual([expect.objectContaining({ id: 'approval-1', kind: 'approval' })]);
   });
 
   test('keeps a pending approval older than the recap window and absent from the sampled feed', async () => {
@@ -247,29 +247,42 @@ describe('ActivityService.getRecap', () => {
     expect(approve).toHaveBeenCalledWith(ownerId, 'Approved in Activity');
   });
 
-  test('fails closed when a non-owner attempts a legacy Activity approval', async () => {
+  test('allows a pod member to approve a legacy Activity approval', async () => {
     const storedApproval = new Activity({ type: 'approval_needed', action: 'approval_needed', podId: pod._id });
     const approve = jest.fn().mockResolvedValue();
     storedApproval.approve = approve;
     findByIdSpy = jest.spyOn(Activity, 'findById').mockResolvedValue(storedApproval);
     Pod.findById.mockReturnValue({ select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue(pod) })) });
 
-    const result = await ActivityService.approveActivity(String(storedApproval._id), 'member-2', 'Nope');
+    const result = await ActivityService.approveActivity(String(storedApproval._id), 'member-1', 'Approved');
 
-    expect(result).toEqual({ success: false, status: 403, error: 'Only the workspace owner can decide this' });
+    expect(result).toEqual({ success: true, status: 'approved' });
+    expect(approve).toHaveBeenCalledWith('member-1', 'Approved');
+  });
+
+  test('fails closed when a non-member attempts a legacy Activity approval', async () => {
+    const storedApproval = new Activity({ type: 'approval_needed', action: 'approval_needed', podId: pod._id });
+    const approve = jest.fn().mockResolvedValue();
+    storedApproval.approve = approve;
+    findByIdSpy = jest.spyOn(Activity, 'findById').mockResolvedValue(storedApproval);
+    Pod.findById.mockReturnValue({ select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue(pod) })) });
+
+    const result = await ActivityService.approveActivity(String(storedApproval._id), 'non-member', 'Nope');
+
+    expect(result).toEqual({ success: false, status: 403, error: 'Only pod members can decide this' });
     expect(approve).not.toHaveBeenCalled();
   });
 
-  test('fails closed when a non-owner attempts a legacy Activity rejection', async () => {
+  test('fails closed when a non-member attempts a legacy Activity rejection', async () => {
     const storedApproval = new Activity({ type: 'approval_needed', action: 'approval_needed', podId: pod._id });
     const reject = jest.fn().mockResolvedValue();
     storedApproval.reject = reject;
     findByIdSpy = jest.spyOn(Activity, 'findById').mockResolvedValue(storedApproval);
     Pod.findById.mockReturnValue({ select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue(pod) })) });
 
-    const result = await ActivityService.rejectActivity(String(storedApproval._id), 'member-2', 'Nope');
+    const result = await ActivityService.rejectActivity(String(storedApproval._id), 'non-member', 'Nope');
 
-    expect(result).toEqual({ success: false, status: 403, error: 'Only the workspace owner can decide this' });
+    expect(result).toEqual({ success: false, status: 403, error: 'Only pod members can decide this' });
     expect(reject).not.toHaveBeenCalled();
   });
 });

--- a/backend/routes/activity.ts
+++ b/backend/routes/activity.ts
@@ -224,8 +224,8 @@ router.post('/:activityId/approve', auth, async (req: Req, res: Res) => {
     const { activityId } = req.params || {};
     const { notes } = (req.body || {}) as { notes?: string };
     const userId = getAuthenticatedUserId(req);
-    const result = await ActivityService.approveActivity(activityId, userId, notes) as { success?: boolean; error?: string };
-    if (!result.success) return res.status(400).json({ error: result.error });
+    const result = await ActivityService.approveActivity(activityId, userId, notes) as { success?: boolean; error?: string; status?: number };
+    if (!result.success) return res.status(result.status || 400).json({ error: result.error });
     return res.json(result);
   } catch (error) {
     console.error('Error approving activity:', error);
@@ -238,8 +238,8 @@ router.post('/:activityId/reject', auth, async (req: Req, res: Res) => {
     const { activityId } = req.params || {};
     const { notes } = (req.body || {}) as { notes?: string };
     const userId = getAuthenticatedUserId(req);
-    const result = await ActivityService.rejectActivity(activityId, userId, notes) as { success?: boolean; error?: string };
-    if (!result.success) return res.status(400).json({ error: result.error });
+    const result = await ActivityService.rejectActivity(activityId, userId, notes) as { success?: boolean; error?: string; status?: number };
+    if (!result.success) return res.status(result.status || 400).json({ error: result.error });
     return res.json(result);
   } catch (error) {
     console.error('Error rejecting activity:', error);

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -1502,10 +1502,15 @@ class ActivityService {
   static async getPendingApprovals(userId: unknown): Promise<unknown[]> {
     try {
       const pods: Array<{ _id: unknown }> = await Pod.find({
-        // Pod.members is an ObjectId[] with no role field. This owner lookup
-        // replaces the inert members.role branch, which implied a nonexistent
-        // admin audience for pending approvals.
-        createdBy: userId,
+        // Pending approvals belong to every pod member. `members` is an
+        // ObjectId[] (not a role-bearing object), so querying
+        // `members.userId` or `members.role` silently excludes members.
+        // Keep createdBy for legacy rows created before creators were added
+        // to members on save.
+        $or: [
+          { createdBy: userId },
+          { members: userId },
+        ],
       })
         .select('_id')
         .lean();

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -132,7 +132,7 @@ class ActivityService {
         { 'members.userId': userId },
         { members: userId },
       ],
-    }).select('_id name type createdBy').lean();
+    }).select('_id name type').lean();
 
     const requestedPodId = typeof options.podId === 'string' ? options.podId : '';
     const scopedPods = requestedPodId
@@ -141,16 +141,6 @@ class ActivityService {
     if (requestedPodId && scopedPods.length === 0) {
       throw new Error('Access denied');
     }
-    // Membership grants read access to the activity projection. Approval is
-    // different: ADR-020 D3 assigns its side effect to the workspace owner.
-    // Keep that distinction in the queue itself so a member never receives a
-    // button whose server-side write must be refused.
-    const ownedPodIds = new Set(
-      scopedPods
-        .filter((pod) => String(pod.createdBy || '') === String(userId))
-        .map((pod) => String(pod._id)),
-    );
-
     const scopedPodIds = new Set(scopedPods.map((pod) => String(pod._id)));
     // filter: 'agents' — the recap is about agent WORK. Without it, the
     // 100-slot feed budget was consumed entirely by `summary` activities
@@ -290,7 +280,7 @@ class ActivityService {
       new Date(right.timestamp || 0).getTime() - new Date(left.timestamp || 0).getTime()
     );
     const approvalQueue = Array.from(queueCandidates.values())
-      .filter((activity) => isPendingApproval(activity) && ownedPodIds.has(String(activity.pod?.id || '')))
+      .filter(isPendingApproval)
       .sort(newestFirst);
     const mentionQueue = Array.from(queueCandidates.values())
       .filter((activity) => activity.flags?.isMention && !acknowledgedMentionIds.has(String(activity.id)))
@@ -503,14 +493,9 @@ class ActivityService {
         { 'members.userId': userId },
         { members: userId },
       ],
-    }).select('_id name type createdBy').lean();
+    }).select('_id name type').lean();
     const podIds = pods.map((p) => p._id);
     const podName = new Map(pods.map((p) => [String(p._id), p.name as string]));
-    const ownedPodIds = new Set(
-      pods
-        .filter((pod) => String(pod.createdBy || '') === String(userId))
-        .map((pod) => String(pod._id)),
-    );
 
     type QueueItem = {
       kind: 'approval' | 'mention' | 'decision' | 'press';
@@ -537,9 +522,6 @@ class ActivityService {
         agentMetadata?: { agentName?: string };
       }>;
       for (const a of approvals) {
-        // A member may read a pending approval, but it is Needs-you work only
-        // for the workspace owner. The write side enforces the same rule.
-        if (!ownedPodIds.has(String(a.podId || ''))) continue;
         items.push({
           kind: 'approval',
           // RAW Activity id — the existing Activity actions key on it.
@@ -1487,8 +1469,8 @@ class ActivityService {
         return { success: false, error: 'Activity is not an approval request' };
       }
 
-      const ownershipError = await ActivityService.requireActivityApprovalOwner(activity, userId);
-      if (ownershipError) return ownershipError;
+      const membershipError = await ActivityService.requireActivityApprovalMember(activity, userId);
+      if (membershipError) return membershipError;
 
       await activity.approve(userId, notes);
       return { success: true, status: 'approved' };
@@ -1510,8 +1492,8 @@ class ActivityService {
         return { success: false, error: 'Activity is not an approval request' };
       }
 
-      const ownershipError = await ActivityService.requireActivityApprovalOwner(activity, userId);
-      if (ownershipError) return ownershipError;
+      const membershipError = await ActivityService.requireActivityApprovalMember(activity, userId);
+      if (membershipError) return membershipError;
 
       await activity.reject(userId, notes);
       return { success: true, status: 'rejected' };
@@ -1524,20 +1506,26 @@ class ActivityService {
 
   /**
    * Legacy Activity approval rows predate ApprovalAction.ownerUserId. Their
-   * only durable workspace authority is the owning pod's creator. Do this at
-   * write time (not just in the queue projection): a stale or forged client
-   * must not turn member read access into approval authority.
+   * read rule is pod membership (with the creator fallback for old rows), so
+   * write authorization must use the identical predicate. Do this at write
+   * time: a stale or forged client must not turn an Activity id into broad
+   * authenticated approval authority.
    */
-  private static async requireActivityApprovalOwner(
+  private static async requireActivityApprovalMember(
     activity: { podId?: unknown },
     userId: unknown,
   ): Promise<Record<string, unknown> | null> {
     const rawPodId = activity.podId as { _id?: unknown } | undefined;
     const podId = rawPodId?._id || activity.podId;
-    const pod = await Pod.findById(podId).select('createdBy').lean();
+    const pod = await Pod.findById(podId).select('createdBy members').lean();
     if (!pod) return { success: false, status: 404, error: 'Approval pod not found' };
-    if (!pod.createdBy || String(pod.createdBy) !== String(userId)) {
-      return { success: false, status: 403, error: 'Only the workspace owner can decide this' };
+    const isCreator = String(pod.createdBy || '') === String(userId);
+    const isMember = Array.isArray(pod.members) && pod.members.some((member: unknown) => {
+      const memberId = member as { _id?: unknown } | undefined;
+      return String(memberId?._id || member) === String(userId);
+    });
+    if (!isCreator && !isMember) {
+      return { success: false, status: 403, error: 'Only pod members can decide this' };
     }
     return null;
   }

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -132,7 +132,7 @@ class ActivityService {
         { 'members.userId': userId },
         { members: userId },
       ],
-    }).select('_id name type').lean();
+    }).select('_id name type createdBy').lean();
 
     const requestedPodId = typeof options.podId === 'string' ? options.podId : '';
     const scopedPods = requestedPodId
@@ -141,6 +141,15 @@ class ActivityService {
     if (requestedPodId && scopedPods.length === 0) {
       throw new Error('Access denied');
     }
+    // Membership grants read access to the activity projection. Approval is
+    // different: ADR-020 D3 assigns its side effect to the workspace owner.
+    // Keep that distinction in the queue itself so a member never receives a
+    // button whose server-side write must be refused.
+    const ownedPodIds = new Set(
+      scopedPods
+        .filter((pod) => String(pod.createdBy || '') === String(userId))
+        .map((pod) => String(pod._id)),
+    );
 
     const scopedPodIds = new Set(scopedPods.map((pod) => String(pod._id)));
     // filter: 'agents' — the recap is about agent WORK. Without it, the
@@ -281,7 +290,7 @@ class ActivityService {
       new Date(right.timestamp || 0).getTime() - new Date(left.timestamp || 0).getTime()
     );
     const approvalQueue = Array.from(queueCandidates.values())
-      .filter(isPendingApproval)
+      .filter((activity) => isPendingApproval(activity) && ownedPodIds.has(String(activity.pod?.id || '')))
       .sort(newestFirst);
     const mentionQueue = Array.from(queueCandidates.values())
       .filter((activity) => activity.flags?.isMention && !acknowledgedMentionIds.has(String(activity.id)))
@@ -494,9 +503,14 @@ class ActivityService {
         { 'members.userId': userId },
         { members: userId },
       ],
-    }).select('_id name type').lean();
+    }).select('_id name type createdBy').lean();
     const podIds = pods.map((p) => p._id);
     const podName = new Map(pods.map((p) => [String(p._id), p.name as string]));
+    const ownedPodIds = new Set(
+      pods
+        .filter((pod) => String(pod.createdBy || '') === String(userId))
+        .map((pod) => String(pod._id)),
+    );
 
     type QueueItem = {
       kind: 'approval' | 'mention' | 'decision' | 'press';
@@ -523,6 +537,9 @@ class ActivityService {
         agentMetadata?: { agentName?: string };
       }>;
       for (const a of approvals) {
+        // A member may read a pending approval, but it is Needs-you work only
+        // for the workspace owner. The write side enforces the same rule.
+        if (!ownedPodIds.has(String(a.podId || ''))) continue;
         items.push({
           kind: 'approval',
           // RAW Activity id — the existing Activity actions key on it.
@@ -1470,6 +1487,9 @@ class ActivityService {
         return { success: false, error: 'Activity is not an approval request' };
       }
 
+      const ownershipError = await ActivityService.requireActivityApprovalOwner(activity, userId);
+      if (ownershipError) return ownershipError;
+
       await activity.approve(userId, notes);
       return { success: true, status: 'approved' };
     } catch (error) {
@@ -1490,6 +1510,9 @@ class ActivityService {
         return { success: false, error: 'Activity is not an approval request' };
       }
 
+      const ownershipError = await ActivityService.requireActivityApprovalOwner(activity, userId);
+      if (ownershipError) return ownershipError;
+
       await activity.reject(userId, notes);
       return { success: true, status: 'rejected' };
     } catch (error) {
@@ -1497,6 +1520,26 @@ class ActivityService {
       console.error('Error rejecting activity:', error);
       return { success: false, error: err.message };
     }
+  }
+
+  /**
+   * Legacy Activity approval rows predate ApprovalAction.ownerUserId. Their
+   * only durable workspace authority is the owning pod's creator. Do this at
+   * write time (not just in the queue projection): a stale or forged client
+   * must not turn member read access into approval authority.
+   */
+  private static async requireActivityApprovalOwner(
+    activity: { podId?: unknown },
+    userId: unknown,
+  ): Promise<Record<string, unknown> | null> {
+    const rawPodId = activity.podId as { _id?: unknown } | undefined;
+    const podId = rawPodId?._id || activity.podId;
+    const pod = await Pod.findById(podId).select('createdBy').lean();
+    if (!pod) return { success: false, status: 404, error: 'Approval pod not found' };
+    if (!pod.createdBy || String(pod.createdBy) !== String(userId)) {
+      return { success: false, status: 403, error: 'Only the workspace owner can decide this' };
+    }
+    return null;
   }
 
   static async getPendingApprovals(userId: unknown): Promise<unknown[]> {

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -12,6 +12,8 @@ const Post = require('../models/Post');
 const Task = require('../models/Task');
 // eslint-disable-next-line global-require
 const DecisionRequest = require('../models/DecisionRequest');
+// eslint-disable-next-line global-require
+const isPodMember = require('../utils/isPodMember');
 
 let PGMessage: unknown = null;
 try {
@@ -1519,12 +1521,7 @@ class ActivityService {
     const podId = rawPodId?._id || activity.podId;
     const pod = await Pod.findById(podId).select('createdBy members').lean();
     if (!pod) return { success: false, status: 404, error: 'Approval pod not found' };
-    const isCreator = String(pod.createdBy || '') === String(userId);
-    const isMember = Array.isArray(pod.members) && pod.members.some((member: unknown) => {
-      const memberId = member as { _id?: unknown } | undefined;
-      return String(memberId?._id || member) === String(userId);
-    });
-    if (!isCreator && !isMember) {
+    if (!isPodMember(pod, userId)) {
       return { success: false, status: 403, error: 'Only pod members can decide this' };
     }
     return null;


### PR DESCRIPTION
## Summary
- include ordinary Pod.members ObjectId entries in the legacy Activity approval read
- retain creator coverage for legacy pod rows
- pin the exact query against creator-only regression

## Verification
- `npm test -- --runInBand __tests__/unit/services/activityService.pendingApprovals.test.js __tests__/unit/services/activityService.recap.test.js __tests__/unit/services/activityService.decisionQueue.test.js` (14 passing)
- `npm run build`
- mutation: replacing the member predicate with a wrong id fails the new test

## UX gate
- two-account walk: creator raises an approval; non-creator member sees and acts on it in Needs-you