### PR TITLE
ci(adr): resolve the ADR checker from the effective tree, not the PR head

### DIFF
--- a/.github/workflows/adr-numbering-guard.yml
+++ b/.github/workflows/adr-numbering-guard.yml
@@ -102,7 +102,23 @@ jobs:
                 esac
               done
 
-          node scripts/verify-adr-numbering.js --dir "$eff/docs/adr"
+          # The checker itself has to be resolved the same way as the ADRs, and
+          # for the same reason. On a `pull_request` event GitHub takes the
+          # WORKFLOW from the merge ref but this job checks out the PR HEAD —
+          # so every PR branched before this guard landed has the workflow file
+          # and not the script, and `node scripts/...` died with
+          # MODULE_NOT_FOUND. That reds the PR with no ADR output at all, which
+          # reads as a broken guard rather than a real collision (#1504).
+          # Effective content: the PR's version if it changed the script,
+          # otherwise main's.
+          bin=$(mktemp -d)
+          if git cat-file -e "HEAD:scripts/verify-adr-numbering.js" 2>/dev/null; then
+            git show "HEAD:scripts/verify-adr-numbering.js" > "$bin/verify-adr-numbering.js"
+          else
+            git show "FETCH_HEAD:scripts/verify-adr-numbering.js" > "$bin/verify-adr-numbering.js"
+          fi
+
+          node "$bin/verify-adr-numbering.js" --dir "$eff/docs/adr"
 
       # The check above cannot see a collision between two PRs that are both
       # still open — neither tree contains the other's file. That is the state


### PR DESCRIPTION
`ADR numbers are unique` is red on #1504 with no ADR output in the log. That is my bug, not #1504's.

The PR arm checks out the PR **head** on purpose — `refs/pull/N/merge` is recomputed lazily and can be badly stale. But GitHub takes the **workflow file** from the merge ref. So any PR branched before #1481 landed (12:27Z today) runs this workflow against a tree that has no `scripts/verify-adr-numbering.js`, and the step dies with `MODULE_NOT_FOUND` before printing a single ADR line. #1504 was first; nearly every open PR would have hit it on its next event.

Fix: resolve the checker the same way the ADRs are already resolved — the PR's version if the PR changed the script, `main`'s otherwise.

Verified, all three from a real checkout at the affected head:

| case | result |
|---|---|
| #1504 head `9bb229df` (script absent) | green — `✓ 29 ADRs, 29 distinct numbers` |
| same head + a synthetic second `ADR-025` | red — names both files |
| `main` head (script present) | resolves from HEAD, green |

The mutation matters: without it, "green on #1504" is equally consistent with a guard that now checks nothing.

Unrelated but re-measured while testing: #1295 no longer adds a second ADR-025. It was rebased at 13:52Z and now only modifies ADR-025/027. The collision I filed against it is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)